### PR TITLE
Fix flex attention autotuner benchmarking 2x workload bug

### DIFF
--- a/torch/_inductor/kernel/flex/common.py
+++ b/torch/_inductor/kernel/flex/common.py
@@ -274,7 +274,9 @@ def create_indices_fake(x) -> torch.Tensor:
     return indices
 
 
-def create_num_blocks_fake_generator(sparse_indices):
+def create_num_blocks_fake_generator(
+    sparse_indices, is_full_blocks=False, has_full_blocks=True
+):
     """Create a fake num_blocks that is used for autotuning.
 
     The idea here is that we need to create a real tensor with real data
@@ -283,20 +285,39 @@ def create_num_blocks_fake_generator(sparse_indices):
     that we are computing 0 blocks for each row, which would provide bogus
     autotuning results.
 
-    In this case, we choose to use min(16, max_block) blocks, because I
-    (Horace) think it'll probably result in pretty representative performance.
-    If it's too short then prefetching won't help. If it's too long then
-    autotuning will take longer for no good reason.
+    For flex attention kernels, KV blocks are split into "normal" blocks
+    (which need mask evaluation) and "full" blocks (where the mask always
+    passes, skipping evaluation). These two sets are disjoint: their counts
+    should sum to the total number of KV blocks.
+
+    When has_full_blocks is True (the kernel has both loops):
+      - normal blocks = 1 (one boundary block with mask evaluation)
+      - full blocks = max_blocks - 1 (remaining blocks skip mask evaluation)
+    This is representative of typical workloads where most blocks are full.
+
+    When has_full_blocks is False (the kernel only has the normal loop):
+      - normal blocks = max_blocks (all work goes through the single loop)
+      - full blocks: N/A (no full blocks loop in the kernel)
+
+    Previously, both normal and full were independently set to max_blocks,
+    causing the kernel to process 2x the actual workload during autotuning.
     """
 
     def create_num_blocks_fake(x) -> torch.Tensor:
-        num_blocks_for_autotuning = V.graph.sizevars.optimization_hint(
-            sparse_indices.shape[-1]
-        )
+        max_blocks = V.graph.sizevars.optimization_hint(sparse_indices.shape[-1])
         size = V.graph.sizevars.optimization_hints(x.get_size())
+        if not has_full_blocks:
+            # No full blocks loop in the kernel; all work is in normal blocks.
+            count = max_blocks
+        elif is_full_blocks:
+            # Full blocks: most blocks skip mask evaluation.
+            count = max(0, max_blocks - 1)
+        else:
+            # Normal blocks: just 1 boundary block needs mask evaluation.
+            count = min(1, max_blocks)
         return torch.full(
             size,
-            num_blocks_for_autotuning,
+            count,
             dtype=x.get_dtype(),
             device=x.get_device(),
         )

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -479,9 +479,9 @@ def flex_attention(
         + list(mask_mod_other_buffers)
     )
     input_gen_fns = {
-        5: create_num_blocks_fake_generator(kv_indices),
+        5: create_num_blocks_fake_generator(kv_indices, has_full_blocks=has_full_blocks),
         6: create_indices_fake,
-        7: create_num_blocks_fake_generator(full_kv_indices),
+        7: create_num_blocks_fake_generator(full_kv_indices, is_full_blocks=True),
         8: create_indices_fake,
     }
 
@@ -1002,13 +1002,13 @@ def flex_attention_backward(*args, **kwargs):
         + joint_outputs.mutated_grads
     )
     input_gen_fns = {
-        8: create_num_blocks_fake_generator(kv_indices),  # kv_num_blocks
+        8: create_num_blocks_fake_generator(kv_indices, has_full_blocks=has_full_blocks),  # kv_num_blocks
         9: create_indices_fake,
-        10: create_num_blocks_fake_generator(q_indices),  # q_num_blocks
+        10: create_num_blocks_fake_generator(q_indices, has_full_blocks=has_full_blocks),  # q_num_blocks
         11: create_indices_fake,
-        12: create_num_blocks_fake_generator(full_kv_indices),  # full_kv_num_blocks
+        12: create_num_blocks_fake_generator(full_kv_indices, is_full_blocks=True),  # full_kv_num_blocks
         13: create_indices_fake,
-        14: create_num_blocks_fake_generator(full_q_indices),  # full_q_num_blocks
+        14: create_num_blocks_fake_generator(full_q_indices, is_full_blocks=True),  # full_q_num_blocks
         15: create_indices_fake,
     }
 

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -407,9 +407,9 @@ def create_flex_decoding_kernel(*args, **kwargs):
     )
 
     input_gen_fns = {
-        5: create_num_blocks_fake_generator(kv_indices),
+        5: create_num_blocks_fake_generator(kv_indices, has_full_blocks=has_full_blocks),
         6: create_indices_fake,
-        7: create_num_blocks_fake_generator(full_kv_indices),
+        7: create_num_blocks_fake_generator(full_kv_indices, is_full_blocks=True),
         8: create_indices_fake,
     }
 

--- a/torch/_inductor/kernel/flex/flex_flash_attention.py
+++ b/torch/_inductor/kernel/flex/flex_flash_attention.py
@@ -446,9 +446,9 @@ def create_flex_flash_attention_kernel(
     input_gen_fns: dict[int, Callable] | None = None
     if has_full_blocks:
         input_gen_fns = {
-            4: create_num_blocks_fake_generator(kv_indices),
+            4: create_num_blocks_fake_generator(kv_indices, has_full_blocks=True),
             5: create_indices_fake,
-            6: create_num_blocks_fake_generator(full_kv_indices),
+            6: create_num_blocks_fake_generator(full_kv_indices, is_full_blocks=True),
             7: create_indices_fake,
         }
 
@@ -671,9 +671,9 @@ def create_flex_flash_attention_backward_kernel(
     input_gen_fns: dict[int, Callable] | None = None
     if has_block_mask:
         input_gen_fns = {
-            8: create_num_blocks_fake_generator(q_indices),
+            8: create_num_blocks_fake_generator(q_indices, has_full_blocks=True),
             9: create_indices_fake,
-            10: create_num_blocks_fake_generator(full_q_indices),
+            10: create_num_blocks_fake_generator(full_q_indices, is_full_blocks=True),
             11: create_indices_fake,
         }
 


### PR DESCRIPTION
## Summary

Fix a bug in `create_num_blocks_fake_generator` where the autotuner's fake data for `kv_num_blocks` and `full_kv_num_blocks` both independently used `max_blocks`, causing the kernel to process **2x the actual workload** during benchmarking.

## Problem

Flex attention kernels split KV blocks into two disjoint sets:
- **Normal blocks** (boundary, need mask evaluation): iterate `kv_num_blocks` times
- **Full blocks** (interior, skip mask evaluation): iterate `full_kv_num_blocks` times

These two sets should satisfy `normal + full = total`. However, `create_num_blocks_fake_generator` was called independently for both, each filling `max_blocks` (e.g., 13), so the kernel processed `13 + 13 = 26` blocks instead of the real `13`.

This caused the autotuner to **misrank configs** — larger tile configs (128x32) were disproportionately penalized by the doubled workload, leading the autotuner to pick slower configs (32x16).

## Fix

Add `is_full_blocks` and `has_full_blocks` parameters to `create_num_blocks_fake_generator`:
- When the kernel has both loops (`has_full_blocks=True`): `normal=1, full=max-1`
- When the kernel only has the normal loop (`has_full_blocks=False`): `normal=max`

This is representative of typical workloads (e.g., causal mask) where most blocks are full and only ~1 boundary block needs mask evaluation.

## Results (Intel Data Center GPU Max 1550, fp16, seq_len=512/1664)

**Before fix** — autotuner picks wrong config:
| Config | Autotuner | Actual | TFlops |
|---|---|---|---|
| 128x32_w16 | 0.30ms | 0.17ms | 70.3 |
| 32x16_w4 | 0.20ms | 0.20ms | 58.2 |

**After fix** — autotuner picks correct config:
| Config | Autotuner | Actual | TFlops |
|---|---|---|---|
| 128x32_w16 | 0.17ms | 0.17ms | 70.6 |
| 32x16_w4 | 0.21ms | 0.20ms | 58.6 |

## Attribution

This PR was written with the assistance of AI (Claude).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @drisspg