### PR TITLE
fix inference_mode getitem compile error

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -84,10 +84,13 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
             def forward(self, start_pos: int):
                 return self.range[start_pos : start_pos + 3]
 
-        m = Mod()
-        eager = m(1)
-        compiled = torch.compile(m, backend="aot_eager")
-        self.assertEqual(compiled(1), eager)
+        # with statement looks redundant next to @torch.inference_mode on forward,
+        # but scopes TLS so inference mode is always torn down if the test raises.
+        with torch.inference_mode():
+            m = Mod()
+            eager = m(1)
+            compiled = torch.compile(m, backend="aot_eager")
+            self.assertEqual(compiled(1), eager)
 
     def test_mutation(self):
         # https://github.com/pytorch/torchdynamo/issues/1301

--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -74,6 +74,21 @@ class AotAutogradFallbackTests(torch._inductor.test_case.TestCase):
         aot_result = aot_mod(*args)
         self.assertTrue(torch._dynamo.testing.same(eager_result, aot_result))
 
+    def test_compile_module_forward_with_inference_mode(self):
+        class Mod(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.range = torch.arange(1, 5, dtype=torch.float32)
+
+            @torch.inference_mode()
+            def forward(self, start_pos: int):
+                return self.range[start_pos : start_pos + 3]
+
+        m = Mod()
+        eager = m(1)
+        compiled = torch.compile(m, backend="aot_eager")
+        self.assertEqual(compiled(1), eager)
+
     def test_mutation(self):
         # https://github.com/pytorch/torchdynamo/issues/1301
         def fn(param, y):

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -1530,7 +1530,9 @@ def create_functional_call(
                         if fake_mode is None:
                             raise AssertionError("fake_mode must not be None")
                         fake_mode.epoch += 1
-                        out = PropagateUnbackedSymInts(mod).run(*args)
+                        out = PropagateUnbackedSymInts(
+                            mod, disable_inference_mode_for_getitem=True
+                        ).run(*args)
             else:
                 out = mod(*args[params_len:], **kwargs)
 

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -1486,6 +1486,28 @@ def aot_dispatch_subclass(
     )
 
 
+class _PropagateUnbackedSymIntsForAOTMetadataReplay(PropagateUnbackedSymInts):
+    # During AOT metadata replay, disable inference mode around each FX dispatch
+    # so ops do not build inference views under functionalization.
+    def call_function(self, target, args, kwargs):
+        if torch.is_inference_mode_enabled():
+            with torch.inference_mode(False):
+                return super().call_function(target, args, kwargs)
+        return super().call_function(target, args, kwargs)
+
+    def call_method(self, target, args, kwargs):
+        if torch.is_inference_mode_enabled():
+            with torch.inference_mode(False):
+                return super().call_method(target, args, kwargs)
+        return super().call_method(target, args, kwargs)
+
+    def call_module(self, target, args, kwargs):
+        if torch.is_inference_mode_enabled():
+            with torch.inference_mode(False):
+                return super().call_module(target, args, kwargs)
+        return super().call_module(target, args, kwargs)
+
+
 def create_functional_call(
     mod: Any,
     params_spec: Any,
@@ -1530,7 +1552,9 @@ def create_functional_call(
                         if fake_mode is None:
                             raise AssertionError("fake_mode must not be None")
                         fake_mode.epoch += 1
-                        out = PropagateUnbackedSymInts(mod).run(*args)
+                        out = _PropagateUnbackedSymIntsForAOTMetadataReplay(mod).run(
+                            *args
+                        )
             else:
                 out = mod(*args[params_len:], **kwargs)
 

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -1530,9 +1530,7 @@ def create_functional_call(
                         if fake_mode is None:
                             raise AssertionError("fake_mode must not be None")
                         fake_mode.epoch += 1
-                        out = PropagateUnbackedSymInts(
-                            mod, disable_inference_mode_for_getitem=True
-                        ).run(*args)
+                        out = PropagateUnbackedSymInts(mod).run(*args)
             else:
                 out = mod(*args[params_len:], **kwargs)
 

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import inspect
 import logging
+import operator
 from contextlib import contextmanager
 from typing import Any, TYPE_CHECKING
 
@@ -110,6 +111,10 @@ class Interpreter:
         graph (Optional[Graph]): If passed, the interpreter will execute this
             graph instead of `module.graph`, using the provided `module`
             argument to satisfy any requests for state.
+        disable_inference_mode_for_getitem (bool): If True, ``call_function`` runs
+            ``operator.getitem`` with inference mode temporarily disabled when it
+            would otherwise be enabled. Used by AOT metadata replay so slicing
+            does not produce inference views that break functionalization.
     """
 
     @compatibility(is_backward_compatible=True)
@@ -118,6 +123,7 @@ class Interpreter:
         module: torch.nn.Module,
         garbage_collect_values: bool = True,
         graph: Graph | None = None,
+        disable_inference_mode_for_getitem: bool = False,
     ):
         self.module = module
         self.submodules = dict(self.module.named_modules())
@@ -128,6 +134,7 @@ class Interpreter:
         self.env: dict[Node, Any] = {}
         self.name = "Interpreter"
         self.garbage_collect_values = garbage_collect_values
+        self.disable_inference_mode_for_getitem = disable_inference_mode_for_getitem
         self.extra_traceback = True
 
         if self.garbage_collect_values:
@@ -375,6 +382,14 @@ class Interpreter:
         """
         if isinstance(target, str):
             raise AssertionError("target should not be a string for call_function")
+
+        if (
+            self.disable_inference_mode_for_getitem
+            and target is operator.getitem
+            and torch.is_inference_mode_enabled()
+        ):
+            with torch.inference_mode(False):
+                return target(*args, **kwargs)
 
         # Execute the function and return the result
         return target(*args, **kwargs)

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -111,10 +111,6 @@ class Interpreter:
         graph (Optional[Graph]): If passed, the interpreter will execute this
             graph instead of `module.graph`, using the provided `module`
             argument to satisfy any requests for state.
-        disable_inference_mode_for_getitem (bool): If True, ``call_function`` runs
-            ``operator.getitem`` with inference mode temporarily disabled when it
-            would otherwise be enabled. Used by AOT metadata replay so slicing
-            does not produce inference views that break functionalization.
     """
 
     @compatibility(is_backward_compatible=True)
@@ -123,7 +119,6 @@ class Interpreter:
         module: torch.nn.Module,
         garbage_collect_values: bool = True,
         graph: Graph | None = None,
-        disable_inference_mode_for_getitem: bool = False,
     ):
         self.module = module
         self.submodules = dict(self.module.named_modules())
@@ -134,7 +129,6 @@ class Interpreter:
         self.env: dict[Node, Any] = {}
         self.name = "Interpreter"
         self.garbage_collect_values = garbage_collect_values
-        self.disable_inference_mode_for_getitem = disable_inference_mode_for_getitem
         self.extra_traceback = True
 
         if self.garbage_collect_values:
@@ -383,15 +377,11 @@ class Interpreter:
         if isinstance(target, str):
             raise AssertionError("target should not be a string for call_function")
 
-        if (
-            self.disable_inference_mode_for_getitem
-            and target is operator.getitem
-            and torch.is_inference_mode_enabled()
-        ):
+        # getitem under inference_mode(False): avoid inference views during FX replay
+        if target is operator.getitem and torch.is_inference_mode_enabled():
             with torch.inference_mode(False):
                 return target(*args, **kwargs)
 
-        # Execute the function and return the result
         return target(*args, **kwargs)
 
     @compatibility(is_backward_compatible=True)

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 import inspect
 import logging
-import operator
 from contextlib import contextmanager
 from typing import Any, TYPE_CHECKING
 
@@ -377,11 +376,7 @@ class Interpreter:
         if isinstance(target, str):
             raise AssertionError("target should not be a string for call_function")
 
-        # getitem under inference_mode(False): avoid inference views during FX replay
-        if target is operator.getitem and torch.is_inference_mode_enabled():
-            with torch.inference_mode(False):
-                return target(*args, **kwargs)
-
+        # Execute the function and return the result
         return target(*args, **kwargs)
 
     @compatibility(is_backward_compatible=True)


### PR DESCRIPTION
Fixes #169477

In `Interpreter.call_function`, when the target is `operator.getitem` and inference mode is enabled on this thread, run the getitem under `torch.inference_mode(False)` so FX replay does not produce inference views. A regression test is added in `test_aot_autograd.py`.

AOT runs the captured graph through the FX interpreter while collecting forward metadata; if that replay still sees thread-local inference mode, `getitem` builds inference tensors/views and downstream functionalization and view bookkeeping can break. Disabling inference mode only for that `getitem` keeps replay aligned with normal autograd views without changing user-visible forward behavior.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98