### PR TITLE
[ROCm][CI] Remove nightly branch push trigger from rocm-nightly workflow

### DIFF
--- a/.github/workflows/rocm-nightly.yml
+++ b/.github/workflows/rocm-nightly.yml
@@ -2,8 +2,6 @@ name: rocm-nightly
 
 on:
   push:
-    branches:
-      - nightly
     tags:
       - ciflow/rocm-nightly/*
   workflow_dispatch:


### PR DESCRIPTION
The rocm-nightly workflow uniquely triggers on push to the nightly branch (no other PyTorch workflow does this). This causes the build job to hang for 8+ hours on the "Select all requested test configurations" step because filter_test_configs.py (https://github.com/pytorch/pytorch/blob/main/.github/scripts/filter_test_configs.py#L503) runs git cherry -v origin/main without a timeout. On the nightly branch, this walks the entire divergence history from main through a treeless clone, triggering massive on-demand object fetches that never complete within the job timeout.

Every nightly branch push since Apr 1 has been cancelled after hanging: https://github.com/pytorch/pytorch/actions/runs/23997169745, https://github.com/pytorch/pytorch/actions/runs/23974550962, https://github.com/pytorch/pytorch/actions/runs/23938846651, https://github.com/pytorch/pytorch/actions/runs/23890180706.

The schedule cron (midnight UTC) on main already provides daily rocm-nightly coverage and is unaffected since HEAD ~ origin/main makes it irrelevant as other rocm .yml files do not have the same line.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang