### PR TITLE
[pytorch] Fix resource loading for PAR compatibility using importlib.resources (#179587)

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -26,6 +26,7 @@ Error Formatting:
     - Debugging utilities for error reporting
 """
 
+import importlib.resources
 import json
 import logging
 import re
@@ -33,12 +34,10 @@ import textwrap
 import typing
 from enum import auto, Enum
 from functools import lru_cache
-from pathlib import Path
 from traceback import extract_stack, format_exc, format_list, FrameSummary, StackSummary
 from typing import Any, NoReturn, TYPE_CHECKING
 
 import torch._guards
-from torch._utils_internal import get_file_path_2
 
 from . import config
 from .utils import counters
@@ -571,12 +570,12 @@ def _load_gb_type_to_gb_id_map() -> dict[str, Any]:
     Includes historical gb_type (mapping behavior of duplicate gb_types with different gb_ids is undefined).
     """
     try:
-        script_dir = Path(__file__).resolve().parent
-        registry_path = get_file_path_2(
-            "", str(script_dir), "graph_break_registry.json"
+        registry_ref = (
+            importlib.resources.files("torch._dynamo") / "graph_break_registry.json"
         )
-        with open(registry_path) as f:
-            registry = json.load(f)
+        with importlib.resources.as_file(registry_ref) as registry_path:
+            with open(registry_path) as f:
+                registry = json.load(f)
     except Exception:
         log.exception("Error accessing the registry file")
         # pyrefly: ignore [implicit-any]

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -24,7 +24,7 @@ import dis
 import enum
 import functools
 import gc
-import importlib
+import importlib.resources
 import inspect
 import itertools
 import json
@@ -4157,9 +4157,12 @@ def import_submodule(mod: types.ModuleType) -> None:
     """
     Ensure all the files in a given submodule are imported
     """
-    for filename in sorted(os.listdir(os.path.dirname(cast(str, mod.__file__)))):
-        if filename.endswith(".py") and filename[0] != "_":
-            importlib.import_module(f"{mod.__name__}.{filename[:-3]}")
+    for item in sorted(
+        importlib.resources.files(mod.__name__).iterdir(),
+        key=lambda x: x.name,
+    ):
+        if item.name.endswith(".py") and item.name[0] != "_":
+            importlib.import_module(f"{mod.__name__}.{item.name[:-3]}")
 
 
 def object_has_getattribute(value: Any) -> bool:

--- a/torch/_inductor/kernel/flex/common.py
+++ b/torch/_inductor/kernel/flex/common.py
@@ -1,10 +1,10 @@
 # mypy: allow-untyped-defs
 """Common utilities and functions for flex attention kernels"""
 
+import importlib.resources
 import math
 from collections.abc import Sequence
 from functools import partial
-from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
 import sympy
@@ -357,7 +357,7 @@ def next_power_of_two(n):
     return 2 ** math.ceil(math.log2(n))
 
 
-_FLEX_TEMPLATE_DIR = Path(__file__).parent / "templates"
+_FLEX_TEMPLATE_DIR = importlib.resources.files("torch._inductor.kernel.flex") / "templates"
 load_flex_template = partial(load_template, template_dir=_FLEX_TEMPLATE_DIR)
 
 

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -1,8 +1,8 @@
 # mypy: allow-untyped-defs
+import importlib.resources
 import logging
 from collections.abc import Sequence
 from functools import partial
-from pathlib import Path
 from typing import Any
 
 import torch
@@ -259,8 +259,8 @@ def is_batch_stride_largest_or_zero(mat1, mat2, layout) -> bool:
     return True
 
 
-_KERNEL_TEMPLATE_DIR = Path(__file__).parent / "templates"
+_KERNEL_TEMPLATE_DIR = importlib.resources.files("torch._inductor.kernel") / "templates"
 load_kernel_template = partial(load_template, template_dir=_KERNEL_TEMPLATE_DIR)
 
-_KERNEL_TEMPLATE_FB_DIR = Path(__file__).parent.parent / "fb" / "tlx_templates"
+_KERNEL_TEMPLATE_FB_DIR = importlib.resources.files("torch._inductor.fb") / "tlx_templates"
 load_fb_kernel_template = partial(load_template, template_dir=_KERNEL_TEMPLATE_FB_DIR)

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -5,7 +5,7 @@ import contextlib
 import dataclasses
 import enum
 import functools
-import importlib
+import importlib.resources
 import inspect
 import io
 import itertools
@@ -80,7 +80,7 @@ from torch.fx.experimental.symbolic_shapes import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence, ValuesView
-    from pathlib import Path
+    from importlib.abc import Traversable
 
     from torch import SymBool, SymFloat, SymInt
     from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND
@@ -4415,9 +4415,9 @@ def is_nonfreeable_buffers(dep: Dep) -> bool:
 
 
 # Make sure to also include your jinja templates within torch_package_data in setup.py, or this function won't be able to find them
-def load_template(name: str, template_dir: Path) -> str:
+def load_template(name: str, template_dir: Traversable) -> str:
     """Load a template file and return its content."""
-    with open(template_dir / f"{name}.py.jinja") as f:
+    with (template_dir / f"{name}.py.jinja").open() as f:
         return f.read()
 
 


### PR DESCRIPTION
Summary:

Several functions use `Path(__file__).parent`, `os.listdir(os.path.dirname(__file__))`,
or `get_file_path_2()` which fail when running from PAR files because `__file__`
resolves to `/proc/self/fd/N/...` - a file descriptor path that doesn't support
filesystem traversal.

This change uses `importlib.resources.files()` which properly handles resources
inside PAR archives by accessing them through Python's package system.

Files fixed:
- `torch/_inductor/kernel/flex/common.py`: `load_flex_template`
- `torch/_inductor/kernel/mm_common.py`: `load_kernel_template`, `load_fb_kernel_template`
- `torch/_dynamo/utils.py`: `import_submodule`
- `torch/_dynamo/exc.py`: `_load_gb_type_to_gb_id_map`

Test Plan:
CI

Also, confirmed that PAR binary from fbpkg runs as expected.

Differential Revision: D99780509


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98