### PR TITLE
[pyrefly] Add type annotations to core torch/fx types

### DIFF
--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -6,7 +6,7 @@ import itertools
 import pickle
 import weakref
 from abc import abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from typing import Any, NewType, TypeVar
 from typing_extensions import override, Self
 
@@ -75,7 +75,7 @@ def _unpickle_as_none() -> None:
     return None
 
 
-def _unpickle_as_weakref(referent: object) -> weakref.ref:
+def _unpickle_as_weakref(referent: object) -> weakref.ref[object]:
     return weakref.ref(referent)
 
 
@@ -84,7 +84,7 @@ def _unpickle_as_dead_weakref() -> Callable[[], None]:
 
 
 @contextlib.contextmanager
-def patch_pytree_map_over_slice():
+def patch_pytree_map_over_slice() -> Generator[None]:
     if slice in pytree.SUPPORTED_NODES:
         yield
         return

--- a/torch/fx/_pytree.py
+++ b/torch/fx/_pytree.py
@@ -7,7 +7,7 @@ import torch.return_types
 from torch.utils._pytree import PyTree, tree_flatten, TreeSpec
 
 
-FlattenFnSpec = Callable[[PyTree, TreeSpec], list]
+FlattenFnSpec = Callable[[PyTree, TreeSpec], list[Any]]
 FlattenFnExactMatchSpec = Callable[[PyTree, TreeSpec], bool]
 
 # Keep deprecated alias for backward compatibility
@@ -52,7 +52,7 @@ def tree_flatten_spec(
     if spec.type in SUPPORTED_NODES:
         flatten_fn_spec = SUPPORTED_NODES[spec.type]
         child_pytrees = flatten_fn_spec(pytree, spec)
-        result = []
+        result: list[Any] = []
         for child, child_spec in zip(child_pytrees, spec.children()):
             flat = tree_flatten_spec(child, child_spec)
             result += flat

--- a/torch/fx/_utils.py
+++ b/torch/fx/_utils.py
@@ -1,16 +1,18 @@
-# mypy: allow-untyped-defs
 import sys
+from typing import Any
 
 import torch
 from torch._logging import LazyString
 
 
-def lazy_format_graph_code(name, gm, maybe_id=None, **kwargs):
+def lazy_format_graph_code(
+    name: str, gm: torch.fx.GraphModule, maybe_id: int | None = None, **kwargs: Any
+) -> LazyString:
     """
     Returns a LazyString that formats the graph code.
     """
 
-    def format_name():
+    def format_name() -> str:
         if maybe_id is not None:
             return f"{name} {maybe_id}"
         else:
@@ -35,14 +37,14 @@ def lazy_format_graph_code(name, gm, maybe_id=None, **kwargs):
     )
 
 
-def _format_graph_code(name, filename, graph_str):
+def _format_graph_code(name: str, filename: str, graph_str: str) -> str:
     """
     Returns a string that formats the graph code.
     """
     return f"TRACED GRAPH\n {name} {filename} {graph_str}\n"
 
 
-def first_call_function_nn_module_stack(graph: torch.fx.Graph) -> dict | None:
+def first_call_function_nn_module_stack(graph: torch.fx.Graph) -> dict[str, Any] | None:
     """
     Returns the nn_module_stack of the first call_function node.
     """
@@ -52,14 +54,15 @@ def first_call_function_nn_module_stack(graph: torch.fx.Graph) -> dict | None:
     return None
 
 
-def get_node_context(node, num_nodes=2) -> str:
+def get_node_context(node: torch.fx.Node, num_nodes: int = 2) -> str:
     """
     Returns a string of the last num_nodes nodes in the graph.
     """
     node_contexts = []
     cur = node
     for _ in range(num_nodes):
-        node_contexts.append(cur.format_node())
+        # cast to str to handle None return value
+        node_contexts.append(str(cur.format_node()))
         if cur.op == "root":
             break
         cur = cur.prev

--- a/torch/fx/annotate.py
+++ b/torch/fx/annotate.py
@@ -1,11 +1,15 @@
-# mypy: allow-untyped-defs
+from typing import Any
+
 from torch.fx.proxy import Proxy
 
 from ._compatibility import compatibility
 
 
+__all__ = ["annotate"]
+
+
 @compatibility(is_backward_compatible=False)
-def annotate(val, type):
+def annotate(val: Any, type: type) -> Any:
     """
     Annotates a Proxy object with a given type.
 

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -655,7 +655,7 @@ class Node(_NodeBase):
             return f"return {self.args[0]}"
         else:
 
-            def stringify_shape(shape: Iterable) -> str:
+            def stringify_shape(shape: Iterable[Any]) -> str:
                 return f"[{', '.join([str(x) for x in shape])}]"
 
             meta_val = self.meta.get(

--- a/torch/fx/tensor_type.py
+++ b/torch/fx/tensor_type.py
@@ -1,7 +1,11 @@
-# mypy: allow-untyped-defs
+from collections.abc import Sequence
+
 from torch.fx.experimental.unification import Var  # type: ignore[attr-defined]
 
 from ._compatibility import compatibility
+
+
+__all__ = ["Dyn", "TensorType", "is_consistent", "is_more_precise"]
 
 
 @compatibility(is_backward_compatible=False)
@@ -14,21 +18,21 @@ class TensorType:
                 return torch.add(x, y)
     """
 
-    def __init__(self, dim):
+    def __init__(self, dim: Sequence[object]) -> None:
         self.__origin__ = TensorType
         self.__args__ = dim
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"TensorType[{self.__args__}]"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, self.__class__):
             return list(self.__args__) == list(other.__args__)
         else:
             return False
 
     @staticmethod
-    def __class_getitem__(*args):
+    def __class_getitem__(*args: object) -> "TensorType":
         if len(args) == 1 and isinstance(args[0], tuple):
             args = args[0]
         return TensorType(tuple(args))
@@ -42,13 +46,13 @@ class _DynType:
     def __init__(self) -> None:
         self.__name__ = "_DynType"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, self.__class__)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Dyn"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Dyn"
 
 
@@ -56,7 +60,7 @@ Dyn = _DynType()
 
 
 @compatibility(is_backward_compatible=False)
-def is_consistent(t1, t2):
+def is_consistent(t1: object, t2: object) -> bool:
     """
     A binary relation denoted by ~ that determines if t1 is consistent with t2.
     The relation is reflexive, symmetric but not transitive.
@@ -84,7 +88,7 @@ def is_consistent(t1, t2):
 
 
 @compatibility(is_backward_compatible=False)
-def is_more_precise(t1, t2):
+def is_more_precise(t1: object, t2: object) -> bool:
     """
     A binary relation denoted by <= that determines if t1 is more precise than t2.
     The relation is reflexive and transitive.


### PR DESCRIPTION
Add return type annotations and parameterize generic types across core torch/fx utility files to satisfy pyrefly's `unannotated-return` and `implicit-any` checks.

Authored with Claude.