### PR TITLE
Fix MPS SDPA correctness when score matrix exceeds 2^32 elements

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -14,7 +14,12 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_scaled_dot_product_attention_math_for_mps_native.h>
+#include <ATen/ops/arange.h>
 #include <ATen/ops/empty_native.h>
+#include <ATen/ops/full.h>
+#include <ATen/ops/le.h>
+#include <ATen/ops/where.h>
+#include <ATen/ops/zeros.h>
 #endif
 
 namespace at {
@@ -39,17 +44,15 @@ static inline std::tuple<Tensor, bool> ensure_4d(const Tensor& x) {
   }
 }
 
-// general version
-static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
-                                                   const Tensor& key,
-                                                   const Tensor& value,
-                                                   const std::optional<Tensor>& attn_mask,
-                                                   double dropout_p,
-                                                   bool is_causal,
-                                                   const std::optional<Tensor>& dropout_mask,
-                                                   std::optional<double> scale,
-                                                   const Tensor& orig_query,
-                                                   bool unsqueezed) {
+// Builds and runs a single MPSGraph SDPA call. Caller is responsible for any
+// chunking along the Q axis and for synthesizing per-chunk masks; see
+// sdpa_general_mps below for the chunking wrapper.
+static std::tuple<Tensor, Tensor> sdpa_general_mps_impl(const Tensor& query,
+                                                        const Tensor& key,
+                                                        const Tensor& value,
+                                                        const std::optional<Tensor>& attn_mask,
+                                                        bool is_causal,
+                                                        double scale_factor) {
   using namespace mps;
   struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
@@ -68,7 +71,6 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
   int64_t maxSeqLength = key.size(2);
   auto out = at::empty({batchSize, num_head, qSize, valueHeadSize}, query.options());
   auto attn = at::empty({batchSize, num_head, qSize, maxSeqLength}, query.options());
-  auto scale_factor = sdp::calculate_scale(query, scale).expect_float();
   @autoreleasepool {
     auto mkey = __func__ + getTensorsStringKey({query, key, value}) + ":" + std::to_string(is_causal) + ":" +
         std::to_string(attn_mask.has_value());
@@ -147,6 +149,79 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
     }
     NSDictionary* outs = dictionaryFromPlaceholders(outputPlaceholder, attnPlaceholder);
     runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outs);
+  }
+  return {std::move(out), std::move(attn)};
+}
+
+// general version
+static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
+                                                   const Tensor& key,
+                                                   const Tensor& value,
+                                                   const std::optional<Tensor>& attn_mask,
+                                                   double dropout_p,
+                                                   bool is_causal,
+                                                   const std::optional<Tensor>& dropout_mask,
+                                                   std::optional<double> scale,
+                                                   const Tensor& orig_query,
+                                                   bool unsqueezed) {
+  int64_t batchSize = query.size(0);
+  int64_t num_head = query.size(1);
+  int64_t qSize = query.size(2);
+  int64_t kSize = key.size(2);
+  int64_t valueHeadSize = value.size(3);
+
+  auto scale_factor = sdp::calculate_scale(query, scale).expect_float();
+
+  // Apple's MPSGraph corrupts SDPA outputs when the score matrix exceeds 2^32
+  // total elements (pytorch/pytorch#179352). Chunk along the Q axis to keep
+  // each impl call below the threshold. SDPA's softmax is row-wise over Q so
+  // chunking is mathematically exact.
+  constexpr uint64_t kScoreElemThreshold = 1ULL << 32;
+  uint64_t total_score_elems = static_cast<uint64_t>(batchSize) * static_cast<uint64_t>(num_head) *
+      static_cast<uint64_t>(qSize) * static_cast<uint64_t>(kSize);
+
+  Tensor out;
+  Tensor attn;
+  if (total_score_elems <= kScoreElemThreshold) {
+    std::tie(out, attn) = sdpa_general_mps_impl(query, key, value, attn_mask, is_causal, scale_factor);
+  } else {
+    uint64_t per_q_row =
+        static_cast<uint64_t>(batchSize) * static_cast<uint64_t>(num_head) * static_cast<uint64_t>(kSize);
+    int64_t q_chunk = static_cast<int64_t>(std::max<uint64_t>(1, kScoreElemThreshold / per_q_row));
+    if (per_q_row > kScoreElemThreshold) {
+      TORCH_WARN_ONCE("MPS SDPA: B*H*kv_seq (=",
+                      per_q_row,
+                      ") exceeds the score-matrix element threshold ",
+                      kScoreElemThreshold,
+                      "; even single-row Q chunks exceed it and outputs may still be incorrect.");
+    }
+
+    out = at::empty({batchSize, num_head, qSize, valueHeadSize}, query.options());
+    attn = at::empty({batchSize, num_head, qSize, kSize}, query.options());
+
+    for (int64_t qs = 0; qs < qSize; qs += q_chunk) {
+      int64_t cur = std::min(q_chunk, qSize - qs);
+      auto q_slice = query.narrow(2, qs, cur);
+
+      std::optional<Tensor> chunk_mask;
+      if (is_causal) {
+        // Synthesize a per-chunk additive causal mask: 0 if j <= (qs + i)
+        // else -1e20 (matching the value used by the in-graph causal path).
+        // Pass it as attn_mask with is_causal=false so the impl's causal
+        // branch (which assumes the chunk starts at row 0) is bypassed.
+        auto i_idx = at::arange(qs, qs + cur, query.options().dtype(kLong)).unsqueeze(1);
+        auto j_idx = at::arange(0, kSize, query.options().dtype(kLong)).unsqueeze(0);
+        auto valid = at::le(j_idx, i_idx);
+        auto m2d = at::where(valid, at::zeros({}, query.options()), at::full({}, -1e20, query.options()));
+        chunk_mask = m2d.unsqueeze(0).unsqueeze(0).expand({batchSize, num_head, cur, kSize});
+      } else if (attn_mask) {
+        chunk_mask = attn_mask->narrow(2, qs, cur);
+      }
+
+      auto chunk_result = sdpa_general_mps_impl(q_slice, key, value, chunk_mask, /*is_causal=*/false, scale_factor);
+      out.narrow(2, qs, cur).copy_(std::get<0>(chunk_result));
+      attn.narrow(2, qs, cur).copy_(std::get<1>(chunk_result));
+    }
   }
 
   auto final_out = out;

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -2,6 +2,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <fmt/format.h>
 #include <iostream>
+#include <limits>
 #include <optional>
 
 #include <ATen/core/Tensor.h>
@@ -14,12 +15,9 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/_scaled_dot_product_attention_math_for_mps_native.h>
-#include <ATen/ops/arange.h>
 #include <ATen/ops/empty_native.h>
 #include <ATen/ops/full.h>
-#include <ATen/ops/le.h>
-#include <ATen/ops/where.h>
-#include <ATen/ops/zeros.h>
+#include <ATen/ops/triu.h>
 #endif
 
 namespace at {
@@ -172,11 +170,14 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
 
   auto scale_factor = sdp::calculate_scale(query, scale).expect_float();
 
-  // Apple's MPSGraph corrupts SDPA outputs when the score matrix exceeds 2^32
-  // total elements (pytorch/pytorch#179352). Chunk along the Q axis to keep
-  // each impl call below the threshold. SDPA's softmax is row-wise over Q so
-  // chunking is mathematically exact.
-  constexpr uint64_t kScoreElemThreshold = 1ULL << 32;
+  // Apple's MPSGraph corrupts SDPA outputs (and on some codepaths fails an
+  // internal assertion in MPSNDArrayMatrixMultiplication) when a stride
+  // inside the score matrix exceeds the kernel's 32-bit limit. Empirically
+  // the cliff is at B*H*Nq*Nkv ~= 2^32 elements; chunk along Q so each impl
+  // call stays strictly below UINT32_MAX. SDPA's softmax is row-wise over Q,
+  // so chunking is mathematically exact. See pytorch/pytorch#179352 and
+  // Apple Feedback Assistant FB22437937.
+  constexpr uint64_t kScoreElemThreshold = std::numeric_limits<uint32_t>::max();
   uint64_t total_score_elems = static_cast<uint64_t>(batchSize) * static_cast<uint64_t>(num_head) *
       static_cast<uint64_t>(qSize) * static_cast<uint64_t>(kSize);
 
@@ -205,14 +206,12 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
 
       std::optional<Tensor> chunk_mask;
       if (is_causal) {
-        // Synthesize a per-chunk additive causal mask: 0 if j <= (qs + i)
-        // else -1e20 (matching the value used by the in-graph causal path).
-        // Pass it as attn_mask with is_causal=false so the impl's causal
+        // Synthesize a per-chunk additive causal mask: -1e20 where j > qs+i,
+        // else 0. Built in float32 to match the in-graph causal path, which
+        // upcasts the score matrix to float32 before applying the mask. Passed
+        // as attn_mask with is_causal=false so the impl's in-graph causal
         // branch (which assumes the chunk starts at row 0) is bypassed.
-        auto i_idx = at::arange(qs, qs + cur, query.options().dtype(kLong)).unsqueeze(1);
-        auto j_idx = at::arange(0, kSize, query.options().dtype(kLong)).unsqueeze(0);
-        auto valid = at::le(j_idx, i_idx);
-        auto m2d = at::where(valid, at::zeros({}, query.options()), at::full({}, -1e20, query.options()));
+        auto m2d = at::triu(at::full({cur, kSize}, -1e20, query.options().dtype(kFloat)), qs + 1);
         chunk_mask = m2d.unsqueeze(0).unsqueeze(0).expand({batchSize, num_head, cur, kSize});
       } else if (attn_mask) {
         chunk_mask = attn_mask->narrow(2, qs, cur);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9875,6 +9875,44 @@ class TestSDPA(TestCaseMPS):
         out = ep.module()(q2, mask2)
         self.assertEqual(out.shape, (1, 4, 7, 128))
 
+    @unittest.skipIf(IS_CI, "Score-matrix > 2^32 elements; ~50 GB peak RAM, too heavy for CI")
+    @unittest.skipIf(total_memory < 64_000_000_000, "Needs at least 64 GB system RAM")
+    @parametrize("variant", ["no_mask", "causal", "add_mask"])
+    def test_sdpa_large_score_matrix_179352(self, variant):
+        # Regression test for https://github.com/pytorch/pytorch/issues/179352.
+        # Apple's MPSGraph corrupts SDPA outputs when the score matrix
+        # B*H*Nq*Nkv exceeds 2^32 total elements. sdpa_general_mps now chunks
+        # along the Q axis to keep each impl call under the threshold; this
+        # exercises that path on the smallest "canary" shape from the issue.
+        torch.manual_seed(1729)
+        # 1 * 8 * 16384 * 65536 = 2^33 -- crosses the 2^32 score-element threshold.
+        B, H, Nq, Nkv, D = 1, 8, 16384, 65536, 64
+
+        with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
+            q = torch.randn(B, H, Nq, D, dtype=torch.float32, device="mps")
+            k = torch.randn(B, H, Nkv, D, dtype=torch.float32, device="mps")
+            v = torch.randn(B, H, Nkv, D, dtype=torch.float32, device="mps")
+
+            mask = None
+            is_causal = False
+            if variant == "causal":
+                is_causal = True
+            elif variant == "add_mask":
+                mask = torch.randn(Nq, Nkv, dtype=torch.float32, device="mps") * 0.1
+
+            y = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=is_causal
+            )
+            y_ref = F.scaled_dot_product_attention(
+                q.cpu(), k.cpu(), v.cpu(),
+                attn_mask=(mask.cpu() if mask is not None else None),
+                dropout_p=0.0, is_causal=is_causal,
+            )
+            # Tolerances are loose enough for fp32 reduction noise on a ~1B
+            # element score matrix but tight enough to catch the broken-path
+            # corruption (which produced max_rel_err ~ 1.0 on this shape).
+            self.assertEqual(y.cpu(), y_ref, atol=1e-3, rtol=1e-3)
+
     def test_sdpa_no_mask_causal_fp16_L7(self):
         self._test_sdpa_no_mask(True, torch.float16, 7)
 


### PR DESCRIPTION
## Summary

Fixes #179352. Apple's MPSGraph corrupts SDPA outputs when the score
matrix `B*H*Nq*Nkv` exceeds 2^32 total elements: at the canary shape
(`B=1, H=8, Nq=16384, Nkv=65536, D=64`), output diverges from CPU with
cosine similarity ~0.44 and max relative error ~1.2. The threshold is
independent of dtype, of `is_causal`, and of whether an explicit
`attn_mask` is supplied — the bug is in the matmul/softmax sequence
underneath all four MPSGraph codepaths.

The bug is reachable via `sdpa_general_mps` in
`aten/src/ATen/native/mps/operations/Attention.mm`, which builds an
MPSGraph of the form `matrixMultiplicationWithPrimaryTensor` (Q·Kᵀ) →
optional causal/additive mask → `softMaxWithTensor` →
`matrixMultiplicationWithPrimaryTensor` (·V). The threshold shape
(element-counted, not byte-counted, exactly at 2^32) is consistent
with a 32-bit flat element index somewhere inside Apple's matmul or
softmax kernel, but the bug has not been confirmed against Apple
source. PyTorch's own custom Metal kernels in
`aten/src/ATen/native/mps/kernels/Attention.metal` are not involved
for shapes that hit this bug — `_scaled_dot_product_attention_math_mps`
only dispatches to those when `query_seq_len <= 8`, and the affected
shapes have much larger Q.

Note that `Attention.mm` also defines a third path,
`sdpa_full_attention_mps`, that wires up the custom `attention` Metal
kernel and would not go through MPSGraph at all — but it is dead code
on `main`, never called from the dispatcher (the
`test_fast_full_attention_*` tests are correspondingly all skipped
with "Full attention fast kernel not implemented yet"). Enabling it
was therefore not a viable fix for this PR.

Since SDPA's softmax is row-wise over the Q axis, splitting Q into
chunks and concatenating outputs is mathematically exact.
`sdpa_general_mps` now factors its existing graph build/run into
`sdpa_general_mps_impl` and wraps it: when the score matrix is small
enough (≤ 2^32 elements) it calls the impl once, preserving the
original codepath byte-for-byte; otherwise it loops over Q slices of
size `max(1, 2^32 / (B*H*Nkv))` and stitches the outputs back
together. For `is_causal=True`, the wrapper synthesizes a per-chunk
additive causal mask from the chunk's Q offset and passes it to the
impl with `is_causal=false` (the in-graph causal path assumes the
chunk starts at row 0). User-supplied `attn_mask` is narrowed along
the Q axis. A `TORCH_WARN_ONCE` guards the unrealistic edge case where
`B*H*Nkv` alone exceeds 2^32.

Suggested review order: read the new `sdpa_general_mps_impl` first
(it's the unchanged old body), then the new `sdpa_general_mps`
wrapper, then the test.

## Test plan

- [x] \`python test/test_mps.py -k attention -v\` — 96 tests, all pass
  (skipped=24, expected failures=10, identical to baseline)
- [x] \`python test/test_mps.py -k test_sdpa_large_score_matrix_179352 -v\`
  — 4/4 pass on a 64 GB Mac (3 variants + meta)
- [x] Empirical sweep across dtypes (fp32/fp16/bf16),
  \`is_causal=True/False\`, and bool/additive masks — all formerly
  failing shapes now match CPU to ~1e-5 max relative error
- [x] Lint clean (\`spin lint\`)
- [x] Skipped on CI by design (\`total_memory >= 64 GB\` + \`IS_CI\` gates)

Authored with the assistance of Claude (Anthropic).