### PR TITLE
Preserve seq_nr when patching autograd.grad

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2713,6 +2713,28 @@ instantiate_device_type_tests(
 class ActivationCheckpointingNonStrictTracerTests(torch._dynamo.test_case.TestCase):
     """Tests for non-strict tracing flag interaction with checkpoint."""
 
+    def test_backward_nodes_have_seq_nr_under_non_strict(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = nn.Parameter(torch.randn(4, 4))
+
+            def forward(self, x):
+                return checkpoint(
+                    lambda x: torch.sin(x @ self.w), x, use_reentrant=False
+                )
+
+        gm = self._trace_train_step(Model(), torch.randn(2, 4))
+        backward_seq_nrs = [
+            node.meta["seq_nr"]
+            for node in gm.graph.nodes
+            if node.meta.get("custom", {}).get("autograd_backward", False)
+            and "seq_nr" in node.meta
+        ]
+
+        self.assertTrue(backward_seq_nrs)
+        self.assertTrue(all(seq_nr >= 0 for seq_nr in backward_seq_nrs))
+
     def test_patch_autograd_grad_requires_non_strict_tracing(self):
         x = torch.randn(2, 4, requires_grad=True)
         loss = torch.sin(x).sum()

--- a/torch/_functorch/_aot_autograd/logging_utils.py
+++ b/torch/_functorch/_aot_autograd/logging_utils.py
@@ -139,6 +139,16 @@ def setup_stacktrace_preservation_hooks(roots: list[torch.autograd.graph.Node]) 
         node.register_hook(get_posthook(special_stack, node._sequence_nr()))
 
 
+def setup_stacktrace_preservation_hooks_from_tensors(outputs: Any) -> None:
+    roots = [
+        t.grad_fn
+        for t in (outputs if isinstance(outputs, (list, tuple)) else (outputs,))
+        if isinstance(t, torch.Tensor) and t.grad_fn is not None
+    ]
+    if roots:
+        setup_stacktrace_preservation_hooks(roots)
+
+
 def describe_input(i: int, aot_config: AOTConfig) -> str:
     if i < aot_config.num_params_buffers:
         return f"parameter/buffer {i}"

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -492,6 +492,9 @@ def _patch_autograd_grad():
 
     import torch.autograd
     import torch.fx.traceback as fx_traceback
+    from torch._functorch._aot_autograd.logging_utils import (
+        setup_stacktrace_preservation_hooks_from_tensors,
+    )
 
     _orig_grad = torch.autograd.grad
 
@@ -502,6 +505,8 @@ def _patch_autograd_grad():
                 "_patch_autograd_grad() must be used under "
                 "_non_strict_tracing_context()"
             )
+
+        setup_stacktrace_preservation_hooks_from_tensors(outputs)
 
         with fx_traceback.annotate({"autograd_backward": True}):
             return _orig_grad(outputs, inputs, *args, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179598
* #179105
* #179043

Add seq_nr tracking to the patched `autograd.grad` path under
non-strict tracing, and cover it with a train-step tracing test.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98