### PR TITLE
[ROCm][Inductor] Add config flag to disable pointer_range_32 optimization (#179604)

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -189,6 +189,59 @@ class TestCodegenTriton(InductorTestCase):
             sympy.Float(0.5) + TruncToFloat(s0),
         )
 
+    @inductor_config.patch("triton.emit_pointer_range_32", True)
+    def test_config_of_emit_pointer_range_32_enabled(self):
+        from torch._inductor.utils import (
+            get_triton_attrs_descriptor_version,
+            TritonAttrsDescriptorVersion,
+        )
+
+        sixteen = sympy.Integer(16)
+        s0 = sympy.Symbol("s0", positive=True, integer=True)
+
+        config = triton_utils.config_of(
+            [SizeArg("A", sixteen), SizeArg("B", s0)],
+            pointer_range_override=(0,),
+        )
+
+        if get_triton_attrs_descriptor_version() in {
+            TritonAttrsDescriptorVersion.V0_NO_TRITON,
+            TritonAttrsDescriptorVersion.V1_COMPILER,
+            TritonAttrsDescriptorVersion.V2_BACKENDS,
+            TritonAttrsDescriptorVersion.V3_BACKENDS_TUPLE,
+        }:
+            self.assertEqual(config.pointer_range_32, (0,))
+        else:
+            self.assertIsInstance(config, dict)
+            self.assertIn(["tt.pointer_range", 32], config[(0,)])
+
+    @inductor_config.patch("triton.emit_pointer_range_32", False)
+    def test_config_of_emit_pointer_range_32_disabled(self):
+        from torch._inductor.utils import (
+            get_triton_attrs_descriptor_version,
+            TritonAttrsDescriptorVersion,
+        )
+
+        sixteen = sympy.Integer(16)
+        s0 = sympy.Symbol("s0", positive=True, integer=True)
+
+        config = triton_utils.config_of(
+            [SizeArg("A", sixteen), SizeArg("B", s0)],
+            pointer_range_override=(),
+        )
+
+        if get_triton_attrs_descriptor_version() in {
+            TritonAttrsDescriptorVersion.V0_NO_TRITON,
+            TritonAttrsDescriptorVersion.V1_COMPILER,
+            TritonAttrsDescriptorVersion.V2_BACKENDS,
+            TritonAttrsDescriptorVersion.V3_BACKENDS_TUPLE,
+        }:
+            self.assertEqual(config.pointer_range_32, ())
+        else:
+            self.assertIsInstance(config, dict)
+            if (0,) in config:
+                self.assertNotIn(["tt.pointer_range", 32], config[(0,)])
+
     @unittest.skipUnless(torch.version.hip is not None, "pointer_range_32 is HIP-only")
     @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
     def test_pointer_range_in_generated_code(self):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5839,7 +5839,10 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         # Compute configs after codegen_body() so we know if the kernel
         # uses atomic ops. On HIP, buffer ops don't support atomics, so
         # we must not tag any args with pointer_range_32 in that case.
-        if torch.version.hip is not None and self.atomic_add_found:
+        # Also disable pointer_range_32 when the config flag is off.
+        if torch.version.hip is not None and (
+            self.atomic_add_found or not config.triton.emit_pointer_range_32
+        ):
             triton_meta["configs"] = [config_of(signature, pointer_range_override=())]
         else:
             triton_meta["configs"] = [config_of(signature)]

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1872,6 +1872,13 @@ class triton:
     # hint to Triton when arguments are divisible by 16
     divisible_by_16 = os.environ.get("TORCHINDUCTOR_DIVISIBLE_BY_16", "1") == "1"
 
+    # On AMD/HIP, annotate pointer args with tt.pointer_range=32 when the
+    # tensor storage provably fits in 2 GB. This lets Triton emit efficient
+    # buffer load/store ops. Disable if a Triton compiler bug is triggered.
+    emit_pointer_range_32 = (
+        os.environ.get("TORCHINDUCTOR_EMIT_POINTER_RANGE_32", "1") == "1"
+    )
+
     # Minimum R0_BLOCK to be used for a TritonSplitScanKernel
     # NOTE: This also indirectly controls the size of workspace buffer required
     min_split_scan_rblock = 256


### PR DESCRIPTION
Summary:

Add config.triton.emit_pointer_range_32 (default True) to allow disabling
the tt.pointer_range=32 annotation on AMD/HIP targets. When set to False,
pointer_range_32 is always empty.

This provides a workaround for a Triton compiler bug triggered by
canonicalize_pointers when pointer_range_32 annotations are present.

Test Plan: existing inductor tests, set config.triton.emit_pointer_range_32=False to disable

Reviewed By: eellison

Differential Revision: D99457504


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos