### PR TITLE
[ROCm] Fix efficient attention meta kernel logsumexp dim for HIP

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6672,9 +6672,14 @@ def meta__efficient_attention_forward(
             )
         actual_max_seqlen_q = max_seqlen_q
     actual_max_seqlen_k = max_seqlen_k if max_seqlen_k is not None else N
-    logsumexp_dim = (
-        math.ceil(actual_max_seqlen_q / 32) * 32 if compute_log_sumexp else 0
-    )
+    if torch.version.hip and torch.cuda.is_available():
+        # See https://github.com/pytorch/pytorch/issues/146848
+        # ROCm CK and AOTriton return logsumexp with raw seqlen, no rounding
+        logsumexp_dim = actual_max_seqlen_q if compute_log_sumexp else 0
+    else:
+        logsumexp_dim = (
+            math.ceil(actual_max_seqlen_q / 32) * 32 if compute_log_sumexp else 0
+        )
     logsum_exp = torch.empty(
         (logsumexp_batch_dim, num_heads, logsumexp_dim),
         dtype=torch.float,


### PR DESCRIPTION
Fixes #146848

The `_efficient_attention_forward` meta kernel rounds `logsumexp_dim` up to a multiple of 32 (CUDA xFormers convention), but ROCm CK and AOTriton backends return the raw seqlen without rounding. The sibling `_scaled_dot_product_efficient_attention` already has this fix (line 6326) but `_efficient_attention_forward` was missed.

Authored with assistance from Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang