### PR TITLE
Added c10::layout typecaster for torch.layout

### DIFF
--- a/test/cpp_extensions/extension.cpp
+++ b/test/cpp_extensions/extension.cpp
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include <torch/headeronly/core/Layout.h>
 
 // test include_dirs in setuptools.setup with relative path
 #include <tmp.h>
@@ -58,4 +59,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("get_symintarrayref", []() { return at::SymIntArrayRef({1, 2, 3}); });
   m.def("get_tensor", []() { return random_tensor(); });
   m.def("get_math_type", &get_math_type);
+  m.def("roundtrip_layout", [](c10::Layout layout) -> c10::Layout { return layout; });
 }

--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -279,16 +279,17 @@ class TestPybindTypeCasters(common.TestCase):
         for funcs in union_functions:
             with self.subTest(msg=f"check {[f.__name__ for f in funcs]}"):
                 self.check_union(funcs)
-    
+
     def test_pybind_layout_types(self):
-        layouts = [torch.strided,
+        layouts = [
+            torch.strided,
             torch.sparse_coo,
             torch.sparse_csr,
             torch.sparse_csc,
             torch.sparse_bsr,
             torch.sparse_bsc,
             torch._mkldnn,
-            torch.jagged
+            torch.jagged,
         ]
         for layout in layouts:
             with self.subTest(msg=f"check {layout}"):

--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -279,6 +279,20 @@ class TestPybindTypeCasters(common.TestCase):
         for funcs in union_functions:
             with self.subTest(msg=f"check {[f.__name__ for f in funcs]}"):
                 self.check_union(funcs)
+    
+    def test_pybind_layout_types(self):
+        layouts = [torch.strided,
+            torch.sparse_coo,
+            torch.sparse_csr,
+            torch.sparse_csc,
+            torch.sparse_bsr,
+            torch.sparse_bsc,
+            torch._mkldnn,
+            torch.jagged
+        ]
+        for layout in layouts:
+            with self.subTest(msg=f"check {layout}"):
+                self.assertEqual(cpp_extension.roundtrip_layout(layout), layout)
 
 
 @torch.testing._internal.common_utils.markDynamoStrictTest

--- a/torch/csrc/utils/pybind.cpp
+++ b/torch/csrc/utils/pybind.cpp
@@ -166,17 +166,10 @@ py::handle type_caster<c10::Layout>::cast(
     c10::Layout layout,
     return_value_policy /*unused*/,
     handle /*parent*/) {
-  PyObject* layout_obj =
-      reinterpret_cast<PyObject*>(torch::getTHPLayout(layout));
-  TORCH_CHECK(layout_obj, "Invalid layout: ", static_cast<int>(layout));
-  return handle(layout_obj).inc_ref(); // Increment ref count to ensure the
-                                       // object isn't deallocated
+  return handle(Py_NewRef(torch::getTHPLayout(layout)));
 }
 
 bool type_caster<c10::Layout>::load(handle src, bool /*convert*/) {
-  if (!src) {
-    return false;
-  }
   if (!THPLayout_Check(src.ptr())) {
     return false;
   }

--- a/torch/csrc/utils/pybind.cpp
+++ b/torch/csrc/utils/pybind.cpp
@@ -162,4 +162,27 @@ py::handle type_caster<c10::Scalar>::cast(
     TORCH_INTERNAL_ASSERT(0, "unrecognized scalar type ", scalar.type());
   }
 }
+py::handle type_caster<c10::Layout>::cast(
+    c10::Layout layout,
+    return_value_policy /*unused*/,
+    handle /*parent*/) {
+  PyObject* layout_obj =
+      reinterpret_cast<PyObject*>(torch::getTHPLayout(layout));
+  TORCH_CHECK(layout_obj, "Invalid layout: ", static_cast<int>(layout));
+  return handle(layout_obj).inc_ref(); // Increment ref count to ensure the
+                                       // object isn't deallocated
+}
+
+bool type_caster<c10::Layout>::load(handle src, bool /*convert*/) {
+  if (!src) {
+    return false;
+  }
+  if (!THPLayout_Check(src.ptr())) {
+    return false;
+  }
+  const auto layout = reinterpret_cast<THPLayout*>(src.ptr());
+  value = layout->layout;
+  return true;
+}
+
 } // namespace pybind11::detail

--- a/torch/csrc/utils/pybind.cpp
+++ b/torch/csrc/utils/pybind.cpp
@@ -162,5 +162,4 @@ py::handle type_caster<c10::Scalar>::cast(
     TORCH_INTERNAL_ASSERT(0, "unrecognized scalar type ", scalar.type());
   }
 }
-
 } // namespace pybind11::detail

--- a/torch/csrc/utils/pybind.cpp
+++ b/torch/csrc/utils/pybind.cpp
@@ -162,20 +162,4 @@ py::handle type_caster<c10::Scalar>::cast(
     TORCH_INTERNAL_ASSERT(0, "unrecognized scalar type ", scalar.type());
   }
 }
-py::handle type_caster<c10::Layout>::cast(
-    c10::Layout layout,
-    return_value_policy /*unused*/,
-    handle /*parent*/) {
-  return handle(Py_NewRef(torch::getTHPLayout(layout)));
-}
-
-bool type_caster<c10::Layout>::load(handle src, bool /*convert*/) {
-  if (!THPLayout_Check(src.ptr())) {
-    return false;
-  }
-  const auto layout = reinterpret_cast<THPLayout*>(src.ptr());
-  value = layout->layout;
-  return true;
-}
-
 } // namespace pybind11::detail

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -360,7 +360,7 @@ struct type_caster<c10::complex<T>> {
   }
 };
 template <>
-struct type_caster<c10::Layout> {
+struct TORCH_PYTHON_API type_caster<c10::Layout> {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   PYBIND11_TYPE_CASTER(c10::Layout, _("torch.layout"));

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -359,7 +359,6 @@ struct type_caster<c10::complex<T>> {
     return handle(PyComplex_FromDoubles(complex.real(), complex.imag()));
   }
 };
-
 template <>
 struct type_caster<c10::Layout>
 {
@@ -381,15 +380,12 @@ struct type_caster<c10::Layout>
   PYBIND11_TYPE_CASTER(c10::Layout, _("torch.layout"));
 
   static handle
-    cast(c10::Layout& layout, return_value_policy /*unused*/, handle /*parent*/) {
-      const auto _torch = py::module_::import("torch");
-      const auto cast_layout = static_cast<uint8_t>(layout);
-      if(cast_layout >= static_cast<uint8_t>(c10::Layout::NumOptions))
-      {
-        //not found
-        throw py::type_error("Unvalid layout specification");
-      }
-      return _torch.attr(layout_str.at(cast_layout));
+    cast(c10::Layout layout, return_value_policy /*unused*/, handle /*parent*/) {
+        PyObject* layout_obj = reinterpret_cast<PyObject*>(torch::getTHPLayout(layout));
+        if (!layout_obj) {
+            throw py::type_error("Unsupported or invalid layout for casting");
+        }
+        return handle(layout_obj).inc_ref(); // Increment ref count to ensure the object isn't deallocated
     }
 
     bool load(handle src, bool /*convert*/) {
@@ -401,11 +397,12 @@ struct type_caster<c10::Layout>
       {
         return false;
       }
-      const auto layout = reinterpret_cast<THPLayout*>(src.ptr()); 
+      const auto layout = reinterpret_cast<THPLayout*>(src.ptr());
       value = layout->layout;
       return true;
     }
   };
+
 } // namespace pybind11::detail
 
 namespace torch::impl {

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -368,25 +368,8 @@ struct type_caster<c10::Layout> {
   static handle cast(
       c10::Layout layout,
       return_value_policy /*unused*/,
-      handle /*parent*/) {
-    PyObject* layout_obj =
-        reinterpret_cast<PyObject*>(torch::getTHPLayout(layout));
-    TORCH_CHECK(layout_obj, "Invalid layout: ", static_cast<int>(layout));
-    return handle(layout_obj).inc_ref(); // Increment ref count to ensure the
-                                         // object isn't deallocated
-  }
-
-  bool load(handle src, bool /*convert*/) {
-    if (!src) {
-      return false;
-    }
-    if (!THPLayout_Check(src.ptr())) {
-      return false;
-    }
-    const auto layout = reinterpret_cast<THPLayout*>(src.ptr());
-    value = layout->layout;
-    return true;
-  }
+      handle /*parent*/);
+  bool load(handle src, bool /*convert*/);
 };
 
 } // namespace pybind11::detail

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -359,6 +359,7 @@ struct type_caster<c10::complex<T>> {
     return handle(PyComplex_FromDoubles(complex.real(), complex.imag()));
   }
 };
+
 template <>
 struct TORCH_PYTHON_API type_caster<c10::Layout> {
  public:

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -360,48 +360,49 @@ struct type_caster<c10::complex<T>> {
   }
 };
 template <>
-struct type_caster<c10::Layout>
-{
-  private:
-    //order must be the same as c10::Layout
-    inline static constexpr auto layout_str = std::to_array({
-      "strided",
-      "sparse_coo",
-      "sparse_csr",
-      "_mkldnn",
-      "sparse_csc",
-      "sparse_bsr",
-      "sparse_bsc",
-      "jagged"
-    });
-  static_assert(layout_str.size() == static_cast<size_t>(c10::Layout::NumOptions), "layout_str must have the same number of elements as c10::Layout");
-  public:
+struct type_caster<c10::Layout> {
+ private:
+  // order must be the same as c10::Layout
+  inline static constexpr auto layout_str = std::to_array(
+      {"strided",
+       "sparse_coo",
+       "sparse_csr",
+       "_mkldnn",
+       "sparse_csc",
+       "sparse_bsr",
+       "sparse_bsc",
+       "jagged"});
+  static_assert(
+      layout_str.size() == static_cast<size_t>(c10::Layout::NumOptions),
+      "layout_str must have the same number of elements as c10::Layout");
+
+ public:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   PYBIND11_TYPE_CASTER(c10::Layout, _("torch.layout"));
 
-  static handle
-    cast(c10::Layout layout, return_value_policy /*unused*/, handle /*parent*/) {
-        PyObject* layout_obj = reinterpret_cast<PyObject*>(torch::getTHPLayout(layout));
-        if (!layout_obj) {
-            throw py::type_error("Unsupported or invalid layout for casting");
-        }
-        return handle(layout_obj).inc_ref(); // Increment ref count to ensure the object isn't deallocated
-    }
+  static handle cast(
+      c10::Layout layout,
+      return_value_policy /*unused*/,
+      handle /*parent*/) {
+    PyObject* layout_obj =
+        reinterpret_cast<PyObject*>(torch::getTHPLayout(layout));
+    TORCH_CHECK(layout_obj, "Invalid layout: ", static_cast<int>(layout));
+    return handle(layout_obj).inc_ref(); // Increment ref count to ensure the
+                                         // object isn't deallocated
+  }
 
-    bool load(handle src, bool /*convert*/) {
-      if (!src)
-      {
-        return false;
-      }
-      if(!THPLayout_Check(src.ptr()))
-      {
-        return false;
-      }
-      const auto layout = reinterpret_cast<THPLayout*>(src.ptr());
-      value = layout->layout;
-      return true;
+  bool load(handle src, bool /*convert*/) {
+    if (!src) {
+      return false;
     }
-  };
+    if (!THPLayout_Check(src.ptr())) {
+      return false;
+    }
+    const auto layout = reinterpret_cast<THPLayout*>(src.ptr());
+    value = layout->layout;
+    return true;
+  }
+};
 
 } // namespace pybind11::detail
 

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -361,21 +361,6 @@ struct type_caster<c10::complex<T>> {
 };
 template <>
 struct type_caster<c10::Layout> {
- private:
-  // order must be the same as c10::Layout
-  inline static constexpr auto layout_str = std::to_array(
-      {"strided",
-       "sparse_coo",
-       "sparse_csr",
-       "_mkldnn",
-       "sparse_csc",
-       "sparse_bsr",
-       "sparse_bsc",
-       "jagged"});
-  static_assert(
-      layout_str.size() == static_cast<size_t>(c10::Layout::NumOptions),
-      "layout_str must have the same number of elements as c10::Layout");
-
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   PYBIND11_TYPE_CASTER(c10::Layout, _("torch.layout"));

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/csrc/Layout.h>
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pythoncapi_compat.h>
 
@@ -359,6 +360,52 @@ struct type_caster<c10::complex<T>> {
   }
 };
 
+template <>
+struct type_caster<c10::Layout>
+{
+  private:
+    //order must be the same as c10::Layout
+    inline static constexpr auto layout_str = std::to_array({
+      "strided",
+      "sparse_coo",
+      "sparse_csr",
+      "_mkldnn",
+      "sparse_csc",
+      "sparse_bsr",
+      "sparse_bsc",
+      "jagged"
+    });
+  static_assert(layout_str.size() == static_cast<size_t>(c10::Layout::NumOptions), "layout_str must have the same number of elements as c10::Layout");
+  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+  PYBIND11_TYPE_CASTER(c10::Layout, _("torch.layout"));
+
+  static handle
+    cast(c10::Layout& layout, return_value_policy /*unused*/, handle /*parent*/) {
+      const auto _torch = py::module_::import("torch");
+      const auto cast_layout = static_cast<uint8_t>(layout);
+      if(cast_layout >= static_cast<uint8_t>(c10::Layout::NumOptions))
+      {
+        //not found
+        throw py::type_error("Unvalid layout specification");
+      }
+      return _torch.attr(layout_str.at(cast_layout));
+    }
+
+    bool load(handle src, bool /*convert*/) {
+      if (!src)
+      {
+        return false;
+      }
+      if(!THPLayout_Check(src.ptr()))
+      {
+        return false;
+      }
+      const auto layout = reinterpret_cast<THPLayout*>(src.ptr()); 
+      value = layout->layout;
+      return true;
+    }
+  };
 } // namespace pybind11::detail
 
 namespace torch::impl {

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -369,10 +369,19 @@ struct TORCH_PYTHON_API type_caster<c10::Layout> {
   static handle cast(
       c10::Layout layout,
       return_value_policy /*unused*/,
-      handle /*parent*/);
-  bool load(handle src, bool /*convert*/);
-};
+      handle /*parent*/) {
+    return handle(Py_NewRef(torch::getTHPLayout(layout)));
+  }
 
+  bool load(handle src, bool /*convert*/) {
+    if (!THPLayout_Check(src.ptr())) {
+      return false;
+    }
+    const auto layout = reinterpret_cast<THPLayout*>(src.ptr());
+    value = layout->layout;
+    return true;
+  }
+};
 } // namespace pybind11::detail
 
 namespace torch::impl {

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -361,7 +361,7 @@ struct type_caster<c10::complex<T>> {
 };
 
 template <>
-struct TORCH_PYTHON_API type_caster<c10::Layout> {
+struct type_caster<c10::Layout> {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   PYBIND11_TYPE_CASTER(c10::Layout, _("torch.layout"));


### PR DESCRIPTION
This code translates between C++ c10::Layout and torch.layout objects. This change is needed downstream to implement torch-spyre support.

Replaces https://github.com/pytorch/pytorch/pull/179493 to satisfy CLA check

@Skylion007 @isuruf 