### PR TITLE
  Install stacktrace hooks in patched autograd.grad under non-strict tracing

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2725,15 +2725,24 @@ class ActivationCheckpointingNonStrictTracerTests(torch._dynamo.test_case.TestCa
                 )
 
         gm = self._trace_train_step(Model(), torch.randn(2, 4))
-        backward_seq_nrs = [
+        forward_seq_nrs = {
             node.meta["seq_nr"]
             for node in gm.graph.nodes
-            if node.meta.get("custom", {}).get("autograd_backward", False)
+            if node.op == "call_function"
+            and not node.meta.get("custom", {}).get("autograd_backward", False)
             and "seq_nr" in node.meta
-        ]
+        }
+        backward_seq_nrs = {
+            node.meta["seq_nr"]
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.meta.get("custom", {}).get("autograd_backward", False)
+            and "seq_nr" in node.meta
+        }
 
+        self.assertTrue(forward_seq_nrs)
         self.assertTrue(backward_seq_nrs)
-        self.assertTrue(all(seq_nr >= 0 for seq_nr in backward_seq_nrs))
+        self.assertSetEqual(backward_seq_nrs, forward_seq_nrs)
 
     def test_patch_autograd_grad_requires_non_strict_tracing(self):
         x = torch.randn(2, 4, requires_grad=True)

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2713,6 +2713,28 @@ instantiate_device_type_tests(
 class ActivationCheckpointingNonStrictTracerTests(torch._dynamo.test_case.TestCase):
     """Tests for non-strict tracing flag interaction with checkpoint."""
 
+    def test_backward_nodes_have_seq_nr_under_non_strict(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = nn.Parameter(torch.randn(4, 4))
+
+            def forward(self, x):
+                return checkpoint(
+                    lambda x: torch.sin(x @ self.w), x, use_reentrant=False
+                )
+
+        gm = self._trace_train_step(Model(), torch.randn(2, 4))
+        backward_seq_nrs = [
+            node.meta["seq_nr"]
+            for node in gm.graph.nodes
+            if node.meta.get("custom", {}).get("autograd_backward", False)
+            and "seq_nr" in node.meta
+        ]
+
+        self.assertTrue(backward_seq_nrs)
+        self.assertTrue(all(seq_nr >= 0 for seq_nr in backward_seq_nrs))
+
     def test_patch_autograd_grad_requires_non_strict_tracing(self):
         x = torch.randn(2, 4, requires_grad=True)
         loss = torch.sin(x).sum()

--- a/torch/_functorch/_aot_autograd/logging_utils.py
+++ b/torch/_functorch/_aot_autograd/logging_utils.py
@@ -139,6 +139,16 @@ def setup_stacktrace_preservation_hooks(roots: list[torch.autograd.graph.Node]) 
         node.register_hook(get_posthook(special_stack, node._sequence_nr()))
 
 
+def setup_stacktrace_preservation_hooks_from_tensors(outputs: Any) -> None:
+    roots = [
+        t.grad_fn
+        for t in (outputs if isinstance(outputs, (list, tuple)) else (outputs,))
+        if isinstance(t, torch.Tensor) and t.grad_fn is not None
+    ]
+    if roots:
+        setup_stacktrace_preservation_hooks(roots)
+
+
 def describe_input(i: int, aot_config: AOTConfig) -> str:
     if i < aot_config.num_params_buffers:
         return f"parameter/buffer {i}"

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -490,6 +490,9 @@ def _patch_autograd_grad():
 
     import torch.autograd
     import torch.fx.traceback as fx_traceback
+    from torch._functorch._aot_autograd.logging_utils import (
+        setup_stacktrace_preservation_hooks_from_tensors,
+    )
 
     _orig_grad = torch.autograd.grad
 
@@ -500,6 +503,8 @@ def _patch_autograd_grad():
                 "_patch_autograd_grad() must be used under "
                 "_non_strict_tracing_context()"
             )
+
+        setup_stacktrace_preservation_hooks_from_tensors(outputs)
 
         with fx_traceback.annotate({"autograd_backward": True}):
             return _orig_grad(outputs, inputs, *args, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179610
* #179105
* #179043

Install stacktrace-preservation hooks in the patched `autograd.grad`
 path used during non-strict tracing.

 Under tracing, the usual autograd-engine path that propagates `seq_nr`
 metadata does not run automatically, so backward FX nodes can lose the
 `seq_nr` information needed to correlate them with their forward
 counterparts. Factor hook setup into a helper that extracts roots from
 tensor outputs and invoke it before calling into autograd.

 Add a train-step tracing test that checks backward nodes carry the same
 `seq_nr` metadata as the corresponding forward nodes.

This is basically what we do in TorchTitan today and I am just upstreaming it. 

Authored with Claude.

ghstack-source-id: e70fbc104001e064670f942105563208005fc8e3
 Pull Request resolved: https://github.com/pytorch/pytorch/pull/179610

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98