### PR TITLE
[BE] Create upload-build-artifacts action, mirror download-build-artifacts

### DIFF
--- a/.github/actions/upload-build-artifacts/action.yml
+++ b/.github/actions/upload-build-artifacts/action.yml
@@ -1,0 +1,37 @@
+name: Upload PyTorch Build Artifacts
+
+description: Upload build artifacts to S3 or GHA.
+
+inputs:
+  name:
+    description: Name of the artifact
+    required: true
+  use-gha:
+    description: If set to any value, use GHA to upload the artifact. Otherwise use S3.
+    required: false
+  s3-bucket:
+    description: S3 bucket to upload builds
+    required: false
+    default: "gha-artifacts"
+
+runs:
+  using: composite
+  steps:
+    - name: Upload PyTorch Build Artifacts to S3
+      if: ${{ !inputs.use-gha }}
+      uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
+      with:
+        name: ${{ inputs.name }}
+        retention-days: 14
+        if-no-files-found: error
+        path: artifacts.zip
+        s3-bucket: ${{ inputs.s3-bucket }}
+
+    - name: Upload PyTorch Build Artifacts to GHA
+      if: ${{ inputs.use-gha }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.name }}
+        retention-days: 1
+        if-no-files-found: error
+        path: artifacts.zip

--- a/.github/actions/upload-build-artifacts/action.yml
+++ b/.github/actions/upload-build-artifacts/action.yml
@@ -29,9 +29,9 @@ runs:
 
     - name: Upload PyTorch Build Artifacts to GHA
       if: ${{ inputs.use-gha }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.name }}
-        retention-days: 1
+        retention-days: 14
         if-no-files-found: error
         path: artifacts.zip

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -584,9 +584,6 @@ jobs:
         if: inputs.build-generates-artifacts && (steps.build.outcome != 'skipped' || steps.use-old-whl.outputs.reuse == 'true')
         with:
           name: ${{ inputs.build-environment }}
-          retention-days: 14
-          if-no-files-found: error
-          path: artifacts.zip
           s3-bucket: ${{ inputs.s3-bucket }}
 
       - name: Upload sccache stats

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -584,6 +584,9 @@ jobs:
         if: inputs.build-generates-artifacts && (steps.build.outcome != 'skipped' || steps.use-old-whl.outputs.reuse == 'true')
         with:
           name: ${{ inputs.build-environment }}
+          retention-days: 14
+          if-no-files-found: error
+          path: artifacts.zip
           s3-bucket: ${{ inputs.s3-bucket }}
 
       - name: Upload sccache stats


### PR DESCRIPTION
Extract the S3-vs-GHA upload logic into a composite action that picks the backend based on the use-gha input, matching the pattern used by download-build-artifacts https://github.com/pytorch/pytorch/tree/main/.github/actions/download-build-artifacts