### PR TITLE
 Add kernel annotation support for CUDA graph traces

### DIFF
--- a/test/test_cuda_graph_annotations.py
+++ b/test/test_cuda_graph_annotations.py
@@ -1,0 +1,311 @@
+# Owner(s): ["module: cuda graphs"]
+
+"""Tests for CUDA graph kernel annotation via mark_kernels."""
+
+import unittest
+
+import torch
+from torch.cuda._graph_annotations import (
+    _is_tools_id_unavailable,
+    clear_kernel_annotations,
+    enable_annotations,
+    get_kernel_annotations,
+    mark_kernels,
+    remap_to_exec_graph,
+    resolve_pending_annotations,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+TEST_CUDA = torch.cuda.is_available()
+
+try:
+    import cuda.bindings.runtime  # noqa: F401
+
+    TEST_CUDA_BINDINGS = True
+except ImportError:
+    TEST_CUDA_BINDINGS = False
+
+
+@unittest.skipUnless(TEST_CUDA, "CUDA not available")
+@unittest.skipUnless(TEST_CUDA_BINDINGS, "cuda.bindings not available")
+@unittest.skipIf(
+    _is_tools_id_unavailable(),
+    "cudaGraphNodeGetToolsId not available (needs cuda-compat >= 13.1)",
+)
+class TestMarkKernels(TestCase):
+    def setUp(self):
+        enable_annotations()
+        clear_kernel_annotations()
+
+    def tearDown(self):
+        clear_kernel_annotations()
+
+    def test_noop_outside_capture(self):
+        x = torch.randn(8, device="cuda")
+        with mark_kernels("test"):
+            _ = x + 1
+        self.assertEqual(len(get_kernel_annotations()), 0)
+
+    def test_single_scope(self):
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph):
+            with mark_kernels("phase_a"):
+                _ = x + 1
+            resolve_pending_annotations()
+
+        annotations = get_kernel_annotations()
+        self.assertGreater(len(annotations), 0)
+        for anns in annotations.values():
+            for ann in anns:
+                self.assertEqual(ann, "phase_a")
+
+    def test_multiple_scopes_no_overlap(self):
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph):
+            with mark_kernels("scope_1"):
+                _ = x + 1
+            with mark_kernels("scope_2"):
+                _ = x * 2
+            resolve_pending_annotations()
+
+        annotations = get_kernel_annotations()
+        scope_1_ids = set()
+        scope_2_ids = set()
+        for tid, anns in annotations.items():
+            self.assertEqual(len(anns), 1)
+            if anns[0] == "scope_1":
+                scope_1_ids.add(tid)
+            elif anns[0] == "scope_2":
+                scope_2_ids.add(tid)
+
+        self.assertGreater(len(scope_1_ids), 0)
+        self.assertGreater(len(scope_2_ids), 0)
+        self.assertEqual(len(scope_1_ids & scope_2_ids), 0)
+
+    def test_dict_annotation(self):
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        annotation = {"name": "all_gather", "Group size": 2, "dtype": "bfloat16"}
+        with torch.cuda.graph(graph):
+            with mark_kernels(annotation):
+                _ = x + 1
+            resolve_pending_annotations()
+
+        annotations = get_kernel_annotations()
+        self.assertGreater(len(annotations), 0)
+        for anns in annotations.values():
+            self.assertEqual(anns[0]["name"], "all_gather")
+            self.assertEqual(anns[0]["Group size"], 2)
+
+    def test_clear_resets_state(self):
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph):
+            with mark_kernels("test"):
+                _ = x + 1
+            resolve_pending_annotations()
+
+        self.assertGreater(len(get_kernel_annotations()), 0)
+        clear_kernel_annotations()
+        self.assertEqual(len(get_kernel_annotations()), 0)
+
+    def test_resolve_without_scopes_is_noop(self):
+        resolve_pending_annotations()
+        self.assertEqual(len(get_kernel_annotations()), 0)
+
+    def test_scope_with_no_kernels(self):
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph):
+            _ = x + 1
+            with mark_kernels("empty"):
+                pass
+            _ = x * 2
+            resolve_pending_annotations()
+
+        for anns in get_kernel_annotations().values():
+            for ann in anns:
+                self.assertNotEqual(ann, "empty")
+
+    def test_only_annotates_scope_kernels(self):
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph):
+            _ = x + 1
+            _ = x * 2
+            with mark_kernels("tagged"):
+                _ = x + 3
+            _ = x - 1
+            resolve_pending_annotations()
+
+        annotations = get_kernel_annotations()
+        total_annotated = sum(len(anns) for anns in annotations.values())
+        self.assertGreater(total_annotated, 0)
+        for anns in annotations.values():
+            for ann in anns:
+                self.assertEqual(ann, "tagged")
+
+    def test_nested_scopes_innermost_wins(self):
+        """With nested string scopes, the innermost name wins."""
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph):
+            with mark_kernels("outer"):
+                _ = x + 1  # outer only
+                with mark_kernels("inner"):
+                    _ = x * 2  # nested: inner should win
+                _ = x - 1  # outer only
+            resolve_pending_annotations()
+
+        annotations = get_kernel_annotations()
+        outer_ids = set()
+        inner_ids = set()
+        for tid, anns in annotations.items():
+            self.assertEqual(
+                len(anns), 1, f"toolsId {hex(tid)} has {len(anns)} annotations"
+            )
+            ann = anns[0]
+            # Outer-only kernels stay as raw strings
+            if ann == "outer":
+                outer_ids.add(tid)
+            # Nested kernels get merged into a dict
+            elif isinstance(ann, dict) and ann["name"] == "inner":
+                inner_ids.add(tid)
+
+        self.assertGreater(len(outer_ids), 0, "Should have outer-only kernels")
+        self.assertGreater(len(inner_ids), 0, "Should have inner kernels")
+        self.assertEqual(len(outer_ids & inner_ids), 0)
+
+    def test_nested_dict_scopes_inner_wins_common_keys(self):
+        """With truly nested dict scopes, inner wins for common keys,
+        outer-only keys are preserved."""
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        outer_ann = {"name": "ag_collective", "stream": 71}
+        inner_ann = {
+            "name": "all_gather",
+            "stream": 62,
+            "In msg nelems": 1024,
+            "dtype": "bfloat16",
+        }
+
+        with torch.cuda.graph(graph):
+            with mark_kernels(outer_ann):
+                _ = x + 1  # outer only
+                with mark_kernels(inner_ann):
+                    _ = x * 2  # nested
+                _ = x - 1  # outer only
+            resolve_pending_annotations()
+
+        annotations = get_kernel_annotations()
+        outer_only_ids = set()
+        nested_ids = set()
+        for tid, anns in annotations.items():
+            self.assertEqual(len(anns), 1)
+            ann = anns[0]
+            self.assertIsInstance(ann, dict)
+            if ann["name"] == "ag_collective":
+                outer_only_ids.add(tid)
+            elif ann["name"] == "all_gather":
+                nested_ids.add(tid)
+                # Inner wins for common keys
+                self.assertEqual(ann["stream"], 62)
+                # Inner-only keys preserved
+                self.assertEqual(ann["In msg nelems"], 1024)
+                self.assertEqual(ann["dtype"], "bfloat16")
+
+        self.assertGreater(len(outer_only_ids), 0, "Should have outer-only kernels")
+        self.assertGreater(len(nested_ids), 0, "Should have nested kernels")
+
+    def test_same_range_scopes_inner_wins_common_keys(self):
+        """With same-range scopes (inner ctx exits first), inner wins
+        for common keys, outer-only keys are preserved."""
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        outer_ann = {"name": "ag_collective", "stream": 71}
+        inner_ann = {
+            "name": "all_gather",
+            "stream": 62,
+            "In msg nelems": 1024,
+            "dtype": "bfloat16",
+        }
+
+        with torch.cuda.graph(graph):
+            # Both scopes wrap the same kernels; inner exits first.
+            with mark_kernels(outer_ann):
+                with mark_kernels(inner_ann):
+                    _ = x + 1
+            resolve_pending_annotations()
+
+        annotations = get_kernel_annotations()
+        self.assertGreater(len(annotations), 0)
+        for anns in annotations.values():
+            self.assertEqual(len(anns), 1)
+            ann = anns[0]
+            self.assertIsInstance(ann, dict)
+            # Inner wins for common keys
+            self.assertEqual(ann["name"], "all_gather", "Inner name should win")
+            self.assertEqual(ann["stream"], 62, "Inner stream should win")
+            # Inner-only keys preserved
+            self.assertEqual(ann["In msg nelems"], 1024)
+            self.assertEqual(ann["dtype"], "bfloat16")
+
+    def test_remap_to_exec_graph(self):
+        from cuda.bindings import runtime as cuda_runtime
+
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph):
+            with mark_kernels("test"):
+                _ = x + 1
+            resolve_pending_annotations()
+
+        annotations_before = dict(get_kernel_annotations())
+        self.assertGreater(len(annotations_before), 0)
+
+        exec_handle = cuda_runtime.cudaGraphExec_t(
+            init_value=graph.raw_cuda_graph_exec()
+        )
+        _, exec_graph_id = cuda_runtime.cudaGraphExecGetId(exec_handle)
+
+        remap_to_exec_graph(graph)
+
+        annotations_after = get_kernel_annotations()
+        self.assertEqual(len(annotations_after), len(annotations_before))
+        for tools_id in annotations_after:
+            self.assertEqual(tools_id >> 32, exec_graph_id)
+
+    def test_disabled_is_noop(self):
+        from torch.cuda._graph_annotations import disable_annotations
+
+        disable_annotations()
+
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph):
+            with mark_kernels("should_not_appear"):
+                _ = x + 1
+            resolve_pending_annotations()
+
+        self.assertEqual(len(get_kernel_annotations()), 0)
+
+        # Re-enable for other tests
+        enable_annotations()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1673,6 +1673,12 @@ class triton:
     # skip warmup for cudagraph trees
     skip_cudagraph_warmup = False
 
+    # Enable kernel annotation recording during CUDA graph capture.
+    # When enabled, mark_kernels() scopes within captured code will attach
+    # metadata to kernel graph nodes for matching to profiler traces.
+    # Requires cuda.bindings package and a compatible driver (cuda-compat >= 13.1).
+    cudagraph_kernel_annotations = True
+
     # Synchronize before and after every compiled graph.
     debug_sync_graph = False
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -84,6 +84,12 @@ from torch._inductor.cudagraph_utils import (
     PlaceholderInfo,
     WrappedFunction,
 )
+from torch.cuda._graph_annotations import (
+    clear_kernel_annotations,
+    enable_annotations,
+    remap_to_exec_graph,
+    resolve_pending_annotations,
+)
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.storage import UntypedStorage
 from torch.utils import _pytree as pytree
@@ -1303,6 +1309,9 @@ class CUDAGraphNode:
             ]
             check_memory_pool(self.device, self.cuda_graphs_pool, memory)
 
+        if config.triton.cudagraph_kernel_annotations:
+            clear_kernel_annotations()
+
         with (
             preserve_rng_state(),
             torch.cuda.device(self.device),
@@ -1317,6 +1326,11 @@ class CUDAGraphNode:
             get_history_recording(),
         ):
             static_outputs = model(inputs)
+            if config.triton.cudagraph_kernel_annotations:
+                resolve_pending_annotations()
+
+        if config.triton.cudagraph_kernel_annotations:
+            remap_to_exec_graph(self.graph)
 
         # running model should reclaim memory
         assert len(inputs) == 0
@@ -2042,6 +2056,9 @@ class CUDAGraphTreeManager:
                 ),
             ):
                 pass
+
+        if config.triton.cudagraph_kernel_annotations:
+            enable_annotations()
 
         self.graph_counter = itertools.count(0)
         self.func_counter = itertools.count(0)

--- a/torch/cuda/_annotate_cuda_graph_trace.py
+++ b/torch/cuda/_annotate_cuda_graph_trace.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Post-process a profiler trace to add CUDA graph kernel annotations.
+
+Reads a profiler trace (gzipped or plain JSON) and a kernel annotations
+pickle, matches kernel events by their graph node id, and writes an
+annotated trace with the annotation fields added to each kernel event's
+args (displayed alongside grid/block size in trace viewers).
+
+The annotations pickle is auto-discovered from the trace file's parent
+directory (one level up, matching the rank from the trace filename).
+
+Usage:
+    python -m torch.cuda._annotate_cuda_graph_trace <trace_file> [-a <annotations_pkl>] [-o <output_file>]
+
+Examples:
+    # Auto-discover annotations pickle from trace location
+    python -m torch.cuda._annotate_cuda_graph_trace \\
+        traces/step_000000000014/000000.*.pt.trace.json.gz
+
+    # Explicit annotations pickle
+    python -m torch.cuda._annotate_cuda_graph_trace trace.json.gz -a annotations.pkl
+"""
+
+import argparse
+import gzip
+import json
+import pickle
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+_WORK_CATEGORIES = {"kernel", "gpu_memcpy", "gpu_memset"}
+
+
+def _move_overlapping_to_stream(
+    trace: dict, default_stream: int = 7, overlap_stream: int = 8
+) -> int:
+    """Move graphed kernels that overlap with their predecessor to a separate stream.
+
+    Perfetto cannot display overlapping (non-nested) events on the same
+    stream -- they get hidden.  This pass detects graphed kernel events on
+    *default_stream* whose start timestamp falls before the previous
+    kernel's end, and moves them to *overlap_stream* so they're visible.
+
+    Returns the number of events moved.
+    """
+    graphed_on_default = [
+        e
+        for e in trace["traceEvents"]
+        if e.get("cat") == "kernel"
+        and e.get("tid") == default_stream
+        and e.get("args", {}).get("graph node id", 0) != 0
+    ]
+    graphed_on_default.sort(key=lambda e: e["ts"])
+
+    moved = 0
+    prev_end = 0.0
+    for event in graphed_on_default:
+        ts = event["ts"]
+        dur = event.get("dur", 0)
+        if ts < prev_end:
+            event["tid"] = overlap_stream
+            event.get("args", {})["stream"] = overlap_stream
+            moved += 1
+        else:
+            prev_end = ts + dur
+
+    return moved
+
+
+def _fix_overlapping_timestamps(trace: dict, max_adjust_us: float = 1.0) -> int:
+    """Clamp graphed kernel/memcpy timestamps so they don't overlap on the same stream.
+
+    CUPTI can produce slightly overlapping timestamps for consecutive graphed
+    events, causing Perfetto to hide events that sit entirely "under" their
+    neighbours.  This pass sorts graphed work events per stream and ensures
+    each event starts at or after the previous event's end.
+
+    Overlaps larger than *max_adjust_us* are flagged as warnings and left
+    unchanged, since they likely indicate a real issue rather than CUPTI
+    timestamp jitter.
+
+    Returns the number of events adjusted.
+    """
+    per_stream: dict[int, list[dict]] = defaultdict(list)
+    for event in trace["traceEvents"]:
+        if (
+            event.get("cat") in _WORK_CATEGORIES
+            and event.get("args", {}).get("graph node id", 0) != 0
+        ):
+            per_stream[event.get("tid")].append(event)
+
+    adjusted = 0
+    for tid, events in per_stream.items():
+        events.sort(key=lambda e: e["ts"])
+        prev_end = 0.0
+        for event in events:
+            ts = event["ts"]
+            dur = event.get("dur", 0)
+            if ts < prev_end:
+                overlap = prev_end - ts
+                if overlap > max_adjust_us:
+                    print(
+                        f"WARNING: large overlap {overlap:.3f}us on stream {tid} "
+                        f"for {event.get('name', '?')[:60]}, skipping adjustment"
+                    )
+                else:
+                    event["ts"] = prev_end
+                    adjusted += 1
+            prev_end = event["ts"] + dur
+
+    return adjusted
+
+
+def annotate_trace(
+    trace: dict,
+    annotations: dict[int, list[Any]],
+    default_stream: int = 7,
+) -> int:
+    """Add annotation fields to kernel events matching the annotations dict.
+
+    Each annotation entry is a list (from nested ``mark_kernels`` scopes).
+    Fields from all annotations are merged into the event args; if multiple
+    annotations define the same key, later entries in the list win.
+
+    For graphed events (graph_node_id != 0), reassigns ``tid`` and
+    ``args["stream"]`` to the stream recorded in annotations, or to
+    *default_stream* if there is no annotation.  Also moves the
+    corresponding ``ac2g`` flow-finish events to the new tid so that
+    CPU-to-GPU correlation arrows are preserved.
+
+    Removes ``gpu_user_annotation`` events and orphaned ``ac2g`` events
+    from streams that have no kernel or memcpy events after reassignment,
+    since CUPTI replicates these onto every stream during graph replay.
+
+    Returns the number of events annotated.
+    """
+    # Build an index of ac2g 'f' events keyed by (tid, ts) so we can
+    # move them together with the kernel events they correspond to.
+    ac2g_f_index: dict[tuple, list] = {}
+    for event in trace["traceEvents"]:
+        if event.get("cat") == "ac2g" and event.get("ph") == "f":
+            key = (event.get("tid"), event.get("ts"))
+            ac2g_f_index.setdefault(key, []).append(event)
+
+    annotated = 0
+    for event in trace.get("traceEvents", []):
+        args = event.get("args", {})
+        graph_node_id = args.get("graph node id")
+        if graph_node_id is None or graph_node_id == 0:
+            continue
+        stream_id = None
+        if graph_node_id in annotations:
+            for ann in annotations[graph_node_id]:
+                if isinstance(ann, dict):
+                    for key, value in ann.items():
+                        args[key] = str(value)
+                    if "stream" in ann:
+                        stream_id = int(ann["stream"])
+                else:
+                    args["annotation"] = str(ann)
+            annotated += 1
+
+        # Reassign stream: use annotated stream if available, else default
+        if stream_id is None:
+            stream_id = default_stream
+        old_key = (event.get("tid"), event.get("ts"))
+        event["tid"] = stream_id
+        args["stream"] = stream_id
+
+        # Move the matching ac2g 'f' event(s) to the same new tid
+        for ac2g_event in ac2g_f_index.get(old_key, ()):
+            ac2g_event["tid"] = stream_id
+
+    # Remove gpu_user_annotation events and ac2g flow-finish events from
+    # streams that have no real kernel/memcpy/memset work -- these are
+    # noise replicated by CUPTI onto every stream during graph replay.
+    tids_with_work = set()
+    for event in trace["traceEvents"]:
+        if event.get("cat") in _WORK_CATEGORIES:
+            tids_with_work.add(event.get("tid"))
+
+    def _is_noise(event: dict) -> bool:
+        cat = event.get("cat")
+        if cat == "gpu_user_annotation":
+            return event.get("tid") not in tids_with_work
+        if cat == "ac2g" and event.get("ph") == "f":
+            return event.get("tid") not in tids_with_work
+        return False
+
+    original_count = len(trace["traceEvents"])
+    trace["traceEvents"] = [
+        event for event in trace["traceEvents"] if not _is_noise(event)
+    ]
+    removed = original_count - len(trace["traceEvents"])
+    if removed:
+        print(f"Removed {removed} noise events from empty streams")
+
+    # Clean up metadata: remove thread_name / thread_sort_index entries
+    # for noise streams that have no real (non-metadata) events, and add
+    # thread_name entries for our new annotation streams.
+    all_tids_in_trace = {
+        e.get("tid") for e in trace["traceEvents"] if e.get("ph") != "M"
+    }
+    # Find the GPU process pid from existing thread_name metadata
+    gpu_pid = 0
+    for event in trace["traceEvents"]:
+        if (
+            event.get("ph") == "M"
+            and event.get("name") == "thread_name"
+            and str(event.get("args", {}).get("name", "")).startswith("stream ")
+        ):
+            gpu_pid = event.get("pid", 0)
+            break
+
+    # Remove metadata entries for tids with no non-metadata events
+    trace["traceEvents"] = [
+        event
+        for event in trace["traceEvents"]
+        if event.get("ph") != "M" or event.get("tid") in all_tids_in_trace
+    ]
+
+    # Add thread_name metadata for new annotation tids that lack one
+    existing_thread_names = {
+        e.get("tid")
+        for e in trace["traceEvents"]
+        if e.get("ph") == "M" and e.get("name") == "thread_name"
+    }
+    for tid in sorted(tids_with_work - existing_thread_names):
+        trace["traceEvents"].append(
+            {
+                "ph": "M",
+                "pid": gpu_pid,
+                "tid": tid,
+                "name": "thread_name",
+                "args": {"name": f"stream {tid}"},
+            }
+        )
+
+    return annotated
+
+
+def load_trace(path: Path) -> dict:
+    if path.suffix == ".gz" or path.name.endswith(".json.gz"):
+        with gzip.open(path, "rt") as f:
+            return json.load(f)
+    else:
+        with open(path) as f:
+            return json.load(f)
+
+
+def save_trace(trace: dict, path: Path) -> None:
+    if path.suffix == ".gz" or path.name.endswith(".json.gz"):
+        with gzip.open(path, "wt") as f:
+            json.dump(trace, f)
+    else:
+        with open(path, "w") as f:
+            json.dump(trace, f)
+
+
+def _find_annotations_pkl(trace_file: Path) -> Path | None:
+    """Auto-discover the annotations pickle from the trace file location.
+
+    Trace files live in e.g. ``traces/step_000000000014/000000.<id>.pt.trace.json.gz``
+    where the leading digits are the rank. The pickle lives one level up:
+    ``traces/kernel_annotations_rank0_*.pkl``.
+    """
+    match = re.match(r"^(\d+)", trace_file.name)
+    if not match:
+        return None
+    rank = int(match.group(1))
+
+    traces_dir = trace_file.parent.parent
+    candidates = sorted(traces_dir.glob(f"kernel_annotations_rank{rank}_*.pkl"))
+    if candidates:
+        return candidates[0]
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Annotate a profiler trace with CUDA graph kernel annotations."
+    )
+    parser.add_argument(
+        "trace_file", type=Path, help="Input trace file (.json or .json.gz)"
+    )
+    parser.add_argument(
+        "-a",
+        "--annotations",
+        type=Path,
+        default=None,
+        help="Kernel annotations pickle file. Auto-discovered if omitted.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output file path. Defaults to <trace_file>.annotated.<ext>",
+    )
+    parser.add_argument(
+        "--default-stream",
+        type=int,
+        default=7,
+        help="Stream ID to assign to unannotated graphed events (default: 7).",
+    )
+    args = parser.parse_args()
+
+    annotations_pkl = args.annotations
+    if annotations_pkl is None:
+        annotations_pkl = _find_annotations_pkl(args.trace_file)
+        if annotations_pkl is None:
+            print(
+                f"Could not auto-discover annotations pickle for {args.trace_file}. "
+                f"Use -a to specify it explicitly.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"Auto-discovered annotations: {annotations_pkl}")
+
+    with open(annotations_pkl, "rb") as f:
+        annotations = pickle.load(f)
+    print(f"Loaded {len(annotations)} kernel annotations")
+
+    trace = load_trace(args.trace_file)
+    total_events = len(trace.get("traceEvents", []))
+    print(f"Loaded trace with {total_events} events")
+
+    count = annotate_trace(trace, annotations, default_stream=args.default_stream)
+    print(f"Annotated {count} kernel events")
+
+    overlap_moved = _move_overlapping_to_stream(
+        trace, default_stream=args.default_stream
+    )
+    if overlap_moved:
+        print(f"Moved {overlap_moved} overlapping events to stream 8")
+
+    ts_fixed = _fix_overlapping_timestamps(trace)
+    if ts_fixed:
+        print(f"Fixed {ts_fixed} overlapping graphed event timestamps")
+
+    output = args.output
+    if output is None:
+        name = args.trace_file.name
+        if name.endswith(".json.gz"):
+            output = args.trace_file.with_name(
+                name.replace(".json.gz", ".annotated.json.gz")
+            )
+        elif name.endswith(".json"):
+            output = args.trace_file.with_suffix(".annotated.json")
+        else:
+            output = args.trace_file.with_suffix(args.trace_file.suffix + ".annotated")
+
+    save_trace(trace, output)
+    print(f"Saved annotated trace to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -1,0 +1,433 @@
+"""Annotate CUDA graph kernel nodes during capture.
+
+During CUDA graph capture, ``mark_kernels`` uses ``cudaGraphGetNodes``
+to count nodes before and after the wrapped region.  Nodes at indices
+``[before, after)`` are the ones added within the scope.  Each kernel
+or memcpy node found is annotated by its ``toolsId`` so it can later
+be matched to profiler trace events.
+
+The annotations can be pickled and later merged into a Chrome profiler
+trace using ``torch.cuda._annotate_cuda_graph_trace``.
+
+Requires ``cuda.bindings`` package and a CUDA driver that supports
+``cudaGraphNodeGetToolsId`` (CUDA >= 13.1 or appropriate cuda-compat).
+When unavailable, ``mark_kernels`` silently becomes a no-op.
+
+Usage during capture::
+
+    from torch.cuda._graph_annotations import (
+        enable_annotations,
+        mark_kernels,
+        resolve_pending_annotations,
+        remap_to_exec_graph,
+    )
+
+    enable_annotations()
+
+    with torch.cuda.graph(graph):
+        with mark_kernels("phase_A"):
+            y = workload_a(x)
+        with mark_kernels("phase_B"):
+            z = workload_b(y)
+        resolve_pending_annotations()
+
+    remap_to_exec_graph(graph)
+"""
+
+from collections import defaultdict
+from contextlib import contextmanager
+from logging import getLogger
+from typing import Any
+
+import torch
+
+
+try:
+    from cuda.bindings import (  # pyrefly: ignore[missing-import]
+        runtime as _cuda_runtime,
+    )
+
+    _HAS_CUDA_BINDINGS = True
+except ImportError:
+    _cuda_runtime = None  # type: ignore[assignment]
+    _HAS_CUDA_BINDINGS = False
+
+
+logger = getLogger(__name__)
+
+
+# Tri-state: None = not probed, True = available, False = unavailable.
+# Deferred to first use to avoid premature CUDA initialization.
+_tools_id_available: bool | None = None
+
+# Global kill switch. When False, mark_kernels and mark_stream are no-ops.
+_annotations_enabled: bool = False
+
+
+def enable_annotations() -> None:
+    """Enable kernel annotation recording."""
+    global _annotations_enabled
+    _annotations_enabled = True
+
+
+def disable_annotations() -> None:
+    """Disable kernel annotation recording."""
+    global _annotations_enabled
+    _annotations_enabled = False
+
+
+def _is_tools_id_unavailable() -> bool:
+    """Return True if we already know cudaGraphNodeGetToolsId is missing."""
+    if not _HAS_CUDA_BINDINGS:
+        return True
+    if _tools_id_available is False:
+        return True
+    if not hasattr(_cuda_runtime, "cudaGraphNodeGetToolsId"):
+        return True
+    return False
+
+
+def _check_cuda(result: Any) -> Any:
+    err, *out = result
+    if (
+        err
+        != _cuda_runtime.cudaError_t.cudaSuccess  # pyrefly: ignore[missing-attribute]
+    ):
+        _, err_str = (
+            _cuda_runtime.cudaGetErrorString(  # pyrefly: ignore[missing-attribute]
+                err
+            )
+        )
+        if isinstance(err_str, bytes):
+            err_str = err_str.decode()
+        raise RuntimeError(f"CUDA error: {err} ({err_str})")
+    if len(out) == 0:
+        return None
+    if len(out) == 1:
+        return out[0]
+    return out
+
+
+def _get_tools_id(node: Any) -> int | None:
+    """Return the toolsId for a graph node, or None if unavailable."""
+    global _tools_id_available
+    if _tools_id_available is None:
+        try:
+            tools_id = _check_cuda(
+                _cuda_runtime.cudaGraphNodeGetToolsId(  # pyrefly: ignore[missing-attribute]
+                    node
+                )
+            )
+        except Exception:
+            _tools_id_available = False
+            logger.info(
+                "cudaGraphNodeGetToolsId not available; "
+                "CUDA graph kernel annotations will be disabled"
+            )
+            return None
+        _tools_id_available = True
+        return tools_id
+    return _check_cuda(
+        _cuda_runtime.cudaGraphNodeGetToolsId(  # pyrefly: ignore[missing-attribute]
+            node
+        )
+    )
+
+
+def _get_capture_graph(stream: Any) -> Any:
+    """Return the graph handle for the active capture, or None."""
+    status, _id, graph, _deps, _edge_data, _num_deps = _check_cuda(
+        _cuda_runtime.cudaStreamGetCaptureInfo(  # pyrefly: ignore[missing-attribute]
+            stream
+        )
+    )
+    if (
+        status
+        != _cuda_runtime.cudaStreamCaptureStatus.cudaStreamCaptureStatusActive  # pyrefly: ignore[missing-attribute]
+    ):
+        return None
+    return graph
+
+
+def _get_node_count(graph: Any) -> int:
+    """Return the number of nodes currently in the graph."""
+    _, num = _check_cuda(
+        _cuda_runtime.cudaGraphGetNodes(  # pyrefly: ignore[missing-attribute]
+            graph, numNodes=0
+        )
+    )
+    return num
+
+
+# toolsId -> list of annotation objects.
+_kernel_annotations: defaultdict[int, list[Any]] = defaultdict(list)
+
+# Node types we annotate. Initialized lazily to avoid touching cuda.bindings
+# at import time.
+_ANNOTATABLE_TYPES: set[Any] | None = None
+
+
+def _get_annotatable_types() -> set[Any]:
+    global _ANNOTATABLE_TYPES
+    if _ANNOTATABLE_TYPES is None:
+        _ANNOTATABLE_TYPES = {
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeKernel,  # pyrefly: ignore[missing-attribute]
+            _cuda_runtime.cudaGraphNodeType.cudaGraphNodeTypeMemcpy,  # pyrefly: ignore[missing-attribute]
+        }
+    return _ANNOTATABLE_TYPES
+
+
+# Pending scopes: (annotation, start_node_index, end_node_index).
+_pending_scopes: list[tuple[Any, int, int]] = []
+
+# Graph handle saved during capture for post-capture resolution.
+_capture_graph: Any = None
+
+
+@contextmanager  # type: ignore[arg-type]
+def mark_kernels(annotation: Any):
+    """Context manager that records node index ranges for later annotation.
+
+    During capture, calls ``cudaGraphGetNodes`` to count graph nodes before
+    and after the scope.  Nodes at indices ``[before, after)`` were added
+    inside the scope.  After capture, ``resolve_pending_annotations``
+    enumerates all nodes and annotates kernel/memcpy nodes in those ranges.
+
+    Must be called inside an active ``torch.cuda.graph()`` capture.  If the
+    current stream is not capturing, or if ``cudaGraphNodeGetToolsId`` is not
+    available, the context manager is a no-op.
+
+    Args:
+        annotation: Arbitrary object appended to the annotation list for
+            every kernel/memcpy node whose index falls within this scope.
+    """
+    if not _annotations_enabled or _is_tools_id_unavailable():
+        yield
+        return
+
+    stream = _cuda_runtime.cudaStream_t(  # pyrefly: ignore[missing-attribute]
+        init_value=torch.cuda.current_stream().cuda_stream
+    )
+    graph = _get_capture_graph(stream)
+    if graph is None:
+        yield
+        return
+
+    global _capture_graph
+    _capture_graph = graph
+
+    start_count = _get_node_count(graph)
+
+    yield
+
+    end_count = _get_node_count(graph)
+
+    if end_count > start_count:
+        _pending_scopes.append((annotation, start_count, end_count))
+
+
+def resolve_pending_annotations() -> None:
+    """Resolve pending scope index ranges into kernel annotations.
+
+    Enumerates all graph nodes and annotates kernel/memcpy nodes whose
+    indices fall within recorded scope ranges. Must be called while still
+    inside the ``torch.cuda.graph()`` capture context.
+    """
+    global _capture_graph
+    if not _pending_scopes:
+        _capture_graph = None
+        return
+
+    # Get a fresh graph handle from the active capture.
+    stream = _cuda_runtime.cudaStream_t(  # pyrefly: ignore[missing-attribute]
+        init_value=torch.cuda.current_stream().cuda_stream
+    )
+    graph = _get_capture_graph(stream)
+    if graph is None:
+        graph = _capture_graph
+    if graph is None:
+        logger.warning("resolve_pending_annotations: no graph handle available")
+        _pending_scopes.clear()
+        return
+
+    try:
+        num = _get_node_count(graph)
+        if num == 0:
+            _pending_scopes.clear()
+            _capture_graph = None
+            return
+
+        nodes, num = _check_cuda(
+            _cuda_runtime.cudaGraphGetNodes(  # pyrefly: ignore[missing-attribute]
+                graph, numNodes=num
+            )
+        )
+        annotatable = _get_annotatable_types()
+
+        # Sort by (start, -end, -append_index). The append index encodes
+        # nesting depth: inner context managers exit first, so they are
+        # appended to _pending_scopes first (smaller index). Using
+        # -append_index as tiebreaker ensures that for same-range scopes
+        # the outer scope (larger index) sorts first and is pushed onto
+        # the stack first, leaving the inner scope on top.
+        sorted_scopes = sorted(
+            (
+                (ann, start, end, i)
+                for i, (ann, start, end) in enumerate(_pending_scopes)
+            ),
+            key=lambda s: (s[1], -s[2], -s[3]),
+        )
+        scope_ptr = 0
+        active_stack: list[tuple[int, Any]] = []  # (end_idx, annotation)
+
+        for i in range(num):
+            # Pop scopes whose range ended.
+            while active_stack and active_stack[-1][0] <= i:
+                active_stack.pop()
+
+            # Push scopes that start at or before this index.
+            while scope_ptr < len(sorted_scopes) and sorted_scopes[scope_ptr][1] <= i:
+                ann, _start_idx, end_idx, _idx = sorted_scopes[scope_ptr]
+                if end_idx > i:
+                    active_stack.append((end_idx, ann))
+                scope_ptr += 1
+
+            if not active_stack:
+                continue
+
+            node = nodes[i]
+            node_type = _check_cuda(
+                _cuda_runtime.cudaGraphNodeGetType(  # pyrefly: ignore[missing-attribute]
+                    node
+                )
+            )
+            if node_type not in annotatable:
+                continue
+
+            tools_id = _get_tools_id(node)
+            if tools_id is None:
+                logger.warning(
+                    "resolve_pending_annotations: toolsId unavailable, aborting"
+                )
+                _pending_scopes.clear()
+                _capture_graph = None
+                return
+
+            if len(active_stack) == 1:
+                _kernel_annotations[tools_id].append(active_stack[0][1])
+            else:
+                # Merge all active scopes into one dict. Inner scopes sit
+                # on top of the stack. Iterating reversed (inner first)
+                # with setdefault lets the inner scope's values win for
+                # overlapping keys (e.g. name, stream) while outer scopes
+                # fill in any missing keys.
+                merged: dict[str, Any] = {}
+                for _, ann in reversed(active_stack):
+                    if isinstance(ann, dict):
+                        for ak, av in ann.items():
+                            merged.setdefault(ak, av)
+                    else:
+                        merged.setdefault("name", ann)
+                _kernel_annotations[tools_id].append(merged)
+    except Exception:
+        logger.exception("resolve_pending_annotations failed")
+    finally:
+        _pending_scopes.clear()
+        _capture_graph = None
+
+
+def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
+    """Remap annotation keys from capture graph ID to exec graph ID.
+
+    During capture, toolsId encodes the capture graph's ID in the upper
+    32 bits. After instantiation, the profiler uses the exec graph's ID.
+    This function rewrites the keys so annotations match the trace.
+
+    Must be called after the ``torch.cuda.graph()`` context exits.
+    """
+    if not _kernel_annotations:
+        return
+
+    exec_handle = _cuda_runtime.cudaGraphExec_t(  # pyrefly: ignore[missing-attribute]
+        init_value=torch_cuda_graph.raw_cuda_graph_exec()
+    )
+    exec_graph_id = _check_cuda(
+        _cuda_runtime.cudaGraphExecGetId(  # pyrefly: ignore[missing-attribute]
+            exec_handle
+        )
+    )
+
+    remapped: dict[int, list[Any]] = {}
+    for tools_id, ann_list in _kernel_annotations.items():
+        node_id = tools_id & 0xFFFFFFFF
+        new_tools_id = (exec_graph_id << 32) | node_id
+        if new_tools_id in remapped:
+            remapped[new_tools_id].extend(ann_list)
+        else:
+            remapped[new_tools_id] = list(ann_list)
+
+    _kernel_annotations.clear()
+    _kernel_annotations.update(remapped)
+
+
+def get_kernel_annotations() -> dict[int, list[Any]]:
+    """Return the current kernel annotation map (toolsId -> annotations)."""
+    return _kernel_annotations
+
+
+def clear_kernel_annotations() -> None:
+    """Clear all recorded kernel annotations and pending scopes."""
+    global _capture_graph
+    _kernel_annotations.clear()
+    _pending_scopes.clear()
+    _capture_graph = None
+
+
+# Counter-based stream ID registry. IDs start at 60 (above the highest
+# observed non-graphed CUDA stream ID) so every assigned lane is visually
+# distinct in Perfetto and doesn't collide with real streams.
+_stream_id_counter: int = 60
+_stream_id_map: dict[int, int] = {}
+
+
+def _get_stream_id(stream: torch.cuda.Stream) -> int:
+    """Return a small, stable stream ID for the given CUDA stream."""
+    global _stream_id_counter
+    key = stream.cuda_stream
+    if key not in _stream_id_map:
+        _stream_id_map[key] = _stream_id_counter
+        _stream_id_counter += 1
+    return _stream_id_map[key]
+
+
+def get_stream_for_pg(pg_key: str) -> int:
+    """Return a unique stream ID for the given process group key."""
+    global _stream_id_counter
+    if pg_key not in _stream_id_map:
+        _stream_id_map[pg_key] = _stream_id_counter  # type: ignore[assignment]
+        _stream_id_counter += 1
+    return _stream_id_map[pg_key]  # type: ignore[return-value]
+
+
+@contextmanager  # type: ignore[arg-type]
+def mark_stream(stream: torch.cuda.Stream, annotation: Any):
+    """Switch to stream, inject its ID into annotation, and mark kernels.
+
+    If *stream* is already the current stream, no stream switch or stream ID
+    injection happens — the kernels stay on whatever stream is active (which
+    keeps the trace faithful when e.g. FSDP uses the current stream for
+    copy-in instead of a separate one).
+    """
+    if not _annotations_enabled:
+        with torch.cuda.stream(stream):
+            yield
+        return
+    if stream.cuda_stream == torch.cuda.current_stream().cuda_stream:
+        with mark_kernels(annotation):
+            yield
+    else:
+        if isinstance(annotation, dict):
+            annotation["stream"] = _get_stream_id(stream)
+        with torch.cuda.stream(stream):
+            with mark_kernels(annotation):
+                yield


### PR DESCRIPTION
## [cuda graphs] Add kernel annotation support for CUDA graph traces

### Summary

Adds infrastructure to annotate individual kernels within CUDA graph captures so their metadata (e.g., collective op name, process group, message sizes) appears in perfetto/chrome profiler traces.

This is a port of the internal implementation (D95237028, D96410655) to OSS PyTorch.

**Three components:**

- **`torch/cuda/_graph_annotations.py`** — Core annotation module. Provides `mark_kernels()` context manager that tracks which graph nodes are added during capture using `cudaGraphGetNodes` and `cudaGraphNodeGetToolsId`. Includes `mark_stream()` for stream-aware annotations, nested scope merging (inner wins common keys), and `remap_to_exec_graph()` to fix up graph IDs post-instantiation. Gracefully no-ops when `cuda.bindings` is unavailable.

- **`torch/_inductor/cudagraph_trees.py`** — Integration into `CUDAGraphNode._record()`. Gated behind `config.triton.cudagraph_kernel_annotations` (default `False`). Calls `clear_kernel_annotations()` before capture, `resolve_pending_annotations()` inside the capture context, and `remap_to_exec_graph()` after capture ends.

- **`torch/cuda/_annotate_cuda_graph_trace.py`** — Post-processing script. Reads a profiler trace JSON and an annotations pickle, matches kernel events by `graph node id`, merges annotation fields, reassigns streams, fixes overlapping timestamps from CUPTI, and cleans up noise events. Runnable as `python -m torch.cuda._annotate_cuda_graph_trace`.

### Requirements

- `cuda-python` package (`pip install cuda-python`) for `cuda.bindings.runtime`
- `cuda-compat >= 13.1` on `LD_LIBRARY_PATH` (or driver >= 13.1) for `cudaGraphNodeGetToolsId`

### Example usage

#### 1. Annotating kernels during CUDA graph capture

```python
import torch
from torch.cuda._graph_annotations import (
    enable_annotations,
    mark_kernels,
    resolve_pending_annotations,
    remap_to_exec_graph,
    clear_kernel_annotations,
    get_kernel_annotations,
)

enable_annotations()
clear_kernel_annotations()

x = torch.randn(1024, device="cuda")
graph = torch.cuda.CUDAGraph()

with torch.cuda.graph(graph):
    # Annotate a region with a string
    with mark_kernels("forward_pass"):
        y = x + 1
        z = y * 2

    # Annotate with a dict for richer metadata
    with mark_kernels({"name": "all_gather", "Group size": 8, "dtype": "bfloat16"}):
        w = z - 1

    resolve_pending_annotations()

remap_to_exec_graph(graph)

# Save annotations for later trace post-processing
import pickle
with open("kernel_annotations.pkl", "wb") as f:
    pickle.dump(dict(get_kernel_annotations()), f)

# Replay the graph
graph.replay()
```

#### 2. Annotating with stream awareness (for collectives)

```python
from torch.cuda._graph_annotations import mark_stream, get_stream_for_pg

# Get a unique stream ID for a process group
stream_id = get_stream_for_pg("default_pg")

# mark_stream switches to the stream, injects stream ID, and wraps mark_kernels
ag_stream = torch.cuda.Stream()
with mark_stream(ag_stream, {"name": "all_gather", "stream": stream_id}):
    # collective ops here
    pass
```

#### 3. Nested scopes (inner wins for common keys)

```python
with torch.cuda.graph(graph):
    with mark_kernels({"name": "fsdp_ag", "stream": 71}):
        # outer scope
        with mark_kernels({"name": "all_gather", "stream": 62, "dtype": "bf16"}):
            # inner scope — kernels here get name="all_gather", stream=62, dtype="bf16"
            y = x + 1
        # back to outer — kernels here get name="fsdp_ag", stream=71
        z = y * 2
    resolve_pending_annotations()
```

#### 4. Post-processing a profiler trace

```bash
# After collecting a profiler trace, merge annotations into it:
python -m torch.cuda._annotate_cuda_graph_trace \
    traces/step_14/000000.pt.trace.json.gz \
    -a kernel_annotations.pkl \
    -o annotated_trace.json.gz

# Or auto-discover the annotations pickle from the trace directory:
python -m torch.cuda._annotate_cuda_graph_trace \
    traces/step_14/000000.pt.trace.json.gz
```

#### 5. Enabling via inductor config (for torch.compile + cudagraph trees)

```python
import torch._inductor.config as config
config.triton.cudagraph_kernel_annotations = True

# Now any CUDA graph captured by the inductor will automatically
# call clear/resolve/remap around the capture. Users still need
# mark_kernels() in their model code to annotate specific regions.
```

#### 6. E2E Example adding annotation to perfetto trace:

```python
"""End-to-end example: capture a CUDA graph with annotations, profile it,
and post-process the trace so kernel events carry the annotation metadata.

Run with:
    LD_LIBRARY_PATH=/home/shangdiy/.conda/envs/pytorch-3.12/cuda-compat:$LD_LIBRARY_PATH \
        python agent_space/e2e_annotated_trace.py
"""
import json
import pickle
import tempfile
from pathlib import Path

import torch
from torch.cuda._graph_annotations import (
    clear_kernel_annotations,
    enable_annotations,
    get_kernel_annotations,
    mark_kernels,
    remap_to_exec_graph,
    resolve_pending_annotations,
)
from torch.cuda._annotate_cuda_graph_trace import annotate_trace


def main() -> None:
    enable_annotations()
    clear_kernel_annotations()

    # --- 1. Capture a CUDA graph with annotated regions ---
    x = torch.randn(256, device="cuda")
    graph = torch.cuda.CUDAGraph()

    with torch.cuda.graph(graph):
        with mark_kernels({"name": "linear_fwd", "layer": "0"}):
            y = x * 2 + 1

        with mark_kernels({"name": "all_gather", "dtype": "float32", "Group size": 4}):
            z = y + x

        with mark_kernels("residual_add"):
            out = z + y

        resolve_pending_annotations()

    remap_to_exec_graph(graph)

    annotations = dict(get_kernel_annotations())
    print(f"Captured {len(annotations)} annotated kernel(s)")
    for tid, anns in annotations.items():
        print(f"  toolsId=0x{tid:016x}: {anns}")

    # --- 2. Profile a graph replay ---
    if True:
        tmpdir = "agent_space"
        trace_path = Path(tmpdir) / "trace.json"
        ann_path = Path(tmpdir) / "annotations.pkl"
        out_path = Path(tmpdir) / "trace.annotated.json"

        # Save annotations pickle
        with open(ann_path, "wb") as f:
            pickle.dump(annotations, f)

        # Profile the graph replay
        with torch.profiler.profile(
            activities=[
                torch.profiler.ProfilerActivity.CPU,
                torch.profiler.ProfilerActivity.CUDA,
            ],
        ) as prof:
            for _ in range(3):
                graph.replay()
            torch.cuda.synchronize()

        prof.export_chrome_trace(str(trace_path))
        print(f"\nExported raw trace to {trace_path}")

        # --- 3. Load trace and annotate ---
        with open(trace_path) as f:
            trace = json.load(f)

        count = annotate_trace(trace, annotations)
        print(f"Annotated {count} kernel event(s)")

        # Save annotated trace
        with open(out_path, "w") as f:
            json.dump(trace, f)
        print(f"\nSaved annotated trace to {out_path}")


if __name__ == "__main__":
    main()
```

Result:

<img width="926" height="412" alt="Screenshot 2026-04-08 at 4 06 44 PM" src="https://github.com/user-attachments/assets/96f7799f-ea13-4487-8ed9-11ac24bfcdc3" />



### Files changed

| File | Change |
|------|--------|
| `torch/cuda/_graph_annotations.py` | New — core annotation module |
| `torch/cuda/_annotate_cuda_graph_trace.py` | New — trace post-processing script |
| `test/test_cuda_graph_annotations.py` | New — 13 tests |
| `torch/_inductor/config.py` | Add `cudagraph_kernel_annotations` flag |
| `torch/_inductor/cudagraph_trees.py` | Integrate annotations into capture flow |

### Test plan

```bash
# Install prerequisites
pip install cuda-python
conda install -c nvidia/label/cuda-13.1.0 cuda-compat

# Run tests
LD_LIBRARY_PATH=$CONDA_PREFIX/cuda-compat:$LD_LIBRARY_PATH \
    python test/test_cuda_graph_annotations.py -v
```
Authored with Claude.


based on D95237028 , D96410655
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo