### PR TITLE
Fix index out of range error

### DIFF
--- a/test/dynamo/test_list.py
+++ b/test/dynamo/test_list.py
@@ -261,7 +261,8 @@ class ListTests(TupleTests):
         p = self.thetype("abcd")
         self.assertEqual(p.pop(), "d")
         self.assertEqual(p.pop(1), "b")
-        self.assertRaises(IndexError, p.pop, 10)
+        # The length of p is now 2, valid indices are 0, 1
+        self.assertRaises(IndexError, p.pop, 2)
 
         # Wrong number of arguments
         self.assertRaises(TypeError, p.pop, 2, 3)

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -822,7 +822,7 @@ class CommonListMethodsVariable(BaseListVariable):
 
             if len(args):
                 idx = args[0].as_python_constant()
-                if idx > len(self.items):
+                if idx >= len(self.items):
                     raise_observed_exception(
                         IndexError, tx, args=["pop index out of range"]
                     )


### PR DESCRIPTION
While running tests, I noticed the error,
`torch._dynamo.exc.InternalTorchDynamoError: IndexError: pop index out of range` if attempted pop() with an index equal to the length. For example, if `self.assertRaises(IndexError, p.pop, 10)` in tests is changed to `self.assertRaises(IndexError, p.pop, 2)`, it will run into IndexError: pop index out of range. The original assertion with 10 passes because it's higher than the index length.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98