### PR TITLE
[CUDA] Fix CUDA IPC deserialization mismatch with `expandable_segments` on `FABRIC_HANDLE`

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -143,7 +143,7 @@ namespace Native {
 // counter to track order for Mempool Registration
 std::atomic<int32_t> registration_counter_global{-1};
 
-static char SHAREABLE_HANDLE_VERSION = 2;
+static char SHAREABLE_HANDLE_VERSION = 3;
 enum ShareableHandleType : char {
   SHAREABLE_CUDA_MALLOC = 'c',
   SHAREABLE_CUDA_EXPANDABLE_SEGMENT = 'e'
@@ -381,12 +381,15 @@ struct ExpandableSegment {
       c10::DeviceIndex device,
       std::optional<cudaStream_t> stream,
       size_t segment_size,
-      std::vector<c10::DeviceIndex> peers)
+      std::vector<c10::DeviceIndex> peers,
+      Expandable_Segments_Handle_Type handle_type =
+          Expandable_Segments_Handle_Type::UNSPECIFIED)
       : device_(device),
         stream_(stream),
         // 2MB for small pool, 20MB for large pool
         segment_size_(segment_size),
-        peers_(std::move(peers)) {
+        peers_(std::move(peers)),
+        handle_type_(handle_type) {
     cudaDeviceProp prop{};
     C10_CUDA_CHECK(cudaGetDeviceProperties(&prop, device_));
     mapped_size_ = 0;
@@ -420,22 +423,30 @@ struct ExpandableSegment {
       return rangeFromHandles(begin, end);
     }
 
-    // if the handle type is not specified, try to use fabric handle first.
-    // if it fails, use posix file handle
-    if (CUDAAllocatorConfig::expandable_segments_handle_type() ==
-        Expandable_Segments_Handle_Type::UNSPECIFIED) {
-#ifndef USE_ROCM
-      CUDAAllocatorConfig::set_expandable_segments_handle_type(
-          Expandable_Segments_Handle_Type::FABRIC_HANDLE);
-      auto output = map(range);
-      if (output.ptr != nullptr) {
-        return output;
-      }
+    // In fbcode, IPC handle types for expandable segments are disabled by
+    // default because some jobs were failing (see
+    // https://github.com/pytorch/pytorch/pull/132890), but can be explicitly
+    // enabled via environment variable when IPC functionality is required
+    // (e.g., for multi-process communication with CTran). In non-fbcode
+    // builds, IPC handle types are enabled by default.
+#ifdef FBCODE_CAFFE2
+    constexpr bool default_enable_ipc = false;
+#else
+    constexpr bool default_enable_ipc = true;
 #endif
-      // if fabric handle is not supported, use posix file handle.
-      CUDAAllocatorConfig::set_expandable_segments_handle_type(
-          Expandable_Segments_Handle_Type::POSIX_FD);
-      return map(range);
+    static const bool enable_ipc_handles =
+        c10::utils::check_env("TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC")
+            .value_or(default_enable_ipc);
+
+    // Determine IPC handle type upfront based on config and device capability.
+    // Resolve once per segment lifetime: fromShared() pre-sets handle_type_
+    // from the wire header, and subsequent in-place map() calls (for segment
+    // expansion) keep the same type. This avoids the old lazy try-fallback
+    // pattern that mutated a process-global config and could mis-attribute the
+    // handle type across devices.
+    if (enable_ipc_handles &&
+        handle_type_ == Expandable_Segments_Handle_Type::UNSPECIFIED) {
+      handle_type_ = detectHandleType(device_);
     }
 
     if (end > handles_.size()) {
@@ -446,31 +457,16 @@ struct ExpandableSegment {
       CUmemGenericAllocationHandle handle = 0;
       CUmemAllocationProp prop = {};
       prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-      // In fbcode, IPC handle types for expandable segments are disabled by
-      // default because some jobs were failing (see
-      // https://github.com/pytorch/pytorch/pull/132890), but can be explicitly
-      // enabled via environment variable when IPC functionality is required
-      // (e.g., for multi-process communication with CTran). In non-fbcode
-      // builds, IPC handle types are enabled by default.
-#ifdef FBCODE_CAFFE2
-      static const bool default_enable_ipc = false;
-#else
-      static const bool default_enable_ipc = true;
-#endif
-      static const bool enable_ipc_handles =
-          c10::utils::check_env("TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC")
-              .value_or(default_enable_ipc);
       if (enable_ipc_handles) {
-        if (CUDAAllocatorConfig::expandable_segments_handle_type() !=
-            Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
+        if (handle_type_ == Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
+#ifndef USE_ROCM
+          prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+#endif
+        } else {
 #ifdef USE_ROCM
           prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
 #else
           prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-#endif
-        } else {
-#ifndef USE_ROCM
-          prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
 #endif
         }
       }
@@ -512,26 +508,11 @@ struct ExpandableSegment {
           }
           trimHandles();
           return rangeFromHandles(begin, begin);
+        }
 #ifdef USE_ROCM
-        } else {
-          C10_CUDA_CHECK(status);
-        }
+        C10_CUDA_CHECK(status);
 #else
-        } else if (
-            CUDAAllocatorConfig::expandable_segments_handle_type() ==
-            Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
-          // we are testing if we can use fabric handle.
-          // if we can, we will use it.
-          // if we can't, we will use posix file handle.
-          // so we should not return an error here.
-          // in practice, we can get CUDA_ERROR_NOT_SUPPORTED or
-          // CUDA_ERROR_NOT_PERMITTED to be safe, any non out-of-memory error is
-          // considered as the handle type is not supported. if the handle type
-          // is not supported, return a null range to indicate it.
-          return SegmentRange(nullptr, 0);
-        } else {
-          C10_CUDA_DRIVER_CHECK(status);
-        }
+        C10_CUDA_DRIVER_CHECK(status);
 #endif
       }
       handles_.at(i) = Handle{handle, std::nullopt};
@@ -560,6 +541,15 @@ struct ExpandableSegment {
   // other process, and then restored as an exapandable segment
   // via ExpandableSegment::fromShared(istream);
   SegmentRange share(SegmentRange range, std::ostream& buf) {
+    // IPC requires handle_type_ to have been resolved (which happens inside
+    // map() when enable_ipc_handles is true). If a caller tries to IPC-share
+    // a segment that was allocated with IPC handles disabled, fail loudly
+    // instead of writing an UNSPECIFIED type into the wire header.
+    TORCH_CHECK(
+        handle_type_ != Expandable_Segments_Handle_Type::UNSPECIFIED,
+        "Cannot share an expandable_segments allocation: IPC handles are ",
+        "disabled. Set TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC=1 or disable ",
+        "expandable_segments for cross-process tensors.");
     auto begin = segmentLeft(range.ptr);
     auto end = segmentRight(range.ptr + range.size);
 
@@ -575,13 +565,13 @@ struct ExpandableSegment {
 #endif
     header.segment_size = segment_size_;
     header.num_handles = end - begin;
+    header.handle_type = handle_type_;
 
     buf.write(reinterpret_cast<const char*>(&header), sizeof(ShareHeader));
     for (auto i : c10::irange(begin, end)) {
       // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
       auto& handle = handles_.at(i).value();
-      if (CUDAAllocatorConfig::expandable_segments_handle_type() !=
-          Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
+      if (handle_type_ != Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
         if (!handle.shareable_handle) {
           int fd = 0;
 #ifdef USE_ROCM
@@ -630,8 +620,37 @@ struct ExpandableSegment {
       std::istream& buf) {
     ShareHeader header{};
     buf.read(reinterpret_cast<char*>(&header), sizeof(ShareHeader));
+    // Sanitize the handle_type from the wire header: guard against corrupted
+    // or future-version payloads that somehow slipped past the version gate.
+    TORCH_CHECK(
+        header.handle_type == Expandable_Segments_Handle_Type::UNSPECIFIED ||
+            header.handle_type == Expandable_Segments_Handle_Type::POSIX_FD ||
+            header.handle_type ==
+                Expandable_Segments_Handle_Type::FABRIC_HANDLE,
+        "Unknown Expandable_Segments_Handle_Type in IPC share header: ",
+        static_cast<int>(header.handle_type));
+#ifndef USE_ROCM
+    // If the producer exported a FABRIC handle, the consumer's device must
+    // also support fabric access; otherwise cuMemImportFromShareableHandle
+    // fails deep in the driver with an unhelpful error. Fail fast with an
+    // actionable diagnostic instead.
+    if (header.handle_type == Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
+      TORCH_CHECK(
+          cuda::get_fabric_access(device),
+          "expandable_segments IPC: received FABRIC handle from producer ",
+          "but consumer device ",
+          static_cast<int>(device),
+          " does not support fabric access. Configure ",
+          "PYTORCH_CUDA_ALLOC_CONF=expandable_segments_handle_type:posix_fd ",
+          "on the producer, or disable expandable_segments.");
+    }
+#endif
     auto segment = std::make_unique<ExpandableSegment>(
-        device, std::nullopt, header.segment_size, std::move(peers));
+        device,
+        std::nullopt,
+        header.segment_size,
+        std::move(peers),
+        header.handle_type);
 // older build setups (e.g. multiwheels) do not have this syscall, added 2020
 // but the kernel on the system might still support it.
 #ifndef _WIN32
@@ -642,8 +661,7 @@ struct ExpandableSegment {
 #define SYS_pidfd_getfd 438
 #endif
 #endif // !_WIN32
-    if (CUDAAllocatorConfig::expandable_segments_handle_type() !=
-        Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
+    if (header.handle_type != Expandable_Segments_Handle_Type::FABRIC_HANDLE) {
 #ifdef _WIN32
       TORCH_CHECK(
           false, "IPC expandable segments are not supported on Windows");
@@ -773,6 +791,42 @@ struct ExpandableSegment {
   }
 
  private:
+  // Decide the IPC handle type to use for this segment, based on the global
+  // config and per-device fabric capability. Called once per segment lifetime
+  // (gated on handle_type_ == UNSPECIFIED in map()). On ROCm, FABRIC handles
+  // are not supported and any FABRIC config is rejected with a clear error.
+  static Expandable_Segments_Handle_Type detectHandleType(
+      c10::DeviceIndex device) {
+#ifndef USE_ROCM
+    switch (CUDAAllocatorConfig::expandable_segments_handle_type()) {
+      case Expandable_Segments_Handle_Type::POSIX_FD:
+        return Expandable_Segments_Handle_Type::POSIX_FD;
+      case Expandable_Segments_Handle_Type::FABRIC_HANDLE:
+        TORCH_CHECK(
+            cuda::get_fabric_access(device),
+            "expandable_segments: FABRIC handle type configured but device ",
+            static_cast<int>(device),
+            " does not support fabric access. Set ",
+            "PYTORCH_CUDA_ALLOC_CONF=expandable_segments_handle_type:posix_fd ",
+            "or disable expandable_segments.");
+        return Expandable_Segments_Handle_Type::FABRIC_HANDLE;
+      case Expandable_Segments_Handle_Type::UNSPECIFIED:
+        return cuda::get_fabric_access(device)
+            ? Expandable_Segments_Handle_Type::FABRIC_HANDLE
+            : Expandable_Segments_Handle_Type::POSIX_FD;
+    }
+    TORCH_INTERNAL_ASSERT(false, "unhandled Expandable_Segments_Handle_Type");
+#else
+    TORCH_CHECK(
+        CUDAAllocatorConfig::expandable_segments_handle_type() !=
+            Expandable_Segments_Handle_Type::FABRIC_HANDLE,
+        "expandable_segments: FABRIC handle type is not supported on ROCm. ",
+        "Set PYTORCH_CUDA_ALLOC_CONF=expandable_segments_handle_type:posix_fd.");
+    (void)device;
+    return Expandable_Segments_Handle_Type::POSIX_FD;
+#endif
+  }
+
   void setAccess(c10::DeviceIndex device, size_t begin, size_t end) {
 #if defined(USE_ROCM) && (ROCM_VERSION >= 70200)
     constexpr int num_desc = 2;
@@ -910,18 +964,28 @@ struct ExpandableSegment {
     std::optional<std::variant<int, CUmemFabricHandle>> shareable_handle;
   };
   struct ShareHeader {
+    // All fields have in-class default initializers so that
+    // ShareHeader header{}; and a single missing pair of braces cannot leak
+    // indeterminate bytes over IPC.
 #ifdef _WIN32
-    int pid;
+    int pid = 0;
 #else
-    pid_t pid;
+    pid_t pid = 0;
 #endif
-    size_t segment_size;
-    size_t num_handles;
+    size_t segment_size = 0;
+    size_t num_handles = 0;
+    Expandable_Segments_Handle_Type handle_type =
+        Expandable_Segments_Handle_Type::UNSPECIFIED;
   };
   std::vector<std::optional<Handle>> handles_;
   // devices on which this memory should be mapped in addition
   // to the device where the physical memory lives (device_).
   std::vector<c10::DeviceIndex> peers_;
+  // IPC handle type of the expandable segment. Resolved once per segment
+  // lifetime (see map() / detectHandleType) and serialized into ShareHeader
+  // so that the consumer can deserialize the correct handle shape.
+  Expandable_Segments_Handle_Type handle_type_ =
+      Expandable_Segments_Handle_Type::UNSPECIFIED;
 };
 #else
 struct ExpandableSegment {

--- a/test/distributed/test_p2p_ipc.py
+++ b/test/distributed/test_p2p_ipc.py
@@ -5,6 +5,7 @@
 
 import os
 import unittest
+from contextlib import contextmanager
 
 import torch
 from torch.multiprocessing.reductions import reduce_tensor
@@ -12,7 +13,7 @@ from torch.testing._internal.common_distributed import MultiProcContinuousTest
 from torch.testing._internal.common_utils import (
     requires_cuda_p2p_access,
     run_tests,
-    skipIfRocm,
+    TEST_WITH_ROCM,
 )
 
 
@@ -21,22 +22,47 @@ device_type = "cuda"
 device_module = torch.get_device_module(device_type)
 
 
+@contextmanager
+def _scoped_env(key: str, value: str):
+    """Set an env var for the duration of the context, then restore it."""
+    prior = os.environ.get(key)
+    os.environ[key] = value
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = prior
+
+
 @requires_cuda_p2p_access()
 class P2PIpcTest(MultiProcContinuousTest):
     @classmethod
     def backend_str(cls):
         return "gloo"
 
-    def _init_device(self) -> None:
-        # init and pin the process to the device
+    def _init_device(self, *, allocate: bool = True) -> None:
+        # init and pin the process to the device. When `allocate` is False, we
+        # only set the device without triggering a CUDA allocation. This is
+        # required for the expandable_segments IPC regression test: if the
+        # consumer allocates before fromShared(), that allocation would
+        # "prime" the legacy process-global handle_type and mask the
+        # #179220 (EBADF) bug we are guarding against.
         device_module.set_device(self.device)
-        torch.empty(1, device=self.device)
+        if allocate:
+            torch.empty(1, device=self.device)
 
     @property
     def device(self) -> torch.device:
         return torch.device(device_type, self.rank)
 
-    def _test_p2p_ipc_impl(self, tensor_size: int = 2333) -> None:
+    def _test_p2p_ipc_impl(
+        self,
+        tensor_size: int = 2333,
+        *,
+        consumer_prealloc: bool = True,
+    ) -> None:
         """
         Core P2P IPC test implementation.
 
@@ -50,8 +76,13 @@ class P2PIpcTest(MultiProcContinuousTest):
         Args:
             tensor_size: Size of the tensor to allocate. Larger sizes are needed
                         to trigger expandable segment allocation.
+            consumer_prealloc: Whether ranks other than 0 allocate on the
+                        device before receiving the IPC handle. Set to False
+                        to exercise the expandable_segments IPC path where the
+                        consumer has never touched the allocator (regression
+                        guard for #179220).
         """
-        self._init_device()
+        self._init_device(allocate=(self.rank == 0 or consumer_prealloc))
 
         tensor: torch.Tensor
 
@@ -76,8 +107,8 @@ class P2PIpcTest(MultiProcContinuousTest):
         device_module.synchronize()
         torch.distributed.barrier()
 
-        if not tensor.allclose(tensor, 1):
-            raise AssertionError("Expected tensor to be close to 1")
+        expected = torch.ones_like(tensor)
+        self.assertEqual(tensor, expected, atol=0.0, rtol=0.0)
 
         torch.distributed.barrier()
 
@@ -85,28 +116,33 @@ class P2PIpcTest(MultiProcContinuousTest):
         """Test P2P IPC with regular cudaMalloc allocations."""
         self._test_p2p_ipc_impl()
 
-    @unittest.skip("Requires fix for expandable segments IPC handle type propagation")
-    @skipIfRocm(msg="expandable_segments mode is not supported on ROCm")
+    @unittest.skipIf(
+        TEST_WITH_ROCM, "expandable_segments mode is not supported on ROCm"
+    )
     def test_p2p_ipc_expandable_segments(self) -> None:
         """
         Test P2P IPC with expandable segments enabled.
 
-        This exercises the SHAREABLE_CUDA_EXPANDABLE_SEGMENT path in
-        CUDACachingAllocator::shareIpcHandle() which uses
-        cuMemExportToShareableHandle() instead of cudaIpcGetMemHandle().
+        Exercises the SHAREABLE_CUDA_EXPANDABLE_SEGMENT path in
+        ExpandableSegment::share / fromShared. The consumer does NOT
+        pre-allocate: that's required to catch the #179220 (EBADF) bug where
+        the consumer's process-global handle_type was UNSPECIFIED and the
+        wire header did not carry the producer's handle type, causing the
+        consumer to read a 64-byte fabric handle as a 4-byte POSIX fd.
         """
-        # Enable IPC handles for expandable segments (disabled by default in fbcode)
-        os.environ["TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC"] = "1"
+        # Enable IPC handles for expandable segments (disabled by default in
+        # fbcode). Use a scoped env so state does not leak across tests.
+        with _scoped_env("TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC", "1"):
+            torch.cuda.memory._set_allocator_settings("expandable_segments:True")
+            torch.cuda.empty_cache()
 
-        # Set expandable segments BEFORE any CUDA allocation
-        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
-
-        # Clear existing cached memory to force new allocations from expandable segments
-        torch.cuda.empty_cache()
-
-        # Use a larger tensor size (8MB) to ensure expandable segment allocation
-        # Default segment size is 2MB, so this will trigger segment creation
-        self._test_p2p_ipc_impl(tensor_size=2 * 1024 * 1024)
+            # Use a larger tensor size (8MB) to ensure expandable segment
+            # allocation. Default segment size is 2MB, so this will trigger
+            # segment creation.
+            self._test_p2p_ipc_impl(
+                tensor_size=2 * 1024 * 1024,
+                consumer_prealloc=False,
+            )
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Fix #179220

The IPC handle type is determined lazily in ExpandableSegment::map() on first allocation and stored in a process-global `CUDAAllocatorConfig::expandable_segments_handle_type()`. The producer probes this on its first allocation, but the consumer a freshly spawned process never allocates before receiving IPC data, so its handle type is still `UNSPECIFIED`.

`ExpandableSegment::share()` serializes handles based on the producer's probed type, but the `ShareHeader` struct doesn't include which type was used. `ExpandableSegment::fromShared()` then checks the consumer's local (uninitialized) state to decide how to deserialize, takes the wrong branch.



cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia