### PR TITLE
Enable ruff rule PLW1510 codebase wide

### DIFF
--- a/.ci/pytorch/smoke_test/check_binary_symbols.py
+++ b/.ci/pytorch/smoke_test/check_binary_symbols.py
@@ -131,7 +131,7 @@ def _compile_and_extract_symbols(
 
         result = subprocess.run(
             compile_flags + [str(cpp_file), "-o", str(obj_file)],
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
             timeout=60,
         )
@@ -212,7 +212,7 @@ int main() { return 0; }
 
             result = subprocess.run(
                 compile_flags + [str(cpp_file), "-o", str(obj_file)],
-                capture_output=True,
+                check=False, capture_output=True,
                 text=True,
                 timeout=60,
             )

--- a/.ci/pytorch/smoke_test/check_wheel_tags.py
+++ b/.ci/pytorch/smoke_test/check_wheel_tags.py
@@ -157,7 +157,7 @@ def _check_dylibs_minos(dylibs: list, expected_minos: str, source: str) -> None:
         try:
             result = subprocess.run(
                 ["otool", "-l", str(dylib)],
-                capture_output=True,
+                check=False, capture_output=True,
                 text=True,
                 timeout=30,
             )

--- a/.github/scripts/check_doc_redirects.py
+++ b/.github/scripts/check_doc_redirects.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 def run_git(args: list[str]) -> str:
     """Run a git command and return stdout."""
-    result = subprocess.run(["git"] + args, capture_output=True, text=True)
+    result = subprocess.run(["git"] + args, check=False, capture_output=True, text=True)
     return result.stdout.strip()
 
 

--- a/.github/scripts/test_map_ec2_to_arc.py
+++ b/.github/scripts/test_map_ec2_to_arc.py
@@ -25,7 +25,7 @@ def run(
     else:
         env.pop("GITHUB_OUTPUT", None)
 
-    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+    return subprocess.run(cmd, check=False, capture_output=True, text=True, env=env)
 
 
 def parse_output(stdout: str) -> dict:

--- a/benchmarks/distributed/ddp/benchmark.py
+++ b/benchmarks/distributed/ddp/benchmark.py
@@ -33,7 +33,7 @@ def allgather_object(obj):
 
 
 def allgather_run(cmd):
-    proc = subprocess.run(shlex.split(cmd), capture_output=True)
+    proc = subprocess.run(shlex.split(cmd), check=False, capture_output=True)
     if proc.returncode != 0:
         raise AssertionError(
             f"Command '{cmd}' failed with return code {proc.returncode}: {proc.stderr.decode('utf-8')}"

--- a/benchmarks/dynamo/perf_cli.py
+++ b/benchmarks/dynamo/perf_cli.py
@@ -109,7 +109,7 @@ SUITE_ALIASES = {
 
 def gh(*args: str, json_output: bool = False) -> str | dict | list:
     cmd = ["gh"] + list(args)
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
     if result.returncode != 0:
         print(f"gh error: {result.stderr.strip()}", file=sys.stderr)
         sys.exit(1)
@@ -119,7 +119,7 @@ def gh(*args: str, json_output: bool = False) -> str | dict | list:
 
 
 def git(*args: str) -> str:
-    result = subprocess.run(["git"] + list(args), capture_output=True, text=True)
+    result = subprocess.run(["git"] + list(args), check=False, capture_output=True, text=True)
     return result.stdout.strip()
 
 

--- a/benchmarks/inference/server.py
+++ b/benchmarks/inference/server.py
@@ -333,7 +333,7 @@ if __name__ == "__main__":
             [
                 "wget",
                 "https://download.pytorch.org/models/resnet18-f37072fd.pth",
-            ]
+            ], check=False
         )
         if p.returncode == 0:
             downloaded_checkpoint = True

--- a/benchmarks/instruction_counts/execution/runner.py
+++ b/benchmarks/instruction_counts/execution/runner.py
@@ -266,7 +266,7 @@ class Runner:
             cmd = f'{source_cmd}{PYTHON_CMD} -c "import torch"'
             proc = subprocess.run(
                 cmd,
-                shell=True,
+                check=False, shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 encoding="utf-8",

--- a/benchmarks/upload_scribe.py
+++ b/benchmarks/upload_scribe.py
@@ -41,7 +41,7 @@ class ScribeUploader:
         for m in messages:
             json_str = json.dumps(m)
             cmd = ["scribe_cat", self.category, json_str]
-            subprocess.run(cmd)
+            subprocess.run(cmd, check=False)
 
     def upload(self, messages):
         if os.environ.get("SCRIBE_INTERN"):

--- a/docs/cpp/check_coverage.py
+++ b/docs/cpp/check_coverage.py
@@ -686,7 +686,7 @@ def run_coverxygen(xml_dir: Path) -> str:
                 "--exclude",
                 ".*/stable/library\\.h",
             ],
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
             timeout=120,
         )

--- a/functorch/dim/magic_trace.py
+++ b/functorch/dim/magic_trace.py
@@ -24,9 +24,9 @@ def magic_trace(
                 magic_trace_cache,
                 "-q",
                 "https://github.com/janestreet/magic-trace/releases/download/v1.0.2/magic-trace",
-            ]
+            ], check=False
         )
-        subprocess.run(["chmod", "+x", magic_trace_cache])
+        subprocess.run(["chmod", "+x", magic_trace_cache], check=False)
     args = [magic_trace_cache, "attach", "-pid", str(pid), "-o", output]
     p = subprocess.Popen(args, stderr=subprocess.PIPE, encoding="utf-8")
     if p.stderr is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,7 @@ select = [
     "PLW1501", # bad open mode
     "PLW1507", # shallow copy os.environ
     "PLW1509", # preexec_fn not safe with threads
+    "PLW1510", # subprocess.run without explicit check
     "PLW2101", # useless lock statement
     "PLW3301", # nested min max
     "PT006", # TODO: enable more PT rules

--- a/scripts/compile_tests/update_failures.py
+++ b/scripts/compile_tests/update_failures.py
@@ -78,14 +78,14 @@ def patch_file(
     def remove_file(path, name):
         file = os.path.join(path, name)
         cmd = ["git", "rm", file]
-        subprocess.run(cmd)
+        subprocess.run(cmd, check=False)
 
     def add_file(path, name):
         file = os.path.join(path, name)
         with open(file, "w") as fp:
             pass
         cmd = ["git", "add", file]
-        subprocess.run(cmd)
+        subprocess.run(cmd, check=False)
 
     covered_unexpected_successes = set()
 

--- a/scripts/lintrunner.py
+++ b/scripts/lintrunner.py
@@ -89,7 +89,7 @@ def check_lintrunner_installed(venv_dir: Path) -> None:
             str(venv_dir / "bin" / "python"),
             "lintrunner",
         ],
-        stdout=subprocess.DEVNULL,
+        check=False, stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
     if result.returncode != 0:

--- a/setup.py
+++ b/setup.py
@@ -435,7 +435,7 @@ for i, arg in enumerate(sys.argv):
                     "-v",
                     "--no-build-isolation",
                 ],
-                env={**os.environ},
+                check=False, env={**os.environ},
             )
             sys.exit(result.returncode)
     if arg == "--":
@@ -698,7 +698,7 @@ def get_nightly_git_hash(version: str) -> str:
             torch_version_spec,
         ]
 
-        result = subprocess.run(download_cmd, capture_output=True, text=True)
+        result = subprocess.run(download_cmd, check=False, capture_output=True, text=True)
         if result.returncode != 0:
             raise RuntimeError(
                 f"Failed to download {version} wheel for git hash extraction: {result.stderr}"
@@ -844,7 +844,7 @@ def download_and_extract_nightly_wheel(version: str) -> None:
         ]
 
         report("-- Downloading nightly PyTorch wheel...")
-        result = subprocess.run(download_cmd, capture_output=True, text=True)
+        result = subprocess.run(download_cmd, check=False, capture_output=True, text=True)
         if result.returncode != 0:
             # Try to get the latest nightly version for the same variant to help the user
             variant = extract_variant_from_version(version)

--- a/test/cpp_extensions/libtorch_agn_2_10_extension/test_version_compatibility.py
+++ b/test/cpp_extensions/libtorch_agn_2_10_extension/test_version_compatibility.py
@@ -97,7 +97,7 @@ if not IS_WINDOWS:
 
             cmd.extend([str(source_file), "-o", str(output_file)])
 
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=30)
 
             if result.returncode == 0:
                 return True, ""
@@ -131,7 +131,7 @@ if not IS_WINDOWS:
 
             cmd.extend([str(source_file), "-o", str(output_file)])
 
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=30)
 
             if result.returncode == 0:
                 return True, ""

--- a/test/cpp_extensions/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/test_libtorch_agnostic.py
@@ -1348,7 +1348,7 @@ except RuntimeError as e:
 
         result = subprocess.run(
             [sys.executable, "-c", test_script],
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
             env=env,
         )
@@ -1524,7 +1524,7 @@ except RuntimeError as e:
 
         result = subprocess.run(
             [sys.executable, "-c", test_script],
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
             env=env,
         )

--- a/test/distributed/tensor/test_strategy_validation.py
+++ b/test/distributed/tensor/test_strategy_validation.py
@@ -1438,7 +1438,7 @@ class TestMainModule(TestCase):
                 "cpu",
                 *extra_args,
             ],
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
             timeout=120,
         )

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3023,7 +3023,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
                 )
                 result = subprocess.run(
                     [sys.executable, "-c", script],
-                    env=env,
+                    check=False, env=env,
                     capture_output=True,
                     text=True,
                 )

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -4590,7 +4590,7 @@ torch.testing.assert_close(out_export, out_orig)
 """
         result = subprocess.run(
             [sys.executable, "-c", code],
-            env=env,
+            check=False, env=env,
             capture_output=True,
             text=True,
         )

--- a/test/dynamo/test_fx_graph_runnable.py
+++ b/test/dynamo/test_fx_graph_runnable.py
@@ -185,7 +185,7 @@ class FxGraphRunnableTest(TestCase):
             tmp.write(payload)
             tmp.flush()
             res = subprocess.run(
-                [sys.executable, tmp.name], capture_output=True, text=True, timeout=45
+                [sys.executable, tmp.name], check=False, capture_output=True, text=True, timeout=45
             )
 
             self.assertEqual(
@@ -633,7 +633,7 @@ class TestFxGraphRunnableMultiProcessGroup(TestCase):
                 tmp.flush()
                 result = subprocess.run(
                     [sys.executable, tmp.name],
-                    capture_output=True,
+                    check=False, capture_output=True,
                     text=True,
                     timeout=60,
                 )

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -8162,7 +8162,7 @@ import torch
 torch._inductor.aoti_load_package("{model_path}")
 """
             result = subprocess.run(
-                [sys.executable, "-c", script], capture_output=True, text=True
+                [sys.executable, "-c", script], check=False, capture_output=True, text=True
             )
             self.assertEqual(
                 result.returncode,

--- a/test/inductor/test_deterministic.py
+++ b/test/inductor/test_deterministic.py
@@ -164,7 +164,7 @@ class DeterministicTest(TestCase):
             print("Command", cmd)
             env = os.environ.copy()
             _setup_env(env)
-            out = subprocess.run(cmd.split(), capture_output=True, env=env)
+            out = subprocess.run(cmd.split(), check=False, capture_output=True, env=env)
 
             # We don't check the accuracy against eager here because some
             # of the combination between model and precision can not
@@ -181,7 +181,7 @@ class DeterministicTest(TestCase):
 
             # distort benchmarking results
             env["TORCHINDUCTOR_DISTORT_BENCHMARKING_RESULT"] = "inverse"
-            out = subprocess.run(cmd.split(), capture_output=True, env=env)
+            out = subprocess.run(cmd.split(), check=False, capture_output=True, env=env)
             self.assertTrue(
                 "The result is bitwise equivalent to the previously saved result"
                 in out.stdout.decode(),

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -265,7 +265,7 @@ class TestLazyCompileKernelCollision(InductorTestCase):
             # First run: cold compile, populates on-disk caches.
             r1 = subprocess.run(
                 [sys.executable, "-c", _LAZY_COMPILE_COLLISION_SCRIPT],
-                capture_output=True,
+                check=False, capture_output=True,
                 text=True,
                 env=env,
             )
@@ -273,7 +273,7 @@ class TestLazyCompileKernelCollision(InductorTestCase):
             # Second run: warm caches trigger the collision without the fix.
             r2 = subprocess.run(
                 [sys.executable, "-c", _LAZY_COMPILE_COLLISION_SCRIPT],
-                capture_output=True,
+                check=False, capture_output=True,
                 text=True,
                 env=env,
             )

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -827,7 +827,7 @@ torch.cuda.synchronize()
 """
             p = subprocess.run(
                 [sys.executable, "-c", script],
-                cwd=os.path.dirname(os.path.realpath(__file__)),
+                check=False, cwd=os.path.dirname(os.path.realpath(__file__)),
                 capture_output=True,
                 text=True,
             )

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -157,7 +157,7 @@ class TestCppExtensionJIT(common.TestCase):
             if IS_WINDOWS:
                 # rmtree returns permission error: [WinError 5] Access is denied
                 # on Windows, this is a workaround
-                subprocess.run(["rd", "/s", "/q", temp_dir], stdout=subprocess.PIPE)
+                subprocess.run(["rd", "/s", "/q", temp_dir], check=False, stdout=subprocess.PIPE)
             else:
                 shutil.rmtree(temp_dir)
 
@@ -305,7 +305,7 @@ class TestCppExtensionJIT(common.TestCase):
             if IS_WINDOWS:
                 # rmtree returns permission error: [WinError 5] Access is denied
                 # on Windows, this is a word-around
-                subprocess.run(["rm", "-rf", temp_dir], stdout=subprocess.PIPE)
+                subprocess.run(["rm", "-rf", temp_dir], check=False, stdout=subprocess.PIPE)
             else:
                 shutil.rmtree(temp_dir)
 
@@ -1528,7 +1528,7 @@ except RuntimeError as e:
 
                 result = subprocess.run(
                     [sys.executable, "-c", test_script],
-                    capture_output=True,
+                    check=False, capture_output=True,
                     text=True,
                     env=env,
                 )

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -335,7 +335,7 @@ torch.cuda.memory._set_allocator_settings(
 t = torch.ones(1024 * 1024, pin_memory=True)
 print(t.is_pinned())
 """
-        proc = subprocess.run([sys.executable, "-c", script], capture_output=True)
+        proc = subprocess.run([sys.executable, "-c", script], check=False, capture_output=True)
         self.assertEqual(proc.returncode, 0)
 
     def test_cudart_register(self):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4577,7 +4577,7 @@ except RuntimeError as e:
 """
         result = subprocess.run(
             [sys.executable, "-c", script],
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stderr)

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1303,7 +1303,7 @@ for t in threads:
 """
         result = subprocess.run(
             [sys.executable, "-c", script],
-            capture_output=True,
+            check=False, capture_output=True,
             timeout=60,
         )
         self.assertEqual(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -813,7 +813,7 @@ class TestStandaloneCPPJIT(TestCase):
             for shell in [True, False]:
                 r = subprocess.run(
                     [exec_path],
-                    shell=shell,
+                    check=False, shell=shell,
                     stdout=subprocess.PIPE,
                 )
                 self.assertEqual(r.returncode, 0)

--- a/tools/create_worktree.py
+++ b/tools/create_worktree.py
@@ -72,7 +72,7 @@ def get_submodule_commit(parent_repo: Path, submodule_path: str) -> str | None:
     """Get the commit hash a parent repo expects for a submodule."""
     result = subprocess.run(
         ["git", "ls-tree", "HEAD", submodule_path],
-        capture_output=True,
+        check=False, capture_output=True,
         text=True,
         cwd=parent_repo,
     )
@@ -165,7 +165,7 @@ def clone_submodule_recursive(
     # `git submodule status --recursive` recognizes them.
     subprocess.run(
         ["git", "submodule", "init"],
-        cwd=worktree_sub,
+        check=False, cwd=worktree_sub,
         capture_output=True,
         text=True,
     )

--- a/tools/experimental/torchfuzz/multi_process_fuzzer.py
+++ b/tools/experimental/torchfuzz/multi_process_fuzzer.py
@@ -116,7 +116,7 @@ def run_fuzzer_with_seed(
 
         result = subprocess.run(
             cmd,
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
             timeout=300,  # 5 minute timeout per seed
         )

--- a/tools/experimental/torchfuzz/test_determinism.py
+++ b/tools/experimental/torchfuzz/test_determinism.py
@@ -17,7 +17,7 @@ def run_fuzzer_with_seed(seed):
             f.unlink()
 
     result = subprocess.run(
-        cmd, capture_output=True, text=True, cwd=Path(__file__).parent
+        cmd, check=False, capture_output=True, text=True, cwd=Path(__file__).parent
     )
 
     # Always attempt to read the generated file even if execution failed.

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -37,7 +37,7 @@ def get_tag(pytorch_root: str | Path) -> str:
     try:
         tag = subprocess.run(
             ["git", "describe", "--tags", "--exact"],
-            cwd=pytorch_root,
+            check=False, cwd=pytorch_root,
             encoding="ascii",
             capture_output=True,
         ).stdout.strip()

--- a/tools/linter/adapters/actionlint_linter.py
+++ b/tools/linter/adapters/actionlint_linter.py
@@ -56,7 +56,7 @@ def run_command(
     try:
         return subprocess.run(
             args,
-            capture_output=True,
+            check=False, capture_output=True,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/cmake_linter.py
+++ b/tools/linter/adapters/cmake_linter.py
@@ -61,7 +61,7 @@ def run_command(
     try:
         return subprocess.run(
             args,
-            capture_output=True,
+            check=False, capture_output=True,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/grep_linter.py
+++ b/tools/linter/adapters/grep_linter.py
@@ -58,7 +58,7 @@ def run_command(
     try:
         return subprocess.run(
             args,
-            capture_output=True,
+            check=False, capture_output=True,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/lintrunner_version_linter.py
+++ b/tools/linter/adapters/lintrunner_version_linter.py
@@ -35,7 +35,7 @@ def toVersionString(version_tuple: tuple[int, int, int]) -> str:
 
 if __name__ == "__main__":
     version_str = (
-        subprocess.run(["lintrunner", "-V"], stdout=subprocess.PIPE)
+        subprocess.run(["lintrunner", "-V"], check=False, stdout=subprocess.PIPE)
         .stdout.decode("utf-8")
         .strip()
     )

--- a/tools/linter/adapters/mypy_linter.py
+++ b/tools/linter/adapters/mypy_linter.py
@@ -70,7 +70,7 @@ def run_command(
     try:
         return subprocess.run(
             args,
-            capture_output=True,
+            check=False, capture_output=True,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/pyrefly_linter.py
+++ b/tools/linter/adapters/pyrefly_linter.py
@@ -97,7 +97,7 @@ def run_command(
     try:
         return subprocess.run(
             args,
-            capture_output=True,
+            check=False, capture_output=True,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/shellcheck_linter.py
+++ b/tools/linter/adapters/shellcheck_linter.py
@@ -48,7 +48,7 @@ def run_command(
     try:
         return subprocess.run(
             args,
-            capture_output=True,
+            check=False, capture_output=True,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -236,7 +236,7 @@ def get_added_lines(filename: str) -> set[int]:
         # Check uncommitted changes (working directory vs HEAD)
         result = subprocess.run(
             ["git", "diff", "HEAD", filename],
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
             timeout=5,
         )
@@ -246,7 +246,7 @@ def get_added_lines(filename: str) -> set[int]:
         # Get merge-base with origin/main to check all PR commits
         result = subprocess.run(
             ["git", "fetch", "origin", "main"],
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
             timeout=600,
         )
@@ -257,7 +257,7 @@ def get_added_lines(filename: str) -> set[int]:
 
         result = subprocess.run(
             ["git", "merge-base", "HEAD", "origin/main"],
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
             timeout=5,
         )
@@ -271,7 +271,7 @@ def get_added_lines(filename: str) -> set[int]:
         merge_base = result.stdout.strip()
         result = subprocess.run(
             ["git", "diff", f"{merge_base}..HEAD", filename],
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
             timeout=5,
         )

--- a/tools/linter/clang_tidy/generate_build_files.py
+++ b/tools/linter/clang_tidy/generate_build_files.py
@@ -9,7 +9,7 @@ def run_cmd(cmd: list[str]) -> None:
     print(f"Running: {cmd}")
     result = subprocess.run(
         cmd,
-        capture_output=True,
+        check=False, capture_output=True,
     )
     stdout, stderr = (
         result.stdout.decode("utf-8").strip(),

--- a/tools/nightly_hotpatch.py
+++ b/tools/nightly_hotpatch.py
@@ -160,11 +160,11 @@ def apply_patch(patch_file: str, target_dir: str | None, strip_count: int) -> No
                 1, f"-d{target_dir}"
             )  # Insert -d option right after 'patch'
             print(f"Running command: {' '.join(patch_command)}")
-            result = subprocess.run(patch_command, capture_output=True, text=True)
+            result = subprocess.run(patch_command, check=False, capture_output=True, text=True)
         else:
             patch_command.insert(1, f"-d{target_dir}")
             print(f"Running command: {' '.join(patch_command)}")
-            result = subprocess.run(patch_command, capture_output=True, text=True)
+            result = subprocess.run(patch_command, check=False, capture_output=True, text=True)
 
         # Check if the patch was applied successfully
         if result.returncode != 0:

--- a/tools/nvcc_fix_deps.py
+++ b/tools/nvcc_fix_deps.py
@@ -97,7 +97,7 @@ def extract_include_arg(include_dirs: list[Path], i: int, args: list[str]) -> No
 
 if __name__ == "__main__":
     ret = subprocess.run(
-        sys.argv[1:], stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr
+        sys.argv[1:], check=False, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr
     )
 
     depfile_path = None

--- a/tools/stale_issues.py
+++ b/tools/stale_issues.py
@@ -50,7 +50,7 @@ def gh_issue_list(search, label, limit):
     ]
     if label:
         cmd += ["-l", label]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
     if result.returncode != 0:
         print(result.stderr, file=sys.stderr)
         sys.exit(1)
@@ -73,7 +73,7 @@ def gh_issue_count(search_query):
             "-f",
             "per_page=1",
         ],
-        capture_output=True,
+        check=False, capture_output=True,
         text=True,
     )
     return result.stdout.strip() if result.returncode == 0 else "?"
@@ -149,7 +149,7 @@ def cmd_labels(args):
                 "-f",
                 f"page={page}",
             ],
-            capture_output=True,
+            check=False, capture_output=True,
             text=True,
         )
         if result.returncode != 0:
@@ -177,7 +177,7 @@ SUBSCRIPTION_DIR = os.path.join(
 def gh_graphql(query):
     result = subprocess.run(
         ["gh", "api", "graphql", "-f", f"query={query}"],
-        capture_output=True,
+        check=False, capture_output=True,
         text=True,
     )
     if result.returncode != 0:
@@ -193,7 +193,7 @@ def subscription_state_path(issue_number):
 def cmd_subscription_save(args):
     result = subprocess.run(
         ["gh", "api", f"repos/pytorch/pytorch/issues/{args.issue}", "--jq", ".node_id"],
-        capture_output=True,
+        check=False, capture_output=True,
         text=True,
     )
     if result.returncode != 0:
@@ -252,7 +252,7 @@ def cmd_collaborator_check(args):
             f"repos/pytorch/pytorch/collaborators/{args.username}",
             "--silent",
         ],
-        capture_output=True,
+        check=False, capture_output=True,
         text=True,
     )
     if result.returncode == 0:

--- a/tools/testing/explicit_ci_jobs.py
+++ b/tools/testing/explicit_ci_jobs.py
@@ -17,7 +17,7 @@ def commit_ci(files: list[str], message: str) -> None:
     # Check that there are no other modified files than the ones edited by this
     # tool
     stdout = subprocess.run(
-        ["git", "status", "--porcelain"], stdout=subprocess.PIPE
+        ["git", "status", "--porcelain"], check=False, stdout=subprocess.PIPE
     ).stdout.decode()
     for line in stdout.split("\n"):
         if line == "":
@@ -28,8 +28,8 @@ def commit_ci(files: list[str], message: str) -> None:
             )
 
     # Make the commit
-    subprocess.run(["git", "add"] + files)
-    subprocess.run(["git", "commit", "-m", message])
+    subprocess.run(["git", "add"] + files, check=False)
+    subprocess.run(["git", "commit", "-m", message], check=False)
 
 
 if __name__ == "__main__":

--- a/tools/testing/update_slow_tests.py
+++ b/tools/testing/update_slow_tests.py
@@ -192,11 +192,11 @@ if __name__ == "__main__":
     if open_pr is not None:
         pr_num, branch_name = open_pr
 
-    subprocess.run(["git", "checkout", "-b", branch_name], cwd=REPO_ROOT)
-    subprocess.run(["git", "add", "test/slow_tests.json"], cwd=REPO_ROOT)
-    subprocess.run(["git", "commit", "-m", "Update slow tests"], cwd=REPO_ROOT)
+    subprocess.run(["git", "checkout", "-b", branch_name], check=False, cwd=REPO_ROOT)
+    subprocess.run(["git", "add", "test/slow_tests.json"], check=False, cwd=REPO_ROOT)
+    subprocess.run(["git", "commit", "-m", "Update slow tests"], check=False, cwd=REPO_ROOT)
     subprocess.run(
-        f"git push --set-upstream origin {branch_name} -f".split(), cwd=REPO_ROOT
+        f"git push --set-upstream origin {branch_name} -f".split(), check=False, cwd=REPO_ROOT
     )
 
     params = {

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2978,7 +2978,7 @@ def _precompile_header(
             but calling a fast hashing utility in a subprocess is cheap."""
             # If Windows support needs to be added here, use certutil -hashfile.
             cmd_output = subprocess.run(
-                ("openssl", "sha512", filename), capture_output=True, text=True
+                ("openssl", "sha512", filename), check=False, capture_output=True, text=True
             )
             return cmd_output.stdout.split()[-1]
 

--- a/torch/_inductor/compiler_bisector.py
+++ b/torch/_inductor/compiler_bisector.py
@@ -724,7 +724,7 @@ def command_line_usage() -> None:
                 # mechanisms. The subprocess reads run_state and bisect_range from
                 # files, and writes the actual count during find_max_bounds.
 
-            result = subprocess.run(run_cmd, env=env)
+            result = subprocess.run(run_cmd, check=False, env=env)
             return result.returncode == 0
 
         bisection_manager.delete_bisect_status()

--- a/torch/_strobelight/cli_function_profiler.py
+++ b/torch/_strobelight/cli_function_profiler.py
@@ -119,7 +119,7 @@ class StrobelightCLIFunctionProfiler:
             command.append(",".join(self.sample_tags))
 
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, check=False, capture_output=True)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -144,7 +144,7 @@ class StrobelightCLIFunctionProfiler:
 
         command = ["strobeclient", "getRunStatus", "--run-id", f"{self.current_run_id}"]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, check=False, capture_output=True)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -169,7 +169,7 @@ class StrobelightCLIFunctionProfiler:
     def _stop_run(self) -> None:
         command = ["strobeclient", "stopRun", "--run-id", str(self.current_run_id)]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, check=False, capture_output=True)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -192,7 +192,7 @@ class StrobelightCLIFunctionProfiler:
     def _get_results(self) -> None:
         command = ["strobeclient", "getRunStatus", "--run-id", str(self.current_run_id)]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, check=False, capture_output=True)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 

--- a/torch/_strobelight/compile_time_profiler.py
+++ b/torch/_strobelight/compile_time_profiler.py
@@ -30,7 +30,7 @@ def get_fburl(url: str) -> str:
     # Attempt to shorten the URL
     try:
         result = subprocess.run(
-            ["fburl", url], capture_output=True, stdin=subprocess.DEVNULL
+            ["fburl", url], check=False, capture_output=True, stdin=subprocess.DEVNULL
         )
         if result.returncode == 0:
             short_url = result.stdout.decode("utf-8")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -6015,7 +6015,7 @@ def remove_cpp_extensions_build_root():
         if IS_WINDOWS:
             # rmtree returns permission error: [WinError 5] Access is denied
             # on Windows, this is a workaround
-            subprocess.run(["rm", "-rf", default_build_root], stdout=subprocess.PIPE)
+            subprocess.run(["rm", "-rf", default_build_root], check=False, stdout=subprocess.PIPE)
         else:
             shutil.rmtree(default_build_root, ignore_errors=True)
 

--- a/torch/utils/_get_clean_triton.py
+++ b/torch/utils/_get_clean_triton.py
@@ -109,7 +109,7 @@ def process_file(
 
             result = subprocess.run(
                 [sys.executable, input_filename],
-                env=env,
+                check=False, env=env,
                 capture_output=True,
                 text=True,
                 cwd=os.path.dirname(input_filename) or ".",

--- a/torch/utils/_strobelight/cli_function_profiler.py
+++ b/torch/utils/_strobelight/cli_function_profiler.py
@@ -117,7 +117,7 @@ class StrobelightCLIFunctionProfiler:
             command.append(",".join(self.sample_tags))
 
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, check=False, capture_output=True)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -142,7 +142,7 @@ class StrobelightCLIFunctionProfiler:
 
         command = ["strobeclient", "getRunStatus", "--run-id", f"{self.current_run_id}"]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, check=False, capture_output=True)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -167,7 +167,7 @@ class StrobelightCLIFunctionProfiler:
     def _stop_run(self) -> None:
         command = ["strobeclient", "stopRun", "--run-id", str(self.current_run_id)]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, check=False, capture_output=True)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -190,7 +190,7 @@ class StrobelightCLIFunctionProfiler:
     def _get_results(self) -> None:
         command = ["strobeclient", "getRunStatus", "--run-id", str(self.current_run_id)]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, check=False, capture_output=True)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -612,6 +612,7 @@ class _ValgrindWrapper:
                     args,
                     stdout=f_stdout_stderr,
                     stderr=subprocess.STDOUT,
+                    check=False,
                     **kwargs,
                 )
                 with open(stdout_stderr_log) as f:


### PR DESCRIPTION
## Summary

Enable the `PLW1510` ruff rule (`subprocess.run` without explicit `check` argument) codebase wide by adding it to the `select` list in `pyproject.toml`.

All 89 existing `subprocess.run()` calls that lacked an explicit `check` argument now have `check=False` added, preserving existing behavior while making the intent explicit at each call site.

Fixes #115016

## Test plan

- `ruff check --select PLW1510 .` passes with zero violations
- All changes are behavior-preserving (`check=False` is the default when omitted)
- No functional changes to any code paths

Co-authored-by: Claude <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98