### PR TITLE
[Profiler] Reduce size of the payload used in test_profiler_name_pattern

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3162,7 +3162,7 @@ class TestExperimentalUtils(TestCase):
 
     def test_utils_compute_queue_depth_when_no_cuda_events(self):
         # For traces with only cpu events, we expect empty queue depth list
-        x = torch.ones((1024, 1024))
+        x = torch.ones((100, 100))
         with profile() as prof:
             for _ in range(5):
                 x = x @ x
@@ -3212,7 +3212,7 @@ aten::copy_""",
         )
 
     def test_profiler_name_pattern(self):
-        x = torch.ones((128, 128))
+        x = torch.ones((100, 100))
         with profile() as prof:
             for _ in range(5):
                 x = x @ x

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3212,7 +3212,7 @@ aten::copy_""",
         )
 
     def test_profiler_name_pattern(self):
-        x = torch.ones((4096, 4096))
+        x = torch.ones((128, 128))
         with profile() as prof:
             for _ in range(5):
                 x = x @ x


### PR DESCRIPTION
Seeing some bad behavior on Kineto CI: https://github.com/pytorch/kineto/actions/runs/24094147555/job/70288270890

This test (test_profiler_name_pattern) is using a 4096 x 4096 tensor and running matmul + add on it multiple times on CPU. This is taking 4+ minutes and for some reason is causing bad behavior for a lot of other tests.

There's no good reason for the test to have such a big payload, as it's just testing the `NamePattern` class (not sure if this is still used). Reducing the payload size makes the tests run a lot faster and resolves the issue. Need to figure out what's going on to cause this behavior in the first place.