### PR TITLE
[DTensor] Raise error for unsupported Split(Flatten) sharding propagation

### DIFF
--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -730,6 +730,83 @@ class TestViewOps(DTensorContinuousTestBase):
             view_shapes.extend(trailing_dims)
         return tuple(view_shapes)
 
+    def _test_dtensor_flatten_split_case(self, in_shape, out_shape, placements, mesh):
+        """Test a single Split(Flatten) view case.
+
+        Representable cases must produce zero communication and correct output.
+        Unrepresentable cases must raise RuntimeError with a specific message.
+        """
+        nelem = math.prod(in_shape)
+        global_tensor = torch.arange(nelem).view(in_shape)
+        in_dt = distribute_tensor(global_tensor, mesh, placements, src_data_rank=None)
+        comm_mode = CommDebugMode()
+        try:
+            with comm_mode:
+                out_dt = in_dt.view(list(out_shape))
+        except RuntimeError as e:
+            self.assertRegex(
+                str(e),
+                r"is not supported yet"
+                r"|is not evenly divisible by mesh dimension",
+            )
+            return
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        expected = global_tensor.view(list(out_shape))
+        self.assertEqual(out_dt.full_tensor(), expected)
+
+    def test_dtensor_flatten_split_multi_mesh(self):
+        """Test views producing Split(Flatten) rules.
+
+        Complements test_dtensor_flatten_multi_mesh (pure Flatten rules) and
+        test_dtensor_unflatten_multi_mesh (pure Split(InputDim) rules) by
+        covering the hybrid case: an input dim crosses two output groups,
+        so view_groups produces Split(Flatten(...)) rules.
+
+        Uses {2*M-1, 2*M, 2*M+1} dim values (M = mesh size for the shard
+        mesh dim) to cover even/uneven divisibility, following the same
+        pattern as _run_flatten_single_shard.
+        """
+        for mesh_shape in [(self.world_size,), (3, 2)]:
+            if self.world_size < math.prod(mesh_shape):
+                continue
+            mesh = init_device_mesh(self.device_type, mesh_shape)
+            for shard_mesh_dim in range(mesh.ndim):
+                M = mesh.size(shard_mesh_dim)
+                dim_vals = [2 * M - 1, 2 * M, 2 * M + 1]
+                for a, b in itertools.product(dim_vals, repeat=2):
+                    in_shape = (a, b)
+                    total = a * b
+                    all_factors = self._get_all_factorizations(total)
+                    for out_shape in all_factors:
+                        if in_shape == out_shape:
+                            continue
+                        rules = view_groups(list(in_shape), list(out_shape))
+                        if not any(
+                            isinstance(r, Split) and isinstance(r.input_dim, Flatten)
+                            for r in rules
+                        ):
+                            continue
+                        for shard_dim in range(len(in_shape)):
+                            if in_shape[shard_dim] % M != 0:
+                                continue
+                            placements = tuple(
+                                Shard(shard_dim) if i == shard_mesh_dim else Replicate()
+                                for i in range(mesh.ndim)
+                            )
+                            with self.subTest(
+                                in_shape=in_shape,
+                                out_shape=out_shape,
+                                shard=shard_dim,
+                                mesh_dim=shard_mesh_dim,
+                                mesh_shape=mesh_shape,
+                            ):
+                                self._test_dtensor_flatten_split_case(
+                                    in_shape,
+                                    out_shape,
+                                    placements,
+                                    mesh,
+                                )
+
     def test_dtensor_flatten_multi_mesh(self):
         """Test flatten operations across 1D and 2D meshes with all placement patterns.
 
@@ -2168,6 +2245,7 @@ TestViewOpsWithLocalTensor = create_local_tensor_test_class(
         "test_dtensor_flatten_1d",
         "test_dtensor_flatten_2d",
         "test_dtensor_flatten_multi_mesh",
+        "test_dtensor_flatten_split_multi_mesh",
     ],
     base_class=LocalDTensorContinuousTestBase,
 )

--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -733,26 +733,18 @@ class TestViewOps(DTensorContinuousTestBase):
     def _test_dtensor_flatten_split_case(self, in_shape, out_shape, placements, mesh):
         """Test a single Split(Flatten) view case.
 
-        Representable cases must produce zero communication and correct output.
-        Unrepresentable cases must raise RuntimeError with a specific message.
+        All Split(Flatten) cases must raise RuntimeError until proper support
+        is implemented.
         """
         nelem = math.prod(in_shape)
         global_tensor = torch.arange(nelem).view(in_shape)
         in_dt = distribute_tensor(global_tensor, mesh, placements, src_data_rank=None)
-        comm_mode = CommDebugMode()
-        try:
-            with comm_mode:
-                out_dt = in_dt.view(list(out_shape))
-        except RuntimeError as e:
-            self.assertRegex(
-                str(e),
-                r"is not supported yet"
-                r"|is not evenly divisible by mesh dimension",
-            )
-            return
-        self.assertEqual(comm_mode.get_total_counts(), 0)
-        expected = global_tensor.view(list(out_shape))
-        self.assertEqual(out_dt.full_tensor(), expected)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"is not supported yet"
+            r"|is not evenly divisible by mesh dimension",
+        ):
+            in_dt.view(list(out_shape))
 
     def test_dtensor_flatten_split_multi_mesh(self):
         """Test views producing Split(Flatten) rules.

--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -733,18 +733,26 @@ class TestViewOps(DTensorContinuousTestBase):
     def _test_dtensor_flatten_split_case(self, in_shape, out_shape, placements, mesh):
         """Test a single Split(Flatten) view case.
 
-        All Split(Flatten) cases must raise RuntimeError until proper support
-        is implemented.
+        Representable cases must produce zero communication and correct output.
+        Unrepresentable cases must raise RuntimeError with a specific message.
         """
         nelem = math.prod(in_shape)
         global_tensor = torch.arange(nelem).view(in_shape)
         in_dt = distribute_tensor(global_tensor, mesh, placements, src_data_rank=None)
-        with self.assertRaisesRegex(
-            RuntimeError,
-            r"is not supported yet"
-            r"|is not evenly divisible by mesh dimension",
-        ):
-            in_dt.view(list(out_shape))
+        comm_mode = CommDebugMode()
+        try:
+            with comm_mode:
+                out_dt = in_dt.view(list(out_shape))
+        except RuntimeError as e:
+            self.assertRegex(
+                str(e),
+                r"is not supported yet"
+                r"|is not evenly divisible by mesh dimension",
+            )
+            return
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        expected = global_tensor.view(list(out_shape))
+        self.assertEqual(out_dt.full_tensor(), expected)
 
     def test_dtensor_flatten_split_multi_mesh(self):
         """Test views producing Split(Flatten) rules.

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -1117,6 +1117,11 @@ class _ViewShardingPropagator:
                     f"{tgt_shard_dims} for Shard(dim={p.dim}) on mesh dim {mesh_dim}."
                 )
         cmd = self.rule[tgt_shard_dim]
+        if isinstance(cmd, Split) and isinstance(cmd.input_dim, Flatten):
+            raise RuntimeError(
+                f"Shard(dim={p.dim}) through Split(Flatten(...), {cmd.group_shape}) "
+                f"is not supported yet."
+            )
         if isinstance(cmd, (Split, InputDim)):
             # Split/InputDim: 1:1 dim mapping, sharding transfers directly.
             # Flatten needs stride computation below (multiple dims merge).

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -1118,10 +1118,12 @@ class _ViewShardingPropagator:
                 )
         cmd = self.rule[tgt_shard_dim]
         if isinstance(cmd, Split) and isinstance(cmd.input_dim, Flatten):
-            raise RuntimeError(
-                f"Shard(dim={p.dim}) through Split(Flatten(...), {cmd.group_shape}) "
-                f"is not supported yet."
-            )
+            first_dim = cmd.input_dim.input_dims[0]
+            if isinstance(first_dim, InputDim) and p.dim != first_dim.input_dim:
+                raise RuntimeError(
+                    f"Shard(dim={p.dim}) through Split(Flatten(...), {cmd.group_shape}) "
+                    f"is not supported yet for non-first flatten dims."
+                )
         if isinstance(cmd, (Split, InputDim)):
             # Split/InputDim: 1:1 dim mapping, sharding transfers directly.
             # Flatten needs stride computation below (multiple dims merge).


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #179664
* #179509
* __->__ #179632

_rewrite_plain_shard silently treated Split(Flatten(...)) as a plain Split,
returning Shard(output_dim) instead of _StridedShard — producing wrong results
for non-first flatten dims. Raise RuntimeError until proper support is added.