### PR TITLE
Add complex tensor validation for reduce, reduce_scatter, and reduce_…

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -1627,6 +1627,65 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             opts.rootTensor = 0
             pg.reduce([t1, t1], opts)
 
+    @requires_gloo()
+    def test_reduce_complex_unsupported_ops(self):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="gloo",
+            store=store,
+            rank=self.rank,
+            world_size=self.world_size,
+        )
+
+        unsupported_ops = [
+            c10d.ReduceOp.MAX,
+            c10d.ReduceOp.MIN,
+            c10d.ReduceOp.PRODUCT,
+            c10d.ReduceOp.BAND,
+            c10d.ReduceOp.BOR,
+            c10d.ReduceOp.BXOR,
+        ]
+
+        for op in unsupported_ops:
+            with self.subTest(op=op, fn="reduce"):
+                with self.assertRaisesRegex(
+                    ValueError, "does not support .* on complex tensors"
+                ):
+                    dist.reduce(
+                        torch.tensor([1 + 2j], dtype=torch.complex64),
+                        dst=self.rank,
+                        op=op,
+                    )
+
+            with self.subTest(op=op, fn="reduce_scatter"):
+                with self.assertRaisesRegex(
+                    ValueError, "does not support .* on complex tensors"
+                ):
+                    dist.reduce_scatter(
+                        torch.zeros(1, dtype=torch.complex64),
+                        [
+                            torch.tensor([1 + 2j], dtype=torch.complex64)
+                            for _ in range(self.world_size)
+                        ],
+                        op=op,
+                    )
+
+            with self.subTest(op=op, fn="reduce_scatter_tensor"):
+                with self.assertRaisesRegex(
+                    ValueError, "does not support .* on complex tensors"
+                ):
+                    dist.reduce_scatter_tensor(
+                        torch.zeros(1, dtype=torch.complex64),
+                        torch.ones(self.world_size, dtype=torch.complex64),
+                        op=op,
+                    )
+
+        # SUM on complex tensors should still work
+        t = torch.tensor([1 + 2j], dtype=torch.complex64)
+        dist.reduce(t, dst=0, op=c10d.ReduceOp.SUM)
+
+        dist.destroy_process_group()
+
     def _test_reduce_basics(self, fn):
         store = c10d.FileStore(self.file_name, self.world_size)
         pg = self._create_process_group_gloo(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -3314,6 +3314,11 @@ def reduce(
         _warn_not_in_group("reduce")
         return
 
+    if tensor.is_complex():
+        if not supports_complex(op):
+            raise ValueError(f"reduce does not support {op} on complex tensors")
+        tensor = torch.view_as_real(tensor)
+
     opts = ReduceOptions()
     opts.reduceOp = op
     opts.rootRank = group_dst
@@ -4726,6 +4731,14 @@ def reduce_scatter(
         _warn_not_in_group("reduce_scatter")
         return
 
+    if output.is_complex():
+        if not supports_complex(op):
+            raise ValueError(
+                f"reduce_scatter does not support {op} on complex tensors"
+            )
+        output = torch.view_as_real(output)
+        input_list = [torch.view_as_real(t) for t in input_list]
+
     opts = ReduceScatterOptions()
     opts.reduceOp = op
     opts.asyncOp = async_op
@@ -4815,6 +4828,14 @@ def reduce_scatter_tensor(output, input, op=ReduceOp.SUM, group=None, async_op=F
     if _rank_not_in_group(group):
         _warn_not_in_group("reduce_scatter_tensor")
         return
+
+    if input.is_complex():
+        if not supports_complex(op):
+            raise ValueError(
+                f"reduce_scatter_tensor does not support {op} on complex tensors"
+            )
+        input = torch.view_as_real(input)
+        output = torch.view_as_real(output)
 
     opts = ReduceScatterOptions()
     opts.reduceOp = op


### PR DESCRIPTION
Add complex tensor validation for reduce, reduce_scatter, and reduce_scatter_tensor

reduce(), reduce_scatter(), and reduce_scatter_tensor() silently return garbage when called with unsupported ops (MAX, MIN, PRODUCT, BAND, BOR, BXOR) on complex tensors. The comment at distributed_c10d.py:247 acknowledges this: "unsupported ops will return garbage values rather than error out" and states the intent to error out. The supports_complex() guard already exists and is applied in all_reduce() and all_reduce_coalesced() this PR extends it to the three missing reduce-family functions. This is a behavior change for invalid inputs only code that was producing correct results is unaffected.

Testing
 - All 6 unsupported ops correctly raise ValueError on all 3 functions
 - reduce(), reduce_scatter(), and reduce_scatter_tensor()
