### PR TITLE
[decomp] Fix addmm decomposition crash with out_dtype under FakeTensorMode

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1331,14 +1331,20 @@ class DecompOneOffTests(TestCase):
     def test_addmm_out_dtype_decomp(self, device):
         from torch._subclasses.fake_tensor import FakeTensorMode
 
-        with FakeTensorMode():
-            a = torch.randn(4, 8, dtype=torch.bfloat16)
-            b = torch.randn(8, 4, dtype=torch.bfloat16)
-            c = torch.zeros(4, 4, dtype=torch.float32)
-            out = torch.addmm(c, a, b, out_dtype=torch.float32)
+        cases = [
+            {"beta": 1, "alpha": 1},
+            {"beta": 0, "alpha": 1},
+            {"beta": 2, "alpha": 3},
+        ]
+        for kwargs in cases:
+            with FakeTensorMode():
+                a = torch.randn(4, 8, dtype=torch.bfloat16)
+                b = torch.randn(8, 4, dtype=torch.bfloat16)
+                c = torch.zeros(4, 4, dtype=torch.float32)
+                out = torch.addmm(c, a, b, out_dtype=torch.float32, **kwargs)
 
-        self.assertEqual(out.dtype, torch.float32)
-        self.assertEqual(out.shape, (4, 4))
+            self.assertEqual(out.dtype, torch.float32)
+            self.assertEqual(out.shape, (4, 4))
 
 
 instantiate_device_type_tests(DecompOneOffTests, globals())

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1327,6 +1327,19 @@ class DecompOneOffTests(TestCase):
             in generated_codes[1]
         )
 
+    @onlyCPU
+    def test_addmm_out_dtype_decomp(self, device):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            a = torch.randn(4, 8, dtype=torch.bfloat16)
+            b = torch.randn(8, 4, dtype=torch.bfloat16)
+            c = torch.zeros(4, 4, dtype=torch.float32)
+            out = torch.addmm(c, a, b, out_dtype=torch.float32)
+
+        self.assertEqual(out.dtype, torch.float32)
+        self.assertEqual(out.shape, (4, 4))
+
 
 instantiate_device_type_tests(DecompOneOffTests, globals())
 

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -1327,24 +1327,26 @@ class DecompOneOffTests(TestCase):
             in generated_codes[1]
         )
 
-    @onlyCPU
+    @onlyCUDA
+    @skipIfCrossRef
     def test_addmm_out_dtype_decomp(self, device):
-        from torch._subclasses.fake_tensor import FakeTensorMode
-
         cases = [
             {"beta": 1, "alpha": 1},
             {"beta": 0, "alpha": 1},
             {"beta": 2, "alpha": 3},
         ]
         for kwargs in cases:
-            with FakeTensorMode():
-                a = torch.randn(4, 8, dtype=torch.bfloat16)
-                b = torch.randn(8, 4, dtype=torch.bfloat16)
-                c = torch.zeros(4, 4, dtype=torch.float32)
-                out = torch.addmm(c, a, b, out_dtype=torch.float32, **kwargs)
+            a = torch.randn(4, 8, dtype=torch.bfloat16, device=device)
+            b = torch.randn(8, 4, dtype=torch.bfloat16, device=device)
+            c = torch.randn(4, 4, dtype=torch.float32, device=device)
 
-            self.assertEqual(out.dtype, torch.float32)
-            self.assertEqual(out.shape, (4, 4))
+            ref = torch.ops.aten.addmm.dtype(c, a, b, torch.float32, **kwargs)
+            res = torch._decomp.decompositions.addmm_dtype(
+                c, a, b, out_dtype=torch.float32, **kwargs
+            )
+
+            self.assertEqual(res.dtype, torch.float32)
+            self.assertEqual(res, ref)
 
 
 instantiate_device_type_tests(DecompOneOffTests, globals())

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1517,7 +1517,7 @@ def tensor_split_tensor_indices_or_sections_py_impl(
 
 
 # TODO: this doesn't appear to have enough precision in bfloat16
-@register_decomposition(aten.addmm)
+@register_decomposition([aten.addmm.default, aten.addmm.out])
 @out_wrapper(exact_dtype=True)
 @pw_cast_for_opmath
 def addmm(self: Tensor, mat1: Tensor, mat2: Tensor, beta: int = 1, alpha: int = 1):
@@ -1535,6 +1535,22 @@ def addmm(self: Tensor, mat1: Tensor, mat2: Tensor, beta: int = 1, alpha: int = 
     # Alternative, we can write `(beta * self + out).contiguous()`, but it introduces another copy in some cases.
     # This implementation is not ideal, and we should revisit this when we have a better solution.
     return out + beta * self
+
+
+@register_decomposition([aten.addmm.dtype, aten.addmm.dtype_out])
+@out_wrapper(exact_dtype=True)
+def addmm_dtype(
+    self: Tensor,
+    mat1: Tensor,
+    mat2: Tensor,
+    out_dtype: torch.dtype,
+    beta: int = 1,
+    alpha: int = 1,
+):
+    out = alpha * torch.mm(mat1, mat2, out_dtype=out_dtype)
+    if beta == 0:
+        return out
+    return out + beta * self.to(out_dtype)
 
 
 @register_decomposition(aten._addmm_activation)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179634

`register_decomposition(aten.addmm)` registered the same decomposition
for all overloads including `addmm.dtype`, which has an extra positional
`out_dtype` arg. This caused `out_dtype` (a `torch.dtype`) to be bound
to `beta`, resulting in `TypeError: unsupported operand type(s) for *:
'torch.dtype' and 'FakeTensor'`.

Fix by registering the existing decomposition only for `addmm.default`
and `addmm.out`, and adding a separate `addmm_dtype` decomposition that
properly handles the `out_dtype` parameter.