### PR TITLE
[fx] Handle GraphModule in PythonKeyTracer.create_arg

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -872,6 +872,38 @@ class TestRealProxyTensor(TestCase):
         )
         self.assertTrue(torch_fn_absent, "torch_fn metadata should be absent when mode is disabled")
 
+    def test_create_arg_graphmodule(self):
+        # Test that PythonKeyTracer.create_arg handles GraphModule objects
+        # by converting them to get_attr nodes. This is needed when HOPs
+        # like flex_attention store subgraph GraphModules as submodules
+        # and pass them as arguments during tracing.
+        from torch.fx.experimental.proxy_tensor import PythonKeyTracer
+
+        class Inner(nn.Module):
+            def forward(self, x):
+                return x * 2
+
+        tracer = PythonKeyTracer()
+        tracer.root = nn.Module()
+        tracer.graph = torch.fx.Graph(tracer_cls=type(tracer))
+
+        subgraph = torch.fx.GraphModule(Inner(), torch.fx.Graph())
+
+        # Case 1: GraphModule already registered as submodule
+        tracer.root.register_module("my_subgraph", subgraph)
+        node = tracer.create_arg(subgraph)
+        self.assertIsInstance(node, torch.fx.Node)
+        self.assertEqual(node.op, "get_attr")
+        self.assertEqual(node.target, "my_subgraph")
+
+        # Case 2: unregistered GraphModule gets auto-registered
+        subgraph2 = torch.fx.GraphModule(Inner(), torch.fx.Graph())
+        node2 = tracer.create_arg(subgraph2)
+        self.assertIsInstance(node2, torch.fx.Node)
+        self.assertEqual(node2.op, "get_attr")
+        self.assertIn("_subgraph", node2.target)
+
+
 class TestFakeProxyTensor(TestCase):
     def test_issue82547(self):
         x = nn.Parameter(torch.randn(3, 3))

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1434,6 +1434,19 @@ class PythonKeyTracer(Tracer):
             setattr(self.root, qualname, a)
 
             return self.create_node("get_attr", qualname, (), {})
+        elif isinstance(a, torch.fx.GraphModule):
+            # Higher-order ops like flex_attention store subgraph
+            # GraphModules as submodules of the tracer root (registered
+            # in their trace_* functions). Convert them to get_attr
+            # nodes so they survive re-tracing (e.g. when compile_fx
+            # re-enters aot_autograd on a scooped backward submodule).
+            for n, m in self.root.named_modules():
+                if m is a and n:
+                    return self.create_node("get_attr", n, (), {})
+
+            qualname = self.get_fresh_qualname("_subgraph")
+            self.root.register_module(qualname, a)
+            return self.create_node("get_attr", qualname, (), {})
         elif isinstance(a, py_sym_types):
             if a.node.constant is None:
                 raise AssertionError("a.node.constant should not be None")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #179637
* #179396

Higher-order ops like flex_attention store subgraph GraphModules as
submodules of the tracer root. When compile_fx re-enters aot_autograd
on a scooped backward submodule (e.g. via regional_inductor →
standalone_compile), the tracer hits NotImplementedError on
GraphModuleImpl in create_arg because it doesn't know how to convert
GraphModule objects to FX graph arguments.

Fix by adding GraphModule handling to PythonKeyTracer.create_arg,
following the same pattern as Parameter: look up the module in the
root's named_modules and create a get_attr node.