### PR TITLE
Cache cuSPARSELt matmul plan/descriptors in _cslt_sparse_mm (#179642)

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -1,7 +1,10 @@
 #include <ATen/native/sparse/cuda/cuSPARSELtOps.h>
+#include <c10/util/hash.h>
+#include <atomic>
 #include <unordered_map>
 #include <mutex>
 #include <string_view>
+#include <compare>
 #if AT_CUSPARSELT_ENABLED()
 
 namespace at::native {
@@ -16,6 +19,114 @@ namespace at::native {
 // DeviceThreadHandlePool.
 thread_local cusparseLtHandle_t handle;
 thread_local bool handle_initialized = false;
+
+static std::atomic<int64_t> g_cslt_plan_init_count{0};
+static std::atomic<int64_t> g_cslt_cache_hit_count{0};
+static constexpr int64_t kLogInterval = 100;
+static constexpr size_t kMaxPlanCacheSize = 1024;
+
+// ---------------------------------------------------------------------------
+// Plan Cache: avoids recreating cuSPARSELt descriptors / plan / workspace on
+// every _cslt_sparse_mm call. In inference the set of (m,k,n,dtype,...) tuples
+// is small and fixed, so caching gives a large CPU-side speedup.
+// ---------------------------------------------------------------------------
+struct CuSparseLtPlanCacheKey {
+  int64_t m, k, n;
+  cudaDataType input_type;
+  cudaDataType output_type;
+  cudaDataType C_type;
+  cusparseComputeType compute_type;
+  bool transpose_result;
+  bool is_B_contiguous;
+  int alg_id;
+  int split_k;
+  int split_k_mode;
+  bool has_bias;
+  int tensor_alpha_mode;
+
+  bool operator==(const CuSparseLtPlanCacheKey&) const = default;
+};
+
+struct CuSparseLtPlanCacheKeyHash {
+  size_t operator()(const CuSparseLtPlanCacheKey& k) const {
+    return c10::get_hash(
+        k.m, k.k, k.n,
+        k.input_type, k.output_type, k.C_type,
+        k.compute_type,
+        k.transpose_result, k.is_B_contiguous,
+        k.alg_id, k.split_k, k.split_k_mode,
+        k.has_bias, k.tensor_alpha_mode);
+  }
+};
+
+struct CachedPlanEntry {
+  cusparseLtMatDescriptor_t sparse_input_descriptor;
+  cusparseLtMatDescriptor_t dense_input_descriptor;
+  cusparseLtMatDescriptor_t res_descriptor;
+  cusparseLtMatDescriptor_t C_descriptor;
+  cusparseLtMatmulDescriptor_t matmul;
+  cusparseLtMatmulAlgSelection_t alg_sel;
+  cusparseLtMatmulPlan_t plan;
+  size_t workspace_size;
+  bool initialized = false;
+
+  CachedPlanEntry() = default;
+  CachedPlanEntry(const CachedPlanEntry&) = delete;
+  CachedPlanEntry& operator=(const CachedPlanEntry&) = delete;
+  CachedPlanEntry(CachedPlanEntry&& other) noexcept
+      : sparse_input_descriptor(other.sparse_input_descriptor),
+        dense_input_descriptor(other.dense_input_descriptor),
+        res_descriptor(other.res_descriptor),
+        C_descriptor(other.C_descriptor),
+        matmul(other.matmul),
+        alg_sel(other.alg_sel),
+        plan(other.plan),
+        workspace_size(other.workspace_size),
+        initialized(other.initialized) {
+    other.initialized = false;
+  }
+  CachedPlanEntry& operator=(CachedPlanEntry&& other) noexcept {
+    if (this != &other) {
+      destroy();
+      sparse_input_descriptor = other.sparse_input_descriptor;
+      dense_input_descriptor = other.dense_input_descriptor;
+      res_descriptor = other.res_descriptor;
+      C_descriptor = other.C_descriptor;
+      matmul = other.matmul;
+      alg_sel = other.alg_sel;
+      plan = other.plan;
+      workspace_size = other.workspace_size;
+      initialized = other.initialized;
+      other.initialized = false;
+    }
+    return *this;
+  }
+
+  ~CachedPlanEntry() {
+    destroy();
+  }
+
+ private:
+  void destroy() {
+    if (!initialized) {
+      return;
+    }
+    cusparseLtMatmulPlanDestroy(&plan);
+    cusparseLtMatDescriptorDestroy(&sparse_input_descriptor);
+    cusparseLtMatDescriptorDestroy(&dense_input_descriptor);
+    cusparseLtMatDescriptorDestroy(&res_descriptor);
+    cusparseLtMatDescriptorDestroy(&C_descriptor);
+    initialized = false;
+  }
+};
+
+using PlanCache = std::unordered_map<
+    CuSparseLtPlanCacheKey,
+    CachedPlanEntry,
+    CuSparseLtPlanCacheKeyHash>;
+
+// Thread-local so no locking is needed; matches the thread-local handle.
+thread_local PlanCache plan_cache;
 
 #ifdef USE_ROCM
 // Single global flag for platform-wide hipSparseLt support
@@ -155,14 +266,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     TORCH_CUDASPARSE_CHECK(cusparseLtInit(&handle));
     handle_initialized = true;
   }
-  // cuSPARSELt constructs
-  cusparseLtMatmulDescriptor_t matmul;
-  cusparseLtMatmulPlan_t plan;
-  cusparseLtMatmulAlgSelection_t alg_sel;
 
-  int tensor_alpha_mode = 0;
-  float alpha = 1.0;
-  float beta = 0.0;
   cudaDataType input_type;
   cudaDataType output_type;
   cudaDataType C_type;
@@ -316,7 +420,243 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   int64_t n = dense_B.size(1);
   int64_t m = compressed_A.size(0);
 
-  // initialize sparse descriptor
+  // Resolve alpha early so we can include tensor_alpha_mode in cache key.
+  int tensor_alpha_mode = 0;
+  float alpha = 1.0;
+  float beta = 0.0;
+  const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
+  auto alpha_ptr = &alpha;
+  if (alpha_opt.has_value()) {
+    if (alpha_tensor.numel() == 1) {
+      alpha = alpha_tensor.item<float>();
+    } else {
+      tensor_alpha_mode = 1;
+      alpha_ptr = static_cast<float*>(alpha_tensor.data_ptr());
+    }
+  }
+
+  bool has_bias = bias_opt.has_value();
+  const void* bias_data_ptr =
+      has_bias ? bias_opt.value().data_ptr() : nullptr;
+  bool b_is_contiguous = dense_B.is_contiguous();
+
+  // ------------------------------------------------------------------
+  // Helper lambda: initialise all cuSPARSELt objects inside *entry*.
+  // The objects MUST be initialised at their final address because the
+  // library may store internal cross-pointers (e.g. the plan references
+  // the matmul descriptor, which references the matrix descriptors).
+  // ------------------------------------------------------------------
+  auto init_plan_entry = [&](CachedPlanEntry& entry) {
+    TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
+        &handle,
+        &entry.sparse_input_descriptor,
+        m,
+        k,
+        k,
+        16,
+        input_type,
+        CUSPARSE_ORDER_ROW,
+        CUSPARSELT_SPARSITY_50_PERCENT));
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+        &handle,
+        &entry.dense_input_descriptor,
+        b_is_contiguous ? k : n,
+        b_is_contiguous ? n : k,
+        b_is_contiguous ? n : k,
+        16,
+        input_type,
+        CUSPARSE_ORDER_ROW));
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+        &handle,
+        &entry.res_descriptor,
+        m,
+        n,
+        transpose_result ? m : n,
+        16,
+        output_type,
+        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
+        &handle,
+        &entry.C_descriptor,
+        m,
+        n,
+        transpose_result ? m : n,
+        16,
+        C_type,
+        transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
+        &handle,
+        &entry.matmul,
+        CUSPARSE_OPERATION_NON_TRANSPOSE,
+        b_is_contiguous ? CUSPARSE_OPERATION_NON_TRANSPOSE
+                        : CUSPARSE_OPERATION_TRANSPOSE,
+        &entry.sparse_input_descriptor,
+        &entry.dense_input_descriptor,
+        &entry.C_descriptor,
+        &entry.res_descriptor,
+        compute_type));
+
+    if (has_bias) {
+      void* dBias = const_cast<void*>(bias_data_ptr);
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+          &handle,
+          &entry.matmul,
+          CUSPARSELT_MATMUL_BIAS_POINTER,
+          &dBias,
+          sizeof(dBias)));
+    }
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
+        &handle,
+        &entry.alg_sel,
+        &entry.matmul,
+        CUSPARSELT_MATMUL_ALG_DEFAULT));
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
+        &handle,
+        &entry.alg_sel,
+        CUSPARSELT_MATMUL_ALG_CONFIG_ID,
+        &alg_id,
+        sizeof(alg_id)));
+
+    if (split_k != 1) {
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
+          &handle, &entry.alg_sel,
+          CUSPARSELT_MATMUL_SPLIT_K,
+          &split_k,
+          sizeof(split_k)));
+      if (split_k_mode > 0) {
+        auto skMode = static_cast<cusparseLtSplitKMode_t>(split_k_mode);
+        TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
+            &handle,
+            &entry.alg_sel,
+            CUSPARSELT_MATMUL_SPLIT_K_MODE,
+            &skMode,
+            sizeof(skMode)));
+      }
+    }
+
+    if (tensor_alpha_mode == 1) {
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+          &handle,
+          &entry.matmul,
+          CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
+          &tensor_alpha_mode,
+          sizeof(tensor_alpha_mode)));
+    }
+
+    TORCH_CUDASPARSE_CHECK(
+        cusparseLtMatmulPlanInit(&handle, &entry.plan, &entry.matmul, &entry.alg_sel));
+
+    int64_t cnt = g_cslt_plan_init_count.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (cnt % kLogInterval == 0 || cnt <= 3) {
+      TORCH_WARN("[cuSPARSELt CACHE MISS] cusparseLtMatmulPlanInit called ", cnt,
+                 " times, m=", m, " k=", k, " n=", n, " alg_id=", alg_id);
+    }
+
+    TORCH_CUDASPARSE_CHECK(
+        cusparseLtMatmulGetWorkspace(&handle, &entry.plan, &entry.workspace_size));
+
+    entry.initialized = true;
+  };
+
+  // ------------------------------------------------------------------
+  // Fast path: reuse a cached plan when not doing algorithm search.
+  // ------------------------------------------------------------------
+  if (!search_alg_id) {
+    CuSparseLtPlanCacheKey cache_key{
+        m, k, n,
+        input_type, output_type, C_type, compute_type,
+        transpose_result, b_is_contiguous,
+        alg_id, split_k, split_k_mode,
+        has_bias, tensor_alpha_mode};
+
+    auto cache_it = plan_cache.find(cache_key);
+
+    if (cache_it != plan_cache.end()) {
+      int64_t hit_cnt = g_cslt_cache_hit_count.fetch_add(1, std::memory_order_relaxed) + 1;
+      if (hit_cnt % kLogInterval == 0 || hit_cnt <= 3) {
+        TORCH_WARN("[cuSPARSELt CACHE HIT] count=", hit_cnt,
+                   ", m=", m, " k=", k, " n=", n);
+      }
+    }
+
+    if (cache_it == plan_cache.end()) {
+      // ---- cache miss: evict all if cache is full -------------------
+      if (plan_cache.size() >= kMaxPlanCacheSize) {
+        plan_cache.clear();
+      }
+      // ---- init directly at stable map address ----------------------
+      auto [it, inserted] = plan_cache.try_emplace(cache_key);
+      struct CacheEraseGuard {
+        PlanCache& cache;
+        PlanCache::iterator iter;
+        bool committed = false;
+        ~CacheEraseGuard() {
+          if (!committed) {
+            cache.erase(iter);
+          }
+        }
+      } guard{plan_cache, it};
+      init_plan_entry(it->second);
+      guard.committed = true;
+      cache_it = it;
+    }
+
+    // ---- execute matmul from cached plan ----------------------------
+    auto& cached = cache_it->second;
+
+    // Re-set bias pointer before every matmul because the caller may
+    // pass a different tensor each time (same shape but different
+    // data_ptr due to PyTorch's caching allocator).
+    if (has_bias) {
+      void* dBias = const_cast<void*>(bias_data_ptr);
+      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+          &handle,
+          &cached.matmul,
+          CUSPARSELT_MATMUL_BIAS_POINTER,
+          &dBias,
+          sizeof(dBias)));
+    }
+
+    auto res_tensor_options =
+        c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
+    at::Tensor res = transpose_result
+        ? at::empty({n, m}, res_tensor_options)
+        : at::empty({m, n}, res_tensor_options);
+
+    auto& allocator = *::c10::cuda::CUDACachingAllocator::get();
+    auto workspacePtr = allocator.allocate(cached.workspace_size);
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
+        &handle,
+        &cached.plan,
+        alpha_ptr,
+        compressed_A.data_ptr(),
+        dense_B.data_ptr(),
+        &beta,
+        res.data_ptr(),
+        res.data_ptr(),
+        workspacePtr.get(),
+        &stream,
+        1));
+
+    return {
+        res,
+        alg_id,
+        split_k,
+        static_cast<int64_t>(split_k_mode),
+        0};
+  }
+
+  // ------------------------------------------------------------------
+  // Search path: build everything on the stack, destroy after search.
+  // ------------------------------------------------------------------
   cusparseLtMatDescriptor_t sparse_input_descriptor;
   TORCH_CUDASPARSE_CHECK(cusparseLtStructuredDescriptorInit(
       &handle,
@@ -329,23 +669,21 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       CUSPARSE_ORDER_ROW,
       CUSPARSELT_SPARSITY_50_PERCENT));
 
-  // initialize dense input descriptor
   cusparseLtMatDescriptor_t dense_input_descriptor;
   TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
-      &handle,
-      &dense_input_descriptor,
-      (dense_B.is_contiguous()) ? k : n,
-      (dense_B.is_contiguous()) ? n : k,
-      (dense_B.is_contiguous()) ? n : k,
+      &handle, &dense_input_descriptor,
+      b_is_contiguous ? k : n,
+      b_is_contiguous ? n : k,
+      b_is_contiguous ? n : k,
       16,
       input_type,
       CUSPARSE_ORDER_ROW));
 
-  // create result tensor
   auto res_tensor_options =
       c10::TensorOptions().dtype(out_dtype).device(dense_B.device());
-  at::Tensor res = (transpose_result) ? at::empty({n, m}, res_tensor_options)
-                                      : at::empty({m, n}, res_tensor_options);
+  at::Tensor res = transpose_result
+      ? at::empty({n, m}, res_tensor_options)
+      : at::empty({m, n}, res_tensor_options);
 
   cusparseLtMatDescriptor_t res_descriptor;
   TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
@@ -353,40 +691,37 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       &res_descriptor,
       m,
       n,
-      (transpose_result) ? m : n,
+      transpose_result ? m : n,
       16,
       output_type,
-      (transpose_result) ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
+      transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
 
-  // For float8, need fp16 C_descriptor, can't use FP8 for this matrix
   cusparseLtMatDescriptor_t C_descriptor;
   TORCH_CUDASPARSE_CHECK(cusparseLtDenseDescriptorInit(
       &handle,
       &C_descriptor,
       m,
       n,
-      (transpose_result) ? m : n,
+      transpose_result ? m : n,
       16,
       C_type,
-      (transpose_result) ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
+      transpose_result ? CUSPARSE_ORDER_COL : CUSPARSE_ORDER_ROW));
 
-  // initialize matmul
+  cusparseLtMatmulDescriptor_t matmul;
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescriptorInit(
       &handle,
       &matmul,
       CUSPARSE_OPERATION_NON_TRANSPOSE,
-      (dense_B.is_contiguous()) ? CUSPARSE_OPERATION_NON_TRANSPOSE
-                                : CUSPARSE_OPERATION_TRANSPOSE,
+      b_is_contiguous ? CUSPARSE_OPERATION_NON_TRANSPOSE
+                      : CUSPARSE_OPERATION_TRANSPOSE,
       &sparse_input_descriptor,
       &dense_input_descriptor,
       &C_descriptor,
       &res_descriptor,
       compute_type));
 
-  // set bias pointer for matmul, need to assign to get location
-  if (bias_opt.has_value()) {
-    auto& bias = bias_opt.value();
-    void* dBias = bias.data_ptr();
+  if (has_bias) {
+    void* dBias = const_cast<void*>(bias_data_ptr);
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
         &handle,
         &matmul,
@@ -395,10 +730,10 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         sizeof(dBias)));
   }
 
+  cusparseLtMatmulAlgSelection_t alg_sel;
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSelectionInit(
       &handle, &alg_sel, &matmul, CUSPARSELT_MATMUL_ALG_DEFAULT));
 
-  // set matmul search params
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
       &handle,
       &alg_sel,
@@ -407,7 +742,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
       sizeof(alg_id)));
 
   cusparseLtSplitKMode_t splitKMode;
-  int max_alg_id;
+  int max_alg_id = 0;
   if (split_k != 1) {
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
         &handle,
@@ -415,7 +750,6 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         CUSPARSELT_MATMUL_SPLIT_K,
         &split_k,
         sizeof(split_k)));
-
     if (split_k_mode > 0) {
       splitKMode = static_cast<cusparseLtSplitKMode_t>(split_k_mode);
       TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgSetAttribute(
@@ -427,24 +761,16 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
     }
   }
 
-  // set tensor_alpha_mode and alpha pointer for matmul
-  const auto alpha_tensor = alpha_opt.has_value() ? *alpha_opt : Tensor{};
-  auto alpha_ptr = &alpha;
-  if (alpha_opt.has_value()) {
-    if (alpha_tensor.numel() == 1) {
-      alpha = alpha_tensor.item<float>();
-    } else {
-      tensor_alpha_mode = 1;
-      TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
-          &handle,
-          &matmul,
-          CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
-          &tensor_alpha_mode,
-          sizeof(tensor_alpha_mode)));
-      alpha_ptr = static_cast<float*>(alpha_tensor.data_ptr());
-    }
+  if (tensor_alpha_mode == 1) {
+    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulDescSetAttribute(
+        &handle,
+        &matmul,
+        CUSPARSELT_MATMUL_ALPHA_VECTOR_SCALING,
+        &tensor_alpha_mode,
+        sizeof(tensor_alpha_mode)));
   }
 
+  cusparseLtMatmulPlan_t plan;
   TORCH_CUDASPARSE_CHECK(
       cusparseLtMatmulPlanInit(&handle, &plan, &matmul, &alg_sel));
 
@@ -456,78 +782,49 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
   auto workspacePtr = allocator.allocate(workspace_size);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  if (search_alg_id) {
-    // run matmul search
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulSearch(
-        &handle,
-        &plan,
-        alpha_ptr,
-        compressed_A.data_ptr(),
-        dense_B.data_ptr(),
-        &beta,
-        res.data_ptr(),
-        res.data_ptr(),
-        workspacePtr.get(),
-        // jank because of the way we want this to be an array of streams
-        &stream,
-        1));
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulSearch(
+      &handle,
+      &plan,
+      alpha_ptr,
+      compressed_A.data_ptr(),
+      dense_B.data_ptr(),
+      &beta,
+      res.data_ptr(),
+      res.data_ptr(),
+      workspacePtr.get(),
+      &stream,
+      1));
 
-    // get matmul params used
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
-        &handle,
-        &alg_sel,
-        CUSPARSELT_MATMUL_ALG_CONFIG_ID,
-        &alg_id,
-        sizeof(alg_id)));
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
+      &handle,
+      &alg_sel,
+      CUSPARSELT_MATMUL_ALG_CONFIG_ID,
+      &alg_id,
+      sizeof(alg_id)));
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
+      &handle,
+      &alg_sel,
+      CUSPARSELT_MATMUL_SPLIT_K,
+      &split_k,
+      sizeof(split_k)));
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
+      &handle,
+      &alg_sel,
+      CUSPARSELT_MATMUL_SPLIT_K_MODE,
+      &splitKMode,
+      sizeof(splitKMode)));
+  TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
+      &handle,
+      &alg_sel,
+      CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID,
+      &max_alg_id,
+      sizeof(max_alg_id)));
 
-#ifndef USE_ROCM
-    // hipSPARSELt does not support querying SPLIT_K attributes
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
-        &handle,
-        &alg_sel,
-        CUSPARSELT_MATMUL_SPLIT_K,
-        &split_k,
-        sizeof(split_k)));
-
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
-        &handle,
-        &alg_sel,
-        CUSPARSELT_MATMUL_SPLIT_K_MODE,
-        &splitKMode,
-        sizeof(splitKMode)));
-#endif
-
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
-        &handle,
-        &alg_sel,
-        CUSPARSELT_MATMUL_ALG_CONFIG_MAX_ID,
-        &max_alg_id,
-        sizeof(max_alg_id)));
-
-  } else {
-    // do normal matmul
-    TORCH_CUDASPARSE_CHECK(cusparseLtMatmul(
-        &handle,
-        &plan,
-        alpha_ptr,
-        compressed_A.data_ptr(),
-        dense_B.data_ptr(),
-        &beta,
-        res.data_ptr(),
-        res.data_ptr(),
-        workspacePtr.get(),
-        // jank because of the way we want this to be an array of streams
-        &stream,
-        1));
-  }
-
-  // destroy descriptors
   TORCH_CUDASPARSE_CHECK(
       cusparseLtMatDescriptorDestroy(&sparse_input_descriptor));
   TORCH_CUDASPARSE_CHECK(
       cusparseLtMatDescriptorDestroy(&dense_input_descriptor));
   TORCH_CUDASPARSE_CHECK(cusparseLtMatDescriptorDestroy(&res_descriptor));
-  // destroy plan
   TORCH_CUDASPARSE_CHECK(cusparseLtMatmulPlanDestroy(&plan));
 
   return {
@@ -590,7 +887,7 @@ int64_t _cslt_sparse_mm_search(
 
 } // namespace at::native
 
-#else // No cuSPARSELt support, throw error if these functions are called.
+#else // No cuSPARSELt support, report error if these functions are called.
 
 namespace at::native {
 

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1609,6 +1609,129 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
         sparse_result = torch.mm(A_sparse, B).to(torch.float16)
         torch.testing.assert_close(sparse_result, dense_result, rtol=1e-3, atol=1e-3)
 
+    # ---- Plan cache tests ----
+    #
+    # These tests verify that cached plans produce bit-identical results
+    # to fresh plans. We compare sparse_mm outputs against each other
+
+    @training_dtypes
+    def test_cslt_plan_cache_repeated_calls_correctness(self, dtype, device):
+        """Repeated calls with the same shape must produce bit-identical
+        results (cache hit must match cache miss exactly)."""
+        A = rand_sparse_semi_structured_mask(256, 128, dtype=dtype)
+        A_compressed = torch._cslt_compress(A)
+        B = torch.rand((128, 128), device=device).to(dtype)
+
+        # First call — cache miss
+        ref = torch._cslt_sparse_mm(A_compressed, B)
+
+        # Subsequent calls — cache hits, must be identical
+        for _ in range(5):
+            result = torch._cslt_sparse_mm(A_compressed, B)
+            self.assertTrue(
+                torch.equal(result, ref),
+                "Cache hit produced different result than cache miss",
+            )
+
+    @training_dtypes
+    def test_cslt_plan_cache_different_shapes(self, dtype, device):
+        """Multiple distinct shapes should each cache independently.
+        For each shape, cache hit must match cache miss exactly."""
+        shapes = [(128, 128, 64), (256, 128, 128), (512, 256, 128)]
+        for m, k, n in shapes:
+            A = rand_sparse_semi_structured_mask(m, k, dtype=dtype)
+            A_compressed = torch._cslt_compress(A)
+            B = torch.rand((k, n), device=device).to(dtype)
+
+            # First call (cache miss) → reference
+            ref = torch._cslt_sparse_mm(A_compressed, B)
+            # Second call (cache hit) → must be identical
+            result = torch._cslt_sparse_mm(A_compressed, B)
+            self.assertTrue(
+                torch.equal(result, ref),
+                f"Cache hit differs from miss for shape ({m},{k},{n})",
+            )
+
+    @training_dtypes
+    def test_cslt_plan_cache_interleaved_shapes(self, dtype, device):
+        """Interleave calls across two shapes; every cache hit must
+        return the same result as its corresponding cache miss."""
+        shapes_data = []
+        for m, k, n in [(256, 128, 64), (512, 256, 128)]:
+            A = rand_sparse_semi_structured_mask(m, k, dtype=dtype)
+            A_compressed = torch._cslt_compress(A)
+            B = torch.rand((k, n), device=device).to(dtype)
+            # First call (cache miss) → reference
+            ref = torch._cslt_sparse_mm(A_compressed, B)
+            shapes_data.append((A_compressed, B, ref))
+
+        # Interleave: all subsequent calls are cache hits
+        for _ in range(5):
+            for A_compressed, B, ref in shapes_data:
+                result = torch._cslt_sparse_mm(A_compressed, B)
+                self.assertTrue(
+                    torch.equal(result, ref),
+                    "Interleaved cache hit differs from miss",
+                )
+
+    @training_dtypes
+    def test_cslt_plan_cache_with_bias(self, dtype, device):
+        """has_bias differentiates cache keys. Both with-bias and
+        without-bias cache hits must match their respective misses."""
+        A = rand_sparse_semi_structured_mask(128, 128, dtype=dtype)
+        A_compressed = torch._cslt_compress(A)
+        B = torch.rand((128, 128), device=device).to(dtype)
+        bias = torch.rand(128, device=device).to(dtype)
+
+        # Cache miss for no-bias and with-bias entries
+        ref_no_bias = torch._cslt_sparse_mm(A_compressed, B)
+        ref_bias = torch._cslt_sparse_mm(A_compressed, B, bias=bias)
+
+        # They should differ (bias changes the result)
+        self.assertFalse(
+            torch.equal(ref_no_bias, ref_bias),
+            "With-bias and no-bias results should differ",
+        )
+
+        # Cache hits must match their respective misses exactly
+        r1 = torch._cslt_sparse_mm(A_compressed, B)
+        self.assertTrue(torch.equal(r1, ref_no_bias))
+
+        r2 = torch._cslt_sparse_mm(A_compressed, B, bias=bias)
+        self.assertTrue(torch.equal(r2, ref_bias))
+
+    def test_cslt_plan_cache_hit_message(self, device):
+        """Subsequent calls with the same shape must trigger a cache hit.
+        We capture the TORCH_WARN messages emitted by the C++ plan cache
+        and verify that a CACHE HIT is reported on the second call."""
+        import warnings
+
+        dtype = torch.float16
+        # Use a shape unlikely to collide with other tests in this suite.
+        A = rand_sparse_semi_structured_mask(256, 256, dtype=dtype)
+        A_compressed = torch._cslt_compress(A)
+        B = torch.randn((256, 128), device=device, dtype=dtype)
+
+        # First call — cache miss (primes the cache)
+        torch._cslt_sparse_mm(A_compressed, B)
+
+        # Second call — should be a cache hit; capture the warning
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            torch._cslt_sparse_mm(A_compressed, B)
+
+        cache_hit_msgs = [
+            str(w.message)
+            for w in caught
+            if "cuSPARSELt CACHE HIT" in str(w.message)
+        ]
+        self.assertGreater(
+            len(cache_hit_msgs),
+            0,
+            "Expected a '[cuSPARSELt CACHE HIT]' warning on the second call, "
+            f"but only got: {[str(w.message) for w in caught]}",
+        )
+
 
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FP8_SPARSE,


### PR DESCRIPTION
Summary:

Previously, every call to `_cslt_sparse_mm` recreated all cuSPARSELt
descriptors, matmul plan, and workspace from scratch — even when the
matrix shapes and parameters were identical. This caused significant
CPU-side overhead (~50-200μs per call for plan creation).

This diff adds a thread-local plan cache keyed on
(m, k, n, dtype, compute_type, transpose, alg_id, split_k, bias, ...)
so that repeated calls with the same configuration reuse the existing
plan and descriptors. The cache:

- Is thread-local (matching the existing thread-local cuSPARSELt handle)
- Initializes objects directly at their stable map address to avoid
  invalidating internal cuSPARSELt cross-pointers.
- Re-sets the bias data pointer before each matmul (the caller may pass
  a different tensor with the same shape due to PyTorch's caching allocator).
- Uses a RAII guard to roll back on init failure.
- Evicts all entries when the cache exceeds 1024 entries.
- Only applies to the normal execution path; the algorithm search path
  (`search_alg_id=true`) remains uncached.
- adds TORCH_WARN logs on cache miss/hit for debuggability.

Test Plan:
python -m pytest ${HOME}/local/fbsource/fbcode/caffe2/test/test_sparse_semi_structured.py -k "plan_cache" -v

```
============================================================================ test session starts =============================================================================
platform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/zihaoliu/miniforge3/bin/python
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=(HealthCheck.too_slow,)
rootdir: /home/zihaoliu/local/fbsource/fbcode/caffe2
configfile: pytest.ini
plugins: hypothesis-6.151.10
collected 144 items / 135 deselected / 9 selected                                                                                                                            
Running 9 items in this shard

local/fbsource/fbcode/caffe2/test/test_sparse_semi_structured.py::TestSparseSemiStructuredCUSPARSELTCUDA::test_cslt_plan_cache_different_shapes_cuda_bfloat16 PASSED [1.2694s] [ 11%]
local/fbsource/fbcode/caffe2/test/test_sparse_semi_structured.py::TestSparseSemiStructuredCUSPARSELTCUDA::test_cslt_plan_cache_different_shapes_cuda_float16 PASSED [0.0400s] [ 22%]
local/fbsource/fbcode/caffe2/test/test_sparse_semi_structured.py::TestSparseSemiStructuredCUSPARSELTCUDA::test_cslt_plan_cache_interleaved_shapes_cuda_bfloat16 PASSED [0.0319s] [ 33%]
local/fbsource/fbcode/caffe2/test/test_sparse_semi_structured.py::TestSparseSemiStructuredCUSPARSELTCUDA::test_cslt_plan_cache_interleaved_shapes_cuda_float16 PASSED [0.0317s] [ 44%]
local/fbsource/fbcode/caffe2/test/test_sparse_semi_structured.py::TestSparseSemiStructuredCUSPARSELTCUDA::test_cslt_plan_cache_repeated_calls_correctness_cuda_bfloat16 PASSED [0.0081s] [ 55%]
local/fbsource/fbcode/caffe2/test/test_sparse_semi_structured.py::TestSparseSemiStructuredCUSPARSELTCUDA::test_cslt_plan_cache_repeated_calls_correctness_cuda_float16 PASSED [0.0084s] [ 66%]
local/fbsource/fbcode/caffe2/test/test_sparse_semi_structured.py::TestSparseSemiStructuredCUSPARSELTCUDA::test_cslt_plan_cache_warm_faster_than_cold_cuda PASSED [0.0186s] [ 77%]
local/fbsource/fbcode/caffe2/test/test_sparse_semi_structured.py::TestSparseSemiStructuredCUSPARSELTCUDA::test_cslt_plan_cache_with_bias_cuda_bfloat16 PASSED [0.0050s] [ 88%]
local/fbsource/fbcode/caffe2/test/test_sparse_semi_structured.py::TestSparseSemiStructuredCUSPARSELTCUDA::test_cslt_plan_cache_with_bias_cuda_float16 PASSED [0.0048s] [100%]

===================================================================== 9 passed, 135 deselected in 10.92s =====================================================================
(base) [zihaoliu@devgpu073.odn1 ~]$ 
```




(base) [zihaoliu@devgpu073.odn1 ~/fbsource/fbcode (c603752558)]$ buck2 run //scripts/zihaoliu:benchmark_cusparselt_plan_cache   --local-only   mode/opt   -c fbcode.platform010_cuda_version=12.8   -c fbcode.nvcc_arch=h100a   -m fbcode//caffe2:enable_cusparselt   2>/dev/null
```
========================================================================
cuSPARSELt Plan Cache Benchmark
  Device:  NVIDIA H100
  Dtype:   FP16
  Shapes:  quick (6 configs)
  Repeat:  200
========================================================================

========================================================================
Benchmark 1: Cost breakdown (handle init / plan create / cache hit)
========================================================================

  First-ever call (handle init + plan):       15122 μs
  Subsequent same shape (cache hit):            8.8 μs
  New shape (plan create, no handle):         428.3 μs
  Same new shape (cache hit):                   9.0 μs
  ─────────────────────────────────────────────────
  Estimated plan-creation overhead:           419.2 μs
  Handle init overhead:                       14694 μs  (one-time)

========================================================================
Benchmark 2: Per-shape plan creation vs cache hit (wall-clock μs)
  NOTE: 'cold' = first call for a NEW shape (after handle is warm)
========================================================================

               shape    cold(μs)    warm(μs)  overhead(μs)    saved%
--------------------------------------------------------------------
           64x128x64       261.4         8.4         253.0     96.8%
         128x256x128       260.2         8.4         251.8     96.8%
         256x256x128       256.2         8.3         247.9     96.7%
         512x512x256       260.3         8.3         252.1     96.8%
       1024x1024x512       261.5         9.1         252.3     96.5%
      2048x2048x1024       282.4        13.3         269.1     95.3%

========================================================================
Benchmark 3: Throughput with cached plans (interleaved shapes)
========================================================================

  Shapes: 6
  Total calls: 1200
  Elapsed: 9.8 ms
  Throughput: 122,031 calls/sec
  Avg latency: 8.2 μs/call

========================================================================
Benchmark 4: Cumulative savings estimate over 10,000 calls
========================================================================
========================================================================

  Plan creation cost:   341.4 μs
  Cached call cost:     8.2 μs
  Overhead per call:    333.1 μs
  Over 10,000 calls:
    Without cache: 3.4 sec
    With cache:    0.1 sec
    Saved:         3331.3 ms (3.33 sec)

========================================================================
Done.
========================================================================
```


mts benchmark on model 1022428314/0
| before cache | after adding cache|
| {F1987917836} | {F1987917848} |

Differential Revision: D99512728


