### PR TITLE
Add missing type annotations across torch._dynamo

### DIFF
--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -70,7 +70,13 @@ def _(
 
 
 @zeros_and_scatter.register_vmap  # type: ignore[misc]
-def _(info, indims, shape, indices, value):  # type: ignore[no-untyped-def]
+def _(
+    info: Any,
+    indims: Any,
+    shape: list[int],
+    indices: list[Tensor],
+    value: Tensor,
+) -> tuple[Tensor, None]:
     """The batching rule is special in that it returns a tensor that is not batched"""
     indices_indims = indims[1]
     expanded_indices = []
@@ -106,7 +112,7 @@ class ModIndex(torch.autograd.Function):
         ctx.input_shape = x.shape
 
     @staticmethod
-    def backward(ctx, gradOut):  # type: ignore[no-untyped-def]
+    def backward(ctx: Any, gradOut: Tensor) -> tuple[Tensor, None]:
         indices = ctx.saved_tensors
         return (
             torch.ops.flex_lib.zeros_and_scatter(
@@ -119,7 +125,7 @@ class ModIndex(torch.autograd.Function):
 
     @classmethod
     @torch._export.wrappers.allow_in_pre_dispatch_graph
-    def apply(cls, *args, **kwargs):  # type: ignore[no-untyped-def]
+    def apply(cls, *args: Any, **kwargs: Any) -> Any:
         return super().apply(*args, **kwargs)
 
 

--- a/torch/_dynamo/_trace_wrapped_higher_order_op.py
+++ b/torch/_dynamo/_trace_wrapped_higher_order_op.py
@@ -112,13 +112,15 @@ class ModIndex(torch.autograd.Function):
         ctx.input_shape = x.shape
 
     @staticmethod
-    def backward(ctx: Any, gradOut: Tensor) -> tuple[Tensor, None]:
+    def backward(ctx: Any, *grad_outputs: Any) -> tuple[Tensor, None]:
+        (grad_out,) = grad_outputs
+        assert isinstance(grad_out, Tensor)
         indices = ctx.saved_tensors
         return (
             torch.ops.flex_lib.zeros_and_scatter(
                 ctx.input_shape,
                 indices,
-                gradOut,
+                grad_out,
             ),
             None,
         )

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -173,7 +173,7 @@ class AOTCompileSaveResult:
     serialized_data: bytes
 
 
-def atomic_write_binary(file_path: str, data: bytes):
+def atomic_write_binary(file_path: str, data: bytes) -> None:
     dir_name = os.path.dirname(file_path) or "."
 
     with tempfile.NamedTemporaryFile(

--- a/torch/_dynamo/backends/registry.py
+++ b/torch/_dynamo/backends/registry.py
@@ -135,7 +135,9 @@ def lookup_backend(compiler_fn: str | CompilerFn) -> CompilerFn:
 
 
 # NOTE: can't type this due to public api mismatch; follow up with dev team
-def list_backends(exclude_tags=("debug", "experimental")) -> list[str]:  # type: ignore[no-untyped-def]
+def list_backends(
+    exclude_tags: Sequence[str] | None = ("debug", "experimental"),
+) -> list[str]:
     """
     Return valid strings that can be passed to:
 

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -73,6 +73,7 @@ def run(fn: Callable[_P, _R] | None = None) -> Any:
 
 
 if TYPE_CHECKING:
+
     def disable(
         fn: Callable[_P, _R] | None = None,
         recursive: bool = True,
@@ -82,7 +83,7 @@ if TYPE_CHECKING:
     ) -> Any: ...
 
 
-def disable(fn=None, recursive=True, *, reason=None, wrapping=True):  # type: ignore[no-untyped-def]
+def disable(fn=None, recursive=True, *, reason=None, wrapping=True):  # type: ignore[no-untyped-def]  # noqa: F811
     """
     Decorator to disable TorchDynamo
 
@@ -184,15 +185,17 @@ class set_stance(_DecoratorContextManager):
 
 
 if TYPE_CHECKING:
+
     def assume_constant_result(fn: F) -> F: ...
 
 
-def assume_constant_result(fn):  # type: ignore[no-untyped-def]
+def assume_constant_result(fn):  # type: ignore[no-untyped-def]  # noqa: F811
     fn._dynamo_marked_constant = True  # type: ignore[attr-defined]
     return fn
 
 
 if TYPE_CHECKING:
+
     @overload
     def allow_in_graph(fn: F) -> F: ...
 

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -72,13 +72,17 @@ def run(fn: Callable[_P, _R] | None = None) -> Any:
     return RunOnlyContext()
 
 
-def disable(
-    fn: Callable[_P, _R] | None = None,
-    recursive: bool = True,
-    *,
-    reason: str | None = None,
-    wrapping: bool = True,
-) -> Any:
+if TYPE_CHECKING:
+    def disable(
+        fn: Callable[_P, _R] | None = None,
+        recursive: bool = True,
+        *,
+        reason: str | None = None,
+        wrapping: bool = True,
+    ) -> Any: ...
+
+
+def disable(fn=None, recursive=True, *, reason=None, wrapping=True):  # type: ignore[no-untyped-def]
     """
     Decorator to disable TorchDynamo
 
@@ -179,22 +183,24 @@ class set_stance(_DecoratorContextManager):
         return self.__class__(self.stance.stance, force_backend=self.stance.backend)
 
 
-def assume_constant_result(fn: F) -> F:
+if TYPE_CHECKING:
+    def assume_constant_result(fn: F) -> F: ...
+
+
+def assume_constant_result(fn):  # type: ignore[no-untyped-def]
     fn._dynamo_marked_constant = True  # type: ignore[attr-defined]
     return fn
 
 
-@overload
-def allow_in_graph(fn: F) -> F: ...
+if TYPE_CHECKING:
+    @overload
+    def allow_in_graph(fn: F) -> F: ...
+
+    @overload
+    def allow_in_graph(fn: list[F] | tuple[F, ...]) -> list[F]: ...
 
 
-@overload
-def allow_in_graph(fn: list[F] | tuple[F, ...]) -> list[F]: ...
-
-
-def allow_in_graph(
-    fn: F | list[F] | tuple[F, ...],
-) -> F | list[F]:
+def allow_in_graph(fn):  # type: ignore[no-untyped-def]
     """
     Tells the compiler frontend (Dynamo) to skip symbolic introspection of the function
     and instead directly write it to the graph when encountered.

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -72,7 +72,13 @@ def run(fn: Callable[_P, _R] | None = None) -> Any:
     return RunOnlyContext()
 
 
-def disable(fn=None, recursive=True, *, reason=None, wrapping=True):  # type: ignore[no-untyped-def]
+def disable(
+    fn: Callable[_P, _R] | None = None,
+    recursive: bool = True,
+    *,
+    reason: str | None = None,
+    wrapping: bool = True,
+) -> Any:
     """
     Decorator to disable TorchDynamo
 
@@ -173,12 +179,14 @@ class set_stance(_DecoratorContextManager):
         return self.__class__(self.stance.stance, force_backend=self.stance.backend)
 
 
-def assume_constant_result(fn):  # type: ignore[no-untyped-def]
+def assume_constant_result(fn: F) -> F:
     fn._dynamo_marked_constant = True  # type: ignore[attr-defined]
     return fn
 
 
-def allow_in_graph(fn):  # type: ignore[no-untyped-def]
+def allow_in_graph(
+    fn: F | list[F] | tuple[F, ...],
+) -> F | list[F]:
     """
     Tells the compiler frontend (Dynamo) to skip symbolic introspection of the function
     and instead directly write it to the graph when encountered.

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -184,6 +184,14 @@ def assume_constant_result(fn: F) -> F:
     return fn
 
 
+@overload
+def allow_in_graph(fn: F) -> F: ...
+
+
+@overload
+def allow_in_graph(fn: list[F] | tuple[F, ...]) -> list[F]: ...
+
+
 def allow_in_graph(
     fn: F | list[F] | tuple[F, ...],
 ) -> F | list[F]:

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -634,14 +634,18 @@ def create_fx_graph_from_captured_output(
             )
             assert graph_module._wrapped_call.cls_call is None
 
-            def dynamo_wrapped_call(self, *args: object, **kwargs: object) -> object:
+            def dynamo_wrapped_call(
+                self: Any, *args: object, **kwargs: object
+            ) -> object:
                 assert "forward" not in self.__dict__
 
                 fwd_hooks = self._forward_hooks
                 fwd_pre_hooks = self._forward_pre_hooks
                 original_forward = type(self).forward
 
-                def patched_forward(self, *args: object, **kwargs: object) -> object:
+                def patched_forward(
+                    self: Any, *args: object, **kwargs: object
+                ) -> object:
                     self._forward_hooks = fwd_hooks
                     self._forward_pre_hooks = fwd_pre_hooks
                     return original_forward(self, *args, **kwargs)

--- a/torch/_dynamo/graph_deduplication.py
+++ b/torch/_dynamo/graph_deduplication.py
@@ -11,7 +11,7 @@ import logging
 import operator
 from collections import defaultdict, deque
 from collections.abc import Generator, Iterable
-from typing import Any
+from typing import TYPE_CHECKING
 
 import torch
 import torch.fx
@@ -21,6 +21,9 @@ from torch.utils._ordered_set import OrderedSet
 
 from .graph_region_tracker import Node, Region
 from .graph_utils import _detect_cycles, _get_flat_args, _get_flat_args_unique
+
+if TYPE_CHECKING:
+    from .output_graph import OutputGraph
 
 
 # Represents an index into the region
@@ -35,7 +38,7 @@ last_node_to_additional_deps: dict[Node, OrderedSet[Node]] | None = None
 
 
 def apply_graph_deduplication(
-    output_graph: Any,
+    output_graph: "OutputGraph",
 ) -> dict[str, torch.fx.GraphModule]:
     """
     This is the main entry point for applying the graph deduplication pass. \

--- a/torch/_dynamo/graph_deduplication.py
+++ b/torch/_dynamo/graph_deduplication.py
@@ -22,6 +22,7 @@ from torch.utils._ordered_set import OrderedSet
 from .graph_region_tracker import Node, Region
 from .graph_utils import _detect_cycles, _get_flat_args, _get_flat_args_unique
 
+
 if TYPE_CHECKING:
     from .output_graph import OutputGraph
 

--- a/torch/_dynamo/graph_deduplication.py
+++ b/torch/_dynamo/graph_deduplication.py
@@ -11,6 +11,7 @@ import logging
 import operator
 from collections import defaultdict, deque
 from collections.abc import Generator, Iterable
+from typing import Any
 
 import torch
 import torch.fx
@@ -33,7 +34,9 @@ log = logging.getLogger(__name__)
 last_node_to_additional_deps: dict[Node, OrderedSet[Node]] | None = None
 
 
-def apply_graph_deduplication(output_graph) -> dict[str, torch.fx.GraphModule]:  # type: ignore[no-untyped-def]
+def apply_graph_deduplication(
+    output_graph: Any,
+) -> dict[str, torch.fx.GraphModule]:
     """
     This is the main entry point for applying the graph deduplication pass. \
 Deduplication occurs in two phases:

--- a/torch/_dynamo/graph_region_tracker.py
+++ b/torch/_dynamo/graph_region_tracker.py
@@ -65,7 +65,7 @@ graph_expansion_log = torch._logging.getArtifactLogger(
 )
 
 
-def debug_log(msg: str, *args) -> None:  # type: ignore[no-untyped-def]
+def debug_log(msg: str, *args: Any) -> None:
     graph_expansion_log.debug(msg, *args)
 
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1100,20 +1100,20 @@ def check_closure(value: Any, metadata: Any) -> bool:
 
 
 def register_guard_check_spec(
-    get_metadata_fn,
-    eval_fn,
-):
+    get_metadata_fn: Any,
+    eval_fn: Any,
+) -> Callable[[Any], Any]:
     """Attach a GuardCheckSpec to a guard method for auto-dispatch."""
     handler = GuardCheckSpec(get_metadata_fn=get_metadata_fn, eval_fn=eval_fn)
 
-    def decorator(fn):
+    def decorator(fn: Any) -> Any:
         fn.guard_check_spec = handler
         return fn
 
     return decorator
 
 
-def skip_guard_check_spec(fn):
+def skip_guard_check_spec(fn: Any) -> Any:
     """Mark a guard method as skipped during auto-cache dispatch."""
     fn.guard_check_spec = SKIP_GUARD
     return fn
@@ -1129,15 +1129,15 @@ class UnsupportedGuardCheckSpec:
         self._name = name
 
     @property
-    def get_metadata_fn(self):
+    def get_metadata_fn(self) -> Any:
         raise NotImplementedError(f"Guard check spec not implemented for {self._name}")
 
     @property
-    def eval_fn(self):
+    def eval_fn(self) -> Any:
         raise NotImplementedError(f"Guard check spec not implemented for {self._name}")
 
 
-def unsupported_guard_check_spec(fn):
+def unsupported_guard_check_spec(fn: Any) -> Any:
     """Mark a guard method as unsupported for auto-cache dispatch."""
     fn.guard_check_spec = UnsupportedGuardCheckSpec(fn.__name__)
     return fn

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2732,7 +2732,7 @@ class OutputGraph(OutputGraphCommon):
             if self.torch_function_subclass_inlined:
                 real_compiled_fn = compiled_fn
 
-                def _tf_disabled_wrapper(*args, **kwargs):
+                def _tf_disabled_wrapper(*args: Any, **kwargs: Any) -> Any:
                     with torch._C.DisableTorchFunctionSubclass():
                         return real_compiled_fn(*args, **kwargs)
 

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -426,7 +426,7 @@ def instantiate_user_defined_class_object(
 
 
 def mutable_mapping_update(
-    self,
+    self: Any,
     data: Mapping[T, U] | Iterable[tuple[T, U]] = (),
     /,
     **kwargs: Any,
@@ -499,7 +499,7 @@ def foreach_map_fn(*args: Any) -> Any:
 
 
 def foreach_lerp_inplace(
-    self,
+    self: list[torch.Tensor] | tuple[torch.Tensor, ...],
     end: list[torch.Tensor] | tuple[torch.Tensor, ...],
     weight: float | int | torch.Tensor,
 ) -> None:

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -502,7 +502,7 @@ def foreach_lerp_inplace(
     self: list[torch.Tensor] | tuple[torch.Tensor, ...],
     end: list[torch.Tensor] | tuple[torch.Tensor, ...],
     weight: float | int | torch.Tensor,
-) -> None:
+) -> list[torch.Tensor] | tuple[torch.Tensor, ...]:
     # Decompose lerp via addcmul_ for FMA.  Uses the same dual-formula
     # approach as CUDA's native lerp to get bitwise identical results:
     #   |w| <  0.5  (low):  fma(w, diff, start)

--- a/torch/_dynamo/polyfills/builtins.py
+++ b/torch/_dynamo/polyfills/builtins.py
@@ -5,17 +5,17 @@ Python polyfills for builtins
 from __future__ import annotations
 
 import builtins
+import collections.abc
 import functools
 import operator
 import typing
-from collections.abc import Callable
 from typing import Any, TYPE_CHECKING, TypeVar
 
 from ..decorators import substitute_in_graph
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable, Iterator
 
 
 __all__ = [
@@ -68,7 +68,7 @@ class _CallableIterator(typing.Generic[_T]):
         self.fn = fn
         self.sentinel = sentinel
 
-    def __iter__(self) -> "_CallableIterator[_T]":
+    def __iter__(self) -> _CallableIterator[_T]:
         return self
 
     def __next__(self) -> _T:
@@ -122,7 +122,7 @@ def iter_(
         # callable object.
         fn = fn_or_iterable
 
-        if not isinstance(fn, Callable):  # type: ignore[arg-type]
+        if not isinstance(fn, collections.abc.Callable):  # type: ignore[arg-type]
             raise TypeError("iter(v, w): v must be a callable")
 
         return _CallableIterator(fn, sentinel)

--- a/torch/_dynamo/polyfills/builtins.py
+++ b/torch/_dynamo/polyfills/builtins.py
@@ -9,7 +9,7 @@ import functools
 import operator
 import typing
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeVar
+from typing import Any, TYPE_CHECKING, TypeVar
 
 from ..decorators import substitute_in_graph
 
@@ -63,15 +63,15 @@ def sum(iterable: Iterable[_T], /, start: _T = 0) -> _T:  # type: ignore[assignm
     return functools.reduce(operator.add, iterable, start)
 
 
-class _CallableIterator:
-    def __init__(self, fn, sentinel):  # type: ignore[no-untyped-def]
+class _CallableIterator(typing.Generic[_T]):
+    def __init__(self, fn: Callable[[], _T], sentinel: object) -> None:
         self.fn = fn
         self.sentinel = sentinel
 
-    def __iter__(self):  # type: ignore[no-untyped-def]
+    def __iter__(self) -> "_CallableIterator[_T]":
         return self
 
-    def __next__(self):  # type: ignore[no-untyped-def]
+    def __next__(self) -> _T:
         # The iterator created in this case will call object with no arguments
         # for each call to its __next__() method;
         r = self.fn()
@@ -88,7 +88,11 @@ _sentinel_missing = object()
 
 
 # TODO(guilhermeleobas): use substitute_in_graph for iter()
-def iter_(fn_or_iterable, sentinel=_sentinel_missing, /):  # type: ignore[no-untyped-def]
+def iter_(
+    fn_or_iterable: Callable[[], _T] | Iterable[_T],
+    sentinel: object = _sentinel_missing,
+    /,
+) -> Iterator[_T] | Iterator[Any]:
     # Without a second argument, object must be a collection object which supports
     # the iterable (__iter__) or the sequence protocol (__getitem__ with an integer
     # starting at 0)
@@ -102,7 +106,7 @@ def iter_(fn_or_iterable, sentinel=_sentinel_missing, /):  # type: ignore[no-unt
                 raise TypeError(f"'{type(iterator)}' object is not iterable")
         if hasattr(iterable, "__getitem__"):
             # Needs to be a new function to avoid iter becoming a generator
-            def sequence_protocol(iterable):  # type: ignore[no-untyped-def]
+            def sequence_protocol(iterable: Any) -> Iterator[Any]:
                 i = 0
                 while True:
                     try:

--- a/torch/_dynamo/polyfills/heapq.py
+++ b/torch/_dynamo/polyfills/heapq.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import heapq
 import importlib
 import sys
+from collections.abc import Callable, Iterable, Iterator
 from typing import TYPE_CHECKING, TypeVar
 
 from ..decorators import substitute_in_graph
@@ -105,15 +106,27 @@ def heapreplace(heap: list[_T], item: _T) -> _T:
 
 
 @substitute_in_graph(heapq.merge)  # type: ignore[arg-type]
-def merge(*iterables, key=None, reverse=False):  # type: ignore[no-untyped-def]
+def merge(
+    *iterables: Iterable[_T],
+    key: Callable[[_T], object] | None = None,
+    reverse: bool = False,
+) -> Iterator[_T]:
     return py_heapq.merge(*iterables, key=key, reverse=reverse)
 
 
 @substitute_in_graph(heapq.nlargest)  # type: ignore[arg-type]
-def nlargest(n, iterable, key=None):  # type: ignore[no-untyped-def]
+def nlargest(
+    n: int,
+    iterable: Iterable[_T],
+    key: Callable[[_T], object] | None = None,
+) -> list[_T]:
     return py_heapq.nlargest(n, iterable, key=key)
 
 
 @substitute_in_graph(heapq.nsmallest)  # type: ignore[arg-type]
-def nsmallest(n, iterable, key=None):  # type: ignore[no-untyped-def]
+def nsmallest(
+    n: int,
+    iterable: Iterable[_T],
+    key: Callable[[_T], object] | None = None,
+) -> list[_T]:
     return py_heapq.nsmallest(n, iterable, key=key)

--- a/torch/_dynamo/polyfills/heapq.py
+++ b/torch/_dynamo/polyfills/heapq.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 import heapq
 import importlib
 import sys
-from collections.abc import Callable, Iterable, Iterator
 from typing import TYPE_CHECKING, TypeVar
 
 from ..decorators import substitute_in_graph
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
     from types import ModuleType
 
 

--- a/torch/_dynamo/polyfills/itertools.py
+++ b/torch/_dynamo/polyfills/itertools.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import itertools
 import operator
 from collections.abc import Callable
-from typing import overload, TYPE_CHECKING, TypeAlias, TypeVar
+from typing import Any, overload, TYPE_CHECKING, TypeAlias, TypeVar
 
 from ..decorators import substitute_in_graph
 
@@ -243,7 +243,7 @@ def tee(iterable: Iterable[_T], n: int = 2, /) -> tuple[Iterator[_T], ...]:
     iterator = iter(iterable)
     shared_link = [None, None]
 
-    def _tee(link) -> Iterator[_T]:  # type: ignore[no-untyped-def]
+    def _tee(link: list[Any]) -> Iterator[_T]:
         try:
             while True:
                 if link[1] is None:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1440,7 +1440,7 @@ class InstructionTranslatorBase(
     if sys.version_info >= (3, 11):
 
         def update_block_stack(
-            self: "InstructionTranslatorBase", inst: Instruction
+            self: InstructionTranslatorBase, inst: Instruction
         ) -> None:
             # 3.11+ no longer uses a block stack, but we still keep track of one
             # so that we know which contexts are currently active.
@@ -1488,7 +1488,7 @@ class InstructionTranslatorBase(
     else:
 
         def update_block_stack(
-            self: "InstructionTranslatorBase", inst: Instruction
+            self: InstructionTranslatorBase, inst: Instruction
         ) -> None:
             pass
 
@@ -3992,7 +3992,7 @@ class InstructionTranslatorBase(
 
     if sys.version_info >= (3, 11):
 
-        def BINARY_OP(self: "InstructionTranslatorBase", inst: Instruction) -> None:
+        def BINARY_OP(self: InstructionTranslatorBase, inst: Instruction) -> None:
             assert inst.arg is not None
             return _binary_op_lookup[inst.arg](self, inst)
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1439,7 +1439,9 @@ class InstructionTranslatorBase(
 
     if sys.version_info >= (3, 11):
 
-        def update_block_stack(self, inst: Instruction) -> None:
+        def update_block_stack(
+            self: "InstructionTranslatorBase", inst: Instruction
+        ) -> None:
             # 3.11+ no longer uses a block stack, but we still keep track of one
             # so that we know which contexts are currently active.
             # For our purposes, all exception table entries with the same target
@@ -1485,7 +1487,9 @@ class InstructionTranslatorBase(
 
     else:
 
-        def update_block_stack(self, inst: Instruction) -> None:
+        def update_block_stack(
+            self: "InstructionTranslatorBase", inst: Instruction
+        ) -> None:
             pass
 
     @property
@@ -3988,7 +3992,7 @@ class InstructionTranslatorBase(
 
     if sys.version_info >= (3, 11):
 
-        def BINARY_OP(self, inst: Instruction) -> None:
+        def BINARY_OP(self: "InstructionTranslatorBase", inst: Instruction) -> None:
             assert inst.arg is not None
             return _binary_op_lookup[inst.arg](self, inst)
 

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -70,13 +70,17 @@ def remove_optimized_module_prefix(name: str) -> str:
     return re.sub(r"^_orig_mod[.]", "", name)
 
 
-def extract_graph_and_tracker(fn, *args, **kwargs):  # type: ignore[no-untyped-def]
+def extract_graph_and_tracker(
+    fn: Callable[..., Any], *args: Any, **kwargs: Any
+) -> tuple[fx.Graph, Any]:
     from torch._dynamo.symbolic_convert import InstructionTranslator
 
     gm = None
     region_tracker = None
 
-    def extract_graph_backend(_gm, *args, **kwargs):  # type: ignore[no-untyped-def]
+    def extract_graph_backend(
+        _gm: fx.GraphModule, *args: Any, **kwargs: Any
+    ) -> fx.GraphModule:
         nonlocal gm
         nonlocal region_tracker
         gm = _gm
@@ -87,7 +91,9 @@ def extract_graph_and_tracker(fn, *args, **kwargs):  # type: ignore[no-untyped-d
     return gm.graph, region_tracker  # type: ignore[union-attr]
 
 
-def extract_graph(fn, *args, **kwargs):  # type: ignore[no-untyped-def]
+def extract_graph(
+    fn: Callable[..., Any], *args: Any, **kwargs: Any
+) -> tuple[Any, list[torch.fx.GraphModule], list[torch.fx.GraphModule], list[torch.fx.GraphModule]]:
     backend = AotEagerAndRecordGraphs()
     result = torch.compile(backend=backend)(fn)(*args, **kwargs)
     return result, backend.graphs, backend.fw_graphs, backend.bw_graphs
@@ -330,14 +336,16 @@ class InductorAndRecordGraphs:
         self.graphs: list[torch.fx.GraphModule] = []
         self.inductor_graphs: list[torch.fx.GraphModule] = []
 
-    def __call__(self, gm, example_inputs):  # type: ignore[no-untyped-def]
+    def __call__(
+        self, gm: torch.fx.GraphModule, example_inputs: list[torch.Tensor]
+    ) -> Any:
         import torch._inductor.compile_fx as compile_fx_mod
 
         self.graphs.append(gm)
 
         old_compile_fx_inner = compile_fx_mod._compile_fx_inner
 
-        def patched(*args, **kwargs):  # type: ignore[no-untyped-def]
+        def patched(*args: Any, **kwargs: Any) -> Any:
             self.inductor_graphs.append(args[0])
             return old_compile_fx_inner(*args, **kwargs)
 

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -93,7 +93,12 @@ def extract_graph_and_tracker(
 
 def extract_graph(
     fn: Callable[..., Any], *args: Any, **kwargs: Any
-) -> tuple[Any, list[torch.fx.GraphModule], list[torch.fx.GraphModule], list[torch.fx.GraphModule]]:
+) -> tuple[
+    Any,
+    list[torch.fx.GraphModule],
+    list[torch.fx.GraphModule],
+    list[torch.fx.GraphModule],
+]:
     backend = AotEagerAndRecordGraphs()
     result = torch.compile(backend=backend)(fn)(*args, **kwargs)
     return result, backend.graphs, backend.fw_graphs, backend.bw_graphs

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -993,7 +993,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         """
         super().__init_subclass__(**kwargs)
 
-        def as_python_constant_failure(self) -> NoReturn:
+        def as_python_constant_failure(self: "VariableTracker") -> NoReturn:
             raise AsPythonConstantNotImplementedError(
                 self, msg=f"{self} is self-referential"
             )
@@ -1002,7 +1002,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             cls, "as_python_constant", as_python_constant_failure
         )
 
-        def reconstruct_failure(self) -> NoReturn:
+        def reconstruct_failure(self: "VariableTracker") -> NoReturn:
             unimplemented(
                 gb_type="Reconstruction failure (self-referential)",
                 context=str(self),
@@ -1033,7 +1033,9 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             return
 
         @functools.wraps(original_method)
-        def guarded_method(self, *args: Any, **kwargs: Any) -> VariableTracker:
+        def guarded_method(
+            self: "VariableTracker", *args: Any, **kwargs: Any
+        ) -> Any:
             active = _vt_active_calls.get()
             if active is None:
                 active = set()

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -1033,9 +1033,7 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             return
 
         @functools.wraps(original_method)
-        def guarded_method(
-            self: "VariableTracker", *args: Any, **kwargs: Any
-        ) -> Any:
+        def guarded_method(self: "VariableTracker", *args: Any, **kwargs: Any) -> Any:
             active = _vt_active_calls.get()
             if active is None:
                 active = set()

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -1014,7 +1014,9 @@ class ConstDictVariable(VariableTracker):
         """
         return False
 
-    def var_getattr(self, tx: "InstructionTranslator", name: str):
+    def var_getattr(
+        self, tx: "InstructionTranslator", name: str
+    ) -> VariableTracker:
         if name == "__class__":
             return VariableTracker.build(tx, self.python_type())
         return super().var_getattr(tx, name)

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -1014,9 +1014,7 @@ class ConstDictVariable(VariableTracker):
         """
         return False
 
-    def var_getattr(
-        self, tx: "InstructionTranslator", name: str
-    ) -> VariableTracker:
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         if name == "__class__":
             return VariableTracker.build(tx, self.python_type())
         return super().var_getattr(tx, name)

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -443,9 +443,7 @@ class BaseUserFunctionVariable(VariableTracker):
     def get_module(self) -> str:
         return self.get_globals()["__name__"]
 
-    def var_getattr(
-        self, tx: "InstructionTranslator", name: str
-    ) -> VariableTracker:
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         fn_dict = self.get_dict_vt(tx)
 
         # missing: __globals__, __closure__, __kwdefautls__, __defaults__

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -443,7 +443,9 @@ class BaseUserFunctionVariable(VariableTracker):
     def get_module(self) -> str:
         return self.get_globals()["__name__"]
 
-    def var_getattr(self, tx: "InstructionTranslator", name: str):
+    def var_getattr(
+        self, tx: "InstructionTranslator", name: str
+    ) -> VariableTracker:
         fn_dict = self.get_dict_vt(tx)
 
         # missing: __globals__, __closure__, __kwdefautls__, __defaults__
@@ -2408,7 +2410,7 @@ class WrapperUserFunctionVariable(BaseUserFunctionVariable):
             return VariableTracker.build(tx, val, source)
         return super().var_getattr(tx, name)
 
-    def get_function(self):
+    def get_function(self) -> Any:
         return getattr(self.wrapper_obj, self.attr_to_trace)
 
     def self_args(self) -> list[VariableTracker]:
@@ -3561,7 +3563,7 @@ def emit_noargs_leaf_function_to_graph(
         make_leaf_function_wrappers,
     )
 
-    def fake_impl():
+    def fake_impl() -> None:
         return None
 
     captured_out_spec: list[pytree.TreeSpec | None] = [None]
@@ -3608,7 +3610,7 @@ class TritonSetAllocatorVariable(VariableTracker):
         # Emit an invoke_leaf_function node so it runs at runtime.
         set_allocator = self.value
 
-        def real_impl():
+        def real_impl() -> None:
             set_allocator(alloc_fn)
             return None
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2073,7 +2073,7 @@ def add_hop_context(cls: type[HOP_VT_Alias]) -> type[HOP_VT_Alias]:
 
     @functools.wraps(original_call_function)
     def wrapped_call_function(
-        self: VariableTracker, *args: Any, **kwargs: Any
+        self: HOP_VT_Alias, *args: Any, **kwargs: Any
     ) -> VariableTracker:
         try:
             return original_call_function(self, *args, **kwargs)

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2072,7 +2072,9 @@ def add_hop_context(cls: type[HOP_VT_Alias]) -> type[HOP_VT_Alias]:
     original_call_function = cls.call_function
 
     @functools.wraps(original_call_function)
-    def wrapped_call_function(self, *args: Any, **kwargs: Any) -> VariableTracker:
+    def wrapped_call_function(
+        self: VariableTracker, *args: Any, **kwargs: Any
+    ) -> VariableTracker:
         try:
             return original_call_function(self, *args, **kwargs)
         except UncapturedHigherOrderOpError as e:

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -715,7 +715,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(*tracing_state_functions())
         def handle_tracing_state_functions(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -741,7 +741,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(*dispatch_key_set_functions)
         def handle_dispatch_key_set_functions(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -773,7 +773,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.overrides.get_default_nowrap_functions.__wrapped__)
         def handle_get_default_nowrap_functions(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -788,7 +788,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.ops.inductor.accumulate_grad_.default)
         def handle_accumulate_grad_(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -799,7 +799,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(math.radians)
         def handle_radians(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -814,7 +814,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
             @register(math.fma)
             def handle_fma(
-                self,
+                self: "TorchInGraphFunctionVariable",
                 tx: "InstructionTranslator",
                 *args: VariableTracker,
                 **kwargs: VariableTracker,
@@ -832,7 +832,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.is_inference_mode_enabled)
         def handle_is_inference_mode_enabled(
-            self, tx: "InstructionTranslator"
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator"
         ) -> NoReturn:
             unimplemented(
                 gb_type="Encountered torch.is_inference_mode_enabled during tracing",
@@ -846,7 +846,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.is_tensor, torch.overrides.is_tensor_like)
         def handle_is_tensor(
-            self, tx: "InstructionTranslator", arg: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", arg: VariableTracker
         ) -> VariableTracker:
             if arg.is_tensor() or (
                 self.value is torch.overrides.is_tensor_like
@@ -862,7 +862,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             torch.is_complex,
         )
         def handle_is_floating_point(
-            self, tx: "InstructionTranslator", input: Any
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", input: Any
         ) -> VariableTracker | None:
             input_arg = input
             if input_arg.is_tensor() and input_arg.dtype is not None:
@@ -876,7 +876,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.numel)
         def handle_numel(
-            self, tx: "InstructionTranslator", input: Any
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", input: Any
         ) -> VariableTracker | None:
             if input.is_tensor() and input.valid_size():
                 return VariableTracker.build(tx, product(input.size))
@@ -887,7 +887,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.compile)
         def handle_torch_compile(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -908,7 +908,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.library.wrap_triton)
         def handle_wrap_triton(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -929,7 +929,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(*REWRITE_OPS_TO_TENSOR_SIZE_METHOD)
         def handle_tensor_size_rewrites(
-            self, tx: "InstructionTranslator", input: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", input: VariableTracker
         ) -> VariableTracker:
             assert input.is_tensor()
             return input.call_method(tx, "size", [], {})
@@ -942,7 +942,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             torch.nn.modules.utils._ntuple,
         )
         def handle_ntuple(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -951,14 +951,14 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.is_grad_enabled)
         def handle_is_grad_enabled(
-            self, tx: "InstructionTranslator"
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator"
         ) -> ConstantVariable:
             install_guard(GradModeVariable._guards_singleton)
             return VariableTracker.build(tx, torch.is_grad_enabled())
 
         @register(torch.use_deterministic_algorithms)
         def handle_use_deterministic_algorithms(
-            self, tx: "InstructionTranslator", mode: Any, warn_only: bool = False
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", mode: Any, warn_only: bool = False
         ) -> VariableTracker:
             # pyrefly: ignore [missing-attribute]
             if warn_only and warn_only.as_python_constant():
@@ -981,7 +981,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.autocast_increment_nesting)
         def handle_autocast_increment_nesting(
-            self, tx: "InstructionTranslator"
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator"
         ) -> VariableTracker:
             tx.output.create_node(
                 "call_function", torch.autocast_increment_nesting, (), {}
@@ -992,7 +992,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.autocast_decrement_nesting)
         def handle_autocast_decrement_nesting(
-            self, tx: "InstructionTranslator"
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator"
         ) -> VariableTracker:
             tx.output.create_node(
                 "call_function", torch.autocast_decrement_nesting, (), {}
@@ -1003,7 +1003,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.set_autocast_enabled)
         def handle_set_autocast_enabled(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             device_type: VariableTracker,
             enabled: VariableTracker,
@@ -1023,7 +1023,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.set_autocast_cache_enabled)
         def handle_set_autocast_cache_enabled(
-            self, tx: "InstructionTranslator", enabled: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", enabled: VariableTracker
         ) -> VariableTracker:
             tx.output.create_node(
                 "call_function", torch.set_autocast_cache_enabled, (enabled.as_proxy(),)
@@ -1035,7 +1035,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._functorch._grad_increment_nesting)
         def handle_grad_increment_nesting(
-            self, tx: "InstructionTranslator"
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator"
         ) -> VariableTracker:
             tx.output.create_node(
                 "call_function", torch._C._functorch._grad_increment_nesting
@@ -1046,7 +1046,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._functorch._grad_decrement_nesting)
         def handle_grad_decrement_nesting(
-            self, tx: "InstructionTranslator"
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator"
         ) -> VariableTracker:
             tx.output.create_node(
                 "call_function", torch._C._functorch._grad_decrement_nesting
@@ -1057,7 +1057,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._functorch.set_inplace_requires_grad_allowed)
         def handle_set_inplace_requires_grad_allowed(
-            self, tx: "InstructionTranslator", allowed: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", allowed: VariableTracker
         ) -> VariableTracker:
             tx.output.create_node(
                 "call_function",
@@ -1075,7 +1075,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.are_deterministic_algorithms_enabled)
         def handle_are_deterministic_algorithms_enabled(
-            self, tx: "InstructionTranslator"
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator"
         ) -> ConstantVariable:
             guard = Guard(
                 GlobalStateSource(),
@@ -1088,7 +1088,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._is_torch_function_enabled)
         def handle_is_torch_function_enabled(
-            self, tx: "InstructionTranslator"
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator"
         ) -> ConstantVariable:
             install_guard(TorchFunctionDisableVariable._guards_singleton)
             # see comment on SymbolicTorchFunctionState class as to why
@@ -1099,7 +1099,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._is_torch_function_all_disabled)
         def handle_is_torch_function_all_disabled(
-            self, tx: "InstructionTranslator"
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator"
         ) -> ConstantVariable:
             install_guard(TorchFunctionDisableVariable._guards_singleton)
             return VariableTracker.build(
@@ -1108,7 +1108,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._is_torch_function_mode_enabled)
         def handle_is_torch_function_mode_enabled(
-            self, tx: "InstructionTranslator"
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator"
         ) -> ConstantVariable:
             install_guard(TorchFunctionDisableVariable._guards_singleton)
             # _is_torch_function_mode_enabled returns True only if:
@@ -1126,7 +1126,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             torch.overrides.has_torch_function_unary,
         )
         def handle_has_torch_function(
-            self, tx: "InstructionTranslator", *args: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", *args: VariableTracker
         ) -> ConstantVariable:
             elems = (
                 args[0].unpack_var_sequence(tx)
@@ -1142,13 +1142,13 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             )
         )
         def handle_device_interface_stream(
-            self, tx: "InstructionTranslator", stream: "StreamVariable"
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", stream: "StreamVariable"
         ) -> StreamContextVariable:
             return StreamContextVariable.create(tx, stream)
 
         @register(torch.from_numpy)
         def handle_from_numpy(
-            self, tx: "InstructionTranslator", *args: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", *args: VariableTracker
         ) -> TensorVariable:
             if not config.trace_numpy:
                 unimplemented(
@@ -1185,13 +1185,13 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.jit.annotate)
         def handle_jit_annotate(
-            self, tx: "InstructionTranslator", the_type: Any, the_value: V
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", the_type: Any, the_value: V
         ) -> V:
             return the_value
 
         @register(torch.backends.cudnn.is_acceptable)
         def handle_cudnn_is_acceptable(
-            self, tx: "InstructionTranslator", tensor: Any, *extra: Any
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", tensor: Any, *extra: Any
         ) -> ConstantVariable:
             # is_acceptable(tensor) returns true if
             #   (a) tensor dtype/device are supported by cudnn
@@ -1209,7 +1209,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.utils.hooks.BackwardHook)
         def handle_backward_hook(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1218,7 +1218,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.nn.Parameter)
         def handle_parameter(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1227,7 +1227,10 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.ops.aten.sym_size, torch.ops.aten.sym_size.int)
         def handle_sym_size(
-            self_: Any, tx: "InstructionTranslator", self, dim: Any | None = None
+            self_: Any,
+            tx: "InstructionTranslator",
+            self: VariableTracker,
+            dim: Any | None = None,
         ) -> VariableTracker | None:
             # we see this when retracing already traced code
             if dim is not None:
@@ -1236,7 +1239,10 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.ops.aten.sym_stride, torch.ops.aten.sym_stride.int)
         def handle_sym_stride(
-            self_: Any, tx: "InstructionTranslator", self, dim: Any | None = None
+            self_: Any,
+            tx: "InstructionTranslator",
+            self: VariableTracker,
+            dim: Any | None = None,
         ) -> VariableTracker | None:
             if dim is not None:
                 return self.call_method(tx, "stride", [dim], {})
@@ -1244,7 +1250,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.addcdiv)
         def handle_addcdiv(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1265,7 +1271,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.full)
         def handle_full(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             size: VariableTracker,
             fill_value: VariableTracker,
@@ -1334,7 +1340,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._assert)
         def handle_assert(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             condition: VariableTracker,
             message: VariableTracker,
@@ -1348,7 +1354,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(SDPAParams)
         def handle_sdpa_params(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1384,7 +1390,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                 get_world_size,
             )
             def handle_constant_processgroup_functions(
-                self,
+                self: "TorchInGraphFunctionVariable",
                 tx: "InstructionTranslator",
                 *args: VariableTracker,
                 **kwargs: VariableTracker,
@@ -1436,7 +1442,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.nested.nested_tensor)
         def handle_nested_tensor(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             tensor_list: VariableTracker | None = None,
             *args: VariableTracker,
@@ -1469,7 +1475,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.nn.functional.one_hot)
         def handle_one_hot(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1490,7 +1496,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.guarding_hint_or_throw)
         def handle_guarding_hint_or_throw(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             expr: VariableTracker,
         ) -> VariableTracker | None:
@@ -1508,7 +1514,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.optimization_hint)
         def handle_optimization_hint(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             expr: VariableTracker,
             fallback: VariableTracker | None = None,
@@ -1528,7 +1534,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.guard_size_oblivious)  # type: ignore[deprecated]
         def handle_guard_size_oblivious(
-            self, tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 # TODO: this probably should be folded somewhere else but I'm not sure where
@@ -1546,7 +1552,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.guard_or_true)
         def handle_guard_or_true(
-            self, tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 # TODO: this probably should be folded somewhere else but I'm not sure where
@@ -1562,7 +1568,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.guard_or_false)
         def handle_guard_or_false(
-            self, tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 # TODO: this probably should be folded somewhere else but I'm not sure where
@@ -1578,7 +1584,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.statically_known_false)
         def handle_statically_known_false(
-            self, tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 return VariableTracker.build(
@@ -1594,7 +1600,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.has_free_unbacked_symbols)
         def handle_has_free_unbacked_symbols(
-            self, tx: "InstructionTranslator", x: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", x: VariableTracker
         ) -> VariableTracker | None:
             from .tensor import TensorVariable
 
@@ -1610,7 +1616,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.guard_scalar)
         def guard_scalar(
-            self, tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
         ) -> VariableTracker:
             if isinstance(expr, SymNodeVariable):
                 val = expr.sym_num
@@ -1631,7 +1637,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.statically_known_true)
         def handle_statically_known_true(
-            self, tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 return VariableTracker.build(
@@ -1647,7 +1653,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.sym_and)
         def handle_sym_and(
-            self, tx: "InstructionTranslator", *terms: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", *terms: VariableTracker
         ) -> VariableTracker | None:
             if all(isinstance(x, SymNodeVariable) for x in terms):
                 return SymNodeVariable.create(
@@ -1661,7 +1667,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.sym_or)
         def handle_sym_or(
-            self, tx: "InstructionTranslator", *terms: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", *terms: VariableTracker
         ) -> VariableTracker | None:
             if all(isinstance(x, SymNodeVariable) for x in terms):
                 return SymNodeVariable.create(
@@ -1675,7 +1681,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.has_static_value)
         def handle_has_static_value(
-            self, tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 val = expr.sym_num
@@ -1690,7 +1696,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._autograd._unsafe_set_version_counter)
         def handle_unsafe_set_version_counter(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1703,7 +1709,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._functorch.peek_interpreter_stack)
         def handle_functorch_peek_interpreter_stack(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1716,7 +1722,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._functorch.pyfunctorch.coerce_cinterpreter)
         def handle_functorch_pyfunctorch_coerce_cinterpreter(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1729,7 +1735,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.tensor)
         def handle_torch_tensor(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1767,7 +1773,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._pop_torch_function_stack)
         def handle_pop_torch_function(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1788,7 +1794,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._push_on_torch_function_stack)
         def handle_push_torch_function(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1805,7 +1811,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._len_torch_function_stack)
         def handle_len_torch_function(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1818,7 +1824,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._get_function_stack_at)
         def handle_get_stack_at(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1834,7 +1840,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.get_device_module.__wrapped__)
         def handle_get_device_module(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1878,7 +1884,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.accelerator.current_stream, torch.cuda.current_stream)
         def handle_current_stream(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1937,7 +1943,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             torch.cpu.synchronize,
         )
         def handle_synchronize(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1971,7 +1977,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.set_default_device)
         def handle_set_default_device(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -1993,7 +1999,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._check)
         def handle_check(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -2104,7 +2110,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.cuda._exchange_device)
         def handle_exchange_device(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -2113,7 +2119,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.cuda._maybe_exchange_device)
         def handle_maybe_exchange_device(
-            self,
+            self: "TorchInGraphFunctionVariable",
             tx: "InstructionTranslator",
             *args: VariableTracker,
             **kwargs: VariableTracker,
@@ -2123,7 +2129,12 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             )
 
         @register(torch.autograd.grad)
-        def handle_autograd_grad(self, tx: "InstructionTranslator", *args, **kwargs):
+        def handle_autograd_grad(
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            *args: VariableTracker,
+            **kwargs: VariableTracker,
+        ) -> VariableTracker:
             """
             Handle torch.autograd.grad() calls within compiled regions.
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -846,7 +846,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.is_tensor, torch.overrides.is_tensor_like)
         def handle_is_tensor(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", arg: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            arg: VariableTracker,
         ) -> VariableTracker:
             if arg.is_tensor() or (
                 self.value is torch.overrides.is_tensor_like
@@ -862,7 +864,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             torch.is_complex,
         )
         def handle_is_floating_point(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", input: Any
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            input: Any,
         ) -> VariableTracker | None:
             input_arg = input
             if input_arg.is_tensor() and input_arg.dtype is not None:
@@ -876,7 +880,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.numel)
         def handle_numel(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", input: Any
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            input: Any,
         ) -> VariableTracker | None:
             if input.is_tensor() and input.valid_size():
                 return VariableTracker.build(tx, product(input.size))
@@ -929,7 +935,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(*REWRITE_OPS_TO_TENSOR_SIZE_METHOD)
         def handle_tensor_size_rewrites(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", input: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            input: VariableTracker,
         ) -> VariableTracker:
             assert input.is_tensor()
             return input.call_method(tx, "size", [], {})
@@ -958,7 +966,10 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.use_deterministic_algorithms)
         def handle_use_deterministic_algorithms(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", mode: Any, warn_only: bool = False
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            mode: Any,
+            warn_only: bool = False,
         ) -> VariableTracker:
             # pyrefly: ignore [missing-attribute]
             if warn_only and warn_only.as_python_constant():
@@ -1023,7 +1034,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.set_autocast_cache_enabled)
         def handle_set_autocast_cache_enabled(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", enabled: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            enabled: VariableTracker,
         ) -> VariableTracker:
             tx.output.create_node(
                 "call_function", torch.set_autocast_cache_enabled, (enabled.as_proxy(),)
@@ -1057,7 +1070,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch._C._functorch.set_inplace_requires_grad_allowed)
         def handle_set_inplace_requires_grad_allowed(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", allowed: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            allowed: VariableTracker,
         ) -> VariableTracker:
             tx.output.create_node(
                 "call_function",
@@ -1126,7 +1141,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             torch.overrides.has_torch_function_unary,
         )
         def handle_has_torch_function(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", *args: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            *args: VariableTracker,
         ) -> ConstantVariable:
             elems = (
                 args[0].unpack_var_sequence(tx)
@@ -1142,13 +1159,17 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             )
         )
         def handle_device_interface_stream(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", stream: "StreamVariable"
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            stream: "StreamVariable",
         ) -> StreamContextVariable:
             return StreamContextVariable.create(tx, stream)
 
         @register(torch.from_numpy)
         def handle_from_numpy(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", *args: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            *args: VariableTracker,
         ) -> TensorVariable:
             if not config.trace_numpy:
                 unimplemented(
@@ -1185,13 +1206,19 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.jit.annotate)
         def handle_jit_annotate(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", the_type: Any, the_value: V
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            the_type: Any,
+            the_value: V,
         ) -> V:
             return the_value
 
         @register(torch.backends.cudnn.is_acceptable)
         def handle_cudnn_is_acceptable(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", tensor: Any, *extra: Any
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            tensor: Any,
+            *extra: Any,
         ) -> ConstantVariable:
             # is_acceptable(tensor) returns true if
             #   (a) tensor dtype/device are supported by cudnn
@@ -1534,7 +1561,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.guard_size_oblivious)  # type: ignore[deprecated]
         def handle_guard_size_oblivious(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            expr: VariableTracker,
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 # TODO: this probably should be folded somewhere else but I'm not sure where
@@ -1552,7 +1581,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.guard_or_true)
         def handle_guard_or_true(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            expr: VariableTracker,
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 # TODO: this probably should be folded somewhere else but I'm not sure where
@@ -1568,7 +1599,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.guard_or_false)
         def handle_guard_or_false(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            expr: VariableTracker,
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 # TODO: this probably should be folded somewhere else but I'm not sure where
@@ -1584,7 +1617,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.statically_known_false)
         def handle_statically_known_false(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            expr: VariableTracker,
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 return VariableTracker.build(
@@ -1600,7 +1635,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.has_free_unbacked_symbols)
         def handle_has_free_unbacked_symbols(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", x: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            x: VariableTracker,
         ) -> VariableTracker | None:
             from .tensor import TensorVariable
 
@@ -1616,7 +1653,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.guard_scalar)
         def guard_scalar(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            expr: VariableTracker,
         ) -> VariableTracker:
             if isinstance(expr, SymNodeVariable):
                 val = expr.sym_num
@@ -1637,7 +1676,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.statically_known_true)
         def handle_statically_known_true(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            expr: VariableTracker,
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 return VariableTracker.build(
@@ -1653,7 +1694,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.sym_and)
         def handle_sym_and(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", *terms: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            *terms: VariableTracker,
         ) -> VariableTracker | None:
             if all(isinstance(x, SymNodeVariable) for x in terms):
                 return SymNodeVariable.create(
@@ -1667,7 +1710,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.sym_or)
         def handle_sym_or(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", *terms: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            *terms: VariableTracker,
         ) -> VariableTracker | None:
             if all(isinstance(x, SymNodeVariable) for x in terms):
                 return SymNodeVariable.create(
@@ -1681,7 +1726,9 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
         @register(torch.fx.experimental.symbolic_shapes.has_static_value)
         def handle_has_static_value(
-            self: "TorchInGraphFunctionVariable", tx: "InstructionTranslator", expr: VariableTracker
+            self: "TorchInGraphFunctionVariable",
+            tx: "InstructionTranslator",
+            expr: VariableTracker,
         ) -> VariableTracker | None:
             if isinstance(expr, SymNodeVariable):
                 val = expr.sym_num
@@ -1873,6 +1920,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
             # need to guard only on no-arg get_device_module
             if device is None:
+                assert self.source is not None
                 source = CallFunctionNoArgsSource(self.source)
                 install_guard(source.make_guard(GuardBuilder.ID_MATCH))
             # assumes `module` is in the form `torch.xyz`
@@ -3090,8 +3138,8 @@ For now, dynamo will explicitly graph break when it encounters user code with th
     def call_nn_parameter(
         cls,
         tx: "InstructionTranslator",
-        data: Any | None = None,
-        requires_grad: bool = True,
+        data: VariableTracker | None = None,
+        requires_grad: bool | VariableTracker = True,
     ) -> VariableTracker:
         """A call to torch.nn.Parameter() gets lifted to before the graph"""
         if tx.export:

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -3178,6 +3178,10 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                 ],
             )
 
+        from .tensor import TensorVariable
+
+        assert isinstance(data, TensorVariable)
+
         # this results in cleaner graphs, but only works for inputs
         if data.source:
             return cls._nn_param_via_prefix_insert(tx, data, requires_grad)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -2669,7 +2669,9 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
             return self.exc_vt.call_method(tx, name, args, kwargs)
         return super().call_method(tx, name, args, kwargs)
 
-    def var_getattr(self, tx: "InstructionTranslator", name: str):
+    def var_getattr(
+        self, tx: "InstructionTranslator", name: str
+    ) -> VariableTracker:
         if name in (
             "args",
             "__cause__",

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -2669,9 +2669,7 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
             return self.exc_vt.call_method(tx, name, args, kwargs)
         return super().call_method(tx, name, args, kwargs)
 
-    def var_getattr(
-        self, tx: "InstructionTranslator", name: str
-    ) -> VariableTracker:
+    def var_getattr(self, tx: "InstructionTranslator", name: str) -> VariableTracker:
         if name in (
             "args",
             "__cause__",

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import contextlib
 import io
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, TypeVar
 from typing_extensions import ParamSpec
 
@@ -212,7 +212,9 @@ def substitute_in_graph(
     )
 
 
-def list_backends(exclude_tags=("debug", "experimental")) -> list[str]:
+def list_backends(
+    exclude_tags: Sequence[str] | None = ("debug", "experimental"),
+) -> list[str]:
     """
     Return valid strings that can be passed to `torch.compile(..., backend="name")`.
 


### PR DESCRIPTION
## Summary
- add the remaining missing function annotations across `torch._dynamo`
- finish the repeated local handler annotations in `torch/_dynamo/variables/torch.py`
- type the remaining decorator, polyfill, guard, and testing helpers without changing runtime behavior

## Root cause
`torch._dynamo` was already mostly annotated, but a scattered set of helper functions, local closures, and compatibility wrappers still had untyped parameters or return values. That left Dynamo short of full function-signature annotation coverage even though the remaining work was mostly mechanical.

## Proposed fix
- add explicit parameter and return annotations to the remaining untyped Dynamo functions
- use concrete local types where they were already obvious in context, and use `Any` only for dynamic dispatch hooks or wrapper surfaces that intentionally accept heterogeneous values
- complete the large repeated handler set in `torch/_dynamo/variables/torch.py` so the whole tree is covered consistently

## Why this is the right long term fix
This finishes the annotation pass without changing behavior, makes future typing/lint enforcement simpler, and avoids leaving Dynamo in a partially typed state where the remaining gaps are hard to track down one by one.

## Testing
- `python3 -m compileall -q torch/_dynamo`
- `git diff --check`
- AST validation script confirming there are no remaining unannotated function parameters, varargs, kwargs, or return types under `torch/_dynamo`
- Runtime tests were not runnable in this container because `/usr/bin/python3` is missing `typing_extensions`, so importing `torch` fails before the test suite can start.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98