### PR TITLE
[MPSInductor] Fix MetalScheduling constructor

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -6811,7 +6811,6 @@ class CommonTemplate:
             )
             self.assertEqual(fn(*inputs), opt_fn(*inputs))
 
-    @xfail_if_mps  # 'NullHandler' object has no attribute 'wrapper_code'
     def test_masked_scatter(self):
         def fn(value, mask, source):
             return torch.masked_scatter(value, mask, source)

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -19,7 +19,7 @@ from torch.utils._sympy.printers import CppPrinter, ExprPrinter as ExprPrinter_
 from torch.utils._sympy.value_ranges import ValueRanges
 
 from ..utils import ceildiv, get_bounds_index_expr, get_kernel_metadata
-from ..virtualized import ops, OpsWrapper, V
+from ..virtualized import NullHandler, ops, OpsWrapper, V
 from .common import (
     CSEVariable,
     DeferredLine,
@@ -1183,6 +1183,8 @@ class MetalScheduling(SIMDScheduling):
 
     def __init__(self, scheduler: Scheduler | None) -> None:
         super().__init__(scheduler)
+        if isinstance(V.graph, NullHandler):
+            return
         wrapper = V.graph.wrapper_code
         if wrapper is not None:
             if not V.graph.cpp_wrapper:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #179646
* #179589

If  `has_backend_feature()` is called, it constructs Scheduling object with Non schduler, just to query featues.
Guard all subsequent initialization on `V.graph` not being an instance of `NullHandler`, which is a common pattern for other implementations

This fixes `test_masked_scatter`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo