### PR TITLE
[fx_graph_runnable] Add generator for after_aot repro

### DIFF
--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -16,7 +16,7 @@ from torch._dynamo.repro.after_aot import (
 )
 from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.testing._internal.common_utils import IS_FBCODE
+from torch.testing._internal.common_utils import IS_FBCODE, TEST_CUDA
 from torch.utils._traceback import report_compile_source_on_error
 from torch.utils._triton import has_triton
 
@@ -132,6 +132,43 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
         save_graph_repro(buf, gm, args, "inductor_accuracy")
         r = buf.getvalue()
         self.assertIn("reader.opaque('__torch__.MyClass')", r)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    def test_dump_generator(self):
+        torch.cuda.init()
+        gen = torch.cuda.default_generators[0].clone_state()
+        writer = InputWriter(None)
+        writer.generator("fwd_rng_state_0", gen)
+        self.assertExpectedInline(
+            "\n".join(writer._lines),
+            """reader.generator('cuda', 0)  # fwd_rng_state_0""",
+        )
+        reader = InputReader(None)
+        env = {"reader": reader, "torch": torch}
+        exec("\n".join(writer._lines), env)
+        self.assertIsInstance(reader.args[0], torch._C.Generator)
+        self.assertEqual(reader.args[0].device, torch.device("cuda", 0))
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    def test_graphsafe_rng_repro(self):
+        """save_graph_repro should emit reader.generator() for Generator args."""
+        torch.cuda.init()
+        gen = torch.cuda.default_generators[0].clone_state()
+
+        def f(x):
+            return (x * x,)
+
+        args = [torch.randn(4, device="cuda"), gen]
+        gm = make_fx(f)(args[0])
+        with gm.graph.inserting_before(next(iter(gm.graph.nodes))):
+            gm.graph.placeholder("fwd_rng_state_0")
+        gm.recompile()
+
+        buf = io.StringIO()
+        save_graph_repro(buf, gm, args, "inductor_accuracy")
+        r = buf.getvalue()
+        self.assertIn("reader.generator('cuda', 0)", r)
+        self.assertNotIn("reader.unsupported(", r)
 
     @unittest.skipIf(not torch.distributed.is_available(), "requires distributed")
     def test_extract_distributed_info_skips_non_string_group_name(self):

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -588,6 +588,9 @@ class NopInputReader:
     def unsupported(self, name: str) -> None:
         pass
 
+    def generator(self, device_type: str, device_index: int) -> None:
+        pass
+
     def opaque(self, script_class_name: str) -> None:
         self.total += 1
 
@@ -679,6 +682,11 @@ class InputReader:
 
     def unsupported(self, name: str) -> None:
         self.args.append(None)
+
+    def generator(self, device_type: str, device_index: int) -> torch._C.Generator:
+        gen = torch.cuda.default_generators[device_index].clone_state()
+        self.args.append(gen)
+        return gen
 
     def opaque(self, script_class_name: str) -> None:
         self.args.append(None)
@@ -820,6 +828,12 @@ class InputWriter:
         if isinstance(val, torch.SymInt):
             val = val.node.hint
         self._lines.append(f"reader.symint({val!r})  # {name}")
+
+    def generator(self, name: str, arg: torch._C.Generator) -> None:
+        device = arg.device
+        self._lines.append(
+            f"reader.generator({device.type!r}, {device.index!r})  # {name}"
+        )
 
     def opaque(self, name: str, script_class_name: str) -> None:
         self._lines.append(f"reader.opaque({script_class_name!r})  # {name}")

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -689,6 +689,8 @@ if "__compile_source__" in globals():
             writer.const(placeholder)
         elif isinstance(arg, FakeScriptObject):
             writer.opaque(placeholder, arg.script_class_name)
+        elif isinstance(arg, torch._C.Generator):
+            writer.generator(placeholder, arg)
         else:
             writer.unsupported(placeholder, arg)
 


### PR DESCRIPTION




E2E Example:

```
import torch
import torch.utils.checkpoint

torch._logging.set_logs(aot_graphs=True)


def fn(q, k, v):
    return torch.nn.functional.scaled_dot_product_attention(
        q, k, v, dropout_p=0.1, is_causal=True
    )


def checkpointed_fn(q, k, v):
    return torch.utils.checkpoint.checkpoint(fn, q, k, v, use_reentrant=False)


model = torch.compile(checkpointed_fn)

q = torch.randn(2, 8, 64, 32, device="cuda", dtype=torch.float16, requires_grad=True)
k = torch.randn(2, 8, 64, 32, device="cuda", dtype=torch.float16, requires_grad=True)
v = torch.randn(2, 8, 64, 32, device="cuda", dtype=torch.float16, requires_grad=True)

out = model(q, k, v)
out.sum().backward()
```

fx_graph_runnable, note the **reader.generator('cuda', 0)  # fwd_rng_state_0** generated.
Without the PR, it will generate `reader.unsupported('fwd_rng_state_0')  # unsupported type for dumping: <class 'torch._C.Generator'>` and error out with 
```
    device_idx = rng_state.device.index
                 ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'device'
```


```
.....
torch._higher_order_ops.triton_kernel_wrap.kernel_side_table.reset_table()

from torch.nn import *
class Repro(torch.nn.Module):
    def __init__(self) -> None:
        super().__init__()



    def forward(self, primals_1, primals_2, primals_3, fwd_rng_state_0):
        graphsafe_run_with_rng_state = torch.ops.higher_order.graphsafe_run_with_rng_state(torch.ops.aten._scaled_dot_product_efficient_attention.default, primals_1, primals_2, primals_3, None, True, 0.1, True, rng_state = fwd_rng_state_0);  fwd_rng_state_0 = None
        getitem = graphsafe_run_with_rng_state[0];  graphsafe_run_with_rng_state = None
        return (getitem, primals_1, primals_2, primals_3)

def load_args(reader):
    buf0 = reader.storage(None, 65536, device=device(type='cuda', index=0), dtype_hint=torch.float16)
    reader.tensor(buf0, (2, 8, 64, 32), dtype=torch.float16, is_leaf=True)  # primals_1
    buf1 = reader.storage(None, 65536, device=device(type='cuda', index=0), dtype_hint=torch.float16)
    reader.tensor(buf1, (2, 8, 64, 32), dtype=torch.float16, is_leaf=True)  # primals_2
    buf2 = reader.storage(None, 65536, device=device(type='cuda', index=0), dtype_hint=torch.float16)
    reader.tensor(buf2, (2, 8, 64, 32), dtype=torch.float16, is_leaf=True)  # primals_3
    reader.generator('cuda', 0)  # fwd_rng_state_0
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98