### PR TITLE
[make_fx] Handle torch.Generator in proxy tensor tracing and Inductor

### DIFF
--- a/test/functorch/test_aot_joint_with_descriptors.py
+++ b/test/functorch/test_aot_joint_with_descriptors.py
@@ -796,6 +796,111 @@ class inner_f(torch.nn.Module):
         compiled_fn(*dict(model.named_parameters()).values(), inputs).sum().backward()
         self.assertIsNotNone(model.linear.weight.grad)
 
+    @requires_cuda
+    def test_export_and_compile_with_selective_ac(self):
+        """
+        Test that torch.compile works on a pre-partitioned AOT autograd graph
+        containing graphsafe_run_with_rng_state (from selective activation
+        checkpointing). This exercises the code path where make_fx re-traces
+        a graph that already has Generator-typed arguments flowing into the
+        graphsafe_run_with_rng_state higher-order op.
+        """
+        import functools
+        import itertools
+
+        from torch._subclasses import FakeTensorMode
+        from torch.utils.checkpoint import (
+            CheckpointPolicy,
+            create_selective_checkpoint_contexts,
+        )
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op in (
+                torch.ops.aten._scaled_dot_product_flash_attention.default,
+                torch.ops.aten._scaled_dot_product_efficient_attention.default,
+                torch.ops.aten._scaled_dot_product_cudnn_attention.default,
+            ):
+                return CheckpointPolicy.MUST_RECOMPUTE
+            return CheckpointPolicy.MUST_SAVE
+
+        class AttentionBlock(nn.Module):
+            def __init__(self, nheads, dim):
+                super().__init__()
+                self.nheads = nheads
+                self.wq = nn.Linear(dim, dim, bias=False)
+                self.wk = nn.Linear(dim, dim, bias=False)
+                self.wv = nn.Linear(dim, dim, bias=False)
+                self.wo = nn.Linear(dim, dim, bias=False)
+
+            def _compute_attention(self, x):
+                q = self.wq(x)
+                k = self.wk(x)
+                v = self.wv(x)
+                q = q.unflatten(-1, (self.nheads, -1)).permute(0, 2, 1, 3)
+                k = k.unflatten(-1, (self.nheads, -1)).permute(0, 2, 1, 3)
+                v = v.unflatten(-1, (self.nheads, -1)).permute(0, 2, 1, 3)
+                o = nn.functional.scaled_dot_product_attention(q, k, v)
+                o = o.permute(0, 2, 1, 3).flatten(-2)
+                o = self.wo(o)
+                return o
+
+            def forward(self, x, context_fn=None):
+                return (
+                    torch.utils.checkpoint.checkpoint(
+                        self._compute_attention,
+                        x,
+                        use_reentrant=False,
+                        context_fn=context_fn,
+                    )
+                    + x
+                )
+
+        class AttentionWithPolicy(nn.Module):
+            def __init__(self, nheads, dim):
+                super().__init__()
+                self.block = AttentionBlock(nheads, dim)
+                self.context_fn = functools.partial(
+                    create_selective_checkpoint_contexts, policy_fn
+                )
+
+            def forward(self, x):
+                return self.block(x, context_fn=self.context_fn)
+
+        nheads, dim, bs, seq_len = 8, 128, 2, 16
+        model = AttentionWithPolicy(nheads, dim).cuda()
+
+        fake_mode = FakeTensorMode()
+        with fake_mode:
+            inputs = (torch.rand(bs, seq_len, dim, device="cuda"),)
+
+        gm = dynamo_graph_capture_for_export(model)(*inputs)
+
+        with ExitStack() as stack:
+            joint_with_descriptors = aot_export_joint_with_descriptors(
+                stack,
+                gm,
+                inputs,
+            )
+            parallel_model_fn = aot_compile_joint_with_descriptors(
+                joint_with_descriptors,
+            )
+
+        class WrapperModule(torch.nn.Module):
+            def forward(self, *args):
+                params = [
+                    v
+                    for k, v in itertools.chain(
+                        dict(model.named_parameters(remove_duplicate=False)).items(),
+                        dict(model.named_buffers(remove_duplicate=False)).items(),
+                    )
+                ]
+                return parallel_model_fn([*params, *args])
+
+        real_inputs = (torch.rand(bs, seq_len, dim, device="cuda"),)
+        compiled = torch.compile(WrapperModule(), fullgraph=True)
+        out = compiled(*real_inputs)
+        out.sum().backward()
+
     def test_preserve_annotate_simple(self):
         """Test basic linear module with aot_export_joint_with_descriptors"""
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1488,7 +1488,7 @@ class GraphLowering(torch.fx.Interpreter):
         target: str,  # type: ignore[override]
         args: tuple[()],  # type: ignore[override]
         kwargs: dict[str, object],
-    ) -> Constant | TensorBox | ShapeAsConstantBuffer | ir.Subgraph | TorchBindObject:
+    ) -> Constant | TensorBox | ShapeAsConstantBuffer | ir.Subgraph | TorchBindObject | ir.GeneratorState:
         # this is a constant
         value = getattr_recursive(self.module, target)  # type: ignore[arg-type]
 
@@ -1513,6 +1513,10 @@ class GraphLowering(torch.fx.Interpreter):
             self.torchbind_constants[target] = value  # type: ignore[arg-type]
             self.constant_reprs[target] = ""
             return TorchBindObject(name=target, value=value)  # type: ignore[arg-type]
+        elif isinstance(value, torch.Generator):
+            self.torchbind_constants[target] = value  # type: ignore[arg-type]
+            self.constant_reprs[target] = ""
+            return ir.GeneratorState(name=target, device=value.device)
 
         assert isinstance(value, torch.Tensor)
         if (

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1440,6 +1440,14 @@ class PythonKeyTracer(Tracer):
                 raise AssertionError("a.node.constant should not be None")
             return a.node.constant
 
+        # Generators are mutable state objects (e.g. CUDA RNG generators) that
+        # appear as arguments to higher-order ops like graphsafe_run_with_rng_state.
+        # Hoist them as module attributes so they survive as get_attr nodes in the graph.
+        if isinstance(a, torch.Generator):
+            qualname = self.get_fresh_qualname("_generator_constant")
+            setattr(self.root, qualname, a)
+            return self.create_node("get_attr", qualname, (), {})
+
         # Try reconstructing untracked opaque reference types from existing
         # graph inputs (e.g. derive a DeviceMesh submesh from its root mesh).
         if isinstance(a, (FakeScriptObject, OpaqueBase)):


### PR DESCRIPTION
When a pre-partitioned AOT autograd forward graph containing graphsafe_run_with_rng_state is re-traced by make_fx (e.g. when torch.compile wraps an AutoParallel module), the Generator object passed as rng_state could not be serialized into the graph — create_arg raised NotImplementedError for torch._C.Generator.

Fix by hoisting Generator objects as module attributes (get_attr nodes) in PythonKeyTracer.create_arg, and teaching Inductor's get_attr handler to produce an ir.GeneratorState backed by torchbind_constants so the Generator is available as a module-level variable in the compiled code.

<!-- ps-id: d542629c-9c69-49bd-ac66-a6569e111771 -->

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo