### PR TITLE
[ROCm] Add gfx1103 to wheel build arch list

### DIFF
--- a/.ci/docker/almalinux/build.sh
+++ b/.ci/docker/almalinux/build.sh
@@ -36,7 +36,7 @@ case ${DOCKER_TAG_PREFIX} in
     ;;
   rocm*)
     BASE_TARGET=rocm
-    PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx950;gfx1150;gfx1151"
+    PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1200;gfx1201;gfx950;gfx1150;gfx1151"
     EXTRA_BUILD_ARGS="${EXTRA_BUILD_ARGS} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH}"
     ;;
   *)

--- a/.ci/docker/manywheel/build.sh
+++ b/.ci/docker/manywheel/build.sh
@@ -95,7 +95,7 @@ case ${image} in
         MANY_LINUX_VERSION="2_28"
         DEVTOOLSET_VERSION="13"
         GPU_IMAGE=rocm/dev-almalinux-8:${GPU_ARCH_VERSION}-complete
-        PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx950;gfx1150;gfx1151"
+        PYTORCH_ROCM_ARCH="gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1200;gfx1201;gfx950;gfx1150;gfx1151"
         DOCKER_GPU_BUILD_ARG="--build-arg ROCM_VERSION=${GPU_ARCH_VERSION} --build-arg PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}"
         ;;
     manylinux2_28-builder:xpu)


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                              
                                                                                                                                                                                                                                           
Add gfx1103 to `PYTORCH_ROCM_ARCH` in the manywheel build script.                                                                                                                                                                       
                                                                                                                                                                                                                                           
gfx1103 is the RDNA3 iGPU in AMD Phoenix/HawkPoint APUs (Ryzen 7040/8040 series). These are widely deployed laptop/desktop APUs. The ROCm compiler already supports gfx1103, and runtime support has already been merged:               
                                                                                                                                                                                                                                           
   - hipBLASLt: #172180                                                                                                                                                                                                                    
   - aotriton: #168351                                                                                                                                                                                                                     
                                                                                                                                                                                                                                           
However, gfx1103 is missing from the wheel build arch list, so no native kernels are included in the published wheels. Users must set `HSA_OVERRIDE_GFX_VERSION=11.0.0` (or `11.0.2`), which causes GPU page faults and hard hangs due to ISA differences:

   ```
   amdgpu: [gfxhub] page fault (src_id:0 ring:169 vmid:0 pasid:0)
   amdgpu:   in page starting at address 0x0000000000000000 from client 10
   amdgpu:   Faulty UTCL2 client ID: CPC (0x5)
   amdgpu:   WALKER_ERROR: 0x1
   amdgpu:   MAPPING_ERROR: 0x1
   ```

   This follows the same pattern as #147761 which added gfx1102.

   ## Test plan

   - [x] Verify gfx1103 wheel builds successfully in ROCm CI
   - [x] Verified locally that gfx1103 is accepted by the ROCm compiler (`rocminfo` reports gfx1103, `/dev/kfd` present)
   - [x] Confirmed runtime support already merged (hipBLASLt, aotriton)


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang