### PR TITLE
[CI] Fix use-gha input string truthiness bug in artifact actions

### DIFF
--- a/.github/actions/download-build-artifacts/action.yml
+++ b/.github/actions/download-build-artifacts/action.yml
@@ -18,14 +18,14 @@ runs:
   using: composite
   steps:
     - name: Download PyTorch Build Artifacts from S3
-      if: ${{ !inputs.use-gha }}
+      if: inputs.use-gha == '' || inputs.use-gha == 'false'
       uses: seemethere/download-artifact-s3@v4
       with:
         name: ${{ inputs.name }}
         s3-bucket: ${{ inputs.s3-bucket }}
 
     - name: Download PyTorch Build Artifacts from GHA
-      if: ${{ inputs.use-gha }}
+      if: inputs.use-gha != '' && inputs.use-gha != 'false'
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}

--- a/.github/actions/download-td-artifacts/action.yml
+++ b/.github/actions/download-td-artifacts/action.yml
@@ -11,13 +11,13 @@ runs:
   using: composite
   steps:
     - name: Download TD Artifacts from S3
-      if: ${{ !inputs.use-gha }}
+      if: inputs.use-gha == '' || inputs.use-gha == 'false'
       uses: seemethere/download-artifact-s3@v4
       with:
         name: td_results
 
     - name: Download TD Artifacts from GHA
-      if: inputs.use-gha
+      if: inputs.use-gha != '' && inputs.use-gha != 'false'
       uses: actions/download-artifact@v4
       with:
         name: td_results.json

--- a/.github/actions/upload-build-artifacts/action.yml
+++ b/.github/actions/upload-build-artifacts/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Upload PyTorch Build Artifacts to S3
-      if: ${{ !inputs.use-gha }}
+      if: inputs.use-gha == '' || inputs.use-gha == 'false'
       uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
       with:
         name: ${{ inputs.name }}
@@ -28,7 +28,7 @@ runs:
         s3-bucket: ${{ inputs.s3-bucket }}
 
     - name: Upload PyTorch Build Artifacts to GHA
-      if: ${{ inputs.use-gha }}
+      if: inputs.use-gha != '' && inputs.use-gha != 'false'
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.name }}


### PR DESCRIPTION
GitHub Actions composite action inputs are always strings. When callers pass `use-gha: ${{ steps.aws-creds.outcome != 'success' }}` and aws-creds succeeds, the input becomes the string "false" — which is truthy (non-empty string). This caused `!inputs.use-gha` to evaluate to false, skipping S3 upload and incorrectly uploading to GHA instead.

Replace truthiness checks with explicit string comparisons so that "false" and empty string both route to S3, while any other value ("true", "yes", etc.) routes to GHA.

I discovered this issue when `use-gha` was clearly set to false in https://github.com/pytorch/pytorch/actions/runs/24113191297/job/70351942055#step:12:5, but the GHA code path was still executed

### Testing

https://github.com/pytorch/pytorch/actions/runs/24115934376