### PR TITLE
[FSDP2] Cache shard_mesh to avoid repeated _create_sub_mesh calls (#179655)

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -238,6 +238,7 @@ class FSDPParam:
         else:
             self.mesh_info = mesh_info  # pyrefly: ignore[bad-assignment]
             fsdp_placement = None
+        self._shard_mesh = self._init_shard_mesh()
         if param.device != device and param.device.type != "meta":
             raise AssertionError(
                 f"Expects the parameter to already be moved to device {device} but got {param.device}"
@@ -891,14 +892,17 @@ class FSDPParam:
     def _sharded_local_tensor(self) -> torch.Tensor:
         return cast(DTensor, self.sharded_param)._local_tensor
 
-    @property
-    def shard_mesh(self):
+    def _init_shard_mesh(self) -> DeviceMesh:
         mesh = self.mesh_info.mesh
         if mesh.ndim == 1:
             return mesh
         if mesh.mesh_dim_names is None:
             raise AssertionError("Expected mesh_dim_names to not be None")
         return mesh[mesh.mesh_dim_names[-1]]
+
+    @property
+    def shard_mesh(self):
+        return self._shard_mesh
 
     @property
     def shard_mesh_from_root(self):


### PR DESCRIPTION
Summary:

For HSDP (2D mesh), every call to the `shard_mesh` property triggers
`DeviceMesh.__getitem__` → `_create_sub_mesh` → `DeviceMesh.__init__`
→ `check_non_overlap` → `all_ranks_from_zero` → `flatten`. This Python
object construction overhead is repeated on every forward pass for each
FSDP param group during the pre-forward unshard (`_prefetch_unshard` →
`unshard` → `foreach_all_gather` → `all_gather_inputs`).

This is particularly visible when using custom tensor subclasses like
`FP4CastWeightTensor` (for MX4 quantized all-gather), which bypass the
fast `use_foreach_copy` path in `_get_param_all_gather_inputs` and
force each param group through `all_gather_inputs` → `shard_mesh_from_root`
→ `shard_mesh` on every iteration.

Cache the computed shard mesh in `_cached_shard_mesh` on first access.
This is safe because the mesh topology (`mesh_info.mesh`, `ndim`,
`mesh_dim_names`) is immutable during training.

Test Plan:
Profiled with Perfetto traces on a 96-GPU HSDP OmniFM V4 eval job
(B200, hsdp_replica=3). Compared baseline trace vs MX4 linear-enabled
trace — confirmed `_create_sub_mesh` appears in the pre-forward unshard
callstack for every `FSDPSimpleDHENLayer` forward pass. With this fix,
the cached path avoids the repeated `DeviceMesh` construction.

Existing FSDP extension tests cover this path:
- `test_all_gather_extension_hsdp_mesh` (2D mesh, verifies shard submesh is 1D)
- `test_all_gather_extensions_monkey_patch` (1D mesh path)

before
 {F1987743217} 
after
 {F1987743669}

Reviewed By: weifengpy

Differential Revision: D99671240


