### PR TITLE
Add OpaqueGenerator to allow make_fx trace Generator

### DIFF
--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -16,6 +16,7 @@ from torch._dynamo.repro.after_aot import (
 )
 from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch._prims.rng_prims import OpaqueGenerator
 from torch.testing._internal.common_utils import IS_FBCODE, TEST_CUDA
 from torch.utils._traceback import report_compile_source_on_error
 from torch.utils._triton import has_triton
@@ -146,7 +147,7 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
         reader = InputReader(None)
         env = {"reader": reader, "torch": torch}
         exec("\n".join(writer._lines), env)
-        self.assertIsInstance(reader.args[0], torch._C.Generator)
+        self.assertIsInstance(reader.args[0], OpaqueGenerator)
         self.assertEqual(reader.args[0].device, torch.device("cuda", 0))
 
     @unittest.skipIf(not TEST_CUDA, "requires CUDA")

--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3567,5 +3567,59 @@ def forward(self, p_linear_weight, p_linear_bias, obj_lifted_custom_0, x):
 instantiate_parametrized_tests(TestOpaqueObject)
 
 
+@unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+class TestOpaqueGenerator(TestCase):
+    def test_make_fx_with_opaque_generator(self):
+        """make_fx should trace through OpaqueGenerator inputs."""
+        from torch._prims.rng_prims import (
+            graphsafe_run_with_rng_state,
+            OpaqueGenerator,
+        )
+
+        torch.cuda.init()
+
+        class M(torch.nn.Module):
+            def forward(self, q, k, v, rng_state):
+                out = graphsafe_run_with_rng_state(
+                    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+                    q, k, v, None, True, 0.1, True,
+                    rng_state=rng_state,
+                )
+                return out[0]
+
+        q = torch.randn(2, 8, 64, 32, device="cuda", dtype=torch.float16)
+        k = torch.randn(2, 8, 64, 32, device="cuda", dtype=torch.float16)
+        v = torch.randn(2, 8, 64, 32, device="cuda", dtype=torch.float16)
+        gen = OpaqueGenerator(torch.cuda.default_generators[0].clone_state())
+
+        gm = make_fx(M(), tracing_mode="real")(q, k, v, gen)
+
+        # The last placeholder (generator) should be used by graphsafe_run_with_rng_state
+        placeholders = [n for n in gm.graph.nodes if n.op == "placeholder"]
+        gen_placeholder = placeholders[-1]
+        self.assertEqual(len(gen_placeholder.users), 1)
+        user = next(iter(gen_placeholder.users))
+        self.assertIs(user.target, graphsafe_run_with_rng_state)
+
+        # Verify the traced graph produces the same result as eager.
+        # Use dropout_p=0.0 so the result is deterministic.
+        class M0(torch.nn.Module):
+            def forward(self, q, k, v, rng_state):
+                out = graphsafe_run_with_rng_state(
+                    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+                    q, k, v, None, False, 0.0, True,
+                    rng_state=rng_state,
+                )
+                return out[0]
+
+        gen1 = OpaqueGenerator(torch.cuda.default_generators[0].clone_state())
+        gen2 = OpaqueGenerator(torch.cuda.default_generators[0].clone_state())
+        gm0 = make_fx(M0(), tracing_mode="real")(q, k, v, gen1)
+        expected = M0()(q, k, v, gen2)
+        gen3 = OpaqueGenerator(torch.cuda.default_generators[0].clone_state())
+        actual = gm0(q, k, v, gen3)
+        self.assertEqual(actual, expected)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -683,8 +683,10 @@ class InputReader:
     def unsupported(self, name: str) -> None:
         self.args.append(None)
 
-    def generator(self, device_type: str, device_index: int) -> torch._C.Generator:
-        gen = torch.cuda.default_generators[device_index].clone_state()
+    def generator(self, device_type: str, device_index: int) -> Any:
+        from torch._prims.rng_prims import OpaqueGenerator
+
+        gen = OpaqueGenerator(torch.cuda.default_generators[device_index].clone_state())
         self.args.append(gen)
         return gen
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1237,7 +1237,7 @@ class GraphLowering(torch.fx.Interpreter):
             self.graph_input_names.append(target)
             return None
         # See note: Note: [Generator arguments in AOTDispatcher]
-        elif isinstance(example, torch.Generator):
+        elif isinstance(example, (torch.Generator, torch._prims.rng_prims.OpaqueGenerator)):
             assert len(V.graph.current_node.users) == 1 and next(
                 iter(V.graph.current_node.users)
             ).target in (

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -337,6 +337,8 @@ def register_graphsafe_run_with_rng_state_op():
 
     @graphsafe_run_with_rng_state.py_impl(DispatchKey.CUDA)
     def impl_cuda(op, *args, rng_state=None, **kwargs):
+        if isinstance(rng_state, OpaqueGenerator):
+            rng_state = rng_state.generator
         # pyrefly: ignore [missing-attribute]
         device_idx = rng_state.device.index
         generator = torch.cuda.default_generators[device_idx]
@@ -392,6 +394,40 @@ def register_graphsafe_run_with_rng_state_op():
 
 
 graphsafe_run_with_rng_state = register_graphsafe_run_with_rng_state_op()
+
+
+class OpaqueGenerator(torch._opaque_base.OpaqueBase):
+    """Opaque wrapper around torch._C.Generator for FX tracing.
+
+    torch._C.Generator doesn't support weakref or __dict__, so it can't be
+    tracked by FX's proxy infrastructure directly. This wrapper implements the
+    opaque value type protocol so generators flow through make_fx properly.
+    """
+
+    def __init__(self, generator: torch.Generator) -> None:
+        self.generator = generator
+
+    @property
+    def device(self) -> torch.device:
+        return self.generator.device
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, OpaqueGenerator):
+            return NotImplemented
+        return self.generator is other.generator
+
+    def __hash__(self) -> int:
+        return id(self.generator)
+
+    def __fx_repr__(self) -> tuple[str, dict[str, type]]:
+        device = self.generator.device
+        return (
+            f"OpaqueGenerator(torch.cuda.default_generators[{device.index}].clone_state())",
+            {"OpaqueGenerator": OpaqueGenerator, "torch": torch},
+        )
+
+
+torch._library.opaque_object.register_opaque_type(OpaqueGenerator, typ="value")
 
 
 def register_run_dtensor_rng_op():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179661
* __->__ #179658
* #179657


Following the context from #179657. Repro scripts call `make_fx` to retrace the module into a `GraphModule`, but
`make_fx` couldn't handle `torch._C.Generator` arguments — FX's proxy
infrastructure requires weakref support and `create_arg`/codegen support that
Generator lacked.

This introduces `OpaqueGenerator`, a wrapper class registered as an opaque value
type via `register_opaque_type`. It implements `__eq__`, `__hash__`, and
`__fx_repr__` so FX tracing, proxy tracking, and codegen all work through the
existing opaque type infrastructure without any changes to `torch/fx/`. The
`InputReader` returns `OpaqueGenerator` instances, and the inductor placeholder
handler accepts them alongside raw generators.

Authored with Claude.

**Alternatively, we can change `torch._C.Generator` itself to an Opaque Object class, see #179661**

### Test plan

- `python test/test_opaque_obj_v2.py TestOpaqueGenerator.test_make_fx_with_generator`
- `python agent_space/repro.py` (end-to-end repro with `run_repro`)


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98