### PR TITLE
[opaque_obj] Fix meta["val"] for reconstructed opaque nodes and partitioner classification

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3890,7 +3890,6 @@ class GraphModule(torch.nn.Module):
         from torch.utils.checkpoint import CheckpointPolicy
 
         m = OpaqueMultiplier(2.0)
-        x = torch.randn(3, requires_grad=True)
 
         fake_mode = FakeTensorMode(shape_env=ShapeEnv())
 

--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3828,6 +3828,7 @@ class GraphModule(torch.nn.Module):
         child._scale = 0.5
 
         from torch._library.opaque_object import _OPAQUE_TYPES
+
         original_reconstruct_fn = _OPAQUE_TYPES[OpaqueMultiplier].reconstruct_fn
 
         def multiplier_reconstruct_fn(obj, get_tracked_proxy, tracer):
@@ -3856,12 +3857,9 @@ class GraphModule(torch.nn.Module):
             derive_nodes = [
                 n
                 for n in gm.graph.nodes
-                if n.op == "call_function"
-                and "derive_multiplier" in str(n.target)
+                if n.op == "call_function" and "derive_multiplier" in str(n.target)
             ]
-            self.assertGreater(
-                len(derive_nodes), 0, "No derive_multiplier node found"
-            )
+            self.assertGreater(len(derive_nodes), 0, "No derive_multiplier node found")
 
             for node in derive_nodes:
                 self.assertIn(
@@ -3876,9 +3874,7 @@ class GraphModule(torch.nn.Module):
                     f"Node {node.name} should be classified as opaque",
                 )
         finally:
-            _OPAQUE_TYPES[OpaqueMultiplier].reconstruct_fn = (
-                original_reconstruct_fn
-            )
+            _OPAQUE_TYPES[OpaqueMultiplier].reconstruct_fn = original_reconstruct_fn
 
     def test_partitioner_must_save_opaque_node(self):
         """Opaque nodes tagged MUST_SAVE go to saved_opaque_nodes.

--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3779,6 +3779,173 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(result[0], x * 2)
         self.assertIs(result[1], m)
 
+    def test_reconstruct_fn_sets_meta_val(self):
+        """Opaque nodes created via reconstruct_fn have meta['val'] set.
+
+        When _try_reconstruct_opaque dispatches through a custom op via
+        Proxy.__torch_function__, the resulting node does not get
+        meta['val'] set automatically (unlike the __torch_dispatch__
+        path which calls track_tensor_tree).  The fix in
+        _try_reconstruct_opaque ensures set_meta is called so that
+        downstream consumers like the min-cut partitioner can classify
+        the node correctly via is_opaque_node().
+        """
+        from torch._functorch._aot_autograd.graph_compile import is_opaque_node
+
+        # Use the already-registered OpaqueMultiplier type.
+        # Register a reconstruct_fn that derives one multiplier from
+        # another via a custom op — mirrors how DeviceMesh submeshes
+        # are derived from a parent mesh via _get_submesh.
+        multiplier_type = get_opaque_type_name(OpaqueMultiplier)
+
+        self.lib.define(
+            f"derive_multiplier({multiplier_type} parent, float scale)"
+            f" -> {multiplier_type}",
+        )
+
+        @torch.library.impl(
+            "_TestOpaqueObject::derive_multiplier",
+            "CompositeExplicitAutograd",
+            lib=self.lib,
+        )
+        def derive_impl(parent, scale):
+            return OpaqueMultiplier(parent.multiplier * scale)
+
+        @torch.library.register_fake(
+            "_TestOpaqueObject::derive_multiplier", lib=self.lib
+        )
+        def derive_fake(parent, scale):
+            return OpaqueMultiplier(0.0)
+
+        parent = OpaqueMultiplier(3.0)
+        # The "child" is derived at eager time before tracing.
+        # It's NOT passed as an input — it's captured in a closure,
+        # simulating how DeviceMesh submeshes are captured in DTensor
+        # backward closures.  This forces _try_reconstruct_opaque to
+        # be called when make_fx encounters the child.
+        child = OpaqueMultiplier(parent.multiplier * 0.5)
+        child._parent = parent
+        child._scale = 0.5
+
+        from torch._library.opaque_object import _OPAQUE_TYPES
+        original_reconstruct_fn = _OPAQUE_TYPES[OpaqueMultiplier].reconstruct_fn
+
+        def multiplier_reconstruct_fn(obj, get_tracked_proxy, tracer):
+            if not hasattr(obj, "_parent"):
+                return None
+            parent_proxy = get_tracked_proxy(obj._parent)
+            if parent_proxy is None:
+                return None
+            return torch.ops._TestOpaqueObject.derive_multiplier(
+                parent_proxy, obj._scale
+            )
+
+        _OPAQUE_TYPES[OpaqueMultiplier].reconstruct_fn = multiplier_reconstruct_fn
+        try:
+            # child is captured from the closure, NOT an input
+            def fn(parent, x):
+                return torch.ops._TestOpaqueObject.mul_with_scale(child, x)
+
+            fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+            with fake_mode:
+                fake_x = torch.randn(4)
+
+            gm = make_fx(fn, tracing_mode="fake")(parent, fake_x)
+
+            # Find the derive_multiplier node (created by reconstruct_fn)
+            derive_nodes = [
+                n
+                for n in gm.graph.nodes
+                if n.op == "call_function"
+                and "derive_multiplier" in str(n.target)
+            ]
+            self.assertGreater(
+                len(derive_nodes), 0, "No derive_multiplier node found"
+            )
+
+            for node in derive_nodes:
+                self.assertIn(
+                    "val",
+                    node.meta,
+                    f"Node {node.name} created via reconstruct_fn is missing "
+                    f"meta['val']. This would cause the partitioner to fail "
+                    f"with 'Expected {node.name} to be a tensor'.",
+                )
+                self.assertTrue(
+                    is_opaque_node(node),
+                    f"Node {node.name} should be classified as opaque",
+                )
+        finally:
+            _OPAQUE_TYPES[OpaqueMultiplier].reconstruct_fn = (
+                original_reconstruct_fn
+            )
+
+    def test_partitioner_must_save_opaque_node(self):
+        """Opaque nodes tagged MUST_SAVE go to saved_opaque_nodes.
+
+        When activation checkpointing tags an opaque node with
+        CheckpointPolicy.MUST_SAVE, the default_partition function
+        must route it to saved_opaque_nodes (not saved_values).
+        Otherwise the runtime assertion in save_from_forward will
+        fail because it expects all saved_values to be Tensors.
+        """
+        from functorch.compile import default_partition
+        from torch._functorch._aot_autograd.graph_compile import is_opaque_node
+        from torch.utils.checkpoint import CheckpointPolicy
+
+        m = OpaqueMultiplier(2.0)
+        x = torch.randn(3, requires_grad=True)
+
+        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+
+        # Build a joint fwd+bwd graph where the opaque node is tagged
+        # MUST_SAVE — simulates activation checkpointing.
+        graph = torch.fx.Graph()
+        m_node = graph.placeholder("m")
+        m_node.meta["val"] = m
+        x_node = graph.placeholder("x")
+        with fake_mode:
+            x_node.meta["val"] = torch.randn(3)
+
+        mul_node = graph.call_function(
+            torch.ops._TestOpaqueObject.mul_with_scale.default,
+            (m_node, x_node),
+        )
+        with fake_mode:
+            mul_node.meta["val"] = torch.randn(3)
+
+        # Tag the opaque node as MUST_SAVE
+        m_node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+
+        # Create backward portion: identity backward
+        bw_node = graph.call_function(torch.ops.aten.mul.Scalar, (mul_node, 1.0))
+        with fake_mode:
+            bw_node.meta["val"] = torch.randn(3)
+
+        graph.output((mul_node, bw_node))
+        joint_gm = torch.fx.GraphModule({}, graph)
+
+        # Run default_partition — this should NOT raise even though
+        # the opaque node is tagged MUST_SAVE.
+        num_fwd_outputs = 1
+        fw_module, bw_module = default_partition(
+            joint_gm, [], num_fwd_outputs=num_fwd_outputs
+        )
+
+        # Verify the opaque node ended up in the forward graph as
+        # a pass-through (not as a saved tensor that would fail the
+        # save_from_forward assertion).
+        fw_opaque_nodes = [
+            n
+            for n in fw_module.graph.nodes
+            if n.op == "placeholder" and is_opaque_node(n)
+        ]
+        self.assertGreater(
+            len(fw_opaque_nodes),
+            0,
+            "Forward graph should have opaque placeholder nodes",
+        )
+
 
 instantiate_parametrized_tests(TestOpaqueObject)
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1352,14 +1352,20 @@ def default_partition(
             # Must be ordered before MUST_SAVE tags to avoid saving tuples marked MUST_SAVE.
             continue
         if node.meta.get("recompute") == CheckpointPolicy.MUST_SAVE:
-            saved_values.append(node)
+            if is_opaque_node(node):
+                saved_opaque_nodes.append(node)
+            else:
+                saved_values.append(node)
             continue
         if is_impure(node):
             if graph_has_recomputable_ops:
                 raise AssertionError(
                     f"Trying to apply AC on a graph with impure op: {node}, {node.target}"
                 )
-            saved_values.append(node)
+            if is_opaque_node(node):
+                saved_opaque_nodes.append(node)
+            else:
+                saved_values.append(node)
             continue
         if is_opaque_node(node):
             saved_opaque_nodes.append(node)

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1491,8 +1491,15 @@ class PythonKeyTracer(Tracer):
         if result is None:
             return None
 
-        # result is a Proxy from dispatching through a custom op.
-        # The op dispatch already registered the output in opaque_tracker.
+        # The reconstruct_fn dispatches through a custom op with a Proxy
+        # argument, which goes through Proxy.__torch_function__.  That path
+        # creates a graph node but does NOT populate meta["val"] (unlike the
+        # ProxyTorchDispatchMode.__torch_dispatch__ path which calls
+        # track_tensor_tree).  Set it here so downstream consumers (e.g. the
+        # min-cut partitioner) can classify the node correctly.
+        if "val" not in result.node.meta:
+            set_meta(result, a)
+
         # Also register for the *input* object so dedup works for re-encounters.
         set_proxy_slot(a, self, result)
         if id(real_obj) not in self._opaque_real_obj_proxy:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #179660

When an opaque object (e.g. a DeviceMesh submesh) is reconstructed during
tracing via `_try_reconstruct_opaque`, the reconstruct_fn dispatches through
a custom op with a Proxy argument.  This goes through
`Proxy.__torch_function__`, which creates a graph node but does NOT populate
`meta["val"]` — unlike the `ProxyTorchDispatchMode.__torch_dispatch__` path,
which calls `track_tensor_tree` to set it.

Without `meta["val"]`, `is_opaque_node()` returns False for these nodes,
causing two downstream failures in the min-cut partitioner
(`default_partition`):

1. Nodes tagged `CheckpointPolicy.MUST_SAVE` by activation checkpointing
   are routed to `saved_values` instead of `saved_opaque_nodes`.  The
   runtime `save_from_forward` then hits:
   `AssertionError: Expected _get_submesh_1 to be a tensor`

2. Impure opaque nodes hit the same `saved_values` path with the same
   assertion failure.

This is needed to support precompile with regional_inductor in torchtitan.
In that setting, DTensor operations produce DeviceMesh submeshes via
`_get_submesh` call_function nodes, which are opaque objects derived from
the parent mesh (hoisted as a graph input).  When activation checkpointing
is applied and the partitioner runs, these submesh nodes must be correctly
classified as opaque so they go through the opaque save/restore path rather
than the tensor save path.

Fix:
- proxy_tensor.py: Call `set_meta(result, a)` in `_try_reconstruct_opaque`
  after the reconstruct_fn returns, so the node gets `meta["val"]` set.
- partitioners.py: Add `is_opaque_node()` checks in the MUST_SAVE and
  is_impure branches of `default_partition`, routing opaque nodes to
  `saved_opaque_nodes` instead of `saved_values`.

Tests:
- test_reconstruct_fn_sets_meta_val: Verifies that nodes created via
  reconstruct_fn have meta["val"] set and is_opaque_node() returns True.
- test_partitioner_must_save_opaque_node: Verifies that opaque nodes
  tagged MUST_SAVE are correctly routed through the partitioner without
  triggering the tensor assertion.