### PR TITLE
[Claude Code] Fix flaky test_deferred_layout_constraint_cat_fusion by mocking subprocess autotuning

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2863,6 +2863,10 @@ class TestMaxAutotune(TestCase):
 
         with (
             fresh_cache(),
+            mock.patch(
+                "torch._inductor.autotune_process.run_autotune_in_subprocess",
+                mock_benchmark_choice_wrapper(aten_time=1.0, triton_time=0.1),
+            ),
             mock.patch.object(
                 AlgorithmSelectorCache,
                 "benchmark_choice",


### PR DESCRIPTION
Summary: Also mock run_autotune_in_subprocess in test_deferred_layout_constraint_cat_fusion to ensure deterministic kernel selection. Without this mock, when autotuning runs in a subprocess, the benchmark_choice mock is bypassed, leading to non-deterministic triton template selection and flaky FileCheck assertions. This matches the pattern used by other similar tests in the same file (e.g., test_deferred_layout_constraint_cat_index_put, test_deferred_layout_constraint_cat_scatter).

Test Plan:
Ran the test 10 times consecutively with all passes, confirming flakiness is resolved.

buck test fbcode//mode/opt fbcode//caffe2/test/inductor:max_autotune -- --exact 'fbcode//caffe2/test/inductor:max_autotune - test_deferred_layout_constraint_cat_fusion_epilogue_False (caffe2.test.inductor.test_max_autotune.TestMaxAutotune)'

Differential Revision: D99862590




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo