### PR TITLE
[DTensor] Add propagate_single_dim for single-dim sharding strategy

### DIFF
--- a/test/distributed/tensor/test_view_ops.py
+++ b/test/distributed/tensor/test_view_ops.py
@@ -25,6 +25,7 @@ from torch.distributed.tensor._ops._view_ops import (
     Flatten,
     InputDim,
     propagate_shape_and_sharding,
+    propagate_single_dim,
     Repeat,
     Singleton,
     Split,
@@ -301,6 +302,98 @@ class TestViewOps(DTensorContinuousTestBase):
                 (2, 3),
                 strict_view=True,
             )
+
+    def test_build_input_to_output_map(self):
+        """_build_input_to_output_map produces a complete mesh-free structural mapping."""
+        build = _ViewShardingPropagator._build_input_to_output_map
+
+        # Identity: (6,) → (6,)
+        rule = view_groups((6,), (6,))
+        self.assertEqual(build(rule), {0: [0]})
+
+        # Flatten: (2, 3, 4) → (6, 4)
+        rule = view_groups((2, 3, 4), (6, 4))
+        m = build(rule)
+        self.assertEqual(m[0], [0])
+        self.assertEqual(m[1], [0])
+        self.assertEqual(m[2], [1])
+
+        # Split: (6,) → (2, 3)
+        rule = view_groups((6,), (2, 3))
+        self.assertEqual(build(rule), {0: [0, 1]})
+
+        # Split(Flatten): (2, 3) → (3, 2)
+        rule = view_groups((2, 3), (3, 2))
+        m = build(rule)
+        # Both input dims participate in the flatten group
+        self.assertIn(0, m)
+        self.assertIn(1, m)
+        # At least one maps to both output dims
+        has_both = any(len(v) == 2 for v in m.values())
+        self.assertTrue(has_both)
+
+    def test_propagate_single_dim(self):
+        """propagate_single_dim matches propagate_shape_and_sharding for 1D mesh."""
+        cases = [
+            # (in_shape, out_shape, placement, mesh_dim_size)
+            ((6,), (2, 3), Shard(0), 2),
+            ((2, 3, 4), (6, 4), Shard(0), 2),
+            ((2, 3, 4), (6, 4), Shard(0), 3),
+            ((2, 3, 4), (6, 4), Shard(2), 2),
+            ((24,), (4, 6), Shard(0), 2),
+            ((4, 6), (24,), Shard(0), 2),
+            ((4, 6), (24,), Shard(1), 2),
+            ((6, 4), (3, 8), Shard(0), 3),
+        ]
+        for in_shape, out_shape, placement, mesh_size in cases:
+            rule = view_groups(in_shape, out_shape)
+            # Multi-dim with 1D mesh
+            inp_tgt_multi, out_multi = propagate_shape_and_sharding(
+                [placement], in_shape, rule, (mesh_size,)
+            )
+            # Single-dim
+            inp_tgt_single, out_single = propagate_single_dim(
+                placement, in_shape, rule, mesh_size
+            )
+            self.assertEqual(
+                inp_tgt_single,
+                inp_tgt_multi[0],
+                f"input mismatch for {in_shape}→{out_shape} {placement} mesh={mesh_size}",
+            )
+            self.assertEqual(
+                out_single,
+                out_multi[0],
+                f"output mismatch for {in_shape}→{out_shape} {placement} mesh={mesh_size}",
+            )
+
+    def test_propagate_single_dim_strided_shard(self):
+        """propagate_single_dim handles _StridedShard inputs correctly."""
+        # (2, 3, 4) → (6, 4): Shard(1) produces _StridedShard(0, sf=2)
+        # strict_view=True needed because non-strict disallows non-first flatten dims
+        in_shape = (2, 3, 4)
+        out_shape = (6, 4)
+        rule = view_groups(in_shape, out_shape)
+        inp_tgt, out_plc = propagate_single_dim(
+            Shard(1), in_shape, rule, 3, strict_view=True
+        )
+        self.assertEqual(inp_tgt, Shard(1))
+        self.assertEqual(out_plc, _StridedShard(0, split_factor=2))
+
+        # Then unflatten back: (6, 4) → (2, 3, 4) with _StridedShard(0, sf=2)
+        # should resolve back to Shard(1)
+        reverse_rule = view_groups(out_shape, in_shape)
+        inp_tgt2, out_plc2 = propagate_single_dim(
+            _StridedShard(0, split_factor=2), out_shape, reverse_rule, 3
+        )
+        self.assertEqual(inp_tgt2, _StridedShard(0, split_factor=2))
+        self.assertEqual(out_plc2, Shard(1))
+
+    def test_propagate_single_dim_replicate_passthrough(self):
+        """Replicate and Partial pass through unchanged in single-dim mode."""
+        rule = view_groups((6,), (2, 3))
+        inp_tgt, out_plc = propagate_single_dim(Replicate(), (6,), rule, 2)
+        self.assertEqual(inp_tgt, Replicate())
+        self.assertEqual(out_plc, Replicate())
 
     def test_view_ops(self):
         mesh_shape = (dist.get_world_size() // 2, 2)

--- a/torch/distributed/tensor/_ops/VIEW_OPS_SINGLE_DIM.md
+++ b/torch/distributed/tensor/_ops/VIEW_OPS_SINGLE_DIM.md
@@ -42,6 +42,29 @@ inp_tgt, out_plc = propagate_single_dim(
 )
 ```
 
+## Migration status
+
+All view ops now use `register_single_dim_view_strategy`. The old
+`register_op_strategy_map` has been deleted.
+
+## strict_view and reject_redistribution
+
+`aten.view.default` and `aten._unsafe_view.default` use `strict_view=True`,
+which forbids communication. At strategy enumeration time, `_smallest_factor`
+mesh sizes guarantee divisibility, so the propagator doesn't see the real mesh.
+At expansion time, a `reject_redistribution` callback re-runs
+`propagate_shape_and_sharding` with the actual mesh sizes across all mesh dims
+simultaneously, preserving cross-mesh-dim validation (e.g. SS double-shard,
+progressive local_tensor_shapes division). On success it returns a zero-cost
+`OpStrategy`; on failure it raises `RuntimeError`.
+
+## Inplace view ops
+
+View ops are metadata-only, so inplace variants (e.g. `squeeze_`) are
+registered with `is_view_op=True`. This skips the inplace placement
+constraint in `expand_to_full_mesh_op_strategy` that would otherwise reject
+valid dim-index shifts (e.g. `Shard(1) → Shard(0)` after squeezing dim 0).
+
 ## Refactoring
 
 `_build_input_to_output_map(rule)` was extracted from `analyze()` as a

--- a/torch/distributed/tensor/_ops/VIEW_OPS_SINGLE_DIM.md
+++ b/torch/distributed/tensor/_ops/VIEW_OPS_SINGLE_DIM.md
@@ -1,0 +1,56 @@
+# View Ops: Single-Dim Sharding Propagation
+
+## Problem
+
+`_ViewShardingPropagator` processes all mesh dims together with cross-mesh-dim
+coupling:
+
+- `local_tensor_shapes` progressive division — mesh dim j divides before j+1
+  reads
+- `_expected_split_factor()` — iterates earlier mesh dims' placements
+- `strided_shard_claimed_dims` — cross-mesh-dim output dim claims
+- `_is_last_shard_in_flatten_range()` — reads later mesh dims
+- `matched_strided_mesh_dims` in `_analyze_split()` — cross-mesh-dim tracking
+
+Single-dim strategy (`single_dim_strategy.py`) requires each mesh dim to be
+processable independently: `(placement, mesh_dim_size) → output_placement`.
+
+## Solution
+
+Constructing the propagator with `mesh_sizes=(mesh_dim_size,)` makes all
+cross-mesh-dim interactions naturally vacuous:
+
+- Progressive division: only one mesh dim, so no prior division
+- `_expected_split_factor()`: iterates zero earlier placements
+- `strided_shard_claimed_dims`: only one mesh dim can claim
+- `_is_last_shard_in_flatten_range()`: vacuously true with one mesh dim
+
+This means **no rewrite methods need to change** — existing
+`_rewrite_plain_shard`, `_rewrite_split_flatten_shard`, and
+`_rewrite_strided_shard` work correctly when the propagator sees a 1D mesh.
+
+## API
+
+```python
+from torch.distributed.tensor._ops._view_ops import propagate_single_dim
+
+inp_tgt, out_plc = propagate_single_dim(
+    placement=Shard(0),
+    global_input_shape=(2, 3, 4),
+    rule=view_groups((2, 3, 4), (6, 4)),
+    mesh_dim_size=2,
+)
+```
+
+## Refactoring
+
+`_build_input_to_output_map(rule)` was extracted from `analyze()` as a
+mesh-free structural mapping `{input_dim: [output_dims]}`. This separates
+structural dim tracking (which input dims map to which output dims) from
+shardability analysis (which dims can be sharded on which mesh dims).
+
+## Semantic difference: single-dim vs multi-dim
+
+For 2D mesh where both mesh dims shard the same input dim, single-dim produces
+different results from multi-dim. This is intentional — the caller composes
+independent per-mesh-dim results.

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -622,6 +622,28 @@ def propagate_single_dim(
     return input_tgt_placements[0], output_placements[0]
 
 
+class _MetaShim:
+    """Wraps TensorMeta so dim_map lambdas can access .ndim (missing on NamedTuple)."""
+
+    __slots__ = ("shape", "ndim")
+
+    def __init__(self, meta: TensorMeta) -> None:
+        self.shape = meta.shape
+        self.ndim = len(meta.shape)
+
+
+def _smallest_factor(n: int) -> int:
+    """Return smallest prime factor of n. n must be >= 2."""
+    if n % 2 == 0:
+        return 2
+    i = 3
+    while i * i <= n:
+        if n % i == 0:
+            return i
+        i += 2
+    return n
+
+
 class _ViewShardingPropagator:
     """Two-phase sharding propagator for view ops.
 
@@ -1458,15 +1480,53 @@ def register_op_strategy_map(
         return output_strategy
 
 
-register_op_strategy_map(aten.squeeze.default, torch.squeeze)
+def register_single_dim_view_strategy(
+    aten_op_overload: torch._ops.OpOverload,
+    local_op_name: Callable[..., torch.Tensor],
+    schema_info: RuntimeSchemaInfo | None = None,
+    strict_view: bool = False,
+) -> None:
+    """Register a view op under single-dim strategy using propagate_single_dim.
+
+    For each input dim, computes the output placement by calling
+    propagate_single_dim with a mesh_dim_size that guarantees divisibility
+    (smallest prime factor of the dim size).  The expansion infrastructure
+    handles actual divisibility checking at match time via is_tensor_shardable.
+    """
+    dim_map_fn: Callable[..., DimMap] = dim_maps[local_op_name]
+
+    @register_single_dim_strategy(aten_op_overload, schema_info=schema_info)
+    def view_single_dim(op, args_schema, kwargs_schema):
+        input_meta = cast(TensorMeta, args_schema[0])
+        shimmed_args = (_MetaShim(input_meta), *args_schema[1:])
+        rule = dim_map_fn(*shimmed_args, **kwargs_schema)
+
+        strategies: list[list[Placement | _ShardingPlaceholder]] = []
+        for d in range(len(input_meta.shape)):
+            dim_size = input_meta.shape[d]
+            if dim_size <= 1:
+                continue
+            mesh_dim_size = _smallest_factor(dim_size)
+            inp_tgt, out_plc = propagate_single_dim(
+                Shard(d), tuple(input_meta.shape), rule, mesh_dim_size, strict_view
+            )
+            if isinstance(inp_tgt, (Shard, _StridedShard)):
+                strategies.append([out_plc, inp_tgt])
+        # Partial placements pass through unchanged for view ops.
+        for reduce_op in ("sum", "avg", "max", "min"):
+            strategies.append([Partial(reduce_op), Partial(reduce_op)])
+        return strategies
+
+
+register_single_dim_view_strategy(aten.squeeze.default, torch.squeeze)
 register_op_strategy_map(aten.squeeze_.default, torch.squeeze)
 register_op_strategy_map(
     aten.squeeze_.dim, torch.squeeze, schema_info=RuntimeSchemaInfo(1)
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.squeeze.dim, torch.squeeze, schema_info=RuntimeSchemaInfo(1)
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.squeeze.dims, torch.squeeze, schema_info=RuntimeSchemaInfo(1)
 )
 register_op_strategy_map(
@@ -1478,12 +1538,12 @@ register_op_strategy_map(
     schema_info=RuntimeSchemaInfo(1),
     strict_view=True,
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.view_copy.default,
     Tensor.view,
     schema_info=RuntimeSchemaInfo(1),
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.reshape.default, torch.reshape, schema_info=RuntimeSchemaInfo(1)
 )
 register_op_strategy_map(
@@ -1492,22 +1552,22 @@ register_op_strategy_map(
     schema_info=RuntimeSchemaInfo(1),
     strict_view=True,
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.unsqueeze.default, torch.unsqueeze, schema_info=RuntimeSchemaInfo(1)
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.expand.default, Tensor.expand, schema_info=RuntimeSchemaInfo(1)
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.expand_copy.default, Tensor.expand, schema_info=RuntimeSchemaInfo(1)
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.permute.default, torch.permute, schema_info=RuntimeSchemaInfo(1)
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.repeat.default, Tensor.repeat, schema_info=RuntimeSchemaInfo(1)
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.transpose.int, torch.transpose, schema_info=RuntimeSchemaInfo(1)
 )
 
@@ -1529,4 +1589,4 @@ def view_as_complex_single_dim_strategy(op, args_schema, kwargs_schema):
     return strategies
 
 
-register_op_strategy_map(aten.view_as_real.default, torch.view_as_real)
+register_single_dim_view_strategy(aten.view_as_real.default, torch.view_as_real)

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -14,19 +14,13 @@ from torch.distributed.tensor._op_schema import (
     OpSpec,
     OpStrategy,
     RuntimeSchemaInfo,
-    StrategyType,
 )
 from torch.distributed.tensor._ops.single_dim_strategy import (
     _ShardingPlaceholder,
     register_single_dim_strategy,
 )
-from torch.distributed.tensor._ops.utils import (
-    generate_redistribute_costs,
-    normalize_dim,
-    normalize_dims,
-    prod,
-    register_op_strategy,
-)
+from torch.distributed.tensor._ops.utils import normalize_dim, normalize_dims, prod
+from torch.distributed.tensor.device_mesh import DeviceMesh
 from torch.distributed.tensor.placement_types import (
     _StridedShard,
     Partial,
@@ -1416,68 +1410,76 @@ class _ViewShardingPropagator:
         return _StridedShard(tgt_shard_dim, split_factor=p.split_factor), new_shapes
 
 
-def register_op_strategy_map(
-    aten_op_overload: torch._ops.OpOverload,
-    local_op_name: Callable[..., torch.Tensor],
-    schema_info: RuntimeSchemaInfo | None = None,
-    strict_view: bool = False,
-) -> None:
+def _make_view_reject_redistribution(
+    dim_map_fn: Callable[..., DimMap],
+    strict_view: bool,
+) -> Callable[
+    [OpSchema, DeviceMesh, TensorMeta | Sequence[TensorMeta | None] | None],
+    OpStrategy,
+]:
+    """Create a reject_redistribution function for strict view ops.
+
+    Re-runs propagate_shape_and_sharding with the actual mesh sizes across
+    all mesh dims simultaneously.  This catches uneven-divisibility errors
+    (e.g. flatten of an unevenly sharded non-last dim) and handles cross-
+    mesh-dim interactions (e.g. SS sharding) that the strategy enumeration
+    phase cannot detect because it uses _smallest_factor per dim independently.
     """
-    Helper that registers strategies for view-like operators that follow a pattern:
-      (1) define the way input dims are split/combined to form output dims (dim_maps)
-      (2) register a strategy for the op schema that uses the dim_map as a sharding prop rule
 
-    strict_view: if True, we will error out if the view-operation would require resharding the input.
-       Currently, this should be set to 'true' for any "view" ops.
-       We could diverge behavior for "reshape" ops which could perform a redistribute implicitly.
-    """
-    dim_map: Callable[..., DimMap] = dim_maps[local_op_name]
+    def reject_fn(
+        op_schema: OpSchema,
+        mesh: DeviceMesh,
+        output_tensor_meta: TensorMeta | Sequence[TensorMeta | None] | None,
+    ) -> OpStrategy:
+        input_meta = cast(TensorMeta, op_schema.args_meta[0])
+        shimmed_args = (_MetaShim(input_meta), *op_schema.args_meta[1:])
+        rule = dim_map_fn(*shimmed_args, **op_schema.kwargs_meta)
+        global_shape = tuple(input_meta.shape)
 
-    @register_op_strategy(aten_op_overload, schema_info=schema_info)
-    def reshape_strategy(op_schema: OpSchema) -> StrategyType:
-        rules = dim_map(*op_schema.args_schema, **op_schema.kwargs_schema)
-        input_strategy = cast(OpStrategy, op_schema.args_schema[0])
-        mesh = op_schema.get_mesh_from_args(validate=False)
+        # Extract input specs from OpStrategy-wrapped args
+        input_specs: list[DTensorSpec] = []
+        for arg in op_schema.args_schema:
+            if isinstance(arg, OpStrategy):
+                if len(arg.strategies) != 1:
+                    raise AssertionError
+                input_specs.append(arg.strategies[0].output_spec)
+        if len(input_specs) == 0:
+            raise AssertionError("No tensor inputs found")
 
-        global_in_shape = input_strategy.shape
-        if global_in_shape is None:
-            raise AssertionError("Shape required.")
+        # Validate with all mesh dims simultaneously via the multi-dim
+        # propagator.  This will raise RuntimeError if the view is invalid
+        # (e.g. uneven flatten on a non-last dim).
+        mesh_sizes = tuple(mesh.size(i) for i in range(mesh.ndim))
+        input_placements = input_specs[0].placements
+        _, out_placements = propagate_shape_and_sharding(
+            input_placements, global_shape, rule, mesh_sizes, strict_view
+        )
 
-        output_strategy = OpStrategy([])
-        for input_placement_strategy in input_strategy.strategies:
-            input_src_spec = input_placement_strategy.output_spec
+        # Build OpStrategy with zero redistribute cost
+        out_placements_tuple = tuple(out_placements)
+        if output_tensor_meta is None:
+            out_meta = None
+        elif isinstance(output_tensor_meta, TensorMeta):
+            out_meta = output_tensor_meta
+        else:
+            out_meta = output_tensor_meta[0] if output_tensor_meta else None
 
-            input_tgt_placements, output_placements = propagate_shape_and_sharding(
-                input_src_spec.placements,
-                tuple(global_in_shape),
-                rules,
-                mesh.shape,
-                strict_view,
-            )
-
-            # TODO: optimize this. we shouldn't simply blindly replicate
-            #       unshardable dims ...
-            # FIXME: this can be wrong for situations where we have
-            #        [Shard(0), Shard(0)]
-            input_tgt_spec = DTensorSpec(
-                placements=tuple(input_tgt_placements),
-                mesh=mesh,
-                tensor_meta=input_src_spec.tensor_meta,
-            )
-            redistribute_costs: list[list[float]] = [
-                generate_redistribute_costs(input_strategy, input_tgt_spec)
-            ]
-
-            output_spec = DTensorSpec(mesh=mesh, placements=tuple(output_placements))
-            output_strategy.strategies.append(
+        output_spec = DTensorSpec(mesh, out_placements_tuple, tensor_meta=out_meta)
+        arg_specs = [
+            DTensorSpec(mesh, spec.placements, tensor_meta=spec.tensor_meta)
+            for spec in input_specs
+        ]
+        return OpStrategy(
+            [
                 OpSpec(
                     output_specs=output_spec,
-                    input_specs=(input_tgt_spec,),
-                    redistribute_cost=redistribute_costs,
+                    input_specs=arg_specs,
+                    redistribute_cost=[[0.0] for _ in input_specs],
                 )
-            )
+            ]
+        )
 
-        return output_strategy
+    return reject_fn
 
 
 def register_single_dim_view_strategy(
@@ -1495,7 +1497,18 @@ def register_single_dim_view_strategy(
     """
     dim_map_fn: Callable[..., DimMap] = dim_maps[local_op_name]
 
-    @register_single_dim_strategy(aten_op_overload, schema_info=schema_info)
+    reject_fn = (
+        _make_view_reject_redistribution(dim_map_fn, strict_view)
+        if strict_view
+        else None
+    )
+
+    @register_single_dim_strategy(
+        aten_op_overload,
+        schema_info=schema_info,
+        reject_redistribution=reject_fn,
+        is_view_op=True,
+    )
     def view_single_dim(op, args_schema, kwargs_schema):
         input_meta = cast(TensorMeta, args_schema[0])
         shimmed_args = (_MetaShim(input_meta), *args_schema[1:])
@@ -1507,9 +1520,16 @@ def register_single_dim_view_strategy(
             if dim_size <= 1:
                 continue
             mesh_dim_size = _smallest_factor(dim_size)
-            inp_tgt, out_plc = propagate_single_dim(
-                Shard(d), tuple(input_meta.shape), rule, mesh_dim_size, strict_view
-            )
+            try:
+                inp_tgt, out_plc = propagate_single_dim(
+                    Shard(d), tuple(input_meta.shape), rule, mesh_dim_size, strict_view
+                )
+            except RuntimeError:
+                # strict_view can raise for unflatten patterns where the first
+                # output dim isn't divisible by _smallest_factor of the input
+                # dim.  Skip this candidate; actual shardability is validated
+                # at match time by is_tensor_shardable.
+                continue
             if isinstance(inp_tgt, (Shard, _StridedShard)):
                 strategies.append([out_plc, inp_tgt])
         # Partial placements pass through unchanged for view ops.
@@ -1519,8 +1539,8 @@ def register_single_dim_view_strategy(
 
 
 register_single_dim_view_strategy(aten.squeeze.default, torch.squeeze)
-register_op_strategy_map(aten.squeeze_.default, torch.squeeze)
-register_op_strategy_map(
+register_single_dim_view_strategy(aten.squeeze_.default, torch.squeeze)
+register_single_dim_view_strategy(
     aten.squeeze_.dim, torch.squeeze, schema_info=RuntimeSchemaInfo(1)
 )
 register_single_dim_view_strategy(
@@ -1529,10 +1549,10 @@ register_single_dim_view_strategy(
 register_single_dim_view_strategy(
     aten.squeeze.dims, torch.squeeze, schema_info=RuntimeSchemaInfo(1)
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.squeeze_.dims, torch.squeeze, schema_info=RuntimeSchemaInfo(1)
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten.view.default,
     Tensor.view,
     schema_info=RuntimeSchemaInfo(1),
@@ -1546,7 +1566,7 @@ register_single_dim_view_strategy(
 register_single_dim_view_strategy(
     aten.reshape.default, torch.reshape, schema_info=RuntimeSchemaInfo(1)
 )
-register_op_strategy_map(
+register_single_dim_view_strategy(
     aten._unsafe_view.default,
     Tensor.view,
     schema_info=RuntimeSchemaInfo(1),

--- a/torch/distributed/tensor/_ops/_view_ops.py
+++ b/torch/distributed/tensor/_ops/_view_ops.py
@@ -596,6 +596,32 @@ def propagate_shape_and_sharding(
     return input_tgt_placements, output_placements
 
 
+def propagate_single_dim(
+    placement: Placement,
+    global_input_shape: Shape,
+    rule: DimMap,
+    mesh_dim_size: int,
+    strict_view: bool = False,
+) -> tuple[Placement, Placement]:
+    """Propagate one placement through a view op, independently of other mesh dims.
+
+    This is the single-dim entry point for single-dim sharding strategy.
+    Each mesh dim is processed independently with no cross-mesh-dim state:
+    no progressive local_tensor_shapes division, no strided_shard_claimed_dims,
+    no _expected_split_factor adjustment from earlier mesh dims.
+
+    Returns (input_tgt_placement, output_placement).
+    """
+    input_tgt_placements, output_placements = propagate_shape_and_sharding(
+        input_src_placements=(placement,),
+        global_input_shape=global_input_shape,
+        rule=rule,
+        mesh_sizes=(mesh_dim_size,),
+        strict_view=strict_view,
+    )
+    return input_tgt_placements[0], output_placements[0]
+
+
 class _ViewShardingPropagator:
     """Two-phase sharding propagator for view ops.
 
@@ -643,86 +669,98 @@ class _ViewShardingPropagator:
     # Public API: analyze → rewrite_output_placements
     # ------------------------------------------------------------------
 
-    def analyze(
-        self,
-    ) -> tuple[Sequence[Placement], dict[int, list[int]]]:
-        """Phase 1: walk the DimMap rule, return (input_tgt_placements, input_to_output_tensor_dims)."""
-        input_dims_in_rule = self._input_dims_in_rule(self.rule)
+    @staticmethod
+    def _collect_all_input_dims(cmd: DimSpec) -> list[InputDim]:
+        """Collect all InputDim nodes from a DimSpec tree, regardless of sharding.
 
-        # Default: shardable if the dim appears in the rule. Refined by _analyze_*.
-        for dim in range(len(self.global_input_shape)):
-            self.shard_allowed[dim] = [dim in input_dims_in_rule] * self.mesh_ndim
+        For Split, only split_id==0 returns dims — later split_ids are linked
+        via the root chase in _build_input_to_output_map.
+        """
+        if isinstance(cmd, InputDim):
+            return [cmd]
+        elif isinstance(cmd, Flatten):
+            return [d for d in cmd.input_dims if isinstance(d, InputDim)]
+        elif isinstance(cmd, Split):
+            if cmd.split_id == 0:
+                return _ViewShardingPropagator._collect_all_input_dims(cmd.input_dim)
+            return []
+        else:
+            return []
 
-        # Walk the rule to refine shard_allowed and build input_to_output_tensor_dims.
-        #
-        # Flatten example: view([2, 3, 4], [6, 4])
-        #   rule = (Flatten(InputDim(0), InputDim(1)), InputDim(2))
-        #   output_dim=0 (Flatten): hits the isinstance(cmd, Flatten) branch.
-        #     Maps input dims 0 and 1 to output dim 0.  Result: {0: [0], 1: [0]}
-        #   output_dim=1 (InputDim(2)): hits the len(in_dims) > 0 branch.
-        #     Maps input dim 2 to output dim 1.  Result: {0: [0], 1: [0], 2: [1]}
-        #
-        # Split example: view([6], [2, 3])
-        #   rule = (Split(InputDim(0), (2,3), 0), Split(InputDim(0), (2,3), 1))
-        #   output_dim=0 (split_id=0): hits the len(in_dims) > 0 branch.
-        #     Maps input dim 0 to output dim 0.  Result: {0: [0]}
-        #   output_dim=1 (split_id=1): hits the isinstance(cmd, Split) branch
-        #     because _analyze_split returns [] for split_id>0.  Chases root
-        #     InputDim(0) and appends output dim 1.  Result: {0: [0, 1]}
-        input_to_output_tensor_dims: dict[int, list[int]] = {}
-        for output_dim, cmd in enumerate(self.rule):
-            in_dims = self._analyze_dim(cmd)
+    @staticmethod
+    def _build_input_to_output_map(rule: DimMap) -> dict[int, list[int]]:
+        """Build {input_dim: [output_dims]} from the DimMap rule. Mesh-free.
+
+        This is a purely structural mapping: which input dims participate in
+        which output dims.  No sharding or mesh information is needed.
+
+        Examples:
+          Flatten: view([2, 3, 4], [6, 4])
+            rule = (Flatten(InputDim(0), InputDim(1)), InputDim(2))
+            → {0: [0], 1: [0], 2: [1]}
+
+          Split: view([6], [2, 3])
+            rule = (Split(InputDim(0), (2,3), 0), Split(InputDim(0), (2,3), 1))
+            → {0: [0, 1]}
+
+          Split(Flatten): view([2, 3], [3, 2])
+            rule = (Split(Flatten(InputDim(0), InputDim(1)), (3,2), 0),
+                    Split(Flatten(InputDim(0), InputDim(1)), (3,2), 1))
+            → {0: [0, 1], 1: [0, 1]}
+        """
+        collect = _ViewShardingPropagator._collect_all_input_dims
+        input_to_output: dict[int, list[int]] = {}
+        for output_dim, cmd in enumerate(rule):
+            in_dims = collect(cmd)
             if isinstance(cmd, Flatten):
                 for in_dim in in_dims:
-                    if in_dim.input_dim in input_to_output_tensor_dims:
+                    if in_dim.input_dim in input_to_output:
                         raise AssertionError(
                             f"Input dim {in_dim.input_dim} already mapped to output dims "
-                            f"{input_to_output_tensor_dims[in_dim.input_dim]}"
+                            f"{input_to_output[in_dim.input_dim]}"
                         )
-                    input_to_output_tensor_dims[in_dim.input_dim] = [output_dim]
+                    input_to_output[in_dim.input_dim] = [output_dim]
             elif len(in_dims) > 0:
-                # InputDim (identity), Split(split_id=0), or
-                # Split(Flatten(...), split_id=0) which returns multiple dims.
                 for in_dim in in_dims:
-                    if in_dim.input_dim not in input_to_output_tensor_dims:
-                        input_to_output_tensor_dims[in_dim.input_dim] = [output_dim]
+                    if in_dim.input_dim not in input_to_output:
+                        input_to_output[in_dim.input_dim] = [output_dim]
                     else:
-                        input_to_output_tensor_dims[in_dim.input_dim].append(output_dim)
+                        input_to_output[in_dim.input_dim].append(output_dim)
             elif isinstance(cmd, Split):
-                # Split(split_id>0): _analyze_split returned [], so chase the
-                # root input dim and append this output dim to its existing entry.
-                #
-                # Flatten+Split example: view([2, 3], [3, 2])
-                #   rule = (Split(Flatten(InputDim(0), InputDim(1)), (3,2), 0),
-                #           Split(Flatten(InputDim(0), InputDim(1)), (3,2), 1))
-                #   output_dim=0 (split_id=0): _analyze_split returns all
-                #     sharded InputDims from the inner Flatten.  If only
-                #     InputDim(0) is sharded: {0: [0]}.  If both are sharded:
-                #     {0: [0], 1: [0]}.
-                #   output_dim=1 (split_id=1): chases the root input dim
-                #     used as key by split_id=0 and appends output_dim 1.
-                #     E.g. {0: [0, 1]} (or {0: [0, 1], 1: [0]} if both sharded).
+                # Split(split_id>0): chase root to find an InputDim already
+                # in the map (populated by split_id=0) and append this output_dim.
                 root_spec = cmd.input_dim
                 while isinstance(root_spec, (Flatten, Split)):
                     if isinstance(root_spec, Flatten):
-                        # Find whichever input dim was used as the key by
-                        # split_id=0.  input_dims[0] is not always the key
-                        # because strict-mode _analyze_flatten may return a
-                        # non-first sharded dim (e.g. InputDim(1)).
                         root_spec = next(
                             (
                                 fd
                                 for fd in root_spec.input_dims
                                 if isinstance(fd, InputDim)
-                                and fd.input_dim in input_to_output_tensor_dims
+                                and fd.input_dim in input_to_output
                             ),
                             root_spec.input_dims[0],
                         )
                     else:
                         root_spec = root_spec.input_dim
                 root = root_spec if isinstance(root_spec, InputDim) else None
-                if root is not None and root.input_dim in input_to_output_tensor_dims:
-                    input_to_output_tensor_dims[root.input_dim].append(output_dim)
+                if root is not None and root.input_dim in input_to_output:
+                    input_to_output[root.input_dim].append(output_dim)
+        return input_to_output
+
+    def analyze(
+        self,
+    ) -> tuple[Sequence[Placement], dict[int, list[int]]]:
+        """Phase 1: walk the DimMap rule, return (input_tgt_placements, input_to_output_tensor_dims)."""
+        # Structural mapping — mesh-free, computed once.
+        input_to_output_tensor_dims = self._build_input_to_output_map(self.rule)
+
+        # Shardability analysis — sets self.shard_allowed per (input_dim, mesh_dim).
+        input_dims_in_rule = self._input_dims_in_rule(self.rule)
+        for dim in range(len(self.global_input_shape)):
+            self.shard_allowed[dim] = [dim in input_dims_in_rule] * self.mesh_ndim
+        for _output_dim, cmd in enumerate(self.rule):
+            self._analyze_dim(cmd)
 
         input_tgt_placements: list[Placement] = []
         for mesh_dim, p in enumerate(self.input_src_placements):

--- a/torch/distributed/tensor/_ops/single_dim_strategy.py
+++ b/torch/distributed/tensor/_ops/single_dim_strategy.py
@@ -80,6 +80,22 @@ class _SingleDimStrategyInfo:
     # than the op's compute mesh.  These args must be Replicate.
     # See Note [Multi-mesh args] in expand_to_full_mesh_op_strategy.
     different_mesh_args: list[int] | None = field(default=None)
+    # When set, the expansion bypasses normal strategy enumeration and calls
+    # this function to validate the actual input placements against the actual
+    # mesh.  The function must return an OpStrategy (zero-cost) on success or
+    # raise RuntimeError on failure.  Used for strict view ops where
+    # communication is not allowed and validation requires the real mesh sizes.
+    reject_redistribution: (
+        Callable[
+            [OpSchema, DeviceMesh, TensorMeta | Sequence[TensorMeta | None] | None],
+            OpStrategy,
+        ]
+        | None
+    ) = field(default=None)
+    # View ops are metadata-only, so inplace variants (e.g. squeeze_) should
+    # not be subject to the inplace placement constraint in
+    # expand_to_full_mesh_op_strategy.
+    is_view_op: bool = field(default=False)
 
     # Delegate to func so this can be used interchangeably with a raw
     # _SingleDimStrategyFunc (e.g. in tests that call strategy functions directly).
@@ -494,6 +510,16 @@ def _expand_single_dim_strategy_to_mesh(
     # Note: circular import, failed to untangle with #168221, reverted
     from torch.distributed.tensor._ops.utils import expand_to_full_mesh_op_strategy
 
+    # For ops that reject redistribution (e.g. strict view ops), call the
+    # validation function with the actual mesh sizes.  This must be OUTSIDE
+    # the cached _create_expanded_strategy_impl because op_schema placements
+    # differ across calls but the cache key may not distinguish them.
+    if strategy_info.reject_redistribution is not None:
+        result = strategy_info.reject_redistribution(
+            op_schema, mesh, output_tensor_meta
+        )
+        return lambda op, args_schema, kwargs_schema: result
+
     def _create_expanded_strategy_impl(
         op_schema: OpSchema,
         output_tensor_meta: TensorMeta | Sequence[TensorMeta | None] | None,
@@ -505,10 +531,14 @@ def _expand_single_dim_strategy_to_mesh(
                 strategy_info, op_schema, output_tensor_meta
             )
 
-            # Detect inplace ops by checking if the base op name ends with '_'
-            op_name = op.name()
-            base_name = op_name.split("::")[1].split(".")[0]
-            is_inplace = base_name.endswith("_")
+            # Detect inplace ops by checking if the base op name ends with '_'.
+            # View ops are metadata-only so inplace variants (e.g. squeeze_)
+            # don't need the inplace placement constraint.
+            is_inplace = False
+            if not strategy_info.is_view_op:
+                op_name = op.name()
+                base_name = op_name.split("::")[1].split(".")[0]
+                is_inplace = base_name.endswith("_")
 
             element_mesh = prepared_strategy.element_mesh or mesh
 
@@ -662,6 +692,14 @@ def register_single_dim_strategy(
     allow_unbacked_sharding: bool | None = None,
     allow_uneven_sharding: bool = False,
     different_mesh_args: list[int] | None = None,
+    reject_redistribution: (
+        Callable[
+            [OpSchema, DeviceMesh, TensorMeta | Sequence[TensorMeta | None] | None],
+            OpStrategy,
+        ]
+        | None
+    ) = None,
+    is_view_op: bool = False,
 ) -> Callable[[_SingleDimStrategyFunc], _SingleDimStrategyFunc]:
     """
     Registers a single_dim_strategy function for the given op.
@@ -711,6 +749,8 @@ def register_single_dim_strategy(
             allow_unbacked_sharding=allow_unbacked_sharding,
             allow_uneven_sharding=allow_uneven_sharding,
             different_mesh_args=different_mesh_args,
+            reject_redistribution=reject_redistribution,
+            is_view_op=is_view_op,
         )
         registration_wrapper(info)
         return impl


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #179664
* #179509

Extract mesh-free structural mapping (_build_input_to_output_map) from
analyze() and add propagate_single_dim() as the entry point for
single-dim sharding strategy where each mesh dim is processed
independently with no cross-mesh-dim state.

The key insight is that constructing the propagator with
mesh_sizes=(mesh_dim_size,) makes all cross-dim interactions
(progressive local_tensor_shapes division, strided_shard_claimed_dims,
_expected_split_factor) naturally vacuous — no rewrite methods need to
change.

Authored with Claude.