### PR TITLE
[Claude Code] Fix flaky shared memory pruning test by increasing safety margin

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -936,8 +936,9 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
             + gemm_config.block_n * gemm_config.block_k
         )
 
-        # Extra bytes to account for barriers in boundary conditions
-        extra_bytes = 128
+        # Extra bytes to account for barriers, alignment padding,
+        # and other Triton compiler overhead in boundary conditions
+        extra_bytes = 1024
 
         # In persistent tma case, the layout conversion from mma -> blocked layout
         # is not free and takes additional shared memory, while next loads are prefetched


### PR DESCRIPTION
Summary:
The shared memory estimation in get_shared_memory_estimation() used only 128
extra bytes to account for Triton compiler overhead (barriers, alignment
padding, register spilling). This was too tight for borderline GEMM
configurations like GemmConfig(block_m=64, block_n=64, block_k=128,
num_stages=4, num_warps=8) with float32, causing intermittent compilation
failures where the checker predicted the config would fit but Triton's actual
usage slightly exceeded the limit.

Increased the safety margin from 128 to 1024 bytes to provide a more
conservative upper bound that accounts for non-deterministic Triton compiler
overhead.

Test Plan:
Ran the flaky test 10 consecutive times, all passed:

buck test fbcode//mode/opt fbcode//caffe2/test/inductor:max_autotune -- --exact 'fbcode//caffe2/test/inductor:max_autotune - test_shared_memory_pruning_addmm_float32_mat1_transposed_True_mat2_transposed_False_use_tma_False (caffe2.test.inductor.test_max_autotune.TestTemplateConfigPruning)'

Before fix: 94% pass rate (256 passes / 16 failures in 7-day window).
After fix: 10/10 passes in stress test.

Differential Revision: D99865028




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo