### PR TITLE
[Claude Code][dynamo] Skip dataclass __init__ frames in eval_frame hook

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -2345,12 +2345,13 @@ class CatchErrorsWrapper:
             return ConvertFrameReturn()
 
         if (
-            frame.f_code.co_filename == "<string>" and frame.f_code.co_name == "__new__"
+            frame.f_code.co_filename == "<string>"
+            and frame.f_code.co_name in ("__new__", "__init__")
         ) or (
             frame.f_code.co_filename.endswith("collections/__init__.py")
             and frame.f_code.co_name == "_make"
         ):
-            # nametuple constructor/_make
+            # namedtuple constructor/_make, dataclass __init__, etc.
             return ConvertFrameReturn()
 
         if (


### PR DESCRIPTION
Summary:
Python's dataclasses module generates __init__ methods via exec(),
giving them <string> as co_filename. When DynamoCompileOptions (a
dataclass) is instantiated while the eval_frame hook is active, the
generated __init__ frame gets intercepted and counted as an extra
compilation frame.

Extend the existing namedtuple skip check in CatchErrorsWrapper.__call__
to also skip __init__@<string> frames, matching the existing
__new__@<string> skip for namedtuples.

Fixes test_torch_dispatch_ignore_compile_internals.

Test Plan:
- Ran `test_torch_dispatch_ignore_compile_internals` — passes (previously failing with `counters["frames"]["total"]` == 2 instead of 1)
- Ran full `test_modes.py` suite — all tests pass
- `arc lint` clean

Differential Revision: D99932600




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98