### PR TITLE
[Claude Code] Update expected frames total count in test_nested_graph_break_in_try_block

### DIFF
--- a/test/dynamo/test_nested_graph_breaks.py
+++ b/test/dynamo/test_nested_graph_breaks.py
@@ -704,7 +704,7 @@ class NestedGraphBreakTests(torch._dynamo.test_case.TestCaseWithNestedGraphBreak
         self.assertEqual(cnts.frame_count, 4)
         # 5 additions from f5+f4+(first part of f3), 4 additions from f2+f1
         self.assertEqual(cnts.op_count, 9)
-        self.assertEqual(torch._dynamo.utils.counters["frames"]["total"], 4)
+        self.assertEqual(torch._dynamo.utils.counters["frames"]["total"], 5)
 
     def test_nested_step_unsupported(self):
         global f1, f2, f3


### PR DESCRIPTION
Summary:
Recent changes to how resume functions are created for nested graph breaks cause an additional frame to enter the convert_frame pipeline when a graph break occurs inside a try/finally block. The frame is quickly skipped but increments the total frames counter.

The functional behavior is unchanged: frame_count=4, op_count=9, and output correctness all pass. Only the total frames counter assertion needed updating from 4 to 5.

Differential Revision: D99928321




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98