### PR TITLE
[Claude Code] Fix flaky test by increasing shared memory estimation safety margin

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -936,8 +936,9 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
             + gemm_config.block_n * gemm_config.block_k
         )
 
-        # Extra bytes to account for barriers in boundary conditions
-        extra_bytes = 128
+        # Extra bytes to account for TMA descriptors, barriers, alignment padding,
+        # and other Triton compiler overhead in shared memory allocation
+        extra_bytes = 1024
 
         # In persistent tma case, the layout conversion from mma -> blocked layout
         # is not free and takes additional shared memory, while next loads are prefetched


### PR DESCRIPTION
Summary:
Increase extra_bytes from 128 to 1024 in get_shared_memory_estimation to account for TMA descriptors, barriers, alignment padding, and other Triton compiler overhead in shared memory allocation.

The previous 128-byte margin was insufficient for borderline configs like GemmConfig(64, 64, 128, 4, 8) with bfloat16 addmm TMA, causing the shared memory checker to predict configs would fit when actual compilation sometimes exceeded GPU shared memory limits. This resulted in a flaky assertion failure in test_shared_memory_pruning_addmm.

The test had a 93.4% pass rate (226/242 runs) with the old margin. Increasing to 1024 bytes provides sufficient headroom for the variable compiler overhead while remaining small relative to typical total data usage (~100KB+), so it won't aggressively prune valid configs.

Test Plan:
Ran the flaky test 10 times consecutively with 0 failures:

buck test fbcode//mode/opt fbcode//caffe2/test/inductor:max_autotune -- --exact 'fbcode//caffe2/test/inductor:max_autotune - test_shared_memory_pruning_addmm_bfloat16_mat1_transposed_True_mat2_transposed_False_use_tma_True (caffe2.test.inductor.test_max_autotune.TestTemplateConfigPruning)'

All 10 runs: Pass 2. Fail 0.

Differential Revision: D99930674




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo