### PR TITLE
port test/dynamo/test_deviceguard.py to Intel GPU

### DIFF
--- a/test/dynamo/test_deviceguard.py
+++ b/test/dynamo/test_deviceguard.py
@@ -7,6 +7,7 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.device_interface import CudaInterface, DeviceGuard
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU
+from torch.testing._internal.common_utils import TEST_XPU
 
 
 class TestDeviceGuard(torch._dynamo.test_case.TestCase):
@@ -46,7 +47,7 @@ class TestDeviceGuard(torch._dynamo.test_case.TestCase):
         self.assertEqual(device_guard.idx, None)
 
 
-@unittest.skipIf(not TEST_CUDA, "No CUDA available.")
+@unittest.skipIf(not TEST_CUDA and not TEST_XPU, "No CUDA and XPU available.")
 class TestCUDADeviceGuard(torch._dynamo.test_case.TestCase):
     """
     Unit tests for the DeviceGuard class using a CudaInterface.
@@ -58,26 +59,35 @@ class TestCUDADeviceGuard(torch._dynamo.test_case.TestCase):
 
     @unittest.skipIf(not TEST_MULTIGPU, "need multiple GPU")
     def test_device_guard(self):
-        current_device = torch.cuda.current_device()
+        current_device = torch.cuda.current_device() if TEST_CUDA else torch.xpu.current_device()
 
         device_guard = DeviceGuard(self.device_interface, 1)
 
         with device_guard as _:
-            self.assertEqual(torch.cuda.current_device(), 1)
+            if TEST_CUDA:
+                self.assertEqual(torch.cuda.current_device(), 1)
+            else:
+                self.assertEqual(torch.xpu.current_device(), 1)
             self.assertEqual(device_guard.prev_idx, 0)
             self.assertEqual(device_guard.idx, 1)
 
-        self.assertEqual(torch.cuda.current_device(), current_device)
+        if TEST_CUDA:
+            self.assertEqual(torch.cuda.current_device(), current_device)
+        else:
+            self.assertEqual(torch.xpu.current_device(), current_device)
         self.assertEqual(device_guard.prev_idx, 0)
         self.assertEqual(device_guard.idx, 1)
 
     def test_device_guard_no_index(self):
-        current_device = torch.cuda.current_device()
+        current_device = torch.cuda.current_device() if TEST_CUDA else torch.xpu.current_device()
 
         device_guard = DeviceGuard(self.device_interface, None)
 
         with device_guard as _:
-            self.assertEqual(torch.cuda.current_device(), current_device)
+            if TEST_CUDA:
+                self.assertEqual(torch.cuda.current_device(), current_device)
+            else:
+                self.assertEqual(torch.xpu.current_device(), current_device)
             self.assertEqual(device_guard.prev_idx, -1)
             self.assertEqual(device_guard.idx, None)
 

--- a/test/dynamo/test_deviceguard.py
+++ b/test/dynamo/test_deviceguard.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
-from torch._dynamo.device_interface import CudaInterface, DeviceGuard
+from torch._dynamo.device_interface import CudaInterface, DeviceGuard, XpuInterface
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU
 from torch.testing._internal.common_utils import TEST_XPU
 
@@ -55,7 +55,7 @@ class TestCUDADeviceGuard(torch._dynamo.test_case.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.device_interface = CudaInterface
+        self.device_interface = CudaInterface if TEST_CUDA else XpuInterface
 
     @unittest.skipIf(not TEST_MULTIGPU, "need multiple GPU")
     def test_device_guard(self):


### PR DESCRIPTION
# Pre-approved PR

Before submitting, please review:
- [The Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions#getting-started-with-pull-requests)
- [AI-Assisted Development](CONTRIBUTING.md#ai-assisted-development) policy

---

## Approved by

@<!-- Maintainer handle who agreed to this PR. -->

## Summary

Extends `test/dynamo/test_deviceguard.py` to run on Intel GPU (XPU) in addition to CUDA.

Key changes:
- **Import**: Added `XpuInterface` from `torch._dynamo.device_interface` and `TEST_XPU` from `common_utils`
- **Class skip condition**: Changed from `not TEST_CUDA` to `not TEST_CUDA and not TEST_XPU` so `TestCUDADeviceGuard` runs on XPU-only machines
- **`setUp` fix**: `self.device_interface` now selects `XpuInterface` when CUDA is unavailable (`CudaInterface if TEST_CUDA else XpuInterface`), preventing incorrect dispatch to CUDA APIs on XPU backends
- **Test methods**: Branch on `TEST_CUDA` to call the appropriate `torch.cuda` / `torch.xpu` APIs for device queries

Backend compatibility:
| Environment | Behavior |
|---|---|
| CUDA-only | Unchanged — `CudaInterface` used, all `torch.cuda` paths taken |
| XPU-only | `XpuInterface` used; multi-GPU test auto-skipped via `TEST_MULTIGPU` |
| Both | CUDA takes precedence |
| Neither | Entire class skipped |

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [ ] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.