### PR TITLE
[XPU] Enable xpu fastpath for MultiheadAttention and TransformerEncoder/Decoder

### DIFF
--- a/torch/csrc/jit/passes/autocast.cpp
+++ b/torch/csrc/jit/passes/autocast.cpp
@@ -108,7 +108,7 @@ std::optional<AutocastScope> parseAutocast(
     TORCH_CHECK(
         dtype != c10::ScalarType::Undefined,
         "Autocast has invalid fast_dtype attribute");
-    if (device == "cuda" || device == "mps") {
+    if (device == "cuda" || device == "mps" || device == "xpu") {
       scope.context.gpu_enabled = enabled.value();
       scope.context.gpu_scalar_type = dtype;
     } else if (device == "cpu") {
@@ -351,7 +351,24 @@ void handleBlock(Block* block, AutocastContext initial_state) {
         break;
 
       case aten::is_autocast_enabled:
-        updateAutocastEnabledCheck(node, current_state().gpu_enabled);
+        if (node->schema().overload_name() == "device_type") {
+          // aten::is_autocast_enabled.device_type(str device_type) -> bool
+          // The device_type argument must be a string constant.
+          auto device_str = constant_as<std::string>(node->input(0));
+          if (device_str.has_value()) {
+            bool enabled = false;
+            const auto& s = device_str.value();
+            if (s == "cuda" || s == "mps" || s == "xpu") {
+              enabled = current_state().gpu_enabled;
+            } else if (s == "cpu") {
+              enabled = current_state().cpu_enabled;
+            }
+            updateAutocastEnabledCheck(node, enabled);
+          }
+        } else {
+          // aten::is_autocast_enabled() -> bool  (deprecated, CUDA-only)
+          updateAutocastEnabledCheck(node, current_state().gpu_enabled);
+        }
         break;
 
       case aten::is_autocast_cpu_enabled:
@@ -518,9 +535,12 @@ void Autocast(const std::shared_ptr<Graph>& graph) {
   GRAPH_DUMP("\nBefore Autocast: ", graph);
   if (autocastEnabled()) {
     AutocastContext init = {
-        at::autocast::is_autocast_enabled(at::kCUDA),
+        at::autocast::is_autocast_enabled(at::kCUDA) ||
+            at::autocast::is_autocast_enabled(at::kXPU),
         at::autocast::is_autocast_enabled(at::kCPU),
-        at::autocast::get_autocast_dtype(at::kCUDA),
+        at::autocast::is_autocast_enabled(at::kCUDA)
+            ? at::autocast::get_autocast_dtype(at::kCUDA)
+            : at::autocast::get_autocast_dtype(at::kXPU),
         at::autocast::get_autocast_dtype(at::kCPU)};
     handleBlock(graph->block(), init);
   }

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -733,6 +733,22 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs{
         },
         aliasAnalysisConservative()),
     OperatorGeneratorArgs(
+        TORCH_SELECTIVE_SCHEMA(
+            "aten::is_autocast_enabled.device_type(str device_type) -> bool"),
+        [](Stack& stack) {
+#if defined BUILD_LITE_INTERPRETER || defined C10_MOBILE
+          pop(stack);
+          push(stack, false);
+#else
+          auto device_type_str = pop(stack).toStringRef();
+          at::DeviceType device_type =
+              at::Device(device_type_str).type();
+          bool enabled = at::autocast::is_autocast_enabled(device_type);
+          push(stack, enabled);
+#endif
+        },
+        aliasAnalysisConservative()),
+    OperatorGeneratorArgs(
         TORCH_SELECTIVE_SCHEMA("aten::is_autocast_cpu_enabled() -> bool"),
         [](Stack& stack) {
 #if defined BUILD_LITE_INTERPRETER || defined C10_MOBILE

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -124,9 +124,8 @@ bool isSortableListOfObjectsOrTuples(
     const IValue& v = ivalues.get(i);
     auto curr_type = v.type();
     if (*curr_type != *type) {
-      why_not << "Only values of same type can be compared. "
-              << "Found " << type->repr_str() << " and "
-              << curr_type->repr_str();
+      why_not << "Only values of same type can be compared. " << "Found "
+              << type->repr_str() << " and " << curr_type->repr_str();
       return false;
     }
   }
@@ -741,8 +740,7 @@ static const std::vector<OperatorGeneratorArgs> opGenArgs{
           push(stack, false);
 #else
           auto device_type_str = pop(stack).toStringRef();
-          at::DeviceType device_type =
-              at::Device(device_type_str).type();
+          at::DeviceType device_type = at::Device(device_type_str).type();
           bool enabled = at::autocast::is_autocast_enabled(device_type);
           push(stack, enabled);
 #endif

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1413,7 +1413,7 @@ class MultiheadAttention(Module):
             elif not all(_check_arg_device(x) for x in tensor_args):
                 why_not_fast_path = (
                     "some Tensor argument's device is neither one of "
-                    f"cpu, cuda or {torch.utils.backend_registration._privateuse1_backend_name}"
+                    f"cpu, cuda, xpu or {torch.utils.backend_registration._privateuse1_backend_name}"
                 )
             elif torch.is_grad_enabled() and any(
                 _arg_requires_grad(x) for x in tensor_args

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1058,6 +1058,7 @@ def _check_arg_device(x: torch.Tensor | None) -> bool:
         return x.device.type in [
             "cpu",
             "cuda",
+            "xpu",
             torch.utils.backend_registration._privateuse1_backend_name,
         ]
     return True
@@ -1391,7 +1392,7 @@ class MultiheadAttention(Module):
                 "supplying both src_key_padding_mask and src_mask at the same time \
                                  is not supported with NestedTensor input"
             )
-        elif torch.is_autocast_enabled():
+        elif torch.is_autocast_enabled(query.device.type):
             why_not_fast_path = "autocast is enabled"
 
         fast_path_blocked_by_tracing = False

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -487,7 +487,7 @@ class TransformerEncoder(Module):
             why_not_sparsity_fast_path = (
                 "src_key_padding_mask and mask were both supplied"
             )
-        elif torch.is_autocast_enabled():
+        elif torch.is_autocast_enabled(src.device.type):
             why_not_sparsity_fast_path = "autocast is enabled"
 
         if not why_not_sparsity_fast_path:
@@ -862,7 +862,7 @@ class TransformerEncoderLayer(Module):
             why_not_sparsity_fast_path = "neither src_key_padding_mask nor src_mask are not supported with NestedTensor input"
         elif self.self_attn.num_heads % 2 == 1:
             why_not_sparsity_fast_path = "num_head is odd"
-        elif torch.is_autocast_enabled():
+        elif torch.is_autocast_enabled(src.device.type):
             why_not_sparsity_fast_path = "autocast is enabled"
         elif any(
             len(getattr(m, "_forward_hooks", {}))


### PR DESCRIPTION
This PR aims to fix several UTs in test_transformers.py to upstream xpu UTs

TestTransformersXPU,test_disable_fastpath_xpu  => fix by register XPU in supported device list.
TestTransformersXPU,test_transformerencoder_fastpath => fix by using device in `torch.is_autocast_enabled()`

The UTs also has jit path and `torch.is_autocast_enabled()` doesn't register the function with device parameter in jit yet so that this PR also register jit for `torch.is_autocast_enabled()` 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @mcarilli @ptrblck @leslie-fang-intel