### PR TITLE
[torch][inductor] Add dump_python_module config for AOT single-pass mode (#179702)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -317,6 +317,31 @@ class AOTInductorTestsTemplate:
             )
             FileCheck().check("&kernels_.loaded_modules_").run(code)
 
+    @config.patch(
+        {
+            "triton.autotune_at_compile_time": True,
+            "dump_python_module": True,
+            "benchmark_kernel": True,
+        }
+    )
+    def test_dump_python_module(self):
+        if self.device != GPU_TYPE or self.device == "mps":
+            raise unittest.SkipTest("requires GPU")
+
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(10, 10)
+
+            def forward(self, x, y):
+                return x + self.linear(y)
+
+        example_inputs = (
+            torch.randn(10, 10, device=self.device),
+            torch.randn(10, 10, device=self.device),
+        )
+        self.check_model(Model(), example_inputs)
+
     def test_triton_kernel_bool_param(self):
         if self.device != GPU_TYPE or self.device == "mps":
             raise unittest.SkipTest("requires GPU")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6505,6 +6505,42 @@ class AOTInductorTestsTemplate:
                 dynamic_shapes=dynamic_shapes,
             )
 
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_kernel_profile_scatter_fallback(self):
+        # Scatter fallback kernels use a separate codegen path
+        # (_generate_scatter_fallback) that must also be wrapped in
+        # KernelContextGuard and RAIIAtenRecordFunctionHandle profiling
+        # blocks when profiling is enabled.  RAIIAtenRecordFunctionHandle
+        # is what actually creates the RecordFunction / External id linkage.
+        class Model(torch.nn.Module):
+            def forward(self, inp, index, src):
+                return torch.scatter(inp, 1, index, src)
+
+        example_inputs = (
+            torch.ones((3, 5), device=self.device, dtype=torch.int64),
+            torch.tensor([[0, 1, 2, 0]], device=self.device, dtype=torch.int64),
+            torch.zeros((2, 5), device=self.device, dtype=torch.int64),
+        )
+
+        with config.patch(
+            {
+                "cpp.enable_kernel_profile": True,
+                "cpp.enable_kernel_context_guard": True,
+            }
+        ):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            FileCheck().check("KernelContextGuard").run(code)
+            # RAIIAtenRecordFunctionHandle creates the RecordFunction that
+            # produces the External id linkage in GPU traces.
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            self.check_model(Model(), example_inputs)
+
     def test_aoti_user_defined_triton_kernel_profiling(self):
         if self.device != GPU_TYPE or self.device == "mps":
             raise unittest.SkipTest("requires GPU")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6524,6 +6524,43 @@ class AOTInductorTestsTemplate:
                 dynamic_shapes=dynamic_shapes,
             )
 
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_kernel_profile_combo_kernel_numel(self):
+        # Combo kernels (multiple independent pointwise ops fused together)
+        # are NOT wrapped in {} profiling scope blocks, unlike regular kernels.
+        # Their numel variables are declared at function scope. With profiling
+        # enabled, the codegen must not re-emit int64_t declarations for the
+        # same numel variable at function scope, which would cause a
+        # "redefinition" C++ compilation error.
+        if self.device != GPU_TYPE:
+            raise unittest.SkipTest("combo kernels require GPU")
+
+        class Model(torch.nn.Module):
+            def forward(self, a, b):
+                # Two independent pointwise ops on same-shaped tensors
+                # triggers combo kernel fusion
+                return a.sin(), b.cos()
+
+        example_inputs = (
+            torch.randn(4, 8, device=self.device),
+            torch.randn(4, 8, device=self.device),
+        )
+        dim0 = Dim("dim0", min=1, max=32)
+        dynamic_shapes = {"a": {0: dim0}, "b": {0: dim0}}
+
+        with config.patch({"cpp.enable_kernel_profile": True, "combo_kernels": True}):
+            # This compilation would fail with "redefinition of
+            # '..._xnumel'" if numel declarations at function scope
+            # were not properly deduplicated.
+            self.check_model(
+                Model(),
+                example_inputs,
+                dynamic_shapes=dynamic_shapes,
+            )
+
     def test_aoti_user_defined_triton_kernel_profiling(self):
         if self.device != GPU_TYPE or self.device == "mps":
             raise unittest.SkipTest("requires GPU")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6468,6 +6468,43 @@ class AOTInductorTestsTemplate:
                 dynamic_shapes=dynamic_shapes,
             )
 
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_kernel_profile_combo_kernel_numel(self):
+        # Combo kernels (multiple independent pointwise ops fused together)
+        # are NOT wrapped in {} profiling scope blocks, unlike regular kernels.
+        # Their numel variables are declared at function scope. With profiling
+        # enabled, the codegen must not re-emit int64_t declarations for the
+        # same numel variable at function scope, which would cause a
+        # "redefinition" C++ compilation error.
+        if self.device != GPU_TYPE:
+            raise unittest.SkipTest("combo kernels require GPU")
+
+        class Model(torch.nn.Module):
+            def forward(self, a, b):
+                # Two independent pointwise ops on same-shaped tensors
+                # triggers combo kernel fusion
+                return a.sin(), b.cos()
+
+        example_inputs = (
+            torch.randn(4, 8, device=self.device),
+            torch.randn(4, 8, device=self.device),
+        )
+        dim0 = Dim("dim0", min=1, max=32)
+        dynamic_shapes = {"a": {0: dim0}, "b": {0: dim0}}
+
+        with config.patch({"cpp.enable_kernel_profile": True, "combo_kernels": True}):
+            # This compilation would fail with "redefinition of
+            # '..._xnumel'" if numel declarations at function scope
+            # were not properly deduplicated.
+            self.check_model(
+                Model(),
+                example_inputs,
+                dynamic_shapes=dynamic_shapes,
+            )
+
     def test_aoti_user_defined_triton_kernel_profiling(self):
         if self.device != GPU_TYPE or self.device == "mps":
             raise unittest.SkipTest("requires GPU")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6309,6 +6309,176 @@ class AOTInductorTestsTemplate:
             self.check_model(Model(N, K, self.device), example_inputs)
 
     @unittest.skipIf(
+        config.triton.native_matmul, "different kernel name when native matmul"
+    )
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_input_shapes(self):
+        # Verify that kernel profiling records tensor input shapes,
+        # scalar args, output handles, and ReinterpretView logical shapes.
+        class Model(torch.nn.Module):
+            def __init__(self, n, k, device):
+                super().__init__()
+                self.weight = torch.randn(n, k, device=device)
+                self.bias = torch.randn(n, device=device)
+
+            def forward(self, a):
+                # addmm: exercises scalar args (alpha, beta) and output handle
+                out = torch.nn.functional.linear(a, self.weight, self.bias)
+                # mm with transposed view: exercises ReinterpretView input path
+                return torch.mm(out.t(), a)
+
+        M = 8
+        N = 6
+        K = 16
+        model = Model(N, K, self.device)
+        a = torch.randn(M, K, device=self.device)
+        example_inputs = (a,)
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Verify that tensor inputs are converted to IValues for
+            # shape recording (3-arg RAIIAtenRecordFunctionHandle form).
+            FileCheck().check("aoti_torch_tensor_to_ivalue").run(code)
+            # Verify dummy scalar IValues are generated for non-tensor args.
+            FileCheck().check("aoti_torch_int64_to_ivalue").run(code)
+            FileCheck().check("std::vector<C10IValueHandle>").run(code)
+            # Verify output tensor is included in IValues for out-variant
+            # kernels.
+            FileCheck().check_regex(r"tmp_.*_output\b").run(code)
+            # Verify ReinterpretView inputs use reinterpret_tensor_wrapper
+            # for correct logical shapes in profiling.
+            FileCheck().check("reinterpret_tensor_wrapper").run(code)
+
+            self.check_model(Model(N, K, self.device), example_inputs)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_conv_input_shapes(self):
+        # Convolution is a single-output ExternKernelAlloc, so it flows through
+        # the alloc codegen path; verify its tensor inputs are recorded with
+        # shapes when profiling is enabled (3-arg RAIIAtenRecordFunctionHandle
+        # with an IValue vector).
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 6, kernel_size=3, padding=1).to(device)
+
+            def forward(self, x):
+                return self.conv(x)
+
+        model = Model(self.device)
+        x = torch.randn(2, 3, 16, 16, device=self.device)
+        example_inputs = (x,)
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Conv tensor inputs are converted to IValues for shape recording,
+            # collected into a vector, and passed to the record function.
+            FileCheck().check("aoti_torch_tensor_to_ivalue").run(code)
+            FileCheck().check("std::vector<C10IValueHandle>").run(code)
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            # Conv on CUDA uses TF32, which differs from the fp32 reference by
+            # ~1e-3; the profiling assertions above are this test's focus.
+            self.check_model(Model(self.device), example_inputs, atol=1e-2, rtol=1e-2)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_multi_output_fallback_input_shapes(self):
+        # A tuple-returning fallback (scaled_dot_product_attention) is the
+        # representative kernel reaching generate_c_shim_fallback_kernel;
+        # zero-output and dict-returning fallbacks route there too. Its q/k/v
+        # are transposed views, so this pins down that the recorded shapes are
+        # the logical view shapes and not the base buffers.
+        #
+        # A fused backend is required: without one SDPA decomposes to math and
+        # emits no extern shim. CPU always has one; XPU has no fp32 fused path.
+        if self.device == "xpu":
+            raise unittest.SkipTest("XPU has no fused fp32 SDPA backend")
+        if self.device != "cpu" and not (
+            PLATFORM_SUPPORTS_FLASH_ATTENTION or PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
+        ):
+            raise unittest.SkipTest("Some archs don't support fused SDPA")
+        class Model(torch.nn.Module):
+            def forward(self, q, k, v):
+                # transpose() makes each operand a ReinterpretView whose logical
+                # shape differs from its base buffer.
+                return torch.nn.functional.scaled_dot_product_attention(
+                    q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+                )
+
+        example_inputs = tuple(
+            torch.randn(4, 8, 2, 16, device=self.device) for _ in range(3)
+        )
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            # The handle must be the reinterpret expression, not a bare buffer
+            # name: a base-buffer handle would record the wrong shape while
+            # still looking populated to a trace consumer. The IValue variable
+            # carries the shim name, so match it in the same line to pin the
+            # assertion to this kernel rather than any transposed GEMM.
+            FileCheck().check_regex(
+                r"aoti_torch_tensor_to_ivalue\(wrap_with_raii_handle_if_needed\("
+                r"reinterpret_tensor_wrapper.*"
+                r"tmp_aoti_torch_\w*scaled_dot_product\w*_input_0\)"
+            ).run(code)
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            self.check_model(Model(), example_inputs)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_tensor_list_input_shapes(self):
+        # A tensor-list fallback collapses its whole list into a single codegen
+        # arg, so the profiling handles for its ReinterpretView inputs have no
+        # positional correspondence with the kernel's args.
+        if self.device != "cpu":
+            raise unittest.SkipTest("aten.cat only falls back to ATen for cpu uint8")
+
+        class Model(torch.nn.Module):
+            def forward(self, a, b, c, d):
+                # Slicing makes every list element a ReinterpretView, and four
+                # elements outnumber the kernel's args.
+                return torch.cat([a[:, :2], b[:, :2], c[:, :2], d[:, :2]], dim=1)
+
+        example_inputs = tuple(
+            torch.randint(0, 255, (4, 8), dtype=torch.uint8, device=self.device)
+            for _ in range(4)
+        )
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            FileCheck().check("aoti_torch_cpu_cat").run(code)
+            # A handle for the fourth input proves the handles are derived per
+            # input: the kernel's args collapse the whole list into a single
+            # entry, so a positional args lookup cannot reach index 3.
+            FileCheck().check("tmp_aoti_torch_cpu_cat_input_3").run(code)
+            # The IValue variable name is built from the loop index alone, so
+            # pin the handle expression too: the slices must be recorded as
+            # reinterpret views rather than their base buffers.
+            FileCheck().check(
+                "aoti_torch_tensor_to_ivalue(wrap_with_raii_handle_if_needed("
+                "reinterpret_tensor_wrapper"
+            ).run(code)
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            self.check_model(Model(), example_inputs)
+
+    @unittest.skipIf(
         sys.platform not in ["linux", "win32"],
         "enable_kernel_profile only supported on linux and win32",
     )

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -32,6 +32,7 @@ from torch._inductor.package import package_aoti
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import (
+    get_code,
     is_big_gpu,
     maybe_aoti_standalone_config,
     run_and_get_cpp_code,
@@ -6308,6 +6309,52 @@ class AOTInductorTestsTemplate:
 
             self.check_model(Model(N, K, self.device), example_inputs)
 
+    @common_utils.parametrize("enable_kernel_profile", (True, False))
+    def test_aoti_profiler_proxy_executor(self, enable_kernel_profile):
+        """Test RAIIAtenRecordFunctionHandle profiling for AOT ProxyExecutor path.
+
+        Custom ops are not in the c-shim so they go through FallbackKernel ->
+        proxy_executor in AOT mode. This verifies profiling is emitted around
+        aoti_torch_proxy_executor_call_function.
+        """
+
+        if sys.platform not in ["linux", "win32"]:
+            raise unittest.SkipTest(
+                "enable_kernel_profile only supported on linux and win32"
+            )
+
+        with torch.library._scoped_library("proftest", "FRAGMENT") as lib:
+            torch.library.define(
+                "proftest::add_one",
+                "(Tensor a) -> Tensor",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            @torch.library.impl(
+                "proftest::add_one", "CompositeExplicitAutograd", lib=lib
+            )
+            @torch.library.register_fake("proftest::add_one", lib=lib)
+            def add_one_impl(a: torch.Tensor) -> torch.Tensor:
+                return a + 1
+
+            class Model(torch.nn.Module):
+                def forward(self, x):
+                    return torch.ops.proftest.add_one(x)
+
+            example_inputs = (torch.randn(4, 4, device=self.device),)
+            with config.patch({"cpp.enable_kernel_profile": enable_kernel_profile}):
+                _, code = run_and_get_cpp_code(
+                    AOTIRunnerUtil.compile, Model(), example_inputs
+                )
+                FileCheck().check("aoti_torch_proxy_executor_call_function").run(code)
+                if enable_kernel_profile:
+                    FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+                else:
+                    FileCheck().check_not("RAIIAtenRecordFunctionHandle").run(code)
+
+                self.check_model(Model(), example_inputs)
+
     @unittest.skipIf(
         config.triton.native_matmul, "different kernel name when native matmul"
     )
@@ -9863,6 +9910,165 @@ class TestCheckLowerboundConfig(TestCase):
                 0,
                 exactly=True,
             ).run(code)
+
+
+class TestCppWrapperFallbackProfiling(TestCase):
+    """Test RAIIAtenRecordFunctionHandle profiling for non-AOT cpp_wrapper fallback paths.
+
+    These paths are only triggered in cpp_wrapper mode WITHOUT AOT (i.e., torch.compile
+    with config.cpp_wrapper=True), so they cannot be tested via AOTIRunnerUtil.compile.
+    Uses get_code to generate code without compiling/running (avoids ASAN issues).
+    """
+
+    device = "cpu"
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    @common_utils.parametrize("enable_kernel_profile", (True, False))
+    def test_aoti_profiler_nopython_dispatcher(self, enable_kernel_profile):
+        """Test profiling for non-AOT nopython dispatcher path.
+
+        Custom ops with simple types (Tensor -> Tensor) go through
+        aoti_torch_call_dispatcher in non-AOT cpp_wrapper mode because they
+        are StableIValue-compatible and not in the c-shim.
+        """
+        with torch.library._scoped_library("proftest", "FRAGMENT") as lib:
+            torch.library.define(
+                "proftest::nopython_add",
+                "(Tensor a) -> Tensor",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            @torch.library.impl(
+                "proftest::nopython_add", "CompositeExplicitAutograd", lib=lib
+            )
+            @torch.library.register_fake("proftest::nopython_add", lib=lib)
+            def nopython_add_impl(a: torch.Tensor) -> torch.Tensor:
+                return a + 1
+
+            class Model(torch.nn.Module):
+                def forward(self, x):
+                    return torch.ops.proftest.nopython_add(x)
+
+            example_inputs = (torch.randn(4, 4),)
+            with config.patch(
+                {
+                    "cpp_wrapper": True,
+                    "cpp.enable_kernel_profile": enable_kernel_profile,
+                }
+            ):
+                compiled = torch.compile(Model())
+                codes = get_code(compiled, *example_inputs)
+                code = codes[0]
+                FileCheck().check("aoti_torch_call_dispatcher").run(code)
+                if enable_kernel_profile:
+                    FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+                else:
+                    FileCheck().check_not("RAIIAtenRecordFunctionHandle").run(code)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    @common_utils.parametrize("enable_kernel_profile", (True, False))
+    def test_aoti_profiler_python_fallback(self, enable_kernel_profile):
+        """Test profiling for non-AOT Python fallback path.
+
+        Custom ops whose return type is not boxed-dispatch compatible (only
+        Tensor, Tensor? and () are) go through PyObject_CallObject in non-AOT
+        cpp_wrapper mode. A Tensor[] return is the cheapest such schema; a
+        Tensor[] argument is boxed-compatible and would not reach this path.
+        """
+        with torch.library._scoped_library("proftest", "FRAGMENT") as lib:
+            torch.library.define(
+                "proftest::python_cat",
+                "(Tensor[] tensors, int dim=0) -> Tensor[]",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            # CompositeExplicitAutograd also covers Meta, so it supplies the
+            # shape propagation that tracing needs. A separate Python fake impl
+            # would additionally require a C++ m.set_python_module companion.
+            @torch.library.impl(
+                "proftest::python_cat", "CompositeExplicitAutograd", lib=lib
+            )
+            def python_cat_impl(
+                tensors: list[torch.Tensor], dim: int = 0
+            ) -> list[torch.Tensor]:
+                return [torch.cat(tensors, dim=dim)]
+
+            class Model(torch.nn.Module):
+                def forward(self, x, y):
+                    return torch.ops.proftest.python_cat([x, y])[0]
+
+            example_inputs = (torch.randn(4, 4), torch.randn(4, 4))
+            with config.patch(
+                {
+                    "cpp_wrapper": True,
+                    "cpp.enable_kernel_profile": enable_kernel_profile,
+                }
+            ):
+                compiled = torch.compile(Model())
+                codes = get_code(compiled, *example_inputs)
+                code = codes[0]
+                FileCheck().check("PyObject_CallObject").run(code)
+                if enable_kernel_profile:
+                    FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+                else:
+                    FileCheck().check_not("RAIIAtenRecordFunctionHandle").run(code)
+
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    @common_utils.parametrize("enable_kernel_profile", (True, False))
+    def test_aoti_profiler_gpu_non_triton(self, enable_kernel_profile):
+        """Test profiling for GPU non-Triton kernel call path (CUTLASS/ROCm templates).
+
+        Non-Triton GPU kernels use kernels.{name}() direct calls. This path requires
+        max_autotune with CUTLASS backend availability (SM80+).
+        """
+        if not SM80OrLater:
+            raise unittest.SkipTest("CUTLASS requires SM80+")
+        from torch._inductor.codegen.cutlass.utils import try_import_cutlass
+
+        if not try_import_cutlass():
+            raise unittest.SkipTest("CUTLASS lib not available")
+
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.weight = torch.randn(64, 64, device=device, dtype=torch.float16)
+
+            def forward(self, x):
+                return torch.nn.functional.linear(x, self.weight)
+
+        model = Model(GPU_TYPE)
+        example_inputs = (torch.randn(2, 64, device=GPU_TYPE, dtype=torch.float16),)
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "CUTLASS",
+                "cpp.enable_kernel_profile": enable_kernel_profile,
+            }
+        ):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Non-Triton kernels use direct kernels.{name}() calls
+            if "kernels." in code:
+                if enable_kernel_profile:
+                    FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+                else:
+                    FileCheck().check_not("RAIIAtenRecordFunctionHandle").run(code)
+
+
+common_utils.instantiate_parametrized_tests(TestCppWrapperFallbackProfiling)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6561,6 +6561,42 @@ class AOTInductorTestsTemplate:
                 dynamic_shapes=dynamic_shapes,
             )
 
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_kernel_profile_scatter_fallback(self):
+        # Scatter fallback kernels use a separate codegen path
+        # (_generate_scatter_fallback) that must also be wrapped in
+        # KernelContextGuard and RAIIAtenRecordFunctionHandle profiling
+        # blocks when profiling is enabled.  RAIIAtenRecordFunctionHandle
+        # is what actually creates the RecordFunction / External id linkage.
+        class Model(torch.nn.Module):
+            def forward(self, inp, index, src):
+                return torch.scatter(inp, 1, index, src)
+
+        example_inputs = (
+            torch.ones((3, 5), device=self.device, dtype=torch.int64),
+            torch.tensor([[0, 1, 2, 0]], device=self.device, dtype=torch.int64),
+            torch.zeros((2, 5), device=self.device, dtype=torch.int64),
+        )
+
+        with config.patch(
+            {
+                "cpp.enable_kernel_profile": True,
+                "cpp.enable_kernel_context_guard": True,
+            }
+        ):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            FileCheck().check("KernelContextGuard").run(code)
+            # RAIIAtenRecordFunctionHandle creates the RecordFunction that
+            # produces the External id linkage in GPU traces.
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            self.check_model(Model(), example_inputs)
+
     def test_aoti_user_defined_triton_kernel_profiling(self):
         if self.device != GPU_TYPE or self.device == "mps":
             raise unittest.SkipTest("requires GPU")

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6309,6 +6309,120 @@ class AOTInductorTestsTemplate:
             self.check_model(Model(N, K, self.device), example_inputs)
 
     @unittest.skipIf(
+        config.triton.native_matmul, "different kernel name when native matmul"
+    )
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_input_shapes(self):
+        # Verify that kernel profiling records tensor input shapes,
+        # scalar args, output handles, and ReinterpretView logical shapes.
+        class Model(torch.nn.Module):
+            def __init__(self, n, k, device):
+                super().__init__()
+                self.weight = torch.randn(n, k, device=device)
+                self.bias = torch.randn(n, device=device)
+
+            def forward(self, a):
+                # addmm: exercises scalar args (alpha, beta) and output handle
+                out = torch.nn.functional.linear(a, self.weight, self.bias)
+                # mm with transposed view: exercises ReinterpretView input path
+                return torch.mm(out.t(), a)
+
+        M = 8
+        N = 6
+        K = 16
+        model = Model(N, K, self.device)
+        a = torch.randn(M, K, device=self.device)
+        example_inputs = (a,)
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Verify that tensor inputs are converted to IValues for
+            # shape recording (3-arg RAIIAtenRecordFunctionHandle form).
+            FileCheck().check("aoti_torch_tensor_to_ivalue").run(code)
+            # Verify dummy scalar IValues are generated for non-tensor args.
+            FileCheck().check("aoti_torch_int64_to_ivalue").run(code)
+            FileCheck().check("std::vector<C10IValueHandle>").run(code)
+            # Verify output tensor is included in IValues for out-variant
+            # kernels.
+            FileCheck().check_regex(r"tmp_.*_output\b").run(code)
+            # Verify ReinterpretView inputs use reinterpret_tensor_wrapper
+            # for correct logical shapes in profiling.
+            FileCheck().check("reinterpret_tensor_wrapper").run(code)
+
+            self.check_model(Model(N, K, self.device), example_inputs)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_conv_input_shapes(self):
+        # Convolution flows through the extern/fallback kernel codegen path;
+        # verify its tensor inputs are recorded with shapes when profiling is
+        # enabled (3-arg RAIIAtenRecordFunctionHandle with an IValue vector).
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 6, kernel_size=3, padding=1).to(device)
+
+            def forward(self, x):
+                return self.conv(x)
+
+        model = Model(self.device)
+        x = torch.randn(2, 3, 16, 16, device=self.device)
+        example_inputs = (x,)
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Conv tensor inputs are converted to IValues for shape recording,
+            # collected into a vector, and passed to the record function.
+            FileCheck().check("aoti_torch_tensor_to_ivalue").run(code)
+            FileCheck().check("std::vector<C10IValueHandle>").run(code)
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            # Conv on CUDA uses TF32, which differs from the fp32 reference by
+            # ~1e-3; the profiling assertions above are this test's focus.
+            self.check_model(Model(self.device), example_inputs, atol=1e-2, rtol=1e-2)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    def test_aoti_profiler_tensor_list_input_shapes(self):
+        # A tensor-list fallback collapses its whole list into a single codegen
+        # arg, so the profiling handles for its ReinterpretView inputs have no
+        # positional correspondence with the kernel's args.
+        if self.device != "cpu":
+            raise unittest.SkipTest("aten.cat only falls back to ATen for cpu uint8")
+
+        class Model(torch.nn.Module):
+            def forward(self, a, b, c, d):
+                # Slicing makes every list element a ReinterpretView, and four
+                # elements outnumber the kernel's args.
+                return torch.cat([a[:, :2], b[:, :2], c[:, :2], d[:, :2]], dim=1)
+
+        example_inputs = tuple(
+            torch.randint(0, 255, (4, 8), dtype=torch.uint8, device=self.device)
+            for _ in range(4)
+        )
+        with config.patch({"cpp.enable_kernel_profile": True}):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, Model(), example_inputs
+            )
+            FileCheck().check("aoti_torch_cpu_cat").run(code)
+            # A handle for the fourth input proves the handles are derived per
+            # input: the kernel's args collapse the whole list into a single
+            # entry, so a positional args lookup cannot reach index 3.
+            FileCheck().check("tmp_aoti_torch_cpu_cat_input_3").run(code)
+            FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+
+            self.check_model(Model(), example_inputs)
+
+    @unittest.skipIf(
         sys.platform not in ["linux", "win32"],
         "enable_kernel_profile only supported on linux and win32",
     )

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -32,6 +32,7 @@ from torch._inductor.package import package_aoti
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import (
+    get_code,
     is_big_gpu,
     maybe_aoti_standalone_config,
     run_and_get_cpp_code,
@@ -6308,6 +6309,52 @@ class AOTInductorTestsTemplate:
 
             self.check_model(Model(N, K, self.device), example_inputs)
 
+    @common_utils.parametrize("enable_kernel_profile", (True, False))
+    def test_aoti_profiler_proxy_executor(self, enable_kernel_profile):
+        """Test RAIIAtenRecordFunctionHandle profiling for AOT ProxyExecutor path.
+
+        Custom ops are not in the c-shim so they go through FallbackKernel ->
+        proxy_executor in AOT mode. This verifies profiling is emitted around
+        aoti_torch_proxy_executor_call_function.
+        """
+
+        if sys.platform not in ["linux", "win32"]:
+            raise unittest.SkipTest(
+                "enable_kernel_profile only supported on linux and win32"
+            )
+
+        with torch.library._scoped_library("proftest", "FRAGMENT") as lib:
+            torch.library.define(
+                "proftest::add_one",
+                "(Tensor a) -> Tensor",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            @torch.library.impl(
+                "proftest::add_one", "CompositeExplicitAutograd", lib=lib
+            )
+            @torch.library.register_fake("proftest::add_one", lib=lib)
+            def add_one_impl(a: torch.Tensor) -> torch.Tensor:
+                return a + 1
+
+            class Model(torch.nn.Module):
+                def forward(self, x):
+                    return torch.ops.proftest.add_one(x)
+
+            example_inputs = (torch.randn(4, 4, device=self.device),)
+            with config.patch({"cpp.enable_kernel_profile": enable_kernel_profile}):
+                _, code = run_and_get_cpp_code(
+                    AOTIRunnerUtil.compile, Model(), example_inputs
+                )
+                FileCheck().check("aoti_torch_proxy_executor_call_function").run(code)
+                if enable_kernel_profile:
+                    FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+                else:
+                    FileCheck().check_not("RAIIAtenRecordFunctionHandle").run(code)
+
+                self.check_model(Model(), example_inputs)
+
     @unittest.skipIf(
         config.triton.native_matmul, "different kernel name when native matmul"
     )
@@ -9807,6 +9854,165 @@ class TestCheckLowerboundConfig(TestCase):
                 0,
                 exactly=True,
             ).run(code)
+
+
+class TestCppWrapperFallbackProfiling(TestCase):
+    """Test RAIIAtenRecordFunctionHandle profiling for non-AOT cpp_wrapper fallback paths.
+
+    These paths are only triggered in cpp_wrapper mode WITHOUT AOT (i.e., torch.compile
+    with config.cpp_wrapper=True), so they cannot be tested via AOTIRunnerUtil.compile.
+    Uses get_code to generate code without compiling/running (avoids ASAN issues).
+    """
+
+    device = "cpu"
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    @common_utils.parametrize("enable_kernel_profile", (True, False))
+    def test_aoti_profiler_nopython_dispatcher(self, enable_kernel_profile):
+        """Test profiling for non-AOT nopython dispatcher path.
+
+        Custom ops with simple types (Tensor -> Tensor) go through
+        aoti_torch_call_dispatcher in non-AOT cpp_wrapper mode because they
+        are StableIValue-compatible and not in the c-shim.
+        """
+        with torch.library._scoped_library("proftest", "FRAGMENT") as lib:
+            torch.library.define(
+                "proftest::nopython_add",
+                "(Tensor a) -> Tensor",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            @torch.library.impl(
+                "proftest::nopython_add", "CompositeExplicitAutograd", lib=lib
+            )
+            @torch.library.register_fake("proftest::nopython_add", lib=lib)
+            def nopython_add_impl(a: torch.Tensor) -> torch.Tensor:
+                return a + 1
+
+            class Model(torch.nn.Module):
+                def forward(self, x):
+                    return torch.ops.proftest.nopython_add(x)
+
+            example_inputs = (torch.randn(4, 4),)
+            with config.patch(
+                {
+                    "cpp_wrapper": True,
+                    "cpp.enable_kernel_profile": enable_kernel_profile,
+                }
+            ):
+                compiled = torch.compile(Model())
+                codes = get_code(compiled, *example_inputs)
+                code = codes[0]
+                FileCheck().check("aoti_torch_call_dispatcher").run(code)
+                if enable_kernel_profile:
+                    FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+                else:
+                    FileCheck().check_not("RAIIAtenRecordFunctionHandle").run(code)
+
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    @common_utils.parametrize("enable_kernel_profile", (True, False))
+    def test_aoti_profiler_python_fallback(self, enable_kernel_profile):
+        """Test profiling for non-AOT Python fallback path.
+
+        Custom ops whose return type is not boxed-dispatch compatible (only
+        Tensor, Tensor? and () are) go through PyObject_CallObject in non-AOT
+        cpp_wrapper mode. A Tensor[] return is the cheapest such schema; a
+        Tensor[] argument is boxed-compatible and would not reach this path.
+        """
+        with torch.library._scoped_library("proftest", "FRAGMENT") as lib:
+            torch.library.define(
+                "proftest::python_cat",
+                "(Tensor[] tensors, int dim=0) -> Tensor[]",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            # CompositeExplicitAutograd also covers Meta, so it supplies the
+            # shape propagation that tracing needs. A separate Python fake impl
+            # would additionally require a C++ m.set_python_module companion.
+            @torch.library.impl(
+                "proftest::python_cat", "CompositeExplicitAutograd", lib=lib
+            )
+            def python_cat_impl(
+                tensors: list[torch.Tensor], dim: int = 0
+            ) -> list[torch.Tensor]:
+                return [torch.cat(tensors, dim=dim)]
+
+            class Model(torch.nn.Module):
+                def forward(self, x, y):
+                    return torch.ops.proftest.python_cat([x, y])[0]
+
+            example_inputs = (torch.randn(4, 4), torch.randn(4, 4))
+            with config.patch(
+                {
+                    "cpp_wrapper": True,
+                    "cpp.enable_kernel_profile": enable_kernel_profile,
+                }
+            ):
+                compiled = torch.compile(Model())
+                codes = get_code(compiled, *example_inputs)
+                code = codes[0]
+                FileCheck().check("PyObject_CallObject").run(code)
+                if enable_kernel_profile:
+                    FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+                else:
+                    FileCheck().check_not("RAIIAtenRecordFunctionHandle").run(code)
+
+    @unittest.skipIf(not HAS_GPU, "requires GPU")
+    @unittest.skipIf(
+        sys.platform not in ["linux", "win32"],
+        "enable_kernel_profile only supported on linux and win32",
+    )
+    @common_utils.parametrize("enable_kernel_profile", (True, False))
+    def test_aoti_profiler_gpu_non_triton(self, enable_kernel_profile):
+        """Test profiling for GPU non-Triton kernel call path (CUTLASS/ROCm templates).
+
+        Non-Triton GPU kernels use kernels.{name}() direct calls. This path requires
+        max_autotune with CUTLASS backend availability (SM80+).
+        """
+        if not SM80OrLater:
+            raise unittest.SkipTest("CUTLASS requires SM80+")
+        from torch._inductor.codegen.cutlass.utils import try_import_cutlass
+
+        if not try_import_cutlass():
+            raise unittest.SkipTest("CUTLASS lib not available")
+
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.weight = torch.randn(64, 64, device=device, dtype=torch.float16)
+
+            def forward(self, x):
+                return torch.nn.functional.linear(x, self.weight)
+
+        model = Model(GPU_TYPE)
+        example_inputs = (torch.randn(2, 64, device=GPU_TYPE, dtype=torch.float16),)
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "CUTLASS",
+                "cpp.enable_kernel_profile": enable_kernel_profile,
+            }
+        ):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            # Non-Triton kernels use direct kernels.{name}() calls
+            if "kernels." in code:
+                if enable_kernel_profile:
+                    FileCheck().check("RAIIAtenRecordFunctionHandle").run(code)
+                else:
+                    FileCheck().check_not("RAIIAtenRecordFunctionHandle").run(code)
+
+
+common_utils.instantiate_parametrized_tests(TestCppWrapperFallbackProfiling)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -208,6 +208,12 @@ CPU_TEST_FAILURES = {
     "test_duplicate_constant_folding": fail_stack_allocation(is_skip=True),
     "test_aot_inductor_consts_cpp_build": fail_stack_allocation(is_skip=True),
     "test_stride_with_unbacked_expr": fail_minimal_arrayref_interface(is_skip=True),
+    # TODO: error: no member named 'get' in 'ArrayRefTensor<T>' -- a TensorList
+    # fallback renders its elements as `<elem>.get()`, which graph inputs do not
+    # provide under the minimal arrayref interface.
+    "test_aoti_profiler_tensor_list_input_shapes": fail_minimal_arrayref_interface(
+        is_skip=True
+    ),
     # TODO: use of deleted function RAIIAtenTensorHandle
     "test_dup_unbacked_sym_decl": fail_minimal_arrayref_interface(is_skip=True),
     # TODO: use of deleted function RAIIAtenTensorHandle

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2305,17 +2305,17 @@ class CppWrapperCpu(PythonWrapperCodegen):
             self.writeline(f"int64_t {sym} = {cexpr(expr)};")
 
     def _generate_symbolic_call_arg_helper(
-        self, arg: SymbolicCallArg, graph: GraphLowering
+        self, arg: SymbolicCallArg, graph: GraphLowering, in_profile_scope: bool = False
     ) -> None:
-        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
-            "linux",
-            "win32",
-        ]
-        if enable_kernel_profile or (arg.inner, graph) not in self.kernel_numel_expr:
-            # When enable_kernel_profile is on, each kernel call is wrapped in
-            # its own {} scope block, so we must redeclare the variable each
-            # time since prior declarations are no longer visible.
-            self.kernel_numel_expr.add((arg.inner, graph))
+        if in_profile_scope or (arg.inner, graph) not in self.kernel_numel_expr:
+            # When inside a kernel profile {} scope block, we must always
+            # redeclare since prior declarations from other scope blocks are
+            # not visible. We intentionally skip adding to kernel_numel_expr
+            # in that case because the block-scoped declaration won't be
+            # visible at function scope either. At function scope, we declare
+            # on first use and assign thereafter.
+            if not in_profile_scope:
+                self.kernel_numel_expr.add((arg.inner, graph))
             self.writeline(f"int64_t {arg.inner} = {cexpr(arg.inner_expr)};")
         else:
             self.writeline(f"{arg.inner} = {cexpr(arg.inner_expr)};")
@@ -4426,12 +4426,18 @@ if (!custom_op_wrapper) {
         # KernelContextGuard _ctx("{kernel_name}", {stack_trace_str});
         # ... operations...
         # }
+        self._kernel_profile_scope_depth = (
+            getattr(self, "_kernel_profile_scope_depth", 0) + 1
+        )
         self.writeline("{")
 
     def write_kernel_context_guard_end(
         self,
     ):
         # End of a kernel context guarded block.
+        self._kernel_profile_scope_depth = (
+            getattr(self, "_kernel_profile_scope_depth", 0) - 1
+        )
         self.writeline("}")
 
     def write_kernel_context_guard(

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -4475,3 +4475,30 @@ if (!custom_op_wrapper) {
             stack_trace_str += "\n"
         stack_trace_str += ')"'
         self.writeline(f'KernelContextGuard _ctx("{kernel_name}", {stack_trace_str});')
+
+    def write_record_function_handle(
+        self,
+        kernel_name: str,
+        input_handles: list[str] | None = None,
+    ):
+        sanitized = kernel_name.replace("::", "_").replace(".", "_")
+        if input_handles:
+            for idx, handle in enumerate(input_handles):
+                ivalue_var = f"tmp_{sanitized}_input_{idx}"
+                self.writeline(f"C10IValueHandle {ivalue_var};")
+                self.writeline(f"aoti_torch_tensor_to_ivalue({handle}, &{ivalue_var});")
+                self.writeline(f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});")
+            inputs_vec = f"{sanitized}_inputs_"
+            ivalue_names = ", ".join(
+                f"tmp_{sanitized}_input_{idx}" for idx in range(len(input_handles))
+            )
+            self.writeline(
+                f"std::vector<C10IValueHandle> {inputs_vec}({{{ivalue_names}}});"
+            )
+            self.writeline(
+                f'RAIIAtenRecordFunctionHandle record_{sanitized}_("{kernel_name}", nullptr, {inputs_vec});'
+            )
+        else:
+            self.writeline(
+                f'RAIIAtenRecordFunctionHandle record_{sanitized}_("{kernel_name}", nullptr);'
+            )

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -4473,3 +4473,30 @@ if (!custom_op_wrapper) {
             stack_trace_str += "\n"
         stack_trace_str += ')"'
         self.writeline(f'KernelContextGuard _ctx("{kernel_name}", {stack_trace_str});')
+
+    def write_record_function_handle(
+        self,
+        kernel_name: str,
+        input_handles: list[str] | None = None,
+    ):
+        sanitized = kernel_name.replace("::", "_").replace(".", "_")
+        if input_handles:
+            for idx, handle in enumerate(input_handles):
+                ivalue_var = f"tmp_{sanitized}_input_{idx}"
+                self.writeline(f"C10IValueHandle {ivalue_var};")
+                self.writeline(f"aoti_torch_tensor_to_ivalue({handle}, &{ivalue_var});")
+                self.writeline(f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});")
+            inputs_vec = f"{sanitized}_inputs_"
+            ivalue_names = ", ".join(
+                f"tmp_{sanitized}_input_{idx}" for idx in range(len(input_handles))
+            )
+            self.writeline(
+                f"std::vector<C10IValueHandle> {inputs_vec}({{{ivalue_names}}});"
+            )
+            self.writeline(
+                f'RAIIAtenRecordFunctionHandle record_{sanitized}_("{kernel_name}", nullptr, {inputs_vec});'
+            )
+        else:
+            self.writeline(
+                f'RAIIAtenRecordFunctionHandle record_{sanitized}_("{kernel_name}", nullptr);'
+            )

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3757,6 +3757,14 @@ if (!custom_op_wrapper) {
         dispatch_lines.writeline("{")
 
         with dispatch_lines.indent():
+            enable_kernel_profile = (
+                config.cpp.enable_kernel_profile and sys.platform in ["linux", "win32"]
+            )
+            if enable_kernel_profile:
+                kernel_name = op_overload._schema.name.replace("::", "_")
+                dispatch_lines.writeline(
+                    f'RAIIAtenRecordFunctionHandle record_{kernel_name}_("{op_overload._schema.name}", nullptr);'
+                )
             tmp_var_number = count()
 
             def parse_arg(arg_type: torch.JitType, codegen_arg: str) -> str:
@@ -4183,6 +4191,17 @@ if (!custom_op_wrapper) {
                 for output_arg in output_args  # type: ignore[arg-type]
                 if output_arg is not None
             ]
+        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
+            "linux",
+            "win32",
+        ]
+        if enable_kernel_profile:
+            safe_name = python_kernel_name.replace(".", "_")
+            lines = (
+                f'RAIIAtenRecordFunctionHandle record_{safe_name}_("{python_kernel_name}", nullptr);\n'
+                + lines
+            )
+
         scope_gil_acquire = self.generate_scoped_gil_acquire(
             declarations_before_scope, lines
         )
@@ -4217,6 +4236,16 @@ if (!custom_op_wrapper) {
         )
 
         extern_kernel_node_index = len(V.extern_kernel_nodes) - 1
+        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
+            "linux",
+            "win32",
+        ]
+        if enable_kernel_profile:
+            kernel_name = str(op_overload).replace(".", "_")
+            self.writeline("{")
+            self.writeline(
+                f'RAIIAtenRecordFunctionHandle record_{kernel_name}_("{op_overload}", nullptr);'
+            )
         self.writeline(
             f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_proxy_executor_call_function(proxy_executor, "
             f"{extern_kernel_node_index}, "
@@ -4225,6 +4254,8 @@ if (!custom_op_wrapper) {
             f"{len(tensor_call_args)}, "
             f"{tensor_call_str}));"
         )
+        if enable_kernel_profile:
+            self.writeline("}")
 
     def codegen_runtime_lookup_tensor_call_args(
         self, tensor_call_args: Sequence[str]

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -46,11 +46,13 @@ from .cpp_utils import (
     LAYOUT_TO_ATEN,
 )
 from .wrapper import (
+    _get_profiling_input_handles,
     _rewrite_symbol_solution_for_int_codegen,
     codegen_reinterpret_view_helper,
     EnterSubgraphLine,
     ExitSubgraphLine,
     HasWriteLine,
+    kernel_profile_enabled,
     PythonWrapperCodegen,
     SymbolicCallArg,
     WrapperLine,
@@ -1875,6 +1877,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
         *,
         debug_args: list[str] | None = None,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
+        output_handle: str | None = None,
     ) -> None:
         """debug_args kwarg allows CppWrapperCpuArrayRef to pass in wrapped arguments in
         place of args while preserving debug printer output."""
@@ -1885,10 +1890,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         debug_printer_manager.set_printer_args(
             debug_args if debug_args is not None else args, kernel, None, None, "extern"
         )
-        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
-            "linux",
-            "win32",
-        ]
+        enable_kernel_profile = kernel_profile_enabled()
         enable_kernel_context_guard = (
             enable_kernel_profile and config.cpp.enable_kernel_context_guard
         )
@@ -1899,7 +1901,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
             ]
             if enable_kernel_profile:
                 call_code = shim_fn_codes[0]
-                shim_fn_codes = ["{"]
+                stack_trace_str = ""
                 if enable_kernel_context_guard:
                     stack_trace_str = 'R"('
                     if stack_traces:
@@ -1908,16 +1910,85 @@ class CppWrapperCpu(PythonWrapperCodegen):
                                 stack_trace_str += f"\n{line}"
                             stack_trace_str += "\n"
                     stack_trace_str += ')"'
-                    shim_fn_codes.append(
-                        f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+
+                has_profiling_inputs = input_handles or num_scalars > 0 or output_handle
+                if has_profiling_inputs:
+                    # Generate IValue conversions so that tensor shapes
+                    # and scalar types are recorded by the profiler.
+                    # Recorded order is [tensor inputs..., scalars..., out],
+                    # which is not the shim's argument order: `out` is passed
+                    # first, and scalars keep their schema position. This
+                    # matches the eager trace layout, so consumers must not zip
+                    # "Input Dims" against the kernel signature.
+                    ivalue_lines: list[str] = []
+                    ivalue_names: list[str] = []
+
+                    if input_handles:
+                        for idx, handle in enumerate(input_handles):
+                            ivalue_var = f"tmp_{shim_fn}_input_{idx}"
+                            ivalue_lines.extend(
+                                [
+                                    f"C10IValueHandle {ivalue_var};",
+                                    f"aoti_torch_tensor_to_ivalue({handle}, &{ivalue_var});",
+                                    f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                                ]
+                            )
+                            ivalue_names.append(ivalue_var)
+
+                    # Generate dummy scalar IValues (we only care about
+                    # shapes, so use int64(0) as a placeholder).
+                    for idx in range(num_scalars):
+                        ivalue_var = f"tmp_{shim_fn}_scalar_{idx}"
+                        ivalue_lines.extend(
+                            [
+                                f"C10IValueHandle {ivalue_var};",
+                                f"aoti_torch_int64_to_ivalue(0, &{ivalue_var});",
+                                f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                            ]
+                        )
+                        ivalue_names.append(ivalue_var)
+
+                    if output_handle:
+                        ivalue_var = f"tmp_{shim_fn}_output"
+                        ivalue_lines.extend(
+                            [
+                                f"C10IValueHandle {ivalue_var};",
+                                f"aoti_torch_tensor_to_ivalue({output_handle}, &{ivalue_var});",
+                                f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                            ]
+                        )
+                        ivalue_names.append(ivalue_var)
+
+                    inputs_vec_var = f"{shim_fn}_inputs_"
+                    ivalue_lines.append(
+                        f"std::vector<C10IValueHandle> {inputs_vec_var}({{{', '.join(ivalue_names)}}});"
                     )
-                shim_fn_codes.extend(
-                    [
-                        f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
-                        call_code,
-                        "}",
-                    ]
-                )
+
+                    shim_fn_codes = ["{", *ivalue_lines]
+                    if enable_kernel_context_guard:
+                        shim_fn_codes.append(
+                            f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+                        )
+                    shim_fn_codes.extend(
+                        [
+                            f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr, {inputs_vec_var});""",
+                            call_code,
+                            "}",
+                        ]
+                    )
+                else:
+                    shim_fn_codes = ["{"]
+                    if enable_kernel_context_guard:
+                        shim_fn_codes.append(
+                            f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+                        )
+                    shim_fn_codes.extend(
+                        [
+                            f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
+                            call_code,
+                            "}",
+                        ]
+                    )
             self.writelines(shim_fn_codes)
 
     def generate_c_shim_extern_kernel_alloc(
@@ -1937,8 +2008,22 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
         device = d.type if (d := extern_kernel.get_device()) else self.device
 
+        # input_handles / num_scalars are consumed only inside the C shim's
+        # enable_kernel_profile branch, so compute them only when profiling is on.
+        input_handles = None
+        num_scalars = 0
+        if kernel_profile_enabled():
+            num_kwargs = sum(
+                1 for key in extern_kernel.ordered_kwargs_for_cpp_kernel if key != "out"
+            )
+            input_handles = _get_profiling_input_handles(extern_kernel.inputs)
+            num_scalars = len(extern_kernel.constant_args) + num_kwargs
         self.generate_c_shim_extern_kernel_call(
-            extern_kernel.get_kernel_name(), args, device
+            extern_kernel.get_kernel_name(),
+            args,
+            device,
+            input_handles=input_handles,
+            num_scalars=num_scalars,
         )
 
         if extern_kernel.python_kernel_name in (
@@ -1964,6 +2049,19 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def generate_c_shim_fallback_kernel(
         self, fallback_kernel: ir.FallbackKernel, args: list[str]
     ) -> None:
+        # input_handles / num_scalars are consumed only inside the C shim's
+        # enable_kernel_profile branch, so compute them only when profiling is on.
+        input_handles = None
+        num_scalars = 0
+        if kernel_profile_enabled():
+            input_handles = _get_profiling_input_handles(fallback_kernel.inputs)
+            num_kwargs = sum(
+                1
+                for key in fallback_kernel.ordered_kwargs_for_cpp_kernel
+                if key != "out"
+            )
+            num_scalars = len(fallback_kernel.constant_args) + num_kwargs
+
         output_args = []
         output_raii_handles = []
         output_name_base = fallback_kernel.get_name()
@@ -2001,6 +2099,8 @@ class CppWrapperCpu(PythonWrapperCodegen):
             fallback_kernel.cpp_kernel_name,  # type: ignore[arg-type]
             args,
             device,
+            input_handles=input_handles,
+            num_scalars=num_scalars,
         )
         for raii_handle in output_raii_handles:
             self.writeline(raii_handle)
@@ -2013,16 +2113,25 @@ class CppWrapperCpu(PythonWrapperCodegen):
         args: list[str],
         device: str,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
     ) -> None:
         if out_view:
             out_name = f"{out}_as_strided"
             self.writeline(f"auto {out_name} = {out_view};")
             args.insert(0, out_name)
         else:
+            out_name = out
             args.insert(0, out)
 
         self.generate_c_shim_extern_kernel_call(
-            kernel, args, device, stack_traces=stack_traces
+            kernel,
+            args,
+            device,
+            stack_traces=stack_traces,
+            input_handles=input_handles,
+            num_scalars=num_scalars,
+            output_handle=out_name,
         )
 
     def _get_scatter_reduce_enum(self, reduce):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -46,11 +46,13 @@ from .cpp_utils import (
     LAYOUT_TO_ATEN,
 )
 from .wrapper import (
+    _get_profiling_input_handles,
     _rewrite_symbol_solution_for_int_codegen,
     codegen_reinterpret_view_helper,
     EnterSubgraphLine,
     ExitSubgraphLine,
     HasWriteLine,
+    kernel_profile_enabled,
     PythonWrapperCodegen,
     SymbolicCallArg,
     WrapperLine,
@@ -1875,6 +1877,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
         *,
         debug_args: list[str] | None = None,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
+        output_handle: str | None = None,
     ) -> None:
         """debug_args kwarg allows CppWrapperCpuArrayRef to pass in wrapped arguments in
         place of args while preserving debug printer output."""
@@ -1885,10 +1890,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         debug_printer_manager.set_printer_args(
             debug_args if debug_args is not None else args, kernel, None, None, "extern"
         )
-        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
-            "linux",
-            "win32",
-        ]
+        enable_kernel_profile = kernel_profile_enabled()
         enable_kernel_context_guard = (
             enable_kernel_profile and config.cpp.enable_kernel_context_guard
         )
@@ -1899,7 +1901,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
             ]
             if enable_kernel_profile:
                 call_code = shim_fn_codes[0]
-                shim_fn_codes = ["{"]
+                stack_trace_str = ""
                 if enable_kernel_context_guard:
                     stack_trace_str = 'R"('
                     if stack_traces:
@@ -1908,16 +1910,80 @@ class CppWrapperCpu(PythonWrapperCodegen):
                                 stack_trace_str += f"\n{line}"
                             stack_trace_str += "\n"
                     stack_trace_str += ')"'
-                    shim_fn_codes.append(
-                        f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+
+                has_profiling_inputs = input_handles or num_scalars > 0 or output_handle
+                if has_profiling_inputs:
+                    # Generate IValue conversions so that tensor shapes
+                    # and scalar types are recorded by the profiler.
+                    ivalue_lines: list[str] = []
+                    ivalue_names: list[str] = []
+
+                    if input_handles:
+                        for idx, handle in enumerate(input_handles):
+                            ivalue_var = f"tmp_{shim_fn}_input_{idx}"
+                            ivalue_lines.extend(
+                                [
+                                    f"C10IValueHandle {ivalue_var};",
+                                    f"aoti_torch_tensor_to_ivalue({handle}, &{ivalue_var});",
+                                    f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                                ]
+                            )
+                            ivalue_names.append(ivalue_var)
+
+                    # Generate dummy scalar IValues (we only care about
+                    # shapes, so use int64(0) as a placeholder).
+                    for idx in range(num_scalars):
+                        ivalue_var = f"tmp_{shim_fn}_scalar_{idx}"
+                        ivalue_lines.extend(
+                            [
+                                f"C10IValueHandle {ivalue_var};",
+                                f"aoti_torch_int64_to_ivalue(0, &{ivalue_var});",
+                                f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                            ]
+                        )
+                        ivalue_names.append(ivalue_var)
+
+                    if output_handle:
+                        ivalue_var = f"tmp_{shim_fn}_output"
+                        ivalue_lines.extend(
+                            [
+                                f"C10IValueHandle {ivalue_var};",
+                                f"aoti_torch_tensor_to_ivalue({output_handle}, &{ivalue_var});",
+                                f"RAIIC10IValueHandle RAII_{ivalue_var}({ivalue_var});",
+                            ]
+                        )
+                        ivalue_names.append(ivalue_var)
+
+                    inputs_vec_var = f"{shim_fn}_inputs_"
+                    ivalue_lines.append(
+                        f"std::vector<C10IValueHandle> {inputs_vec_var}({{{', '.join(ivalue_names)}}});"
                     )
-                shim_fn_codes.extend(
-                    [
-                        f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
-                        call_code,
-                        "}",
-                    ]
-                )
+
+                    shim_fn_codes = ["{", *ivalue_lines]
+                    if enable_kernel_context_guard:
+                        shim_fn_codes.append(
+                            f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+                        )
+                    shim_fn_codes.extend(
+                        [
+                            f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr, {inputs_vec_var});""",
+                            call_code,
+                            "}",
+                        ]
+                    )
+                else:
+                    shim_fn_codes = ["{"]
+                    if enable_kernel_context_guard:
+                        shim_fn_codes.append(
+                            f"""KernelContextGuard _ctx("{shim_fn}", {stack_trace_str});"""
+                        )
+                    shim_fn_codes.extend(
+                        [
+                            f"""RAIIAtenRecordFunctionHandle record_{shim_fn}_("{shim_fn}", nullptr);""",
+                            call_code,
+                            "}",
+                        ]
+                    )
             self.writelines(shim_fn_codes)
 
     def generate_c_shim_extern_kernel_alloc(
@@ -1937,8 +2003,22 @@ class CppWrapperCpu(PythonWrapperCodegen):
 
         device = d.type if (d := extern_kernel.get_device()) else self.device
 
+        # input_handles / num_scalars are consumed only inside the C shim's
+        # enable_kernel_profile branch, so compute them only when profiling is on.
+        input_handles = None
+        num_scalars = 0
+        if kernel_profile_enabled():
+            num_kwargs = sum(
+                1 for key in extern_kernel.ordered_kwargs_for_cpp_kernel if key != "out"
+            )
+            input_handles = _get_profiling_input_handles(extern_kernel.inputs)
+            num_scalars = len(extern_kernel.constant_args) + num_kwargs
         self.generate_c_shim_extern_kernel_call(
-            extern_kernel.get_kernel_name(), args, device
+            extern_kernel.get_kernel_name(),
+            args,
+            device,
+            input_handles=input_handles,
+            num_scalars=num_scalars,
         )
 
         if extern_kernel.python_kernel_name in (
@@ -1964,6 +2044,18 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def generate_c_shim_fallback_kernel(
         self, fallback_kernel: ir.FallbackKernel, args: list[str]
     ) -> None:
+        # input_handles / num_scalars are consumed only inside the C shim's
+        # enable_kernel_profile branch, so compute them only when profiling is on.
+        # Multi-output fallbacks record the physical buffer for every tensor
+        # input; the logical view shape is not tracked here.
+        input_handles = None
+        if kernel_profile_enabled():
+            input_handles = [
+                inp.get_name()
+                for inp in fallback_kernel.inputs
+                if isinstance(inp, ir.IRNode)
+            ]
+
         output_args = []
         output_raii_handles = []
         output_name_base = fallback_kernel.get_name()
@@ -1997,10 +2089,20 @@ class CppWrapperCpu(PythonWrapperCodegen):
         args = args + output_args
         device = d.type if (d := fallback_kernel.get_device()) else self.device
 
+        num_scalars = 0
+        if kernel_profile_enabled():
+            num_kwargs = sum(
+                1
+                for key in fallback_kernel.ordered_kwargs_for_cpp_kernel
+                if key != "out"
+            )
+            num_scalars = len(fallback_kernel.constant_args) + num_kwargs
         self.generate_c_shim_extern_kernel_call(
             fallback_kernel.cpp_kernel_name,  # type: ignore[arg-type]
             args,
             device,
+            input_handles=input_handles,
+            num_scalars=num_scalars,
         )
         for raii_handle in output_raii_handles:
             self.writeline(raii_handle)
@@ -2013,16 +2115,25 @@ class CppWrapperCpu(PythonWrapperCodegen):
         args: list[str],
         device: str,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
     ) -> None:
         if out_view:
             out_name = f"{out}_as_strided"
             self.writeline(f"auto {out_name} = {out_view};")
             args.insert(0, out_name)
         else:
+            out_name = out
             args.insert(0, out)
 
         self.generate_c_shim_extern_kernel_call(
-            kernel, args, device, stack_traces=stack_traces
+            kernel,
+            args,
+            device,
+            stack_traces=stack_traces,
+            input_handles=input_handles,
+            num_scalars=num_scalars,
+            output_handle=out_name,
         )
 
     def _get_scatter_reduce_enum(self, reduce):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3759,6 +3759,14 @@ if (!custom_op_wrapper) {
         dispatch_lines.writeline("{")
 
         with dispatch_lines.indent():
+            enable_kernel_profile = (
+                config.cpp.enable_kernel_profile and sys.platform in ["linux", "win32"]
+            )
+            if enable_kernel_profile:
+                kernel_name = op_overload._schema.name.replace("::", "_")
+                dispatch_lines.writeline(
+                    f'RAIIAtenRecordFunctionHandle record_{kernel_name}_("{op_overload._schema.name}", nullptr);'
+                )
             tmp_var_number = count()
 
             def parse_arg(arg_type: torch.JitType, codegen_arg: str) -> str:
@@ -4185,6 +4193,17 @@ if (!custom_op_wrapper) {
                 for output_arg in output_args  # type: ignore[arg-type]
                 if output_arg is not None
             ]
+        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
+            "linux",
+            "win32",
+        ]
+        if enable_kernel_profile:
+            safe_name = python_kernel_name.replace(".", "_")
+            lines = (
+                f'RAIIAtenRecordFunctionHandle record_{safe_name}_("{python_kernel_name}", nullptr);\n'
+                + lines
+            )
+
         scope_gil_acquire = self.generate_scoped_gil_acquire(
             declarations_before_scope, lines
         )
@@ -4219,6 +4238,16 @@ if (!custom_op_wrapper) {
         )
 
         extern_kernel_node_index = len(V.extern_kernel_nodes) - 1
+        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
+            "linux",
+            "win32",
+        ]
+        if enable_kernel_profile:
+            kernel_name = str(op_overload).replace(".", "_")
+            self.writeline("{")
+            self.writeline(
+                f'RAIIAtenRecordFunctionHandle record_{kernel_name}_("{op_overload}", nullptr);'
+            )
         self.writeline(
             f"AOTI_TORCH_ERROR_CODE_CHECK(aoti_torch_proxy_executor_call_function(proxy_executor, "
             f"{extern_kernel_node_index}, "
@@ -4227,6 +4256,8 @@ if (!custom_op_wrapper) {
             f"{len(tensor_call_args)}, "
             f"{tensor_call_str}));"
         )
+        if enable_kernel_profile:
+            self.writeline("}")
 
     def codegen_runtime_lookup_tensor_call_args(
         self, tensor_call_args: Sequence[str]

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2307,17 +2307,17 @@ class CppWrapperCpu(PythonWrapperCodegen):
             self.writeline(f"int64_t {sym} = {cexpr(expr)};")
 
     def _generate_symbolic_call_arg_helper(
-        self, arg: SymbolicCallArg, graph: GraphLowering
+        self, arg: SymbolicCallArg, graph: GraphLowering, in_profile_scope: bool = False
     ) -> None:
-        enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
-            "linux",
-            "win32",
-        ]
-        if enable_kernel_profile or (arg.inner, graph) not in self.kernel_numel_expr:
-            # When enable_kernel_profile is on, each kernel call is wrapped in
-            # its own {} scope block, so we must redeclare the variable each
-            # time since prior declarations are no longer visible.
-            self.kernel_numel_expr.add((arg.inner, graph))
+        if in_profile_scope or (arg.inner, graph) not in self.kernel_numel_expr:
+            # When inside a kernel profile {} scope block, we must always
+            # redeclare since prior declarations from other scope blocks are
+            # not visible. We intentionally skip adding to kernel_numel_expr
+            # in that case because the block-scoped declaration won't be
+            # visible at function scope either. At function scope, we declare
+            # on first use and assign thereafter.
+            if not in_profile_scope:
+                self.kernel_numel_expr.add((arg.inner, graph))
             self.writeline(f"int64_t {arg.inner} = {cexpr(arg.inner_expr)};")
         else:
             self.writeline(f"{arg.inner} = {cexpr(arg.inner_expr)};")
@@ -4428,12 +4428,18 @@ if (!custom_op_wrapper) {
         # KernelContextGuard _ctx("{kernel_name}", {stack_trace_str});
         # ... operations...
         # }
+        self._kernel_profile_scope_depth = (
+            getattr(self, "_kernel_profile_scope_depth", 0) + 1
+        )
         self.writeline("{")
 
     def write_kernel_context_guard_end(
         self,
     ):
         # End of a kernel context guarded block.
+        self._kernel_profile_scope_depth = (
+            getattr(self, "_kernel_profile_scope_depth", 0) - 1
+        )
         self.writeline("}")
 
     def write_kernel_context_guard(

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -1050,29 +1050,55 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
         self.writeline("}")
 
     def generate_c_shim_extern_kernel_call(
-        self, kernel: str, args: list[str], device: str, **_
+        self,
+        kernel: str,
+        args: list[str],
+        device: str,
+        *,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
+        output_handle: str | None = None,
+        **_,
     ) -> None:
         # In the abi_compatible mode, we call fallback aten ops through a C shim layer
         # Setting self.allow_stack_allocation to False because the exchange between
         # ArrayRefTensor and at::Tensor is still fragile.
         self.allow_stack_allocation = False
 
-        wrapped_args = []
-        for arg in args:
+        def borrow_as_tensor_if_needed(expr: str) -> str:
             # We only really *need* borrow_arrayref_tensor_as_tensor for
             # ArrayRefTensors. The code flowing into here uses `0` for nullptr, which
             # borrow_arrayref_tensor_as_tensor would blindly coerce to int, so just
             # avoid wrapping integers.  Name matching is to find tensor is hacky, but
             # fixing all the ArrayRefTensor issues is not a priority for now.
-            if isinstance(arg, str) and arg.startswith(
+            if isinstance(expr, str) and expr.startswith(
                 ("buf", "arg", "wrap_with_raii_handle_if_needed")
             ):
                 self._assert_safe_to_use_borrow_arrayref_tensor_as_tensor()
-                arg = f"borrow_arrayref_tensor_as_tensor({arg})"
-            wrapped_args.append(arg)
+                return f"borrow_arrayref_tensor_as_tensor({expr})"
+            return expr
 
+        wrapped_args = [borrow_as_tensor_if_needed(arg) for arg in args]
+
+        # The profiling handles are passed to aoti_torch_tensor_to_ivalue, which
+        # takes an AtenTensorHandle. ArrayRefTensor has no conversion to one, so
+        # borrow it as a tensor exactly like the positional args above.
         super().generate_c_shim_extern_kernel_call(
-            kernel, wrapped_args, device, debug_args=args
+            kernel,
+            wrapped_args,
+            device,
+            debug_args=args,
+            input_handles=(
+                None
+                if input_handles is None
+                else [borrow_as_tensor_if_needed(handle) for handle in input_handles]
+            ),
+            num_scalars=num_scalars,
+            output_handle=(
+                None
+                if output_handle is None
+                else borrow_as_tensor_if_needed(output_handle)
+            ),
         )
 
     def generate_scatter_fallback(self, node: ir.ScatterFallback):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -1113,6 +1113,19 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             for x in inputs
         ]
 
+    def write_record_function_handle(
+        self,
+        kernel_name: str,
+        input_handles: list[str] | None = None,
+    ):
+        # ArrayRef tensors are not AtenTensorHandle, so we cannot call
+        # aoti_torch_tensor_to_ivalue on them.  Emit RAIIAtenRecordFunctionHandle
+        # without input metadata instead.
+        sanitized = kernel_name.replace("::", "_").replace(".", "_")
+        self.writeline(
+            f'RAIIAtenRecordFunctionHandle record_{sanitized}_("{kernel_name}", nullptr);'
+        )
+
     def generate_index_put_fallback(self, node: ir.IndexPutFallback) -> None:
         # No stack allocation when there is a fallback op
         self.allow_stack_allocation = False

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1848,7 +1848,17 @@ static inline void ensure_triton_kernel_compiles_started() {{
             # JIT: call the extern "C" symbol directly (resolved at link time
             # via extra_flags pointing at the compiled .so).
             kernel_prefix = "kernels." if V.graph.aot_mode else ""
+            enable_kernel_profile = (
+                config.cpp.enable_kernel_profile and sys.platform in ["linux", "win32"]
+            )
+            if enable_kernel_profile:
+                self.writeline("{")
+                self.writeline(
+                    f'RAIIAtenRecordFunctionHandle record_{kernel_name}_("{kernel_name}", nullptr);'
+                )
             self.writeline(f"{kernel_prefix}{kernel_name}({call_args_str}, {stream});")
+            if enable_kernel_profile:
+                self.writeline("}")
 
     def prepare_triton_wrapper_args(
         self, call_args: list[Any], arg_types: list[Any]

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -12,6 +12,7 @@ import operator
 import os
 import random
 import re
+import sys
 import tempfile
 from collections.abc import Callable
 from itertools import chain, count
@@ -667,6 +668,38 @@ class ExternKernelAllocLine(WrapperLine):
         return converter._generate_extern_kernel_alloc
 
 
+def kernel_profile_enabled() -> bool:
+    """Whether the C shim emits kernel-profiling instrumentation.
+
+    RAIIAtenRecordFunctionHandle is only available on these platforms. Callers
+    that build profiling metadata must use this rather than the config flag
+    alone: `_get_profiling_input_handles` emits codegen for its inputs, so
+    building metadata the shim then declines to emit would leak a handle."""
+    return config.cpp.enable_kernel_profile and sys.platform in ("linux", "win32")
+
+
+def _get_profiling_input_handles(
+    inputs: Sequence[IRNode | Sequence[IRNode]],
+) -> list[str]:
+    """Build input handles for profiling: re-derive the codegen expression for
+    ReinterpretView inputs (to capture logical view shapes) and use get_name()
+    for everything else. Nested Sequence[IRNode] inputs (e.g. a tensor list)
+    have no single handle and are skipped.
+
+    The expression is derived per input rather than read out of the kernel's
+    codegen args: a kernel whose schema interleaves non-tensor arguments, takes
+    an optional tensor, or collapses a tensor list into a single
+    `<array-ptr>, <len>` token has no positional correspondence between its
+    inputs and its args."""
+    handles = []
+    for inp in inputs:
+        if isinstance(inp, ReinterpretView):
+            handles.append(inp.codegen_reference())
+        elif isinstance(inp, IRNode):
+            handles.append(inp.get_name())
+    return handles
+
+
 @dataclasses.dataclass
 class ExternKernelOutLine(WrapperLine):
     wrapper: PythonWrapperCodegen
@@ -685,6 +718,19 @@ class ExternKernelOutLine(WrapperLine):
         else:
             kernel_name = node.get_kernel_name()
         device = d.type if (d := node.get_device()) else V.graph.device_type
+        # input_handles / num_scalars are consumed only inside the C shim's
+        # enable_kernel_profile branch, so compute them only when the C++ wrapper
+        # is generating code and profiling is on.
+        input_handles = None
+        num_scalars = 0
+        if V.graph.cpp_wrapper and kernel_profile_enabled():
+            # Count scalar args from both constant_args and kwargs
+            # (e.g., addmm has alpha/beta in kwargs, not constant_args).
+            num_kwargs = sum(
+                1 for key in self.node.ordered_kwargs_for_cpp_kernel if key != "out"
+            )
+            input_handles = _get_profiling_input_handles(self.node.inputs)
+            num_scalars = len(self.node.constant_args) + num_kwargs
         self.wrapper._generate_extern_kernel_out_helper(
             kernel_name,
             node.codegen_reference(),
@@ -692,6 +738,8 @@ class ExternKernelOutLine(WrapperLine):
             args,
             device,
             self.node.get_stack_traces(),
+            input_handles=input_handles,
+            num_scalars=num_scalars,
         )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
@@ -2278,7 +2326,11 @@ class PythonWrapperCodegen(CodeGen):
         args: list[str],
         device: str,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
     ) -> None:
+        # input_handles / num_scalars are consumed only by the CppWrapperCpu
+        # override (to record profiling metadata); the Python wrapper ignores them.
         # add debug printer code for triton kernel calls at (jit) inductor level
         debug_printer_manager = V.graph.wrapper_code.debug_printer
         debug_printer_manager.set_printer_args(args, kernel, None, None, "extern")

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1350,9 +1350,12 @@ class SymbolicCallArgLine(WrapperLine):
     wrapper: PythonWrapperCodegen
     arg: SymbolicCallArg
     graph: GraphLowering
+    in_profile_scope: bool = False
 
     def codegen(self, code: IndentedBuffer) -> None:
-        self.wrapper._generate_symbolic_call_arg_helper(self.arg, self.graph)
+        self.wrapper._generate_symbolic_call_arg_helper(
+            self.arg, self.graph, self.in_profile_scope
+        )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
         return converter._generate_symbolic_call_arg
@@ -3771,12 +3774,15 @@ class PythonWrapperCodegen(CodeGen):
 
         is_benchmark_kernel = kernel_name == ""
         if not is_benchmark_kernel:
-            self.writeline(SymbolicCallArgLine(self, arg, V.graph))
+            in_scope = getattr(self, "_kernel_profile_scope_depth", 0) > 0
+            self.writeline(
+                SymbolicCallArgLine(self, arg, V.graph, in_profile_scope=in_scope)
+            )
 
         return arg
 
     def _generate_symbolic_call_arg_helper(
-        self, arg: SymbolicCallArg, graph: GraphLowering
+        self, arg: SymbolicCallArg, graph: GraphLowering, in_profile_scope: bool = False
     ) -> None:
         self.writeline(f"{arg.inner} = {pexpr(arg.inner_expr)}")
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1413,9 +1413,12 @@ class SymbolicCallArgLine(WrapperLine):
     wrapper: PythonWrapperCodegen
     arg: SymbolicCallArg
     graph: GraphLowering
+    in_profile_scope: bool = False
 
     def codegen(self, code: IndentedBuffer) -> None:
-        self.wrapper._generate_symbolic_call_arg_helper(self.arg, self.graph)
+        self.wrapper._generate_symbolic_call_arg_helper(
+            self.arg, self.graph, self.in_profile_scope
+        )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
         return converter._generate_symbolic_call_arg
@@ -3878,12 +3881,15 @@ class PythonWrapperCodegen(CodeGen):
 
         is_benchmark_kernel = kernel_name == ""
         if not is_benchmark_kernel:
-            self.writeline(SymbolicCallArgLine(self, arg, V.graph))
+            in_scope = getattr(self, "_kernel_profile_scope_depth", 0) > 0
+            self.writeline(
+                SymbolicCallArgLine(self, arg, V.graph, in_profile_scope=in_scope)
+            )
 
         return arg
 
     def _generate_symbolic_call_arg_helper(
-        self, arg: SymbolicCallArg, graph: GraphLowering
+        self, arg: SymbolicCallArg, graph: GraphLowering, in_profile_scope: bool = False
     ) -> None:
         self.writeline(f"{arg.inner} = {pexpr(arg.inner_expr)}")
 

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1307,9 +1307,10 @@ class IndexPutFallbackLine(WrapperLine):
             for idx in self.indices
         ]
 
-        self.wrapper._generate_index_put_fallback(
-            node.get_kernel_name(), x, indices, values, *node.codegen_const_args()
-        )
+        with self.wrapper.profiled_kernel_scope(node.get_kernel_name(), node):
+            self.wrapper._generate_index_put_fallback(
+                node.get_kernel_name(), x, indices, values, *node.codegen_const_args()
+            )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
         return converter._generate_index_put_fallback
@@ -1330,16 +1331,17 @@ class ScatterFallbackLine(WrapperLine):
             (x, index) = (t.codegen_reference() for t in node.inputs)
             src = node.constant_args[1]
         device = d.type if (d := node.get_device()) else V.graph.device_type
-        self.wrapper._generate_scatter_fallback(
-            x,
-            [x, node.constant_args[0], index, src],
-            node.cpp_kernel_name,
-            node.python_kernel_name,
-            node.src_is_tensor,
-            node.kwargs["reduce"],
-            node.codegen_kwargs(),
-            device,
-        )
+        with self.wrapper.profiled_kernel_scope(node.cpp_kernel_name, node):
+            self.wrapper._generate_scatter_fallback(
+                x,
+                [x, node.constant_args[0], index, src],
+                node.cpp_kernel_name,
+                node.python_kernel_name,
+                node.src_is_tensor,
+                node.kwargs["reduce"],
+                node.codegen_kwargs(),
+                device,
+            )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
         return converter._generate_scatter_fallback
@@ -5037,6 +5039,44 @@ class PythonWrapperCodegen(CodeGen):
         Mark the end of kernel context guard
         """
         return
+
+    def write_record_function_handle(
+        self,
+        kernel_name: str,
+        input_handles: list[str] | None = None,
+    ):
+        return
+
+    @contextlib.contextmanager
+    def profiled_kernel_scope(self, kernel_name, node_schedule):
+        """Context manager that wraps a kernel call in a RAIIAtenRecordFunctionHandle
+        profiling block when config.cpp.enable_kernel_profile is enabled, plus a
+        KernelContextGuard when config.cpp.enable_kernel_context_guard is also enabled.
+        On PythonWrapperCodegen the write_* methods are no-ops, so this is
+        effectively a no-op.  CppWrapperCpu overrides those methods, making
+        this context manager emit real profiling wrappers."""
+        try:
+            if config.cpp.enable_kernel_profile:
+                self.write_kernel_context_guard_begin()
+                if config.cpp.enable_kernel_context_guard:
+                    self.write_kernel_context_guard(kernel_name, node_schedule)
+                input_handles = self._get_extern_kernel_input_handles(node_schedule)
+                self.write_record_function_handle(kernel_name, input_handles)
+            yield
+        finally:
+            if config.cpp.enable_kernel_profile:
+                self.write_kernel_context_guard_end()
+
+    @staticmethod
+    def _get_extern_kernel_input_handles(node_schedule) -> list[str] | None:
+        """Extract tensor input handle names from an ExternKernel node."""
+        if not isinstance(node_schedule, ir.ExternKernel):
+            return None
+        handles = []
+        for inp in node_schedule.inputs:
+            if isinstance(inp, (ir.Buffer, ir.ReinterpretView)):
+                handles.append(inp.get_name())
+        return handles if handles else None
 
 
 class SubgraphPythonWrapperCodegen(PythonWrapperCodegen):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1370,9 +1370,10 @@ class IndexPutFallbackLine(WrapperLine):
             for idx in self.indices
         ]
 
-        self.wrapper._generate_index_put_fallback(
-            node.get_kernel_name(), x, indices, values, *node.codegen_const_args()
-        )
+        with self.wrapper.profiled_kernel_scope(node.get_kernel_name(), node):
+            self.wrapper._generate_index_put_fallback(
+                node.get_kernel_name(), x, indices, values, *node.codegen_const_args()
+            )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
         return converter._generate_index_put_fallback
@@ -1393,16 +1394,17 @@ class ScatterFallbackLine(WrapperLine):
             (x, index) = (t.codegen_reference() for t in node.inputs)
             src = node.constant_args[1]
         device = d.type if (d := node.get_device()) else V.graph.device_type
-        self.wrapper._generate_scatter_fallback(
-            x,
-            [x, node.constant_args[0], index, src],
-            node.cpp_kernel_name,
-            node.python_kernel_name,
-            node.src_is_tensor,
-            node.kwargs["reduce"],
-            node.codegen_kwargs(),
-            device,
-        )
+        with self.wrapper.profiled_kernel_scope(node.cpp_kernel_name, node):
+            self.wrapper._generate_scatter_fallback(
+                x,
+                [x, node.constant_args[0], index, src],
+                node.cpp_kernel_name,
+                node.python_kernel_name,
+                node.src_is_tensor,
+                node.kwargs["reduce"],
+                node.codegen_kwargs(),
+                device,
+            )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
         return converter._generate_scatter_fallback
@@ -5159,6 +5161,50 @@ class PythonWrapperCodegen(CodeGen):
         Mark the end of kernel context guard
         """
         return
+
+    def write_record_function_handle(
+        self,
+        kernel_name: str,
+        input_handles: list[str] | None = None,
+    ):
+        return
+
+    @contextlib.contextmanager
+    def profiled_kernel_scope(self, kernel_name, node_schedule):
+        """Context manager that wraps a kernel call in a RAIIAtenRecordFunctionHandle
+        profiling block when config.cpp.enable_kernel_profile is enabled, plus a
+        KernelContextGuard when config.cpp.enable_kernel_context_guard is also enabled.
+        On PythonWrapperCodegen the write_* methods are no-ops, so this is
+        effectively a no-op.  CppWrapperCpu overrides those methods, making
+        this context manager emit real profiling wrappers."""
+        try:
+            if kernel_profile_enabled():
+                self.write_kernel_context_guard_begin()
+                if config.cpp.enable_kernel_context_guard:
+                    self.write_kernel_context_guard(kernel_name, node_schedule)
+                # Deriving the handles emits codegen for ReinterpretView
+                # inputs, which only the C++ wrapper consumes.
+                input_handles = None
+                if V.graph.cpp_wrapper:
+                    input_handles = self._get_extern_kernel_input_handles(
+                        node_schedule
+                    )
+                self.write_record_function_handle(kernel_name, input_handles)
+            yield
+        finally:
+            if kernel_profile_enabled():
+                self.write_kernel_context_guard_end()
+
+    @staticmethod
+    def _get_extern_kernel_input_handles(node_schedule) -> list[str] | None:
+        """Extract tensor input handle expressions from an ExternKernel node.
+
+        Uses the shared helper so a ReinterpretView records its logical view
+        shape. get_name() would return the base buffer, which the profiler
+        would report as a real but wrong shape."""
+        if not isinstance(node_schedule, ir.ExternKernel):
+            return None
+        return _get_profiling_input_handles(node_schedule.inputs) or None
 
 
 class SubgraphPythonWrapperCodegen(PythonWrapperCodegen):

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -12,6 +12,7 @@ import operator
 import os
 import random
 import re
+import sys
 import tempfile
 from collections.abc import Callable
 from enum import Enum
@@ -724,6 +725,38 @@ class ExternKernelAllocLine(WrapperLine):
         return converter._generate_extern_kernel_alloc
 
 
+def kernel_profile_enabled() -> bool:
+    """Whether the C shim emits kernel-profiling instrumentation.
+
+    RAIIAtenRecordFunctionHandle is only available on these platforms. Callers
+    that build profiling metadata must use this rather than the config flag
+    alone: `_get_profiling_input_handles` emits codegen for its inputs, so
+    building metadata the shim then declines to emit would leak a handle."""
+    return config.cpp.enable_kernel_profile and sys.platform in ("linux", "win32")
+
+
+def _get_profiling_input_handles(
+    inputs: Sequence[IRNode | Sequence[IRNode]],
+) -> list[str]:
+    """Build input handles for profiling: re-derive the codegen expression for
+    ReinterpretView inputs (to capture logical view shapes) and use get_name()
+    for everything else. Nested Sequence[IRNode] inputs (e.g. a tensor list)
+    have no single handle and are skipped.
+
+    The expression is derived per input rather than read out of the kernel's
+    codegen args: a kernel whose schema interleaves non-tensor arguments, takes
+    an optional tensor, or collapses a tensor list into a single
+    `<array-ptr>, <len>` token has no positional correspondence between its
+    inputs and its args."""
+    handles = []
+    for inp in inputs:
+        if isinstance(inp, ReinterpretView):
+            handles.append(inp.codegen_reference())
+        elif isinstance(inp, IRNode):
+            handles.append(inp.get_name())
+    return handles
+
+
 @dataclasses.dataclass
 class ExternKernelOutLine(WrapperLine):
     wrapper: PythonWrapperCodegen
@@ -742,6 +775,19 @@ class ExternKernelOutLine(WrapperLine):
         else:
             kernel_name = node.get_kernel_name()
         device = d.type if (d := node.get_device()) else V.graph.device_type
+        # input_handles / num_scalars are consumed only inside the C shim's
+        # enable_kernel_profile branch, so compute them only when the C++ wrapper
+        # is generating code and profiling is on.
+        input_handles = None
+        num_scalars = 0
+        if V.graph.cpp_wrapper and kernel_profile_enabled():
+            # Count scalar args from both constant_args and kwargs
+            # (e.g., addmm has alpha/beta in kwargs, not constant_args).
+            num_kwargs = sum(
+                1 for key in self.node.ordered_kwargs_for_cpp_kernel if key != "out"
+            )
+            input_handles = _get_profiling_input_handles(self.node.inputs)
+            num_scalars = len(self.node.constant_args) + num_kwargs
         self.wrapper._generate_extern_kernel_out_helper(
             kernel_name,
             node.codegen_reference(),
@@ -749,6 +795,8 @@ class ExternKernelOutLine(WrapperLine):
             args,
             device,
             self.node.get_stack_traces(),
+            input_handles=input_handles,
+            num_scalars=num_scalars,
         )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
@@ -2358,7 +2406,11 @@ class PythonWrapperCodegen(CodeGen):
         args: list[str],
         device: str,
         stack_traces: OrderedSet[str] | None = None,
+        input_handles: list[str] | None = None,
+        num_scalars: int = 0,
     ) -> None:
+        # input_handles / num_scalars are consumed only by the CppWrapperCpu
+        # override (to record profiling metadata); the Python wrapper ignores them.
         # add debug printer code for triton kernel calls at (jit) inductor level
         debug_printer_manager = V.graph.wrapper_code.debug_printer
         debug_printer_manager.set_printer_args(args, kernel, None, None, "extern")

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1073,6 +1073,11 @@ min_num_split = int(os.environ.get("TORCHINDUCTOR_MIN_NUM_SPLIT", 0))
 
 benchmark_kernel = os.environ.get("TORCHINDUCTOR_BENCHMARK_KERNEL", "0") == "1"
 
+# In single-pass AOT mode (autotune_at_compile_time=True), also generate the
+# Python compiled module (.py) via an extra codegen pass. The .py is written to
+# PyCodeCache for debugging/profiling but is not used for compilation.
+dump_python_module = os.environ.get("TORCHINDUCTOR_DUMP_PYTHON_MODULE", "0") == "1"
+
 # Enable constant and index_expr folding
 constant_and_index_propagation = True
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1067,6 +1067,11 @@ min_num_split = int(os.environ.get("TORCHINDUCTOR_MIN_NUM_SPLIT", 0))
 
 benchmark_kernel = os.environ.get("TORCHINDUCTOR_BENCHMARK_KERNEL", "0") == "1"
 
+# In single-pass AOT mode (autotune_at_compile_time=True), also generate the
+# Python compiled module (.py) via an extra codegen pass. The .py is written to
+# PyCodeCache for debugging/profiling but is not used for compilation.
+dump_python_module = os.environ.get("TORCHINDUCTOR_DUMP_PYTHON_MODULE", "0") == "1"
+
 # Enable constant and index_expr folding
 constant_and_index_propagation = True
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -56,7 +56,7 @@ from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.numbers import int_oo
 from torch.utils._typing_utils import not_none
 
-from . import config, ir
+from . import config, ir, metrics
 from .codegen.common import (
     BackendFeature,
     DeviceOpOverrides,
@@ -2696,6 +2696,13 @@ class GraphLowering(torch.fx.Interpreter):
                         real_inputs = extract_real_inputs()
                         self.extract_autotune_inputs(real_inputs)
                         save_triton_kernel_perf_artifact(self)
+
+                if (
+                    config.dump_python_module
+                    and self.aot_mode
+                    and not self.is_const_graph
+                ):
+                    self._dump_python_module()
                 return self.codegen()
             else:
                 if not self.aot_mode:
@@ -2990,6 +2997,80 @@ class GraphLowering(torch.fx.Interpreter):
 
         with config.patch("triton.store_cubin", False):
             self.scheduler = Scheduler(self.operations)
+
+    def _dump_python_module(self) -> None:
+        """Generate a Python compiled module (.py) for debugging/profiling.
+
+        Called before codegen() so that both this dump pass and the real C++
+        pass create their schedulers from the same operations list. The
+        scheduler's finalize_multi_template_buffers may mutate the operations
+        list via _replace_operation_buffer; we snapshot and restore it so the
+        real pass sees identical input and produces matching kernel names.
+        """
+        from .codecache import PyCodeCache
+
+        # Save the const_module's name iterator so the dump pass
+        # doesn't advance it for the subsequent real C++ codegen pass.
+        const_module = self.const_module
+        saved_names_iter = None
+        if const_module:
+            pos = next(const_module.wrapper_code._names_iter)
+            saved_names_iter = itertools.count(pos)
+            const_module.wrapper_code._names_iter = itertools.count(pos)
+
+        # Snapshot the operations graph state.  _replace_operation_buffer
+        # (called during Scheduler.__init__) mutates these in-place; we
+        # restore them afterwards so the real codegen pass sees the same
+        # unmutated state and produces identical kernel names.
+        saved_operations = list(self.operations)
+        saved_buffers = list(self.buffers)
+        saved_name_to_buffer = dict(self.name_to_buffer)
+        saved_name_to_op = dict(self.name_to_op)
+
+        # Steps 1-3 mutate graph/wrapper state; the finally block restores it
+        # unconditionally so the real C++ codegen pass runs on the pre-dump
+        # state even if the dump pass raises.
+        try:
+            # Step 1: Create Python wrapper (needs cpp_wrapper=False so
+            # init_wrapper_code selects PythonWrapperCodegen).
+            self.cpp_wrapper = False
+            self.init_wrapper_code()
+
+            # Step 2: Create scheduler with cpp_wrapper=True so fusion
+            # decisions match the real C++ pass.
+            self.cpp_wrapper = True
+            self._update_scheduler()
+
+            # Step 3: Generate code through the Python wrapper.
+            self.cpp_wrapper = False
+            with config.patch({"triton.autotune_at_compile_time": False}):
+                self.wrapper_code.push_codegened_graph(self)
+                self.scheduler.codegen()
+                result = self.wrapper_code.generate(self.is_inference)
+                self.wrapper_code.pop_codegened_graph()
+
+            # Write the .py to PyCodeCache for debugging/profiling.
+            wrapper_code = result[0]
+            output_code_log.debug("Output code: \n%s", wrapper_code.value)
+            key, path = PyCodeCache.write(wrapper_code.value)
+            log.info("Compiled module path: %s", path)
+            if config.benchmark_kernel:
+                print(f"Compiled module path: {path}", file=sys.stderr)
+        finally:
+            # Restore all state for the real C++ codegen pass.
+            self.cpp_wrapper = True
+            if const_module:
+                const_module.wrapper_code._names_iter = saved_names_iter
+            self.operations = saved_operations
+            self.buffers = saved_buffers
+            self.name_to_buffer = saved_name_to_buffer
+            self.name_to_op = saved_name_to_op
+            self.removed_buffers.clear()
+            self.removed_operations.clear()
+            self.inplaced_to_remove.clear()
+            V.graph.sizevars.precomputed_replacements.clear()
+            V.graph.sizevars.inv_precomputed_replacements.clear()
+            metrics.reset()
 
     def codegen(self) -> tuple[ValueWithLineMap, ValueWithLineMap]:
         with dynamo_timed("GraphLowering.codegen", log_pt2_compile_event=True):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8857,7 +8857,8 @@ class InplaceCopyFallback(ExternKernel):
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         (dst, src, non_blocking) = self.codegen_args()
-        wrapper.codegen_device_copy(src, dst, non_blocking)
+        with wrapper.profiled_kernel_scope("aoti_torch_copy_", self):
+            wrapper.codegen_device_copy(src, dst, non_blocking)
 
     def should_allocate(self) -> bool:
         return False
@@ -9155,12 +9156,13 @@ class DeviceCopy(ExternKernelOut):
         args = self.codegen_args()
         if len(args) != 2:
             raise AssertionError("Expected len(args) == 2")
-        if self.output_view:
-            wrapper.codegen_device_copy(
-                args[0], self.output_view.codegen_reference(), args[1]
-            )
-        else:
-            wrapper.codegen_device_copy(args[0], self.codegen_reference(), args[1])
+        with wrapper.profiled_kernel_scope("aoti_torch_copy_", self):
+            if self.output_view:
+                wrapper.codegen_device_copy(
+                    args[0], self.output_view.codegen_reference(), args[1]
+                )
+            else:
+                wrapper.codegen_device_copy(args[0], self.codegen_reference(), args[1])
         if isinstance(self.layout, Layout) and self.layout.is_pinned:
             wrapper.sync_d2h_copy(self.get_name())
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8961,7 +8961,8 @@ class InplaceCopyFallback(ExternKernel):
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         (dst, src, non_blocking) = self.codegen_args()
-        wrapper.codegen_device_copy(src, dst, non_blocking)
+        with wrapper.profiled_kernel_scope("aoti_torch_copy_", self):
+            wrapper.codegen_device_copy(src, dst, non_blocking)
 
     def should_allocate(self) -> bool:
         return False
@@ -9259,12 +9260,13 @@ class DeviceCopy(ExternKernelOut):
         args = self.codegen_args()
         if len(args) != 2:
             raise AssertionError("Expected len(args) == 2")
-        if self.output_view:
-            wrapper.codegen_device_copy(
-                args[0], self.output_view.codegen_reference(), args[1]
-            )
-        else:
-            wrapper.codegen_device_copy(args[0], self.codegen_reference(), args[1])
+        with wrapper.profiled_kernel_scope("aoti_torch_copy_", self):
+            if self.output_view:
+                wrapper.codegen_device_copy(
+                    args[0], self.output_view.codegen_reference(), args[1]
+                )
+            else:
+                wrapper.codegen_device_copy(args[0], self.codegen_reference(), args[1])
         if isinstance(self.layout, Layout) and self.layout.is_pinned:
             wrapper.sync_d2h_copy(self.get_name())
 


### PR DESCRIPTION
Summary:

When `autotune_at_compile_time=True` (the default for AOT compilation),
the single-pass codegen flow goes directly from C++ wrapper generation
to .so compilation, skipping `compile_to_module()` entirely. This means
no Python compiled module (.py) is written to PyCodeCache — unlike the
two-pass flow (`autotune_at_compile_time=False`) which generates the .py
as a functional intermediate.

The Python compiled module is valuable for debugging and profiling: it
contains all Triton kernel definitions with their source code, the
`call()` function showing the full execution graph, and
`benchmark_compiled_module()` for standalone benchmarking. Crucially,
the kernel names in the .py (e.g., `triton_poi_fused_add_0`) can be
correlated with kernel names in Kineto traces to map profiling data
back to specific Triton kernel source code.

This diff adds a `dump_python_module` config flag (env var:
`TORCHINDUCTOR_DUMP_PYTHON_MODULE=1`) that, when enabled in single-pass
AOT mode, performs an extra codegen pass with `cpp_wrapper=False` to
generate and write the Python module before proceeding with the normal
C++ codegen.

**Kernel name parity.** For the .py kernel names to match the Kineto
trace, the dump pass must produce the same scheduler node ordering as
the real C++ pass. Two mechanisms ensure this:

1. The dump's `Scheduler.__init__` calls `finalize_multi_template_buffers`,
   which may mutate the shared `operations` list via
   `_replace_operation_buffer` (replacing `MultiTemplateBuffer` nodes with
   `ExternKernelOut` for extern kernel winners). Without protection, these
   mutations leak into the subsequent real C++ pass, causing its scheduler
   to see different operations and produce different kernel names. The fix
   snapshots `operations`, `buffers`, `name_to_buffer`, and `name_to_op`
   before creating the dump scheduler and restores them afterward.

2. When `use_runtime_constant_folding=True`, `init_wrapper_code()` shares
   the `const_module`'s `_names_iter` counter by reference with the main
   wrapper. The dump pass saves and restores this iterator position so
   both passes start kernel suffix numbering from the same point.

The extra pass also patches `autotune_at_compile_time=False` to avoid
redundant autotuning, and cleans up all modified state (removed_buffers,
removed_operations, inplaced_to_remove, precomputed_replacements,
metrics) before the real C++ codegen — matching the state cleanup
pattern of the existing two-pass flow.

Authored with Claude.

Test Plan:
- Added `test_dump_python_module` in test_aot_inductor.py that compiles
  a simple model with `autotune_at_compile_time=True`,
  `dump_python_module=True`, and `benchmark_kernel=True`, verifying the
  model produces correct output (catches state cleanup regressions).
- Manually verified on MI300 with a production recommendation model
  (model 1007387234, batch 512) that:
  - The .py is generated and "Compiled module path:" is printed
  - Kernel names in the .py match kernel names in the Kineto trace
    (328/328 triton kernels match after the operations snapshot/restore
    fix — previously 0/328 matched due to _replace_operation_buffer
    state leakage)
  - The benchmark runs to completion with correct results
  - Testing with additional models in progress

Differential Revision: D97504969


