### PR TITLE
Fix flaky reentrant backward test by passing explicit grad for non-scalar output

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12571,7 +12571,7 @@ class TestAutogradDeviceType(TestCase):
             @staticmethod
             def backward(ctx, grad):
                 # Reentrant backward in child will take much longer.
-                reentrant_root.backward()
+                reentrant_root.backward(grad)
                 return grad
 
         # Parent gpu graph.


### PR DESCRIPTION
Fixes #179703

More detailed description of the problem is in the issue #179703 

## What this PR changes

In `test/test_autograd.py`, `_test_reentrant_parent_error_on_cpu` [(THIS LINE)](https://github.com/pytorch/pytorch/blob/3b39608061aac9da750ad3954197400b191286c3/test/test_autograd.py#L12574) defines a reentrant autograd function whose backward currently does:

```python
reentrant_root.backward()
```

This PR changes it to:

```python
reentrant_root.backward(grad)
```

## Why this solution

`reentrant_root` is non-scalar (`[3, 3]`). For non-scalar outputs, `.backward()` requires an explicit gradient seed. Calling `.backward()` without that seed can raise:

`RuntimeError: grad can be implicitly created only for scalar outputs`

## Effect on test behavior

Before this change, the test had two competing error sources:

1. Intended error: `"Simulate error"` from `SimulateBackwardError`
2. Accidental error: non-scalar `.backward()` without explicit grad

Because execution order is nondeterministic, CI could intermittently fail when (2) happened first.

After this change, the accidental error source is removed. The test now consistently validates only the intended behavior.

