### PR TITLE
[dynamo] Add tp_repr slot: unified repr() dispatch via repr_impl

### DIFF
--- a/test/dynamo/test_repr_protocol.py
+++ b/test/dynamo/test_repr_protocol.py
@@ -1,0 +1,205 @@
+# Owner(s): ["module: dynamo"]
+
+"""Tests for tp_repr slot implementation in Dynamo.
+
+Tests that repr() and __repr__() are dispatched through the unified
+repr_impl / generic_repr path, matching CPython's PyObject_Repr semantics.
+"""
+
+import collections
+import torch
+import torch._dynamo.testing
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class ReprProtocolTests(TestCase):
+    def test_repr_constant_int(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            val = 42
+            return x + len(repr(val))
+
+        x = torch.randn(2)
+        ref = x + len(repr(42))
+        self.assertEqual(fn(x), ref)
+
+    def test_repr_constant_string(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            val = "hello"
+            return x + len(repr(val))
+
+        x = torch.randn(2)
+        ref = x + len(repr("hello"))
+        self.assertEqual(fn(x), ref)
+
+    def test_repr_constant_none(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            val = None
+            return x + len(repr(val))
+
+        x = torch.randn(2)
+        ref = x + len(repr(None))
+        self.assertEqual(fn(x), ref)
+
+    def test_repr_constant_bool(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            val = True
+            return x + len(repr(val))
+
+        x = torch.randn(2)
+        ref = x + len(repr(True))
+        self.assertEqual(fn(x), ref)
+
+    def test_repr_user_defined_object_custom_repr(self):
+        class Config:
+            def __repr__(self):
+                return "Config()"
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x, config):
+            return x * len(repr(config))
+
+        config = Config()
+        x = torch.randn(2, 2)
+        ref = x * len(repr(config))
+        self.assertEqual(fn(x, config), ref)
+
+    def test_repr_user_defined_object_default_repr(self):
+        class Obj:
+            pass
+
+        obj = Obj()
+
+        @torch.compile(backend="eager")
+        def fn(x, o):
+            r = repr(o)
+            return x + len(r)
+
+        x = torch.randn(2)
+        fn(x, obj)
+
+    def test_repr_exception_no_args(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(t):
+            try:
+                raise ValueError
+            except ValueError as e:
+                return t.sin(), repr(e)
+
+        t = torch.randn(2)
+        y, r = fn(t)
+        self.assertEqual(y, t.sin())
+        self.assertEqual(r, "ValueError()")
+
+    def test_repr_exception_single_arg(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(t):
+            try:
+                raise ValueError("test error")
+            except ValueError as e:
+                return t.sin(), repr(e)
+
+        t = torch.randn(2)
+        y, r = fn(t)
+        self.assertEqual(y, t.sin())
+        self.assertEqual(r, "ValueError('test error')")
+
+    def test_repr_exception_multi_args(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(t):
+            try:
+                raise ValueError("hello", 42)
+            except ValueError as e:
+                return t.sin(), repr(e)
+
+        t = torch.randn(2)
+        y, r = fn(t)
+        self.assertEqual(y, t.sin())
+        self.assertEqual(r, "ValueError('hello', 42)")
+
+    def test_repr_range(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            r = range(1, 10, 2)
+            return x + len(repr(r))
+
+        x = torch.randn(2)
+        ref = x + len(repr(range(1, 10, 2)))
+        self.assertEqual(fn(x), ref)
+
+    def test_repr_dict(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            d = {"a": 1, "b": 2}
+            return x + len(repr(d))
+
+        x = torch.randn(2)
+        fn(x)
+
+    def test_repr_dict_view_keys(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            d = {"a": 1, "b": 2}
+            keys = d.keys()
+            r = repr(keys)
+            return x + len(r)
+
+        x = torch.randn(2)
+        fn(x)
+
+    def test_repr_user_defined_class(self):
+        class MyClass:
+            pass
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            r = repr(MyClass)
+            return x + len(r)
+
+        x = torch.randn(2)
+        fn(x)
+
+    def test_repr_dunder_method(self):
+        """Test that obj.__repr__() routes through the same path as repr(obj)."""
+
+        class Config:
+            def __repr__(self):
+                return "Config(x=1)"
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x, config):
+            return x * len(config.__repr__())
+
+        config = Config()
+        x = torch.randn(2, 2)
+        ref = x * len(config.__repr__())
+        self.assertEqual(fn(x, config), ref)
+
+    def test_repr_defaultdict(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            d = collections.defaultdict(list)
+            d["a"].append(1)
+            return x + len(repr(d))
+
+        x = torch.randn(2)
+        fn(x)
+
+    def test_repr_returns_string(self):
+        """CPython raises TypeError if __repr__ returns non-string."""
+
+        class BadRepr:
+            def __repr__(self):
+                return 42  # type: ignore[return-value]
+
+        obj = BadRepr()
+        # CPython itself would raise TypeError here
+        with self.assertRaises(TypeError):
+            repr(obj)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -589,6 +589,10 @@ class VariableTracker(metaclass=VariableTrackerMeta):
             from .object_protocol import generic_len
 
             return generic_len(tx, self)
+        elif name == "__repr__" and not (args or kwargs):
+            from .object_protocol import generic_repr
+
+            return generic_repr(tx, self)
         elif (
             name == "__getattr__"
             and len(args) == 1
@@ -955,6 +959,20 @@ class VariableTracker(metaclass=VariableTrackerMeta):
                 f"'{self.python_type_name()}' object cannot be interpreted as an integer"
             ],
         )
+
+    def repr_impl(
+        self,
+        tx: Any,
+    ) -> "VariableTracker":
+        """Mirrors CPython's tp_repr slot.
+
+        https://github.com/python/cpython/blob/v3.13.3/Objects/object.c#L734-L779
+
+        Subclasses override to provide repr() for their type. The base
+        implementation signals that this VT does not implement repr, which
+        causes generic_repr to fall through to unimplemented.
+        """
+        return None  # type: ignore[return-value]
 
     def __init__(
         self,

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1668,57 +1668,14 @@ class BuiltinVariable(BaseBuiltinVariable):
         return None
 
     def call_repr(
-        self, tx: "InstructionTranslator", arg: VariableTracker
+        self,
+        tx: "InstructionTranslator",
+        arg: VariableTracker,
     ) -> VariableTracker | None:
-        """Handle repr() on user defined objects."""
-        if isinstance(
-            arg,
-            (variables.ExceptionVariable, variables.UserDefinedExceptionObjectVariable),
-        ):
-            try:
-                const_args = tuple(a.as_python_constant() for a in arg.args)
-            except NotImplementedError:
-                return None
-            if len(const_args) == 0:
-                value = f"{arg.exc_type.__name__}()"
-            elif len(const_args) == 1:
-                value = f"{arg.exc_type.__name__}({const_args[0]!r})"
-            else:
-                value = f"{arg.exc_type.__name__}{const_args!r}"
-            return VariableTracker.build(tx, value)
-        if isinstance(arg, variables.UserDefinedObjectVariable):
-            repr_method = arg.value.__repr__
+        # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/object.c#L734-L779
+        from .object_protocol import generic_repr
 
-            if type(arg.value).__repr__ is object.__repr__:
-                # Default repr - build and trace it
-                fn_vt = VariableTracker.build(tx, repr_method)
-                return fn_vt.call_function(tx, [], {})
-            elif is_wrapper_or_member_descriptor(repr_method):
-                unimplemented(
-                    gb_type="Attempted to call repr() method implemented in C/C++",
-                    context="",
-                    explanation=f"{type(arg.value)} has a C/C++ based repr method. This is not supported.",
-                    hints=["Write the repr method in Python"],
-                )
-            else:
-                bound_method = repr_method.__func__
-                fn_vt = VariableTracker.build(tx, bound_method)
-                return fn_vt.call_function(tx, [arg], {})
-        if isinstance(arg, variables.UserDefinedClassVariable):
-            if type(arg.value).__repr__ is type.__repr__:
-                return VariableTracker.build(tx, repr(arg.value))
-        if isinstance(
-            arg,
-            (
-                RangeVariable,
-                ConstDictVariable,
-                DefaultDictVariable,
-                OrderedSetClassVariable,
-                DictViewVariable,
-            ),
-        ):
-            return VariableTracker.build(tx, arg.debug_repr())
-        return None
+        return generic_repr(tx, arg)
 
     def call_str(
         self, tx: "InstructionTranslator", arg: VariableTracker

--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -124,6 +124,11 @@ its type to `common_constant_types`.
     def __repr__(self) -> str:
         return f"ConstantVariable({type(self.value).__name__}: {repr(self.value)})"
 
+    def repr_impl(
+        self, tx: "InstructionTranslator"
+    ) -> "VariableTracker | None":
+        return ConstantVariable.create(repr(self.value))
+
     def as_python_constant(self) -> Any:
         return self.value
 

--- a/torch/_dynamo/variables/dicts.py
+++ b/torch/_dynamo/variables/dicts.py
@@ -297,6 +297,11 @@ class ConstDictVariable(VariableTracker):
     def as_proxy(self) -> dict[Any, Any]:
         return {k.vt.as_proxy(): v.as_proxy() for k, v in self.items.items()}
 
+    def repr_impl(
+        self, tx: "InstructionTranslator"
+    ) -> "VariableTracker | None":
+        return VariableTracker.build(tx, self.debug_repr())
+
     def debug_repr(self) -> str:
         items: list[str] = []
         for k, v in self.items.items():
@@ -1631,6 +1636,11 @@ class OrderedSetClassVariable(VariableTracker):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
+    def repr_impl(
+        self, tx: "InstructionTranslator"
+    ) -> "VariableTracker | None":
+        return VariableTracker.build(tx, self.debug_repr())
+
     def as_python_constant(self) -> type[OrderedSet[Any]]:
         return OrderedSet
 
@@ -1905,6 +1915,11 @@ class DictViewVariable(VariableTracker):
             return CONSTANT_VARIABLE_TRUE
         return CONSTANT_VARIABLE_FALSE
 
+    def repr_impl(
+        self, tx: "InstructionTranslator"
+    ) -> "VariableTracker | None":
+        return VariableTracker.build(tx, self.debug_repr())
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -1918,8 +1933,6 @@ class DictViewVariable(VariableTracker):
             return ListIteratorVariable(
                 self.view_items_vt, mutation_type=ValueMutationNew()
             )
-        elif name == "__repr__":
-            return VariableTracker.build(tx, self.debug_repr())
         return super().call_method(tx, name, args, kwargs)
 
     def sq_length(self, tx: "InstructionTranslator") -> VariableTracker:

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -464,6 +464,11 @@ class RangeVariable(BaseListVariable):
         assert stop is not None
         super().__init__([start, stop, step], **kwargs)
 
+    def repr_impl(
+        self, tx: "InstructionTranslator"
+    ) -> "VariableTracker | None":
+        return VariableTracker.build(tx, self.debug_repr())
+
     def debug_repr(self) -> str:
         repr = f"range({self.start()}, {self.stop()}"
         if self.step() != 1:

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -687,6 +687,22 @@ class ExceptionVariable(VariableTracker):
             )
         return super().var_getattr(tx, name)
 
+    def repr_impl(
+        self, tx: "InstructionTranslator"
+    ) -> VariableTracker | None:
+        # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/exceptions.c#L230-L250
+        try:
+            const_args = tuple(a.as_python_constant() for a in self.args)
+        except NotImplementedError:
+            return None
+        if len(const_args) == 0:
+            value = f"{self.exc_type.__name__}()"
+        elif len(const_args) == 1:
+            value = f"{self.exc_type.__name__}({const_args[0]!r})"
+        else:
+            value = f"{self.exc_type.__name__}{const_args!r}"
+        return VariableTracker.build(tx, value)
+
     def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.exc_type})"
 

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -2,8 +2,8 @@
 Dynamo implementations of CPython's PyObject_* default slot algorithms.
 
 Analogous to CPython's Objects/object.c, this module holds the general
-comparison dispatch machinery that is independent of any specific type.
-Per-type richcompare_impl hooks live in their respective VT files.
+dispatch machinery that is independent of any specific type.
+Per-type tp_slot hooks (repr_impl, etc.) live in their respective VT files.
 """
 
 from functools import lru_cache
@@ -136,3 +136,31 @@ def generic_len(
     if type_implements_sq_length(T):
         return obj.sq_length(tx)
     return vt_mapping_size(tx, obj)
+
+
+def generic_repr(
+    tx: "InstructionTranslator", obj: "VariableTracker"
+) -> "VariableTracker":
+    # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/object.c#L734-L779
+    """
+    Implements PyObject_Repr semantics for VariableTracker objects.
+
+    Dispatches to obj.repr_impl(tx). If the VT does not implement repr_impl
+    (returns None), falls through to unimplemented to trigger a graph break.
+
+    CPython checks tp_repr != NULL; if NULL it returns a default
+    "<%s object at %p>" string. In Dynamo, VTs that don't override repr_impl
+    cause a graph break since we cannot produce a meaningful repr at trace time.
+    """
+    result = obj.repr_impl(tx)
+    if result is not None:
+        return result
+
+    unimplemented(
+        gb_type="Unsupported repr() call",
+        context=f"repr({obj})",
+        explanation=f"Dynamo does not know how to trace repr() on {obj.python_type_name()}",
+        hints=[
+            *graph_break_hints.SUPPORTABLE,
+        ],
+    )

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -219,6 +219,14 @@ class UserDefinedClassVariable(UserDefinedVariable):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.value})"
 
+    def repr_impl(
+        self, tx: "InstructionTranslator"
+    ) -> "VariableTracker | None":
+        # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/typeobject.c#L1382-L1407
+        if type(self.value).__repr__ is type.__repr__:
+            return VariableTracker.build(tx, repr(self.value))
+        return None
+
     @staticmethod
     @functools.cache
     def _constant_fold_classes() -> set[type[object]]:
@@ -1335,6 +1343,27 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.value_type.__name__})"
+
+    def repr_impl(
+        self, tx: "InstructionTranslator"
+    ) -> "VariableTracker | None":
+        # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/object.c#L734-L779
+        repr_method = self.value.__repr__
+
+        if type(self.value).__repr__ is object.__repr__:
+            fn_vt = VariableTracker.build(tx, repr_method)
+            return fn_vt.call_function(tx, [], {})
+        elif is_wrapper_or_member_descriptor(repr_method):
+            unimplemented(
+                gb_type="Attempted to call repr() method implemented in C/C++",
+                context="",
+                explanation=f"{type(self.value)} has a C/C++ based repr method. This is not supported.",
+                hints=["Write the repr method in Python"],
+            )
+        else:
+            bound_method = repr_method.__func__
+            fn_vt = VariableTracker.build(tx, bound_method)
+            return fn_vt.call_function(tx, [self], {})
 
     def get_dict_vt(self, tx: "InstructionTranslator") -> "DunderDictVariable":
         if self.dict_vt is None:
@@ -2737,6 +2766,11 @@ class UserDefinedExceptionObjectVariable(UserDefinedObjectVariable):
     @property
     def python_stack(self) -> traceback.StackSummary | None:
         return self.exc_vt.python_stack
+
+    def repr_impl(
+        self, tx: "InstructionTranslator"
+    ) -> "VariableTracker | None":
+        return self.exc_vt.repr_impl(tx)
 
     def debug_repr(self) -> str:
         return self.exc_vt.debug_repr()


### PR DESCRIPTION
## Summary

Refactor repr() handling to follow the tp_slot pattern established by `generic_len`/`sq_length` and `nb_index_impl`, as part of the broader effort to bridge the CPython-Dynamo gap design doc
This moves repr logic out of `BuiltinVariable.call_repr`'s isinstance cascade and into per-VT `repr_impl` methods, with a `generic_repr` dispatcher in `object_protocol.py` mirroring CPython's [`PyObject_Repr`](https://github.com/python/cpython/blob/v3.13.3/Objects/object.c#L734-L779).



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @anijain2305
