### PR TITLE
[ROCm][Windows] Fix Windows DLL linkage for batch norm (`-Winconsistent-dllimport`)

### DIFF
--- a/aten/src/ATen/native/cudnn/BatchNorm.h
+++ b/aten/src/ATen/native/cudnn/BatchNorm.h
@@ -1,6 +1,6 @@
 namespace at::native {
 
-TORCH_API size_t
+TORCH_CUDA_CU_API size_t
 _get_cudnn_batch_norm_reserve_space_size(const Tensor& input_t, bool training);
 
 } // namespace at::native


### PR DESCRIPTION
Fixes `warning: 'at::native::_get_cudnn_batch_norm_reserve_space_size' redeclared without 'dllimport' attribute: 'dllexport' attribute added [-Winconsistent-dllimport]`.

Fix: `aten/src/ATen/native/cudnn/BatchNorm.h`: change the forward declaration from `TORCH_API` to `TORCH_CUDA_CU_API` for `_get_cudnn_batch_norm_reserve_space_size`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang