### PR TITLE
[pytorch][inductor] Add _print_NaN to sympy expression printers (#179708)

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -368,6 +368,29 @@ class ExprPrinterTests(InductorTestCase):
             texpr(expr), """libdevice.llrint((1/2)*x).to(tl.int64)"""
         )
 
+    def test_print_nan(self):
+        expr = sympy.nan
+        self.assertExpectedInline(pexpr(expr), """math.nan""")
+        self.assertExpectedInline(
+            cexpr(expr), """std::numeric_limits<double>::quiet_NaN()"""
+        )
+
+    def test_print_infinity(self):
+        expr = sympy.oo
+        self.assertExpectedInline(pexpr(expr), """math.inf""")
+        self.assertExpectedInline(
+            cexpr(expr),
+            """std::numeric_limits<double>::infinity()""",
+        )
+
+    def test_print_negative_infinity(self):
+        expr = -sympy.oo
+        self.assertExpectedInline(pexpr(expr), """-math.inf""")
+        self.assertExpectedInline(
+            cexpr(expr),
+            """-std::numeric_limits<double>::infinity()""",
+        )
+
     def test_print_integer(self):
         expr = sympy.S((-1) << 63)
         self.assertExpectedInline(cexpr(expr), f"""(-1{LONG_SUFFIX} << 63)""")

--- a/torch/utils/_sympy/printers.py
+++ b/torch/utils/_sympy/printers.py
@@ -97,6 +97,9 @@ class ExprPrinter(StrPrinter):
             f"_print_NegativeInfinity not implemented for {type(self)}"
         )
 
+    def _print_NaN(self, expr: sympy.Expr) -> str:
+        raise NotImplementedError(f"_print_NaN not implemented for {type(self)}")
+
     def _print_FloorDiv(self, expr: sympy.Expr) -> str:
         raise NotImplementedError(f"_print_FloorDiv not implemented for {type(self)}")
 
@@ -175,6 +178,9 @@ class PythonPrinter(ExprPrinter):
 
     def _print_NegativeInfinity(self, expr: sympy.Expr) -> str:
         return "-math.inf"
+
+    def _print_NaN(self, expr: sympy.Expr) -> str:
+        return "math.nan"
 
     # WARNING: this is dangerous for Triton, which has C-style modulus
     def _print_PythonMod(self, expr: sympy.Expr) -> str:
@@ -655,3 +661,6 @@ class CppPrinter(ExprPrinter):
 
     def _print_NegativeInfinity(self, expr: sympy.Expr) -> str:
         return f"-{self._print_Infinity(expr)}"
+
+    def _print_NaN(self, expr: sympy.Expr) -> str:
+        return "std::numeric_limits<double>::quiet_NaN()"


### PR DESCRIPTION
Summary:

When sympy expressions contain `sympy.nan` (e.g., in guard code for
comparison ops with NaN inputs), the default sympy printer emits bare
`nan`, which is not defined in the generated Python or C++ code. This
causes `NameError: name 'nan' is not defined` at runtime.

This mirrors the existing `_print_Infinity` and `_print_NegativeInfinity`
overrides that were already in place:

- `ExprPrinter`: raises `NotImplementedError` (safety net for subclasses)
- `PythonPrinter`: returns `"math.nan"`
- `CppPrinter`: returns `"std::numeric_limits<double>::quiet_NaN()"`

Also adds unit tests for NaN, Infinity, and NegativeInfinity printing.

Fixes 120 opinfo e2e test failures (20 per op) across 6 comparison ops:
eq, ge, gt, le, lt, ne — all test cases involving NaN inputs.

Test Plan:
- `buck test //caffe2/test/inductor:test_indexing -- ExprPrinterTests` — all 17 tests pass (14 existing + 3 new)
- e2e: `opinfo-test "eq; 2; 0; tensor, i8x23; float, nan"` — verifies NaN guard code generation works end-to-end

Differential Revision: D99380088


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo