### PR TITLE
Enable test_transform_bias_rescale_qkv_nested_xpu_float32 test

### DIFF
--- a/test/test_native_mha.py
+++ b/test/test_native_mha.py
@@ -106,7 +106,6 @@ class TestMHADeviceType(TestCase):
     @dtypesIfXPU(torch.float)
     @dtypes(torch.float)
     @skipMeta
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/2182")
     @onlyOn(["cuda", "xpu"])
     def test_transform_bias_rescale_qkv_nested(self, device, dtype):
         for use_padding in (False, True):


### PR DESCRIPTION
This test passes on latest software versions on
XPU device.

Fixes: https://github.com/intel/torch-xpu-ops/issues/2182