### PR TITLE
Fix ConvTranspose3d complex half accuracy by promoting 3D transposed complex convolution to double

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -906,16 +906,6 @@ at::Tensor complex_convolution(
     bool transposed,
     SymIntArrayRef output_padding,
     const c10::SymInt& groups) {
-  if (transposed && input.ndimension() == 5 &&
-      input.scalar_type() == at::kComplexHalf) {
-    auto bias_cf64 = bias.defined() ? bias.to(at::kComplexDouble) : bias;
-    return complex_convolution(
-        input.to(at::kComplexDouble),
-        weight.to(at::kComplexDouble),
-        bias_cf64,
-        stride, padding, dilation, transposed, output_padding, groups)
-        .to(at::kComplexHalf);
-  }
   check_input_same_type_as_parameters(input, weight, bias);
   auto [i_r, i_i] = complex_to_real(input.resolve_conj());
   auto [w_r, w_i] = complex_to_real(weight.resolve_conj());
@@ -1219,7 +1209,15 @@ at::Tensor conv_transpose3d_symint(
 
   auto [input, is_batched] = batchify(input_, /*num_spatial_dims=*/ 3, "conv_transpose3d");
   Tensor output;
-  if (at::isComplexType(input_.scalar_type())) {
+  if (input_.scalar_type() == at::kComplexHalf) {
+    auto bias_cf64 = bias.defined() ? bias.to(at::kComplexDouble) : bias;
+    output = complex_convolution(
+        input.to(at::kComplexDouble),
+        weight.to(at::kComplexDouble),
+        bias_cf64,
+        stride, padding, dilation, true, output_padding, groups)
+        .to(at::kComplexHalf);
+  } else if (at::isComplexType(input_.scalar_type())) {
     output = complex_convolution(
       input, weight, bias, stride, padding, dilation, true, output_padding, groups);
   } else {

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -906,6 +906,16 @@ at::Tensor complex_convolution(
     bool transposed,
     SymIntArrayRef output_padding,
     const c10::SymInt& groups) {
+  if (transposed && input.ndimension() == 5 &&
+      input.scalar_type() == at::kComplexHalf) {
+    auto bias_cf64 = bias.defined() ? bias.to(at::kComplexDouble) : bias;
+    return complex_convolution(
+        input.to(at::kComplexDouble),
+        weight.to(at::kComplexDouble),
+        bias_cf64,
+        stride, padding, dilation, transposed, output_padding, groups)
+        .to(at::kComplexHalf);
+  }
   check_input_same_type_as_parameters(input, weight, bias);
   auto [i_r, i_i] = complex_to_real(input.resolve_conj());
   auto [w_r, w_i] = complex_to_real(weight.resolve_conj());

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3996,8 +3996,6 @@ module_db: list[ModuleInfo] = [
                    # Not implemented for chalf on CPU
                    DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
                                 dtypes=(torch.chalf,), device_type='cuda'),
-                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
-                                dtypes=(torch.chalf,), device_type='xpu'),
                ),
                decorators=(
                    DecorateInfo(precisionOverride({torch.float32: 1e-04}), 'TestModule', 'test_memory_format'),


### PR DESCRIPTION
Fixes: https://github.com/intel/torch-xpu-ops/issues/3030
This PR improves ConvTranspose3d accuracy for complex half inputs by promoting the 3D transposed complex convolution path to complex double and casting the result back to complex half. This fixes the accuracy issue observed in the XPU parity test.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01