### PR TITLE
Add __all__ to torch.amp to explicitly declare public API

### DIFF
--- a/torch/amp/__init__.py
+++ b/torch/amp/__init__.py
@@ -7,3 +7,13 @@ from .autocast_mode import (
     is_autocast_available,
 )
 from .grad_scaler import GradScaler
+
+__all__ = [
+    "_enter_autocast",
+    "_exit_autocast",
+    "autocast",
+    "custom_bwd",
+    "custom_fwd",
+    "is_autocast_available",
+    "GradScaler",
+]


### PR DESCRIPTION
### 🚀 The feature, motivation and pitch

This PR adds an explicit `__all__` attribute to `torch/amp/__init__.py` to clearly declare the module's public API. Currently, the module imports several names from submodules (`_enter_autocast`, `_exit_autocast`, `autocast`, `custom_bwd`, `custom_fwd`, `is_autocast_available`, `GradScaler`) but does not declare them in `__all__`.

According to PEP 8, modules should explicitly declare their public API using the `__all__` attribute to better support introspection. Adding `__all__` also helps static type checkers like pyright and pylance correctly recognize these names as publicly exported symbols, preventing false-positive "not exported" warnings.

This is a code quality improvement only and has no user-facing impact.

### 📝 Changes

Added `__all__` to `torch/amp/__init__.py`:

```python
__all__ = [
    "_enter_autocast",
    "_exit_autocast",
    "autocast",
    "custom_bwd",
    "custom_fwd",
    "is_autocast_available",
    "GradScaler",
]
```

### ✅ Verification

- Verified that `from torch.amp import *` correctly imports only the symbols listed in `__all__`.
- Verified that static type checkers (pyright) no longer report "not exported" warnings for these symbols.
- The change follows the same pattern as previously accepted PRs: #108630 and #78553.

### 📋 Additional context

Related PRs for reference:
- #108630: Added `__all__` to `torch.cuda.amp` modules
- #78553: Added `__all__` to `torch.profiler`

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5