### PR TITLE
[pyrefly] Add type annotations to torch/fx proxy, interpreter, symbol…

### DIFF
--- a/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
@@ -1,4 +1,4 @@
-torch.fx._symbolic_trace.Tracer.__init__(self, autowrap_modules: Tuple[Callable] = (<module math>,), autowrap_functions: Tuple[Callable, ...] = (,), param_shapes_constant: bool = False) -> None
+torch.fx._symbolic_trace.Tracer.__init__(self, autowrap_modules: Tuple[Callable] = (<module math>,), autowrap_functions: Tuple[Callable[..., Any], ...] = (,), param_shapes_constant: bool = False) -> None
 torch.fx._symbolic_trace.Tracer.call_module(self, m: torch.nn.modules.module.Module, forward: Callable[..., Any], args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> Any
 torch.fx._symbolic_trace.Tracer.create_arg(self, a: Any) -> 'Argument'
 torch.fx._symbolic_trace.Tracer.get_fresh_qualname(self, prefix: str) -> str
@@ -6,7 +6,7 @@ torch.fx._symbolic_trace.Tracer.is_leaf_module(self, m: torch.nn.modules.module.
 torch.fx._symbolic_trace.Tracer.path_of_module(self, mod: torch.nn.modules.module.Module) -> str
 torch.fx._symbolic_trace.Tracer.trace(self, root: Union[torch.nn.modules.module.Module, Callable[..., Any]], concrete_args: Optional[Dict[str, Any]] = None) -> torch.fx.graph.Graph
 torch.fx._symbolic_trace.symbolic_trace(root: Union[torch.nn.modules.module.Module, Callable[..., Any]], concrete_args: Optional[Dict[str, Any]] = None) -> torch.fx.graph_module.GraphModule
-torch.fx._symbolic_trace.wrap(fn_or_name: Union[str, Callable])
+torch.fx._symbolic_trace.wrap(fn_or_name: torch.fx.node.Target) -> torch.fx.node.Target
 torch.fx.graph.Graph.__init__(self, owning_module: Optional[GraphModule] = None, tracer_cls: Optional[Type[Tracer]] = None, tracer_extras: Optional[Dict[str, Any]] = None)
 torch.fx.graph.Graph.call_function(self, the_function: Callable[..., Any], args: Optional[Tuple[Argument, ...]] = None, kwargs: Optional[Dict[str, Argument]] = None, type_expr: Optional[Any] = None, name: Optional[str] = None) -> torch.fx.node.Node
 torch.fx.graph.Graph.call_method(self, method_name: str, args: Optional[Tuple[Argument, ...]] = None, kwargs: Optional[Dict[str, Argument]] = None, type_expr: Optional[Any] = None) -> torch.fx.node.Node
@@ -31,20 +31,20 @@ torch.fx.graph_module.GraphModule.delete_submodule(self, target: str) -> bool
 torch.fx.graph_module.GraphModule.recompile(self) -> torch.fx.graph.PythonCode
 torch.fx.graph_module.reduce_graph_module(body: Dict[Any, Any], import_block: str) -> torch.nn.modules.module.Module
 torch.fx.graph_module.reduce_package_graph_module(importer: Callable, body: Dict[Any, Any], generated_module_name: str) -> torch.nn.modules.module.Module
-torch.fx.interpreter.Interpreter.__init__(self, module: torch.nn.modules.module.Module, garbage_collect_values: bool = True, graph: Optional[torch.fx.graph.Graph] = None)
-torch.fx.interpreter.Interpreter.boxed_run(self, args_list)
+torch.fx.interpreter.Interpreter.__init__(self, module: torch.nn.modules.module.Module, garbage_collect_values: bool = True, graph: Optional[torch.fx.graph.Graph] = None) -> None
+torch.fx.interpreter.Interpreter.boxed_run(self, args_list: List[Any]) -> Any
 torch.fx.interpreter.Interpreter.call_function(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any
 torch.fx.interpreter.Interpreter.call_method(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any
 torch.fx.interpreter.Interpreter.call_module(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any
-torch.fx.interpreter.Interpreter.fetch_args_kwargs_from_env(self, n: torch.fx.node.Node) -> Tuple[Tuple, Dict]
-torch.fx.interpreter.Interpreter.fetch_attr(self, target: str)
+torch.fx.interpreter.Interpreter.fetch_args_kwargs_from_env(self, n: torch.fx.node.Node) -> Tuple[Tuple[Any, ...], Dict[str, Any]]
+torch.fx.interpreter.Interpreter.fetch_attr(self, target: str) -> Any
 torch.fx.interpreter.Interpreter.get_attr(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any
 torch.fx.interpreter.Interpreter.map_nodes_to_values(self, args: torch.fx.node.Argument, n: torch.fx.node.Node) -> torch.fx.node.Argument
 torch.fx.interpreter.Interpreter.output(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any
 torch.fx.interpreter.Interpreter.placeholder(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any
-torch.fx.interpreter.Interpreter.run(self, *args, initial_env: Optional[Dict[torch.fx.node.Node, Any]] = None, enable_io_processing: bool = True) -> Any
+torch.fx.interpreter.Interpreter.run(self, *args: Any, initial_env: Optional[Dict[torch.fx.node.Node, Any]] = None, enable_io_processing: bool = True) -> Any
 torch.fx.interpreter.Interpreter.run_node(self, n: torch.fx.node.Node) -> Any
-torch.fx.interpreter.Transformer.__init__(self, module)
+torch.fx.interpreter.Transformer.__init__(self, module: torch.fx.graph_module.GraphModule) -> None
 torch.fx.interpreter.Transformer.call_function(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any
 torch.fx.interpreter.Transformer.call_module(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any
 torch.fx.interpreter.Transformer.get_attr(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> torch.fx.proxy.Proxy
@@ -64,14 +64,14 @@ torch.fx.node.map_arg(a: torch.fx.node.Argument, fn: Callable[[torch.fx.node.Nod
 torch.fx.passes.reinplace.reinplace(gm, *sample_args)
 torch.fx.passes.runtime_assert.insert_deferred_runtime_asserts(gm: torch.fx.graph_module.GraphModule, shape_env: Any, name: str, export: bool = False) -> None
 torch.fx.passes.split_module.split_module(m: torch.fx.graph_module.GraphModule, root_m: torch.nn.modules.module.Module, split_callback: Callable[[torch.fx.node.Node], int], qualname_map: Optional[Dict[str, str]] = None, keep_original_order: Optional[bool] = False, keep_original_node_name: Optional[bool] = False, keep_original_input_name: bool = True, partition_affix: Optional[str] = None, tuple_return: bool = False)
-torch.fx.proxy.Attribute.__init__(self, root: torch.fx.proxy.Proxy, attr: str)
-torch.fx.proxy.Proxy.__init__(self, node: torch.fx.node.Node, tracer: 'Optional[TracerBase]' = None)
-torch.fx.proxy.Proxy.keys(self)
+torch.fx.proxy.Attribute.__init__(self, root: torch.fx.proxy.Proxy, attr: str) -> None
+torch.fx.proxy.Proxy.__init__(self, node: torch.fx.node.Node, tracer: 'Optional[TracerBase]' = None) -> None
+torch.fx.proxy.Proxy.keys(self) -> 'Proxy'
 torch.fx.proxy.TracerBase.create_arg(self, a: Any) -> torch.fx.node.Argument
 torch.fx.proxy.TracerBase.create_node(self, kind: str, target: torch.fx.node.Target, args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, torch.fx.node.Argument], name: Optional[str] = None, type_expr: Optional[Any] = None) -> torch.fx.node.Node
-torch.fx.proxy.TracerBase.create_proxy(self, kind: str, target: torch.fx.node.Target, args: Tuple[Any, ...], kwargs: Dict[str, Any], name: Optional[str] = None, type_expr: Optional[Any] = None, proxy_factory_fn: Callable[[torch.fx.node.Node], Proxy] = None)
+torch.fx.proxy.TracerBase.create_proxy(self, kind: str, target: torch.fx.node.Target, args: Tuple[Any, ...], kwargs: Dict[str, Any], name: Optional[str] = None, type_expr: Optional[Any] = None, proxy_factory_fn: Optional[Callable[[torch.fx.node.Node], Proxy]] = None) -> 'Proxy'
 torch.fx.proxy.TracerBase.iter(self, obj: 'Proxy') -> Iterator
-torch.fx.proxy.TracerBase.keys(self, obj: 'Proxy') -> Any
+torch.fx.proxy.TracerBase.keys(self, obj: 'Proxy') -> 'Proxy'
 torch.fx.proxy.TracerBase.proxy(self, node: torch.fx.node.Node) -> 'Proxy'
 torch.fx.proxy.TracerBase.to_bool(self, obj: 'Proxy') -> bool
 torch.fx.subgraph_rewriter.replace_pattern(gm: torch.fx.graph_module.GraphModule, pattern: Union[Callable[..., Any], torch.fx.graph_module.GraphModule], replacement: Union[Callable[..., Any], torch.fx.graph_module.GraphModule]) -> List[torch.fx.subgraph_rewriter.Match]

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2649,9 +2649,11 @@ class OutputGraph(OutputGraphCommon):
                 )
 
             if self.package is not None:
-                gm._backend_id = name
+                gm._backend_id = name  # pyrefly: ignore[bad-argument-type]
 
+            # pyrefly: ignore[bad-argument-type]
             gm.compile_subgraph_reason = self.compile_subgraph_reason
+            # pyrefly: ignore[bad-argument-type]
             gm.meta["dynamo_flat_name_to_original_fqn"] = (
                 self.dynamo_flat_name_to_original_fqn.copy()
             )

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -1029,7 +1029,7 @@ backend_aot_accuracy_fails = functools.partial(backend_accuracy_fails, only_fwd=
 
 def repro_common(
     options: Any, mod: nn.Module, load_args: Any
-) -> tuple[torch.fx.GraphModule, Sequence[Any]]:
+) -> tuple[torch.fx.GraphModule, list[Any]]:
     # Invariant for graphs we generate with the repro script
     assert not any(mod.named_parameters())
     for n, b in mod.named_buffers():
@@ -1278,7 +1278,7 @@ def repro_get_args(
     options: Any, mod: nn.Module, load_args: Any
 ) -> tuple[torch.fx.GraphModule, list[Any]]:
     mod, args = repro_common(options, mod, load_args)
-    return mod, args  # type: ignore[return-value]
+    return mod, args
 
 
 def repro_run(options: Any, mod: nn.Module, load_args: Any) -> None:

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1293,7 +1293,7 @@ def aot_module_simplified(
 def boxed_nop_preserve_node_meta(
     gm: torch.fx.GraphModule, example_inputs: Sequence[InputType]
 ) -> Any:
-    def run(args: Sequence[Any]) -> OutputCode:
+    def run(args: list[Any]) -> OutputCode:
         with torch.fx.traceback.preserve_node_meta():
             return torch.fx.Interpreter(gm).boxed_run(args)
 

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -533,7 +533,12 @@ class LoopBodyBlock:
         from .index_propagation import IndexPropagation
 
         handler: Any = CountOps(
-            CaptureIndexing(proxy_ops, body, tracer),
+            CaptureIndexing(
+                # pyrefly: ignore[bad-argument-type]
+                proxy_ops,
+                body,
+                tracer,
+            ),
             body.op_counts,
         )
         if config.constant_and_index_propagation:

--- a/torch/_inductor/subgraph_lowering.py
+++ b/torch/_inductor/subgraph_lowering.py
@@ -5,7 +5,7 @@ import operator
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any, cast, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -14,7 +14,7 @@ from torch.utils._ordered_set import OrderedSet
 from . import ir
 from .exc import SubgraphLoweringException
 from .graph import GraphLowering
-from .ops_handler import SimpleCSEHandler
+from .ops_handler import OpsHandler, SimpleCSEHandler
 from .virtualized import ops, V, WrapperHandler
 
 
@@ -137,7 +137,7 @@ class InputDescriptor:
 class TracingOpsHandler(WrapperHandler):
     def __init__(self, tracer: torch.fx.Tracer, num_inputs: int) -> None:
         parent = tracer.create_proxy("placeholder", "ops", (), {})
-        super().__init__(parent)
+        super().__init__(cast(OpsHandler[Any], parent))
         self.tracer = tracer
 
         self.placeholders = [

--- a/torch/fx/_lazy_graph_module.py
+++ b/torch/fx/_lazy_graph_module.py
@@ -1,5 +1,6 @@
-# mypy: allow-untyped-defs
+from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any, TYPE_CHECKING
 
 from torch.fx.graph_module import (
     _format_import_block,
@@ -12,13 +13,17 @@ from torch.package import PackageExporter, sys_importer
 from ._compatibility import compatibility
 
 
+if TYPE_CHECKING:
+    from torch.fx.graph import PythonCode
+
+
 _use_lazy_graph_module_flag = False
 _force_skip_lazy_graph_module_flag = False
 
 
 @compatibility(is_backward_compatible=False)
 @contextmanager
-def _force_skip_lazy_graph_module():
+def _force_skip_lazy_graph_module() -> Iterator[None]:
     """
     Skip using lazy graph module disregarding the setting of _use_lazy_graph_module.
     Use to skip _LazyGraphModule when testing inductor torchscript related backend.
@@ -37,7 +42,7 @@ def _force_skip_lazy_graph_module():
 
 @compatibility(is_backward_compatible=False)
 @contextmanager
-def _use_lazy_graph_module(should_use: bool):
+def _use_lazy_graph_module(should_use: bool) -> Iterator[None]:
     try:
         global _use_lazy_graph_module_flag
         prior = _use_lazy_graph_module_flag
@@ -50,11 +55,13 @@ def _use_lazy_graph_module(should_use: bool):
 
 
 @compatibility(is_backward_compatible=False)
-def _get_graph_module_cls():
+def _get_graph_module_cls() -> type[GraphModule]:
     return _LazyGraphModule if _use_lazy_graph_module_flag else GraphModule
 
 
-def _make_graph_module(*args, graph_module_cls=None, **kwargs):
+def _make_graph_module(
+    *args: Any, graph_module_cls: type[GraphModule] | None = None, **kwargs: Any
+) -> GraphModule:
     if graph_module_cls is None:
         graph_module_cls = _get_graph_module_cls()
 
@@ -88,14 +95,14 @@ class _LazyGraphModule(GraphModule):
     """
 
     @classmethod
-    def from_graphmodule(cls, gm: GraphModule):
+    def from_graphmodule(cls, gm: GraphModule) -> GraphModule:
         if isinstance(gm, _LazyGraphModule):
             return gm
         else:
             return _LazyGraphModule(gm, gm.graph)
 
     @staticmethod
-    def force_recompile(gm):
+    def force_recompile(gm: GraphModule) -> None:
         """
         Sometimes we need force a recompile as a workaround
         - we want to do the real recompilation before symbolic_trace to avoid error:
@@ -104,15 +111,15 @@ class _LazyGraphModule(GraphModule):
         if isinstance(gm, _LazyGraphModule):
             gm.real_recompile()
 
-    def real_recompile(self):
+    def real_recompile(self) -> None:
         if self._needs_recompile():
             self._real_recompile()
 
     @classmethod
-    def _needs_recompile(cls):
+    def _needs_recompile(cls) -> bool:
         return cls.forward is cls._lazy_forward
 
-    def _lazy_forward(self, *args, **kwargs):
+    def _lazy_forward(self, *args: Any, **kwargs: Any) -> Any:
         # Call self.real_recompile() rather than self._real_recompile() here.
         # The _lazy_forward method may be saved and call repeatedly.
         # Calling self.real_recompile can make sure we skip recompilation if
@@ -128,7 +135,9 @@ class _LazyGraphModule(GraphModule):
 
     forward = _lazy_forward
 
-    def __reduce_package__(self, exporter: PackageExporter):
+    def __reduce_package__(
+        self, exporter: PackageExporter
+    ) -> tuple[Any, tuple[Any, str]]:
         """
         Follow GraphModule.__reduce__ but call 'self._real_recompile' rather
         than 'self.recompile' since for a _LazyGraphModule, self.recompile just
@@ -148,7 +157,7 @@ class _LazyGraphModule(GraphModule):
             (dict_without_graph, generated_module_name),
         )
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple[Any, tuple[Any, str]]:
         """
         Follow GraphModule.__reduce__ but call 'self._real_recompile' rather
         than 'self.recompile' since for a _LazyGraphModule, self.recompile just
@@ -160,11 +169,11 @@ class _LazyGraphModule(GraphModule):
         del dict_without_graph["_graph"]
         return (reduce_graph_module, (dict_without_graph, import_block))
 
-    def _real_recompile(self):
+    def _real_recompile(self) -> "PythonCode":
         return super().recompile()
 
     @classmethod
-    def recompile(cls):
+    def recompile(cls) -> None:  # pyrefly: ignore[bad-override]
         cls.forward = cls._lazy_forward
 
     @property

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import builtins
 import collections
 import contextlib
@@ -9,10 +8,10 @@ import logging
 import math
 import os
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Iterator
 from itertools import chain
-from types import CodeType, FunctionType, ModuleType
-from typing import Any, get_args, NamedTuple, TypeAlias
+from types import CodeType, FunctionType, ModuleType, TracebackType
+from typing import Any, get_args, NamedTuple, overload, ParamSpec, TypeAlias, TypeVar
 
 import torch
 import torch.utils._pytree as pytree
@@ -32,9 +31,13 @@ log = logging.getLogger(__name__)
 
 HAS_VARSTUFF = inspect.CO_VARARGS | inspect.CO_VARKEYWORDS
 
+_F = TypeVar("_F", bound=Callable[..., Any])
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+
 # These need to run in global scope to handle nested calls correctly
-_orig_module_call: Callable = torch.nn.Module.__call__
-_orig_module_getattr: Callable = torch.nn.Module.__getattr__
+_orig_module_call: Callable[..., Any] = torch.nn.Module.__call__
+_orig_module_getattr: Callable[..., Any] = torch.nn.Module.__getattr__
 
 _proxyable_classes: dict[type, None] = {}
 
@@ -49,7 +52,7 @@ _constant_attribute_types = get_args(_ConstantAttributeType)
 
 # We only want to print this once to avoid flooding logs
 @functools.lru_cache
-def is_fx_tracing_warning():
+def is_fx_tracing_warning() -> None:
     log.warning(
         "is_fx_tracing will return true for both fx.symbolic_trace and "
         "torch.export. Please use "
@@ -58,12 +61,12 @@ def is_fx_tracing_warning():
     )
 
 
-def is_fx_tracing():
+def is_fx_tracing() -> bool:
     is_fx_tracing_warning()
     return _is_fx_tracing_flag
 
 
-def is_fx_symbolic_tracing():
+def is_fx_symbolic_tracing() -> bool:
     return _is_fx_tracing_flag and not torch.compiler.is_compiling()
 
 
@@ -116,20 +119,22 @@ class ProxyableClassMeta(type):
     tracing.
     """
 
-    def __init__(cls, name, bases, attrs):
+    def __init__(
+        cls, name: str, bases: tuple[type, ...], attrs: dict[str, Any]
+    ) -> None:
         _proxyable_classes.setdefault(cls)
         super().__init__(name, bases, attrs)
 
-    def __call__(cls, *args, **kwargs):
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
         instance = cls.__new__(cls)  # type: ignore[call-overload]
 
         if not is_fx_tracing():
             cls.__init__(instance, *args, **kwargs)  # type: ignore[misc]
             return instance
 
-        found_proxies = []
+        found_proxies: list[Proxy] = []
 
-        def check_proxy(a):
+        def check_proxy(a: object) -> None:
             if isinstance(a, Proxy):
                 found_proxies.append(a)
 
@@ -147,7 +152,7 @@ class ProxyableClassMeta(type):
 def _patch_function(fn: FunctionType, nargs: int) -> FunctionType:
     co = fn.__code__
     co_flags = co.co_flags & ~HAS_VARSTUFF
-    co_args: tuple
+    co_args: tuple[Any, ...]
     if hasattr(co, "co_qualname"):
         # Python-3.11+ code signature
         co_args = (
@@ -223,7 +228,7 @@ class PHBase:
     Object representing an input placeholder to `concrete_args`
     """
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "PH"
 
 
@@ -236,14 +241,14 @@ class PHWithMeta(PHBase):
     Object representing an input placeholder to `concrete_args`
     """
 
-    def __init__(self, ph_key: str | None = None):
+    def __init__(self, ph_key: str | None = None) -> None:
         super().__init__()
 
         # Provide a hey for user to identify placeholder node during analysis
         self.ph_key = ph_key
 
 
-def _transfer_attrs(fr, to):
+def _transfer_attrs(fr: object, to: object) -> None:
     for attr_name in dir(fr):
         attr_val = getattr(fr, attr_name)
         if (
@@ -279,7 +284,7 @@ class Tracer(TracerBase):
     def __init__(
         self,
         autowrap_modules: tuple[ModuleType] = (math,),
-        autowrap_functions: tuple[Callable, ...] = (),
+        autowrap_functions: tuple[Callable[..., Any], ...] = (),
         param_shapes_constant: bool = False,
     ) -> None:
         # This method's signature is overridden by the first line of this class'
@@ -581,7 +586,9 @@ class Tracer(TracerBase):
         return ret_val
 
     @compatibility(is_backward_compatible=False)
-    def getattr(self, attr: str, attr_val: Any, parameter_proxy_cache: dict[str, Any]):
+    def getattr(
+        self, attr: str, attr_val: Any, parameter_proxy_cache: dict[str, Proxy]
+    ) -> Any:
         """
         Method that specifies the behavior of this ``Tracer`` when we call getattr
         on a call to an ``nn.Module`` instance.
@@ -605,8 +612,10 @@ class Tracer(TracerBase):
         """
 
         def maybe_get_proxy_for_attr(
-            attr_val, collection_to_search, parameter_proxy_cache
-        ):
+            attr_val: Any,
+            collection_to_search: Iterable[tuple[str, Any]],
+            parameter_proxy_cache: dict[str, Proxy],
+        ) -> Proxy | None:
             for n, p in collection_to_search:
                 if attr_val is p:
                     if n not in parameter_proxy_cache:
@@ -646,7 +655,12 @@ class Tracer(TracerBase):
 
     # This method will be refactored
     @compatibility(is_backward_compatible=False)
-    def create_args_for_root(self, root_fn, is_module, concrete_args=None):
+    def create_args_for_root(
+        self,
+        root_fn: Callable[..., Any],
+        is_module: bool,
+        concrete_args: dict[str, Any] | tuple[Any, ...] | None = None,
+    ) -> tuple[Any, list[Any]]:
         """
         Create ``placeholder`` nodes corresponding to the signature of the ``root``
         Module. This method introspects root's signature and emits those
@@ -708,7 +722,7 @@ class Tracer(TracerBase):
                 )
             concrete_args = dict(zip(arg_names, concrete_args))
 
-        def proxy_placeholder(name):
+        def proxy_placeholder(name: str) -> Any:
             return self._proxy_placeholder(name, concrete_args, sig, fn_for_analysis)
 
         args.extend(proxy_placeholder(names) for names in arg_names)
@@ -730,7 +744,9 @@ class Tracer(TracerBase):
                 _PyTreeInfo(orig_args[:total_args], in_spec, None)
             )
 
-            def flatten_fn(*args):
+            # TODO: annotate return type. inspect.get_annotations(flatten_fn)
+            # leaks the return annotation into the generated forward() code.
+            def flatten_fn(*args: Any):  # pyrefly: ignore[unannotated-parameter]
                 tree_args = pytree.tree_unflatten(list(args), in_spec)
                 tree_out = root_fn(*tree_args)
                 out_args, out_spec = pytree.tree_flatten(tree_out)
@@ -787,7 +803,9 @@ class Tracer(TracerBase):
                 # without this.
                 from torch.fx._lazy_graph_module import _LazyGraphModule
 
-                _LazyGraphModule.force_recompile(root)
+                _LazyGraphModule.force_recompile(
+                    root  # pyrefly: ignore[bad-argument-type]
+                )
 
                 self.root = root
 
@@ -823,7 +841,9 @@ class Tracer(TracerBase):
                 str,
             ] = {}
 
-            def collect_tensor_attrs(m: torch.nn.Module, prefix_atoms: list[str]):
+            def collect_tensor_attrs(
+                m: torch.nn.Module, prefix_atoms: list[str]
+            ) -> None:
                 for k, v in m.__dict__.items():
                     if isinstance(v, _constant_attribute_types):
                         self.tensor_attrs[v] = ".".join(prefix_atoms + [k])
@@ -847,13 +867,15 @@ class Tracer(TracerBase):
             # Method dispatch on parameters is not recorded unless it's directly used.
             # Thus, we need to insert a proxy when __getattr__ requests a parameter.
             @functools.wraps(_orig_module_getattr)
-            def module_getattr_wrapper(mod, attr):
+            def module_getattr_wrapper(mod: torch.nn.Module, attr: str) -> Any:
                 attr_val = _orig_module_getattr(mod, attr)
                 return self.getattr(attr, attr_val, parameter_proxy_cache)
 
             @functools.wraps(_orig_module_call)
-            def module_call_wrapper(mod, *args, **kwargs):
-                def forward(*args, **kwargs):
+            def module_call_wrapper(
+                mod: torch.nn.Module, *args: Any, **kwargs: Any
+            ) -> Any:
+                def forward(*args: Any, **kwargs: Any) -> Any:
                     return _orig_module_call(mod, *args, **kwargs)
 
                 _autowrap_check(
@@ -907,7 +929,7 @@ class Tracer(TracerBase):
             _is_fx_tracing_flag = old_is_fx_tracing_flag
         return self.graph
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: dict[int, Any]) -> "Tracer":
         # _autowrap_search contains modules, which cannot be deepcopied.
         new_tracer = Tracer.__new__(Tracer)
 
@@ -921,11 +943,17 @@ class Tracer(TracerBase):
 
         return new_tracer
 
-    def _proxy_placeholder(self, name, concrete_args, sig, fn_for_analysis):
+    def _proxy_placeholder(
+        self,
+        name: str,
+        concrete_args: dict[str, Any] | None,
+        sig: inspect.Signature,
+        fn_for_analysis: Callable[..., Any],
+    ) -> Any:
         if concrete_args is not None and name in concrete_args:
             cnt = 0
 
-            def replace_ph(x):
+            def replace_ph(x: object) -> object:
                 nonlocal cnt
                 cnt += 1
                 param = sig.parameters[name]
@@ -993,7 +1021,7 @@ class Tracer(TracerBase):
 # the purposes of the wrap() API.
 # We key by the globals dict id and function name to ensure we're wrapping a given
 # function only once.
-_wrapped_fns_to_patch: dict[tuple[int, str], dict] = {}
+_wrapped_fns_to_patch: dict[tuple[int, str], dict[str, Any]] = {}
 
 # List of methods on classes to wrap (class type, function name)
 # this currently only works for Tensor.* methods that aren't traced properly
@@ -1008,25 +1036,26 @@ if os.environ.get("FX_PATCH_GETITEM") == "1":
     _wrapped_methods_to_patch.append((torch.Tensor, "__getitem__"))
 
 
-def _find_proxy(*objects_to_search):
+def _find_proxy(*objects_to_search: object) -> Proxy | None:
     """
     Recursively search a data structure for a Proxy() and return it,
     return None if not found.
     """
     proxy = None
 
-    def find_proxy(x):
+    def find_proxy(x: object) -> None:
         nonlocal proxy
         if isinstance(x, Proxy):
             proxy = x
 
+    # pyrefly: ignore[bad-specialization]
     map_aggregate(objects_to_search, find_proxy)
     return proxy
 
 
-def _create_wrapped_func(orig_fn):
+def _create_wrapped_func(orig_fn: Callable[_P, _T]) -> Callable[_P, _T]:
     @functools.wraps(orig_fn)
-    def wrapped(*args, **kwargs):
+    def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> Any:
         """
         Given an closed-over ``orig_function`` to invoke, search the args and kwargs for
         a Proxy object. If there is one, emit a ``call_function`` node to preserve the
@@ -1045,11 +1074,11 @@ def _create_wrapped_func(orig_fn):
     return wrapped
 
 
-def _create_wrapped_method(cls, name):
+def _create_wrapped_method(cls: type, name: str) -> Callable[..., Any]:
     orig_fn = getattr(cls, name)
 
     @functools.wraps(orig_fn)
-    def wrapped(*args, **kwargs):
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
         """
         Search the args and kwargs for a Proxy object. If there is one,
         emit a ``call_method`` node to preserve the call to this method
@@ -1065,39 +1094,39 @@ def _create_wrapped_method(cls, name):
 
 
 class _PatchedFn(NamedTuple):
-    frame_dict: Any
+    frame_dict: Any  # dict[str, Any] for SetItem/Del, type for SetAttr
     fn_name: str
-    orig_fn: Any
-    new_fn: Any
+    orig_fn: Callable[..., Any] | None
+    new_fn: Callable[..., Any]
 
-    def revert(self):
+    def revert(self) -> None:
         raise NotImplementedError
 
-    def patch(self):
+    def patch(self) -> None:
         raise NotImplementedError
 
 
 class _PatchedFnSetItem(_PatchedFn):
-    def revert(self):
+    def revert(self) -> None:
         self.frame_dict[self.fn_name] = self.orig_fn
 
-    def patch(self):
+    def patch(self) -> None:
         self.frame_dict[self.fn_name] = self.new_fn
 
 
 class _PatchedFnDel(_PatchedFn):
-    def revert(self):
+    def revert(self) -> None:
         del self.frame_dict[self.fn_name]
 
-    def patch(self):
+    def patch(self) -> None:
         self.frame_dict[self.fn_name] = self.new_fn
 
 
 class _PatchedFnSetAttr(_PatchedFn):
-    def revert(self):
+    def revert(self) -> None:
         setattr(self.frame_dict, self.fn_name, self.orig_fn)
 
-    def patch(self):
+    def patch(self) -> None:
         setattr(self.frame_dict, self.fn_name, self.new_fn)
 
 
@@ -1111,9 +1140,9 @@ class _Patcher:
         self,
         frame_dict: dict[str, Any],
         name: str,
-        new_fn: Callable,
+        new_fn: Callable[..., Any],
         deduplicate: bool = True,
-    ):
+    ) -> None:
         """
         Replace frame_dict[name] with new_fn until we exit the context manager.
         """
@@ -1130,8 +1159,8 @@ class _Patcher:
             self.patches_made[-1].patch()
 
     def patch_method(
-        self, cls: type, name: str, new_fn: Callable, deduplicate: bool = True
-    ):
+        self, cls: type, name: str, new_fn: Callable[..., Any], deduplicate: bool = True
+    ) -> None:
         """
         Replace object_or_dict.name with new_fn until we exit the context manager.
         """
@@ -1142,7 +1171,7 @@ class _Patcher:
         self.patches_made.append(_PatchedFnSetAttr(cls, name, orig_fn, new_fn))
         self.patches_made[-1].patch()
 
-    def visit_once(self, thing: Any):
+    def visit_once(self, thing: object) -> bool:
         """Return True on the first call to with thing, otherwise false"""
         idx = id(thing)
         if idx in self.visited:
@@ -1150,7 +1179,7 @@ class _Patcher:
         self.visited.add(idx)
         return True
 
-    def revert_all_patches(self):
+    def revert_all_patches(self) -> list[_PatchedFn]:
         """
         Remove all the stored patcheds. It doesn't modify patches_made.
         """
@@ -1158,7 +1187,7 @@ class _Patcher:
             patch.revert()
         return self.patches_made
 
-    def reapply_all_patches(self):
+    def reapply_all_patches(self) -> list[_PatchedFn]:
         """
         Patch all the stored patcheds. It doesn't modify patches_made.
         """
@@ -1166,10 +1195,15 @@ class _Patcher:
             patch.patch()
         return self.patches_made
 
-    def __enter__(self):
+    def __enter__(self) -> "_Patcher":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """
         Undo all the changes made via self.patch() and self.patch_method()
         """
@@ -1183,7 +1217,7 @@ CURRENT_PATCHER: _Patcher | None = None
 
 
 @contextlib.contextmanager
-def _new_patcher():
+def _new_patcher() -> Iterator[_Patcher]:
     global CURRENT_PATCHER
     prior_patcher = CURRENT_PATCHER
     try:
@@ -1198,7 +1232,7 @@ def _new_patcher():
 
 
 @contextlib.contextmanager
-def _maybe_revert_all_patches():
+def _maybe_revert_all_patches() -> Iterator[None]:
     current_patcher = CURRENT_PATCHER
     patches_made = None
     patches_removed = None
@@ -1215,7 +1249,7 @@ def _maybe_revert_all_patches():
             )
 
 
-def _patch_wrapped_functions(patcher: _Patcher):
+def _patch_wrapped_functions(patcher: _Patcher) -> None:
     """
     Go through ``_wrapped_fn_patch_table`` and, for each frame object, wrap
     the listed global functions in the `_create_wrapped_func` wrapper.
@@ -1233,7 +1267,7 @@ def _patch_wrapped_functions(patcher: _Patcher):
 
 def _autowrap_check(
     patcher: _Patcher, frame_dict: dict[str, Any], function_ids: set[int]
-):
+) -> None:
     """
     Some methods, like `math.sqrt` are common enough we want to automatically wrap them as we see them.
     This method searches a scope for them and patches them if found.
@@ -1248,8 +1282,12 @@ def _autowrap_check(
                 patcher.patch(frame_dict, name, _create_wrapped_func(value))
 
 
+@overload
+def wrap(fn_or_name: _F) -> _F: ...
+@overload
+def wrap(fn_or_name: str) -> str: ...
 @compatibility(is_backward_compatible=True)
-def wrap(fn_or_name: str | Callable):
+def wrap(fn_or_name: str | Callable[..., Any]) -> str | Callable[..., Any]:
     """
     This function can be called at module-level scope to register fn_or_name as a "leaf function".
     A "leaf function" will be preserved as a CallFunction node in the FX trace instead of being
@@ -1382,6 +1420,6 @@ def symbolic_trace(
 
 
 @wrap
-def _assert_is_none(value, msg):
+def _assert_is_none(value: object, msg: str) -> None:
     if value is not None:
         raise AssertionError(msg)

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1328,7 +1328,13 @@ def proxy_call(
     else:
         constant = None
 
-    track_tensor_tree(out, proxy_out, constant=constant, tracer=tracer)
+    track_tensor_tree(
+        out,
+        proxy_out,
+        # pyrefly: ignore[bad-argument-type]
+        constant=constant,
+        tracer=tracer,
+    )
     _maybe_record_pointwise_barrier(func, proxy_mode)
     return out
 

--- a/torch/fx/experimental/schema_type_annotation.py
+++ b/torch/fx/experimental/schema_type_annotation.py
@@ -1,13 +1,19 @@
 # mypy: allow-untyped-defs
+from __future__ import annotations
+
 import inspect
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.fx
 from torch._jit_internal import boolean_dispatched
 from torch.fx import Transformer
-from torch.fx.node import Argument, Target
 from torch.fx.operator_schemas import _torchscript_type_to_python_type
+
+
+if TYPE_CHECKING:
+    from torch.fx.graph_module import GraphModule
+    from torch.fx.node import Argument, Target
 
 
 class AnnotateTypesWithSchema(Transformer):
@@ -31,7 +37,7 @@ class AnnotateTypesWithSchema(Transformer):
 
     def __init__(
         self,
-        module: torch.nn.Module,
+        module: GraphModule,
         annotate_functionals: bool = True,
         annotate_modules: bool = True,
         annotate_get_attrs: bool = True,

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -1,8 +1,8 @@
-# mypy: allow-untyped-defs
 import inspect
 import logging
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 import torch
 import torch.fx.traceback as fx_traceback
@@ -19,15 +19,12 @@ from .node import Argument, map_aggregate, map_arg, Node, Target
 from .proxy import Proxy
 
 
-if TYPE_CHECKING:
-    from collections.abc import Iterator
-
 log = logging.getLogger(__name__)
 
 __all__ = ["Interpreter", "Transformer"]
 
 
-def _format_fx_node(n):
+def _format_fx_node(n: Node) -> str:
     """
     Format a torch.fx.Node into a human-readable string for debug logging.
 
@@ -118,7 +115,7 @@ class Interpreter:
         module: torch.nn.Module,
         garbage_collect_values: bool = True,
         graph: Graph | None = None,
-    ):
+    ) -> None:
         self.module = module
         self.submodules = dict(self.module.named_modules())
         if graph is not None:
@@ -138,7 +135,7 @@ class Interpreter:
             node_to_last_use: dict[Node, Node] = {}
             self.user_to_last_uses: dict[Node, list[Node]] = {}
 
-            def register_last_uses(n: Node, user: Node):
+            def register_last_uses(n: Node, user: Node) -> None:
                 if n not in node_to_last_use:
                     node_to_last_use[n] = user
                     self.user_to_last_uses.setdefault(user, []).append(n)
@@ -150,7 +147,7 @@ class Interpreter:
     @compatibility(is_backward_compatible=True)
     def run(
         self,
-        *args,
+        *args: Any,
         initial_env: dict[Node, Any] | None = None,
         enable_io_processing: bool = True,
     ) -> Any:
@@ -240,7 +237,7 @@ class Interpreter:
                 )
 
     @compatibility(is_backward_compatible=True)
-    def boxed_run(self, args_list):
+    def boxed_run(self, args_list: list[Any]) -> Any:
         """
         Run `module` via interpretation and return the result.  This uses the "boxed"
         calling convention, where you pass a list of arguments, which will be cleared
@@ -267,7 +264,7 @@ class Interpreter:
         return self.run(initial_env=env)
 
     @contextmanager
-    def _set_current_node(self, node):
+    def _set_current_node(self, node: Node) -> Iterator[None]:
         with fx_traceback.set_current_meta(
             node, f"Interpreter_{self.__class__.__name__}"
         ):
@@ -452,7 +449,7 @@ class Interpreter:
 
     # Helper methods
     @compatibility(is_backward_compatible=True)
-    def fetch_attr(self, target: str):
+    def fetch_attr(self, target: str) -> Any:
         """
         Fetch an attribute from the ``Module`` hierarchy of ``self.module``.
 
@@ -473,7 +470,9 @@ class Interpreter:
         return attr_itr
 
     @compatibility(is_backward_compatible=True)
-    def fetch_args_kwargs_from_env(self, n: Node) -> tuple[tuple, dict]:
+    def fetch_args_kwargs_from_env(
+        self, n: Node
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         """
         Fetch the concrete values of ``args`` and ``kwargs`` of node ``n``
         from the current execution environment.
@@ -568,18 +567,18 @@ class Transformer(Interpreter):
     """
 
     @compatibility(is_backward_compatible=True)
-    def __init__(self, module):
+    def __init__(self, module: GraphModule) -> None:
         super().__init__(module)
         self.new_graph = Graph()
         self.new_graph.set_codegen(module.graph._codegen)
 
         class TransformerTracer(Tracer):
-            def __init__(self, graph: Graph):
+            def __init__(self, graph: Graph) -> None:
                 super().__init__()
                 self.graph = graph
                 self.tensor_attrs: dict[torch.Tensor, str] = {}  # type: ignore[assignment]
 
-            def is_leaf_module(self, _, __) -> bool:
+            def is_leaf_module(self, _: torch.nn.Module, __: str) -> bool:
                 return True
 
         self.tracer = TransformerTracer(self.new_graph)

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 import collections
 import copy
 import dis
@@ -9,10 +7,12 @@ import logging
 import operator
 import sys
 import traceback
+import types
 from collections import OrderedDict
 from collections.abc import Callable, Iterator
 from dataclasses import fields, is_dataclass
-from typing import Any, TypeVar
+from typing import Any, cast, TypeVar
+from typing_extensions import Never
 
 import torch
 import torch.fx.traceback as fx_traceback
@@ -117,7 +117,7 @@ class Scope:
 
     """
 
-    def __init__(self, module_path: str, module_type: Any):
+    def __init__(self, module_path: str, module_type: Any) -> None:
         super().__init__()
         self.module_path = module_path
         self.module_type = module_type
@@ -134,7 +134,7 @@ class ScopeContextManager:
         self,
         scope: Scope,
         current_scope: Scope,
-    ):
+    ) -> None:
         super().__init__()
         # Keep a copy of prev scope to restore on exit
         self._prev_scope = copy.copy(scope)
@@ -144,10 +144,10 @@ class ScopeContextManager:
         # Save a reference so we can restore it
         self._scope = scope
 
-    def __enter__(self):
+    def __enter__(self) -> Scope:
         return self._scope
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: object) -> None:
         self._scope.module_path = self._prev_scope.module_path
         self._scope.module_type = self._prev_scope.module_type
         return
@@ -217,7 +217,8 @@ class TracerBase:
         """
 
         if kind == "call_function" and self.check_mutable_operations:
-            check_for_mutable_operation(target, args, kwargs)
+            target_fn = cast(Callable[..., Any], target)
+            check_for_mutable_operation(target_fn, args, kwargs)
 
         node = self.graph.create_node(kind, target, args, kwargs, name, type_expr)
         # TODO node_name_to_scope will be depreciated in favor of
@@ -254,7 +255,7 @@ class TracerBase:
             # See Note [Functionalization View Replay Annotation]
             # Overriding some node meta with the original node meta of the
             # regenerated node.
-            replay_node: Node = fx_traceback.get_current_replay_node()
+            replay_node: Node | None = fx_traceback.get_current_replay_node()
             if replay_node is not None:
                 node.meta["is_functional_regenerated"] = True
                 if "custom" in replay_node.meta:
@@ -280,7 +281,7 @@ class TracerBase:
     ) -> traceback.StackSummary:
         # This method can be overridden to customize the frame filtering logic
         # for the recorded stack trace
-        user_frames = []
+        user_frames: list[traceback.FrameSummary] = []
         if self._record_forward_stack_traces_only:
             user_frames = [
                 frame
@@ -301,7 +302,7 @@ class TracerBase:
             # Not having a "forward" call in the stacktrace implies the
             # stacktrace will probably be irrelevant
             if first_forward == -1:
-                user_frames = []
+                user_frames: list[traceback.FrameSummary] = []
 
         from torch.fx.experimental.symbolic_shapes import uninteresting_files
 
@@ -326,9 +327,8 @@ class TracerBase:
         kwargs: dict[str, Any],
         name: str | None = None,
         type_expr: Any | None = None,
-        # fix noqa when updating bc tests
-        proxy_factory_fn: Callable[[Node], "Proxy"] = None,  # noqa: RUF013
-    ):
+        proxy_factory_fn: Callable[[Node], "Proxy"] | None = None,
+    ) -> "Proxy":
         """
         Create a Node from the given arguments, then return the Node
         wrapped in a Proxy object.
@@ -355,7 +355,7 @@ class TracerBase:
 
         return proxy
 
-    def _find_user_frame(self):
+    def _find_user_frame(self) -> types.FrameType | None:
         """
         Find the Python stack frame executing the user code during
         symbolic tracing.
@@ -440,14 +440,14 @@ class TracerBase:
             )
 
         elif isinstance(a, range):
-            return range(
-                self.create_arg(a.start),
-                self.create_arg(a.stop),
-                self.create_arg(a.step),
+            return range(  # pyrefly: ignore[no-matching-overload]
+                self.create_arg(a.start),  # pyrefly: ignore[bad-argument-type]
+                self.create_arg(a.stop),  # pyrefly: ignore[bad-argument-type]
+                self.create_arg(a.step),  # pyrefly: ignore[bad-argument-type]
             )
 
         elif isinstance(a, (torch._ops.OpOverload, torch._ops.HigherOrderOperator)):
-            return a
+            return a  # pyrefly: ignore[bad-return]
 
         elif is_opaque_value_type(type(a)):
             return a
@@ -460,7 +460,7 @@ class TracerBase:
             return self.create_node("call_function", a.__class__, (), kwargs)
 
         elif isinstance(a, (*base_types, enum.Enum)) or a is None or a is ...:
-            return a
+            return a  # pyrefly: ignore[bad-return]
 
         raise NotImplementedError(f"argument of type: {type(a)}")
 
@@ -494,7 +494,7 @@ class TracerBase:
         )
 
     @compatibility(is_backward_compatible=True)
-    def keys(self, obj: "Proxy") -> Any:
+    def keys(self, obj: "Proxy") -> "Proxy":
         """Called when a proxy object is has the keys() method called.
         This is what happens when ** is called on a proxy. This should return an
         iterator it ** is suppose to work in your custom tracer.
@@ -502,7 +502,7 @@ class TracerBase:
         return Attribute(obj, "keys")()
 
 
-def _get_seq_nr(node_name: str = ""):
+def _get_seq_nr(node_name: str = "") -> int | None:
     """
     Returns the seq_nr node meta for the current proxy node that we're creating.
     The seq_nr number in node meta is related to but not the same as the "sequence number"
@@ -547,7 +547,7 @@ def _get_seq_nr(node_name: str = ""):
         # See Note [Functionalization View Replay Annotation]
         # Overriding some node meta with the original node meta of the
         # regenerated node.
-        replay_node: Node = fx_traceback.get_current_replay_node()
+        replay_node: Node | None = fx_traceback.get_current_replay_node()
         if replay_node is not None:
             if "seq_nr" in replay_node.meta:
                 annotation_log.debug("%s: seq_nr from replay_node", node_name)
@@ -559,16 +559,16 @@ def _get_seq_nr(node_name: str = ""):
 # used in Proxy object when just appending to the graph while not tracing.
 @compatibility(is_backward_compatible=True)
 class GraphAppendingTracer(TracerBase):
-    def __init__(self, graph: Graph):
+    def __init__(self, graph: Graph) -> None:
         super().__init__()
         self.graph = graph
         self.scope = Scope("", None)
-        self.module_stack = collections.OrderedDict()
-        self.node_name_to_scope = {}
+        self.module_stack: OrderedDict[str, tuple[str, Any]] = collections.OrderedDict()
+        self.node_name_to_scope: dict[str, tuple[str, type]] = {}
 
 
 @compatibility(is_backward_compatible=False)
-def assert_fn(x):
+def assert_fn(x: object) -> None:
     if not x:
         raise AssertionError("Assertion failed")
 
@@ -609,7 +609,7 @@ class Proxy:
     """
 
     @compatibility(is_backward_compatible=True)
-    def __init__(self, node: Node, tracer: "TracerBase | None" = None):
+    def __init__(self, node: Node, tracer: "TracerBase | None" = None) -> None:
         if tracer is None:
             # This allows you to create a Proxy object around a raw Node
             tracer = GraphAppendingTracer(node.graph)
@@ -619,21 +619,21 @@ class Proxy:
     def __repr__(self) -> str:
         return f"Proxy({self.node.name})"
 
-    def __getattr__(self, k) -> "Attribute":
+    def __getattr__(self, k: str) -> "Attribute":
         # note: not added to the graph yet, if this is a method call
         # we peephole optimize to the method invocation
         return Attribute(self, k)
 
-    def __getstate__(self) -> dict:
+    def __getstate__(self) -> dict[str, Any]:
         return self.__dict__
 
-    def __deepcopy__(self, memo) -> dict:
+    def __deepcopy__(self, memo: dict[int, Any]) -> "Proxy":
         # We have to explicitly override this method, because otherwise deepcopy
         # will go to __getattr__(self, "__deepcopy__") and return a
         # Attribute(__deepcopy__), and may go into an infinite loop in some cases.
         import copy
 
-        new_dict = {}
+        new_dict: dict[str, Any] = {}
         for k, v in self.__dict__.items():
             try:
                 new_obj = copy.deepcopy(v, memo)
@@ -655,11 +655,11 @@ class Proxy:
             new_proxy.__dict__[k] = v
         return new_proxy
 
-    def __setstate__(self, d):
+    def __setstate__(self, d: dict[str, Any]) -> None:
         # This is called when being unpickled/loaded.
         self.__dict__ = d
 
-    def __call__(self, *args, **kwargs) -> "Proxy":
+    def __call__(self, *args: Any, **kwargs: Any) -> "Proxy":
         return self.tracer.create_proxy(
             "call_method", "__call__", (self,) + args, kwargs
         )
@@ -686,7 +686,7 @@ class Proxy:
 
         return self.tracer.iter(self)
 
-    def __abs__(self):
+    def __abs__(self) -> "Proxy":
         return self.tracer.create_proxy("call_function", operator.abs, (self,), {})
 
     def __bool__(self) -> bool:
@@ -725,10 +725,10 @@ class Proxy:
         return self.tracer.to_bool(self)
 
     @compatibility(is_backward_compatible=True)
-    def keys(self):
+    def keys(self) -> "Proxy":
         return self.tracer.keys(self)
 
-    def __len__(self):
+    def __len__(self) -> int:
         raise RuntimeError(
             "'len' is not supported in symbolic tracing by default. If you want "
             "this call to be recorded, please call torch.fx.wrap('len') at "
@@ -736,13 +736,19 @@ class Proxy:
         )
 
     @classmethod
-    def __torch_function__(cls, orig_method, types, args=None, kwargs=None):
+    def __torch_function__(
+        cls,
+        orig_method: Callable[..., Any],
+        types: tuple[type, ...],
+        args: tuple[Any, ...] | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ) -> "Proxy":
         args = args if args else ()
         kwargs = kwargs if kwargs else {}
 
-        tracers: dict[Any, None] = {}
+        tracers: dict[TracerBase, None] = {}
 
-        def find_tracer(a):
+        def find_tracer(a: Any) -> None:
             if isinstance(a, cls):
                 tracers[a.tracer] = None
 
@@ -788,7 +794,9 @@ class MetaProxy(Proxy):
     A Proxy subclass that propagates metadata (meta['val']) during graph tracing.
     """
 
-    def __init__(self, node: Node, tracer: "TracerBase | None" = None, fake_mode=None):
+    def __init__(
+        self, node: Node, tracer: "TracerBase | None" = None, fake_mode: Any = None
+    ) -> None:
         super().__init__(node, tracer)
         self.fake_mode = fake_mode
 
@@ -796,7 +804,13 @@ class MetaProxy(Proxy):
         return f"MetaProxy({self.node.name})"
 
     @classmethod
-    def __torch_function__(cls, orig_method, types, args=None, kwargs=None):
+    def __torch_function__(
+        cls,
+        orig_method: Callable[..., Any],
+        types: tuple[type, ...],
+        args: tuple[Any, ...] | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ) -> "MetaProxy":
         args = args if args else ()
         kwargs = kwargs if kwargs else {}
 
@@ -823,14 +837,14 @@ class MetaProxy(Proxy):
 @compatibility(is_backward_compatible=True)
 class Attribute(Proxy):
     @compatibility(is_backward_compatible=True)
-    def __init__(self, root: Proxy, attr: str):
+    def __init__(self, root: Proxy, attr: str) -> None:
         self.root = root
         self.attr = attr
         self.tracer = root.tracer
         self._node: Node | None = None
 
     @property
-    def node(self):
+    def node(self) -> Node:  # pyrefly: ignore[bad-override]
         # the node for attributes is added lazily, since most will just be method calls
         # which do not rely on the getitem call
         if self._node is None:
@@ -839,7 +853,7 @@ class Attribute(Proxy):
             ).node
         return self._node
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> "Proxy":
         return self.tracer.create_proxy(
             "call_method", self.attr, (self.root,) + args, kwargs
         )
@@ -853,7 +867,9 @@ class ParameterProxy(Proxy):
     so that conditional tests on these attributes will not throw exception during tracing
     """
 
-    def __init__(self, tracer: TracerBase, node: Node, name, param):
+    def __init__(
+        self, tracer: TracerBase, node: Node, name: str, param: torch.nn.Parameter
+    ) -> None:
         super().__init__(node, tracer)
         if not isinstance(param, torch.nn.Parameter):
             raise AssertionError(f"Expected Parameter, got {type(param)}")
@@ -864,30 +880,30 @@ class ParameterProxy(Proxy):
         return f"ParameterProxy({self.name})"
 
     @property
-    def shape(self):
+    def shape(self) -> torch.Size:
         return self.param.shape
 
-    def size(self):
+    def size(self) -> torch.Size:
         return self.param.size()
 
-    def dim(self):
+    def dim(self) -> int:
         return self.param.dim()
 
     @property
-    def ndim(self):
+    def ndim(self) -> int:
         return self.param.ndim
 
-    def numel(self):
+    def numel(self) -> int:
         return self.param.numel()
 
-    def nelement(self):
+    def nelement(self) -> int:
         return self.param.nelement()
 
 
 for method in magic_methods:
 
-    def _scope(method):
-        def impl(*args, **kwargs):
+    def _scope(method: str) -> None:
+        def impl(*args: Any, **kwargs: Any) -> "Proxy":
             tracer = args[0].tracer
             target = getattr(operator, method)
             return tracer.create_proxy("call_function", target, args, kwargs)
@@ -899,10 +915,10 @@ for method in magic_methods:
     _scope(method)
 
 
-def _define_reflectable(orig_method_name):
+def _define_reflectable(orig_method_name: str) -> None:
     method_name = f"__r{orig_method_name.strip('_')}__"
 
-    def impl(self, rhs):
+    def impl(self: "Proxy", rhs: Any) -> "Proxy":
         target = getattr(operator, orig_method_name)
         return self.tracer.create_proxy("call_function", target, (rhs, self), {})
 
@@ -915,15 +931,15 @@ for orig_method_name in reflectable_magic_methods:
     _define_reflectable(orig_method_name)
 
 
-def _no_nodes_error(arg):
+def _no_nodes_error(arg: Argument) -> Never:
     raise RuntimeError(
         "Keys for dictionaries used as an argument cannot contain a "
         f"Node. Got key: {arg}"
     )
 
 
-def _create_arg_dict(self, a):
-    r = {}
+def _create_arg_dict(self: TracerBase, a: dict[Any, Any]) -> dict[Any, Argument]:
+    r: dict[Any, Argument] = {}
     for k, v in a.items():
         if not isinstance(k, str):
             # Check for invalid dict keys. We do not want a Proxy to appear

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -1,11 +1,11 @@
-# mypy: allow-untyped-defs
 import copy
 import logging
 import traceback
 from collections import defaultdict
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any, Optional, ParamSpec, TypeVar, Union
 
 from torch._utils_internal import signpost_event
 
@@ -14,6 +14,9 @@ from .graph import Graph
 from .graph_module import GraphModule
 from .node import Node
 
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 log = logging.getLogger(__name__)
 
@@ -82,7 +85,7 @@ class NodeSource:
     """
 
     class NodeInfo:
-        def __init__(self, name: str, target: str, graph_id: int):
+        def __init__(self, name: str, target: str, graph_id: int) -> None:
             self.name = name
             self.target = target
             self.graph_id = graph_id
@@ -99,7 +102,7 @@ class NodeSource:
         node: Node | None,
         pass_name: str = "",
         action: Union["NodeSourceAction", list["NodeSourceAction"]] | None = None,
-    ):
+    ) -> None:
         self.pass_name = pass_name
 
         if action is None:
@@ -139,15 +142,15 @@ class NodeSource:
     def graph_id(self) -> int:
         return self.node_info.graph_id if self.node_info else -1
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.print_readable()
 
-    def _get_action_string(self):
+    def _get_action_string(self) -> str:
         if self._action_string is None:
             self._action_string = "+".join([a.name.lower() for a in self.action])
         return self._action_string
 
-    def print_readable(self, indent=0):
+    def print_readable(self, indent: int = 0) -> str:
         if indent > 9:
             return ""
         result = ""
@@ -160,7 +163,7 @@ class NodeSource:
             result += item.print_readable(indent + 1)
         return result
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         if self._dict is None:
             # Convert the object to a dictionary
             action_string = self._get_action_string()
@@ -177,15 +180,15 @@ class NodeSource:
             raise AssertionError("_dict is None after initialization")
         return self._dict
 
-    def __eq__(self, other: object):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, NodeSource):
             return False
         return self.to_dict() == other.to_dict()
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         # Create a hash based on the dictionary representation
         # We need to convert the dict to a hashable form
-        def _make_hashable(obj):
+        def _make_hashable(obj: Any) -> Any:
             if isinstance(obj, dict):
                 return tuple(sorted((k, _make_hashable(v)) for k, v in obj.items()))
             elif isinstance(obj, list):
@@ -196,7 +199,7 @@ class NodeSource:
         return hash(_make_hashable(self.to_dict()))
 
     @classmethod
-    def _from_dict(cls, d: dict | None) -> Optional["NodeSource"]:
+    def _from_dict(cls, d: dict[str, Any] | None) -> Optional["NodeSource"]:
         """
         Recursively deserialize from_node metadata from dictionary data.
         It is used to deserialize the from_node field from serialized metadata.
@@ -253,7 +256,7 @@ class NodeSource:
 
 @compatibility(is_backward_compatible=False)
 @contextmanager
-def preserve_node_meta(enable=True):
+def preserve_node_meta(enable: bool = True) -> Iterator[None]:
     global should_preserve_node_meta
     global current_meta
     saved_should_preserve_node_meta = should_preserve_node_meta
@@ -268,7 +271,7 @@ def preserve_node_meta(enable=True):
 
 
 @contextmanager
-def _preserve_node_seq_nr(preserve_seq_nr=True):
+def _preserve_node_seq_nr(preserve_seq_nr: bool = True) -> Iterator[None]:
     """
     Temporarily enables or disables the preservation of node.meta["seq_nr"] in the
     tracing context.
@@ -284,7 +287,7 @@ def _preserve_node_seq_nr(preserve_seq_nr=True):
 
 
 @compatibility(is_backward_compatible=False)
-def set_stack_trace(stack: list[str]):
+def set_stack_trace(stack: list[str]) -> None:
     global current_meta
 
     if should_preserve_node_meta:
@@ -298,7 +301,7 @@ def set_stack_trace(stack: list[str]):
 
 @compatibility(is_backward_compatible=False)
 @contextmanager
-def annotate(annotation_dict: dict):
+def annotate(annotation_dict: dict[str, Any]) -> Iterator[None]:
     """
     Temporarily adds custom annotations to the current tracing context.
     The fx_node produced from this tracing context will have the
@@ -338,7 +341,7 @@ def annotate(annotation_dict: dict):
 
     try:
         if not has_custom:
-            current_meta["custom"] = {}
+            current_meta["custom"] = dict[str, Any]()
 
         # Update with all key-value pairs from the input dict
         current_meta["custom"].update(annotation_dict)
@@ -352,7 +355,9 @@ def annotate(annotation_dict: dict):
 
 
 @compatibility(is_backward_compatible=False)
-def annotate_fn(annotation_dict: dict):
+def annotate_fn(
+    annotation_dict: dict[str, Any],
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
     """
     A decorator that wraps a function with the annotate context manager.
     Use this when you want to annotate an entire function instead of a specific code block.
@@ -377,19 +382,21 @@ def annotate_fn(annotation_dict: dict):
     """
     from functools import wraps
 
-    def decorator(func):
+    def decorator(func: Callable[_P, _R]) -> Callable[_P, _R]:
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        # NB: Do not annotate with _P.args/_P.kwargs here. Dynamo guards on
+        # the identity of ParamSpec annotation objects, causing guard failures.
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             with annotate(annotation_dict):
                 return func(*args, **kwargs)
 
-        return wrapper
+        return wrapper  # type: ignore[return-value]
 
     return decorator
 
 
 @compatibility(is_backward_compatible=False)
-def set_grad_fn_seq_nr(seq_nr):
+def set_grad_fn_seq_nr(seq_nr: int) -> None:
     global current_meta
 
     if should_preserve_node_meta:
@@ -401,7 +408,7 @@ def set_grad_fn_seq_nr(seq_nr):
 
 
 @compatibility(is_backward_compatible=False)
-def reset_grad_fn_seq_nr():
+def reset_grad_fn_seq_nr() -> None:
     # NB: reset state properly, this would be helpful towards supporting
     #     reentrant autograd if we actually wanted to do that.
     global current_meta
@@ -437,7 +444,7 @@ def _is_preserving_node_seq_nr() -> bool:
 
 @compatibility(is_backward_compatible=False)
 @contextmanager
-def set_current_meta(node, pass_name=""):
+def set_current_meta(node: Node, pass_name: str = "") -> Iterator[None]:
     global current_meta
     if should_preserve_node_meta and node.meta:
         saved_meta = current_meta
@@ -465,7 +472,7 @@ def get_current_meta() -> dict[str, Any]:
 
 @compatibility(is_backward_compatible=False)
 @contextmanager
-def set_current_replay_node(node):
+def set_current_replay_node(node: Node | None) -> Iterator[None]:
     """
     Set the currently replay node. If `current_replay_node` is not None,
     then we're re-generating the `current_replay_node` in FunctionalTensorMode.
@@ -481,7 +488,7 @@ def set_current_replay_node(node):
 
 
 @compatibility(is_backward_compatible=False)
-def get_current_replay_node():
+def get_current_replay_node() -> Node | None:
     """
     Get the currently replay node
     """
@@ -522,7 +529,7 @@ def _get_custom_metadata(gm: GraphModule) -> str:
     if not isinstance(gm, GraphModule):
         raise AssertionError(f"Expected GraphModule, got {type(gm)}")
 
-    def helper(gm: GraphModule):
+    def helper(gm: GraphModule) -> list[Any]:
         custom_metadata = []
         for node in gm.graph.nodes:
             if hasattr(node, "meta") and node.meta.get("custom", None):
@@ -530,7 +537,10 @@ def _get_custom_metadata(gm: GraphModule) -> str:
             if node.op == "get_attr" and isinstance(
                 getattr(gm, node.target), GraphModule
             ):
-                custom_metadata.append(helper(getattr(gm, node.target)))
+                custom_metadata.append(
+                    # pyrefly: ignore[bad-argument-type]
+                    helper(getattr(gm, node.target))
+                )
         return custom_metadata
 
     return "\n".join(str(x) for x in helper(gm))


### PR DESCRIPTION
…ic_trace, traceback

Remove mypy suppressions. Add return type, parameter type, and generic type annotations. Backward-compatible APIs use pyrefly ignore comments.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98