### PR TITLE
Skip div-to-mul-reciprocal when division_rounding is enabled

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2907,6 +2907,78 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
 
                 self.assertEqual(eager_div, compiled_div)
 
+    @config.patch({"eager_numerics.division_rounding": True})
+    def test_truediv_by_constant_emulate_division_rounding(self):
+        # Eager CUDA replaces `tensor / scalar` with `tensor * (1/scalar)`
+        # using a reciprocal computed in double precision (see
+        # BinaryDivTrueKernel.cu, is_cpu_scalar branch).  Inductor's
+        # div_prim applies the same optimisation via get_constant_value,
+        # so the two should be bitwise identical regardless of the
+        # division_rounding flag.
+
+        @torch.compile
+        def compiled_divide(x):
+            return x / 6.0
+
+        x = torch.randn(100, dtype=torch.float32, device=device_type)
+
+        torch._dynamo.reset()
+        compiled_out = compiled_divide(x)
+        eager_out = x / 6.0
+
+        self.assertEqual(eager_out, compiled_out, atol=0, rtol=0)
+
+    @config.patch({"eager_numerics.division_rounding": True})
+    def test_truediv_tensor_by_tensor_emulate_division_rounding(self):
+        # When both operands are tensors passed as arguments, eager CUDA
+        # uses true IEEE division (DivFunctor path in BinaryDivTrueKernel.cu).
+        # Inductor sees the divisor as a dynamic value, so it emits
+        # ops.truediv which becomes tl.div_rn under division_rounding.
+        # Both use true division -> bitwise match.
+
+        @torch.compile
+        def compiled_divide(x, y):
+            return x / y
+
+        x = torch.randn(100, dtype=torch.float32, device=device_type)
+        y = torch.tensor(6.0, device=device_type, dtype=torch.float32)
+
+        torch._dynamo.reset()
+        compiled_out = compiled_divide(x, y)
+        eager_out = x / y
+
+        self.assertEqual(eager_out, compiled_out, atol=0, rtol=0)
+
+    @unittest.expectedFailure
+    @config.patch({"eager_numerics.division_rounding": True})
+    def test_truediv_by_inlined_tensor_constant_emulate_division_rounding(self):
+        # Known mismatch: when a constant tensor is created inside the
+        # compiled function, inductor constant-folds it and applies the
+        # reciprocal optimisation (same as the scalar path).  But eager
+        # sees `tensor / tensor` — both operands are CUDA tensors — so
+        # it dispatches to true IEEE division (DivFunctor path in
+        # BinaryDivTrueKernel.cu).  The two differ by up to 1 ULP.
+        #
+        # We cannot fix this in div_prim because by the time the IR
+        # reaches get_constant_value, the distinction between "originally
+        # a Python scalar" and "originally a tensor that was constant-
+        # folded" has been erased — both look like ir.Constant.  Skipping
+        # the reciprocal optimisation for all constants (as PR #179719
+        # tried) would fix this case but break the more common
+        # `tensor / scalar` pattern where eager also uses reciprocal.
+
+        @torch.compile
+        def compiled_divide(x):
+            return x / torch.tensor(6.0, device=device_type, dtype=torch.float32)
+
+        x = torch.randn(100, dtype=torch.float32, device=device_type)
+
+        torch._dynamo.reset()
+        compiled_out = compiled_divide(x)
+        eager_out = x / torch.tensor(6.0, device=device_type, dtype=torch.float32)
+
+        self.assertEqual(eager_out, compiled_out, atol=0, rtol=0)
+
     @skipIfXpu(msg="triton dependency - torch-xpu-ops: 2554")
     @config.patch({"eager_numerics.division_rounding": False})
     @xfailIfROCm

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7156,7 +7156,10 @@ def div_prim(a, b):
     # Disable CPU optimization to avoid precision issues.
     # see https://github.com/pytorch/pytorch/issues/157959
     if (divisor := get_constant_value(b)) is not None and a.get_device().type != "cpu":
-        # Replace divide by constant with multiply by reciprocal
+        # Replace divide by constant with multiply by reciprocal.
+        # This is correct even when division_rounding is enabled: eager CUDA
+        # also replaces constant divisions with reciprocal multiplies, so
+        # matching eager means doing the same here.
 
         if divisor.value == 0:
             reciprocal = math.copysign(float("inf"), divisor.value)


### PR DESCRIPTION
(a) Added code comment explaining why Inductor still converts `f/const` to `f * (1/constant)` even when `eager_numerics.division_rounding` is enabled.
(b) Added 3 tests to show current status:
<img width="678" height="166" alt="image" src="https://github.com/user-attachments/assets/9ae83711-bc71-4178-b682-a939b3345f95" />

Inspired by https://github.com/pytorch/pytorch/issues/179577, note that this PR can't fix https://github.com/pytorch/pytorch/issues/179577 since it was caused by the design of the model which has `x/1e-8`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos