### PR TITLE
[EZ][CD] Bump numpy pin to 2.3.4 for Python 3.14 builds

### DIFF
--- a/.ci/manywheel/build_common.sh
+++ b/.ci/manywheel/build_common.sh
@@ -118,6 +118,9 @@ retry pip install -qUr requirements-build.txt
 python setup.py clean
 retry pip install -qr requirements.txt
 case ${DESIRED_PYTHON} in
+  cp314*)
+    retry pip install -q --pre numpy==2.3.4
+    ;;
   cp31*)
     retry pip install -q --pre numpy==2.1.0
     ;;

--- a/.ci/wheel/build_wheel.sh
+++ b/.ci/wheel/build_wheel.sh
@@ -132,20 +132,12 @@ CONDA_ENV_CREATE_FLAGS=""
 RENAME_WHEEL=false
 VERIFY_WHEELNAME=true
 case $desired_python in
-    3.14t)
-        echo "Using 3.14 deps"
-        NUMPY_PINNED_VERSION="==2.1.0"
+    3.14*)
+        echo "Using ${desired_python} deps"
+        NUMPY_PINNED_VERSION="==2.3.4"
         ;;
-    3.14)
-        echo "Using 3.14t deps"
-        NUMPY_PINNED_VERSION="==2.1.0"
-        ;;
-    3.13t)
-        echo "Using 3.13t deps"
-        NUMPY_PINNED_VERSION="==2.1.0"
-        ;;
-    3.13)
-        echo "Using 3.13 deps"
+    3.13*)
+        echo "Using ${desired_python} deps"
         NUMPY_PINNED_VERSION="==2.1.0"
         ;;
     3.12)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #179720

numpy 2.3.2 is the earliest version that publishes cp314 wheels on PyPI.
The previous pin (2.1.0) forced both Linux and macOS CD builds to compile numpy from source, slowing down the pipeline.
Bump to 2.3.4 to match the version already used in requirements-ci.txt.

Also fixes swapped echo messages in the macOS build script.