### PR TITLE
Pin claude-code-action to v1.0.89 to fix Bedrock auth regression

### DIFF
--- a/.github/workflows/claude-autorevert-advisor.yml
+++ b/.github/workflows/claude-autorevert-advisor.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run AI Advisor
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.89
         with:
           allowed_bots: "pytorch-auto-revert[bot]"
           use_bedrock: "true"

--- a/.github/workflows/claude-issue-triage-run.yml
+++ b/.github/workflows/claude-issue-triage-run.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run Issue Triage
         timeout-minutes: 5
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.89
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRIAGE_HOOK_DEBUG_LOG: /tmp/triage_hooks.log


### PR DESCRIPTION
## Summary
- Pin `anthropics/claude-code-action` from `@v1` (floating) to `@v1.0.89` in both Claude workflows
- v1.0.90 (released Apr 8 04:42 UTC) bumped Claude Code CLI from 2.1.92 → 2.1.96, which breaks AWS Bedrock SigV4 authentication
- Every triage and autorevert-advisor run since the release has been failing with `403` errors

## Affected workflows
- `claude-issue-triage-run.yml`
- `claude-autorevert-advisor.yml`

## Test plan
- [x] Tested in pytorch/ciforge first: https://github.com/pytorch/ciforge/actions/runs/24149179180 (passed)
- [ ] Unpin once upstream fixes the regression

cc @izaitsevfb