### PR TITLE
[inductor] Raise split reduction threshold from 8K to 524K on Blackwell+

### DIFF
--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -478,7 +478,12 @@ class InductorChoices:
             # we leak reduction autotune configs here, and will need to refactor to avoid this later
             if numel_hint >= 2 * num_sm:  # don't split if there are enough outputs
                 return 1
-            if reduction_numel_hint <= 8192:
+            # based on sum(x[N]) on GB200, split reduction provides higher performance when N >= 1M
+            # TODO: test more hardwares
+            no_split_threshold = (
+                524288 if props.major is not None and props.major >= 10 else 8192
+            )
+            if reduction_numel_hint <= no_split_threshold:
                 return 1
             if reduction_numel_hint * numel_hint <= min_elements_per_device:
                 split_size = min_elements_per_thread


### PR DESCRIPTION
The split reduction heuristic was too aggressive for small-batch, moderate-reduction workloads (e.g. entropy/softmax over vocab=32K). With the old threshold of 8192, a batch=1 entropy computation over 32K vocab was split into 8 kernel launches (4 CTAs + tree-reduce for each of the 3 reduction steps), making torch.compile 2x slower than eager.

Raising the threshold to 524K on Blackwell (SM >= 10.0) avoids unnecessary splitting for practical softmax/entropy/layernorm vocab sizes while preserving splits for truly large reductions (>1M) where single-CTA throughput becomes a bottleneck. Older architectures retain the original 8192 threshold.

Benchmark on GB200 (global sum, batch=1):
  n=32K:  split 0.047ms → nosplit 0.036ms  (-25%)
  n=524K: split 0.040ms → nosplit 0.032ms  (-19%)
  n=1M:   split 0.042ms → nosplit 0.050ms  (+18%, still splits with new threshold)
  n=8M:   split 0.042ms → nosplit 0.595ms  (regression, still splits with new threshold)

Fixes https://github.com/pytorch/pytorch/issues/179697

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo