### PR TITLE
Fix MemorySanitizer use-of-uninitialized-value in PyCapsule_IsValid.

### DIFF
--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -3015,6 +3015,7 @@ class GuardManager {
       if (PyCapsule_IsValid(e.cap, "GuardManager*")) {
         PyCapsule_SetName(e.cap, "DeadGuardManager");
       }
+      Py_DECREF(e.cap);
       Py_CLEAR(e.wr); // kills weakref (may remove callback)
     }
     _tag_safe_entries.clear();
@@ -3455,6 +3456,7 @@ class GuardManager {
       return false;
     }
     // These will be decrefed in destructor
+    Py_INCREF(capsule);
     _tag_safe_entries.push_back({wr, capsule});
     return true;
   }


### PR DESCRIPTION
Fix MemorySanitizer use-of-uninitialized-value in PyCapsule_IsValid.

The `GuardManager` stores raw pointers to `capsule` objects in `_tag_safe_entries` without increasing their reference count. If the target object of the weakref dies, the callback is triggered and then released by the weakref, which in turn destroys the capsule. This leaves a dangling pointer in `_tag_safe_entries`.

This change ensures that `capsule` stays alive while in `_tag_safe_entries` by increasing its reference count when added, and decreasing it when `cleanup_tag_safe_entries` is called.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98