### PR TITLE
Fix torch.compile istft failing when length exceeds reconstructed sig…

### DIFF
--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1597,6 +1597,42 @@ class TestFFT(TestCase):
         with self.assertRaisesRegex(RuntimeError, "istft input and window must be on the same device"):
             torch.istft(x.to(device), n_fft=100, window=window)
 
+    @onlyNativeDeviceTypes
+    @skipCPUIfNoFFT
+    def test_istft_compile_length_exceeds_signal(self, device):
+        """torch.compile should not error when istft length exceeds the reconstructed signal size.
+
+        Regression test for https://github.com/pytorch/pytorch/issues/179593
+        """
+        n_fft = 1024
+        hop_length = 512
+        # length intentionally exceeds the reconstructed signal size so the
+        # narrow-then-pad path is exercised.
+        length = 51712
+        window = torch.hann_window(n_fft, device=device)
+        spec = torch.view_as_complex(
+            torch.randn(16, n_fft // 2 + 1, 100, 2, device=device)
+        )
+
+        with self.assertWarnsOnceRegex(
+            UserWarning, "The length of signal is shorter than the length parameter."
+        ):
+            eager_out = torch.istft(
+                spec, n_fft=n_fft, hop_length=hop_length,
+                window=window, length=length,
+            )
+
+        compiled_istft = torch.compile(torch.istft)
+        with self.assertWarnsOnceRegex(
+            UserWarning, "The length of signal is shorter than the length parameter."
+        ):
+            compiled_out = compiled_istft(
+                spec, n_fft=n_fft, hop_length=hop_length,
+                window=window, length=length,
+            )
+
+        self.assertEqual(eager_out, compiled_out)
+
 
 class FFTDocTestFinder:
     '''The default doctest finder doesn't like that function.__module__ doesn't

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3818,9 +3818,12 @@ def istft(
     else:
         end = expected_output_signal_len
 
-    length = max(0, end - start)
-    y = y.narrow(dim=1, start=start, length=length)
-    window_envelop = window_envelop.narrow(dim=1, start=start, length=length)
+    # Clamp narrow length to available tensor extent so that we don't error
+    # when length exceeds the reconstructed signal size (matching eager behavior
+    # which uses slice that silently clamps, then zero-pads afterward).
+    narrow_length = max(0, min(end, expected_output_signal_len) - start)
+    y = y.narrow(dim=1, start=start, length=narrow_length)
+    window_envelop = window_envelop.narrow(dim=1, start=start, length=narrow_length)
 
     y = y / window_envelop
     if original_ndim == 2:


### PR DESCRIPTION
Fix torch.compile `istft` failing when length exceeds reconstructed signal size

The Python ref for istft used `narrow` which hard-checks that `start + length <= dim_size`, causing torch.compile to error when the `length` parameter exceeds the reconstructed signal size. Eager mode succeeds because C++ `slice` silently clamps the end index, then zero-pads the result.

Fix by clamping the narrow length to the available tensor extent, allowing execution to reach the existing zero-padding logic that was previously dead code.

Fixes https://github.com/pytorch/pytorch/issues/179593