### PR TITLE
Skip expensive debug_lines computation in AOT autograd cache

### DIFF
--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -758,12 +758,17 @@ def autograd_cache_key(
             pickler = AOTAutogradCachePickler(gm)
             # The prefix distinguishes among the other kinds of objects we cache
             key = "a" + pickler.get_hash(details)
-            debug_lines = pickler.debug_lines(details)
-            log.debug(
-                "Autograd graph cache hash details for key %s:\n%s",
-                key,
-                LazyString(lambda: "\n".join(debug_lines)),
-            )
+            # debug_lines re-hashes every attribute individually and is
+            # expensive. Only compute when debug logging is enabled.
+            if log.isEnabledFor(logging.DEBUG):
+                debug_lines = pickler.debug_lines(details)
+                log.debug(
+                    "Autograd graph cache hash details for key %s:\n%s",
+                    key,
+                    LazyString(lambda: "\n".join(debug_lines)),
+                )
+            else:
+                debug_lines: list[str] = []
             return key, debug_lines
         except Exception:
             # If enable_aot_compile is set, we're in AOT precompile mode where we always


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179910
* #179734
* __->__ #179733

FxGraphCachePickler.debug_lines re-hashes every attribute of the cache
details object individually. This runs unconditionally even when debug
logging is disabled.

Gate the computation behind log.isEnabledFor(logging.DEBUG) so the
cost is only paid when someone is actively debugging cache key
differences.

On a vLLM Meta-Llama-3-70B-Instruct TP=4 benchmark, this reduces
cold compile time from 30.50 ± 0.50 s to 29.40 ± 0.90 s (1.04x)
and cache lookup time from 11.35 ± 0.45 ms to 6.25 ± 0.30 ms
(1.82x).

Authored with Claude.

cc @oulgen @jamesjwu @aorenste @anijain2305 @laithsakka @penguinwu @masnesral @coconutruben @aditvenk