### PR TITLE
Speed up ConfigModule._get_dict by avoiding unnecessary work

### DIFF
--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -529,7 +529,9 @@ class ConfigModule(ModuleType):
                 it skips it.
         """
         config: dict[str, Any] = {}
-        for key in self._config:
+        for key, entry in self._config.items():
+            if entry.alias is not None:
+                continue
             if ignored_keys and key in ignored_keys:
                 continue
             if ignored_prefixes:
@@ -537,14 +539,23 @@ class ConfigModule(ModuleType):
                     continue
             if skip_default and self._is_default(key):
                 continue
-            if self._config[key].alias is not None:
-                continue
 
-            curr_entry = self._config[key]
-            has_been_warned = curr_entry._deprecation_warned
-            curr_entry._deprecation_warned = True
-            config[key] = copy.deepcopy(getattr(self, key))
-            curr_entry._deprecation_warned = has_been_warned
+            # Read value directly, bypassing __getattr__ overhead
+            # (deprecation warnings, alias resolution).
+            user_override = entry.user_override.get()
+            if entry.env_value_force is not _UNSET_SENTINEL:
+                val = entry.env_value_force
+            elif user_override is not _UNSET_SENTINEL:
+                val = user_override
+            elif entry.env_value_default is not _UNSET_SENTINEL:
+                val = entry.env_value_default
+            elif entry.justknob is not None:
+                val = justknobs_check(name=entry.justknob, default=entry.default)
+            else:
+                val = entry.default
+            if isinstance(val, (list, set, dict)):
+                val = copy.deepcopy(val)
+            config[key] = val
 
         return config
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179910
* __->__ #179734
* #179733

_get_dict is called from save_config_portable on every AOT autograd
cache key computation.

1. It called copy.deepcopy on every config value, but the vast
   majority are immutable types (bool, int, str, None) that don't
   need copying. Now only list/set/dict values are deep-copied.

2. It went through __getattr__ for every value, which includes
   deprecation warning checks, alias resolution, and other overhead.
   Now reads values directly from config entries.

On a vLLM Meta-Llama-3-70B-Instruct TP=4 benchmark, this reduces
cold compile time from 29.40 ± 0.90 s to 28.50 ± 0.40 s (1.03x)
and cache lookup time from 6.25 ± 0.30 ms to 5.20 ± 0.45 ms
(1.20x).

Authored with Claude.

cc @oulgen @jamesjwu @aorenste @anijain2305 @laithsakka @penguinwu @masnesral @coconutruben @aditvenk