### PR TITLE
[CI] Add torchtitan test on pull when hash is updated

### DIFF
--- a/.github/workflows/torchtitan.yml
+++ b/.github/workflows/torchtitan.yml
@@ -1,6 +1,9 @@
 name: torchtitan-test
 
 on:
+  pull_request:
+    paths:
+      - .github/ci_commit_pins/torchtitan.txt‎
   push:
     branches:
       - main


### PR DESCRIPTION
I noticed that https://github.com/pytorch/pytorch/pull/178727 does not actually run torchtitan test. Hence adding it here.