### PR TITLE
[CI] Auto-trigger torchtitan tests when commit pin is updated

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -190,6 +190,8 @@
 - test/distributed/**/*mem*/**
 
 "ciflow/torchtitan":
+# torchtitan commit pin updates
+- .github/ci_commit_pins/torchtitan.txt
 # torch.distributed (FSDP, DTensor, etc.)
 - torch/distributed/**
 # torch.compile


### PR DESCRIPTION
 ## Summary                                                             
  When a PR updates `.github/ci_commit_pins/torchtitan.txt`, the  torchtitan CI workflow should run automatically. Currently it doesn't because the pin file path is not in the `ciflow/torchtitan` labeler  config.                                                            
                                                                         
This adds the pin file path to `.github/labeler.yml` so the labeler auto-applies the `ciflow/torchtitan` label, which triggers the workflow via the existing ciflow tag mechanism.                                
                                                                         
This is problematic PR example: https://github.com/pytorch/pytorch/pull/178727

  ## Test plan                                                    
  - Create a PR that modifies `.github/ci_commit_pins/torchtitan.txt`
  - Verify the `ciflow/torchtitan` label is auto-applied by the labeler
  - Verify the `torchtitan-test` workflow is triggered    