### PR TITLE
torch.backends.fp32_precision setter propagate to cudnn.conv/rnn

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -81,6 +81,9 @@ std::string precision2str(Float32Precision prec) {
       return "tf32";
     case Float32Precision::BF16:
       return "bf16";
+    case Float32Precision::DEFAULT:
+      // DEFAULT is an internal sentinel and should be resolved before reaching here
+      TORCH_CHECK(false, "DEFAULT precision should not be visible externally");
   }
   TORCH_CHECK(false, "Invalid enum Float32Precision(", static_cast<int>(prec), ")");
 }
@@ -391,13 +394,30 @@ Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op)
   TORCH_CHECK(it != fp32_precision.end(), "Invalid (backend, op) pair: (", backend, ", ", op, ")");
 
   Float32Precision precision = it->second;
-  if (precision == Float32Precision::NONE) {
+  // DEFAULT and NONE both fall through to parent settings.
+  // We track whether the original stored value was DEFAULT so we can apply the
+  // correct legacy fallback at the end (TF32 for CUDA conv/rnn).
+  bool started_as_default = (precision == Float32Precision::DEFAULT);
+  if (precision == Float32Precision::NONE || precision == Float32Precision::DEFAULT) {
     key.second = Float32Op::ALL;
     precision = fp32_precision.find(key)->second;
   }
-  if (precision == Float32Precision::NONE) {
+  if (precision == Float32Precision::NONE || precision == Float32Precision::DEFAULT) {
     key.first = Float32Backend::GENERIC;
     precision = fp32_precision.find(key)->second;
+  }
+
+  // When the original stored value was DEFAULT and no parent specifies a concrete
+  // precision, apply the legacy backend default (TF32 for CUDA conv/rnn).
+  if (started_as_default && (precision == Float32Precision::NONE || precision == Float32Precision::DEFAULT)) {
+    if (backend == Float32Backend::CUDA && (op == Float32Op::CONV || op == Float32Op::RNN)) {
+      return Float32Precision::TF32;
+    }
+    return Float32Precision::NONE;
+  }
+
+  if (precision == Float32Precision::DEFAULT) {
+    precision = Float32Precision::NONE;
   }
 
   // "cuda" does not support "bf16"
@@ -445,6 +465,9 @@ void Context::setFloat32Precision(Float32Backend backend, Float32Op op, Float32P
   TORCH_CHECK(
       !(backend == Float32Backend::CUDA && p == Float32Precision::BF16),
       "backend 'cuda' does not support precision 'bf16'");
+  TORCH_CHECK(
+      p != Float32Precision::DEFAULT,
+      "DEFAULT precision is internal and cannot be set explicitly");
 
   it->second = p;
 }

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -220,21 +220,17 @@ bool Context::allowTF32CuDNN(std::optional<Float32Op> op) const {
   if (!op.has_value()) {
     bool allow_tf32_rnn = float32Precision(Float32Backend::CUDA, Float32Op::RNN) == Float32Precision::TF32;
     bool allow_tf32_conv = float32Precision(Float32Backend::CUDA, Float32Op::CONV) == Float32Precision::TF32;
-    // Only raise if conv and rnn disagree — that is a genuine mix of the
-    // legacy and new APIs. The legacy allow_tf32_cudnn bool is not included
-    // in this check because it can be stale when the new-API generic path
-    // (torch.backends.fp32_precision) was used to set the precision.
     TORCH_CHECK(
-        allow_tf32_rnn == allow_tf32_conv,
+        allow_tf32_rnn == allow_tf32_conv && allow_tf32_rnn == allow_tf32_cudnn,
         "PyTorch is checking whether allow_tf32 is enabled for cuDNN without a specific operator name,",
         "but the current flag(s) indicate that cuDNN conv and cuDNN RNN have different TF32 flags.",
         "This combination indicates that you have used a mix of the legacy and new APIs to set the TF32 flags. ",
         "We suggest only using the new API to set the TF32 flag(s). See also: ",
         "https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
-    return allow_tf32_conv;
   } else {
     return float32Precision(Float32Backend::CUDA, op.value()) == Float32Precision::TF32;
   }
+  return allow_tf32_cudnn;
 }
 
 void Context::setAllowTF32CuDNN(bool b) {

--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -220,17 +220,21 @@ bool Context::allowTF32CuDNN(std::optional<Float32Op> op) const {
   if (!op.has_value()) {
     bool allow_tf32_rnn = float32Precision(Float32Backend::CUDA, Float32Op::RNN) == Float32Precision::TF32;
     bool allow_tf32_conv = float32Precision(Float32Backend::CUDA, Float32Op::CONV) == Float32Precision::TF32;
+    // Only raise if conv and rnn disagree — that is a genuine mix of the
+    // legacy and new APIs. The legacy allow_tf32_cudnn bool is not included
+    // in this check because it can be stale when the new-API generic path
+    // (torch.backends.fp32_precision) was used to set the precision.
     TORCH_CHECK(
-        allow_tf32_rnn == allow_tf32_conv && allow_tf32_rnn == allow_tf32_cudnn,
+        allow_tf32_rnn == allow_tf32_conv,
         "PyTorch is checking whether allow_tf32 is enabled for cuDNN without a specific operator name,",
         "but the current flag(s) indicate that cuDNN conv and cuDNN RNN have different TF32 flags.",
         "This combination indicates that you have used a mix of the legacy and new APIs to set the TF32 flags. ",
         "We suggest only using the new API to set the TF32 flag(s). See also: ",
         "https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices");
+    return allow_tf32_conv;
   } else {
     return float32Precision(Float32Backend::CUDA, op.value()) == Float32Precision::TF32;
   }
-  return allow_tf32_cudnn;
 }
 
 void Context::setAllowTF32CuDNN(bool b) {
@@ -394,30 +398,32 @@ Float32Precision Context::float32Precision(Float32Backend backend, Float32Op op)
   TORCH_CHECK(it != fp32_precision.end(), "Invalid (backend, op) pair: (", backend, ", ", op, ")");
 
   Float32Precision precision = it->second;
-  // DEFAULT and NONE both fall through to parent settings.
-  // We track whether the original stored value was DEFAULT so we can apply the
-  // correct legacy fallback at the end (TF32 for CUDA conv/rnn).
-  bool started_as_default = (precision == Float32Precision::DEFAULT);
-  if (precision == Float32Precision::NONE || precision == Float32Precision::DEFAULT) {
+
+  // DEFAULT means "inherit from parent if set, otherwise use the legacy TF32
+  // default". It is only used as the initial state for CUDA conv/rnn.
+  if (precision == Float32Precision::DEFAULT) {
+    key.second = Float32Op::ALL;
+    Float32Precision parent = fp32_precision.find(key)->second;
+    if (parent == Float32Precision::NONE || parent == Float32Precision::DEFAULT) {
+      key.first = Float32Backend::GENERIC;
+      parent = fp32_precision.find(key)->second;
+    }
+    if (parent != Float32Precision::NONE && parent != Float32Precision::DEFAULT) {
+      // A parent explicitly overrides; apply it (cuda does not support bf16).
+      return (backend == Float32Backend::CUDA && parent == Float32Precision::BF16)
+          ? Float32Precision::NONE
+          : parent;
+    }
+    return Float32Precision::TF32;
+  }
+
+  if (precision == Float32Precision::NONE) {
     key.second = Float32Op::ALL;
     precision = fp32_precision.find(key)->second;
   }
-  if (precision == Float32Precision::NONE || precision == Float32Precision::DEFAULT) {
+  if (precision == Float32Precision::NONE) {
     key.first = Float32Backend::GENERIC;
     precision = fp32_precision.find(key)->second;
-  }
-
-  // When the original stored value was DEFAULT and no parent specifies a concrete
-  // precision, apply the legacy backend default (TF32 for CUDA conv/rnn).
-  if (started_as_default && (precision == Float32Precision::NONE || precision == Float32Precision::DEFAULT)) {
-    if (backend == Float32Backend::CUDA && (op == Float32Op::CONV || op == Float32Op::RNN)) {
-      return Float32Precision::TF32;
-    }
-    return Float32Precision::NONE;
-  }
-
-  if (precision == Float32Precision::DEFAULT) {
-    precision = Float32Precision::NONE;
   }
 
   // "cuda" does not support "bf16"

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -47,8 +47,9 @@ enum class CuBLASReductionOption : uint8_t {
 };
 enum class TORCH_API Float32Backend { GENERIC, CUDA, MKLDNN };
 enum class TORCH_API Float32Op { ALL, CONV, RNN, MATMUL };
-// DEFAULT is an internal-only sentinel meaning "use legacy backend default unless
-// a parent setting overrides it". NONE means "explicitly set to inherit/no-op".
+// DEFAULT is an internal-only sentinel meaning "use legacy backend default
+// unless a parent setting overrides it". NONE means "explicitly set to
+// inherit/no-op".
 enum class TORCH_API Float32Precision { NONE, IEEE, TF32, BF16, DEFAULT };
 
 enum class TORCH_API CuDNNDepthwiseKernel { AUTO, CUDNN, NATIVE };

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -47,7 +47,9 @@ enum class CuBLASReductionOption : uint8_t {
 };
 enum class TORCH_API Float32Backend { GENERIC, CUDA, MKLDNN };
 enum class TORCH_API Float32Op { ALL, CONV, RNN, MATMUL };
-enum class TORCH_API Float32Precision { NONE, IEEE, TF32, BF16 };
+// DEFAULT is an internal-only sentinel meaning "use legacy backend default unless
+// a parent setting overrides it". NONE means "explicitly set to inherit/no-op".
+enum class TORCH_API Float32Precision { NONE, IEEE, TF32, BF16, DEFAULT };
 
 enum class TORCH_API CuDNNDepthwiseKernel { AUTO, CUDNN, NATIVE };
 
@@ -539,8 +541,8 @@ class TORCH_API Context {
       {{Float32Backend::MKLDNN, Float32Op::RNN}, Float32Precision::NONE},
       {{Float32Backend::MKLDNN, Float32Op::MATMUL}, Float32Precision::NONE},
       {{Float32Backend::CUDA, Float32Op::ALL}, Float32Precision::NONE},
-      {{Float32Backend::CUDA, Float32Op::CONV}, Float32Precision::TF32},
-      {{Float32Backend::CUDA, Float32Op::RNN}, Float32Precision::TF32},
+      {{Float32Backend::CUDA, Float32Op::CONV}, Float32Precision::DEFAULT},
+      {{Float32Backend::CUDA, Float32Op::RNN}, Float32Precision::DEFAULT},
       {{Float32Backend::CUDA, Float32Op::MATMUL},
        float32_matmul_precision == at::Float32MatmulPrecision::HIGHEST
            ? Float32Precision::NONE

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1126,6 +1126,34 @@ print(t.is_pinned())
             with self.assertRaisesRegex(RuntimeError, "mix of the legacy and new APIs"):
                 print(torch.backends.cuda.matmul.allow_tf32)
 
+    @recover_orig_fp32_precision
+    @serialTest()
+    def test_set_flags_with_mixed_tf32_state(self):
+        # Reproduce the scenario from torch.export._ignore_backend_decomps():
+        # user sets conv.fp32_precision="ieee" (new API) without syncing the
+        # legacy allow_tf32_cudnn flag, creating a mixed state where
+        # `torch.backends.cudnn.allow_tf32` raises RuntimeError.
+        # set_flags() must not raise when saving/restoring in this mixed state.
+        torch.backends.cudnn.conv.fp32_precision = "ieee"
+        # Confirm mixed state raises on the legacy getter.
+        with self.assertRaisesRegex(RuntimeError, "mix of the legacy and new APIs"):
+            print(torch.backends.cudnn.allow_tf32)
+        # set_flags() saves+applies new value without raising.
+        orig = torch.backends.cudnn.set_flags(False)
+        # Restoring should also not raise.
+        torch.backends.cudnn.set_flags(*orig)
+        # After restore, new-API conv precision is back to "ieee".
+        self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "ieee")
+
+        # Also verify: setting both allow_tf32 AND fp32_precision together
+        # (the corrected usage) is fully round-tripped by set_flags.
+        torch.backends.cudnn.allow_tf32 = False
+        torch.backends.cudnn.conv.fp32_precision = "ieee"
+        orig = torch.backends.cudnn.set_flags(True)
+        torch.backends.cudnn.set_flags(*orig)
+        self.assertFalse(torch.backends.cudnn.allow_tf32)
+        self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "ieee")
+
     def test_type_conversions(self):
         x = torch.randn(5, 5)
         self.assertIsInstance(x.float(), torch.FloatTensor)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -9329,5 +9329,35 @@ instantiate_device_type_tests(TestCudaDeviceParametrized, globals())
 instantiate_device_type_tests(TestCudaGreenContexts, globals(), except_for="cpu")
 
 
+# Tests for fp32_precision flag propagation that don't require an actual CUDA
+# device — they only exercise C++ context state management.
+class TestFP32PrecisionFlags(TestCase):
+    @recover_orig_fp32_precision
+    @serialTest()
+    def test_generic_fp32_precision_propagates_to_cudnn_conv_rnn(self):
+        # Setting the top-level generic fp32_precision should propagate to
+        # cudnn.conv and cudnn.rnn when they are in "inherit" mode (NONE or
+        # initial DEFAULT).  This is a regression test for the bug where their
+        # initial DEFAULT value was not inheriting from the generic setting.
+        #
+        # Reset to "inherit" (NONE) first so the test is not order-dependent on
+        # whether a prior test left explicit TF32 in place.
+        torch.backends.cudnn.conv.fp32_precision = "none"
+        torch.backends.cudnn.rnn.fp32_precision = "none"
+
+        # Use the flags() context manager to avoid flags_frozen() errors when
+        # setting the top-level generic precision via ContextProp.
+        with torch.backends.flags(fp32_precision="ieee"):
+            self.assertEqual(torch.backends.cudnn.fp32_precision, "ieee")
+            self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "ieee")
+            self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "ieee")
+            self.assertEqual(torch.backends.cudnn.rnn.fp32_precision, "ieee")
+
+            # A more-specific override still takes precedence over the generic
+            torch.backends.cudnn.conv.fp32_precision = "tf32"
+            self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "tf32")
+            self.assertEqual(torch.backends.cudnn.rnn.fp32_precision, "ieee")
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1126,34 +1126,6 @@ print(t.is_pinned())
             with self.assertRaisesRegex(RuntimeError, "mix of the legacy and new APIs"):
                 print(torch.backends.cuda.matmul.allow_tf32)
 
-    @recover_orig_fp32_precision
-    @serialTest()
-    def test_set_flags_with_mixed_tf32_state(self):
-        # Reproduce the scenario from torch.export._ignore_backend_decomps():
-        # user sets conv.fp32_precision="ieee" (new API) without syncing the
-        # legacy allow_tf32_cudnn flag, creating a mixed state where
-        # `torch.backends.cudnn.allow_tf32` raises RuntimeError.
-        # set_flags() must not raise when saving/restoring in this mixed state.
-        torch.backends.cudnn.conv.fp32_precision = "ieee"
-        # Confirm mixed state raises on the legacy getter.
-        with self.assertRaisesRegex(RuntimeError, "mix of the legacy and new APIs"):
-            print(torch.backends.cudnn.allow_tf32)
-        # set_flags() saves+applies new value without raising.
-        orig = torch.backends.cudnn.set_flags(False)
-        # Restoring should also not raise.
-        torch.backends.cudnn.set_flags(*orig)
-        # After restore, new-API conv precision is back to "ieee".
-        self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "ieee")
-
-        # Also verify: setting both allow_tf32 AND fp32_precision together
-        # (the corrected usage) is fully round-tripped by set_flags.
-        torch.backends.cudnn.allow_tf32 = False
-        torch.backends.cudnn.conv.fp32_precision = "ieee"
-        orig = torch.backends.cudnn.set_flags(True)
-        torch.backends.cudnn.set_flags(*orig)
-        self.assertFalse(torch.backends.cudnn.allow_tf32)
-        self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "ieee")
-
     def test_type_conversions(self):
         x = torch.randn(5, 5)
         self.assertIsInstance(x.float(), torch.FloatTensor)
@@ -9363,28 +9335,20 @@ class TestFP32PrecisionFlags(TestCase):
     @recover_orig_fp32_precision
     @serialTest()
     def test_generic_fp32_precision_propagates_to_cudnn_conv_rnn(self):
-        # Setting the top-level generic fp32_precision should propagate to
-        # cudnn.conv and cudnn.rnn when they are in "inherit" mode (NONE or
-        # initial DEFAULT).  This is a regression test for the bug where their
-        # initial DEFAULT value was not inheriting from the generic setting.
-        #
-        # Reset to "inherit" (NONE) first so the test is not order-dependent on
-        # whether a prior test left explicit TF32 in place.
-        torch.backends.cudnn.conv.fp32_precision = "none"
-        torch.backends.cudnn.rnn.fp32_precision = "none"
-
-        # Use the flags() context manager to avoid flags_frozen() errors when
-        # setting the top-level generic precision via ContextProp.
+        # Regression test: setting torch.backends.fp32_precision = "ieee"
+        # must propagate to cudnn.conv and cudnn.rnn.
+        torch.backends.fp32_precision = "ieee"
+        self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "ieee")
+        self.assertEqual(torch.backends.cudnn.rnn.fp32_precision, "ieee")
+        self.assertEqual(torch.backends.cudnn.fp32_precision, "ieee")
+        self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "ieee")
         with torch.backends.flags(fp32_precision="ieee"):
-            self.assertEqual(torch.backends.cudnn.fp32_precision, "ieee")
-            self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "ieee")
             self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "ieee")
             self.assertEqual(torch.backends.cudnn.rnn.fp32_precision, "ieee")
-
-            # A more-specific override still takes precedence over the generic
-            torch.backends.cudnn.conv.fp32_precision = "tf32"
-            self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "tf32")
-            self.assertEqual(torch.backends.cudnn.rnn.fp32_precision, "ieee")
+            self.assertEqual(torch.backends.cudnn.fp32_precision, "ieee")
+            self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "ieee")
+            # allow_tf32 should return False cleanly — no RuntimeError.
+        self.assertFalse(torch.backends.cudnn.allow_tf32)
 
 
 if __name__ == "__main__":

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1126,6 +1126,8 @@ print(t.is_pinned())
             with self.assertRaisesRegex(RuntimeError, "mix of the legacy and new APIs"):
                 print(torch.backends.cuda.matmul.allow_tf32)
 
+
+
     def test_type_conversions(self):
         x = torch.randn(5, 5)
         self.assertIsInstance(x.float(), torch.FloatTensor)
@@ -9337,18 +9339,11 @@ class TestFP32PrecisionFlags(TestCase):
     def test_generic_fp32_precision_propagates_to_cudnn_conv_rnn(self):
         # Regression test: setting torch.backends.fp32_precision = "ieee"
         # must propagate to cudnn.conv and cudnn.rnn.
-        torch.backends.fp32_precision = "ieee"
-        self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "ieee")
-        self.assertEqual(torch.backends.cudnn.rnn.fp32_precision, "ieee")
-        self.assertEqual(torch.backends.cudnn.fp32_precision, "ieee")
-        self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "ieee")
         with torch.backends.flags(fp32_precision="ieee"):
             self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "ieee")
             self.assertEqual(torch.backends.cudnn.rnn.fp32_precision, "ieee")
             self.assertEqual(torch.backends.cudnn.fp32_precision, "ieee")
             self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "ieee")
-            # allow_tf32 should return False cleanly — no RuntimeError.
-        self.assertFalse(torch.backends.cudnn.allow_tf32)
 
 
 if __name__ == "__main__":

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1126,8 +1126,6 @@ print(t.is_pinned())
             with self.assertRaisesRegex(RuntimeError, "mix of the legacy and new APIs"):
                 print(torch.backends.cuda.matmul.allow_tf32)
 
-
-
     def test_type_conversions(self):
         x = torch.randn(5, 5)
         self.assertIsInstance(x.float(), torch.FloatTensor)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -9337,6 +9337,8 @@ class TestFP32PrecisionFlags(TestCase):
     def test_generic_fp32_precision_propagates_to_cudnn_conv_rnn(self):
         # Regression test: setting torch.backends.fp32_precision = "ieee"
         # must propagate to cudnn.conv and cudnn.rnn.
+        self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "tf32")
+        self.assertEqual(torch.backends.cudnn.rnn.fp32_precision, "tf32")
         with torch.backends.flags(fp32_precision="ieee"):
             self.assertEqual(torch.backends.cudnn.conv.fp32_precision, "ieee")
             self.assertEqual(torch.backends.cudnn.rnn.fp32_precision, "ieee")

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -160,12 +160,19 @@ def set_flags(
     _fp32_precision="none",
     _depthwise_kernel=None,
 ):
+    try:
+        _allow_tf32_saved = torch._C._get_cudnn_allow_tf32()
+    except RuntimeError:
+        # conv and RNN have different TF32 flags (mixed legacy/new API usage);
+        # save None so the restore step skips the legacy setter and lets the
+        # new-API _fp32_precision restore handle the TF32 state instead.
+        _allow_tf32_saved = None
     orig_flags = (
         torch._C._get_cudnn_enabled(),
         torch._C._get_cudnn_benchmark(),
         None if not is_available() else torch._C._cuda_get_cudnn_benchmark_limit(),
         torch._C._get_cudnn_deterministic(),
-        torch._C._get_cudnn_allow_tf32(),
+        _allow_tf32_saved,
         torch._C._get_fp32_precision_getter("cuda", "all"),
         torch._C._get_cudnn_depthwise_kernel(),
     )

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -160,19 +160,12 @@ def set_flags(
     _fp32_precision="none",
     _depthwise_kernel=None,
 ):
-    try:
-        _allow_tf32_saved = torch._C._get_cudnn_allow_tf32()
-    except RuntimeError:
-        # conv and RNN have different TF32 flags (mixed legacy/new API usage);
-        # save None so the restore step skips the legacy setter and lets the
-        # new-API _fp32_precision restore handle the TF32 state instead.
-        _allow_tf32_saved = None
     orig_flags = (
         torch._C._get_cudnn_enabled(),
         torch._C._get_cudnn_benchmark(),
         None if not is_available() else torch._C._cuda_get_cudnn_benchmark_limit(),
         torch._C._get_cudnn_deterministic(),
-        _allow_tf32_saved,
+        torch._C._get_cudnn_allow_tf32(),
         torch._C._get_fp32_precision_getter("cuda", "all"),
         torch._C._get_cudnn_depthwise_kernel(),
     )


### PR DESCRIPTION
fixes [179445](https://github.com/pytorch/pytorch/issues/179445)

issue#1 
torch.backends.fp32_precision setter doesn't propagate to cudnn.conv/rnn, I have tried to invoke default to handle this. 
issue#2 not resolved as that seems like legit to me. we need to error out if someone tries to use legacy and new API at the same time. 
suggested workaround to @ydshieh 

Let me know what you think.

