### PR TITLE
[BE] Refactor shared interpolation helpers into SamplingHelpers.h

### DIFF
--- a/aten/src/ATen/native/mps/kernels/GridSampler.metal
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.metal
@@ -1,4 +1,5 @@
 #include <ATen/native/mps/kernels/GridSampler.h>
+#include <ATen/native/mps/kernels/SamplingHelpers.h>
 #include <c10/metal/utils.h>
 #include <metal_array>
 #include <metal_stdlib>
@@ -148,35 +149,6 @@ struct PadReflection {
   }
 };
 
-// Cubic convolution helper 1: for |x| < 1
-template <typename T>
-static T cubic_convolution1(T x, T A) {
-  return ((A + 2) * x - (A + 3)) * x * x + 1;
-}
-
-// Cubic convolution helper 2: for 1 <= |x| < 2
-template <typename T>
-static T cubic_convolution2(T x, T A) {
-  return ((A * x - 5 * A) * x + 8 * A) * x - 4 * A;
-}
-
-// Get cubic upsampling coefficients (Catmull-Rom spline with A=-0.75)
-template <typename T>
-static void get_cubic_coefficients(T coeffs[4], T t) {
-  T A = static_cast<T>(-0.75);
-  coeffs[0] = cubic_convolution2(t + 1, A);
-  coeffs[1] = cubic_convolution1(t, A);
-  coeffs[2] = cubic_convolution1(1 - t, A);
-  coeffs[3] = cubic_convolution2(2 - t, A);
-}
-
-// 1D cubic interpolation
-template <typename T>
-static T cubic_interp1d(T x0, T x1, T x2, T x3, T t) {
-  T coeffs[4];
-  get_cubic_coefficients(coeffs, t);
-  return x0 * coeffs[0] + x1 * coeffs[1] + x2 * coeffs[2] + x3 * coeffs[3];
-}
 
 // 2D Bilinear interpolation
 template <typename Pad, typename T>

--- a/aten/src/ATen/native/mps/kernels/GridSampler.metal
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.metal
@@ -149,7 +149,6 @@ struct PadReflection {
   }
 };
 
-
 // 2D Bilinear interpolation
 template <typename Pad, typename T>
 static T interpolate_bilinear_2d(

--- a/aten/src/ATen/native/mps/kernels/SamplingHelpers.h
+++ b/aten/src/ATen/native/mps/kernels/SamplingHelpers.h
@@ -2,7 +2,8 @@
 
 // Shared cubic interpolation helpers used by both GridSampler and UpSample
 // kernels. Based on the Catmull-Rom spline with A=-0.75.
-// See https://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm
+// See
+// https://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm
 
 template <typename accscalar_t>
 accscalar_t cubic_convolution1(accscalar_t x, accscalar_t A) {

--- a/aten/src/ATen/native/mps/kernels/SamplingHelpers.h
+++ b/aten/src/ATen/native/mps/kernels/SamplingHelpers.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// Shared cubic interpolation helpers used by both GridSampler and UpSample
+// kernels. Based on the Catmull-Rom spline with A=-0.75.
+// See https://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm
+
+template <typename accscalar_t>
+accscalar_t cubic_convolution1(accscalar_t x, accscalar_t A) {
+  return ((A + 2) * x - (A + 3)) * x * x + 1;
+}
+
+template <typename accscalar_t>
+accscalar_t cubic_convolution2(accscalar_t x, accscalar_t A) {
+  return ((A * x - 5 * A) * x + 8 * A) * x - 4 * A;
+}
+
+template <typename accscalar_t>
+void get_cubic_coefficients(accscalar_t coeffs[4], accscalar_t t) {
+  accscalar_t A = -0.75;
+
+  accscalar_t x1 = t;
+  coeffs[0] = cubic_convolution2<accscalar_t>(x1 + 1.0, A);
+  coeffs[1] = cubic_convolution1<accscalar_t>(x1, A);
+
+  accscalar_t x2 = 1.0 - t;
+  coeffs[2] = cubic_convolution1<accscalar_t>(x2, A);
+  coeffs[3] = cubic_convolution2<accscalar_t>(x2 + 1.0, A);
+}
+
+template <typename scalar_t, typename accscalar_t>
+accscalar_t cubic_interp1d(
+    scalar_t x0,
+    scalar_t x1,
+    scalar_t x2,
+    scalar_t x3,
+    accscalar_t t) {
+  accscalar_t coeffs[4];
+  get_cubic_coefficients<accscalar_t>(coeffs, t);
+
+  return x0 * coeffs[0] + x1 * coeffs[1] + x2 * coeffs[2] + x3 * coeffs[3];
+}

--- a/aten/src/ATen/native/mps/kernels/UpSample.metal
+++ b/aten/src/ATen/native/mps/kernels/UpSample.metal
@@ -1,48 +1,10 @@
+#include <ATen/native/mps/kernels/SamplingHelpers.h>
 #include <ATen/native/mps/kernels/UpSample.h>
 #include <c10/metal/atomic.h>
 #include <metal_stdlib>
 
 using namespace metal;
 using namespace c10::metal;
-
-// Based on
-// https://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm
-template <typename accscalar_t>
-accscalar_t cubic_convolution1(accscalar_t x, accscalar_t A) {
-  return ((A + 2) * x - (A + 3)) * x * x + 1;
-}
-
-template <typename accscalar_t>
-accscalar_t cubic_convolution2(accscalar_t x, accscalar_t A) {
-  return ((A * x - 5 * A) * x + 8 * A) * x - 4 * A;
-}
-
-template <typename accscalar_t>
-void get_cubic_upsampling_coefficients(accscalar_t coeffs[4], accscalar_t t) {
-  accscalar_t A = -0.75;
-
-  accscalar_t x1 = t;
-  coeffs[0] = cubic_convolution2<accscalar_t>(x1 + 1.0, A);
-  coeffs[1] = cubic_convolution1<accscalar_t>(x1, A);
-
-  // opposite coefficients
-  accscalar_t x2 = 1.0 - t;
-  coeffs[2] = cubic_convolution1<accscalar_t>(x2, A);
-  coeffs[3] = cubic_convolution2<accscalar_t>(x2 + 1.0, A);
-}
-
-template <typename scalar_t, typename accscalar_t>
-accscalar_t cubic_interp1d(
-    scalar_t x0,
-    scalar_t x1,
-    scalar_t x2,
-    scalar_t x3,
-    accscalar_t t) {
-  accscalar_t coeffs[4];
-  get_cubic_upsampling_coefficients<accscalar_t>(coeffs, t);
-
-  return x0 * coeffs[0] + x1 * coeffs[1] + x2 * coeffs[2] + x3 * coeffs[3];
-}
 
 template <typename accscalar_t>
 accscalar_t area_pixel_compute_source_index(
@@ -720,8 +682,8 @@ kernel void upsample_bicubic2d_backward(
   float x_coeffs[4];
   float y_coeffs[4];
 
-  get_cubic_upsampling_coefficients(x_coeffs, t_x);
-  get_cubic_upsampling_coefficients(y_coeffs, t_y);
+  get_cubic_coefficients(x_coeffs, t_x);
+  get_cubic_coefficients(y_coeffs, t_y);
 
   for (int n = 0; n < output_sizes.x; n++) {
     for (int c = 0; c < output_sizes.y; ++c) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #179756
* __->__ #179751

Move `cubic_convolution1`, `cubic_convolution2`, `get_cubic_coefficients`, and `cubic_interp1d` into a shared header used by both GridSampler.metal and UpSample.metal