### PR TITLE
Add IS_SM70/IS_SM75 lazy vals, eliminate local get_device_capability() in test_linalg

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -39,8 +39,8 @@ from torch.testing._internal.common_dtype import (
     all_types, all_types_and_complex_and, floating_and_complex_types, integral_types,
     floating_and_complex_types_and, floating_types_and, complex_types,
 )
-from torch.testing._internal.common_cuda import CDNA2OrLater, SM80OrLater, SM90OrLater, tf32_on_and_off, _get_magma_version, \
-    _get_torch_cuda_version, TEST_MULTIGPU
+from torch.testing._internal.common_cuda import CDNA2OrLater, IS_SM70, IS_SM75, SM80OrLater, SM90OrLater, \
+    tf32_on_and_off, _get_magma_version, _get_torch_cuda_version, TEST_MULTIGPU
 from torch.testing._internal.common_quantization import _group_quantize_tensor, _dynamically_quantize_per_channel, \
     _group_quantize_tensor_symmetric
 from torch.testing._internal.common_mkldnn import reduced_f32_on_and_off
@@ -7924,15 +7924,12 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
         # NOTE: We're just exercising terrible failures here.
         version = _get_torch_cuda_version()
-        SM80OrLater = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 0)
-        SM70 = torch.cuda.is_available() and torch.cuda.get_device_capability() == (7, 0)
-        SM75 = torch.cuda.is_available() and torch.cuda.get_device_capability() == (7, 5)
 
         if TEST_WITH_ROCM:
             _test(17, k, n, use_transpose_a, use_transpose_b, True)
         else:
             if not use_transpose_a and use_transpose_b:
-                if SM80OrLater or (version >= (12, 3) and (SM70 or SM75)):
+                if SM80OrLater or (version >= (12, 3) and (IS_SM70 or IS_SM75)):
                     _test(17, k, n, use_transpose_a, use_transpose_b, version > (11, 7))
                 else:
                     with self.assertRaisesRegex(RuntimeError,
@@ -7950,7 +7947,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
                     _test(17, k, n, use_transpose_a, use_transpose_b)
 
             if not use_transpose_a and not use_transpose_b:
-                if SM80OrLater or (version >= (12, 3) and (SM70 or SM75)):
+                if SM80OrLater or (version >= (12, 3) and (IS_SM70 or IS_SM75)):
                     _test(17, k, n, use_transpose_a, use_transpose_b)
                 else:
                     with self.assertRaisesRegex(RuntimeError,

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -40,6 +40,8 @@ IS_THOR = LazyVal(lambda: torch.cuda.is_available() and torch.version.cuda is no
                   ((torch.cuda.get_device_capability() == (11, 0) and int(torch.version.cuda[:2]) >= 13) or
                    (torch.cuda.get_device_capability() == (10, 1) and int(torch.version.cuda[:2]) < 13)))
 IS_JETSON = LazyVal(lambda: torch.cuda.is_available() and (torch.cuda.get_device_capability() in [(7, 2), (8, 7)] or IS_THOR))
+IS_SM70 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (7, 0))
+IS_SM75 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (7, 5))
 IS_SM89 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (8, 9))
 IS_SM90 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (9, 0))
 IS_SM100 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0))


### PR DESCRIPTION
Addresses #175211.

`test__int_mm` in `test/test_linalg.py` was computing SM capability checks inline:

```python
SM80OrLater = torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 0)
SM70 = torch.cuda.is_available() and torch.cuda.get_device_capability() == (7, 0)
SM75 = torch.cuda.is_available() and torch.cuda.get_device_capability() == (7, 5)
```

The first line shadowed the `SM80OrLater` already imported from `common_cuda`. The latter two had no module-level equivalents.

This PR:
1. Adds `IS_SM70` and `IS_SM75` as `LazyVal` entries in `common_cuda.py`, following the existing `IS_SM89`/`IS_SM90`/`IS_SM100` pattern.
2. Imports them in `test_linalg.py` and removes the three local inline definitions.

No hardware needed to verify — logic is identical to the originals, just lifted to module scope as LazyVals.

**Duplicate check:** no open PR addresses this file/issue combination.

**Tests run:** Syntax-validated locally (`ast.parse`). CPU-only CI path exercised.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang