### PR TITLE
support all the back ends in FR

### DIFF
--- a/torch/distributed/debug/_debug_handlers.py
+++ b/torch/distributed/debug/_debug_handlers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from tabulate import tabulate
@@ -27,6 +28,9 @@ from torch.distributed.flight_recorder.components.types import (
 
 if TYPE_CHECKING:
     from torch.distributed.debug._frontend import FrontendServer, HTTPRequestHandler
+
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -635,10 +639,14 @@ class TorchCommsHealthCheckHandler(DebugHandler):
             if resp.status_code == 200:
                 try:
                     data = resp.json()
-                    if not data.get("healthy", True):
-                        return True
                 except Exception:
-                    pass
+                    logger.exception(
+                        "failed to parse health check response as JSON; "
+                        "treating rank as healthy"
+                    )
+                    continue
+                if not data.get("healthy", True):
+                    return True
         return False
 
     def _handle(self, req: HTTPRequestHandler) -> bytes:

--- a/torch/distributed/flight_recorder/components/types.py
+++ b/torch/distributed/flight_recorder/components/types.py
@@ -418,9 +418,19 @@ class Op:
     ):
         self.profiling_name = event["profiling_name"]
         comm_lib_backend, name = self.profiling_name.split(":")
-        if comm_lib_backend not in ["nccl", "ncclx", "gloo", "xccl"]:
+        _SUPPORTED_BACKENDS = {
+            "nccl",
+            "ncclx",
+            "xccl",
+            "gloo",
+            "rccl",
+            "rcclx",
+            "mccl",
+            "hccl",
+        }
+        if comm_lib_backend not in _SUPPORTED_BACKENDS:
             raise AssertionError(
-                f"name formatting error? {comm_lib_backend} not in supported backends"
+                f"name formatting error? {comm_lib_backend} not in {_SUPPORTED_BACKENDS}"
             )
         parts = name.split(" ")
         type = parts[0]


### PR DESCRIPTION

Summary:
Expand the set of supported communication backends in the flight recorder to include ncclx, gloo, rccl, rcclx, mccl, and hccl, in addition to the existing nccl and xccl. This prevents false assertion errors when using these valid backends and improves the error message to show all supported options.
