### PR TITLE
[pt2] Add indices dtype check to embedding meta registration

### DIFF
--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -323,6 +323,38 @@ class TestEmbeddingNNDeviceType(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, "'weight' must be 2-D"):
                 torch.nn.functional.embedding(indices, weight)
 
+    def test_embedding_float_indices_error(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/178042
+        # torch.compile should raise the same dtype error as eager when
+        # nn.Embedding receives float indices, even if the result is unused.
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(3, 16, kernel_size=1)
+                self.embedding = torch.nn.Embedding(100, 32)
+                self.fc = torch.nn.Linear(16 * 32 * 32, 10)
+
+            def forward(self, x, token_ids):
+                conv_out = self.conv(x)
+                gelu_out = torch.nn.functional.gelu(conv_out)
+                self.embedding(token_ids)  # result unused (dead code)
+                return self.fc(gelu_out.view(x.size(0), -1))
+
+        model = Model().to(device)
+        x = torch.randn(2, 3, 32, 32, device=device)
+        float_indices = torch.randn(2, 8, device=device)
+
+        error_msg = "Expected tensor for argument #1 'indices'"
+
+        with self.assertRaisesRegex(RuntimeError, error_msg):
+            model(x, float_indices)
+
+        for backend in ["aot_eager", "inductor"]:
+            torch._dynamo.reset()
+            compiled = torch.compile(model, backend=backend, fullgraph=True)
+            with self.assertRaisesRegex(RuntimeError, error_msg):
+                compiled(x, float_indices)
+
     @dtypesIfCUDA(torch.float16, torch.float64)
     @dtypesIfXPU(torch.float16, torch.float64)
     @dtypes(torch.float64)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8749,6 +8749,13 @@ def embedding(
 ) -> Tensor:
     if weight.dim() != 2:
         raise AssertionError(f"'weight' must be 2-D, got {weight.dim()}-D")
+    torch._check(
+        indices.dtype in (torch.long, torch.int32),
+        lambda: (
+            "Expected tensor for argument #1 'indices' to have one of the following "
+            f"scalar types: Long, Int; but got {indices.dtype} instead"
+        ),
+    )
     weight_shape = weight.shape
     indices_shape = indices.shape
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/178042


The `aten.embedding` meta function was missing the indices dtype check that exists in C++ (`checkScalarTypes` in `Embedding.cpp`). During compile, FakeTensor tracing passes the invalid op through without error, and then AOTAutograd's DCE removes the dead node — so the C++ check is never reached.

Added `torch._check` for indices dtype in the meta function so the error fires during tracing, before DCE runs.

**Test:** `test_embedding_float_indices_error` in `test/nn/test_embedding.py` — covers eager, `aot_eager`, `inductor` 

Co-authored-with: Claude 

cc @bdhirsh @penguinwu @bobrenjc93 @aorenste