### PR TITLE
[Claude Code] Skip test_remove_noop_slice1 on cuda in subprocess mode (#179755)

### DIFF
--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -68,7 +68,7 @@ test_failures = {
         ("xpu", "cuda"),
         is_skip=(TEST_WITH_ROCM and isRocmArchAnyOf(MI350_ARCH)) or not TEST_WITH_ROCM,
     ),
-    "test_remove_noop_slice1": TestFailure(("xpu"), is_skip=True),
+    "test_remove_noop_slice1": TestFailure(("xpu", "cuda"), is_skip=True),
     "test_remove_noop_slice_scatter": TestFailure(("xpu"), is_skip=True),
     "test_remove_noop_view_default": TestFailure(("xpu"), is_skip=True),
     "test_remove_noop_view_dtype": TestFailure(("xpu"), is_skip=True),


### PR DESCRIPTION
Summary:

The test_remove_noop_slice1_cuda test is flaky (9.2% PFS, 18.8% SFS) because get_post_grad_graph relies on logs_to_string to capture log output in the parent process, but in subprocess compilation mode (FxCompileMode.SUBPROCESS), the post_grad_graphs artifact logger has propagate=True (set by configure_artifact_log when explicitly enabled via TORCH_LOGS), which causes _LoggerState.__init__'s filter to skip capturing it. This makes subprocess log replay unreliable, resulting in an empty string instead of the expected post-grad graph.

The sibling test test_remove_noop_slice already skips cuda in subprocess mode for the same reason. This change adds "cuda" to test_remove_noop_slice1's TestFailure entry to match.

Test Plan:
Ran the test and confirmed it is now correctly skipped:
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:compile_subprocess -- --exact 'fbcode//caffe2/test/inductor:compile_subprocess - test_remove_noop_slice1_cuda (caffe2.test.inductor.test_compile_subprocess.GPUTests)'
Result: OK (skipped=1)

Differential Revision: D100057995




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo