### PR TITLE
Fix OSDC build runner resolution

### DIFF
--- a/.github/scripts/map_ec2_to_arc.py
+++ b/.github/scripts/map_ec2_to_arc.py
@@ -25,12 +25,19 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "matrix",
+        nargs="?",
+        default=None,
         help="GitHub Actions test matrix string to transform",
     )
     parser.add_argument(
         "--prefix",
         default="",
         help="Runner prefix to strip from labels (e.g. 'mt-')",
+    )
+    parser.add_argument(
+        "--build-runner",
+        default=None,
+        help="Map a single EC2 runner label for the build job's runs-on",
     )
     return parser.parse_args()
 
@@ -59,6 +66,20 @@ def main() -> None:
     args = parse_args()
     arc_yaml = Path(__file__).resolve().parent.parent / "arc.yaml"
     mapping = load_mapping(arc_yaml)
+
+    # Single build runner mapping mode
+    if args.build_runner:
+        clean = strip_prefix(args.build_runner.strip(), args.prefix)
+        if clean.startswith("l-"):
+            # Already an ARC label, pass through
+            mapped = args.prefix + clean
+        elif clean in mapping:
+            mapped = args.prefix + mapping[clean]
+        else:
+            print(f"error: no ARC runner found for '{clean}'", file=sys.stderr)
+            sys.exit(1)
+        set_output("runner", mapped)
+        return
 
     matrix = yaml.safe_load(args.matrix)
     if not matrix:

--- a/.github/scripts/test_map_ec2_to_arc.py
+++ b/.github/scripts/test_map_ec2_to_arc.py
@@ -28,6 +28,22 @@ def run(
     return subprocess.run(cmd, capture_output=True, text=True, env=env)
 
 
+def run_build_runner(
+    runner: str, prefix: str = "", github_output: str | None = None
+) -> subprocess.CompletedProcess:
+    cmd = [sys.executable, str(SCRIPT), "--build-runner", runner]
+    if prefix:
+        cmd += ["--prefix", prefix]
+
+    env = os.environ.copy()
+    if github_output is not None:
+        env["GITHUB_OUTPUT"] = github_output
+    else:
+        env.pop("GITHUB_OUTPUT", None)
+
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+
 def parse_output(stdout: str) -> dict:
     """Extract the JSON matrix from the 'Setting test-matrix=...' line."""
     prefix = "Setting test-matrix="
@@ -35,6 +51,15 @@ def parse_output(stdout: str) -> dict:
         if line.startswith(prefix):
             return json.loads(line[len(prefix) :])
     raise ValueError(f"no test-matrix output found in: {stdout}")
+
+
+def parse_runner_output(stdout: str) -> str:
+    """Extract the runner label from the 'Setting runner=...' line."""
+    prefix = "Setting runner="
+    for line in stdout.splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix) :]
+    raise ValueError(f"no runner output found in: {stdout}")
 
 
 def check(condition: bool, msg: str = "") -> None:
@@ -168,6 +193,75 @@ def test_github_output_file():
         )
         written = json.loads(contents[len("test-matrix=") :].strip())
         check(written["include"][0]["runner"] == "l-x86iavx512-8-64")
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_build_runner_ec2_to_arc():
+    """--build-runner maps an EC2 label to its ARC equivalent."""
+    result = run_build_runner("linux.4xlarge")
+    check(result.returncode == 0, result.stderr)
+    runner = parse_runner_output(result.stdout)
+    check(runner == "l-x86iavx512-16-128", f"got {runner}")
+
+
+def test_build_runner_arm64():
+    """--build-runner correctly maps ARM64 EC2 labels (the actual bug scenario)."""
+    result = run_build_runner("linux.arm64.m8g.4xlarge")
+    check(result.returncode == 0, result.stderr)
+    runner = parse_runner_output(result.stdout)
+    check(runner == "l-arm64g4-16-62", f"got {runner}")
+
+
+def test_build_runner_arc_passthrough():
+    """--build-runner passes through labels already in ARC format."""
+    result = run_build_runner("l-x86iavx512-8-64")
+    check(result.returncode == 0, result.stderr)
+    runner = parse_runner_output(result.stdout)
+    check(runner == "l-x86iavx512-8-64", f"got {runner}")
+
+
+def test_build_runner_with_prefix():
+    """--build-runner handles prefix correctly."""
+    result = run_build_runner("mt-linux.arm64.m8g.4xlarge", prefix="mt-")
+    check(result.returncode == 0, result.stderr)
+    runner = parse_runner_output(result.stdout)
+    check(runner == "mt-l-arm64g4-16-62", f"got {runner}")
+
+
+def test_build_runner_arc_passthrough_with_prefix():
+    """--build-runner with prefix correctly handles already-ARC labels."""
+    result = run_build_runner("mt-l-x86iavx512-8-64", prefix="mt-")
+    check(result.returncode == 0, result.stderr)
+    runner = parse_runner_output(result.stdout)
+    check(runner == "mt-l-x86iavx512-8-64", f"got {runner}")
+
+
+def test_build_runner_unknown_fails():
+    """--build-runner fails for unknown labels."""
+    result = run_build_runner("bogus.runner")
+    check(result.returncode == 1)
+    check("no ARC runner found for 'bogus.runner'" in result.stderr)
+
+
+def test_build_runner_github_output():
+    """--build-runner writes to GITHUB_OUTPUT when set."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        tmp_path = f.name
+
+    try:
+        result = run_build_runner(
+            "linux.arm64.2xlarge", github_output=tmp_path
+        )
+        check(result.returncode == 0, result.stderr)
+
+        contents = Path(tmp_path).read_text()
+        check(
+            contents.startswith("runner="),
+            f"unexpected file contents: {contents}",
+        )
+        written = contents[len("runner=") :].strip()
+        check(written == "l-arm64g2-6-32", f"got {written}")
     finally:
         os.unlink(tmp_path)
 

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -464,14 +464,35 @@ jobs:
           docker stop -a || true
           docker kill -a || true
 
+  resolve-arc-runner:
+    permissions:
+      contents: read
+    # Don't run on forked repos
+    if: github.repository_owner == 'pytorch' && inputs.use-arc
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      runner: ${{ steps.resolve.outputs.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve build runner
+        id: resolve
+        env:
+          BUILD_RUNNER: ${{ inputs.runner }}
+          RUNNER_PREFIX: ${{ inputs.runner_prefix }}
+        run: |
+          pip3 install -q pyyaml 2>/dev/null || pip3 install -q --break-system-packages pyyaml
+          python3 .github/scripts/map_ec2_to_arc.py --build-runner "${BUILD_RUNNER}" --prefix "${RUNNER_PREFIX}"
+
   build-osdc:
+    needs: [resolve-arc-runner]
     permissions:
       id-token: write
       contents: read
       actions: read
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch' && inputs.use-arc
-    runs-on: ${{ inputs.runner_prefix }}${{ startsWith(inputs.runner, 'l-') && inputs.runner || 'l-x86iavx512-8-64' }}
+    runs-on: ${{ needs.resolve-arc-runner.outputs.runner }}
     container:
       image: ghcr.io/pytorch/${{ inputs.docker-image-name }}
     timeout-minutes: 480


### PR DESCRIPTION
- Add --build-runner flag to map_ec2_to_arc.py for single runner mapping
- Add resolve-arc-runner job to _linux-build.yml that runs the mapping
- Replace inline expression with resolved output for build-osdc runs-on
- Add tests covering EC2-to-ARC, passthrough, prefix, and error cases

The build-osdc job previously used an inline expression to pick its runner label, which fell back to a hardcoded default when the input wasn't already an ARC label. This broke ARM64 builds since their EC2 labels were never mapped. A dedicated resolution step now uses the same arc.yaml mapping that test runners already use, so build jobs land on the correct runner for all architectures.

Authored with Claude.