### PR TITLE
Fix circular import crash in torch.backends.python_native during CF agent initialization

### DIFF
--- a/torch/backends/python_native/__init__.py
+++ b/torch/backends/python_native/__init__.py
@@ -335,10 +335,17 @@ class PythonNativeModule(PropModule):
 
     def __getattr__(self, name: str):
         """Dynamic attribute access for DSL controllers."""
+        # Skip dunder attributes to avoid triggering DSL registry lookups
+        # during torch initialization. inspect.getmodule() calls
+        # hasattr(module, '__file__') which would otherwise cause a circular
+        # import through _get_dsl_registry() while torch is still loading.
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(f"module '{self.__name__}' has no attribute '{name}'")
+
         if name in self.all_dsls:
             return self._get_dsl_controller(name)
 
-        # Expose internal functions for testing
+        # Expose private functions for testing
         if name == "_get_dsl_module":
             return _get_dsl_module
         if name == "_get_registry_functions":


### PR DESCRIPTION
Summary:
During agent startup, `import torch` crashes with:
  ImportError: cannot import name 'dsl_registry' from partially initialized
  module 'torch._native.dsl_registry' (most likely due to a circular import)

Root cause: `PythonNativeModule.__getattr__` does not guard against special
attribute lookups. During `import torch`, `torch.utils._debug_mode._mode`
registers a custom op via a decorator that runs at module load time. This calls
`inspect.getframeinfo()` -> `inspect.getmodule()`, which iterates over all
entries in `sys.modules` and calls `hasattr(module, '__file__')` on each.

When it reaches the `PythonNativeModule` object (which replaced the original
module in `sys.modules`), `__file__` is not a real attribute, so Python falls
through to `__getattr__('__file__')`. The current implementation
unconditionally checks `self.all_dsls`, which calls `_get_dsl_registry()`,
which does `from torch._native.dsl_registry import dsl_registry`. But that
module is still mid-initialization as part of `torch/__init__.py` — the
`dsl_registry` symbol has not been assigned yet — causing the circular import.

Fix: Add a guard in `__getattr__` to immediately raise `AttributeError` for
`__file__` lookups, preventing the DSL registry from being triggered during
torch initialization. This is safe because `__file__` is never a valid DSL
name, and any module that legitimately has `__file__` would resolve it through
normal attribute lookup before `__getattr__` is ever called.

Test Plan:
Verified that the agent starts successfully and
processes queries without the circular import crash. Previously, any import
chain reaching `import torch` during tools class instantiation would
consistently trigger the error.

Reviewed By: Mingming-Ding

Differential Revision: D100057507


