### PR TITLE
xpu: enable dpclang sycl compiler

### DIFF
--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -23,13 +23,22 @@ IF(NOT MKLDNN_FOUND)
     if(WIN32)
       # Windows
       set(DNNL_HOST_COMPILER "DEFAULT")
+      set(DNNL_C_COMPILER "icx")
       set(SYCL_CXX_DRIVER "icx")
       set(DNNL_LIB_NAME "dnnl.lib")
     elseif(LINUX)
       # Linux
       # g++ is soft linked to /usr/bin/cxx, oneDNN would not treat it as an absolute path
       set(DNNL_HOST_COMPILER "g++")
-      set(SYCL_CXX_DRIVER "icpx")
+      if("${XPU_SYCL_COMPILER}" MATCHES "icx")
+        set(DNNL_C_COMPILER "icx")
+        set(SYCL_CXX_DRIVER "icpx")
+      elseif("${XPU_SYCL_COMPILER}" MATCHES "dpclang")
+        set(DNNL_C_COMPILER "dpclang")
+        set(SYCL_CXX_DRIVER "dpclang++")
+      else()
+        message(FATAL_ERROR "Unsupported SYCL compiler: ${XPU_SYCL_COMPILER}")
+      endif()
       set(DNNL_LIB_NAME "libdnnl.a")
     else()
       MESSAGE(FATAL_ERROR "OneDNN for Intel GPU in PyTorch currently supports only Windows and Linux.
@@ -50,7 +59,7 @@ IF(NOT MKLDNN_FOUND)
       GIT_TAG v3.11.2
       PREFIX ${XPU_MKLDNN_DIR_PREFIX}
       BUILD_IN_SOURCE 0
-      CMAKE_ARGS  -DCMAKE_C_COMPILER=icx
+      CMAKE_ARGS  -DCMAKE_C_COMPILER=${DNNL_C_COMPILER}
       -DCMAKE_CXX_COMPILER=${SYCL_CXX_DRIVER}
       -DDNNL_GPU_RUNTIME=SYCL
       -DDNNL_CPU_RUNTIME=THREADPOOL

--- a/cmake/Modules/FindSYCLToolkit.cmake
+++ b/cmake/Modules/FindSYCLToolkit.cmake
@@ -7,41 +7,24 @@
 
 include(FindPackageHandleStandardArgs)
 
-set(SYCL_ROOT "")
-if(DEFINED ENV{SYCL_ROOT})
-  set(SYCL_ROOT $ENV{SYCL_ROOT})
-elseif(DEFINED ENV{CMPLR_ROOT})
-  set(SYCL_ROOT $ENV{CMPLR_ROOT})
-else()
-  # Use the default path to ensure proper linking with torch::xpurt when the user is working with libtorch.
-  if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    set(SYCL_ROOT "/opt/intel/oneapi/compiler/latest")
-  elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    set(SYCL_ROOT "C:/Program Files (x86)/Intel/oneAPI/compiler/latest")
-  endif()
-  if(NOT EXISTS ${SYCL_ROOT})
-    set(SYCL_ROOT "")
-  endif()
-endif()
+# DPCLANG is an open source DPC++ compiler shipped with Linux distros
+function(parse_dpclang_version major minor patch)
+  # Execute the SYCL compiler with the --version flag to match the version string.
+  execute_process(COMMAND ${SYCL_COMPILER} --version OUTPUT_VARIABLE SYCL_VERSION_STRING)
+  string(REGEX REPLACE "DPC\\+\\+ compiler ([0-9]+\\.[0-9]+\\.[0-9]+) (.*)" "\\1"
+               SYCL_VERSION_STRING_MATCH ${SYCL_VERSION_STRING})
+  string(REPLACE "." ";" SYCL_VERSION_LIST ${SYCL_VERSION_STRING_MATCH})
+  # Split the version number list into major, minor, and patch components.
+  list(GET SYCL_VERSION_LIST 0 VERSION_MAJOR)
+  list(GET SYCL_VERSION_LIST 1 VERSION_MINOR)
+  list(GET SYCL_VERSION_LIST 2 VERSION_PATCH)
+  set(${major} "${VERSION_MAJOR}" PARENT_SCOPE)
+  set(${minor} "${VERSION_MINOR}" PARENT_SCOPE)
+  set(${patch} "${VERSION_PATCH}" PARENT_SCOPE)
+endfunction()
 
-string(COMPARE EQUAL "${SYCL_ROOT}" "" nosyclfound)
-if(nosyclfound)
-  set(SYCL_FOUND False)
-  set(SYCL_REASON_FAILURE "SYCL library not set!!")
-  set(SYCL_NOT_FOUND_MESSAGE "${SYCL_REASON_FAILURE}")
-  return()
-endif()
-
-# Find SYCL compiler executable.
-find_program(
-  SYCL_COMPILER
-  NAMES icx
-  PATHS "${SYCL_ROOT}"
-  PATH_SUFFIXES bin bin64
-  NO_DEFAULT_PATH
-  )
-
-function(parse_sycl_compiler_version version_number)
+# ICX is a closed source DPC++ compiler shipped with oneAPI Toolkits
+function(parse_icx_compiler_version version_number)
   # Execute the SYCL compiler with the --version flag to match the version string.
   execute_process(COMMAND ${SYCL_COMPILER} --version OUTPUT_VARIABLE SYCL_VERSION_STRING)
   string(REGEX REPLACE "Intel\\(R\\) (.*) Compiler ([0-9]+\\.[0-9]+\\.[0-9]+) (.*)" "\\2"
@@ -56,51 +39,124 @@ function(parse_sycl_compiler_version version_number)
   set(${version_number} "${VERSION_NUMBER_MATCH}" PARENT_SCOPE)
 endfunction()
 
-if(SYCL_COMPILER)
-  parse_sycl_compiler_version(SYCL_COMPILER_VERSION)
+function(map_dpclang_version_to_icx major minor patch out_version_number)
+  # Map dpclang compiler version to oneAPI icx version
+  math(EXPR icx_major "2019 + ${major}")
+  # Calculate the version number in the format XXXXYYZZ, using the formula (major * 10000 + minor * 100 + patch).
+  math(EXPR VERSION_NUMBER_MATCH "${icx_major} * 10000 + ${minor} * 100 + ${patch}")
+  set(${out_version_number} "${VERSION_NUMBER_MATCH}" PARENT_SCOPE)
+endfunction()
+
+if("${XPU_SYCL_COMPILER}" MATCHES "dpclang")
+  find_program(SYCL_COMPILER dpclang++)
+  if(SYCL_COMPILER)
+    parse_dpclang_version(
+      SYCL_COMPILER_VERSION_MAJOR
+      SYCL_COMPILER_VERSION_MINOR
+      SYCL_COMPILER_VERSION_PATCH)
+    map_dpclang_version_to_icx(
+      ${SYCL_COMPILER_VERSION_MAJOR}
+      ${SYCL_COMPILER_VERSION_MINOR}
+      ${SYCL_COMPILER_VERSION_PATCH}
+      SYCL_COMPILER_VERSION)
+  endif()
+  if(NOT SYCL_COMPILER_VERSION)
+    set(SYCL_FOUND False)
+    set(SYCL_REASON_FAILURE "Cannot parse sycl compiler version to get SYCL_COMPILER_VERSION!")
+    set(SYCL_NOT_FOUND_MESSAGE "${SYCL_REASON_FAILURE}")
+    return()
+  endif()
+
+  find_package(PkgConfig)
+  if(PkgConfig_FOUND)
+    pkg_check_modules(LIBSYCL_DPCPP IMPORTED_TARGET sycl-dpcpp-${SYCL_COMPILER_VERSION_MAJOR})
+    if(LIBSYCL_DPCPP_FOUND)
+      set(SYCL_INCLUDE_DIR ${LIBSYCL_DPCPP_INCLUDE_DIRS})
+      set(SYCL_LIBRARY_DIR ${LIBSYCL_DPCPP_LIBRARY_DIRS})
+      set(SYCL_LIBRARY ${LIBSYCL_DPCPP_LIBRARIES})
+    endif()
+  endif()
+elseif("${XPU_SYCL_COMPILER}" MATCHES "icx")
+  set(SYCL_ROOT "")
+  if(DEFINED ENV{SYCL_ROOT})
+    set(SYCL_ROOT $ENV{SYCL_ROOT})
+  elseif(DEFINED ENV{CMPLR_ROOT})
+    set(SYCL_ROOT $ENV{CMPLR_ROOT})
+  else()
+    # Use the default path to ensure proper linking with torch::xpurt when the user is working with libtorch.
+    if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+      set(SYCL_ROOT "/opt/intel/oneapi/compiler/latest")
+    elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
+      set(SYCL_ROOT "C:/Program Files (x86)/Intel/oneAPI/compiler/latest")
+    endif()
+    if(NOT EXISTS ${SYCL_ROOT})
+      set(SYCL_ROOT "")
+    endif()
+  endif()
+
+  string(COMPARE EQUAL "${SYCL_ROOT}" "" nosyclfound)
+  if(nosyclfound)
+    set(SYCL_FOUND False)
+    set(SYCL_REASON_FAILURE "SYCL library not set!!")
+    set(SYCL_NOT_FOUND_MESSAGE "${SYCL_REASON_FAILURE}")
+    return()
+  endif()
+
+  # Find SYCL compiler executable.
+  find_program(
+    SYCL_COMPILER
+    NAMES icx
+    PATHS "${SYCL_ROOT}"
+    PATH_SUFFIXES bin bin64
+    NO_DEFAULT_PATH
+    )
+
+  if(SYCL_COMPILER)
+    parse_icx_compiler_version(SYCL_COMPILER_VERSION)
+  endif()
+
+  if(NOT SYCL_COMPILER_VERSION)
+    set(SYCL_FOUND False)
+    set(SYCL_REASON_FAILURE "Cannot parse sycl compiler version to get SYCL_COMPILER_VERSION!")
+    set(SYCL_NOT_FOUND_MESSAGE "${SYCL_REASON_FAILURE}")
+    return()
+  endif()
+
+  # Find include path from binary.
+  find_file(
+    SYCL_INCLUDE_DIR
+    NAMES include
+    HINTS ${SYCL_ROOT}
+    NO_DEFAULT_PATH
+    )
+
+  # Find include/sycl path from include path.
+  find_file(
+    SYCL_INCLUDE_SYCL_DIR
+    NAMES sycl
+    HINTS ${SYCL_ROOT}/include/
+    NO_DEFAULT_PATH
+    )
+
+  # Due to the unrecognized compilation option `-fsycl` in other compiler.
+  list(APPEND SYCL_INCLUDE_DIR ${SYCL_INCLUDE_SYCL_DIR})
+
+ # Find library directory from binary.
+  find_file(
+    SYCL_LIBRARY_DIR
+    NAMES lib lib64
+    HINTS ${SYCL_ROOT}
+    NO_DEFAULT_PATH
+    )
+
+  # Find SYCL library fullname.
+  find_library(
+    SYCL_LIBRARY
+    NAMES "sycl"
+    HINTS ${SYCL_LIBRARY_DIR}
+    NO_DEFAULT_PATH
+  )
 endif()
-
-if(NOT SYCL_COMPILER_VERSION)
-  set(SYCL_FOUND False)
-  set(SYCL_REASON_FAILURE "Cannot parse sycl compiler version to get SYCL_COMPILER_VERSION!")
-  set(SYCL_NOT_FOUND_MESSAGE "${SYCL_REASON_FAILURE}")
-  return()
-endif()
-
-# Find include path from binary.
-find_file(
-  SYCL_INCLUDE_DIR
-  NAMES include
-  HINTS ${SYCL_ROOT}
-  NO_DEFAULT_PATH
-  )
-
-# Find include/sycl path from include path.
-find_file(
-  SYCL_INCLUDE_SYCL_DIR
-  NAMES sycl
-  HINTS ${SYCL_ROOT}/include/
-  NO_DEFAULT_PATH
-  )
-
-# Due to the unrecognized compilation option `-fsycl` in other compiler.
-list(APPEND SYCL_INCLUDE_DIR ${SYCL_INCLUDE_SYCL_DIR})
-
-# Find library directory from binary.
-find_file(
-  SYCL_LIBRARY_DIR
-  NAMES lib lib64
-  HINTS ${SYCL_ROOT}
-  NO_DEFAULT_PATH
-  )
-
-# Find SYCL library fullname.
-find_library(
-  SYCL_LIBRARY
-  NAMES "sycl"
-  HINTS ${SYCL_LIBRARY_DIR}
-  NO_DEFAULT_PATH
-)
 
 if(NOT SYCL_LIBRARY)
   set(SYCL_FOUND False)

--- a/cmake/public/xpu.cmake
+++ b/cmake/public/xpu.cmake
@@ -5,6 +5,21 @@ if(TARGET torch::xpurt)
   return()
 endif()
 
+# "icx" is a closed source DPC++ compiler shipped with oneAPI Toolkits
+# "dpclang" is an open source DPC++ compiler shipped with Linux distros
+
+# Check if the XPU_SYCL_COMPILER is NOT already set (e.g. from -D command line)
+if(NOT DEFINED XPU_SYCL_COMPILER)
+    if(DEFINED ENV{XPU_SYCL_COMPILER})
+        set(XPU_SYCL_COMPILER "$ENV{XPU_SYCL_COMPILER}")
+    else()
+        set(XPU_SYCL_COMPILER "icx")
+    endif()
+endif()
+
+# Finalize the setting as a CACHE variable so it appears in cache files
+set(XPU_SYCL_COMPILER "${XPU_SYCL_COMPILER}" CACHE STRING "SYCL compiler to use")
+
 set(XPU_HOST_CXX_FLAGS)
 
 # Find SYCL library.
@@ -22,6 +37,9 @@ add_library(torch::sycl INTERFACE IMPORTED)
 set_property(
     TARGET torch::sycl PROPERTY INTERFACE_INCLUDE_DIRECTORIES
     ${SYCL_INCLUDE_DIR})
+set_property(
+    TARGET torch::sycl PROPERTY INTERFACE_LINK_DIRECTORIES
+    ${SYCL_LIBRARY_DIR})
 set_property(
     TARGET torch::sycl PROPERTY INTERFACE_LINK_LIBRARIES
     ${SYCL_LIBRARY})


### PR DESCRIPTION
`dpclang` compiler is an open source version of the closed source Intel DPC++ compiler. `dpclang` is being supported by Intel in the https://github.com/intel/llvm public repository and got recently packaged into upcoming Ubuntu 26.04 LTS.

This commit enables minimal support of `dpclang` compiler in PyTorch building towards fully open source PyTorch stack on Linux. Limitations:

* Kineto, XCCL and oneMKL paths were not enabled and might require additional work
* SYCL-TLA, oneDNN and Pytorch itself might require additional changes to properly handle dpclang compiler as it does not support `__INTEL_LLVM_COMPILER` macro

We will address above limitations in the follow up patches. At the moment the following procedure can be used to build PyTorch for XPU with `dpclang` compiler on Ubuntu 26.04:

* Do NOT activate oneAPI environment
* Install open source DPC++ compiler, OpenCL and few other tools with:
```
apt-get install dpclang-6 ocl-icd-opencl-dev pkg-config libze-dev
```
* Build PyTorch as follows:

```
XPU_SYCL_COMPILER=dpclang USE_KINETO=0 USE_ONEMKL_XPU=0 \
  python3 setup.py develop
```

The dependency from https://github.com/intel/torch-xpu-ops/pull/3287 is weak in a sense that the change is transparent to the current production build of the PyTorch for XPU using oneAPI DL Essentials. The change in torch-xpu-ops is only required for the build with the `dpclang`.

Needs: https://github.com/intel/torch-xpu-ops/pull/3287

CC: @guangyey @EikanWang @chuanqi129 @frenchwr

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal