### PR TITLE
[cuda graphs] Integrate kernel annotations into inductor cudagraph trees

### DIFF
--- a/test/test_cuda_graph_annotations.py
+++ b/test/test_cuda_graph_annotations.py
@@ -307,6 +307,72 @@ class TestMarkKernels(TestCase):
         enable_annotations()
 
 
+@unittest.skipUnless(TEST_CUDA, "CUDA not available")
+class TestInductorAnnotationCodegen(TestCase):
+    """Tests that inductor emits mark_kernels calls in generated code."""
+
+    def _get_compiled_code(self, model, example_input, annotations_enabled):
+        import torch._inductor.config as inductor_config
+        from torch._inductor.utils import run_and_get_code
+
+        with inductor_config.patch(
+            {
+                "triton.cudagraph_kernel_annotations": annotations_enabled,
+            }
+        ):
+            compiled = torch.compile(model)
+            _, codes = run_and_get_code(compiled, example_input)
+        return codes
+
+    def test_annotation_codegen_enabled(self):
+        """When config is enabled, generated code should contain _mark_kernels calls."""
+
+        class SimpleModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.relu(x @ torch.ones(64, 64, device="cuda")) + 1
+
+        model = SimpleModel().cuda()
+        x = torch.randn(32, 64, device="cuda")
+        codes = self._get_compiled_code(model, x, annotations_enabled=True)
+
+        code = codes[0]
+        self.assertIn("_mark_kernels", code)
+        self.assertIn("_annotation_ctx", code)
+        self.assertIn("__enter__", code)
+        self.assertIn("__exit__", code)
+
+    def test_annotation_codegen_disabled(self):
+        """When config is disabled, generated code should NOT contain _mark_kernels."""
+
+        class SimpleModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.relu(x @ torch.ones(64, 64, device="cuda")) + 1
+
+        model = SimpleModel().cuda()
+        x = torch.randn(32, 64, device="cuda")
+        codes = self._get_compiled_code(model, x, annotations_enabled=False)
+
+        code = codes[0]
+        self.assertNotIn("_mark_kernels", code)
+        self.assertNotIn("_annotation_ctx", code)
+
+    def test_annotation_contains_fx_node_names(self):
+        """Generated annotation should reference FX node names."""
+
+        class SimpleModel(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        model = SimpleModel().cuda()
+        x = torch.randn(32, 64, device="cuda")
+        codes = self._get_compiled_code(model, x, annotations_enabled=True)
+
+        code = codes[0]
+        # The add op should show up as an FX node name in the annotation
+        self.assertIn("_mark_kernels", code)
+        self.assertIn("add", code)
+
+
 class TestAnnotateTrace(TestCase):
     """Tests for the trace post-processing functions (no GPU required)."""
 

--- a/test/test_cuda_graph_annotations.py
+++ b/test/test_cuda_graph_annotations.py
@@ -307,5 +307,183 @@ class TestMarkKernels(TestCase):
         enable_annotations()
 
 
+class TestAnnotateTrace(TestCase):
+    """Tests for the trace post-processing functions (no GPU required)."""
+
+    def _make_kernel_event(
+        self, name: str, tid: int, ts: float, dur: float, graph_node_id: int = 0
+    ) -> dict:
+        return {
+            "cat": "kernel",
+            "name": name,
+            "tid": tid,
+            "ts": ts,
+            "dur": dur,
+            "args": {"graph node id": graph_node_id},
+        }
+
+    def test_annotate_dict_annotation(self):
+        from torch.cuda._annotate_cuda_graph_trace import annotate_trace
+
+        trace = {
+            "traceEvents": [
+                self._make_kernel_event("kern_a", 1, 100, 10, graph_node_id=42),
+                self._make_kernel_event("kern_b", 1, 200, 10, graph_node_id=0),
+            ]
+        }
+        annotations = {42: [{"name": "all_gather", "dtype": "bf16"}]}
+        count = annotate_trace(trace, annotations, default_stream=7)
+
+        self.assertEqual(count, 1)
+        args = trace["traceEvents"][0]["args"]
+        self.assertEqual(args["name"], "all_gather")
+        self.assertEqual(args["dtype"], "bf16")
+        # Graphed event should be moved to default stream
+        self.assertEqual(trace["traceEvents"][0]["tid"], 7)
+
+    def test_annotate_string_annotation(self):
+        from torch.cuda._annotate_cuda_graph_trace import annotate_trace
+
+        trace = {
+            "traceEvents": [
+                self._make_kernel_event("kern", 1, 100, 10, graph_node_id=99),
+            ]
+        }
+        annotations = {99: ["phase_a"]}
+        count = annotate_trace(trace, annotations, default_stream=7)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(trace["traceEvents"][0]["args"]["annotation"], "phase_a")
+
+    def test_annotate_unannotated_graphed_events_get_default_stream(self):
+        from torch.cuda._annotate_cuda_graph_trace import annotate_trace
+
+        trace = {
+            "traceEvents": [
+                self._make_kernel_event("kern", 5, 100, 10, graph_node_id=50),
+            ]
+        }
+        # No annotation for graph_node_id=50
+        count = annotate_trace(trace, {}, default_stream=7)
+
+        self.assertEqual(count, 0)
+        self.assertEqual(trace["traceEvents"][0]["tid"], 7)
+
+    def test_annotate_non_graphed_events_untouched(self):
+        from torch.cuda._annotate_cuda_graph_trace import annotate_trace
+
+        event = self._make_kernel_event("kern", 3, 100, 10, graph_node_id=0)
+        trace = {"traceEvents": [event]}
+        annotate_trace(trace, {}, default_stream=7)
+
+        # graph_node_id=0 means not graphed, tid should be unchanged
+        self.assertEqual(trace["traceEvents"][0]["tid"], 3)
+
+    def test_annotate_stream_from_annotation(self):
+        from torch.cuda._annotate_cuda_graph_trace import annotate_trace
+
+        trace = {
+            "traceEvents": [
+                self._make_kernel_event("kern", 1, 100, 10, graph_node_id=42),
+            ]
+        }
+        annotations = {42: [{"name": "rs", "stream": 62}]}
+        annotate_trace(trace, annotations, default_stream=7)
+
+        self.assertEqual(trace["traceEvents"][0]["tid"], 62)
+
+    def test_move_overlapping_to_stream(self):
+        from torch.cuda._annotate_cuda_graph_trace import _move_overlapping_to_stream
+
+        trace = {
+            "traceEvents": [
+                self._make_kernel_event("a", 7, 100, 20, graph_node_id=1),
+                # Overlaps: starts at 110 < 120 (end of a)
+                self._make_kernel_event("b", 7, 110, 15, graph_node_id=2),
+                # No overlap: starts at 130 >= 125 (end of b on stream 8)
+                self._make_kernel_event("c", 7, 130, 10, graph_node_id=3),
+            ]
+        }
+        moved = _move_overlapping_to_stream(trace, default_stream=7, overlap_stream=8)
+
+        self.assertEqual(moved, 1)
+        self.assertEqual(trace["traceEvents"][0]["tid"], 7)
+        self.assertEqual(trace["traceEvents"][1]["tid"], 8)
+        self.assertEqual(trace["traceEvents"][2]["tid"], 7)
+
+    def test_fix_overlapping_timestamps(self):
+        from torch.cuda._annotate_cuda_graph_trace import _fix_overlapping_timestamps
+
+        trace = {
+            "traceEvents": [
+                self._make_kernel_event("a", 7, 100, 10, graph_node_id=1),
+                # Overlaps by 0.5us (within threshold)
+                self._make_kernel_event("b", 7, 109.5, 10, graph_node_id=2),
+            ]
+        }
+        adjusted = _fix_overlapping_timestamps(trace, max_adjust_us=1.0)
+
+        self.assertEqual(adjusted, 1)
+        self.assertEqual(trace["traceEvents"][1]["ts"], 110)
+
+    def test_fix_overlapping_timestamps_large_overlap_skipped(self):
+        from torch.cuda._annotate_cuda_graph_trace import _fix_overlapping_timestamps
+
+        trace = {
+            "traceEvents": [
+                self._make_kernel_event("a", 7, 100, 10, graph_node_id=1),
+                # Overlaps by 5us (exceeds threshold)
+                self._make_kernel_event("b", 7, 105, 10, graph_node_id=2),
+            ]
+        }
+        adjusted = _fix_overlapping_timestamps(trace, max_adjust_us=1.0)
+
+        self.assertEqual(adjusted, 0)
+        # Should be unchanged
+        self.assertEqual(trace["traceEvents"][1]["ts"], 105)
+
+    def test_noise_removal(self):
+        from torch.cuda._annotate_cuda_graph_trace import annotate_trace
+
+        trace = {
+            "traceEvents": [
+                self._make_kernel_event("kern", 7, 100, 10, graph_node_id=1),
+                # Noise: gpu_user_annotation on stream 99 with no work
+                {
+                    "cat": "gpu_user_annotation",
+                    "tid": 99,
+                    "ts": 100,
+                    "dur": 10,
+                },
+                # ac2g flow finish on stream 99 (no work there)
+                {"cat": "ac2g", "ph": "f", "tid": 99, "ts": 100},
+            ]
+        }
+        annotate_trace(trace, {}, default_stream=7)
+
+        # Noise events on stream 99 should be removed
+        cats = [e.get("cat") for e in trace["traceEvents"]]
+        self.assertNotIn("gpu_user_annotation", cats)
+        tids = [e.get("tid") for e in trace["traceEvents"] if e.get("cat") == "ac2g"]
+        for tid in tids:
+            self.assertNotEqual(tid, 99)
+
+    def test_ac2g_flow_events_follow_kernel(self):
+        from torch.cuda._annotate_cuda_graph_trace import annotate_trace
+
+        trace = {
+            "traceEvents": [
+                self._make_kernel_event("kern", 5, 100, 10, graph_node_id=42),
+                {"cat": "ac2g", "ph": "f", "tid": 5, "ts": 100},
+            ]
+        }
+        annotations = {42: [{"name": "ag", "stream": 62}]}
+        annotate_trace(trace, annotations, default_stream=7)
+
+        # Both kernel and ac2g should be moved to stream 62
+        self.assertEqual(trace["traceEvents"][0]["tid"], 62)
+        self.assertEqual(trace["traceEvents"][1]["tid"], 62)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1377,6 +1377,10 @@ class PythonWrapperCodegen(CodeGen):
         elif torch._inductor.config.test_configs.track_memory_lifecycle:
             inductor_debug_utils = "from torch._inductor.runtime.debug_utils import tracked_empty_strided\n"
 
+        cudagraph_annotation_import = ""
+        if config.triton.cudagraph_kernel_annotations:
+            cudagraph_annotation_import = "from torch.cuda._graph_annotations import mark_kernels as _mark_kernels"
+
         self.imports.splice(
             f"""
                 {aot_config_comment}
@@ -1395,6 +1399,7 @@ class PythonWrapperCodegen(CodeGen):
                 from {async_compile.__name__} import AsyncCompile
                 from torch._inductor.select_algorithm import extern_kernels
                 {inductor_debug_utils}
+                {cudagraph_annotation_import}
             """,
             strip=True,
         )
@@ -4200,6 +4205,15 @@ class PythonWrapperCodegen(CodeGen):
         Mark the end of kernel context guard
         """
         return
+
+    def write_cudagraph_annotation_begin(self, annotation: str) -> None:
+        self.writeline(
+            f'_annotation_ctx = _mark_kernels({{"name": {annotation!r}}})'
+        )
+        self.writeline("_annotation_ctx.__enter__()")
+
+    def write_cudagraph_annotation_end(self) -> None:
+        self.writeline("_annotation_ctx.__exit__(None, None, None)")
 
 
 class SubgraphPythonWrapperCodegen(PythonWrapperCodegen):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1673,6 +1673,12 @@ class triton:
     # skip warmup for cudagraph trees
     skip_cudagraph_warmup = False
 
+    # Enable kernel annotation recording during CUDA graph capture.
+    # When enabled, mark_kernels() scopes within captured code will attach
+    # metadata to kernel graph nodes for matching to profiler traces.
+    # Requires cuda.bindings package and a compatible driver (cuda-compat >= 13.1).
+    cudagraph_kernel_annotations = False
+
     # Synchronize before and after every compiled graph.
     debug_sync_graph = False
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -84,6 +84,12 @@ from torch._inductor.cudagraph_utils import (
     PlaceholderInfo,
     WrappedFunction,
 )
+from torch.cuda._graph_annotations import (
+    clear_kernel_annotations,
+    enable_annotations,
+    remap_to_exec_graph,
+    resolve_pending_annotations,
+)
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.storage import UntypedStorage
 from torch.utils import _pytree as pytree
@@ -1303,6 +1309,9 @@ class CUDAGraphNode:
             ]
             check_memory_pool(self.device, self.cuda_graphs_pool, memory)
 
+        if config.triton.cudagraph_kernel_annotations:
+            clear_kernel_annotations()
+
         with (
             preserve_rng_state(),
             torch.cuda.device(self.device),
@@ -1317,6 +1326,11 @@ class CUDAGraphNode:
             get_history_recording(),
         ):
             static_outputs = model(inputs)
+            if config.triton.cudagraph_kernel_annotations:
+                resolve_pending_annotations()
+
+        if config.triton.cudagraph_kernel_annotations:
+            remap_to_exec_graph(self.graph)
 
         # running model should reclaim memory
         assert len(inputs) == 0
@@ -2042,6 +2056,9 @@ class CUDAGraphTreeManager:
                 ),
             ):
                 pass
+
+        if config.triton.cudagraph_kernel_annotations:
+            enable_annotations()
 
         self.graph_counter = itertools.count(0)
         self.func_counter = itertools.count(0)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3075,6 +3075,17 @@ def template_fusion_pw_node(node1: BaseSchedulerNode, node2: BaseSchedulerNode):
     return node2 if is_epilogue_fusion(node1, node2) else node1
 
 
+def _get_fx_node_names(node: BaseSchedulerNode) -> str:
+    """Extract comma-separated FX node names for CUDA graph annotation."""
+    names: list[str] = []
+    for snode in node.get_nodes():
+        if snode.node is not None:
+            for origin in snode.node.get_origins():
+                if origin.op == "call_function" and origin.name not in names:
+                    names.append(origin.name)
+    return ", ".join(names)
+
+
 class Scheduler:
     """
     A Scheduler is a graph of BaseSchedulerNodes. It is responsible for
@@ -7584,6 +7595,17 @@ class Scheduler:
             self.current_node = node
             self.buffer_names_to_free.update(node.last_usage)
 
+            annotation_name = ""
+            if (
+                config.triton.cudagraph_kernel_annotations
+                and not isinstance(node, NopKernelSchedulerNode)
+            ):
+                annotation_name = _get_fx_node_names(node)
+                if annotation_name:
+                    V.graph.wrapper_code.write_cudagraph_annotation_begin(
+                        annotation_name
+                    )
+
             if node.is_template():
                 prologue, template_node, epilogue = node.get_prologue_template_epilogue(
                     list(node.get_nodes())
@@ -7615,6 +7637,9 @@ class Scheduler:
             else:
                 assert isinstance(node, NopKernelSchedulerNode)
                 node.mark_run()
+
+            if annotation_name:
+                V.graph.wrapper_code.write_cudagraph_annotation_end()
 
             # pyrefly: ignore [unbound-name]
             if config.triton.debug_sync_kernel:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179769
* #179867
* #179768

Add config.triton.cudagraph_kernel_annotations (default False) and wire
up clear/resolve/remap calls in CUDAGraphNode._record() so that
mark_kernels() scopes firing during cudagraph capture are automatically
processed.


**WIP: current progress: it works, but has bugs, the annotation is not accurate yet**
Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo