### PR TITLE
[ROCm] Add version guard to ROCm workaround for watchdog polling during graph capture

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -223,7 +223,7 @@ std::string getExceptionMsgFromExceptionPtr(
   }
 }
 
-#ifdef USE_ROCM
+#if defined(USE_ROCM) && ROCM_VERSION < 70201
 // Indicates that we're in the watchdog's event-query phase. This allows ROCm
 // workaround behavior to be applied only to watchdog-side queries, while
 // preserving existing behavior for user/main-thread `WorkNCCL::isCompleted()`
@@ -242,9 +242,9 @@ struct RocmWatchdogEventQueryContextGuard {
  private:
   bool previous_;
 };
-#endif // USE_ROCM
+#endif // defined(USE_ROCM) && ROCM_VERSION < 70201
 
-#ifdef USE_ROCM
+#if defined(USE_ROCM) && ROCM_VERSION < 70201
 // Watchdog-side cudaEventQuery workaround for HIP runtimes without the
 // capture-mode fix.
 // TODO: Remove once all supported runtimes include
@@ -280,7 +280,7 @@ bool queryEventWithRocmWatchdogCaptureWorkaround(
 
   return false;
 }
-#endif // USE_ROCM
+#endif // defined(USE_ROCM) && ROCM_VERSION < 70201
 
 inline void errorIfCapturingNonCapturableNCCL(c10::cuda::CaptureStatus status) {
   // parentheses avoid some compiler warnings
@@ -705,7 +705,7 @@ bool ProcessGroupNCCL::WorkNCCL::startedGPUExecutionInternal() const {
     return false;
   }
   // Checking the work's corresponding CUDA event's status
-#ifdef USE_ROCM
+#if defined(USE_ROCM) && ROCM_VERSION < 70201
   if (!queryEventWithRocmWatchdogCaptureWorkaround(ncclStartEvent_)) {
 #else
   if (!ncclStartEvent_->query()) {
@@ -722,7 +722,7 @@ bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal() const {
   // hang if another thread is holding the CUDA global context lock. For
   // example, when doing a `cudaDeviceSynchronize` or even
   // `cudaStreamSynchronize`.
-#ifdef USE_ROCM
+#if defined(USE_ROCM) && ROCM_VERSION < 70201
   if (!queryEventWithRocmWatchdogCaptureWorkaround(ncclEndEvent_)) {
 #else
   if (!ncclEndEvent_->query()) {
@@ -2367,7 +2367,7 @@ void ProcessGroupNCCL::Watchdog::runLoop() {
       // Skip if work has encountered an error.
 
       bool timedout = false;
-#ifdef USE_ROCM
+#if defined(USE_ROCM) && ROCM_VERSION < 70201
       // On ROCm, watchdog event queries may be intentionally skipped during
       // active graph capture to avoid HIP runtime capture invalidation.
       // In that window, timeout checks can report false positives for
@@ -2444,7 +2444,7 @@ void ProcessGroupNCCL::Watchdog::runLoop() {
       // allow watchdog to do an event query on a side thread
       at::cuda::CUDAGuard device_guard(work.ncclEndEvent_->device_index());
       at::cuda::CUDAStreamCaptureModeGuard g{cudaStreamCaptureModeThreadLocal};
-#ifdef USE_ROCM
+#if defined(USE_ROCM) && ROCM_VERSION < 70201
       // Mark this thread/scope as watchdog event-query context so the ROCm
       // workaround applies only here (not to main-thread wait()/isCompleted()).
       RocmWatchdogEventQueryContextGuard watchdog_event_query_context_guard;


### PR DESCRIPTION
Previously, https://github.com/pytorch/pytorch/pull/176251 had introduced a Pytorch side workaround to address https://github.com/pytorch/pytorch/issues/177309. This was meant to be a temporary fix till we have the hip runtime fix.

The runtime fix was introduced in rocm 7.2.1, but to ensure backwards compatibility, we are adding a version guard so that the workaround only takes effect in ROCm versions without the runtime fix.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang