### PR TITLE
[CI] Fix aarch64 build-osdc using x86 runner on ARC

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -471,7 +471,7 @@ jobs:
       actions: read
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch' && inputs.use-arc
-    runs-on: ${{ inputs.runner_prefix }}${{ startsWith(inputs.runner, 'l-') && inputs.runner || 'l-x86iavx512-8-64' }}
+    runs-on: ${{ inputs.runner_prefix }}${{ startsWith(inputs.runner, 'l-') && inputs.runner || contains(inputs.runner, 'arm64') && 'l-arm64g4-16-62' || 'l-x86iavx512-8-64' }}
     container:
       image: ghcr.io/pytorch/${{ inputs.docker-image-name }}
     timeout-minutes: 480


### PR DESCRIPTION
The build-osdc runs-on expression defaults to x86 (l-x86iavx512-8-64) when the runner input doesn't start with 'l-'. EC2-format arm64 labels like linux.arm64.m8g.4xlarge start with 'linux.', so they hit the x86 fallback instead of being routed to an arm64 ARC runner.

Add a contains(inputs.runner, 'arm64') check to route arm64 builds to l-arm64g4-16-62 before falling back to the x86 default.