### PR TITLE
[ROCm][CI] add gfx1103 to magma, remove ROCm 7 build

### DIFF
--- a/.ci/magma-rocm/Makefile
+++ b/.ci/magma-rocm/Makefile
@@ -18,7 +18,6 @@ DOCKER_RUN = set -eou pipefail; ${DOCKER_CMD} run --rm -i \
 .PHONY: all
 all: magma-rocm72
 all: magma-rocm71
-all: magma-rocm70
 
 .PHONY:
 clean:
@@ -33,9 +32,4 @@ magma-rocm72:
 .PHONY: magma-rocm71
 magma-rocm71: DESIRED_ROCM := 7.1
 magma-rocm71:
-	$(DOCKER_RUN)
-
-.PHONY: magma-rocm70
-magma-rocm70: DESIRED_ROCM := 7.0
-magma-rocm70:
 	$(DOCKER_RUN)

--- a/.ci/magma-rocm/Makefile
+++ b/.ci/magma-rocm/Makefile
@@ -5,7 +5,7 @@ DESIRED_ROCM ?= 7.2
 DESIRED_ROCM_SHORT = $(subst .,,$(DESIRED_ROCM))
 PACKAGE_NAME = magma-rocm
 # inherit this from underlying docker image, do not pass this env var to docker
-#PYTORCH_ROCM_ARCH ?= gfx900;gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201
+#PYTORCH_ROCM_ARCH ?= gfx900;gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1200;gfx1201
 
 DOCKER_RUN = set -eou pipefail; ${DOCKER_CMD} run --rm -i \
 	-v $(shell git rev-parse --show-toplevel)/.ci:/builder \

--- a/.github/workflows/build-magma-rocm-linux.yml
+++ b/.github/workflows/build-magma-rocm-linux.yml
@@ -34,7 +34,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        rocm_version: ["72", "71", "70"]
+        rocm_version: ["72", "71"]
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Followup to #179653

Update commented `PYTORCH_ROCM_ARCH` list in the magma-rocm Makefile to include gfx1103, triggering a magma tarball refresh once the almalinux image is available.

While we're at it, remove ROCm 7 build (keep 7.1 and 7.2).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang