### PR TITLE
Revert "[dynamo] Handle IndexError during fake tensor eval as clean graph break"

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3923,14 +3923,6 @@ def _get_fake_value_impl(
                 hints=[*graph_break_hints.USER_ERROR],
                 from_exc=cause,
             )
-        elif isinstance(cause, IndexError):
-            unimplemented(
-                gb_type="IndexError when making fake tensor call",
-                context=f"IndexError {node.target}: {cause}",
-                explanation=str(cause),
-                hints=[*graph_break_hints.USER_ERROR],
-                from_exc=cause,
-            )
         msg = get_concrete_sizes_from_symints(str(e), fake_mode)
         _wrap_graph_break_with_torch_runtime_err(
             lambda: unimplemented(

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1602,9 +1602,6 @@ class TypingVariable(VariableTracker):
         else:
             return SourcelessBuilder.create(tx, value)
 
-    def is_callable(self) -> bool:
-        return callable(self.value)
-
     def as_python_constant(self) -> Any:
         return self.value
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179792
* __->__ #179791
* #179790
* #179665

This reverts commit e1c65ed936210eb2dbbddef216121fba69fd97bb.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98