### PR TITLE
[dynamo] Add is_callable override on TypingVariable

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -183,14 +183,14 @@ from user code:
                 zip(range(5), range(10))
             ),
             """\
-Unsupported function call
-  Explanation: Dynamo does not know how to trace the function `UserDefinedObjectVariable(zip)`
-  Hint: Avoid calling `UserDefinedObjectVariable(zip)` in your code.
-  Hint: Please report an issue to PyTorch.
+Observed exception
+  Explanation: Dynamo found no exception handler at the top-level compiled function when encountering an exception. Exception will propagate outside the compiled region.
+  Hint: Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance("force_eager")`.
+  Hint: It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues.
 
-  Developer debug context: call_function UserDefinedObjectVariable(zip) [] {}
+  Developer debug context: raised exception TypeError("'zip' object is not callable")
 
- For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0147.html
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0088.html
 
 from user code:
    File "test_error_messages.py", line N, in fn

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -1269,6 +1269,10 @@ class InstructionTranslatorBase(
             inner_fn = fn.fn
         if inner_fn and callable(inner_fn) and is_forbidden(inner_fn):
             raise AssertionError(f"Attempt to trace forbidden callable {inner_fn}")
+        if not fn.is_callable():
+            from torch._dynamo.exc import raise_type_error
+
+            raise_type_error(self, f"'{fn.python_type_name()}' object is not callable")
         self.push(fn.call_function(self, args, kwargs))  # type: ignore[arg-type]
 
     def inline_generator_function(

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -561,9 +561,15 @@ class VariableTracker(metaclass=VariableTrackerMeta):
         args: Sequence["VariableTracker"],
         kwargs: dict[str, "VariableTracker"],
     ) -> "VariableTracker":
-        from .object_protocol import generic_call
-
-        return generic_call(tx, self, args, kwargs)
+        unimplemented(
+            gb_type="Unsupported function call",
+            context=f"call_function {self} {args} {kwargs}",
+            explanation=f"Dynamo does not know how to trace the function `{self.debug_repr()}`",
+            hints=[
+                f"Avoid calling `{self.debug_repr()}` in your code.",
+                "Please report an issue to PyTorch.",
+            ],
+        )
 
     def sq_length(self, tx: Any) -> "VariableTracker":
         """Called when sq_length is not implemented."""

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1602,6 +1602,9 @@ class TypingVariable(VariableTracker):
         else:
             return SourcelessBuilder.create(tx, value)
 
+    def is_callable(self) -> bool:
+        return callable(self.value)
+
     def as_python_constant(self) -> Any:
         return self.value
 

--- a/torch/_dynamo/variables/object_protocol.py
+++ b/torch/_dynamo/variables/object_protocol.py
@@ -19,8 +19,6 @@ from .constant import CONSTANT_VARIABLE_FALSE, CONSTANT_VARIABLE_TRUE
 
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from ..symbolic_convert import InstructionTranslator
 
 
@@ -124,23 +122,6 @@ def vt_mapping_size(
         raise_type_error(tx, f"{obj.python_type_name()} is not a mapping")
 
     raise_type_error(tx, f"object of type {obj.python_type_name()} has no len()")
-
-
-def generic_call(
-    tx: "InstructionTranslator",
-    fn: "VariableTracker",
-    args: "Sequence[VariableTracker]",
-    kwargs: "dict[str, VariableTracker]",
-) -> "VariableTracker":
-    # ref: https://github.com/python/cpython/blob/v3.13.3/Objects/call.c#L332-L367
-    """
-    Mirrors PyObject_Call — raises TypeError when tp_call is NULL.
-
-    This is the base VariableTracker.call_function implementation.  Subclasses
-    that represent callable Python objects override call_function directly, so
-    this only runs when no override exists (i.e. the object is not callable).
-    """
-    raise_type_error(tx, f"'{fn.python_type_name()}' object is not callable")
 
 
 def generic_len(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179792
* #179791
* #179790
* #179665

Typing objects like List, Callable are callable in CPython, so
TypingVariable.is_callable should delegate to callable(self.value).

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98