### PR TITLE
[cudagraph] Accept opaque values (DeviceMesh, ProcessGroup) in cudagraph pipeline

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -65,6 +65,16 @@ requires_multigpu = functools.partial(
 )
 from io import StringIO
 
+from torch._library.opaque_object import OpaqueBase, register_opaque_type
+
+
+class _CudagraphTestScaleFactor(OpaqueBase):
+    def __init__(self, factor):
+        self.factor = factor
+
+
+register_opaque_type(_CudagraphTestScaleFactor, typ="reference")
+
 
 def get_compile_fn(backend):
     if backend == "cudagraphs":
@@ -5099,6 +5109,30 @@ if HAS_CUDA_AND_TRITON:
             run(20)
             run(10)
             run(25)
+
+        @torch._inductor.config.patch("triton.skip_cudagraph_warmup", True)
+        def test_opaque_value_input_cudagraph(self):
+            """Opaque reference-type objects (e.g. DeviceMesh, ProcessGroup)
+            passed alongside tensors must be marked "static" so they are
+            excluded from the tensor-copy path (non_static_input_idx).
+            "Static" here just means "don't copy as a tensor", not that
+            the object is semantically immutable."""
+
+            sf = _CudagraphTestScaleFactor(3.0)
+
+            def foo(args):
+                obj = args[0]
+                x = args[1]
+                args.clear()
+                return (x * obj.factor,)
+
+            inp = torch.rand([4], device="cuda")
+            foo_cg = self.cudagraphify_impl(foo, [sf, inp], ())
+            result = foo_cg([sf, inp])
+            self.assertEqual(result[0], inp * 3.0)
+
+            result2 = foo_cg([sf, inp])
+            self.assertEqual(result2[0], inp * 3.0)
 
     class TestSAC(TestCase):
         def _make_observer_mode(self):

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -940,11 +940,6 @@ class CUDAGraphNode:
         # here just means "don't try to copy this as a tensor" — it
         # does NOT mean the object is semantically immutable.
         #
-        # Note: the cudagraph tree itself has no guard on opaque object
-        # identity. Correctness relies on dynamo guarding on identity
-        # upstream — a different opaque object triggers recompilation
-        # before it reaches this layer.
-        #
         # Opaque indices must also be excluded from any list passed to
         # _tensors_data_ptrs_at_indices_equal (the C++ data-pointer
         # stability check), because opaque objects have no data_ptr.

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -84,10 +84,10 @@ from torch._inductor.cudagraph_utils import (
     PlaceholderInfo,
     WrappedFunction,
 )
+from torch._library.opaque_object import is_opaque_value
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.storage import UntypedStorage
 from torch.utils import _pytree as pytree
-from torch._library.opaque_object import is_opaque_value
 from torch.utils._ordered_set import OrderedSet
 from torch.utils.weak import TensorWeakRef
 
@@ -970,8 +970,7 @@ class CUDAGraphNode:
         self.non_managed_static_input_idxs: LevelList[int] = [
             i
             for i in wrapped_function.static_input_idxs
-            if i not in self.cudagraph_managed_idxs
-            and i not in opaque_input_idxs
+            if i not in self.cudagraph_managed_idxs and i not in opaque_input_idxs
         ]
 
         self.tensor_static_input_idxs: list[int] = [
@@ -1756,7 +1755,9 @@ class CUDAGraphNode:
         ):
             for i, inp in enumerate(inputs):
                 if not isinstance(inp, torch.Tensor):
-                    assert isinstance(inp, (int, torch.Generator)) or is_opaque_value(inp)
+                    assert isinstance(inp, (int, torch.Generator)) or is_opaque_value(
+                        inp
+                    )
 
                     recording_inputs.append(inp)
                 elif i not in self.static_input_idxs:

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -87,6 +87,7 @@ from torch._inductor.cudagraph_utils import (
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.storage import UntypedStorage
 from torch.utils import _pytree as pytree
+from torch._library.opaque_object import is_opaque_value
 from torch.utils._ordered_set import OrderedSet
 from torch.utils.weak import TensorWeakRef
 
@@ -932,9 +933,30 @@ class CUDAGraphNode:
         # and also aliases an output of the current CUDAGraphNode
         self.preserved_aliased_inputs: InputList[bool] = [False] * len(inputs)
 
+        # Opaque values (e.g. DeviceMesh, ProcessGroup) are non-tensor
+        # inputs that cannot be copied like tensors. We include them in
+        # static_input_idxs to keep them out of non_static_input_idx
+        # (which drives the tensor-copy path during replay). "Static"
+        # here just means "don't try to copy this as a tensor" — it
+        # does NOT mean the object is semantically immutable.
+        #
+        # Note: the cudagraph tree itself has no guard on opaque object
+        # identity. Correctness relies on dynamo guarding on identity
+        # upstream — a different opaque object triggers recompilation
+        # before it reaches this layer.
+        #
+        # Opaque indices must also be excluded from any list passed to
+        # _tensors_data_ptrs_at_indices_equal (the C++ data-pointer
+        # stability check), because opaque objects have no data_ptr.
+        # That is why tensor_static_input_idxs and
+        # non_managed_static_input_idxs filter them out below.
+        opaque_input_idxs = OrderedSet(
+            i for i, inp in enumerate(inputs) if is_opaque_value(inp)
+        )
         self.static_input_idxs: list[int] = list(
             OrderedSet(wrapped_function.static_input_idxs)
             | OrderedSet(self.cudagraph_managed_idxs)
+            | opaque_input_idxs
         )
 
         self.non_static_input_idx: LevelList[int] = [
@@ -949,6 +971,11 @@ class CUDAGraphNode:
             i
             for i in wrapped_function.static_input_idxs
             if i not in self.cudagraph_managed_idxs
+            and i not in opaque_input_idxs
+        ]
+
+        self.tensor_static_input_idxs: list[int] = [
+            i for i in self.static_input_idxs if i not in opaque_input_idxs
         ]
 
         def maybe_get_static_data_ptr(
@@ -1729,7 +1756,7 @@ class CUDAGraphNode:
         ):
             for i, inp in enumerate(inputs):
                 if not isinstance(inp, torch.Tensor):
-                    assert isinstance(inp, (int, torch.Generator))
+                    assert isinstance(inp, (int, torch.Generator)) or is_opaque_value(inp)
 
                     recording_inputs.append(inp)
                 elif i not in self.static_input_idxs:
@@ -1788,13 +1815,13 @@ class CUDAGraphNode:
             and not torch._C._tensors_data_ptrs_at_indices_equal(
                 inputs,  # type: ignore[arg-type]
                 self.static_input_data_ptrs,
-                self.static_input_idxs,
+                self.tensor_static_input_idxs,
             )
         ):
             status = CheckInvariantStatus.StaticInputIdxMismatch
             _logger = functools.partial(
                 _logger,
-                self.static_input_idxs,
+                self.tensor_static_input_idxs,
                 status,
             )
             return status, _logger

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -40,6 +40,7 @@ from torch._inductor.cudagraph_utils import (
     log_cudagraph_skip_and_bump_counter,
 )
 from torch._inductor.freezing_utils import has_frozen_params, is_frozen_param
+from torch._library.opaque_object import is_opaque_value
 from torch._inductor.utils import (
     _unstable_customized_partition_wrapper,
     align_inputs_from_check_idxs,
@@ -615,6 +616,7 @@ class CompiledFxGraph(OutputCode):
                     (
                         all(
                             isinstance(t, (torch.Tensor, torch.SymInt, torch.Generator))
+                            or is_opaque_value(t)
                             for t in example_inputs
                         ),
                         "non-Tensor inputs",

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -40,7 +40,6 @@ from torch._inductor.cudagraph_utils import (
     log_cudagraph_skip_and_bump_counter,
 )
 from torch._inductor.freezing_utils import has_frozen_params, is_frozen_param
-from torch._library.opaque_object import is_opaque_value
 from torch._inductor.utils import (
     _unstable_customized_partition_wrapper,
     align_inputs_from_check_idxs,
@@ -51,6 +50,7 @@ from torch._inductor.utils import (
     output_node,
     set_tracing_context_output_strides,
 )
+from torch._library.opaque_object import is_opaque_value
 from torch.fx._graph_pickler import _node_metadata_key_filter_safe, _ops_filter_safe
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._python_dispatch import is_in_torch_dispatch_mode


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179793
* #179660
* #179396

When custom operators pass opaque reference-type objects (e.g.
DeviceMesh, ProcessGroup) as inputs through the cudagraph tree
pipeline, several things previously went wrong:

1. The cudagraph eligibility check in CompiledFxGraph rejected
   the graph with "non-Tensor inputs" because FakeScriptObject
   doesn't pass the isinstance(t, (Tensor, SymInt, Generator))
   check. Fixed by adding an is_opaque_value(t) alternative.

2. CUDAGraphNode.__init__ didn't include opaque inputs in
   static_input_idxs, so they ended up in non_static_input_idx
   and the replay path tried to copy them as tensors. Fixed by
   detecting opaque inputs and merging their indices into
   static_input_idxs. Marking them "static" here just means
   "exclude from the tensor-copy path" — it does NOT mean the
   object is semantically immutable. 

3. The assertion in _allocate_and_copy_recording_inputs only
   allowed int and Generator for non-tensor inputs, crashing on
   opaque objects. Relaxed to also accept is_opaque_value().

4. Opaque indices must be excluded from the lists passed to
   _tensors_data_ptrs_at_indices_equal (which checks tensor
   pointer stability), because opaque objects have no data_ptr.
   Added tensor_static_input_idxs and filtered opaque indices
   from non_managed_static_input_idxs.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo