### PR TITLE
[ROCm] [CI] Set MIOPEN_FIND_MODE=FAST in op benchmark CI to prevent cold-cache timeout

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2100,6 +2100,12 @@ test_operator_benchmark() {
   cd benchmarks/operator_benchmark/pt_extension
   python -m pip install . -v --no-build-isolation
 
+  # On ROCm, MIOpen exhaustive kernel search can take hours per shape on cold cache.
+  # Use FAST mode (heuristics only) to keep benchmark CI from timing out.
+  if [[ "${ROCM_VERSION:-}" != "" ]]; then
+    export MIOPEN_FIND_MODE=FAST
+  fi
+
   cd "${TEST_DIR}"/benchmarks/operator_benchmark
   $TASKSET python -m benchmark_all_test --device "$1" --tag-filter "$2" \
       --output-csv "${TEST_REPORTS_DIR}/operator_benchmark_eager_float32_cpu.csv" \
@@ -2122,6 +2128,12 @@ test_operator_microbenchmark() {
   python -m pip install . -v --no-build-isolation
 
   cd "${TEST_DIR}"/benchmarks/operator_benchmark
+
+  # On ROCm, MIOpen exhaustive kernel search can take hours per shape on cold cache.
+  # Use FAST mode (heuristics only) to keep benchmark CI from timing out.
+  if [[ "${ROCM_VERSION:-}" != "" ]]; then
+    export MIOPEN_FIND_MODE=FAST
+  fi
 
   # NOTE: When adding a new test here, please update README: ../../benchmarks/operator_benchmark/README.md
   for OP_BENCHMARK_TESTS in matmul mm addmm bmm conv optimizer activation norm scaled_mm scaled_grouped_mm; do

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2102,7 +2102,7 @@ test_operator_benchmark() {
 
   # On ROCm, MIOpen exhaustive kernel search can take hours per shape on cold cache.
   # Use FAST mode (heuristics only) to keep benchmark CI from timing out.
-  if [[ "${ROCM_VERSION:-}" != "" ]]; then
+  if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     export MIOPEN_FIND_MODE=FAST
   fi
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2131,7 +2131,7 @@ test_operator_microbenchmark() {
 
   # On ROCm, MIOpen exhaustive kernel search can take hours per shape on cold cache.
   # Use FAST mode (heuristics only) to keep benchmark CI from timing out.
-  if [[ "${ROCM_VERSION:-}" != "" ]]; then
+  if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     export MIOPEN_FIND_MODE=FAST
   fi
 


### PR DESCRIPTION
## Problem

On ROCm with a cold MIOpen cache, each op benchmark config can take **10–15 min** due to MIOpen's kernel search, causing CI timeouts.

## Fix

Set `MIOPEN_FIND_MODE=FAST` (heuristics only) before running benchmark tests on ROCm. Guarded by `ROCM_VERSION` — no effect on CUDA CI or production training.

**Measured on MI350 (ROCm 7.2), worst-case config:**
`ConvTranspose3d(IC=32, OC=64, kernel=5, stride=2, input=1×32×128×128×128, fp32, BWD)`

| Find mode | Duration (cold cache) |
|---|---|
| Default | ~13.2 min |
| `FAST` | ~1.2 min |

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang