### PR TITLE
[Inductor] Don't expand bias for addmm in max-autotune mode (#179808)

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -774,6 +774,34 @@ class TestMaxAutotune(TestCase):
         with config.patch({"max_autotune": True}):
             torch.compile(mm, dynamic=dynamic)(a, b)
 
+    @fresh_cache()
+    def test_addmm_1d_bias_no_reinterpret_tensor(self):
+        """
+        Verify that aten addmm with 1D bias does not wrap bias in reinterpret_tensor.
+        This ensures cublasLt uses its optimized bias epilogue (requires dim==1).
+        """
+
+        def addmm(x, a, b):
+            return torch.addmm(x, a, b)
+
+        x = torch.randn(100).to(GPU_TYPE)
+        a = torch.randn(100, 10).to(GPU_TYPE)
+        b = torch.randn(10, 100).to(GPU_TYPE)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "ATEN",
+            }
+        ):
+            Y_compiled, code = run_and_get_code(torch.compile(addmm), x, a, b)
+            Y = addmm(x, a, b)
+            torch.testing.assert_close(Y_compiled, Y, atol=1e-2, rtol=1e-2)
+
+            # Verify addmm is called without reinterpret_tensor on bias
+            FileCheck().check("addmm").run(code[0])
+            self.assertNotIn("addmm(reinterpret_tensor", code[0])
+
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -2692,58 +2720,6 @@ class TestMaxAutotune(TestCase):
                 _ = compiled_fn(bias, x, w)
         finally:
             clear_preprocessing_fns(clear_defaults=False)
-
-    @unittest.skipIf(not torch.version.hip, "ROCM only")
-    @config.patch(
-        {
-            "max_autotune": True,
-            "max_autotune_gemm_backends": "ATEN",
-            "triton.autotune_cublasLt": True,
-            "triton.native_matmul": False,
-        }
-    )
-    def test_rocm_addmm_aten_bias_input_is_1d(self):
-        """
-        ROCm regression test for addmm autotune input wiring.
-        A 1D bias is required for hipBLASLt bias-fused addmm kernels; expanded 2D
-        bias disables that fused path. Exercise the real bias_addmm heuristic
-        so regressions in the runtime path are caught as part of this test.
-        """
-        bias_input_ranks: dict[str, set[int]] = {"addmm": set(), "bias_addmm": set()}
-
-        def capture_bias_input_rank(choices):
-            for choice in choices:
-                if isinstance(choice, ExternKernelCaller) and choice.name in (
-                    "addmm",
-                    "bias_addmm",
-                ):
-                    bias_node = choice.input_nodes[0]
-                    bias_input_ranks[choice.name].add(len(bias_node.get_size()))
-            return choices
-
-        add_preprocessing_fn(capture_bias_input_rank)
-        try:
-            bias = torch.randn(64, device=GPU_TYPE)
-            mat1 = torch.randn(32, 128, device=GPU_TYPE)
-            mat2 = torch.randn(128, 64, device=GPU_TYPE)
-
-            compiled_fn = torch.compile(
-                lambda b, x, w: torch.addmm(b, x, w),
-                dynamic=False,
-            )
-            _ = compiled_fn(bias, mat1, mat2)
-
-            self.assertTrue(
-                bias_input_ranks["addmm"], "Expected ATen addmm choice to be generated"
-            )
-            self.assertTrue(
-                bias_input_ranks["bias_addmm"],
-                "Expected ATen bias_addmm choice to be generated",
-            )
-            self.assertEqual(bias_input_ranks["addmm"], {1})
-            self.assertEqual(bias_input_ranks["bias_addmm"], {1})
-        finally:
-            clear_preprocessing_fns()
 
     @config.patch(
         {"test_configs.max_mm_configs": 4, "max_autotune_gemm_backends": "TRITON"}

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -669,22 +669,18 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
 
     if use_aten_gemm_kernels():
         aten_templates: list[ExternKernelChoice | KernelTemplate] = [aten_addmm]
-        # For ROCm, check original inp since kernel_inputs_aten uses inp (not inp_expanded)
-        bias_to_check = inp if torch.version.hip else inp_expanded
         if (
-            bias_to_check.get_stride()[0] == 0
+            inp.get_stride()[0] == 0
+            and len(inp.get_size()) == 2
             and inductor_config.triton.autotune_cublasLt
             and not V.graph.cpp_wrapper  # bias_addmm only has a Python implementation
         ):
             aten_templates.append(aten_bias_addmm)
 
         # On ROCm, ATen choices use original bias input; non-ROCm keeps unified inputs.
-        if torch.version.hip:
-            choices.extend(
-                V.choices.get_template_configs(kernel_inputs_aten, aten_templates, name)
-            )
-        else:
-            templates_to_use.extend(aten_templates)
+        choices.extend(
+            V.choices.get_template_configs(kernel_inputs_aten, aten_templates, name)
+        )
 
     if is_nonzero and use_triton_template(layout, check_max_autotune=False):
         templates_to_use.append(mm_template)

--- a/torch/_inductor/template_heuristics/aten.py
+++ b/torch/_inductor/template_heuristics/aten.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
-import torch
 from torch._inductor import config as inductor_config
 
 from ..kernel.bmm import aten_baddbmm, aten_bmm, aten_bmm_dtype
@@ -87,11 +86,9 @@ class ATenBiasAddMMConfigHeuristics(
         nodes = kernel_inputs.nodes()
         # for addmm, bias is the first input
         bias = nodes[0]
-        # Conditions should be checked in tuned_addmm before adding this template.
-        # On ROCm, tuned_addmm passes the original 1D bias input so hipBLASLt
-        # fused-bias kernels can see the native bias form. In that case the bias
-        # no longer has the expanded stride-0 layout used on the non-ROCm path.
-        is_rocm_1d_bias = torch.version.hip and len(bias.get_size()) == 1
-        valid_bias_input = is_rocm_1d_bias or bias.get_stride()[0] == 0
-        assert valid_bias_input and inductor_config.triton.autotune_cublasLt
+        assert (
+            len(bias.get_size()) == 2
+            and bias.get_stride()[0] == 0
+            and inductor_config.triton.autotune_cublasLt
+        )
         yield from super()._get_template_configs_impl(kernel_inputs, op_name)


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/179808

Previously `reinterpret_tensor` was always added to `addmm` in max-autotune mode, even if aten was chosen. This can lead to performance regressions e2e. Instead, we preserve the 1D bias if it is 1D and feed different kernel inputs to NVIDIA and AMD paths. https://github.com/pytorch/pytorch/pull/177130 did this previously just for amd after discovering the same regression. The test added by that PR was removed as we no longer use `bias_addmm` for 1D biases. 

Test Plan: `test_addmm_1d_bias_no_reinterpret_tensor`

Reviewed By: njriasan

Differential Revision: D100157470


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo