### PR TITLE
Clean up dead code in torch.compile helpers

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4576,7 +4576,7 @@ class CheckFunctionManager:
     def compile_check_fn(
         self,
         builder: GuardBuilder,
-        guards_out: list[Guard],
+        _guards_out: list[Guard],
         guard_fail_fn: Callable[[GuardFail], None] | None,
     ) -> None:
         # see parallel handling of ".0" / "___implicit0" in _eval_frame.c

--- a/torch/_dynamo/repro/aoti.py
+++ b/torch/_dynamo/repro/aoti.py
@@ -101,7 +101,6 @@ def dump_to_minify(
                     config_patches=options,
                     save_dir=subdir,
                     command="run",
-                    module_in_comment=True,
                 )
             log.warning("Writing repro file to %s", file_name)
             if use_buck:
@@ -143,7 +142,6 @@ def save_graph_repro_ep(
     command: str = "run",
     accuracy: str | bool | None = None,
     check_str: str | None = None,
-    module_in_comment: bool = False,
     strict: bool = False,
 ) -> None:
     # Save graph for reproducing the error.
@@ -213,7 +211,6 @@ def dump_compiler_graph_state(
             config_patches=config_patches,
             save_dir=subdir,
             accuracy=accuracy,
-            module_in_comment=True,
             strict=strict,
         )
     curdir = os.getcwd()
@@ -383,9 +380,6 @@ def export_for_aoti_minifier(
             if re.search(pattern, str(e)) is not None:
                 return None
         raise AOTIMinifierError(e) from e
-    # we should never reach here
-    # pyrefly: ignore [unreachable]
-    return None
 
 
 def repro_minify(

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2863,7 +2863,7 @@ class _AOTDispatchAutogradFunctionFactory:
                 )
                 rng_state.add_backward_args(ctx, all_args)
 
-                def impl_fn(double_ctx: Any = None) -> Any:
+                def impl_fn(_double_ctx: Any = None) -> Any:
                     out = CompiledFunction._backward_impl(ctx, all_args)
                     return _backward_epilogue_functional(
                         CompiledFunction.metadata,
@@ -2899,7 +2899,7 @@ class _AOTDispatchAutogradFunctionFactory:
 
                     @staticmethod
                     # pyrefly: ignore [bad-override]
-                    def forward(double_ctx: Any, *unused_args: Any) -> Any:
+                    def forward(double_ctx: Any, *_unused_args: Any) -> Any:
                         return impl_fn(double_ctx)
 
                     @staticmethod

--- a/torch/_higher_order_ops/flex_attention.py
+++ b/torch/_higher_order_ops/flex_attention.py
@@ -811,7 +811,7 @@ class FlexAttentionAutogradOp(torch.autograd.Function):
         ctx: Any,
         grad_out: Tensor,
         grad_logsumexp: Tensor,
-        grad_max_scores: Tensor,
+        _grad_max_scores: Tensor,
     ) -> tuple[Tensor | None, ...]:
         fw_args = saved_values(ctx)
         (

--- a/torch/_inductor/autoheuristic/autoheuristic.py
+++ b/torch/_inductor/autoheuristic/autoheuristic.py
@@ -286,8 +286,8 @@ class AutoHeuristicSelectAlgorithm(AutoHeuristic):
             name: str,
             input_nodes: list[Any],
             choices: list[ChoiceCaller],
-            profiled_time: Callable[[], dict[ChoiceCaller, float]],
-            precompile_times: dict[ChoiceCaller, float],
+            _profiled_time: Callable[[], dict[ChoiceCaller, float]],
+            _precompile_times: dict[ChoiceCaller, float],
         ) -> None:
             current_inputs_key = create_inputs_key(input_nodes)
             if current_inputs_key != ah_inputs_key:

--- a/torch/_inductor/cache.py
+++ b/torch/_inductor/cache.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from tempfile import gettempdir
 from threading import Lock
 from typing import Any, Generic, TYPE_CHECKING, TypeVar
-from typing_extensions import assert_never, override, Self
+from typing_extensions import override, Self
 
 from torch.utils._filelock import FileLock
 
@@ -292,8 +292,6 @@ class OnDiskCache(AsyncCache[Key, Value]):
             raise CacheError(
                 f"Failed to get fpath for key {key!r}, key is not pickle-able."
             ) from err
-        # pyrefly: ignore [bad-argument-type]
-        assert_never(key)
 
     def _flock_from_fpath(self: Self, fpath: Path) -> FileLock:
         """

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -3261,7 +3261,6 @@ class CppPythonBindingsCodeCache(CppCodeCache):
 
     cpp_compile_command_flags = {
         # kernels have no dependency on libtorch
-        "include_pytorch": False,
         "shared": True,
     }
     entry_function = "kernel"
@@ -3447,7 +3446,6 @@ class CppWrapperCodeCache(CppPythonBindingsCodeCache):
         CppWrapperCodeCache.cache.clear()
 
     cpp_compile_command_flags = {
-        "include_pytorch": True,
         "shared": True,
     }
     entry_function = "inductor_entry_cpp"

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -360,9 +360,9 @@ class _LoggerState:
 
     def __exit__(
         self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: types.TracebackType | None,
+        _exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _traceback: types.TracebackType | None,
     ) -> None:
         assert self.captured_logs is not None
         self.captured_logs.remove()
@@ -704,22 +704,4 @@ class _DebugFileFxCompile(_SerializedFxCompile):
         with open(name, "wb") as f:
             f.write(pickled_input.value)
         print(f"Wrote to {name}")
-
-        if False:
-            name = os.path.join(
-                tempfile.gettempdir(), f"pytorch_compile_fx_tmp_actual_{idx}.bin"
-            )
-            actual = self._run_in_child(pickled_input)
-            with open(name, "wb") as f:
-                f.write(actual.value)
-            return actual
-        elif False:
-            name = os.path.join(
-                tempfile.gettempdir(), f"pytorch_compile_fx_tmp_output_{idx}.bin"
-            )
-            with open(name, "rb") as f:
-                result = _WireProtocolPickledOutput(f.read())
-                print(f"Read from {name}")
-            return result
-        else:
-            os._exit(-1)
+        os._exit(-1)

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -531,8 +531,6 @@ def _is_msvc_cl(cpp_compiler: str) -> bool:
     except FileNotFoundError:
         return False
 
-    # pyrefly: ignore [unreachable]
-    return False
 
 
 @functools.cache
@@ -576,8 +574,6 @@ def _is_intel_compiler(cpp_compiler: str) -> bool:
         # --version args not support.
         return False
 
-    # pyrefly: ignore [unreachable]
-    return False
 
 
 @functools.cache
@@ -872,7 +868,7 @@ def _get_os_related_cpp_cflags(cpp_compiler: str) -> list[str]:
     return cflags
 
 
-def _get_os_related_cpp_definitions(cpp_compiler: str) -> list[str]:
+def _get_os_related_cpp_definitions() -> list[str]:
     os_definitions: list[str] = []
     if _IS_WINDOWS:
         # On Windows, we need disable min/max macro to avoid C2589 error, as PyTorch CMake:
@@ -1039,7 +1035,7 @@ def get_cpp_options(
         + _get_os_related_cpp_cflags(cpp_compiler)
     )
 
-    definitions += _get_os_related_cpp_definitions(cpp_compiler)
+    definitions += _get_os_related_cpp_definitions()
 
     if not _IS_WINDOWS and config.aot_inductor.enable_lto and _is_clang(cpp_compiler):
         ldflags.append("fuse-ld=lld")
@@ -1213,9 +1209,7 @@ def _get_build_args_of_chosen_isa(vec_isa: VecISA) -> tuple[list[str], list[str]
     return macros, build_flags
 
 
-def _get_torch_related_args(
-    include_pytorch: bool, aot_mode: bool
-) -> tuple[list[str], list[str], list[str]]:
+def _get_torch_related_args(aot_mode: bool) -> tuple[list[str], list[str], list[str]]:
     from torch.utils.cpp_extension import include_paths, TORCH_LIB_PATH
 
     libraries = []
@@ -1559,7 +1553,7 @@ def get_cpp_torch_options(
         torch_include_dirs,
         torch_libraries_dirs,
         torch_libraries,
-    ) = _get_torch_related_args(include_pytorch=include_pytorch, aot_mode=aot_mode)
+    ) = _get_torch_related_args(aot_mode=aot_mode)
 
     python_include_dirs, python_libraries_dirs = _get_python_related_args()
 

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -532,7 +532,6 @@ def _is_msvc_cl(cpp_compiler: str) -> bool:
         return False
 
 
-
 @functools.cache
 def _is_intel_compiler(cpp_compiler: str) -> bool:
     def _check_minimal_version(compiler_version: TorchVersion) -> None:
@@ -573,7 +572,6 @@ def _is_intel_compiler(cpp_compiler: str) -> bool:
     except subprocess.SubprocessError:
         # --version args not support.
         return False
-
 
 
 @functools.cache
@@ -1514,7 +1512,6 @@ def get_caching_allocator_macro() -> list[str]:
 def get_cpp_torch_options(
     cpp_compiler: str,
     vec_isa: VecISA,
-    include_pytorch: bool,
     aot_mode: bool,
     use_relative_path: bool,
     use_mmap_weights: bool,
@@ -1619,7 +1616,6 @@ class CppTorchOptions(CppOptions):
     def __init__(
         self,
         vec_isa: VecISA = invalid_vec_isa,
-        include_pytorch: bool = False,
         warning_all: bool = True,
         aot_mode: bool = False,
         compile_only: bool = False,
@@ -1657,7 +1653,6 @@ class CppTorchOptions(CppOptions):
         ) = get_cpp_torch_options(
             cpp_compiler=self._compiler,
             vec_isa=vec_isa,
-            include_pytorch=include_pytorch,
             aot_mode=aot_mode,
             use_relative_path=use_relative_path,
             use_mmap_weights=use_mmap_weights,
@@ -1831,7 +1826,6 @@ class CppTorchDeviceOptions(CppTorchOptions):
     def __init__(
         self,
         vec_isa: VecISA = invalid_vec_isa,
-        include_pytorch: bool = False,
         device_type: str = "cuda",
         aot_mode: bool = False,
         compile_only: bool = False,
@@ -1847,7 +1841,6 @@ class CppTorchDeviceOptions(CppTorchOptions):
     ) -> None:
         super().__init__(
             vec_isa=vec_isa,
-            include_pytorch=include_pytorch,
             aot_mode=aot_mode,
             compile_only=compile_only,
             use_relative_path=use_relative_path,

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -429,7 +429,7 @@ def cudagraphify_impl(
             log.info("Recording cudagraph tree for symint key %s", int_key)
 
         if not has_warn:
-            has_warn = maybe_warning_due_to_dynamic_shape(fn_cache, int_key)
+            has_warn = maybe_warning_due_to_dynamic_shape(fn_cache)
 
         # first get indices we need to check to align, then update our static inputs,
         # and finally copy

--- a/torch/_inductor/cudagraph_utils.py
+++ b/torch/_inductor/cudagraph_utils.py
@@ -319,7 +319,6 @@ def log_data_ptr_mismatch(
 
 def maybe_warning_due_to_dynamic_shape(
     fn_cache: dict[tuple[int, ...], Callable[..., Any]],
-    new_int_key: Any,
 ) -> bool:
     num_cudagraphs = len(fn_cache.keys()) + 1
 

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -128,7 +128,7 @@ def create_fx_from_snodes(snodes: list[BaseSchedulerNode]) -> fx.Graph:
     """
 
     def get_fake_func(name: str) -> Callable[..., int]:
-        def func1(*args: Any) -> int:
+        def func1(*_args: Any) -> int:
             return 0
 
         func1.__name__ = name
@@ -225,7 +225,6 @@ def update_orig_fx_node_name_to_buf_name(
     nodes: SchedulerNodeList | None,
     node_name_to_buf_name: dict[str, str],
     parent_buf_name: str | None = None,
-    n_origins: int = 0,
 ) -> None:
     if nodes is None:
         return
@@ -517,9 +516,9 @@ class DebugContext:
 
     def __exit__(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: Any | None,
+        _exc_type: type[BaseException] | None,
+        _exc_val: BaseException | None,
+        _exc_tb: Any | None,
     ) -> None:
         if self._prof:
             self._prof.disable()
@@ -596,7 +595,7 @@ class DebugFormatter:
     def fx_graph_transformed(
         self,
         gm: torch.fx.GraphModule,
-        inputs: list[torch.Tensor],
+        _inputs: list[torch.Tensor],
     ) -> None:
         with self.fopen("fx_graph_transformed.py") as fd:
             fd.write(gm.print_readable(print_output=False))


### PR DESCRIPTION
## Summary
Use ruff and vulture to remove dead code in torch.compile-related helpers across Dynamo, AOTAutograd, higher-order ops, and Inductor.

## Root cause
Several torch.compile helper paths had unreachable branches, unused internal parameters, and stale debug-only code that analyzer tooling continued to flag.

## Proposed fix
- remove unreachable returns and dead `if False` debug branches
- drop unused internal parameters where the call sites are local to the helper
- rename interface-required callback parameters that are intentionally unused so analyzer output stays actionable

## Why this is the right long term fix
This keeps analyzer signal high without changing public behavior: true dead code is deleted, and protocol-required arguments are made explicit instead of being left as ambiguous unused variables.

## Testing
- `python3 -m compileall torch/_dynamo/guards.py torch/_dynamo/repro/aoti.py torch/_functorch/_aot_autograd/runtime_wrappers.py torch/_higher_order_ops/flex_attention.py torch/_inductor/autoheuristic/autoheuristic.py torch/_inductor/cache.py torch/_inductor/compile_fx_ext.py torch/_inductor/cpp_builder.py torch/_inductor/cudagraph_trees.py torch/_inductor/cudagraph_utils.py torch/_inductor/debug.py`
- `python3 -m ruff check torch/_inductor/compile_fx_ext.py torch/_inductor/debug.py torch/_inductor/autoheuristic/autoheuristic.py torch/_inductor/cudagraph_utils.py torch/_inductor/cache.py --select ARG001,ARG002,F401,F841`
- `vulture torch/_inductor/compile_fx_ext.py torch/_inductor/debug.py torch/_inductor/autoheuristic/autoheuristic.py torch/_inductor/cudagraph_utils.py torch/_inductor/cache.py --min-confidence 100`
- attempted `PYTHONPATH=. python3 test/dynamo/test_repros.py -k test_guard_same_frame_fail_message` but the checkout is not built and is missing `torch/lib/libtorch_global_deps.so`

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98