### PR TITLE
[inductor] Refactor LoopBody define-by-run capture helpers

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -17,6 +17,7 @@ from torch._inductor import config as inductor_config, ir, metrics
 from torch._inductor.codegen.triton import TritonScheduling
 from torch._inductor.graph import GraphLowering
 from torch._inductor.invert_expr_analysis import generate_inverse_formula
+from torch._inductor.loop_body import LoopBody, MemoryUsageType
 from torch._inductor.scheduler import SchedulerNode
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.test_operators import realize
@@ -123,6 +124,18 @@ class ImplDetailTest(MockSchedulerTest):
         computed_buf.decide_layout()
         return computed_buf
 
+    @staticmethod
+    def _create_buffer(name, shape, dtype=torch.float32):
+        return ir.Buffer(
+            name=name,
+            layout=ir.FixedLayout(
+                torch.device(GPU_TYPE),
+                dtype=dtype,
+                size=shape,
+                stride=ir.FlexibleLayout.contiguous_strides(shape),
+            ),
+        )
+
     def test_reorder_twice(self):
         """
         This may happen in practice if we pick a order when fusing A and B.
@@ -207,6 +220,80 @@ class ImplDetailTest(MockSchedulerTest):
             new_body.indexing_exprs["index0"],
             z2 + 49 * z1 + 2401 * ModularIndexing(z3, 1, 64),
         )
+
+    def test_loop_body_define_by_run_capture_helpers(self):
+        x = self._create_buffer("x", (8,))
+        i0 = sympy_index_symbol("i0")
+        r0 = sympy_index_symbol("r0")
+        iter_vars = [i0]
+        reduce_vars = [r0]
+        var_ranges = {
+            i0: 8,
+            r0: 4,
+        }
+
+        def inner_fn(index, rindex):
+            indirect = ops.indirect_indexing(index[0] + rindex[0], x.get_size()[0])
+            masked = ops.masked(
+                ops.lt(
+                    ops.index_expr(rindex[0], torch.int64),
+                    ops.constant(2, torch.int64),
+                ),
+                lambda: ops.load(x.get_name(), indirect),
+                ops.constant(0.0, x.get_dtype()),
+            )
+            (scanned,) = ops.scan(
+                (x.get_dtype(),),
+                lambda lhs, rhs: (ops.add(lhs[0], rhs[0]),),
+                (masked,),
+            )
+            ops.store("out", index[0], scanned)
+
+        body = LoopBody(
+            inner_fn,
+            (iter_vars, reduce_vars),
+            var_ranges,
+            iter_vars,
+            reduce_vars,
+        )
+
+        masked_name = next(
+            name for name in body.subblocks if name.startswith("masked_subblock")
+        )
+        scan_name = next(name for name in body.submodules if name.startswith("scan"))
+        indirect_name = next(
+            name for name in body.submodules if name.startswith("set_indirect")
+        )
+
+        self.assertIn(masked_name, body.submodules)
+        self.assertNotIn(scan_name, body.subblocks)
+        self.assertNotIn(indirect_name, body.subblocks)
+        self.assertEqual(len(body.indirect_vars), 1)
+        self.assertEqual(body.indirect_var_ranges[body.indirect_vars[0]], 8)
+        self.assertTrue(body.has_op("masked"))
+        self.assertTrue(body.has_op("scan"))
+        self.assertTrue(body.has_op("indirect_indexing"))
+        self.assertEqual(
+            [entry.buffer_name for entry in body.memory_usage[MemoryUsageType.LOAD]],
+            ["x"],
+        )
+        self.assertEqual(
+            [entry.buffer_name for entry in body.memory_usage[MemoryUsageType.STORE]],
+            ["out"],
+        )
+        self.assertTrue(body.subblocks[masked_name].contains_only_ops(("load",)))
+
+        p0 = sympy_index_symbol("p0")
+        p1 = sympy_index_symbol("p1")
+        copied = LoopBody(
+            body,
+            ([p0], [p1]),
+            {p0: 8, p1: 4},
+            [p0],
+            [p1],
+        )
+        self.assertEqual(set(body.submodules), set(copied.submodules))
+        self.assertEqual(set(body.subblocks), set(copied.subblocks))
 
 
 @inductor_config.patch(

--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -292,8 +292,26 @@ class ImplDetailTest(MockSchedulerTest):
             [p0],
             [p1],
         )
-        self.assertEqual(set(body.submodules), set(copied.submodules))
-        self.assertEqual(set(body.subblocks), set(copied.subblocks))
+        q0 = sympy_index_symbol("q0")
+        q1 = sympy_index_symbol("q1")
+        copied_twice = LoopBody(
+            copied,
+            ([q0], [q1]),
+            {q0: 8, q1: 4},
+            [q0],
+            [q1],
+        )
+
+        for cloned in (copied, copied_twice):
+            self.assertEqual(set(body.submodules), set(cloned.submodules))
+            self.assertEqual(set(body.subblocks), set(cloned.subblocks))
+            self.assertGreater(len(list(cloned.root_block.graph.nodes)), 0)
+            self.assertTrue(
+                all(
+                    name == "get_index" or hasattr(submodule, "clone")
+                    for name, submodule in cloned.submodules.items()
+                )
+            )
 
 
 @inductor_config.patch(

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -455,9 +455,6 @@ class LoopBody:
         self.submodules[name] = block
         return name
 
-    def add_callable_submodule(self, fn, prefix):
-        return self.add_submodule(fn, prefix)
-
     def add_indirect(self, size):
         var = sympy_index_symbol_with_prefix(SymT.INDIRECT, len(self.indirect_vars))
         assert var not in self.indirect_var_ranges
@@ -529,7 +526,7 @@ class LoopBody:
             check=check,
             wrap_neg=wrap_neg,
         )
-        return var, self.add_callable_submodule(shim, f"set_{var}")
+        return var, self.add_submodule(shim, f"set_{var}")
 
     def _scan_shim(self, combine_fn):
         def shim(dtypes, values):
@@ -539,7 +536,7 @@ class LoopBody:
 
     def add_scan_submodule(self, combine_fn):
         shim = self._make_cloneable_shim(LoopBody._scan_shim, combine_fn=combine_fn)
-        return self.add_callable_submodule(shim, "scan")
+        return self.add_submodule(shim, "scan")
 
     def _masked_subblock_shim(self, name):
         def shim(mask, other):

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -456,9 +456,7 @@ class LoopBody:
         return name
 
     def add_callable_submodule(self, fn, prefix):
-        name = self.add_submodule(fn, prefix)
-        self.submodules[name] = fn
-        return name
+        return self.add_submodule(fn, prefix)
 
     def add_indirect(self, size):
         var = sympy_index_symbol_with_prefix(SymT.INDIRECT, len(self.indirect_vars))
@@ -507,7 +505,11 @@ class LoopBody:
 
     def _make_cloneable_shim(self, shim_factory, **kwargs):
         shim = shim_factory(self, **kwargs)
-        shim.clone = functools.partial(shim_factory, **kwargs)  # type: ignore[attr-defined]
+        shim.clone = functools.partial(  # type: ignore[attr-defined]
+            LoopBody._make_cloneable_shim,
+            shim_factory=shim_factory,
+            **kwargs,
+        )
         return shim
 
     def _indirect_index_shim(self, var, size, check, wrap_neg):

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import collections
+import contextlib
 import functools
 import itertools
 import re
@@ -93,6 +94,12 @@ class LoopBody:
     """
     Captures the body of a Loops subclass into an FX graph.  Persists any
     indexing simplifications and makes it easier to analyze loop bodies.
+
+    The capture pipeline is still define-by-run: we run the user callback once with
+    a tracing ``V.ops`` handler installed. The handler records symbolic indexing,
+    registers synthetic ``call_module`` targets for control-flow-like constructs
+    such as ``masked``/``scan``/``indirect_indexing``, and emits an FX graph that
+    can later be replayed with a different ``V.ops`` interpretation.
     """
 
     indexing_exprs: dict[str, sympy.Expr]
@@ -448,6 +455,11 @@ class LoopBody:
         self.submodules[name] = block
         return name
 
+    def add_callable_submodule(self, fn, prefix):
+        name = self.add_submodule(fn, prefix)
+        self.submodules[name] = fn
+        return name
+
     def add_indirect(self, size):
         var = sympy_index_symbol_with_prefix(SymT.INDIRECT, len(self.indirect_vars))
         assert var not in self.indirect_var_ranges
@@ -480,40 +492,67 @@ class LoopBody:
             for name, expr in self.indexing_exprs.items()
         }
 
-    def __call__(self, *indices, allow_same_symbol_in_index=False):
+    @contextlib.contextmanager
+    def indexing_context(self, indices, allow_same_symbol_in_index=False):
+        assert self.indexing is None
         self.indexing = self.indexing_from_args(indices, allow_same_symbol_in_index)
-        result = self.root_block()
-        self.indexing = None
-        return result
+        try:
+            yield
+        finally:
+            self.indexing = None
 
-    def bind_set_indirect_shim(self, var, size, check, wrap_neg):
+    def __call__(self, *indices, allow_same_symbol_in_index=False):
+        with self.indexing_context(indices, allow_same_symbol_in_index):
+            return self.root_block()
+
+    def _make_cloneable_shim(self, shim_factory, **kwargs):
+        shim = shim_factory(self, **kwargs)
+        shim.clone = functools.partial(shim_factory, **kwargs)  # type: ignore[attr-defined]
+        return shim
+
+    def _indirect_index_shim(self, var, size, check, wrap_neg):
         def set_indirect(new_var):
             self.replace_indirect(
                 var, V.ops.indirect_indexing(new_var, size, check, wrap_neg)
             )
 
-        set_indirect.clone = functools.partial(  # type: ignore[attr-defined]
-            LoopBody.bind_set_indirect_shim,
+        return set_indirect
+
+    def add_indirect_index_submodule(self, size, check=True, wrap_neg=True):
+        var = self.add_indirect(size)
+        shim = self._make_cloneable_shim(
+            LoopBody._indirect_index_shim,
             var=var,
             size=size,
             check=check,
             wrap_neg=wrap_neg,
         )
-        return set_indirect
+        return var, self.add_callable_submodule(shim, f"set_{var}")
 
-    def bind_scan_shim(self, combine_fn):
+    def _scan_shim(self, combine_fn):
         def shim(dtypes, values):
             return V.ops.scan(dtypes, combine_fn, values)
 
-        shim.clone = functools.partial(LoopBody.bind_scan_shim, combine_fn=combine_fn)  # type: ignore[attr-defined]
         return shim
 
-    def bind_masked_shim(self, name):
+    def add_scan_submodule(self, combine_fn):
+        shim = self._make_cloneable_shim(LoopBody._scan_shim, combine_fn=combine_fn)
+        return self.add_callable_submodule(shim, "scan")
+
+    def _masked_subblock_shim(self, name):
         def shim(mask, other):
             return V.ops.masked(mask, self.subblocks[name], other)
 
-        shim.clone = functools.partial(LoopBody.bind_masked_shim, name=name)  # type: ignore[attr-defined]
         return shim
+
+    def add_masked_subblock(self, masked_body):
+        name = self.add_submodule(None, "masked_subblock")
+        self.submodules[name] = self._make_cloneable_shim(
+            LoopBody._masked_subblock_shim,
+            name=name,
+        )
+        self.subblocks[name] = LoopBodyBlock(self, masked_body, [])
+        return name
 
 
 class LoopBodyBlock:
@@ -524,22 +563,26 @@ class LoopBodyBlock:
     operations will manifest as an extra LoopBodyBlock.
     """
 
-    def __init__(self, body: LoopBody, fn: Callable[..., Any], args: list[Any]):
-        self.body = body
-
-        tracer = LightTracer()
-        proxy_ops = tracer.create_proxy("placeholder", "ops", (), {})
-
+    @staticmethod
+    def _make_tracing_handler(body: LoopBody, tracer: LightTracer):
         from .index_propagation import IndexPropagation
 
+        proxy_ops = tracer.create_proxy("placeholder", "ops", (), {})
         handler: Any = CountOps(
             CaptureIndexing(proxy_ops, body, tracer),
             body.op_counts,
         )
         if config.constant_and_index_propagation:
             handler = IndexPropagation(
-                handler, self.body.var_ranges, self.body.indirect_var_ranges
+                handler, body.var_ranges, body.indirect_var_ranges
             )
+        return handler
+
+    def __init__(self, body: LoopBody, fn: Callable[..., Any], args: list[Any]):
+        self.body = body
+
+        tracer = LightTracer()
+        handler = self._make_tracing_handler(body, tracer)
 
         with V.set_ops_handler(handler):
             # This indirection is just a cute way to get IndexPropagation to
@@ -633,6 +676,13 @@ class CaptureIndexing(WrapperHandler):
             (self.body.add_index_expr(expr, mtype, **kwargs),),
             {},
         )
+
+    def _call_submodule(self, name: str, *args: Any):
+        return self.tracer.create_proxy("call_module", name, args, {})
+
+    @staticmethod
+    def _proxy_tuple(result_proxy, size: int):
+        return tuple(result_proxy[i] for i in range(size))
 
     def _simplify(self, expr: sympy.Expr) -> sympy.Expr:
         return V.graph.sizevars.simplify_with_ranges(expr, self.body.var_ranges)
@@ -736,12 +786,8 @@ class CaptureIndexing(WrapperHandler):
         """
         Recursively capture the masked out body in another LoopBodyBlock
         """
-        name = self.body.add_submodule(None, "masked_subblock")
-        self.body.submodules[name] = self.body.bind_masked_shim(name)
-        self.body.subblocks[name] = LoopBodyBlock(self.body, masked_body, [])
-        return self.tracer.create_proxy(
-            "call_module", name, (mask_proxy, other_proxy), {}
-        )
+        name = self.body.add_masked_subblock(masked_body)
+        return self._call_submodule(name, mask_proxy, other_proxy)
 
     def scan(
         self,
@@ -749,26 +795,20 @@ class CaptureIndexing(WrapperHandler):
         combine_fn: Callable[[tuple[Any, ...], tuple[Any, ...]], tuple[Any, ...]],
         value_proxy,
     ):
-        shim = self.body.bind_scan_shim(combine_fn)
-        name = self.body.add_submodule(shim, "scan")
-        result = self.tracer.create_proxy(
-            "call_module",
-            name,
-            (dtype_proxy, value_proxy),
-            {},
-        )
+        name = self.body.add_scan_submodule(combine_fn)
+        result = self._call_submodule(name, dtype_proxy, value_proxy)
         # Proxies are iterable, but some methods expect tuples/lists
-        return tuple(result[i] for i in range(len(value_proxy)))
+        return self._proxy_tuple(result, len(value_proxy))
 
     def sort(self, dtypes, values, stable, descending):
         result = self._inner.sort(dtypes, values, stable, descending)
         # Proxies are iterable, but some methods expect tuples/lists
-        return tuple(result[i] for i in range(len(values)))
+        return self._proxy_tuple(result, len(values))
 
     def frexp(self, value_proxy):
         result = self._inner.frexp(value_proxy)
         # Proxies are iterable, but some methods expect tuples/lists
-        return (result[0], result[1])
+        return self._proxy_tuple(result, 2)
 
     def indirect_indexing(self, index_proxy, size, check=True, wrap_neg=True):
         """
@@ -776,14 +816,12 @@ class CaptureIndexing(WrapperHandler):
         Introduce a call_module to update the indexing.
         """
 
-        var = self.body.add_indirect(size)
-        set_indirect = self.body.bind_set_indirect_shim(var, size, check, wrap_neg)
-        self.tracer.create_proxy(
-            "call_module",
-            self.body.add_submodule(set_indirect, f"set_{var}"),
-            (index_proxy,),
-            {},
+        var, submodule_name = self.body.add_indirect_index_submodule(
+            size,
+            check=check,
+            wrap_neg=wrap_neg,
         )
+        self._call_submodule(submodule_name, index_proxy)
         return var
 
     def output(self, *result):


### PR DESCRIPTION
## Summary
This refactor makes Inductor's define-by-run `LoopBody` capture path easier to follow by separating synthetic `call_module` registration, cloneable shim creation, and tracing-handler construction.

## Root cause problem
`LoopBody` mixed three different responsibilities in the same capture path: registering synthetic FX submodules for define-by-run control flow, building cloneable shims so copied loop bodies still replay correctly, and layering the `V.ops` handlers that record the trace.

## Proposed fix
Introduce named `LoopBody` helpers for registering masked/scan/indirect-indexing submodules, centralize cloneable shim creation, make the temporary indexing state explicit with a context manager, and factor the tracing handler stack into a dedicated `LoopBodyBlock` helper. Add a focused regression test that exercises masked, scan, and indirect-indexing capture together.

## Why the proposed fix is the right long term fix
This keeps behavior unchanged while making the capture pipeline match the mental model Inductor uses elsewhere: define-by-run bodies are recorded once, replayed under alternate handlers, and copied by cloning explicit shims instead of relying on ad hoc setup spread across `CaptureIndexing`.

## Testing
- `python3 -m compileall torch/_inductor/loop_body.py test/inductor/test_loop_ordering.py`
- `git diff --check`
- Attempted targeted runtime test: `python3 test/inductor/test_loop_ordering.py ImplDetailTest.test_loop_body_define_by_run_capture_helpers` (blocked in this environment because the available Python lacks `torch`, `numpy`, and `typing_extensions`)

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo