### PR TITLE
Refactor Dynamo bytecode emission helpers

### DIFF
--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -154,8 +154,6 @@ class PyCodegen:
             self.clear_tos()
 
     def _emit_source(self, value: Source) -> None:
-        # Source-based reconstruction is the fast path for values that still
-        # have a live Python object behind them.
         source = self.overridden_sources.get(value, value)
         if self.top_of_stack is value:
             self._output.append(create_dup_top())
@@ -204,17 +202,9 @@ class PyCodegen:
             return False
         if value.is_realized() and isinstance(value, LocalGeneratorObjectVariable):
             return False
-        return isinstance(value.mutation_type, ValueMutationExisting) or (
-            self.value_from_source
-        )
-
-    def _get_graph_output_entry(self, value: VariableTracker) -> GraphOutputEntry:
-        graph_outputs_key = id(value.as_proxy())
-        if graph_outputs_key not in self.graph_outputs:
-            self.graph_outputs[graph_outputs_key] = GraphOutputEntry(
-                len(self.graph_outputs), value
-            )
-        return self.graph_outputs[graph_outputs_key]
+        if isinstance(value.mutation_type, ValueMutationExisting):
+            return True
+        return self.value_from_source
 
     def _emit_graph_output_item(self, value: VariableTracker) -> None:
         graph_output_index = self.add_graph_output(value)
@@ -230,9 +220,7 @@ class PyCodegen:
         self, value: TensorWithTFOverrideVariable
     ) -> None:
         graph_output_index = self.add_graph_output(value)
-        self.add_push_null(
-            lambda: self.load_import_from(utils.__name__, "to_subclass")
-        )
+        self.add_push_null(lambda: self.load_import_from(utils.__name__, "to_subclass"))
         self.load_graph_output(graph_output_index)
         self._output.append(
             self.create_load_global(
@@ -253,8 +241,8 @@ class PyCodegen:
         | NumpyNdarrayVariable
         | TorchScriptObjectVariable,
     ) -> None:
-        graph_output_index = self.add_graph_output(value)
         if isinstance(value, NumpyNdarrayVariable):
+            graph_output_index = self.add_graph_output(value)
             self.add_push_null(
                 lambda: self.load_import_from(utils.__name__, "to_numpy_helper")
             )
@@ -263,6 +251,7 @@ class PyCodegen:
         elif isinstance(value, UnspecializedPythonVariable) and value.need_unwrap:
             self._emit_graph_output_item(value)
         else:
+            graph_output_index = self.add_graph_output(value)
             self.load_graph_output(graph_output_index)
 
     def _emit_nn_module(self, value: NNModuleVariable) -> None:
@@ -426,7 +415,12 @@ class PyCodegen:
         self.top_of_stack = value
 
     def add_graph_output(self, value: VariableTracker) -> int:
-        return self._get_graph_output_entry(value).index
+        graph_outputs_key = id(value.as_proxy())
+        if graph_outputs_key not in self.graph_outputs:
+            self.graph_outputs[graph_outputs_key] = GraphOutputEntry(
+                len(self.graph_outputs), value
+            )
+        return self.graph_outputs[graph_outputs_key].index
 
     def load_graph_output(self, index: int) -> None:
         output = self._output
@@ -659,9 +653,7 @@ class PyCodegen:
             nested_sources.append(source.index)
         return nested_sources
 
-    def _mark_reused_grapharg_sources(
-        self, graphargs: list["GraphArg"]
-    ) -> None:
+    def _mark_reused_grapharg_sources(self, graphargs: list["GraphArg"]) -> None:
         # Sources reused across graph inputs become temp locals so later codegen
         # can load them directly instead of replaying a long source chain.
         seen_sources: OrderedSet[Source] = OrderedSet()

--- a/torch/_dynamo/codegen.py
+++ b/torch/_dynamo/codegen.py
@@ -153,6 +153,187 @@ class PyCodegen:
             # NULL will be at top of stack
             self.clear_tos()
 
+    def _emit_source(self, value: Source) -> None:
+        # Source-based reconstruction is the fast path for values that still
+        # have a live Python object behind them.
+        source = self.overridden_sources.get(value, value)
+        if self.top_of_stack is value:
+            self._output.append(create_dup_top())
+            return
+
+        cached_tempvar = self.tempvars.get(source)
+        if cached_tempvar is not None:
+            self._output.append(self.create_load(cached_tempvar))
+            self.top_of_stack = source
+            return
+
+        self.uses[source] += 1
+        try:
+            self.call_reconstruct(source)
+        except NotImplementedError:
+            unimplemented(
+                gb_type="Reconstruction failure: source.reconstruct not implemented",
+                context=str(source),
+                explanation=f"Dynamo has no bytecode reconstruction implemented for {type(source)} variable {source}.",
+                hints=[*graph_break_hints.DYNAMO_BUG],
+            )
+        if source in self.tempvars:
+            self._output.append(create_dup_top())
+            self.add_cache(source)
+        self.top_of_stack = source
+
+    def _try_load_cached_var(self, value: VariableTracker, allow_cache: bool) -> bool:
+        if not allow_cache:
+            return False
+        if self.top_of_stack is value:
+            self._output.append(create_dup_top())
+            return True
+
+        cached_tempvar = self.tempvars.get(value)
+        if cached_tempvar is None:
+            return False
+
+        self._output.append(self.create_load(cached_tempvar))
+        self.top_of_stack = value
+        return True
+
+    def _should_reconstruct_value_from_source(
+        self, value: VariableTracker, allow_cache: bool
+    ) -> bool:
+        if value.source is None or not allow_cache:
+            return False
+        if value.is_realized() and isinstance(value, LocalGeneratorObjectVariable):
+            return False
+        return isinstance(value.mutation_type, ValueMutationExisting) or (
+            self.value_from_source
+        )
+
+    def _get_graph_output_entry(self, value: VariableTracker) -> GraphOutputEntry:
+        graph_outputs_key = id(value.as_proxy())
+        if graph_outputs_key not in self.graph_outputs:
+            self.graph_outputs[graph_outputs_key] = GraphOutputEntry(
+                len(self.graph_outputs), value
+            )
+        return self.graph_outputs[graph_outputs_key]
+
+    def _emit_graph_output_item(self, value: VariableTracker) -> None:
+        graph_output_index = self.add_graph_output(value)
+
+        def gen_fn() -> None:
+            self.load_graph_output(graph_output_index)
+            self._output.append(self.create_load_attr("item"))
+
+        self.add_push_null(gen_fn)
+        self._output.extend(create_call_function(0, False))
+
+    def _emit_tensor_with_tf_override(
+        self, value: TensorWithTFOverrideVariable
+    ) -> None:
+        graph_output_index = self.add_graph_output(value)
+        self.add_push_null(
+            lambda: self.load_import_from(utils.__name__, "to_subclass")
+        )
+        self.load_graph_output(graph_output_index)
+        self._output.append(
+            self.create_load_global(
+                value.global_mangled_class_name(self.tx),  # type: ignore[arg-type]
+                add=True,
+            )
+        )
+        self._output.extend(create_call_function(2, False))
+
+    def _emit_realized_symnode_float(self, value: SymNodeVariable) -> None:
+        self._emit_graph_output_item(value.as_tensor(self.tx, torch.float64))
+
+    def _emit_traced_graph_output(
+        self,
+        value: TensorVariable
+        | SymNodeVariable
+        | UnspecializedPythonVariable
+        | NumpyNdarrayVariable
+        | TorchScriptObjectVariable,
+    ) -> None:
+        graph_output_index = self.add_graph_output(value)
+        if isinstance(value, NumpyNdarrayVariable):
+            self.add_push_null(
+                lambda: self.load_import_from(utils.__name__, "to_numpy_helper")
+            )
+            self.load_graph_output(graph_output_index)
+            self._output.extend(create_call_function(1, False))
+        elif isinstance(value, UnspecializedPythonVariable) and value.need_unwrap:
+            self._emit_graph_output_item(value)
+        else:
+            self.load_graph_output(graph_output_index)
+
+    def _emit_nn_module(self, value: NNModuleVariable) -> None:
+        parts = value.module_key.split(".")
+        if parts[0] in self.code_options["co_varnames"]:
+            self._output.append(self.create_load(parts[0]))
+            parts = parts[1:]
+        else:
+            assert self.root is not None
+            self._output.append(self.create_load_const_unchecked(self.root))
+        for part in parts:
+            self._output.append(self.create_load_attr(part))
+
+    def _emit_reconstructed_variable(
+        self, value: VariableTracker, allow_cache: bool
+    ) -> None:
+        self.uses[value] += 1
+        try:
+            self.call_reconstruct(value)
+        except NotImplementedError as e:
+            unimplemented(
+                gb_type="Reconstruction failure",
+                context=str(value),
+                explanation=f"Dynamo has no bytecode reconstruction implemented for sourceless variable {value}.",
+                hints=[
+                    "If Dynamo is attempting to trace a return statement and your code is attempting to return a variable "
+                    "that Dynamo cannot reconstruct, then remove it from the return statement.",
+                    *graph_break_hints.CAUSED_BY_EARLIER_GRAPH_BREAK,
+                    "Report an issue to PyTorch if you need reconstrtuction support. Note that objects that don't have "
+                    "reconstruction rules may be fundamentally unreconstructable.",
+                ],
+                from_exc=e,
+            )
+        if allow_cache and value in self.tempvars:
+            self._output.append(create_dup_top())
+            self.add_cache(value)
+
+    def _emit_variable(self, value: VariableTracker, allow_cache: bool) -> None:
+        if value.is_python_constant() and is_safe_constant(value.as_python_constant()):
+            self._output.append(self.create_load_const(value.as_python_constant()))
+        elif isinstance(value, TensorWithTFOverrideVariable):
+            self._emit_tensor_with_tf_override(value)
+        elif (
+            isinstance(value, SymNodeVariable)
+            and value.python_type() is float
+            and not self.tx.export
+        ):
+            # This is a little unusual; force the output convention to be a
+            # Tensor here.  Don't do this for export because this is
+            # apparently load bearing for export tests (but I am a bit
+            # doubtful it actually works in the real world)
+            # NB: It works to add_graph_output on a computed expression
+            # as_tensor here, because we memoize as_tensor calls on
+            # SymNodeVariable!
+            self._emit_realized_symnode_float(value)
+        elif isinstance(
+            value,
+            (
+                TensorVariable,
+                SymNodeVariable,
+                UnspecializedPythonVariable,
+                NumpyNdarrayVariable,
+                TorchScriptObjectVariable,
+            ),
+        ):
+            self._emit_traced_graph_output(value)
+        elif isinstance(value, NNModuleVariable):
+            self._emit_nn_module(value)
+        else:
+            self._emit_reconstructed_variable(value, allow_cache)
+
     def __call__(
         self, value: VariableTracker | Source | None, allow_cache: bool = True
     ) -> None:
@@ -200,48 +381,13 @@ class PyCodegen:
         """
         assert value is not None
         if isinstance(value, Source):
-            # If the source needs to be overridden, use the new one.
-            source = self.overridden_sources.get(value, value)
             assert allow_cache is True, "allow_cache must be True for Source"
-            if self.top_of_stack is value:
-                self._output.append(create_dup_top())
-                return
-
-            if self.tempvars.get(source) is not None:
-                self._output.append(self.create_load(self.tempvars[source]))
-                self.top_of_stack = source
-                return
-
-            self.uses[source] += 1
-            try:
-                self.call_reconstruct(source)
-            except NotImplementedError:
-                unimplemented(
-                    gb_type="Reconstruction failure: source.reconstruct not implemented",
-                    context=str(source),
-                    explanation=f"Dynamo has no bytecode reconstruction implemented for {type(source)} variable {source}.",
-                    hints=[*graph_break_hints.DYNAMO_BUG],
-                )
-            if source in self.tempvars:
-                self._output.append(create_dup_top())
-                self.add_cache(source)
-            self.top_of_stack = source
-
+            self._emit_source(value)
             return
 
         assert isinstance(value, VariableTracker)
-        output = self._output
-        graph_outputs = self.graph_outputs
-
-        if allow_cache:
-            if self.top_of_stack is value:
-                output.append(create_dup_top())
-                return
-
-            if self.tempvars.get(value) is not None:
-                output.append(self.create_load(self.tempvars[value]))
-                self.top_of_stack = value
-                return
+        if self._try_load_cached_var(value, allow_cache):
+            return
 
         if value.is_realized() and isinstance(
             value, ContextlibContextManagerLocalGeneratorObjectVariable
@@ -256,142 +402,31 @@ class PyCodegen:
             )
 
         # Dynamo normally prefers codegen from source to account for aliasing.
-        if (
-            value.source is not None
-            and allow_cache
-            and not (
-                value.is_realized() and isinstance(value, LocalGeneratorObjectVariable)
-            )
-        ):
-            # There's a corner case for export: for instance, if the computation
-            # graph is just identity on an input tensor, Dynamo would just emit
-            # a `LOAD_FAST` from the input source, rather than generating an
-            # identity FX graph.
-            #
-            # However, export wants to maximize graph capture; in the case
-            # above, export _wants to_ obtain an identity FX graph (despite it
-            # appears unnecessarily expensive for `torch.compile`), so we have
-            # the following option to override Dynamo's preference for codegen
-            # from source. Moreover, this option applies recursively, for cases
-            # like input tensor being returned in a new dictionary.
-            #
-            # And why the `ValueMutationExisting` check? Not sure, so leaving it
-            # to keep the old behavior, as when `value_from_source` was
-            # introduced. TODO sort out the invariants among side effect,
-            # codegen and export.
-            if (
-                isinstance(value.mutation_type, ValueMutationExisting)
-                or self.value_from_source
-            ):
-                return self(value.source)
+        # There's a corner case for export: for instance, if the computation
+        # graph is just identity on an input tensor, Dynamo would just emit
+        # a `LOAD_FAST` from the input source, rather than generating an
+        # identity FX graph.
+        #
+        # However, export wants to maximize graph capture; in the case
+        # above, export _wants to_ obtain an identity FX graph (despite it
+        # appears unnecessarily expensive for `torch.compile`), so we have
+        # the following option to override Dynamo's preference for codegen
+        # from source. Moreover, this option applies recursively, for cases
+        # like input tensor being returned in a new dictionary.
+        #
+        # And why the `ValueMutationExisting` check? Not sure, so leaving it
+        # to keep the old behavior, as when `value_from_source` was
+        # introduced. TODO sort out the invariants among side effect,
+        # codegen and export.
+        if self._should_reconstruct_value_from_source(value, allow_cache):
+            return self(value.source)
 
-        if value.is_python_constant() and is_safe_constant(value.as_python_constant()):
-            output.append(self.create_load_const(value.as_python_constant()))
-        elif isinstance(value, TensorWithTFOverrideVariable):
-            graph_outputs_key = self.add_graph_output(value)
-
-            self.add_push_null(
-                lambda: self.load_import_from(utils.__name__, "to_subclass")
-            )
-            self.load_graph_output(graph_outputs[graph_outputs_key].index)
-            output.append(
-                self.create_load_global(
-                    value.global_mangled_class_name(self.tx),  # type: ignore[arg-type]
-                    add=True,
-                )
-            )
-            output.extend(create_call_function(2, False))
-        elif (
-            isinstance(value, SymNodeVariable)
-            and value.python_type() is float
-            and not self.tx.export
-        ):
-            # This is a little unusual; force the output convention to be a
-            # Tensor here.  Don't do this for export because this is
-            # apparently load bearing for export tests (but I am a bit
-            # doubtful it actually works in the real world)
-            # NB: It works to add_graph_output on a computed expression
-            # as_tensor here, because we memoize as_tensor calls on
-            # SymNodeVariable!
-            graph_outputs_key = self.add_graph_output(
-                value.as_tensor(self.tx, torch.float64)
-            )
-
-            def gen_fn() -> None:
-                self.load_graph_output(graph_outputs[graph_outputs_key].index)
-                output.append(self.create_load_attr("item"))
-
-            self.add_push_null(gen_fn)
-            output.extend(create_call_function(0, False))
-        elif isinstance(
-            value,
-            (
-                TensorVariable,
-                SymNodeVariable,
-                UnspecializedPythonVariable,
-                NumpyNdarrayVariable,
-                TorchScriptObjectVariable,
-            ),
-        ):
-            graph_outputs_key = self.add_graph_output(value)
-
-            if isinstance(value, NumpyNdarrayVariable):
-                self.add_push_null(
-                    lambda: self.load_import_from(utils.__name__, "to_numpy_helper")
-                )
-                self.load_graph_output(graph_outputs[graph_outputs_key].index)
-                output.extend(create_call_function(1, False))
-            elif isinstance(value, UnspecializedPythonVariable) and value.need_unwrap:
-
-                def gen_fn() -> None:
-                    self.load_graph_output(graph_outputs[graph_outputs_key].index)
-                    output.append(self.create_load_attr("item"))
-
-                self.add_push_null(gen_fn)
-                output.extend(create_call_function(0, False))
-            else:
-                self.load_graph_output(graph_outputs[graph_outputs_key].index)
-        elif isinstance(value, NNModuleVariable):
-            parts = value.module_key.split(".")
-            if parts[0] in self.code_options["co_varnames"]:
-                output.append(self.create_load(parts[0]))
-                parts = parts[1:]
-            else:
-                assert self.root is not None
-                output.append(self.create_load_const_unchecked(self.root))
-            for part in parts:
-                output.append(self.create_load_attr(part))
-        else:
-            self.uses[value] += 1
-            try:
-                self.call_reconstruct(value)
-            except NotImplementedError as e:
-                unimplemented(
-                    gb_type="Reconstruction failure",
-                    context=str(value),
-                    explanation=f"Dynamo has no bytecode reconstruction implemented for sourceless variable {value}.",
-                    hints=[
-                        "If Dynamo is attempting to trace a return statement and your code is attempting to return a variable "
-                        "that Dynamo cannot reconstruct, then remove it from the return statement.",
-                        *graph_break_hints.CAUSED_BY_EARLIER_GRAPH_BREAK,
-                        "Report an issue to PyTorch if you need reconstrtuction support. Note that objects that don't have "
-                        "reconstruction rules may be fundamentally unreconstructable.",
-                    ],
-                    from_exc=e,
-                )
-            if allow_cache and value in self.tempvars:
-                self._output.append(create_dup_top())
-                self.add_cache(value)
+        self._emit_variable(value, allow_cache)
 
         self.top_of_stack = value
 
     def add_graph_output(self, value: VariableTracker) -> int:
-        graph_outputs_key = id(value.as_proxy())
-        if graph_outputs_key not in self.graph_outputs:
-            self.graph_outputs[graph_outputs_key] = GraphOutputEntry(
-                len(self.graph_outputs), value
-            )
-        return graph_outputs_key
+        return self._get_graph_output_entry(value).index
 
     def load_graph_output(self, index: int) -> None:
         output = self._output
@@ -615,80 +650,86 @@ class PyCodegen:
         if source not in self.tempvars:
             self.tempvars[source] = None
 
+    @staticmethod
+    def _extract_nested_sources(source: Source) -> list[Source]:
+        nested_sources: list[Source] = []
+        if isinstance(source, ChainedSource):
+            nested_sources.append(source.base)
+        if isinstance(source, DictGetItemSource) and isinstance(source.index, Source):
+            nested_sources.append(source.index)
+        return nested_sources
+
+    def _mark_reused_grapharg_sources(
+        self, graphargs: list["GraphArg"]
+    ) -> None:
+        # Sources reused across graph inputs become temp locals so later codegen
+        # can load them directly instead of replaying a long source chain.
+        seen_sources: OrderedSet[Source] = OrderedSet()
+        pending_sources = deque(
+            arg.source for arg in graphargs if arg.source is not None
+        )
+        while pending_sources:
+            current_source = pending_sources.popleft()
+            if current_source in seen_sources:
+                self.mark_source_temp(current_source)
+                # Don't recurse further once we know we want to cache this
+                # source. This keeps the pre-graph temp set small.
+                continue
+            seen_sources.add(current_source)
+            pending_sources.extend(self._extract_nested_sources(current_source))
+
+    def _start_runtime_overhead_recording(self) -> str | None:
+        if not config.record_runtime_overhead:
+            return None
+        self.add_push_null(
+            lambda: self.load_import_from(
+                utils.__name__, "record_pregraph_bytecode_enter"
+            )
+        )
+        self.extend_output(create_call_function(0, False))
+        cm_var = self.new_var()
+        self.store(cm_var)
+        return cm_var
+
+    def _finish_runtime_overhead_recording(self, cm_var: str | None) -> None:
+        if not config.record_runtime_overhead:
+            return
+        self.add_push_null(
+            lambda: self.load_import_from(
+                utils.__name__, "record_pregraph_bytecode_exit"
+            )
+        )
+        assert cm_var is not None
+        self.extend_output([self.create_load(cm_var)])
+        self.extend_output(create_call_function(1, False))
+        self.pop_top()
+
+    def _emit_grapharg(self, arg: "GraphArg") -> None:
+        if arg.pass_arg_as_tensor:
+            self.add_push_null(
+                lambda: self.extend_output(
+                    [
+                        self.create_load_python_module(torch),
+                        self.create_load_attr("_as_tensor_fullprec"),
+                    ]
+                )
+            )
+            self.call_reconstruct(arg)
+            self.extend_output(create_call_function(1, False))
+        else:
+            self.call_reconstruct(arg)
+
     def make_call_generated_code(self, fn_name: str) -> None:
         """Call the generated code function stored in fn_name"""
         self.extend_output(self.load_function_name(fn_name, True))
 
         graphargs = self.tx.output.graphargs
+        self._mark_reused_grapharg_sources(graphargs)
 
-        def extract_nested_sources(source: Source) -> list[Source]:
-            nested_sources: list[Source] = []
-            if isinstance(source, ChainedSource):
-                nested_sources.append(source.base)
-            if isinstance(source, DictGetItemSource) and isinstance(
-                source.index, Source
-            ):
-                nested_sources.append(source.index)
-            return nested_sources
-
-        def collect_temp_sources(sources: deque[Source], codegen: PyCodegen) -> None:
-            seen_sources: OrderedSet[Source] = OrderedSet()
-            while sources:
-                current_source = sources.popleft()
-                if current_source in seen_sources:
-                    # This source is used at least twice, so it can be reused
-                    codegen.mark_source_temp(current_source)
-                    # Dont trace source further. This prevents us from marking too
-                    # many nodes as temp sources.
-                    continue
-                seen_sources.add(current_source)
-                sources.extend(extract_nested_sources(current_source))
-
-        # Collect all the sources that are used more than once, so that we can
-        # generate tmp variables in the generated pre-graph bytecode. This
-        # essentially implements CSE.
-        collect_temp_sources(
-            deque([arg.source for arg in graphargs if arg.source is not None]), self
-        )
-
-        cm_var = None
-        if config.record_runtime_overhead:
-            # Record the pregraph bytecode start
-            self.add_push_null(
-                lambda: self.load_import_from(
-                    utils.__name__, "record_pregraph_bytecode_enter"
-                )
-            )
-            self.extend_output(create_call_function(0, False))
-            cm_var = self.new_var()
-            self.store(cm_var)
-
+        cm_var = self._start_runtime_overhead_recording()
         for arg in graphargs:
-            if arg.pass_arg_as_tensor:
-                self.add_push_null(
-                    lambda: self.extend_output(
-                        [
-                            self.create_load_python_module(torch),
-                            self.create_load_attr("_as_tensor_fullprec"),
-                        ]
-                    )
-                )
-                self.call_reconstruct(arg)
-                self.extend_output(create_call_function(1, False))
-            else:
-                self.call_reconstruct(arg)
-
-        if config.record_runtime_overhead:
-            # Record the pregraph bytecode end
-            self.add_push_null(
-                lambda: self.load_import_from(
-                    utils.__name__, "record_pregraph_bytecode_exit"
-                )
-            )
-            assert cm_var is not None
-            self.extend_output([self.create_load(cm_var)])
-            self.extend_output(create_call_function(1, False))
-            self.pop_top()
+            self._emit_grapharg(arg)
+        self._finish_runtime_overhead_recording(cm_var)
 
         self.extend_output(create_call_function(len(graphargs), False))
 


### PR DESCRIPTION
## Summary
This refactor splits `PyCodegen`'s bytecode emission into smaller helpers so the source, graph-output, and generated-call paths are easier to follow.

## Root cause problem
The main bytecode generation flow in `PyCodegen.__call__` mixed source reconstruction, tempvar reuse, graph output handling, and fallback reconstruction in one large method. `make_call_generated_code` also hid temp-source CSE and runtime-overhead bookkeeping inside nested functions, which made the control flow harder to read.

## Proposed fix
Factor those responsibilities into named helper methods for:
- source emission and cached variable reuse
- source-vs-variable dispatch
- graph output emission for special variable classes
- grapharg temp-source marking and runtime-overhead bookkeeping for generated calls

## Why this is the right long term fix
Dynamo's bytecode generation keeps accumulating Python-version-specific behavior and special variable cases. Keeping each emission path behind a small helper makes future changes easier to reason about without re-parsing one monolithic method.

## Testing
- `PYTHONPATH=/tmp/repos/pytorch/pytorch python3 test/dynamo/test_reconstruct.py`
- `PYTHONPATH=/tmp/repos/pytorch/pytorch python3 test/dynamo/test_subclasses.py -k test_tensor_subclass_attr_codegen_tos`
- `PYTHONPATH=/tmp/repos/pytorch/pytorch python3 test/dynamo/test_model_output.py -k test_mo_reconstruct_bytecode` (skipped: requires HuggingFace)

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98