### PR TITLE
Replace BF16 matmul OpInfo checks with a feature query

### DIFF
--- a/test/test_cuda_compatibility.py
+++ b/test/test_cuda_compatibility.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import torch
 import torch.cuda
+from torch.testing._internal.common_cuda import evaluate_platform_supports_bf16_matmul
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -152,6 +153,40 @@ class TestCheckCapability(TestCase):
                 "install a PyTorch release that supports one of these CUDA versions",
                 msg,
             )
+
+
+class TestCommonCudaFeatureQueries(TestCase):
+    @patch("torch.testing._internal.common_cuda.SM53OrLater", True)
+    def test_bf16_matmul_supports_cuda_sm53_or_later(self, *args):
+        with (
+            patch("torch.version.cuda", "12.6"),
+            patch("torch.version.hip", None),
+        ):
+            self.assertTrue(evaluate_platform_supports_bf16_matmul())
+
+    @patch("torch.testing._internal.common_cuda.SM53OrLater", False)
+    def test_bf16_matmul_rejects_cuda_before_sm53(self, *args):
+        with (
+            patch("torch.version.cuda", "12.6"),
+            patch("torch.version.hip", None),
+        ):
+            self.assertFalse(evaluate_platform_supports_bf16_matmul())
+
+    @patch("torch.testing._internal.common_cuda.SM53OrLater", False)
+    def test_bf16_matmul_supports_rocm_without_cuda_capability_query(self, *args):
+        with (
+            patch("torch.version.cuda", None),
+            patch("torch.version.hip", "6.4.0"),
+        ):
+            self.assertTrue(evaluate_platform_supports_bf16_matmul())
+
+    @patch("torch.testing._internal.common_cuda.SM53OrLater", False)
+    def test_bf16_matmul_requires_supported_accelerator(self, *args):
+        with (
+            patch("torch.version.cuda", None),
+            patch("torch.version.hip", None),
+        ):
+            self.assertFalse(evaluate_platform_supports_bf16_matmul())
 
 
 if __name__ == "__main__":

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -134,6 +134,14 @@ def evaluate_platform_supports_bf16():
     return False
 
 
+def evaluate_platform_supports_bf16_matmul():
+    if torch.version.cuda:
+        return SM53OrLater
+    elif torch.version.hip:
+        return True
+    return False
+
+
 def evaluate_platform_supports_bf16_atomics():
     if torch.version.cuda:
         return SM80OrLater
@@ -149,6 +157,7 @@ def evaluate_platform_supports_half_atomics():
 
 
 PLATFORM_SUPPORTS_BF16: bool = LazyVal(lambda: evaluate_platform_supports_bf16())
+PLATFORM_SUPPORTS_BF16_MATMUL: bool = LazyVal(lambda: evaluate_platform_supports_bf16_matmul())
 PLATFORM_SUPPORTS_BF16_ATOMICS: bool = LazyVal(lambda: evaluate_platform_supports_bf16_atomics())
 PLATFORM_SUPPORTS_HALF_ATOMICS: bool = LazyVal(lambda: evaluate_platform_supports_half_atomics())
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -33,7 +33,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION, PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-    SM53OrLater, SM80OrLater, SM89OrLater, with_tf32_off, TEST_CUDNN,
+    PLATFORM_SUPPORTS_BF16_MATMUL, SM80OrLater, SM89OrLater, with_tf32_off, TEST_CUDNN,
     _get_torch_cuda_version,
 )
 from torch.testing._internal.common_quantized import (
@@ -12698,7 +12698,7 @@ op_db: list[OpInfo] = [
            dtypes=all_types_and_complex_and(torch.bfloat16, torch.float16),
            dtypesIfCUDA=floating_and_complex_types_and(torch.float16,
                                                        *[torch.bfloat16]
-                                                       if SM53OrLater or TEST_WITH_ROCM else []),
+                                                       if PLATFORM_SUPPORTS_BF16_MATMUL else []),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
            # Runs very slowly on slow gradcheck - alternatively reduce input sizes
            gradcheck_fast_mode=True,
@@ -12729,7 +12729,7 @@ op_db: list[OpInfo] = [
            ],
            skips=(
                # NVIDIA only assures that bfloat16 is supported by bmm if SM >= 5.3
-               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not SM53OrLater),
+               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not PLATFORM_SUPPORTS_BF16_MATMUL),
                # addbmm does not correctly warn when resizing out= inputs
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning'),
                # https://github.com/pytorch/pytorch/issues/55907
@@ -12745,7 +12745,7 @@ op_db: list[OpInfo] = [
            dtypesIfCUDA=floating_types_and(torch.float16, torch.complex64, torch.complex128,
                                            torch.bfloat16),
            backward_dtypesIfCUDA=floating_types_and(torch.float16,
-                                                    *[torch.bfloat16] if SM53OrLater or TEST_WITH_ROCM else [],
+                                                    *[torch.bfloat16] if PLATFORM_SUPPORTS_BF16_MATMUL else [],
                                                     torch.complex64, torch.complex128),
            # Runs very slowly on slow gradcheck - alternatively reduce input sizes
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
@@ -12812,7 +12812,7 @@ op_db: list[OpInfo] = [
            dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16),
            dtypesIfCUDA=floating_and_complex_types_and(torch.float16,
                                                        *[torch.bfloat16]
-                                                       if SM53OrLater or TEST_WITH_ROCM else []),
+                                                       if PLATFORM_SUPPORTS_BF16_MATMUL else []),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
            assert_autodiffed=True,
            assert_jit_shape_analysis=True,
@@ -12820,7 +12820,7 @@ op_db: list[OpInfo] = [
            supports_fwgrad_bwgrad=True,
            skips=(
                # NVIDIA only assures that bfloat16 is supported by bmm if SM >= 5.3
-               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not SM53OrLater),
+               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not PLATFORM_SUPPORTS_BF16_MATMUL),
                DecorateInfo(toleranceOverride({torch.float32: tol(atol=1e-5, rtol=1e-5)}),
                             "TestCommon", "test_out"),
                # AssertionError: Tensor-likes are not close!
@@ -14811,7 +14811,7 @@ op_db: list[OpInfo] = [
            dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16),
            dtypesIfCUDA=floating_and_complex_types_and(torch.float16,
                                                        *[torch.bfloat16]
-                                                       if SM53OrLater or TEST_WITH_ROCM else []),
+                                                       if PLATFORM_SUPPORTS_BF16_MATMUL else []),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
            assert_autodiffed=True,
            assert_jit_shape_analysis=True,
@@ -14823,7 +14823,7 @@ op_db: list[OpInfo] = [
            sample_inputs_func=partial(sample_inputs_matmul, is_rmatmul=False),
            decorators=[
                # NVIDIA only assures that bfloat16 is supported by bmm if SM >= 5.3
-               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not SM53OrLater),
+               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not PLATFORM_SUPPORTS_BF16_MATMUL),
                # ROCm intermittently fails the test with standard atol/rtol
                DecorateInfo(toleranceOverride({torch.float32: tol(atol=1e-4, rtol=0)}),
                             'TestCommon', 'test_noncontiguous_samples', device_type='cuda',
@@ -17070,14 +17070,14 @@ op_db: list[OpInfo] = [
            sample_inputs_func=sample_inputs_bilinear,
            dtypes=all_types_and(torch.float16, torch.bfloat16),
            dtypesIfCUDA=floating_types_and(torch.float16,
-                                           *[torch.bfloat16] if SM53OrLater or TEST_WITH_ROCM else []),
+                                           *[torch.bfloat16] if PLATFORM_SUPPORTS_BF16_MATMUL else []),
            decorators=(
                DecorateInfo(toleranceOverride({torch.float16: tol(atol=2e-03, rtol=1.3e-03)}),
                             'TestInductorOpInfo', 'test_comprehensive', device_type='cpu'),
            ),
            skips=(
                # NVIDIA only assures that bfloat16 is supported by bmm if SM >= 5.3
-               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not SM53OrLater),
+               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not PLATFORM_SUPPORTS_BF16_MATMUL),
                DecorateInfo(unittest.skip("Skipped!"), 'TestNNCOpInfo', 'test_nnc_correctness', dtypes=(torch.bfloat16,)),
            ),
            # Runs very slowly on slow gradcheck - alternatively reduce input sizes
@@ -18645,7 +18645,7 @@ op_db: list[OpInfo] = [
            dtypes=all_types_and_complex_and(torch.bfloat16, torch.float16),
            dtypesIfCUDA=floating_and_complex_types_and(torch.float16,
                                                        *[torch.bfloat16]
-                                                       if SM53OrLater or TEST_WITH_ROCM else []),
+                                                       if PLATFORM_SUPPORTS_BF16_MATMUL else []),
            assert_autodiffed=True,
            sample_inputs_func=partial(sample_inputs_matmul, is_rmatmul=True),
            # Runs very slowly on slow gradcheck - alternatively reduce input sizes
@@ -18656,7 +18656,7 @@ op_db: list[OpInfo] = [
            check_batched_forward_grad=False,
            decorators=(
                # NVIDIA only assures that bfloat16 is supported by bmm if SM >= 5.3
-               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not SM53OrLater),
+               DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes', device_type='cuda', active_if=not PLATFORM_SUPPORTS_BF16_MATMUL),
                DecorateInfo(toleranceOverride({torch.complex64: tol(atol=1e-05, rtol=1.2e-03)}),
                             'TestMathBits', 'test_conj_view'),
                DecorateInfo(toleranceOverride({torch.float32: tol(atol=1e-05, rtol=1.2e-03)}),


### PR DESCRIPTION
Refs #175211

## Summary
This adds `PLATFORM_SUPPORTS_BF16_MATMUL` in `common_cuda.py` and uses it for the BF16 dtype and `test_dtypes` gating on the matmul-like OpInfo entries (`addbmm`, `baddbmm`, `bmm`, `matmul`, `nn.functional.bilinear`, and `__rmatmul__`).

The goal is just to replace the raw `SM53OrLater or TEST_WITH_ROCM` checks with a named feature query while keeping the current CUDA and ROCm behavior. I kept the sparse test cleanup in a separate follow-up PR to keep this review focused.

I didn't find an open PR covering this same `#175211` slice.

## Testing
- `python -m compileall test/test_cuda_compatibility.py torch/testing/_internal/common_cuda.py torch/testing/_internal/common_methods_invocations.py`
- local smoke check for `evaluate_platform_supports_bf16_matmul()` covering CUDA SM53+, CUDA pre-SM53, ROCm, and no accelerator

I couldn't run the full test target from this checkout because this tree is not built locally and the machine is missing `expecttest`.

AI assistance was used for code search and drafting. I reviewed the final diff and verification output before opening the PR.