### PR TITLE
Use PLATFORM_SUPPORTS_BF16 in sparse matmul BF16 gating

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -19,7 +19,7 @@ from numbers import Number
 from typing import Any
 from packaging import version
 from torch.testing._internal.common_cuda import \
-    (SM80OrLater, TEST_MULTIGPU)
+    (PLATFORM_SUPPORTS_BF16, SM80OrLater, TEST_MULTIGPU)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, ops, dtypes, dtypesIfCUDA, dtypesIfMPS, onlyCPU, onlyCUDA, precisionOverride,
      deviceCountAtLeast, OpDTypes, onlyNativeDeviceTypes, skipCUDAIf, expectedFailureMPS,
@@ -3855,7 +3855,7 @@ class TestSparse(TestSparseBase):
     @dtypes(*floating_and_complex_types())
     @dtypesIfMPS(*all_mps_types())
     @dtypesIfCUDA(*floating_types_and(*[torch.half] if not TEST_WITH_ROCM else [],
-                                      *[torch.bfloat16] if SM80OrLater and not TEST_WITH_ROCM else [],
+                                      *[torch.bfloat16] if PLATFORM_SUPPORTS_BF16 else [],
                                       torch.complex64,
                                       *[torch.complex128]
                                       if CUSPARSE_SPMM_COMPLEX128_SUPPORTED or HIPSPARSE_SPMM_COMPLEX128_SUPPORTED


### PR DESCRIPTION
Refs #175211

## Summary
This is the small follow-up cleanup for the sparse matmul BF16 dtype gate in `test_sparse.py`. It switches the inline `SM80OrLater and not TEST_WITH_ROCM` check to the existing `PLATFORM_SUPPORTS_BF16` helper and leaves the separate large-tensor `SM80OrLater` guard alone.

I kept this split from the OpInfo helper change so the review stays narrow.

I didn't find an open PR covering this same sparse BF16 #175211 slice.

## Testing
- `python -m compileall test/test_sparse.py`

I couldn't run the full sparse test target from this checkout because this tree is not built locally and the machine is missing `expecttest`.

AI assistance was used for code search and drafting. I reviewed the final diff and verification output before opening the PR.