### PR TITLE
Split onehot checks for CPU and accelerators

### DIFF
--- a/aten/src/ATen/native/Onehot.cpp
+++ b/aten/src/ATen/native/Onehot.cpp
@@ -48,16 +48,14 @@ Tensor one_hot(const Tensor &self, int64_t num_classes) {
     }
 
     // non-empty tensor
-    if (self.device().type() != at::kCUDA && self.device().type() != at::kMPS &&
-        self.device().type() != at::kPrivateUse1 && self.device().type() != at::kXLA) {
+    if (self.device().is_cpu()) {
       // for cuda, rely on device assert thrown by scatter
       TORCH_CHECK(self.min().item().toLong() >= 0, "Class values must be non-negative.");
     }
     if (num_classes == -1) {
         num_classes = self.max().item().toLong() + 1;
     } else {
-        if (self.device().type() != at::kCUDA && self.device().type() != at::kMPS &&
-            self.device().type() != at::kPrivateUse1 && self.device().type() != at::kXLA) {
+        if (self.device().is_cpu()) {
           // rely on device asserts from scatter to avoid sync here
           TORCH_CHECK(num_classes > self.max().item().toLong(), "Class values must be smaller than num_classes.");
         } else {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10089,11 +10089,7 @@ class TestNNDeviceType(NNTestCase):
     def test_one_hot(self, device):
         # cuda throws device assert for invalid data
         # xla & mps ignore out of bound indices
-        if (
-            self.device_type != 'cuda'
-            and self.device_type != 'xla'
-            and self.device_type != 'mps'
-        ):
+        if self.device_type == 'cpu':
             with self.assertRaises(RuntimeError):
                 torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)
 


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/3284

Currently OneHot has boundary checks for CPU and these checks are skipped for `CUDA`, `MPS`, `XLA` and `PrivateUser1`. As `XPU` is not included on the list it causes D2H calls that affect performance.

Instead of adding `XPU` to the list I think it's better to flip the condition to check boundaries only for `CPU` and allow accelerators to skip this validation.