### PR TITLE
Use AVX2/VSX for bfloat16 and half in randn kernel

### DIFF
--- a/aten/src/ATen/native/cpu/DistributionTemplates.h
+++ b/aten/src/ATen/native/cpu/DistributionTemplates.h
@@ -85,134 +85,94 @@ struct RandomKernel {
 
 // ==================================================== Normal ========================================================
 
-#ifdef CPU_CAPABILITY_AVX2
-void normal_fill_16_AVX2(float *data,
-                         const __m256* two_pi,
-                         const __m256* one,
-                         const __m256* minus_two,
-                         const __m256* mean,
-                         const __m256* std_v) {
-  const __m256 u1 = _mm256_sub_ps(*one, _mm256_loadu_ps(data));
-  const __m256 u2 = _mm256_loadu_ps(data + 8);
-  // sincos256_ps and log256_ps are from avx_mathfun.h
-  const __m256 radius = _mm256_sqrt_ps(_mm256_mul_ps(*minus_two, log256_ps(u1)));
-  const __m256 theta = _mm256_mul_ps(*two_pi, u2);
-  __m256 sintheta, costheta;
-  sincos256_ps(theta, &sintheta, &costheta);
-  const __m256 n1 = _mm256_mul_ps(radius, costheta);
-  const __m256 n2 = _mm256_mul_ps(radius, sintheta);
-  _mm256_storeu_ps(data, _mm256_fmadd_ps(n1, *std_v, *mean));
-  _mm256_storeu_ps(data + 8, _mm256_fmadd_ps(n2, *std_v, *mean));
-}
+// Box-Muller transform on 16 elements (8 pairs of uniforms).
+// Primary template is scalar; float specialization uses SIMD when available.
+// Constructed once with mean/std so constants are not rebuilt per call.
+template <typename opmath_t, bool enable = true>
+struct NormalFill16 {
+  opmath_t mean_;
+  opmath_t std_;
 
-template<typename RNG>
-void normal_fill_AVX2(const TensorBase &self, const float mean, const float std, RNG generator) {
-  float *data = self.data_ptr<float>();
-  auto size = self.numel();
-  std::lock_guard<std::mutex> lock(generator->mutex_);
-  for (const auto i : c10::irange(size)) {
-    at::uniform_real_distribution<float> uniform(0, 1);
-    data[i] = uniform(generator);
-  }
-  const __m256 two_pi = _mm256_set1_ps(2.0f * c10::pi<double>);
-  const __m256 one = _mm256_set1_ps(1.0f);
-  const __m256 minus_two = _mm256_set1_ps(-2.0f);
-  const __m256 mean_v = _mm256_set1_ps(mean);
-  const __m256 std_v = _mm256_set1_ps(std);
+  NormalFill16(opmath_t mean, opmath_t std)
+    : mean_(mean), std_(std) {}
 
-  for (int64_t i = 0; i < size - 15; i += 16) {
-    normal_fill_16_AVX2(data + i, &two_pi, &one, &minus_two, &mean_v, &std_v);
-  }
-
-  if (size % 16 != 0) {
-    // Recompute the last 16 values.
-    data = data + size - 16;
-    for (const auto i : c10::irange(16)) {
-      at::uniform_real_distribution<float> uniform(0, 1);
-      data[i] = uniform(generator);
+  void operator()(opmath_t* data) const {
+    for (const auto j : c10::irange(8)) {
+      const opmath_t u1 = 1 - data[j]; // [0, 1) -> (0, 1] for log.
+      const opmath_t u2 = data[j + 8];
+      const opmath_t radius = std::sqrt(-2 * std::log(u1));
+      const opmath_t theta = 2.0f * c10::pi<double> * u2;
+      data[j] = radius * std::cos(theta) * std_ + mean_;
+      data[j + 8] = radius * std::sin(theta) * std_ + mean_;
     }
-    normal_fill_16_AVX2(data, &two_pi, &one, &minus_two, &mean_v, &std_v);
   }
-}
+};
+
+#if defined(CPU_CAPABILITY_AVX2)
+
+template <>
+struct NormalFill16<float, true> {
+  __m256 mean_;
+  __m256 std_;
+  __m256 two_pi_ = _mm256_set1_ps(2.0f * c10::pi<double>);
+  __m256 one_ = _mm256_set1_ps(1.0f);
+  __m256 minus_two_ = _mm256_set1_ps(-2.0f);
+
+  NormalFill16(float mean, float std)
+    : mean_(_mm256_set1_ps(mean)), std_(_mm256_set1_ps(std)) {}
+
+  void operator()(float* data) const {
+    const __m256 u1 = _mm256_sub_ps(one_, _mm256_loadu_ps(data));
+    const __m256 u2 = _mm256_loadu_ps(data + 8);
+    // sincos256_ps and log256_ps are from avx_mathfun.h
+    const __m256 radius = _mm256_sqrt_ps(_mm256_mul_ps(minus_two_, log256_ps(u1)));
+    const __m256 theta = _mm256_mul_ps(two_pi_, u2);
+    __m256 sintheta, costheta;
+    sincos256_ps(theta, &sintheta, &costheta);
+    const __m256 n1 = _mm256_mul_ps(radius, costheta);
+    const __m256 n2 = _mm256_mul_ps(radius, sintheta);
+    _mm256_storeu_ps(data, _mm256_fmadd_ps(n1, std_, mean_));
+    _mm256_storeu_ps(data + 8, _mm256_fmadd_ps(n2, std_, mean_));
+  }
+};
+
+#elif defined(__VSX__) || defined(CPU_CAPABILITY_VSX)
+
+template <>
+struct NormalFill16<float, Vectorized<float>::size() == 8> {
+  using Vec = Vectorized<float>;
+  Vec mean_;
+  Vec std_;
+  Vec two_pi_ = Vec(2.0f * c10::pi<double>);
+  Vec one_ = Vec(1.0f);
+  Vec minus_two_ = Vec(-2.0f);
+
+  NormalFill16(float mean, float std)
+    : mean_(mean), std_(std) {}
+
+  void operator()(float* data) const {
+    Vec u1 = one_ - Vec::loadu(data);
+    Vec u2 = Vec::loadu(data + 8);
+    Vec radius = (minus_two_ * u1.log()).sqrt();
+    Vec theta = two_pi_ * u2;
+    Vec output1 = radius * theta.cos() * std_ + mean_;
+    Vec output2 = radius * theta.sin() * std_ + mean_;
+    output1.store(data);
+    output2.store(data + 8);
+  }
+};
+
 #endif
 
-template <typename scalar_t>
-void normal_fill_16(scalar_t *data, const scalar_t mean, const scalar_t std) {
-  for (const auto j : c10::irange(8)) {
-    const scalar_t u1 = 1 - data[j]; // [0, 1) -> (0, 1] for log.
-    const scalar_t u2 = data[j + 8];
-    const scalar_t radius = std::sqrt(-2 * std::log(u1));
-    const scalar_t theta = 2.0f * c10::pi<double> * u2;
-    data[j] = radius * std::cos(theta) * std + mean;
-    data[j + 8] = radius * std::sin(theta) * std + mean;
-  }
-}
-
-#if defined(__VSX__)  || defined(CPU_CAPABILITY_VSX)
-static void normal_fill_16_VSX(float *data,const Vectorized<float> &two_pi,const Vectorized<float> &one,const Vectorized<float> &minus_two,const Vectorized<float> &mean,const Vectorized<float> &std) {
-  using Vec = Vectorized<float>;
-  Vec u1=one-Vec::loadu(data);
-  Vec u2=Vec::loadu(data+8);
-  Vec radius=(minus_two * u1.log());
-  radius=radius.sqrt();
-  Vec theta=two_pi * u2;
-  Vec output_vec=radius * theta.cos() * std + mean;
-  Vec output_vec2=radius * theta.sin() * std + mean;
-  output_vec.store(data);
-  output_vec2.store(data+8);
-}
-
 template <typename scalar_t, typename RNG>
-void normal_fill_VSX(const TensorBase &self, const scalar_t mean, const scalar_t std, RNG generator) {
-  float *data = self.data_ptr<float>();
-  auto size = self.numel();
-  std::lock_guard<std::mutex> lock(generator->mutex_);
-  for (const auto i : c10::irange(size)) {
-    at::uniform_real_distribution<scalar_t> uniform(0, 1);
-    data[i] = uniform(generator);
-  }
-
-  using Vec = Vectorized<float>;
-  const Vec two_pi = Vec(2.0f * c10::pi<double>);
-  const Vec one = Vec(1.0f);
-  const Vec minus_two = Vec(-2.0f);
-  const Vec var_vec  = Vec(std);
-  const Vec mean_vec = Vec(mean);
-
-  for (int64_t i = 0; i < size - 15; i += 16) {
-    if(Vec::size()==8) {
-      normal_fill_16_VSX(data + i, two_pi, one, minus_two, mean_vec, var_vec);
-    }
-    else{
-      normal_fill_16<scalar_t>(data + i, mean, std);
-    }
-  }
-  if (size % 16 != 0) {
-    // Recompute the last 16 values.
-    data = data + size - 16;
-    for (const auto i : c10::irange(16)) {
-      at::uniform_real_distribution<scalar_t> uniform(0, 1);
-      data[i] = uniform(generator);
-    }
-    if(Vec::size()==8){
-      normal_fill_16_VSX(data, two_pi, one, minus_two, mean_vec, var_vec);
-    }
-    else{
-      normal_fill_16<scalar_t>(data, mean, std);
-    }
-  }
-}
-#endif //VSX
-
-template <typename scalar_t, typename RNG>
-void normal_fill(const TensorBase &self, const scalar_t mean, const scalar_t std, RNG generator) {
+void normal_fill(const TensorBase &self, double mean, double std, RNG generator) {
   using opmath_t = at::opmath_type<scalar_t>;
   scalar_t *data = self.data_ptr<scalar_t>();
   auto size = self.numel();
   std::lock_guard<std::mutex> lock(generator->mutex_);
-  auto omean = static_cast<opmath_t>(mean);
-  auto ostd = static_cast<opmath_t>(std);
   at::uniform_real_distribution<opmath_t> uniform(0, 1);
+  NormalFill16<opmath_t> normal_fill_16(
+      static_cast<opmath_t>(mean), static_cast<opmath_t>(std));
 
   if constexpr (std::is_same_v<scalar_t, opmath_t>) {
     // float/double: generate uniform samples directly into the output buffer,
@@ -221,35 +181,37 @@ void normal_fill(const TensorBase &self, const scalar_t mean, const scalar_t std
       data[i] = uniform(generator);
     }
     for (int64_t i = 0; i < size - 15; i += 16) {
-      normal_fill_16<scalar_t>(data + i, omean, ostd);
+      normal_fill_16(data + i);
     }
+    // Recompute the last 16 values.
     if (size % 16 != 0) {
       data = data + size - 16;
       for (const auto i : c10::irange(16)) {
         data[i] = uniform(generator);
       }
-      normal_fill_16<scalar_t>(data, omean, ostd);
+      normal_fill_16(data);
     }
   } else {
     // bf16/fp16: generate in opmath_t precision using a stack buffer,
     // apply Box-Muller, then cast down to scalar_t.
     opmath_t buf[16];
     for (int64_t i = 0; i < size - 15; i += 16) {
-      for (int j = 0; j < 16; j++) {
+      for (const auto j : c10::irange(16)) {
         buf[j] = uniform(generator);
       }
-      normal_fill_16<opmath_t>(buf, omean, ostd);
-      for (int j = 0; j < 16; j++) {
+      normal_fill_16(buf);
+      for (const auto j : c10::irange(16)) {
         data[i + j] = static_cast<scalar_t>(buf[j]);
       }
     }
+    // Recompute the last 16 values.
     if (size % 16 != 0) {
       int64_t offset = size - 16;
-      for (int j = 0; j < 16; j++) {
+      for (const auto j : c10::irange(16)) {
         buf[j] = uniform(generator);
       }
-      normal_fill_16<opmath_t>(buf, omean, ostd);
-      for (int j = 0; j < 16; j++) {
+      normal_fill_16(buf);
+      for (const auto j : c10::irange(16)) {
         data[offset + j] = static_cast<scalar_t>(buf[j]);
       }
     }
@@ -259,28 +221,18 @@ void normal_fill(const TensorBase &self, const scalar_t mean, const scalar_t std
 template<typename RNG>
 void normal_kernel(const TensorBase &self, double mean, double std, RNG generator) {
   auto size = self.numel();
-  if (self.scalar_type() == ScalarType::Float && size >= 16 && self.is_contiguous()) {
-#ifdef CPU_CAPABILITY_AVX2
-    normal_fill_AVX2(self, static_cast<float>(mean), static_cast<float>(std), generator);
-#elif defined(__VSX__)  || defined(CPU_CAPABILITY_VSX)
-    normal_fill_VSX(self, static_cast<float>(mean), static_cast<float>(std), generator);
-#else
-    normal_fill(self, static_cast<float>(mean), static_cast<float>(std), generator);
-#endif
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, self.scalar_type(), "normal_kernel_cpu", [&] {
-      if (size >= 16 && self.is_contiguous()) {
-        normal_fill<scalar_t>(self, static_cast<scalar_t>(mean), static_cast<scalar_t>(std), generator);
-      } else {
-        auto iter = TensorIterator::borrowing_nullary_op(self);
-        std::lock_guard<std::mutex> lock(generator->mutex_);
-        cpu_serial_kernel(iter, [mean, std, generator]() -> scalar_t {
-          at::normal_distribution<double> normal(mean, std);
-          return static_cast<scalar_t>(normal(generator));
-        });
-      }
-    });
-  }
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, self.scalar_type(), "normal_kernel_cpu", [&] {
+    if (size >= 16 && self.is_contiguous()) {
+      normal_fill<scalar_t>(self, mean, std, generator);
+    } else {
+      auto iter = TensorIterator::borrowing_nullary_op(self);
+      std::lock_guard<std::mutex> lock(generator->mutex_);
+      cpu_serial_kernel(iter, [mean, std, generator]() -> scalar_t {
+        at::normal_distribution<double> normal(mean, std);
+        return static_cast<scalar_t>(normal(generator));
+      });
+    }
+  });
 }
 
 template<typename RNG>

--- a/aten/src/ATen/native/cpu/DistributionTemplates.h
+++ b/aten/src/ATen/native/cpu/DistributionTemplates.h
@@ -102,8 +102,8 @@ struct NormalFill16 {
       const opmath_t u2 = data[j + 8];
       const opmath_t radius = std::sqrt(-2 * std::log(u1));
       const opmath_t theta = 2.0f * c10::pi<double> * u2;
-      data[j] = radius * std::cos(theta) * std_ + mean_;
-      data[j + 8] = radius * std::sin(theta) * std_ + mean_;
+      data[j] = std::fma(radius * std::cos(theta), std_, mean_);
+      data[j + 8] = std::fma(radius * std::sin(theta), std_, mean_);
     }
   }
 };


### PR DESCRIPTION
The old implementation did not use AVX2/VSX instructions for
bf16, fp16 even though the intermediate computation was done
in float32. This commit fixes this divergence in logic.

This shows a ~2x improvement in randn for bfloat16 on x86_64.

Resolves #173173

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01