### PR TITLE
[dynamo] Make torch.compile transparent to FX symbolic tracing

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7850,33 +7850,39 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             dynamo_result = graph(x)
             self.assertTrue(same(real, dynamo_result))
 
-    def test_error_on_nested_fx_trace(self):
+    def test_fx_trace_through_compiled_function(self):
+        # torch.compile-wrapped functions should be transparent to FX
+        # symbolic tracing — the tracer sees the original function.
         input = torch.rand(2, 3)
 
         def f(x):
-            x + x
+            return x + x
 
         real = f(input)
 
         optimized = torch.compile(f, backend="eager")
         self.assertTrue(same(optimized(input), real))
 
-        with self.assertRaisesRegex(RuntimeError, "Detected that you are using FX"):
-            gm = torch.fx.symbolic_trace(optimized)
+        # FX tracing should succeed and produce correct results
+        gm = torch.fx.symbolic_trace(optimized)
+        self.assertTrue(same(gm(input), real))
 
-    @patch.object(torch._dynamo.config, "error_on_nested_fx_trace", False)
-    def test_no_error_on_nested_fx_trace(self):
+    def test_fx_trace_through_compiled_module(self):
+        # torch.compile-wrapped nn.Modules should be unwrapped during
+        # FX symbolic tracing so the tracer sees the original module.
         input = torch.rand(2, 3)
 
-        def f(x):
-            x + x
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x + x
 
-        real = f(input)
+        mod = M()
+        real = mod(input)
 
-        optimized = torch.compile(f, backend="eager")
+        optimized = torch.compile(mod, backend="eager")
         self.assertTrue(same(optimized(input), real))
 
-        # should not error
+        # FX tracing should see through the OptimizedModule
         gm = torch.fx.symbolic_trace(optimized)
         self.assertTrue(same(gm(input), real))
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7940,9 +7940,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         self.assertTrue(same(gm(input), mod(input)))
 
         # The graph has inlined ops from Inner.forward, no call_module
-        call_module_nodes = [
-            n for n in gm.graph.nodes if n.op == "call_module"
-        ]
+        call_module_nodes = [n for n in gm.graph.nodes if n.op == "call_module"]
         self.assertEqual(len(call_module_nodes), 0)
 
     # ===== skip_compiled_module_during_fx_trace=True =====
@@ -7986,9 +7984,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         gm = torch.fx.symbolic_trace(mod)
 
         # The graph should have a call_module node for inner
-        call_module_nodes = [
-            n for n in gm.graph.nodes if n.op == "call_module"
-        ]
+        call_module_nodes = [n for n in gm.graph.nodes if n.op == "call_module"]
         self.assertEqual(len(call_module_nodes), 1)
         self.assertEqual(call_module_nodes[0].target, "inner")
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7850,7 +7850,11 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             dynamo_result = graph(x)
             self.assertTrue(same(real, dynamo_result))
 
+    # ===== error_on_nested_fx_trace=True (default) =====
+    # FX tracing into torch.compile-wrapped code errors by default.
+
     def test_error_on_nested_fx_trace(self):
+        # Function wrapped with torch.compile: errors during FX trace.
         input = torch.rand(2, 3)
 
         def f(x):
@@ -7864,10 +7868,40 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         with self.assertRaisesRegex(RuntimeError, "Detected that you are using FX"):
             gm = torch.fx.symbolic_trace(optimized)
 
+    def test_error_on_nested_fx_trace_module(self):
+        # Module wrapped with torch.compile: errors during FX trace.
+        class Inner(torch.nn.Module):
+            def forward(self, x):
+                return x + x
+
+        class Outer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.inner = torch.compile(Inner(), backend="eager")
+
+            def forward(self, x):
+                return self.inner(x) + 1
+
+        mod = Outer()
+        with self.assertRaisesRegex(RuntimeError, "Detected that you are using FX"):
+            torch.fx.symbolic_trace(mod)
+
+    # ===== error_on_nested_fx_trace=False =====
+    # FX tracing falls back to eager: dynamo is skipped and the original
+    # function runs with Proxy args. This means the compiled region runs
+    # UNCOMPILED during the FX trace AND in the resulting graph — the
+    # compile wrapper is bypassed and the graph inlines the original ops.
+    #
+    # WARNING: this causes a performance regression if the resulting graph
+    # is used on the hot path, because the compiled region loses its
+    # torch.compile optimization. Only use this when the FX trace is a
+    # one-time setup step (e.g., torchrec pipeline init) and the compiled
+    # module will be re-wrapped after tracing.
+
     @patch.object(torch._dynamo.config, "error_on_nested_fx_trace", False)
     def test_fx_trace_through_compiled_function(self):
-        # With error_on_nested_fx_trace=False, torch.compile-wrapped
-        # functions are transparent to FX symbolic tracing.
+        # Function case: FX traces through the original function eagerly.
+        # The graph contains the inlined ops, NOT a compiled call.
         input = torch.rand(2, 3)
 
         def f(x):
@@ -7878,9 +7912,91 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         optimized = torch.compile(f, backend="eager")
         self.assertTrue(same(optimized(input), real))
 
-        # FX tracing should succeed and produce correct results
         gm = torch.fx.symbolic_trace(optimized)
         self.assertTrue(same(gm(input), real))
+
+    @patch.object(torch._dynamo.config, "error_on_nested_fx_trace", False)
+    def test_fx_trace_through_compiled_module_eager(self):
+        # Module case without skip_compiled_module_during_fx_trace:
+        # FX traces into the module eagerly, inlining the ops.
+        # The compiled module's ops appear as individual nodes in the graph.
+        # This LOSES compilation — the module runs uncompiled.
+        class Inner(torch.nn.Module):
+            def forward(self, x):
+                return x + x
+
+        class Outer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.inner = torch.compile(Inner(), backend="eager")
+
+            def forward(self, x):
+                return self.inner(x) + 1
+
+        mod = Outer()
+        input = torch.rand(2, 3)
+
+        gm = torch.fx.symbolic_trace(mod)
+        self.assertTrue(same(gm(input), mod(input)))
+
+        # The graph has inlined ops from Inner.forward, no call_module
+        call_module_nodes = [
+            n for n in gm.graph.nodes if n.op == "call_module"
+        ]
+        self.assertEqual(len(call_module_nodes), 0)
+
+    # ===== skip_compiled_module_during_fx_trace=True =====
+    # Compiled modules are treated as leaf nodes during FX tracing.
+    # The tracer does NOT enter them — they appear as a single call_module
+    # node. The module KEEPS its torch.compile wrapper, so it runs compiled
+    # when the graph executes. No performance regression.
+    #
+    # Requires error_on_nested_fx_trace=False (so compile_wrapper on methods
+    # inside the model can still fall back to eager).
+    #
+    # Use this when FX tracing a model that has torch.compile-wrapped child
+    # modules and you want to preserve their compilation.
+
+    @torch._dynamo.config.patch(
+        error_on_nested_fx_trace=False,
+        skip_compiled_module_during_fx_trace=True,
+    )
+    def test_fx_trace_compiled_module_is_leaf(self):
+        # Module case with skip_compiled_module_during_fx_trace=True:
+        # The compiled module is a leaf — single call_module node.
+        # Compilation is preserved.
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        class Inner(torch.nn.Module):
+            def forward(self, x):
+                return x + x
+
+        class Outer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.inner = torch.compile(Inner(), backend=cnts)
+
+            def forward(self, x):
+                return self.inner(x) + 1
+
+        mod = Outer()
+        input = torch.rand(2, 3)
+
+        # FX tracing should succeed with the compiled inner module as a leaf
+        gm = torch.fx.symbolic_trace(mod)
+
+        # The graph should have a call_module node for inner
+        call_module_nodes = [
+            n for n in gm.graph.nodes if n.op == "call_module"
+        ]
+        self.assertEqual(len(call_module_nodes), 1)
+        self.assertEqual(call_module_nodes[0].target, "inner")
+
+        # Running the traced graph should still compile the inner module
+        result = gm(input)
+        expected = mod(input)
+        self.assertTrue(same(result, expected))
+        self.assertEqual(cnts.frame_count, 1)
 
     def test_not_dynamic_scope(self):
         def f(y):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -7850,9 +7850,24 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             dynamo_result = graph(x)
             self.assertTrue(same(real, dynamo_result))
 
+    def test_error_on_nested_fx_trace(self):
+        input = torch.rand(2, 3)
+
+        def f(x):
+            x + x
+
+        real = f(input)
+
+        optimized = torch.compile(f, backend="eager")
+        self.assertTrue(same(optimized(input), real))
+
+        with self.assertRaisesRegex(RuntimeError, "Detected that you are using FX"):
+            gm = torch.fx.symbolic_trace(optimized)
+
+    @patch.object(torch._dynamo.config, "error_on_nested_fx_trace", False)
     def test_fx_trace_through_compiled_function(self):
-        # torch.compile-wrapped functions should be transparent to FX
-        # symbolic tracing — the tracer sees the original function.
+        # With error_on_nested_fx_trace=False, torch.compile-wrapped
+        # functions are transparent to FX symbolic tracing.
         input = torch.rand(2, 3)
 
         def f(x):
@@ -7864,25 +7879,6 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         self.assertTrue(same(optimized(input), real))
 
         # FX tracing should succeed and produce correct results
-        gm = torch.fx.symbolic_trace(optimized)
-        self.assertTrue(same(gm(input), real))
-
-    def test_fx_trace_through_compiled_module(self):
-        # torch.compile-wrapped nn.Modules should be unwrapped during
-        # FX symbolic tracing so the tracer sees the original module.
-        input = torch.rand(2, 3)
-
-        class M(torch.nn.Module):
-            def forward(self, x):
-                return x + x
-
-        mod = M()
-        real = mod(input)
-
-        optimized = torch.compile(mod, backend="eager")
-        self.assertTrue(same(optimized(input), real))
-
-        # FX tracing should see through the OptimizedModule
         gm = torch.fx.symbolic_trace(optimized)
         self.assertTrue(same(gm(input), real))
 

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -502,10 +502,19 @@ error_on_nested_jit_trace = True
 
 # If true (default), error if we symbolically trace over a dynamo-optimized
 # function. If false, dynamo is skipped and the original function runs eagerly,
-# allowing FX tracing to see through torch.compile wrappers.
+# allowing FX tracing to see through torch.compile wrappers. WARNING: the
+# compiled region runs uncompiled in the resulting graph, which may cause a
+# performance regression.
 # Use config.patch(error_on_nested_fx_trace=False) as a context manager to
 # scope this to a specific FX trace call.
 error_on_nested_fx_trace = True
+
+# If true, torch.compile-wrapped modules are treated as leaf modules during
+# FX symbolic tracing — the tracer won't enter them, preserving compilation.
+# Unlike error_on_nested_fx_trace=False alone, this keeps the module compiled
+# in the resulting graph, avoiding performance regression.
+# Requires error_on_nested_fx_trace=False.
+skip_compiled_module_during_fx_trace = False
 
 # If true, force dynamo compilation even when inside FX symbolic tracing.
 # This allows nested compilation where the outer tracer (e.g., make_fx) can

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -500,8 +500,8 @@ raise_on_unsafe_aot_autograd = False
 # This flag is ignored and maintained for backwards compatibility.
 error_on_nested_jit_trace = True
 
-# If true, error with a better message if we symbolically trace over a
-# dynamo-optimized function. If false, silently suppress dynamo.
+# This flag is ignored. torch.compile-wrapped functions are now
+# automatically transparent to FX symbolic tracing.
 error_on_nested_fx_trace = True
 
 # If true, force dynamo compilation even when inside FX symbolic tracing.

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -500,8 +500,11 @@ raise_on_unsafe_aot_autograd = False
 # This flag is ignored and maintained for backwards compatibility.
 error_on_nested_jit_trace = True
 
-# This flag is ignored. torch.compile-wrapped functions are now
-# automatically transparent to FX symbolic tracing.
+# If true (default), error if we symbolically trace over a dynamo-optimized
+# function. If false, dynamo is skipped and the original function runs eagerly,
+# allowing FX tracing to see through torch.compile wrappers.
+# Use config.patch(error_on_nested_fx_trace=False) as a context manager to
+# scope this to a specific FX trace call.
 error_on_nested_fx_trace = True
 
 # If true, force dynamo compilation even when inside FX symbolic tracing.

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -996,18 +996,15 @@ class _TorchDynamoContext:
                     if not _in_hop_compile():
                         if torch._guards.TracingContext.try_get() is not None:
                             return fn(*args, **kwargs)
-                # Skip nested compile - just inline the function
+                # Skip nested compile - just inline the function.
+                # FX symbolic tracing passes Proxy objects, not real tensors,
+                # so dynamo cannot compile. Unwrap transparently so the
+                # tracer sees the original function.
                 if (
                     is_fx_symbolic_tracing()
                     and not config.force_compile_during_fx_trace
                 ):
-                    if config.error_on_nested_fx_trace:
-                        raise RuntimeError(
-                            "Detected that you are using FX to symbolically trace "
-                            "a dynamo-optimized function. This is not supported at the moment."
-                        )
-                    else:
-                        return fn(*args, **kwargs)
+                    return fn(*args, **kwargs)
 
                 if is_jit_tracing():
                     raise RuntimeError(

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1004,6 +1004,11 @@ class _TorchDynamoContext:
                     is_fx_symbolic_tracing()
                     and not config.force_compile_during_fx_trace
                 ):
+                    if config.error_on_nested_fx_trace:
+                        raise RuntimeError(
+                            "Detected that you are using FX to symbolically trace "
+                            "a dynamo-optimized function. This is not supported at the moment."
+                        )
                     return fn(*args, **kwargs)
 
                 if is_jit_tracing():

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -780,11 +780,6 @@ class Tracer(TracerBase):
         old_is_fx_tracing_flag = _is_fx_tracing_flag
         _is_fx_tracing_flag = True
         try:
-            # Unwrap OptimizedModule (torch.compile wrapper) so we trace
-            # the original module.
-            if hasattr(root, "_orig_mod"):
-                root = root._orig_mod
-
             if isinstance(root, torch.nn.Module):
                 # do real recompilation for _LazyGraphModule before retracing since the trace
                 # method can not trace the _lazy_forward method. Got error:
@@ -858,11 +853,6 @@ class Tracer(TracerBase):
 
             @functools.wraps(_orig_module_call)
             def module_call_wrapper(mod, *args, **kwargs):
-                # Unwrap OptimizedModule (torch.compile wrapper) so the
-                # tracer sees the original module instead of the compiled one.
-                if hasattr(mod, "_orig_mod"):
-                    mod = mod._orig_mod
-
                 def forward(*args, **kwargs):
                     return _orig_module_call(mod, *args, **kwargs)
 

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -780,6 +780,11 @@ class Tracer(TracerBase):
         old_is_fx_tracing_flag = _is_fx_tracing_flag
         _is_fx_tracing_flag = True
         try:
+            # Unwrap OptimizedModule (torch.compile wrapper) so we trace
+            # the original module.
+            if hasattr(root, "_orig_mod"):
+                root = root._orig_mod
+
             if isinstance(root, torch.nn.Module):
                 # do real recompilation for _LazyGraphModule before retracing since the trace
                 # method can not trace the _lazy_forward method. Got error:
@@ -853,6 +858,11 @@ class Tracer(TracerBase):
 
             @functools.wraps(_orig_module_call)
             def module_call_wrapper(mod, *args, **kwargs):
+                # Unwrap OptimizedModule (torch.compile wrapper) so the
+                # tracer sees the original module instead of the compiled one.
+                if hasattr(mod, "_orig_mod"):
+                    mod = mod._orig_mod
+
                 def forward(*args, **kwargs):
                     return _orig_module_call(mod, *args, **kwargs)
 

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -487,6 +487,13 @@ class Tracer(TracerBase):
                 submodule ``bar``, which contains submodule ``baz``, that module will
                 appear with the qualified name ``foo.bar.baz`` here.
         """
+        # When enabled, treat torch.compile-wrapped modules as leaves
+        # so FX does not enter the compiled region.
+        if hasattr(m, "_torchdynamo_orig_callable"):
+            import torch._dynamo.config as dynamo_config
+
+            if dynamo_config.skip_compiled_module_during_fx_trace:
+                return True
         return (
             m.__module__.startswith("torch.nn")
             or m.__module__.startswith("torch.ao.nn")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179836


## Summary

Adds a new config `skip_compiled_module_during_fx_trace` that treats `torch.compile`-wrapped modules as leaf modules during FX symbolic tracing. This preserves compilation while allowing FX tracing to succeed.

Also adds comprehensive tests and documentation for the existing `error_on_nested_fx_trace` config, which previously had no test coverage for the `False` path.

### The problem

When FX symbolic tracing (`torch.fx.symbolic_trace`) encounters a `torch.compile`-wrapped function or module, dynamo's `compile_wrapper` detects FX tracing and raises:

```
RuntimeError: Detected that you are using FX to symbolically trace
a dynamo-optimized function. This is not supported at the moment.
```

This affects torchrec's `_rewrite_model`, which FX-traces models to build a
pipeline graph for sparse data distribution. When a model has PT2-compiled
submodules, this one-time setup step crashes (S645492).

### The configs

| Config | Default | Behavior |
|---|---|---|
| `error_on_nested_fx_trace=True` | **default** | Error — FX tracing into compiled code raises RuntimeError |
| `error_on_nested_fx_trace=False` | | Eager fallback — dynamo is skipped, original function runs with Proxy args. FX traces through the compiled region's internals. |
| `skip_compiled_module_during_fx_trace=True` | | **New.** Compiled modules become leaf nodes — FX emits a single `call_module` node without entering them. Compilation is preserved. Requires `error_on_nested_fx_trace=False`. |

### Why the eager fallback doesn't cause perf regression

The FX trace is a **one-time setup step** (e.g., torchrec's pipeline init), not
the training hot path. The `compile_wrapper` checks `is_fx_symbolic_tracing()`
at call time:

- **During FX trace**: `is_fx_symbolic_tracing()=True` → falls back to eager
- **During training**: `is_fx_symbolic_tracing()=False` → dynamo compiles normally

The `compile_wrapper` is still installed on the method/module. Training is
fully compiled.

### Recommended usage

The config should be scoped to the FX trace call using `config.patch`, **not**
set globally in the model config. Setting it globally (e.g., via
`DynamoConfigOverride` in `model_config.py`) is wrong — it disables the error
for the entire training run, silently masking any accidental FX+compile
interactions:

```python
# GOOD: scoped to the FX trace call
with torch._dynamo.config.patch(
    error_on_nested_fx_trace=False,
    skip_compiled_module_during_fx_trace=True,
):
    graph = tracer.trace(model, concrete_args=concrete_args)

# BAD: global override in model config
PT2Config(
    dynamo_config_override=DynamoConfigOverride(error_on_nested_fx_trace=False),
)
```

The ideal fix is in torchrec's `_rewrite_model` (`torchrec/distributed/
train_pipeline/utils.py`), wrapping the `tracer.trace()` call. This fixes it
for all models, not just one model config.

## Changes

- `torch/_dynamo/config.py`: New `skip_compiled_module_during_fx_trace` config,
  updated comments with perf warning on `error_on_nested_fx_trace`
- `torch/fx/_symbolic_trace.py`: `is_leaf_module` returns `True` for
  `OptimizedModule` when `skip_compiled_module_during_fx_trace=True`
- `test/dynamo/test_misc.py`: Five tests covering all config combinations:
  - `True` (default): error on function, error on module
  - `False`: eager fallback for function, eager fallback for module (inlines ops, no call_module)
  - `False` + `skip_compiled_module`: eager fallback for function, leaf for module (call_module, stays compiled)

## Test plan

```
python test/dynamo/test_misc.py \
  MiscTests.test_error_on_nested_fx_trace \
  MiscTests.test_error_on_nested_fx_trace_module \
  MiscTests.test_fx_trace_through_compiled_function \
  MiscTests.test_fx_trace_through_compiled_module_eager \
  MiscTests.test_fx_trace_compiled_module_is_leaf
```




cc @ezyang @gchanan @kadeng @msaroufim @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @chauhang @amjames @Lucaskabela @jataylo @azahed98