### PR TITLE
Fix reflection/replication pad stride mismatch under torch.compile

### DIFF
--- a/test/inductor/pallas_expected_failures/CpuTests.test_reflection_pad2d_channels_last_cpu
+++ b/test/inductor/pallas_expected_failures/CpuTests.test_reflection_pad2d_channels_last_cpu
@@ -1,0 +1,3 @@
+FAIL
+AssertionError: Tensor-likes are not close!
+Numerical accuracy issue in reflection_pad2d with channels_last input

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -8522,6 +8522,17 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             ),
         )
 
+    def test_reflection_pad2d_channels_last(self):
+        def fn(a):
+            return (aten.reflection_pad2d(a, [1, 2, 2, 1]),)
+
+        # channels_last input: stride order should be preserved in compiled output
+        self.common(
+            fn,
+            (torch.randn([2, 8, 4, 5]).to(memory_format=torch.channels_last),),
+            exact_stride=True,
+        )
+
     def test_reflection_pad2d_backward(self):
         def template(size, padding):
             def fn(grad_output, x):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5212,8 +5212,20 @@ def _reflection_or_replication_pad(
         idx[i + nc_dim] = idx_fn(padding_left[i], inp_shape[i], padding_right[i])
         result = aten._unsafe_index(result, idx)
 
-    # convert output to correct memory format, if necessary
-    memory_format = utils.suggest_memory_format(result)
+    # Convert output to correct memory format, if necessary.
+    # Use the original input (a), not result, because _unsafe_index can
+    # produce non-standard strides — so suggest_memory_format(result) may
+    # not reflect the desired output format.
+    #
+    # CPU vs CUDA eager behavior differs:
+    #   CPU:  allocates output via at::empty_like with suggest_memory_format,
+    #         preserving the input's format (e.g. channels_last).
+    #   CUDA: kernel writes to a flat contiguous buffer with linear indexing,
+    #         always producing contiguous output regardless of input format.
+    if a.device.type in ("cuda", "mps"):
+        memory_format = torch.contiguous_format
+    else:
+        memory_format = utils.suggest_memory_format(a)
     result = result.contiguous(memory_format=memory_format)
     return result
 


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/179442
The `_reflection_or_replication_pad` decomposition uses `_unsafe_index` which can produce non-standard strides from channels_last inputs. The existing memory format correction called `suggest_memory_format(result)` — but since `_unsafe_index` output strides don't reliably reflect the desired format, this gave wrong results.

Fix: use the original input's memory format to decide the output format. On CUDA, the eager C++ kernel always returns contiguous regardless of input format, so force `contiguous_format` there. On CPU, preserve the input's memory format (e.g. channels_last) to match eager.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo