### PR TITLE
Fix FlightRecorder trace analyzer to accept ncclx and gloo backends (#179842)

### DIFF
--- a/torch/distributed/flight_recorder/components/types.py
+++ b/torch/distributed/flight_recorder/components/types.py
@@ -418,9 +418,9 @@ class Op:
     ):
         self.profiling_name = event["profiling_name"]
         comm_lib_backend, name = self.profiling_name.split(":")
-        if comm_lib_backend not in ["nccl", "xccl"]:
+        if comm_lib_backend not in ["nccl", "ncclx", "gloo", "xccl"]:
             raise AssertionError(
-                f"name formatting error? {comm_lib_backend} != 'nccl' or 'xccl'"
+                f"name formatting error? {comm_lib_backend} not in supported backends"
             )
         parts = name.split(" ")
         type = parts[0]


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/torchcomms/pull/2013


Two fixes:                                                             
                                                            
  1. FR trace analyzer backend allowlist: D99020245 generalized FlightRecorder profiling_name to use the actual backend name (e.g. "ncclx:", "gloo:") instead of hardcoded "nccl:". The FR trace analyzer's Op class needs to accept these additional backend prefixes to avoid AssertionError when parsing traces from non-nccl backends.
  2. Sync op post-hook retirement race: TorchComm::postHook() deferred all post-hook invocations (including flight recorder entry retirement) to a callback that fires when the work's status transitions to COMPLETED. For synchronous operations (async_op=false), nobody calls work->wait() and the status only transitions asynchronously via the watchdog thread, so retired_ was never set by the time dump_json(include_completed=False) was called. Fix: invoke post-hooks synchronously for sync ops, since they run on the current CUDA stream and are complete from the user's perspective when the function returns. Added async_op field to PostHookArgs to distinguish sync vs async.

Test Plan:
Previously all tests below were failing:

fbcode//comms/torchcomms/hooks/fr/tests/py:FlightRecorderTest_1x8_backend_ncclx_initmode_default_memalloc_expseg_transport_baseline: https://www.internalfb.com/intern/testinfra/testrun/33495522229099048

fbcode//comms/torchcomms/hooks/fr/tests/py:FlightRecorderTest_1x8_backend_ncclx_initmode_default_memalloc_default_transport_baseline: https://www.internalfb.com/intern/testinfra/testrun/4785074963057659

fbcode//comms/torchcomms/hooks/fr/tests/py:FlightRecorderTest_1x8_backend_ncclx_initmode_default_memalloc_default_transport_ctran: https://www.internalfb.com/intern/testinfra/testrun/34058472182524345

fbcode//comms/torchcomms/hooks/fr/tests/py:FlightRecorderTest_1x8_backend_ncclx_initmode_fast_memalloc_default_transport_baseline: https://www.internalfb.com/intern/testinfra/testrun/18858823453032553

fbcode//comms/torchcomms/hooks/fr/tests/py:FlightRecorderTest_1x8_backend_ncclx_initmode_default_memalloc_expseg_transport_ctran: https://www.internalfb.com/intern/testinfra/testrun/12103424162971880

fbcode//comms/torchcomms/hooks/fr/tests/py:FlightRecorderTest_1x8_backend_ncclx_initmode_fast_memalloc_expseg_transport_baseline: https://www.internalfb.com/intern/testinfra/testrun/23362423080399978

fbcode//comms/torchcomms/hooks/fr/tests/py:FlightRecorderTest_1x8_backend_ncclx_initmode_fast_memalloc_default_transport_ctran: https://www.internalfb.com/intern/testinfra/testrun/9288674396164707

fbcode//comms/torchcomms/hooks/fr/tests/py:FlightRecorderTest_1x8_backend_ncclx_initmode_fast_memalloc_expseg_transport_ctran: https://www.internalfb.com/intern/testinfra/testrun/30680772461998465

Reviewed By: dolpm

Differential Revision: D100117074


