### PR TITLE
[inductor] Fix MSVC const pointer emission in cpp wrapper temporary arrays

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -123,15 +123,16 @@ class CppWrapperCpu(PythonWrapperCodegen):
         # e.g. const double** is possible, but not const double* const*.  This means
         # that an array containing pointers must _already_ be properly const-qualified
         # by the c_type, and not add additional const-ness.
-        # MSVC does not support implicitly converting a const iterator to a const pointer.
-        ptr_call = (
-            "data()"
-            if force_mutable or c_type.endswith("*") or cpp_builder.is_msvc_cl()
-            else "cbegin()"
-        )
-        return (
-            f"std::array<{c_type}, {len(elements)}>{{{', '.join(elements)}}}.{ptr_call}"
-        )
+        array_expr = f"std::array<{c_type}, {len(elements)}>{{{', '.join(elements)}}}"
+        if force_mutable or c_type.endswith("*"):
+            return f"{array_expr}.data()"
+
+        # MSVC does not support implicitly converting a const iterator to a const
+        # pointer, so use data() and cast to keep const qualification.
+        if cpp_builder.is_msvc_cl():
+            return f"static_cast<const {c_type}*>({array_expr}.data())"
+
+        return f"{array_expr}.cbegin()"
 
     def _generate_kernel_call_helper(
         self,


### PR DESCRIPTION
## Summary
Fix a Windows-only constness regression in CPP wrapper temporary array pointers that caused C2664 in convolution_backward when TORCHINDUCTOR_CPP_WRAPPER=1.

## Root cause
On MSVC, temporary array pointer emission for non-pointer element types was changed to always use mutable .data().
For optional list arguments this degraded const qualification, producing int64_t** where the C shim expects const int64_t**.
Linux used the cbegin path, which preserved constness, so the case passed there.

## Fix
- Keep mutable .data() for force_mutable or pointer-element arrays.
- On MSVC for non-pointer element arrays, emit static_cast<const T*>(array.data()) to preserve const qualification while avoiding iterator-to-pointer conversion issues.
- Keep the existing cbegin path on non-MSVC.

## Validation
- Command: set TORCHINDUCTOR_CPP_WRAPPER=1;& pytest -v test/inductor/test_cpu_repro.py -k test_conv1d_strided_weight_torch_compile

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo