### PR TITLE
Promote integer + bfloat16 to float32 in type promotion table

### DIFF
--- a/c10/core/ScalarType.cpp
+++ b/c10/core/ScalarType.cpp
@@ -110,19 +110,19 @@ ScalarType promoteTypes(ScalarType a, ScalarType b) {
   array<std::array<ScalarType, index2dtype.size()>, index2dtype.size()>
       _promoteTypesLookup = {{
       /*        u1  i1  i2  i4  i8  f2  f4  f8  c2  c4  c8  b1  bf*/
-      /* u1 */ {u1, i2, i2, i4, i8, f2, f4, f8, c2, c4, c8, u1, bf},
-      /* i1 */ {i2, i1, i2, i4, i8, f2, f4, f8, c2, c4, c8, i1, bf},
-      /* i2 */ {i2, i2, i2, i4, i8, f2, f4, f8, c2, c4, c8, i2, bf},
-      /* i4 */ {i4, i4, i4, i4, i8, f2, f4, f8, c2, c4, c8, i4, bf},
-      /* i8 */ {i8, i8, i8, i8, i8, f2, f4, f8, c2, c4, c8, i8, bf},
+      /* u1 */ {u1, i2, i2, i4, i8, f2, f4, f8, c2, c4, c8, u1, f4},
+      /* i1 */ {i2, i1, i2, i4, i8, f2, f4, f8, c2, c4, c8, i1, f4},
+      /* i2 */ {i2, i2, i2, i4, i8, f2, f4, f8, c2, c4, c8, i2, f4},
+      /* i4 */ {i4, i4, i4, i4, i8, f2, f4, f8, c2, c4, c8, i4, f4},
+      /* i8 */ {i8, i8, i8, i8, i8, f2, f4, f8, c2, c4, c8, i8, f4},
       /* f2 */ {f2, f2, f2, f2, f2, f2, f4, f8, c2, c4, c8, f2, f4},
       /* f4 */ {f4, f4, f4, f4, f4, f4, f4, f8, c4, c4, c8, f4, f4},
       /* f8 */ {f8, f8, f8, f8, f8, f8, f8, f8, c8, c8, c8, f8, f8},
       /* c2 */ {c2, c2, c2, c2, c2, c2, c4, c8, c2, c4, c8, c2, c4},
       /* c4 */ {c4, c4, c4, c4, c4, c4, c4, c8, c4, c4, c8, c4, c4},
       /* c8 */ {c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8},
-      /* b1 */ {u1, i1, i2, i4, i8, f2, f4, f8, c2, c4, c8, b1, bf},
-      /* bf */ {bf, bf, bf, bf, bf, f4, f4, f8, c4, c4, c8, bf, bf},
+      /* b1 */ {u1, i1, i2, i4, i8, f2, f4, f8, c2, c4, c8, b1, f4},
+      /* bf */ {f4, f4, f4, f4, f4, f4, f4, f8, c4, c4, c8, f4, bf},
   }};
   // clang-format on
   return _promoteTypesLookup[ix_a][ix_b];


### PR DESCRIPTION
bfloat16 has only 8 mantissa bits, so it cannot exactly represent integers above 256. The previous rule (integer + bf16 → bf16) silently rounded values, e.g. int32(257) + bf16(0) = bf16(256). This was extrapolated from NumPy's "float absorbs integer" convention, but NumPy has no bfloat16 type.

Change integer + bf16 (and bool + bf16) to promote to float32, matching Triton's promotion behavior. bf16 + bf16 is unchanged.

Fixes https://github.com/pytorch/pytorch/issues/179845