### PR TITLE
[ROCm][UT] Remove previously retained Triton 3.7 skip for torchinductor_opinfo test

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -38,7 +38,6 @@ from torch.testing._internal.common_utils import (
     IS_X86,
     skipCUDAMemoryLeakCheckIf,
     skipIfCrossRef,
-    skipIfRocm,
     skipIfTorchDynamo,
     suppress_warnings,
     TEST_MKL,
@@ -1225,7 +1224,6 @@ class TestInductorOpInfo(TestCase):
     @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @skipIfTorchDynamo("Test uses dynamo already")
     @skipIfCrossRef
-    @skipIfRocm(msg="Fails with Triton 3.7 on MI200")
     @_ops(op_db[START:END])
     @skipOps("TestInductorOpInfo", "test_comprehensive", test_skips_or_fails)
     @patch("torch._dynamo.config.raise_on_unsafe_aot_autograd", True)


### PR DESCRIPTION
Remove the intentionally retained `@skipIfRocm(msg=\"Fails with Triton 3.7 on MI200\")` decorator from `test_torchinductor_opinfo.py::TestInductorOpInfo.test_comprehensive`. 

The NEW FAILURE reported by CI is due to the shard timing out because the sharding logic is using an unrealistic time in [test_times.json](https://raw.githubusercontent.com/pytorch/test-infra/refs/heads/generated-stats/stats/test-times.json). Note that this is enabling several thousands UT. The test_torchinductor_opinfo is completing, but there are several restarts due to hitting the 30 minute mark.

test_torchinductor_opinfo summary below (from a previous run):
```
MI300:
- PASSED: 3549
- SKIPPED: 715
- XFAILED: 53
- FAILED/ERROR: 0
```

```
MI355:

- PASSED: 3293
- SKIPPED: 751
- XFAILED: 74
- FAILED/ERROR: 0
```

After rebase, the latest runs also ran test_torchinductor_opinfo successfully: [rocm-mi300](https://github.com/pytorch/pytorch/actions/runs/24598305023/job/71933767526) and [rocm-mi355](https://github.com/pytorch/pytorch/actions/runs/24598305307)

Made with [Cursor](https://cursor.com)

Related PRs:
https://github.com/pytorch/pytorch/pull/174896
https://github.com/pytorch/pytorch/pull/178450
https://github.com/pytorch/pytorch/pull/178559
https://github.com/pytorch/pytorch/pull/179794


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben