### PR TITLE
[inductor] Fix MSVC path append in kernel context stack compression

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/kernel_context_tls.h
+++ b/torch/csrc/inductor/aoti_runtime/kernel_context_tls.h
@@ -97,7 +97,7 @@ struct KernelContext {
       }
       res_stack += std::string{function} + '[' + std::string{p} + ']';
       res_stack += '\n';
-      res_stack += fs::path{filename}.filename();
+      res_stack += fs::path{filename}.filename().string();
       res_stack += '\n';
       res_stack += std::to_string(fileline);
       res_stack += '\n';


### PR DESCRIPTION
Summary
This fixes a Windows-only C++ compile error in the CPP wrapper path used by inductor repro tests. Linux passed, but MSVC failed when compiling generated wrapper code that includes kernel_context_tls.h.

Root cause
In KernelContext::compress_stack, we appended std::filesystem::path directly to std::string:
res_stack += fs::path{filename}.filename();

MSVC does not provide an implicit conversion for std::string::operator+= with std::filesystem::path, causing C2679. Linux toolchains did not surface this in our test coverage, which is why the issue appeared Windows-only.

Fix
Convert the path explicitly to std::string before appending:
res_stack += fs::path{filename}.filename().string();

This keeps behavior unchanged while making the code portable across toolchains.

Testing
Ran targeted CPP-wrapper test on Windows with TORCHINDUCTOR_CPP_WRAPPER=1:

pytest -v test_cpu_repro.py -k test_cpp_kernel_profile