### PR TITLE
[pyrefly] Add type annotations to torch/fx/experimental proxy_tensor,…

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -310,7 +310,7 @@ class AutogradCompilerInstance:
         self,
         inputs: list[torch.Tensor],
         sizes: list[int],
-        scalars: list[int | float],
+        scalars: list[IntLikeType | FloatLikeType],
         origins: list[list[tuple[int, str]]],
         accumulate_grad: bool,
         check_nans: bool,
@@ -382,7 +382,8 @@ class AutogradCompilerInstance:
                 (proxies[i],),
                 {},
             )
-            self.symnode_proxy_lookup[symint.node] = proxies[i]
+            if not isinstance(symint, int):
+                self.symnode_proxy_lookup[symint.node] = proxies[i]
         proxies = self.bind_objects_to_proxies(sym_sizes, proxies, sizes_origins)
 
         for idx, val in enumerate(scalars):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1267,6 +1267,8 @@ class VariableBuilder:
                     hint=value.real,  # type: ignore[attr-defined]
                     source=source,
                 )
+                if not isinstance(node, SymInt):
+                    raise AssertionError(f"Expected SymInt, got {type(node)}")
 
             # Bind to graph input
             sym_node_proxy = self.tx.output.root_tracer.create_graph_input(
@@ -1329,6 +1331,8 @@ class VariableBuilder:
                         hints=[*graph_break_hints.SUPPORTABLE],
                     )
             assert new_symint is not None
+            if not isinstance(new_symint, SymInt):
+                raise AssertionError(f"Expected SymInt, got {type(new_symint)}")
             sym_node_proxy = self.tx.output.root_tracer.create_graph_input(
                 re.sub(r"[^a-zA-Z0-9]+", "_", self.name),
                 type(new_symint),
@@ -2766,6 +2770,8 @@ class VariableBuilder:
                 dynamic_dim=dynamic_dim,
                 excluded_value=excluded_scalar,
             )
+            if not isinstance(wrapped_value, SymInt):
+                raise AssertionError(f"Expected SymInt, got {type(wrapped_value)}")
 
             self.tx.output.tracked_fakes.append(
                 TrackedFake(wrapped_value, self.source, context)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -121,6 +121,7 @@ from .virtualized import ops, OpsValue, V
 if TYPE_CHECKING:
     from torch.fx.experimental.symbolic_shapes import SympyBoolean
     from torch.fx.node import Argument
+    from torch.types import IntLikeType
 
     from .codegen.cutlass.template import CUTLASSTemplate
     from .codegen.wrapper import PythonWrapperCodegen
@@ -6411,7 +6412,11 @@ class ExternKernel(InputsKernel):
         tensor_args: list[IRNode] = []
         non_tensor_args: list[object] = []
         real_non_tensor_args: list[
-            FakeScriptObject | torch._C.Generator | torch._C.ScriptObject | torch.Tensor
+            FakeScriptObject
+            | torch._C.Generator
+            | torch._C.ScriptObject
+            | torch.Tensor
+            | IntLikeType
         ] = []
         for arg in args_flat:
             match arg:

--- a/torch/_subclasses/_fake_tensor_utils.py
+++ b/torch/_subclasses/_fake_tensor_utils.py
@@ -35,9 +35,10 @@ class _DeconstructedSymNode:
         return _DeconstructedSymNode(
             node._expr,
             node.pytype,
+            # pyrefly: ignore[bad-argument-type]
             node._hint,
             node.constant,
-            # pyrefly: ignore [bad-argument-type]
+            # pyrefly: ignore[bad-argument-type]
             node.fx_node,
         )
 

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -426,9 +426,9 @@ def _unique(
 
         if dim is None:
             if unique_consecutive:
-                arg.unique_consecutive_memo = nnz
+                arg.unique_consecutive_memo = nnz  # pyrefly: ignore[bad-assignment]
             else:
-                arg.unique_memo = nnz
+                arg.unique_memo = nnz  # pyrefly: ignore[bad-assignment]
 
     if dim is None:
         # pyrefly: ignore[no-matching-overload]
@@ -909,7 +909,7 @@ def nonzero(fake_mode: FakeTensorMode, func: OpOverload, arg: FakeTensor) -> Fak
 
             _constrain_range_for_size(nnz, max=maxval)
 
-        arg.nonzero_memo = nnz
+        arg.nonzero_memo = nnz  # pyrefly: ignore[bad-assignment]
     return arg.new_empty_strided((nnz, arg.dim()), (1, nnz), dtype=torch.int64)  # type: ignore[return]
 
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -664,7 +664,9 @@ class SymNumberMemoDescriptor:
         return r
 
     def __set__(
-        self, obj: FakeTensor, value: torch.SymInt | torch.SymFloat | None
+        self,
+        obj: FakeTensor,
+        value: torch.SymInt | torch.SymFloat | torch.SymBool | int | float | None,
     ) -> None:
         if value is None:
             setattr(obj, self._memo(obj), None)
@@ -3076,7 +3078,7 @@ class FakeTensorMode(TorchDispatchMode):
 
     def create_symbolic_nested_int(
         self, *, nt_tensor_id: int | None = None
-    ) -> torch.SymInt:
+    ) -> IntLikeType:
         # See Note: [Creating symbolic nested int]
         # Returned nested int always has coeff=1; multiply the result by coeff if needed
         import torch.nested._internal.nested_tensor

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     # Import the following modules during type checking to enable code intelligence features,
     # Do not import unconditionally, as they import sympy and importing sympy is very slow
     from torch.fx.experimental.symbolic_shapes import ShapeEnv, SymbolicContext
+    from torch.types import IntLikeType
 
 
 def _is_fake_tensor(t: object) -> TypeIs[FakeTensor]:
@@ -1094,7 +1095,7 @@ class MetaConverter(Generic[_TensorT]):
             src: torch._guards.Source,
             symbolic_context: torch.fx.experimental.symbolic_shapes.SymbolicContext
             | None = symbolic_context,
-        ) -> tuple[tuple[int, ...], tuple[int, ...], int]:
+        ) -> tuple[tuple[IntLikeType, ...], tuple[IntLikeType, ...], IntLikeType]:
             # local import to prevent circular import
             from torch.fx.experimental.symbolic_shapes import is_symbolic
 
@@ -1165,8 +1166,8 @@ class MetaConverter(Generic[_TensorT]):
         # symbolic context.
         def empty_create_subclass(
             t: MetaTensorDesc[Any],
-            outer_size: tuple[int, ...],
-            outer_stride: tuple[int, ...],
+            outer_size: tuple[IntLikeType, ...],
+            outer_stride: tuple[IntLikeType, ...],
             symbolic_context: torch.fx.experimental.symbolic_shapes.SymbolicContext
             | None = symbolic_context,
             source: torch._guards.Source | None = source,
@@ -1204,7 +1205,9 @@ class MetaConverter(Generic[_TensorT]):
                 raise AssertionError("source must not be None")
             sub = self._empty_create_subclass(
                 t,
+                # pyrefly: ignore[bad-argument-type]
                 outer_size,
+                # pyrefly: ignore[bad-argument-type]
                 outer_stride,
                 shape_env,
                 symbolic_context,
@@ -1345,7 +1348,7 @@ class MetaConverter(Generic[_TensorT]):
                     sym_eq,
                 )
 
-                def symint_visitor_fn(s: int) -> int:
+                def symint_visitor_fn(s: int) -> IntLikeType:
                     nonlocal symbolic_context
                     from torch.fx.experimental.symbolic_shapes import DimDynamic
 
@@ -1452,7 +1455,11 @@ class MetaConverter(Generic[_TensorT]):
                 # NB: we do NOT suppress guards here, we need to remove ephemeral
                 # sources
                 fake_t = t.view_func.apply(
-                    t, base, symint_visitor_fn, tensor_visitor_fn
+                    t,
+                    base,
+                    # pyrefly: ignore[bad-argument-type]
+                    symint_visitor_fn,
+                    tensor_visitor_fn,
                 )
 
                 # Ensure the output has symbolic shapes according to the outer symbolic context.

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-decorators
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #
@@ -22,6 +21,7 @@ from dataclasses import dataclass
 from typing import (
     Any,
     Concatenate,
+    Literal,
     overload,
     Protocol,
     TYPE_CHECKING,
@@ -109,6 +109,7 @@ __all__ = [
 ]
 
 _ProxyTracer = Union["PythonKeyTracer", "_GraphAppendingTracerEx"]
+_TracingMode: TypeAlias = Literal["real", "fake", "symbolic"]
 
 _AnyScriptObject = (torch.ScriptObject, FakeScriptObject)
 _AnyScriptObjectType = torch.ScriptObject | FakeScriptObject
@@ -119,9 +120,9 @@ prim = torch.ops.prim
 log = logging.getLogger(__name__)
 not_implemented_log = torch._logging.getArtifactLogger(__name__, "not_implemented")
 
-CURRENT_DECOMPOSITION_TABLE: contextvars.ContextVar[Mapping[OpOverload, Callable]] = (
-    contextvars.ContextVar("CURRENT_DECOMPOSITION_TABLE")
-)
+CURRENT_DECOMPOSITION_TABLE: contextvars.ContextVar[
+    Mapping[OpOverload, Callable[..., Any]]
+] = contextvars.ContextVar("CURRENT_DECOMPOSITION_TABLE")
 
 CONSTANT_NUMEL_LIMIT = 1
 
@@ -161,8 +162,8 @@ def fake_signature(fn: Callable[_P, R], nargs: int) -> Callable[_P, R]:
 
 @contextmanager
 def decompose(
-    decomposition_table: Mapping[OpOverload, Callable] | None,
-) -> Generator[Mapping[OpOverload, Callable], None, None]:
+    decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None,
+) -> Generator[Mapping[OpOverload, Callable[..., Any]], None, None]:
     table = decomposition_table or {}
     token = CURRENT_DECOMPOSITION_TABLE.set(table)
     try:
@@ -454,7 +455,7 @@ def get_proxy_slot(
     obj: Tensor | _AnyScriptObjectType | PySymType | OpaqueBase,
     tracer: _ProxyTracer,
     default: object = no_default,
-    transform: Callable = lambda x: x,
+    transform: Callable[..., Any] = lambda x: x,
 ) -> object:
     tracker: Any
     if isinstance(obj, Tensor):
@@ -1659,9 +1660,9 @@ def _make_temp_remove_mode_context_manager(
 
 @torch._disable_dynamo
 def dispatch_trace(
-    root: Module | Callable,
+    root: Module | Callable[..., Any],
     tracer: Tracer,
-    concrete_args: tuple[Any, ...] | None = None,
+    concrete_args: tuple[object, ...] | None = None,
 ) -> GraphModule:
     graph = tracer.trace(root, concrete_args)  # type: ignore[arg-type]
 
@@ -1809,7 +1810,7 @@ class PreDispatchTorchFunctionMode(TorchFunctionMode):
 
     def __torch_function__(
         self,
-        func: OpOverload | Callable,
+        func: OpOverload | Callable[..., Any],
         types: tuple[torch._C._TensorMeta, ...],
         args: tuple[object, ...] = (),
         kwargs: dict[str, object] | None = None,
@@ -1876,7 +1877,7 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
     def __init__(
         self,
         tracer: _ProxyTracer,
-        tracing_mode: str,
+        tracing_mode: _TracingMode,
         pre_dispatch: bool = False,
         _allow_fake_constant: bool = False,
         _error_on_data_dependent_ops: bool = True,
@@ -2044,7 +2045,7 @@ class DecompositionInterpreter(fx.Interpreter):
         self,
         module: fx.GraphModule,
         new_graph: fx.Graph,
-        decomposition_table: Mapping[OpOverload, Callable] | None = None,
+        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None = None,
         **kwargs: object,
     ) -> None:
         super().__init__(module, **kwargs)  # type: ignore[arg-type]
@@ -2111,7 +2112,7 @@ class _SelectiveDecomposeInterpreter(fx.Interpreter):
         self,
         module: fx.GraphModule,
         should_decompose: Callable[[fx.Node], bool],
-        decomposition_table: Mapping[OpOverload, Callable],
+        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None,
         **kwargs: object,
     ) -> None:
         """
@@ -2126,7 +2127,7 @@ class _SelectiveDecomposeInterpreter(fx.Interpreter):
     def recursive_wrap(
         gm: fx.GraphModule,
         should_decompose: Callable[[fx.Node], bool],
-        decomposition_table: Mapping[OpOverload, Callable],
+        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None,
         **kwargs: object,
     ) -> _SelectiveDecomposeInterpreter:
         """
@@ -2157,7 +2158,7 @@ class _SelectiveDecomposeInterpreter(fx.Interpreter):
             gm, should_decompose, decomposition_table, **kwargs
         )
 
-    def run_node(self, n):
+    def run_node(self, n: fx.Node) -> Any:
         if self.should_decompose(n):
             with decompose(self.decomposition_table):
                 result = super().run_node(n)
@@ -2168,9 +2169,9 @@ class _SelectiveDecomposeInterpreter(fx.Interpreter):
 
 def selective_decompose(
     joint_gm: fx.GraphModule,
-    *args,
-    decomposition,
-    should_decompose,
+    *args: object,
+    decomposition: Mapping[OpOverload, Callable[..., Any]] | None,
+    should_decompose: Callable[..., bool],
     trace_joint_graph: bool,
 ) -> fx.GraphModule:
     """Retrace a joint graph module and selectively apply decomposition."""
@@ -2179,13 +2180,13 @@ def selective_decompose(
         # the arg name, primals and tangents, are important.
         # make_fx keeps the name in the traced graph and partitioner later relies
         # on the name to partition joint graph correctly.
-        def wrap_fn(primals: list[Any], tangents: list[Any]):
+        def wrap_fn(primals: list[Any], tangents: list[Any]) -> Any:
             return _SelectiveDecomposeInterpreter.recursive_wrap(
                 joint_gm, should_decompose, decomposition
             ).run(*args)
     else:
 
-        def wrap_fn(*args):
+        def wrap_fn(*args: Any) -> Any:
             return _SelectiveDecomposeInterpreter.recursive_wrap(
                 joint_gm, should_decompose, decomposition
             ).run(*args)
@@ -2390,7 +2391,7 @@ class _ModuleStackTracer(PythonKeyTracer):
         return self.attr_proxy_map[attr_val]
 
     def trace(  # type: ignore[override]
-        self, root: Module | Callable, concrete_args: dict[str, object] | None
+        self, root: Module | Callable[..., Any], concrete_args: dict[str, object] | None
     ) -> fx.Graph:
         res = super().trace(root, concrete_args)
 
@@ -2461,7 +2462,7 @@ class _ModuleStackTracer(PythonKeyTracer):
     def call_module(
         self,
         m: Module,
-        forward: Callable,
+        forward: Callable[..., Any],
         args: tuple[object, ...],
         kwargs: dict[str, object],
     ) -> None:
@@ -2536,8 +2537,8 @@ class _ModuleStackTracer(PythonKeyTracer):
 class _MakefxTracer:
     def __init__(
         self,
-        decomposition_table: Mapping[OpOverload, Callable] | None,
-        tracing_mode: str,
+        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None,
+        tracing_mode: _TracingMode,
         _allow_non_fake_inputs: bool,
         pre_dispatch: bool,
         record_module_stack: bool,
@@ -2550,13 +2551,13 @@ class _MakefxTracer:
     ) -> None:
         # Configurations that are used to initialize the context managers and their states.
         # Should not modify them during tracing.
-        self.decomposition_table: dict[OpOverload, Callable] = dict(
+        self.decomposition_table: dict[OpOverload, Callable[..., Any]] = dict(
             decomposition_table or {}
         )
         self.decomposition_table.setdefault(
             torch.ops.aten.sym_numel.default, torch._decomp.decompositions.sym_numel
         )
-        self.tracing_mode: str = tracing_mode
+        self.tracing_mode: _TracingMode = tracing_mode
         self._allow_non_fake_inputs: bool = _allow_non_fake_inputs
         self.pre_dispatch: bool = pre_dispatch
         self.record_module_stack: bool = record_module_stack
@@ -2568,13 +2569,13 @@ class _MakefxTracer:
         # Remember to specify how to initialize it from user inputs and from parent tracer whenever
         # adding new modes in _MakefxTracer.
         self.fake_tensor_mode: FakeTensorMode | None = None
-        self.proxy_mode: nullcontext | ProxyTorchDispatchMode = nullcontext()
-        self.proxy_function_mode: nullcontext | PreDispatchTorchFunctionMode = (
+        self.proxy_mode: nullcontext[None] | ProxyTorchDispatchMode = nullcontext()
+        self.proxy_function_mode: nullcontext[None] | PreDispatchTorchFunctionMode = (
             nullcontext()
         )
         self.fx_tracer: PythonKeyTracer | None = None
-        self.python_dispatcher_mode: nullcontext | Any = nullcontext()
-        self.torch_fn_metadata_mode: nullcontext | TorchFunctionMetadataMode = (
+        self.python_dispatcher_mode: nullcontext[None] | Any = nullcontext()
+        self.torch_fn_metadata_mode: nullcontext[None] | TorchFunctionMetadataMode = (
             nullcontext()
         )
         self.record_stack_traces = record_stack_traces
@@ -2595,11 +2596,11 @@ class _MakefxTracer:
     def _restore_modes(
         self,
         prev_fake_tensor_mode: FakeTensorMode | None,
-        prev_proxy_mode: nullcontext | ProxyTorchDispatchMode,
-        prev_proxy_function_mode: nullcontext | PreDispatchTorchFunctionMode,
+        prev_proxy_mode: nullcontext[None] | ProxyTorchDispatchMode,
+        prev_proxy_function_mode: nullcontext[None] | PreDispatchTorchFunctionMode,
         prev_fx_tracer: PythonKeyTracer | None,
-        prev_python_dispatcher_mode: nullcontext | Any,
-        prev_torch_fn_metadata_mode: nullcontext | TorchFunctionMetadataMode,
+        prev_python_dispatcher_mode: nullcontext[None] | Any,
+        prev_torch_fn_metadata_mode: nullcontext[None] | TorchFunctionMetadataMode,
     ) -> None:
         self.fake_tensor_mode = prev_fake_tensor_mode
         self.proxy_mode = prev_proxy_mode
@@ -2610,7 +2611,7 @@ class _MakefxTracer:
 
     @contextmanager
     def _init_modes_from_inputs(
-        self, f: Callable, args: tuple[object, ...]
+        self, f: Callable[..., Any], args: tuple[object, ...]
     ) -> Generator[None, None, None]:
         prev_modes = self._checkpoint_modes()
         try:
@@ -2775,7 +2776,7 @@ class _MakefxTracer:
 
         return pytree.tree_map(inner_wrap_fake, args)
 
-    def _trace_inner(self, f: Callable, *args: object) -> GraphModule:
+    def _trace_inner(self, f: Callable[..., Any], *args: object) -> GraphModule:
         # TODO: We need to explicitly import torch._dynamo before calling dispatch_trace,
         # because dispatch_trace will introduce the lazy import of torch._dynamo,
         # and some contexts set before calling dispatch_trace will cause problems with the import of torch._dynamo,
@@ -2789,7 +2790,7 @@ class _MakefxTracer:
 
         # FX doesn't support varargs, so we gotta fake up a wrapper
         # TODO: Would be nice to fix this at the source...
-        func: Callable = f
+        func: Callable[..., Any] = f
         if (
             not hasattr(inspect.unwrap(f), "__code__")
             or inspect.unwrap(f).__code__.co_flags & inspect.CO_VARARGS
@@ -2855,7 +2856,7 @@ class _MakefxTracer:
             t.shape_env = self.fake_tensor_mode.shape_env  # type: ignore[assignment]
         return t
 
-    def trace(self, f: Callable, *args: object) -> fx.GraphModule:
+    def trace(self, f: Callable[..., Any], *args: object) -> fx.GraphModule:
         with self._init_modes_from_inputs(f, args):
             return self._trace_inner(f, *args)
 
@@ -2864,8 +2865,8 @@ class _MakefxTracer:
 
     def _make_sub_tracer(
         self,
-        decomp_table: Mapping[OpOverload, Callable] | None = None,
-        tracing_mode: str = "real",
+        decomp_table: Mapping[OpOverload, Callable[..., Any]] | None = None,
+        tracing_mode: _TracingMode = "real",
     ) -> _MakefxTracer:
         return _MakefxTracer(
             decomp_table if decomp_table is not None else self.decomposition_table,
@@ -2878,13 +2879,16 @@ class _MakefxTracer:
             parent_tracer=self,
         )
 
-    def trace_subgraph(self, f: Callable, *args: object) -> GraphModule:
+    def trace_subgraph(self, f: Callable[..., Any], *args: object) -> GraphModule:
         sub_tracer = self._make_sub_tracer()
         with sub_tracer._init_modes_from_parent(self):
             return sub_tracer._trace_inner(f, *args)
 
     def trace_subgraph_custom_decomp(
-        self, f: Callable, decomp_table: Mapping[OpOverload, Callable], *args: object
+        self,
+        f: Callable[..., Any],
+        decomp_table: Mapping[OpOverload, Callable[..., Any]],
+        *args: object,
     ) -> GraphModule:
         if not isinstance(decomp_table, Mapping):
             raise AssertionError(f"Expected Mapping, got {type(decomp_table)}")
@@ -2908,9 +2912,9 @@ def _set_make_fx_tracer(tracer: _MakefxTracer) -> Generator[None, None, None]:
 
 
 def make_fx(
-    f: Callable,
-    decomposition_table: Mapping[OpOverload, Callable] | None = None,
-    tracing_mode: str = "real",
+    f: Callable[..., Any],
+    decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None = None,
+    tracing_mode: _TracingMode = "real",
     _allow_non_fake_inputs: bool = False,
     *,
     pre_dispatch: bool = False,
@@ -3033,11 +3037,11 @@ def maybe_handle_decomp(
 
 
 def get_isolated_graphmodule(
-    func: Callable,
+    func: Callable[..., Any],
     args: tuple[object, ...],
     kwargs: dict[str, object],
-    tracing_mode: str = "real",
-    decomposition_table: Mapping[OpOverload, Callable] | None = None,
+    tracing_mode: _TracingMode = "real",
+    decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None = None,
 ) -> GraphModule:
     """A helper function used to get the GraphModule for the given func.
 

--- a/torch/fx/experimental/recording.py
+++ b/torch/fx/experimental/recording.py
@@ -1,14 +1,24 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 import functools
 import inspect
 import itertools
 import logging
-from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ParamSpec, TYPE_CHECKING, TypeVar
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 import torch
 import torch.utils._pytree as pytree
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from torch.fx.experimental.symbolic_shapes import ShapeEnv, TrackedFake
 
 
 log = logging.getLogger(__name__)
@@ -81,21 +91,21 @@ __all__ = [
 @dataclass
 class ShapeEnvEvent:
     # ShapeEnv method.
-    f: Callable
+    f: Callable[..., Any]
 
     # Arguments and keyword arguments called with.
-    args: list[Any] | None = None
+    args: list[object] | None = None
     kwargs: dict[str, Any] | None = None
 
     # List of tracked_fakes at the time the method was called.
-    tracked_fakes: list[Any] | None = None
+    tracked_fakes: list[TrackedFake] | None = None
 
     # Name of the captured event.
     # Used for special handling of particular methods.
     name: str | None = None
 
     # Replay itself, but using shape_env as self.
-    def run(self, shape_env=None) -> Any:
+    def run(self, shape_env: ShapeEnv | None = None) -> Any:
         from torch.fx.experimental.symbolic_shapes import (
             is_symbolic,
             ShapeEnv,
@@ -147,7 +157,7 @@ class ShapeEnvEvent:
             return name_to_node[x.name]
 
         # Replaces the value of an specific argument by the result of fn.
-        def replacearg(index: int, key: str, fn: Callable):
+        def replacearg(index: int, key: str, fn: Callable[..., Any]) -> None:
             if index < len(args):
                 args[index] = fn(args[index])
             if key in kwargs:
@@ -196,7 +206,9 @@ NEST = 0
 #   2. SymInt, SymFloat, or SymBool arguments
 # If we find more than one object of any of the above types, we
 # also check that the ShapeEnv instance is the same for all of them.
-def _extract_shape_env_and_assert_equal(args, kwargs):
+def _extract_shape_env_and_assert_equal(
+    args: tuple[object, ...] | list[object], kwargs: dict[str, object]
+) -> ShapeEnv | None:
     from torch.fx.experimental.symbolic_shapes import is_symbolic, ShapeEnv, SymTypes
 
     def assert_equal(old: ShapeEnv | None, new: ShapeEnv) -> ShapeEnv:
@@ -241,8 +253,8 @@ def _extract_shape_env_and_assert_equal(args, kwargs):
 #   - ShapeEnv.guard_or_defer_runtime_assert
 def record_shapeenv_event(
     *, save_tracked_fakes: bool = False, name: str | None = None
-) -> Callable:
-    def decorator(fn: Callable) -> Callable:
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    def decorator(fn: Callable[_P, _R]) -> Callable[_P, _R]:
         if not callable(fn):
             raise AssertionError(f"Expected callable, got {type(fn)}")
         args = inspect.getfullargspec(fn).args
@@ -256,7 +268,7 @@ def record_shapeenv_event(
             name = fn.__name__
 
         @functools.wraps(fn)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
             if not isinstance(args[0], ShapeEnv):
@@ -269,7 +281,7 @@ def record_shapeenv_event(
             )
             NEST += 1
 
-            def retlog(r):
+            def retlog(r: _R) -> _R:
                 trace_shape_events_log.debug("%s-> %s", " " * (NEST - 1), r)
                 return r
 
@@ -346,7 +358,7 @@ def record_shapeenv_event(
 # It assumes the first event is the constructor call.
 #
 # fn: transforms an old FX node into one corresponding to the newly created ShapeEnv.
-def replay_shape_env_events(events):
+def replay_shape_env_events(events: list[ShapeEnvEvent]) -> ShapeEnv:
     from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
     constructor_event = events[0]
@@ -394,7 +406,7 @@ class FakeTensorMeta:
         return len(self.tensor_size)
 
     @staticmethod
-    def from_fake(fake) -> "FakeTensorMeta":
+    def from_fake(fake: torch.Tensor) -> FakeTensorMeta:
         return FakeTensorMeta(
             fake.size(), fake.stride(), fake.storage_offset(), fake.is_nested
         )
@@ -446,7 +458,12 @@ class FakeTensorMeta:
 
 # Checks whether the state of two ShapeEnv are equal w.r.t. the guards
 # returned by ShapeEnv.produce_guards.
-def shape_env_check_state_equal(env1, env2, non_state_variable_names, map_value):
+def shape_env_check_state_equal(
+    env1: ShapeEnv,
+    env2: ShapeEnv,
+    non_state_variable_names: tuple[str, ...],
+    map_value: Callable[[str, object], object],
+) -> None:
     # Collect and remove variables that don't necessarily represent the state
     # of a ShapeEnv. Note: we copy the dictionary so that we don't modify the
     # instance itself.
@@ -476,7 +493,7 @@ def shape_env_check_state_equal(env1, env2, non_state_variable_names, map_value)
     # Here, we allow the value of each field to be mapped, so that we appropriately
     # compare the two values.
     def compare_vars(
-        map_value: Callable[[str, Any], Any],
+        map_value: Callable[[str, object], object],
     ) -> list[tuple[str, str, str]]:
         env1_set, env2_set = set(env1_vars), set(env2_vars)
 

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from __future__ import annotations
 
 
@@ -23,7 +21,7 @@ import math
 import operator
 import sys
 from functools import lru_cache, update_wrapper
-from typing import TYPE_CHECKING
+from typing import Any, overload, TYPE_CHECKING
 
 import torch
 import torch._logging.structured as structured
@@ -43,6 +41,11 @@ from torch._logging import dtrace_structured
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Self
+
+    import sympy
+
     from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
 log = logging.getLogger(__name__)
@@ -62,7 +65,15 @@ __all__ = ["SymNode", "method_to_operator", "magic_methods", "DynamicInt"]
 from torch.types import py_sym_types as SymTypes
 
 
-def _to_symtype(t):
+@overload
+def _to_symtype(t: type[bool]) -> type[SymBool]: ...
+@overload
+def _to_symtype(t: type[int]) -> type[SymInt]: ...
+@overload
+def _to_symtype(t: type[float]) -> type[SymFloat]: ...
+@overload
+def _to_symtype(t: type) -> type: ...
+def _to_symtype(t: type) -> type:
     if t is bool:
         return SymBool
     if t is int:
@@ -92,14 +103,14 @@ class SymNode:
 
     def __init__(
         self,
-        expr,
-        shape_env,
-        pytype,
+        expr: object,
+        shape_env: ShapeEnv | None,
+        pytype: type,
         hint: HintType | object,
-        constant=None,
-        fx_node=None,
-        optimized_summation=False,
-    ):
+        constant: int | float | bool | None = None,
+        fx_node: object = None,
+        optimized_summation: bool = False,
+    ) -> None:
         self._expr = expr
         self.shape_env = shape_env
         self.pytype = pytype
@@ -134,7 +145,7 @@ class SymNode:
         # potential refinements to unbacked symints this got harder to keep
         # in sync, so we've deleted it for now.)
 
-        def compute_hint():
+        def compute_hint() -> HintType | SymInt | SymFloat | SymBool:
             from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
 
             # This occasionally gets exercised by, e.g.,
@@ -144,6 +155,8 @@ class SymNode:
             # expensive.
             if has_free_unbacked_symbols(self.expr):
                 return None
+            if self.shape_env is None:
+                raise RuntimeError("shape_env is required to compute hint")
             hint = self.shape_env._maybe_evaluate_static(self.expr, compute_hint=True)
             if hint is not None:
                 hint = self.pytype(hint) if not isinstance(hint, SymTypes) else hint
@@ -197,9 +210,14 @@ class SymNode:
         return hash((self._expr, self.pytype, self._hint, self.constant, self.fx_node))
 
     @property
-    def expr(self):
-        if isinstance(self._expr, int) or self._expr.is_number:
+    def expr(self) -> sympy.Basic:
+        if (
+            isinstance(self._expr, int)
+            or self._expr.is_number  # pyrefly: ignore[missing-attribute]
+        ):
             return self._expr
+        if self.shape_env is None:
+            raise AssertionError("shape_env is required to access expr")
         ver = self.shape_env._replacements_version_counter
         if ver == 0:
             return self._expr
@@ -211,20 +229,20 @@ class SymNode:
         return result
 
     @property
-    def hint(self):
+    def hint(self) -> HintType | SymInt | SymFloat | SymBool:
         return self._hint
 
-    def has_hint(self):
+    def has_hint(self) -> bool:
         return self._hint is not None
 
-    def maybe_as_int(self):
+    def maybe_as_int(self) -> int | None:
         if self.expr.is_number:
             return int(self.expr)
         else:
             return None
 
     # NB: This does conversions, not sure if this is good or not
-    def maybe_as_float(self):
+    def maybe_as_float(self) -> float | None:
         import sympy
 
         if isinstance(self.expr, sympy.Float):
@@ -232,7 +250,7 @@ class SymNode:
         else:
             return None
 
-    def maybe_as_bool(self):
+    def maybe_as_bool(self) -> bool | None:
         import sympy
 
         if self.expr is sympy.true:
@@ -242,16 +260,16 @@ class SymNode:
         else:
             return None
 
-    def is_int(self):
+    def is_int(self) -> bool:
         return self.pytype is int
 
-    def is_float(self):
+    def is_float(self) -> bool:
         return self.pytype is float
 
-    def is_bool(self):
+    def is_bool(self) -> bool:
         return self.pytype is bool
 
-    def is_nested_int(self):
+    def is_nested_int(self) -> bool:
         # Unbacked SymInts cannot be nested int today
         return (
             self._hint is not None
@@ -259,7 +277,7 @@ class SymNode:
             and self._hint.node.is_nested_int()
         )
 
-    def wrap_int(self, num):
+    def wrap_int(self, num: int) -> SymNode:
         if type(num) is not int:
             raise AssertionError(f"Expected int, got {type(num)}")
         import sympy
@@ -268,7 +286,7 @@ class SymNode:
             sympy.Integer(num), self.shape_env, int, num, constant=num, fx_node=num
         )
 
-    def wrap_float(self, num):
+    def wrap_float(self, num: float) -> SymNode:
         if type(num) is not float:
             raise AssertionError(f"Expected float, got {type(num)}")
         import sympy
@@ -277,7 +295,7 @@ class SymNode:
             sympy.Float(num), self.shape_env, float, num, constant=num, fx_node=num
         )
 
-    def wrap_bool(self, num):
+    def wrap_bool(self, num: bool) -> SymNode:
         if type(num) is not bool:
             raise AssertionError(f"Expected bool, got {type(num)}")
         import sympy
@@ -291,16 +309,16 @@ class SymNode:
             fx_node=num,
         )
 
-    def clone(self):
+    def clone(self) -> SymNode:
         return self
 
-    def str(self):
+    def str(self) -> builtins.str:
         return f"{self.expr}"
 
-    def __str__(self):
+    def __str__(self) -> builtins.str:
         return self.str()
 
-    def __repr__(self):
+    def __repr__(self) -> builtins.str:
         rep = [
             f"SymNode({self._expr}, shape_env={self.shape_env}, pytype={self.pytype}",
         ]
@@ -324,70 +342,70 @@ class SymNode:
     def pos(self) -> SymNode:
         return self._pos()  # type: ignore[attr-defined]
 
-    def round(self, ndigits=None) -> SymNode:
+    def round(self, ndigits: int | None = None) -> SymNode:
         return self._round(ndigits)  # type: ignore[attr-defined]
 
     def trunc(self) -> SymNode:
         return self._trunc()  # type: ignore[attr-defined]
 
-    def add(self, other) -> SymNode:
+    def add(self, other: SymNode) -> SymNode:
         return self._add(other)  # type: ignore[attr-defined]
 
-    def sub(self, other) -> SymNode:
+    def sub(self, other: SymNode) -> SymNode:
         return self._sub(other)  # type: ignore[attr-defined]
 
-    def mul(self, other) -> SymNode:
+    def mul(self, other: SymNode) -> SymNode:
         return self._mul(other)  # type: ignore[attr-defined]
 
-    def mod(self, other) -> SymNode:
+    def mod(self, other: SymNode) -> SymNode:
         return self._mod(other)  # type: ignore[attr-defined]
 
-    def float_pow(self, other) -> SymNode:
+    def float_pow(self, other: SymNode) -> SymNode:
         return self._float_pow(other)  # type: ignore[attr-defined]
 
-    def pow_by_natural(self, other) -> SymNode:
+    def pow_by_natural(self, other: SymNode) -> SymNode:
         return self._pow_by_natural(other)  # type: ignore[attr-defined]
 
-    def and_(self, other) -> SymNode:
+    def and_(self, other: SymNode) -> SymNode:
         return self._and_(other)  # type: ignore[attr-defined]
 
-    def or_(self, other) -> SymNode:
+    def or_(self, other: SymNode) -> SymNode:
         return self._or_(other)  # type: ignore[attr-defined]
 
-    def float_truediv(self, other) -> SymNode:
+    def float_truediv(self, other: SymNode) -> SymNode:
         return self._float_truediv(other)  # type: ignore[attr-defined]
 
-    def int_truediv(self, other) -> SymNode:
+    def int_truediv(self, other: SymNode) -> SymNode:
         return self._int_truediv(other)  # type: ignore[attr-defined]
 
-    def int_floordiv(self, other) -> SymNode:
+    def int_floordiv(self, other: SymNode) -> SymNode:
         return self._int_floordiv(other)  # type: ignore[attr-defined]
 
-    def lshift(self, other) -> SymNode:
+    def lshift(self, other: SymNode) -> SymNode:
         return self._lshift(other)  # type: ignore[attr-defined]
 
-    def rshift(self, other) -> SymNode:
+    def rshift(self, other: SymNode) -> SymNode:
         return self._rshift(other)  # type: ignore[attr-defined]
 
     def sym_not(self) -> SymNode:  # noqa: F811
         return self._sym_not()  # type: ignore[attr-defined]
 
-    def eq(self, other) -> SymNode:
+    def eq(self, other: SymNode) -> SymNode:
         return self._eq(other)  # type: ignore[attr-defined]
 
-    def ne(self, other) -> SymNode:
+    def ne(self, other: SymNode) -> SymNode:
         return self._ne(other)  # type: ignore[attr-defined]
 
-    def gt(self, other) -> SymNode:
+    def gt(self, other: SymNode) -> SymNode:
         return self._gt(other)  # type: ignore[attr-defined]
 
-    def lt(self, other) -> SymNode:
+    def lt(self, other: SymNode) -> SymNode:
         return self._lt(other)  # type: ignore[attr-defined]
 
-    def le(self, other) -> SymNode:
+    def le(self, other: SymNode) -> SymNode:
         return self._le(other)  # type: ignore[attr-defined]
 
-    def ge(self, other) -> SymNode:
+    def ge(self, other: SymNode) -> SymNode:
         return self._ge(other)  # type: ignore[attr-defined]
 
     def floor(self) -> SymNode:
@@ -408,74 +426,86 @@ class SymNode:
     def neg(self) -> SymNode:
         return self._neg()  # type: ignore[attr-defined]
 
-    def sym_min(self, other) -> SymNode:  # noqa: F811
+    def sym_min(self, other: SymNode) -> SymNode:  # noqa: F811
         return self._sym_min(other)  # type: ignore[attr-defined]
 
-    def sym_max(self, other) -> SymNode:  # noqa: F811
+    def sym_max(self, other: SymNode) -> SymNode:  # noqa: F811
         return self._sym_max(other)  # type: ignore[attr-defined]
 
-    def sym_ite(self, then_val, else_val) -> SymNode:
+    def sym_ite(self, then_val: SymNode, else_val: SymNode) -> SymNode:
         return self._sym_ite(then_val, else_val)  # type: ignore[attr-defined]
 
-    def is_contiguous(self, sizes, strides) -> SymNode:
+    def is_contiguous(self, sizes: list[SymNode], strides: list[SymNode]) -> SymNode:
         return self._is_contiguous(sizes, strides)  # type: ignore[attr-defined]
 
-    def is_channels_last_contiguous_2d(self, sizes, strides) -> SymNode:
+    def is_channels_last_contiguous_2d(
+        self, sizes: list[SymNode], strides: list[SymNode]
+    ) -> SymNode:
         return self._is_channels_last_contiguous_2d(sizes, strides)  # type: ignore[attr-defined]
 
-    def is_channels_last_contiguous_3d(self, sizes, strides) -> SymNode:
+    def is_channels_last_contiguous_3d(
+        self, sizes: list[SymNode], strides: list[SymNode]
+    ) -> SymNode:
         return self._is_channels_last_contiguous_3d(sizes, strides)  # type: ignore[attr-defined]
 
-    def is_channels_last_strides_2d(self, sizes, strides) -> SymNode:
+    def is_channels_last_strides_2d(
+        self, sizes: list[SymNode], strides: list[SymNode]
+    ) -> SymNode:
         return self._is_channels_last_strides_2d(sizes, strides)  # type: ignore[attr-defined]
 
-    def is_channels_last_strides_3d(self, sizes, strides) -> SymNode:
+    def is_channels_last_strides_3d(
+        self, sizes: list[SymNode], strides: list[SymNode]
+    ) -> SymNode:
         return self._is_channels_last_strides_3d(sizes, strides)  # type: ignore[attr-defined]
 
-    def is_non_overlapping_and_dense_indicator(self, sizes, strides) -> SymNode:
+    def is_non_overlapping_and_dense_indicator(
+        self, sizes: list[SymNode], strides: list[SymNode]
+    ) -> SymNode:
         return self._is_non_overlapping_and_dense_indicator(sizes, strides)  # type: ignore[attr-defined]
 
     # Make C++ happy
-    def sym_or(self, other):
+    def sym_or(self, other: SymNode) -> SymNode:
         return self.or_(other)
 
-    def sym_and(self, other):
+    def sym_and(self, other: SymNode) -> SymNode:
         return self.and_(other)
 
     # Integer bitwise ops
-    def bitwise_and(self, other):
+    def bitwise_and(self, other: SymNode) -> SymNode:
         return self._bitwise_and(other)  # type: ignore[attr-defined]
 
-    def bitwise_or(self, other):
+    def bitwise_or(self, other: SymNode) -> SymNode:
         return self._bitwise_or(other)  # type: ignore[attr-defined]
 
-    def bitwise_xor(self, other):
+    def bitwise_xor(self, other: SymNode) -> SymNode:
         return self._bitwise_xor(other)  # type: ignore[attr-defined]
 
     # There is no int_truediv available from C++
-    def truediv(self, other):
+    def truediv(self, other: SymNode) -> SymNode:
         return self.float_truediv(other)
 
-    def floordiv(self, other) -> SymNode:
+    def floordiv(self, other: SymNode) -> SymNode:
         return self.int_floordiv(other)
 
     # We didn't bind integer pow in C++
-    def pow(self, other):
+    def pow(self, other: SymNode) -> SymNode:
         return self.float_pow(other)
 
-    def is_non_overlapping_and_dense(self, sizes, strides):
+    def is_non_overlapping_and_dense(
+        self, sizes: list[SymNode], strides: list[SymNode]
+    ) -> SymNode:
         return self.is_non_overlapping_and_dense_indicator(sizes, strides).eq(
             to_node(self, 1)
         )  # type: ignore[attr-defined]
 
-    def int_(self):
+    def int_(self) -> int:
         return self.guard_int("", 0)  # NB: uses Python backtrace
 
     # This one is currently done by hand, but if we add other variadic
     # functions consider factoring it out to be metaprogrammed too.  Note that
     # some load bearing logic is directly in torch.sym_sum
 
-    def sym_sum(self, args) -> SymNode:
+    def sym_sum(self, args: list[SymNode]) -> SymNode:
         import sympy
 
         # Inner impl
@@ -503,8 +533,10 @@ class SymNode:
                 break
             size_hints.append(a.hint)
         else:
-            out_hint = sum(size_hints)
+            out_hint = sum(size_hints)  # pyrefly: ignore[no-matching-overload]
 
+        if self.shape_env is None:
+            raise RuntimeError("shape_env is required for sym_sum")
         fx_node, _ = self.shape_env._create_fx_call_function(
             torch.sym_sum, (tuple(a.fx_node for a in args),)
         )
@@ -512,11 +544,13 @@ class SymNode:
         # NB: Only for integers!
         return SymNode(out, self.shape_env, int, out_hint, fx_node=fx_node)
 
-    def evaluate(self, size_oblivious=False):
+    def evaluate(self, size_oblivious: bool = False) -> bool | int | float:
+        if self.shape_env is None:
+            raise RuntimeError("shape_env is required to evaluate")
         return self.shape_env.evaluate_sym_node(self, size_oblivious)
 
     # You can manually trigger a guard with this function
-    def guard_int(self, file, line):
+    def guard_int(self, file: builtins.str, line: int) -> int:
         # TODO: use the file/line for some useful diagnostic on why a
         # guard occurred
         r = self.evaluate()
@@ -526,7 +560,7 @@ class SymNode:
             log.warning("Failed to convert to int: %s", r)
             raise
 
-    def guard_float(self, file, line):
+    def guard_float(self, file: builtins.str, line: int) -> float:
         # TODO: use the file/line for some useful diagnostic on why a
         # guard occurred
         r = self.evaluate()
@@ -536,7 +570,7 @@ class SymNode:
             log.warning("Failed to convert to float: %s", r)
             raise
 
-    def guard_bool(self, file, line):
+    def guard_bool(self, file: builtins.str, line: int) -> bool:
         # TODO: use the file/line for some useful diagnostic on why a
         # guard occurred
         r = self.evaluate()
@@ -546,9 +580,11 @@ class SymNode:
             log.warning("Failed to convert to bool: %s", r)
             raise
 
-    def expect_true(self, file, line):
+    def expect_true(self, file: builtins.str, line: int) -> bool:
         from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 
+        if self.shape_env is None:
+            raise RuntimeError("shape_env is required for expect_true")
         if (
             self.has_hint()
             and not free_unbacked_symbols(self.expr)
@@ -564,14 +600,14 @@ class SymNode:
             self.expr, f"{file}:{line}", fx_node=self.fx_node
         )
 
-    def statically_known_true(self, file, line):
+    def statically_known_true(self, file: builtins.str, line: int) -> bool:
         from torch.fx.experimental.symbolic_shapes import statically_known_true
 
         if not self.is_bool():
             raise AssertionError("Expected bool type")
         return statically_known_true(SymBool(self))
 
-    def guard_size_oblivious(self, file, line):
+    def guard_size_oblivious(self, file: builtins.str, line: int) -> bool:
         """
         Like guard_bool, but if we encounter unbacked symbols, if those symbols
         are size-like, we will treat them as >= 2 for the purposes of the analysis.
@@ -591,35 +627,35 @@ class SymNode:
             log.warning("Failed to convert to bool: %s", r)
             raise
 
-    def guard_or_false(self, file, line):
+    def guard_or_false(self, file: builtins.str, line: int) -> bool:
         from torch.fx.experimental.symbolic_shapes import guard_or_false
 
         if not self.is_bool():
             raise AssertionError("Expected bool type")
         return guard_or_false(SymBool(self))
 
-    def guard_or_true(self, file, line):
+    def guard_or_true(self, file: builtins.str, line: int) -> bool:
         from torch.fx.experimental.symbolic_shapes import guard_or_true
 
         if not self.is_bool():
             raise AssertionError("Expected bool type")
         return guard_or_true(SymBool(self))
 
-    def bool_(self):
+    def bool_(self) -> bool:
         return self.guard_bool("", 0)
 
-    def is_symbolic(self):
+    def is_symbolic(self) -> bool:
         return True
 
-    def nested_int(self):
+    def nested_int(self) -> None:
         return None
 
-    def is_constant(self):
+    def is_constant(self) -> bool:
         return False
 
 
 class _DynamicScalar:
-    def __new__(cls, *args):
+    def __new__(cls, *args: object) -> Self:
         if cls is _DynamicScalar:
             raise TypeError("_DynamicScalar is an abstract base class, use DynamicInt.")
         return super().__new__(cls, *args)
@@ -637,19 +673,21 @@ class DynamicInt(_DynamicScalar, int):
         fn(x)  # compiles x as a dynamic integer input; returns f(4)
     """
 
-    def __new__(cls, val):
+    def __new__(cls, val: int) -> Self:
         if not isinstance(val, int):
             raise AssertionError(f"Expected int, got {type(val)}")
         obj = super().__new__(cls, int(val))
         return obj
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"DynamicInt({self.real})"
 
-    def __floordiv__(self, other):  # // was casting to int without these overrides?
+    def __floordiv__(
+        self, other: int
+    ) -> DynamicInt:  # // was casting to int without these overrides?
         return DynamicInt(self.real // other)
 
-    def __rfloordiv__(self, other):
+    def __rfloordiv__(self, other: int) -> DynamicInt:
         return DynamicInt(other // self.real)
 
 
@@ -706,8 +744,8 @@ unary_magic_methods = {
 
 
 # Adding math ops: sqrt, cos, sin, ...
-def _get_sym_node_fn(name):
-    def fn(self):
+def _get_sym_node_fn(name: str) -> Callable[[SymNode], SymNode]:
+    def fn(self: SymNode) -> SymNode:
         return getattr(self, f"_sym_{name}")()
 
     return fn
@@ -786,25 +824,25 @@ always_bool_magic_methods = {
 # Methods that have a `__foo__` as well as `__rfoo__`
 
 
-def _sympy_float_truediv(a, b):
+def _sympy_float_truediv(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import FloatTrueDiv
 
     return FloatTrueDiv(a, b)
 
 
-def _sympy_int_truediv(a, b):
+def _sympy_int_truediv(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import IntTrueDiv
 
     return IntTrueDiv(a, b)
 
 
-def _sympy_floordiv(a, b):
+def _sympy_floordiv(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import FloorDiv
 
     return FloorDiv(a, b)
 
 
-def _sympy_mod(a, b):
+def _sympy_mod(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import Mod, PythonMod
 
     if a.is_nonnegative and b.is_nonnegative:
@@ -813,43 +851,45 @@ def _sympy_mod(a, b):
         return PythonMod(a, b)
 
 
-def _sympy_pow_by_natural(a, b):
+def _sympy_pow_by_natural(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import PowByNatural
 
     return PowByNatural(a, b)
 
 
-def _sympy_float_pow(a, b):
+def _sympy_float_pow(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import FloatPow
 
     return FloatPow(a, b)
 
 
-def _sympy_and(a, b):
+def _sympy_and(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     import sympy
 
     return sympy.And(a, b)
 
 
-def _sympy_or(a, b):
+def _sympy_or(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     import sympy
 
     return sympy.Or(a, b)
 
 
-def _sympy_lshift(a, b):
+def _sympy_lshift(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import LShift
 
     return LShift(a, b)
 
 
-def _sympy_rshift(a, b):
+def _sympy_rshift(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import RShift
 
     return RShift(a, b)
 
 
-def _binary_search_insert_arg(ordered_args, new_arg):
+def _binary_search_insert_arg(
+    ordered_args: list[sympy.Basic], new_arg: sympy.Basic
+) -> list[sympy.Basic] | None:
     """
     If new_arg is found in ordered_args None is returned, else the new
     ordered_args with new_arg inserted
@@ -884,8 +924,11 @@ def _binary_search_insert_arg(ordered_args, new_arg):
 
 
 def _optimized_add(
-    lhs, rhs, lhs_is_optimized_summation=False, rhs_is_optimized_summation=False
-):
+    lhs: sympy.Basic,
+    rhs: sympy.Basic,
+    lhs_is_optimized_summation: bool = False,
+    rhs_is_optimized_summation: bool = False,
+) -> tuple[bool, sympy.Basic]:
     """
     Custom optimization for Add used to optimize incremental binary summations of certain properties. The idea
     is when we know the expression is a summation of unique symbols all we need to know is the correct order of symbols,
@@ -899,7 +942,7 @@ def _optimized_add(
     import sympy
     from sympy.core.basic import _args_sortkey as sortkey
 
-    def make_optimized(ordered_args):
+    def make_optimized(ordered_args: list[sympy.Basic]) -> tuple[bool, sympy.Basic]:
         if ordered_args is None:
             raise AssertionError("ordered_args is None")
         # Use _from_args directly to bypass _exec_constructor_postprocessors
@@ -951,19 +994,19 @@ def _optimized_add(
     return (_is_symbols_binary_summation(result), result)
 
 
-def _bitwise_and(a, b):
+def _bitwise_and(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import BitwiseFn_bitwise_and
 
     return BitwiseFn_bitwise_and(a, b)
 
 
-def _bitwise_or(a, b):
+def _bitwise_or(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import BitwiseFn_bitwise_or
 
     return BitwiseFn_bitwise_or(a, b)
 
 
-def _bitwise_xor(a, b):
+def _bitwise_xor(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import BitwiseFn_bitwise_xor
 
     return BitwiseFn_bitwise_xor(a, b)
@@ -989,7 +1032,7 @@ reflectable_magic_methods = {
 }
 
 
-def _floor_ceil_helper(a, fn):
+def _floor_ceil_helper(a: sympy.Basic, fn: Callable[..., sympy.Basic]) -> sympy.Basic:
     import sympy
 
     if isinstance(a, sympy.Mul):
@@ -1007,7 +1050,7 @@ def _floor_ceil_helper(a, fn):
     return fn(a)
 
 
-def _sympy_floor(a):
+def _sympy_floor(a: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import FloorToInt
 
     return FloorToInt(a)
@@ -1015,67 +1058,67 @@ def _sympy_floor(a):
 
 # NB: this is Python trunc semantics which returns an int.  Do NOT use this to
 # represent torch.trunc (which is float to float)
-def _sympy_trunc(a):
+def _sympy_trunc(a: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import TruncToInt
 
     return TruncToInt(a)
 
 
-def _sympy_ceil(a):
+def _sympy_ceil(a: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import CeilToInt
 
     return CeilToInt(a)
 
 
-def _sympy_eq(a, b):
+def _sympy_eq(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     import sympy
 
     return sympy.Eq(a, b)
 
 
-def _sympy_ne(a, b):
+def _sympy_ne(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     import sympy
 
     return sympy.Ne(a, b)
 
 
-def _sympy_gt(a, b):
+def _sympy_gt(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     import sympy
 
     return sympy.Gt(a, b)
 
 
-def _sympy_lt(a, b):
+def _sympy_lt(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     import sympy
 
     return sympy.Lt(a, b)
 
 
-def _sympy_le(a, b):
+def _sympy_le(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     import sympy
 
     return sympy.Le(a, b)
 
 
-def _sympy_ge(a, b):
+def _sympy_ge(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     import sympy
 
     return sympy.Ge(a, b)
 
 
-def _sympy_min(a, b):
+def _sympy_min(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import Min
 
     return Min(a, b)
 
 
-def _sympy_max(a, b):
+def _sympy_max(a: sympy.Basic, b: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import Max
 
     return Max(a, b)
 
 
-def _sympy_ite(a, t, f):
+def _sympy_ite(a: sympy.Basic, t: sympy.Basic, f: sympy.Basic) -> sympy.Basic:
     import sympy
 
     return sympy.Piecewise((t, a), (f, True))
@@ -1084,8 +1127,8 @@ def _sympy_ite(a, t, f):
 current_module = sys.modules[__name__]
 
 
-def _get_sym_math_fn(name):
-    def fn(a):
+def _get_sym_math_fn(name: str) -> Callable[[sympy.Basic], sympy.Basic]:
+    def fn(a: sympy.Basic) -> sympy.Basic:
         import torch.utils._sympy.functions
 
         return getattr(torch.utils._sympy.functions, f"OpaqueUnaryFn_{name}")(a)
@@ -1102,13 +1145,15 @@ for name in math_op_names:
 del fn, name, priv_sympy_name  # type: ignore[possibly-undefined]
 
 
-def _sympy_abs(a):
+def _sympy_abs(a: sympy.Basic) -> sympy.Basic:
     import sympy
 
     return sympy.Abs(a)
 
 
-def _sympy_round(number, ndigits=None):
+def _sympy_round(
+    number: sympy.Basic, ndigits: sympy.Basic | None = None
+) -> sympy.Basic:
     from torch.utils._sympy.functions import RoundDecimal, RoundToInt
 
     if ndigits is None:
@@ -1117,7 +1162,7 @@ def _sympy_round(number, ndigits=None):
         return RoundDecimal(number, ndigits)
 
 
-def _sympy_sym_float(a):
+def _sympy_sym_float(a: sympy.Basic) -> sympy.Basic:
     from torch.utils._sympy.functions import ToFloat
 
     # NB: Cannot use a * 1.0 here, because 0 * 1.0 is 0 which incorrectly
@@ -1125,7 +1170,7 @@ def _sympy_sym_float(a):
     return ToFloat(a)
 
 
-def _sympy_is_integer(a):
+def _sympy_is_integer(a: sympy.Basic) -> sympy.Basic:
     import sympy
 
     from torch.utils._sympy.functions import ToFloat
@@ -1164,12 +1209,16 @@ for name in math_op_names:
 del name, sym_name, math_op_names, current_module  # type: ignore[possibly-undefined]
 
 
-def sympy_is_contiguous(sizes, strides):
+def sympy_is_contiguous(
+    sizes: list[sympy.Basic], strides: list[sympy.Basic]
+) -> sympy.Basic:
     dim = len(sizes)
     return sympy_is_contiguous_generic(sizes, strides, list(range(dim - 1, -1, -1)))
 
 
-def sympy_is_contiguous_generic(sizes, strides, dim_order):
+def sympy_is_contiguous_generic(
+    sizes: list[sympy.Basic], strides: list[sympy.Basic], dim_order: list[int]
+) -> sympy.Basic:
     import sympy
 
     dim = len(sizes)
@@ -1193,15 +1242,21 @@ def sympy_is_contiguous_generic(sizes, strides, dim_order):
 # happens you will need to refactor this
 
 
-def sympy_is_channels_last_contiguous_2d(sizes, strides):
+def sympy_is_channels_last_contiguous_2d(
+    sizes: list[sympy.Basic], strides: list[sympy.Basic]
+) -> sympy.Basic:
     return sympy_is_contiguous_generic(sizes, strides, [1, 3, 2, 0])
 
 
-def sympy_is_channels_last_contiguous_3d(sizes, strides):
+def sympy_is_channels_last_contiguous_3d(
+    sizes: list[sympy.Basic], strides: list[sympy.Basic]
+) -> sympy.Basic:
     return sympy_is_contiguous_generic(sizes, strides, [1, 4, 3, 2, 0])
 
 
-def sympy_is_channels_last_strides_generic(sizes, strides, dim_order):
+def sympy_is_channels_last_strides_generic(
+    sizes: list[sympy.Basic], strides: list[sympy.Basic], dim_order: list[int]
+) -> sympy.Basic:
     import sympy
 
     from torch.utils._sympy.functions import Max
@@ -1241,15 +1296,21 @@ def sympy_is_channels_last_strides_generic(sizes, strides, dim_order):
     return r
 
 
-def sympy_is_channels_last_strides_2d(sizes, strides):
+def sympy_is_channels_last_strides_2d(
+    sizes: list[sympy.Basic], strides: list[sympy.Basic]
+) -> sympy.Basic:
     return sympy_is_channels_last_strides_generic(sizes, strides, [1, 3, 2, 0])
 
 
-def sympy_is_channels_last_strides_3d(sizes, strides):
+def sympy_is_channels_last_strides_3d(
+    sizes: list[sympy.Basic], strides: list[sympy.Basic]
+) -> sympy.Basic:
     return sympy_is_channels_last_strides_generic(sizes, strides, [1, 4, 3, 2, 0])
 
 
-def _sympy_is_non_overlapping_and_dense_indicator(sizes, strides):
+def _sympy_is_non_overlapping_and_dense_indicator(
+    sizes: list[sympy.Basic], strides: list[sympy.Basic]
+) -> sympy.Basic:
     from torch.utils._sympy.functions import IsNonOverlappingAndDenseIndicator
 
     return IsNonOverlappingAndDenseIndicator(*sizes, *strides)
@@ -1267,7 +1328,7 @@ sizes_strides_methods = {
 }
 
 
-def to_node(self, num):
+def to_node(self: SymNode, num: object) -> SymNode:
     if isinstance(num, SymTypes):
         return num.node
     elif type(num) is bool:
@@ -1282,7 +1343,7 @@ def to_node(self, num):
         return NotImplemented
 
 
-def wrap_node(x):
+def wrap_node(x: SymNode) -> SymInt | SymFloat | SymBool | int | float | bool:
     # TODO: let C++ also take advantage of this
     if isinstance(x, SymNode) and x.constant is not None:
         return x.constant
@@ -1296,11 +1357,11 @@ def wrap_node(x):
         raise AssertionError(f"unrecognized return type {x}")
 
 
-def method_to_operator(method):
+def method_to_operator(method: str) -> Callable[..., object]:
     return METHOD_TO_OPERATOR[method]
 
 
-def _make_node_magic(method, func):
+def _make_node_magic(method: str, func: Callable[..., sympy.Basic]) -> None:
     func = lru_cache(256)(func)
 
     if method in magic_methods_on_operator_with_trailing_underscore:
@@ -1325,9 +1386,9 @@ def _make_node_magic(method, func):
             | {"<string>"}
         )
 
-    def capture_provenance(fn):
+    def capture_provenance(fn: Callable[..., SymNode]) -> Callable[..., SymNode]:
         @functools.wraps(fn)
-        def wrapper(self, other=None):
+        def wrapper(self: SymNode, other: SymNode | None = None) -> SymNode:
             if other is None:
                 result = fn(self)
             else:
@@ -1338,7 +1399,7 @@ def _make_node_magic(method, func):
                 else:
                     arguments = [self]
 
-                def get_id(sym_node) -> int | None:
+                def get_id(sym_node: SymNode) -> int | None:
                     # We don't want to return an ID if the input is a constant
                     import sympy
 
@@ -1372,7 +1433,7 @@ def _make_node_magic(method, func):
         return wrapper
 
     @capture_provenance
-    def binary_magic_impl(self, other):
+    def binary_magic_impl(self: SymNode, other: SymNode) -> SymNode:
         from torch.fx.experimental.proxy_tensor import (
             get_proxy_mode,
             handle_sym_dispatch,
@@ -1398,6 +1459,8 @@ def _make_node_magic(method, func):
                 # Special handling for mod that requires access to the value
                 # ranges
                 shape_env = self.shape_env
+                if shape_env is None:
+                    raise AssertionError("shape_env is required for mod")
                 if (
                     self.expr.is_nonnegative
                     or shape_env.bound_sympy(self.expr).lower >= 0
@@ -1481,6 +1544,8 @@ def _make_node_magic(method, func):
 
         # Create a FX node that corresponds to the operation being applied to
         # this node.
+        if self.shape_env is None:
+            raise RuntimeError("shape_env is required for binary op")
         fx_node, _ = self.shape_env._create_fx_call_function(
             op, (self.fx_node, other.fx_node)
         )
@@ -1496,7 +1561,7 @@ def _make_node_magic(method, func):
         return result
 
     @capture_provenance
-    def unary_magic_impl(self):
+    def unary_magic_impl(self: SymNode) -> SymNode:
         from torch.fx.experimental.proxy_tensor import (
             get_proxy_mode,
             handle_sym_dispatch,
@@ -1507,6 +1572,8 @@ def _make_node_magic(method, func):
             return to_node(self, handle_sym_dispatch(op, (wrap_node(self),), {}))
         # TODO: consider constant prop here
         expr = self.expr
+        if self.shape_env is None:
+            raise RuntimeError("shape_env is required for unary op")
         if method == "floor" or method == "ceiling":
             expr = self.shape_env._simplify_floor_div(expr)
 
@@ -1536,7 +1603,9 @@ def _make_node_magic(method, func):
         setattr(SymNode, f"_{method_attr}", unary_magic_impl)
     elif method == "sym_ite":
 
-        def sym_ite_impl(pred_node, then_node, else_node):
+        def sym_ite_impl(
+            pred_node: SymNode, then_node: SymNode, else_node: SymNode
+        ) -> SymNode:
             from torch.fx.experimental.proxy_tensor import (
                 get_proxy_mode,
                 handle_sym_dispatch,
@@ -1574,6 +1643,8 @@ def _make_node_magic(method, func):
                 )
                 raise
 
+            if pred_node.shape_env is None:
+                raise RuntimeError("shape_env is required for sym_ite")
             fx_node, _ = pred_node.shape_env._create_fx_call_function(
                 sym_ite, (pred_node.fx_node, then_node.fx_node, else_node.fx_node)
             )
@@ -1584,7 +1655,7 @@ def _make_node_magic(method, func):
         setattr(SymNode, f"_{method_attr}", sym_ite_impl)
     elif method == "round":
 
-        def round_impl(self, ndigits=None):
+        def round_impl(self: SymNode, ndigits: int | None = None) -> SymNode:
             from torch.fx.experimental.proxy_tensor import (
                 get_proxy_mode,
                 handle_sym_dispatch,
@@ -1610,7 +1681,9 @@ def _make_node_magic(method, func):
 
             out_hint = None
             if self.hint is not None:
-                out_hint = op(self.hint, ndigits)
+                out_hint = op(  # pyrefly: ignore[no-matching-overload]
+                    self.hint, ndigits
+                )
 
             # Internally, None is used as sentinel to indicate that a something is not a node on an FX graph. At the
             # same time, there is no way to wrap a plain None into an FX node. Thus, there is no way to pass None here
@@ -1622,6 +1695,8 @@ def _make_node_magic(method, func):
             args = [self.fx_node]
             if ndigits is not None:
                 args.append(ndigits)
+            if self.shape_env is None:
+                raise RuntimeError("shape_env is required for round")
             fx_node, _ = self.shape_env._create_fx_call_function(op, tuple(args))
             return SymNode(out, self.shape_env, pytype, out_hint, fx_node=fx_node)
 
@@ -1630,10 +1705,12 @@ def _make_node_magic(method, func):
         setattr(SymNode, f"_{method_attr}", binary_magic_impl)
 
 
-def _make_node_sizes_strides(method, func):
+def _make_node_sizes_strides(method: str, func: Callable[..., sympy.Basic]) -> None:
     # NB: don't LRU cache, lots of arguments
 
-    def sizes_strides_impl(self, sizes, strides):
+    def sizes_strides_impl(
+        self: SymNode, sizes: list[SymNode], strides: list[SymNode]
+    ) -> SymNode:
         from torch.fx.experimental.proxy_tensor import (
             get_proxy_mode,
             handle_sym_dispatch,
@@ -1686,7 +1763,9 @@ def _make_node_sizes_strides(method, func):
     # TODO: This is technically hotpath, but in the ideal end state
     # guards on this will resolve at a higher level so you never
     # spend time in this code
-    def sizes_strides_user(sizes, strides):
+    def sizes_strides_user(
+        sizes: list[object], strides: list[object]
+    ) -> SymInt | SymFloat | SymBool | int | float | bool:
         import sympy
 
         from torch.fx.experimental.symbolic_shapes import (
@@ -1702,7 +1781,10 @@ def _make_node_sizes_strides(method, func):
                     )
                 )
         if method == "is_non_overlapping_and_dense_indicator":
-            return eval_is_non_overlapping_and_dense(sizes, strides)
+            return eval_is_non_overlapping_and_dense(
+                sizes,  # pyrefly: ignore[bad-argument-type]
+                strides,  # pyrefly: ignore[bad-argument-type]
+            )
         else:
             # TODO: this is an awful implementation
             return bool(
@@ -1724,7 +1806,7 @@ for method, func in sizes_strides_methods.items():
     _make_node_sizes_strides(method, func)
 
 
-def _make_user_magic(method, user_type):
+def _make_user_magic(method: str, user_type: type) -> None:
     # User magic takes care of wrapping the other operand into a node,
     # so that our internal logic can assume everything is nodes
     if method in magic_methods_on_operator_with_trailing_underscore:
@@ -1732,7 +1814,9 @@ def _make_user_magic(method, user_type):
     else:
         method_attr = method
 
-    def get_constant(x: SymInt | int | SymFloat | float | SymBool | bool):
+    def get_constant(
+        x: SymInt | int | SymFloat | float | SymBool | bool,
+    ) -> int | float | bool:
         if isinstance(x, (int, float, bool)):
             return x
         if isinstance(x, SymInt):
@@ -1741,7 +1825,7 @@ def _make_user_magic(method, user_type):
             return x.node.guard_bool("", 0)
         raise AssertionError("expect to be called with constant SymBools")
 
-    def is_constant(x):
+    def is_constant(x: SymInt | int | SymFloat | float | SymBool | bool) -> bool:
         if isinstance(x, (int, float, bool)):
             return True
         if isinstance(x, (SymInt, SymFloat, SymBool)):
@@ -1776,7 +1860,7 @@ def _make_user_magic(method, user_type):
 
     if method in bool_becomes_int_magic_methods:
 
-        def promote(x):
+        def promote(x: object) -> Any:
             """Implements True+True=2, which works in python but not sympy"""
             if isinstance(x, SymBool):
                 return SymInt(x.node.wrap_int(int(x)))
@@ -1784,10 +1868,10 @@ def _make_user_magic(method, user_type):
 
     else:
 
-        def promote(x):
+        def promote(x: object) -> Any:
             return x
 
-    def promote2(self, other):
+    def promote2(self: object, other: object) -> tuple[Any, Any]:
         # TODO: Remove eq and other relations from this list.
         # CPython has fancy implementations for these to get as much precision
         # as possible instead of just promoting to float64 and praying, so we
@@ -1829,13 +1913,13 @@ def _make_user_magic(method, user_type):
     # Alternatively, we could also rewrap into constant Symbool (i.e. by
     # implementing wrap_bool in ConstantSymNodeImpl), but we're not doing that
     # today for no particular reason.
-    def unary_magic_impl(self):
+    def unary_magic_impl(self: object) -> Any:
         self = promote(self)
         if is_constant(self):
             return (method_to_operator(method))(get_constant(self))
         return wrap_node(getattr(self.node, method_attr)())
 
-    def binary_magic_impl(self, other):
+    def binary_magic_impl(self: object, other: object) -> Any:
         if not isinstance(other, (int, float, bool, SymInt, SymFloat, SymBool)):
             return NotImplemented
         sym_node_log.debug("MAGIC %s %s %s", method, self, other)
@@ -1852,7 +1936,7 @@ def _make_user_magic(method, user_type):
         ret = wrap_node(getattr(self.node, method_attr)(other_node))
         return get_constant(ret) if is_constant(ret) else ret
 
-    def rbinary_magic_impl(self, other):
+    def rbinary_magic_impl(self: object, other: object) -> Any:
         if not isinstance(other, (int, float, bool, SymInt, SymFloat, SymBool)):
             return NotImplemented
         self = promote(self)
@@ -1868,7 +1952,7 @@ def _make_user_magic(method, user_type):
         ret = wrap_node(getattr(other_node, method_attr)(self.node))
         return get_constant(ret) if is_constant(ret) else ret
 
-    def setattrs(user_type, attr, symnode_impl):
+    def setattrs(user_type: type, attr: str, symnode_impl: object) -> None:
         """
         Registers the SymNode magic method on SymInt/Float/Bool,
         and optionally registers a corresponding wrapped method on DynamicInt.
@@ -1878,8 +1962,10 @@ def _make_user_magic(method, user_type):
         setattr(user_type, attr, symnode_impl)
 
         # DynamicInt impl
-        def dynamic_int_impl(*args):
-            args = [x.real if isinstance(x, DynamicInt) else x for x in args]
+        def dynamic_int_impl(*args: object) -> Any:
+            args = [  # pyrefly: ignore[bad-assignment]
+                x.real if isinstance(x, DynamicInt) else x for x in args
+            ]
             out = getattr(int, attr)(*args)
             if isinstance(out, int) and not isinstance(out, bool):
                 return DynamicInt(out)
@@ -1895,7 +1981,9 @@ def _make_user_magic(method, user_type):
         setattrs(user_type, method, update_wrapper(unary_magic_impl, orig))
     elif method == "sym_ite":
 
-        def sym_ite_magic_impl(pred, then_val, else_val):
+        def sym_ite_magic_impl(
+            pred: SymBool, then_val: object, else_val: object
+        ) -> Any:
             pred_node = pred.node
             then_node = to_node(pred_node, then_val)
             else_node = to_node(pred_node, else_val)
@@ -1910,12 +1998,17 @@ def _make_user_magic(method, user_type):
                     "then_node and else_node must be SymNodes with same pytype"
                 )
             ret = wrap_node(getattr(pred.node, method_attr)(then_node, else_node))
-            return get_constant(ret) if ret.node.is_constant() else ret
+            return (
+                get_constant(ret)
+                # pyrefly: ignore[missing-attribute]
+                if ret.node.is_constant()
+                else ret
+            )
 
         setattrs(user_type, f"__{method}__", sym_ite_magic_impl)
     elif method == "round":
 
-        def round_magic_impl(self, ndigits=None):
+        def round_magic_impl(self: SymFloat, ndigits: int | None = None) -> Any:
             if is_constant(self):
                 return builtins.round(get_constant(self), ndigits)
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -136,7 +136,9 @@ def guarding_hint_or_throw(
     """
     if isinstance(a, SymNode):
         if a._hint is not None:
-            return a._hint
+            return a._hint  # pyrefly: ignore[bad-return]
+        if a.shape_env is None:
+            raise AssertionError("shape_env is required for guarding_hint_or_throw")
         hint = a.shape_env.guarding_hint_or_throw(a.expr)
         a._hint = hint
         return hint
@@ -943,7 +945,7 @@ def _reduce_to_lowest_terms(expr: sympy.Expr) -> sympy.Expr:
     return expr
 
 
-def is_nested_int(s: IntLikeType) -> TypeGuard[SymInt]:
+def is_nested_int(s: IntLikeType | FloatLikeType) -> TypeGuard[SymInt]:
     return isinstance(s, torch.SymInt) and s.node.is_nested_int()
 
 
@@ -1142,7 +1144,7 @@ def find_symbol_binding_fx_nodes(
     Returns:
         A dictionary mapping from sympy Symbols to their binding FX nodes
     """
-    r = {}
+    r: dict[sympy.Symbol, torch.fx.Node] = {}
     # NB: Prefer first occurrence of symbol
     for node in graph.nodes:
         if (s := is_symbol_binding_fx_node(node)) is not None and s not in r:
@@ -1161,7 +1163,7 @@ class Specialization:
     """
 
     source: TensorPropertySource
-    check_fn: Callable
+    check_fn: Callable[[int], bool]
 
 
 # Analogous to ConvertIntSource
@@ -1256,7 +1258,7 @@ def _free_unbacked_symbols_with_path(
         pending = set()
     r = {}
 
-    def match_tensor(a: torch.Tensor, real_tensor: torch.Tensor | None = None):
+    def match_tensor(a: torch.Tensor, real_tensor: torch.Tensor | None = None) -> None:
         r.update(
             go(
                 a.size(),
@@ -1733,6 +1735,7 @@ def _advise_is_size(a: SymInt) -> None:
         isinstance(a, SymInt)
         and isinstance(a.node, SymNode)
         and isinstance(a.node.expr, sympy.Symbol)
+        and a.node.shape_env is not None
         and a.node.shape_env.is_unbacked_symint(a.node.expr)
     ):
         _constrain_range_for_size(a)
@@ -1743,6 +1746,7 @@ def _advise_is_bounded(a: SymInt, upper_bound: IntLikeType) -> None:
         isinstance(a, SymInt)
         and isinstance(a.node, SymNode)
         and isinstance(a.node.expr, sympy.Symbol)
+        and a.node.shape_env is not None
         and a.node.shape_env.is_unbacked_symint(a.node.expr)
         and isinstance(upper_bound, int)  # TODO: relax
     ):
@@ -2008,7 +2012,7 @@ class StrictMinMaxConstraint(Constraint):
     for N=0/1 too.
     """
 
-    vr: ValueRanges
+    vr: ValueRanges[sympy.Expr]
 
     def render(self, source: Source) -> str:
         """Format the constrain equation"""
@@ -2291,7 +2295,7 @@ class StatelessSymbolicContext(SymbolicContext, Generic[_P1, _T1]):
 # is used.
 # TODO(voz): Shape env validation
 @dataclass(frozen=True, slots=True, kw_only=True)
-class StatefulSymbolicContext(StatelessSymbolicContext):
+class StatefulSymbolicContext(StatelessSymbolicContext[..., Any]):
     """
     Create symbols in ``create_symbolic_sizes_strides_storage_offset`` via
     a symbolic_context determination as given by a cache of Source:Symbol. A cache hit
@@ -2380,7 +2384,8 @@ def _expandsums(args: list[sympy.Expr]) -> tuple[sympy.Expr, bool]:
         - A boolean indicating whether expansion occurred (True if multiple additive
           expressions were present or if there was at least one additive and one other expression)
     """
-    adds, other = [], []
+    adds: list[sympy.Expr] = []
+    other: list[sympy.Expr] = []
     for arg in args:
         if arg.is_Add:
             adds.append(arg)
@@ -2474,7 +2479,7 @@ def safe_expand(r: _SympyT) -> _SympyT:
 
 class _SymbolInfo(NamedTuple):
     k: sympy.Symbol
-    vr: ValueRanges | None
+    vr: ValueRanges[sympy.Expr] | None
     val: sympy.Integer | None
     is_size_like: bool
 
@@ -2952,7 +2957,7 @@ class _CppShapeGuardsHelper(_ShapeGuardsHelper):
 
 
 class LoggingShapeGuardPrinter(ShapeGuardPythonPrinter):
-    def __init__(self, var_to_sources: Mapping[sympy.Symbol, list[Source]]):
+    def __init__(self, var_to_sources: Mapping[sympy.Symbol, list[Source]]) -> None:
         super().__init__(var_to_sources, lambda n: n.name, var_to_sources)
 
 
@@ -2969,7 +2974,7 @@ class DynamicDimConstraintPrinter(PythonPrinter):
         self,
         symbol_to_source: dict[sympy.Symbol, list[Source]],
         source_name_to_debug_name: Mapping[str, str],
-    ):
+    ) -> None:
         super().__init__()
         self.symbol_to_source = symbol_to_source
         self.source_name_to_debug_name = source_name_to_debug_name
@@ -3210,7 +3215,7 @@ class DimConstraints:
     def _reduce_congruences(self) -> dict[sympy.Symbol, set[sympy.Expr]]:
         reduced_congruences: dict[sympy.Symbol, set[sympy.Expr]] = {}
         for s, congruences in self._congruences.items():
-            remainder_modulus_pairs = []
+            remainder_modulus_pairs: list[tuple[sympy.Integer, sympy.Integer]] = []
             congruences_to_check = set()
             for congruence in congruences:
                 base, divisor = congruence.args
@@ -3687,8 +3692,8 @@ class DimConstraints:
 
         self._process_derived_dim_roots(results, name_to_dim)
 
-        dims = []
-        others = []
+        dims: list[str] = []
+        others: list[str] = []
 
         # order results by source name
         results2 = {
@@ -3759,7 +3764,7 @@ class ValueRangesSLoc:
 
 
 @contextmanager
-def _suppress_guards(shape_env: ShapeEnv) -> Iterator[None]:
+def _suppress_guards(shape_env: ShapeEnv) -> Generator[None, None, None]:
     shape_env._suppress_guards_enter()
     try:
         yield
@@ -3922,7 +3927,7 @@ class ShapeEnv:
         # are conservative: the int MUST fall in the range, but the
         # range may contain ints which may not actually appear in
         # practice
-        self.var_to_range: dict[sympy.Symbol, ValueRanges] = {}
+        self.var_to_range: dict[sympy.Symbol, ValueRanges[sympy.Expr]] = {}
         self.var_to_range_sloc: dict[sympy.Symbol, ValueRangesSLoc] = {}
         self.source_name_to_debug_name: dict[str, str] = {}
         self.var_to_sources: dict[sympy.Symbol, list[Source]] = {}
@@ -3955,7 +3960,7 @@ class ShapeEnv:
         self.size_like: set[sympy.Symbol] = set()
         # Duck-shaping says that if two input tensors have the same size,
         # they get assigned the same symbolic variable
-        self.val_to_var: dict[int, sympy.Symbol] = {}
+        self.val_to_var: dict[IntLikeType | FloatLikeType, sympy.Symbol] = {}
         self.unbacked_symfloat_counter = 0
         self.unbacked_symint_counter = 0
         # Similar to guards, but these MUST evaluate to true and can
@@ -4046,7 +4051,9 @@ class ShapeEnv:
         #   2. list of arguments
         # This drastically reduces the size of the FX graph, avoiding
         # duplicated nodes.
-        self.fx_node_cache: dict[tuple[Callable, tuple[Any, ...]], torch.fx.Node] = {}
+        self.fx_node_cache: dict[
+            tuple[Callable[..., Any], tuple[Any, ...]], torch.fx.Node
+        ] = {}
         self.source_to_symbol: dict[str, sympy.Symbol] = {}
 
         # Suppose you want to replace an unbacked symbol with another
@@ -4143,7 +4150,7 @@ class ShapeEnv:
     @contextmanager
     def patch_source_specialization(
         self, source: Source, check_fn: Callable[[sympy.Symbol], sympy.Expr]
-    ) -> Iterator[None]:
+    ) -> Generator[None, None, None]:
         """
         Temporarily add symbol-level axioms to the ShapeEnv. This is useful when you want to "fork"
         and have parallel universes of ShapeEnvs. For example, we use this when doing multi-graph
@@ -4273,7 +4280,7 @@ class ShapeEnv:
         return len(self.events) - 1
 
     @contextmanager
-    def _recording(self) -> Iterator[None]:
+    def _recording(self) -> Generator[None, None, None]:
         self.is_recording = True
         try:
             yield
@@ -4285,7 +4292,9 @@ class ShapeEnv:
         self._set_replacement(orig_s, new_s, "eliminate_unbacked")
 
     @record_shapeenv_event()
-    def set_real_tensor_prop_unbacked_vals(self, k: sympy.Symbol, v: int) -> None:
+    def set_real_tensor_prop_unbacked_vals(
+        self, k: sympy.Symbol, v: int | float | torch.Tensor
+    ) -> None:
         """Used only when propagate_real_tensors; registers a value for an
         unbacked symbol, which can be used last resort to resolve hints."""
         log.info("set_real_tensor_prop_unbacked_vals %s = %s", k, v)
@@ -4411,7 +4420,7 @@ class ShapeEnv:
         return prev
 
     @contextmanager
-    def ignore_fresh_unbacked_symbols(self) -> Iterator[None]:
+    def ignore_fresh_unbacked_symbols(self) -> Generator[None, None, None]:
         """
         Indicates that the newly allocated unbacked SymInts are being
         discarded
@@ -4470,8 +4479,8 @@ class ShapeEnv:
     @record_shapeenv_event()
     def _create_fx_call_function(
         self,
-        op: Callable,
-        args: tuple,
+        op: Callable[..., object],
+        args: tuple[Any, ...],
     ) -> tuple[torch.fx.Node | None, bool]:
         # Cache this tuple in order to avoid duplicated nodes.
         node_key = (op, args)
@@ -4566,7 +4575,7 @@ class ShapeEnv:
         return _suppress_guards(self)
 
     @contextmanager
-    def error_on_new_guards(self) -> Iterator[None]:
+    def error_on_new_guards(self) -> Generator[None, None, None]:
         """Context manager that raises _ShapeEnvGuardError if a guard is attempted.
 
         Temporarily freezes the ShapeEnv and makes _check_frozen raise
@@ -4981,7 +4990,7 @@ class ShapeEnv:
         self,
         sym: sympy.Expr,
         *,
-        hint: int | None,
+        hint: int | float | bool | torch.SymInt | None,
         source: Source | None = None,
     ) -> IntLikeType:
         """Create a SymInt value from a symbolic expression
@@ -5027,7 +5036,7 @@ class ShapeEnv:
         self,
         sym: sympy.Expr,
         *,
-        hint: int | float | bool | None,
+        hint: int | float | bool | torch.SymInt | None,
         source: Source | None = None,
     ) -> FloatLikeType:
         """Create a SymFloat value from a symbolic expression"""
@@ -5100,7 +5109,7 @@ class ShapeEnv:
         self,
         prefix: str,
         symbol: sympy.Symbol,
-        vr: ValueRanges,
+        vr: ValueRanges[sympy.Expr],
         source: Source | None = None,
         sym_node: SymNode | None = None,
     ) -> None:
@@ -5224,7 +5233,7 @@ class ShapeEnv:
         source: Source,
         dynamic_dim: DimDynamic = DimDynamic.DUCK,
         constraint_dim: DimConstraint = None,  # NB: includes None
-        symbolic_context: StatelessSymbolicContext | None = None,
+        symbolic_context: SymbolicContext | None = None,
     ) -> sympy.Expr:
         """
         Create a symbol with an unspecified value
@@ -5250,13 +5259,13 @@ class ShapeEnv:
     @record_shapeenv_event()
     def create_symbol(
         self,
-        val: int,
+        val: IntLikeType | FloatLikeType,
         source: Source,
         dynamic_dim: DimDynamic = DimDynamic.DUCK,
         constraint_dim: DimConstraint = None,  # NB: includes None
         positive: bool | None = True,
         do_not_specialize_zero_one: bool = False,
-        symbolic_context: StatelessSymbolicContext | None = None,
+        symbolic_context: SymbolicContext | None = None,
     ) -> sympy.Expr:
         """Create a new symbol which is tracked by this ShapeEnv"""
         # check if constraint_dim is actually static integer
@@ -5270,7 +5279,7 @@ class ShapeEnv:
                     f"Static shape constraint of {constraint_dim.vr.lower} does not match input size of {val}, "
                     f"for {source.name}"
                 )
-            if symbolic_context:
+            if isinstance(symbolic_context, StatelessSymbolicContext):
                 from torch._dynamo.source import TensorPropertySource
 
                 if not isinstance(source, TensorPropertySource):
@@ -5677,7 +5686,9 @@ class ShapeEnv:
             raise AssertionError(f"len({placeholders}) != len({sources})")
         Tensorlike = (torch.Tensor, FakeTensorMeta)
 
-        def _create_no_constraints_context(t: Tensor) -> StatelessSymbolicContext:
+        def _create_no_constraints_context(
+            t: Tensor,
+        ) -> StatelessSymbolicContext[..., Any]:
             return StatelessSymbolicContext(
                 # Ignored; only the constraints part is relevant below.
                 dynamic_sizes=[DimDynamic.DYNAMIC] * t.dim(),
@@ -6297,7 +6308,7 @@ class ShapeEnv:
 
             if not sources:
                 raise AssertionError(f"sources must not be empty for symbol {symbol}")
-            bounds = []
+            bounds: list[sympy.Basic] = []
             rf = source_ref(sources[0])
             verbose_expr = ""
             if r.lower not in (-sympy.oo, -int_oo):
@@ -6688,7 +6699,7 @@ class ShapeEnv:
 
     def bound_sympy(
         self, expr: sympy.Expr, size_oblivious: bool = False
-    ) -> ValueRanges:
+    ) -> ValueRanges[sympy.Expr]:
         """Given a sympy expression, computes a ValueRanges bound for what values it can be"""
         # TODO: maybe it's guaranteed x in is var_to_range?
         var_to_range = {x: self.var_to_range.get(x, None) for x in expr.free_symbols}
@@ -6851,7 +6862,7 @@ class ShapeEnv:
         compute_hint: bool = False,
         size_oblivious: bool = False,
         axioms: tuple[SympyBoolean] | None = None,
-        var_to_range: tuple[tuple[sympy.Symbol, ValueRanges]] | None = None,
+        var_to_range: tuple[tuple[sympy.Symbol, ValueRanges[sympy.Expr]]] | None = None,
     ) -> sympy.Basic | None:
         """
         Tries to evaluate expr without introducing guards
@@ -6944,7 +6955,7 @@ class ShapeEnv:
         tracks only replacement changes) to cache calls to this method, so
         depending on other state would cause stale cache results.
         """
-        replacements = {}
+        replacements: dict[sympy.Basic, sympy.Basic] = {}
         # pyrefly: ignore [missing-attribute]
         for s in expr.free_symbols:
             r = self._find(s)
@@ -6980,7 +6991,7 @@ class ShapeEnv:
         # Simplify max(0/1, x) to x when x >= 0/1. max(1, x) is a commonly introduced
         # expression when creating contiguous strides.
         if not size_oblivious:
-            min_max_replacements = {}
+            min_max_replacements: dict[sympy.Basic, sympy.Basic] = {}
             for atom in expr.atoms(Max):  # type: ignore[has-type]
                 if len(atom.args) > 2:
                     continue
@@ -6996,7 +7007,7 @@ class ShapeEnv:
                 expr = expr.xreplace(min_max_replacements)
 
         if expr.has(TruncToInt):
-            trunc_replacements = {}
+            trunc_replacements: dict[sympy.Basic, sympy.Basic] = {}
             for atom in expr.atoms(TruncToInt):
                 if isinstance(atom.args[0], IntTrueDiv):
                     base, divisor = atom.args[0].args
@@ -7016,7 +7027,7 @@ class ShapeEnv:
         # for now just do a separate pass to catch common nested case
         if expr.has(FloorDiv):
             self._update_divisible()
-            div_replacements = {}
+            div_replacements: dict[sympy.Basic, sympy.Basic] = {}
             for atom in expr.atoms(FloorDiv):
                 base, divisor = atom.args
                 if isinstance(divisor, FloorDiv):
@@ -7031,7 +7042,7 @@ class ShapeEnv:
                 expr = expr.xreplace(div_replacements)
                 expr = safe_expand(expr)
         if expr.has(FloorDiv):
-            div_replacements = {}
+            div_replacements: dict[sympy.Basic, sympy.Basic] = {}
             pows = expr.atoms(sympy.Pow)
             rationals = expr.atoms(sympy.Rational).difference(expr.atoms(sympy.Integer))
             for fd in expr.atoms(FloorDiv):
@@ -7205,7 +7216,7 @@ class ShapeEnv:
     def _update_var_to_range(
         self,
         symbol: sympy.Symbol,
-        vr: ValueRanges,
+        vr: ValueRanges[sympy.Expr],
         vr_sloc: ValueRangesSLoc | None = None,
         *,
         is_constraint: bool = False,
@@ -7593,11 +7604,11 @@ class ShapeEnv:
     # See: Note - On 0/1 specialization
     def _default_value_range(
         self, do_not_specialize_zero_one: bool = False
-    ) -> ValueRanges:
+    ) -> ValueRanges[sympy.Expr]:
         lower = 0 if (do_not_specialize_zero_one or not self.specialize_zero_one) else 2
         return ValueRanges(lower, int_oo)
 
-    def _default_unspecified_value_range(self) -> ValueRanges:
+    def _default_unspecified_value_range(self) -> ValueRanges[sympy.Expr]:
         return ValueRanges.unknown_int()
 
     @_lru_cache
@@ -7848,8 +7859,8 @@ class ShapeEnv:
         self._expr_sym_node_id = id(sym_node)
         return self.evaluate_expr(
             sym_node.expr,
-            sym_node.hint,
-            sym_node.fx_node,
+            sym_node.hint,  # pyrefly: ignore[bad-argument-type]
+            sym_node.fx_node,  # pyrefly: ignore[bad-argument-type]
             size_oblivious,
             fallback_value=fallback_value,
         )
@@ -8696,6 +8707,8 @@ def _remove_effect_token_unbacked_bindings(
 # that we apply is unbacked renaming.
 def _get_placeholder_expr(sym_node: SymNode) -> sympy.Expr:
     shape_env = sym_node.shape_env
+    if shape_env is None:
+        raise AssertionError("shape_env is required for _get_placeholder_expr")
     result = sym_node._expr
     if result in shape_env.unbacked_renamings:
         return shape_env.unbacked_renamings[result]


### PR DESCRIPTION
… symbolic_shapes, sym_node

Remove mypy suppressions. Add return type, parameter type annotations, and parameterize Callable/nullcontext/ValueRanges types.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @xmfan @aditvenk