### PR TITLE
[dynamo] add some opaque object tests

### DIFF
--- a/test/dynamo/test_reconstruct.py
+++ b/test/dynamo/test_reconstruct.py
@@ -559,6 +559,61 @@ class ReconstructTest(torch._dynamo.test_case.TestCase):
                 opt_gn = torch.compile(gn, backend="eager", fullgraph=True)
                 opt_gn(torch.ones(3))
 
+    def test_opaque_reference_as_python_constant(self):
+        """TSOV.as_python_constant must succeed for reference-type opaque
+        objects. Without this, __eq__ between two opaque objects graph breaks.
+        """
+        import torch._library.opaque_object
+        import torch._opaque_base
+
+        class Config(torch._opaque_base.OpaqueBase):
+            def __init__(self, v):
+                self.v = v
+
+            def __bool__(self):
+                return True
+
+            def __eq__(self, other):
+                return isinstance(other, Config) and self.v == other.v
+
+            def __hash__(self):
+                return hash(self.v)
+
+        torch._library.opaque_object.register_opaque_type(Config, typ="reference")
+
+        cfg = Config(42)
+
+        def fn(x, cfg):
+            if cfg:
+                return x + 1
+            return x
+
+        opt = torch.compile(fn, backend="eager", fullgraph=True)
+        result = opt(torch.ones(4), cfg)
+        self.assertEqual(result, torch.ones(4) + 1)
+
+    def test_call_once_guard_allows_super_delegation(self):
+        """_add_call_once_guard must key on (id(self), id(original_method))
+        so that super().as_python_constant() between VT subclasses is not
+        mistaken for a self-referential call.
+        """
+        from torch._dynamo.variables.base import VariableTracker
+
+        class _Parent(VariableTracker):
+            def as_python_constant(self):
+                return 42
+
+        class _Child(_Parent):
+            def as_python_constant(self):
+                return super().as_python_constant()
+
+        child = _Child()
+        # With name-based keying, _Child and _Parent share the same key
+        # (id(self), "as_python_constant"), causing a false
+        # AsPythonConstantNotImplementedError("self-referential").
+        self.assertEqual(child.as_python_constant(), 42)
+        self.assertTrue(child.is_python_constant())
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179866

Add opaque object tests introduced in https://github.com/pytorch/pytorch/pull/177430 in order to guard against future opaque object bugs.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98