### PR TITLE
[cuda graphs] Add enable_annotations kwarg to torch.cuda.graph

### DIFF
--- a/test/test_cuda_graph_annotations.py
+++ b/test/test_cuda_graph_annotations.py
@@ -305,6 +305,65 @@ class TestMarkKernels(TestCase):
         # Re-enable for other tests
         enable_annotations()
 
+    def test_enable_annotations_kwarg(self):
+        """enable_annotations on torch.cuda.graph auto-resolves annotations."""
+        from torch.cuda._graph_annotations import disable_annotations
+
+        # Start with annotations disabled to verify the kwarg enables them.
+        disable_annotations()
+        clear_kernel_annotations()
+
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph, enable_annotations=True):
+            with mark_kernels("auto"):
+                _ = x + 1
+
+        annotations = get_kernel_annotations()
+        self.assertGreater(len(annotations), 0)
+        for anns in annotations.values():
+            for ann in anns:
+                self.assertEqual(ann, {"str": "auto"})
+
+    def test_enable_annotations_does_not_clear(self):
+        """Annotations from a previous graph survive a second capture."""
+        from torch.cuda._graph_annotations import disable_annotations
+
+        disable_annotations()
+        clear_kernel_annotations()
+
+        graph1 = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph1, enable_annotations=True):
+            with mark_kernels("first"):
+                _ = x + 1
+
+        first_count = len(get_kernel_annotations())
+        self.assertGreater(first_count, 0)
+
+        graph2 = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph2, enable_annotations=True):
+            with mark_kernels("second"):
+                _ = x * 2
+
+        # Both graphs' annotations should be present.
+        self.assertGreater(len(get_kernel_annotations()), first_count)
+
+    def test_enable_annotations_false_does_not_auto_resolve(self):
+        """Without enable_annotations, pending scopes are not resolved."""
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        # enable_annotations=False (default): no auto-resolve.
+        with torch.cuda.graph(graph):
+            with mark_kernels("unresolved"):
+                _ = x + 1
+
+        # Annotations should be empty because resolve was never called.
+        self.assertEqual(len(get_kernel_annotations()), 0)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_cuda_graph_annotations.py
+++ b/test/test_cuda_graph_annotations.py
@@ -351,6 +351,35 @@ class TestMarkKernels(TestCase):
         # Both graphs' annotations should be present.
         self.assertGreater(len(get_kernel_annotations()), first_count)
 
+    def test_enable_annotations_remaps_to_exec_graph(self):
+        """enable_annotations=True must remap toolsIds to the exec graph ID."""
+        from cuda.bindings import runtime as cuda_runtime
+
+        clear_kernel_annotations()
+
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph, enable_annotations=True):
+            with mark_kernels("remap_test"):
+                _ = x + 1
+
+        exec_handle = cuda_runtime.cudaGraphExec_t(
+            init_value=graph.raw_cuda_graph_exec()
+        )
+        _, exec_graph_id = cuda_runtime.cudaGraphExecGetId(exec_handle)
+
+        annotations = get_kernel_annotations()
+        self.assertGreater(len(annotations), 0)
+        for tools_id in annotations:
+            graph_id = tools_id >> 32
+            self.assertEqual(
+                graph_id,
+                exec_graph_id,
+                f"toolsId 0x{tools_id:016x} has graph_id {graph_id}, "
+                f"expected exec_graph_id {exec_graph_id}",
+            )
+
     def test_enable_annotations_false_does_not_auto_resolve(self):
         """Without enable_annotations, pending scopes are not resolved."""
         graph = torch.cuda.CUDAGraph()

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -160,6 +160,9 @@ _pending_scopes: list[tuple[Any, int, int]] = []
 # Graph handle saved during capture for post-capture resolution.
 _capture_graph: Any = None
 
+# Capture graph ID saved by resolve_pending_annotations for remap_to_exec_graph.
+_last_capture_graph_id: int | None = None
+
 
 @contextmanager  # type: ignore[arg-type]
 def mark_kernels(annotation: str | dict[str, Any]):
@@ -242,6 +245,13 @@ def resolve_pending_annotations() -> None:
                 graph, numNodes=num
             )
         )
+
+        # Save capture graph ID for remap_to_exec_graph.
+        global _last_capture_graph_id
+        if num > 0:
+            first_tid = _get_tools_id(nodes[0])
+            _last_capture_graph_id = (first_tid >> 32) if first_tid else None
+
         annotatable = _get_annotatable_types()
 
         # Sort by (start, -end, -append_index). The append index encodes
@@ -337,8 +347,17 @@ def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
         )
     )
 
+    # Only remap annotations from the most recent capture graph.
+    # Previously remapped annotations (from earlier captures) keep their
+    # correct exec graph IDs.
+    capture_graph_id = _last_capture_graph_id
     remapped: dict[int, list[Any]] = {}
     for tools_id, ann_list in _kernel_annotations.items():
+        graph_id = tools_id >> 32
+        if capture_graph_id is not None and graph_id != capture_graph_id:
+            # Belongs to a different graph — keep as-is.
+            remapped[tools_id] = ann_list
+            continue
         node_id = tools_id & 0xFFFFFFFF
         new_tools_id = (exec_graph_id << 32) | node_id
         if new_tools_id in remapped:

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -197,6 +197,11 @@ class graph:
             may be unsafe. "global" will error on actions in other threads, "thread_local" will only error for
             actions in the current thread, and "relaxed" will not error on actions. Do NOT change this setting
             unless you're familiar with `cudaStreamCaptureMode <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85>`_
+        enable_annotations (bool, optional): If ``True``, enables kernel annotation
+            recording on entry and automatically calls
+            :func:`~torch.cuda._graph_annotations.resolve_pending_annotations` before
+            the capture ends.  Annotations are **not** cleared on exit so that multiple
+            graphs in the same workload can accumulate annotations.
 
     .. note::
         For effective memory sharing, if you pass a ``pool`` used by a previous capture and the previous capture
@@ -217,6 +222,7 @@ class graph:
         pool: _POOL_HANDLE | None = None,
         stream: torch.cuda.Stream | None = None,
         capture_error_mode: str = "global",
+        enable_annotations: bool = False,
     ):
         # Lazy-init of default_capture_stream helps avoid circular-import errors.
         # Not thread safe, but graphs already have the general (explicitly documented)
@@ -233,6 +239,7 @@ class graph:
         self.stream_ctx = torch.cuda.stream(self.capture_stream)
         self.cuda_graph = cuda_graph
         self.capture_error_mode = capture_error_mode
+        self._enable_annotations = enable_annotations
 
     def __enter__(self) -> None:
         # Free as much memory as we can for the graph
@@ -250,6 +257,13 @@ class graph:
         # pyrefly: ignore [missing-attribute]
         torch._C._host_emptyCache()
 
+        if self._enable_annotations:
+            from torch.cuda._graph_annotations import (
+                enable_annotations as _enable_ann,
+            )
+
+            _enable_ann()
+
         # Stackoverflow seems comfortable with this pattern
         # https://stackoverflow.com/questions/26635684/calling-enter-and-exit-manually#39172487
         self.stream_ctx.__enter__()
@@ -262,6 +276,11 @@ class graph:
         )
 
     def __exit__(self, *args: object) -> None:
+        if self._enable_annotations:
+            from torch.cuda._graph_annotations import resolve_pending_annotations
+
+            resolve_pending_annotations()
+
         self.cuda_graph.capture_end()
         self.stream_ctx.__exit__(*args)
         # returning None should propagate exceptions from either capture_end or stream_ctx.__exit__()

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -202,6 +202,7 @@ class graph:
             :func:`~torch.cuda._graph_annotations.resolve_pending_annotations` before
             the capture ends.  Annotations are **not** cleared on exit so that multiple
             graphs in the same workload can accumulate annotations.
+            Requires ``cuda.bindings`` package and cuda-compat >= 13.1 or CUDA driver >= 13.1.
 
     .. note::
         For effective memory sharing, if you pass a ``pool`` used by a previous capture and the previous capture

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -259,9 +259,7 @@ class graph:
         torch._C._host_emptyCache()
 
         if self._enable_annotations:
-            from torch.cuda._graph_annotations import (
-                enable_annotations as _enable_ann,
-            )
+            from torch.cuda._graph_annotations import enable_annotations as _enable_ann
 
             _enable_ann()
 

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -284,6 +284,11 @@ class graph:
 
         self.cuda_graph.capture_end()
         self.stream_ctx.__exit__(*args)
+
+        if self._enable_annotations:
+            from torch.cuda._graph_annotations import remap_to_exec_graph
+
+            remap_to_exec_graph(self.cuda_graph)
         # returning None should propagate exceptions from either capture_end or stream_ctx.__exit__()
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179769
* __->__ #179867
* #179768

Extend the torch.cuda.graph context manager with an enable_annotations
keyword that enables kernel annotation recording on entry and
automatically calls resolve_pending_annotations() before the capture
ends. Annotations are not cleared on exit so multiple graphs in the
same workload can accumulate annotations.

Authored with Claude.