### PR TITLE
Add DynamicInt pow operation propagation

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -2046,6 +2046,13 @@ class TestSymNumberMagicMethods(TestCase):
         with self.assertRaises(ZeroDivisionError):
             y % x
 
+        # test pow operations preserve DynamicInt type
+        check(w**2, 1)  # DynamicInt ** int
+        check(2**z, 4)  # int ** DynamicInt
+        check(y**x, 1)  # DynamicInt ** DynamicInt
+        check(pow(z, 2), 4)  # pow(DynamicInt, int)
+        self.assertTrue(isinstance(pow(y, 3, 5), DynamicInt))  # pow with modulo
+
         # math, numpy
         self.assertEqual(math.cos(x), y)
         self.assertEqual(math.prod([z, z], start=z), 8)

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -652,6 +652,27 @@ class DynamicInt(_DynamicScalar, int):
     def __rfloordiv__(self, other):
         return DynamicInt(other // self.real)
 
+    def __pow__(self, other, modulo=None):
+        if modulo is not None:
+            result = pow(self.real, other, modulo)
+        else:
+            result = self.real**other
+        # Only create DynamicInt if result is int, otherwise return plain value
+        # (e.g., negative exponent produces float)
+        if isinstance(result, int):
+            return DynamicInt(result)
+        return result
+
+    def __rpow__(self, other, modulo=None):
+        if modulo is not None:
+            result = pow(other, self.real, modulo)
+        else:
+            result = other**self.real
+        # Only create DynamicInt if result is int, otherwise return plain value
+        if isinstance(result, int):
+            return DynamicInt(result)
+        return result
+
 
 # TODO: this probably needs the sizes-strides eval functions
 METHOD_TO_OPERATOR = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179868

Ensure DynamicInt instances preserve their type through power operations
by implementing __pow__ and __rpow__ methods. This ensures that expressions
like DynamicInt(2) ** 3 return DynamicInt(8) rather than plain int(8),
maintaining dynamism for torch.compile.

Added test coverage for:
- DynamicInt ** int
- int ** DynamicInt
- DynamicInt ** DynamicInt
- pow(DynamicInt, int)
- pow(DynamicInt, int, mod)

Fixes issue where power operations would strip DynamicInt wrapper,
potentially causing missed recompilations or incorrect guards.