### PR TITLE
Add multi-tensor fast path for p=0 norm

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -285,7 +285,8 @@ struct LpNormFunctor {
         for (int ii = 0; ii < kILP; ii++) {
           const auto next = static_cast<out_opmath_t>(r_x[ii]);
           if constexpr (norm_type == NormType::L0) {
-            vals[ii] += next != out_opmath_t(0) ? out_opmath_t(1) : out_opmath_t(0);
+            vals[ii] +=
+                next != out_opmath_t(0) ? out_opmath_t(1) : out_opmath_t(0);
           } else if constexpr (norm_type == NormType::LInf) {
             vals[ii] = max_propagate_nan(vals[ii], ::abs(next));
           } else {
@@ -302,7 +303,8 @@ struct LpNormFunctor {
           if (i < n && i < chunk_size) {
             const auto next = static_cast<out_opmath_t>(x[i]);
             if constexpr (norm_type == NormType::L0) {
-              vals[ii] += next != out_opmath_t(0) ? out_opmath_t(1) : out_opmath_t(0);
+              vals[ii] +=
+                  next != out_opmath_t(0) ? out_opmath_t(1) : out_opmath_t(0);
             } else if constexpr (norm_type == NormType::LInf) {
               vals[ii] = max_propagate_nan(vals[ii], ::abs(next));
             } else {
@@ -321,8 +323,8 @@ struct LpNormFunctor {
         val += vals[i];
       }
     }
-    auto final_val = norm_type == NormType::L0 ||
-            norm_type == NormType::L1 || norm_type == NormType::L2
+    auto final_val = norm_type == NormType::L0 || norm_type == NormType::L1 ||
+            norm_type == NormType::L2
         ? at::native::cuda_utils::BlockReduceSum(val, s_vals)
         : at::native::cuda_utils::BlockReduceMax(val, s_vals);
 

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -28,8 +28,8 @@
 
 namespace at::native {
 
-// _foreach_norm supports only L1, L2, and inf norm
-enum class NormType { L1, L2, LInf };
+// _foreach_norm supports L0, L1, L2, and inf norm
+enum class NormType { L0, L1, L2, LInf };
 
 // NOTE: This is a simple variant of TensorListMetadata in MultiTensorApply.cuh
 // as we only need to track addresses for the lpnorm_cleanup function below.
@@ -284,7 +284,9 @@ struct LpNormFunctor {
 #pragma unroll
         for (int ii = 0; ii < kILP; ii++) {
           const auto next = static_cast<out_opmath_t>(r_x[ii]);
-          if constexpr (norm_type == NormType::LInf) {
+          if constexpr (norm_type == NormType::L0) {
+            vals[ii] += next != out_opmath_t(0) ? out_opmath_t(1) : out_opmath_t(0);
+          } else if constexpr (norm_type == NormType::LInf) {
             vals[ii] = max_propagate_nan(vals[ii], ::abs(next));
           } else {
             vals[ii] += norm_type == NormType::L1 ? ::abs(next) : next * next;
@@ -299,7 +301,9 @@ struct LpNormFunctor {
           int i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             const auto next = static_cast<out_opmath_t>(x[i]);
-            if constexpr (norm_type == NormType::LInf) {
+            if constexpr (norm_type == NormType::L0) {
+              vals[ii] += next != out_opmath_t(0) ? out_opmath_t(1) : out_opmath_t(0);
+            } else if constexpr (norm_type == NormType::LInf) {
               vals[ii] = max_propagate_nan(vals[ii], ::abs(next));
             } else {
               vals[ii] += norm_type == NormType::L1 ? ::abs(next) : next * next;
@@ -317,7 +321,8 @@ struct LpNormFunctor {
         val += vals[i];
       }
     }
-    auto final_val = norm_type == NormType::L1 || norm_type == NormType::L2
+    auto final_val = norm_type == NormType::L0 ||
+            norm_type == NormType::L1 || norm_type == NormType::L2
         ? at::native::cuda_utils::BlockReduceSum(val, s_vals)
         : at::native::cuda_utils::BlockReduceMax(val, s_vals);
 
@@ -351,8 +356,8 @@ __global__ void lpnorm_cleanup(
       val += output_this_tensor[i];
     }
   }
-  out_opmath_t final_val =
-      norm_type == NormType::L1 || norm_type == NormType::L2
+  out_opmath_t final_val = norm_type == NormType::L0 ||
+          norm_type == NormType::L1 || norm_type == NormType::L2
       ? at::native::cuda_utils::BlockReduceSum<out_opmath_t>(val, vals)
       : at::native::cuda_utils::BlockReduceMax(val, vals);
   if (threadIdx.x == 0) {
@@ -479,7 +484,13 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
         AT_DISPATCH_OUT_DTYPES(
             output_dtype, ForeachNormDispatchName<apply_root>::value, [&]() {
               using out_opmath_t = typename at::opmath_type<out_t>;
-              if (p == static_cast<double>(1)) {
+              if (p == static_cast<double>(0)) {
+                multi_tensor_apply<1>(
+                    tensor_lists,
+                    LpNormFunctor<scalar_t, NormType::L0, out_t>(),
+                    output_per_tensor.template mutable_data_ptr<out_opmath_t>(),
+                    max_chunks_per_tensor);
+              } else if (p == static_cast<double>(1)) {
                 multi_tensor_apply<1>(
                     tensor_lists,
                     LpNormFunctor<scalar_t, NormType::L1, out_t>(),
@@ -522,7 +533,16 @@ std::vector<Tensor> foreach_tensor_norm_cuda_internal(
                           .template mutable_data_ptr<out_t>();
                 }
 
-                if (p == static_cast<double>(1)) {
+                if (p == static_cast<double>(0)) {
+                  lpnorm_cleanup<scalar_t, NormType::L0, out_t, apply_root>
+                      <<<num_tensors_this_kernel, 512, 0, stream>>>(
+                          output_per_tensor
+                                  .template const_data_ptr<out_opmath_t>() +
+                              i * MAX_TENSORS_PER_KERNEL *
+                                  max_chunks_per_tensor,
+                          addr_struct,
+                          max_chunks_per_tensor);
+                } else if (p == static_cast<double>(1)) {
                   lpnorm_cleanup<scalar_t, NormType::L1, out_t, apply_root>
                       <<<num_tensors_this_kernel, 512, 0, stream>>>(
                           output_per_tensor
@@ -616,7 +636,8 @@ std::vector<Tensor> foreach_tensor_norm_cuda(
         });
   }
   if (!can_use_fast_route(tensors) || has_int_or_complex ||
-      !(p == static_cast<double>(1) || p == static_cast<double>(2) ||
+      !(p == static_cast<double>(0) || p == static_cast<double>(1) ||
+        p == static_cast<double>(2) ||
         p == std::numeric_limits<double>::infinity())) {
     return foreach_tensor_norm_slow(tensors, ord, dtype);
   }

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1076,7 +1076,7 @@ class TestForeach(TestCase):
         import math
 
         if op.name == "_foreach_norm":
-            ords = [1, 2]
+            ords = [0, 1, 2]
             if not intersperse_empty_tensors:
                 # inf norm over an empty tensor is not defined by vector norm as it expects an identity
                 ords.append(math.inf)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9961,7 +9961,7 @@ class foreach_norm_sample_func(foreach_inputs_sample_func):
         for ord in (0, 1, 2, -1, -2, float('inf'), float('-inf')):
             input = sample_inputs_foreach(None, device, dtype, NUM_SIZE0_TENSORS, zero_size=True, **_foreach_inputs_kwargs)
             disable_fastpath = True
-            if ord in (1, 2, float('inf')) and dtype in floating_types_and(torch.half, torch.bfloat16):
+            if ord in (0, 1, 2, float('inf')) and dtype in floating_types_and(torch.half, torch.bfloat16):
                 disable_fastpath = False
             yield ForeachSampleInput(input, ord=ord, disable_fastpath=disable_fastpath)
 
@@ -9987,7 +9987,7 @@ class foreach_norm_sample_func(foreach_inputs_sample_func):
             _foreach_inputs_kwargs["intersperse_empty_tensors"] = intersperse_empty_tensors
             input = sample_inputs_foreach(None, device, dtype, num_tensors, zero_size=False, **_foreach_inputs_kwargs)
             disable_fastpath = True
-            if ord in (1, 2, float('inf')) and dtype in floating_types_and(torch.half, torch.bfloat16):
+            if ord in (0, 1, 2, float('inf')) and dtype in floating_types_and(torch.half, torch.bfloat16):
                 disable_fastpath = False
             yield ForeachSampleInput(input, ord=ord, disable_fastpath=disable_fastpath, dtype=out_dtype)
 
@@ -10004,7 +10004,7 @@ class foreach_norm_sample_func(foreach_inputs_sample_func):
             for input in nan_inputs:
                 x = torch.tensor(input, device=device)
                 disable_fastpath = True
-                if ord in (1, 2, float('inf')) and dtype in floating_types_and(torch.half, torch.bfloat16):
+                if ord in (0, 1, 2, float('inf')) and dtype in floating_types_and(torch.half, torch.bfloat16):
                     disable_fastpath = False
                 yield ForeachSampleInput([x], ord=ord, disable_fastpath=disable_fastpath)
 


### PR DESCRIPTION
The foreach norm CUDA kernel already has fast paths for p=1, p=2, and p=inf, but p=0 (count of nonzero elements) fell back to the slow per-tensor loop. This adds a NormType::L0 path that uses the same multi_tensor_apply infrastructure, counting nonzeros per element and reducing via BlockReduceSum.

