### PR TITLE
Use a PDL feature query in Inductor test gating

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -12,7 +12,7 @@ import torch
 import torch._inductor
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_cuda import SM90OrLater
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_PDL, SM90OrLater
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -1098,8 +1098,7 @@ class ComboKernelPDLTests(TestCase):
         super().tearDown()
 
     @requires_gpu_and_triton
-    @skipIfRocm
-    @unittest.skipIf(not SM90OrLater, "PDL requires SM90 or later (Hopper+)")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_PDL, "PDL requires NVIDIA sm90+")
     def test_pdl_codegen_in_combo_kernel(self):
         """Test that PDL flag and gdc calls are generated in combo kernels."""
 
@@ -1138,8 +1137,7 @@ class ComboKernelPDLTests(TestCase):
         )
 
     @requires_gpu_and_triton
-    @skipIfRocm
-    @unittest.skipIf(not SM90OrLater, "PDL requires SM90 or later (Hopper+)")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_PDL, "PDL requires NVIDIA sm90+")
     def test_pdl_combo_kernel_pointwise(self):
         """Test that pointwise combo kernels produce correct results with PDL."""
 
@@ -1181,8 +1179,7 @@ class ComboKernelPDLTests(TestCase):
         )
 
     @requires_gpu_and_triton
-    @skipIfRocm
-    @unittest.skipIf(not SM90OrLater, "PDL requires SM90 or later (Hopper+)")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_PDL, "PDL requires NVIDIA sm90+")
     def test_pdl_combo_kernel_reduction(self):
         """Test that reduction combo kernels produce correct results with PDL."""
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -74,6 +74,7 @@ from torch.testing._internal.common_cuda import (
     IS_SM90,
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+    PLATFORM_SUPPORTS_PDL,
     SM80OrLater,
     SM90OrLater,
     TEST_CUDNN,
@@ -16147,7 +16148,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertEqual(eager_result5, compiled_result5)
 
     @requires_cuda_and_triton
-    @skipCUDAIf(not SM90OrLater or TEST_WITH_ROCM, "PDL requires NVIDIA sm90+")
+    @skipCUDAIf(not PLATFORM_SUPPORTS_PDL, "PDL requires NVIDIA sm90+")
     @config.patch({"triton.enable_pdl": True})
     def test_pdl_mutation(self):
         def fn(a, b, c):
@@ -16178,7 +16179,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         ).run(code)
 
     @requires_cuda_and_triton
-    @skipCUDAIf(not SM90OrLater or TEST_WITH_ROCM, "PDL requires NVIDIA sm90+")
+    @skipCUDAIf(not PLATFORM_SUPPORTS_PDL, "PDL requires NVIDIA sm90+")
     @config.patch(
         {
             "triton.enable_pdl": True,

--- a/test/test_cuda_compatibility.py
+++ b/test/test_cuda_compatibility.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import torch
 import torch.cuda
+from torch.testing._internal.common_cuda import evaluate_platform_supports_pdl
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -152,6 +153,40 @@ class TestCheckCapability(TestCase):
                 "install a PyTorch release that supports one of these CUDA versions",
                 msg,
             )
+
+
+class TestCommonCudaFeatureQueries(TestCase):
+    @patch("torch.testing._internal.common_cuda.SM90OrLater", True)
+    def test_pdl_supports_cuda_sm90_or_later(self, *args):
+        with (
+            patch("torch.version.cuda", "12.6"),
+            patch("torch.version.hip", None),
+        ):
+            self.assertTrue(evaluate_platform_supports_pdl())
+
+    @patch("torch.testing._internal.common_cuda.SM90OrLater", False)
+    def test_pdl_rejects_cuda_before_sm90(self, *args):
+        with (
+            patch("torch.version.cuda", "12.6"),
+            patch("torch.version.hip", None),
+        ):
+            self.assertFalse(evaluate_platform_supports_pdl())
+
+    @patch("torch.testing._internal.common_cuda.SM90OrLater", True)
+    def test_pdl_rejects_rocm(self, *args):
+        with (
+            patch("torch.version.cuda", None),
+            patch("torch.version.hip", "6.4.0"),
+        ):
+            self.assertFalse(evaluate_platform_supports_pdl())
+
+    @patch("torch.testing._internal.common_cuda.SM90OrLater", True)
+    def test_pdl_requires_supported_accelerator(self, *args):
+        with (
+            patch("torch.version.cuda", None),
+            patch("torch.version.hip", None),
+        ):
+            self.assertFalse(evaluate_platform_supports_pdl())
 
 
 if __name__ == "__main__":

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -112,6 +112,13 @@ def evaluate_platform_supports_green_context():
         return False
     return int(driver_version.split('.')[0]) >= 570
 
+
+def evaluate_platform_supports_pdl():
+    if torch.version.cuda:
+        return SM90OrLater
+    return False
+
+
 PLATFORM_SUPPORTS_FLASH_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_flash_attention())
 PLATFORM_SUPPORTS_MEM_EFF_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_efficient_attention())
 PLATFORM_SUPPORTS_CUDNN_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_cudnn_attention())
@@ -123,6 +130,7 @@ PLATFORM_SUPPORTS_FUSED_ATTENTION: bool = LazyVal(lambda: PLATFORM_SUPPORTS_FLAS
 PLATFORM_SUPPORTS_FUSED_SDPA: bool = TEST_CUDA and not TEST_WITH_ROCM
 
 PLATFORM_SUPPORTS_CK_SDPA: bool = LazyVal(lambda: evaluate_platform_supports_ck_sdpa())
+PLATFORM_SUPPORTS_PDL: bool = LazyVal(lambda: evaluate_platform_supports_pdl())
 
 
 def evaluate_platform_supports_bf16():


### PR DESCRIPTION
﻿This keeps the PDL test gating in the `#175211` style instead of spelling it as raw CUDA-vs-ROCm capability checks inline.

Changes:
- add `evaluate_platform_supports_pdl()` / `PLATFORM_SUPPORTS_PDL`
- add focused compatibility coverage for the helper
- use the helper in the existing Inductor PDL test gates

Verification:
- `python agent_space/pdl_feature_query_repro.py`
- `python -m py_compile torch/testing/_internal/common_cuda.py test/test_cuda_compatibility.py test/inductor/test_torchinductor.py test/inductor/test_combo_kernels.py`

Notes:
- this branch stays in the existing `#175211` cleanup lane
- local PyTorch test entrypoints are still blocked in this clone by the missing `expecttest` dependency, so the regression helper was exercised through the scratch repro and the touched files were syntax-checked directly


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo