### PR TITLE
Use a feature query for _scaled_mm float8 test gating

### DIFF
--- a/test/test_cuda_compatibility.py
+++ b/test/test_cuda_compatibility.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import torch
 import torch.cuda
+from torch.testing._internal.common_cuda import evaluate_platform_supports_scaled_mm_float8
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -152,6 +153,40 @@ class TestCheckCapability(TestCase):
                 "install a PyTorch release that supports one of these CUDA versions",
                 msg,
             )
+
+
+class TestCommonCudaFeatureQueries(TestCase):
+    @patch("torch.testing._internal.common_cuda.SM89OrLater", True)
+    def test_scaled_mm_float8_supports_cuda_sm89_or_later(self, *args):
+        with (
+            patch("torch.version.cuda", "12.6"),
+            patch("torch.version.hip", None),
+        ):
+            self.assertTrue(evaluate_platform_supports_scaled_mm_float8())
+
+    @patch("torch.testing._internal.common_cuda.SM89OrLater", False)
+    def test_scaled_mm_float8_rejects_cuda_before_sm89(self, *args):
+        with (
+            patch("torch.version.cuda", "12.6"),
+            patch("torch.version.hip", None),
+        ):
+            self.assertFalse(evaluate_platform_supports_scaled_mm_float8())
+
+    @patch("torch.testing._internal.common_cuda.SM89OrLater", True)
+    def test_scaled_mm_float8_rejects_rocm(self, *args):
+        with (
+            patch("torch.version.cuda", None),
+            patch("torch.version.hip", "6.4.0"),
+        ):
+            self.assertFalse(evaluate_platform_supports_scaled_mm_float8())
+
+    @patch("torch.testing._internal.common_cuda.SM89OrLater", True)
+    def test_scaled_mm_float8_requires_supported_accelerator(self, *args):
+        with (
+            patch("torch.version.cuda", None),
+            patch("torch.version.hip", None),
+        ):
+            self.assertFalse(evaluate_platform_supports_scaled_mm_float8())
 
 
 if __name__ == "__main__":

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -225,11 +225,19 @@ def evaluate_platform_supports_fp8_sparse():
             )
     return False
 
+
+def evaluate_platform_supports_scaled_mm_float8():
+    if torch.version.cuda:
+        return SM89OrLater
+    return False
+
+
 PLATFORM_SUPPORTS_MX_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_mx_gemm())
 PLATFORM_SUPPORTS_FP8: bool = LazyVal(lambda: evaluate_platform_supports_fp8())
 PLATFORM_SUPPORTS_FP8_SPARSE: bool = LazyVal(lambda: evaluate_platform_supports_fp8_sparse())
 PLATFORM_SUPPORTS_FP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_fp8_grouped_gemm())
 PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM: bool = LazyVal(lambda: evaluate_platform_supports_mxfp8_grouped_gemm())
+PLATFORM_SUPPORTS_SCALED_MM_FLOAT8: bool = LazyVal(lambda: evaluate_platform_supports_scaled_mm_float8())
 
 if TEST_NUMBA:
     try:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -33,7 +33,8 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION, PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-    SM53OrLater, SM80OrLater, SM89OrLater, with_tf32_off, TEST_CUDNN,
+    PLATFORM_SUPPORTS_SCALED_MM_FLOAT8,
+    SM53OrLater, SM80OrLater, with_tf32_off, TEST_CUDNN,
     _get_torch_cuda_version,
 )
 from torch.testing._internal.common_quantized import (
@@ -17248,7 +17249,7 @@ op_db: list[OpInfo] = [
         supports_out=True,
         supports_forward_ad=False,
         supports_autograd=False,
-        decorators=[onlyCUDA, skipCUDAIf(not SM89OrLater or TEST_WITH_ROCM, 'Requires CUDA SM >= 8.9')],
+        decorators=[onlyCUDA, skipCUDAIf(not PLATFORM_SUPPORTS_SCALED_MM_FLOAT8, 'Requires CUDA SM >= 8.9')],
         skips=(
             # Sample inputs isn't really parametrized on dtype
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes'),
@@ -17278,7 +17279,7 @@ op_db: list[OpInfo] = [
         supports_out=True,
         supports_forward_ad=False,
         supports_autograd=False,
-        decorators=[skipXPU, skipCUDAIf(not SM89OrLater or TEST_WITH_ROCM, 'Requires CUDA SM >= 8.9')],
+        decorators=[skipXPU, skipCUDAIf(not PLATFORM_SUPPORTS_SCALED_MM_FLOAT8, 'Requires CUDA SM >= 8.9')],
         skips=(
             # Sample inputs isn't really parametrized on dtype
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes'),


### PR DESCRIPTION
This keeps the `_scaled_mm` OpInfo gating in the `#175211` style instead of spelling the CUDA-vs-ROCm capability check inline.

Changes:
- add `evaluate_platform_supports_scaled_mm_float8()` / `PLATFORM_SUPPORTS_SCALED_MM_FLOAT8`
- add focused compatibility coverage for the helper
- use the helper in the `_scaled_mm` and `_scaled_mm_v2` OpInfo decorators

Verification:
- `python agent_space/scaled_mm_feature_query_repro.py`
- `python -m py_compile torch/testing/_internal/common_cuda.py test/test_cuda_compatibility.py torch/testing/_internal/common_methods_invocations.py`

Notes:
- this stays in the existing `#175211` cleanup lane
- local PyTorch test entrypoints are still blocked in this clone by the missing `expecttest` dependency, so the helper behavior was exercised through the scratch repro and the touched files were syntax-checked directly
