### PR TITLE
Refactor tensor type handling in Python

### DIFF
--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -975,17 +975,17 @@ def argument_type_str_pyi(t: Type) -> str:
         if str(t.elem) == "int":
             ret = "_int | _size" if t.size is not None else "_size"
         elif t.is_tensor_like():
-            # Tensor?[] translates to tuple[Tensor | None, ...] | list[Tensor | None] | None
-            # Tensor[] translates to tuple[Tensor, ...] | list[Tensor]
+            # Tensor?[] translates to Sequence[Tensor | None] | None
+            # Tensor[] translates to Sequence[Tensor]
             if isinstance(t.elem, OptionalType):
                 add_optional = True
                 elem_str = "Tensor | None"
             else:
                 elem_str = "Tensor"
             ret = (
-                f"Tensor | tuple[{elem_str}, ...] | list[{elem_str}]"
+                f"Tensor | Sequence[{elem_str}]"
                 if t.size is not None
-                else f"tuple[{elem_str}, ...] | list[{elem_str}]"
+                else f"Sequence[{elem_str}]"
             )
         elif str(t.elem) == "float":
             ret = "Sequence[_float]"


### PR DESCRIPTION
This pull request updates the way tensor-like sequence types are represented in Python type annotations generated by `torchgen`. The main change is to simplify and standardize the type hints for tensor sequences by using `Sequence` instead of separate `tuple` and `list` types.

**Type annotation simplification:**

* Updated the `argument_type_str_pyi` function in `torchgen/api/python.py` to represent tensor-like sequences as `Sequence[Tensor]` (or `Sequence[Tensor | None]` for optional types), instead of the previous union of `tuple` and `list` types. This makes the generated type hints more concise and consistent.