### PR TITLE
[Composable] Fix replicate() DTensor hook registration for effective …

### DIFF
--- a/torch/distributed/_composable/replicate.py
+++ b/torch/distributed/_composable/replicate.py
@@ -222,7 +222,8 @@ def replicate(
         root_mesh = device_mesh._get_root_mesh()
         # if a root mesh is not the same as device_mesh,
         # meaning the device_mesh is sliced out from the root mesh.
-        if root_mesh != device_mesh:
+        # exclude scenarios where the root mesh has only one effective dim.
+        if root_mesh != device_mesh and sum(1 for s in root_mesh.shape if s > 1) > 1:
             # TODO: This is a temporary work around to enable DDP + TP.
             # We should do the logic in DDP so that the 2D implementation is
             # sound and the state_dict works out of the box.


### PR DESCRIPTION
Fix overly strict condition in `replicate()` that registers DTensor localization hooks even when the root mesh defines only 1D parallelism (e.g., a 3D mesh `(dp, tp, pp)` where `tp=1` and `pp=1`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                          
 