### PR TITLE
[SymmMem] Unify symmetric memory key and map types across backends

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
@@ -2,12 +2,19 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <utility>
+
+#include <c10/util/hash.h>
 
 #if defined(USE_ROCM)
 #include <hip/hip_runtime_api.h>
 #endif
 
 namespace c10d::symmetric_memory {
+
+using SymmMemKey = std::pair<void*, std::string>;
+using SymmMemKeyHash = c10::hash<SymmMemKey>;
 
 // Covers NVL72
 constexpr int max_cuda_p2p_domain_size = 72;

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp
@@ -13,7 +13,12 @@
 
 namespace c10d::symmetric_memory {
 
+// Key type for the symmetric memory map. `void*` for tensor storage ptr,
+// `std::string` for group name.
 using SymmMemKey = std::pair<void*, std::string>;
+// Hash function for the symmetric memory map. c10::hash has a std::pair
+// specialization (line 323-329 of hash.h) that delegates to the tuple hasher
+// which combines hashes of each element.
 using SymmMemKeyHash = c10::hash<SymmMemKey>;
 
 // Covers NVL72

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -9,6 +9,7 @@
 #include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
 #include <torch/csrc/distributed/c10d/cuda/utils.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh>
+#include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp>
@@ -61,32 +62,16 @@ struct NCCLAllocation {
 
 namespace {
 
-struct NCCLSymmMemKey {
-  void* ptr;
-  std::string group_name;
-
-  bool operator==(const NCCLSymmMemKey& other) const noexcept {
-    return ptr == other.ptr && group_name == other.group_name;
-  }
-};
-
-struct NCCLSymmMemKeyHash {
-  size_t operator()(const NCCLSymmMemKey& key) const {
-    auto seed = c10::hash_combine(0, std::hash<void*>{}(key.ptr));
-    return c10::hash_combine(seed, std::hash<std::string>{}(key.group_name));
-  }
-};
-
 // Base allocation ptr -> owning NCCL allocation metadata.
 using NCCLAllocMap = ska::flat_hash_map<void*, std::unique_ptr<NCCLAllocation>>;
 // (Tensor storage/data ptr, group name) -> cached SymmetricMemory handle.
 using NCCLSymmMemMap = ska::flat_hash_map<
-    NCCLSymmMemKey,
+    SymmMemKey,
     c10::intrusive_ptr<NCCLSymmetricMemory>,
-    NCCLSymmMemKeyHash>;
+    SymmMemKeyHash>;
 // Base allocation ptr -> cached `(tensor ptr, group)` keys derived from it.
 using NCCLSymmMemKeysByAlloc =
-    ska::flat_hash_map<void*, ska::flat_hash_set<NCCLSymmMemKey, NCCLSymmMemKeyHash>>;
+    ska::flat_hash_map<void*, ska::flat_hash_set<SymmMemKey, SymmMemKeyHash>>;
 
 bool pointer_in_allocation(void* ptr, const NCCLAllocation& allocation) {
   auto ptr_int = reinterpret_cast<uintptr_t>(ptr);
@@ -507,7 +492,7 @@ class NCCLSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
       const std::optional<std::string>& group_name) override {
     TORCH_CHECK(group_name.has_value(), "group_name must be provided");
     NCCLAllocation* allocation;
-    NCCLSymmMemKey key{ptr, *group_name};
+    SymmMemKey key{ptr, *group_name};
     {
       std::lock_guard<std::mutex> lock(mutex_);
       auto it = symm_mems_.find(key);

--- a/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NVSHMEMSymmetricMemory.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
 #include <torch/csrc/distributed/c10d/cuda/utils.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.hpp>
@@ -10,6 +11,7 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/error.h>
+#include <c10/util/flat_hash_map.h>
 
 #include <mutex>
 
@@ -407,7 +409,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     TORCH_CHECK(group_name.has_value());
     std::lock_guard<std::mutex> lock(mutex_);
     {
-      auto it = symm_mems_.find(std::make_tuple(ptr, *group_name));
+      auto it = symm_mems_.find(SymmMemKey{ptr, *group_name});
       if (it != symm_mems_.end()) {
         return it->second;
       }
@@ -432,7 +434,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
 
     // Search again using allocation base ptr (which is the key we use for
     // caching, see below)
-    auto it = symm_mems_.find(std::make_tuple(allocation->ptr, *group_name));
+    auto it = symm_mems_.find(SymmMemKey{allocation->ptr, *group_name});
     c10::intrusive_ptr<NVSHMEMSymmetricMemory> symm_mem;
     if (it != symm_mems_.end()) {
       // Base allocation has been rendezvoused
@@ -444,7 +446,7 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
     }
 
     // Cache rendezvous using allocation's base address as key
-    symm_mems_[std::make_tuple(allocation->ptr, *group_name)] = symm_mem;
+    symm_mems_[SymmMemKey{allocation->ptr, *group_name}] = symm_mem;
 
     // TODO: change the `ptr` below to `tensor.data_ptr()` when adding support
     // for user slice/view operations. For MemPool support,
@@ -488,9 +490,10 @@ class NVSHMEMSymmetricMemoryAllocator : public SymmetricMemoryAllocator {
  private:
   std::mutex mutex_;
   std::unordered_map<void*, std::unique_ptr<NVSHMEMAllocation>> allocations_;
-  std::map<
-      std::tuple<void*, std::string>,
-      c10::intrusive_ptr<NVSHMEMSymmetricMemory>>
+  ska::flat_hash_map<
+      SymmMemKey,
+      c10::intrusive_ptr<NVSHMEMSymmetricMemory>,
+      SymmMemKeyHash>
       symm_mems_;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #179903

Introduce a shared `SymmMemKey` (`std::pair<void*, std::string>`) in
CUDASymmetricMemoryTypes.hpp, replacing the NCCL-local custom struct +
hash and the NVSHMEM `std::map<std::tuple<...>>`. Both backends now use
the same key type with `c10::hash` for hashing. As a side-effect,
NVSHMEM's rendezvous cache switches from `std::map` (O(log n)) to
`ska::flat_hash_map` (O(1) amortized).