### PR TITLE
Extract shared context setup in standalone_compile

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3911,6 +3911,7 @@ class HOPCacheTests(CacheKeyEquivalenceMixin, torch._dynamo.test_case.TestCase):
             self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
 
 
+@instantiate_parametrized_tests
 class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
     """
     Verify that the exposed autograd_cache_key API function produces the same
@@ -4010,18 +4011,6 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
                 ignore_shape_env=True,
             )
 
-    def _standalone_compile_cache_key(
-        self, fx_graph, example_inputs, dynamic_shapes="from_example_inputs"
-    ):
-        """Call standalone_compile.autograd_cache_key, the top-level API
-        that mirrors standalone_compile's dynamic_shapes interface."""
-        with self._tracing_context():
-            return standalone_compile_autograd_cache_key(
-                fx_graph,
-                example_inputs,
-                dynamic_shapes=dynamic_shapes,
-            )
-
     @requires_triton()
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)
@@ -4038,10 +4027,9 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         gt_key, fx_graph, example_inputs = self._compile_and_capture(fn, x)
         api_key, _ = self._aot_autograd_cache_key(fx_graph, example_inputs)
         cfx_key, _ = self._compile_fx_cache_key(fx_graph, example_inputs)
-        sc_key, _ = self._standalone_compile_cache_key(fx_graph, example_inputs)
+
         self.assertEqual(gt_key, api_key)
         self.assertEqual(gt_key, cfx_key)
-        self.assertEqual(gt_key, sc_key)
 
     @requires_triton()
     @inductor_config.patch("fx_graph_remote_cache", False)
@@ -4061,14 +4049,10 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         key2, _ = self._aot_autograd_cache_key(fx_graph, example_inputs)
         cfx_key1, _ = self._compile_fx_cache_key(fx_graph, example_inputs)
         cfx_key2, _ = self._compile_fx_cache_key(fx_graph, example_inputs)
-        sc_key1, _ = self._standalone_compile_cache_key(fx_graph, example_inputs)
-        sc_key2, _ = self._standalone_compile_cache_key(fx_graph, example_inputs)
         self.assertEqual(gt_key, key1)
         self.assertEqual(key1, key2)
         self.assertEqual(gt_key, cfx_key1)
         self.assertEqual(cfx_key1, cfx_key2)
-        self.assertEqual(gt_key, sc_key1)
-        self.assertEqual(sc_key1, sc_key2)
 
     @requires_triton()
     @inductor_config.patch("fx_graph_remote_cache", False)
@@ -4091,14 +4075,10 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         api_key2, _ = self._aot_autograd_cache_key(graph2, inputs2)
         cfx_key1, _ = self._compile_fx_cache_key(graph1, inputs1)
         cfx_key2, _ = self._compile_fx_cache_key(graph2, inputs2)
-        sc_key1, _ = self._standalone_compile_cache_key(graph1, inputs1)
-        sc_key2, _ = self._standalone_compile_cache_key(graph2, inputs2)
         self.assertEqual(gt_key1, api_key1)
         self.assertEqual(gt_key2, api_key2)
         self.assertEqual(gt_key1, cfx_key1)
         self.assertEqual(gt_key2, cfx_key2)
-        self.assertEqual(gt_key1, sc_key1)
-        self.assertEqual(gt_key2, sc_key2)
         self.assertNotEqual(gt_key1, gt_key2)
 
     @requires_triton()
@@ -4124,14 +4104,10 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         api_key2, _ = self._aot_autograd_cache_key(graph2, inputs2)
         cfx_key1, _ = self._compile_fx_cache_key(graph1, inputs1)
         cfx_key2, _ = self._compile_fx_cache_key(graph2, inputs2)
-        sc_key1, _ = self._standalone_compile_cache_key(graph1, inputs1)
-        sc_key2, _ = self._standalone_compile_cache_key(graph2, inputs2)
         self.assertEqual(gt_key1, api_key1)
         self.assertEqual(gt_key2, api_key2)
         self.assertEqual(gt_key1, cfx_key1)
         self.assertEqual(gt_key2, cfx_key2)
-        self.assertEqual(gt_key1, sc_key1)
-        self.assertEqual(gt_key2, sc_key2)
         self.assertNotEqual(gt_key1, gt_key2)
 
     @requires_triton()
@@ -4156,46 +4132,9 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         gt_key, fx_graph, example_inputs = self._compile_and_capture(mod, x)
         api_key, _ = self._aot_autograd_cache_key(fx_graph, example_inputs)
         cfx_key, _ = self._compile_fx_cache_key(fx_graph, example_inputs)
-        sc_key, _ = self._standalone_compile_cache_key(fx_graph, example_inputs)
+
         self.assertEqual(gt_key, api_key)
         self.assertEqual(gt_key, cfx_key)
-        self.assertEqual(gt_key, sc_key)
-
-    @requires_triton()
-    @inductor_config.patch("fx_graph_remote_cache", False)
-    @inductor_config.patch("fx_graph_cache", True)
-    @functorch_config.patch(
-        {"enable_autograd_cache": True, "strict_autograd_cache": True}
-    )
-    def test_standalone_compile_cache_key_varies_with_dynamic_shapes(self):
-        """dynamic_shapes controls ignore_shape_env, which affects the key.
-
-        "from_example_inputs" ignores the shape env (ignore_shape_env=True),
-        while "from_graph" and "from_tracing_context" include it
-        (ignore_shape_env=False). This must produce different cache keys.
-        """
-
-        def fn(x):
-            return x.sin() + x.cos()
-
-        x = torch.randn(4, 4)
-        _, fx_graph, example_inputs = self._compile_and_capture(fn, x)
-
-        ei_key, _ = self._standalone_compile_cache_key(
-            fx_graph, example_inputs, dynamic_shapes="from_example_inputs"
-        )
-        fg_key, _ = self._standalone_compile_cache_key(
-            fx_graph, example_inputs, dynamic_shapes="from_graph"
-        )
-        tc_key, _ = self._standalone_compile_cache_key(
-            fx_graph, example_inputs, dynamic_shapes="from_tracing_context"
-        )
-        # "from_graph" and "from_tracing_context" both resolve to
-        # ignore_shape_env=False, so they produce identical keys.
-        self.assertEqual(fg_key, tc_key)
-        # "from_example_inputs" sets ignore_shape_env=True, producing a
-        # different key than the other two options.
-        self.assertNotEqual(ei_key, fg_key)
 
     def test_cache_key_for_multiple_outputs(self):
         """autograd_cache_key matches compilation for multiple outputs."""
@@ -4207,10 +4146,86 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         gt_key, fx_graph, example_inputs = self._compile_and_capture(fn, x)
         api_key, _ = self._aot_autograd_cache_key(fx_graph, example_inputs)
         cfx_key, _ = self._compile_fx_cache_key(fx_graph, example_inputs)
-        sc_key, _ = self._standalone_compile_cache_key(fx_graph, example_inputs)
+
         self.assertEqual(gt_key, api_key)
         self.assertEqual(gt_key, cfx_key)
-        self.assertEqual(gt_key, sc_key)
+
+    @requires_triton()
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch(
+        {"enable_autograd_cache": True, "strict_autograd_cache": True}
+    )
+    @parametrize(
+        "dynamic_shapes",
+        ("from_example_inputs", "from_graph", "from_tracing_context"),
+    )
+    @parametrize("aot", (False, True))
+    def test_standalone_compile_cache_key_matches_standalone_compile(
+        self, dynamic_shapes, aot
+    ):
+        """standalone_compile.autograd_cache_key matches the real key
+        produced when running standalone_compile end-to-end."""
+        from contextlib import nullcontext
+
+        from torch._inductor.standalone_compile import standalone_compile
+
+        # Build an FX graph directly: sin(x) + cos(x)
+        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+        with fake_mode:
+            fake_x = torch.randn(4, 4)
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["example_value"] = fake_x
+        sin = graph.call_method("sin", (x,))
+        sin.meta["example_value"] = fake_x.sin()
+        cos = graph.call_method("cos", (x,))
+        cos.meta["example_value"] = fake_x.cos()
+        add = graph.call_function(operator.add, (sin, cos))
+        add.meta["example_value"] = fake_x.sin() + fake_x.cos()
+        graph.output((add,))
+        fx_graph = GraphModule(torch.nn.Module(), graph)
+        example_inputs = [torch.randn(4, 4)]
+
+        # from_tracing_context requires an ambient TracingContext, simulating
+        # a call from within a torch.compile backend.
+        outer_context = (
+            torch._guards.tracing(torch._guards.TracingContext(fake_mode))
+            if dynamic_shapes == "from_tracing_context"
+            else nullcontext()
+        )
+
+        # Run standalone_compile and capture the real cache key.
+        real_cache_key_fn = autograd_cache.autograd_cache_key
+        captured_key = None
+
+        def capturing_cache_key(mod, ei, config, compiler_config_extra=None):
+            nonlocal captured_key
+            captured_key, _ = real_cache_key_fn(mod, ei, config, compiler_config_extra)
+            return captured_key, _
+
+        with outer_context:
+            with patch(
+                "torch._functorch._aot_autograd.autograd_cache.autograd_cache_key",
+                side_effect=capturing_cache_key,
+            ):
+                standalone_compile(
+                    fx_graph,
+                    example_inputs,
+                    dynamic_shapes=dynamic_shapes,
+                    options={},
+                    aot=aot,
+                )
+
+            self.assertIsNotNone(captured_key)
+
+            sc_key, _ = standalone_compile_autograd_cache_key(
+                fx_graph,
+                example_inputs,
+                dynamic_shapes=dynamic_shapes,
+                aot=aot,
+            )
+            self.assertEqual(captured_key, sc_key)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import copy
 import logging
 import os
@@ -377,6 +378,63 @@ def _resolve_ignore_shape_env(dynamic_shapes: Any):
     return dynamic_shapes == "from_example_inputs"
 
 
+def _resolve_fake_mode(gm: GraphModule, dynamic_shapes: Any) -> FakeTensorMode:
+    if dynamic_shapes == "from_example_inputs":
+        return FakeTensorMode(shape_env=ShapeEnv())
+    elif dynamic_shapes == "from_tracing_context":
+        # Reuse fake_mode from the TracingContext.
+        # NB: The TracingContext only exists if we're currently in a torch.compile backend.
+        context = torch._guards.TracingContext.get()
+        assert context.fake_mode is not None
+        return context.fake_mode
+    elif dynamic_shapes == "from_graph":
+        # Strategy: find a FakeTensor in the graph output, grab its FakeTensorMode.
+        # The graph passed to standalone_compile must be an Inductor-approved graph,
+        # which means that there is at least one Tensor output and the output node
+        # contains a flat list of Tensors.
+        last_node = next(iter(reversed(gm.graph.nodes)))
+        assert last_node.op == "output"
+        assert len(last_node.args) == 1
+
+        # If gm came from Dynamo, then last_node.args[0] is always a list,
+        # even in single-Tensor returns.
+        #
+        # It's possible to get into a situation where last_node.args[0]
+        # is a Node (and not a list!). This happens if you call split_module
+        # on the graph. We allow for this case since it is common.
+        nodes = (
+            [last_node.args[0]]
+            if isinstance(last_node.args[0], torch.fx.Node)
+            else last_node.args[0]
+        )
+        for node in nodes:
+            if "example_value" in node.meta:
+                maybe_tensor = node.meta["example_value"]
+                if isinstance(maybe_tensor, torch._subclasses.fake_tensor.FakeTensor):
+                    return maybe_tensor.fake_mode
+
+        return FakeTensorMode(shape_env=ShapeEnv())
+    else:
+        raise ValueError(
+            f"standalone_compile got unsupported `dynamic_shapes` value: dynamic_shapes={dynamic_shapes}."
+        )
+
+
+@contextlib.contextmanager
+def _standalone_context(gm: GraphModule, dynamic_shapes: Any, aot: bool):
+    from torch.compiler._cache import CacheArtifactManager
+
+    fake_mode = _resolve_fake_mode(gm, dynamic_shapes)
+    tracing_context = torch._guards.TracingContext(fake_mode)
+    with (
+        torch._guards.tracing(tracing_context),
+        CacheArtifactManager.with_fresh_cache(),
+        config.patch("triton.autotune_at_compile_time", True),
+        torch._functorch.config.patch("bundled_autograd_cache", aot),
+    ):
+        yield
+
+
 def standalone_compile(
     gm: GraphModule,
     example_inputs: Sequence[InputType],
@@ -388,60 +446,10 @@ def standalone_compile(
     """
     Implementation of torch.inductor.standalone_compile
     """
-    from torch.compiler._cache import CacheArtifactManager
-
     from .compile_fx import compile_fx
 
     ignore_shape_env = _resolve_ignore_shape_env(dynamic_shapes)
-    if dynamic_shapes == "from_example_inputs":
-        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
-    elif dynamic_shapes == "from_tracing_context":
-        # Reuse fake_mode from the TracingContext.
-        # NB: The TracingContext only exists if we're currently in a torch.compile backend.
-        context = torch._guards.TracingContext.get()
-        assert context.fake_mode is not None
-        fake_mode = context.fake_mode
-    elif dynamic_shapes == "from_graph":
-        fake_mode = FakeTensorMode(shape_env=ShapeEnv())
-        # Strategy: find a FakeTensor in the graph output, grab its FakeTensorMode.
-        # The graph passed to standalone_compile must be an Inductor-approved graph,
-        # which means that there is at least one Tensor output and the output node
-        # contains a flat list of Tensors.
-        last_node = next(iter(reversed(gm.graph.nodes)))
-        assert last_node.op == "output"
-        assert len(last_node.args) == 1
-
-        def handle_node(node: torch.fx.Node) -> None:
-            nonlocal fake_mode
-            if "example_value" in node.meta:
-                maybe_tensor = node.meta["example_value"]
-                if isinstance(maybe_tensor, torch._subclasses.fake_tensor.FakeTensor):
-                    fake_mode = maybe_tensor.fake_mode
-
-        # If gm came from Dynamo, then last_node.args[0] is always a list,
-        # even in single-Tensor returns.
-        #
-        # It's possible to get into a situation where last_node.args[0]
-        # is a Node (and not a list!). This happens if you call split_module
-        # on the graph. We allow for this case since it is common.
-        if isinstance(last_node.args[0], torch.fx.Node):
-            handle_node(last_node.args[0])
-        else:
-            for node in last_node.args[0]:
-                handle_node(node)
-
-    else:
-        raise ValueError(
-            f"standalone_compile got unsupported `dynamic_shapes` value: dynamic_shapes={dynamic_shapes}."
-        )
-
-    context = torch._guards.TracingContext(fake_mode)
-    with (
-        torch._guards.tracing(context),
-        CacheArtifactManager.with_fresh_cache(),
-        config.patch("triton.autotune_at_compile_time", True),
-        torch._functorch.config.patch("bundled_autograd_cache", aot),
-    ):
+    with _standalone_context(gm, dynamic_shapes, aot):
         # compile_fx can mutate gm
         # TODO: this is only needed if we dont hit the cache!!
         gm = copy.deepcopy(gm)
@@ -469,12 +477,14 @@ def autograd_cache_key(
     graph,
     example_inputs,
     dynamic_shapes: Any,
+    aot: bool = False,  # AOT mode, which uses BundledAOTAutogradCache
 ):
     from . import compile_fx
 
     ignore_shape_env = _resolve_ignore_shape_env(dynamic_shapes)
-    return compile_fx.autograd_cache_key(
-        graph,
-        example_inputs,
-        ignore_shape_env=ignore_shape_env,
-    )
+    with _standalone_context(graph, dynamic_shapes, aot):
+        return compile_fx.autograd_cache_key(
+            graph,
+            example_inputs,
+            ignore_shape_env=ignore_shape_env,
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179993
* #179916
* __->__ #179915

Factor out _resolve_fake_mode and _standalone_context from
standalone_compile so that autograd_cache_key uses the same
tracing context, fake mode resolution, and CacheArtifactManager
setup. This ensures the two code paths stay in sync.

Add a test that runs standalone_compile end-to-end, captures the
real cache key via patching, and asserts that the
standalone_compile.autograd_cache_key API produces the same key.
Parametrized over dynamic_shapes and aot to cover all modes.
Remove standalone compile key assertions from the torch.compile-path
tests since the two pipelines set up different contexts.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98