### PR TITLE
Add missing test decorators to test_cache_key_for_multiple_outputs

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -4136,6 +4136,12 @@ class CacheKeyAPITests(torch._dynamo.test_case.TestCase):
         self.assertEqual(gt_key, api_key)
         self.assertEqual(gt_key, cfx_key)
 
+    @requires_triton()
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch(
+        {"enable_autograd_cache": True, "strict_autograd_cache": True}
+    )
     def test_cache_key_for_multiple_outputs(self):
         """autograd_cache_key matches compilation for multiple outputs."""
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179993
* __->__ #179916
* #179915

This test was missing @requires_triton, @inductor_config.patch, and
@functorch_config.patch decorators that all other tests in
CacheKeyAPITests have.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98