### PR TITLE
[MTIA][Inductor] Eliminate redundant copy kernel for concat graph outputs with comprehensive_padding (#179919)

### DIFF
--- a/test/inductor/test_padding.py
+++ b/test/inductor/test_padding.py
@@ -778,6 +778,52 @@ class PaddingTest(TestCaseBase):
         output_line = f"buf12 = empty_strided_{GPU_TYPE}({output_shape}, {output_stride}, torch.float32)"
         self.assertTrue(output_line in code[0])
 
+    @requires_gpu()
+    def test_concat_output_no_redundant_copy_with_padding(self):
+        """
+        When comprehensive_padding is enabled, ConcatKernel pads its output
+        buffer strides. The graph output should accept the padded strides
+        directly instead of generating a redundant copy kernel.
+        """
+
+        def f(x):
+            a = x + 1
+            # a has two consumers (mul and cat), which forces ConcatKernel
+            # over pointwise_cat. Both inputs are Pointwise with
+            # FlexibleLayout so they realize directly into concat slices.
+            b = a * 2
+            return torch.cat([a, b], dim=1)
+
+        # Use dim=131 so concat output dim (262) is not aligned to
+        # padding_alignment_bytes/4=32, triggering stride padding.
+        x = torch.randn(128, 131, device=GPU_TYPE)
+
+        with config.patch(
+            {
+                "comprehensive_padding": True,
+                "pad_outputs": True,
+                "padding_stride_threshold": 0,
+                "inplace_buffers": False,
+            }
+        ):
+            result, code = run_and_get_code(torch.compile(f), x)
+
+        ref = f(x)
+        self.assertTrue(torch.allclose(ref, result, atol=1e-3, rtol=1e-3))
+        # Only one output buffer should be allocated for the concat result.
+        # Without the fix, a second empty_strided is allocated and a copy
+        # kernel is generated to copy from the padded concat buffer to it.
+        # Count actual buffer allocations (not import lines) by matching
+        # "= empty_strided_<device>(" pattern.
+        import re
+
+        num_allocs = len(re.findall(rf"= empty_strided_{GPU_TYPE}\(", code[0]))
+        self.assertEqual(
+            num_allocs,
+            1,
+            "Expected exactly one buffer allocation for concat output (no redundant copy)",
+        )
+
     @parametrize(
         "shape,alignment_bytes,enable_pad",
         [

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6693,6 +6693,7 @@ class ExternKernel(InputsKernel):
         exact_strides: Sequence[_IntLike] | None = None,
         allow_padding: bool = False,
     ) -> IRNode:
+        """Ensure x has the requested stride order or exact strides, inserting a copy if needed."""
         assert order is not None or exact_strides is not None
         # Layout generally doesn't matter, but some consuming external ops might have requirements
         if x.get_numel() in (0, 1) and not exact_strides:
@@ -6741,7 +6742,17 @@ class ExternKernel(InputsKernel):
                         exact_strides=exact_strides,
                     )
                     return x
-            elif isinstance(x.get_layout(), (FixedLayout, NonOwningLayout)) and (
+
+            # When padding is allowed, check if the buffer's existing strides
+            # match padded versions of the requested strides (e.g. concat graph
+            # outputs that were already padded by ConcatKernel).
+            padded_exact_strides = None
+            if allow_padding and exact_strides:
+                padded_exact_strides = list(
+                    Layout._pad_strides(exact_strides, x.get_size(), x.get_dtype())
+                )
+
+            if isinstance(x.get_layout(), (FixedLayout, NonOwningLayout)) and (
                 (order and x.get_layout().is_stride_ordered(order))
                 or (
                     exact_strides
@@ -6755,6 +6766,15 @@ class ExternKernel(InputsKernel):
                     if exact_strides is not None
                     else x
                 )
+            # Accept already-padded buffers when padding is allowed
+            elif (
+                padded_exact_strides is not None
+                and isinstance(x.get_layout(), (FixedLayout, NonOwningLayout))
+                and significant_strides_equal(
+                    padded_exact_strides, x.get_layout().stride, x.get_size()
+                )
+            ):
+                return try_match_insignificant_strides(x, padded_exact_strides)
             elif isinstance(
                 (mutation_layout := x.get_layout()), MutationLayoutSHOULDREMOVE
             ):


### PR DESCRIPTION
Summary:

Eliminates a redundant Triton copy kernel generated when a ConcatKernel output is a graph output with comprehensive_padding enabled.

**Root cause**: When `comprehensive_padding` is enabled, `ConcatKernel.create()` applies `_pad_strides` to the output buffer (e.g., stride `(352, 1)` for shape `(6144, 341)`). When Inductor enforces graph output strides via `require_exact_strides`, it uses the FakeTensor metadata strides `(341, 1)` from eager execution. The `significant_strides_equal` check in `require_strides` fails because `352 != 341`, causing a fallthrough to `copy_input` which allocates a separate output buffer and generates a redundant Pointwise copy kernel.

**Fix in `require_strides` (ir.py)**: When `allow_padding=True` (which is the case for non-user-visible graph outputs), pad the requested `exact_strides` via `Layout._pad_strides()` before the FixedLayout compatibility check. This way the existing `significant_strides_equal` naturally matches buffers that were already padded, without needing a separate padding branch. The padded `exact_strides` also flows correctly into `try_match_insignificant_strides` for size-1 dimension fixup.

**Test case (test_padding.py)**: Added `test_concat_output_no_redundant_copy_with_padding` which verifies that a concat graph output with comprehensive_padding produces only one buffer allocation (no redundant copy).

**MTIA test case (fused_view_ops.py)**: Added `ConcatWithGemm` module that tests add + gemm feeding into concat with the `exclude_gemms` filter profile. Expected Triton kernel count is 2 (add-into-concat-slice, gemm-result-into-concat-slice) — the redundant full-buffer copy is eliminated.

Authored with Claude.

Test Plan:
OSS test:
buck test fbcode//caffe2/test/inductor:padding-library -- test_concat_output_no_redundant_copy_with_padding
Pass 1. Fail 0.

MTIA test (RE):
buck test fbcode//mtia/compiler/graph_compiler/test_library:afg_inductor_unittest -- -r view_ops_concat_with_gemm
Pass 2. Fail 0.

OSS padding test suite (no regressions):
buck test fbcode//caffe2/test/inductor:padding-library
Pass 69. Fail 0.

Reviewed By: blaine-rister

Differential Revision: D100257161


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo