### PR TITLE
[WIP] faketensor cpp: HOPs

### DIFF
--- a/test/test_proxy_tensor_with_cpp_fake.py
+++ b/test/test_proxy_tensor_with_cpp_fake.py
@@ -108,18 +108,17 @@ class TestCppFakeProxyTensor(TestCase):
     fake tensor semantics.
     """
 
-    def _test(self, f, inps):
+    def _test(self, f, inps, compare_graph=False):
         # Trace under C++ fake mode
         with cpp_fake_tensor_mode():
             cpp_gm = make_fx(f, tracing_mode="real")(*inps)
 
-        # Trace under Python fake mode
-        py_gm = make_fx(f, tracing_mode="fake")(*inps)
-
-        # Compare graph structure
-        cpp_ops = [n.target for n in cpp_gm.graph.nodes if n.op == "call_function"]
-        py_ops = [n.target for n in py_gm.graph.nodes if n.op == "call_function"]
-        self.assertEqual(cpp_ops, py_ops)
+        if compare_graph:
+            # Trace under Python fake mode and compare graph structure
+            py_gm = make_fx(f, tracing_mode="fake")(*inps)
+            cpp_ops = [n.target for n in cpp_gm.graph.nodes if n.op == "call_function"]
+            py_ops = [n.target for n in py_gm.graph.nodes if n.op == "call_function"]
+            self.assertEqual(cpp_ops, py_ops)
 
         # Verify correctness with real inputs
         new_inps = tree_map(_create_new_input, inps)
@@ -790,7 +789,7 @@ def forward(self, x_1):
                 x.sum() > 2, lambda x: (x.cos(),), lambda x: (x.sin(),), [x]
             )
 
-        self._test(f, (self._make_arg(2, 2, 2),))
+        self._test(f, (self._make_arg(2, 2, 2),), compare_graph=True)
 
     def test_while_loop_simple(self):
         """Mirrors hop_db simple_while_loop."""
@@ -805,7 +804,7 @@ def forward(self, x_1):
 
             return while_loop_op(cond_fn, body_fn, (iter_t, x), ())
 
-        self._test(f, (torch.tensor(3), self._make_arg(2, 3, 4)))
+        self._test(f, (torch.tensor(3), self._make_arg(2, 3, 4)), compare_graph=True)
 
     def test_map_simple(self):
         """Mirrors hop_db simple_map."""
@@ -818,7 +817,7 @@ def forward(self, x_1):
             return map_impl(inner_f, [x0, x1], (y0, y1))
 
         self._test(f, (self._make_arg(2, 2, 2), self._make_arg(2, 2, 2),
-                        self._make_arg(1), self._make_arg(1)))
+                        self._make_arg(1), self._make_arg(1)), compare_graph=True)
 
     def test_scan_simple(self):
         """Mirrors hop_db simple_scan."""
@@ -831,7 +830,7 @@ def forward(self, x_1):
         def f(init, xs):
             return scan_op(combine_fn, [init], [xs], ())
 
-        self._test(f, (self._make_arg(2, 2), self._make_arg(2, 2, 2)))
+        self._test(f, (self._make_arg(2, 2), self._make_arg(2, 2, 2)), compare_graph=True)
 
 
 # --- OpInfo-based exhaustive tests for C++ FakeTensor mode ---

--- a/test/test_proxy_tensor_with_cpp_fake.py
+++ b/test/test_proxy_tensor_with_cpp_fake.py
@@ -767,6 +767,9 @@ def forward(self, x_1):
     # map_impl, scan_op) directly, bypassing the user-facing wrappers that route
     # through torch.compile/Dynamo.
 
+    def _make_arg(self, *shape, low=0.1, high=2):
+        return make_tensor(*shape, low=low, high=high, dtype=torch.float, device="cpu")
+
     def test_cond_simple(self):
         """Mirrors hop_db simple_cond."""
         from torch._higher_order_ops.cond import cond_op
@@ -776,7 +779,7 @@ def forward(self, x_1):
                 x.sum() > 2, lambda x: (x.cos(),), lambda x: (x.sin(),), [x]
             )
 
-        self._test(f, (make_tensor(2, 2, 2, low=0.1, high=2, dtype=torch.float, device="cpu"),))
+        self._test(f, (self._make_arg(2, 2, 2),))
 
     def test_while_loop_simple(self):
         """Mirrors hop_db simple_while_loop."""
@@ -791,11 +794,7 @@ def forward(self, x_1):
 
             return while_loop_op(cond_fn, body_fn, (iter_t, x), ())
 
-        inp = (torch.tensor(3), make_tensor(2, 3, 4, low=0.1, high=2, dtype=torch.float, device="cpu"))
-        with cpp_fake_tensor_mode():
-            gm = make_fx(f, tracing_mode="real")(*inp)
-        new_inp = (torch.tensor(2), torch.randn(2, 3, 4))
-        self.assertEqual(gm(*new_inp), f(*new_inp))
+        self._test(f, (torch.tensor(3), self._make_arg(2, 3, 4)))
 
     def test_map_simple(self):
         """Mirrors hop_db simple_map."""
@@ -807,15 +806,8 @@ def forward(self, x_1):
         def f(x0, x1, y0, y1):
             return map_impl(inner_f, [x0, x1], (y0, y1))
 
-        x0 = make_tensor(2, 2, 2, low=0.1, high=2, dtype=torch.float, device="cpu")
-        x1 = make_tensor(2, 2, 2, low=0.1, high=2, dtype=torch.float, device="cpu")
-        y0 = make_tensor(1, low=0.1, high=2, dtype=torch.float, device="cpu")
-        y1 = make_tensor(1, low=0.1, high=2, dtype=torch.float, device="cpu")
-        with cpp_fake_tensor_mode():
-            gm = make_fx(f, tracing_mode="real")(x0, x1, y0, y1)
-        new_args = (torch.randn(2, 2, 2), torch.randn(2, 2, 2),
-                    torch.randn(1), torch.randn(1))
-        self.assertEqual(gm(*new_args), f(*new_args))
+        self._test(f, (self._make_arg(2, 2, 2), self._make_arg(2, 2, 2),
+                        self._make_arg(1), self._make_arg(1)))
 
     def test_scan_simple(self):
         """Mirrors hop_db simple_scan."""
@@ -828,12 +820,7 @@ def forward(self, x_1):
         def f(init, xs):
             return scan_op(combine_fn, [init], [xs], ())
 
-        init = make_tensor(2, 2, low=0.1, high=2, dtype=torch.float, device="cpu")
-        xs = make_tensor(2, 2, 2, low=0.1, high=2, dtype=torch.float, device="cpu")
-        with cpp_fake_tensor_mode():
-            gm = make_fx(f, tracing_mode="real")(init, xs)
-        new_init, new_xs = torch.randn(2, 2), torch.randn(2, 2, 2)
-        self.assertEqual(gm(new_init, new_xs), f(new_init, new_xs))
+        self._test(f, (self._make_arg(2, 2), self._make_arg(2, 2, 2)))
 
 
 # --- OpInfo-based exhaustive tests for C++ FakeTensor mode ---

--- a/test/test_proxy_tensor_with_cpp_fake.py
+++ b/test/test_proxy_tensor_with_cpp_fake.py
@@ -109,10 +109,21 @@ class TestCppFakeProxyTensor(TestCase):
     """
 
     def _test(self, f, inps):
+        # Trace under C++ fake mode
         with cpp_fake_tensor_mode():
-            fx_f = make_fx(f, tracing_mode="real")(*inps)
+            cpp_gm = make_fx(f, tracing_mode="real")(*inps)
+
+        # Trace under Python fake mode
+        py_gm = make_fx(f, tracing_mode="fake")(*inps)
+
+        # Compare graph structure
+        cpp_ops = [n.target for n in cpp_gm.graph.nodes if n.op == "call_function"]
+        py_ops = [n.target for n in py_gm.graph.nodes if n.op == "call_function"]
+        self.assertEqual(cpp_ops, py_ops)
+
+        # Verify correctness with real inputs
         new_inps = tree_map(_create_new_input, inps)
-        r1 = fx_f(*new_inps)
+        r1 = cpp_gm(*new_inps)
         r2 = f(*new_inps)
         self.assertEqual(r1, r2)
 

--- a/test/test_proxy_tensor_with_cpp_fake.py
+++ b/test/test_proxy_tensor_with_cpp_fake.py
@@ -761,6 +761,125 @@ def forward(self, x_1):
         x = torch.randn(3, device="cuda")
         self.assertEqual(gm(x), f(x))
 
+    # --- Higher Order Op tests (calling internal ops directly) ---
+
+    def test_cond(self):
+        from torch._higher_order_ops.cond import cond_op
+
+        def f(x):
+            pred = x.shape[0] > 0  # static bool, but traced as a tensor pred
+            return cond_op(
+                torch.tensor(True),
+                lambda x: x.cos(),
+                lambda x: x.sin(),
+                [x],
+            )
+
+        self._test(f, (torch.randn(3, 4),))
+
+    def test_cond_branches_same_output(self):
+        from torch._higher_order_ops.cond import cond_op
+
+        def f(pred, x):
+            return cond_op(pred, lambda x: x + 1, lambda x: x - 1, [x])
+
+        with cpp_fake_tensor_mode():
+            gm = make_fx(f, tracing_mode="real")(torch.tensor(True), torch.randn(3, 4))
+        x = torch.randn(3, 4)
+        self.assertEqual(gm(torch.tensor(True), x), x + 1)
+        self.assertEqual(gm(torch.tensor(False), x), x - 1)
+
+    def test_cond_nested(self):
+        from torch._higher_order_ops.cond import cond_op
+
+        def f(pred, x):
+            def true_fn(x):
+                return cond_op(pred, lambda x: x.cos(), lambda x: x.sin(), [x])
+
+            def false_fn(x):
+                return x + 1
+
+            return cond_op(pred, true_fn, false_fn, [x])
+
+        with cpp_fake_tensor_mode():
+            gm = make_fx(f, tracing_mode="real")(torch.tensor(True), torch.randn(3))
+        x = torch.randn(3)
+        self.assertEqual(gm(torch.tensor(True), x), f(torch.tensor(True), x))
+
+    def test_while_loop(self):
+        from torch._higher_order_ops.while_loop import while_loop_op
+
+        def f(iter_t, x):
+            def cond_fn(iter_t, x):
+                return iter_t > 0
+
+            def body_fn(iter_t, x):
+                return iter_t - 1, x.cos()
+
+            return while_loop_op(cond_fn, body_fn, (iter_t, x), ())
+
+        inp = (torch.tensor(3), torch.randn(2, 3))
+        with cpp_fake_tensor_mode():
+            gm = make_fx(f, tracing_mode="real")(*inp)
+
+        new_inp = (torch.tensor(2), torch.randn(2, 3))
+        r1 = gm(*new_inp)
+        r2 = f(*new_inp)
+        self.assertEqual(r1, r2)
+
+    def test_map(self):
+        from torch._higher_order_ops.map import map_impl
+
+        def f(xs, y):
+            def body(x, y):
+                return x.cos() + y
+
+            return map_impl(body, [xs], (y,))
+
+        xs = torch.randn(3, 4)
+        y = torch.randn(4)
+        with cpp_fake_tensor_mode():
+            gm = make_fx(f, tracing_mode="real")(xs, y)
+        new_xs, new_y = torch.randn(3, 4), torch.randn(4)
+        self.assertEqual(gm(new_xs, new_y), f(new_xs, new_y))
+
+    def test_map_multi_output(self):
+        from torch._higher_order_ops.map import map_impl
+
+        def f(xs, y):
+            def body(x, y):
+                return x.cos() + y, x.sin()
+
+            return map_impl(body, [xs], (y,))
+
+        xs = torch.randn(3, 4)
+        y = torch.randn(4)
+        with cpp_fake_tensor_mode():
+            gm = make_fx(f, tracing_mode="real")(xs, y)
+        new_xs, new_y = torch.randn(3, 4), torch.randn(4)
+        r1 = gm(new_xs, new_y)
+        r2 = f(new_xs, new_y)
+        self.assertEqual(r1[0], r2[0])
+        self.assertEqual(r1[1], r2[1])
+
+    def test_scan(self):
+        from torch._higher_order_ops.scan import scan_op
+
+        def f(init, xs):
+            def combine_fn(carry, x):
+                return carry + x, carry.clone()
+
+            return scan_op(combine_fn, [init], [xs], [])
+
+        init = torch.randn(4)
+        xs = torch.randn(3, 4)
+        with cpp_fake_tensor_mode():
+            gm = make_fx(f, tracing_mode="real")(init, xs)
+        new_init, new_xs = torch.randn(4), torch.randn(3, 4)
+        r1 = gm(new_init, new_xs)
+        r2 = f(new_init, new_xs)
+        self.assertEqual(r1, r2)
+
 
 # --- OpInfo-based exhaustive tests for C++ FakeTensor mode ---
 
@@ -884,7 +1003,14 @@ _cpp_fake_decomps = {
     }
 }
 
-filtered_hop_db = [op for op in hop_db if op.name != "auto_functionalize"]
+# HOPs whose user-facing wrappers (torch.cond, etc.) call torch.compile internally,
+# creating a Python FakeTensorMode that conflicts with C++ fake mode.
+# These are tested directly via internal ops in TestCppFakeProxyTensor.
+_HOP_SKIP_USER_FACING = {
+    "cond", "map", "scan", "while_loop", "while_loop_stack_output",
+    "auto_functionalize",
+}
+filtered_hop_db = [op for op in hop_db if op.name not in _HOP_SKIP_USER_FACING]
 
 
 @unittest.skipIf(not torch._dynamo.is_dynamo_supported(), "Cond requires dynamo")

--- a/test/test_proxy_tensor_with_cpp_fake.py
+++ b/test/test_proxy_tensor_with_cpp_fake.py
@@ -11,6 +11,7 @@ Python handler (decomposition, fake_impl, etc.) and calls it. Sub-ops
 re-enter C++ Fake dispatch, so all results remain C++ fake tensors.
 """
 
+from torch.testing import make_tensor
 from torch.testing._internal.common_utils import TestCase, run_tests
 import torch
 import torch._dynamo
@@ -761,52 +762,24 @@ def forward(self, x_1):
         x = torch.randn(3, device="cuda")
         self.assertEqual(gm(x), f(x))
 
-    # --- Higher Order Op tests (calling internal ops directly) ---
+    # --- Higher Order Op tests ---
+    # These mirror the hop_db entries but call internal ops (cond_op, while_loop_op,
+    # map_impl, scan_op) directly, bypassing the user-facing wrappers that route
+    # through torch.compile/Dynamo.
 
-    def test_cond(self):
+    def test_cond_simple(self):
+        """Mirrors hop_db simple_cond."""
         from torch._higher_order_ops.cond import cond_op
 
         def f(x):
-            pred = x.shape[0] > 0  # static bool, but traced as a tensor pred
             return cond_op(
-                torch.tensor(True),
-                lambda x: x.cos(),
-                lambda x: x.sin(),
-                [x],
+                x.sum() > 2, lambda x: (x.cos(),), lambda x: (x.sin(),), [x]
             )
 
-        self._test(f, (torch.randn(3, 4),))
+        self._test(f, (make_tensor(2, 2, 2, low=0.1, high=2, dtype=torch.float, device="cpu"),))
 
-    def test_cond_branches_same_output(self):
-        from torch._higher_order_ops.cond import cond_op
-
-        def f(pred, x):
-            return cond_op(pred, lambda x: x + 1, lambda x: x - 1, [x])
-
-        with cpp_fake_tensor_mode():
-            gm = make_fx(f, tracing_mode="real")(torch.tensor(True), torch.randn(3, 4))
-        x = torch.randn(3, 4)
-        self.assertEqual(gm(torch.tensor(True), x), x + 1)
-        self.assertEqual(gm(torch.tensor(False), x), x - 1)
-
-    def test_cond_nested(self):
-        from torch._higher_order_ops.cond import cond_op
-
-        def f(pred, x):
-            def true_fn(x):
-                return cond_op(pred, lambda x: x.cos(), lambda x: x.sin(), [x])
-
-            def false_fn(x):
-                return x + 1
-
-            return cond_op(pred, true_fn, false_fn, [x])
-
-        with cpp_fake_tensor_mode():
-            gm = make_fx(f, tracing_mode="real")(torch.tensor(True), torch.randn(3))
-        x = torch.randn(3)
-        self.assertEqual(gm(torch.tensor(True), x), f(torch.tensor(True), x))
-
-    def test_while_loop(self):
+    def test_while_loop_simple(self):
+        """Mirrors hop_db simple_while_loop."""
         from torch._higher_order_ops.while_loop import while_loop_op
 
         def f(iter_t, x):
@@ -818,67 +791,49 @@ def forward(self, x_1):
 
             return while_loop_op(cond_fn, body_fn, (iter_t, x), ())
 
-        inp = (torch.tensor(3), torch.randn(2, 3))
+        inp = (torch.tensor(3), make_tensor(2, 3, 4, low=0.1, high=2, dtype=torch.float, device="cpu"))
         with cpp_fake_tensor_mode():
             gm = make_fx(f, tracing_mode="real")(*inp)
+        new_inp = (torch.tensor(2), torch.randn(2, 3, 4))
+        self.assertEqual(gm(*new_inp), f(*new_inp))
 
-        new_inp = (torch.tensor(2), torch.randn(2, 3))
-        r1 = gm(*new_inp)
-        r2 = f(*new_inp)
-        self.assertEqual(r1, r2)
-
-    def test_map(self):
+    def test_map_simple(self):
+        """Mirrors hop_db simple_map."""
         from torch._higher_order_ops.map import map_impl
 
-        def f(xs, y):
-            def body(x, y):
-                return x.cos() + y
+        def inner_f(x0, x1, y0, y1):
+            return [x0.cos().add_(1.0) * y0, (x1 + y1.sin()).cos_().view(x1.size())]
 
-            return map_impl(body, [xs], (y,))
+        def f(x0, x1, y0, y1):
+            return map_impl(inner_f, [x0, x1], (y0, y1))
 
-        xs = torch.randn(3, 4)
-        y = torch.randn(4)
+        x0 = make_tensor(2, 2, 2, low=0.1, high=2, dtype=torch.float, device="cpu")
+        x1 = make_tensor(2, 2, 2, low=0.1, high=2, dtype=torch.float, device="cpu")
+        y0 = make_tensor(1, low=0.1, high=2, dtype=torch.float, device="cpu")
+        y1 = make_tensor(1, low=0.1, high=2, dtype=torch.float, device="cpu")
         with cpp_fake_tensor_mode():
-            gm = make_fx(f, tracing_mode="real")(xs, y)
-        new_xs, new_y = torch.randn(3, 4), torch.randn(4)
-        self.assertEqual(gm(new_xs, new_y), f(new_xs, new_y))
+            gm = make_fx(f, tracing_mode="real")(x0, x1, y0, y1)
+        new_args = (torch.randn(2, 2, 2), torch.randn(2, 2, 2),
+                    torch.randn(1), torch.randn(1))
+        self.assertEqual(gm(*new_args), f(*new_args))
 
-    def test_map_multi_output(self):
-        from torch._higher_order_ops.map import map_impl
-
-        def f(xs, y):
-            def body(x, y):
-                return x.cos() + y, x.sin()
-
-            return map_impl(body, [xs], (y,))
-
-        xs = torch.randn(3, 4)
-        y = torch.randn(4)
-        with cpp_fake_tensor_mode():
-            gm = make_fx(f, tracing_mode="real")(xs, y)
-        new_xs, new_y = torch.randn(3, 4), torch.randn(4)
-        r1 = gm(new_xs, new_y)
-        r2 = f(new_xs, new_y)
-        self.assertEqual(r1[0], r2[0])
-        self.assertEqual(r1[1], r2[1])
-
-    def test_scan(self):
+    def test_scan_simple(self):
+        """Mirrors hop_db simple_scan."""
         from torch._higher_order_ops.scan import scan_op
 
+        def combine_fn(carry, x):
+            result = carry @ x + x
+            return result, carry.clone()
+
         def f(init, xs):
-            def combine_fn(carry, x):
-                return carry + x, carry.clone()
+            return scan_op(combine_fn, [init], [xs], ())
 
-            return scan_op(combine_fn, [init], [xs], [])
-
-        init = torch.randn(4)
-        xs = torch.randn(3, 4)
+        init = make_tensor(2, 2, low=0.1, high=2, dtype=torch.float, device="cpu")
+        xs = make_tensor(2, 2, 2, low=0.1, high=2, dtype=torch.float, device="cpu")
         with cpp_fake_tensor_mode():
             gm = make_fx(f, tracing_mode="real")(init, xs)
-        new_init, new_xs = torch.randn(4), torch.randn(3, 4)
-        r1 = gm(new_init, new_xs)
-        r2 = f(new_init, new_xs)
-        self.assertEqual(r1, r2)
+        new_init, new_xs = torch.randn(2, 2), torch.randn(2, 2, 2)
+        self.assertEqual(gm(new_init, new_xs), f(new_init, new_xs))
 
 
 # --- OpInfo-based exhaustive tests for C++ FakeTensor mode ---

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -864,6 +864,11 @@ def assoiciative_scan_fake_tensor_mode(mode, combine_fn, xs, additional_inputs):
         return tuple(x.clone() for x in xs)
 
 
+@associative_scan_op.py_impl(DispatchKey.Fake)
+def associative_scan_fake_dispatch(combine_fn, xs, additional_inputs):
+    return tuple(x.clone() for x in xs)
+
+
 @associative_scan_op.py_functionalize_impl
 def associative_scan_functionalize(ctx, combine_fn, xs, additional_inputs):
     from torch._higher_order_ops.utils import _check_alias_and_mutation

--- a/torch/_higher_order_ops/auto_functionalize.py
+++ b/torch/_higher_order_ops/auto_functionalize.py
@@ -871,6 +871,16 @@ def auto_functionalized_fake(
         return result
 
 
+@auto_functionalized.py_impl(DispatchKey.Fake)
+def auto_functionalized_fake_dispatch(
+    _mutable_op: OpOverload,
+    **kwargs: Any,
+) -> tuple[Any, tuple[Tensor, ...]]:
+    return auto_functionalized_dense(
+        _mutable_op, _only_clone_these_tensors=None, **kwargs
+    )
+
+
 @auto_functionalized.py_impl(ProxyTorchDispatchMode)
 def auto_functionalized_proxy(
     mode,
@@ -995,6 +1005,16 @@ def auto_functionalized_v2_fake(
             _mutable_op, _only_clone_these_bases=None, **kwargs
         )
         return result
+
+
+@auto_functionalized_v2.py_impl(DispatchKey.Fake)
+def auto_functionalized_v2_fake_dispatch(
+    _mutable_op: _MutableOpType,
+    **kwargs: dict[str, Any],
+) -> tuple[Any, tuple[Tensor, ...]]:
+    return auto_functionalized_v2_dense(
+        _mutable_op, _only_clone_these_bases=None, **kwargs
+    )
 
 
 @auto_functionalized_v2.py_impl(ProxyTorchDispatchMode)

--- a/torch/_higher_order_ops/base_hop.py
+++ b/torch/_higher_order_ops/base_hop.py
@@ -66,6 +66,7 @@ class BaseHOP(HigherOrderOperator, abc.ABC):
         self.py_functionalize_impl(self._call_Functionalize)
         self.py_impl(ProxyTorchDispatchMode)(self._call_ProxyTorchDispatchMode)
         self.py_impl(FakeTensorMode)(self._call_FakeTensorMode)
+        self.py_impl(DispatchKey.Fake)(self._call_Fake)
         self.py_impl(DispatchKey.CompositeExplicitAutograd)(
             self._call_CompositeExplicitAutograd
         )
@@ -131,6 +132,9 @@ class BaseHOP(HigherOrderOperator, abc.ABC):
         # TODO: this should probably route through FakeTensorMode to reuse caching
         with mode:
             return subgraph(*operands)
+
+    def _call_Fake(self, subgraph, *operands, **kwargs):
+        return subgraph(*operands)
 
     # NOTE [Support input mutation of hops]
     # To support input mutation, hop's subgraph must be functionalized because many inductor passes are

--- a/torch/_higher_order_ops/cond.py
+++ b/torch/_higher_order_ops/cond.py
@@ -433,6 +433,71 @@ def cond_fake_tensor_mode(mode, pred, true_fn, false_fn, operands):
     return pytree.tree_unflatten(merged_outs, true_out_spec)
 
 
+@cond_op.py_impl(DispatchKey.Fake)
+def cond_fake_dispatch(pred, true_fn, false_fn, operands):
+    # C++ fake tensor mode is active in TLS — ops inside the subgraphs
+    # hit C++ fakeFallback directly.
+    flat_true_outs, true_out_spec = pytree.tree_flatten(true_fn(*operands))
+    flat_false_outs, false_out_spec = pytree.tree_flatten(false_fn(*operands))
+    if true_out_spec != false_out_spec:
+        raise RuntimeError(
+            "Unmatched output spec from torch.cond branches: "
+            f"true branch tree_spec {true_out_spec} vs false branch tree_spec {false_out_spec}."
+        )
+
+    merged_outs = []
+    for true_out, false_out in zip(flat_true_outs, flat_false_outs):
+        merged_outs.append(_merge_output_static(true_out, false_out))
+    return pytree.tree_unflatten(merged_outs, true_out_spec)
+
+
+def _merge_output_static(
+    a: torch.Tensor | int | None,
+    b: torch.Tensor | int | None,
+):
+    """Static-shape merge for cond branches under C++ fake tensor mode.
+
+    Unlike _merge_output, this does not create unbacked symints for differing
+    sizes — sizes, strides, dtype, and device must match exactly.
+    """
+    if a is None or b is None:
+        if not (a is None and b is None):
+            raise AssertionError(f"expected both a and b to be None, got a={a}, b={b}")
+        return None
+
+    if type(a) is int and type(b) is int:
+        if a != b:
+            raise RuntimeError(
+                f"Expected same int output from cond branches but got {a} and {b}"
+            )
+        return a
+
+    if not (isinstance(a, torch.Tensor) and isinstance(b, torch.Tensor)):
+        raise AssertionError(
+            f"expected both a and b to be Tensor, got a={type(a)}, b={type(b)}"
+        )
+
+    check_tensor_meta_match(
+        a,
+        b,
+        ("dtype", "device", "layout", "dim", "is_quantized", "is_conj", "is_sparse"),
+        msg_prefix="When merging two branches' output in torch.cond, ",
+    )
+
+    if a.size() != b.size():
+        raise RuntimeError(
+            f"Expected same size from cond branches but got {a.size()} and {b.size()}. "
+            "Use symbolic tracing to support dynamic shapes in cond branches."
+        )
+    if a.stride() != b.stride():
+        raise RuntimeError(
+            f"Expected same stride from cond branches but got {a.stride()} and {b.stride()}. "
+            "Consider using contiguous() to make the two branches have the same contiguousness."
+        )
+
+    return a
+
+
 def check_tensor_meta_match(
     t1: torch.Tensor, t2: torch.Tensor, attr_names: tuple[str, ...], msg_prefix: str
 ) -> None:

--- a/torch/_higher_order_ops/effects.py
+++ b/torch/_higher_order_ops/effects.py
@@ -165,6 +165,16 @@ def with_effects_fake(
         return result
 
 
+@with_effects.py_impl(DispatchKey.Fake)
+def with_effects_fake_dispatch(
+    token: torch.Tensor,
+    op: torch._ops.OpOverload,
+    *args: tuple[Any, ...],
+    **kwargs: dict[str, Any],
+) -> tuple[torch.Tensor, ...]:
+    return with_effects_dense(token, op, *args, **kwargs)
+
+
 @with_effects.py_impl(ProxyTorchDispatchMode)
 def with_effects_proxy(
     mode,

--- a/torch/_higher_order_ops/hints_wrap.py
+++ b/torch/_higher_order_ops/hints_wrap.py
@@ -86,6 +86,12 @@ def hints_wrapper_fake_tensor_mode(mode, body_func, args, kwargs, hints):
         return body_func(*flat_args, **kwargs)
 
 
+@hints_wrapper.py_impl(DispatchKey.Fake)
+def hints_wrapper_fake_dispatch(body_func, args, kwargs, hints):
+    flat_args = pytree.tree_leaves(args)
+    return body_func(*flat_args, **kwargs)
+
+
 @hints_wrapper.py_functionalize_impl
 def hints_wrapper_functionalize(ctx, body_fn, args, kwargs, hints):
     from torch._higher_order_ops.utils import _check_alias_and_mutation

--- a/torch/_higher_order_ops/inline_asm_elementwise.py
+++ b/torch/_higher_order_ops/inline_asm_elementwise.py
@@ -255,6 +255,11 @@ def _(mode, *inputs, asm_str, constraints, dtype, is_pure=True, pack=1):
         return _elementwise_output_like(*inputs, dtype=dtype)
 
 
+@inline_asm_elementwise.py_impl(DispatchKey.Fake)
+def _inline_asm_fake_dispatch(*inputs, asm_str, constraints, dtype, is_pure=True, pack=1):
+    return _elementwise_output_like(*inputs, dtype=dtype)
+
+
 @inline_asm_elementwise.py_impl(ProxyTorchDispatchMode)
 def _(mode, *inputs, asm_str, constraints, dtype, is_pure=True, pack=1):
     proxy_args = pytree.tree_map(mode.tracer.unwrap_proxy, inputs)

--- a/torch/_higher_order_ops/map.py
+++ b/torch/_higher_order_ops/map.py
@@ -303,6 +303,19 @@ def map_fake_tensor_mode(mode, f, xs, args):
         return _broadcast_to_batch(example_output, batch_size)
 
 
+@map_impl.py_impl(DispatchKey.Fake)
+def map_fake_dispatch(f, xs, args):
+    from torch._higher_order_ops.utils import first_slice_copy
+
+    first_row = pytree.tree_map(first_slice_copy, xs)
+    example_output = f(*first_row, *args)
+
+    flat_xs, _ = pytree.tree_flatten(xs)
+    batch_size = flat_xs[0].shape[0]
+
+    return _broadcast_to_batch(example_output, batch_size)
+
+
 @map_impl.py_functionalize_impl
 def map_functionalize(ctx, f, xs, pos_args):
     from torch._higher_order_ops.utils import (

--- a/torch/_higher_order_ops/out_dtype.py
+++ b/torch/_higher_order_ops/out_dtype.py
@@ -155,6 +155,15 @@ def out_dtype_fake_tensor_mode(
         return out_dtype_dense(op, output_dtype, *args)
 
 
+@out_dtype.py_impl(DispatchKey.Fake)
+def out_dtype_fake_dispatch(
+    op: torch._ops.OpOverload,
+    output_dtype: torch.dtype,
+    *args,
+):
+    return out_dtype_dense(op, output_dtype, *args)
+
+
 @out_dtype.py_functionalize_impl
 def out_dtype_func(ctx, op, output_dtype, *args):
     unwrapped_args = tuple(ctx.unwrap_tensors(arg) for arg in args)

--- a/torch/_higher_order_ops/print.py
+++ b/torch/_higher_order_ops/print.py
@@ -2,6 +2,7 @@ import builtins
 
 import torch
 import torch.utils._pytree as pytree
+from torch._C import DispatchKey
 from torch._ops import HigherOrderOperator
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.fx.experimental.proxy_tensor import ProxyTorchDispatchMode
@@ -88,6 +89,12 @@ def print_proxy_torch_dispatch_mode(
 @print.py_impl(FakeTensorMode)
 # pyre-ignore
 def print_fake_tensor_mode(mode, format_str: str, *args: object, **kwargs: object):
+    return None
+
+
+@print.py_impl(DispatchKey.Fake)
+# pyre-ignore
+def print_fake_dispatch(format_str: str, *args: object, **kwargs: object):
     return None
 
 

--- a/torch/_higher_order_ops/run_const_graph.py
+++ b/torch/_higher_order_ops/run_const_graph.py
@@ -74,6 +74,17 @@ def run_const_graph_fake_tensor_mode(
         return graph(*args)
 
 
+@run_const_graph.py_impl(DispatchKey.Fake)
+def run_const_graph_fake_dispatch(
+    graph: torch.fx.GraphModule, args: tuple[object, ...]
+) -> object:
+    if not isinstance(graph, torch.fx.GraphModule):
+        raise AssertionError(
+            f"expected graph to be torch.fx.GraphModule, got {type(graph)}"
+        )
+    return graph(*args)
+
+
 @run_const_graph.py_impl(DispatchKey.CPU)
 def run_const_graph_cpu(
     graph: torch.fx.GraphModule, args: tuple[object, ...]

--- a/torch/_higher_order_ops/scan.py
+++ b/torch/_higher_order_ops/scan.py
@@ -856,6 +856,24 @@ def scan_fake_tensor_mode(mode, combine_fn, init, xs, additional_inputs):
         return out
 
 
+@scan_op.py_impl(DispatchKey.Fake)
+def scan_fake_dispatch(combine_fn, init, xs, additional_inputs):
+    scan_length = xs[0].shape[0]
+    carry, outputs = _extract_carry_and_out(
+        combine_fn(
+            *init,
+            *[first_slice_copy(inp) for inp in xs],
+            *additional_inputs,
+        ),
+        len(init),
+    )
+    out = (
+        *carry,
+        *(stack_y(t, scan_length) for t in outputs),
+    )
+    return out
+
+
 @scan_op.py_functionalize_impl
 def scan_functionalize(ctx, combine_fn, init, xs, additional_inputs):
     from torch._higher_order_ops.utils import (

--- a/torch/_higher_order_ops/strict_mode.py
+++ b/torch/_higher_order_ops/strict_mode.py
@@ -88,6 +88,11 @@ def strict_mode_fake_tensor_mode(mode, callable, operands):
     return true_outs
 
 
+@strict_mode_op.py_impl(DispatchKey.Fake)
+def strict_mode_fake_dispatch(callable, operands):
+    return callable(*operands)
+
+
 @strict_mode_op.py_functionalize_impl
 def strict_mode_func(ctx, callable, inputs):
     unwrapped_inputs = ctx.unwrap_tensors(inputs)

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1363,6 +1363,18 @@ def triton_kernel_wrapper_mutation_fake_tensor_mode(
         return None
 
 
+@triton_kernel_wrapper_mutation.py_impl(DispatchKey.Fake)
+def triton_kernel_wrapper_mutation_fake_dispatch(
+    *,
+    kernel_idx: int,
+    constant_args_idx: int,
+    grid: list["TritonGridType"],
+    tma_descriptor_metadata: TMADescriptorMetadata,
+    kwargs: dict[str, Any],
+) -> None:
+    return None
+
+
 @triton_kernel_wrapper_mutation.py_impl(DispatchKey.Meta)
 def _(
     *,
@@ -1535,6 +1547,23 @@ def triton_kernel_wrapper_functional_fake_tensor_mode(
             for key, val in kwargs.items()
             if key in tensors_to_clone
         }
+
+
+@triton_kernel_wrapper_functional.py_impl(DispatchKey.Fake)
+def triton_kernel_wrapper_functional_fake_dispatch(
+    *,
+    kernel_idx: int,
+    constant_args_idx: int,
+    grid: list["TritonGridType"],
+    tma_descriptor_metadata: TMADescriptorMetadata,
+    kwargs: dict[str, Any],
+    tensors_to_clone: list[str],
+) -> dict[str, Any]:
+    return {
+        key: clone_preserve_strides(val)
+        for key, val in kwargs.items()
+        if key in tensors_to_clone
+    }
 
 
 @triton_kernel_wrapper_functional.py_impl(ProxyTorchDispatchMode)

--- a/torch/_higher_order_ops/while_loop.py
+++ b/torch/_higher_order_ops/while_loop.py
@@ -576,6 +576,26 @@ def while_loop_fake_tensor_mode(
         )
 
 
+@while_loop_op.py_impl(DispatchKey.Fake)
+def while_loop_fake_dispatch(
+    cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
+):
+    if stack_output:
+        raise NotImplementedError(
+            "while_loop with stack_output=True requires symbolic shapes (ShapeEnv), "
+            "which is not supported under C++ fake tensor mode."
+        )
+    body_outs = body_fn(*carried_inputs, *additional_inputs)
+    check_meta_consistency(
+        carried_inputs,
+        body_outs,
+        "carried_inputs",
+        "body_output",
+        include_contiguity=False,
+    )
+    return body_outs
+
+
 @while_loop_op.py_functionalize_impl
 def while_loop_func(
     ctx, cond_fn, body_fn, carried_inputs, additional_inputs, stack_output=False
@@ -942,6 +962,10 @@ while_loop_stack_output_op.py_impl(ProxyTorchDispatchMode)(
 
 while_loop_stack_output_op.py_impl(FakeTensorMode)(
     functools.partial(while_loop_fake_tensor_mode, stack_output=True)
+)
+
+while_loop_stack_output_op.py_impl(DispatchKey.Fake)(
+    functools.partial(while_loop_fake_dispatch, stack_output=True)
 )
 
 while_loop_stack_output_op.py_functionalize_impl(


### PR DESCRIPTION
registering higher order ops with Fake dispatch key, testing by calling the internal op directly instead of user facing API which wraps it in compile (since compile isnt integrated w/ C++ faketensor, it will create a Python FakeTensorMode)

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #182724
* #182059
* #181773
* #181004
* #180378
* __->__ #179921
* #179862
* #178540
* #178030
* #178431
* #178430
* #178429
* #178428
* #178536

