### PR TITLE
[TorchAO][hipSPARSELt] Add alg_id to FP8 semi-structured sparsity benchmark

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
+++ b/aten/src/ATen/native/sparse/cuda/cuSPARSELtOps.cpp
@@ -480,6 +480,8 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         &alg_id,
         sizeof(alg_id)));
 
+#ifndef USE_ROCM
+    // hipSPARSELt does not support querying SPLIT_K attributes
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,
         &alg_sel,
@@ -493,6 +495,7 @@ std::tuple<at::Tensor, int64_t, int64_t, int64_t, int64_t> _cslt_sparse_mm_impl(
         CUSPARSELT_MATMUL_SPLIT_K_MODE,
         &splitKMode,
         sizeof(splitKMode)));
+#endif
 
     TORCH_CUDASPARSE_CHECK(cusparseLtMatmulAlgGetAttribute(
         &handle,


### PR DESCRIPTION
Summary:
What: Adds `alg_id` search to select the best performing hipSPARSELt kernel for each shape at runtime.

Why: 
* Default `alg_id=0` performs poorly for many shapes on MI350X — with 13/18 Fixed K shapes regressing vs. dense
* alg_id search recovers significant performance: Fixed K improves from 5/18 to 17/18 shapes beating dense, and the kernel bug shapes (M=N=11264–14336) recover from 0.11x to ~1.30x

Test Plan:
```
buck run mode/amd-gpu -c cxx.extra_cxxflags=-Wno-unused-value scripts/gylls/torchao:benchmark_semi_structured_sparsity -- --mode nvidia-fixed-mn --dtype fp8 --backend cusparselt -save
```
| Mode | Avg Speedup | Min | Max | Notes |
| -- |
| BERT Shapes | 0.95x | 0.72x | 1.11x | 2/4 shapes beat dense; small shapes still regress |
| Fixed K=10240 | 1.22x | 0.85x | 1.47x | 17/18 shapes beat dense after alg_id search; kernel bug shapes recover to ~1.30x |
| Fixed M=N=10240 | 1.42x | 1.12x | 1.57x | Sparse outperforms dense across all K values |
| M4 Target Shapes | 1.05x | 0.84x | 1.29x | Large N (133120) shapes gain 1.17–1.29x; small N (20544) still regresses |

* FP8 2:4 sparsity on MI350X shows strong results with alg_id search — Fixed K improves from mostly regressing to 17/18 shapes beating dense (avg 1.22x), and the kernel bug shapes (M=N=11264–14336) recover to ~1.30x using alg_id.
* Small M/N shapes (BERT, M4 small-N) remain below 1x for most shapes regardless of alg_id — sparse overhead dominates at these sizes and sparsity should not be enabled by default.

Benchmark results with alg_id: https://fburl.com/gdoc/dg622pvx

Differential Revision: D99334033


