### PR TITLE
Use ROCM_VERSION instead of TORCH_HIP_VERSION to gate expandable segments (#179930)

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -35,7 +35,7 @@ class C10_CUDA_API CUDAAllocatorConfig {
     bool enabled = c10::CachingAllocator::AcceleratorAllocatorConfig::
         use_expandable_segments();
 #if !defined(PYTORCH_C10_DRIVER_API_SUPPORTED) && \
-    (!defined(USE_ROCM) || (TORCH_HIP_VERSION < 702))
+    (!defined(USE_ROCM) || (ROCM_VERSION < 70000))
     if (enabled) {
       TORCH_WARN_ONCE("expandable_segments not supported on this platform")
     }

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2289,6 +2289,10 @@ torch.cuda.synchronize()
     )
     def test_graph_rng_after_failed_capture(self):
         """Test that a stream can be captured again for RNG after a failed capture."""
+        if TEST_WITH_ROCM and self.expandable_segments:
+            self.skipTest(
+                "ROCm expandable segments has known issue with graph capture recovery - #179911"
+            )
         stream = torch.cuda.Stream()
         graph = torch.cuda.CUDAGraph()
         x = torch.ones(1, device="cuda")


### PR DESCRIPTION
Summary:

Use `ROCM_VERSION` (format: `major*10000 + minor*100 + patch`) instead of `TORCH_HIP_VERSION` (format: `major*100 + minor`) to gate expandable segments on ROCm.

The previous gate `TORCH_HIP_VERSION < 702` was accidentally disabling expandable segments on ROCm versions 7.0.x (since `TORCH_HIP_VERSION` for HIP 7.0 = 700 < 702). The corrected gate `ROCM_VERSION < 70000` properly limits the disable to ROCm < 7.0.0.

Also adds a test skip for `test_graph_rng_after_failed_capture` on ROCm when expandable segments are active. This is a pre-existing issue (tracked in pytorch/pytorch#179911) where CUDA graph capture failure recovery doesn't work correctly with expandable segments on ROCm. The skip is conditioned on `TEST_WITH_ROCM and self.expandable_segments` so the test still runs on ROCm without expandable segments.

Test Plan:
- CI (internal + GitHub Actions)
- Build verification: `buck build fbcode//caffe2/c10/cuda:cuda --config caffe2.enable_hip=true` passes
- Test skip verified: `test_graph_rng_after_failed_capture` will be skipped only when ROCm + expandable segments are both active

Reviewed By: mrajpal, joshuuuasu, banitag1

Differential Revision: D100184839




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang