### PR TITLE
Hipify CUdeviceptr in lazy scratch allocation codegen

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -399,7 +399,8 @@ class DeferredTritonCallWrapper:
             size_expr = f"{kernel_name}_result.{scratch_name}"
             var = f"{scratch_name}_ptr"
             prefix.splice(
-                f"""\
+                maybe_hipify_code_wrapper(
+                    f"""\
                 {device_ptr_type} {var} = 0;
                 RAIIAtenTensorHandle {var}_tensor;
                 if ({size_expr} > 0) {{
@@ -413,6 +414,7 @@ class DeferredTritonCallWrapper:
                     {var} = reinterpret_cast<{device_ptr_type}>({var}_tensor.data_ptr());
                 }}
             """
+                )
             )
             call_args_str += f", &{var}"
         return call_args_str


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179978

The _generate_lazy_scratch method emits CUdeviceptr (a CUDA driver API
type) without passing the generated code through maybe_hipify_code_wrapper.
On ROCm builds, CUdeviceptr is not defined in HIP headers, causing a C++
compile error in test_cpu_scalar_with_gpu_tensor_cpp_cuda.

Wrap the generated code block in maybe_hipify_code_wrapper() so
CUdeviceptr is mapped to hipDeviceptr_t on ROCm, matching the pattern
used at the other codegen sites in the same file.

Should fix CI errors that look like:
```
error: ‘CUdeviceptr’ was not declared in this scope
```

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo