### PR TITLE
Add DynamicShapesType alias for standalone_compile

### DIFF
--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -9,7 +9,7 @@ from typing import Any, IO, Literal, Optional, TYPE_CHECKING, Union
 
 import torch.fx
 
-from .standalone_compile import CompiledArtifact  # noqa: TC001
+from .standalone_compile import CompiledArtifact, DynamicShapesType  # noqa: TC001
 
 
 if TYPE_CHECKING:
@@ -407,9 +407,7 @@ def standalone_compile(
     gm: torch.fx.GraphModule,
     example_inputs: list[InputType],
     *,
-    dynamic_shapes: Literal[
-        "from_example_inputs", "from_tracing_context", "from_graph"
-    ] = "from_graph",
+    dynamic_shapes: DynamicShapesType = "from_graph",
     options: dict[str, Any] | None = None,
     aot: bool = False,  # AOT mode, which uses BundledAOTAutogradCache
 ) -> CompiledArtifact:

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -10,6 +10,9 @@ from abc import ABC, abstractmethod
 from contextlib import AbstractContextManager, nullcontext
 from typing import Any, Literal, TYPE_CHECKING
 
+
+DynamicShapesType = Literal["from_example_inputs", "from_tracing_context", "from_graph"]
+
 import torch.fx
 from torch._dynamo.aot_compile_types import BundledAOTAutogradSerializableCallable
 from torch._dynamo.utils import dynamo_timed
@@ -372,13 +375,15 @@ class AOTCompiledArtifact(CompiledArtifact):
             return AOTCompiledArtifact.deserialize(artifact)
 
 
-def _resolve_ignore_shape_env(dynamic_shapes: Any):
+def _resolve_ignore_shape_env(dynamic_shapes: DynamicShapesType):
     # tells compile_fx to ignore the shape_envs on the ambient context
     # and the graph_module.
     return dynamic_shapes == "from_example_inputs"
 
 
-def _resolve_fake_mode(gm: GraphModule, dynamic_shapes: Any) -> FakeTensorMode:
+def _resolve_fake_mode(
+    gm: GraphModule, dynamic_shapes: DynamicShapesType
+) -> FakeTensorMode:
     if dynamic_shapes == "from_example_inputs":
         return FakeTensorMode(shape_env=ShapeEnv())
     elif dynamic_shapes == "from_tracing_context":
@@ -421,7 +426,7 @@ def _resolve_fake_mode(gm: GraphModule, dynamic_shapes: Any) -> FakeTensorMode:
 
 
 @contextlib.contextmanager
-def _standalone_context(gm: GraphModule, dynamic_shapes: Any, aot: bool):
+def _standalone_context(gm: GraphModule, dynamic_shapes: DynamicShapesType, aot: bool):
     from torch.compiler._cache import CacheArtifactManager
 
     fake_mode = _resolve_fake_mode(gm, dynamic_shapes)
@@ -439,7 +444,7 @@ def standalone_compile(
     gm: GraphModule,
     example_inputs: Sequence[InputType],
     *,
-    dynamic_shapes: Any,
+    dynamic_shapes: DynamicShapesType,
     options: Any,
     aot: bool = False,  # AOT mode, which uses BundledAOTAutogradCache
 ) -> CompiledArtifact:
@@ -476,7 +481,7 @@ def standalone_compile(
 def autograd_cache_key(
     graph,
     example_inputs,
-    dynamic_shapes: Any,
+    dynamic_shapes: DynamicShapesType,
     aot: bool = False,  # AOT mode, which uses BundledAOTAutogradCache
 ):
     from . import compile_fx


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #179993
* #179916
* #179915

Replace `dynamic_shapes: Any` with a proper
`Literal["from_example_inputs", "from_tracing_context", "from_graph"]`
type alias in all standalone_compile internal functions. The public API
in `__init__.py` already used the inline Literal — this shares a single
alias so the two stay in sync.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo