### PR TITLE
Make ruff the source of truth over flake8 for shared lint rules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,13 +12,21 @@ ignore =
     # to line this up with executable bit
     EXE001,
     # these ignores are from flake8-bugbear; please fix!
-    B007,B008,B017,B019,B023,B028,B903,B905,B906,B907,B908,B910
+    B007,B008,B017,B019,B023,B028,B903,B905,B906,B907,B908,B910,
     # these ignores are from flake8-simplify. please fix or ignore with commented reason
     SIM105,SIM108,SIM110,SIM111,SIM113,SIM114,SIM115,SIM116,SIM117,SIM118,SIM119,SIM12,
     # SIM104 is already covered by pyupgrade ruff
     SIM104,
     # flake8-simplify code styles
-    SIM102,SIM103,SIM106,SIM112
+    SIM102,SIM103,SIM106,SIM112,
+    # Codes where ruff is the source of truth. Ruff handles these (sometimes
+    # differently than flake8). As ruff promotes preview codes, move them here
+    # from ruff's external list.
+    B001,B036,B902,B904,B950,
+    C406,C417,C419,C901,
+    E121,E122,E124,E128,E131,E712,E722,E723,E731,
+    F401,F722,F723,F811,F812,
+    G001,G003,G004,G010,G200,G201,G202
 per-file-ignores =
     __init__.py: F401
     test/**: F821

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,21 +138,29 @@ quote-style = "double"
 [tool.ruff.lint]
 # NOTE: Synchoronize the ignores with .flake8
 external = [
-    "B001",
-    "B902",
-    "B950",
-    "E121",
-    "E122",
-    "E128",
-    "E131",
-    "E704",
-    "E723",
-    "F723",
-    "F812",
+    # Codes from flake8-only plugins that ruff doesn't implement.
     "P201",
     "P204",
     "T484",
     "TOR901",
+    # Codes that are preview-only in ruff, so flake8 is still the enforcer.
+    # As ruff promotes these out of preview, move them to flake8's ignore list.
+    "B901",
+    "B909",
+    "E115",
+    "E201",
+    "E221",
+    "E225",
+    "E226",
+    "E227",
+    "E231",
+    "E241",
+    "E261",
+    "E262",
+    "E265",
+    "E266",
+    "E272",
+    "E306",
 ]
 ignore = [
     # these ignores are from flake8-bugbear; please fix!


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179997
* #179996
* __->__ #179995

For codes that both ruff and flake8 check, ruff is now the enforcer.
Flake8 ignores those codes so it won't conflict. Codes still in ruff
preview stay in ruff's external list so flake8 continues to enforce
them. As ruff promotes preview codes, move them to flake8's ignore.

Authored with Claude.