### PR TITLE
Remove unused noqa directives in torch/

### DIFF
--- a/torch/_C/_distributed_rpc.pyi
+++ b/torch/_C/_distributed_rpc.pyi
@@ -78,8 +78,8 @@ class _TensorPipeRpcBackendOptionsBase(RpcBackendOptions):
         _channels: list | None,
         rpc_timeout: float = ...,
         init_method: str = ...,
-        device_maps: dict[str, dict[torch.device, torch.device]] = {},  # noqa: B006
-        devices: list[torch.device] = [],  # noqa: B006
+        device_maps: dict[str, dict[torch.device, torch.device]] = {},
+        devices: list[torch.device] = [],
     ) -> None: ...
     def _set_device_map(
         self,

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1712,7 +1712,7 @@ def _check_with(
     error_type,
     cond: builtins.bool | SymBool,
     message: _Callable[[], str],
-):  # noqa: F811
+):
     if not isinstance(cond, (builtins.bool, SymBool)):
         raise TypeError(f"cond must be a bool, but got {type(cond)}")
 
@@ -1743,7 +1743,7 @@ def _check_with(
     raise error_type(message_evaluated)
 
 
-def _check(cond, message=None):  # noqa: F811
+def _check(cond, message=None):
     r"""Throws error containing an optional message if the specified condition
     is False.
 
@@ -1797,7 +1797,7 @@ def _check_is_size(i, message=None, *, max=None):
         _advise_is_bounded(i, max)
 
 
-def _check_index(cond, message=None):  # noqa: F811
+def _check_index(cond, message=None):
     r"""Throws error containing an optional message if the specified condition
     is False.
 
@@ -1815,7 +1815,7 @@ def _check_index(cond, message=None):  # noqa: F811
     _check_with(IndexError, cond, message)  # pyrefly: ignore [bad-argument-type]
 
 
-def _check_value(cond, message=None):  # noqa: F811
+def _check_value(cond, message=None):
     r"""Throws error containing an optional message if the specified condition
     is False.
 
@@ -1833,7 +1833,7 @@ def _check_value(cond, message=None):  # noqa: F811
     _check_with(ValueError, cond, message)  # pyrefly: ignore [bad-argument-type]
 
 
-def _check_type(cond, message=None):  # noqa: F811
+def _check_type(cond, message=None):
     r"""Throws error containing an optional message if the specified condition
     is False.
 
@@ -1851,7 +1851,7 @@ def _check_type(cond, message=None):  # noqa: F811
     _check_with(TypeError, cond, message)  # pyrefly: ignore [bad-argument-type]
 
 
-def _check_not_implemented(cond, message=None):  # noqa: F811
+def _check_not_implemented(cond, message=None):
     r"""Throws error containing an optional message if the specified condition
     is False.
 
@@ -1874,7 +1874,7 @@ def _check_not_implemented(cond, message=None):  # noqa: F811
     )
 
 
-def _check_tensor_all_with(error_type, cond, message=None):  # noqa: F811
+def _check_tensor_all_with(error_type, cond, message=None):
     if not is_tensor(cond):
         raise TypeError(f"cond must be a tensor, but got {type(cond)}")
 
@@ -1885,7 +1885,7 @@ def _check_tensor_all_with(error_type, cond, message=None):  # noqa: F811
 
 
 # C++ equivalent: `TORCH_CHECK_TENSOR_ALL`
-def _check_tensor_all(cond, message=None):  # noqa: F811
+def _check_tensor_all(cond, message=None):
     r"""Throws error containing an optional message if the specified condition
     is False.
 

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -75,7 +75,7 @@ from .utils import (
 
 
 # Register polyfill functions
-from .polyfills import loader as _  # usort: skip # noqa: F401
+from .polyfills import loader as _  # usort: skip
 
 
 __all__ = [

--- a/torch/_dynamo/bytecode_debugger.py
+++ b/torch/_dynamo/bytecode_debugger.py
@@ -71,7 +71,7 @@ BREAKPOINT_MARKER = _BreakpointMarker()
 
 # Import NULL_STACK_VALUE sentinel from C++ module
 # This is returned by _get_frame_value_stack_with_depth for NULL stack slots
-from torch._C._dynamo.eval_frame import NULL_STACK_VALUE  # noqa: F401
+from torch._C._dynamo.eval_frame import NULL_STACK_VALUE
 
 
 @dataclass

--- a/torch/_dynamo/callback.py
+++ b/torch/_dynamo/callback.py
@@ -29,7 +29,7 @@ import enum
 import threading
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from dataclasses import dataclass, field  # noqa: F811
+from dataclasses import dataclass, field
 from typing import Any
 
 

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -985,7 +985,7 @@ class AutogradCompilerInstance:
         # Dynamo guards will error instead of creating aliasing guards unless we unpack them in the graph
         unpack_nodes: OrderedSet[torch.fx.Node] = OrderedSet()
         i: int | None = None
-        for i, node in enumerate(self.fx_tracer.graph.find_nodes(op="placeholder")):  # noqa: B007
+        for i, node in enumerate(self.fx_tracer.graph.find_nodes(op="placeholder")):
             unpack_nodes.update(node.users.keys())
         assert i == len(_graph_placeholders) - 1
 

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -909,7 +909,7 @@ inline_invoke_subgraph: bool = False
 invalidate_compile_context_weakrefs: bool | None = None
 
 if TYPE_CHECKING:
-    from torch.utils._config_typing import *  # noqa: F401, F403
+    from torch.utils._config_typing import *  # noqa: F403
 
     def _make_closure_patcher(**changes: Any) -> Any: ...
 

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -1477,7 +1477,7 @@ def compile_frame(  # type: ignore[return]
             failed_tracer_output = getattr(e, "_torch_dynamo_tracer_output", None)
             if failed_tracer_output:
                 failed_tracer_output._cleanup_output_graph()
-            log.debug(  # noqa: G200
+            log.debug(
                 "Received signal to skip frame (without graph break): %s %s \
                 %s %s",
                 e,

--- a/torch/_dynamo/dynamo_profiler.py
+++ b/torch/_dynamo/dynamo_profiler.py
@@ -381,7 +381,7 @@ class DynamoProfilerState:
 
             if gprof2dot.returncode != 0:
                 print(
-                    f"gprof2dot failed: {gprof2dot_err.decode()}"  # noqa: B950
+                    f"gprof2dot failed: {gprof2dot_err.decode()}"
                 )
                 return None
 

--- a/torch/_dynamo/graph_region_tracker.py
+++ b/torch/_dynamo/graph_region_tracker.py
@@ -271,7 +271,7 @@ class GraphRegionTracker:
                 duplicates.append(node)
                 self.node_to_duplicates[node] = duplicates
         except NodeHashException as e:
-            log.debug("Unable to hash node %s with exception %s", node, e)  # noqa: G200
+            log.debug("Unable to hash node %s with exception %s", node, e)
 
     def track_node_mutations(
         self,

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3488,7 +3488,7 @@ class GuardBuilder(GuardBuilderBase):
             if not static:
                 if hasattr(value, "_dynamo_dynamic_indices"):
                     dynamic_indices = value._dynamo_dynamic_indices
-                    code_part = f"(({tensor_name}._dynamo_dynamic_indices.issubset({dynamic_indices})) if hasattr({tensor_name}, '_dynamo_dynamic_indices') else True)"  # noqa: B950
+                    code_part = f"(({tensor_name}._dynamo_dynamic_indices.issubset({dynamic_indices})) if hasattr({tensor_name}, '_dynamo_dynamic_indices') else True)"
                     code.append(code_part)
                     self.get_guard_manager(guard).add_dynamic_indices_guard(
                         dynamic_indices,
@@ -3515,7 +3515,7 @@ class GuardBuilder(GuardBuilderBase):
                 # tensors that have the attribute when compile-time didn't.
                 if hasattr(value, "_dynamo_unbacked_indices"):
                     shape_ids = getattr(value, "_dynamo_shape_ids", None)
-                    code_part = f"((getattr({tensor_name}, '_dynamo_shape_ids', None) == {shape_ids!r}) if hasattr({tensor_name}, '_dynamo_unbacked_indices') else True)"  # noqa: B950
+                    code_part = f"((getattr({tensor_name}, '_dynamo_shape_ids', None) == {shape_ids!r}) if hasattr({tensor_name}, '_dynamo_unbacked_indices') else True)"
                     code.append(code_part)
                     self.get_guard_manager(guard).add_lambda_guard(
                         lambda x, expected=shape_ids: (
@@ -3534,7 +3534,7 @@ class GuardBuilder(GuardBuilderBase):
                 # tensors that have the attribute when compile-time didn't.
                 if hasattr(value, "_dynamo_unbacked_indices"):
                     unbacked_bounds = getattr(value, "_dynamo_unbacked_bounds", None)
-                    code_part = f"((getattr({tensor_name}, '_dynamo_unbacked_bounds', None) == {unbacked_bounds!r}) if hasattr({tensor_name}, '_dynamo_unbacked_indices') else True)"  # noqa: B950
+                    code_part = f"((getattr({tensor_name}, '_dynamo_unbacked_bounds', None) == {unbacked_bounds!r}) if hasattr({tensor_name}, '_dynamo_unbacked_indices') else True)"
                     code.append(code_part)
                     self.get_guard_manager(guard).add_lambda_guard(
                         lambda x, expected=unbacked_bounds: (
@@ -4151,7 +4151,7 @@ def make_guard_filter_entry(guard: Guard, builder: GuardBuilder) -> GuardFilterE
             # doesn't exist.
             value = builder.get(guard)
             has_value = True
-        except:  # noqa: B001,E722
+        except:  # noqa: E722
             value = MISSING
             has_value = False
     is_global = get_global_source_name(guard.originating_source) is not None
@@ -4183,7 +4183,7 @@ def pickle_guards_state(
                 try:
                     type(base).__new__(type(base))
                     empty_values[id(base)] = base
-                except:  # noqa: E722, B001
+                except:  # noqa: E722
                     pass
         elif id(leaf) not in guard_tree_values:
             # TODO See if we have lift this branch as the first one.
@@ -5247,7 +5247,7 @@ def guard_error_hook(
     for guard in guard_manager.code_parts:
         try:
             eval(guard, guard_manager.global_scope, local_scope)
-        except:  # noqa: B001,E722
+        except:  # noqa: E722
             print(f"Malformed guard:\n{guard}")
 
 

--- a/torch/_dynamo/resume_execution.py
+++ b/torch/_dynamo/resume_execution.py
@@ -106,7 +106,7 @@ def _try_except_tf_mode_template(dummy: Any, stack_var_name: Any) -> None:
     global __import_torch_dot__dynamo_dot_utils
     try:
         dummy
-    except:  # noqa: E722, B001
+    except:
         __import_torch_dot__dynamo_dot_utils.set_torch_function_mode_stack(  # type: ignore[name-defined]
             stack_var_name
         )

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3170,7 +3170,7 @@ def dict_keys_repr(const_keys: Any, *, local: Any) -> str:
 GLOBAL_KEY_PREFIX = "__dict_key"
 
 
-from torch._subclasses import UnsupportedFakeTensorException  # noqa: F401
+from torch._subclasses import UnsupportedFakeTensorException
 
 
 def get_safe_global_name(tx: InstructionTranslatorBase, root: str, obj: Any) -> str:

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -766,17 +766,17 @@ class VariableBuilder:
             pass
 
         if has_triton_experimental_host_tma():
-            from triton.tools.experimental_descriptor import (  # noqa: F811
+            from triton.tools.experimental_descriptor import (
                 create_1d_tma_descriptor,
                 create_2d_tma_descriptor,
             )
         if has_triton_tensor_descriptor_host_tma():
-            from triton.tools.tensor_descriptor import TensorDescriptor  # noqa: F811
+            from triton.tools.tensor_descriptor import TensorDescriptor
         if has_triton():
             import triton as triton_mod
 
             if hasattr(triton_mod, "set_allocator"):
-                set_allocator = triton_mod.set_allocator  # noqa: F811
+                set_allocator = triton_mod.set_allocator
 
         # Handle exact type() match
         type_dispatch = self._type_dispatch().get(type(value))
@@ -2840,7 +2840,7 @@ class VariableBuilder:
             # break because they expect all cuda inputs but our tensorified
             # float will be a f64[] cpu tensor. Fixes the following test
             # when specialize_float=False
-            # python test/inductor/test_compiled_optimizers.py CompiledOptimizerTests.test_rmsprop_weight_decay_maximize_capturable_cuda # noqa: B950
+            # python test/inductor/test_compiled_optimizers.py CompiledOptimizerTests.test_rmsprop_weight_decay_maximize_capturable_cuda
             or torch._inductor.config.triton.cudagraphs
             or justknobs_check("pytorch/compiler:unspecialize_float_killswitch", False)
             or (

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -1145,7 +1145,7 @@ class BuiltinVariable(BaseBuiltinVariable):
                     except TypeError as e:
                         has_constant_handler = obj.has_constant_handler(args, kwargs)
                         if not has_constant_handler:
-                            log.warning(  # noqa: G200
+                            log.warning(
                                 "incorrect arg count %s %s and no constant handler",
                                 self_handler,
                                 e,

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -759,7 +759,7 @@ class UserFunctionVariable(BaseUserFunctionVariable):
 
             if not isinstance(fn_var, UserFunctionVariable):
                 fn_name = fn_var.get_name()
-                msg = f"Applying `nonstrict_trace` to function <{fn_name}>; however, `nonstrict_trace` currently requires the function to be defined outside `torch.compile` region."  # noqa: B950
+                msg = f"Applying `nonstrict_trace` to function <{fn_name}>; however, `nonstrict_trace` currently requires the function to be defined outside `torch.compile` region."
                 unimplemented(
                     gb_type="Limitation of `nonstrict_trace",
                     context=f"{self}",

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -1842,7 +1842,7 @@ def speculate_subgraph_with_auto_output_flattening(
             f"fall back to eager-mode PyTorch, which could lead to a slowdown."
         )
         log.info(msg)
-        log.info(ex)  # noqa: G200
+        log.info(ex)
         raise ex
 
 
@@ -2042,7 +2042,7 @@ def speculate_subgraph(
             f"fall back to eager-mode PyTorch, which could lead to a slowdown."
         )
         log.info(msg)
-        log.info(ex)  # noqa: G200
+        log.info(ex)
         raise ex
 
 
@@ -5665,7 +5665,7 @@ class LocalMapWrappedHigherOrderVariable(WrapHigherOrderVariable):
         return out
 
 
-from .invoke_subgraph import InvokeSubgraphHigherOrderVariable  # noqa: E402
+from .invoke_subgraph import InvokeSubgraphHigherOrderVariable
 
 
 # Map operator names to their corresponding variable for fast TorchHigherOrderOperatorVariable.make()

--- a/torch/_dynamo/variables/iter.py
+++ b/torch/_dynamo/variables/iter.py
@@ -465,7 +465,7 @@ class ZipVariable(IteratorVariable):
 
         idx: int | None = None
         try:
-            for idx, it in enumerate(self.iterables):  # noqa:B007
+            for idx, it in enumerate(self.iterables):
                 args.append(get_item(it))
         except ObservedUserStopIteration:
             if self.strict:

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -574,7 +574,7 @@ class TensorVariable(VariableTracker):
                 )
             elif name in self._strict_mode_conditional_banned_ops():
                 raise UnknownPropertiesDuringBackwardTrace(
-                    f"Unknown property {name} during speculating backward, dynamo will insert contiguous call ahead and speculate it again"  # noqa: B950
+                    f"Unknown property {name} during speculating backward, dynamo will insert contiguous call ahead and speculate it again"
                 )
 
         if name == "__class__":

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -489,7 +489,7 @@ def call_torch_function(
     #
     # Also notice the `cls` is not explicitly passed in the reference
     # implementations:
-    # 1. https://github.com/pytorch/pytorch/blob/8d81806211bc3c0ee6c2ef235017bacf1d775a85/torch/csrc/utils/python_arg_parser.cpp#L368-L374  # noqa: B950
+    # 1. https://github.com/pytorch/pytorch/blob/8d81806211bc3c0ee6c2ef235017bacf1d775a85/torch/csrc/utils/python_arg_parser.cpp#L368-L374
     # 2. https://github.com/pytorch/pytorch/blob/8d81806211bc3c0ee6c2ef235017bacf1d775a85/torch/overrides.py#L1741-L1743
     tf_args = [
         fn,

--- a/torch/_export/config.py
+++ b/torch/_export/config.py
@@ -37,7 +37,7 @@ use_legacy_dynamo_graph_capture = True
 
 
 if TYPE_CHECKING:
-    from torch.utils._config_typing import *  # noqa: F401, F403
+    from torch.utils._config_typing import *  # noqa: F403
 
     def _make_closure_patcher(**changes: Any) -> Any: ...
 

--- a/torch/_export/converter.py
+++ b/torch/_export/converter.py
@@ -663,7 +663,7 @@ class TS2FXGraphConverter:
         def to_float_tensor(t):
             return t.to(dtype=torch.float).item()
 
-        inp_list = [self.get_fx_value_by_ir_value(inp) for inp in node.inputs()]  # noqa: C416
+        inp_list = [self.get_fx_value_by_ir_value(inp) for inp in node.inputs()]
         fx_node = self.fx_graph.call_function(
             to_float_tensor,
             tuple(inp_list),
@@ -750,7 +750,7 @@ class TS2FXGraphConverter:
         self.name_to_constant[name] = value
 
     def convert_prim_CallMethod(self, node: torch._C.Node):
-        inp_list = [self.get_fx_value_by_ir_value(inp) for inp in node.inputs()]  # noqa: C416
+        inp_list = [self.get_fx_value_by_ir_value(inp) for inp in node.inputs()]
         fx_node = self.fx_graph.call_method(
             node.s("name"),
             tuple(inp_list),

--- a/torch/_export/passes/lift_constants_pass.py
+++ b/torch/_export/passes/lift_constants_pass.py
@@ -137,7 +137,7 @@ def _unused_constant(node: torch.fx.Node) -> list[torch.fx.Node] | None:
 
     This function returns None if this constant is being used, otherwise it returns the
     lift_fresh and detach node to be removed later.
-    """  # noqa: B950
+    """
     if len(node.users) > 1:
         return None
 

--- a/torch/_export/passes/replace_quantized_ops_with_standard_ops_pass.py
+++ b/torch/_export/passes/replace_quantized_ops_with_standard_ops_pass.py
@@ -285,7 +285,7 @@ def _conv1d_op_with_squeeze(
 ) -> torch.Tensor:
     # In quantized version, conv1d is emulated using conv2d with squeeze and unsqueeze
     # operations before and after the conv2d operation to match the dimension of weights.
-    # Reference: https://github.com/pytorch/pytorch/blob/eca0cb0fbe84bb0a34fa94afe261bceecd52c436/aten/src/ATen/native/quantized/cpu/qconv.cpp#L1827  # noqa: B950
+    # Reference: https://github.com/pytorch/pytorch/blob/eca0cb0fbe84bb0a34fa94afe261bceecd52c436/aten/src/ATen/native/quantized/cpu/qconv.cpp#L1827
     s_inp = torch.ops.aten.unsqueeze(inp, 2)
     conv1d_res = torch.ops.aten.conv2d(
         s_inp,

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -397,7 +397,7 @@ def _check_symint(
                     path = get_keystr(keypath)
                     if i is not None:
                         path += f".shape[{i}]"
-                    raise RuntimeError(  # noqa: B904
+                    raise RuntimeError(
                         f"Expected input {path} = {arg} to be "
                         f"of the form {symint.node.expr}, where {symbol} is an integer"
                     )

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -78,7 +78,7 @@ from .runtime_wrappers import (
     SerializableCompiledFunction,
     SubclassMeta,
 )
-from .schemas import AOTAutogradCacheInfo, AOTConfig, ViewAndMutationMeta  # noqa: F401
+from .schemas import AOTAutogradCacheInfo, AOTConfig, ViewAndMutationMeta
 
 
 if TYPE_CHECKING:
@@ -957,7 +957,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         except Exception as e:
             cache_key = None
             counters["aot_autograd"]["autograd_cache_bypass"] += 1
-            log.info("Bypassing autograd cache due to: %s", e)  # noqa: G200
+            log.info("Bypassing autograd cache due to: %s", e)
             cache_state = "bypass"
             cache_event_time = time.time_ns()
             cache_info["cache_bypass_reason"] = str(e)
@@ -1136,7 +1136,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
                         ),
                     )
         except Exception as e:
-            log.info("AOTAutograd cache unable to load compiled graph: %s", e)  # noqa: G200
+            log.info("AOTAutograd cache unable to load compiled graph: %s", e)
             if config.strict_autograd_cache:
                 raise e
         if entry is not None:
@@ -1191,7 +1191,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         except (pickle.PicklingError, TypeError, AttributeError) as e:
             bad_field = AOTAutogradCache._find_unpicklable_field(entry)
             error_str = str(e)
-            log.warning("AOTAutograd cache unable to serialize compiled graph: %s", e)  # noqa: G200
+            log.warning("AOTAutograd cache unable to serialize compiled graph: %s", e)
             torch._logging.trace_structured(
                 "artifact",
                 metadata_fn=lambda: {
@@ -1213,10 +1213,10 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         """Handle exceptions during save, re-raising if strict mode is enabled."""
         if is_bypass:
             counters["aot_autograd"]["autograd_cache_bypass"] += 1
-            log.info("Bypassing autograd cache due to: %s", e)  # noqa: G200
+            log.info("Bypassing autograd cache due to: %s", e)
             bypass_reason = str(e)
         else:
-            log.warning("AOTAutograd cache unable to serialize compiled graph: %s", e)  # noqa: G200
+            log.warning("AOTAutograd cache unable to serialize compiled graph: %s", e)
             bypass_reason = "Unable to serialize: " + str(e)
         if remote:
             log_cache_bypass("bypass_aot_autograd", bypass_reason)

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -2363,7 +2363,7 @@ def _cache_autograd_info(
         # NB: aot_config here is technically not needed as an argument: we could just
         # close over aot_config.cache_info, since aot_config never changes.
         # But closing over random variables is confusing IMO, so I'm leaving it.
-        def try_save_cache_entry(  # noqa: F811
+        def try_save_cache_entry(
             compiled_bw_func: Callable[..., Any],
             bw_module: torch.fx.GraphModule,
             _fw_metadata: ViewAndMutationMeta,

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -382,7 +382,7 @@ class SubclassCreationMeta:
         # `_make_size_runtime_safe` replaces any nested int with a dummy value (-1)
         # to prevent serializing a SymInt at runtime. Internally, nested tensor __tensor_unflatten__
         # is designed to safely ignore this dummy value.
-        # For more details, see: https://github.com/pytorch/pytorch/blob/5141ade8e30c64e873e14dcc8de233da45d15025/torch/nested/_internal/nested_tensor.py#L266-L299  # noqa: B950
+        # For more details, see: https://github.com/pytorch/pytorch/blob/5141ade8e30c64e873e14dcc8de233da45d15025/torch/nested/_internal/nested_tensor.py#L266-L299
         self.outer_size = tuple(map(_make_size_runtime_safe, self.outer_size))
         self.outer_stride = tuple(map(_make_size_runtime_safe, self.outer_stride))
 

--- a/torch/_functorch/_aot_autograd/streams.py
+++ b/torch/_functorch/_aot_autograd/streams.py
@@ -16,7 +16,7 @@ from torch.utils._runtime_estimation import (
 
 
 if TYPE_CHECKING:
-    from .schemas import ViewAndMutationMeta  # noqa: TC004
+    from .schemas import ViewAndMutationMeta
 
 from .indexed_dict import IndexedDict
 

--- a/torch/_functorch/_aot_autograd/subclass_codegen.py
+++ b/torch/_functorch/_aot_autograd/subclass_codegen.py
@@ -332,7 +332,7 @@ def _compile_and_exec_source(
 
     code = compile(source, f"<{artifact_name}>", "exec")
     local_dict: dict[str, object] = {}
-    exec(code, globals_dict, local_dict)  # noqa: S102
+    exec(code, globals_dict, local_dict)
     fn = local_dict[fn_name]
     if wrapped_fn is not None:
         functools.update_wrapper(fn, wrapped_fn)  # type: ignore[arg-type]

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -34,12 +34,12 @@ from torch.fx.experimental.proxy_tensor import make_fx
 
 from . import config
 from ._aot_autograd import autograd_cache
-from ._aot_autograd.autograd_cache import (  # noqa: F401
+from ._aot_autograd.autograd_cache import (
     AOTAutogradCache,
     should_use_local_autograd_cache,
     should_use_remote_autograd_cache,
 )
-from ._aot_autograd.collect_metadata_analysis import (  # noqa: F401
+from ._aot_autograd.collect_metadata_analysis import (
     run_functionalized_fw_and_collect_metadata,
 )
 from ._aot_autograd.descriptors import (
@@ -77,7 +77,7 @@ from ._aot_autograd.graph_capture_wrappers import (  # noqa: F401
     fn_input_mutations_to_outputs,
     fn_prepped_for_autograd,
 )
-from ._aot_autograd.graph_compile import (  # noqa: F401
+from ._aot_autograd.graph_compile import (
     aot_stage1_graph_capture,
     aot_stage2_compile,
     aot_stage2_export,
@@ -1826,7 +1826,7 @@ def aot_export_joint_simple(
 
     if config.debug_assert:
         # Smoke test that after partitioning, we can run the forward without any calling convention changes.
-        fw_module, _bw_module = default_partition(  # noqa: F821
+        fw_module, _bw_module = default_partition(
             # type: ignore[bad-argument-type]
             fx_g,
             args,

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -116,7 +116,7 @@ def fx_graph_cse(fx_g: torch.fx.graph.Graph) -> fx.Graph:
             # replace the meta of downstream users. eg. one bug we've seen is:
             #
             # _local_scalar_dense_11: "Sym(u14)" = torch.ops.aten._local_scalar_dense.default(select_10);
-            # sym_sum_2: "Sym(u19 + u20 + u21)" = torch.sym_sum((_local_scalar_dense_11, _local_scalar_dense_12, _local_scalar_dense_13)) # noqa: B950
+            # sym_sum_2: "Sym(u19 + u20 + u21)" = torch.sym_sum((_local_scalar_dense_11, _local_scalar_dense_12, _local_scalar_dense_13))
             #
             # Notice how _local_scalar_dense_11 is u14 but sym_sum_2's meta is incorrectly the old
             # pre-cse value of u19.

--- a/torch/_functorch/compilers.py
+++ b/torch/_functorch/compilers.py
@@ -447,8 +447,8 @@ def _save_fx_default(
         if dump_example_input:
             torch.save(
                 args,
-                f"{folder_name}/{current_name}/{current_name}_{type_name}_{graph_index}/{current_name}_{type_name}_{graph_index}.pt",  # noqa: B950
-            )  # noqa: E501
+                f"{folder_name}/{current_name}/{current_name}_{type_name}_{graph_index}/{current_name}_{type_name}_{graph_index}.pt",
+            )
 
     def graph_saver_forward(
         gm: fx.GraphModule, example_inputs: list[torch.Tensor]

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -437,7 +437,7 @@ selective_decompose: bool = False
 
 
 if TYPE_CHECKING:
-    from torch.utils._config_typing import *  # noqa: F401, F403
+    from torch.utils._config_typing import *  # noqa: F403
 
 
 # adds patch, save_config, invalid config checks, etc

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1743,7 +1743,7 @@ def functionalize_rng_ops(
         return torch.device("cpu")
 
     def get_sample_rng_state(device: torch.device | None) -> torch.Tensor:
-        from torch._guards import detect_fake_mode  # noqa: F401
+        from torch._guards import detect_fake_mode
 
         fake_mode = detect_fake_mode()
         if fake_mode is None:
@@ -2844,7 +2844,7 @@ def get_default_op_list() -> OpTypes:
         aten.unsqueeze,
         aten.rsub,
         aten._to_copy,
-    ]  # noqa: E501,B950
+    ]
     recomputable_view_ops = [aten.squeeze, aten.unsqueeze, aten.alias]
     recomputable_view_ops += [
         aten.view,
@@ -2894,7 +2894,7 @@ def get_default_op_list() -> OpTypes:
         aten.maximum,
         prims.iota,
         prims._low_memory_max_pool_offsets_to_indices,
-    ]  # noqa: E501,B950
+    ]
     # Natalia said that we should allow recomputing indexing :)
     default_recomputable_ops += [aten.index, aten.gather]
     default_recomputable_ops += view_ops
@@ -2923,7 +2923,7 @@ def get_default_op_list() -> OpTypes:
         aten._efficient_attention_forward,
         aten.upsample_bilinear2d,
         aten._scaled_mm,
-    ]  # noqa: E501,B950
+    ]
 
     fusible_ops = recomputable_ops | random_ops
     return OpTypes(
@@ -3195,7 +3195,7 @@ def choose_saved_values_set(
             # if idx in all_recomputable_banned_nodes:
             try:
                 dont_ban.add(all_recomputable_banned_nodes[idx])
-            except BaseException:  # noqa: B036
+            except BaseException:
                 pass
 
         if not dont_ban.issubset(all_recomputable_banned_nodes):

--- a/torch/_higher_order_ops/invoke_leaf_function.py
+++ b/torch/_higher_order_ops/invoke_leaf_function.py
@@ -150,7 +150,7 @@ def _resolve_mutated_flat_indices(
     indices: list[int] = []
     for expr in mutates_args:
         # Empty __builtins__ prevents access to builtins like __import__, open, exec.
-        result = eval(expr, {"__builtins__": {}}, namespace)  # noqa: S307
+        result = eval(expr, {"__builtins__": {}}, namespace)
         leaves = pytree.tree_leaves(result)
         for sentinel in leaves:
             if not isinstance(sentinel, int):

--- a/torch/_higher_order_ops/partitioner.py
+++ b/torch/_higher_order_ops/partitioner.py
@@ -65,7 +65,7 @@ class HopPartitionedGraph:
 
         if len(fw_outputs) != self.n_fw_outputs + self.n_intermediates:
             invalid_reasons.append(
-                f"len(fw_outputs) ({len(fw_outputs)}) != n_fw_outputs ({self.n_fw_outputs}) + n_intermediates ({self.n_intermediates})"  # noqa: B950
+                f"len(fw_outputs) ({len(fw_outputs)}) != n_fw_outputs ({self.n_fw_outputs}) + n_intermediates ({self.n_intermediates})"
             )
 
         bw_phs = list(self.bw_gm.graph.find_nodes(op="placeholder"))

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1341,7 +1341,7 @@ def triton_kernel_wrapper_mutation_dense(
         for k, v in tma_descriptor_metadata.items():
             tensor = kwargs[k]
             if (exp_meta := maybe_unpack_tma_experimental_metadata(v)) is not None:
-                from triton.tools.experimental_descriptor import (  # noqa: F401
+                from triton.tools.experimental_descriptor import (
                     create_1d_tma_descriptor,
                     create_2d_tma_descriptor,
                 )
@@ -1740,7 +1740,7 @@ class TritonHOPifier:
         kwargs: dict,
     ) -> list["TritonConfig"]:
         # Reimplement autotuner.prune_configs(...) here
-        # see: https://github.com/triton-lang/triton/blob/e57b46897191b3b3061c78d0d60e58e94be565b6/python/triton/runtime/autotuner.py   # noqa: E501,B950
+        # see: https://github.com/triton-lang/triton/blob/e57b46897191b3b3061c78d0d60e58e94be565b6/python/triton/runtime/autotuner.py
         # We do this to avoid calling prune_configs, which in turn calls early_config_prune and perf_model
         # These are both user-defined functions which can contain side effects, so we want to sandbox them in Dynamo
 
@@ -2136,7 +2136,7 @@ class TritonHOPifier:
                     return self.call_triton_kernel(new_var, args, kwargs, tx)
 
         # These are the default values in upstream Triton
-        # see: https://github.com/triton-lang/triton/blob/e57b46897191b3b3061c78d0d60e58e94be565b6/python/triton/runtime/autotuner.py # noqa: E501,B950
+        # see: https://github.com/triton-lang/triton/blob/e57b46897191b3b3061c78d0d60e58e94be565b6/python/triton/runtime/autotuner.py
         default_perf_model = None
         default_early_config_prune = None
 

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -466,9 +466,9 @@ def _check_alias_and_mutation(graph_module, inputs_fake, name, pre_dispatch):
         graph_module, inputs_fake, pre_dispatch=pre_dispatch
     )
     if aliases:
-        raise RuntimeError(f"{name} might be aliasing the input or the output!")  # noqa: F541
+        raise RuntimeError(f"{name} might be aliasing the input or the output!")
     if inp_mutation:
-        raise RuntimeError(f"{name} might be modifying the input!")  # noqa: F541
+        raise RuntimeError(f"{name} might be modifying the input!")
 
 
 def unique_graph_id(proxy_mode, prefix):

--- a/torch/_higher_order_ops/wrap.py
+++ b/torch/_higher_order_ops/wrap.py
@@ -237,7 +237,7 @@ class WrapWithSetGradEnabled(HigherOrderOperator):
     ) -> _R:
         # Dynamo already traces the body of HigherOrderOp beforehand when it
         # so no need to trace into it.
-        import torch._dynamo  # noqa: F401
+        import torch._dynamo
         from torch._dynamo import disable
 
         @disable
@@ -270,7 +270,7 @@ class WrapWithAutocast(HigherOrderOperator):
     ) -> _R:
         # Dynamo already traces the body of HigherOrderOp beforehand when it
         # so no need to trace into it.
-        import torch._dynamo  # noqa: F401
+        import torch._dynamo
         from torch._dynamo import disable
 
         @disable
@@ -303,7 +303,7 @@ class DynamoBypassingWrapper(HigherOrderOperator):
     ):
         # Dynamo already traces the body of HigherOrderOp beforehand when it
         # so no need to trace into it.
-        import torch._dynamo  # noqa: F401
+        import torch._dynamo
         from torch._dynamo import disable
 
         is_compiling = isinstance(wrapper_fn_or_key, str)

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -23,7 +23,7 @@ from ctypes import byref, c_size_t, c_void_p, CDLL
 from typing import Any, IO, TYPE_CHECKING
 
 import torch
-import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
+import torch._inductor.async_compile
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.testing import rand_strided
 from torch._inductor import ir
@@ -1003,7 +1003,7 @@ class CUTLASSBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest):
         self.device_interface.synchronize()  # shake out any device errors
         self.workspace_size = c_workspace_size.value
         autotuning_log.debug(
-            "update_workspace_size called: new workspace size=%d, self.kernel_name=%s, self.source_file=%s, self.hash_key=%s, self.DLL=%s, args=%s, self.extra_args=%s",  # noqa: B950
+            "update_workspace_size called: new workspace size=%d, self.kernel_name=%s, self.source_file=%s, self.hash_key=%s, self.DLL=%s, args=%s, self.extra_args=%s",
             self.workspace_size,
             self.kernel_name,
             self.source_file,

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1757,7 +1757,7 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
             )
         except BypassFxGraphCache as e:
             counters["inductor"]["fxgraph_cache_bypass"] += 1
-            log.info("Bypassing FX Graph Cache because '%s'", e)  # noqa: G200
+            log.info("Bypassing FX Graph Cache because '%s'", e)
             if remote:
                 log_cache_bypass("bypass_fx_graph", str(e))
             cache_info = {

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -2613,7 +2613,7 @@ class KernelTemplate:
             choices.append(self.generate(**kwargs))
             return None
         except NotImplementedError as e:
-            log.info(  # noqa: G200
+            log.info(
                 "Cannot Append Choice: %s. KernelTemplate type is %s",
                 e,
                 type(self),

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -5246,7 +5246,7 @@ class CppScheduling(BaseScheduling):
                 for _node in node.get_outer_nodes()
             ):
                 # Ref to the typical case of local buffer in
-                # https://github.com/pytorch/pytorch/blob/1115a25c36340554442f28f9570abd42f0aface2/aten/src/ATen/native/cpu/SoftMaxKernel.cpp#L159 # noqa: B950
+                # https://github.com/pytorch/pytorch/blob/1115a25c36340554442f28f9570abd42f0aface2/aten/src/ATen/native/cpu/SoftMaxKernel.cpp#L159
                 # where the buffer is with size of last dim and contiguous.
                 # Only support this typical case at first.
                 visited_scheduler_nodes: OrderedSet[str] = OrderedSet()

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -14,7 +14,7 @@ import sympy
 
 import torch
 import torch._higher_order_ops.torchbind
-import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
+import torch._inductor.async_compile
 import torch._ops
 from torch._inductor.runtime.runtime_utils import dynamo_timed
 from torch.fx.experimental.symbolic_shapes import ConvertIntKey, DivideByKey, SymTypes
@@ -2734,7 +2734,7 @@ if (!custom_op_wrapper) {
             dispatch_lines.writeline("AOTI_TORCH_ERROR_CODE_CHECK(")
             with dispatch_lines.indent():
                 dispatch_lines.writeline(
-                    f'aoti_torch_call_dispatcher("{op_overload._schema.name}", "{op_overload._schema.overload_name}", dispatch_vars.data())'  # noqa: B950
+                    f'aoti_torch_call_dispatcher("{op_overload._schema.name}", "{op_overload._schema.overload_name}", dispatch_vars.data())'
                 )
             dispatch_lines.writeline(");")
 
@@ -2807,7 +2807,7 @@ if (!custom_op_wrapper) {
             for idx, output_arg in enumerate(output_args):
                 if output_arg is None:
                     continue
-                lines += f"{output_arg} = reinterpret_cast<AtenTensorHandle>(PyCapsule_GetPointer(PyList_GET_ITEM(py_{buf_name}.get(), {idx}), NULL));\n"  # noqa: B950
+                lines += f"{output_arg} = reinterpret_cast<AtenTensorHandle>(PyCapsule_GetPointer(PyList_GET_ITEM(py_{buf_name}.get(), {idx}), NULL));\n"
 
         if raw_outputs:
             declarations_before_scope = [

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -5,7 +5,7 @@ from typing import Any
 import sympy
 
 import torch
-import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
+import torch._inductor.async_compile
 import torch._ops
 
 from .. import config, ir

--- a/torch/_inductor/codegen/cutedsl/cutedsl_template.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_template.py
@@ -57,10 +57,10 @@ class CuteDSLTemplate(KernelTemplate):
             choices.append(self.generate(**kwargs))
             return None
         except NotImplementedError as e:
-            log.debug("CuteDSL template choice generation failed: %s", e)  # noqa: G200
+            log.debug("CuteDSL template choice generation failed: %s", e)
             return e
         except Exception as e:
-            log.debug("CuteDSL template choice generation error: %s", e)  # noqa: G200
+            log.debug("CuteDSL template choice generation error: %s", e)
             return NotImplementedError(f"CuteDSL template failed: {e}")
 
     def generate(self, **kwargs: Any) -> ChoiceCaller:

--- a/torch/_inductor/codegen/cutlass/gemm_template.py
+++ b/torch/_inductor/codegen/cutlass/gemm_template.py
@@ -412,7 +412,7 @@ int main(int argc, char** argv) {
 }
 
 #endif
-"""  # noqa: B950
+"""
 
 
 @clear_on_fresh_cache
@@ -803,7 +803,7 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
         if all_match:
             return op
         log.warning(
-            f"Cutlass GEMM Layout change: Input and/or output layouts have changed between autotuning/retuning and call to render on {self}. Applying workaround. This can lead to suboptimal performance. Match List: {match_list}"  # noqa: G004, B950
+            f"Cutlass GEMM Layout change: Input and/or output layouts have changed between autotuning/retuning and call to render on {self}. Applying workaround. This can lead to suboptimal performance. Match List: {match_list}"  # noqa: G004
         )
         new_op = copy.deepcopy(op)
 
@@ -1362,7 +1362,7 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
             f"(({arg_type}){arg_name}_data.get())"
             for arg_type, arg_name in zip(arg_types, arg_names)
         ]
-        return f"{kernel.kernel_name}({', '.join(arguments)}, M, N, K, B, lda, ldb, ldc, ldd, 0, 0, 0, swizzle, workspace_size_ptr, (uint8_t*)workspace_data.get(), 0);"  # noqa: B950
+        return f"{kernel.kernel_name}({', '.join(arguments)}, M, N, K, B, lda, ldb, ldc, ldd, 0, 0, 0, swizzle, workspace_size_ptr, (uint8_t*)workspace_data.get(), 0);"
 
     def _render_evt(
         self,
@@ -1372,7 +1372,7 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
         name_to_buffer: dict[str, Buffer],
         output_dtype: torch.dtype,
         accumulator_dtype: torch.dtype,
-    ) -> tuple[str, str, str, EVTArgRenames]:  # type: ignore[name-defined]  # noqa: F821
+    ) -> tuple[str, str, str, EVTArgRenames]:  # type: ignore[name-defined]
         raise NotImplementedError("_render_evt in CUTLASSGemmTemplate not implemented")
 
 
@@ -1422,7 +1422,7 @@ class CUTLASS3xGemmTemplate(CUTLASSGemmTemplate):
         return (GEMM_ARGS_CUTLASS_3X, GEMM_ARGS_CUTLASS_3X_EPILOGUE)
 
     @staticmethod
-    def _has_tma_epilogue(  # noqa: F821 # type: ignore[arg-type,name-defined]
+    def _has_tma_epilogue(  # type: ignore[arg-type,name-defined]
         op: "cutlass_library.gemm_op.GemmOperation",  # type: ignore[name-defined,arg-type] # noqa: F821
     ) -> bool:  # type: ignore[name-defined]
         """Helper method: Determine whether a given Cutlass GEMM op has a TMA Epilogue"""
@@ -1862,7 +1862,7 @@ class CUTLASS2xGemmTemplate(CUTLASSGemmTemplate):
         # SparseGemm in CUTLASS has specific alignment check that for
         # small k could make some of the choices throw kMisalignedOperand
         # CUTLASS error when run, see:
-        # https://github.com/NVIDIA/cutlass/blob/e01b9b5029b7caca5a43c29f7d2714d7cf1dcae8/include/cutlass/gemm/kernel/sparse_gemm.h#L198-L200  # noqa: B950
+        # https://github.com/NVIDIA/cutlass/blob/e01b9b5029b7caca5a43c29f7d2714d7cf1dcae8/include/cutlass/gemm/kernel/sparse_gemm.h#L198-L200
         # So, let's skip these choices if that would be the case.
         X = self.input_nodes[0]
         return (X.get_size()[1] * 2) % op.tile_description.tile_shape[2] == 0

--- a/torch/_inductor/codegen/cutlass/lib_extensions/gemm_operation_extensions.py
+++ b/torch/_inductor/codegen/cutlass/lib_extensions/gemm_operation_extensions.py
@@ -8,8 +8,8 @@ from ..utils import try_import_cutlass
 if try_import_cutlass():
     import enum
 
-    from cutlass_library.gemm_operation import *  # noqa: F401, F403
-    from cutlass_library.library import *  # noqa: F401, F403
+    from cutlass_library.gemm_operation import *  # noqa: F403
+    from cutlass_library.library import *  # noqa: F403
 
     _LOGGER = logging.getLogger(__name__)
 

--- a/torch/_inductor/codegen/cutlass/scheduling.py
+++ b/torch/_inductor/codegen/cutlass/scheduling.py
@@ -282,13 +282,13 @@ size: {cutlass_template_buffer.get_size()}"
                 not_implemented_op = not_implemented_op[4:]
                 why(
                     f"Cannot fuse epilogue node {node_to_fuse} into {cutlass_template_buffer.name}, \
-likely due to unsupported operation: {not_implemented_op}"  # noqa: G004, B950
+likely due to unsupported operation: {not_implemented_op}"
                 )
                 return False
             else:  # Likely due to unsupported dtype.
                 why(
                     f"Cannot fuse epilogue node {node_to_fuse} into {cutlass_template_buffer.name}. \
-Reason: {not_implemented_op}"  # noqa: G004, B950
+Reason: {not_implemented_op}"
                 )
                 return False
 

--- a/torch/_inductor/codegen/cutlass/template.py
+++ b/torch/_inductor/codegen/cutlass/template.py
@@ -23,7 +23,7 @@ from .utils import DTYPE_TO_CUTLASS_TYPE
 
 
 if TYPE_CHECKING:
-    from ...scheduler import BaseSchedulerNode  # noqa: TC004
+    from ...scheduler import BaseSchedulerNode
 else:
     BaseSchedulerNode = Any
 

--- a/torch/_inductor/codegen/cutlass/utils.py
+++ b/torch/_inductor/codegen/cutlass/utils.py
@@ -78,10 +78,10 @@ def try_import_cutlass() -> bool:
     """
     if config.is_fbcode():
         try:
-            import cutlass_cppgen  # type: ignore[import-not-found]  # noqa: F401
+            import cutlass_cppgen  # type: ignore[import-not-found]
             import cutlass_library  # type: ignore[import-not-found]
         except ImportError as e:
-            log.warning(  # noqa: G200
+            log.warning(
                 "Failed to import CUTLASS packages in fbcode: %s, ignoring the CUTLASS backend.",
                 e,
             )
@@ -163,15 +163,15 @@ def try_import_cutlass() -> bool:
                 )
 
         try:
-            import cutlass_cppgen  # type: ignore[import-not-found]  # noqa: F401, F811
-            import cutlass_library.generator  # noqa: F401
-            import cutlass_library.library  # noqa: F401
+            import cutlass_cppgen  # type: ignore[import-not-found]  # noqa: F401
+            import cutlass_library.generator
+            import cutlass_library.library
             import cutlass_library.manifest  # noqa: F401
             import pycute  # type: ignore[import-not-found]  # noqa: F401
 
             return True
         except ImportError as e:
-            log.debug(  # noqa: G200
+            log.debug(
                 "Failed to import CUTLASS packages: %s, ignoring the CUTLASS backend.",
                 e,
             )

--- a/torch/_inductor/codegen/pallas.py
+++ b/torch/_inductor/codegen/pallas.py
@@ -7,9 +7,9 @@ import re
 import typing_extensions
 from typing import Any, cast, TYPE_CHECKING
 
-import sympy  # noqa: TC002
+import sympy
 
-import torch  # noqa: TC001
+import torch
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import ModularIndexing
 

--- a/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py
@@ -509,7 +509,7 @@ class CKGemmTemplate(CKTemplate):
                         torch.cuda.get_device_properties(X_meta.device).warp_size,
                     )
                 except Exception as e:
-                    log.debug(  # noqa: G200
+                    log.debug(
                         "Failed to prefetch_stages for %s with exception %s", op.name, e
                     )
                     # be conservative here and disable the op
@@ -549,7 +549,7 @@ class CKGemmTemplate(CKTemplate):
         stages = version_to_stages.get(version)
         if stages is None:
             # This means we're at stage 2, and this requires computation
-            # See github.com/ROCm/composable_kernel/blob/d6a4605/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops_v2.hpp#L143 # noqa: B950
+            # See github.com/ROCm/composable_kernel/blob/d6a4605/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops_v2.hpp#L143
             wgp_per_cu = max(4 * warp_size // op.block_size, 1)
             full_mem_band_prefetch_stages = math.ceil(
                 32768

--- a/torch/_inductor/codegen/rocm/rocm_benchmark_request.py
+++ b/torch/_inductor/codegen/rocm/rocm_benchmark_request.py
@@ -117,7 +117,7 @@ class ROCmBenchmarkRequest(GPUDeviceBenchmarkMixin, BenchmarkRequest):
         torch.cuda.synchronize()  # shake out any CUDA errors
         self.workspace_size = c_workspace_size.value
         log.debug(
-            "update_workspace_size called: new workspace size=%d, self.kernel_name=%s, self.source_file=%s, self.hash_key=%s, self.DLL=%s, args=%s, self.extra_args=%s",  # noqa: B950
+            "update_workspace_size called: new workspace size=%d, self.kernel_name=%s, self.source_file=%s, self.hash_key=%s, self.DLL=%s, args=%s, self.extra_args=%s",
             self.workspace_size,
             self.kernel_name,
             self.source_file,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5386,7 +5386,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         hint_override=self.hint_override,
                     )
                     result.writeline(
-                        f"{var_name} = rand_strided({size}, {stride}, device='{buf.get_device()}', dtype={buf.get_dtype()})"  # noqa: B950 line too long
+                        f"{var_name} = rand_strided({size}, {stride}, device='{buf.get_device()}', dtype={buf.get_dtype()})"
                     )
                 elif arg_name in V.graph.constants:
                     # note that random seed is put in V.graph.constants
@@ -5400,7 +5400,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                         hint_override=self.hint_override,
                     )
                     result.writeline(
-                        f"{var_name} = rand_strided({size}, {stride}, device='{const_tensor.device}', dtype={const_tensor.dtype})"  # type: ignore[arg-type]  # noqa: B950 line too long
+                        f"{var_name} = rand_strided({size}, {stride}, device='{const_tensor.device}', dtype={const_tensor.dtype})"  # type: ignore[arg-type]
                     )
                 elif isinstance(arg_sig, SizeArg):
                     symval_hint = V.graph.sizevars.optimization_hint_with_override(
@@ -5466,7 +5466,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
             result.writeline("args = get_args()")
             result.writeline(
-                f"ms = benchmarker.benchmark(lambda: call(args), device='{V.graph.get_current_device_or_throw().type}', rep=40)"  # noqa: B950 line too long
+                f"ms = benchmarker.benchmark(lambda: call(args), device='{V.graph.get_current_device_or_throw().type}', rep=40)"
             )
             result.writeline(f"num_gb = {num_gb}")
             result.writeline("gb_per_s = num_gb / (ms / 1e3)")
@@ -6659,7 +6659,7 @@ class TritonScheduling(SIMDScheduling):
             except Exception as e:
                 if config.triton.disallow_failing_autotune_kernels_TESTING_ONLY:
                     raise
-                log.debug(  # noqa: G200
+                log.debug(
                     "Exception (%s) in compiling fused nodes %s",
                     e,
                     node_names,

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -1012,7 +1012,7 @@ class ComboKernel(Kernel):
                     size = V.graph.sizevars.optimization_hints(buf.get_size())
                     stride = V.graph.sizevars.optimization_hints(buf.get_stride())
                     result.writeline(
-                        f"{var_name} = rand_strided({size}, {stride}, device='{buf.get_device()}', dtype={buf.get_dtype()})"  # noqa: B950 line too long
+                        f"{var_name} = rand_strided({size}, {stride}, device='{buf.get_device()}', dtype={buf.get_dtype()})"
                     )
                 elif arg_name in V.graph.constants:
                     # note that random seed is put in V.graph.constants
@@ -1020,7 +1020,7 @@ class ComboKernel(Kernel):
                     size = V.graph.sizevars.optimization_hints(const_tensor.size())
                     stride = V.graph.sizevars.optimization_hints(const_tensor.stride())
                     result.writeline(
-                        f"{var_name} = rand_strided({size}, {stride}, device='{const_tensor.device}', dtype={const_tensor.dtype})"  # type: ignore[arg-type]  # noqa: B950 line too long
+                        f"{var_name} = rand_strided({size}, {stride}, device='{const_tensor.device}', dtype={const_tensor.dtype})"  # type: ignore[arg-type]
                     )
                 elif isinstance(arg_sig, SizeArg):
                     symval_hint = V.graph.sizevars.optimization_hint(arg_sig.expr)

--- a/torch/_inductor/comms.py
+++ b/torch/_inductor/comms.py
@@ -1751,7 +1751,7 @@ def _find_buffers_with_changed_last_use_sink_waits(
 
     for buf in candidate_bufs:
         snode_last_use = buf_to_snode_last_use[buf]
-        if snode_last_use != candidate:  # noqa: E711
+        if snode_last_use != candidate:
             continue
 
         # candidate is last use of buf
@@ -2186,7 +2186,7 @@ def visualize_overlap(order):
     cur_comm_node = None
 
     def step_log(step, msg):
-        overlap_log.debug(f"{step:>6}: {msg}")  # noqa: G004
+        overlap_log.debug(f"{step:>6}: {msg}")
 
     for step, snode in enumerate(order):
         if cur_comm_node is None:
@@ -2205,14 +2205,14 @@ def visualize_overlap(order):
             if contains_collective(snode):
                 total_est_runtime += estimate_op_runtime(snode)
                 cur_comm_node = snode.node
-                step_log(step, f"{node_summary(snode)}")  # noqa: G004
+                step_log(step, f"{node_summary(snode)}")
             elif is_wait(snode.node):  # end of this comm op
                 step_log(step, f"{node_summary(snode)}")
                 cur_comm_node = None
             else:  # overlapped compute op
                 step_log(step, f"| {node_summary(snode)}")
     overlap_log.debug(
-        f"Est. runtime (ms): {total_est_runtime / 1000 / 1000}"  # noqa: G004
+        f"Est. runtime (ms): {total_est_runtime / 1000 / 1000}"
     )
 
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -3185,7 +3185,7 @@ def _aoti_flatten_inputs(
     ]
 
     if in_spec is not None and received_spec != in_spec:
-        raise ValueError(  # noqa: B904
+        raise ValueError(
             "Trying to flatten user inputs with exported input tree spec: \n"
             f"{in_spec}\n"
             "but actually got inputs with tree spec of: \n"

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING, TypeGuard
 from typing_extensions import final, override, Self
 
-import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
+import torch._inductor.async_compile
 import torch.fx
 from torch._inductor.codecache import BypassFxGraphCache, FxGraphCache
 from torch._inductor.metrics import CachedMetricsDeltas, CachedMetricsHelper
@@ -473,7 +473,7 @@ class _SerializedFxCompile(FxCompile):
             # we can't cache (or serialize)
             FxGraphCache._check_for_hop(gm)
         except BypassFxGraphCache as e:
-            log.debug("Skipping %s compile: %s", type(self), e)  # noqa: G200
+            log.debug("Skipping %s compile: %s", type(self), e)
             return None
 
         # Triton kernel wrapper nodes contain references to the kernel_side_table

--- a/torch/_inductor/compile_fx_subproc.py
+++ b/torch/_inductor/compile_fx_subproc.py
@@ -6,7 +6,7 @@ import os
 from typing import TYPE_CHECKING
 from typing_extensions import final, override
 
-import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
+import torch._inductor.async_compile
 import torch.fx
 from torch._inductor.compile_worker.subproc_pool import (
     AnyPool,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2639,7 +2639,7 @@ class test_configs:
 
 
 if TYPE_CHECKING:
-    from torch.utils._config_typing import *  # noqa: F401, F403
+    from torch.utils._config_typing import *  # noqa: F403
 
 
 class eager_numerics:

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -853,7 +853,7 @@ def _get_os_related_cpp_cflags(cpp_compiler: str) -> list[str]:
             # For Intel oneAPI, ref: https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170
             "Zc:__cplusplus",
             # Enable max compatible to msvc for oneAPI headers.
-            # ref: https://github.com/pytorch/pytorch/blob/db38c44ad639e7ada3e9df2ba026a2cb5e40feb0/cmake/public/utils.cmake#L352-L358 # noqa: B950
+            # ref: https://github.com/pytorch/pytorch/blob/db38c44ad639e7ada3e9df2ba026a2cb5e40feb0/cmake/public/utils.cmake#L352-L358
             "permissive-",
         ]
     else:

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -67,7 +67,7 @@ extern "C" void __avx_chk_kernel() {
     auto tmp1 = tmp0.exp();
     tmp1.store(in_out_ptr0);
 }
-"""  # noqa: B950
+"""
 
     _avx_py_load = """
 import torch

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1859,7 +1859,7 @@ def check_memory_pool(
     live_storages_ptrs: list[StorageWeakRefWrapper],
 ) -> None:
     """Validate cudagraph pool allocations against tracked live storages and surface leaks."""
-    assert all(isinstance(elem, StorageWeakRefWrapper) for elem in live_storages_ptrs)  # noqa: C419
+    assert all(isinstance(elem, StorageWeakRefWrapper) for elem in live_storages_ptrs)
     unique_storages = {stor.data_ptr() for stor in live_storages_ptrs if stor()}  # noqa: set_linter
 
     # check if there is a divergence first, then do the expensive snapshot call after

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -34,7 +34,7 @@ from torch.types import FileLike
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._pytree import tree_map
 
-from . import config, ir  # noqa: F811, this is needed
+from . import config, ir
 from .ir import ExternKernel
 from .scheduler import (
     BaseSchedulerNode,

--- a/torch/_inductor/fx_passes/auto_chunker/propagator.py
+++ b/torch/_inductor/fx_passes/auto_chunker/propagator.py
@@ -478,7 +478,7 @@ def propagate_general_copy_metadata(
             return PropagateStatus.FAIL
 
         # apply any to a list to avoid short-circuit
-        changed = any(  # noqa: C419
+        changed = any(
             [  # noqa: C419
                 copy_chunking_meta(node, meta)
                 if not need_handle_broadcast or node_ndim[node] == out_ndim
@@ -493,7 +493,7 @@ def propagate_general_copy_metadata(
         # where we attach chunking metadata to tangents that need to be
         # included in the chunking subgraph.
         # This is different to having a None ChunkingMeta
-        changed |= any(  # noqa: C419
+        changed |= any(
             [  # noqa: C419
                 set_chunking_meta(node)
                 for node in scalar_args

--- a/torch/_inductor/fx_passes/numeric_utils.py
+++ b/torch/_inductor/fx_passes/numeric_utils.py
@@ -207,7 +207,7 @@ def numeric_check_if_enabled(
                 precision=precision,
             )
     except Exception as e:
-        logger.warning(  # noqa: G200
+        logger.warning(
             "Runtime numeric check failed in pre grad fx passes with error: %s", e
         )
         traceback.print_exc()

--- a/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
+++ b/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
@@ -47,7 +47,7 @@ class WhyNoBucket:
     def __call__(self, reason: str, *args: Any) -> None:
         if bucket_log.isEnabledFor(logging.DEBUG):
             bucket_log.debug(
-                "cannot bucket %s with %s: " + reason,  # noqa: G003
+                "cannot bucket %s with %s: " + reason,
                 self.name1,
                 self.name2,
                 *args,

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -141,7 +141,6 @@ def _get_dim(node: Any):
     )
 
 
-# noqa: W605
 # ############The pattern to be optimized is#########
 #         unbind (dim=0)
 #       /   ...    \
@@ -1430,7 +1429,6 @@ def simplify_split_cat(match: Match, split_sections: list[int], dim: int):
     SplitCatSimplifier().simplify(match.graph, split_node, split_sections)
 
 
-# noqa: W605
 # ############pattern to be optimized is#########
 
 #                 split_node(dim=1)

--- a/torch/_inductor/inductor_prims.py
+++ b/torch/_inductor/inductor_prims.py
@@ -318,14 +318,14 @@ def _low_memory_max_pool_offsets_to_indices_aten(
 
 
 _low_memory_max_pool_with_offsets = make_prim(
-    "_low_memory_max_pool_with_offsets(Tensor self, SymInt[] kernel_size, SymInt[] stride,  SymInt[] padding, SymInt[] dilation, bool ceil_mode) -> (Tensor, Tensor)",  # noqa: B950
+    "_low_memory_max_pool_with_offsets(Tensor self, SymInt[] kernel_size, SymInt[] stride,  SymInt[] padding, SymInt[] dilation, bool ceil_mode) -> (Tensor, Tensor)",
     _low_memory_max_pool_with_offsets_aten,
     return_type=(_prims.RETURN_TYPE.NEW, _prims.RETURN_TYPE.NEW),
     doc="Instead of returning indices, returns indices offsets.",
 )
 
 _low_memory_max_pool_offsets_to_indices = make_prim(
-    "_low_memory_max_pool_offsets_to_indices(Tensor self, SymInt[] kernel_size, SymInt[] input_size, SymInt[] stride, SymInt[] padding, SymInt[] dilation) -> Tensor",  # noqa: B950
+    "_low_memory_max_pool_offsets_to_indices(Tensor self, SymInt[] kernel_size, SymInt[] input_size, SymInt[] stride, SymInt[] padding, SymInt[] dilation) -> Tensor",
     _low_memory_max_pool_offsets_to_indices_aten,
     doc="Convert small int offsets to regular indices.",
 )

--- a/torch/_inductor/kernel/flex/flex_cpu.py
+++ b/torch/_inductor/kernel/flex/flex_cpu.py
@@ -84,7 +84,7 @@ def lower_cpu(
             "torch.compile on current platform is not supported for CPU."
         )
 
-    fake_buffers: list[Buffer] = []  # noqa: F821
+    fake_buffers: list[Buffer] = []
 
     # [Note] Handle the case where the split sizes are not statically known.
     # The value of cur_qSplitSize and cur_kvSplitSize are decided during runtime.

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -87,7 +87,7 @@ def _use_flex_decoding(query, kv_indices, value, kernel_options, enable_gqa) -> 
         and pw_of_two
     )
     log.debug(
-        "Use flex decoding %s, force_flex_attention=%s, short_query_length=%s, static_batch=%s, static_num_heads=%s",  # noqa: B950
+        "Use flex decoding %s, force_flex_attention=%s, short_query_length=%s, static_batch=%s, static_num_heads=%s",
         out,
         force_flex,
         short_query_length,

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/__init__.py
@@ -1,2 +1,2 @@
 # CuTeDSL Cutlass API registrations for PyTorch Inductor.
-from . import dense_blockscaled_gemm_kernel  # noqa: F401
+from . import dense_blockscaled_gemm_kernel

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -742,7 +742,7 @@ def register_onednn_fusion_ops():
 
             # When channels less than 8, w_scale/w_zp is Pointwise instead of ConstantBuffer
             # Refer to
-            # https://github.com/pytorch/pytorch/blob/f353d17755ed23b02924c962a86ff99a3405fe10/torch/_inductor/graph.py#L570-L577  # noqa: B950
+            # https://github.com/pytorch/pytorch/blob/f353d17755ed23b02924c962a86ff99a3405fe10/torch/_inductor/graph.py#L570-L577
             if w_zp is None:
                 # If w_zp is None, then it's a dummy tensor created to denote the
                 # absence of a zero point, and thus w is int8 symmetrically quantized.
@@ -1055,7 +1055,7 @@ def register_onednn_fusion_ops():
 
             # When channels less than 8, w_scale/w_zp is Pointwise instead of ConstantBuffer
             # Refer to
-            # https://github.com/pytorch/pytorch/blob/f353d17755ed23b02924c962a86ff99a3405fe10/torch/_inductor/graph.py#L570-L577  # noqa: B950
+            # https://github.com/pytorch/pytorch/blob/f353d17755ed23b02924c962a86ff99a3405fe10/torch/_inductor/graph.py#L570-L577
             w_scale.realize()
             w_zp.realize()
             if w_zp.get_dtype() != torch.int32 and isinstance(

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -279,7 +279,7 @@ class CoordescTuner:
         try:
             candidate_timing = self.call_func(func, candidate_config)
         except Exception as e:
-            log.debug("Got exception %s", e)  # noqa: G200
+            log.debug("Got exception %s", e)
             return False, float("inf")
 
         if self.has_improvement(best_timing, candidate_timing):

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Callable
 from typing import Any, TypeVar
 
-from .triton_compat import (  # noqa: F401
+from .triton_compat import (
     _log2,
     builtins_use_semantic_kwarg,
     JITFunction,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2017,7 +2017,7 @@ class StaticTritonCompileResult(CompileResult[_T]):
             result = check_can_launch()
             return result
         except CannotStaticallyLaunchKernel as e:
-            log.info("Bypassing StaticallyLaunchedCudaKernel due to %s", e)  # noqa: G200
+            log.info("Bypassing StaticallyLaunchedCudaKernel due to %s", e)
             if torch._inductor.config.strict_static_triton_launcher:
                 raise e
             return None

--- a/torch/_inductor/runtime/triton_lazy_compile.py
+++ b/torch/_inductor/runtime/triton_lazy_compile.py
@@ -114,7 +114,7 @@ def start_kernel_compile(
 
     # Evaluate the kernel source to get the Future or CachingAutotuner
     # The kernel_source is like: async_compile.triton('name', '''...''', ...)
-    kernel_obj = eval(kernel_source.strip())  # noqa: S307
+    kernel_obj = eval(kernel_source.strip())
 
     pending_kernels[kernel_name] = kernel_obj
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 import sympy
 
 import torch
-import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
+import torch._inductor.async_compile
 import torch.utils._pytree as pytree
 from torch._dynamo.utils import counters, dynamo_timed
 from torch._inductor.autotune_process import use_pipelined_autotuning
@@ -1252,11 +1252,11 @@ class BaseSchedulerNode:
             except ValueError as e:
                 # We don't know how to estimate runtime for this collective,
                 # falling back to 0
-                log.info(e)  # noqa: G200
+                log.info(e)
                 return 0
             except TypeError as e:
                 # this happens when the collective is not of type ir._CollectiveKernel
-                log.info(e)  # noqa: G200
+                log.info(e)
                 return 0
 
         elif is_wait(self.node):
@@ -4422,7 +4422,7 @@ class Scheduler:
                             future.result()
                     except Exception as e:
                         if fusion_log.isEnabledFor(logging.DEBUG):
-                            fusion_log.debug(  # noqa: G200
+                            fusion_log.debug(
                                 "Exception in compiling %s: %s",
                                 "prologue" if not epilogue_fusion else "epilogue",
                                 e,
@@ -4557,7 +4557,7 @@ class Scheduler:
                     # triton  will unpredictably error with valid prologue fusions
                     except Exception as e:
                         if fusion_log.isEnabledFor(logging.DEBUG):
-                            fusion_log.debug(  # noqa: G200
+                            fusion_log.debug(
                                 "Exception in compiling %s: %s",
                                 "prologue" if not epilogue_fusion else "epilogue",
                                 e,

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -27,7 +27,7 @@ from unittest.mock import patch
 import sympy
 
 import torch
-import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
+import torch._inductor.async_compile
 from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.testing import rand_strided
 from torch._dynamo.utils import (
@@ -2524,7 +2524,7 @@ class TritonTemplate(KernelTemplate):
                 choices.append(choice)
             return None
         except NotImplementedError as e:
-            log.info(  # noqa: G200
+            log.info(
                 "Cannot Append Choice: %s. KernelTemplate type is %s",
                 e,
                 type(self),
@@ -4469,7 +4469,7 @@ class AlgorithmSelectorCache(PersistentCache):
                             "select_algorithm_num_precompilation_exceptions"
                         ] += 1
                         exceptions.append((futures[future], e))
-                        log.exception(  # noqa: G202
+                        log.exception(
                             "Exception %s for benchmark choice %s",
                             e,
                             futures[future],
@@ -4899,7 +4899,7 @@ class AlgorithmSelectorCache(PersistentCache):
                     from triton.runtime.autotuner import OutOfResources
 
                     if isinstance(e, OutOfResources):
-                        log.warning(e)  # noqa: G200
+                        log.warning(e)
                         timing = float("inf")
                     else:
                         raise e

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -422,7 +422,7 @@ def _do_bench_using_profiling(
 @functools.cache
 def has_torchvision_roi_align() -> bool:
     try:
-        from torchvision.ops import roi_align  # noqa: F401
+        from torchvision.ops import roi_align
 
         torch._C._dispatch_has_kernel_for_dispatch_key("torchvision::nms", "Meta")
         return roi_align is not None and hasattr(

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -1379,8 +1379,7 @@ def _disable_emit_hooks():
         torch._C._jit_set_emit_hooks(hooks[0], hooks[1])
 
 
-def _disable_emit_hooks_decorator(_DecoratorContextManager) -> None:  # noqa: F811
-    # noqa: F841
+def _disable_emit_hooks_decorator(_DecoratorContextManager) -> None:
     def __enter__(self) -> None:
         self.hooks = torch._C._jit_get_emit_hooks()
         torch._C._jit_set_emit_hooks(None, None)

--- a/torch/_library/fake_class_registry.py
+++ b/torch/_library/fake_class_registry.py
@@ -30,7 +30,7 @@ class FakeScriptObject:
                 with _disable_current_modes():
                     real_obj = copy.deepcopy(x)
             except (RuntimeError, TypeError) as e:
-                log.warning(  # noqa: G200
+                log.warning(
                     "Unable to deepcopy the custom object %s due to %s. "
                     "Defaulting to the user given object. This might be "
                     "dangerous as side effects may be directly applied "

--- a/torch/_library/infer_schema.py
+++ b/torch/_library/infer_schema.py
@@ -234,7 +234,7 @@ def derived_types(
 
     def derived_seq_types(typ: type | typing._SpecialForm):
         return (
-            typing.Sequence[typ],  # type: ignore[valid-type]  # noqa: UP006
+            typing.Sequence[typ],  # type: ignore[valid-type]
             typing.List[typ],  # type: ignore[valid-type]  # noqa: UP006
             GenericAlias(collections.abc.Sequence, (typ,)),
             GenericAlias(list, (typ,)),

--- a/torch/_library/opaque_object.py
+++ b/torch/_library/opaque_object.py
@@ -44,7 +44,7 @@ from typing_extensions import TypeIs
 from weakref import WeakKeyDictionary
 
 import torch
-from torch._opaque_base import OpaqueBase, OpaqueBaseMeta  # noqa: F401
+from torch._opaque_base import OpaqueBase, OpaqueBaseMeta
 
 
 if TYPE_CHECKING:

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -1,4 +1,3 @@
-# flake8: noqa: B950
 from ._internal import register_artifact, register_log
 
 

--- a/torch/_logging/scribe.py
+++ b/torch/_logging/scribe.py
@@ -59,5 +59,5 @@ struct TorchOpenSourceSignpostLogEntry {
   # The weight of the record according to current sampling rate
   18: optional i64 weight;
 }
-""",  # noqa: B950
+""",
 )

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8412,17 +8412,17 @@ def _meta_grouped_mm_common(
             fp8_dtype = torch.float8_e4m3fnuz
         torch._check(
             mat_a.dtype == fp8_dtype and mat_b.dtype == fp8_dtype,
-            lambda: f"Expected inputs of E4M3 FP8 type but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",  # noqa: B950
+            lambda: f"Expected inputs of E4M3 FP8 type but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",
         )
     else:
         torch._check(
             mat_a.dtype == torch.bfloat16 and mat_b.dtype == torch.bfloat16,
-            lambda: f"Expected inputs of BF16 type but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",  # noqa: B950
+            lambda: f"Expected inputs of BF16 type but got mat_a.dtype={mat_a.dtype} and mat_b.dtype={mat_b.dtype}.",
         )
 
     torch._check(
         mat_a.dim() in [2, 3] and mat_b.dim() in [2, 3],
-        lambda: f"Multiplicands must be 2D or 3D but got mat_a.dim()={mat_a.dim()} and mat_b.dim()={mat_b.dim()}",  # noqa: B950
+        lambda: f"Multiplicands must be 2D or 3D but got mat_a.dim()={mat_a.dim()} and mat_b.dim()={mat_b.dim()}",
     )
 
     mat_a_is_2d = mat_a.dim() == 2
@@ -8446,11 +8446,11 @@ def _meta_grouped_mm_common(
 
         torch._check(
             is_row_major(mat_a),
-            lambda: f"Expected mat_a tensor to be row major in the last two dimensions, got strides {mat_a.stride()[-2:]}",  # noqa: B950
+            lambda: f"Expected mat_a tensor to be row major in the last two dimensions, got strides {mat_a.stride()[-2:]}",
         )
         torch._check(
             is_col_major(mat_b),
-            lambda: f"Expected mat_b tensor to be column major in the last two dimensions, got strides {mat_b.stride()[-2:]}",  # noqa: B950
+            lambda: f"Expected mat_b tensor to be column major in the last two dimensions, got strides {mat_b.stride()[-2:]}",
         )
 
     def check_valid_strides(mat_name, mat):
@@ -8462,19 +8462,19 @@ def _meta_grouped_mm_common(
         ):
             torch._check(
                 mat_stride[end_dim] % alignment == 0,
-                lambda: f"Expected {mat_name} stride along {end_dim} dim to be multiple of 16 bytes, got {mat_stride[end_dim]}.",  # noqa: B950
+                lambda: f"Expected {mat_name} stride along {end_dim} dim to be multiple of 16 bytes, got {mat_stride[end_dim]}.",
             )
         elif mat_stride[end_dim] == 1 and mat_stride[end_dim - 1] >= max(
             1, mat.shape[end_dim]
         ):
             torch._check(
                 mat_stride[end_dim - 1] % alignment == 0,
-                lambda: f"Expected {mat_name} stride along {end_dim - 1} dim to be multiple of 16 bytes, got {mat_stride[end_dim - 1]}.",  # noqa: B950
+                lambda: f"Expected {mat_name} stride along {end_dim - 1} dim to be multiple of 16 bytes, got {mat_stride[end_dim - 1]}.",
             )
         else:
             torch._check(
                 False,
-                lambda: f"Invalid strides/sizes, got {mat_stride} for strides and {mat.shape} for sizes.",  # noqa: B950
+                lambda: f"Invalid strides/sizes, got {mat_stride} for strides and {mat.shape} for sizes.",
             )
 
     check_valid_strides("mat_a", mat_a)
@@ -8487,7 +8487,7 @@ def _meta_grouped_mm_common(
                 scale_a.dtype == torch.float8_e8m0fnu
                 and scale_b.dtype == torch.float8_e8m0fnu
             ),
-            lambda: f"For FP8 scales must both be float32, or for MXFP8 both scales must be float8_e8m0fnu. Got scale_a.dtype={scale_a.dtype} and scale_b.dtype={scale_b.dtype}.",  # noqa: B950
+            lambda: f"For FP8 scales must both be float32, or for MXFP8 both scales must be float8_e8m0fnu. Got scale_a.dtype={scale_a.dtype} and scale_b.dtype={scale_b.dtype}.",
         )
         is_mxfp8 = (
             scale_a.dtype == torch.float8_e8m0fnu
@@ -8507,7 +8507,7 @@ def _meta_grouped_mm_common(
                 if is_mxfp8:
                     torch._check(
                         scale.dim() == mat.dim(),
-                        lambda: f"For MXFP8, scale must have same number of dimensions as target tensor, but {scale_name} has mat.ndim={mat.ndim} and scale.ndim={scale.ndim}",  # noqa: B950
+                        lambda: f"For MXFP8, scale must have same number of dimensions as target tensor, but {scale_name} has mat.ndim={mat.ndim} and scale.ndim={scale.ndim}",
                     )
                 else:
                     torch._check(
@@ -8516,7 +8516,7 @@ def _meta_grouped_mm_common(
                     )
                     torch._check(
                         scale.shape[0] == mat.shape[scaled_dim] * scale_multiplier,
-                        lambda: f"Expected {scale_name} to have {mat.shape[scaled_dim] * scale_multiplier} elements, got {scale.shape[0]} elements.",  # noqa: B950
+                        lambda: f"Expected {scale_name} to have {mat.shape[scaled_dim] * scale_multiplier} elements, got {scale.shape[0]} elements.",
                     )
             else:
                 torch._check(
@@ -8532,7 +8532,7 @@ def _meta_grouped_mm_common(
                 if is_mxfp8:
                     torch._check(
                         scale.ndim == mat.ndim - 1,
-                        lambda: f"For MXFP8, 3d tensor should have 2d scales, but {scale_name} has mat.ndim={mat.ndim} and scale.ndim={scale.ndim}",  # noqa: B950
+                        lambda: f"For MXFP8, 3d tensor should have 2d scales, but {scale_name} has mat.ndim={mat.ndim} and scale.ndim={scale.ndim}",
                     )
                     # TODO: This logic only holds for RHS tensor in 2d-3d case.
                     # We'll need to update it to handle LHS 3d tensor in 3d-2d and 3d-3d cases.
@@ -8542,7 +8542,7 @@ def _meta_grouped_mm_common(
                     blocked_N = round_up(N, 128)
                     torch._check(
                         scale.shape[0] == G and scale.shape[1] == blocked_K * blocked_N,
-                        lambda: f"For MXFP8, expected mat.shape={mat.shape} to have scale shape of ({G},{blocked_K * blocked_N}), but got {scale.shape}",  # noqa: B950
+                        lambda: f"For MXFP8, expected mat.shape={mat.shape} to have scale shape of ({G},{blocked_K * blocked_N}), but got {scale.shape}",
                     )
                 else:
                     torch._check(
@@ -8551,7 +8551,7 @@ def _meta_grouped_mm_common(
                     )
                     torch._check(
                         scale.shape[1] == mat.shape[1 + scaled_dim],
-                        lambda: f"Expected {scale_name} non-batch dimension to be {mat.shape[1 + scaled_dim]}, got {scale.shape[1]}.",  # noqa: B950
+                        lambda: f"Expected {scale_name} non-batch dimension to be {mat.shape[1 + scaled_dim]}, got {scale.shape[1]}.",
                     )
 
         scale_multiplier = (
@@ -9010,11 +9010,11 @@ def activate_meta():
             in {
                 "aten::empty_strided",  # causing infinite recursion, test_meta.py
                 "aten::clone",  # causing infinite recursion
-                "aten::_to_copy",  # causing infinite recursion, test_serialization.py -k test_tensor_subclass_getstate_overwrite  # noqa: B950
-                "aten::copy_",  # Exception not raised, test_torch.py -k test_storage_meta_errors_cpu_int64  # noqa: B950
-                "aten::constant_pad_nd",  # requires_grad mismatch, test_ops.py -k test_fake_crossref_backward_amp_istft_cuda_float32  # noqa: B950
-                "aten::rot90",  # requires_grad mismatch! test_ops.py -k test_fake_crossref_backward_amp_rot90_cuda_float32  # noqa: B950
-                "aten::as_strided_scatter",  # requires_grad mismatch, test_ops.py -k test_fake_crossref_backward_no_amp_as_strided_scatter_cuda_float32  # noqa: B950
+                "aten::_to_copy",  # causing infinite recursion, test_serialization.py -k test_tensor_subclass_getstate_overwrite
+                "aten::copy_",  # Exception not raised, test_torch.py -k test_storage_meta_errors_cpu_int64
+                "aten::constant_pad_nd",  # requires_grad mismatch, test_ops.py -k test_fake_crossref_backward_amp_istft_cuda_float32
+                "aten::rot90",  # requires_grad mismatch! test_ops.py -k test_fake_crossref_backward_amp_rot90_cuda_float32
+                "aten::as_strided_scatter",  # requires_grad mismatch, test_ops.py -k test_fake_crossref_backward_no_amp_as_strided_scatter_cuda_float32
             }
         ):
             pass

--- a/torch/_numpy/_dtypes.py
+++ b/torch/_numpy/_dtypes.py
@@ -447,6 +447,6 @@ def issubdtype(arg1, arg2):
 
 
 __all__ = ["dtype", "DType", "typecodes", "issubdtype", "set_default_dtype", "sctypes"]
-__all__ += list(_names.keys())  # noqa: PLE0605
-__all__ += list(_name_aliases.keys())  # noqa: PLE0605
+__all__ += list(_names.keys())
+__all__ += list(_name_aliases.keys())
 __all__ += _abstract_dtypes  # noqa: PLE0605

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -2467,7 +2467,7 @@ def _iota_aten(
 
 
 iota = _make_prim(
-    schema="iota(SymInt length, *, SymInt start, SymInt step, ScalarType dtype, Device device, bool requires_grad) -> Tensor",  # noqa: B950
+    schema="iota(SymInt length, *, SymInt start, SymInt step, ScalarType dtype, Device device, bool requires_grad) -> Tensor",
     return_type=RETURN_TYPE.NEW,
     meta=_iota_meta,
     impl_aten=_iota_aten,
@@ -2575,7 +2575,7 @@ _empty_permuted_doc = """
 
 # TODO: add layout, pin_memory
 empty_permuted = _make_prim(
-    schema="empty_permuted(SymInt[] shape, int[] physical_layout, *, ScalarType dtype, Device device, bool requires_grad) -> Tensor",  # noqa: B950
+    schema="empty_permuted(SymInt[] shape, int[] physical_layout, *, ScalarType dtype, Device device, bool requires_grad) -> Tensor",
     return_type=RETURN_TYPE.NEW,
     meta=_empty_permuted_meta,
     impl_aten=torch.empty_permuted,
@@ -2832,7 +2832,7 @@ _normal_doc = """
 
 normal = _make_prim(
     schema=(
-        "normal(SymInt[] shape, *, Scalar mean, Scalar std, ScalarType dtype, Device device, bool requires_grad, Generator? generator=None) -> Tensor"  # noqa: B950
+        "normal(SymInt[] shape, *, Scalar mean, Scalar std, ScalarType dtype, Device device, bool requires_grad, Generator? generator=None) -> Tensor"
     ),
     return_type=RETURN_TYPE.NEW,
     meta=_normal_meta,

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -78,7 +78,7 @@ def philox_rand_offset(
 
 def register_philox_rand():
     name = "philox_rand"
-    schema = "(SymInt[] size, Tensor seed, Tensor offset, int[]? stride, Device? device=None, ScalarType? dtype=None) -> (Tensor, Tensor)"  # noqa: B950
+    schema = "(SymInt[] size, Tensor seed, Tensor offset, int[]? stride, Device? device=None, ScalarType? dtype=None) -> (Tensor, Tensor)"
 
     def _philox_rand_meta(
         shape: torch.Size,

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2334,7 +2334,7 @@ class FakeTensorMode(TorchDispatchMode):
                     "mismatched_fake_kernel",
                     metadata_fn=lambda: {
                         "op": str(func),
-                        "reason": f"mismatch between fake value {fake} and real value {real}",  # noqa: F821
+                        "reason": f"mismatch between fake value {fake} and real value {real}",
                     },
                 )
                 return _infer_fake_from_real_tensor(self, func, real), True  # type: ignore[arg-type]
@@ -2678,7 +2678,7 @@ class FakeTensorMode(TorchDispatchMode):
                 # we shouldn't broadly catch all errors here;
                 # some come from real-kernel mutation/aliasing checks we want to run.
                 # add more exception types as needed.
-                log.debug(  # noqa: G200
+                log.debug(
                     "real-tensor fallback failed for %s: %s; silently ignoring",
                     func,
                     exc,

--- a/torch/amp/grad_scaler.py
+++ b/torch/amp/grad_scaler.py
@@ -449,7 +449,7 @@ class GradScaler:
                 found_inf = cast(
                     torch.Tensor,
                     sum(
-                        [  # noqa: C419
+                        [
                             t.to(scaler.device, non_blocking=True)
                             for t in optimizer_state["found_inf_per_device"].values()
                         ]

--- a/torch/ao/__init__.py
+++ b/torch/ao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING as _TYPE_CHECKING
 if _TYPE_CHECKING:
     from types import ModuleType
 
-    from torch.ao import (  # noqa: TC004
+    from torch.ao import (
         nn as nn,
         ns as ns,
         pruning as pruning,

--- a/torch/ao/nn/__init__.py
+++ b/torch/ao/nn/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING as _TYPE_CHECKING
 if _TYPE_CHECKING:
     from types import ModuleType
 
-    from torch.ao.nn import (  # noqa: TC004
+    from torch.ao.nn import (
         intrinsic as intrinsic,
         qat as qat,
         quantizable as quantizable,

--- a/torch/ao/nn/intrinsic/__init__.py
+++ b/torch/ao/nn/intrinsic/__init__.py
@@ -1,12 +1,12 @@
 import types
 
 from .modules import *  # noqa: F403
-from .modules.fused import _FusedModule  # noqa: F403
+from .modules.fused import _FusedModule
 
 
 # # Subpackages
-# from . import qat  # noqa: F403
-# from . import quantized  # noqa: F403
+# from . import qat
+# from . import quantized
 
 __all__ = [
     "ConvBn1d",

--- a/torch/ao/nn/intrinsic/modules/__init__.py
+++ b/torch/ao/nn/intrinsic/modules/__init__.py
@@ -1,4 +1,4 @@
-from .fused import (  # noqa: F401
+from .fused import (
     _FusedModule,
     BNReLU2d,
     BNReLU3d,

--- a/torch/ao/nn/quantized/dynamic/modules/conv.py
+++ b/torch/ao/nn/quantized/dynamic/modules/conv.py
@@ -68,7 +68,7 @@ class Conv1d(nnq.Conv1d):
         reduce_range=True,
     ):
         warnings.warn(
-            f"The current implementation of the {self._get_name()} module has poor numerical accuracy and its use is not recommended",  # noqa: B950
+            f"The current implementation of the {self._get_name()} module has poor numerical accuracy and its use is not recommended",
             stacklevel=2,
         )
         factory_kwargs = {"device": device, "dtype": dtype}
@@ -241,7 +241,7 @@ class Conv3d(nnq.Conv3d):
         dtype=None,
     ):
         warnings.warn(
-            f"The current implementation of the {self._get_name()} module has poor numerical accuracy and its use is not recommended",  # noqa: B950
+            f"The current implementation of the {self._get_name()} module has poor numerical accuracy and its use is not recommended",
             stacklevel=2,
         )
         if padding_mode == "reflect":
@@ -334,7 +334,7 @@ class ConvTranspose1d(nnq.ConvTranspose1d):
         dtype=None,
     ):
         warnings.warn(
-            f"The current implementation of the {self._get_name()} module has poor numerical accuracy and its use is not recommended",  # noqa: B950
+            f"The current implementation of the {self._get_name()} module has poor numerical accuracy and its use is not recommended",
             stacklevel=2,
         )
         factory_kwargs = {"device": device, "dtype": dtype}
@@ -417,7 +417,7 @@ class ConvTranspose2d(nnq.ConvTranspose2d):
         dtype=None,
     ):
         warnings.warn(
-            f"The current implementation of the {self._get_name()} module has poor numerical accuracy and its use is not recommended",  # noqa: B950
+            f"The current implementation of the {self._get_name()} module has poor numerical accuracy and its use is not recommended",
             stacklevel=2,
         )
         factory_kwargs = {"device": device, "dtype": dtype}
@@ -500,7 +500,7 @@ class ConvTranspose3d(nnq.ConvTranspose3d):
         dtype=None,
     ):
         warnings.warn(
-            f"The current implementation of the {self._get_name()} module has poor numerical accuracy and its use is not recommended",  # noqa: B950
+            f"The current implementation of the {self._get_name()} module has poor numerical accuracy and its use is not recommended",
             stacklevel=2,
         )
         factory_kwargs = {"device": device, "dtype": dtype}

--- a/torch/ao/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/ao/nn/quantized/dynamic/modules/rnn.py
@@ -5,7 +5,7 @@ from typing_extensions import deprecated
 
 import torch
 import torch.nn as nn
-from torch import Tensor  # noqa: F401
+from torch import Tensor
 from torch._jit_internal import Dict, List, Optional, Tuple, Union  # noqa: F401
 from torch.ao.nn.quantized.modules.utils import _quantize_weight
 from torch.nn.utils.rnn import PackedSequence

--- a/torch/ao/nn/quantized/functional.py
+++ b/torch/ao/nn/quantized/functional.py
@@ -221,7 +221,7 @@ def conv1d(
         >>> q_filters = torch.quantize_per_tensor(filters, scale, zero_point, dtype_filters)
         >>> q_inputs = torch.quantize_per_tensor(inputs, scale, zero_point, dtype_inputs)
         >>> qF.conv1d(q_inputs, q_filters, bias, padding=1, scale=scale, zero_point=zero_point)
-    """  # noqa: E501
+    """
     if padding_mode != "zeros":
         raise NotImplementedError("Only zero-padding is supported!")
     if input.dtype != torch.quint8:
@@ -293,7 +293,7 @@ def conv2d(
         >>> q_filters = torch.quantize_per_tensor(filters, scale, zero_point, dtype_filters)
         >>> q_inputs = torch.quantize_per_tensor(inputs, scale, zero_point, dtype_inputs)
         >>> qF.conv2d(q_inputs, q_filters, bias, padding=1, scale=scale, zero_point=zero_point)
-    """  # noqa: E501
+    """
     if padding_mode != "zeros":
         raise NotImplementedError("Only zero-padding is supported!")
     if input.dtype != torch.quint8:
@@ -369,7 +369,7 @@ def conv3d(
         >>> q_filters = torch.quantize_per_tensor(filters, scale, zero_point, dtype_filters)
         >>> q_inputs = torch.quantize_per_tensor(inputs, scale, zero_point, dtype_inputs)
         >>> qF.conv3d(q_inputs, q_filters, bias, padding=1, scale=scale, zero_point=zero_point)
-    """  # noqa: E501
+    """
     if padding_mode != "zeros":
         raise NotImplementedError("Only zero-padding is supported!")
     if input.dtype != torch.quint8:

--- a/torch/ao/nn/quantized/modules/embedding_ops.py
+++ b/torch/ao/nn/quantized/modules/embedding_ops.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import torch
 import torch.nn as nn
-from torch import Tensor  # noqa: F401
+from torch import Tensor
 from torch._jit_internal import List, Optional  # noqa: F401
 
 from .utils import _hide_packed_params_repr, _quantize_weight

--- a/torch/ao/nn/quantized/reference/modules/rnn.py
+++ b/torch/ao/nn/quantized/reference/modules/rnn.py
@@ -573,7 +573,7 @@ class LSTM(RNNBase):
             flat_weights.append(weight)
         return flat_weights
 
-    def forward(self, input, hx=None):  # noqa: F811
+    def forward(self, input, hx=None):
         orig_input = input
         # xxx: isinstance check needs to be in conditional for TorchScript to compile
         batch_sizes = None
@@ -742,7 +742,7 @@ class GRU(RNNBase):
             flat_weights.append(weight)
         return flat_weights
 
-    def forward(self, input, hx=None):  # noqa: F811
+    def forward(self, input, hx=None):
         # Note: this is copied from the forward of GRU in https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/rnn.py
         # only changed self._flat_weights to self.get_flat_weights()
         # TODO: maybe we can try inheriting from that class and define get_flat_weights

--- a/torch/ao/quantization/__init__.py
+++ b/torch/ao/quantization/__init__.py
@@ -8,7 +8,7 @@ import torch
 from torch import Tensor
 
 from .fake_quantize import *  # noqa: F403
-from .fuse_modules import fuse_modules, fuse_modules_qat  # noqa: F403
+from .fuse_modules import fuse_modules, fuse_modules_qat
 from .fuser_method_mappings import *  # noqa: F403
 from .observer import *  # noqa: F403
 from .qconfig import *  # noqa: F403

--- a/torch/ao/quantization/backend_config/_common_operator_config_utils.py
+++ b/torch/ao/quantization/backend_config/_common_operator_config_utils.py
@@ -157,7 +157,7 @@ def _get_binary_op_configs(
         ]
         binary_op_configs.extend(
             BackendPatternConfig(bop_pattern)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             ._set_num_tensor_args_to_observation_type(
                 num_tensor_args_to_observation_type_mapping
             )
@@ -165,7 +165,7 @@ def _get_binary_op_configs(
         )
     # matmul
     binary_op_configs.append(
-        BackendPatternConfig(torch.matmul).set_dtype_configs(dtype_configs)  # noqa: E131
+        BackendPatternConfig(torch.matmul).set_dtype_configs(dtype_configs)
     )
     return binary_op_configs
 
@@ -182,7 +182,7 @@ def _get_linear_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPattern
     # linear module
     linear_configs.append(
         BackendPatternConfig(torch.nn.Linear)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         .set_root_module(torch.nn.Linear)
         .set_reference_quantized_module(nnqr.Linear)
@@ -191,7 +191,7 @@ def _get_linear_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPattern
     # linear qat module
     linear_configs.append(
         BackendPatternConfig(nnqat.Linear)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         .set_root_module(torch.nn.Linear)
         .set_reference_quantized_module(nnqr.Linear)
@@ -199,7 +199,7 @@ def _get_linear_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPattern
     # functional linear
     linear_configs.append(
         BackendPatternConfig(torch.nn.functional.linear)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 1, "bias": 2})
     )
@@ -210,14 +210,14 @@ def _get_linear_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPattern
     # linear relu, linear module + relu module
     linear_configs.append(
         BackendPatternConfig((torch.nn.Linear, torch.nn.ReLU))
-        .set_dtype_configs(dtype_configs)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
         .set_fuser_method(_sequential_wrapper2(nni.LinearReLU))
         .set_fused_module(nni.LinearReLU)
     )
     # linear relu, linear module + functional relu
     linear_configs.append(
         BackendPatternConfig((torch.nn.Linear, torch.nn.functional.relu))
-        .set_dtype_configs(dtype_configs)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
         .set_fuser_method(_sequential_wrapper2(nni.LinearReLU))
         .set_fused_module(nni.LinearReLU)
     )
@@ -226,7 +226,7 @@ def _get_linear_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPattern
     # linear relu, fused module
     linear_configs.append(
         BackendPatternConfig(nni.LinearReLU)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         .set_root_module(torch.nn.Linear)
         .set_reference_quantized_module(nnqr.Linear)
@@ -235,7 +235,7 @@ def _get_linear_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPattern
     # linear relu, qat fused module
     linear_configs.append(
         BackendPatternConfig(nniqat.LinearReLU)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         .set_root_module(torch.nn.Linear)
         .set_reference_quantized_module(nnqr.Linear)
@@ -244,13 +244,13 @@ def _get_linear_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPattern
     # linear relu, functional linear + relu module
     linear_configs.append(
         BackendPatternConfig((F.linear, torch.nn.ReLU))
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
     )
     # linear relu, functional linear + functional relu
     linear_configs.append(
         BackendPatternConfig((F.linear, F.relu))
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
     )
 
@@ -259,7 +259,7 @@ def _get_linear_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPattern
     # 3.1 linear bn fusion
     linear_configs.append(
         BackendPatternConfig((nn.Linear, nn.BatchNorm1d))
-        .set_dtype_configs(dtype_configs)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
         .set_fuser_method(fuse_linear_bn)
         .set_fused_module(nni.LinearBn1d)
     )
@@ -268,7 +268,7 @@ def _get_linear_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPattern
     # linear bn, fused module
     linear_configs.append(
         BackendPatternConfig(nni.LinearBn1d)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         .set_root_module(torch.nn.Linear)
         .set_reference_quantized_module(nnqr.Linear)
@@ -277,7 +277,7 @@ def _get_linear_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPattern
     # linear bn, qat fused module
     linear_configs.append(
         BackendPatternConfig(nniqat.LinearBn1d)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         .set_root_module(torch.nn.Linear)
         .set_reference_quantized_module(nnqr.Linear)
@@ -297,7 +297,7 @@ def _get_conv_configs(dtype_configs):
         # conv module
         conv_configs.append(
             BackendPatternConfig(convs.root)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -306,7 +306,7 @@ def _get_conv_configs(dtype_configs):
         # conv qat module
         conv_configs.append(
             BackendPatternConfig(convs.qat)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -314,7 +314,7 @@ def _get_conv_configs(dtype_configs):
         # functional conv
         conv_configs.append(
             BackendPatternConfig(convs.func)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             ._set_input_type_to_index({"weight": 1, "bias": 2})
         )
@@ -325,14 +325,14 @@ def _get_conv_configs(dtype_configs):
         # conv relu fusion, conv module + relu module
         conv_configs.append(
             BackendPatternConfig((convs.root, torch.nn.ReLU))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_fuser_method(_sequential_wrapper2(convs.fused_conv_relu))
             .set_fused_module(convs.fused_conv_relu)
         )
         # conv relu fusion, conv module + functional relu
         conv_configs.append(
             BackendPatternConfig((convs.root, F.relu))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_fuser_method(_sequential_wrapper2(convs.fused_conv_relu))
             .set_fused_module(convs.fused_conv_relu)
         )
@@ -340,7 +340,7 @@ def _get_conv_configs(dtype_configs):
         # conv relu, fused module
         conv_configs.append(
             BackendPatternConfig(convs.fused_conv_relu)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -349,7 +349,7 @@ def _get_conv_configs(dtype_configs):
         # conv relu, qat fused module
         conv_configs.append(
             BackendPatternConfig(convs.relu_qat)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -358,26 +358,26 @@ def _get_conv_configs(dtype_configs):
         # conv relu, functional conv + relu module
         conv_configs.append(
             BackendPatternConfig((convs.func, torch.nn.ReLU))
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
         )
         # conv relu, functional conv + functional relu
         conv_configs.append(
             BackendPatternConfig((convs.func, F.relu))
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
         )
 
         # fused conv relu
         conv_configs.append(
             BackendPatternConfig(convs.fused_conv_relu)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_qat_module(convs.relu_qat)
         )
 
         conv_configs.append(
             BackendPatternConfig(convs.relu_qat)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
         )
@@ -388,21 +388,21 @@ def _get_conv_configs(dtype_configs):
         # conv + bn fusion
         conv_configs.append(
             BackendPatternConfig((convs.root, convs.bn))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_fuser_method(fuse_conv_bn)
             .set_fused_module(convs.fused_conv_bn)
         )
         # conv + bn + relu module fusion
         conv_configs.append(
             BackendPatternConfig((convs.root, convs.bn, nn.ReLU))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_fuser_method(fuse_conv_bn_relu)
             .set_fused_module(convs.fused_conv_bn_relu)
         )
         # conv + bn + relu functional fusion
         conv_configs.append(
             BackendPatternConfig((convs.root, convs.bn, F.relu))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_fuser_method(fuse_conv_bn_relu)
             .set_fused_module(convs.fused_conv_bn_relu)
@@ -413,21 +413,21 @@ def _get_conv_configs(dtype_configs):
         # fused conv bn
         conv_configs.append(
             BackendPatternConfig(convs.fused_conv_bn)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_qat_module(convs.bn_qat)
         )
 
         # fused conv bn relu
         conv_configs.append(
             BackendPatternConfig(convs.fused_conv_bn_relu)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_qat_module(convs.bn_relu_qat)
         )
 
         # conv bn, qat fused module
         conv_configs.append(
             BackendPatternConfig(convs.bn_qat)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -435,7 +435,7 @@ def _get_conv_configs(dtype_configs):
         # conv bn relu, qat fused module
         conv_configs.append(
             BackendPatternConfig(convs.bn_relu_qat)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -445,7 +445,7 @@ def _get_conv_configs(dtype_configs):
         # 4.1 conv transpose config
         conv_configs.append(
             BackendPatternConfig(convs.transpose)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_root_module(convs.transpose)
             .set_reference_quantized_module(convs.transpose_reference)
         )
@@ -453,7 +453,7 @@ def _get_conv_configs(dtype_configs):
         # 4.2 conv transpose + bn fusion
         conv_configs.append(
             BackendPatternConfig((convs.transpose, convs.bn))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_fuser_method(fuse_convtranspose_bn)
             .set_root_module(convs.transpose)
             .set_reference_quantized_module(convs.transpose_reference)
@@ -462,7 +462,7 @@ def _get_conv_configs(dtype_configs):
         # 4.3 functional conv transpose
         conv_configs.append(
             BackendPatternConfig(convs.func_transpose)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             ._set_input_type_to_index({"weight": 1, "bias": 2})
         )
 
@@ -481,12 +481,12 @@ def _get_ln_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPatternConf
     ln_configs = []
     ln_configs.append(
         BackendPatternConfig(torch.nn.LayerNorm)
-        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)  # noqa: E131
+        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)
         .set_dtype_configs(dtype_configs)
     )
     ln_configs.append(
         BackendPatternConfig(torch.nn.functional.layer_norm)
-        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)  # noqa: E131
+        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 2, "bias": 3})
     )
@@ -512,21 +512,21 @@ def _get_default_op_configs(
     ]
     configs = [
         BackendPatternConfig(op)
-        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)  # noqa: E131
+        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)
         .set_dtype_configs(dtype_configs)
         for op in default_ops
     ]
 
     configs.append(
         BackendPatternConfig(torch.nn.functional.group_norm)
-        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)  # noqa: E131
+        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 2, "bias": 3})
     )
 
     configs.append(
         BackendPatternConfig(torch.nn.functional.instance_norm)
-        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)  # noqa: E131
+        .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT)
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 3, "bias": 4})
     )
@@ -584,7 +584,7 @@ def _get_fixed_qparams_op_configs(
             BackendPatternConfig(fixed_qparam_op)
             .set_observation_type(
                 ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-            )  # noqa: E131
+            )
             .set_dtype_configs(new_dtype_configs)
         )
     return fixed_qparams_op_configs
@@ -682,14 +682,14 @@ def _get_bn_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPatternConf
         # bn module + relu module fusion config
         bn_configs.append(
             BackendPatternConfig((bn, nn.ReLU))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_fuser_method(_sequential_wrapper2(fused_bn))
             .set_fused_module(fused_bn)
         )
         # bn module + F.relu fusion config
         bn_configs.append(
             BackendPatternConfig((bn, F.relu))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_fuser_method(_sequential_wrapper2(fused_bn))
             .set_fused_module(fused_bn)
         )
@@ -697,7 +697,7 @@ def _get_bn_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPatternConf
             BackendPatternConfig(bn)
             .set_observation_type(
                 ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-            )  # noqa: E131
+            )
             .set_dtype_configs(dtype_configs)
         )
 
@@ -707,7 +707,7 @@ def _get_bn_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPatternConf
             BackendPatternConfig(fused_bn)
             .set_observation_type(
                 ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-            )  # noqa: E131
+            )
             .set_dtype_configs(dtype_configs)
         )
     return bn_configs
@@ -726,7 +726,7 @@ def _get_rnn_op_configs(dtype_configs: list[DTypeConfig]) -> list[BackendPattern
             BackendPatternConfig(rnn_op)
             .set_observation_type(
                 ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-            )  # noqa: E131
+            )
             .set_dtype_configs(dtype_configs)
             .set_root_module(rnn_op)
             .set_reference_quantized_module(ref_rnn_op)
@@ -746,7 +746,7 @@ def _get_embedding_op_configs(
             BackendPatternConfig(embedding_op)
             .set_observation_type(
                 ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-            )  # noqa: E131
+            )
             .set_dtype_configs(dtype_configs)
             .set_qat_module(qat_embedding_op)
             .set_root_module(embedding_op)
@@ -758,7 +758,7 @@ def _get_embedding_op_configs(
             BackendPatternConfig(qat_embedding_op)
             .set_observation_type(
                 ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-            )  # noqa: E131
+            )
             .set_dtype_configs(dtype_configs)
             .set_root_module(embedding_op)
             .set_reference_quantized_module(ref_embedding_op)

--- a/torch/ao/quantization/backend_config/_qnnpack_pt2e.py
+++ b/torch/ao/quantization/backend_config/_qnnpack_pt2e.py
@@ -53,20 +53,20 @@ def get_linear_configs():
 
     # linear_configs.append(
     #     BackendPatternConfig((torch.ops.aten.addmm.default, MatchAllNode, MatchAllNode, torch.ops.aten.t.default))
-    #     .set_observation_type(observation_type)  # noqa: E131
+    #     .set_observation_type(observation_type)
     #     .set_dtype_configs(dtype_configs)
     #     ._set_root_node_getter(root_node_getter))
 
     linear_configs.append(
         BackendPatternConfig(torch.ops.aten.addmm.default)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 2, "bias": 0})
     )
     # linear is decomposed to `t - mm` if bias is not present
     linear_configs.append(
         BackendPatternConfig(torch.ops.aten.mm.default)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 1})
     )
@@ -79,7 +79,7 @@ def get_conv_configs():
     dtype_configs = [weighted_op_quint8_dtype_config]
     conv_configs.append(
         BackendPatternConfig(torch.ops.aten.convolution.default)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 1, "bias": 2})
     )
@@ -87,7 +87,7 @@ def get_conv_configs():
         BackendPatternConfig(
             (torch.ops.aten.convolution.default, torch.ops.aten.relu.default)
         )
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 1, "bias": 2})
     )
@@ -96,7 +96,7 @@ def get_conv_configs():
         BackendPatternConfig(
             (torch.ops.aten.convolution.default, torch.ops.aten.relu_.default)
         )
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 1, "bias": 2})
     )
@@ -117,7 +117,7 @@ def get_pooling_configs():
         ._set_pattern_complex_format(
             (operator.getitem, torch.ops.aten.max_pool2d_with_indices.default, 0)
         )
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         ._set_root_node_getter(root_node_getter)
     )
@@ -131,7 +131,7 @@ def get_relu_configs():
     dtype_configs = [weighted_op_quint8_dtype_config]
     backend_pattern_configs.append(
         BackendPatternConfig(torch.ops.aten.relu.default)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
     )
     return backend_pattern_configs
@@ -160,7 +160,7 @@ def get_binary_op_configs():
         ]
         binary_op_configs.extend(
             BackendPatternConfig(bop_pattern)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             ._set_num_tensor_args_to_observation_type(
                 num_tensor_args_to_observation_type_mapping
             )

--- a/torch/ao/quantization/backend_config/executorch.py
+++ b/torch/ao/quantization/backend_config/executorch.py
@@ -113,7 +113,7 @@ def _get_linear_configs() -> list[BackendPatternConfig]:
     # linear module
     linear_configs.append(
         BackendPatternConfig(torch.nn.Linear)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         .set_root_module(torch.nn.Linear)
         .set_reference_quantized_module(nnqr.Linear)
@@ -122,7 +122,7 @@ def _get_linear_configs() -> list[BackendPatternConfig]:
     # linear qat module
     linear_configs.append(
         BackendPatternConfig(nnqat.Linear)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         .set_root_module(torch.nn.Linear)
         .set_reference_quantized_module(nnqr.Linear)
@@ -130,7 +130,7 @@ def _get_linear_configs() -> list[BackendPatternConfig]:
     # functional linear
     linear_configs.append(
         BackendPatternConfig(torch.nn.functional.linear)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         ._set_input_type_to_index({"weight": 1, "bias": 2})
     )
@@ -153,7 +153,7 @@ def _get_conv_configs() -> list[BackendPatternConfig]:
         # conv module
         conv_configs.append(
             BackendPatternConfig(convs.root)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -162,7 +162,7 @@ def _get_conv_configs() -> list[BackendPatternConfig]:
         # conv qat module
         conv_configs.append(
             BackendPatternConfig(convs.qat)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -170,7 +170,7 @@ def _get_conv_configs() -> list[BackendPatternConfig]:
         # functional conv
         conv_configs.append(
             BackendPatternConfig(convs.func)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             ._set_input_type_to_index({"weight": 1, "bias": 2})
         )
@@ -180,21 +180,21 @@ def _get_conv_configs() -> list[BackendPatternConfig]:
         # conv module + relu module
         conv_configs.append(
             BackendPatternConfig((convs.root, nn.ReLU))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_fuser_method(_sequential_wrapper2(convs.fused_conv_relu))
             .set_fused_module(convs.fused_conv_relu)
         )
         # conv module + functional relu
         conv_configs.append(
             BackendPatternConfig((convs.root, F.relu))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_fuser_method(_sequential_wrapper2(convs.fused_conv_relu))
             .set_fused_module(convs.fused_conv_relu)
         )
         # fused conv relu module
         conv_configs.append(
             BackendPatternConfig(convs.fused_conv_relu)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -203,7 +203,7 @@ def _get_conv_configs() -> list[BackendPatternConfig]:
         # conv relu, qat fused module
         conv_configs.append(
             BackendPatternConfig(convs.relu_qat)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -211,25 +211,25 @@ def _get_conv_configs() -> list[BackendPatternConfig]:
         # functional conv + relu module
         conv_configs.append(
             BackendPatternConfig((convs.func, nn.ReLU))
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
         )
         # functional conv + functional relu
         conv_configs.append(
             BackendPatternConfig((convs.func, F.relu))
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
         )
         # fused conv relu
         conv_configs.append(
             BackendPatternConfig(convs.fused_conv_relu)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_qat_module(convs.relu_qat)
         )
 
         conv_configs.append(
             BackendPatternConfig(convs.relu_qat)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
         )
@@ -239,21 +239,21 @@ def _get_conv_configs() -> list[BackendPatternConfig]:
         # conv + batchnorm (+ relu)
         conv_configs.append(
             BackendPatternConfig((convs.root, convs.bn))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_fuser_method(fuse_conv_bn)
             .set_fused_module(convs.fused_conv_bn)
         )
         # conv + bn + relu module fusion
         conv_configs.append(
             BackendPatternConfig((convs.root, convs.bn, nn.ReLU))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_fuser_method(fuse_conv_bn_relu)
             .set_fused_module(convs.fused_conv_bn_relu)
         )
         # conv + bn + relu functional fusion
         conv_configs.append(
             BackendPatternConfig((convs.root, convs.bn, F.relu))
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_fuser_method(fuse_conv_bn_relu)
             .set_fused_module(convs.fused_conv_bn_relu)
@@ -263,21 +263,21 @@ def _get_conv_configs() -> list[BackendPatternConfig]:
         # fused conv bn
         conv_configs.append(
             BackendPatternConfig(convs.fused_conv_bn)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_qat_module(convs.bn_qat)
         )
 
         # fused conv bn relu
         conv_configs.append(
             BackendPatternConfig(convs.fused_conv_bn_relu)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             .set_qat_module(convs.bn_relu_qat)
         )
 
         # conv bn, qat fused module
         conv_configs.append(
             BackendPatternConfig(convs.bn_qat)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -285,7 +285,7 @@ def _get_conv_configs() -> list[BackendPatternConfig]:
         # conv bn relu, qat fused module
         conv_configs.append(
             BackendPatternConfig(convs.bn_relu_qat)
-            .set_observation_type(observation_type)  # noqa: E131
+            .set_observation_type(observation_type)
             .set_dtype_configs(dtype_configs)
             .set_root_module(convs.root)
             .set_reference_quantized_module(convs.reference)
@@ -326,7 +326,7 @@ def _get_binary_ops_configs() -> list[BackendPatternConfig]:
         ]
         binary_op_configs.extend(
             BackendPatternConfig(bop_pattern)
-            .set_dtype_configs(dtype_configs)  # noqa: E131
+            .set_dtype_configs(dtype_configs)
             ._set_num_tensor_args_to_observation_type(
                 num_tensor_args_to_observation_type_mapping
             )
@@ -386,7 +386,7 @@ def _get_share_qparams_ops_configs() -> list[BackendPatternConfig]:
     ]
     share_qparams_op_configs: list[BackendPatternConfig] = [
         BackendPatternConfig(op)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         for op in share_qparams_ops
     ]
@@ -405,7 +405,7 @@ def _get_bn_configs() -> list[BackendPatternConfig]:
     bn_configs = []
     bn_configs.append(
         BackendPatternConfig(nn.BatchNorm2d)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
     )
     return bn_configs
@@ -448,7 +448,7 @@ def _get_embedding_op_configs() -> list[BackendPatternConfig]:
             BackendPatternConfig(embedding_op)
             .set_observation_type(
                 ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-            )  # noqa: E131
+            )
             .set_dtype_configs(dtype_configs)
             .set_qat_module(qat_embedding_op)
             .set_root_module(embedding_op)
@@ -459,7 +459,7 @@ def _get_embedding_op_configs() -> list[BackendPatternConfig]:
             BackendPatternConfig(qat_embedding_op)
             .set_observation_type(
                 ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-            )  # noqa: E131
+            )
             .set_dtype_configs(dtype_configs)
             .set_root_module(embedding_op)
             .set_reference_quantized_module(ref_embedding_op)
@@ -470,7 +470,7 @@ def _get_embedding_op_configs() -> list[BackendPatternConfig]:
             BackendPatternConfig(torch.nn.functional.embedding)
             .set_observation_type(
                 ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-            )  # noqa: E131
+            )
             .set_dtype_configs(dtype_configs)
             ._set_input_type_to_index({"weight": 1})
         )

--- a/torch/ao/quantization/backend_config/onednn.py
+++ b/torch/ao/quantization/backend_config/onednn.py
@@ -190,7 +190,7 @@ for with_bn, add_op in conv_add_left_optioins:
             BackendPatternConfig()
             ._set_pattern_complex_format(
                 (add_op, (nn.BatchNorm2d, nn.Conv2d), MatchAllNode)
-            )  # noqa: E131
+            )
             .set_observation_type(observation_type)
             .set_dtype_configs(conv_dtype_configs)
             .set_fuser_method(_fuse_conv_bn_add_left)
@@ -201,7 +201,7 @@ for with_bn, add_op in conv_add_left_optioins:
     else:
         conv_configs.append(
             BackendPatternConfig()
-            ._set_pattern_complex_format((add_op, nn.Conv2d, MatchAllNode))  # noqa: E131
+            ._set_pattern_complex_format((add_op, nn.Conv2d, MatchAllNode))
             .set_observation_type(observation_type)
             .set_dtype_configs(conv_dtype_configs)
             .set_fuser_method(_fuse_conv_add_left)
@@ -273,7 +273,7 @@ for with_bn, add_op in conv_add_optioins:
             BackendPatternConfig()
             ._set_pattern_complex_format(
                 (add_op, MatchAllNode, (nn.BatchNorm2d, nn.Conv2d))
-            )  # noqa: E131
+            )
             .set_observation_type(observation_type)
             .set_dtype_configs(conv_dtype_configs)
             .set_fuser_method(_fuse_conv_bn_add_right)
@@ -284,7 +284,7 @@ for with_bn, add_op in conv_add_optioins:
     else:
         conv_configs.append(
             BackendPatternConfig()
-            ._set_pattern_complex_format((add_op, MatchAllNode, nn.Conv2d))  # noqa: E131
+            ._set_pattern_complex_format((add_op, MatchAllNode, nn.Conv2d))
             .set_observation_type(observation_type)
             .set_dtype_configs(conv_dtype_configs)
             .set_fuser_method(_fuse_conv_add_right)
@@ -295,7 +295,7 @@ for with_bn, add_op in conv_add_optioins:
 
 conv_configs.append(
     BackendPatternConfig(nni.ConvAdd2d)
-    .set_observation_type(observation_type)  # noqa: E131
+    .set_observation_type(observation_type)
     .set_dtype_configs(conv_dtype_configs)
     .set_root_module(nn.Conv2d)
     .set_reference_quantized_module(nnqr.Conv2d)
@@ -376,7 +376,7 @@ for with_bn, add_op in conv_add_relu_left_optioins:
             BackendPatternConfig()
             ._set_pattern_complex_format(
                 (nn.ReLU, (add_op, (nn.BatchNorm2d, nn.Conv2d), MatchAllNode))
-            )  # noqa: E131
+            )
             .set_observation_type(observation_type)
             .set_dtype_configs(conv_dtype_configs)
             .set_fuser_method(_fuse_conv_bn_add_relu_left)
@@ -387,7 +387,7 @@ for with_bn, add_op in conv_add_relu_left_optioins:
     else:
         conv_configs.append(
             BackendPatternConfig()
-            ._set_pattern_complex_format((nn.ReLU, (add_op, nn.Conv2d, MatchAllNode)))  # noqa: E131
+            ._set_pattern_complex_format((nn.ReLU, (add_op, nn.Conv2d, MatchAllNode)))
             .set_observation_type(observation_type)
             .set_dtype_configs(conv_dtype_configs)
             .set_fuser_method(_fuse_conv_add_relu_left)
@@ -469,7 +469,7 @@ for with_bn, add_op in conv_add_relu_left_optioins:
             BackendPatternConfig()
             ._set_pattern_complex_format(
                 (nn.ReLU, (add_op, MatchAllNode, (nn.BatchNorm2d, nn.Conv2d)))
-            )  # noqa: E131
+            )
             .set_observation_type(observation_type)
             .set_dtype_configs(conv_dtype_configs)
             .set_fuser_method(_fuse_conv_bn_add_relu_right)
@@ -480,7 +480,7 @@ for with_bn, add_op in conv_add_relu_left_optioins:
     else:
         conv_configs.append(
             BackendPatternConfig()
-            ._set_pattern_complex_format((nn.ReLU, (add_op, MatchAllNode, nn.Conv2d)))  # noqa: E131
+            ._set_pattern_complex_format((nn.ReLU, (add_op, MatchAllNode, nn.Conv2d)))
             .set_observation_type(observation_type)
             .set_dtype_configs(conv_dtype_configs)
             .set_fuser_method(_fuse_conv_add_relu_right)
@@ -491,7 +491,7 @@ for with_bn, add_op in conv_add_relu_left_optioins:
 
 conv_configs.append(
     BackendPatternConfig(nni.ConvAddReLU2d)
-    .set_observation_type(observation_type)  # noqa: E131
+    .set_observation_type(observation_type)
     .set_dtype_configs(conv_dtype_configs)
     .set_root_module(nn.Conv2d)
     .set_reference_quantized_module(nnqr.Conv2d)
@@ -523,14 +523,14 @@ def _add_eltwise_fusion_configs(
     # 1 base module + op module fusion config
     configs.append(
         BackendPatternConfig((root_module, post_module))
-        .set_dtype_configs(dtype_configs)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
         .set_fuser_method(fuser_method)
         .set_fused_module(fused_module)
     )
     # base module + functional post op
     configs.append(
         BackendPatternConfig((root_module, post_op))
-        .set_dtype_configs(dtype_configs)  # noqa: E131
+        .set_dtype_configs(dtype_configs)
         .set_fuser_method(fuser_method)
         .set_fused_module(fused_module)
     )
@@ -538,7 +538,7 @@ def _add_eltwise_fusion_configs(
     # 2 fused module configs
     configs.append(
         BackendPatternConfig(fused_module)
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
         .set_root_module(root_module)
         .set_reference_quantized_module(ref_quant_module)
@@ -547,12 +547,12 @@ def _add_eltwise_fusion_configs(
     # 3 functional base op + post op configs
     configs.append(
         BackendPatternConfig((root_op, post_module))
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
     )
     configs.append(
         BackendPatternConfig((root_op, post_op))
-        .set_observation_type(observation_type)  # noqa: E131
+        .set_observation_type(observation_type)
         .set_dtype_configs(dtype_configs)
     )
 
@@ -574,7 +574,7 @@ _add_eltwise_fusion_configs(
 # Configs for linear module + batchnorm + leaky_relu
 linear_configs.append(
     BackendPatternConfig((nn.Linear, nn.BatchNorm1d, nn.LeakyReLU))
-    .set_dtype_configs(linear_dtype_configs)  # noqa: E131
+    .set_dtype_configs(linear_dtype_configs)
     .set_fuser_method(_fuse_linear_bn_leaky_relu)
     .set_fused_module(nni.LinearLeakyReLU)
 )

--- a/torch/ao/quantization/experimental/adaround_optimization.py
+++ b/torch/ao/quantization/experimental/adaround_optimization.py
@@ -76,11 +76,11 @@ class AdaptiveRoundingOptimizer:
                 # Knowing activation ahead-of-time would be helpful for asymmetric formulation
                 # But this is challenging in eager mode, but graph module.
                 layer_list.append((name, module, q_module))
-        print(f"Total number of layers : {len(layer_list)}")  # noqa: G004
+        print(f"Total number of layers : {len(layer_list)}")
 
         for name, module, q_module in layer_list:
             print(
-                f"Kick start adaptive rounding on {name} module {module}"  # noqa: G004
+                f"Kick start adaptive rounding on {name} module {module}"
             )
             self.optimize_adaptive_rounding(
                 module,
@@ -162,7 +162,7 @@ class AdaptiveRoundingOptimizer:
             soft_quant_loss = F.mse_loss(out_soft_quant, fp_out)
             hard_quant_loss = F.mse_loss(out_hard_quant, fp_out)
             print(
-                f"soft quant loss: {soft_quant_loss.item()} hard quant loss: {hard_quant_loss.item()}"  # noqa: G004
+                f"soft quant loss: {soft_quant_loss.item()} hard quant loss: {hard_quant_loss.item()}"
             )
 
     def optimize_adaptive_rounding(
@@ -240,8 +240,8 @@ class AdaptiveRoundingOptimizer:
                 break
             if iteration % 30 == 0:
                 print(
-                    f"glob iter {global_idx} regularization_loss {regularization_loss.item()} "  # noqa: G004
-                    f"reconstruction_loss {reconstruction_loss.item()}"  # noqa: G004
+                    f"glob iter {global_idx} regularization_loss {regularization_loss.item()} "
+                    f"reconstruction_loss {reconstruction_loss.item()}"
                 )
         print("==================== After adaround ====================")
         self._compute_and_display_local_losses(ada_quantizer, q_module, inp[0], out[0])

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -438,7 +438,7 @@ def _load_packed_weight(
     for attr_name in state_dict:
         if attr_name.startswith("_packed_weight") and isinstance(
             state_dict[attr_name], torch._C.ScriptObject
-        ):  # type: ignore[attr-defined] # noqa: B950
+        ):  # type: ignore[attr-defined]
             setattr(self, attr_name, state_dict[attr_name])
             attrs_to_pop.append(attr_name)
 
@@ -534,7 +534,7 @@ def fold_weight(
     quantized_model.register_load_state_dict_pre_hook(_load_packed_weight)
 
     if keep_original_weights:
-        setattr(  # noqa: B010
+        setattr(
             quantized_model, ORIGINAL_WEIGHTS_LOOKUP, original_weights_lookup
         )
 

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -210,7 +210,7 @@ def _replace_observer_with_quantize_dequantize_node_decomposed(
                 # TODO: we can add the information of whether a value needs to
                 # be registered as an attribute in qparams dict itself
                 if key in ["_scale_", "_zero_point_"] and (
-                    not isinstance(value_or_node, (float, int))  # noqa: UP038
+                    not isinstance(value_or_node, (float, int))
                 ):
                     # For scale and zero_point values we register them as buffers in the root module.
                     # However, note that when the values are not tensors, as in the case of
@@ -596,7 +596,7 @@ def _maybe_recursive_remove_dequantize(arg: Any, node: Node, graph: Graph) -> No
         # we only replace the specific use since dequantize could be used by other nodes
         # as well
         node.replace_input_with(arg, quantize_node)
-    elif isinstance(arg, (list, tuple)):  # noqa: UP038
+    elif isinstance(arg, (list, tuple)):
         for arg_element in arg:
             _maybe_recursive_remove_dequantize(arg_element, node, graph)
     elif isinstance(arg, dict):
@@ -838,7 +838,7 @@ def convert_weighted_module(
                 "weight_hh": weight_qparams_hh,
             }
         )
-    elif isinstance(float_module, (torch.nn.LSTM, torch.nn.GRU)):  # noqa: UP038
+    elif isinstance(float_module, (torch.nn.LSTM, torch.nn.GRU)):
         # format for wq_or_wq_dict (flattened attributes):
         # {"weight_ih_l0_scale": ..., "weight_ih_l0_qscheme": ..., ...}
         for wn in float_module._flat_weights_names:
@@ -1217,12 +1217,12 @@ def convert(
             return_node = node
             output = node.args[0]
             # outputs can be Node, list, tuple, dict, other cases are not supported yet
-            if isinstance(output, (list, tuple)):  # noqa: UP038
+            if isinstance(output, (list, tuple)):
                 for idx in output_quantized_idxs:
                     _maybe_recursive_remove_dequantize(
                         output[idx], return_node, model.graph
                     )
-            elif isinstance(output, (Node, dict)):  # noqa: UP038
+            elif isinstance(output, (Node, dict)):
                 # we treat dict as a single argument currently, but it can be extended
                 # to support {"key": dtype} after we change output_quantized_idxs to
                 # dict

--- a/torch/ao/quantization/fx/graph_module.py
+++ b/torch/ao/quantization/fx/graph_module.py
@@ -177,7 +177,7 @@ class QuantizedGraphModule(GraphModule):
         for attr_name in state_dict:
             if attr_name.startswith("_packed_weight") and isinstance(
                 state_dict[attr_name], torch._C.ScriptObject
-            ):  # type: ignore[attr-defined] # noqa: B950
+            ):  # type: ignore[attr-defined]
                 setattr(self, attr_name, state_dict[attr_name])
                 attrs_to_pop.append(attr_name)
 

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -182,7 +182,7 @@ def _is_input_arg_dtype_supported_by_backend(
     """Check if the configured qconfig for the argument
     is supported by the backend or not
     """
-    if isinstance(arg, (list, tuple)):  # noqa: UP038
+    if isinstance(arg, (list, tuple)):
         return all(
             _is_input_arg_dtype_supported_by_backend(
                 a,
@@ -396,7 +396,7 @@ def _qat_swap_modules(
 def _add_matched_node_name_to_set(matched_node_pattern: NodePattern, s: set[str]):
     if isinstance(matched_node_pattern, Node):
         s.add(matched_node_pattern.name)
-    elif isinstance(matched_node_pattern, (list, tuple)):  # noqa: UP038
+    elif isinstance(matched_node_pattern, (list, tuple)):
         for maybe_node in matched_node_pattern:
             _add_matched_node_name_to_set(maybe_node, s)
 
@@ -446,7 +446,7 @@ def _set_target_dtype_info_for_matched_node_pattern(
     """Sets the target_dtype_info for each node in matched_node_pattern
     Note: processed_nodes is used to ensure we only process each node once
     """
-    if isinstance(matched_node_pattern, (list, tuple)):  # noqa: UP038
+    if isinstance(matched_node_pattern, (list, tuple)):
         for node_pattern in matched_node_pattern:
             _set_target_dtype_info_for_matched_node_pattern(
                 node_pattern,
@@ -734,7 +734,7 @@ def _maybe_insert_input_observer_for_arg_or_kwarg(
     """
     # for ops such as torch.cat([x0, x1]),
     # traverse through the list
-    if isinstance(arg, (list, tuple)):  # noqa: UP038
+    if isinstance(arg, (list, tuple)):
         new_arg_to_return = []
         for inner_arg in arg:
             new_inner_arg = _maybe_insert_input_observer_for_arg_or_kwarg(
@@ -1155,7 +1155,7 @@ def _maybe_insert_observers_before_graph_output(
                 return observer_node
             else:
                 return maybe_node
-        elif isinstance(maybe_node, (list, tuple)):  # noqa: UP038
+        elif isinstance(maybe_node, (list, tuple)):
             results = [
                 _recursive_maybe_replace_node_with_obs(
                     inner_node,
@@ -1247,7 +1247,7 @@ def propagate_dtypes_for_known_nodes(
 
                 # when an argument is a tuple, it does not show up as another node so we need to go through
                 # all elements of the tuple manually
-                if isinstance(arg, (tuple, list)):  # noqa: UP038
+                if isinstance(arg, (tuple, list)):
                     arg_list = list(arg)
                 else:
                     arg_list = [arg]
@@ -1282,7 +1282,7 @@ def _maybe_make_input_output_share_observers(
     first_arg = None
     # find the first non-Tensor arg
     for i in range(len(node.args)):
-        if isinstance(node.args[i], (Node, list, tuple)):  # noqa: UP038
+        if isinstance(node.args[i], (Node, list, tuple)):
             first_arg = node.args[i]
             break
 
@@ -1290,7 +1290,7 @@ def _maybe_make_input_output_share_observers(
     if first_arg is None:
         return False
 
-    if isinstance(first_arg, (list, tuple)):  # noqa: UP038
+    if isinstance(first_arg, (list, tuple)):
         first_arg_arg = first_arg[0]
     elif isinstance(first_arg, Node):
         first_arg_arg = first_arg
@@ -1329,7 +1329,7 @@ def _maybe_make_input_output_share_observers(
         raise AssertionError("target_to_use must be a string")
     obs_mod_to_use = named_modules[target_to_use]
 
-    if isinstance(first_arg, (list, tuple)):  # noqa: UP038
+    if isinstance(first_arg, (list, tuple)):
         # set all other input observer nodes to use that module
         for input_idx, input_arg in enumerate(first_arg):
             if input_idx == 0:

--- a/torch/ao/quantization/quantize_fx.py
+++ b/torch/ao/quantization/quantize_fx.py
@@ -10,9 +10,9 @@ from torch.fx.graph_module import _USER_PRESERVED_ATTRIBUTES_KEY
 from .backend_config import BackendConfig, get_tensorrt_backend_config  # noqa: F401
 from .fx.convert import convert
 from .fx.custom_config import ConvertCustomConfig, FuseCustomConfig, PrepareCustomConfig
-from .fx.fuse import fuse  # noqa: F401
+from .fx.fuse import fuse
 from .fx.graph_module import ObservedGraphModule  # noqa: F401
-from .fx.prepare import prepare  # noqa: F401
+from .fx.prepare import prepare
 from .fx.tracer import QuantizationTracer, Scope, ScopeContextManager  # noqa: F401
 from .fx.utils import (  # noqa: F401
     get_custom_module_class_keys,

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -571,7 +571,7 @@ def _is_checkpoint_valid():
     return Variable._execution_engine.is_checkpoint_valid()
 
 
-def variable(*args, **kwargs):  # noqa: D103
+def variable(*args, **kwargs):
     raise RuntimeError(
         "torch.autograd.variable(...) is deprecated, use torch.tensor(...) instead"
     )

--- a/torch/autograd/anomaly_mode.py
+++ b/torch/autograd/anomaly_mode.py
@@ -76,7 +76,7 @@ class detect_anomaly:
 
     """
 
-    def __init__(self, check_nan=True) -> None:  # noqa: D107
+    def __init__(self, check_nan=True) -> None:
         self.prev = torch.is_anomaly_enabled()
         self.check_nan = check_nan
         self.prev_check_nan = torch.is_anomaly_check_nan_enabled()
@@ -87,10 +87,10 @@ class detect_anomaly:
             stacklevel=2,
         )
 
-    def __enter__(self) -> None:  # noqa: D105
+    def __enter__(self) -> None:
         torch.set_anomaly_enabled(True, self.check_nan)
 
-    def __exit__(self, *args: object) -> None:  # noqa: D105
+    def __exit__(self, *args: object) -> None:
         torch.set_anomaly_enabled(self.prev, self.prev_check_nan)
 
 
@@ -111,13 +111,13 @@ class set_detect_anomaly:
 
     """
 
-    def __init__(self, mode: bool, check_nan: bool = True) -> None:  # noqa: D107
+    def __init__(self, mode: bool, check_nan: bool = True) -> None:
         self.prev = torch.is_anomaly_enabled()
         self.prev_check_nan = torch.is_anomaly_check_nan_enabled()
         torch.set_anomaly_enabled(mode, check_nan)
 
-    def __enter__(self) -> None:  # noqa: D105
+    def __enter__(self) -> None:
         pass
 
-    def __exit__(self, *args: object) -> None:  # noqa: D105
+    def __exit__(self, *args: object) -> None:
         torch.set_anomaly_enabled(self.prev, self.prev_check_nan)

--- a/torch/autograd/functional.py
+++ b/torch/autograd/functional.py
@@ -568,7 +568,7 @@ def _jacfwd(func, inputs, strict=False, vectorize=False):
                 # batch dimension represents that of the inputs
                 jacobian_input_i_output_j = jac.permute(*range(1, jac.ndim), 0).reshape(
                     (*output_i.shape, *input_j.shape)
-                )  # noqa: C409
+                )
 
                 jacobian_output_i_output.append(jacobian_input_i_output_j)
             jacobian_input_output.append(jacobian_output_i_output)

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -2013,7 +2013,7 @@ def gradcheck(
     check_backward_ad: bool = True,
     fast_mode: bool = False,
     masked: bool | None = None,
-) -> bool:  # noqa: D400,D205
+) -> bool:
     r"""Check gradients computed via small finite differences against analytical
     gradients wrt tensors in :attr:`inputs` that are of floating point or complex type
     and with ``requires_grad=True``.
@@ -2182,7 +2182,7 @@ def gradgradcheck(
     check_rev_over_rev: bool = True,
     fast_mode: bool = False,
     masked: bool = False,
-) -> bool:  # noqa: D400,D205
+) -> bool:
     r"""Check gradients of gradients computed via small finite differences
     against analytical gradients wrt tensors in :attr:`inputs` and
     :attr:`grad_outputs` that are of floating point or complex type and with

--- a/torch/backends/_nnapi/serializer.py
+++ b/torch/backends/_nnapi/serializer.py
@@ -246,12 +246,12 @@ def broadcast_shapes(shape1, shape2):
         # s2 = [1] * (len(s1) - len(s2)) + s2
         raise Exception(  # noqa: TRY002
             "Non-equal-rank broadcast is not supported yet."
-        )  # noqa: TRY002
+        )
     if len(s2) > len(s1):
         # s3 = [1] * (len(s2) - len(s1)) + s1
         raise Exception(  # noqa: TRY002
             "Non-equal-rank broadcast is not supported yet."
-        )  # noqa: TRY002
+        )
     ret = []
     for d1, d2 in zip(s1, s2):
         if d1 == 1:
@@ -263,7 +263,7 @@ def broadcast_shapes(shape1, shape2):
         else:
             raise Exception(  # noqa: TRY002
                 f"Cannot broadcast shapes: {shape1} and {shape2}"
-            )  # noqa: TRY002
+            )
     return tuple(ret)
 
 
@@ -420,7 +420,7 @@ class _NnapiSerializer:
         else:
             raise Exception(  # noqa: TRY002
                 f"Can't handle input with dtype '{tensor.dtype}'"
-            )  # noqa: TRY002
+            )
         return Operand(
             shape=tuple(tensor.shape),
             # pyrefly: ignore [bad-argument-type]
@@ -512,7 +512,7 @@ class _NnapiSerializer:
                 # many callsites to support flexible size.
                 raise Exception(  # noqa: TRY002
                     "Flexible size is not supported for this operand."
-                )  # noqa: TRY002
+                )
             if s < 0:
                 # runtime flex
                 LOG.warning("Operand %s has runtime flex shape", oper)
@@ -551,7 +551,7 @@ class _NnapiSerializer:
         if record is None:
             raise Exception(  # noqa: TRY002
                 f"Could not find constant value for '{jitval!r}'."
-            )  # noqa: TRY002
+            )
         ctype, _ = record
         if typekind is not None and ctype.kind() != typekind:
             raise Exception(  # noqa: TRY002
@@ -583,7 +583,7 @@ class _NnapiSerializer:
             else:
                 raise Exception(  # noqa: TRY002
                     "Unknown dim value, dimensions should be >= -1"
-                )  # noqa: TRY002
+                )
             shape_parts.append(",")
         shape_parts.append(")")
         shape_code = "".join(shape_parts)
@@ -611,7 +611,7 @@ class _NnapiSerializer:
 
         raise Exception(  # noqa: TRY002
             f"Unsupported output operand type: {oper.op_type}"
-        )  # noqa: TRY002
+        )
 
     def forward_operand_shape(self, out_op_id, out_dim, in_op_id, in_dim):
         self.compute_operand_shape(out_op_id, out_dim, flex_name(in_op_id, in_dim))
@@ -625,7 +625,7 @@ class _NnapiSerializer:
         if oper.shape[2:] != (1, 1):
             raise Exception(  # noqa: TRY002
                 "Automatic transpose only supported for H,W == 1,1"
-            )  # noqa: TRY002
+            )
 
         out_oper = oper._replace(dim_order=DimOrder.CHANNELS_LAST)
 
@@ -666,7 +666,7 @@ class _NnapiSerializer:
             return value
         raise Exception(  # noqa: TRY002
             f"Can't handle size arg of type '{ctype!r}' for '{jitval!r}'"
-        )  # noqa: TRY002
+        )
 
     def get_conv_pool_args_2d_from_pack(self, kernel_size, packed_config):
         pc = [i.item() for i in packed_config]
@@ -770,7 +770,7 @@ class _NnapiSerializer:
         else:
             raise Exception(  # noqa: TRY002
                 f"Unsupported return type: {retn_input.type()}"
-            )  # noqa: TRY002
+            )
 
         if return_shapes is not None:
             if len(return_shapes) != len(return_values):
@@ -955,7 +955,7 @@ class _NnapiSerializer:
         if not adder:
             raise Exception(  # noqa: TRY002
                 f"Unsupported node kind ({node.kind()!r}) in node {node!r}"
-            )  # noqa: TRY002
+            )
         adder(self, node)
 
     def _identity(self, node):
@@ -1155,7 +1155,7 @@ class _NnapiSerializer:
         if any(dim == 0 for dim in in_oper.shape[start_dim : end_dim + 1]):
             raise Exception(  # noqa: TRY002
                 "Flattening flexible dims is not supported yet"
-            )  # noqa: TRY002
+            )
         non_flattened_dims = in_oper.shape[:start_dim] + in_oper.shape[end_dim + 1 :]
         if non_flattened_dims.count(0) > 1:
             raise Exception("Only 1 dim can be flexible")  # noqa: TRY002
@@ -1220,7 +1220,7 @@ class _NnapiSerializer:
         if start_value >= stop_value:
             raise Exception(  # noqa: TRY002
                 "Slice start value should be less than stop value"
-            )  # noqa: TRY002
+            )
 
         out_len = (stop_value - start_value) // step_value
         out_shape = tuple(
@@ -1513,7 +1513,7 @@ class _NnapiSerializer:
 
         self.add_operation(opcode, inputs, outputs)
 
-    def _do_add_binary(self, node, opcode, fuse_code, *, qparams=None):  # noqa: D401
+    def _do_add_binary(self, node, opcode, fuse_code, *, qparams=None):
         """Helper for pointwise binary broadcast ops with superfluous extra args."""
         if node.outputsSize() != 1:
             raise AssertionError(
@@ -1542,7 +1542,7 @@ class _NnapiSerializer:
         else:
             raise Exception(  # noqa: TRY002
                 f"Can't do a NNAPI binary op: {opcode} on two constants"
-            )  # noqa: TRY002
+            )
 
         if in0_oper.op_type != in1_oper.op_type:
             raise AssertionError(
@@ -1597,7 +1597,7 @@ class _NnapiSerializer:
         if alpha != 1:
             raise Exception(  # noqa: TRY002
                 "NNAPI does not support add/sub with alpha."
-            )  # noqa: TRY002
+            )
 
         self._do_add_binary(node, opcode, fuse_code)
 
@@ -1661,7 +1661,7 @@ class _NnapiSerializer:
         if opcode is None:
             raise Exception(  # noqa: TRY002
                 "NNAPI only supports hardtanh with args (-1, 1) or (0, 6)."
-            )  # noqa: TRY002
+            )
 
         inputs = [None] * 1
         inputs[0] = in_id
@@ -1712,7 +1712,7 @@ class _NnapiSerializer:
             elif dim <= 1:
                 raise Exception(  # noqa: TRY002
                     "PReLU requires fixed size for dim 0 and dim 1."
-                )  # noqa: TRY002
+                )
             else:
                 self.forward_operand_shape(out_id, dim, in_id, dim)
 
@@ -2033,7 +2033,7 @@ class _NnapiSerializer:
                 else:
                     raise Exception(  # noqa: TRY002
                         "Size and scale cannot both be None."
-                    )  # noqa: TRY002
+                    )
 
         inputs = [None] * 4
         inputs[0] = image_id
@@ -2507,7 +2507,7 @@ class _NnapiSerializer:
         else:
             raise Exception(  # noqa: TRY002
                 f"Unsupported input type for conv2d: {image_oper.op_type}"
-            )  # noqa: TRY002
+            )
 
         if len(image_oper.shape) != 4:
             raise AssertionError(

--- a/torch/backends/cudnn/rnn.py
+++ b/torch/backends/cudnn/rnn.py
@@ -32,7 +32,7 @@ def get_cudnn_mode(mode):
         # pyrefly: ignore [missing-attribute]
         return int(_cudnn.RNNMode.gru)
     else:
-        raise ValueError(f"Unknown mode: {mode}")  # noqa: TRY002
+        raise ValueError(f"Unknown mode: {mode}")
 
 
 # NB: We don't actually need this class anymore (in fact, we could serialize the

--- a/torch/backends/xeon/run_cpu.py
+++ b/torch/backends/xeon/run_cpu.py
@@ -345,7 +345,7 @@ or /.local/lib/ or /usr/local/lib/ or /usr/local/lib64/ or /usr/lib or /usr/lib6
             find_tc = self.add_lib_preload(lib_type="tcmalloc")
             if not find_tc:
                 msg = f'{self.msg_lib_notfound} you can use "conda install -c conda-forge gperftools" to install {{0}}'
-                logger.warning(msg.format("TCmalloc", "tcmalloc"))  # noqa: G001
+                logger.warning(msg.format("TCmalloc", "tcmalloc"))
             else:
                 logger.info("Use TCMalloc memory allocator")
 
@@ -353,7 +353,7 @@ or /.local/lib/ or /usr/local/lib/ or /usr/local/lib64/ or /usr/lib or /usr/lib6
             find_je = self.add_lib_preload(lib_type="jemalloc")
             if not find_je:
                 msg = f'{self.msg_lib_notfound} you can use "conda install -c conda-forge jemalloc" to install {{0}}'
-                logger.warning(msg.format("Jemalloc", "jemalloc"))  # noqa: G001
+                logger.warning(msg.format("Jemalloc", "jemalloc"))
             else:
                 logger.info("Use JeMalloc memory allocator")
                 self.set_env(
@@ -426,7 +426,7 @@ Value applied: %s. Value ignored: %s",
             find_iomp = self.add_lib_preload(lib_type="iomp5")
             if not find_iomp:
                 msg = f'{self.msg_lib_notfound} you can use "conda install mkl" to install {{0}}'
-                logger.warning(msg.format("iomp", "iomp5"))  # noqa: G001
+                logger.warning(msg.format("iomp", "iomp5"))
             else:
                 logger.info("Using Intel OpenMP")
                 if set_kmp_affinity:

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -361,7 +361,7 @@ def set_enable_guard_collectives(enabled: bool):
 
     Returns the previous setting of enabled.
     """
-    from torch._C._dynamo.eval_frame import set_guard_complete_hook  # noqa: F401
+    from torch._C._dynamo.eval_frame import set_guard_complete_hook
     from torch._dynamo.eval_frame import guard_collectives_hook
 
     if enabled:

--- a/torch/cuda/_memory_viz.py
+++ b/torch/cuda/_memory_viz.py
@@ -105,7 +105,7 @@ def format_flamegraph(flamegraph_lines, flamegraph_script=None):
             try:
                 os.chmod(f.name, 0o755)
                 os.rename(f.name, flamegraph_script)
-            except OSError:  # noqa: B001,E722
+            except OSError:
                 # Ok to skip, the file will be removed by tempfile
                 pass
     args = [flamegraph_script, "--countname", "bytes"]

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -111,7 +111,7 @@ class CUDAGraph(_CUDAGraph):
                 may be unsafe. "global" will error on actions in other threads, "thread_local" will only error for
                 actions in the current thread, and "relaxed" will not error on these actions. Do NOT change this setting
                 unless you're familiar with `cudaStreamCaptureMode <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85>`_
-        """  # noqa: B950
+        """
         super().capture_begin(pool=pool, capture_error_mode=capture_error_mode)
 
     def capture_end(self) -> None:
@@ -168,14 +168,14 @@ class CUDAGraph(_CUDAGraph):
         r"""Returns the underlying cudaGraph_t. ``keep_graph`` must be True.
 
         See the following for APIs for how to manipulate this object: `Graph Managmement <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__GRAPH.html>`_ and `cuda-python Graph Management bindings <https://nvidia.github.io/cuda-python/cuda-bindings/latest/module/runtime.html#graph-management>`_
-        """  # noqa: B950
+        """
         return super().raw_cuda_graph()
 
     def raw_cuda_graph_exec(self) -> int:
         r"""Returns the underlying cudaGraphExec_t. ``instantiate`` must have been called if ``keep_graph`` is True, or ``capture_end`` must have been called if ``keep_graph`` is False. If you call ``instantiate()`` after ``raw_cuda_graph_exec()``, the previously returned cudaGraphExec_t will be destroyed. It is your responsibility not to use this object after destruction.
 
         See the following for APIs for how to manipulate this object: `Graph Execution <https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__GRAPH__EXEC.html>`_ and `cuda-python Graph Execution bindings <https://nvidia.github.io/cuda-python/cuda-bindings/latest/module/runtime.html#graph-execution>`_
-        """  # noqa: B950
+        """
         return super().raw_cuda_graph_exec()
 
 
@@ -207,7 +207,7 @@ class graph:
 
     .. _cudaStreamCaptureMode:
         https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g9d0535d93a214cbf126835257b16ba85
-    """  # noqa: B950
+    """
 
     default_capture_stream: torch.cuda.Stream | None = None
 

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -178,7 +178,7 @@ class Event(torch._C._CudaEventBase):
 
     .. _CUDA Event Documentation:
        https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EVENT.html
-    """  # noqa: B950
+    """
 
     def __new__(
         cls, enable_timing=False, blocking=False, interprocess=False, external=False

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -101,7 +101,7 @@ RANK_TYPES = (
 )
 
 
-from torch._utils import _chunk_or_narrow_cat  # noqa: F401
+from torch._utils import _chunk_or_narrow_cat
 
 
 """
@@ -1594,7 +1594,7 @@ ops_defs = [
     "all_gather_into_tensor_coalesced(Tensor[] input, str tag, int[] ranks, int group_size) -> Tensor[]",
     "reduce_scatter_tensor(Tensor input, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor",
     "reduce_scatter_tensor_coalesced(Tensor[] inputs, str reduceOp, str tag, int[] ranks, int group_size) -> Tensor[]",
-    "all_to_all_single(Tensor input, SymInt[]? output_split_sizes, SymInt[]? input_split_sizes, str tag, int[] ranks, int group_size) -> Tensor",  # noqa: B950
+    "all_to_all_single(Tensor input, SymInt[]? output_split_sizes, SymInt[]? input_split_sizes, str tag, int[] ranks, int group_size) -> Tensor",
 ]
 
 my_module = sys.modules[__name__]

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1891,7 +1891,7 @@ class _ExceptionRaisingThread(threading.Thread):
     def run(self):
         try:
             super().run()
-        except BaseException as e:  # noqa: B036
+        except BaseException as e:
             self.exception = e
 
     def join(self, timeout=None):

--- a/torch/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/distributed/_shard/sharded_tensor/__init__.py
@@ -14,7 +14,7 @@ from .api import (
     ShardedTensorMetadata,
     TensorProperties,
 )
-from .metadata import ShardMetadata  # noqa: F401
+from .metadata import ShardMetadata
 
 
 if TYPE_CHECKING:

--- a/torch/distributed/_tensor/__init__.py
+++ b/torch/distributed/_tensor/__init__.py
@@ -26,7 +26,7 @@ for submodule in submodules:
         full_module_name
     )
 
-from torch.distributed.tensor import (  # noqa: F401
+from torch.distributed.tensor import (
     DeviceMesh,
     distribute_module,
     distribute_tensor,

--- a/torch/distributed/_tensor/api.py
+++ b/torch/distributed/_tensor/api.py
@@ -6,4 +6,4 @@ imports in a few releases
 TODO: throw warnings when this module imported
 """
 
-from torch.distributed.tensor._api import *  # noqa: F401, F403
+from torch.distributed.tensor._api import *  # noqa: F403

--- a/torch/distributed/_tensor/placement_types.py
+++ b/torch/distributed/_tensor/placement_types.py
@@ -6,5 +6,5 @@ imports in a few releases
 TODO: throw warnings when this module imported
 """
 
-from torch.distributed.tensor._dtensor_spec import *  # noqa: F401, F403
-from torch.distributed.tensor.placement_types import *  # noqa: F401, F403
+from torch.distributed.tensor._dtensor_spec import *  # noqa: F403
+from torch.distributed.tensor.placement_types import *  # noqa: F403

--- a/torch/distributed/_tools/runtime_estimator.py
+++ b/torch/distributed/_tools/runtime_estimator.py
@@ -87,7 +87,7 @@ class RuntimeEstimator(TorchDispatchMode):
         self.mod_bw_post_order: list[str] = []
         self.total_runtime: float = 0.0
 
-    # Adapted from: https://github.com/pytorch/pytorch/blob/9b902b3ee3bd608a19543362b66bf06c373dd374/torch/_subclasses/fake_tensor.py#L1969  # noqa: PGH004,B950
+    # Adapted from: https://github.com/pytorch/pytorch/blob/9b902b3ee3bd608a19543362b66bf06c373dd374/torch/_subclasses/fake_tensor.py#L1969
     # NB: returns fake tensors
     @classmethod
     def _maybe_run_and_benchmark_fallback_kernel(  # type: ignore[no-untyped-def]
@@ -217,7 +217,7 @@ class RuntimeEstimator(TorchDispatchMode):
         res = func(*args, **kwargs or {})
         return (res, mean_op_time)
 
-    # Adapted from: https://github.com/pytorch/pytorch/blob/9b902b3ee3bd608a19543362b66bf06c373dd374/torch/_inductor/scheduler.py#L589  # noqa: PGH004,B950
+    # Adapted from: https://github.com/pytorch/pytorch/blob/9b902b3ee3bd608a19543362b66bf06c373dd374/torch/_inductor/scheduler.py#L589
     @classmethod
     def _roofline_estimate(cls, func, args, kwargs) -> tuple[Any, float]:  # type: ignore[no-untyped-def]
         """

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -94,7 +94,7 @@ def _should_compress(
     uncompressed_el_count is the uncompressed element count, i.e. ``num_rows`` * ``num_cols``; and,
 
     compress_el_count is the element count after compression, i.e. (``num_rows`` + ``num_cols``) * ``matrix_approximation_rank``.
-    """  # noqa: B950
+    """
     uncompressed_size = num_rows * num_cols
     compressed_size = (num_rows + num_cols) * matrix_approximation_rank
     return (
@@ -150,7 +150,7 @@ class PowerSGDState:
         If error feedback or warm-up is enabled, the minimum value of ``start_powerSGD_iter`` allowed in DDP is 2.
         This is because there is another internal optimization that rebuilds buckets at iteration 1 in DDP,
         and this can conflict with any tensor memorized before the rebuild process.
-    """  # noqa: B950
+    """
 
     __slots__ = [
         "process_group",
@@ -324,7 +324,7 @@ class PowerSGDState:
         numel_before_compression is the total number of elements before compression was applied; and,
 
         numel_after_compression is the total number of elements after compression was applied.
-        """  # noqa: B950
+        """
         compress_rate = (
             self.total_numel_before_compression / self.total_numel_after_compression
             if self.total_numel_after_compression > 0
@@ -397,7 +397,7 @@ def powerSGD_hook(
         >>> state = PowerSGDState(process_group=process_group, matrix_approximation_rank=1,
                                   start_powerSGD_iter=10, min_compression_rate=0.5)
         >>> ddp_model.register_comm_hook(state, powerSGD_hook)
-    """  # noqa: B950
+    """
     process_group = state.process_group
     group_to_use = (
         process_group if process_group is not None else not_none(dist.group.WORLD)
@@ -710,7 +710,7 @@ def batched_powerSGD_hook(
         >>> # xdoctest: +SKIP
         >>> state = PowerSGDState(process_group=process_group, matrix_approximation_rank=1)
         >>> ddp_model.register_comm_hook(state, batched_powerSGD_hook)
-    """  # noqa: B950
+    """
     process_group = state.process_group
     group_to_use = (
         process_group if process_group is not None else not_none(dist.group.WORLD)

--- a/torch/distributed/checkpoint/_async_process_executor.py
+++ b/torch/distributed/checkpoint/_async_process_executor.py
@@ -275,7 +275,7 @@ class _AsyncCheckpointProcess:
                 # GC can optionally be called manually after each checkpoint
                 gc.disable()
                 logger.info("Disabled automatic garbage collection")
-        except BaseException as e:  # noqa: B036
+        except BaseException as e:
             logger.error(
                 f"Checkpoint background process failed during initialization: {e}"  # noqa: G004
             )
@@ -337,7 +337,7 @@ class _AsyncCheckpointProcess:
                             )
                             gc.freeze()
                     first_request = False
-                except BaseException as e:  # noqa: B036
+                except BaseException as e:
                     logger.error(
                         f"Checkpoint save failed for checkpoint_id={obj.checkpoint_request_id.checkpoint_id}: {e}"  # noqa: G004
                     )

--- a/torch/distributed/checkpoint/_fsspec_filesystem.py
+++ b/torch/distributed/checkpoint/_fsspec_filesystem.py
@@ -47,11 +47,11 @@ class FileSystem(FileSystemBase):
         with self.fs.open(path, mode) as stream:
             try:
                 yield stream
-            except:  # noqa: B001,E722
+            except:
                 if any(ch in mode for ch in "w+a"):  # cleanup file if not read-only
                     try:
                         self.rm_file(path)
-                    except:  # noqa: B001,E722
+                    except:  # noqa: E722
                         pass
                 raise
 

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -244,7 +244,7 @@ def _load_state_dict(
             and "kwargs" in inspect.signature(storage_reader.read_metadata).parameters
         ):
             try:
-                metadata = storage_reader.read_metadata(rank=distW.rank)  # noqa: F841
+                metadata = storage_reader.read_metadata(rank=distW.rank)
                 use_collectives = False
             except Exception as e:
                 rank_metadata_exc = e

--- a/torch/distributed/checkpoint/utils.py
+++ b/torch/distributed/checkpoint/utils.py
@@ -191,7 +191,7 @@ class _DistWrapper:
         local_data: WRAPPED_EXCEPTION | T
         try:
             local_data = map_fun()
-        except BaseException as e:  # noqa: B036
+        except BaseException as e:
             local_data = _wrap_exception(e)
 
         all_data = self.gather_object(local_data)
@@ -208,7 +208,7 @@ class _DistWrapper:
                         list[R | CheckpointException],
                         reduce_fun(cast(list[T], all_data)),
                     )
-                except BaseException as e:  # noqa: B036
+                except BaseException as e:
                     node_failures[self.rank] = _wrap_exception(e)
 
             if len(node_failures) > 0:
@@ -239,7 +239,7 @@ class _DistWrapper:
         local_data: T | WRAPPED_EXCEPTION
         try:
             local_data = map_fun()
-        except BaseException as e:  # noqa: B036
+        except BaseException as e:
             local_data = _wrap_exception(e)
 
         all_data = self.gather_object(local_data)
@@ -251,7 +251,7 @@ class _DistWrapper:
             if len(node_failures) == 0:
                 try:
                     result = reduce_fun(cast(list[T], all_data))
-                except BaseException as e:  # noqa: B036
+                except BaseException as e:
                     node_failures[self.rank] = _wrap_exception(e)
 
             if len(node_failures) > 0:
@@ -279,7 +279,7 @@ class _DistWrapper:
         result: T | WRAPPED_EXCEPTION
         try:
             result = map_fun()
-        except BaseException as e:  # noqa: B036
+        except BaseException as e:
             result = _wrap_exception(e)
 
         all_results = self.all_gather_object(result)
@@ -305,7 +305,7 @@ class _DistWrapper:
         if self.is_coordinator:
             try:
                 result = map_fun()
-            except BaseException as e:  # noqa: B036
+            except BaseException as e:
                 result = CheckpointException(step, {self.rank: _wrap_exception(e)})
         # pyrefly: ignore [bad-argument-type]
         final_result = self.broadcast_object(result)

--- a/torch/distributed/config.py
+++ b/torch/distributed/config.py
@@ -29,7 +29,7 @@ use_torchcomms: bool = Config(
 
 
 if TYPE_CHECKING:
-    from torch.utils._config_typing import *  # noqa: F401, F403
+    from torch.utils._config_typing import *  # noqa: F403
 
 
 # adds patch, save_config, invalid config checks, etc

--- a/torch/distributed/debug/__init__.py
+++ b/torch/distributed/debug/__init__.py
@@ -4,7 +4,7 @@ import socket
 from typing import Literal, TYPE_CHECKING
 
 # import for registration side effect
-import torch.distributed.debug._handlers  # noqa: F401
+import torch.distributed.debug._handlers
 from torch._C._distributed_c10d import _WorkerServer
 from torch.distributed.debug._store import get_rank, tcpstore_client
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1021,7 +1021,7 @@ def _store_based_barrier(
         except RuntimeError as e:
             worker_count = store.add(store_key, 0)
             # Print status periodically to keep track.
-            logger.debug(  # noqa: G200
+            logger.debug(
                 "Waiting in store based barrier to initialize process group for %s seconds"
                 "rank: %s, key: %s (world_size=%s, num_workers_joined=%s, timeout=%s error=%s)",
                 time.time() - start,

--- a/torch/distributed/elastic/agent/server/__init__.py
+++ b/torch/distributed/elastic/agent/server/__init__.py
@@ -29,7 +29,7 @@ Or can be coordinated, communicating to other agents (that manage workers
 in the same job) to make a collective decision.
 """
 
-from .api import (  # noqa: F401
+from .api import (
     ElasticAgent,
     RunResult,
     SimpleElasticAgent,

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -748,7 +748,7 @@ class SimpleElasticAgent(ElasticAgent):
             self._record_worker_events(result)
             return result
         except RendezvousGracefulExitError as e:
-            logger.info("Rendezvous gracefully exited: %s", e)  # noqa: G200
+            logger.info("Rendezvous gracefully exited: %s", e)
         except SignalException as e:
             logger.warning("Received %s death signal, shutting down workers", e.sigval)
             self._shutdown(e.sigval, timeout=self._shutdown_timeout)

--- a/torch/distributed/elastic/events/__init__.py
+++ b/torch/distributed/elastic/events/__init__.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 from torch.distributed.elastic.events.handlers import get_logging_handler
 
-from .api import (  # noqa: F401
+from .api import (
     Event,
     EventMetadataValue,
     EventSource,

--- a/torch/distributed/elastic/metrics/__init__.py
+++ b/torch/distributed/elastic/metrics/__init__.py
@@ -142,7 +142,7 @@ Now all metrics in the group ``my_app`` will be printed to stdout as:
 
 from typing import Optional
 
-from .api import (  # noqa: F401
+from .api import (
     configure,
     ConsoleMetricHandler,
     get_elapsed_time_ms,
@@ -163,6 +163,6 @@ def initialize_metrics(cfg: MetricsConfig | None = None):
 
 
 try:
-    from torch.distributed.elastic.metrics.static_init import *  # type: ignore[import] # noqa: F401 F403
+    from torch.distributed.elastic.metrics.static_init import *  # type: ignore[import] # noqa: F403
 except ModuleNotFoundError:
     pass

--- a/torch/distributed/elastic/multiprocessing/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/__init__.py
@@ -66,7 +66,7 @@ implementations of the parent :class:`api.PContext` class.
 from collections.abc import Callable
 from typing import Optional, Union
 
-from torch.distributed.elastic.multiprocessing.api import (  # noqa: F401
+from torch.distributed.elastic.multiprocessing.api import (
     _validate_full_rank,
     DefaultLogsSpecs,
     LogsDest,

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -89,7 +89,7 @@ def _terminate_process_handler(signum: int, frame: FrameType | None) -> None:
 def _get_kill_signal() -> signal.Signals:
     """Get the kill signal. SIGKILL for unix, CTRL_C_EVENT for windows."""
     if IS_WINDOWS:
-        return signal.CTRL_C_EVENT  # type: ignore[attr-defined] # noqa: F821
+        return signal.CTRL_C_EVENT  # type: ignore[attr-defined]
     else:
         return signal.SIGKILL
 
@@ -97,7 +97,7 @@ def _get_kill_signal() -> signal.Signals:
 def _get_default_signal() -> signal.Signals:
     """Get the default termination signal. SIGTERM for unix, CTRL_C_EVENT for windows."""
     if IS_WINDOWS:
-        return signal.CTRL_C_EVENT  # type: ignore[attr-defined] # noqa: F821
+        return signal.CTRL_C_EVENT  # type: ignore[attr-defined]
     else:
         return signal.SIGTERM
 

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -64,8 +64,8 @@ from typing_extensions import ParamSpec
 
 from torch.distributed.elastic.utils.logging import get_logger
 
-from .error_handler import ErrorHandler  # noqa: F401
-from .handlers import get_error_handler  # noqa: F401
+from .error_handler import ErrorHandler
+from .handlers import get_error_handler
 
 
 __all__ = [

--- a/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
+++ b/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py
@@ -22,7 +22,7 @@ IS_WINDOWS = sys.platform == "win32"
 def _get_default_signal() -> signal.Signals:
     """Get the default termination signal. SIGTERM for unix, CTRL_C_EVENT for windows."""
     if IS_WINDOWS:
-        return signal.CTRL_C_EVENT  # type: ignore[attr-defined] # noqa: F821
+        return signal.CTRL_C_EVENT  # type: ignore[attr-defined]
     else:
         return signal.SIGTERM
 

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -207,7 +207,7 @@ class EtcdRendezvousHandler(RendezvousHandler):
         try:
             self.set_closed()
             return True
-        except BaseException:  # noqa: B036
+        except BaseException:
             logger.warning("Shutdown failed", exc_info=True)
             return False
 
@@ -332,7 +332,7 @@ class EtcdRendezvous:
                 # to avoid spamming etcd
                 # FIXME: there are a few things that fall under this like
                 # etcd.EtcdKeyNotFound, etc, which could be handled more explicitly.
-                logger.info("Rendezvous attempt failed, will retry. Reason: %s", e)  # noqa: G200
+                logger.info("Rendezvous attempt failed, will retry. Reason: %s", e)
                 time.sleep(1)
 
     def init_phase(self):

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -176,7 +176,7 @@ class EtcdServer:
             except Exception as e:
                 curr_retries += 1
                 stop_etcd(self._etcd_proc)
-                logger.warning(  # noqa: G200
+                logger.warning(
                     "Failed to start etcd server, got error: %s, retrying", e
                 )
                 if curr_retries >= num_retries:

--- a/torch/distributed/elastic/timer/__init__.py
+++ b/torch/distributed/elastic/timer/__init__.py
@@ -39,16 +39,16 @@ In the example above if ``trainer_func`` takes more than 60 seconds to
 complete, then the worker process is killed and the agent retries the worker group.
 """
 
-from .api import (  # noqa: F401
+from .api import (
     configure,
     expires,
     TimerClient,
     TimerRequest,
     TimerServer,
 )
-from .file_based_local_timer import (  # noqa: F401
+from .file_based_local_timer import (
     FileTimerClient,
     FileTimerRequest,
     FileTimerServer,
 )
-from .local_timer import LocalTimerClient, LocalTimerServer  # noqa: F401
+from .local_timer import LocalTimerClient, LocalTimerServer

--- a/torch/distributed/elastic/utils/__init__.py
+++ b/torch/distributed/elastic/utils/__init__.py
@@ -6,4 +6,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .api import get_env_variable_or_raise, get_socket_with_port, macros  # noqa: F401
+from .api import get_env_variable_or_raise, get_socket_with_port, macros

--- a/torch/distributed/elastic/utils/data/__init__.py
+++ b/torch/distributed/elastic/utils/data/__init__.py
@@ -6,5 +6,5 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .cycling_iterator import CyclingIterator  # noqa: F401
-from .elastic_distributed_sampler import ElasticDistributedSampler  # noqa: F401
+from .cycling_iterator import CyclingIterator
+from .elastic_distributed_sampler import ElasticDistributedSampler

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -331,7 +331,7 @@ def _full_post_state_dict_hook(
             try:
                 state_dict[fqn] = state_dict[fqn].detach().clone()
                 state_dict[fqn]._has_been_cloned = True  # type: ignore[attr-defined]
-            except BaseException as e:  # noqa: B036
+            except BaseException as e:
                 warnings.warn(
                     f"Failed to clone() tensor with name {fqn} on rank {fsdp_state.rank}. "
                     "This may mean that this state_dict entry could point to invalid "

--- a/torch/distributed/launcher/__init__.py
+++ b/torch/distributed/launcher/__init__.py
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from torch.distributed.launcher.api import (  # noqa: F401
+from torch.distributed.launcher.api import (
     elastic_launch,
     launch_agent,
     LaunchConfig,

--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -326,7 +326,7 @@ def _pipe_split():
 
 
 @torch.library.register_fake("pippy::_pipe_split")  # type: ignore[no-redef]
-def _pipe_split():  # noqa: F811
+def _pipe_split():
     return None
 
 

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -1951,7 +1951,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
                 # do the communication
                 _wait_batch_p2p(_batch_p2p(ops))
             except Exception as e:
-                logger.error(  # noqa: G200
+                logger.error(
                     "[Rank %s] pipeline schedule %s caught the following exception '%s' \
 at time_step %s when running action %s",
                     self.rank,

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -38,7 +38,7 @@ if is_available():
 
     import torch.distributed.autograd as dist_autograd
     from torch._C._distributed_c10d import Store
-    from torch._C._distributed_rpc import (  # noqa: F401
+    from torch._C._distributed_rpc import (
         _cleanup_python_rpc_handler,
         _DEFAULT_INIT_METHOD,
         _DEFAULT_RPC_TIMEOUT_SEC,
@@ -72,23 +72,23 @@ if is_available():
     )
 
     if _is_tensorpipe_available:
-        from torch._C._distributed_rpc import (  # noqa: F401
+        from torch._C._distributed_rpc import (
             _DEFAULT_NUM_WORKER_THREADS,
             _TensorPipeRpcBackendOptionsBase,
             TensorPipeAgent,
         )
 
     from . import api, backend_registry, functions
-    from .api import *  # noqa: F401,F403
+    from .api import *  # noqa: F403
     from .backend_registry import BackendType
-    from .options import TensorPipeRpcBackendOptions  # noqa: F401
+    from .options import TensorPipeRpcBackendOptions
     from .server_process_global_profiler import _server_process_global_profile
 
     rendezvous_iterator: Generator[tuple[Store, int, int], None, None]
 
     __all__ += ["init_rpc", "BackendType", "TensorPipeRpcBackendOptions"]
     # pyrefly: ignore [unresolvable-dunder-all]
-    __all__ = __all__ + api.__all__ + backend_registry.__all__  # noqa: PLE0605
+    __all__ = __all__ + api.__all__ + backend_registry.__all__
 
     def init_rpc(
         name,

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -226,8 +226,8 @@ def _handle_exception(result):
         exc = None
         try:
             exc = result.exception_type(exception_msg)
-        except BaseException as e:  # noqa: B036
-            raise RuntimeError(  # noqa: B904
+        except BaseException as e:
+            raise RuntimeError(
                 f"Failed to create original exception type. Error msg was {str(e)}"
                 f" Original exception on remote side was {exception_msg}"
             ) from e

--- a/torch/distributed/rpc/rref_proxy.py
+++ b/torch/distributed/rpc/rref_proxy.py
@@ -53,13 +53,13 @@ def _invoke_rpc(rref, rpc_api, func_name, timeout, *args, **kwargs):
         def _wrap_rref_type_cont(fut):
             try:
                 _rref_type_cont(fut).then(_complete_op)
-            except BaseException as ex:  # noqa: B036
+            except BaseException as ex:
                 result.set_exception(ex)
 
         def _complete_op(fut):
             try:
                 result.set_result(fut.value())
-            except BaseException as ex:  # noqa: B036
+            except BaseException as ex:
                 result.set_exception(ex)
 
         rref_fut.then(_wrap_rref_type_cont)

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -380,7 +380,7 @@ utility
 
     if __name__ == "__main__":
         main()
-"""  # noqa: E501
+"""
 
 import os
 import sys

--- a/torch/distributed/tensor/__init__.py
+++ b/torch/distributed/tensor/__init__.py
@@ -2,7 +2,7 @@
 
 import torch
 import torch.distributed.tensor._ops  # force import all built-in dtensor ops
-from torch.distributed.device_mesh import DeviceMesh, init_device_mesh  # noqa: F401
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.tensor._api import (
     distribute_module,
     distribute_tensor,

--- a/torch/distributed/tensor/_decompositions.py
+++ b/torch/distributed/tensor/_decompositions.py
@@ -236,7 +236,7 @@ class DecompShardingStrategy:
         n_outputs = len(output_placements)
         strategy_schema = self.sharding_prop._wrap_with_op_strategy(op_schema)
         # Import here to avoid circular import at module load time
-        from torch.distributed.tensor._ops.utils import (  # noqa: F811
+        from torch.distributed.tensor._ops.utils import (
             expand_to_full_mesh_op_strategy,
         )
 

--- a/torch/distributed/tensor/parallel/input_reshard.py
+++ b/torch/distributed/tensor/parallel/input_reshard.py
@@ -65,7 +65,7 @@ def input_reshard(
     return module
 
 
-def _pack_hook_tp(mesh: DeviceMesh, input_reshard_dim: int, x: torch.Tensor) -> Any:  # noqa: D401
+def _pack_hook_tp(mesh: DeviceMesh, input_reshard_dim: int, x: torch.Tensor) -> Any:
     """Hook function called after FWD to shard input."""
     if isinstance(x, DTensor) and all(p.is_replicate() for p in x._spec.placements):
         return x.redistribute(device_mesh=mesh, placements=[Shard(input_reshard_dim)])
@@ -83,7 +83,7 @@ def _pack_hook_tp(mesh: DeviceMesh, input_reshard_dim: int, x: torch.Tensor) -> 
         return x
 
 
-def _unpack_hook_tp(mesh: DeviceMesh, input_reshard_dim: int, x: Any) -> torch.Tensor:  # noqa: D401
+def _unpack_hook_tp(mesh: DeviceMesh, input_reshard_dim: int, x: Any) -> torch.Tensor:
     """Hook function called before activation recomputing in BWD to restore input."""
     if (
         isinstance(x, DTensor)

--- a/torch/distributed/tensor/placement_types.py
+++ b/torch/distributed/tensor/placement_types.py
@@ -746,7 +746,7 @@ class _StridedShard(torch._C._distributed.StridedShard):
         Needed for passing this type as an opaque object input to a custom op.
         """
         return (
-            f"torch.distributed.tensor.placement_types._StridedShard(dim={self.dim}, sf={self.split_factor})",  # noqa: B950
+            f"torch.distributed.tensor.placement_types._StridedShard(dim={self.dim}, sf={self.split_factor})",
             {},
         )
 
@@ -1536,7 +1536,7 @@ class _MaskPartial(Partial):
         Needed for passing this type as an input to a custom op.
         """
         return (
-            f"torch.distributed.tensor.placement_types.MaskPartial(reduce_op={self.reduce_op}, offset_shape={self.offset_shape}, offset_dim={self.offset_dim})",  # noqa: B950
+            f"torch.distributed.tensor.placement_types.MaskPartial(reduce_op={self.reduce_op}, offset_shape={self.offset_shape}, offset_dim={self.offset_dim})",
             {},
         )
 

--- a/torch/export/_draft_export.py
+++ b/torch/export/_draft_export.py
@@ -101,7 +101,7 @@ class FailureReport:
     torch.ops.{op} is missing a fake kernel implementation.
 
     Please refer to https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit#heading=h.ahugy69p2jmz for more detailed instructions on how to write a meta implementation.
-"""  # noqa: B950
+"""
 
         elif self.failure_type == FailureType.GUARD_ADDED:
             locals_info = (
@@ -140,7 +140,7 @@ class FailureReport:
 
     Please add `torch._check(...)` to the original code to assert this data-dependent assumption.
     Please refer to https://docs.google.com/document/d/1kZ_BbB3JnoLbUZleDT6635dHs88ZVYId8jT-yTFgf3A/edit#heading=h.boi2xurpqa0o for more details.
-"""  # noqa: B950
+"""
 
         elif self.failure_type == FailureType.MISMATCHED_FAKE_KERNEL:
             op = self.data["op"]
@@ -150,7 +150,7 @@ class FailureReport:
     The reason for the mismatch is: {reason}.
 
     Please refer to https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit#heading=h.ahugy69p2jmz for more detailed instructions on how to write a fake implementation.
-"""  # noqa: B950
+"""
 
         else:
             raise ValueError(f"Unknown failure type: {self.failure_type}")

--- a/torch/export/_swap.py
+++ b/torch/export/_swap.py
@@ -58,7 +58,7 @@ def _try_remove_connecting_pytrees(curr_module_node: torch.fx.Node) -> None:
 
     Currently this optimization only works for the case where all of the outputs
     of `foo` go directly into `bar`, and `bar` has no other inputs.
-    """  # noqa: B950
+    """
 
     log.debug("Trying to remove pytrees for module call %s", curr_module_node)
 
@@ -328,7 +328,7 @@ def _swap_module_helper(
         The `call_module` node should now reference the swapped torch.nn.Module.
         The `tree_flatten_spec` call will deconstruct the eager outputs of the
         swapped module into tensors.
-        """  # noqa: B950
+        """
 
         submod_name = name.replace(".", "_")
         sub_gm, orig_inputs, orig_outputs = fuse_as_graphmodule(

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -74,7 +74,7 @@ def _check_inputs_match(args, kwargs, in_spec: pytree.TreeSpec) -> list:
     )
 
     if not eq_spec(received_spec, in_spec):
-        raise ValueError(  # noqa: B904
+        raise ValueError(
             "Trying to flatten user inputs with exported input tree spec: \n"
             f"{in_spec}\n"
             "but actually got inputs with tree spec of: \n"

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -1118,7 +1118,7 @@ def _process_dynamic_shapes(
             if solution is not None:
                 return int(solution[1])
             else:
-                raise UserError(  # noqa: B904
+                raise UserError(
                     UserErrorType.CONSTRAINT_VIOLATION,
                     f"Expected shape[{i}] = {tensor.shape[i]} of input Tensor to be "
                     f"of the form {expr}, where {symbol} is an integer",

--- a/torch/export/experimental/__init__.py
+++ b/torch/export/experimental/__init__.py
@@ -325,7 +325,7 @@ class _ExportPackage:
             return ep.module()(*args, **kwargs)
 
         if isinstance(fn, torch.nn.Module):
-            _exporter_context = torch._dynamo.eval_frame.OptimizedModule(  # type: ignore[assignment] # noqa: F811
+            _exporter_context = torch._dynamo.eval_frame.OptimizedModule(  # type: ignore[assignment]
                 fn,
                 lambda _: _exporter_context,  # type: ignore[arg-type]
             )

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -1283,7 +1283,7 @@ class _ModuleFrame:
         if x.graph is not self.flat_graph:
             raise AssertionError(
                 "expected x.graph to be flat_graph, got different graph"
-            )  # noqa: F541
+            )
         # x is not in subgraph, create a new placeholder for subgraph
         with self.graph.inserting_before(None):
             placeholder_node = self.graph.placeholder(x.name, type_expr=x.type)
@@ -1310,7 +1310,7 @@ class _ModuleFrame:
         if x.graph is not self.flat_graph:
             raise AssertionError(
                 "expected x.graph to be flat_graph, got different graph"
-            )  # noqa: F541
+            )
         if x in self.node_map:
             return self.node_map[x]
         self.print(f"remap_input({x})")

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1254,7 +1254,7 @@ else:
         pass
 
 
-def tensordot(  # noqa: F811
+def tensordot(
     a,
     b,
     dims=2,
@@ -1682,7 +1682,7 @@ else:
         pass
 
 
-def norm(  # noqa: F811
+def norm(
     input,
     p: float | str | None = "fro",
     dim=None,

--- a/torch/fx/__init__.py
+++ b/torch/fx/__init__.py
@@ -85,14 +85,14 @@ repository.
 '''
 
 from torch.fx import immutable_collections
-from torch.fx._symbolic_trace import (  # noqa: F401
+from torch.fx._symbolic_trace import (
     PH,
     ProxyableClassMeta,
     symbolic_trace,
     Tracer,
     wrap,
 )
-from torch.fx.graph import CodeGen, Graph  # noqa: F401
+from torch.fx.graph import CodeGen, Graph
 from torch.fx.graph_module import GraphModule
 from torch.fx.interpreter import Interpreter, Transformer
 from torch.fx.node import has_side_effect, map_arg, Node

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -15,7 +15,7 @@ from torch.utils._import_utils import import_dill
 
 dill = import_dill()
 if dill is not None:
-    pickle = dill  # noqa: F811
+    pickle = dill
 
 import torch
 import torch.utils._pytree as pytree

--- a/torch/fx/experimental/normalize.py
+++ b/torch/fx/experimental/normalize.py
@@ -149,7 +149,7 @@ class NormalizeOperators(AnnotateTypesWithSchema):
         self, target: Target, args: tuple[Argument, ...], kwargs: dict[str, Any]
     ):
         # Normalize operators according to the magic methods implemented on tensors here:
-        # https://github.com/pytorch/pytorch/blob/28c5d90b679c6b38bf4183ec99f16d933c2f1bcd/tools/autograd/templates/python_variable_methods.cpp#L1137 # noqa: B950
+        # https://github.com/pytorch/pytorch/blob/28c5d90b679c6b38bf4183ec99f16d933c2f1bcd/tools/autograd/templates/python_variable_methods.cpp#L1137
 
         if not callable(target):
             raise AssertionError(f"Expected callable target, got {type(target)}")

--- a/torch/fx/experimental/recording.py
+++ b/torch/fx/experimental/recording.py
@@ -325,7 +325,7 @@ def record_shapeenv_event(
                 if not shape_env.should_record_events or shape_env.is_recording:
                     # If ShapeEnv is disabled or already recording an event, re-raise the exception without logging.
                     raise
-                log.error(  # noqa: G201
+                log.error(
                     "failed while running %s(*%s, **%s)",
                     name,
                     args[1:],

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -29,7 +29,7 @@ import torch
 import torch._logging.structured as structured
 
 # NB: The sym_* functions are used via getattr() and must be imported here.
-from torch import (  # noqa: F401
+from torch import (
     sym_float,
     sym_ite,
     sym_max,
@@ -369,7 +369,7 @@ class SymNode:
     def rshift(self, other) -> SymNode:
         return self._rshift(other)  # type: ignore[attr-defined]
 
-    def sym_not(self) -> SymNode:  # noqa: F811
+    def sym_not(self) -> SymNode:
         return self._sym_not()  # type: ignore[attr-defined]
 
     def eq(self, other) -> SymNode:
@@ -396,7 +396,7 @@ class SymNode:
     def is_integer(self) -> SymNode:
         return self._is_integer()  # type: ignore[attr-defined]
 
-    def sym_float(self) -> SymNode:  # noqa: F811
+    def sym_float(self) -> SymNode:
         return self._sym_float()  # type: ignore[attr-defined]
 
     def sym_int(self) -> SymNode:
@@ -408,10 +408,10 @@ class SymNode:
     def neg(self) -> SymNode:
         return self._neg()  # type: ignore[attr-defined]
 
-    def sym_min(self, other) -> SymNode:  # noqa: F811
+    def sym_min(self, other) -> SymNode:
         return self._sym_min(other)  # type: ignore[attr-defined]
 
-    def sym_max(self, other) -> SymNode:  # noqa: F811
+    def sym_max(self, other) -> SymNode:
         return self._sym_max(other)  # type: ignore[attr-defined]
 
     def sym_ite(self, then_val, else_val) -> SymNode:

--- a/torch/fx/experimental/unification/__init__.py
+++ b/torch/fx/experimental/unification/__init__.py
@@ -1,4 +1,4 @@
 # mypy: disable-error-code=attr-defined
-from .core import reify, unify  # noqa: F403
-from .more import unifiable  # noqa: F403
-from .variable import isvar, Var, var, variables, vars  # noqa: F403
+from .core import reify, unify
+from .more import unifiable
+from .variable import isvar, Var, var, variables, vars

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -37,8 +37,8 @@ log = logging.getLogger(__name__)
 __all__ = ["PythonCode", "CodeGen", "Graph"]
 
 if TYPE_CHECKING:
-    from ._symbolic_trace import Tracer  # noqa: F401
-    from .graph_module import GraphModule  # noqa: F401
+    from ._symbolic_trace import Tracer
+    from .graph_module import GraphModule
 
 
 # Mapping of builtins to their `typing` equivalent.

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -692,12 +692,12 @@ class {module_name}(torch.nn.Module):
         for buffer_name, buffer in self._buffers.items():
             if buffer is None:
                 continue
-            model_str += f"{tab * 2}self.register_buffer('{buffer_name}', torch.empty({list(buffer.shape)}, dtype={buffer.dtype}))\n"  # noqa: B950
+            model_str += f"{tab * 2}self.register_buffer('{buffer_name}', torch.empty({list(buffer.shape)}, dtype={buffer.dtype}))\n"
 
         for param_name, param in self._parameters.items():
             if param is None:
                 continue
-            model_str += f"{tab * 2}setattr(self, '{param_name}', torch.nn.Parameter(torch.empty({list(param.shape)}, dtype={param.dtype})))\n"  # noqa: B950
+            model_str += f"{tab * 2}setattr(self, '{param_name}', torch.nn.Parameter(torch.empty({list(param.shape)}, dtype={param.dtype})))\n"
 
         model_str += (
             f"{tab * 2}self.load_state_dict(torch.load(r'{folder}/state_dict.pt'))\n"

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -49,7 +49,7 @@ base_types = typing.get_args(BaseArgumentTypes)
 
 Target: TypeAlias = Callable[..., Any] | str
 
-Argument = Optional[  # noqa: UP007, UP045
+Argument = Optional[  # noqa: UP045
     Union[
         tuple["Argument", ...],
         Sequence["Argument"],

--- a/torch/fx/passes/_tensorify_python_scalars.py
+++ b/torch/fx/passes/_tensorify_python_scalars.py
@@ -256,7 +256,7 @@ def tensorify_python_scalars(
 
             # Specialize all dimensions that contain symfloats. Here's
             # an example test that requires this:
-            # PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=4 python test/inductor/test_torchinductor_opinfo.py TestInductorOpInfoCUDA.test_comprehensive_nn_functional_interpolate_bicubic_cuda_float32 # noqa: B950
+            # PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=4 python test/inductor/test_torchinductor_opinfo.py TestInductorOpInfoCUDA.test_comprehensive_nn_functional_interpolate_bicubic_cuda_float32
 
             val = node.meta.get("val")
             if isinstance(val, FakeTensor):

--- a/torch/fx/passes/dialect/common/cse_pass.py
+++ b/torch/fx/passes/dialect/common/cse_pass.py
@@ -27,7 +27,7 @@ rand_ops = {
     aten.randint,
     aten.randn,
     aten.randperm,
-}  # noqa: E501,B950
+}
 
 inplace_ops = {
     aten.add_,
@@ -39,7 +39,7 @@ inplace_ops = {
     aten.relu_,
     aten.sigmoid_,
     aten.tanh_,
-}  # noqa: E501
+}
 
 
 @torch.fx._compatibility.compatibility(is_backward_compatible=False)

--- a/torch/fx/passes/split_module.py
+++ b/torch/fx/passes/split_module.py
@@ -411,7 +411,7 @@ def split_module(
             )
             torch.fx.graph.map_arg(
                 node.kwargs, lambda def_node: record_cross_partition_use(def_node, node)
-            )  # noqa: B950
+            )
 
     original_partition_order = list(partitions.keys())
     # find partitions with no dependencies
@@ -640,7 +640,7 @@ def split_module(
 
         base_mod_attrs[partition.submod_name] = _make_graph_module(
             partition.targets, partition.graph
-        )  # noqa: B950
+        )
 
         # Emit call in base graph to this submodule
         output_val = base_mod_graph.call_module(
@@ -672,7 +672,7 @@ def split_module(
         if node.op == "output":
             base_mod_graph.output(
                 torch.fx.graph.map_arg(node.args[0], lambda n: base_mod_env[n.name])
-            )  # noqa: B950
+            )
 
     ret = _make_graph_module(base_mod_attrs, base_mod_graph)
     log.debug(

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 from typing_extensions import deprecated
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlparse  # noqa: F401
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 import torch

--- a/torch/jit/_monkeytype_config.py
+++ b/torch/jit/_monkeytype_config.py
@@ -171,7 +171,7 @@ else:
         def __init__(self) -> None:
             pass
 
-    monkeytype_trace = None  # type: ignore[assignment]  # noqa: F811
+    monkeytype_trace = None  # type: ignore[assignment]
 
 
 def jit_code_filter(code: CodeType) -> bool:

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -284,7 +284,7 @@ class OrderedModuleDict(OrderedDictWrapper):
 #     parameters are initialized _before_ the script compiler resolve references to
 #     `self.param` or `self.module`.
 class ScriptMeta(type):
-    def __init__(cls, name, bases, attrs):  # noqa: B902
+    def __init__(cls, name, bases, attrs):
         # Aggregate all the ScriptMethods and constants from superclasses
         cls._methods: dict[str, Any] = {}
         cls._constants_set = set(getattr(cls, "__constants__", ()))

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -145,7 +145,7 @@ def is_function_or_method(the_callable):
 
 
 def is_vararg(the_callable):
-    if not is_function_or_method(the_callable) and callable(the_callable):  # noqa: B004
+    if not is_function_or_method(the_callable) and callable(the_callable):
         # If `the_callable` is a class, de-sugar the call so we can still get
         # the signature
         the_callable = the_callable.__call__
@@ -164,7 +164,7 @@ def get_param_names(fn, n_args):
         not is_function_or_method(fn)
         and callable(fn)
         and is_function_or_method(fn.__call__)
-    ):  # noqa: B004
+    ):
         # De-sugar calls to classes
         fn = fn.__call__
 
@@ -271,7 +271,7 @@ def get_type_line(source):
                 "The annotation prefix in line "
                 + str(wrong_type_lines[0][0])
                 + " is probably invalid.\nIt must be '# type:'"
-                + "\nSee PEP 484 (https://www.python.org/dev/peps/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code)"  # noqa: B950
+                + "\nSee PEP 484 (https://www.python.org/dev/peps/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code)"
                 + "\nfor examples"
             )
         return None

--- a/torch/jit/supported_ops.py
+++ b/torch/jit/supported_ops.py
@@ -104,7 +104,7 @@ def _get_nn_functional_ops():
             scripted = torch.jit.script(attr)
             scripted_schema = scripted.schema
             functions.append(_emit_schema(name, elem, scripted_schema))
-        except:  # noqa: B001,E722
+        except:  # noqa: E722
             # Skip interpolate / boolean dispatched things
             pass
 

--- a/torch/library.py
+++ b/torch/library.py
@@ -19,7 +19,7 @@ from torch._library.custom_ops import (
     device_types_t,
 )
 from torch._library.effects import EffectType
-from torch._library.infer_schema import infer_schema  # noqa: F401
+from torch._library.infer_schema import infer_schema
 from torch._library.triton import triton_op, wrap_triton
 from torch._ops import OpOverload
 from torch.types import _dtype

--- a/torch/multiprocessing/__init__.py
+++ b/torch/multiprocessing/__init__.py
@@ -29,7 +29,7 @@ __all__ = ["set_sharing_strategy", "get_sharing_strategy", "get_all_sharing_stra
 from multiprocessing import *  # noqa: F403
 
 
-__all__ += multiprocessing.__all__  # noqa: PLE0605 type: ignore[attr-defined]
+__all__ += multiprocessing.__all__
 
 
 # This call adds a Linux specific prctl(2) wrapper function to this module.

--- a/torch/nn/attention/__init__.py
+++ b/torch/nn/attention/__init__.py
@@ -194,4 +194,4 @@ current_flash_attention_impl.__module__ = __name__
 restore_flash_attention_impl.__module__ = __name__
 
 # Import built-in implementations to trigger self-registration
-from . import _fa3, _fa4  # noqa: F401  # noqa: F401
+from . import _fa3, _fa4

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-# flake8: noqa: B950
 """This module implements the user facing API for flex_attention in PyTorch."""
 
 from __future__ import annotations

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -146,7 +146,7 @@ Examples::
     >>> inputs = torch.randn(1, 4, 5, 5)
     >>> F.conv2d(inputs, filters, padding=1)
 """,
-)  # noqa: E501
+)
 
 conv3d = _add_docstr(
     torch.conv3d,
@@ -196,7 +196,7 @@ Examples::
     >>> inputs = torch.randn(20, 16, 50, 10, 20)
     >>> F.conv3d(inputs, filters)
 """,
-)  # noqa: E501
+)
 
 conv_transpose1d = _add_docstr(
     torch.conv_transpose1d,
@@ -280,7 +280,7 @@ Examples::
     >>> weights = torch.randn(4, 8, 3, 3)
     >>> F.conv_transpose2d(inputs, weights, padding=1)
 """,
-)  # noqa: E501
+)
 
 conv_transpose3d = _add_docstr(
     torch.conv_transpose3d,
@@ -322,7 +322,7 @@ Examples::
     >>> weights = torch.randn(16, 33, 3, 3, 3)
     >>> F.conv_transpose3d(inputs, weights)
 """,
-)  # noqa: E501
+)
 
 conv_tbc = _add_docstr(
     torch.conv_tbc,
@@ -443,7 +443,7 @@ def fractional_max_pool2d_with_indices(
     output_ratio: Optional[BroadcastingList2[float]] = None,  # noqa: UP045
     return_indices: bool = False,
     _random_samples: Tensor | None = None,
-) -> tuple[Tensor, Tensor]:  # noqa: D400
+) -> tuple[Tensor, Tensor]:
     r"""
     fractional_max_pool2d(input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None)
 
@@ -556,7 +556,7 @@ def fractional_max_pool3d_with_indices(
     output_ratio: Optional[BroadcastingList3[float]] = None,  # noqa: UP045
     return_indices: bool = False,
     _random_samples: Tensor | None = None,
-) -> tuple[Tensor, Tensor]:  # noqa: D400
+) -> tuple[Tensor, Tensor]:
     r"""
     fractional_max_pool3d(input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None)
 
@@ -674,7 +674,7 @@ def max_pool1d_with_indices(
     dilation: BroadcastingList1[int] = 1,
     ceil_mode: bool = False,
     return_indices: bool = False,
-) -> tuple[Tensor, Tensor]:  # noqa: D400
+) -> tuple[Tensor, Tensor]:
     r"""
     max_pool1d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False)
 
@@ -764,7 +764,7 @@ def max_pool2d_with_indices(
     dilation: BroadcastingList2[int] = 1,
     ceil_mode: bool = False,
     return_indices: bool = False,
-) -> tuple[Tensor, Tensor]:  # noqa: D400
+) -> tuple[Tensor, Tensor]:
     r"""
     max_pool2d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False)
 
@@ -854,7 +854,7 @@ def max_pool3d_with_indices(
     dilation: BroadcastingList3[int] = 1,
     ceil_mode: bool = False,
     return_indices: bool = False,
-) -> tuple[Tensor, Tensor]:  # noqa: D400
+) -> tuple[Tensor, Tensor]:
     r"""
     max_pool3d(input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False, return_indices=False)
 
@@ -1201,7 +1201,7 @@ def adaptive_max_pool1d_with_indices(
     input: Tensor,
     output_size: BroadcastingList1[int],
     return_indices: bool = False,
-) -> tuple[Tensor, Tensor]:  # noqa: D400
+) -> tuple[Tensor, Tensor]:
     r"""
     adaptive_max_pool1d(input, output_size, return_indices=False)
 
@@ -1256,7 +1256,7 @@ def adaptive_max_pool2d_with_indices(
     input: Tensor,
     output_size: BroadcastingList2[int],
     return_indices: bool = False,
-) -> tuple[Tensor, Tensor]:  # noqa: D400
+) -> tuple[Tensor, Tensor]:
     r"""adaptive_max_pool2d(input, output_size, return_indices=False)
 
     Applies a 2D adaptive max pooling over an input signal composed of
@@ -1313,7 +1313,7 @@ def adaptive_max_pool3d_with_indices(
     input: Tensor,
     output_size: BroadcastingList3[int],
     return_indices: bool = False,
-) -> tuple[Tensor, Tensor]:  # noqa: D400
+) -> tuple[Tensor, Tensor]:
     r"""
     adaptive_max_pool3d(input, output_size, return_indices=False)
 
@@ -1709,7 +1709,7 @@ In-place version of :func:`~threshold`.
 )
 
 
-def relu(input: Tensor, inplace: bool = False) -> Tensor:  # noqa: D400,D402
+def relu(input: Tensor, inplace: bool = False) -> Tensor:
     r"""relu(input, inplace=False) -> Tensor
 
     Applies the rectified linear unit function element-wise. See
@@ -1734,7 +1734,7 @@ In-place version of :func:`~relu`.
 )
 
 
-def glu(input: Tensor, dim: int = -1) -> Tensor:  # noqa: D400,D402
+def glu(input: Tensor, dim: int = -1) -> Tensor:
     r"""
     glu(input, dim=-1) -> Tensor
 
@@ -1766,7 +1766,7 @@ def hardtanh(
     min_val: float = -1.0,
     max_val: float = 1.0,
     inplace: bool = False,
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""
     hardtanh(input, min_val=-1., max_val=1., inplace=False) -> Tensor
 
@@ -1796,7 +1796,7 @@ In-place version of :func:`~hardtanh`.
 )
 
 
-def relu6(input: Tensor, inplace: bool = False) -> Tensor:  # noqa: D400,D402
+def relu6(input: Tensor, inplace: bool = False) -> Tensor:
     r"""relu6(input, inplace=False) -> Tensor
 
     Applies the element-wise function :math:`\text{ReLU6}(x) = \min(\max(0,x), 6)`.
@@ -1836,7 +1836,7 @@ In-place version of :func:`~elu`.
 )
 
 
-def selu(input: Tensor, inplace: bool = False) -> Tensor:  # noqa: D400,D402
+def selu(input: Tensor, inplace: bool = False) -> Tensor:
     r"""selu(input, inplace=False) -> Tensor
 
     Applies element-wise,
@@ -1869,7 +1869,7 @@ def celu(
     input: Tensor,
     alpha: float = 1.0,
     inplace: bool = False,
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""celu(input, alpha=1., inplace=False) -> Tensor
 
     Applies element-wise,
@@ -1902,7 +1902,7 @@ def leaky_relu(
     input: Tensor,
     negative_slope: float = 0.01,
     inplace: bool = False,
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""
     leaky_relu(input, negative_slope=0.01, inplace=False) -> Tensor
 
@@ -1959,7 +1959,7 @@ def rrelu(
     upper: float = 1.0 / 3,
     training: bool = False,
     inplace: bool = False,
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""rrelu(input, lower=1./8, upper=1./3, training=False, inplace=False) -> Tensor
 
     Randomized leaky ReLU.
@@ -2034,7 +2034,7 @@ See :class:`~torch.nn.Hardshrink` for more details.
 )
 
 
-def tanhshrink(input):  # noqa: D400,D402
+def tanhshrink(input):
     r"""tanhshrink(input) -> Tensor
 
     Applies element-wise, :math:`\text{Tanhshrink}(x) = x - \text{Tanh}(x)`
@@ -2046,7 +2046,7 @@ def tanhshrink(input):  # noqa: D400,D402
     return input - input.tanh()
 
 
-def softsign(input):  # noqa: D400,D402
+def softsign(input):
     r"""softsign(input) -> Tensor
 
     Applies element-wise, the function :math:`\text{SoftSign}(x) = \frac{x}{1 + |x|}`
@@ -2282,7 +2282,7 @@ See :class:`~torch.nn.Softshrink` for more details.
 )
 
 
-def tanh(input):  # noqa: D400,D402
+def tanh(input):
     r"""tanh(input) -> Tensor
 
     Applies element-wise,
@@ -2293,7 +2293,7 @@ def tanh(input):  # noqa: D400,D402
     return input.tanh()
 
 
-def sigmoid(input):  # noqa: D400,D402
+def sigmoid(input):
     r"""sigmoid(input) -> Tensor
 
     Applies the element-wise function :math:`\text{Sigmoid}(x) = \frac{1}{1 + \exp(-x)}`
@@ -3813,7 +3813,7 @@ def l1_loss(
     reduce: bool | None = None,
     reduction: str = "mean",
     weight: Tensor | None = None,
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""Compute the L1 loss, with optional weighting.
 
     Function that takes the mean element-wise absolute value difference.
@@ -3968,7 +3968,7 @@ def margin_ranking_loss(
     size_average: bool | None = None,
     reduce: bool | None = None,
     reduction: str = "mean",
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""Compute the margin ranking loss.
 
     See :class:`~torch.nn.MarginRankingLoss` for details.
@@ -4018,7 +4018,7 @@ def hinge_embedding_loss(
     size_average: bool | None = None,
     reduce: bool | None = None,
     reduction: str = "mean",
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""Compute the hinge embedding loss.
 
     See :class:`~torch.nn.HingeEmbeddingLoss` for details.
@@ -4061,7 +4061,7 @@ def multilabel_margin_loss(
     size_average: bool | None = None,
     reduce: bool | None = None,
     reduction: str = "mean",
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""Compute the multilabel margin loss.
 
     See :class:`~torch.nn.MultiLabelMarginLoss` for details.
@@ -4103,7 +4103,7 @@ def soft_margin_loss(
     size_average: bool | None = None,
     reduce: bool | None = None,
     reduction: str = "mean",
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""Compute the soft margin loss.
 
     See :class:`~torch.nn.SoftMarginLoss` for details.
@@ -4146,7 +4146,7 @@ def multilabel_soft_margin_loss(
     size_average: bool | None = None,
     reduce: bool | None = None,
     reduction: str = "mean",
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""Compute the multilabel soft margin loss.
 
     See :class:`~torch.nn.MultiLabelSoftMarginLoss` for details.
@@ -4207,7 +4207,7 @@ def cosine_embedding_loss(
     size_average: bool | None = None,
     reduce: bool | None = None,
     reduction: str = "mean",
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""Compute the cosine embedding loss.
 
     See :class:`~torch.nn.CosineEmbeddingLoss` for details.
@@ -4255,7 +4255,7 @@ def multi_margin_loss(
     size_average: bool | None = None,
     reduce: bool | None = None,
     reduction: str = "mean",
-) -> Tensor:  # noqa: D400,D402
+) -> Tensor:
     r"""Compute the multi margin loss, with optional weighting.
 
     See :class:`~torch.nn.MultiMarginLoss` for details.
@@ -4446,14 +4446,14 @@ Examples::
 
 
 @_overload
-def upsample(  # noqa: F811
+def upsample(
     input: Tensor,
     size: int | None = None,
     scale_factor: float | None = None,
     mode: str = "nearest",
     align_corners: bool | None = None,
     # pyrefly: ignore [bad-return]
-) -> Tensor:  # noqa: B950
+) -> Tensor:
     pass
 
 
@@ -4465,7 +4465,7 @@ def upsample(  # noqa: F811
     mode: str = "nearest",
     align_corners: bool | None = None,
     # pyrefly: ignore [bad-return]
-) -> Tensor:  # noqa: B950
+) -> Tensor:
     pass
 
 
@@ -4559,7 +4559,7 @@ def _is_integer(x) -> bool:
 
 
 @_overload
-def interpolate(  # noqa: F811
+def interpolate(
     input: Tensor,
     size: int | None = None,
     scale_factor: list[float] | None = None,
@@ -4568,7 +4568,7 @@ def interpolate(  # noqa: F811
     recompute_scale_factor: bool | None = None,
     antialias: bool = False,
     # pyrefly: ignore [bad-return]
-) -> Tensor:  # noqa: B950
+) -> Tensor:
     pass
 
 
@@ -4582,7 +4582,7 @@ def interpolate(  # noqa: F811
     recompute_scale_factor: bool | None = None,
     antialias: bool = False,
     # pyrefly: ignore [bad-return]
-) -> Tensor:  # noqa: B950
+) -> Tensor:
     pass
 
 
@@ -4596,7 +4596,7 @@ def interpolate(  # noqa: F811
     recompute_scale_factor: bool | None = None,
     antialias: bool = False,
     # pyrefly: ignore [bad-return]
-) -> Tensor:  # noqa: B950
+) -> Tensor:
     pass
 
 
@@ -4622,7 +4622,7 @@ def interpolate(  # noqa: F811
     align_corners: bool | None = None,
     recompute_scale_factor: bool | None = None,
     antialias: bool = False,
-) -> Tensor:  # noqa: B950
+) -> Tensor:
     r"""Down/up samples the input.
 
     Tensor interpolated to either the given :attr:`size` or the given
@@ -4970,7 +4970,7 @@ if interpolate.__doc__:
 
 
 @_overload
-def upsample_nearest(  # noqa: F811
+def upsample_nearest(
     input: Tensor,
     size: int | None = None,
     scale_factor: float | None = None,
@@ -5022,7 +5022,7 @@ if upsample_nearest.__doc__:
 
 
 @_overload
-def upsample_bilinear(  # noqa: F811
+def upsample_bilinear(
     input: Tensor,
     size: int | None = None,
     scale_factor: float | None = None,

--- a/torch/nn/intrinsic/__init__.py
+++ b/torch/nn/intrinsic/__init__.py
@@ -13,10 +13,10 @@ from torch.ao.nn.intrinsic import (
     LinearBn1d,
     LinearReLU,
 )
-from torch.ao.nn.intrinsic.modules.fused import _FusedModule  # noqa: F401
+from torch.ao.nn.intrinsic.modules.fused import _FusedModule
 
 # Include the subpackages in case user imports from it directly
-from torch.nn.intrinsic import modules, qat, quantized  # noqa: F401
+from torch.nn.intrinsic import modules, qat, quantized
 
 
 __all__ = [

--- a/torch/nn/intrinsic/quantized/__init__.py
+++ b/torch/nn/intrinsic/quantized/__init__.py
@@ -1,6 +1,6 @@
 # to ensure customers can use the module below
 # without importing it directly
-from torch.nn.intrinsic.quantized import dynamic, modules  # noqa: F401
+from torch.nn.intrinsic.quantized import dynamic, modules
 from torch.nn.intrinsic.quantized.modules import *  # noqa: F403
 
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1322,7 +1322,7 @@ class MultiheadAttention(Module):
 
             .. note::
                 `batch_first` argument is ignored for unbatched inputs.
-        """  # noqa: B950
+        """
         why_not_fast_path = ""
         if (
             (attn_mask is not None and torch.is_floating_point(attn_mask))

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -49,7 +49,7 @@ convolution_notes = {
         In other words, for an input of size :math:`(N, C_{in}, L_{in})`,
         a depthwise convolution with a depthwise multiplier `K` can be performed with the arguments
         :math:`(C_\text{in}=C_\text{in}, C_\text{out}=C_\text{in} \times \text{K}, ..., \text{groups}=C_\text{in})`.""",
-}  # noqa: B950
+}
 
 
 class _ConvNd(Module):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -72,7 +72,7 @@ _global_parameter_registration_hooks: dict[int, Callable] = OrderedDict()
 
 
 class _WrappedHook:
-    def __init__(self, hook: Callable, module: Optional["Module"] = None) -> None:  # noqa: UP045
+    def __init__(self, hook: Callable, module: Optional["Module"] = None) -> None:
         self.hook: Callable = hook
         functools.update_wrapper(self, hook)
 
@@ -475,7 +475,7 @@ class Module:
     _load_state_dict_pre_hooks: dict[int, Callable]
     _state_dict_pre_hooks: dict[int, Callable]
     _load_state_dict_post_hooks: dict[int, Callable]
-    _modules: dict[str, Optional["Module"]]  # noqa: UP045
+    _modules: dict[str, Optional["Module"]]
     call_super_init: bool = False
     _compiled_call_impl: Callable | None = None
 
@@ -639,7 +639,7 @@ class Module:
                     param = output
             self._parameters[name] = param
 
-    def add_module(self, name: str, module: Optional["Module"]) -> None:  # noqa: UP045
+    def add_module(self, name: str, module: Optional["Module"]) -> None:
         r"""Add a child module to the current module.
 
         The module can be accessed as an attribute using the given name.
@@ -667,7 +667,7 @@ class Module:
                 module = output
         self._modules[name] = module
 
-    def register_module(self, name: str, module: Optional["Module"]) -> None:  # noqa: UP045
+    def register_module(self, name: str, module: Optional["Module"]) -> None:
         r"""Alias for :func:`add_module`."""
         self.add_module(name, module)
 
@@ -2835,7 +2835,7 @@ class Module:
 
     def named_modules(
         self,
-        memo: set["Module"] | None = None,  # noqa: UP007
+        memo: set["Module"] | None = None,
         prefix: str = "",
         remove_duplicate: bool = True,
     ):

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -654,7 +654,7 @@ class RNN(RNNBase):
         super().__init__(mode, *args, **kwargs)
 
     @overload
-    @torch._jit_internal._overload_method  # noqa: F811
+    @torch._jit_internal._overload_method
     def forward(
         self,
         input: Tensor,
@@ -663,7 +663,7 @@ class RNN(RNNBase):
         pass
 
     @overload
-    @torch._jit_internal._overload_method  # noqa: F811
+    @torch._jit_internal._overload_method
     def forward(
         self,
         input: PackedSequence,
@@ -671,7 +671,7 @@ class RNN(RNNBase):
     ) -> tuple[PackedSequence, Tensor]:
         pass
 
-    def forward(self, input, hx=None):  # noqa: F811
+    def forward(self, input, hx=None):
         """
         Runs the forward pass.
         """
@@ -1058,25 +1058,25 @@ class LSTM(RNNBase):
 
     # Same as above, see torch/nn/modules/module.py::_forward_unimplemented
     @overload  # type: ignore[override]
-    @torch._jit_internal._overload_method  # noqa: F811
+    @torch._jit_internal._overload_method
     def forward(
         self,
         input: Tensor,
         hx: tuple[Tensor, Tensor] | None = None,
-    ) -> tuple[Tensor, tuple[Tensor, Tensor]]:  # noqa: F811
+    ) -> tuple[Tensor, tuple[Tensor, Tensor]]:
         pass
 
     # Same as above, see torch/nn/modules/module.py::_forward_unimplemented
     @overload
-    @torch._jit_internal._overload_method  # noqa: F811
+    @torch._jit_internal._overload_method
     def forward(
         self,
         input: PackedSequence,
         hx: tuple[Tensor, Tensor] | None = None,
-    ) -> tuple[PackedSequence, tuple[Tensor, Tensor]]:  # noqa: F811
+    ) -> tuple[PackedSequence, tuple[Tensor, Tensor]]:
         pass
 
-    def forward(self, input, hx=None):  # noqa: F811
+    def forward(self, input, hx=None):
         self._update_flat_weights()
 
         orig_input = input
@@ -1356,24 +1356,24 @@ class GRU(RNNBase):
         super().__init__("GRU", *args, **kwargs)
 
     @overload  # type: ignore[override]
-    @torch._jit_internal._overload_method  # noqa: F811
+    @torch._jit_internal._overload_method
     def forward(
         self,
         input: Tensor,
         hx: Tensor | None = None,
-    ) -> tuple[Tensor, Tensor]:  # noqa: F811
+    ) -> tuple[Tensor, Tensor]:
         pass
 
     @overload
-    @torch._jit_internal._overload_method  # noqa: F811
+    @torch._jit_internal._overload_method
     def forward(
         self,
         input: PackedSequence,
         hx: Tensor | None = None,
-    ) -> tuple[PackedSequence, Tensor]:  # noqa: F811
+    ) -> tuple[PackedSequence, Tensor]:
         pass
 
-    def forward(self, input, hx=None):  # noqa: F811
+    def forward(self, input, hx=None):
         self._update_flat_weights()
 
         orig_input = input

--- a/torch/nn/qat/__init__.py
+++ b/torch/nn/qat/__init__.py
@@ -1,11 +1,10 @@
-# flake8: noqa: F401
 r"""QAT Dynamic Modules.
 
 This package is in the process of being deprecated.
 Please, use `torch.ao.nn.qat.dynamic` instead.
 """
 
-from torch.nn.qat import dynamic, modules  # noqa: F403
+from torch.nn.qat import dynamic, modules
 from torch.nn.qat.modules import *  # noqa: F403
 
 

--- a/torch/nn/qat/dynamic/__init__.py
+++ b/torch/nn/qat/dynamic/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""QAT Dynamic Modules.
 
 This package is in the process of being deprecated.

--- a/torch/nn/qat/modules/__init__.py
+++ b/torch/nn/qat/modules/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""QAT Modules.
 
 This package is in the process of being deprecated.

--- a/torch/nn/qat/modules/embedding_ops.py
+++ b/torch/nn/qat/modules/embedding_ops.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""QAT Modules.
 
 This file is in the process of migration to `torch/ao/nn/qat`, and

--- a/torch/nn/quantized/__init__.py
+++ b/torch/nn/quantized/__init__.py
@@ -1,4 +1,4 @@
-from torch.nn.quantized import dynamic, functional, modules  # noqa: F403
+from torch.nn.quantized import dynamic, functional, modules
 from torch.nn.quantized.modules import *  # noqa: F403
 from torch.nn.quantized.modules import MaxPool2d
 

--- a/torch/nn/quantized/_reference/modules/__init__.py
+++ b/torch/nn/quantized/_reference/modules/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""Quantized Reference Modules.
 
 This module is in the process of migration to

--- a/torch/nn/quantized/dynamic/modules/__init__.py
+++ b/torch/nn/quantized/dynamic/modules/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""Quantized Dynamic Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized/dynamic`,

--- a/torch/nn/quantized/dynamic/modules/conv.py
+++ b/torch/nn/quantized/dynamic/modules/conv.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""Quantized Dynamic Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized/dynamic`,

--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""Quantized Dynamic Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized/dynamic`,

--- a/torch/nn/quantized/functional.py
+++ b/torch/nn/quantized/functional.py
@@ -7,4 +7,4 @@ Note::
     Please, use the `torch.ao.nn.quantized.functional` instead.
 """
 
-from torch.ao.nn.quantized.functional import *  # noqa: F401,F403
+from torch.ao.nn.quantized.functional import *  # noqa: F403

--- a/torch/nn/quantized/modules/dropout.py
+++ b/torch/nn/quantized/modules/dropout.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and

--- a/torch/nn/quantized/modules/embedding_ops.py
+++ b/torch/nn/quantized/modules/embedding_ops.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and

--- a/torch/nn/quantized/modules/functional_modules.py
+++ b/torch/nn/quantized/modules/functional_modules.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and

--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and

--- a/torch/nn/quantized/modules/normalization.py
+++ b/torch/nn/quantized/modules/normalization.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""Quantized Modules.
 
 This file is in the process of migration to `torch/ao/nn/quantized`, and

--- a/torch/onnx/_internal/exporter/_analysis.py
+++ b/torch/onnx/_internal/exporter/_analysis.py
@@ -1,7 +1,7 @@
 """Compatibility analyzer for PyTorch models."""
 
 # mypy: allow-untyped-defs
-# flake8: noqa: B950 We do not need flake8 as it complains line length
+
 from __future__ import annotations
 
 import dataclasses

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -1,5 +1,5 @@
 # mypy: allow-untyped-defs
-# flake8: noqa: B950 We do not need flake8 as it complains line length
+
 from __future__ import annotations
 
 import ctypes

--- a/torch/onnx/_internal/exporter/_registration.py
+++ b/torch/onnx/_internal/exporter/_registration.py
@@ -80,7 +80,7 @@ class OnnxDecompMeta:
                     # When the function is targeting an HOP, for example, it will accept
                     # functions as arguments and fail to generate an ONNX signature.
                     # In this case we set signature to None and dispatch to this function always.
-                    logger.warning(  # noqa: G200
+                    logger.warning(
                         "Failed to infer the signature for function '%s' because '%s'"
                         "All nodes targeting `%s` will be dispatched to this function",
                         self.onnx_function,

--- a/torch/onnx/_internal/exporter/_torchlib/ops/core.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/core.py
@@ -1,7 +1,7 @@
 """torch.ops.aten operators under the `core` module."""
 # mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
 # pyrefly: ignore-errors
-# ruff: noqa: TCH001,TCH002
+# ruff: noqa: TCH001
 
 from __future__ import annotations
 

--- a/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/nn.py
@@ -1,8 +1,7 @@
 """torch.ops.aten operators under the `core` module."""
 # mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
 # pyrefly: ignore-errors
-# ruff: noqa: TC001,TC002
-# flake8: noqa: B950
+# ruff: noqa: TC001
 
 from __future__ import annotations
 

--- a/torch/onnx/_internal/exporter/_torchlib/ops/symops.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/symops.py
@@ -2,7 +2,7 @@
 
 # mypy: disable-error-code="misc,arg-type,type-arg,valid-type,assignment,return-value,type-var,operator,no-untyped-def,index"
 # pyrefly: ignore-errors
-# ruff: noqa: TCH001,TCH002,TC003
+# ruff: noqa: TC003
 
 from __future__ import annotations
 

--- a/torch/onnx/ops/__init__.py
+++ b/torch/onnx/ops/__init__.py
@@ -4,7 +4,6 @@ This module provides a set of functions to create ONNX operators in the FX graph
 which are exportable to ONNX.
 """
 
-# flake8: noqa: B950
 from __future__ import annotations
 
 

--- a/torch/onnx/ops/_impl.py
+++ b/torch/onnx/ops/_impl.py
@@ -5,7 +5,6 @@ NOTE: Fake implementations:
     for more details on how to create fake kernels.
 """
 
-# flake8: noqa: B950
 import math
 from collections.abc import Callable
 from typing import TypeVar

--- a/torch/onnx/ops/_symbolic_impl.py
+++ b/torch/onnx/ops/_symbolic_impl.py
@@ -11,7 +11,6 @@ zeros based on the input shape and dtype, and a "fake" implementation that does 
 or less the same thing but is required by the `torch.library.custom_op` interface.
 """
 
-# flake8: noqa: B950
 import dataclasses
 from collections.abc import Sequence
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_helper import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_helper import *  # noqa: F403

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset10 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset10 import *  # noqa: F403
 from torch.onnx._internal.torchscript_exporter.symbolic_opset10 import (  # noqa: F401
     _slice,
 )

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset11 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset11 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset12 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset12 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset13 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset13 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset14 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset14 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset15.py
+++ b/torch/onnx/symbolic_opset15.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset15 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset15 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset16.py
+++ b/torch/onnx/symbolic_opset16.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset16 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset16 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset17.py
+++ b/torch/onnx/symbolic_opset17.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset17 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset17 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset18.py
+++ b/torch/onnx/symbolic_opset18.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset18 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset18 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset19.py
+++ b/torch/onnx/symbolic_opset19.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset19 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset19 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset20.py
+++ b/torch/onnx/symbolic_opset20.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset20 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset20 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset7.py
+++ b/torch/onnx/symbolic_opset7.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset7 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset7 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset8 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset8 import *  # noqa: F403

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 __all__: list[str] = []
 
-from torch.onnx._internal.torchscript_exporter.symbolic_opset9 import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.symbolic_opset9 import *  # noqa: F403
 from torch.onnx._internal.torchscript_exporter.symbolic_opset9 import (  # noqa: F401
     _prepare_onnx_paddings,
     _reshape_from_tensor,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -6,4 +6,4 @@ from __future__ import annotations
 __all__: list[str] = []
 
 
-from torch.onnx._internal.torchscript_exporter.utils import *  # noqa: F401,F403
+from torch.onnx._internal.torchscript_exporter.utils import *  # noqa: F403

--- a/torch/optim/_multi_tensor/__init__.py
+++ b/torch/optim/_multi_tensor/__init__.py
@@ -11,7 +11,7 @@ from functools import partialmethod
 from torch import optim
 
 
-def partialclass(cls, *args, **kwargs):  # noqa: D103
+def partialclass(cls, *args, **kwargs):
     class NewCls(cls):
         __init__ = partialmethod(cls.__init__, *args, **kwargs)
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -120,7 +120,7 @@ class LRScheduler:
         self,
         optimizer: Optimizer,
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
@@ -380,7 +380,7 @@ class LambdaLR(LRScheduler):
         optimizer: Optimizer,
         lr_lambda: Callable[[int], float] | list[Callable[[int], float]],
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         self.optimizer = optimizer
 
         self.lr_lambdas: list[Callable[[int], float]]
@@ -495,7 +495,7 @@ class MultiplicativeLR(LRScheduler):
         optimizer: Optimizer,
         lr_lambda: Callable[[int], float] | list[Callable[[int], float]],
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         self.optimizer = optimizer
 
         self.lr_lambdas: list[Callable[[int], float]]
@@ -624,7 +624,7 @@ class StepLR(LRScheduler):
         step_size: int,
         gamma: float = 0.1,
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         self.step_size = step_size
         self.gamma = gamma
         super().__init__(optimizer, last_epoch)
@@ -710,7 +710,7 @@ class MultiStepLR(LRScheduler):
         milestones: Iterable[int],
         gamma: float = 0.1,
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         self.milestones = Counter(milestones)
         self.gamma = gamma
         super().__init__(optimizer, last_epoch)
@@ -809,7 +809,7 @@ class ConstantLR(LRScheduler):
         factor: float = 1.0 / 3,
         total_iters: int = 5,
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         if factor > 1.0 or factor < 0:
             raise ValueError(
                 "Constant multiplicative factor expected to be between 0 and 1."
@@ -917,7 +917,7 @@ class LinearLR(LRScheduler):
         end_factor: float = 1.0,
         total_iters: int = 5,
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         if start_factor > 1.0 or start_factor <= 0:
             raise ValueError(
                 "Starting multiplicative factor expected to be greater than 0 and less or equal to 1."
@@ -1030,7 +1030,7 @@ class ExponentialLR(LRScheduler):
         optimizer: Optimizer,
         gamma: float,
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         self.gamma = gamma
         super().__init__(optimizer, last_epoch)
 
@@ -1122,7 +1122,7 @@ class SequentialLR(LRScheduler):
         schedulers: list[LRScheduler],
         milestones: list[int],
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         if len(schedulers) < 1:
             raise ValueError(
                 f"{self.__class__.__name__} expects at least one scheduler, but got no scheduler."
@@ -1266,7 +1266,7 @@ class PolynomialLR(LRScheduler):
         total_iters: int = 5,
         power: float = 1.0,
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         self.total_iters = total_iters
         self.power = power
         super().__init__(optimizer, last_epoch)
@@ -1390,7 +1390,7 @@ class CosineAnnealingLR(LRScheduler):
         T_max: int,
         eta_min: float = 0.0,
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         self.T_max = T_max
         self.eta_min = eta_min
         super().__init__(optimizer, last_epoch)
@@ -1507,7 +1507,7 @@ class ChainedScheduler(LRScheduler):
 
     def __init__(
         self, schedulers: Sequence[LRScheduler], optimizer: Optimizer | None = None
-    ) -> None:  # noqa: D107
+    ) -> None:
         if len(schedulers) < 1:
             raise ValueError(
                 f"{self.__class__.__name__} expects at least one scheduler to be chained, but got no scheduler."
@@ -1648,7 +1648,7 @@ class ReduceLROnPlateau(LRScheduler):
         cooldown: int = 0,
         min_lr: list[float] | float = 0,
         eps: float = 1e-8,
-    ) -> None:  # noqa: D107
+    ) -> None:
         if factor >= 1.0:
             raise ValueError("Factor should be < 1.0.")
         self.factor = factor
@@ -1734,10 +1734,10 @@ class ReduceLROnPlateau(LRScheduler):
                 _update_param_group_val(param_group, "lr", new_lr)
 
     @property
-    def in_cooldown(self):  # noqa: D102
+    def in_cooldown(self):
         return self.cooldown_counter > 0
 
-    def _is_better(self, a, best):  # noqa: D102
+    def _is_better(self, a, best):
         if self.mode == "min" and self.threshold_mode == "rel":
             rel_epsilon = 1.0 - self.threshold
             return a < best * rel_epsilon
@@ -1891,7 +1891,7 @@ class CyclicLR(LRScheduler):
         base_momentum: float = 0.8,
         max_momentum: float = 0.9,
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         # Attach optimizer
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")
@@ -2061,7 +2061,7 @@ class CyclicLR(LRScheduler):
         return lrs
 
     @override
-    def state_dict(self) -> dict[str, Any]:  # noqa: D102
+    def state_dict(self) -> dict[str, Any]:
         """Return the state of the scheduler as a :class:`dict`.
 
         It contains an entry for every variable in ``self.__dict__`` which
@@ -2142,7 +2142,7 @@ class CosineAnnealingWarmRestarts(LRScheduler):
         T_mult: int = 1,
         eta_min: float = 0.0,
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         if T_0 <= 0 or not isinstance(T_0, int):
             raise ValueError(f"Expected positive integer T_0, but got {T_0}")
         if T_mult < 1 or not isinstance(T_mult, int):
@@ -2394,7 +2394,7 @@ class OneCycleLR(LRScheduler):
         final_div_factor: float = 1e4,
         three_phase: bool = False,
         last_epoch: int = -1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         # Validate optimizer
         if not isinstance(optimizer, Optimizer):
             raise TypeError(f"{type(optimizer).__name__} is not an Optimizer")

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -29,7 +29,7 @@ from .optimizer import (
 __all__ = ["NAdam", "nadam"]
 
 
-class NAdam(Optimizer):  # noqa: D101
+class NAdam(Optimizer):
     def __init__(
         self,
         params: ParamsT,
@@ -44,7 +44,7 @@ class NAdam(Optimizer):  # noqa: D101
         maximize: bool = False,
         capturable: bool = False,
         differentiable: bool = False,
-    ) -> None:  # noqa: D107
+    ) -> None:
         if isinstance(lr, Tensor) and lr.numel() != 1:
             raise ValueError("Tensor lr must be 1-element")
         if not 0.0 <= lr:
@@ -73,7 +73,7 @@ class NAdam(Optimizer):  # noqa: D101
         }
         super().__init__(params, defaults)
 
-    def __setstate__(self, state):  # noqa: D105
+    def __setstate__(self, state):
         super().__setstate__(state)
         for group in self.param_groups:
             group.setdefault("maximize", False)

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -374,7 +374,7 @@ class Optimizer:
         'OrderedDict[int, Callable[["Optimizer"], None]]'
     )
 
-    def __init__(self, params: ParamsT, defaults: dict[str, Any]) -> None:  # noqa: D107
+    def __init__(self, params: ParamsT, defaults: dict[str, Any]) -> None:
         torch._C._log_api_usage_once("python.optimizer")
         self.defaults = defaults
         self._optimizer_step_pre_hooks = OrderedDict()
@@ -409,14 +409,14 @@ class Optimizer:
         # https://github.com/pytorch/pytorch/issues/72948
         self._warned_capturable_if_run_uncaptured = True
 
-    def __getstate__(self) -> dict[str, Any]:  # noqa: D105
+    def __getstate__(self) -> dict[str, Any]:
         return {
             "defaults": self.defaults,
             "state": self.state,
             "param_groups": self.param_groups,
         }
 
-    def __setstate__(self, state: dict[str, Any]) -> None:  # noqa: D105
+    def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
         if "_optimizer_step_pre_hooks" not in self.__dict__:
             self._optimizer_step_pre_hooks = OrderedDict()
@@ -433,7 +433,7 @@ class Optimizer:
         self._patch_step_function()  # To support multiprocessing pickle/unpickle
         self.defaults.setdefault("differentiable", False)
 
-    def __repr__(self) -> str:  # noqa: D105
+    def __repr__(self) -> str:
         format_string = self.__class__.__name__ + " ("
         for i, group in enumerate(self.param_groups):
             format_string += "\n"
@@ -510,7 +510,7 @@ class Optimizer:
         """
 
     @staticmethod
-    def profile_hook_step(func: Callable[_P, R]) -> Callable[_P, R]:  # noqa: D102
+    def profile_hook_step(func: Callable[_P, R]) -> Callable[_P, R]:
         @functools.wraps(func)
         def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> R:
             self, *_ = args
@@ -618,7 +618,7 @@ class Optimizer:
 
     def register_state_dict_pre_hook(
         self, hook: Callable[["Optimizer"], None], prepend: bool = False
-    ) -> RemovableHandle:  # noqa: D101
+    ) -> RemovableHandle:
         r"""Register a state dict pre-hook which will be called before :meth:`~torch.optim.Optimizer.state_dict` is called.
 
         It should have the following signature::
@@ -811,7 +811,7 @@ class Optimizer:
         self,
         hook: Callable[["Optimizer", StateDict], StateDict | None],
         prepend: bool = False,
-    ) -> RemovableHandle:  # noqa: D205 D400
+    ) -> RemovableHandle:
         r"""Register a load_state_dict pre-hook which will be called before
         :meth:`~torch.optim.Optimizer.load_state_dict` is called. It should have the
         following signature::
@@ -848,7 +848,7 @@ class Optimizer:
 
     def register_load_state_dict_post_hook(
         self, hook: Callable[["Optimizer"], None], prepend: bool = False
-    ) -> RemovableHandle:  # noqa: D205 D400
+    ) -> RemovableHandle:
         r"""Register a load_state_dict post-hook which will be called after
         :meth:`~torch.optim.Optimizer.load_state_dict` is called. It should have the
         following signature::

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -28,7 +28,7 @@ from .optimizer import (
 __all__ = ["RAdam", "radam"]
 
 
-class RAdam(Optimizer):  # noqa: D101
+class RAdam(Optimizer):
     def __init__(
         self,
         params: ParamsT,
@@ -42,7 +42,7 @@ class RAdam(Optimizer):  # noqa: D101
         maximize: bool = False,
         capturable: bool = False,
         differentiable: bool = False,
-    ) -> None:  # noqa: D107
+    ) -> None:
         if isinstance(lr, Tensor) and lr.numel() != 1:
             raise ValueError("Tensor lr must be 1-element")
         if not 0.0 <= lr:
@@ -69,7 +69,7 @@ class RAdam(Optimizer):  # noqa: D101
         }
         super().__init__(params, defaults)
 
-    def __setstate__(self, state):  # noqa: D105
+    def __setstate__(self, state):
         super().__setstate__(state)
         for group in self.param_groups:
             group.setdefault("foreach", None)

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -27,7 +27,7 @@ from .optimizer import (
 __all__ = ["RMSprop", "rmsprop"]
 
 
-class RMSprop(Optimizer):  # noqa: D101
+class RMSprop(Optimizer):
     def __init__(
         self,
         params: ParamsT,
@@ -41,7 +41,7 @@ class RMSprop(Optimizer):  # noqa: D101
         foreach: bool | None = None,
         maximize: bool = False,
         differentiable: bool = False,
-    ) -> None:  # noqa: D107
+    ) -> None:
         if isinstance(lr, Tensor) and lr.numel() != 1:
             raise ValueError("Tensor lr must be 1-element")
         if not 0.0 <= lr:
@@ -69,7 +69,7 @@ class RMSprop(Optimizer):  # noqa: D101
         }
         super().__init__(params, defaults)
 
-    def __setstate__(self, state):  # noqa: D105
+    def __setstate__(self, state):
         super().__setstate__(state)
         for group in self.param_groups:
             group.setdefault("momentum", 0)

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -27,7 +27,7 @@ from .optimizer import (
 __all__ = ["Rprop", "rprop"]
 
 
-class Rprop(Optimizer):  # noqa: D101
+class Rprop(Optimizer):
     def __init__(
         self,
         params: ParamsT,
@@ -39,7 +39,7 @@ class Rprop(Optimizer):  # noqa: D101
         foreach: bool | None = None,
         maximize: bool = False,
         differentiable: bool = False,
-    ) -> None:  # noqa: D107
+    ) -> None:
         if isinstance(lr, Tensor) and lr.numel() != 1:
             raise ValueError("Tensor lr must be 1-element")
         if not 0.0 <= lr:
@@ -58,7 +58,7 @@ class Rprop(Optimizer):  # noqa: D101
         }
         super().__init__(params, defaults)
 
-    def __setstate__(self, state):  # noqa: D105
+    def __setstate__(self, state):
         super().__setstate__(state)
         for group in self.param_groups:
             group.setdefault("foreach", None)

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -25,7 +25,7 @@ from .optimizer import (
 __all__ = ["SGD", "sgd"]
 
 
-class SGD(Optimizer):  # noqa: D101
+class SGD(Optimizer):
     def __init__(
         self,
         params: ParamsT,
@@ -39,7 +39,7 @@ class SGD(Optimizer):  # noqa: D101
         foreach: bool | None = None,
         differentiable: bool = False,
         fused: bool | None = None,
-    ) -> None:  # noqa: D107
+    ) -> None:
         if isinstance(lr, Tensor) and lr.numel() != 1:
             raise ValueError("Tensor lr must be 1-element")
         if lr < 0.0:
@@ -72,7 +72,7 @@ class SGD(Optimizer):  # noqa: D101
             if foreach:
                 raise RuntimeError("`fused` and `foreach` cannot be `True` together.")
 
-    def __setstate__(self, state):  # noqa: D105
+    def __setstate__(self, state):
         super().__setstate__(state)
         for group in self.param_groups:
             group.setdefault("nesterov", False)

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -271,7 +271,7 @@ class AveragedModel(Module):
         multi_avg_fn: Callable[[PARAM_LIST, PARAM_LIST, Tensor | int], None]
         | None = None,
         use_buffers=False,
-    ) -> None:  # noqa: D107
+    ) -> None:
         super().__init__()
         if avg_fn is not None and multi_avg_fn is not None:
             raise AssertionError(
@@ -478,7 +478,7 @@ class SWALR(LRScheduler):
         anneal_epochs=10,
         anneal_strategy: Literal["cos", "linear"] = "cos",
         last_epoch=-1,
-    ) -> None:  # noqa: D107
+    ) -> None:
         swa_lrs = _format_param("swa_lr", optimizer, swa_lr)
         for swa_lr, group in zip(swa_lrs, optimizer.param_groups, strict=True):
             group["swa_lr"] = swa_lr

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -20,7 +20,7 @@ please report the benchmarks in ``benchmarks/overrides_benchmark``. See the
 instructions in the ``README.md`` in that directory.
 """
 
-import __future__  # noqa: F404
+import __future__
 
 import collections
 import contextlib
@@ -604,10 +604,10 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.linalg.eigvalsh: lambda input, UPLO="L", out=None: -1,
         torch.einsum: lambda equation, *operands: -1,
         torch.embedding: (
-            lambda input, weight, padding_idx=None, max_norm=None, norm_type=2.0, scale_grad_by_freq=False, sparse=False: -1  # noqa: B950
+            lambda input, weight, padding_idx=None, max_norm=None, norm_type=2.0, scale_grad_by_freq=False, sparse=False: -1
         ),
         torch.embedding_bag: (
-            lambda input, weight, offsets, max_norm=None, norm_type=2, scale_grad_by_freq=False, mode="mean", sparse=False, per_sample_weights=None, padding_idx=None: -1  # noqa: B950
+            lambda input, weight, offsets, max_norm=None, norm_type=2, scale_grad_by_freq=False, mode="mean", sparse=False, per_sample_weights=None, padding_idx=None: -1
         ),
         torch.empty_like: lambda input, dtype=None, layout=None, device=None, requires_grad=False: -1,
         torch.eq: lambda input, other, out=None: -1,
@@ -621,11 +621,11 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.fake_quantize_per_channel_affine: lambda input, scale, zero_point, axis, quant_min, quant_max: -1,
         torch.fake_quantize_per_tensor_affine: lambda input, scale, zero_point, quant_min, quant_max: -1,
         torch.fused_moving_avg_obs_fake_quant: (
-            lambda x, observer_on, fake_quant_on, averaging_const, running_min, running_max, scale, zero_point, quant_min, quant_max, ch_axis, per_row_fake_quant=False, symmetric_quant=False: -1  # noqa: B950
+            lambda x, observer_on, fake_quant_on, averaging_const, running_min, running_max, scale, zero_point, quant_min, quant_max, ch_axis, per_row_fake_quant=False, symmetric_quant=False: -1
         ),
         torch.fbgemm_linear_fp16_weight: lambda input, packed_weight, bias, output: -1,
         torch.fbgemm_linear_fp16_weight_fp32_activation: lambda input, packed_weight, bias, output: -1,
-        torch.fbgemm_linear_int8_weight: lambda input, weight, packed, col_offsets, weight_scale, weight_zero_point, bias: -1,  # noqa: B950
+        torch.fbgemm_linear_int8_weight: lambda input, weight, packed, col_offsets, weight_scale, weight_zero_point, bias: -1,
         torch.fbgemm_linear_int8_weight_fp32_activation: (
             lambda input, weight, packed, col_offsets, weight_scale, weight_zero_point, bias: -1
         ),
@@ -666,7 +666,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.fmod: lambda input, other, out=None: -1,
         torch.frac: lambda input, out=None: -1,
         torch.frexp: lambda input, out=None: -1,
-        torch.full_like: lambda input, fill_value, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False: -1,  # noqa: B950
+        torch.full_like: lambda input, fill_value, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False: -1,
         torch._functional_assert_async: lambda input, msg, dep_token: -1,
         torch.lu_unpack: lambda LU_data, LU_pivots, unpack_data=True, unpack_pivots=True: -1,
         torch.gather: lambda input, dim, index, out=None, sparse_grad=False: -1,
@@ -691,7 +691,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.hardshrink: lambda input, lambd=0.5: -1,
         torch.hash_tensor: lambda input, dim=None, keepdim=False, mode=0, out=None: -1,
         torch.heaviside: lambda input, values, out=None: -1,
-        torch.hinge_embedding_loss: lambda input, target, margin=1.0, size_average=None, reduce=None, reduction="mean": -1,  # noqa: B950
+        torch.hinge_embedding_loss: lambda input, target, margin=1.0, size_average=None, reduce=None, reduction="mean": -1,
         torch.histc: lambda input, bins=100, min=0, max=0, out=None: -1,
         torch.histogram: lambda input, bins=100, min=None, max=None, weight=None, density=False, out=None: -1,
         torch.histogramdd: lambda input, bins, range=None, weight=None, density=False: -1,
@@ -734,7 +734,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.isclose: lambda input, other, rtol=1e-05, atol=1e-08, equal_nan=False: -1,
         torch.isnan: lambda input: -1,
         torch.istft: (
-            lambda input, n_fft, hop_length=None, win_length=None, window=None, center=True, normalized=False, onesided=None, length=None, return_complex=False: -1  # noqa: B950
+            lambda input, n_fft, hop_length=None, win_length=None, window=None, center=True, normalized=False, onesided=None, length=None, return_complex=False: -1
         ),
         torch.kl_div: lambda input, target, size_average=None, reduce=None, reduction="mean", log_target=False: -1,
         torch.kron: lambda input, other: -1,
@@ -749,7 +749,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.less_equal: lambda input, other, out=None: -1,
         torch.lerp: lambda input, end, weight, out=None: -1,
         torch.lgamma: lambda input, out=None: -1,
-        torch.lobpcg: lambda input, k=None, B=None, X=None, n=None, iK=None, niter=None, tol=None, largest=None, method=None, tracker=None, ortho_iparams=None, ortho_fparams=None, ortho_bparams=None: -1,  # noqa: B950
+        torch.lobpcg: lambda input, k=None, B=None, X=None, n=None, iK=None, niter=None, tol=None, largest=None, method=None, tracker=None, ortho_iparams=None, ortho_fparams=None, ortho_bparams=None: -1,
         torch.log: lambda input, out=None: -1,
         torch.log_softmax: lambda input, dim, dtype=None: -1,
         torch.log10: lambda input, out=None: -1,
@@ -771,7 +771,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.less: lambda input, other, out=None: -1,
         torch.lu: lambda A, pivot=True, get_infos=False, out=None: -1,
         torch.lu_solve: lambda b, LU_data, LU_pivots, out=None: -1,
-        torch.margin_ranking_loss: lambda input1, input2, target, margin=0, size_average=None, reduce=None, reduction="mean": -1,  # type: ignore[attr-defined]  # noqa: B950
+        torch.margin_ranking_loss: lambda input1, input2, target, margin=0, size_average=None, reduce=None, reduction="mean": -1,  # type: ignore[attr-defined]
         torch.masked_fill: lambda input, mask, value: -1,
         torch.masked_scatter: lambda input, mask, source: -1,
         torch.masked_select: lambda input, mask, out=None: -1,
@@ -807,7 +807,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.miopen_batch_norm: (
             lambda input, weight, bias, running_mean, running_var, training, exponential_average_factor, epsilon: -1
         ),
-        torch.miopen_convolution: lambda input, weight, bias, padding, stride, dilation, groups, benchmark, deterministic: -1,  # noqa: B950
+        torch.miopen_convolution: lambda input, weight, bias, padding, stride, dilation, groups, benchmark, deterministic: -1,
         torch.miopen_convolution_add_relu: lambda input, weight, z, alpha, bias, stride, padding, dilation, groups: -1,
         torch.miopen_convolution_relu: lambda input, weight, bias, stride, padding, dilation, groups: -1,
         torch.miopen_convolution_transpose: (
@@ -817,7 +817,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
             lambda input, weight, bias, padding, stride, dilation, groups, benchmark, deterministic: -1
         ),
         torch.miopen_rnn: (
-            lambda input, weight, weight_stride0, hx, cx, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state: -1  # noqa: B950
+            lambda input, weight, weight_stride0, hx, cx, mode, hidden_size, num_layers, batch_first, dropout, train, bidirectional, batch_sizes, dropout_state: -1
         ),
         torch.mm: lambda input, mat2, out_dtype=None, out=None: -1,
         torch.mode: lambda input, dim=-1, keepdim=False, out=None: -1,
@@ -855,10 +855,10 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.nn.functional.affine_grid: lambda theta, size, align_corners=None: -1,
         torch.nn.functional.alpha_dropout: lambda input, p=0.5, training=False, inplace=False: -1,
         torch.nn.functional.avg_pool2d: (
-            lambda input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True, divisor_override=None: -1  # noqa: B950
+            lambda input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True, divisor_override=None: -1
         ),
         torch.nn.functional.avg_pool3d: (
-            lambda input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True, divisor_override=None: -1  # noqa: B950
+            lambda input, kernel_size, stride=None, padding=0, ceil_mode=False, count_include_pad=True, divisor_override=None: -1
         ),
         torch.nn.functional.batch_norm: (
             lambda input, running_mean, running_var, weight=None, bias=None, training=False, momentum=0.1, eps=1e-05: -1
@@ -875,7 +875,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
             lambda input1, input2, target, margin=0, size_average=None, reduce=None, reduction="mean": -1
         ),
         torch.nn.functional.cross_entropy: (
-            lambda input, target, weight=None, size_average=None, ignore_index=-100, reduce=None, reduction="mean", label_smoothing=0.0: -1  # noqa: B950
+            lambda input, target, weight=None, size_average=None, ignore_index=-100, reduce=None, reduction="mean", label_smoothing=0.0: -1
         ),
         torch.nn.functional.ctc_loss: (
             lambda log_probs, targets, input_lengths, target_lengths, blank=0, reduction="mean", zero_infinity=False: -1
@@ -886,29 +886,29 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.nn.functional.dropout3d: lambda input, p=0.5, training=True, inplace=False: -1,
         torch.nn.functional.elu: lambda input, alpha=1.0, inplace=False: -1,
         torch.nn.functional.embedding: (
-            lambda input, weight, padding_idx=None, max_norm=None, norm_type=2.0, scale_grad_by_freq=False, sparse=False: -1  # noqa: B950
+            lambda input, weight, padding_idx=None, max_norm=None, norm_type=2.0, scale_grad_by_freq=False, sparse=False: -1
         ),
         torch.nn.functional.embedding_bag: (
-            lambda input, weight, offsets=None, max_norm=None, norm_type=2, scale_grad_by_freq=False, mode="mean", sparse=False, per_sample_weights=None, include_last_offset=False, padding_idx=None: -1  # noqa: B950
+            lambda input, weight, offsets=None, max_norm=None, norm_type=2, scale_grad_by_freq=False, mode="mean", sparse=False, per_sample_weights=None, include_last_offset=False, padding_idx=None: -1
         ),
         torch.nn.functional.feature_alpha_dropout: lambda input, p=0.5, training=False, inplace=False: -1,
         torch.nn.functional.fold: lambda input, output_size, kernel_size, dilation=1, padding=0, stride=1: -1,
         torch.nn.functional.fractional_max_pool2d: (
-            lambda input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None: -1  # noqa: B950
+            lambda input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None: -1
         ),
         torch.nn.functional.fractional_max_pool2d_with_indices: (
-            lambda input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None: -1  # noqa: B950
+            lambda input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None: -1
         ),
         torch.nn.functional.fractional_max_pool3d: (
-            lambda input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None: -1  # noqa: B950
+            lambda input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None: -1
         ),
         torch.nn.functional.fractional_max_pool3d_with_indices: (
-            lambda input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None: -1  # noqa: B950
+            lambda input, kernel_size, output_size=None, output_ratio=None, return_indices=False, _random_samples=None: -1
         ),
         torch.nn.functional.gaussian_nll_loss: lambda input, target, var, full=False, eps=1e-06, reduction="mean": -1,
         torch.nn.functional.gelu: lambda input, approximate="none": -1,
         torch.nn.functional.glu: lambda input, dim=-1: -1,
-        torch.nn.functional.grid_sample: lambda input, grid, mode="bilinear", padding_mode="zeros", align_corners=None: -1,  # noqa: B950
+        torch.nn.functional.grid_sample: lambda input, grid, mode="bilinear", padding_mode="zeros", align_corners=None: -1,
         torch.nn.functional.group_norm: lambda input, num_groups, weight=None, bias=None, eps=1e-05: -1,
         torch.nn.functional.gumbel_softmax: lambda logits, tau=1, hard=False, eps=1e-10, dim=-1: -1,
         torch.nn.functional.hardshrink: lambda input, lambd=0.5: -1,
@@ -917,12 +917,12 @@ def get_testing_overrides() -> dict[Callable, Callable]:
             lambda input, target, margin=1.0, size_average=None, reduce=None, reduction="mean": -1
         ),
         torch.nn.functional.instance_norm: (
-            lambda input, running_mean=None, running_var=None, weight=None, bias=None, use_input_stats=True, momentum=0.1, eps=1e-05: -1  # noqa: B950
+            lambda input, running_mean=None, running_var=None, weight=None, bias=None, use_input_stats=True, momentum=0.1, eps=1e-05: -1
         ),
         torch.nn.functional.interpolate: (
-            lambda input, size=None, scale_factor=None, mode="nearest", align_corners=None, recompute_scale_factor=None, antialias=False: -1  # noqa: B950
+            lambda input, size=None, scale_factor=None, mode="nearest", align_corners=None, recompute_scale_factor=None, antialias=False: -1
         ),
-        torch.nn.functional.kl_div: lambda input, target, size_average=None, reduce=None, reduction="mean", log_target=False: -1,  # noqa: B950
+        torch.nn.functional.kl_div: lambda input, target, size_average=None, reduce=None, reduction="mean", log_target=False: -1,
         torch.nn.functional.l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", weight=None: -1,
         torch.nn.functional.layer_norm: lambda input, normalized_shape, weight=None, bias=None, eps=1e-05: -1,
         torch.nn.functional.leaky_relu: lambda input, negative_slope=0.01, inplace=False: -1,
@@ -954,12 +954,12 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.nn.functional.max_pool3d_with_indices: (
             lambda input, kernel_size, stride=None, padding=0, dilation=1, return_indices=False, ceil_mode=False: -1
         ),
-        torch.nn.functional.max_unpool1d: lambda input, indices, kernel_size, stride=None, padding=0, output_size=None: -1,  # noqa: B950
-        torch.nn.functional.max_unpool2d: lambda input, indices, kernel_size, stride=None, padding=0, output_size=None: -1,  # noqa: B950
-        torch.nn.functional.max_unpool3d: lambda input, indices, kernel_size, stride=None, padding=0, output_size=None: -1,  # noqa: B950
+        torch.nn.functional.max_unpool1d: lambda input, indices, kernel_size, stride=None, padding=0, output_size=None: -1,
+        torch.nn.functional.max_unpool2d: lambda input, indices, kernel_size, stride=None, padding=0, output_size=None: -1,
+        torch.nn.functional.max_unpool3d: lambda input, indices, kernel_size, stride=None, padding=0, output_size=None: -1,
         torch.nn.functional.mse_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", weight=None: -1,
         torch.nn.functional.multi_head_attention_forward: (
-            lambda query, key, value, embed_dim_to_check, num_heads, in_proj_weight, in_proj_bias, bias_k, bias_v, add_zero_attn, dropout_p, out_proj_weight, out_proj_bias, training=True, key_padding_mask=None, need_weights=True, attn_mask=None, use_separate_proj_weight=False, q_proj_weight=None, k_proj_weight=None, v_proj_weight=None, static_k=None, static_v=None, average_attn_weights=None, is_causal=False: -1  # noqa: B950
+            lambda query, key, value, embed_dim_to_check, num_heads, in_proj_weight, in_proj_bias, bias_k, bias_v, add_zero_attn, dropout_p, out_proj_weight, out_proj_bias, training=True, key_padding_mask=None, need_weights=True, attn_mask=None, use_separate_proj_weight=False, q_proj_weight=None, k_proj_weight=None, v_proj_weight=None, static_k=None, static_v=None, average_attn_weights=None, is_causal=False: -1
         ),
         torch.nn.functional.multi_margin_loss: (
             lambda input, target, p=1, margin=1.0, weight=None, size_average=None, reduce=None, reduction="mean": -1
@@ -978,20 +978,20 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.nn.functional.pad: lambda input, pad, mode="constant", value=0: -1,
         torch.nn.functional.pairwise_distance: lambda x1, x2, p=2.0, eps=1e-06, keepdim=False: -1,
         torch.nn.functional.poisson_nll_loss: (
-            lambda input, target, log_input=True, full=False, size_average=None, eps=1e-08, reduce=None, reduction="mean": -1  # noqa: B950
+            lambda input, target, log_input=True, full=False, size_average=None, eps=1e-08, reduce=None, reduction="mean": -1
         ),
         torch.nn.functional.prelu: lambda input, weight: -1,
         torch.nn.functional.relu: lambda input, inplace=False: -1,
         torch.nn.functional.relu6: lambda input, inplace=False: -1,
         torch.nn.functional.rms_norm: lambda input, normalized_shape, weight=None, eps=1e-6: -1,
-        torch.nn.functional.rrelu: lambda input, lower=0.125, upper=0.3333333333333333, training=False, inplace=False: -1,  # noqa: B950
+        torch.nn.functional.rrelu: lambda input, lower=0.125, upper=0.3333333333333333, training=False, inplace=False: -1,
         torch.nn.functional.selu: lambda input, inplace=False: -1,
         torch.nn.functional.silu: lambda input, inplace=False: -1,
         torch.nn.functional.mish: lambda input, inplace=False: -1,
         torch.nn.functional.scaled_dot_product_attention: lambda query, key, value, attn_mask=None, dropout_p=0.0: -1,
-        torch.nn.functional.smooth_l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", beta=1.0: -1,  # noqa: B950
+        torch.nn.functional.smooth_l1_loss: lambda input, target, size_average=None, reduce=None, reduction="mean", beta=1.0: -1,
         torch.nn.functional.huber_loss: lambda input, target, reduction="mean", delta=1.0, weight=None: -1,
-        torch.nn.functional.soft_margin_loss: lambda input, target, size_average=None, reduce=None, reduction="mean": -1,  # noqa: B950
+        torch.nn.functional.soft_margin_loss: lambda input, target, size_average=None, reduce=None, reduction="mean": -1,
         torch.nn.functional.softmax: lambda input, dim=None, _stacklevel=3, dtype=None: -1,
         torch.nn.functional.softmin: lambda input, dim=None, _stacklevel=3, dtype=None: -1,
         torch.nn.functional.softplus: lambda input, beta=1, threshold=20: -1,
@@ -1000,7 +1000,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.nn.functional.tanhshrink: lambda input: -1,
         torch.nn.functional.threshold: lambda input, threshold, value, inplace=False: -1,
         torch.nn.functional.triplet_margin_loss: (
-            lambda anchor, positive, negative, margin=1.0, p=2, eps=1e-06, swap=False, size_average=None, reduce=None, reduction="mean": -1  # noqa: B950
+            lambda anchor, positive, negative, margin=1.0, p=2, eps=1e-06, swap=False, size_average=None, reduce=None, reduction="mean": -1
         ),
         torch.nn.functional.triplet_margin_with_distance_loss: (
             lambda anchor, positive, negative, *, distance_function=None, margin=1.0, swap=False, reduction="mean": -1
@@ -1009,7 +1009,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.nn.init.uniform_: lambda tensor, a=0.0, b=1.0, generator=None: -1,
         torch.nn.init.normal_: lambda tensor, mean=0.0, std=1.0, generator=None: -1,
         torch.nn.init.constant_: lambda tensor, val: -1,
-        torch.nn.init.kaiming_uniform_: lambda tensor, a=0, mode="fan_in", nonlinearity="leaky_relu", generator=None: -1,  # noqa: B950
+        torch.nn.init.kaiming_uniform_: lambda tensor, a=0, mode="fan_in", nonlinearity="leaky_relu", generator=None: -1,
         torch.nonzero: lambda input, as_tuple=False: -1,
         torch.nonzero_static: lambda input, *, size, fill_value=-1: -1,
         torch.argwhere: lambda input: -1,
@@ -1056,10 +1056,10 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.quantize_per_tensor_dynamic: lambda input, dtype, reduce_range: -1,
         torch.quantized_batch_norm: lambda input, weight, bias, mean, var, eps, output_scale, output_zero_point: -1,
         torch.quantized_gru_cell: (
-            lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1  # noqa: B950
+            lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1
         ),
         torch.quantized_lstm_cell: (
-            lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1  # noqa: B950
+            lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1
         ),
         torch.quantized_max_pool1d: (
             lambda input, kernel_size, stride=(), padding=(0,), dilation=(
@@ -1080,10 +1080,10 @@ def get_testing_overrides() -> dict[Callable, Callable]:
             ), ceil_mode=False: -1
         ),
         torch.quantized_rnn_relu_cell: (
-            lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1  # noqa: B950
+            lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1
         ),
         torch.quantized_rnn_tanh_cell: (
-            lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1  # noqa: B950
+            lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih, col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1
         ),
         torch.rad2deg: lambda input, out=None: -1,
         torch.ravel: lambda input: -1,
@@ -1099,9 +1099,9 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.repeat_interleave: lambda input, dim=None: -1,
         torch.reshape: lambda input, shape: -1,
         torch.rms_norm: lambda input, normalized_shape, weight=None, eps=1e-6: -1,
-        torch.rnn_relu: lambda input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first: -1,  # noqa: B950
+        torch.rnn_relu: lambda input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first: -1,
         torch.rnn_relu_cell: lambda input, hx, w_ih, w_hh, b_ih=None, b_hh=None: -1,
-        torch.rnn_tanh: lambda input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first: -1,  # noqa: B950
+        torch.rnn_tanh: lambda input, hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first: -1,
         torch.rnn_tanh_cell: lambda input, hx, w_ih, w_hh, b_ih=None, b_hh=None: -1,
         torch.roll: lambda input, shifts, dims=None: -1,
         torch.rot90: lambda input, k=1, dims=(0, 1): -1,
@@ -1116,7 +1116,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.scatter_add: lambda input, dim, index, src: -1,
         torch.scatter_reduce: lambda input, dim, index, src, reduce, include_self=True: -1,
         torch.searchsorted: lambda sorted_sequence, input, out_int32=False, right=False, out=None: -1,
-        torch._segment_reduce: lambda data, reduce="max", lengths=None, indices=None, offsets=None, axis=0, unsafe=False: -1,  # noqa: B950
+        torch._segment_reduce: lambda data, reduce="max", lengths=None, indices=None, offsets=None, axis=0, unsafe=False: -1,
         torch.select: lambda input, dim, index: -1,
         torch.select_scatter: lambda input, src, dim, index: -1,
         torch.slice_inverse: lambda input, src, dim=0, start=None, end=None, step=1: -1,
@@ -1147,7 +1147,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.std: lambda input, dim=None: -1,
         torch.std_mean: lambda input, dim=None: -1,
         torch.stft: (
-            lambda input, n_fft, hop_length=None, win_length=None, window=None, center=True, pad_mode="reflect", normalized=False, onesided=True, return_complex=None, align_to_window=None: -1  # noqa: B950
+            lambda input, n_fft, hop_length=None, win_length=None, window=None, center=True, pad_mode="reflect", normalized=False, onesided=True, return_complex=None, align_to_window=None: -1
         ),
         torch.sub: lambda input, other, out=None: -1,
         torch.subtract: lambda input, other, out=None: -1,
@@ -1252,7 +1252,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.linalg.solve_triangular: lambda input, B, upper, left=True, unitriangular=False: -1,
         torch.tril: lambda input, diagonal=0, out=None: -1,
         torch.triplet_margin_loss: (
-            lambda anchor, positive, negative, margin=1.0, p=2, eps=1e-06, swap=False, size_average=None, reduce=None, reduction="mean": -1  # noqa: B950
+            lambda anchor, positive, negative, margin=1.0, p=2, eps=1e-06, swap=False, size_average=None, reduce=None, reduction="mean": -1
         ),
         torch.triu: lambda input, diagonal=0, out=None: -1,
         torch.true_divide: lambda input, other: -1,
@@ -1274,7 +1274,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.where: lambda condition, x=None, y=None: -1,
         torch._wrapped_linear_prepack: lambda weight, weight_scale, weight_zero_point, bias : -1,
         torch._wrapped_quantized_linear_prepacked: (
-            lambda input, input_scale, input_zero_point, prepacked, out_scale, out_zero_point, out_channel : -1  # noqa: B950
+            lambda input, input_scale, input_zero_point, prepacked, out_scale, out_zero_point, out_channel : -1
         ),
         torch.zeros_like: lambda input, dtype=None, layout=None, device=None, requires_grad=False: -1,
         torch._fw_primal_copy: lambda self, level: -1,
@@ -1587,7 +1587,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
                 dist.scatter: lambda tensor, scatter_list=None, src=None, group=None, async_op=False, group_src=None: -1,
                 dist.reduce_scatter: lambda output, input_list, op=None, group=None, async_op=False: -1,
                 dist.reduce_scatter_tensor: lambda output, input, op=None, group=None, async_op=False: -1,
-                dist.all_to_all_single: lambda output, input, output_split_sizes=None, input_split_sizes=None, group=None, async_op=False: -1,  # noqa: B950
+                dist.all_to_all_single: lambda output, input, output_split_sizes=None, input_split_sizes=None, group=None, async_op=False: -1,
                 dist.all_to_all: lambda output_tensor_list, input_tensor_list, group=None, async_op=False: -1,
                 dist.isend: lambda tensor, dst=None, group=None, tag=0, group_dst=None: -1,
                 dist.irecv: lambda tensor, src=None, group=None, tag=0, group_src=None: -1,

--- a/torch/package/_importlib.py
+++ b/torch/package/_importlib.py
@@ -62,8 +62,8 @@ def _calc___package__(globals):
     spec = globals.get("__spec__")
     if package is not None:
         if spec is not None and package != spec.parent:
-            _warnings.warn(  # noqa: G010
-                f"__package__ != __spec__.parent ({package!r} != {spec.parent!r})",  # noqa: G004
+            _warnings.warn(
+                f"__package__ != __spec__.parent ({package!r} != {spec.parent!r})",
                 ImportWarning,
                 stacklevel=3,
             )
@@ -71,7 +71,7 @@ def _calc___package__(globals):
     elif spec is not None:
         return spec.parent
     else:
-        _warnings.warn(  # noqa: G010
+        _warnings.warn(
             "can't resolve package from __spec__ or __package__, "
             "falling back on __name__ and __path__",
             ImportWarning,

--- a/torch/quantization/fx/__init__.py
+++ b/torch/quantization/fx/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""
 This file is in the process of migration to `torch/ao/quantization`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/quantization/fx/quantization_patterns.py
+++ b/torch/quantization/fx/quantization_patterns.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F401
 r"""
 This file is in the process of migration to `torch/ao/quantization`, and
 is kept here for compatibility while the migration process is ongoing.

--- a/torch/sparse/_triton_ops.py
+++ b/torch/sparse/_triton_ops.py
@@ -552,28 +552,28 @@ def scatter_mm_meta(
                 TILE_N = 16
                 GROUP_SIZE = 4
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
             elif (Ms, Ks) == (32, 32):
                 SPLIT_N = 2
                 TILE_M = 32
                 TILE_N = 16
                 GROUP_SIZE = 4
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
             elif (Ms, Ks) == (64, 64):
                 SPLIT_N = 1
                 TILE_M = 32
                 TILE_N = 32
                 GROUP_SIZE = 4
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
             elif (Ms, Ks) == (128, 128):
                 SPLIT_N = 1
                 TILE_M = 32
                 TILE_N = 32
                 GROUP_SIZE = 2
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
         elif (M, K, N) == (512,) * 3:
             if (Ms, Ks) == (16, 16):
                 SPLIT_N = 8
@@ -581,28 +581,28 @@ def scatter_mm_meta(
                 TILE_N = 64
                 GROUP_SIZE = 2
                 num_stages = 1
-                num_warps = 2  # noqa: E225,E231,E702
+                num_warps = 2  # noqa: E225, E231
             elif (Ms, Ks) == (32, 32):
                 SPLIT_N = 8
                 TILE_M = 32
                 TILE_N = 64
                 GROUP_SIZE = 4
                 num_stages = 1
-                num_warps = 2  # noqa: E225,E231,E702
+                num_warps = 2  # noqa: E225, E231
             elif (Ms, Ks) == (64, 64):
                 SPLIT_N = 4
                 TILE_M = 32
                 TILE_N = 128
                 GROUP_SIZE = 4
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
             elif (Ms, Ks) == (128, 128):
                 SPLIT_N = 8
                 TILE_M = 64
                 TILE_N = 64
                 GROUP_SIZE = 4
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
         elif (M, K, N) == (1024,) * 3:
             if (Ms, Ks) == (16, 16):
                 SPLIT_N = 4
@@ -610,35 +610,35 @@ def scatter_mm_meta(
                 TILE_N = 128
                 GROUP_SIZE = 2
                 num_stages = 1
-                num_warps = 1  # noqa: E225,E231,E702
+                num_warps = 1  # noqa: E225, E231
             elif (Ms, Ks) == (32, 32):
                 SPLIT_N = 8
                 TILE_M = 32
                 TILE_N = 64
                 GROUP_SIZE = 2
                 num_stages = 1
-                num_warps = 1  # noqa: E225,E231,E702
+                num_warps = 1  # noqa: E225, E231
             elif (Ms, Ks) == (64, 64):
                 SPLIT_N = 16
                 TILE_M = 64
                 TILE_N = 64
                 GROUP_SIZE = 4
                 num_stages = 1
-                num_warps = 2  # noqa: E225,E231,E702
+                num_warps = 2  # noqa: E225, E231
             elif (Ms, Ks) == (128, 128):
                 SPLIT_N = 16
                 TILE_M = 64
                 TILE_N = 64
                 GROUP_SIZE = 4
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
             elif (Ms, Ks) == (256, 256):
                 SPLIT_N = 16
                 TILE_M = 64
                 TILE_N = 64
                 GROUP_SIZE = 2
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
         elif (M, K, N) == (2048,) * 3:
             if (Ms, Ks) == (16, 16):
                 SPLIT_N = 4
@@ -646,35 +646,35 @@ def scatter_mm_meta(
                 TILE_N = 128
                 GROUP_SIZE = 8
                 num_stages = 1
-                num_warps = 1  # noqa: E225,E231,E702
+                num_warps = 1  # noqa: E225, E231
             elif (Ms, Ks) == (32, 32):
                 SPLIT_N = 4
                 TILE_M = 32
                 TILE_N = 64
                 GROUP_SIZE = 4
                 num_stages = 1
-                num_warps = 1  # noqa: E225,E231,E702
+                num_warps = 1  # noqa: E225, E231
             elif (Ms, Ks) == (64, 64):
                 SPLIT_N = 4
                 TILE_M = 64
                 TILE_N = 128
                 GROUP_SIZE = 4
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
             elif (Ms, Ks) == (128, 128):
                 SPLIT_N = 8
                 TILE_M = 64
                 TILE_N = 64
                 GROUP_SIZE = 4
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
             elif (Ms, Ks) == (256, 256):
                 SPLIT_N = 4
                 TILE_M = 64
                 TILE_N = 64
                 GROUP_SIZE = 2
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
         elif (M, K, N) == (4096,) * 3:
             if (Ms, Ks) == (16, 16):
                 SPLIT_N = 2
@@ -682,21 +682,21 @@ def scatter_mm_meta(
                 TILE_N = 256
                 GROUP_SIZE = 2
                 num_stages = 1
-                num_warps = 2  # noqa: E225,E231,E702
+                num_warps = 2  # noqa: E225, E231
             elif (Ms, Ks) == (32, 32):
                 SPLIT_N = 2
                 TILE_M = 32
                 TILE_N = 64
                 GROUP_SIZE = 2
                 num_stages = 1
-                num_warps = 1  # noqa: E225,E231,E702
+                num_warps = 1  # noqa: E225, E231
             elif (Ms, Ks) == (64, 64):
                 SPLIT_N = 2
                 TILE_M = 64
                 TILE_N = 128
                 GROUP_SIZE = 2
                 num_stages = 1
-                num_warps = 4  # noqa: E225,E231,E702
+                num_warps = 4  # noqa: E225, E231
 
     if SPLIT_N is None:
         # Assume NVIDIA GeForce RTX 2060 SUPER:

--- a/torch/sparse/semi_structured.py
+++ b/torch/sparse/semi_structured.py
@@ -77,7 +77,7 @@ class SparseSemiStructuredTensor(torch.Tensor):
     __slots__ = ["packed", "meta", "packed_t", "meta_t", "compressed_swizzled_bitmask"]
 
     @staticmethod
-    def __new__(  # noqa: PYI034
+    def __new__(
         cls,
         shape: torch.Size,
         packed: torch.Tensor | None,

--- a/torch/testing/_comparison.py
+++ b/torch/testing/_comparison.py
@@ -368,7 +368,7 @@ def make_tensor_mismatch_msg(
     )
 
 
-class UnsupportedInputs(Exception):  # noqa: B903
+class UnsupportedInputs(Exception):
     """Exception to be raised during the construction of a :class:`Pair` in case it doesn't support the inputs."""
 
 
@@ -1319,7 +1319,7 @@ def not_close_error_metas(
         )
     except ErrorMeta as error_meta:
         # Explicitly raising from None to hide the internal traceback
-        raise error_meta.to_error() from None  # noqa: RSE102
+        raise error_meta.to_error() from None
 
     error_metas: list[ErrorMeta] = []
     for pair in pairs:

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1178,7 +1178,7 @@ class ops(_TestParametrizer):
                         except Exception as e:
                             tracked_input = get_tracked_input()
                             if PRINT_REPRO_ON_FAILURE and tracked_input is not None:
-                                e_tracked = Exception(  # noqa: TRY002
+                                e_tracked = Exception(
                                     f"{str(e)}\n\nCaused by {tracked_input.type_desc} "
                                     f"at index {tracked_input.index}: "
                                     f"{_serialize_sample(tracked_input.val)}"

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -970,7 +970,7 @@ class MultiProcessTestCase(TestCase):
         try:
             getattr(self, test_name)()
         except unittest.SkipTest as se:
-            logger.info(  # noqa: G200
+            logger.info(
                 "Process %s skipping test %s for following reason: %s",
                 self.rank,
                 test_name,
@@ -1309,7 +1309,7 @@ def spawn_threads_and_init_comms(
             )
             try:
                 callback()
-            except BaseException as ex:  # noqa: B036
+            except BaseException as ex:
                 # Exceptions are handled in MultiThreadedTestCase
                 MultiThreadedTestCase.exception_queue.put((rank, sys.exc_info()))
                 ProcessLocalGroup.exception_handle(
@@ -1470,7 +1470,7 @@ class MultiThreadedTestCase(TestCase):
 
         try:
             getattr(self, test_name)()
-        except BaseException as ex:  # noqa: B036
+        except BaseException as ex:
             self.exception_queue.put((rank, sys.exc_info()))
             ProcessLocalGroup.exception_handle(
                 ex
@@ -1841,7 +1841,7 @@ class MultiProcContinuousTest(TestCase):
             try:
                 cls._run_test_given_id(test_id)
                 completion_queue.put(test_id)
-            except BaseException as ex:  # noqa: B036
+            except BaseException as ex:
                 if isinstance(ex, SystemExit):
                     # Get exit code from the process
                     exit_code = getattr(ex, "code", None)
@@ -1906,7 +1906,7 @@ class MultiProcContinuousTest(TestCase):
             cls.processes.append(process)
             cls.task_queues.append(task_queue)
             cls.completion_queues.append(completion_queue)
-            logger.debug("Started process %s with pid %s", rank, process.pid)  # noqa: UP031
+            logger.debug("Started process %s with pid %s", rank, process.pid)
 
     @classmethod
     def _get_world_size(cls, device_type: str) -> int:
@@ -2063,7 +2063,7 @@ class MultiProcContinuousTest(TestCase):
                     if isinstance(rv, BaseException):
                         logger.warning(
                             f"Detected failure from Rank {i} in: {self.id()}, "  # noqa: G004
-                            f"skipping rest of tests in Test class: {self.__class__.__name__}"  # noqa: G004
+                            f"skipping rest of tests in Test class: {self.__class__.__name__}"
                         )
                         self.__class__.poison_pill = True
                         deferred_exception = rv

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -50,11 +50,11 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._utils import wrapper_set_seed
 
-import torch._refs as refs  # noqa: F401
+import torch._refs as refs
 import torch._refs.nn.functional
 import torch._refs.special
 import torch._refs.linalg
-import torch._prims as prims  # noqa: F401
+import torch._prims as prims
 from torch.utils import _pytree as pytree
 
 
@@ -13624,7 +13624,7 @@ op_db: list[OpInfo] = [
                # undefined value tensor:
                #   File "<string>", line 3
                # def the_method(i0):
-               #     return torch.cov(i0, correction=0, fweights=None, aweights=tensor([0.0518, 0.4681], dtype=torch.float32, requires_grad=True)) # noqa: B950
+               #     return torch.cov(i0, correction=0, fweights=None, aweights=tensor([0.0518, 0.4681], dtype=torch.float32, requires_grad=True))
                #                                                                ~~~~~~ <--- HERE
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit'),
                DecorateInfo(toleranceOverride({torch.float16: tol(atol=8e-3, rtol=1.4e-3)}),
@@ -14369,7 +14369,7 @@ op_db: list[OpInfo] = [
                # see discussion : https://github.com/pytorch/pytorch/issues/56660
                # RuntimeError:
                # Arguments for call are not valid.
-               DecorateInfo(unittest.skip("Skipped!"), 'TestJit', 'test_variant_consistency_jit', dtypes=(torch.float32, torch.complex64)),  # noqa: B950
+               DecorateInfo(unittest.skip("Skipped!"), 'TestJit', 'test_variant_consistency_jit', dtypes=(torch.float32, torch.complex64)),
                DecorateInfo(unittest.skip("Skipped!"), 'TestNNCOpInfo', 'test_nnc_correctness'),
                DecorateInfo(unittest.skip("Skipped!"), 'TestCudaFuserOpInfo'),
            ),
@@ -15521,8 +15521,8 @@ op_db: list[OpInfo] = [
            sample_inputs_func=sample_inputs_as_strided_scatter,
            error_inputs_func=error_inputs_as_strided_scatter,
            skips=(
-               DecorateInfo(unittest.skip('Works for int64, fails for everything else'), 'TestCommon', 'test_noncontiguous_samples'),  # noqa: B950
-               DecorateInfo(unittest.skip('Fails in most cases, passes on LAZY for some reason'), 'TestCommon', 'test_variant_consistency_eager'),  # noqa: B950
+               DecorateInfo(unittest.skip('Works for int64, fails for everything else'), 'TestCommon', 'test_noncontiguous_samples'),
+               DecorateInfo(unittest.skip('Fails in most cases, passes on LAZY for some reason'), 'TestCommon', 'test_variant_consistency_eager'),
                DecorateInfo(unittest.skip('Fails on cuda'), 'TestCommon', 'test_complex_half_reference_testing',
                             active_if=not TEST_WITH_ROCM),
                DecorateInfo(unittest.expectedFailure, 'TestBwdGradients', 'test_fn_grad'),

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1067,7 +1067,7 @@ def wait_for_process(p, timeout=None):
         else:
             p.kill()
         raise
-    except:  # noqa: B001,E722, copied from python core library
+    except:
         p.kill()
         raise
     finally:
@@ -2242,7 +2242,7 @@ def skipIfWindows(func=None, *, msg="test doesn't currently work on the Windows 
 
         @wraps(fn)
         def wrapper(*args, **kwargs):
-            if IS_WINDOWS:  # noqa: F821
+            if IS_WINDOWS:
                 raise unittest.SkipTest(reason)
             else:
                 return fn(*args, **kwargs)
@@ -2257,7 +2257,7 @@ def skipIfWindowsXPU(func=None, *, msg="test doesn't currently work on the Windo
 
         @wraps(fn)
         def wrapper(*args, **kwargs):
-            if IS_WINDOWS and torch.xpu.is_available():  # noqa: F821
+            if IS_WINDOWS and torch.xpu.is_available():
                 raise unittest.SkipTest(reason)
             else:
                 return fn(*args, **kwargs)
@@ -3545,7 +3545,7 @@ class TestCase(expecttest.TestCase):
                     def wrapper(*args, **kwargs):
                         try:
                             f(*args, **kwargs)
-                        except BaseException as e:  # noqa: B036
+                        except BaseException as e:
                             self.skipTest(e)
                         raise RuntimeError(f"Unexpected success, please remove `{file_name}`")
                     return wrapper
@@ -3567,7 +3567,7 @@ class TestCase(expecttest.TestCase):
                     def wrapper(*args, **kwargs):
                         try:
                             f(*args, **kwargs)
-                        except BaseException as e:  # noqa: B036
+                        except BaseException as e:
                             self.skipTest(e)
                         method = getattr(self, self._testMethodName)
                         if getattr(method, "__unittest_expecting_failure__", False):

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -5011,7 +5011,7 @@ class DistributedTest:
                     self.register_buffer("buffer", torch.randn(1, 2))
                     self.p = torch.nn.Parameter(torch.randn(10, 5), requires_grad=False)
 
-                def forward(self_, x):  # noqa: B902
+                def forward(self_, x):
                     params = self_.m.parameters()
                     for p in params:
                         self.assertEqual(mp_config.param_dtype, p.dtype)
@@ -7982,11 +7982,11 @@ class DistributedTest:
             }
 
             class ToyModel(torch.nn.Module):
-                def __init__(self_):  # noqa: B902
+                def __init__(self_):
                     super().__init__()
                     self_.lin = nn.Linear(10, 10, bias=False)
 
-                def forward(self_, x, expected_type):  # noqa: B902
+                def forward(self_, x, expected_type):
                     # Similar to scatter, the recursive to in the single-device
                     # case does not move tensors if they are in a custom type.
                     self.assertTrue(isinstance(x, expected_type))
@@ -8045,11 +8045,11 @@ class DistributedTest:
             b = torch.rand(batch, dim, device=self.rank)
 
             class NamedTupleModule(torch.nn.Module):
-                def __init__(self_):  # noqa: B902
+                def __init__(self_):
                     super().__init__()
                     self_.lin = nn.Linear(10, 1)
 
-                def forward(self_, input, expected_type):  # noqa: B902
+                def forward(self_, input, expected_type):
                     # Without NamedTuple support, this would be of type tuple.
                     self.assertTrue(
                         isinstance(input, expected_type),

--- a/torch/testing/_internal/distributed/rpc/jit/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/dist_autograd_test.py
@@ -19,7 +19,7 @@ def local_add(t1, t2):
 
 
 @torch.jit.script
-def remote_add(t1, t2, dst: str):  # noqa: E999
+def remote_add(t1, t2, dst: str):
     return rpc_async(dst, local_add, (t1, t2)).wait()
 
 

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -508,7 +508,7 @@ def two_args_two_kwargs(
 
 @torch.jit.script
 def assorted_types_args_kwargs(
-    tensor_arg: Tensor,  # noqa: E999
+    tensor_arg: Tensor,
     str_arg: str,
     int_arg: int,
     tensor_kwarg: Tensor = torch.tensor([2, 2]),
@@ -684,7 +684,7 @@ class JitRpcOpTest:
 
             @torch.jit.script
             def script_rpc_async_call_with_less_args(
-                dst_worker_name: str,  # noqa: E999
+                dst_worker_name: str,
             ):
                 args = (torch.tensor([1, 1]),)
                 kwargs = {}
@@ -729,7 +729,7 @@ class JitRpcOpTest:
         # Notice, kwargs matching happens during execution.
         @torch.jit.script
         def script_rpc_async_call_with_unexpected_kwarg(
-            dst_worker_name: str,  # noqa: E999
+            dst_worker_name: str,
         ):
             args = (torch.tensor([1, 1]), torch.tensor([2, 2]))
             kwargs = {"third_kwarg": torch.tensor([1, 1])}

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -3549,7 +3549,7 @@ class RpcTest(RpcAgentTestFixture, RpcTestCommon):
                 print(f"Got msg {msg}")
                 self.assertTrue("Original exception on remote side was" in msg)
                 self.assertTrue("CustomException" in msg)
-            except BaseException as e:  # noqa: B036
+            except BaseException as e:
                 raise RuntimeError(f"Failure - expected RuntimeError, got {e}") from e
             finally:
                 self.assertTrue(exc_caught)

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -10,7 +10,7 @@ import unittest
 from subprocess import CalledProcessError
 
 import torch
-import torch._inductor.async_compile  # noqa: F401 required to warm up AsyncCompile pools
+import torch._inductor.async_compile
 import torch._inductor.config as config
 from torch._inductor.codecache import CppCodeCache
 from torch._inductor.codegen.common import (
@@ -393,7 +393,7 @@ class MockGraphHandler(GraphLowering):
         self.constants = {}
         self.scheduler = None
 
-    def get_dtype(self, buffer_name: str) -> torch.dtype:  # noqa: ARG002
+    def get_dtype(self, buffer_name: str) -> torch.dtype:
         """Return default dtype for any buffer (for testing)."""
         return torch.float32
 

--- a/torch/testing/_internal/opinfo/definitions/sparse.py
+++ b/torch/testing/_internal/opinfo/definitions/sparse.py
@@ -3,9 +3,9 @@
 import os
 
 import torch
-from torch.testing import make_tensor  # noqa: F401
+from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import highest_precision_float
-from torch.testing._internal.opinfo.core import (  # noqa: F401
+from torch.testing._internal.opinfo.core import (
     BinaryUfuncInfo,
     ErrorInput,
     generate_elementwise_binary_tensors,

--- a/torch/testing/_internal/torchbind_impls.py
+++ b/torch/testing/_internal/torchbind_impls.py
@@ -96,7 +96,6 @@ def register_fake_operators():
 
 
 def register_fake_classes():
-    # noqa: F841
     @torch._library.register_fake_class("_TorchScriptTesting::_Foo")
     class FakeFoo:
         def __init__(self, x: int, y: int):

--- a/torch/utils/_config_typing.pyi
+++ b/torch/utils/_config_typing.pyi
@@ -22,7 +22,7 @@ Note that the import should happen before the call to install_config_module(), o
 """
 
 if not TYPE_CHECKING:  # noqa: PYI002
-    raise AssertionError("Do not use at runtime")  # noqa: W291
+    raise AssertionError("Do not use at runtime")
 
 def save_config() -> bytes: ...
 def save_config_portable(*, ignore_private_configs: bool = True) -> dict[str, Any]: ...

--- a/torch/utils/_contextlib.py
+++ b/torch/utils/_contextlib.py
@@ -50,7 +50,7 @@ def _wrap_generator(ctx_factory, func):
                         gen.close()
                     raise
 
-                except BaseException:  # noqa: B036
+                except BaseException:
                     # Propagate the exception thrown at us by the caller
                     with ctx_factory():
                         response = gen.throw(*sys.exc_info())

--- a/torch/utils/_pallas.py
+++ b/torch/utils/_pallas.py
@@ -85,7 +85,7 @@ def has_jax_tpu_backend() -> bool:
 def has_torch_tpu() -> bool:
     """Check if torch_tpu is installed and available."""
     try:
-        import torch_tpu.api  # noqa: F401  # type: ignore[import]
+        import torch_tpu.api  # type: ignore[import]
 
         # Verify hardware/runtime access
         torch_tpu.api.tpu_device()

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -808,8 +808,8 @@ class MinMaxBase(Expr, LatticeOp):  # type: ignore[misc]
                     if isinstance(a, other):
                         a0 = a.args[0]
                         if (  # noqa: E712
-                            (a0 > T) if other == Max else (a0 < T)  # noqa: E712
-                        ) == True:  # noqa: E712
+                            (a0 > T) if other == Max else (a0 < T)
+                        ) == True:
                             args[i] = cls.identity  # type: ignore[attr-defined]
 
         # remove redundant symbolic args
@@ -939,12 +939,12 @@ class MinMaxBase(Expr, LatticeOp):  # type: ignore[misc]
     _eval_is_algebraic = lambda s: _torf(i.is_algebraic for i in s.args)  # noqa: E731
     _eval_is_antihermitian = lambda s: _torf(  # noqa: E731
         i.is_antihermitian
-        for i in s.args  # noqa: E731
-    )  # noqa: E731
+        for i in s.args
+    )
     _eval_is_commutative = lambda s: _torf(  # noqa: E731
         i.is_commutative
-        for i in s.args  # noqa: E731
-    )  # noqa: E731
+        for i in s.args
+    )
     _eval_is_complex = lambda s: _torf(i.is_complex for i in s.args)  # noqa: E731
     _eval_is_composite = lambda s: _torf(i.is_composite for i in s.args)  # noqa: E731
     _eval_is_even = lambda s: _torf(i.is_even for i in s.args)  # noqa: E731
@@ -958,12 +958,12 @@ class MinMaxBase(Expr, LatticeOp):  # type: ignore[misc]
     _eval_is_noninteger = lambda s: _torf(i.is_noninteger for i in s.args)  # noqa: E731
     _eval_is_nonnegative = lambda s: _torf(  # noqa: E731
         i.is_nonnegative
-        for i in s.args  # noqa: E731
-    )  # noqa: E731
+        for i in s.args
+    )
     _eval_is_nonpositive = lambda s: _torf(  # noqa: E731
         i.is_nonpositive
-        for i in s.args  # noqa: E731
-    )  # noqa: E731
+        for i in s.args
+    )
     _eval_is_nonzero = lambda s: _torf(i.is_nonzero for i in s.args)  # noqa: E731
     _eval_is_odd = lambda s: _torf(i.is_odd for i in s.args)  # noqa: E731
     _eval_is_polar = lambda s: _torf(i.is_polar for i in s.args)  # noqa: E731
@@ -973,12 +973,12 @@ class MinMaxBase(Expr, LatticeOp):  # type: ignore[misc]
     _eval_is_real = lambda s: _torf(i.is_real for i in s.args)  # noqa: E731
     _eval_is_extended_real = lambda s: _torf(  # noqa: E731
         i.is_extended_real
-        for i in s.args  # noqa: E731
-    )  # noqa: E731
+        for i in s.args
+    )
     _eval_is_transcendental = lambda s: _torf(  # noqa: E731
         i.is_transcendental
-        for i in s.args  # noqa: E731
-    )  # noqa: E731
+        for i in s.args
+    )
     _eval_is_zero = lambda s: _torf(i.is_zero for i in s.args)  # noqa: E731
 
 

--- a/torch/utils/_sympy/singleton_int.py
+++ b/torch/utils/_sympy/singleton_int.py
@@ -80,14 +80,14 @@ def _eval_is_ge(a, b):
 
 
 @dispatch(SingletonInt, sympy.Integer)  # type: ignore[no-redef]
-def _eval_is_ge(a, b):  # noqa: F811
+def _eval_is_ge(a, b):
     if b <= 2:
         return sympy.true
     raise ValueError("Symbolic SingletonInt: Relation is indeterminate")
 
 
 @dispatch(SingletonInt, SingletonInt)  # type: ignore[no-redef]
-def _eval_is_ge(a, b):  # noqa: F811
+def _eval_is_ge(a, b):
     if a._val == b._val:
         if a._coeff >= b._coeff:
             return sympy.true

--- a/torch/utils/benchmark/utils/common.py
+++ b/torch/utils/benchmark/utils/common.py
@@ -223,7 +223,7 @@ class Measurement:
   {'Median: ' if n > 1 else ''}{self._median / time_scale:.2f} {time_unit}
   {iqr_filter}IQR:    {self.iqr / time_scale:.2f} {time_unit} ({self._p25 / time_scale:.2f} to {self._p75 / time_scale:.2f})
   {n} measurement{'s' if n > 1 else ''}, {self.number_per_run} runs {'per measurement,' if n > 1 else ','} {self.num_threads} thread{'s' if self.num_threads > 1 else ''}
-{newline.join(self._warnings)}""".strip()  # noqa: B950
+{newline.join(self._warnings)}""".strip()
 
         return "\n".join(l for l in repr_str.splitlines(keepends=False) if skip_line not in l)
 

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -225,7 +225,7 @@ class BackwardHook:
                 if self.input_tensors_index is None:
                     warnings.warn("Full backward hook is firing when gradients are computed "
                                   "with respect to module outputs since no inputs require gradients. See "
-                                  "https://docs.pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.register_full_backward_hook "  # noqa: B950
+                                  "https://docs.pytorch.org/docs/main/generated/torch.nn.Module.html#torch.nn.Module.register_full_backward_hook "
                                   "for more details.",
                                   stacklevel=5)
                     grad_inputs = self._pack_with_none([], [], self.n_inputs)

--- a/torch/xpu/graphs.py
+++ b/torch/xpu/graphs.py
@@ -136,14 +136,14 @@ class XPUGraph(_XPUGraph):
         r"""Returns the underlying xpuGraph_t. ``keep_graph`` must be True.
 
         XPU doesn't provide APIs to manipulate this object.
-        """  # noqa: B950
+        """
         return super().raw_xpu_graph()
 
     def raw_xpu_graph_exec(self) -> int:
         r"""Returns the underlying xpuGraphExec_t. ``instantiate`` must have been called if ``keep_graph`` is True, or ``capture_end`` must have been called if ``keep_graph`` is False. If you call ``instantiate()`` after ``raw_xpu_graph_exec()``, the previously returned xpuGraphExec_t will be destroyed. It is your responsibility not to use this object after destruction.
 
         XPU doesn't provide APIs to manipulate this object.
-        """  # noqa: B950
+        """
         return super().raw_xpu_graph_exec()
 
 
@@ -162,7 +162,7 @@ class graph:
         For effective memory sharing, if you pass a ``pool`` used by a previous capture and the previous capture
         used an explicit ``stream`` argument, you should pass the same ``stream`` argument to this capture.
 
-    """  # noqa: B950
+    """
 
     default_capture_stream: torch.xpu.Stream | None = None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #179997
* __->__ #179996
* #179995

Prepare for turning on RUF100 which checks for unused `noqa` markers

Authored with Claude.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @mcarilli @ptrblck @leslie-fang-intel @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98 @xmfan @aditvenk