### PR TITLE
Set LD_LIBRARY_PATH for valgrind in run_tests.sh

### DIFF
--- a/aten/tools/run_tests.sh
+++ b/aten/tools/run_tests.sh
@@ -55,6 +55,7 @@ run_if_exists cuda_allocator_test
 if [ "$VALGRIND" == "ON" ]; then
   # NB: As these tests are invoked by valgrind, let's leave them for now as it's
   # unclear if valgrind -> python -> gtest would work
+  export LD_LIBRARY_PATH="${CPP_TESTS_DIR}:${LD_LIBRARY_PATH}"
   valgrind --suppressions="$VALGRIND_SUP" --error-exitcode=1 "${CPP_TESTS_DIR}/basic" --gtest_filter='-*CUDA'
   if [[ -x ${CPP_TESTS_DIR}/tensor_interop_test ]]; then
     valgrind --suppressions="$VALGRIND_SUP" --error-exitcode=1 "${CPP_TESTS_DIR}/tensor_interop_test"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180003

The valgrind step runs build/bin/basic directly without setting
LD_LIBRARY_PATH, so the dynamic linker can't find libtorch.so even
though it was symlinked into build/bin/. The earlier pytest invocations
work because run_test.py sets up the library path.

Should fix CI errors that look like:
```
build/bin/basic: error while loading shared libraries: libtorch.so: cannot open shared object file: No such file or directory
```


Authored with Claude.