### PR TITLE
Vjp inline compile

### DIFF
--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -6855,21 +6855,27 @@ class GraphModule(torch.nn.Module):
 
         def wrapper_fn(x):
             a = x.cos() * 2
-            out, vjpfunc = torch.func.vjp(fn, a)
-            return vjpfunc
+            grad_val = torch.func.grad(fn)(a)
+            b = a.sin() * 2
+            out, vjpfunc = torch.func.vjp(fn, b)
+
+            return vjpfunc, grad_val
 
         x = torch.randn(3, 3)
 
         backend = EagerAndRecordGraphs()
-        result = torch.compile(wrapper_fn, backend=backend, fullgraph=False)(x)
-        ref = wrapper_fn(x)
+        result_vjpfunc, result_grad = torch.compile(
+            wrapper_fn, backend=backend, fullgraph=False
+        )(x)
+        ref_vjpfunc, ref_grad = wrapper_fn(x)
 
-        grad_result = result(torch.ones([]))
-        ref_grad = ref(torch.ones([]))
-        self.assertEqual(grad_result[0], ref_grad[0])
+        grad_result = result_vjpfunc(torch.ones([]))
+        ref_result = ref_vjpfunc(torch.ones([]))
 
-        # Ops before vjp should be captured in a compiled graph
-        self.assertGreaterEqual(len(backend.graphs), 1)
+        self.assertEqual(grad_result[0], ref_result[0])
+        self.assertEqual(result_grad, ref_grad)
+
+        self.assertEqual(len(backend.graphs), 1)
         if torch._dynamo.config.assume_static_by_default:
             self.assertExpectedInline(
                 backend.graphs[0].code.strip(),
@@ -6878,7 +6884,23 @@ def forward(self, L_x_ : torch.Tensor):
     l_x_ = L_x_
     cos = l_x_.cos();  l_x_ = None
     a = cos * 2;  cos = None
-    return (a,)""",
+    _saved_tensors_hooks_disable = torch._C._autograd._saved_tensors_hooks_disable("torch.func.{grad, vjp, jacrev, hessian} don't yet support saved tensor hooks. Please open an issue with your use case.");  _saved_tensors_hooks_disable = None
+    _grad_increment_nesting = torch._C._functorch._grad_increment_nesting();  _grad_increment_nesting = None
+    diff_args = torch._C._functorch._wrap_for_grad(a, 1)
+    set_inplace_requires_grad_allowed = torch._C._functorch.set_inplace_requires_grad_allowed(True);  set_inplace_requires_grad_allowed = None
+    _set_tensor_requires_grad = torch._functorch.eager_transforms._set_tensor_requires_grad(diff_args);  _set_tensor_requires_grad = None
+    set_inplace_requires_grad_allowed_1 = torch._C._functorch.set_inplace_requires_grad_allowed(False);  set_inplace_requires_grad_allowed_1 = None
+    sin = diff_args.sin()
+    output = sin.sum();  sin = None
+    _autograd_grad = torch._functorch.eager_transforms._autograd_grad((output,), [diff_args], create_graph = True);  diff_args = None
+    grad_input = _autograd_grad[0];  _autograd_grad = None
+    grad_input_1 = torch._C._functorch._unwrap_for_grad(grad_input, 1);  grad_input = None
+    output_1 = torch._C._functorch._unwrap_for_grad(output, 1);  output = output_1 = None
+    _grad_decrement_nesting = torch._C._functorch._grad_decrement_nesting();  _grad_decrement_nesting = None
+    _saved_tensors_hooks_enable = torch._C._autograd._saved_tensors_hooks_enable();  _saved_tensors_hooks_enable = None
+    sin_1 = a.sin();  a = None
+    b = sin_1 * 2;  sin_1 = None
+    return (b, grad_input_1)""",
             )
 
 

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -6833,6 +6833,54 @@ class GraphModule(torch.nn.Module):
         actual = opt(x)
         self.assertEqual(expected, actual)
 
+    def test_vjp_returning_fullgraph_errors(self):
+        def fn(x):
+            return x.sin().sum()
+
+        def wrapper_fn(x):
+            out, vjpfunc = torch.func.vjp(fn, x)
+            return vjpfunc
+
+        x = torch.randn(3, 3)
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            r"vjp.*closure.*TensorWrapper",
+        ):
+            torch.compile(wrapper_fn, backend="eager", fullgraph=True)(x)
+
+    def test_vjp_returning_graph_break(self):
+        def fn(x):
+            return x.sin().sum()
+
+        def wrapper_fn(x):
+            a = x.cos() * 2
+            out, vjpfunc = torch.func.vjp(fn, a)
+            return vjpfunc
+
+        x = torch.randn(3, 3)
+
+        backend = EagerAndRecordGraphs()
+        result = torch.compile(wrapper_fn, backend=backend, fullgraph=False)(x)
+        ref = wrapper_fn(x)
+
+        grad_result = result(torch.ones([]))
+        ref_grad = ref(torch.ones([]))
+        self.assertEqual(grad_result[0], ref_grad[0])
+
+        # Ops before vjp should be captured in a compiled graph
+        self.assertGreaterEqual(len(backend.graphs), 1)
+        if torch._dynamo.config.assume_static_by_default:
+            self.assertExpectedInline(
+                backend.graphs[0].code.strip(),
+                """\
+def forward(self, L_x_ : torch.Tensor):
+    l_x_ = L_x_
+    cos = l_x_.cos();  l_x_ = None
+    a = cos * 2;  cos = None
+    return (a,)""",
+            )
+
 
 class ActivationCheckpointingTests(torch._dynamo.test_case.TestCase):
     def _validate(self, fn, backend, *args, skip_check=False, fullgraph=True):

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -132,6 +132,13 @@ class TensorifyScalarRestartAnalysis(RestartAnalysis):
     pass
 
 
+class VjpWrappedOutputRestartAnalysis(RestartAnalysis):
+    """Raised when vjp's deferred backward closure leaks wrapped tensors as output.
+
+    On restart, the vjp call will graph break instead of being inlined.
+    """
+
+
 # Used (primarily for backends) to skip tracing the current frame
 # and all future invocations of it.
 # NOTE: this does NOT cause a graph break, and thus no graph break messages

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -1887,6 +1887,28 @@
       ]
     }
   ],
+  "GB4083": [
+    {
+      "Gb_type": "returning vjp wrapped tensor",
+      "Context": "node_names",
+      "Explanation": "vjp returns a closure (vjpfunc) that captures tensors still wrapped at a functorch level (TensorWrapper). Returning vjpfunc from a compiled region is not supported.",
+      "Hints": [
+        "Consume the vjp result inside the compiled function ",
+        "instead of returning it."
+      ]
+    }
+  ],
+  "GB5756": [
+    {
+      "Gb_type": "vjp wrapped tensor leaked as output",
+      "Context": "vjp call: {self.fn.__name__}",
+      "Explanation": "vjp returns a closure (vjpfunc) that captures tensors still wrapped at a functorch level (TensorWrapper). Returning vjpfunc from a compiled region is not supported. Graph breaking here to preserve partial acceleration.",
+      "Hints": [
+        "Consume the vjp result inside the compiled function ",
+        "instead of returning it."
+      ]
+    }
+  ],
   "GB0151": [
     {
       "Gb_type": "Unsupported inspect call",
@@ -2081,28 +2103,6 @@
       "Hints": [
         "Avoid accessing {name} of tensor subclass in torch.compile region",
         "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
-      ]
-    }
-  ],
-  "GB8770": [
-    {
-      "Gb_type": "returning functorch wrapped tensor",
-      "Context": "node_names",
-      "Explanation": "The result of a functorch transform (vjp/jvp/grad) cannot be returned from a compiled region.",
-      "Hints": [
-        "Consume the functorch transform result inside the compiled ",
-        "function instead of returning it."
-      ]
-    }
-  ],
-  "GB5378": [
-    {
-      "Gb_type": "functorch wrapped tensor leaked as output",
-      "Context": "transform: {self.fn.__name__}",
-      "Explanation": "This functorch transform produces tensors that are still wrapped at a functorch level (TensorWrapper). These cannot be included as compiled graph outputs because aot_autograd cannot access the storage of TensorWrapper tensors.",
-      "Hints": [
-        "Consume the functorch transform result inside the compiled ",
-        "function instead of returning it."
       ]
     }
   ],

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2084,6 +2084,28 @@
       ]
     }
   ],
+  "GB8770": [
+    {
+      "Gb_type": "returning functorch wrapped tensor",
+      "Context": "node_names",
+      "Explanation": "The result of a functorch transform (vjp/jvp/grad) cannot be returned from a compiled region.",
+      "Hints": [
+        "Consume the functorch transform result inside the compiled ",
+        "function instead of returning it."
+      ]
+    }
+  ],
+  "GB5378": [
+    {
+      "Gb_type": "functorch wrapped tensor leaked as output",
+      "Context": "transform: {self.fn.__name__}",
+      "Explanation": "This functorch transform produces tensors that are still wrapped at a functorch level (TensorWrapper). These cannot be included as compiled graph outputs because aot_autograd cannot access the storage of TensorWrapper tensors.",
+      "Hints": [
+        "Consume the functorch transform result inside the compiled ",
+        "function instead of returning it."
+      ]
+    }
+  ],
   "GB0164": [
     {
       "Gb_type": "Unsupported tensor subclass overridden attribute access",

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2546,7 +2546,7 @@ class OutputGraph(OutputGraphCommon):
     ) -> None:
         """Detect graph outputs that are still functorch-wrapped (TensorWrapper).
 
-        When vjpfunc or tensors derived from it leak as graph outputs, 
+        When vjpfunc or tensors derived from it leak as graph outputs,
         AOTAutograd cannot access TensorWrapper storage.
         """
         from .variables.tensor import TensorVariable
@@ -2558,7 +2558,7 @@ class OutputGraph(OutputGraphCommon):
             example_value = var.proxy.node.meta.get("example_value")
             if example_value is None:
                 continue
-            if torch._C._functorch.is_functorch_wrapped_tensor(example_value):
+            if torch._C._functorch.is_gradtrackingtensor(example_value):
                 wrapped_outputs.append(var.proxy.node.name)
 
         if not wrapped_outputs:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2541,6 +2541,55 @@ class OutputGraph(OutputGraphCommon):
                         restart_reason="source-less requires_grad_() intermediate leaked as output"
                     )
 
+    def _validate_no_vjp_wrapped_outputs(
+        self, rv: list["VariableTracker"], tx: "InstructionTranslatorBase"
+    ) -> None:
+        """Detect graph outputs that are still functorch-wrapped (TensorWrapper).
+
+        When vjpfunc or tensors derived from it leak as graph outputs, 
+        AOTAutograd cannot access TensorWrapper storage.
+        """
+        from .variables.tensor import TensorVariable
+
+        wrapped_outputs: list[str] = []
+        for i, var in enumerate(rv):
+            if not isinstance(var, TensorVariable):
+                continue
+            example_value = var.proxy.node.meta.get("example_value")
+            if example_value is None:
+                continue
+            if torch._C._functorch.is_functorch_wrapped_tensor(example_value):
+                wrapped_outputs.append(var.proxy.node.name)
+
+        if not wrapped_outputs:
+            return
+
+        node_names = ", ".join(wrapped_outputs)
+
+        if tx.one_graph:
+            unimplemented(
+                gb_type="returning vjp wrapped tensor",
+                context=node_names,
+                explanation=(
+                    "vjp returns a closure (vjpfunc) that captures tensors "
+                    "still wrapped at a functorch level (TensorWrapper). "
+                    "Returning vjpfunc from a compiled region is not "
+                    "supported."
+                ),
+                hints=[
+                    "Consume the vjp result inside the compiled function "
+                    "instead of returning it.",
+                ],
+            )
+        else:
+            tx.speculation_log.graph_break_on_vjp_wrapped_output = True
+            raise exc.VjpWrappedOutputRestartAnalysis(
+                restart_reason=(
+                    "vjp deferred backward closure leaked wrapped tensors "
+                    f"as graph outputs: {node_names}"
+                )
+            )
+
     def compile_and_call_fx_graph(
         self,
         tx: "InstructionTranslatorBase",
@@ -2576,6 +2625,8 @@ class OutputGraph(OutputGraphCommon):
             # Check if autograd.grad is used with outputs that require grad
             # This would cause double backward issues in aot_autograd
             self._validate_outputs_safe_for_autograd_nodes(rv, tx)
+
+            self._validate_no_vjp_wrapped_outputs(rv, tx)
 
             output_node = self.create_node(
                 "output",

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2552,7 +2552,7 @@ class OutputGraph(OutputGraphCommon):
         from .variables.tensor import TensorVariable
 
         wrapped_outputs: list[str] = []
-        for i, var in enumerate(rv):
+        for var in rv:
             if not isinstance(var, TensorVariable):
                 continue
             example_value = var.proxy.node.meta.get("example_value")

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2558,7 +2558,10 @@ class OutputGraph(OutputGraphCommon):
             example_value = var.proxy.node.meta.get("example_value")
             if example_value is None:
                 continue
-            if torch._C._functorch.is_gradtrackingtensor(example_value):
+            if (
+                torch._C._functorch.is_gradtrackingtensor(example_value)
+                and torch._C._functorch.maybe_get_level(example_value) == -2
+            ):
                 wrapped_outputs.append(var.proxy.node.name)
 
         if not wrapped_outputs:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -291,6 +291,10 @@ class SpeculationLog:
     # instead of tracing it. Set when we detect that such an intermediate
     # leaks as a graph output with requires_grad=True.
     graph_break_on_requires_grad_: bool = False
+    # If True, graph break at vjp instead of inlining it. Set when we detect
+    # that vjp's deferred backward closure leaks TensorWrapper tensors as
+    # graph outputs.
+    graph_break_on_vjp_wrapped_output: bool = False
 
     def restart(self) -> None:
         self.index = 0

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -3262,6 +3262,22 @@ class FunctorchHigherOrderVariable(UserFunctionVariable):
         args: Sequence[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
+        if tx.speculation_log.graph_break_on_vjp_wrapped_output:
+            unimplemented(
+                gb_type="vjp wrapped tensor leaked as output",
+                context=f"vjp call: {self.fn.__name__}",
+                explanation=(
+                    "vjp returns a closure (vjpfunc) that captures tensors "
+                    "still wrapped at a functorch level (TensorWrapper). "
+                    "Returning vjpfunc from a compiled region is not "
+                    "supported. Graph breaking here to preserve partial "
+                    "acceleration."
+                ),
+                hints=[
+                    "Consume the vjp result inside the compiled function "
+                    "instead of returning it.",
+                ],
+            )
         return super().call_function(tx, args, kwargs)
 
     def should_allow_nested_graph_breaks(self) -> bool:

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -3262,7 +3262,10 @@ class FunctorchHigherOrderVariable(UserFunctionVariable):
         args: Sequence[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        if tx.speculation_log.graph_break_on_vjp_wrapped_output:
+        if (
+            tx.speculation_log.graph_break_on_vjp_wrapped_output
+            and self.fn is torch._functorch.eager_transforms.vjp
+        ):
             unimplemented(
                 gb_type="vjp wrapped tensor leaked as output",
                 context=f"vjp call: {self.fn.__name__}",


### PR DESCRIPTION
Fixes #172026
Fixes #179510

When a user defines a function returning the vjp_fn from a torch.func.vjp call, the vjp_fn is properly returned as a callable in eager mode. When the function is compiled, Dynamo inlines the vjp implementation during tracing, which is correct when the vjp result is consumed within the compiled region. The failure occurs when the TensorWrapper tensors captured by vjp_fn's closure escape as graph outputs — these wrappers reference a grad nesting level that has already been decremented, and AOTAutograd's functionalization cannot access their storage.

The fix uses the RestartAnalysis pattern to optimistically trace through vjp, trusting that its result will be consumed within the compiled region. If wrapped tensors are detected in graph outputs at compile time (via is_gradtrackingtensor), a VjpWrappedOutputRestartAnalysis is raised. On retrace, any vjp call that in the region will graph-break, preserving partial acceleration for surrounding code. Other functorch transforms (e.g., grad, vmap) routed through FunctorchHigherOrderVariable are unaffected.

Tests verify: 
- returning vjp_fn with fullgraph=True raises Unsupported with an actionable message
- without fullgraph, the vjp graph-breaks while producing correct results matching eager mode
- other functorch transforms (grad) in the same function are still traced into the compiled graph and not erroneously graph-broken
- Existing tests already verify other functions compile (e.g. test_*_freevar_tensor)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98
