### PR TITLE
[aot_compile] Support aot_eager backend.

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -706,6 +706,25 @@ class TestAOTCompile(torch._inductor.test_case.TestCase):
             actual = compiled_fn(*inputs)
             self.assertEqual(expected, actual)
 
+    def test_aot_eager_backend(self):
+        def fn(x, y):
+            return x + y
+
+        compiled_fn = torch.compile(
+            fn, fullgraph=True, backend="aot_eager"
+        ).aot_compile(((torch.randn(3, 4), torch.randn(3, 4)), {}))
+        inputs = (torch.randn(3, 4), torch.randn(3, 4))
+        expected = fn(*inputs)
+        actual = compiled_fn(*inputs)
+        self.assertEqual(expected, actual)
+        compiled_fn.save_compiled_function(self.path())
+        torch._dynamo.reset()
+        with torch.compiler.set_stance("fail_on_recompile"):
+            with open(self.path(), "rb") as f:
+                compiled_fn = torch.compiler.load_compiled_function(f)
+            actual = compiled_fn(*inputs)
+            self.assertEqual(expected, actual)
+
     def test_decorated_function_with_functools_wrap_aot(self):
         def check_inputs(fn):
             @functools.wraps(fn)

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -387,12 +387,20 @@ def aot_compile_fullgraph(
             compiled_fn = backend(
                 backend_input.graph_module, backend_input.example_inputs
             )
-            # If Inductor backend is used, grab the compiled_fn from PrecompileContext
+            # If Inductor backend or AOTAutograd-based backend is used,
+            # wrap the compiled_fn for serialization.
             # TODO: this should be replaced once we make the backend return the SerializableCallable directly.
-            if isinstance(backend, torch._TorchCompileInductorWrapper) or (
-                hasattr(backend, "compiler_fn")
-                and isinstance(
-                    backend.compiler_fn, torch._dynamo.backends.common.AotAutograd
+            if (
+                isinstance(backend, torch._TorchCompileInductorWrapper)
+                or (
+                    hasattr(backend, "compiler_fn")
+                    and isinstance(
+                        backend.compiler_fn, torch._dynamo.backends.common.AotAutograd
+                    )
+                )
+                or (
+                    hasattr(compiled_fn, "serialize")
+                    and compiled_fn.serialize is not None
                 )
             ):
                 compiled_fn = BundledAOTAutogradSerializableCallable(compiled_fn)

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -36,6 +36,7 @@ from torch import _guards
 from torch._dynamo.output_graph import GraphCompileReason
 from torch._functorch import config as functorch_config
 from torch._functorch.compilers import ts_compile
+from torch._inductor.output_code import OutputCode
 
 from .common import aot_autograd
 from .registry import CompiledFn, CompilerFn, register_debug_backend as register_backend
@@ -261,6 +262,54 @@ def invoke_subgraph(
     )(gm, fake_tensor_inputs)
 
 
+@dataclasses.dataclass
+class AOTEagerOutputCode(OutputCode):
+    """
+    An OutputCode that wraps a GraphModule for eager-mode execution.
+
+    This allows non-inductor backends (like aot_eager) to participate in
+    the bundled autograd cache and aot_compile serialization flow.
+    """
+
+    gm: torch.fx.GraphModule | None = None
+    _serialized_gm: bytes | None = dataclasses.field(default=None, init=False)
+
+    def __call__(self, inputs: Any) -> Any:
+        assert self.gm is not None
+        return self.gm.forward(inputs)
+
+    def prepare_for_serialization(self) -> None:
+        from torch.fx._graph_pickler import GraphPickler, Options
+
+        assert self.gm is not None
+        for node in self.gm.graph.nodes:
+            node.meta.pop("nn_module_stack", None)
+            node.meta.pop("source_fn_stack", None)
+            node.meta.pop("example_value", None)
+
+        self._serialized_gm = GraphPickler.dumps(self.gm, Options(ops_filter=None))
+        self.gm = None
+
+    def post_compile(self, *args: Any, **kwargs: Any) -> None:
+        if self.gm is None and self._serialized_gm is not None:
+            from torch._subclasses import FakeTensorMode
+            from torch.fx._graph_pickler import GraphPickler
+            from torch.fx.experimental.symbolic_shapes import ShapeEnv
+            from torch.fx.graph import _BoxedCodeGen
+
+            fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+            gm = GraphPickler.loads(self._serialized_gm, fake_mode)
+            assert isinstance(gm, torch.fx.GraphModule)
+            self.gm = gm
+            assert isinstance(self.gm, torch.fx.GraphModule)
+            self.gm.graph.set_codegen(_BoxedCodeGen())
+            self.gm.recompile()
+            self._serialized_gm = None
+
+    def set_triton_bundle(self, triton_bundle: Any) -> None:
+        pass
+
+
 # used boxed call to discard inputs when they are no longer needed
 def boxed_nop(
     fx_g: torch.fx.GraphModule, example_inputs: list[torch.Tensor]
@@ -270,6 +319,11 @@ def boxed_nop(
     # Set the graph to use boxed codegen
     fx_g.graph.set_codegen(_BoxedCodeGen())
     fx_g.recompile()
+
+    if functorch_config.force_autograd_cache or functorch_config.bundled_autograd_cache:
+        result = AOTEagerOutputCode(gm=fx_g)
+        result._boxed_call = True  # type: ignore[attr-defined]
+        return result
 
     # Wrap the forward method in a function so we can set _boxed_call attribute
     forward_fn = fx_g.forward


### PR DESCRIPTION
Summary:

As title. We're making aot_compile publicly available to be used so for
the completeness reason (and trivial to support) we added a test to
ensure aot_eager backend can work well with .aot_compile()

Test Plan:

pytest test/dynamo/test_aot_compile.py

Reviewers:

Subscribers:

Tasks:

Tags:


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98