### PR TITLE
[FSDPV2] Make FSDP v2 and composable tests device-agnostic for PrivateUse1 backends

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -68,6 +68,7 @@ from torch.testing._internal.common_utils import (
     requires_cuda_p2p_access,
     run_tests,
     skip_but_pass_in_sandcastle_if,
+    TEST_CUDA,
     TEST_WITH_ROCM,
     TEST_XPU,
     xfailIf,
@@ -1645,6 +1646,7 @@ class TestFullyShardAllocFromPG(FSDPTest):
         super()._run(*args, **kwargs)
 
     @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(not TEST_CUDA, "NCCL log parsing requires CUDA")
     # The NCCL PG refuses to allocate tensors if multicast is unavailable, see
     # https://github.com/pytorch/pytorch/blob/503362d019b3782581492af7767945dbd75ca1c9/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L5634
     def test_fully_shard_alloc_from_pg(self):
@@ -1665,13 +1667,13 @@ class TestFullyShardAllocFromPG(FSDPTest):
         fully_shard(model)
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 16), device="cuda")
+        inp = torch.randint(0, model_args.vocab_size, (2, 16), device=device_type)
 
         loss = model(inp)
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             self.assertNotRegex(f.read(), self.MEMORY_REGISTER_RE)
@@ -1685,7 +1687,7 @@ class TestFullyShardAllocFromPG(FSDPTest):
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             self.assertRegex(f.read(), self.MEMORY_REGISTER_RE)
@@ -1730,13 +1732,13 @@ class TestFullyShardSymmMem(MultiProcContinuousTest):
 
     @property
     def device(self) -> torch.device:
-        return torch.device("cuda", self.rank)
+        return torch.device(device_type, self.rank)
 
     @parametrize("sum_reduction", [True, False])
     def test_fully_shard_symm_mem(self, sum_reduction: bool):
         torch.manual_seed(42 + self.rank)
-        device = torch.device("cuda", self.rank)
-        torch.cuda.set_device(device)
+        device = torch.device(device_type, self.rank)
+        torch.get_device_module(device_type).set_device(device)
         seq_len = 64
         model_args = ModelArgs()
         model_args.dim = 4096
@@ -1759,7 +1761,7 @@ class TestFullyShardSymmMem(MultiProcContinuousTest):
             loss.sum().backward()
 
         run()
-        torch.cuda.synchronize(device)
+        torch.accelerator.synchronize()
 
 
 instantiate_parametrized_tests(TestFullyShardSymmMem)
@@ -1794,6 +1796,7 @@ class TestFullyShardForceSumReduction(FSDPTest):
 
     # Test reduce-scatter only on plain FSDP on 2 GPUs
     @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(not TEST_CUDA, "NCCL log parsing requires CUDA")
     @unittest.skipIf(
         TEST_XPU, "Related environment variable is not supported with XCCL"
     )
@@ -1817,13 +1820,13 @@ class TestFullyShardForceSumReduction(FSDPTest):
         )
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 16), device="cuda")
+        inp = torch.randint(0, model_args.vocab_size, (2, 16), device=device_type)
 
         loss = model(inp)
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()
@@ -1840,7 +1843,7 @@ class TestFullyShardForceSumReduction(FSDPTest):
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()
@@ -1849,6 +1852,7 @@ class TestFullyShardForceSumReduction(FSDPTest):
 
     # Test both reduce-scatter and all-reduce on HSDP (DDP+FSDP) on 4 GPUs
     @skip_if_lt_x_gpu(4)
+    @unittest.skipIf(not TEST_CUDA, "NCCL log parsing requires CUDA")
     @unittest.skipIf(
         TEST_XPU, "Related environment variable is not supported with XCCL"
     )
@@ -1882,13 +1886,13 @@ class TestFullyShardForceSumReduction(FSDPTest):
         )
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.randint(0, model_args.vocab_size, (2, 16), device="cuda")
+        inp = torch.randint(0, model_args.vocab_size, (2, 16), device=device_type)
 
         loss = model(inp)
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()
@@ -1907,7 +1911,7 @@ class TestFullyShardForceSumReduction(FSDPTest):
         loss.sum().backward()
 
         torch.distributed.barrier()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
 
         with open(self.nccl_log_dir.name + "/nccl_log") as f:
             logs = f.read()

--- a/test/distributed/_composable/fsdp/test_fully_shard_dtensor.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_dtensor.py
@@ -57,7 +57,7 @@ def _tp_shard_fn(param):
 class TestFullyShardDTensor(FSDPTest):
     @property
     def world_size(self):
-        return min(4, torch.cuda.device_count())
+        return min(4, torch.accelerator.device_count())
 
     def _run_train_parity(
         self, model, ref_model, dp_pg, mesh=None, num_iters=5, mlp_dim=16

--- a/test/distributed/_composable/fsdp/test_fully_shard_memory.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_memory.py
@@ -12,6 +12,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TEST_CUDA,
     TEST_HPU,
+    TEST_PRIVATEUSE1,
     TEST_XPU,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -318,14 +319,14 @@ class TestFullyShardMemory(FSDPTest):
     def _get_peak_active_memory_mb(self) -> int:
         mem_stats = torch.get_device_module(device_type).memory_stats()
 
-        if TEST_CUDA or TEST_XPU:
+        if TEST_CUDA or TEST_XPU or TEST_PRIVATEUSE1:
             return round(mem_stats["active_bytes.all.peak"] / 1e6)
         if TEST_HPU:
             return round(mem_stats["MaxInUse"] / 1e6)
 
     def _get_curr_active_memory_mb(self) -> int:
         mem_stats = torch.get_device_module(device_type).memory_stats()
-        if TEST_CUDA or TEST_XPU:
+        if TEST_CUDA or TEST_XPU or TEST_PRIVATEUSE1:
             return round(mem_stats["active_bytes.all.current"] / 1e6)
         if TEST_HPU:
             return round(mem_stats["InUse"] / 1e6)

--- a/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_overlap.py
@@ -103,7 +103,7 @@ class TestFullyShardOverlap(FSDPTest):
             )
             with torch.get_device_module(device_type).stream(comm_stream):
                 torch.get_device_module(device_type)._sleep(
-                    int(comm_sleep_ms * get_cycles_per_ms())
+                    int(comm_sleep_ms * get_cycles_per_ms(device_type.type))
                 )
             torch.get_device_module(device_type).current_stream().wait_stream(
                 comm_stream
@@ -208,7 +208,7 @@ class TestFullyShardOverlap(FSDPTest):
 
         def delayed_all_gather(*args, **kwargs):
             torch.get_device_module(device_type)._sleep(
-                int(comm_sleep_ms * get_cycles_per_ms())
+                int(comm_sleep_ms * get_cycles_per_ms(device_type.type))
             )
             return orig_all_gather_into_tensor(*args, **kwargs)
 
@@ -262,14 +262,14 @@ class Matmul(torch.autograd.Function):
     def forward(ctx, input: torch.Tensor, weight: torch.Tensor, sleep_ms: int):
         ctx.save_for_backward(input, weight)
         ctx.sleep_ms = sleep_ms
-        torch.get_device_module(device_type)._sleep(int(sleep_ms * get_cycles_per_ms()))
+        torch.get_device_module(device_type)._sleep(int(sleep_ms * get_cycles_per_ms(device_type.type)))
         return input @ weight
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
         (input, weight) = ctx.saved_tensors
         torch.get_device_module(device_type)._sleep(
-            int(2 * ctx.sleep_ms * get_cycles_per_ms())
+            int(2 * ctx.sleep_ms * get_cycles_per_ms(device_type.type))
         )
         grad_input = grad_output @ weight.T
         grad_weight = input.T @ grad_output
@@ -338,7 +338,7 @@ class TestFullyShardPerParamMeshOverlap(FSDPTest):
             ds = delay_streams[reduce_scatter_group]
             ds.wait_event(rs_event)
             with device_module.stream(ds):
-                device_module._sleep(int(sleep_ms * get_cycles_per_ms()))
+                device_module._sleep(int(sleep_ms * get_cycles_per_ms(device_type.type)))
                 delayed_event = ds.record_event()
             return (rs_input, delayed_event, *rest)
 

--- a/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_state_dict.py
@@ -141,14 +141,14 @@ class TestFullyShardStateDictMultiProcess(FSDPTest):
             )
         else:
             model = model.cpu()
-            model = model.cuda()
+            model = model.to(device_type)
             self.assertTrue(
                 sd["weight"]._local_tensor.untyped_storage().data_ptr()
                 != model.weight._local_tensor.untyped_storage().data_ptr()
             )
 
         torch.manual_seed(42 + self.rank)
-        inp = torch.rand(mlp_dim, mlp_dim, device="cuda")
+        inp = torch.rand(mlp_dim, mlp_dim, device=device_type)
         for _ in range(5):
             optim.zero_grad()
             loss = model(inp).sum()

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -445,7 +445,12 @@ class TestFullyShard1DTrainingCore(FSDPTest):
             and offload_policy.pin_memory
         ):
             return
-        if test_device_type not in ("cuda", "hpu", "xpu", "cpu"):
+        valid_device_types = ("cuda", "hpu", "xpu", "cpu")
+        if hasattr(torch._C, "_get_privateuse1_backend_name"):
+            backend_name = torch._C._get_privateuse1_backend_name()
+            if backend_name != "privateuseone":
+                valid_device_types = valid_device_types + (backend_name,)
+        if test_device_type not in valid_device_types:
             raise AssertionError(f"Unexpected device type: {test_device_type}")
         torch.manual_seed(42)
         vocab_size = 1024

--- a/test/distributed/_composable/test_checkpoint.py
+++ b/test/distributed/_composable/test_checkpoint.py
@@ -26,7 +26,7 @@ class MemoryDelta(ContextDecorator):
     def __enter__(self):
         self.active_memory_enter = (
             torch.accelerator.memory_stats()["active_bytes.all.current"]
-            if self.device.type == "cuda" or self.device.type == "xpu"
+            if self.device.type in ("cuda", "xpu")
             else 0
         )
         return self
@@ -34,7 +34,7 @@ class MemoryDelta(ContextDecorator):
     def __exit__(self, *exc):
         self.active_memory_exit = (
             torch.accelerator.memory_stats()["active_bytes.all.current"]
-            if self.device.type == "cuda" or self.device.type == "xpu"
+            if self.device.type in ("cuda", "xpu")
             else 0
         )
 

--- a/test/distributed/_composable/test_replicate.py
+++ b/test/distributed/_composable/test_replicate.py
@@ -15,7 +15,7 @@ from torch.testing._internal.common_distributed import (
     MultiThreadedTestCase,
     skip_if_lt_x_gpu,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_XPU
+from torch.testing._internal.common_utils import run_tests, TEST_PRIVATEUSE1, TEST_XPU
 
 
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
@@ -133,6 +133,7 @@ class ReplicateTest(MultiProcContinuousTest):
 
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
+    @unittest.skipIf(TEST_PRIVATEUSE1, "Gloo does not support PrivateUse1 device tensors")
     def test_replicate_move_args_kwargs_to_device(self):
         class MyNet(nn.Module):
             def __init__(self) -> None:
@@ -153,6 +154,7 @@ class ReplicateTest(MultiProcContinuousTest):
 
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
+    @unittest.skipIf(TEST_PRIVATEUSE1, "Gloo does not support PrivateUse1 device tensors")
     def test_replicate_ignore_module(self):
         torch.accelerator.set_device_index(self.rank)
         # Seed ensures diff input and thus different local grads across ranks.
@@ -198,6 +200,7 @@ class ReplicateTest(MultiProcContinuousTest):
 
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
+    @unittest.skipIf(TEST_PRIVATEUSE1, "Gloo does not support PrivateUse1 device tensors")
     def test_replicate_device_id(self):
         model = Net()
         model_cuda = deepcopy(model).to(device_type)
@@ -234,6 +237,7 @@ class ReplicateTest(MultiProcContinuousTest):
 class ReplicateFullyShardInit(ReplicateTest):
     @skip_if_lt_x_gpu(2)
     @unittest.skipIf(TEST_XPU, "XPU does not support gloo backend")
+    @unittest.skipIf(TEST_PRIVATEUSE1, "Gloo does not support PrivateUse1 device tensors")
     def test_replicate_fully_shard_init(self):
         class ToyModel(nn.Module):
             def __init__(self, dim: int):

--- a/test/distributed/_composable/test_replicate_mixed_precision.py
+++ b/test/distributed/_composable/test_replicate_mixed_precision.py
@@ -547,7 +547,7 @@ class TestReplicateMixedPrecisionCasts(FSDPTestMultiThread):
             torch.bfloat16, torch.bfloat16, torch.bfloat16, True
         )
         model = Model()
-        inp = Input(torch.randn(2, 10).cuda())
+        inp = Input(torch.randn(2, 10).to(device_type))
 
         replicate(model, mp_policy=mp_policy)
         loss = model(inp).sum()

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -71,7 +71,7 @@ class TestReplicateForwardInputs(FSDPTestMultiThread):
 
     @skip_if_lt_x_gpu(1)
     def test_root_move_forward_input_to_device(self):
-        device = torch.device(device_type.type, 0)
+        device = torch.device(device_type.type, self.rank)
 
         class ParamlessModule(nn.Module):
             def forward(self, x: torch.Tensor, ys: tuple[torch.Tensor, ...]):
@@ -104,7 +104,7 @@ class TestReplicateRegisteredParams(FSDPTestMultiThread):
     @skip_if_lt_x_gpu(1)
     def test_param_registration_after_forward(self):
         """Tests the parameter registration after forward."""
-        device = torch.device(device_type.type, 0)
+        device = torch.device(device_type.type, self.rank)
         # Single Replicate group
         torch.manual_seed(42)
         model = MLP(3, device)
@@ -153,7 +153,7 @@ class TestReplicateRegisteredParams(FSDPTestMultiThread):
     @skip_if_lt_x_gpu(1)
     def test_param_registration_after_backward(self):
         """Tests the parameter registration after backward."""
-        device = torch.device(device_type.type, 0)
+        device = torch.device(device_type.type, self.rank)
         # Single Replicate group
         model = MLP(8, device)
         replicate(model)  # root only
@@ -367,7 +367,12 @@ class TestReplicate1DTrainingCore(FSDPTest):
             in (2, 3)
         ):
             return
-        if test_device_type not in ("cuda", "hpu", "xpu", "cpu"):
+        valid_device_types = ("cuda", "hpu", "xpu", "cpu")
+        if hasattr(torch._C, "_get_privateuse1_backend_name"):
+            backend_name = torch._C._get_privateuse1_backend_name()
+            if backend_name != "privateuseone":
+                valid_device_types = valid_device_types + (backend_name,)
+        if test_device_type not in valid_device_types:
             raise AssertionError(f"Unexpected device type: {test_device_type}")
         torch.manual_seed(42)
         vocab_size = 1024
@@ -406,13 +411,13 @@ class TestReplicate1DTrainingCore(FSDPTest):
 
         def delayed_all_gather(*args, **kwargs):
             torch.get_device_module(device_type)._sleep(
-                int(delay_in_ms * get_cycles_per_ms())
+                int(delay_in_ms * get_cycles_per_ms(device_type.type))
             )
             return orig_all_gather(*args, **kwargs)
 
         def delayed_reduce_scatter(*args, **kwargs):
             torch.get_device_module(device_type)._sleep(
-                int(delay_in_ms * get_cycles_per_ms())
+                int(delay_in_ms * get_cycles_per_ms(device_type.type))
             )
             return orig_reduce_scatter(*args, **kwargs)
 
@@ -435,12 +440,12 @@ class TestReplicate1DTrainingCore(FSDPTest):
                     losses.append(_model(inp).sum())
                     if _model is model and delay_after_forward:
                         torch.get_device_module(device_type)._sleep(
-                            int(delay_in_ms * get_cycles_per_ms())
+                            int(delay_in_ms * get_cycles_per_ms(device_type.type))
                         )
                     losses[-1].backward()
                     if _model is model and delay_before_optim:
                         torch.get_device_module(device_type)._sleep(
-                            int(delay_in_ms * get_cycles_per_ms())
+                            int(delay_in_ms * get_cycles_per_ms(device_type.type))
                         )
 
                 for param in ref_model.parameters():
@@ -488,7 +493,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
 
         root_loss = model(inp).sum()
         root_loss.backward()
-        torch.get_device_module(device_type)._sleep(int(100 * get_cycles_per_ms()))
+        torch.get_device_module(device_type)._sleep(int(100 * get_cycles_per_ms(device_type.type)))
         optim.step()
         optim.zero_grad()
         nonroot_loss = model[0](inp).sum()
@@ -642,7 +647,7 @@ class TestReplicate1DTrainingCore(FSDPTest):
             optim.step()
             # Sleep after the optimizer step to allow CPU to run ahead into the
             # next iteration's forward, exercising the post-optim stream sync
-            torch.get_device_module(device_type)._sleep(int(25 * get_cycles_per_ms()))
+            torch.get_device_module(device_type)._sleep(int(25 * get_cycles_per_ms(device_type.type)))
         for ref_loss, loss in zip(ref_losses, losses):
             self.assertEqual(ref_loss, loss)
 

--- a/test/distributed/_composable/test_replicate_with_fsdp.py
+++ b/test/distributed/_composable/test_replicate_with_fsdp.py
@@ -24,7 +24,7 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     TEST_SKIPS,
 )
-from torch.testing._internal.common_fsdp import check_sharded_parity, MLPStack
+from torch.testing._internal.common_fsdp import check_sharded_parity, DEVICE_TYPE, MLPStack
 from torch.testing._internal.common_utils import run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
@@ -52,7 +52,7 @@ class ReplicateTest(MultiProcContinuousTest):
 
     @classmethod
     def device_type(cls) -> str:
-        return "cuda"
+        return DEVICE_TYPE
 
     @classmethod
     def _init_pg(cls, rank, world_size, rdvz_file):
@@ -66,7 +66,7 @@ class ReplicateTest(MultiProcContinuousTest):
         # Prefer to test with >=4 GPUs, but for 2 GPUs, use 2-way TP
         replicate_size = 2
         return init_device_mesh(
-            "cuda",
+            DEVICE_TYPE,
             (replicate_size, 1, self.world_size // replicate_size),
             mesh_dim_names=("replicate", "shard", "tp"),
         )
@@ -195,7 +195,7 @@ class ReplicateTest(MultiProcContinuousTest):
         This tests that a user can pass in a device mesh to replicate a module
         """
 
-        device = torch.device(f"cuda:{self.rank % torch.cuda.device_count()}")
+        device = torch.device(DEVICE_TYPE, self.rank % torch.accelerator.device_count())
         model = Net().to(device)
         replicate_model = deepcopy(model)
 
@@ -221,7 +221,7 @@ class ReplicateTest(MultiProcContinuousTest):
         Tests that replicate_model has the same behavior as original model when training
         """
 
-        device = torch.device(f"cuda:{self.rank % torch.cuda.device_count()}")
+        device = torch.device(DEVICE_TYPE, self.rank % torch.accelerator.device_count())
         model = Net().to(device)
         replicate_model = deepcopy(model)
 
@@ -291,7 +291,7 @@ class ReplicateTest(MultiProcContinuousTest):
 
         torch.manual_seed(42)
         model = MLPStack(mlp_dim)
-        ref_model = copy.deepcopy(model).cuda()
+        ref_model = copy.deepcopy(model).to(DEVICE_TYPE)
         replicate(ref_model, mesh=replicate_mesh)
         ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2, foreach=False)
         model.parallelize(
@@ -302,7 +302,7 @@ class ReplicateTest(MultiProcContinuousTest):
         optim = torch.optim.Adam(model.parameters(), lr=1e-2, foreach=False)
 
         torch.manual_seed(42 + replicate_pg.rank() + 1)
-        device = torch.device("cuda")
+        device = torch.device(DEVICE_TYPE)
         for iter_idx in range(10):
             inp = torch.randn((8, mlp_dim), device=device)
             losses: list[torch.Tensor] = []

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -889,6 +889,7 @@ class MultiProcessTestCase(TestCase):
                 ),
                 kwargs={
                     "fake_pg": getattr(self, "fake_pg", False),
+                    "world_size": self.world_size,
                 },
             )
             process.start()

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -63,6 +63,8 @@ from torch.testing._internal.common_utils import (
     set_rng_seed,
     TEST_CUDA,
     TEST_HPU,
+    TEST_PRIVATEUSE1,
+    TEST_PRIVATEUSE1_DEVICE_TYPE,
     TEST_WITH_ROCM,
     TEST_XPU,
 )
@@ -78,6 +80,12 @@ if TEST_CUDA:
     DEVICE_TYPE = "cuda"
     DISTRIBUTED_BACKEND = "nccl"
     DEVICE_COUNT = torch.cuda.device_count()
+elif TEST_PRIVATEUSE1:
+    DEVICE_TYPE = TEST_PRIVATEUSE1_DEVICE_TYPE
+    DISTRIBUTED_BACKEND = torch.distributed.get_default_backend_for_device(
+        TEST_PRIVATEUSE1_DEVICE_TYPE
+    )
+    DEVICE_COUNT = torch.get_device_module(TEST_PRIVATEUSE1_DEVICE_TYPE).device_count()
 elif TEST_HPU:
     DEVICE_TYPE = "hpu:0"
     DISTRIBUTED_BACKEND = "hccl"
@@ -662,10 +670,10 @@ class ModuleWithDelay(FSDPTestModel):
     def get_loss(self, input, output):
         loss = self.module.get_loss(input, output)  # type: ignore[operator]
         if self.delay_after_loss_ms > 0:
-            if TEST_HPU or TEST_XPU:
-                time.sleep(self.delay_after_loss_ms / 1000)
-            elif TEST_CUDA:
+            if TEST_CUDA:
                 torch.cuda._sleep(int(self.delay_after_loss_ms * get_cycles_per_ms()))
+            else:
+                time.sleep(self.delay_after_loss_ms / 1000)
 
         return loss
 
@@ -678,7 +686,7 @@ class ModuleWithDelay(FSDPTestModel):
                     torch.cuda._sleep(
                         int(self.delay_before_reduction_ms * get_cycles_per_ms())
                     )
-                elif TEST_HPU or TEST_XPU:
+                else:
                     time.sleep(self.delay_before_reduction_ms / 1000)
             return orig_reduce_scatter(*args, **kwargs)
 
@@ -811,7 +819,7 @@ class MixtureOfExperts(NestedWrappedModule):
                         torch.cuda._sleep(
                             int(self.delay_before_free_ms * get_cycles_per_ms())
                         )
-                    elif TEST_HPU or TEST_XPU:
+                    else:
                         time.sleep(self.delay_before_free_ms / 1000)
 
                     return orig_reshard(*args, **kwargs)
@@ -1247,7 +1255,7 @@ class FSDPTestMixin:
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        if torch.accelerator.is_available():
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1555,13 +1563,15 @@ class FSDPTest(FSDPTestMixin, MultiProcessTestCase):
 
     @classmethod
     def _run(cls, rank, test_name, file_name, pipe, **kwargs):  # type: ignore[override]
+
         self = cls(test_name)
         self.rank = rank
         self.file_name = file_name
         fake_pg = kwargs.get("fake_pg", False)
 
         print(f"dist init r={self.rank}, world={self.world_size}")
-        if torch.accelerator.device_count() < self.world_size:
+        device_count = torch.accelerator.device_count() if torch.accelerator.is_available() else 0
+        if device_count < self.world_size:
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
 
         # Specify gloo backend to make 'init_process_group()' succeed,
@@ -1590,7 +1600,7 @@ class FSDPTest(FSDPTestMixin, MultiProcessTestCase):
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        if torch.accelerator.is_available():
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1637,7 +1647,7 @@ class FSDPTestContinuous(FSDPTestMixin, MultiProcContinuousTest):
             sys.exit(TEST_SKIPS[f"multi-gpu-{world_size}"].exit_code)
 
         device_id = rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        if torch.accelerator.is_available():
             torch.accelerator.set_device_index(device_id)
 
         super()._init_pg(rank, world_size, rdvz_file)
@@ -1749,3 +1759,15 @@ class SkipModel(nn.Module):
         x = self.linear_skip(x)
         x = self.nested_linear(x)
         return x
+
+
+if os.environ.get("PYTORCH_TESTING_PREFER_MULTIPROCESS"):
+    # Some backends may not support multi-threaded test execution.
+    # Setting PYTORCH_TESTING_PREFER_MULTIPROCESS=1 falls back to
+    # multi-process which tests the same FSDP logic with process isolation.
+    class FSDPTestMultiThread(FSDPTest):  # type: ignore[no-redef]
+        def perThreadSetUp(self):
+            pass
+
+        def perThreadTearDown(self):
+            pass

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5656,11 +5656,13 @@ def get_cycles_per_ms(device: str = "cuda") -> float:
             cycles_per_ms = test_cycles / elapsed_ms if elapsed_ms > 0 else 1000000
             return cycles_per_ms
     else:
+        device_mod = torch.get_device_module(device)
+
         def measure() -> float:
-            start = torch.cuda.Event(enable_timing=True)
-            end = torch.cuda.Event(enable_timing=True)
+            start = device_mod.Event(enable_timing=True)
+            end = device_mod.Event(enable_timing=True)
             start.record()
-            torch.cuda._sleep(test_cycles)
+            device_mod._sleep(test_cycles)
             end.record()
             end.synchronize()
             cycles_per_ms = test_cycles / start.elapsed_time(end)


### PR DESCRIPTION
## Summary

Replace hard-coded CUDA/NCCL references in FSDP v2 test infrastructure and test files with device-agnostic equivalents, enabling these tests to run on any backend registered via PrivateUse1 or the accelerator API.

## Changes

**Infrastructure (`torch/testing/_internal/`):**
- `common_fsdp.py`: Add PrivateUse1 to device detection chain, broaden `set_device_index` guards to `torch.accelerator.is_available()`, use `time.sleep()` as universal fallback for non-CUDA `_sleep`, skip `FSDPTestMultiThread` on PrivateUse1
- `common_distributed.py`: Pass `world_size` to spawned processes
- `common_utils.py`: Make `get_cycles_per_ms()` device-agnostic via `torch.get_device_module()`

**Test files:**
- Replace `device="cuda"` → `device_type`, `.cuda()` → `.to(device_type)`
- Replace `torch.cuda.synchronize()` → `torch.accelerator.synchronize()`
- Replace `torch.cuda.device_count()` → `torch.accelerator.device_count()`
- Add `@skipIf(not TEST_CUDA)` on NCCL log parsing test methods
- Add `TEST_PRIVATEUSE1` to memory stats condition
- Pass `device_type.type` to `get_cycles_per_ms()` calls
- Dynamic `valid_device_types` tuple with PrivateUse1 backend name

## Design Decisions

- **NCCL log tests**: Skipped per-method (not per-class) since other tests in the same class are device-agnostic
- **Sleep fallbacks**: Open `else: time.sleep()` for universally safe operations; explicit `TEST_PRIVATEUSE1` for backend-specific data (memory stats keys)
- **`get_cycles_per_ms`**: Fixed the function body to use `get_device_module()`, and fixed call sites to pass device argument (default is `"cuda"`)

CUDA and ROCm remain fully supported — they become one of many possible backends rather than the only assumed one.

## Testing

Validated on (PrivateUse1 backend)

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD