### PR TITLE
[DTensor] error on random ops when tensor and mesh device mismatch

### DIFF
--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -956,6 +956,21 @@ class DTensorTest(DTensorTestBase):
         self.assertEqual(dt_scalar.full_tensor(), 42.0)
         self.assertEqual(dt_scalar.to_local(), 42.0)
 
+    @with_comms
+    def test_dtensor_random_op_device_mismatch_error(self):
+        # Random ops on a DTensor whose local tensor device doesn't
+        # match the mesh should error. Without this, the RNG tracker
+        # doesn't advance state for CPU tensors on a CUDA mesh,
+        # causing trunc_normal_ to loop forever.
+        mesh = init_device_mesh(self.device_type, (self.world_size,))
+        with torch.device("meta"):
+            t = torch.empty(4, 4)
+        dt = DTensor.from_local(t, mesh, [Shard(0)])
+        dt = torch.empty_like(dt, device="cpu")
+
+        with self.assertRaisesRegex(RuntimeError, "random op"):
+            dt.normal_(0, 1)
+
 
 DTensorTestWithLocalTensor = create_local_tensor_test_class(
     DTensorTest,

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -324,6 +324,28 @@ class OpDispatcher:
             # run local op computation with potentially modified args/kwargs
             local_tensor_args = cast(tuple[object, ...], local_tensor_args)
             if op_call in self._random_ops:
+                # Check that the local tensor device matches the mesh.
+                # The DTensor RNG tracker is device-specific (e.g., CUDA)
+                # and does not advance state for tensors on a different
+                # device (e.g., CPU), causing random ops to silently
+                # produce identical values on every call. This makes
+                # rejection-sampling loops like trunc_normal_ infinite.
+                first_local = cast(torch.Tensor, local_tensor_args[0])
+                if (
+                    first_local.device.type != mesh.device_type
+                    and not first_local.is_meta
+                ):
+                    raise RuntimeError(
+                        f"DTensor random op {op_call}: local tensor is on "
+                        f"{first_local.device} but the device mesh expects "
+                        f"'{mesh.device_type}'. The DTensor RNG tracker "
+                        f"cannot advance state across different device types, "
+                        f"which causes random ops to produce identical values "
+                        f"on every call. Use a device mesh matching the tensor "
+                        f"device (e.g., cpu mesh with gloo backend for CPU "
+                        f"tensors)."
+                    )
+
                 if not random._rng_tracker and is_rng_supported_mesh(mesh):
                     # Default to `OffsetBasedRNGTracker` if the parallelism API did not already construct one
                     # Skip RNG state sync during tracing to avoid lazily initializing real RNG state under fake mode.


### PR DESCRIPTION
we can have DTensor with cuda mesh and cpu local tensor, for example
```
mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("dp",))
with torch.device("meta"):
    t = torch.empty(256, 256)
dt = DTensor.from_local(t, mesh, [Shard(0)])
dt = torch.empty_like(dt, device="cpu")
print(f"mesh={dt.device_mesh.device_type}, local={dt._local_tensor.device}", flush=True)
```

it gets stuck in the infiniate loop, when calling `nn.init.trunc_normal_(dt)`, because cpu RNG does not advance correctly
```
# torch/nn/init.py:117-125
  while True:                                                                                                                                                                                                                    
      mask = (result < lo) | (result > hi)                                                                                                                                                                                         
      if not mask.any():
          break                                                                                                                                                                                                                    
      result = torch.where(                                                                                                                                                                                                      
          mask,                                                                                                                                                                                                                    
          torch.empty_like(result).normal_(mean, std, generator=generator),                                                                                                                                                      
          result,                                                                                                                                                                                                                  
      )
```

there are multiple aspect of fixing - but raising error for the illegal case is a good starter

Repro
```
  # torchrun --nproc_per_node=1 repro.py
  import torch, torch.distributed as dist
  from torch.distributed.device_mesh import init_device_mesh
  from torch.distributed.tensor import DTensor, Shard

  dist.init_process_group("nccl")
  torch.cuda.set_device(0)

  mesh = init_device_mesh("cuda", (1,))
  with torch.device("meta"):
      t = torch.empty(4)
  dt = DTensor.from_local(t, mesh, [Shard(0)])
  dt = torch.empty_like(dt, device="cpu")

  # RNG doesn't advance: two normal_() calls produce identical values.
  # This makes trunc_normal_ (init.py:123) loop forever.
  torch.manual_seed(42)
  a = dt.normal_(0, 1).to_local().clone()
  b = torch.empty_like(dt).normal_(0, 1).to_local()
  assert not torch.equal(a, b), f"BUG: RNG not advancing, a == b == {a}"
```