### PR TITLE
[pyrefly] Add type annotations to torch/fx/experimental/migrate_gradu…

### DIFF
--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -1772,9 +1772,7 @@
     "Optional",
     "Union"
   ],
-  "torch.fx.experimental.migrate_gradual_types.constraint": [
-    "TensorType"
-  ],
+  "torch.fx.experimental.migrate_gradual_types.constraint": [],
   "torch.fx.experimental.migrate_gradual_types.constraint_generator": [
     "ApplyBroadcasting",
     "BatchNorm2d",
@@ -1830,6 +1828,7 @@
     "IndexSelect",
     "List",
     "Prod",
+    "Sequence",
     "T",
     "TGreatestUpperBound",
     "TVar",
@@ -1844,6 +1843,7 @@
     "BinConstraintD",
     "BinConstraintT",
     "Conj",
+    "Constraint",
     "ConstraintGenerator",
     "D",
     "DVar",

--- a/torch/fx/experimental/migrate_gradual_types/constraint.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint.py
@@ -1,4 +1,40 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeAlias
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = [
+    "ApplyBroadcasting",
+    "BinConstraintD",
+    "BinConstraintT",
+    "BinaryConstraint",
+    "BVar",
+    "CalcConv",
+    "CalcMaxPool",
+    "CalcProduct",
+    "CanReshape",
+    "Conj",
+    "Constraint",
+    "DGreatestUpperBound",
+    "Disj",
+    "DVar",
+    "F",
+    "GetItem",
+    "GetItemTensor",
+    "IndexSelect",
+    "Prod",
+    "T",
+    "TGreatestUpperBound",
+    "Transpose",
+    "TVar",
+    "is_algebraic_expression",
+    "is_bool_expr",
+    "is_dim",
+]
+
 from torch.fx.experimental.migrate_gradual_types.operation import (
     op_add,
     op_div,
@@ -10,7 +46,7 @@ from torch.fx.experimental.migrate_gradual_types.operation import (
     op_neq,
     op_sub,
 )
-from torch.fx.tensor_type import Dyn, TensorType
+from torch.fx.tensor_type import _DynType, Dyn, TensorType
 
 
 class Constraint:
@@ -18,55 +54,53 @@ class Constraint:
 
 
 class Conj(Constraint):
-    def __init__(self, conjuncts):
+    def __init__(self, conjuncts: Sequence[Constraint]) -> None:
         """
         :param conjuncts: Conjunction of constraints
         """
-        self.conjucts = conjuncts
+        self.conjucts = list(conjuncts)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Conj):
-            return self.conjucts == other.conjucts and self.conjucts == other.conjucts
+            return self.conjucts == other.conjucts
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"And({self.conjucts})"
 
 
 class Disj(Constraint):
-    def __init__(self, disjuncts):
+    def __init__(self, disjuncts: Sequence[Constraint]) -> None:
         """
         :param disjuncts: Disjunction of constraints
         """
-        self.disjuncts = disjuncts
+        self.disjuncts = list(disjuncts)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Disj):
-            return (
-                self.disjuncts == other.disjuncts and self.disjuncts == other.disjuncts
-            )
+            return self.disjuncts == other.disjuncts
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Or({self.disjuncts})"
 
 
 class Prod(Constraint):
-    def __init__(self, products):
+    def __init__(self, products: Sequence[DVar | int | _DynType]) -> None:
         """
         :param products: lists of dimensions to multiply
         """
-        self.products = products
+        self.products = list(products)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Prod):
-            return self.products == other.products and self.products == other.products
+            return self.products == other.products
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Product({self.products})"
 
 
@@ -78,10 +112,10 @@ class T(Constraint):
     def __init__(self) -> None:
         pass
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, T)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "True"
 
 
@@ -93,10 +127,10 @@ class F(Constraint):
     def __init__(self) -> None:
         pass
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, F)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "False"
 
 
@@ -105,7 +139,7 @@ class BinaryConstraint(Constraint):
     Represents all binary operations
     """
 
-    def __init__(self, lhs, rhs, op):
+    def __init__(self, lhs: _Operand, rhs: _Operand, op: str | None) -> None:
         """
         :param lhs: lhs of the constraint
         :param rhs: rhs of the constraint
@@ -115,7 +149,7 @@ class BinaryConstraint(Constraint):
         self.rhs = rhs
         self.op = op
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, BinaryConstraint):
             return (
                 self.lhs == other.lhs and self.rhs == other.rhs and self.op == other.op
@@ -123,7 +157,7 @@ class BinaryConstraint(Constraint):
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"({self.lhs} {self.op} {self.rhs})"
 
 
@@ -132,7 +166,7 @@ class BinConstraintT(BinaryConstraint):
     Binary constraints about tensors
     """
 
-    def __init__(self, lhs, rhs, op):
+    def __init__(self, lhs: _Operand, rhs: _Operand, op: str | None) -> None:
         if not (
             (isinstance(lhs, (TVar, TensorType, int)) or lhs == Dyn)
             and (isinstance(rhs, (TVar, TensorType, int)) or rhs == Dyn)
@@ -146,7 +180,7 @@ class BinConstraintD(BinaryConstraint):
     Binary constraints about dimensions
     """
 
-    def __init__(self, lhs, rhs, op):
+    def __init__(self, lhs: _Operand, rhs: _Operand, op: str | None) -> None:
         if not (is_algebraic_expression(lhs) or is_dim(lhs) or is_bool_expr(lhs)):
             raise AssertionError(f"Invalid lhs type: {type(lhs)}")
         if not (is_algebraic_expression(rhs) or is_dim(rhs) or is_bool_expr(rhs)):
@@ -160,7 +194,7 @@ class TGreatestUpperBound(Constraint):
     Greatest Upper bound for tensors with dynamic type
     """
 
-    def __init__(self, res, rhs1, rhs2):
+    def __init__(self, res: TVar, rhs1: TVar, rhs2: TVar) -> None:
         """
         :param res: tensor variable that stores the result of the output
         :param rhs1: tensor or tensor variable
@@ -170,10 +204,10 @@ class TGreatestUpperBound(Constraint):
         self.rhs1 = rhs1
         self.rhs2 = rhs2
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.res} = {self.rhs1}\u2294*{self.rhs2}"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, TGreatestUpperBound):
             return (
                 self.res == other.res
@@ -189,7 +223,12 @@ class DGreatestUpperBound(Constraint):
     Greatest Upper bound for dimensions
     """
 
-    def __init__(self, res, rhs1, rhs2):
+    def __init__(
+        self,
+        res: DVar | int | _DynType,
+        rhs1: DVar | int | _DynType,
+        rhs2: DVar | int | _DynType,
+    ) -> None:
         """
         :param res: Dimension variable to store the result
         :param rhs1: dimension variable 1
@@ -206,10 +245,10 @@ class DGreatestUpperBound(Constraint):
         self.rhs1 = rhs1
         self.rhs2 = rhs2
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.res} = {self.rhs1}\u2294{self.rhs2}"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, DGreatestUpperBound):
             return (
                 self.res == other.res
@@ -225,7 +264,7 @@ class CanReshape(Constraint):
     can_reshape constraint
     """
 
-    def __init__(self, src, target):
+    def __init__(self, src: TVar, target: TensorType) -> None:
         """
         :param src: tensor variable
         :param target: tensor
@@ -233,10 +272,10 @@ class CanReshape(Constraint):
         self.src = src
         self.target = target
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"can-reshape({self.src}, {self.target})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, CanReshape):
             return self.src == other.src and self.target == other.target
         else:
@@ -244,7 +283,14 @@ class CanReshape(Constraint):
 
 
 class IndexSelect(Constraint):
-    def __init__(self, tensor_size, input_var, dim_replace, index, output):
+    def __init__(
+        self,
+        tensor_size: int,
+        input_var: TVar,
+        dim_replace: DVar | _DynType,
+        index: int,
+        output: TVar,
+    ) -> None:
         """
         Args:
             input_var: input to index_select
@@ -268,7 +314,7 @@ class IndexSelect(Constraint):
         self.index = index
         self.output = output
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f" {self.output} = "
             f"IndexSelect({self.input_var}, "
@@ -277,7 +323,7 @@ class IndexSelect(Constraint):
             f"{self.index})"
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, IndexSelect):
             return (
                 self.tensor_size == other.tensor_size
@@ -291,7 +337,9 @@ class IndexSelect(Constraint):
 
 
 class Transpose(Constraint):
-    def __init__(self, tensor_size, input_var, index1, index2, output):
+    def __init__(
+        self, tensor_size: int, input_var: TVar, index1: int, index2: int, output: TVar
+    ) -> None:
         """
         Args:
             tensor_size: current tensor size
@@ -315,7 +363,7 @@ class Transpose(Constraint):
         self.index2 = index2
         self.output = output
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f" {self.output} = "
             f"Transpose({self.input_var}, "
@@ -324,7 +372,7 @@ class Transpose(Constraint):
             f"{self.index2})"
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Transpose):
             return (
                 self.tensor_size == other.tensor_size
@@ -338,7 +386,9 @@ class Transpose(Constraint):
 
 
 class GetItem(Constraint):
-    def __init__(self, tensor_size, index, res, input_var):
+    def __init__(
+        self, tensor_size: int, index: int, res: DVar, input_var: TVar
+    ) -> None:
         """
         Constraint for getting item given a tensor size
         :param tensor_size: actual number
@@ -354,10 +404,10 @@ class GetItem(Constraint):
         self.index = index
         self.input_var = input_var
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f" {self.res} = GetItem({self.input_var}, tensor_size: {self.tensor_size}, {self.index})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, GetItem):
             return (
                 self.res == other.res
@@ -370,7 +420,13 @@ class GetItem(Constraint):
 
 
 class GetItemTensor(Constraint):
-    def __init__(self, tensor_size, index_tuple, res, input_var):
+    def __init__(
+        self,
+        tensor_size: int,
+        index_tuple: tuple[None | slice, ...],
+        res: TVar,
+        input_var: TVar,
+    ) -> None:
         """
         Constraint for getting item given a tensor size
         However, when the argument is a tuple, we will
@@ -388,10 +444,10 @@ class GetItemTensor(Constraint):
         self.index_tuple = index_tuple
         self.input_var = input_var
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f" {self.res} = GetItemT({self.input_var}, tensor_size: {self.tensor_size}, {self.index_tuple})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, GetItemTensor):
             return (
                 self.res == other.res
@@ -406,15 +462,15 @@ class GetItemTensor(Constraint):
 class CalcConv(Constraint):
     def __init__(
         self,
-        conv_result,
-        input_var,
-        c_out,
-        kernel,
-        padding,
-        stride,
-        dilation,
-        matching_constraint_vars,
-    ):
+        conv_result: TVar,
+        input_var: TVar,
+        c_out: int,
+        kernel: int | tuple[int, int],
+        padding: int | tuple[int, int],
+        stride: int | tuple[int, int],
+        dilation: int | tuple[int, int],
+        matching_constraint_vars: list[DVar],
+    ) -> None:
         """
         :param conv_result: the convolution result
         :param input_var: input to convolution
@@ -430,7 +486,7 @@ class CalcConv(Constraint):
         self.dilation = dilation
         self.matching_constraint = matching_constraint_vars
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"{self.conv_result} ="
             f" calc-conv({self.input_var},"
@@ -439,7 +495,7 @@ class CalcConv(Constraint):
             f" {self.dilation})"
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, CalcConv):
             return (
                 self.conv_result == other.conv_result
@@ -458,14 +514,14 @@ class CalcConv(Constraint):
 class CalcMaxPool(Constraint):
     def __init__(
         self,
-        maxpool_result,
-        input_var,
-        kernel,
-        padding,
-        stride,
-        dilation,
-        matching_constraint_vars,
-    ):
+        maxpool_result: TVar,
+        input_var: TVar,
+        kernel: int | tuple[int, int],
+        padding: int | tuple[int, int],
+        stride: int | tuple[int, int],
+        dilation: int | tuple[int, int],
+        matching_constraint_vars: list[DVar],
+    ) -> None:
         """
         :param maxpool_result: the result of maxpool
         :param input_var: input to convolution
@@ -479,7 +535,7 @@ class CalcMaxPool(Constraint):
         self.dilation = dilation
         self.matching_constraint = matching_constraint_vars
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"{self.maxpool_result} ="
             f" calc-maxpool({self.input_var},"
@@ -488,7 +544,7 @@ class CalcMaxPool(Constraint):
             f" {self.dilation})"
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, CalcMaxPool):
             return (
                 self.maxpool_result == other.maxpool_result
@@ -504,7 +560,7 @@ class CalcMaxPool(Constraint):
 
 
 class ApplyBroadcasting(Constraint):
-    def __init__(self, res1, res2, input1, input2):
+    def __init__(self, res1: TVar, res2: TVar, input1: TVar, input2: TVar) -> None:
         """
         :param res1: resulting tensor 1
         :param res2: resulting tensor 2
@@ -516,7 +572,7 @@ class ApplyBroadcasting(Constraint):
         self.input1 = input1
         self.input2 = input2
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, ApplyBroadcasting):
             return (
                 self.res1 == other.res1
@@ -527,7 +583,7 @@ class ApplyBroadcasting(Constraint):
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"{self.res1}, {self.res2} ="
             f" apply-broadcasting({self.input1},"
@@ -540,7 +596,9 @@ class CalcProduct(Constraint):
     Given correct dimensions, calculate the product for flatten accounting for Dyn
     """
 
-    def __init__(self, start, end, flattened, dims_to_flatten):
+    def __init__(
+        self, start: int, end: int, flattened: TVar, dims_to_flatten: list[DVar]
+    ) -> None:
         """
         :param start: start index
         :param end: end index
@@ -561,7 +619,7 @@ class CalcProduct(Constraint):
         self.dims_to_flatten = dims_to_flatten
         self.flattened = flattened
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, CalcProduct):
             return (
                 self.start == other.start
@@ -573,7 +631,7 @@ class CalcProduct(Constraint):
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.flattened} = CalcProduct({self.start}, {self.end}, {self.dims_to_flatten})"
 
 
@@ -582,16 +640,16 @@ class TVar:
     Tensor variable with no tensor constructor
     """
 
-    def __init__(self, tvar):
+    def __init__(self, tvar: int) -> None:
         """
         :param tvar: tensor variable
         """
         self.tvar = tvar
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"TV({self.tvar})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, TVar):
             return self.tvar == other.tvar
         else:
@@ -603,16 +661,16 @@ class DVar:
     Dimension variable
     """
 
-    def __init__(self, c):
+    def __init__(self, c: int) -> None:
         """
         :param c: character or number
         """
         self.c = c
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"DV({self.c})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, DVar):
             return self.c == other.c
         else:
@@ -624,35 +682,52 @@ class BVar:
     Boolean variable
     """
 
-    def __init__(self, c):
+    def __init__(self, c: int) -> None:
         """
         :param c: character or number
         """
         self.c = c
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"BV({self.c})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, BVar):
             return self.c == other.c
         else:
             return False
 
 
-def is_algebraic_expression(constraint):
+_Operand: TypeAlias = (
+    TVar
+    | TensorType
+    | DVar
+    | int
+    | float
+    | bool
+    | _DynType
+    | BinConstraintD
+    | Prod
+    | BVar
+    | Conj
+    | Disj
+    | None
+)
+
+
+def is_algebraic_expression(constraint: object) -> bool:
     if isinstance(constraint, BinConstraintD):
         return constraint.op in [op_add, op_sub, op_div, op_mul, op_mod]
     else:
         return isinstance(constraint, Prod)
 
 
-def is_bool_expr(constraint):
+def is_bool_expr(constraint: object) -> bool:
     if isinstance(constraint, BinConstraintD):
         return constraint.op in [op_gt, op_lt, op_neq, op_eq]
     else:
         return isinstance(constraint, (BVar, Conj, Disj))
 
 
-def is_dim(d):
+def is_dim(d: object) -> bool:
     return isinstance(d, (DVar, int)) or d == Dyn

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -1,8 +1,7 @@
-# mypy: allow-untyped-defs
 import operator
 import warnings
-from collections.abc import Callable, Iterable
-from typing import TypeVar
+from collections.abc import Callable, Iterable, Sequence
+from typing import TypeAlias, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -11,11 +10,13 @@ from torch.fx.experimental.migrate_gradual_types.constraint import (
     ApplyBroadcasting,
     BinConstraintD,
     BinConstraintT,
+    BVar,
     CalcConv,
     CalcMaxPool,
     CalcProduct,
     CanReshape,
     Conj,
+    Constraint,
     DGreatestUpperBound,
     Disj,
     DVar,
@@ -49,6 +50,7 @@ from torch.fx.experimental.migrate_gradual_types.util import (
     gen_tensor_dims,
     gen_tvar,
 )
+from torch.fx.graph import Graph
 from torch.fx.node import Node, Target
 from torch.fx.tensor_type import Dyn, TensorType
 from torch.nn.modules.batchnorm import BatchNorm2d
@@ -58,7 +60,9 @@ from torch.nn.modules.conv import Conv2d
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
-_INFERENCE_RULES: dict[Target, Callable] = {}
+_SymbolDict: TypeAlias = dict[Node, TVar | DVar | BVar]
+
+_INFERENCE_RULES: dict[Target, Callable[..., tuple[list[Constraint], int]]] = {}
 
 MAX_TENSOR_RANK = 4
 
@@ -117,13 +121,15 @@ def register_inference_rule(
     def register(fn: Callable[_P, _T]) -> Callable[_P, _T]:
         if call_target in _INFERENCE_RULES:
             raise RuntimeError(f"Inference rule already registered for {call_target}!")
-        _INFERENCE_RULES[call_target] = fn
+        _INFERENCE_RULES[call_target] = fn  # pyrefly: ignore[unsupported-operation]
         return fn
 
     return register
 
 
-def generate_flatten_constraints(start_dim, end_dim, input, flattened, n, counter):
+def generate_flatten_constraints(
+    start_dim: int, end_dim: int, input: TVar, flattened: TVar, n: int, counter: int
+) -> tuple[Conj, int]:
     d, counter = gen_tensor_dims(n, counter)
     c1 = BinConstraintT(input, TensorType(d), op_eq)
     start_dim = n if start_dim == -1 else abs(start_dim)
@@ -134,7 +140,9 @@ def generate_flatten_constraints(start_dim, end_dim, input, flattened, n, counte
 
 
 @register_inference_rule(getattr)
-def get_attr_inference_rule(n: Node, symbols, constraints, counter):
+def get_attr_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     If the attribute is "device" then the tensor shape is preserved
     """
@@ -155,7 +163,9 @@ def get_attr_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.bmm)
-def bmm_inference_rule(n: Node, symbols, constraints, counter):
+def bmm_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Constraints that match the input to a size 3 tensor
     and switch the dimensions according to the rules
@@ -227,7 +237,9 @@ def bmm_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule("index_select")
-def index_select_inference_rule(n: Node, symbols, constraints, counter):
+def index_select_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     We constrain the second argument to a vector or Dyn.
     The output replaces the input with the shape of the vector
@@ -256,7 +268,13 @@ def index_select_inference_rule(n: Node, symbols, constraints, counter):
             Disj(
                 [
                     IndexSelect(
-                        i + 1, symbols[n.args[0]], dims[0], n.args[1], index_select
+                        i + 1,
+                        symbols[  # pyrefly: ignore[bad-argument-type, bad-index]
+                            n.args[0]
+                        ],
+                        dims[0],
+                        n.args[1],
+                        index_select,
                     )
                     for i in range(MAX_TENSOR_RANK)
                 ]
@@ -268,7 +286,15 @@ def index_select_inference_rule(n: Node, symbols, constraints, counter):
             is_dyn,
             Disj(
                 [
-                    IndexSelect(i + 1, symbols[n.args[0]], Dyn, n.args[1], index_select)
+                    IndexSelect(
+                        i + 1,
+                        symbols[  # pyrefly: ignore[bad-argument-type, bad-index]
+                            n.args[0]
+                        ],
+                        Dyn,
+                        n.args[1],
+                        index_select,
+                    )
                     for i in range(MAX_TENSOR_RANK)
                 ]
             ),
@@ -279,7 +305,9 @@ def index_select_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule("expand")
-def expand_inference_rule(n: Node, symbols, constraints, counter):
+def expand_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     We generate the exact constraints as we do for tensor additions but we constraint
     the rank of this expression to be equal to len(n.args[1:]) so that only
@@ -308,13 +336,22 @@ def expand_inference_rule(n: Node, symbols, constraints, counter):
     e2_constraint = BinConstraintT(
         e2,
         TensorType(
-            [arg if isinstance(arg, int) else symbols[arg] for arg in n.args[1:]]
+            [
+                arg
+                if isinstance(arg, int)
+                else symbols[arg]  # pyrefly: ignore[bad-index]
+                for arg in n.args[1:]
+            ]
         ),
         op_eq,
     )
 
     constraints, counter = gen_broadcasting_constraints(
-        e1, e2, symbols, counter, expand
+        e1,  # pyrefly: ignore[bad-argument-type]
+        e2,
+        symbols,
+        counter,
+        expand,
     )
 
     # constraint the output size
@@ -341,7 +378,9 @@ def expand_inference_rule(n: Node, symbols, constraints, counter):
 @register_inference_rule("contiguous")
 @register_inference_rule(torch.ones)
 @register_inference_rule(torch.zeros)
-def equality_inference_rule(n: Node, symbols, constraints, counter):
+def equality_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     We generate the constraint: input = output
     """
@@ -356,23 +395,27 @@ def equality_inference_rule(n: Node, symbols, constraints, counter):
         # then we have dimension variables
         else:
             for arg in n.args:
-                if not isinstance(symbols[arg], DVar):
-                    raise AssertionError(f"Expected DVar, got {type(symbols[arg])}")
-        my_size = [symbols[arg] for arg in n.args]
+                if not isinstance(symbols[arg], DVar):  # pyrefly: ignore[bad-index]
+                    raise AssertionError(
+                        f"Expected DVar, got {type(symbols[arg])}"  # pyrefly: ignore[bad-index]
+                    )
+        my_size = [symbols[arg] for arg in n.args]  # pyrefly: ignore[bad-index]
         return [BinConstraintT(output, TensorType(my_size), op_eq)], counter
 
     elif isinstance(n.args[0], tuple):
         # then the tuple is the size
         if len(n.args[0]) > 4:
             raise AssertionError(f"Expected len <= 4, got {len(n.args[0])}")
-        my_size = [symbols[arg] for arg in n.args[0]]
+        my_size = [symbols[arg] for arg in n.args[0]]  # pyrefly: ignore[bad-index]
         return [BinConstraintT(output, TensorType(my_size), op_eq)], counter
     else:
         raise NotImplementedError("Method not yet implemented")
 
 
 @register_inference_rule("transpose")
-def transpose_inference_rule(n: Node, symbols, constraints, counter):
+def transpose_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Can be considered as a sequence of two index selects, so we generate constraints accordingly
     """
@@ -407,7 +450,9 @@ def transpose_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule("type_as")
-def type_inference_rule(n: Node, symbols, constraints, counter):
+def type_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     We generate the constraint: input = output
     """
@@ -434,7 +479,9 @@ def type_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule("masked_fill_")
-def masked_fill_inference_rule(n: Node, symbols, constraints, counter):
+def masked_fill_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Similar to addition. For now we implement the constraints when
     the argument is a boolean tensor. There is also a case for when
@@ -463,11 +510,13 @@ def masked_fill_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.nn.functional.embedding)
-def embedding_inference_rule_functional(n: Node, symbols, constraints, counter):
+def embedding_inference_rule_functional(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
-    embedding_dim_weights = symbols[n.args[1]]
+    embedding_dim_weights = symbols[n.args[1]]  # pyrefly: ignore[bad-index]
 
     # will treat this as a static shape. So we will not use matching.
     weight_dims, counter = gen_tensor_dims(2, counter)
@@ -480,7 +529,13 @@ def embedding_inference_rule_functional(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.nn.modules.sparse.Embedding)
-def embedding_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def embedding_inference_rule(
+    n: Node,
+    module_instance: torch.nn.Embedding,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     """
     The output shape differs from the input shape in the last dimension
     """
@@ -489,10 +544,12 @@ def embedding_inference_rule(n: Node, module_instance, symbols, constraints, cou
     return gen_embedding_rules(n, symbols, module_instance.embedding_dim, counter)
 
 
-def gen_embedding_rules(n: Node, symbols, embedding_dim, counter):
+def gen_embedding_rules(
+    n: Node, symbols: _SymbolDict, embedding_dim: int | DVar, counter: int
+) -> tuple[list[Constraint], int]:
     embedding_output, counter = gen_tvar(counter)
     symbols[n] = embedding_output
-    embedding_input = symbols[n.args[0]]
+    embedding_input = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
 
     input_dyn = BinConstraintT(embedding_input, Dyn, op_eq)
     output_dyn = BinConstraintT(embedding_output, Dyn, op_eq)
@@ -520,18 +577,22 @@ def gen_embedding_rules(n: Node, symbols, embedding_dim, counter):
 
 
 @register_inference_rule(torch.tensor)
-def tensor_inference_rule(n: Node, symbols, constraints, counter):
+def tensor_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     If the tensor is a scalar, we will skip it since we
     do not support scalars yet. We will add support in the future
     if it's needed. For our examples so far, scalars are not needed.
     """
-    return [], counter
+    return [], counter  # pyrefly: ignore[implicit-any]
 
 
 @register_inference_rule("reshape")
 @register_inference_rule("view")
-def view_inference_rule(n: Node, symbols, constraints, counter):
+def view_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Similar to reshape but with an extra condition on the strides
     """
@@ -564,7 +625,7 @@ def view_inference_rule(n: Node, symbols, constraints, counter):
     t2_type = TensorType(t2_type)  # type: ignore[assignment]
 
     c1 = BinConstraintT(my_view, t2_type, op_eq)
-    c2 = CanReshape(src_var, t2_type)
+    c2 = CanReshape(src_var, t2_type)  # pyrefly: ignore[bad-argument-type]
 
     # TODO: add the extra check mentioned here:
     # https://pytorch.org/docs/stable/generated/torch.Tensor.view.html#torch.Tensor.view
@@ -573,7 +634,9 @@ def view_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule("size")
-def size_inference_rule(n: Node, symbols, constraints, counter):
+def size_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     The constraint is just lhs = rhs.
     Ex: size = input_ids.size()
@@ -583,7 +646,7 @@ def size_inference_rule(n: Node, symbols, constraints, counter):
         # generate the new variable
         size, counter = gen_tvar(counter)
         symbols[n] = size
-        input = symbols[n.args[0]]
+        input = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
         c = BinConstraintT(input, size, op_eq)
         return [c], counter
 
@@ -593,9 +656,14 @@ def size_inference_rule(n: Node, symbols, constraints, counter):
             # generate the new variable
             size_index, counter = gen_dvar(counter)
             symbols[n] = size_index
-            input = symbols[n.args[0]]
+            input = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
             c2 = [
-                GetItem(i + 1, n.args[1], size_index, input)
+                GetItem(
+                    i + 1,
+                    n.args[1],
+                    size_index,
+                    input,  # pyrefly: ignore[bad-argument-type]
+                )
                 for i in range(MAX_TENSOR_RANK)
             ]
             c3 = BinConstraintD(0, size_index, op_leq)
@@ -613,7 +681,7 @@ def size_inference_rule(n: Node, symbols, constraints, counter):
         raise NotImplementedError
 
 
-def range_check(i, n):
+def range_check(i: int, n: int) -> T | F:
     """
     Checks if an index i is within range of a size n list
     Args:
@@ -629,7 +697,9 @@ def range_check(i, n):
 
 
 @register_inference_rule(torch.cumsum)
-def cumsum_inference_rule(n: Node, symbols, constraints, counter):
+def cumsum_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Input and output shapes should be equal
     We should verify that the index is valid
@@ -668,14 +738,18 @@ def cumsum_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(_assert_is_none)
-def assert_inference_rule(n: Node, symbols, constraints, counter):
+def assert_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if len(n.users) != 0:
         raise AssertionError(f"Expected no users, got {len(n.users)}")
-    return [], counter
+    return [], counter  # pyrefly: ignore[implicit-any]
 
 
 @register_inference_rule(operator.getitem)
-def getitem_inference_rule(n: Node, symbols, constraints, counter):
+def getitem_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -732,7 +806,7 @@ def getitem_inference_rule(n: Node, symbols, constraints, counter):
             ]
         else:
             # TODO: we should figure out why there is a key-error here.
-            return [], counter
+            return [], counter  # pyrefly: ignore[implicit-any]
 
         return [Disj([c1, *c2])], counter
 
@@ -741,7 +815,9 @@ def getitem_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(operator.gt)
-def gt_inference_rule(n: Node, symbols, constraints, counter):
+def gt_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], (Node, int)):
         raise AssertionError(f"Expected Node or int, got {type(n.args[0])}")
     if not isinstance(n.args[1], (Node, int)):
@@ -804,7 +880,9 @@ def gt_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(operator.eq)
-def eq_inference_rule(n: Node, symbols, constraints, counter):
+def eq_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], (Node, int)):
         raise AssertionError(f"Expected Node or int, got {type(n.args[0])}")
     if not isinstance(n.args[1], (Node, int)):
@@ -845,7 +923,9 @@ def eq_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(operator.ne)
-def neq_inference_rule(n: Node, symbols, constraints, counter):
+def neq_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Translates to inconsistent in gradual types.
     To prove inequality, we should prove that
@@ -973,7 +1053,9 @@ def neq_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(operator.lt)
-def lt_inference_rule(n: Node, symbols, constraints, counter):
+def lt_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], (Node, int)):
         raise AssertionError(f"Expected Node or int, got {type(n.args[0])}")
     if not isinstance(n.args[1], (Node, int)):
@@ -1018,7 +1100,9 @@ def lt_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.full)
-def full_inference_rule(n: Node, symbols, constraints, counter):
+def full_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     full, counter = gen_tvar(counter)
     symbols[n] = full
     res = []
@@ -1026,7 +1110,9 @@ def full_inference_rule(n: Node, symbols, constraints, counter):
     if not isinstance(n.args[0], Iterable):
         raise AssertionError(f"Expected Iterable, got {type(n.args[0])}")
     for arg in n.args[0]:
-        dim = arg if isinstance(arg, int) else symbols[arg]
+        dim = (
+            arg if isinstance(arg, int) else symbols[arg]  # pyrefly: ignore[bad-index]
+        )
         res.append(dim)
     c = BinConstraintT(full, TensorType(list(res)), op_eq)  # type: ignore[arg-type]
     return [c], counter
@@ -1034,12 +1120,14 @@ def full_inference_rule(n: Node, symbols, constraints, counter):
 
 # TODO normalize index
 @register_inference_rule(torch.arange)
-def arange_inference_rule(n: Node, symbols, constraints, counter):
+def arange_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     start = 0
     step = 1
 
     if len(n.args) == 1:
-        end = symbols[n.args[0]]
+        end = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
     else:
         raise NotImplementedError("Not yet implemented")
 
@@ -1078,7 +1166,9 @@ def arange_inference_rule(n: Node, symbols, constraints, counter):
     ], counter
 
 
-def gen_broadcasting_constraints(e1, e2, symbols, counter, output_var):
+def gen_broadcasting_constraints(
+    e1: TVar, e2: TVar, symbols: _SymbolDict, counter: int, output_var: TVar
+) -> tuple[list[Constraint], int]:
     # additional vars that don't correspond to expressions
     e11, counter = gen_tvar(counter)
     e22, counter = gen_tvar(counter)
@@ -1095,7 +1185,9 @@ def gen_broadcasting_constraints(e1, e2, symbols, counter, output_var):
 @register_inference_rule("ne")
 @register_inference_rule(torch.add)
 @register_inference_rule(operator.add)
-def broadcasting_inference_rule(n: Node, symbols, constraints, counter):
+def broadcasting_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:  # pyrefly: ignore[bad-return]
     op_code = None
     if n.target is operator.add or n.target is torch.add:
         op_code = op_add
@@ -1111,7 +1203,13 @@ def broadcasting_inference_rule(n: Node, symbols, constraints, counter):
             e1 = symbols[n.args[0]]
             e2 = symbols[n.args[1]]
 
-            return gen_broadcasting_constraints(e1, e2, symbols, counter, my_output)
+            return gen_broadcasting_constraints(
+                e1,  # pyrefly: ignore[bad-argument-type]
+                e2,  # pyrefly: ignore[bad-argument-type]
+                symbols,
+                counter,
+                my_output,
+            )
         else:
             raise NotImplementedError("Method not yet implemented")
 
@@ -1168,7 +1266,9 @@ def broadcasting_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.flatten)
-def flatten_inference_rule(n: Node, symbols, constraints, counter):
+def flatten_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -1199,7 +1299,12 @@ def flatten_inference_rule(n: Node, symbols, constraints, counter):
     const = []
     for i in range(1, MAX_TENSOR_RANK + 1):
         c, counter = generate_flatten_constraints(
-            start_dim, end_dim, input, flattened, i, counter
+            start_dim,
+            end_dim,
+            input,  # pyrefly: ignore[bad-argument-type]
+            flattened,
+            i,
+            counter,
         )
         const.append(c)
 
@@ -1207,17 +1312,30 @@ def flatten_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.nn.functional.layer_norm)
-def layer_norm_functional(n: Node, symbols, constraints, counter):
+def layer_norm_functional(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     We generate the constraint: input = output
     """
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
-    return gen_layer_norm_constraints(n, n.args[1], symbols, counter)
+    return gen_layer_norm_constraints(
+        n,
+        n.args[1],  # pyrefly: ignore[bad-argument-type]
+        symbols,
+        counter,
+    )
 
 
 @register_inference_rule(torch.nn.LayerNorm)
-def layer_norm_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def layer_norm_inference_rule(
+    n: Node,
+    module_instance: torch.nn.LayerNorm,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     """
     Input and output shapes should be equal.
     Input should be consistent with the normalized_shape
@@ -1229,10 +1347,12 @@ def layer_norm_inference_rule(n: Node, module_instance, symbols, constraints, co
     )
 
 
-def gen_layer_norm_constraints(n: Node, normalized_shape, symbols, counter):
+def gen_layer_norm_constraints(
+    n: Node, normalized_shape: Sequence[int], symbols: _SymbolDict, counter: int
+) -> tuple[list[Constraint], int]:
     output, counter = gen_tvar(counter)
     symbols[n] = output
-    input = symbols[n.args[0]]
+    input = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
 
     input_dyn = BinConstraintT(input, Dyn, op_eq)
     output_dyn = BinConstraintT(output, Dyn, op_eq)
@@ -1258,7 +1378,13 @@ def gen_layer_norm_constraints(n: Node, normalized_shape, symbols, counter):
 
 @register_inference_rule(torch.nn.Dropout)
 @register_inference_rule(torch.nn.ReLU)
-def relu_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def relu_inference_rule(
+    n: Node,
+    module_instance: torch.nn.Module,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     """
     Input and output shapes should be equal.
     """
@@ -1273,7 +1399,13 @@ def relu_inference_rule(n: Node, module_instance, symbols, constraints, counter)
 
 
 @register_inference_rule(torch.nn.Linear)
-def linear_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def linear_inference_rule(
+    n: Node,
+    module_instance: torch.nn.Linear,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     """
     Input and output sizes should be the same except for the last dimension
     If the input is Dyn, then so should the output
@@ -1286,7 +1418,9 @@ def linear_inference_rule(n: Node, module_instance, symbols, constraints, counte
 
 
 @register_inference_rule("dim")
-def torch_dim_inference_rule(n: Node, symbols, constraints, counter):
+def torch_dim_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     my_dim, counter = gen_dvar(counter)
@@ -1313,12 +1447,16 @@ def torch_dim_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch._C._nn.linear)
-def torch_linear_inference_rule(n: Node, symbols, constraints, counter):
+def torch_linear_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     weight_dims, counter = gen_tensor_dims(2, counter)
     equality_constraint = BinConstraintT(
-        symbols[n.args[1]], TensorType(weight_dims), op_eq
+        symbols[n.args[1]],  # pyrefly: ignore[bad-index]
+        TensorType(weight_dims),
+        op_eq,
     )
     constraints, counter = linear_constraints(
         n, weight_dims[1], weight_dims[0], symbols, counter
@@ -1326,10 +1464,16 @@ def torch_linear_inference_rule(n: Node, symbols, constraints, counter):
     return [equality_constraint] + constraints, counter
 
 
-def linear_constraints(n: Node, in_features, out_features, symbols, counter):
+def linear_constraints(
+    n: Node,
+    in_features: int | DVar,
+    out_features: int | DVar,
+    symbols: _SymbolDict,
+    counter: int,
+) -> tuple[list[Constraint], int]:
     linear_output, counter = gen_tvar(counter)
     symbols[n] = linear_output
-    linear_input = symbols[n.args[0]]
+    linear_input = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
 
     input_dyn = BinConstraintT(linear_input, Dyn, op_eq)
     output_dyn = BinConstraintT(linear_output, Dyn, op_eq)
@@ -1357,7 +1501,9 @@ def linear_constraints(n: Node, in_features, out_features, symbols, counter):
     return [Disj([c1, Disj(c2)])], counter
 
 
-def add_layer_norm_constraints(input_dim, normalized_dim):
+def add_layer_norm_constraints(
+    input_dim: list[DVar], normalized_dim: list[int]
+) -> list[Constraint]:
     """
     The constraints say that the type has te form: [*, 1024, 1024]
      while the normalized_dim have the form [1024, 1024]
@@ -1372,16 +1518,21 @@ def add_layer_norm_constraints(input_dim, normalized_dim):
         return [F()]
 
     else:
-        constraints = []
+        constraints: list[Constraint] = []
         for i, n in zip(reversed(input_dim), reversed(normalized_dim)):
             constraints.append(BinConstraintD(i, n, op_consistency))
         return constraints
 
 
-def add_linear_constraints(dims1, dims2, in_features, out_features):
+def add_linear_constraints(
+    dims1: list[DVar],
+    dims2: list[DVar],
+    in_features: int | DVar,
+    out_features: int | DVar,
+) -> list[Constraint]:
     if len(dims1) != len(dims2):
         raise AssertionError(f"Expected same length, got {len(dims1)} vs {len(dims2)}")
-    constraints = []
+    constraints: list[Constraint] = []
     for i in range(len(dims1)):
         if i == len(dims1) - 1:
             constraints.append(BinConstraintD(dims1[i], in_features, op_consistency))
@@ -1393,7 +1544,9 @@ def add_linear_constraints(dims1, dims2, in_features, out_features):
 
 
 @register_inference_rule(torch.reshape)
-def reshape_inference_rule(n: Node, symbols, constraints, counter):
+def reshape_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -1405,13 +1558,19 @@ def reshape_inference_rule(n: Node, symbols, constraints, counter):
     t2 = n.args[1]
     t2_type = TensorType([Dyn if elem == -1 else elem for elem in t2])  # type: ignore[union-attr]
     c1 = BinConstraintT(my_reshape, t2_type, op_eq)  # type: ignore[union-attr]
-    c2 = CanReshape(src_var, t2_type)
+    c2 = CanReshape(src_var, t2_type)  # pyrefly: ignore[bad-argument-type]
 
     return [c1, c2], counter
 
 
 @register_inference_rule(BatchNorm2d)
-def batchnorm_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def batchnorm_inference_rule(
+    n: Node,
+    module_instance: BatchNorm2d,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -1434,7 +1593,13 @@ def batchnorm_inference_rule(n: Node, module_instance, symbols, constraints, cou
 
 
 @register_inference_rule(torch.nn.AdaptiveAvgPool2d)
-def adaptive_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def adaptive_inference_rule(
+    n: Node,
+    module_instance: torch.nn.AdaptiveAvgPool2d,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -1453,7 +1618,16 @@ def adaptive_inference_rule(n: Node, module_instance, symbols, constraints, coun
     c2 = BinConstraintT(
         avg_pool,
         TensorType(
-            [d1, d2, module_instance.output_size[0], module_instance.output_size[1]]
+            [
+                d1,
+                d2,
+                module_instance.output_size[  # pyrefly: ignore[bad-index, unsupported-operation]
+                    0
+                ],
+                module_instance.output_size[  # pyrefly: ignore[bad-index, unsupported-operation]
+                    1
+                ],
+            ]
         ),
         op_eq,
     )
@@ -1462,7 +1636,13 @@ def adaptive_inference_rule(n: Node, module_instance, symbols, constraints, coun
 
 
 @register_inference_rule(Conv2d)
-def conv2d_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def conv2d_inference_rule(
+    n: Node,
+    module_instance: Conv2d,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -1481,12 +1661,12 @@ def conv2d_inference_rule(n: Node, module_instance, symbols, constraints, counte
 
     c3 = CalcConv(
         my_conv,
-        input_var,
+        input_var,  # pyrefly: ignore[bad-argument-type]
         module_instance.out_channels,
-        module_instance.kernel_size,
-        module_instance.padding,
-        module_instance.stride,
-        module_instance.dilation,
+        module_instance.kernel_size,  # pyrefly: ignore[bad-argument-type]
+        module_instance.padding,  # pyrefly: ignore[bad-argument-type]
+        module_instance.stride,  # pyrefly: ignore[bad-argument-type]
+        module_instance.dilation,  # pyrefly: ignore[bad-argument-type]
         [d1, d2, d3, d4],
     )
 
@@ -1496,7 +1676,13 @@ def conv2d_inference_rule(n: Node, module_instance, symbols, constraints, counte
 
 
 @register_inference_rule(torch.nn.MaxPool2d)
-def maxpool_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def maxpool_inference_rule(
+    n: Node,
+    module_instance: torch.nn.MaxPool2d,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     maxpool, counter = gen_tvar(counter)
@@ -1510,7 +1696,7 @@ def maxpool_inference_rule(n: Node, module_instance, symbols, constraints, count
 
     c2 = CalcMaxPool(
         maxpool,
-        input_var,
+        input_var,  # pyrefly: ignore[bad-argument-type]
         module_instance.kernel_size,
         module_instance.padding,
         module_instance.stride,
@@ -1524,21 +1710,21 @@ def maxpool_inference_rule(n: Node, module_instance, symbols, constraints, count
 
 
 class ConstraintGenerator:
-    def __init__(self, traced, graph=None):
+    def __init__(self, traced: torch.nn.Module, graph: Graph | None = None) -> None:
         self.traced = traced  # traced or tracer.root
         self.traced_params = dict(self.traced.named_parameters())
         self.constraints = []
         self.symbol_dict = {}
         self.graph = traced.graph if hasattr(traced, "graph") else graph
 
-    def generate_constraints(self, counter=0):
+    def generate_constraints(self, counter: int = 0) -> tuple[Conj, int]:
         """
         Iterate through every node and generate constraints
         Effect: self.constraints will be populated with the final constraints
         """
         graph = self.graph
 
-        all_constraints = []
+        all_constraints: list[Constraint] = []
 
         # pyrefly: ignore [missing-attribute]
         for n in graph.nodes:
@@ -1547,7 +1733,9 @@ class ConstraintGenerator:
 
         return Conj(all_constraints), counter
 
-    def generate_constraints_node(self, n: Node, counter):
+    def generate_constraints_node(
+        self, n: Node, counter: int
+    ) -> tuple[list[Constraint], int]:
         """
         Generate constraints the given node:
         Currently supported operations:
@@ -1586,7 +1774,9 @@ class ConstraintGenerator:
                 )
 
         elif n.op == "call_module":
-            module_instance = self.traced.get_submodule(n.target)
+            module_instance = self.traced.get_submodule(
+                n.target  # pyrefly: ignore[bad-argument-type]
+            )
             if type(module_instance) in _INFERENCE_RULES:
                 return _INFERENCE_RULES[type(module_instance)](
                     n, module_instance, self.symbol_dict, self.constraints, counter
@@ -1607,7 +1797,9 @@ class ConstraintGenerator:
                 )
 
         elif n.op == "get_attr":
-            t = self.traced_params.get(n.target, None)
+            t = self.traced_params.get(  # pyrefly: ignore[no-matching-overload]
+                n.target, None
+            )
 
             if isinstance(t, torch.Tensor):
                 if len(t.shape) > 0:
@@ -1618,12 +1810,12 @@ class ConstraintGenerator:
                     return [BinConstraintT(output, attr_type, op_eq)], counter
                 else:
                     # scalar?
-                    return [], counter
+                    return [], counter  # pyrefly: ignore[implicit-any]
             else:
-                return [], counter
+                return [], counter  # pyrefly: ignore[implicit-any]
 
         elif n.op == "output":
-            return [], counter
+            return [], counter  # pyrefly: ignore[implicit-any]
 
         else:
             raise NotImplementedError(f"Method {n.op} not yet implemented")

--- a/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
@@ -1,7 +1,6 @@
-# mypy: ignore-errors
 import copy
 import itertools
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 from torch.fx.experimental.migrate_gradual_types.constraint import (
     ApplyBroadcasting,
@@ -47,14 +46,54 @@ from torch.fx.experimental.migrate_gradual_types.util import (
     gen_nat_constraints,
     gen_tensor_dims,
 )
-from torch.fx.tensor_type import Dyn, TensorType
+from torch.fx.tensor_type import _DynType, Dyn, TensorType
 
 
-_TRANSFORMATION_RULES: dict[Constraint, Callable] = {}
+__all__ = [
+    "apply_padding",
+    "broadcast_dim",
+    "calc_last_two_dims",
+    "create_equality_constraints_for_broadcasting",
+    "gen_all_reshape_possibilities",
+    "gen_broadcasting_constraints",
+    "gen_consistency_constraints",
+    "gen_greatest_upper_bound",
+    "gen_lists_of_dims",
+    "generate_all_broadcasting_possibilities_no_padding",
+    "generate_all_int_dyn_dim_possibilities",
+    "generate_binconstraint_d",
+    "generate_binconstraint_t",
+    "generate_broadcasting",
+    "generate_calc_conv",
+    "generate_calc_maxpool",
+    "generate_calc_product",
+    "generate_conj",
+    "generate_d_gub",
+    "generate_disj",
+    "generate_gub",
+    "generate_reshape",
+    "is_dim_div_by_target",
+    "is_target_div_by_dim",
+    "no_broadcast_dim_with_index",
+    "register_transformation_rule",
+    "transform_constraint",
+    "transform_get_item",
+    "transform_get_item_tensor",
+    "transform_index_select",
+    "transform_transpose",
+    "valid_index",
+    "valid_index_tensor",
+]
 
 
-def register_transformation_rule(call_target):
-    def register(fn):
+_TransformFn = Callable[[Constraint, int], tuple[Constraint, int]]
+_TRANSFORMATION_RULES: dict[type, _TransformFn] = {}
+
+
+def register_transformation_rule(
+    call_target: type[Constraint],
+) -> Callable[[_TransformFn], _TransformFn]:
+    def register(fn: _TransformFn) -> _TransformFn:
         if call_target in _TRANSFORMATION_RULES:
             raise RuntimeError(
                 f"Transformation rule already registered for {call_target}!"
@@ -65,7 +104,7 @@ def register_transformation_rule(call_target):
     return register
 
 
-def valid_index(index, dims):
+def valid_index(index: int, dims: list[DVar]) -> Constraint:
     """
     Given a list of dimensions, checks if an index is valid in the list
     """
@@ -77,10 +116,12 @@ def valid_index(index, dims):
 
 
 @register_transformation_rule(Transpose)
-def transform_transpose(constraint, counter):
+def transform_transpose(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Similar to a sequence of two index-selects
     """
+    if not isinstance(constraint, Transpose):
+        raise TypeError(type(constraint))
     dims, counter = gen_tensor_dims(constraint.tensor_size, counter)
     is_valid_index1 = valid_index(constraint.index1, dims)
     is_valid_index2 = valid_index(constraint.index2, dims)
@@ -104,21 +145,25 @@ def transform_transpose(constraint, counter):
 
 
 @register_transformation_rule(IndexSelect)
-def transform_index_select(constraint, counter):
+def transform_index_select(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     The constraints consider the given tensor size, checks if the index is valid
     and if so, generates a constraint for replacing the input dimension
     with the required dimension
     """
+    if not isinstance(constraint, IndexSelect):
+        raise TypeError(type(constraint))
     dims, counter = gen_tensor_dims(constraint.tensor_size, counter)
     is_valid_index = valid_index(constraint.index, dims)
     nat_constraints = gen_nat_constraints(dims)
 
     # if the index is valid then replace the input dimension with the new dimension
     # otherwise the dimension will not be replaced and the clause will contain False
+    new_dims = copy.deepcopy(dims)
     if is_valid_index == T():
-        new_dims = copy.deepcopy(dims)
-        new_dims[constraint.index] = constraint.dim_replace
+        new_dims[constraint.index] = constraint.dim_replace  # type: ignore[unsupported-operation]
 
     transformed_constraint = Conj(
         [
@@ -134,7 +179,7 @@ def transform_index_select(constraint, counter):
 
 
 @register_transformation_rule(GetItem)
-def transform_get_item(constraint, counter):
+def transform_get_item(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     generate an equality of the form:
     t = [a1, ..., an]
@@ -149,6 +194,8 @@ def transform_get_item(constraint, counter):
     Returns: simplified constraints for GetItem
 
     """
+    if not isinstance(constraint, GetItem):
+        raise TypeError(type(constraint))
     dims, counter = gen_tensor_dims(constraint.tensor_size, counter)
     nat_constraints = gen_nat_constraints(dims)
 
@@ -170,7 +217,7 @@ def transform_get_item(constraint, counter):
     return Conj(all_constraints), counter
 
 
-def valid_index_tensor(index, dims):
+def valid_index_tensor(index: tuple[None | slice, ...], dims: list[DVar]) -> Constraint:
     """
     if the slice instances exceed the length of the dimensions
     then this is a type error so we return False
@@ -186,7 +233,9 @@ def valid_index_tensor(index, dims):
 
 
 @register_transformation_rule(GetItemTensor)
-def transform_get_item_tensor(constraint, counter):
+def transform_get_item_tensor(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     When the index is a tuple, then the output will be a tensor
     TODO: we have to check if this is the case for all HF models
@@ -200,6 +249,8 @@ def transform_get_item_tensor(constraint, counter):
 
      slice with default arguments does not change the rank
     """
+    if not isinstance(constraint, GetItemTensor):
+        raise TypeError(type(constraint))
     if not isinstance(constraint.index_tuple, tuple):
         raise AssertionError(
             f"Expected tuple for index_tuple, got {type(constraint.index_tuple)}"
@@ -212,7 +263,8 @@ def transform_get_item_tensor(constraint, counter):
     # generate a place-holder list of the right rank
     # where "slice" does not contribute to the rank and "None" does
     none_c = constraint.index_tuple.count(None)
-    resulting_tensor_dims = (none_c + len(dims)) * [None]
+    # list invariance: [None] * n types as list[None], but elements are reassigned to int/DVar
+    resulting_tensor_dims: list[int | DVar | None] = [None] * (none_c + len(dims))  # type: ignore[assignment]
 
     dim_index = 0
     for i in range(len(constraint.index_tuple)):
@@ -251,10 +303,14 @@ def transform_get_item_tensor(constraint, counter):
 
 
 @register_transformation_rule(BinConstraintT)
-def generate_binconstraint_t(constraint, counter):
+def generate_binconstraint_t(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transform binary constraints for tensors
     """
+    if not isinstance(constraint, BinConstraintT):
+        raise TypeError(type(constraint))
 
     # precision constraints
     if constraint.op == op_precision:
@@ -280,6 +336,8 @@ def generate_binconstraint_t(constraint, counter):
                     + [BinConstraintD(1, new_dim, op_leq) for new_dim in new_dims]
                 )
                 return Conj(new_dim_constraints), counter
+        else:
+            return constraint, counter
 
     # matching
     elif constraint.op == op_matching:
@@ -342,15 +400,21 @@ def generate_binconstraint_t(constraint, counter):
 
 
 @register_transformation_rule(BinConstraintD)
-def generate_binconstraint_d(constraint, counter):
+def generate_binconstraint_d(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transform binary constraints for dimensions
     """
+    if not isinstance(constraint, BinConstraintD):
+        raise TypeError(type(constraint))
     if constraint.op == op_precision:
         if isinstance(constraint.lhs, int):
             return BinConstraintD(constraint.lhs, constraint.rhs, op_eq), counter
         elif constraint.lhs == Dyn:
             return T(), counter
+        else:
+            return constraint, counter
 
     elif constraint.op == op_consistency:
         return (
@@ -369,10 +433,12 @@ def generate_binconstraint_d(constraint, counter):
 
 
 @register_transformation_rule(Conj)
-def generate_conj(constraint, counter):
+def generate_conj(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Transform conjunctions
     """
+    if not isinstance(constraint, Conj):
+        raise TypeError(type(constraint))
     new = []
     for c in constraint.conjucts:
         new_c, counter = transform_constraint(c, counter)
@@ -381,10 +447,12 @@ def generate_conj(constraint, counter):
 
 
 @register_transformation_rule(Disj)
-def generate_disj(constraint, counter):
+def generate_disj(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Transform disjunctions
     """
+    if not isinstance(constraint, Disj):
+        raise TypeError(type(constraint))
     new = []
     for c in constraint.disjuncts:
         new_c, counter = transform_constraint(c, counter)
@@ -393,11 +461,13 @@ def generate_disj(constraint, counter):
 
 
 @register_transformation_rule(TGreatestUpperBound)
-def generate_gub(constraint, counter):
+def generate_gub(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Transform greatest upper bound for tensors. Results in equality and Greatest Upper Bound
     on dimensions
     """
+    if not isinstance(constraint, TGreatestUpperBound):
+        raise TypeError(type(constraint))
     c1 = Conj(
         [
             Disj(
@@ -416,10 +486,12 @@ def generate_gub(constraint, counter):
 
 
 @register_transformation_rule(DGreatestUpperBound)
-def generate_d_gub(constraint, counter):
+def generate_d_gub(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Transform greatest upper bound for dimensions into equality constraints
     """
+    if not isinstance(constraint, DGreatestUpperBound):
+        raise TypeError(type(constraint))
     c1 = Conj(
         [
             BinConstraintD(constraint.rhs1, Dyn, op_eq),
@@ -442,7 +514,9 @@ def generate_d_gub(constraint, counter):
 
 
 @register_transformation_rule(CalcConv)
-def generate_calc_conv(constraint, counter):
+def generate_calc_conv(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
+    if not isinstance(constraint, CalcConv):
+        raise TypeError(type(constraint))
     d, counter = gen_tensor_dims(4, counter)
     conv_result = TensorType([d[0], d[1], d[2], d[3]])
 
@@ -475,10 +549,14 @@ def generate_calc_conv(constraint, counter):
 
 
 @register_transformation_rule(CalcMaxPool)
-def generate_calc_maxpool(constraint, counter):
+def generate_calc_maxpool(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transform maxpool constraints
     """
+    if not isinstance(constraint, CalcMaxPool):
+        raise TypeError(type(constraint))
     d, counter = gen_tensor_dims(4, counter)
     maxpool_result = TensorType([d[0], d[1], d[2], d[3]])
 
@@ -503,10 +581,14 @@ def generate_calc_maxpool(constraint, counter):
 
 
 @register_transformation_rule(CalcProduct)
-def generate_calc_product(constraint, counter):
+def generate_calc_product(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transform flatten constraints
     """
+    if not isinstance(constraint, CalcProduct):
+        raise TypeError(type(constraint))
     start = constraint.start
     end = constraint.end
     dims = constraint.dims_to_flatten
@@ -524,7 +606,7 @@ def generate_calc_product(constraint, counter):
 
     all_possibilities = generate_all_int_dyn_dim_possibilities(mid)
 
-    all_constraints = []
+    all_constraints: list[Constraint] = []
 
     for p in all_possibilities:
         p = list(p)
@@ -575,10 +657,12 @@ def generate_calc_product(constraint, counter):
 
 
 @register_transformation_rule(CanReshape)
-def generate_reshape(constraint, counter):
+def generate_reshape(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Transform reshape constraints
     """
+    if not isinstance(constraint, CanReshape):
+        raise TypeError(type(constraint))
     d, counter = gen_tensor_dims(4, counter)
 
     d1 = d[0]
@@ -710,10 +794,14 @@ def generate_reshape(constraint, counter):
 
 
 @register_transformation_rule(ApplyBroadcasting)
-def generate_broadcasting(constraint, counter):
+def generate_broadcasting(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transform broadcasting constraints
     """
+    if not isinstance(constraint, ApplyBroadcasting):
+        raise TypeError(type(constraint))
     e11, e12 = constraint.res1, constraint.res2
     e1, e2 = constraint.input1, constraint.input2
 
@@ -784,7 +872,9 @@ def generate_broadcasting(constraint, counter):
     )
 
 
-def transform_constraint(constraint: Constraint, counter: int):
+def transform_constraint(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transforms a constraint into a simpler constraint.
     Ex: precision and consistency are transformed to equality
@@ -802,7 +892,9 @@ def transform_constraint(constraint: Constraint, counter: int):
         return constraint, counter
 
 
-def calc_last_two_dims(constraint, d: list[DVar]):
+def calc_last_two_dims(
+    constraint: CalcConv | CalcMaxPool, d: list[DVar]
+) -> tuple[Constraint, Constraint]:
     """
     Generates constraints for the last two dimensions of a convolution or a maxpool output
     Args:
@@ -874,7 +966,9 @@ def calc_last_two_dims(constraint, d: list[DVar]):
     return c4, c5
 
 
-def generate_all_int_dyn_dim_possibilities(my_list: list[DVar]):
+def generate_all_int_dyn_dim_possibilities(
+    my_list: list[DVar],
+) -> list[tuple[BinConstraintD, ...]]:
     """
     Generate all possibilities of being equal or not equal to dyn for my_list
     Args:
@@ -896,7 +990,9 @@ def generate_all_int_dyn_dim_possibilities(my_list: list[DVar]):
     return all_possibilities
 
 
-def is_target_div_by_dim(target: list[int], dim: list[DVar]):
+def is_target_div_by_dim(
+    target: Sequence[DVar | int | _DynType], dim: DVar | Prod
+) -> BinConstraintD:
     """
     Generate constraints to check if the target dimensions are divisible by the input dimensions
     Args:
@@ -909,7 +1005,9 @@ def is_target_div_by_dim(target: list[int], dim: list[DVar]):
     return BinConstraintD(BinConstraintD(Prod(target), dim, op_mod), 0, op_eq)
 
 
-def is_dim_div_by_target(target: list[int], dim: list[DVar]):
+def is_dim_div_by_target(
+    target: Sequence[DVar | int | _DynType], dim: DVar | Prod
+) -> BinConstraintD:
     """
     Generate constraints to check if the input dimensions is divisible by the target dimensions
     Args:
@@ -922,7 +1020,9 @@ def is_dim_div_by_target(target: list[int], dim: list[DVar]):
     return BinConstraintD(BinConstraintD(dim, Prod(target), op_mod), 0, op_eq)
 
 
-def gen_all_reshape_possibilities(list_of_dims, target):
+def gen_all_reshape_possibilities(
+    list_of_dims: list[DVar], target: Sequence[DVar | int | _DynType]
+) -> Constraint:
     """
     Consider all possibilities what the input dimensions could be (number or dynamic)
     Then generate the appropriate constraints using multiplication or mod depending on the possibility
@@ -942,7 +1042,7 @@ def gen_all_reshape_possibilities(list_of_dims, target):
     all_constraints = []
 
     for p in all_possibilities:
-        to_multiply = []
+        to_multiply: list[DVar] = []
 
         p = list(p)
 
@@ -950,7 +1050,7 @@ def gen_all_reshape_possibilities(list_of_dims, target):
             if not isinstance(constraint, BinConstraintD):
                 raise AssertionError(f"Expected BinConstraintD, got {type(constraint)}")
             if constraint.op == op_neq:
-                to_multiply.append(constraint.lhs)
+                to_multiply.append(constraint.lhs)  # type: ignore[arg-type]
 
         if not to_multiply:
             all_constraints.append(Conj(p))
@@ -967,7 +1067,14 @@ def gen_all_reshape_possibilities(list_of_dims, target):
     return Disj(all_constraints)
 
 
-def broadcast_dim(tensor_input1, tensor_input2, res1, res2, index, padding=False):
+def broadcast_dim(
+    tensor_input1: Sequence[DVar | None],
+    tensor_input2: Sequence[DVar],
+    res1: Sequence[DVar],
+    res2: Sequence[DVar],
+    index: int,
+    padding: bool = False,
+) -> Constraint:
     """
     Apply broadcasting to the 'index' dimension of tensor_input1.
     Args:
@@ -989,7 +1096,7 @@ def broadcast_dim(tensor_input1, tensor_input2, res1, res2, index, padding=False
         # then the inputs are the same length so they all have dimensions at "index"
         return Conj(
             [
-                BinConstraintD(tensor_input1[index], 1, op_eq),
+                BinConstraintD(tensor_input1[index], 1, op_eq),  # type: ignore[arg-type]
                 BinConstraintD(res1[index], res2[index], op_eq),
                 BinConstraintD(res2[index], tensor_input2[index], op_eq),
             ]
@@ -1014,7 +1121,7 @@ def apply_padding(
     d11: list[DVar],
     d12: list[DVar],
     counter: int,
-):
+) -> tuple[Constraint, int]:
     """
     We are considering the possibility where one input has less dimensions than
     another input, so we apply padding to the broadcasted results
@@ -1080,7 +1187,7 @@ def apply_padding(
 
 def no_broadcast_dim_with_index(
     d1: list[DVar], d2: list[DVar], d3: list[DVar], d4: list[DVar], i: int
-):
+) -> Constraint:
     """
     Args:
         d1: input 1
@@ -1115,7 +1222,9 @@ def no_broadcast_dim_with_index(
     )
 
 
-def gen_lists_of_dims(num_tensors: int, dim_size: int, counter: int):
+def gen_lists_of_dims(
+    num_tensors: int, dim_size: int, counter: int
+) -> tuple[list[list[DVar]], int]:
     """
     Generate lists of DVar to represent tensor dimensions
     Args:
@@ -1144,7 +1253,7 @@ def create_equality_constraints_for_broadcasting(
     d2: list[DVar],
     d11: list[DVar],
     d12: list[DVar],
-):
+) -> list[BinConstraintT]:
     """
     Create equality constraints for when no broadcasting occurs
     Args:
@@ -1168,7 +1277,9 @@ def create_equality_constraints_for_broadcasting(
     return [e1_tensor, e11_tensor, e2_tensor, e12_tensor]
 
 
-def gen_consistency_constraints(constraint: Constraint, counter: int):
+def gen_consistency_constraints(
+    constraint: BinConstraintT, counter: int
+) -> tuple[list[Constraint], int]:
     """
     Args:
         constraint: Consistency constraint on tensors
@@ -1178,7 +1289,7 @@ def gen_consistency_constraints(constraint: Constraint, counter: int):
 
     """
 
-    all_constraints = []
+    all_constraints: list[Constraint] = []
 
     for i in range(1, MAX_TENSOR_RANK + 1):
         new_dims_rhs_1, counter = gen_tensor_dims(i, counter)
@@ -1203,7 +1314,9 @@ def gen_consistency_constraints(constraint: Constraint, counter: int):
     return all_constraints, counter
 
 
-def gen_greatest_upper_bound(constraint: TGreatestUpperBound, counter: int):
+def gen_greatest_upper_bound(
+    constraint: TGreatestUpperBound, counter: int
+) -> tuple[list[Constraint], int]:
     """
     Args:
         constraint: Greatest upper bound on tensors
@@ -1213,10 +1326,10 @@ def gen_greatest_upper_bound(constraint: TGreatestUpperBound, counter: int):
 
     """
 
-    all_constraints = []
+    all_constraints: list[Constraint] = []
 
     for i in range(1, MAX_TENSOR_RANK + 1):
-        c = []
+        c: list[Constraint] = []
         dims1, counter = gen_tensor_dims(i, counter)
         c1tensor = TensorType(dims1)
 
@@ -1249,7 +1362,7 @@ def gen_greatest_upper_bound(constraint: TGreatestUpperBound, counter: int):
 
 def generate_all_broadcasting_possibilities_no_padding(
     d1: list[DVar], d2: list[DVar], d11: list[DVar], d12: list[DVar]
-):
+) -> Constraint:
     """
     Generate broadcasting constraints assuming no padding. Broadcasting can happen at any dimension.
     We look at all combinations for all dimensions in d1 and d2
@@ -1279,7 +1392,7 @@ def generate_all_broadcasting_possibilities_no_padding(
 
 def gen_broadcasting_constraints(
     e1: TVar, e2: TVar, e11: TVar, e12: TVar, i: int, counter: int
-):
+) -> tuple[Constraint, Constraint, Constraint, list[BinConstraintD], int]:
     """
     Simulates broadcasting on e1 and e2 and returns the results
     respectively in e11 and e12. Because of gradual types,

--- a/torch/fx/experimental/migrate_gradual_types/transform_to_z3.py
+++ b/torch/fx/experimental/migrate_gradual_types/transform_to_z3.py
@@ -1,9 +1,29 @@
-# mypy: allow-untyped-defs
+from typing import Any, TypeAlias
+
+import torch
+
+
+__all__ = [
+    "evaluate_conditional_with_constraints",
+    "iterate_till_fixed_point",
+    "transform_algebraic_expression",
+    "transform_all_constraints",
+    "transform_all_constraints_trace_time",
+    "transform_dimension",
+    "transform_to_z3",
+    "transform_var",
+]
+
+
+# z3 is an optional dependency with no type stubs, so we use aliases for its types.
+_Z3Expr: TypeAlias = Any
+_Z3Result: TypeAlias = Any
 from torch.fx.experimental.migrate_gradual_types.constraint import (
     BinConstraintD,
     BinConstraintT,
     BVar,
     Conj,
+    Constraint,
     Disj,
     DVar,
     F,
@@ -32,7 +52,9 @@ from torch.fx.experimental.migrate_gradual_types.operation import (
     op_neq,
     op_sub,
 )
-from torch.fx.tensor_type import Dyn, TensorType
+from torch.fx.graph import Graph
+from torch.fx.node import Node
+from torch.fx.tensor_type import _DynType, Dyn, TensorType
 
 
 try:
@@ -46,7 +68,9 @@ try:
 
     HAS_Z3 = True
 
-    def transform_to_z3(constraint, counter, dimension_dict):
+    def transform_to_z3(
+        constraint: Constraint, counter: int, dimension_dict: dict[int, int]
+    ) -> tuple[_Z3Expr, int]:
         if isinstance(constraint, Conj):
             conjuncts = []
             for c in constraint.conjucts:
@@ -69,8 +93,16 @@ try:
 
         elif isinstance(constraint, BinConstraintT):
             if constraint.op == op_eq:
-                lhs, counter = transform_var(constraint.lhs, counter, dimension_dict)
-                rhs, counter = transform_var(constraint.rhs, counter, dimension_dict)
+                lhs, counter = transform_var(
+                    constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
+                )
+                rhs, counter = transform_var(
+                    constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
+                )
                 return (lhs == rhs), counter
 
             else:
@@ -80,7 +112,9 @@ try:
             if constraint.op == op_eq:
                 if isinstance(constraint.lhs, BVar) and is_bool_expr(constraint.rhs):
                     transformed_rhs, counter = transform_to_z3(
-                        constraint.rhs, counter, dimension_dict
+                        constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                        counter,
+                        dimension_dict,
                     )
                     transformed_lhs = z3.Bool(constraint.lhs.c)
                     return transformed_lhs == transformed_rhs, counter
@@ -88,10 +122,14 @@ try:
                 elif is_dim(constraint.lhs) and is_dim(constraint.rhs):
                     # with dimension transformations we consider the encoding
                     lhs, counter = transform_dimension(
-                        constraint.lhs, counter, dimension_dict
+                        constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                        counter,
+                        dimension_dict,
                     )
                     rhs, counter = transform_dimension(
-                        constraint.rhs, counter, dimension_dict
+                        constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                        counter,
+                        dimension_dict,
                     )
                     return lhs == rhs, counter
 
@@ -99,10 +137,14 @@ try:
                     # then we have an algebraic expression which means that we disregard the
                     # first element of the encoding
                     lhs, counter = transform_algebraic_expression(
-                        constraint.lhs, counter, dimension_dict
+                        constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                        counter,
+                        dimension_dict,
                     )
                     rhs, counter = transform_algebraic_expression(
-                        constraint.rhs, counter, dimension_dict
+                        constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                        counter,
+                        dimension_dict,
                     )
                     return lhs == rhs, counter
 
@@ -113,15 +155,19 @@ try:
                 if not is_dim(constraint.rhs):
                     raise AssertionError("Expected rhs to be a dimension")
                 lhs, counter = transform_dimension(
-                    constraint.lhs, counter, dimension_dict
+                    constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 rhs, counter = transform_dimension(
-                    constraint.rhs, counter, dimension_dict
+                    constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 if constraint.rhs == Dyn or constraint.lhs == Dyn:
                     if constraint.rhs == Dyn:
                         return lhs.arg(0) == 1, counter
-                    elif constraint.lhs == Dyn:
+                    else:
                         return rhs.arg(0) == 1, counter
 
                 # if one of the instances is a number
@@ -137,7 +183,7 @@ try:
                             counter,
                         )
 
-                    elif isinstance(constraint.rhs, int):
+                    else:
                         return (
                             z3.Or(
                                 [
@@ -173,10 +219,14 @@ try:
                 if not (is_dim(constraint.lhs) and is_dim(constraint.rhs)):
                     raise AssertionError("Expected both lhs and rhs to be dimensions")
                 lhs, counter = transform_algebraic_expression(
-                    constraint.lhs, counter, dimension_dict
+                    constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 rhs, counter = transform_algebraic_expression(
-                    constraint.rhs, counter, dimension_dict
+                    constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 return lhs <= rhs, counter
 
@@ -184,10 +234,14 @@ try:
                 if not (is_dim(constraint.lhs) and is_dim(constraint.rhs)):
                     raise AssertionError("Expected both lhs and rhs to be dimensions")
                 lhs, counter = transform_algebraic_expression(
-                    constraint.lhs, counter, dimension_dict
+                    constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 rhs, counter = transform_algebraic_expression(
-                    constraint.rhs, counter, dimension_dict
+                    constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 return lhs > rhs, counter
 
@@ -195,10 +249,14 @@ try:
                 if not (is_dim(constraint.lhs) and is_dim(constraint.rhs)):
                     raise AssertionError("Expected both lhs and rhs to be dimensions")
                 lhs, counter = transform_algebraic_expression(
-                    constraint.lhs, counter, dimension_dict
+                    constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 rhs, counter = transform_algebraic_expression(
-                    constraint.rhs, counter, dimension_dict
+                    constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 return lhs < rhs, counter
 
@@ -208,7 +266,11 @@ try:
         else:
             raise NotImplementedError("Operation not yet implemented")
 
-    def transform_var(tensor, counter, dimension_dict):
+    def transform_var(
+        tensor: TVar | TensorType | _DynType,
+        counter: int,
+        dimension_dict: dict[int, int],
+    ) -> tuple[_Z3Expr, int]:
         """
         Transforms tensor variables to a format understood by z3
         Args:
@@ -217,7 +279,7 @@ try:
 
         """
         if isinstance(tensor, TensorType):
-            res = []
+            res: list[_Z3Expr] = []
             for t in tensor.__args__:
                 transformed, counter = transform_dimension(t, counter, dimension_dict)
                 res.append(transformed)
@@ -232,6 +294,10 @@ try:
                 return tensor_type.tensor3(res[0], res[1], res[2]), counter
             elif len(tensor.__args__) == 4:
                 return tensor_type.tensor4(res[0], res[1], res[2], res[3]), counter
+            else:
+                raise AssertionError(
+                    f"Unexpected tensor args length: {len(tensor.__args__)}"
+                )
 
         elif tensor == Dyn:
             return z3_dyn, counter
@@ -239,7 +305,12 @@ try:
         elif isinstance(tensor, TVar):
             return z3.Const(tensor.tvar, tensor_type), counter
 
-    def transform_dimension(dimension, counter, dimension_dict):
+        else:
+            raise NotImplementedError(f"Unsupported tensor type: {type(tensor)}")
+
+    def transform_dimension(
+        dimension: DVar | int | _DynType, counter: int, dimension_dict: dict[int, int]
+    ) -> tuple[_Z3Expr, int]:
         """
         Takes a dimension variable or a number and transforms it to a tuple
         according to our scheme
@@ -266,7 +337,14 @@ try:
                 dimension_dict[dimension.c] = counter
                 return D(z3.Int(counter), z3.Int(dimension.c)), counter
 
-    def transform_algebraic_expression(expr, counter, dimension_dict):
+        else:
+            raise NotImplementedError(f"Unsupported dimension type: {type(dimension)}")
+
+    def transform_algebraic_expression(
+        expr: DVar | int | _DynType | Prod | BinConstraintD,
+        counter: int,
+        dimension_dict: dict[int, int],
+    ) -> tuple[_Z3Expr, int]:
         """
         Transforms an algebraic expression to z3 format
         Args:
@@ -280,7 +358,11 @@ try:
             raise AssertionError("Expected algebraic expression or dimension")
 
         if is_dim(expr):
-            transformed, counter = transform_dimension(expr, counter, dimension_dict)
+            transformed, counter = transform_dimension(
+                expr,  # pyrefly: ignore[bad-argument-type]
+                counter,
+                dimension_dict,
+            )
             return transformed.arg(1), counter
 
         elif isinstance(expr, Prod):
@@ -294,13 +376,17 @@ try:
 
         elif is_algebraic_expression(expr):
             lhs, counter = transform_algebraic_expression(
-                expr.lhs, counter, dimension_dict
+                expr.lhs,  # pyrefly: ignore[missing-attribute]
+                counter,
+                dimension_dict,
             )
             rhs, counter = transform_algebraic_expression(
-                expr.rhs, counter, dimension_dict
+                expr.rhs,  # pyrefly: ignore[missing-attribute]
+                counter,
+                dimension_dict,
             )
 
-            if expr.op == op_sub:
+            if expr.op == op_sub:  # pyrefly: ignore[missing-attribute]
                 c = lhs - rhs
 
             elif expr.op == op_add:
@@ -323,31 +409,25 @@ try:
         else:
             raise RuntimeError
 
-    def transform_all_constraints(traced, counter=0):
+    def transform_all_constraints(traced: torch.nn.Module, counter: int = 0) -> _Z3Expr:
         """
         Given a trace, generates constraints and transforms them to z3 format
 
         """
-        dimension_dict = {}  # type: ignore[var-annotated]
+        dimension_dict: dict[int, int] = {}
 
         generator = ConstraintGenerator(traced)
         new_constraints, counter = generator.generate_constraints(counter)
 
-        # print(new_constraints.conjucts[0])
-        # print(*new_constraints.conjucts, sep='\n')
-
-        # transform precision, matching, consistency till obtaining a fixed point
         new_constraints, counter = iterate_till_fixed_point(new_constraints, counter)
-        # print(new_constraints)
-        # print(new_constraints.conjucts)
-        # new_constraints.conjucts = new_constraints.conjucts[:-1]
-        # print(*new_constraints.conjucts, sep='\n')
 
         transformed, counter = transform_to_z3(new_constraints, counter, dimension_dict)
         # print(transformed)
         return transformed
 
-    def iterate_till_fixed_point(constraints, counter):
+    def iterate_till_fixed_point(
+        constraints: Constraint, counter: int
+    ) -> tuple[Constraint, int]:
         """
         Transform constraints till reaching a fixed point
         """
@@ -357,7 +437,9 @@ try:
             constraints, counter = transform_constraint(constraints, counter)
         return constraints, counter
 
-    def transform_all_constraints_trace_time(tracer_root, graph, node, counter=0):
+    def transform_all_constraints_trace_time(
+        tracer_root: torch.nn.Module, graph: Graph, node: Node, counter: int = 0
+    ) -> tuple[_Z3Expr, _Z3Expr]:
         """
         Takes a node and a graph and generates two sets of constraints.
         One set constraints the node's constraints and another set
@@ -373,7 +455,7 @@ try:
         its negation.
 
         """
-        dimension_dict = {}  # type: ignore[var-annotated]
+        dimension_dict: dict[int, int] = {}
 
         generator = ConstraintGenerator(tracer_root, graph)
         new_constraints, counter = generator.generate_constraints(counter)
@@ -394,10 +476,14 @@ try:
         # we make sure the constraint is of the form:
         # c = b where b is a boolean expression
         # and we consider b (constraint.rhs) for transformation
+        if not isinstance(condition_constraint, BinConstraintD):
+            raise TypeError(type(condition_constraint))
         if not isinstance(condition_constraint.lhs, BVar):
             raise AssertionError(f"Expected BVar, got {type(condition_constraint.lhs)}")
         if not is_bool_expr(condition_constraint.rhs):
             raise AssertionError("Expected bool expression for rhs")
+        if not isinstance(condition_constraint.rhs, Constraint):
+            raise TypeError(type(condition_constraint.rhs))
         condition_constraint_rhs = condition_constraint.rhs
 
         # transform the condition constraint
@@ -420,8 +506,12 @@ try:
         )
 
     def evaluate_conditional_with_constraints(
-        tracer_root, graph, node, counter=0, user_constraints=None
-    ):
+        tracer_root: torch.nn.Module,
+        graph: Graph,
+        node: Node,
+        counter: int = 0,
+        user_constraints: _Z3Expr | None = None,
+    ) -> tuple[_Z3Result, _Z3Result]:
         """
         Given an IR and a node representing a conditional, evaluate the conditional
         and its negation

--- a/torch/fx/tensor_type.py
+++ b/torch/fx/tensor_type.py
@@ -1,8 +1,16 @@
-from collections.abc import Sequence
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
 
 from torch.fx.experimental.unification import Var  # type: ignore[attr-defined]
 
 from ._compatibility import compatibility
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from torch.fx.experimental.migrate_gradual_types.constraint import DVar
 
 
 __all__ = ["Dyn", "TensorType", "is_consistent", "is_more_precise"]
@@ -18,7 +26,9 @@ class TensorType:
                 return torch.add(x, y)
     """
 
-    def __init__(self, dim: Sequence[object]) -> None:
+    __args__: Sequence[DVar | int | _DynType]
+
+    def __init__(self, dim: Sequence[Any]) -> None:
         self.__origin__ = TensorType
         self.__args__ = dim
 
@@ -32,7 +42,7 @@ class TensorType:
             return False
 
     @staticmethod
-    def __class_getitem__(*args: object) -> "TensorType":
+    def __class_getitem__(*args: object) -> TensorType:
         if len(args) == 1 and isinstance(args[0], tuple):
             args = args[0]
         return TensorType(tuple(args))


### PR DESCRIPTION
…al_types

Remove mypy suppressions. Add return type and parameter type annotations to constraint classes, generator, transformation, and z3 transform.

Authored with Claude.