### PR TITLE
[retrybot] Add Initialize containers to retryable step names

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -59,6 +59,8 @@ retryable_workflows:
 - linux-binary
 - windows-binary
 - inductor-A100-perf-nightly
+retryable_step_names:
+- Initialize containers
 labeler_config: labeler.yml
 label_to_label_config: label_to_label.yml
 mergebot: true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #179999
* #179994
* #179969
* __->__ #180082

OSDC test-osdc jobs that fail at the "Initialize containers" step
(an infra failure) are not being retried by the retrybot. This is
because a cascading failure in "Print remaining test logs" triggers
the user-failure heuristic (step name contains "test"), causing the
bot to skip the retry.

Adding "Initialize containers" to retryable_step_names ensures these
infra failures are always retried regardless of other step failures.

Signed-off-by: Huy Do <huydhn@gmail.com>