### PR TITLE
[Profiler] Improve events() <> chrome trace parity test

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4192,7 +4192,7 @@ class TestProfilerEventsParity(TestCase):
             json_records[key] = metadata_dict_from_trace_args(args)
 
         failure_msg = """
-        IMPORTANT: Are you bumping the Kineto submodule hash and seeing this message?
+        IMPORTANT: Are you making a kineto change or bumping the hash and seeing this message?
         If so, please check the schema for EventMetadata (torch/autograd/profiler_util.py).
         It is currently missing these keys, which were found in the JSON metadata args.
         """

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4160,7 +4160,8 @@ class TestProfilerEventsParity(TestCase):
                 trace = json.load(f)
 
         json_records = {}
-        unexpected_trace_key_failures = []
+        # Track unexpected (event_name, cat, key) combos, deduplicated
+        unexpected_combos: set[tuple[str, str, str]] = set()
 
         # Loop through the trace events to perform a comparison
         for te in trace["traceEvents"]:
@@ -4175,12 +4176,8 @@ class TestProfilerEventsParity(TestCase):
                 continue
 
             # Any metadata keys that show up in JSON should show up in events()
-            unexpected_trace_keys = set(args) - supported_trace_keys
-            if unexpected_trace_keys:
-                unexpected_trace_key_failures.append(
-                    f"Event: {(te['name'][:100], cat, ext_id, correlation)}\n"
-                    f"Unexpected keys: {sorted(unexpected_trace_keys)}"
-                )
+            for k in set(args) - supported_trace_keys:
+                unexpected_combos.add((te["name"][:100], cat, k))
 
             # Build the same key from JSON to try to match with a FunctionEvent
             key = (te["name"], te["cat"], ext_id, correlation)
@@ -4211,10 +4208,12 @@ to the events() property. The steps are:
 
 For a model PR to follow, see: https://github.com/pytorch/pytorch/pull/180100
 ===================================================================================="""
-        if unexpected_trace_key_failures:
-            raise AssertionError(
-                f"\n{failure_msg}\n" + "\n\n".join(unexpected_trace_key_failures)
+        if unexpected_combos:
+            summary = "\n".join(
+                f"  {name} ({cat}): {key!r}"
+                for name, cat, key in sorted(unexpected_combos)
             )
+            raise AssertionError(f"\n{failure_msg}\n\nUnmapped keys:\n{summary}")
 
         self.assertGreater(len(json_records), 0, "No device-side records were compared")
         self.assertEqual(

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4191,13 +4191,26 @@ class TestProfilerEventsParity(TestCase):
             )
             json_records[key] = metadata_dict_from_trace_args(args)
 
-        failure_msg = """
-        ====================================================================================
-        IMPORTANT: Are you making a kineto change or bumping the hash and seeing this message?
-        If so, please check the schema for EventMetadata (torch/autograd/profiler_util.py).
-        It is currently missing these keys, which were found in the JSON metadata args.
-        =====================================================================================
-        """
+        failure_msg = """\
+====================================================================================
+IMPORTANT: Are you making a Kineto change or bumping the third_party/kineto
+submodule hash and seeing this message?
+
+New metadata keys (see below) were found in the Chrome trace JSON that are not
+yet exposed through the profiler's events() API (i.e. EventMetadata in
+torch/autograd/profiler_util.py).
+
+To fix this properly, you need to make sure the new Kineto data makes its way
+to the events() property. The steps are:
+
+1. Add the new key(s) to _EVENT_METADATA_KEYS in torch/autograd/profiler_util.py
+   with the appropriate field name and type converter.
+2. Add corresponding field(s) to the EventMetadata dataclass in the same file.
+3. If the key should NOT be mapped (e.g. it duplicates an existing FunctionEvent
+   attribute), add it to allowed_non_structured_trace_keys in this test instead.
+
+For a model PR to follow, see: https://github.com/pytorch/pytorch/pull/180100
+===================================================================================="""
         if unexpected_trace_key_failures:
             raise AssertionError(
                 f"\n{failure_msg}\n" + "\n\n".join(unexpected_trace_key_failures)

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4140,6 +4140,7 @@ class TestProfilerEventsParity(TestCase):
             z = x + y
             z.cpu()
 
+        # Build a mapping from key to events() FunctionEvent metadata
         event_records = {}
         for fe in prof.events():
             if fe.external_id == 0 or fe.id == 0 or fe.activity_type not in target_cats:
@@ -4159,6 +4160,9 @@ class TestProfilerEventsParity(TestCase):
                 trace = json.load(f)
 
         json_records = {}
+        unexpected_trace_key_failures = []
+
+        # Loop through the trace events to perform a comparison
         for te in trace["traceEvents"]:
             cat = te.get("cat", "")
             args = te.get("args", {})
@@ -4170,19 +4174,13 @@ class TestProfilerEventsParity(TestCase):
             if cat not in target_cats:
                 continue
 
+            # Any metadata keys that show up in JSON should show up in events()
             unexpected_trace_keys = set(args) - supported_trace_keys
-
-            failure_msg = """
-            IMPORTANT: Are you bumping the Kineto submodule hash and seeing this message?
-            If so, please check the schema for EventMetadata (torch/autograd/profiler_util.py).
-            It is currently missing these keys, which were found in the JSON metadata args.
-            """
-            self.assertEqual(
-                unexpected_trace_keys,
-                set(),
-                f"{failure_msg}\nEvent: {(te['name'], cat, ext_id, correlation)}\n"
-                f"Unexpected keys: {sorted(unexpected_trace_keys)}",
-            )
+            if unexpected_trace_keys:
+                unexpected_trace_key_failures.append(
+                    f"Event: {(te['name'], cat, ext_id, correlation)}\n"
+                    f"Unexpected keys: {sorted(unexpected_trace_keys)}"
+                )
 
             # Build the same key from JSON to try to match with a FunctionEvent
             key = (te["name"], te["cat"], ext_id, correlation)
@@ -4193,6 +4191,15 @@ class TestProfilerEventsParity(TestCase):
             )
             json_records[key] = metadata_dict_from_trace_args(args)
 
+        failure_msg = """
+        IMPORTANT: Are you bumping the Kineto submodule hash and seeing this message?
+        If so, please check the schema for EventMetadata (torch/autograd/profiler_util.py).
+        It is currently missing these keys, which were found in the JSON metadata args.
+        """
+        self.assertFalse(
+            unexpected_trace_key_failures,
+            f"{failure_msg}\n" + "\n\n".join(unexpected_trace_key_failures),
+        )
         self.assertGreater(len(json_records), 0, "No device-side records were compared")
         self.assertEqual(
             set(event_records),

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4082,7 +4082,52 @@ class TestProfilerEventsParity(TestCase):
                 )
 
     def test_structured_metadata_matches_chrome_trace(self):
+        # Compare metadata fields between events() and Chrome trace JSON to make sure they stay in parity
+        # 1. Run a dummy workload with profiling enabled and collect the json/events() outputs
+        # 2. Parse each event instance in the json and events() to create a key->value mapping
+        #      - The key is a tuple of metadata fields that should be unique for each event
+        #      - The value is a dict of metadata fields for that event
+        # 3. Ensure that the keys and values match between the json and events() outputs
+
         from torch.autograd.profiler_util import _EVENT_METADATA_KEYS
+
+        target_cats = ("cuda_runtime", "gpu_memcpy", "kernel")
+        allowed_non_structured_trace_keys = {
+            "External id",
+            "correlation",
+            "cbid",
+            "cid",
+            "device",
+            "kind",
+            "kernel",
+            "ptr",
+            "src",
+            "dst",
+        }
+        supported_trace_keys = set(_EVENT_METADATA_KEYS).union(
+            allowed_non_structured_trace_keys
+        )
+
+        def metadata_dict_from_trace_args(args):
+            out = {}
+            for kineto_key, (field_name, convert) in _EVENT_METADATA_KEYS.items():
+                if kineto_key in args:
+                    raw_value = args[kineto_key]
+                    out[field_name] = (
+                        convert(raw_value) if isinstance(raw_value, str) else raw_value
+                    )
+            return out
+
+        def metadata_dict_from_function_event(fe):
+            if fe.event_metadata is None:
+                return {}
+
+            out = {}
+            for field_name, _ in _EVENT_METADATA_KEYS.values():
+                val = getattr(fe.event_metadata, field_name)
+                if val is not None:
+                    out[field_name] = val
+            return out
 
         with profile(
             activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
@@ -4095,47 +4140,74 @@ class TestProfilerEventsParity(TestCase):
             z = x + y
             z.cpu()
 
-        # Build lookup from External id -> FunctionEvent
-        fe_by_ext_id = {}
+        event_records = {}
         for fe in prof.events():
-            if fe.external_id != 0:
-                fe_by_ext_id[fe.external_id] = fe
+            if fe.external_id == 0 or fe.id == 0 or fe.activity_type not in target_cats:
+                continue
+            # Using just one of these keys could result in collisions, so try to uniquely identify the event with all of them
+            key = (fe.name, fe.activity_type, fe.external_id, fe.id)
+            self.assertNotIn(
+                key,
+                event_records,
+                f"Duplicate FunctionEvent record key encountered: {key}",
+            )
+            event_records[key] = metadata_dict_from_function_event(fe)
 
         with TemporaryFileName(mode="w+") as fname:
             prof.export_chrome_trace(fname)
             with open(fname) as f:
                 trace = json.load(f)
 
-            checked_kernel = 0
-            checked_memcpy = 0
-            for te in trace["traceEvents"]:
-                cat = te.get("cat", "")
-                args = te.get("args", {})
-                ext_id = args.get("External id")
-                if ext_id is None or ext_id not in fe_by_ext_id:
-                    continue
-                fe = fe_by_ext_id[ext_id]
+        json_records = {}
+        for te in trace["traceEvents"]:
+            cat = te.get("cat", "")
+            args = te.get("args", {})
+            ext_id = args.get("External id")
+            correlation = args.get("correlation")
 
-                if cat in ("kernel", "gpu_memcpy") and fe.event_metadata is not None:
-                    em = fe.event_metadata
-                    for kineto_key, (field_name, _) in _EVENT_METADATA_KEYS.items():
-                        if kineto_key in args:
-                            val = getattr(em, field_name)
-                            self.assertIsNotNone(
-                                val,
-                                f"'{fe.name}': {field_name} is None "
-                                f"but JSON has '{kineto_key}': {args[kineto_key]}",
-                            )
-                    if cat == "kernel":
-                        self.assertIsInstance(em.registers_per_thread, int)
-                        self.assertGreater(em.registers_per_thread, 0)
-                        checked_kernel += 1
-                    elif cat == "gpu_memcpy":
-                        if em.bytes is not None:
-                            self.assertGreater(em.bytes, 0)
-                        checked_memcpy += 1
+            if ext_id is None or correlation is None:
+                continue
+            if cat not in target_cats:
+                continue
 
-            self.assertGreater(checked_kernel, 0, "No kernel events were cross-checked")
+            unexpected_trace_keys = set(args) - supported_trace_keys
+
+            failure_msg = """
+            IMPORTANT: Are you bumping the Kineto submodule hash and seeing this message?
+            If so, please check the schema for EventMetadata (torch/autograd/profiler_util.py).
+            It is currently missing these keys, which were found in the JSON metadata args.
+            """
+            self.assertEqual(
+                unexpected_trace_keys,
+                set(),
+                f"{failure_msg}\nEvent: {(te['name'], cat, ext_id, correlation)}\n"
+                f"Unexpected keys: {sorted(unexpected_trace_keys)}",
+            )
+
+            # Build the same key from JSON to try to match with a FunctionEvent
+            key = (te["name"], te["cat"], ext_id, correlation)
+            self.assertNotIn(
+                key,
+                json_records,
+                f"Duplicate Chrome trace record key encountered: {key}",
+            )
+            json_records[key] = metadata_dict_from_trace_args(args)
+
+        self.assertGreater(len(json_records), 0, "No device-side records were compared")
+        self.assertEqual(
+            set(event_records),
+            set(json_records),
+            "Device event identities differ between events() and Chrome trace JSON",
+        )
+
+        for key in json_records:
+            expected_meta = json_records[key]
+            actual_meta = event_records[key]
+            self.assertEqual(
+                actual_meta,
+                expected_meta,
+                f"{key}: structured metadata differs between events() and Chrome trace JSON",
+            )
 
 
 if __name__ == "__main__":

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4178,7 +4178,7 @@ class TestProfilerEventsParity(TestCase):
             unexpected_trace_keys = set(args) - supported_trace_keys
             if unexpected_trace_keys:
                 unexpected_trace_key_failures.append(
-                    f"Event: {(te['name'], cat, ext_id, correlation)}\n"
+                    f"Event: {(te['name'][:100], cat, ext_id, correlation)}\n"
                     f"Unexpected keys: {sorted(unexpected_trace_keys)}"
                 )
 
@@ -4192,14 +4192,17 @@ class TestProfilerEventsParity(TestCase):
             json_records[key] = metadata_dict_from_trace_args(args)
 
         failure_msg = """
+        ====================================================================================
         IMPORTANT: Are you making a kineto change or bumping the hash and seeing this message?
         If so, please check the schema for EventMetadata (torch/autograd/profiler_util.py).
         It is currently missing these keys, which were found in the JSON metadata args.
+        =====================================================================================
         """
-        self.assertFalse(
-            unexpected_trace_key_failures,
-            f"{failure_msg}\n" + "\n\n".join(unexpected_trace_key_failures),
-        )
+        if unexpected_trace_key_failures:
+            raise AssertionError(
+                f"\n{failure_msg}\n" + "\n\n".join(unexpected_trace_key_failures)
+            )
+
         self.assertGreater(len(json_records), 0, "No device-side records were compared")
         self.assertEqual(
             set(event_records),


### PR DESCRIPTION
This was failing on ROCm and recently exposed by removing the early exit hack. Taking this as an opportunity to beef it up some more.

Basically this will loop through events() and json outputs, fetch all the events, match them, and compare to make sure that every key in json is present in events and that the two match.

Sample failure that I artificially induced:

```
AssertionError: 
====================================================================================
IMPORTANT: Are you making a Kineto change or bumping the third_party/kineto
submodule hash and seeing this message?

New metadata keys (see below) were found in the Chrome trace JSON that are not
yet exposed through the profiler's events() API (i.e. EventMetadata in
torch/autograd/profiler_util.py).

To fix this properly, you need to make sure the new Kineto data makes its way
to the events() property. The steps are:

1. Add the new key(s) to _EVENT_METADATA_KEYS in torch/autograd/profiler_util.py
   with the appropriate field name and type converter.
2. Add corresponding field(s) to the EventMetadata dataclass in the same file.
3. If the key should NOT be mapped (e.g. it duplicates an existing FunctionEvent
   attribute), add it to allowed_non_structured_trace_keys in this test instead.

For a model PR to follow, see: https://github.com/pytorch/pytorch/pull/180100
====================================================================================

Unmapped keys:
  Memcpy DtoH (Device -> Pageable) (gpu_memcpy): 'device'
  ampere_sgemm_32x128_nn (kernel): 'device'
  cudaDeviceGetAttribute (cuda_runtime): 'cbid'
  cudaDeviceGetStreamPriorityRange (cuda_runtime): 'cbid'
  cudaFree (cuda_runtime): 'cbid'
  cudaGetDriverEntryPoint (cuda_runtime): 'cbid'
  cudaGetSymbolAddress (cuda_runtime): 'cbid'
  cudaLaunchKernel (cuda_runtime): 'cbid'
  cudaMalloc (cuda_runtime): 'cbid'
  cudaMemcpyAsync (cuda_runtime): 'cbid'
  cudaOccupancyMaxActiveBlocksPerMultiprocessor (cuda_runtime): 'cbid'
  cudaStreamGetCaptureInfo_v2 (cuda_runtime): 'cbid'
  cudaStreamIsCapturing (cuda_runtime): 'cbid'
  cudaStreamSynchronize (cuda_runtime): 'cbid'
  void at::native::(anonymous namespace)::distribution_elementwise_grid_stride_kernel<float, 4, at::na (kernel): 'device'
  void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctor_add<float>, std::array<cha (kernel): 'device'
```