### PR TITLE
Refactor AOTAutograd cache key helpers

### DIFF
--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -320,6 +320,14 @@ def _get_context_fn_cache_hash(context_fn: Callable[..., Any]) -> str | None:
     return None
 
 
+def _iter_graph_modules(
+    gm: torch.fx.GraphModule,
+) -> Generator[torch.fx.GraphModule, None, None]:
+    for module in gm.modules():
+        if isinstance(module, torch.fx.GraphModule):
+            yield module
+
+
 def _collect_context_fn_hashes(gm: torch.fx.GraphModule) -> list[str]:
     """
     Collect cache hashes from all context_fn used in SAC HOPs within the graph module.
@@ -328,9 +336,7 @@ def _collect_context_fn_hashes(gm: torch.fx.GraphModule) -> list[str]:
     lacks a cache_hash attribute.
     """
     hashes = []
-    for module in gm.modules():
-        if not isinstance(module, torch.fx.GraphModule):
-            continue
+    for module in _iter_graph_modules(gm):
         context_fn = module.meta.get("_checkpoint_context_fn")
         if context_fn is not None:
             cache_hash = _get_context_fn_cache_hash(context_fn)
@@ -345,6 +351,32 @@ def _collect_context_fn_hashes(gm: torch.fx.GraphModule) -> list[str]:
                 )
             hashes.append(cache_hash)
     return hashes
+
+
+def _collect_wrapped_user_cache_hashes(gm: torch.fx.GraphModule) -> list[str]:
+    wrapped_user_cache_hashes = []
+    for node in gm.graph.nodes:
+        if node.meta and node.meta.get("is_wrapped", False):
+            wrapped_user_cache_hashes.append(node.meta["user_cache_hash"])
+    return wrapped_user_cache_hashes
+
+
+def _collect_saved_tensors_hooks_fx_wrap_cache_hashes(
+    gm: torch.fx.GraphModule,
+) -> tuple[list[str], list[str]]:
+    if not hasattr(gm, "saved_tensors_hooks_pack_0"):
+        return ([], [])
+
+    return (
+        _collect_wrapped_user_cache_hashes(
+            # pyrefly: ignore[bad-argument-type]
+            gm.saved_tensors_hooks_pack_0
+        ),
+        _collect_wrapped_user_cache_hashes(
+            # pyrefly: ignore[bad-argument-type]
+            gm.saved_tensors_hooks_unpack_0
+        ),
+    )
 
 
 def _get_custom_estimator_solver_uuids(
@@ -406,6 +438,20 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
     a safe and stable cache key for AOTAutograd.
     """
 
+    def _iter_triton_kernels_from_node(self, node: Node) -> Generator[Any, None, None]:
+        if isinstance(node.target, torch._ops.OpOverloadPacket):
+            for attr in node.target._dir:
+                custom_op = getattr(node.target, attr, None)
+                if custom_op is not None:
+                    yield from torch._library.triton.get_triton_kernels_for_op(
+                        custom_op._name
+                    )
+            return
+        if isinstance(node.target, torch._ops.OpOverload):
+            yield from torch._library.triton.get_triton_kernels_for_op(
+                node.target._name
+            )
+
     def get_triton_source_codes_from_gm(
         self,
         gm: torch.fx.GraphModule,
@@ -414,23 +460,9 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
             raise AssertionError("Triton is not available")
 
         triton_kernels = []
-        for module in gm.modules():
-            if not isinstance(module, torch.fx.GraphModule):
-                continue
+        for module in _iter_graph_modules(gm):
             for node in module.graph.nodes:
-                if isinstance(node.target, torch._ops.OpOverloadPacket):
-                    attrs = node.target._dir
-                    for attr in attrs:
-                        if custom_op := getattr(node.target, attr, None):
-                            kernels = torch._library.triton.get_triton_kernels_for_op(
-                                custom_op._name
-                            )
-                            triton_kernels.extend(kernels)
-                elif isinstance(node.target, torch._ops.OpOverload):
-                    kernels = torch._library.triton.get_triton_kernels_for_op(
-                        node.target._name
-                    )
-                    triton_kernels.extend(kernels)
+                triton_kernels.extend(self._iter_triton_kernels_from_node(node))
 
         triton_kernel_source_codes = []
         from torch._inductor.codegen.wrapper import (
@@ -457,47 +489,37 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
         aot_config: AOTConfig,
         fx_config: _CompileFxKwargs,
     ) -> None:
-        # FxGraphHashDetails contains all the keys related to inductor. Also includes some system info
+        # FxGraphHashDetails contains all the keys related to inductor. Also
+        # includes some system info.
         self.aot_config = aot_config
+        self._record_runtime_state(gm)
+        self.saved_tensors_hooks_fx_wrap_cache_hashes = (
+            _collect_saved_tensors_hooks_fx_wrap_cache_hashes(gm)
+        )
+        self.sac_context_fn_hashes = _collect_context_fn_hashes(gm)
+
+        # Note: We use the live config module, not self.autograd_config (the
+        # saved config), because activation_memory_budget_runtime_estimator and
+        # activation_memory_budget_solver are excluded from save_config (in
+        # _save_config_ignore) since they're not serializable. We must access the
+        # config module directly to get the patched runtime values.
+        self.custom_estimator_solver_uuids = _get_custom_estimator_solver_uuids(config)
+        self._init_fx_graph_hash_details(gm, example_inputs, fx_config)
+
+    def _record_runtime_state(self, gm: torch.fx.GraphModule) -> None:
         self.grad_enabled = torch.is_grad_enabled()
         self.disable_amp = torch._C._is_any_autocast_enabled()
         self.deterministic_algorithms = torch.are_deterministic_algorithms_enabled()
         self.autograd_config = config.save_config()
-        self.saved_tensors_hooks_fx_wrap_cache_hashes: tuple[list[str], list[str]] = (
-            [],
-            [],
-        )
         if has_triton_package():
             self.triton_kernel_source_codes = self.get_triton_source_codes_from_gm(gm)
 
-        if hasattr(gm, "saved_tensors_hooks_pack_0"):
-
-            def _add_wrapped_user_cache_hashes(
-                _gm: torch.fx.GraphModule, _l: list[str]
-            ) -> None:
-                for node in _gm.graph.nodes:
-                    if node.meta and node.meta.get("is_wrapped", False):
-                        _l.append(node.meta["user_cache_hash"])
-
-            _add_wrapped_user_cache_hashes(
-                # pyrefly: ignore[bad-argument-type]
-                gm.saved_tensors_hooks_pack_0,
-                self.saved_tensors_hooks_fx_wrap_cache_hashes[0],
-            )
-            _add_wrapped_user_cache_hashes(
-                # pyrefly: ignore[bad-argument-type]
-                gm.saved_tensors_hooks_unpack_0,
-                self.saved_tensors_hooks_fx_wrap_cache_hashes[1],
-            )
-
-        self.sac_context_fn_hashes: list[str] = _collect_context_fn_hashes(gm)
-
-        # Note: We use the live config module, not self.autograd_config (the saved config),
-        # because activation_memory_budget_runtime_estimator and activation_memory_budget_solver
-        # are excluded from save_config (in _save_config_ignore) since they're not serializable.
-        # We must access the config module directly to get the patched runtime values.
-        self.custom_estimator_solver_uuids = _get_custom_estimator_solver_uuids(config)
-
+    def _init_fx_graph_hash_details(
+        self,
+        gm: torch.fx.GraphModule,
+        example_inputs: Sequence[Any],
+        fx_config: _CompileFxKwargs,
+    ) -> None:
         try:
             # FXGraphCache has constraints on what can be pickled in its inductor
             # config. Check that the gm is cacheable by inductor first,
@@ -531,21 +553,10 @@ class AOTAutogradCachePickler(FxGraphCachePickler):
         fall through to the default __reduce_ex__ which includes non-deterministic
         storage addresses. This method catches those cases using isinstance checks.
         """
-        from torch.utils._python_dispatch import is_traceable_wrapper_subclass
-
         # Handle tensor subclasses that aren't exactly torch.Tensor
         # dispatch_table already handles torch.Tensor exactly
         if isinstance(obj, torch.Tensor) and type(obj) is not torch.Tensor:
-            if hasattr(obj, "_stable_hash_for_caching"):
-                return (_ident, (obj._stable_hash_for_caching(),))
-            if is_traceable_wrapper_subclass(obj):
-                warn_once(
-                    f"{type(obj).__name__} does not implement _stable_hash_for_caching. "
-                    "For PT2-compatible tensor subclasses, it is recommended to implement "
-                    "_stable_hash_for_caching(self) -> str for stable AOT autograd caching."
-                )
-                return (_ident, (self._default_stable_hash_for_caching(obj),))
-            return self._reduce_tensor(obj)
+            return self._reduce_tensor_subclass(obj)
         # Return NotImplemented to fall back to default behavior
         return NotImplemented
 
@@ -563,64 +574,84 @@ class AOTAutogradCachePickler(FxGraphCachePickler):
     # a default implementation here that uses __tensor_flatten__ to recursively
     # hash inner tensors and metadata.
 
-    def _get_stable_hash(self, obj: Any) -> str:
-        """
-        Get stable hash for a tensor or opaque object, dispatching to custom or default implementation.
-        """
+    def _hash_bytes_for_cache(self, data: bytes) -> str:
+        return hashlib.blake2b(data, digest_size=16).hexdigest()
+
+    def _hash_pickled_value_for_cache(self, value: Any) -> str:
+        return self._hash_bytes_for_cache(pickle.dumps(value))
+
+    def _stable_hash_for_cache_value(self, obj: Any) -> str:
+        """Get a stable hash for an object used inside tensor subclass metadata."""
         from torch._opaque_base import OpaqueBase
         from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
         if hasattr(obj, "_stable_hash_for_caching"):
             return obj._stable_hash_for_caching()
-        elif isinstance(obj, torch.Tensor) and is_traceable_wrapper_subclass(obj):
+        if isinstance(obj, torch.Tensor) and is_traceable_wrapper_subclass(obj):
             return self._default_stable_hash_for_caching(obj)
-        elif isinstance(obj, OpaqueBase):
+        if isinstance(obj, OpaqueBase):
             # Opaque objects are runtime pass-throughs; only the type matters
             # for cache key purposes, not the instance identity or value.
-            type_name = type(obj).__qualname__
-            return hashlib.blake2b(type_name.encode(), digest_size=16).hexdigest()
-        elif isinstance(obj, torch.Tensor):
-            metadata = extract_tensor_metadata_for_cache_key(obj)
-            return hashlib.blake2b(pickle.dumps(metadata), digest_size=16).hexdigest()
-        else:
-            return hashlib.blake2b(pickle.dumps(obj), digest_size=16).hexdigest()
+            return self._hash_bytes_for_cache(type(obj).__qualname__.encode())
+        if isinstance(obj, torch.Tensor):
+            return self._hash_pickled_value_for_cache(
+                extract_tensor_metadata_for_cache_key(obj)
+            )
+        return self._hash_pickled_value_for_cache(obj)
+
+    def _reduce_tensor_subclass(
+        self, tensor: torch.Tensor
+    ) -> tuple[Callable[..., Any], tuple[Any]]:
+        from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+        if hasattr(tensor, "_stable_hash_for_caching"):
+            return (_ident, (tensor._stable_hash_for_caching(),))
+        if is_traceable_wrapper_subclass(tensor):
+            warn_once(
+                f"{type(tensor).__name__} does not implement _stable_hash_for_caching. "
+                "For PT2-compatible tensor subclasses, it is recommended to implement "
+                "_stable_hash_for_caching(self) -> str for stable AOT autograd caching."
+            )
+            return (_ident, (self._default_stable_hash_for_caching(tensor),))
+        return self._reduce_tensor(tensor)
+
+    def _collect_inner_tensor_hashes(
+        self, tensor: torch.Tensor, inner_tensor_names: Sequence[str]
+    ) -> dict[str, str]:
+        inner_hashes = {}
+        for name in inner_tensor_names:
+            inner_hashes[name] = self._stable_hash_for_cache_value(
+                getattr(tensor, name)
+            )
+        return inner_hashes
+
+    def _stabilize_tensor_subclass_metadata(self, obj: Any) -> Any:
+        from torch._opaque_base import OpaqueBase
+
+        if isinstance(obj, OpaqueBase):
+            return type(obj).__qualname__
+        if isinstance(obj, tuple):
+            return tuple(self._stabilize_tensor_subclass_metadata(x) for x in obj)
+        if isinstance(obj, list):
+            return [self._stabilize_tensor_subclass_metadata(x) for x in obj]
+        if isinstance(obj, dict):
+            return {
+                k: self._stabilize_tensor_subclass_metadata(v) for k, v in obj.items()
+            }
+        return obj
 
     def _default_stable_hash_for_caching(self, tensor: torch.Tensor) -> str:
         """
         Default stable hash implementation for traceable wrapper subclasses.
         """
-        from torch._opaque_base import OpaqueBase
-
         inner_tensor_names, subclass_metadata = tensor.__tensor_flatten__()  # type: ignore[attr-defined]
-
-        # Recursively get hashes of inner tensors/opaque objects
-        inner_hashes: dict[str, str] = {}
-        for name in inner_tensor_names:
-            inner = getattr(tensor, name)
-            inner_hashes[name] = self._get_stable_hash(inner)
-
-        # Stabilize metadata: replace OpaqueBase instances with their type name
-        # since their repr includes memory addresses
-        def _stabilize(obj: Any) -> Any:
-            if isinstance(obj, OpaqueBase):
-                return type(obj).__qualname__
-            if isinstance(obj, tuple):
-                return tuple(_stabilize(x) for x in obj)
-            if isinstance(obj, list):
-                return [_stabilize(x) for x in obj]
-            if isinstance(obj, dict):
-                return {k: _stabilize(v) for k, v in obj.items()}
-            return obj
-
-        cache_data = pickle.dumps(
-            (
-                tensor.shape,
-                tensor.requires_grad,
-                _stabilize(subclass_metadata),
-                inner_hashes,
-            )
+        cache_payload = (
+            tensor.shape,
+            tensor.requires_grad,
+            self._stabilize_tensor_subclass_metadata(subclass_metadata),
+            self._collect_inner_tensor_hashes(tensor, inner_tensor_names),
         )
-        return hashlib.blake2b(cache_data, digest_size=16).hexdigest()
+        return self._hash_pickled_value_for_cache(cache_payload)
 
     def _reduce_aot_config(
         self, aot_config: AOTConfig
@@ -723,6 +754,41 @@ def create_fx_config(
     }
 
 
+def _check_triton_cache_version() -> None:
+    if not has_triton_package():
+        return
+
+    # Due to https://github.com/triton-lang/triton/issues/3729, if triton is <
+    # 3.2.0, AOTAutogradCache may cause us to attempt to load a cache entry
+    # without initializing the CUDA context on the autograd thread.
+    #
+    # Without caching, we naturally do this initialization when tracing through
+    # the graph with the autograd engine.
+    import triton
+
+    if triton.__version__ < "3.2.0":
+        raise BypassAOTAutogradCache("AOTAutogradCache requires triton 3.2.0")
+
+
+def _get_debug_lines_for_cache_key(
+    pickler: AOTAutogradCachePickler,
+    details: AOTAutogradCacheDetails,
+    key: str,
+) -> list[str]:
+    # debug_lines re-hashes every attribute individually and is expensive. Only
+    # compute when debug logging is enabled.
+    if not log.isEnabledFor(logging.DEBUG):
+        return []
+
+    debug_lines = pickler.debug_lines(details)
+    log.debug(
+        "Autograd graph cache hash details for key %s:\n%s",
+        key,
+        LazyString(lambda: "\n".join(debug_lines)),
+    )
+    return debug_lines
+
+
 def autograd_cache_key(
     mod: torch.fx.GraphModule | torch._dynamo.utils.GmWrapper,
     example_inputs: Sequence[Any],
@@ -738,37 +804,14 @@ def autograd_cache_key(
     with sanitize_gm_for_cache(gm):
         try:
             check_cacheable(gm)
-            if has_triton_package():
-                # Due to https://github.com/triton-lang/triton/issues/3729,
-                # if triton is < 3.2.0, AOTAutogradCache may cause us to
-                # attempt to load a cache entry without initializing
-                # the CUDA context on the autograd thread.
-
-                # Without caching, we naturally do this initialization when
-                # tracing through the graph with the autograd engine.
-                import triton
-
-                if triton.__version__ < "3.2.0":
-                    raise BypassAOTAutogradCache(
-                        "AOTAutogradCache requires triton 3.2.0"
-                    )
+            _check_triton_cache_version()
             details = AOTAutogradCacheDetails(
                 gm, example_inputs, config, create_fx_config(compiler_config_extra)
             )
             pickler = AOTAutogradCachePickler(gm)
             # The prefix distinguishes among the other kinds of objects we cache
             key = "a" + pickler.get_hash(details)
-            # debug_lines re-hashes every attribute individually and is
-            # expensive. Only compute when debug logging is enabled.
-            if log.isEnabledFor(logging.DEBUG):
-                debug_lines = pickler.debug_lines(details)
-                log.debug(
-                    "Autograd graph cache hash details for key %s:\n%s",
-                    key,
-                    LazyString(lambda: "\n".join(debug_lines)),
-                )
-            else:
-                debug_lines: list[str] = []
+            debug_lines = _get_debug_lines_for_cache_key(pickler, details, key)
             return key, debug_lines
         except Exception:
             # If enable_aot_compile is set, we're in AOT precompile mode where we always


### PR DESCRIPTION
## Summary
Refactor the AOTAutograd cache key path so the policy is easier to read and audit without changing cache behavior.

## Root cause problem
AOTAutograd cache key generation mixed graph traversal, runtime-state capture, Triton gating, and tensor-subclass stable hashing inside a few long methods. That made the cache contract harder to understand and evolve safely.

## Proposed fix
- factor repeated graph-module traversal and saved-tensors hook hash collection into shared helpers
- split `AOTAutogradCacheDetails` initialization into explicit runtime-state capture and FXGraph hash setup steps
- split tensor-subclass hashing into focused helpers for subclass reduction, metadata stabilization, and nested value hashing
- pull Triton-version validation and debug-line generation out of `autograd_cache_key` so the entrypoint reads as the actual cache-key flow

## Why this is the right long term fix
This keeps the cache semantics unchanged while making each piece of the key-generation policy explicit. That is the safest way to maintain determinism and extend the cache code without introducing hidden behavior changes.

## Testing
- `python3 -m compileall torch/_functorch/_aot_autograd/autograd_cache.py`
- `python3 -m py_compile torch/_functorch/_aot_autograd/autograd_cache.py`
- `/tmp/repos/.venv-pytest/bin/python test/dynamo/test_aot_autograd_cache.py -v AOTAutogradCachePicklerTests CacheKeyAPITests`
  - `CacheKeyAPITests` skipped on `requires triton` in this CPU-only environment

Drafted via Codex, published after manual review by @bobrenjc93