### PR TITLE
[ez] Fix CompiledBackward docstring

### DIFF
--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -249,7 +249,7 @@ class GenericCompiledBackward(InductorOutput[TOut]):
 @dataclass
 class CompiledBackward(GenericCompiledBackward[CompiledFxGraph], FxGraphCacheLoadable):
     """
-    Cacheable entry for a forward function
+    Cacheable entry for a backward function
     """
 
     def _is_backward(self) -> bool:


### PR DESCRIPTION
## Summary
Correct the `CompiledBackward` class docstring so it describes a backward function instead of a forward function.

## Root cause problem
`CompiledBackward` inherited a copy-pasted docstring from `CompiledForward`, so the backward cache entry was documented incorrectly.

## Proposed fix
Replace "forward function" with "backward function" in `CompiledBackward`'s class docstring.

## Why this is the right long term fix
The class documentation now matches the actual role of the cached object, which removes avoidable confusion without coupling this cleanup to any larger refactor.

## Validation
- `python3 -m compileall torch/_functorch/_aot_autograd/aot_autograd_result.py`
- `python3` AST check confirming `CompiledBackward`'s docstring text

Drafted via Codex, published after manual review by @bobrenjc93