### PR TITLE
Use shared constants for cache key prefixes

### DIFF
--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -33,6 +33,7 @@ from torch._functorch import config
 from torch._inductor.codecache import (
     _ident,
     add_ephemeral_timeout_increase_for_distributed,
+    AOTAUTOGRAD_CACHE_PREFIX,
     BypassFxGraphCache,
     create_cache,
     extract_tensor_metadata_for_cache_key,
@@ -810,7 +811,7 @@ def autograd_cache_key(
             )
             pickler = AOTAutogradCachePickler(gm)
             # The prefix distinguishes among the other kinds of objects we cache
-            key = "a" + pickler.get_hash(details)
+            key = AOTAUTOGRAD_CACHE_PREFIX + pickler.get_hash(details)
             debug_lines = _get_debug_lines_for_cache_key(pickler, details, key)
             return key, debug_lines
         except Exception:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -152,6 +152,9 @@ output_code_log = torch._logging.getArtifactLogger(__name__, "output_code")
 autotuning_log = torch._logging.getArtifactLogger(__name__, "autotuning")
 log = logging.getLogger(__name__)
 
+FXGRAPH_CACHE_PREFIX = "c"
+AOTAUTOGRAD_CACHE_PREFIX = "a"
+
 
 def get_cpp_wrapper_cubin_path_name() -> str:
     return "cubin_path" if torch.version.hip is None else "hsaco_path"
@@ -343,7 +346,7 @@ def code_hash(code: str | bytes, extra: str | bytes = "") -> str:
     if extra:
         extra_b = extra if isinstance(extra, bytes) else extra.encode("utf-8")
         hashing_str = hashing_str + b"||" + extra_b
-    return "c" + sha256_hash(hashing_str)
+    return FXGRAPH_CACHE_PREFIX + sha256_hash(hashing_str)
 
 
 def get_path(

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -154,6 +154,7 @@ log = logging.getLogger(__name__)
 
 FXGRAPH_CACHE_PREFIX = "c"
 AOTAUTOGRAD_CACHE_PREFIX = "a"
+COMPILED_FX_GRAPH_CACHE_PREFIX = "f"
 
 
 def get_cpp_wrapper_cubin_path_name() -> str:
@@ -1127,7 +1128,7 @@ def compiled_fx_graph_hash(
 
     # The prefix distinguishes among the other kinds of objects we
     # cache in this module.
-    key = "f" + pickler.get_hash(details)
+    key = COMPILED_FX_GRAPH_CACHE_PREFIX + pickler.get_hash(details)
     debug_lines = pickler.debug_lines(details)
     debug_str = "\n".join(debug_lines)
     log.debug(f"FX graph cache hash details for key {key}:\n{debug_str}")  # noqa: G004


### PR DESCRIPTION
## Summary
Centralize the shared cache key namespace prefixes in `torch/_inductor/codecache.py` and reuse them from the AOTAutograd cache key builder.

## Root cause
The `"c"` and `"a"` cache key namespace prefixes were hardcoded in separate modules. That duplicated cache infrastructure details across files and made it easy for related cache key builders to drift.

## Proposed fix
Define `FXGRAPH_CACHE_PREFIX = "c"` and `AOTAUTOGRAD_CACHE_PREFIX = "a"` in `torch/_inductor/codecache.py`, use `FXGRAPH_CACHE_PREFIX` in `code_hash()`, and import `AOTAUTOGRAD_CACHE_PREFIX` into `autograd_cache.py` for AOTAutograd key construction.

## Why this is the right long term fix
`codecache.py` owns the base cache infrastructure, so keeping the namespace prefixes there gives them a single source of truth and reduces the chance of future cache key inconsistencies.

## Testing
- `python3 -m py_compile torch/_inductor/codecache.py torch/_functorch/_aot_autograd/autograd_cache.py`
- AST validation script checking the new constants and both updated key constructors
- `rg` verification that the old bare `"a"`/`"c"` cache key prefix literals are gone from the touched constructors

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo