### PR TITLE
Refactor duplicated AOTAutograd cache-save checks

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -116,6 +116,12 @@ def is_opaque_node(node: Any) -> bool:
 _thread_local = threading.local()
 
 
+def _should_save_cache(*compiled_fns: Callable[..., Any]) -> bool:
+    if should_bundle_autograd_cache():
+        return True
+    return all(hasattr(fn, "_fx_graph_cache_key") for fn in compiled_fns)
+
+
 @contextmanager
 def maybe_skip_decompose(aot_config: AOTConfig) -> Generator[None, None, None]:
     old_decomp = aot_config.decompositions
@@ -493,14 +499,8 @@ def _cache_inference_info(
 
     cache_info = aot_config.cache_info
 
-    def should_save_cache() -> bool:
-        if should_bundle_autograd_cache():
-            return True
-        else:
-            return hasattr(compiled_fw, "_fx_graph_cache_key")
-
     entry: GenericAOTAutogradResult[Any, Any] | None = None
-    if cache_info is not None and should_save_cache():
+    if cache_info is not None and _should_save_cache(compiled_fw):
         time_taken_ns = time.time_ns() - cache_info.start_time_ns
         guards_expr = AOTAutogradCache.generate_guards_expression(cache_info)
         entry = AOTAutogradCache.make_entry(
@@ -2438,15 +2438,9 @@ def _cache_autograd_info(
         ) -> GenericAOTAutogradResult[Any, Any] | None:
             cache_info = aot_config.cache_info
 
-            def should_save_cache() -> bool:
-                if should_bundle_autograd_cache():
-                    return True
-                else:
-                    return hasattr(compiled_fw_func, "_fx_graph_cache_key") and hasattr(
-                        compiled_bw_func, "_fx_graph_cache_key"
-                    )
-
-            if cache_info is not None and should_save_cache():
+            if cache_info is not None and _should_save_cache(
+                compiled_fw_func, compiled_bw_func
+            ):
                 if forward_time_taken_ns is None:
                     raise AssertionError("forward_time_taken_ns must not be None")
                 # TODO: technically, AOTAutograd does a *little* bit of post processing work


### PR DESCRIPTION
## Summary
- extract a module-level `_should_save_cache(*compiled_fns)` helper in `torch/_functorch/_aot_autograd/graph_compile.py`
- replace the duplicated inference and autograd `should_save_cache()` closures with the shared helper

## Root cause problem
The cache-save predicate was duplicated in two closures with nearly identical logic. That duplication makes the inference and autograd paths easier to drift apart the next time the save policy changes.

## Proposed fix
Introduce `_should_save_cache(*compiled_fns)` so the policy lives in one place: save immediately when `should_bundle_autograd_cache()` is enabled, otherwise require every compiled function to carry `_fx_graph_cache_key`. Use that helper in both call sites and delete the inline closures.

## Why this is the right long term fix
A shared helper keeps the cache persistence rule consistent across inference and autograd, reduces repeated logic, and makes future policy updates one edit instead of two.

## Testing
- `python3 -m compileall torch/_functorch/_aot_autograd/graph_compile.py`
- `python3` AST verification for helper presence and both call-site replacements
- `git diff --check`
- Runtime PyTorch tests could not run in this environment because there is no built or installed `torch`, and the default Python is also missing basic test dependencies like `typing_extensions`.

Drafted via Codex, published after manual review by @bobrenjc93