### PR TITLE
Move backward post_compile into GenericCompiledBackward

### DIFF
--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -246,7 +246,10 @@ class GenericCompiledBackward(InductorOutput[TOut]):
     num_symints_saved_for_bw_: int
 
     def post_compile(self, result: TOut, fx_config: _CompileFxKwargs) -> TOut:
-        compiled_bw = super().post_compile(result, fx_config)
+        # The concrete post_compile comes from the loadable mixin in each subclass MRO.
+        compiled_bw = super().post_compile(  # pyrefly: ignore[missing-attribute]
+            result, fx_config
+        )
         # See note [Wrapping bw_compiler in disable]
         # This is done by _wrapped_bw_compiler in torch/_dynamo/backends/common.py
         # But since on cache hit we do not call the bw_compiler, we need to reapply the disable

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -245,6 +245,15 @@ class GenericCompiledBackward(InductorOutput[TOut]):
     backward_state_indices: list[int]
     num_symints_saved_for_bw_: int
 
+    def post_compile(self, result: TOut, fx_config: _CompileFxKwargs) -> TOut:
+        compiled_bw = super().post_compile(result, fx_config)
+        # See note [Wrapping bw_compiler in disable]
+        # This is done by _wrapped_bw_compiler in torch/_dynamo/backends/common.py
+        # But since on cache hit we do not call the bw_compiler, we need to reapply the disable
+        return torch._dynamo.disable(  # type: ignore[return-value]
+            compiled_bw, reason="do not trace generated backwards pass"
+        )
+
 
 @dataclass
 class CompiledBackward(GenericCompiledBackward[CompiledFxGraph], FxGraphCacheLoadable):
@@ -254,17 +263,6 @@ class CompiledBackward(GenericCompiledBackward[CompiledFxGraph], FxGraphCacheLoa
 
     def _is_backward(self) -> bool:
         return True
-
-    def post_compile(
-        self, result: CompiledFxGraph, fx_config: _CompileFxKwargs
-    ) -> CompiledFxGraph:
-        compiled_bw = super().post_compile(result, fx_config)
-        # See note [Wrapping bw_compiler in disable]
-        # This is done by _wrapped_bw_compiler in torch/_dynamo/backends/common.py
-        # But since on cache hit we do not call the bw_compiler, we need to reapply the disable
-        return torch._dynamo.disable(  # type: ignore[return-value]
-            compiled_bw, reason="do not trace generated backwards pass"
-        )
 
 
 # Generic bundled forward/backward classes that work with any OutputCode type
@@ -288,17 +286,6 @@ class BundledCompiledBackward(
     Generic backward function for bundled compilation.
     Works with any OutputCode type (CompiledFxGraph, RegionalOutputCode, etc.)
     """
-
-    def post_compile(
-        self, result: TOutputCode, fx_config: _CompileFxKwargs
-    ) -> TOutputCode:
-        compiled_bw = super().post_compile(result, fx_config)
-        # See note [Wrapping bw_compiler in disable]
-        # This is done by _wrapped_bw_compiler in torch/_dynamo/backends/common.py
-        # But since on cache hit we do not call the bw_compiler, we need to reapply the disable
-        return torch._dynamo.disable(  # type: ignore[return-value]
-            compiled_bw, reason="do not trace generated backwards pass"
-        )
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Root cause:
The backward cache wrappers duplicated the same `post_compile` implementation in both `CompiledBackward` and `BundledCompiledBackward`, even though the behavior is shared by all generated backwards.

Proposed fix:
Move the shared `post_compile` implementation into `GenericCompiledBackward`, keep delegating through `super().post_compile(...)` so each subclass still lands on its cache-specific loader via MRO, and fix the `CompiledBackward` docstring to say `backward function`.

Why this is the right long term fix:
The `torch._dynamo.disable(...)` wrapper is common backward-specific behavior, not something that should be maintained separately per cache transport. Centralizing it in the shared base removes duplication and keeps future changes to backward post-compile handling in one place.

## Testing

- `python3 -m compileall torch/_functorch/_aot_autograd/aot_autograd_result.py`
- `git diff --check`
- Runtime `python3 test/dynamo/test_aot_autograd_cache.py -v -k 'test_vmap or test_regional_inductor_with_backward'` was attempted, but this container does not have a built `torch` or basic Python deps such as `typing_extensions`.
- Standalone Python MRO proof script passed for the relevant inheritance order.

Drafted via Codex, published after manual review by @bobrenjc93