### PR TITLE
Refactor GenericAOTAutogradResult.wrap_post_compile

### DIFF
--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -389,123 +389,115 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         if self.compiled_bw is not None:
             self.compiled_bw.pre_save()
 
-    # Turn result into the original callable
-    def wrap_post_compile(
-        self,
-        args: list[torch.Tensor],
-        aot_config: AOTConfig,
-        fx_config: _CompileFxKwargs,
-        # pyrefly: ignore [implicit-any]
-    ) -> Callable:
-        """
-        This function takes a result and carefully reconstructs the original callable
-        that AOTAutograd returned the first time it was run. It does this by running the various
-        post compile steps that AOTAutograd runs on its compiled artifact after running the fw/bw compilers.
+    def _log_cached_graphs(self, aot_config: AOTConfig) -> None:
+        if not aot_config.enable_log:
+            return
 
-        In the inference path, this consists of the Subclass, FunctionalzedRngRuntime, and RuntimeWrappers.
-        In the autograd path, this consists of AOTAutogradDispatch.post_compile.
+        if self.aot_joint_graph_str is not None:
+            torch._logging.trace_structured(
+                "aot_joint_graph", payload_fn=lambda: self.aot_joint_graph_str
+            )
+            aot_graphs_log.info(
+                "Joint graph (from cache)\n\n%s", self.aot_joint_graph_str
+            )
 
-        The steps here should match exactly the steps that are run in aot_dispatch_base and aot_dispatch_autograd.
+        if self.aot_forward_graph_str is not None:
+            from torchgen.utils import dataclass_repr
 
-        Notably absent from the cached path are:
-        - DebugAssertWrapper
-        - FakifiedOutWrapper
-
-        Which we'll handle separately later on, if necessary.
-        """
-        from torch._dynamo.utils import CompileEventLogger, dynamo_timed
-
-        # Log the output of AOTAutogradCache
-        if aot_config.enable_log:
-            if self.aot_joint_graph_str is not None:
-                torch._logging.trace_structured(
-                    "aot_joint_graph", payload_fn=lambda: self.aot_joint_graph_str
-                )
-                aot_graphs_log.info(
-                    "Joint graph (from cache)\n\n%s", self.aot_joint_graph_str
-                )
-
-            if self.aot_forward_graph_str is not None:
-                from torchgen.utils import dataclass_repr
-
+            torch._logging.trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "aot_forward_graph_fw_metadata",
+                    "encoding": "string",
+                },
+                payload_fn=lambda: dataclass_repr(self.runtime_metadata),
+            )
+            if self.maybe_subclass_meta is not None:
                 torch._logging.trace_structured(
                     "artifact",
                     metadata_fn=lambda: {
-                        "name": "aot_forward_graph_fw_metadata",
+                        "name": "aot_forward_graph_fw_subclass_metadata",
                         "encoding": "string",
                     },
-                    payload_fn=lambda: dataclass_repr(self.runtime_metadata),
-                )
-                if self.maybe_subclass_meta is not None:
-                    torch._logging.trace_structured(
-                        "artifact",
-                        metadata_fn=lambda: {
-                            "name": "aot_forward_graph_fw_subclass_metadata",
-                            "encoding": "string",
-                        },
-                        payload_fn=lambda: dataclass_repr(self.maybe_subclass_meta),
-                    )
-
-                # It's called an inference graph if not running with autograd
-                has_backward = self.aot_backward_graph_str is not None
-                torch._logging.trace_structured(
-                    "aot_forward_graph" if has_backward else "aot_inference_graph",
-                    payload_fn=lambda: self.aot_forward_graph_str,
-                )
-                aot_graphs_log.info(
-                    "Forward graph (from cache)\n\n%s",
-                    self.aot_forward_graph_str,
+                    payload_fn=lambda: dataclass_repr(self.maybe_subclass_meta),
                 )
 
-            if self.aot_backward_graph_str is not None:
-                torch._logging.trace_structured(
-                    "aot_backward_graph", payload_fn=lambda: self.aot_backward_graph_str
-                )
-                aot_graphs_log.info(
-                    "Backward graph (from cache)\n\n%s",
-                    self.aot_backward_graph_str,
-                )
-        with dynamo_timed("AOTAutogradCache.inductor_load"):
-            compiled_fw_func = self.compiled_fw.load(args)
-            compiled_bw_func = None
-            if self.compiled_bw is not None:
-                compiled_bw_func = self.compiled_bw.load(args)
-                needs_autograd = True
-                CompileEventLogger.try_add_pt2_compile(
-                    "backend_compile", dispatch_mode="autograd"
-                )
-                # Now that we've loaded forward and backward, call post compile on both
-                # This avoids setting things like BoxedBools in fx_config until
-                # after both forward and backward cache hit
-                fw_fx_config: _CompileFxKwargs = {
-                    **fx_config,
-                    "is_backward": False,
-                }
-                bw_fx_config: _CompileFxKwargs = {
-                    **fx_config,
-                    "is_backward": True,
-                }
-                compiled_fw_func = self.compiled_fw.post_compile(
-                    compiled_fw_func, fw_fx_config
-                )
-                compiled_bw_func = self.compiled_bw.post_compile(
-                    compiled_bw_func, bw_fx_config
-                )
-            else:
-                inference_fx_config: _CompileFxKwargs = {
-                    **fx_config,
-                    "is_backward": False,
-                }
+            # It's called an inference graph if not running with autograd
+            has_backward = self.aot_backward_graph_str is not None
+            torch._logging.trace_structured(
+                "aot_forward_graph" if has_backward else "aot_inference_graph",
+                payload_fn=lambda: self.aot_forward_graph_str,
+            )
+            aot_graphs_log.info(
+                "Forward graph (from cache)\n\n%s",
+                self.aot_forward_graph_str,
+            )
 
-                needs_autograd = False
-                CompileEventLogger.try_add_pt2_compile(
-                    "backend_compile", dispatch_mode="inference"
-                )
-                compiled_fw_func = self.compiled_fw.post_compile(
-                    compiled_fw_func, inference_fx_config
-                )
+        if self.aot_backward_graph_str is not None:
+            torch._logging.trace_structured(
+                "aot_backward_graph", payload_fn=lambda: self.aot_backward_graph_str
+            )
+            aot_graphs_log.info(
+                "Backward graph (from cache)\n\n%s",
+                self.aot_backward_graph_str,
+            )
 
-        # Wrap the forward function in post compile wrappers
+    def _load_and_post_compile(
+        self,
+        args: list[torch.Tensor],
+        fx_config: _CompileFxKwargs,
+    ) -> tuple[Callable[..., Any], Callable[..., Any] | None, bool]:
+        from torch._dynamo.utils import CompileEventLogger
+
+        compiled_fw_func = self.compiled_fw.load(args)
+        if self.compiled_bw is not None:
+            compiled_bw_func = self.compiled_bw.load(args)
+            needs_autograd = True
+            CompileEventLogger.try_add_pt2_compile(
+                "backend_compile", dispatch_mode="autograd"
+            )
+            # Now that we've loaded forward and backward, call post compile on both
+            # This avoids setting things like BoxedBools in fx_config until
+            # after both forward and backward cache hit
+            fw_fx_config: _CompileFxKwargs = {
+                **fx_config,
+                "is_backward": False,
+            }
+            bw_fx_config: _CompileFxKwargs = {
+                **fx_config,
+                "is_backward": True,
+            }
+            compiled_fw_func = self.compiled_fw.post_compile(
+                compiled_fw_func, fw_fx_config
+            )
+            compiled_bw_func = self.compiled_bw.post_compile(
+                compiled_bw_func, bw_fx_config
+            )
+            return compiled_fw_func, compiled_bw_func, needs_autograd
+
+        inference_fx_config: _CompileFxKwargs = {
+            **fx_config,
+            "is_backward": False,
+        }
+
+        needs_autograd = False
+        CompileEventLogger.try_add_pt2_compile(
+            "backend_compile", dispatch_mode="inference"
+        )
+        compiled_fw_func = self.compiled_fw.post_compile(
+            compiled_fw_func, inference_fx_config
+        )
+        return compiled_fw_func, None, needs_autograd
+
+    def _apply_runtime_wrappers(
+        self,
+        compiled_fw_func: Callable[..., Any],
+        compiled_bw_func: Callable[..., Any] | None,
+        needs_autograd: bool,
+        aot_config: AOTConfig,
+    ) -> Callable[..., Any]:
+        from torch._dynamo.utils import CompileEventLogger
+
         compiled_fw_func = AOTDispatchSubclassWrapper(
             trace_joint=needs_autograd,
             fw_only=None,
@@ -559,7 +551,6 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
                 try_save_cache_entry=None,
             )
             compiled_function = AOTDispatchAutograd.post_compile(compile_spec)
-
         else:
             compiled_function = RuntimeWrapper(
                 indices_of_inps_to_detach=self.indices_of_inps_to_detach,
@@ -576,9 +567,9 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
             aot_config,
             runtime_metadata=self.runtime_metadata,
         )
+        return compiled_function
 
-        # Now that we're pretty sure it's a successful load, add guards
-        # to the existing shape environment from the cache
+    def _install_guards(self, args: list[torch.Tensor]) -> None:
         if self.guards_expr:
             from .autograd_cache import AOTAutogradCache
 
@@ -587,6 +578,42 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
             if check is not True:
                 raise AssertionError(f"guards check failed: {check}")
 
+    # Turn result into the original callable
+    def wrap_post_compile(
+        self,
+        args: list[torch.Tensor],
+        aot_config: AOTConfig,
+        fx_config: _CompileFxKwargs,
+        # pyrefly: ignore [implicit-any]
+    ) -> Callable:
+        """
+        This function takes a result and carefully reconstructs the original callable
+        that AOTAutograd returned the first time it was run. It does this by running the various
+        post compile steps that AOTAutograd runs on its compiled artifact after running the fw/bw compilers.
+
+        In the inference path, this consists of the Subclass, FunctionalzedRngRuntime, and RuntimeWrappers.
+        In the autograd path, this consists of AOTAutogradDispatch.post_compile.
+
+        The steps here should match exactly the steps that are run in aot_dispatch_base and aot_dispatch_autograd.
+
+        Notably absent from the cached path are:
+        - DebugAssertWrapper
+        - FakifiedOutWrapper
+
+        Which we'll handle separately later on, if necessary.
+        """
+        from torch._dynamo.utils import dynamo_timed
+
+        self._log_cached_graphs(aot_config)
+        with dynamo_timed("AOTAutogradCache.inductor_load"):
+            compiled_fw_func, compiled_bw_func, needs_autograd = (
+                self._load_and_post_compile(args, fx_config)
+            )
+
+        compiled_function = self._apply_runtime_wrappers(
+            compiled_fw_func, compiled_bw_func, needs_autograd, aot_config
+        )
+        self._install_guards(args)
         return compiled_function
 
 

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -551,6 +551,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
                 try_save_cache_entry=None,
             )
             compiled_function = AOTDispatchAutograd.post_compile(compile_spec)
+
         else:
             compiled_function = RuntimeWrapper(
                 indices_of_inps_to_detach=self.indices_of_inps_to_detach,
@@ -613,6 +614,8 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         compiled_function = self._apply_runtime_wrappers(
             compiled_fw_func, compiled_bw_func, needs_autograd, aot_config
         )
+        # Now that we're pretty sure it's a successful load, add guards
+        # to the existing shape environment from the cache.
         self._install_guards(args)
         return compiled_function
 

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -570,7 +570,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         )
         return compiled_function
 
-    def _install_guards(self, args: list[torch.Tensor]) -> None:
+    def _check_guards(self, args: list[torch.Tensor]) -> None:
         if self.guards_expr:
             from .autograd_cache import AOTAutogradCache
 
@@ -585,8 +585,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         args: list[torch.Tensor],
         aot_config: AOTConfig,
         fx_config: _CompileFxKwargs,
-        # pyrefly: ignore [implicit-any]
-    ) -> Callable:
+    ) -> Callable[..., Any]:
         """
         This function takes a result and carefully reconstructs the original callable
         that AOTAutograd returned the first time it was run. It does this by running the various
@@ -616,7 +615,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         )
         # Now that we're pretty sure it's a successful load, add guards
         # to the existing shape environment from the cache.
-        self._install_guards(args)
+        self._check_guards(args)
         return compiled_function
 
 


### PR DESCRIPTION
## Summary
Refactor `GenericAOTAutogradResult.wrap_post_compile` into four private helpers so the cached post-compile flow is easier to follow.

## Root cause problem
`wrap_post_compile` had grown into a single large method that mixed four distinct phases: cached-graph logging, fw/bw load plus `post_compile`, runtime wrapper installation, and guard evaluation.

## Proposed fix
Split the existing logic into `_log_cached_graphs`, `_load_and_post_compile`, `_apply_runtime_wrappers`, and `_install_guards`, and have `wrap_post_compile` call them in sequence while keeping the `dynamo_timed("AOTAutogradCache.inductor_load")` scope around the load/post-compile step.

## Why the proposed fix is the right long term fix
This keeps behavior unchanged while making each phase explicit and independently maintainable, which reduces the chance of accidental regressions when the cached AOTAutograd path changes again.

## Testing
- `python3 -m compileall torch/_functorch/_aot_autograd/aot_autograd_result.py`
- Ran a focused Python smoke test under local stubs that covered helper orchestration, inference and autograd load/post-compile paths, runtime wrapper application, and guard installation. The native PyTorch test suite could not run in this environment because there is no built/importable local `torch` tree.

Drafted via Codex, published after manual review by @bobrenjc93