### PR TITLE
Refactor AOT cache serialization to use CacheableAOTConfig

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3226,11 +3226,15 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
 
         config = self.default_config()
         config2 = self.default_config()
-        config2.fw_compiler = lambda gm, inputs: gm
+        config2.aot_id = 1
+        config3 = self.default_config()
+        config3.fw_compiler = lambda gm, inputs: gm
 
         c1 = self.gen_cache_key(fn, config)
         c2 = self.gen_cache_key(fn, config2)
+        c3 = self.gen_cache_key(fn, config3)
         self.assertEqual(c1, c2)
+        self.assertEqual(c1, c3)
 
     def test_to_cacheable_strips_runtime_only_fields(self):
         config = self.default_config()
@@ -3255,10 +3259,6 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
 
         base_config = self.default_config()
         base = self.gen_cache_key(fn, base_config)
-
-        config_with_aot_id = self.default_config()
-        config_with_aot_id.aot_id = 1
-        self.assertNotEqual(base, self.gen_cache_key(fn, config_with_aot_id))
 
         config_with_static_inputs = self.default_config()
         config_with_static_inputs.static_input_indices = [0]

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3251,11 +3251,15 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
 
         config = self.default_config()
         config2 = self.default_config()
-        config2.fw_compiler = lambda gm, inputs: gm
+        config2.aot_id = 1
+        config3 = self.default_config()
+        config3.fw_compiler = lambda gm, inputs: gm
 
         c1 = self.gen_cache_key(fn, config)
         c2 = self.gen_cache_key(fn, config2)
+        c3 = self.gen_cache_key(fn, config3)
         self.assertEqual(c1, c2)
+        self.assertEqual(c1, c3)
 
     def test_to_cacheable_strips_runtime_only_fields(self):
         config = self.default_config()
@@ -3280,10 +3284,6 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
 
         base_config = self.default_config()
         base = self.gen_cache_key(fn, base_config)
-
-        config_with_aot_id = self.default_config()
-        config_with_aot_id.aot_id = 1
-        self.assertNotEqual(base, self.gen_cache_key(fn, config_with_aot_id))
 
         config_with_static_inputs = self.default_config()
         config_with_static_inputs.static_input_indices = [0]

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -31,7 +31,7 @@ from torch._functorch._aot_autograd.autograd_cache import (
     BypassAOTAutogradCache,
     sanitize_gm_for_cache,
 )
-from torch._functorch._aot_autograd.schemas import AOTConfig
+from torch._functorch._aot_autograd.schemas import AOTConfig, CacheableAOTConfig
 from torch._guards import TracingContext
 from torch._inductor import config as inductor_config
 from torch._inductor.custom_graph_pass import (
@@ -3245,23 +3245,53 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         c2 = self.gen_cache_key(fn, config)
         self.assertEqual(c1, c2)
 
-    def test_identical_graphs_and_configs(self):
+    def test_runtime_only_configs_do_not_change_key(self):
         def fn(x):
             return x.sin().cos()
 
-        def fn2(x):
-            y = x.sin()
-            z = y.cos()
-            return z
-
-        # Make the id different, but otherwise identical
         config = self.default_config()
         config2 = self.default_config()
-        config2.aot_id = 1
+        config2.fw_compiler = lambda gm, inputs: gm
 
         c1 = self.gen_cache_key(fn, config)
         c2 = self.gen_cache_key(fn, config2)
         self.assertEqual(c1, c2)
+
+    def test_to_cacheable_strips_runtime_only_fields(self):
+        config = self.default_config()
+        config.fw_compiler = lambda gm, inputs: gm
+        config.bw_compiler = lambda gm, inputs: gm
+        config.partition_fn = lambda *args: args
+        config.decompositions = None
+        config.inference_compiler = lambda gm, inputs: gm
+        config.static_input_indices = [0]
+        config.precompile_backend_id = "backend"
+
+        cacheable = config.to_cacheable()
+
+        self.assertIsInstance(cacheable, CacheableAOTConfig)
+        self.assertEqual(cacheable.static_input_indices, [0])
+        self.assertEqual(cacheable.precompile_backend_id, "backend")
+        self.assertFalse(hasattr(cacheable, "fw_compiler"))
+
+    def test_different_cacheable_configs(self):
+        def fn(x):
+            return x.sin().cos()
+
+        base_config = self.default_config()
+        base = self.gen_cache_key(fn, base_config)
+
+        config_with_aot_id = self.default_config()
+        config_with_aot_id.aot_id = 1
+        self.assertNotEqual(base, self.gen_cache_key(fn, config_with_aot_id))
+
+        config_with_static_inputs = self.default_config()
+        config_with_static_inputs.static_input_indices = [0]
+        self.assertNotEqual(base, self.gen_cache_key(fn, config_with_static_inputs))
+
+        config_with_backend = self.default_config()
+        config_with_backend.precompile_backend_id = "backend"
+        self.assertNotEqual(base, self.gen_cache_key(fn, config_with_backend))
 
     def test_different_graphs(self):
         def fn(x):

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -31,7 +31,7 @@ from torch._functorch._aot_autograd.autograd_cache import (
     BypassAOTAutogradCache,
     sanitize_gm_for_cache,
 )
-from torch._functorch._aot_autograd.schemas import AOTConfig
+from torch._functorch._aot_autograd.schemas import AOTConfig, CacheableAOTConfig
 from torch._guards import TracingContext
 from torch._inductor import config as inductor_config
 from torch._inductor.custom_graph_pass import (
@@ -3220,23 +3220,53 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         c2 = self.gen_cache_key(fn, config)
         self.assertEqual(c1, c2)
 
-    def test_identical_graphs_and_configs(self):
+    def test_runtime_only_configs_do_not_change_key(self):
         def fn(x):
             return x.sin().cos()
 
-        def fn2(x):  # noqa: F841
-            y = x.sin()
-            z = y.cos()
-            return z
-
-        # Make the id different, but otherwise identical
         config = self.default_config()
         config2 = self.default_config()
-        config2.aot_id = 1
+        config2.fw_compiler = lambda gm, inputs: gm
 
         c1 = self.gen_cache_key(fn, config)
         c2 = self.gen_cache_key(fn, config2)
         self.assertEqual(c1, c2)
+
+    def test_to_cacheable_strips_runtime_only_fields(self):
+        config = self.default_config()
+        config.fw_compiler = lambda gm, inputs: gm
+        config.bw_compiler = lambda gm, inputs: gm
+        config.partition_fn = lambda *args: args
+        config.decompositions = None
+        config.inference_compiler = lambda gm, inputs: gm
+        config.static_input_indices = [0]
+        config.precompile_backend_id = "backend"
+
+        cacheable = config.to_cacheable()
+
+        self.assertIsInstance(cacheable, CacheableAOTConfig)
+        self.assertEqual(cacheable.static_input_indices, [0])
+        self.assertEqual(cacheable.precompile_backend_id, "backend")
+        self.assertFalse(hasattr(cacheable, "fw_compiler"))
+
+    def test_different_cacheable_configs(self):
+        def fn(x):
+            return x.sin().cos()
+
+        base_config = self.default_config()
+        base = self.gen_cache_key(fn, base_config)
+
+        config_with_aot_id = self.default_config()
+        config_with_aot_id.aot_id = 1
+        self.assertNotEqual(base, self.gen_cache_key(fn, config_with_aot_id))
+
+        config_with_static_inputs = self.default_config()
+        config_with_static_inputs.static_input_indices = [0]
+        self.assertNotEqual(base, self.gen_cache_key(fn, config_with_static_inputs))
+
+        config_with_backend = self.default_config()
+        config_with_backend.precompile_backend_id = "backend"
+        self.assertNotEqual(base, self.gen_cache_key(fn, config_with_backend))
 
     def test_different_graphs(self):
         def fn(x):

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -56,7 +56,7 @@ from .utils import simple_wraps
 if TYPE_CHECKING:
     from torch._inductor.compile_fx import _CompileFxKwargs
 
-    from .schemas import CacheableAOTConfig, ViewAndMutationMeta
+    from .schemas import AOTConfig, CacheableAOTConfig, ViewAndMutationMeta
 
 log = logging.getLogger(__name__)
 aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")
@@ -396,7 +396,9 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         if self.compiled_bw is not None:
             self.compiled_bw.pre_save()
 
-    def _log_cached_graphs(self, aot_config: AOTConfig) -> None:
+    def _log_cached_graphs(
+        self, aot_config: AOTConfig | CacheableAOTConfig
+    ) -> None:
         if not aot_config.enable_log:
             return
 
@@ -590,7 +592,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
     def wrap_post_compile(
         self,
         args: list[torch.Tensor],
-        aot_config: AOTConfig,
+        aot_config: AOTConfig | CacheableAOTConfig,
         fx_config: _CompileFxKwargs,
     ) -> Callable[..., Any]:
         """
@@ -612,13 +614,20 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         from torch._dynamo.utils import dynamo_timed
 
         self._log_cached_graphs(aot_config)
+        # Cache hits only retain the cacheable subset of AOTConfig. Narrow once
+        # here so the existing post-compile wrapper stack can keep its compile-time
+        # AOTConfig annotations.
+        runtime_aot_config = cast(AOTConfig, aot_config)
         with dynamo_timed("AOTAutogradCache.inductor_load"):
             compiled_fw_func, compiled_bw_func, needs_autograd = (
                 self._load_and_post_compile(args, fx_config)
             )
 
         compiled_function = self._apply_runtime_wrappers(
-            compiled_fw_func, compiled_bw_func, needs_autograd, aot_config
+            compiled_fw_func,
+            compiled_bw_func,
+            needs_autograd,
+            runtime_aot_config,
         )
         # Now that we're pretty sure it's a successful load, add guards
         # to the existing shape environment from the cache.
@@ -706,7 +715,7 @@ def deserialize_bundled_cache_entry(
     with torch._guards.tracing(context):
         compiled_fn = entry.wrap_post_compile(
             [],
-            cast(AOTConfig, entry.sanitized_aot_config),
+            entry.sanitized_aot_config,
             {
                 "cudagraphs": cudagraphs,
                 "boxed_forward_device_index": boxed_forward_device_index,

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -56,7 +56,7 @@ from .utils import simple_wraps
 if TYPE_CHECKING:
     from torch._inductor.compile_fx import _CompileFxKwargs
 
-    from .schemas import AOTConfig, CacheableAOTConfig, ViewAndMutationMeta
+    from .schemas import CacheableAOTConfig, ViewAndMutationMeta
 
 log = logging.getLogger(__name__)
 aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -396,9 +396,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         if self.compiled_bw is not None:
             self.compiled_bw.pre_save()
 
-    def _log_cached_graphs(
-        self, aot_config: AOTConfig | CacheableAOTConfig
-    ) -> None:
+    def _log_cached_graphs(self, aot_config: AOTConfig | CacheableAOTConfig) -> None:
         if not aot_config.enable_log:
             return
 

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -56,7 +56,7 @@ from .utils import simple_wraps
 if TYPE_CHECKING:
     from torch._inductor.compile_fx import _CompileFxKwargs
 
-    from .schemas import CacheableAOTConfig, ViewAndMutationMeta
+    from .schemas import AOTConfig, CacheableAOTConfig, ViewAndMutationMeta
 
 log = logging.getLogger(__name__)
 aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")
@@ -397,7 +397,9 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         if self.compiled_bw is not None:
             self.compiled_bw.pre_save()
 
-    def _log_cached_graphs(self, aot_config: AOTConfig) -> None:
+    def _log_cached_graphs(
+        self, aot_config: AOTConfig | CacheableAOTConfig
+    ) -> None:
         if not aot_config.enable_log:
             return
 
@@ -601,7 +603,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
     def wrap_post_compile(
         self,
         args: list[torch.Tensor],
-        aot_config: AOTConfig,
+        aot_config: AOTConfig | CacheableAOTConfig,
         fx_config: _CompileFxKwargs,
     ) -> Callable[..., Any]:
         """
@@ -623,13 +625,20 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         from torch._dynamo.utils import dynamo_timed
 
         self._log_cached_graphs(aot_config)
+        # Cache hits only retain the cacheable subset of AOTConfig. Narrow once
+        # here so the existing post-compile wrapper stack can keep its compile-time
+        # AOTConfig annotations.
+        runtime_aot_config = cast(AOTConfig, aot_config)
         with dynamo_timed("AOTAutogradCache.inductor_load"):
             compiled_fw_func, compiled_bw_func, needs_autograd = (
                 self._load_and_post_compile(args, fx_config)
             )
 
         compiled_function = self._apply_runtime_wrappers(
-            compiled_fw_func, compiled_bw_func, needs_autograd, aot_config
+            compiled_fw_func,
+            compiled_bw_func,
+            needs_autograd,
+            runtime_aot_config,
         )
         # Now that we're pretty sure it's a successful load, add guards
         # to the existing shape environment from the cache.
@@ -717,7 +726,7 @@ def deserialize_bundled_cache_entry(
     with torch._guards.tracing(context):
         compiled_fn = entry.wrap_post_compile(
             [],
-            cast(AOTConfig, entry.sanitized_aot_config),
+            entry.sanitized_aot_config,
             {
                 "cudagraphs": cudagraphs,
                 "boxed_forward_device_index": boxed_forward_device_index,

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -397,9 +397,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         if self.compiled_bw is not None:
             self.compiled_bw.pre_save()
 
-    def _log_cached_graphs(
-        self, aot_config: AOTConfig | CacheableAOTConfig
-    ) -> None:
+    def _log_cached_graphs(self, aot_config: AOTConfig | CacheableAOTConfig) -> None:
         if not aot_config.enable_log:
             return
 

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -24,7 +24,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from copy import copy
 from dataclasses import dataclass
-from typing import Any, Generic, TYPE_CHECKING, TypeVar
+from typing import Any, cast, Generic, TYPE_CHECKING, TypeVar
 
 import torch
 from torch._dynamo.precompile_context import BackendCacheArtifact
@@ -49,14 +49,14 @@ from .runtime_wrappers import (
     SerializableCompiledFunction,
     SubclassMeta,
 )
-from .schemas import AOTAutogradCacheInfo  # noqa: F401
+from .schemas import AOTAutogradCacheInfo, AOTConfig  # noqa: F401
 from .utils import simple_wraps
 
 
 if TYPE_CHECKING:
     from torch._inductor.compile_fx import _CompileFxKwargs
 
-    from .schemas import AOTConfig, ViewAndMutationMeta
+    from .schemas import CacheableAOTConfig, ViewAndMutationMeta
 
 log = logging.getLogger(__name__)
 aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")
@@ -382,7 +382,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
     backward_time_taken_ns: int
 
     # Used by standalone_compile
-    sanitized_aot_config: AOTConfig
+    sanitized_aot_config: CacheableAOTConfig
 
     guards_expr: str | None
 
@@ -717,7 +717,7 @@ def deserialize_bundled_cache_entry(
     with torch._guards.tracing(context):
         compiled_fn = entry.wrap_post_compile(
             [],
-            entry.sanitized_aot_config,
+            cast(AOTConfig, entry.sanitized_aot_config),
             {
                 "cudagraphs": cudagraphs,
                 "boxed_forward_device_index": boxed_forward_device_index,

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -24,7 +24,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from copy import copy
 from dataclasses import dataclass
-from typing import Any, Generic, TYPE_CHECKING, TypeVar
+from typing import Any, cast, Generic, TYPE_CHECKING, TypeVar
 
 import torch
 from torch._dynamo.precompile_context import BackendCacheArtifact
@@ -49,14 +49,14 @@ from .runtime_wrappers import (
     SerializableCompiledFunction,
     SubclassMeta,
 )
-from .schemas import AOTAutogradCacheInfo  # noqa: F401
+from .schemas import AOTAutogradCacheInfo, AOTConfig  # noqa: F401
 from .utils import simple_wraps
 
 
 if TYPE_CHECKING:
     from torch._inductor.compile_fx import _CompileFxKwargs
 
-    from .schemas import AOTConfig, ViewAndMutationMeta
+    from .schemas import CacheableAOTConfig, ViewAndMutationMeta
 
 log = logging.getLogger(__name__)
 aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")
@@ -381,7 +381,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
     backward_time_taken_ns: int
 
     # Used by standalone_compile
-    sanitized_aot_config: AOTConfig
+    sanitized_aot_config: CacheableAOTConfig
 
     guards_expr: str | None
 
@@ -706,7 +706,7 @@ def deserialize_bundled_cache_entry(
     with torch._guards.tracing(context):
         compiled_fn = entry.wrap_post_compile(
             [],
-            entry.sanitized_aot_config,
+            cast(AOTConfig, entry.sanitized_aot_config),
             {
                 "cudagraphs": cudagraphs,
                 "boxed_forward_device_index": boxed_forward_device_index,

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -635,10 +635,11 @@ class AOTAutogradCachePickler(FxGraphCachePickler):
         """
         cacheable = aot_config.to_cacheable()
         return (
-            CacheableAOTConfig,
+            # Cache entries persist the full CacheableAOTConfig, but cache keys
+            # intentionally ignore the debug-only aot_id so equivalent graphs can hit.
+            _ident,
             (
                 cacheable.num_params_buffers,
-                cacheable.aot_id,
                 cacheable.keep_inference_input_mutations,
                 cacheable.is_export,
                 cacheable.no_tangents,

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -79,7 +79,12 @@ from .runtime_wrappers import (
     SerializableCompiledFunction,
     SubclassMeta,
 )
-from .schemas import AOTAutogradCacheInfo, AOTConfig, ViewAndMutationMeta
+from .schemas import (
+    AOTAutogradCacheInfo,
+    AOTConfig,
+    CacheableAOTConfig,
+    ViewAndMutationMeta,
+)
 
 
 if TYPE_CHECKING:
@@ -660,17 +665,21 @@ class AOTAutogradCachePickler(FxGraphCachePickler):
         """
         Reduce the config to a stable key for caching.
         """
+        cacheable = aot_config.to_cacheable()
         return (
-            _ident,
+            CacheableAOTConfig,
             (
-                aot_config.num_params_buffers,
-                aot_config.keep_inference_input_mutations,
-                aot_config.is_export,
-                aot_config.no_tangents,
-                aot_config.dynamic_shapes,
-                aot_config.aot_autograd_arg_pos_to_source,
-                aot_config.enable_log,
-                aot_config.pre_dispatch,
+                cacheable.num_params_buffers,
+                cacheable.aot_id,
+                cacheable.keep_inference_input_mutations,
+                cacheable.is_export,
+                cacheable.no_tangents,
+                cacheable.dynamic_shapes,
+                cacheable.aot_autograd_arg_pos_to_source,
+                cacheable.static_input_indices,
+                cacheable.enable_log,
+                cacheable.pre_dispatch,
+                cacheable.precompile_backend_id,
             ),
         )
 
@@ -1337,7 +1346,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         indices_of_inps_to_detach: list[int],
         forward_time_taken_ns: int,
         backward_time_taken_ns: int,
-        sanitized_aot_config: AOTConfig,
+        sanitized_aot_config: CacheableAOTConfig,
         guards_expr: str | None,
         backward_state_indices: list[int] | None,
         num_symints_saved_for_bw: int | None,

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -78,7 +78,12 @@ from .runtime_wrappers import (
     SerializableCompiledFunction,
     SubclassMeta,
 )
-from .schemas import AOTAutogradCacheInfo, AOTConfig, ViewAndMutationMeta
+from .schemas import (
+    AOTAutogradCacheInfo,
+    AOTConfig,
+    CacheableAOTConfig,
+    ViewAndMutationMeta,
+)
 
 
 if TYPE_CHECKING:
@@ -628,17 +633,21 @@ class AOTAutogradCachePickler(FxGraphCachePickler):
         """
         Reduce the config to a stable key for caching.
         """
+        cacheable = aot_config.to_cacheable()
         return (
-            _ident,
+            CacheableAOTConfig,
             (
-                aot_config.num_params_buffers,
-                aot_config.keep_inference_input_mutations,
-                aot_config.is_export,
-                aot_config.no_tangents,
-                aot_config.dynamic_shapes,
-                aot_config.aot_autograd_arg_pos_to_source,
-                aot_config.enable_log,
-                aot_config.pre_dispatch,
+                cacheable.num_params_buffers,
+                cacheable.aot_id,
+                cacheable.keep_inference_input_mutations,
+                cacheable.is_export,
+                cacheable.no_tangents,
+                cacheable.dynamic_shapes,
+                cacheable.aot_autograd_arg_pos_to_source,
+                cacheable.static_input_indices,
+                cacheable.enable_log,
+                cacheable.pre_dispatch,
+                cacheable.precompile_backend_id,
             ),
         )
 
@@ -1294,7 +1303,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         indices_of_inps_to_detach: list[int],
         forward_time_taken_ns: int,
         backward_time_taken_ns: int,
-        sanitized_aot_config: AOTConfig,
+        sanitized_aot_config: CacheableAOTConfig,
         guards_expr: str | None,
         backward_state_indices: list[int] | None,
         num_symints_saved_for_bw: int | None,

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -667,10 +667,11 @@ class AOTAutogradCachePickler(FxGraphCachePickler):
         """
         cacheable = aot_config.to_cacheable()
         return (
-            CacheableAOTConfig,
+            # Cache entries persist the full CacheableAOTConfig, but cache keys
+            # intentionally ignore the debug-only aot_id so equivalent graphs can hit.
+            _ident,
             (
                 cacheable.num_params_buffers,
-                cacheable.aot_id,
                 cacheable.keep_inference_input_mutations,
                 cacheable.is_export,
                 cacheable.no_tangents,

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -309,28 +309,6 @@ def aot_stage2_export(
     return compiled_fn, aot_state.fw_metadata
 
 
-def sanitize_aot_config(input: AOTConfig) -> AOTConfig:
-    return AOTConfig(
-        fw_compiler=None,
-        bw_compiler=None,
-        partition_fn=None,
-        decompositions={},
-        inference_compiler=None,
-        num_params_buffers=input.num_params_buffers,
-        aot_id=input.aot_id,
-        keep_inference_input_mutations=input.keep_inference_input_mutations,
-        is_export=input.is_export,
-        no_tangents=input.no_tangents,
-        aot_autograd_arg_pos_to_source=input.aot_autograd_arg_pos_to_source,
-        dynamic_shapes=input.dynamic_shapes,
-        enable_log=input.enable_log,
-        static_input_indices=input.static_input_indices,
-        pre_dispatch=input.pre_dispatch,
-        cache_info=None,
-        precompile_backend_id=input.precompile_backend_id,
-    )
-
-
 def _get_inner_meta(
     maybe_subclass_meta: SubclassMeta | None,
     fw_metadata: ViewAndMutationMeta,
@@ -527,7 +505,7 @@ def _cache_inference_info(
             indices_of_inps_to_detach=[],
             forward_time_taken_ns=time_taken_ns,
             backward_time_taken_ns=0,
-            sanitized_aot_config=sanitize_aot_config(aot_config),
+            sanitized_aot_config=aot_config.to_cacheable(),
             guards_expr=guards_expr,
             backward_state_indices=None,
             num_symints_saved_for_bw=None,
@@ -2605,7 +2583,7 @@ def _cache_autograd_info(
                     _indices_of_inps_to_detach,
                     forward_time_taken_ns,
                     backward_time_taken_ns,
-                    sanitized_aot_config=sanitize_aot_config(aot_config),
+                    sanitized_aot_config=aot_config.to_cacheable(),
                     guards_expr=guards_expr,
                     backward_state_indices=backward_state_indices,
                     num_symints_saved_for_bw=num_symints_saved_for_bw,

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -308,28 +308,6 @@ def aot_stage2_export(
     return compiled_fn, aot_state.fw_metadata
 
 
-def sanitize_aot_config(input: AOTConfig) -> AOTConfig:
-    return AOTConfig(
-        fw_compiler=None,
-        bw_compiler=None,
-        partition_fn=None,
-        decompositions={},
-        inference_compiler=None,
-        num_params_buffers=input.num_params_buffers,
-        aot_id=input.aot_id,
-        keep_inference_input_mutations=input.keep_inference_input_mutations,
-        is_export=input.is_export,
-        no_tangents=input.no_tangents,
-        aot_autograd_arg_pos_to_source=input.aot_autograd_arg_pos_to_source,
-        dynamic_shapes=input.dynamic_shapes,
-        enable_log=input.enable_log,
-        static_input_indices=input.static_input_indices,
-        pre_dispatch=input.pre_dispatch,
-        cache_info=None,
-        precompile_backend_id=input.precompile_backend_id,
-    )
-
-
 def _get_inner_meta(
     maybe_subclass_meta: SubclassMeta | None,
     fw_metadata: ViewAndMutationMeta,
@@ -516,7 +494,7 @@ def _cache_inference_info(
             indices_of_inps_to_detach=[],
             forward_time_taken_ns=time_taken_ns,
             backward_time_taken_ns=0,
-            sanitized_aot_config=sanitize_aot_config(aot_config),
+            sanitized_aot_config=aot_config.to_cacheable(),
             guards_expr=guards_expr,
             backward_state_indices=None,
             num_symints_saved_for_bw=None,
@@ -2475,7 +2453,7 @@ def _cache_autograd_info(
                     _indices_of_inps_to_detach,
                     forward_time_taken_ns,
                     backward_time_taken_ns,
-                    sanitized_aot_config=sanitize_aot_config(aot_config),
+                    sanitized_aot_config=aot_config.to_cacheable(),
                     guards_expr=guards_expr,
                     backward_state_indices=backward_state_indices,
                     num_symints_saved_for_bw=num_symints_saved_for_bw,

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -1092,6 +1092,30 @@ class AOTAutogradCacheInfo:
 
 
 @dataclass
+class CacheableAOTConfig:
+    """
+    Serializable subset of AOTConfig used by cache keys and cached entries.
+    """
+
+    num_params_buffers: int
+    aot_id: int
+    keep_inference_input_mutations: bool
+    is_export: bool = False
+    no_tangents: bool = False
+    dynamic_shapes: bool = False
+    aot_autograd_arg_pos_to_source: list[Source] | None = None
+    static_input_indices: list[int] | None = None
+    enable_log: bool = True
+    # this is always false outside of export.
+    pre_dispatch: bool = False
+    precompile_backend_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.pre_dispatch and not self.is_export:
+            raise AssertionError("Can only have pre_dispatch IR for export.")
+
+
+@dataclass
 class AOTConfig:
     """
     Configuration for AOTDispatcher
@@ -1130,6 +1154,21 @@ class AOTConfig:
     # This mode is used to track torch_fn metadata but can interfere with
     # certain tracing scenarios.
     _disable_torch_fn_metadata_mode: bool = False
+
+    def to_cacheable(self) -> CacheableAOTConfig:
+        return CacheableAOTConfig(
+            num_params_buffers=self.num_params_buffers,
+            aot_id=self.aot_id,
+            keep_inference_input_mutations=self.keep_inference_input_mutations,
+            is_export=self.is_export,
+            no_tangents=self.no_tangents,
+            dynamic_shapes=self.dynamic_shapes,
+            aot_autograd_arg_pos_to_source=self.aot_autograd_arg_pos_to_source,
+            static_input_indices=self.static_input_indices,
+            enable_log=self.enable_log,
+            pre_dispatch=self.pre_dispatch,
+            precompile_backend_id=self.precompile_backend_id,
+        )
 
     def __post_init__(self) -> None:
         if self.pre_dispatch:


### PR DESCRIPTION
## Summary

### Root cause
AOTConfig mixed cache-serializable fields with runtime-only callables, so `sanitize_aot_config()` had to rebuild a partial AOTConfig just to strip unpickleable state before caching.

### Proposed fix
- Add `CacheableAOTConfig` in `schemas.py` and `AOTConfig.to_cacheable()` as the single source of truth for the serializable subset.
- Use `CacheableAOTConfig` for `GenericAOTAutogradResult.sanitized_aot_config` and for `AOTAutogradCachePickler._reduce_aot_config`.
- Delete `sanitize_aot_config()` and update focused cache-key tests around runtime-only versus cacheable fields.

### Why this is the right long-term fix
It removes duplicated field lists, makes the cacheable subset explicit in the type system, and keeps cache-key reduction and cached-entry serialization aligned on the same schema.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98