### PR TITLE
[Profiler] Add priority key to EventsMetadata

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -558,6 +558,7 @@ class EventMetadata(NamedTuple):
     shared_memory: int | None
     grid: list[int] | None
     block: list[int] | None
+    priority: int | None
     blocks_per_sm: float | None
     warps_per_sm: float | None
     occupancy: float | None
@@ -607,6 +608,7 @@ _EVENT_METADATA_KEYS: dict[str, tuple[str, Callable[[str], Any]]] = {
     "shared memory": ("shared_memory", int),
     "grid": ("grid", _to_int_list),
     "block": ("block", _to_int_list),
+    "priority": ("priority", int),
     "blocks per SM": ("blocks_per_sm", float),
     "warps per SM": ("warps_per_sm", float),
     "est. achieved occupancy %": ("occupancy", float),


### PR DESCRIPTION
As titled

Demo, on top of https://github.com/pytorch/kineto/pull/1361

```
with torch.profiler.profile(
    activities=[torch.profiler.ProfilerActivity.CUDA],
    experimental_config=torch._C._profiler._ExperimentalConfig(expose_kineto_event_metadata=True)
) as prof:
    x = torch.randn(500, 500, device='cuda')
    y = torch.randn(500, 500, device='cuda')
    result = torch.matmul(x, y)
```

```
EventMetadata(registers_per_thread=84, shared_memory=12672, grid=[7, 7, 1], block=[64, 1, 1], priority=4, blocks_per_sm=0.331081, warps_per_sm=0.662162, occupancy=1.0, queued=0, graph_id=0, graph_node_id=0, stream=7, context=1, bytes=None, bandwidth_gb_s=None, collective_name=None, dtype=None, in_msg_nelems=None, out_msg_nelems=None, in_split_size=None, out_split_size=None, global_rank_start=None, global_rank_stride=None, group_size=None, process_group_name=None, process_group_desc=None, group_ranks=None, rank=None, src_rank=None, dst_rank=None, seq=None, is_async=None)
```