### PR TITLE
[Inductor] Add explicit headers for CPP wrapper to fix MSVC compilation

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -230,6 +230,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
         for device in V.graph.device_types:
             if device != "meta":
                 self.add_device_include(device)
+        self.header.splice("#include <vector>")
+        self.header.splice("#include <cstdint>")
+        self.header.splice("#include <torch/csrc/inductor/runtime/interface.h>")
 
         if V.graph.aot_mode:
             if config.aot_inductor.dynamic_linkage:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -230,9 +230,17 @@ class CppWrapperCpu(PythonWrapperCodegen):
         for device in V.graph.device_types:
             if device != "meta":
                 self.add_device_include(device)
-        self.header.splice("#include <vector>")
-        self.header.splice("#include <cstdint>")
-        self.header.splice("#include <torch/csrc/inductor/runtime/interface.h>")
+        if not self.included_devices:
+            # When only meta device is present, add_device_include is never
+            # called so we need to pull in the common header explicitly.
+            if V.graph.aot_mode:
+                self.header.splice(
+                    "#include <torch/csrc/inductor/aoti_include/common.h>"
+                )
+            else:
+                self.header.splice(
+                    "#include <torch/csrc/inductor/cpp_wrapper/common.h>"
+                )
 
         if V.graph.aot_mode:
             if config.aot_inductor.dynamic_linkage:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -472,9 +472,17 @@ class CppWrapperCpu(PythonWrapperCodegen):
         for device in V.graph.device_types:
             if device != "meta":
                 self.add_device_include(device)
-        self.header.splice("#include <vector>")
-        self.header.splice("#include <cstdint>")
-        self.header.splice("#include <torch/csrc/inductor/runtime/interface.h>")
+        if not self.included_devices:
+            # When only meta device is present, add_device_include is never
+            # called so we need to pull in the common header explicitly.
+            if V.graph.aot_mode:
+                self.header.splice(
+                    "#include <torch/csrc/inductor/aoti_include/common.h>"
+                )
+            else:
+                self.header.splice(
+                    "#include <torch/csrc/inductor/cpp_wrapper/common.h>"
+                )
 
         if V.graph.aot_mode:
             if config.aot_inductor.dynamic_linkage:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -476,11 +476,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
             # When only meta device is present, add_device_include is never
             # called so we need to pull in the common header explicitly.
             if V.graph.aot_mode:
-                self.header.writeln(
+                self.header.writeline(
                     "#include <torch/csrc/inductor/aoti_include/common.h>"
                 )
             else:
-                self.header.writeln(
+                self.header.writeline(
                     "#include <torch/csrc/inductor/cpp_wrapper/common.h>"
                 )
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -476,11 +476,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
             # When only meta device is present, add_device_include is never
             # called so we need to pull in the common header explicitly.
             if V.graph.aot_mode:
-                self.header.append(
+                self.header.writeln(
                     "#include <torch/csrc/inductor/aoti_include/common.h>"
                 )
             else:
-                self.header.append(
+                self.header.writeln(
                     "#include <torch/csrc/inductor/cpp_wrapper/common.h>"
                 )
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -472,6 +472,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
         for device in V.graph.device_types:
             if device != "meta":
                 self.add_device_include(device)
+        self.header.splice("#include <vector>")
+        self.header.splice("#include <cstdint>")
+        self.header.splice("#include <torch/csrc/inductor/runtime/interface.h>")
 
         if V.graph.aot_mode:
             if config.aot_inductor.dynamic_linkage:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -476,11 +476,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
             # When only meta device is present, add_device_include is never
             # called so we need to pull in the common header explicitly.
             if V.graph.aot_mode:
-                self.header.splice(
+                self.header.append(
                     "#include <torch/csrc/inductor/aoti_include/common.h>"
                 )
             else:
-                self.header.splice(
+                self.header.append(
                     "#include <torch/csrc/inductor/cpp_wrapper/common.h>"
                 )
 


### PR DESCRIPTION
Summary:
This PR addresses MSVC compilation failures in the Inductor CPP wrapper backend when targeting the meta device.

Technical Details:
On Windows, the MSVC compiler requires explicit inclusion of standard library headers and runtime interface definitions which are currently implicitly handled or skipped during meta device codegen. Specifically, when TORCHINDUCTOR_CPP_WRAPPER=1 is set, the generated code fails to resolve std::vector, cstdint types, and the AtenTensorHandle abstraction.

Since add_device_include is bypassed for the meta device, the generated wrapper lacks the necessary context for MSVC's stricter lookup rules. This PR explicitly injects the required headers into the codegen's header splice to ensure parity between Linux and Windows compilation environments.

Fixes:

error C2039: 'vector': is not a member of 'std'

error C2065: 'AtenTensorHandle': undeclared identifier

Missing cstdint type definitions.

Link to Issue:
Fixes https://github.com/pytorch/pytorch/issues/179902

Validation:
Verified on Windows Server 2022 (MSVC 19.42) with: set TORCHINDUCTOR_CPP_WRAPPER=1 & pytest -v test/inductor/test_cpu_repro.py -k test_meta_device

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo