### PR TITLE
[CI] Use apt valgrind instead of building from source

### DIFF
--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -28,11 +28,9 @@ install_ubuntu() {
   add-apt-repository ppa:git-core/ppa -y
   apt-get update
   # TODO: Some of these may not be necessary
-  ccache_deps="asciidoc docbook-xml docbook-xsl xsltproc"
   deploy_deps="libffi-dev libbz2-dev libreadline-dev libncurses5-dev libncursesw5-dev libgdbm-dev libsqlite3-dev uuid-dev tk-dev"
   numpy_deps="gfortran"
   apt-get install -y --no-install-recommends \
-    $ccache_deps \
     $numpy_deps \
     ${deploy_deps} \
     ${cmake3} \
@@ -63,7 +61,8 @@ install_ubuntu() {
     gpg-agent \
     gdb \
     bc \
-    zip
+    zip \
+    valgrind
 
   # Should resolve issues related to various apt package repository cert issues
   # see: https://github.com/pytorch/pytorch/issues/65931
@@ -85,16 +84,3 @@ case "$ID" in
     exit 1
     ;;
 esac
-
-# Install Valgrind separately since the apt-get version is too old.
-mkdir valgrind_build && cd valgrind_build
-VALGRIND_VERSION=3.20.0
-wget https://ossci-linux.s3.amazonaws.com/valgrind-${VALGRIND_VERSION}.tar.bz2
-tar -xjf valgrind-${VALGRIND_VERSION}.tar.bz2
-cd valgrind-${VALGRIND_VERSION}
-./configure --prefix=/usr/local
-make -j$[$(nproc) - 2]
-sudo make install
-cd ../../
-rm -rf valgrind_build
-alias valgrind="/usr/local/bin/valgrind"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #180180
* __->__ #180130
* #180133

The apt valgrind (3.18.1 on jammy) is sufficient for PyTorch's usage (primarily callgrind-based instruction counting in benchmarks). Building 3.20.0 from source also pulled in unnecessary build deps (asciidoc, docbook-xml, docbook-xsl, xsltproc). This saves ~130 MB in the install_base Docker layer and ~70s of build time.

Added suppression for dlopen false-positive, that were fixed in https://sourceware.org/git/?p=valgrind.git;a=commit;h=947388eb043ea1c44b37df94046e1eee790ad776

Authored with Claude.