### PR TITLE
[CI] Add --no-install-recommends to clang >= 18 install

### DIFF
--- a/.ci/docker/common/install_clang.sh
+++ b/.ci/docker/common/install_clang.sh
@@ -15,7 +15,7 @@ if [ -n "$CLANG_VERSION" ]; then
 
   sudo apt-get update
   if [[ $CLANG_VERSION -ge 18 ]]; then
-    apt-get install -y libomp-${CLANG_VERSION}-dev libclang-rt-${CLANG_VERSION}-dev clang-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
+    apt-get install -y --no-install-recommends libomp-${CLANG_VERSION}-dev libclang-rt-${CLANG_VERSION}-dev clang-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
   else
     apt-get install -y --no-install-recommends clang-"$CLANG_VERSION" llvm-"$CLANG_VERSION"
   fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #180180
* #180130
* __->__ #180133

The clang >= 18 apt-get path was missing `--no-install-recommends`, which pulled in llvm-18-dev (~428 MB) as a
recommended dependency of clang-18. The dev package is not needed for CI builds. This brings the install_clang layer from 877 MB to 449 MB.

Authored with Claude.