### PR TITLE
dynamo: migrate typing vars to typing_extensions

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -15,8 +15,8 @@ import types
 import typing
 import unittest
 from dataclasses import dataclass, field
-from typing import Any, Generic, TypeVar
-from typing_extensions import NamedTuple
+from typing import Any, Generic
+from typing_extensions import NamedTuple, TypeVar
 from unittest.mock import patch
 
 import numpy as np

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -30,6 +30,7 @@ import unittest
 import unittest.mock as mock
 import warnings
 import weakref
+from typing_extensions import TypeVar
 from unittest.mock import patch
 
 import numpy as np
@@ -121,7 +122,7 @@ parametrize_pytree_module = parametrize(
 )
 
 MyTuple = collections.namedtuple("MyTuple", ["a", "b", "ab"])
-T = typing.TypeVar("T")
+T = TypeVar("T")
 
 
 # Defined in CPython's Include/object.h

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -50,8 +50,8 @@ import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from types import CellType, CodeType, FunctionType, ModuleType
-from typing import Any, NoReturn, TypeVar
-from typing_extensions import ParamSpec
+from typing import Any, NoReturn
+from typing_extensions import ParamSpec, TypeVar
 from weakref import ReferenceType
 
 import torch

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -34,7 +34,8 @@ import tempfile
 import textwrap
 from collections import Counter
 from importlib import import_module
-from typing import Any, TYPE_CHECKING, TypeVar
+from typing import Any, TYPE_CHECKING
+from typing_extensions import TypeVar
 
 import torch
 import torch._prims_common as utils

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -8,8 +8,8 @@ import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Any, overload, TYPE_CHECKING, TypeVar
-from typing_extensions import ParamSpec
+from typing import Any, overload, TYPE_CHECKING
+from typing_extensions import ParamSpec, TypeVar
 
 import torch
 import torch.utils._pytree as pytree

--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -23,8 +23,8 @@ Key functionality groups:
 import functools
 import warnings
 from collections.abc import Callable
-from typing import Any, TYPE_CHECKING, TypeVar
-from typing_extensions import deprecated, ParamSpec
+from typing import Any, TYPE_CHECKING
+from typing_extensions import deprecated, ParamSpec, TypeVar
 
 import torch
 import torch.utils._pytree as pytree

--- a/torch/_dynamo/functional_export.py
+++ b/torch/_dynamo/functional_export.py
@@ -5,7 +5,8 @@ import traceback
 import types
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Optional, TYPE_CHECKING, TypeVar
+from typing import Any, Optional, TYPE_CHECKING
+from typing_extensions import TypeVar
 
 import sympy
 

--- a/torch/_dynamo/graph_id_filter.py
+++ b/torch/_dynamo/graph_id_filter.py
@@ -6,7 +6,8 @@ import functools
 import logging
 import re
 import warnings
-from typing import Any, Generic, TYPE_CHECKING, TypeVar
+from typing import Any, Generic, TYPE_CHECKING
+from typing_extensions import TypeVar
 
 
 if TYPE_CHECKING:

--- a/torch/_dynamo/graph_region_tracker.py
+++ b/torch/_dynamo/graph_region_tracker.py
@@ -23,7 +23,8 @@ import operator
 import pickle
 from collections import defaultdict, deque
 from dataclasses import fields
-from typing import Any, TYPE_CHECKING, TypeVar
+from typing import Any, TYPE_CHECKING
+from typing_extensions import TypeVar
 
 import torch._logging
 import torch.fx

--- a/torch/_dynamo/metrics_context.py
+++ b/torch/_dynamo/metrics_context.py
@@ -19,8 +19,8 @@ import heapq
 import logging
 import time
 from collections.abc import Callable
-from typing import Any, TYPE_CHECKING
-from typing_extensions import Self, TypeAlias
+from typing import Any, TYPE_CHECKING, TypeAlias
+from typing_extensions import Self
 
 
 if TYPE_CHECKING:

--- a/torch/_dynamo/metrics_context.py
+++ b/torch/_dynamo/metrics_context.py
@@ -19,8 +19,8 @@ import heapq
 import logging
 import time
 from collections.abc import Callable
-from typing import Any, TYPE_CHECKING, TypeAlias
-from typing_extensions import Self
+from typing import Any, TYPE_CHECKING
+from typing_extensions import Self, TypeAlias
 
 
 if TYPE_CHECKING:

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -22,8 +22,8 @@ import pickle
 import re
 import zlib
 from collections import defaultdict
-from typing import TYPE_CHECKING, TypeVar
-from typing_extensions import override, Self
+from typing import TYPE_CHECKING
+from typing_extensions import override, Self, TypeVar
 
 import torch._dynamo.config
 import torch._utils_internal

--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -11,8 +11,8 @@ from collections import OrderedDict
 from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Sequence
 from itertools import repeat as _repeat
 from operator import eq, ne
-from typing import Any, TYPE_CHECKING, TypeGuard, TypeVar
-from typing_extensions import TypeIs
+from typing import Any, TYPE_CHECKING, TypeGuard
+from typing_extensions import TypeIs, TypeVar
 
 import torch
 

--- a/torch/_dynamo/polyfills/_collections.py
+++ b/torch/_dynamo/polyfills/_collections.py
@@ -3,7 +3,8 @@ Python polyfills for builtins
 """
 
 from collections.abc import Iterable, MutableMapping
-from typing import TypeVar
+
+from typing_extensions import TypeVar
 
 from ..decorators import substitute_in_graph
 

--- a/torch/_dynamo/polyfills/_collections.py
+++ b/torch/_dynamo/polyfills/_collections.py
@@ -3,7 +3,6 @@ Python polyfills for builtins
 """
 
 from collections.abc import Iterable, MutableMapping
-
 from typing_extensions import TypeVar
 
 from ..decorators import substitute_in_graph

--- a/torch/_dynamo/polyfills/builtins.py
+++ b/torch/_dynamo/polyfills/builtins.py
@@ -9,7 +9,8 @@ import functools
 import operator
 import typing
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
+from typing_extensions import TypeVar
 
 from ..decorators import substitute_in_graph
 

--- a/torch/_dynamo/polyfills/copy.py
+++ b/torch/_dynamo/polyfills/copy.py
@@ -4,7 +4,7 @@ Python polyfills for copy
 
 from __future__ import annotations
 
-from typing import TypeVar
+from typing_extensions import TypeVar
 
 from ..decorators import substitute_in_graph
 

--- a/torch/_dynamo/polyfills/functools.py
+++ b/torch/_dynamo/polyfills/functools.py
@@ -4,7 +4,6 @@ Python polyfills for functools
 
 import functools
 from collections.abc import Callable, Iterable
-
 from typing_extensions import TypeVar
 
 from ..decorators import substitute_in_graph

--- a/torch/_dynamo/polyfills/functools.py
+++ b/torch/_dynamo/polyfills/functools.py
@@ -4,7 +4,8 @@ Python polyfills for functools
 
 import functools
 from collections.abc import Callable, Iterable
-from typing import TypeVar
+
+from typing_extensions import TypeVar
 
 from ..decorators import substitute_in_graph
 

--- a/torch/_dynamo/polyfills/heapq.py
+++ b/torch/_dynamo/polyfills/heapq.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 import heapq
 import importlib
 import sys
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
+from typing_extensions import TypeVar
 
 from ..decorators import substitute_in_graph
 

--- a/torch/_dynamo/polyfills/itertools.py
+++ b/torch/_dynamo/polyfills/itertools.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 import itertools
 import operator
 from collections.abc import Callable
-from typing import overload, TYPE_CHECKING, TypeAlias, TypeVar
+from typing import overload, TYPE_CHECKING
+from typing_extensions import TypeAlias, TypeVar, TypeVarTuple, Unpack
 
 from ..decorators import substitute_in_graph
 
@@ -38,6 +39,7 @@ _U = TypeVar("_U")
 _Predicate: TypeAlias = Callable[[_T], object]
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")
+_Ts = TypeVarTuple("_Ts")
 
 
 # Reference: https://docs.python.org/3/library/itertools.html#itertools.chain
@@ -142,34 +144,9 @@ def takewhile(predicate: _Predicate[_T], iterable: Iterable[_T], /) -> Iterator[
         yield x
 
 
-@overload
 def starmap(
-    function: Callable[[], _U],
-    iterable: Iterable[tuple[()]],
-    /,
-) -> itertools.starmap[_U]: ...
-
-
-@overload
-def starmap(
-    function: Callable[[_T], _U],
-    iterable: Iterable[tuple[_T]],
-    /,
-) -> itertools.starmap[_U]: ...
-
-
-@overload
-def starmap(
-    function: Callable[[_T, _T1], _U],
-    iterable: Iterable[tuple[_T, _T1]],
-    /,
-) -> itertools.starmap[_U]: ...
-
-
-@overload
-def starmap(
-    function: Callable[[_T, _T1, _T2], _U],
-    iterable: Iterable[tuple[_T, _T1, _T2]],
+    function: Callable[[Unpack[_Ts]], _U],
+    iterable: Iterable[tuple[Unpack[_Ts]]],
     /,
 ) -> itertools.starmap[_U]: ...
 

--- a/torch/_dynamo/polyfills/itertools.py
+++ b/torch/_dynamo/polyfills/itertools.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 import itertools
 import operator
 from collections.abc import Callable
-from typing import overload, TYPE_CHECKING
-from typing_extensions import TypeAlias, TypeVar, TypeVarTuple, Unpack
+from typing import overload, TYPE_CHECKING, TypeAlias
+from typing_extensions import TypeVar, TypeVarTuple, Unpack
 
 from ..decorators import substitute_in_graph
 
@@ -144,6 +144,7 @@ def takewhile(predicate: _Predicate[_T], iterable: Iterable[_T], /) -> Iterator[
         yield x
 
 
+@overload
 def starmap(
     function: Callable[[Unpack[_Ts]], _U],
     iterable: Iterable[tuple[Unpack[_Ts]]],

--- a/torch/_dynamo/polyfills/itertools.py
+++ b/torch/_dynamo/polyfills/itertools.py
@@ -146,8 +146,16 @@ def takewhile(predicate: _Predicate[_T], iterable: Iterable[_T], /) -> Iterator[
 
 @overload
 def starmap(
-    function: Callable[[Unpack[_Ts]], _U],
-    iterable: Iterable[tuple[Unpack[_Ts]]],
+    function: Callable[[], _U],
+    iterable: Iterable[tuple[()]],
+    /,
+) -> itertools.starmap[_U]: ...
+
+
+@overload
+def starmap(
+    function: Callable[[_T, Unpack[_Ts]], _U],
+    iterable: Iterable[tuple[_T, Unpack[_Ts]]],
     /,
 ) -> itertools.starmap[_U]: ...
 

--- a/torch/_dynamo/polyfills/operator.py
+++ b/torch/_dynamo/polyfills/operator.py
@@ -5,8 +5,8 @@ Python polyfills for operator
 from __future__ import annotations
 
 import operator
-from typing import Any, overload, TYPE_CHECKING, TypeVar
-from typing_extensions import TypeVarTuple, Unpack
+from typing import Any, overload, TYPE_CHECKING
+from typing_extensions import TypeVar, TypeVarTuple, Unpack
 
 from ..decorators import substitute_in_graph
 

--- a/torch/_dynamo/polyfills/pytree.py
+++ b/torch/_dynamo/polyfills/pytree.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Any, TYPE_CHECKING, TypeVar
+from typing import Any, TYPE_CHECKING
+from typing_extensions import TypeVar
 
 import optree
 import optree._C

--- a/torch/_dynamo/precompile_context.py
+++ b/torch/_dynamo/precompile_context.py
@@ -5,7 +5,8 @@ from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic
+from typing_extensions import TypeVar
 
 import torch
 from torch._dynamo.package import (

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -45,8 +45,8 @@ import traceback
 import types
 import weakref
 from collections import deque
-from typing import Any, cast, NoReturn, TYPE_CHECKING, TypeAlias, TypeVar
-from typing_extensions import TypeIs
+from typing import Any, cast, NoReturn, TYPE_CHECKING
+from typing_extensions import TypeAlias, TypeIs, TypeVar
 
 import torch
 import torch._logging

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -45,8 +45,8 @@ import traceback
 import types
 import weakref
 from collections import deque
-from typing import Any, cast, NoReturn, TYPE_CHECKING
-from typing_extensions import TypeAlias, TypeIs, TypeVar
+from typing import Any, cast, NoReturn, TYPE_CHECKING, TypeAlias
+from typing_extensions import TypeIs, TypeVar
 
 import torch
 import torch._logging

--- a/torch/_dynamo/testing.py
+++ b/torch/_dynamo/testing.py
@@ -24,8 +24,8 @@ import sys
 import types
 import unittest
 from collections.abc import Callable, Generator, Sequence
-from typing import Any, overload, TypeVar
-from typing_extensions import ParamSpec
+from typing import Any, overload
+from typing_extensions import ParamSpec, TypeVar
 from unittest.mock import patch
 
 import torch

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -57,9 +57,10 @@ from typing import (
     Literal,
     NoReturn,
     overload,
+    TypeAlias,
     TypeGuard,
 )
-from typing_extensions import ParamSpec, TypeAlias, TypeIs, TypeVar
+from typing_extensions import ParamSpec, TypeIs, TypeVar
 
 import torch
 import torch._functorch.config

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -57,11 +57,9 @@ from typing import (
     Literal,
     NoReturn,
     overload,
-    TypeAlias,
     TypeGuard,
-    TypeVar,
 )
-from typing_extensions import ParamSpec, TypeIs
+from typing_extensions import ParamSpec, TypeAlias, TypeIs, TypeVar
 
 import torch
 import torch._functorch.config

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -38,6 +38,7 @@ import weakref
 from collections.abc import Callable, MutableMapping
 from types import ModuleType
 from typing import Any, NamedTuple, NoReturn, overload, TYPE_CHECKING, Union
+from typing_extensions import TypeVar
 
 import sympy
 
@@ -327,8 +328,6 @@ log = logging.getLogger(__name__)
 static_inputs_log = torch._logging.getArtifactLogger(
     __name__, "cudagraph_static_inputs"
 )
-from typing import TypeVar
-
 
 # Placeholder for a VariableTracker to be used in proxy
 # creation so that we don't type erase

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -33,8 +33,14 @@ import types
 from collections import namedtuple
 from collections.abc import Callable, Sequence
 from types import CellType, FunctionType
-from typing import Any, cast, Literal, Optional, TYPE_CHECKING, TypeVar
-from typing_extensions import Never
+from typing import (
+    Any,
+    cast,
+    Literal,
+    Optional,
+    TYPE_CHECKING,
+)
+from typing_extensions import Never, TypeVar
 from weakref import WeakKeyDictionary
 
 import torch

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -33,13 +33,7 @@ import types
 from collections import namedtuple
 from collections.abc import Callable, Sequence
 from types import CellType, FunctionType
-from typing import (
-    Any,
-    cast,
-    Literal,
-    Optional,
-    TYPE_CHECKING,
-)
+from typing import Any, cast, Literal, Optional, TYPE_CHECKING
 from typing_extensions import Never, TypeVar
 from weakref import WeakKeyDictionary
 

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -74,8 +74,7 @@ if TYPE_CHECKING:
     from . import AutogradFunctionContextVariable
 
 from collections.abc import Generator, Iterable
-from typing import ParamSpec
-from typing_extensions import TypeVar
+from typing_extensions import ParamSpec, TypeVar
 
 
 P = ParamSpec("P")

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -74,7 +74,8 @@ if TYPE_CHECKING:
     from . import AutogradFunctionContextVariable
 
 from collections.abc import Generator, Iterable
-from typing import ParamSpec, TypeVar
+from typing import ParamSpec
+from typing_extensions import TypeVar
 
 
 P = ParamSpec("P")

--- a/torch/_dynamo/variables/script_object.py
+++ b/torch/_dynamo/variables/script_object.py
@@ -23,8 +23,8 @@ import functools
 import inspect
 import types
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, TYPE_CHECKING, TypeVar
-from typing_extensions import ParamSpec
+from typing import Any, TYPE_CHECKING
+from typing_extensions import ParamSpec, TypeVar
 
 import torch
 import torch.utils._pytree as pytree

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -33,8 +33,8 @@ import math
 import re
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import nullcontext
-from typing import Any, NoReturn, TYPE_CHECKING, TypeVar, Union
-from typing_extensions import TypeIs
+from typing import Any, NoReturn, TYPE_CHECKING, Union
+from typing_extensions import TypeIs, TypeVar
 
 import torch._C
 import torch._refs


### PR DESCRIPTION
## Summary
- migrate Dynamo Python sources and a small non-vendored Dynamo test surface to import `TypeVar` and `TypeAlias` from `typing_extensions`
- replace the fixed-arity `itertools.starmap` overload ladder with a `TypeVarTuple`-based overload in the Dynamo polyfill
- move more than 100 Dynamo typing call sites onto the `typing_extensions` variants in one pass

## Root cause
Dynamo had drifted into a mixed state where some files already depended on `typing_extensions`, while many other Dynamo modules still defined `TypeVar` and `TypeAlias` through `typing`. That leaves the package using two typing surfaces for the same abstractions and makes it harder to consistently adopt newer backported typing features like `TypeVarTuple`.

## Proposed fix
Standardize the touched Dynamo files on `typing_extensions.TypeVar` and `typing_extensions.TypeAlias`, and use `typing_extensions.TypeVarTuple` where Dynamo already benefits from variadic typing in the `itertools.starmap` polyfill.

## Why this is the right long term fix
`typing_extensions` is already the compatibility layer Dynamo uses for other typing features across the codebase. Consolidating `TypeVar` and `TypeAlias` on the same surface reduces version skew, makes future typing cleanups more mechanical, and lets Dynamo adopt variadic typing without waiting on each supported Python baseline to expose the same stdlib surface.

## Validation
- `python3 -m compileall torch/_dynamo test/dynamo/test_functions.py test/dynamo/test_misc.py`
- Direct runtime test execution is blocked in this environment because the checkout cannot import `torch`: the box lacks a global `typing_extensions` install, the generated `torch.version` module, and a built/installed `torch` runtime.

Drafted via Codex, published after manual review by @bobrenjc93


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98