### PR TITLE
Use typing_extensions aliases across aot_autograd

### DIFF
--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -24,7 +24,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from copy import copy
 from dataclasses import dataclass
-from typing import Any, Generic, TYPE_CHECKING, TypeVar
+from typing import Any, Generic, TYPE_CHECKING
+from typing_extensions import TypeVar
 
 import torch
 from torch._dynamo.precompile_context import BackendCacheArtifact
@@ -49,7 +50,6 @@ from .runtime_wrappers import (
     SerializableCompiledFunction,
     SubclassMeta,
 )
-from .schemas import AOTAutogradCacheInfo  # noqa: F401
 from .utils import simple_wraps
 
 

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -32,7 +32,6 @@ from torch.utils._python_dispatch import (
 )
 
 from .descriptors import (
-    AOTInput,
     AOTOutput,
     InputMutationAOTOutput,
     IntermediateBaseAOTOutput,
@@ -51,6 +50,7 @@ from .functional_utils import (
     was_inductor_storage_resized,
 )
 from .schemas import (
+    AOTInputList,
     InputAliasInfo,
     MemoryFormatMeta,
     MutationType,
@@ -166,7 +166,7 @@ def coerce_tangent_and_suggest_memory_format(
 def run_functionalized_fw_and_collect_metadata(
     f: Callable[..., Any],
     *,
-    flat_args_descs: list[AOTInput],
+    flat_args_descs: AOTInputList,
     keep_input_mutations: bool,
     # Note: this is guaranteed to be set when running under dynamo
     static_input_indices: list[int] | None = None,
@@ -425,7 +425,7 @@ def run_functionalized_fw_and_collect_metadata(
         # maps the id of an intermediate base to its index in the output of the compiled forward
         intermediate_base_tensor_id_to_output_idx: dict[int, int] = {}
         intermediate_bases: list[torch.Tensor] = []
-        intermediate_bases_descs: list[AOTInput] = []
+        intermediate_bases_descs: AOTInputList = []
         # Why Do We Care If Storage Changed?
         # It's important to understand the implications of storage changes in complex scenarios. Take this example:
         #

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -19,7 +19,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torchgen.utils import dataclass_repr
 
 from .. import config
-from .descriptors import AOTInput, BackwardTokenAOTInput
+from .descriptors import BackwardTokenAOTInput
 from .functional_utils import (
     assert_functional_graph,
     propagate_input_mutation_stacktraces,
@@ -32,7 +32,14 @@ from .graph_capture_wrappers import (
     fn_prepped_for_autograd,
     handle_effect_tokens_fn,
 )
-from .schemas import AOTConfig, FxValue, SubclassMeta, TraceFn, ViewAndMutationMeta
+from .schemas import (
+    AOTConfig,
+    AOTInputList,
+    FlatFxValues,
+    SubclassMeta,
+    TraceFn,
+    ViewAndMutationMeta,
+)
 from .streams import (
     assign_backward_streams,
     assign_epilogue_copy_streams,
@@ -92,7 +99,7 @@ def _extract_tangent_source_stack_traces(
 def _create_graph(
     f: Callable[..., Any],
     args: list[torch.Tensor],
-    args_descs: list[AOTInput]
+    args_descs: AOTInputList
     | None = None,  # keep compat with old clients; maybe we should split into two impls
     *,
     aot_config: AOTConfig,
@@ -283,12 +290,12 @@ def _create_graph_and_save_traced_inputs(
 
 def aot_dispatch_base_graph(
     flat_fn: TraceFn,
-    flat_args: list[FxValue],
-    flat_args_descs: list[AOTInput],
+    flat_args: FlatFxValues,
+    flat_args_descs: AOTInputList,
     aot_config: AOTConfig,
     *,
     fw_metadata: ViewAndMutationMeta,
-) -> tuple[torch.fx.GraphModule, list[FxValue], list[AOTInput], SubclassMeta | None]:
+) -> tuple[torch.fx.GraphModule, FlatFxValues, AOTInputList, SubclassMeta | None]:
     # aot_dispatch_base requires functionalization, but doesn't need to handle as many cases as the autograd case.
     # The cases that aot_dispatch_base doesn't need to handle include:
     # - outputs that are aliases of graph intermediates
@@ -468,14 +475,14 @@ def aot_dispatch_base_graph(
 def aot_dispatch_autograd_graph(
     flat_fn: TraceFn,
     flat_args: list[Any],
-    flat_args_descs: list[AOTInput],
+    flat_args_descs: AOTInputList,
     aot_config: AOTConfig,
     *,
     fw_metadata: ViewAndMutationMeta,
 ) -> tuple[
     torch.fx.GraphModule,
     tuple[list[Any], list[Any]],
-    tuple[list[AOTInput], list[AOTInput]],
+    tuple[AOTInputList, AOTInputList],
     SubclassMeta | None,
 ]:
     # NB: flat_fn here is the original user function (as far as

--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -15,7 +15,8 @@ import warnings
 from collections.abc import Callable, Generator
 from contextlib import AbstractContextManager, contextmanager, ExitStack, nullcontext
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any
+from typing_extensions import TypeVar
 from unittest.mock import patch
 
 import torch
@@ -44,7 +45,6 @@ from torch.utils._pytree import TreeSpec
 from .. import config
 from .collect_metadata_analysis import run_functionalized_fw_and_collect_metadata
 from .descriptors import (
-    AOTInput,
     AOTOutput,
     BackwardTokenAOTOutput,
     ForwardTokenAOTInput,
@@ -74,15 +74,23 @@ from .functional_utils import (
 from .logging_utils import setup_stacktrace_preservation_hooks
 from .schemas import (
     AOTConfig,
+    AOTInputList,
+    AOTOutputList,
+    FlatFxValues,
     FxValue,
     InputAliasInfo,
     JointTraceFn,
+    JointTraceFnResult,
     MutationType,
+    OptionalAOTOutputList,
     OutputType,
     PreppedForAutogradTraceFn,
+    PreppedForAutogradTraceResult,
     SubclassMeta,
     SubclassTracingInfo,
     TraceFn,
+    TraceFnResult,
+    UpdatedFlatArgsDescs,
     ViewAndMutationMeta,
 )
 from .subclass_utils import (
@@ -106,7 +114,7 @@ from .utils import (
 # will be left in the graph, and we only return metadata-mutated inputs as outputs.
 def fn_input_mutations_to_outputs(
     fn: Callable[..., Any],
-    args_descs: list[AOTInput],
+    args_descs: AOTInputList,
     meta: ViewAndMutationMeta,
     keep_data_input_mutations: bool,
 ) -> Any:
@@ -165,14 +173,14 @@ def disable_autocast() -> Generator[None, None, None]:
 #     if we trace the backward.
 def fn_prepped_for_autograd(
     fn: TraceFn,
-    args_descs: list[AOTInput],
+    args_descs: AOTInputList,
     meta: ViewAndMutationMeta,
     aot_config: AOTConfig,
 ) -> PreppedForAutogradTraceFn:
     @simple_wraps(fn)
     def inner_fn(
         *args: FxValue,
-    ) -> tuple[tuple[list[FxValue], list[bool]], list[AOTOutput]]:
+    ) -> PreppedForAutogradTraceResult:
         args_maybe_cloned = [
             maybe_to_fresh_input(i, t, meta) for i, t in enumerate(args)
         ]
@@ -293,7 +301,7 @@ class JointFnHandle:
 #     (the way this is handled is that we ensure any inputs that normally get mutated are cloned first)
 def create_joint(
     fn: Callable[..., Any],
-    primals_descs: list[AOTInput] | None = None,
+    primals_descs: AOTInputList | None = None,
     *,
     aot_config: AOTConfig,
 ) -> Callable[..., Any]:
@@ -302,12 +310,7 @@ def create_joint(
     # post_forward
     # NB: this type is inaccurate when primals_descs is None
     @simple_wraps(fn)
-    def inner_fn(
-        primals: list[FxValue], tangents: list[FxValue]
-    ) -> tuple[
-        tuple[list[FxValue], list[Tensor | None]],
-        tuple[list[AOTOutput], list[AOTOutput | None]],
-    ]:
+    def inner_fn(primals: FlatFxValues, tangents: FlatFxValues) -> JointTraceFnResult:
         outs_descs = None
         if primals_descs is None:
             outs, tangent_mask = fn(*primals)
@@ -478,22 +481,16 @@ def create_joint(
 
     @simple_wraps(inner_fn)
     def inner_fn_with_anomaly(
-        primals: list[FxValue], tangents: list[FxValue]
-    ) -> tuple[
-        tuple[list[FxValue], list[Tensor | None]],
-        tuple[list[AOTOutput], list[AOTOutput | None]],
-    ]:
+        primals: FlatFxValues, tangents: FlatFxValues
+    ) -> JointTraceFnResult:
         with fx_traceback.preserve_node_meta(), warnings.catch_warnings():
             warnings.filterwarnings("ignore", "Anomaly Detection has been enabled.")
             with torch.autograd.detect_anomaly(check_nan=False):
                 return inner_fn(primals, tangents)
 
     def joint_helper(
-        primals: list[FxValue], tangents: list[FxValue]
-    ) -> tuple[
-        tuple[list[FxValue], list[Tensor | None]],
-        tuple[list[AOTOutput], list[AOTOutput | None]],
-    ]:
+        primals: FlatFxValues, tangents: FlatFxValues
+    ) -> JointTraceFnResult:
         return inner_fn_with_anomaly(primals, tangents)
 
     joint_helper.handle = joint_fn_handle  # type: ignore[attr-defined]
@@ -505,7 +502,7 @@ def create_joint(
 def create_functionalized_rng_ops_wrapper(
     func: Callable[..., Any],
     args: Any,
-    args_descs: list[AOTInput],
+    args_descs: AOTInputList,
     trace_joint: bool = True,
 ) -> Any:
     # Functionalization of rng ops changes the calling convention of the joint graph.
@@ -551,8 +548,8 @@ def create_functionalized_rng_ops_wrapper(
             )
 
     def traced_joint(
-        primals: list[FxValue],
-        tangents: list[FxValue],
+        primals: FlatFxValues,
+        tangents: FlatFxValues,
         fwd_seed: Tensor,
         fwd_base_offset: Tensor,
         bwd_seed: Tensor,
@@ -865,8 +862,8 @@ def create_functionalized_fn(
 
     @simple_wraps(fn)
     def _functionalized_f_helper(
-        *args: list[FxValue],
-    ) -> tuple[tuple[list[FxValue], list[Tensor]], list[AOTOutput | None]]:
+        *args: FlatFxValues,
+    ) -> tuple[tuple[FlatFxValues, list[Tensor]], OptionalAOTOutputList]:
         with maybe_enable_thunkify():
             # See Note [Disabling Functionalize TLS Above Python Functionalization]
             disable_above = torch._C._ExcludeDispatchKeyGuard(
@@ -1168,7 +1165,7 @@ def create_functionalized_fn(
     # Kinda annoying, but needed to make sure that the fx graph we trace out has "primals"
     # and "tangents" as its input names (which are special-cased by the partitioner)
     # TODO (tmanlaibaatar) revisit this if we ever need to turn on non-strict joint graph export
-    def joint_helper(primals: list[FxValue], tangents: list[FxValue]) -> Any:
+    def joint_helper(primals: FlatFxValues, tangents: FlatFxValues) -> Any:
         return _functionalized_f_helper(primals, tangents)
 
     helper = joint_helper if trace_joint else _functionalized_f_helper
@@ -1184,7 +1181,7 @@ def create_functionalized_fn(
 def handle_effect_tokens_fn(
     fn: Callable[..., Any],
     args: Any,
-    args_descs: list[AOTInput],
+    args_descs: AOTInputList,
     *,
     meta: ViewAndMutationMeta,
     trace_joint: bool,
@@ -1306,8 +1303,8 @@ def handle_effect_tokens_fn(
 #   In particular, we need this to tell the partitioner how many dense forward outputs there are.
 def aot_dispatch_subclass(
     flat_fn_maybe_joint: JointTraceFn | TraceFn,
-    args: list[FxValue] | tuple[list[FxValue], list[FxValue]],
-    args_descs: list[AOTInput] | tuple[list[AOTInput], list[AOTInput]],
+    args: FlatFxValues | tuple[FlatFxValues, FlatFxValues],
+    args_descs: UpdatedFlatArgsDescs,
     *,
     is_joint_structure: bool,
     meta: ViewAndMutationMeta,
@@ -1379,20 +1376,18 @@ def aot_dispatch_subclass(
         )
 
     def joint_fn(
-        primals: list[FxValue], tangents: list[FxValue]
-    ) -> tuple[
-        tuple[list[FxValue], list[FxValue]], tuple[list[AOTOutput], list[AOTOutput]]
-    ]:
+        primals: FlatFxValues, tangents: FlatFxValues
+    ) -> tuple[tuple[FlatFxValues, FlatFxValues], tuple[AOTOutputList, AOTOutputList]]:
         with maybe_enable_thunkify():
             return inner_fn(
                 flat_fn_maybe_joint, (primals, tangents), use_trace_joint=True
             )
 
-    def fw_fn(*primals: FxValue) -> tuple[list[FxValue], list[AOTOutput]]:
+    def fw_fn(*primals: FxValue) -> TraceFnResult:
         with maybe_enable_thunkify():
             return inner_fn(flat_fn_maybe_joint, primals, use_trace_joint=False)
 
-    def metadata_fn(*primals: FxValue) -> tuple[list[FxValue], list[AOTOutput]]:
+    def metadata_fn(*primals: FxValue) -> TraceFnResult:
         @simple_wraps(fw_only)
         def inner_fw_only(*args: Any) -> Any:
             return call_and_expect_output_descs(fw_only, args)
@@ -1400,14 +1395,10 @@ def aot_dispatch_subclass(
         return inner_fn(inner_fw_only, primals, use_trace_joint=False)
 
     if is_joint_structure:
-        primals_wrapped: list[FxValue] = typing.cast(list[FxValue], args[0])
-        primals_wrapped_descs: list[AOTInput] = typing.cast(
-            list[AOTInput], args_descs[0]
-        )
-        tangents_wrapped: list[FxValue] = typing.cast(list[FxValue], args[1])
-        tangents_wrapped_descs: list[AOTInput] = typing.cast(
-            list[AOTInput], args_descs[1]
-        )
+        primals_wrapped: FlatFxValues = typing.cast(FlatFxValues, args[0])
+        primals_wrapped_descs: AOTInputList = typing.cast(AOTInputList, args_descs[0])
+        tangents_wrapped: FlatFxValues = typing.cast(FlatFxValues, args[1])
+        tangents_wrapped_descs: AOTInputList = typing.cast(AOTInputList, args_descs[1])
 
         # Add extra symints (size/strides) as input to the forward graph
         primals_unwrapped_pair = unwrap_tensor_subclasses(
@@ -1434,8 +1425,8 @@ def aot_dispatch_subclass(
         primals_unwrapped_descs = args_descs_unwrapped[0]  # type: ignore[assignment]
         fn_to_trace = joint_fn  # type: ignore[assignment]
     else:
-        primals_wrapped: list[FxValue] = typing.cast(list[FxValue], args)
-        primals_wrapped_descs: list[AOTInput] = typing.cast(list[AOTInput], args_descs)
+        primals_wrapped: FlatFxValues = typing.cast(FlatFxValues, args)
+        primals_wrapped_descs: AOTInputList = typing.cast(AOTInputList, args_descs)
 
         args_unwrapped, args_descs_unwrapped = unwrap_tensor_subclasses(  # type: ignore[assignment]
             primals_wrapped,

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -19,7 +19,7 @@ import traceback
 from collections import defaultdict
 from collections.abc import Callable, Generator
 from contextlib import contextmanager, nullcontext
-from typing import Any
+from typing import Any, TypeAlias
 
 import torch
 import torch.utils._pytree as pytree
@@ -55,7 +55,7 @@ from .autograd_cache import (
     should_bundle_autograd_cache,
     should_use_remote_autograd_cache,
 )
-from .descriptors import AOTOutput, PlainAOTOutput
+from .descriptors import PlainAOTOutput
 from .graph_capture import aot_dispatch_autograd_graph, aot_dispatch_base_graph
 from .logging_utils import track_graph_compiling
 from .runtime_wrappers import (
@@ -79,11 +79,14 @@ from .runtime_wrappers import (
 from .schemas import (
     AOTConfig,
     AOTGraphCapture,
+    AOTOutputList,
     AOTState,
     FlatFn,
+    FlatFxValues,
     FxValue,
     MutationType,
     SubclassMeta,
+    UpdatedFlatArgs,
     ViewAndMutationMeta,
 )
 from .subclass_utils import compute_inner_mutated_inp_indices_from_subclass_meta
@@ -95,6 +98,9 @@ from .utils import (
     strict_zip,
     unlift_tokens,
 )
+
+
+DispatchReturn: TypeAlias = tuple[Callable[..., Any], ViewAndMutationMeta]
 
 
 def is_opaque_node(node: Any) -> bool:
@@ -169,11 +175,6 @@ aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")
 
 aten = torch.ops.aten
 
-# Returns a Callable and a ViewAndMutationMeta.
-# Currently, only export needs the ViewAndMutationMeta after this function.
-# TODO: Refactor this
-DispatchReturn = tuple[Callable[..., Any], ViewAndMutationMeta]
-
 
 def _create_wrappers_for_dispatch(needs_autograd: bool) -> list[CompilerWrapper]:
     """
@@ -188,15 +189,15 @@ def aot_stage1_graph_capture(
 ) -> AOTGraphCapture:
     # NB: flat_fn at this point coincides with the initial info from forward
     # metadata collection returning a list[Tensor].  We are now going to
-    # augment the output to return a tuple[list[Tensor], list[AOTOutput]] and
+    # augment the output to return a tuple[list[Tensor], AOTOutputList] and
     # then preserve this convention through the rest of the passes.
 
     # TODO: We could test for consistency with fw_metadata, but this is not a
     # big deal
     @simple_wraps(orig_flat_fn)
-    def orig_flat_fn2(*args: FxValue) -> tuple[list[FxValue], list[AOTOutput]]:
+    def orig_flat_fn2(*args: FxValue) -> tuple[FlatFxValues, AOTOutputList]:
         out = orig_flat_fn(*args)
-        out_descs: list[AOTOutput] = type(out)(  # type: ignore[assignment]
+        out_descs: AOTOutputList = type(out)(  # type: ignore[assignment]
             PlainAOTOutput(i)  # type: ignore[misc]
             for i in range(len(out))  # type: ignore[misc]
         )
@@ -219,7 +220,7 @@ def aot_stage1_graph_capture(
     # NB: This is currently only used for backwards, where fwd/bwd
     # deterministic TLS can be different
     aot_state.fw_metadata.deterministic = torch.are_deterministic_algorithms_enabled()
-    updated_flat_args: list[Any] | tuple[list[Any], list[Any]]
+    updated_flat_args: UpdatedFlatArgs
 
     with maybe_skip_decompose(aot_config):
         # if config.selective_decompose, skip decomposition and apply selective_decompose
@@ -1731,7 +1732,7 @@ def _log_fw_bw_graphs(
 
 def _partition_joint_graph_into_fw_bw(
     fx_g: torch.fx.GraphModule,
-    joint_inputs: list[Any] | tuple[list[Any], list[Any]],
+    joint_inputs: UpdatedFlatArgs,
     inner_meta: ViewAndMutationMeta,
     fw_metadata: ViewAndMutationMeta,
     aot_config: AOTConfig,
@@ -1779,7 +1780,7 @@ def _partition_joint_graph_into_fw_bw(
 
 
 def _joint_inputs_for_forward(
-    joint_inputs: list[Any] | tuple[list[Any], list[Any]],
+    joint_inputs: UpdatedFlatArgs,
 ) -> list[Any]:
     return joint_inputs[0] if isinstance(joint_inputs, tuple) else joint_inputs
 
@@ -1787,11 +1788,11 @@ def _joint_inputs_for_forward(
 def _maybe_unlift_partitioned_effect_tokens(
     fw_module: torch.fx.GraphModule,
     bw_module: torch.fx.GraphModule,
-    joint_inputs: list[Any] | tuple[list[Any], list[Any]],
+    joint_inputs: UpdatedFlatArgs,
     fw_metadata: ViewAndMutationMeta,
     aot_config: AOTConfig,
     num_inner_fwd_outputs: int,
-) -> tuple[int, list[Any] | tuple[list[Any], list[Any]]]:
+) -> tuple[int, UpdatedFlatArgs]:
     num_tokens = len(fw_metadata.tokens)
 
     # See Note [Side-Effectful Tokens in AOTAutograd]
@@ -1990,7 +1991,7 @@ def _compute_indices_of_inps_to_detach(
 
 def _aot_stage2a_partition(
     fx_g: torch.fx.GraphModule,
-    joint_inputs: list[Any] | tuple[list[Any], list[Any]],
+    joint_inputs: UpdatedFlatArgs,
     maybe_subclass_meta: SubclassMeta | None,
     fw_metadata: ViewAndMutationMeta,
     aot_config: AOTConfig,

--- a/torch/_functorch/_aot_autograd/indexed_dict.py
+++ b/torch/_functorch/_aot_autograd/indexed_dict.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterator, MutableMapping
-from typing import Generic, TypeVar
+from typing import Generic
+from typing_extensions import TypeVar
 
 
 K = TypeVar("K")

--- a/torch/_functorch/_aot_autograd/input_output_analysis.py
+++ b/torch/_functorch/_aot_autograd/input_output_analysis.py
@@ -23,9 +23,10 @@ from torch._subclasses.functional_tensor import FunctionalTensor
 from torch.fx.experimental.symbolic_shapes import is_concrete_int
 
 from .collect_metadata_analysis import coerce_tangent_and_suggest_memory_format
-from .descriptors import AOTInput, InputMutationAOTOutput, TangentAOTInput
+from .descriptors import InputMutationAOTOutput, TangentAOTInput
 from .schemas import (
     AOTConfig,
+    AOTInputList,
     BackwardSignature,
     GraphSignature,
     InputAliasInfo,
@@ -129,7 +130,7 @@ def create_synthetic_base_metadata(
     synthetic_base_info: list[int | tuple[int, torch.Tensor]],
     outer_args: list[Any],
     inner_args: list[Any],
-    inner_args_desc: list[AOTInput],
+    inner_args_desc: AOTInputList,
 ) -> tuple[ViewAndMutationMeta, list[int]]:
     # maps inner arg indices to outer arg indices
     synthetic_base_to_indices: dict[int, list[int]] = {}

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -19,7 +19,7 @@ from collections.abc import Callable, Generator, Sequence
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from functools import wraps
-from typing import Any
+from typing import Any, TypeAlias
 
 import torch
 import torch.fx as fx
@@ -58,7 +58,6 @@ from .. import config
 from .collect_metadata_analysis import run_functionalized_fw_and_collect_metadata
 from .descriptors import (
     AOTInput,
-    AOTOutput,
     DummyAOTInput,
     MetadataMutationAOTOutput,
     SyntheticBaseAOTInput,
@@ -74,7 +73,10 @@ from .input_output_analysis import (
 from .logging_utils import describe_input, format_guard_bug_msg, track_graph_compiling
 from .schemas import (
     AOTConfig,
+    AOTInputList,
+    AOTOutputList,
     CompilerWrapper,
+    FlatFxValues,
     FxValue,
     InductorWrapper,
     InputAliasInfo,
@@ -114,6 +116,10 @@ def _unwrap_tensor_subclasses_no_symints(
 zip = strict_zip
 
 aot_graphs_log = getArtifactLogger(__name__, "aot_graphs")
+
+OutputHandler: TypeAlias = Callable[[dict[int, Any], list[Any], Any], Any]
+OutputStrideMetadata: TypeAlias = list[list[int] | None]
+UpdatedInputStorageIndices: TypeAlias = list[int | tuple[int, torch.Tensor]]
 
 
 def _unwrap_no_symints(args: list[Any]) -> list[Any]:
@@ -202,7 +208,9 @@ class NoopAliasHandler:
     ) -> None:
         pass
 
-    def __call__(self, orig_inputs: list[Any], fw_outs: list[Any], out: Any) -> Any:
+    def __call__(
+        self, orig_inputs: dict[int, Any], fw_outs: list[Any], out: Any
+    ) -> Any:
         return out
 
 
@@ -227,7 +235,7 @@ class AliasOfInputHandler:
         self.replay_views = config.view_replay_for_aliased_outputs
 
     def __call__(
-        self, orig_inputs: list[Any], fw_outs: list[Any], out: Any
+        self, orig_inputs: dict[int, Any], fw_outs: list[Any], out: Any
     ) -> torch.Tensor:
         aliased_base_tensor = orig_inputs[self.base_idx]
         return gen_alias_from_base(
@@ -247,7 +255,7 @@ class IsInputHandler:
         self.unwrap_out = _unwrap_tensoralias if trace_joint else _identity
 
     def __call__(
-        self, orig_inputs: list[Any], fw_outs: list[Any], out: Any
+        self, orig_inputs: dict[int, Any], fw_outs: list[Any], out: Any
     ) -> torch.Tensor:
         aliased_base_tensor = orig_inputs[self.base_idx]
         return aliased_base_tensor
@@ -275,7 +283,7 @@ class AliasOfIntermediateHandler:
         self.replay_views = config.view_replay_for_aliased_outputs
 
     def __call__(
-        self, orig_inputs: list[Any], fw_outs: list[Any], out: Any
+        self, orig_inputs: dict[int, Any], fw_outs: list[Any], out: Any
     ) -> torch.Tensor:
         aliased_base_tensor = fw_outs[self.base_idx]
         return gen_alias_from_base(
@@ -301,7 +309,7 @@ _HANDLER_MAP = {
 
 def make_output_handler(
     info: Any, runtime_metadata: ViewAndMutationMeta, trace_joint: bool
-) -> Any:
+) -> OutputHandler:
     handler_type = _HANDLER_MAP[info.output_type]
     return handler_type(info, runtime_metadata, trace_joint)
 
@@ -537,7 +545,7 @@ class _RuntimeForwardEpilogue:
     trace_joint: bool
     keep_input_mutations: bool
     epilogue_args_idx: tuple[int, ...] = field(init=False)
-    output_handlers: tuple[Any, ...] = field(init=False)
+    output_handlers: tuple[OutputHandler, ...] = field(init=False)
 
     def __post_init__(self) -> None:
         epilogue_args_idx = list(self.runtime_metadata.mutated_inp_runtime_indices)
@@ -957,7 +965,7 @@ class FakifiedOutWrapper(InductorWrapper):
     # TracingContext.fwd_output_strides
     # Generated from actually doing compile
     # NB: an entry is None if it's not a Tensor
-    fwd_output_strides: list[list[int] | None] | None = None
+    fwd_output_strides: OutputStrideMetadata | None = None
     needs_post_compile: bool = True
 
     def pre_compile(
@@ -1007,9 +1015,7 @@ class FakifiedOutWrapper(InductorWrapper):
         return out
 
     # To be called post compile
-    def set_fwd_output_strides(
-        self, fwd_output_strides: list[list[int] | None]
-    ) -> None:
+    def set_fwd_output_strides(self, fwd_output_strides: OutputStrideMetadata) -> None:
         self.fwd_output_strides = fwd_output_strides
 
     def post_compile(
@@ -1054,12 +1060,12 @@ class AOTDispatchSubclassWrapper(CompilerWrapper):
     def pre_compile(
         self,
         flat_fn: TraceFn,
-        flat_args: list[FxValue],
-        flat_args_descs: list[AOTInput],
+        flat_args: FlatFxValues,
+        flat_args_descs: AOTInputList,
         aot_config: AOTConfig,
         *,
         fw_metadata: ViewAndMutationMeta,
-    ) -> tuple[TraceFn, list[FxValue], list[AOTInput], ViewAndMutationMeta]:
+    ) -> tuple[TraceFn, FlatFxValues, AOTInputList, ViewAndMutationMeta]:
         (new_flat_fn, new_flat_args, new_flat_args_descs, subclass_meta) = (
             aot_dispatch_subclass(
                 flat_fn,
@@ -1239,19 +1245,19 @@ class AOTDedupeWrapper(CompilerWrapper):
     def pre_compile(
         self,
         flat_fn: TraceFn,
-        flat_args: list[FxValue],
-        flat_args_descs: list[AOTInput],
+        flat_args: FlatFxValues,
+        flat_args_descs: AOTInputList,
         aot_config: AOTConfig,
         *,
         fw_metadata: ViewAndMutationMeta,
-    ) -> tuple[TraceFn, list[FxValue], list[AOTInput], ViewAndMutationMeta]:
+    ) -> tuple[TraceFn, FlatFxValues, AOTInputList, ViewAndMutationMeta]:
         # Use information about whether or not flat_fn mutates its arguments
         # or not to handle dupe args
 
         # Strategy 1: For any input that is not mutated, we can leafify it if we
         # need to remove a duplicate.
-        leaf_flat_args: list[FxValue] = []
-        leaf_flat_args_descs: list[AOTInput] = []
+        leaf_flat_args: FlatFxValues = []
+        leaf_flat_args_descs: AOTInputList = []
         args_set = set()
         ok = True
 
@@ -1378,7 +1384,7 @@ class AOTDedupeWrapper(CompilerWrapper):
         @simple_wraps(flat_fn)
         def wrapped_flat_fn(
             *args: FxValue,
-        ) -> tuple[list[FxValue], list[AOTOutput]]:
+        ) -> tuple[FlatFxValues, AOTOutputList]:
             outs, out_descs = call_and_expect_output_descs(
                 flat_fn,
                 self.add_dupe_args(args),  # type: ignore[arg-type]
@@ -1493,12 +1499,12 @@ class AOTSyntheticBaseWrapper(CompilerWrapper):
     def pre_compile(
         self,
         flat_fn: TraceFn,
-        flat_args: list[FxValue],
-        flat_args_descs: list[AOTInput],
+        flat_args: FlatFxValues,
+        flat_args_descs: AOTInputList,
         aot_config: AOTConfig,
         *,
         fw_metadata: ViewAndMutationMeta,
-    ) -> tuple[Callable[..., Any], list[FxValue], list[AOTInput], ViewAndMutationMeta]:
+    ) -> tuple[Callable[..., Any], FlatFxValues, AOTInputList, ViewAndMutationMeta]:
         is_inference = not self.trace_joint
         (
             flat_args_with_synthetic_bases,
@@ -1763,12 +1769,12 @@ def merge_view_inputs(
     aot_config: AOTConfig,
     fwd_inputs: list[Any],
     # This is None when called at runtime from post_compile closure
-    fwd_inputs_descs: list[AOTInput] | None,
+    fwd_inputs_descs: AOTInputList | None,
     mutated_input_info: list[InputAliasInfo],
     *,
     # The autograd case currently has more restrictions than the inference case.
     is_inference: bool,
-) -> tuple[list[Any], list[AOTInput], list[int | tuple[int, torch.Tensor]] | None]:
+) -> tuple[list[Any], AOTInputList, UpdatedInputStorageIndices | None]:
     if fwd_inputs_descs is None:
         fwd_inputs_descs = [DummyAOTInput(i) for i in range(len(fwd_inputs))]
 
@@ -1984,7 +1990,7 @@ def merge_view_inputs(
             inner_calling_convention_meta[old_idx] = new_idx
 
         # post process into a list
-        post_processed_calling_convention_meta: list[int | tuple[int, torch.Tensor]] = [
+        post_processed_calling_convention_meta: UpdatedInputStorageIndices = [
             -1 for _ in range(len(inner_calling_convention_meta))
         ]
         for k, v in inner_calling_convention_meta.items():
@@ -3302,12 +3308,12 @@ class DebugAssertWrapper(CompilerWrapper):
 def pre_compile(
     wrappers: list[CompilerWrapper],
     flat_fn: TraceFn,
-    flat_args: list[FxValue],
-    flat_args_descs: list[AOTInput],
+    flat_args: FlatFxValues,
+    flat_args_descs: AOTInputList,
     aot_config: AOTConfig,
     *,
     fw_metadata: ViewAndMutationMeta,
-) -> tuple[TraceFn, list[FxValue], list[AOTInput], ViewAndMutationMeta]:
+) -> tuple[TraceFn, FlatFxValues, AOTInputList, ViewAndMutationMeta]:
     """
     Runs a sequence of wrappers on the given function and arguments.
     Mutates wrappers in place.

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -9,8 +9,8 @@ import collections
 import functools
 from dataclasses import dataclass, field, replace
 from enum import Enum
-from typing import Any, NewType, Protocol, TYPE_CHECKING, TypeVar
-from typing_extensions import ParamSpec
+from typing import Any, NewType, Protocol, TYPE_CHECKING, TypeAlias
+from typing_extensions import ParamSpec, TypeVar
 
 import torch
 import torch.utils._pytree as pytree
@@ -22,6 +22,7 @@ from torch.fx.experimental._backward_state import BackwardState
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 from .. import config
+from .descriptors import AOTInput, AOTOutput
 from .functional_utils import _check_if_mutation_can_be_in_graph, ViewMetaSequence
 from .utils import strict_zip
 
@@ -36,12 +37,14 @@ if TYPE_CHECKING:
     from torch._ops import OpOverload
     from torch.types import IntLikeType
 
-    from .descriptors import AOTInput, AOTOutput
     from .graph_capture_wrappers import JointFnHandle
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 zip = strict_zip
+
+AOTInputList: TypeAlias = list[AOTInput]
+AOTOutputList: TypeAlias = list[AOTOutput]
 
 
 OutputType = Enum(
@@ -434,7 +437,7 @@ class ViewAndMutationMeta:
     traced_tangents: list[Any]
 
     # TODO doc
-    traced_tangents_descs: list[AOTInput]
+    traced_tangents_descs: AOTInputList
 
     # Each of these is a list telling us about subclasses for the inputs/outputs/grad_outs
     # They are used throughout AOTDispatch to tell us how to generate a list of subclass tensors,
@@ -1180,10 +1183,10 @@ class AOTState:
     #
     # (By the way, this is NEVER the joint inputs!  Those only ever go in
     # AOTGraphCapture)
-    flat_args: list[FxValue]
+    flat_args: FlatFxValues
 
     # The descriptor for each argument in flat_args.
-    flat_args_descs: list[AOTInput]
+    flat_args_descs: AOTInputList
 
     # This contains view and mutation information about the function, which we
     # detected by doing an initial trace when we created this state.
@@ -1214,6 +1217,20 @@ class AOTState:
 
 
 FxValue = Tensor | int | SymInt | BackwardState | OpaqueBase
+FlatFxValues: TypeAlias = list[FxValue]
+FlatTensorList: TypeAlias = list[Tensor]
+OptionalTensorList: TypeAlias = list[Tensor | None]
+OptionalAOTOutputList: TypeAlias = list[AOTOutput | None]
+TraceFnResult: TypeAlias = tuple[FlatFxValues, AOTOutputList]
+PreppedForAutogradTraceResult: TypeAlias = tuple[
+    tuple[FlatFxValues, list[bool]], AOTOutputList
+]
+JointTraceFnResult: TypeAlias = tuple[
+    tuple[FlatFxValues, OptionalTensorList],
+    tuple[AOTOutputList, OptionalAOTOutputList],
+]
+UpdatedFlatArgs: TypeAlias = list[Any] | tuple[list[Any], list[Any]]
+UpdatedFlatArgsDescs: TypeAlias = AOTInputList | tuple[AOTInputList, AOTInputList]
 
 
 class CompilerWrapper:
@@ -1246,12 +1263,12 @@ class CompilerWrapper:
     def pre_compile(
         self,
         flat_fn: TraceFn,
-        flat_args: list[FxValue],
-        flat_args_descs: list[AOTInput],
+        flat_args: FlatFxValues,
+        flat_args_descs: AOTInputList,
         aot_config: AOTConfig,
         *,
         fw_metadata: ViewAndMutationMeta,
-    ) -> tuple[TraceFn, list[FxValue], list[AOTInput], ViewAndMutationMeta]:
+    ) -> tuple[TraceFn, FlatFxValues, AOTInputList, ViewAndMutationMeta]:
         """
         Process the inputs to the compiler_fn. You can pass in extra metadata via kwargs.
         Args:
@@ -1308,7 +1325,7 @@ class InductorWrapper:
     def pre_compile(
         self,
         fw_module: torch.fx.GraphModule,
-        flat_args: list[Tensor],
+        flat_args: FlatTensorList,
         aot_config: AOTConfig,
         *,
         fw_metadata: ViewAndMutationMeta,
@@ -1368,9 +1385,9 @@ class AOTGraphCapture:  # Produced by aot_stage1_graph_capture
     # larger than the original flat_args as all tangents get inputs.  The
     # tuple organizes into primals and tangents.  When not autograd it's just
     # a plain list.
-    updated_flat_args: list[Any] | tuple[list[Any], list[Any]]
+    updated_flat_args: UpdatedFlatArgs
 
-    updated_flat_args_descs: list[AOTInput] | tuple[list[AOTInput], list[AOTInput]]
+    updated_flat_args_descs: UpdatedFlatArgsDescs
 
     # Metadata about subclass inputs/outputs in the graph trace.
     maybe_subclass_meta: Any
@@ -1423,29 +1440,26 @@ class SerializableAOTDispatchCompiler(AOTDispatchCompiler):
 
 
 class FlatFn(Protocol):
-    def __call__(self, *args: FxValue) -> list[FxValue]: ...
+    def __call__(self, *args: FxValue) -> FlatFxValues: ...
 
 
 class TraceFn(Protocol):
-    def __call__(self, *args: FxValue) -> tuple[list[FxValue], list[AOTOutput]]: ...
+    def __call__(self, *args: FxValue) -> TraceFnResult: ...
 
 
 class PreppedForAutogradTraceFn(Protocol):
     def __call__(
         self,
         *args: FxValue,
-    ) -> tuple[tuple[list[FxValue], list[bool]], list[AOTOutput]]: ...
+    ) -> PreppedForAutogradTraceResult: ...
 
 
 class JointTraceFn(Protocol):
     handle: JointFnHandle
 
     def __call__(
-        self, primals: list[FxValue], tangents: list[FxValue]
-    ) -> tuple[
-        tuple[list[FxValue], list[Tensor | None]],
-        tuple[list[AOTOutput], list[AOTOutput | None]],
-    ]: ...
+        self, primals: FlatFxValues, tangents: FlatFxValues
+    ) -> JointTraceFnResult: ...
 
 
 @dataclass

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -6,7 +6,8 @@ and this includes tensor subclasses that implement __torch_dispatch__.
 
 import collections
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, TypeGuard, TypeVar
+from typing import Any, TypeGuard
+from typing_extensions import TypeVar
 
 import torch
 import torch.utils._pytree as pytree
@@ -34,6 +35,7 @@ from .descriptors import (
 )
 from .schemas import (
     FakifiedFlatArgs,
+    FlatFxValues,
     FxValue,
     MutationType,
     OpaqueMeta,
@@ -254,11 +256,11 @@ AOTDescriptor = TypeVar("AOTDescriptor", AOTInput, AOTOutput)
 # primals (but not tangents) on entry to the forward. See the runtime version of
 # this function below.
 def unwrap_tensor_subclasses(
-    wrapped_args: list[FxValue],
+    wrapped_args: FlatFxValues,
     wrapped_args_descs: Sequence[AOTDescriptor],
     *,
     append_symints: bool,
-) -> tuple[list[FxValue], list[AOTDescriptor]]:
+) -> tuple[FlatFxValues, list[AOTDescriptor]]:
     def _maybe_fakeify_opaque(v: Any) -> Any:
         # Registered opaque types need to be wrapped as FakeScriptObject for
         # compile-time FX tracing (proxy slot tracking, hashability, etc.).
@@ -276,7 +278,7 @@ def unwrap_tensor_subclasses(
         t: FxValue,
         desc: AOTDescriptor,
         *,
-        out: tuple[list[FxValue], list[AOTDescriptor]],
+        out: tuple[FlatFxValues, list[AOTDescriptor]],
     ) -> None:
         # unwrap a subclass into plain tensors and their size/stride if "append_symint"
         # is True
@@ -312,7 +314,7 @@ def unwrap_tensor_subclasses(
             out[1].extend(SubclassSize(desc, i) for i, _ in sizes)
             out[1].extend(SubclassStride(desc, i) for i, _ in strides)
 
-    xs_inner: list[FxValue] = []
+    xs_inner: FlatFxValues = []
     descs_inner: list[AOTDescriptor] = []
 
     for x, desc in zip(wrapped_args, wrapped_args_descs):

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -25,6 +25,7 @@ from torch.fx.experimental.proxy_tensor import py_sym_types
 
 
 _T = TypeVar("_T")
+_F = TypeVar("_F", bound=Callable[..., Any])
 if TYPE_CHECKING:
     from .schemas import AOTConfig, ViewAndMutationMeta
 
@@ -766,7 +767,7 @@ _Ts = TypeVarTuple("_Ts")
 
 
 def call_and_expect_output_descs(
-    fn: Callable[[*_Ts], tuple[Any, Any]], args: tuple[Unpack[_Ts]]
+    fn: Callable[[Unpack[_Ts]], tuple[Any, Any]], args: tuple[Unpack[_Ts]]
 ) -> tuple[Any, Any]:
     from .descriptors import AOTOutput
 
@@ -801,7 +802,7 @@ def call_and_expect_output_descs(
     return outs_pair
 
 
-def fn_wrappers(fn: Callable[..., Any]) -> list[Callable[..., Any]]:
+def fn_wrappers(fn: _F) -> list[_F]:
     fns = [fn]
     f = fn
     while hasattr(f, "__wrapped__"):


### PR DESCRIPTION
## Summary

This PR keeps AOTAutograd type annotations DRY where aliases carry AOT-specific meaning, while reverting the generic container/callable aliases called out in review. Shared aliases now cover semantic AOT shapes like `AOTInputList`, `AOTOutputList`, `FlatFxValues`, `TraceFnResult`, and runtime wrapper metadata. Generic shapes use standard spellings such as `list[str]`, `list[int]`, and `dict[str, Any]`, and `utils.py` uses `TypeVarTuple` directly where the callable argument tuple needs to be preserved.

## Root Cause

`aot_autograd` had repeated long structural annotations for domain-specific AOT values across runtime wrappers, graph capture, cache plumbing, and schema definitions. The first draft also introduced generic aliases such as `StringList`, `IndexList`, and catch-all callable/container aliases, which hid common Python types without adding semantic value.

## Proposed Fix

- Keep semantic aliases in `schemas.py` and small runtime-wrapper metadata aliases where they name AOT concepts.
- Remove generic aliases and replace call sites with standard built-in generic types.
- Use `typing_extensions.TypeVarTuple`/`Unpack` directly in `call_and_expect_output_descs` to preserve the callable argument tuple as requested in review.
- Keep typing imports consolidated through `typing_extensions` where needed for compatibility.

## Why This Is The Right Long Term Fix

This gives repeated AOT-specific shapes a single stable vocabulary while avoiding abstraction over common Python containers. The result reduces noisy duplicated annotations but still leaves reviewers/readers seeing normal built-in types for generic data structures, and the variadic `utils.py` signature models the real calling convention without an imprecise alias.

## Validation

- `python3 -m compileall -q torch/_functorch/_aot_autograd`
- `git diff --cached --check` before commit
- `python3 tools/linter/adapters/pyfmt_linter.py <changed files>`
- `python3 tools/linter/adapters/ruff_linter.py --config=pyproject.toml --show-disable --no-fix <changed files>`
- `python3 tools/linter/adapters/flake8_linter.py <changed files>`

## Build/Test Notes

- `PYTHONPATH=. python3 test/functorch/test_aotdispatch.py -k typing -v` was attempted but stopped before collection because the local source tree has not finished building `torch/lib/libtorch_global_deps.so`.
- A CPU `python3 setup.py develop` build was attempted after initializing submodules and installing local build tools; CMake configured and then expanded into a full ~6,976-target C++ dependency build, so I stopped it before completion because the change is typing-only and the build was not going to finish in a useful window.
- `lintrunner -a <changed files>` was attempted after installing `lintrunner`/`uv`; the PyRefly adapter reported unrelated repo-wide missing `torch` attributes outside this diff, while targeted pyfmt/ruff/flake8 checks passed.

Drafted via Codex, published after manual review by @bobrenjc93