### PR TITLE
torch.fx: use typing_extensions aliases more aggressively

### DIFF
--- a/torch/fx/_compatibility.py
+++ b/torch/fx/_compatibility.py
@@ -1,6 +1,7 @@
 import textwrap
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
+from typing_extensions import TypeVar
 
 
 _BACK_COMPAT_OBJECTS: dict[Any, None] = {}

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -7,8 +7,8 @@ import pickle
 import weakref
 from abc import abstractmethod
 from collections.abc import Callable, Generator
-from typing import Any, NewType, TypeVar
-from typing_extensions import override, Self
+from typing import Any, NewType
+from typing_extensions import override, Self, TypeVar
 
 from torch.utils._import_utils import import_dill
 

--- a/torch/fx/_pytree.py
+++ b/torch/fx/_pytree.py
@@ -1,18 +1,18 @@
 from collections import namedtuple
 from collections.abc import Callable
-from typing import Any, TypeVar
-from typing_extensions import NamedTuple
+from typing import Any, TypeAlias
+from typing_extensions import NamedTuple, TypeVar
 
 import torch.return_types
 from torch.utils._pytree import PyTree, tree_flatten, TreeSpec
 
 
-FlattenFnSpec = Callable[[PyTree, TreeSpec], list[Any]]
-FlattenFnExactMatchSpec = Callable[[PyTree, TreeSpec], bool]
+FlattenFnSpec: TypeAlias = Callable[[PyTree, TreeSpec], list[Any]]
+FlattenFnExactMatchSpec: TypeAlias = Callable[[PyTree, TreeSpec], bool]
 
 # Keep deprecated alias for backward compatibility
-FlattenFuncSpec = FlattenFnSpec  # deprecated
-FlattenFuncExactMatchSpec = FlattenFnExactMatchSpec  # deprecated
+FlattenFuncSpec: TypeAlias = FlattenFnSpec  # deprecated
+FlattenFuncExactMatchSpec: TypeAlias = FlattenFnExactMatchSpec  # deprecated
 
 SUPPORTED_NODES: dict[type[Any], FlattenFnSpec] = {}
 SUPPORTED_NODES_EXACT_MATCH: dict[type[Any], FlattenFnExactMatchSpec | None] = {}

--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -2,8 +2,8 @@ import itertools
 import operator
 from collections.abc import Callable
 from functools import reduce
-from typing import Any, TypeVar
-from typing_extensions import ParamSpec
+from typing import Any
+from typing_extensions import ParamSpec, TypeVar
 
 import sympy
 

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -1,8 +1,8 @@
 import operator
 import warnings
 from collections.abc import Callable, Iterable, Sequence
-from typing import TypeAlias, TypeVar
-from typing_extensions import ParamSpec
+from typing import TypeAlias
+from typing_extensions import ParamSpec, TypeVar
 
 import torch
 from torch.fx._symbolic_trace import _assert_is_none

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -26,10 +26,9 @@ from typing import (
     Protocol,
     TYPE_CHECKING,
     TypeAlias,
-    TypeVar,
     Union,
 )
-from typing_extensions import ParamSpec, Self, TypeVarTuple, Unpack
+from typing_extensions import ParamSpec, Self, TypeVar, TypeVarTuple, Unpack
 from weakref import WeakKeyDictionary
 
 import torch
@@ -109,11 +108,11 @@ __all__ = [
     "maybe_disable_thunkify",
 ]
 
-_ProxyTracer = Union["PythonKeyTracer", "_GraphAppendingTracerEx"]
+_ProxyTracer: TypeAlias = Union["PythonKeyTracer", "_GraphAppendingTracerEx"]
 _TracingMode: TypeAlias = Literal["real", "fake", "symbolic"]
 
 _AnyScriptObject = (torch.ScriptObject, FakeScriptObject)
-_AnyScriptObjectType = torch.ScriptObject | FakeScriptObject
+_AnyScriptObjectType: TypeAlias = torch.ScriptObject | FakeScriptObject
 
 aten = torch.ops.aten
 prim = torch.ops.prim
@@ -121,17 +120,21 @@ prim = torch.ops.prim
 log = logging.getLogger(__name__)
 not_implemented_log = torch._logging.getArtifactLogger(__name__, "not_implemented")
 
-CURRENT_DECOMPOSITION_TABLE: contextvars.ContextVar[
-    Mapping[OpOverload, Callable[..., Any]]
-] = contextvars.ContextVar("CURRENT_DECOMPOSITION_TABLE")
-
-CONSTANT_NUMEL_LIMIT = 1
-
 T = TypeVar("T")
 U = TypeVar("U")
 _P = ParamSpec("_P")
 R = TypeVar("R")
 _Ts = TypeVarTuple("_Ts")
+DecompositionTable: TypeAlias = Mapping[OpOverload, Callable[..., Any]]
+MaybeDecompositionTable: TypeAlias = DecompositionTable | None
+TensorMetaTuple: TypeAlias = tuple[torch._C._TensorMeta, ...]
+MaybeNestedTensors: TypeAlias = "_NestedTensors | None"
+
+CURRENT_DECOMPOSITION_TABLE: contextvars.ContextVar[DecompositionTable] = (
+    contextvars.ContextVar("CURRENT_DECOMPOSITION_TABLE")
+)
+
+CONSTANT_NUMEL_LIMIT = 1
 
 # We currently convert all SymInt to proxies before we use them.
 # This could plausibly be handled at the Dynamo level.
@@ -163,8 +166,8 @@ def fake_signature(fn: Callable[_P, R], nargs: int) -> Callable[_P, R]:
 
 @contextmanager
 def decompose(
-    decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None,
-) -> Generator[Mapping[OpOverload, Callable[..., Any]], None, None]:
+    decomposition_table: MaybeDecompositionTable,
+) -> Generator[DecompositionTable, None, None]:
     table = decomposition_table or {}
     token = CURRENT_DECOMPOSITION_TABLE.set(table)
     try:
@@ -886,10 +889,10 @@ def track_tensor(
     set_proxy_slot(tensor, tracer, _ProxyTensor(proxy, constant))
 
 
-_NestedProxys = Union[  # noqa: UP007
+_NestedProxys: TypeAlias = Union[  # noqa: UP007
     Proxy, Sequence["_NestedProxys"], Mapping[object, "_NestedProxys"]
 ]
-_NestedTensors = Union[  # noqa: UP007
+_NestedTensors: TypeAlias = Union[  # noqa: UP007
     Tensor, Sequence["_NestedTensors"], Mapping[object, "_NestedTensors"]
 ]
 
@@ -898,7 +901,7 @@ def track_tensor_tree(
     inner_res: T,
     proxy_res: _NestedProxys,
     *,
-    constant: _NestedTensors | None,
+    constant: MaybeNestedTensors,
     tracer: _ProxyTracer,
 ) -> T:
     # NB: We call set_unbacked_bindings only on the *topmost* call to
@@ -917,7 +920,7 @@ def track_tensor_tree(
     _set_unbacked_bindings(inner_res, proxy_res)
 
     def wrap_with_proxy(
-        e: object, proxy: _NestedProxys, constant: _NestedTensors | None
+        e: object, proxy: _NestedProxys, constant: MaybeNestedTensors
     ) -> None:
         if isinstance(e, Tensor):
             if not isinstance(proxy, Proxy):
@@ -951,9 +954,7 @@ def track_tensor_tree(
             if isinstance(proxy, fx.Proxy):
                 set_meta(proxy, e)
 
-            def get_constant(
-                c: _NestedTensors | None, idx: int
-            ) -> _NestedTensors | None:
+            def get_constant(c: MaybeNestedTensors, idx: int) -> MaybeNestedTensors:
                 if c is None:
                     return None
                 else:
@@ -1788,7 +1789,7 @@ class TorchFunctionMetadataMode(TorchFunctionMode):
     def __torch_function__(
         self,
         func: OpOverload,
-        types: tuple[torch._C._TensorMeta, ...],
+        types: TensorMetaTuple,
         args: tuple[object, ...] = (),
         kwargs: dict[str, object] | None = None,
     ) -> object:
@@ -1818,7 +1819,7 @@ class PreDispatchTorchFunctionMode(TorchFunctionMode):
     def __torch_function__(
         self,
         func: OpOverload | Callable[..., Any],
-        types: tuple[torch._C._TensorMeta, ...],
+        types: TensorMetaTuple,
         args: tuple[object, ...] = (),
         kwargs: dict[str, object] | None = None,
     ) -> object:
@@ -1917,7 +1918,7 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
     def __torch_dispatch__(
         self,
         func: OpOverload,
-        types: tuple[torch._C._TensorMeta, ...],
+        types: TensorMetaTuple,
         args: tuple[object, ...] = (),
         kwargs: dict[str, object] | None = None,
     ) -> object:
@@ -1957,7 +1958,7 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
     def __sym_dispatch__(
         self,
         func: OpOverload,
-        types: tuple[torch._C._TensorMeta, ...],
+        types: TensorMetaTuple,
         args: tuple[object, ...],
         kwargs: dict[str, object],
     ) -> object:
@@ -2052,7 +2053,7 @@ class DecompositionInterpreter(fx.Interpreter):
         self,
         module: fx.GraphModule,
         new_graph: fx.Graph,
-        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None = None,
+        decomposition_table: MaybeDecompositionTable = None,
         **kwargs: object,
     ) -> None:
         super().__init__(module, **kwargs)  # type: ignore[arg-type]
@@ -2119,7 +2120,7 @@ class _SelectiveDecomposeInterpreter(fx.Interpreter):
         self,
         module: fx.GraphModule,
         should_decompose: Callable[[fx.Node], bool],
-        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None,
+        decomposition_table: MaybeDecompositionTable,
         **kwargs: object,
     ) -> None:
         """
@@ -2134,7 +2135,7 @@ class _SelectiveDecomposeInterpreter(fx.Interpreter):
     def recursive_wrap(
         gm: fx.GraphModule,
         should_decompose: Callable[[fx.Node], bool],
-        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None,
+        decomposition_table: MaybeDecompositionTable,
         **kwargs: object,
     ) -> _SelectiveDecomposeInterpreter:
         """
@@ -2177,7 +2178,7 @@ class _SelectiveDecomposeInterpreter(fx.Interpreter):
 def selective_decompose(
     joint_gm: fx.GraphModule,
     *args: object,
-    decomposition: Mapping[OpOverload, Callable[..., Any]] | None,
+    decomposition: MaybeDecompositionTable,
     should_decompose: Callable[..., bool],
     trace_joint_graph: bool,
 ) -> fx.GraphModule:
@@ -2544,7 +2545,7 @@ class _ModuleStackTracer(PythonKeyTracer):
 class _MakefxTracer:
     def __init__(
         self,
-        decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None,
+        decomposition_table: MaybeDecompositionTable,
         tracing_mode: _TracingMode,
         _allow_non_fake_inputs: bool,
         pre_dispatch: bool,
@@ -2872,7 +2873,7 @@ class _MakefxTracer:
 
     def _make_sub_tracer(
         self,
-        decomp_table: Mapping[OpOverload, Callable[..., Any]] | None = None,
+        decomp_table: MaybeDecompositionTable = None,
         tracing_mode: _TracingMode = "real",
     ) -> _MakefxTracer:
         return _MakefxTracer(
@@ -2894,7 +2895,7 @@ class _MakefxTracer:
     def trace_subgraph_custom_decomp(
         self,
         f: Callable[..., Any],
-        decomp_table: Mapping[OpOverload, Callable[..., Any]],
+        decomp_table: DecompositionTable,
         *args: object,
     ) -> GraphModule:
         if not isinstance(decomp_table, Mapping):
@@ -2920,7 +2921,7 @@ def _set_make_fx_tracer(tracer: _MakefxTracer) -> Generator[None, None, None]:
 
 def make_fx(
     f: Callable[..., Any],
-    decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None = None,
+    decomposition_table: MaybeDecompositionTable = None,
     tracing_mode: _TracingMode = "real",
     _allow_non_fake_inputs: bool = False,
     *,
@@ -3048,7 +3049,7 @@ def get_isolated_graphmodule(
     args: tuple[object, ...],
     kwargs: dict[str, object],
     tracing_mode: _TracingMode = "real",
-    decomposition_table: Mapping[OpOverload, Callable[..., Any]] | None = None,
+    decomposition_table: MaybeDecompositionTable = None,
 ) -> GraphModule:
     """A helper function used to get the GraphModule for the given func.
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -45,9 +45,8 @@ from typing import (
     TYPE_CHECKING,
     TypeAlias,
     TypeGuard,
-    TypeVar,
 )
-from typing_extensions import deprecated, ParamSpec
+from typing_extensions import deprecated, ParamSpec, TypeVar
 
 import torch
 import torch.fx
@@ -112,9 +111,6 @@ if TYPE_CHECKING:
     from torch._subclasses.fake_tensor import FakeTensor
     from torch.types import BoolLikeType, FloatLikeType, IntLikeType
 
-
-InputList = list
-DimList = list
 
 log = logging.getLogger(__name__)
 
@@ -260,6 +256,15 @@ def log_lru_cache_stats(wrapped_f: functools._lru_cache_wrapper[object]) -> None
 # So make sure only type checker evaluates this alias.
 # Xref: https://www.internalfb.com/diff/D53324783
 SympyBoolean: TypeAlias = "sympy.logic.boolalg.Boolean"
+SympyExprList: TypeAlias = list[sympy.Expr]
+MaybeFxNode: TypeAlias = torch.fx.Node | None
+MaybeSympyBasic: TypeAlias = sympy.Basic | None
+IntLikeSequence: TypeAlias = "Sequence[IntLikeType]"
+# Preserve the historical generic alias spelling for BC checks and pyrefly.
+DimList = list
+SymbolBindings: TypeAlias = dict[sympy.Symbol, int]
+MaybeSymbolicContext: TypeAlias = "SymbolicContext | None"
+MaybeEqualityConstraint: TypeAlias = "EqualityConstraint | None"
 
 
 _T = TypeVar("_T")
@@ -797,7 +802,7 @@ def canonicalize_bool_expr(expr: _T) -> _T:
 
 def _sympy_from_args(
     cls: type[sympy.Add | sympy.Mul],
-    args: list[sympy.Expr],
+    args: SympyExprList,
     sort: bool = True,
     is_commutative: bool | None = None,
 ) -> sympy.Expr:
@@ -1932,7 +1937,7 @@ def eval_guards(
     )
 
 
-def bind_symbols(gm: torch.fx.GraphModule, *args: Tensor) -> dict[sympy.Symbol, int]:
+def bind_symbols(gm: torch.fx.GraphModule, *args: Tensor) -> SymbolBindings:
     if gm.shape_env is None:
         raise AssertionError("gm.shape_env must not be None")
     return gm.shape_env.bind_symbols(fx_placeholder_vals(gm), args)  # type: ignore[operator, union-attr]
@@ -2051,7 +2056,7 @@ class RelaxedUnspecConstraint(Constraint):
 # NB: None here indicates the client constraint is whatever is implicitly
 # inferred by guards from tracing, and that a backend can add whatever guards
 # it wants (including fully specializing the value).
-DimConstraint = StrictMinMaxConstraint | RelaxedUnspecConstraint | None
+DimConstraint: TypeAlias = StrictMinMaxConstraint | RelaxedUnspecConstraint | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -2238,7 +2243,7 @@ class StatelessSymbolicContext(SymbolicContext, Generic[_P1, _T1]):
     # If the tensor is a view, this should be populated for the base. It contains
     # information on how to allocate symbols when recursively fakeifying the base
     # during view fake-ification.
-    view_base_context: SymbolicContext | None = None
+    view_base_context: MaybeSymbolicContext = None
     # Maps dimension index to shape_id.
     shape_ids: dict[int, str | None] | None = None
     # Maps dimension index to (min, max) bounds for unbacked dimensions.
@@ -2348,7 +2353,7 @@ class TrackedFake:
 
     fake: FakeTensor | SymInt | SymFloat
     source: Source
-    symbolic_context: SymbolicContext | None
+    symbolic_context: MaybeSymbolicContext
 
     def __hash__(self) -> int:
         return hash((self.fake, self.source.name))
@@ -2370,7 +2375,7 @@ def is_symbolic(
 IndicatorTypes = (IsNonOverlappingAndDenseIndicator,)
 
 
-def _expandsums(args: list[sympy.Expr]) -> tuple[sympy.Expr, bool]:
+def _expandsums(args: SympyExprList) -> tuple[sympy.Expr, bool]:
     """
     Expand products of sums into sums of products.
 
@@ -2442,8 +2447,8 @@ def _fast_expand(expr: _SympyT) -> _SympyT:
                 return S.One / sympy.expand_multinomial(S.One / expr, deep=False)
     # pyrefly: ignore [missing-attribute]
     elif expr.is_Mul:
-        num: list[sympy.Expr] = []
-        den: list[sympy.Expr] = []
+        num: SympyExprList = []
+        den: SympyExprList = []
         # pyrefly: ignore [missing-attribute]
         for arg in expr.args:
             if arg.is_Pow and arg.args[1] == -1:
@@ -3942,7 +3947,7 @@ class ShapeEnv:
         # dict (backed hints are read from backed_var_to_val), we still
         # want them to always be stored here, since this dict is used as
         # part of the FxGraphCache key.
-        self.var_to_hint_override: dict[sympy.Symbol, int] = {}
+        self.var_to_hint_override: SymbolBindings = {}
         # Maps a source to the *original* symbol that was assigned to it
         self.source_to_var: dict[str, sympy.Symbol] = {}
         # Maps from sympy ints to expressions representing them
@@ -4013,7 +4018,7 @@ class ShapeEnv:
         self.symbol_guard_counter: Counter[sympy.Symbol] = collections.Counter()
         # A selection of important fields on co_field; solely used for
         # signpost_event
-        self.co_fields = co_fields if co_fields else {}
+        self.co_fields = co_fields or {}
 
         # Whenever we allocate a fresh unbacked Symbol, we add it to this
         # pending list.  Unbacked symbol allocation can occur at unpredictable
@@ -4084,7 +4089,7 @@ class ShapeEnv:
         # bindings.  At the moment, this is not tracked, but we potentially
         # could track this at the IR level using a higher order operator
         # with something like effect token tracking.
-        self.unbacked_alloc_order: dict[sympy.Symbol, int] = {}
+        self.unbacked_alloc_order: SymbolBindings = {}
 
         self.specialization_stacks: dict[Source, traceback.StackSummary] = {}
 
@@ -4484,7 +4489,7 @@ class ShapeEnv:
         self,
         op: Callable[..., object],
         args: tuple[Any, ...],
-    ) -> tuple[torch.fx.Node | None, bool]:
+    ) -> tuple[MaybeFxNode, bool]:
         # Cache this tuple in order to avoid duplicated nodes.
         node_key = (op, args)
         # Flags whether the returned node was cached or not.
@@ -4516,7 +4521,7 @@ class ShapeEnv:
         self,
         symbol: sympy.Symbol,
         type: type,
-    ) -> torch.fx.Node | None:
+    ) -> MaybeFxNode:
         if not self._translation_validation_enabled:
             return None
 
@@ -4540,7 +4545,7 @@ class ShapeEnv:
 
         return self.fx_node_cache[node_key]
 
-    def _remove_fx_node(self, node: torch.fx.Node | None) -> None:
+    def _remove_fx_node(self, node: MaybeFxNode) -> None:
         if self._translation_validation_enabled and node is not None:
             self.name_to_node.pop(node.name)
             self.graph.erase_node(node)
@@ -4628,21 +4633,21 @@ class ShapeEnv:
 
     def _produce_dyn_sizes(
         self,
-        ex_size: Sequence[IntLikeType],
+        ex_size: IntLikeSequence,
         source: Source,
         symbolic_context: SymbolicContext,
-    ) -> list[sympy.Expr]:
+    ) -> SympyExprList:
         return self._produce_dyn_sizes_from_int_tuple(
             tuple(ex_size), source, symbolic_context
         )
 
     def _produce_dyn_sizes_from_int_tuple(
         self,
-        tensor_size: Sequence[IntLikeType],
+        tensor_size: IntLikeSequence,
         source: Source,
         symbolic_context: SymbolicContext,
         hint_overrides: dict[int, int] | None = None,
-    ) -> list[sympy.Expr]:
+    ) -> SympyExprList:
         if not all(not is_symbolic(val) for val in tensor_size):
             raise AssertionError(
                 f"Expect size to be a plain tuple of ints but got {tensor_size}"
@@ -4690,7 +4695,7 @@ class ShapeEnv:
         ex: torch.Tensor,
         source: Source,
         *,
-        symbolic_context: SymbolicContext | None = None,
+        symbolic_context: MaybeSymbolicContext = None,
     ) -> tuple[
         tuple[IntLikeType, ...],
         tuple[IntLikeType, ...],
@@ -4773,13 +4778,13 @@ class ShapeEnv:
         self,
         # NB: SymInt is allowed here due to nested int, normally you don't
         # actually pass true symbolic sizes to this function
-        ex_size: Sequence[IntLikeType],
-        ex_stride: Sequence[IntLikeType],
+        ex_size: IntLikeSequence,
+        ex_stride: IntLikeSequence,
         ex_storage_offset: IntLikeType,
         is_dim_dynamic: Sequence[bool],
         source: Source,
         *,
-        symbolic_context: SymbolicContext | None = None,
+        symbolic_context: MaybeSymbolicContext = None,
         hint_overrides: dict[int, int] | None = None,
     ) -> tuple[
         tuple[IntLikeType, ...],
@@ -4848,7 +4853,7 @@ class ShapeEnv:
 
         from torch._dynamo.source import TensorProperty, TensorPropertySource
 
-        size: list[sympy.Expr] = self._produce_dyn_sizes_from_int_tuple(
+        size: SympyExprList = self._produce_dyn_sizes_from_int_tuple(
             ex_size, source, symbolic_context, hint_overrides=hint_overrides
         )
         # Record tensor exclusion constraints for stable graph selection.
@@ -4933,15 +4938,13 @@ class ShapeEnv:
         self,
         source: Source,
         size: Sequence[sympy.Expr],
-        ex_size: Sequence[IntLikeType],
-        ex_stride: Sequence[IntLikeType],
+        ex_size: IntLikeSequence,
+        ex_stride: IntLikeSequence,
         dynamic_strides: Sequence[DimDynamic],
-        constraint_strides: Sequence[
-            StrictMinMaxConstraint | RelaxedUnspecConstraint | None
-        ],
+        constraint_strides: Sequence[DimConstraint],
         are_sizes_static: bool,
         symbolic_context: SymbolicContext,
-    ) -> list[sympy.Expr]:
+    ) -> SympyExprList:
         from torch._dynamo.source import TensorProperty, TensorPropertySource
 
         stride: list[sympy.Expr | None] = [None] * len(size)
@@ -5236,7 +5239,7 @@ class ShapeEnv:
         source: Source,
         dynamic_dim: DimDynamic = DimDynamic.DUCK,
         constraint_dim: DimConstraint = None,  # NB: includes None
-        symbolic_context: SymbolicContext | None = None,
+        symbolic_context: MaybeSymbolicContext = None,
     ) -> sympy.Expr:
         """
         Create a symbol with an unspecified value
@@ -5268,7 +5271,7 @@ class ShapeEnv:
         constraint_dim: DimConstraint = None,  # NB: includes None
         positive: bool | None = True,
         do_not_specialize_zero_one: bool = False,
-        symbolic_context: SymbolicContext | None = None,
+        symbolic_context: MaybeSymbolicContext = None,
     ) -> sympy.Expr:
         """Create a new symbol which is tracked by this ShapeEnv"""
         # check if constraint_dim is actually static integer
@@ -5640,10 +5643,10 @@ class ShapeEnv:
         source_ref: Callable[[Source], str] = lambda n: n.name,
         *,
         guards: list[ShapeGuard] | None = None,
-        input_contexts: DimList[SymbolicContext] | None = None,
+        input_contexts: list[SymbolicContext] | None = None,
         # Encodes user-specified input shape equations of the form s = s' and s = fn(s').
         # (See docs on EqualityConstraint for details of the encoding.)
-        equalities_inputs: EqualityConstraint | None = None,
+        equalities_inputs: MaybeEqualityConstraint = None,
         _simplified: bool = False,
         # Indicates if we should produce guards for known static values.
         ignore_static: bool = True,
@@ -6627,7 +6630,7 @@ class ShapeEnv:
 
     def bind_symbols(
         self, placeholders: Sequence[FakeTensor], args: Sequence[Tensor]
-    ) -> dict[sympy.Symbol, int]:
+    ) -> SymbolBindings:
         """
         Given a paired list of placeholders (fake tensors with
         symbolic sizes) and concrete arguments (regular tensors
@@ -6644,7 +6647,7 @@ class ShapeEnv:
         another copy.  This assumes the guards are already checked,
         though if it's cheap we'll check for shenanigans
         """
-        bindings: dict[sympy.Symbol, int] = {}
+        bindings: SymbolBindings = {}
 
         def bind_symint(arg: object, val: object) -> None:
             if isinstance(val, SymInt):
@@ -6814,7 +6817,7 @@ class ShapeEnv:
 
         return True
 
-    def _maybe_fast_eval_comparison(self, expr: sympy.Basic) -> sympy.Basic | None:
+    def _maybe_fast_eval_comparison(self, expr: sympy.Basic) -> MaybeSympyBasic:
         """
         Fast path for trivial comparisons: sum of non-negative terms >= 0.
         Returns sympy.true if pattern matches, None otherwise.
@@ -6840,8 +6843,8 @@ class ShapeEnv:
     def _maybe_evaluate_range_only(
         self,
         expr: sympy.Basic,
-        fallback: sympy.Basic | None = None,
-    ) -> sympy.Basic | None:
+        fallback: MaybeSympyBasic = None,
+    ) -> MaybeSympyBasic:
         """
         Lightweight range-based evaluation using only bound_sympy (value range
         analysis), without expensive simplification, axiom matching, or symbol
@@ -6866,7 +6869,7 @@ class ShapeEnv:
         size_oblivious: bool = False,
         axioms: tuple[SympyBoolean] | None = None,
         var_to_range: tuple[tuple[sympy.Symbol, ValueRanges[sympy.Expr]]] | None = None,
-    ) -> sympy.Basic | None:
+    ) -> MaybeSympyBasic:
         """
         Tries to evaluate expr without introducing guards
 
@@ -7072,7 +7075,7 @@ class ShapeEnv:
     @lru_cache(256)
     def size_hint(
         self, expr: sympy.Basic, *, allow_none: bool = False
-    ) -> sympy.Basic | None:
+    ) -> MaybeSympyBasic:
         """
         Gets a size hint for a given expression from the underlying shapes we had.
         Does not introduce a guard, so only use this when you can guarantee that
@@ -7943,7 +7946,7 @@ class ShapeEnv:
         self,
         orig_expr: sympy.Basic,
         hint: int | bool | float | None = None,
-        fx_node: torch.fx.Node | None = None,
+        fx_node: MaybeFxNode = None,
         size_oblivious: bool = False,
         fallback_value: bool | None = None,
         *,
@@ -7972,7 +7975,7 @@ class ShapeEnv:
         self,
         orig_expr: sympy.Basic,
         hint: int | bool | float | None,
-        fx_node: torch.fx.Node | None,
+        fx_node: MaybeFxNode,
         size_oblivious: bool,
         forcing_spec: bool,
         _suppress_guards_tls: bool,
@@ -8014,7 +8017,7 @@ class ShapeEnv:
         self,
         orig_expr: sympy.Basic,
         hint: bool | int | float | None = None,
-        fx_node: torch.fx.Node | None = None,
+        fx_node: MaybeFxNode = None,
         size_oblivious: bool = False,
         fallback_value: bool | None = None,
         *,
@@ -8051,7 +8054,7 @@ class ShapeEnv:
             else:
                 return sympy.sympify(hint)
 
-        concrete_val: sympy.Basic | None
+        concrete_val: MaybeSympyBasic
 
         # Check if:
         #   1. 'translation_validation' is set
@@ -8343,7 +8346,7 @@ class ShapeEnv:
     @lru_cache(256)
     @record_shapeenv_event(save_tracked_fakes=True)
     def guard_or_defer_runtime_assert(
-        self, orig_expr: SympyBoolean, msg: str, fx_node: torch.fx.Node | None = None
+        self, orig_expr: SympyBoolean, msg: str, fx_node: MaybeFxNode = None
     ) -> bool:
         """
         Adds a guard that orig_expr is True if we can or fall back to adding an assert

--- a/torch/fx/experimental/unification/multipledispatch/core.py
+++ b/torch/fx/experimental/unification/multipledispatch/core.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, TYPE_CHECKING, TypeVar
-from typing_extensions import TypeVarTuple, Unpack
+from typing import Any, TYPE_CHECKING
+from typing_extensions import TypeVar, TypeVarTuple, Unpack
 
 
 if TYPE_CHECKING:

--- a/torch/fx/immutable_collections.py
+++ b/torch/fx/immutable_collections.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
-from typing import Any, NoReturn, TypeVar
-from typing_extensions import Self
+from typing import Any, NoReturn
+from typing_extensions import Self, TypeVar
 
 from torch.utils._pytree import (
     _dict_flatten,

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -29,7 +29,7 @@ __all__ = ["Node", "map_arg", "map_aggregate", "has_side_effect"]
 
 log = logging.getLogger(__name__)
 
-BaseArgumentTypes = Union[  # noqa: UP007
+BaseArgumentTypes: TypeAlias = Union[  # noqa: UP007
     str,
     int,
     float,
@@ -49,7 +49,7 @@ base_types = typing.get_args(BaseArgumentTypes)
 
 Target: TypeAlias = Callable[..., Any] | str
 
-Argument = Optional[  # noqa: UP045
+Argument: TypeAlias = Optional[  # noqa: UP045
     Union[
         tuple["Argument", ...],
         Sequence["Argument"],

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -6,6 +6,7 @@ import typing
 import warnings
 from collections.abc import Callable
 from typing import Any, cast, Literal, NamedTuple, overload, TYPE_CHECKING
+from typing_extensions import TypeVar
 
 import torch
 from torch._jit_internal import boolean_dispatched
@@ -79,7 +80,7 @@ _type_eval_globals = {
     "__torch__": _FakeGlobalNamespace(),
     "NoneType": type(None),
     "Storage": torch.UntypedStorage,
-    "t": typing.TypeVar("t"),
+    "t": TypeVar("t"),
     "PyObject": Any,
 }
 for k in dir(typing):

--- a/torch/fx/passes/graph_transform_observer.py
+++ b/torch/fx/passes/graph_transform_observer.py
@@ -1,7 +1,7 @@
 import os
 from collections.abc import Callable
 from types import TracebackType
-from typing import TypeVar
+from typing_extensions import TypeVar
 
 from torch.fx import Graph, Node
 from torch.fx._compatibility import compatibility

--- a/torch/fx/passes/operator_support.py
+++ b/torch/fx/passes/operator_support.py
@@ -1,5 +1,6 @@
 import abc
 import typing as t
+from typing import TypeAlias
 
 import torch
 import torch.fx
@@ -19,10 +20,10 @@ __all__ = [
 ]
 
 # fx.Node.target typename, as returned by `get_node_target()`
-TargetTypeName = str
+TargetTypeName: TypeAlias = str
 
 # Arguments' dtypes for a given node, see `OperatorSupport`
-SupportedArgumentDTypes = (
+SupportedArgumentDTypes: TypeAlias = (
     tuple[
         t.Sequence[t.Sequence[torch.dtype]],
         dict[str, t.Sequence[torch.dtype]],
@@ -30,7 +31,7 @@ SupportedArgumentDTypes = (
     | None
 )
 
-SupportDict = t.Mapping[TargetTypeName, SupportedArgumentDTypes]
+SupportDict: TypeAlias = t.Mapping[TargetTypeName, SupportedArgumentDTypes]
 
 
 @compatibility(is_backward_compatible=False)
@@ -135,7 +136,9 @@ class OperatorSupport(OperatorSupportBase):
 # and composing them into more complex ones
 # ======================================================================
 
-IsNodeSupported = t.Callable[[t.Mapping[str, torch.nn.Module], torch.fx.Node], bool]
+IsNodeSupported: TypeAlias = t.Callable[
+    [t.Mapping[str, torch.nn.Module], torch.fx.Node], bool
+]
 
 
 @compatibility(is_backward_compatible=False)

--- a/torch/fx/passes/tools_common.py
+++ b/torch/fx/passes/tools_common.py
@@ -3,7 +3,7 @@ import heapq
 import operator
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeAlias
 
 import torch
 import torch.fx
@@ -20,11 +20,11 @@ __all__ = [
     "stable_topological_sort",
 ]
 
-Tensors = tuple[torch.Tensor] | list[torch.Tensor]
-TensorOrTensors = torch.Tensor | Tensors
-NodeList = list[torch.fx.Node]
-NodeSet = set[torch.fx.Node]
-Names = list[str]
+Tensors: TypeAlias = tuple[torch.Tensor] | list[torch.Tensor]
+TensorOrTensors: TypeAlias = torch.Tensor | Tensors
+NodeList: TypeAlias = list[torch.fx.Node]
+NodeSet: TypeAlias = set[torch.fx.Node]
+Names: TypeAlias = list[str]
 CALLABLE_NODE_OPS = {"call_module", "call_function", "call_method"}
 
 
@@ -38,7 +38,7 @@ def get_acc_ops_name(k: str | type) -> str:
         module = k.__module__.replace(
             "torch._ops", "torch.ops"
         )  # WAR for bug in how torch.ops assigns module
-        return f"{module if module else ''}.{k.__name__}"
+        return f"{module or ''}.{k.__name__}"
 
 
 @compatibility(is_backward_compatible=False)

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -11,8 +11,8 @@ import types
 from collections import OrderedDict
 from collections.abc import Callable, Iterator
 from dataclasses import fields, is_dataclass
-from typing import Any, cast, TypeVar
-from typing_extensions import Never
+from typing import Any, cast
+from typing_extensions import Never, TypeVar
 
 import torch
 import torch.fx.traceback as fx_traceback


### PR DESCRIPTION
## Summary
- move `TypeVar` and `TypeAlias` imports in `torch/fx` over to `typing_extensions`
- add explicit `TypeAlias` definitions for repeated FX annotation shapes, especially in `proxy_tensor.py` and `symbolic_shapes.py`
- mark smaller existing FX aliases explicitly so the typing migration covers 100+ annotation call sites across the subtree

## Validation
- `python3 -m compileall torch/fx test/test_fx.py test/test_fx_experimental.py test/test_proxy_tensor.py`
- `PATH=/root/.local/bin:$PATH USE_CUDA=0 BUILD_TEST=0 USE_DISTRIBUTED=0 USE_MKLDNN=0 python3 setup.py build --cmake-only`

## Notes
- Runtime FX tests were not run in this checkout because it still does not have a built `torch` runtime / binary extension.

Drafted via Codex, published after manual review by @bobrenjc93