### PR TITLE
Add CPU tensor validation to FBGEMM operators to prevent segfault

### DIFF
--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -60,6 +60,11 @@ Tensor fbgemm_linear_int8_weight_fp32_activation(
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
+  TORCH_CHECK(input.is_cpu(), "fbgemm_linear_int8_weight_fp32_activation only supports CPU tensors");
+  TORCH_CHECK(weight.is_cpu(), "fbgemm_linear_int8_weight_fp32_activation only supports CPU tensors");
+  TORCH_CHECK(packed.is_cpu(), "fbgemm_linear_int8_weight_fp32_activation only supports CPU tensors");
+  TORCH_CHECK(col_offsets.is_cpu(), "fbgemm_linear_int8_weight_fp32_activation only supports CPU tensors");
+  TORCH_CHECK(bias.is_cpu(), "fbgemm_linear_int8_weight_fp32_activation only supports CPU tensors");
 
   TORCH_WARN_ONCE("fbgemm_linear_int8_weight_fp32_activation is deprecated "
                   "and will be removed in a future PyTorch release.")
@@ -232,6 +237,7 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
+  TORCH_CHECK(weight.is_cpu(), "fbgemm_linear_quantize_weight only supports CPU tensors");
   const Tensor weight_contig = weight.contiguous();
 
   // Calculate weight statistics
@@ -298,6 +304,7 @@ Tensor fbgemm_pack_quantized_matrix(const Tensor& weight) {
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
+  TORCH_CHECK(weight.is_cpu(), "fbgemm_pack_quantized_matrix only supports CPU tensors");
   const int64_t K = weight.size(1);
   const int64_t N = weight.size(0);
   const Tensor weight_contig = weight.contiguous();
@@ -383,6 +390,7 @@ Tensor fbgemm_pack_gemm_matrix_fp16(const Tensor& weight) {
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
+  TORCH_CHECK(weight.is_cpu(), "fbgemm_pack_gemm_matrix_fp16 only supports CPU tensors");
 
   const int64_t K = weight.size(1);
   const int64_t N = weight.size(0);
@@ -419,6 +427,8 @@ Tensor fbgemm_linear_fp16_weight_fp32_activation(
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
+  TORCH_CHECK(input.is_cpu(), "fbgemm_linear_fp16_weight_fp32_activation only supports CPU tensors");
+  TORCH_CHECK(packed_weight.is_cpu(), "fbgemm_linear_fp16_weight_fp32_activation only supports CPU tensors");
 
   const Tensor input_contig = input.contiguous();
   const float* input_ptr = input_contig.const_data_ptr<float>();

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -3508,6 +3508,13 @@ class TestDynamicQuantizedOps(TestCase):
                          msg="torch.ops.quantized.fbgemm_linear_dynamic results are off")
 
     @skipIfNoFBGEMM
+    @unittest.skipIf(not TEST_CUDA, "No CUDA")
+    def test_fbgemm_linear_quantize_weight_cuda_error(self):
+        w = torch.zeros((3, 3), dtype=torch.float32, device="cuda")
+        with self.assertRaisesRegex(RuntimeError, "only supports CPU tensors"):
+            torch.fbgemm_linear_quantize_weight(w)
+
+    @skipIfNoFBGEMM
     @given(
         input_channels=st.integers(16, 32),
         output_channels=st.integers(4, 8),


### PR DESCRIPTION
Fixes #173495

FBGEMM operators segfault when passed CUDA tensors because they read GPU memory pointers as CPU memory. Added `TORCH_CHECK(tensor.is_cpu(), ...)` to all FBGEMM functions that directly access tensor data, and a test verifying the error is raised.

cc @jerryzh168 @malfet