### PR TITLE
Clarify that spectral_norm does not compute the true operator norm for conv layers

### DIFF
--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -551,17 +551,29 @@ def spectral_norm(
         \mathbf{x}_{SN} = \dfrac{\mathbf{x}}{\|\mathbf{x}\|_2}
 
     Spectral normalization stabilizes the training of discriminators (critics)
-    in Generative Adversarial Networks (GANs) by reducing the Lipschitz constant
-    of the model. :math:`\sigma` is approximated performing one iteration of the
-    `power method`_ every time the weight is accessed. If the dimension of the
-    weight tensor is greater than 2, it is reshaped to 2D in power iteration
-    method to get spectral norm.
+    in Generative Adversarial Networks (GANs) by rescaling the weight tensor
+    with spectral norm :math:`\sigma` of the weight matrix calculated using
+    power iteration method. If the dimension of the weight tensor is greater
+    than 2, it is reshaped to 2D in power iteration method to get spectral
+    norm.
 
+    See `Miyato et al. (2018)`_ .
 
-    See `Spectral Normalization for Generative Adversarial Networks`_ .
+    .. warning::
+        For convolutional layers, the weight tensor is reshaped to 2D by
+        flattening all dimensions except the output channel dimension. The
+        spectral norm of this reshaped matrix is **not** the same as the
+        operator norm (true Lipschitz constant) of the convolutional layer,
+        which depends on the input spatial dimensions. This is a known
+        approximation from `Miyato et al. (2018)`_ that works well in
+        practice for training stabilization, but does not provide tight
+        Lipschitz bounds. See `Sedghi et al. (2019)`_ for an exact
+        characterization of singular values of convolutional layers.
+
+    .. _`Miyato et al. (2018)`: https://arxiv.org/abs/1802.05957
+    .. _`Sedghi et al. (2019)`: https://arxiv.org/abs/1805.10408
 
     .. _`power method`: https://en.wikipedia.org/wiki/Power_iteration
-    .. _`Spectral Normalization for Generative Adversarial Networks`: https://arxiv.org/abs/1802.05957
 
     .. note::
         This function is implemented using the parametrization functionality

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -284,9 +284,22 @@ def spectral_norm(
     norm. This is implemented via a hook that calculates spectral norm and
     rescales weight before every :meth:`~Module.forward` call.
 
-    See `Spectral Normalization for Generative Adversarial Networks`_ .
+    See `Miyato et al. (2018)`_ .
 
-    .. _`Spectral Normalization for Generative Adversarial Networks`: https://arxiv.org/abs/1802.05957
+    .. _`Miyato et al. (2018)`: https://arxiv.org/abs/1802.05957
+
+    .. warning::
+        For convolutional layers, the weight tensor is reshaped to 2D by
+        flattening all dimensions except the output channel dimension. The
+        spectral norm of this reshaped matrix is **not** the same as the
+        operator norm (true Lipschitz constant) of the convolutional layer,
+        which depends on the input spatial dimensions. This is a known
+        approximation from `Miyato et al. (2018)`_ that works well in
+        practice for training stabilization, but does not provide tight
+        Lipschitz bounds. See `Sedghi et al. (2019)`_ for an exact
+        characterization of singular values of convolutional layers.
+
+    .. _`Sedghi et al. (2019)`: https://arxiv.org/abs/1805.10408
 
     Args:
         module (nn.Module): containing module


### PR DESCRIPTION
## Summary

- Add a warning to the `spectral_norm` docstrings in both `torch.nn.utils.parametrizations` and `torch.nn.utils.spectral_norm` clarifying that for convolutional layers, the spectral norm of the reshaped weight matrix is not the operator norm (true Lipschitz constant) of the convolutional layer
- Fix misleading "reducing the Lipschitz constant" phrasing in the parametrizations docstring

For conv layers, `spectral_norm` flattens the weight to 2D and runs power iteration on that matrix. This is the approach from Miyato et al. (2018), which works well for GAN training stabilization, but the resulting value is not the true operator norm of the convolution — that depends on the input spatial dimensions and the Toeplitz-like structure of the convolution. This distinction matters for users who need tight Lipschitz bounds (certified robustness, Wasserstein distance estimation, etc.).

The warning references Sedghi et al. (2019), which provides an exact FFT-based characterization of singular values of convolutional layers.

Addresses #99149 and #13505.

## Test plan
- Doc-only change, no functional changes
- Verified RST reference links are consistent

Authored with the help of Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)