### PR TITLE
Fix typo in Ruff lint sync comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ docstring-code-format = true
 quote-style = "double"
 
 [tool.ruff.lint]
-# NOTE: Synchoronize the ignores with .flake8
+# NOTE: Synchronize the ignores with .flake8
 external = [
     # Codes from flake8-only plugins that ruff doesn't implement.
     "P201",


### PR DESCRIPTION
## Summary
Fix a typo in the comment above  in  by changing  to .

## Testing
- Not run (comment-only change)