### PR TITLE
Fix empty changed-files handling in Filepath heuristic

### DIFF
--- a/tools/test/heuristics/test_utils.py
+++ b/tools/test/heuristics/test_utils.py
@@ -4,6 +4,7 @@ import sys
 import unittest
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -52,6 +53,16 @@ class TestHeuristicsUtils(unittest.TestCase):
                 TestRun("test3"): 0.2,
             },
         )
+
+    def test_query_changed_files_filters_empty_diff_output(self) -> None:
+        with mock.patch.object(utils, "get_merge_base", return_value="base"), mock.patch(
+            "tools.testing.target_determination.heuristics.utils.subprocess.run"
+        ) as run:
+            run.return_value = mock.Mock(returncode=0, stdout=b"")
+            self.assertEqual(utils.query_changed_files(), [])
+
+    def test_is_docs_only_change_ignores_empty_entries(self) -> None:
+        self.assertFalse(utils.is_docs_only_change([""]))
 
 
 if __name__ == "__main__":

--- a/tools/test/heuristics/test_utils.py
+++ b/tools/test/heuristics/test_utils.py
@@ -55,9 +55,12 @@ class TestHeuristicsUtils(unittest.TestCase):
         )
 
     def test_query_changed_files_filters_empty_diff_output(self) -> None:
-        with mock.patch.object(utils, "get_merge_base", return_value="base"), mock.patch(
-            "tools.testing.target_determination.heuristics.utils.subprocess.run"
-        ) as run:
+        with (
+            mock.patch.object(utils, "get_merge_base", return_value="base"),
+            mock.patch(
+                "tools.testing.target_determination.heuristics.utils.subprocess.run"
+            ) as run,
+        ):
             run.return_value = mock.Mock(returncode=0, stdout=b"")
             self.assertEqual(utils.query_changed_files(), [])
 

--- a/tools/testing/target_determination/heuristics/utils.py
+++ b/tools/testing/target_determination/heuristics/utils.py
@@ -86,8 +86,8 @@ def query_changed_files() -> list[str]:
     if proc.returncode != 0:
         raise RuntimeError("Unable to get changed files")
 
-    lines = proc.stdout.decode().strip().split("\n")
-    lines = [line.strip() for line in lines]
+    lines = proc.stdout.decode().splitlines()
+    lines = [line.strip() for line in lines if line.strip()]
     print(f"Changed files: {lines}")
     return lines
 
@@ -101,13 +101,11 @@ def is_docs_only_change(changed_files: list[str]) -> bool:
     Returns True if all changed files are documentation-only files
     (e.g., .rst, .md files) that don't require running tests.
     """
+    changed_files = [f for f in changed_files if f]
     if not changed_files:
         return False
 
     for f in changed_files:
-        # Skip empty strings that might come from git diff output
-        if not f:
-            continue
         # Check if the file extension is in the docs-only set
         ext = os.path.splitext(f)[1].lower()
         if ext not in DOCS_ONLY_EXTENSIONS:


### PR DESCRIPTION
Summary:
- filter empty entries from query_changed_files when git diff --name-only has no output
- treat empty changed-file entries as non-doc changes instead of skipping all tests
- add heuristic tests for the empty-diff edge case

Testing:
- python3 -m unittest tools/test/heuristics/test_utils.py