### PR TITLE
[MPS] RMSNorm speedup

### DIFF
--- a/aten/src/ATen/native/mps/operations/RMSNorm.mm
+++ b/aten/src/ATen/native/mps/operations/RMSNorm.mm
@@ -55,7 +55,7 @@ std::tuple<Tensor, Tensor> _fused_rms_norm_mps(const Tensor& input,
       if (N <= LOOPED_LIMIT) {
         size_t threadgroup_needed = (N + N_READS - 1) / N_READS;
         size_t simds_needed = (threadgroup_needed + SIMD_SIZE - 1) / SIMD_SIZE;
-        size_t threadgroup_size = SIMD_SIZE * simds_needed;
+        threadgroup_size = SIMD_SIZE * simds_needed;
         assert(threadgroup_size <= maxThreadsPerGroup);
       }
       size_t n_threads = M * threadgroup_size;


### PR DESCRIPTION
inner size_t threadgroup_size redaclaration shadowed the outer one, so we computed the optimal inner_size and discarded and still launched max thread groups with many threads being idle which killed perf. See speedups below:
<img width="1800" height="480" alt="image" src="https://github.com/user-attachments/assets/09a360c2-c3d6-4688-b06b-9f1f860cec2b" />
