### PR TITLE
Use a feature query for larger mem-eff attention shapes

### DIFF
--- a/test/test_cuda_compatibility.py
+++ b/test/test_cuda_compatibility.py
@@ -5,6 +5,9 @@ from unittest.mock import patch
 
 import torch
 import torch.cuda
+from torch.testing._internal.common_cuda import (
+    evaluate_platform_supports_mem_eff_attention_large_shapes,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -152,6 +155,23 @@ class TestCheckCapability(TestCase):
                 "install a PyTorch release that supports one of these CUDA versions",
                 msg,
             )
+
+
+class TestCommonCudaFeatureQueries(TestCase):
+    @patch("torch.testing._internal.common_cuda.SM80OrLater", True)
+    def test_mem_eff_attention_large_shapes_supports_cuda_sm80_or_later(self, *args):
+        with patch("torch.testing._internal.common_cuda.TEST_WITH_ROCM", False):
+            self.assertTrue(evaluate_platform_supports_mem_eff_attention_large_shapes())
+
+    @patch("torch.testing._internal.common_cuda.SM80OrLater", False)
+    def test_mem_eff_attention_large_shapes_rejects_cuda_before_sm80(self, *args):
+        with patch("torch.testing._internal.common_cuda.TEST_WITH_ROCM", False):
+            self.assertFalse(evaluate_platform_supports_mem_eff_attention_large_shapes())
+
+    @patch("torch.testing._internal.common_cuda.SM80OrLater", False)
+    def test_mem_eff_attention_large_shapes_supports_rocm(self, *args):
+        with patch("torch.testing._internal.common_cuda.TEST_WITH_ROCM", True):
+            self.assertTrue(evaluate_platform_supports_mem_eff_attention_large_shapes())
 
 
 if __name__ == "__main__":

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -47,9 +47,9 @@ from torch._dynamo.testing import CompileCounterWithBackend
 from torch.testing._internal.common_methods_invocations import wrapper_set_seed
 from torch.testing._internal.common_cuda import (
     IS_JETSON,
-    SM80OrLater,
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION_LARGE_SHAPES,
     PLATFORM_SUPPORTS_FUSED_ATTENTION,
     PLATFORM_SUPPORTS_CUDNN_ATTENTION,
     PLATFORM_SUPPORTS_CK_SDPA,
@@ -223,7 +223,7 @@ PLATFORM_SPECIFIC_SDPA = get_platform_specific_sdpa()
 # Indicate the Efficient attention backend can support:
 # 1. sequence longher than 512
 # 2. head dimsion larger than 64
-MEM_EFF_CAPABILITY_MATCHES_SM80 = SM80OrLater or TEST_WITH_ROCM
+MEM_EFF_CAPABILITY_MATCHES_SM80 = PLATFORM_SUPPORTS_MEM_EFF_ATTENTION_LARGE_SHAPES
 
 def rand_sdpa_tensor(shape: SdpaShape, device: str, dtype: torch.dtype, type: str,
                      requires_grad: bool = False, packed: bool = False) -> torch.Tensor:

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -99,6 +99,9 @@ def evaluate_platform_supports_efficient_attention():
         return True
     return False
 
+def evaluate_platform_supports_mem_eff_attention_large_shapes():
+    return TEST_WITH_ROCM or SM80OrLater
+
 def evaluate_platform_supports_cudnn_attention():
     return (not TEST_WITH_ROCM) and SM80OrLater and (TEST_CUDNN_VERSION >= 90000)
 
@@ -114,6 +117,9 @@ def evaluate_platform_supports_green_context():
 
 PLATFORM_SUPPORTS_FLASH_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_flash_attention())
 PLATFORM_SUPPORTS_MEM_EFF_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_efficient_attention())
+PLATFORM_SUPPORTS_MEM_EFF_ATTENTION_LARGE_SHAPES: bool = LazyVal(
+    lambda: evaluate_platform_supports_mem_eff_attention_large_shapes()
+)
 PLATFORM_SUPPORTS_CUDNN_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_cudnn_attention())
 # This condition always evaluates to PLATFORM_SUPPORTS_MEM_EFF_ATTENTION but for logical clarity we keep it separate
 PLATFORM_SUPPORTS_FUSED_ATTENTION: bool = LazyVal(lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION or


### PR DESCRIPTION
This keeps the larger mem-eff attention shape gating in the `#175211` cleanup lane instead of spelling the platform condition inline.

Changes:
- add `evaluate_platform_supports_mem_eff_attention_large_shapes()` / `PLATFORM_SUPPORTS_MEM_EFF_ATTENTION_LARGE_SHAPES`
- add focused compatibility coverage for the helper
- use the helper in the existing `test_transformers.py` mem-eff attention shape gate

Verification:
- `python agent_space/mem_eff_large_shape_repro.py`
- `python -m py_compile torch/testing/_internal/common_cuda.py test/test_cuda_compatibility.py test/test_transformers.py`

Notes:
- this stays in the existing `#175211` cleanup lane
- the change is intentionally narrow: one helper, one compatibility test file, and one consumer file