### PR TITLE
Use a feature query for grouped gemm compile gating

### DIFF
--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -27,14 +27,16 @@ from torch.distributed.tensor._ops.single_dim_strategy import (
 )
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.placement_types import _StridedShard
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8, SM90OrLater
+from torch.testing._internal.common_cuda import (
+    PLATFORM_SUPPORTS_FP8,
+    PLATFORM_SUPPORTS_GROUPED_GEMM_COMPILE,
+)
 from torch.testing._internal.common_device_type import E4M3_MAX_POS, e4m3_type
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
-    TEST_WITH_ROCM,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     create_local_tensor_test_class,
@@ -1004,8 +1006,10 @@ class DistMatrixOpsTest(DTensorTestBase):
             dist_result_full = dist_result.full_tensor()
             self.assertEqual(local_result, dist_result_full)
 
-    @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")
-    @unittest.skipIf(not SM90OrLater, "Grouped gemm supported on SM90")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_GROUPED_GEMM_COMPILE,
+        "Grouped gemm requires CUDA SM90+",
+    )
     @with_comms
     @skip_unless_torch_gpu
     @parametrize(
@@ -1109,23 +1113,23 @@ class DistMatrixOpsTest(DTensorTestBase):
         pad = [1, 1]  # pad last dim only
         expected = torch.nn.functional.pad(t, pad, value=0.0)
 
-        # Shard on non-padded dim (dim 0) — should work directly
+        # Shard on non-padded dim (dim 0) - should work directly
         dt = distribute_tensor(t, device_mesh, [Shard(0)])
         result = torch.nn.functional.pad(dt, pad, value=0.0)
         self.assertEqual(result.full_tensor(), expected)
 
-        # Shard on padded dim (dim 1) — forces redistribute to Replicate
+        # Shard on padded dim (dim 1) - forces redistribute to Replicate
         dt = distribute_tensor(t, device_mesh, [Shard(1)])
         result = torch.nn.functional.pad(dt, pad, value=0.0)
         self.assertEqual(result.full_tensor(), expected)
 
-        # Partial input with value=0 — Partial passes through
+        # Partial input with value=0 - Partial passes through
         dt = distribute_tensor(t, device_mesh, [Partial()])
         result = torch.nn.functional.pad(dt, pad, value=0.0)
         self.assertEqual(result.placements, (Partial(),))
         self.assertEqual(result.full_tensor(), expected)
 
-        # Partial input with value!=0 — forces redistribute to Replicate
+        # Partial input with value!=0 - forces redistribute to Replicate
         expected_nz = torch.nn.functional.pad(t, pad, value=1.0)
         dt = distribute_tensor(t, device_mesh, [Partial()])
         result = torch.nn.functional.pad(dt, pad, value=1.0)

--- a/test/test_cuda_compatibility.py
+++ b/test/test_cuda_compatibility.py
@@ -5,6 +5,9 @@ from unittest.mock import patch
 
 import torch
 import torch.cuda
+from torch.testing._internal.common_cuda import (
+    evaluate_platform_supports_grouped_gemm_compile,
+)
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -152,6 +155,23 @@ class TestCheckCapability(TestCase):
                 "install a PyTorch release that supports one of these CUDA versions",
                 msg,
             )
+
+
+class TestCommonCudaFeatureQueries(TestCase):
+    @patch("torch.testing._internal.common_cuda.SM90OrLater", True)
+    def test_grouped_gemm_compile_supports_cuda_sm90_or_later(self, *args):
+        with patch("torch.testing._internal.common_cuda.TEST_WITH_ROCM", False):
+            self.assertTrue(evaluate_platform_supports_grouped_gemm_compile())
+
+    @patch("torch.testing._internal.common_cuda.SM90OrLater", False)
+    def test_grouped_gemm_compile_rejects_cuda_before_sm90(self, *args):
+        with patch("torch.testing._internal.common_cuda.TEST_WITH_ROCM", False):
+            self.assertFalse(evaluate_platform_supports_grouped_gemm_compile())
+
+    @patch("torch.testing._internal.common_cuda.SM90OrLater", True)
+    def test_grouped_gemm_compile_rejects_rocm(self, *args):
+        with patch("torch.testing._internal.common_cuda.TEST_WITH_ROCM", True):
+            self.assertFalse(evaluate_platform_supports_grouped_gemm_compile())
 
 
 if __name__ == "__main__":

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -20,6 +20,7 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import (
     blas_library_context,
     PLATFORM_SUPPORTS_BF16,
+    PLATFORM_SUPPORTS_GROUPED_GEMM_COMPILE,
     SM80OrLater,
     SM90OrLater,
     SM100OrLater,
@@ -591,9 +592,11 @@ class TestMatmulCuda(InductorTestCase):
                 start = offs_cpu[i]
             self.grouped_mm_helper(a, blist, gOlist, agradlist, bgradlist, outlist)
 
-    @unittest.skipIf(TEST_WITH_ROCM, "ROCm doesn't support CUTLASS")
     # TODO(future PR): enable compile for torch.nn.functional.grouped_mm fallback path
-    @unittest.skipIf(not SM90OrLater, "Grouped gemm with compile supported on SM90")
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_GROUPED_GEMM_COMPILE,
+        "Grouped gemm with compile requires CUDA SM90+",
+    )
     @parametrize("op", ["2d/2d", "2d/3d", "3d/2d", "3d/3d"])
     @parametrize("a_row_major", [False, True])
     @parametrize("b_row_major", [False, True])

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -99,6 +99,9 @@ def evaluate_platform_supports_efficient_attention():
         return True
     return False
 
+def evaluate_platform_supports_grouped_gemm_compile():
+    return SM90OrLater and not TEST_WITH_ROCM
+
 def evaluate_platform_supports_cudnn_attention():
     return (not TEST_WITH_ROCM) and SM80OrLater and (TEST_CUDNN_VERSION >= 90000)
 
@@ -114,6 +117,9 @@ def evaluate_platform_supports_green_context():
 
 PLATFORM_SUPPORTS_FLASH_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_flash_attention())
 PLATFORM_SUPPORTS_MEM_EFF_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_efficient_attention())
+PLATFORM_SUPPORTS_GROUPED_GEMM_COMPILE: bool = LazyVal(
+    lambda: evaluate_platform_supports_grouped_gemm_compile()
+)
 PLATFORM_SUPPORTS_CUDNN_ATTENTION: bool = LazyVal(lambda: evaluate_platform_supports_cudnn_attention())
 # This condition always evaluates to PLATFORM_SUPPORTS_MEM_EFF_ATTENTION but for logical clarity we keep it separate
 PLATFORM_SUPPORTS_FUSED_ATTENTION: bool = LazyVal(lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION or


### PR DESCRIPTION
This keeps the grouped-gemm compile gating in the `#175211` cleanup lane instead of repeating the CUDA SM90 / ROCm exclusion inline.

Changes:
- add `evaluate_platform_supports_grouped_gemm_compile()` / `PLATFORM_SUPPORTS_GROUPED_GEMM_COMPILE`
- add focused compatibility coverage for the helper
- use the helper in the grouped-gemm compile test sites in `test_matmul_cuda.py` and `test/distributed/tensor/test_matrix_ops.py`

Verification:
- `python agent_space/grouped_gemm_compile_repro.py`
- `python -m py_compile torch/testing/_internal/common_cuda.py test/test_cuda_compatibility.py test/test_matmul_cuda.py test/distributed/tensor/test_matrix_ops.py`

Notes:
- this stays in the existing `#175211` cleanup lane
- the change is intentionally narrow and only replaces the duplicated compile-gating condition