### PR TITLE
add CODEOWNERS entries for FSDP, DDP, DTensor view

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,6 +48,17 @@ nn/qat/ @jerryzh168
 # c10d backend APIs
 /torch/csrc/distributed/c10d/Backend.* @kwen2501
 /torch/csrc/distributed/c10d/Ops.* @kwen2501
+# FSDP, DDP
+/torch/distributed/_composable/fsdp/ @weifengpy
+/torch/distributed/_composable/replicate.py @weifengpy
+/torch/distributed/_composable/replicate_with_fsdp.py @weifengpy
+/torch/distributed/fsdp/ @weifengpy
+/torch/distributed/optim/ @weifengpy
+/torch/nn/parallel/ @weifengpy
+# DTensor view, matmul, _StridedShard
+/torch/distributed/tensor/placement_types.py @weifengpy
+/torch/distributed/tensor/_ops/_view_ops.py @weifengpy
+/torch/distributed/tensor/_ops/_matrix_ops.py @weifengpy
 
 # ONNX Export
 /torch/_dynamo/backends/onnxrt.py @titaiwangms @xadupre @justinchuby


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180178

Per the repo header, CODEOWNERS is used for PR notification subscriptions only — approvals are not required for merges.

Add @weifengpy as code owner for review notifications on:

  - FSDP: _composable/fsdp/, replicate_with_fsdp.py, distributed/fsdp/
  - Distributed optimizers: distributed/optim/
  - DTensor view, matmul, _StridedShard: placement_types.py, _view_ops.py, _matrix_ops.py
  - DDP: _composable/replicate.py, nn/parallel/