### PR TITLE
[CI] Run torchbench install as jenkins user instead of chowning

### DIFF
--- a/.ci/docker/common/install_inductor_benchmark_deps.sh
+++ b/.ci/docker/common/install_inductor_benchmark_deps.sh
@@ -18,18 +18,15 @@ function install_timm() {
 function install_torchbench() {
   local commit
   commit=$(get_pinned_commit torchbench)
-  git clone https://github.com/pytorch/benchmark torchbench
+  as_jenkins git clone https://github.com/pytorch/benchmark torchbench
   pushd torchbench
-  git checkout "$commit"
+  as_jenkins git checkout "$commit"
 
-  python install.py --continue_on_fail
+  conda_run python install.py --continue_on_fail
 
   echo "Print all dependencies after TorchBench is installed"
-  python -mpip freeze
+  conda_run python -mpip freeze
   popd
-
-  chown -R jenkins torchbench
-  chown -R jenkins /opt/conda
 }
 
 # Pango is needed for weasyprint which is needed for doctr

--- a/.ci/docker/common/install_inductor_benchmark_deps.sh
+++ b/.ci/docker/common/install_inductor_benchmark_deps.sh
@@ -18,6 +18,7 @@ function install_timm() {
 function install_torchbench() {
   local commit
   commit=$(get_pinned_commit torchbench)
+  mkdir torchbench && chown jenkins torchbench
   as_jenkins git clone https://github.com/pytorch/benchmark torchbench
   pushd torchbench
   as_jenkins git checkout "$commit"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #180180
* #180130
* #180133

Run git clone, git checkout, and python install.py as the jenkins user directly (via as_jenkins/conda_run), matching the pattern used by install_huggingface() and install_timm() in the same file. This removes two expensive recursive chown calls on the torchbench dir and /opt/conda.

Authored with Claude.