### PR TITLE
autograd: handle kMkldnn and kJagged layouts in record_stream_any_impl

### DIFF
--- a/torch/csrc/autograd/input_buffer.cpp
+++ b/torch/csrc/autograd/input_buffer.cpp
@@ -70,6 +70,14 @@ void record_stream_any_impl(Variable& var, const c10::Stream& stream) {
       case c10::kStrided:
         guard.recordDataPtrOnStream(var.storage().data_ptr(), stream);
         break;
+      case c10::kMkldnn:
+        // MKL-DNN tensors do not support stream recording via storage().
+        // They are not used in CUDA stream contexts, so we skip silently.
+        break;
+      case c10::kJagged:
+        // Jagged (nested) tensors manage their own storage internally.
+        // Stream recording is handled at the nested tensor level, not here.
+        break;
       default:
         TORCH_INTERNAL_ASSERT(
             false, "Unknown layout in record_stream_any_impl");


### PR DESCRIPTION
Previously, tensors with kMkldnn or kJagged layouts would hit the default TORCH_INTERNAL_ASSERT(false) in record_stream_any_impl, causing a hard crash if such tensors ever reached this code path.

kMkldnn tensors do not support stream recording via storage() and are not used in CUDA stream contexts, so we skip silently.

kJagged (nested) tensors manage their own storage internally and handle stream recording at the nested tensor level.

Related: https://github.com/pytorch/pytorch/issues/60306