### PR TITLE
Export auto-generated unstructured inplace meta dispatch symbols 

### DIFF
--- a/tools/test/test_codegen.py
+++ b/tools/test/test_codegen.py
@@ -25,9 +25,11 @@ from torchgen.model import (
     Location,
     NativeFunction,
     OperatorName,
+    should_generate_inplace_meta_kernel,
 )
 from torchgen.native_function_generation import add_generated_native_functions
 from torchgen.selective_build.selector import SelectiveBuilder
+from torchgen.utils import Target
 
 
 class TestCreateDerivative(unittest.TestCase):
@@ -389,6 +391,82 @@ TORCH_API bool kernel_1();
 } // namespace at
         """
         self.assertEqual("\n".join(declaration), target)
+
+
+class TestInplaceMetaKernelGeneration(unittest.TestCase):
+    def setUp(self) -> None:
+        # An inplace op with CPU dispatch only (no Meta entry)
+        self.inplace_func, _ = NativeFunction.from_yaml(
+            {
+                "func": "my_op_(Tensor(a!) self, Tensor other) -> Tensor(a!)",
+                "dispatch": {"CPU": "my_op_cpu"},
+            },
+            loc=Location(__file__, 1),
+            valid_tags=set(),
+        )
+
+        # A non-inplace (functional) op
+        self.functional_func, _ = NativeFunction.from_yaml(
+            {
+                "func": "my_func(Tensor self) -> Tensor",
+                "dispatch": {"CPU": "my_func_cpu"},
+            },
+            loc=Location(__file__, 1),
+            valid_tags=set(),
+        )
+
+        # Meta BackendIndex with no explicit kernels
+        self.meta_backend_index = BackendIndex(
+            dispatch_key=DispatchKey.Meta,
+            use_out_as_primary=True,
+            external=False,
+            device_guard=False,
+            index={},
+        )
+
+        self.selector = SelectiveBuilder.get_nop_selector()
+
+    def test_inplace_op_generates_meta_declaration(self) -> None:
+        """Unstructured inplace ops should get a TORCH_API meta declaration."""
+        reg = dest.RegisterDispatchKey(
+            self.meta_backend_index,
+            target=Target.NAMESPACED_DECLARATION,
+            selector=self.selector,
+            rocm=False,
+            symint=True,
+            class_method_name=None,
+            skip_dispatcher_op_registration=False,
+        )
+        result = reg(self.inplace_func)
+        self.assertTrue(len(result) > 0)
+        self.assertTrue(any("TORCH_API" in decl for decl in result))
+
+    def test_functional_op_no_meta_declaration(self) -> None:
+        """Non-inplace ops without explicit Meta kernel should not generate."""
+        reg = dest.RegisterDispatchKey(
+            self.meta_backend_index,
+            target=Target.NAMESPACED_DECLARATION,
+            selector=self.selector,
+            rocm=False,
+            symint=True,
+            class_method_name=None,
+            skip_dispatcher_op_registration=False,
+        )
+        result = reg(self.functional_func)
+        self.assertEqual(result, [])
+
+    def test_shared_helper_matches(self) -> None:
+        """should_generate_inplace_meta_kernel agrees with RegisterDispatchKey."""
+        self.assertTrue(
+            should_generate_inplace_meta_kernel(
+                self.inplace_func, self.meta_backend_index
+            )
+        )
+        self.assertFalse(
+            should_generate_inplace_meta_kernel(
+                self.functional_func, self.meta_backend_index
+            )
+        )
 
 
 # Test for native_function_generation

--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -35,6 +35,7 @@ from torchgen.model import (
     NativeFunction,
     NativeFunctionsGroup,
     SchemaKind,
+    should_generate_inplace_meta_kernel,
     TensorOptionsArguments,
 )
 from torchgen.utils import mapMaybe, Target
@@ -407,13 +408,7 @@ class RegisterDispatchKey:
             if not self.backend_index.has_kernel(f):
                 if (
                     self.backend_index.dispatch_key == DispatchKey.Meta
-                    and f.func.kind() is SchemaKind.inplace
-                    and
-                    # Defer to composites for meta implementation
-                    not f.has_composite_kernel
-                    and
-                    # Inplace list operations are not supported
-                    len(f.func.returns) == 1
+                    and should_generate_inplace_meta_kernel(f, self.backend_index)
                 ):
                     inplace_meta = True
                 elif (

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2294,6 +2294,23 @@ def gen_source_files(
                         DispatchKey.CompositeExplicitAutogradNonFunctional,
                     ):
                         is_registered = True
+                    # Unstructured inplace ops get auto-generated meta kernels
+                    # (see gen_unstructured in register_dispatch_key.py), so
+                    # their dispatch headers need to be included too.
+                    elif dispatch_key == DispatchKey.Meta:
+                        fns = (
+                            g.functions()
+                            if isinstance(g, NativeFunctionsGroup)
+                            else [g]
+                        )
+                        if any(
+                            f.func.kind() is SchemaKind.inplace
+                            and not backend_index.has_kernel(f)
+                            and not f.has_composite_kernel
+                            and len(f.func.returns) == 1
+                            for f in fns
+                        ):
+                            is_registered = True
                     if not is_registered:
                         continue
 

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -70,6 +70,7 @@ from torchgen.model import (
     OptionalType,
     SchemaKind,
     SelfArgument,
+    should_generate_inplace_meta_kernel,
     STRUCTURED_DISPATCH_KEYS,
     TensorOptionsArguments,
     Type,
@@ -2304,10 +2305,7 @@ def gen_source_files(
                             else [g]
                         )
                         if any(
-                            f.func.kind() is SchemaKind.inplace
-                            and not backend_index.has_kernel(f)
-                            and not f.has_composite_kernel
-                            and len(f.func.returns) == 1
+                            should_generate_inplace_meta_kernel(f, backend_index)
                             for f in fns
                         ):
                             is_registered = True

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -2854,6 +2854,21 @@ def gets_generated_out_inplace_wrapper(
     )
 
 
+def should_generate_inplace_meta_kernel(
+    f: NativeFunction, backend_index: BackendIndex
+) -> bool:
+    """Whether an unstructured inplace op should get an auto-generated meta kernel.
+
+    See gen_unstructured() in torchgen/dest/register_dispatch_key.py.
+    """
+    return (
+        f.func.kind() is SchemaKind.inplace
+        and not backend_index.has_kernel(f)
+        and not f.has_composite_kernel
+        and len(f.func.returns) == 1
+    )
+
+
 # NativeFunction objects that are views (f.is_view_op returns True)
 # are added into a `NativeFunctionsViewGroup`, which we can use to
 # easily access the generated (optional) view_copy NativeFunction.


### PR DESCRIPTION
Fixes #167818

Unstructured inplace ops (like _index_put_impl_) get auto-generated meta kernels in gen_unstructured(), but the operator_headers() function in gen.py didn't account for these when deciding which dispatch headers to include in RegisterMeta_N.cpp. This meant the TORCH_API declaration was never seen by the compiler, leaving these symbols as LOCAL instead of GLOBAL in libtorch_cpu.so.

The fix adds a new condition that mirrors the inplace_meta logic from register_dispatch_key.py, ensuring these headers are included.

This PR was co-authored with Claude.

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD @sunjiabin17 