### PR TITLE
add OneCycleLR degenerate phase cases

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2681,6 +2681,12 @@ class TestLRScheduler(TestCase):
         )
 
     def test_onecycle_lr_degenerate_phase(self):
+        # NOTE: This test documents current behavior, not intended API behavior.
+        # For very small `total_steps`, certain `pct_start` values produce a phase
+        # where `end_step == start_step`. This leads to a division by zero in the
+        # interpolation term `(step - start) / (end - start)` during initialization,
+        # raising a ZeroDivisionError.
+        #
         # A two step schedule with pct_start=0.5 leaves the first phase with no width.
         # Right now that reaches the phase math and crashes with ZeroDivisionError.
         with self.assertRaises(ZeroDivisionError):

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -2680,6 +2680,37 @@ class TestLRScheduler(TestCase):
             optim.param_groups[0]["lr"],
         )
 
+    def test_onecycle_lr_degenerate_phase(self):
+        # A two step schedule with pct_start=0.5 leaves the first phase with no width.
+        # Right now that reaches the phase math and crashes with ZeroDivisionError.
+        with self.assertRaises(ZeroDivisionError):
+            scheduler = OneCycleLR(
+                self.opt,
+                max_lr=1e-3,
+                total_steps=2,
+                pct_start=0.5,
+            )
+
+    def test_onecycle_lr_degenerate_single_step_phase(self):
+        # A single step schedule with pct_start=1.0 runs into the same degenerate case.
+        with self.assertRaises(ZeroDivisionError):
+            scheduler = OneCycleLR(
+                self.opt,
+                max_lr=1e-3,
+                total_steps=1,
+                pct_start=1.0,
+            )
+
+    def test_onecycle_lr_degenerate_three_phase(self):
+        # Switching to three phases does not avoid the issue for this tiny schedule.
+        with self.assertRaises(ZeroDivisionError):
+            scheduler = OneCycleLR(
+                self.opt,
+                max_lr=1e-3,
+                total_steps=2,
+                pct_start=0.5,
+                three_phase=True,
+            )
 
 instantiate_parametrized_tests(TestLRScheduler)
 


### PR DESCRIPTION
This PR adds failing tests that highlight degenerate phase handling in `OneCycleLR` for very small schedules.

When `total_steps` is tiny, certain values of `pct_start` produce phases with zero width (for example, `total_steps=2, pct_start=0.5` or `total_steps=1, pct_start=1.0`). In these cases, the scheduler proceeds with phase construction and hits a division by zero during initialization, raising a `ZeroDivisionError`.

This behavior is not limited to the default two-phase schedule. Enabling `three_phase=True` does not avoid the issue, as the same degenerate phase math is reached for these small configurations.

This PR is tests only. It documents the current behavior and makes the failure mode explicit for degenerate schedules. A follow up PR can introduce proper validation or adjust the phase construction logic so that these edge cases are handled consistently (e.g., by raising a clear `ValueError` or defining a valid behavior for zero-length phases).

**Related discussion**
This test is part of the broader scheduler cleanup work described in:
“RFC: Internal Unification of LRScheduler Semantics for Correct Resuming and Composition” #168044
