### PR TITLE
Validate opt_dtype in nanmean to reject non-floating-point types

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1482,6 +1482,12 @@ Tensor& nanmean_out(
     bool keepdim,
     std::optional<ScalarType> opt_dtype,
     Tensor& result) {
+  if (opt_dtype.has_value()) {
+    TORCH_CHECK(
+        at::isFloatingType(opt_dtype.value()) || at::isComplexType(opt_dtype.value()),
+        "nanmean(): Optional dtype must be either a floating point or complex dtype. Got: ",
+        toString(opt_dtype.value()));
+  }
   // Check if dtype is an integral type or Bool and raise an error
   TORCH_CHECK(
     !at::isIntegralType(self.scalar_type(), /*includeBool=*/true),
@@ -1500,6 +1506,12 @@ Tensor nanmean(
     at::OptionalIntArrayRef dim,
     bool keepdim,
     std::optional<ScalarType> opt_dtype) {
+  if (opt_dtype.has_value()) {
+    TORCH_CHECK(
+        at::isFloatingType(opt_dtype.value()) || at::isComplexType(opt_dtype.value()),
+        "nanmean(): Optional dtype must be either a floating point or complex dtype. Got: ",
+        toString(opt_dtype.value()));
+  }
   TORCH_CHECK(
       self.is_floating_point() || self.is_complex(),
       "nanmean(): expected input to have floating point or complex dtype but got ",

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2300,6 +2300,25 @@ class TestReductions(TestCase):
             ):
                 torch.nanmean(t)
 
+    @onlyCPU
+    @dtypes(torch.float, torch.double)
+    def test_nanmean_opt_dtype_validation(self, device, dtype):
+        t = make_tensor((3,), dtype=dtype, device=device)
+        t_empty = make_tensor((0,), dtype=dtype, device=device)
+
+        for bad_dtype in [torch.int64, torch.int32, torch.bool]:
+            for tensor in [t, t_empty]:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    r"nanmean\(\): Optional dtype must be either a floating point or complex dtype",
+                ):
+                    torch.nanmean(tensor, dtype=bad_dtype)
+
+        # Valid floating dtypes should still work
+        for good_dtype in [torch.float32, torch.float64]:
+            result = torch.nanmean(t, dtype=good_dtype)
+            self.assertEqual(result.dtype, good_dtype)
+
     @precisionOverride({torch.float16: 1e-2, torch.bfloat16: 1e-2})
     @dtypes(*set(all_types_and(torch.half, torch.bfloat16)) - {torch.uint8})
     @parametrize("fn_name", [


### PR DESCRIPTION
# Fixing an Issue

## Issue

Fixes #131043

## Summary

`nanmean()` validated only `self.scalar_type()` but ignored the explicit `dtype=` parameter. Two broken cases:

- `torch.nanmean(torch.tensor([0., 1., 2.]), dtype=torch.int64)` hit kernel dispatch failure with confusing `"nansum_cpu" not implemented for 'Long'` instead of a dtype error
- `torch.nanmean(torch.tensor([]), dtype=torch.int64)` silently returned `tensor(nan)` because the empty-tensor fast path in `nansum` (`iter.numel() == 0 -> result.zero_()`) bypassed the kernel entirely

Added `opt_dtype` validation to both `nanmean()` and `nanmean_out()` in `ReduceOps.cpp`, same pattern `mean()` uses at line 300. Now raises: `nanmean(): Optional dtype must be either a floating point or complex dtype. Got: Long`

Test added in `test_reductions.py` covering both empty and non-empty tensors with bad dtypes.

This PR was authored with assistance from Claude (Anthropic).

## Checklist

- [ ] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. Previously these calls either crashed with an internal error or silently produced wrong results. Now they raise a clear validation error.