### PR TITLE
[inductor] Fix stride mismatch for user-visible reductions

### DIFF
--- a/test/inductor/test_padding.py
+++ b/test/inductor/test_padding.py
@@ -908,7 +908,6 @@ class PaddingTest(TestCaseBase):
         )
         self.assertEqual(result.stride(), expected_stride)
 
-
     def test_reduction_comprehensive_padding_stride(self):
         """Comprehensive padding should not cause stride mismatches for
         user-visible reductions.

--- a/test/inductor/test_padding.py
+++ b/test/inductor/test_padding.py
@@ -909,6 +909,26 @@ class PaddingTest(TestCaseBase):
         self.assertEqual(result.stride(), expected_stride)
 
 
+    def test_reduction_comprehensive_padding_stride(self):
+        """Comprehensive padding should not cause stride mismatches for
+        user-visible reductions.
+
+        Regression test for https://github.com/pytorch/pytorch/issues/179931
+        """
+
+        def program(x):
+            y = torch.nn.functional.adaptive_avg_pool2d(x, 7)
+            return y.flatten(1).sum(dim=-1)
+
+        x = torch.randn(4, 2049, 8, 8, dtype=torch.float32, device=GPU_TYPE)
+        eager = program(x.clone())
+
+        with config.patch({"comprehensive_padding": True}):
+            compiled = torch.compile(program, backend="inductor")(x.clone())
+
+        self.assertEqual(eager, compiled)
+
+
 if __name__ == "__main__":
     if HAS_GPU:
         run_tests()

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -329,7 +329,15 @@ def mark_nodes_dislike_padding(
                     prior.meta["dislike_padding"] = True
         # We only want to mark output nodes. So, move it after the above prior nodes process.
         if not config.pad_outputs and cur in extended_user_visible_nodes:
-            cur.meta["dislike_padding"] = True
+            # Reductions (ops_like_padding) produce new output buffers with
+            # fresh strides, so their output stride constraint is already
+            # enforced by allow_padding=False in as_exact_strides. Setting
+            # dislike_padding here would suppress input padding during
+            # freeze, causing a stride mismatch when an earlier lowering
+            # step (e.g. is_contiguous_storage_and_layout) already mutated
+            # the input layout to padded strides.
+            if op not in ops_like_padding:
+                cur.meta["dislike_padding"] = True
 
 
 def is_mkldnn_conv(node: Node) -> bool:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/179931

Don't set `dislike_padding` on user-visible reduction nodes in `mark_nodes_dislike_padding` since it may lead to stride conflict with earlier `is_contiguous_storage_and_layout`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo