### PR TITLE
XPU oneDNN: thread-local LRU cache for FP matmul primitives + post_ops deduplication

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -173,28 +173,15 @@ struct PostOpsMatmulKeySink {
 
   void append_binary(
       dnnl::algorithm aalgorithm, const dnnl::memory::desc& src1_desc) {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(cur_ != nullptr);
-    (void)aalgorithm;
-    (void)src1_desc;
-    const PostOpParam& op = *cur_;
-    key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(op.algo_)));
-    if (op.binary_.defined()) {
-      key.push_back(static_cast<dnnl::memory::dim>(op.binary_.dim()));
-      for (int64_t i = 0; i < op.binary_.dim(); ++i) {
-        key.push_back(op.binary_.size(i));
-        key.push_back(op.binary_.stride(i));
-      }
-      key.push_back(static_cast<dnnl::memory::dim>(
-          static_cast<int>(c10::toUnderlying(op.binary_.scalar_type()))));
-    } else {
+    key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(aalgorithm)));
+    const auto md_dims = src1_desc.get_dims();
+    if (md_dims.empty()) {
       key.push_back(-1);
-    }
-    const auto md_dims = op.meta_.get_dims();
-    if (!md_dims.empty()) {
+    } else {
       key.insert(key.end(), md_dims.begin(), md_dims.end());
       key.push_back(static_cast<dnnl::memory::dim>(
-          static_cast<int>(op.meta_.get_data_type())));
-      const auto md_strides = op.meta_.get_strides();
+          static_cast<int>(src1_desc.get_data_type())));
+      const auto md_strides = src1_desc.get_strides();
       key.insert(key.end(), md_strides.begin(), md_strides.end());
     }
   }

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -136,11 +136,6 @@ namespace detail {
 
 struct PostOpsMatmulKeySink {
   dnnl::memory::dims& key;
-  const PostOpParam* cur_ = nullptr;
-
-  void bind_curr(const PostOpParam& op) {
-    cur_ = &op;
-  }
 
   void push_op_kind(kind_t kind) {
     key.push_back(static_cast<dnnl::memory::dim>(kind));
@@ -155,18 +150,12 @@ struct PostOpsMatmulKeySink {
 
   void append_eltwise(
       dnnl::algorithm aalgorithm, float alpha, float beta) {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(cur_ != nullptr);
     push_f32(key, alpha);
     push_f32(key, beta);
     key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(aalgorithm)));
   }
 
-  void append_sum(
-      float scale,
-      std::int32_t zero_point,
-      dnnl::memory::data_type data_type =
-          dnnl::memory::data_type::undef) {
-    (void)data_type;
+  void append_sum(float scale, std::int32_t zero_point) {
     push_f32(key, scale);
     key.push_back(static_cast<dnnl::memory::dim>(zero_point));
   }
@@ -192,23 +181,9 @@ struct PostOpsMatmulKeySink {
   void append_prelu(int mask) {
     key.push_back(static_cast<dnnl::memory::dim>(mask));
   }
-
-  void unknown_post_op_kind() {
-    key.push_back(-999);
-  }
 };
 
 } // namespace detail
-
-inline void fp_matmul_post_sink_bind_curr(
-    dnnl::post_ops& /*sink*/,
-    const PostOpParam& /*op*/) noexcept {}
-
-inline void fp_matmul_post_sink_bind_curr(
-    detail::PostOpsMatmulKeySink& sink,
-    const PostOpParam& op) {
-  sink.bind_curr(op);
-}
 
 inline void fp_matmul_post_sink_push_kind(
     dnnl::post_ops& /*sink*/,
@@ -218,12 +193,6 @@ inline void fp_matmul_post_sink_push_kind(
     detail::PostOpsMatmulKeySink& sink,
     kind_t kind) {
   sink.push_op_kind(kind);
-}
-
-inline void fp_matmul_post_sink_on_unknown(dnnl::post_ops& /*sink*/) noexcept {}
-
-inline void fp_matmul_post_sink_on_unknown(detail::PostOpsMatmulKeySink& sink) {
-  sink.unknown_post_op_kind();
 }
 
 class Attr {
@@ -440,7 +409,6 @@ class Attr {
   template <typename PostOpsSink>
   void emit_post_ops_for_matmul_cache_and_dnnl(PostOpsSink&& sink) const {
     for (const auto& op : ops_params_) {
-      fp_matmul_post_sink_bind_curr(sink, op);
       fp_matmul_post_sink_push_kind(sink, op.kind_);
       switch (op.kind_) {
         case kind_t::eltwise:
@@ -457,7 +425,6 @@ class Attr {
           sink.append_prelu(op.mask_);
           break;
         default:
-          fp_matmul_post_sink_on_unknown(sink);
           break;
       }
     }

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -156,7 +156,6 @@ struct PostOpsMatmulKeySink {
   void append_eltwise(
       dnnl::algorithm aalgorithm, float alpha, float beta) {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(cur_ != nullptr);
-    push_f32(key, cur_->scale_);
     push_f32(key, alpha);
     push_f32(key, beta);
     key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(aalgorithm)));
@@ -178,7 +177,6 @@ struct PostOpsMatmulKeySink {
     (void)aalgorithm;
     (void)src1_desc;
     const PostOpParam& op = *cur_;
-    push_f32(key, op.scale_);
     key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(op.algo_)));
     if (op.binary_.defined()) {
       key.push_back(static_cast<dnnl::memory::dim>(op.binary_.dim()));

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -212,6 +212,13 @@ class Attr {
   Attr() : q_scale_(1.f) {}
   Attr(float q_scale, int64_t zp = 0) : q_scale_(q_scale), q_zero_point_(zp) {}
 
+  float q_scale() const noexcept {
+    return q_scale_;
+  }
+  int64_t q_zero_point() const noexcept {
+    return q_zero_point_;
+  }
+
   /***** eltwise *****/
   dnnl::algorithm kind_with_relu = dnnl::algorithm::eltwise_relu;
   dnnl::algorithm kind_with_sigmoid = dnnl::algorithm::eltwise_logistic;
@@ -347,10 +354,15 @@ class Attr {
     return *this;
   }
 
-  dnnl::post_ops extract_post_ops() {
-    dnnl::memory::dims cache_key;
-    detail::PostOpsMatmulKeySink key_sink{cache_key};
+  dnnl::memory::dims get_post_ops_key() const {
+    dnnl::memory::dims key;
+    detail::PostOpsMatmulKeySink key_sink{key};
     emit_post_ops_for_matmul_cache_and_dnnl(key_sink);
+    return key;
+  }
+
+  dnnl::post_ops extract_post_ops() {
+    dnnl::memory::dims cache_key = get_post_ops_key();
     auto& cache = detail::get_extract_post_ops_lru_cache();
     auto pos = cache.find(cache_key);
     if (pos != cache.end()) {
@@ -410,22 +422,6 @@ class Attr {
             {DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1, binary_m});
       }
     }
-  }
-
-  dnnl::memory::dims matmul_primitive_cache_key_extra() const {
-    dnnl::memory::dims key;
-    auto push_f32 = [&](float f) {
-      uint32_t u = 0;
-      static_assert(sizeof(float) == sizeof(uint32_t));
-      std::memcpy(&u, &f, sizeof(float));
-      key.push_back(static_cast<dnnl::memory::dim>(u));
-    };
-    key.push_back(static_cast<dnnl::memory::dim>(ops_params_.size()));
-    push_f32(q_scale_);
-    key.push_back(static_cast<dnnl::memory::dim>(q_zero_point_));
-    detail::PostOpsMatmulKeySink key_sink{key};
-    emit_post_ops_for_matmul_cache_and_dnnl(key_sink);
-    return key;
   }
 
  private:

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -174,15 +174,18 @@ struct PostOpsMatmulKeySink {
   void append_binary(
       dnnl::algorithm aalgorithm, const dnnl::memory::desc& src1_desc) {
     key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(aalgorithm)));
-    const auto md_dims = src1_desc.get_dims();
-    if (md_dims.empty()) {
-      key.push_back(-1);
-    } else {
-      key.insert(key.end(), md_dims.begin(), md_dims.end());
-      key.push_back(static_cast<dnnl::memory::dim>(
-          static_cast<int>(src1_desc.get_data_type())));
-      const auto md_strides = src1_desc.get_strides();
-      key.insert(key.end(), md_strides.begin(), md_strides.end());
+    dnnl::memory::desc md = src1_desc;
+    const std::vector<uint8_t> blob = md.get_blob();
+    key.push_back(static_cast<dnnl::memory::dim>(blob.size()));
+    constexpr size_t kPack = sizeof(dnnl::memory::dim);
+    size_t off = 0;
+    while (off < blob.size()) {
+      const size_t rest = blob.size() - off;
+      const size_t chunk = rest < kPack ? rest : kPack;
+      dnnl::memory::dim packed = 0;
+      std::memcpy(&packed, blob.data() + off, chunk);
+      key.push_back(packed);
+      off += chunk;
     }
   }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 
+#include <cstdint>
 #include <cstring>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
@@ -130,6 +131,112 @@ struct PostOpParam {
   dnnl::algorithm algo_ = dnnl::algorithm::eltwise_relu;
   kind_t kind_ = kind_t::eltwise;
 };
+
+namespace detail {
+
+struct PostOpsMatmulKeySink {
+  dnnl::memory::dims& key;
+  const PostOpParam* cur_ = nullptr;
+
+  void bind_curr(const PostOpParam& op) {
+    cur_ = &op;
+  }
+
+  void push_op_kind(kind_t kind) {
+    key.push_back(static_cast<dnnl::memory::dim>(kind));
+  }
+
+  static void push_f32(dnnl::memory::dims& d, float f) {
+    uint32_t u = 0;
+    static_assert(sizeof(float) == sizeof(uint32_t));
+    std::memcpy(&u, &f, sizeof(float));
+    d.push_back(static_cast<dnnl::memory::dim>(u));
+  }
+
+  void append_eltwise(
+      dnnl::algorithm aalgorithm, float alpha, float beta) {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(cur_ != nullptr);
+    push_f32(key, cur_->scale_);
+    push_f32(key, alpha);
+    push_f32(key, beta);
+    key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(aalgorithm)));
+  }
+
+  void append_sum(
+      float scale,
+      std::int32_t zero_point,
+      dnnl::memory::data_type data_type =
+          dnnl::memory::data_type::undef) {
+    (void)data_type;
+    push_f32(key, scale);
+    key.push_back(static_cast<dnnl::memory::dim>(zero_point));
+  }
+
+  void append_binary(
+      dnnl::algorithm aalgorithm, const dnnl::memory::desc& src1_desc) {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(cur_ != nullptr);
+    (void)aalgorithm;
+    (void)src1_desc;
+    const PostOpParam& op = *cur_;
+    push_f32(key, op.scale_);
+    key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(op.algo_)));
+    if (op.binary_.defined()) {
+      key.push_back(static_cast<dnnl::memory::dim>(op.binary_.dim()));
+      for (int64_t i = 0; i < op.binary_.dim(); ++i) {
+        key.push_back(op.binary_.size(i));
+        key.push_back(op.binary_.stride(i));
+      }
+      key.push_back(static_cast<dnnl::memory::dim>(
+          static_cast<int>(c10::toUnderlying(op.binary_.scalar_type()))));
+    } else {
+      key.push_back(-1);
+    }
+    const auto md_dims = op.meta_.get_dims();
+    if (!md_dims.empty()) {
+      key.insert(key.end(), md_dims.begin(), md_dims.end());
+      key.push_back(static_cast<dnnl::memory::dim>(
+          static_cast<int>(op.meta_.get_data_type())));
+      const auto md_strides = op.meta_.get_strides();
+      key.insert(key.end(), md_strides.begin(), md_strides.end());
+    }
+  }
+
+  void append_prelu(int mask) {
+    key.push_back(static_cast<dnnl::memory::dim>(mask));
+  }
+
+  void unknown_post_op_kind() {
+    key.push_back(-999);
+  }
+};
+
+} // namespace detail
+
+inline void fp_matmul_post_sink_bind_curr(
+    dnnl::post_ops& /*sink*/,
+    const PostOpParam& /*op*/) noexcept {}
+
+inline void fp_matmul_post_sink_bind_curr(
+    detail::PostOpsMatmulKeySink& sink,
+    const PostOpParam& op) {
+  sink.bind_curr(op);
+}
+
+inline void fp_matmul_post_sink_push_kind(
+    dnnl::post_ops& /*sink*/,
+    kind_t /*kind*/) noexcept {}
+
+inline void fp_matmul_post_sink_push_kind(
+    detail::PostOpsMatmulKeySink& sink,
+    kind_t kind) {
+  sink.push_op_kind(kind);
+}
+
+inline void fp_matmul_post_sink_on_unknown(dnnl::post_ops& /*sink*/) noexcept {}
+
+inline void fp_matmul_post_sink_on_unknown(detail::PostOpsMatmulKeySink& sink) {
+  sink.unknown_post_op_kind();
+}
 
 class Attr {
  public:
@@ -272,44 +379,8 @@ class Attr {
   }
 
   dnnl::post_ops extract_post_ops() {
-    // this function is used to extract post ops params from the ops_params_
-    // and put them into onednn post ops
-    for (size_t i = 0; i < ops_params_.size(); ++i) {
-      kind_t kind = ops_params_[i].kind_;
-      switch (kind) {
-        case kind_t::eltwise: {
-          dnnl::algorithm algo = ops_params_[i].algo_;
-          float alpha = ops_params_[i].alpha_;
-          float beta = ops_params_[i].beta_;
-          dnnl_post_ops_.append_eltwise(algo, alpha, beta);
-          break;
-        }
-        case kind_t::sum: {
-          float scale = ops_params_[i].scale_;
-          int64_t zero_point = ops_params_[i].zero_point_;
-          // TODO [Asymmetric]:
-          // Post-sum zp for gpu is not supported currently
-          dnnl_post_ops_.append_sum(scale, zero_point);
-          break;
-        }
-        case kind_t::binary: {
-          dnnl::algorithm algo = ops_params_[i].algo_;
-          auto expected_md = ops_params_[i].expected_meta_;
-          // In this case user may create src1 memory descriptor with
-          // format_tag::any or set a specific tag. However, in later case if
-          // tags mismatch with dst, it would result in suboptimal performance.
-          // So here we use format_tag::any to make sure the fast can be
-          // selected.
-          // Thus we use expected_md (with format_any) here to create pd instead
-          // of original md
-          dnnl_post_ops_.append_binary(algo, expected_md);
-          break;
-        }
-        default:
-          break;
-      }
-    }
-
+    dnnl_post_ops_ = dnnl::post_ops();
+    emit_post_ops_for_matmul_cache_and_dnnl(dnnl_post_ops_);
     return dnnl_post_ops_;
   }
 
@@ -372,46 +443,36 @@ class Attr {
     key.push_back(static_cast<dnnl::memory::dim>(ops_params_.size()));
     push_f32(q_scale_);
     key.push_back(static_cast<dnnl::memory::dim>(q_zero_point_));
+    detail::PostOpsMatmulKeySink key_sink{key};
+    emit_post_ops_for_matmul_cache_and_dnnl(key_sink);
+    return key;
+  }
+
+ private:
+  template <typename PostOpsSink>
+  void emit_post_ops_for_matmul_cache_and_dnnl(PostOpsSink&& sink) const {
     for (const auto& op : ops_params_) {
-      key.push_back(static_cast<dnnl::memory::dim>(op.kind_));
-      const kind_t post_kind = op.kind_;
-      if (post_kind == kind_t::eltwise) {
-        push_f32(op.scale_);
-        push_f32(op.alpha_);
-        push_f32(op.beta_);
-        key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(op.algo_)));
-      } else if (post_kind == kind_t::sum) {
-        push_f32(op.scale_);
-        key.push_back(static_cast<dnnl::memory::dim>(op.zero_point_));
-      } else if (post_kind == kind_t::binary) {
-        push_f32(op.scale_);
-        key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(op.algo_)));
-        if (op.binary_.defined()) {
-          key.push_back(static_cast<dnnl::memory::dim>(op.binary_.dim()));
-          for (int64_t i = 0; i < op.binary_.dim(); ++i) {
-            key.push_back(op.binary_.size(i));
-            key.push_back(op.binary_.stride(i));
-          }
-          key.push_back(static_cast<dnnl::memory::dim>(
-              static_cast<int>(c10::toUnderlying(op.binary_.scalar_type()))));
-        } else {
-          key.push_back(-1);
-        }
-        const auto md_dims = op.meta_.get_dims();
-        if (!md_dims.empty()) {
-          key.insert(key.end(), md_dims.begin(), md_dims.end());
-          key.push_back(static_cast<dnnl::memory::dim>(
-              static_cast<int>(op.meta_.get_data_type())));
-          const auto md_strides = op.meta_.get_strides();
-          key.insert(key.end(), md_strides.begin(), md_strides.end());
-        }
-      } else if (post_kind == kind_t::prelu) {
-        key.push_back(static_cast<dnnl::memory::dim>(op.mask_));
-      } else {
-        key.push_back(-999);
+      fp_matmul_post_sink_bind_curr(sink, op);
+      fp_matmul_post_sink_push_kind(sink, op.kind_);
+      switch (op.kind_) {
+        case kind_t::eltwise:
+          sink.append_eltwise(op.algo_, op.alpha_, op.beta_);
+          break;
+        case kind_t::sum:
+          sink.append_sum(
+              op.scale_, static_cast<std::int32_t>(op.zero_point_));
+          break;
+        case kind_t::binary:
+          sink.append_binary(op.algo_, op.expected_meta_);
+          break;
+        case kind_t::prelu:
+          sink.append_prelu(op.mask_);
+          break;
+        default:
+          fp_matmul_post_sink_on_unknown(sink);
+          break;
       }
     }
-    return key;
   }
 
   float q_scale_ = 1.0; // the scale used to quantize the fused result from fp32

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -271,7 +271,7 @@ class Attr {
     return *this;
   }
 
-  dnnl::post_ops extract_post_ops(const at::Tensor& dst) {
+  dnnl::post_ops extract_post_ops() {
     // this function is used to extract post ops params from the ops_params_
     // and put them into onednn post ops
     for (size_t i = 0; i < ops_params_.size(); ++i) {

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <ATen/ATen.h>
+
+#include <cstring>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
 #include <oneapi/dnnl/dnnl.hpp>
@@ -357,6 +359,59 @@ class Attr {
             {DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1, binary_m});
       }
     }
+  }
+
+  dnnl::memory::dims matmul_primitive_cache_key_extra() const {
+    dnnl::memory::dims key;
+    auto push_f32 = [&](float f) {
+      uint32_t u = 0;
+      static_assert(sizeof(float) == sizeof(uint32_t));
+      std::memcpy(&u, &f, sizeof(float));
+      key.push_back(static_cast<dnnl::memory::dim>(u));
+    };
+    key.push_back(static_cast<dnnl::memory::dim>(ops_params_.size()));
+    push_f32(q_scale_);
+    key.push_back(static_cast<dnnl::memory::dim>(q_zero_point_));
+    for (const auto& op : ops_params_) {
+      key.push_back(static_cast<dnnl::memory::dim>(op.kind_));
+      const kind_t post_kind = op.kind_;
+      if (post_kind == kind_t::eltwise) {
+        push_f32(op.scale_);
+        push_f32(op.alpha_);
+        push_f32(op.beta_);
+        key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(op.algo_)));
+      } else if (post_kind == kind_t::sum) {
+        push_f32(op.scale_);
+        key.push_back(static_cast<dnnl::memory::dim>(op.zero_point_));
+      } else if (post_kind == kind_t::binary) {
+        push_f32(op.scale_);
+        key.push_back(static_cast<dnnl::memory::dim>(static_cast<int>(op.algo_)));
+        if (op.binary_.defined()) {
+          key.push_back(static_cast<dnnl::memory::dim>(op.binary_.dim()));
+          for (int64_t i = 0; i < op.binary_.dim(); ++i) {
+            key.push_back(op.binary_.size(i));
+            key.push_back(op.binary_.stride(i));
+          }
+          key.push_back(static_cast<dnnl::memory::dim>(
+              static_cast<int>(c10::toUnderlying(op.binary_.scalar_type()))));
+        } else {
+          key.push_back(-1);
+        }
+        const auto md_dims = op.meta_.get_dims();
+        if (!md_dims.empty()) {
+          key.insert(key.end(), md_dims.begin(), md_dims.end());
+          key.push_back(static_cast<dnnl::memory::dim>(
+              static_cast<int>(op.meta_.get_data_type())));
+          const auto md_strides = op.meta_.get_strides();
+          key.insert(key.end(), md_strides.begin(), md_strides.end());
+        }
+      } else if (post_kind == kind_t::prelu) {
+        key.push_back(static_cast<dnnl::memory::dim>(op.mask_));
+      } else {
+        key.push_back(-999);
+      }
+    }
+    return key;
   }
 
   float q_scale_ = 1.0; // the scale used to quantize the fused result from fp32

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -332,7 +332,7 @@ class Attr {
   }
 
   void construct_post_binary(
-      dnnl::primitive_desc& pd,
+      const dnnl::primitive_desc& pd,
       std::unordered_map<int, dnnl::memory>& args) {
     // This function is used to construct binary memory desc in binary post ops.
     // According to oneDNN doc, the binary tensor can be in shape of

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -336,9 +336,9 @@ class Attr {
   }
 
   dnnl::post_ops extract_post_ops() {
-    dnnl_post_ops_ = dnnl::post_ops();
-    emit_post_ops_for_matmul_cache_and_dnnl(dnnl_post_ops_);
-    return dnnl_post_ops_;
+    dnnl::post_ops po;
+    emit_post_ops_for_matmul_cache_and_dnnl(po);
+    return po;
   }
 
   bool with_sum() {
@@ -434,7 +434,6 @@ class Attr {
                         // to int8, only works for int8 case
   int64_t q_zero_point_ = 0;
   std::vector<PostOpParam> ops_params_; // series of post ops
-  dnnl::post_ops dnnl_post_ops_;
 };
 
 static inline void construct_attr_for_unary(

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <ATen/native/mkldnn/xpu/detail/DnnlExt.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
 #include <oneapi/dnnl/dnnl.hpp>
@@ -183,6 +184,17 @@ struct PostOpsMatmulKeySink {
   }
 };
 
+constexpr std::size_t kExtractPostOpsLruCapacity = 512;
+
+inline lru_cache<dnnl::memory::dims, dnnl::post_ops>&
+get_extract_post_ops_lru_cache() {
+  static thread_local lru_cache<dnnl::memory::dims, dnnl::post_ops> cache;
+  if (cache.max_size() == 0) {
+    cache.resize(kExtractPostOpsLruCapacity);
+  }
+  return cache;
+}
+
 } // namespace detail
 
 inline void fp_matmul_post_sink_push_kind(
@@ -336,9 +348,20 @@ class Attr {
   }
 
   dnnl::post_ops extract_post_ops() {
+    dnnl::memory::dims cache_key;
+    detail::PostOpsMatmulKeySink key_sink{cache_key};
+    emit_post_ops_for_matmul_cache_and_dnnl(key_sink);
+    auto& cache = detail::get_extract_post_ops_lru_cache();
+    auto pos = cache.find(cache_key);
+    if (pos != cache.end()) {
+      return pos->second;
+    }
     dnnl::post_ops po;
     emit_post_ops_for_matmul_cache_and_dnnl(po);
-    return po;
+    auto [it, inserted] =
+        cache.insert({std::move(cache_key), std::move(po)});
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(inserted);
+    return it->second;
   }
 
   bool with_sum() {

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
@@ -107,7 +107,7 @@ sycl::event convolution(
 
   // extract post ops
   dnnl::primitive_attr pattr;
-  dnnl::post_ops po = attr.extract_post_ops(dst);
+  dnnl::post_ops po = attr.extract_post_ops();
   pattr.set_post_ops(po);
 
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
@@ -181,7 +181,7 @@ sycl::event deconvolution(
 
   // construct primitive attr
   dnnl::primitive_attr pattr;
-  dnnl::post_ops po = attr.extract_post_ops(dst);
+  dnnl::post_ops po = attr.extract_post_ops();
   pattr.set_post_ops(po);
 #if ONEDNN_SUPPORT_DETERMINISTIC
   if (at::globalContext().deterministicAlgorithms() ||

--- a/aten/src/ATen/native/mkldnn/xpu/detail/LRUCache.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/LRUCache.h
@@ -81,7 +81,24 @@ class lru_cache {
 
     // Insert new at front
     vlist_.emplace_front(value);
-    map_[value.first] = vlist_.begin();
+    map_[vlist_.begin()->first] = vlist_.begin();
+
+    trim();
+
+    return {vlist_.begin(), true};
+  }
+
+  std::pair<list_iter, bool> insert(value_type&& value) {
+    auto it = map_.find(value.first);
+    if (it != map_.end()) {
+      vlist_.splice(vlist_.begin(), vlist_, it->second);
+      return {it->second, false};
+    }
+
+    vlist_.emplace_front(std::move(value));
+    // After std::move(value), value.first must not be used (moved-from); index
+    // the map with the key stored in the new list node instead.
+    map_[vlist_.begin()->first] = vlist_.begin();
 
     trim();
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -170,14 +170,13 @@ FpMatmulCacheValue lookup_or_build_fpmatmul_cached_primitive(
   // Named args... are lvalues; avoid std::forward twice (moved-from risk).
   dnnl::memory::dims cache_key =
       build_fpmatmul_primitive_cache_key(args...);
-  auto cache_it = primitive_cache.find(cache_key);
-  if (cache_it != primitive_cache.end()) {
-    return cache_it->second;
+  auto [it, inserted] = primitive_cache.insert(
+      FpMatmulLruCache::value_type{std::move(cache_key), {}});
+  if (!inserted) {
+    return it->second;
   }
-  FpMatmulCacheValue entry =
-      make_fpmatmul_cached_primitive(args..., engine, dst);
-  primitive_cache.insert({std::move(cache_key), entry});
-  return entry;
+  it->second = make_fpmatmul_cached_primitive(args..., engine, dst);
+  return it->second;
 }
 
 } // namespace

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -167,14 +167,15 @@ FpMatmulCacheValue lookup_or_build_fpmatmul_cached_primitive(
     Args&&... args,
     dnnl::engine& engine,
     const at::Tensor& dst) {
-  dnnl::memory::dims cache_key = build_fpmatmul_primitive_cache_key(
-      std::forward<Args>(args)...);
+  // Named args... are lvalues; avoid std::forward twice (moved-from risk).
+  dnnl::memory::dims cache_key =
+      build_fpmatmul_primitive_cache_key(args...);
   auto cache_it = primitive_cache.find(cache_key);
   if (cache_it != primitive_cache.end()) {
     return cache_it->second;
   }
-  FpMatmulCacheValue entry = make_fpmatmul_cached_primitive(
-      std::forward<Args>(args)..., engine, dst);
+  FpMatmulCacheValue entry =
+      make_fpmatmul_cached_primitive(args..., engine, dst);
   primitive_cache.insert({std::move(cache_key), entry});
   return entry;
 }

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -18,7 +18,6 @@ namespace {
 
 using dim_t = dnnl::memory::dim;
 
-constexpr int64_t kFpMatmulPrimitiveCacheKeyVersion = 1;
 constexpr size_t kFpMatmulPrimitiveCacheCapacity = 512;
 
 struct FpMatmulCachedPrimitive {
@@ -107,7 +106,6 @@ void build_fpmatmul_primitive_cache_key_rec(
 template <typename... Args>
 dnnl::memory::dims build_fpmatmul_primitive_cache_key(Args&&... args) {
   dnnl::memory::dims key;
-  key.push_back(kFpMatmulPrimitiveCacheKeyVersion);
   build_fpmatmul_primitive_cache_key_rec(key, std::forward<Args>(args)...);
   return key;
 }

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -164,10 +164,9 @@ FpMatmulCacheValue make_fpmatmul_cached_primitive(
 template <typename... Args>
 FpMatmulCacheValue lookup_or_build_fpmatmul_cached_primitive(
     FpMatmulLruCache& primitive_cache,
-    Args&&... args,
     dnnl::engine& engine,
-    const at::Tensor& dst) {
-  // Named args... are lvalues; avoid std::forward twice (moved-from risk).
+    const at::Tensor& dst,
+    Args&&... args) {
   dnnl::memory::dims cache_key =
       build_fpmatmul_primitive_cache_key(args...);
   auto [it, inserted] = primitive_cache.insert(
@@ -352,6 +351,8 @@ sycl::event matmul(
       with_bias, bias_dims, bias_dt, bias_strides};
   FpMatmulCacheValue entry = lookup_or_build_fpmatmul_cached_primitive(
       primitive_cache,
+      engine,
+      dst,
       m1_dims,
       m2_dims,
       dst_dims,
@@ -364,9 +365,7 @@ sycl::event matmul(
       bias_key,
       deterministic,
       allow_tf32_oneapi,
-      attr,
-      engine,
-      dst);
+      attr);
 
   // STEP4: create memory
   dnnl::memory::desc m1_usr_md(m1_dims, m1_usr_dt, m1_strides);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -54,7 +54,6 @@ dnnl::memory::dims build_fpmatmul_primitive_cache_key(
     dnnl::memory::data_type m1_dt,
     dnnl::memory::data_type m2_dt,
     dnnl::memory::data_type dst_dt,
-    bool m2_trans,
     bool with_bias,
     const dnnl::memory::dims& bias_dims,
     dnnl::memory::data_type bias_dt,
@@ -79,7 +78,6 @@ dnnl::memory::dims build_fpmatmul_primitive_cache_key(
   key.push_back(static_cast<dim_t>(static_cast<int>(m1_dt)));
   key.push_back(static_cast<dim_t>(static_cast<int>(m2_dt)));
   key.push_back(static_cast<dim_t>(static_cast<int>(dst_dt)));
-  key.push_back(m2_trans ? 1 : 0);
   key.push_back(with_bias ? 1 : 0);
   if (with_bias) {
     append_dims(bias_dims);
@@ -102,7 +100,6 @@ FpMatmulCacheValue make_fpmatmul_cached_primitive(
     dnnl::memory::data_type m1_dt,
     dnnl::memory::data_type m2_dt,
     dnnl::memory::data_type dst_dt,
-    [[maybe_unused]] bool m2_trans,
     bool with_bias,
     const dnnl::memory::dims& bias_dims,
     dnnl::memory::data_type bias_dt,
@@ -352,7 +349,6 @@ sycl::event matmul(
       m1_dt,
       m2_dt,
       dst_dt,
-      m2_trans,
       with_bias,
       bias_dims,
       bias_dt,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -31,6 +31,39 @@ struct FpMatmulCachedPrimitive {
 using FpMatmulCacheValue = std::shared_ptr<FpMatmulCachedPrimitive>;
 using FpMatmulLruCache = lru_cache<dnnl::memory::dims, FpMatmulCacheValue>;
 
+// Single bundle for cache key and primitive build so new fields require one
+// initializer site and both code paths see the same data at compile time.
+struct FpMatmulPrimitiveCacheParams {
+  int device_id;
+  int64_t rank;
+  int64_t m;
+  int64_t n;
+  int64_t k;
+  int64_t mb;
+  dnnl::memory::dims m1_dims;
+  dnnl::memory::dims m2_dims;
+  dnnl::memory::dims dst_dims;
+  dnnl::memory::dims m1_strides;
+  dnnl::memory::dims m2_strides;
+  dnnl::memory::dims dst_strides;
+  dnnl::memory::data_type m1_usr_dt;
+  dnnl::memory::data_type m2_usr_dt;
+  dnnl::memory::data_type dst_usr_dt;
+  dnnl::memory::data_type m1_dt;
+  dnnl::memory::data_type m2_dt;
+  dnnl::memory::data_type dst_dt;
+  bool m2_trans;
+  bool with_bias;
+  dnnl::memory::dims bias_dims;
+  dnnl::memory::data_type bias_dt;
+  dnnl::memory::dims bias_strides;
+  bool deterministic;
+  bool allow_tf32_oneapi;
+  Attr& attr;
+  dnnl::engine& engine;
+  const at::Tensor& dst;
+};
+
 FpMatmulLruCache& get_fpmatmul_primitive_cache(int device_id) {
   static thread_local std::unordered_map<int, FpMatmulLruCache> caches;
   auto [it, _] = caches.try_emplace(device_id, FpMatmulLruCache());
@@ -42,61 +75,98 @@ FpMatmulLruCache& get_fpmatmul_primitive_cache(int device_id) {
 }
 
 dnnl::memory::dims build_fpmatmul_primitive_cache_key(
-    int device_id,
-    int64_t rank,
-    int64_t m,
-    int64_t n,
-    int64_t k,
-    int64_t mb,
-    const dnnl::memory::dims& m1_strides,
-    const dnnl::memory::dims& m2_strides,
-    const dnnl::memory::dims& dst_strides,
-    dnnl::memory::data_type m1_usr_dt,
-    dnnl::memory::data_type m2_usr_dt,
-    dnnl::memory::data_type dst_usr_dt,
-    dnnl::memory::data_type m1_dt,
-    dnnl::memory::data_type m2_dt,
-    dnnl::memory::data_type dst_dt,
-    bool m2_trans,
-    bool with_bias,
-    const dnnl::memory::dims& bias_dims,
-    dnnl::memory::data_type bias_dt,
-    const dnnl::memory::dims& bias_strides,
-    bool deterministic,
-    bool allow_tf32_oneapi,
-    const Attr& attr) {
+    const FpMatmulPrimitiveCacheParams& p) {
   dnnl::memory::dims key;
   auto append_dims = [&](const dnnl::memory::dims& d) {
     key.insert(key.end(), d.begin(), d.end());
   };
 
   key.push_back(kFpMatmulPrimitiveCacheKeyVersion);
-  key.push_back(static_cast<dim_t>(device_id));
-  key.push_back(rank);
-  key.push_back(m);
-  key.push_back(n);
-  key.push_back(k);
-  key.push_back(mb);
-  append_dims(m1_strides);
-  append_dims(m2_strides);
-  append_dims(dst_strides);
-  key.push_back(static_cast<dim_t>(static_cast<int>(m1_usr_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(m2_usr_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(dst_usr_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(m1_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(m2_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(dst_dt)));
-  key.push_back(m2_trans ? 1 : 0);
-  key.push_back(with_bias ? 1 : 0);
-  if (with_bias) {
-    append_dims(bias_dims);
-    key.push_back(static_cast<dim_t>(static_cast<int>(bias_dt)));
-    append_dims(bias_strides);
+  key.push_back(static_cast<dim_t>(p.device_id));
+  key.push_back(p.rank);
+  key.push_back(p.m);
+  key.push_back(p.n);
+  key.push_back(p.k);
+  key.push_back(p.mb);
+  append_dims(p.m1_strides);
+  append_dims(p.m2_strides);
+  append_dims(p.dst_strides);
+  key.push_back(static_cast<dim_t>(static_cast<int>(p.m1_usr_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(p.m2_usr_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(p.dst_usr_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(p.m1_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(p.m2_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(p.dst_dt)));
+  key.push_back(p.m2_trans ? 1 : 0);
+  key.push_back(p.with_bias ? 1 : 0);
+  if (p.with_bias) {
+    append_dims(p.bias_dims);
+    key.push_back(static_cast<dim_t>(static_cast<int>(p.bias_dt)));
+    append_dims(p.bias_strides);
   }
-  key.push_back(deterministic ? 1 : 0);
-  key.push_back(allow_tf32_oneapi ? 1 : 0);
-  append_dims(attr.matmul_primitive_cache_key_extra());
+  key.push_back(p.deterministic ? 1 : 0);
+  key.push_back(p.allow_tf32_oneapi ? 1 : 0);
+  append_dims(p.attr.matmul_primitive_cache_key_extra());
   return key;
+}
+
+FpMatmulCacheValue make_fpmatmul_cached_primitive(
+    FpMatmulPrimitiveCacheParams& p) {
+  dnnl::post_ops po = p.attr.extract_post_ops(p.dst);
+
+  // STEP1: create memory desc
+  dnnl::memory::desc m1_md(p.m1_dims, p.m1_dt, p.m1_strides);
+  dnnl::memory::desc m2_md(p.m2_dims, p.m2_dt, p.m2_strides);
+  dnnl::memory::desc dst_md(p.dst_dims, p.dst_dt, p.dst_strides);
+
+  // STEP2: creat attribute
+  dnnl::primitive_attr pattr;
+  pattr.set_post_ops(po);
+
+#if ONEDNN_SUPPORT_DETERMINISTIC
+  if (p.deterministic) {
+    pattr.set_deterministic(true);
+  }
+#endif
+
+  // scratchpad
+  pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+  if (p.m1_dt == dnnl::memory::data_type::f32) {
+    if (p.allow_tf32_oneapi) {
+      pattr.set_fpmath_mode(dnnl::fpmath_mode::tf32);
+    } else {
+      pattr.set_fpmath_mode(dnnl::fpmath_mode::strict);
+    }
+  }
+
+  // STEP3: create primitive
+  dnnl::matmul::primitive_desc matmul_pd =
+      p.with_bias ? dnnl::matmul::primitive_desc(
+                        p.engine,
+                        m1_md,
+                        m2_md,
+                        dnnl::memory::desc(
+                            p.bias_dims, p.bias_dt, p.bias_strides),
+                        dst_md,
+                        pattr)
+                  : dnnl::matmul::primitive_desc(
+                        p.engine, m1_md, m2_md, dst_md, pattr);
+
+  return std::make_shared<FpMatmulCachedPrimitive>(std::move(matmul_pd));
+}
+
+FpMatmulCacheValue lookup_or_build_fpmatmul_cached_primitive(
+    FpMatmulLruCache& primitive_cache,
+    FpMatmulPrimitiveCacheParams& params) {
+  dnnl::memory::dims cache_key = build_fpmatmul_primitive_cache_key(params);
+  auto cache_it = primitive_cache.find(cache_key);
+  if (cache_it != primitive_cache.end()) {
+    return cache_it->second;
+  }
+  FpMatmulCacheValue entry = make_fpmatmul_cached_primitive(params);
+  primitive_cache.insert({std::move(cache_key), entry});
+  return entry;
 }
 
 } // namespace
@@ -266,14 +336,16 @@ sycl::event matmul(
       m1_dt == dnnl::memory::data_type::f32 &&
       at::globalContext().allowTF32OneDNN();
 
-  const int device_id = c10::xpu::current_device();
-  dnnl::memory::dims cache_key = build_fpmatmul_primitive_cache_key(
-      device_id,
+  FpMatmulPrimitiveCacheParams cache_params{
+      c10::xpu::current_device(),
       dims,
       m,
       n,
       k,
       mb,
+      m1_dims,
+      m2_dims,
+      dst_dims,
       m1_strides,
       m2_strides,
       dst_strides,
@@ -290,58 +362,15 @@ sycl::event matmul(
       bias_strides,
       deterministic,
       allow_tf32_oneapi,
-      attr);
+      attr,
+      engine,
+      dst,
+  };
 
-  auto& primitive_cache = get_fpmatmul_primitive_cache(device_id);
-  auto cache_it = primitive_cache.find(cache_key);
-  FpMatmulCacheValue entry;
-  if (cache_it != primitive_cache.end()) {
-    entry = cache_it->second;
-  } else {
-    dnnl::post_ops po = attr.extract_post_ops(dst);
-
-    // STEP1: create memory desc
-    dnnl::memory::desc m1_md(m1_dims, m1_dt, m1_strides);
-    dnnl::memory::desc m2_md(m2_dims, m2_dt, m2_strides);
-    dnnl::memory::desc dst_md(dst_dims, dst_dt, dst_strides);
-
-    // STEP2: creat attribute
-    dnnl::primitive_attr pattr;
-    pattr.set_post_ops(po);
-
-#if ONEDNN_SUPPORT_DETERMINISTIC
-    if (deterministic) {
-      pattr.set_deterministic(true);
-    }
-#endif
-
-    // scratchpad
-    pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-
-    if (m1_dt == dnnl::memory::data_type::f32) {
-      if (allow_tf32_oneapi) {
-        pattr.set_fpmath_mode(dnnl::fpmath_mode::tf32);
-      } else {
-        pattr.set_fpmath_mode(dnnl::fpmath_mode::strict);
-      }
-    }
-
-    // STEP3: create primitive
-    dnnl::matmul::primitive_desc matmul_pd =
-        with_bias
-        ? dnnl::matmul::primitive_desc(
-              engine,
-              m1_md,
-              m2_md,
-              dnnl::memory::desc(bias_dims, bias_dt, bias_strides),
-              dst_md,
-              pattr)
-        : dnnl::matmul::primitive_desc(
-              engine, m1_md, m2_md, dst_md, pattr);
-
-    entry = std::make_shared<FpMatmulCachedPrimitive>(std::move(matmul_pd));
-    primitive_cache.insert({cache_key, entry});
-  }
+  auto& primitive_cache =
+      get_fpmatmul_primitive_cache(cache_params.device_id);
+  FpMatmulCacheValue entry = lookup_or_build_fpmatmul_cached_primitive(
+      primitive_cache, cache_params);
 
   // STEP4: create memory
   dnnl::memory::desc m1_usr_md(m1_dims, m1_usr_dt, m1_strides);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -42,51 +42,73 @@ FpMatmulLruCache& get_fpmatmul_primitive_cache(int device_id) {
   return c;
 }
 
-// build_* and make_* must keep identical parameter lists; lookup forwards the
-// same pack to both so arity/type mismatches fail at compile time.
-dnnl::memory::dims build_fpmatmul_primitive_cache_key(
-    const dnnl::memory::dims& m1_dims,
-    const dnnl::memory::dims& m2_dims,
-    const dnnl::memory::dims& dst_dims,
-    const dnnl::memory::dims& m1_strides,
-    const dnnl::memory::dims& m2_strides,
-    const dnnl::memory::dims& dst_strides,
-    dnnl::memory::data_type m1_dt,
-    dnnl::memory::data_type m2_dt,
-    dnnl::memory::data_type dst_dt,
-    bool with_bias,
-    const dnnl::memory::dims& bias_dims,
-    dnnl::memory::data_type bias_dt,
-    const dnnl::memory::dims& bias_strides,
-    bool deterministic,
-    bool allow_tf32_oneapi,
-    Attr& attr,
-    dnnl::engine&,
-    const at::Tensor&) {
-  dnnl::memory::dims key;
-  auto append_dims = [&](const dnnl::memory::dims& d) {
-    key.insert(key.end(), d.begin(), d.end());
-  };
+// Bias fields as one key part so build_fpmatmul_primitive_cache_key_rec stays
+// in sync with make_fpmatmul_cached_primitive's single variadic forward.
+struct FpMatmulCacheBiasKeyParts {
+  bool with_bias;
+  const dnnl::memory::dims& bias_dims;
+  dnnl::memory::data_type bias_dt;
+  const dnnl::memory::dims& bias_strides;
+};
 
-  key.push_back(kFpMatmulPrimitiveCacheKeyVersion);
-  append_dims(m1_dims);
-  append_dims(m2_dims);
-  append_dims(dst_dims);
-  append_dims(m1_strides);
-  append_dims(m2_strides);
-  append_dims(dst_strides);
-  key.push_back(static_cast<dim_t>(static_cast<int>(m1_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(m2_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(dst_dt)));
-  key.push_back(with_bias ? 1 : 0);
-  if (with_bias) {
-    append_dims(bias_dims);
-    key.push_back(static_cast<dim_t>(static_cast<int>(bias_dt)));
-    append_dims(bias_strides);
+inline void append_fp_matmul_cache_key_part(
+    dnnl::memory::dims& key,
+    const dnnl::memory::dims& d) {
+  key.insert(key.end(), d.begin(), d.end());
+}
+
+inline void append_fp_matmul_cache_key_part(
+    dnnl::memory::dims& key,
+    dnnl::memory::data_type dt) {
+  key.push_back(static_cast<dim_t>(static_cast<int>(dt)));
+}
+
+inline void append_fp_matmul_cache_key_part(dnnl::memory::dims& key, bool b) {
+  key.push_back(b ? 1 : 0);
+}
+
+inline void append_fp_matmul_cache_key_part(
+    dnnl::memory::dims& key,
+    const FpMatmulCacheBiasKeyParts& b) {
+  key.push_back(b.with_bias ? 1 : 0);
+  if (b.with_bias) {
+    append_fp_matmul_cache_key_part(key, b.bias_dims);
+    append_fp_matmul_cache_key_part(key, b.bias_dt);
+    append_fp_matmul_cache_key_part(key, b.bias_strides);
   }
-  key.push_back(deterministic ? 1 : 0);
-  key.push_back(allow_tf32_oneapi ? 1 : 0);
-  append_dims(attr.matmul_primitive_cache_key_extra());
+}
+
+inline void append_fp_matmul_cache_key_part(dnnl::memory::dims& key, Attr& attr) {
+  append_fp_matmul_cache_key_part(
+      key, attr.matmul_primitive_cache_key_extra());
+}
+
+inline void append_fp_matmul_cache_key_part(
+    dnnl::memory::dims& key,
+    dnnl::engine&) {}
+
+inline void append_fp_matmul_cache_key_part(
+    dnnl::memory::dims& key,
+    const at::Tensor&) {}
+
+void build_fpmatmul_primitive_cache_key_rec(dnnl::memory::dims& /*key*/) {}
+
+template <typename Head, typename... Tail>
+void build_fpmatmul_primitive_cache_key_rec(
+    dnnl::memory::dims& key,
+    Head&& head,
+    Tail&&... tail) {
+  append_fp_matmul_cache_key_part(key, std::forward<Head>(head));
+  build_fpmatmul_primitive_cache_key_rec(key, std::forward<Tail>(tail)...);
+}
+
+// Each forwarded argument type must have append_fp_matmul_cache_key_part so new
+// parameters cannot be silently skipped in the key.
+template <typename... Args>
+dnnl::memory::dims build_fpmatmul_primitive_cache_key(Args&&... args) {
+  dnnl::memory::dims key;
+  key.push_back(kFpMatmulPrimitiveCacheKeyVersion);
+  build_fpmatmul_primitive_cache_key_rec(key, std::forward<Args>(args)...);
   return key;
 }
 
@@ -100,10 +122,7 @@ FpMatmulCacheValue make_fpmatmul_cached_primitive(
     dnnl::memory::data_type m1_dt,
     dnnl::memory::data_type m2_dt,
     dnnl::memory::data_type dst_dt,
-    bool with_bias,
-    const dnnl::memory::dims& bias_dims,
-    dnnl::memory::data_type bias_dt,
-    const dnnl::memory::dims& bias_strides,
+    const FpMatmulCacheBiasKeyParts& bias,
     bool deterministic,
     bool allow_tf32_oneapi,
     Attr& attr,
@@ -139,16 +158,16 @@ FpMatmulCacheValue make_fpmatmul_cached_primitive(
 
   // STEP3: create primitive
   dnnl::matmul::primitive_desc matmul_pd =
-      with_bias ? dnnl::matmul::primitive_desc(
-                        engine,
-                        m1_md,
-                        m2_md,
-                        dnnl::memory::desc(
-                            bias_dims, bias_dt, bias_strides),
-                        dst_md,
-                        pattr)
-                  : dnnl::matmul::primitive_desc(
-                        engine, m1_md, m2_md, dst_md, pattr);
+      bias.with_bias ? dnnl::matmul::primitive_desc(
+                           engine,
+                           m1_md,
+                           m2_md,
+                           dnnl::memory::desc(
+                               bias.bias_dims, bias.bias_dt, bias.bias_strides),
+                           dst_md,
+                           pattr)
+                     : dnnl::matmul::primitive_desc(
+                           engine, m1_md, m2_md, dst_md, pattr);
 
   return std::make_shared<FpMatmulCachedPrimitive>(std::move(matmul_pd));
 }
@@ -338,6 +357,8 @@ sycl::event matmul(
 
   const int device_id = c10::xpu::current_device();
   auto& primitive_cache = get_fpmatmul_primitive_cache(device_id);
+  const FpMatmulCacheBiasKeyParts bias_key{
+      with_bias, bias_dims, bias_dt, bias_strides};
   FpMatmulCacheValue entry = lookup_or_build_fpmatmul_cached_primitive(
       primitive_cache,
       m1_dims,
@@ -349,10 +370,7 @@ sycl::event matmul(
       m1_dt,
       m2_dt,
       dst_dt,
-      with_bias,
-      bias_dims,
-      bias_dt,
-      bias_strides,
+      bias_key,
       deterministic,
       allow_tf32_oneapi,
       attr,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <unordered_map>
+#include <utility>
 
 namespace at::native::onednn {
 
@@ -31,39 +32,6 @@ struct FpMatmulCachedPrimitive {
 using FpMatmulCacheValue = std::shared_ptr<FpMatmulCachedPrimitive>;
 using FpMatmulLruCache = lru_cache<dnnl::memory::dims, FpMatmulCacheValue>;
 
-// Single bundle for cache key and primitive build so new fields require one
-// initializer site and both code paths see the same data at compile time.
-struct FpMatmulPrimitiveCacheParams {
-  int device_id;
-  int64_t rank;
-  int64_t m;
-  int64_t n;
-  int64_t k;
-  int64_t mb;
-  dnnl::memory::dims m1_dims;
-  dnnl::memory::dims m2_dims;
-  dnnl::memory::dims dst_dims;
-  dnnl::memory::dims m1_strides;
-  dnnl::memory::dims m2_strides;
-  dnnl::memory::dims dst_strides;
-  dnnl::memory::data_type m1_usr_dt;
-  dnnl::memory::data_type m2_usr_dt;
-  dnnl::memory::data_type dst_usr_dt;
-  dnnl::memory::data_type m1_dt;
-  dnnl::memory::data_type m2_dt;
-  dnnl::memory::data_type dst_dt;
-  bool m2_trans;
-  bool with_bias;
-  dnnl::memory::dims bias_dims;
-  dnnl::memory::data_type bias_dt;
-  dnnl::memory::dims bias_strides;
-  bool deterministic;
-  bool allow_tf32_oneapi;
-  Attr& attr;
-  dnnl::engine& engine;
-  const at::Tensor& dst;
-};
-
 FpMatmulLruCache& get_fpmatmul_primitive_cache(int device_id) {
   static thread_local std::unordered_map<int, FpMatmulLruCache> caches;
   auto [it, _] = caches.try_emplace(device_id, FpMatmulLruCache());
@@ -74,57 +42,113 @@ FpMatmulLruCache& get_fpmatmul_primitive_cache(int device_id) {
   return c;
 }
 
+// build_* and make_* must keep identical parameter lists; lookup forwards the
+// same pack to both so arity/type mismatches fail at compile time.
 dnnl::memory::dims build_fpmatmul_primitive_cache_key(
-    const FpMatmulPrimitiveCacheParams& p) {
+    int device_id,
+    int64_t rank,
+    int64_t m,
+    int64_t n,
+    int64_t k,
+    int64_t mb,
+    [[maybe_unused]] const dnnl::memory::dims& m1_dims,
+    [[maybe_unused]] const dnnl::memory::dims& m2_dims,
+    [[maybe_unused]] const dnnl::memory::dims& dst_dims,
+    const dnnl::memory::dims& m1_strides,
+    const dnnl::memory::dims& m2_strides,
+    const dnnl::memory::dims& dst_strides,
+    dnnl::memory::data_type m1_usr_dt,
+    dnnl::memory::data_type m2_usr_dt,
+    dnnl::memory::data_type dst_usr_dt,
+    dnnl::memory::data_type m1_dt,
+    dnnl::memory::data_type m2_dt,
+    dnnl::memory::data_type dst_dt,
+    bool m2_trans,
+    bool with_bias,
+    const dnnl::memory::dims& bias_dims,
+    dnnl::memory::data_type bias_dt,
+    const dnnl::memory::dims& bias_strides,
+    bool deterministic,
+    bool allow_tf32_oneapi,
+    Attr& attr,
+    dnnl::engine&,
+    const at::Tensor&) {
   dnnl::memory::dims key;
   auto append_dims = [&](const dnnl::memory::dims& d) {
     key.insert(key.end(), d.begin(), d.end());
   };
 
   key.push_back(kFpMatmulPrimitiveCacheKeyVersion);
-  key.push_back(static_cast<dim_t>(p.device_id));
-  key.push_back(p.rank);
-  key.push_back(p.m);
-  key.push_back(p.n);
-  key.push_back(p.k);
-  key.push_back(p.mb);
-  append_dims(p.m1_strides);
-  append_dims(p.m2_strides);
-  append_dims(p.dst_strides);
-  key.push_back(static_cast<dim_t>(static_cast<int>(p.m1_usr_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(p.m2_usr_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(p.dst_usr_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(p.m1_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(p.m2_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(p.dst_dt)));
-  key.push_back(p.m2_trans ? 1 : 0);
-  key.push_back(p.with_bias ? 1 : 0);
-  if (p.with_bias) {
-    append_dims(p.bias_dims);
-    key.push_back(static_cast<dim_t>(static_cast<int>(p.bias_dt)));
-    append_dims(p.bias_strides);
+  key.push_back(static_cast<dim_t>(device_id));
+  key.push_back(rank);
+  key.push_back(m);
+  key.push_back(n);
+  key.push_back(k);
+  key.push_back(mb);
+  append_dims(m1_strides);
+  append_dims(m2_strides);
+  append_dims(dst_strides);
+  key.push_back(static_cast<dim_t>(static_cast<int>(m1_usr_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(m2_usr_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(dst_usr_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(m1_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(m2_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(dst_dt)));
+  key.push_back(m2_trans ? 1 : 0);
+  key.push_back(with_bias ? 1 : 0);
+  if (with_bias) {
+    append_dims(bias_dims);
+    key.push_back(static_cast<dim_t>(static_cast<int>(bias_dt)));
+    append_dims(bias_strides);
   }
-  key.push_back(p.deterministic ? 1 : 0);
-  key.push_back(p.allow_tf32_oneapi ? 1 : 0);
-  append_dims(p.attr.matmul_primitive_cache_key_extra());
+  key.push_back(deterministic ? 1 : 0);
+  key.push_back(allow_tf32_oneapi ? 1 : 0);
+  append_dims(attr.matmul_primitive_cache_key_extra());
   return key;
 }
 
 FpMatmulCacheValue make_fpmatmul_cached_primitive(
-    FpMatmulPrimitiveCacheParams& p) {
-  dnnl::post_ops po = p.attr.extract_post_ops(p.dst);
+    [[maybe_unused]] int device_id,
+    [[maybe_unused]] int64_t rank,
+    [[maybe_unused]] int64_t m,
+    [[maybe_unused]] int64_t n,
+    [[maybe_unused]] int64_t k,
+    [[maybe_unused]] int64_t mb,
+    const dnnl::memory::dims& m1_dims,
+    const dnnl::memory::dims& m2_dims,
+    const dnnl::memory::dims& dst_dims,
+    const dnnl::memory::dims& m1_strides,
+    const dnnl::memory::dims& m2_strides,
+    const dnnl::memory::dims& dst_strides,
+    [[maybe_unused]] dnnl::memory::data_type m1_usr_dt,
+    [[maybe_unused]] dnnl::memory::data_type m2_usr_dt,
+    [[maybe_unused]] dnnl::memory::data_type dst_usr_dt,
+    dnnl::memory::data_type m1_dt,
+    dnnl::memory::data_type m2_dt,
+    dnnl::memory::data_type dst_dt,
+    [[maybe_unused]] bool m2_trans,
+    bool with_bias,
+    const dnnl::memory::dims& bias_dims,
+    dnnl::memory::data_type bias_dt,
+    const dnnl::memory::dims& bias_strides,
+    bool deterministic,
+    bool allow_tf32_oneapi,
+    Attr& attr,
+    dnnl::engine& engine,
+    const at::Tensor& dst) {
+  dnnl::post_ops po = attr.extract_post_ops(dst);
 
   // STEP1: create memory desc
-  dnnl::memory::desc m1_md(p.m1_dims, p.m1_dt, p.m1_strides);
-  dnnl::memory::desc m2_md(p.m2_dims, p.m2_dt, p.m2_strides);
-  dnnl::memory::desc dst_md(p.dst_dims, p.dst_dt, p.dst_strides);
+  dnnl::memory::desc m1_md(m1_dims, m1_dt, m1_strides);
+  dnnl::memory::desc m2_md(m2_dims, m2_dt, m2_strides);
+  dnnl::memory::desc dst_md(dst_dims, dst_dt, dst_strides);
 
   // STEP2: creat attribute
   dnnl::primitive_attr pattr;
   pattr.set_post_ops(po);
 
 #if ONEDNN_SUPPORT_DETERMINISTIC
-  if (p.deterministic) {
+  if (deterministic) {
     pattr.set_deterministic(true);
   }
 #endif
@@ -132,8 +156,8 @@ FpMatmulCacheValue make_fpmatmul_cached_primitive(
   // scratchpad
   pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-  if (p.m1_dt == dnnl::memory::data_type::f32) {
-    if (p.allow_tf32_oneapi) {
+  if (m1_dt == dnnl::memory::data_type::f32) {
+    if (allow_tf32_oneapi) {
       pattr.set_fpmath_mode(dnnl::fpmath_mode::tf32);
     } else {
       pattr.set_fpmath_mode(dnnl::fpmath_mode::strict);
@@ -142,29 +166,32 @@ FpMatmulCacheValue make_fpmatmul_cached_primitive(
 
   // STEP3: create primitive
   dnnl::matmul::primitive_desc matmul_pd =
-      p.with_bias ? dnnl::matmul::primitive_desc(
-                        p.engine,
+      with_bias ? dnnl::matmul::primitive_desc(
+                        engine,
                         m1_md,
                         m2_md,
                         dnnl::memory::desc(
-                            p.bias_dims, p.bias_dt, p.bias_strides),
+                            bias_dims, bias_dt, bias_strides),
                         dst_md,
                         pattr)
                   : dnnl::matmul::primitive_desc(
-                        p.engine, m1_md, m2_md, dst_md, pattr);
+                        engine, m1_md, m2_md, dst_md, pattr);
 
   return std::make_shared<FpMatmulCachedPrimitive>(std::move(matmul_pd));
 }
 
+template <typename... Args>
 FpMatmulCacheValue lookup_or_build_fpmatmul_cached_primitive(
     FpMatmulLruCache& primitive_cache,
-    FpMatmulPrimitiveCacheParams& params) {
-  dnnl::memory::dims cache_key = build_fpmatmul_primitive_cache_key(params);
+    Args&&... args) {
+  dnnl::memory::dims cache_key = build_fpmatmul_primitive_cache_key(
+      std::forward<Args>(args)...);
   auto cache_it = primitive_cache.find(cache_key);
   if (cache_it != primitive_cache.end()) {
     return cache_it->second;
   }
-  FpMatmulCacheValue entry = make_fpmatmul_cached_primitive(params);
+  FpMatmulCacheValue entry =
+      make_fpmatmul_cached_primitive(std::forward<Args>(args)...);
   primitive_cache.insert({std::move(cache_key), entry});
   return entry;
 }
@@ -336,8 +363,11 @@ sycl::event matmul(
       m1_dt == dnnl::memory::data_type::f32 &&
       at::globalContext().allowTF32OneDNN();
 
-  FpMatmulPrimitiveCacheParams cache_params{
-      c10::xpu::current_device(),
+  const int device_id = c10::xpu::current_device();
+  auto& primitive_cache = get_fpmatmul_primitive_cache(device_id);
+  FpMatmulCacheValue entry = lookup_or_build_fpmatmul_cached_primitive(
+      primitive_cache,
+      device_id,
       dims,
       m,
       n,
@@ -364,13 +394,7 @@ sycl::event matmul(
       allow_tf32_oneapi,
       attr,
       engine,
-      dst,
-  };
-
-  auto& primitive_cache =
-      get_fpmatmul_primitive_cache(cache_params.device_id);
-  FpMatmulCacheValue entry = lookup_or_build_fpmatmul_cached_primitive(
-      primitive_cache, cache_params);
+      dst);
 
   // STEP4: create memory
   dnnl::memory::desc m1_usr_md(m1_dims, m1_usr_dt, m1_strides);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -1,16 +1,105 @@
-
 #include <c10/xpu/XPUFunctions.h>
 
 #include <ATen/ATen.h>
-#include <ATen/record_function.h>
 
 #include <Attr.h>
+#include <ATen/native/mkldnn/xpu/detail/DnnlExt.h>
 #include <Utils.h>
 
 #include <c10/core/ScalarType.h>
+#include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
+#include <unordered_map>
 
 namespace at::native::onednn {
+
+namespace {
+
+using dim_t = dnnl::memory::dim;
+
+constexpr int64_t kFpMatmulPrimitiveCacheKeyVersion = 1;
+constexpr size_t kFpMatmulPrimitiveCacheCapacity = 512;
+
+struct FpMatmulCachedPrimitive {
+  dnnl::matmul::primitive_desc pd;
+  primitive_ext prim;
+
+  explicit FpMatmulCachedPrimitive(dnnl::matmul::primitive_desc&& p)
+      : pd(std::move(p)), prim(dnnl::matmul(pd)) {}
+};
+
+using FpMatmulCacheValue = std::shared_ptr<FpMatmulCachedPrimitive>;
+using FpMatmulLruCache = lru_cache<dnnl::memory::dims, FpMatmulCacheValue>;
+
+FpMatmulLruCache& get_fpmatmul_primitive_cache(int device_id) {
+  static thread_local std::unordered_map<int, FpMatmulLruCache> caches;
+  auto [it, _] = caches.try_emplace(device_id, FpMatmulLruCache());
+  auto& c = it->second;
+  if (c.max_size() == 0) {
+    c.resize(kFpMatmulPrimitiveCacheCapacity);
+  }
+  return c;
+}
+
+dnnl::memory::dims build_fpmatmul_primitive_cache_key(
+    int device_id,
+    int64_t rank,
+    int64_t m,
+    int64_t n,
+    int64_t k,
+    int64_t mb,
+    const dnnl::memory::dims& m1_strides,
+    const dnnl::memory::dims& m2_strides,
+    const dnnl::memory::dims& dst_strides,
+    dnnl::memory::data_type m1_usr_dt,
+    dnnl::memory::data_type m2_usr_dt,
+    dnnl::memory::data_type dst_usr_dt,
+    dnnl::memory::data_type m1_dt,
+    dnnl::memory::data_type m2_dt,
+    dnnl::memory::data_type dst_dt,
+    bool m2_trans,
+    bool with_bias,
+    const dnnl::memory::dims& bias_dims,
+    dnnl::memory::data_type bias_dt,
+    const dnnl::memory::dims& bias_strides,
+    bool deterministic,
+    bool allow_tf32_oneapi,
+    const Attr& attr) {
+  dnnl::memory::dims key;
+  auto append_dims = [&](const dnnl::memory::dims& d) {
+    key.insert(key.end(), d.begin(), d.end());
+  };
+
+  key.push_back(kFpMatmulPrimitiveCacheKeyVersion);
+  key.push_back(static_cast<dim_t>(device_id));
+  key.push_back(rank);
+  key.push_back(m);
+  key.push_back(n);
+  key.push_back(k);
+  key.push_back(mb);
+  append_dims(m1_strides);
+  append_dims(m2_strides);
+  append_dims(dst_strides);
+  key.push_back(static_cast<dim_t>(static_cast<int>(m1_usr_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(m2_usr_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(dst_usr_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(m1_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(m2_dt)));
+  key.push_back(static_cast<dim_t>(static_cast<int>(dst_dt)));
+  key.push_back(m2_trans ? 1 : 0);
+  key.push_back(with_bias ? 1 : 0);
+  if (with_bias) {
+    append_dims(bias_dims);
+    key.push_back(static_cast<dim_t>(static_cast<int>(bias_dt)));
+    append_dims(bias_strides);
+  }
+  key.push_back(deterministic ? 1 : 0);
+  key.push_back(allow_tf32_oneapi ? 1 : 0);
+  append_dims(attr.matmul_primitive_cache_key_extra());
+  return key;
+}
+
+} // namespace
 
 sycl::event matmul(
     at::Tensor& result,
@@ -120,12 +209,7 @@ sycl::event matmul(
   auto m1_dt = m1_usr_dt;
   auto m2_dt = m2_usr_dt;
   auto dst_dt = dst_usr_dt;
-  dnnl::memory::data_type bias_dt;
-
-  dnnl::memory::desc m1_md, m1_usr_md, m1_any_md;
-  dnnl::memory::desc m2_md, m2_usr_md, m2_any_md;
-  dnnl::memory::desc dst_md, dst_usr_md, dst_any_md;
-  dnnl::memory::desc bias_md;
+  dnnl::memory::data_type bias_dt = dnnl::memory::data_type::undef;
 
   // Naive Master weight
   if (m1_dt == dnnl::memory::data_type::bf16 &&
@@ -173,89 +257,128 @@ sycl::event matmul(
     bias_strides = get_onednn_strides(b);
   }
 
-  dnnl::post_ops po = attr.extract_post_ops(dst);
+  bool deterministic = false;
+#if ONEDNN_SUPPORT_DETERMINISTIC
+  deterministic = at::globalContext().deterministicAlgorithms() ||
+      at::globalContext().deterministicMkldnn();
+#endif
+  const bool allow_tf32_oneapi =
+      m1_dt == dnnl::memory::data_type::f32 &&
+      at::globalContext().allowTF32OneDNN();
 
-  std::unordered_map<int, dnnl::memory> args;
-  dnnl::matmul matmul_p;
-  dnnl::matmul::primitive_desc matmul_pd;
+  const int device_id = c10::xpu::current_device();
+  dnnl::memory::dims cache_key = build_fpmatmul_primitive_cache_key(
+      device_id,
+      dims,
+      m,
+      n,
+      k,
+      mb,
+      m1_strides,
+      m2_strides,
+      dst_strides,
+      m1_usr_dt,
+      m2_usr_dt,
+      dst_usr_dt,
+      m1_dt,
+      m2_dt,
+      dst_dt,
+      m2_trans,
+      with_bias,
+      bias_dims,
+      bias_dt,
+      bias_strides,
+      deterministic,
+      allow_tf32_oneapi,
+      attr);
 
-  // STEP1: create memory desc
-  m1_md = dnnl::memory::desc(m1_dims, m1_dt, m1_strides);
-  m2_md = dnnl::memory::desc(m2_dims, m2_dt, m2_strides);
-  dst_md = dnnl::memory::desc(dst_dims, dst_dt, dst_strides);
+  auto& primitive_cache = get_fpmatmul_primitive_cache(device_id);
+  auto cache_it = primitive_cache.find(cache_key);
+  FpMatmulCacheValue entry;
+  if (cache_it != primitive_cache.end()) {
+    entry = cache_it->second;
+  } else {
+    dnnl::post_ops po = attr.extract_post_ops(dst);
 
-  // STEP2: creat attribute
-  dnnl::primitive_attr pattr;
-  pattr.set_post_ops(po);
+    // STEP1: create memory desc
+    dnnl::memory::desc m1_md(m1_dims, m1_dt, m1_strides);
+    dnnl::memory::desc m2_md(m2_dims, m2_dt, m2_strides);
+    dnnl::memory::desc dst_md(dst_dims, dst_dt, dst_strides);
+
+    // STEP2: creat attribute
+    dnnl::primitive_attr pattr;
+    pattr.set_post_ops(po);
 
 #if ONEDNN_SUPPORT_DETERMINISTIC
-  if (at::globalContext().deterministicAlgorithms() ||
-      at::globalContext().deterministicMkldnn())
-    pattr.set_deterministic(true);
+    if (deterministic) {
+      pattr.set_deterministic(true);
+    }
 #endif
 
-  // scratchpad
-  pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    // scratchpad
+    pattr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-  if (m1_dt == dnnl::memory::data_type::f32) {
-    bool allow_tf32 = at::globalContext().allowTF32OneDNN();
-    if (allow_tf32) {
-      pattr.set_fpmath_mode(dnnl::fpmath_mode::tf32);
-    } else {
-      pattr.set_fpmath_mode(dnnl::fpmath_mode::strict);
+    if (m1_dt == dnnl::memory::data_type::f32) {
+      if (allow_tf32_oneapi) {
+        pattr.set_fpmath_mode(dnnl::fpmath_mode::tf32);
+      } else {
+        pattr.set_fpmath_mode(dnnl::fpmath_mode::strict);
+      }
     }
+
+    // STEP3: create primitive
+    dnnl::matmul::primitive_desc matmul_pd =
+        with_bias
+        ? dnnl::matmul::primitive_desc(
+              engine,
+              m1_md,
+              m2_md,
+              dnnl::memory::desc(bias_dims, bias_dt, bias_strides),
+              dst_md,
+              pattr)
+        : dnnl::matmul::primitive_desc(
+              engine, m1_md, m2_md, dst_md, pattr);
+
+    entry = std::make_shared<FpMatmulCachedPrimitive>(std::move(matmul_pd));
+    primitive_cache.insert({cache_key, entry});
   }
-
-  // STEP3: create primitive
-  if (with_bias) {
-    bias_md = dnnl::memory::desc(bias_dims, bias_dt, bias_strides);
-    matmul_pd = dnnl::matmul::primitive_desc(
-        engine, m1_md, m2_md, bias_md, dst_md, pattr);
-  } else {
-    matmul_pd =
-        dnnl::matmul::primitive_desc(engine, m1_md, m2_md, dst_md, pattr);
-  }
-
-  matmul_p = dnnl::matmul(matmul_pd);
-
-  m1_usr_md = dnnl::memory::desc(m1_dims, m1_usr_dt, m1_strides);
-  m2_usr_md = dnnl::memory::desc(m2_dims, m2_usr_dt, m2_strides);
-  dst_usr_md = dnnl::memory::desc(dst_dims, dst_usr_dt, dst_strides);
 
   // STEP4: create memory
+  dnnl::memory::desc m1_usr_md(m1_dims, m1_usr_dt, m1_strides);
+  dnnl::memory::desc m2_usr_md(m2_dims, m2_usr_dt, m2_strides);
+  dnnl::memory::desc dst_usr_md(dst_dims, dst_usr_dt, dst_strides);
+
   auto m1_usr_m = make_onednn_memory(m1_usr_md, engine, m1.data_ptr());
   auto m2_usr_m = make_onednn_memory(m2_usr_md, engine, m2.data_ptr());
   auto dst_usr_m = make_onednn_memory(dst_usr_md, engine, dst.data_ptr());
 
-  auto expected_m1_md = matmul_pd.src_desc();
-  auto expected_m2_md = matmul_pd.weights_desc();
-  auto expected_dst_md = matmul_pd.dst_desc();
-
   dnnl::memory m1_m = m1_usr_m, m2_m = m2_usr_m, dst_m = dst_usr_m;
-  at::Tensor m1_, m2_, dst_;
 
-  if (attr.with_binary())
-    attr.construct_post_binary(matmul_pd, args);
+  std::unordered_map<int, dnnl::memory> args;
+  if (attr.with_binary()) {
+    attr.construct_post_binary(entry->pd, args);
+  }
 
-  size_t scratchpad_size = matmul_pd.scratchpad_desc().get_size();
+  const size_t scratchpad_size = entry->pd.scratchpad_desc().get_size();
   at::Tensor scratchpad_tensor = at::empty(
       {static_cast<int64_t>(scratchpad_size)},
       m1.options().dtype(at::kByte),
       std::nullopt);
   auto scratchpad_memory = make_onednn_memory(
-      matmul_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
+      entry->pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
   args.insert({DNNL_ARG_SCRATCHPAD, scratchpad_memory});
 
   args.insert({DNNL_ARG_SRC, m1_m});
   args.insert({DNNL_ARG_WEIGHTS, m2_m});
   args.insert({DNNL_ARG_DST, dst_m});
   if (with_bias) {
+    dnnl::memory::desc bias_md(bias_dims, bias_dt, bias_strides);
     auto bias_m = make_onednn_memory(bias_md, engine, b.data_ptr());
     args.insert({DNNL_ARG_BIAS, bias_m});
   }
 
   sycl::event matmul_event =
-      dnnl::sycl_interop::execute(matmul_p, stream, args, deps);
+      dnnl::sycl_interop::execute(entry->prim, stream, args, deps);
 
   if (!dst.is_same(result))
     result.copy_(dst);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -117,7 +117,7 @@ FpMatmulCacheValue make_fpmatmul_cached_primitive(
     Attr& attr,
     dnnl::engine& engine,
     const at::Tensor& dst) {
-  dnnl::post_ops po = attr.extract_post_ops(dst);
+  dnnl::post_ops po = attr.extract_post_ops();
 
   // STEP1: create memory desc
   dnnl::memory::desc m1_md(m1_dims, m1_dt, m1_strides);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -41,8 +41,8 @@ FpMatmulLruCache& get_fpmatmul_primitive_cache(int device_id) {
   return c;
 }
 
-// Bias fields as one key part so build_fpmatmul_primitive_cache_key_rec stays
-// in sync with make_fpmatmul_cached_primitive's single variadic forward.
+// Bias-related key fields as one unit for build_fpmatmul_primitive_cache_key_rec
+// and make_fpmatmul_cached_primitive (engine / dst are not part of the cache key).
 struct FpMatmulCacheBiasKeyParts {
   bool with_bias;
   const dnnl::memory::dims& bias_dims;
@@ -80,14 +80,6 @@ inline void append_fp_matmul_cache_key_part(dnnl::memory::dims& key, Attr& attr)
   append_fp_matmul_cache_key_part(
       key, attr.matmul_primitive_cache_key_extra());
 }
-
-inline void append_fp_matmul_cache_key_part(
-    dnnl::memory::dims& key,
-    dnnl::engine&) {}
-
-inline void append_fp_matmul_cache_key_part(
-    dnnl::memory::dims& key,
-    const at::Tensor&) {}
 
 void build_fpmatmul_primitive_cache_key_rec(dnnl::memory::dims& /*key*/) {}
 
@@ -172,15 +164,17 @@ FpMatmulCacheValue make_fpmatmul_cached_primitive(
 template <typename... Args>
 FpMatmulCacheValue lookup_or_build_fpmatmul_cached_primitive(
     FpMatmulLruCache& primitive_cache,
-    Args&&... args) {
+    Args&&... args,
+    dnnl::engine& engine,
+    const at::Tensor& dst) {
   dnnl::memory::dims cache_key = build_fpmatmul_primitive_cache_key(
       std::forward<Args>(args)...);
   auto cache_it = primitive_cache.find(cache_key);
   if (cache_it != primitive_cache.end()) {
     return cache_it->second;
   }
-  FpMatmulCacheValue entry =
-      make_fpmatmul_cached_primitive(std::forward<Args>(args)...);
+  FpMatmulCacheValue entry = make_fpmatmul_cached_primitive(
+      std::forward<Args>(args)..., engine, dst);
   primitive_cache.insert({std::move(cache_key), entry});
   return entry;
 }

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -46,14 +46,9 @@ FpMatmulLruCache& get_fpmatmul_primitive_cache(int device_id) {
 // same pack to both so arity/type mismatches fail at compile time.
 dnnl::memory::dims build_fpmatmul_primitive_cache_key(
     int device_id,
-    int64_t rank,
-    int64_t m,
-    int64_t n,
-    int64_t k,
-    int64_t mb,
-    [[maybe_unused]] const dnnl::memory::dims& m1_dims,
-    [[maybe_unused]] const dnnl::memory::dims& m2_dims,
-    [[maybe_unused]] const dnnl::memory::dims& dst_dims,
+    const dnnl::memory::dims& m1_dims,
+    const dnnl::memory::dims& m2_dims,
+    const dnnl::memory::dims& dst_dims,
     const dnnl::memory::dims& m1_strides,
     const dnnl::memory::dims& m2_strides,
     const dnnl::memory::dims& dst_strides,
@@ -80,11 +75,9 @@ dnnl::memory::dims build_fpmatmul_primitive_cache_key(
 
   key.push_back(kFpMatmulPrimitiveCacheKeyVersion);
   key.push_back(static_cast<dim_t>(device_id));
-  key.push_back(rank);
-  key.push_back(m);
-  key.push_back(n);
-  key.push_back(k);
-  key.push_back(mb);
+  append_dims(m1_dims);
+  append_dims(m2_dims);
+  append_dims(dst_dims);
   append_dims(m1_strides);
   append_dims(m2_strides);
   append_dims(dst_strides);
@@ -109,11 +102,6 @@ dnnl::memory::dims build_fpmatmul_primitive_cache_key(
 
 FpMatmulCacheValue make_fpmatmul_cached_primitive(
     [[maybe_unused]] int device_id,
-    [[maybe_unused]] int64_t rank,
-    [[maybe_unused]] int64_t m,
-    [[maybe_unused]] int64_t n,
-    [[maybe_unused]] int64_t k,
-    [[maybe_unused]] int64_t mb,
     const dnnl::memory::dims& m1_dims,
     const dnnl::memory::dims& m2_dims,
     const dnnl::memory::dims& dst_dims,
@@ -368,11 +356,6 @@ sycl::event matmul(
   FpMatmulCacheValue entry = lookup_or_build_fpmatmul_cached_primitive(
       primitive_cache,
       device_id,
-      dims,
-      m,
-      n,
-      k,
-      mb,
       m1_dims,
       m2_dims,
       dst_dims,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -69,7 +69,6 @@ inline void append_fp_matmul_cache_key_part(dnnl::memory::dims& key, bool b) {
 inline void append_fp_matmul_cache_key_part(
     dnnl::memory::dims& key,
     const FpMatmulCacheBiasKeyParts& b) {
-  key.push_back(b.with_bias ? 1 : 0);
   if (b.with_bias) {
     append_fp_matmul_cache_key_part(key, b.bias_dims);
     append_fp_matmul_cache_key_part(key, b.bias_dt);

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -78,7 +78,7 @@ inline void append_fp_matmul_cache_key_part(
 
 inline void append_fp_matmul_cache_key_part(dnnl::memory::dims& key, Attr& attr) {
   append_fp_matmul_cache_key_part(
-      key, attr.matmul_primitive_cache_key_extra());
+      key, attr.get_post_ops_key());
 }
 
 void build_fpmatmul_primitive_cache_key_rec(dnnl::memory::dims& /*key*/) {}

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -45,7 +45,6 @@ FpMatmulLruCache& get_fpmatmul_primitive_cache(int device_id) {
 // build_* and make_* must keep identical parameter lists; lookup forwards the
 // same pack to both so arity/type mismatches fail at compile time.
 dnnl::memory::dims build_fpmatmul_primitive_cache_key(
-    int device_id,
     const dnnl::memory::dims& m1_dims,
     const dnnl::memory::dims& m2_dims,
     const dnnl::memory::dims& dst_dims,
@@ -74,7 +73,6 @@ dnnl::memory::dims build_fpmatmul_primitive_cache_key(
   };
 
   key.push_back(kFpMatmulPrimitiveCacheKeyVersion);
-  key.push_back(static_cast<dim_t>(device_id));
   append_dims(m1_dims);
   append_dims(m2_dims);
   append_dims(dst_dims);
@@ -101,7 +99,6 @@ dnnl::memory::dims build_fpmatmul_primitive_cache_key(
 }
 
 FpMatmulCacheValue make_fpmatmul_cached_primitive(
-    [[maybe_unused]] int device_id,
     const dnnl::memory::dims& m1_dims,
     const dnnl::memory::dims& m2_dims,
     const dnnl::memory::dims& dst_dims,
@@ -355,7 +352,6 @@ sycl::event matmul(
   auto& primitive_cache = get_fpmatmul_primitive_cache(device_id);
   FpMatmulCacheValue entry = lookup_or_build_fpmatmul_cached_primitive(
       primitive_cache,
-      device_id,
       m1_dims,
       m2_dims,
       dst_dims,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -51,9 +51,6 @@ dnnl::memory::dims build_fpmatmul_primitive_cache_key(
     const dnnl::memory::dims& m1_strides,
     const dnnl::memory::dims& m2_strides,
     const dnnl::memory::dims& dst_strides,
-    dnnl::memory::data_type m1_usr_dt,
-    dnnl::memory::data_type m2_usr_dt,
-    dnnl::memory::data_type dst_usr_dt,
     dnnl::memory::data_type m1_dt,
     dnnl::memory::data_type m2_dt,
     dnnl::memory::data_type dst_dt,
@@ -79,9 +76,6 @@ dnnl::memory::dims build_fpmatmul_primitive_cache_key(
   append_dims(m1_strides);
   append_dims(m2_strides);
   append_dims(dst_strides);
-  key.push_back(static_cast<dim_t>(static_cast<int>(m1_usr_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(m2_usr_dt)));
-  key.push_back(static_cast<dim_t>(static_cast<int>(dst_usr_dt)));
   key.push_back(static_cast<dim_t>(static_cast<int>(m1_dt)));
   key.push_back(static_cast<dim_t>(static_cast<int>(m2_dt)));
   key.push_back(static_cast<dim_t>(static_cast<int>(dst_dt)));
@@ -105,9 +99,6 @@ FpMatmulCacheValue make_fpmatmul_cached_primitive(
     const dnnl::memory::dims& m1_strides,
     const dnnl::memory::dims& m2_strides,
     const dnnl::memory::dims& dst_strides,
-    [[maybe_unused]] dnnl::memory::data_type m1_usr_dt,
-    [[maybe_unused]] dnnl::memory::data_type m2_usr_dt,
-    [[maybe_unused]] dnnl::memory::data_type dst_usr_dt,
     dnnl::memory::data_type m1_dt,
     dnnl::memory::data_type m2_dt,
     dnnl::memory::data_type dst_dt,
@@ -358,9 +349,6 @@ sycl::event matmul(
       m1_strides,
       m2_strides,
       dst_strides,
-      m1_usr_dt,
-      m2_usr_dt,
-      dst_usr_dt,
       m1_dt,
       m2_dt,
       dst_dt,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QConv.cpp
@@ -121,7 +121,7 @@ at::Tensor quantized_convolution(
   dnnl::memory::dims _dilation = compatible_dilation(dilation);
   dnnl::post_ops po;
   // extract post ops
-  po = attr.extract_post_ops(output);
+  po = attr.extract_post_ops();
   int mask_ac = 0, mask_weight;
   // [Note: Per-channel quantization mask setting]
   // Per-channel quantization is on weight output channel mostly, mask_weight=

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -211,7 +211,7 @@ void quantized_matmul(
   std::unordered_map<int, dnnl::memory> args;
 
   dnnl::post_ops po;
-  po = attr.extract_post_ops(dst);
+  po = attr.extract_post_ops();
   bool m1_need_zp = (input_zero_point != 0);
   bool dst_need_zp = (output_zero_point != 0);
   bool wgh_is_per_channel = weight_scales.numel() > 1;

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -3095,6 +3095,41 @@ class TestMemPool(TestCase):
         self.assertTrue(after_pool_release < peak_reserved)
         self.assertTrue(after_pool_release > 0)
 
+    def test_onednn_matmul_primitive_cache_repeated_mm(self):
+        for dtype in (torch.float32, torch.bfloat16):
+            m, n, k = 32, 48, 64
+            a = torch.randn(m, k, device="xpu", dtype=dtype)
+            b = torch.randn(k, n, device="xpu", dtype=dtype)
+            ref = torch.mm(a.cpu(), b.cpu())
+            for _ in range(30):
+                out = torch.mm(a, b)
+                self.assertEqual(out.cpu(), ref)
+
+    def test_onednn_matmul_primitive_cache_bmm_addmm(self):
+        dtype = torch.bfloat16
+        batch, m, n, k = 4, 16, 24, 32
+        a = torch.randn(batch, m, k, device="xpu", dtype=dtype)
+        b = torch.randn(batch, k, n, device="xpu", dtype=dtype)
+        ref_bmm = torch.bmm(a.cpu(), b.cpu())
+        for _ in range(15):
+            self.assertEqual(torch.bmm(a, b).cpu(), ref_bmm)
+        x = torch.randn(m, k, device="xpu", dtype=dtype)
+        y = torch.randn(k, n, device="xpu", dtype=dtype)
+        bias = torch.randn(n, device="xpu", dtype=dtype)
+        ref_addmm = torch.addmm(bias.cpu(), x.cpu(), y.cpu())
+        for _ in range(15):
+            self.assertEqual(torch.addmm(bias, x, y).cpu(), ref_addmm)
+
+    def test_onednn_matmul_primitive_cache_addmm_beta_zero(self):
+        x = torch.randn(10, 30, device="xpu", dtype=torch.float32)
+        y = torch.randn(30, 20, device="xpu", dtype=torch.float32)
+        z = torch.randn(10, 20, device="xpu", dtype=torch.float32)
+        ref_cpu = torch.addmm(z.cpu(), x.cpu(), y.cpu(), beta=0.0, alpha=1.0)
+        for _ in range(20):
+            self.assertEqual(
+                torch.addmm(z, x, y, beta=0.0, alpha=1.0).cpu(), ref_cpu
+            )
+
 
 instantiate_parametrized_tests(TestXpu)
 instantiate_parametrized_tests(TestCachingHostAllocatorXpuGraph)


### PR DESCRIPTION
## Summary
Introduces **thread-local LRU caching** for oneDNN **FP matmul** primitives on XPU (keyed by shapes, strides, dtypes, bias, flags, and fused post-op fingerprint) and a **second thread-local LRU** that reuses identical **`dnnl::post_ops`** built from `Attr`. Refactors **`Attr`** so post-op emission and cache keys share one code path via **`get_post_ops_key()`**, used both by the matmul primitive cache and **`extract_post_ops()`**.
Extends **`lru_cache`** with **`find()`** and fixes **rvalue `insert`** so the map is keyed from the list node after `std::move` of the pair. Adds **XPU tests** that repeatedly run `mm` / `bmm` / `addmm` to exercise cache hits.

## Motivation
- Rebuilding matmul `primitive_desc` and `dnnl::post_ops` on every call is wasteful for hot shapes and repeated fusion configs.
- A single, explicit serialization for “what post-ops mean” avoids drift between LRU keys and actual `post_ops` emission.
## What changed (high level)
### `Matmul.cpp`
- **TLS LRU** per **device id** (`std::unordered_map<int, …>`), capacity **512** (lazy resize).
- Cached value: `shared_ptr` with `dnnl::matmul::primitive_desc` + `primitive_ext`.
- **Variadic** `build_fpmatmul_primitive_cache_key` / `append_fp_matmul_cache_key_part` overloads so new key pieces are added deliberately.
- **`lookup_or_build_fpmatmul_cached_primitive`**: one `insert` + branch on miss (no double lookup).
- Matmul cache key includes **`attr.get_post_ops_key()`** (post-op fingerprint only; no separate version tag / redundant user dtypes / `m2_trans` where removed in the series).
### `Attr.h`
- **`PostOpsMatmulKeySink`**: encodes fused post-ops into `dnnl::memory::dims` (binary via `memory_desc` blob packing).
- **`emit_post_ops_for_matmul_cache_and_dnnl`**: shared loop for **`dnnl::post_ops`** and key sink; `fp_matmul_post_sink_push_kind` is no-op for `dnnl::post_ops`, records `kind_t` for the key sink.
- **`get_post_ops_key()`**: single implementation of that fingerprint.
- **`extract_post_ops()`**: `cache_key = get_post_ops_key()` → **`find`** on TLS LRU → on miss one default `dnnl::post_ops`, emit, **`insert`** moved key/value (no empty `post_ops` in `insert`).
- **Simplified matmul key**: removed unused prefix fields from the old `matmul_primitive_cache_key_extra`; accessors **`q_scale()`** / **`q_zero_point()`** preserve API for `Attr(float, zp)` (e.g. QMatmul/QConv).
### `LRUCache.h`
- **`find(key)`** with LRU splice-to-front.
- **`insert(value_type&&)`**: index map with **`vlist_.begin()->first`** after move.
### Call sites
- Minor signature / include updates in **Conv / Deconv / QConv / QMatmul** as needed for refactors.
### `test/test_xpu.py`
- `test_onednn_matmul_primitive_cache_repeated_mm`
- `test_onednn_matmul_primitive_cache_bmm_addmm`
- `test_onednn_matmul_primitive_cache_addmm_beta_zero`
## How to review (suggested order)
1. `Matmul.cpp` — cache key composition, lookup/build, TLS map.
2. `Attr.h` — `get_post_ops_key` / `extract_post_ops` / emit path, binary key correctness.
3. `LRUCache.h` — `find` + move-safe `insert`.
4. `test_xpu.py` — smoke tests for repeated matmul-family ops.
## Testing
```bash
python test/test_xpu.py TestXpu.test_onednn_matmul_primitive_cache_repeated_mm
python test/test_xpu.py TestXpu.test_onednn_matmul_primitive_cache_bmm_addmm
python test/test_xpu.py TestXpu.test_onednn_matmul_primitive_cache_addmm_beta_zero
```

## Relation to existing code (not a new pattern)
This follows the same approach already used for Intel XPU oneDNN matmul in the tree below, so the change is **aligning the eager FP matmul path with an established, in-repo XPU pattern**, not introducing a novel caching design.
In `aten/src/ATen/native/mkldnn/xpu/detail/DnnlExt.h`, `matmul_primitive_cache_t` caches `dnnl::matmul` as `primitive_ext` in `at::native::onednn::lru_cache<dnnl::memory::dims, primitive_ext>`, with a **thread-local** cache indexed by **device id** and **capacity 512** (see `max_cache_capacity` and `get_cache` there; storage is a fixed `std::array` of per-device caches). That path is exercised by weight-only quantized matmul, e.g. `WoQMatmul.cpp` via `matmul_primitive_create_and_cache`.
This PR **extends that idea to the general floating-point matmul** implementation in `Matmul.cpp` (`mm` / `bmm` / `addmm` style paths with full `Attr` fusion). It reuses the same `lru_cache` helper from `LRUCache.h`, the same **512** entry cap, and the same **build on miss / reuse on hit** split. Storage is **thread-local** and **per device id** as well; the implementation uses a `thread_local` `std::unordered_map<int, …>` instead of the WoQ helper’s fixed array, so it is not limited to 16 device slots.
The cache key is richer because this entry point supports arbitrary ranks, layouts, dtypes, bias, deterministic / TF32 flags, and fused post-ops—hence variadic `build_fpmatmul_primitive_cache_key` / `append_fp_matmul_cache_key_part`, the post-op fingerprint from **`Attr::get_post_ops_key()`** (shared with `extract_post_ops()`), and caching a small handle object that holds **`dnnl::matmul::primitive_desc` plus a `primitive_ext`** built from it so execution still uses a stable primitive.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01