### PR TITLE
[Inductor][CPP] Fix check_bounds for inductor cpp backend

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -4438,6 +4438,92 @@ class CPUReproTests(TestCase):
             res2 = jit_func(x)
         self.assertEqual(res1, res2)
 
+    def test_sdpa_closure_mask_recompile(self):
+        # Regression test for closure-composed attention masks on CPU Inductor.
+        def causal_fn(b, h, q, kv):
+            return kv <= q
+
+        def padding_fn(padding_mask):
+            def inner(b, h, q, kv):
+                return padding_mask[b, kv]
+
+            return inner
+
+        def and_masks(f1, f2):
+            def combined(b, h, q, kv):
+                return f1(b, h, q, kv) & f2(b, h, q, kv)
+
+            return combined
+
+        def make_mask_closure(batch_size, q_len, kv_len, q_offset, padding_mask):
+            fn = and_masks(causal_fn, padding_fn(padding_mask))
+            b = torch.arange(batch_size)[:, None, None, None]
+            h = torch.arange(1)[None, :, None, None]
+            q = (torch.arange(q_len) + q_offset)[None, None, :, None]
+            kv = torch.arange(kv_len)[None, None, None, :]
+            return fn(b, h, q, kv).expand(batch_size, 1, q_len, kv_len)
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj = torch.nn.Linear(32, 32, bias=False)
+
+            def forward(self, x, past_k, past_v, padding_mask, q_offset):
+                B, S, _ = x.shape
+                q = self.proj(x).view(B, S, 4, 8).transpose(1, 2)
+                k = x.view(B, S, 4, 8).transpose(1, 2)
+                v = k.clone()
+                if past_k is not None:
+                    k = torch.cat([past_k, k], dim=2)
+                    v = torch.cat([past_v, v], dim=2)
+
+                mask = make_mask_closure(B, S, k.shape[2], q_offset, padding_mask)
+                out = F.scaled_dot_product_attention(q, k, v, attn_mask=mask)
+                return out.transpose(1, 2).reshape(B, S, 32), k, v
+
+        torch._dynamo.reset()
+        torch.manual_seed(0)
+
+        eager_model = Model().eval()
+        compiled_model = Model().eval()
+        compiled_model.load_state_dict(eager_model.state_dict())
+        compiled = torch.compile(compiled_model, backend="inductor")
+
+        pad_mask = torch.ones(1, 8, dtype=torch.bool)
+        pad_mask[0, :2] = False
+
+        # Prefill: seq_len=8
+        x = torch.randn(1, 8, 32)
+        with torch.no_grad():
+            ref_out, ref_k, ref_v = eager_model(x, None, None, pad_mask, q_offset=0)
+            out, k, v = compiled(x, None, None, pad_mask, q_offset=0)
+        torch.testing.assert_close(out, ref_out)
+        torch.testing.assert_close(k, ref_k)
+        torch.testing.assert_close(v, ref_v)
+
+        # Decode: seq_len=1 and kv grows, which exercises recompilation.
+        for _ in range(3):
+            pad_mask = torch.cat([pad_mask, torch.ones(1, 1, dtype=torch.bool)], dim=1)
+            x = torch.randn(1, 1, 32)
+            with torch.no_grad():
+                ref_out, ref_k, ref_v = eager_model(
+                    x,
+                    ref_k,
+                    ref_v,
+                    pad_mask,
+                    q_offset=ref_k.shape[2],
+                )
+                out, k, v = compiled(
+                    x,
+                    k,
+                    v,
+                    pad_mask,
+                    q_offset=k.shape[2],
+                )
+            torch.testing.assert_close(out, ref_out)
+            torch.testing.assert_close(k, ref_k)
+            torch.testing.assert_close(v, ref_v)
+
     def test_scalar_mul_bfloat16(self):
         def f(x):
             return torch.ops.aten.mul.Tensor(x, 1.7015043497085571)

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2187,14 +2187,25 @@ class CppKernel(Kernel):
             csevar = ops.index_expr(expr, torch.int64).value
             buffer = V.kernel.compute
         else:
-            # indexing in loads
-            prior_compute = V.kernel.compute
-            try:
-                V.kernel.compute = self.loads
+            # Prefer to put the assert in loads so it runs before the actual
+            # memory access.  However, if the index expression may have already
+            # been CSE'd into compute by a prior ops.index_expr call, placing a
+            # reference to it in loads would be a forward reference (loads are
+            # emitted before compute in the kernel body).  In that case fall
+            # back to compute.
+            idx_str = cexpr(self.rename_indexing(expr))
+            if self.cse.try_get(idx_str) is not None:
+                # Already defined in compute; assert must go in compute too.
                 csevar = ops.index_expr(expr, torch.int64).value
-            finally:
-                V.kernel.compute = prior_compute
-            buffer = self.loads
+                buffer = V.kernel.compute
+            else:
+                prior_compute = V.kernel.compute
+                try:
+                    V.kernel.compute = self.loads
+                    csevar = ops.index_expr(expr, torch.int64).value
+                finally:
+                    V.kernel.compute = prior_compute
+                buffer = self.loads
 
         size_str = V.kernel.sexpr(self.rename_indexing(size)) if upper else None
 

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -2195,7 +2195,6 @@ class CppKernel(Kernel):
             # back to compute.
             idx_str = cexpr(self.rename_indexing(expr))
             if self.cse.try_get(idx_str) is not None:
-                # Already defined in compute; assert must go in compute too.
                 csevar = ops.index_expr(expr, torch.int64).value
                 buffer = V.kernel.compute
             else:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/178244.

The node `check_bounds` is prefer to put index expression bound checks in `loads` so it runs before the memory access on CPP backend.
However, if the index expression may have already been CSE'd into `compute` by a prior `ops.index_expr` call, placing a reference to it in loads would be a forward reference, for example:
```
...
TORCH_CHECK((at::vec::VecMask<int64_t,2>::set(at::vec::VecMask<int64_t,2>::from(1), (at::vec::VecMask<int64_t,2>(tmp2 < at::vec::VectorizedN<int64_t,2>(ks1))), static_cast<int64_t>(9L))).all_masked(), "index out of bounds: tmp2 < ks1");
auto tmp8 = at::vec::VecMask<float,1>::from(in_ptr3 + static_cast<int64_t>(x0), static_cast<int64_t>(9L));
auto tmp0 = x0;
auto tmp1 = c10::convert<int64_t>(tmp0);
auto tmp2 = at::vec::VectorizedN<int64_t,2>::arange(tmp1, 1);
...
```
In that case, tmp2 is referenced but not defined yet, and we need to put bound checks to `compute`:
```
...
auto tmp8 = at::vec::VecMask<float,1>::from(in_ptr3 + static_cast<int64_t>(x0), static_cast<int64_t>(9L));
auto tmp0 = x0;
auto tmp1 = c10::convert<int64_t>(tmp0);
auto tmp2 = at::vec::VectorizedN<int64_t,2>::arange(tmp1, 1);
auto tmp3 = ks0;
auto tmp4 = c10::convert<int64_t>(tmp3);
auto tmp5 = at::vec::VectorizedN<int64_t,2>(tmp4);
auto tmp6 = at::vec::VecMask<int64_t,2>(tmp2 <= tmp5);
TORCH_CHECK((at::vec::VecMask<int64_t,2>::set(at::vec::VecMask<int64_t,2>::from(1), (at::vec::VecMask<int64_t,2>(tmp2 < at::vec::VectorizedN<int64_t,2>(ks1))), static_cast<int64_t>(9L))).all_masked(), "index out of bounds: tmp2 < ks1");
...
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo