### PR TITLE
fix: aten.quantize_per_tensor isn't a MKLDNN-specific operator

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2938,12 +2938,6 @@ if torch._C._has_mkldnn:
         "quantized", "IMPL", "Meta"
     )
 
-    @register_meta(aten.quantize_per_tensor)
-    def meta_quantize_per_tensor(
-        input: torch.Tensor, scale: float, zero_point: int, dtype: torch.dtype
-    ) -> torch.Tensor:
-        return torch.empty_like(input)
-
     @register_meta(torch.ops.quantized.max_pool2d)
     def meta_quantized_max_pool2d(
         input,
@@ -3002,6 +2996,14 @@ def check_dim_size(tensor, dim, dim_size, size):
         lambda: f"Expected a tensor of dimension {dim} and tensor.size[{dim_size}] == {size}, "
         + f"but got : dimension {tensor.dim()} and tensor.size[{dim_size}] = {tensor.shape[dim_size]}",
     )
+
+
+@register_meta(aten.quantize_per_tensor)
+def meta_quantize_per_tensor(
+    input: torch.Tensor, scale: float, zero_point: int, dtype: torch.dtype
+) -> torch.Tensor:
+    print(f"meta_quantize_per_tensor: {input.dtype}")
+    return torch.empty_like(input)
 
 
 @register_meta(aten.avg_pool2d.default)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3002,7 +3002,6 @@ def check_dim_size(tensor, dim, dim_size, size):
 def meta_quantize_per_tensor(
     input: torch.Tensor, scale: float, zero_point: int, dtype: torch.dtype
 ) -> torch.Tensor:
-    print(f"meta_quantize_per_tensor: {input.dtype}")
     return torch.empty_like(input)
 
 


### PR DESCRIPTION
`aten.quantize_per_tensor` is a base operator in the aten namespace, not an MKLDNN-specific one. The meta-tensor support should not be conditional on whether the MKLDNN backend is enabled in the build.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98