### PR TITLE
Enable ACL operator fusions for aarch64

### DIFF
--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -1565,19 +1565,18 @@ if torch._C._has_mkldnn:
 
     @functools.cache
     def _mkldnn_fusion_init():
-        # TODO: aarch64: enable op fusion for acl once it supports fused operators. Disabling it for now.
-        # Otherwise even the matmul or innerproduct can not be accelerated with acl
         if (
             not torch.backends.mkldnn.enabled
             or not torch.backends.mkldnn.is_available()
         ):
             return
 
+        _register_unary_fusion()
+        _register_binary_fusion()
+        _register_binary_unary_fusion()
+        _register_inplace_fusion()
+
         if not torch.ops.mkldnn._is_mkldnn_acl_supported():
-            _register_unary_fusion()
-            _register_inplace_fusion()
-            _register_binary_unary_fusion()
-            _register_binary_fusion()
             _register_quantization_lowerings()
 
         _register_woq_lowerings()


### PR DESCRIPTION
The inductor mkldnn fusion pass previously disabled ALL fusions when ACL was detected as the backend. This was overly conservative -- ACL has supported fused post-ops (relu, tanh, sigmoid, elu, etc.) for a while now.

Changes:
- Register unary, binary, binary+unary, and inplace fusions unconditionally (only quantization lowerings remain ACL-gated)
- All activation fusions including hardswish, swish, and hardsigmoid are now registered on all platforms. ACL natively supports swish via a mapping in oneDNN's acl_utils.cpp convert_to_acl_act()

Impact (with --freezing):
  resnet50:           1.153x -> 1.325x (+15%)
  mobilenet_v2:       1.452x -> 1.698x (+17%)
  mobilenet_v3_large: 1.376x -> 1.644x (+19%)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos