### PR TITLE
[Test] Make dynamo/test_minifier.py device-agnostic for out-of-tree backends

### DIFF
--- a/test/dynamo/test_minifier.py
+++ b/test/dynamo/test_minifier.py
@@ -1,5 +1,4 @@
 # Owner(s): ["module: dynamo"]
-import unittest
 
 import torch._dynamo
 from torch._dynamo.test_minifier_common import MinifierTestBase
@@ -7,13 +6,8 @@ from torch.testing._internal.common_device_type import instantiate_device_type_t
 from torch.testing._internal.common_utils import skipIfNNModuleInlined
 
 
-requires_gpu = unittest.skipUnless(
-    torch.cuda.is_available() or torch.xpu.is_available(), "requires cuda or xpu"
-)
-
-
 class MinifierTests(MinifierTestBase):
-    # Test that compile, runtime, and accuracy errors after dynamo can be repro'd (both CPU and CUDA/XPU)
+    # Test that compile, runtime, and accuracy errors after dynamo can be repro'd
     def _test_after_dynamo(self, device, backend, expected_error):
         run_code = f"""\
 @torch.compile(backend={backend!r})
@@ -25,50 +19,26 @@ def inner(x):
         x = torch.cos(x)
     return x
 
-inner(torch.randn(20, 20).to("{device}"))
+inner(torch.randn(20, 20, device="{device}"))
 """
         self._run_full_test(run_code, "dynamo", expected_error, isolate=False)
 
-    def test_after_dynamo_cpu_compile_error(self):
-        self._test_after_dynamo(
-            "cpu", "relu_compile_error_TESTING_ONLY", "ReluCompileError"
-        )
+    def test_after_dynamo_compile_error(self, device):
+        self._test_after_dynamo(device, "relu_compile_error_TESTING_ONLY", "ReluCompileError")
 
-    def test_after_dynamo_cpu_runtime_error(self):
-        self._test_after_dynamo(
-            "cpu", "relu_runtime_error_TESTING_ONLY", "ReluRuntimeError"
-        )
+    def test_after_dynamo_runtime_error(self, device):
+        self._test_after_dynamo(device, "relu_runtime_error_TESTING_ONLY", "ReluRuntimeError")
 
-    def test_after_dynamo_cpu_accuracy_error(self):
-        self._test_after_dynamo(
-            "cpu", "relu_accuracy_error_TESTING_ONLY", "AccuracyError"
-        )
+    def test_after_dynamo_accuracy_error(self, device):
+        self._test_after_dynamo(device, "relu_accuracy_error_TESTING_ONLY", "AccuracyError")
 
-    @requires_gpu
-    def test_after_dynamo_cuda_compile_error(self, device):
-        self._test_after_dynamo(
-            device, "relu_compile_error_TESTING_ONLY", "ReluCompileError"
-        )
-
-    @requires_gpu
-    def test_after_dynamo_cuda_runtime_error(self, device):
-        self._test_after_dynamo(
-            device, "relu_runtime_error_TESTING_ONLY", "ReluRuntimeError"
-        )
-
-    @requires_gpu
-    def test_after_dynamo_cuda_accuracy_error(self, device):
-        self._test_after_dynamo(
-            device, "relu_accuracy_error_TESTING_ONLY", "AccuracyError"
-        )
-
-    def test_after_dynamo_non_leaf_compile_error(self):
-        run_code = """\
+    def test_after_dynamo_non_leaf_compile_error(self, device):
+        run_code = f"""\
 @torch.compile(backend="non_leaf_compile_error_TESTING_ONLY")
 def inner(x):
     return x + 1
 
-inner(torch.randn(20, 20, requires_grad=True) + 1)
+inner(torch.randn(20, 20, requires_grad=True, device="{device}") + 1)
 """
         self._run_full_test(
             run_code, "dynamo", "TestingOnlyCompileError", isolate=False
@@ -84,44 +54,25 @@ inner(torch.randn(20, 20, requires_grad=True) + 1)
                 x = torch.cos(x)
             return x
 
-        inner(torch.randn(20, 20).to(device))
+        inner(torch.randn(20, 20, device=device))
 
-    def test_after_dynamo_cpu_compile_backend_passes(self):
-        self._test_after_dynamo_backend_passes("cpu", "relu_compile_error_TESTING_ONLY")
+    def test_after_dynamo_compile_backend_passes(self, device):
+        self._test_after_dynamo_backend_passes(device, "relu_compile_error_TESTING_ONLY")
 
-    def test_after_dynamo_cpu_runtime_backend_passes(self):
-        self._test_after_dynamo_backend_passes("cpu", "relu_runtime_error_TESTING_ONLY")
+    def test_after_dynamo_runtime_backend_passes(self, device):
+        self._test_after_dynamo_backend_passes(device, "relu_runtime_error_TESTING_ONLY")
 
-    def test_after_dynamo_cpu_accuracy_backend_passes(self):
-        self._test_after_dynamo_backend_passes(
-            "cpu", "relu_accuracy_error_TESTING_ONLY"
-        )
+    def test_after_dynamo_accuracy_backend_passes(self, device):
+        self._test_after_dynamo_backend_passes(device, "relu_accuracy_error_TESTING_ONLY")
 
-    @requires_gpu
-    def test_after_dynamo_cuda_compile_backend_passes(self, device):
-        self._test_after_dynamo_backend_passes(
-            device, "relu_compile_error_TESTING_ONLY"
-        )
-
-    @requires_gpu
-    def test_after_dynamo_cuda_runtime_backend_passes(self, device):
-        self._test_after_dynamo_backend_passes(
-            device, "relu_runtime_error_TESTING_ONLY"
-        )
-
-    @requires_gpu
-    def test_after_dynamo_cuda_accuracy_backend_passes(self, device):
-        self._test_after_dynamo_backend_passes(
-            device, "relu_accuracy_error_TESTING_ONLY"
-        )
-
-    # Test that a module with mixed cpu/(cuda|xpu) parts with an error after dynamo can be repro'd
+    # Test that a module with mixed cpu/gpu parts with an error after dynamo can be repro'd
     @skipIfNNModuleInlined()
-    @requires_gpu
-    def test_cpu_cuda_module_after_dynamo(self, device):
+    def test_cpu_gpu_module_after_dynamo(self, device):
         backend_name = "relu_compile_error_TESTING_ONLY"
         run_code = f"""\
-class CpuCudaModule(torch.nn.Module):
+device = "{device}"
+
+class CpuGpuModule(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
         self.m_x = torch.nn.Linear(20, 20).to(device)
@@ -134,7 +85,7 @@ class CpuCudaModule(torch.nn.Module):
     def forward(self, x, y):
         return self.m_x(x) + self.p_x + self.b_x, self.m_y(y) + self.p_y + self.b_y
 
-mod = CpuCudaModule()
+mod = CpuGpuModule()
 
 @torch.compile(backend={backend_name!r})
 def inner(x1, y1):
@@ -186,7 +137,7 @@ class Repro(torch.nn.Module):
         )
 
     # Test if we can actually get a minified graph
-    def test_if_graph_minified(self):
+    def test_if_graph_minified(self, device):
         backend_name = "relu_compile_error_TESTING_ONLY"
         run_code = f"""\
 @torch.compile(backend={backend_name!r})
@@ -198,7 +149,7 @@ def inner(x):
         x = torch.cos(x)
     return x
 
-inner(torch.randn(20, 20))
+inner(torch.randn(20, 20, device="{device}"))
 """
 
         res = self._run_full_test(run_code, "dynamo", "ReluCompileError", isolate=False)
@@ -216,10 +167,7 @@ class Repro(torch.nn.Module):
         )
 
 
-devices = ["cuda", "xpu", "cpu"]
-instantiate_device_type_tests(
-    MinifierTests, globals(), only_for=devices, allow_xpu=True
-)
+instantiate_device_type_tests(MinifierTests, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_minifier.py
+++ b/test/dynamo/test_minifier.py
@@ -77,14 +77,14 @@ inner(torch.randn(20, 20, requires_grad=True, device="{device}") + 1)
             device, "relu_accuracy_error_TESTING_ONLY"
         )
 
-    # Test that a module with mixed cpu/gpu parts with an error after dynamo can be repro'd
+    # Test that a module with mixed cpu/device parts  with an error after dynamo can be repro'd
     @skipIfNNModuleInlined()
-    def test_cpu_gpu_module_after_dynamo(self, device):
+    def test_cpu_device_module_after_dynamo(self, device):
         backend_name = "relu_compile_error_TESTING_ONLY"
         run_code = f"""\
 device = "{device}"
 
-class CpuGpuModule(torch.nn.Module):
+class CpuDeviceModule(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
         self.m_x = torch.nn.Linear(20, 20).to(device)
@@ -97,7 +97,7 @@ class CpuGpuModule(torch.nn.Module):
     def forward(self, x, y):
         return self.m_x(x) + self.p_x + self.b_x, self.m_y(y) + self.p_y + self.b_y
 
-mod = CpuGpuModule()
+mod = CpuDeviceModule()
 
 @torch.compile(backend={backend_name!r})
 def inner(x1, y1):

--- a/test/dynamo/test_minifier.py
+++ b/test/dynamo/test_minifier.py
@@ -24,13 +24,19 @@ inner(torch.randn(20, 20, device="{device}"))
         self._run_full_test(run_code, "dynamo", expected_error, isolate=False)
 
     def test_after_dynamo_compile_error(self, device):
-        self._test_after_dynamo(device, "relu_compile_error_TESTING_ONLY", "ReluCompileError")
+        self._test_after_dynamo(
+            device, "relu_compile_error_TESTING_ONLY", "ReluCompileError"
+        )
 
     def test_after_dynamo_runtime_error(self, device):
-        self._test_after_dynamo(device, "relu_runtime_error_TESTING_ONLY", "ReluRuntimeError")
+        self._test_after_dynamo(
+            device, "relu_runtime_error_TESTING_ONLY", "ReluRuntimeError"
+        )
 
     def test_after_dynamo_accuracy_error(self, device):
-        self._test_after_dynamo(device, "relu_accuracy_error_TESTING_ONLY", "AccuracyError")
+        self._test_after_dynamo(
+            device, "relu_accuracy_error_TESTING_ONLY", "AccuracyError"
+        )
 
     def test_after_dynamo_non_leaf_compile_error(self, device):
         run_code = f"""\
@@ -57,13 +63,19 @@ inner(torch.randn(20, 20, requires_grad=True, device="{device}") + 1)
         inner(torch.randn(20, 20, device=device))
 
     def test_after_dynamo_compile_backend_passes(self, device):
-        self._test_after_dynamo_backend_passes(device, "relu_compile_error_TESTING_ONLY")
+        self._test_after_dynamo_backend_passes(
+            device, "relu_compile_error_TESTING_ONLY"
+        )
 
     def test_after_dynamo_runtime_backend_passes(self, device):
-        self._test_after_dynamo_backend_passes(device, "relu_runtime_error_TESTING_ONLY")
+        self._test_after_dynamo_backend_passes(
+            device, "relu_runtime_error_TESTING_ONLY"
+        )
 
     def test_after_dynamo_accuracy_backend_passes(self, device):
-        self._test_after_dynamo_backend_passes(device, "relu_accuracy_error_TESTING_ONLY")
+        self._test_after_dynamo_backend_passes(
+            device, "relu_accuracy_error_TESTING_ONLY"
+        )
 
     # Test that a module with mixed cpu/gpu parts with an error after dynamo can be repro'd
     @skipIfNNModuleInlined()


### PR DESCRIPTION
## Summary

Refactor `test/dynamo/test_minifier.py` to make it fully device-agnostic and support out-of-tree backends (e.g., XPU, privateuse1).

**Changes:**
- Remove `import unittest` and custom `requires_gpu` skip decorator
- Consolidate 12 duplicate test methods (6 hardcoded CPU + 6 `@requires_gpu` GPU) into 9 device-parametrized tests by adding `device` parameter to all test methods
- Fix device scoping bug in `test_cpu_device_module_after_dynamo` by explicitly defining `device = "{device}"` in generated `exec()`'d code
- Remove `only_for=["cuda","xpu","cpu"]` restriction from `instantiate_device_type_tests` to allow third-party accelerators
- Rename `test_cpu_cuda_module` to `test_cpu_device_module` (device-neutral naming)

**Coverage:**
- No test coverage is lost - all original distinct test code paths are preserved
- Two new coverage points gained: `test_after_dynamo_non_leaf_compile_error` and `test_if_graph_minified` now run on GPU (previously CPU-only)
- 30 test instances -> 18 by eliminating duplicate runs (12 tests that ran identically on CPU twice)

**Test results (CUDA machine):**

| | Before | After |
|---|---|---|
| Tests collected | 30 | 18 |
| Passed | 28 | 16 |
| Skipped | 2 | 2 |
| Runtime | 6.38s | 4.95s |

The 2 skips are `test_cpu_device_module_after_dynamo` on both device classes (pre-existing `@skipIfNNModuleInlined`).

## Test plan

- Ran `TEST_CONFIG=cuda python3 test/run_test.py -i dynamo/test_minifier` - all 16 passed, 2 skipped
- Verified CUDA tests genuinely run on CUDA (different RMSE values vs CPU in accuracy tests)
- Verified no hardcoded device strings remain

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @desertfire @williamwen42 @mikaylagawarecki @mansiag05 @fffrog @guilhermeleobas 


