### PR TITLE
[CI] Upgrade py3.14t dynamo_wrapped runners to linux.4xlarge to fix OOM

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -188,9 +188,11 @@ jobs:
           { config: "default", shard: 5, num_shards: 5, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
           { config: "crossref", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
           { config: "crossref", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
-          { config: "dynamo_wrapped", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
-          { config: "dynamo_wrapped", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
-          { config: "dynamo_wrapped", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+          # Free-threaded Python 3.14t has ~20-50% higher per-object memory overhead from biased reference counting and
+          # per-object locks, and test_nn (531 tests) under dynamo wrapping with compiled autograd consistently OOMs at 64GB.
+          { config: "dynamo_wrapped", shard: 1, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "dynamo_wrapped", shard: 2, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "dynamo_wrapped", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
           { config: "einops", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
           { config: "openreg", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
         ]}


### PR DESCRIPTION
The linux-jammy-py3.14t-clang18 / test-osdc (dynamo_wrapped, 1, 3) job has been flakily OOMing since ~April 11. Investigation across 8 failing jobs shows the same pattern:

- test_nn.py (531 tests) runs under dynamo wrapping with compiled autograd
- After ~11 minutes with zero output, the OSDC Kubernetes pod is OOM-killed (exit code 137 / SIGKILL)
- The pod has 64GB RAM (linux.2xlarge → l-x86iavx512-8-64 on OSDC)

Free-threaded Python 3.14t has significantly higher per-object memory overhead (per-object locks, biased reference counting) compared to standard CPython. Dynamo compilation creates millions of objects per test, and with 531 tests plus compiled autograd, the cumulative memory from allocator fragmentation exceeds the 64GB pod limit.