### PR TITLE
[MPS] Fix mm with stride-0 inputs on macOS < 26.4

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -23,6 +23,7 @@ enum class MacOSVersion : uint32_t {
   MACOS_VER_15_1_PLUS,
   MACOS_VER_15_2_PLUS,
   MACOS_VER_26_0_PLUS,
+  MACOS_VER_26_4_PLUS,
 };
 
 //-----------------------------------------------------------------

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -66,6 +66,7 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
   static bool _macos_15_1_plus = is_os_version_at_least(15, 1);
   static bool _macos_15_2_plus = is_os_version_at_least(15, 2);
   static bool _macos_26_0_plus = is_os_version_at_least(26, 0);
+  static bool _macos_26_4_plus = is_os_version_at_least(26, 4);
 
   switch (version) {
     case MacOSVersion::MACOS_VER_14_4_PLUS:
@@ -78,6 +79,8 @@ bool MPSDevice::isMacOS13Plus(MacOSVersion version) const {
       return _macos_15_2_plus;
     case MacOSVersion::MACOS_VER_26_0_PLUS:
       return _macos_26_0_plus;
+    case MacOSVersion::MACOS_VER_26_4_PLUS:
+      return _macos_26_4_plus;
     default:
       return false;
   }

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -442,8 +442,6 @@ MPSNDArray* getStridedMPSNDArray(const TensorBase& src, MPSNDArray* srcNDArray) 
   auto sizes = src.sizes();
   auto nStrides = strides.size();
   auto nonZeroStrides = src.strides();
-  int64_t crtNonZeroStride = 1;
-  bool hasZeroStrides = false;
   auto sortedStridesIndices = getSortedStrides(nonZeroStrides);
 
   NSMutableArray<NSNumber*>* sortedStridesShape = [NSMutableArray arrayWithCapacity:nStrides];
@@ -500,6 +498,16 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor,
   id<MTLBuffer> srcBuf = getMTLBufferStorage(src);
 
   static const bool is_macOS_15_0_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
+  // MPS strided API does not support stride 0 (from expand), so fall back
+  // to the gather/clone path for such tensors.
+  if (useMPSStridedAPI) {
+    for (auto s : src.strides()) {
+      if (s == 0) {
+        useMPSStridedAPI = false;
+        break;
+      }
+    }
+  }
   // Use gather kernel to solve strides for macOS < 15.0
   // Starting with macOS 15.0, MPS supports native strides directly in the kernels
   if (!is_macOS_15_0_or_newer || !useMPSStridedAPI) {

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -498,9 +498,6 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor,
   id<MTLBuffer> srcBuf = getMTLBufferStorage(src);
 
   static const bool is_macOS_15_0_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
-  // MPS strided API does not support stride 0 (from expand), so fall back
-  // to the gather/clone path for such tensors.
-  useMPSStridedAPI &= !std::ranges::any_of(src.strides(), [](auto s) { return s == 0; });
   // Use gather kernel to solve strides for macOS < 15.0
   // Starting with macOS 15.0, MPS supports native strides directly in the kernels
   if (!is_macOS_15_0_or_newer || !useMPSStridedAPI) {

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -500,14 +500,7 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor,
   static const bool is_macOS_15_0_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
   // MPS strided API does not support stride 0 (from expand), so fall back
   // to the gather/clone path for such tensors.
-  if (useMPSStridedAPI) {
-    for (auto s : src.strides()) {
-      if (s == 0) {
-        useMPSStridedAPI = false;
-        break;
-      }
-    }
-  }
+  useMPSStridedAPI &= !std::ranges::any_of(src.strides(), [](auto s) { return s == 0; });
   // Use gather kernel to solve strides for macOS < 15.0
   // Starting with macOS 15.0, MPS supports native strides directly in the kernels
   if (!is_macOS_15_0_or_newer || !useMPSStridedAPI) {

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -712,13 +712,21 @@ static Tensor& mm_out_mps_impl(const Tensor& self, const Tensor& other, Tensor& 
     });
     // MPS TODO:
     // Strided API doesn't play nice with complex data types (at least not in case of matmul).
+    // MPSGraph's matrixMultiplication produces incorrect results with stride-0 NDArray
+    // inputs on macOS < 26.4 (only every 16th row is computed). Contiguify such tensors
+    // by disabling the strided API so they go through the gather/clone path first.
+    // See https://github.com/pytorch/pytorch/issues/180201
+    static const bool is_macOS_26_4_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_26_4_PLUS);
+    auto hasZeroStride = [](const Tensor& t) {
+      return std::ranges::any_of(t.strides(), [](auto s) { return s == 0; });
+    };
+    auto useStridedSelf = !isComplexType(self.scalar_type()) && (is_macOS_26_4_or_newer || !hasZeroStride(self));
+    auto useStridedOther = !isComplexType(other.scalar_type()) && (is_macOS_26_4_or_newer || !hasZeroStride(other));
     auto selfPlaceholder = self.numel() != 0
-        ? Placeholder(
-              cachedGraph->inputTensor_, self, nil, true, MPSDataTypeInvalid, !isComplexType(self.scalar_type()))
+        ? Placeholder(cachedGraph->inputTensor_, self, nil, true, MPSDataTypeInvalid, useStridedSelf)
         : Placeholder();
     auto otherPlaceholder = other.numel() != 0
-        ? Placeholder(
-              cachedGraph->otherTensor_, other, nil, true, MPSDataTypeInvalid, !isComplexType(other.scalar_type()))
+        ? Placeholder(cachedGraph->otherTensor_, other, nil, true, MPSDataTypeInvalid, useStridedOther)
         : Placeholder();
     auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -13189,19 +13189,21 @@ class TestConsistency(TestCaseMPS):
 
     def test_autograd_sum_expand_stride_zero(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/180201
-        # MPS strided API does not handle stride 0 (from expand in sum backward),
-        # causing corrupted gradients when using autograd.grad(y.sum(), x).
-        torch.manual_seed(123)
-        w = torch.randn(16, 3, device="mps")
-        b = torch.randn(16, device="mps")
+        # Matmul backward with stride-0 gradient (from sum of a size-1 output)
+        # produces corrupted (mostly zero) gradients on some macOS versions.
+        torch.manual_seed(42)
+        w1, b1 = torch.randn(16, 3), torch.randn(16)
+        w2, b2 = torch.randn(1, 16), torch.randn(1)
 
-        torch.manual_seed(0)
-        x = torch.randn(64, 3, device="mps", requires_grad=True)
-        y = torch.sin(x @ w.T + b).sum(-1)
+        x_mps = torch.randn(64, 3, device="mps", requires_grad=True)
+        x_cpu = x_mps.detach().cpu().requires_grad_(True)
 
-        grad_sum = torch.autograd.grad(y.sum(), x)[0]
-        grad_explicit = torch.autograd.grad(y, x, grad_outputs=torch.ones_like(y))[0]
-        self.assertEqual(grad_sum, grad_explicit)
+        y_mps = (x_mps @ w1.T.to("mps") + b1.to("mps")) @ w2.T.to("mps") + b2.to("mps")
+        y_cpu = (x_cpu @ w1.T + b1) @ w2.T + b2
+
+        y_mps.sum().backward()
+        y_cpu.sum().backward()
+        self.assertEqual(x_mps.grad, x_cpu.grad)
 
 
 class TestErrorInputs(TestCase):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -13187,6 +13187,23 @@ class TestConsistency(TestCaseMPS):
             self.assertEqual(op(x, y[0]), op(x.to("mps"), y.to("mps")[0]).cpu())
 
 
+    def test_autograd_sum_expand_stride_zero(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/180201
+        # MPS strided API does not handle stride 0 (from expand in sum backward),
+        # causing corrupted gradients when using autograd.grad(y.sum(), x).
+        torch.manual_seed(123)
+        w = torch.randn(16, 3, device="mps")
+        b = torch.randn(16, device="mps")
+
+        torch.manual_seed(0)
+        x = torch.randn(64, 3, device="mps", requires_grad=True)
+        y = torch.sin(x @ w.T + b).sum(-1)
+
+        grad_sum = torch.autograd.grad(y.sum(), x)[0]
+        grad_explicit = torch.autograd.grad(y, x, grad_outputs=torch.ones_like(y))[0]
+        self.assertEqual(grad_sum, grad_explicit)
+
+
 class TestErrorInputs(TestCase):
     _ignore_not_implemented_error = True
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -13187,23 +13187,16 @@ class TestConsistency(TestCaseMPS):
             self.assertEqual(op(x, y[0]), op(x.to("mps"), y.to("mps")[0]).cpu())
 
 
-    def test_autograd_sum_expand_stride_zero(self):
+    def test_mm_stride_zero(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/180201
-        # Matmul backward with stride-0 gradient (from sum of a size-1 output)
-        # produces corrupted (mostly zero) gradients on some macOS versions.
-        torch.manual_seed(42)
-        w1, b1 = torch.randn(16, 3), torch.randn(16)
-        w2, b2 = torch.randn(1, 16), torch.randn(1)
-
-        x_mps = torch.randn(64, 3, device="mps", requires_grad=True)
-        x_cpu = x_mps.detach().cpu().requires_grad_(True)
-
-        y_mps = (x_mps @ w1.T.to("mps") + b1.to("mps")) @ w2.T.to("mps") + b2.to("mps")
-        y_cpu = (x_cpu @ w1.T + b1) @ w2.T + b2
-
-        y_mps.sum().backward()
-        y_cpu.sum().backward()
-        self.assertEqual(x_mps.grad, x_cpu.grad)
+        # MPS arrayViewWithShape:strides: mishandles stride-0 tensors in mm,
+        # producing zero rows for every 16th threadgroup when M>=16 and N>=16.
+        # Fixed in macOS 26.4, but still needed for older versions.
+        expanded = torch.ones(1, 1, device="mps").expand(64, 1)
+        w = torch.randn(1, 16, device="mps")
+        result = expanded.mm(w)
+        expected = torch.ones(64, 1, device="mps").mm(w)
+        self.assertEqual(result, expected)
 
 
 class TestErrorInputs(TestCase):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -13186,12 +13186,10 @@ class TestConsistency(TestCaseMPS):
             # Broadcast
             self.assertEqual(op(x, y[0]), op(x.to("mps"), y.to("mps")[0]).cpu())
 
-
     def test_mm_stride_zero(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/180201
-        # MPS arrayViewWithShape:strides: mishandles stride-0 tensors in mm,
-        # producing zero rows for every 16th threadgroup when M>=16 and N>=16.
-        # Fixed in macOS 26.4, but still needed for older versions.
+        # MPSGraph matrixMultiplication produces incorrect results with stride-0
+        # inputs on macOS < 26.4 (only every 16th row is correct).
         expanded = torch.ones(1, 1, device="mps").expand(64, 1)
         w = torch.randn(1, 16, device="mps")
         result = expanded.mm(w)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #180236

MPSGraph's matrixMultiplication produces incorrect results when given stride-0 NDArray inputs (from tensor.expand()) on macOS >=15.0,<26.4. Only every 16th row of the output is computed correctly; the rest are zeroed.

Fix disables the MPS strided API specifically for mm inputs that have stride 0, causing them to be materialized contiguously via the gather/clone path before being passed to MPSGraph. The check is skipped on macOS >= 26.4 where underlying issue apparently has been fixed.

Fixes https://github.com/pytorch/pytorch/issues/180201

Co-authored-by: Claude <noreply@anthropic.com>