### PR TITLE
[TPU][Pallas] TPUs do not support 64-bit ints or floats.

### DIFF
--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -231,17 +231,17 @@ def torch_dtype_to_jax_runtime(dtype: torch.dtype) -> Any:
 
     dtype_map = {
         torch.float32: jnp.float32,
-        torch.float64: jnp.float64,
+        torch.float64: jnp.float32,
         torch.float16: jnp.float16,
         torch.bfloat16: jnp.bfloat16,
         torch.int32: jnp.int32,
-        torch.int64: jnp.int64,
+        torch.int64: jnp.int32,
         torch.int16: jnp.int16,
         torch.int8: jnp.int8,
         torch.uint8: jnp.uint8,
         torch.bool: jnp.bool_,
         torch.complex64: jnp.complex64,
-        torch.complex128: jnp.complex128,
+        torch.complex128: jnp.complex64,
     }
     if dtype not in dtype_map:
         raise ValueError(f"Unsupported dtype for JAX conversion: {dtype}")


### PR DESCRIPTION
Note: this PR unblocks https://github.com/pytorch/helion/pull/2019

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo