### PR TITLE
Add lucaskabela to more Dynamo CODEOWNERS paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -60,6 +60,9 @@ nn/qat/ @jerryzh168
 /torch/distributed/tensor/_ops/_view_ops.py @weifengpy
 /torch/distributed/tensor/_ops/_matrix_ops.py @weifengpy
 
+# Dynamo
+/torch/_dynamo/ @lucaskabela
+
 # ONNX Export
 /torch/_dynamo/backends/onnxrt.py @titaiwangms @xadupre @justinchuby
 /torch/csrc/jit/passes/onnx.h @titaiwangms @xadupre


### PR DESCRIPTION
## Summary

1. What is the root cause problem
`CODEOWNERS` only has a few narrow `torch/_dynamo` entries today, so most Dynamo changes do not automatically request `@lucaskabela` even though he is actively maintaining that area.

2. What is the proposed fix
Add a broad `/torch/_dynamo/ @lucaskabela` rule before the existing narrower Dynamo-specific entries.

3. Why the proposed fix is the right long term fix
A single directory-level rule keeps default Dynamo ownership easy to maintain while still preserving specialized owners anywhere a later, more specific `CODEOWNERS` rule already exists.

## Testing
- `python3` targeted `CODEOWNERS` match validation for representative Dynamo paths
- `git diff --check`

Drafted via Codex, published after manual review by @bobrenjc93