### PR TITLE
Fix beta triton build failures from circular imports and constexpr attrs

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2713,10 +2713,25 @@ common_constant_types: set[type] = {
     torch.utils._pytree.GetAttrKey,
 }
 
-if has_triton_package():
-    import triton
+_triton_dtype_added = False
 
-    common_constant_types.add(triton.language.dtype)
+
+def _maybe_add_triton_dtype() -> None:
+    global _triton_dtype_added
+    if _triton_dtype_added:
+        return
+    if has_triton_package():
+        try:
+            import triton
+
+            common_constant_types.add(triton.language.dtype)
+            _triton_dtype_added = True
+        except (ImportError, AttributeError):
+            # triton is partially initialized (circular import), retry later
+            pass
+    else:
+        _triton_dtype_added = True
+
 
 """
     Difference between is_safe_constant and common_constant_types.
@@ -2727,6 +2742,7 @@ if has_triton_package():
 
 
 def is_safe_constant(v: Any) -> bool:
+    _maybe_add_triton_dtype()
     if istype(v, (tuple, frozenset)):
         return all(map(is_safe_constant, v))
     return isinstance(

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -35,11 +35,20 @@ class TileHint(Enum):
 
 
 # Define `AttrsDescriptorWrapper` function with clear conditional handling
+_triton_attrs_resolved = False
 if has_triton_package():
-    import triton
-    import triton.backends.compiler
-    import triton.compiler.compiler
+    try:
+        import triton
+        import triton.backends.compiler
+        import triton.compiler.compiler
 
+        _triton_attrs_resolved = True
+    except (ImportError, AttributeError):
+        # triton is partially initialized (circular import during backend
+        # discovery). Fall through to the namedtuple fallback below.
+        pass
+
+if _triton_attrs_resolved:
     if hasattr(triton.backends.compiler, "AttrsDescriptor"):
         # Triton 3.2.0 - the second implementation
         from triton.backends.compiler import AttrsDescriptor


### PR DESCRIPTION
Summary:
Three issues introduced by D99796020 caused build failures for triton_beta targets:

1. torch/_dynamo/utils.py accessed triton.language.dtype at module level,
   which triggered a circular import when triton's backend discovery
   imported torch. Defer the addition to common_constant_types into a
   lazy helper called from is_safe_constant().

2. torch/_inductor/runtime/hints.py imported triton.compiler.compiler at
   module level, hitting the same circular import during backend discovery.
   Wrap in try/except and fall through to the namedtuple fallback.

3. triton CC compiler passed divisibility attrs for constexpr args.
   Upstream triton PR #8846 changed ASTFunction.deserialize() from
   find_paths_if (which skipped constexprs) to apply_with_path (which
   processes all args). When constexpr args at the end of the parameter
   list carried divisibility attrs, fn.set_arg_attr() was called with
   cursor >= fn.get_num_args(), raising IndexError. Filter constants out
   of the attrs dict in gen_compile_arg().


https://www.internalfb.com/intern/test/281475266929396?ref_report_id=0

Authored with Claude.

Test Plan:
buck build --flagfile fbcode//mode/opt --config fbcode.nvcc_arch=h100a fbcode//pytorch/tritonbench/test/test_gpu:test_gpu_triton_beta

Result: BUILD SUCCEEDED

Differential Revision: D100333216




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98