### PR TITLE
[FR] Add ncclx and gloo to FlightRecorder trace analyzer backend allowlist (#180268)

### DIFF
--- a/test/distributed/flight_recorder/test_fr_analysis.py
+++ b/test/distributed/flight_recorder/test_fr_analysis.py
@@ -10,6 +10,7 @@ from torch.distributed.flight_recorder.components.types import (
     COLLECTIVES,
     MatchInfo,
     MatchState,
+    Op,
 )
 from torch.distributed.flight_recorder.components.utils import match_one_event
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -176,6 +177,45 @@ class FlightRecorderEventTest(TestCase):
             membership = {"0": {0, 1}}
             result = match_one_event(event, event, membership, "0").state
             self.assertEqual(result, expectedState)
+
+
+class FlightRecorderOpBackendTest(TestCase):
+    """Tests that the Op class accepts all supported backend prefixes."""
+
+    def _make_event(self, backend: str, collective: str = "all_reduce"):
+        return {
+            "profiling_name": f"{backend}:{collective}",
+            "state": "completed",
+            "process_group": ("0", "default"),
+            "input_sizes": [[4, 4]],
+            "output_sizes": [[4, 4]],
+            "input_dtypes": "float32",
+            "output_dtypes": "float32",
+            "collective_seq_id": "1",
+            "p2p_seq_id": "0",
+            "time_created_ns": 0,
+            "frames": [],
+        }
+
+    def test_nccl_backend(self):
+        op = Op(self._make_event("nccl"), {"0": {0, 1}}, "0")
+        self.assertEqual(op.type, "all_reduce")
+
+    def test_ncclx_backend(self):
+        op = Op(self._make_event("ncclx"), {"0": {0, 1}}, "0")
+        self.assertEqual(op.type, "all_reduce")
+
+    def test_gloo_backend(self):
+        op = Op(self._make_event("gloo"), {"0": {0, 1}}, "0")
+        self.assertEqual(op.type, "all_reduce")
+
+    def test_xccl_backend(self):
+        op = Op(self._make_event("xccl"), {"0": {0, 1}}, "0")
+        self.assertEqual(op.type, "all_reduce")
+
+    def test_unsupported_backend_raises(self):
+        with self.assertRaises(AssertionError):
+            Op(self._make_event("unknown_backend"), {"0": {0, 1}}, "0")
 
 
 class FlightMatchInfoTest(TestCase):

--- a/torch/distributed/flight_recorder/components/types.py
+++ b/torch/distributed/flight_recorder/components/types.py
@@ -418,9 +418,9 @@ class Op:
     ):
         self.profiling_name = event["profiling_name"]
         comm_lib_backend, name = self.profiling_name.split(":")
-        if comm_lib_backend not in ["nccl", "xccl"]:
+        if comm_lib_backend not in ["nccl", "ncclx", "gloo", "xccl"]:
             raise AssertionError(
-                f"name formatting error? {comm_lib_backend} != 'nccl' or 'xccl'"
+                f"name formatting error? {comm_lib_backend} not in supported backends"
             )
         parts = name.split(" ")
         type = parts[0]


### PR DESCRIPTION
Summary:

D99020245 generalized FlightRecorder profiling_name to use the actual backend name (e.g. "ncclx:", "gloo:") instead of hardcoded "nccl:". The FR trace analyzer's Op class needs to accept these additional backend prefixes to avoid AssertionError when parsing traces from non-nccl backends.

This is the types.py-only portion of D100117074, split out so it can land independently without the C++ TorchComm changes that caused OSS CI failures.

Test Plan: Python-only change — adds two strings to an allowlist. No behavioral change for existing "nccl:" and "xccl:" prefixes.

Reviewed By: dolpm

Differential Revision: D100657879


