### PR TITLE
[Profiler] Rename occupancy -> est_occupancy_pct

### DIFF
--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -561,7 +561,8 @@ class EventMetadata(NamedTuple):
     priority: int | None
     blocks_per_sm: float | None
     warps_per_sm: float | None
-    occupancy: float | None
+    occupancy: dict[str, Any] | None
+    est_occupancy_pct: float | None
     queued: int | None
     graph_id: int | None
     graph_node_id: int | None
@@ -590,10 +591,6 @@ class EventMetadata(NamedTuple):
     is_async: bool | None
 
 
-def _to_int_list(v: str) -> list[int]:
-    return json.loads(v)
-
-
 def _to_str(v: str) -> str:
     return v.strip('"')
 
@@ -606,12 +603,13 @@ def _to_bool(v: str) -> bool:
 _EVENT_METADATA_KEYS: dict[str, tuple[str, Callable[[str], Any]]] = {
     "registers per thread": ("registers_per_thread", int),
     "shared memory": ("shared_memory", int),
-    "grid": ("grid", _to_int_list),
-    "block": ("block", _to_int_list),
+    "grid": ("grid", json.loads),  # list[int]
+    "block": ("block", json.loads),  # list[int]
     "priority": ("priority", int),
     "blocks per SM": ("blocks_per_sm", float),
     "warps per SM": ("warps_per_sm", float),
-    "est. achieved occupancy %": ("occupancy", float),
+    "est. achieved occupancy %": ("est_occupancy_pct", float),
+    "occupancy": ("occupancy", json.loads),  # dict[str, Any]
     "queued": ("queued", int),
     "graph id": ("graph_id", int),
     "graph node id": ("graph_node_id", int),


### PR DESCRIPTION
Changes to EventMetadata:

- occupancy -> est_occupancy_pct
- introduces occupancy dictionary (which was added in https://github.com/pytorch/kineto/pull/1330)

Moves json convertor inline so we don't have multiple helpers each doing the same thing with different output types.