### PR TITLE
[ROCm][inductor][UT] Preserve combo kernel HIP compile options

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -625,6 +625,28 @@ class ComboKernelTests(TestCase):
                 torch._inductor.metrics.generated_kernel_count, expected_kernel_count
             )
 
+    @unittest.skipIf(not torch.version.hip, "ROCm only")
+    @requires_gpu_and_triton
+    def test_combo_kernel_amd_special_config_args(self):
+        if not torch._inductor.config.combo_kernel_per_subkernel_blocks:
+            self.skipTest("requires combo_kernel_per_subkernel_blocks")
+
+        def fn(a, b):
+            return a * 2.0, b + 1.0
+
+        inps = [
+            torch.rand(1024, device=GPU_TYPE),
+            torch.rand(1024, device=GPU_TYPE),
+        ]
+        out_eager = fn(*inps)
+
+        torch._inductor.metrics.reset()
+        fn_c = torch.compile(fn)
+        out_compiled, _ = run_and_get_code(fn_c, *inps)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
     @skipIfXpu(msg="Profiler JSON traceEvents is not supported on XPU")
     @requires_gpu_and_triton
     @unittest.skipIf(not SM90OrLater, "Avoid oom on CI")

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -625,9 +625,12 @@ class ComboKernelTests(TestCase):
                 torch._inductor.metrics.generated_kernel_count, expected_kernel_count
             )
 
+    # waves_per_eu, matrix_instr_nonkdim, and kpack are HIP-only Triton
+    # compile options, so only ROCm exercises this combo-kernel rewrite path.
     @unittest.skipIf(not torch.version.hip, "ROCm only")
     @requires_gpu_and_triton
-    def test_combo_kernel_amd_special_config_args(self):
+    @parametrize("max_autotune", [False, True])
+    def test_combo_kernel_amd_special_config_args(self, max_autotune):
         if not torch._inductor.config.combo_kernel_per_subkernel_blocks:
             self.skipTest("requires combo_kernel_per_subkernel_blocks")
 
@@ -641,8 +644,9 @@ class ComboKernelTests(TestCase):
         out_eager = fn(*inps)
 
         torch._inductor.metrics.reset()
-        fn_c = torch.compile(fn)
-        out_compiled, _ = run_and_get_code(fn_c, *inps)
+        with torch._inductor.config.patch("max_autotune", max_autotune):
+            fn_c = torch.compile(fn)
+            out_compiled, _ = run_and_get_code(fn_c, *inps)
 
         self.assertEqual(out_eager, out_compiled)
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -45,6 +45,7 @@ from torch._inductor.runtime.hints import (
 )
 from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
+    _update_combo_kernel_kwargs,
     autotune_hints_to_configs,
     CachingAutotuner,
     template,
@@ -91,6 +92,50 @@ class TestTritonHeuristics(TestCase):
             if key not in cfg.kwargs:
                 continue
             self.assertTrue(cfg.kwargs[key] <= TRITON_MAX_BLOCK[label])
+
+    def test_combo_kernel_amd_special_config_args_are_kernel_wide(self):
+        combo_kwargs = {}
+        _update_combo_kernel_kwargs(
+            combo_kwargs,
+            {
+                "XBLOCK": 128,
+                "R0_BLOCK": 64,
+                "waves_per_eu": 2,
+                "matrix_instr_nonkdim": 16,
+                "kpack": 2,
+            },
+            subkernel_idx=1,
+            skip_rblock=False,
+        )
+        self.assertEqual(
+            combo_kwargs,
+            {
+                "XBLOCK_1": 128,
+                "R0_BLOCK_1": 64,
+                "waves_per_eu": 2,
+                "matrix_instr_nonkdim": 16,
+                "kpack": 2,
+            },
+        )
+
+        combo_kwargs = {}
+        _update_combo_kernel_kwargs(
+            combo_kwargs,
+            {
+                "XBLOCK": 128,
+                "R0_BLOCK": 64,
+                "waves_per_eu": 2,
+            },
+            subkernel_idx=0,
+            skip_rblock=True,
+        )
+        self.assertEqual(
+            combo_kwargs,
+            {
+                "XBLOCK_0": 128,
+                "waves_per_eu": 2,
+            },
+        )
 
     def _test_artificial_zgrid(self):
         def forward(primals_1, primals_2, primals_5):

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -45,7 +45,6 @@ from torch._inductor.runtime.hints import (
 )
 from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
-    _update_combo_kernel_kwargs,
     autotune_hints_to_configs,
     CachingAutotuner,
     template,
@@ -92,50 +91,6 @@ class TestTritonHeuristics(TestCase):
             if key not in cfg.kwargs:
                 continue
             self.assertTrue(cfg.kwargs[key] <= TRITON_MAX_BLOCK[label])
-
-    def test_combo_kernel_amd_special_config_args_are_kernel_wide(self):
-        combo_kwargs = {}
-        _update_combo_kernel_kwargs(
-            combo_kwargs,
-            {
-                "XBLOCK": 128,
-                "R0_BLOCK": 64,
-                "waves_per_eu": 2,
-                "matrix_instr_nonkdim": 16,
-                "kpack": 2,
-            },
-            subkernel_idx=1,
-            skip_rblock=False,
-        )
-        self.assertEqual(
-            combo_kwargs,
-            {
-                "XBLOCK_1": 128,
-                "R0_BLOCK_1": 64,
-                "waves_per_eu": 2,
-                "matrix_instr_nonkdim": 16,
-                "kpack": 2,
-            },
-        )
-
-        combo_kwargs = {}
-        _update_combo_kernel_kwargs(
-            combo_kwargs,
-            {
-                "XBLOCK": 128,
-                "R0_BLOCK": 64,
-                "waves_per_eu": 2,
-            },
-            subkernel_idx=0,
-            skip_rblock=True,
-        )
-        self.assertEqual(
-            combo_kwargs,
-            {
-                "XBLOCK_0": 128,
-                "waves_per_eu": 2,
-            },
-        )
 
     def _test_artificial_zgrid(self):
         def forward(primals_1, primals_2, primals_5):

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1351,10 +1351,9 @@ class CachingAutotuner(KernelInterface):
             for ci, cfg in enumerate(cfgs):
                 trial_kwargs = dict(current_kwargs)
                 for idx in member_indices:
-                    for key, value in cfg.kwargs.items():
-                        if skip_rblock and key.startswith("R") and "BLOCK" in key:
-                            continue
-                        trial_kwargs[f"{key}_{idx}"] = value
+                    _update_combo_kernel_kwargs(
+                        trial_kwargs, cfg.kwargs, idx, skip_rblock
+                    )
 
                 if trial_kwargs == current_kwargs:
                     log.debug("    cfg[%d] skip (same as current)", ci)
@@ -2924,6 +2923,27 @@ def _combo_tiling_signature(
     )
 
 
+_COMBO_KERNEL_HIP_COMPILE_OPTION_KEYS = frozenset(
+    ("matrix_instr_nonkdim", "waves_per_eu", "kpack")
+)
+
+
+def _update_combo_kernel_kwargs(
+    kwargs: dict[str, Any],
+    cfg_kwargs: dict[str, Any],
+    subkernel_idx: int,
+    skip_rblock: bool,
+) -> None:
+    for key, value in cfg_kwargs.items():
+        # These are Triton backend compile options, not per-subkernel constexpr args.
+        if key in _COMBO_KERNEL_HIP_COMPILE_OPTION_KEYS:
+            kwargs[key] = value
+            continue
+        if skip_rblock and key.startswith("R") and "BLOCK" in key:
+            continue
+        kwargs[f"{key}_{subkernel_idx}"] = value
+
+
 def _handle_combo_kernel_per_subkernel_blocks(
     size_hints: dict[str, int],
     inductor_meta: dict[str, Any],
@@ -3012,20 +3032,20 @@ def _handle_combo_kernel_per_subkernel_blocks(
 
         group_coordesc_fields: OrderedSet[str] = OrderedSet()
         cfg = cfgs[0]
-        for key, value in cfg.kwargs.items():
+        _update_combo_kernel_kwargs(combined_kwargs, cfg.kwargs, i, skip_rblock)
+        for key in cfg.kwargs:
             if skip_rblock and key.startswith("R") and "BLOCK" in key:
                 continue
-
+            if not key.endswith("BLOCK"):
+                continue
             combined_key = f"{key}_{i}"
-            combined_kwargs[combined_key] = value
-            if key.endswith("BLOCK"):
-                group_coordesc_fields.add(combined_key)
-                prefix = key.removesuffix("BLOCK").lower()
-                if prefix in size_hints_i:
-                    combo_coordesc_field_limits[combined_key] = min(
-                        TRITON_MAX_BLOCK[prefix.upper()],
-                        size_hints_i[prefix],
-                    )
+            group_coordesc_fields.add(combined_key)
+            prefix = key.removesuffix("BLOCK").lower()
+            if prefix in size_hints_i:
+                combo_coordesc_field_limits[combined_key] = min(
+                    TRITON_MAX_BLOCK[prefix.upper()],
+                    size_hints_i[prefix],
+                )
 
         all_num_warps.append(cfg.num_warps)
         all_num_stages.append(cfg.num_stages)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -759,12 +759,28 @@ class CachingAutotuner(KernelInterface):
         compile_meta["num_warps"] = cfg.num_warps
         compile_meta["num_stages"] = cfg.num_stages
 
-        cfg_kwargs = cfg.kwargs
+        cfg_kwargs = {**cfg.kwargs}
         if self.device_props.type == "hip":
-            cfg_kwargs = {**cfg_kwargs}
-            for k in ("matrix_instr_nonkdim", "waves_per_eu", "kpack"):
-                if k in cfg_kwargs:
-                    compile_meta[k] = cfg_kwargs.pop(k)
+            # `compile_meta["signature"]` contains the actual Triton kernel argument
+            # names, including constexprs such as XBLOCK_0/XBLOCK_1 for combo kernels.
+            # Any HIP config kwarg that is *not* in that signature is not a kernel
+            # argument at all; it is a backend compile option that should be forwarded
+            # to triton.compile via `options`, not materialized as a constexpr.
+            signature_arg_names = set(compile_meta["signature"])
+            backend_options = {
+                key: value
+                for key, value in cfg_kwargs.items()
+                if key not in signature_arg_names
+            }
+            cfg_kwargs = {
+                key: value
+                for key, value in cfg_kwargs.items()
+                if key in signature_arg_names
+            }
+            if backend_options:
+                # Stash backend-only options separately so they do not get mixed into
+                # `constants`, which are interpreted as signature-bound constexpr args.
+                compile_meta["backend_options"] = backend_options
         compile_meta["constants"].update(cfg_kwargs)
 
         for i in get_constexprs(self.fn):
@@ -832,12 +848,9 @@ class CachingAutotuner(KernelInterface):
                 if v := getattr(cfg, k, None):
                     options[k] = v
         if self.device_props.type == "hip":
-            if "waves_per_eu" in compile_meta:
-                options["waves_per_eu"] = compile_meta["waves_per_eu"]
-            if "matrix_instr_nonkdim" in compile_meta:
-                options["matrix_instr_nonkdim"] = compile_meta["matrix_instr_nonkdim"]
-            if "kpack" in compile_meta:
-                options["kpack"] = compile_meta["kpack"]
+            # HIP backend options are consumed by Triton out-of-band from the kernel
+            # signature. They are intentionally *not* present in `constants`.
+            options.update(compile_meta.get("backend_options", {}))
 
         if self.device_props.type == "xpu" and XPU_KERNEL_FORMAT == "zebin":
             options["generate_native_code"] = True
@@ -1314,6 +1327,7 @@ class CachingAutotuner(KernelInterface):
             assert hasattr(self, "_reload_kernel")
             self.fn = self._reload_kernel().fn
 
+        signature_keys = set(self.triton_meta["signature"])
         best_config = launcher.config
         current_kwargs = dict(best_config.kwargs)
         base_num_warps = best_config.num_warps
@@ -1352,7 +1366,7 @@ class CachingAutotuner(KernelInterface):
                 trial_kwargs = dict(current_kwargs)
                 for idx in member_indices:
                     _update_combo_kernel_kwargs(
-                        trial_kwargs, cfg.kwargs, idx, skip_rblock
+                        trial_kwargs, cfg.kwargs, idx, skip_rblock, signature_keys
                     )
 
                 if trial_kwargs == current_kwargs:
@@ -2923,25 +2937,22 @@ def _combo_tiling_signature(
     )
 
 
-_COMBO_KERNEL_HIP_COMPILE_OPTION_KEYS = frozenset(
-    ("matrix_instr_nonkdim", "waves_per_eu", "kpack")
-)
-
-
 def _update_combo_kernel_kwargs(
     kwargs: dict[str, Any],
     cfg_kwargs: dict[str, Any],
     subkernel_idx: int,
     skip_rblock: bool,
+    signature_keys: set[str],
 ) -> None:
     for key, value in cfg_kwargs.items():
-        # These are Triton backend compile options, not per-subkernel constexpr args.
-        if key in _COMBO_KERNEL_HIP_COMPILE_OPTION_KEYS:
-            kwargs[key] = value
-            continue
         if skip_rblock and key.startswith("R") and "BLOCK" in key:
             continue
-        kwargs[f"{key}_{subkernel_idx}"] = value
+        suffixed_key = f"{key}_{subkernel_idx}"
+        # Only suffix keys that actually exist in the combo kernel signature.
+        # Signature keys are real per-subkernel constexpr args such as XBLOCK_0.
+        # Everything else must stay unsuffixed so HIP-specific compile options like
+        # waves_per_eu continue to flow through the backend-options path above.
+        kwargs[suffixed_key if suffixed_key in signature_keys else key] = value
 
 
 def _handle_combo_kernel_per_subkernel_blocks(
@@ -2982,6 +2993,7 @@ def _handle_combo_kernel_per_subkernel_blocks(
     all_num_stages: list[int] = []
     unique_warp_stage_pairs: OrderedSet[tuple[int, int]] = OrderedSet()
     combo_coordesc_field_limits: dict[str, int] = {}
+    signature_keys = set(triton_meta.get("signature", ()))
 
     # Group sub-kernels with identical config kwargs to skip redundant tuning.
     group_map: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -3032,7 +3044,9 @@ def _handle_combo_kernel_per_subkernel_blocks(
 
         group_coordesc_fields: OrderedSet[str] = OrderedSet()
         cfg = cfgs[0]
-        _update_combo_kernel_kwargs(combined_kwargs, cfg.kwargs, i, skip_rblock)
+        _update_combo_kernel_kwargs(
+            combined_kwargs, cfg.kwargs, i, skip_rblock, signature_keys
+        )
         for key in cfg.kwargs:
             if skip_rblock and key.startswith("R") and "BLOCK" in key:
                 continue

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -766,7 +766,7 @@ class CachingAutotuner(KernelInterface):
             # Any HIP config kwarg that is *not* in that signature is not a kernel
             # argument at all; it is a backend compile option that should be forwarded
             # to triton.compile via `options`, not materialized as a constexpr.
-            signature_arg_names = set(compile_meta["signature"])
+            signature_arg_names = OrderedSet(compile_meta["signature"])
             backend_options = {
                 key: value
                 for key, value in cfg_kwargs.items()
@@ -1327,7 +1327,7 @@ class CachingAutotuner(KernelInterface):
             assert hasattr(self, "_reload_kernel")
             self.fn = self._reload_kernel().fn
 
-        signature_keys = set(self.triton_meta["signature"])
+        signature_keys = OrderedSet(self.triton_meta["signature"])
         best_config = launcher.config
         current_kwargs = dict(best_config.kwargs)
         base_num_warps = best_config.num_warps
@@ -2942,7 +2942,7 @@ def _update_combo_kernel_kwargs(
     cfg_kwargs: dict[str, Any],
     subkernel_idx: int,
     skip_rblock: bool,
-    signature_keys: set[str],
+    signature_keys: OrderedSet[str],
 ) -> None:
     for key, value in cfg_kwargs.items():
         if skip_rblock and key.startswith("R") and "BLOCK" in key:
@@ -2993,7 +2993,7 @@ def _handle_combo_kernel_per_subkernel_blocks(
     all_num_stages: list[int] = []
     unique_warp_stage_pairs: OrderedSet[tuple[int, int]] = OrderedSet()
     combo_coordesc_field_limits: dict[str, int] = {}
-    signature_keys = set(triton_meta.get("signature", ()))
+    signature_keys = OrderedSet(triton_meta.get("signature", ()))
 
     # Group sub-kernels with identical config kwargs to skip redundant tuning.
     group_map: dict[tuple[Any, ...], dict[str, Any]] = {}


### PR DESCRIPTION
Fixes #180011
Fixes #180012
Fixes #180013
Fixes #180014
Fixes #180015
Fixes #180016
Fixes #180021
Fixes #179952
Fixes #180022
Fixes #180025
Fixes #180027
Fixes #180028
Fixes #180029
Fixes #180549

This appears to have regressed in #177715, where combo-kernel autotuning started materializing alternate per-subkernel configs. This change keeps Triton HIP compile options such as `waves_per_eu`, `matrix_instr_nonkdim`, and `kpack` kernel-wide when combo kernels rewrite per-subkernel configs, avoiding invalid names like `waves_per_eu_0`. It also routes both baseline combo configs and sequential combo autotune trials through the same kwarg rewrite helper and adds a regression test covering combo-kernel kwarg rewriting for AMD special config args.

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos