### PR TITLE
Update flake8 linter for python 3.14

### DIFF
--- a/tools/linter/adapters/flake8_linter.py
+++ b/tools/linter/adapters/flake8_linter.py
@@ -7,7 +7,7 @@
 #   "flake8-executable==2.1.3",
 #   "flake8-logging-format==2024.24.12",
 #   "flake8-pyi==25.5.0",
-#   "flake8-simplify==0.22.0",
+#   "flake8-simplify==0.30.0",
 #   "mccabe==0.7.0",
 #   "pycodestyle==2.14.0",
 #   "pyflakes==3.4.0",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180282

Version 0.22.0 of flake8-simplify isn't compatible with python 3.14