### PR TITLE
[ROCm][inductor][UT] Allow 1D bias_addmm candidate generation

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2763,6 +2763,79 @@ class TestMaxAutotune(TestCase):
         finally:
             clear_preprocessing_fns()
 
+    @unittest.skipIf(not torch.version.hip, "ROCM only")
+    @config.patch(
+        {
+            "max_autotune": True,
+            "max_autotune_gemm_backends": "ATEN",
+            "triton.autotune_cublasLt": True,
+            "triton.native_matmul": False,
+        }
+    )
+    def test_rocm_addmm_bias_addmm_candidate_for_1d_bias(self):
+        """
+        ROCm regression test for addmm autotune candidate generation.
+        A 1D bias addmm should still generate both addmm and bias_addmm candidates.
+        """
+
+        bias_meta: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] = {}
+
+        def capture_bias_input_metadata(choices):
+            for choice in choices:
+                if isinstance(choice, ExternKernelCaller) and choice.name in (
+                    "addmm",
+                    "bias_addmm",
+                ):
+                    bias_node = choice.input_nodes[0]
+                    bias_meta[choice.name] = (
+                        tuple(bias_node.get_size()),
+                        tuple(bias_node.get_stride()),
+                    )
+            return choices
+
+        add_preprocessing_fn(capture_bias_input_metadata)
+        try:
+            bias = torch.randn(64, device=GPU_TYPE)
+            mat1 = torch.randn(32, 128, device=GPU_TYPE)
+            mat2 = torch.randn(128, 64, device=GPU_TYPE)
+
+            compiled_fn = torch.compile(
+                lambda b, x, w: torch.addmm(b, x, w),
+                dynamic=False,
+            )
+            out = compiled_fn(bias, mat1, mat2)
+            ref = torch.addmm(bias, mat1, mat2)
+            torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+            self.assertIn(
+                "addmm", bias_meta, "Expected ATen addmm choice to be generated"
+            )
+            self.assertIn(
+                "bias_addmm",
+                bias_meta,
+                "Expected ATen bias_addmm choice to be generated",
+            )
+
+            addmm_size, _ = bias_meta["addmm"]
+            self.assertEqual(
+                len(addmm_size), 1, f"Expected addmm bias input rank 1, got {addmm_size}"
+            )
+
+            bias_addmm_size, bias_addmm_stride = bias_meta["bias_addmm"]
+            self.assertIn(
+                len(bias_addmm_size),
+                (1, 2),
+                f"Expected bias_addmm rank 1 or 2, got {bias_addmm_size}",
+            )
+            if len(bias_addmm_size) == 2:
+                self.assertEqual(
+                    bias_addmm_stride[0],
+                    0,
+                    f"Expected expanded bias_addmm to have stride[0] == 0, got {bias_addmm_stride}",
+                )
+        finally:
+            clear_preprocessing_fns()
+
     @config.patch(
         {"test_configs.max_mm_configs": 4, "max_autotune_gemm_backends": "ATEN,TRITON"}
     )

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2818,7 +2818,9 @@ class TestMaxAutotune(TestCase):
 
             addmm_size, _ = bias_meta["addmm"]
             self.assertEqual(
-                len(addmm_size), 1, f"Expected addmm bias input rank 1, got {addmm_size}"
+                len(addmm_size),
+                1,
+                f"Expected addmm bias input rank 1, got {addmm_size}",
             )
 
             bias_addmm_size, bias_addmm_stride = bias_meta["bias_addmm"]

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -668,19 +668,26 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
     templates_to_use: list[ExternKernelChoice | KernelTemplate] = []
 
     if use_aten_gemm_kernels():
-        aten_templates: list[ExternKernelChoice | KernelTemplate] = [aten_addmm]
+        # Keep aten.addmm on native input so 1D bias is preserved on ROCm.
+        choices.extend(
+            V.choices.get_template_configs(kernel_inputs_aten, [aten_addmm], name)
+        )
+
+        bias_to_check = inp if torch.version.hip else inp_expanded
+        is_rocm_1d_bias = torch.version.hip and len(bias_to_check.get_size()) == 1
+        is_expanded_bias = (
+            len(bias_to_check.get_size()) == 2 and bias_to_check.get_stride()[0] == 0
+        )
         if (
-            inp.get_stride()[0] == 0
-            and len(inp.get_size()) == 2
+            (is_rocm_1d_bias or is_expanded_bias)
             and inductor_config.triton.autotune_cublasLt
             and not V.graph.cpp_wrapper  # bias_addmm only has a Python implementation
         ):
-            aten_templates.append(aten_bias_addmm)
-
-        # On ROCm, ATen choices use original bias input; non-ROCm keeps unified inputs.
-        choices.extend(
-            V.choices.get_template_configs(kernel_inputs_aten, aten_templates, name)
-        )
+            # Use expanded kernel_inputs for aten_bias_addmm so template heuristic
+            # remains valid (expects 2D stride-0 bias).
+            choices.extend(
+                V.choices.get_template_configs(kernel_inputs, [aten_bias_addmm], name)
+            )
 
     if is_nonzero and use_triton_template(layout, check_max_autotune=False):
         templates_to_use.append(mm_template)

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -669,10 +669,15 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
 
     if use_aten_gemm_kernels():
         aten_templates: list[ExternKernelChoice | KernelTemplate] = [aten_addmm]
-        # For ROCm, check original inp since kernel_inputs_aten uses inp (not inp_expanded)
+        # For ROCm, kernel_inputs_aten keeps the native 1D bias so hipBLASLt
+        # fused-bias kernels can still see the original bias form.
         bias_to_check = inp if torch.version.hip else inp_expanded
+        is_rocm_1d_bias = torch.version.hip and len(bias_to_check.get_size()) == 1
+        valid_bias_for_bias_addmm = (
+            is_rocm_1d_bias or bias_to_check.get_stride()[0] == 0
+        )
         if (
-            bias_to_check.get_stride()[0] == 0
+            valid_bias_for_bias_addmm
             and inductor_config.triton.autotune_cublasLt
             and not V.graph.cpp_wrapper  # bias_addmm only has a Python implementation
         ):


### PR DESCRIPTION
Fixes #180031
Fixes #179967

## Problem

On ROCm, `torch.addmm` with a native 1D bias stopped generating the `bias_addmm` autotune candidate after #180270.
When that candidate is dropped, max-autotune can miss the fused hipBLASLt bias path.

## Root Cause

`bias_addmm` eligibility in `tuned_addmm` became tied to the expanded 2D stride-0 bias form.
For ROCm, a native 1D bias could therefore be filtered out before candidate selection.

## Fix

Update `tuned_addmm` candidate wiring so that:

- `addmm` remains generated from native inputs (preserves 1D-bias path),
- `bias_addmm` remains eligible for ROCm 1D-bias workloads, and
- existing heuristic expectations stay valid.

## Tests

- Existing: `test_addmm_1d_bias_no_reinterpret_tensor`
- New ROCm regression test: verify 1D-bias `addmm` still generates both `addmm` and `bias_addmm` candidates.
- Existing lookup-table coverage for `bias_addmm` path remains passing.

## Scope

Targeted ROCm addmm candidate-generation fix.
No intended behavior change outside this path.
