### PR TITLE
Fix activation quantization creating duplicate backward placeholders

### DIFF
--- a/test/inductor/test_quantization.py
+++ b/test/inductor/test_quantization.py
@@ -47,6 +47,29 @@ class FeedforwardNN(torch.nn.Module):
         return x
 
 
+class SharedOutputAndSavedModule(torch.nn.Module):
+    """A module where a 3D intermediate is both a user output and saved for backward.
+
+    This triggers the bug in T264303372: the activation quantization pass would
+    quantize both the user output and saved-for-backward positions of the same
+    tensor, creating duplicate backward placeholders that shift the stride mapping.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.scale = torch.nn.Parameter(torch.ones(8, 8))
+        self.W = torch.nn.Parameter(torch.randn(64, 32))
+
+    def forward(self, x):
+        h = x.view(x.shape[0], 8, 8)
+        attn = h * torch.sigmoid(h)
+        # attn is both returned (user output) and needed by backward (mul saves it)
+        scaled = attn * self.scale
+        flat = scaled.flatten(1)
+        result = flat @ self.W
+        return result, attn
+
+
 class LayernormNN(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -227,6 +250,37 @@ class TestQuantization(TestCase):
             counters["inductor"]["activation_quantization_bwd_aten_pass"], 1
         )
         self.assertTrue(torch.allclose(ref, res))
+        counters.clear()
+
+    @requires_gpu()
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={},
+        post_grad_fusion_options={
+            "activation_quantization_aten_pass": {
+                "quant_type": "torch.float8_e5m2",
+                "use_scaling": True,
+                "size_in_mb": 0.0,
+                "exclude_primals": True,
+                "allowed_dtypes": "torch.bfloat16;torch.float32",
+            },
+        },
+    )
+    def test_activation_quantization_shared_output_and_saved(self):
+        """Test that activation quantization works when a tensor is both a user
+        output and a saved-for-backward activation (T264303372)."""
+        counters.clear()
+        module = SharedOutputAndSavedModule().to(GPU_TYPE)
+        x = torch.randn(8, 64, device=GPU_TYPE, requires_grad=True)
+        compiled = torch.compile(module)
+        result, attn = compiled(x)
+        loss = result.sum() + attn.sum()
+        loss.backward()
+        self.assertEqual(
+            counters["inductor"]["activation_quantization_fwd_aten_pass"], 1
+        )
+        self.assertEqual(
+            counters["inductor"]["activation_quantization_bwd_aten_pass"], 1
+        )
         counters.clear()
 
 

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -704,7 +704,7 @@ def calculate_range(dtype: torch.dtype) -> tuple[float, float]:
     return info.min, info.max
 
 
-def quantize_activation_fw(graph: torch.fx.Graph) -> None:
+def quantize_activation_fw(graph: torch.fx.Graph, num_fwd_outputs: int = 0) -> None:
     output = graph.find_nodes(op="output")[0]
     fwd_outputs = output.args[0]
     quant_type = get_quant_type()
@@ -713,6 +713,14 @@ def quantize_activation_fw(graph: torch.fx.Graph) -> None:
     tensor_scale_nodes: list[fx.Node] = []
     sym_scale_nodes: list[fx.Node] = []
     for position, node in enumerate(fwd_outputs):
+        # Don't quantize user-visible forward outputs. A tensor may appear as
+        # both a user output and a saved-for-backward activation (same FX node
+        # at two positions). Quantizing the user output position would:
+        # 1. Return fp8 to the user instead of the original precision
+        # 2. Create duplicate fp8_quant/fp8_scale backward placeholders that
+        #    shift the stride mapping in _aot_stage2b_bw_compile (T264303372)
+        if position < num_fwd_outputs:
+            continue
         # check if the activation node is the node saved for quantization
         if node.meta.get("saved_for_quantization", False):
             # case: use scaling
@@ -853,6 +861,7 @@ def perform_fp8_activation_quantization(
     fwd_module: fx.GraphModule,
     bwd_module: fx.GraphModule,
     bwd_module_inputs: dict[str, fx.Node],
+    num_fwd_outputs: int = 0,
 ) -> None:
     trace_structured(
         "artifact",
@@ -865,7 +874,7 @@ def perform_fp8_activation_quantization(
         ),
     )
 
-    quantize_activation_fw(fwd_module.graph)
+    quantize_activation_fw(fwd_module.graph, num_fwd_outputs)
 
     trace_structured(
         "artifact",
@@ -944,6 +953,7 @@ def enable_activation_quantization(
     fwd_module: fx.GraphModule,
     bwd_module: fx.GraphModule,
     static_lifetime_input_nodes: OrderedSet[fx.Node] | None = None,
+    num_fwd_outputs: int = 0,
 ) -> None:
     static_input_names: list[str] = (
         [node.name for node in static_lifetime_input_nodes]
@@ -975,7 +985,9 @@ def enable_activation_quantization(
             should_perform_fp8_quant = True
 
     if should_perform_fp8_quant:
-        perform_fp8_activation_quantization(fwd_module, bwd_module, bwd_module_inputs)
+        perform_fp8_activation_quantization(
+            fwd_module, bwd_module, bwd_module_inputs, num_fwd_outputs
+        )
 
 
 def _extract_fwd_bwd_modules(
@@ -1207,7 +1219,11 @@ def _extract_fwd_bwd_modules(
         is not None
     ):
         enable_activation_quantization(
-            saved_values, fwd_module, bwd_module, static_lifetime_input_nodes
+            saved_values,
+            fwd_module,
+            bwd_module,
+            static_lifetime_input_nodes,
+            num_fwd_outputs,
         )
     return fwd_module, bwd_module
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180287

When a tensor appears as both a user output and a saved-for-backward
activation, the activation quantization pass quantized both positions
in the forward output. This caused duplicate fp8_quant/fp8_scale
backward placeholders, shifting the position-based stride mapping in
_aot_stage2b_bw_compile and crashing with "mismatch in length of
strides and shape" when as_strided was called with mismatched ndim.

Fix by skipping user output positions (first num_fwd_outputs entries)
in quantize_activation_fw. User outputs should not be quantized to
fp8 anyway — only saved-for-backward activations should be.

Fixes T264303372

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo