### PR TITLE
[CI] Update dynamic CPU inductor HuggingFace expected graph breaks after transformers bump

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 
@@ -50,7 +50,7 @@ LayoutLMForMaskedLM,pass,0
 
 
 
-M2M100ForConditionalGeneration,pass,7
+M2M100ForConditionalGeneration,pass,0
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #180289

The transformers 5.2.0 -> 5.5.3 bump in #179913 updated the static CSV, but missed the dynamic variant. This aligns the dynamic expected values with what the new transformers version actually produces.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98