### PR TITLE
[Generator] Add weak reference support to torch.Generator

### DIFF
--- a/test/jit/test_generator.py
+++ b/test/jit/test_generator.py
@@ -189,6 +189,15 @@ class TestGenerator(JitTestCase):
             print(loaded_module.forward.code)
             raise
 
+    def test_weakref(self):
+        """torch.Generator must support weak references for the proxy
+        tensor tracker (WeakIdKeyDictionary) to work during tracing."""
+        import weakref
+
+        g = torch.Generator()
+        wr = weakref.ref(g)
+        self.assertIs(wr(), g)
+
 
 if __name__ == "__main__":
     raise_on_run_directly("test/test_jit.py")

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -27,11 +27,15 @@ PyObject* THPGenerator_initDefaultGenerator(const at::Generator& cdata) {
     throw python_error();
   auto self_ = reinterpret_cast<THPGenerator*>(self.get());
   self_->cdata = cdata;
+  self_->weakreflist = nullptr;
   return self.release();
 }
 
 static void THPGenerator_dealloc(PyObject* _self) {
   auto self = reinterpret_cast<THPGenerator*>(_self);
+  if (self->weakreflist) {
+    PyObject_ClearWeakRefs(_self);
+  }
   if (self->cdata.defined()) {
     self->cdata.set_pyobj(nullptr);
     self->cdata.~Generator();
@@ -51,6 +55,7 @@ static PyObject* THPGenerator_pynew(
 
   THPGeneratorPtr self(
       reinterpret_cast<THPGenerator*>(type->tp_alloc(type, 0)));
+  self->weakreflist = nullptr;
 
   c10::DeviceType device_type = device.type();
   if (device_type == at::kCPU) {
@@ -337,7 +342,7 @@ static PyTypeObject THPGeneratorType = {
     nullptr, /* tp_traverse */
     nullptr, /* tp_clear */
     nullptr, /* tp_richcompare */
-    0, /* tp_weaklistoffset */
+    offsetof(THPGenerator, weakreflist), /* tp_weaklistoffset */
     nullptr, /* tp_iter */
     nullptr, /* tp_iternext */
     THPGenerator_methods, /* tp_methods */
@@ -404,6 +409,7 @@ PyObject* THPGenerator_NewWithVar(PyTypeObject* type, Generator gen) {
   if (obj) {
     auto g = reinterpret_cast<THPGenerator*>(obj);
     new (&g->cdata) Generator(std::move(gen));
+    g->weakreflist = nullptr;
     set_pyobj(g->cdata, obj);
   }
   return obj;

--- a/torch/csrc/Generator.h
+++ b/torch/csrc/Generator.h
@@ -8,6 +8,7 @@
 struct THPGenerator {
   PyObject_HEAD
   at::Generator cdata;
+  PyObject* weakreflist;
 };
 
 // Creates a new Python object wrapping the default at::Generator. The reference


### PR DESCRIPTION
Stacked PRs:
 * #180292
 * #180291
 * __->__#180290


--- --- ---

### [Generator] Add weak reference support to torch.Generator


torch.Generator is defined via the raw CPython API and did not set
tp_weaklistoffset, so weakref.ref(generator) raised TypeError. The
proxy tensor tracing infrastructure tracks opaque objects in a
WeakIdKeyDictionary, so weak reference support is a prerequisite for
treating Generator as an opaque reference type.

Add a PyObject* weakrefs field to THPGenerator, set tp_weaklistoffset,
initialize the field in all constructors, and clear weak refs in dealloc.
This follows the same pattern used for torch.Stream (#164304) and
torch.Event (#164522).

<!-- ps-id: d542629c-9c69-49bd-ac66-a6569e111771 -->
