### PR TITLE
[Generator] Set OpaqueBaseMeta as torch.Generator's metaclass

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3783,6 +3783,24 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(result[0], x * 2)
         self.assertIs(result[1], m)
 
+    def test_generator_has_opaque_base_meta(self):
+        """torch.Generator uses OpaqueBaseMeta so isinstance() sees through
+        FakeScriptObject wrappers during tracing."""
+        from torch._opaque_base import OpaqueBaseMeta
+
+        self.assertIsInstance(torch.Generator, OpaqueBaseMeta)
+
+        from torch._library.fake_class_registry import (
+            FakeScriptObject,
+            maybe_to_fake_obj,
+        )
+        from torch._subclasses import FakeTensorMode
+
+        g = torch.Generator()
+        fso = maybe_to_fake_obj(FakeTensorMode(), g)
+        self.assertIsInstance(fso, FakeScriptObject)
+        self.assertIsInstance(fso, torch.Generator)
+
 
 instantiate_parametrized_tests(TestOpaqueObject)
 

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -360,8 +360,38 @@ static PyTypeObject THPGeneratorType = {
 
 bool THPGenerator_init(PyObject* module) {
   THPGeneratorClass = reinterpret_cast<PyObject*>(&THPGeneratorType);
+
+  // Use OpaqueBaseMeta as the metaclass so that
+  // isinstance(fake_script_obj, torch.Generator) works during tracing,
+  // mirroring the pattern used for ProcessGroup in c10d/init.cpp.
+  PyObject* opaque_base_module = PyImport_ImportModule("torch._opaque_base");
+  if (!opaque_base_module)
+    return false;
+  PyObject* opaque_base_meta =
+      PyObject_GetAttrString(opaque_base_module, "OpaqueBaseMeta");
+  Py_DECREF(opaque_base_module);
+  if (!opaque_base_meta)
+    return false;
+  // Not DECREF'd: the static THPGeneratorType holds this as its metaclass
+  // for the entire process lifetime.
+  Py_SET_TYPE(&THPGeneratorType, (PyTypeObject*)opaque_base_meta);
+
   if (PyType_Ready(&THPGeneratorType) < 0)
     return false;
+
+  // PyType_Ready with OpaqueBaseMeta derives __module__ from the metaclass
+  // instead of tp_name, which breaks pickle. Override it so that pickle
+  // resolves Generator via torch.Generator.
+  PyObject* torch_str = PyUnicode_FromString("torch");
+  if (!torch_str)
+    return false;
+  if (PyDict_SetItemString(THPGeneratorType.tp_dict, "__module__", torch_str) <
+      0) {
+    Py_DECREF(torch_str);
+    return false;
+  }
+  Py_DECREF(torch_str);
+
   Py_INCREF(&THPGeneratorType);
   PyModule_AddObject(
       module, "Generator", reinterpret_cast<PyObject*>(&THPGeneratorType));

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -473,7 +473,7 @@ static PyObject* THPModule_addDocStr(PyObject* _unused, PyObject* args) {
           m->d_getset->name);
     }
     m->d_getset->doc = doc_str;
-  } else if (Py_TYPE(obj) == &PyType_Type) {
+  } else if (PyType_Check(obj)) {
     PyTypeObject* t = reinterpret_cast<PyTypeObject*>(obj);
     if (t->tp_doc) {
       return PyErr_Format(


### PR DESCRIPTION
Stacked PRs:
 * #180292
 * __->__#180291
 * #180290


--- --- ---

### [Generator] Set OpaqueBaseMeta as torch.Generator's metaclass


Set OpaqueBaseMeta as the metaclass for torch.Generator so that
isinstance(fake_script_obj, torch.Generator) returns True when the
FakeScriptObject wraps a real Generator. This is the same pattern
used for ProcessGroup (c10d/init.cpp) and Placement
(python_placement.cpp), except those use pybind11's py::metaclass()
while Generator uses the raw CPython API.

Also fix add_docstr in Module.cpp to use PyType_Check(obj) instead of
Py_TYPE(obj) == &PyType_Type, since OpaqueBaseMeta is a subclass of
type and the exact check would reject it.

<!-- ps-id: d542629c-9c69-49bd-ac66-a6569e111771 -->
