### PR TITLE
[Generator] Register torch.Generator as opaque reference type

### DIFF
--- a/test/functorch/test_aot_joint_with_descriptors.py
+++ b/test/functorch/test_aot_joint_with_descriptors.py
@@ -796,6 +796,111 @@ class inner_f(torch.nn.Module):
         compiled_fn(*dict(model.named_parameters()).values(), inputs).sum().backward()
         self.assertIsNotNone(model.linear.weight.grad)
 
+    @requires_cuda
+    def test_export_and_compile_with_selective_ac(self):
+        """
+        Test that torch.compile works on a pre-partitioned AOT autograd graph
+        containing graphsafe_run_with_rng_state (from selective activation
+        checkpointing). The Generator object used by graphsafe_run_with_rng_state
+        is registered as an opaque reference type and flows through the base
+        Tracer.create_arg in make_fx, then through Inductor's get_attr handler.
+        """
+        import functools
+        import itertools
+
+        from torch._subclasses import FakeTensorMode
+        from torch.utils.checkpoint import (
+            CheckpointPolicy,
+            create_selective_checkpoint_contexts,
+        )
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op in (
+                torch.ops.aten._scaled_dot_product_flash_attention.default,
+                torch.ops.aten._scaled_dot_product_efficient_attention.default,
+                torch.ops.aten._scaled_dot_product_cudnn_attention.default,
+            ):
+                return CheckpointPolicy.MUST_RECOMPUTE
+            return CheckpointPolicy.MUST_SAVE
+
+        class AttentionBlock(nn.Module):
+            def __init__(self, nheads, dim):
+                super().__init__()
+                self.nheads = nheads
+                self.wq = nn.Linear(dim, dim, bias=False)
+                self.wk = nn.Linear(dim, dim, bias=False)
+                self.wv = nn.Linear(dim, dim, bias=False)
+                self.wo = nn.Linear(dim, dim, bias=False)
+
+            def _compute_attention(self, x):
+                q = self.wq(x)
+                k = self.wk(x)
+                v = self.wv(x)
+                q = q.unflatten(-1, (self.nheads, -1)).permute(0, 2, 1, 3)
+                k = k.unflatten(-1, (self.nheads, -1)).permute(0, 2, 1, 3)
+                v = v.unflatten(-1, (self.nheads, -1)).permute(0, 2, 1, 3)
+                o = nn.functional.scaled_dot_product_attention(q, k, v)
+                o = o.permute(0, 2, 1, 3).flatten(-2)
+                o = self.wo(o)
+                return o
+
+            def forward(self, x, context_fn=None):
+                return (
+                    torch.utils.checkpoint.checkpoint(
+                        self._compute_attention,
+                        x,
+                        use_reentrant=False,
+                        context_fn=context_fn,
+                    )
+                    + x
+                )
+
+        class AttentionWithPolicy(nn.Module):
+            def __init__(self, nheads, dim):
+                super().__init__()
+                self.block = AttentionBlock(nheads, dim)
+                self.context_fn = functools.partial(
+                    create_selective_checkpoint_contexts, policy_fn
+                )
+
+            def forward(self, x):
+                return self.block(x, context_fn=self.context_fn)
+
+        nheads, dim, bs, seq_len = 8, 128, 2, 16
+        model = AttentionWithPolicy(nheads, dim).cuda()
+
+        fake_mode = FakeTensorMode()
+        with fake_mode:
+            inputs = (torch.rand(bs, seq_len, dim, device="cuda"),)
+
+        gm = dynamo_graph_capture_for_export(model)(*inputs)
+
+        with ExitStack() as stack:
+            joint_with_descriptors = aot_export_joint_with_descriptors(
+                stack,
+                gm,
+                inputs,
+            )
+            parallel_model_fn = aot_compile_joint_with_descriptors(
+                joint_with_descriptors,
+            )
+
+        class WrapperModule(torch.nn.Module):
+            def forward(self, *args):
+                params = [
+                    v
+                    for k, v in itertools.chain(
+                        dict(model.named_parameters(remove_duplicate=False)).items(),
+                        dict(model.named_buffers(remove_duplicate=False)).items(),
+                    )
+                ]
+                return parallel_model_fn([*params, *args])
+
+        real_inputs = (torch.rand(bs, seq_len, dim, device="cuda"),)
+        compiled = torch.compile(WrapperModule(), fullgraph=True)
+        out = compiled(*real_inputs)
+        out.sum().backward()
+
     def test_preserve_annotate_simple(self):
         """Test basic linear module with aot_export_joint_with_descriptors"""
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1717,8 +1717,9 @@ class CommonTemplate:
 
         self.common(fn, (torch.linspace(-10, 10, 41), None), assert_equal=False)
 
-        # generator not yet supported in dynamo
-        with self.assertRaisesRegex(torch._dynamo.exc.Unsupported, "Generator"):
+        # Generator is an opaque reference type so dynamo traces through it,
+        # but Inductor does not yet support the generator= kwarg for random ops.
+        with self.assertRaises(torch._dynamo.exc.BackendCompilerFailed):
             self.common(fn, (torch.linspace(-10, 10, 41), torch.Generator(self.device)))
 
     def test_sgn_extremal(self):

--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3801,6 +3801,18 @@ class GraphModule(torch.nn.Module):
         self.assertIsInstance(fso, FakeScriptObject)
         self.assertIsInstance(fso, torch.Generator)
 
+    def test_generator_registered_as_opaque_reference(self):
+        """torch.Generator is registered as an opaque reference type so it
+        is hoisted as a graph input during dynamo tracing and handled by
+        the base Tracer.create_arg during make_fx tracing."""
+        from torch._library.opaque_object import (
+            is_opaque_reference_type,
+            is_opaque_type,
+        )
+
+        self.assertTrue(is_opaque_type(torch.Generator))
+        self.assertTrue(is_opaque_reference_type(torch.Generator))
+
 
 instantiate_parametrized_tests(TestOpaqueObject)
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -3048,5 +3048,10 @@ def _as_tensor_fullprec(t):
 if _is_device_backend_autoload_enabled():
     _import_device_backends()
 
+from torch._library.opaque_object import register_opaque_type
+
+
+register_opaque_type(torch.Generator, typ="reference")
+
 # Register all registered custom / override ops in torch/_native
 import torch._native

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1231,6 +1231,14 @@ class GraphLowering(torch.fx.Interpreter):
             self.graph_input_names.append(target)
             return expr
         elif isinstance(example, FakeScriptObject):
+            # Generators wrapped in FakeScriptObject (from dynamo opaque
+            # reference tracing) need GeneratorState for proper device
+            # tracking in downstream codegen.
+            if isinstance(example.real_obj, torch.Generator):
+                gen = ir.GeneratorState(name=target, device=example.real_obj.device)
+                self.graph_inputs[target] = gen  # type: ignore[assignment]
+                self.graph_input_names.append(target)
+                return gen
             obj = TorchBindObject(name=target, value=example)
             self.graph_inputs[target] = obj
             self.graph_input_names.append(target)
@@ -1488,7 +1496,14 @@ class GraphLowering(torch.fx.Interpreter):
         target: str,  # type: ignore[override]
         args: tuple[()],  # type: ignore[override]
         kwargs: dict[str, object],
-    ) -> Constant | TensorBox | ShapeAsConstantBuffer | ir.Subgraph | TorchBindObject:
+    ) -> (
+        Constant
+        | TensorBox
+        | ShapeAsConstantBuffer
+        | ir.Subgraph
+        | TorchBindObject
+        | ir.GeneratorState
+    ):
         # this is a constant
         value = getattr_recursive(self.module, target)  # type: ignore[arg-type]
 
@@ -1509,11 +1524,14 @@ class GraphLowering(torch.fx.Interpreter):
             self.torchbind_constants[target] = value
             self.constant_reprs[target] = ""
             return TorchBindObject(name=target, value=value)
+        elif isinstance(value, torch.Generator):
+            self.torchbind_constants[target] = value  # type: ignore[arg-type]
+            self.constant_reprs[target] = ""
+            return ir.GeneratorState(name=target, device=value.device)
         elif is_opaque_type(type(value)):
             self.torchbind_constants[target] = value  # type: ignore[arg-type]
             self.constant_reprs[target] = ""
             return TorchBindObject(name=target, value=value)  # type: ignore[arg-type]
-
         assert isinstance(value, torch.Tensor)
         if (
             config.aot_inductor.use_runtime_constant_folding

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -423,7 +423,18 @@ PyObject* THPGenerator_Wrap(const Generator& gen) {
 }
 
 at::Generator THPGenerator_Unwrap(PyObject* state) {
+  // During tracing, Generator may be wrapped in a FakeScriptObject which
+  // passes isinstance(fso, torch.Generator) via OpaqueBaseMeta but cannot
+  // be reinterpret_cast'd to THPGenerator. Unwrap to the real Generator.
   if (!Py_IS_TYPE(state, &THPGeneratorType)) {
+    PyObject* real_obj = PyObject_GetAttrString(state, "real_obj");
+    if (real_obj && Py_IS_TYPE(real_obj, &THPGeneratorType)) {
+      at::Generator gen = reinterpret_cast<THPGenerator*>(real_obj)->cdata;
+      Py_DECREF(real_obj);
+      return gen;
+    }
+    Py_XDECREF(real_obj);
+    PyErr_Clear();
     TORCH_CHECK_TYPE(
         false,
         fmt::format(

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -1144,7 +1144,7 @@ inline bool PythonArgs::isNone(int i) {
 inline std::optional<at::Generator> PythonArgs::generator(int i) {
   if (!args[i])
     return std::nullopt;
-  return reinterpret_cast<THPGenerator*>(args[i])->cdata;
+  return THPGenerator_Unwrap(args[i]);
 }
 
 inline at::Storage PythonArgs::storage(int i) {


### PR DESCRIPTION
Stacked PRs:
 * __->__#180292
 * #180291
 * #180290


--- --- ---

### [Generator] Register torch.Generator as opaque reference type


Register torch.Generator as an opaque reference type via
register_opaque_type. This tells dynamo and the proxy tensor
infrastructure that Generator is a mutable stateful object that should
be hoisted as a graph input (not baked into the graph as a constant).

In Inductor, two changes are needed:

In get_attr, reorder the Generator check before the generic
is_opaque_type check. Since Generator is now a registered opaque type,
the generic handler would match first and return TorchBindObject, but
downstream codegen expects GeneratorState for device tracking.

In the placeholder handler, detect when a FakeScriptObject wraps a
Generator (from dynamo's opaque reference tracing) and create a
GeneratorState instead of a generic TorchBindObject.

<!-- ps-id: d542629c-9c69-49bd-ac66-a6569e111771 -->
