### PR TITLE
Work around possible bug in _stash_obj_in_tls

### DIFF
--- a/test/inductor/test_config.py
+++ b/test/inductor/test_config.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 import math
+import threading
 import unittest
 
 import torch
@@ -389,6 +390,40 @@ class TestInductorConfig(TestCase):
         called = False
         z.grad_fn.apply(torch.tensor(0))
         self.assertFalse(called)
+
+    @requires_gpu
+    @torch._inductor.config.patch(fx_graph_cache=False)
+    def test_config_read_in_new_thread(self):
+        @torch.compile
+        def f(x, y):
+            z = x @ y
+            return z.sin().sum()
+
+        called = False
+
+        def my_pass(graph):
+            nonlocal called
+            called = True
+
+        x, y = (
+            torch.randn(3, 3, device=GPU_TYPE, requires_grad=True),
+            torch.randn(3, 3, device=GPU_TYPE),
+        )
+        z = f(x, y)
+        z.backward()
+        self.assertFalse(called)
+        torch._dynamo.reset()
+        z = f(x, y)
+
+        def call_backwards():
+            with torch._inductor.config.patch(post_grad_custom_pre_pass=my_pass):
+                z.backward()
+
+        t = threading.Thread(target=call_backwards)
+        t.start()
+        t.join()
+
+        self.assertTrue(called)
 
 
 if __name__ == "__main__":

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2875,7 +2875,8 @@ class _AOTDispatchAutogradFunctionFactory:
 
                 if (
                     torch._C._is_key_in_tls("context")
-                    and (config_ctx := torch._C._get_obj_in_tls("context")) is not None
+                    and (config_ctx := torch._C._get_obj_in_tls("context")[0])
+                    is not None
                 ):
                     impl_fn = functools.partial(config_ctx.run, impl_fn)
 

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -866,6 +866,9 @@ def _register_logging_hooks_on_whole_graph(
     return unregister_hooks
 
 
+_local = threading.local()
+
+
 def _engine_run_backward(
     t_outputs: Sequence[torch.Tensor | GradientEdge],
     *args: Any,
@@ -875,9 +878,13 @@ def _engine_run_backward(
     if attach_logging_hooks:
         unregister_hooks = _register_logging_hooks_on_whole_graph(t_outputs)
 
-    # Need to save the context so compiler config will be visible in device threads
-    torch._C._stash_obj_in_tls("context", contextvars.copy_context())
-
+    if not hasattr(_local, "context_holder"):
+        # This is used to hold the contextvars context, needed to make compiler config visible in device threads.  We
+        # use a (thread local) single-element list which gets updated for each backwards call to avoid stashing a new
+        # object in the tls every time
+        _local.context_holder = [None]
+        torch._C._stash_obj_in_tls("context", _local.context_holder)
+    _local.context_holder[0] = contextvars.copy_context()
     try:
         return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
             t_outputs, *args, **kwargs
@@ -885,4 +892,4 @@ def _engine_run_backward(
     finally:
         if attach_logging_hooks:
             unregister_hooks()  # type: ignore[possibly-undefined]
-        torch._C._stash_obj_in_tls("context", None)
+        _local.context_holder[0] = None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180295

This is an alternative to https://github.com/pytorch/pytorch/pull/179327 which only makes a single call (per thread) to
_stash_obj_in_tls to avoid possible lifecycle management issues.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo