### PR TITLE
[PyTorch] Add _jit_replace_submodule (#180296)

### DIFF
--- a/test/jit/test_module_apis.py
+++ b/test/jit/test_module_apis.py
@@ -137,5 +137,93 @@ class TestModuleAPIs(JitTestCase):
         self.assertTrue(m2.sub.customized_load_state_dict_called)
 
 
+    def test_jit_replace_submodule(self):
+        """Tests _jit_replace_submodule replaces a submodule with type remapping."""
+
+        class SubA(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class SubB(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x) * 2
+
+        class Parent(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.child = SubA()
+
+            def forward(self, x):
+                return self.child(x)
+
+        root = torch.jit.script(Parent())
+        new_child = torch.jit.script(SubB())
+
+        inp = torch.randn(2, 4)
+        # Before replacement, runs SubA.forward
+        out_before = root(inp)
+
+        torch._C._jit_replace_submodule(root._c, root._c, "child", new_child._c)
+
+        # After replacement, runs SubB.forward (output * 2)
+        out_after = root(inp)
+        self.assertFalse(torch.equal(out_before, out_after))
+
+        # Verify the submodule type was updated
+        self.assertEqual(
+            root._c.attr("child").type().name(),
+            new_child._c.type().name(),
+        )
+
+    def test_jit_replace_submodule_nested(self):
+        """Tests _jit_replace_submodule on a nested submodule with graph remapping."""
+
+        class Leaf(torch.nn.Module):
+            def __init__(self, scale: float) -> None:
+                super().__init__()
+                self.scale = scale
+
+            def forward(self, x):
+                return x * self.scale
+
+        class Mid(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.leaf = Leaf(1.0)
+
+            def forward(self, x):
+                return self.leaf(x)
+
+        class Root(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.mid = Mid()
+
+            def forward(self, x):
+                return self.mid(x)
+
+        root = torch.jit.script(Root())
+        new_leaf = torch.jit.script(Leaf(3.0))
+
+        inp = torch.randn(2, 4)
+        out_before = root(inp)
+
+        # Replace mid.leaf with a new Leaf(3.0)
+        torch._C._jit_replace_submodule(
+            root._c, root.mid._c, "leaf", new_leaf._c
+        )
+
+        out_after = root(inp)
+        self.assertEqual(out_after, inp * 3.0)
+
+
 if __name__ == "__main__":
     raise_on_run_directly("test/test_jit.py")

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -1012,6 +1012,213 @@ class TestModule(TestCase):
                 self.assertTrue(all(a != b for a, b in zip(p_cdatas_before, p_cdatas_after)))
 
 
+class TestJitReplaceSubmodule(TestCase):
+    def test_jit_replace_submodule(self):
+        from torch.jit._recursive import wrap_cpp_module
+
+        class SubA(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class SubB(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x) * 2
+
+        class Parent(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.child = SubA()
+
+            def forward(self, x):
+                return self.child(x)
+
+        root = torch.jit.script(Parent())
+        new_child = torch.jit.script(SubB())
+
+        inp = torch.randn(2, 4)
+        out_before = root(inp)
+
+        root = wrap_cpp_module(
+            torch._C._jit_replace_submodule(root._c, "child", new_child._c)
+        )
+
+        out_after = root(inp)
+        self.assertFalse(torch.equal(out_before, out_after))
+        self.assertEqual(
+            root.child._c._type().name(),
+            new_child._c._type().name(),
+        )
+
+    def test_jit_replace_submodule_nested(self):
+        class Leaf(torch.nn.Module):
+            def __init__(self, scale: float) -> None:
+                super().__init__()
+                self.scale = scale
+
+            def forward(self, x):
+                return x * self.scale
+
+        class Mid(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.leaf = Leaf(1.0)
+
+            def forward(self, x):
+                return self.leaf(x)
+
+        class Root(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.mid = Mid()
+
+            def forward(self, x):
+                return self.mid(x)
+
+        root = torch.jit.script(Root())
+        new_leaf = torch.jit.script(Leaf(3.0))
+
+        inp = torch.randn(2, 4)
+        root = torch.jit._recursive.wrap_cpp_module(
+            torch._C._jit_replace_submodule(root._c, "mid.leaf", new_leaf._c)
+        )
+
+        out_after = root(inp)
+        self.assertEqual(out_after, inp * 3.0)
+
+    def test_jit_replace_submodule_empty_qualified_name(self):
+        class Leaf(torch.nn.Module):
+            def forward(self, x):
+                return x
+
+        class Root(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.child = Leaf()
+
+            def forward(self, x):
+                return self.child(x)
+
+        root = torch.jit.script(Root())
+        new_child = torch.jit.script(Leaf())
+
+        with self.assertRaisesRegex(RuntimeError, "non-empty qualified_name"):
+            torch._C._jit_replace_submodule(root._c, "", new_child._c)
+
+    def test_jit_replace_submodule_missing_segment(self):
+        class Leaf(torch.nn.Module):
+            def forward(self, x):
+                return x
+
+        class Root(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.child = Leaf()
+
+            def forward(self, x):
+                return self.child(x)
+
+        root = torch.jit.script(Root())
+        new_child = torch.jit.script(Leaf())
+
+        with self.assertRaisesRegex(RuntimeError, "could not find submodule path segment 'missing'"):
+            torch._C._jit_replace_submodule(root._c, "missing.leaf", new_child._c)
+
+        with self.assertRaisesRegex(RuntimeError, "could not find submodule path segment 'missing'"):
+            torch._C._jit_replace_submodule(root._c, "missing", new_child._c)
+
+    def test_jit_replace_submodule_non_module_attribute(self):
+        class Leaf(torch.nn.Module):
+            def forward(self, x):
+                return x
+
+        class Root(torch.nn.Module):
+            scalar: int
+
+            def __init__(self) -> None:
+                super().__init__()
+                self.child = Leaf()
+                self.scalar = 7
+
+            def forward(self, x):
+                return self.child(x) + self.scalar
+
+        root = torch.jit.script(Root())
+        new_child = torch.jit.script(Leaf())
+
+        with self.assertRaisesRegex(RuntimeError, "'scalar'.*is not a submodule"):
+            torch._C._jit_replace_submodule(root._c, "scalar", new_child._c)
+
+        with self.assertRaisesRegex(RuntimeError, "'scalar'.*is not a submodule"):
+            torch._C._jit_replace_submodule(root._c, "scalar.nested", new_child._c)
+
+    def test_jit_replace_submodule_shared_parent_type(self):
+        class Leaf(torch.nn.Module):
+            def __init__(self, scale: float) -> None:
+                super().__init__()
+                self.scale = scale
+
+            def forward(self, x):
+                return x * self.scale
+
+        class Mid(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.leaf = Leaf(1.0)
+
+            def forward(self, x):
+                return self.leaf(x)
+
+        class Root(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.mid_a = Mid()
+                self.mid_b = Mid()
+
+            def forward(self, x):
+                return self.mid_a(x) + self.mid_b(x)
+
+        root = torch.jit.script(Root())
+        new_leaf = torch.jit.script(Leaf(2.0))
+
+        with self.assertRaisesRegex(Exception, "unique parent types"):
+            torch._C._jit_replace_submodule(root._c, "mid_a.leaf", new_leaf._c)
+
+    def test_jit_replace_submodule_empty_path_segment(self):
+        class Leaf(torch.nn.Module):
+            def forward(self, x):
+                return x
+
+        class Mid(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.leaf = Leaf()
+
+            def forward(self, x):
+                return self.leaf(x)
+
+        class Root(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.mid = Mid()
+
+            def forward(self, x):
+                return self.mid(x)
+
+        root = torch.jit.script(Root())
+        new_leaf = torch.jit.script(Leaf())
+
+        with self.assertRaisesRegex(RuntimeError, "empty path segments"):
+            torch._C._jit_replace_submodule(root._c, "mid..leaf", new_leaf._c)
+
+
 instantiate_device_type_tests(TestModule, globals(), allow_mps=True, allow_xpu=True)
 
 if __name__ == '__main__':

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -85,6 +85,153 @@ using ClassMethodDefaults = std::unordered_map<std::string, FunctionDefaults>;
 
 namespace {
 
+std::unordered_set<TypePtr> getSharedModuleTypes(Module& mod) {
+  std::unordered_set<TypePtr> types;
+  std::unordered_set<TypePtr> duplicate_types;
+
+  for (auto module : mod.modules()) {
+    auto module_type = module.type();
+    if (types.count(module_type) > 0) {
+      duplicate_types.insert(module_type);
+    }
+    types.insert(module_type);
+  }
+
+  return duplicate_types;
+}
+
+Module cloneSubmoduleToCompilationUnit(
+    const Module& source,
+    const std::shared_ptr<CompilationUnit>& target_cu) {
+  std::unordered_map<TypePtr, TypePtr> type_remap;
+  std::unordered_map<c10::ivalue::Object*, Module> module_remap;
+
+  std::function<Module(const Module&)> clone_module =
+      [&](const Module& current) -> Module {
+    auto* current_obj = current._ivalue().get();
+    auto existing = module_remap.find(current_obj);
+    if (existing != module_remap.end()) {
+      return existing->second;
+    }
+
+    const bool type_already_cloned =
+        type_remap.find(current.type()) != type_remap.end();
+    if (!type_already_cloned) {
+      TORCH_CHECK(
+          current.type()->name().has_value(),
+          "cloneSubmoduleToCompilationUnit requires module types to have a qualified name; got an unnamed type ",
+          current.type()->repr_str());
+    }
+    Module cloned = type_already_cloned
+        ? Module(target_cu, type_remap.at(current.type())->cast<ClassType>())
+        : Module(*current.type()->name(), target_cu, true);
+
+    if (!type_already_cloned) {
+      type_remap[current.type()] = cloned.type();
+    }
+    module_remap.emplace(current_obj, cloned);
+
+    const auto num_attrs = current.type()->numAttributes();
+    for (const auto i : c10::irange(num_attrs)) {
+      const auto& attr_name = current.type()->getAttributeName(i);
+      IValue attr = current._ivalue()->getSlot(i);
+      TypePtr attr_type = current.type()->getAttribute(i);
+      if (attr_type->is_module()) {
+        Module cloned_child = clone_module(attr.toModule());
+        cloned.type()->addOrCheckAttribute(
+            attr_name,
+            attr_type->cast<ClassType>() ? cloned_child.type() : attr_type,
+            current.type()->is_parameter(i),
+            current.type()->is_buffer(i));
+        cloned._ivalue()->setAttr(attr_name, cloned_child._ivalue());
+      } else {
+        cloned.register_attribute(
+            attr_name,
+            attr_type,
+            attr.deepcopy(),
+            current.type()->is_parameter(i),
+            current.type()->is_buffer(i));
+      }
+    }
+
+    if (!type_already_cloned) {
+      for (size_t i = 0; i < current.type()->numConstants(); ++i) {
+        cloned.type()->addConstant(
+            current.type()->getConstantName(i), current.type()->getConstant(i));
+      }
+      for (Function* fn : current.type()->methods()) {
+        cloned.clone_method(current, fn->name());
+      }
+    }
+
+    return cloned;
+  };
+
+  return clone_module(source);
+}
+
+std::pair<Module, std::string> lookupParentModuleAndAttribute(
+    Module root,
+    const std::string& qualified_name) {
+  TORCH_CHECK(
+      !qualified_name.empty(),
+      "_jit_replace_submodule requires a non-empty qualified_name");
+
+  std::vector<std::string> atoms;
+  std::stringstream qualified_name_stream(qualified_name);
+  std::string atom;
+  while (std::getline(qualified_name_stream, atom, '.')) {
+    TORCH_CHECK(
+        !atom.empty(),
+        "_jit_replace_submodule does not support empty path segments in qualified_name: ",
+        qualified_name);
+    atoms.push_back(atom);
+  }
+
+  TORCH_CHECK(
+      !atoms.empty(),
+      "_jit_replace_submodule requires a non-empty qualified_name");
+
+  Module parent = root;
+  for (const auto i : c10::irange(atoms.size() - 1)) {
+    const auto& child_name = atoms[i];
+    TORCH_CHECK(
+        parent.hasattr(child_name),
+        "_jit_replace_submodule could not find submodule path segment '",
+        child_name,
+        "' in qualified_name '",
+        qualified_name,
+        "'");
+    auto child = parent.attr(child_name);
+    TORCH_CHECK(
+        child.isModule(),
+        "_jit_replace_submodule path segment '",
+        child_name,
+        "' in qualified_name '",
+        qualified_name,
+        "' is not a submodule");
+    parent = child.toModule();
+  }
+
+  const auto& attr_name = atoms.back();
+  TORCH_CHECK(
+      parent.hasattr(attr_name),
+      "_jit_replace_submodule could not find submodule path segment '",
+      attr_name,
+      "' in qualified_name '",
+      qualified_name,
+      "'");
+  TORCH_CHECK(
+      parent.attr(attr_name).isModule(),
+      "_jit_replace_submodule path segment '",
+      attr_name,
+      "' in qualified_name '",
+      qualified_name,
+      "' is not a submodule");
+
+  return {parent, attr_name};
+}
+
 // A resolver that will inspect the outer Python scope to find `name`.
 struct PythonResolver : public Resolver {
   explicit PythonResolver(ResolutionCallback rcb) : rcb_(std::move(rcb)) {}
@@ -2439,6 +2586,75 @@ void initJitScriptBindings(PyObject* module) {
   m.def("_jit_is_script_object", [](const py::object& obj) {
     return py::isinstance<Object>(obj);
   });
+
+  // Replace a submodule in a ScriptModule with type-safe ClassType update
+  // and graph type remapping.  Modelled after the backend-lowering pass in
+  // backend_init.cpp which does unsafeChangeAttributeType + remapTypes.
+  //
+  // Returns a cloned root module with the replacement applied. This avoids
+  // mutating a live module hierarchy after methods may already have created
+  // optimized executors.
+  //
+  // Args:
+  //   root   – top-level ScriptModule to clone and update.
+  //   qualified_name – fully qualified path to the submodule to replace.
+  //   new_submodule – the replacement ScriptModule.
+  m.def(
+      "_jit_replace_submodule",
+      [](Module& root,
+         const std::string& qualified_name,
+         Module& new_submodule) {
+        auto cloned_root = root.clone();
+        auto parent_and_attr =
+            lookupParentModuleAndAttribute(cloned_root, qualified_name);
+        auto parent = parent_and_attr.first;
+        const auto& attr_name = parent_and_attr.second;
+        auto old_submodule = parent.attr(attr_name).toModule();
+        auto old_type = old_submodule.type();
+        auto duplicate_types = getSharedModuleTypes(cloned_root);
+
+        if (duplicate_types.count(parent.type()) > 0) {
+          throw py::cast_error(c10::str(
+              "_jit_replace_submodule only supports module hierarchies with unique parent types; ",
+              parent.type()->repr_str(),
+              " is shared"));
+        }
+
+        auto remapped_submodule = cloneSubmoduleToCompilationUnit(
+            new_submodule, cloned_root._ivalue()->compilation_unit());
+        auto new_type = remapped_submodule.type();
+
+        // 1. Update the parent's ClassType to accept the new submodule type.
+        parent.type()->unsafeChangeAttributeType(attr_name, new_type);
+
+        // 2. Set the new submodule value (now passes the subtype check).
+        parent.setattr(attr_name, remapped_submodule._ivalue());
+
+        // 3. Remap the old type to the new type in all graphs reachable
+        //    from the root so that compiled code references the correct
+        //    type.
+        std::unordered_map<TypePtr, TypePtr> type_remap;
+        type_remap[old_type] = new_type;
+        auto type_remap_fn = [&type_remap](TypePtr in) {
+          auto it = type_remap.find(in);
+          if (it == type_remap.end()) {
+            return in;
+          }
+          return it->second;
+        };
+        for (auto module : cloned_root.modules()) {
+          auto module_type = module.type();
+          for (auto& fn : module_type->methods()) {
+            auto method = module.get_method(fn->name());
+            auto graph = method.graph();
+            graph->remapTypes(type_remap_fn);
+            auto new_schema =
+                fn->getSchema().cloneWithRemappedTypes(type_remap_fn);
+            fn->setSchema(new_schema);
+          }
+        }
+        return cloned_root;
+      });
 
   m.def("_get_file_format", [](const std::string& path) {
     switch (getFileFormat(path)) {

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -592,8 +592,9 @@ struct slot_dict_impl {
 
   static void bind(const py::module& m, const char* name) {
     py::class_<slot_dict_impl<Policy>>(m, name)
-        .def(py::init(
-            [](Module& m) { return slot_dict_impl<Policy>(m._ivalue()); }))
+        .def(py::init([](Module& m) {
+          return slot_dict_impl<Policy>(m._ivalue());
+        }))
         .def("contains", &slot_dict_impl<Policy>::contains)
         .def("items", &slot_dict_impl<Policy>::items)
         .def("setattr", &slot_dict_impl<Policy>::setattr)
@@ -772,13 +773,14 @@ void initJitScriptBindings(PyObject* module) {
                   auto ivalue = toIValue(std::move(value), type);
                   self.setattr(name, ivalue);
                 } catch (std::exception& e) {
-                  throw py::cast_error(c10::str(
-                      "Could not cast attribute '",
-                      name,
-                      "' to type ",
-                      type->repr_str(),
-                      ": ",
-                      e.what()));
+                  throw py::cast_error(
+                      c10::str(
+                          "Could not cast attribute '",
+                          name,
+                          "' to type ",
+                          type->repr_str(),
+                          ": ",
+                          e.what()));
                 }
               })
           .def(
@@ -878,11 +880,12 @@ void initJitScriptBindings(PyObject* module) {
 
                   if (auto qualname = self.type()->name()) {
                     auto class_type = getCustomClass(qualname->qualifiedName());
-                    auto self = Object(c10::ivalue::Object::create(
-                        c10::StrongTypePtr(
-                            std::shared_ptr<torch::jit::CompilationUnit>(),
-                            class_type),
-                        1));
+                    auto self = Object(
+                        c10::ivalue::Object::create(
+                            c10::StrongTypePtr(
+                                std::shared_ptr<torch::jit::CompilationUnit>(),
+                                class_type),
+                            1));
 
                     if (auto setstate_method =
                             self.find_method("__setstate__")) {
@@ -917,60 +920,66 @@ void initJitScriptBindings(PyObject* module) {
                 err << "which does not have a __getstate__ method defined!";
                 throw std::runtime_error(err.str());
               })
-          .def(py::pickle(
-              [](const Object& self)
-                  -> std::tuple<py::object, std::string> { // __getstate__
-                if (auto getstate_method = self.find_method("__getstate__")) {
-                  auto object_state = toPyObject((*getstate_method)(Stack{}));
-                  TORCH_INTERNAL_ASSERT(self.type()->name());
-                  return std::make_tuple(
-                      object_state, self.type()->name()->qualifiedName());
-                }
-                std::stringstream err;
-                err << "Tried to serialize object ";
-                if (auto qualname = self.type()->name()) {
-                  err << qualname->qualifiedName() << ' ';
-                }
-                err << "which does not have a __getstate__ method defined!";
-                throw std::runtime_error(err.str());
-              },
-              [](const std::tuple<py::object, std::string>& state_tup)
-                  -> Object {
-                auto [state, qualname] = state_tup;
-                auto class_type = getCustomClass(qualname);
-                TORCH_CHECK(
-                    class_type,
-                    "Tried to deserialize class ",
-                    qualname,
-                    " which is not known to the runtime. "
-                    "If this is a custom C++ class, make "
-                    "sure the appropriate code is linked.");
+          .def(
+              py::pickle(
+                  [](const Object& self)
+                      -> std::tuple<py::object, std::string> { // __getstate__
+                    if (auto getstate_method =
+                            self.find_method("__getstate__")) {
+                      auto object_state =
+                          toPyObject((*getstate_method)(Stack{}));
+                      TORCH_INTERNAL_ASSERT(self.type()->name());
+                      return std::make_tuple(
+                          object_state, self.type()->name()->qualifiedName());
+                    }
+                    std::stringstream err;
+                    err << "Tried to serialize object ";
+                    if (auto qualname = self.type()->name()) {
+                      err << qualname->qualifiedName() << ' ';
+                    }
+                    err << "which does not have a __getstate__ method defined!";
+                    throw std::runtime_error(err.str());
+                  },
+                  [](const std::tuple<py::object, std::string>& state_tup)
+                      -> Object {
+                    auto [state, qualname] = state_tup;
+                    auto class_type = getCustomClass(qualname);
+                    TORCH_CHECK(
+                        class_type,
+                        "Tried to deserialize class ",
+                        qualname,
+                        " which is not known to the runtime. "
+                        "If this is a custom C++ class, make "
+                        "sure the appropriate code is linked.");
 
-                auto self = Object(c10::ivalue::Object::create(
-                    c10::StrongTypePtr(
-                        std::shared_ptr<torch::jit::CompilationUnit>(),
-                        class_type),
-                    1));
-                if (auto setstate_method = self.find_method("__setstate__")) {
-                  auto setstate_schema =
-                      setstate_method->function().getSchema();
-                  TORCH_INTERNAL_ASSERT(
-                      setstate_schema.arguments().size() == 2,
-                      "__setstate__ method for class ",
-                      class_type->repr_str(),
-                      " must have exactly 2 arguments!");
-                  auto state_type = setstate_schema.arguments().at(1).type();
-                  (*setstate_method)(Stack{toIValue(state, state_type)});
-                  return self;
-                }
-                std::stringstream err;
-                err << "Tried to deserialize object ";
-                if (auto qualname = class_type->name()) {
-                  err << qualname->qualifiedName() << ' ';
-                }
-                err << "which does not have a __setstate__ method defined!";
-                throw std::runtime_error(err.str());
-              }));
+                    auto self = Object(
+                        c10::ivalue::Object::create(
+                            c10::StrongTypePtr(
+                                std::shared_ptr<torch::jit::CompilationUnit>(),
+                                class_type),
+                            1));
+                    if (auto setstate_method =
+                            self.find_method("__setstate__")) {
+                      auto setstate_schema =
+                          setstate_method->function().getSchema();
+                      TORCH_INTERNAL_ASSERT(
+                          setstate_schema.arguments().size() == 2,
+                          "__setstate__ method for class ",
+                          class_type->repr_str(),
+                          " must have exactly 2 arguments!");
+                      auto state_type =
+                          setstate_schema.arguments().at(1).type();
+                      (*setstate_method)(Stack{toIValue(state, state_type)});
+                      return self;
+                    }
+                    std::stringstream err;
+                    err << "Tried to deserialize object ";
+                    if (auto qualname = class_type->name()) {
+                      err << qualname->qualifiedName() << ' ';
+                    }
+                    err << "which does not have a __setstate__ method defined!";
+                    throw std::runtime_error(err.str());
+                  }));
 
   py::class_<Object::Property>(m, "ScriptObjectProperty")
       .def_property_readonly(
@@ -1355,9 +1364,10 @@ void initJitScriptBindings(PyObject* module) {
       });
 
   py::class_<mobile::Module>(m, "LiteScriptModule")
-      .def(py::init<
-           c10::intrusive_ptr<c10::ivalue::Object>,
-           std::shared_ptr<mobile::CompilationUnit>>())
+      .def(
+          py::init<
+              c10::intrusive_ptr<c10::ivalue::Object>,
+              std::shared_ptr<mobile::CompilationUnit>>())
       .def(
           "find_method",
           [](mobile::Module& m, const std::string& method_name) {
@@ -2439,6 +2449,57 @@ void initJitScriptBindings(PyObject* module) {
   m.def("_jit_is_script_object", [](const py::object& obj) {
     return py::isinstance<Object>(obj);
   });
+
+  // Replace a submodule in a ScriptModule with type-safe ClassType update
+  // and graph type remapping.  Modelled after the backend-lowering pass in
+  // backend_init.cpp which does unsafeChangeAttributeType + remapTypes.
+  //
+  // Args:
+  //   root   – top-level ScriptModule whose full graph hierarchy will be
+  //            type-remapped (analogous to `mod` in backend_init.cpp).
+  //   parent – direct parent of the submodule being replaced.
+  //   attr_name – attribute name on `parent` to replace.
+  //   new_submodule – the replacement ScriptModule.
+  m.def(
+      "_jit_replace_submodule",
+      [](Module& root,
+         Module& parent,
+         const std::string& attr_name,
+         Module& new_submodule) {
+        auto old_submodule = parent.attr(attr_name).toModule();
+        auto old_type = old_submodule.type();
+        auto new_type = new_submodule.type();
+
+        // 1. Update the parent's ClassType to accept the new submodule type.
+        parent.type()->unsafeChangeAttributeType(attr_name, new_type);
+
+        // 2. Set the new submodule value (now passes the subtype check).
+        parent.setattr(attr_name, new_submodule._ivalue());
+
+        // 3. Remap the old type to the new type in all graphs reachable
+        //    from the root so that compiled code references the correct
+        //    type.
+        std::unordered_map<TypePtr, TypePtr> type_remap;
+        type_remap[old_type] = new_type;
+        auto type_remap_fn = [&type_remap](TypePtr in) {
+          auto it = type_remap.find(in);
+          if (it == type_remap.end()) {
+            return in;
+          }
+          return it->second;
+        };
+        for (auto module : root.modules()) {
+          auto module_type = module.type();
+          for (auto& fn : module_type->methods()) {
+            auto method = module.get_method(fn->name());
+            auto graph = method.graph();
+            graph->remapTypes(type_remap_fn);
+            auto new_schema =
+                fn->getSchema().cloneWithRemappedTypes(type_remap_fn);
+            fn->setSchema(new_schema);
+          }
+        }
+      });
 
   m.def("_get_file_format", [](const std::string& path) {
     switch (getFileFormat(path)) {


### PR DESCRIPTION
Summary:

Adds torch._C._jit_replace_submodule so scripted modules can swap submodules while updating the parent ClassType and remapping referenced types across reachable graphs. Includes direct and nested tests that verify the replaced submodule runs correctly and exposes the new type.

Context:  We currently use torch.package to pass eager models around and swap compiled subgraphs into eager model before torchscripting. But torch.package introduces dependency issues that are difficult to handle. This change allows us to pass a torchscripted model around and swap compiled subgraphs directly into the torchscripted model so we don't have to use torch.package.

Test Plan:
```
buck test fbcode//caffe2/test:jit -- TestModuleAPIs.test_jit_replace_submodule TestModuleAPIs.test_jit_replace_submodule_nested
```

Reviewed By: ZixinYang

Differential Revision: D100195628


