### PR TITLE
Fix inductor AOTI codegen for float('inf')/float('-inf') kernel args (#180297)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -4259,6 +4259,36 @@ class AOTInductorTestsTemplate:
             dynamic_shapes=dynamic_shapes,
         )
 
+    @common_utils.parametrize("threshold", [float("inf"), float("-inf"), float("nan")])
+    def test_triton_kernel_inf_float_arg(self, threshold):
+        if self.device != GPU_TYPE or self.device == "mps":
+            raise unittest.SkipTest("requires GPU")
+
+        @triton.jit
+        def clamp_kernel(
+            in_ptr, out_ptr, threshold, n_elements, BLOCK_SIZE: "tl.constexpr"
+        ):
+            pid = tl.program_id(0)
+            offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr + offsets, mask=mask)
+            out = tl.where(x > threshold, threshold, x)
+            tl.store(out_ptr + offsets, out, mask=mask)
+
+        class Model(torch.nn.Module):
+            def __init__(self, t):
+                super().__init__()
+                self.t = t
+
+            def forward(self, x):
+                out = torch.empty_like(x)
+                n = x.numel()
+                clamp_kernel[(n,)](x, out, self.t, n, BLOCK_SIZE=16)
+                return out
+
+        example_inputs = (torch.randn(16, device=self.device),)
+        self.check_model(Model(threshold), example_inputs)
+
     def test_triton_kernel_weird_param_order(self):
         if self.device != GPU_TYPE:
             raise unittest.SkipTest("requires GPU")

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1293,9 +1293,8 @@ static struct TritonKernelCompileInit {{
             call_args_str = ", ".join(casted)
             self.writeline(f"kernels.{kernel_name}({call_args_str}, {stream});")
 
-    @staticmethod
     def prepare_triton_wrapper_args(
-        call_args: list[Any], arg_types: list[Any]
+        self, call_args: list[Any], arg_types: list[Any]
     ) -> tuple[list[Any], list[Any]]:
         assert len(call_args) == len(arg_types), (call_args, arg_types)
         new_args = []
@@ -1309,7 +1308,10 @@ static struct TritonKernelCompileInit {{
             elif isinstance(arg, bool):
                 new_args.append(str(arg).lower())
             elif isinstance(arg, (int, float, SymbolicCallArg)):
-                new_args.append(str(arg))
+                if isinstance(arg, float):
+                    new_args.append(self.generate_float_value(arg))
+                else:
+                    new_args.append(str(arg))
             else:
                 new_args.append(cexpr(V.graph.sizevars.simplify(arg)))
             new_args_types.append(arg_type)

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1471,6 +1471,7 @@ class PythonWrapperCodegen(CodeGen):
         self.kernel_autotune_defs.splice(
             f"""
                 import torch
+                from math import inf, nan
                 from torch._dynamo.testing import rand_strided
                 from torch._dynamo.utils import preserve_rng_state
                 from torch._inductor.select_algorithm import AlgorithmSelectorCache


### PR DESCRIPTION
Summary:

Triton team found a case where `inf`-like arguments were not handled by Inductor. So, this is our fix.
---
Two bugs in PyTorch Inductor's AOTI code generation cause compilation failures when user-defined Triton kernels (via triton_op) receive float('-inf') or float('inf') as scalar arguments:

1. C++ wrapper codegen (cpp_wrapper_gpu.py): `prepare_triton_wrapper_args` used `str(float('-inf'))` which produces bare `"-inf"` — not valid C++. Now emits `std::numeric_limits<double>::infinity()` for inf/nan values, consistent with the existing `CppWrapperCpu.generate_float_value()` method.

2. Python autotune exec scope (wrapper.py): `write_kernel_autotune_defs_header()` was missing `from math import inf, nan`. The main wrapper imports (line 1389) include this, but the autotune exec scope did not, causing NameError when `repr()` of metadata dicts produces bare `inf`.

Test Plan:
Added `test_triton_kernel_inf_float_arg` to `test_aot_inductor.py` with a minimal inline Triton kernel that takes a float threshold parameter, parametrized over `float('inf')`, `float('-inf')`, and `float('nan')`.

Without this fix, the test fails with a C++ compile error:
```
CppCompileError: C++ compile error
error: use of undeclared identifier 'inf'
```
Test session (without fix): https://www.internalfb.com/intern/testinfra/testrun/10696049280457430

Reviewed By: desertfire

Differential Revision: D100722617




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo