### PR TITLE
Fix undefined symbolic variable in fx_graph_runnable repro scripts (#180298)

### DIFF
--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -10,6 +10,7 @@ import unittest
 import torch._dynamo.test_case
 from torch._dynamo.repro.after_aot import (
     _extract_distributed_info,
+    _get_compile_args,
     InputReader,
     InputWriter,
     save_graph_repro,
@@ -184,6 +185,132 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
 
         result = _extract_distributed_info(gm)
         self.assertEqual(result, {})
+
+    def test_get_compile_args_symbolic_tracing(self):
+        """_get_compile_args extracts FakeTensor/SymInt from symbolic tracing."""
+
+        def f(x, size):
+            return (x[:size],)
+
+        args = [torch.randn(10), 5]
+        gm = make_fx(f, tracing_mode="symbolic")(*args)
+        result = _get_compile_args(gm, args)
+        # Should NOT be the same object — metadata was extracted
+        self.assertIsNot(result, args)
+        # First element should be a FakeTensor (not a concrete tensor)
+        self.assertIsInstance(result[0], torch._subclasses.FakeTensor)
+        # Second element should be a SymInt (not a concrete int)
+        self.assertIsInstance(result[1], torch.SymInt)
+
+    def test_get_compile_args_preserves_shapes(self):
+        """_get_compile_args preserves symbolic shape info from traced graph."""
+
+        def f(x):
+            return (x * 2,)
+
+        args = [torch.randn(4, 8)]
+        gm = make_fx(f, tracing_mode="symbolic")(*args)
+        result = _get_compile_args(gm, args)
+        # FakeTensor should preserve the shape
+        self.assertEqual(result[0].shape, torch.Size([4, 8]))
+
+    def test_get_compile_args_real_tracing_returns_concrete(self):
+        """_get_compile_args returns original args for real-mode tracing.
+
+        make_fx with tracing_mode='real' produces FakeTensors in placeholder
+        metadata, but from different FakeTensorModes.  Extracting these would
+        cause a FakeTensorMode mismatch in Inductor.  _get_compile_args must
+        detect this and return concrete args instead.
+        """
+
+        def f(x, y):
+            return (x + y,)
+
+        args = [torch.randn(4), torch.randn(4)]
+        gm = make_fx(f, tracing_mode="real")(*args)
+        result = _get_compile_args(gm, args)
+        # For real tracing (no SymInt inputs), should return args as-is
+        self.assertIs(result, args)
+
+    def test_get_compile_args_empty_graph(self):
+        """_get_compile_args handles empty graph with no placeholders."""
+        gm = torch.fx.GraphModule({}, torch.fx.Graph())
+        gm.graph.output(None)
+        gm.recompile()
+        args = [torch.randn(4)]
+        result = _get_compile_args(gm, args)
+        self.assertIs(result, args)
+
+    def test_get_compile_args_e2e_symbolic_compile(self):
+        """E2E: compile_fx_inner fails with concrete args but succeeds
+        with _get_compile_args for symbolically-traced graphs.
+
+        This is the minimal repro for the 'NameError: name s48 is not
+        defined' bug in fx_graph_runnable repro scripts.
+        """
+        from torch._inductor.compile_fx import compile_fx_inner
+
+        def f(n, x, y):
+            sliced = x[:n]
+            scaled = sliced * (n - 1)
+            return (scaled + y[:n],)
+
+        N = 16
+        concrete_args = [N, torch.randn(32), torch.randn(32)]
+        gm = make_fx(f, tracing_mode="symbolic")(*concrete_args)
+
+        # BUG: concrete args cause NameError on undefined symbolic variable
+        with self.assertRaises(NameError):
+            compiled = compile_fx_inner(gm, concrete_args)
+            self.assertNotIsInstance(compiled, str)
+            compiled(list(concrete_args))
+
+        # FIX: _get_compile_args extracts symbolic metadata
+        symbolic_args = _get_compile_args(gm, concrete_args)
+        compiled = compile_fx_inner(gm, symbolic_args)
+        self.assertNotIsInstance(compiled, str)
+        result = compiled(list(concrete_args))
+        self.assertEqual(result[0].shape, torch.Size([N]))
+
+    def test_get_compile_args_e2e_real_no_fake_mode_mismatch(self):
+        """E2E: compile_fx_inner fails when given FakeTensors from
+        different FakeTensorModes (extracted from real-mode traced graph
+        placeholder metadata) but succeeds with _get_compile_args which
+        returns concrete args for real-mode tracing.
+
+        This is the minimal repro for the FakeTensorMode mismatch
+        AssertionError that affected 85/126 graphs in the model extractor.
+        """
+        from torch._inductor.compile_fx import compile_fx_inner
+
+        def f(x, y):
+            return (x + y,)
+
+        args = [torch.randn(4), torch.randn(4)]
+        gm = make_fx(f, tracing_mode="real")(*args)
+
+        # Verify that real-mode tracing creates FakeTensors with
+        # different FakeTensorModes in placeholder metadata
+        placeholders = [n for n in gm.graph.nodes if n.op == "placeholder"]
+        fake_modes = set()
+        for n in placeholders:
+            val = n.meta.get("val")
+            if isinstance(val, torch._subclasses.FakeTensor):
+                fake_modes.add(id(val.fake_mode))
+        self.assertGreater(len(fake_modes), 1, "Expected different FakeTensorModes")
+
+        # BUG: manually extracting FakeTensors causes mode mismatch
+        fake_args = [n.meta["val"] for n in placeholders]
+        with self.assertRaisesRegex(Exception, "fake mode.*doesn't match"):
+            compile_fx_inner(gm, fake_args)
+
+        # FIX: _get_compile_args returns concrete args for real mode
+        compile_args = _get_compile_args(gm, args)
+        self.assertIs(compile_args, args)
+        compiled = compile_fx_inner(gm, compile_args)
+        self.assertNotIsInstance(compiled, str)
+        result = compiled(list(args))
+        self.assertEqual(result[0].shape, torch.Size([4]))
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -988,7 +988,8 @@ def inductor_fails(
     sync()
 
     try:
-        compile_mod = compile_fx_inner(fx_g, args)
+        compile_args = _get_compile_args(fx_g, args)
+        compile_mod = compile_fx_inner(fx_g, compile_args)
         assert not isinstance(compile_mod, str)
         compile_mod(args)
         sync()
@@ -1010,10 +1011,15 @@ def inductor_accuracy_fails(
 ) -> bool:
     from torch._inductor.compile_fx import compile_fx_inner
 
+    def _compile_with_symbolic_args(
+        gm: torch.fx.GraphModule, inputs: list[Any]
+    ) -> torch.fx.GraphModule:
+        return compile_fx_inner(gm, _get_compile_args(gm, inputs))  # type: ignore[return-value]
+
     return backend_aot_accuracy_fails(
         fx_g,
         args,  # type: ignore[arg-type]
-        compile_fx_inner,  # type: ignore[arg-type]
+        _compile_with_symbolic_args,  # type: ignore[arg-type]
         require_fp64=require_fp64,
         ignore_non_fp=ignore_non_fp,
     )
@@ -1071,6 +1077,33 @@ def repro_common(
     torch._inductor.config.generate_intermediate_hooks = True
 
     return mod, args
+
+
+def _get_compile_args(mod: torch.fx.GraphModule, args: Sequence[Any]) -> Sequence[Any]:
+    """Extract FakeTensor/SymInt args from the traced graph for compilation.
+
+    When repro_common traces with tracing_mode='symbolic', the resulting
+    GraphModule's placeholder nodes carry FakeTensor/SymInt metadata.
+    compile_fx_inner needs these (not the concrete args) so that Inductor
+    generates proper symbolic-size bindings in the output code.
+
+    For tracing_mode='real', concrete args are fine — we must NOT extract
+    FakeTensor metadata because different nodes may have FakeTensors from
+    different FakeTensorModes, causing a FakeTensorMode mismatch assertion
+    in Inductor.  We detect symbolic tracing by checking for SymInt values,
+    which only exist when tracing_mode='symbolic'.
+    """
+    placeholders = [n for n in mod.graph.nodes if n.op == "placeholder"]
+    if not placeholders:
+        return args
+    # Only extract metadata if the graph was traced with symbolic mode.
+    # SymInt values in placeholder metadata are the reliable indicator —
+    # FakeTensors appear in both real and symbolic modes, but only symbolic
+    # tracing creates SymInts for integer inputs.
+    has_symint = any(isinstance(n.meta.get("val"), torch.SymInt) for n in placeholders)
+    if not has_symint:
+        return args
+    return [n.meta.get("val", a) for n, a in zip(placeholders, args)]
 
 
 ACCURACY_FAILS: dict[str, Callable[[torch.fx.GraphModule, Any], bool]] = {
@@ -1147,8 +1180,9 @@ def repro_analyze(options: Any, mod: nn.Module, load_args: Any) -> None:
     # It is certainly faster though!  It probably makes sense to let the
     # user specify the offload strategy.
 
+    compile_args = _get_compile_args(mod, args)
     with tqdm(desc="Compiling"):
-        compiled = compile_fx_inner(mod, args)
+        compiled = compile_fx_inner(mod, compile_args)
     total = counters["inductor"]["intermediate_hooks"]
 
     known_names = set()
@@ -1288,7 +1322,8 @@ def repro_run(options: Any, mod: nn.Module, load_args: Any) -> None:
 
     from torch.cuda import synchronize
 
-    compiled = compile_fx_inner(mod, args)
+    compile_args = _get_compile_args(mod, args)
+    compiled = compile_fx_inner(mod, compile_args)
     assert not isinstance(compiled, str)
 
     if options.accuracy != "":


### PR DESCRIPTION
Summary:

## Background

fx_graph_runnable repro scripts are standalone Python scripts that reconstruct an FX graph module and call `run_repro()` from `torch._dynamo.repro.after_aot` to recompile and execute the graph through Inductor. When the original graph had dynamic shapes, the repro script is generated with `tracing_mode='symbolic'`.

## The Bug

`repro_common()` in `after_aot.py` traces with `make_fx(mod, tracing_mode='symbolic')(*args)` which creates SymInt/FakeTensor metadata on placeholder nodes. But it then passes the original *concrete* args to `compile_fx_inner`. Inductor generates code referencing symbolic variables (e.g. `s0`, `s48`) that were never bound, causing:

```
NameError: name 's48' is not defined
```

A related bug: for `tracing_mode='real'`, extracting FakeTensors from placeholder metadata causes a FakeTensorMode mismatch assertion because `make_fx` creates a different FakeTensorMode for each output tensor in real mode.

## The Fix

Add `_get_compile_args()` which:
- For symbolic tracing: extracts FakeTensor/SymInt metadata from placeholder nodes and passes those to `compile_fx_inner`
- For real tracing: returns concrete args unchanged (avoiding FakeTensorMode mismatch)

Detection: SymInt values in placeholder metadata are the reliable indicator of symbolic tracing — FakeTensors appear in both modes, but only symbolic tracing creates SymInts.

All callers of `compile_fx_inner` in the repro pipeline (`repro_run`, `repro_analyze`, `inductor_fails`, `inductor_accuracy_fails`) are updated to use `_get_compile_args`.

Test Plan:
Unit tests:
```
python test/dynamo/test_after_aot.py TestAfterAot.test_get_compile_args_symbolic_tracing
python test/dynamo/test_after_aot.py TestAfterAot.test_get_compile_args_preserves_shapes
python test/dynamo/test_after_aot.py TestAfterAot.test_get_compile_args_real_tracing_returns_concrete
python test/dynamo/test_after_aot.py TestAfterAot.test_get_compile_args_empty_graph
python test/dynamo/test_after_aot.py TestAfterAot.test_get_compile_args_e2e_symbolic_compile
python test/dynamo/test_after_aot.py TestAfterAot.test_get_compile_args_e2e_real_no_fake_mode_mismatch
```

Reviewed By: PaulZhang12

Differential Revision: D100024815




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98