### PR TITLE
Add OpaqueGenerator to allow make_fx trace Generator

### DIFF
--- a/test/dynamo/test_after_aot.py
+++ b/test/dynamo/test_after_aot.py
@@ -15,6 +15,7 @@ from torch._dynamo.repro.after_aot import (
     save_graph_repro,
 )
 from torch._higher_order_ops.triton_kernel_wrap import kernel_side_table
+from torch._prims.rng_prims import OpaqueGenerator
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import IS_FBCODE, TEST_CUDA
 from torch.utils._traceback import report_compile_source_on_error
@@ -146,7 +147,7 @@ reader.tensor(buf0, (3, 4, 5, 6), (120, 1, 24, 4), is_leaf=True)  # x""",
         reader = InputReader(None)
         env = {"reader": reader, "torch": torch}
         exec("\n".join(writer._lines), env)
-        self.assertIsInstance(reader.args[0], torch._C.Generator)
+        self.assertIsInstance(reader.args[0], OpaqueGenerator)
         self.assertEqual(reader.args[0].device, torch.device("cuda", 0))
 
     @unittest.skipIf(not TEST_CUDA, "requires CUDA")

--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3961,7 +3961,13 @@ class TestOpaqueGenerator(TestCase):
             def forward(self, q, k, v, rng_state):
                 out = graphsafe_run_with_rng_state(
                     torch.ops.aten._scaled_dot_product_efficient_attention.default,
-                    q, k, v, None, True, 0.1, True,
+                    q,
+                    k,
+                    v,
+                    None,
+                    True,
+                    0.1,
+                    True,
                     rng_state=rng_state,
                 )
                 return out[0]
@@ -3986,7 +3992,13 @@ class TestOpaqueGenerator(TestCase):
             def forward(self, q, k, v, rng_state):
                 out = graphsafe_run_with_rng_state(
                     torch.ops.aten._scaled_dot_product_efficient_attention.default,
-                    q, k, v, None, False, 0.0, True,
+                    q,
+                    k,
+                    v,
+                    None,
+                    False,
+                    0.0,
+                    True,
                     rng_state=rng_state,
                 )
                 return out[0]

--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -3949,5 +3949,56 @@ class GraphModule(torch.nn.Module):
 instantiate_parametrized_tests(TestOpaqueObject)
 
 
+@unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+class TestOpaqueGenerator(TestCase):
+    def test_make_fx_with_opaque_generator(self):
+        """make_fx should trace through OpaqueGenerator inputs."""
+        from torch._prims.rng_prims import graphsafe_run_with_rng_state, OpaqueGenerator
+
+        torch.cuda.init()
+
+        class M(torch.nn.Module):
+            def forward(self, q, k, v, rng_state):
+                out = graphsafe_run_with_rng_state(
+                    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+                    q, k, v, None, True, 0.1, True,
+                    rng_state=rng_state,
+                )
+                return out[0]
+
+        q = torch.randn(2, 8, 64, 32, device="cuda", dtype=torch.float16)
+        k = torch.randn(2, 8, 64, 32, device="cuda", dtype=torch.float16)
+        v = torch.randn(2, 8, 64, 32, device="cuda", dtype=torch.float16)
+        gen = OpaqueGenerator(torch.cuda.default_generators[0].clone_state())
+
+        gm = make_fx(M(), tracing_mode="real")(q, k, v, gen)
+
+        # The last placeholder (generator) should be used by graphsafe_run_with_rng_state
+        placeholders = [n for n in gm.graph.nodes if n.op == "placeholder"]
+        gen_placeholder = placeholders[-1]
+        self.assertEqual(len(gen_placeholder.users), 1)
+        user = next(iter(gen_placeholder.users))
+        self.assertIs(user.target, graphsafe_run_with_rng_state)
+
+        # Verify the traced graph produces the same result as eager.
+        # Use dropout_p=0.0 so the result is deterministic.
+        class M0(torch.nn.Module):
+            def forward(self, q, k, v, rng_state):
+                out = graphsafe_run_with_rng_state(
+                    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+                    q, k, v, None, False, 0.0, True,
+                    rng_state=rng_state,
+                )
+                return out[0]
+
+        gen1 = OpaqueGenerator(torch.cuda.default_generators[0].clone_state())
+        gen2 = OpaqueGenerator(torch.cuda.default_generators[0].clone_state())
+        gm0 = make_fx(M0(), tracing_mode="real")(q, k, v, gen1)
+        expected = M0()(q, k, v, gen2)
+        gen3 = OpaqueGenerator(torch.cuda.default_generators[0].clone_state())
+        actual = gm0(q, k, v, gen3)
+        self.assertEqual(actual, expected)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -683,8 +683,10 @@ class InputReader:
     def unsupported(self, name: str) -> None:
         self.args.append(None)
 
-    def generator(self, device_type: str, device_index: int) -> torch._C.Generator:
-        gen = torch.cuda.default_generators[device_index].clone_state()
+    def generator(self, device_type: str, device_index: int) -> Any:
+        from torch._prims.rng_prims import OpaqueGenerator
+
+        gen = OpaqueGenerator(torch.cuda.default_generators[device_index].clone_state())
         self.args.append(gen)
         return gen
 

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1244,7 +1244,9 @@ class GraphLowering(torch.fx.Interpreter):
             self.graph_input_names.append(target)
             return None
         # See note: Note: [Generator arguments in AOTDispatcher]
-        elif isinstance(example, torch.Generator):
+        elif isinstance(
+            example, (torch.Generator, torch._prims.rng_prims.OpaqueGenerator)
+        ):
             assert len(V.graph.current_node.users) == 1 and next(
                 iter(V.graph.current_node.users)
             ).target in (

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -337,6 +337,8 @@ def register_graphsafe_run_with_rng_state_op():
 
     @graphsafe_run_with_rng_state.py_impl(DispatchKey.CUDA)
     def impl_cuda(op, *args, rng_state=None, **kwargs):
+        if isinstance(rng_state, OpaqueGenerator):
+            rng_state = rng_state.generator
         # pyrefly: ignore [missing-attribute]
         device_idx = rng_state.device.index
         generator = torch.cuda.default_generators[device_idx]
@@ -392,6 +394,26 @@ def register_graphsafe_run_with_rng_state_op():
 
 
 graphsafe_run_with_rng_state = register_graphsafe_run_with_rng_state_op()
+
+
+class OpaqueGenerator(torch._opaque_base.OpaqueBase):
+    """Opaque wrapper around torch._C.Generator for FX tracing.
+
+    torch._C.Generator doesn't support weakref or __dict__, so it can't be
+    tracked by FX's proxy infrastructure directly. This wrapper implements the
+    opaque reference type protocol so generators flow through make_fx properly.
+    Generators are stateful objects, so reference semantics are appropriate.
+    """
+
+    def __init__(self, generator: torch.Generator) -> None:
+        self.generator = generator
+
+    @property
+    def device(self) -> torch.device:
+        return self.generator.device
+
+
+torch._library.opaque_object.register_opaque_type(OpaqueGenerator, typ="reference")
 
 
 def register_run_dtensor_rng_op():


### PR DESCRIPTION
Summary:
torch._C.Generator doesn't support weakref or __dict__, so it can't be tracked by FX's proxy infrastructure directly. This adds an OpaqueGenerator wrapper that implements the opaque reference type protocol so generators flow through make_fx properly.

After the generator serialization fix (D100061960), repro_common calls `make_fx(mod)(*args)` with Generator objects in args. `make_fx`'s tracer fails in `TracerBase.create_arg` because it can't create an FX proxy for `torch._C.Generator`.

This introduces OpaqueGenerator, a wrapper class registered as an opaque reference type via register_opaque_type. Generators are stateful objects, so reference semantics are appropriate — the generator becomes a graph input (placeholder) rather than being baked into the graph as a constant.

Changes:
- Add OpaqueGenerator class in torch/_prims/rng_prims.py inheriting from OpaqueBase
- Register it as an opaque reference type
- Update InputReader.generator to return OpaqueGenerator instead of raw Generator
- Update inductor graph.py to recognize OpaqueGenerator in placeholder handling
- Update CUDA impl to unwrap OpaqueGenerator before accessing .device
- Add test_make_fx_with_opaque_generator in test_opaque_obj_v2.py
- Update test_dump_generator assertion in test_after_aot.py

Test Plan:
Unit tests:
```
python test/test_opaque_obj_v2.py TestOpaqueGenerator.test_make_fx_with_opaque_generator
python test/dynamo/test_after_aot.py TestAfterAot.test_dump_generator
```

Differential Revision: D100707158




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98