### PR TITLE
[DTensor] Register sharding strategies for upsample/interpolation backward ops

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1654,17 +1654,74 @@ class DistMathOpsTest(DTensorTestBase):
     @with_comms
     @skip_unless_torch_gpu
     def test_interpolation_upsample_ops(self):
+        """Test forward and backward for F.interpolate with DTensor.
+
+        Verifies output and gradient correctness for all interpolation modes
+        across batch-shard, channel-shard, and replicate placements. Also
+        checks that sharded placements incur no communication in backward.
+        """
         device_mesh = self.build_device_mesh()
         F = torch.nn.functional
+        comm_mode = CommDebugMode()
 
+        # Test configs: (input_shape, output_size, mode, align_corners)
+        # Covers upsample forward and backward ops. "area" mode is excluded
+        # here because it dispatches to adaptive_avg_pool2d (tested separately).
+        test_configs = [
+            # 1D: (N, C, L)
+            ((8, 4, 16), (8,), "linear", True),
+            ((8, 4, 16), (32,), "nearest", None),
+            # 2D: (N, C, H, W)
+            ((8, 4, 8, 8), (16, 16), "bilinear", True),
+            ((8, 4, 8, 8), (16, 16), "bicubic", True),
+            ((8, 4, 8, 8), (4, 4), "nearest", None),
+            # 3D: (N, C, D, H, W)
+            ((8, 4, 4, 4, 4), (8, 8, 8), "trilinear", True),
+        ]
+
+        placements_to_test = [[Shard(0)], [Shard(1)], [Replicate()]]
+
+        for shape, out_size, mode, align_corners in test_configs:
+            for placements in placements_to_test:
+                with self.subTest(shape=shape, mode=mode, placements=placements):
+                    kwargs = {"size": out_size, "mode": mode}
+                    if align_corners is not None:
+                        kwargs["align_corners"] = align_corners
+
+                    # Reference: plain tensor forward + backward
+                    inp_ref = torch.randn(
+                        shape, device=self.device_type, requires_grad=True
+                    )
+                    out_ref = F.interpolate(inp_ref, **kwargs)
+                    out_ref.sum().backward()
+
+                    # DTensor: forward + backward
+                    inp = inp_ref.detach().clone().requires_grad_(True)
+                    dt_inp = distribute_tensor(inp, device_mesh, placements)
+                    dt_out = F.interpolate(dt_inp, **kwargs)
+
+                    self.assertEqual(dt_out.full_tensor(), out_ref)
+
+                    dt_out.sum().backward()
+                    self.assertEqual(dt_inp.grad.full_tensor(), inp_ref.grad)
+
+                    # No communication needed: upsample backward runs
+                    # independently on each local shard or replica.
+                    inp2 = inp_ref.detach().clone().requires_grad_(True)
+                    dt_inp2 = distribute_tensor(inp2, device_mesh, placements)
+                    dt_out2 = F.interpolate(dt_inp2, **kwargs)
+                    with comm_mode:
+                        dt_out2.sum().backward()
+                    self.assertEqual(
+                        comm_mode.get_total_counts(),
+                        0,
+                        f"Unexpected communication in backward for "
+                        f"{mode} with {placements}",
+                    )
+
+        # Forward-only tests for pooling ops (backward uses different ops)
         inp = torch.randn(8, 3, 16, 16, device=self.device_type)
         dt_inp = distribute_tensor(inp, device_mesh, [Shard(0)])
-
-        # F.interpolate with nearest mode
-        expected = F.interpolate(inp, size=(8, 8), mode="nearest")
-        result = F.interpolate(dt_inp, size=(8, 8), mode="nearest")
-        self.assertEqual(result.full_tensor(), expected)
-        self.assertTrue(result.placements[0].is_shard(0))
 
         # F.interpolate with area mode
         expected = F.interpolate(inp, size=(8, 8), mode="area")

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1640,6 +1640,7 @@ def linalg_cross_strategy(
 
 @register_single_dim_strategy(
     [
+        # Forward ops
         aten.upsample_nearest1d.default,
         aten.upsample_nearest2d.default,
         aten.upsample_nearest3d.default,
@@ -1651,6 +1652,18 @@ def linalg_cross_strategy(
         aten.upsample_bilinear2d.default,
         aten.upsample_linear1d.default,
         aten.upsample_trilinear3d.default,
+        # Backward ops
+        aten.upsample_nearest1d_backward.default,
+        aten.upsample_nearest2d_backward.default,
+        aten.upsample_nearest3d_backward.default,
+        aten._upsample_nearest_exact1d_backward.default,
+        aten._upsample_nearest_exact2d_backward.default,
+        aten._upsample_nearest_exact3d_backward.default,
+        aten._upsample_bilinear2d_aa_backward.default,
+        aten.upsample_bicubic2d_backward.default,
+        aten.upsample_bilinear2d_backward.default,
+        aten.upsample_linear1d_backward.default,
+        aten.upsample_trilinear3d_backward.default,
     ],
     schema_info=RuntimeSchemaInfo(1),
 )


### PR DESCRIPTION
Register DTensor sharding strategies for all `F.interpolate` / upsample backward ops. The forward ops already had strategies registered in `interp_upsample_1out_1in_strategy`, but the corresponding backward ops were missing, causing `NotImplementedError` during `loss.backward()` when a DTensor flows through `F.interpolate`.                                                                                                            
                                                            
This was discovered while devloping Qwen3-VL in torchtitan, where a learnable position embedding (DTensor with `Replicate` placement) passes through `F.interpolate(mode='bilinear')` for resolution-adaptive position encoding. Forward worked, backward crashed: `NotImplementedError: Operator aten.upsample_bilinear2d_backward.default does not have a sharding strategy registered`.  

Test plan
 - `python test/distributed/tensor/test_math_ops.py -k test_interpolation_upsample_ops`. 2 tests, 18 subtests, all pass                           
 - Verified end-to-end in torchtitan Qwen3-VL training with `F.interpolate` on DTensor parameters (forward + backward)

