### PR TITLE
[PyTorch] Update _cslt_sparse_mm meta registration for hipSPARSELt

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -826,10 +826,6 @@ def meta__cslt_sparse_mm(
 
     is_8bit_input_type = compressed_A.dtype in [torch.int8, torch.float8_e4m3fn]
 
-    if is_8bit_input_type:
-        if dense_B.is_contiguous():
-            raise AssertionError("dense input must be transposed for 8bit dtypes")
-
     n = dense_B.size(1)
     m = compressed_A.size(0)
     if bias is not None:
@@ -845,6 +841,7 @@ def meta__cslt_sparse_mm(
             in {
                 torch.float16,
                 torch.bfloat16,
+                torch.float32,
                 torch.int32,
                 torch.float8_e4m3fn,
             }


### PR DESCRIPTION
Summary:
Two changes to the `_cslt_sparse_mm` meta registration to support hipSPARSELt:

1. Remove the assertion requiring transposed dense input for 8-bit dtypes — hipSPARSELt handles both contiguous and transposed inputs.
2. Add `torch.float32` to the allowed `out_dtype` set — hipSPARSELt supports float32 output.

Split from D100640267 to land PyTorch and TorchAO changes separately.

Test Plan: Tested as part of D100640267 — the hipSPARSELt sparse tensor subclass exercises both code paths.

Differential Revision: D102398583
