### PR TITLE
Add _Float16 support for Tensor::item() C++ API

### DIFF
--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -58,4 +58,11 @@ T* TensorBase::data_ptr() const {
  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(DEFINE_ITEM)
  #undef DEFINE_ITEM
 
+#if defined(C10_HAS_FLOAT16_TYPE)
+template <>
+TORCH_API _Float16 Tensor::item() const {
+  return static_cast<_Float16>(item().toHalf());
+}
+#endif
+
  } //namespace at

--- a/torch/headeronly/util/Half.h
+++ b/torch/headeronly/util/Half.h
@@ -98,7 +98,7 @@ struct alignas(2) Half {
   inline C10_HOST_DEVICE Half(float value);
   inline C10_HOST_DEVICE operator float() const;
 #if defined(C10_HAS_FLOAT16_TYPE)
-  inline Half(_Float16 value);
+  explicit inline Half(_Float16 value);
   inline operator _Float16() const;
 #endif
 #endif

--- a/torch/headeronly/util/Half.h
+++ b/torch/headeronly/util/Half.h
@@ -67,8 +67,8 @@
 // __FLT16_MAX__ is defined by GCC/Clang when _Float16 is available.
 // Excluded on aarch64 (already has native float16_t from ARM NEON)
 // and during CUDA/HIP compilation (they have their own half types).
-#if defined(__FLT16_MAX__) && !defined(__aarch64__) && \
-    !defined(__CUDACC__) && !defined(__HIPCC__)
+#if defined(__FLT16_MAX__) && !defined(__aarch64__) && !defined(__CUDACC__) && \
+    !defined(__HIPCC__)
 #define C10_HAS_FLOAT16_TYPE 1
 #endif
 
@@ -98,7 +98,6 @@ struct alignas(2) Half {
   inline C10_HOST_DEVICE Half(float value);
   inline C10_HOST_DEVICE operator float() const;
 #if defined(C10_HAS_FLOAT16_TYPE)
-  explicit inline Half(_Float16 value);
   inline operator _Float16() const;
 #endif
 #endif
@@ -480,8 +479,6 @@ inline C10_HOST_DEVICE Half::operator float() const {
 }
 
 #if defined(C10_HAS_FLOAT16_TYPE)
-inline Half::Half(_Float16 value)
-    : x(detail::fp16_ieee_from_fp32_value(static_cast<float>(value))) {}
 inline Half::operator _Float16() const {
   return static_cast<_Float16>(detail::fp16_ieee_to_fp32_value(x));
 }

--- a/torch/headeronly/util/Half.h
+++ b/torch/headeronly/util/Half.h
@@ -63,6 +63,15 @@
 #endif // __x86_64__ || _M_X64 || __i386 || _M_IX86
 #endif // __GNUC__ || __clang__
 
+// Detect compiler-builtin _Float16 type support.
+// __FLT16_MAX__ is defined by GCC/Clang when _Float16 is available.
+// Excluded on aarch64 (already has native float16_t from ARM NEON)
+// and during CUDA/HIP compilation (they have their own half types).
+#if defined(__FLT16_MAX__) && !defined(__aarch64__) && \
+    !defined(__CUDACC__) && !defined(__HIPCC__)
+#define C10_HAS_FLOAT16_TYPE 1
+#endif
+
 namespace c10 {
 
 struct alignas(2) Half {
@@ -88,6 +97,10 @@ struct alignas(2) Half {
 #else
   inline C10_HOST_DEVICE Half(float value);
   inline C10_HOST_DEVICE operator float() const;
+#if defined(C10_HAS_FLOAT16_TYPE)
+  inline Half(_Float16 value);
+  inline operator _Float16() const;
+#endif
 #endif
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
@@ -465,6 +478,14 @@ inline C10_HOST_DEVICE Half::operator float() const {
   return detail::fp16_ieee_to_fp32_value(x);
 #endif
 }
+
+#if defined(C10_HAS_FLOAT16_TYPE)
+inline Half::Half(_Float16 value)
+    : x(detail::fp16_ieee_from_fp32_value(static_cast<float>(value))) {}
+inline Half::operator _Float16() const {
+  return static_cast<_Float16>(detail::fp16_ieee_to_fp32_value(x));
+}
+#endif
 
 #endif /* !defined(__aarch64__) || defined(__CUDACC__) \
         */


### PR DESCRIPTION
Fixes #157776

Adds a conversion operator from c10::Half to the compiler-builtin
_Float16 type, and an item<_Float16>() specialization. This follows
the existing pattern used for ARM's native float16_t on aarch64.

All changes are guarded by a new C10_HAS_FLOAT16_TYPE macro
(requires __FLT16_MAX__, excluded on aarch64/CUDA/HIP), so platforms
without _Float16 support are unaffected.

cc @malfet
