### PR TITLE
Skip test/inductor/test_lookup_table.py::TestLookupTableE2E::test_valid_lookup_table_entry_operation_addmm

### DIFF
--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -907,7 +907,9 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
     def test_valid_lookup_table_entry(self, operation):
         """Test when there's a valid entry for the operation"""
         if operation == "addmm" and torch.version.hip:
-            self.skipTest("skipping on ROCm since https://github.com/pytorch/pytorch/issues/179955 didn't skip as expected")
+            self.skipTest(
+                "skipping on ROCm since https://github.com/pytorch/pytorch/issues/179955 didn't skip as expected"
+            )
         k = 256 if operation == "mm_plus_mm" else 64
         tensors = self.create_tensors(operation, k=k)
 

--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -906,6 +906,8 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
     @fresh_cache()
     def test_valid_lookup_table_entry(self, operation):
         """Test when there's a valid entry for the operation"""
+        if operation == "addmm" and torch.version.hip:
+            self.skipTest("skipping on ROCm since https://github.com/pytorch/pytorch/issues/179955 didn't skip as expected")
         k = 256 if operation == "mm_plus_mm" else 64
         tensors = self.create_tensors(operation, k=k)
 


### PR DESCRIPTION
Skip in-code since https://github.com/pytorch/pytorch/issues/179955 isn't working as expected: https://github.com/pytorch/test-infra/issues/7963

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo