### PR TITLE
[ROCm] Handle profiler trace format differences in combo kernel tests

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -480,10 +480,14 @@ class ComboKernelTests(TestCase):
                 for event in trace_json["traceEvents"]
                 if "triton_poi_fused_0" in event["name"]
             ]
-            if torch._inductor.config.combo_kernel_per_subkernel_blocks:
-                self.assertEqual([3795, 1, 1], triton_events[0]["args"]["grid"])
-            else:
-                self.assertEqual([791, 4096, 1], triton_events[0]["args"]["grid"])
+            # ROCTracer does not report grid metadata for Triton kernels
+            # launched via hipModuleLaunchKernel, so grid may be absent.
+            grid = triton_events[0].get("args", {}).get("grid")
+            if grid is not None:
+                if torch._inductor.config.combo_kernel_per_subkernel_blocks:
+                    self.assertEqual([3795, 1, 1], grid)
+                else:
+                    self.assertEqual([791, 4096, 1], grid)
 
         self.assertEqual(out_eager, out_compiled)
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
@@ -523,7 +527,10 @@ class ComboKernelTests(TestCase):
                     for e in trace_json["traceEvents"]
                     if "triton_poi_fused" in e["name"]
                 ]
-                return triton_events[0]["args"]["grid"], out
+                # ROCTracer does not report grid metadata for Triton kernels
+                # launched via hipModuleLaunchKernel, so grid may be absent.
+                grid = triton_events[0].get("args", {}).get("grid")
+                return grid, out
 
         x1 = torch.randn(1024, 512, device=GPU_TYPE)
         y1 = torch.randn(2048, 256, device=GPU_TYPE)
@@ -535,13 +542,14 @@ class ComboKernelTests(TestCase):
         grid2, out2 = get_grid(x2, y2)
         eager_out2 = fn(x2, y2)
 
-        self.assertNotEqual(grid1[0], grid2[0])
         self.assertEqual(out1, eager_out1)
         self.assertEqual(out2, eager_out2)
 
-        if torch._inductor.config.combo_kernel_per_subkernel_blocks:
-            self.assertEqual(grid1[1], 1)
-            self.assertEqual(grid2[1], 1)
+        if grid1 is not None and grid2 is not None:
+            self.assertNotEqual(grid1[0], grid2[0])
+            if torch._inductor.config.combo_kernel_per_subkernel_blocks:
+                self.assertEqual(grid1[1], 1)
+                self.assertEqual(grid2[1], 1)
 
     @requires_gpu_and_triton
     @parametrize("pointwise_only,expected_kernel_count", [(False, 2), (True, 3)])
@@ -618,11 +626,14 @@ class ComboKernelTests(TestCase):
                 for event in trace_json["traceEvents"]
                 if "triton_poi_fused_0" in event["name"]
             ]
-
-            if torch._inductor.config.combo_kernel_per_subkernel_blocks:
-                self.assertEqual([83660, 1, 1], triton_events[0]["args"]["grid"])
-            else:
-                self.assertEqual([4, 45260, 2], triton_events[0]["args"]["grid"])
+            # ROCTracer does not report grid metadata for Triton kernels
+            # launched via hipModuleLaunchKernel, so grid may be absent.
+            grid = triton_events[0].get("args", {}).get("grid")
+            if grid is not None:
+                if torch._inductor.config.combo_kernel_per_subkernel_blocks:
+                    self.assertEqual([83660, 1, 1], grid)
+                else:
+                    self.assertEqual([4, 45260, 2], grid)
 
         self.assertEqual(out_eager, out_compiled)
 


### PR DESCRIPTION
Fixes #180017.
Fixes #180018.
Fixes #180019.

Three combo kernel tests access `event["args"]["grid"]` from profiler chrome traces. The grid key structure differs between CUPTI and ROCTracer trace formats, so this throws `KeyError` on ROCm.

Use `.get()` and only assert on grid values when present. All other validation (numerical correctness, kernel counts, codegen) still runs. No change to CUDA path where grid is always present there so assertions execute as before.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben