### PR TITLE
Move AllocatorConfig static functions into cpp to fix DSO boundary issues

### DIFF
--- a/c10/core/AllocatorConfig.cpp
+++ b/c10/core/AllocatorConfig.cpp
@@ -11,6 +11,28 @@ constexpr size_t kRoundUpPowerOfTwoStart = 1 * kMB; // 1MB
 constexpr size_t kRoundUpPowerOfTwoEnd = 64 * 1024ul * kMB; // 64GB
 } // anonymous namespace
 
+std::unordered_set<std::string>& AcceleratorAllocatorConfig::getMutableKeys() {
+  static std::unordered_set<std::string> keys{
+      "large_segment_size_mb",
+      "max_split_size_mb",
+      "max_non_split_rounding_mb",
+      "garbage_collection_threshold",
+      "roundup_power2_divisions",
+      "expandable_segments",
+      "pinned_use_background_threads"};
+  return keys;
+}
+
+const std::unordered_set<std::string>& AcceleratorAllocatorConfig::getKeys() {
+  return getMutableKeys();
+}
+
+std::function<void(const std::string&)>& AcceleratorAllocatorConfig::
+    getConfigParserHook() {
+  static std::function<void(const std::string&)> hook{nullptr};
+  return hook;
+}
+
 AcceleratorAllocatorConfig& AcceleratorAllocatorConfig::instance() {
   static AcceleratorAllocatorConfig instance;
   static bool env_flag [[maybe_unused]] = []() {

--- a/c10/core/AllocatorConfig.h
+++ b/c10/core/AllocatorConfig.h
@@ -234,32 +234,17 @@ class C10_API AcceleratorAllocatorConfig {
 
   // Use `Construct On First Use Idiom` to avoid `Static Initialization Order`
   // issue.
-  static std::unordered_set<std::string>& getMutableKeys() {
-    static std::unordered_set<std::string> keys{
-        "large_segment_size_mb",
-        "max_split_size_mb",
-        "max_non_split_rounding_mb",
-        "garbage_collection_threshold",
-        "roundup_power2_divisions",
-        "expandable_segments",
-        "pinned_use_background_threads"};
-    return keys;
-  }
+  static std::unordered_set<std::string>& getMutableKeys();
 
   // Returns the set of valid keys for the allocator configuration.
   // This set is used to validate the presence and correctness of keys in
   // device-specific configuration parsers.
-  static const std::unordered_set<std::string>& getKeys() {
-    return getMutableKeys();
-  }
+  static const std::unordered_set<std::string>& getKeys();
 
   // Optional hook for parsing additional device-specific allocator settings.
   // This allows backends (e.g., CUDA, XPU) to register a custom parser for
   // their own environment configuration extensions.
-  static std::function<void(const std::string&)>& getConfigParserHook() {
-    static std::function<void(const std::string&)> hook{nullptr};
-    return hook;
-  }
+  static std::function<void(const std::string&)>& getConfigParserHook();
 
   // Registers a device-specific configuration parser hook and its key. This
   // allows backends to parse additional device-specific configuration options


### PR DESCRIPTION
When getMutableKeys(), getKeys(), and getConfigParserHook() were defined as static member functions in the header, each containing a function-local static variable, custom accelerator backends compiled as separate DSOs (.so files) would each get their own copy of these statics. This broke the intended process-wide singleton semantics.

The getConfigParserHook() case is particularly problematic: a backend would register its custom config parser into its own DSO's copy of the static, but the core libtorch code would read from a different copy, making hook registration silently ineffective.

Moving these definitions into AllocatorConfig.cpp (compiled into libtorch.so) ensures a single definition of both the functions and their static locals, so all DSOs resolve to the same symbols at link time.