### PR TITLE
[ROCm][Windows] Remove redundant cuSPARSE/hipSPARSE error-string forward declarations

### DIFF
--- a/aten/src/ATen/cuda/Exceptions.h
+++ b/aten/src/ATen/cuda/Exceptions.h
@@ -68,8 +68,6 @@ C10_EXPORT const char* _cublasGetErrorEnum(cublasStatus_t error);
                 " when calling `" #EXPR "`");                   \
   } while (0)
 
-const char *cusparseGetErrorString(cusparseStatus_t status);
-
 #define TORCH_CUDASPARSE_CHECK(EXPR)                            \
   do {                                                          \
     cusparseStatus_t __err = EXPR;                              \


### PR DESCRIPTION
Drop the extra `cusparseGetErrorString` / `hipsparseGetErrorString` forward declarations from `aten/src/ATen/cuda/Exceptions.h` and `aten/src/ATen/hip/Exceptions.h`. Those symbols are already declared by the headers we include first `<cusparse.h>` and `<hipsparse/hipsparse.h>`. 
This fix removes a redundant forward declaration that could cause `-Winconsistent-dllimport` when the vendor header already declares the same function with dllimport/export macros.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang