### PR TITLE
[Test] Make dynamo/test_unspec.py device-agnostic for out-of-tree backends

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -12,8 +12,9 @@ import torch._dynamo.testing
 import torch.nn.functional as F
 from torch._dynamo.comptime import comptime
 from torch._dynamo.testing import CompileCounter, CompileCounterWithBackend, same
+from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import requires_cuda, skipIfWindows
+from torch.testing._internal.common_utils import skipIfWindows
 from torch.testing._internal.logging_utils import logs_to_string
 
 
@@ -63,50 +64,6 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 2)
 
-    @requires_cuda
-    def test_no_recompilations_with_efficient_attention(self):
-        def fn(q, k, v, attn_mask):
-            from torch.nn.attention import sdpa_kernel, SDPBackend
-            from torch.nn.functional import scaled_dot_product_attention
-
-            with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
-                return scaled_dot_product_attention(
-                    q, k, v, attn_mask=attn_mask, scale=1.0
-                )
-
-        def make_q_k_v_mask(batch, num_heads, head_dim, seq_len_kv):
-            from collections import namedtuple
-            from functools import partial
-
-            dtype = torch.float16
-            device = "cuda"
-            make_tensor = partial(
-                torch.rand, device=device, dtype=dtype, requires_grad=True
-            )
-            seq_len_q = 64
-            SdpaShape = namedtuple(
-                "Sdpa_Shape", ["batch", "num_heads", "seq_len", "head_dim"]
-            )
-            query = make_tensor(SdpaShape(batch, num_heads, seq_len_q, head_dim))
-            kv_shape = SdpaShape(batch, num_heads, seq_len_kv, head_dim)
-            key, value = make_tensor(kv_shape), make_tensor(kv_shape)
-            mask = torch.randn(
-                (batch, num_heads, seq_len_q, seq_len_kv), device=device, dtype=dtype
-            )
-
-            return query, key, value, mask
-
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts)
-
-        q, k, v, mask = make_q_k_v_mask(16, 16, 64, 15)
-        opt_fn(q, k, v, mask)
-
-        q, k, v, mask = make_q_k_v_mask(16, 16, 64, 16)
-        opt_fn(q, k, v, mask)
-
-        self.assertEqual(cnts.frame_count, 1)
-
     @unittest.expectedFailure  # array scalars decay to 0D arrays
     def test_builtin_max_min(self):
         # test unspecialized primitive max/min
@@ -125,7 +82,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
     def test_feed_random_values_into_graph_only(self):
         def fn(shape):
             torch.manual_seed(123)
-            x = torch.randn(shape, device="cpu") * random.randint(30, 100)
+            x = torch.randn(shape) * random.randint(30, 100)
             return x
 
         shape = [2, 3]
@@ -598,7 +555,7 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
     def test_to_tensor(self):
         def f1():
             a = np.random.uniform(low=-1, high=1, size=(20, 1))
-            return torch.tensor([a, a, a, a], dtype=torch.float64, device="cpu")
+            return torch.tensor([a, a, a, a], dtype=torch.float64)
 
         def f2():
             a = torch.tensor([[[123]]])
@@ -1012,6 +969,56 @@ def forward(self):
 
 
 class UnspecTestsDevice(torch._dynamo.test_case.TestCase):
+    @torch._dynamo.config.patch(assume_static_by_default=False)
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+        "Platform does not support efficient attention",
+    )
+    def test_no_recompilations_with_efficient_attention(self, device):
+        if self.device_type == "cpu":
+            raise unittest.SkipTest("EFFICIENT_ATTENTION requires a non-CPU device")
+
+        def fn(q, k, v, attn_mask):
+            from torch.nn.attention import sdpa_kernel, SDPBackend
+            from torch.nn.functional import scaled_dot_product_attention
+
+            with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+                return scaled_dot_product_attention(
+                    q, k, v, attn_mask=attn_mask, scale=1.0
+                )
+
+        def make_q_k_v_mask(batch, num_heads, head_dim, seq_len_kv):
+            from collections import namedtuple
+            from functools import partial
+
+            dtype = torch.float16
+            make_tensor = partial(
+                torch.rand, device=device, dtype=dtype, requires_grad=True
+            )
+            seq_len_q = 64
+            SdpaShape = namedtuple(
+                "Sdpa_Shape", ["batch", "num_heads", "seq_len", "head_dim"]
+            )
+            query = make_tensor(SdpaShape(batch, num_heads, seq_len_q, head_dim))
+            kv_shape = SdpaShape(batch, num_heads, seq_len_kv, head_dim)
+            key, value = make_tensor(kv_shape), make_tensor(kv_shape)
+            mask = torch.randn(
+                (batch, num_heads, seq_len_q, seq_len_kv), device=device, dtype=dtype
+            )
+
+            return query, key, value, mask
+
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts)
+
+        q, k, v, mask = make_q_k_v_mask(16, 16, 64, 15)
+        opt_fn(q, k, v, mask)
+
+        q, k, v, mask = make_q_k_v_mask(16, 16, 64, 16)
+        opt_fn(q, k, v, mask)
+
+        self.assertEqual(cnts.frame_count, 1)
+
     def test_builtin_functions_on_device(self, device):
         def fn(x, scaler):
             m = torch.nn.ReLU()
@@ -1023,16 +1030,13 @@ class UnspecTestsDevice(torch._dynamo.test_case.TestCase):
         scaler = 0.23  # 0.23 is unspecialized
         ref = fn(x, scaler)
         cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch._dynamo.optimize(cnts)(fn)
+        opt_fn = torch.compile(fn, backend=cnts)
         res = opt_fn(x, scaler)
         self.assertTrue(same(ref, res))
         self.assertEqual(ref.device, res.device)
 
 
-devices = ["cuda", "hpu", "xpu"]
-instantiate_device_type_tests(
-    UnspecTestsDevice, globals(), only_for=devices, allow_xpu=True
-)
+instantiate_device_type_tests(UnspecTestsDevice, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests


### PR DESCRIPTION
**Summary**
Refactors test/dynamo/test_unspec.py to remove hardcoded device references and make UnspecTestsDevice fully device-agnostic for out-of-tree accelerator backends.

**Changes**

- Move test_no_recompilations_with_efficient_attention from UnspecTests to UnspecTestsDevice with a device parameter and capability-based skip (PLATFORM_SUPPORTS_MEM_EFF_ATTENTION) instead of the CUDA-specific @requires_cuda decorator. This allows the test to run on any accelerator that supports efficient attention (CUDA, XPU, ROCm) while skipping on CPU at runtime.
- Remove hardcoded only_for=["cuda", "hpu", "xpu"] device list from instantiate_device_type_tests, letting the framework automatically handle all available devices including out-of-tree backends.
- Replace hardcoded device="cuda" inside the attention test with the device parameter provided by instantiate_device_type_tests.
- Remove redundant device="cpu" from tensor constructors in tracing tests where CPU is already the default.
- Modernize deprecated API: torch._dynamo.optimize() → torch.compile().

**Test plan**

- Ran TEST_CONFIG=cuda python3 test/run_test.py -i dynamo/test_unspec.py :  52 passed, 1 skipped, 2 xfailed, 0 failed
- test_no_recompilations_with_efficient_attention_cuda : PASSED
- test_no_recompilations_with_efficient_attention_cpu : correctly SKIPPED
- test_builtin_functions_on_device_cpu : PASSED
- test_builtin_functions_on_device_cuda : PASSED
- All 42 UnspecTests tracing tests :  unchanged and passing

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @desertfire @williamwen42 @mikaylagawarecki @mansiag05 @fffrog @guilhermeleobas