### PR TITLE
[Profiler][PrivateUse1] Make `PrivateUse1ProfilerRegistry::registerWithKineto()` private to fix data race

### DIFF
--- a/torch/csrc/profiler/standalone/privateuse1_profiler.h
+++ b/torch/csrc/profiler/standalone/privateuse1_profiler.h
@@ -63,17 +63,16 @@ class TORCH_API PrivateUse1ProfilerRegistry {
   // Useful for testing to verify the registration logic.
   bool isRegisteredWithKineto() const;
 
-  // Register the factory with Kineto's activity profiler.
-  // This is called internally when Kineto is ready.
-  // Safe to call multiple times - will only register once.
-  void registerWithKineto();
-
   // Mark that Kineto has been initialized.
   // If a factory was registered before Kineto init, it will be forwarded.
   void onKinetoInit();
 
  private:
   PrivateUse1ProfilerRegistry() = default;
+
+  // Register the factory with Kineto's activity profiler.
+  // Caller must hold mutex_.
+  void registerWithKineto();
 
   mutable std::mutex mutex_;
   PrivateUse1ProfilerFactory factory_;


### PR DESCRIPTION
Fixes #180331

### Summary

Move `PrivateUse1ProfilerRegistry::registerWithKineto()` from `public` to `private` to eliminate a thread-safety bug introduced by the method's implicit lock requirement not being enforced at the API boundary.

### Problem

`registerWithKineto()` reads and writes `factory_` and `registered_with_kineto_` without acquiring `mutex_`. All **internal** callers (`registerFactory`, `onKinetoInit`) correctly hold `mutex_` before calling it, but because the method was declared `public`, **external** callers could invoke it lock-free, creating a data race.

cc @divyanshk 