### PR TITLE
`test_scaled_mm_vs_emulated_row_wise`: scale tolerance by sqrt(K)

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1335,10 +1335,9 @@ class TestFP8Matmul(TestCase):
                 x_fp8, x_scales, y_fp8, y_scales, output_dtype, bias
             )
 
-            if base_dtype in {torch.bfloat16, torch.float16}:
-                atol, rtol = 7e-2, 7e-2
-            else:
-                atol, rtol = 2e-3, 2e-3
+            # Numerical differences scale with sqrt(K), so tolerance needs to scale accordingly
+            # The cosine_sim check ensures that accumulation differences don't change the "direction" of the result
+            atol, rtol = 1e-3 * math.sqrt(K), 1e-3 * math.sqrt(K)
 
             self.assertEqual(out_scaled_mm, out_emulated, atol=atol, rtol=rtol)
 


### PR DESCRIPTION
#167653 changed the shape used for `test_scaled_mm_vs_emulated_row_wise`, and the larger K dimension in the new shape (512 instead of 16) is causing numerical mismatches greater than the fixed tolerance in this test. The emulated approach accumulates differently than the cuBLAS kernel, so numerical differences are expected as scale increases. Plotting average absolute mismatch against K (holding M and N constant) shows a clear O(sqrt(K)) relationship. Therefore, I've adjusted the tolerance to scale with sqrt(K) as well. The existing cosine similarity check ensures goodness of the output compared to the emulated result even as numerical differences increase between the two approaches. 

cc @eqy 