### PR TITLE
[MPS] Flatten 5D tensors to 4D in batch_norm for performance

### DIFF
--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -96,6 +96,16 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
                                                          Tensor& output,
                                                          Tensor& save_mean,
                                                          Tensor& save_var) {
+  // Flatten 5D to 4D: MPSGraph normalization is significantly slower for rank-5 tensors.
+  // Merging spatial dims is safe since BatchNorm reduces over all dims except channel.
+  if (self.dim() == 5) {
+    auto input_4d = self.contiguous().reshape({self.size(0), self.size(1), self.size(2) * self.size(3), self.size(4)});
+    auto output_4d = output.reshape(input_4d.sizes());
+    return batch_norm_mps_out(
+        input_4d, weight_opt, bias_opt, running_mean_opt, running_var_opt,
+        train, momentum, epsilon, output_4d, save_mean, save_var);
+  }
+
   TORCH_CHECK_NOT_IMPLEMENTED(self.scalar_type() != kLong, "Long batch norm is not supported with MPS");
   TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(self.scalar_type()),
                               "Batch norm for complex is not supported for MPS");
@@ -541,6 +551,18 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
                                                            bool train,
                                                            double epsilon,
                                                            std::array<bool, 3> grad_input_mask) {
+  // Flatten 5D to 4D (see batch_norm_mps_out for rationale).
+  if (input.dim() == 5) {
+    auto input_4d = input.contiguous().reshape({input.size(0), input.size(1), input.size(2) * input.size(3), input.size(4)});
+    auto grad_out_4d = grad_out.contiguous().reshape(input_4d.sizes());
+    auto [gi, gw, gb] = batch_norm_backward_mps(
+        grad_out_4d, input_4d, weight_opt, running_mean_opt, running_var_opt,
+        save_mean_opt, save_var_opt, train, epsilon, grad_input_mask);
+    if (gi.defined())
+      gi = gi.reshape(input.sizes());
+    return std::make_tuple(std::move(gi), std::move(gw), std::move(gb));
+  }
+
   Tensor grad_input;
   Tensor grad_weight;
   Tensor grad_bias;

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -101,9 +101,17 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
   if (self.dim() == 5) {
     auto input_4d = self.contiguous().reshape({self.size(0), self.size(1), self.size(2) * self.size(3), self.size(4)});
     auto output_4d = output.reshape(input_4d.sizes());
-    return batch_norm_mps_out(
-        input_4d, weight_opt, bias_opt, running_mean_opt, running_var_opt,
-        train, momentum, epsilon, output_4d, save_mean, save_var);
+    return batch_norm_mps_out(input_4d,
+                              weight_opt,
+                              bias_opt,
+                              running_mean_opt,
+                              running_var_opt,
+                              train,
+                              momentum,
+                              epsilon,
+                              output_4d,
+                              save_mean,
+                              save_var);
   }
 
   TORCH_CHECK_NOT_IMPLEMENTED(self.scalar_type() != kLong, "Long batch norm is not supported with MPS");
@@ -553,11 +561,19 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
                                                            std::array<bool, 3> grad_input_mask) {
   // Flatten 5D to 4D (see batch_norm_mps_out for rationale).
   if (input.dim() == 5) {
-    auto input_4d = input.contiguous().reshape({input.size(0), input.size(1), input.size(2) * input.size(3), input.size(4)});
+    auto input_4d =
+        input.contiguous().reshape({input.size(0), input.size(1), input.size(2) * input.size(3), input.size(4)});
     auto grad_out_4d = grad_out.contiguous().reshape(input_4d.sizes());
-    auto [gi, gw, gb] = batch_norm_backward_mps(
-        grad_out_4d, input_4d, weight_opt, running_mean_opt, running_var_opt,
-        save_mean_opt, save_var_opt, train, epsilon, grad_input_mask);
+    auto [gi, gw, gb] = batch_norm_backward_mps(grad_out_4d,
+                                                input_4d,
+                                                weight_opt,
+                                                running_mean_opt,
+                                                running_var_opt,
+                                                save_mean_opt,
+                                                save_var_opt,
+                                                train,
+                                                epsilon,
+                                                grad_input_mask);
     if (gi.defined())
       gi = gi.reshape(input.sizes());
     return std::make_tuple(std::move(gi), std::move(gw), std::move(gb));


### PR DESCRIPTION
## Summary

MPSGraph normalization ops (`normalizationWithTensor:`, `normalizationGradientWithIncomingGradientTensor:`) are significantly slower for rank-5 tensors (BatchNorm3d) compared to rank-4 (BatchNorm2d) with the same number of elements.

Since BatchNorm reduces over all dimensions except the channel dim, spatial dimensions can be safely merged: `[N, C, D, H, W]` → `[N, C, D*H, W]`. This PR adds a 5D→4D reshape at the top of `batch_norm_mps_out` and `batch_norm_backward_mps`, then recurses into the existing 4D path.

## Benchmark (M4 Pro, shape [4, 64, 64, 64, 64])

| | Before | After |
|---|---|---|
| nn.BatchNorm3d fwd+bwd | 8.7 ms | 3.5 ms (**2.4x**) |
| native_batch_norm (forward) | 4.5 ms | 4.5 ms (parity with 4D) |
| native_batch_norm_backward | 6.7 ms | 6.8 ms (parity with 4D) |

## Test plan

All 5 existing MPS batch_norm tests pass:

```
test/test_mps.py::TestMPS::test_batch_norm PASSED
test/test_mps.py::TestMPS::test_batch_norm_backward PASSED
test/test_mps.py::TestMPS::test_batch_norm_backward_weight_bias_gradients PASSED
test/test_mps.py::TestMPS::test_batch_norm_mixed_dtype PASSED
test/test_mps.py::TestMPS::test_batch_norm_slices PASSED
```

Correctness: max diff between 5D and equivalent 4D is 2.38e-07 (float32 machine epsilon).

Fixes #180334

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo