### PR TITLE
[Test]Make test/dynamo/test_functions.py device-agnostic for out-of-tree accelerators

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3992,9 +3992,7 @@ class GraphModule(torch.nn.Module):
 
         @torch.compile(backend="eager")
         def func():
-            make_tensor = partial(
-                torch.rand, dtype=torch.float16, requires_grad=True
-            )
+            make_tensor = partial(torch.rand, dtype=torch.float16, requires_grad=True)
 
             bsz, num_heads, seq_len_q, seq_len_kv, head_dim = (16, 16, 128, 128, 16)
             make_q_tensor = partial(

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -668,7 +668,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
     @make_test
     def test_device_constant(a):
-        return a + torch.ones(1, device=torch.device("cpu"))
+        return a + torch.ones(1)
 
     @make_test
     def test_tuple1(a, b):
@@ -1278,13 +1278,13 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
     @make_test
     def test_device(x):
-        if not x.is_cuda:
+        if x.device.type == "cpu":
             return x + 1
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     @make_test
     def test_get_device_properties_tensor_device(a):
-        x = a.to("cuda")
+        x = a.to(device_type)
         prop = torch.cuda.get_device_properties(x.device)
         if prop.major == 8:
             return x + prop.multi_processor_count
@@ -1311,10 +1311,10 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         m = a.type("torch.HalfTensor")
         return b.type(m.type())
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(not HAS_GPU, "requires gpu")
     @make_test
     def test_tensor_type5(a, b):
-        m = a.type(torch.cuda.HalfTensor)
+        m = a.to(device_type).half()
         return b.type(m.type())
 
     @make_test
@@ -3974,7 +3974,7 @@ class GraphModule(torch.nn.Module):
         @torch.compile(backend="eager")
         def func():
             make_tensor = partial(
-                torch.rand, device="cpu", dtype=torch.float16, requires_grad=True
+                torch.rand, dtype=torch.float16, requires_grad=True
             )
 
             bsz, num_heads, seq_len_q, seq_len_kv, head_dim = (16, 16, 128, 128, 16)
@@ -4237,9 +4237,9 @@ class GraphModule(torch.nn.Module):
         def self_fn(x):
             return x.unsqueeze_(dim=1) + 1
 
-        v = torch.ones([3], device="cpu")
+        v = torch.ones([3])
         # identical tensor since modify inplace
-        v2 = torch.ones([3], device="cpu")
+        v2 = torch.ones([3])
         opt_fn = torch.compile(fn, backend="eager")
         opt_self_fn = torch.compile(self_fn, backend="eager")
         self.assertEqual(v, v2)
@@ -4325,7 +4325,7 @@ class GraphModule(torch.nn.Module):
         def fn(x):
             return retry(cached_fn)(x)
 
-        x = torch.tensor(2.0, device="cpu")
+        x = torch.tensor(2.0)
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(fn(x), opt_fn(x))
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3973,9 +3973,7 @@ class GraphModule(torch.nn.Module):
 
         @torch.compile(backend="eager")
         def func():
-            make_tensor = partial(
-                torch.rand, dtype=torch.float16, requires_grad=True
-            )
+            make_tensor = partial(torch.rand, dtype=torch.float16, requires_grad=True)
 
             bsz, num_heads, seq_len_q, seq_len_kv, head_dim = (16, 16, 128, 128, 16)
             make_q_tensor = partial(

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -668,7 +668,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
     @make_test
     def test_device_constant(a):
-        return a + torch.ones(1, device=torch.device("cpu"))
+        return a + torch.ones(1)
 
     @make_test
     def test_tuple1(a, b):
@@ -1278,7 +1278,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
     @make_test
     def test_device(x):
-        if not x.is_cuda:
+        if x.device.type == "cpu":
             return x + 1
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
@@ -1311,10 +1311,10 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         m = a.type("torch.HalfTensor")
         return b.type(m.type())
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(not HAS_GPU, "requires gpu")
     @make_test
     def test_tensor_type5(a, b):
-        m = a.type(torch.cuda.HalfTensor)
+        m = a.to(device_type).half()
         return b.type(m.type())
 
     @make_test
@@ -3993,7 +3993,7 @@ class GraphModule(torch.nn.Module):
         @torch.compile(backend="eager")
         def func():
             make_tensor = partial(
-                torch.rand, device="cpu", dtype=torch.float16, requires_grad=True
+                torch.rand, dtype=torch.float16, requires_grad=True
             )
 
             bsz, num_heads, seq_len_q, seq_len_kv, head_dim = (16, 16, 128, 128, 16)
@@ -4256,9 +4256,9 @@ class GraphModule(torch.nn.Module):
         def self_fn(x):
             return x.unsqueeze_(dim=1) + 1
 
-        v = torch.ones([3], device="cpu")
+        v = torch.ones([3])
         # identical tensor since modify inplace
-        v2 = torch.ones([3], device="cpu")
+        v2 = torch.ones([3])
         opt_fn = torch.compile(fn, backend="eager")
         opt_self_fn = torch.compile(self_fn, backend="eager")
         self.assertEqual(v, v2)
@@ -4344,7 +4344,7 @@ class GraphModule(torch.nn.Module):
         def fn(x):
             return retry(cached_fn)(x)
 
-        x = torch.tensor(2.0, device="cpu")
+        x = torch.tensor(2.0)
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(fn(x), opt_fn(x))
 


### PR DESCRIPTION
**Summary**
Removes hardcoded CUDA device references and redundant device="cpu" from test/dynamo/test_functions.py to support out-of-tree accelerator backends (PrivateUse1/OpenReg).

**Changes**

- Remove redundant device="cpu" from 5 tensor constructors where CPU is already the default (torch.ones, torch.rand, torch.tensor). These are tracing tests where device is irrelevant per maintainer guidance.
- Replace a.to("cuda") with a.to(device_type) in test_get_device_properties_tensor_device, using the module-level accelerator-aware device_type variable.
- Replace torch.cuda.HalfTensor with a.to(device_type).half() in test_tensor_type5 and update the skip decorator from torch.cuda.is_available() to HAS_GPU so the test runs on any available accelerator.
- Replace x.is_cuda with x.device.type == "cpu" in test_device for a device-agnostic property check.
- CUDA-specific tests that use APIs with no generic equivalent (torch.cuda.get_device_properties, torch.backends.cuda.matmul.allow_tf32) are left unchanged.

**Test plan**

- Ran TEST_CONFIG=cuda python3 test/run_test.py -i dynamo/test_functions.py : 493 passed, 3 skipped, 2 xfailed, 0 failed
- All 8 modified tests pass including test_device, test_device_constant, test_tensor_type5, test_get_device_properties_tensor_device, test_unsqueeze_inplace, test_rand_tensor_partial

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @williamwen42 @mikaylagawarecki @mansiag05 @fffrog @guilhermeleobas