### PR TITLE
Update persons_of_interest.rst for ExecuTorch

### DIFF
--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -350,6 +350,7 @@ ExecuTorch (Edge, Mobile)
 -  (emeritus) Kimish Patel (`kimishpatel <https://github.com/kimishpatel>`__)
 -  (emeritus) Dave Bort (`dbort <https://github.com/dbort>`__)
 -  (emeritus) Martin Yuan (`iseeyuan <https://github.com/iseeyuan>`__)
+-  (emeritus) Mengwei Liu (`larryliu0820 <https://github.com/larryliu0820>`__)
 
 TorchCodec
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Mengwei Liu was one of the module maintainers of ExecuTorch, who was in charge of many subcomponents like CUDA backend, selective build, opset, runtime, LLM runners, and many more spanning wide range of stuff.

Not mentioning him previously as the Module maintainers was an oversight, but now that he's not active, I'd still like to attribute his past contributions. Thank you, Mengwei