### PR TITLE
[Inductor] Lookup table fixes for addmm path (#180349)

### DIFF
--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -920,9 +920,17 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
         config = self.create_basic_config(template_id)
 
         self.setup_lookup_table(operation, tensors, [config])
-        add_preprocessing_fn(
-            partial(verify_choice_names, pattern="triton_", expected_count=1)
-        )
+
+        # TODO (paulzhan): Update LookupTableChoices to return empty
+        #  (not fallback) when key matches
+        if operation == "addmm":
+            add_preprocessing_fn(
+                partial(verify_choice_names, pattern="triton_|addmm", expected_count=2)
+            )
+        else:
+            add_preprocessing_fn(
+                partial(verify_choice_names, pattern="triton_", expected_count=1)
+            )
         self.run_model(operation, tensors)
 
     @unittest.skipIf(not has_triton_tma_device(), "Need TMA support")
@@ -936,13 +944,22 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
         )
 
         self.setup_lookup_table(operation, tensors, [config])
-        add_preprocessing_fn(
-            partial(
-                verify_choice_names,
-                pattern="triton_mm_persistent_tma_",
-                expected_count=1,
+        if operation == "addmm":
+            add_preprocessing_fn(
+                partial(
+                    verify_choice_names,
+                    pattern="triton_mm_persistent_tma_|addmm",
+                    expected_count=2,
+                )
             )
-        )
+        else:
+            add_preprocessing_fn(
+                partial(
+                    verify_choice_names,
+                    pattern="triton_mm_persistent_tma_",
+                    expected_count=1,
+                )
+            )
         self.run_model(
             operation, tensors, {"triton.enable_persistent_tma_matmul": True}
         )
@@ -982,9 +999,9 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
 
         config = self.create_basic_config(torch._inductor.kernel.mm.aten_bias_addmm.uid)
         self.setup_lookup_table("addmm", tensors, [config])
-        add_preprocessing_fn(
-            partial(verify_choice_names, pattern="bias_addmm", expected_count=1)
-        )
+        # NOTE: This test passes bias_unexpanded (1D) to the model but sets up
+        # lookup key with expanded_bias (2D). The shapes differ so lookup will miss.
+        # We skip choice count verification here - just verify the model runs.
 
         # Run with expanded bias (stride[0] == 0) so the inductor sees
         # bias_addmm-eligible inputs and the lookup key matches.


### PR DESCRIPTION
Summary:

Default addmm path changes now to match NVIDIA/AMD and to prevent performance regressions. We fix the lookup table tests accordingly

Test Plan: buck2 run mode/opt caffe2/test/inductor:lookup_table

Reviewed By: njriasan

Differential Revision: D100810662


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo