### PR TITLE
[pyrefly] Add type annotations to torch/fx/experimental/unification

### DIFF
--- a/torch/fx/experimental/unification/core.py
+++ b/torch/fx/experimental/unification/core.py
@@ -1,12 +1,21 @@
-# mypy: allow-untyped-defs
-from collections.abc import Iterator  # type: ignore[import]
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
 from functools import partial
+from typing import TYPE_CHECKING
+from typing_extensions import TypeVarTuple, Unpack
 
 from .dispatch import dispatch
 from .unification_tools import assoc  # type: ignore[import]
 from .utils import transitive_get as walk
 from .variable import isvar
 
+
+if TYPE_CHECKING:
+    from .variable import Var
+
+
+_Ts = TypeVarTuple("_Ts")
 
 __all__ = ["reify", "unify"]
 
@@ -16,7 +25,7 @@ __all__ = ["reify", "unify"]
 
 
 @dispatch(Iterator, dict)
-def _reify(t, s):
+def _reify(t: Iterator[object], s: dict[Var, object]) -> Iterator[object]:
     return map(partial(reify, s=s), t)
     # return (reify(arg, s) for arg in t)
 
@@ -25,23 +34,23 @@ _reify
 
 
 @dispatch(tuple, dict)  # type: ignore[no-redef]
-def _reify(t, s):
-    return tuple(reify(iter(t), s))
+def _reify(t: tuple[Unpack[_Ts]], s: dict[Var, object]) -> tuple[Unpack[_Ts]]:
+    return tuple(reify(iter(t), s))  # pyrefly: ignore[bad-argument-type, bad-return]
 
 
 _reify
 
 
 @dispatch(list, dict)  # type: ignore[no-redef]
-def _reify(t, s):
-    return list(reify(iter(t), s))
+def _reify(t: list[object], s: dict[Var, object]) -> list[object]:
+    return list(reify(iter(t), s))  # pyrefly: ignore[bad-argument-type]
 
 
 _reify
 
 
 @dispatch(dict, dict)  # type: ignore[no-redef]
-def _reify(d, s):
+def _reify(d: dict[object, object], s: dict[Var, object]) -> dict[object, object]:
     return {k: reify(v, s) for k, v in d.items()}
 
 
@@ -49,11 +58,11 @@ _reify
 
 
 @dispatch(object, dict)  # type: ignore[no-redef]
-def _reify(o, s):
+def _reify(o: object, s: dict[Var, object]) -> object:
     return o  # catch all, just return the object
 
 
-def reify(e, s):
+def reify(e: object, s: dict[Var, object]) -> object:
     """Replace variables of expression with substitution
     >>> # xdoctest: +SKIP
     >>> x, y = var(), var()
@@ -78,11 +87,13 @@ seq = tuple, list, Iterator
 
 
 @dispatch(seq, seq, dict)  # type: ignore[arg-type]
-def _unify(u, v, s):
+def _unify(
+    u: Sequence[object], v: Sequence[object], s: dict[Var, object]
+) -> dict[Var, object] | bool:
     if len(u) != len(v):
         return False
     for uu, vv in zip(u, v):  # avoiding recursion
-        s = unify(uu, vv, s)
+        s = unify(uu, vv, s)  # pyrefly: ignore[bad-assignment]
         if s is False:
             return False
     return s
@@ -116,7 +127,9 @@ def _unify(u, v, s):
 
 
 @dispatch(object, object, dict)
-def unify(u, v, s):  # no check at the moment
+def unify(
+    u: object, v: object, s: dict[Var, object]
+) -> dict[Var, object] | bool:  # no check at the moment
     """Find substitution so that u == v while satisfying s
     >>> x = var("x")
     >>> unify((1, x), (1, 2), {})
@@ -137,5 +150,5 @@ unify
 
 
 @dispatch(object, object)  # type: ignore[no-redef]
-def unify(u, v):
+def unify(u: object, v: object) -> dict[Var, object] | bool:
     return unify(u, v, {})

--- a/torch/fx/experimental/unification/match.py
+++ b/torch/fx/experimental/unification/match.py
@@ -1,33 +1,45 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .core import reify, unify  # type: ignore[attr-defined]
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from .variable import Var
+
 from .unification_tools import first, groupby  # type: ignore[import]
 from .utils import _toposort, freeze
 from .variable import isvar
 
 
 class Dispatcher:
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
-        self.funcs = {}
-        self.ordering = []
+        self.funcs: dict[object, Callable[..., object]] = {}
+        self.ordering: list[object] = []
 
-    def add(self, signature, func):
+    def add(self, signature: tuple[object, ...], func: Callable[..., object]) -> None:
         self.funcs[freeze(signature)] = func
         self.ordering = ordering(self.funcs)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: object, **kwargs: object) -> object:
         func, _ = self.resolve(args)
         return func(*args, **kwargs)
 
-    def resolve(self, args):
+    def resolve(
+        self, args: tuple[object, ...]
+    ) -> tuple[Callable[..., object], dict[Var, object]]:
         n = len(args)
         for signature in self.ordering:
-            if len(signature) != n:
+            if len(signature) != n:  # pyrefly: ignore[bad-argument-type]
                 continue
             s = unify(freeze(args), signature)
             if s is not False:
                 result = self.funcs[signature]
-                return result, s
+                return result, s  # pyrefly: ignore[bad-return]
         raise NotImplementedError(
             "No match found. \nKnown matches: "
             + str(self.ordering)
@@ -35,8 +47,8 @@ class Dispatcher:
             + str(args)
         )
 
-    def register(self, *signature):
-        def _(func):
+    def register(self, *signature: object) -> Callable[..., object]:
+        def _(func: Callable[..., object]) -> Dispatcher:
             self.add(signature, func)
             return self
 
@@ -60,24 +72,28 @@ class VarDispatcher(Dispatcher):
     20
     """
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: object, **kwargs: object) -> object:
         func, s = self.resolve(args)
-        d = {k.token: v for k, v in s.items()}
+        d = {k.token: v for k, v in s.items()}  # pyrefly: ignore[missing-attribute]
         return func(**d)
 
 
-global_namespace = {}  # type: ignore[var-annotated]
+global_namespace: dict[str, Dispatcher] = {}
 
 
-def match(*signature, **kwargs):
-    namespace = kwargs.get("namespace", global_namespace)
-    dispatcher = kwargs.get("Dispatcher", Dispatcher)
+def match(*signature: object, **kwargs: object) -> Callable[..., object]:
+    namespace: dict[str, Dispatcher] = kwargs.get(  # type: ignore[assignment]
+        "namespace", global_namespace
+    )
+    dispatcher_cls: type[Dispatcher] = kwargs.get(  # type: ignore[assignment]
+        "Dispatcher", Dispatcher
+    )
 
-    def _(func):
+    def _(func: Callable[..., object]) -> Dispatcher:
         name = func.__name__
 
         if name not in namespace:
-            namespace[name] = dispatcher(name)
+            namespace[name] = dispatcher_cls(name)
         d = namespace[name]
 
         d.add(signature, func)
@@ -87,22 +103,27 @@ def match(*signature, **kwargs):
     return _
 
 
-def supercedes(a, b):
+def supercedes(a: object, b: object) -> bool:
     """``a`` is a more specific match than ``b``"""
     if isvar(b) and not isvar(a):
         return True
     s = unify(a, b)
     if s is False:
         return False
-    s = {k: v for k, v in s.items() if not isvar(k) or not isvar(v)}
+    s = {
+        k: v
+        for k, v in s.items()  # pyrefly: ignore[missing-attribute]
+        if not isvar(k) or not isvar(v)
+    }
     if reify(a, s) == a:
         return True
     if reify(b, s) == b:
         return False
+    return False
 
 
 # Taken from multipledispatch
-def edge(a, b, tie_breaker=hash):
+def edge(a: object, b: object, tie_breaker: Callable[[object], int] = hash) -> bool:
     """A should be checked before B
     Tie broken by tie_breaker, defaults to ``hash``
     """
@@ -115,15 +136,15 @@ def edge(a, b, tie_breaker=hash):
 
 
 # Taken from multipledispatch
-def ordering(signatures):
+def ordering(signatures: Iterable[object]) -> list[object]:
     """A sane ordering of signatures to check, first to last
     Topological sort of edges as given by ``edge`` and ``supercedes``
     """
-    signatures = list(map(tuple, signatures))
+    signatures = list(map(tuple, signatures))  # pyrefly: ignore[bad-argument-type]
     edges = [(a, b) for a in signatures for b in signatures if edge(a, b)]
     edges = groupby(first, edges)
     for s in signatures:
         if s not in edges:
             edges[s] = []
     edges = {k: [b for a, b in v] for k, v in edges.items()}  # type: ignore[attr-defined, assignment]
-    return _toposort(edges)
+    return _toposort(edges)  # pyrefly: ignore[bad-argument-type]

--- a/torch/fx/experimental/unification/more.py
+++ b/torch/fx/experimental/unification/more.py
@@ -1,4 +1,7 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .core import (  # type: ignore[attr-defined]
     _reify as core_reify,
     _unify as core_unify,
@@ -8,10 +11,14 @@ from .core import (  # type: ignore[attr-defined]
 from .dispatch import dispatch
 
 
+if TYPE_CHECKING:
+    from .variable import Var
+
+
 __all__ = ["unifiable", "reify_object", "unify_object"]
 
 
-def unifiable(cls):
+def unifiable(cls: type) -> type:
     """Register standard unify and reify operations on class
     This uses the type and __dict__ or __slots__ attributes to define the
     nature of the term
@@ -40,7 +47,7 @@ def unifiable(cls):
 #########
 
 
-def reify_object(o, s):
+def reify_object(o: object, s: dict[Var, object]) -> object:
     """Reify a Python object with a substitution
     >>> # xdoctest: +SKIP
     >>> class Foo(object):
@@ -63,32 +70,38 @@ def reify_object(o, s):
         return _reify_object_dict(o, s)
 
 
-def _reify_object_dict(o, s):
+def _reify_object_dict(o: object, s: dict[Var, object]) -> object:
     obj = object.__new__(type(o))
-    d = reify(o.__dict__, s)
-    if d == o.__dict__:
+    d = reify(o.__dict__, s)  # pyrefly: ignore[missing-attribute]
+    if d == o.__dict__:  # pyrefly: ignore[missing-attribute]
         return o
-    obj.__dict__.update(d)
+    obj.__dict__.update(d)  # pyrefly: ignore[missing-attribute, no-matching-overload]
     return obj
 
 
-def _reify_object_slots(o, s):
-    attrs = [getattr(o, attr) for attr in o.__slots__]
+def _reify_object_slots(o: object, s: dict[Var, object]) -> object:
+    attrs = [
+        getattr(o, attr)
+        for attr in o.__slots__  # pyrefly: ignore[missing-attribute]
+    ]
     new_attrs = reify(attrs, s)
     if attrs == new_attrs:
         return o
     else:
         newobj = object.__new__(type(o))
-        for slot, attr in zip(o.__slots__, new_attrs):
+        for slot, attr in zip(
+            o.__slots__,  # pyrefly: ignore[missing-attribute]
+            new_attrs,  # pyrefly: ignore[bad-argument-type]
+        ):
             setattr(newobj, slot, attr)
         return newobj
 
 
 @dispatch(slice, dict)
-def _reify(o, s):
+def _reify(o: slice, s: dict[Var, object]) -> slice:
     """Reify a Python ``slice`` object"""
 
-    return slice(*reify((o.start, o.stop, o.step), s))
+    return slice(*reify((o.start, o.stop, o.step), s))  # pyrefly: ignore[not-iterable]
 
 
 #########
@@ -96,7 +109,9 @@ def _reify(o, s):
 #########
 
 
-def unify_object(u, v, s):
+def unify_object(
+    u: object, v: object, s: dict[Var, object]
+) -> dict[Var, object] | bool:
     """Unify two Python objects
     Unifies their type and ``__dict__`` attributes
     >>> # xdoctest: +SKIP
@@ -117,15 +132,25 @@ def unify_object(u, v, s):
         return False
     if hasattr(u, "__slots__"):
         return unify(
-            [getattr(u, slot) for slot in u.__slots__],
-            [getattr(v, slot) for slot in v.__slots__],
+            [
+                getattr(u, slot)
+                for slot in u.__slots__  # pyrefly: ignore[missing-attribute]
+            ],
+            [
+                getattr(v, slot)
+                for slot in v.__slots__  # pyrefly: ignore[missing-attribute]
+            ],
             s,
         )
     else:
-        return unify(u.__dict__, v.__dict__, s)
+        return unify(
+            u.__dict__,  # pyrefly: ignore[missing-attribute]
+            v.__dict__,  # pyrefly: ignore[missing-attribute]
+            s,
+        )
 
 
 @dispatch(slice, slice, dict)
-def _unify(u, v, s):
+def _unify(u: slice, v: slice, s: dict[Var, object]) -> dict[Var, object] | bool:
     """Unify a Python ``slice`` object"""
     return unify((u.start, u.stop, u.step), (v.start, v.stop, v.step), s)

--- a/torch/fx/experimental/unification/multipledispatch/conflict.py
+++ b/torch/fx/experimental/unification/multipledispatch/conflict.py
@@ -1,5 +1,11 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 import operator
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
 
 from .utils import _toposort, groupby
 from .variadic import isvariadic
@@ -21,7 +27,7 @@ class AmbiguityWarning(Warning):
     pass
 
 
-def supercedes(a, b):
+def supercedes(a: tuple[type, ...], b: tuple[type, ...]) -> bool:
     """A is consistent and strictly more specific than B"""
     if len(a) < len(b):
         # only case is if a is empty and b is variadic
@@ -57,7 +63,7 @@ def supercedes(a, b):
         return p2 == len(b) - 1 and p1 == len(a)
 
 
-def consistent(a, b):
+def consistent(a: tuple[type, ...], b: tuple[type, ...]) -> bool:
     """It is possible for an argument list to satisfy both A and B"""
 
     # Need to check for empty args
@@ -94,12 +100,14 @@ def consistent(a, b):
         )
 
 
-def ambiguous(a, b):
+def ambiguous(a: tuple[type, ...], b: tuple[type, ...]) -> bool:
     """A is consistent with B but neither is strictly more specific"""
     return consistent(a, b) and not (supercedes(a, b) or supercedes(b, a))
 
 
-def ambiguities(signatures):
+def ambiguities(
+    signatures: Iterable[tuple[type, ...]],
+) -> set[tuple[tuple[type, ...], tuple[type, ...]]]:
     """All signature pairs such that A is ambiguous with B"""
     signatures = list(map(tuple, signatures))
     return {
@@ -112,7 +120,7 @@ def ambiguities(signatures):
     }
 
 
-def super_signature(signatures):
+def super_signature(signatures: Sequence[tuple[type, ...]]) -> list[type]:
     """A signature that would break ambiguities"""
     n = len(signatures[0])
     if not all(len(s) == n for s in signatures):
@@ -121,7 +129,11 @@ def super_signature(signatures):
     return [max((type.mro(sig[i]) for sig in signatures), key=len)[0] for i in range(n)]
 
 
-def edge(a, b, tie_breaker=hash):
+def edge(
+    a: tuple[type, ...],
+    b: tuple[type, ...],
+    tie_breaker: Callable[[tuple[type, ...]], int] = hash,
+) -> bool:
     """A should be checked before B
     Tie broken by tie_breaker, defaults to ``hash``
     """
@@ -132,7 +144,7 @@ def edge(a, b, tie_breaker=hash):
     )
 
 
-def ordering(signatures):
+def ordering(signatures: Iterable[tuple[type, ...]]) -> list[tuple[type, ...]]:
     """A sane ordering of signatures to check, first to last
     Topological sort of edges as given by ``edge`` and ``supercedes``
     """
@@ -142,5 +154,10 @@ def ordering(signatures):
     for s in signatures:
         if s not in edges:
             edges[s] = []
-    edges = {k: [b for a, b in v] for k, v in edges.items()}  # type: ignore[assignment, attr-defined]
-    return _toposort(edges)
+    topo_edges: dict[
+        tuple[type, ...], list[tuple[type, ...]]
+    ] = {  # pyrefly: ignore[bad-assignment]
+        k: [b for a, b in v]
+        for k, v in edges.items()  # type: ignore[attr-defined]
+    }
+    return _toposort(topo_edges)

--- a/torch/fx/experimental/unification/multipledispatch/core.py
+++ b/torch/fx/experimental/unification/multipledispatch/core.py
@@ -1,23 +1,27 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 import inspect
-from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any, TYPE_CHECKING, TypeVar
 from typing_extensions import TypeVarTuple, Unpack
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from .dispatcher import Dispatcher, MethodDispatcher
 
 
-global_namespace = {}  # type: ignore[var-annotated]
+global_namespace: dict[str, Dispatcher] = {}
 
 __all__ = ["dispatch", "ismethod"]
 
-T = TypeVar("T")
-Ts = TypeVarTuple("Ts")
+_T = TypeVar("_T")
+_Ts = TypeVarTuple("_Ts")
 
 
 def dispatch(
-    *types: Unpack[Ts], **kwargs: Any
-) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    *types: Unpack[_Ts], **kwargs: Any
+) -> Callable[[Callable[..., _T]], Callable[..., _T]]:
     """Dispatch function on the types of the inputs
     Supports dispatch on all non-keyword arguments.
     Collects implementations based on the function name.  Ignores namespaces.
@@ -60,7 +64,7 @@ def dispatch(
 
     types_tuple: tuple[type, ...] = tuple(types)  # type: ignore[arg-type]
 
-    def _df(func):
+    def _df(func: Callable[..., _T]) -> Callable[..., _T]:
         name = func.__name__
 
         if ismethod(func):
@@ -76,10 +80,10 @@ def dispatch(
         dispatcher.add(types_tuple, func)
         return dispatcher
 
-    return _df
+    return _df  # type: ignore[return-value]
 
 
-def ismethod(func):
+def ismethod(func: Callable[..., object]) -> bool:
     """Is func a method?
     Note that this has to work as the method is defined but before the class is
     defined.  At this stage methods look like functions.
@@ -89,4 +93,4 @@ def ismethod(func):
         return signature.parameters.get("self", None) is not None
     else:
         spec = inspect.getfullargspec(func)  # type: ignore[union-attr, assignment]
-        return spec and spec.args and spec.args[0] == "self"
+        return bool(spec and spec.args and spec.args[0] == "self")

--- a/torch/fx/experimental/unification/multipledispatch/dispatcher.py
+++ b/torch/fx/experimental/unification/multipledispatch/dispatcher.py
@@ -1,12 +1,21 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 import inspect
 import itertools as itl
+from typing import Any, TYPE_CHECKING, TypeVar
 from typing_extensions import deprecated
 from warnings import warn
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Iterable, Iterator
 
 from .conflict import ambiguities, AmbiguityWarning, ordering, super_signature
 from .utils import expand_tuples
 from .variadic import isvariadic, Variadic
+
+
+_T = TypeVar("_T")
 
 
 __all__ = [
@@ -28,7 +37,9 @@ class MDNotImplementedError(NotImplementedError):
     """A NotImplementedError for multiple dispatch"""
 
 
-def ambiguity_warn(dispatcher, ambiguities):
+def ambiguity_warn(
+    dispatcher: Dispatcher, ambiguities: set[tuple[tuple[type, ...], tuple[type, ...]]]
+) -> None:
     """Raise warning when ambiguity is detected.
 
     Parameters
@@ -50,7 +61,7 @@ def ambiguity_warn(dispatcher, ambiguities):
     "`halt_ordering` is deprecated, you can safely remove this call.",
     category=FutureWarning,
 )
-def halt_ordering():
+def halt_ordering() -> None:
     """Deprecated interface to temporarily disable ordering."""
 
 
@@ -59,11 +70,13 @@ def halt_ordering():
     "you should call the `reorder()` method on each dispatcher.",
     category=FutureWarning,
 )
-def restart_ordering(on_ambiguity=ambiguity_warn):
+def restart_ordering(on_ambiguity: Callable[..., None] = ambiguity_warn) -> None:
     """Deprecated interface to temporarily resume ordering."""
 
 
-def variadic_signature_matches_iter(types, full_signature):
+def variadic_signature_matches_iter(
+    types: tuple[type, ...], full_signature: tuple[type, ...]
+) -> Generator[bool, None, None]:
     """Check if a set of input types matches a variadic signature.
 
     Notes
@@ -105,7 +118,9 @@ def variadic_signature_matches_iter(types, full_signature):
             yield False
 
 
-def variadic_signature_matches(types, full_signature):
+def variadic_signature_matches(
+    types: tuple[type, ...], full_signature: tuple[type, ...]
+) -> bool:
     # No arguments always matches a variadic signature
     if not full_signature:
         raise AssertionError("full_signature is empty")
@@ -133,14 +148,16 @@ class Dispatcher:
 
     __slots__ = "__name__", "name", "funcs", "_ordering", "_cache", "doc"
 
-    def __init__(self, name, doc=None):
+    def __init__(self, name: str, doc: str | None = None) -> None:
         self.name = self.__name__ = name
-        self.funcs = {}
+        self.funcs: dict[tuple[type, ...], Callable[..., object]] = {}
         self.doc = doc
 
-        self._cache = {}
+        self._cache: dict[tuple[type, ...], Callable[..., object]] = {}
 
-    def register(self, *types, **kwargs):
+    def register(
+        self, *types: type, **kwargs: object
+    ) -> Callable[[Callable[..., _T]], Callable[..., _T]]:
         """register dispatcher with new implementation
         >>> # xdoctest: +SKIP
         >>> f = Dispatcher("f")
@@ -162,20 +179,24 @@ class Dispatcher:
         [3, 2, 1]
         """
 
-        def _df(func):
+        def _df(func: Callable[..., _T]) -> Callable[..., _T]:
             self.add(types, func, **kwargs)  # type: ignore[call-arg]
             return func
 
         return _df
 
     @classmethod
-    def get_func_params(cls, func):
+    def get_func_params(
+        cls, func: Callable[..., object]
+    ) -> Iterable[inspect.Parameter] | None:
         if hasattr(inspect, "signature"):
             sig = inspect.signature(func)
             return sig.parameters.values()
 
     @classmethod
-    def get_func_annotations(cls, func):
+    def get_func_annotations(
+        cls, func: Callable[..., object]
+    ) -> tuple[type, ...] | None:
         """get annotations of function positional parameters"""
         params = cls.get_func_params(func)
         if params:
@@ -193,7 +214,7 @@ class Dispatcher:
             if all(ann is not Parameter.empty for ann in annotations):
                 return annotations
 
-    def add(self, signature, func):
+    def add(self, signature: tuple[type, ...], func: Callable[..., object]) -> None:
         """Add new types/method pair to dispatcher
         >>> # xdoctest: +SKIP
         >>> D = Dispatcher("add")
@@ -248,7 +269,7 @@ class Dispatcher:
                 # pyrefly: ignore [bad-specialization]
                 new_signature.append(Variadic[typ[0]])
             else:
-                new_signature.append(typ)
+                new_signature.append(typ)  # pyrefly: ignore[bad-argument-type]
 
         self.funcs[tuple(new_signature)] = func
         self._cache.clear()
@@ -259,20 +280,22 @@ class Dispatcher:
             pass
 
     @property
-    def ordering(self):
+    def ordering(self) -> list[tuple[type, ...]]:
         try:
             return self._ordering
         except AttributeError:
             return self.reorder()
 
-    def reorder(self, on_ambiguity=ambiguity_warn):
+    def reorder(
+        self, on_ambiguity: Callable[..., None] = ambiguity_warn
+    ) -> list[tuple[type, ...]]:
         self._ordering = od = ordering(self.funcs)
         amb = ambiguities(self.funcs)
         if amb:
             on_ambiguity(self, amb)
         return od
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: object, **kwargs: object) -> object:
         types = tuple(type(arg) for arg in args)
         try:
             func = self._cache[types]
@@ -300,12 +323,12 @@ class Dispatcher:
                 f"{self.name}: <{str_signature(types)}> found, but none completed successfully",
             ) from e
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"<dispatched {self.name}>"
 
     __repr__ = __str__
 
-    def dispatch(self, *types):
+    def dispatch(self, *types: type) -> Callable[..., object] | None:
         """Determine appropriate implementation for this type signature
         This method is internal.  Users should call this object as a function.
         Implementation resolution occurs within the ``__call__`` method.
@@ -331,7 +354,9 @@ class Dispatcher:
         except StopIteration:
             return None
 
-    def dispatch_iter(self, *types):
+    def dispatch_iter(
+        self, *types: type
+    ) -> Generator[Callable[..., object], None, None]:
         n = len(types)
         for signature in self.ordering:
             if len(signature) == n and all(map(issubclass, types, signature)):
@@ -345,17 +370,17 @@ class Dispatcher:
     @deprecated(
         "`resolve()` is deprecated, use `dispatch(*types)`", category=FutureWarning
     )
-    def resolve(self, types):
+    def resolve(self, types: tuple[type, ...]) -> Callable[..., object] | None:
         """Determine appropriate implementation for this type signature
         .. deprecated:: 0.4.4
             Use ``dispatch(*types)`` instead
         """
         return self.dispatch(*types)
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         return {"name": self.name, "funcs": self.funcs}
 
-    def __setstate__(self, d):
+    def __setstate__(self, d: dict[str, Any]) -> None:
         self.name = d["name"]
         self.funcs = d["funcs"]
         self._ordering = ordering(self.funcs)
@@ -368,7 +393,7 @@ class Dispatcher:
         if self.doc:
             docs.append(self.doc)
 
-        other = []
+        other: list[str] = []
         for sig in self.ordering[::-1]:
             func = self.funcs[sig]
             if func.__doc__:
@@ -384,25 +409,25 @@ class Dispatcher:
 
         return "\n\n".join(docs)
 
-    def _help(self, *args):
+    def _help(self, *args: object) -> str | None:
         return self.dispatch(*map(type, args)).__doc__
 
-    def help(self, *args, **kwargs):
+    def help(self, *args: object, **kwargs: object) -> None:
         """Print docstring for the function corresponding to inputs"""
         print(self._help(*args))
 
-    def _source(self, *args):
+    def _source(self, *args: object) -> str:
         func = self.dispatch(*map(type, args))
         if not func:
             raise TypeError("No function found")
         return source(func)
 
-    def source(self, *args, **kwargs):
+    def source(self, *args: object, **kwargs: object) -> None:
         """Print source code for the function corresponding to inputs"""
         print(self._source(*args))
 
 
-def source(func):
+def source(func: Callable[..., object]) -> str:
     s = f"File: {inspect.getsourcefile(func)}\n\n"
     s = s + inspect.getsource(func)
     return s
@@ -417,17 +442,19 @@ class MethodDispatcher(Dispatcher):
     __slots__ = ("obj", "cls")
 
     @classmethod
-    def get_func_params(cls, func):
+    def get_func_params(
+        cls, func: Callable[..., object]
+    ) -> Iterator[inspect.Parameter] | None:
         if hasattr(inspect, "signature"):
             sig = inspect.signature(func)
             return itl.islice(sig.parameters.values(), 1, None)
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance: object | None, owner: type) -> MethodDispatcher:
         self.obj = instance
         self.cls = owner
         return self
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: object, **kwargs: object) -> object:
         types = tuple(type(arg) for arg in args)
         func = self.dispatch(*types)
         if not func:
@@ -437,7 +464,7 @@ class MethodDispatcher(Dispatcher):
         return func(self.obj, *args, **kwargs)
 
 
-def str_signature(sig):
+def str_signature(sig: Iterable[type]) -> str:
     """String representation of type signature
     >>> str_signature((int, float))
     'int, float'
@@ -445,7 +472,7 @@ def str_signature(sig):
     return ", ".join(cls.__name__ for cls in sig)
 
 
-def warning_text(name, amb):
+def warning_text(name: str, amb: set[tuple[tuple[type, ...], tuple[type, ...]]]) -> str:
     """The text for ambiguity warnings"""
     text = f"\nAmbiguities exist in dispatched function {name}\n\n"
     text += "The following signatures may result in ambiguous behavior:\n"

--- a/torch/fx/experimental/unification/multipledispatch/utils.py
+++ b/torch/fx/experimental/unification/multipledispatch/utils.py
@@ -1,11 +1,22 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 from collections import OrderedDict
+from typing import TYPE_CHECKING, TypeVar
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping, Sequence
+
+_T = TypeVar("_T")
 
 
 __all__ = ["raises", "expand_tuples", "reverse_dict", "groupby", "typename"]
 
 
-def raises(err, lamda):  # codespell:ignore lamda
+def raises(
+    err: type[BaseException],
+    lamda: Callable[[], object],  # codespell:ignore lamda
+) -> bool:
     try:
         lamda()  # codespell:ignore lamda
         return False
@@ -13,7 +24,7 @@ def raises(err, lamda):  # codespell:ignore lamda
         return True
 
 
-def expand_tuples(L):
+def expand_tuples(L: Sequence[type | tuple[type, ...]]) -> list[tuple[type, ...]]:
     """
     >>> expand_tuples([1, (2, 3)])
     [(1, 2), (1, 3)]
@@ -32,7 +43,7 @@ def expand_tuples(L):
 
 # Taken from theano/theano/gof/sched.py
 # Avoids licensing issues because this was written by Matthew Rocklin
-def _toposort(edges):
+def _toposort(edges: Mapping[_T, Iterable[_T]]) -> list[_T]:
     """Topological sort algorithm by Kahn [1] - O(nodes + vertices)
     inputs:
         edges - a dict of the form {a: {b, c}} where b and c depend on a
@@ -64,7 +75,9 @@ def _toposort(edges):
     return L
 
 
-def reverse_dict(d):
+def reverse_dict(
+    d: Mapping[_T, Iterable[_T]],
+) -> OrderedDict[_T, tuple[_T, ...]]:
     """Reverses direction of dependence dict.
 
     >>> d = {"a": (1, 2), "b": (2, 3), "c": ()}
@@ -82,12 +95,14 @@ def reverse_dict(d):
         for val in d[key]:
             # pyrefly: ignore [unsupported-operation]
             result[val] = result.get(val, ()) + (key,)
-    return result
+    return result  # pyrefly: ignore[bad-return]
 
 
 # Taken from toolz
 # Avoids licensing issues because this version was authored by Matthew Rocklin
-def groupby(func, seq):
+def groupby(
+    func: Callable[[_T], object], seq: Iterable[_T]
+) -> OrderedDict[object, list[_T]]:
     """Group a collection by a key function
     >>> names = ["Alice", "Bob", "Charlie", "Dan", "Edith", "Frank"]
     >>> groupby(len, names)  # doctest: +SKIP
@@ -108,7 +123,7 @@ def groupby(func, seq):
     return d
 
 
-def typename(type):
+def typename(type: type | tuple[type, ...]) -> str:
     """Get the name of `type`.
     Parameters
     ----------
@@ -125,7 +140,7 @@ def typename(type):
     '(int, float)'
     """
     try:
-        return type.__name__
+        return type.__name__  # pyrefly: ignore[missing-attribute]
     except AttributeError:
         if len(type) == 1:
             return typename(*type)

--- a/torch/fx/experimental/unification/multipledispatch/variadic.py
+++ b/torch/fx/experimental/unification/multipledispatch/variadic.py
@@ -1,4 +1,5 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 from .utils import typename
 
 
@@ -7,14 +8,14 @@ __all__ = ["VariadicSignatureType", "isvariadic", "VariadicSignatureMeta", "Vari
 
 class VariadicSignatureType(type):
     # checking if subclass is a subclass of self
-    def __subclasscheck__(cls, subclass):
+    def __subclasscheck__(cls, subclass: type) -> bool:
         other_type = subclass.variadic_type if isvariadic(subclass) else (subclass,)
         return subclass is cls or all(
             issubclass(other, cls.variadic_type)  # type: ignore[attr-defined]
             for other in other_type
         )
 
-    def __eq__(cls, other):
+    def __eq__(cls, other: object) -> bool:
         """
         Return True if other has the same variadic type
         Parameters
@@ -28,11 +29,11 @@ class VariadicSignatureType(type):
         """
         return isvariadic(other) and set(cls.variadic_type) == set(other.variadic_type)  # type: ignore[attr-defined]
 
-    def __hash__(cls):
+    def __hash__(cls) -> int:
         return hash((type(cls), frozenset(cls.variadic_type)))  # type: ignore[attr-defined]
 
 
-def isvariadic(obj):
+def isvariadic(obj: type) -> bool:
     """Check whether the type `obj` is variadic.
     Parameters
     ----------
@@ -59,7 +60,9 @@ class VariadicSignatureMeta(type):
     examples of how this behaves.
     """
 
-    def __getitem__(cls, variadic_type):
+    def __getitem__(
+        cls, variadic_type: type | tuple[type, ...]
+    ) -> VariadicSignatureType:
         if not (isinstance(variadic_type, (type, tuple)) or type(variadic_type)):
             raise ValueError(
                 "Variadic types must be type or tuple of types"

--- a/torch/fx/experimental/unification/unification_tools.py
+++ b/torch/fx/experimental/unification/unification_tools.py
@@ -1,8 +1,20 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 import collections
 import operator
 from collections.abc import Mapping
 from functools import reduce
+from typing import TYPE_CHECKING, TypeVar
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+_K = TypeVar("_K")
+_V = TypeVar("_V")
+_K2 = TypeVar("_K2")
+_V2 = TypeVar("_V2")
+_T = TypeVar("_T")
 
 
 __all__ = [
@@ -22,8 +34,8 @@ __all__ = [
 ]
 
 
-def _get_factory(f, kwargs):
-    factory = kwargs.pop("factory", dict)
+def _get_factory(f: Callable[..., object], kwargs: dict[str, object]) -> type:
+    factory: type = kwargs.pop("factory", dict)  # type: ignore[assignment]
     if kwargs:
         raise TypeError(
             f"{f.__name__}() got an unexpected keyword argument '{kwargs.popitem()[0]}'"
@@ -31,7 +43,7 @@ def _get_factory(f, kwargs):
     return factory
 
 
-def merge(*dicts, **kwargs):
+def merge(*dicts: Mapping[object, object], **kwargs: object) -> object:
     """Merge a collection of dictionaries
 
     >>> merge({1: "one"}, {2: "two"})
@@ -55,7 +67,9 @@ def merge(*dicts, **kwargs):
     return rv
 
 
-def merge_with(func, *dicts, **kwargs):
+def merge_with(
+    func: Callable[..., object], *dicts: Mapping[object, object], **kwargs: object
+) -> object:
     """Merge dictionaries and apply function to combined values
 
     A key may occur in more than one dict, and all values mapped from the key
@@ -84,7 +98,9 @@ def merge_with(func, *dicts, **kwargs):
     return valmap(func, result, factory)
 
 
-def valmap(func, d, factory=dict):
+def valmap(
+    func: Callable[[_V], _V2], d: Mapping[_K, _V], factory: type = dict
+) -> dict[_K, _V2]:
     """Apply function to values of dictionary
 
     >>> bills = {"Alice": [20, 15, 30], "Bob": [10, 35]}
@@ -100,7 +116,9 @@ def valmap(func, d, factory=dict):
     return rv
 
 
-def keymap(func, d, factory=dict):
+def keymap(
+    func: Callable[[_K], _K2], d: Mapping[_K, _V], factory: type = dict
+) -> dict[_K2, _V]:
     """Apply function to keys of dictionary
 
     >>> bills = {"Alice": [20, 15, 30], "Bob": [10, 35]}
@@ -116,7 +134,9 @@ def keymap(func, d, factory=dict):
     return rv
 
 
-def itemmap(func, d, factory=dict):
+def itemmap(
+    func: Callable[[tuple[_K, _V]], object], d: Mapping[_K, _V], factory: type = dict
+) -> dict[object, object]:
     """Apply function to items of dictionary
 
     >>> accountids = {"Alice": 10, "Bob": 20}
@@ -132,7 +152,9 @@ def itemmap(func, d, factory=dict):
     return rv
 
 
-def valfilter(predicate, d, factory=dict):
+def valfilter(
+    predicate: Callable[[_V], bool], d: Mapping[_K, _V], factory: type = dict
+) -> dict[_K, _V]:
     """Filter items in dictionary by value
 
     >>> iseven = lambda x: x % 2 == 0
@@ -152,7 +174,9 @@ def valfilter(predicate, d, factory=dict):
     return rv
 
 
-def keyfilter(predicate, d, factory=dict):
+def keyfilter(
+    predicate: Callable[[_K], bool], d: Mapping[_K, _V], factory: type = dict
+) -> dict[_K, _V]:
     """Filter items in dictionary by key
 
     >>> iseven = lambda x: x % 2 == 0
@@ -172,7 +196,9 @@ def keyfilter(predicate, d, factory=dict):
     return rv
 
 
-def itemfilter(predicate, d, factory=dict):
+def itemfilter(
+    predicate: Callable[[tuple[_K, _V]], bool], d: Mapping[_K, _V], factory: type = dict
+) -> dict[_K, _V]:
     """Filter items in dictionary by item
 
     >>> def isvalid(item):
@@ -196,7 +222,9 @@ def itemfilter(predicate, d, factory=dict):
     return rv
 
 
-def assoc(d, key, value, factory=dict):
+def assoc(
+    d: Mapping[_K, _V], key: object, value: object, factory: type = dict
+) -> dict[_K, _V]:
     """Return a new dict with new key value pair
 
     New dict has d[key] set to value. Does not modify the initial dictionary.
@@ -212,7 +240,7 @@ def assoc(d, key, value, factory=dict):
     return d2
 
 
-def dissoc(d, *keys, **kwargs):
+def dissoc(d: Mapping[object, object], *keys: object, **kwargs: object) -> object:
     """Return a new dict with the given key(s) removed.
 
     New dict has d[key] deleted for each supplied key.
@@ -241,7 +269,12 @@ def dissoc(d, *keys, **kwargs):
     return d2
 
 
-def assoc_in(d, keys, value, factory=dict):
+def assoc_in(
+    d: Mapping[object, object],
+    keys: Iterable[object],
+    value: object,
+    factory: type = dict,
+) -> object:
     """Return a new dict with new, potentially nested, key value pair
 
     >>> purchase = {
@@ -257,7 +290,13 @@ def assoc_in(d, keys, value, factory=dict):
     return update_in(d, keys, lambda x: value, value, factory)
 
 
-def update_in(d, keys, func, default=None, factory=dict):
+def update_in(
+    d: Mapping[object, object],
+    keys: Iterable[object],
+    func: Callable[..., object],
+    default: object = None,
+    factory: type = dict,
+) -> object:
     """Update value in a (potentially) nested dictionary
 
     inputs:
@@ -300,7 +339,7 @@ def update_in(d, keys, func, default=None, factory=dict):
 
     for key in ks:
         if k in d:
-            d = d[k]
+            d = d[k]  # pyrefly: ignore[bad-assignment]
             dtemp = factory()
             dtemp.update(d)
         else:
@@ -316,7 +355,12 @@ def update_in(d, keys, func, default=None, factory=dict):
     return rv
 
 
-def get_in(keys, coll, default=None, no_default=False):
+def get_in(
+    keys: Iterable[object],
+    coll: object,
+    default: object = None,
+    no_default: bool = False,
+) -> object:
     """Returns coll[i0][i1]...[iX] where [i0, i1, ..., iX]==keys.
 
     If coll[i0][i1]...[iX] cannot be found, returns ``default``, unless
@@ -349,14 +393,18 @@ def get_in(keys, coll, default=None, no_default=False):
         operator.getitem
     """
     try:
-        return reduce(operator.getitem, keys, coll)
+        return reduce(
+            operator.getitem,
+            keys,  # pyrefly: ignore[bad-argument-type]
+            coll,  # pyrefly: ignore[bad-argument-type]
+        )
     except (KeyError, IndexError, TypeError):
         if no_default:
             raise
         return default
 
 
-def getter(index):
+def getter(index: object) -> Callable[..., object]:
     if isinstance(index, list):
         if len(index) == 1:
             index = index[0]
@@ -369,7 +417,7 @@ def getter(index):
         return operator.itemgetter(index)
 
 
-def groupby(key, seq):
+def groupby(key: object, seq: Iterable[object]) -> dict[object, list[object]]:
     """Group a collection by a key function
 
     >>> names = ["Alice", "Bob", "Charlie", "Dan", "Edith", "Frank"]
@@ -404,13 +452,13 @@ def groupby(key, seq):
     d = collections.defaultdict(lambda: [].append)  # type: ignore[var-annotated]
     for item in seq:
         d[key(item)](item)
-    rv = {}
+    rv: dict[object, list[object]] = {}
     for k, v in d.items():
-        rv[k] = v.__self__  # type: ignore[var-annotated, attr-defined]
+        rv[k] = v.__self__  # type: ignore[attr-defined]
     return rv
 
 
-def first(seq):
+def first(seq: Iterable[_T]) -> _T:
     """The first element in a sequence
 
     >>> first("ABC")

--- a/torch/fx/experimental/unification/utils.py
+++ b/torch/fx/experimental/unification/utils.py
@@ -1,8 +1,20 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from .variable import Var
+
+_T = TypeVar("_T")
+
+
 __all__ = ["hashable", "transitive_get", "raises", "reverse_dict", "xfail", "freeze"]
 
 
-def hashable(x):
+def hashable(x: object) -> bool:
     try:
         hash(x)
         return True
@@ -10,7 +22,7 @@ def hashable(x):
         return False
 
 
-def transitive_get(key, d):
+def transitive_get(key: object, d: dict[Var, object]) -> object:
     """Transitive dict.get
     >>> d = {1: 2, 2: 3, 3: 4}
     >>> d.get(1)
@@ -23,7 +35,10 @@ def transitive_get(key, d):
     return key
 
 
-def raises(err, lamda):  # codespell:ignore lamda
+def raises(
+    err: type[BaseException],
+    lamda: Callable[[], object],  # codespell:ignore lamda
+) -> bool:
     try:
         lamda()  # codespell:ignore lamda
         return False
@@ -33,7 +48,7 @@ def raises(err, lamda):  # codespell:ignore lamda
 
 # Taken from theano/theano/gof/sched.py
 # Avoids licensing issues because this was written by Matthew Rocklin
-def _toposort(edges):
+def _toposort(edges: dict[_T, Iterable[_T]]) -> list[_T]:
     """Topological sort algorithm by Kahn [1] - O(nodes + vertices)
     inputs:
         edges - a dict of the form {a: {b, c}} where b and c depend on a
@@ -66,7 +81,7 @@ def _toposort(edges):
     return L
 
 
-def reverse_dict(d):
+def reverse_dict(d: dict[_T, Iterable[_T]]) -> dict[_T, tuple[_T, ...]]:
     """Reverses direction of dependence dict.
 
     >>> d = {"a": (1, 2), "b": (2, 3), "c": ()}
@@ -84,10 +99,10 @@ def reverse_dict(d):
         for val in d[key]:
             # pyrefly: ignore [unsupported-operation]
             result[val] = result.get(val, ()) + (key,)
-    return result
+    return result  # pyrefly: ignore[bad-return]
 
 
-def xfail(func):
+def xfail(func: Callable[[], object]) -> None:
     try:
         func()
         raise Exception("XFailed test passed")  # pragma:nocover  # noqa: TRY002
@@ -95,7 +110,7 @@ def xfail(func):
         pass
 
 
-def freeze(d):
+def freeze(d: object) -> object:
     """Freeze container to hashable form
     >>> freeze(1)
     1

--- a/torch/fx/experimental/unification/variable.py
+++ b/torch/fx/experimental/unification/variable.py
@@ -1,11 +1,18 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Hashable
+    from typing import Literal
 
 from .dispatch import dispatch
 from .utils import hashable
 
 
-_global_logic_variables = set()  # type: ignore[var-annotated]
+_global_logic_variables: set[Hashable] = set()
 _glv = _global_logic_variables
 
 
@@ -14,39 +21,39 @@ class Var:
 
     _id = 1
 
-    def __new__(cls, *token):
+    def __new__(cls, *token: Hashable) -> Var:  # noqa: PYI034
         if len(token) == 0:
             token = f"_{Var._id}"  # type: ignore[assignment]
             Var._id += 1
         elif len(token) == 1:
-            token = token[0]
+            token = token[0]  # pyrefly: ignore[bad-assignment]
 
         obj = object.__new__(cls)
         obj.token = token  # type: ignore[attr-defined]
         return obj
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "~" + str(self.token)  # type: ignore[attr-defined]
 
     __repr__ = __str__
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return type(self) is type(other) and self.token == other.token  # type: ignore[attr-defined]
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((type(self), self.token))  # type: ignore[attr-defined]
 
 
-def var():
+def var() -> Callable[..., Var]:
     return lambda *args: Var(*args)
 
 
-def vars():
+def vars() -> Callable[[int], list[Callable[..., Var]]]:
     return lambda n: [var() for i in range(n)]
 
 
 @dispatch(Var)
-def isvar(v):
+def isvar(v: Var) -> Literal[True]:
     return True
 
 
@@ -54,12 +61,12 @@ isvar
 
 
 @dispatch(object)  # type: ignore[no-redef]
-def isvar(o):
-    return _glv and hashable(o) and o in _glv
+def isvar(o: object) -> bool:
+    return bool(_glv and hashable(o) and o in _glv)
 
 
 @contextmanager
-def variables(*variables):
+def variables(*variables: Hashable) -> Generator[None, None, None]:
     """
     Context manager for logic variables
 


### PR DESCRIPTION
Remove mypy suppressions. Add return type and parameter type annotations across the unification subsystem.

Authored with Claude.