### PR TITLE
[dynamo] Only tag the last node as autograd.backward

### DIFF
--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2438,10 +2438,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
                     )
                 tx.output.autograd_grad_consumed_grad_fns.update(non_leaf_consumed)
 
-            with (
-                torch.fx.traceback.preserve_node_meta(),
-                torch.fx.traceback.annotate({"autograd_backward": True}),
-            ):
+            with torch.fx.traceback.preserve_node_meta():
                 proxy = tx.output.create_proxy(
                     "call_function",
                     torch.autograd.grad,

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -249,6 +249,14 @@ def aot_stage1_graph_capture(
                     fw_metadata=aot_state.fw_metadata,
                 )
             )
+            # Tag the last autograd.grad node as backward for the remat pass.
+            last_grad_node = None
+            for node in graph.graph.nodes:
+                if node.op == "call_function" and node.target is torch.autograd.grad:
+                    last_grad_node = node
+            if last_grad_node is not None:
+                last_grad_node.meta.setdefault("custom", {})["autograd_backward"] = True
+
             # Apply AC rematerialization to forward+loss+bwd graph
             if torch._functorch.config.remat_using_tags_for_fwd_loss_bwd_graph:
                 from torch._functorch._activation_checkpointing.remat_using_tags_for_fwd_loss_bwd_graph_pass import (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180358

Its a heuristic change, where we only tag the last autograd.grad node as
backward so that remat AC passes can work automatically.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98