### PR TITLE
[BE] TensorWithFlatten rename to TraceableWrapperSubclass and Improved Typing

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -61,6 +61,49 @@ def _identity(x):
     return x
 
 
+class _TraceableWrapperSubclassTestBase(torch.Tensor):
+    elem: torch.Tensor
+
+    __slots__ = ["elem"]
+
+    @staticmethod
+    def __new__(cls, elem):
+        r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
+            cls,
+            elem.size(),
+            dtype=elem.dtype,
+            layout=elem.layout,
+            device=elem.device,
+            requires_grad=elem.requires_grad,
+            strides=elem.stride(),
+            storage_offset=elem.storage_offset(),
+        )
+        r.elem = elem
+        return r
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        raise RuntimeError("NYI")
+
+
+class _StaticUnflattenWrapper(_TraceableWrapperSubclassTestBase):
+    def __tensor_flatten__(self):
+        return ["elem"], {"kind": "static"}
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, metadata, outer_size, outer_stride):
+        return _StaticUnflattenWrapper(inner_tensors["elem"])
+
+
+class _ClassmethodUnflattenWrapper(_TraceableWrapperSubclassTestBase):
+    def __tensor_flatten__(self):
+        return ["elem"], {"kind": "classmethod"}
+
+    @classmethod
+    def __tensor_unflatten__(cls, inner_tensors, metadata, outer_size, outer_stride):
+        return cls(inner_tensors["elem"])
+
+
 class TestDispatcherPythonBindings(TestCase):
     def test_call_boxed(self) -> None:
         sin = torch._C._dispatch_find_schema_or_throw("aten::sin", "")
@@ -1083,81 +1126,45 @@ $6: f32[1] = torch._ops.aten.add_.Tensor($1, $5)""",
         self.assertEqual(type(torch.randint_like(MyTensor(2), high=3)), MyTensor)
 
     def test_traceable_wrapper_subclass_protocol_runtime_check(self) -> None:
-        class WrapperBase(torch.Tensor):
-            elem: torch.Tensor
+        @torch._dynamo.disable
+        def run_checks() -> None:
+            base = torch.randn(2, 2)
+            static = _StaticUnflattenWrapper(base)
+            classmethod_wrapper = _ClassmethodUnflattenWrapper(base)
 
-            __slots__ = ["elem"]
+            self.assertFalse(is_traceable_wrapper_subclass(base))
+            self.assertTrue(is_traceable_wrapper_subclass(static))
+            self.assertTrue(is_traceable_wrapper_subclass(classmethod_wrapper))
+            self.assertTrue(is_traceable_wrapper_subclass_type(type(static)))
+            self.assertTrue(
+                is_traceable_wrapper_subclass_type(type(classmethod_wrapper))
+            )
+            self.assertFalse(is_traceable_wrapper_subclass_type(torch.Tensor))
 
-            @staticmethod
-            def __new__(cls, elem):
-                r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
-                    cls,
-                    elem.size(),
-                    dtype=elem.dtype,
-                    layout=elem.layout,
-                    device=elem.device,
-                    requires_grad=elem.requires_grad,
-                    strides=elem.stride(),
-                    storage_offset=elem.storage_offset(),
-                )
-                r.elem = elem
-                return r
+            static_attrs, static_meta = static.__tensor_flatten__()
+            static_rebuilt = type(static).__tensor_unflatten__(
+                {attr: getattr(static, attr) for attr in static_attrs},
+                static_meta,
+                static.size(),
+                static.stride(),
+            )
+            self.assertIs(type(static_rebuilt), _StaticUnflattenWrapper)
+            self.assertEqual(static_rebuilt.elem, static.elem)
 
-            @classmethod
-            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
-                raise RuntimeError("NYI")
+            classmethod_attrs, classmethod_meta = classmethod_wrapper.__tensor_flatten__()
+            classmethod_rebuilt = type(classmethod_wrapper).__tensor_unflatten__(
+                {
+                    attr: getattr(classmethod_wrapper, attr)
+                    for attr in classmethod_attrs
+                },
+                classmethod_meta,
+                classmethod_wrapper.size(),
+                classmethod_wrapper.stride(),
+            )
+            self.assertIs(type(classmethod_rebuilt), _ClassmethodUnflattenWrapper)
+            self.assertEqual(classmethod_rebuilt.elem, classmethod_wrapper.elem)
 
-        class StaticUnflattenWrapper(WrapperBase):
-            def __tensor_flatten__(self):
-                return ["elem"], {"kind": "static"}
-
-            @staticmethod
-            def __tensor_unflatten__(inner_tensors, metadata, outer_size, outer_stride):
-                return StaticUnflattenWrapper(inner_tensors["elem"])
-
-        class ClassmethodUnflattenWrapper(WrapperBase):
-            def __tensor_flatten__(self):
-                return ["elem"], {"kind": "classmethod"}
-
-            @classmethod
-            def __tensor_unflatten__(
-                cls, inner_tensors, metadata, outer_size, outer_stride
-            ):
-                return cls(inner_tensors["elem"])
-
-        base = torch.randn(2, 2)
-        static = StaticUnflattenWrapper(base)
-        classmethod_wrapper = ClassmethodUnflattenWrapper(base)
-
-        self.assertFalse(is_traceable_wrapper_subclass(base))
-        self.assertTrue(is_traceable_wrapper_subclass(static))
-        self.assertTrue(is_traceable_wrapper_subclass(classmethod_wrapper))
-        self.assertTrue(is_traceable_wrapper_subclass_type(type(static)))
-        self.assertTrue(
-            is_traceable_wrapper_subclass_type(type(classmethod_wrapper))
-        )
-        self.assertFalse(is_traceable_wrapper_subclass_type(torch.Tensor))
-
-        static_attrs, static_meta = static.__tensor_flatten__()
-        static_rebuilt = type(static).__tensor_unflatten__(
-            {attr: getattr(static, attr) for attr in static_attrs},
-            static_meta,
-            static.size(),
-            static.stride(),
-        )
-        self.assertIs(type(static_rebuilt), StaticUnflattenWrapper)
-
-        classmethod_attrs, classmethod_meta = classmethod_wrapper.__tensor_flatten__()
-        classmethod_rebuilt = type(classmethod_wrapper).__tensor_unflatten__(
-            {
-                attr: getattr(classmethod_wrapper, attr)
-                for attr in classmethod_attrs
-            },
-            classmethod_meta,
-            classmethod_wrapper.size(),
-            classmethod_wrapper.stride(),
-        )
-        self.assertIs(type(classmethod_rebuilt), ClassmethodUnflattenWrapper)
+        run_checks()
 
     def test_make_fx_with_subclass(self) -> None:
         def f(x, y):

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -49,6 +49,8 @@ from torch.utils._python_dispatch import (
     _get_current_dispatch_mode,
     _get_current_dispatch_mode_stack,
     is_in_torch_dispatch_mode,
+    is_traceable_wrapper_subclass,
+    is_traceable_wrapper_subclass_type,
     TorchDispatchMode,
 )
 from torch.utils._pytree import tree_map, tree_map_only
@@ -1079,6 +1081,83 @@ $6: f32[1] = torch._ops.aten.add_.Tensor($1, $5)""",
 
         self.assertEqual(type(torch.full_like(MyTensor(2), 1.0)), MyTensor)
         self.assertEqual(type(torch.randint_like(MyTensor(2), high=3)), MyTensor)
+
+    def test_traceable_wrapper_subclass_protocol_runtime_check(self) -> None:
+        class WrapperBase(torch.Tensor):
+            elem: torch.Tensor
+
+            __slots__ = ["elem"]
+
+            @staticmethod
+            def __new__(cls, elem):
+                r = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
+                    cls,
+                    elem.size(),
+                    dtype=elem.dtype,
+                    layout=elem.layout,
+                    device=elem.device,
+                    requires_grad=elem.requires_grad,
+                    strides=elem.stride(),
+                    storage_offset=elem.storage_offset(),
+                )
+                r.elem = elem
+                return r
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                raise RuntimeError("NYI")
+
+        class StaticUnflattenWrapper(WrapperBase):
+            def __tensor_flatten__(self):
+                return ["elem"], {"kind": "static"}
+
+            @staticmethod
+            def __tensor_unflatten__(inner_tensors, metadata, outer_size, outer_stride):
+                return StaticUnflattenWrapper(inner_tensors["elem"])
+
+        class ClassmethodUnflattenWrapper(WrapperBase):
+            def __tensor_flatten__(self):
+                return ["elem"], {"kind": "classmethod"}
+
+            @classmethod
+            def __tensor_unflatten__(
+                cls, inner_tensors, metadata, outer_size, outer_stride
+            ):
+                return cls(inner_tensors["elem"])
+
+        base = torch.randn(2, 2)
+        static = StaticUnflattenWrapper(base)
+        classmethod_wrapper = ClassmethodUnflattenWrapper(base)
+
+        self.assertFalse(is_traceable_wrapper_subclass(base))
+        self.assertTrue(is_traceable_wrapper_subclass(static))
+        self.assertTrue(is_traceable_wrapper_subclass(classmethod_wrapper))
+        self.assertTrue(is_traceable_wrapper_subclass_type(type(static)))
+        self.assertTrue(
+            is_traceable_wrapper_subclass_type(type(classmethod_wrapper))
+        )
+        self.assertFalse(is_traceable_wrapper_subclass_type(torch.Tensor))
+
+        static_attrs, static_meta = static.__tensor_flatten__()
+        static_rebuilt = type(static).__tensor_unflatten__(
+            {attr: getattr(static, attr) for attr in static_attrs},
+            static_meta,
+            static.size(),
+            static.stride(),
+        )
+        self.assertIs(type(static_rebuilt), StaticUnflattenWrapper)
+
+        classmethod_attrs, classmethod_meta = classmethod_wrapper.__tensor_flatten__()
+        classmethod_rebuilt = type(classmethod_wrapper).__tensor_unflatten__(
+            {
+                attr: getattr(classmethod_wrapper, attr)
+                for attr in classmethod_attrs
+            },
+            classmethod_meta,
+            classmethod_wrapper.size(),
+            classmethod_wrapper.stride(),
+        )
+        self.assertIs(type(classmethod_rebuilt), ClassmethodUnflattenWrapper)
 
     def test_make_fx_with_subclass(self) -> None:
         def f(x, y):

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1151,7 +1151,9 @@ $6: f32[1] = torch._ops.aten.add_.Tensor($1, $5)""",
             self.assertIs(type(static_rebuilt), _StaticUnflattenWrapper)
             self.assertEqual(static_rebuilt.elem, static.elem)
 
-            classmethod_attrs, classmethod_meta = classmethod_wrapper.__tensor_flatten__()
+            classmethod_attrs, classmethod_meta = (
+                classmethod_wrapper.__tensor_flatten__()
+            )
             classmethod_rebuilt = type(classmethod_wrapper).__tensor_unflatten__(
                 {
                     attr: getattr(classmethod_wrapper, attr)

--- a/torch/_functorch/_aot_autograd/subclass_utils.py
+++ b/torch/_functorch/_aot_autograd/subclass_utils.py
@@ -5,7 +5,6 @@ and this includes tensor subclasses that implement __torch_dispatch__.
 """
 
 import collections
-import typing
 from collections.abc import Callable, Iterable, Sequence
 from typing import Any, TypeGuard, TypeVar
 
@@ -17,7 +16,10 @@ from torch._library.opaque_object import is_opaque_reference_type
 from torch._opaque_base import OpaqueBase
 from torch._subclasses.fake_tensor import get_plain_tensors
 from torch.types import IntLikeType
-from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+from torch.utils._python_dispatch import (
+    is_traceable_wrapper_subclass,
+    TraceableWrapperSubclass,
+)
 
 from .descriptors import (
     AOTInput,
@@ -328,7 +330,7 @@ def runtime_unwrap_tensor_subclasses(
     subclass_metas: list[PlainTensorMeta | SubclassCreationMeta] | None = None,
 ) -> list[int | Tensor | SymInt | OpaqueBase]:
     def flatten_subclass(
-        x: Tensor,
+        x: Tensor | TraceableWrapperSubclass,
         subclass_meta: PlainTensorMeta | SubclassCreationMeta | OpaqueMeta | None,
         *,
         out: list[OpaqueBase | SymInt | Tensor | int],
@@ -397,14 +399,14 @@ def runtime_unwrap_tensor_subclasses(
             continue
 
         if subclass_metas is None:
-            get_plain_tensors(typing.cast(Tensor, x), out=xs_inner)
+            get_plain_tensors(x, out=xs_inner)
         else:
             subclass_meta = subclass_metas[idx]
             if not isinstance(subclass_meta, SubclassCreationMeta):
                 raise AssertionError(
                     f"expected SubclassCreationMeta, got {type(subclass_meta)}"
                 )
-            flatten_subclass(typing.cast(Tensor, x), subclass_meta, out=xs_inner)
+            flatten_subclass(x, subclass_meta, out=xs_inner)
 
     return xs_inner
 
@@ -435,7 +437,7 @@ def remap_unwrapped_subclass_arg_indices(
         num_indices = 1
         if is_traceable_wrapper_subclass(arg):
             num_indices = (
-                len(get_plain_tensors(typing.cast(Tensor, arg), out=[]))
+                len(get_plain_tensors(arg, out=[]))
                 + len(enumerate_filter_symints(arg.size()))
                 + len(enumerate_filter_symints(arg.stride()))
             )

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -43,8 +43,8 @@ from torch.types import IntLikeType, py_sym_types
 from torch.utils._mode_utils import no_dispatch
 from torch.utils._python_dispatch import (
     is_traceable_wrapper_subclass,
-    TraceableWrapperSubclass,
     TorchDispatchMode,
+    TraceableWrapperSubclass,
 )
 from torch.utils._pytree import KeyPath, keystr, PyTree, tree_map, tree_map_, TreeSpec
 from torch.utils._stats import count

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -43,6 +43,7 @@ from torch.types import IntLikeType, py_sym_types
 from torch.utils._mode_utils import no_dispatch
 from torch.utils._python_dispatch import (
     is_traceable_wrapper_subclass,
+    TraceableWrapperSubclass,
     TorchDispatchMode,
 )
 from torch.utils._pytree import KeyPath, keystr, PyTree, tree_map, tree_map_, TreeSpec
@@ -182,7 +183,9 @@ def disable_fake_tensor_cache(fake_mode: FakeTensorMode) -> Generator[None, None
 
 
 def get_plain_tensors(
-    subclass: Tensor, *, out: list[Tensor | int | SymInt | OpaqueBase]
+    subclass: Tensor | TraceableWrapperSubclass,
+    *,
+    out: list[Tensor | int | SymInt | OpaqueBase],
 ) -> list[Tensor | int | SymInt | OpaqueBase]:
     # This function is used in Runtime, do not add redundant asserts
     todo = [subclass]

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -75,8 +75,8 @@ from torch.utils._python_dispatch import (
     _push_mode,
     _unset_infra_mode,
     autograd_would_have_decomposed,
-    TraceableWrapperSubclass,
     TorchDispatchMode,
+    TraceableWrapperSubclass,
 )
 from torch.utils._stats import count
 from torch.utils._thunk import Thunk

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -75,6 +75,7 @@ from torch.utils._python_dispatch import (
     _push_mode,
     _unset_infra_mode,
     autograd_would_have_decomposed,
+    TraceableWrapperSubclass,
     TorchDispatchMode,
 )
 from torch.utils._stats import count
@@ -506,11 +507,11 @@ def get_proxy_slot(
     return res
 
 
-# Recursively traverses tensor subclasses,
+# Recursively traverses traceable wrapper subclasses,
 # returnining an (unordered) list of Proxy objects that are tracked
 # for all inner tensors, given the current extant proxy mode.
 # Returns an empty list if no proxy mode is active.
-def _get_proxies(t: torch.Tensor) -> list[Proxy]:
+def _get_proxies(t: torch.Tensor | TraceableWrapperSubclass) -> list[Proxy]:
     proxies = []
     mode = torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.PROXY)
     if mode is None:

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -20,10 +20,11 @@ from torch._C import (
     DispatchKey,
 )
 from torch._C._dynamo.guards import set_is_in_mode_without_ignore_compile_internals
+from torch._opaque_base import OpaqueBase
 
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
 
 # TODO: Limitations and things about enable_torch_dispatch_mode we should fix before exposing it:
@@ -449,18 +450,40 @@ class BaseTorchDispatchMode(TorchDispatchMode):
         return func(*args, **kwargs)
 
 
-# Subtypes which have __tensor_flatten__ and __tensor_unflatten__.
-class TensorWithFlatten(Protocol):
+# Python typing cannot express Intersection[torch.Tensor, Protocol], so this
+# protocol repeats the Tensor members that call sites commonly use after
+# is_traceable_wrapper_subclass() narrows a value to this protocol.
+class TraceableWrapperSubclass(Protocol):
+    """
+    Canonical protocol for wrapper tensor subclasses that PT2 can trace through.
+
+    ``__tensor_flatten__`` must return stable attribute names for the inner
+    values that participate in tracing together with any metadata needed to
+    rebuild the outer subclass.
+
+    ``__tensor_unflatten__`` must reconstruct an equivalent wrapper subclass
+    instance from the flattened inner values, metadata, and requested outer
+    size/stride. Callers may pass tensor attrs and registered reference-type
+    opaques in ``inner_tensors``. The returned tensor is expected to preserve
+    the requested outer size/stride. If ``attrs, metadata =
+    x.__tensor_flatten__()``, then ``type(x).__tensor_unflatten__`` must round-
+    trip from ``{name: getattr(x, name) for name in attrs}``, ``metadata``,
+    ``x.size()``, and ``x.stride()`` to an equivalent instance of ``x``.
+
+    ``__tensor_unflatten__`` may be implemented as either a ``@staticmethod``
+    or a ``@classmethod``; the runtime check below intentionally uses duck
+    typing to support both forms.
+    """
+
     def __tensor_flatten__(self) -> tuple[Sequence[str], object]: ...
 
     @staticmethod
     def __tensor_unflatten__(
-        inner_tensors: int, flatten_spec: int, outer_size: int, outer_stride: int
+        inner_tensors: Mapping[str, torch.Tensor | OpaqueBase],
+        metadata: object,
+        outer_size: Sequence[int | torch.SymInt],
+        outer_stride: Sequence[int | torch.SymInt],
     ) -> torch.Tensor: ...
-
-    # It would be really nice to be able to say that the return of
-    # is_traceable_wrapper_subclass() is Intersection[torch.Tensor,
-    # TensorWithFlatten] - but that doesn't exist.
 
     shape: torch._C.Size
 
@@ -512,51 +535,36 @@ class TensorWithFlatten(Protocol):
     ) -> torch.Tensor: ...
 
 
-def is_traceable_wrapper_subclass(t: object) -> TypeIs[TensorWithFlatten]:
+TensorWithFlatten = TraceableWrapperSubclass
+
+
+def _has_traceable_wrapper_subclass_protocol(t: object) -> bool:
+    return hasattr(t, "__tensor_flatten__") and hasattr(t, "__tensor_unflatten__")
+
+
+def is_traceable_wrapper_subclass(t: object) -> TypeIs[TraceableWrapperSubclass]:
     """
-    Returns whether or not a tensor subclass that implements __torch_dispatch__
-    is 'traceable' with torch.compile.
-    In order for a tensor subclass to support TorchDispatchMode-style tracing in PT2,
-    It must implement two magic methods: __tensor_flatten__ and __tensor_unflatten__.
-    It is also expected to obey some restrictions around traceability and aliasing:
-        * The subclass's __torch_dispatch__() implementation should desugar into pytorch
-            dispatcher operations that can be traced into a graph.
-        * The subclass should use return_and_correct_aliasing(). This is needed today to make
-            sure that torch.compile does the right thing in a few cases around input mutation
-            and output aliasing.
+    Returns whether ``t`` is a tensor subclass that matches the
+    ``TraceableWrapperSubclass`` protocol at runtime.
 
-    Expected magic method signatures:
-        attrs, ctx = t.__tensor_flatten__()
-            attrs: list of attribute name strings for inner tensors
-            ctx: dict containing any other subclass-specific metadata needed for unflattening
-
-        t = MySubClass.__tensor_unflatten__(inner_tensors, ctx, outer_size, outer_stride)
-            inner_tensors: dict mapping attribute name -> tensor for each inner tensor
-            ctx: dict with subclass metadata in the form that __tensor_flatten__() produces
-            outer_size: expected (possibly symbolic) size that the returned subclass
-                instance should have. Note that this arg is useful for certain subclasses
-                that require the shape info to be constructed. In most cases, this arg can be
-                safely ignored.
-            outer_stride: expected (possibly symbolic) stride that the returned subclass
-                instance should have. Note that this arg is useful for certain subclasses
-                that require the stride info to be constructed. In most cases, this arg can be
-                safely ignored.
+    See ``TraceableWrapperSubclass`` for the canonical flatten/unflatten
+    contract. Matching the protocol is necessary but not sufficient for full
+    PT2 support: the subclass's ``__torch_dispatch__`` implementation must also
+    desugar into traceable dispatcher operations and preserve aliasing semantics
+    with ``return_and_correct_aliasing()`` when needed.
     """
     is_subclass = isinstance(t, torch.Tensor) and type(t) is not torch.Tensor
-    return (
-        is_subclass
-        and hasattr(t, "__tensor_flatten__")
-        and hasattr(t, "__tensor_unflatten__")
-    )
+    return is_subclass and _has_traceable_wrapper_subclass_protocol(t)
 
 
-def is_traceable_wrapper_subclass_type(t: type) -> TypeIs[type[TensorWithFlatten]]:
+def is_traceable_wrapper_subclass_type(
+    t: type,
+) -> TypeIs[type[TraceableWrapperSubclass]]:
     """Same as above, but takes a type argument instead of an instance."""
     return (
         issubclass(t, torch.Tensor)
         and t is not torch.Tensor
-        and hasattr(t, "__tensor_flatten__")
-        and hasattr(t, "__tensor_unflatten__")
+        and _has_traceable_wrapper_subclass_protocol(t)
     )
 
 

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -20,11 +20,12 @@ from torch._C import (
     DispatchKey,
 )
 from torch._C._dynamo.guards import set_is_in_mode_without_ignore_compile_internals
-from torch._opaque_base import OpaqueBase
 
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
+
+    from torch._opaque_base import OpaqueBase
 
 
 # TODO: Limitations and things about enable_torch_dispatch_mode we should fix before exposing it:
@@ -472,7 +473,8 @@ class TraceableWrapperSubclass(Protocol):
 
     ``__tensor_unflatten__`` may be implemented as either a ``@staticmethod``
     or a ``@classmethod``; the runtime check below intentionally uses duck
-    typing to support both forms.
+    typing to support both forms, even though static type checkers may only
+    recognize the ``@staticmethod`` form as conforming to this protocol.
     """
 
     def __tensor_flatten__(self) -> tuple[Sequence[str], object]: ...


### PR DESCRIPTION
## Summary
- define `TraceableWrapperSubclass` in `torch/utils/_python_dispatch.py` as the canonical traceable wrapper subclass protocol, including the flatten/unflatten invariants and supported `__tensor_unflatten__` forms
- thread that protocol through the fake, AOT, and proxy helper boundaries so the contract is referenced directly instead of living in casts and comments
- add a focused runtime test that covers both `@staticmethod` and `@classmethod` `__tensor_unflatten__` implementations

## Root cause
The traceable wrapper subclass contract was only implied by repeated `hasattr(..., "__tensor_flatten__")` checks and an internal structural type with inaccurate method signatures. That left the canonical meaning of the protocol split across helpers, comments, and downstream assumptions.

## Proposed fix
Introduce an explicit `TraceableWrapperSubclass` protocol in `torch/utils/_python_dispatch.py`, move the contract documentation there, make `is_traceable_wrapper_subclass()` reference that canonical protocol, and update the affected fake/proxy/AOT helpers to use the protocol type directly.

## Why this is the right long term fix
This keeps the runtime behavior unchanged while giving PT2 wrapper-subclass support one documented source of truth. Future call sites can reference the same protocol instead of re-expressing the contract, which reduces drift in both signatures and invariants.

## Testing
- `python3 -m compileall torch/utils/_python_dispatch.py torch/_subclasses/fake_tensor.py torch/_functorch/_aot_autograd/subclass_utils.py torch/fx/experimental/proxy_tensor.py test/test_python_dispatch.py`
- `PYTHONPATH=/tmp/repos/pytorch/pytorch python3 test/test_python_dispatch.py TestPythonDispatch.test_traceable_wrapper_subclass_protocol_runtime_check TestPythonDispatch.test_make_fx_with_subclass TestPythonDispatch.test_make_wrapper_subclass_propagates_metadata`
- `PYTHONPATH=/tmp/repos/pytorch/pytorch python3 test/dynamo/test_subclasses.py SubclassTests.test_deferred_init_subclass_init_not_traced`

Drafted via Codex, published after manual review by @Lucaskabela 