### PR TITLE
[hop] Fix validate_subgraph_args_types for make_fx

### DIFF
--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -989,6 +989,11 @@ def diff_tensor_meta(
 #      hops may receive int inputs from the shape of outer tensor inputs.
 #      However, CompositeExplicitAutograd won't receive SymInt inputs because it only accepts real tensor inputs.
 def validate_subgraph_args_types(lifted_args: tuple[Any, ...] | list[Any]):
+    # Skip validation during vanilla FX symbolic tracing, where args
+    # are Proxy objects.The validation only applies to real dispatch
+    # paths listed above.
+    if torch.fx._symbolic_trace.is_fx_symbolic_tracing():
+        return
     allowed_types = (torch.Tensor, int, torch.SymInt)
     if not all(
         isinstance(arg, (torch.Tensor, int, torch.SymInt)) for arg in lifted_args


### PR DESCRIPTION
When using `make_fx` to trace flex_attention in torchtitan
```
NGPU=8 MODULE=graph_trainer.deepseek_v3 CONFIG=graph_trainer_deepseek_v3_debugmodel_flex_attn ./run_train.sh --compile.mode aot_fx_trace 
```
We are seeing spamming output: 
```

[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191] fx graph cache unable to load compiled graph
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191] Traceback (most recent call last):
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]   File "/data/users/yimingzhou/pytorch/torch/_inductor/codecache.py", line 1189, in iterate_over_candidates
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]     yield pickle.loads(content), content, True
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]           ^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]   File "/data/users/yimingzhou/pytorch/torch/fx/graph_module.py", line 150, in reduce_graph_module
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]     return _deserialize_graph_module(forward, body)
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]   File "/data/users/yimingzhou/pytorch/torch/fx/graph_module.py", line 204, in _deserialize_graph_module
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]     graph = KeepModules().trace(com, **tracer_extras)
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]   File "/data/users/yimingzhou/pytorch/torch/_dynamo/eval_frame.py", line 1281, in _fn
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]     return fn(*args, **kwargs)
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]            ^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]   File "/data/users/yimingzhou/pytorch/torch/fx/_symbolic_trace.py", line 890, in trace
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]     (self.create_arg(fn(*args)),),
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]                      ^^^^^^^^^
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]   File "<eval_with_key>.895", line 14, in forward
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]     flex_attention_backward = torch.ops.higher_order.flex_attention_backward(arg0_1, arg1_1, arg2_1, arg3_1, arg4_1, arg5_1, None, fw_graph0, joint_graph0, (2048, 2048, arg6_1, arg7_1, arg8_1, arg9_1, arg10_1, arg11_1, arg12_1, arg13_1, 128, 128, mask_graph0), 0.07216878364870322, {'BACKEND': 'AUTO', 'PRESCALE_QK': False, 'ROWS_GUARANTEED_SAFE': False, 'BLOCKS_ARE_CONTIGUOUS': False, 'WRITE_DQ': True, 'OUTPUT_LOGSUMEXP': True, 'OUTPUT_MAX': False}, (), (arg14_1,));  arg0_1 = arg1_1 = arg2_1 = arg3_1 = arg4_1 = arg5_1 = fw_graph0 = joint_graph0 = arg6_1 = arg7_1 = arg8_1 = arg9_1 = arg10_1 = arg11_1 = arg12_1 = arg13_1 = mask_graph0 = arg14_1 = None
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]   File "/data/users/yimingzhou/pytorch/torch/_higher_order_ops/flex_attention.py", line 151, in __call__
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]     validate_subgraph_args_types(score_mod_other_buffers + mask_mod_other_buffers)
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]   File "/data/users/yimingzhou/pytorch/torch/_higher_order_ops/utils.py", line 996, in validate_subgraph_args_types
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191]     raise AssertionError(
[rank0]:[rank0]:W0413 17:15:58.522000 2204081 /data/users/yimingzhou/pytorch/torch/_inductor/codecache.py:1191] AssertionError: (Proxy(arg14_1),) can only be of (<class 'torch.Tensor'>, <class 'int'>, <class 'torch.SymInt'>) but got (<class 'torch.fx.proxy.Proxy'>,)
```

Full spamming output: P2271152518

The reason is  `validate_subgraph_args_types` raises AssertionError when encountering `torch.fx.proxy.Proxy` arguments, this causes failures when the FX graph cache tries to deserialize cached compiled graphs containing higher-order ops like `flex_attention` and `flex_attention_backward`.

The fix skips validation when `is_fx_symbolic_tracing()` is True.