### PR TITLE
[inductor] Fix torch.compile crash on cumsum with broadcast input when scan dim >= 129

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2364,6 +2364,15 @@ class CommonTemplate:
             self.common(fn, (inp.view(-1),), rtol=1e-4, atol=1e-5, check_lowp=False)
             self.common(fn, (inp.view(10, -1),), rtol=1e-4, atol=1e-5, check_lowp=False)
 
+    def test_split_cumsum_broadcast(self):
+        # https://github.com/pytorch/pytorch/issues/180221
+        def fn(x, b):
+            return torch.cumsum(x + b, dim=1)
+
+        x = make_tensor(1, 129, 64, low=0, dtype=torch.float32, device=self.device)
+        b = make_tensor(64, low=0, dtype=torch.float32, device=self.device)
+        self.common(fn, (x, b))
+
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
     @skip_if_gpu_halide  # accuracy issue
     def test_split_cumsum_low_prec(self):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -306,7 +306,7 @@ class TritonSymbols:
                     if prefix_str[sym] == tree.prefix
                 ]
                 assert len(tree_match) == 1, "# of Match expected to 1"
-                
+
                 if tree_match[0].tensor_dim is None:
                     # tree has no tensor dimension (e.g. no_x_dim mode),
                     # treat as scalar

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -306,9 +306,16 @@ class TritonSymbols:
                     if prefix_str[sym] == tree.prefix
                 ]
                 assert len(tree_match) == 1, "# of Match expected to 1"
-
-                shape[tree_match[0].tensor_dim] = str(cls.get_block_size(tree_match[0]))
-                var_shape = tuple(shape)
+                
+                if tree_match[0].tensor_dim is None:
+                    # tree has no tensor dimension (e.g. no_x_dim mode),
+                    # treat as scalar
+                    var_shape = ()
+                else:
+                    shape[tree_match[0].tensor_dim] = str(
+                        cls.get_block_size(tree_match[0])
+                    )
+                    var_shape = tuple(shape)
 
             # Union current variable shape
             expr_shape = get_broadcasted_shape(expr_shape, var_shape)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/180221

SplitScan kernels set `no_x_dim=True`, so the "x" range tree gets `tensor_dim=None`. When a broadcast variable (e.g. bias) references this tree, `get_block_shape` does `shape[None]` and crashes with TypeError.

Fix: treat `tensor_dim=None` as scalar shape `()` in `get_block_shape`, matching how other scalar symbols (e.g. `SymT.SIZE`) are handled.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos