### PR TITLE
[pr-review skill] Missing tests must block approval

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -190,6 +190,8 @@ Reference the specific infrastructure the PR should be using.]
 ### Recommendation
 **Approve** / **Request Changes** / **Needs Discussion**
 
+Missing tests (new functionality without tests, bug fixes without regression tests) always means **Request Changes**.
+
 [Brief justification for recommendation]
 ```
 

--- a/.claude/skills/pr-review/review-checklist.md
+++ b/.claude/skills/pr-review/review-checklist.md
@@ -160,6 +160,7 @@ When a PR touches code in the scope of any item below, **stop and investigate** 
 ### Test Existence
 
 - [ ] **Tests exist** - New functionality has corresponding tests
+- [ ] **Regression tests for bug fixes** - Bug fixes must include a test that reproduces the bug before the fix
 - [ ] **Tests are in the right place** - Tests should be added to an existing test file next to other related tests
 - [ ] **New test file is rare** - New test file should only be added when new major features are added
 


### PR DESCRIPTION
## Author Notes

Minor review skill update to ensure there is always test

## Agent Notes

Updates the pr-review skill to enforce that missing tests always results in "Request Changes":

- Added a "Regression tests for bug fixes" checklist item to the review checklist
- Added an explicit rule in the recommendation section that missing tests (new functionality without tests, bug fixes without regression tests) always means **Request Changes**, not a suggestion

Authored with Claude.