### PR TITLE
[ROCm] - Disable test_dtensor_pp_integrating

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -199,6 +199,7 @@ ROCM_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
     "higher_order_ops/test_inline_asm_elementwise",
+    "distributed/pipelining/test_dtensor_pp_integration"
 ]
 
 # Add architecture-specific blocklist entries

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -199,7 +199,7 @@ ROCM_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
     "higher_order_ops/test_inline_asm_elementwise",
-    "distributed/pipelining/test_dtensor_pp_integration"
+    "distributed/pipelining/test_dtensor_pp_integration",
 ]
 
 # Add architecture-specific blocklist entries


### PR DESCRIPTION
Trying get CI back to green

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @jerrymannil @xinyazhang