### PR TITLE
[Dynamo] Inline root module forward hooks when compiling modules

### DIFF
--- a/test/dynamo/test_hooks.py
+++ b/test/dynamo/test_hooks.py
@@ -1079,8 +1079,8 @@ def forward(self, L_x_ : torch.Tensor):
         self.assertEqual(ref, res)
         self.assertEqual(cnts.frame_count, 2)
 
-    @torch._dynamo.config.patch(wrap_top_frame=True)
-    def test_wrap_top_frame_with_hooks(self):
+    @torch._dynamo.config.patch(wrap_top_frame=False)
+    def test_root_module_hooks_compile_in_single_frame(self):
         class ToyModel(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1089,25 +1089,41 @@ def forward(self, L_x_ : torch.Tensor):
             def forward(self, x):
                 return self.net1(x)
 
-        mod = ToyModel()
-        mod.register_forward_pre_hook(lambda mod, input: input[0] + 1)
-
-        # Case 1: torch.compile(mod)
-        cnts = torch._dynamo.testing.CompileCounter()
-        compiled_mod = torch.compile(mod, backend=cnts)
-
         x = torch.rand(18, 18)
-        ref = mod(x)
-        res = compiled_mod(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
 
-        # Case 2: mod.compile()
-        cnts = torch._dynamo.testing.CompileCounter()
-        mod.compile(backend=cnts)
-        res = mod(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
+        for hook_type, register_hook in (
+            (
+                "forward_pre_hook",
+                lambda mod: mod.register_forward_pre_hook(
+                    lambda mod, input: input[0] + 1
+                ),
+            ),
+            (
+                "forward_hook",
+                lambda mod: mod.register_forward_hook(
+                    lambda mod, input, output: output + 1
+                ),
+            ),
+        ):
+            with self.subTest(hook_type=hook_type):
+                mod = ToyModel()
+                register_hook(mod)
+
+                # Case 1: torch.compile(mod)
+                cnts = torch._dynamo.testing.CompileCounter()
+                compiled_mod = torch.compile(mod, backend=cnts)
+
+                ref = mod(x)
+                res = compiled_mod(x)
+                self.assertEqual(ref, res)
+                self.assertEqual(cnts.frame_count, 1)
+
+                # Case 2: mod.compile()
+                cnts = torch._dynamo.testing.CompileCounter()
+                mod.compile(backend=cnts)
+                res = mod(x)
+                self.assertEqual(ref, res)
+                self.assertEqual(cnts.frame_count, 1)
 
     def test_global_module_forward_pre_hook(self):
         class Mod(torch.nn.Module):

--- a/test/dynamo/test_modules.py
+++ b/test/dynamo/test_modules.py
@@ -2546,15 +2546,15 @@ class OptimizedModuleTest(torch._dynamo.test_case.TestCase):
         loss_bwd = loss.backward()
 
         self.assertEqual(eager_loss_bwd, loss_bwd)
-        self.assertEqual(cnt.frame_count, 2)
+        self.assertEqual(cnt.frame_count, 1)
 
         # Ndim change, recompile
         pred = model(torch.randn([10, 10, 10]))
-        self.assertEqual(cnt.frame_count, 4)
+        self.assertEqual(cnt.frame_count, 2)
 
         # Stable
         pred = model(torch.randn([10, 10, 10]))
-        self.assertEqual(cnt.frame_count, 4)
+        self.assertEqual(cnt.frame_count, 2)
 
     def test_dunder_call_explicitly(self):
         # hooks should be triggered if explicit calling `__call__`

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -950,21 +950,29 @@ class _TorchDynamoContext:
         except TypeError:
             filename = None
 
-        wrap_root_module_call_with_hooks = (
-            isinstance(fn, types.MethodType)
-            and getattr(fn, "__name__", "") in {"_call_impl", "_wrapped_call_impl"}
-            and isinstance(getattr(fn, "__self__", None), torch.nn.Module)
-            and utils.nnmodule_has_hooks(fn.__self__, check_forward_hooks=True)
-        )
-        if config.debug_force_nested_calls:
-            fn = external_utils.wrap_inline(fn)
-        elif config.wrap_top_frame or wrap_root_module_call_with_hooks or (
+        wrap_root_module_call_with_hooks = False
+        if isinstance(fn, types.MethodType):
+            bound_module = getattr(fn, "__self__", None)
+            wrap_root_module_call_with_hooks = (
+                getattr(fn, "__name__", "") in {"_call_impl", "_wrapped_call_impl"}
+                and isinstance(bound_module, torch.nn.Module)
+                and utils.nnmodule_has_hooks(bound_module, check_forward_hooks=True)
+            )
+
+        wrap_builtin_without_frame = (
             (filename is None or trace_rules.check(fn) or top_level_in_graph)
             and (
                 getattr(fn, "__name__", "")
                 not in ["_call_impl", "_wrapped_call_impl", "_lazy_forward"]
             )
             and filename not in DONT_WRAP_FILES
+        )
+        if config.debug_force_nested_calls:
+            fn = external_utils.wrap_inline(fn)
+        elif (
+            config.wrap_top_frame
+            or wrap_root_module_call_with_hooks
+            or wrap_builtin_without_frame
         ):
             # call to a builtin without a frame for us to capture
             fn = external_utils.wrap_inline(fn)

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -442,13 +442,21 @@ class OptimizedModule(torch.nn.Module):
         if isinstance(self.dynamo_ctx, DisableContext):
             # No need to check trace rules
             self.forward = self.dynamo_ctx(self._orig_mod.__call__)
-        elif config.wrap_top_frame or (
-            isinstance(self._orig_mod.forward, types.MethodType)
-            and (trace_rules.check(self._orig_mod.forward))
+        elif (
+            config.wrap_top_frame
+            or utils.nnmodule_has_hooks(
+                self._orig_mod, check_forward_hooks=True
+            )
+            or (
+                isinstance(self._orig_mod.forward, types.MethodType)
+                and (trace_rules.check(self._orig_mod.forward))
+            )
         ):
             # This may be a torch.nn.* instance in trace_rules.py which
             # won't trigger a frame evaluation workaround to add an extra
-            # frame we can capture
+            # frame we can capture. We also force the wrapper when the root
+            # module has forward hooks so Dynamo captures the hook and forward
+            # in the same frame.
             self.forward = self.dynamo_ctx(external_utils.wrap_inline(self._orig_mod))
         else:
             # Invoke hooks outside of dynamo then pickup the inner frame
@@ -941,9 +949,16 @@ class _TorchDynamoContext:
             filename = inspect.getsourcefile(fn)
         except TypeError:
             filename = None
+
+        wrap_root_module_call_with_hooks = (
+            isinstance(fn, types.MethodType)
+            and getattr(fn, "__name__", "") in {"_call_impl", "_wrapped_call_impl"}
+            and isinstance(getattr(fn, "__self__", None), torch.nn.Module)
+            and utils.nnmodule_has_hooks(fn.__self__, check_forward_hooks=True)
+        )
         if config.debug_force_nested_calls:
             fn = external_utils.wrap_inline(fn)
-        elif config.wrap_top_frame or (
+        elif config.wrap_top_frame or wrap_root_module_call_with_hooks or (
             (filename is None or trace_rules.check(fn) or top_level_in_graph)
             and (
                 getattr(fn, "__name__", "")

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -444,9 +444,7 @@ class OptimizedModule(torch.nn.Module):
             self.forward = self.dynamo_ctx(self._orig_mod.__call__)
         elif (
             config.wrap_top_frame
-            or utils.nnmodule_has_hooks(
-                self._orig_mod, check_forward_hooks=True
-            )
+            or utils.nnmodule_has_hooks(self._orig_mod, check_forward_hooks=True)
             or (
                 isinstance(self._orig_mod.forward, types.MethodType)
                 and (trace_rules.check(self._orig_mod.forward))


### PR DESCRIPTION
Fix #117584

## Root cause
The root `nn.Module` hook path still compiles in two frames by default. `torch.compile(mod)` only wrapped the top module call when `wrap_top_frame=True` or when Dynamo already knew it needed an inline wrapper, so per-module forward hooks on the root module were still traced separately from the module body. `module.compile()` had the same gap because the generic top-frame wrapper path explicitly skips `_call_impl` unless `wrap_top_frame=True`.

## Proposed fix
Wrap the top frame only when the compiled root module actually has per-module forward hooks. Apply that same narrow condition to bound `_call_impl` and `_wrapped_call_impl` methods so `module.compile()` and `torch.compile(mod)` share the same root-hook behavior. Update the regression test to cover the default configuration for both `register_forward_pre_hook` and `register_forward_hook`, across both public module compilation entry points.

## Why this is the right long term fix
This fixes the graph break exactly where it occurs, without changing the default path for hook-free modules. That keeps the behavior change narrowly scoped, avoids the broad fallout from earlier attempts that wrapped every top module frame, and makes the two public module-compilation APIs behave consistently when root-module forward hooks are present.

## Testing
- Ran the issue repro and verified `frame_count == 1` for both `register_forward_pre_hook` and `register_forward_hook`, under both `torch.compile(mod)` and `mod.compile()`.
- Ran `HooksTests.test_root_module_hooks_compile_in_single_frame`
- Ran `HooksTests.test_nnmodule_hook_guards`
- Ran `HooksTests.test_global_module_forward_pre_hook`

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98