### PR TITLE
Fix profiler unit tests

### DIFF
--- a/.ci/docker/common/install_cuda.sh
+++ b/.ci/docker/common/install_cuda.sh
@@ -174,7 +174,7 @@ function install_132 {
   CUSPARSELT_VERSION=0.8.1.1
   echo "Installing CUDA 13.2 and cuDNN ${CUDNN_VERSION} and NVSHMEM and NCCL and cuSparseLt-${CUSPARSELT_VERSION}"
   # install CUDA 13.2 in the same container
-  install_cuda 13.2.0 cuda_13.2.0_595.45.04_linux
+  install_cuda 13.2.1 cuda_13.2.1_595.58.03_linux
 
   # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
   install_cudnn 13 $CUDNN_VERSION

--- a/.ci/pytorch/cpp_doc_push_script.sh
+++ b/.ci/pytorch/cpp_doc_push_script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This is where the local pytorch install in the docker image is located
-pt_checkout="${GITHUB_WORKSPACE:-/var/lib/jenkins/workspace}"
+pt_checkout="/var/lib/jenkins/workspace"
 
 # Since we're cat-ing this file, we need to escape all $'s
 echo "cpp_doc_push_script.sh: Invoked with $*"

--- a/.ci/pytorch/python_doc_push_script.sh
+++ b/.ci/pytorch/python_doc_push_script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This is where the local pytorch install in the docker image is located
-pt_checkout="${GITHUB_WORKSPACE:-/var/lib/jenkins/workspace}"
+pt_checkout="/var/lib/jenkins/workspace"
 
 source "$pt_checkout/.ci/pytorch/common_utils.sh"
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1802,9 +1802,7 @@ EOF
     fi
 
     # Ensure invalid item is in the test output.
-    # Use a here-string instead of a pipe to avoid SIGPIPE when grep -q
-    # exits early on large output (causes exit code 141 with pipefail).
-    grep -q "${invalid_item_name}" <<< "${test_output}" && ret=$? || ret=$?
+    echo "${test_output}" | grep -q "${invalid_item_name}" && ret=$? || ret=$?
 
     if [ $ret -ne 0 ]; then
         cat << EOF

--- a/.ci/pytorch/windows/internal/cuda_install.bat
+++ b/.ci/pytorch/windows/internal/cuda_install.bat
@@ -59,7 +59,7 @@ set CUDNN_FOLDER=cudnn-windows-x86_64-9.20.0.48_cuda13-archive
 goto cuda_download
 
 :cuda132
-set CUDA_INSTALL_EXE=cuda_13.2.0_windows.exe
+set CUDA_INSTALL_EXE=cuda_13.2.1_windows.exe
 set "ARGS="
 set CUDNN_FOLDER=cudnn-windows-x86_64-9.20.0.48_cuda13-archive
 goto cuda_download

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -28,7 +28,7 @@ CUDA_STABLE = "13.0"
 CUDA_ARCHES_FULL_VERSION = {
     "12.6": "12.6.3",
     "13.0": "13.0.2",
-    "13.2": "13.2.0",
+    "13.2": "13.2.1",
 }
 CUDA_ARCHES_CUDNN_VERSION = {
     "12.6": "9",
@@ -73,7 +73,7 @@ PYTORCH_EXTRA_INSTALL_REQUIREMENTS = {
         "nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
     ),
     "13.2": (
-        "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | "  # noqa: B950
+        "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | "  # noqa: B950
         "cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | "
         "nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | "
         "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -47,26 +47,6 @@ on:
         description: prefix for runner label
         type: string
         default: ""
-      use-arc:
-        required: false
-        type: boolean
-        default: false
-        description: If true, use ARC (OSDC) runner path instead of EC2.
-      python-version:
-        required: false
-        type: string
-        default: ""
-        description: Python version to use for the OSDC build.
-      compiler:
-        required: false
-        type: string
-        default: ""
-        description: Compiler to use for the OSDC build.
-      cuda-version:
-        required: false
-        type: string
-        default: ""
-        description: CUDA version to use for the OSDC build.
     secrets:
       GH_PYTORCHBOT_TOKEN:
         required: false
@@ -75,7 +55,7 @@ on:
 jobs:
   build-docs:
     # Don't run on forked repos.
-    if: github.repository_owner == 'pytorch' && !inputs.use-arc
+    if: github.repository_owner == 'pytorch'
     runs-on: ${{ matrix.runner }}
     environment: ${{ (github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v')) && 'pytorchbot-env' || '' }}
     strategy:
@@ -265,148 +245,6 @@ jobs:
       - name: Teardown Linux
         uses: pytorch/test-infra/.github/actions/teardown-linux@main
         if: always()
-
-  build-docs-osdc:
-    if: github.repository_owner == 'pytorch' && inputs.use-arc
-    permissions:
-      id-token: write
-      contents: read
-      actions: read
-    runs-on: ${{ matrix.runner }}
-    container:
-      image: ${{ inputs.docker-image }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - docs_type: cpp
-            runner: ${{ inputs.runner_prefix }}l-x86iavx512-48-384
-            timeout-minutes: 360
-          - docs_type: python
-            runner: ${{ inputs.runner_prefix }}l-x86iavx512-16-128
-            timeout-minutes: 30
-    name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}
-    steps:
-      - name: Setup Linux
-        id: setup-linux
-        uses: pytorch/pytorch/.github/actions/setup-linux@main
-        with:
-          use-arc: true
-          python-version: ${{ inputs.python-version }}
-          compiler: ${{ inputs.compiler }}
-          cuda-version: ${{ inputs.cuda-version }}
-          submodules: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Configure AWS credentials
-        id: aws-creds
-        continue-on-error: true
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
-        with:
-          role-to-assume: arn:aws:iam::308535385114:role/arc
-          aws-region: us-east-1
-          role-duration-seconds: 18000
-
-      - name: Download build artifacts
-        uses: pytorch/pytorch/.github/actions/download-build-artifacts@main
-        with:
-          name: ${{ inputs.build-environment }}
-          s3-bucket: ${{ inputs.s3-bucket }}
-          use-gha: ${{ steps.aws-creds.outcome != 'success' }}
-
-      - name: Generate netrc (only for docs-push)
-        if: inputs.push
-        env:
-          GITHUB_PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-        run: |
-          rm -rf "${HOME}/.netrc"
-          echo "machine github.com" > "${HOME}/.netrc"
-          echo "login pytorchbot" >> "${HOME}/.netrc"
-          echo "password ${GITHUB_PYTORCHBOT_TOKEN}" >> "${HOME}/.netrc"
-
-      - name: Build ${{ matrix.docs_type }} docs
-        timeout-minutes: ${{ matrix.timeout-minutes }}
-        id: build-docs
-        env:
-          WITH_PUSH: ${{ inputs.push }}
-          DOCS_TYPE: ${{ matrix.docs_type }}
-          RUN_DOXYGEN: ${{ inputs.run-doxygen }}
-          BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
-          SHA1: ${{ github.sha }}
-        shell: bash
-        run: |
-          set -ex
-          if [[ "${GITHUB_REF}" =~ ^refs/tags/v([0-9]+\.[0-9]+)\.* ]]; then
-            target="${BASH_REMATCH[1]}"
-          else
-            target="main"
-          fi
-          export DOCS_VERSION="${target}"
-          pip install $(echo dist/*.whl)[opt-einsum]
-          ./.ci/pytorch/${DOCS_TYPE}_doc_push_script.sh
-
-      - name: Upload Python Docs Preview
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
-        if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'python' && steps.build-docs.outcome == 'success' }}
-        with:
-          retention-days: 14
-          s3-bucket: doc-previews
-          if-no-files-found: error
-          path: pytorch_docs/main/
-          s3-prefix: pytorch/pytorch/${{ github.event.pull_request.number }}
-
-      - name: Upload C++ Docs Preview
-        uses: seemethere/upload-artifact-s3@baba72d0712b404f646cebe0730933554ebce96a # v5.1.0
-        if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
-        with:
-          retention-days: 14
-          if-no-files-found: error
-          s3-bucket: doc-previews
-          path: cppdocs/
-          s3-prefix: pytorch/pytorch/${{ github.event.pull_request.number }}/cppdocs
-
-      - name: Post C++ Docs Coverage Comment
-        if: ${{ steps.aws-creds.outcome == 'success' && github.event_name == 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUM="${{ github.event.pull_request.number }}"
-          MARKER="<!-- cpp-docs-coverage -->"
-
-          # Only post if the PR touches docs/cpp
-          if ! gh pr diff "$PR_NUM" --name-only | grep -q '^docs/cpp/'; then
-            echo "No changes to docs/cpp/, skipping coverage comment."
-            exit 0
-          fi
-
-          # Skip if we already posted
-          if gh pr view "$PR_NUM" --json comments --jq '.comments[].body' | grep -q "$MARKER"; then
-            echo "Coverage comment already posted, skipping."
-            exit 0
-          fi
-
-          body="${MARKER}
-          ## C++ Docs
-
-          - [Doc Preview](https://docs-preview.pytorch.org/pytorch/pytorch/${PR_NUM}/cppdocs/index.html)
-          - [API Coverage Report](https://docs-preview.pytorch.org/pytorch/pytorch/${PR_NUM}/cppdocs/_coverage/cpp_coverage.txt)
-          - [HTML Issues Report](https://docs-preview.pytorch.org/pytorch/pytorch/${PR_NUM}/cppdocs/_coverage/cpp_html_issues.txt)"
-
-          if [ -f cppdocs/_coverage/index.html ]; then
-            body="${body}
-          - [Coverxygen Report (interactive)](https://docs-preview.pytorch.org/pytorch/pytorch/${PR_NUM}/cppdocs/_coverage/index.html)"
-          fi
-
-          gh pr comment "$PR_NUM" --body "$body"
-
-      - name: Upload C++ Docs Preview (nightly dry-run)
-        if: ${{ steps.aws-creds.outcome == 'success' && !inputs.push && github.event_name != 'pull_request' && matrix.docs_type == 'cpp' && steps.build-docs.outcome == 'success' }}
-        run: |
-          # Unlike EC2 runners, the OSDC container doesn't have aws CLI pre-installed
-          pip install awscli==1.29.40
-          aws s3 cp cppdocs/ s3://doc-previews/pytorch/pytorch/nightly-${{ github.sha }}/cppdocs --recursive --quiet
-          echo "C++ docs preview available at:"
-          echo "https://docs-preview.pytorch.org/pytorch/pytorch/nightly-${{ github.sha }}/cppdocs/index.html"
 
   memory-viz-tests:
     # Tests for torch memory visualizer

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -284,7 +284,7 @@ jobs:
       ALPINE_IMAGE: "arm64v8/alpine"
       build_name: manywheel-py3_10-cuda-aarch64-13_2
       build_environment: linux-aarch64-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
       timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -575,7 +575,7 @@ jobs:
       ALPINE_IMAGE: "arm64v8/alpine"
       build_name: manywheel-py3_11-cuda-aarch64-13_2
       build_environment: linux-aarch64-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
       timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -866,7 +866,7 @@ jobs:
       ALPINE_IMAGE: "arm64v8/alpine"
       build_name: manywheel-py3_12-cuda-aarch64-13_2
       build_environment: linux-aarch64-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
       timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -1157,7 +1157,7 @@ jobs:
       ALPINE_IMAGE: "arm64v8/alpine"
       build_name: manywheel-py3_13-cuda-aarch64-13_2
       build_environment: linux-aarch64-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
       timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -1448,7 +1448,7 @@ jobs:
       ALPINE_IMAGE: "arm64v8/alpine"
       build_name: manywheel-py3_13t-cuda-aarch64-13_2
       build_environment: linux-aarch64-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
       timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -1739,7 +1739,7 @@ jobs:
       ALPINE_IMAGE: "arm64v8/alpine"
       build_name: manywheel-py3_14-cuda-aarch64-13_2
       build_environment: linux-aarch64-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
       timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -2030,7 +2030,7 @@ jobs:
       ALPINE_IMAGE: "arm64v8/alpine"
       build_name: manywheel-py3_14t-cuda-aarch64-13_2
       build_environment: linux-aarch64-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
       timeout-minutes: 420
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -272,7 +272,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build_name: manywheel-py3_10-cuda13_2
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -884,7 +884,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build_name: manywheel-py3_11-cuda13_2
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -1496,7 +1496,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build_name: manywheel-py3_12-cuda13_2
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -2108,7 +2108,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build_name: manywheel-py3_13-cuda13_2
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -2720,7 +2720,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build_name: manywheel-py3_13t-cuda13_2
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -3332,7 +3332,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build_name: manywheel-py3_14-cuda13_2
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -3944,7 +3944,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build_name: manywheel-py3_14t-cuda13_2
       build_environment: linux-binary-manywheel
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.0; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
+      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' | nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -218,11 +218,11 @@ jobs:
     secrets: inherit
 
   # ╠══════════════════════════════════════════════════════════════════════╣
-  # ║ linux-docs                                                           ║
+  # ║ linux-docs (TODO (huydhn): EC2-only)                                 ║
   # ╠══════════════════════════════════════════════════════════════════════╣
 
   linux-docs:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-docs ') }}
+    if: ${{ (needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-docs ')) && needs.get-label-type.outputs.use-arc != 'true' }}
     name: linux-docs
     uses: ./.github/workflows/_docs.yml
     needs:
@@ -233,10 +233,6 @@ jobs:
       build-environment: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-gcc11-build.outputs.docker-image }}
       run-doxygen: true
-      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      python-version: "3.10"
-      compiler: gcc11
     secrets: inherit
 
   # ╠══════════════════════════════════════════════════════════════════════╣

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -62,9 +62,6 @@ std::string DeviceTypeName(DeviceType d, bool lower_case) {
           ". If you have recently updated the caffe2.proto file to add a new "
           "device type, did you forget to update the DeviceTypeName() "
           "function to reflect such recent changes?");
-      // The below code won't run but is needed to suppress some compiler
-      // warnings.
-      return "";
   }
 }
 

--- a/c10/cuda/CUDAMallocAsyncAllocator.cpp
+++ b/c10/cuda/CUDAMallocAsyncAllocator.cpp
@@ -797,8 +797,6 @@ struct CudaMallocAsyncAllocator : public CUDAAllocator {
         "(For backend:native, snapshot returns a detailed summary of all "
         "blocks tracked by the allocator, but the cudaMallocAsync backend "
         "does not track individual blocks.)");
-    // Alternative: TORCH_WARN
-    return {};
   }
 
   // CUDAGraph interactions

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -47,7 +47,7 @@ IF(NOT MKLDNN_FOUND)
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
-      GIT_TAG v3.10.2
+      GIT_TAG v3.11.2
       PREFIX ${XPU_MKLDNN_DIR_PREFIX}
       BUILD_IN_SOURCE 0
       CMAKE_ARGS  -DCMAKE_C_COMPILER=icx

--- a/docs/source/community/persons_of_interest.rst
+++ b/docs/source/community/persons_of_interest.rst
@@ -350,6 +350,8 @@ ExecuTorch (Edge, Mobile)
 -  (emeritus) Kimish Patel (`kimishpatel <https://github.com/kimishpatel>`__)
 -  (emeritus) Dave Bort (`dbort <https://github.com/dbort>`__)
 -  (emeritus) Martin Yuan (`iseeyuan <https://github.com/iseeyuan>`__)
+-  (emeritus) Mengwei Liu (`larryliu0820 <https://github.com/larryliu0820>`__)
+-  (emeritus) Chen Lai (`cccclai <https://github.com/cccclai>`__)
 
 TorchCodec
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -1772,9 +1772,7 @@
     "Optional",
     "Union"
   ],
-  "torch.fx.experimental.migrate_gradual_types.constraint": [
-    "TensorType"
-  ],
+  "torch.fx.experimental.migrate_gradual_types.constraint": [],
   "torch.fx.experimental.migrate_gradual_types.constraint_generator": [
     "ApplyBroadcasting",
     "BatchNorm2d",
@@ -1830,6 +1828,7 @@
     "IndexSelect",
     "List",
     "Prod",
+    "Sequence",
     "T",
     "TGreatestUpperBound",
     "TVar",
@@ -1844,6 +1843,7 @@
     "BinConstraintD",
     "BinConstraintT",
     "Conj",
+    "Constraint",
     "ConstraintGenerator",
     "D",
     "DVar",

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2827,6 +2827,17 @@ instantiate_device_type_tests(
 class ActivationCheckpointingNonStrictTracerTests(torch._dynamo.test_case.TestCase):
     """Tests for non-strict tracing flag interaction with checkpoint."""
 
+    @staticmethod
+    def _count_backward_regions(gm):
+        regions = 0
+        in_backward = False
+        for node in gm.graph.nodes:
+            is_backward = bool(node.meta.get("autograd_backward", False))
+            if is_backward and not in_backward:
+                regions += 1
+            in_backward = is_backward
+        return regions
+
     def test_backward_nodes_have_seq_nr_under_non_strict(self):
         class Model(nn.Module):
             def __init__(self):
@@ -2843,14 +2854,14 @@ class ActivationCheckpointingNonStrictTracerTests(torch._dynamo.test_case.TestCa
             node.meta["seq_nr"]
             for node in gm.graph.nodes
             if node.op == "call_function"
-            and not node.meta.get("custom", {}).get("autograd_backward", False)
+            and not node.meta.get("autograd_backward", False)
             and "seq_nr" in node.meta
         }
         backward_seq_nrs = {
             node.meta["seq_nr"]
             for node in gm.graph.nodes
             if node.op == "call_function"
-            and node.meta.get("custom", {}).get("autograd_backward", False)
+            and node.meta.get("autograd_backward", False)
             and "seq_nr" in node.meta
         }
 
@@ -2869,6 +2880,60 @@ class ActivationCheckpointingNonStrictTracerTests(torch._dynamo.test_case.TestCa
                 "_non_strict_tracing_context\\(\\)",
             ):
                 torch.autograd.grad(loss, (x,))
+
+    def test_patch_autograd_grad_does_not_leak_backward_tag(self):
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch.fx.traceback import preserve_node_meta
+
+        x = torch.randn(2, 4, requires_grad=True)
+
+        def fn(x):
+            with torch.fx.traceback.annotate({"ac_region_id": 0}):
+                y = torch.sin(x)
+                torch.autograd.grad(y.sum(), (x,))
+                return torch.neg(y)
+
+        with (
+            torch.compiler._non_strict_tracing_context(),
+            torch.compiler._patch_autograd_grad(),
+            preserve_node_meta(),
+        ):
+            gm = make_fx(fn)(x)
+
+        backward_nodes = [
+            node for node in gm.graph.nodes if node.meta.get("autograd_backward", False)
+        ]
+        self.assertTrue(backward_nodes)
+
+        neg_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.neg.default
+        )
+        self.assertEqual(len(neg_nodes), 1)
+        self.assertNotIn("autograd_backward", neg_nodes[0].meta)
+        self.assertEqual(neg_nodes[0].meta.get("custom", {}), {"ac_region_id": 0})
+
+    def test_patch_autograd_grad_mlp_has_single_contiguous_backward_region(self):
+        class Block(nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.fc1 = nn.Linear(dim, dim * 2)
+                self.fc2 = nn.Linear(dim * 2, dim)
+
+            def forward(self, x):
+                return x + self.fc2(torch.relu(self.fc1(x)))
+
+        class Model(nn.Module):
+            def __init__(self, dim=32, depth=6):
+                super().__init__()
+                self.blocks = nn.ModuleList([Block(dim) for _ in range(depth)])
+
+            def forward(self, x):
+                for block in self.blocks:
+                    x = block(x)
+                return x
+
+        gm = self._trace_train_step(Model(), torch.randn(4, 16, 32))
+        self.assertEqual(self._count_backward_regions(gm), 1)
 
     def _trace_train_step(self, mod, x):
         import torch.utils._pytree as pytree

--- a/test/dynamo/test_fwd_loss_bwd.py
+++ b/test/dynamo/test_fwd_loss_bwd.py
@@ -89,7 +89,6 @@ class GraphModule(torch.nn.Module):
         loss: "f32[]" = res.sum();  res = None
 
         grad = torch.autograd.grad(loss, (l_mod_parameters_weight_, l_mod_parameters_bias_));  l_mod_parameters_weight_ = l_mod_parameters_bias_ = None
-
         getitem: "f32[4, 4]" = grad[0]
         getitem_1: "f32[4]" = grad[1];  grad = None
 
@@ -228,7 +227,6 @@ class GraphModule(torch.nn.Module):
         loss: "f32[]" = res.sum();  res = None
 
         grad = torch.autograd.grad(loss, l_mod_parameters_weight_);  l_mod_parameters_weight_ = None
-
         getitem: "f32[4, 4]" = grad[0];  grad = None
 
         detach: "f32[]" = loss.detach();  loss = None
@@ -447,7 +445,6 @@ class GraphModule(torch.nn.Module):
         loss: "f32[]" = res.sum();  res = None
 
         grad = torch.autograd.grad(loss, (l_mod_parameters_weight_, l_mod_parameters_bias_), materialize_grads = False, allow_unused = True);  loss = l_mod_parameters_weight_ = l_mod_parameters_bias_ = None
-
         weight_grad: "f32[4, 4]" = grad[0]
         bias_grad: "f32[4]" = grad[1];  grad = None
 
@@ -883,7 +880,6 @@ class GraphModule(torch.nn.Module):
         loss: "f32[]" = res.sum();  res = None
 
         grad = torch.autograd.grad(loss, [l_mod_parameters_weight_, l_mod_parameters_bias_], allow_unused = False)
-
         getitem: "f32[4, 4]" = grad[0]
         getitem_1: "f32[4]" = grad[1];  grad = None
 
@@ -927,7 +923,6 @@ class GraphModule(torch.nn.Module):
         loss: "f32[]" = res.sum();  res = None
 
         grad = torch.autograd.grad(loss, [l_mod_parameters_weight_, l_mod_parameters_bias_], allow_unused = True)
-
         getitem: "f32[4, 4]" = grad[0]
         getitem_1: "f32[4]" = grad[1];  grad = None
 
@@ -973,7 +968,6 @@ class GraphModule(torch.nn.Module):
         gradient: "f32[2, 4]" = torch.ones_like(res)
 
         grad = torch.autograd.grad(res, [l_mod_parameters_weight_, l_mod_parameters_bias_], gradient, allow_unused = False);  gradient = None
-
         getitem: "f32[4, 4]" = grad[0]
         getitem_1: "f32[4]" = grad[1];  grad = None
 
@@ -1021,7 +1015,6 @@ class GraphModule(torch.nn.Module):
         loss: "f32[]" = res.sum();  res = None
 
         grad = torch.autograd.grad(loss, [l_mod_parameters_weight_, l_mod_parameters_bias_], allow_unused = False, retain_graph = True)
-
         getitem: "f32[4, 4]" = grad[0]
         getitem_1: "f32[4]" = grad[1];  grad = None
 
@@ -1035,7 +1028,6 @@ class GraphModule(torch.nn.Module):
         _set_grad_enabled_1 = torch._C._set_grad_enabled(True);  _set_grad_enabled_1 = None
 
         grad_1 = torch.autograd.grad(loss, [l_mod_parameters_weight_, l_mod_parameters_bias_], allow_unused = False)
-
         getitem_2: "f32[4, 4]" = grad_1[0]
         getitem_3: "f32[4]" = grad_1[1];  grad_1 = None
 
@@ -1126,7 +1118,6 @@ class GraphModule(torch.nn.Module):
         loss: "f32[]" = y.sum();  y = None
 
         grad = torch.autograd.grad(loss, [w]);  loss = w = None
-
         grad_1: "f32[4, 4]" = grad[0];  grad = None
         return (grad_1,)
 """,  # noqa: B950

--- a/test/dynamo/test_fx_annotate.py
+++ b/test/dynamo/test_fx_annotate.py
@@ -1,5 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
+import warnings
+
 import torch
 import torch._dynamo.test_case
 import torch.fx.traceback as fx_traceback
@@ -236,6 +238,56 @@ class AnnotateTests(torch._dynamo.test_case.TestCase):
 ('call_function', 'getitem_4', {'compile_inductor': 0})
 ('call_function', 'getitem_5', {'compile_inductor': 0})""",  # noqa: B950
         )
+
+    @requires_cuda_and_triton
+    def test_flex_attention_backward_tag_does_not_leak(self):
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch.fx.traceback import preserve_node_meta
+
+        def causal_mask(batch, head, q_idx, kv_idx):
+            del batch, head
+            return q_idx >= kv_idx
+
+        q = torch.randn(
+            1, 2, 128, 32, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        k = torch.randn(
+            1, 2, 128, 32, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        v = torch.randn(
+            1, 2, 128, 32, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+        block_mask = create_block_mask(causal_mask, 1, 2, 128, 128, device="cuda")
+
+        def fn(q, k, v, block_mask):
+            with fx_traceback.annotate({"ac_region_id": 0}):
+                y = flex_attention(q, k, v, block_mask=block_mask)
+                torch.autograd.grad(y, (q, k, v), torch.ones_like(y))
+                return y.cos()
+
+        warnings.filterwarnings(
+            "ignore",
+            message="flex_attention called without torch.compile",
+        )
+        with (
+            torch._dynamo.config.patch(error_on_nested_fx_trace=False),
+            torch.compiler._non_strict_tracing_context(),
+            torch.compiler._patch_autograd_grad(),
+            preserve_node_meta(),
+        ):
+            gm = make_fx(fn, record_stack_traces=True)(q, k, v, block_mask)
+
+        backward_nodes = [
+            node for node in gm.graph.nodes if node.meta.get("autograd_backward", False)
+        ]
+        self.assertTrue(backward_nodes)
+
+        flex_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.higher_order.flex_attention
+        )
+        self.assertEqual(len(flex_nodes), 1)
+        self.assertNotIn("autograd_backward", flex_nodes[0].meta)
+        self.assertEqual(flex_nodes[0].meta.get("custom", {}), {"ac_region_id": 0})
 
     def test_as_decorator(self):
         class Mod(torch.nn.Module):

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -117,10 +117,62 @@ class TestIndexingSimplification(InductorTestCase):
         self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), expr)
         var_ranges = {i2: 784}
         expr = ModularIndexing(ModularIndexing(i2, 1, 28), 7, 4)
-        expected = FloorDiv(ModularIndexing(i2, 1, 28), 7)
+        # FloorDiv(ModularIndexing(b, d1, m), d2) simplifies to
+        # ModularIndexing(b, d1*d2, m//d2) when d2 | m
+        expected = ModularIndexing(i2, 7, 4)
         self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), expected)
         expr = ModularIndexing(ModularIndexing(i2, 1, 28) + 1, 7, 4)
         self.assertEqual(sizevars.simplify_with_ranges(expr, var_ranges), expr)
+
+    def test_floordiv_modularindexing_simplification(self):
+        sizevars = SizeVarAllocator()
+        i0 = sympy.Symbol("i0", integer=True, nonneg=True)
+
+        # FloorDiv(ModularIndexing(b, d1, m), d2) -> ModularIndexing(b, d1*d2, m//d2)
+        # when d2 divides m
+        self.assertEqual(
+            sizevars.simplify_with_ranges(
+                FloorDiv(ModularIndexing(i0, 1, 8192), 128), {}
+            ),
+            ModularIndexing(i0, 128, 64),
+        )
+        self.assertEqual(
+            sizevars.simplify_with_ranges(FloorDiv(ModularIndexing(i0, 2, 120), 6), {}),
+            ModularIndexing(i0, 12, 20),
+        )
+        # Does NOT simplify when d2 does not divide m
+        expr = FloorDiv(ModularIndexing(i0, 1, 28), 5)
+        self.assertEqual(sizevars.simplify_with_ranges(expr, {}), expr)
+
+        # FloorDiv(base, divisor) -> 0 when 0 <= base < divisor
+        self.assertEqual(
+            sizevars.simplify_with_ranges(FloorDiv(ModularIndexing(i0, 1, 10), 10), {}),
+            sympy.S.Zero,
+        )
+
+    def test_remove_zero_terms_generalized(self):
+        sizevars = SizeVarAllocator()
+        i0 = sympy.Symbol("i0", integer=True, nonneg=True)
+        i1 = sympy.Symbol("i1", integer=True, nonneg=True)
+
+        # FloorDiv(v + 128*i1, 8192): gcd(128*i1, 8192) = 128
+        # Old rule fails (128 != 8192), new rule: v < 128 => drop v
+        self.assertEqual(
+            sizevars.simplify_with_ranges(FloorDiv(i0 + 128 * i1, 8192), {i0: 128}),
+            FloorDiv(128 * i1, 8192),
+        )
+        # v range equals gcd exactly — still safe since v < gcd (strict)
+        # v=127 max, 127 < 128
+        self.assertEqual(
+            sizevars.simplify_with_ranges(FloorDiv(i0 + 6 * i1, 18), {i0: 6}),
+            FloorDiv(6 * i1, 18),
+        )
+        # v range exceeds gcd — cannot simplify
+        expr = FloorDiv(i0 + 128 * i1, 8192)
+        self.assertEqual(
+            sizevars.simplify_with_ranges(expr, {i0: 129}),
+            expr,
+        )
 
     def test_indexing_join(self):
         sizevars = SizeVarAllocator()

--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -924,9 +924,17 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
         config = self.create_basic_config(template_id)
 
         self.setup_lookup_table(operation, tensors, [config])
-        add_preprocessing_fn(
-            partial(verify_choice_names, pattern="triton_", expected_count=1)
-        )
+
+        # TODO (paulzhan): Update LookupTableChoices to return empty
+        #  (not fallback) when key matches
+        if operation == "addmm":
+            add_preprocessing_fn(
+                partial(verify_choice_names, pattern="triton_|addmm", expected_count=2)
+            )
+        else:
+            add_preprocessing_fn(
+                partial(verify_choice_names, pattern="triton_", expected_count=1)
+            )
         self.run_model(operation, tensors)
 
     @unittest.skipIf(not has_triton_tma_device(), "Need TMA support")
@@ -940,13 +948,22 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
         )
 
         self.setup_lookup_table(operation, tensors, [config])
-        add_preprocessing_fn(
-            partial(
-                verify_choice_names,
-                pattern="triton_mm_persistent_tma_",
-                expected_count=1,
+        if operation == "addmm":
+            add_preprocessing_fn(
+                partial(
+                    verify_choice_names,
+                    pattern="triton_mm_persistent_tma_|addmm",
+                    expected_count=2,
+                )
             )
-        )
+        else:
+            add_preprocessing_fn(
+                partial(
+                    verify_choice_names,
+                    pattern="triton_mm_persistent_tma_",
+                    expected_count=1,
+                )
+            )
         self.run_model(
             operation, tensors, {"triton.enable_persistent_tma_matmul": True}
         )
@@ -986,9 +1003,9 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
 
         config = self.create_basic_config(torch._inductor.kernel.mm.aten_bias_addmm.uid)
         self.setup_lookup_table("addmm", tensors, [config])
-        add_preprocessing_fn(
-            partial(verify_choice_names, pattern="bias_addmm", expected_count=1)
-        )
+        # NOTE: This test passes bias_unexpanded (1D) to the model but sets up
+        # lookup key with expanded_bias (2D). The shapes differ so lookup will miss.
+        # We skip choice count verification here - just verify the model runs.
 
         # Run with expanded bias (stride[0] == 0) so the inductor sees
         # bias_addmm-eligible inputs and the lookup key matches.

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -827,6 +827,34 @@ class TestMaxAutotune(TestCase):
         with config.patch({"max_autotune": True}):
             torch.compile(mm, dynamic=dynamic)(a, b)
 
+    @fresh_cache()
+    def test_addmm_1d_bias_no_reinterpret_tensor(self):
+        """
+        Verify that aten addmm with 1D bias does not wrap bias in reinterpret_tensor.
+        This ensures cublasLt uses its optimized bias epilogue (requires dim==1).
+        """
+
+        def addmm(x, a, b):
+            return torch.addmm(x, a, b)
+
+        x = torch.randn(100).to(GPU_TYPE)
+        a = torch.randn(100, 10).to(GPU_TYPE)
+        b = torch.randn(10, 100).to(GPU_TYPE)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "ATEN",
+            }
+        ):
+            Y_compiled, code = run_and_get_code(torch.compile(addmm), x, a, b)
+            Y = addmm(x, a, b)
+            torch.testing.assert_close(Y_compiled, Y, atol=1e-2, rtol=1e-2)
+
+            # Verify addmm is called without reinterpret_tensor on bias
+            FileCheck().check("addmm").run(code[0])
+            self.assertNotIn("addmm(reinterpret_tensor", code[0])
+
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
@@ -2737,58 +2765,6 @@ class TestMaxAutotune(TestCase):
                 _ = compiled_fn(bias, x, w)
         finally:
             clear_preprocessing_fns(clear_defaults=False)
-
-    @unittest.skipIf(not torch.version.hip, "ROCM only")
-    @config.patch(
-        {
-            "max_autotune": True,
-            "max_autotune_gemm_backends": "ATEN",
-            "triton.autotune_cublasLt": True,
-            "triton.native_matmul": False,
-        }
-    )
-    def test_rocm_addmm_aten_bias_input_is_1d(self):
-        """
-        ROCm regression test for addmm autotune input wiring.
-        A 1D bias is required for hipBLASLt bias-fused addmm kernels; expanded 2D
-        bias disables that fused path. Exercise the real bias_addmm heuristic
-        so regressions in the runtime path are caught as part of this test.
-        """
-        bias_input_ranks: dict[str, set[int]] = {"addmm": set(), "bias_addmm": set()}
-
-        def capture_bias_input_rank(choices):
-            for choice in choices:
-                if isinstance(choice, ExternKernelCaller) and choice.name in (
-                    "addmm",
-                    "bias_addmm",
-                ):
-                    bias_node = choice.input_nodes[0]
-                    bias_input_ranks[choice.name].add(len(bias_node.get_size()))
-            return choices
-
-        add_preprocessing_fn(capture_bias_input_rank)
-        try:
-            bias = torch.randn(64, device=GPU_TYPE)
-            mat1 = torch.randn(32, 128, device=GPU_TYPE)
-            mat2 = torch.randn(128, 64, device=GPU_TYPE)
-
-            compiled_fn = torch.compile(
-                lambda b, x, w: torch.addmm(b, x, w),
-                dynamic=False,
-            )
-            _ = compiled_fn(bias, mat1, mat2)
-
-            self.assertTrue(
-                bias_input_ranks["addmm"], "Expected ATen addmm choice to be generated"
-            )
-            self.assertTrue(
-                bias_input_ranks["bias_addmm"],
-                "Expected ATen bias_addmm choice to be generated",
-            )
-            self.assertEqual(bias_input_ranks["addmm"], {1})
-            self.assertEqual(bias_input_ranks["bias_addmm"], {1})
-        finally:
-            clear_preprocessing_fns()
 
     @config.patch(
         {"test_configs.max_mm_configs": 4, "max_autotune_gemm_backends": "TRITON"}

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1058,6 +1058,11 @@ def xfail_if_triton_cpu(fn):
     return fn
 
 
+def xfail_if_pallas(fn):
+    fn._expected_failure_pallas = True
+    return fn
+
+
 def skip_if_gpu_halide(fn):
     @functools.wraps(fn)
     def wrapper(self, *args, **kwargs):
@@ -2604,6 +2609,8 @@ class CommonTemplate:
     @xfail_if_triton_cpu
     @skipCUDAIf(True, "No _dyn_quant_pack_4bit_weight implementation on CUDA")
     @skipIfXpu(msg="No _dyn_quant_pack_4bit_weight implementation on XPU")
+    # Pallas codegen doesn't handle reduction axis after FloorDiv(ModularIndexing) simplification
+    @xfail_if_pallas
     def test__dyn_quant_pack_4bit_weight_fp32(self):
         q_group = 32
         k = 128
@@ -2640,6 +2647,8 @@ class CommonTemplate:
     @skipCUDAIf(True, "No _dyn_quant_pack_4bit_weight implementation on CUDA")
     @skipIfXpu(msg="No _dyn_quant_pack_4bit_weight implementation on XPU")
     @skip_if_halide  # bf16
+    # Pallas codegen doesn't handle reduction axis after FloorDiv(ModularIndexing) simplification
+    @xfail_if_pallas
     def test__dyn_quant_pack_4bit_weight_bf16(self):
         k = 128
         n = 128
@@ -2678,6 +2687,8 @@ class CommonTemplate:
 
     @xfail_if_mps_unimplemented
     @xfail_if_triton_cpu
+    # Pallas codegen doesn't handle reduction axis after FloorDiv(ModularIndexing) simplification
+    @xfail_if_pallas
     @skipCUDAIf(True, "No _dyn_quant_matmul_4bit implementation on CUDA")
     @skipIfXpu(msg="No _dyn_quant_matmul_4bit implementation on XPU")
     def test__dyn_quant_matmul_4bit_fp32_input(self):

--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 from typing import Any
+from unittest.mock import patch
 
 import numpy as np
 
@@ -222,11 +223,8 @@ class TestExecutionTrace(TestCase):
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     @skipIfHpu
     @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
+    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "1", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1"})
     def test_execution_trace_env_enabled_with_kineto(self, device):
-        import os
-
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE"] = "1"
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS"] = "1"
         trace_called_num = 0
 
         def trace_handler(p):
@@ -364,11 +362,8 @@ class TestExecutionTrace(TestCase):
                 f"Expected {expected_loop_events} loop events, got {loop_count}"
             )
 
+    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "0", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "0"})
     def test_execution_trace_env_disabled(self, device):
-        import os
-
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE"] = "0"
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS"] = "0"
         use_device = (
             torch.profiler.ProfilerActivity.CUDA
             or torch.profiler.ProfilerActivity.HPU in supported_activities()
@@ -466,16 +461,12 @@ class TestExecutionTrace(TestCase):
         "need triton and device(CUDA or XPU) availability to run",
     )
     @skipCPUIf(True, "skip CPU device for testing profiling triton")
+    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "1", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1"})
     def test_execution_trace_env_enabled_with_pt2(self, device):
         # clean up the local cache for triton kernel
         from torch._inductor.codecache import PyCodeCache
 
         PyCodeCache.cache_clear(purge=True)
-
-        import os
-
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE"] = "1"
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS"] = "1"
 
         @torchdynamo.optimize("inductor")
         def fn(a, b, c):
@@ -766,8 +757,8 @@ class TestExecutionTrace(TestCase):
         not TEST_CUDA,
         "need CUDA device availability to run",
     )
+    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_RANGE": "1"})
     def test_execution_trace_record_integral_tensor_range(self):
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_RANGE"] = "1"
         t1 = torch.tensor([[1, 2], [3, 4]]).cuda()
         t2 = torch.tensor([[0, 0], [1, 0]]).cuda()
         with (
@@ -805,13 +796,10 @@ class TestExecutionTrace(TestCase):
         not TEST_CUDA,
         "need CUDA device availability to run",
     )
+    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_DATA": "aten::gather"})
     def test_execution_trace_record_integral_tensor_data(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             fp_name = os.path.join(temp_dir, "test.et.json")
-
-            os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_DATA"] = (
-                "aten::gather"
-            )
             et = ExecutionTraceObserver()
             et.register_callback(fp_name)
             et.set_extra_resource_collection(True)

--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -223,7 +223,13 @@ class TestExecutionTrace(TestCase):
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     @skipIfHpu
     @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
-    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "1", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1"})
+    @patch.dict(
+        os.environ,
+        {
+            "ENABLE_PYTORCH_EXECUTION_TRACE": "1",
+            "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1",
+        },
+    )
     def test_execution_trace_env_enabled_with_kineto(self, device):
         trace_called_num = 0
 
@@ -362,7 +368,13 @@ class TestExecutionTrace(TestCase):
                 f"Expected {expected_loop_events} loop events, got {loop_count}"
             )
 
-    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "0", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "0"})
+    @patch.dict(
+        os.environ,
+        {
+            "ENABLE_PYTORCH_EXECUTION_TRACE": "0",
+            "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "0",
+        },
+    )
     def test_execution_trace_env_disabled(self, device):
         use_device = (
             torch.profiler.ProfilerActivity.CUDA
@@ -461,7 +473,13 @@ class TestExecutionTrace(TestCase):
         "need triton and device(CUDA or XPU) availability to run",
     )
     @skipCPUIf(True, "skip CPU device for testing profiling triton")
-    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "1", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1"})
+    @patch.dict(
+        os.environ,
+        {
+            "ENABLE_PYTORCH_EXECUTION_TRACE": "1",
+            "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1",
+        },
+    )
     def test_execution_trace_env_enabled_with_pt2(self, device):
         # clean up the local cache for triton kernel
         from torch._inductor.codecache import PyCodeCache
@@ -757,7 +775,9 @@ class TestExecutionTrace(TestCase):
         not TEST_CUDA,
         "need CUDA device availability to run",
     )
-    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_RANGE": "1"})
+    @patch.dict(
+        os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_RANGE": "1"}
+    )
     def test_execution_trace_record_integral_tensor_range(self):
         t1 = torch.tensor([[1, 2], [3, 4]]).cuda()
         t2 = torch.tensor([[0, 0], [1, 0]]).cuda()
@@ -796,7 +816,10 @@ class TestExecutionTrace(TestCase):
         not TEST_CUDA,
         "need CUDA device availability to run",
     )
-    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_DATA": "aten::gather"})
+    @patch.dict(
+        os.environ,
+        {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_DATA": "aten::gather"},
+    )
     def test_execution_trace_record_integral_tensor_data(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             fp_name = os.path.join(temp_dir, "test.et.json")

--- a/third_party/mkl-dnn.BUILD
+++ b/third_party/mkl-dnn.BUILD
@@ -18,6 +18,7 @@ _DNNL_RUNTIME_OMP = {
     "#cmakedefine ONEDNN_BUILD_GRAPH": "#undef ONEDNN_BUILD_GRAPH",
     "#cmakedefine DNNL_EXPERIMENTAL_PROFILING": "#undef DNNL_EXPERIMENTAL_PROFILING",
     "#cmakedefine DNNL_EXPERIMENTAL_LOGGING": "#undef DNNL_EXPERIMENTAL_LOGGING",
+    "#cmakedefine DNNL_SAFE_RBP": "#undef DNNL_SAFE_RBP",
     "#cmakedefine DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER": "#undef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER",
     "#cmakedefine DNNL_DISABLE_GPU_REF_KERNELS": "#undef DNNL_DISABLE_GPU_REF_KERNELS",
     "#cmakedefine01 BUILD_TRAINING": "#define BUILD_TRAINING 1",
@@ -69,7 +70,7 @@ template_rule(
     out = "include/oneapi/dnnl/dnnl_version.h",
     substitutions = {
         "@DNNL_VERSION_MAJOR@": "3",
-        "@DNNL_VERSION_MINOR@": "10",
+        "@DNNL_VERSION_MINOR@": "11",
         "@DNNL_VERSION_PATCH@": "2",
     },
 )
@@ -85,7 +86,7 @@ template_rule(
     name = "include_dnnl_version_hash",
     src = "include/oneapi/dnnl/dnnl_version_hash.h.in",
     out = "include/oneapi/dnnl/dnnl_version_hash.h",
-    substitutions = {"@DNNL_VERSION_HASH@": "f1d471933dc852f956fd05389f9313c7148783d5",}
+    substitutions = {"@DNNL_VERSION_HASH@": "03c022d3ffdcee958cfacbe720048e725fdf644c",}
 )
 
 cc_library(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -2440,7 +2440,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
 
             with (
                 torch.fx.traceback.preserve_node_meta(),
-                torch.fx.traceback.annotate({"autograd_backward": True}),
+                torch.fx.traceback._set_autograd_backward(),
             ):
                 proxy = tx.output.create_proxy(
                     "call_function",

--- a/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
+++ b/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
@@ -40,13 +40,13 @@ def _is_backward_node(node: fx.Node, use_phase: bool = False) -> bool:
     """Check if node is in backward region.
 
     If use_phase is True, only checks custom["phase"] == "backward"
-    (user annotation). Otherwise falls back to custom["autograd_backward"],
+    (user annotation). Otherwise falls back to node.meta["autograd_backward"],
     which Dynamo adds when tracing torch.autograd.grad.
     """
     custom = node.meta.get("custom", _EMPTY_CUSTOM_META)
     if use_phase:
         return custom.get("phase") == "backward"
-    return custom.get("autograd_backward", False)
+    return node.meta.get("autograd_backward", False)
 
 
 def _has_user_phase_annotation(gm: fx.GraphModule) -> bool:
@@ -84,7 +84,7 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
     Duplicate recompute nodes for backward use. DCE removes unused forward versions.
 
     Backward regions are identified by custom["phase"] == "backward" (user
-    annotation) or custom["autograd_backward"] == True (set automatically when
+    annotation) or node.meta["autograd_backward"] == True (set automatically when
     Dynamo traces torch.autograd.grad). When the user provides phase
     annotations, only those annotated regions are used.
 

--- a/torch/_functorch/_aot_autograd/logging_utils.py
+++ b/torch/_functorch/_aot_autograd/logging_utils.py
@@ -117,6 +117,7 @@ def setup_stacktrace_preservation_hooks(roots: list[torch.autograd.graph.Node]) 
 
             fx_traceback.set_stack_trace(stack_)
             fx_traceback.set_grad_fn_seq_nr(seq_nr)
+            fx_traceback._mark_autograd_backward()
 
         return prehook
 
@@ -126,6 +127,7 @@ def setup_stacktrace_preservation_hooks(roots: list[torch.autograd.graph.Node]) 
         def posthook(grad_input: Any, grad_output: Any) -> None:
             fx_traceback.set_stack_trace(special_stack_)
             fx_traceback.reset_grad_fn_seq_nr()
+            fx_traceback._reset_autograd_backward()
 
         return posthook
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -681,9 +681,7 @@ use_pre_grad_passes: bool = True
 #   requires custom passes to implement uuid() for the cache key.
 # "default": resolves to "late" when possible (no custom pass, or custom pass
 #   with uuid), falls back to "early" otherwise.
-pre_grad_pass_timing: Literal["early", "late", "default"] = (
-    "late" if is_fbcode() else "default"
-)
+pre_grad_pass_timing: Literal["early", "late", "default"] = "default"
 
 
 use_joint_graph_passes: bool = True

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -669,22 +669,18 @@ def tuned_addmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
 
     if use_aten_gemm_kernels():
         aten_templates: list[ExternKernelChoice | KernelTemplate] = [aten_addmm]
-        # For ROCm, check original inp since kernel_inputs_aten uses inp (not inp_expanded)
-        bias_to_check = inp if torch.version.hip else inp_expanded
         if (
-            bias_to_check.get_stride()[0] == 0
+            inp.get_stride()[0] == 0
+            and len(inp.get_size()) == 2
             and inductor_config.triton.autotune_cublasLt
             and not V.graph.cpp_wrapper  # bias_addmm only has a Python implementation
         ):
             aten_templates.append(aten_bias_addmm)
 
         # On ROCm, ATen choices use original bias input; non-ROCm keeps unified inputs.
-        if torch.version.hip:
-            choices.extend(
-                V.choices.get_template_configs(kernel_inputs_aten, aten_templates, name)
-            )
-        else:
-            templates_to_use.extend(aten_templates)
+        choices.extend(
+            V.choices.get_template_configs(kernel_inputs_aten, aten_templates, name)
+        )
 
     if is_nonzero and use_triton_template(layout, check_max_autotune=False):
         templates_to_use.append(mm_template)

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -221,19 +221,29 @@ class SizeVarAllocator:
 
             for v in base.free_symbols:
                 if v in var_ranges:
-                    # var smaller than divisor can be removed
-                    # if the rest is guaranteed to be multiple of divisor
                     rest = sympy.Wild("_rest", exclude=[v])
                     m = base.match(v + rest)
                     if m and v not in m[rest].free_symbols:
+                        # v can be removed if it doesn't affect the FloorDiv.
+                        # rest is always a multiple of gcd(rest, divisor), so
+                        # rest % divisor is also a multiple of that gcd. The
+                        # worst case is rest % divisor == divisor - gcd, so
+                        # adding v is safe when v < gcd.
                         gcd = sympy.gcd(m[rest], divisor)
-                        if gcd == divisor:
-                            if statically_known(v < divisor):
-                                base = m[rest]
+                        if statically_known(v < gcd):
+                            base = m[rest]
             return base
 
         def visit_indexing_div(base, divisor):
-            return FloorDiv(remove_zero_terms(base, divisor), divisor)
+            base = remove_zero_terms(base, divisor)
+            if statically_known(base >= 0) and statically_known(base < divisor):
+                return sympy.S.Zero
+            # FloorDiv(ModularIndexing(b, d1, m), d2) = ModularIndexing(b, d1*d2, m//d2)
+            if isinstance(base, ModularIndexing) and isinstance(divisor, sympy.Integer):
+                b, d1, m = base.args
+                if m % divisor == 0:
+                    return ModularIndexing(b, d1 * divisor, FloorDiv(m, divisor))
+            return FloorDiv(base, divisor)
 
         def visit_modular_indexing(base, divisor, modulus):
             base = remove_zero_terms(base, divisor)

--- a/torch/_inductor/template_heuristics/aten.py
+++ b/torch/_inductor/template_heuristics/aten.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
-import torch
 from torch._inductor import config as inductor_config
 
 from ..kernel.bmm import aten_baddbmm, aten_bmm, aten_bmm_dtype
@@ -87,11 +86,9 @@ class ATenBiasAddMMConfigHeuristics(
         nodes = kernel_inputs.nodes()
         # for addmm, bias is the first input
         bias = nodes[0]
-        # Conditions should be checked in tuned_addmm before adding this template.
-        # On ROCm, tuned_addmm passes the original 1D bias input so hipBLASLt
-        # fused-bias kernels can see the native bias form. In that case the bias
-        # no longer has the expanded stride-0 layout used on the non-ROCm path.
-        is_rocm_1d_bias = torch.version.hip and len(bias.get_size()) == 1
-        valid_bias_input = is_rocm_1d_bias or bias.get_stride()[0] == 0
-        assert valid_bias_input and inductor_config.triton.autotune_cublasLt
+        assert (
+            len(bias.get_size()) == 2
+            and bias.get_stride()[0] == 0
+            and inductor_config.triton.autotune_cublasLt
+        )
         yield from super()._get_template_configs_impl(kernel_inputs, op_name)

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -696,7 +696,7 @@ class FunctionEvent(FormattedTimesMixin):
         is_legacy (bool): Whether this is from the legacy profiler.
         flops (int): Estimated floating point operations.
         is_user_annotation (bool): Whether this is a user-annotated region.
-        metadata_json (str): Additional metadata in JSON format.
+        metadata_json (str): Deprecated. Use event_metadata instead.
         event_metadata (EventMetadata): Additional metadata in structured format.
         structured_input_shapes (List[List[int] | List[List[int]]]): Like ``input_shapes``
             but distinguishes TensorList inputs.  Plain tensor inputs are ``List[int]``;
@@ -809,7 +809,7 @@ class FunctionEvent(FormattedTimesMixin):
         self.self_cpu_percent = -1
         self.total_cpu_percent = -1
         self.total_device_percent = -1
-        self.metadata_json = metadata_json
+        self._metadata_json = metadata_json
         self.flow_id: int | None = flow_id
         self.flow_type: int | None = flow_type
         self.flow_start: bool | None = flow_start
@@ -879,6 +879,14 @@ class FunctionEvent(FormattedTimesMixin):
         return self.device_memory_usage - sum(
             child.device_memory_usage for child in self.cpu_children
         )
+
+    @property
+    @deprecated(
+        "`metadata_json` is deprecated. Use `event_metadata` instead.",
+        category=FutureWarning,
+    )
+    def metadata_json(self):
+        return self._metadata_json
 
     @property
     @deprecated(

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -482,14 +482,13 @@ def _non_strict_tracing_context():
 def _patch_autograd_grad():
     """Patch autograd.grad for non-strict make_fx tracing.
 
-    This patch annotates the traced backward region with
-    custom["autograd_backward"] before delegating to the real
-    torch.autograd.grad.
+    This patch installs autograd hooks so traced backward nodes preserve
+    stack trace, seq_nr, and autograd_backward metadata before delegating to
+    the real torch.autograd.grad.
     """
     import functools
 
     import torch.autograd
-    import torch.fx.traceback as fx_traceback
     from torch._functorch._aot_autograd.logging_utils import (
         setup_stacktrace_preservation_hooks_from_tensors,
     )
@@ -505,9 +504,7 @@ def _patch_autograd_grad():
             )
 
         setup_stacktrace_preservation_hooks_from_tensors(outputs)
-
-        with fx_traceback.annotate({"autograd_backward": True}):
-            return _orig_grad(outputs, inputs, *args, **kwargs)
+        return _orig_grad(outputs, inputs, *args, **kwargs)
 
     torch.autograd.grad = _patched_grad
     try:

--- a/torch/csrc/Storage.cpp
+++ b/torch/csrc/Storage.cpp
@@ -254,7 +254,6 @@ static PyObject* THPStorage_pynew(
           "but one of the items was of type ",
           THPUtils_typename(item.get()),
           " instead of int");
-      return nullptr;
     }
   }
   return self;
@@ -302,7 +301,6 @@ static PyObject* THPStorage_get(THPStorage* self, PyObject* index) {
           step,
           ", but only a step of "
           "1 is supported");
-      return nullptr;
     }
 
     const auto& storage = THPStorage_Unpack(self);
@@ -351,7 +349,6 @@ static int THPStorage_set(THPStorage* self, PyObject* index, PyObject* value) {
         "can only set storage content with a int types, but got ",
         THPUtils_typename(value),
         " instead");
-    return -1;
   }
 
   uint8_t rvalue = THPByteUtils_unpackReal(value);
@@ -374,7 +371,6 @@ static int THPStorage_set(THPStorage* self, PyObject* index, PyObject* value) {
           step,
           ", but only a step of "
           "1 is supported");
-      return 0;
     }
     // TODO: check the bounds only once
     // TODO: fill?
@@ -384,7 +380,6 @@ static int THPStorage_set(THPStorage* self, PyObject* index, PyObject* value) {
   }
   TORCH_CHECK(
       false, "can't index a " THPStorageStr " with ", THPUtils_typename(index));
-  return -1;
   END_HANDLE_TH_ERRORS_RET(-1)
 }
 

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -2317,7 +2317,6 @@ Tensor error_for_max_pool2d_double_backward() { // This is mps-only.
       "max_pool2d with `return_indices=False` is not infinitely differentiable.",
       " If you want to calculate higher order derivatives, e.g. second order,",
       " set `return_indices=True`.");
-  return Tensor();
 }
 
 Tensor glu_double_backward(

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -479,11 +479,10 @@ static Tensor _fw_primal(
   std::function<at::Tensor(const at::Tensor&)> rev_func = nullptr;
   if (!self.unsafeGetTensorImpl()->support_as_strided()) {
     func = std::make_unique<ViewViewFunc>(self.sym_sizes());
-    rev_func = [=](const at::Tensor& input_view) {
+    rev_func = [=](const at::Tensor& input_view) -> at::Tensor {
       TORCH_INTERNAL_ASSERT(
           false,
           "Reverse view_func for _fw_primal() is not currently supported");
-      return Tensor();
     };
   }
   auto result = as_view(
@@ -512,11 +511,10 @@ static Tensor _make_dual(
   std::function<at::Tensor(const at::Tensor&)> rev_func = nullptr;
   if (!primal.unsafeGetTensorImpl()->support_as_strided()) {
     func = std::make_unique<ViewViewFunc>(primal.sym_sizes());
-    rev_func = [=](const at::Tensor& input_view) {
+    rev_func = [=](const at::Tensor& input_view) -> at::Tensor {
       TORCH_INTERNAL_ASSERT(
           false,
           "Reverse view_func for _make_dual() is not currently supported");
-      return Tensor();
     };
   }
   auto result = as_view(

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -657,13 +657,13 @@ static void autogradNotImplementedInplaceOrViewFallbackImpl(
          "which does not have a derivative implemented is forbidden.");
     auto erroring_view_func = std::make_unique<ErroringViewFunc>(error_msg);
 
-    const auto erroring_rev_view_func = [op_name = op_name](const at::Tensor&) {
+    const auto erroring_rev_view_func =
+        [op_name = op_name](const at::Tensor&) -> at::Tensor {
       TORCH_CHECK(
           false,
           "Accessing the reverse view for ",
           op_name,
           " which does not have a derivative implemented is forbidden.");
-      return at::Tensor();
     };
 
     if (aliased_output_iv.isTensorList()) {

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -1135,7 +1135,6 @@ int64_t KinetoEvent::privateuse1ElapsedUs() const {
   }
   return (int64_t)torch::profiler::impl::privateuse1Stubs()->elapsed(
       &privateuse1_event_start, &privateuse1_event_end);
-  return -1;
 }
 
 void KinetoEvent::getPerfEventCounters(std::vector<uint64_t>& in) const {

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -118,9 +118,8 @@ ViewInfo ViewInfo::chain(
             "Attempted to chain views when the parent view has no view_func() and "
             "does not support as_strided(). This is not supported.";
         view_func = std::make_unique<ErroringViewFunc>(error_msg);
-        rev_view_func = [=](const at::Tensor& root_view) {
+        rev_view_func = [=](const at::Tensor& root_view) -> at::Tensor {
           TORCH_CHECK(false, error_msg);
-          return root_view;
         };
       }
     }

--- a/torch/csrc/distributed/c10d/GlooDeviceFactory.cpp
+++ b/torch/csrc/distributed/c10d/GlooDeviceFactory.cpp
@@ -195,22 +195,25 @@ std::shared_ptr<::gloo::transport::Device> makeGlooDevice(
         transportName.value(), interfaceName, hostName, lazyInit);
   }
 
-#ifdef __linux__
+#if defined(__linux__)
+
   return GlooDeviceRegistry()->Create(
       "LINUX", interfaceName, hostName, lazyInit);
-#endif
 
-#ifdef __APPLE__
+#elif defined(__APPLE__)
+
   return GlooDeviceRegistry()->Create(
       "APPLE", interfaceName, hostName, lazyInit);
-#endif
 
-#ifdef _WIN32
+#elif defined(_WIN32)
+
   return GlooDeviceRegistry()->Create(
       "WIN32", interfaceName, hostName, lazyInit);
-#endif
+#else
 
   return nullptr;
+
+#endif
 }
 } // anonymous namespace
 

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -56,7 +56,6 @@ std::string opTypeToString(OpType opType) {
     default:
       TORCH_INTERNAL_ASSERT(false, "Unknown op type!");
   }
-  return "UNKNOWN";
 }
 
 bool isP2POp(OpType opType, bool batchP2P /*= false*/) {

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -133,7 +133,6 @@ ncclRedOpRAII getNcclReduceOp(
           C10_THROW_ERROR(
               TypeError,
               "PreMulSum Data type must be half, float, bfloat16 or double");
-          return ncclRedOp_t{};
       }
 #else
       C10_THROW_ERROR(ValueError, "PreMulSum requires NCCL>=2.11.1");

--- a/torch/csrc/distributed/c10d/Types.cpp
+++ b/torch/csrc/distributed/c10d/Types.cpp
@@ -16,7 +16,6 @@ bool isComplexViewAsRealAllowed(const ReduceOp& reduceOp) {
     default:
       return false;
   }
-  return false;
 }
 
 } // namespace c10d

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -393,28 +393,18 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
           .def(
               py::pickle(
                   /* __getstate__ */
-                  [](const PyRRef& /* unused */) {
+                  [](const PyRRef& /* unused */) -> py::tuple {
                     TORCH_CHECK(
                         false,
                         "Can not pickle rref in python pickler, rref can only be "
                         "pickled when using RPC");
-                    // Note that this return has no meaning since we always
-                    // throw, it's only here to satisfy Pybind API's
-                    // requirement.
-                    return py::make_tuple();
                   },
                   /* __setstate__ */
-                  [](py::tuple /* unused */) { // NOLINT
+                  [](py::tuple /* unused */) -> std::nullptr_t { // NOLINT
                     TORCH_CHECK(
                         false,
                         "Can not unpickle rref in python pickler, rref can only be "
                         "unpickled when using RPC");
-                    // Note that this return has no meaning since we always
-                    // throw, it's only here to satisfy PyBind's API
-                    // requirement.
-                    return PyRRef(
-                        py::cast<py::none>(Py_None),
-                        py::cast<py::none>(Py_None));
                   }),
               py::call_guard<py::gil_scoped_release>())
           .def(

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
@@ -213,8 +213,9 @@ class CoreMLBackend: public torch::jit::PyTorchBackendInterface {
 #elif TARGET_OS_MAC
     NSOperatingSystemVersion supportedVer = {10, 13, 0};
     return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:supportedVer];
-#endif
+#else
     return false;
+#endif
   }
 };
 

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1209,7 +1209,6 @@ bool Node::hasSideEffects() const {
       return true;
   }
   TORCH_INTERNAL_ASSERT(false, "Unhandled AliasAnalysisKind case");
-  return false; // silence compiler warning
 }
 
 // Assign this node a topological position, to facilitate fast isBefore() and

--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -387,7 +387,6 @@ bool InterpreterState::run(Stack& stack) {
     //    }
     //  }
   }
-  return false;
 }
 
 IValue& InterpreterState::reg(size_t reg) {

--- a/torch/csrc/jit/mobile/type_parser.cpp
+++ b/torch/csrc/jit/mobile/type_parser.cpp
@@ -158,7 +158,6 @@ TypePtr TypeParser::parse() {
         " is not supported in the parser, ",
         "or the token is in wrong format.");
   }
-  return nullptr;
 }
 
 // NamedTuple custom type will be following structure:
@@ -243,7 +242,6 @@ TypePtr TypeParser::parseCustomType() {
       TORCH_CHECK(
           false, "Can't find definition for the type: ", qualified_name);
     }
-    return nullptr;
   }
 }
 

--- a/torch/csrc/jit/passes/autocast.cpp
+++ b/torch/csrc/jit/passes/autocast.cpp
@@ -133,8 +133,6 @@ std::optional<AutocastScope> parseAutocast(
     //
     TORCH_CHECK(false, "Unsupported autocast syntax");
   }
-
-  return std::nullopt;
 }
 
 void castTensorInputs(

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -95,7 +95,6 @@ std::optional<at::ScalarType> ONNXTypeToATenType(int32_t onnx_type) {
           onnx_type,
           " is an unexpected tensor scalar type");
   }
-  return std::optional<at::ScalarType>{};
 }
 
 Node* addNodeToBlock(Block* block, Symbol kind, ArrayRef<Value*> inputs) {

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
@@ -215,12 +215,11 @@ static void moveConstantTensorsOutOfSubgraph(
     const std::shared_ptr<Graph>& tensorexpr_graph) {
   auto parent = tensorexpr_graph_node->owningGraph();
 
-  auto env = [&](Value* v) {
+  auto env = [&](Value* v) -> Value* {
     TORCH_INTERNAL_ASSERT(
         false,
         "this should never happen since constant nodes do not have any inputs",
         v->debugName());
-    return v;
   };
 
   WithInsertPoint wip(tensorexpr_graph_node);

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -516,7 +516,6 @@ void unmergeNode(Node* n, Node* subgraphNode) {
         false,
         "all inputs should've been mapped. Couldn't map %",
         v->debugName());
-    return v;
   };
 
   for (auto i : c10::irange(subgraph->outputs().size())) {

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -2183,20 +2183,12 @@ void initJITBindings(PyObject* module) {
       .def(
           py::pickle(
               /* __getstate__ */
-              [](const PythonFutureWrapper& /* unused */) {
+              [](const PythonFutureWrapper& /* unused */) -> py::tuple {
                 TORCH_CHECK(false, "Can not pickle torch.futures.Future");
-                // Note that this return has no meaning since we always
-                // throw, it's only here to satisfy Pybind API's
-                // requirement.
-                return py::make_tuple();
               },
               /* __setstate__ */
-              [](const py::tuple& /* unused */) {
+              [](const py::tuple& /* unused */) -> std::nullptr_t {
                 TORCH_CHECK(false, "Can not unpickle torch.futures.Future");
-                // Note that this return has no meaning since we always
-                // throw, it's only here to satisfy PyBind's API
-                // requirement.
-                return nullptr;
               }),
           py::call_guard<py::gil_scoped_release>());
 
@@ -2220,20 +2212,12 @@ void initJITBindings(PyObject* module) {
       .def(
           py::pickle(
               /* __getstate__ */
-              [](const PythonAwaitWrapper& /* unused */) {
+              [](const PythonAwaitWrapper& /* unused */) -> py::tuple {
                 TORCH_CHECK(false, "Can not pickle torch.jit._Await");
-                // Note that this return has no meaning since we always
-                // throw, it's only here to satisfy Pybind API's
-                // requirement.
-                return py::make_tuple();
               },
               /* __setstate__ */
-              [](const py::tuple& /* unused */) {
+              [](const py::tuple& /* unused */) -> std::nullptr_t {
                 TORCH_CHECK(false, "Can not unpickle torch.jit._Await");
-                // Note that this return has no meaning since we always
-                // throw, it's only here to satisfy PyBind's API
-                // requirement.
-                return nullptr;
               }),
           py::call_guard<py::gil_scoped_release>());
 

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -118,8 +118,9 @@ static FusionStrategy getInitialStrategy() {
 // TODO remove ifdef
 #ifdef FBCODE_CAFFE2
   return {{FusionBehavior::STATIC, 20}};
-#endif
+#else
   return mixed;
+#endif
 }
 
 // defer initial value so that we can load in gflags

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -132,7 +132,6 @@ void checkDoubleInRange(double a) {
       a < double(std::numeric_limits<int64_t>::min())) {
     throw c10::Error(
         "Cannot convert float " + std::to_string(a) + " to integer");
-    return;
   }
 }
 

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -1446,7 +1446,6 @@ void check_onnx_proto(const std::string& proto_string) {
   onnx::ModelProto model;
   if (!ParseProtoFromBytes(&model, proto_string.c_str(), proto_string.size())) {
     throw std::runtime_error("Invalid ONNX proto string.");
-    return;
   }
   // 1. baseline check
   // These two checks prevent broken graph being generated

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -103,7 +103,6 @@ void* CodeGen::argToPtr(const BufferArg& bufferArg, const CallArg& callArg) {
     default:
       throw unsupported_dtype();
   }
-  return nullptr;
 }
 
 void CodeGen::call_with_numel(void** args, int64_t numel) {

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -20,7 +20,6 @@ int64_t InterpValue::intValue() const {
   AT_FORALL_INT_TYPES(TYPE_CASE);
 #undef TYPE_CASE
   throw unsupported_dtype();
-  return 0;
 }
 
 template <typename T>
@@ -662,7 +661,6 @@ class SimpleIREvaluatorImpl : public IRVisitor {
       default:
         throw unsupported_dtype();
     }
-    return {};
   }
 
   void check_bounds_throw(int64_t idx, int64_t bound, const BufPtr& buf) {

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -37,8 +37,8 @@ static inline ExprPtr newBinaryOpOfType(
     case IRNodeType::kRshift:
       return alloc<Rshift>(lhs, rhs);
     default:
-      TORCH_INTERNAL_ASSERT(false, "unsupported expr_type: ", static_cast<int>(expr_type));
-      return nullptr;
+      TORCH_INTERNAL_ASSERT(
+          false, "unsupported expr_type: ", static_cast<int>(expr_type));
   }
 }
 

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -330,8 +330,9 @@ bool mkldnnPrepackedConvIsSupportedJit(const torch::jit::Node* node) {
       _pair_int(*pad),
       _pair_int(*dilation),
       groups->toInt());
-#endif
+#else
   return false;
+#endif
 }
 
 bool isConv2d(const Node* node) {

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -2830,7 +2830,6 @@ LoopNest::AccessResult LoopNest::cacheAccesses(
       if (reduceOp) {
         throw std::runtime_error(
             "can only cache accesses used by at most a single reduceOp");
-        return {nullptr, nullptr};
       }
 
       reduceOp = ro;
@@ -2842,7 +2841,6 @@ LoopNest::AccessResult LoopNest::cacheAccesses(
   auto bounds_it = consumer_bounds_info.find(producer);
   if (bounds_it == consumer_bounds_info.end()) {
     throw std::runtime_error("consumer does not use the Tensor produced");
-    return {nullptr, nullptr};
   }
 
   TORCH_INTERNAL_ASSERT(

--- a/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
@@ -341,8 +341,9 @@ bool mkldnnPrepackedConvIsSupported(
       input.dims[0] * input.dims[1] * input.dims[2] * input.dims[3] > 20480;
   GRAPH_DEBUG("mkldnnPrepackedConvIsSupported: ", use_mkldnn);
   return use_mkldnn;
-#endif
+#else
   return false;
+#endif
 }
 
 Tensor computeConv2d(

--- a/torch/csrc/jit/tensorexpr/operators/misc.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/misc.cpp
@@ -152,8 +152,6 @@ ExprHandle demoteOutput(
     default:
       throw unsupported_dtype();
   }
-
-  return e;
 }
 
 std::optional<TensorInfo> getTensorInfo(const BufHandle& b) {

--- a/torch/csrc/jit/tensorexpr/types.cpp
+++ b/torch/csrc/jit/tensorexpr/types.cpp
@@ -115,7 +115,6 @@ std::string Dtype::ToCppString() const {
     default:
       throw unsupported_dtype();
   }
-  return "invalid";
 }
 
 } // namespace torch::jit::tensorexpr

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -144,8 +144,6 @@ size_t assertFindRegex(
       extra_msg(ss);
     }
     throw std::runtime_error(ss.str());
-
-    return std::string::npos;
   }
   return pos;
 }

--- a/torch/csrc/lazy/python/init.cpp
+++ b/torch/csrc/lazy/python/init.cpp
@@ -272,8 +272,6 @@ void initLazyBindings(PyObject* module) {
 #else
         TORCH_CHECK(
             false, "TorchScript backend not yet supported in FBCODE builds");
-        return std::make_pair(
-            std::vector<int64_t>(), std::vector<at::IValue>());
 #endif // !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
       });
   // TODO(shunting) revisit this part for XLA
@@ -303,13 +301,13 @@ void initLazyBindings(PyObject* module) {
         for (torch::jit::IValue elem : stack) {
           result.push_back(elem.toTensor());
         }
+        return result;
 #else
         TORCH_CHECK(
             false, "TorchScript backend not yet supported in FBCODE builds");
 #endif // !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
-        return result;
       });
-  lazy_ts_backend.def("_get_latest_computation_graph", []() {
+  lazy_ts_backend.def("_get_latest_computation_graph", []() -> std::string {
 #if !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
     auto computation = LazyGraphExecutor::Get()
                            ->GetComputationCache()
@@ -321,7 +319,6 @@ void initLazyBindings(PyObject* module) {
 #else
     TORCH_CHECK(
         false, "TorchScript backend not yet supported in FBCODE builds");
-    return "";
 #endif // !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
   });
 

--- a/torch/fx/experimental/migrate_gradual_types/constraint.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint.py
@@ -1,4 +1,40 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeAlias
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = [
+    "ApplyBroadcasting",
+    "BinConstraintD",
+    "BinConstraintT",
+    "BinaryConstraint",
+    "BVar",
+    "CalcConv",
+    "CalcMaxPool",
+    "CalcProduct",
+    "CanReshape",
+    "Conj",
+    "Constraint",
+    "DGreatestUpperBound",
+    "Disj",
+    "DVar",
+    "F",
+    "GetItem",
+    "GetItemTensor",
+    "IndexSelect",
+    "Prod",
+    "T",
+    "TGreatestUpperBound",
+    "Transpose",
+    "TVar",
+    "is_algebraic_expression",
+    "is_bool_expr",
+    "is_dim",
+]
+
 from torch.fx.experimental.migrate_gradual_types.operation import (
     op_add,
     op_div,
@@ -10,7 +46,7 @@ from torch.fx.experimental.migrate_gradual_types.operation import (
     op_neq,
     op_sub,
 )
-from torch.fx.tensor_type import Dyn, TensorType
+from torch.fx.tensor_type import _DynType, Dyn, TensorType
 
 
 class Constraint:
@@ -18,55 +54,53 @@ class Constraint:
 
 
 class Conj(Constraint):
-    def __init__(self, conjuncts):
+    def __init__(self, conjuncts: Sequence[Constraint]) -> None:
         """
         :param conjuncts: Conjunction of constraints
         """
-        self.conjucts = conjuncts
+        self.conjucts = list(conjuncts)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Conj):
-            return self.conjucts == other.conjucts and self.conjucts == other.conjucts
+            return self.conjucts == other.conjucts
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"And({self.conjucts})"
 
 
 class Disj(Constraint):
-    def __init__(self, disjuncts):
+    def __init__(self, disjuncts: Sequence[Constraint]) -> None:
         """
         :param disjuncts: Disjunction of constraints
         """
-        self.disjuncts = disjuncts
+        self.disjuncts = list(disjuncts)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Disj):
-            return (
-                self.disjuncts == other.disjuncts and self.disjuncts == other.disjuncts
-            )
+            return self.disjuncts == other.disjuncts
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Or({self.disjuncts})"
 
 
 class Prod(Constraint):
-    def __init__(self, products):
+    def __init__(self, products: Sequence[DVar | int | _DynType]) -> None:
         """
         :param products: lists of dimensions to multiply
         """
-        self.products = products
+        self.products = list(products)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Prod):
-            return self.products == other.products and self.products == other.products
+            return self.products == other.products
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Product({self.products})"
 
 
@@ -78,10 +112,10 @@ class T(Constraint):
     def __init__(self) -> None:
         pass
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, T)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "True"
 
 
@@ -93,10 +127,10 @@ class F(Constraint):
     def __init__(self) -> None:
         pass
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, F)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "False"
 
 
@@ -105,7 +139,7 @@ class BinaryConstraint(Constraint):
     Represents all binary operations
     """
 
-    def __init__(self, lhs, rhs, op):
+    def __init__(self, lhs: _Operand, rhs: _Operand, op: str | None) -> None:
         """
         :param lhs: lhs of the constraint
         :param rhs: rhs of the constraint
@@ -115,7 +149,7 @@ class BinaryConstraint(Constraint):
         self.rhs = rhs
         self.op = op
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, BinaryConstraint):
             return (
                 self.lhs == other.lhs and self.rhs == other.rhs and self.op == other.op
@@ -123,7 +157,7 @@ class BinaryConstraint(Constraint):
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"({self.lhs} {self.op} {self.rhs})"
 
 
@@ -132,7 +166,7 @@ class BinConstraintT(BinaryConstraint):
     Binary constraints about tensors
     """
 
-    def __init__(self, lhs, rhs, op):
+    def __init__(self, lhs: _Operand, rhs: _Operand, op: str | None) -> None:
         if not (
             (isinstance(lhs, (TVar, TensorType, int)) or lhs == Dyn)
             and (isinstance(rhs, (TVar, TensorType, int)) or rhs == Dyn)
@@ -146,7 +180,7 @@ class BinConstraintD(BinaryConstraint):
     Binary constraints about dimensions
     """
 
-    def __init__(self, lhs, rhs, op):
+    def __init__(self, lhs: _Operand, rhs: _Operand, op: str | None) -> None:
         if not (is_algebraic_expression(lhs) or is_dim(lhs) or is_bool_expr(lhs)):
             raise AssertionError(f"Invalid lhs type: {type(lhs)}")
         if not (is_algebraic_expression(rhs) or is_dim(rhs) or is_bool_expr(rhs)):
@@ -160,7 +194,7 @@ class TGreatestUpperBound(Constraint):
     Greatest Upper bound for tensors with dynamic type
     """
 
-    def __init__(self, res, rhs1, rhs2):
+    def __init__(self, res: TVar, rhs1: TVar, rhs2: TVar) -> None:
         """
         :param res: tensor variable that stores the result of the output
         :param rhs1: tensor or tensor variable
@@ -170,10 +204,10 @@ class TGreatestUpperBound(Constraint):
         self.rhs1 = rhs1
         self.rhs2 = rhs2
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.res} = {self.rhs1}\u2294*{self.rhs2}"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, TGreatestUpperBound):
             return (
                 self.res == other.res
@@ -189,7 +223,12 @@ class DGreatestUpperBound(Constraint):
     Greatest Upper bound for dimensions
     """
 
-    def __init__(self, res, rhs1, rhs2):
+    def __init__(
+        self,
+        res: DVar | int | _DynType,
+        rhs1: DVar | int | _DynType,
+        rhs2: DVar | int | _DynType,
+    ) -> None:
         """
         :param res: Dimension variable to store the result
         :param rhs1: dimension variable 1
@@ -206,10 +245,10 @@ class DGreatestUpperBound(Constraint):
         self.rhs1 = rhs1
         self.rhs2 = rhs2
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.res} = {self.rhs1}\u2294{self.rhs2}"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, DGreatestUpperBound):
             return (
                 self.res == other.res
@@ -225,7 +264,7 @@ class CanReshape(Constraint):
     can_reshape constraint
     """
 
-    def __init__(self, src, target):
+    def __init__(self, src: TVar, target: TensorType) -> None:
         """
         :param src: tensor variable
         :param target: tensor
@@ -233,10 +272,10 @@ class CanReshape(Constraint):
         self.src = src
         self.target = target
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"can-reshape({self.src}, {self.target})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, CanReshape):
             return self.src == other.src and self.target == other.target
         else:
@@ -244,7 +283,14 @@ class CanReshape(Constraint):
 
 
 class IndexSelect(Constraint):
-    def __init__(self, tensor_size, input_var, dim_replace, index, output):
+    def __init__(
+        self,
+        tensor_size: int,
+        input_var: TVar,
+        dim_replace: DVar | _DynType,
+        index: int,
+        output: TVar,
+    ) -> None:
         """
         Args:
             input_var: input to index_select
@@ -268,7 +314,7 @@ class IndexSelect(Constraint):
         self.index = index
         self.output = output
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f" {self.output} = "
             f"IndexSelect({self.input_var}, "
@@ -277,7 +323,7 @@ class IndexSelect(Constraint):
             f"{self.index})"
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, IndexSelect):
             return (
                 self.tensor_size == other.tensor_size
@@ -291,7 +337,9 @@ class IndexSelect(Constraint):
 
 
 class Transpose(Constraint):
-    def __init__(self, tensor_size, input_var, index1, index2, output):
+    def __init__(
+        self, tensor_size: int, input_var: TVar, index1: int, index2: int, output: TVar
+    ) -> None:
         """
         Args:
             tensor_size: current tensor size
@@ -315,7 +363,7 @@ class Transpose(Constraint):
         self.index2 = index2
         self.output = output
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f" {self.output} = "
             f"Transpose({self.input_var}, "
@@ -324,7 +372,7 @@ class Transpose(Constraint):
             f"{self.index2})"
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Transpose):
             return (
                 self.tensor_size == other.tensor_size
@@ -338,7 +386,9 @@ class Transpose(Constraint):
 
 
 class GetItem(Constraint):
-    def __init__(self, tensor_size, index, res, input_var):
+    def __init__(
+        self, tensor_size: int, index: int, res: DVar, input_var: TVar
+    ) -> None:
         """
         Constraint for getting item given a tensor size
         :param tensor_size: actual number
@@ -354,10 +404,10 @@ class GetItem(Constraint):
         self.index = index
         self.input_var = input_var
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f" {self.res} = GetItem({self.input_var}, tensor_size: {self.tensor_size}, {self.index})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, GetItem):
             return (
                 self.res == other.res
@@ -370,7 +420,13 @@ class GetItem(Constraint):
 
 
 class GetItemTensor(Constraint):
-    def __init__(self, tensor_size, index_tuple, res, input_var):
+    def __init__(
+        self,
+        tensor_size: int,
+        index_tuple: tuple[None | slice, ...],
+        res: TVar,
+        input_var: TVar,
+    ) -> None:
         """
         Constraint for getting item given a tensor size
         However, when the argument is a tuple, we will
@@ -388,10 +444,10 @@ class GetItemTensor(Constraint):
         self.index_tuple = index_tuple
         self.input_var = input_var
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f" {self.res} = GetItemT({self.input_var}, tensor_size: {self.tensor_size}, {self.index_tuple})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, GetItemTensor):
             return (
                 self.res == other.res
@@ -406,15 +462,15 @@ class GetItemTensor(Constraint):
 class CalcConv(Constraint):
     def __init__(
         self,
-        conv_result,
-        input_var,
-        c_out,
-        kernel,
-        padding,
-        stride,
-        dilation,
-        matching_constraint_vars,
-    ):
+        conv_result: TVar,
+        input_var: TVar,
+        c_out: int,
+        kernel: int | tuple[int, int],
+        padding: int | tuple[int, int],
+        stride: int | tuple[int, int],
+        dilation: int | tuple[int, int],
+        matching_constraint_vars: list[DVar],
+    ) -> None:
         """
         :param conv_result: the convolution result
         :param input_var: input to convolution
@@ -430,7 +486,7 @@ class CalcConv(Constraint):
         self.dilation = dilation
         self.matching_constraint = matching_constraint_vars
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"{self.conv_result} ="
             f" calc-conv({self.input_var},"
@@ -439,7 +495,7 @@ class CalcConv(Constraint):
             f" {self.dilation})"
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, CalcConv):
             return (
                 self.conv_result == other.conv_result
@@ -458,14 +514,14 @@ class CalcConv(Constraint):
 class CalcMaxPool(Constraint):
     def __init__(
         self,
-        maxpool_result,
-        input_var,
-        kernel,
-        padding,
-        stride,
-        dilation,
-        matching_constraint_vars,
-    ):
+        maxpool_result: TVar,
+        input_var: TVar,
+        kernel: int | tuple[int, int],
+        padding: int | tuple[int, int],
+        stride: int | tuple[int, int],
+        dilation: int | tuple[int, int],
+        matching_constraint_vars: list[DVar],
+    ) -> None:
         """
         :param maxpool_result: the result of maxpool
         :param input_var: input to convolution
@@ -479,7 +535,7 @@ class CalcMaxPool(Constraint):
         self.dilation = dilation
         self.matching_constraint = matching_constraint_vars
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"{self.maxpool_result} ="
             f" calc-maxpool({self.input_var},"
@@ -488,7 +544,7 @@ class CalcMaxPool(Constraint):
             f" {self.dilation})"
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, CalcMaxPool):
             return (
                 self.maxpool_result == other.maxpool_result
@@ -504,7 +560,7 @@ class CalcMaxPool(Constraint):
 
 
 class ApplyBroadcasting(Constraint):
-    def __init__(self, res1, res2, input1, input2):
+    def __init__(self, res1: TVar, res2: TVar, input1: TVar, input2: TVar) -> None:
         """
         :param res1: resulting tensor 1
         :param res2: resulting tensor 2
@@ -516,7 +572,7 @@ class ApplyBroadcasting(Constraint):
         self.input1 = input1
         self.input2 = input2
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, ApplyBroadcasting):
             return (
                 self.res1 == other.res1
@@ -527,7 +583,7 @@ class ApplyBroadcasting(Constraint):
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"{self.res1}, {self.res2} ="
             f" apply-broadcasting({self.input1},"
@@ -540,7 +596,9 @@ class CalcProduct(Constraint):
     Given correct dimensions, calculate the product for flatten accounting for Dyn
     """
 
-    def __init__(self, start, end, flattened, dims_to_flatten):
+    def __init__(
+        self, start: int, end: int, flattened: TVar, dims_to_flatten: list[DVar]
+    ) -> None:
         """
         :param start: start index
         :param end: end index
@@ -561,7 +619,7 @@ class CalcProduct(Constraint):
         self.dims_to_flatten = dims_to_flatten
         self.flattened = flattened
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, CalcProduct):
             return (
                 self.start == other.start
@@ -573,7 +631,7 @@ class CalcProduct(Constraint):
         else:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.flattened} = CalcProduct({self.start}, {self.end}, {self.dims_to_flatten})"
 
 
@@ -582,16 +640,16 @@ class TVar:
     Tensor variable with no tensor constructor
     """
 
-    def __init__(self, tvar):
+    def __init__(self, tvar: int) -> None:
         """
         :param tvar: tensor variable
         """
         self.tvar = tvar
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"TV({self.tvar})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, TVar):
             return self.tvar == other.tvar
         else:
@@ -603,16 +661,16 @@ class DVar:
     Dimension variable
     """
 
-    def __init__(self, c):
+    def __init__(self, c: int) -> None:
         """
         :param c: character or number
         """
         self.c = c
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"DV({self.c})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, DVar):
             return self.c == other.c
         else:
@@ -624,35 +682,52 @@ class BVar:
     Boolean variable
     """
 
-    def __init__(self, c):
+    def __init__(self, c: int) -> None:
         """
         :param c: character or number
         """
         self.c = c
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"BV({self.c})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, BVar):
             return self.c == other.c
         else:
             return False
 
 
-def is_algebraic_expression(constraint):
+_Operand: TypeAlias = (
+    TVar
+    | TensorType
+    | DVar
+    | int
+    | float
+    | bool
+    | _DynType
+    | BinConstraintD
+    | Prod
+    | BVar
+    | Conj
+    | Disj
+    | None
+)
+
+
+def is_algebraic_expression(constraint: object) -> bool:
     if isinstance(constraint, BinConstraintD):
         return constraint.op in [op_add, op_sub, op_div, op_mul, op_mod]
     else:
         return isinstance(constraint, Prod)
 
 
-def is_bool_expr(constraint):
+def is_bool_expr(constraint: object) -> bool:
     if isinstance(constraint, BinConstraintD):
         return constraint.op in [op_gt, op_lt, op_neq, op_eq]
     else:
         return isinstance(constraint, (BVar, Conj, Disj))
 
 
-def is_dim(d):
+def is_dim(d: object) -> bool:
     return isinstance(d, (DVar, int)) or d == Dyn

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -1,8 +1,7 @@
-# mypy: allow-untyped-defs
 import operator
 import warnings
-from collections.abc import Callable, Iterable
-from typing import TypeVar
+from collections.abc import Callable, Iterable, Sequence
+from typing import TypeAlias, TypeVar
 from typing_extensions import ParamSpec
 
 import torch
@@ -11,11 +10,13 @@ from torch.fx.experimental.migrate_gradual_types.constraint import (
     ApplyBroadcasting,
     BinConstraintD,
     BinConstraintT,
+    BVar,
     CalcConv,
     CalcMaxPool,
     CalcProduct,
     CanReshape,
     Conj,
+    Constraint,
     DGreatestUpperBound,
     Disj,
     DVar,
@@ -49,6 +50,7 @@ from torch.fx.experimental.migrate_gradual_types.util import (
     gen_tensor_dims,
     gen_tvar,
 )
+from torch.fx.graph import Graph
 from torch.fx.node import Node, Target
 from torch.fx.tensor_type import Dyn, TensorType
 from torch.nn.modules.batchnorm import BatchNorm2d
@@ -58,7 +60,9 @@ from torch.nn.modules.conv import Conv2d
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
-_INFERENCE_RULES: dict[Target, Callable] = {}
+_SymbolDict: TypeAlias = dict[Node, TVar | DVar | BVar]
+
+_INFERENCE_RULES: dict[Target, Callable[..., tuple[list[Constraint], int]]] = {}
 
 MAX_TENSOR_RANK = 4
 
@@ -117,13 +121,15 @@ def register_inference_rule(
     def register(fn: Callable[_P, _T]) -> Callable[_P, _T]:
         if call_target in _INFERENCE_RULES:
             raise RuntimeError(f"Inference rule already registered for {call_target}!")
-        _INFERENCE_RULES[call_target] = fn
+        _INFERENCE_RULES[call_target] = fn  # pyrefly: ignore[unsupported-operation]
         return fn
 
     return register
 
 
-def generate_flatten_constraints(start_dim, end_dim, input, flattened, n, counter):
+def generate_flatten_constraints(
+    start_dim: int, end_dim: int, input: TVar, flattened: TVar, n: int, counter: int
+) -> tuple[Conj, int]:
     d, counter = gen_tensor_dims(n, counter)
     c1 = BinConstraintT(input, TensorType(d), op_eq)
     start_dim = n if start_dim == -1 else abs(start_dim)
@@ -134,7 +140,9 @@ def generate_flatten_constraints(start_dim, end_dim, input, flattened, n, counte
 
 
 @register_inference_rule(getattr)
-def get_attr_inference_rule(n: Node, symbols, constraints, counter):
+def get_attr_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     If the attribute is "device" then the tensor shape is preserved
     """
@@ -155,7 +163,9 @@ def get_attr_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.bmm)
-def bmm_inference_rule(n: Node, symbols, constraints, counter):
+def bmm_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Constraints that match the input to a size 3 tensor
     and switch the dimensions according to the rules
@@ -227,7 +237,9 @@ def bmm_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule("index_select")
-def index_select_inference_rule(n: Node, symbols, constraints, counter):
+def index_select_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     We constrain the second argument to a vector or Dyn.
     The output replaces the input with the shape of the vector
@@ -256,7 +268,13 @@ def index_select_inference_rule(n: Node, symbols, constraints, counter):
             Disj(
                 [
                     IndexSelect(
-                        i + 1, symbols[n.args[0]], dims[0], n.args[1], index_select
+                        i + 1,
+                        symbols[  # pyrefly: ignore[bad-argument-type, bad-index]
+                            n.args[0]
+                        ],
+                        dims[0],
+                        n.args[1],
+                        index_select,
                     )
                     for i in range(MAX_TENSOR_RANK)
                 ]
@@ -268,7 +286,15 @@ def index_select_inference_rule(n: Node, symbols, constraints, counter):
             is_dyn,
             Disj(
                 [
-                    IndexSelect(i + 1, symbols[n.args[0]], Dyn, n.args[1], index_select)
+                    IndexSelect(
+                        i + 1,
+                        symbols[  # pyrefly: ignore[bad-argument-type, bad-index]
+                            n.args[0]
+                        ],
+                        Dyn,
+                        n.args[1],
+                        index_select,
+                    )
                     for i in range(MAX_TENSOR_RANK)
                 ]
             ),
@@ -279,7 +305,9 @@ def index_select_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule("expand")
-def expand_inference_rule(n: Node, symbols, constraints, counter):
+def expand_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     We generate the exact constraints as we do for tensor additions but we constraint
     the rank of this expression to be equal to len(n.args[1:]) so that only
@@ -308,13 +336,22 @@ def expand_inference_rule(n: Node, symbols, constraints, counter):
     e2_constraint = BinConstraintT(
         e2,
         TensorType(
-            [arg if isinstance(arg, int) else symbols[arg] for arg in n.args[1:]]
+            [
+                arg
+                if isinstance(arg, int)
+                else symbols[arg]  # pyrefly: ignore[bad-index]
+                for arg in n.args[1:]
+            ]
         ),
         op_eq,
     )
 
     constraints, counter = gen_broadcasting_constraints(
-        e1, e2, symbols, counter, expand
+        e1,  # pyrefly: ignore[bad-argument-type]
+        e2,
+        symbols,
+        counter,
+        expand,
     )
 
     # constraint the output size
@@ -341,7 +378,9 @@ def expand_inference_rule(n: Node, symbols, constraints, counter):
 @register_inference_rule("contiguous")
 @register_inference_rule(torch.ones)
 @register_inference_rule(torch.zeros)
-def equality_inference_rule(n: Node, symbols, constraints, counter):
+def equality_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     We generate the constraint: input = output
     """
@@ -356,23 +395,27 @@ def equality_inference_rule(n: Node, symbols, constraints, counter):
         # then we have dimension variables
         else:
             for arg in n.args:
-                if not isinstance(symbols[arg], DVar):
-                    raise AssertionError(f"Expected DVar, got {type(symbols[arg])}")
-        my_size = [symbols[arg] for arg in n.args]
+                if not isinstance(symbols[arg], DVar):  # pyrefly: ignore[bad-index]
+                    raise AssertionError(
+                        f"Expected DVar, got {type(symbols[arg])}"  # pyrefly: ignore[bad-index]
+                    )
+        my_size = [symbols[arg] for arg in n.args]  # pyrefly: ignore[bad-index]
         return [BinConstraintT(output, TensorType(my_size), op_eq)], counter
 
     elif isinstance(n.args[0], tuple):
         # then the tuple is the size
         if len(n.args[0]) > 4:
             raise AssertionError(f"Expected len <= 4, got {len(n.args[0])}")
-        my_size = [symbols[arg] for arg in n.args[0]]
+        my_size = [symbols[arg] for arg in n.args[0]]  # pyrefly: ignore[bad-index]
         return [BinConstraintT(output, TensorType(my_size), op_eq)], counter
     else:
         raise NotImplementedError("Method not yet implemented")
 
 
 @register_inference_rule("transpose")
-def transpose_inference_rule(n: Node, symbols, constraints, counter):
+def transpose_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Can be considered as a sequence of two index selects, so we generate constraints accordingly
     """
@@ -407,7 +450,9 @@ def transpose_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule("type_as")
-def type_inference_rule(n: Node, symbols, constraints, counter):
+def type_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     We generate the constraint: input = output
     """
@@ -434,7 +479,9 @@ def type_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule("masked_fill_")
-def masked_fill_inference_rule(n: Node, symbols, constraints, counter):
+def masked_fill_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Similar to addition. For now we implement the constraints when
     the argument is a boolean tensor. There is also a case for when
@@ -463,11 +510,13 @@ def masked_fill_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.nn.functional.embedding)
-def embedding_inference_rule_functional(n: Node, symbols, constraints, counter):
+def embedding_inference_rule_functional(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
-    embedding_dim_weights = symbols[n.args[1]]
+    embedding_dim_weights = symbols[n.args[1]]  # pyrefly: ignore[bad-index]
 
     # will treat this as a static shape. So we will not use matching.
     weight_dims, counter = gen_tensor_dims(2, counter)
@@ -480,7 +529,13 @@ def embedding_inference_rule_functional(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.nn.modules.sparse.Embedding)
-def embedding_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def embedding_inference_rule(
+    n: Node,
+    module_instance: torch.nn.Embedding,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     """
     The output shape differs from the input shape in the last dimension
     """
@@ -489,10 +544,12 @@ def embedding_inference_rule(n: Node, module_instance, symbols, constraints, cou
     return gen_embedding_rules(n, symbols, module_instance.embedding_dim, counter)
 
 
-def gen_embedding_rules(n: Node, symbols, embedding_dim, counter):
+def gen_embedding_rules(
+    n: Node, symbols: _SymbolDict, embedding_dim: int | DVar, counter: int
+) -> tuple[list[Constraint], int]:
     embedding_output, counter = gen_tvar(counter)
     symbols[n] = embedding_output
-    embedding_input = symbols[n.args[0]]
+    embedding_input = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
 
     input_dyn = BinConstraintT(embedding_input, Dyn, op_eq)
     output_dyn = BinConstraintT(embedding_output, Dyn, op_eq)
@@ -520,18 +577,22 @@ def gen_embedding_rules(n: Node, symbols, embedding_dim, counter):
 
 
 @register_inference_rule(torch.tensor)
-def tensor_inference_rule(n: Node, symbols, constraints, counter):
+def tensor_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     If the tensor is a scalar, we will skip it since we
     do not support scalars yet. We will add support in the future
     if it's needed. For our examples so far, scalars are not needed.
     """
-    return [], counter
+    return [], counter  # pyrefly: ignore[implicit-any]
 
 
 @register_inference_rule("reshape")
 @register_inference_rule("view")
-def view_inference_rule(n: Node, symbols, constraints, counter):
+def view_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Similar to reshape but with an extra condition on the strides
     """
@@ -564,7 +625,7 @@ def view_inference_rule(n: Node, symbols, constraints, counter):
     t2_type = TensorType(t2_type)  # type: ignore[assignment]
 
     c1 = BinConstraintT(my_view, t2_type, op_eq)
-    c2 = CanReshape(src_var, t2_type)
+    c2 = CanReshape(src_var, t2_type)  # pyrefly: ignore[bad-argument-type]
 
     # TODO: add the extra check mentioned here:
     # https://pytorch.org/docs/stable/generated/torch.Tensor.view.html#torch.Tensor.view
@@ -573,7 +634,9 @@ def view_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule("size")
-def size_inference_rule(n: Node, symbols, constraints, counter):
+def size_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     The constraint is just lhs = rhs.
     Ex: size = input_ids.size()
@@ -583,7 +646,7 @@ def size_inference_rule(n: Node, symbols, constraints, counter):
         # generate the new variable
         size, counter = gen_tvar(counter)
         symbols[n] = size
-        input = symbols[n.args[0]]
+        input = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
         c = BinConstraintT(input, size, op_eq)
         return [c], counter
 
@@ -593,9 +656,14 @@ def size_inference_rule(n: Node, symbols, constraints, counter):
             # generate the new variable
             size_index, counter = gen_dvar(counter)
             symbols[n] = size_index
-            input = symbols[n.args[0]]
+            input = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
             c2 = [
-                GetItem(i + 1, n.args[1], size_index, input)
+                GetItem(
+                    i + 1,
+                    n.args[1],
+                    size_index,
+                    input,  # pyrefly: ignore[bad-argument-type]
+                )
                 for i in range(MAX_TENSOR_RANK)
             ]
             c3 = BinConstraintD(0, size_index, op_leq)
@@ -613,7 +681,7 @@ def size_inference_rule(n: Node, symbols, constraints, counter):
         raise NotImplementedError
 
 
-def range_check(i, n):
+def range_check(i: int, n: int) -> T | F:
     """
     Checks if an index i is within range of a size n list
     Args:
@@ -629,7 +697,9 @@ def range_check(i, n):
 
 
 @register_inference_rule(torch.cumsum)
-def cumsum_inference_rule(n: Node, symbols, constraints, counter):
+def cumsum_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Input and output shapes should be equal
     We should verify that the index is valid
@@ -668,14 +738,18 @@ def cumsum_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(_assert_is_none)
-def assert_inference_rule(n: Node, symbols, constraints, counter):
+def assert_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if len(n.users) != 0:
         raise AssertionError(f"Expected no users, got {len(n.users)}")
-    return [], counter
+    return [], counter  # pyrefly: ignore[implicit-any]
 
 
 @register_inference_rule(operator.getitem)
-def getitem_inference_rule(n: Node, symbols, constraints, counter):
+def getitem_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -732,7 +806,7 @@ def getitem_inference_rule(n: Node, symbols, constraints, counter):
             ]
         else:
             # TODO: we should figure out why there is a key-error here.
-            return [], counter
+            return [], counter  # pyrefly: ignore[implicit-any]
 
         return [Disj([c1, *c2])], counter
 
@@ -741,7 +815,9 @@ def getitem_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(operator.gt)
-def gt_inference_rule(n: Node, symbols, constraints, counter):
+def gt_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], (Node, int)):
         raise AssertionError(f"Expected Node or int, got {type(n.args[0])}")
     if not isinstance(n.args[1], (Node, int)):
@@ -804,7 +880,9 @@ def gt_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(operator.eq)
-def eq_inference_rule(n: Node, symbols, constraints, counter):
+def eq_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], (Node, int)):
         raise AssertionError(f"Expected Node or int, got {type(n.args[0])}")
     if not isinstance(n.args[1], (Node, int)):
@@ -845,7 +923,9 @@ def eq_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(operator.ne)
-def neq_inference_rule(n: Node, symbols, constraints, counter):
+def neq_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     Translates to inconsistent in gradual types.
     To prove inequality, we should prove that
@@ -973,7 +1053,9 @@ def neq_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(operator.lt)
-def lt_inference_rule(n: Node, symbols, constraints, counter):
+def lt_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], (Node, int)):
         raise AssertionError(f"Expected Node or int, got {type(n.args[0])}")
     if not isinstance(n.args[1], (Node, int)):
@@ -1018,7 +1100,9 @@ def lt_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.full)
-def full_inference_rule(n: Node, symbols, constraints, counter):
+def full_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     full, counter = gen_tvar(counter)
     symbols[n] = full
     res = []
@@ -1026,7 +1110,9 @@ def full_inference_rule(n: Node, symbols, constraints, counter):
     if not isinstance(n.args[0], Iterable):
         raise AssertionError(f"Expected Iterable, got {type(n.args[0])}")
     for arg in n.args[0]:
-        dim = arg if isinstance(arg, int) else symbols[arg]
+        dim = (
+            arg if isinstance(arg, int) else symbols[arg]  # pyrefly: ignore[bad-index]
+        )
         res.append(dim)
     c = BinConstraintT(full, TensorType(list(res)), op_eq)  # type: ignore[arg-type]
     return [c], counter
@@ -1034,12 +1120,14 @@ def full_inference_rule(n: Node, symbols, constraints, counter):
 
 # TODO normalize index
 @register_inference_rule(torch.arange)
-def arange_inference_rule(n: Node, symbols, constraints, counter):
+def arange_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     start = 0
     step = 1
 
     if len(n.args) == 1:
-        end = symbols[n.args[0]]
+        end = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
     else:
         raise NotImplementedError("Not yet implemented")
 
@@ -1078,7 +1166,9 @@ def arange_inference_rule(n: Node, symbols, constraints, counter):
     ], counter
 
 
-def gen_broadcasting_constraints(e1, e2, symbols, counter, output_var):
+def gen_broadcasting_constraints(
+    e1: TVar, e2: TVar, symbols: _SymbolDict, counter: int, output_var: TVar
+) -> tuple[list[Constraint], int]:
     # additional vars that don't correspond to expressions
     e11, counter = gen_tvar(counter)
     e22, counter = gen_tvar(counter)
@@ -1095,7 +1185,9 @@ def gen_broadcasting_constraints(e1, e2, symbols, counter, output_var):
 @register_inference_rule("ne")
 @register_inference_rule(torch.add)
 @register_inference_rule(operator.add)
-def broadcasting_inference_rule(n: Node, symbols, constraints, counter):
+def broadcasting_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:  # pyrefly: ignore[bad-return]
     op_code = None
     if n.target is operator.add or n.target is torch.add:
         op_code = op_add
@@ -1111,7 +1203,13 @@ def broadcasting_inference_rule(n: Node, symbols, constraints, counter):
             e1 = symbols[n.args[0]]
             e2 = symbols[n.args[1]]
 
-            return gen_broadcasting_constraints(e1, e2, symbols, counter, my_output)
+            return gen_broadcasting_constraints(
+                e1,  # pyrefly: ignore[bad-argument-type]
+                e2,  # pyrefly: ignore[bad-argument-type]
+                symbols,
+                counter,
+                my_output,
+            )
         else:
             raise NotImplementedError("Method not yet implemented")
 
@@ -1168,7 +1266,9 @@ def broadcasting_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.flatten)
-def flatten_inference_rule(n: Node, symbols, constraints, counter):
+def flatten_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -1199,7 +1299,12 @@ def flatten_inference_rule(n: Node, symbols, constraints, counter):
     const = []
     for i in range(1, MAX_TENSOR_RANK + 1):
         c, counter = generate_flatten_constraints(
-            start_dim, end_dim, input, flattened, i, counter
+            start_dim,
+            end_dim,
+            input,  # pyrefly: ignore[bad-argument-type]
+            flattened,
+            i,
+            counter,
         )
         const.append(c)
 
@@ -1207,17 +1312,30 @@ def flatten_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch.nn.functional.layer_norm)
-def layer_norm_functional(n: Node, symbols, constraints, counter):
+def layer_norm_functional(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     """
     We generate the constraint: input = output
     """
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
-    return gen_layer_norm_constraints(n, n.args[1], symbols, counter)
+    return gen_layer_norm_constraints(
+        n,
+        n.args[1],  # pyrefly: ignore[bad-argument-type]
+        symbols,
+        counter,
+    )
 
 
 @register_inference_rule(torch.nn.LayerNorm)
-def layer_norm_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def layer_norm_inference_rule(
+    n: Node,
+    module_instance: torch.nn.LayerNorm,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     """
     Input and output shapes should be equal.
     Input should be consistent with the normalized_shape
@@ -1229,10 +1347,12 @@ def layer_norm_inference_rule(n: Node, module_instance, symbols, constraints, co
     )
 
 
-def gen_layer_norm_constraints(n: Node, normalized_shape, symbols, counter):
+def gen_layer_norm_constraints(
+    n: Node, normalized_shape: Sequence[int], symbols: _SymbolDict, counter: int
+) -> tuple[list[Constraint], int]:
     output, counter = gen_tvar(counter)
     symbols[n] = output
-    input = symbols[n.args[0]]
+    input = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
 
     input_dyn = BinConstraintT(input, Dyn, op_eq)
     output_dyn = BinConstraintT(output, Dyn, op_eq)
@@ -1258,7 +1378,13 @@ def gen_layer_norm_constraints(n: Node, normalized_shape, symbols, counter):
 
 @register_inference_rule(torch.nn.Dropout)
 @register_inference_rule(torch.nn.ReLU)
-def relu_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def relu_inference_rule(
+    n: Node,
+    module_instance: torch.nn.Module,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     """
     Input and output shapes should be equal.
     """
@@ -1273,7 +1399,13 @@ def relu_inference_rule(n: Node, module_instance, symbols, constraints, counter)
 
 
 @register_inference_rule(torch.nn.Linear)
-def linear_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def linear_inference_rule(
+    n: Node,
+    module_instance: torch.nn.Linear,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     """
     Input and output sizes should be the same except for the last dimension
     If the input is Dyn, then so should the output
@@ -1286,7 +1418,9 @@ def linear_inference_rule(n: Node, module_instance, symbols, constraints, counte
 
 
 @register_inference_rule("dim")
-def torch_dim_inference_rule(n: Node, symbols, constraints, counter):
+def torch_dim_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     my_dim, counter = gen_dvar(counter)
@@ -1313,12 +1447,16 @@ def torch_dim_inference_rule(n: Node, symbols, constraints, counter):
 
 
 @register_inference_rule(torch._C._nn.linear)
-def torch_linear_inference_rule(n: Node, symbols, constraints, counter):
+def torch_linear_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     weight_dims, counter = gen_tensor_dims(2, counter)
     equality_constraint = BinConstraintT(
-        symbols[n.args[1]], TensorType(weight_dims), op_eq
+        symbols[n.args[1]],  # pyrefly: ignore[bad-index]
+        TensorType(weight_dims),
+        op_eq,
     )
     constraints, counter = linear_constraints(
         n, weight_dims[1], weight_dims[0], symbols, counter
@@ -1326,10 +1464,16 @@ def torch_linear_inference_rule(n: Node, symbols, constraints, counter):
     return [equality_constraint] + constraints, counter
 
 
-def linear_constraints(n: Node, in_features, out_features, symbols, counter):
+def linear_constraints(
+    n: Node,
+    in_features: int | DVar,
+    out_features: int | DVar,
+    symbols: _SymbolDict,
+    counter: int,
+) -> tuple[list[Constraint], int]:
     linear_output, counter = gen_tvar(counter)
     symbols[n] = linear_output
-    linear_input = symbols[n.args[0]]
+    linear_input = symbols[n.args[0]]  # pyrefly: ignore[bad-index]
 
     input_dyn = BinConstraintT(linear_input, Dyn, op_eq)
     output_dyn = BinConstraintT(linear_output, Dyn, op_eq)
@@ -1357,7 +1501,9 @@ def linear_constraints(n: Node, in_features, out_features, symbols, counter):
     return [Disj([c1, Disj(c2)])], counter
 
 
-def add_layer_norm_constraints(input_dim, normalized_dim):
+def add_layer_norm_constraints(
+    input_dim: list[DVar], normalized_dim: list[int]
+) -> list[Constraint]:
     """
     The constraints say that the type has te form: [*, 1024, 1024]
      while the normalized_dim have the form [1024, 1024]
@@ -1372,16 +1518,21 @@ def add_layer_norm_constraints(input_dim, normalized_dim):
         return [F()]
 
     else:
-        constraints = []
+        constraints: list[Constraint] = []
         for i, n in zip(reversed(input_dim), reversed(normalized_dim)):
             constraints.append(BinConstraintD(i, n, op_consistency))
         return constraints
 
 
-def add_linear_constraints(dims1, dims2, in_features, out_features):
+def add_linear_constraints(
+    dims1: list[DVar],
+    dims2: list[DVar],
+    in_features: int | DVar,
+    out_features: int | DVar,
+) -> list[Constraint]:
     if len(dims1) != len(dims2):
         raise AssertionError(f"Expected same length, got {len(dims1)} vs {len(dims2)}")
-    constraints = []
+    constraints: list[Constraint] = []
     for i in range(len(dims1)):
         if i == len(dims1) - 1:
             constraints.append(BinConstraintD(dims1[i], in_features, op_consistency))
@@ -1393,7 +1544,9 @@ def add_linear_constraints(dims1, dims2, in_features, out_features):
 
 
 @register_inference_rule(torch.reshape)
-def reshape_inference_rule(n: Node, symbols, constraints, counter):
+def reshape_inference_rule(
+    n: Node, symbols: _SymbolDict, constraints: list[Constraint], counter: int
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -1405,13 +1558,19 @@ def reshape_inference_rule(n: Node, symbols, constraints, counter):
     t2 = n.args[1]
     t2_type = TensorType([Dyn if elem == -1 else elem for elem in t2])  # type: ignore[union-attr]
     c1 = BinConstraintT(my_reshape, t2_type, op_eq)  # type: ignore[union-attr]
-    c2 = CanReshape(src_var, t2_type)
+    c2 = CanReshape(src_var, t2_type)  # pyrefly: ignore[bad-argument-type]
 
     return [c1, c2], counter
 
 
 @register_inference_rule(BatchNorm2d)
-def batchnorm_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def batchnorm_inference_rule(
+    n: Node,
+    module_instance: BatchNorm2d,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -1434,7 +1593,13 @@ def batchnorm_inference_rule(n: Node, module_instance, symbols, constraints, cou
 
 
 @register_inference_rule(torch.nn.AdaptiveAvgPool2d)
-def adaptive_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def adaptive_inference_rule(
+    n: Node,
+    module_instance: torch.nn.AdaptiveAvgPool2d,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -1453,7 +1618,16 @@ def adaptive_inference_rule(n: Node, module_instance, symbols, constraints, coun
     c2 = BinConstraintT(
         avg_pool,
         TensorType(
-            [d1, d2, module_instance.output_size[0], module_instance.output_size[1]]
+            [
+                d1,
+                d2,
+                module_instance.output_size[  # pyrefly: ignore[bad-index, unsupported-operation]
+                    0
+                ],
+                module_instance.output_size[  # pyrefly: ignore[bad-index, unsupported-operation]
+                    1
+                ],
+            ]
         ),
         op_eq,
     )
@@ -1462,7 +1636,13 @@ def adaptive_inference_rule(n: Node, module_instance, symbols, constraints, coun
 
 
 @register_inference_rule(Conv2d)
-def conv2d_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def conv2d_inference_rule(
+    n: Node,
+    module_instance: Conv2d,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
 
@@ -1481,12 +1661,12 @@ def conv2d_inference_rule(n: Node, module_instance, symbols, constraints, counte
 
     c3 = CalcConv(
         my_conv,
-        input_var,
+        input_var,  # pyrefly: ignore[bad-argument-type]
         module_instance.out_channels,
-        module_instance.kernel_size,
-        module_instance.padding,
-        module_instance.stride,
-        module_instance.dilation,
+        module_instance.kernel_size,  # pyrefly: ignore[bad-argument-type]
+        module_instance.padding,  # pyrefly: ignore[bad-argument-type]
+        module_instance.stride,  # pyrefly: ignore[bad-argument-type]
+        module_instance.dilation,  # pyrefly: ignore[bad-argument-type]
         [d1, d2, d3, d4],
     )
 
@@ -1496,7 +1676,13 @@ def conv2d_inference_rule(n: Node, module_instance, symbols, constraints, counte
 
 
 @register_inference_rule(torch.nn.MaxPool2d)
-def maxpool_inference_rule(n: Node, module_instance, symbols, constraints, counter):
+def maxpool_inference_rule(
+    n: Node,
+    module_instance: torch.nn.MaxPool2d,
+    symbols: _SymbolDict,
+    constraints: list[Constraint],
+    counter: int,
+) -> tuple[list[Constraint], int]:
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     maxpool, counter = gen_tvar(counter)
@@ -1510,7 +1696,7 @@ def maxpool_inference_rule(n: Node, module_instance, symbols, constraints, count
 
     c2 = CalcMaxPool(
         maxpool,
-        input_var,
+        input_var,  # pyrefly: ignore[bad-argument-type]
         module_instance.kernel_size,
         module_instance.padding,
         module_instance.stride,
@@ -1524,21 +1710,21 @@ def maxpool_inference_rule(n: Node, module_instance, symbols, constraints, count
 
 
 class ConstraintGenerator:
-    def __init__(self, traced, graph=None):
+    def __init__(self, traced: torch.nn.Module, graph: Graph | None = None) -> None:
         self.traced = traced  # traced or tracer.root
         self.traced_params = dict(self.traced.named_parameters())
         self.constraints = []
         self.symbol_dict = {}
         self.graph = traced.graph if hasattr(traced, "graph") else graph
 
-    def generate_constraints(self, counter=0):
+    def generate_constraints(self, counter: int = 0) -> tuple[Conj, int]:
         """
         Iterate through every node and generate constraints
         Effect: self.constraints will be populated with the final constraints
         """
         graph = self.graph
 
-        all_constraints = []
+        all_constraints: list[Constraint] = []
 
         # pyrefly: ignore [missing-attribute]
         for n in graph.nodes:
@@ -1547,7 +1733,9 @@ class ConstraintGenerator:
 
         return Conj(all_constraints), counter
 
-    def generate_constraints_node(self, n: Node, counter):
+    def generate_constraints_node(
+        self, n: Node, counter: int
+    ) -> tuple[list[Constraint], int]:
         """
         Generate constraints the given node:
         Currently supported operations:
@@ -1586,7 +1774,9 @@ class ConstraintGenerator:
                 )
 
         elif n.op == "call_module":
-            module_instance = self.traced.get_submodule(n.target)
+            module_instance = self.traced.get_submodule(
+                n.target  # pyrefly: ignore[bad-argument-type]
+            )
             if type(module_instance) in _INFERENCE_RULES:
                 return _INFERENCE_RULES[type(module_instance)](
                     n, module_instance, self.symbol_dict, self.constraints, counter
@@ -1607,7 +1797,9 @@ class ConstraintGenerator:
                 )
 
         elif n.op == "get_attr":
-            t = self.traced_params.get(n.target, None)
+            t = self.traced_params.get(  # pyrefly: ignore[no-matching-overload]
+                n.target, None
+            )
 
             if isinstance(t, torch.Tensor):
                 if len(t.shape) > 0:
@@ -1618,12 +1810,12 @@ class ConstraintGenerator:
                     return [BinConstraintT(output, attr_type, op_eq)], counter
                 else:
                     # scalar?
-                    return [], counter
+                    return [], counter  # pyrefly: ignore[implicit-any]
             else:
-                return [], counter
+                return [], counter  # pyrefly: ignore[implicit-any]
 
         elif n.op == "output":
-            return [], counter
+            return [], counter  # pyrefly: ignore[implicit-any]
 
         else:
             raise NotImplementedError(f"Method {n.op} not yet implemented")

--- a/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py
@@ -1,7 +1,6 @@
-# mypy: ignore-errors
 import copy
 import itertools
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 from torch.fx.experimental.migrate_gradual_types.constraint import (
     ApplyBroadcasting,
@@ -47,14 +46,54 @@ from torch.fx.experimental.migrate_gradual_types.util import (
     gen_nat_constraints,
     gen_tensor_dims,
 )
-from torch.fx.tensor_type import Dyn, TensorType
+from torch.fx.tensor_type import _DynType, Dyn, TensorType
 
 
-_TRANSFORMATION_RULES: dict[Constraint, Callable] = {}
+__all__ = [
+    "apply_padding",
+    "broadcast_dim",
+    "calc_last_two_dims",
+    "create_equality_constraints_for_broadcasting",
+    "gen_all_reshape_possibilities",
+    "gen_broadcasting_constraints",
+    "gen_consistency_constraints",
+    "gen_greatest_upper_bound",
+    "gen_lists_of_dims",
+    "generate_all_broadcasting_possibilities_no_padding",
+    "generate_all_int_dyn_dim_possibilities",
+    "generate_binconstraint_d",
+    "generate_binconstraint_t",
+    "generate_broadcasting",
+    "generate_calc_conv",
+    "generate_calc_maxpool",
+    "generate_calc_product",
+    "generate_conj",
+    "generate_d_gub",
+    "generate_disj",
+    "generate_gub",
+    "generate_reshape",
+    "is_dim_div_by_target",
+    "is_target_div_by_dim",
+    "no_broadcast_dim_with_index",
+    "register_transformation_rule",
+    "transform_constraint",
+    "transform_get_item",
+    "transform_get_item_tensor",
+    "transform_index_select",
+    "transform_transpose",
+    "valid_index",
+    "valid_index_tensor",
+]
 
 
-def register_transformation_rule(call_target):
-    def register(fn):
+_TransformFn = Callable[[Constraint, int], tuple[Constraint, int]]
+_TRANSFORMATION_RULES: dict[type, _TransformFn] = {}
+
+
+def register_transformation_rule(
+    call_target: type[Constraint],
+) -> Callable[[_TransformFn], _TransformFn]:
+    def register(fn: _TransformFn) -> _TransformFn:
         if call_target in _TRANSFORMATION_RULES:
             raise RuntimeError(
                 f"Transformation rule already registered for {call_target}!"
@@ -65,7 +104,7 @@ def register_transformation_rule(call_target):
     return register
 
 
-def valid_index(index, dims):
+def valid_index(index: int, dims: list[DVar]) -> Constraint:
     """
     Given a list of dimensions, checks if an index is valid in the list
     """
@@ -77,10 +116,12 @@ def valid_index(index, dims):
 
 
 @register_transformation_rule(Transpose)
-def transform_transpose(constraint, counter):
+def transform_transpose(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Similar to a sequence of two index-selects
     """
+    if not isinstance(constraint, Transpose):
+        raise TypeError(type(constraint))
     dims, counter = gen_tensor_dims(constraint.tensor_size, counter)
     is_valid_index1 = valid_index(constraint.index1, dims)
     is_valid_index2 = valid_index(constraint.index2, dims)
@@ -104,21 +145,25 @@ def transform_transpose(constraint, counter):
 
 
 @register_transformation_rule(IndexSelect)
-def transform_index_select(constraint, counter):
+def transform_index_select(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     The constraints consider the given tensor size, checks if the index is valid
     and if so, generates a constraint for replacing the input dimension
     with the required dimension
     """
+    if not isinstance(constraint, IndexSelect):
+        raise TypeError(type(constraint))
     dims, counter = gen_tensor_dims(constraint.tensor_size, counter)
     is_valid_index = valid_index(constraint.index, dims)
     nat_constraints = gen_nat_constraints(dims)
 
     # if the index is valid then replace the input dimension with the new dimension
     # otherwise the dimension will not be replaced and the clause will contain False
+    new_dims = copy.deepcopy(dims)
     if is_valid_index == T():
-        new_dims = copy.deepcopy(dims)
-        new_dims[constraint.index] = constraint.dim_replace
+        new_dims[constraint.index] = constraint.dim_replace  # type: ignore[unsupported-operation]
 
     transformed_constraint = Conj(
         [
@@ -134,7 +179,7 @@ def transform_index_select(constraint, counter):
 
 
 @register_transformation_rule(GetItem)
-def transform_get_item(constraint, counter):
+def transform_get_item(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     generate an equality of the form:
     t = [a1, ..., an]
@@ -149,6 +194,8 @@ def transform_get_item(constraint, counter):
     Returns: simplified constraints for GetItem
 
     """
+    if not isinstance(constraint, GetItem):
+        raise TypeError(type(constraint))
     dims, counter = gen_tensor_dims(constraint.tensor_size, counter)
     nat_constraints = gen_nat_constraints(dims)
 
@@ -170,7 +217,7 @@ def transform_get_item(constraint, counter):
     return Conj(all_constraints), counter
 
 
-def valid_index_tensor(index, dims):
+def valid_index_tensor(index: tuple[None | slice, ...], dims: list[DVar]) -> Constraint:
     """
     if the slice instances exceed the length of the dimensions
     then this is a type error so we return False
@@ -186,7 +233,9 @@ def valid_index_tensor(index, dims):
 
 
 @register_transformation_rule(GetItemTensor)
-def transform_get_item_tensor(constraint, counter):
+def transform_get_item_tensor(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     When the index is a tuple, then the output will be a tensor
     TODO: we have to check if this is the case for all HF models
@@ -200,6 +249,8 @@ def transform_get_item_tensor(constraint, counter):
 
      slice with default arguments does not change the rank
     """
+    if not isinstance(constraint, GetItemTensor):
+        raise TypeError(type(constraint))
     if not isinstance(constraint.index_tuple, tuple):
         raise AssertionError(
             f"Expected tuple for index_tuple, got {type(constraint.index_tuple)}"
@@ -212,7 +263,8 @@ def transform_get_item_tensor(constraint, counter):
     # generate a place-holder list of the right rank
     # where "slice" does not contribute to the rank and "None" does
     none_c = constraint.index_tuple.count(None)
-    resulting_tensor_dims = (none_c + len(dims)) * [None]
+    # list invariance: [None] * n types as list[None], but elements are reassigned to int/DVar
+    resulting_tensor_dims: list[int | DVar | None] = [None] * (none_c + len(dims))  # type: ignore[assignment]
 
     dim_index = 0
     for i in range(len(constraint.index_tuple)):
@@ -251,10 +303,14 @@ def transform_get_item_tensor(constraint, counter):
 
 
 @register_transformation_rule(BinConstraintT)
-def generate_binconstraint_t(constraint, counter):
+def generate_binconstraint_t(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transform binary constraints for tensors
     """
+    if not isinstance(constraint, BinConstraintT):
+        raise TypeError(type(constraint))
 
     # precision constraints
     if constraint.op == op_precision:
@@ -280,6 +336,8 @@ def generate_binconstraint_t(constraint, counter):
                     + [BinConstraintD(1, new_dim, op_leq) for new_dim in new_dims]
                 )
                 return Conj(new_dim_constraints), counter
+        else:
+            return constraint, counter
 
     # matching
     elif constraint.op == op_matching:
@@ -342,15 +400,21 @@ def generate_binconstraint_t(constraint, counter):
 
 
 @register_transformation_rule(BinConstraintD)
-def generate_binconstraint_d(constraint, counter):
+def generate_binconstraint_d(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transform binary constraints for dimensions
     """
+    if not isinstance(constraint, BinConstraintD):
+        raise TypeError(type(constraint))
     if constraint.op == op_precision:
         if isinstance(constraint.lhs, int):
             return BinConstraintD(constraint.lhs, constraint.rhs, op_eq), counter
         elif constraint.lhs == Dyn:
             return T(), counter
+        else:
+            return constraint, counter
 
     elif constraint.op == op_consistency:
         return (
@@ -369,10 +433,12 @@ def generate_binconstraint_d(constraint, counter):
 
 
 @register_transformation_rule(Conj)
-def generate_conj(constraint, counter):
+def generate_conj(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Transform conjunctions
     """
+    if not isinstance(constraint, Conj):
+        raise TypeError(type(constraint))
     new = []
     for c in constraint.conjucts:
         new_c, counter = transform_constraint(c, counter)
@@ -381,10 +447,12 @@ def generate_conj(constraint, counter):
 
 
 @register_transformation_rule(Disj)
-def generate_disj(constraint, counter):
+def generate_disj(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Transform disjunctions
     """
+    if not isinstance(constraint, Disj):
+        raise TypeError(type(constraint))
     new = []
     for c in constraint.disjuncts:
         new_c, counter = transform_constraint(c, counter)
@@ -393,11 +461,13 @@ def generate_disj(constraint, counter):
 
 
 @register_transformation_rule(TGreatestUpperBound)
-def generate_gub(constraint, counter):
+def generate_gub(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Transform greatest upper bound for tensors. Results in equality and Greatest Upper Bound
     on dimensions
     """
+    if not isinstance(constraint, TGreatestUpperBound):
+        raise TypeError(type(constraint))
     c1 = Conj(
         [
             Disj(
@@ -416,10 +486,12 @@ def generate_gub(constraint, counter):
 
 
 @register_transformation_rule(DGreatestUpperBound)
-def generate_d_gub(constraint, counter):
+def generate_d_gub(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Transform greatest upper bound for dimensions into equality constraints
     """
+    if not isinstance(constraint, DGreatestUpperBound):
+        raise TypeError(type(constraint))
     c1 = Conj(
         [
             BinConstraintD(constraint.rhs1, Dyn, op_eq),
@@ -442,7 +514,9 @@ def generate_d_gub(constraint, counter):
 
 
 @register_transformation_rule(CalcConv)
-def generate_calc_conv(constraint, counter):
+def generate_calc_conv(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
+    if not isinstance(constraint, CalcConv):
+        raise TypeError(type(constraint))
     d, counter = gen_tensor_dims(4, counter)
     conv_result = TensorType([d[0], d[1], d[2], d[3]])
 
@@ -475,10 +549,14 @@ def generate_calc_conv(constraint, counter):
 
 
 @register_transformation_rule(CalcMaxPool)
-def generate_calc_maxpool(constraint, counter):
+def generate_calc_maxpool(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transform maxpool constraints
     """
+    if not isinstance(constraint, CalcMaxPool):
+        raise TypeError(type(constraint))
     d, counter = gen_tensor_dims(4, counter)
     maxpool_result = TensorType([d[0], d[1], d[2], d[3]])
 
@@ -503,10 +581,14 @@ def generate_calc_maxpool(constraint, counter):
 
 
 @register_transformation_rule(CalcProduct)
-def generate_calc_product(constraint, counter):
+def generate_calc_product(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transform flatten constraints
     """
+    if not isinstance(constraint, CalcProduct):
+        raise TypeError(type(constraint))
     start = constraint.start
     end = constraint.end
     dims = constraint.dims_to_flatten
@@ -524,7 +606,7 @@ def generate_calc_product(constraint, counter):
 
     all_possibilities = generate_all_int_dyn_dim_possibilities(mid)
 
-    all_constraints = []
+    all_constraints: list[Constraint] = []
 
     for p in all_possibilities:
         p = list(p)
@@ -575,10 +657,12 @@ def generate_calc_product(constraint, counter):
 
 
 @register_transformation_rule(CanReshape)
-def generate_reshape(constraint, counter):
+def generate_reshape(constraint: Constraint, counter: int) -> tuple[Constraint, int]:
     """
     Transform reshape constraints
     """
+    if not isinstance(constraint, CanReshape):
+        raise TypeError(type(constraint))
     d, counter = gen_tensor_dims(4, counter)
 
     d1 = d[0]
@@ -710,10 +794,14 @@ def generate_reshape(constraint, counter):
 
 
 @register_transformation_rule(ApplyBroadcasting)
-def generate_broadcasting(constraint, counter):
+def generate_broadcasting(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transform broadcasting constraints
     """
+    if not isinstance(constraint, ApplyBroadcasting):
+        raise TypeError(type(constraint))
     e11, e12 = constraint.res1, constraint.res2
     e1, e2 = constraint.input1, constraint.input2
 
@@ -784,7 +872,9 @@ def generate_broadcasting(constraint, counter):
     )
 
 
-def transform_constraint(constraint: Constraint, counter: int):
+def transform_constraint(
+    constraint: Constraint, counter: int
+) -> tuple[Constraint, int]:
     """
     Transforms a constraint into a simpler constraint.
     Ex: precision and consistency are transformed to equality
@@ -802,7 +892,9 @@ def transform_constraint(constraint: Constraint, counter: int):
         return constraint, counter
 
 
-def calc_last_two_dims(constraint, d: list[DVar]):
+def calc_last_two_dims(
+    constraint: CalcConv | CalcMaxPool, d: list[DVar]
+) -> tuple[Constraint, Constraint]:
     """
     Generates constraints for the last two dimensions of a convolution or a maxpool output
     Args:
@@ -874,7 +966,9 @@ def calc_last_two_dims(constraint, d: list[DVar]):
     return c4, c5
 
 
-def generate_all_int_dyn_dim_possibilities(my_list: list[DVar]):
+def generate_all_int_dyn_dim_possibilities(
+    my_list: list[DVar],
+) -> list[tuple[BinConstraintD, ...]]:
     """
     Generate all possibilities of being equal or not equal to dyn for my_list
     Args:
@@ -896,7 +990,9 @@ def generate_all_int_dyn_dim_possibilities(my_list: list[DVar]):
     return all_possibilities
 
 
-def is_target_div_by_dim(target: list[int], dim: list[DVar]):
+def is_target_div_by_dim(
+    target: Sequence[DVar | int | _DynType], dim: DVar | Prod
+) -> BinConstraintD:
     """
     Generate constraints to check if the target dimensions are divisible by the input dimensions
     Args:
@@ -909,7 +1005,9 @@ def is_target_div_by_dim(target: list[int], dim: list[DVar]):
     return BinConstraintD(BinConstraintD(Prod(target), dim, op_mod), 0, op_eq)
 
 
-def is_dim_div_by_target(target: list[int], dim: list[DVar]):
+def is_dim_div_by_target(
+    target: Sequence[DVar | int | _DynType], dim: DVar | Prod
+) -> BinConstraintD:
     """
     Generate constraints to check if the input dimensions is divisible by the target dimensions
     Args:
@@ -922,7 +1020,9 @@ def is_dim_div_by_target(target: list[int], dim: list[DVar]):
     return BinConstraintD(BinConstraintD(dim, Prod(target), op_mod), 0, op_eq)
 
 
-def gen_all_reshape_possibilities(list_of_dims, target):
+def gen_all_reshape_possibilities(
+    list_of_dims: list[DVar], target: Sequence[DVar | int | _DynType]
+) -> Constraint:
     """
     Consider all possibilities what the input dimensions could be (number or dynamic)
     Then generate the appropriate constraints using multiplication or mod depending on the possibility
@@ -942,7 +1042,7 @@ def gen_all_reshape_possibilities(list_of_dims, target):
     all_constraints = []
 
     for p in all_possibilities:
-        to_multiply = []
+        to_multiply: list[DVar] = []
 
         p = list(p)
 
@@ -950,7 +1050,7 @@ def gen_all_reshape_possibilities(list_of_dims, target):
             if not isinstance(constraint, BinConstraintD):
                 raise AssertionError(f"Expected BinConstraintD, got {type(constraint)}")
             if constraint.op == op_neq:
-                to_multiply.append(constraint.lhs)
+                to_multiply.append(constraint.lhs)  # type: ignore[arg-type]
 
         if not to_multiply:
             all_constraints.append(Conj(p))
@@ -967,7 +1067,14 @@ def gen_all_reshape_possibilities(list_of_dims, target):
     return Disj(all_constraints)
 
 
-def broadcast_dim(tensor_input1, tensor_input2, res1, res2, index, padding=False):
+def broadcast_dim(
+    tensor_input1: Sequence[DVar | None],
+    tensor_input2: Sequence[DVar],
+    res1: Sequence[DVar],
+    res2: Sequence[DVar],
+    index: int,
+    padding: bool = False,
+) -> Constraint:
     """
     Apply broadcasting to the 'index' dimension of tensor_input1.
     Args:
@@ -989,7 +1096,7 @@ def broadcast_dim(tensor_input1, tensor_input2, res1, res2, index, padding=False
         # then the inputs are the same length so they all have dimensions at "index"
         return Conj(
             [
-                BinConstraintD(tensor_input1[index], 1, op_eq),
+                BinConstraintD(tensor_input1[index], 1, op_eq),  # type: ignore[arg-type]
                 BinConstraintD(res1[index], res2[index], op_eq),
                 BinConstraintD(res2[index], tensor_input2[index], op_eq),
             ]
@@ -1014,7 +1121,7 @@ def apply_padding(
     d11: list[DVar],
     d12: list[DVar],
     counter: int,
-):
+) -> tuple[Constraint, int]:
     """
     We are considering the possibility where one input has less dimensions than
     another input, so we apply padding to the broadcasted results
@@ -1080,7 +1187,7 @@ def apply_padding(
 
 def no_broadcast_dim_with_index(
     d1: list[DVar], d2: list[DVar], d3: list[DVar], d4: list[DVar], i: int
-):
+) -> Constraint:
     """
     Args:
         d1: input 1
@@ -1115,7 +1222,9 @@ def no_broadcast_dim_with_index(
     )
 
 
-def gen_lists_of_dims(num_tensors: int, dim_size: int, counter: int):
+def gen_lists_of_dims(
+    num_tensors: int, dim_size: int, counter: int
+) -> tuple[list[list[DVar]], int]:
     """
     Generate lists of DVar to represent tensor dimensions
     Args:
@@ -1144,7 +1253,7 @@ def create_equality_constraints_for_broadcasting(
     d2: list[DVar],
     d11: list[DVar],
     d12: list[DVar],
-):
+) -> list[BinConstraintT]:
     """
     Create equality constraints for when no broadcasting occurs
     Args:
@@ -1168,7 +1277,9 @@ def create_equality_constraints_for_broadcasting(
     return [e1_tensor, e11_tensor, e2_tensor, e12_tensor]
 
 
-def gen_consistency_constraints(constraint: Constraint, counter: int):
+def gen_consistency_constraints(
+    constraint: BinConstraintT, counter: int
+) -> tuple[list[Constraint], int]:
     """
     Args:
         constraint: Consistency constraint on tensors
@@ -1178,7 +1289,7 @@ def gen_consistency_constraints(constraint: Constraint, counter: int):
 
     """
 
-    all_constraints = []
+    all_constraints: list[Constraint] = []
 
     for i in range(1, MAX_TENSOR_RANK + 1):
         new_dims_rhs_1, counter = gen_tensor_dims(i, counter)
@@ -1203,7 +1314,9 @@ def gen_consistency_constraints(constraint: Constraint, counter: int):
     return all_constraints, counter
 
 
-def gen_greatest_upper_bound(constraint: TGreatestUpperBound, counter: int):
+def gen_greatest_upper_bound(
+    constraint: TGreatestUpperBound, counter: int
+) -> tuple[list[Constraint], int]:
     """
     Args:
         constraint: Greatest upper bound on tensors
@@ -1213,10 +1326,10 @@ def gen_greatest_upper_bound(constraint: TGreatestUpperBound, counter: int):
 
     """
 
-    all_constraints = []
+    all_constraints: list[Constraint] = []
 
     for i in range(1, MAX_TENSOR_RANK + 1):
-        c = []
+        c: list[Constraint] = []
         dims1, counter = gen_tensor_dims(i, counter)
         c1tensor = TensorType(dims1)
 
@@ -1249,7 +1362,7 @@ def gen_greatest_upper_bound(constraint: TGreatestUpperBound, counter: int):
 
 def generate_all_broadcasting_possibilities_no_padding(
     d1: list[DVar], d2: list[DVar], d11: list[DVar], d12: list[DVar]
-):
+) -> Constraint:
     """
     Generate broadcasting constraints assuming no padding. Broadcasting can happen at any dimension.
     We look at all combinations for all dimensions in d1 and d2
@@ -1279,7 +1392,7 @@ def generate_all_broadcasting_possibilities_no_padding(
 
 def gen_broadcasting_constraints(
     e1: TVar, e2: TVar, e11: TVar, e12: TVar, i: int, counter: int
-):
+) -> tuple[Constraint, Constraint, Constraint, list[BinConstraintD], int]:
     """
     Simulates broadcasting on e1 and e2 and returns the results
     respectively in e11 and e12. Because of gradual types,

--- a/torch/fx/experimental/migrate_gradual_types/transform_to_z3.py
+++ b/torch/fx/experimental/migrate_gradual_types/transform_to_z3.py
@@ -1,9 +1,29 @@
-# mypy: allow-untyped-defs
+from typing import Any, TypeAlias
+
+import torch
+
+
+__all__ = [
+    "evaluate_conditional_with_constraints",
+    "iterate_till_fixed_point",
+    "transform_algebraic_expression",
+    "transform_all_constraints",
+    "transform_all_constraints_trace_time",
+    "transform_dimension",
+    "transform_to_z3",
+    "transform_var",
+]
+
+
+# z3 is an optional dependency with no type stubs, so we use aliases for its types.
+_Z3Expr: TypeAlias = Any
+_Z3Result: TypeAlias = Any
 from torch.fx.experimental.migrate_gradual_types.constraint import (
     BinConstraintD,
     BinConstraintT,
     BVar,
     Conj,
+    Constraint,
     Disj,
     DVar,
     F,
@@ -32,7 +52,9 @@ from torch.fx.experimental.migrate_gradual_types.operation import (
     op_neq,
     op_sub,
 )
-from torch.fx.tensor_type import Dyn, TensorType
+from torch.fx.graph import Graph
+from torch.fx.node import Node
+from torch.fx.tensor_type import _DynType, Dyn, TensorType
 
 
 try:
@@ -46,7 +68,9 @@ try:
 
     HAS_Z3 = True
 
-    def transform_to_z3(constraint, counter, dimension_dict):
+    def transform_to_z3(
+        constraint: Constraint, counter: int, dimension_dict: dict[int, int]
+    ) -> tuple[_Z3Expr, int]:
         if isinstance(constraint, Conj):
             conjuncts = []
             for c in constraint.conjucts:
@@ -69,8 +93,16 @@ try:
 
         elif isinstance(constraint, BinConstraintT):
             if constraint.op == op_eq:
-                lhs, counter = transform_var(constraint.lhs, counter, dimension_dict)
-                rhs, counter = transform_var(constraint.rhs, counter, dimension_dict)
+                lhs, counter = transform_var(
+                    constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
+                )
+                rhs, counter = transform_var(
+                    constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
+                )
                 return (lhs == rhs), counter
 
             else:
@@ -80,7 +112,9 @@ try:
             if constraint.op == op_eq:
                 if isinstance(constraint.lhs, BVar) and is_bool_expr(constraint.rhs):
                     transformed_rhs, counter = transform_to_z3(
-                        constraint.rhs, counter, dimension_dict
+                        constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                        counter,
+                        dimension_dict,
                     )
                     transformed_lhs = z3.Bool(constraint.lhs.c)
                     return transformed_lhs == transformed_rhs, counter
@@ -88,10 +122,14 @@ try:
                 elif is_dim(constraint.lhs) and is_dim(constraint.rhs):
                     # with dimension transformations we consider the encoding
                     lhs, counter = transform_dimension(
-                        constraint.lhs, counter, dimension_dict
+                        constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                        counter,
+                        dimension_dict,
                     )
                     rhs, counter = transform_dimension(
-                        constraint.rhs, counter, dimension_dict
+                        constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                        counter,
+                        dimension_dict,
                     )
                     return lhs == rhs, counter
 
@@ -99,10 +137,14 @@ try:
                     # then we have an algebraic expression which means that we disregard the
                     # first element of the encoding
                     lhs, counter = transform_algebraic_expression(
-                        constraint.lhs, counter, dimension_dict
+                        constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                        counter,
+                        dimension_dict,
                     )
                     rhs, counter = transform_algebraic_expression(
-                        constraint.rhs, counter, dimension_dict
+                        constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                        counter,
+                        dimension_dict,
                     )
                     return lhs == rhs, counter
 
@@ -113,15 +155,19 @@ try:
                 if not is_dim(constraint.rhs):
                     raise AssertionError("Expected rhs to be a dimension")
                 lhs, counter = transform_dimension(
-                    constraint.lhs, counter, dimension_dict
+                    constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 rhs, counter = transform_dimension(
-                    constraint.rhs, counter, dimension_dict
+                    constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 if constraint.rhs == Dyn or constraint.lhs == Dyn:
                     if constraint.rhs == Dyn:
                         return lhs.arg(0) == 1, counter
-                    elif constraint.lhs == Dyn:
+                    else:
                         return rhs.arg(0) == 1, counter
 
                 # if one of the instances is a number
@@ -137,7 +183,7 @@ try:
                             counter,
                         )
 
-                    elif isinstance(constraint.rhs, int):
+                    else:
                         return (
                             z3.Or(
                                 [
@@ -173,10 +219,14 @@ try:
                 if not (is_dim(constraint.lhs) and is_dim(constraint.rhs)):
                     raise AssertionError("Expected both lhs and rhs to be dimensions")
                 lhs, counter = transform_algebraic_expression(
-                    constraint.lhs, counter, dimension_dict
+                    constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 rhs, counter = transform_algebraic_expression(
-                    constraint.rhs, counter, dimension_dict
+                    constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 return lhs <= rhs, counter
 
@@ -184,10 +234,14 @@ try:
                 if not (is_dim(constraint.lhs) and is_dim(constraint.rhs)):
                     raise AssertionError("Expected both lhs and rhs to be dimensions")
                 lhs, counter = transform_algebraic_expression(
-                    constraint.lhs, counter, dimension_dict
+                    constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 rhs, counter = transform_algebraic_expression(
-                    constraint.rhs, counter, dimension_dict
+                    constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 return lhs > rhs, counter
 
@@ -195,10 +249,14 @@ try:
                 if not (is_dim(constraint.lhs) and is_dim(constraint.rhs)):
                     raise AssertionError("Expected both lhs and rhs to be dimensions")
                 lhs, counter = transform_algebraic_expression(
-                    constraint.lhs, counter, dimension_dict
+                    constraint.lhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 rhs, counter = transform_algebraic_expression(
-                    constraint.rhs, counter, dimension_dict
+                    constraint.rhs,  # pyrefly: ignore[bad-argument-type]
+                    counter,
+                    dimension_dict,
                 )
                 return lhs < rhs, counter
 
@@ -208,7 +266,11 @@ try:
         else:
             raise NotImplementedError("Operation not yet implemented")
 
-    def transform_var(tensor, counter, dimension_dict):
+    def transform_var(
+        tensor: TVar | TensorType | _DynType,
+        counter: int,
+        dimension_dict: dict[int, int],
+    ) -> tuple[_Z3Expr, int]:
         """
         Transforms tensor variables to a format understood by z3
         Args:
@@ -217,7 +279,7 @@ try:
 
         """
         if isinstance(tensor, TensorType):
-            res = []
+            res: list[_Z3Expr] = []
             for t in tensor.__args__:
                 transformed, counter = transform_dimension(t, counter, dimension_dict)
                 res.append(transformed)
@@ -232,6 +294,10 @@ try:
                 return tensor_type.tensor3(res[0], res[1], res[2]), counter
             elif len(tensor.__args__) == 4:
                 return tensor_type.tensor4(res[0], res[1], res[2], res[3]), counter
+            else:
+                raise AssertionError(
+                    f"Unexpected tensor args length: {len(tensor.__args__)}"
+                )
 
         elif tensor == Dyn:
             return z3_dyn, counter
@@ -239,7 +305,12 @@ try:
         elif isinstance(tensor, TVar):
             return z3.Const(tensor.tvar, tensor_type), counter
 
-    def transform_dimension(dimension, counter, dimension_dict):
+        else:
+            raise NotImplementedError(f"Unsupported tensor type: {type(tensor)}")
+
+    def transform_dimension(
+        dimension: DVar | int | _DynType, counter: int, dimension_dict: dict[int, int]
+    ) -> tuple[_Z3Expr, int]:
         """
         Takes a dimension variable or a number and transforms it to a tuple
         according to our scheme
@@ -266,7 +337,14 @@ try:
                 dimension_dict[dimension.c] = counter
                 return D(z3.Int(counter), z3.Int(dimension.c)), counter
 
-    def transform_algebraic_expression(expr, counter, dimension_dict):
+        else:
+            raise NotImplementedError(f"Unsupported dimension type: {type(dimension)}")
+
+    def transform_algebraic_expression(
+        expr: DVar | int | _DynType | Prod | BinConstraintD,
+        counter: int,
+        dimension_dict: dict[int, int],
+    ) -> tuple[_Z3Expr, int]:
         """
         Transforms an algebraic expression to z3 format
         Args:
@@ -280,7 +358,11 @@ try:
             raise AssertionError("Expected algebraic expression or dimension")
 
         if is_dim(expr):
-            transformed, counter = transform_dimension(expr, counter, dimension_dict)
+            transformed, counter = transform_dimension(
+                expr,  # pyrefly: ignore[bad-argument-type]
+                counter,
+                dimension_dict,
+            )
             return transformed.arg(1), counter
 
         elif isinstance(expr, Prod):
@@ -294,13 +376,17 @@ try:
 
         elif is_algebraic_expression(expr):
             lhs, counter = transform_algebraic_expression(
-                expr.lhs, counter, dimension_dict
+                expr.lhs,  # pyrefly: ignore[missing-attribute]
+                counter,
+                dimension_dict,
             )
             rhs, counter = transform_algebraic_expression(
-                expr.rhs, counter, dimension_dict
+                expr.rhs,  # pyrefly: ignore[missing-attribute]
+                counter,
+                dimension_dict,
             )
 
-            if expr.op == op_sub:
+            if expr.op == op_sub:  # pyrefly: ignore[missing-attribute]
                 c = lhs - rhs
 
             elif expr.op == op_add:
@@ -323,31 +409,25 @@ try:
         else:
             raise RuntimeError
 
-    def transform_all_constraints(traced, counter=0):
+    def transform_all_constraints(traced: torch.nn.Module, counter: int = 0) -> _Z3Expr:
         """
         Given a trace, generates constraints and transforms them to z3 format
 
         """
-        dimension_dict = {}  # type: ignore[var-annotated]
+        dimension_dict: dict[int, int] = {}
 
         generator = ConstraintGenerator(traced)
         new_constraints, counter = generator.generate_constraints(counter)
 
-        # print(new_constraints.conjucts[0])
-        # print(*new_constraints.conjucts, sep='\n')
-
-        # transform precision, matching, consistency till obtaining a fixed point
         new_constraints, counter = iterate_till_fixed_point(new_constraints, counter)
-        # print(new_constraints)
-        # print(new_constraints.conjucts)
-        # new_constraints.conjucts = new_constraints.conjucts[:-1]
-        # print(*new_constraints.conjucts, sep='\n')
 
         transformed, counter = transform_to_z3(new_constraints, counter, dimension_dict)
         # print(transformed)
         return transformed
 
-    def iterate_till_fixed_point(constraints, counter):
+    def iterate_till_fixed_point(
+        constraints: Constraint, counter: int
+    ) -> tuple[Constraint, int]:
         """
         Transform constraints till reaching a fixed point
         """
@@ -357,7 +437,9 @@ try:
             constraints, counter = transform_constraint(constraints, counter)
         return constraints, counter
 
-    def transform_all_constraints_trace_time(tracer_root, graph, node, counter=0):
+    def transform_all_constraints_trace_time(
+        tracer_root: torch.nn.Module, graph: Graph, node: Node, counter: int = 0
+    ) -> tuple[_Z3Expr, _Z3Expr]:
         """
         Takes a node and a graph and generates two sets of constraints.
         One set constraints the node's constraints and another set
@@ -373,7 +455,7 @@ try:
         its negation.
 
         """
-        dimension_dict = {}  # type: ignore[var-annotated]
+        dimension_dict: dict[int, int] = {}
 
         generator = ConstraintGenerator(tracer_root, graph)
         new_constraints, counter = generator.generate_constraints(counter)
@@ -394,10 +476,14 @@ try:
         # we make sure the constraint is of the form:
         # c = b where b is a boolean expression
         # and we consider b (constraint.rhs) for transformation
+        if not isinstance(condition_constraint, BinConstraintD):
+            raise TypeError(type(condition_constraint))
         if not isinstance(condition_constraint.lhs, BVar):
             raise AssertionError(f"Expected BVar, got {type(condition_constraint.lhs)}")
         if not is_bool_expr(condition_constraint.rhs):
             raise AssertionError("Expected bool expression for rhs")
+        if not isinstance(condition_constraint.rhs, Constraint):
+            raise TypeError(type(condition_constraint.rhs))
         condition_constraint_rhs = condition_constraint.rhs
 
         # transform the condition constraint
@@ -420,8 +506,12 @@ try:
         )
 
     def evaluate_conditional_with_constraints(
-        tracer_root, graph, node, counter=0, user_constraints=None
-    ):
+        tracer_root: torch.nn.Module,
+        graph: Graph,
+        node: Node,
+        counter: int = 0,
+        user_constraints: _Z3Expr | None = None,
+    ) -> tuple[_Z3Result, _Z3Result]:
         """
         Given an IR and a node representing a conditional, evaluate the conditional
         and its negation

--- a/torch/fx/passes/regional_inductor.py
+++ b/torch/fx/passes/regional_inductor.py
@@ -1,6 +1,9 @@
+# mypy: allow-untyped-defs
+
+import contextlib
 import functools
 import logging
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from typing import Any, ParamSpec, TypeVar
 
 
@@ -25,6 +28,17 @@ def _dummy_wrapper(fn: Callable[_P, _R]) -> Callable[_P, _R]:
         return fn(*args, **kwargs)
 
     return inner
+
+
+@contextlib.contextmanager
+def _disable_remat_for_regional_subcompile() -> Iterator[None]:
+    # In torch.compile, regional_inductor subcompiles run after the enclosing
+    # non-strict full graph has already been partitioned, so any graph-SAC
+    # remat pass has already run before we reach this nested compile.
+    # Rerunning remat here can see stage-2-reordered backward nodes that
+    # violate remat's contiguous-backward-region assumption.
+    with torch._functorch.config.patch(remat_using_tags_for_fwd_loss_bwd_graph=False):
+        yield
 
 
 def _compile_submod(gm: torch.fx.GraphModule, prefix: str) -> torch.fx.GraphModule:
@@ -77,7 +91,10 @@ def _compile_submod(gm: torch.fx.GraphModule, prefix: str) -> torch.fx.GraphModu
                         f"Available config keys can be found in torch._inductor.config"
                     )
 
-            with inductor_config.patch(inductor_options):
+            with (
+                inductor_config.patch(inductor_options),
+                _disable_remat_for_regional_subcompile(),
+            ):
                 compiled_fn = torch._inductor.standalone_compile(
                     submod,
                     fake_inputs,

--- a/torch/fx/passes/regional_inductor_invoke_subgraph.py
+++ b/torch/fx/passes/regional_inductor_invoke_subgraph.py
@@ -6,7 +6,10 @@ import torch
 from torch._inductor.standalone_compile import AOTCompiledArtifact
 from torch.compiler._cache import CacheArtifactManager
 from torch.fx._compatibility import compatibility
-from torch.fx.passes.regional_inductor import _dummy_wrapper
+from torch.fx.passes.regional_inductor import (
+    _disable_remat_for_regional_subcompile,
+    _dummy_wrapper,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -65,6 +68,7 @@ def _compile_submod(
             torch._guards.tracing(context),
             CacheArtifactManager.with_fresh_cache(),
             torch._functorch.config.patch("bundled_autograd_cache", True),
+            _disable_remat_for_regional_subcompile(),
         ):
             # compile_fx can mutate gm
             gm = copy.deepcopy(submod)

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -238,6 +238,7 @@ class TracerBase:
 
                 if fx_traceback.GRADIENT_ACC_SPECIAL_STACK in stack_trace:
                     node.meta["is_gradient_acc"] = True
+                    node.meta["autograd_backward"] = True
 
             # Explicitly set the stack_trace, nn_module_stack and source_fn on the node.meta
             # If other meta fields are needed, they can be added here
@@ -262,6 +263,9 @@ class TracerBase:
                     node.meta["custom"] = replay_node.meta.get("custom")
                 if "stack_trace" in replay_node.meta:
                     node.stack_trace = replay_node.meta.get("stack_trace")
+
+            if current_meta.get("autograd_backward", False):
+                node.meta["autograd_backward"] = True
 
         elif self.module_stack:
             node.meta["nn_module_stack"] = copy.copy(self.module_stack)

--- a/torch/fx/tensor_type.py
+++ b/torch/fx/tensor_type.py
@@ -1,8 +1,16 @@
-from collections.abc import Sequence
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
 
 from torch.fx.experimental.unification import Var  # type: ignore[attr-defined]
 
 from ._compatibility import compatibility
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from torch.fx.experimental.migrate_gradual_types.constraint import DVar
 
 
 __all__ = ["Dyn", "TensorType", "is_consistent", "is_more_precise"]
@@ -18,7 +26,9 @@ class TensorType:
                 return torch.add(x, y)
     """
 
-    def __init__(self, dim: Sequence[object]) -> None:
+    __args__: Sequence[DVar | int | _DynType]
+
+    def __init__(self, dim: Sequence[Any]) -> None:
         self.__origin__ = TensorType
         self.__args__ = dim
 
@@ -32,7 +42,7 @@ class TensorType:
             return False
 
     @staticmethod
-    def __class_getitem__(*args: object) -> "TensorType":
+    def __class_getitem__(*args: object) -> TensorType:
         if len(args) == 1 and isinstance(args[0], tuple):
             args = args[0]
         return TensorType(tuple(args))

--- a/torch/fx/traceback.py
+++ b/torch/fx/traceback.py
@@ -395,6 +395,38 @@ def annotate_fn(
     return decorator
 
 
+@contextmanager
+def _set_autograd_backward(enable: bool = True) -> Iterator[None]:
+    global current_meta
+
+    had_autograd_backward = "autograd_backward" in current_meta
+    old_autograd_backward = current_meta.get("autograd_backward", False)
+
+    if enable:
+        _mark_autograd_backward()
+    try:
+        yield
+    finally:
+        if had_autograd_backward:
+            current_meta["autograd_backward"] = old_autograd_backward
+        else:
+            _reset_autograd_backward()
+
+
+@compatibility(is_backward_compatible=False)
+def _mark_autograd_backward() -> None:
+    global current_meta
+
+    current_meta["autograd_backward"] = True
+
+
+@compatibility(is_backward_compatible=False)
+def _reset_autograd_backward() -> None:
+    global current_meta
+
+    current_meta.pop("autograd_backward", None)
+
+
 @compatibility(is_backward_compatible=False)
 def set_grad_fn_seq_nr(seq_nr: int) -> None:
     global current_meta

--- a/torch/nativert/executor/PlacementUtils.cpp
+++ b/torch/nativert/executor/PlacementUtils.cpp
@@ -22,6 +22,5 @@ bool isSameDevice(const c10::Device& a, const c10::Device& b) {
     return b.is_mtia();
   }
   TORCH_CHECK(false, "isSameDevice: Unsupported device type ", a, " and ", b);
-  return false;
 }
 } // namespace torch::nativert

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -25,7 +25,7 @@ from torch.testing._internal.common_nn import (
     nllloss_reference, nlllossNd_reference, smoothl1loss_reference, softmarginloss_reference, get_reduction)
 from torch.testing._internal.common_utils import (
     freeze_rng_state, skipIfMPS, GRADCHECK_NONDET_TOL, TEST_WITH_ROCM, IS_WINDOWS,
-    skipIfTorchDynamo)
+    skipIfTorchDynamo, skipIfXpu)
 from types import ModuleType
 import operator
 
@@ -3977,6 +3977,8 @@ module_db: list[ModuleInfo] = [
                    # Not implemented for chalf on CPU
                    DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
                                 dtypes=(torch.chalf,), device_type='cuda'),
+                   DecorateInfo(skipIfXpu, 'TestModule', 'test_cpu_gpu_parity',
+                                dtypes=(torch.chalf,), device_type='xpu'),
                ),
                decorators=(
                    DecorateInfo(precisionOverride({torch.float32: 1e-04}), 'TestModule', 'test_memory_format'),
@@ -3996,7 +3998,7 @@ module_db: list[ModuleInfo] = [
                    # Not implemented for chalf on CPU
                    DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
                                 dtypes=(torch.chalf,), device_type='cuda'),
-                   DecorateInfo(unittest.expectedFailure, 'TestModule', 'test_cpu_gpu_parity',
+                   DecorateInfo(skipIfXpu, 'TestModule', 'test_cpu_gpu_parity',
                                 dtypes=(torch.chalf,), device_type='xpu'),
                ),
                decorators=(


### PR DESCRIPTION
Profiler unit tests were calling `os.environ["key"] = "value"` to change local behavior. But that changes the testing processes environment, polluting other tests.

This causes strange failures, where running `python -m pytest test/profiler/test_memory_profiler.py` would succeed, but then tests in that file would fail when all tests were run with `python -m pytest test/profiler/`. Using `unittest.mock.patch` ensures these changes are isolated.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @mcarilli @ptrblck @leslie-fang-intel @EikanWang @voznesenskym @penguinwu @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98