### PR TITLE
Refactor FakeTensorMode._dispatch_impl into named phases

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -85,8 +85,6 @@ CONSTANT_NUMEL_LIMIT = 1
 
 RECURSION_COUNT = 0
 # Internal sentinels shared across the extracted dispatch helpers.
-# `_DISPATCH_UNHANDLED` means a phase intentionally declined to handle an op,
-# while `_NO_REAL_OUT` marks the absence of a propagated real-tensor result.
 _DISPATCH_UNHANDLED = object()
 _NO_REAL_OUT = object()
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -84,6 +84,8 @@ aten = torch._ops.ops.aten
 CONSTANT_NUMEL_LIMIT = 1
 
 RECURSION_COUNT = 0
+_DISPATCH_UNHANDLED = object()
+_NO_REAL_OUT = object()
 
 
 # Check if device type supports device index
@@ -141,6 +143,17 @@ class UnsupportedMutationAliasingException(RuntimeError):
 @dataclass
 class MetadataMismatchError(RuntimeError):
     reason: str
+
+
+@dataclass(frozen=True)
+class _RealTensorPropagationState:
+    real_out: object = _NO_REAL_OUT
+    real_args: Sequence[object] | None = None
+    real_kwargs: Mapping[str, object] | None = None
+
+    @property
+    def has_real_out(self) -> bool:
+        return self.real_out is not _NO_REAL_OUT
 
 
 class FakeTensorTLS(threading.local):
@@ -2432,139 +2445,112 @@ class FakeTensorMode(TorchDispatchMode):
             _clear_pending_unbacked()
         return pytree.tree_unflatten(fake_leaves, fake_spec)
 
-    def _dispatch_impl(
+    def _check_unrecognized_subclass(
+        self, flat_args: Sequence[object]
+    ) -> object | None:
+        if not _check_for_subclass(flat_args):
+            return None
+
+        unrecognized_types = [type(x) for x in flat_args if _check_for_subclass_arg(x)]
+        not_implemented_log.debug(
+            "FakeTensorMode unrecognized subclass(es): %s", unrecognized_types
+        )
+        return NotImplemented
+
+    def _should_avoid_device_init(
+        self, func: OpOverload, kwargs: Mapping[str, object]
+    ) -> bool:
+        if not self.avoid_device_init:
+            return False
+
+        if (
+            func is torch.ops.aten._to_copy.default
+            and "device" in kwargs
+            and kwargs["device"].type != "cpu"  # type: ignore[attr-defined]
+        ):
+            return True
+        return func is torch.ops.prims.device_put.default
+
+    def _try_constant_propagation(
         self,
         func: OpOverload,
-        types: Sequence[type],
         args: Sequence[object],
         kwargs: Mapping[str, object],
+        *,
+        flat_args: Sequence[object],
+        args_spec: TreeSpec,
+        flat_arg_fake_tensors: Sequence[FakeTensor],
+        has_symbolic_sizes: bool,
+        is_lift_func: bool,
+        avoiding_device_init: bool,
     ) -> FakeTensor | None:
-        from torch._higher_order_ops.utils import registered_hop_fake_fns
-
-        flat_args, args_spec = pytree.tree_flatten((args, kwargs))
-
-        # DO NOT PUT LOGIC BEFORE UNRECOGNIZED TYPE CHECKING
-        # We must throw NotImplemented in case of unrecognized types to handle subclasses.
-        # Throwing the exception will pass the control to the next __torch_dispatch__.
-        # See [subclass inputs] below
-        # NB: If you're seeing a mysterious infinite loop involving fake
-        # tensor, it might be related to this line.  Though I'm not sure
-        # how you'll know to read this comment, as this line won't show up
-        # in the stack trace.
-        has_unrecognized_types = _check_for_subclass(flat_args)
-        if has_unrecognized_types:
-            unrecognized_types = [
-                type(x) for x in flat_args if _check_for_subclass_arg(x)
-            ]
-            not_implemented_log.debug(
-                "FakeTensorMode unrecognized subclass(es): %s", unrecognized_types
-            )
-            return NotImplemented
-
-        flat_arg_fake_tensors = [t for t in flat_args if self.is_our_fake(t)]
-        has_symbolic_sizes = any(
-            i._has_symbolic_sizes_strides for i in flat_arg_fake_tensors
-        ) or any(isinstance(a, SymInt) for a in flat_args)
-
-        converter = self.fake_tensor_converter
-
-        is_lift_func = func in self.lift_fns
-
-        # If we are trying to avoid device init, then we need to avoid constant
-        # prop on constant tensors for ops that change devices.
-        avoiding_device_init = False
-        if self.avoid_device_init:
-            if (
-                func is torch.ops.aten._to_copy.default
-                and "device" in kwargs
-                and kwargs["device"].type != "cpu"  # type: ignore[attr-defined]
-            ):
-                avoiding_device_init = True
-            if func is torch.ops.prims.device_put.default:
-                avoiding_device_init = True
-
-        # skip const prop for aten._to_copy if
-        # 1. input tensor is on "meta" device
-        # 2. destination device is unavailable, captured by `avoiding_device_init`
         device_conversion_skip_const_prop = (
             func is torch.ops.aten._to_copy.default
             and isinstance(args[0], torch.Tensor)
             and args[0].device.type == "meta"
         ) or avoiding_device_init
 
-        # To constant propagate through these functions:
-        # 1, If this is a lift due to a torch.tensor call,
-        #    the input tensor is guaranteed to be a
-        #    constant, so we keep a copy of the original argument along so
-        #    we can query it if we're asked to item() it at some later point.
-        #    (Note that you can always call a lift fn manually, so we do
-        #    have to check if there are any fake tensors!)
-        # 2, Some functions that allow Python numbers to bind to Tensors, e.g, torch.div
-        if (is_lift_func and not flat_arg_fake_tensors) or (
+        should_const_prop = (is_lift_func and not flat_arg_fake_tensors) or (
             should_allow_numbers_as_tensors(func)
             and not has_symbolic_sizes
             and not flat_arg_fake_tensors
             and not device_conversion_skip_const_prop
-        ):
-            if not all(t.constant is not None for t in flat_arg_fake_tensors):
-                raise AssertionError(
-                    f"{func} should not have fake inputs without constants"
-                )
-            const_flat_args = [
-                a.constant if self.is_our_fake(a) else a for a in flat_args
-            ]
-            const_args, const_kwargs = pytree.tree_unflatten(const_flat_args, args_spec)
-            out = func(*const_args, **const_kwargs)
-            if type(out) is Tensor and self.may_turn_const(out):
-                # NB: not in_kernel_invocation_manager because we're doing real
-                # compute here
-                # NB: no_dispatch() here is VERY DANGEROUS (like, segfault
-                # dangerous) if this is actually a wrapper subclass tensor,
-                # therefore the exact type test above
-                with no_dispatch():
-                    out = out.clone()
-                return converter.from_real_tensor(self, out, make_constant=True)
-
-        # if we are in the dispatch mode, we will enter this function even if the inputs
-        # are not FakeTensors. For now, throw if any non-Fake Tensor inputs
-        # and just support constructors.
-
-        # this is generated from torch.tensor(), which does not use the
-        # dispatcher, to allow wrapper subclasses to wrap the new tensor
-        if is_lift_func:
-            if len(kwargs) != 0 or len(args) != 1:
-                raise AssertionError(
-                    f"Expected exactly one arg for lift func, got args={args} kwargs={kwargs}"
-                )
-
-            if type(args[0]) is Tensor:
-                return converter.from_real_tensor(self, args[0])
-
-        # Recompute flat_arg_fake_tensors here again in case some of the inputs
-        # were real tensors and fakified in validate_and_convert_non_fake_tensors
-        (flat_args, flat_arg_fake_tensors) = self.validate_and_convert_non_fake_tensors(
-            func, converter, flat_args, args_spec
         )
-        del args, kwargs  # Invalidated
+        if not should_const_prop:
+            return None
 
-        # The current constant handling only support tracing systems
-        # (aot autograd, torchdynamo) where each operation is run consecutively.
-        # Because each operation is run in order, we can trace out and support
-        # sequences like: x = torch.tensor(0.); y = x.add_(1)
-        # Whenever a constant is written to but with inputs that cannot be evaluated
-        # statically, such as random_(), we invalidate all constants that alias the input
-        # We will rely on functionalization for use of fake tensors constants as persistent
-        # objects on an FX Graph.
+        if not all(t.constant is not None for t in flat_arg_fake_tensors):
+            raise AssertionError(f"{func} should not have fake inputs without constants")
 
+        const_flat_args = [a.constant if self.is_our_fake(a) else a for a in flat_args]
+        const_args, const_kwargs = pytree.tree_unflatten(const_flat_args, args_spec)
+        out = func(*const_args, **const_kwargs)
+        if type(out) is not Tensor or not self.may_turn_const(out):
+            return None
+
+        # NB: not in_kernel_invocation_manager because we're doing real
+        # compute here
+        # NB: no_dispatch() here is VERY DANGEROUS (like, segfault
+        # dangerous) if this is actually a wrapper subclass tensor,
+        # therefore the exact type test above
+        with no_dispatch():
+            out = out.clone()
+        return self.fake_tensor_converter.from_real_tensor(
+            self, out, make_constant=True
+        )
+
+    def _try_lift(
+        self,
+        func: OpOverload,
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+    ) -> FakeTensor | None:
+        if func not in self.lift_fns:
+            return None
+
+        if len(kwargs) != 0 or len(args) != 1:
+            raise AssertionError(
+                f"Expected exactly one arg for lift func, got args={args} kwargs={kwargs}"
+            )
+
+        if type(args[0]) is Tensor:
+            return self.fake_tensor_converter.from_real_tensor(self, args[0])
+        return None
+
+    def _try_constant_propagation_on_fake_inputs(
+        self,
+        func: OpOverload,
+        *,
+        flat_args: Sequence[object],
+        args_spec: TreeSpec,
+        flat_arg_fake_tensors: Sequence[FakeTensor],
+        has_symbolic_sizes: bool,
+        avoiding_device_init: bool,
+    ) -> object:
         all_constant = all(e.constant is not None for e in flat_arg_fake_tensors)
-        if (
+        if not (
             isinstance(func, torch._ops.OpOverload)
             and torch.Tag.nondeterministic_seeded not in func.tags
-            # We dispatch size/stride/numel on the FakeTensor not its constant, so bail on inplace_view.
-            # Example: fake_a.transpose_(0,1) would mutate fake_a.constant in-place, changing its
-            # shape from (2,3) to (3,2), while fake_a.shape still reports (2,3) → divergence.
-            # However, detach_ is safe: it only mutates requires_grad (not shape/stride/data),
-            # and constants are used purely for their values, not autograd.
             and (
                 torch.Tag.inplace_view not in func.tags or func is aten.detach_.default
             )
@@ -2574,123 +2560,104 @@ class FakeTensorMode(TorchDispatchMode):
             and not avoiding_device_init
             and func is not aten._nested_tensor_from_tensor_list.default
         ):
-            const_flat_args = [
-                a.constant if self.is_our_fake(a) else a for a in flat_args
-            ]
-            const_args, const_kwargs = pytree.tree_unflatten(const_flat_args, args_spec)
+            return _DISPATCH_UNHANDLED
 
-            # NB: not in_kernel_invocation_manager(self) as we want to do REAL
-            # compute
-            with no_dispatch():
-                out = func(*const_args, **const_kwargs)
+        const_flat_args = [a.constant if self.is_our_fake(a) else a for a in flat_args]
+        const_args, const_kwargs = pytree.tree_unflatten(const_flat_args, args_spec)
 
-            flat_out = pytree.tree_leaves(out)
-            flat_out_tensors = [t for t in flat_out if isinstance(t, Tensor)]
-            all_constant = all(self.may_turn_const(t) for t in flat_out_tensors)
+        # NB: not in_kernel_invocation_manager(self) as we want to do REAL
+        # compute
+        with no_dispatch():
+            out = func(*const_args, **const_kwargs)
 
-            if all_constant:
-                return pytree.tree_map_only(
-                    Tensor,
-                    lambda t: converter.from_real_tensor(self, t, make_constant=True),
-                    out,
-                )
+        flat_out = pytree.tree_leaves(out)
+        flat_out_tensors = [t for t in flat_out if isinstance(t, Tensor)]
+        if all(self.may_turn_const(t) for t in flat_out_tensors):
+            return pytree.tree_map_only(
+                Tensor,
+                lambda t: self.fake_tensor_converter.from_real_tensor(
+                    self, t, make_constant=True
+                ),
+                out,
+            )
 
-            # we weren't able to turn outputs to constants,
-            # so invalidate all constants that might be aliases of the outputs
-            for ten in flat_out_tensors:
-                converter.invalidate_constant_aliases(ten)
+        # We weren't able to turn outputs to constants, so invalidate all
+        # constants that might be aliases of the outputs.
+        for ten in flat_out_tensors:
+            self.fake_tensor_converter.invalidate_constant_aliases(ten)
+        return _DISPATCH_UNHANDLED
 
-        # we are falling through to running non constant tensors, any input constant that
-        # is written to must be invalidated
-        args, kwargs = pytree.tree_unflatten(flat_args, args_spec)
+    def _maybe_dispatch_higher_order_operator(
+        self,
+        func: OpOverload,
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+    ) -> tuple[bool, object]:
+        from torch._higher_order_ops.utils import registered_hop_fake_fns
 
-        if (
+        if not (
             isinstance(func, torch._ops.HigherOrderOperator)
             and func in registered_hop_fake_fns
         ):
-            # Reenable the fake tensor mode for the registered fake function
-            maybe_ignore_fresh_unbacked_symbols = (
-                contextlib.nullcontext
-                if self.shape_env is None
-                else self.shape_env.ignore_fresh_unbacked_symbols
-            )
+            return False, None
 
-            with self, maybe_ignore_fresh_unbacked_symbols():
-                return registered_hop_fake_fns[func](*args, **kwargs)
+        maybe_ignore_fresh_unbacked_symbols = (
+            contextlib.nullcontext
+            if self.shape_env is None
+            else self.shape_env.ignore_fresh_unbacked_symbols
+        )
+        with self, maybe_ignore_fresh_unbacked_symbols():
+            return True, registered_hop_fake_fns[func](*args, **kwargs)
 
-        self.invalidate_written_to_constants(func, flat_arg_fake_tensors, args, kwargs)
+    def _has_unresolved_real_tensor_prop_inputs(
+        self, flat_args: Sequence[object]
+    ) -> bool:
+        from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 
-        def maybe_to_real_tensor(
-            t: T,
-        ) -> T | Tensor | torch._C.ScriptObject | None:
-            if isinstance(t, FakeTensor):
-                return t.real_tensor
-            elif isinstance(t, py_sym_types):
-                if self.shape_env is None:
-                    raise AssertionError(
-                        "self.shape_env must not be None for symbolic types"
-                    )
-                return t.node.pytype(
-                    t.node.expr.xreplace(self.shape_env.backed_var_to_val).xreplace(
-                        self.shape_env.real_tensor_prop_unbacked_vals
-                    )
+        return any(
+            (
+                isinstance(a, py_sym_types)
+                and (syms := free_unbacked_symbols(a))
+                and self.shape_env is not None
+                and any(
+                    s not in self.shape_env.real_tensor_prop_unbacked_vals
+                    for s in syms
                 )
-            elif isinstance(t, FakeScriptObject):
-                return t.real_obj
-            else:
-                return t
-
-        from torch.fx.experimental.symbolic_shapes import (
-            compute_unbacked_bindings,
-            free_unbacked_symbols,
+            )
+            for a in flat_args
         )
 
-        nil = object()
-
-        real_out = nil
-        if (
-            self.propagate_real_tensors
-            and all(e.real_tensor is not None for e in flat_arg_fake_tensors)
-            and not any(
-                (
-                    isinstance(a, py_sym_types)
-                    and (syms := free_unbacked_symbols(a))
-                    and self.shape_env is not None
-                    and any(
-                        s not in self.shape_env.real_tensor_prop_unbacked_vals
-                        for s in syms
-                    )
+    def _maybe_to_real_tensor(
+        self, t: T
+    ) -> T | Tensor | torch._C.ScriptObject | None:
+        if isinstance(t, FakeTensor):
+            return t.real_tensor
+        if isinstance(t, py_sym_types):
+            if self.shape_env is None:
+                raise AssertionError("self.shape_env must not be None for symbolic types")
+            return t.node.pytype(
+                t.node.expr.xreplace(self.shape_env.backed_var_to_val).xreplace(
+                    self.shape_env.real_tensor_prop_unbacked_vals
                 )
-                for a in flat_args
             )
+        if isinstance(t, FakeScriptObject):
+            return t.real_obj
+        return t
+
+    def _prepare_real_tensor_propagation(
+        self,
+        func: OpOverload,
+        *,
+        flat_args: Sequence[object],
+        args_spec: TreeSpec,
+        flat_arg_fake_tensors: Sequence[FakeTensor],
+    ) -> _RealTensorPropagationState:
+        if not self.propagate_real_tensors:
+            return _RealTensorPropagationState()
+
+        if not all(e.real_tensor is not None for e in flat_arg_fake_tensors) or (
+            self._has_unresolved_real_tensor_prop_inputs(flat_args)
         ):
-            log.debug("propagate_real_tensors %s", func)
-            real_flat_args = [maybe_to_real_tensor(a) for a in flat_args]
-            real_args, real_kwargs = pytree.tree_unflatten(real_flat_args, args_spec)
-
-            is_builtin = library_utils.is_builtin(func)
-            if not is_builtin:
-                mutation_checker = library_utils.MutationChecker(
-                    func, real_flat_args, args_spec
-                )
-
-            try:
-                real_out = func(*real_args, **real_kwargs)
-            except ZeroDivisionError as exc:
-                # we shouldn't broadly catch all errors here;
-                # some come from real-kernel mutation/aliasing checks we want to run.
-                # add more exception types as needed.
-                log.debug(  # noqa: G200
-                    "real-tensor fallback failed for %s: %s; silently ignoring",
-                    func,
-                    exc,
-                )
-
-            if not is_builtin:
-                mutation_checker.check()  # type: ignore[possibly-undefined]
-                library_utils.check_aliasing_constraint(func._name, flat_args, real_out)
-
-        elif self.propagate_real_tensors:
             # This can happen occasionally legitimately, specifically when you
             # are inside the meta of a data dependent operation and you create
             # a tensor on an unbacked SymInt; at this point in time we don't
@@ -2706,95 +2673,162 @@ class FakeTensorMode(TorchDispatchMode):
                 if self.shape_env
                 else None,
             )
+            return _RealTensorPropagationState()
 
-        def maybe_propagate_real_tensors(fake_out: T) -> T:
-            import sympy
+        log.debug("propagate_real_tensors %s", func)
+        real_flat_args = [self._maybe_to_real_tensor(a) for a in flat_args]
+        real_args, real_kwargs = pytree.tree_unflatten(real_flat_args, args_spec)
 
-            log.debug("maybe_propagate_real_tensors %s", func)
+        real_out = _NO_REAL_OUT
+        is_builtin = library_utils.is_builtin(func)
+        if not is_builtin:
+            mutation_checker = library_utils.MutationChecker(
+                func, real_flat_args, args_spec
+            )
 
-            def go(t: object, real_t: Tensor) -> None:
-                if isinstance(t, FakeTensor):
-                    # NB: unconditionally overwrite
-                    log.debug(
-                        "maybe_propagate_real_tensors %s -> %s", id(t), id(real_t)
+        try:
+            real_out = func(*real_args, **real_kwargs)
+        except ZeroDivisionError as exc:
+            # We shouldn't broadly catch all errors here; some come from
+            # real-kernel mutation/aliasing checks we want to run.
+            log.debug(  # noqa: G200
+                "real-tensor fallback failed for %s: %s; silently ignoring",
+                func,
+                exc,
+            )
+
+        if not is_builtin:
+            mutation_checker.check()  # type: ignore[possibly-undefined]
+            library_utils.check_aliasing_constraint(func._name, flat_args, real_out)
+
+        return _RealTensorPropagationState(real_out, real_args, real_kwargs)
+
+    def _set_real_tensor_output(self, fake_value: object, real_value: object) -> None:
+        import sympy
+        from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
+
+        if isinstance(fake_value, FakeTensor):
+            log.debug(
+                "maybe_propagate_real_tensors %s -> %s",
+                id(fake_value),
+                id(real_value),
+            )
+            fake_value.real_tensor = cast(Tensor, real_value)
+            for sym, real_sym in zip(fake_value.size(), cast(Tensor, real_value).size()):
+                self._set_real_tensor_output(sym, real_sym)
+            for sym, real_sym in zip(
+                fake_value.stride(), cast(Tensor, real_value).stride()
+            ):
+                self._set_real_tensor_output(sym, real_sym)
+            self._set_real_tensor_output(
+                fake_value.storage_offset(), cast(Tensor, real_value).storage_offset()
+            )
+            return
+
+        if isinstance(fake_value, py_sym_types) and free_unbacked_symbols(fake_value):
+            if isinstance(fake_value.node.expr, sympy.Symbol):
+                if self.shape_env is None:
+                    raise AssertionError(
+                        "self.shape_env must not be None for symbolic Symbol"
                     )
-                    t.real_tensor = real_t
-                    for s, real_s in zip(t.size(), real_t.size()):
-                        go(s, real_s)  # type: ignore[arg-type]
-                    for s, real_s in zip(t.stride(), real_t.stride()):
-                        go(s, real_s)  # type: ignore[arg-type]
-                    go(t.storage_offset(), real_t.storage_offset())  # type: ignore[arg-type]
-                elif isinstance(t, py_sym_types) and free_unbacked_symbols(t):
-                    if isinstance(t.node.expr, sympy.Symbol):
-                        if self.shape_env is None:
-                            raise AssertionError(
-                                "self.shape_env must not be None for symbolic Symbol"
-                            )
-                        self.shape_env.set_real_tensor_prop_unbacked_vals(
-                            t.node.expr, real_t
-                        )
-                    elif (
-                        isinstance(s := t.node.expr, sympy.Eq)
-                        and isinstance(s.lhs, sympy.Symbol)
-                        and s.rhs == 1
-                    ):
-                        if self.shape_env is None:
-                            raise AssertionError(
-                                "self.shape_env must not be None for symbolic Eq"
-                            )
-
-                        self.shape_env.set_real_tensor_prop_unbacked_vals(s, real_t)
-
-            if real_out is not nil:
-                # cross check fake/real outputs, and optionally override fake kernel mismatches
-                if not torch._functorch.config.generate_fake_kernels_from_real_mismatches:
-                    self._maybe_infer_fake_kernel_from_pytree_out(
-                        func,
-                        (args, kwargs),
-                        (real_args, real_kwargs),
-                        fake_out,
-                        real_out,
+                self.shape_env.set_real_tensor_prop_unbacked_vals(
+                    fake_value.node.expr, real_value
+                )
+            elif (
+                isinstance(expr := fake_value.node.expr, sympy.Eq)
+                and isinstance(expr.lhs, sympy.Symbol)
+                and expr.rhs == 1
+            ):
+                if self.shape_env is None:
+                    raise AssertionError(
+                        "self.shape_env must not be None for symbolic Eq"
                     )
-                else:
-                    # this can override the output only when the flag is True
-                    fake_out = self._maybe_infer_fake_kernel_from_pytree_out(  # type: ignore[assignment]
-                        func,
-                        (args, kwargs),
-                        (real_args, real_kwargs),
-                        fake_out,
-                        real_out,
-                    )
+                self.shape_env.set_real_tensor_prop_unbacked_vals(expr, real_value)
 
-                # populate real_tensor_prop_unbacked_vals
-                if (
-                    not isinstance(fake_out, Tensor)
-                    and not isinstance(real_out, Tensor)
-                    and type(fake_out) is not type(real_out)
-                ):
-                    # This can happen when decompositions have different return types,
-                    # e.g. namedtuple vs. tuple vs. list.
-                    tree_map_(
-                        go,
-                        tuple(pytree.tree_flatten(fake_out)),
-                        tuple(pytree.tree_flatten(real_out)),
-                    )
-                else:
-                    tree_map_(go, fake_out, real_out)
+    def _bind_real_tensor_outputs(self, fake_out: object, real_out: object) -> None:
+        if (
+            not isinstance(fake_out, Tensor)
+            and not isinstance(real_out, Tensor)
+            and type(fake_out) is not type(real_out)
+        ):
+            # Decompositions may return namedtuple, tuple, or list variants for
+            # the same logical outputs, so walk flattened leaves in that case.
+            tree_map_(
+                self._set_real_tensor_output,
+                tuple(pytree.tree_flatten(fake_out)),
+                tuple(pytree.tree_flatten(real_out)),
+            )
+            return
 
-                # If a data-dependent op is used in a decomposition, we
-                # may need to get the unbacked settings "early"
-                # TODO: Is this really needed?
-                compute_unbacked_bindings(self.shape_env, fake_out, peek=True)
+        tree_map_(self._set_real_tensor_output, fake_out, real_out)
 
+    def _propagate_real_tensors(
+        self,
+        func: OpOverload,
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+        fake_out: T,
+        real_state: _RealTensorPropagationState,
+    ) -> T:
+        from torch.fx.experimental.symbolic_shapes import compute_unbacked_bindings
+
+        log.debug("maybe_propagate_real_tensors %s", func)
+        if not real_state.has_real_out:
             return fake_out
 
-        # Try for fastpath
-        if has_symbolic_sizes:
-            fast_impl = get_fast_op_impls().get(func)
-            if fast_impl is not None:
-                return maybe_propagate_real_tensors(fast_impl(self, *args, **kwargs))
+        if real_state.real_args is None or real_state.real_kwargs is None:
+            raise AssertionError("real tensor propagation state is missing inputs")
 
-        # If there's a Python meta, prefer that over the decomposition
+        if not torch._functorch.config.generate_fake_kernels_from_real_mismatches:
+            self._maybe_infer_fake_kernel_from_pytree_out(
+                func,
+                (args, kwargs),
+                (real_state.real_args, real_state.real_kwargs),
+                fake_out,
+                real_state.real_out,
+            )
+        else:
+            fake_out = self._maybe_infer_fake_kernel_from_pytree_out(  # type: ignore[assignment]
+                func,
+                (args, kwargs),
+                (real_state.real_args, real_state.real_kwargs),
+                fake_out,
+                real_state.real_out,
+            )
+
+        self._bind_real_tensor_outputs(fake_out, real_state.real_out)
+
+        # If a data-dependent op is used in a decomposition, we may need to get
+        # the unbacked settings "early".
+        # TODO: Is this really needed?
+        compute_unbacked_bindings(self.shape_env, fake_out, peek=True)
+        return fake_out
+
+    def _dispatch_to_fast_op_impl(
+        self,
+        func: OpOverload,
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+        *,
+        has_symbolic_sizes: bool,
+    ) -> object:
+        if not has_symbolic_sizes:
+            return _DISPATCH_UNHANDLED
+
+        fast_impl = get_fast_op_impls().get(func)
+        if fast_impl is None:
+            return _DISPATCH_UNHANDLED
+        return fast_impl(self, *args, **kwargs)
+
+    def _dispatch_to_decomposition_or_prim(
+        self,
+        func: OpOverload,
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+        *,
+        flat_arg_fake_tensors: Sequence[FakeTensor],
+        has_symbolic_sizes: bool,
+    ) -> object:
         from torch._decomp import meta_table
 
         if (
@@ -2806,7 +2840,6 @@ class FakeTensorMode(TorchDispatchMode):
         ):
             from torch._decomp import decomposition_table
 
-            # Prefer Python decompositions over C++ ones
             if func in decomposition_table and (
                 has_symbolic_sizes
                 or (
@@ -2817,57 +2850,74 @@ class FakeTensorMode(TorchDispatchMode):
                 )
             ):
                 with self:
-                    return maybe_propagate_real_tensors(
-                        decomposition_table[func](*args, **kwargs)
-                    )
+                    return decomposition_table[func](*args, **kwargs)
 
             with self:
-                # Decomposes CompositeImplicitAutograd ops
-                r = func.decompose(*args, **kwargs)
-                if r is not NotImplemented:
-                    return maybe_propagate_real_tensors(r)
+                result = func.decompose(*args, **kwargs)
+                if result is not NotImplemented:
+                    return result
 
-        # prims already wrap FakeTensor inputs to FakeTensor outputs
-        # and do device logic, we dont need do anything but run them
-        # and ensure that Meta kernels are dispatched to (see)
-        # Fake Tensor Dispatch Keys
-        # TODO - we should be use the prim aten impl
-        # TODO - fix prims complex ops
         if (
             "prims::" in func._schema.name
             and hasattr(func, "prim_meta_impl")
             and not stride_incorrect_op(func)
         ):
             with self:
-                return maybe_propagate_real_tensors(
-                    func.prim_meta_impl(*args, **kwargs)
-                )
+                return func.prim_meta_impl(*args, **kwargs)
+        return _DISPATCH_UNHANDLED
 
+    def _dispatch_to_profiled_fake_kernel(
+        self,
+        func: OpOverload,
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+    ) -> object:
         profiles = torch._dynamo.config._custom_ops_profile
-        if profiles is not None:
-            if func in profiles.data:
-                return profiles.generic_fake_kernel(func, self, *args, **kwargs)
+        if profiles is None or func not in profiles.data:
+            return _DISPATCH_UNHANDLED
+        return profiles.generic_fake_kernel(func, self, *args, **kwargs)
 
-        if (
+    def _maybe_infer_fake_kernel_from_real_out(
+        self,
+        func: OpOverload,
+        real_state: _RealTensorPropagationState,
+        *,
+        require_missing_fake_kernel: bool,
+    ) -> object:
+        if not (
             self.propagate_real_tensors
-            and real_out is not nil
+            and real_state.has_real_out
             and not library_utils.is_builtin(func)
             and self.shape_env is not None
         ):
-            # Automatically infer a Fake kernel if there isn't one.
-            if not library_utils.has_fake_kernel(func):
-                result = inferred_fake_kernel_from_real_out(self, func, real_out)
+            return _DISPATCH_UNHANDLED
 
-                dtrace_structured(
-                    "missing_fake_kernel",
-                    metadata_fn=lambda: {
-                        "op": str(func),
-                    },
-                )
-                return maybe_propagate_real_tensors(result)
+        if require_missing_fake_kernel and library_utils.has_fake_kernel(func):
+            return _DISPATCH_UNHANDLED
 
-        # Users can register FakeTensor rules for custom operators
-        # Call them if they exist.
+        result = inferred_fake_kernel_from_real_out(self, func, real_state.real_out)
+        dtrace_structured(
+            "missing_fake_kernel",
+            metadata_fn=lambda: {
+                "op": str(func),
+            },
+        )
+        return result
+
+    def _dispatch_to_registered_fake_impls(
+        self,
+        func: OpOverload,
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+        *,
+        real_state: _RealTensorPropagationState,
+    ) -> object:
+        result = self._maybe_infer_fake_kernel_from_real_out(
+            func, real_state, require_missing_fake_kernel=True
+        )
+        if result is not _DISPATCH_UNHANDLED:
+            return result
+
         maybe_fake_impl = torch._library.simple_registry.singleton.find(
             func.name()
         ).fake_impl.kernel
@@ -2875,78 +2925,241 @@ class FakeTensorMode(TorchDispatchMode):
             try:
                 ctx = torch._library.fake_impl.FakeImplCtx(self, func)
                 with torch._library.fake_impl.set_ctx_getter(lambda: ctx), self:
-                    result = maybe_fake_impl(*args, **kwargs)
-                    return maybe_propagate_real_tensors(result)
+                    return maybe_fake_impl(*args, **kwargs)
+            except MissingOpProfile as error:
+                result = self._maybe_infer_fake_kernel_from_real_out(
+                    func, real_state, require_missing_fake_kernel=False
+                )
+                if result is not _DISPATCH_UNHANDLED:
+                    return result
+                raise error
 
-            except MissingOpProfile as e:
-                # If we have a fake kernel registered generated from OpProfiles
-                # but there doesn't exist a profile for the existing inputs, and we are in
-                if (
-                    self.propagate_real_tensors
-                    and real_out is not nil
-                    and not library_utils.is_builtin(func)
-                    and self.shape_env is not None
-                ):
-                    result = inferred_fake_kernel_from_real_out(self, func, real_out)
-
-                    dtrace_structured(
-                        "missing_fake_kernel",
-                        metadata_fn=lambda: {
-                            "op": str(func),
-                        },
-                    )
-                    return maybe_propagate_real_tensors(result)
-                else:
-                    raise e
-
-        # special handling for funcs registered through `register_op_impl`,
-        # e.g., manipulating args on constructor calls to construct meta tensors
-        # and then afterwards wrapping them to a FakeTensor
         for run_impl_check, op_impl in op_implementations_checks:
             if run_impl_check(func):
                 # pyrefly: ignore [bad-argument-count]
                 op_impl_out = op_impl(self, func, *args, **kwargs)
                 if op_impl_out is not NotImplemented:
                     # pyrefly: ignore [bad-return]
-                    return maybe_propagate_real_tensors(op_impl_out)
+                    return op_impl_out
 
-        def maybe_run_unsafe_fallback(
-            error: RuntimeError | None = None,
-        ) -> FakeTensor | None:
-            # We infer the meta of a custom ops that return None to just
-            # return None. custom ops are not allowed to mutate metadata
-            # of their inputs, so this is safe.
-            if torch._library.utils.can_generate_trivial_fake_impl(func):
-                return None
-            # no meta kernel registered, fallback to kernel for the device
-            if has_symbolic_sizes or not self.can_run_unsafe_fallback(func):
-                raise UnsupportedOperatorException(func)
-            if error is None:
-                error = UnsupportedOperatorException(func)
-            return run_fallback_kernel(self, func, flat_args, args_spec, error)
+        return _DISPATCH_UNHANDLED
 
-        # Optimization: If there is no Meta kernel, it takes a surprisingly long
-        # amount of time to catch the NotImplementedError, so we check it here.
+    def _maybe_run_unsafe_fallback(
+        self,
+        func: OpOverload,
+        *,
+        flat_args: Sequence[object],
+        args_spec: TreeSpec,
+        has_symbolic_sizes: bool,
+        error: RuntimeError | None = None,
+    ) -> FakeTensor | None:
+        # We infer the meta of custom ops that return None to just return None.
+        # Custom ops are not allowed to mutate metadata of their inputs, so this
+        # is safe.
+        if torch._library.utils.can_generate_trivial_fake_impl(func):
+            return None
+
+        if has_symbolic_sizes or not self.can_run_unsafe_fallback(func):
+            raise UnsupportedOperatorException(func)
+
+        if error is None:
+            error = UnsupportedOperatorException(func)
+        return run_fallback_kernel(self, func, flat_args, args_spec, error)
+
+    def _dispatch_to_meta_or_fallback(
+        self,
+        func: OpOverload,
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+        *,
+        flat_args: Sequence[object],
+        args_spec: TreeSpec,
+        has_symbolic_sizes: bool,
+    ) -> object:
+        # Optimization: If there is no Meta kernel, it takes a surprisingly
+        # long time to catch the NotImplementedError, so we check it here.
         if not has_meta(func):
-            fallback = maybe_run_unsafe_fallback()
-            return maybe_propagate_real_tensors(fallback)
+            return self._maybe_run_unsafe_fallback(
+                func,
+                flat_args=flat_args,
+                args_spec=args_spec,
+                has_symbolic_sizes=has_symbolic_sizes,
+            )
 
-        # run kernel registered to meta for func, which include
-        # python meta registrations, prims, decomps, and c++ meta fns (structured kernels)
-        # It's possible that the kernel will return NotImplementedError
+        # Run the kernel registered to meta for func, which includes Python
+        # meta registrations, prims, decomps, and C++ meta fns.
         try:
             with in_kernel_invocation_manager(self):
-                r = func(*args, **kwargs)
+                result = func(*args, **kwargs)
         except NotImplementedError as not_implemented_error:
-            return maybe_run_unsafe_fallback(not_implemented_error)
+            return self._maybe_run_unsafe_fallback(
+                func,
+                flat_args=flat_args,
+                args_spec=args_spec,
+                has_symbolic_sizes=has_symbolic_sizes,
+                error=not_implemented_error,
+            )
         except Exception:
             log.exception("failed while attempting to run meta for %s", func)
             raise
 
-        return maybe_propagate_real_tensors(
-            self.wrap_meta_outputs_with_default_device_logic(
-                r, func, flat_args, device=kwargs.get("device")
-            )
+        return self.wrap_meta_outputs_with_default_device_logic(
+            result, func, flat_args, device=kwargs.get("device")
+        )
+
+    def _dispatch_to_op_impl(
+        self,
+        func: OpOverload,
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+        *,
+        flat_args: Sequence[object],
+        args_spec: TreeSpec,
+        flat_arg_fake_tensors: Sequence[FakeTensor],
+        has_symbolic_sizes: bool,
+        real_state: _RealTensorPropagationState,
+    ) -> object:
+        result = self._dispatch_to_fast_op_impl(
+            func, args, kwargs, has_symbolic_sizes=has_symbolic_sizes
+        )
+        if result is not _DISPATCH_UNHANDLED:
+            return self._propagate_real_tensors(func, args, kwargs, result, real_state)
+
+        result = self._dispatch_to_decomposition_or_prim(
+            func,
+            args,
+            kwargs,
+            flat_arg_fake_tensors=flat_arg_fake_tensors,
+            has_symbolic_sizes=has_symbolic_sizes,
+        )
+        if result is not _DISPATCH_UNHANDLED:
+            return self._propagate_real_tensors(func, args, kwargs, result, real_state)
+
+        result = self._dispatch_to_profiled_fake_kernel(func, args, kwargs)
+        if result is not _DISPATCH_UNHANDLED:
+            return result
+
+        result = self._dispatch_to_registered_fake_impls(
+            func, args, kwargs, real_state=real_state
+        )
+        if result is not _DISPATCH_UNHANDLED:
+            return self._propagate_real_tensors(func, args, kwargs, result, real_state)
+
+        result = self._dispatch_to_meta_or_fallback(
+            func,
+            args,
+            kwargs,
+            flat_args=flat_args,
+            args_spec=args_spec,
+            has_symbolic_sizes=has_symbolic_sizes,
+        )
+        return self._propagate_real_tensors(func, args, kwargs, result, real_state)
+
+    def _dispatch_impl(
+        self,
+        func: OpOverload,
+        types: Sequence[type],
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+    ) -> FakeTensor | None:
+        flat_args, args_spec = pytree.tree_flatten((args, kwargs))
+
+        # DO NOT PUT LOGIC BEFORE UNRECOGNIZED TYPE CHECKING
+        # We must throw NotImplemented in case of unrecognized types to handle subclasses.
+        # Throwing the exception will pass the control to the next __torch_dispatch__.
+        # See [subclass inputs] below
+        # NB: If you're seeing a mysterious infinite loop involving fake
+        # tensor, it might be related to this line.  Though I'm not sure
+        # how you'll know to read this comment, as this line won't show up
+        # in the stack trace.
+        unrecognized_subclass = self._check_unrecognized_subclass(flat_args)
+        if unrecognized_subclass is not None:
+            return unrecognized_subclass
+
+        flat_arg_fake_tensors = [t for t in flat_args if self.is_our_fake(t)]
+        has_symbolic_sizes = any(
+            i._has_symbolic_sizes_strides for i in flat_arg_fake_tensors
+        ) or any(isinstance(a, SymInt) for a in flat_args)
+
+        is_lift_func = func in self.lift_fns
+        avoiding_device_init = self._should_avoid_device_init(func, kwargs)
+
+        maybe_const_prop = self._try_constant_propagation(
+            func,
+            args,
+            kwargs,
+            flat_args=flat_args,
+            args_spec=args_spec,
+            flat_arg_fake_tensors=flat_arg_fake_tensors,
+            has_symbolic_sizes=has_symbolic_sizes,
+            is_lift_func=is_lift_func,
+            avoiding_device_init=avoiding_device_init,
+        )
+        if maybe_const_prop is not None:
+            return maybe_const_prop
+
+        # if we are in the dispatch mode, we will enter this function even if the inputs
+        # are not FakeTensors. For now, throw if any non-Fake Tensor inputs
+        # and just support constructors.
+
+        # this is generated from torch.tensor(), which does not use the
+        # dispatcher, to allow wrapper subclasses to wrap the new tensor
+        maybe_lift = self._try_lift(func, args, kwargs)
+        if maybe_lift is not None:
+            return maybe_lift
+
+        # Recompute flat_arg_fake_tensors here again in case some of the inputs
+        # were real tensors and fakified in validate_and_convert_non_fake_tensors
+        (flat_args, flat_arg_fake_tensors) = self.validate_and_convert_non_fake_tensors(
+            func, self.fake_tensor_converter, flat_args, args_spec
+        )
+
+        # The current constant handling only support tracing systems
+        # (aot autograd, torchdynamo) where each operation is run consecutively.
+        # Because each operation is run in order, we can trace out and support
+        # sequences like: x = torch.tensor(0.); y = x.add_(1)
+        # Whenever a constant is written to but with inputs that cannot be evaluated
+        # statically, such as random_(), we invalidate all constants that alias the input
+        # We will rely on functionalization for use of fake tensors constants as persistent
+        # objects on an FX Graph.
+        maybe_const_prop = self._try_constant_propagation_on_fake_inputs(
+            func,
+            flat_args=flat_args,
+            args_spec=args_spec,
+            flat_arg_fake_tensors=flat_arg_fake_tensors,
+            has_symbolic_sizes=has_symbolic_sizes,
+            avoiding_device_init=avoiding_device_init,
+        )
+        if maybe_const_prop is not _DISPATCH_UNHANDLED:
+            return maybe_const_prop
+
+        # we are falling through to running non constant tensors, any input constant that
+        # is written to must be invalidated
+        args, kwargs = pytree.tree_unflatten(flat_args, args_spec)
+
+        handled_hop, hop_result = self._maybe_dispatch_higher_order_operator(
+            func, args, kwargs
+        )
+        if handled_hop:
+            return hop_result
+
+        self.invalidate_written_to_constants(func, flat_arg_fake_tensors, args, kwargs)
+
+        real_state = self._prepare_real_tensor_propagation(
+            func,
+            flat_args=flat_args,
+            args_spec=args_spec,
+            flat_arg_fake_tensors=flat_arg_fake_tensors,
+        )
+        return self._dispatch_to_op_impl(
+            func,
+            args,
+            kwargs,
+            flat_args=flat_args,
+            args_spec=args_spec,
+            flat_arg_fake_tensors=flat_arg_fake_tensors,
+            has_symbolic_sizes=has_symbolic_sizes,
+            real_state=real_state,
         )
 
     # WARNING: DO NOT add any additional namespaces/operators here if they refer to operators

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2447,7 +2447,7 @@ class FakeTensorMode(TorchDispatchMode):
 
     def _check_unrecognized_subclass(
         self, flat_args: Sequence[object]
-    ) -> object | None:
+    ) -> types.NotImplementedType | None:
         if not _check_for_subclass(flat_args):
             return None
 
@@ -2500,7 +2500,9 @@ class FakeTensorMode(TorchDispatchMode):
             return None
 
         if not all(t.constant is not None for t in flat_arg_fake_tensors):
-            raise AssertionError(f"{func} should not have fake inputs without constants")
+            raise AssertionError(
+                f"{func} should not have fake inputs without constants"
+            )
 
         const_flat_args = [a.constant if self.is_our_fake(a) else a for a in flat_args]
         const_args, const_kwargs = pytree.tree_unflatten(const_flat_args, args_spec)
@@ -2615,26 +2617,23 @@ class FakeTensorMode(TorchDispatchMode):
         from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 
         return any(
-            (
-                isinstance(a, py_sym_types)
-                and (syms := free_unbacked_symbols(a))
-                and self.shape_env is not None
-                and any(
-                    s not in self.shape_env.real_tensor_prop_unbacked_vals
-                    for s in syms
-                )
+            isinstance(a, py_sym_types)
+            and (syms := free_unbacked_symbols(a))
+            and self.shape_env is not None
+            and any(
+                s not in self.shape_env.real_tensor_prop_unbacked_vals for s in syms
             )
             for a in flat_args
         )
 
-    def _maybe_to_real_tensor(
-        self, t: T
-    ) -> T | Tensor | torch._C.ScriptObject | None:
+    def _maybe_to_real_tensor(self, t: T) -> T | Tensor | torch._C.ScriptObject | None:
         if isinstance(t, FakeTensor):
             return t.real_tensor
         if isinstance(t, py_sym_types):
             if self.shape_env is None:
-                raise AssertionError("self.shape_env must not be None for symbolic types")
+                raise AssertionError(
+                    "self.shape_env must not be None for symbolic types"
+                )
             return t.node.pytype(
                 t.node.expr.xreplace(self.shape_env.backed_var_to_val).xreplace(
                     self.shape_env.real_tensor_prop_unbacked_vals
@@ -2714,7 +2713,9 @@ class FakeTensorMode(TorchDispatchMode):
                 id(real_value),
             )
             fake_value.real_tensor = cast(Tensor, real_value)
-            for sym, real_sym in zip(fake_value.size(), cast(Tensor, real_value).size()):
+            for sym, real_sym in zip(
+                fake_value.size(), cast(Tensor, real_value).size()
+            ):
                 self._set_real_tensor_output(sym, real_sym)
             for sym, real_sym in zip(
                 fake_value.stride(), cast(Tensor, real_value).stride()
@@ -2726,13 +2727,14 @@ class FakeTensorMode(TorchDispatchMode):
             return
 
         if isinstance(fake_value, py_sym_types) and free_unbacked_symbols(fake_value):
+            real_sym_value = cast(int | float | Tensor, real_value)
             if isinstance(fake_value.node.expr, sympy.Symbol):
                 if self.shape_env is None:
                     raise AssertionError(
                         "self.shape_env must not be None for symbolic Symbol"
                     )
                 self.shape_env.set_real_tensor_prop_unbacked_vals(
-                    fake_value.node.expr, real_value
+                    fake_value.node.expr, real_sym_value
                 )
             elif (
                 isinstance(expr := fake_value.node.expr, sympy.Eq)
@@ -2743,7 +2745,7 @@ class FakeTensorMode(TorchDispatchMode):
                     raise AssertionError(
                         "self.shape_env must not be None for symbolic Eq"
                     )
-                self.shape_env.set_real_tensor_prop_unbacked_vals(expr, real_value)
+                self.shape_env.set_real_tensor_prop_unbacked_vals(expr, real_sym_value)
 
     def _bind_real_tensor_outputs(self, fake_out: object, real_out: object) -> None:
         if (
@@ -2772,9 +2774,9 @@ class FakeTensorMode(TorchDispatchMode):
     ) -> T:
         from torch.fx.experimental.symbolic_shapes import compute_unbacked_bindings
 
-        log.debug("maybe_propagate_real_tensors %s", func)
         if not real_state.has_real_out:
             return fake_out
+        log.debug("maybe_propagate_real_tensors %s", func)
 
         if real_state.real_args is None or real_state.real_kwargs is None:
             raise AssertionError("real tensor propagation state is missing inputs")
@@ -2936,10 +2938,8 @@ class FakeTensorMode(TorchDispatchMode):
 
         for run_impl_check, op_impl in op_implementations_checks:
             if run_impl_check(func):
-                # pyrefly: ignore [bad-argument-count]
-                op_impl_out = op_impl(self, func, *args, **kwargs)
+                op_impl_out = cast(Any, op_impl)(self, func, *args, **kwargs)
                 if op_impl_out is not NotImplemented:
-                    # pyrefly: ignore [bad-return]
                     return op_impl_out
 
         return _DISPATCH_UNHANDLED
@@ -3004,7 +3004,10 @@ class FakeTensorMode(TorchDispatchMode):
             raise
 
         return self.wrap_meta_outputs_with_default_device_logic(
-            result, func, flat_args, device=kwargs.get("device")
+            result,
+            func,
+            flat_args,
+            device=cast(torch.device | None, kwargs.get("device")),
         )
 
     def _dispatch_to_op_impl(
@@ -3061,7 +3064,7 @@ class FakeTensorMode(TorchDispatchMode):
         types: Sequence[type],
         args: Sequence[object],
         kwargs: Mapping[str, object],
-    ) -> FakeTensor | None:
+    ) -> object:
         flat_args, args_spec = pytree.tree_flatten((args, kwargs))
 
         # DO NOT PUT LOGIC BEFORE UNRECOGNIZED TYPE CHECKING
@@ -3245,7 +3248,7 @@ class FakeTensorMode(TorchDispatchMode):
         r: object,
         func: OpOverload,
         flat_args: Sequence[object],
-        device: torch.device,
+        device: torch.device | None,
     ) -> PyTree:
         converter = self.fake_tensor_converter
 
@@ -3270,7 +3273,9 @@ class FakeTensorMode(TorchDispatchMode):
             if is_our_fake:
                 torch._check(
                     e.device == common_device,
-                    lambda: f"FakeTensor is wrapped to wrong device, found {e.device}, expected {common_device}",
+                    lambda: (
+                        f"FakeTensor is wrapped to wrong device, found {e.device}, expected {common_device}"
+                    ),
                 )
                 return cast(T, e)
             elif converter is not None:

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -84,6 +84,9 @@ aten = torch._ops.ops.aten
 CONSTANT_NUMEL_LIMIT = 1
 
 RECURSION_COUNT = 0
+# Internal sentinels shared across the extracted dispatch helpers.
+# `_DISPATCH_UNHANDLED` means a phase intentionally declined to handle an op,
+# while `_NO_REAL_OUT` marks the absence of a propagated real-tensor result.
 _DISPATCH_UNHANDLED = object()
 _NO_REAL_OUT = object()
 
@@ -154,6 +157,16 @@ class _RealTensorPropagationState:
     @property
     def has_real_out(self) -> bool:
         return self.real_out is not _NO_REAL_OUT
+
+
+@dataclass(frozen=True)
+class _DispatchState:
+    # Shared inputs/state for the extracted dispatch phases.
+    flat_args: Sequence[object]
+    args_spec: TreeSpec
+    flat_arg_fake_tensors: Sequence[FakeTensor]
+    has_symbolic_sizes: bool
+    avoiding_device_init: bool
 
 
 class FakeTensorTLS(threading.local):
@@ -1851,22 +1864,19 @@ class FakeTensorMode(TorchDispatchMode):
         func: OpOverload,
         args: Sequence[object],
         kwargs: Mapping[str, object],
-        output: FakeTensor | None,
+        output: object,
     ) -> None:
-        # Is this even possible? According to the signature this can be None but
-        # not `int`. So either the signature is a lie or (part of) this line is
-        # unnecessary...
-        if isinstance(output, (int, type(None))):
+        if isinstance(output, (int, torch.SymInt, type(None))):
             return
+
+        # Some ops return tuples of Tensors, but it's rare, so avoid the
+        # complexity of caching other output types.
+        if not isinstance(output, FakeTensor):
+            raise _BypassDispatchCache("non-FakeTensor output")
 
         # Check for symbolic content that should bypass caching - raises
         # _BypassDispatchCache if necessary.
         _validate_symbolic_output_for_caching(state, output)
-
-        # Some ops return tuples of Tensors, but it's rare, so avoid
-        # the complexity of caching other types.
-        if not isinstance(output, FakeTensor):
-            raise _BypassDispatchCache("non-FakeTensor output")
 
         # Avoid caching FakeTensors with constants attached since those
         # can be invalidated.
@@ -1893,12 +1903,15 @@ class FakeTensorMode(TorchDispatchMode):
         func: OpOverload,
         args: Sequence[object],
         kwargs: Mapping[str, object],
-        output: FakeTensor,
+        output: object,
     ) -> _DispatchCacheEntryOutputInfo:
         if isinstance(output, (int, torch.SymInt, type(None))):
             return _DispatchCacheEntryOutputInfo(
                 inplace_idx=None, metadata=None, view_idx=None, constant_value=output
             )
+
+        if not isinstance(output, FakeTensor):
+            raise AssertionError(f"Expected FakeTensor output, got {type(output)}")
 
         # If this is an in-place op, the entry records which input arg is aliased.
         for idx in range(len(args)):
@@ -1970,7 +1983,7 @@ class FakeTensorMode(TorchDispatchMode):
         func: OpOverload,
         args: Sequence[object],
         kwargs: Mapping[str, object],
-        output: FakeTensor | None,
+        output: object,
     ) -> _DispatchCacheValidEntry:
         """
         Make a cache entry object for the given 'output' Tensor. Raises
@@ -2477,35 +2490,39 @@ class FakeTensorMode(TorchDispatchMode):
         args: Sequence[object],
         kwargs: Mapping[str, object],
         *,
-        flat_args: Sequence[object],
-        args_spec: TreeSpec,
-        flat_arg_fake_tensors: Sequence[FakeTensor],
-        has_symbolic_sizes: bool,
+        dispatch_state: _DispatchState,
         is_lift_func: bool,
-        avoiding_device_init: bool,
     ) -> FakeTensor | None:
         device_conversion_skip_const_prop = (
             func is torch.ops.aten._to_copy.default
             and isinstance(args[0], torch.Tensor)
             and args[0].device.type == "meta"
-        ) or avoiding_device_init
+        ) or dispatch_state.avoiding_device_init
 
-        should_const_prop = (is_lift_func and not flat_arg_fake_tensors) or (
+        should_const_prop = (
+            is_lift_func and not dispatch_state.flat_arg_fake_tensors
+        ) or (
             should_allow_numbers_as_tensors(func)
-            and not has_symbolic_sizes
-            and not flat_arg_fake_tensors
+            and not dispatch_state.has_symbolic_sizes
+            and not dispatch_state.flat_arg_fake_tensors
             and not device_conversion_skip_const_prop
         )
         if not should_const_prop:
             return None
 
-        if not all(t.constant is not None for t in flat_arg_fake_tensors):
+        if not all(
+            t.constant is not None for t in dispatch_state.flat_arg_fake_tensors
+        ):
             raise AssertionError(
                 f"{func} should not have fake inputs without constants"
             )
 
-        const_flat_args = [a.constant if self.is_our_fake(a) else a for a in flat_args]
-        const_args, const_kwargs = pytree.tree_unflatten(const_flat_args, args_spec)
+        const_flat_args = [
+            a.constant if self.is_our_fake(a) else a for a in dispatch_state.flat_args
+        ]
+        const_args, const_kwargs = pytree.tree_unflatten(
+            const_flat_args, dispatch_state.args_spec
+        )
         out = func(*const_args, **const_kwargs)
         if type(out) is not Tensor or not self.may_turn_const(out):
             return None
@@ -2543,13 +2560,11 @@ class FakeTensorMode(TorchDispatchMode):
         self,
         func: OpOverload,
         *,
-        flat_args: Sequence[object],
-        args_spec: TreeSpec,
-        flat_arg_fake_tensors: Sequence[FakeTensor],
-        has_symbolic_sizes: bool,
-        avoiding_device_init: bool,
+        dispatch_state: _DispatchState,
     ) -> object:
-        all_constant = all(e.constant is not None for e in flat_arg_fake_tensors)
+        all_constant = all(
+            e.constant is not None for e in dispatch_state.flat_arg_fake_tensors
+        )
         if not (
             isinstance(func, torch._ops.OpOverload)
             and torch.Tag.nondeterministic_seeded not in func.tags
@@ -2557,15 +2572,19 @@ class FakeTensorMode(TorchDispatchMode):
                 torch.Tag.inplace_view not in func.tags or func is aten.detach_.default
             )
             and all_constant
-            and len(flat_arg_fake_tensors) != 0
-            and not has_symbolic_sizes
-            and not avoiding_device_init
+            and len(dispatch_state.flat_arg_fake_tensors) != 0
+            and not dispatch_state.has_symbolic_sizes
+            and not dispatch_state.avoiding_device_init
             and func is not aten._nested_tensor_from_tensor_list.default
         ):
             return _DISPATCH_UNHANDLED
 
-        const_flat_args = [a.constant if self.is_our_fake(a) else a for a in flat_args]
-        const_args, const_kwargs = pytree.tree_unflatten(const_flat_args, args_spec)
+        const_flat_args = [
+            a.constant if self.is_our_fake(a) else a for a in dispatch_state.flat_args
+        ]
+        const_args, const_kwargs = pytree.tree_unflatten(
+            const_flat_args, dispatch_state.args_spec
+        )
 
         # NB: not in_kernel_invocation_manager(self) as we want to do REAL
         # compute
@@ -2647,16 +2666,14 @@ class FakeTensorMode(TorchDispatchMode):
         self,
         func: OpOverload,
         *,
-        flat_args: Sequence[object],
-        args_spec: TreeSpec,
-        flat_arg_fake_tensors: Sequence[FakeTensor],
+        dispatch_state: _DispatchState,
     ) -> _RealTensorPropagationState:
         if not self.propagate_real_tensors:
             return _RealTensorPropagationState()
 
-        if not all(e.real_tensor is not None for e in flat_arg_fake_tensors) or (
-            self._has_unresolved_real_tensor_prop_inputs(flat_args)
-        ):
+        if not all(
+            e.real_tensor is not None for e in dispatch_state.flat_arg_fake_tensors
+        ) or self._has_unresolved_real_tensor_prop_inputs(dispatch_state.flat_args):
             # This can happen occasionally legitimately, specifically when you
             # are inside the meta of a data dependent operation and you create
             # a tensor on an unbacked SymInt; at this point in time we don't
@@ -2666,8 +2683,8 @@ class FakeTensorMode(TorchDispatchMode):
             log.debug(
                 "SKIPPED propagate_real_tensors %s(%s, %s) %s",
                 func,
-                flat_arg_fake_tensors,
-                flat_args,
+                dispatch_state.flat_arg_fake_tensors,
+                dispatch_state.flat_args,
                 self.shape_env.real_tensor_prop_unbacked_vals
                 if self.shape_env
                 else None,
@@ -2675,14 +2692,18 @@ class FakeTensorMode(TorchDispatchMode):
             return _RealTensorPropagationState()
 
         log.debug("propagate_real_tensors %s", func)
-        real_flat_args = [self._maybe_to_real_tensor(a) for a in flat_args]
-        real_args, real_kwargs = pytree.tree_unflatten(real_flat_args, args_spec)
+        real_flat_args = [
+            self._maybe_to_real_tensor(a) for a in dispatch_state.flat_args
+        ]
+        real_args, real_kwargs = pytree.tree_unflatten(
+            real_flat_args, dispatch_state.args_spec
+        )
 
         real_out = _NO_REAL_OUT
         is_builtin = library_utils.is_builtin(func)
         if not is_builtin:
             mutation_checker = library_utils.MutationChecker(
-                func, real_flat_args, args_spec
+                func, real_flat_args, dispatch_state.args_spec
             )
 
         try:
@@ -2698,12 +2719,15 @@ class FakeTensorMode(TorchDispatchMode):
 
         if not is_builtin:
             mutation_checker.check()  # type: ignore[possibly-undefined]
-            library_utils.check_aliasing_constraint(func._name, flat_args, real_out)
+            library_utils.check_aliasing_constraint(
+                func._name, dispatch_state.flat_args, real_out
+            )
 
         return _RealTensorPropagationState(real_out, real_args, real_kwargs)
 
     def _set_real_tensor_output(self, fake_value: object, real_value: object) -> None:
         import sympy
+
         from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
 
         if isinstance(fake_value, FakeTensor):
@@ -2812,9 +2836,9 @@ class FakeTensorMode(TorchDispatchMode):
         args: Sequence[object],
         kwargs: Mapping[str, object],
         *,
-        has_symbolic_sizes: bool,
+        dispatch_state: _DispatchState,
     ) -> object:
-        if not has_symbolic_sizes:
+        if not dispatch_state.has_symbolic_sizes:
             return _DISPATCH_UNHANDLED
 
         fast_impl = get_fast_op_impls().get(func)
@@ -2828,8 +2852,7 @@ class FakeTensorMode(TorchDispatchMode):
         args: Sequence[object],
         kwargs: Mapping[str, object],
         *,
-        flat_arg_fake_tensors: Sequence[FakeTensor],
-        has_symbolic_sizes: bool,
+        dispatch_state: _DispatchState,
     ) -> object:
         from torch._decomp import meta_table
 
@@ -2837,18 +2860,22 @@ class FakeTensorMode(TorchDispatchMode):
             func not in meta_table
             and not self.cpp_meta_supports_symint(func)
             and not (
-                has_symbolic_sizes and func in self._unbacked_special_fake_handling_ops
+                dispatch_state.has_symbolic_sizes
+                and func in self._unbacked_special_fake_handling_ops
             )
         ):
             from torch._decomp import decomposition_table
 
             if func in decomposition_table and (
-                has_symbolic_sizes
+                dispatch_state.has_symbolic_sizes
                 or (
                     # TODO: Remove these exclusions, so that we can remove
                     # this leg entirely
                     torch_decomp_decompositions(func)
-                    and all(not is_sparse_any(e) for e in flat_arg_fake_tensors)
+                    and all(
+                        not is_sparse_any(e)
+                        for e in dispatch_state.flat_arg_fake_tensors
+                    )
                 )
             ):
                 with self:
@@ -2948,9 +2975,7 @@ class FakeTensorMode(TorchDispatchMode):
         self,
         func: OpOverload,
         *,
-        flat_args: Sequence[object],
-        args_spec: TreeSpec,
-        has_symbolic_sizes: bool,
+        dispatch_state: _DispatchState,
         error: RuntimeError | None = None,
     ) -> FakeTensor | None:
         # We infer the meta of custom ops that return None to just return None.
@@ -2959,12 +2984,18 @@ class FakeTensorMode(TorchDispatchMode):
         if torch._library.utils.can_generate_trivial_fake_impl(func):
             return None
 
-        if has_symbolic_sizes or not self.can_run_unsafe_fallback(func):
+        if dispatch_state.has_symbolic_sizes or not self.can_run_unsafe_fallback(func):
             raise UnsupportedOperatorException(func)
 
         if error is None:
             error = UnsupportedOperatorException(func)
-        return run_fallback_kernel(self, func, flat_args, args_spec, error)
+        return run_fallback_kernel(
+            self,
+            func,
+            dispatch_state.flat_args,
+            dispatch_state.args_spec,
+            error,
+        )
 
     def _dispatch_to_meta_or_fallback(
         self,
@@ -2972,18 +3003,14 @@ class FakeTensorMode(TorchDispatchMode):
         args: Sequence[object],
         kwargs: Mapping[str, object],
         *,
-        flat_args: Sequence[object],
-        args_spec: TreeSpec,
-        has_symbolic_sizes: bool,
+        dispatch_state: _DispatchState,
     ) -> object:
         # Optimization: If there is no Meta kernel, it takes a surprisingly
         # long time to catch the NotImplementedError, so we check it here.
         if not has_meta(func):
             return self._maybe_run_unsafe_fallback(
                 func,
-                flat_args=flat_args,
-                args_spec=args_spec,
-                has_symbolic_sizes=has_symbolic_sizes,
+                dispatch_state=dispatch_state,
             )
 
         # Run the kernel registered to meta for func, which includes Python
@@ -2994,9 +3021,7 @@ class FakeTensorMode(TorchDispatchMode):
         except NotImplementedError as not_implemented_error:
             return self._maybe_run_unsafe_fallback(
                 func,
-                flat_args=flat_args,
-                args_spec=args_spec,
-                has_symbolic_sizes=has_symbolic_sizes,
+                dispatch_state=dispatch_state,
                 error=not_implemented_error,
             )
         except Exception:
@@ -3006,7 +3031,7 @@ class FakeTensorMode(TorchDispatchMode):
         return self.wrap_meta_outputs_with_default_device_logic(
             result,
             func,
-            flat_args,
+            dispatch_state.flat_args,
             device=cast(torch.device | None, kwargs.get("device")),
         )
 
@@ -3016,14 +3041,11 @@ class FakeTensorMode(TorchDispatchMode):
         args: Sequence[object],
         kwargs: Mapping[str, object],
         *,
-        flat_args: Sequence[object],
-        args_spec: TreeSpec,
-        flat_arg_fake_tensors: Sequence[FakeTensor],
-        has_symbolic_sizes: bool,
+        dispatch_state: _DispatchState,
         real_state: _RealTensorPropagationState,
     ) -> object:
         result = self._dispatch_to_fast_op_impl(
-            func, args, kwargs, has_symbolic_sizes=has_symbolic_sizes
+            func, args, kwargs, dispatch_state=dispatch_state
         )
         if result is not _DISPATCH_UNHANDLED:
             return self._propagate_real_tensors(func, args, kwargs, result, real_state)
@@ -3032,8 +3054,7 @@ class FakeTensorMode(TorchDispatchMode):
             func,
             args,
             kwargs,
-            flat_arg_fake_tensors=flat_arg_fake_tensors,
-            has_symbolic_sizes=has_symbolic_sizes,
+            dispatch_state=dispatch_state,
         )
         if result is not _DISPATCH_UNHANDLED:
             return self._propagate_real_tensors(func, args, kwargs, result, real_state)
@@ -3052,9 +3073,7 @@ class FakeTensorMode(TorchDispatchMode):
             func,
             args,
             kwargs,
-            flat_args=flat_args,
-            args_spec=args_spec,
-            has_symbolic_sizes=has_symbolic_sizes,
+            dispatch_state=dispatch_state,
         )
         return self._propagate_real_tensors(func, args, kwargs, result, real_state)
 
@@ -3086,17 +3105,20 @@ class FakeTensorMode(TorchDispatchMode):
 
         is_lift_func = func in self.lift_fns
         avoiding_device_init = self._should_avoid_device_init(func, kwargs)
+        dispatch_state = _DispatchState(
+            flat_args=flat_args,
+            args_spec=args_spec,
+            flat_arg_fake_tensors=flat_arg_fake_tensors,
+            has_symbolic_sizes=has_symbolic_sizes,
+            avoiding_device_init=avoiding_device_init,
+        )
 
         maybe_const_prop = self._try_constant_propagation(
             func,
             args,
             kwargs,
-            flat_args=flat_args,
-            args_spec=args_spec,
-            flat_arg_fake_tensors=flat_arg_fake_tensors,
-            has_symbolic_sizes=has_symbolic_sizes,
+            dispatch_state=dispatch_state,
             is_lift_func=is_lift_func,
-            avoiding_device_init=avoiding_device_init,
         )
         if maybe_const_prop is not None:
             return maybe_const_prop
@@ -3114,7 +3136,15 @@ class FakeTensorMode(TorchDispatchMode):
         # Recompute flat_arg_fake_tensors here again in case some of the inputs
         # were real tensors and fakified in validate_and_convert_non_fake_tensors
         (flat_args, flat_arg_fake_tensors) = self.validate_and_convert_non_fake_tensors(
-            func, self.fake_tensor_converter, flat_args, args_spec
+            func,
+            self.fake_tensor_converter,
+            dispatch_state.flat_args,
+            dispatch_state.args_spec,
+        )
+        dispatch_state = dataclasses.replace(
+            dispatch_state,
+            flat_args=flat_args,
+            flat_arg_fake_tensors=flat_arg_fake_tensors,
         )
 
         # The current constant handling only support tracing systems
@@ -3127,18 +3157,16 @@ class FakeTensorMode(TorchDispatchMode):
         # objects on an FX Graph.
         maybe_const_prop = self._try_constant_propagation_on_fake_inputs(
             func,
-            flat_args=flat_args,
-            args_spec=args_spec,
-            flat_arg_fake_tensors=flat_arg_fake_tensors,
-            has_symbolic_sizes=has_symbolic_sizes,
-            avoiding_device_init=avoiding_device_init,
+            dispatch_state=dispatch_state,
         )
         if maybe_const_prop is not _DISPATCH_UNHANDLED:
             return maybe_const_prop
 
         # we are falling through to running non constant tensors, any input constant that
         # is written to must be invalidated
-        args, kwargs = pytree.tree_unflatten(flat_args, args_spec)
+        args, kwargs = pytree.tree_unflatten(
+            dispatch_state.flat_args, dispatch_state.args_spec
+        )
 
         handled_hop, hop_result = self._maybe_dispatch_higher_order_operator(
             func, args, kwargs
@@ -3150,18 +3178,13 @@ class FakeTensorMode(TorchDispatchMode):
 
         real_state = self._prepare_real_tensor_propagation(
             func,
-            flat_args=flat_args,
-            args_spec=args_spec,
-            flat_arg_fake_tensors=flat_arg_fake_tensors,
+            dispatch_state=dispatch_state,
         )
         return self._dispatch_to_op_impl(
             func,
             args,
             kwargs,
-            flat_args=flat_args,
-            args_spec=args_spec,
-            flat_arg_fake_tensors=flat_arg_fake_tensors,
-            has_symbolic_sizes=has_symbolic_sizes,
+            dispatch_state=dispatch_state,
             real_state=real_state,
         )
 


### PR DESCRIPTION
## Summary
Root cause:
`FakeTensorMode._dispatch_impl` had grown into a 300+ line method that mixed subclass bailout, constant propagation, lift handling, HigherOrderOperator routing, real-tensor propagation, and meta/fallback dispatch in one place. That made behavior-preserving edits harder because unrelated paths had to stay in context together.

Proposed fix:
- extract named helpers for the major phases, including `_check_unrecognized_subclass`, `_try_constant_propagation`, `_try_lift`, `_prepare_real_tensor_propagation`, and `_dispatch_to_op_impl`
- keep the existing dispatch ordering and special cases intact, including the custom op profile path that intentionally bypasses real-tensor propagation
- split the fastpath/decomposition/registered fake impl/meta fallback routing into smaller methods so phase-specific changes no longer require loading the full monolith

Why this is the right long term fix:
- future edits to constant propagation, lift handling, or real-tensor propagation are now isolated to focused helpers instead of one 300+ line control-flow block
- the smaller phase boundaries make review safer because control-flow ordering is explicit and easier to verify

## Testing
- `python3 -m compileall torch/_subclasses/fake_tensor.py`
- `python3` smoke harness loading the patched `torch/_subclasses/fake_tensor.py` against `torch-2.12.0.dev20260414+cpu` and exercising lift-backed constant creation, inplace constant propagation, and number-as-tensor constant propagation

Drafted via Codex, published after manual review by @bobrenjc93