### PR TITLE
Add const_data_ptr() Python binding for read-only data pointer access

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -311,6 +311,7 @@ Tensor class reference
     Tensor.chalf
     Tensor.cfloat
     Tensor.cdouble
+    Tensor.const_data_ptr
     Tensor.data_ptr
     Tensor.deg2rad
     Tensor.dequantize

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4975,10 +4975,6 @@ class TestTorchDeviceType(TestCase):
         self.assertTrue(torch._C._is_cow_tensor(t))
         self.assertTrue(torch._C._is_cow_tensor(clone))
 
-        # data_ptr does trigger materialization
-        clone.data_ptr()
-        self.assertFalse(torch._C._is_cow_tensor(clone))
-
     # See Note [lazy_clone_ tests with inductor enabled]
     @skipXLA
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4957,6 +4957,31 @@ class TestTorchDeviceType(TestCase):
     # that they have to materialize in the expected order.
     @skipXLA
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
+    def test_const_data_ptr(self, device, dtype):
+        t = torch.tensor([[0, 1], [2, 3]], device=device, dtype=dtype)
+
+        # For a regular tensor, const_data_ptr and data_ptr return the same address
+        self.assertEqual(t.const_data_ptr(), t.data_ptr())
+
+        clone = t._lazy_clone()
+
+        self.assertTrue(torch._C._is_cow_tensor(t))
+        self.assertTrue(torch._C._is_cow_tensor(clone))
+
+        # const_data_ptr should not trigger COW materialization
+        addr = clone.const_data_ptr()
+        self.assertEqual(addr, t.const_data_ptr())
+
+        self.assertTrue(torch._C._is_cow_tensor(t))
+        self.assertTrue(torch._C._is_cow_tensor(clone))
+
+        # data_ptr does trigger materialization
+        clone.data_ptr()
+        self.assertFalse(torch._C._is_cow_tensor(clone))
+
+    # See Note [lazy_clone_ tests with inductor enabled]
+    @skipXLA
+    @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))
     def test_lazy_clone(self, device, dtype):
         t = torch.tensor([[0, 1], [2, 3]], device=device, dtype=dtype)
         t_orig_storage_addr = torch._C._storage_address(t)

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -212,7 +212,7 @@ static PyObject * THPVariable_const_data_ptr(PyObject* self_, PyObject* args)
     return handle_torch_function(self_, "const_data_ptr", args);
   }
   auto& self = THPVariable_Unpack(self_);
-  return wrap(reinterpret_cast<intptr_t>(self.const_data_ptr()));
+  return wrap(const_cast<void*>(self.const_data_ptr()));
   END_HANDLE_TH_ERRORS
 }
 

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -203,6 +203,20 @@ static PyObject * THPVariable_data_ptr(PyObject* self_, PyObject* args)
 }
 
 // implemented on the python object to avoid dispatch overhead
+// Unlike data_ptr(), this is a read-only access that does not trigger
+// copy-on-write materialization.
+static PyObject * THPVariable_const_data_ptr(PyObject* self_, PyObject* args)
+{
+  HANDLE_TH_ERRORS
+  if (check_has_torch_function(self_)) {
+    return handle_torch_function(self_, "const_data_ptr", args);
+  }
+  auto& self = THPVariable_Unpack(self_);
+  return wrap(reinterpret_cast<intptr_t>(self.const_data_ptr()));
+  END_HANDLE_TH_ERRORS
+}
+
+// implemented on the python object to avoid dispatch overhead
 static PyObject * THPVariable_storage_offset(PyObject* self_, PyObject* args)
 {
   HANDLE_TH_ERRORS
@@ -1297,6 +1311,7 @@ PyMethodDef variable_methods[] = {
   {"mtia", castPyCFunctionWithKeywords(THPVariable_mtia), METH_VARARGS | METH_KEYWORDS, nullptr},
   {"xpu", castPyCFunctionWithKeywords(THPVariable_xpu), METH_VARARGS | METH_KEYWORDS, nullptr},
   {"ipu", castPyCFunctionWithKeywords(THPVariable_ipu), METH_VARARGS | METH_KEYWORDS, nullptr},
+  {"const_data_ptr", THPVariable_const_data_ptr, METH_NOARGS, nullptr},
   {"data_ptr", THPVariable_data_ptr, METH_NOARGS, nullptr},
   {"dim", THPVariable_dim, METH_NOARGS, nullptr},
   {"has_names", THPVariable_has_names, METH_NOARGS, nullptr},

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1444,6 +1444,14 @@ class TensorVariable(VariableTracker):
     ) -> "DataPtrVariable":
         return DataPtrVariable(self)
 
+    def method_const_data_ptr(
+        self,
+        tx: "InstructionTranslator",
+        *args: VariableTracker,
+        **kwargs: VariableTracker,
+    ) -> "DataPtrVariable":
+        return DataPtrVariable(self, method_name="const_data_ptr")
+
     def method_record_stream(
         self,
         tx: "InstructionTranslator",
@@ -2573,15 +2581,17 @@ class DataPtrVariable(VariableTracker):
     def __init__(
         self,
         from_tensor: TensorVariable,
+        method_name: str = "data_ptr",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.from_tensor = from_tensor
+        self.method_name = method_name
 
     def python_type(self) -> type:
         return int
 
     def reconstruct(self, codegen: "PyCodegen") -> None:
         codegen(self.from_tensor)
-        codegen.load_method("data_ptr")
+        codegen.load_method(self.method_name)
         codegen.call_method(0)

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1516,11 +1516,36 @@ In-place version of :meth:`~Tensor.cumsum`
 )
 
 add_docstr_all(
+    "const_data_ptr",
+    r"""
+const_data_ptr() -> int
+
+Returns the address of the first element of :attr:`self` tensor.
+
+Unlike :meth:`data_ptr`, this is guaranteed to be a read-only access
+that will not trigger copy-on-write materialization. For regular
+(non-COW) tensors, the return value is identical to :meth:`data_ptr`.
+
+.. warning::
+
+    The returned pointer must not be used to mutate the tensor data.
+    Use :meth:`data_ptr` when write access is needed.
+""",
+)
+
+add_docstr_all(
     "data_ptr",
     r"""
 data_ptr() -> int
 
 Returns the address of the first element of :attr:`self` tensor.
+
+.. note::
+
+    If the tensor is a copy-on-write tensor (e.g. created via
+    :meth:`_lazy_clone`), calling this method will materialize the
+    copy. Use :meth:`const_data_ptr` if you only need read-only access
+    to the data pointer.
 """,
 )
 

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1432,6 +1432,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         Tensor.mtia: lambda self, memory_format=torch.preserve_format: -1,
         Tensor.xpu: lambda self, memory_format=torch.preserve_format: -1,
         Tensor.ipu: lambda self, memory_format=torch.preserve_format: -1,
+        Tensor.const_data_ptr: lambda self: -1,
         Tensor.data_ptr: lambda self: -1,
         Tensor.dense_dim: lambda self: -1,
         Tensor.diagonal_scatter: lambda self, src, offset=0, dim1=0, dim2=1: -1,


### PR DESCRIPTION
## Author Notes

API is straightforward and doc is to the point.

## Agent Notes

Exposes `TensorBase::const_data_ptr()` to Python as `Tensor.const_data_ptr()`. Unlike `data_ptr()`, this goes through the read-only storage path (`StorageImpl::data()`) and does not trigger copy-on-write materialization.

Changes:
- `tools/autograd/templates/python_variable_methods.cpp`: Add `THPVariable_const_data_ptr` binding and register it in the method table.
- `torch/_tensor_docs.py`: Add docstring for `const_data_ptr()`, update `data_ptr()` docstring to mention COW behavior and point to `const_data_ptr`.
- `docs/source/tensors.rst`: Add `Tensor.const_data_ptr` to the autosummary table.
- `test/test_torch.py`: Add `test_const_data_ptr` verifying `data_ptr() == const_data_ptr()` on regular tensors and that `const_data_ptr()` does not materialize COW tensors.

Authored with Claude.

## Test plan

- `test_const_data_ptr` checks that `const_data_ptr() == data_ptr()` on a regular tensor
- Same test verifies `const_data_ptr()` on a COW tensor does not trigger materialization
- Same test verifies `data_ptr()` does trigger materialization as a control

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98