### PR TITLE
Show forward op name instead of backward node name in autograd errors

### DIFF
--- a/test/nn/test_module_hooks.py
+++ b/test/nn/test_module_hooks.py
@@ -1542,7 +1542,7 @@ class TestModuleHookNN(NNTestCase):
                 # Input inplace error should throw an error
                 with self.assertRaisesRegex(
                     RuntimeError,
-                    "Output 0 of BackwardHookFunctionBackward is "
+                    "Output 0 of BackwardHookFunction is "
                     "a view and is being modified inplace.",
                 ):
                     mod(inp.clone(), True)
@@ -1554,7 +1554,7 @@ class TestModuleHookNN(NNTestCase):
                 local_inp[0] *= 1
                 with self.assertRaisesRegex(
                     RuntimeError,
-                    "Output 0 of BackwardHookFunctionBackward is "
+                    "Output 0 of BackwardHookFunction is "
                     "a view and its base or another view",
                 ):
                     # Any operation involving the view will fail here
@@ -1564,8 +1564,7 @@ class TestModuleHookNN(NNTestCase):
                 out = mod(inp, False)
                 with self.assertRaisesRegex(
                     RuntimeError,
-                    "BackwardHookFunctionBackward is a view "
-                    "and is being modified inplace.",
+                    "BackwardHookFunction is a view and is being modified inplace.",
                 ):
                     out += 1
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4375,16 +4375,26 @@ class TestAutograd(TestCase):
         # not the backward node (e.g. "AddBackward0").
         # Use b * b (not b * 2) so MulBackward saves b and detects the
         # version mismatch when unpacking.
+
+        # add(Tensor, Tensor) → AddBackward0 → "Add" (variant 0 is stripped).
         a = torch.randn(5, requires_grad=True)
-        b = a + 1
+        b = a + torch.randn(5)
         c = b * b
         with torch.no_grad():
             b += 1
         with self.assertRaisesRegex(RuntimeError, r"output 0 of Add,"):
             c.backward(torch.ones(5))
 
-        # Same for user-defined autograd Functions: the error should say
-        # "MyFunc" not "MyFuncBackward".
+        # add(Tensor, Scalar) → AddBackward1 → "Add1" (non-zero variant kept).
+        a = torch.randn(5, requires_grad=True)
+        b = a + 1
+        c = b * b
+        with torch.no_grad():
+            b += 1
+        with self.assertRaisesRegex(RuntimeError, r"output 0 of Add1,"):
+            c.backward(torch.ones(5))
+
+        # Custom autograd Function: "MyFunc" not "MyFuncBackward".
         class MyFunc(torch.autograd.Function):
             @staticmethod
             def forward(ctx, x):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4376,22 +4376,12 @@ class TestAutograd(TestCase):
         # Use b * b (not b * 2) so MulBackward saves b and detects the
         # version mismatch when unpacking.
 
-        # add(Tensor, Tensor) → AddBackward0 → "Add" (variant 0 is stripped).
-        a = torch.randn(5, requires_grad=True)
-        b = a + torch.randn(5)
-        c = b * b
-        with torch.no_grad():
-            b += 1
-        with self.assertRaisesRegex(RuntimeError, r"output 0 of Add,"):
-            c.backward(torch.ones(5))
-
-        # add(Tensor, Scalar) → AddBackward1 → "Add1" (non-zero variant kept).
         a = torch.randn(5, requires_grad=True)
         b = a + 1
         c = b * b
         with torch.no_grad():
             b += 1
-        with self.assertRaisesRegex(RuntimeError, r"output 0 of Add1,"):
+        with self.assertRaisesRegex(RuntimeError, r"output 0 of Add,"):
             c.backward(torch.ones(5))
 
         # Custom autograd Function: "MyFunc" not "MyFuncBackward".

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4384,6 +4384,16 @@ class TestAutograd(TestCase):
         with self.assertRaisesRegex(RuntimeError, r"output 0 of Add,"):
             c.backward(torch.ones(5))
 
+        # sum(dim=...) uses SumBackward1; the non-zero variant number is
+        # preserved so the message says "Sum1" not "Sum".
+        a = torch.randn(3, 4, requires_grad=True)
+        b = a.sum(dim=1)
+        c = b * b
+        with torch.no_grad():
+            b += 1
+        with self.assertRaisesRegex(RuntimeError, r"output 0 of Sum1,"):
+            c.backward(torch.ones(3))
+
         # Custom autograd Function: "MyFunc" not "MyFuncBackward".
         class MyFunc(torch.autograd.Function):
             @staticmethod

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4373,9 +4373,11 @@ class TestAutograd(TestCase):
     def test_inplace_version_error_shows_forward_op_name(self):
         # The error message should refer to the forward op (e.g. "Add"),
         # not the backward node (e.g. "AddBackward0").
+        # Use b * b (not b * 2) so MulBackward saves b and detects the
+        # version mismatch when unpacking.
         a = torch.randn(5, requires_grad=True)
         b = a + 1
-        c = b * 2
+        c = b * b
         with torch.no_grad():
             b += 1
         with self.assertRaisesRegex(RuntimeError, r"output 0 of Add,"):
@@ -4396,7 +4398,7 @@ class TestAutograd(TestCase):
 
         a = torch.randn(5, requires_grad=True)
         b = MyFunc.apply(a)
-        c = b * 2
+        c = b * b
         with torch.no_grad():
             b += 1
         with self.assertRaisesRegex(RuntimeError, r"output 0 of MyFunc,"):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4370,6 +4370,38 @@ class TestAutograd(TestCase):
             RuntimeError, "modified by an inplace operation", lambda: z.backward()
         )
 
+    def test_inplace_version_error_shows_forward_op_name(self):
+        # The error message should refer to the forward op (e.g. "Add"),
+        # not the backward node (e.g. "AddBackward0").
+        a = torch.randn(5, requires_grad=True)
+        b = a + 1
+        c = b * 2
+        with torch.no_grad():
+            b += 1
+        with self.assertRaisesRegex(RuntimeError, r"output 0 of Add,"):
+            c.backward(torch.ones(5))
+
+        # Same for user-defined autograd Functions: the error should say
+        # "MyFunc" not "MyFuncBackward".
+        class MyFunc(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.save_for_backward(x)
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, grad):
+                (x,) = ctx.saved_tensors
+                return grad * x
+
+        a = torch.randn(5, requires_grad=True)
+        b = MyFunc.apply(a)
+        c = b * 2
+        with torch.no_grad():
+            b += 1
+        with self.assertRaisesRegex(RuntimeError, r"output 0 of MyFunc,"):
+            c.backward(torch.ones(5))
+
     def test_increment_version(self):
         a = torch.rand(5, requires_grad=True)
         v = a._version
@@ -8822,9 +8854,7 @@ for shape in [(1,), ()]:
             is_view=True,
             should_raise_tuple=(None, None, None),
         )
-        inp_change_err = (
-            "Output {} of UnbindBackward0 is a view and is being modified inplace."
-        )
+        inp_change_err = "Output {} of Unbind is a view and is being modified inplace."
         run_test(
             grad_mode=True,
             requires_grad=True,
@@ -8971,17 +9001,17 @@ for shape in [(1,), ()]:
 
         fn_id_to_inplace_on_view_err_msg = {
             "one_output": (
-                "Output 0 of IdOneOutputBackward is a view and is being "
+                "Output 0 of IdOneOutput is a view and is being "
                 "modified inplace. This view was created inside a custom Function"
             ),
             "two_output": (
-                "Output 0 of IdTwoOutputBackward is a view and is being modified inplace."
+                "Output 0 of IdTwoOutput is a view and is being modified inplace."
                 " This view is the output of a function that returns multiple views.",
                 "Pure view custom Function can only have one input Tensor and one output Tensor."
                 " Open an issue if you need to support more.",
             ),
             "view_of_temp": (
-                "Output 0 of ViewOfTempBackward is a view and is being "
+                "Output 0 of ViewOfTemp is a view and is being "
                 "modified inplace. This view was created inside a custom Function",
                 "a view of a leaf Variable that requires grad is being used in an in-place operation",
             ),
@@ -9281,7 +9311,7 @@ for shape in [(1,), ()]:
         out = ComplexView.apply(a.clone(), idx)
         with self.assertRaisesRegex(
             RuntimeError,
-            "Output 0 of ComplexViewBackward is a view and is being modified inplace",
+            "Output 0 of ComplexView is a view and is being modified inplace",
         ):
             out += 1
 

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -54,12 +54,18 @@ auto Node::forward_op_name() const -> std::string {
     return n;
   }
   // Verify everything after "Backward" is digits (e.g., "Backward0").
-  for (size_t i = pos + 8; i < n.size(); ++i) {
+  auto suffix_start = pos + 8;
+  for (size_t i = suffix_start; i < n.size(); ++i) {
     if (!std::isdigit(static_cast<unsigned char>(n[i]))) {
       return n;
     }
   }
-  return n.substr(0, pos);
+  // Keep the numeric suffix if it is not "0" (e.g., "AddBackward1" → "Add1").
+  auto suffix = n.substr(suffix_start);
+  if (suffix == "0" || suffix.empty()) {
+    return n.substr(0, pos);
+  }
+  return n.substr(0, pos) + suffix;
 }
 
 AnomalyMetadata* Node::metadata() noexcept {

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -46,6 +46,22 @@ auto Node::name() const -> std::string {
   return c10::demangle(typeid(*this).name());
 }
 
+auto Node::forward_op_name() const -> std::string {
+  auto n = name();
+  // Strip "Backward<N>" suffix to get the forward op name.
+  auto pos = n.rfind("Backward");
+  if (pos == std::string::npos) {
+    return n;
+  }
+  // Verify everything after "Backward" is digits (e.g., "Backward0").
+  for (size_t i = pos + 8; i < n.size(); ++i) {
+    if (!std::isdigit(static_cast<unsigned char>(n[i]))) {
+      return n;
+    }
+  }
+  return n.substr(0, pos);
+}
+
 AnomalyMetadata* Node::metadata() noexcept {
   if (!anomaly_metadata_) {
     anomaly_metadata_ = Engine::get_default_engine().make_anomaly_metadata();

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -406,6 +406,10 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
   /// Returns the name of the dynamic type of the function, for debugging.
   virtual std::string name() const;
 
+  /// Returns the name of the corresponding forward op by stripping the
+  /// "Backward<N>" suffix from name(), if present.
+  std::string forward_op_name() const;
+
   /// The difference between functions `should_compute_output` and
   /// `task_should_compute_output`:
   /// - `should_compute_output` should only be used during graph construction

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -180,7 +180,7 @@ Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
       }
       if (grad_fn) {
         message << ", which is output " << output_nr_ << " of "
-                << grad_fn->name() << ',';
+                << grad_fn->forward_op_name() << ',';
       }
       message << " is at version " << current_version << "; expected version "
               << saved_version_ << " instead.";

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -787,7 +787,7 @@ void handle_view_on_rebase(
             "Output ",
             diff_view_meta->output_nr_,
             " of ",
-            grad_fn->name(),
+            grad_fn->forward_op_name(),
             " is a view of a view which was created in");
       } else {
         prefix = "A view was created in";
@@ -814,7 +814,7 @@ void handle_view_on_rebase(
           "Output ",
           diff_view_meta->output_nr_,
           " of ",
-          grad_fn->name(),
+          grad_fn->forward_op_name(),
           " is a view and ",
           modified_obj,
           " modified inplace.");


### PR DESCRIPTION
## Author Notes

The naming change is simple, but more tests might need fixing. Let's see how CI is.

## Agent Notes

Autograd error messages for inplace modifications and view-on-rebase now show the forward operation name (e.g. "Add") instead of the backward node name (e.g. "AddBackward0"), making them more intuitive for users who think in terms of forward operations.

Adds `Node::forward_op_name()` which strips the "Backward\<N\>" suffix from `name()`. This is used in two error paths:
- Version mismatch errors in `saved_variable.cpp` ("modified by an inplace operation")
- View-on-rebase errors in `variable.cpp` ("is a view and is being modified inplace")

Updated all test assertions across `test/test_autograd.py` and `test/nn/test_module_hooks.py` to match the new format.

Authored with Claude.