### PR TITLE
[caching] Fix SymBool pickling issue with torch.cond.

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -59,6 +59,25 @@ def aot_eager_regional_inductor():
     )
 
 
+class SingleCondModel(torch.nn.Module):
+    def __init__(self, d=64):
+        super().__init__()
+        self.fc1 = torch.nn.Linear(d, d)
+        self.fc2 = torch.nn.Linear(d, d)
+
+    def forward(self, x):
+        x = self.fc1(x)
+
+        def true_fn(x):
+            return x * 2.0
+
+        def false_fn(x):
+            return x * 3.0
+
+        x = torch.cond(x.shape[0] < 32, true_fn, false_fn, (x,))
+        return self.fc2(x)
+
+
 class MooType:
     def __init__(self, x):
         self.x = x
@@ -958,6 +977,43 @@ from user code:
         if not hasattr(backend_result.compiled_fn, "serialize"):
             raise AssertionError("Expected compiled_fn to have 'serialize' attribute")
         self.assertIsNotNone(backend_result.compiled_fn.serialize)
+
+    def test_aot_cache_predicate_not_pickleable(self):
+        import torch._functorch.config as functorch_config
+        import torch._inductor.config as inductor_config
+
+        model = SingleCondModel().eval()
+
+        old_cacheable = torch.ops.higher_order.cond._cacheable
+        torch.ops.higher_order.cond._cacheable = True
+        try:
+            with (
+                functorch_config.patch(
+                    enable_autograd_cache=True,
+                    force_non_lazy_backward_lowering=True,
+                    strict_autograd_cache=True,
+                ),
+                inductor_config.patch(
+                    fx_graph_cache=True,
+                    fx_graph_remote_cache=False,
+                ),
+            ):
+                compiled = torch.compile(model, backend="inductor", dynamic=True)
+
+                # Test both branches of the cond predicate (x.shape[0] < 32).
+                for batch_size in (16, 64):
+                    inp = torch.randn(batch_size, 64)
+                    expected = model(inp)
+                    actual = compiled(inp)
+                    self.assertEqual(expected, actual)
+
+                # If the SymBool predicate is not pickleable, the FxGraphCache
+                # silently bypasses instead of caching. Assert no bypass occurred.
+                self.assertEqual(
+                    torch._dynamo.utils.counters["inductor"]["fxgraph_cache_bypass"], 0
+                )
+        finally:
+            torch.ops.higher_order.cond._cacheable = old_cacheable
 
     def test_fullgraph_capture_with_pytree_module(self):
         from torch._dynamo.functional_export import dynamo_graph_capture_for_export

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -523,6 +523,7 @@ class FxGraphCachePickler(pickle.Pickler):
                 torch.Tensor: functools.partial(self._reduce_tensor),
                 torch.nn.parameter.Parameter: functools.partial(self._reduce_tensor),
                 torch.SymInt: functools.partial(self._reduce_symint),
+                torch.SymBool: functools.partial(self._reduce_symbool),
                 torch.fx.experimental._backward_state.BackwardState: functools.partial(
                     self._reduce_unsupported
                 ),
@@ -597,6 +598,14 @@ class FxGraphCachePickler(pickle.Pickler):
         # For hashing purposes, we only care about the name of the symbol and not the
         # backed value. We evaluate guards stored with a cached graph to ensure a cached
         # entity with SymInt args is safe to reuse.
+        return (_ident, (str(s),))
+
+    def _reduce_symbool(self, s: torch.SymBool) -> tuple[Callable[[T], T], tuple[str]]:
+        """
+        Custom reducer to pickle SymBools.
+        """
+        # Same approach as _reduce_symint: use the string representation for
+        # hashing.  Guards ensure correctness on cache reload.
         return (_ident, (str(s),))
 
     def _reduce_unsupported(self, s: Any) -> NoReturn:

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1572,7 +1572,7 @@ class PythonWrapperCodegen(CodeGen):
             if isinstance(
                 buf,
                 (
-                    sympy.Expr,
+                    sympy.Basic,
                     ir.TorchBindObject,
                     ir.GeneratorState,
                     ir.OpaqueObjectState,
@@ -1594,7 +1594,7 @@ class PythonWrapperCodegen(CodeGen):
     def codegen_input_nan_asserts(self) -> None:
         self.prefix.writeline("# make sure graph inputs are not nan/inf")
         for name, buf in self.get_graph_inputs().items():
-            if isinstance(buf, (sympy.Expr, ir.TorchBindObject)):
+            if isinstance(buf, (sympy.Basic, ir.TorchBindObject)):
                 continue
             line = f"assert not {name}.isnan().any().item()"
             self.prefix.writeline(line)
@@ -2598,6 +2598,11 @@ class PythonWrapperCodegen(CodeGen):
                     add_expr_input(
                         name, V.graph.sizevars.optimization_hint(value, fallback=42)
                     )
+                elif isinstance(value, sympy.Basic):
+                    # sympy.Boolean (e.g. StrictLessThan from torch.cond predicates)
+                    # is not a sympy.Expr so optimization_hint cannot handle it.
+                    # Use False as a fallback for benchmark harness purposes.
+                    add_expr_input(name, False)
                 elif isinstance(value, ir.GeneratorState):
                     add_expr_input(
                         name,

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1618,7 +1618,7 @@ class GraphLowering(torch.fx.Interpreter):
                 value,
                 (
                     TorchBindObject,
-                    sympy.Expr,
+                    sympy.Basic,
                     torch._inductor.ir.GeneratorState,
                     torch._inductor.ir.OpaqueObjectState,
                 ),


### PR DESCRIPTION
Summary:

From vllm we got an issue report https://github.com/vllm-project/vllm/pull/39386 that aot compile has trouble serializing SymBool in the graph when torch.cond is used.

```
EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/aot_autograd.py", line 1093, in aot_module_simplified
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     compiled_fn = AOTAutogradCache.try_load(
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/autograd_cache.py", line 721, in try_load
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     raise e
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/autograd_cache.py", line 633, in try_load
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     cache_key, debug_lines = autograd_cache_key(
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]                              ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/app/rfc/2nd/vllm/vllm/compilation/backends.py", line 326, in autograd_cache_key
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     result = orig(*args, **kwargs)
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]              ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/autograd_cache.py", line 496, in autograd_cache_key
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     key = "a" + pickler.get_hash(details)
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]                 ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/codecache.py", line 640, in get_hash
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     serialized_data = self.dumps(obj)
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]                       ^^^^^^^^^^^^^^^
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/codecache.py", line 625, in dumps
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     self.dump(obj)
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108] RuntimeError: <pybind11_builtins.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1 object at 0x7f39e8116030> is not pickleable.
```

This PR tries to faithfully reproduce the same error and fix the
issue for both caching (pickling) and inductor.

Test Plan:

CI

Reviewers:

Subscribers:

Tasks:

Tags:


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98