### PR TITLE
Fix build with MAGMA 2.10.0

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -51,11 +51,11 @@ struct MagmaInitializer {
 } initializer;
 }  // namespace (anonymous)
 
-#define AT_MAGMA_VERSION MAGMA_VERSION_MAJOR*100 + MAGMA_VERSION_MINOR*10 + MAGMA_VERSION_MICRO
+#define AT_MAGMA_VERSION MAGMA_VERSION_MAJOR*10000 + MAGMA_VERSION_MINOR*100 + MAGMA_VERSION_MICRO
 
-// Check that MAGMA never releases MAGMA_VERSION_MINOR >= 10 or MAGMA_VERSION_MICRO >= 10
-#if MAGMA_VERSION_MINOR >= 10 || MAGMA_VERSION_MICRO >= 10
-#error "MAGMA release minor or micro version >= 10, please correct AT_MAGMA_VERSION"
+// Check that MAGMA never releases MAGMA_VERSION_MINOR >= 100 or MAGMA_VERSION_MICRO >= 100
+#if MAGMA_VERSION_MINOR >= 100 || MAGMA_VERSION_MICRO >= 100
+#error "MAGMA release minor or micro version >= 100, please correct AT_MAGMA_VERSION"
 #endif
 
 #endif
@@ -123,7 +123,7 @@ void magmaEig(
     magma_int_t *info);
 #endif
 
-#if AT_MAGMA_VERSION >= 254
+#if AT_MAGMA_VERSION >= 20504
 
 template <>
 void magmaLdlHermitian<double>(
@@ -179,7 +179,7 @@ void magmaLdlHermitian<c10::complex<float>>(
   AT_CUDA_CHECK(cudaGetLastError());
 }
 
-#endif // AT_MAGMA_VERSION >= 254
+#endif // AT_MAGMA_VERSION >= 20504
 
 template<>
 void magmaLu<double>(
@@ -597,7 +597,7 @@ void ldl_factor_kernel(
     // If cusolver and magma 2.5.4+ are both available and hermitian=true,
     // call magma for complex inputs
 #ifdef USE_LINALG_SOLVER
-#if AT_MAGMA_ENABLED() && (AT_MAGMA_VERSION >= 254)
+#if AT_MAGMA_ENABLED() && (AT_MAGMA_VERSION >= 20504)
       if (LD.is_complex() && hermitian) {
         return ldl_factor_magma(
             LD, pivots, info, upper, hermitian);


### PR DESCRIPTION
I am aware that MAGMA is deprecated, but this is relatively low hanging fruit I experienced when building PyTorch against MAGMA 2.10.0 .

The `BatchLinearAlgebra.cpp` uses internally a `AT_MAGMA_VERSION` macro that is used to encode the MAGMA version as a single integer, for easy comparison. The encoding scheme failed if a minor or micro version of magma reached 10, that happened with MAGMA 2.10.0 . 

This PR fixes the encoding to work fine until the MAGMA minor or micro version reaches 100 .