### PR TITLE
Simplify condition for linux-docs job

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -222,7 +222,7 @@ jobs:
   # ╠══════════════════════════════════════════════════════════════════════╣
 
   linux-docs:
-    if: ${{ (needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-docs ')) && needs.get-label-type.outputs.use-arc != 'true' }}
+    if: ${{ (needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-docs ')) }}
     name: linux-docs
     uses: ./.github/workflows/_docs.yml
     needs:


### PR DESCRIPTION
Removed condition for 'use-arc' in linux-docs job as all trunk jobs are using OSDC, so we no longer run those