### PR TITLE
[pyrefly] Add type annotations to remaining torch/fx/experimental files

### DIFF
--- a/torch/fx/experimental/_constant_symnode.py
+++ b/torch/fx/experimental/_constant_symnode.py
@@ -5,7 +5,7 @@ from typing import *  # noqa: F403
 # This needs to exist because the Python version of nested int is not compatible
 # with the C++ version of constant symnode.
 class ConstantIntNode:
-    def __init__(self, val: int):
+    def __init__(self, val: int) -> None:
         self.val = val
 
     def is_constant(self) -> bool:

--- a/torch/fx/experimental/_dynamism.py
+++ b/torch/fx/experimental/_dynamism.py
@@ -26,8 +26,10 @@ def module_to_nested_dict(module: torch.nn.Module) -> dict[str, Any]:
     """Recursively converts an nn.Module into a nested dictionary with explicit 'parameters' and 'modules' keys."""
     self_dict: dict[str, Any] = {}
 
-    self_dict["_parameters"] = {}
-    self_dict["_modules"] = {}
+    parameters: dict[str, torch.Tensor] = {}
+    modules: dict[str, dict[str, Any]] = {}
+    self_dict["_parameters"] = parameters
+    self_dict["_modules"] = modules
 
     for attr_name in dir(module):
         try:

--- a/torch/fx/experimental/_size_hinting.py
+++ b/torch/fx/experimental/_size_hinting.py
@@ -191,7 +191,7 @@ def _get_unbacked_replacements(shape_env: ShapeEnv) -> dict[sympy.Expr, sympy.Ex
         expression becomes the canonical expression.
         """
 
-        def __init__(self, eq_graph: dict[sympy.Expr, OrderedSet[sympy.Expr]]):
+        def __init__(self, eq_graph: dict[sympy.Expr, OrderedSet[sympy.Expr]]) -> None:
             self.eq_graph = eq_graph
             self.expressions = list(eq_graph.keys())
             self.reverse_expressions = {
@@ -201,15 +201,15 @@ def _get_unbacked_replacements(shape_env: ShapeEnv) -> dict[sympy.Expr, sympy.Ex
             self.size = [1] * len(self.expressions)
             self._build_canonical_expr_mapping()
 
-        def _build_canonical_expr_mapping(self):
+        def _build_canonical_expr_mapping(self) -> None:
             for expr, edges in self.eq_graph.items():
                 for adj in edges:
                     self.union_expr(expr, adj)
 
-        def union_expr(self, a: sympy.Expr, b: sympy.Expr):
+        def union_expr(self, a: sympy.Expr, b: sympy.Expr) -> bool:
             return self.union(self.reverse_expressions[a], self.reverse_expressions[b])
 
-        def union(self, a: int, b: int):
+        def union(self, a: int, b: int) -> bool:
             rootA = self.find(a)
             rootB = self.find(b)
             if rootA == rootB:
@@ -219,16 +219,16 @@ def _get_unbacked_replacements(shape_env: ShapeEnv) -> dict[sympy.Expr, sympy.Ex
             self.size[leader] += self.size[other]
             return True
 
-        def find_expr(self, expr: sympy.Expr):
+        def find_expr(self, expr: sympy.Expr) -> sympy.Expr:
             parent = self.find(self.reverse_expressions[expr])
             return self.expressions[parent]
 
-        def find(self, x: int):
+        def find(self, x: int) -> int:
             if self.leader[x] != x:
                 self.leader[x] = self.find(self.leader[x])
             return self.leader[x]
 
-        def choose_leader(self, a: int, b: int):
+        def choose_leader(self, a: int, b: int) -> tuple[int, int]:
             """
             The leader will become the canonical expression.
             Returns a (leader, follower) tuple.

--- a/torch/fx/experimental/accelerator_partitioner.py
+++ b/torch/fx/experimental/accelerator_partitioner.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import operator
 from collections import deque
 from typing import NamedTuple
@@ -73,7 +72,7 @@ class PartitionResult(NamedTuple):
 """Followings are some helper functions for partition manipulation"""
 
 
-def reset_partition_device(partitions):
+def reset_partition_device(partitions: list[Partition]) -> None:
     for partition in partitions:
         partition.logical_device_ids = []
 
@@ -214,14 +213,14 @@ def get_device_partition_stats(
 
 def get_device_to_partitions_mapping(
     partitions: list[Partition], devices: list[Device]
-):
+) -> bool:
     """Given a list of partitions and a list of devices,
     map each partition into a device.
     """
 
     def calculate_extra_mem_bytes_needed_for(
         partition: Partition, partitions: list[Partition]
-    ):
+    ) -> int:
         all_nodes: set[Node] = set()
         for p in partitions:
             all_nodes = all_nodes.union(p.nodes)
@@ -233,7 +232,7 @@ def get_device_to_partitions_mapping(
             extra_size_needed += get_extra_size_of(node, all_nodes)
         return extra_size_needed
 
-    def find_device_for(partition: Partition):
+    def find_device_for(partition: Partition) -> bool:
         """Given a partition, find a logical device for the partition
         The algorithm is to put the partition on the device
         that has just enough mem left for that partition.
@@ -269,7 +268,7 @@ def get_device_to_partitions_mapping(
     return found_device
 
 
-def check_dependency(partition):
+def check_dependency(partition: Partition) -> bool:
     """Given a partition,check if there is a circular dependency on
     this partition using bfs
     """
@@ -385,7 +384,7 @@ class Partitioner:
         return ret
 
     def find_single_partition(
-        self, total_size_of_graph, logical_device_id: int = 0
+        self, total_size_of_graph: int, logical_device_id: int = 0
     ) -> None:
         """Fit the whole fx module into one device"""
         partition_0 = self.create_partition()
@@ -416,7 +415,7 @@ class Partitioner:
         and then try to map those partitions into logical devices with enough mem left.
         """
 
-        def find_device_based_on_size(node) -> Device:
+        def find_device_based_on_size(node: Node) -> Device:
             """Given a node, this function is to find a logical device
             that could fit the node.
             """
@@ -610,7 +609,7 @@ class Partitioner:
         self.partitions.append(partition)
         return partition
 
-    def create_single_node_partition(self, node):
+    def create_single_node_partition(self, node: Node) -> None:
         """Create a partition for a single node"""
         partition = self.create_partition()
         partition.add_node(node)
@@ -664,7 +663,7 @@ class Partitioner:
                 )
             return
 
-        def calculate_mem_bytes_needed(p1, p2):
+        def calculate_mem_bytes_needed(p1: Partition, p2: Partition) -> int:
             """Given two partitions, calculate how many mem bytes
             are needed if two partitions are combined
             """
@@ -695,20 +694,23 @@ class Partitioner:
                         break
             return find_combination, partitions
 
-        def reset_partition_in_sparse_nn(partition, new_partition=True):
-            """If crossing the boundary between non-embedding nodes and
-            embedding nodes, create a new partition
-            """
+        def reset_partition_in_sparse_nn(partition: Partition) -> Partition:
+            """Finalize current partition and create a new one."""
             if in_embedding_region:
                 embedding_partitions.append(partition)
             else:
                 non_embedding_partitions.append(partition)
-            if new_partition:
-                partition = self.create_partition()
-                # pyrefly: ignore [missing-attribute]
-                partition.left_mem_bytes = available_mem_bytes
-                return partition
-            return None
+            partition = self.create_partition()
+            # pyrefly: ignore [missing-attribute]
+            partition.left_mem_bytes = available_mem_bytes
+            return partition
+
+        def finalize_partition(partition: Partition) -> None:
+            """Finalize current partition without creating a new one."""
+            if in_embedding_region:
+                embedding_partitions.append(partition)
+            else:
+                non_embedding_partitions.append(partition)
 
         def is_embedding_node(node: Node) -> bool:
             """Check if a node is an embedding node"""
@@ -752,7 +754,7 @@ class Partitioner:
                             node.target + "is too large to fit into a device"
                         )
                 partition.add_node(node)
-        reset_partition_in_sparse_nn(partition, new_partition=False)
+        finalize_partition(partition)
         # Set parents and children for partitions
         set_parents_and_children(self.partitions)
         # Combining non-embedding partitions
@@ -816,7 +818,9 @@ class Partitioner:
         #3. Repeat #2 until the cost cannot be reduced.
         """
 
-        def try_combining_partitions(p0_index, p1_index, partitions) -> float:
+        def try_combining_partitions(
+            p0_index: int, p1_index: int, partitions: list[Partition]
+        ) -> float:
             """Given two partitions and a list of partitions, combine these two partitions
             and see what is the cost of the modified partition list
             """
@@ -855,7 +859,8 @@ class Partitioner:
             return float("inf")
 
         def search_combination(
-            transfer_rate_bytes_per_sec, node_to_latency_mapping
+            transfer_rate_bytes_per_sec: float,
+            node_to_latency_mapping: dict[Node, NodeLatency],
         ) -> bool:
             """Given transfer rate between partitions and each node's latency,
             find two partitions to combine so the cost of the partitions can
@@ -940,7 +945,9 @@ class Partitioner:
         are tried.
         """
 
-        def swap_nodes(n0, n1, p0, p1):
+        def swap_nodes(
+            n0: Node | None, n1: Node | None, p0: Partition, p1: Partition
+        ) -> None:
             # Either n0 or n1 could be None
             # That means we simply move the node
             # to another partition
@@ -952,8 +959,13 @@ class Partitioner:
                 p1.remove_node(n1)
 
         def try_swap_nodes(
-            n0, n1, p0, p1, node_to_latency_mapping, transfer_rate_per_sec
-        ):
+            n0: Node | None,
+            n1: Node | None,
+            p0: Partition,
+            p1: Partition,
+            node_to_latency_mapping: dict[Node, NodeLatency],
+            transfer_rate_per_sec: float,
+        ) -> float:
             cost = float("inf")
             swap_nodes(n0, n1, p0, p1)
             # Reorganize partitions after swapping
@@ -984,8 +996,12 @@ class Partitioner:
             return cost
 
         def swap_node_to_partition(
-            node, p0, p1, node_to_latency_mapping, transfer_rate_per_sec
-        ):
+            node: Node,
+            p0: Partition,
+            p1: Partition,
+            node_to_latency_mapping: dict[Node, NodeLatency],
+            transfer_rate_per_sec: float,
+        ) -> tuple[float, list[Node]]:
             """This function helps to swap one node from partition p0
             with all the nodes in another partition p1
             """
@@ -1060,8 +1076,10 @@ class Partitioner:
         return
 
     def aot_based_partition(
-        self, node_to_partition_mapping, partition_to_logical_device_mapping
-    ):
+        self,
+        node_to_partition_mapping: dict[Node, int],
+        partition_to_logical_device_mapping: dict[int, list[int]],
+    ) -> None:
         """This function helps to rebuild the partitions given the nodes and its
         corresponding partition id
         """

--- a/torch/fx/experimental/const_fold.py
+++ b/torch/fx/experimental/const_fold.py
@@ -1,6 +1,6 @@
-# mypy: allow-untyped-defs
 import re
 from collections.abc import Callable
+from typing import Any
 
 import torch.fx
 from torch.fx.node import map_arg
@@ -31,7 +31,7 @@ class FoldedGraphModule(torch.fx.GraphModule):
         const_subgraph: torch.fx.Graph | None = None,
         fx_const_folded_attrs_name: str | None = None,
         device_for_folded_attrs: str = "cuda",
-    ):
+    ) -> None:
         super().__init__(root, graph)
         self.const_subgraph_module = (
             None
@@ -42,12 +42,12 @@ class FoldedGraphModule(torch.fx.GraphModule):
         self.fx_const_folded_attrs_name = fx_const_folded_attrs_name
         self.device_for_folded_attrs = device_for_folded_attrs
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: object, **kwargs: object) -> Any:
         if not self.has_folding_been_run:
             self.run_folding()
         return super().__call__(*args)
 
-    def run_folding(self):
+    def run_folding(self) -> None:
         # If there's no const subgraph module or attr output names to use, return
         # early as there is no const folding to perform.
         if (
@@ -65,7 +65,7 @@ class FoldedGraphModule(torch.fx.GraphModule):
         # Tuple[Tensor,].
         folded_attrs = self.const_subgraph_module()
 
-        def _create_param(i):
+        def _create_param(i: torch.Tensor | int) -> torch.nn.Parameter:
             return torch.nn.Parameter(
                 i.detach().clone()
                 if not isinstance(i, int)
@@ -110,7 +110,7 @@ def _inline_module(
     replacement_mapping: dict[torch.fx.Node, torch.fx.Node] = {}
     ph_count = 0
 
-    def replacement_fn(node):
+    def replacement_fn(node: torch.fx.Node) -> torch.fx.Node:
         new_node = replacement_mapping[node]
         new_node.meta = node.meta.copy()
         return new_node
@@ -281,7 +281,7 @@ def split_const_subgraphs(
 
     # Partition the module into two: submod_0 for constant folding subgraph, and
     # submod_1 for the rest.
-    def mod_partition(node: torch.fx.Node):
+    def mod_partition(node: torch.fx.Node) -> int:
         return 0 if node in const_nodes else 1
 
     split = split_module(mod_traced, module, mod_partition)

--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -1,9 +1,8 @@
-# mypy: allow-untyped-defs
 import itertools
 import operator
 from collections.abc import Callable
 from functools import reduce
-from typing import TypeVar
+from typing import Any, TypeVar
 from typing_extensions import ParamSpec
 
 import sympy
@@ -20,9 +19,9 @@ from torch.nn.modules.conv import Conv2d
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
-_INFERENCE_RULES: dict[Target, Callable] = {}
-_REFINEMENT_RULES: dict[Target, Callable] = {}
-_RULES: dict[Target, Callable] = {}
+_INFERENCE_RULES: dict[Target, Callable[..., Any]] = {}
+_REFINEMENT_RULES: dict[Target, Callable[..., Any]] = {}
+_RULES: dict[Target, Callable[..., Any]] = {}
 
 __all__ = [
     "GraphTypeChecker",
@@ -60,7 +59,8 @@ __all__ = [
 ]
 
 
-def expand_to_tensor_dim(t, n):
+# TODO: narrow t to TensorType | _DynType once Node.type is narrowed
+def expand_to_tensor_dim(t: Any, n: int) -> TensorType:
     """
     Expand a type to the desired tensor dimension if possible
     Raise an error otherwise.
@@ -80,7 +80,7 @@ def expand_to_tensor_dim(t, n):
         raise TypeError(f"Cannot match the type {t}")
 
 
-def broadcast_types(t1, t2):
+def broadcast_types(t1: Any, t2: Any) -> tuple[Any, Any]:
     """
     Applies broadcasting to both given types such that they
     become consistent with each other and returns two new
@@ -163,7 +163,7 @@ def register_algebraic_expressions_inference_rule(
 
 @register_inference_rule(torch.add)
 @register_inference_rule(operator.add)
-def add_inference_rule(n: Node):
+def add_inference_rule(n: Node) -> Any:
     """
     Apply the addition inference rule. This includes:
     - scalar addition
@@ -228,7 +228,7 @@ def add_inference_rule(n: Node):
 
 
 @register_inference_rule(getattr)
-def get_attr_inference_rule(n: Node, traced):
+def get_attr_inference_rule(n: Node, traced: Any) -> Any:
     """
     The current getattr rule only handles the shape attribute
     Can be extended to other attributes
@@ -247,7 +247,7 @@ def get_attr_inference_rule(n: Node, traced):
 
 
 @register_inference_rule(torch.transpose)
-def transpose_inference_rule(n: Node):
+def transpose_inference_rule(n: Node) -> Any:
     """
     We check that dimensions for the transpose operations
     are within range of the tensor type of the node
@@ -285,7 +285,7 @@ def transpose_inference_rule(n: Node):
 
 
 @register_inference_rule(torch.reshape)
-def reshape_inference_rule(n: Node):
+def reshape_inference_rule(n: Node) -> TensorType:
     """
     Without dynamism, the rule checks that the
     product of the elements of the argument tensor
@@ -328,7 +328,7 @@ def reshape_inference_rule(n: Node):
 
 
 @register_inference_rule(BatchNorm2d)
-def bn2d_inference_rule(n: Node, module_instance):
+def bn2d_inference_rule(n: Node, module_instance: Any) -> Any:
     """
     Given a BatchNorm2D instance and a node check the following conditions:
     - the input type can be expanded to a size 4 tensor: t =  (x_1, x_2, x_3, x_4)
@@ -364,7 +364,7 @@ def bn2d_inference_rule(n: Node, module_instance):
         )
 
 
-def calculate_out_dimension(d_in, module_instance, index):
+def calculate_out_dimension(d_in: Any, module_instance: Any, index: int) -> Any:
     """
     For calculating h_in and w_out according to the conv2D documentation
     """
@@ -405,7 +405,8 @@ def calculate_out_dimension(d_in, module_instance, index):
         )
 
 
-def get_greatest_upper_bound(type1, type2):
+# TODO: narrow params/return to TensorType | _DynType once Node.type is narrowed
+def get_greatest_upper_bound(type1: Any, type2: Any) -> Any:
     """
     Get the most precise type that's consistent with the given types
     """
@@ -424,7 +425,7 @@ def get_greatest_upper_bound(type1, type2):
 
 
 @register_inference_rule(Conv2d)
-def conv2d_inference_rule(n: Node, module_instance):
+def conv2d_inference_rule(n: Node, module_instance: Any) -> Any:
     """
     Given a Conv2D instance and a node check the following conditions:
     - the input type can be expanded to a size 4 tensor: t =  (x_1, x_2, H, W)
@@ -457,7 +458,7 @@ def conv2d_inference_rule(n: Node, module_instance):
 
 
 @register_inference_rule(torch.nn.ReLU)
-def relu_inference_rule(n: Node, module_instance):
+def relu_inference_rule(n: Node, module_instance: Any) -> Any:
     """
     Input and output shapes should be equal.
     """
@@ -472,7 +473,7 @@ def relu_inference_rule(n: Node, module_instance):
     return n.type
 
 
-def maxpool2d_check(typ, module_instance):
+def maxpool2d_check(typ: Any, module_instance: Any) -> TensorType:
     """
     Applies the maxpool2d shape information to the input
     this affects the last two dimensions
@@ -494,7 +495,7 @@ def maxpool2d_check(typ, module_instance):
 
 
 @register_inference_rule(torch.nn.MaxPool2d)
-def maxpool2d_inference_rule(n: Node, module_instance):
+def maxpool2d_inference_rule(n: Node, module_instance: Any) -> Any:
     """
     Given a MaxPool2D instance and a node check the following conditions:
     - Input size matches size 3 or 4
@@ -515,7 +516,7 @@ def maxpool2d_inference_rule(n: Node, module_instance):
     return n.type
 
 
-def linear_check(tensor_type, module_instance):
+def linear_check(tensor_type: Any, module_instance: Any) -> TensorType:
     """
     Checks that an input tensor type satisfies the conditions for linear operation
     and returns the output type based on in and out features given by module_instance
@@ -534,7 +535,7 @@ def linear_check(tensor_type, module_instance):
 
 
 @register_inference_rule(torch.nn.Linear)
-def linear_inference_rule(n: Node, module_instance):
+def linear_inference_rule(n: Node, module_instance: Any) -> Any:
     """
     Applies the shape information to the input then gets the greatest upper bound
     of the resulting type and the existing type
@@ -549,7 +550,7 @@ def linear_inference_rule(n: Node, module_instance):
     return n.type
 
 
-def adaptiveavgpool2d_check(tensor_type, module_instance):
+def adaptiveavgpool2d_check(tensor_type: Any, module_instance: Any) -> TensorType:
     output_size = module_instance.output_size
     if isinstance(output_size, int):
         output_size = [output_size, output_size]
@@ -573,7 +574,7 @@ def adaptiveavgpool2d_check(tensor_type, module_instance):
 
 
 @register_inference_rule(torch.nn.AdaptiveAvgPool2d)
-def adaptiveavgpool2d_inference_rule(n: Node, module_instance):
+def adaptiveavgpool2d_inference_rule(n: Node, module_instance: Any) -> Any:
     """
     The input and output sizes should be the same except for the last
     two dimensions taken from the input, which represent width and height
@@ -588,7 +589,7 @@ def adaptiveavgpool2d_inference_rule(n: Node, module_instance):
     return n.type
 
 
-def flatten_check(tensor_type, start_dim, end_dim):
+def flatten_check(tensor_type: Any, start_dim: int, end_dim: int) -> TensorType:
     l = len(tensor_type.__args__)
 
     start_dim = l if start_dim == -1 else abs(start_dim)
@@ -612,7 +613,7 @@ def flatten_check(tensor_type, start_dim, end_dim):
 
 
 @register_inference_rule(torch.flatten)
-def flatten_inference_rule(n: Node):
+def flatten_inference_rule(n: Node) -> Any:
     """
     Applies the flatten shape information to the input then gets the
     greatest upper bound of the resulting type and the existing type
@@ -645,11 +646,11 @@ def flatten_inference_rule(n: Node):
 
 
 class GraphTypeChecker:
-    def __init__(self, env, traced):
+    def __init__(self, env: dict[str, Any], traced: torch.fx.GraphModule) -> None:
         self.env = env
         self.traced = traced
 
-    def type_check(self):
+    def type_check(self) -> bool:
         """
         A gradual type checker for graphs
         Effect: every node's field type will be
@@ -663,7 +664,7 @@ class GraphTypeChecker:
             self.type_check_node(n)
         return True
 
-    def type_check_node(self, n: Node):
+    def type_check_node(self, n: Node) -> Any:
         """
         Type check a given fx node.
         Current operations:
@@ -704,6 +705,7 @@ class GraphTypeChecker:
                 )
 
         elif n.op == "call_module":
+            # pyrefly: ignore[bad-argument-type]
             module_instance = self.traced.get_submodule(n.target)
             if type(module_instance) in _INFERENCE_RULES:
                 return _INFERENCE_RULES[type(module_instance)](n, module_instance)
@@ -714,7 +716,7 @@ class GraphTypeChecker:
 
         elif n.op == "output":
 
-            def get_node_type(a):
+            def get_node_type(a: Any) -> Any:
                 return a.type
 
             n.type = torch.fx.node.map_arg(n.args[0], get_node_type)
@@ -725,12 +727,12 @@ class GraphTypeChecker:
 
 
 @register_refinement_rule(Conv2d)
-def conv_refinement_rule(n: Node):
+def conv_refinement_rule(n: Node) -> list[Any] | None:
     """
     The equality constraints are between the first dimension of
     the input and output
     """
-    res = []
+    res: list[Any] = []
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     arg_type = n.args[0].type
@@ -740,12 +742,12 @@ def conv_refinement_rule(n: Node):
 
 
 @register_refinement_rule(torch.nn.Linear)
-def linear_refinement_rule(n: Node):
+def linear_refinement_rule(n: Node) -> list[Any]:
     """
     The equality constraints are between the first dimension of
     the input and output
     """
-    res = []
+    res: list[Any] = []
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     arg_type = n.args[0].type
@@ -756,11 +758,11 @@ def linear_refinement_rule(n: Node):
 
 @register_refinement_rule(BatchNorm2d)
 @register_refinement_rule(torch.nn.ReLU)
-def all_eq(n: Node):
+def all_eq(n: Node) -> list[Any]:
     """
     For operations where the input shape is equal to the output shape
     """
-    res = []
+    res: list[Any] = []
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     arg_type = n.args[0].type
@@ -773,12 +775,12 @@ def all_eq(n: Node):
 
 @register_refinement_rule(torch.nn.AdaptiveAvgPool2d)
 @register_refinement_rule(torch.nn.MaxPool2d)
-def first_two_eq(n: Node):
+def first_two_eq(n: Node) -> list[Any]:
     """
     For operations where the first two dimensions of the input and output shape
     are equal
     """
-    res = []
+    res: list[Any] = []
     if not isinstance(n.args[0], Node):
         raise AssertionError(f"Expected Node, got {type(n.args[0])}")
     arg_type = n.args[0].type
@@ -791,7 +793,7 @@ def first_two_eq(n: Node):
 
 @register_refinement_rule(torch.add)
 @register_refinement_rule(operator.add)
-def element_wise_eq(n: Node):
+def element_wise_eq(n: Node) -> list[Any]:
     """
     For element-wise operations and handles broadcasting.
     Note that after applying broadcasting to the arguments
@@ -806,7 +808,7 @@ def element_wise_eq(n: Node):
     including unification) and another iteration to establish equality between the operands
     and the resulting type, requiring another round of constraint generation and unificaiton.
     """
-    res = []
+    res: list[Any] = []
     if isinstance(n.args[0], Node) and isinstance(n.args[1], Node):
         arg_type1 = n.args[0].type
         arg_type2 = n.args[1].type
@@ -832,7 +834,7 @@ def element_wise_eq(n: Node):
 
 
 @register_refinement_rule(torch.flatten)
-def flatten_refinement_rule(n: Node):
+def flatten_refinement_rule(n: Node) -> list[Any]:
     """
     Generates equality constraints between the dimensions of the input and output
     that will not be involved in the flatten operation
@@ -870,7 +872,7 @@ def flatten_refinement_rule(n: Node):
 
 
 @register_algebraic_expressions_inference_rule(Conv2d)
-def conv_rule(n: Node, module_instance):
+def conv_rule(n: Node, module_instance: Any) -> TensorType | None:
     """
     Represents the output in terms of an algrbraic expression w.r.t
     the input when possible
@@ -895,12 +897,12 @@ class Refine:
     Currently all constraints are equality constraints.
     """
 
-    def __init__(self, traced):
+    def __init__(self, traced: Any) -> None:
         self.constraints = []
         self.traced = traced
         self.symbol_iter = itertools.count(start=0, step=1)
 
-    def refine(self):
+    def refine(self) -> bool:
         """
         Generates constraints for
         every node in the graph based on
@@ -911,7 +913,7 @@ class Refine:
             self.refine_node(n)
         return True
 
-    def symbolic_relations(self):
+    def symbolic_relations(self) -> bool:
         """
         Infers algebraic relations
         """
@@ -920,7 +922,7 @@ class Refine:
             self.infer_symbolic_relations(n)
         return True
 
-    def replace_dyn_with_fresh_var(self, typ):
+    def replace_dyn_with_fresh_var(self, typ: Any) -> Any:
         """
         Replace all unknown types with fresh type variables.
         """
@@ -937,7 +939,7 @@ class Refine:
         else:
             return typ
 
-    def convert_to_sympy_symbols(self, typ):
+    def convert_to_sympy_symbols(self, typ: Any) -> Any:
         """
         Replace all unknown types with fresh type variables.
         """
@@ -953,7 +955,7 @@ class Refine:
         else:
             return typ
 
-    def refine_node(self, n: Node):
+    def refine_node(self, n: Node) -> Any:
         """
         Returns a list of equality constraints for
         call_module and call_function nodes.
@@ -977,13 +979,13 @@ class Refine:
 
         if n.op == "output":
 
-            def get_node_type(a):
+            def get_node_type(a: Any) -> Any:
                 return a.type
 
             n.type = torch.fx.node.map_arg(n.args[0], get_node_type)
             return n.type
 
-    def infer_symbolic_relations(self, n: Node):
+    def infer_symbolic_relations(self, n: Node) -> Any:
         n.type = self.convert_to_sympy_symbols(n.type)
         if n.op == "call_function":
             if n.target in _RULES:
@@ -996,14 +998,14 @@ class Refine:
 
         if n.op == "output":
 
-            def get_node_type(a):
+            def get_node_type(a: Any) -> Any:
                 return a.type
 
             n.type = torch.fx.node.map_arg(n.args[0], get_node_type)
             return n.type
 
 
-def get_parameter(traced, target: str):
+def get_parameter(traced: Any, target: str) -> torch.nn.Parameter:
     """
     Returns the parameter given by ``target`` if it exists,
     otherwise throws an error.

--- a/torch/fx/experimental/merge_matmul.py
+++ b/torch/fx/experimental/merge_matmul.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import itertools
 import operator
 
@@ -33,7 +32,7 @@ def split_result_tensors(
     return torch.split(result, splits)
 
 
-def may_depend_on(a: Node, b: Node, search_depth: int = 6):
+def may_depend_on(a: Node, b: Node, search_depth: int = 6) -> bool:
     """
     Determine if one node depends on another in a torch.fx.Graph.
 
@@ -70,7 +69,7 @@ def may_depend_on(a: Node, b: Node, search_depth: int = 6):
     return False
 
 
-def are_nodes_independent(nodes: list[Node]):
+def are_nodes_independent(nodes: list[Node]) -> bool:
     """
     Check if all of the given nodes are pairwise-data independent.
 
@@ -88,7 +87,7 @@ def are_nodes_independent(nodes: list[Node]):
     return True
 
 
-def merge_matmul(in_mod: torch.nn.Module):
+def merge_matmul(in_mod: torch.nn.Module) -> torch.fx.GraphModule:
     """
     A graph transformation that merges matrix multiplication operations that share the same right-hand
     side operand into one large matrix multiplication.

--- a/torch/fx/experimental/meta_tracer.py
+++ b/torch/fx/experimental/meta_tracer.py
@@ -1,31 +1,55 @@
-# mypy: allow-untyped-defs
 import builtins
 import functools
 import warnings
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TypeVar
 
 import torch
 import torch.fx
+from torch.fx.node import Node
+from torch.fx.proxy import Proxy
 
 
-def embedding_override(self, input):
+_C = TypeVar("_C", bound=Callable[..., Any])
+
+__all__ = [
+    "embedding_override",
+    "functional_relu_override",
+    "gen_constructor_wrapper",
+    "manual_meta_overrides",
+    "MetaAttribute",
+    "MetaDeviceAttribute",
+    "MetaProxy",
+    "MetaTracer",
+    "nn_layernorm_override",
+    "proxys_to_metas",
+    "symbolic_trace",
+    "torch_abs_override",
+    "torch_nn_relu_override",
+    "torch_relu_override",
+    "torch_where_override",
+]
+
+
+def embedding_override(self: torch.nn.Embedding, input: torch.Tensor) -> torch.Tensor:
     return torch.empty(*input.shape, self.weight.shape[-1], device="meta")
 
 
-def nn_layernorm_override(self, input):
+def nn_layernorm_override(
+    self: torch.nn.LayerNorm, input: torch.Tensor
+) -> torch.Tensor:
     return input
 
 
-def torch_relu_override(x):
+def torch_relu_override(x: torch.Tensor) -> torch.Tensor:
     return x
 
 
-def torch_nn_relu_override(self, x):
+def torch_nn_relu_override(self: torch.nn.ReLU, x: torch.Tensor) -> torch.Tensor:
     return x
 
 
-def functional_relu_override(x, inplace=False):
+def functional_relu_override(x: torch.Tensor, inplace: bool = False) -> torch.Tensor:
     if inplace:
         raise AssertionError(
             "dont support inplace functional.relu for metatensor analysis"
@@ -33,19 +57,23 @@ def functional_relu_override(x, inplace=False):
     return x
 
 
-def torch_where_override(condition, x, y):
+def torch_where_override(
+    condition: torch.Tensor, x: torch.Tensor, y: torch.Tensor
+) -> torch.Tensor:
     # torch.where returns the broadcasted tensor of condition, x, and y,
     # so hack it by using addition
     return condition.to(device="meta") + x.to(device="meta") + y.to(device="meta")
 
 
-def torch_abs_override(input, *, out=None):
+def torch_abs_override(
+    input: torch.Tensor, *, out: torch.Tensor | None = None
+) -> torch.Tensor:
     if out is not None:
         raise AssertionError("Dont support in-place abs for MetaTensor analysis")
     return input
 
 
-manual_meta_overrides: dict[Callable, Callable] = {
+manual_meta_overrides: dict[Callable[..., Any], Callable[..., Any]] = {
     torch.nn.Embedding: embedding_override,
     torch.nn.LayerNorm: nn_layernorm_override,
     torch.relu: torch_relu_override,
@@ -56,12 +84,14 @@ manual_meta_overrides: dict[Callable, Callable] = {
 }
 
 
-def gen_constructor_wrapper(target):
+def gen_constructor_wrapper(
+    target: _C,
+) -> tuple[Callable[..., Any], _C]:
     @functools.wraps(target)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         proxy = None
 
-        def check_has_proxy(v):
+        def check_has_proxy(v: Any) -> None:
             if isinstance(v, torch.fx.Proxy):
                 nonlocal proxy
                 proxy = v
@@ -78,23 +108,23 @@ def gen_constructor_wrapper(target):
 
 
 class MetaProxy(torch.fx.Proxy):
-    def install_tensor_meta(self, tensor_meta):
+    def install_tensor_meta(self, tensor_meta: torch.Tensor) -> None:
         self._tensor_meta = tensor_meta
 
-    def size(self, dim=None):
+    def size(self, dim: int | None = None) -> Any:
         if hasattr(self, "_tensor_meta") and self._tensor_meta is not None:
             return self._tensor_meta.size(*[dim] if dim else [])
         return self.tracer.create_proxy(
             "call_method", "size", (self, dim) if dim else (self,), {}
         )
 
-    def dim(self):
+    def dim(self) -> Any:
         if hasattr(self, "_tensor_meta") and self._tensor_meta is not None:
             return self._tensor_meta.dim()
         return self.tracer.create_proxy("call_method", "dim", (self,), {})
 
     @property
-    def shape(self):
+    def shape(self) -> Any:
         if hasattr(self, "_tensor_meta") and self._tensor_meta is not None:
             return self._tensor_meta.shape
         return self.tracer.create_proxy(
@@ -102,7 +132,7 @@ class MetaProxy(torch.fx.Proxy):
         )
 
     @property
-    def dtype(self):
+    def dtype(self) -> Any:
         if hasattr(self, "_tensor_meta") and self._tensor_meta is not None:
             return self._tensor_meta.dtype
         return self.tracer.create_proxy(
@@ -110,12 +140,12 @@ class MetaProxy(torch.fx.Proxy):
         )
 
     @property
-    def device(self):
+    def device(self) -> "MetaDeviceAttribute":
         # Hack so we can track when devices are used. During meta-tensor propagation,
         # replace these values with a constant 'meta'
         return MetaDeviceAttribute(self, "device")
 
-    def __getattr__(self, k):
+    def __getattr__(self, k: str) -> Any:
         if k == "_tensor_meta":
             return self.__getattribute__(k)
         # note: not added to the graph yet, if this is a method call
@@ -124,7 +154,7 @@ class MetaProxy(torch.fx.Proxy):
 
 
 class MetaAttribute(MetaProxy):
-    def __init__(self, root, attr: str):
+    def __init__(self, root: MetaProxy, attr: str) -> None:
         self.root = root
         self.attr = attr
         self.tracer = root.tracer
@@ -140,7 +170,7 @@ class MetaAttribute(MetaProxy):
             ).node
         return self._node
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self.tracer.create_proxy(
             "call_method", self.attr, (self.root,) + args, kwargs
         )
@@ -150,7 +180,7 @@ class MetaDeviceAttribute(MetaAttribute):
     pass
 
 
-def proxys_to_metas(v):
+def proxys_to_metas(v: Any) -> Any:
     if isinstance(v, MetaDeviceAttribute):
         return "meta"
     if isinstance(v, torch.fx.Proxy):
@@ -169,14 +199,14 @@ class MetaTracer(torch.fx.Tracer):
 
     def create_proxy(
         self,
-        kind,
-        target,
-        args,
-        kwargs,
-        name=None,
-        type_expr=None,
-        proxy_factory_fn=None,
-    ):
+        kind: str,
+        target: torch.fx.node.Target,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        name: str | None = None,
+        type_expr: Any = None,
+        proxy_factory_fn: Callable[[Node], Proxy] | None = None,
+    ) -> MetaProxy:
         rv = super().create_proxy(
             kind,
             target,
@@ -190,7 +220,7 @@ class MetaTracer(torch.fx.Tracer):
 
         if kind == "placeholder" and target in self.meta_args:
             rv.install_tensor_meta(self.meta_args[target])
-            return rv
+            return rv  # pyrefly: ignore [bad-return]
 
         if target in self.orig_fns:
             # NOTE: tensor constructors in PyTorch define the `device` argument as
@@ -206,6 +236,7 @@ class MetaTracer(torch.fx.Tracer):
             kwargs_metas = torch.fx.node.map_aggregate(kwargs, proxys_to_metas)
 
             if kind == "call_function":
+                # pyrefly: ignore [no-matching-overload]
                 meta_target = manual_meta_overrides.get(target, target)
 
                 meta_out = meta_target(*args_metas, **kwargs_metas)
@@ -217,6 +248,7 @@ class MetaTracer(torch.fx.Tracer):
                     raise AssertionError("orig_forward not set for call_module")
                 self._disable_module_getattr = True
                 try:
+                    # pyrefly: ignore [bad-argument-type]
                     mod = self.root.get_submodule(target)
                     mod_type = type(mod)
                     if mod_type in manual_meta_overrides:
@@ -231,7 +263,7 @@ class MetaTracer(torch.fx.Tracer):
                 self._disable_module_getattr = True
                 try:
                     attr_itr = self.root
-                    atoms = target.split(".")
+                    atoms = target.split(".")  # pyrefly: ignore [missing-attribute]
                     for atom in atoms:
                         attr_itr = getattr(attr_itr, atom)
                     if not isinstance(attr_itr, torch.Tensor):
@@ -240,7 +272,7 @@ class MetaTracer(torch.fx.Tracer):
                 finally:
                     self._disable_module_getattr = False
             else:
-                return rv
+                return rv  # pyrefly: ignore [bad-return]
 
             # TODO
             if not isinstance(rv, torch.fx.Proxy):
@@ -249,15 +281,23 @@ class MetaTracer(torch.fx.Tracer):
         except Exception as e:
             warnings.warn(f"Could not compute metadata for {kind} target {target}: {e}")
 
-        return rv
+        return rv  # pyrefly: ignore [bad-return]
 
-    def getattr(self, attr, attr_val, parameter_proxy_cache):
+    def getattr(
+        self, attr: str, attr_val: Any, parameter_proxy_cache: dict[str, Proxy]
+    ) -> Any:
         if getattr(self, "_disable_module_getattr", False):
             return attr_val
         else:
             return super().getattr(attr, attr_val, parameter_proxy_cache)
 
-    def call_module(self, m, forward, args, kwargs):
+    def call_module(
+        self,
+        m: torch.nn.Module,
+        forward: Callable[..., Any],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
         self.orig_forward = forward
         return super().call_module(m, forward, args, kwargs)
 
@@ -289,7 +329,7 @@ class MetaTracer(torch.fx.Tracer):
                 return path
             raise
 
-    def proxy(self, node):
+    def proxy(self, node: torch.fx.Node) -> MetaProxy:
         return MetaProxy(node, self)
 
     def trace(self, root, meta_args: dict[str, torch.Tensor], concrete_args=None):  # type: ignore[override]

--- a/torch/fx/experimental/normalize.py
+++ b/torch/fx/experimental/normalize.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import operator
 from collections.abc import Callable
 from typing import Any
@@ -37,7 +36,7 @@ class NormalizeArgs(Transformer):
 
     def __init__(
         self, module: torch.fx.GraphModule, normalize_to_only_use_kwargs: bool = True
-    ):
+    ) -> None:
         super().__init__(module)
         self.node_map: dict[Proxy, Node] = {}
         self.normalize_to_only_use_kwargs = normalize_to_only_use_kwargs
@@ -45,7 +44,7 @@ class NormalizeArgs(Transformer):
     def run_node(self, n: Node) -> Any:
         args, kwargs = self.fetch_args_kwargs_from_env(n)
 
-        def get_type(arg):
+        def get_type(arg: object) -> Any:
             if isinstance(arg, fx.Node):
                 return n.meta.get("type")
             return type(arg)
@@ -72,7 +71,7 @@ class NormalizeArgs(Transformer):
         kwargs: dict[str, Any],
         arg_types: tuple[Any, ...] | None = None,
         kwarg_types: dict[str, Any] | None = None,
-    ):
+    ) -> Proxy:
         if not callable(target):
             raise AssertionError(f"Expected callable target, got {type(target)}")
         new_args_and_kwargs = normalize_function(
@@ -93,7 +92,7 @@ class NormalizeArgs(Transformer):
 
     def call_module(
         self, target: Target, args: tuple[Argument, ...], kwargs: dict[str, Any]
-    ):
+    ) -> Proxy:
         if not isinstance(target, str):
             raise AssertionError(f"Expected str target, got {type(target)}")
         new_args_and_kwargs = normalize_module(
@@ -147,7 +146,7 @@ class NormalizeOperators(AnnotateTypesWithSchema):
 
     def call_function(
         self, target: Target, args: tuple[Argument, ...], kwargs: dict[str, Any]
-    ):
+    ) -> Proxy:
         # Normalize operators according to the magic methods implemented on tensors here:
         # https://github.com/pytorch/pytorch/blob/28c5d90b679c6b38bf4183ec99f16d933c2f1bcd/tools/autograd/templates/python_variable_methods.cpp#L1137
 

--- a/torch/fx/experimental/optimization.py
+++ b/torch/fx/experimental/optimization.py
@@ -1,10 +1,9 @@
-# mypy: allow-untyped-defs
 import copy
 import logging
 import operator
 import time
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from enum import Enum
 from typing import Any, cast
 
@@ -45,11 +44,11 @@ def _parent_name(target: str) -> tuple[str, str]:
 
 # Works for length 2 patterns with 2 modules
 def matches_module_pattern(
-    pattern: Iterable[type], node: fx.Node, modules: dict[str, Any]
-):
+    pattern: Iterable[type], node: fx.Node, modules: dict[str, torch.nn.Module]
+) -> bool:
     if len(node.args) == 0:
         return False
-    nodes: tuple[Any, fx.Node] = (node.args[0], node)
+    nodes: tuple[Argument, fx.Node] = (node.args[0], node)
     for expected_type, current_node in zip(pattern, nodes):
         if not isinstance(current_node, fx.Node):
             return False
@@ -65,8 +64,8 @@ def matches_module_pattern(
 
 
 def replace_node_module(
-    node: fx.Node, modules: dict[str, Any], new_module: torch.nn.Module
-):
+    node: fx.Node, modules: dict[str, torch.nn.Module], new_module: torch.nn.Module
+) -> None:
     if not isinstance(node.target, str):
         raise AssertionError(f"Expected str target, got {type(node.target)}")
     parent_name, name = _parent_name(node.target)
@@ -74,7 +73,9 @@ def replace_node_module(
     setattr(modules[parent_name], name, new_module)
 
 
-def fuse(model: torch.nn.Module, inplace=False, no_trace=False) -> torch.nn.Module:
+def fuse(
+    model: torch.nn.Module, inplace: bool = False, no_trace: bool = False
+) -> torch.nn.Module:
     """
     Fuses convolution/BN and linear/BN layers for inference purposes.
     Will deepcopy your model by default, but can modify the model inplace as well.
@@ -139,7 +140,7 @@ def extract_subgraph(
     nodes: list[fx.Node],
     inputs: list[fx.Node],
     outputs: list[fx.Node],
-):
+) -> fx.GraphModule:
     """
     Given lists of nodes from an existing graph that represent a subgraph, returns a submodule that executes that subgraph.
     """
@@ -183,7 +184,9 @@ mkldnn_map = {
 }
 
 
-def modules_to_mkldnn(nodes: list[fx.Node], modules: dict[str, nn.Module]):
+def modules_to_mkldnn(
+    nodes: list[fx.Node], modules: dict[str, nn.Module]
+) -> dict[nn.Module, nn.Module]:
     """
     For each node, if it's a module that can be preconverted into MKLDNN,
     then we do so and create a mapping to allow us to convert from the MKLDNN
@@ -206,10 +209,10 @@ def modules_to_mkldnn(nodes: list[fx.Node], modules: dict[str, nn.Module]):
 
 
 def reset_modules(
-    nodes: list[fx.Node],
+    nodes: Iterable[fx.Node],
     modules: dict[str, nn.Module],
     old_modules: dict[nn.Module, nn.Module],
-):
+) -> None:
     """
     Maps each module that's been changed with `modules_to_mkldnn` back to its
     original.
@@ -224,14 +227,16 @@ def reset_modules(
 
 
 class MklSubgraph:
-    def __init__(self, fx_graph: fx.Graph):
+    def __init__(self, fx_graph: fx.Graph) -> None:
         self.fx_graph = fx_graph
         self.nodes: list[fx.Node] = []
         self.start_nodes: list[fx.Node] = []
         self.end_nodes: list[fx.Node] = []
 
 
-def gen_mkl_autotuner(example_inputs, iters=10, warmup=1):
+def gen_mkl_autotuner(
+    example_inputs: list[torch.Tensor], iters: int = 10, warmup: int = 1
+) -> Callable[[MklSubgraph], bool]:
     """
     This generates a heuristic that can be passed into `optimize_for_inference` that
     determines whether a subgraph should be run in MKL by running it with the example_inputs.
@@ -254,7 +259,7 @@ def gen_mkl_autotuner(example_inputs, iters=10, warmup=1):
         output_args = cast(list[fx.Node], [node.args[0] for node in graph.end_nodes])
         submodule = extract_subgraph(fx_model, graph.nodes, input_nodes, output_args)
 
-        def benchmark(f):
+        def benchmark(f: Callable[[], object]) -> float:
             for _ in range(warmup):
                 f()
             begin = time.time()
@@ -271,7 +276,7 @@ def gen_mkl_autotuner(example_inputs, iters=10, warmup=1):
         reset_modules(
             submodule.graph.nodes,
             dict(submodule.named_modules()),
-            # pyrefly: ignore [bad-argument-type]
+            # pyrefly: ignore [bad-argument-type]  # old_modules is set before this point
             old_modules,
         )
         no_mkl_time = benchmark(lambda: submodule(*sample_inputs))
@@ -290,11 +295,11 @@ def use_mkl_length(graph: MklSubgraph) -> bool:
 
 
 class UnionFind:
-    def __init__(self, n):
+    def __init__(self, n: int) -> None:
         self.parent: list[int | None] = [None] * n
         self.size: list[int] = [0] * n
 
-    def make_set(self, v: int):
+    def make_set(self, v: int) -> None:
         self.parent[v] = v
         self.size[v] = 1
 
@@ -307,7 +312,7 @@ class UnionFind:
         self.parent[v] = self.find(par)
         return cast(int, self.parent[v])
 
-    def join(self, a: int, b: int):
+    def join(self, a: int, b: int) -> int | None:
         a, b = self.find(a), self.find(b)
         if a == b:
             return a
@@ -425,7 +430,7 @@ def optimize_for_inference(
     num_nodes = len(fx_graph.nodes)
     uf = UnionFind(num_nodes)
 
-    def get_color(n):
+    def get_color(n: fx.Node) -> int | None:
         if hasattr(n, "color"):  # Current node is part of a MKL subgraph
             return uf.find(n.color)
         if hasattr(n, "start_color"):  # Current node is input to MKL subgraph
@@ -463,10 +468,10 @@ def optimize_for_inference(
                 continue
             if any(i is None for i in cur_colors):
                 raise AssertionError("Found None in cur_colors")
-            cur_colors = sorted(cur_colors)
-            node.color = cur_colors[0]
-            for other_color in cur_colors[1:]:
-                uf.join(cur_colors[0], other_color)
+            sorted_colors: list[int] = sorted(cur_colors)  # type: ignore[arg-type]
+            node.color = sorted_colors[0]
+            for other_color in sorted_colors[1:]:
+                uf.join(sorted_colors[0], other_color)
 
     mkldnn_graphs: dict[int, MklSubgraph] = defaultdict(lambda: MklSubgraph(fx_graph))
     for node in fx_graph.nodes:

--- a/torch/fx/experimental/partitioner_utils.py
+++ b/torch/fx/experimental/partitioner_utils.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 from enum import Enum
 from typing import NamedTuple
 
@@ -19,15 +18,15 @@ class Partition:
         self.used_mem_bytes: int = 0
         self.logical_device_ids: list[int] = []
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.partition_id)
 
-    def recalculate_mem_size(self):
+    def recalculate_mem_size(self) -> None:
         self.used_mem_bytes = 0
         for node in self.nodes:
             self.used_mem_bytes += get_extra_size_of(node, self.nodes)
 
-    def add_node(self, node):
+    def add_node(self, node: Node) -> None:
         input_nodes: dict[Node, None] = {}
         map_arg(node.args, input_nodes.setdefault)
         map_arg(node.kwargs, input_nodes.setdefault)
@@ -38,7 +37,7 @@ class Partition:
         self.nodes.add(node)
         self.recalculate_mem_size()
 
-    def remove_node(self, node):
+    def remove_node(self, node: Node) -> None:
         # Remove a node only if the node is in the partition
         if node in self.nodes:
             self.nodes.remove(node)
@@ -151,7 +150,7 @@ def get_latency_of_one_partition(
                 top_nodes.append(node)
         return top_nodes
 
-    def dfs_helper(node: Node, partition_latency) -> PartitionLatency:
+    def dfs_helper(node: Node, partition_latency: PartitionLatency) -> PartitionLatency:
         """Given a top node of a partition, this function returns
         the latency of the critical path in the partition
         """
@@ -235,7 +234,7 @@ def get_comm_latency_between(
     parent_partition: Partition,
     child_partition: Partition,
     transfer_rate_bytes_per_sec: float,
-):
+) -> float:
     """Given two partitions (parent and child),
     calculate the communication latency between the two.
     """
@@ -271,7 +270,7 @@ def get_latency_of_partitioned_graph(
     partitions: list[Partition],
     partition_to_latency_mapping: dict[Partition, PartitionLatency],
     transfer_rate_bytes_per_sec: float,
-):
+) -> float:
     """Given all partitions in a graph, find the critical path among all partitions
     and return its latency as the latency of the whole graph
     """

--- a/torch/fx/experimental/refinement_types.py
+++ b/torch/fx/experimental/refinement_types.py
@@ -1,5 +1,5 @@
 class Equality:
-    def __init__(self, lhs: object, rhs: object):
+    def __init__(self, lhs: object, rhs: object) -> None:
         self.lhs = lhs
         self.rhs = rhs
 

--- a/torch/fx/experimental/rewriter.py
+++ b/torch/fx/experimental/rewriter.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-decorators
-# mypy: allow-untyped-defs
 import ast
 import copy
 import functools
@@ -31,7 +29,7 @@ class AST_Rewriter(ast.NodeTransformer):
     # a disable here. This function is an optimization pass and not really
     # suitable for dynamo tracing anyways.
     @torch._dynamo.disable
-    def rewrite(self, fn: FunctionType):
+    def rewrite(self, fn: FunctionType) -> FunctionType:
         # Normalize the source lines
         sourcelines, _ = inspect.getsourcelines(fn)
         sourcelines = normalize_source_lines(sourcelines)
@@ -53,7 +51,9 @@ class AST_Rewriter(ast.NodeTransformer):
         fn_compiled = globals_dict[new_keys[0]]
 
         # return the compiled function with the original globals
-        def change_func_globals(f, globals):
+        def change_func_globals(
+            f: FunctionType, globals: dict[str, object]
+        ) -> FunctionType:
             """Based on https://stackoverflow.com/a/13503277/2988730 (@unutbu)"""
             # __globals__ is a private member of the function class
             # so we have to copy the function, f, all of its member, except f.__globals__
@@ -66,12 +66,12 @@ class AST_Rewriter(ast.NodeTransformer):
             )
             g = functools.update_wrapper(g, f)
             g.__kwdefaults__ = copy.copy(f.__kwdefaults__)  # type:ignore[attr-defined]
-            return g
+            return g  # pyrefly: ignore [bad-return]
 
         # Return the correct FunctionType object
         return change_func_globals(fn_compiled, globals=fn.__globals__)
 
-    def visit_Assert(self, node):
+    def visit_Assert(self, node: ast.Assert) -> ast.Expr:
         """
         Swap out the Assert node (Python's `assert`) with a callsite to the
         symbolically-traceable torch._assert function
@@ -93,7 +93,7 @@ class AST_Rewriter(ast.NodeTransformer):
         # a replacement for the original _assert node
         return ast.copy_location(expr_wrapper, node)
 
-    def visit_AnnAssign(self, node):
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> ast.Assign:
         """
         Swap out Python's AnnAssign with an Assign node where the annotation function is called.
         Example:
@@ -106,6 +106,7 @@ class AST_Rewriter(ast.NodeTransformer):
             targets=[node.target],
             value=ast.Call(
                 func=ast.Name(id="annotate", ctx=ast.Load()),
+                # pyrefly: ignore [bad-argument-type]
                 args=[node.value, node.annotation],
                 keywords=[],
             ),
@@ -115,20 +116,22 @@ class AST_Rewriter(ast.NodeTransformer):
 class RewritingTracer(Tracer):
     def trace(
         self,
-        root: torch.nn.Module | Callable,
+        root: torch.nn.Module | Callable[..., Any],
         concrete_args: dict[str, Any] | None = None,
     ) -> Graph:
         return super().trace(_rewrite(root), concrete_args)
 
 
-def _rewrite(fn: torch.nn.Module | Callable) -> torch.nn.Module | Callable:
+def _rewrite(
+    fn: torch.nn.Module | Callable[..., Any],
+) -> torch.nn.Module | Callable[..., Any]:
     if isinstance(fn, torch.nn.Module):
         # Rewrite this module's `forward` as well as the `forward`s of
         # all of this module's recursive descendents. Return the new,
         # rewritten module hierarchy.
-        def rewrite_module(m: torch.nn.Module):
+        def rewrite_module(m: torch.nn.Module) -> torch.nn.Module:
             class RewrittenModule(torch.nn.Module):
-                def __init__(self, orig):
+                def __init__(self, orig: torch.nn.Module) -> None:
                     super().__init__()
                     for k, v in orig.__dict__.items():
                         if isinstance(v, torch.nn.Module):

--- a/torch/fx/experimental/schema_type_annotation.py
+++ b/torch/fx/experimental/schema_type_annotation.py
@@ -1,19 +1,17 @@
-# mypy: allow-untyped-defs
-from __future__ import annotations
-
 import inspect
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 import torch
 import torch.fx
 from torch._jit_internal import boolean_dispatched
 from torch.fx import Transformer
+from torch.fx.graph_module import GraphModule
+from torch.fx.node import Argument, Target
 from torch.fx.operator_schemas import _torchscript_type_to_python_type
+from torch.fx.proxy import Proxy
 
 
-if TYPE_CHECKING:
-    from torch.fx.graph_module import GraphModule
-    from torch.fx.node import Argument, Target
+__all__ = ["AnnotateTypesWithSchema"]
 
 
 class AnnotateTypesWithSchema(Transformer):
@@ -41,7 +39,7 @@ class AnnotateTypesWithSchema(Transformer):
         annotate_functionals: bool = True,
         annotate_modules: bool = True,
         annotate_get_attrs: bool = True,
-    ):
+    ) -> None:
         super().__init__(module)
         self.annotate_functionals = annotate_functionals
         self.annotate_modules = annotate_modules
@@ -49,7 +47,7 @@ class AnnotateTypesWithSchema(Transformer):
 
     def call_function(
         self, target: Target, args: tuple[Argument, ...], kwargs: dict[str, Any]
-    ):
+    ) -> Proxy:
         python_ret_type = None
         if self.annotate_functionals and target.__module__ == "torch.nn.functional":
             target_for_analysis = target
@@ -81,7 +79,7 @@ class AnnotateTypesWithSchema(Transformer):
 
     def call_module(
         self, target: Target, args: tuple[Argument, ...], kwargs: dict[str, Any]
-    ):
+    ) -> Proxy:
         python_ret_type = None
         if not isinstance(target, str):
             raise AssertionError(f"Expected str target, got {type(target)}")
@@ -98,10 +96,10 @@ class AnnotateTypesWithSchema(Transformer):
 
     def get_attr(
         self,
-        target: torch.fx.node.Target,
+        target: Target,
         args: tuple[Argument, ...],
         kwargs: dict[str, Any],
-    ):
+    ) -> Proxy:
         attr_proxy = super().get_attr(target, args, kwargs)
 
         if self.annotate_get_attrs:

--- a/torch/fx/experimental/shape_inference/infer_shape.py
+++ b/torch/fx/experimental/shape_inference/infer_shape.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import copy
 from collections import defaultdict
 
@@ -10,6 +9,7 @@ from torch.fx.experimental.shape_inference.infer_symbol_values import (
     infer_symbol_values,
 )
 from torch.fx.experimental.symbolic_shapes import DimDynamic, ShapeEnv
+from torch.types import IntLikeType
 from torch.utils import _pytree
 
 
@@ -18,7 +18,11 @@ This is the function that runs shape inference. It will modify the input graph m
 """
 
 
-def infer_shape(gm, input_tensors):
+def infer_shape(
+    gm: torch.fx.GraphModule, input_tensors: list[torch.Tensor]
+) -> (
+    tuple[torch.fx.GraphModule, list[torch.Tensor], FakeTensorMode, IntLikeType] | None
+):
     # Prepare environments
     shape_env = ShapeEnv()
     fake_mode = FakeTensorMode(shape_env=shape_env, allow_non_fake_inputs=True)
@@ -29,11 +33,11 @@ def infer_shape(gm, input_tensors):
         dim_count += input_tensor.dim() - 1
 
     sample = {f"s{i}": 2 for i in range(dim_count)}
-    init_symints = [
+    init_symints: list[IntLikeType] = [
         mksym(shape_env, v, LocalSource(k), DimDynamic.DYNAMIC)
         for k, v in sample.items()
     ]
-    symints = copy.deepcopy(init_symints)
+    symints: list[IntLikeType] = copy.deepcopy(init_symints)
     symbol_to_idx_dict = {f"s{i}": i for i in range(dim_count)}
     padding_constraints = defaultdict(list)  # type: ignore[var-annotated]
 
@@ -87,7 +91,9 @@ def infer_shape(gm, input_tensors):
                 allowed_try_times -= 1
 
 
-def mksym(shape_env, value, source, dynamic_dim):
+def mksym(
+    shape_env: ShapeEnv, value: int, source: LocalSource, dynamic_dim: DimDynamic
+) -> IntLikeType:
     return shape_env.create_symintnode(
         shape_env.create_symbol(
             value,

--- a/torch/fx/experimental/unify_refinements.py
+++ b/torch/fx/experimental/unify_refinements.py
@@ -1,10 +1,25 @@
-# mypy: allow-untyped-defs
+from typing import Any
+
+import torch
+import torch.fx
 from torch.fx.experimental.graph_gradual_typechecker import Refine
+from torch.fx.experimental.refinement_types import Equality
 from torch.fx.experimental.unification import unify, Var  # type: ignore[attr-defined]
 from torch.fx.tensor_type import TensorType
 
 
-def infer_symbolic_types_single_pass(traced):
+__all__ = [
+    "check_for_type_equality",
+    "convert_eq",
+    "infer_symbolic_types",
+    "infer_symbolic_types_single_pass",
+    "substitute_all_types",
+    "substitute_solution_one_type",
+    "unify_eq",
+]
+
+
+def infer_symbolic_types_single_pass(traced: torch.fx.GraphModule) -> None:
     """
     Calls our symbolic inferencer once.
     """
@@ -14,7 +29,7 @@ def infer_symbolic_types_single_pass(traced):
     substitute_all_types(traced.graph, mgu)
 
 
-def infer_symbolic_types(traced):
+def infer_symbolic_types(traced: torch.fx.GraphModule) -> None:
     """
     Calls our symbolic inferencer twice.
     This is useful when one pass is not enough
@@ -34,7 +49,7 @@ def infer_symbolic_types(traced):
     r.symbolic_relations()
 
 
-def convert_eq(list_of_eq):
+def convert_eq(list_of_eq: list[Equality]) -> tuple[tuple[Any, ...], tuple[Any, ...]]:
     """
     Convert equality constraints in the right format
     to be used by unification library.
@@ -47,7 +62,7 @@ def convert_eq(list_of_eq):
     return tuple(lhs), tuple(rhs)
 
 
-def unify_eq(list_of_eq):
+def unify_eq(list_of_eq: list[Equality]) -> Any:
     """
     Apply unification to a set of
     equality constraints
@@ -56,7 +71,7 @@ def unify_eq(list_of_eq):
     return unify(lhs, rhs)
 
 
-def substitute_solution_one_type(mapping, t):
+def substitute_solution_one_type(mapping: dict[object, object], t: object) -> Any:
     """
     Apply the most general unifier to a type
     """
@@ -91,7 +106,7 @@ def substitute_solution_one_type(mapping, t):
         return t
 
 
-def substitute_all_types(graph, mapping):
+def substitute_all_types(graph: torch.fx.Graph, mapping: dict[object, object]) -> None:
     """
     Apply the most general unifier to all types in a graph
     till reaching a fixed point. If the input and output graph
@@ -112,7 +127,7 @@ def substitute_all_types(graph, mapping):
         n.type = substitute_solution_one_type(mapping, n.type)
 
 
-def check_for_type_equality(g1, g2):
+def check_for_type_equality(g1: torch.fx.Graph, g2: torch.fx.Graph) -> bool:
     """
     A check equality to be used in fixed points.
     We do not use graph equality but instead type

--- a/torch/fx/experimental/validator.py
+++ b/torch/fx/experimental/validator.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import builtins
 import functools
 import logging
@@ -6,7 +5,7 @@ import math
 import operator
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, overload, TYPE_CHECKING, TypeVar
 
 import sympy
 
@@ -19,7 +18,13 @@ from torch.fx.node import Argument, Target
 from torch.utils._sympy.interp import sympy_interp
 
 
+if TYPE_CHECKING:
+    from torch.fx.experimental.symbolic_shapes import ShapeEnv, TrackedFake
+
+
 log = logging.getLogger(__name__)
+
+_R = TypeVar("_R")
 
 try:
     import z3  # type: ignore[import]
@@ -89,7 +94,7 @@ try:
             # Collect the arguments of chains of ADD and MUL.
             # This is safe, since they are associative.
 
-            def collect_str_args(e):
+            def collect_str_args(e: z3.ExprRef) -> list[str]:
                 if not (z3.is_app(e) and e.decl().kind() == kind):
                     return [z3str(e)]
                 else:
@@ -148,9 +153,11 @@ try:
     # We need to convert to/from BitVec in order to use z3 bitwise ops.
     # We assume that integers are 64 bit.
     # If all args are boolean, then use the boolean bitwise op implementation instead, if provided.
-    def _bitwise_op(bitwise_func, bool_func):
+    def _bitwise_op(
+        bitwise_func: Callable[..., Any], bool_func: Callable[..., Any] | None
+    ) -> Callable[..., Any]:
         @functools.wraps(bitwise_func)
-        def wrapper(self, *args):
+        def wrapper(self: "_Z3Ops", *args: z3.ExprRef) -> Any:
             if bool_func is not None and all(
                 isinstance(arg, z3.BoolRef) for arg in args
             ):
@@ -270,7 +277,9 @@ try:
     #
     #   2. Calls an operation that corresponds to 'op', but works with Z3
     #      inhabitants (left as is if it works as is)
-    def z3op(op: Callable, validator: "TranslationValidator") -> Callable:
+    def z3op(
+        op: Callable[..., Any], validator: "TranslationValidator"
+    ) -> Callable[..., Any]:
         # Operations that have booleans as their argument.
         # This is needed because the argument of some FX nodes were
         # literal integers, instead of booleans. So, whenever this flag
@@ -279,8 +288,8 @@ try:
         as_bool = op in boolean_ops
 
         # Lifts the function into 'z3.ExprRef' domain.
-        def lift(func):
-            def wrap(a) -> z3.ExprRef:
+        def lift(func: Callable[..., _R]) -> Callable[..., _R]:
+            def wrap(a: object) -> z3.ExprRef:
                 if isinstance(a, (z3.ArithRef, z3.BoolRef)):
                     return a
                 # Convert it into a Z3 value, if it is some of the supported
@@ -294,7 +303,7 @@ try:
                 raise ValueError(f"can't lift type: {type(a)}")
 
             @functools.wraps(func)
-            def wrapper(*args):
+            def wrapper(*args: object) -> Any:
                 # Lifts the arguments into a list of Z3 inhabitants.
                 if len(args) == 1 and isinstance(args[0], (list, tuple)):
                     wrapped_args = (tuple(wrap(a) for a in args[0]),)
@@ -345,7 +354,9 @@ try:
     # it adds the Z3 expression corresponding to the argument as validator
     # input.
     class PopulateValidator(torch.fx.Interpreter):
-        def __init__(self, graph: torch.fx.Graph, validator: "TranslationValidator"):
+        def __init__(
+            self, graph: torch.fx.Graph, validator: "TranslationValidator"
+        ) -> None:
             # Reference to the translation validator.
             self.validator = validator
 
@@ -389,7 +400,7 @@ try:
             self._validator = validator
             self._ops = _Z3Ops(self._validator)
 
-        def constant(self, value: Any, dtype: torch.dtype) -> z3.ExprRef:
+        def constant(self, value: int | float | bool, dtype: torch.dtype) -> z3.ExprRef:
             # TODO: Probably OK to relax this and allow lower precision
             if dtype is torch.int64:
                 return z3.IntVal(int(value))
@@ -674,7 +685,7 @@ def translation_validation_timeout() -> int:
     return config.translation_validation_timeout
 
 
-def _assert_z3_installed_if_tv_set():
+def _assert_z3_installed_if_tv_set() -> None:
     if not (_HAS_Z3 or not config.translation_validation):
         raise AssertionError(
             "translation validation requires Z3 package. Please, either install "
@@ -683,14 +694,16 @@ def _assert_z3_installed_if_tv_set():
 
 
 class ValidationException(TorchDynamoException):
-    def __init__(self, model, assertions, target_exprs, failed_source_exprs):
+    def __init__(
+        self, model: Any, assertions: Any, target_exprs: Any, failed_source_exprs: Any
+    ) -> None:
         if not _HAS_Z3:
             raise AssertionError("Z3 is required")
 
-        def symbolstr(sym) -> str:
+        def symbolstr(sym: Any) -> str:
             return f"{sym}: {model[sym]}"
 
-        def joinlines(xs) -> str:
+        def joinlines(xs: Any) -> str:
             return "\n".join(f"  ==> {x}" for x in xs)
 
         model_str = joinlines(sorted(map(symbolstr, model)))
@@ -712,12 +725,18 @@ Target Expressions:
 Failed Source Expressions:
 {failed_source_exprs_str}"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.msg}\n\n{self.details}"
 
 
 class BisectValidationException(TorchDynamoException):
-    def __init__(self, validation_exc, expr, failed_action, traced_node):
+    def __init__(
+        self,
+        validation_exc: ValidationException,
+        expr: sympy.Basic,
+        failed_action: str,
+        traced_node: torch.fx.Node,
+    ) -> None:
         self.msg = f"translation validation failed when {failed_action}: {expr}"
         self.details = f"""\
 Failure occurred while running node:
@@ -725,7 +744,7 @@ Failure occurred while running node:
 
 {validation_exc.details}"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.msg}\n\n{self.details}"
 
 
@@ -741,7 +760,7 @@ _assert_z3_installed_if_tv_set()
 # As guards are added by ShapeEnv.evaluate_expr calls, some simplification errors
 # might be silently happening. This function tries to nail down exactly at which
 # point things went wrong from a validation perspective.
-def bisect(shape_env):
+def bisect(shape_env: "ShapeEnv") -> None:
     from torch.fx.experimental.recording import (
         FakeTensorMeta,
         replay_shape_env_events,
@@ -766,7 +785,25 @@ def bisect(shape_env):
     #
     # This is needed so as not to simplify a symbolic expression using a ShapeEnv
     # "from the future", where it may have a different set of replacements.
-    def new_with_shape_env(shape_env: ShapeEnv, fake) -> Any:
+    @overload
+    def new_with_shape_env(shape_env: ShapeEnv, fake: int) -> int: ...
+
+    @overload
+    def new_with_shape_env(shape_env: ShapeEnv, fake: torch.SymInt) -> torch.SymInt: ...
+
+    @overload
+    def new_with_shape_env(
+        shape_env: ShapeEnv, fake: torch.SymFloat
+    ) -> torch.SymFloat: ...
+
+    @overload
+    def new_with_shape_env(
+        shape_env: ShapeEnv, fake: FakeTensorMeta
+    ) -> FakeTensorMeta: ...
+
+    def new_with_shape_env(
+        shape_env: ShapeEnv, fake: int | torch.SymInt | torch.SymFloat | FakeTensorMeta
+    ) -> int | torch.SymInt | torch.SymFloat | FakeTensorMeta:
         if isinstance(fake, int):
             return fake
         if isinstance(fake, torch.SymInt):
@@ -784,7 +821,7 @@ def bisect(shape_env):
 
     # Checks whether the given shape_env fails when produce_guards is called.
     def check_shapeenv_fails(
-        shape_env: ShapeEnv, tracked_fakes: list[Any] | None
+        shape_env: ShapeEnv, tracked_fakes: list["TrackedFake"] | None
     ) -> ValidationException | None:
         if tracked_fakes is None:
             raise AssertionError("tracked_fakes is None")
@@ -793,6 +830,7 @@ def bisect(shape_env):
             # don't populate EqualityConstraint list. Reason: we would also have
             # to save OutputGraph.tracked_fakes_id_to_source.
             shape_env.produce_guards(
+                # pyrefly: ignore [no-matching-overload]  # TrackedFake.fake includes FakeTensor
                 [new_with_shape_env(shape_env, a.fake) for a in tracked_fakes],
                 [a.source for a in tracked_fakes],
                 input_contexts=[a.symbolic_context for a in tracked_fakes],
@@ -859,6 +897,7 @@ def bisect(shape_env):
 
     if not (left in exception and isinstance(exception[left], ValidationException)):
         raise AssertionError("Expected ValidationException at bisect result")
+    left_exception: ValidationException = exception[left]  # type: ignore[assignment]
 
     node = assert_nodes[left]
     event = get_node_event(node)
@@ -885,7 +924,7 @@ def bisect(shape_env):
         )
 
     raise BisectValidationException(
-        exception[left],
+        left_exception,
         expr=args[1],
         failed_action=failed_action,
         traced_node=node.meta[CURRENT_NODE_KEY],

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -292,6 +292,7 @@ class Node(_NodeBase):
     # generated function return type. (Note this is a special case. ``return``
     # does not produce a value, it's more of a notation. Thus, this value
     # describes the type of args[0] in the ``return`` node.
+    # TODO: narrow this to TensorType | _DynType | None
     type: Any | None
     _sort_key: Any
     # If set, use this fn to print this node


### PR DESCRIPTION
Remove mypy suppressions. Add return type and parameter type annotations across miscellaneous experimental files.

Authored with Claude.