### PR TITLE
[PyTorch][Export] Fix NaN handling in export guard codegen and input constraint checks (#180399)

### DIFF
--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -472,7 +472,17 @@ def _check_input_constraints_for_graph(
                 )
 
         elif isinstance(node_val, (int, float, str)):
-            if type(arg) is not type(node_val) or arg != node_val:
+            if type(arg) is not type(node_val):
+                raise RuntimeError(
+                    f"Expected input at {get_keystr(key_path)} to be equal to {node_val}, but got {arg}",
+                )
+            # NaN != NaN in Python, so use math.isnan for NaN-to-NaN comparison
+            if isinstance(node_val, float) and math.isnan(node_val):
+                if not isinstance(arg, float) or not math.isnan(arg):
+                    raise RuntimeError(
+                        f"Expected input at {get_keystr(key_path)} to be nan, but got {arg}",
+                    )
+            elif arg != node_val:
                 raise RuntimeError(
                     f"Expected input at {get_keystr(key_path)} to be equal to {node_val}, but got {arg}",
                 )

--- a/torch/export/_unlift.py
+++ b/torch/export/_unlift.py
@@ -205,7 +205,11 @@ def _convert_guards_code_to_fn(
     code_str += "  return\n"
 
     # populate namespace with sympy globals, materialize function (named `_`)
-    namespace = {**SYMPY_INTERP}
+    namespace = {
+        **SYMPY_INTERP,
+        "math": math,
+        "inf": float("inf"),
+    }
     exec(code_str, namespace)
 
     # create and return a module whose forward is the materialized function
@@ -675,7 +679,9 @@ def _get_input_guards_for_graph(
         if isinstance(meta, int):
             new_guards_code.append(f"{src} == {meta}")
         if isinstance(meta, float):
-            if meta == math.inf:
+            if math.isnan(meta):
+                new_guards_code.append(f"math.isnan({src})")
+            elif meta == math.inf:
                 new_guards_code.append(f"{src} == math.inf")
             elif meta == -math.inf:
                 new_guards_code.append(f"{src} == -math.inf")


### PR DESCRIPTION
Summary:

Two bugs in torch.export prevent NaN float scalar inputs from working:

1. Guard codegen in _convert_guards_code_to_fn (_unlift.py) exec'd guard code in a namespace that lacked nan/inf/math definitions. When _get_input_guards_for_graph generated a guard like "L['args'][1] == nan", the exec failed with NameError. Fix: add math, nan, inf, __math_isnan to the exec namespace, and emit __math_isnan() guards for NaN floats instead of equality (since nan == nan is always False).

2. Input constraint check in _check_input_constraints_for_graph (_export/utils.py) used arg != node_val for float equality, which always fails for NaN (nan != nan is True). Fix: special-case NaN using math.isnan for NaN-to-NaN comparison.

Test Plan:
Tested with opinfo e2e comparison ops with NaN scalar inputs in Export mode:

- le; 2; 0; tensor, f32x23; float, nan (export) — PASS
- eq; 2; 0; tensor, f32x23; float, nan (export) — PASS
- gt; 2; 0; tensor, i32x23; float, nan (export) — PASS

Before: NameError: name 'nan' is not defined (guard codegen), then Guard failed: args_1 == nan (equality check)
After: All pass

Reviewed By: StellarrZ

Differential Revision: D100683118


