### PR TITLE
[FakeTensor] Preserve grad_dtype when converting real tensors to fake tensors

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1633,6 +1633,41 @@ class FakeTensorConverterTest(TestCase):
         if y_weak() is not None:
             raise AssertionError("expected y_weak() is None")
 
+    def test_grad_dtype_preserved(self):
+        t = torch.randn(4, dtype=torch.bfloat16, requires_grad=True)
+        t.grad_dtype = torch.float32
+
+        mode = FakeTensorMode()
+        fake_t = mode.from_tensor(t)
+        self.assertEqual(fake_t.grad_dtype, torch.float32)
+
+    def test_grad_dtype_none_preserved(self):
+        t = torch.randn(4, dtype=torch.bfloat16, requires_grad=True)
+        t.grad_dtype = None
+
+        mode = FakeTensorMode()
+        fake_t = mode.from_tensor(t)
+        self.assertIsNone(fake_t.grad_dtype)
+
+    def test_grad_dtype_make_fx(self):
+        def train_step(w):
+            y = (w.float() * 2).sum()
+            (g,) = torch.autograd.grad(y, w)
+            return g
+
+        w = torch.randn(4, dtype=torch.bfloat16, requires_grad=True)
+        w.grad_dtype = torch.float32
+
+        g_eager = train_step(w)
+
+        fake_mode = FakeTensorMode()
+        w_fake = fake_mode.from_tensor(w)
+        with fake_mode:
+            gm = make_fx(train_step)(w_fake)
+        g_traced = gm(w)
+
+        self.assertEqual(g_eager.dtype, g_traced.dtype)
+
 
 make_propagate_real_tensors_cls(FakeTensorConverterTest)
 

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1669,6 +1669,7 @@ class FakeTensorConverterTest(TestCase):
             re_faked = mode.from_tensor(func_t)
         self.assertTrue(re_faked.requires_grad)
 
+    @skipIfTorchDynamo("make_fx tracing is incompatible with dynamo")
     def test_grad_dtype_make_fx(self):
         def train_step(w):
             y = (w.float() * 2).sum()

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1649,6 +1649,26 @@ class FakeTensorConverterTest(TestCase):
         fake_t = mode.from_tensor(t)
         self.assertIsNone(fake_t.grad_dtype)
 
+    def test_grad_dtype_functional_tensor_no_crash(self):
+        from torch._subclasses.functional_tensor import (
+            FunctionalTensor,
+            FunctionalTensorMode,
+        )
+
+        t = torch.randn(4, dtype=torch.bfloat16, requires_grad=True)
+        t.grad_dtype = torch.float32
+
+        mode = FakeTensorMode()
+        fake_t = mode.from_tensor(t)
+        self.assertEqual(fake_t.grad_dtype, torch.float32)
+
+        with FunctionalTensorMode():
+            func_t = FunctionalTensor.to_functional(fake_t)
+            # Re-fakifying a FunctionalTensor should not crash even though
+            # the inner tensor has a custom grad_dtype.
+            re_faked = mode.from_tensor(func_t)
+        self.assertTrue(re_faked.requires_grad)
+
     def test_grad_dtype_make_fx(self):
         def train_step(w):
             y = (w.float() * 2).sum()

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -456,6 +456,14 @@ class FakeTensorConverter:
         if out is NotImplemented:
             raise UnsupportedFakeTensorException("meta converter nyi")
 
+        # Propagate grad_dtype here rather than in meta_converter because
+        # meta tensors don't carry autograd metadata (grad_dtype is stripped
+        # during meta conversion).
+        if t.requires_grad and t.is_leaf:
+            src_grad_dtype = t.grad_dtype
+            if src_grad_dtype != t.dtype:
+                out.grad_dtype = src_grad_dtype
+
         from torch._dynamo.source import RandomValueSource
 
         value = None

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -457,12 +457,23 @@ class FakeTensorConverter:
             raise UnsupportedFakeTensorException("meta converter nyi")
 
         # Propagate grad_dtype here rather than in meta_converter because
-        # meta tensors don't carry autograd metadata (grad_dtype is stripped
-        # during meta conversion).
-        if t.requires_grad and t.is_leaf:
-            src_grad_dtype = t.grad_dtype
-            if src_grad_dtype != t.dtype:
-                out.grad_dtype = src_grad_dtype
+        # meta tensors don't carry autograd metadata.
+        # Unwrap FunctionalTensor because accessing is_leaf/grad_fn on a
+        # FunctionalTensor view whose base was mutated (e.g. via set_())
+        # triggers lazy view replay through __torch_dispatch__, which
+        # errors without an active FunctionalTensorMode.
+        inner_t = (
+            torch._from_functional_tensor(t.elem)
+            if isinstance(t, torch._subclasses.functional_tensor.FunctionalTensor)
+            else t
+        )
+        if (
+            inner_t.requires_grad
+            and inner_t.is_leaf
+            and inner_t.grad_dtype != inner_t.dtype
+            and out.is_leaf
+        ):
+            out.grad_dtype = inner_t.grad_dtype
 
         from torch._dynamo.source import RandomValueSource
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180403

FakeTensorConverter.from_real_tensor() was not propagating the grad_dtype
attribute, causing make_fx tracing to produce incorrect gradient dtypes.
When a bf16 parameter has grad_dtype=f32, the autograd engine preserves
f32 gradients in eager mode, but under tracing the fake tensor lost this
attribute and the traced graph would cast f32 gradients back to bf16.