### PR TITLE
[Stable C shim] Ensure shim usage linter can handle return types of multiple words.

### DIFF
--- a/tools/linter/adapters/stable_shim_usage_linter.py
+++ b/tools/linter/adapters/stable_shim_usage_linter.py
@@ -82,7 +82,7 @@ def get_shim_functions(
     functions: dict[str, tuple[int, int]] = {}
 
     # Match function declarations like: AOTI_TORCH_EXPORT ... function_name(
-    function_pattern = re.compile(r"AOTI_TORCH_EXPORT\s+\w+\s+(\w+)\s*\(")
+    function_pattern = re.compile(r"AOTI_TORCH_EXPORT.+?(\w+)\s*\(")
     # Also match typedef function pointers
     typedef_pattern = re.compile(r"typedef\s+.*\(\*(\w+)\)")
     # Match using declarations like: using TypeName = ...

--- a/tools/test/stable_shim_usage_linter_data/sample_shim.h
+++ b/tools/test/stable_shim_usage_linter_data/sample_shim.h
@@ -98,6 +98,13 @@ AOTI_TORCH_EXPORT int primary_path(int arg);
 AOTI_TORCH_EXPORT int secondary_path(int arg);
 #endif
 
+
+// Function with a return type that consists of multiple words.
+#if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_0
+AOTI_TORCH_EXPORT const char* function_that_returns_constchar();
+#endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_0
+
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/tools/test/test_stable_shim_usage_linter.py
+++ b/tools/test/test_stable_shim_usage_linter.py
@@ -71,6 +71,8 @@ class TestStableShimUsageLinter(unittest.TestCase):
             # Primary path (2.10) and secondary path (2.9) from #if/#elif
             "primary_path": (2, 10),
             "secondary_path": (2, 9),
+            # Function with a return type made up of two words.
+            "function_that_returns_constchar": (2, 12),
         }
 
         self.assertEqual(result, expected)


### PR DESCRIPTION
## Issue

Relates to https://github.com/pytorch/pytorch/issues/179427 , bugfix for the stable shim usage issue encountered in https://github.com/pytorch/pytorch/pull/180135#discussion_r3068591046 suggested to file a separate PR by @janeyx99.

## Summary
The current stable_shim_usage test doesn't correctly match functions that have a return type consisting of two words, like `const char*`, this PR adds a failing test to stable_shim_usage_linter_data and modifies the regular expression to make it pass.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf) Na; test only, trivial change.


## BC-breaking?

Nope, test only.