### PR TITLE
Fix from 20260414-pytorch-adhoc-3d4a84

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -3150,6 +3150,130 @@ def forward(self, arg0_1, arg1_1):
         self.assertTrue("as_strided_scatter" in str(fw_graph_overlap1.code))
         self.assertTrue("as_strided_scatter" in str(fw_graph_overlap2.code))
 
+    def test_merge_view_inputs_error_non_differentiable_views(self):
+        from unittest.mock import MagicMock
+
+        from torch._functorch._aot_autograd.runtime_wrappers import merge_view_inputs
+        from torch._functorch._aot_autograd.schemas import InputAliasInfo
+
+        def make_input_info(mutates_data):
+            return InputAliasInfo(
+                is_leaf=True,
+                mutates_data=mutates_data,
+                mutates_metadata=False,
+                mutations_hidden_from_autograd=False,
+                mutations_under_no_grad_or_inference_mode=False,
+                mutation_inductor_storage_resize=False,
+                mutates_storage_metadata=False,
+                requires_grad=False,
+                keep_input_mutations=False,
+            )
+
+        cfg = MagicMock()
+        cfg.aot_id = 0
+        cfg.aot_autograd_arg_pos_to_source = None
+
+        # Two inputs sharing storage via set_() — both have _base=None,
+        # so they are not differentiable views of each other.
+        base = torch.randn(10)
+        a = torch.empty(5, dtype=torch.float32)
+        a.set_(base.untyped_storage(), 0, (5,), (1,))
+        b = torch.empty(5, dtype=torch.float32)
+        b.set_(base.untyped_storage(), 0, (5,), (1,))
+
+        fwd_inputs = [a, b]
+        mutated_input_info = [make_input_info(True), make_input_info(False)]
+
+        self.assertExpectedRaisesInline(
+            AssertionError,
+            lambda: merge_view_inputs(
+                cfg, fwd_inputs, None, mutated_input_info, is_inference=False
+            ),
+            """aot_autograd() does not yet handle non-differentiable view input mutations. input 0 (__dummy0) and input 1 (__dummy1) share storage but are not differentiable views of each other.""",  # noqa: B950
+        )
+
+    def test_merge_view_inputs_error_different_bases(self):
+        from unittest.mock import MagicMock
+
+        from torch._functorch._aot_autograd.runtime_wrappers import merge_view_inputs
+        from torch._functorch._aot_autograd.schemas import InputAliasInfo
+
+        def make_input_info(mutates_data):
+            return InputAliasInfo(
+                is_leaf=True,
+                mutates_data=mutates_data,
+                mutates_metadata=False,
+                mutations_hidden_from_autograd=False,
+                mutations_under_no_grad_or_inference_mode=False,
+                mutation_inductor_storage_resize=False,
+                mutates_storage_metadata=False,
+                requires_grad=False,
+                keep_input_mutations=False,
+            )
+
+        cfg = MagicMock()
+        cfg.aot_id = 0
+        cfg.aot_autograd_arg_pos_to_source = None
+
+        # Two views with different _base tensors. Use inference mode to
+        # bypass the site-1 check (which would fire first in training mode).
+        big = torch.randn(10, requires_grad=True)
+        detached_big = big.detach().requires_grad_(True)
+        v1 = big[0:5]
+        v2 = detached_big[0:5]
+
+        fwd_inputs = [v1, v2]
+        mutated_input_info = [make_input_info(True), make_input_info(False)]
+
+        self.assertExpectedRaisesInline(
+            AssertionError,
+            lambda: merge_view_inputs(
+                cfg, fwd_inputs, None, mutated_input_info, is_inference=True
+            ),
+            """aot_autograd() does not yet handle non-differentiable view input mutations. Aliased inputs share storage but have different autograd ._base tensors: input 0 (__dummy0) and input 1 (__dummy1) have ._base fields that point to different tensors.""",  # noqa: B950
+        )
+
+    def test_merge_view_inputs_error_mixed_base_states(self):
+        from unittest.mock import MagicMock
+
+        from torch._functorch._aot_autograd.runtime_wrappers import merge_view_inputs
+        from torch._functorch._aot_autograd.schemas import InputAliasInfo
+
+        def make_input_info(mutates_data):
+            return InputAliasInfo(
+                is_leaf=True,
+                mutates_data=mutates_data,
+                mutates_metadata=False,
+                mutations_hidden_from_autograd=False,
+                mutations_under_no_grad_or_inference_mode=False,
+                mutation_inductor_storage_resize=False,
+                mutates_storage_metadata=False,
+                requires_grad=False,
+                keep_input_mutations=False,
+            )
+
+        cfg = MagicMock()
+        cfg.aot_id = 0
+        cfg.aot_autograd_arg_pos_to_source = None
+
+        # One view with _base set, one with _base=None, sharing storage.
+        # Use inference mode to bypass the site-1 check.
+        big = torch.randn(10, requires_grad=True)
+        a = big[0:5]  # a._base = big
+        b = torch.empty(5, dtype=torch.float32)
+        b.set_(big.untyped_storage(), 0, (5,), (1,))  # _base=None, shares storage
+
+        fwd_inputs = [a, b]
+        mutated_input_info = [make_input_info(True), make_input_info(False)]
+
+        self.assertExpectedRaisesInline(
+            AssertionError,
+            lambda: merge_view_inputs(
+                cfg, fwd_inputs, None, mutated_input_info, is_inference=True
+            ),
+            """aot_autograd() does not yet handle non-differentiable view input mutations. Aliased inputs share storage but have mixed autograd ._base states: ['input 0 (__dummy0)'] have ._base set, while ['input 1 (__dummy1)'] have ._base=None (and are not the synthetic base).""",  # noqa: B950
+        )
+
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
     def test_mem_leak_from_save_for_bw(self):
         # See a full diagnosis at this issue: https://github.com/pytorch/pytorch/issues/94990

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1715,6 +1715,17 @@ def merge_view_inputs(
             return False
         return True
 
+    def _format_input(idx: int) -> str:
+        if (
+            aot_config.aot_autograd_arg_pos_to_source is not None
+            and idx < len(aot_config.aot_autograd_arg_pos_to_source)
+            and aot_config.aot_autograd_arg_pos_to_source[idx] is not None
+        ):
+            name = aot_config.aot_autograd_arg_pos_to_source[idx].name
+        else:
+            name = fwd_inputs_descs[idx].expr()
+        return f"input {idx} ({name})"
+
     if len(fwd_inputs) != len(mutated_input_info):
         raise AssertionError(
             f"expected len(fwd_inputs) == len(mutated_input_info), "
@@ -1793,7 +1804,9 @@ def merge_view_inputs(
             if not is_inference:
                 if not _are_differentiable_views(view1, view2):
                     raise AssertionError(
-                        "aot_autograd() does not yet handle non-differentiable view input mutations."
+                        f"aot_autograd() does not yet handle non-differentiable view input mutations. "
+                        f"{_format_input(idx1)} and {_format_input(idx2)} share storage but are "
+                        f"not differentiable views of each other."
                     )
             # Regenerating views when reinterpreting complex / real tensors seems non-trivial,
             # not handling for now
@@ -1849,15 +1862,30 @@ def merge_view_inputs(
             # Case where all of the aliases require gradients, and have the same _base.
             i, synthetic_base = non_none_bases[0]
             synthetic_base_desc = ViewBaseAOTInput(fwd_inputs_descs[i])
-            for _, other_base in non_none_bases[1:]:
+            for j, other_base in non_none_bases[1:]:
                 if other_base is not synthetic_base:
                     raise AssertionError(
-                        "aot_autograd() does not yet handle non-differentiable view input mutations."
+                        f"aot_autograd() does not yet handle non-differentiable view input mutations. "
+                        f"Aliased inputs share storage but have different autograd ._base tensors: "
+                        f"{_format_input(i)} and {_format_input(j)} have ._base fields that point to different tensors."
                     )
             for alias in aliases_with_none_bases:
                 if alias is not synthetic_base:
+                    none_base_indices = [
+                        _format_input(k)
+                        for k in aliased_input_indices
+                        if fwd_inputs[k]._base is None
+                    ]
+                    has_base_indices = [
+                        _format_input(k)
+                        for k in aliased_input_indices
+                        if fwd_inputs[k]._base is not None
+                    ]
                     raise AssertionError(
-                        "aot_autograd() does not yet handle non-differentiable view input mutations."
+                        f"aot_autograd() does not yet handle non-differentiable view input mutations. "
+                        f"Aliased inputs share storage but have mixed autograd ._base states: "
+                        f"{has_base_indices} have ._base set, while "
+                        f"{none_base_indices} have ._base=None (and are not the synthetic base)."
                     )
         base_args.append(synthetic_base)
         base_args_descs.append(synthetic_base_desc)


### PR DESCRIPTION
## Human Note
Raised by @danielvegamyhre, we have no idea which views caused the issue. This PR adds the problematic node names.

## Agent Report
# Report: Use FX node names in merge_view_inputs error messages

## Summary

Updated error messages in `merge_view_inputs()` to use the Dynamo source name (the FX graph's node identifier) as the primary input identifier, and removed the "All aliased inputs" / "To fix, try calling .clone()" boilerplate from all three error sites.

## Changes

### File: `torch/_functorch/_aot_autograd/runtime_wrappers.py`

**`_format_input(idx)`** — Now prioritizes `aot_config.aot_autograd_arg_pos_to_source[idx].name` (the Dynamo Source name, e.g., `L['self'].weight`, `L['x']`) as the primary identifier. Falls back to `fwd_inputs_descs[idx].expr()` (AOTAutograd descriptor, e.g., `args[0]`, `__dummy0`) when no Dynamo source is available. Removed shape/dtype from the format for conciseness.

New format: `input 0 (L['self'].weight)` (with Dynamo) or `input 0 (__dummy0)` (without).

**All three error sites** — Removed:
- `f"All aliased inputs: [{input_info}]. "`
- `f"To fix, try calling .clone() on the affected inputs before passing them to the compiled function."`

### File: `test/functorch/test_aotdispatch.py`

Updated the 3 `assertExpectedRaisesInline` tests to match the new shorter message format.

### Note on FX node names

The AOTAutograd FX graph hasn't been traced yet when `merge_view_inputs` runs (it's called during `pre_compile`, before `make_fx`). The Dynamo `Source.name` (available via `aot_config.aot_autograd_arg_pos_to_source`) is the closest identifier to an FX node name at this point — it's the expression that Dynamo uses to refer to inputs and is directly derived from how the user references variables in their code.

## Testing

All 9 tests pass (3 tests × 3 inherited classes). `spin fixlint` passes cleanly.


<details>
<summary>Agent Worklog</summary>

## Run 1

> Task: Improve error messages for 'non-differentiable view input mutations' in AOTAutograd.

## Step 1: Exploration

Read the three error sites in `runtime_wrappers.py`:
1. **Line 1795**: `_are_differentiable_views(view1, view2)` fails for consecutive aliased input pairs.
2. **Line 1854**: `other_base is not synthetic_base` — aliased inputs have `_base` fields pointing to different base tensors.
3. **Line 1859**: `alias is not synthetic_base` — mix of aliased inputs with/without `_base`, and `_base=None` ones aren't the synthetic base.

Also read `_are_differentiable_views` (line 1700): returns False when both views have `_base=None` or when they don't share a common `_base`.

Now implementing improved error messages for all three sites.

## Step 2: Implementation

Edited all three `AssertionError` messages in `merge_view_inputs()` to include:
- Input indices involved
- Tensor shapes and dtypes
- Specific failure reason (not differentiable views / different bases / mixed base states)
- Fix suggestion: `.clone()` the inputs

Minor code change: renamed `_` to `j` in site 2's loop to capture the index for the error message.

## Step 3: Testing

Wrote `test_error_messages.py` calling `merge_view_inputs()` directly with crafted inputs.
All three sites produce improved messages. All checks pass (indices, shape, dtype, .clone() suggestion, explanation).

## Step 4: Lint & outputs

`spin fixlint` — no issues. Generated `fix.diff` and `report.md`.


## Run 2

> **User:** you should add tests, they should use assertexpectraises to match the error message

### Step 1: Research test infrastructure

Found `assertExpectedRaisesInline` (from `expecttest.TestCase`, inherited by PyTorch's `TestCase`) — calls the callable, catches the exception, and asserts the full `str(e)` matches the inline expected string. This is the standard pattern used in `test_aotdispatch.py`.

### Step 2: Added tests

Added 3 tests to `TestAOTAutograd` in `test/functorch/test_aotdispatch.py`:

1. **`test_merge_view_inputs_error_non_differentiable_views`** — Site 1: two `set_()` tensors sharing storage with `_base=None` (non-inference mode).
2. **`test_merge_view_inputs_error_different_bases`** — Site 2: two views with different `_base` tensors (inference mode to bypass site 1).
3. **`test_merge_view_inputs_error_mixed_base_states`** — Site 3: one view with `_base` set, one with `_base=None` (inference mode).

All use `assertExpectedRaisesInline` with the full error message inline.

### Step 3: Verification

All 9 tests pass (3 tests × 3 inherited test classes: `TestAOTAutograd`, `TestAOTAutogradWithDynamo`, `TestAOTAutogradWithCache`). `spin fixlint` passes cleanly.



## Run 3

> **User:** could we make the error message more tied to the node name in the graph, including its stack trace ideally?  remove the section about how this commonly happens due to reasons

### Step 1: Research available node/source info

Explored `merge_view_inputs()` context to find what graph-level identifiers are available:
- `fwd_inputs_descs[idx].expr()` — AOTAutograd descriptor giving semantic names like `self.get_parameter('weight')`, `args[0]`
- `aot_config.aot_autograd_arg_pos_to_source[idx].name` — Dynamo source name like `L['self'].weight`, `L['x']`
- Input placeholder nodes don't carry user stack traces (they're function arguments). The Dynamo source name is the best "trace" info available.

### Step 2: Implementation

Added `_format_input(idx)` helper inside `merge_view_inputs()` that builds a string like:
`input 0 (self.get_parameter('weight'), source=L['self'].weight, shape=torch.Size([5, 3]), dtype=torch.float32)`

Updated all 3 error sites to use `_format_input()`. Removed the "This commonly happens when..." section from all 3. Fixed `Source.name` usage (it's a `cached_property`, not a method — `src.name` not `src.name()`).

### Step 3: Tests & lint

Updated the 3 existing `assertExpectedRaisesInline` tests to match new message format. Set `cfg.aot_autograd_arg_pos_to_source = None` on mock configs. All 9 tests pass. `spin fixlint` clean.



## Run 4

> **User:** this ideally should be using the node name in the fx.GraphModule. also remove                         f"All aliased inputs: [{input_info}]. "
                        f"To fix, try calling .clone() on the affected inputs before passing them "
                        f"to the compiled function."

### Step 1: Research FX node name availability

Investigated whether the FX GraphModule's placeholder node names are accessible from `merge_view_inputs()`. Found that:
- The AOTAutograd FX graph has **not been traced yet** at the point `merge_view_inputs` runs (it's called during `pre_compile`, before `make_fx`).
- However, `aot_config.aot_autograd_arg_pos_to_source[idx].name` gives the **Dynamo source name** (e.g., `L['self'].weight`, `L['x']`) — this is the closest thing to an FX node name available at this point, and is directly tied to how the user refers to their inputs.
- `fwd_inputs_descs[idx].expr()` gives AOTAutograd descriptor names (e.g., `self.get_parameter('weight')`, `args[0]`), which are less directly tied to the FX graph.

### Step 2: Implementation

Updated `_format_input()` to:
1. **Prioritize `Source.name`** (the Dynamo source / FX node name) when available
2. **Fall back to `desc.expr()`** (AOTAutograd descriptor) when no Dynamo source exists (e.g., standalone AOTAutograd usage)
3. **Simplified format**: `input {idx} ({name})` — removed shape/dtype which added clutter

Removed from all 3 error sites:
- `f"All aliased inputs: [{input_info}]. "`
- `f"To fix, try calling .clone() on the affected inputs before passing them to the compiled function."`

### Step 3: Tests & lint

Updated all 3 `assertExpectedRaisesInline` test messages. All 9 tests pass (3 tests × 3 inherited classes). `spin fixlint` clean. Generated `fix.diff`.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*