### PR TITLE
[BE] Improve error message around data dependent errors for .any()/.all() uses

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -810,7 +810,7 @@ Data-dependent branching
         # File "test_error_messages.py", line N, in fn, code: if x.sum() > 0:
         gt = gt(sum_1, 0)
 
-  Hint: The branch condition uses a scalar integer tensor. Consider rewriting the computation to use plain Python ints (e.g. use int attributes instead of tensor buffers) so the condition becomes a shape guard instead of data-dependent branching.
+  Hint: For the common pattern `if tensor_cond: x = transform(x)` (e.g. clamping inf/nan values), consider making the code branchless by always applying the transform. Operations like torch.clamp, torch.nan_to_num, and torch.where are typically no-ops on well-behaved inputs and compile without graph breaks.
   Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
   Hint: Use `torch.cond` to express dynamic control flow.
 
@@ -821,6 +821,35 @@ Data-dependent branching
 from user code:
    File "test_error_messages.py", line N, in fn
     if x.sum() > 0:""",
+        )
+
+    def test_data_dependent_branching_bool_tensor_hints(self):
+        def cast_overflow_tensors(tensors, offset=1000):
+            if tensors.isinf().any() or tensors.isnan().any():
+                clamp_value = torch.finfo(tensors.dtype).max - offset
+                tensors = torch.clamp(tensors, min=-clamp_value, max=clamp_value)
+            return tensors
+
+        self.assertExpectedInlineMunged(
+            Unsupported,
+            lambda: torch.compile(
+                cast_overflow_tensors, backend="eager", fullgraph=True
+            )(torch.randn(3)),
+            """\
+Data-dependent branching
+  Explanation: Detected data-dependent branching (e.g. `if my_tensor.sum() > 0:`). Dynamo does not support tracing dynamic control flow.
+  Hint: For the common pattern `if tensor_cond: x = transform(x)` (e.g. clamping inf/nan values), consider making the code branchless by always applying the transform. Operations like torch.clamp, torch.nan_to_num, and torch.where are typically no-ops on well-behaved inputs and compile without graph breaks.
+  Hint: Note: Python `or`/`and` between tensor expressions (e.g. `tensor.any() or other_tensor.any()`) triggers implicit bool conversion. Use `torch.logical_or`/`torch.logical_and` or the `|`/`&` operators instead.
+  Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
+  Hint: Use `torch.cond` to express dynamic control flow.
+
+  Developer debug context: attempted to jump with TensorVariable()
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
+
+from user code:
+   File "test_error_messages.py", line N, in cast_overflow_tensors
+    if tensors.isinf().any() or tensors.isnan().any():""",  # noqa: B950
         )
 
     # Test that the bytecode source attribution is correct with VariableTracker
@@ -888,7 +917,7 @@ Graph Break Reason: Data-dependent branching
         # File "test_error_messages.py", line N, in fn, code: if x.sum() > 0:
         gt = gt(sum_1, 0)
 
-  Hint: The branch condition uses a scalar integer tensor. Consider rewriting the computation to use plain Python ints (e.g. use int attributes instead of tensor buffers) so the condition becomes a shape guard instead of data-dependent branching.
+  Hint: For the common pattern `if tensor_cond: x = transform(x)` (e.g. clamping inf/nan values), consider making the code branchless by always applying the transform. Operations like torch.clamp, torch.nan_to_num, and torch.where are typically no-ops on well-behaved inputs and compile without graph breaks.
   Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
   Hint: Use `torch.cond` to express dynamic control flow.
 
@@ -1109,7 +1138,7 @@ Data-dependent branching
         # File "test_error_messages.py", line N, in gn, code: if x.sum() > 0:
         gt = gt(sum_1, 0)
 
-  Hint: The branch condition uses a scalar integer tensor. Consider rewriting the computation to use plain Python ints (e.g. use int attributes instead of tensor buffers) so the condition becomes a shape guard instead of data-dependent branching.
+  Hint: For the common pattern `if tensor_cond: x = transform(x)` (e.g. clamping inf/nan values), consider making the code branchless by always applying the transform. Operations like torch.clamp, torch.nan_to_num, and torch.where are typically no-ops on well-behaved inputs and compile without graph breaks.
   Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
   Hint: Use `torch.cond` to express dynamic control flow.
 
@@ -1159,7 +1188,7 @@ Data-dependent branching
         # File "test_error_messages.py", line N, in fn, code: if x.sum() > 0:
         gt = gt(sum_1, 0)
 
-  Hint: The branch condition uses a scalar integer tensor. Consider rewriting the computation to use plain Python ints (e.g. use int attributes instead of tensor buffers) so the condition becomes a shape guard instead of data-dependent branching.
+  Hint: For the common pattern `if tensor_cond: x = transform(x)` (e.g. clamping inf/nan values), consider making the code branchless by always applying the transform. Operations like torch.clamp, torch.nan_to_num, and torch.where are typically no-ops on well-behaved inputs and compile without graph breaks.
   Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
   Hint: Use `torch.cond` to express dynamic control flow.
 
@@ -2282,7 +2311,7 @@ Data-dependent branching
         # File "test_error_messages.py", line N, in f1, code: if x.sum() > 0:
         gt = gt(sum_1, 0)
 
-  Hint: The branch condition uses a scalar integer tensor. Consider rewriting the computation to use plain Python ints (e.g. use int attributes instead of tensor buffers) so the condition becomes a shape guard instead of data-dependent branching.
+  Hint: For the common pattern `if tensor_cond: x = transform(x)` (e.g. clamping inf/nan values), consider making the code branchless by always applying the transform. Operations like torch.clamp, torch.nan_to_num, and torch.where are typically no-ops on well-behaved inputs and compile without graph breaks.
   Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
   Hint: Use `torch.cond` to express dynamic control flow.
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -683,13 +683,13 @@ def generic_jump(
         hints: list[str] = []
         if isinstance(value, TensorVariable):
             try:
-                example = value.proxy.node.meta.get("example_value")
+                node = value.proxy.node
+                example = node.meta.get("example_value")
                 if (
                     example is not None
                     and example.dim() == 0
                     and example.dtype
                     in (
-                        torch.bool,
                         torch.int32,
                         torch.int64,
                     )
@@ -700,6 +700,32 @@ def generic_jump(
                         "ints (e.g. use int attributes instead of tensor buffers) "
                         "so the condition becomes a shape guard instead of "
                         "data-dependent branching."
+                    )
+                if (
+                    example is not None
+                    and example.dim() == 0
+                    and example.dtype == torch.bool
+                ):
+                    hints.append(
+                        "For the common pattern `if tensor_cond: x = transform(x)` "
+                        "(e.g. clamping inf/nan values), consider making the code "
+                        "branchless by always applying the transform. Operations like "
+                        "torch.clamp, torch.nan_to_num, and torch.where are typically "
+                        "no-ops on well-behaved inputs and compile without graph breaks."
+                    )
+                # Detect boolean reductions (any/all) which are a telltale sign
+                # of `tensor.any() or other_tensor.any()` patterns.
+                # node.target is a str for call_method nodes (e.g. tensor.any())
+                # and a callable for call_function nodes (e.g. torch.any()).
+                target_name = getattr(node.target, "__name__", None) or (
+                    node.target if isinstance(node.target, str) else None
+                )
+                if target_name in ("any", "all", "bitwise_and", "bitwise_or"):
+                    hints.append(
+                        "Note: Python `or`/`and` between tensor expressions (e.g. "
+                        "`tensor.any() or other_tensor.any()`) triggers implicit bool "
+                        "conversion. Use `torch.logical_or`/`torch.logical_and` or the "
+                        "`|`/`&` operators instead."
                     )
             except Exception:
                 pass


### PR DESCRIPTION
Adds two new hints to the data-dependent branching graph break message:

1. Suggests branchless workarounds (torch.clamp, torch.nan_to_num, torch.where) for the common guard-then-transform pattern like `if tensor.isinf().any(): tensor = clamp(tensor)`.

2. Warns about Python `or`/`and` between tensor expressions causing implicit bool conversion, and suggests torch.logical_or/torch.logical_and or `|`/`&` operators.

Motivation: vLLM's `cast_overflow_tensors` function (used by Voxtral, Qwen2.5-VL, etc.) uses `if tensors.isinf().any() or tensors.isnan().any(): ...` which causes graph breaks. Users attempting to fix this with torch.cond find it difficult to debug. The branchless approach is simpler and more discoverable

### Test plan
```bash
python test/dynamo/test_error_messages.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98