### PR TITLE
linalg.qr: reject overlapping or aliased Q and R in out=

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/core/grad_mode.h>
 #include <ATen/Dispatch.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorMeta.h>
 #include <ATen/TensorOperators.h>
@@ -709,6 +710,14 @@ TORCH_META_FUNC(linalg_qr)(const Tensor& A,
   at::native::checkIsMatrix(A, "linalg.qr");
   at::native::checkFloatingOrComplex(A, "linalg.qr");
   auto [compute_q, reduced_mode] = at::native::_parse_qr_mode(mode);
+
+  if (compute_q) {
+    const auto& out_q = maybe_get_output(0);
+    const auto& out_r = maybe_get_output(1);
+    if (out_q.defined() && out_r.defined()) {
+      at::assert_no_overlap(out_q, out_r);
+    }
+  }
 
   auto A_shape = A.sizes().vec();
   const auto m = A_shape.cend()[-2];

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -715,7 +715,11 @@ TORCH_META_FUNC(linalg_qr)(const Tensor& A,
     const auto& out_q = maybe_get_output(0);
     const auto& out_r = maybe_get_output(1);
     if (out_q.defined() && out_r.defined()) {
-      at::assert_no_overlap(out_q, out_r);
+      // This does the same as at::assert_no_overlap(out_q, out_r); but with a message better suited for this use case.
+      const auto lap = at::get_overlap_status(out_q, out_r);
+      TORCH_CHECK(
+          lap != at::MemOverlapStatus::Partial && lap != at::MemOverlapStatus::Full,
+          "linalg.qr: Q and R in out=(Q, R) cannot alias or partially overlap in memory.");
     }
   }
 

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -715,11 +715,10 @@ TORCH_META_FUNC(linalg_qr)(const Tensor& A,
     const auto& out_q = maybe_get_output(0);
     const auto& out_r = maybe_get_output(1);
     if (out_q.defined() && out_r.defined()) {
-      // This does the same as at::assert_no_overlap(out_q, out_r); but with a message better suited for this use case.
       const auto lap = at::get_overlap_status(out_q, out_r);
       TORCH_CHECK(
-          lap != at::MemOverlapStatus::Partial && lap != at::MemOverlapStatus::Full,
-          "linalg.qr: Q and R in out=(Q, R) cannot alias or partially overlap in memory.");
+          lap == at::MemOverlapStatus::No,
+          "linalg.qr: Q and R in out=(Q, R) must be non-overlapping.");
     }
   }
 

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -716,8 +716,14 @@ TORCH_META_FUNC(linalg_qr)(const Tensor& A,
     const auto& out_r = maybe_get_output(1);
     if (out_q.defined() && out_r.defined()) {
       const auto lap = at::get_overlap_status(out_q, out_r);
+      if (lap == at::MemOverlapStatus::TooHard) {
+        TORCH_WARN_ONCE(
+            "linalg.qr: could not verify whether the out= tensors Q and R are "
+            "memory-disjoint.");
+      }
       TORCH_CHECK(
-          lap == at::MemOverlapStatus::No,
+          lap != at::MemOverlapStatus::Partial &&
+              lap != at::MemOverlapStatus::Full,
           "linalg.qr: Q and R in out=(Q, R) must be non-overlapping.");
     }
   }

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4433,7 +4433,7 @@ class TestLinalg(TestCase):
         out = torch.zeros_like(x)
         with self.assertRaisesRegex(
             RuntimeError,
-            r"linalg\.qr: Q and R in out=\(Q, R\) cannot alias or partially overlap in memory\.",
+            r"linalg\.qr: Q and R in out=\(Q, R\) must be non-overlapping\.",
         ):
             torch.linalg.qr(x, out=(out, out))
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4424,6 +4424,19 @@ class TestLinalg(TestCase):
         with self.assertRaisesRegex(RuntimeError, "qr received unrecognized mode 'hello'"):
             torch.linalg.qr(t2, mode='hello')
 
+    @skipCPUIfNoLapack
+    @skipCUDAIfNoCusolver
+    @dtypes(torch.float)
+    def test_linalg_qr_out_aliased_outputs_error(self, device, dtype):
+        # non-overlapping-tensors check for out=.
+        x = torch.randn(2, 2, device=device, dtype=dtype)
+        out = torch.zeros_like(x)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"unsupported operation: some elements.*single memory location",
+        ):
+            torch.linalg.qr(x, out=(out, out))
+
     def _check_einsum(self, *args, np_args=None):
         if np_args is None:
             np_args = [arg.cpu().numpy() if isinstance(arg, torch.Tensor) else arg for arg in args]

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4433,7 +4433,7 @@ class TestLinalg(TestCase):
         out = torch.zeros_like(x)
         with self.assertRaisesRegex(
             RuntimeError,
-            r"unsupported operation: some elements.*single memory location",
+            r"linalg\.qr: Q and R in out=\(Q, R\) cannot alias or partially overlap in memory\.",
         ):
             torch.linalg.qr(x, out=(out, out))
 


### PR DESCRIPTION
Previously, passing the same tensor for both out arguments of `torch.linalg.qr` could succeed on square matrices and produce wrong results.

This PR adds a check at the start of `TORCH_META_FUNC(linalg_qr)` that checks `at::get_overlap_status` on the `out` tensors if they exist. That runs before `set_output_strided`, so it applies to the real user buffers. The error message is specific to `linalg.qr` and `out=(Q, R)`.  

Currently, there will not be an error if `mode='r'` and the `out` tensor will produce the `R` tensor of the QR factorization. I am open to throwing an error for `mode='r'` too if there is a good reason.

Fixes #180377