### PR TITLE
[Profiler][PrivateUse1] Expose backend name as alias in ProfilerActivity for PrivateUse1

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_misc.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_misc.py
@@ -22,7 +22,9 @@ class TestBackendModule(TestCase):
 
         self.assertTrue(hasattr(ProfilerActivity, "OPENREG"))
         self.assertEqual(ProfilerActivity.OPENREG, ProfilerActivity.PrivateUse1)
-        self.assertEqual(repr(ProfilerActivity.OPENREG), "<ProfilerActivity.OPENREG: 5>")
+        self.assertEqual(
+            repr(ProfilerActivity.OPENREG), "<ProfilerActivity.OPENREG: 5>"
+        )
 
     def test_backend_module_registration(self):
         """Test backend module registration error handling"""

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_misc.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_misc.py
@@ -16,6 +16,14 @@ class TestBackendModule(TestCase):
         with self.assertRaisesRegex(RuntimeError, "has already been set"):
             torch.utils.rename_privateuse1_backend("dev")
 
+    def test_profiler_activity_alias(self):
+        """Test ProfilerActivity exposes device-specific alias for PrivateUse1"""
+        from torch._C._profiler import ProfilerActivity
+
+        self.assertTrue(hasattr(ProfilerActivity, "OPENREG"))
+        self.assertEqual(ProfilerActivity.OPENREG, ProfilerActivity.PrivateUse1)
+        self.assertEqual(repr(ProfilerActivity.OPENREG), "<ProfilerActivity.OPENREG: 5>")
+
     def test_backend_module_registration(self):
         """Test backend module registration error handling"""
 

--- a/torch/utils/backend_registration.py
+++ b/torch/utils/backend_registration.py
@@ -76,9 +76,25 @@ def rename_privateuse1_backend(backend_name: str) -> None:
         >>> a = torch.ones(2, device="foo")
 
     """
+    from torch._C._profiler import ProfilerActivity
+
     _rename_privateuse1_backend(backend_name)
     global _privateuse1_backend_name
     _privateuse1_backend_name = backend_name
+    # Mirror the rename in ProfilerActivity so users can write e.g.
+    # ProfilerActivity.<backend_name> instead of ProfilerActivity.PrivateUse1.
+    pu1 = ProfilerActivity.PrivateUse1
+    alias = backend_name.upper()
+    setattr(ProfilerActivity, alias, pu1)
+
+    original_repr = ProfilerActivity.__repr__
+
+    def custom_repr(self):
+        if self == pu1:
+            return f"<ProfilerActivity.{alias}: {pu1.value}>"
+        return original_repr(self)
+
+    ProfilerActivity.__repr__ = custom_repr
 
 
 def _check_register_once(module, attr) -> None:


### PR DESCRIPTION
Fixes #179806 

### Summary

This pull request improves support for custom backends in PyTorch by ensuring that when a private use backend is renamed, the profiler activity enum (`ProfilerActivity`) also reflects this change. This allows users to refer to the custom backend by its new name in profiling code, making the API more intuitive and consistent.


### Changes

Updates to profiler activity enum for renamed backends:

* When `rename_privateuse1_backend` is called, a new alias is added to `ProfilerActivity` so users can reference the backend by its new name (e.g., `ProfilerActivity.FOO`), and the alias is added to the enum's members.
* The test `test_external_module_register_with_renamed_backend` is updated to check that `ProfilerActivity` exposes the renamed backend as an alias for `PrivateUse1` and that the alias is present in the enum's members.

cc @divyanshk @fffrog 