### PR TITLE
Fix FSDP2 grouped module hooks for partial group forward (chunked loss)

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -832,6 +832,151 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
                 )
 
     @skip_if_lt_x_gpu(2, allow_cpu=True)
+    def test_partial_group_forward_then_standalone(self):
+        """
+        Tests the chunked-loss pattern with grouped FSDP modules: model forward
+        skips one module in the group, then that module is called standalone in a
+        chunk loop with per-chunk backward. This exercises the case where
+        ``modules_to_run`` in ``_register_group_forward_hooks`` has stale entries
+        from a previous incomplete group forward.
+
+        Uses separate ``fully_shard()`` calls as reference to verify gradient
+        correctness end-to-end.
+        """
+        self.run_subtests(
+            {"reshard_after_forward": [True, False]},
+            self._test_partial_group_forward_then_standalone,
+        )
+
+    def _test_partial_group_forward_then_standalone(
+        self,
+        reshard_after_forward: bool | int,
+    ):
+        class ChunkedHeadModel(nn.Module):
+            def __init__(self, dim: int, vocab_size: int) -> None:
+                super().__init__()
+                self.embed = nn.Embedding(vocab_size, dim)
+                self.body = nn.Linear(dim, dim, bias=False)
+                self.norm = nn.RMSNorm(dim)
+                self.head = nn.Linear(dim, vocab_size, bias=False)
+
+            def forward(
+                self, tokens: torch.Tensor, *, skip_head: bool = False
+            ) -> torch.Tensor:
+                h = self.embed(tokens)
+                h = self.body(h)
+                h = self.norm(h)
+                if skip_head:
+                    return h
+                return self.head(h)
+
+        dim, vocab_size, n_chunks = 32, 128, 4
+        fsdp_kwargs: dict = {"reshard_after_forward": reshard_after_forward}
+
+        def _run_chunked(model: nn.Module):
+            """Run the chunked-loss pattern. Returns (total_loss, grads)."""
+            h = model(tokens, skip_head=True)
+            h_detached = h.detach().requires_grad_(True)
+            chunks = torch.chunk(h_detached, n_chunks, dim=1)
+            h_grads: list[torch.Tensor] = []
+            total_loss = torch.tensor(0.0, device=h.device)
+            head_grad_norms: list[float] = []
+            for chunk in chunks:
+                chunk = chunk.contiguous().detach().requires_grad_(True)
+                out = model.head(chunk)
+                loss = out.sum()
+                total_loss += loss.detach()
+                loss.backward()
+                h_grads.append(chunk.grad.detach())
+                head_grad = model.head.weight.grad
+                if isinstance(head_grad, DTensor):
+                    head_grad = head_grad.full_tensor()
+                head_grad_norms.append(head_grad.norm().item())
+            # Verify gradients actually accumulated across chunks
+            for i in range(1, len(head_grad_norms)):
+                self.assertGreater(
+                    head_grad_norms[i],
+                    head_grad_norms[i - 1],
+                    f"head.weight.grad did not grow from chunk {i - 1} to {i}, "
+                    f"gradient accumulation may be broken",
+                )
+            h.backward(torch.cat(h_grads, dim=1))
+            grads = {}
+            for name, param in model.named_parameters():
+                self.assertIsNotNone(param.grad, f"grad is None for {name}")
+                if isinstance(param.grad, DTensor):
+                    grads[name] = param.grad.full_tensor().clone()
+                else:
+                    grads[name] = param.grad.clone()
+            return total_loss, grads
+
+        torch.manual_seed(42)
+        tokens = torch.randint(0, vocab_size, (2, 16), device=device_type.type)
+
+        # Reference: plain model, chunked forward, all-reduce grads
+        torch.manual_seed(42)
+        ref_model = ChunkedHeadModel(dim, vocab_size).to(device_type)
+        with torch.no_grad():
+            for param in ref_model.parameters():
+                dist.broadcast(param, src=0)
+        ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-2)
+
+        # Test: grouped [norm, head] with chunked forward
+        torch.manual_seed(42)
+        model = ChunkedHeadModel(dim, vocab_size).to(device_type)
+        with torch.no_grad():
+            for param in model.parameters():
+                dist.broadcast(param, src=0)
+        fully_shard(model.embed, **fsdp_kwargs)
+        fully_shard(model.body, **fsdp_kwargs)
+        fully_shard([model.norm, model.head], **fsdp_kwargs)
+        fully_shard(model, **fsdp_kwargs)
+        optim = torch.optim.Adam(model.parameters(), lr=1e-2)
+
+        for iter_idx in range(10):
+            # Reference: chunked forward + backward, all-reduce grads
+            ref_loss, ref_grads = _run_chunked(ref_model)
+            for param in ref_model.parameters():
+                if param.grad is not None:
+                    dist.all_reduce(param.grad)
+                    param.grad.div_(self.world_size)
+
+            # Test: chunked forward + backward with grouped FSDP
+            fsdp_loss, grads = _run_chunked(model)
+
+            # Compare losses
+            self.assertEqual(
+                ref_loss, fsdp_loss, msg=f"Loss mismatch at iter {iter_idx}"
+            )
+
+            # Compare gradients
+            for name in ref_grads:
+                self.assertEqual(
+                    grads[name],
+                    ref_grads[name],
+                    msg=f"Gradient mismatch for {name} at iter {iter_idx}",
+                )
+
+            for _optim in (ref_optim, optim):
+                _optim.step()
+                _optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+
+            # Compare parameters after optimizer step
+            for (ref_name, ref_param), (_, fsdp_param) in zip(
+                ref_model.named_parameters(), model.named_parameters()
+            ):
+                fsdp_full = (
+                    fsdp_param.full_tensor()
+                    if isinstance(fsdp_param, DTensor)
+                    else fsdp_param
+                )
+                self.assertEqual(
+                    fsdp_full,
+                    ref_param,
+                    msg=f"Param mismatch for {ref_name} at iter {iter_idx}",
+                )
+
+    @skip_if_lt_x_gpu(2, allow_cpu=True)
     def test_double_forward_with_nested_fsdp_and_checkpoint(self):
         """
         Tests that calling model.forward() twice before backward() works correctly

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -313,6 +313,26 @@ class FSDPState(_State):
         output = self._register_pre_backward_hook(output)
         self._training_state = TrainingState.IDLE
         if self._state_ctx.iter_forward_root is self:
+            for state in self._state_ctx.all_states:
+                if state is not self and state._modules_to_run_forward:
+                    # A grouped fully_shard's forward did not run all modules
+                    # (e.g. chunked loss skipping lm_head). Force-complete the
+                    # group's post-forward so that params are resharded and
+                    # backward hooks are registered on the root output.
+                    warning_once(
+                        logger,
+                        f"{len(state._modules_to_run_forward)} of "
+                        f"{len(state._modules)} modules passed to "
+                        f"fully_shard did not run forward: "
+                        f"{list(state._modules_to_run_forward)}. Consider "
+                        f"using separate fully_shard() calls for modules "
+                        f"that may not always run together.",
+                    )
+                    state._modules_to_run_forward.clear()
+                    for fsdp_param_group in state._fsdp_param_groups:
+                        fsdp_param_group.post_forward(module, input, output)
+                    output = state._register_pre_backward_hook(output)
+                    state._training_state = TrainingState.IDLE
             if all_gather_state := self._comm_ctx.all_gather_state:
                 # Free the last all-gather result if needed; refer to
                 # [Note: Overlapping all-gather copy-in and all-gather]
@@ -364,6 +384,11 @@ class FSDPState(_State):
                     state._finalize_backward()
             if self._state_ctx.is_last_backward:
                 self._comm_ctx.post_forward_order.clear()
+                # Clear iter_forward_root in case a grouped module's
+                # post-forward never fired (e.g. partial group forward
+                # followed by standalone calls in a chunk loop), leaving
+                # iter_forward_root stale.
+                self._state_ctx.iter_forward_root = None
                 # Catch the last module's RS states that no subsequent
                 # module's group N-1 wait will clear.
                 for rs_state in self._comm_ctx.reduce_scatter_states:
@@ -428,11 +453,31 @@ def _register_group_forward_hooks(
     modules_set = set(modules)
 
     @_dynamo_disable
-    @functools.wraps(pre_hook)
-    def wrapped_pre_hook(*args: Any, **kwargs: Any):
-        if len(modules_to_run) == 0:  # first to run
-            modules_to_run.update(modules_set)
-            return pre_hook(*args, **kwargs)
+    def get_wrapped_pre_hook(module: nn.Module):
+        @functools.wraps(pre_hook)
+        def wrapped_pre_hook(*args: Any, **kwargs: Any):
+            if len(modules_to_run) == 0:  # first to run
+                modules_to_run.update(modules_set)
+                return pre_hook(*args, **kwargs)
+            if module not in modules_to_run:
+                # This module already ran and was discarded in a previous
+                # group forward, but other modules in the group were skipped
+                # so the set was never fully cleared. Reset and start a new
+                # group forward so that unshard runs for this call.
+                warning_once(
+                    logger,
+                    f"FSDP group forward: {len(modules_to_run)} of "
+                    f"{len(modules_set)} modules did not run in the previous "
+                    f"group forward: {list(modules_to_run)}. Consider using "
+                    f"separate fully_shard() calls for modules that may not "
+                    f"always run together.",
+                )
+                modules_to_run.clear()
+                modules_to_run.update(modules_set)
+                return pre_hook(*args, **kwargs)
+            # Mid-group: this module hasn't run yet, unshard already happened
+
+        return wrapped_pre_hook
 
     @_dynamo_disable
     def get_wrapped_post_hook(module: nn.Module):
@@ -446,7 +491,7 @@ def _register_group_forward_hooks(
 
     pre_handles = [
         module.register_forward_pre_hook(
-            wrapped_pre_hook, prepend=True, with_kwargs=True
+            get_wrapped_pre_hook(module), prepend=True, with_kwargs=True
         )
         for module in modules
     ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180425

we have `fully_shard([norm, output])` in torchtitan

without chunked loss, norm and output are executed together. it's fine
for fsdp2 to bookkeeping _modules_to_run = [norm, output] to avoid
reshard in between norm and output

with chunked loss, norm is always executed, but output is skipped. it's
not ok to rely on empty _modules_to_run to trigger unshard/reshard

we relax the assumption
1. Per-module pre-hook: wrapped_pre_hook is now per-module (like wrapped_post_hook
  already was). When a module is NOT in modules_to_run, the set is stale from a previous incomplete group
  forward — clear and re-unshard. When it IS in the set, it's a legitimate mid-group call — no-op as before.

2. Root post-forward cleanup — When the root's _post_forward fires, force-complete any child state with
  non-empty _modules_to_run_forward: reshard params and register backward hooks on the root output. Without
  this, h.backward() crashes because the group's _pre_backward hooks were never registered on the model
  forward's output graph

3. Clear iter_forward_root in post-backward — The chunk loop's _pre_forward sets iter_forward_root to the
  group's state, which is never cleared because the group's _post_forward doesn't fire. Without this, iteration
  2+ crashes because _root_pre_forward skips root init.