### PR TITLE
[AMD][PyTorch] Redirect index_add_ to scatter_add_ on HIP for large tensors (#180430)

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1533,6 +1533,23 @@ void index_reduce_func_cuda_impl(
 
 TORCH_IMPL_FUNC(index_add_cuda_out)
 (const Tensor& self, int64_t dim, const Tensor& index, const Tensor& source, const Scalar& alpha, const Tensor& result) {
+#if defined(__HIP_PLATFORM_AMD__)
+  // On AMD MI350X, scatter_add_ outperforms the indexFuncLargeIndex
+  // atomicAdd path across all measured source sizes (>=1.0x at 1K rising
+  // to ~2x for uniform / ~5x for Zipf-distributed indices). Always
+  // redirect for the matching shape; see bench_index_add_powerlaw.py.
+  if (alpha.equal(1) && dim == 0 && self.dim() == 2) {
+    // Mirror index_add_cuda_impl's structured-kernel pre-copy: for
+    // out-of-place / index_add(out=...) the result is uninitialized
+    // and must be seeded with self before accumulating.
+    if (!result.is_same(self)) {
+      result.copy_(self);
+    }
+    auto expanded_index = index.to(at::kLong).unsqueeze(1).expand_as(source);
+    result.scatter_add_(dim, expanded_index, source);
+    return;
+  }
+#endif
   index_add_cuda_impl(self, dim, index, source, alpha, result);
 }
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_device_type import (
     expectedFailureMPS,
     instantiate_device_type_tests,
     onlyCPU,
+    onlyCUDA,
     onlyNativeDeviceTypes,
     onlyOn,
     skipMPS,
@@ -2124,6 +2125,155 @@ class TestIndexing(TestCase):
             num_idx,
             100,
             "3D vec4 sliceSize=128",
+        )
+
+    @onlyCUDA
+    @dtypes(torch.float, torch.bfloat16, torch.half)
+    def test_index_add_correctness_2d_large(self, device, dtype):
+        # Correctness for the path used on HIP when index_add_ is redirected
+        # to scatter_add_ (alpha=1, dim=0, 2D). Uses duplicate indices
+        # (200K src into 1K dest) to stress-test atomic accumulation.
+        # On NVIDIA CUDA this exercises the original index_add_ kernel and
+        # is still useful coverage. Selection is verified separately by
+        # test_index_add_redirect_kernel_selection_hip.
+        num_dest, dim = 1000, 64
+        num_src = 200_000
+
+        idx = torch.randint(0, num_dest, (num_src,), device=device, dtype=torch.int64)
+        src = torch.randn(num_src, dim, dtype=dtype, device=device)
+        dst = torch.zeros(num_dest, dim, dtype=dtype, device=device)
+
+        # Reference on CPU in float32
+        dst_ref = torch.zeros(num_dest, dim, dtype=torch.float32)
+        dst_ref.index_add_(0, idx.cpu(), src.cpu().float())
+
+        dst.index_add_(0, idx, src)
+
+        # bf16/fp16 with ~200 atomicAdds per row accumulates rounding error
+        # up to several tenths in worst-case elements; use L2 relative error
+        # rather than per-element max to avoid flakes from outliers.
+        if dtype in (torch.bfloat16, torch.half):
+            err = (dst.cpu().float() - dst_ref).norm().item()
+            ref_norm = max(dst_ref.norm().item(), 1e-8)
+            self.assertLess(
+                err / ref_norm,
+                1e-2,
+                f"index_add_ {dtype} L2 rel err too high: {err / ref_norm}",
+            )
+        else:
+            self.assertEqual(
+                dst.cpu(),
+                dst_ref,
+                atol=1e-5,
+                rtol=1e-5,
+                msg=f"index_add_ correctness failed for {dtype}",
+            )
+
+    @onlyCUDA
+    @dtypes(torch.float, torch.bfloat16)
+    def test_index_add_correctness_2d_out_of_place(self, device, dtype):
+        # Regression test: torch.index_add (out-of-place) and
+        # torch.index_add(..., out=) hit the same TORCH_IMPL_FUNC as the
+        # in-place variant via structured_delegate. The HIP redirect must
+        # seed `result` with self before scattering, otherwise out-of-place
+        # accumulates into uninitialized memory.
+        num_dest, dim, num_src = 200, 32, 5000
+
+        idx = torch.randint(0, num_dest, (num_src,), device=device, dtype=torch.int64)
+        src = torch.randn(num_src, dim, dtype=dtype, device=device)
+        self_ = torch.randn(num_dest, dim, dtype=dtype, device=device)
+
+        # Reference: CPU fp32 in-place starting from self
+        ref = self_.cpu().float().clone()
+        ref.index_add_(0, idx.cpu(), src.cpu().float())
+
+        # Functional out-of-place: returns a fresh tensor.
+        out_func = torch.index_add(self_, 0, idx, src)
+        # Out-explicit: caller-provided destination tensor.
+        out_explicit = torch.empty_like(self_)
+        torch.index_add(self_, 0, idx, src, out=out_explicit)
+
+        atol = 5e-2 if dtype == torch.bfloat16 else 1e-5
+        rtol = 1e-2 if dtype == torch.bfloat16 else 1e-5
+        self.assertEqual(out_func.cpu().float(), ref, atol=atol, rtol=rtol)
+        self.assertEqual(out_explicit.cpu().float(), ref, atol=atol, rtol=rtol)
+        # self must be untouched by out-of-place form.
+        self.assertFalse(out_func.data_ptr() == self_.data_ptr())
+
+    @onlyCUDA
+    def test_index_add_correctness_2d_alpha(self, device):
+        # Correctness with alpha != 1, which bypasses the HIP redirect and
+        # always hits index_add_'s native alpha-scaling path on both HIP
+        # and CUDA.
+        num_dest, dim = 100, 32
+        num_src = 200_000
+        idx = torch.randint(0, num_dest, (num_src,), device=device, dtype=torch.int64)
+        src = torch.randn(num_src, dim, dtype=torch.float32, device=device)
+        dst = torch.zeros(num_dest, dim, dtype=torch.float32, device=device)
+
+        dst_ref = torch.zeros(num_dest, dim, dtype=torch.float32)
+        dst_ref.index_add_(0, idx.cpu(), src.cpu(), alpha=2.0)
+
+        dst.index_add_(0, idx, src, alpha=2.0)
+        self.assertEqual(dst.cpu(), dst_ref, atol=1e-5, rtol=1e-5)
+
+    @onlyCUDA
+    def test_index_add_redirect_kernel_selection_hip(self, device):
+        # Verify the HIP-only redirect actually fires for matching cases
+        # and does NOT fire for any unmet condition. The redirect calls
+        # scatter_add_ from inside the index_add_ implementation, which
+        # surfaces in the profiler as an aten::scatter_add_ event nested
+        # under aten::index_add_. CUDA (NVIDIA) has no redirect.
+        if not torch.version.hip:
+            raise unittest.SkipTest("redirect is HIP-only")
+
+        n_dest, dim, n_src = 100, 32, 1024
+        idx = torch.randint(0, n_dest, (n_src,), device=device, dtype=torch.int64)
+
+        def saw_scatter_add(fn):
+            with torch.profiler.profile(
+                activities=[torch.profiler.ProfilerActivity.CPU]
+            ) as prof:
+                fn()
+                torch.cuda.synchronize()
+            return any(e.name == "aten::scatter_add_" for e in prof.events())
+
+        # 1. Conditions met (alpha=1, dim=0, 2D): redirect MUST fire.
+        dst = torch.zeros(n_dest, dim, dtype=torch.float32, device=device)
+        src = torch.randn(n_src, dim, dtype=torch.float32, device=device)
+        self.assertTrue(
+            saw_scatter_add(lambda: dst.index_add_(0, idx, src)),
+            "redirect should fire when alpha=1, dim=0, 2D",
+        )
+
+        # 2. alpha != 1 -> bypass.
+        self.assertFalse(
+            saw_scatter_add(lambda: dst.index_add_(0, idx, src, alpha=2.0)),
+            "alpha != 1 must bypass redirect",
+        )
+
+        # 3. dim != 0 -> bypass.
+        dst_t = torch.zeros(dim, n_dest, dtype=torch.float32, device=device)
+        src_t = torch.randn(dim, n_src, dtype=torch.float32, device=device)
+        self.assertFalse(
+            saw_scatter_add(lambda: dst_t.index_add_(1, idx, src_t)),
+            "dim != 0 must bypass redirect",
+        )
+
+        # 4. 1D tensor -> bypass (self.dim() != 2).
+        dst_1d = torch.zeros(n_dest, dtype=torch.float32, device=device)
+        src_1d = torch.randn(n_src, dtype=torch.float32, device=device)
+        self.assertFalse(
+            saw_scatter_add(lambda: dst_1d.index_add_(0, idx, src_1d)),
+            "1D tensor must bypass redirect",
+        )
+
+        # 5. 3D tensor -> bypass (self.dim() != 2).
+        dst_3d = torch.zeros(n_dest, dim, 4, dtype=torch.float32, device=device)
+        src_3d = torch.randn(n_src, dim, 4, dtype=torch.float32, device=device)
+        self.assertFalse(
+            saw_scatter_add(lambda: dst_3d.index_add_(0, idx, src_3d)),
+            "3D tensor must bypass redirect",
         )
 
     @onlyNativeDeviceTypes


### PR DESCRIPTION
Summary:

CONTEXT: On AMD MI350X, index_add_ with large source tensors and Zipf-distributed indices (common in MPZCH embedding tables) suffers from severe bf16 atomicAdd contention. The indexFuncLargeIndex kernel serializes on CAS-loop atomics when many threads target the same destination rows.

WHAT: When running on HIP with alpha=1, dim=0, and 2D tensors, redirect index_add_ to scatter_add_, which uses a different kernel path that avoids the atomicAdd contention bottleneck. The redirect now fires unconditionally for the matching shape; an earlier revision gated it on `source.size(0) > 100000`, but a size sweep showed scatter_add_ is at parity with index_add_ at n=1K and strictly faster from n=5K onward, so the threshold was unnecessarily conservative.

The redirect mirrors `index_add_cuda_impl`'s structured-kernel pre-copy: `if (!result.is_same(self)) result.copy_(self);` — required so that the out-of-place `torch.index_add(self, ...)` and `torch.index_add(self, ..., out=...)` paths (which share the same TORCH_IMPL_FUNC via structured_delegate) seed `result` before scatter_add_ accumulates into it.

Also adds:
- bench_index_add_powerlaw.py: reproduces the issue with Zipf-distributed indices at various alpha values, plus a size sweep that justifies removing the threshold.
- test_index_add_redirect_kernel_selection_hip in test_indexing.py: verifies via torch.profiler that the redirect actually fires for matching cases and is bypassed for alpha != 1, dim != 0, 1D, and 3D inputs (addressing reviewer feedback that prior tests only covered numerical correctness, not selection).
- test_index_add_correctness_2d_out_of_place: regression test for the structured-kernel pre-copy path (functional and explicit-out forms of torch.index_add).

Test Plan:
**Existing benchmark on AMD MI350X (gfx950), dst=[634364, 128] bf16, src=[9039274, 128] bf16:**

| Distribution     | index_add_ (before) | scatter_add_ (after) | Speedup |
|------------------|---------------------|----------------------|---------|
| Uniform          |          7,673 us   |          3,926 us    |   2.0x  |
| Zipf alpha=0.5   |          8,034 us   |          3,912 us    |   2.1x  |
| Zipf alpha=1.0   |         68,996 us   |         16,695 us    |   4.1x  |
| Zipf alpha=1.5   |        397,525 us   |         83,434 us    |   4.8x  |
| Zipf alpha=2.0   |        689,997 us   |        132,012 us    |   5.2x  |
| Zipf alpha=2.5   |        889,804 us   |        161,805 us    |   5.5x  |
| Zipf alpha=3.0   |      1,021,968 us   |        180,512 us    |   5.7x  |

Zipf alpha=1.5 matches the ~420,000 us observed in the IG Threads LSR Slimper training trace. The redirect achieves 4.8x speedup for this case.

**Threshold sweep on AMD MI350X (justifies removing the >100K gate). All bf16, dst=[634364, 128]:**

Uniform indices:

| src_size | index_add_ | scatter_add_ | Speedup |
|---------:|-----------:|-------------:|--------:|
|    1,000 |     21.6us |       21.5us |   1.00x |
|    5,000 |     24.5us |       21.5us |   1.14x |
|   10,000 |     28.4us |       22.6us |   1.26x |
|   50,000 |     62.0us |       36.8us |   1.69x |
|  100,000 |    105.0us |       55.5us |   1.89x |
|  200,000 |    193.7us |       93.3us |   2.08x |
|1,000,000 |    889.4us |      451.7us |   1.97x |
|9,039,274 |  7,698.5us |    3,935.3us |   1.96x |

Zipf alpha=1.5 (the contention regime that motivated this change):

| src_size | index_add_ | scatter_add_ | Speedup |
|---------:|-----------:|-------------:|--------:|
|    1,000 |     61.5us |       25.1us |   2.45x |
|    5,000 |    230.1us |       60.9us |   3.78x |
|   10,000 |    457.0us |      109.4us |   4.18x |
|   50,000 |  2,224.4us |      480.9us |   4.63x |
|  100,000 |  4,397.2us |      937.2us |   4.69x |
|9,039,274 |397,906.9us |   83,519.0us |   4.76x |

Conclusion: scatter_add_ is at parity at the smallest measured size and strictly faster from 5K onward, on every distribution tested. Removing the size gate is a clear win. Bench command:

```
buck run mode/dev-nosan-amd-gpu -m rocm70 -m fbcode//triton/cc:force_noop //scripts/haoyuz/amd/index_add:bench_index_add_powerlaw
```

**Numerical correctness on AMD MI350X (//scripts/haoyuz/amd/index_add:test_index_add_redirect, all 7 PASS):**

```
test_unique_indices_fp32              ... ok  (bit-exact)
test_unique_indices_bf16              ... ok  (no contention -> close to f32 ref)
test_small_exact_bf16                 ... ok  (small int inputs -> both paths exact in bf16)
test_duplicates_fp32_exact            ... ok  (deterministic atomicAdd in fp32)
test_contention_bf16_relative_error   ... ok  (L2 rel err < 0.01)
test_high_contention_zipf_bf16        ... ok  (L2 rel err < 0.5 even with 76K dupes)
test_redirect_kernel_selection_via_profiler ... ok  (profiler confirms scatter_add_ fires only for matching cases)
```

**test_indexing.py changes:**

- `test_index_add_correctness_2d_large` (fp32 + bf16 + fp16): Compares the redirected path to a CPU f32 reference for a 200K x 64 case with duplicate indices. Uses L2 relative error for low-precision dtypes (worst-case per-element error from ~200 atomic accumulations is too large for max-abs).
- `test_index_add_correctness_2d_out_of_place`: Regression test for the structured-kernel pre-copy. Exercises both `torch.index_add(self, ...)` (functional) and `torch.index_add(self, ..., out=...)` paths, which would silently produce garbage if the redirect skipped the `result.copy_(self)` seeding step.
- `test_index_add_correctness_2d_alpha`: Validates alpha != 1 path correctness (which always bypasses the redirect).
- `test_index_add_redirect_kernel_selection_hip`: HIP-only profiler-based test that asserts (a) redirect fires when alpha=1, dim=0, 2D, and (b) is bypassed for alpha != 1, dim != 0, 1D, and 3D inputs. This addresses reviewer feedback that previous tests only checked numerical correctness, not which kernel was selected.

**AI review fixes incorporated in this revision:**

- BUG (critical): Out-of-place `torch.index_add(self, ...)` and `torch.index_add(..., out=)` reach the same TORCH_IMPL_FUNC via `structured_delegate` and start with an uninitialized `result`. The redirect was missing the `result.copy_(self)` seeding that the legacy `index_add_cuda_impl` does at the top of its body — fixed by mirroring that pre-copy.
- Test gap: added `test_index_add_correctness_2d_out_of_place` regression for the above.
- Test fix: `test_small_exact_bf16` previously computed `dst_before` (bypass) but never asserted on it; added assertion.
- Test stability: `test_index_add_correctness_2d_large` used `atol=1e-1` per-element max for bf16, which is borderline tight for 200 dupes/row; switched to L2 relative error (< 1e-2).
- Test guard: standalone `test_index_add_redirect.py` is now class-level HIP-only (numerical comparisons on NVIDIA exercise the same kernel for both paths, providing no real coverage).

Co-authored-by: Claude

Reviewed By: echen4096

Differential Revision: D100635529


