### PR TITLE
[CPU][Inductor] Improve oneDNN qlinear primitive cache: per-thread map and zero-copy cache hit

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -470,6 +470,9 @@ at::Tensor _qconv_prepack_onednn(
 struct QlinearForwardParams {
   dnnl::matmul primitive;
   ideep::exec_args args;
+  ideep::tensor src;
+  ideep::tensor dst;
+  std::optional<ideep::tensor> src1;
   ideep::tensor packed_weight;
   ideep::tensor weight_scales;
   std::optional<ideep::tensor> src_scale;
@@ -480,8 +483,13 @@ struct QlinearForwardParams {
   ideep::tensor scratchpad;
 
   void init_args() {
+    args.insert({DNNL_ARG_SRC, src});
     args.insert({DNNL_ARG_WEIGHTS, packed_weight});
+    args.insert({DNNL_ARG_DST, dst});
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
+    if (src1.has_value()) {
+      args.insert({DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, src1.value()});
+    }
     if (bias.has_value()) {
       args.insert({DNNL_ARG_BIAS, bias.value()});
     }

--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -468,6 +468,11 @@ at::Tensor _qconv_prepack_onednn(
 #endif
 
 struct QlinearForwardParams {
+  int64_t K{-1};
+  int64_t M{-1};
+  int64_t N{-1};
+  c10::ScalarType out_dtype{c10::ScalarType::Undefined};
+  std::vector<int64_t> output_size;
   dnnl::matmul primitive;
   ideep::exec_args args;
   ideep::tensor src;

--- a/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/OnednnUtils.h
@@ -10,6 +10,7 @@
 #endif
 
 #include <c10/util/CallOnce.h>
+#include <c10/util/hash.h>
 
 using PrimitiveCacheKey = std::tuple<
     double, // input_scale
@@ -467,9 +468,25 @@ at::Tensor _qconv_prepack_onednn(
 #define ONEDNN_FP8_QCONV_SUPPORTED
 #endif
 
+struct QlinearForwardCacheKey {
+  int64_t weight_addr;
+  int64_t M;
+
+  bool operator==(const QlinearForwardCacheKey& other) const {
+    return weight_addr == other.weight_addr && M == other.M;
+  }
+};
+
+struct QlinearForwardCacheKeyHash {
+  size_t operator()(const QlinearForwardCacheKey& key) const {
+    const size_t addr_hash = std::hash<int64_t>{}(key.weight_addr);
+    const size_t m_hash = std::hash<int64_t>{}(key.M);
+    return c10::hash_combine(addr_hash, m_hash);
+  }
+};
+
 struct QlinearForwardParams {
   int64_t K{-1};
-  int64_t M{-1};
   int64_t N{-1};
   c10::ScalarType out_dtype{c10::ScalarType::Undefined};
   std::vector<int64_t> output_size;

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1053,18 +1053,19 @@ static at::Tensor fp8_qlinear_onednn_ref(
   return y_f32.to(out_dtype);
 }
 
+template <typename InputScaleType, typename InputZeroPointType>
 static at::Tensor linear_int8_with_onednn_weight(
-    at::Tensor input, // int8 CPU Tensor, not QTensor
-    double input_scale,
-    int64_t input_zero_point,
-    at::Tensor onednn_weight, // int8 tensor from MkldnnCPU
-    at::Tensor weight_scales,
-    at::Tensor weight_zero_points,
-    std::optional<at::Tensor> bias, // plain tensor
+    const at::Tensor& input, // int8 CPU Tensor, not QTensor
+    const InputScaleType& input_scale_arg,
+    const InputZeroPointType& input_zero_point_arg,
+    const at::Tensor& onednn_weight, // int8 tensor from MkldnnCPU
+    const at::Tensor& weight_scales,
+    const at::Tensor& weight_zero_points,
+    const std::optional<at::Tensor>& bias, // plain tensor
     double output_scale,
     int64_t output_zero_point,
     std::optional<c10::ScalarType> output_dtype,
-    std::optional<at::Tensor> other, // extra input for binary post-op
+    const std::optional<at::Tensor>& other, // extra input for binary post-op
     double other_scale,
     int64_t other_zero_point,
     const std::string_view& binary_post_op, // e.g. "none", "sum", "add"
@@ -1086,45 +1087,107 @@ static at::Tensor linear_int8_with_onednn_weight(
         input.scalar_type(), " and ", onednn_weight.scalar_type());
     is_fp8 = true;
   }
+
+  // Fast path with cache of params.
+  static const char* env_var = std::getenv(CACHE_ONEDNN_CONTEXT_FLAG);
+  static const std::string cache_flag_str = env_var ? std::string(env_var) : "";
+  static const bool context_cache_enabled = cache_flag_str != "" && cache_flag_str == "1";
+  static thread_local std::unordered_map<int64_t, QlinearForwardParams>
+      qlinear_forward_params_map;
+  static tensor empty_tensor;
+  static tensor::desc empty_tensor_desc;
+  int64_t weight_addr = at::native::data_ptr_from_mkldnn(onednn_weight);
+#if defined(__powerpc__)
+  bool allow_cache = context_cache_enabled && !is_fp8;
+#else
+  bool allow_cache = context_cache_enabled && !(is_fp8 && !cpuinfo_has_x86_amx_fp16());
+#endif
+  if (allow_cache) {
+    auto it = qlinear_forward_params_map.find(weight_addr);
+    if (it != qlinear_forward_params_map.end()) {
+      auto input_contig =
+          dim == 2 ? input.contiguous() : input.reshape({-1, input.size(dim - 1)}).contiguous();
+      int64_t K = input.size(dim - 1), M = input.numel() / K, N = onednn_weight.size(1);
+
+      auto output_size = input.sizes().vec();
+      output_size[dim - 1] = N;
+      std::vector<int64_t> dst_dims = {M, N};
+      auto out_dtype = output_dtype.has_value() ? output_dtype.value() : input.scalar_type();
+      at::Tensor output = binary_post_op == "sum" ?
+          other.value() :
+          at::empty(
+            dst_dims,
+            at::device(c10::kCPU)
+                .dtype(out_dtype)
+          );
+      if (output.numel() == 0) {
+        return output;
+      }
+
+      auto& params = it->second;
+      params.src.set_data_handle(input_contig.data_ptr());
+      params.dst.set_data_handle(output.data_ptr());
+      if (binary_post_op == "add") {
+        const auto& other_ref = other.value();
+        auto other_2d = other_ref.reshape({-1, other_ref.size(dim - 1)});
+        params.src1->set_data_handle(other_2d.data_ptr());
+      }
+      params.primitive.execute(ideep::stream::default_stream(), params.args);
+      return dim == 2 ? output : output.resize_(output_size);
+    }
+  }
+
+  double input_scale;
+  int64_t input_zero_point;
+  if constexpr (std::is_same_v<std::decay_t<InputScaleType>, at::Tensor>) {
+    TORCH_CHECK(
+        input_scale_arg.numel() == 1 && input_zero_point_arg.numel() <= 1,
+        "onednn int8 linear: act scale/zp size should be 1/<=1");
+    input_scale = input_scale_arg.item().toDouble();
+    input_zero_point =
+        input_zero_point_arg.numel() == 1 ? input_zero_point_arg.item().toLong() : 0;
+  } else {
+    input_scale = input_scale_arg;
+    input_zero_point = input_zero_point_arg;
+  }
+
   TORCH_CHECK(
-      weight_scales.scalar_type() == c10::ScalarType::Float, "weight scales should be dtype c10::ScalarType::Float.");
+      weight_scales.scalar_type() == c10::ScalarType::Float,
+      "weight scales should be dtype c10::ScalarType::Float.");
   TORCH_CHECK(
-      binary_alpha == 1.0f, "onednn qlinear: alpha != 1 for binary post op is not yet supported.");
+      binary_alpha == 1.0f,
+      "onednn qlinear: alpha != 1 for binary post op is not yet supported.");
   bool fp32_output = output_dtype.has_value() && (output_dtype.value() == c10::kFloat);
   bool bf16_output = output_dtype.has_value() && (output_dtype.value() == c10::kBFloat16);
   if (fp32_output || bf16_output) {
     TORCH_CHECK(
-        output_scale == 1.0f && output_zero_point == 0, "onednn qlinear: expect scale=1 and zero point=0 for fp32 output");
+        output_scale == 1.0f && output_zero_point == 0,
+        "onednn qlinear: expect scale=1 and zero point=0 for fp32 output");
   }
   if (binary_post_op != "none") {
-    /* Supported cases for binary post op:
-      +-------------------+--------------+---------------+
-      | Extra input dtype | Output dtype | Post op       |
-      +-------------------+--------------+---------------+
-      | Fp32/bf16         | fp32/bf16    | sum           |
-      +-------------------+--------------+---------------+
-      | Fp32/bf16         | int8         | add           |
-      +-------------------+--------------+---------------+
-      | int8              | fp32/bf16    | not supported |
-      +-------------------+--------------+---------------+
-      | int8              | int8         | sum           |
-      +-------------------+--------------+---------------+
-    */
-    TORCH_CHECK(other.has_value(), "onednn qlinear: the extra input is missing for post op ", binary_post_op);
+    TORCH_CHECK(
+        other.has_value(),
+        "onednn qlinear: the extra input is missing for post op ",
+        binary_post_op);
     if (fp32_output || bf16_output) {
       TORCH_CHECK(
           other_scale == 1.0f && other_zero_point == 0,
-          "onednn qlinear: expect extra input scale = 1.0 and zero point = 0 when output dtype is ", output_dtype.value(),
-          ", but got ", other_scale, " and ", other_zero_point, ", respectively"
-      );
+          "onednn qlinear: expect extra input scale = 1.0 and zero point = 0 when output dtype is ",
+          output_dtype.value(),
+          ", but got ",
+          other_scale,
+          " and ",
+          other_zero_point,
+          ", respectively");
     }
     if (binary_post_op == "sum") {
       auto expected_dtype = output_dtype.has_value() ? output_dtype.value() : input.scalar_type();
       TORCH_CHECK(
           other.value().scalar_type() == expected_dtype,
-          "onednn qlinear: the dtype of extra input for binary post op should be ", expected_dtype,
-          " (same as output dtype), but got ", other.value().scalar_type()
-      );
+          "onednn qlinear: the dtype of extra input for binary post op should be ",
+          expected_dtype,
+          " (same as output dtype), but got ",
+          other.value().scalar_type());
     }
   }
 #if defined(__powerpc__)
@@ -1168,32 +1231,9 @@ static at::Tensor linear_int8_with_onednn_weight(
     return output;
   }
   tensor dst = at::native::itensor_view_from_dense(output);
-  static tensor empty_tensor;
-  static tensor::desc empty_tensor_desc;
   tensor src1 = binary_post_op == "add" ?
       at::native::itensor_view_from_dense(other.value().reshape({-1, other.value().size(dim - 1)})) :
       empty_tensor;
-
-  // Fast path with cache of params
-  static const char* env_var = std::getenv(CACHE_ONEDNN_CONTEXT_FLAG);
-  static const std::string cache_flag_str = env_var ? std::string(env_var) : "";
-  static const bool context_cache_enabled = !cache_flag_str.empty() && cache_flag_str == "1";
-  static thread_local std::unordered_map<int64_t, QlinearForwardParams> qlinear_forward_params_map;
-  int64_t weight_addr = at::native::data_ptr_from_mkldnn(onednn_weight);
-  if (context_cache_enabled) {
-    auto it = qlinear_forward_params_map.find(weight_addr);
-    if (it != qlinear_forward_params_map.end()) {
-      auto& params = it->second;
-      auto& args = params.args;
-      args[DNNL_ARG_SRC] = std::move(src);
-      args[DNNL_ARG_DST] = std::move(dst);
-      if (binary_post_op == "add") {
-        args[DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1] = std::move(src1);
-      }
-      params.primitive.execute(ideep::stream::default_stream(), args);
-      return dim == 2 ? output : output.resize_(output_size);
-    }
-  }
 
   // Regular path
   auto packed_weight = at::native::itensor_from_mkldnn(onednn_weight);
@@ -1296,7 +1336,7 @@ static at::Tensor linear_int8_with_onednn_weight(
   }
   primitive.execute(ideep::stream::default_stream(), args);
   // Update cache if needed
-  if (context_cache_enabled) {
+  if (allow_cache) {
     QlinearForwardParams params;
     params.primitive = primitive;
     params.packed_weight = expected_weight;
@@ -1309,6 +1349,9 @@ static at::Tensor linear_int8_with_onednn_weight(
     params.dst_zero_point = output_zero_point != 0 ? std::make_optional<tensor>(dst_zp_t) : std::nullopt;
     params.bias = with_bias ? std::make_optional<tensor>(onednn_bias) : std::nullopt;
     params.scratchpad = scratchpad;
+    params.src = src;
+    params.dst = dst;
+    params.src1 = binary_post_op == "add" ? std::make_optional<tensor>(src1) : std::nullopt;
     params.init_args();
     qlinear_forward_params_map[weight_addr] = params;
   }
@@ -1409,13 +1452,13 @@ at::Tensor PackedLinearWeightsACL::apply_relu(
 namespace at::native {
 
   Tensor QLinearOnednn::run_pointwise_tensor(
-      Tensor act, // int8 CPU tensor, not QTensor
-      Tensor act_scale,
-      Tensor act_zero_point,
-      Tensor onednn_weight, // int8 tensor from MkldnnCPU
-      Tensor weight_scales,
-      Tensor weight_zero_points,
-      std::optional<Tensor> bias,
+      const Tensor& act, // int8 CPU tensor, not QTensor
+      const Tensor& act_scale,
+      const Tensor& act_zero_point,
+      const Tensor& onednn_weight, // int8 tensor from MkldnnCPU
+      const Tensor& weight_scales,
+      const Tensor& weight_zero_points,
+      const std::optional<Tensor>& bias,
       double output_scale,
       int64_t output_zero_point,
       std::optional<c10::ScalarType> output_dtype,
@@ -1423,14 +1466,10 @@ namespace at::native {
       torch::List<std::optional<at::Scalar>> post_op_args,
       std::string_view post_op_algorithm) {
 #if AT_MKLDNN_ENABLED()
-    // act_zero_point.numel() == 0 for symmetric quantization
-    TORCH_CHECK(act_scale.numel() == 1 && act_zero_point.numel() <= 1,
-        "onednn int8 linear: act scale/zp size should be 1/<=1");
     static std::optional<at::Tensor> other = std::nullopt;
     constexpr std::string_view binary_post_op = "none";
-    int64_t act_zp = act_zero_point.numel() == 1 ? act_zero_point.item().toLong() : 0;
     return linear_int8_with_onednn_weight(
-        act, act_scale.item().toDouble(), act_zp,
+        act, act_scale, act_zero_point,
         onednn_weight, weight_scales, weight_zero_points,
         bias, output_scale, output_zero_point, output_dtype,
         other, /*other scale*/1.0, /*other zp*/0,
@@ -1442,14 +1481,14 @@ namespace at::native {
   }
 
   Tensor QLinearOnednn::run_pointwise_binary_tensor(
-      Tensor act, // int8 CPU tensor, not QTensor
-      Tensor act_scale,
-      Tensor act_zero_point,
-      Tensor onednn_weight, // int8 tensor from MkldnnCPU
-      Tensor weight_scales,
-      Tensor weight_zero_points,
-      std::optional<at::Tensor> other, // extra input for binary post-op
-      std::optional<Tensor> bias,
+      const Tensor& act, // int8 CPU tensor, not QTensor
+      const Tensor& act_scale,
+      const Tensor& act_zero_point,
+      const Tensor& onednn_weight, // int8 tensor from MkldnnCPU
+      const Tensor& weight_scales,
+      const Tensor& weight_zero_points,
+      const std::optional<at::Tensor>& other, // extra input for binary post-op
+      const std::optional<Tensor>& bias,
       double output_scale,
       int64_t output_zero_point,
       std::optional<c10::ScalarType> output_dtype,
@@ -1461,12 +1500,8 @@ namespace at::native {
       torch::List<std::optional<at::Scalar>> unary_post_op_args,
       std::string_view unary_post_op_algorithm) {
 #if AT_MKLDNN_ENABLED()
-    // act_zero_point.numel() == 0 for symmetric quantization
-    TORCH_CHECK(act_scale.numel() == 1 && act_zero_point.numel() <= 1,
-        "onednn int8 linear: act scale/zp size should be 1/<=1");
-    int64_t act_zp = act_zero_point.numel() == 1 ? act_zero_point.item().toLong() : 0;
     return linear_int8_with_onednn_weight(
-        act, act_scale.item().toDouble(), act_zp,
+        act, act_scale, act_zero_point,
         onednn_weight, weight_scales, weight_zero_points,
         bias, output_scale, output_zero_point, output_dtype,
         other, other_scale, other_zero_point,

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1114,7 +1114,7 @@ static at::Tensor linear_int8_with_onednn_weight(
       auto input_contig =
           dim == 2 ? input.contiguous() : input.reshape({-1, input.size(dim - 1)}).contiguous();
       auto& params = it->second;
-        if (params.K == K && params.N == N) {
+      if (params.K == K && params.N == N) {
         at::Tensor output = binary_post_op == "sum"
             ? other.value()
             : at::empty({M, N}, at::device(c10::kCPU).dtype(params.out_dtype));

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1178,7 +1178,7 @@ static at::Tensor linear_int8_with_onednn_weight(
   static const char* env_var = std::getenv(CACHE_ONEDNN_CONTEXT_FLAG);
   static const std::string cache_flag_str = env_var ? std::string(env_var) : "";
   static const bool context_cache_enabled = !cache_flag_str.empty() && cache_flag_str == "1";
-  static std::unordered_map<int64_t, QlinearForwardParams> qlinear_forward_params_map;
+  static thread_local std::unordered_map<int64_t, QlinearForwardParams> qlinear_forward_params_map;
   int64_t weight_addr = at::native::data_ptr_from_mkldnn(onednn_weight);
   if (context_cache_enabled) {
     auto it = qlinear_forward_params_map.find(weight_addr);

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1092,24 +1092,29 @@ static at::Tensor linear_int8_with_onednn_weight(
   static const char* env_var = std::getenv(CACHE_ONEDNN_CONTEXT_FLAG);
   static const std::string cache_flag_str = env_var ? std::string(env_var) : "";
   static const bool context_cache_enabled = cache_flag_str != "" && cache_flag_str == "1";
-  static thread_local std::unordered_map<int64_t, QlinearForwardParams>
+  static thread_local std::unordered_map<
+      QlinearForwardCacheKey,
+      QlinearForwardParams,
+      QlinearForwardCacheKeyHash>
       qlinear_forward_params_map;
   static tensor empty_tensor;
   static tensor::desc empty_tensor_desc;
   int64_t weight_addr = at::native::data_ptr_from_mkldnn(onednn_weight);
+  int64_t K = input.size(dim - 1), M = input.numel() / K, N = onednn_weight.size(1);
+  const QlinearForwardCacheKey cache_key({weight_addr, M});
 #if defined(__powerpc__)
-  bool allow_cache = context_cache_enabled && !is_fp8;
+      bool allow_cache = context_cache_enabled && !is_fp8;
 #else
-  bool allow_cache = context_cache_enabled && !(is_fp8 && !cpuinfo_has_x86_amx_fp16());
+      bool allow_cache =
+          context_cache_enabled && !(is_fp8 && !cpuinfo_has_x86_amx_fp16());
 #endif
   if (allow_cache) {
-    auto it = qlinear_forward_params_map.find(weight_addr);
+    auto it = qlinear_forward_params_map.find(cache_key);
     if (it != qlinear_forward_params_map.end()) {
       auto input_contig =
           dim == 2 ? input.contiguous() : input.reshape({-1, input.size(dim - 1)}).contiguous();
-      int64_t K = input.size(dim - 1), M = input.numel() / K, N = onednn_weight.size(1);
       auto& params = it->second;
-      if (params.K == K && params.M == M && params.N == N) {
+        if (params.K == K && params.N == N) {
         at::Tensor output = binary_post_op == "sum"
             ? other.value()
             : at::empty({M, N}, at::device(c10::kCPU).dtype(params.out_dtype));
@@ -1201,7 +1206,6 @@ static at::Tensor linear_int8_with_onednn_weight(
       dim == 2 ? input.contiguous() : input.reshape({-1, input.size(dim - 1)}).contiguous();
 
   auto src = at::native::itensor_from_tensor(input_contig);
-  int64_t K = input.size(dim - 1), M = input.numel() / K, N = onednn_weight.size(1);
 
   auto output_size = input.sizes().vec();
   output_size[dim - 1] = N;
@@ -1330,7 +1334,6 @@ static at::Tensor linear_int8_with_onednn_weight(
   if (allow_cache) {
     QlinearForwardParams params;
     params.K = K;
-    params.M = M;
     params.N = N;
     params.out_dtype = out_dtype;
     params.output_size = output_size;
@@ -1349,7 +1352,7 @@ static at::Tensor linear_int8_with_onednn_weight(
     params.dst = dst;
     params.src1 = binary_post_op == "add" ? std::make_optional<tensor>(src1) : std::nullopt;
     params.init_args();
-    qlinear_forward_params_map[weight_addr] = params;
+    qlinear_forward_params_map[cache_key] = params;
   }
   return dim == 2 ? output : output.resize_(output_size);
 }

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1108,35 +1108,26 @@ static at::Tensor linear_int8_with_onednn_weight(
       auto input_contig =
           dim == 2 ? input.contiguous() : input.reshape({-1, input.size(dim - 1)}).contiguous();
       int64_t K = input.size(dim - 1), M = input.numel() / K, N = onednn_weight.size(1);
-
-      auto output_size = input.sizes().vec();
-      output_size[dim - 1] = N;
-      std::vector<int64_t> dst_dims = {M, N};
-      auto out_dtype = output_dtype.has_value() ? output_dtype.value() : input.scalar_type();
-      at::Tensor output = binary_post_op == "sum" ?
-          other.value() :
-          at::empty(
-            dst_dims,
-            at::device(c10::kCPU)
-                .dtype(out_dtype)
-          );
-      if (output.numel() == 0) {
-        return output;
-      }
-
       auto& params = it->second;
-      params.src.set_data_handle(input_contig.data_ptr());
-      params.dst.set_data_handle(output.data_ptr());
-      if (binary_post_op == "add") {
-        const auto& other_ref = other.value();
-        auto other_2d = other_ref.reshape({-1, other_ref.size(dim - 1)});
-        params.src1->set_data_handle(other_2d.data_ptr());
+      if (params.K == K && params.M == M && params.N == N) {
+        at::Tensor output = binary_post_op == "sum"
+            ? other.value()
+            : at::empty({M, N}, at::device(c10::kCPU).dtype(params.out_dtype));
+        if (output.numel() == 0) {
+          return output;
+        }
+        params.src.set_data_handle(input_contig.data_ptr());
+        params.dst.set_data_handle(output.data_ptr());
+        if (binary_post_op == "add") {
+          const auto& other_ref = other.value();
+          auto other_2d = other_ref.reshape({-1, other_ref.size(dim - 1)});
+          params.src1->set_data_handle(other_2d.data_ptr());
+        }
+        params.primitive.execute(ideep::stream::default_stream(), params.args);
+        return dim == 2 ? output : output.resize_(params.output_size);
       }
-      params.primitive.execute(ideep::stream::default_stream(), params.args);
-      return dim == 2 ? output : output.resize_(output_size);
     }
   }
-
   double input_scale;
   int64_t input_zero_point;
   if constexpr (std::is_same_v<std::decay_t<InputScaleType>, at::Tensor>) {
@@ -1338,6 +1329,11 @@ static at::Tensor linear_int8_with_onednn_weight(
   // Update cache if needed
   if (allow_cache) {
     QlinearForwardParams params;
+    params.K = K;
+    params.M = M;
+    params.N = N;
+    params.out_dtype = out_dtype;
+    params.output_size = output_size;
     params.primitive = primitive;
     params.packed_weight = expected_weight;
     // keep a copy rather than a view of weight scales

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1452,13 +1452,13 @@ at::Tensor PackedLinearWeightsACL::apply_relu(
 namespace at::native {
 
   Tensor QLinearOnednn::run_pointwise_tensor(
-      const Tensor& act, // int8 CPU tensor, not QTensor
-      const Tensor& act_scale,
-      const Tensor& act_zero_point,
-      const Tensor& onednn_weight, // int8 tensor from MkldnnCPU
-      const Tensor& weight_scales,
-      const Tensor& weight_zero_points,
-      const std::optional<Tensor>& bias,
+      Tensor act, // int8 CPU tensor, not QTensor
+      Tensor act_scale,
+      Tensor act_zero_point,
+      Tensor onednn_weight, // int8 tensor from MkldnnCPU
+      Tensor weight_scales,
+      Tensor weight_zero_points,
+      std::optional<Tensor> bias,
       double output_scale,
       int64_t output_zero_point,
       std::optional<c10::ScalarType> output_dtype,
@@ -1481,14 +1481,14 @@ namespace at::native {
   }
 
   Tensor QLinearOnednn::run_pointwise_binary_tensor(
-      const Tensor& act, // int8 CPU tensor, not QTensor
-      const Tensor& act_scale,
-      const Tensor& act_zero_point,
-      const Tensor& onednn_weight, // int8 tensor from MkldnnCPU
-      const Tensor& weight_scales,
-      const Tensor& weight_zero_points,
-      const std::optional<at::Tensor>& other, // extra input for binary post-op
-      const std::optional<Tensor>& bias,
+      Tensor act, // int8 CPU tensor, not QTensor
+      Tensor act_scale,
+      Tensor act_zero_point,
+      Tensor onednn_weight, // int8 tensor from MkldnnCPU
+      Tensor weight_scales,
+      Tensor weight_zero_points,
+      std::optional<Tensor> other, // extra input for binary post-op
+      std::optional<Tensor> bias,
       double output_scale,
       int64_t output_zero_point,
       std::optional<c10::ScalarType> output_dtype,

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1109,11 +1109,10 @@ static at::Tensor linear_int8_with_onednn_weight(
           context_cache_enabled && !(is_fp8 && !cpuinfo_has_x86_amx_fp16());
 #endif
   if (allow_cache) {
-    auto it = qlinear_forward_params_map.find(cache_key);
-    if (it != qlinear_forward_params_map.end()) {
+    if (qlinear_forward_params_map.contains(cache_key)) {
       auto input_contig =
           dim == 2 ? input.contiguous() : input.reshape({-1, input.size(dim - 1)}).contiguous();
-      auto& params = it->second;
+      auto& params = qlinear_forward_params_map.at(cache_key);
       if (params.K == K && params.N == N) {
         at::Tensor output = binary_post_op == "sum"
             ? other.value()
@@ -1148,42 +1147,44 @@ static at::Tensor linear_int8_with_onednn_weight(
   }
 
   TORCH_CHECK(
-      weight_scales.scalar_type() == c10::ScalarType::Float,
-      "weight scales should be dtype c10::ScalarType::Float.");
+      weight_scales.scalar_type() == c10::ScalarType::Float, "weight scales should be dtype c10::ScalarType::Float.");
   TORCH_CHECK(
-      binary_alpha == 1.0f,
-      "onednn qlinear: alpha != 1 for binary post op is not yet supported.");
+      binary_alpha == 1.0f, "onednn qlinear: alpha != 1 for binary post op is not yet supported.");
   bool fp32_output = output_dtype.has_value() && (output_dtype.value() == c10::kFloat);
   bool bf16_output = output_dtype.has_value() && (output_dtype.value() == c10::kBFloat16);
   if (fp32_output || bf16_output) {
     TORCH_CHECK(
-        output_scale == 1.0f && output_zero_point == 0,
-        "onednn qlinear: expect scale=1 and zero point=0 for fp32 output");
+        output_scale == 1.0f && output_zero_point == 0, "onednn qlinear: expect scale=1 and zero point=0 for fp32 output");
   }
   if (binary_post_op != "none") {
-    TORCH_CHECK(
-        other.has_value(),
-        "onednn qlinear: the extra input is missing for post op ",
-        binary_post_op);
+    /* Supported cases for binary post op:
+      +-------------------+--------------+---------------+
+      | Extra input dtype | Output dtype | Post op       |
+      +-------------------+--------------+---------------+
+      | Fp32/bf16         | fp32/bf16    | sum           |
+      +-------------------+--------------+---------------+
+      | Fp32/bf16         | int8         | add           |
+      +-------------------+--------------+---------------+
+      | int8              | fp32/bf16    | not supported |
+      +-------------------+--------------+---------------+
+      | int8              | int8         | sum           |
+      +-------------------+--------------+---------------+
+    */
+    TORCH_CHECK(other.has_value(), "onednn qlinear: the extra input is missing for post op ", binary_post_op);
     if (fp32_output || bf16_output) {
       TORCH_CHECK(
           other_scale == 1.0f && other_zero_point == 0,
-          "onednn qlinear: expect extra input scale = 1.0 and zero point = 0 when output dtype is ",
-          output_dtype.value(),
-          ", but got ",
-          other_scale,
-          " and ",
-          other_zero_point,
-          ", respectively");
+          "onednn qlinear: expect extra input scale = 1.0 and zero point = 0 when output dtype is ", output_dtype.value(),
+          ", but got ", other_scale, " and ", other_zero_point, ", respectively"
+      );
     }
     if (binary_post_op == "sum") {
       auto expected_dtype = output_dtype.has_value() ? output_dtype.value() : input.scalar_type();
       TORCH_CHECK(
           other.value().scalar_type() == expected_dtype,
-          "onednn qlinear: the dtype of extra input for binary post op should be ",
-          expected_dtype,
-          " (same as output dtype), but got ",
-          other.value().scalar_type());
+          "onednn qlinear: the dtype of extra input for binary post op should be ", expected_dtype,
+          " (same as output dtype), but got ", other.value().scalar_type()
+      );
     }
   }
 #if defined(__powerpc__)

--- a/aten/src/ATen/native/quantized/cpu/qlinear.h
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.h
@@ -7,13 +7,13 @@ namespace at::native {
 class QLinearOnednn final {
  public:
   C10_API static Tensor run_pointwise_tensor(
-      Tensor act, // int8 CPU tensor, not QTensor
-      Tensor act_scale,
-      Tensor act_zero_point,
-      Tensor onednn_weight, // int8 tensor from MkldnnCPU
-      Tensor weight_scales,
-      Tensor weight_zero_points,
-      std::optional<Tensor> bias,
+    const Tensor& act, // int8 CPU tensor, not QTensor
+    const Tensor& act_scale,
+    const Tensor& act_zero_point,
+    const Tensor& onednn_weight, // int8 tensor from MkldnnCPU
+    const Tensor& weight_scales,
+    const Tensor& weight_zero_points,
+    const std::optional<Tensor>& bias,
       double output_scale,
       int64_t output_zero_point,
       std::optional<c10::ScalarType> output_dtype,
@@ -22,14 +22,14 @@ class QLinearOnednn final {
       std::string_view post_op_algorithm);
 
 C10_API static Tensor run_pointwise_binary_tensor(
-      Tensor act, // int8 CPU tensor, not QTensor
-      Tensor act_scale,
-      Tensor act_zero_point,
-      Tensor onednn_weight, // int8 tensor from MkldnnCPU
-      Tensor weight_scales,
-      Tensor weight_zero_points,
-      std::optional<at::Tensor> other, // extra input for binary post-op
-      std::optional<Tensor> bias,
+    const Tensor& act, // int8 CPU tensor, not QTensor
+    const Tensor& act_scale,
+    const Tensor& act_zero_point,
+    const Tensor& onednn_weight, // int8 tensor from MkldnnCPU
+    const Tensor& weight_scales,
+    const Tensor& weight_zero_points,
+    const std::optional<at::Tensor>& other, // extra input for binary post-op
+    const std::optional<Tensor>& bias,
       double output_scale,
       int64_t output_zero_point,
       std::optional<c10::ScalarType> output_dtype,

--- a/aten/src/ATen/native/quantized/cpu/qlinear.h
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.h
@@ -7,13 +7,13 @@ namespace at::native {
 class QLinearOnednn final {
  public:
   C10_API static Tensor run_pointwise_tensor(
-    const Tensor& act, // int8 CPU tensor, not QTensor
-    const Tensor& act_scale,
-    const Tensor& act_zero_point,
-    const Tensor& onednn_weight, // int8 tensor from MkldnnCPU
-    const Tensor& weight_scales,
-    const Tensor& weight_zero_points,
-    const std::optional<Tensor>& bias,
+      Tensor act, // int8 CPU tensor, not QTensor
+      Tensor act_scale,
+      Tensor act_zero_point,
+      Tensor onednn_weight, // int8 tensor from MkldnnCPU
+      Tensor weight_scales,
+      Tensor weight_zero_points,
+      std::optional<Tensor> bias,
       double output_scale,
       int64_t output_zero_point,
       std::optional<c10::ScalarType> output_dtype,
@@ -22,14 +22,14 @@ class QLinearOnednn final {
       std::string_view post_op_algorithm);
 
 C10_API static Tensor run_pointwise_binary_tensor(
-    const Tensor& act, // int8 CPU tensor, not QTensor
-    const Tensor& act_scale,
-    const Tensor& act_zero_point,
-    const Tensor& onednn_weight, // int8 tensor from MkldnnCPU
-    const Tensor& weight_scales,
-    const Tensor& weight_zero_points,
-    const std::optional<at::Tensor>& other, // extra input for binary post-op
-    const std::optional<Tensor>& bias,
+      Tensor act, // int8 CPU tensor, not QTensor
+      Tensor act_scale,
+      Tensor act_zero_point,
+      Tensor onednn_weight, // int8 tensor from MkldnnCPU
+      Tensor weight_scales,
+      Tensor weight_zero_points,
+      std::optional<Tensor> other, // extra input for binary post-op
+      std::optional<Tensor> bias,
       double output_scale,
       int64_t output_zero_point,
       std::optional<c10::ScalarType> output_dtype,

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -260,7 +260,11 @@ def _test_qlinear_pt2e_fast_path_helper(error_conn=None):
                 y_ref = F.linear(x_ref, w_ref, b)
                 qy_ref = torch.quantize_per_tensor(y_ref, y_scale, y_zp, torch.quint8)
 
-                assert qy_ref.dim() == qy_cpu.dim()
+                np.testing.assert_equal(
+                    qy_ref.dim(),
+                    qy_cpu.dim(),
+                    err_msg="Quantized qlinear pt2e output dims do not match.",
+                )
                 np.testing.assert_array_almost_equal(
                     qy_ref.int_repr().cpu().numpy(),
                     qy_cpu.cpu().numpy(),
@@ -345,8 +349,16 @@ def _test_qlinear_fp8_fast_path_helper(error_conn=None):
                 y_ref = F.linear(x_ref, w_ref, b)
                 y_ref = _quantize_fp8_for_process(y_ref, torch.tensor([y_scale]))
 
-                assert y_ref.dim() == qy.dim()
-                assert torch.equal(y_ref.float(), qy.float())
+                np.testing.assert_equal(
+                    y_ref.dim(),
+                    qy.dim(),
+                    err_msg="Quantized qlinear fp8 output dims do not match.",
+                )
+                np.testing.assert_equal(
+                    y_ref.float().cpu().numpy(),
+                    qy.float().cpu().numpy(),
+                    err_msg="Quantized qlinear fp8 outputs do not match.",
+                )
                 if torch.isnan(qy).any():
                     raise AssertionError("Output qy contains NaN values")
         if error_conn is not None:

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -4597,8 +4597,6 @@ class TestQuantizedLinear(TestCase):
         unary_post_op_args=(),
         post_op_algorithms=("none",),
     ):
-        import os
-        test_fast_path = os.getenv("ONEDNN_CACHE_CONTEXT_UNSAFE", "0") == "1"
         qlinear_prepack = torch.ops.onednn.qlinear_prepack
         linear_op = F.linear
         in_channels_list = [4, 8]
@@ -4650,14 +4648,12 @@ class TestQuantizedLinear(TestCase):
                 qw_cpu = qw.int_repr()
                 qw_packed = qlinear_prepack(qw_cpu, x.shape)
 
-                num_iter = 2 if test_fast_path else 1  # rerun to use cache
                 if post_op in ("none", "relu", "gelu"):
-                    for _ in range(num_iter):
-                        qy_cpu = qlinear_op(
-                            qx_cpu, x_scale, x_zp, qw_packed, w_scales, w_zps,
-                            b, used_y_scale, used_y_zp, output_dtype,
-                            post_op, unary_post_op_args, post_op_algo
-                        )
+                    qy_cpu = qlinear_op(
+                        qx_cpu, x_scale, x_zp, qw_packed, w_scales, w_zps,
+                        b, used_y_scale, used_y_zp, output_dtype,
+                        post_op, unary_post_op_args, post_op_algo
+                    )
                     if post_op == "relu":
                         y_ref = F.relu(y_ref)
                     elif post_op == "gelu":
@@ -4674,14 +4670,13 @@ class TestQuantizedLinear(TestCase):
                     accum = qx2.int_repr() if output_dtype is None else qx2.dequantize()
                     if bfloat16_out:
                         accum = accum.bfloat16()
-                    for _ in range(num_iter):
-                        # clone accum otherwise it gets accumulated multiple times
-                        qy_cpu = qlinear_op(
-                            qx_cpu, x_scale, x_zp, qw_packed, w_scales, w_zps,
-                            accum.clone(), b, used_y_scale, used_y_zp, output_dtype,
-                            x2_scale, x2_zp, "sum", binary_alpha,
-                            unary_post_op, unary_post_op_args, post_op_algo
-                        )
+                    # clone accum otherwise it gets accumulated multiple times
+                    qy_cpu = qlinear_op(
+                        qx_cpu, x_scale, x_zp, qw_packed, w_scales, w_zps,
+                        accum.clone(), b, used_y_scale, used_y_zp, output_dtype,
+                        x2_scale, x2_zp, "sum", binary_alpha,
+                        unary_post_op, unary_post_op_args, post_op_algo
+                    )
                     y_ref = y_ref + x2 * binary_alpha
                     if unary_post_op == "relu":
                         y_ref = F.relu(y_ref)
@@ -4694,13 +4689,12 @@ class TestQuantizedLinear(TestCase):
                     x2 = torch.randn(y_ref.size()) * 10
                     unary_post_op = "relu" if post_op == "add_relu" else "none"
                     binary_alpha = 1.0  # we only support alpha=1.0 now
-                    for _ in range(num_iter):
-                        qy_cpu = qlinear_op(
-                            qx_cpu, x_scale, x_zp, qw_packed, w_scales, w_zps,
-                            x2, b, used_y_scale, used_y_zp, output_dtype,
-                            1.0, 0, "add", binary_alpha,
-                            unary_post_op, unary_post_op_args, post_op_algo
-                        )
+                    qy_cpu = qlinear_op(
+                        qx_cpu, x_scale, x_zp, qw_packed, w_scales, w_zps,
+                        x2, b, used_y_scale, used_y_zp, output_dtype,
+                        1.0, 0, "add", binary_alpha,
+                        unary_post_op, unary_post_op_args, post_op_algo
+                    )
                     y_ref = y_ref + x2 * binary_alpha
                     if unary_post_op == "relu":
                         y_ref = F.relu(y_ref)
@@ -4725,6 +4719,83 @@ class TestQuantizedLinear(TestCase):
                     w_s: {w_scale}, w_zp: {w_zp},
                     y_s: {y_scale}, y_zp: {y_zp}""",
                 )
+
+    def _test_qlinear_pt2e_fast_path_helper(self, qlinear_op):
+        import os
+
+        env_key = "ONEDNN_CACHE_CONTEXT_UNSAFE"
+        original_value = os.environ.get(env_key)
+        os.environ[env_key] = "1"
+        try:
+            qlinear_prepack = torch.ops.onednn.qlinear_prepack
+            x_scale, x_zp = 1.2, 1
+            w_scale, w_zp = 0.8, 0
+            y_scale, y_zp = 4.7, 2
+
+            x = torch.rand(1, 4) * 10
+            w = torch.rand(16, 4) * 10
+            b = torch.rand(16) * 10
+
+            qx = torch.quantize_per_tensor(x, x_scale, x_zp, torch.quint8)
+            qw = torch.quantize_per_tensor(w, w_scale, w_zp, torch.qint8)
+            w_scales = torch.Tensor([w_scale])
+            w_zps = torch.Tensor([w_zp]).to(dtype=torch.int)
+
+            qx_cpu = qx.int_repr()
+            w_ref = qw.dequantize()
+
+            with override_quantized_engine('onednn'):
+                # Warm up once to initialize the fast-path cache.
+                qw_packed = qlinear_prepack(qw.int_repr(), qx_cpu.shape)
+                qlinear_op(
+                    qx_cpu,
+                    x_scale,
+                    x_zp,
+                    qw_packed,
+                    w_scales,
+                    w_zps,
+                    b,
+                    y_scale,
+                    y_zp,
+                    None,
+                    "none",
+                    (),
+                    "none",
+                )
+
+                for qx_cpu_iter in (qx_cpu, qx_cpu.repeat(2, 1)):
+                    qw_packed = qlinear_prepack(qw.int_repr(), qx_cpu_iter.shape)
+                    qy_cpu = qlinear_op(
+                        qx_cpu_iter,
+                        x_scale,
+                        x_zp,
+                        qw_packed,
+                        w_scales,
+                        w_zps,
+                        b,
+                        y_scale,
+                        y_zp,
+                        None,
+                        "none",
+                        (),
+                        "none",
+                    )
+
+                    x_ref = x_scale * (qx_cpu_iter.float() - x_zp)
+                    y_ref = F.linear(x_ref, w_ref, b)
+                    qy_ref = torch.quantize_per_tensor(y_ref, y_scale, y_zp, torch.quint8)
+
+                    self.assertEqual(qy_ref.dim(), qy_cpu.dim())
+                    np.testing.assert_array_almost_equal(
+                        qy_ref.int_repr().cpu().numpy(),
+                        qy_cpu.cpu().numpy(),
+                        decimal=0,
+                    )
+        finally:
+            if original_value is None:
+                os.environ.pop(env_key, None)
+            else:
+                os.environ[env_key] = original_value
 
     @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
     @skipIfNoONEDNN
@@ -4769,6 +4840,12 @@ class TestQuantizedLinear(TestCase):
         qlinear = torch.ops.onednn.qlinear_pointwise.binary
         self._test_qlinear_pt2e_helper(qlinear, "add_relu")
 
+    @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
+    @skipIfNoONEDNN
+    def test_qlinear_fast_path_pt2e(self):
+        qlinear = torch.ops.onednn.qlinear_pointwise
+        self._test_qlinear_pt2e_fast_path_helper(qlinear)
+
     def _test_qlinear_fp8_helper(
         self,
         qlinear_op,
@@ -4776,8 +4853,6 @@ class TestQuantizedLinear(TestCase):
         unary_post_op_args=(),
         post_op_algorithms=("none",),
     ):
-        import os
-        test_fast_path = os.getenv("ONEDNN_CACHE_CONTEXT_UNSAFE", "0") == "1"
         qlinear_prepack = torch.ops.onednn.qlinear_prepack
         linear_op = F.linear
         in_channels_list = [4, 8]
@@ -4826,14 +4901,12 @@ class TestQuantizedLinear(TestCase):
                 x_zp = 0
                 w_zps = torch.zeros_like(w_scales, dtype=torch.int)
 
-                num_iter = 2 if test_fast_path else 1  # rerun to use cache
                 if post_op in ("none", "relu", "gelu"):
-                    for _ in range(num_iter):
-                        qy = qlinear_op(
-                            qx, x_scale, x_zp, qw_packed, w_scales, w_zps,
-                            b, used_y_scale, used_y_zp, output_dtype,
-                            post_op, unary_post_op_args, post_op_algo
-                        )
+                    qy = qlinear_op(
+                        qx, x_scale, x_zp, qw_packed, w_scales, w_zps,
+                        b, used_y_scale, used_y_zp, output_dtype,
+                        post_op, unary_post_op_args, post_op_algo
+                    )
                     if post_op == "relu":
                         y_ref = F.relu(y_ref)
                     elif post_op == "gelu":
@@ -4852,13 +4925,12 @@ class TestQuantizedLinear(TestCase):
                     if bfloat16_out:
                         accum = accum.bfloat16()
                         accum_ref = accum_ref.bfloat16()
-                    for _ in range(num_iter):
-                        qy = qlinear_op(
-                            qx, x_scale, x_zp, qw_packed, w_scales, w_zps,
-                            accum.clone(), b, used_y_scale, used_y_zp, output_dtype,
-                            x2_scale, x2_zp, "sum", binary_alpha,
-                            unary_post_op, unary_post_op_args, post_op_algo
-                        )
+                    qy = qlinear_op(
+                        qx, x_scale, x_zp, qw_packed, w_scales, w_zps,
+                        accum.clone(), b, used_y_scale, used_y_zp, output_dtype,
+                        x2_scale, x2_zp, "sum", binary_alpha,
+                        unary_post_op, unary_post_op_args, post_op_algo
+                    )
                     y_ref = y_ref + accum_ref * binary_alpha
                     if unary_post_op == "relu":
                         y_ref = F.relu(y_ref)
@@ -4869,13 +4941,12 @@ class TestQuantizedLinear(TestCase):
                     x2 = torch.rand_like(y_ref)
                     unary_post_op = "relu" if post_op == "add_relu" else "none"
                     binary_alpha = 1.0  # we only support alpha=1.0 now
-                    for _ in range(num_iter):
-                        qy = qlinear_op(
-                            qx, x_scale, x_zp, qw_packed, w_scales, w_zps,
-                            x2, b, used_y_scale, used_y_zp, output_dtype,
-                            1.0, 0, "add", binary_alpha,
-                            unary_post_op, unary_post_op_args, post_op_algo
-                        )
+                    qy = qlinear_op(
+                        qx, x_scale, x_zp, qw_packed, w_scales, w_zps,
+                        x2, b, used_y_scale, used_y_zp, output_dtype,
+                        1.0, 0, "add", binary_alpha,
+                        unary_post_op, unary_post_op_args, post_op_algo
+                    )
                     y_ref = y_ref + x2 * binary_alpha
                     if unary_post_op == "relu":
                         y_ref = F.relu(y_ref)
@@ -4890,6 +4961,77 @@ class TestQuantizedLinear(TestCase):
                 self.assertEqual(y_ref.float(), qy.float())
                 if torch.isnan(qy).any():
                     raise AssertionError("Output qy contains NaN values")
+
+    def _test_qlinear_fp8_fast_path_helper(self, qlinear_op):
+        import os
+
+        env_key = "ONEDNN_CACHE_CONTEXT_UNSAFE"
+        original_value = os.environ.get(env_key)
+        os.environ[env_key] = "1"
+        try:
+            qlinear_prepack = torch.ops.onednn.qlinear_prepack
+            y_scale = 0.3
+            x_zp = 0
+
+            x = torch.rand(1, 4) * 10
+            w = torch.rand(16, 4) * 10
+            b = torch.rand(16) * 10
+
+            qx, x_scale = _quantize_fp8e4m3(x, channelwise=False)
+            qw, w_scales = _quantize_fp8e4m3(w, channelwise=False)
+            w_zps = torch.zeros_like(w_scales, dtype=torch.int)
+
+            with override_quantized_engine('onednn'):
+                # Warm up once to initialize the fast-path cache.
+                qw_packed = qlinear_prepack(qw, qx.shape)
+                qlinear_op(
+                    qx,
+                    x_scale,
+                    x_zp,
+                    qw_packed,
+                    w_scales,
+                    w_zps,
+                    b,
+                    y_scale,
+                    0,
+                    None,
+                    "none",
+                    (),
+                    "none",
+                )
+
+                for qx_iter in (qx, qx.repeat(2, 1)):
+                    qw_packed = qlinear_prepack(qw, qx_iter.shape)
+                    qy = qlinear_op(
+                        qx_iter,
+                        x_scale,
+                        x_zp,
+                        qw_packed,
+                        w_scales,
+                        w_zps,
+                        b,
+                        y_scale,
+                        0,
+                        None,
+                        "none",
+                        (),
+                        "none",
+                    )
+
+                    x_ref = _dequantize_fp8e4m3(qx_iter, x_scale)
+                    w_ref = _dequantize_fp8e4m3(qw, w_scales)
+                    y_ref = F.linear(x_ref, w_ref, b)
+                    y_ref = _quantize_fp8e4m3(y_ref, False, y_scale)[0]
+
+                    self.assertEqual(y_ref.dim(), qy.dim())
+                    self.assertEqual(y_ref.float(), qy.float())
+                    if torch.isnan(qy).any():
+                        raise AssertionError("Output qy contains NaN values")
+        finally:
+            if original_value is None:
+                os.environ.pop(env_key, None)
+            else:
+                os.environ[env_key] = original_value
 
     @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
     @skipIfNoONEDNN
@@ -4933,6 +5075,12 @@ class TestQuantizedLinear(TestCase):
     def test_qlinear_add_relu_fp8(self):
         qlinear = torch.ops.onednn.qlinear_pointwise.binary
         self._test_qlinear_fp8_helper(qlinear, "add_relu")
+
+    @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
+    @skipIfNoONEDNN
+    def test_qlinear_fast_path_fp8(self):
+        qlinear = torch.ops.onednn.qlinear_pointwise
+        self._test_qlinear_fp8_fast_path_helper(qlinear)
 
 
 @unittest.skipIf(IS_MACOS, "Known test failure on Mac.")

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -4,8 +4,11 @@
 
 import copy
 import itertools
+import multiprocessing
+import os
 import operator
 import random
+import traceback
 import unittest
 from typing import NamedTuple, TYPE_CHECKING
 
@@ -193,6 +196,168 @@ def _dequantize_fp8e4m3(qt: torch.Tensor, scale: torch.Tensor):
         scale_reshape = scale.reshape((-1,) + (1,) * (qt.dim() - 1))
         dqt = dqt * scale_reshape
     return dqt
+
+
+def _test_qlinear_pt2e_fast_path_helper(error_conn=None):
+    try:
+        os.environ["ONEDNN_CACHE_CONTEXT_UNSAFE"] = "1"
+
+        qlinear_op = torch.ops.onednn.qlinear_pointwise
+        qlinear_prepack = torch.ops.onednn.qlinear_prepack
+        x_scale, x_zp = 1.2, 1
+        w_scale, w_zp = 0.8, 0
+        y_scale, y_zp = 4.7, 2
+
+        x = torch.rand(1, 4) * 10
+        w = torch.rand(16, 4) * 10
+        b = torch.rand(16) * 10
+
+        qx = torch.quantize_per_tensor(x, x_scale, x_zp, torch.quint8)
+        qw = torch.quantize_per_tensor(w, w_scale, w_zp, torch.qint8)
+        w_scales = torch.tensor([w_scale])
+        w_zps = torch.tensor([w_zp], dtype=torch.int)
+
+        qx_cpu = qx.int_repr()
+        w_ref = qw.dequantize()
+
+        with override_quantized_engine("onednn"):
+            # Warm up once to initialize the fast-path cache.
+            qw_packed = qlinear_prepack(qw.int_repr(), qx_cpu.shape)
+            qlinear_op(
+                qx_cpu,
+                x_scale,
+                x_zp,
+                qw_packed,
+                w_scales,
+                w_zps,
+                b,
+                y_scale,
+                y_zp,
+                None,
+                "none",
+                (),
+                "none",
+            )
+
+            for qx_cpu_iter in (qx_cpu, qx_cpu.repeat(2, 1)):
+                qy_cpu = qlinear_op(
+                    qx_cpu_iter,
+                    x_scale,
+                    x_zp,
+                    qw_packed,
+                    w_scales,
+                    w_zps,
+                    b,
+                    y_scale,
+                    y_zp,
+                    None,
+                    "none",
+                    (),
+                    "none",
+                )
+
+                x_ref = x_scale * (qx_cpu_iter.float() - x_zp)
+                y_ref = F.linear(x_ref, w_ref, b)
+                qy_ref = torch.quantize_per_tensor(y_ref, y_scale, y_zp, torch.quint8)
+
+                assert qy_ref.dim() == qy_cpu.dim()
+                np.testing.assert_array_almost_equal(
+                    qy_ref.int_repr().cpu().numpy(),
+                    qy_cpu.cpu().numpy(),
+                    decimal=0,
+                )
+        if error_conn is not None:
+            error_conn.send("")
+    except Exception:
+        if error_conn is not None:
+            error_conn.send(traceback.format_exc())
+        raise
+    finally:
+        if error_conn is not None:
+            error_conn.close()
+
+
+def _test_qlinear_fp8_fast_path_helper(error_conn=None):
+    try:
+        os.environ["ONEDNN_CACHE_CONTEXT_UNSAFE"] = "1"
+
+        def _quantize_fp8_for_process(tensor, scale):
+            return (tensor / scale).clamp(-448, 448).half().to(torch.float8_e4m3fn)
+
+        def _dequantize_fp8_for_process(qtensor, scale):
+            return qtensor.float() * scale
+
+        qlinear_op = torch.ops.onednn.qlinear_pointwise
+        qlinear_prepack = torch.ops.onednn.qlinear_prepack
+        y_scale = 0.3
+        x_zp = 0
+
+        x = torch.rand(1, 4) * 10
+        w = torch.rand(16, 4) * 10
+        b = torch.rand(16) * 10
+
+        eps = torch.tensor([torch.finfo(torch.float32).eps])
+        quant_max = torch.finfo(torch.float8_e4m3fn).max
+        x_scale = torch.max(x.abs().max().reshape([1]) / quant_max, eps)
+        w_scales = torch.max(w.abs().max().reshape([1]) / quant_max, eps)
+        qx = _quantize_fp8_for_process(x, x_scale)
+        qw = _quantize_fp8_for_process(w, w_scales)
+        w_zps = torch.zeros_like(w_scales, dtype=torch.int)
+
+        with override_quantized_engine("onednn"):
+            # Warm up once to initialize the fast-path cache.
+            qw_packed = qlinear_prepack(qw, qx.shape)
+            qlinear_op(
+                qx,
+                x_scale,
+                x_zp,
+                qw_packed,
+                w_scales,
+                w_zps,
+                b,
+                y_scale,
+                0,
+                None,
+                "none",
+                (),
+                "none",
+            )
+
+            for qx_iter in (qx, qx.repeat(2, 1)):
+                qy = qlinear_op(
+                    qx_iter,
+                    x_scale,
+                    x_zp,
+                    qw_packed,
+                    w_scales,
+                    w_zps,
+                    b,
+                    y_scale,
+                    0,
+                    None,
+                    "none",
+                    (),
+                    "none",
+                )
+
+                x_ref = _dequantize_fp8_for_process(qx_iter, x_scale)
+                w_ref = _dequantize_fp8_for_process(qw, w_scales)
+                y_ref = F.linear(x_ref, w_ref, b)
+                y_ref = _quantize_fp8_for_process(y_ref, torch.tensor([y_scale]))
+
+                assert y_ref.dim() == qy.dim()
+                assert torch.equal(y_ref.float(), qy.float())
+                if torch.isnan(qy).any():
+                    raise AssertionError("Output qy contains NaN values")
+        if error_conn is not None:
+            error_conn.send("")
+    except Exception:
+        if error_conn is not None:
+            error_conn.send(traceback.format_exc())
+        raise
+    finally:
+        if error_conn is not None:
+            error_conn.close()
 
 class TestQuantizedOps(TestCase):
 
@@ -4720,108 +4885,6 @@ class TestQuantizedLinear(TestCase):
                     y_s: {y_scale}, y_zp: {y_zp}""",
                 )
 
-    def _test_qlinear_pt2e_fast_path_helper(self, qlinear_op):
-        import os
-        import subprocess
-        import sys
-        import textwrap
-
-        _ = qlinear_op
-        env = os.environ.copy()
-        env["ONEDNN_CACHE_CONTEXT_UNSAFE"] = "1"
-
-        code = textwrap.dedent(
-            """
-            import numpy as np
-            import torch
-            import torch.nn.functional as F
-            from torch.testing._internal.common_quantized import override_quantized_engine
-
-            qlinear_op = torch.ops.onednn.qlinear_pointwise
-            qlinear_prepack = torch.ops.onednn.qlinear_prepack
-            x_scale, x_zp = 1.2, 1
-            w_scale, w_zp = 0.8, 0
-            y_scale, y_zp = 4.7, 2
-
-            x = torch.rand(1, 4) * 10
-            w = torch.rand(16, 4) * 10
-            b = torch.rand(16) * 10
-
-            qx = torch.quantize_per_tensor(x, x_scale, x_zp, torch.quint8)
-            qw = torch.quantize_per_tensor(w, w_scale, w_zp, torch.qint8)
-            w_scales = torch.Tensor([w_scale])
-            w_zps = torch.Tensor([w_zp]).to(dtype=torch.int)
-
-            qx_cpu = qx.int_repr()
-            w_ref = qw.dequantize()
-
-            with override_quantized_engine("onednn"):
-                # Warm up once to initialize the fast-path cache.
-                qw_packed = qlinear_prepack(qw.int_repr(), qx_cpu.shape)
-                qlinear_op(
-                    qx_cpu,
-                    x_scale,
-                    x_zp,
-                    qw_packed,
-                    w_scales,
-                    w_zps,
-                    b,
-                    y_scale,
-                    y_zp,
-                    None,
-                    "none",
-                    (),
-                    "none",
-                )
-
-                for qx_cpu_iter in (qx_cpu, qx_cpu.repeat(2, 1)):
-                    qy_cpu = qlinear_op(
-                        qx_cpu_iter,
-                        x_scale,
-                        x_zp,
-                        qw_packed,
-                        w_scales,
-                        w_zps,
-                        b,
-                        y_scale,
-                        y_zp,
-                        None,
-                        "none",
-                        (),
-                        "none",
-                    )
-
-                    x_ref = x_scale * (qx_cpu_iter.float() - x_zp)
-                    y_ref = F.linear(x_ref, w_ref, b)
-                    qy_ref = torch.quantize_per_tensor(y_ref, y_scale, y_zp, torch.quint8)
-
-                    assert qy_ref.dim() == qy_cpu.dim()
-                    np.testing.assert_array_almost_equal(
-                        qy_ref.int_repr().cpu().numpy(),
-                        qy_cpu.cpu().numpy(),
-                        decimal=0,
-                    )
-            """
-        )
-
-        proc = subprocess.run(
-            [sys.executable, "-c", code],
-            env=env,
-            cwd=os.getcwd(),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        self.assertEqual(
-            proc.returncode,
-            0,
-            msg=(
-                "Subprocess fast-path validation failed.\n"
-                f"stdout:\n{proc.stdout}\n"
-                f"stderr:\n{proc.stderr}"
-            ),
-        )
-
     @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
     @skipIfNoONEDNN
     def test_qlinear_pt2e(self):
@@ -4868,8 +4931,25 @@ class TestQuantizedLinear(TestCase):
     @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
     @skipIfNoONEDNN
     def test_qlinear_fast_path_pt2e(self):
-        qlinear = torch.ops.onednn.qlinear_pointwise
-        self._test_qlinear_pt2e_fast_path_helper(qlinear)
+        ctx = multiprocessing.get_context("spawn")
+        parent_conn, child_conn = ctx.Pipe(duplex=False)
+        process = ctx.Process(
+            target=_test_qlinear_pt2e_fast_path_helper,
+            args=(child_conn,),
+        )
+        process.start()
+        child_conn.close()
+        process.join()
+        error = parent_conn.recv() if parent_conn.poll() else ""
+        parent_conn.close()
+        self.assertEqual(
+            process.exitcode,
+            0,
+            msg=(
+                "Spawned fast-path validation failed.\n"
+                f"traceback:\n{error}"
+            ),
+        )
 
     def _test_qlinear_fp8_helper(
         self,
@@ -4987,116 +5067,6 @@ class TestQuantizedLinear(TestCase):
                 if torch.isnan(qy).any():
                     raise AssertionError("Output qy contains NaN values")
 
-    def _test_qlinear_fp8_fast_path_helper(self, qlinear_op):
-        import os
-        import subprocess
-        import sys
-        import textwrap
-
-        _ = qlinear_op
-        env = os.environ.copy()
-        env["ONEDNN_CACHE_CONTEXT_UNSAFE"] = "1"
-
-        code = textwrap.dedent(
-            """
-            import torch
-            import torch.nn.functional as F
-            from torch.testing._internal.common_quantized import override_quantized_engine
-
-            def _quantize_fp8e4m3(t, scale):
-                # Align with oneDNN conversion path: fp32 -> fp16 -> fp8.
-                qt = (t / scale).clamp(-448, 448).half().to(torch.float8_e4m3fn)
-                return qt
-
-            def _dequantize_fp8e4m3(qt, scale):
-                return qt.float() * scale
-
-            qlinear_op = torch.ops.onednn.qlinear_pointwise
-            qlinear_prepack = torch.ops.onednn.qlinear_prepack
-            y_scale = 0.3
-            x_zp = 0
-
-            x = torch.rand(1, 4) * 10
-            w = torch.rand(16, 4) * 10
-            b = torch.rand(16) * 10
-
-            x_scale = x.abs().max().reshape([1]) / torch.finfo(torch.float8_e4m3fn).max
-            x_scale = torch.max(x_scale, torch.tensor([torch.finfo(torch.float32).eps]))
-            qx = _quantize_fp8e4m3(x, x_scale)
-
-            w_scale = w.abs().max().reshape([1]) / torch.finfo(torch.float8_e4m3fn).max
-            w_scale = torch.max(w_scale, torch.tensor([torch.finfo(torch.float32).eps]))
-            qw = _quantize_fp8e4m3(w, w_scale)
-
-            w_scales = w_scale
-            w_zps = torch.zeros_like(w_scales, dtype=torch.int)
-
-            with override_quantized_engine("onednn"):
-                # Warm up once to initialize the fast-path cache.
-                qw_packed = qlinear_prepack(qw, qx.shape)
-                qlinear_op(
-                    qx,
-                    x_scale,
-                    x_zp,
-                    qw_packed,
-                    w_scales,
-                    w_zps,
-                    b,
-                    y_scale,
-                    0,
-                    None,
-                    "none",
-                    (),
-                    "none",
-                )
-
-                for qx_iter in (qx, qx.repeat(2, 1)):
-                    qy = qlinear_op(
-                        qx_iter,
-                        x_scale,
-                        x_zp,
-                        qw_packed,
-                        w_scales,
-                        w_zps,
-                        b,
-                        y_scale,
-                        0,
-                        None,
-                        "none",
-                        (),
-                        "none",
-                    )
-
-                    x_ref = _dequantize_fp8e4m3(qx_iter, x_scale)
-                    w_ref = _dequantize_fp8e4m3(qw, w_scales)
-                    y_ref = F.linear(x_ref, w_ref, b)
-                    y_ref = _quantize_fp8e4m3(y_ref, y_scale)
-
-                    assert y_ref.dim() == qy.dim()
-                    assert torch.equal(y_ref.float(), qy.float())
-                    if torch.isnan(qy).any():
-                        raise AssertionError("Output qy contains NaN values")
-            """
-        )
-
-        proc = subprocess.run(
-            [sys.executable, "-c", code],
-            env=env,
-            cwd=os.getcwd(),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        self.assertEqual(
-            proc.returncode,
-            0,
-            msg=(
-                "Subprocess fp8 fast-path validation failed.\n"
-                f"stdout:\n{proc.stdout}\n"
-                f"stderr:\n{proc.stderr}"
-            ),
-        )
-
     @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
     @skipIfNoONEDNN
     def test_qlinear_fp8(self):
@@ -5143,8 +5113,25 @@ class TestQuantizedLinear(TestCase):
     @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
     @skipIfNoONEDNN
     def test_qlinear_fast_path_fp8(self):
-        qlinear = torch.ops.onednn.qlinear_pointwise
-        self._test_qlinear_fp8_fast_path_helper(qlinear)
+        ctx = multiprocessing.get_context("spawn")
+        parent_conn, child_conn = ctx.Pipe(duplex=False)
+        process = ctx.Process(
+            target=_test_qlinear_fp8_fast_path_helper,
+            args=(child_conn,),
+        )
+        process.start()
+        child_conn.close()
+        process.join()
+        error = parent_conn.recv() if parent_conn.poll() else ""
+        parent_conn.close()
+        self.assertEqual(
+            process.exitcode,
+            0,
+            msg=(
+                "Spawned fp8 fast-path validation failed.\n"
+                f"traceback:\n{error}"
+            ),
+        )
 
 
 @unittest.skipIf(IS_MACOS, "Known test failure on Mac.")

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -4722,11 +4722,22 @@ class TestQuantizedLinear(TestCase):
 
     def _test_qlinear_pt2e_fast_path_helper(self, qlinear_op):
         import os
+        import subprocess
+        import sys
+        import textwrap
 
-        env_key = "ONEDNN_CACHE_CONTEXT_UNSAFE"
-        original_value = os.environ.get(env_key)
-        os.environ[env_key] = "1"
-        try:
+        _ = qlinear_op
+        env = os.environ.copy()
+        env["ONEDNN_CACHE_CONTEXT_UNSAFE"] = "1"
+
+        code = textwrap.dedent(
+            """
+            import numpy as np
+            import torch
+            import torch.nn.functional as F
+            from torch.testing._internal.common_quantized import override_quantized_engine
+
+            qlinear_op = torch.ops.onednn.qlinear_pointwise
             qlinear_prepack = torch.ops.onednn.qlinear_prepack
             x_scale, x_zp = 1.2, 1
             w_scale, w_zp = 0.8, 0
@@ -4744,7 +4755,7 @@ class TestQuantizedLinear(TestCase):
             qx_cpu = qx.int_repr()
             w_ref = qw.dequantize()
 
-            with override_quantized_engine('onednn'):
+            with override_quantized_engine("onednn"):
                 # Warm up once to initialize the fast-path cache.
                 qw_packed = qlinear_prepack(qw.int_repr(), qx_cpu.shape)
                 qlinear_op(
@@ -4784,17 +4795,32 @@ class TestQuantizedLinear(TestCase):
                     y_ref = F.linear(x_ref, w_ref, b)
                     qy_ref = torch.quantize_per_tensor(y_ref, y_scale, y_zp, torch.quint8)
 
-                    self.assertEqual(qy_ref.dim(), qy_cpu.dim())
+                    assert qy_ref.dim() == qy_cpu.dim()
                     np.testing.assert_array_almost_equal(
                         qy_ref.int_repr().cpu().numpy(),
                         qy_cpu.cpu().numpy(),
                         decimal=0,
                     )
-        finally:
-            if original_value is None:
-                os.environ.pop(env_key, None)
-            else:
-                os.environ[env_key] = original_value
+            """
+        )
+
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            cwd=os.getcwd(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=(
+                "Subprocess fast-path validation failed.\n"
+                f"stdout:\n{proc.stdout}\n"
+                f"stderr:\n{proc.stderr}"
+            ),
+        )
 
     @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
     @skipIfNoONEDNN
@@ -4963,11 +4989,29 @@ class TestQuantizedLinear(TestCase):
 
     def _test_qlinear_fp8_fast_path_helper(self, qlinear_op):
         import os
+        import subprocess
+        import sys
+        import textwrap
 
-        env_key = "ONEDNN_CACHE_CONTEXT_UNSAFE"
-        original_value = os.environ.get(env_key)
-        os.environ[env_key] = "1"
-        try:
+        _ = qlinear_op
+        env = os.environ.copy()
+        env["ONEDNN_CACHE_CONTEXT_UNSAFE"] = "1"
+
+        code = textwrap.dedent(
+            """
+            import torch
+            import torch.nn.functional as F
+            from torch.testing._internal.common_quantized import override_quantized_engine
+
+            def _quantize_fp8e4m3(t, scale):
+                # Align with oneDNN conversion path: fp32 -> fp16 -> fp8.
+                qt = (t / scale).clamp(-448, 448).half().to(torch.float8_e4m3fn)
+                return qt
+
+            def _dequantize_fp8e4m3(qt, scale):
+                return qt.float() * scale
+
+            qlinear_op = torch.ops.onednn.qlinear_pointwise
             qlinear_prepack = torch.ops.onednn.qlinear_prepack
             y_scale = 0.3
             x_zp = 0
@@ -4976,11 +5020,18 @@ class TestQuantizedLinear(TestCase):
             w = torch.rand(16, 4) * 10
             b = torch.rand(16) * 10
 
-            qx, x_scale = _quantize_fp8e4m3(x, channelwise=False)
-            qw, w_scales = _quantize_fp8e4m3(w, channelwise=False)
+            x_scale = x.abs().max().reshape([1]) / torch.finfo(torch.float8_e4m3fn).max
+            x_scale = torch.max(x_scale, torch.tensor([torch.finfo(torch.float32).eps]))
+            qx = _quantize_fp8e4m3(x, x_scale)
+
+            w_scale = w.abs().max().reshape([1]) / torch.finfo(torch.float8_e4m3fn).max
+            w_scale = torch.max(w_scale, torch.tensor([torch.finfo(torch.float32).eps]))
+            qw = _quantize_fp8e4m3(w, w_scale)
+
+            w_scales = w_scale
             w_zps = torch.zeros_like(w_scales, dtype=torch.int)
 
-            with override_quantized_engine('onednn'):
+            with override_quantized_engine("onednn"):
                 # Warm up once to initialize the fast-path cache.
                 qw_packed = qlinear_prepack(qw, qx.shape)
                 qlinear_op(
@@ -5019,17 +5070,32 @@ class TestQuantizedLinear(TestCase):
                     x_ref = _dequantize_fp8e4m3(qx_iter, x_scale)
                     w_ref = _dequantize_fp8e4m3(qw, w_scales)
                     y_ref = F.linear(x_ref, w_ref, b)
-                    y_ref = _quantize_fp8e4m3(y_ref, False, y_scale)[0]
+                    y_ref = _quantize_fp8e4m3(y_ref, y_scale)
 
-                    self.assertEqual(y_ref.dim(), qy.dim())
-                    self.assertEqual(y_ref.float(), qy.float())
+                    assert y_ref.dim() == qy.dim()
+                    assert torch.equal(y_ref.float(), qy.float())
                     if torch.isnan(qy).any():
                         raise AssertionError("Output qy contains NaN values")
-        finally:
-            if original_value is None:
-                os.environ.pop(env_key, None)
-            else:
-                os.environ[env_key] = original_value
+            """
+        )
+
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            cwd=os.getcwd(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=(
+                "Subprocess fp8 fast-path validation failed.\n"
+                f"stdout:\n{proc.stdout}\n"
+                f"stderr:\n{proc.stderr}"
+            ),
+        )
 
     @unittest.skipIf(IS_FBCODE, "Skip pt2e ops in fbcode")
     @skipIfNoONEDNN

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -4764,7 +4764,6 @@ class TestQuantizedLinear(TestCase):
                 )
 
                 for qx_cpu_iter in (qx_cpu, qx_cpu.repeat(2, 1)):
-                    qw_packed = qlinear_prepack(qw.int_repr(), qx_cpu_iter.shape)
                     qy_cpu = qlinear_op(
                         qx_cpu_iter,
                         x_scale,
@@ -5001,7 +5000,6 @@ class TestQuantizedLinear(TestCase):
                 )
 
                 for qx_iter in (qx, qx.repeat(2, 1)):
-                    qw_packed = qlinear_prepack(qw, qx_iter.shape)
                     qy = qlinear_op(
                         qx_iter,
                         x_scale,


### PR DESCRIPTION
This PR improves the cache mechanism for `onednn::qlinear_pointwise` in two main areas: correctness (thread-safety of the cache map) and performance (eliminating tensor object construction on cache hits).

### Background

`linear_int8_with_onednn_weight` already caches the oneDNN `matmul` primitive and its static arguments (weights, scales, zero points, bias, scratchpad) to avoid recomputing `primitive_desc` on every inference call. Two issues existed:

1. **Thread safety**: the cache map was a plain `static` local, shared across all threads. Concurrent inference threads would race on reads and writes without any synchronization.
2. **Per-call overhead on cache hit**: on every hit, the old code constructed full `ideep::tensor` view objects for `src`/`dst`/`src1` and then `std::move`-d them into the `exec_args` map, which is an O(log n) map mutation even on the fast path.

### Changes

#### Thread-local cache map (`qlinear.cpp`)

The cache map is now declared `thread_local`:

```cpp
// before
static std::unordered_map<int64_t, QlinearForwardParams> qlinear_forward_params_map;

// after
static thread_local std::unordered_map<int64_t, QlinearForwardParams>
    qlinear_forward_params_map;
```

Each inference thread builds and owns its own primitive cache. This eliminates data races with no locking overhead. The trade-off (each thread warms up its own cache independently) is acceptable for typical serving workloads where threads are long-lived and the weight set is fixed.

#### Zero-copy cache hit path (`OnednnUtils.h`, `qlinear.cpp`)

`QlinearForwardParams` now stores `src`, `dst`, and `src1` as persistent `ideep::tensor` members. `init_args()` inserts them into `exec_args` once at cache-population time. On subsequent hits, only `set_data_handle` is called to point the stored tensors at the new activation/output buffers — no tensor view construction, no map mutation:

```cpp
// cache hit fast path
params.src.set_data_handle(input_contig.data_ptr());
params.dst.set_data_handle(output.data_ptr());
if (binary_post_op == "add") {
  params.src1->set_data_handle(other_2d.data_ptr());
}
params.primitive.execute(ideep::stream::default_stream(), params.args);
```

#### Templatized scale/zp to unify callers (`qlinear.cpp`, `qlinear.h`)

`linear_int8_with_onednn_weight` is now templated on `InputScaleType` / `InputZeroPointType`. This allows `run_pointwise_tensor` to pass the scale and zero-point as `Tensor` objects directly (extracted to scalars only on the slow path), while `run_pointwise` continues to pass `double`/`int64_t` scalars. Removes per-call `.item()` extraction on the cache-hit path.

All tensor parameters in `run_pointwise_tensor` / `run_pointwise_binary_tensor` are changed to `const Tensor&` / `const std::optional<Tensor>&` to avoid unnecessary refcount bumps.

> This PR was authored with Claude.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01