### PR TITLE
[ROCm] Add cub::DeviceHistogram to hipify identifier map

### DIFF
--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -2681,6 +2681,7 @@ CUDA_IDENTIFIER_MAP = collections.OrderedDict([
     ("cub::RowMajorTid", "hipcub::RowMajorTid"),
     ("cub::CachingDeviceAllocator", "hipcub::CachingDeviceAllocator"),
     ("cub::CountingInputIterator", "hipcub::CountingInputIterator"),
+    ("cub::DeviceHistogram", "hipcub::DeviceHistogram"),
     ("cub::DeviceRadixSort", "hipcub::DeviceRadixSort"),
     ("cub::DeviceReduce", "hipcub::DeviceReduce"),
     ("cub::DeviceRunLengthEncode", "hipcub::DeviceRunLengthEncode"),


### PR DESCRIPTION
## Problem

The hipify CUDA -> HIP identifier map covers most `cub::Device*` APIs (`DeviceRadixSort`, `DeviceReduce`, `DeviceScan`, `DeviceSegmentedReduce`, `DeviceSelect`, ...) but is missing `cub::DeviceHistogram`. Any third-party CUDA extension that calls it fails to hipify cleanly: hipify rewrites `#include <cub/cub.cuh>` to `<hipcub/hipcub.hpp>` but leaves the `cub::DeviceHistogram::HistogramEven` body reference unchanged, and the build errors out:

```
csrc/histogram_hip.h:33:13: error: use of undeclared identifier 'cub'
```

`hipcub::DeviceHistogram` is a 1:1 wrapper over `rocprim::device_histogram`.

## Usage

`databricks/megablocks` calls `cub::DeviceHistogram::HistogramEven` in `csrc/histogram.h`. The AMD-maintained `ROCm/megablocks` fork ships a `patch_torch.sh` that monkey-patches `cuda_to_hip_mappings.py` at install time to add this exact entry — so the gap is already known downstream as a workaround target.

## Tests

Verified by building megablocks (which uses `cub::DeviceHistogram` in its csrc) against torch with this patch applied: hipification produces `hipcub::DeviceHistogram` calls, the extension compiles, and the histogram op runs at runtime on MI325X (gfx942) under ROCm 6.4.3.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang