### PR TITLE
Add `validate` parameter to `torch.multinomial` to skip input validation

### DIFF
--- a/aten/src/ATen/VmapModeRegistrations.cpp
+++ b/aten/src/ATen/VmapModeRegistrations.cpp
@@ -51,8 +51,8 @@ TORCH_LIBRARY_IMPL(aten, VmapMode, m) {
   m.impl("exponential_", unsupportedRandomOp_<Tensor&, double, std::optional<Generator>>);
   m.impl("geometric_", unsupportedRandomOp_<Tensor&, double, std::optional<Generator>>);
   m.impl("log_normal_", unsupportedRandomOp_<Tensor&, double, double, std::optional<Generator>>);
-  m.impl("multinomial", unsupportedRandomOp<const Tensor&, int64_t, bool, std::optional<Generator>>);
-  m.impl("multinomial.out", unsupportedRandomOp_<const Tensor&, int64_t, bool, std::optional<Generator>, Tensor&>);
+  m.impl("multinomial", unsupportedRandomOp<const Tensor&, int64_t, bool, bool, std::optional<Generator>>);
+  m.impl("multinomial.out", unsupportedRandomOp_<const Tensor&, int64_t, bool, bool, std::optional<Generator>, Tensor&>);
 
   m.impl("normal.Tensor_float", unsupportedRandomOp<const Tensor&, double, std::optional<Generator>>);
   m.impl("normal.Tensor_float_out", unsupportedRandomOp_<const Tensor&, double, std::optional<Generator>, Tensor&>);

--- a/aten/src/ATen/functorch/BatchRulesRandomness.cpp
+++ b/aten/src/ATen/functorch/BatchRulesRandomness.cpp
@@ -221,7 +221,7 @@ static Tensor native_dropout_backward_batch_rule(const Tensor& grad_out, const T
   return result;
 }
 
-static Tensor multinomial_batching_rule(const Tensor& self, const int64_t num_samples, const bool replacement, std::optional<Generator> generator) {
+static Tensor multinomial_batching_rule(const Tensor& self, const int64_t num_samples, const bool replacement, const bool validate, std::optional<Generator> generator) {
   c10::impl::ExcludeDispatchKeyGuard guard(DispatchKey::FuncTorchVmapMode);
   auto maybe_layer = maybeCurrentDynamicLayer();
   const auto cur_level = maybe_layer->layerId();
@@ -245,7 +245,7 @@ static Tensor multinomial_batching_rule(const Tensor& self, const int64_t num_sa
     if (is_2D_case) {
       self_value = reshape_dim_into(0, 0, self_value);
     }
-    auto out = multinomial(self_value, num_samples, replacement, std::move(generator));
+    auto out = multinomial(self_value, num_samples, replacement, validate, std::move(generator));
     if (is_2D_case) {
       out = reshape_dim_outof_symint(0, maybe_layer->batchSize(), out);
     }
@@ -257,7 +257,7 @@ static Tensor multinomial_batching_rule(const Tensor& self, const int64_t num_sa
   // Must be same randomness with unbatched input
   // 1D case: S -> multinomial(S) -> S
   // 2D case: MS -> multinomial(MS) -> MS
-  return multinomial(self_value, num_samples, replacement, std::move(generator));
+  return multinomial(self_value, num_samples, replacement, validate, std::move(generator));
 }
 
 template <typename A, A a, typename C>

--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -556,6 +556,7 @@ constexpr int64_t FLOAT32_MAX_CONSECUTIVE_INT = 1 << (FLT_MANT_DIG);
 Tensor& multinomial_out(const Tensor& self,
     int64_t n_sample,
     bool with_replacement,
+    bool validate,
     std::optional<Generator> gen,
     Tensor& result) {
   TORCH_CHECK(
@@ -593,17 +594,19 @@ Tensor& multinomial_out(const Tensor& self,
   // Reference:
   // https://github.com/pytorch/pytorch/issues/11931#issuecomment-625882503
   if (!with_replacement || n_sample == 1) {
-    // Sanity checks on `self`.
-    auto [self_min, self_max] = self.aminmax();
-    auto is_valid = ((self_max < INFINITY) & (self_min >= 0));
-    at::_assert_async(is_valid, "probability tensor contains either `inf`, `nan` or element < 0");
-    at::Tensor zero_prob_condition;
-    if (self.dim() == 1){
-      zero_prob_condition = (self.sum() == 0);
-    } else {
-      zero_prob_condition = (self.sum(1) == 0).any();
+    if (validate) {
+      // Sanity checks on `self`.
+      auto [self_min, self_max] = self.aminmax();
+      auto is_valid = ((self_max < INFINITY) & (self_min >= 0));
+      at::_assert_async(is_valid, "probability tensor contains either `inf`, `nan` or element < 0");
+      at::Tensor zero_prob_condition;
+      if (self.dim() == 1){
+        zero_prob_condition = (self.sum() == 0);
+      } else {
+        zero_prob_condition = (self.sum(1) == 0).any();
+      }
+      at::_assert_async(~zero_prob_condition, "invalid multinomial distribution (sum of probabilities <= 0)");
     }
-    at::_assert_async(~zero_prob_condition, "invalid multinomial distribution (sum of probabilities <= 0)");
 
     // The algorithm is from gumbel softmax.
     // s = argmax( logp - log(-log(eps)) ) where eps ~ U(0, 1)
@@ -637,9 +640,10 @@ Tensor multinomial(
     const Tensor& self,
     int64_t n_sample,
     bool with_replacement,
+    bool validate,
     std::optional<Generator> gen) {
   Tensor result = at::empty({0}, self.options().dtype(kLong));
-  native::multinomial_out(self, n_sample, with_replacement, std::move(gen), result);
+  native::multinomial_out(self, n_sample, with_replacement, validate, std::move(gen), result);
   return result;
 }
 

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -732,6 +732,7 @@ constexpr int64_t FLOAT32_MAX_CONSECUTIVE_INT = 1 << (FLT_MANT_DIG);
 Tensor& multinomial_out_mps(const Tensor& self,
                             int64_t n_sample,
                             bool with_replacement,
+                            bool validate,
                             std::optional<Generator> gen,
                             Tensor& result) {
   TORCH_CHECK(result.device() == self.device(), "multinomial arguments must have the same device");
@@ -763,16 +764,18 @@ Tensor& multinomial_out_mps(const Tensor& self,
   // Reference:
   // https://github.com/pytorch/pytorch/issues/11931#issuecomment-625882503
   if (!with_replacement || n_sample == 1) {
-    // Sanity checks on `self`.
-    auto is_valid = ((self.max() < INFINITY) & (self.min() >= 0)).item();
-    TORCH_CHECK(is_valid.to<bool>(), "probability tensor contains either `inf`, `nan` or element < 0");
-    bool zero_prob_condition = false;
-    if (self.dim() == 1) {
-      zero_prob_condition = (self.sum() == 0).item().to<bool>();
-    } else {
-      zero_prob_condition = (self.sum(1) == 0).sum().item().to<bool>();
+    if (validate) {
+      // Sanity checks on `self`.
+      auto is_valid = ((self.max() < INFINITY) & (self.min() >= 0)).item();
+      TORCH_CHECK(is_valid.to<bool>(), "probability tensor contains either `inf`, `nan` or element < 0");
+      bool zero_prob_condition = false;
+      if (self.dim() == 1) {
+        zero_prob_condition = (self.sum() == 0).item().to<bool>();
+      } else {
+        zero_prob_condition = (self.sum(1) == 0).sum().item().to<bool>();
+      }
+      TORCH_CHECK(!zero_prob_condition, "invalid multinomial distribution (sum of probabilities <= 0)");
     }
-    TORCH_CHECK(!zero_prob_condition, "invalid multinomial distribution (sum of probabilities <= 0)");
 
     // The algorithm is from gumbel softmax.
     // s = argmax( logp - log(-log(eps)) ) where eps ~ U(0, 1)
@@ -805,9 +808,9 @@ Tensor& multinomial_out_mps(const Tensor& self,
   return result;
 }
 
-Tensor multinomial_mps(const Tensor& self, int64_t n_sample, bool with_replacement, std::optional<Generator> gen) {
+Tensor multinomial_mps(const Tensor& self, int64_t n_sample, bool with_replacement, bool validate, std::optional<Generator> gen) {
   Tensor result = at::empty({0}, self.options().dtype(kLong));
-  multinomial_out_mps(self, n_sample, with_replacement, gen, result);
+  multinomial_out_mps(self, n_sample, with_replacement, validate, gen, result);
   return result;
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9861,13 +9861,13 @@
     CPU, CUDA, MPS: lu_unpack_out
 
 # TODO: remove dispatch section when porting TH CUDA to ATen
-- func: multinomial.out(Tensor self, SymInt num_samples, bool replacement=False, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
+- func: multinomial.out(Tensor self, SymInt num_samples, bool replacement=False, *, bool validate=True, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
   tags: nondeterministic_seeded
   dispatch:
     CPU, CUDA: multinomial_out
     MPS: multinomial_out_mps
 
-- func: multinomial(Tensor self, SymInt num_samples, bool replacement=False, *, Generator? generator=None) -> Tensor
+- func: multinomial(Tensor self, SymInt num_samples, bool replacement=False, *, bool validate=True, Generator? generator=None) -> Tensor
   variants: method, function
   dispatch:
     CPU, CUDA: multinomial

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5481,6 +5481,45 @@ class TestTorchDeviceType(TestCase):
 
     @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double)
+    def test_multinomial_validate_false(self, device, dtype):
+        # Test that validate=False produces valid samples from valid input
+        probs = torch.tensor([0.1, 0.2, 0.3, 0.4], dtype=dtype, device=device)
+        result = torch.multinomial(probs, 1, validate=False)
+        self.assertEqual(result.shape, (1,))
+        self.assertTrue(0 <= result.item() < 4)
+
+        # Test with num_samples > 1, no replacement
+        result = torch.multinomial(probs, 3, replacement=False, validate=False)
+        self.assertEqual(result.shape, (3,))
+        self.assertEqual(result.unique().numel(), 3)
+
+        # Test with replacement
+        result = torch.multinomial(probs, 5, replacement=True, validate=False)
+        self.assertEqual(result.shape, (5,))
+
+        # Test with 2D input
+        probs_2d = torch.tensor([[0.1, 0.9], [0.5, 0.5]], dtype=dtype, device=device)
+        result = torch.multinomial(probs_2d, 1, validate=False)
+        self.assertEqual(result.shape, (2, 1))
+
+        # Test that validate=True (default) still catches invalid input
+        bad_probs = torch.tensor([-1.0, 0.5, 0.5], dtype=dtype, device=device)
+        with self.assertRaises(RuntimeError):
+            torch.multinomial(bad_probs, 1)
+
+        # Test method variant
+        result = probs.multinomial(1, validate=False)
+        self.assertEqual(result.shape, (1,))
+
+        # Test softmax output (the primary use case from the issue)
+        logits = torch.randn(100, dtype=dtype, device=device)
+        softmax_probs = logits.softmax(dim=0)
+        result = torch.multinomial(softmax_probs, 1, validate=False)
+        self.assertEqual(result.shape, (1,))
+        self.assertTrue(0 <= result.item() < 100)
+
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float, torch.double)
     def test_grad_scaling_unscale(self, device, dtype):
         device = torch.device(device)
         device0 = "cuda:0" if device.type == "cuda" else "cpu"

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3025,7 +3025,7 @@
 - name: ne.Tensor(Tensor self, Tensor other) -> Tensor
   output_differentiability: [False]
 
-- name: multinomial(Tensor self, SymInt num_samples, bool replacement=False, *, Generator? generator=None) -> Tensor
+- name: multinomial(Tensor self, SymInt num_samples, bool replacement=False, *, bool validate=True, Generator? generator=None) -> Tensor
   output_differentiability: [False]
 
 - name: nonzero(Tensor self) -> Tensor

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7387,7 +7387,7 @@ def meta_scatter_reduce__two(self, dim, index, src, reduce, include_self=True):
 
 @register_meta([aten.multinomial.default, aten.multinomial.out])
 @out_wrapper()
-def meta_multinomial(input, num_samples, replacement=False, *, generator=None):
+def meta_multinomial(input, num_samples, replacement=False, *, validate=True, generator=None):
     torch._check(
         0 < input.dim() <= 2,
         lambda: f"The probability distributions dimensions must be 1 or 2, but got {input.dim()}",

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7762,7 +7762,7 @@ Alias for :func:`torch.mul`.
 add_docstr(
     torch.multinomial,
     r"""
-multinomial(input, num_samples, replacement=False, *, generator=None, out=None) -> LongTensor
+multinomial(input, num_samples, replacement=False, *, validate=True, generator=None, out=None) -> LongTensor
 
 Returns a tensor where each row contains :attr:`num_samples` indices sampled
 from the multinomial (a stricter definition would be multivariate,
@@ -7799,6 +7799,11 @@ Args:
     replacement (bool, optional): whether to draw with replacement or not
 
 Keyword args:
+    validate (bool, optional): whether to validate the input probability tensor
+        (check for negative values, NaN, Inf, and zero sum). Default: ``True``.
+        Set to ``False`` to skip validation when the caller guarantees the input
+        is valid (e.g. output of :func:`~torch.nn.functional.softmax`), which
+        can provide a significant speedup on CUDA.
     {generator}
     {out}
 

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -826,7 +826,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         torch.msort: lambda input, descending=False, out=None: -1,
         torch.mul: lambda input, other, out=None: -1,
         torch.multiply: lambda input, other, out=None: -1,
-        torch.multinomial: lambda input, num_samples, replacement=False, out=None: -1,
+        torch.multinomial: lambda input, num_samples, replacement=False, *, validate=True, out=None: -1,
         torch.mv: lambda input, vec, out=None: -1,
         torch.mvlgamma: lambda input, p: -1,
         torch.narrow: lambda input, dim, start, length: -1,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1971,6 +1971,8 @@ def sample_inputs_multinomial(self, device, dtype, requires_grad, **kwargs):
         ([3], 3, dict(replacement=True)),
         ([3, 4], 4, dict(replacement=True)),
         ([3, 4], 4, dict(replacement=False)),
+        ([3], 3, dict(validate=False)),
+        ([3, 4], 4, dict(replacement=True, validate=False)),
     ]
 
     for shape, num_samples, kwargs in cases:


### PR DESCRIPTION
## Summary

Adds a `validate` keyword argument (default `True`) to `torch.multinomial`. When `validate=False`, the 10 GPU validation kernels (`aminmax`, `sum`, `assert_async`, etc.) on the fast path (`!with_replacement || n_sample == 1`) are skipped entirely.

Fixes #177127

## Motivation

As profiled in the issue, `torch.multinomial` spends **~66% of GPU time** (~107 µs out of ~161 µs on an RTX 3090 with V=128,000) on input validation — checking for negative values, NaN, Inf, and zero-sum distributions. This validation is unnecessary when the caller knows the input is valid, e.g. when probabilities come directly from `softmax()`, which guarantees values in [0, 1], no NaN/Inf, and sum ~ 1.0.

This matters for **LLM inference**, where `torch.multinomial` is called on every decode step with softmax output. Skipping validation yields an estimated **~3x speedup** for this hot-path operation.

## Changes

| File | Change |
|------|--------|
| `native_functions.yaml` | Add `bool validate=True` as keyword-only arg to both `multinomial` and `multinomial.out` |
| `Distributions.cpp` | Guard the fast-path validation block with `if (validate)` |
| `Distributions.mm` (MPS) | Same guard for the MPS backend |
| `derivatives.yaml` | Update signature |
| `_meta_registrations.py` | Accept new kwarg in meta function |
| `overrides.py` | Update lambda signature |
| `_torch_docs.py` | Document the `validate` kwarg with usage guidance |
| `test_torch.py` | Add `test_multinomial_validate_false` covering 1D/2D, replacement/no-replacement, method variant, and softmax input |
| `common_methods_invocations.py` | Add `validate=False` sample inputs to OpInfo |

## Usage

```python
# Default behavior unchanged (validation on):
torch.multinomial(probs, num_samples=1)

# Skip validation when input is known-valid (e.g. from softmax):
torch.multinomial(probs, num_samples=1, validate=False)

# Method variant also supported:
probs.multinomial(num_samples=1, validate=False)
```

## Design Decisions

- **Keyword-only**: `validate` is keyword-only to prevent positional ambiguity with existing args
- **Default `True`**: Full backward compatibility — existing code is unaffected
- **Name choice**: `validate` follows the pattern used by other PyTorch APIs (e.g. `torch.nn.utils.clip_grad_norm_` uses similar optional validation flags)
- **Both CPU and GPU**: Validation is guarded on both `Distributions.cpp` (CPU/CUDA) and `Distributions.mm` (MPS)

## Testing

- Added `test_multinomial_validate_false` with coverage for all code paths (1D, 2D, with/without replacement, method variant, softmax input)
- Added `validate=False` sample inputs to OpInfo for broader test matrix coverage
- Existing tests pass unchanged (`validate=True` is the default)

cc @jerryzh168 @ptrblck @msaroufim @eqy @tinglvv @nWEIdia
