### PR TITLE
[meta tensors] Fix conv2d kernel size validation for meta and symbolic shapes

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -802,6 +802,53 @@ class TestConvolutionNN(NNTestCase):
                 dtype,
             )
 
+    def test_conv_shapecheck_meta_kernel_larger_than_input(self):
+        """Meta tensors should raise the same error as eager when kernel > input.
+
+        Regression test for https://github.com/pytorch/pytorch/issues/177451
+        """
+        input_tensor = torch.randn(2, 4, 5, 5)
+        weight_tensor = torch.randn(6, 4, 3, 3)
+        kwargs = dict(bias=None, stride=3, padding=0, dilation=[2, 3], groups=1)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Kernel size can't be greater than actual input size"
+        ):
+            F.conv2d(input_tensor, weight_tensor, **kwargs)
+
+        input_meta = input_tensor.to("meta")
+        weight_meta = weight_tensor.to("meta")
+        with self.assertRaisesRegex(
+            RuntimeError, "Kernel size can't be greater than actual input size"
+        ):
+            F.conv2d(input_meta, weight_meta, **kwargs)
+
+        torch._dynamo.reset()
+        compiled_conv = torch.compile(
+            lambda inp, w: F.conv2d(inp, w, **kwargs), backend="aot_eager"
+        )
+        with self.assertRaisesRegex(RuntimeError, "Kernel size can't be greater"):
+            compiled_conv(input_tensor, weight_tensor)
+
+        # Boundary: kernel exactly fits
+        input_exact = torch.randn(2, 4, 5, 7)
+        self.assertEqual(
+            F.conv2d(input_exact, weight_tensor, **kwargs).shape,
+            torch.Size([2, 6, 1, 1]),
+        )
+        self.assertEqual(
+            F.conv2d(input_exact.to("meta"), weight_meta, **kwargs).shape,
+            torch.Size([2, 6, 1, 1]),
+        )
+        torch._dynamo.reset()
+        compiled_valid = torch.compile(
+            lambda inp, w: F.conv2d(inp, w, **kwargs), backend="aot_eager"
+        )
+        self.assertEqual(
+            compiled_valid(input_exact, weight_tensor).shape,
+            torch.Size([2, 6, 1, 1]),
+        )
+
     def test_ConvTranspose2d_output_size(self):
         m = nn.ConvTranspose2d(3, 4, 3, 3, 0, 2)
         i = torch.randn(2, 3, 6, 6)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2606,9 +2606,10 @@ def calc_conv_nd_return_shape(
 
         # pyrefly: ignore [bad-index, index-error]
         padded_input = [dims[i] + 2 * padding[i] for i in range(len(dims))]
-        # pyrefly: ignore [bad-index, index-error]
         effective_kernel = [
-            dilation[i] * (kernel_size[i] - 1) + 1 for i in range(len(dims))
+            # pyrefly: ignore [bad-index, index-error]
+            dilation[i] * (kernel_size[i] - 1) + 1
+            for i in range(len(dims))
         ]
         torch._check(
             sym_and(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2611,7 +2611,9 @@ def calc_conv_nd_return_shape(
             dilation[i] * (kernel_size[i] - 1) + 1 for i in range(len(dims))
         ]
         torch._check(
-            sym_and(*[p >= k for p, k in zip(padded_input, effective_kernel, strict=True)]),
+            sym_and(
+                *[p >= k for p, k in zip(padded_input, effective_kernel, strict=True)]
+            ),
             lambda: (
                 f"Calculated padded input size per channel: "
                 f"({' x '.join(str(x) for x in padded_input)}). "

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2599,6 +2599,27 @@ def calc_conv_nd_return_shape(
         else:
             output_padding_list = output_padding
 
+    # Validate kernel size fits within padded input (mirrors C++ check_shape_forward
+    # in aten/src/ATen/native/Convolution.cpp).
+    if not is_transposed:
+        from torch.fx.experimental.symbolic_shapes import sym_and
+
+        # pyrefly: ignore [bad-index, index-error]
+        padded_input = [dims[i] + 2 * padding[i] for i in range(len(dims))]
+        # pyrefly: ignore [bad-index, index-error]
+        effective_kernel = [
+            dilation[i] * (kernel_size[i] - 1) + 1 for i in range(len(dims))
+        ]
+        torch._check(
+            sym_and(*[p >= k for p, k in zip(padded_input, effective_kernel)]),
+            lambda: (
+                f"Calculated padded input size per channel: "
+                f"({' x '.join(str(x) for x in padded_input)}). "
+                f"Kernel size: ({' x '.join(str(x) for x in effective_kernel)}). "
+                f"Kernel size can't be greater than actual input size"
+            ),
+        )
+
     for i in range(len(dims)):
         # If output_padding is present, we are dealing with a transposed convolution
         if output_padding_list:

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2611,7 +2611,7 @@ def calc_conv_nd_return_shape(
             dilation[i] * (kernel_size[i] - 1) + 1 for i in range(len(dims))
         ]
         torch._check(
-            sym_and(*[p >= k for p, k in zip(padded_input, effective_kernel)]),
+            sym_and(*[p >= k for p, k in zip(padded_input, effective_kernel, strict=True)]),
             lambda: (
                 f"Calculated padded input size per channel: "
                 f"({' x '.join(str(x) for x in padded_input)}). "


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/177451

Meta tensors (`.to('meta')`) dispatch `aten.convolution.default` to the Python meta registration `calc_conv_nd_return_shape` in [`torch/_meta_registrations.py`](https://github.com/pytorch/pytorch/blob/main/torch/_meta_registrations.py), which was missing the kernel-size validation that the C++ counterpart [`check_shape_forward`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/Convolution.cpp#L726-L761) performs. When the convolution kernel is larger than the (padded) input, the meta path silently computed a zero-sized output dimension instead of raising.

This PR adds an explicit validation in `calc_conv_nd_return_shape` (for non-transposed convolutions) that checks `padded_input >= effective_kernel` per spatial dimension using `sym_and` from `torch.fx.experimental.symbolic_shapes`. This ensures correct behavior for both concrete values (meta tensors) and symbolic values (`torch.compile` with dynamic shapes), without forcing guards via Python `bool()` on `SymBool`.

## Changes
- **`torch/_meta_registrations.py`**: Add kernel-size validation using `sym_and` + `torch._check`, mirroring C++ `check_shape_forward`
- **`test/nn/test_convolution.py`**: Add regression test covering eager, meta, and `torch.compile` paths, plus boundary case

## Test plan
- `pytest test/nn/test_convolution.py` — 692 passed, 0 failed
- `pytest test/test_fake_tensor.py` — 323 passed (1 pre-existing `swap_tensors` weakref  failure unrelated)
- `pytest test/test_meta.py` — 48,084 passed (2 pre-existing BLAS failures unrelated)
- `pytest test/dynamo/test_repros.py` — 363 passed (1 pre-existing LAPACK failure unrelated)


cc @malfet @ezyang @eellison @bdhirsh @bobrenjc93 @aorenste @chauhang @penguinwu