### PR TITLE
[xpu][fix] Add xpu to maybe_fallback

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -135,12 +135,12 @@ def _disable_dynamo_if_unsupported(
                 and has_state_steps
                 and (arg := args[state_steps_ind])
                 and isinstance(arg, Sequence)
-                and arg[0].is_cuda
+                and arg[0].device.type in {"cuda", "xpu"}
                 or (
                     "state_steps" in kwargs
                     and (kwarg := kwargs["state_steps"])
                     and isinstance(kwarg, Sequence)
-                    and kwarg[0].is_cuda
+                    and kwarg[0].device.type in {"cuda", "xpu"}
                 )
             ):
                 return disabled_func(*args, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #180453
* __->__ #180451

# Motivation
fix https://github.com/pytorch/pytorch/issues/178746
This UT failed because when `torch.compiler.is_compiling() == True`, [`_group_tensors_by_device_and_dtype`](https://github.com/pytorch/pytorch/blob/ebff479212486018a096d1dd5db1c015bb257602/torch/optim/optimizer.py#L561-L562) returns `None` for dtype, which results in raising `AssertError("dtype is needed to compute eps1 when eps1 is unset")` from https://github.com/pytorch/pytorch/blob/ebff479212486018a096d1dd5db1c015bb257602/torch/optim/_adafactor.py#L502-L505

# Solution
Following CUDA's approach to fallback it.

