### PR TITLE
Fix profiler unit tests 2

### DIFF
--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 from typing import Any
+from unittest.mock import patch
 
 import numpy as np
 
@@ -222,11 +223,8 @@ class TestExecutionTrace(TestCase):
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     @skipIfHpu
     @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
+    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "1", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1"})
     def test_execution_trace_env_enabled_with_kineto(self, device):
-        import os
-
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE"] = "1"
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS"] = "1"
         trace_called_num = 0
 
         def trace_handler(p):
@@ -364,11 +362,8 @@ class TestExecutionTrace(TestCase):
                 f"Expected {expected_loop_events} loop events, got {loop_count}"
             )
 
+    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "0", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "0"})
     def test_execution_trace_env_disabled(self, device):
-        import os
-
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE"] = "0"
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS"] = "0"
         use_device = (
             torch.profiler.ProfilerActivity.CUDA
             or torch.profiler.ProfilerActivity.HPU in supported_activities()
@@ -466,16 +461,12 @@ class TestExecutionTrace(TestCase):
         "need triton and device(CUDA or XPU) availability to run",
     )
     @skipCPUIf(True, "skip CPU device for testing profiling triton")
+    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "1", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1"})
     def test_execution_trace_env_enabled_with_pt2(self, device):
         # clean up the local cache for triton kernel
         from torch._inductor.codecache import PyCodeCache
 
         PyCodeCache.cache_clear(purge=True)
-
-        import os
-
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE"] = "1"
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS"] = "1"
 
         @torchdynamo.optimize("inductor")
         def fn(a, b, c):
@@ -766,8 +757,8 @@ class TestExecutionTrace(TestCase):
         not TEST_CUDA,
         "need CUDA device availability to run",
     )
+    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_RANGE": "1"})
     def test_execution_trace_record_integral_tensor_range(self):
-        os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_RANGE"] = "1"
         t1 = torch.tensor([[1, 2], [3, 4]]).cuda()
         t2 = torch.tensor([[0, 0], [1, 0]]).cuda()
         with (
@@ -805,13 +796,10 @@ class TestExecutionTrace(TestCase):
         not TEST_CUDA,
         "need CUDA device availability to run",
     )
+    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_DATA": "aten::gather"})
     def test_execution_trace_record_integral_tensor_data(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             fp_name = os.path.join(temp_dir, "test.et.json")
-
-            os.environ["ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_DATA"] = (
-                "aten::gather"
-            )
             et = ExecutionTraceObserver()
             et.register_callback(fp_name)
             et.set_extra_resource_collection(True)

--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -223,7 +223,13 @@ class TestExecutionTrace(TestCase):
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     @skipIfHpu
     @skipIfTorchDynamo("profiler gets ignored if dynamo activated")
-    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "1", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1"})
+    @patch.dict(
+        os.environ,
+        {
+            "ENABLE_PYTORCH_EXECUTION_TRACE": "1",
+            "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1",
+        },
+    )
     def test_execution_trace_env_enabled_with_kineto(self, device):
         trace_called_num = 0
 
@@ -362,7 +368,13 @@ class TestExecutionTrace(TestCase):
                 f"Expected {expected_loop_events} loop events, got {loop_count}"
             )
 
-    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "0", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "0"})
+    @patch.dict(
+        os.environ,
+        {
+            "ENABLE_PYTORCH_EXECUTION_TRACE": "0",
+            "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "0",
+        },
+    )
     def test_execution_trace_env_disabled(self, device):
         use_device = (
             torch.profiler.ProfilerActivity.CUDA
@@ -461,7 +473,13 @@ class TestExecutionTrace(TestCase):
         "need triton and device(CUDA or XPU) availability to run",
     )
     @skipCPUIf(True, "skip CPU device for testing profiling triton")
-    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE": "1", "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1"})
+    @patch.dict(
+        os.environ,
+        {
+            "ENABLE_PYTORCH_EXECUTION_TRACE": "1",
+            "ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS": "1",
+        },
+    )
     def test_execution_trace_env_enabled_with_pt2(self, device):
         # clean up the local cache for triton kernel
         from torch._inductor.codecache import PyCodeCache
@@ -757,7 +775,9 @@ class TestExecutionTrace(TestCase):
         not TEST_CUDA,
         "need CUDA device availability to run",
     )
-    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_RANGE": "1"})
+    @patch.dict(
+        os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_RANGE": "1"}
+    )
     def test_execution_trace_record_integral_tensor_range(self):
         t1 = torch.tensor([[1, 2], [3, 4]]).cuda()
         t2 = torch.tensor([[0, 0], [1, 0]]).cuda()
@@ -796,7 +816,10 @@ class TestExecutionTrace(TestCase):
         not TEST_CUDA,
         "need CUDA device availability to run",
     )
-    @patch.dict(os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_DATA": "aten::gather"})
+    @patch.dict(
+        os.environ,
+        {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_DATA": "aten::gather"},
+    )
     def test_execution_trace_record_integral_tensor_data(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             fp_name = os.path.join(temp_dir, "test.et.json")


### PR DESCRIPTION
Profiler unit tests were calling `os.environ["key"] = "value"` to change local behavior. But that changes the testing processes environment, polluting other tests.

This causes strange failures, where running `python -m pytest test/profiler/test_memory_profiler.py` would succeed, but then tests in that file would fail when all tests were run with `python -m pytest test/profiler/`. Using `unittest.mock.patch` ensures these changes are isolated.

Note that this PR is a redo of https://github.com/pytorch/pytorch/pull/180380 because that PR got hosed during a bad rebase.