### PR TITLE
[Test] Make dynamo/test_ctx_manager.py device-agnostic for out-of-tree accelerator backends

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -3352,7 +3352,9 @@ class GraphModule(torch.nn.Module):
 
 instantiate_parametrized_tests(CtxManagerTests)
 instantiate_parametrized_tests(ContextlibContextManagerTests)
-instantiate_device_type_tests(CtxManagerTestsDevice, globals(), except_for=("cpu",), allow_xpu=True)
+instantiate_device_type_tests(
+    CtxManagerTestsDevice, globals(), except_for=("cpu",), allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -17,6 +17,10 @@ from torch._dynamo.testing import (
 from torch._dynamo.utils import counters
 from torch.nn import functional as F
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FLASH_ATTENTION
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyCUDA,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -215,393 +219,6 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(ref, res))
         self.assertEqual(cnts.frame_count, 2)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_context_manager1(self):
-        def fn(x):
-            s = torch.cuda.Stream()
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-            current_stream = torch.cuda.current_stream()
-            s.wait_stream(current_stream)
-            with torch.cuda.stream(s):
-                x = torch.relu(x)
-            current_stream.wait_stream(s)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertExpectedInline(str(cnts.op_count), """9""")
-
-    @unittest.expectedFailure  # https://github.com/pytorch/pytorch/issues/118204
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_across_graph_break(self):
-        def fn(x):
-            s = torch.cuda.Stream()
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-
-            print("foo")
-
-            tcs = torch.cuda.stream(s)
-            current_stream = torch.cuda.current_stream()
-            s.wait_stream(current_stream)
-
-            with tcs:
-                x = torch.relu(x)
-
-            current_stream.wait_stream(s)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(cnts.op_count, 9)
-
-    @unittest.expectedFailure  # https://github.com/pytorch/pytorch/issues/118204
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_context_manager2(self):
-        def fn(x, s):
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-
-            current_stream = torch.cuda.current_stream()
-            s.wait_stream(current_stream)
-
-            with torch.cuda.stream(s):
-                x = torch.relu(x)
-
-            current_stream.wait_stream(s)
-            with torch.cuda.stream(current_stream):
-                x = torch.relu(x)
-
-            s2 = torch.cuda.Stream()
-            s2.wait_stream(current_stream)
-            with torch.cuda.stream(s2):
-                x = torch.relu(x)
-
-            current_stream.wait_stream(s2)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        s = torch.cuda.Stream()
-        ref = fn(x, s)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x, s)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 18)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_method(self):
-        def fn(x):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            new_stream = torch.cuda.Stream()
-            cur_stream = torch.cuda.current_stream()
-            new_stream.wait_stream(cur_stream)
-
-            with torch.cuda.stream(new_stream):
-                x = torch.sin(x)
-                x = torch.add(x, 3)
-
-            cur_stream.wait_stream(new_stream)
-
-            x = torch.add(x, 4)
-            cur_stream.query()
-            cur_stream.synchronize()
-
-            with torch.cuda.stream(new_stream):
-                x = torch.add(x, 5)
-            new_stream.synchronize()
-
-            x = torch.relu(x)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertExpectedInline(str(cnts.op_count), """15""")
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_compared_with_constant(self):
-        def fn(x):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            cur_stream = torch.cuda.current_stream()
-            if cur_stream is not None:
-                return x + 1
-            return x - 1
-
-        def fn2(x):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            cur_stream = torch.cuda.current_stream()
-            if cur_stream != "const_str":
-                return x + 1
-            return x - 1
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        opt_fn2 = torch.compile(fn2, backend=cnts, fullgraph=True)
-        res = opt_fn(x)
-        res2 = opt_fn2(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(ref, res2)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_compared_with_stream(self):
-        def fn(x, s0, s1):
-            if s0 == s1:
-                return x + 1
-            else:
-                return x - 1
-
-        s0 = torch.cuda.Stream()
-        s1 = torch.cuda.Stream()
-        x = torch.randn(2, 2)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-
-        ref0 = fn(x, s0, s1)
-        res0 = opt_fn(x, s0, s1)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(ref0, res0)
-
-        ref1 = fn(x, s1, s1)
-        res1 = opt_fn(x, s1, s1)
-        # We have a re-compilation because of changing inputs
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(ref1, res1)
-
-        torch._dynamo.reset()
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-
-        ref1 = fn(x, s1, s1)
-        res1 = opt_fn(x, s1, s1)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(ref1, res1)
-
-        ref0 = fn(x, s0, s1)
-        res0 = opt_fn(x, s0, s1)
-        # We have a re-compilation because of changing inputs
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(ref0, res0)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    @unittest.skip(
-        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
-    )
-    def test_cuda_event_reconstruct(self):
-        def fn(x):
-            e = torch.cuda.Event()
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-            return x, e
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts)
-        res = opt_fn(x)
-        self.assertEqual(ref[0], res[0])
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 3)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    @unittest.skip(
-        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
-    )
-    def test_cuda_event_across_graph_break(self):
-        def fn(x):
-            e = torch.cuda.Event()
-            e.record()
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-
-            print("foo")
-
-            torch.cuda.current_stream().wait_event(e)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x, e
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts)
-        res = opt_fn(x)
-        self.assertEqual(ref[0], res[0])
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(cnts.op_count, 10)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    @unittest.skip(
-        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
-    )
-    def test_cuda_event_created_outside_of_graph(self):
-        user_stream = torch.cuda.Stream()
-        event = torch.cuda.Event()
-        foo = torch.empty((2, 2), device="cuda")
-
-        def func(foo):
-            event.wait()
-            return foo + 1, event
-
-        x = torch.randn((1024, 1024), device="cuda")
-        cnts = torch._dynamo.testing.CompileCounter()
-
-        def run_iters(fn, compile=False):
-            if compile:
-                fn = torch.compile(fn, backend=cnts)
-            for _ in range(10):
-                with torch.cuda.stream(user_stream):
-                    torch.mm(x, x, out=foo)
-                    event.record()
-                out = fn(foo)
-                # let `fn` finish reading `foo` before writing to it in the next
-                # iteration or `run_iters` call.
-                torch.cuda.current_stream().synchronize()
-            return out
-
-        ref = run_iters(func, compile=False)
-        res = run_iters(func, compile=True)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 4)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    @unittest.skip(
-        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
-    )
-    def test_cuda_event_method_create_stream_outside_of_compile(self):
-        def fn(x, cur_stream, new_stream):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            x = torch.add(x, 3)
-
-            event = cur_stream.record_event()
-            event.query()
-
-            new_stream.wait_event(event)
-            with torch.cuda.stream(new_stream):
-                x = torch.add(x, 4)
-
-            new_event = torch.cuda.Event()
-            new_event.record(new_stream)
-
-            new_event.wait(cur_stream)
-            x = torch.add(x, 5)
-
-            # use new event to sync
-            new_event.synchronize()
-
-            x = torch.relu(x)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        cur_stream = torch.cuda.current_stream()
-        new_stream = torch.cuda.Stream()
-        ref = fn(x, cur_stream, new_stream)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x, cur_stream, new_stream)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertExpectedInline(str(cnts.op_count), """16""")
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_event_method(self):
-        def fn(x):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            cur_stream = torch.cuda.current_stream()
-            new_stream = torch.cuda.Stream()
-
-            x = torch.add(x, 3)
-
-            event = cur_stream.record_event()
-            event.query()
-
-            new_stream.wait_event(event)
-            with torch.cuda.stream(new_stream):
-                x = torch.add(x, 4)
-
-            new_event = torch.Event()
-            new_event.record(new_stream)
-
-            new_event.wait(cur_stream)
-            x = torch.add(x, 5)
-
-            # use new event to sync
-            new_event.synchronize()
-
-            x = torch.relu(x)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertExpectedInline(str(cnts.op_count), """17""")
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_device(self):
-        def fn(x):
-            with torch.cuda.device(x.device.index - 1):
-                x = torch.sin(x + 1)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda__exchange_device_args(self):
-        @torch.compile(backend="eager", fullgraph=True)
-        def fn(args, kwargs):
-            torch.cuda._exchange_device(*args, **kwargs)
-
-        initial_dev = torch.cuda.current_device()
-        for args, kwargs in (((), ()), ((0, 0), ()), ((), ("kwarg",))):
-            self.assertRaises(torch._dynamo.exc.Unsupported, fn, args, kwargs)
-            self.assertEqual(torch.cuda.current_device(), initial_dev)
-
     def test_autograd_profiler_enabled(self):
         def fn(x):
             if torch.autograd._profiler_enabled():
@@ -627,61 +244,6 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             ref = fn(x)
             res = opt_fn(x)
             self.assertTrue(same(ref, res))
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_autocast(self):
-        if not torch.cuda.is_bf16_supported():
-            raise unittest.SkipTest("requires bf16")
-
-        class MyModule(torch.nn.Module):
-            def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-                d_float32 = torch.rand((8, 8), device="cuda")
-
-                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
-                    e_float16 = torch.mm(a_float32, b_float32)
-                    f_float16 = torch.mm(d_float32, e_float16)
-                return f_float16
-
-        module = MyModule()
-        real = module(torch.tensor([0.5]))
-        real_device = real.device
-        real_dtype = real.dtype
-
-        graph, _ = torch._dynamo.export(module)(torch.tensor([[0.0, 0], [0, 0]]))
-        exported = graph(torch.tensor([0.5]))
-        self.assertEqual(exported.device, real_device)
-        self.assertEqual(exported.dtype, real_dtype)
-
-        self.assertEqual(exported.device.type, "cuda")
-        self.assertEqual(exported.device.index, 0)
-        self.assertEqual(exported.dtype, torch.bfloat16)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_amp_autocast(self):
-        class MyModule(torch.nn.Module):
-            def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-
-                with torch.autocast(device_type="cuda", dtype=torch.float64):
-                    c_float64 = torch.mm(a_float32, b_float32)
-                return c_float64
-
-        module = MyModule()
-        real = module(torch.tensor([0.5]))
-        real_device = real.device
-        real_dtype = real.dtype
-
-        graph, _ = torch._dynamo.export(module)(torch.tensor([[0.0, 0], [0, 0]]))
-        exported = graph(torch.tensor([0.5]))
-        self.assertEqual(exported.device, real_device)
-        self.assertEqual(exported.dtype, real_dtype)
-
-        self.assertEqual(exported.device.type, "cuda")
-        self.assertEqual(exported.device.index, 0)
-        self.assertEqual(exported.dtype, torch.float64)
 
     def test_is_autocast_cpu_enabled(self):
         def fn(a_float32, b_float32):
@@ -931,123 +493,6 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(out_16.dtype, torch.bfloat16)
         self.assertEqual(out_32.device.type, "cpu")
         self.assertEqual(out_32.dtype, torch.float32)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_autocast_float64(self):
-        class MyModule(torch.nn.Module):
-            def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-                d_float32 = torch.rand((8, 8), device="cuda")
-
-                with torch.autocast(device_type="cuda", dtype=torch.float64):
-                    e_float64 = torch.mm(a_float32, b_float32)
-                    f_float64 = torch.mm(d_float32, e_float64)
-                return f_float64
-
-        module = MyModule()
-        real = module(torch.tensor([0.5]))
-        real_device = real.device
-        real_dtype = real.dtype
-
-        graph, _ = torch._dynamo.export(module)(torch.tensor([[0.0, 0], [0, 0]]))
-        exported = graph(torch.tensor([0.5]))
-        self.assertEqual(exported.device, real_device)
-        self.assertEqual(exported.dtype, real_dtype)
-
-        self.assertEqual(exported.device.index, 0)
-        self.assertEqual(exported.dtype, torch.float64)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_autocast_device(self):
-        class MyModule(torch.nn.Module):
-            def forward(self, x):
-                a_float32 = torch.rand((8, 8), device="cuda")
-                b_float32 = torch.rand((8, 8), device="cuda")
-                d_float32 = torch.rand((8, 8), device="cuda")
-
-                with torch.autocast("cuda"):
-                    e_float64 = torch.mm(a_float32, b_float32)
-                    f_float64 = torch.mm(d_float32, e_float64)
-                return f_float64
-
-        module = MyModule()
-        real = module(torch.tensor([0.5]))
-        real_device = real.device
-        real_dtype = real.dtype
-
-        graph, _ = torch._dynamo.export(module)(torch.tensor([[0.0, 0], [0, 0]]))
-        exported = graph(torch.tensor([0.5]))
-        self.assertEqual(exported.device, real_device)
-        self.assertEqual(exported.dtype, real_dtype)
-
-        self.assertEqual(exported.device.index, 0)
-        self.assertEqual(exported.dtype, torch.float16)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_autocast_arguments_binding(self):
-        def f1(x):
-            with torch.autocast(device_type="cuda", enabled=False):
-                x = torch.sin(x + 1)
-            return x
-
-        def f2(x):
-            with torch.autocast(device_type="cpu", enabled=False):
-                x = torch.cos(x + 1)
-            return x
-
-        x = torch.rand([2, 3])
-        ref1 = f1(x)
-        ref2 = f2(x)
-        opt_f1 = torch.compile(backend="eager")(f1)
-        opt_f2 = torch.compile(backend="eager")(f2)
-        res1 = opt_f1(x)
-        res2 = opt_f2(x)
-        self.assertTrue(same(ref1, res1))
-        self.assertTrue(same(ref2, res2))
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_autocast_decorator(self):
-        def autocast_func(orig_func):
-            @torch.amp.autocast(device_type="cuda", dtype=torch.float16)
-            def new_fwd(*args, **kwargs):
-                return orig_func(*args, **kwargs)
-
-            return new_fwd
-
-        def autocast_func_cuda(orig_func):
-            @torch.autocast(device_type="cuda", dtype=torch.float16)
-            def new_fwd(*args, **kwargs):
-                return orig_func(*args, **kwargs)
-
-            return new_fwd
-
-        def autocast_func_cpu(orig_func):
-            @torch.autocast(device_type="cpu", dtype=torch.float16)
-            def new_fwd(*args, **kwargs):
-                return orig_func(*args, **kwargs)
-
-            return new_fwd
-
-        def mm(a, b):
-            return torch.mm(a, b)
-
-        mm_float16 = autocast_func(mm)
-        mm_float16_cuda = autocast_func_cuda(mm)
-        mm_float16_cpu = autocast_func_cpu(mm)
-
-        def fn(a, b):
-            return mm_float16(a, b), mm_float16_cuda(a, b), mm_float16_cpu(a, b)
-
-        a_float32 = torch.rand((8, 8), device="cuda")
-        b_float32 = torch.rand((8, 8), device="cuda")
-
-        ref = fn(a_float32, b_float32)
-        opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
-        res = opt_fn(a_float32, b_float32)
-        self.assertTrue(same(ref, res))
-        self.assertTrue(res[0].dtype == torch.float16)
-        self.assertTrue(res[1].dtype == torch.float16)
 
     def test__enter__exit_autocast(self):
         def f(x, y):
@@ -2311,6 +1756,556 @@ class GraphModule(torch.nn.Module):
         self.assertGreater(len(counters["graph_break"]), 0)
 
 
+class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
+    def test_stream_context_manager1(self, device):
+        def fn(x):
+            s = torch.Stream(device=device)
+            x = torch.mul(x, 5)
+            x = torch.add(x, 2)
+            current_stream = torch.accelerator.current_stream()
+            s.wait_stream(current_stream)
+            with s:
+                x = torch.relu(x)
+            current_stream.wait_stream(s)
+            x = torch.add(x, 1)
+            x = torch.cos(x)
+            return x
+
+        x = torch.randn((2, 2), device=device)
+        ref = fn(x)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertExpectedInline(str(cnts.op_count), """9""")
+
+    @unittest.expectedFailure  # https://github.com/pytorch/pytorch/issues/118204
+    def test_stream_across_graph_break(self, device):
+        def fn(x):
+            s = torch.Stream(device=device)
+            x = torch.mul(x, 5)
+            x = torch.add(x, 2)
+
+            print("foo")
+
+            current_stream = torch.accelerator.current_stream()
+            s.wait_stream(current_stream)
+
+            with s:
+                x = torch.relu(x)
+
+            current_stream.wait_stream(s)
+            x = torch.add(x, 1)
+            x = torch.cos(x)
+            return x
+
+        x = torch.randn((2, 2), device=device)
+        ref = fn(x)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+        self.assertEqual(cnts.frame_count, 2)
+        self.assertEqual(cnts.op_count, 9)
+
+    @unittest.expectedFailure  # https://github.com/pytorch/pytorch/issues/118204
+    def test_stream_context_manager2(self, device):
+        def fn(x, s):
+            x = torch.mul(x, 5)
+            x = torch.add(x, 2)
+
+            current_stream = torch.accelerator.current_stream()
+            s.wait_stream(current_stream)
+
+            with s:
+                x = torch.relu(x)
+
+            current_stream.wait_stream(s)
+            with current_stream:
+                x = torch.relu(x)
+
+            s2 = torch.Stream(device=device)
+            s2.wait_stream(current_stream)
+            with s2:
+                x = torch.relu(x)
+
+            current_stream.wait_stream(s2)
+            x = torch.add(x, 1)
+            x = torch.cos(x)
+            return x
+
+        x = torch.randn((2, 2), device=device)
+        s = torch.Stream(device=device)
+        ref = fn(x, s)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+        res = opt_fn(x, s)
+        self.assertEqual(ref, res)
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertEqual(cnts.op_count, 18)
+
+    def test_stream_method(self, device):
+        def fn(x):
+            x = torch.mul(x, 1)
+            x = torch.add(x, 2)
+
+            new_stream = torch.Stream(device=device)
+            cur_stream = torch.accelerator.current_stream()
+            new_stream.wait_stream(cur_stream)
+
+            with new_stream:
+                x = torch.sin(x)
+                x = torch.add(x, 3)
+
+            cur_stream.wait_stream(new_stream)
+
+            x = torch.add(x, 4)
+            cur_stream.query()
+            cur_stream.synchronize()
+
+            with new_stream:
+                x = torch.add(x, 5)
+            new_stream.synchronize()
+
+            x = torch.relu(x)
+            x = torch.cos(x)
+            return x
+
+        x = torch.randn((2, 2), device=device)
+        ref = fn(x)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertExpectedInline(str(cnts.op_count), """15""")
+
+    def test_stream_compared_with_constant(self, device):
+        def fn(x):
+            x = torch.mul(x, 1)
+            x = torch.add(x, 2)
+
+            cur_stream = torch.accelerator.current_stream()
+            if cur_stream is not None:
+                return x + 1
+            return x - 1
+
+        def fn2(x):
+            x = torch.mul(x, 1)
+            x = torch.add(x, 2)
+
+            cur_stream = torch.accelerator.current_stream()
+            if cur_stream != "const_str":
+                return x + 1
+            return x - 1
+
+        x = torch.randn((2, 2), device=device)
+        ref = fn(x)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+        opt_fn2 = torch.compile(fn2, backend=cnts, fullgraph=True)
+        res = opt_fn(x)
+        res2 = opt_fn2(x)
+        self.assertEqual(ref, res)
+        self.assertEqual(ref, res2)
+
+    def test_stream_compared_with_stream(self, device):
+        def fn(x, s0, s1):
+            if s0 == s1:
+                return x + 1
+            else:
+                return x - 1
+
+        s0 = torch.Stream(device=device)
+        s1 = torch.Stream(device=device)
+        x = torch.randn(2, 2)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+
+        ref0 = fn(x, s0, s1)
+        res0 = opt_fn(x, s0, s1)
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertEqual(ref0, res0)
+
+        ref1 = fn(x, s1, s1)
+        res1 = opt_fn(x, s1, s1)
+        self.assertEqual(cnts.frame_count, 2)
+        self.assertEqual(ref1, res1)
+
+        torch._dynamo.reset()
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+
+        ref1 = fn(x, s1, s1)
+        res1 = opt_fn(x, s1, s1)
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertEqual(ref1, res1)
+
+        ref0 = fn(x, s0, s1)
+        res0 = opt_fn(x, s0, s1)
+        self.assertEqual(cnts.frame_count, 2)
+        self.assertEqual(ref0, res0)
+
+    @unittest.skip(
+        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
+    )
+    def test_event_reconstruct(self, device):
+        def fn(x):
+            e = torch.Event(device=device)
+            x = torch.mul(x, 5)
+            x = torch.add(x, 2)
+            return x, e
+
+        x = torch.randn((2, 2), device=device)
+        ref = fn(x)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts)
+        res = opt_fn(x)
+        self.assertEqual(ref[0], res[0])
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertEqual(cnts.op_count, 3)
+
+    @unittest.skip(
+        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
+    )
+    def test_event_across_graph_break(self, device):
+        def fn(x):
+            e = torch.Event(device=device)
+            e.record()
+            x = torch.mul(x, 5)
+            x = torch.add(x, 2)
+
+            print("foo")
+
+            torch.accelerator.current_stream().wait_event(e)
+            x = torch.add(x, 1)
+            x = torch.cos(x)
+            return x, e
+
+        x = torch.randn((2, 2), device=device)
+        ref = fn(x)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts)
+        res = opt_fn(x)
+        self.assertEqual(ref[0], res[0])
+        self.assertEqual(cnts.frame_count, 2)
+        self.assertEqual(cnts.op_count, 10)
+
+    @unittest.skip(
+        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
+    )
+    def test_event_created_outside_of_graph(self, device):
+        user_stream = torch.Stream(device=device)
+        event = torch.Event(device=device)
+        foo = torch.empty((2, 2), device=device)
+
+        def func(foo):
+            event.wait()
+            return foo + 1, event
+
+        x = torch.randn((1024, 1024), device=device)
+        cnts = torch._dynamo.testing.CompileCounter()
+
+        def run_iters(fn, compile=False):
+            if compile:
+                fn = torch.compile(fn, backend=cnts)
+            for _ in range(10):
+                with user_stream:
+                    torch.mm(x, x, out=foo)
+                    event.record()
+                out = fn(foo)
+                torch.accelerator.current_stream().synchronize()
+            return out
+
+        ref = run_iters(func, compile=False)
+        res = run_iters(func, compile=True)
+        self.assertEqual(ref, res)
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertEqual(cnts.op_count, 4)
+
+    @unittest.skip(
+        "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
+    )
+    def test_event_method_create_stream_outside_of_compile(self, device):
+        def fn(x, cur_stream, new_stream):
+            x = torch.mul(x, 1)
+            x = torch.add(x, 2)
+
+            x = torch.add(x, 3)
+
+            event = cur_stream.record_event()
+            event.query()
+
+            new_stream.wait_event(event)
+            with new_stream:
+                x = torch.add(x, 4)
+
+            new_event = torch.Event(device=device)
+            new_event.record(new_stream)
+
+            new_event.wait(cur_stream)
+            x = torch.add(x, 5)
+
+            new_event.synchronize()
+
+            x = torch.relu(x)
+            x = torch.cos(x)
+            return x
+
+        x = torch.randn((2, 2), device=device)
+        cur_stream = torch.accelerator.current_stream()
+        new_stream = torch.Stream(device=device)
+        ref = fn(x, cur_stream, new_stream)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+        res = opt_fn(x, cur_stream, new_stream)
+        self.assertEqual(ref, res)
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertExpectedInline(str(cnts.op_count), """16""")
+
+    def test_event_method(self, device):
+        def fn(x):
+            x = torch.mul(x, 1)
+            x = torch.add(x, 2)
+
+            cur_stream = torch.accelerator.current_stream()
+            new_stream = torch.Stream(device=device)
+
+            x = torch.add(x, 3)
+
+            event = cur_stream.record_event()
+            event.query()
+
+            new_stream.wait_event(event)
+            with new_stream:
+                x = torch.add(x, 4)
+
+            new_event = torch.Event()
+            new_event.record(new_stream)
+
+            new_event.wait(cur_stream)
+            x = torch.add(x, 5)
+
+            new_event.synchronize()
+
+            x = torch.relu(x)
+            x = torch.cos(x)
+            return x
+
+        x = torch.randn((2, 2), device=device)
+        ref = fn(x)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertExpectedInline(str(cnts.op_count), """17""")
+
+    def test_device_context(self, device):
+        device_mod = torch.get_device_module(device)
+
+        def fn(x):
+            with device_mod.device(x.device.index - 1):
+                x = torch.sin(x + 1)
+            return x
+
+        x = torch.randn((2, 2), device=device)
+        ref = fn(x)
+        opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+
+    @onlyCUDA
+    def test_exchange_device_args(self, device):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(args, kwargs):
+            torch.cuda._exchange_device(*args, **kwargs)
+
+        initial_dev = torch.cuda.current_device()
+        for args, kwargs in (((), ()), ((0, 0), ()), ((), ("kwarg",))):
+            self.assertRaises(torch._dynamo.exc.Unsupported, fn, args, kwargs)
+            self.assertEqual(torch.cuda.current_device(), initial_dev)
+
+    @onlyCUDA
+    def test_autocast_bf16(self, device):
+        if not torch.cuda.is_bf16_supported():
+            raise unittest.SkipTest("requires bf16")
+
+        device_type = torch.device(device).type
+
+        class MyModule(torch.nn.Module):
+            def forward(self, x):
+                a_float32 = torch.rand((8, 8), device=device)
+                b_float32 = torch.rand((8, 8), device=device)
+                d_float32 = torch.rand((8, 8), device=device)
+
+                with torch.autocast(device_type=device_type, dtype=torch.bfloat16):
+                    e_float16 = torch.mm(a_float32, b_float32)
+                    f_float16 = torch.mm(d_float32, e_float16)
+                return f_float16
+
+        module = MyModule()
+        real = module(torch.tensor([0.5]))
+        real_device = real.device
+        real_dtype = real.dtype
+
+        graph, _ = torch._dynamo.export(module)(torch.tensor([[0.0, 0], [0, 0]]))
+        exported = graph(torch.tensor([0.5]))
+        self.assertEqual(exported.device, real_device)
+        self.assertEqual(exported.dtype, real_dtype)
+
+        self.assertEqual(exported.device.type, device_type)
+        self.assertEqual(exported.device.index, 0)
+        self.assertEqual(exported.dtype, torch.bfloat16)
+
+    def test_amp_autocast(self, device):
+        device_type = torch.device(device).type
+
+        class MyModule(torch.nn.Module):
+            def forward(self, x):
+                a_float32 = torch.rand((8, 8), device=device)
+                b_float32 = torch.rand((8, 8), device=device)
+
+                with torch.autocast(device_type=device_type, dtype=torch.float64):
+                    c_float64 = torch.mm(a_float32, b_float32)
+                return c_float64
+
+        module = MyModule()
+        real = module(torch.tensor([0.5]))
+        real_device = real.device
+        real_dtype = real.dtype
+
+        graph, _ = torch._dynamo.export(module)(torch.tensor([[0.0, 0], [0, 0]]))
+        exported = graph(torch.tensor([0.5]))
+        self.assertEqual(exported.device, real_device)
+        self.assertEqual(exported.dtype, real_dtype)
+
+        self.assertEqual(exported.device.type, device_type)
+        self.assertEqual(exported.device.index, 0)
+        self.assertEqual(exported.dtype, torch.float64)
+
+    def test_autocast_float64(self, device):
+        device_type = torch.device(device).type
+
+        class MyModule(torch.nn.Module):
+            def forward(self, x):
+                a_float32 = torch.rand((8, 8), device=device)
+                b_float32 = torch.rand((8, 8), device=device)
+                d_float32 = torch.rand((8, 8), device=device)
+
+                with torch.autocast(device_type=device_type, dtype=torch.float64):
+                    e_float64 = torch.mm(a_float32, b_float32)
+                    f_float64 = torch.mm(d_float32, e_float64)
+                return f_float64
+
+        module = MyModule()
+        real = module(torch.tensor([0.5]))
+        real_device = real.device
+        real_dtype = real.dtype
+
+        graph, _ = torch._dynamo.export(module)(torch.tensor([[0.0, 0], [0, 0]]))
+        exported = graph(torch.tensor([0.5]))
+        self.assertEqual(exported.device, real_device)
+        self.assertEqual(exported.dtype, real_dtype)
+
+        self.assertEqual(exported.device.index, 0)
+        self.assertEqual(exported.dtype, torch.float64)
+
+    def test_autocast_device_context(self, device):
+        device_type = torch.device(device).type
+
+        class MyModule(torch.nn.Module):
+            def forward(self, x):
+                a_float32 = torch.rand((8, 8), device=device)
+                b_float32 = torch.rand((8, 8), device=device)
+                d_float32 = torch.rand((8, 8), device=device)
+
+                with torch.autocast(device_type):
+                    e_float64 = torch.mm(a_float32, b_float32)
+                    f_float64 = torch.mm(d_float32, e_float64)
+                return f_float64
+
+        module = MyModule()
+        real = module(torch.tensor([0.5]))
+        real_device = real.device
+        real_dtype = real.dtype
+
+        graph, _ = torch._dynamo.export(module)(torch.tensor([[0.0, 0], [0, 0]]))
+        exported = graph(torch.tensor([0.5]))
+        self.assertEqual(exported.device, real_device)
+        self.assertEqual(exported.dtype, real_dtype)
+
+        self.assertEqual(exported.device.index, 0)
+
+    def test_autocast_arguments_binding(self, device):
+        device_type = torch.device(device).type
+
+        def f1(x):
+            with torch.autocast(device_type=device_type, enabled=False):
+                x = torch.sin(x + 1)
+            return x
+
+        def f2(x):
+            with torch.autocast(device_type="cpu", enabled=False):
+                x = torch.cos(x + 1)
+            return x
+
+        x = torch.rand([2, 3])
+        ref1 = f1(x)
+        ref2 = f2(x)
+        opt_f1 = torch.compile(backend="eager")(f1)
+        opt_f2 = torch.compile(backend="eager")(f2)
+        res1 = opt_f1(x)
+        res2 = opt_f2(x)
+        self.assertTrue(same(ref1, res1))
+        self.assertTrue(same(ref2, res2))
+
+    def test_autocast_decorator(self, device):
+        device_type = torch.device(device).type
+
+        def autocast_func(orig_func):
+            @torch.amp.autocast(device_type=device_type, dtype=torch.float16)
+            def new_fwd(*args, **kwargs):
+                return orig_func(*args, **kwargs)
+
+            return new_fwd
+
+        def autocast_func_device(orig_func):
+            @torch.autocast(device_type=device_type, dtype=torch.float16)
+            def new_fwd(*args, **kwargs):
+                return orig_func(*args, **kwargs)
+
+            return new_fwd
+
+        def autocast_func_cpu(orig_func):
+            @torch.autocast(device_type="cpu", dtype=torch.float16)
+            def new_fwd(*args, **kwargs):
+                return orig_func(*args, **kwargs)
+
+            return new_fwd
+
+        def mm(a, b):
+            return torch.mm(a, b)
+
+        mm_float16 = autocast_func(mm)
+        mm_float16_device = autocast_func_device(mm)
+        mm_float16_cpu = autocast_func_cpu(mm)
+
+        def fn(a, b):
+            return mm_float16(a, b), mm_float16_device(a, b), mm_float16_cpu(a, b)
+
+        a_float32 = torch.rand((8, 8), device=device)
+        b_float32 = torch.rand((8, 8), device=device)
+
+        ref = fn(a_float32, b_float32)
+        opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+        res = opt_fn(a_float32, b_float32)
+        self.assertTrue(same(ref, res))
+        self.assertTrue(res[0].dtype == torch.float16)
+        self.assertTrue(res[1].dtype == torch.float16)
+
+
 class ContextlibContextManagerTests(torch._dynamo.test_case.TestCase):
     def setUp(self):
         super().setUp()
@@ -3357,6 +3352,7 @@ class GraphModule(torch.nn.Module):
 
 instantiate_parametrized_tests(CtxManagerTests)
 instantiate_parametrized_tests(ContextlibContextManagerTests)
+instantiate_device_type_tests(CtxManagerTestsDevice, globals(), except_for=("cpu",), allow_xpu=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary**
Makes test/dynamo/test_ctx_manager.py device-agnostic so that out-of-tree accelerator backends (XPU, HPU, PrivateUse1/OpenReg, etc.) can run existing dynamo context manager tests without modification.

**Key Changes:**

- Create CtxManagerTestsDevice class with 19 device-parameterized tests (stream, event, device context, and autocast), registered via instantiate_device_type_tests(..., except_for=("cpu",), allow_xpu=True)
- Replace CUDA-specific APIs with device-agnostic equivalents:
        - torch.cuda.Stream() → torch.Stream(device=device)
        - torch.cuda.current_stream() → torch.accelerator.current_stream()
        - with torch.cuda.stream(s): → with s:
        - torch.cuda.Event() → torch.Event(device=device)
        - torch.cuda.device(idx) → torch.get_device_module(device).device(idx)
        - device="cuda" → device=device
       - device_type="cuda" in autocast → device_type=torch.device(device).type
- Keep CUDA-only tests that use CUDA-private APIs (_exchange_device, is_bf16_supported) via @onlyCUDA
- No changes to test logic, assertions, or any CPU-only / ContextlibContextManagerTests tests

**Test plan**
- Verified on CUDA: 113 collected, 107 passed, 4 skipped, 2 xfailed - identical to baseline before changes


 cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @desertfire @williamwen42 @mikaylagawarecki @mansiag05 @fffrog @guilhermeleobas