### PR TITLE
[releng] Fix few issues in apply-release-changes.sh

### DIFF
--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -30,11 +30,10 @@ done
 
 echo "Applying to changes to linux binary builds"
 for i in  ".github/workflows/_binary-build-linux.yml" ".github/workflows/_binary-test-linux.yml"; do
-    sed -i "/github.event_name == 'pull_request'/d" $i;
-    sed -i -e s#main#"release/${RELEASE_VERSION}"# $i;
+    sed -i "s#ref: \${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}#ref: \${{ github.sha }}#" $i;
 done
 
-sed -i -e "/generate_ci_workflows.py/i \\\t\t\t\texport RELEASE_VERSION_TAG=${RELEASE_VERSION}" .github/workflows/lint.yml
+sed -i -e "/^        \.github\/scripts\/generate_ci_workflows.py/i \\\t\t\t\texport RELEASE_VERSION_TAG=${RELEASE_VERSION}" .github/workflows/lint.yml
 
 # Triton wheel
 echo "Triton Changes"
@@ -44,6 +43,10 @@ sed -i -e s#-\ main#"-\ release\/${RELEASE_VERSION}"# .github/workflows/build-tr
 echo "XLA Changes"
 sed -i -e s#--quiet#-b\ r"${RELEASE_VERSION}"# .ci/pytorch/common_utils.sh
 sed -i -e s#.*#r"${RELEASE_VERSION}"# .github/ci_commit_pins/xla.txt
+
+# Strip +PTX from CUDA arch lists in release builds
+echo "Stripping +PTX from CUDA arch lists"
+sed -i 's/+PTX//' .ci/manywheel/build_cuda.sh
 
 # Regenerate templates
 export RELEASE_VERSION_TAG=${RELEASE_VERSION}
@@ -58,5 +61,5 @@ sed -i -e s#unstable-jobs.json#"unstable-jobs.json?versionId=${UNSTABLE_VER}"# .
 sed -i -e s#disabled-jobs.json#"disabled-jobs.json?versionId=${DISABLED_VER}"# .github/scripts/filter_test_configs.py
 sed -i -e s#disabled-tests-condensed.json#"disabled-tests-condensed.json?versionId=${DISABLED_TESTS_VER}"# tools/stats/import_test_stats.py
 # Optional
-git commit -m "[RELEASE-ONLY CHANGES] Branch Cut for Release {RELEASE_VERSION}"
-git push origin "${RELEASE_BRANCH}"
+git commit -m "[RELEASE-ONLY CHANGES] Branch Cut for Release ${RELEASE_VERSION}"
+git push origin "release/${RELEASE_VERSION}"

--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -33,7 +33,7 @@ for i in  ".github/workflows/_binary-build-linux.yml" ".github/workflows/_binary
     sed -i "/github.event_name == 'pull_request'/d" $i;
 done
 
-sed -i -e "/^        \.github\/scripts\/generate_ci_workflows.py/i \\        export RELEASE_VERSION_TAG=${RELEASE_VERSION}" .github/workflows/lint.yml
+sed -i "s#^        \.github/scripts/generate_ci_workflows.py#        RELEASE_VERSION_TAG=${RELEASE_VERSION} .github/scripts/generate_ci_workflows.py#" .github/workflows/lint.yml
 
 # Triton wheel
 echo "Triton Changes"

--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -24,16 +24,16 @@ done
 
 echo "Applying to templates"
 for i in .github/templates/*.yml.j2; do
-    sed -i 's#common.checkout(\(.*\))#common.checkout(\1, checkout_pr_head=False)#' $i;
+    sed -i '/checkout_pr_head/!s#common.checkout(\([^)]*\))#common.checkout(\1, checkout_pr_head=False)#' $i;
     sed -i -e s#main#"release/${RELEASE_VERSION}"# $i;
 done
 
 echo "Applying to changes to linux binary builds"
 for i in  ".github/workflows/_binary-build-linux.yml" ".github/workflows/_binary-test-linux.yml"; do
-    sed -i "s#ref: \${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}#ref: \${{ github.sha }}#" $i;
+    sed -i "/github.event_name == 'pull_request'/d" $i;
 done
 
-sed -i -e "/^        \.github\/scripts\/generate_ci_workflows.py/i \\\t\t\t\texport RELEASE_VERSION_TAG=${RELEASE_VERSION}" .github/workflows/lint.yml
+sed -i -e "/^        \.github\/scripts\/generate_ci_workflows.py/i \\        export RELEASE_VERSION_TAG=${RELEASE_VERSION}" .github/workflows/lint.yml
 
 # Triton wheel
 echo "Triton Changes"

--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -62,4 +62,4 @@ sed -i -e s#disabled-jobs.json#"disabled-jobs.json?versionId=${DISABLED_VER}"# .
 sed -i -e s#disabled-tests-condensed.json#"disabled-tests-condensed.json?versionId=${DISABLED_TESTS_VER}"# tools/stats/import_test_stats.py
 # Optional
 # git commit -m "[RELEASE-ONLY CHANGES] Branch Cut for Release ${RELEASE_VERSION}"
-git push origin "release/${RELEASE_VERSION}"
+# git push origin "release/${RELEASE_VERSION}"

--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -61,5 +61,5 @@ sed -i -e s#unstable-jobs.json#"unstable-jobs.json?versionId=${UNSTABLE_VER}"# .
 sed -i -e s#disabled-jobs.json#"disabled-jobs.json?versionId=${DISABLED_VER}"# .github/scripts/filter_test_configs.py
 sed -i -e s#disabled-tests-condensed.json#"disabled-tests-condensed.json?versionId=${DISABLED_TESTS_VER}"# tools/stats/import_test_stats.py
 # Optional
-git commit -m "[RELEASE-ONLY CHANGES] Branch Cut for Release ${RELEASE_VERSION}"
+# git commit -m "[RELEASE-ONLY CHANGES] Branch Cut for Release ${RELEASE_VERSION}"
 git push origin "release/${RELEASE_VERSION}"


### PR DESCRIPTION
## Summary

  Fix several bugs in the release-only changes script that required manual                                                   
  fix-up commits in previous releases (e.g. #170112, #175567).
                                                                                                                             
  - **Binary build checkout ref deleted instead of simplified**: The `sed` that
    removed lines matching `github.event_name == 'pull_request'` deleted the
    entire `ref:` line from the checkout step, causing builds to check out the                                               
    default branch instead of the target SHA. Now replaces the full expression
    with `ref: ${{ github.sha }}`. This also removes the redundant                                                           
    `s#main#release/...#` on these files, which was corrupting a comment                                                     
    ("If doing this in main or release branch").
                                                                                                                             
  - **lint.yml export inserted twice**: The pattern `/generate_ci_workflows.py/`
    matched both the actual script invocation and an `echo` help message,
    inserting `export RELEASE_VERSION_TAG` in both places. Now anchored to only                                              
    match the script invocation line.
                                                                                                                             
  - **+PTX not stripped from CUDA arch lists**: Every release required a manual
    follow-up PR to remove `+PTX` from `.ci/manywheel/build_cuda.sh` (e.g.
    #175567, #157634). Now automated.                                                                                        
   
  - **Commit message missing `$` in variable reference**: `{RELEASE_VERSION}`                                                
    → `${RELEASE_VERSION}`.                                       
                                                                                                                             
  - **`git push` used undefined `RELEASE_BRANCH`**: Replaced with
    `release/${RELEASE_VERSION}`.                                                                                            
                                                                  
  Authored with Claude.

  ## Test plan

Test PR is here: https://github.com/pytorch/pytorch/pull/180466

  - [x] Ran the script locally against current master (version 2.12) and                                                     
    verified all changes match expected release-only output
  - [x] Confirmed `ref: ${{ github.sha }}` present in binary build/test                                                      
    checkout steps (not deleted)                                  
  - [x] Confirmed comment "If doing this in main or release branch" preserved
  - [x] Confirmed `export RELEASE_VERSION_TAG` appears exactly once in lint.yml                                              
  - [x] Confirmed `+PTX` stripped from all CUDA arch entries in build_cuda.sh
  - [x] Confirmed zero `@main` references remain in workflow files 