### PR TITLE
[aoti] Fix cond regression from while_loop arrayref fix (#180468)

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -670,27 +670,6 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
     def is_safe_to_use_borrow_arrayref_tensor_as_tensor(self):
         return not self.allow_stack_allocation and not self.stack_allocated_buffers
 
-    def _borrow_tensor_input_for_assign(self, tensor_expr: str) -> str:
-        # Subgraphs are inlined, so any borrowed handle stays within the wrapper scope.
-        return f"borrow_arrayref_tensor_as_tensor({tensor_expr})"
-
-    def codegen_subgraph_prefix(self, subgraph, outer_inputs, outer_outputs):
-        assert len(subgraph.graph.graph_inputs) == len(outer_inputs)
-
-        for (inner_input, inner_input_val), outer_input in zip(
-            subgraph.graph.graph_inputs.items(), outer_inputs
-        ):
-            if not isinstance(inner_input_val, ir.TensorBox):
-                continue
-
-            self.writeline(f"AtenTensorHandle {inner_input}_handle;")
-            self.writeline(
-                "AOTI_TORCH_ERROR_CODE_CHECK("
-                f"aoti_torch_assign_tensors_out({self._borrow_tensor_input_for_assign(outer_input)}, "
-                f"&{inner_input}_handle));"
-            )
-            self.writeline(f"RAIIAtenTensorHandle {inner_input}({inner_input}_handle);")
-
     def codegen_while_loop(self, while_loop, stack_output=False):
         if stack_output:
             raise NotImplementedError("NYI cpp wrapper for while_loop_stack_output")
@@ -716,7 +695,7 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             self.writeline(f"AtenTensorHandle {out_name}_handle;")
             self.writeline(
                 "AOTI_TORCH_ERROR_CODE_CHECK("
-                f"aoti_torch_assign_tensors_out({self._borrow_tensor_input_for_assign(inp)}, "
+                f"aoti_torch_assign_tensors_out(borrow_arrayref_tensor_as_tensor({inp}), "
                 f"&{out_name}_handle));"
             )
             self.writeline(f"RAIIAtenTensorHandle {out_name}({out_name}_handle);")


### PR DESCRIPTION
Summary:

D100826885 added a `codegen_subgraph_prefix` override that unconditionally wraps all subgraph outer inputs with `borrow_arrayref_tensor_as_tensor()`. This broke `cond` tests because their outer inputs can be intermediate `RAIIAtenTensorHandle` values (not `ArrayRefTensor<T>`), causing C++ compilation failures.

Fix: remove the `codegen_subgraph_prefix` override entirely. The `codegen_while_loop` override already handles borrowing for its initial carried inputs (which ARE `ArrayRefTensor<T>`), and the subgraph calls within while_loop pass `RAIIAtenTensorHandle` names that work fine with the base class `codegen_subgraph_prefix`.

Test Plan:
```
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:aot_inductor_arrayref_cpu_local -- test_cond_simple_cpu_with_stack_allocation_and_minimal_arrayref_interface test_while_loop_with_parameters_cpu_with_stack_allocation_and_minimal_arrayref_interface test_cond_nested_cpu_with_stack_allocation_and_minimal_arrayref_interface test_custom_op_in_subgraph_cpu_with_stack_allocation_and_minimal_arrayref_interface
```
All 4 pass (cond tests were failing before this fix).

Reviewed By: desertfire

Differential Revision: D100990017


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo