### PR TITLE
Handle dict in _iterate_exprs for triton kernel wrapper nodes (#180471)

### DIFF
--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -23,9 +23,11 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.sym_node import method_to_operator, SymNode, to_node
 from torch.fx.experimental.symbolic_shapes import (
     _constrain_range_for_size,
+    _iterate_exprs,
     DimConstraints,
     DimDynamic,
     expect_true,
+    free_symbols,
     guard_bool,
     guard_float,
     guard_int,
@@ -3570,6 +3572,28 @@ class TestUnbacked(TestCase):
         self.assertTrue(has_free_symbols(sympy.sympify("a")))
         self.assertTrue(has_free_symbols(sympy.sympify("a*2")))
         self.assertTrue(has_free_symbols(sympy.sympify("a+b")))
+
+    def test_iterate_exprs_dict(self):
+        """Test that _iterate_exprs handles dict values (e.g. from triton_kernel_wrapper_functional)."""
+        a, b = sympy.symbols("a b")
+
+        # dict with tensor values and string keys — should not crash
+        t = torch.randn(3, 4)
+        result = list(_iterate_exprs({"Out": t}))
+        # concrete tensor has no symbolic exprs
+        self.assertEqual(len(result), 0)
+
+        # dict with sympy keys — should iterate over both keys and values
+        result = list(_iterate_exprs({a: 1, b: 2}))
+        self.assertEqual(len(result), 2)
+        self.assertIn(a, result)
+        self.assertIn(b, result)
+
+        # free_symbols works on dicts with sympy keys
+        self.assertEqual(free_symbols({a + b: 1}), {a, b})
+
+        # empty dict
+        self.assertEqual(list(_iterate_exprs({})), [])
 
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/156135")
     @torch._dynamo.config.patch("capture_scalar_outputs", True)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -986,10 +986,13 @@ def _iterate_exprs(val: IterateExprs) -> Iterator[sympy.Basic]:
         yield val.expr
     elif isinstance(val, sympy.Basic):
         yield val
-    elif isinstance(val, (int, float, bool)):
+    elif isinstance(val, (int, float, bool, str)):
         pass
     elif isinstance(val, (tuple, list)):
         for s in val:
+            yield from _iterate_exprs(s)
+    elif isinstance(val, dict):
+        for s in itertools.chain(val.keys(), val.values()):
             yield from _iterate_exprs(s)
     elif is_sparse_any(val):
         yield from _iterate_exprs(val.size())


### PR DESCRIPTION
Summary:

`_iterate_exprs` raises `AssertionError` when encountering dict-type values in `node.meta["val"]`. This happens because `triton_kernel_wrapper_functional` nodes produce dict outputs (e.g. `{'Out': tensor}`), and `get_first_incompatible_cudagraph_node` passes these to `free_unbacked_symbols` which calls `_iterate_exprs`.

This was exposed by the recent change to propagate `val` metadata in pattern matcher replacement nodes.

Fix: Add dict handling to `_iterate_exprs`, recursively iterating over dict keys and values like the existing tuple/list handling.

Test Plan:
Before fix:
```
torch._inductor.exc.InductorError: AssertionError: cannot extract sympy expressions from {'Out': FakeTensor(..., device='cuda:0', size=(16, 16, 1, 128), dtype=torch.bfloat16)} <class 'torch.fx.immutable_collections.immutable_dict'>
```

After fix: model benchmark with `max-autotune` mode completes successfully.

Reviewed By: laithsakka, coufon

Differential Revision: D100996763
