### PR TITLE
Add USE_RELATIVE_PATHS build option for ccache-friendly worktree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ option(BUILD_MOBILE_AUTOGRAD
        "Build autograd function in mobile build (in development)" OFF)
 cmake_dependent_option(INSTALL_TEST "Install test binaries if BUILD_TEST is on"
                        ON "BUILD_TEST" OFF)
+option(USE_RELATIVE_PATHS "Use relative paths in generated files for ccache friendliness" OFF)
 option(USE_CPP_CODE_COVERAGE "Compile C/C++ with code coverage flags" OFF)
 option(USE_COLORIZE_OUTPUT "Colorize output during compilation" ON)
 option(USE_ASAN "Use Address+Undefined Sanitizers" OFF)

--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -432,6 +432,11 @@ if(INTERN_BUILD_ATEN_OPS)
     function(process_vec NAME)
       list(GET CPU_CAPABILITY_NAMES ${i} CPU_CAPABILITY)
       set(NEW_IMPL ${CMAKE_BINARY_DIR}/aten/src/ATen/${NAME}.${CPU_CAPABILITY}.cpp)
+      # IMPL is absolute here; make it relative to NEW_IMPL's directory so the
+      # generated #include is worktree-independent (ccache/re-cc friendly).
+      if(USE_RELATIVE_PATHS)
+        file(RELATIVE_PATH IMPL "${CMAKE_BINARY_DIR}/aten/src/ATen" "${IMPL}")
+      endif()
       configure_file("${PROJECT_SOURCE_DIR}/cmake/IncludeSource.cpp.in" ${NEW_IMPL})
       set(cpu_kernel_cpp ${NEW_IMPL} ${cpu_kernel_cpp} PARENT_SCOPE) # Create list of copies
       list(GET CPU_CAPABILITY_FLAGS ${i} FLAGS)

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -237,7 +237,15 @@ class CMake:
                 toolset_expr = ",".join([f"{k}={v}" for k, v in toolset_dict.items()])
                 args.append("-T" + toolset_expr)
 
+        # base_dir is used as cmake's source-dir arg and install prefix;
+        # make it relative to build_dir so these are worktree-independent
+        # (ccache/re-cc friendly).  cmake runs with cwd=build_dir so the
+        # relative path resolves correctly.
         base_dir = str(Path(__file__).absolute().parents[2])
+        if os.environ.get("USE_RELATIVE_PATHS"):
+            base_dir = os.path.relpath(
+                str(Path(__file__).resolve().parents[2]), self.build_dir
+            )
         install_dir = os.path.join(base_dir, "torch")
 
         _mkdir_p(install_dir)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180472

When enabled, cmake's source-dir argument, install prefix, and generated
CPU dispatch #includes use relative paths instead of absolute ones. This
makes build artifacts worktree-independent so ccache/re-cc can share
cache entries across worktrees.

Authored with Claude.