### PR TITLE
[CI] Fix checkout path conflict in TD indexer workflow

### DIFF
--- a/.github/workflows/target-determination-indexer.yml
+++ b/.github/workflows/target-determination-indexer.yml
@@ -25,23 +25,18 @@ jobs:
     runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.g5.4xlarge.nvidia.gpu" # 1 GPU A10G 24GB each
     environment: target-determinator-env
     steps:
-      - name: Clone PyTorch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: pytorch
-
       - name: Setup Linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main
 
       - name: Login to ECR
-        uses: ./pytorch/.github/actions/ecr-login
+        uses: ./.github/actions/ecr-login
 
       - name: Calculate docker image
         id: calculate-docker-image
         uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ci-image:pytorch-linux-jammy-cuda12.8-cudnn9-py3-gcc11
-          working-directory: pytorch
+          working-directory: .
 
       - name: Use following to pull public copy of the image
         id: print-ghcr-mirror
@@ -119,8 +114,8 @@ jobs:
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"
           )
-          chmod +x pytorch/.github/scripts/td_llm_indexer.sh
-          docker exec -t "${container_name}" sh -c 'pytorch/.github/scripts/td_llm_indexer.sh'
+          chmod +x .github/scripts/td_llm_indexer.sh
+          docker exec -t "${container_name}" sh -c '.github/scripts/td_llm_indexer.sh'
 
       - name: Upload to s3
         shell: bash -l {0}


### PR DESCRIPTION
The setup-linux composite action already checks out pytorch at the workspace root via checkout-pytorch, which destroys the pytorch/ subdirectory created by the earlier explicit checkout step. Remove the redundant checkout and update all path references accordingly.

Fixes https://github.com/meta-pytorch/pytorch-gha-infra/issues/1091

I'm not sure if this is still relevant, but we can think about removing it later.