### PR TITLE
[Optimus] Add another batch linear anchor node

### DIFF
--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -621,7 +621,7 @@ class PreGradBatchLinearFusion(BatchFusion):
         return getitem_node.args[0]
 
     def match(self, node: torch.fx.Node):
-        if CallFunctionVarArgs(torch.nn.functional.linear).match(
+        if CallFunctionVarArgs([torch.nn.functional.linear, torch._C._nn.linear]).match(
             node
         ) and is_linear_node_can_be_fused(node):
             input = get_arg_value(node, 0, "input")


### PR DESCRIPTION
Summary: We observe our IGCTR has some small torch._C._nn.linear nodes that can be batched together to achieve better kernel performance.

Test Plan:
```
scripts/mengluy/igctr_analysis.sh --mode_path h100_benchmark/igctr_1029181143_2026_h1
```

P2273003779

Differential Revision: D101012802




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos