### PR TITLE
[inductor] Align SM80 flex flash block masks and apply xfail accordingly

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -26,6 +26,8 @@ from torch.testing._internal.common_cuda import (
     IS_SM90,
     PLATFORM_SUPPORTS_FP8,
     SM120OrLater,
+    SM80OrLater,
+    SM90OrLater,
     xfailIfSM120OrLater,
     xfailIfSM12X,
     xfailIfSM90,
@@ -40,6 +42,9 @@ from torch.testing._internal.common_utils import (
     DeterministicGuard,
     parametrize,
 )
+
+
+IS_SM8X = SM80OrLater and not SM90OrLater
 
 
 def _times_two(score, _b, _h, _m, _n):
@@ -283,7 +288,9 @@ def _create_block_mask_for_device(
     dev = torch.device(device)
     if dev.type == "cuda":
         major, _ = torch.cuda.get_device_capability(dev)
-        if major >= 10:
+        if major == 8:
+            kv_block = 64
+        elif major == 10:
             q_block *= 2
     return create_block_mask(
         mask_mod,
@@ -875,6 +882,14 @@ class TestFlexFlash(InductorTestCase):
                 )
 
     @xfailIfSM120OrLater
+    @decorateIf(
+        unittest.expectedFailure,
+        lambda params: (
+            IS_SM8X
+            and not params["case"].requires_grad
+            and params["case"].score_mod_factory is not None
+        ),
+    )
     @dtypes(torch.float16, torch.bfloat16)
     @parametrize("case", MASK_MOD_CASES, name_fn=mask_case_name)
     def test_flash_attention_mask_mod_cases(self, device, dtype, case):
@@ -1039,6 +1054,14 @@ class TestFlexFlash(InductorTestCase):
                 "backward_mqa_block_mask_causal",
                 "backward_mqa_block_mask_causal_per_head",
             }
+        ),
+    )
+    @decorateIf(
+        unittest.expectedFailure,
+        lambda params: (
+            IS_SM8X
+            and not params["case"].requires_grad
+            and params["case"].block_mask_num_heads == 1
         ),
     )
     @decorateIf(


### PR DESCRIPTION
Match the flex flash block mask helper to the Ampere FA4 tile geometry by using a 64-wide KV sparse block, and mark the remaining unhsupported Ampere forward cases as `xfail`.
Match the flex flash block-mask helper to the SM8x FA4 tile geometry by using a 64-wide KV sparse block, and mark the remaining unsupported SM8x forward cases as expected failures.

The remaining failures fall into two error categories. (1) missing `apply_score_mod` in `FlashAttentionForwardSm80` and (2) `pack_gqa` lowering failures for shared-mask GQA/MQA block mask cases.

Authored with CodeX (GPT-5.4).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo