### PR TITLE
[MPS] fix multinomial sigsegv error

### DIFF
--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -16,6 +16,8 @@
 #include <ATen/ops/argmax.h>
 #include <ATen/ops/bernoulli_native.h>
 #include <ATen/ops/cauchy_native.h>
+#include <ATen/ops/clamp.h>
+#include <ATen/ops/cumsum.h>
 #include <ATen/ops/div.h>
 #include <ATen/ops/exponential_native.h>
 #include <ATen/ops/full_like.h>
@@ -23,9 +25,11 @@
 #include <ATen/ops/log_normal_native.h>
 #include <ATen/ops/multinomial_native.h>
 #include <ATen/ops/normal_native.h>
+#include <ATen/ops/rand.h>
 #include <ATen/ops/random_native.h>
 #include <ATen/ops/randperm.h>
 #include <ATen/ops/randperm_native.h>
+#include <ATen/ops/searchsorted.h>
 #include <ATen/ops/topk.h>
 #include <ATen/ops/uniform_native.h>
 #include <ATen/ops/view_as_real.h>
@@ -606,124 +610,15 @@ static Tensor& multinomial_with_replacement_mps_kernel(const Tensor& self,
                                                        const int64_t n_sample,
                                                        std::optional<Generator> generator,
                                                        Tensor& result) {
-  using namespace mps;
-
-  auto mps_gen = get_generator_or_default<MPSGeneratorImpl>(generator, at::mps::detail::getDefaultMPSGenerator());
-  int inputSize = self.dim();
-  int numDist = inputSize == 1 ? 1 : self.size(0);
-  int numCategories = inputSize == 1 ? self.size(0) : self.size(1);
-
-  // Restructure data for 2d
-  auto self_v = inputSize == 1 ? self.view({numDist, numCategories}) : self;
-  auto result_v = inputSize == 1 ? result.view({numDist, n_sample}) : result;
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "multinomial_with_replacement:" + getTensorsStringKey({self}) + ":" + std::to_string(n_sample);
-    auto cachedGraph = LookUpOrCreateCachedGraph<RandomCachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSShape* prob_shape = getMPSShape(self_v);
-      newCachedGraph->stateTensor = mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[ @7 ]);
-
-      auto prob_dtype = getMPSDataType(self_v);
-
-      // This is probability weights
-      newCachedGraph->probTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self_v), prob_shape);
-
-      MPSGraphTensor* sumProbs = [mpsGraph reductionSumWithTensor:newCachedGraph->probTensor axis:-1 name:nil];
-
-      MPSGraphTensor* normalizedProbs = [mpsGraph divisionWithPrimaryTensor:newCachedGraph->probTensor
-                                                            secondaryTensor:sumProbs
-                                                                       name:nil];
-
-      auto ns_numCategories = [NSNumber numberWithInt:numCategories];
-      auto ns_numDist = [NSNumber numberWithInt:numDist];
-      auto ns_n_sample = [NSNumber numberWithInt:n_sample];
-
-      MPSGraphTensor* ones = [mpsGraph constantWithScalar:1.0f
-                                                    shape:@[ ns_numCategories, ns_numCategories ]
-                                                 dataType:prob_dtype];
-      auto zeroTensor = [mpsGraph constantWithScalar:0.0f dataType:MPSDataTypeInt32];
-      auto minusOneTensor = [mpsGraph constantWithScalar:-1.0f dataType:MPSDataTypeInt32];
-
-      MPSGraphTensor* upperTriangle = [mpsGraph bandPartWithTensor:ones
-                                                    numLowerTensor:zeroTensor
-                                                    numUpperTensor:minusOneTensor
-                                                              name:nil];
-      MPSGraphTensor* upperProbRange = [mpsGraph matrixMultiplicationWithPrimaryTensor:normalizedProbs
-                                                                       secondaryTensor:upperTriangle
-                                                                                  name:nil];
-
-      MPSGraphTensor* lowerProbRange = [mpsGraph subtractionWithPrimaryTensor:upperProbRange
-                                                              secondaryTensor:normalizedProbs
-                                                                         name:nil];
-
-      upperProbRange = [mpsGraph reshapeTensor:upperProbRange withShape:@[ ns_numDist, @1, ns_numCategories ] name:nil];
-      lowerProbRange = [mpsGraph reshapeTensor:lowerProbRange withShape:@[ ns_numDist, @1, ns_numCategories ] name:nil];
-
-      MPSGraphRandomOpDescriptor* descriptor =
-          [MPSGraphRandomOpDescriptor descriptorWithDistribution:MPSGraphRandomDistributionUniform dataType:prob_dtype];
-      NSArray<MPSGraphTensor*>* generatorTensors = [mpsGraph randomTensorWithShape:@[ ns_numDist, ns_n_sample, @1 ]
-                                                                        descriptor:descriptor
-                                                                       stateTensor:newCachedGraph->stateTensor
-                                                                              name:nil];
-      MPSGraphTensor* randomTensor = generatorTensors[0];
-
-      auto broadcastShape = @[ ns_numDist, ns_n_sample, ns_numCategories ];
-      int broadcastShapeVals[3] = {numDist, static_cast<int>(n_sample), numCategories};
-      MPSGraphTensor* broadcastShapeTensor =
-          [mpsGraph constantWithData:[NSData dataWithBytes:broadcastShapeVals length:sizeof(int) * broadcastShape.count]
-                               shape:@[ [NSNumber numberWithUnsignedInteger:broadcastShape.count] ]
-                            dataType:MPSDataTypeUInt32];
-
-      MPSGraphTensor* samplesTensor = [mpsGraph broadcastTensor:randomTensor toShape:broadcastShape name:nil];
-      MPSGraphTensor* sampleAbove = [mpsGraph greaterThanWithPrimaryTensor:samplesTensor
-                                                           secondaryTensor:lowerProbRange
-                                                                      name:nil];
-      MPSGraphTensor* sampleBelow = [mpsGraph lessThanWithPrimaryTensor:samplesTensor
-                                                        secondaryTensor:upperProbRange
-                                                                   name:nil];
-      MPSGraphTensor* sampleWithin = [mpsGraph logicalANDWithPrimaryTensor:sampleAbove
-                                                           secondaryTensor:sampleBelow
-                                                                      name:nil];
-      MPSGraphTensor* sampleMask = [mpsGraph castTensor:sampleWithin toType:MPSDataTypeInt32 name:@"sampleMask"];
-      MPSGraphTensor* categoriesTensor = [mpsGraph coordinateAlongAxis:-1
-                                                       withShapeTensor:broadcastShapeTensor
-                                                                  name:nil];
-      MPSGraphTensor* binnedSamplesTensor = [mpsGraph multiplicationWithPrimaryTensor:categoriesTensor
-                                                                      secondaryTensor:sampleMask
-                                                                                 name:nil];
-      MPSGraphTensor* reducedTensor = [mpsGraph reductionSumWithTensor:binnedSamplesTensor axis:-1 name:nil];
-      MPSGraphTensor* reshapeTensor = [mpsGraph reshapeTensor:reducedTensor
-                                                    withShape:@[ ns_numDist, ns_n_sample ]
-                                                         name:nil];
-      newCachedGraph->resultTensor = [mpsGraph castTensor:reshapeTensor
-                                                   toType:getMPSDataType(result)
-                                                     name:@"resultTensor"];
-    });
-    // update the Philox state values on each run of the same graph
-    MPSNDArrayDescriptor* stateDesc =
-        [MPSNDArrayDescriptor descriptorWithDataType:MPSDataTypeInt32 shape:@[ @(at::mps::detail::PHILOX_STATE_N) ]];
-    MPSNDArray* stateNDArray = [[[MPSNDArray alloc] initWithDevice:stream->device() descriptor:stateDesc] autorelease];
-    {
-      // See Note [Acquire lock when using random generators]
-      std::lock_guard<std::mutex> lock(mps_gen->mutex_);
-      // update the Philox state values on each run
-      mps_gen->update_philox_counters();
-      [stateNDArray writeBytes:mps_gen->state_data() strideBytes:nil];
-    }
-    MPSGraphTensorData* stateTensorData = [[[MPSGraphTensorData alloc] initWithMPSNDArray:stateNDArray] autorelease];
-
-    auto probPlaceholder = Placeholder(cachedGraph->probTensor, self_v);
-    auto outputPlaceholder = Placeholder(cachedGraph->resultTensor, result_v);
-    NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{
-      cachedGraph->stateTensor : stateTensorData,
-      probPlaceholder.getMPSGraphTensor() : probPlaceholder.getMPSGraphTensorData()
-    };
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-
-  return result;
+  auto numCategories = self.size(-1);
+  // CDF accumulated in float32 since bfloat16/float16 lose precision summing many small probabilities.
+  // Sample u from U[0, total) and search the unnormalized CDF,
+  // equivalent to normalizing then sampling u from U[0, 1)
+  auto cdf = self.cumsum(-1, /*dtype=*/kFloat);
+  auto uniform = at::rand(result.sizes(), generator, self.options().dtype(kFloat))
+                     .mul_(cdf.select(-1, numCategories - 1).unsqueeze(-1));
+  at::searchsorted_out(result, cdf, uniform);
+  return result.clamp_(0, numCategories - 1);
 }
 
 /* The largest consecutive integer representable in float32 (2^24) */

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8435,6 +8435,19 @@ class TestMPS(TestCaseMPS):
         # indicating the sampling is working properly on non-contiguous tensors
         self.assertNotEqual(len(samples), 1)
 
+    def test_multinomial_large_input_no_segfault(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/178579
+        # The previous MPSGraph kernel materialized an N x N ones matrix and
+        # segfaulted for N >= 2**17
+        # this test just checks that it doesn't segfault so we don't regress
+        n = 2**17
+        probs = torch.rand(n, device="mps")
+        out = torch.multinomial(probs, 100, replacement=True)
+        torch.mps.synchronize()
+        self.assertEqual(out.shape, torch.Size([100]))
+        self.assertEqual(out.dtype, torch.int64)
+        self.assertEqual(out.device.type, "mps")
+
     def test_cumsum_dim_check(self):
         x = torch.rand((3, 3), device="mps")
         self.assertEqual(x.cumsum(1), x.cumsum(-1))


### PR DESCRIPTION
Fixes #178579 

The old MPSGraph kernel built an N×N ones matrix and matmuld against it to compute the CDF (and materialized an (numDist, n_sample, N) compare tensor for sampling) — so it was O(V**2) in both memory and compute.

The new kernel replaces that with native cumsum + searchsorted, the speedup grows with V. This path is only taken when **replacement=True** and **num_samples > 1**. 

Everything else dispatches to the Gumbel-max fast path in multinomial_out_mps. 

| shape | dtype | layout | MPSGraph (µs) | New (µs) | speedup |
|---|---|---|---:|---:|---:|
| 1D V=1024 K=100 | float32 | contig | 50.77 | 26.54 | 1.91× |
| 1D V=1024 K=100 | float16 | contig | 49.30 | 34.39 | 1.43× |
| 1D V=1024 K=100 | bfloat16 | contig | 49.12 | 33.59 | 1.46× |
| 1D V=4096 K=100 | float32 | contig | 550.04 | 26.13 | 21.1× |
| 1D V=4096 K=100 | float16 | contig | 267.88 | 35.00 | 7.65× |
| 1D V=4096 K=100 | bfloat16 | contig | 265.51 | 34.73 | 7.65× |
| 1D V=16384 K=100 | float32 | contig | 8166.81 | 26.03 | 313.7× |
| 1D V=16384 K=100 | float16 | contig | 4277.43 | 35.22 | 121.5× |
| 1D V=16384 K=100 | bfloat16 | contig | 4273.72 | 34.95 | 122.3× |
| 1D V=16384 K=1024 | float32 | contig | 8263.83 | 29.59 | 279.3× |
| 1D V=16384 K=1024 | float16 | contig | 4362.21 | 39.30 | 110.9× |
| 1D V=16384 K=1024 | bfloat16 | contig | 4413.72 | 39.46 | 111.8× |
| 1D V=4096 K=100 | float32 | strided (`::2`) | 563.35 | 27.52 | 20.5× |
| 1D V=4096 K=100 | float16 | strided (`::2`) | 275.63 | 34.95 | 7.89× |
| 1D V=4096 K=100 | bfloat16 | strided (`::2`) | 276.36 | 34.62 | 7.98× |
| 2D 8×1024 K=100 | float32 | contig | 48.66 | 27.33 | 1.78× |
| 2D 8×1024 K=100 | float16 | contig | 49.01 | 35.65 | 1.37× |
| 2D 8×1024 K=100 | bfloat16 | contig | 50.40 | 35.88 | 1.40× |
| 2D 32×1024 K=100 | float32 | contig | 71.52 | 31.00 | 2.31× |
| 2D 32×1024 K=100 | float16 | contig | 60.76 | 37.49 | 1.62× |
| 2D 32×1024 K=100 | bfloat16 | contig | 63.89 | 36.87 | 1.73× |
| 2D 128×1024 K=100 | float32 | contig | 179.44 | 56.41 | 3.18× |
| 2D 128×1024 K=100 | float16 | contig | 145.47 | 59.94 | 2.43× |
| 2D 128×1024 K=100 | bfloat16 | contig | 149.92 | 59.79 | 2.51× |
| 2D 32×4096 K=100 | float32 | contig | 711.55 | 30.30 | 23.5× |
| 2D 32×4096 K=100 | float16 | contig | 362.35 | 42.15 | 8.60× |
| 2D 32×4096 K=100 | bfloat16 | contig | 361.03 | 42.31 | 8.53× |
| 2D 32×1024 K=100 | float32 | transposed | 73.42 | 29.02 | 2.53× |
| 2D 32×1024 K=100 | float16 | transposed | 61.63 | 34.05 | 1.81× |
| 2D 32×1024 K=100 | bfloat16 | transposed | 64.74 | 34.07 | 1.90× |


To confirm the distributions, see below images:

<img width="1440" height="1680" alt="multinomial_mps_dtype_sweep_fixed" src="https://github.com/user-attachments/assets/94dc1e9b-fee4-482d-a06d-52264282bad4" />



## Reason for doing cumsum with float dtype:

<img width="1440" height="1680" alt="multinomial_mps_dtype_sweep_w_half_accum" src="https://github.com/user-attachments/assets/eea7769f-8b5d-4848-8db2-f427b5ede8e7" />
