### PR TITLE
[Inductor] Fix comprehensive_padding leaking padded strides to user-visible view outputs

### DIFF
--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1968,13 +1968,15 @@ class GraphLowering(torch.fx.Interpreter):
                             result.get_size(), torch.channels_last
                         )
                     if not unbacked_symbols_in_strides and len(strides):
-                        # To avoid converting possible view ops to a copy kernel, we use the previous
-                        # require_exact_strides to handle views. But ultimately it's better to require
-                        # the right strides at the tensor definition.
-                        if n.meta["val"]._is_view() or isinstance(
-                            result.data,
-                            ir.BaseView,
-                        ):
+                        # For view ops where padding is allowed (non-user-visible),
+                        # use require_stride_order to avoid unnecessary copies.
+                        # When padding is NOT allowed (user-visible outputs), we must
+                        # use require_exact_strides even for views, otherwise
+                        # comprehensive_padding can leak padded strides to user output.
+                        if (
+                            n.meta["val"]._is_view()
+                            or isinstance(result.data, ir.BaseView)
+                        ) and allow_padding:
                             result = ir.ExternKernel.require_stride_order(
                                 result,
                                 ir.get_stride_order(strides),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #180499
* __->__ #180495

When comprehensive_padding pads intermediate buffer strides for CUDA memory
coalescing, view-like output nodes use require_stride_order which only checks
stride order, not exact values. This allows padded strides to leak to
user-visible outputs, causing stride mismatches vs eager mode (e.g., stride
(8,1) instead of (5,1) for a (3,5) tensor).

This fix is only use require_exact_strides for view outputs
when padding is NOT allowed (user-visible outputs with pad_outputs=False).
Non-user-visible views still use require_stride_order to avoid the memory
regression.

Fixes #152520

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo