### PR TITLE
feat: Add OpenTelemetry trace export support for torch.profiler

### DIFF
--- a/test/profiler/test_opentelemetry.py
+++ b/test/profiler/test_opentelemetry.py
@@ -1,0 +1,304 @@
+# Owner(s): ["oncall: profiler"]
+
+"""Tests for OpenTelemetry trace export support."""
+
+import threading
+import typing
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch.autograd.profiler import profile as _profile
+from torch.profiler import kineto_available, profile, ProfilerActivity
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+def _otel_available() -> bool:
+    try:
+        import opentelemetry.sdk.trace  # noqa: F401
+        import opentelemetry.trace  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _make_in_memory_exporter():
+    """Create a simple in-memory span exporter for testing.
+
+    Avoids depending on ``opentelemetry.sdk.trace.export.in_memory``
+    which may not be present in all SDK versions.
+    """
+    from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+    class _InMemorySpanExporter(SpanExporter):
+        def __init__(self):
+            self._spans: list = []
+            self._lock = threading.Lock()
+
+        def export(self, spans):
+            with self._lock:
+                self._spans.extend(spans)
+            return SpanExportResult.SUCCESS
+
+        def shutdown(self):
+            pass
+
+        def force_flush(self, timeout_millis=0):
+            return True
+
+        def get_finished_spans(self):
+            with self._lock:
+                return list(self._spans)
+
+    return _InMemorySpanExporter()
+
+
+class TestOpenTelemetryExport(TestCase):
+    """Tests for torch.profiler._opentelemetry module."""
+
+    def _simple_payload(self):
+        """Run a simple workload to generate profiler events."""
+        x = torch.ones(10, 10)
+        y = torch.ones(10, 10)
+        z = torch.add(x, y)
+        return z
+
+    def test_import_error_when_otel_missing(self):
+        """Verify a clear error when opentelemetry is not installed."""
+        from torch.profiler._opentelemetry import _check_otel_available
+
+        with patch.dict("sys.modules", {"opentelemetry.sdk.trace": None}):
+            with self.assertRaises(ImportError) as ctx:
+                _check_otel_available()
+            self.assertIn("opentelemetry", str(ctx.exception).lower())
+
+    def test_us_to_ns(self):
+        from torch.profiler._opentelemetry import _us_to_ns
+
+        self.assertEqual(_us_to_ns(1.0), 1_000)
+        self.assertEqual(_us_to_ns(0.5), 500)
+        self.assertEqual(_us_to_ns(1_000_000), 1_000_000_000)
+
+    def test_safe_str_short(self):
+        from torch.profiler._opentelemetry import _safe_str
+
+        self.assertEqual(_safe_str("hello"), "hello")
+
+    def test_safe_str_long(self):
+        from torch.profiler._opentelemetry import _safe_str
+
+        long_str = "x" * 2000
+        result = _safe_str(long_str)
+        self.assertEqual(len(result), 1024)
+        self.assertTrue(result.endswith("..."))
+
+    def test_scope_names(self):
+        from torch.profiler._opentelemetry import _SCOPE_NAMES
+
+        self.assertEqual(_SCOPE_NAMES[0], "FUNCTION")
+        self.assertEqual(_SCOPE_NAMES[7], "USER_SCOPE")
+
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_build_span_attributes(self):
+        """Test attribute extraction from a real FunctionEvent."""
+        from torch.profiler._opentelemetry import _build_span_attributes
+
+        with profile(
+            activities=[ProfilerActivity.CPU],
+            record_shapes=True,
+        ) as prof:
+            self._simple_payload()
+
+        events = prof.events()
+        self.assertTrue(len(events) > 0)
+
+        for event in events:
+            attrs = _build_span_attributes(event)
+            self.assertIn("pytorch.event.id", attrs)
+            self.assertIn("pytorch.thread.id", attrs)
+            self.assertIn("pytorch.scope", attrs)
+            self.assertIn("pytorch.device.type", attrs)
+            self.assertIn("pytorch.cpu_time_total_us", attrs)
+            break  # just test the first event
+
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_build_event_tree(self):
+        """Test that root events are correctly identified."""
+        from torch.profiler._opentelemetry import _build_event_tree
+
+        with profile(
+            activities=[ProfilerActivity.CPU],
+        ) as prof:
+            self._simple_payload()
+
+        events = prof.events()
+        roots = _build_event_tree(events)
+        # Roots should be a subset of all events
+        self.assertTrue(len(roots) <= len(events))
+        # All roots should have no parent
+        for root in roots:
+            self.assertIsNone(root.cpu_parent)
+
+    @unittest.skipIf(not _otel_available(), "opentelemetry not installed")
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_opentelemetry_trace_handler_with_in_memory_exporter(self):
+        """End-to-end test with an in-memory exporter."""
+        from torch.profiler._opentelemetry import opentelemetry_trace_handler
+
+        exporter = _make_in_memory_exporter()
+        handler = opentelemetry_trace_handler(
+            service_name="test-pytorch",
+            span_exporter=exporter,
+        )
+
+        with profile(
+            activities=[ProfilerActivity.CPU],
+            schedule=torch.profiler.schedule(wait=0, warmup=0, active=1, repeat=1),
+            on_trace_ready=handler,
+            record_shapes=True,
+        ) as prof:
+            self._simple_payload()
+            prof.step()
+
+        spans = exporter.get_finished_spans()
+        self.assertTrue(len(spans) > 0, "Expected at least one OTel span to be exported")
+
+        # Verify span attributes
+        for span in spans:
+            self.assertIsNotNone(span.name)
+            self.assertTrue(len(span.name) > 0)
+            attrs = dict(span.attributes) if span.attributes else {}
+            self.assertIn("pytorch.event.id", attrs)
+
+    @unittest.skipIf(not _otel_available(), "opentelemetry not installed")
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_handler_with_explicit_tracer_provider(self):
+        """Test passing an explicit TracerProvider."""
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+        from torch.profiler._opentelemetry import opentelemetry_trace_handler
+
+        exporter = _make_in_memory_exporter()
+        provider = TracerProvider(
+            resource=Resource.create({"service.name": "custom-service"})
+        )
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+        handler = opentelemetry_trace_handler(tracer_provider=provider)
+
+        with profile(
+            activities=[ProfilerActivity.CPU],
+            schedule=torch.profiler.schedule(wait=0, warmup=0, active=1, repeat=1),
+            on_trace_ready=handler,
+        ) as prof:
+            self._simple_payload()
+            prof.step()
+
+        spans = exporter.get_finished_spans()
+        self.assertTrue(len(spans) > 0)
+
+    @unittest.skipIf(not _otel_available(), "opentelemetry not installed")
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_span_parent_child_relationships(self):
+        """Verify that parent-child span relationships are established."""
+        from torch.profiler._opentelemetry import opentelemetry_trace_handler
+
+        exporter = _make_in_memory_exporter()
+        handler = opentelemetry_trace_handler(
+            service_name="test-pytorch",
+            span_exporter=exporter,
+        )
+
+        with profile(
+            activities=[ProfilerActivity.CPU],
+            schedule=torch.profiler.schedule(wait=0, warmup=0, active=1, repeat=1),
+            on_trace_ready=handler,
+        ) as prof:
+            # Do operations that create parent-child relationships
+            x = torch.randn(20, 20)
+            y = torch.mm(x, x)
+            prof.step()
+
+        spans = exporter.get_finished_spans()
+        # Check that at least some spans have parent span IDs
+        span_ids = {s.context.span_id for s in spans}
+        parent_ids = {
+            s.parent.span_id
+            for s in spans
+            if s.parent is not None and s.parent.span_id != 0
+        }
+        # Some spans should reference other spans as parents
+        # (not all, since root spans have no parent)
+        has_children = len(parent_ids & span_ids) > 0 or len(spans) <= 1
+        # This is a soft check - profiler event trees may vary
+        self.assertTrue(len(spans) > 0)
+
+    @unittest.skipIf(not _otel_available(), "opentelemetry not installed")
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_handler_no_events(self):
+        """Handler should not crash when there are no events."""
+        from torch.profiler._opentelemetry import opentelemetry_trace_handler
+
+        exporter = _make_in_memory_exporter()
+        handler = opentelemetry_trace_handler(span_exporter=exporter)
+
+        # Create a mock profile with no events
+        mock_prof = MagicMock()
+        mock_prof.events.return_value = []
+        handler(mock_prof)
+
+        spans = exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)
+
+    @unittest.skipIf(not _otel_available(), "opentelemetry not installed")
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_span_timing(self):
+        """Verify that span timestamps are reasonable."""
+        import time
+
+        from torch.profiler._opentelemetry import opentelemetry_trace_handler
+
+        exporter = _make_in_memory_exporter()
+        handler = opentelemetry_trace_handler(span_exporter=exporter)
+
+        before_ns = time.time_ns()
+        with profile(
+            activities=[ProfilerActivity.CPU],
+            schedule=torch.profiler.schedule(wait=0, warmup=0, active=1, repeat=1),
+            on_trace_ready=handler,
+        ) as prof:
+            self._simple_payload()
+            prof.step()
+        after_ns = time.time_ns()
+
+        spans = exporter.get_finished_spans()
+        self.assertTrue(len(spans) > 0)
+
+        for span in spans:
+            # Span start should be after we started profiling (with some tolerance)
+            # and end should be before now
+            self.assertGreater(span.start_time, 0)
+            self.assertGreaterEqual(span.end_time, span.start_time)
+
+
+class TestOpenTelemetryExportPublicAPI(TestCase):
+    """Test that the public API is accessible from torch.profiler."""
+
+    def test_handler_importable_from_torch_profiler(self):
+        """Verify the handler can be imported from torch.profiler."""
+        from torch.profiler import opentelemetry_trace_handler
+
+        self.assertTrue(callable(opentelemetry_trace_handler))
+
+    def test_handler_in_all(self):
+        """Verify the handler is listed in __all__."""
+        import torch.profiler
+
+        self.assertIn("opentelemetry_trace_handler", torch.profiler.__all__)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/profiler/test_opentelemetry.py
+++ b/test/profiler/test_opentelemetry.py
@@ -3,12 +3,10 @@
 """Tests for OpenTelemetry trace export support."""
 
 import threading
-import typing
 import unittest
 from unittest.mock import MagicMock, patch
 
 import torch
-from torch.autograd.profiler import profile as _profile
 from torch.profiler import kineto_available, profile, ProfilerActivity
 from torch.testing._internal.common_utils import run_tests, TestCase
 
@@ -162,7 +160,9 @@ class TestOpenTelemetryExport(TestCase):
             prof.step()
 
         spans = exporter.get_finished_spans()
-        self.assertTrue(len(spans) > 0, "Expected at least one OTel span to be exported")
+        self.assertTrue(
+            len(spans) > 0, "Expected at least one OTel span to be exported"
+        )
 
         # Verify span attributes
         for span in spans:
@@ -219,7 +219,7 @@ class TestOpenTelemetryExport(TestCase):
         ) as prof:
             # Do operations that create parent-child relationships
             x = torch.randn(20, 20)
-            y = torch.mm(x, x)
+            _y = torch.mm(x, x)
             prof.step()
 
         spans = exporter.get_finished_spans()
@@ -232,8 +232,11 @@ class TestOpenTelemetryExport(TestCase):
         }
         # Some spans should reference other spans as parents
         # (not all, since root spans have no parent)
-        has_children = len(parent_ids & span_ids) > 0 or len(spans) <= 1
-        # This is a soft check - profiler event trees may vary
+        if len(spans) > 1:
+            self.assertTrue(
+                len(parent_ids & span_ids) > 0,
+                "Expected at least one parent-child relationship between spans",
+            )
         self.assertTrue(len(spans) > 0)
 
     @unittest.skipIf(not _otel_available(), "opentelemetry not installed")
@@ -278,10 +281,10 @@ class TestOpenTelemetryExport(TestCase):
         self.assertTrue(len(spans) > 0)
 
         for span in spans:
-            # Span start should be after we started profiling (with some tolerance)
-            # and end should be before now
             self.assertGreater(span.start_time, 0)
             self.assertGreaterEqual(span.end_time, span.start_time)
+            self.assertLessEqual(span.end_time, after_ns)
+            self.assertGreaterEqual(span.start_time, before_ns - 5_000_000_000)
 
 
 class TestOpenTelemetryExportPublicAPI(TestCase):

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -28,12 +28,15 @@ from .profiler import (
     tensorboard_trace_handler,
 )
 
+from ._opentelemetry import opentelemetry_trace_handler
+
 
 __all__ = [
     "profile",
     "schedule",
     "supported_activities",
     "tensorboard_trace_handler",
+    "opentelemetry_trace_handler",
     "ProfilerAction",
     "ProfilerActivity",
     "kineto_available",

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -18,6 +18,7 @@ from torch._environment import is_fbcode
 from torch.autograd.profiler import KinetoStepTracker, record_function
 from torch.optim.optimizer import Optimizer, register_optimizer_step_post_hook
 
+from ._opentelemetry import opentelemetry_trace_handler
 from .profiler import (
     _KinetoProfile,
     ExecutionTraceObserver,
@@ -28,7 +29,7 @@ from .profiler import (
     tensorboard_trace_handler,
 )
 
-from ._opentelemetry import opentelemetry_trace_handler
+opentelemetry_trace_handler.__module__ = "torch.profiler"
 
 
 __all__ = [

--- a/torch/profiler/_opentelemetry.py
+++ b/torch/profiler/_opentelemetry.py
@@ -1,0 +1,306 @@
+"""OpenTelemetry trace export support for PyTorch Profiler.
+
+This module provides an ``on_trace_ready`` handler that converts PyTorch
+profiler events into OpenTelemetry spans, allowing seamless integration
+with any OTel-compatible backend (Jaeger, Zipkin, OTLP, etc.).
+
+The ``opentelemetry-api`` and ``opentelemetry-sdk`` packages are **optional**
+dependencies.  A clear error is raised at runtime if they are missing.
+
+Usage::
+
+    from torch.profiler import profile, schedule
+    from torch.profiler._opentelemetry import opentelemetry_trace_handler
+
+    with profile(
+        activities=[torch.profiler.ProfilerActivity.CPU],
+        schedule=schedule(wait=1, warmup=1, active=2, repeat=1),
+        on_trace_ready=opentelemetry_trace_handler(service_name="my-model"),
+        record_shapes=True,
+        with_stack=True,
+    ) as prof:
+        for step in range(8):
+            train_step()
+            prof.step()
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SpanExporter
+
+    from torch.autograd.profiler_util import FunctionEvent
+    from torch.profiler.profiler import _KinetoProfile
+
+
+logger = logging.getLogger(__name__)
+
+
+def _check_otel_available() -> None:
+    """Raise an informative ``ImportError`` if OpenTelemetry is not installed."""
+    try:
+        import opentelemetry.sdk.trace  # noqa: F401
+        import opentelemetry.trace  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "OpenTelemetry packages are required for opentelemetry_trace_handler. "
+            "Install them with: pip install opentelemetry-api opentelemetry-sdk"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SCOPE_NAMES = {
+    0: "FUNCTION",
+    1: "BACKWARD_FUNCTION",
+    2: "TORCHSCRIPT_FUNCTION",
+    3: "KERNEL_FUNCTION_DTYPE",
+    4: "CUSTOM_CLASS",
+    5: "BUILD_FEATURE",
+    6: "LITE_INTERPRETER",
+    7: "USER_SCOPE",
+    8: "STATIC_RUNTIME_OP",
+    9: "STATIC_RUNTIME_MODEL",
+}
+
+
+def _us_to_ns(us: float) -> int:
+    """Convert microseconds (profiler native unit) to nanoseconds (OTel unit)."""
+    return int(us * 1_000)
+
+
+def _safe_str(value: Any) -> str:
+    """Safely convert a value to a bounded string representation."""
+    s = str(value)
+    if len(s) > 1024:
+        return s[:1021] + "..."
+    return s
+
+
+def _build_span_attributes(event: FunctionEvent) -> dict[str, Any]:
+    """Extract span attributes from a ``FunctionEvent``."""
+    attrs: dict[str, Any] = {}
+
+    # Core identity
+    attrs["pytorch.event.id"] = event.id
+    attrs["pytorch.thread.id"] = event.thread
+    attrs["pytorch.scope"] = _SCOPE_NAMES.get(event.scope, str(event.scope))
+
+    # Device information
+    attrs["pytorch.device.type"] = str(event.device_type).rsplit(".", 1)[-1]
+    attrs["pytorch.device.index"] = event.device_index
+    if event.use_device:
+        attrs["pytorch.device.name"] = event.use_device
+
+    # Timing (in microseconds for readability)
+    attrs["pytorch.cpu_time_total_us"] = event.cpu_time_total
+    attrs["pytorch.self_cpu_time_total_us"] = event.self_cpu_time_total
+    if event.device_time_total > 0:
+        attrs["pytorch.device_time_total_us"] = event.device_time_total
+        attrs["pytorch.self_device_time_total_us"] = event.self_device_time_total
+
+    # Memory
+    if event.cpu_memory_usage != 0:
+        attrs["pytorch.cpu_memory_usage_bytes"] = event.cpu_memory_usage
+    if event.device_memory_usage != 0:
+        attrs["pytorch.device_memory_usage_bytes"] = event.device_memory_usage
+
+    # FLOPs
+    if event.flops is not None and event.flops > 0:
+        attrs["pytorch.flops"] = event.flops
+
+    # Input shapes
+    if event.input_shapes:
+        attrs["pytorch.input_shapes"] = _safe_str(event.input_shapes)
+
+    # Input dtypes
+    input_dtypes = getattr(event, "input_dtypes", None)
+    if input_dtypes:
+        attrs["pytorch.input_dtypes"] = _safe_str(input_dtypes)
+
+    # Stack trace
+    if event.stack:
+        attrs["pytorch.stack"] = "; ".join(event.stack[:10])
+
+    # Flags
+    if event.is_async:
+        attrs["pytorch.is_async"] = True
+    if event.is_user_annotation:
+        attrs["pytorch.is_user_annotation"] = True
+
+    # Kernel info
+    if event.kernels:
+        kernel_names = [k.name for k in event.kernels]
+        attrs["pytorch.kernel_names"] = _safe_str(kernel_names)
+
+    return attrs
+
+
+# ---------------------------------------------------------------------------
+# Event tree reconstruction
+# ---------------------------------------------------------------------------
+
+def _build_event_tree(
+    events: Sequence[FunctionEvent],
+) -> list[FunctionEvent]:
+    """Return the root events (those without a CPU parent).
+
+    The profiler already establishes ``cpu_parent`` / ``cpu_children``
+    relationships, so we simply filter for root nodes.
+    """
+    return [e for e in events if e.cpu_parent is None]
+
+
+# ---------------------------------------------------------------------------
+# Span creation
+# ---------------------------------------------------------------------------
+
+def _export_event_as_span(
+    event: FunctionEvent,
+    tracer: Any,
+    trace_start_ns: int,
+    parent_context: Any | None = None,
+) -> None:
+    """Recursively create OTel spans for *event* and its children.
+
+    Parameters
+    ----------
+    event:
+        The profiler ``FunctionEvent``.
+    tracer:
+        An ``opentelemetry.trace.Tracer`` instance.
+    trace_start_ns:
+        An absolute epoch-nanosecond offset so that profiler-relative
+        timestamps become wall-clock timestamps.
+    parent_context:
+        Optional OTel ``Context`` to set as the parent.
+    """
+    from opentelemetry import context as otel_context
+    from opentelemetry import trace as otel_trace
+
+    attrs = _build_span_attributes(event)
+
+    start_ns = trace_start_ns + _us_to_ns(event.time_range.start)
+    end_ns = trace_start_ns + _us_to_ns(event.time_range.end)
+
+    # Ensure end >= start (defensive)
+    if end_ns < start_ns:
+        end_ns = start_ns
+
+    span = tracer.start_span(
+        name=event.name,
+        attributes=attrs,
+        start_time=start_ns,
+        context=parent_context,
+    )
+    child_context = otel_trace.set_span_in_context(span, parent_context)
+
+    # Recurse into CPU children
+    for child in event.cpu_children:
+        _export_event_as_span(child, tracer, trace_start_ns, child_context)
+
+    span.end(end_time=end_ns)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def opentelemetry_trace_handler(
+    service_name: str = "pytorch",
+    tracer_provider: TracerProvider | None = None,
+    span_exporter: SpanExporter | None = None,
+) -> Callable[..., None]:
+    """Return an ``on_trace_ready`` callback that exports spans via OpenTelemetry.
+
+    This follows the same pattern as
+    :func:`torch.profiler.tensorboard_trace_handler` — it returns a callable
+    that accepts a :class:`torch.profiler.profile` instance.
+
+    Parameters
+    ----------
+    service_name:
+        The OTel service name.  Defaults to ``"pytorch"``.
+    tracer_provider:
+        An explicit ``TracerProvider``.  When *None* a new
+        ``TracerProvider`` is created with a ``SimpleSpanProcessor`` wrapping
+        *span_exporter* (or a ``ConsoleSpanExporter`` if that is also *None*).
+    span_exporter:
+        A ``SpanExporter`` used only when *tracer_provider* is *None*.
+        Ignored when a provider is supplied explicitly.
+
+    Returns
+    -------
+    Callable
+        A callback suitable for the ``on_trace_ready`` argument of
+        :class:`torch.profiler.profile`.
+
+    Example
+    -------
+    ::
+
+        from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+
+        handler = opentelemetry_trace_handler(
+            service_name="my-training-job",
+            span_exporter=ConsoleSpanExporter(),
+        )
+
+        with torch.profiler.profile(
+            on_trace_ready=handler,
+            record_shapes=True,
+        ) as prof:
+            model(inputs)
+    """
+    _check_otel_available()
+
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider as _TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        ConsoleSpanExporter,
+        SimpleSpanProcessor,
+    )
+
+    if tracer_provider is None:
+        resource = Resource.create({"service.name": service_name})
+        tracer_provider = _TracerProvider(resource=resource)
+        exporter = span_exporter or ConsoleSpanExporter()
+        tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    tracer = tracer_provider.get_tracer("torch.profiler")
+
+    def handler(prof: _KinetoProfile) -> None:
+        import time
+
+        events = prof.events()
+        if not events:
+            logger.debug("No profiler events to export as OTel spans.")
+            return
+
+        # Use current wall-clock time as the anchor for the trace.
+        # Profiler timestamps are relative (microseconds since profiling start),
+        # so we offset them from "now minus the latest event end".
+        now_ns = time.time_ns()
+        max_end_us = max(e.time_range.end for e in events)
+        trace_start_ns = now_ns - _us_to_ns(max_end_us)
+
+        roots = _build_event_tree(events)
+        for root_event in roots:
+            _export_event_as_span(root_event, tracer, trace_start_ns)
+
+        logger.debug(
+            "Exported %d profiler events (%d root spans) as OTel spans.",
+            len(events),
+            len(roots),
+        )
+
+    return handler

--- a/torch/profiler/_opentelemetry.py
+++ b/torch/profiler/_opentelemetry.py
@@ -33,8 +33,8 @@ from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import SpanExporter
+    from opentelemetry.sdk.trace import TracerProvider  # pyrefly: ignore [missing-import]
+    from opentelemetry.sdk.trace.export import SpanExporter  # pyrefly: ignore [missing-import]
 
     from torch.autograd.profiler_util import FunctionEvent
     from torch.profiler.profiler import _KinetoProfile
@@ -149,6 +149,7 @@ def _build_span_attributes(event: FunctionEvent) -> dict[str, Any]:
 # Event tree reconstruction
 # ---------------------------------------------------------------------------
 
+
 def _build_event_tree(
     events: Sequence[FunctionEvent],
 ) -> list[FunctionEvent]:
@@ -163,6 +164,7 @@ def _build_event_tree(
 # ---------------------------------------------------------------------------
 # Span creation
 # ---------------------------------------------------------------------------
+
 
 def _export_event_as_span(
     event: FunctionEvent,
@@ -184,7 +186,6 @@ def _export_event_as_span(
     parent_context:
         Optional OTel ``Context`` to set as the parent.
     """
-    from opentelemetry import context as otel_context
     from opentelemetry import trace as otel_trace
 
     attrs = _build_span_attributes(event)


### PR DESCRIPTION
## Summary

Adds opentelemetry_trace_handler() to torch.profiler that converts PyTorch profiler events into OpenTelemetry spans, enabling seamless integration with any OTel-compatible observability backend (Jaeger, Zipkin, OTLP, Datadog, etc.).

Fixes #153614

## Motivation

As discussed in #153614, PyTorch's profiler produces rich tracing data via Kineto, but there's no way to export it as OpenTelemetry spans. Users profiling PyTorch workloads with OTel lack visibility into which specific operations are taking the most time, and manually converting Kineto traces results in spans detached from the correct parent context.

This PR bridges that gap by providing a first-class `on_trace_ready` handler that follows the same pattern as `tensorboard_trace_handler`.

## Design

### API (`torch/profiler/_opentelemetry.py`)

```python
from torch.profiler import profile, schedule, opentelemetry_trace_handler

handler = opentelemetry_trace_handler(
    service_name="my-training-job",       # OTel service name
    tracer_provider=my_provider,          # optional: bring your own TracerProvider
    span_exporter=OTLPSpanExporter(),     # optional: any SpanExporter
)

with profile(
    activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
    schedule=schedule(wait=1, warmup=1, active=2),
    on_trace_ready=handler,
    record_shapes=True,
    with_stack=True,
) as prof:
    for step in range(N):
        train_step()
        prof.step()
```

### Key decisions

| Decision | Rationale |
|----------|-----------|
| **Optional dependency** | `opentelemetry-api` / `opentelemetry-sdk` are imported at call time with a clear `ImportError` if missing |
| **`on_trace_ready` callback** | Follows the established `tensorboard_trace_handler` pattern — zero changes to the profiler core |
| **Parent–child spans** | Walks the profiler's existing `cpu_parent`/`cpu_children` tree to create properly nested OTel spans |
| **Rich attributes** | Each span carries `pytorch.*` attributes: timing, device type/index, input shapes, dtypes, FLOPs, memory usage, stack traces, kernel names |
| **Pluggable export** | Users can inject any `TracerProvider` or `SpanExporter` — works with OTLP, Jaeger, Zipkin, console, or custom backends |

### Span attributes exported

- `pytorch.event.id`, `pytorch.thread.id`, `pytorch.scope`
- `pytorch.device.type`, `pytorch.device.index`, `pytorch.device.name`
- `pytorch.cpu_time_total_us`, `pytorch.self_cpu_time_total_us`
- `pytorch.device_time_total_us`, `pytorch.self_device_time_total_us`
- `pytorch.cpu_memory_usage_bytes`, `pytorch.device_memory_usage_bytes`
- `pytorch.flops`, `pytorch.input_shapes`, `pytorch.input_dtypes`
- `pytorch.stack`, `pytorch.kernel_names`
- `pytorch.is_async`, `pytorch.is_user_annotation`

## Files changed

- **`torch/profiler/_opentelemetry.py`** - New module with the exporter implementation
- **`torch/profiler/__init__.py`** - Export `opentelemetry_trace_handler` in public API
- **`test/profiler/test_opentelemetry.py`** - 14 tests covering unit helpers, attribute extraction, end-to-end export with in-memory exporter, parent-child relationships, timing validation, and graceful handling of missing OTel

## Test plan

All 14 tests pass:
`
$ python -m pytest test/profiler/test_opentelemetry.py -v
14 passed in 0.45s
`

Tests cover:
- Import error when OTel is missing
- Helper functions (`_us_to_ns`, `_safe_str`, `_SCOPE_NAMES`)
- Attribute extraction from real `FunctionEvent`
- Event tree construction (root identification)
- End-to-end handler with in-memory span exporter
- Explicit `TracerProvider` injection
- Parent-child span relationships
- Empty events (no crash)
- Span timing validation
- Public API accessibility (import + `__all__`)

cc @robieta @chaekit @guotuofeng @guyang3532 @dzhulgakov @davidberard98 @briancoutinho @sraikund16 @sanrise @mwootton @divyanshk @jiannanWang @scotts @ryanzhang22