### PR TITLE
[Inductor] Fix pad_mm leaking padded strides to user-visible outputs

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -651,6 +651,29 @@ class PadMMTest(TestCase):
         test_masked_mha(B, H, S, D, device, dtype)
 
 
+    @inductor_config.patch(force_shape_pad=True)
+    def test_pad_mm_user_visible_strides(self):
+        """Verify comprehensive_padding does not leak padded strides to outputs.
+
+        With force_shape_pad, inner dimensions get padded for alignment. The
+        compiled output must still have the same strides as eager, even when
+        the result is a view of a padded buffer internally.
+        """
+        for m, k, n in [(4, 5, 3), (3, 7, 2), (6, 3, 5)]:
+            x = torch.randn(m, k, device=GPU_TYPE)
+            y = torch.randn(k, n, device=GPU_TYPE)
+            eager = torch.mm(x, y)
+            torch.compiler.reset()
+            compiled = torch.compile(torch.mm)(x, y)
+            self.assertEqual(compiled, eager)
+            self.assertEqual(
+                compiled.stride(),
+                eager.stride(),
+                msg=f"Stride mismatch for mm({m},{k}) x ({k},{n}): "
+                f"compiled={compiled.stride()} eager={eager.stride()}",
+            )
+
+
 if __name__ == "__main__":
     if HAS_GPU_AND_TRITON:
         run_tests()

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -258,6 +258,12 @@ def get_static_input_idxs(num_fixed: int) -> list[int]:
 
 def record_original_output_strides(gm: GraphModule) -> None:
     output_node = gm.graph.find_nodes(op="output")[0]
+
+    # Don't overwrite strides that were already recorded (e.g., before
+    # joint_graph_passes which can introduce padded strides via pad_mm).
+    if "original_output_strides" in output_node.meta:
+        return
+
     output_strides = []
 
     if not isinstance(output_node.args[0], torch.fx.Node):
@@ -2115,6 +2121,11 @@ def fw_compiler_freezing(
     from torch._inductor.freezing import convert_conv_weights_to_channels_last, freeze
 
     # partition_fn won't be called
+    # Record original output strides BEFORE joint_graph_passes, because
+    # pad_mm (run as part of joint_graph_passes) can introduce views with
+    # padded strides that would be incorrectly captured as "original".
+    _recursive_record_original_output_strides(aot_autograd_model)
+
     inputs_devices = get_inputs_devices(aot_example_inputs, aot_autograd_model)
     aot_autograd_model = _recursive_joint_graph_passes(
         aot_autograd_model,
@@ -2262,6 +2273,11 @@ def partition_fn(
         # We can skip the invoke_subgraph because the
         # entire_partition_fn is called recursively for invoke_subgraph
         # in partitioning.
+        # Record original output strides BEFORE joint_graph_passes, because
+        # pad_mm (run as part of joint_graph_passes) can introduce views with
+        # padded strides that would be incorrectly captured as "original".
+        _recursive_record_original_output_strides(gm)
+
         inputs_devices = get_inputs_devices(joint_inputs, gm)
         gm = _recursive_joint_graph_passes(
             gm,
@@ -2434,6 +2450,11 @@ def compile_fx_forward(
             )
             for arg in output.args[0]  # type: ignore[union-attr]
         ]
+
+        # Record original output strides BEFORE joint_graph_passes, because
+        # pad_mm (run as part of joint_graph_passes) can introduce views with
+        # padded strides that would be incorrectly captured as "original".
+        _recursive_record_original_output_strides(gm)
 
         inputs_devices = get_inputs_devices(example_inputs, gm)
         gm = _recursive_joint_graph_passes(gm, input_device=next(iter(inputs_devices)))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180499
* #180495

pad_mm pads mm operands to alignment boundaries, then slices the output
back to the original size. This slice is a view that inherits the padded
base strides (e.g., stride (4, 1) instead of (2, 1) for a 3x2 output).
Fixes #152520

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo