### PR TITLE
Enable fetch-tags in checkout-pytorch to fix release tag detection

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -60,7 +60,7 @@ runs:
         # --depth=1 for speed, manually fetch history and other refs as necessary
         fetch-depth: ${{ inputs.fetch-depth }}
         single-branch: true
-        fetch-tags: true
+        fetch-tags: ${{ github.ref_type == 'tag' }}
         submodules: ${{ inputs.submodules }}
         show-progress: false
         filter: ${{ env.filter }}
@@ -108,7 +108,7 @@ runs:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         fetch-depth: ${{ inputs.fetch-depth }}
         single-branch: true
-        fetch-tags: true
+        fetch-tags: ${{ github.ref_type == 'tag' }}
         submodules: ${{ inputs.submodules }}
         show-progress: false
         filter: ${{ env.filter }}

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -60,6 +60,7 @@ runs:
         # --depth=1 for speed, manually fetch history and other refs as necessary
         fetch-depth: ${{ inputs.fetch-depth }}
         single-branch: true
+        fetch-tags: true
         submodules: ${{ inputs.submodules }}
         show-progress: false
         filter: ${{ env.filter }}
@@ -107,6 +108,7 @@ runs:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         fetch-depth: ${{ inputs.fetch-depth }}
         single-branch: true
+        fetch-tags: true
         submodules: ${{ inputs.submodules }}
         show-progress: false
         filter: ${{ env.filter }}


### PR DESCRIPTION
## Summary

  Release candidate builds triggered by tags (e.g. `v2.12.0-rc1`) are incorrectly producing dev nightly versions instead of RC versions.

  The root cause is that #172544 added `single-branch: true` to the `checkout-pytorch` action when switching from `actions/checkout@v4` to `pytorch/test-infra/.github/actions/checkout@main`. With `single-branch: true`, git restricts the fetch refspec and tags are no longer fetched — even with `fetch-depth: 0`.

  This causes `binary_populate_env.sh` to fail at: git describe --tags --match 'v[0-9].[0-9].[0-9]*' --exact
  fatal: No names found, cannot describe anything.

  and fall through to the dev version path, producing `2.12.0.dev20260415+cpu` instead of `2.12.0+cpu`.

  The fix adds `fetch-tags: true` to both checkout steps (primary and retry) in the `checkout-pytorch` action, ensuring tags are explicitly fetched regardless of `single-branch` mode.

  Failing build: https://github.com/pytorch/pytorch/actions/runs/24474783525/job/71524093912

  ## Test plan

  - Verify that a workflow triggered by an RC tag (e.g. `v2.12.0-rc1`) correctly sets `PYTORCH_BUILD_VERSION=2.12.0+cpu` instead of
  `2.12.0.dev<date>+cpu`
  - Verify that nightly builds on the `nightly` branch are unaffected (they should still produce dev versions)