### PR TITLE
[UT][ROCm][inductor] ROCm-specific XFAILS list for torchinductor_opinfo_property

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -437,6 +437,37 @@ XFAIL_DICTS = {
     "binary_numerical": BINARY_NUMERICAL_XFAILS,
 }
 
+# Shared expected failures that should not apply on ROCm.
+# Same structure as the main xfail dicts: test_type -> backend -> op_name -> dtypes.
+ROCM_UNXFAILS = {
+    "binary_numerical": {
+        "inductor_default": {
+            "fmod": {bf16, fp32},
+            "remainder": {ALL},
+        },
+        "inductor_numerics": {
+            "remainder": {ALL},
+        },
+    },
+    "eager_equivalence": {
+        "inductor_default": {
+            "reciprocal": {fp32},
+            "remainder": {ALL},
+        },
+        "inductor_numerics": {
+            "remainder": {ALL},
+        },
+    },
+    "unary_numerical": {
+        "inductor_default": {
+            "exp2": {bf16, fp32},
+            "expm1": {bf16, fp32},
+            "reciprocal": {fp32},
+            "tan": {bf16},
+        },
+    },
+}
+
 # Additional expected failures that only apply on ROCm.
 # Same structure as the main xfail dicts: test_type -> backend -> op_name -> dtypes.
 ROCM_XFAILS = {
@@ -450,6 +481,13 @@ ROCM_XFAILS = {
 
 def is_expected_failure(device_type, op_name, backend, test_type, dtype=None):
     """Check if a test is expected to fail."""
+    if torch.version.hip is not None:
+        rocm_unxfails = (
+            ROCM_UNXFAILS.get(test_type, {}).get(backend, {}).get(op_name, set())
+        )
+        if dtype in rocm_unxfails or ALL in rocm_unxfails:
+            return False
+
     xfails = XFAIL_DICTS.get(test_type, {}).get(backend, {}).get(op_name, set())
     is_xfail = dtype in xfails or ALL in xfails
 

--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -437,67 +437,77 @@ XFAIL_DICTS = {
     "binary_numerical": BINARY_NUMERICAL_XFAILS,
 }
 
-# Shared expected failures that should not apply on ROCm.
-# Same structure as the main xfail dicts: test_type -> backend -> op_name -> dtypes.
-ROCM_UNXFAILS = {
-    "binary_numerical": {
-        "inductor_default": {
-            "fmod": {bf16, fp32},
-            "remainder": {ALL},
-        },
-        "inductor_numerics": {
-            "remainder": {ALL},
-        },
+ROCM_EAGER_EQUIV_XFAILS = {
+    "aot_eager_decomp_partition": {
+        "nn.functional.gelu": {fp32},
+        "nn.functional.layer_norm": {fp32},
+        "nn.functional.rms_norm": {fp32},
+        "softmax": {fp32},
+        "log_softmax": {fp32},
     },
-    "eager_equivalence": {
-        "inductor_default": {
-            "reciprocal": {fp32},
-            "remainder": {ALL},
-        },
-        "inductor_numerics": {
-            "remainder": {ALL},
-        },
+    "inductor_default": {
+        "sigmoid": {fp32},
+        "nn.functional.gelu": {fp32},
+        "nn.functional.layer_norm": {fp32},
+        "nn.functional.silu": {fp16, fp32},
+        "softmax": {fp32},
+        "log_softmax": {fp32},
     },
-    "unary_numerical": {
-        "inductor_default": {
-            "exp2": {bf16, fp32},
-            "expm1": {bf16, fp32},
-            "reciprocal": {fp32},
-            "tan": {bf16},
-        },
+    "inductor_numerics": {
+        "sigmoid": {fp32},
+        "sub": {ALL},
+        "nn.functional.gelu": {fp32},
+        "nn.functional.layer_norm": {fp32},
+        "softmax": {fp32},
+        "log_softmax": {fp32},
     },
 }
 
-# Additional expected failures that only apply on ROCm.
-# Same structure as the main xfail dicts: test_type -> backend -> op_name -> dtypes.
-ROCM_XFAILS = {
-    "batch_invariance": {
-        "inductor_default": {
-            "log1p": {fp32},
-        },
+ROCM_DETERMINISM_XFAILS = {}
+
+ROCM_BATCH_INVARIANCE_XFAILS = {
+    "aot_eager_decomp_partition": {
+        "nn.functional.linear": {ALL},
     },
+    "inductor_default": {
+        "nn.functional.linear": {ALL},
+        "log1p": {fp32},
+    },
+    "inductor_numerics": {
+        "nn.functional.linear": {ALL},
+    },
+}
+
+ROCM_UNARY_NUMERICAL_XFAILS = {
+    "inductor_default": {
+        "log1p": {fp32},
+        "rsqrt": {bf16, fp32},
+        "sigmoid": {fp32},
+        "sin": {fp32},
+        "tan": {fp32},
+        "tanh": {fp32},
+    },
+    "inductor_numerics": {
+        "sigmoid": {fp32},
+    },
+}
+
+ROCM_BINARY_NUMERICAL_XFAILS = {}
+
+ROCM_XFAIL_DICTS = {
+    "eager_equivalence": ROCM_EAGER_EQUIV_XFAILS,
+    "determinism": ROCM_DETERMINISM_XFAILS,
+    "batch_invariance": ROCM_BATCH_INVARIANCE_XFAILS,
+    "unary_numerical": ROCM_UNARY_NUMERICAL_XFAILS,
+    "binary_numerical": ROCM_BINARY_NUMERICAL_XFAILS,
 }
 
 
 def is_expected_failure(device_type, op_name, backend, test_type, dtype=None):
     """Check if a test is expected to fail."""
-    if torch.version.hip is not None:
-        rocm_unxfails = (
-            ROCM_UNXFAILS.get(test_type, {}).get(backend, {}).get(op_name, set())
-        )
-        if dtype in rocm_unxfails or ALL in rocm_unxfails:
-            return False
-
-    xfails = XFAIL_DICTS.get(test_type, {}).get(backend, {}).get(op_name, set())
-    is_xfail = dtype in xfails or ALL in xfails
-
-    if not is_xfail and torch.version.hip is not None:
-        rocm_xfails = (
-            ROCM_XFAILS.get(test_type, {}).get(backend, {}).get(op_name, set())
-        )
-        is_xfail = dtype in rocm_xfails or ALL in rocm_xfails
-
-    return is_xfail
+    xfail_dicts = ROCM_XFAIL_DICTS if torch.version.hip is not None else XFAIL_DICTS
+    xfails = xfail_dicts.get(test_type, {}).get(backend, {}).get(op_name, set())
+    return dtype in xfails or ALL in xfails
 
 
 def compile_fn(fn, backend):


### PR DESCRIPTION
Fixes #180032
Fixes #180033
Fixes #180034
Fixes #180035
Fixes #180036
Fixes #180037
Fixes #180038
Fixes #180039
Fixes #180046
Fixes #180047
Fixes #180048
Fixes #180049
Fixes #180051
Fixes #180053
Fixes #180054
Fixes #180059
Fixes #180060
Fixes #180062
Fixes #180063
Fixes #180069
Fixes #179962

These tests were actually passing on ROCm, but because of the shared (CUDA+ROCm) XFAILED list, those ROCm passes were being turned into failures. This PR adds a ROCm-specific XFAILS list which is a subset of the CUDA XFAILS list.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben