### PR TITLE
[inductor] Add _FastCudaLauncher: vectorcall C extension for pre-bound kernel launch (#180507)

### DIFF
--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -100,6 +100,12 @@ class TestStaticTritonLauncher(TestCase):
         return result
 
     def test_basic(self):
+        """Verify _FastCudaLauncher correctly launches a kernel with tensor + scalar args.
+
+        Compiles a simple kernel, wraps it in _FastCudaLauncher, then invokes
+        via vectorcall and checks the output tensor has the expected value.
+        """
+
         @triton.jit
         def simple_kernel(arg0, arg1):
             x = tl.load(arg0)
@@ -528,6 +534,210 @@ class TestStaticTritonCompileResult(TestCase):
                 mocked.assert_not_called()
 
             self.assertEqual(result, torch.cat(((x * 4), y + 10)))
+
+
+@requires_gpu_and_triton
+@skipIfXpu
+class TestFastCudaLauncher(TestCase):
+    """Tests for _FastCudaLauncher vectorcall C extension."""
+
+    def setUp(self):
+        super().setUp()
+        self.tmp_files = []
+
+    def tearDown(self):
+        super().tearDown()
+        for tmp_file in self.tmp_files:
+            try:
+                os.remove(tmp_file.name)
+            except OSError:
+                pass
+
+    def write_cubin_to_tmp(self, kernel: CompiledKernel) -> str:
+        if hasattr(kernel, "_cubin_path"):
+            return
+        binary_key = "hsaco" if torch.version.hip else "cubin"
+        with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tmp_file:
+            tmp_file.write(kernel.asm[binary_key])
+            self.tmp_files.append(tmp_file)
+            return tmp_file.name
+
+    def _make_launcher(
+        self,
+        compiled_kernel: CompiledKernel,
+    ) -> StaticallyLaunchedCudaKernel:
+        cubin_file = self.write_cubin_to_tmp(compiled_kernel)
+        compiled_kernel._cubin_path = cubin_file
+        result = statically_launched_kernel_by_device(compiled_kernel, GPU_TYPE)
+        old_cubin_path = result.cubin_path
+        if old_cubin_path is None:
+            raise AssertionError
+        result.cubin_path = None
+        result.reload_cubin_from_raw(old_cubin_path)
+        device_interface = get_interface_for_device(GPU_TYPE)
+        result.load_kernel(device_interface.current_device())
+        return result
+
+    def _make_fast_launcher(self, kernel):
+        from torch._C import _FastCudaLauncher
+
+        n_scratch = 0
+        if getattr(kernel, "has_global_scratch", False):
+            n_scratch += 1
+        if getattr(kernel, "has_profile_scratch", False):
+            n_scratch += 1
+        return _FastCudaLauncher(
+            kernel.function, kernel.num_warps, kernel.shared, kernel.arg_tys, n_scratch
+        )
+
+    def test_basic(self):
+        @triton.jit
+        def simple_kernel(arg0, arg1):
+            x = tl.load(arg0)
+            y = arg1
+            tl.store(arg0, x + y)
+
+        arg0 = torch.zeros(1, dtype=torch.int32, device=GPU_TYPE)
+        compiled_kernel = simple_kernel[(1,)](arg0, 5)
+        launcher = self._make_launcher(compiled_kernel)
+        fast = self._make_fast_launcher(launcher)
+
+        new_arg0 = torch.zeros(1, dtype=torch.int32, device=GPU_TYPE)
+        device_interface = get_interface_for_device(GPU_TYPE)
+        stream = device_interface.get_raw_stream(device_interface.current_device())
+        fast(1, 1, 1, stream, new_arg0, 5)
+        self.assertEqual(
+            new_arg0, torch.tensor([5], dtype=torch.int32, device=GPU_TYPE)
+        )
+
+    def test_multiple_tensor_args(self):
+        """Verify _FastCudaLauncher handles multiple tensor pointer args correctly."""
+
+        @triton.jit
+        def add_kernel(a, b, out):
+            x = tl.load(a)
+            y = tl.load(b)
+            tl.store(out, x + y)
+
+        a = torch.tensor([3], dtype=torch.int32, device=GPU_TYPE)
+        b = torch.tensor([7], dtype=torch.int32, device=GPU_TYPE)
+        out = torch.zeros(1, dtype=torch.int32, device=GPU_TYPE)
+        compiled_kernel = add_kernel[(1,)](a, b, out)
+        launcher = self._make_launcher(compiled_kernel)
+        fast = self._make_fast_launcher(launcher)
+
+        out2 = torch.zeros(1, dtype=torch.int32, device=GPU_TYPE)
+        device_interface = get_interface_for_device(GPU_TYPE)
+        stream = device_interface.get_raw_stream(device_interface.current_device())
+        fast(1, 1, 1, stream, a, b, out2)
+        self.assertEqual(out2, torch.tensor([10], dtype=torch.int32, device=GPU_TYPE))
+
+    def test_zero_grid(self):
+        """Verify zero-grid launch is a no-op (kernel does not execute)."""
+
+        @triton.jit
+        def simple_kernel(arg0, arg1):
+            x = tl.load(arg0)
+            tl.store(arg0, x + arg1)
+
+        arg0 = torch.zeros(1, dtype=torch.int32, device=GPU_TYPE)
+        compiled_kernel = simple_kernel[(1,)](arg0, 5)
+        launcher = self._make_launcher(compiled_kernel)
+        fast = self._make_fast_launcher(launcher)
+
+        target = torch.zeros(1, dtype=torch.int32, device=GPU_TYPE)
+        device_interface = get_interface_for_device(GPU_TYPE)
+        stream = device_interface.get_raw_stream(device_interface.current_device())
+        fast(0, 1, 1, stream, target, 99)
+        self.assertEqual(target, torch.tensor([0], dtype=torch.int32, device=GPU_TYPE))
+
+    def test_wrong_arg_count(self):
+        """Verify _FastCudaLauncher raises RuntimeError on argument count mismatch."""
+
+        @triton.jit
+        def simple_kernel(arg0, arg1):
+            x = tl.load(arg0)
+            tl.store(arg0, x + arg1)
+
+        arg0 = torch.zeros(1, dtype=torch.int32, device=GPU_TYPE)
+        compiled_kernel = simple_kernel[(1,)](arg0, 5)
+        launcher = self._make_launcher(compiled_kernel)
+        fast = self._make_fast_launcher(launcher)
+
+        device_interface = get_interface_for_device(GPU_TYPE)
+        stream = device_interface.get_raw_stream(device_interface.current_device())
+        with self.assertRaises(RuntimeError):
+            fast(1, 1, 1, stream, arg0)  # missing arg1
+
+
+@requires_gpu_and_triton
+@torch._inductor.config.patch(
+    {
+        "use_static_triton_launcher": True,
+        "strict_static_triton_launcher": True,
+        "use_fast_triton_launcher": True,
+    }
+)
+class TestFastCudaLauncherCompileResult(TestCase):
+    """E2E tests verifying _FastCudaLauncher is actually used by torch.compile.
+
+    These tests assert both correctness (output matches eager) and that the
+    _FastCudaLauncher C extension was constructed, not silently skipped.
+    """
+
+    def _patch_build_fast_launcher(self):
+        """Context manager that tracks _build_fast_launcher calls.
+
+        Returns a list that accumulates True/False for each call,
+        indicating whether a _FastCudaLauncher was successfully built.
+        """
+        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+        results = []
+        original = CachingAutotuner._build_fast_launcher
+
+        def tracking_build(autotuner_self, launcher):
+            result = original(autotuner_self, launcher)
+            results.append(result is not None)
+            return result
+
+        return mock.patch.object(
+            CachingAutotuner, "_build_fast_launcher", tracking_build
+        ), results
+
+    def test_basic_compile(self):
+        """Verify torch.compile uses _FastCudaLauncher and produces correct output."""
+        patcher, results = self._patch_build_fast_launcher()
+        with patcher:
+
+            @torch.compile
+            def foo(x, y):
+                return x + y
+
+            x = torch.randn(10, device=GPU_TYPE)
+            y = torch.randn(10, device=GPU_TYPE)
+            self.assertEqual(foo(x, y), x + y)
+            self.assertTrue(
+                any(results), "_FastCudaLauncher was not built by any CachingAutotuner"
+            )
+
+    def test_disable_fast_launcher(self):
+        """Verify disabling the config falls back to the regular launcher."""
+        patcher, results = self._patch_build_fast_launcher()
+        with patcher, torch._inductor.config.patch("use_fast_triton_launcher", False):
+
+            @torch.compile
+            def foo(x, y):
+                return x + y
+
+            x = torch.randn(10, device=GPU_TYPE)
+            y = torch.randn(10, device=GPU_TYPE)
+            result = foo(x, y)
+            self.assertEqual(result, x + y)
+            self.assertFalse(
+                any(results),
+                "_FastCudaLauncher should not be built when config is disabled",
+            )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1326,6 +1326,15 @@ strict_static_triton_launcher: bool = Config(
     alias="torch._inductor.config.strict_static_cuda_launcher"
 )
 
+# Use _FastCudaLauncher (vectorcall C extension) instead of
+# StaticallyLaunchedCudaKernel.run for the CachingAutotuner fast path.
+# Pre-binds kernel metadata at first launch and uses THPVariable_Unpack +
+# tensor.data_ptr() in C++ to bypass PyArg_ParseTuple, cuPointerGetAttribute,
+# and cuCtxGetCurrent.
+use_fast_triton_launcher: bool = (
+    os.environ.get("TORCHINDUCTOR_USE_FAST_TRITON_LAUNCHER", "1") == "1"
+)
+
 # gemm autotuning global cache dir
 global_cache_dir: str | None
 if is_fbcode():

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1853,8 +1853,90 @@ class CachingAutotuner(KernelInterface):
             and not autograd_profiler._is_profiler_enabled
             and len(self.launchers) == 1
         ):
-            self._cached_launcher = launcher
+            self._cached_launcher = self._build_fast_launcher(launcher) or launcher
         return result
+
+    def _build_fast_launcher(self, launcher: LauncherType) -> LauncherType | None:
+        """Try to build a _FastCudaLauncher-backed version of the launcher.
+
+        Returns a new launcher function with the runner replaced by a
+        _FastCudaLauncher instance (vectorcall C extension), or None if
+        conditions are not met.  Falls back silently on expected errors,
+        logs a warning on unexpected ones.
+        """
+        import types
+
+        if not self.inductor_meta.get(
+            "use_fast_triton_launcher",
+            torch._inductor.config.use_fast_triton_launcher,
+        ):
+            return None
+
+        try:
+            from torch._C import _FastCudaLauncher
+        except ImportError:
+            return None
+
+        try:
+            # Only works for the static triton launcher path.
+            if not getattr(launcher, "_is_static", False):
+                return None
+
+            # Resolve the bound kernel behind the launcher function.
+            runner = launcher.__globals__.get("runner")
+            if not callable(runner):
+                return None
+            kernel = runner.__self__
+            cu_function = kernel.function
+            num_warps = kernel.num_warps
+            shared = kernel.shared
+            arg_tys = kernel.arg_tys
+            if cu_function is None or num_warps is None:
+                return None
+
+            n_scratch = sum(
+                [
+                    getattr(kernel, "has_global_scratch", False),
+                    getattr(kernel, "has_profile_scratch", False),
+                ]
+            )
+            if torch.version.hip:
+                n_scratch = max(n_scratch, 2)
+
+            fast_runner = _FastCudaLauncher(
+                cu_function, num_warps, shared, arg_tys, n_scratch
+            )
+
+            new_globals = {**launcher.__globals__, "runner": fast_runner}
+            new_launcher = types.FunctionType(
+                launcher.__code__,
+                new_globals,
+                launcher.__name__,
+            )
+            # Copy launcher attributes to the new function object.
+            # NOTE: If new attributes are added to launchers in the future,
+            # they must be added here too — otherwise the fast launcher will
+            # silently drop them.
+            for attr in (
+                "config",
+                "n_regs",
+                "n_spills",
+                "shared",
+                "cache_hash",
+                "store_cubin",
+                "_is_static",
+            ):
+                val = getattr(launcher, attr, None)
+                if val is not None:
+                    setattr(new_launcher, attr, val)
+            return new_launcher
+        except (AttributeError, TypeError, KeyError):
+            # Expected failures - silent fallback is OK
+            return None
+        except Exception:
+            # Unexpected failures - log for debugging
+            log.warning("Unexpected error building fast launcher", exc_info=True)
+            return None
 
     def _interpret_args_grid(
         self, args: tuple[Any, ...], cfg: Config

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -439,6 +439,18 @@ class CachingAutotuner(KernelInterface):
         self._debug_call: _TritonKernelCall | None = None
         self._profiler_ctx: _RecordFunctionFast | None = None
 
+        # Cached launcher for fast path — bypasses all preamble after first
+        # successful steady-state launch.  Set to None until populated.
+        self._cached_launcher: LauncherType | None = None
+        # Pre-compute static eligibility for launcher caching.  These flags
+        # are set once in __init__ and never change, so we avoid re-checking
+        # them on every kernel launch.
+        self._cache_eligible = (
+            not self.triton_interpret
+            and not self.dump_launch_params
+            and not self.dump_launch_tensors
+        )
+
         # Compile-time info included in runtime logginging
         self.compile_id: CompileId | None = None
         self.is_backward = False
@@ -727,12 +739,14 @@ class CachingAutotuner(KernelInterface):
         self.fn.used_global_vals = None
         self.fn.repr = _ConstRepr(self.fn.repr(self.fn))
         self.launchers = []
+        self._cached_launcher = None
         self.fn._hash_lock = None
         return old_values
 
     def restore_after_unpickle(
         self, old_values: tuple[Any, Any, Any, Any, Any, Any] | None
     ) -> None:
+        self._cached_launcher = None
         if old_values:
             (
                 self.fn.fn,
@@ -1734,6 +1748,27 @@ class CachingAutotuner(KernelInterface):
         **kwargs,
     ):  # type:ignore[override]
         """Launch triton kernel call and return result."""
+        # --- FAST PATH ---
+        # After the first successful launch in steady state, cache the launcher
+        # and skip all preamble on subsequent calls (~2µs savings).
+        # Conditions here deliberately differ from the cache-population block
+        # below: we re-check dynamic conditions (profiler, debug mode) every
+        # call so enabling them at runtime falls back to the slow path.
+        # Static conditions (interpret, dump flags, launcher count) were
+        # already validated when the cache was populated.
+        # `not kwargs` is checked here but not at population time because
+        # inductor steady-state never passes kwargs; if it somehow does, the
+        # slow path handles it correctly.
+        fast = self._cached_launcher
+        if (
+            fast is not None
+            and not benchmark_run
+            and not kwargs
+            and not autograd_profiler._is_profiler_enabled
+            and not get_active_debug_mode()
+        ):
+            return fast(*args, stream=stream)
+
         debug_mode = get_active_debug_mode()
         if debug_mode:
             arg_names = list(self.triton_meta.get("signature", {}).keys())
@@ -1806,6 +1841,19 @@ class CachingAutotuner(KernelInterface):
             result = launcher(*args, **kwargs, stream=stream)
         finally:
             self._post_launch()
+
+        # Populate fast path: cache the launcher for future calls.  Static
+        # conditions (interpret, dump flags) are pre-computed in _cache_eligible;
+        # only dynamic conditions are checked here.
+        if (
+            self._cached_launcher is None
+            and self._cache_eligible
+            and not benchmark_run
+            and not debug_mode
+            and not autograd_profiler._is_profiler_enabled
+            and len(self.launchers) == 1
+        ):
+            self._cached_launcher = launcher
         return result
 
     def _interpret_args_grid(

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2390,6 +2390,7 @@ PyObject* initModule() {
 #endif
 #if defined(USE_CUDA)
   ASSERT_TRUE(StaticCudaLauncher_init(module));
+  ASSERT_TRUE(FastCudaLauncher_init(module));
 #endif
 #if defined(USE_XPU) && !defined(_WIN32)
   ASSERT_TRUE(StaticXpuLauncher_init(module));

--- a/torch/csrc/inductor/static_launcher/cuda.cpp
+++ b/torch/csrc/inductor/static_launcher/cuda.cpp
@@ -3,6 +3,7 @@
 #include <ATen/Context.h>
 #include <ATen/cuda/Exceptions.h>
 #include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
+#include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/inductor/static_launcher/cuda.h>
 #include <cstdint>
 
@@ -611,6 +612,293 @@ PyTypeObject StaticCudaLauncherType = {
     nullptr, // tp_alloc
     nullptr, // tp_new
 };
+// ---------------------------------------------------------------------------
+// getPointerFast: extract device pointer WITHOUT cuPointerGetAttribute.
+// Uses THPVariable_Unpack (direct C++ field access) + at::Tensor::data_ptr()
+// instead of going through Python data_ptr() method.
+// No THPVariable_Check or tensor.defined() guard: in the _FastCudaLauncher
+// path all 'O'-typed args are guaranteed to be tensors by inductor codegen.
+// ---------------------------------------------------------------------------
+inline CUdeviceptr getPointerFast(PyObject* obj) {
+  if (THPUtils_checkLong(obj)) {
+#if defined(USE_ROCM)
+    return reinterpret_cast<hipDeviceptr_t>(THPUtils_unpackUInt64(obj));
+#else
+    return THPUtils_unpackUInt64(obj);
+#endif
+  }
+  if (obj == Py_None) {
+    return 0;
+  }
+  // Fast type check: inductor-generated tensors are always exact THPVariable
+  // (or Parameter). Use CheckExact — a single Py_TYPE pointer comparison —
+  // instead of THPVariable_Check which also calls PyObject_IsInstance.
+  if (C10_LIKELY(THPVariable_CheckExact(obj))) {
+    auto tensor = THPVariable_Unpack(obj);
+    TORCH_CHECK(
+        tensor.defined(),
+        "_FastCudaLauncher: received undefined tensor argument");
+    return reinterpret_cast<CUdeviceptr>(tensor.data_ptr());
+  }
+  // Slow fallback for non-tensor objects with a data_ptr() method
+  // (e.g. tensor-like wrappers / proxy objects).
+  PyObject* data_ptr_method = PyObject_GetAttrString(obj, "data_ptr");
+  TORCH_CHECK(
+      data_ptr_method,
+      "_FastCudaLauncher: expected tensor or object with data_ptr() method");
+  PyObject* ret = PyObject_CallNoArgs(data_ptr_method);
+  Py_DECREF(data_ptr_method);
+  TORCH_CHECK(ret, "_FastCudaLauncher: data_ptr() call failed");
+  auto raw = THPUtils_unpackUInt64(ret);
+  Py_DECREF(ret);
+  // C-style cast: static_cast on CUDA (uint64→unsigned long long),
+  // reinterpret_cast on HIP (uint64→void*).
+  return (CUdeviceptr)raw;
+}
+
+// ---------------------------------------------------------------------------
+// _FastCudaLauncher: pre-bound callable that uses vectorcall (PEP 590)
+// to launch a triton kernel with minimal overhead.
+//
+// Pre-binds: CUfunction, numWarps, sharedMemBytes, argTypes, scratch slots.
+// Per-call:  only grid, stream, and kernel args are passed.
+// Skips:     cuCtxGetCurrent, cuPointerGetAttribute, PyArg_ParseTuple for
+//            kernel metadata.
+// ---------------------------------------------------------------------------
+struct FastCudaLauncherObject {
+  PyObject_HEAD
+  vectorcallfunc vectorcall;
+  CUfunction func;
+  uint32_t numWarps;
+  uint32_t sharedMemBytes;
+  int numKernelArgs; // args passed from Python
+  int numTotalArgs; // numKernelArgs + nScratch
+  char argTypes[MAX_ARGS + 1]; // null-terminated
+  // Thread safety: argStorage/kernelArgs are shared across calls but safe
+  // because the GIL is held throughout fast_launcher_vectorcall (no
+  // Py_BEGIN_ALLOW_THREADS).  cuLaunchKernel copies arg values from the
+  // kernelArgs pointers synchronously before returning, so by the time the
+  // GIL could be released the driver already has its own copy.
+  // TODO(T000000): Not safe under free-threaded Python (PEP 703, nogil).
+  // If two threads call the same instance concurrently without the GIL,
+  // they will corrupt argStorage/kernelArgs.  Revisit when nogil is stable.
+  uint64_t argStorage[MAX_ARGS];
+  void* kernelArgs[MAX_ARGS];
+};
+
+static PyObject* fast_launcher_vectorcall(
+    PyObject* callable,
+    PyObject* const* args,
+    size_t nargsf,
+    PyObject* kwnames);
+
+static PyObject* FastCudaLauncher_new(
+    PyTypeObject* type,
+    PyObject* args,
+    PyObject* kwds) {
+  HANDLE_TH_ERRORS
+  auto* self =
+      reinterpret_cast<FastCudaLauncherObject*>(type->tp_alloc(type, 0));
+  if (!self)
+    return nullptr;
+
+  uint64_t func_ptr = 0;
+  int numWarps = 0, shared = 0, nScratch = 0;
+  const char* argTypes = nullptr;
+  if (!PyArg_ParseTuple(
+          args, "Kiisi", &func_ptr, &numWarps, &shared, &argTypes, &nScratch)) {
+    Py_DECREF(self);
+    return nullptr;
+  }
+
+  self->func = reinterpret_cast<CUfunction>(func_ptr); // NOLINT
+  self->numWarps = static_cast<uint32_t>(numWarps);
+  self->sharedMemBytes = static_cast<uint32_t>(shared);
+
+  int nKernel = static_cast<int>(std::strlen(argTypes));
+  int nTotal = nKernel + nScratch;
+  if (nTotal > MAX_ARGS) {
+    Py_DECREF(self);
+    PyErr_Format(
+        PyExc_ValueError,
+        "_FastCudaLauncher: too many arguments (%d > %d)",
+        nTotal,
+        MAX_ARGS);
+    return nullptr;
+  }
+
+  self->numKernelArgs = nKernel;
+  self->numTotalArgs = nTotal;
+  std::memcpy(self->argTypes, argTypes, nKernel);
+  // Scratch slots are pointer type ('O')
+  for (int i = nKernel; i < nTotal; ++i) {
+    self->argTypes[i] = 'O';
+  }
+  self->argTypes[nTotal] = '\0';
+
+  // Pre-compute kernelArgs pointers and zero all storage.
+  std::memset(self->argStorage, 0, sizeof(self->argStorage));
+  for (int i = 0; i < nTotal; ++i) {
+    self->kernelArgs[i] = &self->argStorage[i];
+  }
+
+  // Set vectorcall function pointer.
+  self->vectorcall = fast_launcher_vectorcall;
+
+  return reinterpret_cast<PyObject*>(self);
+  END_HANDLE_TH_ERRORS
+}
+
+static void FastCudaLauncher_dealloc(PyObject* self) {
+  Py_TYPE(self)->tp_free(self);
+}
+
+// The hot path — called every kernel launch via vectorcall.
+// args layout: [grid_x, grid_y, grid_z, stream, kernel_arg0, ...]
+static PyObject* fast_launcher_vectorcall(
+    PyObject* callable,
+    PyObject* const* args,
+    size_t nargsf,
+    PyObject* kwnames) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      kwnames == nullptr,
+      "_FastCudaLauncher: keyword arguments are not supported");
+  auto* self = reinterpret_cast<FastCudaLauncherObject*>(callable);
+  Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+
+  // We expect at least 4 fixed args (grid_x, grid_y, grid_z, stream)
+  // plus numKernelArgs kernel arguments.
+  TORCH_CHECK(
+      nargs >= 4 + self->numKernelArgs,
+      "_FastCudaLauncher: expected ",
+      4 + self->numKernelArgs,
+      " args, got ",
+      nargs);
+
+  // Grid and stream are always integers from inductor codegen.
+  // Debug-only guard; zero cost in release/opt builds.
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      PyLong_Check(args[0]) && PyLong_Check(args[1]) && PyLong_Check(args[2]),
+      "_FastCudaLauncher: grid dimensions must be integers");
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      PyLong_Check(args[3]), "_FastCudaLauncher: stream must be an integer");
+
+  int gridX = static_cast<int>(THPUtils_unpackLong(args[0]));
+  int gridY = static_cast<int>(THPUtils_unpackLong(args[1]));
+  int gridZ = static_cast<int>(THPUtils_unpackLong(args[2]));
+
+  if (gridX <= 0 || gridY <= 0 || gridZ <= 0) {
+    Py_RETURN_NONE;
+  }
+
+  uint64_t stream = THPUtils_unpackUInt64(args[3]);
+
+  // Pack kernel args from Python into pre-allocated argStorage.
+  for (int i = 0; i < self->numKernelArgs; ++i) {
+    PyObject* item = args[4 + i];
+    void* slot = static_cast<void*>(&self->argStorage[i]);
+    char typeChar = self->argTypes[i];
+    switch (typeChar) {
+      case 'O': {
+        *reinterpret_cast<CUdeviceptr*>(slot) = getPointerFast(item);
+        break;
+      }
+      case 'b':
+        convertType<int8_t>(THPUtils_unpackInt, "int8", slot, item);
+        break;
+      case 'h':
+        convertType<int16_t>(THPUtils_unpackInt, "int16", slot, item);
+        break;
+      case 'i':
+        convertType<int32_t>(THPUtils_unpackLong, "int32", slot, item);
+        break;
+      case 'l':
+        convertType<int64_t>(THPUtils_unpackLong, "int64", slot, item);
+        break;
+      case 'B':
+        convertType<uint8_t>(THPUtils_unpackUInt32, "uint8", slot, item);
+        break;
+      case 'H':
+        convertType<uint16_t>(THPUtils_unpackUInt32, "uint16", slot, item);
+        break;
+      case 'I':
+        convertType<uint32_t>(THPUtils_unpackUInt32, "uint32", slot, item);
+        break;
+      case 'K':
+        convertType<uint64_t>(THPUtils_unpackUInt64, "uint64", slot, item);
+        break;
+      case 'f':
+        convertType<float>(THPUtils_unpackDouble, "float", slot, item);
+        break;
+      case 'd':
+        convertType<double>(THPUtils_unpackDouble, "double", slot, item);
+        break;
+      default:
+        TORCH_CHECK(
+            false, "_FastCudaLauncher: unknown arg type '", typeChar, "'");
+    }
+  }
+  // Scratch slots already zeroed at construction time and stay zero.
+  // Invariant: inductor codegen always passes None for scratch args, so the
+  // pre-zeroed nullptr values remain valid across launches.  If scratch
+  // semantics ever require non-null per-launch values, re-zero here.
+
+  launchKernel(
+      self->func,
+      static_cast<uint32_t>(gridX),
+      static_cast<uint32_t>(gridY),
+      static_cast<uint32_t>(gridZ),
+      self->numWarps,
+      self->sharedMemBytes,
+      self->kernelArgs,
+      reinterpret_cast<cudaStream_t>(stream)); // NOLINT
+
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+PyTypeObject FastCudaLauncherType = {
+    PyVarObject_HEAD_INIT(nullptr, 0)
+    "torch._C._FastCudaLauncher", // tp_name
+    sizeof(FastCudaLauncherObject), // tp_basicsize
+    0, // tp_itemsize
+    FastCudaLauncher_dealloc, // tp_dealloc
+    offsetof(FastCudaLauncherObject, vectorcall), // tp_vectorcall_offset
+    nullptr, // tp_getattr
+    nullptr, // tp_setattr
+    nullptr, // tp_reserved
+    nullptr, // tp_repr
+    nullptr, // tp_as_number
+    nullptr, // tp_as_sequence
+    nullptr, // tp_as_mapping
+    nullptr, // tp_hash
+    PyVectorcall_Call, // tp_call — fallback for non-vectorcall callers
+    nullptr, // tp_str
+    nullptr, // tp_getattro
+    nullptr, // tp_setattro
+    nullptr, // tp_as_buffer
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
+    "Pre-bound fast launcher for triton CUDA kernels (vectorcall)", // tp_doc
+    nullptr, // tp_traverse
+    nullptr, // tp_clear
+    nullptr, // tp_richcompare
+    0, // tp_weaklistoffset
+    nullptr, // tp_iter
+    nullptr, // tp_iternext
+    nullptr, // tp_methods
+    nullptr, // tp_members
+    nullptr, // tp_getset
+    nullptr, // tp_base
+    nullptr, // tp_dict
+    nullptr, // tp_descr_get
+    nullptr, // tp_descr_set
+    0, // tp_dictoffset
+    nullptr, // tp_init
+    nullptr, // tp_alloc
+    FastCudaLauncher_new, // tp_new
+};
+
 } // anonymous namespace
 // Module initialization: add StaticCudaLauncher to the module with our static
 // methods.
@@ -638,6 +926,19 @@ bool StaticCudaLauncher_init(PyObject* module) {
           module, "_StaticCudaLauncher", (PyObject*)&StaticCudaLauncherType) <
       0) {
     Py_DECREF(&StaticCudaLauncherType);
+    return false;
+  }
+  return true;
+}
+
+bool FastCudaLauncher_init(PyObject* module) {
+  if (PyType_Ready(&FastCudaLauncherType) < 0) {
+    return false;
+  }
+  Py_INCREF(&FastCudaLauncherType);
+  if (PyModule_AddObject(
+          module, "_FastCudaLauncher", (PyObject*)&FastCudaLauncherType) < 0) {
+    Py_DECREF(&FastCudaLauncherType);
     return false;
   }
   return true;

--- a/torch/csrc/inductor/static_launcher/cuda.h
+++ b/torch/csrc/inductor/static_launcher/cuda.h
@@ -4,4 +4,5 @@
 #include <torch/csrc/python_headers.h>
 
 bool StaticCudaLauncher_init(PyObject* module);
+bool FastCudaLauncher_init(PyObject* module);
 #endif


### PR DESCRIPTION
Summary:

## Motivation

D100887242 added a fast path to CachingAutotuner.run() that bypasses the
Python preamble (~1.4µs savings). However, the actual kernel launch still goes
through StaticallyLaunchedCudaKernel.run() → _StaticCudaLauncher._launch_kernel(),
which carries ~2.2µs of overhead above bare cuLaunchKernel:

  - PyArg_ParseTuple("KiiiiisOK") parsing 9 args per call      ~0.3µs
  - cuCtxGetCurrent validation                                  ~0.1µs
  - Python data_ptr() + cuPointerGetAttribute per tensor arg    ~0.3µs × N
  - parseKernelArgs type-switching loop                         ~0.2µs

All of these are redundant on steady-state launches: kernel metadata is fixed,
CUDA context is guaranteed valid, and tensor pointers are always valid device
pointers.

## Approach

Add `_FastCudaLauncher`, a C Python type that pre-binds kernel metadata at
construction time and uses PEP 590 vectorcall for the fastest Python→C
dispatch:

1. **Construction** (once per kernel): pre-binds CUfunction, block dims,
   shared mem, arg types, scratch slots. Pre-computes
   `kernelArgs[i] = &argStorage[i]`.

2. **__call__** (every launch, via vectorcall — no tuple allocation):
   - Extracts grid + stream directly from the vectorcall args array
   - For tensor args: `THPVariable_Unpack(obj).data_ptr()` — zero-cost
     reinterpret_cast to C++ `at::Tensor`, no Python method call, no
     cuPointerGetAttribute validation
   - For scalar args: same `convertType` as existing path
   - Calls `cuLaunchKernel` directly — no cuCtxGetCurrent check

Integrated into CachingAutotuner: after D100887242 selects the fast launcher,
`_build_fast_launcher()` upgrades it to use `_FastCudaLauncher` by cloning
the launcher function with the runner replaced. Falls back silently to the
original launcher if conditions aren't met (non-static path, missing kernel
info, import failure, etc.).

Gated by `torch._inductor.config.use_fast_triton_launcher` (default ON),
controllable via `TORCHINDUCTOR_USE_FAST_TRITON_LAUNCHER=0`.

## Results

### Microbenchmark (H100, mode/opt, tritonbench launch_latency)

Per-kernel overhead (`nop_inductor_per_kernel`):
- Before (D100887242): 5.64µs (0-arg), 7.05µs (19-arg)
- After:               3.12µs (0-arg), 3.28µs (19-arg)
- Δ:                  -2.52µs (-45%), -3.77µs (-53%)

Raw cuLaunchKernel baseline: 2.09µs (0-arg)
Per-kernel gap to raw CUDA: 3.12µs - 2.09µs = 1.03µs (only ~1µs above driver cost)

### Microbenchmark (GB200, mode/opt, tritonbench launch_latency)

Per-kernel overhead (`nop_inductor_per_kernel`):
- Before (D100881626): 5.21µs (0-arg), 6.93µs (19-arg)
- After:               3.07µs (0-arg), 3.06µs (19-arg)
- Δ:                  -2.14µs (-41%), -3.87µs (-56%)

Raw cuLaunchKernel baseline: 1.32µs (0-arg)
Per-kernel gap to raw CUDA: 3.07µs - 1.32µs = 1.75µs

### E2E model benchmark (H100, torchbench, inductor, no cudagraphs, inference, bfloat16)

Combined effect of D100887242 + this diff vs baseline (D100881626):

| Model        | Calls | Baseline | After  | Δ latency           |
|--------------|------|----------|--------|---------------------|
| hf_Bert      |   285 | 2.513ms  | 1.907ms| -0.606ms (-24.1%)   |
| resnet18     |    69 | 0.894ms  | 0.601ms| -0.293ms (-32.8%)   |
| resnet50     |   175 | 2.242ms  | 2.227ms| ~0% (compute-bound) |
| mobilenet_v2 |   153 | 2.537ms  | 1.147ms| -1.390ms (-54.8%)   |

### E2E model benchmark (GB200, torchbench, inductor, no cudagraphs, inference, bfloat16)

Combined effect of D100887242 + this diff vs baseline (D100881626):

| Model        | Calls | Baseline | After   | Δ latency           |
|--------------|------|----------|---------|---------------------|
| hf_Bert      |   285 | 5.205ms  | 4.371ms | -0.834ms (-16.0%)   |
| resnet18     |    69 | 4.668ms  | 4.667ms | ~0% (noise)         |
| resnet50     |   175 | 8.734ms  | 8.690ms | ~0% (compute-bound) |
| mobilenet_v2 |   153 | 3.929ms  | 2.777ms | -1.152ms (-29.3%)   |

Models with many small kernels (mobilenet_v2, hf_Bert) see the
largest improvements. Compute-bound models (resnet50) are unaffected — the
optimization has zero cost when kernel execution dominates.

With cudagraphs ON, the optimization has ~zero effect (expected — cudagraphs
bypass the Python dispatch path):

| Model (GB200, cudagraphs ON) | Baseline | After   | Δ        |
|------------------------------|----------|---------|----------|
| hf_Bert                      | 1.407ms  | 1.418ms | ~0%      |
| resnet50                     | 8.414ms  | 8.467ms | ~0%      |
| mobilenet_v2                 | 0.892ms  | 0.875ms | ~0%      |


### Inductor Perf Nightly

H100: https://fburl.com/xa99g949
A100: https://fburl.com/491o10qu
(default & inductor deterministic mode are correct mode to check: disable cudagraph, no AOTI)
A100 shows less perf improve might because each kernel has longer execution time, so relative improvement is less.

Test Plan:
## Tritonbench (H100)

```
buck2 run fbcode//mode/opt fbcode//pytorch/tritonbench:run_lite -- \
  --op launch_latency \
  --only nop_inductor_kernel,nop_inductor_per_kernel,nop_triton_compiled_kernel_run,nop_triton_direct_culaunch \
  --metrics walltime --simple-output
```

```
  x_val  nop_inductor_kernel  nop_inductor_per_kernel  nop_triton_compiled_kernel_run  nop_triton_direct_culaunch
      0            0.0248156              0.00312076                     0.00358178                   0.00208895
     19            0.0259619              0.00328259                     0.00501875                   0.00352997
```

## Tritonbench (GB200)

```
buck2 run fbcode//mode/opt \
  -c fbcode.enable_gpu_sections=true \
  -c fbcode.platform010_cuda_version=12.8 \
  -c fbcode.nvcc_arch=b200a \
  fbcode//pytorch/tritonbench:run_lite -- \
  --op launch_latency \
  --only nop_inductor_per_kernel,nop_triton_compiled_kernel_run,nop_triton_direct_culaunch \
  --metrics walltime --simple-output
```

```
  x_val  nop_inductor_per_kernel  nop_triton_compiled_kernel_run  nop_triton_direct_culaunch
      0              0.00307118                      0.0025503                   0.00132063
     19              0.00306199                      0.00360913                  0.00229927
```

## E2E torchbench A/B (no cudagraphs)

```
# Fast ON (default):
buck2 run fbcode//mode/opt fbcode//caffe2/benchmarks/dynamo:torchbench -- \
  --performance --inference --bfloat16 --inductor --disable-cudagraphs \
  --device cuda --only mobilenet_v2

# Fast OFF (fallback):
TORCHINDUCTOR_USE_FAST_TRITON_LAUNCHER=0 buck2 run fbcode//mode/opt \
  fbcode//caffe2/benchmarks/dynamo:torchbench -- \
  --performance --inference --bfloat16 --inductor --disable-cudagraphs \
  --device cuda --only mobilenet_v2
```

## Build

```
buck2 build fbcode//mode/opt fbcode//caffe2:torch_python_cuda_without_torch
```

## Correctness

```
buck2 test fbcode//mode/opt fbcode//caffe2/test:test_torchinductor
```

## Unit test

```
buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:static_triton_launcher -- 'TestFastCudaLauncherCompileResult'
```

Reviewed By: PaulZhang12

Differential Revision: D101027739




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos