### PR TITLE
Increase Python docs build timeout to 45m

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -93,8 +93,7 @@ jobs:
             timeout-minutes: 360
           - docs_type: python
             runner: ${{ inputs.runner_prefix }}linux.c7i.2xlarge
-            # It takes less than 30m to finish python docs unless there are issues
-            timeout-minutes: 30
+            timeout-minutes: 45
     # Set a fixed name for this job instead of using the current matrix-generated name, i.e. build-docs (cpp, linux.12xlarge, 180)
     # The current name requires updating the database last docs push query from test-infra every time the matrix is updated
     name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}
@@ -285,7 +284,7 @@ jobs:
             timeout-minutes: 360
           - docs_type: python
             runner: ${{ inputs.runner_prefix }}l-x86iavx512-16-128
-            timeout-minutes: 30
+            timeout-minutes: 45
     name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}
     steps:
       - name: Setup Linux


### PR DESCRIPTION
## What
Increases the timeout for Python documentation builds from 30 minutes to 45 minutes in both the standard and ARC runner matrix configurations.

## Why
The Python docs build has been occasionally exceeding the 30-minute timeout, causing spurious CI failures. A 45-minute limit provides enough headroom for slower builds while still catching genuinely stuck jobs.

# Changes
- `.github/workflows/_docs.yml`: Updated timeout for Python docs from 30m to 45m in the standard runner matrix (line ~96)
- `.github/workflows/_docs.yml`: Updated timeout for Python docs from 30m to 45m in the ARC runner matrix (line ~287)