### PR TITLE
[runner_determinator] Support per-user rollout percentage for runner experiments

### DIFF
--- a/.github/scripts/runner_determinator.py
+++ b/.github/scripts/runner_determinator.py
@@ -23,7 +23,11 @@ The user list has the following rules:
 
 - Users are GitHub usernames, which must start with the @ prefix
 - Each user is also a comma-separated list of features/experiments to enable
+- Each experiment can optionally include a per-user rollout percentage
+  using the syntax "experiment:percentage" (e.g. "arc:10" for 10% rollout)
+- Without a percentage, opted-in experiments are enabled 100% of the time
 - A "#" prefix opts the user out of all experiments
+- A "-" prefix on an experiment opts the user out of that experiment
 
 Example config:
     # A list of experiments that can be opted into.
@@ -42,12 +46,14 @@ Example config:
     # Opt-ins:
     # Users can opt into the LF fleet by adding their GitHub username to this list
     # and specifying experiments to enable in a comma-separated list.
+    # Optionally append :N to set a per-user rollout percentage (0-100).
     # To always opt out of an experiment, prefix it with a "-".
     # Experiments should be from the above list.
 
     @User1,-lf,split_build
     @User2,lf
     @User3,split_build
+    @User4,lf,arc:10
 """
 
 import json
@@ -301,9 +307,18 @@ def extract_settings_user_opt_in_from_text(rollout_state: str) -> tuple[str, str
         return "", rollout_state
 
 
-class UserOptins(dict[str, list[str]]):
+class UserExperimentConfig(NamedTuple):
     """
-    Dictionary of users with a list of features they have opted into
+    Per-user experiment configuration parsed from the opt-in line.
+    """
+
+    name: str
+    rollout_perc: float = 100  # default: always enabled when opted in
+
+
+class UserOptins(dict[str, list[UserExperimentConfig]]):
+    """
+    Dictionary of users with a list of experiment configs they have opted into
     """
 
 
@@ -326,7 +341,32 @@ def parse_user_opt_in_from_text(user_optin_text: str) -> UserOptins:
 
         if user:
             usr_name = user.split(",")[0].strip("@")
-            optins[usr_name] = [exp.strip(" ") for exp in user.split(",")[1:]]
+            configs = []
+            for exp_str in user.split(",")[1:]:
+                exp_str = exp_str.strip(" ")
+                if not exp_str:
+                    continue
+                # Parse optional per-user rollout percentage (e.g. "arc:10")
+                # Opt-out entries (e.g. "-lf") never have a percentage
+                if ":" in exp_str and not exp_str.startswith("-"):
+                    name, perc_str = exp_str.split(":", 1)
+                    try:
+                        perc = float(perc_str)
+                    except ValueError:
+                        log.warning(
+                            f"Invalid rollout percentage for user {usr_name}, experiment {exp_str}. Defaulting to 100%."
+                        )
+                        perc = 100
+                    if not (0 <= perc <= 100):
+                        log.warning(
+                            f"Rollout percentage {perc} for user {usr_name}, experiment {name} "
+                            f"is out of range [0, 100]. Clamping."
+                        )
+                        perc = max(0.0, min(100.0, perc))
+                    configs.append(UserExperimentConfig(name=name, rollout_perc=perc))
+                else:
+                    configs.append(UserExperimentConfig(name=exp_str, rollout_perc=100))
+            optins[usr_name] = configs
 
     return optins
 
@@ -411,11 +451,24 @@ def parse_users(rollout_state: str) -> UserOptins:
     return parse_user_opt_in_from_text(users_text)
 
 
+def get_user_experiment_config(
+    user: str, user_optins: UserOptins, experiment_name: str
+) -> UserExperimentConfig | None:
+    """
+    Get a user's experiment config if they are opted in.
+    Returns None if the user is not opted into the experiment.
+    """
+    for config in user_optins.get(user, []):
+        if config.name == experiment_name:
+            return config
+    return None
+
+
 def is_user_opted_in(user: str, user_optins: UserOptins, experiment_name: str) -> bool:
     """
     Check if a user is opted into an experiment
     """
-    return experiment_name in user_optins.get(user, [])
+    return get_user_experiment_config(user, user_optins, experiment_name) is not None
 
 
 def is_user_opted_out(user: str, user_optins: UserOptins, experiment_name: str) -> bool:
@@ -424,7 +477,10 @@ def is_user_opted_out(user: str, user_optins: UserOptins, experiment_name: str) 
     """
     # if the experiment is prefixed with a "-", then it's an opt-out
     experiment_optout = "-" + experiment_name
-    if experiment_optout not in user_optins.get(user, []):
+    opted_out = any(
+        config.name == experiment_optout for config in user_optins.get(user, [])
+    )
+    if not opted_out:
         return False
 
     if is_user_opted_in(user, user_optins, experiment_name):
@@ -499,10 +555,37 @@ def get_runner_prefix(
 
         enabled = False
         if opted_in_users:
-            log.info(
-                f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}."
-            )
-            enabled = True
+            # Get the minimum per-user rollout percentage among opted-in requesters.
+            # This is conservative: if the PR author sets 10%, that intent is respected
+            # even if the triggering actor (e.g. pytorchmergebot) has 100%.
+            user_rollout_percs = [
+                get_user_experiment_config(u, user_optins, experiment_name).rollout_perc
+                for u in opted_in_users
+            ]
+            min_perc = min(user_rollout_percs)
+
+            if min_perc >= 100:
+                log.info(
+                    f"{', '.join(opted_in_users)} have opted into experiment {experiment_name}."
+                )
+                enabled = True
+            elif min_perc > 0:
+                if random.uniform(0, 100) <= min_perc:
+                    log.info(
+                        f"{', '.join(opted_in_users)} have opted into experiment {experiment_name} "
+                        f"with {min_perc}% rollout. Enabling this run."
+                    )
+                    enabled = True
+                else:
+                    log.info(
+                        f"{', '.join(opted_in_users)} have opted into experiment {experiment_name} "
+                        f"with {min_perc}% rollout. Not enabling this run."
+                    )
+            else:
+                log.info(
+                    f"{', '.join(opted_in_users)} have opted into experiment {experiment_name} "
+                    f"with 0% rollout. Not enabling."
+                )
 
         elif experiment_settings.rollout_perc:
             # If no user is opted in, then we randomly enable the experiment based on the rollout percentage

--- a/.github/scripts/test_runner_determinator.py
+++ b/.github/scripts/test_runner_determinator.py
@@ -146,10 +146,16 @@ class TestRunnerDeterminatorIssueParser(TestCase):
         """
 
         users = rd.parse_users(settings_text)
-        self.assertDictEqual(
-            {"User1": ["lf"], "User2": ["lf", "otherExp"]},
-            users,
-            "Users not parsed correctly",
+        self.assertEqual(
+            [rd.UserExperimentConfig("lf", 100)],
+            users["User1"],
+        )
+        self.assertEqual(
+            [
+                rd.UserExperimentConfig("lf", 100),
+                rd.UserExperimentConfig("otherExp", 100),
+            ],
+            users["User2"],
         )
 
     def test_parse_users_without_settings(self) -> None:
@@ -161,10 +167,97 @@ class TestRunnerDeterminatorIssueParser(TestCase):
         """
 
         users = rd.parse_users(settings_text)
-        self.assertDictEqual(
-            {"User1": ["lf"], "User2": ["lf", "otherExp"]},
-            users,
-            "Users not parsed correctly",
+        self.assertEqual(
+            [rd.UserExperimentConfig("lf", 100)],
+            users["User1"],
+        )
+        self.assertEqual(
+            [
+                rd.UserExperimentConfig("lf", 100),
+                rd.UserExperimentConfig("otherExp", 100),
+            ],
+            users["User2"],
+        )
+
+    def test_parse_users_with_rollout_perc(self) -> None:
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+            arc:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf,arc:10
+        @User2,arc:50
+        @User3,lf
+
+        """
+
+        users = rd.parse_users(settings_text)
+        self.assertEqual(
+            [
+                rd.UserExperimentConfig("lf", 100),
+                rd.UserExperimentConfig("arc", 10),
+            ],
+            users["User1"],
+        )
+        self.assertEqual(
+            [rd.UserExperimentConfig("arc", 50)],
+            users["User2"],
+        )
+        self.assertEqual(
+            [rd.UserExperimentConfig("lf", 100)],
+            users["User3"],
+        )
+
+    def test_parse_users_invalid_percentage_defaults_to_100(self) -> None:
+        """Non-numeric percentage like arc:abc should default to 100%."""
+        settings_text = """
+        @User1,arc:abc
+        """
+
+        users = rd.parse_users(settings_text)
+        self.assertEqual(
+            [rd.UserExperimentConfig("arc", 100)],
+            users["User1"],
+        )
+
+    def test_parse_users_negative_percentage_clamped_to_zero(self) -> None:
+        """Negative percentage like arc:-5 should be clamped to 0."""
+        settings_text = """
+        @User1,arc:-5
+        """
+
+        users = rd.parse_users(settings_text)
+        self.assertEqual(
+            [rd.UserExperimentConfig("arc", 0)],
+            users["User1"],
+        )
+
+    def test_parse_users_over_100_percentage_clamped(self) -> None:
+        """Percentage over 100 like arc:200 should be clamped to 100."""
+        settings_text = """
+        @User1,arc:200
+        """
+
+        users = rd.parse_users(settings_text)
+        self.assertEqual(
+            [rd.UserExperimentConfig("arc", 100)],
+            users["User1"],
+        )
+
+    def test_parse_users_opt_out_ignores_percentage(self) -> None:
+        """Opt-out entries like -lf should not parse a percentage."""
+        settings_text = """
+        @User1,-lf
+        """
+
+        users = rd.parse_users(settings_text)
+        self.assertEqual(
+            [rd.UserExperimentConfig("-lf", 100)],
+            users["User1"],
         )
 
 
@@ -507,6 +600,211 @@ class TestRunnerDeterminatorGetRunnerPrefix(TestCase):
 
         result = rd.get_runner_prefix(settings_text, ["User1"], EXCEPTION_BRANCH)
         self.assertEqual("lf.", result.prefix, "Runner prefix not correct for user")
+
+    @patch("random.uniform", return_value=5)
+    def test_opted_in_user_with_rollout_perc_enabled(self, mock_uniform: Mock) -> None:
+        """User opted in with 10% rollout, random=5 -> enabled"""
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf:10
+
+        """
+
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("lf.", result.prefix, "Runner prefix not correct for user")
+
+    @patch("random.uniform", return_value=50)
+    def test_opted_in_user_with_rollout_perc_disabled(self, mock_uniform: Mock) -> None:
+        """User opted in with 10% rollout, random=50 -> disabled"""
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf:10
+
+        """
+
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("", result.prefix, "Runner prefix not correct for user")
+
+    def test_opted_in_user_without_rollout_perc_always_enabled(self) -> None:
+        """User opted in without percentage (default 100%) -> always enabled"""
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf
+
+        """
+
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("lf.", result.prefix, "Runner prefix not correct for user")
+
+    @patch("random.uniform", return_value=15)
+    def test_multiple_requesters_uses_min_perc(self, mock_uniform: Mock) -> None:
+        """Two requesters with different rollout_percs, uses the minimum (10%)."""
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf:10
+        @User2,lf:50
+
+        """
+
+        # random=15, min_perc=10 -> 15 > 10 -> disabled
+        result = rd.get_runner_prefix(settings_text, ["User1", "User2"], USER_BRANCH)
+        self.assertEqual("", result.prefix, "Runner prefix not correct for user")
+
+    @patch("random.uniform", return_value=5)
+    def test_multiple_requesters_uses_min_perc_enabled(
+        self, mock_uniform: Mock
+    ) -> None:
+        """Two requesters with different rollout_percs, min=10%, random=5 -> enabled."""
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf:10
+        @User2,lf:50
+
+        """
+
+        result = rd.get_runner_prefix(settings_text, ["User1", "User2"], USER_BRANCH)
+        self.assertEqual("lf.", result.prefix, "Runner prefix not correct for user")
+
+    def test_opt_out_overrides_rollout_perc(self) -> None:
+        """Opt-out (-lf) wins over opt-in with rollout_perc (lf:50)."""
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 100
+        ---
+
+        Users:
+        @User1,-lf,lf:50
+
+        """
+
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("", result.prefix, "Runner prefix not correct for user")
+
+    @patch("random.uniform", return_value=5)
+    def test_opted_in_user_with_rollout_perc_two_experiments(
+        self, mock_uniform: Mock
+    ) -> None:
+        """User opted into lf at 100% and otherExp at 10%, random=5 -> both enabled"""
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+            otherExp:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf,otherExp:10
+
+        """
+
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual(
+            "lf.otherExp.", result.prefix, "Runner prefix not correct for user"
+        )
+
+    @patch("random.uniform", return_value=50)
+    def test_opted_in_user_with_rollout_perc_partial_enable(
+        self, mock_uniform: Mock
+    ) -> None:
+        """User opted into lf at 100% and otherExp at 10%, random=50 -> only lf enabled"""
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+            otherExp:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf,otherExp:10
+
+        """
+
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("lf.", result.prefix, "Runner prefix not correct for user")
+
+    def test_opted_in_user_with_zero_rollout_perc(self) -> None:
+        """User opted in with 0% rollout -> never enabled"""
+        settings_text = """
+        experiments:
+            lf:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,lf:0
+
+        """
+
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("", result.prefix, "Runner prefix not correct for user")
+
+    @patch("random.uniform", return_value=5)
+    def test_arc_opted_in_user_with_rollout_perc_enabled(
+        self, mock_uniform: Mock
+    ) -> None:
+        """User opted into arc with 10% rollout, random=5 -> arc enabled"""
+        settings_text = """
+        experiments:
+            arc:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,arc:10
+
+        """
+
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("mt-", result.prefix)
+        self.assertTrue(result.use_arc)
+
+    @patch("random.uniform", return_value=50)
+    def test_arc_opted_in_user_with_rollout_perc_disabled(
+        self, mock_uniform: Mock
+    ) -> None:
+        """User opted into arc with 10% rollout, random=50 -> arc disabled"""
+        settings_text = """
+        experiments:
+            arc:
+                rollout_perc: 0
+        ---
+
+        Users:
+        @User1,arc:10
+
+        """
+
+        result = rd.get_runner_prefix(settings_text, ["User1"], USER_BRANCH)
+        self.assertEqual("", result.prefix)
+        self.assertFalse(result.use_arc)
 
 
 class TestRunnerDeterminatorArcExperiment(TestCase):


### PR DESCRIPTION
Currently, when a user opts into a runner experiment (e.g. `@huydhn,arc`), 100% of their workflow runs use that experiment's runners. This change adds support for per-user rollout percentages so that opted-in users can control what fraction of their jobs use a given experiment.

New syntax: `@username,experiment:percentage`
- `@huydhn,lf,arc:10` — lf at 100% (default), arc at 10%
- `@User,arc:50` — arc enabled for 50% of runs
- `@User,lf` — unchanged, lf at 100% (backwards compatible)

When multiple workflow requestors are opted in with different percentages, the minimum is used (conservative: PR author intent is respected).

### Testing

https://github.com/pytorch/pytorch/actions/runs/24482567872/job/71550521784?pr=180510#step:4:31