### PR TITLE
 Fix DTensor Partial placement lost during autograd layout invariant (issue #180486)

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -1748,6 +1748,35 @@ class TestNewEmptyStridedUneven(DTensorTestBase):
         )
 
     @with_comms
+    def test_new_empty_propagates_partial(self):
+        """new_empty/new_empty_strided on a Partial DTensor should inherit Partial.
+
+        Uninitialized memory will be overwritten immediately, so the placement
+        only needs to match the source of the subsequent write. Without this,
+        copy_ from a Partial source to a Replicate destination triggers an
+        unwanted all-reduce (issue #180486).
+        """
+        mesh = self.build_device_mesh()
+        partial_dt = DTensor.from_local(
+            torch.randn(4, 8, device=self.device_type),
+            device_mesh=mesh,
+            placements=[Partial()],
+        )
+
+        empty_dt = partial_dt.new_empty(partial_dt.shape)
+        self.assertEqual(empty_dt.placements, (Partial(),))
+
+        empty_strided_dt = partial_dt.new_empty_strided(
+            partial_dt.shape, partial_dt.stride()
+        )
+        self.assertEqual(empty_strided_dt.placements, (Partial(),))
+
+        # Initialized factories must keep Replicate, otherwise their values
+        # would be incorrect after a Partial reduction (e.g. ones * world_size).
+        ones_dt = partial_dt.new_ones(partial_dt.shape)
+        self.assertEqual(ones_dt.placements, (Replicate(),))
+
+    @with_comms
     def test_backward_partial_grad_with_transpose(self):
         """Backward preserves Partial placement when grad is non-contiguous (issue #180486).
 

--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -1748,6 +1748,58 @@ class TestNewEmptyStridedUneven(DTensorTestBase):
         )
 
     @with_comms
+    def test_backward_partial_grad_with_transpose(self):
+        """Backward preserves Partial placement when grad is non-contiguous (issue #180486).
+
+        When a Replicate DTensor parameter is used with to_local(grad_placements=[Partial()]),
+        and the backward produces a non-contiguous gradient (e.g. via transpose), autograd's
+        layout invariant calls new_empty_strided + copy_ to fix strides. This must preserve
+        the Partial placement rather than defaulting to Replicate.
+        """
+        mesh = self.build_device_mesh()
+
+        class _Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(4, 8, 8))
+                self._grad_placement = None
+
+            def forward(self, x):
+                w = self.weight
+                if isinstance(w, DTensor):
+                    w = w.to_local(grad_placements=[Partial()])
+
+                    def _capture(param, model=self):
+                        if param.grad is not None and isinstance(param.grad, DTensor):
+                            model._grad_placement = param.grad.placements
+
+                    self.weight.register_post_accumulate_grad_hook(_capture)
+
+                # transpose backward produces non-contiguous grad
+                w = w.transpose(1, 2).contiguous()
+                return torch.mm(x, w[0])
+
+        model = _Model().to(self.device_type)
+        with torch.no_grad():
+            model.weight = torch.nn.Parameter(
+                DTensor.from_local(
+                    model.weight.data,
+                    device_mesh=mesh,
+                    placements=[Replicate()],
+                )
+            )
+
+        x = torch.randn(2, 8, device=self.device_type, requires_grad=True)
+        out = model(x)
+        out.sum().backward()
+
+        self.assertIsNotNone(model._grad_placement)
+        self.assertTrue(
+            all(isinstance(p, Partial) for p in model._grad_placement),
+            f"Expected Partial grad placement, got {model._grad_placement}",
+        )
+
+    @with_comms
     def test_backward_channels_last(self):
         """Backward preserves channels-last stride order for unevenly-sharded DTensor."""
         mesh = self.build_device_mesh()

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -282,16 +282,17 @@ def new_factory_strategy(op_schema: OpSchema) -> StrategyType:
             )
         )
 
-        # Uninitialized factories (new_empty*) can safely inherit Partial
-        # placement since their contents will be overwritten immediately
-        # (e.g., by autograd's clone_obey_contract: new_empty_strided + copy_).
+        # Sharded inputs always propagate. Uninitialized factories (new_empty*)
+        # also propagate Partial — the memory is about to be overwritten, so the
+        # placement just needs to match the source of the subsequent write
+        # (e.g., autograd's clone_obey_contract: new_empty_strided + copy_).
+        # Initialized factories (new_zeros/ones/full) keep Replicate to avoid
+        # incorrect values after Partial reduction (e.g. ones * world_size).
         is_uninitialized_factory = op_schema.op in (
             aten.new_empty.default,
             aten.new_empty_strided.default,
         )
-        can_propagate_placement = input_spec.is_sharded() or (
-            is_uninitialized_factory and not input_spec.is_replicated()
-        )
+        can_propagate_placement = input_spec.is_sharded() or is_uninitialized_factory
         if tuple(input_shape) == tuple(output_shape) and can_propagate_placement:
             new_factory_strategy.strategies.append(
                 OpSpec(

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -282,7 +282,17 @@ def new_factory_strategy(op_schema: OpSchema) -> StrategyType:
             )
         )
 
-        if tuple(input_shape) == tuple(output_shape) and input_spec.is_sharded():
+        # Uninitialized factories (new_empty*) can safely inherit Partial
+        # placement since their contents will be overwritten immediately
+        # (e.g., by autograd's clone_obey_contract: new_empty_strided + copy_).
+        is_uninitialized_factory = op_schema.op in (
+            aten.new_empty.default,
+            aten.new_empty_strided.default,
+        )
+        can_propagate_placement = input_spec.is_sharded() or (
+            is_uninitialized_factory and not input_spec.is_replicated()
+        )
+        if tuple(input_shape) == tuple(output_shape) and can_propagate_placement:
             new_factory_strategy.strategies.append(
                 OpSpec(
                     output_specs=input_spec,


### PR DESCRIPTION
**Summary** Addresses https://github.com/pytorch/pytorch/issues/180486. When a Replicate DTensor parameter produces a non-contiguous Partial gradient (e.g. via transpose), autograd's clone_obey_contract calls new_empty_strided + copy_ to fix strides. new_empty_strided defaulted to Replicate placement, causing copy_ to trigger an unwanted all-reduce from Partial to Replicate.
                                                                                                                                              
Allow new_empty/new_empty_strided to inherit Partial placement from the input when shapes match, since uninitialized memory is immediately overwritten. Other factories (new_zeros, new_ones, new_full) keep the existing Replicate default to avoid incorrect values after reduction.     

**Test Cases**
1. pytest /data/users/anshulsi/pytorch/test/distributed/tensor/test_tensor_ops.py -k test_backward_partial_grad_with_transpose

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180511

