### PR TITLE
Fix call to fork_rng by by specifying device type

### DIFF
--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -423,7 +423,8 @@ class _PipelineSchedule(ABC):
                 if torch.device(stage.device).type != "cpu"
             }
         )
-        with torch.random.fork_rng(devices=devices):
+        device_type = stages[0].device if stages else "cuda"
+        with torch.random.fork_rng(devices=devices, device_type=device_type):
             if needs_fwd:
                 next_stage_args: Any = None
                 for stage in stages:

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -423,7 +423,7 @@ class _PipelineSchedule(ABC):
                 if torch.device(stage.device).type != "cpu"
             }
         )
-        device_type = stages[0].device if stages else "cuda"
+        device_type = stages[0].device if stages else None
         with torch.random.fork_rng(devices=devices, device_type=device_type):
             if needs_fwd:
                 next_stage_args: Any = None

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -438,7 +438,7 @@ class _PipelineSchedule(ABC):
                 if torch.device(stage.device).type != "cpu"
             }
         )
-        device_type = devices[0] if devices else None
+        device_type = devices[0].type if devices else None
         with torch.random.fork_rng(devices=devices, device_type=device_type):
             if needs_fwd:
                 next_stage_args: Any = None

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -438,7 +438,7 @@ class _PipelineSchedule(ABC):
                 if torch.device(stage.device).type != "cpu"
             }
         )
-        device_type = stages[0].device if stages else None
+        device_type = devices[0] if devices else None
         with torch.random.fork_rng(devices=devices, device_type=device_type):
             if needs_fwd:
                 next_stage_args: Any = None

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -439,6 +439,14 @@ class _PipelineSchedule(ABC):
             }
         )
         device_type = devices[0].type if devices else None
+        # Assert all device types are the same
+        if device_type is not None and not all(
+            device.type == device_type for device in devices
+        ):
+            raise AssertionError(
+                "All stages must have the same device type for RNG forking. "
+                f"Found device types: { {device.type for device in devices} }"
+            )
         with torch.random.fork_rng(devices=devices, device_type=device_type):
             if needs_fwd:
                 next_stage_args: Any = None

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -438,7 +438,7 @@ class _PipelineSchedule(ABC):
                 if torch.device(stage.device).type != "cpu"
             }
         )
-        device_type = stages[0].device if stages else "cuda"
+        device_type = stages[0].device if stages else None
         with torch.random.fork_rng(devices=devices, device_type=device_type):
             if needs_fwd:
                 next_stage_args: Any = None

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -443,9 +443,10 @@ class _PipelineSchedule(ABC):
         if device_type is not None and not all(
             device.type == device_type for device in devices
         ):
+            device_types = {device.type for device in devices}
             raise AssertionError(
                 "All stages must have the same device type for RNG forking. "
-                f"Found device types: { {device.type for device in devices} }"
+                f"Found device types: {device_types}"
             )
         with torch.random.fork_rng(devices=devices, device_type=device_type):
             if needs_fwd:

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -438,7 +438,8 @@ class _PipelineSchedule(ABC):
                 if torch.device(stage.device).type != "cpu"
             }
         )
-        with torch.random.fork_rng(devices=devices):
+        device_type = stages[0].device if stages else "cuda"
+        with torch.random.fork_rng(devices=devices, device_type=device_type):
             if needs_fwd:
                 next_stage_args: Any = None
                 for stage in stages:

--- a/torch/random.py
+++ b/torch/random.py
@@ -159,7 +159,7 @@ def fork_rng(
     enabled=True,
     _caller="fork_rng",
     _devices_kw="devices",
-    device_type="cuda",
+    device_type=None,
 ) -> Generator:
     """
     Forks the RNG, so that when you return, the RNG is reset
@@ -174,9 +174,24 @@ def fork_rng(
         enabled (bool): if ``False``, the RNG is not forked.  This is a convenience
             argument for easily disabling the context manager without having
             to delete it and unindent your Python code under it.
-        device_type (str): device type str, default is `cuda`. As for supported device,
+        device_type (str): device type str, default is ``None``, in which case the type
+            is inferred from ``devices`` if provided (using the first entry), falling back
+            to ``"cuda"`` when the type cannot be determined. As for supported devices,
             see details in :ref:`accelerator<accelerators>`
     """
+
+    if device_type is None:
+        if devices is not None:
+            devices = list(devices)
+            if devices:
+                try:
+                    device_type = torch.device(devices[0]).type
+                except Exception:
+                    device_type = "cuda"
+            else:
+                device_type = "cuda"
+        else:
+            device_type = "cuda"
 
     if device_type == "meta":
         yield

--- a/torch/random.py
+++ b/torch/random.py
@@ -180,25 +180,13 @@ def fork_rng(
             see details in :ref:`accelerator<accelerators>`
     """
 
-    if device_type is None:
-        if devices is not None:
-            devices = list(devices)
-            if devices:
-                try:
-                    device_type = torch.device(devices[0]).type
-                except Exception:
-                    device_type = "cuda"
-            else:
-                device_type = "cuda"
-        else:
-            device_type = "cuda"
+    device_type = device_type or torch.accelerator.current_accelerator().type
 
     if device_type == "meta":
         yield
         return
 
-    device_type = torch.device(device_type).type
-    device_mod = getattr(torch, device_type, None)
+    device_mod = torch.get_device_module(device_type)
     if device_mod is None:
         raise RuntimeError(
             f"torch has no module of `{device_type}`, you should register "

--- a/torch/random.py
+++ b/torch/random.py
@@ -175,16 +175,18 @@ def fork_rng(
             argument for easily disabling the context manager without having
             to delete it and unindent your Python code under it.
         device_type (str): device type str, default is ``None``, in which case the type
-            is inferred from ``devices`` if provided (using the first entry), falling back
+            is taken from :func:`torch.accelerator.current_accelerator`, falling back
             to ``"cuda"`` when the type cannot be determined. As for supported devices,
             see details in :ref:`accelerator<accelerators>`
     """
 
-    device_type = device_type or torch.accelerator.current_accelerator().type
-
     if device_type == "meta":
         yield
         return
+
+    acc = torch.accelerator.current_accelerator()
+    # Default to cuda instead of CPU since CPU rng is always forked
+    device_type = device_type or (acc.type if acc is not None else "cuda")
 
     device_mod = torch.get_device_module(device_type)
     if device_mod is None:


### PR DESCRIPTION
Fixes a bug for non-CUDA devices introduced by https://github.com/pytorch/pytorch/pull/177728 due to a misused call to fork_rng

* Since the call to fork_rng should specify the device type, I specify this in `schedules.py`
* The design of fork_rng seems outdated since the adoption of non-CUDA devices. I change the signature so the device_type default argument is `None`, and is inferred from the passed devices. If it can't be inferred from the device list (because it's a list of ints, for example) we still fallback to the previous value of "cuda".
