### PR TITLE
[mem viz] use segment size for envelope to show fragmentation

### DIFF
--- a/test/profiler/test_memory_viz.js
+++ b/test/profiler/test_memory_viz.js
@@ -125,36 +125,29 @@ function test_pool_free_without_alloc_no_inflation() {
     traces: [
       // No alloc — it happened before recording started or got replaced in ring buffer
       // Only the free_completed event is matched (free_requested is ignored).
-      // Note: real trace events never have segment_pool_id; pool is resolved via find_pool_id
-      // from the segment address ranges.
-      { action: 'free_completed', addr: 5000, size: 1000, frames: [], stream: 0 },
+      { action: 'free_completed', addr: 0x788c2000000, size: 94371840, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x788c2000000, size: 256, frames: [], stream: 0 },
     ],
     segments: [{
-      device: 0, address: 4096, total_size: 8192, segment_pool_id: poolId,
+      device: 0, address: 0x788c0000000, total_size: 83886080, segment_pool_id: poolId,
       stream: 0, blocks: [],
     }],
   });
 
   const result = process_alloc_data(snapshot, 0, false, 15000, true);
   // The free_completed creates an element in initially_allocated + actions.
-  // The fix pre-loads it into the pool (pool.active=1000, envelope grows to 1000).
-  // Then in actions, it's recognized as a free (pool.active goes to 0).
-  // Peak should be 1000 (the initial state), NOT 2000.
-  assert(result.max_size <= 1000,
-    `pool free-without-alloc should not inflate peak: got ${result.max_size}`);
+  // Pre-loaded into pool: pool.active=90M, envelope=max(90M, 80M reserved)=90M.
+  // Then freed (pool.active=0), then small alloc (pool.active=256).
+  // Peak should be 94371840 (max of active and reserved), NOT double-counted.
+  assertEqual(result.max_size, 94371840,
+    'pool free-without-alloc peak should be max(active, reserved)');
 
-  // 1 element: the free_completed event that created an initially_allocated entry
-  assertEqual(result.elements_length, 1, 'should have 1 element');
+  assertEqual(result.elements_length, 2, 'should have 2 elements');
 
-  // max_at_time should show the pool envelope at 1000, then dropping after the free
   assert(result.max_at_time.length > 0, 'max_at_time should not be empty');
-  assertEqual(Math.max(...result.max_at_time), 1000,
-    'max_at_time peak should be 1000 (envelope high-water mark)');
+  assertEqual(Math.max(...result.max_at_time), 94371840,
+    'max_at_time peak should be max(active, reserved)');
 
-  // allocations_over_time should contain:
-  //   - pool envelope (elem = "pool:1,42")
-  //   - stripe for the block (elem = 0, the element index)
-  //   - summarized_mem
   const envelopes = result.allocations_over_time.filter(
     d => typeof d.elem === 'string' && d.elem.startsWith('pool:'));
   assertEqual(envelopes.length, 1, 'should have 1 pool envelope');
@@ -162,8 +155,9 @@ function test_pool_free_without_alloc_no_inflation() {
 
   const stripes = result.allocations_over_time.filter(
     d => typeof d.elem === 'number' && d.opacity === 0.5);
-  assertEqual(stripes.length, 1, 'should have 1 pool stripe');
-  assertEqual(stripes[0].size, 1000, 'stripe size matches block size');
+  assertEqual(stripes.length, 2, 'should have 2 pool stripes');
+  assertEqual(stripes[0].size, 94371840, 'first stripe: pre-loaded block (freed later)');
+  assertEqual(stripes[1].size, 256, 'second stripe: small alloc after free');
 }
 
 function test_pool_alloc_then_free_normal() {
@@ -182,7 +176,8 @@ function test_pool_alloc_then_free_normal() {
   });
 
   const result = process_alloc_data(snapshot, 0, false, 15000, true);
-  assertEqual(result.max_size, 500, 'normal pool alloc/free peak should be 500');
+  // Envelope = segment reserved (8192), which is the pool's GPU footprint
+  assertEqual(result.max_size, 8192, 'pool envelope should be segment reserved (8192)');
 }
 
 function test_multiple_pool_frees_without_alloc() {
@@ -204,11 +199,11 @@ function test_multiple_pool_frees_without_alloc() {
   });
 
   const result = process_alloc_data(snapshot, 0, false, 15000, true);
-  // 3 blocks of 500 each were initially allocated. Pool envelope = 1500.
-  // Then all 3 are freed. Peak should be 1500 (the initial state).
-  // BUG would give 3000+ (each free treated as a new alloc).
-  assert(result.max_size <= 1500,
-    `multiple pool frees should not inflate: got ${result.max_size}, expected <= 1500`);
+  // 3 blocks of 500 each were initially allocated. Pool envelope = 16384 (segment reserved).
+  // Then all 3 are freed. Peak should be 16384 (segment reserved, the initial state).
+  // BUG would give 32768+ (double-counted).
+  assert(result.max_size <= 16384,
+    `multiple pool frees should not inflate: got ${result.max_size}, expected <= 16384`);
 }
 
 function test_non_pool_free_without_alloc() {
@@ -254,8 +249,8 @@ function test_mixed_pool_and_nonpool() {
   });
 
   const result = process_alloc_data(snapshot, 0, false, 15000, true);
-  // Peak: 200 (non-pool) + 400 (pool envelope) = 600
-  assertEqual(result.max_size, 600, 'mixed pool+nonpool peak should be 600');
+  // Peak: 200 (non-pool) + 8192 (pool envelope = segment reserved) = 8392
+  assertEqual(result.max_size, 8392, 'mixed pool+nonpool peak: 200 + 8192 segment reserved');
 }
 
 function test_include_private_inactive_false_ignores_pools() {
@@ -859,15 +854,19 @@ function test_ghost_blocks_private_pool() {
   assertEqual(default_ghost.timesteps[1], pool_ghost.timesteps.at(-1),
     'both ghosts end at the same final timestep');
 
-  // Pool envelope only for (0,1) — default pool ghosts are at global bottom
+  // Pool envelope only for (0,1) — default pool ghosts are at global bottom.
+  // Both pool segments use stream 0, so there should be exactly 1 envelope
+  // (not split by stream, and not "snull" from annotate_snapshot eliding streams).
   const envelopes = aot.filter(d => typeof d.elem === 'string' && d.elem.startsWith('pool:'));
   assertEqual(envelopes.length, 1, '1 pool envelope');
-  assertContains(envelopes[0].elem, '0,1', 'envelope for pool (0,1)');
+  assertContains(envelopes[0].elem, '0,1,s0', 'envelope for pool (0,1)');
 
-  // Envelope initial size at timestep 0 should already include the ghost block
+  // Envelope initial size at timestep 0 = total pool reserved from snapshot
+  // (ghost segment 2 MiB + traced segment ~20 MiB = ~22 MiB)
+  const pool_reserved = 2097152 + 20971520;  // sum of pool (0,1) segment total_sizes
   const env = envelopes[0];
   assertEqual(env.timesteps[0], 0, 'envelope starts at timestep 0');
-  assertEqual(env.size[0], 1048576, 'envelope initial size = ghost (1 MiB)');
+  assertEqual(env.size[0], pool_reserved, 'envelope initial size = total pool reserved');
 
   // Ghost stripe should fit within the envelope
   const env_offset = env.offsets[0];
@@ -876,11 +875,11 @@ function test_ghost_blocks_private_pool() {
   assert(ghost_offset + 1048576 <= env_offset + env.size[0],
     'ghost stripe fits within envelope at timestep 0');
 
-  // Pool envelope max size should include both ghost (1 MiB) + traced (3 MiB) = 4 MiB
+  // Pool envelope max = total pool reserved (same as initial since no segment events)
   const env_max_size = Array.isArray(env.size)
     ? Math.max(...env.size)
     : env.size;
-  assertEqual(env_max_size, 1048576 + 3145728, 'pool envelope max = ghost + traced');
+  assertEqual(env_max_size, pool_reserved, 'pool envelope max = total pool reserved');
 
   // With include_private_inactive=false, ghosts still exist but no pool envelope
   const result_false = process_alloc_data(snapshot, 0, false, 15000, false);
@@ -965,20 +964,22 @@ function test_ghost_stripe_offset_with_multiple_pools() {
 
 function test_full_snapshot_private_pools() {
   console.log('test_full_snapshot_private_pools');
+  // 512 KiB allocs so they're visible relative to the 2 MiB envelope
+  const S = 524288;
   const snapshot = makeSnapshot({
     traces: [
       { action: 'segment_alloc', addr: 0x7f08cde00000, size: 2097152, frames: [], stream: 0 },
-      { action: 'alloc', addr: 0x7f08cde00000, size: 1024, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x7f08cde00000, size: S, frames: [], stream: 0 },
       { action: 'segment_alloc', addr: 0x7f08d2800000, size: 2097152, frames: [], stream: 0 },
-      { action: 'alloc', addr: 0x7f08d2800000, size: 1024, frames: [], stream: 0 },
-      { action: 'free_requested', addr: 0x7f08cde00000, size: 1024, frames: [], stream: 0 },
-      { action: 'free_completed', addr: 0x7f08cde00000, size: 1024, frames: [], stream: 0 },
-      { action: 'free_requested', addr: 0x7f08d2800000, size: 1024, frames: [], stream: 0 },
-      { action: 'free_completed', addr: 0x7f08d2800000, size: 1024, frames: [], stream: 0 },
-      { action: 'alloc', addr: 0x7f08cde00000, size: 1024, frames: [], stream: 0 },
-      { action: 'alloc', addr: 0x7f08d2800000, size: 1024, frames: [], stream: 0 },
-      { action: 'alloc', addr: 0x7f08d2800400, size: 1024, frames: [], stream: 0 },
-      { action: 'alloc', addr: 0x7f08cde00400, size: 1024, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x7f08d2800000, size: S, frames: [], stream: 0 },
+      { action: 'free_requested', addr: 0x7f08cde00000, size: S, frames: [], stream: 0 },
+      { action: 'free_completed', addr: 0x7f08cde00000, size: S, frames: [], stream: 0 },
+      { action: 'free_requested', addr: 0x7f08d2800000, size: S, frames: [], stream: 0 },
+      { action: 'free_completed', addr: 0x7f08d2800000, size: S, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x7f08cde00000, size: S, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x7f08d2800000, size: S, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x7f08d2880000, size: S, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x7f08cde80000, size: S, frames: [], stream: 0 },
     ],
     segments: [
       { device: 0, address: 0x7f08cde00000, total_size: 2097152,
@@ -991,11 +992,21 @@ function test_full_snapshot_private_pools() {
   const result = process_alloc_data(snapshot, 0, false, 15000, true);
 
   assertEqual(result.elements_length, 6, 'should have 6 elements');
-  assertEqual(result.max_size, 4096, 'peak memory should be 4096');
+  assertEqual(result.max_size, 2 * S + 2097152, 'peak = 2 default pool blocks + 2M envelope');
 
+  // Timeline (envelope = 2M from segment reserved, never shrinks):
+  //   alloc 512K in default pool       → 512K
+  //   alloc 512K in private pool       → 512K + 2M envelope = 2.5M
+  //   free 512K from default pool      → 2M (envelope stays)
+  //   free 512K stripe in pool         → 2M (stripe gone, envelope stays)
+  //   alloc 512K in default pool       → 2M + 512K = 2.5M
+  //   alloc 512K stripe in pool        → 2.5M (within envelope)
+  //   alloc 512K stripe in pool        → 2.5M (within envelope)
+  //   alloc 512K in default pool       → 2M + 2*512K = 3M
   const expected_max_at_time = [
-    1024, 2048, 2048, 2048, 2048, 2048, 2048, 2048, 2048,
-    1024, 2048, 2048, 3072, 3072, 3072, 3072, 4096,
+    S, S+2097152, S+2097152, S+2097152, S+2097152, S+2097152,
+    S+2097152, S+2097152, S+2097152,
+    2097152, S+2097152, S+2097152, S+2097152, 2*S+2097152,
   ];
   assertEqual(result.max_at_time.length, expected_max_at_time.length,
     'max_at_time length');
@@ -1005,12 +1016,15 @@ function test_full_snapshot_private_pools() {
   }
 
   const aot = result.allocations_over_time;
-  assertEqual(aot[0].elem, 0, 'first entry is element 0');
-  assertEqual(aot[0].size, 1024, 'element 0 size');
 
   const envelopes = aot.filter(d => typeof d.elem === 'string' && d.elem.startsWith('pool:'));
   assertEqual(envelopes.length, 1, 'should have 1 pool envelope');
   assertEqual(envelopes[0].elem, 'pool:0,1,s0', 'envelope key matches pool (0,1)');
+
+  // Envelope size is driven by segment reserved (2 MiB), not just active allocs
+  const env_max = Array.isArray(envelopes[0].size)
+    ? Math.max(...envelopes[0].size) : envelopes[0].size;
+  assertEqual(env_max, 2097152, 'envelope = segment reserved (2 MiB)');
 
   const stripes = aot.filter(d => typeof d.elem === 'number' && d.opacity === 0.5);
   assertEqual(stripes.length, 3, 'should have 3 pool stripes (elements 1, 3, 4)');
@@ -1085,6 +1099,156 @@ function test_full_snapshot_no_private_pools() {
 }
 
 // ============================================================
+// Pool envelope reserved-memory tests
+// ============================================================
+
+function test_envelope_grows_on_segment_map() {
+  console.log('test_envelope_grows_on_segment_map');
+  // When a private pool alloc triggers segment_map (fragmentation), the envelope
+  // should grow to the reserved size, not just the active allocation size.
+  // Scenario: alloc 500, free 500, alloc 400 triggers segment_map of 400
+  // (can't reuse fragmented free blocks). Reserved = 500 + 400 = 900.
+  const poolId = [1, 10];
+  const snapshot = makeSnapshot({
+    traces: [
+      { action: 'segment_map', addr: 0x1000, size: 500, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x1000, size: 500, frames: [], stream: 0 },
+      { action: 'free_completed', addr: 0x1000, size: 500, frames: [], stream: 0 },
+      { action: 'segment_map', addr: 0x1200, size: 400, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x1200, size: 400, frames: [], stream: 0 },
+    ],
+    segments: [{
+      device: 0, address: 0x1000, total_size: 900, segment_pool_id: poolId,
+      stream: 0, blocks: [],
+    }],
+  });
+
+  const result = process_alloc_data(snapshot, 0, false, 15000, true);
+  // Envelope should be 900 (reserved), not 500 (peak active)
+  const envelopes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'string' && d.elem.startsWith('pool:'));
+  assertEqual(envelopes.length, 1, 'should have 1 pool envelope');
+  const env_max = Array.isArray(envelopes[0].size)
+    ? Math.max(...envelopes[0].size) : envelopes[0].size;
+  assertEqual(env_max, 900, 'envelope should be 900 (reserved), not 500 (peak active)');
+
+  // Stripes inside the envelope should reflect individual block sizes (500, 400),
+  // not grow to the envelope size.
+  const stripes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'number' && d.opacity === 0.5);
+  assertEqual(stripes.length, 2, 'should have 2 pool stripes');
+  const stripe_sizes = stripes.map(s => s.size).sort();
+  assertEqual(stripe_sizes[0], 400, 'stripe for second alloc = 400');
+  assertEqual(stripe_sizes[1], 500, 'stripe for first alloc = 500');
+}
+
+function test_envelope_from_initial_reserved() {
+  console.log('test_envelope_from_initial_reserved');
+  // Segment reserved is 2000 but only 300 is actively allocated.
+  // No segment events in trace — initial reserved = snapshot reserved.
+  // Envelope should be 2000 (reserved), not 300 (active).
+  const poolId = [1, 20];
+  const snapshot = makeSnapshot({
+    traces: [
+      { action: 'alloc', addr: 0x2000, size: 300, frames: [], stream: 0 },
+    ],
+    segments: [{
+      device: 0, address: 0x2000, total_size: 2000, segment_pool_id: poolId,
+      stream: 0, blocks: [],
+    }],
+  });
+
+  const result = process_alloc_data(snapshot, 0, false, 15000, true);
+  const envelopes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'string' && d.elem.startsWith('pool:'));
+  assertEqual(envelopes.length, 1, 'should have 1 envelope');
+  const env_max = Array.isArray(envelopes[0].size)
+    ? Math.max(...envelopes[0].size) : envelopes[0].size;
+  assertEqual(env_max, 2000, 'envelope should be 2000 (segment reserved)');
+}
+
+function test_envelope_segment_map_no_double_count() {
+  console.log('test_envelope_segment_map_no_double_count');
+  // Segment_map events in trace + snapshot reserved should not double-count.
+  // Trace has segment_map of 600. Snapshot total = 600. So initial reserved = 0.
+  // Envelope grows to 600 from the segment_map event.
+  const poolId = [1, 30];
+  const snapshot = makeSnapshot({
+    traces: [
+      { action: 'segment_map', addr: 0x3000, size: 600, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x3000, size: 600, frames: [], stream: 0 },
+    ],
+    segments: [{
+      device: 0, address: 0x3000, total_size: 600, segment_pool_id: poolId,
+      stream: 0, blocks: [],
+    }],
+  });
+
+  const result = process_alloc_data(snapshot, 0, false, 15000, true);
+  const envelopes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'string' && d.elem.startsWith('pool:'));
+  assertEqual(envelopes.length, 1, 'should have 1 envelope');
+  const env_max = Array.isArray(envelopes[0].size)
+    ? Math.max(...envelopes[0].size) : envelopes[0].size;
+  // Should be 600, not 1200 (double-counted)
+  assertEqual(env_max, 600, 'envelope should be 600 (no double count)');
+}
+
+function test_envelope_active_exceeds_reserved() {
+  console.log('test_envelope_active_exceeds_reserved');
+  // Edge case: active > reserved (e.g., segment events lost from ring buffer).
+  // Envelope should use max(active, reserved).
+  // Scenario: segment_map of 500 in trace, snapshot total = 800.
+  // initial reserved = 800 - 500 = 300. After segment_map, reserved = 800.
+  // Then alloc of 800 → active=800 = reserved=800 → envelope=800.
+  // Now a second alloc of 200 with no segment event → active=1000 > reserved=800.
+  // Envelope should grow to 1000 (active exceeds reserved).
+  const poolId = [1, 40];
+  const snapshot = makeSnapshot({
+    traces: [
+      { action: 'segment_map', addr: 0x4000, size: 500, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x4000, size: 800, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x4400, size: 200, frames: [], stream: 0 },
+    ],
+    segments: [{
+      device: 0, address: 0x4000, total_size: 1000, segment_pool_id: poolId,
+      stream: 0, blocks: [],
+    }],
+  });
+
+  const result = process_alloc_data(snapshot, 0, false, 15000, true);
+  const envelopes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'string' && d.elem.startsWith('pool:'));
+  assertEqual(envelopes.length, 1, 'should have 1 envelope');
+  const env_max = Array.isArray(envelopes[0].size)
+    ? Math.max(...envelopes[0].size) : envelopes[0].size;
+  // active=1000 > reserved at time of second alloc (800), envelope = 1000
+  assertEqual(env_max, 1000, 'envelope should be 1000 (active exceeds earlier reserved)');
+}
+
+function test_envelope_default_pool_unaffected() {
+  console.log('test_envelope_default_pool_unaffected');
+  // Default pool (0,0) should NOT get envelope treatment regardless of segment events.
+  const snapshot = makeSnapshot({
+    traces: [
+      { action: 'segment_map', addr: 100, size: 5000, frames: [], stream: 0 },
+      { action: 'alloc', addr: 100, size: 200, frames: [], stream: 0 },
+      { action: 'free_completed', addr: 100, size: 200, frames: [], stream: 0 },
+    ],
+    segments: [{
+      device: 0, address: 0, total_size: 5000, segment_pool_id: [0, 0],
+      stream: 0, blocks: [],
+    }],
+  });
+
+  const result = process_alloc_data(snapshot, 0, false, 15000, true);
+  const envelopes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'string' && d.elem.startsWith('pool:'));
+  assertEqual(envelopes.length, 0, 'default pool should not have envelope');
+  assertEqual(result.max_size, 200, 'default pool peak = active only');
+}
+
+// ============================================================
 // Run all tests
 // ============================================================
 
@@ -1126,6 +1290,11 @@ test_ghost_blocks_private_pool();
 test_ghost_stripe_offset_with_multiple_pools();
 test_full_snapshot_private_pools();
 test_full_snapshot_no_private_pools();
+test_envelope_grows_on_segment_map();
+test_envelope_from_initial_reserved();
+test_envelope_segment_map_no_double_count();
+test_envelope_active_exceeds_reserved();
+test_envelope_default_pool_unaffected();
 
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -802,14 +802,6 @@ function annotate_snapshot(snapshot) {
     }
   }
   snapshot.device_traces = new_traces;
-  // if every event was on the default stream, we elide stream printing
-  if (next_stream == 1) {
-    for (const device_trace of snapshot.device_traces) {
-      for (const t of device_trace) {
-        t.stream = null;
-      }
-    }
-  }
 
   for (const seg of snapshot.segments) {
     seg.stream = stream_name(seg.stream);
@@ -908,7 +900,10 @@ function MemoryPlot(
     .append('polygon')
     .attr('points', format_points)
     .attr('fill', d => colors[d.color % colors.length])
-    .attr('opacity', d => d.opacity ?? 1);
+    .attr('opacity', d => d.opacity ?? 1)
+    .attr('stroke', d => typeof d.elem === 'string' && d.elem.startsWith('pool:') ? 'black' : null)
+    .attr('stroke-width', d => typeof d.elem === 'string' && d.elem.startsWith('pool:') ? 3 : null)
+    .attr('vector-effect', d => typeof d.elem === 'string' && d.elem.startsWith('pool:') ? 'non-scaling-stroke' : null);
 
   const axis = plot_coordinate_space.append('g').call(yaxis);
 
@@ -993,7 +988,13 @@ function ContextViewer(text, data) {
     default_selected: null,
     set_selected: d => {
       if (current_selected !== null) {
-        current_selected.attr('stroke', null).attr('stroke-width', null).attr('stroke-dasharray', null);
+        const prev = current_selected.datum();
+        const is_pool = prev && typeof prev.elem === 'string' && prev.elem.startsWith('pool:');
+        current_selected
+          .attr('stroke', is_pool ? 'black' : null)
+          .attr('stroke-width', is_pool ? 3 : null)
+          .attr('stroke-dasharray', null)
+          .attr('vector-effect', is_pool ? 'non-scaling-stroke' : null);
         restore_search_highlight(current_selected);
       }
       if (d === null) {
@@ -1012,8 +1013,9 @@ function ContextViewer(text, data) {
         } else {
           text.text(`${dd.elem} ${data.context_for_id(dd.elem)}`);
         }
+        const is_pool_sel = typeof dd.elem === 'string' && dd.elem.startsWith('pool:');
         d.attr('stroke', 'black')
-          .attr('stroke-width', 1)
+          .attr('stroke-width', is_pool_sel ? 5 : 1)
           .attr('vector-effect', 'non-scaling-stroke');
       }
       current_selected = d;

--- a/torch/utils/viz/process_alloc_data.js
+++ b/torch/utils/viz/process_alloc_data.js
@@ -644,6 +644,18 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
     }
   }
 
+  // Shift all elements stacked above a pool envelope by delta (no animation).
+  // Used during timestep-0 initialization when there are no transition frames.
+  function shift_above_pool_no_anim(pool_key, delta) {
+    const pidx = current.indexOf(`pool:${pool_key}`);
+    if (pidx >= 0) {
+      for (let j = pidx + 1; j < current.length; j++) {
+        const e = current_data[j];
+        e.offsets[e.offsets.length - 1] += delta;
+      }
+    }
+  }
+
   // Grow a pool envelope to accommodate new_size bytes (the larger of active
   // allocations and reserved segment memory). The envelope only grows (never
   // shrinks) — it represents the pool's actual GPU memory footprint.
@@ -667,16 +679,28 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
   }
 
   // --- Process initially_allocated elements ---
-  // Private pool blocks are pre-loaded into pool state at timestep 0 (no
-  // animation) so that their envelope starts at the correct initial size
-  // and free events are correctly recognized as frees.
+  // These are blocks that existed before the trace window started. They come
+  // from two sources:
+  //   1. Unmatched free events (free_completed without a prior alloc in trace)
+  //   2. active_allocated blocks in the segment snapshot with no trace event
+  //
+  // For private pool blocks: pre-load into pool state at timestep 0 (no
+  // animation). This serves two purposes:
+  //   - The envelope starts at the correct initial size
+  //   - When the free event fires during replay, it's recognized as a free
+  //     (not misinterpreted as a new allocation)
+  //
+  // For non-pool blocks: added to the global stack (draw_elem) or global
+  // summarized band.
   for (const elem of initially_allocated) {
     if (include_private_inactive && get_pool_key(elem)) {
       const pk = get_pool_key(elem);
       const size = elements[elem].size;
       const pool = get_or_create_pool(pk);
+      // Mark as active so the replay loop recognizes the free event
       pool_active_elems[elem] = pk;
 
+      // Create pool envelope on first encounter
       if (pool.envelope_data === null) {
         const env = {
           elem: `pool:${pk}`,
@@ -686,6 +710,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
           color: 9,
         };
         pool.envelope_data = env;
+        // Add to the global stack so elements above it shift when it grows
         current.push(`pool:${pk}`);
         current_data.push(env);
         data.push(env);
@@ -694,7 +719,9 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
       const inner_offset = pool.active;
       pool.active += size;
 
-      // Grow envelope directly without animation — these blocks pre-exist
+      // Grow envelope to fit: use max(active, reserved) because active can
+      // exceed reserved when block sizes are stale (e.g. segment shrank via
+      // unmap after the block was allocated).
       const init_target = Math.max(pool.active, pool.reserved);
       if (init_target > pool.max) {
         const delta = init_target - pool.max;
@@ -702,15 +729,11 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
         const env = pool.envelope_data;
         env.size[env.size.length - 1] = pool.max;
         total_mem += delta;
-        const pidx = current.indexOf(`pool:${pk}`);
-        if (pidx >= 0) {
-          for (let j = pidx + 1; j < current.length; j++) {
-            const e = current_data[j];
-            e.offsets[e.offsets.length - 1] += delta;
-          }
-        }
+        // Shift all elements stacked above this pool's envelope up by delta
+        shift_above_pool_no_anim(pk, delta);
       }
 
+      // Create a colored stripe inside the envelope for this block
       const stripe = {
         elem,
         timesteps: [0],
@@ -724,6 +747,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
       data.push(stripe);
       continue;
     }
+    // Non-pool element: render individually or add to global summarized band
     if (elem in draw_elem) {
       add_allocation(elem);
     } else {
@@ -786,13 +810,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
         const env = pool.envelope_data;
         env.size[env.size.length - 1] = pool.max;
         total_mem += delta;
-        const pidx = current.indexOf(`pool:${pk}`);
-        if (pidx >= 0) {
-          for (let j = pidx + 1; j < current.length; j++) {
-            const e = current_data[j];
-            e.offsets[e.offsets.length - 1] += delta;
-          }
-        }
+        shift_above_pool_no_anim(pk, delta);
       }
     }
     // Fix up pool stripe offsets again after reserved-based envelope growth

--- a/torch/utils/viz/process_alloc_data.js
+++ b/torch/utils/viz/process_alloc_data.js
@@ -408,6 +408,11 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
   const [free, free_completed] = plot_segments
     ? ['segment_free', 'segment_free']
     : ['free', 'free_completed'];
+  // pool_segment_events tracks segment_map/segment_unmap events for private
+  // pools, recording their position relative to the actions list. This lets
+  // the Phase 3 replay grow pool envelopes based on actual reserved memory
+  // (segments) rather than just active allocations.
+  const pool_segment_events = [];
   for (const e of snapshot.device_traces[device]) {
     switch (e.action) {
       case alloc:
@@ -432,6 +437,19 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
         break;
       default:
         break;
+    }
+    if (include_private_inactive &&
+        (e.action === 'segment_alloc' || e.action === 'segment_free' ||
+         e.action === 'segment_map' || e.action === 'segment_unmap')) {
+      const pid = find_pool_id(e.addr);
+      if (isPrivatePoolId(pid)) {
+        const is_add = e.action === 'segment_alloc' || e.action === 'segment_map';
+        pool_segment_events.push({
+          position: actions.length,
+          delta: is_add ? e.size : -e.size,
+          pool_key: format_pool_key(pid, e.stream ?? 0),
+        });
+      }
     }
   }
 
@@ -560,17 +578,20 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
   const pools = {};
   const pool_active_elems = {};
 
+  function format_pool_key(pid, stream) {
+    return `${pid[0]},${pid[1]},s${stream}`;
+  }
+
   function get_pool_key(elem_idx) {
     const pid = elements[elem_idx].segment_pool_id;
     if (!isPrivatePoolId(pid)) return null;
-    const stream = elements[elem_idx].stream;
-    return `${pid[0]},${pid[1]},s${stream}`;
+    return format_pool_key(pid, elements[elem_idx].stream);
   }
 
   function get_or_create_pool(pool_key) {
     if (!(pool_key in pools)) {
       pools[pool_key] = {
-        max: 0, active: 0, envelope_data: null,
+        max: 0, active: 0, reserved: 0, envelope_data: null,
         block_stack: [],  // [{elem, size, inner_offset, stripe_data}]
       };
     }
@@ -615,12 +636,13 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
     }
   }
 
-  // Grow a pool envelope to accommodate new_active bytes.
-  // The envelope only grows (never shrinks) — it represents reserved capacity.
-  function grow_pool_envelope(pool, pool_key, new_active) {
-    if (new_active <= pool.max) return;
-    const delta = new_active - pool.max;
-    pool.max = new_active;
+  // Grow a pool envelope to accommodate new_size bytes (the larger of active
+  // allocations and reserved segment memory). The envelope only grows (never
+  // shrinks) — it represents the pool's actual GPU memory footprint.
+  function grow_pool_envelope(pool, pool_key, new_size) {
+    if (new_size <= pool.max) return;
+    const delta = new_size - pool.max;
+    pool.max = new_size;
     const env = pool.envelope_data;
     env.timesteps.push(timestep);
     env.offsets.push(env.offsets.at(-1));
@@ -665,9 +687,10 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
       pool.active += size;
 
       // Grow envelope directly without animation — these blocks pre-exist
-      if (pool.active > pool.max) {
-        const delta = pool.active - pool.max;
-        pool.max = pool.active;
+      const init_target = Math.max(pool.active, pool.reserved);
+      if (init_target > pool.max) {
+        const delta = init_target - pool.max;
+        pool.max = init_target;
         const env = pool.envelope_data;
         env.size[env.size.length - 1] = pool.max;
         total_mem += delta;
@@ -716,8 +739,72 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
     }
   }
 
+  // --- Initialize pool reserved memory from snapshot ---
+  // reserved = snapshot_total - net_trace_delta, so that replaying segment
+  // events from the trace brings it to the correct final value.
+  if (include_private_inactive) {
+    const snapshot_reserved = {};
+    for (const seg of device_segments) {
+      const pid = seg.segment_pool_id;
+      if (isPrivatePoolId(pid)) {
+        const pk = format_pool_key(pid, seg.stream ?? 0);
+        snapshot_reserved[pk] = (snapshot_reserved[pk] || 0) + seg.total_size;
+      }
+    }
+    const net_from_trace = {};
+    for (const se of pool_segment_events) {
+      net_from_trace[se.pool_key] = (net_from_trace[se.pool_key] || 0) + se.delta;
+    }
+    for (const pk in snapshot_reserved) {
+      const pool = get_or_create_pool(pk);
+      pool.reserved = snapshot_reserved[pk] - (net_from_trace[pk] || 0);
+      // Grow envelope to initial reserved (no animation — pre-existing)
+      if (pool.reserved > pool.max && pool.envelope_data) {
+        const delta = pool.reserved - pool.max;
+        pool.max = pool.reserved;
+        const env = pool.envelope_data;
+        env.size[env.size.length - 1] = pool.max;
+        total_mem += delta;
+        const pidx = current.indexOf(`pool:${pk}`);
+        if (pidx >= 0) {
+          for (let j = pidx + 1; j < current.length; j++) {
+            const e = current_data[j];
+            e.offsets[e.offsets.length - 1] += delta;
+          }
+        }
+      }
+    }
+    // Fix up pool stripe offsets again after reserved-based envelope growth
+    for (const pk in pools) {
+      const p = pools[pk];
+      if (!p.envelope_data) continue;
+      const env_offset = p.envelope_data.offsets.at(-1);
+      for (const block of p.block_stack) {
+        const s = block.stripe_data;
+        for (let i = 0; i < s.offsets.length; i++) {
+          s.offsets[i] = env_offset + block.inner_offset;
+        }
+      }
+    }
+  }
+
   // --- Replay alloc/free actions to build the timeline ---
-  for (const elem of actions) {
+  let seg_event_idx = 0;
+  for (let action_i = 0; action_i < actions.length; action_i++) {
+    // Process segment events that occurred at or before this action position.
+    // These grow pool envelopes based on actual reserved memory changes.
+    while (seg_event_idx < pool_segment_events.length &&
+           pool_segment_events[seg_event_idx].position <= action_i) {
+      const se = pool_segment_events[seg_event_idx];
+      const pool = get_or_create_pool(se.pool_key);
+      pool.reserved += se.delta;
+      if (pool.reserved > pool.max && pool.envelope_data) {
+        grow_pool_envelope(pool, se.pool_key, pool.reserved);
+      }
+      seg_event_idx++;
+    }
+
+    const elem = actions[action_i];
     const size = elements[elem].size;
     const pool_key = include_private_inactive ? get_pool_key(elem) : null;
 
@@ -745,8 +832,9 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
         const inner_offset = pool.active;
         pool.active += size;
 
-        if (pool.active > pool.max) {
-          grow_pool_envelope(pool, pool_key, pool.active);
+        const envelope_target = Math.max(pool.active, pool.reserved);
+        if (envelope_target > pool.max) {
+          grow_pool_envelope(pool, pool_key, envelope_target);
         }
 
         const stripe = {
@@ -832,6 +920,18 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
       total_mem -= size;
     }
     max_size = Math.max(total_mem + total_summarized_mem, max_size);
+  }
+
+  // Process any remaining segment events after the last action
+  while (seg_event_idx < pool_segment_events.length) {
+    const se = pool_segment_events[seg_event_idx];
+    const pool = get_or_create_pool(se.pool_key);
+    pool.reserved += se.delta;
+    if (pool.reserved > pool.max && pool.envelope_data) {
+      grow_pool_envelope(pool, se.pool_key, pool.reserved);
+    }
+    max_size = Math.max(total_mem + total_summarized_mem, max_size);
+    seg_event_idx++;
   }
 
   // --- Finalize: close all still-active elements ---

--- a/torch/utils/viz/process_alloc_data.js
+++ b/torch/utils/viz/process_alloc_data.js
@@ -55,8 +55,12 @@
 //
 //   Block-level views ("Active Memory Timeline", "Allocated Memory (incl. Private Pools)"):
 //     - process_alloc_data matches "alloc" and "free_completed" from device_traces.
-//     - segment_alloc/segment_free/segment_map/segment_unmap are ignored (skipped in switch).
-//     - The segments snapshot is used only to resolve pool_id via find_pool_id().
+//     - segment_alloc/segment_free/segment_map/segment_unmap are skipped in the main
+//       alloc/free switch, but when include_private_inactive=true, segment events for
+//       private pools are captured separately (pool_segment_events) and used to drive
+//       pool envelope sizing based on reserved memory rather than active allocations.
+//     - The segments snapshot is used to resolve pool_id via find_pool_id() and to
+//       compute initial reserved memory per pool for envelope sizing.
 //
 //   Segment-level view ("Active Cached Segment Timeline"):
 //     - process_alloc_data is called with plot_segments=true.
@@ -320,9 +324,13 @@ function format_frames(frames) {
  *
  * 5. PRIVATE POOL ENVELOPES (include_private_inactive=true): Each private pool
  *    (e.g. FSDP's MemPool) gets a single gray "envelope" rectangle whose
- *    height is the pool's high-water mark. Active blocks within the pool are
+ *    height is the pool's reserved memory (from segment_map/segment_unmap
+ *    events and the segment snapshot). Active blocks within the pool are
  *    rendered as colored stripes inside the envelope. The envelope only grows
- *    (never shrinks), representing reserved capacity.
+ *    (never shrinks), representing the pool's actual GPU memory footprint.
+ *    This correctly handles fragmentation: when a large alloc triggers a
+ *    segment_map because existing free blocks aren't contiguous, the envelope
+ *    grows by the reserved amount, not just the active allocation.
  *
  *    Initially-allocated private pool blocks are PRE-LOADED into pool state
  *    so that when their free event appears in the trace, they are correctly
@@ -740,8 +748,21 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
   }
 
   // --- Initialize pool reserved memory from snapshot ---
-  // reserved = snapshot_total - net_trace_delta, so that replaying segment
-  // events from the trace brings it to the correct final value.
+  // The envelope height for each private pool should reflect its reserved
+  // (segment) memory, not just active allocations. We compute the initial
+  // reserved value so that replaying segment_map/segment_unmap events from
+  // the trace arrives at the correct final value (the snapshot total).
+  //
+  // Formula: initial = snapshot_total - net_trace_delta
+  //   - snapshot_total: sum of segment total_size for this pool (ground truth
+  //     at snapshot time)
+  //   - net_trace_delta: sum of segment_map sizes minus segment_unmap sizes
+  //     for this pool in the trace
+  //
+  // This works regardless of trace truncation (ring buffer overflow): the
+  // initial value represents the reserved memory at the start of the trace
+  // window, not at program start. If there are no segment events in the
+  // trace for a pool, net_trace_delta is 0 and initial = snapshot_total.
   if (include_private_inactive) {
     const snapshot_reserved = {};
     for (const seg of device_segments) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #180920
* #180613
* __->__ #180515



### Summary

The "Allocated Memory (incl. Private Pools)" tab shows private memory pools
as gray envelopes. Previously, envelope height was driven by peak active
allocations. This is incorrect when fragmentation causes the allocator to
map new physical pages (segment_map) even though the pool has enough total
free space — the pool's actual GPU footprint (reserved memory) is larger
than its active allocations.

This PR changes envelope height to reflect reserved memory from segment
events, correctly showing the pool's true GPU memory consumption.

### Changes

**process_alloc_data.js:**
- Capture `segment_map`/`segment_unmap` events for private pools during
  Phase 1 (alongside the alloc/free action list)
- Before Phase 3 replay, compute initial reserved per pool from
  `snapshot_total - net_trace_delta` (works regardless of ring buffer
  truncation)
- During replay, interleave segment events to grow pool envelopes based on
  `max(pool.active, pool.reserved)` instead of just `pool.active`
- Extract `format_pool_key()` helper shared by `get_pool_key` and segment
  event tracking
- Update top-level and function docstrings

**MemoryViz.js:**
- Add 3px black border on pool envelope polygons (always visible)
- 5px border when hovered/selected
- Restore envelope border after deselection (instead of clearing to null)
- Remove stream-elision logic that set streams to null (caused "snull" in
  pool keys)

**Tests (test_memory_viz.js):**
- `test_envelope_grows_on_segment_map`: segment_map drives envelope to 900,
  not peak active 500. Verifies stripes inside remain at their individual sizes.
- `test_envelope_from_initial_reserved`: no segment events in trace, envelope
  sized by snapshot reserved
- `test_envelope_segment_map_no_double_count`: trace + snapshot don't
  double-count
- `test_envelope_active_exceeds_reserved`: envelope uses the larger of active
  and reserved
- `test_envelope_default_pool_unaffected`: default pool (0,0) never gets
  envelope treatment
- Updated existing pool tests to assert against new reserved-based envelope
  sizes

Authored with Claude.



link in internal Diff: https://www.internalfb.com/diff/D101274313

