### PR TITLE
[ROCm] Fix evaluate_platform_supports_fp8 false-positive

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -178,6 +178,7 @@ def evaluate_platform_supports_fp8():
             for arch in archs:
                 if arch in torch.cuda.get_device_properties(0).gcnArchName:
                     return True
+            return False
         else:
             return SM90OrLater or torch.cuda.get_device_capability() == (8, 9)
     if torch.xpu.is_available():


### PR DESCRIPTION
On ROCm, evaluate_platform_supports_fp8() did not return False when the device architecture did not match any supported FP8 GPU, causing the function to fall through and report support unconditionally.

Add an explicit False return when no supported ROCm architecture is matched, ensuring correct FP8 capability detection on unsupported devices.

Fixes #179960
Fixes #179949

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang