### PR TITLE
Add thread_time_ns and idle_pct to dynamo_timed chromium events (#180527)

### DIFF
--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -791,6 +791,7 @@ def dynamo_timed(
 
     chromium_log: ChromiumEventLogger = get_chromium_event_logger()
     start_ns = time.time_ns()
+    start_thread_ns = time.thread_time_ns()
     chromium_log.log_event_start(
         event_name, start_ns, event_metadata, log_pt2_compile_event, compile_id
     )
@@ -826,9 +827,20 @@ def dynamo_timed(
     finally:
         end_ns = time.time_ns()
         time_spent_ns = end_ns - start_ns
+        thread_time_spent_ns = time.thread_time_ns() - start_thread_ns
         metrics.append(time_spent_ns / 1e9)
+        idle_pct = (
+            round((1 - thread_time_spent_ns / time_spent_ns) * 100, 1)
+            if time_spent_ns > 0
+            else 0
+        )
         chromium_log.log_event_end(
-            event_name, end_ns, {}, start_ns, log_pt2_compile_event, compile_id
+            event_name,
+            end_ns,
+            {"thread_time_ns": thread_time_spent_ns, "idle_pct": idle_pct},
+            start_ns,
+            log_pt2_compile_event,
+            compile_id,
         )
         if dynamo_compile_column_us:
             # TODO: the events that we capture in calculate_time_spent() seem a little


### PR DESCRIPTION
Summary:

Track CPU thread time alongside wall time in every `dynamo_timed` span.
This enables identifying compilation phases where the CPU is idle
(e.g., waiting on GPU synchronization, blocked on syscalls like munmap,
or waiting on subprocess compilation workers).

Two new fields are added to every chromium event's args:
- `thread_time_ns`: CPU thread time in nanoseconds (consistent with existing ns units in the trace)
- `idle_pct`: percentage of wall time the CPU was idle (wall_time - thread_time) / wall_time

Example usage: open the tlparse chromium trace, find a `dynamo_timed` span,
and check `idle_pct` in the args to see if that phase is CPU-bound or I/O-bound.

Example tlparse output with these changes:
https://manifold.edge.x2p.facebook.net/v0/read/tree/logs/faceless_v2_1chunk_cache_full/index.html?bucketName=tlparse_reports&apiKey=tlparse_reports-key&withPayload=1&timeoutMsec=10000

Test Plan:
Ran faceless_v2 inference pipeline with TORCH_TRACE and verified thread_time_ns
and idle_pct appear in the chromium trace for all dynamo_timed spans.

 {F1988329531}

Differential Revision: D99485668




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98