### PR TITLE
[inductor] Add TORCHINDUCTOR_PERSISTENT_AUTOTUNE_DIR for persistent autotune cache (#180529)

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -505,6 +505,7 @@ class TestRecheckAutotuneCache(TestCase):
 
         result = MagicMock(spec=StaticTritonCompileResult)
         result.config = cfg
+        result.runtime_winner = False
         return result
 
     @staticmethod
@@ -538,7 +539,7 @@ class TestRecheckAutotuneCache(TestCase):
 
         with patch(
             "torch._inductor.runtime.triton_heuristics.check_autotune_cache",
-            return_value=([cached_cfg], None, {"autotune_cache_state": "hit"}),
+            return_value=([cached_cfg], None, {"autotune_cache_state": "hit"}, True),
         ):
             autotuner.recheck_autotune_cache(reload_kernel_from_src=MagicMock())
 
@@ -571,7 +572,7 @@ class TestRecheckAutotuneCache(TestCase):
 
         with patch(
             "torch._inductor.runtime.triton_heuristics.check_autotune_cache",
-            return_value=([cached_cfg], None, {"autotune_cache_state": "hit"}),
+            return_value=([cached_cfg], None, {"autotune_cache_state": "hit"}, True),
         ):
             autotuner.recheck_autotune_cache(reload_kernel_from_src=MagicMock())
 
@@ -597,7 +598,7 @@ class TestRecheckAutotuneCache(TestCase):
 
         with patch(
             "torch._inductor.runtime.triton_heuristics.check_autotune_cache",
-            return_value=([cached_cfg], None, {"autotune_cache_state": "hit"}),
+            return_value=([cached_cfg], None, {"autotune_cache_state": "hit"}, True),
         ):
             autotuner.recheck_autotune_cache(reload_kernel_from_src=MagicMock())
 
@@ -621,7 +622,7 @@ class TestRecheckAutotuneCache(TestCase):
         # Cache returns no hit (empty list)
         with patch(
             "torch._inductor.runtime.triton_heuristics.check_autotune_cache",
-            return_value=([], None, {"autotune_cache_state": "miss"}),
+            return_value=([], None, {"autotune_cache_state": "miss"}, False),
         ):
             autotuner.recheck_autotune_cache(reload_kernel_from_src=MagicMock())
 

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -325,7 +325,11 @@ class TuningProcessPool:
         """
         assert choice.bmreq is not None
 
-        env_vars = ["TORCHINDUCTOR_CACHE_DIR", "TRITON_CACHE_DIR"]
+        env_vars = [
+            "TORCHINDUCTOR_CACHE_DIR",
+            "TRITON_CACHE_DIR",
+            "TORCHINDUCTOR_PERSISTENT_AUTOTUNE_DIR",
+        ]
         extra_env = {v: os.environ[v] for v in env_vars if v in os.environ}
         process = self.process_queue.get()
         process.put(choice.bmreq.benchmark, extra_env=extra_env)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -228,7 +228,10 @@ class CacheBase:
     @clear_on_fresh_cache
     @functools.cache
     def get_local_cache_path() -> Path:
-        return Path(os.path.join(cache_dir(), "cache", CacheBase.get_system()["hash"]))
+        root = config.persistent_autotune_dir or cache_dir()
+        if config.persistent_autotune_dir:  # user-managed local cache
+            return Path(os.path.join(root, "cache"))
+        return Path(os.path.join(root, "cache", CacheBase.get_system()["hash"]))
 
     def __init__(self) -> None:
         self.system = CacheBase.get_system()
@@ -315,7 +318,10 @@ class PersistentCache(CacheBase):
                     break
             return hit
 
-        local_cache = self.get_local_cache() if config.autotune_local_cache else {}
+        cache_enabled = config.autotune_local_cache or bool(
+            config.persistent_autotune_dir
+        )
+        local_cache = self.get_local_cache() if cache_enabled else {}
         if (not check_cache(local_cache)) and (benchmark is not None):
             # re-benchmark everything to try to get consistent numbers from the same machine
             timings = benchmark(choices)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6644,7 +6644,7 @@ class TritonScheduling(SIMDScheduling):
     def benchmark_codegened_module(
         self, mod, n_spills_threshold=8, node_names: OrderedSet[str] | None = None
     ) -> tuple[float, str]:
-        """Benchmark an already compiled module"""
+        """Benchmark a compiled module to measure epilogue fusion speedup."""
         device_interface = get_interface_for_device(V.graph.device_type)
         with (
             preserve_rng_state(),
@@ -6654,6 +6654,16 @@ class TritonScheduling(SIMDScheduling):
 
             def cache_file_path():
                 assert mod.__file__ is not None
+                override_dir = config.persistent_autotune_dir
+                if override_dir:
+                    from torch._inductor.runtime.autotune_cache import (
+                        _name_agnostic_source_hash_from_file,
+                    )
+
+                    basename = _name_agnostic_source_hash_from_file(mod.__file__)
+                    perf_dir = os.path.join(override_dir, "kernel_perf")
+                    os.makedirs(perf_dir, exist_ok=True)
+                    return os.path.join(perf_dir, basename + ".kernel_perf")
                 return os.path.splitext(mod.__file__)[0] + ".kernel_perf"
 
             def store_cache():

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -165,6 +165,17 @@ bundled_autotune_remote_cache: bool | None = bundled_autotune_remote_cache_defau
 # See torch.compiler.config.force_disable_caches
 force_disable_caches: bool = Config(alias="torch.compiler.config.force_disable_caches")
 
+# Directory for persistent autotune cache that survives across code changes
+# and process restarts. When set, autotune results are stored in this directory
+# using name-agnostic keys (based on kernel body, not filename), making the cache
+# stable across kernel renumbering and code changes. Works even when
+# force_disable_caches=True (local autotune cache is enabled, remote stays disabled).
+# Also redirects template selection (PersistentCache) and fusion benchmark
+# (kernel_perf) caches to this directory.
+persistent_autotune_dir: str = os.environ.get(
+    "TORCHINDUCTOR_PERSISTENT_AUTOTUNE_DIR", ""
+)
+
 # Unsafe way to skip dynamic shape guards to get faster cache load
 unsafe_skip_cache_dynamic_shape_guards: bool = False
 

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -112,8 +112,34 @@ class AutotuneCacheArtifact(CacheArtifact):
         return content_bytes
 
 
+_TRITON_NAME_RE = re.compile(r"^def [^(]+\(", re.MULTILINE)
+
+
+def _name_agnostic_source_hash(source: str) -> str:
+    """Hash kernel source with function name stripped, so that kernel
+    renumbering (from model changes or fusion decision changes) doesn't
+    change the cache key.  Same regex as generate_lookup_hash_from_source_code
+    used by the LUT."""
+    source_stripped = _TRITON_NAME_RE.sub("(", source.strip(), count=1)
+    return hashlib.sha256(source_stripped.encode("utf-8")).hexdigest()
+
+
+def _name_agnostic_source_hash_from_file(filename: str) -> str:
+    """Fallback: read entire file and hash with function name stripped.
+    Less stable than fn.src (includes decorator metadata) but better than
+    the raw filename hash."""
+    try:
+        with open(filename) as f:
+            source = f.read()
+        return _name_agnostic_source_hash(source)
+    except OSError:
+        return os.path.basename(filename)
+
+
 @dataclasses.dataclass
 class AutotuneCache:
+    """Cache for storing and retrieving the best triton kernel autotuning configs."""
+
     configs_hash: str
     local_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
     remote_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
@@ -121,24 +147,47 @@ class AutotuneCache:
     # Create a AutotuneCache. Returns None if none of the caches can be used.
     @staticmethod
     def create(
-        inductor_meta: _InductorMetaTy, filename: str, configs_hash: str
+        inductor_meta: _InductorMetaTy,
+        filename: str,
+        configs_hash: str,
+        fn_src: str | None = None,
+        local_enabled: bool = True,
+        remote_enabled: bool = True,
     ) -> AutotuneCache | None:
         cache = AutotuneCache(configs_hash)
-        key = AutotuneCache._prepare_key(filename)
+        key = AutotuneCache._prepare_key(filename, fn_src, configs_hash)
 
-        cache._setup_local_cache(inductor_meta, os.path.dirname(filename), key)
-        cache._setup_remote_autotune_cache(inductor_meta, key)
+        if local_enabled:
+            cache._setup_local_cache(inductor_meta, os.path.dirname(filename), key)
+        if remote_enabled:
+            cache._setup_remote_autotune_cache(inductor_meta, key)
         if cache.local_cache or cache.remote_cache:
             return cache
         else:
             return None
 
     @staticmethod
-    def _prepare_key(filename: str) -> str:
+    def _prepare_key(
+        filename: str, fn_src: str | None = None, configs_hash: str | None = None
+    ) -> str:
+        from torch._inductor.config import persistent_autotune_dir
         from torch.compiler import config as cconfig
 
-        # base of filename is already sha256 hash the source contents
-        key = f"{os.path.basename(filename)}:{cconfig.cache_key_tag}"
+        if persistent_autotune_dir:
+            # Use fn.src (kernel body only) with function name stripped.
+            # Stable across kernel renumbering, model changes, and decorator
+            # metadata changes — only the actual computation matters.
+            assert fn_src is not None, (
+                "fn_src is required for persistent_autotune_dir cache keys"
+            )
+            key = _name_agnostic_source_hash(fn_src)
+            # Include configs_hash so different config sets get separate files
+            if configs_hash:
+                key = f"{key}:{configs_hash}"
+        else:
+            # Default: base of filename is already sha256 hash of source contents
+            key = os.path.basename(filename)
+        key = f"{key}:{cconfig.cache_key_tag}"
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
     # Read the best config options from the most local cache and return it.
@@ -186,8 +235,18 @@ class AutotuneCache:
         """
         hasher = hashlib.sha256()
         hasher.update(cache_key.encode("utf-8"))
-        hasher.update(torch_key())
+        from torch._inductor.config import persistent_autotune_dir
+
+        # Skip torch_key() when using persistent dir so code changes don't invalidate cache
+        if not persistent_autotune_dir:
+            hasher.update(torch_key())
         updated_cache_key = hasher.hexdigest()
+
+        # Use stable directory if persistent_autotune_dir is set,
+        # instead of the per-process temp dir where kernel files live
+        if persistent_autotune_dir:
+            os.makedirs(persistent_autotune_dir, exist_ok=True)
+            dirname = persistent_autotune_dir
 
         cache_filename = f"{dirname}/{updated_cache_key}.best_config"
         local_cache = LocalAutotuneCache()

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -273,23 +273,43 @@ def _dump_launch_tensors(args, kernel_path, kernel_hash, kernel_name):
 
 
 def check_autotune_cache(
-    configs: list[Config], filename: str | None, inductor_meta: dict[str, Any]
-) -> tuple[list[Config], AutotuneCache | None, dict[str, Any]]:
+    configs: list[Config],
+    filename: str | None,
+    fn_src: str | None,
+    inductor_meta: dict[str, Any],
+) -> tuple[list[Config], AutotuneCache | None, dict[str, Any], bool]:
     """
-    Given a list of configs, checks autotune cache and return metadata
+    Given a list of configs, checks autotune cache and return metadata.
+    fn_src is the kernel body source (from fn.src) used for stable cache keys.
+    Returns (configs, autotune_cache, autotune_cache_info, cache_hit).
     """
     autotune_cache = None
     autotune_cache_info = {}
-    disabled = inductor_meta.get("force_disable_caches", False)
+    cache_hit = False
+    force_disabled = inductor_meta.get("force_disable_caches", False)
+    from torch._inductor.config import persistent_autotune_dir
+
+    local_enabled = not force_disabled or bool(persistent_autotune_dir)
+    remote_enabled = not force_disabled
+
+    n_configs = len(configs)
+
     if (
-        not disabled
+        (local_enabled or remote_enabled)
         and filename is not None
-        and (len(configs) > 1 or inductor_meta.get("coordinate_descent_tuning"))
+        and (n_configs > 1 or inductor_meta.get("coordinate_descent_tuning"))
         and os.environ.get("TRITON_INTERPRET", "0") != "1"
     ):
         configs_hash = hash_configs(configs)
 
-        autotune_cache = AutotuneCache.create(inductor_meta, filename, configs_hash)
+        autotune_cache = AutotuneCache.create(
+            inductor_meta,
+            filename,
+            configs_hash,
+            fn_src=fn_src,
+            local_enabled=local_enabled,
+            remote_enabled=remote_enabled,
+        )
         if autotune_cache:
             if best_config := autotune_cache.read_best(inductor_meta, configs):
                 configs = [best_config]
@@ -297,6 +317,7 @@ def check_autotune_cache(
                     best_config
                 )
                 autotune_cache_info["autotune_cache_state"] = "hit"
+                cache_hit = True
 
             else:
                 autotune_cache_info["autotune_cache_state"] = "miss"
@@ -314,11 +335,11 @@ def check_autotune_cache(
             autotune_cache_info["autotune_cache_state"] = "only 1 config"
             autotune_cache_info["only_config"] = triton_config_to_hashable(configs[0])
 
-        if disabled:
+        if not local_enabled and not remote_enabled:
             autotune_cache_info["autotune_cache_state"] = "force_disabled"
             log.debug("autotune caching is disabled by config.force_disable_caches")
 
-    return configs, autotune_cache, autotune_cache_info
+    return configs, autotune_cache, autotune_cache_info, cache_hit
 
 
 class CachingAutotuner(KernelInterface):
@@ -344,6 +365,7 @@ class CachingAutotuner(KernelInterface):
         filename: str | None = None,
         reset_to_zero_arg_names: list[str] | None = None,
         autotune_cache_info: dict[str, Any] | None = None,
+        cache_hit: bool = False,
     ):
         super().__init__()
 
@@ -380,6 +402,7 @@ class CachingAutotuner(KernelInterface):
         self.custom_kernel = custom_kernel
         self.cuda_kernel_saved = False
         self.autotune_cache_info = autotune_cache_info
+        self.cache_hit = cache_hit
         if log.isEnabledFor(logging.DEBUG):
             log.debug(
                 "CachingAutotuner gets %d configs for %s",
@@ -466,33 +489,37 @@ class CachingAutotuner(KernelInterface):
         """
         assert self.is_statically_launchable()
 
+        # If the compile result is already marked as the runtime winner,
+        # all tuning was done in a previous run — skip recheck entirely.
+        if len(self.compile_results) == 1 and self.compile_results[0].runtime_winner:
+            return
+
         configs = [result.config for result in self.compile_results]
 
-        (cached_configs, _, autotune_cache_info) = check_autotune_cache(
-            configs, self.filename, self.inductor_meta
+        fn_src = getattr(self.fn, "src", None)
+        (cached_configs, _, autotune_cache_info, cache_hit) = check_autotune_cache(
+            configs, self.filename, fn_src, self.inductor_meta
         )
         self.autotune_cache_info = autotune_cache_info
-        # I.e. there was an autotune cache hit
-        if len(cached_configs) == 1:
+        if cache_hit:
             best_config = cached_configs[0]
             found_by_coordesc = getattr(best_config, "found_by_coordesc", False)
-            # Grab the best compiled config, if it's in the list of available ones
             best_config_hash = triton_config_to_hashable(best_config)
 
             for compile_result in self.compile_results:
                 if triton_config_to_hashable(compile_result.config) == best_config_hash:
                     compile_result.config.found_by_coordesc = found_by_coordesc
+                    compile_result.runtime_winner = True
                     self.compile_results = [compile_result]
                     return
 
-            # If the best config isn't in our list of compile results,
-            # it's likely because it was found by coordesc after the cache
-            # already saved
             if found_by_coordesc:
                 with dynamo_timed("CachingAutotuner.slow_precompile_config"):
                     if self.fn.fn is None:
                         self.fn = reload_kernel_from_src().fn
-                    self.compile_results = [self._precompile_config(best_config)]
+                    result = self._precompile_config(best_config)
+                    result.runtime_winner = True
+                    self.compile_results = [result]
 
     def set_compile_info(self, compile_id: CompileId | None, is_backward: bool) -> None:
         self.compile_id = compile_id
@@ -518,7 +545,15 @@ class CachingAutotuner(KernelInterface):
             if static_triton_bundle_key is not None and self.is_statically_launchable():
                 TritonBundler.put_static_autotuner(static_triton_bundle_key, self)
             self._make_launchers()
-            self._dynamic_scale_rblock()
+            # If the single compile result is a runtime winner from a previous
+            # run, skip _dynamic_scale_rblock — all tuning was already done.
+            is_runtime_winner = len(self.compile_results) == 1 and getattr(
+                self.compile_results[0], "runtime_winner", False
+            )
+            if is_runtime_winner and self.launchers:
+                self.launchers[0].config.found_by_coordesc = True
+            else:
+                self._dynamic_scale_rblock()
 
     def _precompile_worker(self):
         if self.compile_results:
@@ -544,6 +579,8 @@ class CachingAutotuner(KernelInterface):
                 f"No valid triton configs. {type(exc).__name__}: {exc}"
             )
         self.compile_results = compile_results
+        if self.cache_hit and len(compile_results) == 1:
+            compile_results[0].runtime_winner = True
         self.configs = None
 
     def _dynamic_scale_rblock(self):
@@ -1879,6 +1916,9 @@ class CompileResult(Generic[_T]):
         self.config = config
         self.compile_meta = compile_meta
         self.inductor_meta = inductor_meta
+        # Set True when this config is the final winner from a previous run
+        # (autotuning + coordesc already done). Skips all tuning on load.
+        self.runtime_winner = False
 
     def make_launcher(self) -> LauncherType: ...
 
@@ -2544,10 +2584,6 @@ def cached_autotune(
     configs = unique_configs(configs)
     assert len(configs) == 1 or filename
     inductor_meta = {} if inductor_meta is None else inductor_meta
-
-    configs, autotune_cache, autotune_cache_info = check_autotune_cache(
-        configs, filename, inductor_meta
-    )
     mutated_arg_names = inductor_meta.pop("mutated_arg_names", ())
     optimize_mem = inductor_meta.pop("optimize_mem", True)
 
@@ -2559,6 +2595,12 @@ def cached_autotune(
         reset_to_zero_arg_names.extend(triton_meta.pop("reset_to_zero"))
 
     def decorator(fn):
+        nonlocal configs
+        # fn.src is available here — use it for name-agnostic cache keys
+        fn_src = getattr(fn, "src", None)
+        configs, autotune_cache, autotune_cache_info, cache_hit = check_autotune_cache(
+            configs, filename, fn_src, inductor_meta
+        )
         # Remove XBLOCK from config if it's not a function argument.
         # This way, coordinate descent tuning will not try to tune it.
         #
@@ -2605,6 +2647,7 @@ def cached_autotune(
             custom_kernel=custom_kernel,
             filename=filename,
             autotune_cache_info=autotune_cache_info,
+            cache_hit=cache_hit,
         )
 
     return decorator

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -4146,6 +4146,15 @@ class AlgorithmSelectorCache(PersistentCache):
                 layout.device.type if layout else "unknown",
             )
 
+        # If the cache already has timings for all choices, skip precompilation,
+        # prescreening, and benchmarking entirely — just return cached timings.
+        # The cache check is cheap (dict lookup, no benchmarking on miss).
+        cached_timings = self.lookup(
+            choices, name, inputs_key, benchmark=None, hint_override=hint_override
+        )
+        if cached_timings and len(cached_timings) == len(choices):
+            return cached_timings
+
         precompile_start_ts = time.time()
 
         if not use_pipelined_autotuning():


### PR DESCRIPTION
Summary:

Adds a new environment variable `TORCHINDUCTOR_PERSISTENT_AUTOTUNE_DIR` that enables a persistent local autotune cache that survives across code changes and process restarts. This is useful when `force_disable_caches=True` disables all inductor caches (FxGraphCache, AOTAutogradCache, autotune cache) to get fresh compilation, but you still want to reuse expensive GPU autotuning results from previous runs.

**Problem**: Each torch.compile warmup spends significant time on GPU autotuning — benchmarking multiple Triton kernel configurations to find the fastest one. With `force_disable_caches=True`, this autotuning work is repeated every run, even when the optimal kernel configs don't change.

**Solution**: When `TORCHINDUCTOR_PERSISTENT_AUTOTUNE_DIR=/path/to/dir` is set:
- The autotune cache is enabled for local reads/writes even when `force_disable_caches=True` (remote cache remains disabled)
- Cache keys use the kernel body source (`fn.src`) with function names stripped, making them stable across kernel renumbering
- Cache keys include `configs_hash` so the same kernel with different config sets (e.g., from different batch sizes) gets separate cache entries
- `torch_key()` is excluded from cache keys so PyTorch code changes during development don't invalidate the cache
- The env var is forwarded to async compile worker subprocesses

**Additional optimizations**:
- `runtime_winner` flag on `CompileResult`: when a kernel loads from cache with a single winning config, marks it as the runtime winner. This skips `_dynamic_scale_rblock` (which would add extra launcher configs) and `coordinate_descent_tuning` in subsequent runs, since all tuning was already done.
- `recheck_autotune_cache` early return: on the FxGraphCache load path, if the compile result is already a runtime winner, skip the cache recheck entirely.
- Template selection cache (`select_algorithm.py`): if `PersistentCache` already has timings for all template choices, skip precompilation, prescreening, and benchmarking entirely.
- Fusion benchmark cache (`codegen/triton.py`): redirect `.kernel_perf` files to a stable directory with name-agnostic keys, preventing epilogue fusion benchmark noise from cascading into cache misses.

**Benchmark results** (Faceless V2 video inference, 5x alternating runs on GB200):
- Warmup wall time: 2040s → 679s (67% reduction)
- Sum of compile times: 1537s → 540s (65% reduction)
- GPU inference latency: zero regression across all batch sizes

https://www.internalfb.com/intern/px/p/9qppf

Test Plan: 5x alternating benchmark (baseline, cached) on devgpu with GB200. Each iteration runs the full Faceless V2 inference pipeline with BS=1,2,3,4 warmup. Verified: zero autotuning or coordinate descent events on cached runs (all cache hits), identical GPU latency, consistent wall time reduction.

Differential Revision: D101011060




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98