### PR TITLE
[7A/11][aoti] Add C-ABI-safe V2 interface for UpdateConstantsMap

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -462,6 +462,25 @@ AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
   })
 }
 
+// C-ABI-safe variant: uses an array of (name, handle) pairs instead of an
+// opaque pointer to std::unordered_map, so the host and DSO can use
+// different C++ standard libraries without ABI conflicts.
+AOTIRuntimeError AOTInductorModelUpdateConstantsMapV2(
+    AOTInductorModelHandle model_handle,
+    const AOTInductorConstantMapEntry* pairs,
+    int32_t num_pairs) {
+  auto model =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto constant_map = std::make_shared<torch::aot_inductor::ConstantMap>();
+    constant_map->reserve(num_pairs);
+    for (int32_t i = 0; i < num_pairs; ++i) {
+      constant_map->emplace(pairs[i].name, pairs[i].handle);
+    }
+    model->update_constants_map(std::move(constant_map));
+  })
+}
+
 AOTIRuntimeError AOTInductorModelContainerGetConstantsBlobSize(
     AOTInductorModelContainerHandle container_handle,
     uint64_t* ret_size) {

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -492,6 +492,25 @@ AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
   })
 }
 
+// C-ABI-safe variant: uses an array of (name, handle) pairs instead of an
+// opaque pointer to std::unordered_map, so the host and DSO can use
+// different C++ standard libraries without ABI conflicts.
+AOTIRuntimeError AOTInductorModelUpdateConstantsMapV2(
+    AOTInductorModelHandle model_handle,
+    const AOTInductorConstantMapEntry* pairs,
+    int32_t num_pairs) {
+  auto model =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+    auto constant_map = std::make_shared<torch::aot_inductor::ConstantMap>();
+    constant_map->reserve(num_pairs);
+    for (int32_t i = 0; i < num_pairs; ++i) {
+      constant_map->emplace(pairs[i].name, pairs[i].handle);
+    }
+    model->update_constants_map(std::move(constant_map));
+  })
+}
+
 AOTIRuntimeError AOTInductorModelContainerGetConstantsBlobSize(
     AOTInductorModelContainerHandle container_handle,
     uint64_t* ret_size) {

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -288,6 +288,15 @@ AOTI_API AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
     AOTInductorModelHandle model_handle,
     AOTInductorConstantMapHandle constant_map_handle);
 
+// C-ABI-safe variant of AOTInductorModelUpdateConstantsMap.
+// Uses an array of (name, handle) pairs instead of an opaque pointer to
+// std::unordered_map, so the host and DSO can use different C++ standard
+// libraries without ABI conflicts.
+AOTI_API AOTIRuntimeError AOTInductorModelUpdateConstantsMapV2(
+    AOTInductorModelHandle model_handle,
+    const AOTInductorConstantMapEntry* pairs,
+    int32_t num_pairs);
+
 // Get the size of the constant blob
 AOTI_API AOTIRuntimeError AOTInductorModelContainerGetConstantsBlobSize(
     AOTInductorModelContainerHandle container_handle,

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -297,6 +297,15 @@ AOTI_API AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
     AOTInductorModelHandle model_handle,
     AOTInductorConstantMapHandle constant_map_handle);
 
+// C-ABI-safe variant of AOTInductorModelUpdateConstantsMap.
+// Uses an array of (name, handle) pairs instead of an opaque pointer to
+// std::unordered_map, so the host and DSO can use different C++ standard
+// libraries without ABI conflicts.
+AOTI_API AOTIRuntimeError AOTInductorModelUpdateConstantsMapV2(
+    AOTInductorModelHandle model_handle,
+    const AOTInductorConstantMapEntry* pairs,
+    int32_t num_pairs);
+
 // Get the size of the constant blob
 AOTI_API AOTIRuntimeError AOTInductorModelContainerGetConstantsBlobSize(
     AOTInductorModelContainerHandle container_handle,


### PR DESCRIPTION
Summary:
The legacy AOTInductorModelUpdateConstantsMap passes an opaque pointer to a std::unordered_map across the DSO boundary, which is not ABI-safe when the host binary and the model DSO are built against different C++ standard libraries.

Add AOTInductorModelUpdateConstantsMapV2, which takes a flat array of AOTInductorConstantMapEntry pairs instead. Pure DSO-additive — V1 is retained, no host caller migration in this diff. The slimdsnn host adoption lives in #7B, gated by JK + ODS for safe ramp.

Test Plan:
```
arc lint fbcode/accelerators/workloads/models/slimdsnn/dso_model.cpp fbcode/accelerators/workloads/models/slimdsnn/dso_model.h fbcode/caffe2/torch/_inductor/codegen/aoti_runtime/interface.cpp fbcode/caffe2/torch/csrc/inductor/aoti_runtime/interface.h xplat/caffe2/torch/_inductor/codegen/aoti_runtime/interface.cpp xplat/caffe2/torch/csrc/inductor/aoti_runtime/interface.h
```

Reviewed By: desertfire

Differential Revision: D98624788




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo