### PR TITLE
[AC remat] Skip backward regions that don't need recomputation

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -15,6 +15,7 @@ import torch._dynamo.test_case
 import torch._functorch.config
 import torch.distributed as dist
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.utils.checkpoint
 from functorch.compile import (
     default_partition,
@@ -2816,6 +2817,103 @@ def forward(self, arg0_1, arg1_1, arg2_1):
     detach_6 = torch.ops.aten.detach.default(add);  add = None
     return (detach_6,)""",
         )
+
+    def test_chunked_loss_remat(self):
+        """Chunked loss pattern: multiple backward regions from chunk_loss.backward()
+        calls, but only the final x.backward() region needs remat. The pass should
+        skip the chunk backwards and only rematerialize for the final one."""
+        dim = 32
+        chunksz = 4
+
+        class Block(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.l1 = nn.Linear(dim, dim, bias=False)
+                self.l2 = nn.Linear(dim, dim, bias=False)
+
+            def _fn(self, x):
+                return self.l2(F.gelu(self.l1(x), approximate="tanh"))
+
+            def forward(self, x):
+                return checkpoint(self._fn, x, use_reentrant=False)
+
+        class ChunkedLoss(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.block = Block()
+                self.head = nn.Linear(dim, dim, bias=False)
+
+            def forward(self, x, y):
+                x = self.block(x)
+                x_detached = x.detach().requires_grad_()
+                total = 0
+                for start in range(0, x_detached.shape[0], chunksz):
+                    end = start + chunksz
+                    chunk_loss = (
+                        F.mse_loss(
+                            self.head(x_detached[start:end]),
+                            y[start:end],
+                            reduction="sum",
+                        )
+                        / x_detached.shape[0]
+                    )
+                    chunk_loss.backward()
+                    total = total + chunk_loss.detach()
+                x.backward(x_detached.grad)
+                return total
+
+        model = ChunkedLoss()
+        x = torch.randn(12, dim)
+        y = torch.randn(12, dim)
+
+        result_with, gm_with = self._compile_and_capture(model, True, (x, y))
+        result_without, gm_without = self._compile_and_capture(model, False, (x, y))
+
+        torch.testing.assert_close(result_with, result_without)
+
+        # Without remat, gelu appears once (forward only).
+        # With remat, gelu is duplicated into the backward region.
+        gelu_without = self.count_op(gm_without, torch.ops.aten.gelu.default)
+        gelu_with = self.count_op(gm_with, torch.ops.aten.gelu.default)
+        self.assertEqual(gelu_without, 1)
+        self.assertEqual(gelu_with, 2, "gelu should be recomputed in backward")
+
+    def test_two_backward_regions_needing_remat_errors(self):
+        """Two independent backward calls that both need recompute should error."""
+        dim = 32
+
+        class Block(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.l1 = nn.Linear(dim, dim, bias=False)
+                self.l2 = nn.Linear(dim, dim, bias=False)
+
+            def _fn(self, x):
+                return self.l2(F.gelu(self.l1(x), approximate="tanh"))
+
+            def forward(self, x):
+                return checkpoint(self._fn, x, use_reentrant=False)
+
+        class TwoBackwards(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.block1 = Block()
+                self.block2 = Block()
+
+            def forward(self, x):
+                y = self.block1(x)
+                z = self.block2(y)
+                z.sum().backward(retain_graph=True)
+                y.sum().backward()
+                return z.detach()
+
+        x = torch.randn(8, dim, requires_grad=True)
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.BackendCompilerFailed,
+            "require recomputation",
+        ):
+            self._compile_and_capture(TwoBackwards(), True, (x,))
 
 
 devices = ["cuda", "hpu"]

--- a/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
+++ b/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
@@ -1,5 +1,6 @@
 """AC rematerialize pass: Duplicates recompute nodes for backward, then DCE removes unused forward versions."""
 
+import dataclasses
 import itertools
 import logging
 from typing import Any, overload
@@ -57,26 +58,32 @@ def _has_user_phase_annotation(gm: fx.GraphModule) -> bool:
     )
 
 
-def _collect_backward_region_data(
-    gm: fx.GraphModule,
-) -> tuple[bool, int | None, int | None, int]:
-    use_phase = _has_user_phase_annotation(gm)
-    bwd_start: int | None = None
-    bwd_end: int | None = None
-    num_regions = 0
-    in_backward = False
+@dataclasses.dataclass
+class BackwardRegions:
+    use_phase: bool
+    nodes: list[fx.Node]
+    regions: list[tuple[int, int]]
 
-    for idx, node in enumerate(gm.graph.nodes):
+
+def _collect_backward_regions(gm: fx.GraphModule) -> BackwardRegions:
+    use_phase = _has_user_phase_annotation(gm)
+    nodes = list(gm.graph.nodes)
+    regions = []
+    bwd_start = None
+
+    for idx, node in enumerate(nodes):
         is_bwd = _is_backward_node(node, use_phase=use_phase)
         if is_bwd:
             if bwd_start is None:
                 bwd_start = idx
-            bwd_end = idx + 1
-            if not in_backward:
-                num_regions += 1
-        in_backward = is_bwd
+        elif bwd_start is not None:
+            regions.append((bwd_start, idx))
+            bwd_start = None
 
-    return use_phase, bwd_start, bwd_end, num_regions
+    if bwd_start is not None:
+        regions.append((bwd_start, len(nodes)))
+
+    return BackwardRegions(use_phase=use_phase, nodes=nodes, regions=regions)
 
 
 def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModule:
@@ -88,34 +95,24 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
     Dynamo traces torch.autograd.grad). When the user provides phase
     annotations, only those annotated regions are used.
 
-    Only a single contiguous backward region is supported. If multiple disjoint
-    backward regions are detected, an error is raised. Consecutive backward
-    operations without non-backward nodes between them are treated as a single
-    backward region.
+    The graph may contain multiple disjoint backward regions (e.g. chunked
+    loss). Regions that do not depend on recomputable forward nodes are
+    skipped. Only one region may require remat; if multiple do, we error
+    and ask the user to annotate which region to rematerialize.
     """
     if not has_recomputable_ops(gm):
         return gm
 
-    use_phase, bwd_start, bwd_end, num_regions = _collect_backward_region_data(gm)
-    if num_regions > 1:
-        if use_phase:
-            raise RuntimeError(
-                f"Detected {num_regions} disjoint backward regions annotated with "
-                'phase: "backward" but remat only supports a single backward region. '
-                "Please ensure only one contiguous region is annotated."
-            )
-        raise RuntimeError(
-            f"Detected {num_regions} disjoint backward regions in the graph but remat only supports "
-            "a single backward region. This can happen when non-backward computation appears "
-            "between backward sections. Please annotate the real backward with "
-            'torch.fx.traceback.annotate({"phase": "backward"}).'
-        )
-
-    if bwd_start is None:
+    bwd = _collect_backward_regions(gm)
+    if not bwd.regions:
         return gm
-    if bwd_end is None:
-        raise AssertionError(
-            "backward region should end somewhere when there was explicit backward region start."
+
+    # User-annotated phase regions: multiple annotations is always an error.
+    if bwd.use_phase and len(bwd.regions) > 1:
+        raise RuntimeError(
+            f"Detected {len(bwd.regions)} disjoint backward regions annotated with "
+            'phase: "backward" but remat only supports a single backward region. '
+            "Please ensure only one contiguous region is annotated."
         )
 
     order = {node: idx for idx, node in enumerate(gm.graph.nodes)}
@@ -131,6 +128,28 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
     gm = cleanup_recompute_tags(gm, is_default_partition=True)
 
     force_save_bw_mutation_src(gm)
+
+    def _region_needs_remat(start: int, end: int) -> bool:
+        return any(
+            must_recompute(inp)
+            for node in itertools.islice(gm.graph.nodes, start, end)
+            for inp in node.all_input_nodes
+        )
+
+    remat_regions = [
+        i for i, (s, e) in enumerate(bwd.regions) if _region_needs_remat(s, e)
+    ]
+
+    if len(remat_regions) > 1:
+        raise RuntimeError(
+            f"Detected {len(remat_regions)} disjoint backward regions that require recomputation, "
+            "but remat only supports one such region in a forward-loss-backward graph."
+        )
+
+    if not remat_regions:
+        return gm
+
+    bwd_start, bwd_end = bwd.regions[remat_regions[0]]
 
     new_graph = fx.Graph()
     env: dict[fx.Node, fx.Node] = {}

--- a/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
+++ b/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
@@ -1,6 +1,5 @@
 """AC rematerialize pass: Duplicates recompute nodes for backward, then DCE removes unused forward versions."""
 
-import dataclasses
 import itertools
 import logging
 from typing import Any, overload
@@ -58,32 +57,31 @@ def _has_user_phase_annotation(gm: fx.GraphModule) -> bool:
     )
 
 
-@dataclasses.dataclass
-class BackwardRegions:
-    use_phase: bool
-    nodes: list[fx.Node]
-    regions: list[tuple[int, int]]
+def _collect_backward_regions(
+    gm: fx.GraphModule, use_phase: bool
+) -> list[tuple[int, int, bool]]:
+    """Returns (bwd_start, bwd_end, needs_remat) for each backward region."""
+    regions: list[tuple[int, int, bool]] = []
+    bwd_start: int | None = None
+    needs_remat = False
 
-
-def _collect_backward_regions(gm: fx.GraphModule) -> BackwardRegions:
-    use_phase = _has_user_phase_annotation(gm)
-    nodes = list(gm.graph.nodes)
-    regions = []
-    bwd_start = None
-
-    for idx, node in enumerate(nodes):
-        is_bwd = _is_backward_node(node, use_phase=use_phase)
-        if is_bwd:
+    for idx, node in enumerate(gm.graph.nodes):
+        if _is_backward_node(node, use_phase=use_phase):
             if bwd_start is None:
                 bwd_start = idx
+                needs_remat = False
+            if not needs_remat and any(
+                must_recompute(inp) for inp in node.all_input_nodes
+            ):
+                needs_remat = True
         elif bwd_start is not None:
-            regions.append((bwd_start, idx))
+            regions.append((bwd_start, idx, needs_remat))
             bwd_start = None
 
     if bwd_start is not None:
-        regions.append((bwd_start, len(nodes)))
+        regions.append((bwd_start, idx + 1, needs_remat))
 
-    return BackwardRegions(use_phase=use_phase, nodes=nodes, regions=regions)
+    return regions
 
 
 def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModule:
@@ -103,20 +101,6 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
     if not has_recomputable_ops(gm):
         return gm
 
-    bwd = _collect_backward_regions(gm)
-    if not bwd.regions:
-        return gm
-
-    # User-annotated phase regions: multiple annotations is always an error.
-    if bwd.use_phase and len(bwd.regions) > 1:
-        raise RuntimeError(
-            f"Detected {len(bwd.regions)} disjoint backward regions annotated with "
-            'phase: "backward" but remat only supports a single backward region. '
-            "Please ensure only one contiguous region is annotated."
-        )
-
-    order = {node: idx for idx, node in enumerate(gm.graph.nodes)}
-
     if has_recomputable_rng_ops(gm):
         raise RuntimeError(
             "Activation checkpoint rematerialization in `forward-loss-backward` graph does not support RNG ops "
@@ -129,16 +113,20 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
 
     force_save_bw_mutation_src(gm)
 
-    def _region_needs_remat(start: int, end: int) -> bool:
-        return any(
-            must_recompute(inp)
-            for node in itertools.islice(gm.graph.nodes, start, end)
-            for inp in node.all_input_nodes
+    use_phase = _has_user_phase_annotation(gm)
+    regions = _collect_backward_regions(gm, use_phase)
+    if not regions:
+        return gm
+
+    # User-annotated phase regions: multiple annotations is always an error.
+    if use_phase and len(regions) > 1:
+        raise RuntimeError(
+            f"Detected {len(regions)} disjoint backward regions annotated with "
+            'phase: "backward" but remat only supports a single backward region. '
+            "Please ensure only one contiguous region is annotated."
         )
 
-    remat_regions = [
-        i for i, (s, e) in enumerate(bwd.regions) if _region_needs_remat(s, e)
-    ]
+    remat_regions = [(s, e) for s, e, needs in regions if needs]
 
     if len(remat_regions) > 1:
         raise RuntimeError(
@@ -149,8 +137,9 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
     if not remat_regions:
         return gm
 
-    bwd_start, bwd_end = bwd.regions[remat_regions[0]]
+    bwd_start, bwd_end = remat_regions[0]
 
+    order = {node: idx for idx, node in enumerate(gm.graph.nodes)}
     new_graph = fx.Graph()
     env: dict[fx.Node, fx.Node] = {}
     recomputed_nodes: dict[fx.Node, fx.Node] = {}

--- a/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
+++ b/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
@@ -60,7 +60,11 @@ def _has_user_phase_annotation(gm: fx.GraphModule) -> bool:
 def _collect_backward_regions(
     gm: fx.GraphModule, use_phase: bool
 ) -> list[tuple[int, int, bool]]:
-    """Returns (bwd_start, bwd_end, needs_remat) for each backward region."""
+    """Returns (bwd_start, bwd_end, needs_remat) for each backward region.
+
+    Regions are maximal contiguous runs of backward nodes, as [start, end)
+    indices into the graph node list.
+    """
     regions: list[tuple[int, int, bool]] = []
     bwd_start: int | None = None
     needs_remat = False
@@ -113,6 +117,8 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
 
     force_save_bw_mutation_src(gm)
 
+    # must_recompute (used inside _collect_backward_regions) requires
+    # cleanup_recompute_tags to have run first.
     use_phase = _has_user_phase_annotation(gm)
     regions = _collect_backward_regions(gm, use_phase)
     if not regions:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #180535
* __->__ #180534

The remat pass previously errored on any graph with multiple disjoint
backward regions. This is too strict for patterns like chunked loss,
where intermediate chunk_loss.backward() calls create backward regions
that don't depend on any recomputable forward nodes.

Now we collect all backward regions, filter to those that actually need
remat, and only error if multiple regions need it. User-annotated
phase regions (multiple annotations) still always error. The remat
loop itself is unchanged.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98