### PR TITLE
[AC remat] Per-region independent recomputation, remove user phase annotations

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -15,7 +15,6 @@ import torch._dynamo.test_case
 import torch._functorch.config
 import torch.distributed as dist
 import torch.nn as nn
-import torch.nn.functional as F
 import torch.utils.checkpoint
 from functorch.compile import (
     default_partition,
@@ -2743,177 +2742,49 @@ def forward(self, arg0_1):
         self.assertEqual(ref, result)
         self.assertEqual(x_ref.grad, x_test.grad)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-    def test_multiple_user_phase_annotations_errors(self):
-        x = torch.randn(4, 4, requires_grad=True)
+    def test_two_autograd_grads_independent_recompute(self):
+        """Two autograd.grad calls on the same checkpointed output produce
+        independent recomputes, one per backward region — matching eager AC."""
+        x = torch.randn(2, 4, requires_grad=True)
         w = torch.randn(4, 4, requires_grad=True)
 
         def fn(x, w):
-            z = torch.utils.checkpoint.checkpoint(
+            y = torch.utils.checkpoint.checkpoint(
                 lambda a, b: torch.sin(a @ b), x, w, use_reentrant=False
             )
-            loss = z.sum()
-            with torch.fx.traceback.annotate({"phase": "backward"}):
-                dx, dw = _grad(loss, (x, w))
-            # Non-backward computation between two backward annotations
-            out = dx + dw
-            with torch.fx.traceback.annotate({"phase": "backward"}):
-                out = out * 2
-            return out.detach()
+            g1 = _grad(y.sum(), (x,), retain_graph=True)
+            g2 = _grad(y.sum(), (x,))
+            return (g1[0] + g2[0]).detach()
 
-        with self.assertRaisesRegex(RuntimeError, "backward regions annotated"):
-            self._compile_and_capture(fn, True, (x, w))
+        _, gm_with = self._compile_and_capture(fn, True, (x, w))
 
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-    def test_user_phase_annotation_with_extra_autograd_grad(self):
-        """Only the user-annotated backward region gets rematerialization."""
-        x = torch.randn(4, 4, requires_grad=True)
-        w1 = torch.randn(4, 4, requires_grad=True)
-        w2 = torch.randn(4, 4, requires_grad=True)
-
-        def fn(x, w1, w2):
-            z1 = torch.utils.checkpoint.checkpoint(
-                lambda a, b: torch.sin(a @ b), x, w1, use_reentrant=False
-            )
-            z2 = torch.utils.checkpoint.checkpoint(
-                lambda a, b: torch.sigmoid(a @ b), x, w2, use_reentrant=False
-            )
-            loss1 = z1.sum()
-            loss2 = z2.sum()
-            # Only the first backward is annotated
-            with torch.fx.traceback.annotate({"phase": "backward"}):
-                dx1 = _grad(loss1, (x,))
-            # Second backward NOT annotated — should not get remat
-            dx2 = _grad(loss2, (x,))
-            return (dx1[0] + dx2[0]).detach()
-
-        _, gm_with = self._compile_and_capture(fn, True, (x, w1, w2))
-
+        # mm_recomputed for first grad, mm_recomputed_1 for second grad
         self.assertExpectedInline(
             gm_with.code.strip(),
             """\
-def forward(self, arg0_1, arg1_1, arg2_1):
+def forward(self, arg0_1, arg1_1):
     mm = torch.ops.aten.mm.default(arg0_1, arg1_1)
     sin = torch.ops.aten.sin.default(mm);  mm = None
-    mm_1 = torch.ops.aten.mm.default(arg0_1, arg2_1)
-    sigmoid = torch.ops.aten.sigmoid.default(mm_1);  mm_1 = None
-    detach_4 = torch.ops.aten.detach.default(sigmoid)
-    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
-    sum_2 = torch.ops.aten.sum.default(sigmoid);  sigmoid = None
+    sum_1 = torch.ops.aten.sum.default(sin)
     ones_like = torch.ops.aten.ones_like.default(sum_1, pin_memory = False, memory_format = torch.preserve_format);  sum_1 = None
-    expand = torch.ops.aten.expand.default(ones_like, [4, 4]);  ones_like = None
-    mm_recomputed = torch.ops.aten.mm.default(arg0_1, arg1_1);  arg0_1 = None
+    expand = torch.ops.aten.expand.default(ones_like, [2, 4]);  ones_like = None
+    mm_recomputed = torch.ops.aten.mm.default(arg0_1, arg1_1)
     cos = torch.ops.aten.cos.default(mm_recomputed);  mm_recomputed = None
     mul = torch.ops.aten.mul.Tensor(expand, cos);  expand = cos = None
-    t = torch.ops.aten.t.default(arg1_1);  arg1_1 = None
-    mm_3 = torch.ops.aten.mm.default(mul, t);  mul = t = None
+    t = torch.ops.aten.t.default(arg1_1)
+    mm_2 = torch.ops.aten.mm.default(mul, t);  mul = t = None
+    sum_2 = torch.ops.aten.sum.default(sin);  sin = None
     ones_like_1 = torch.ops.aten.ones_like.default(sum_2, pin_memory = False, memory_format = torch.preserve_format);  sum_2 = None
-    expand_1 = torch.ops.aten.expand.default(ones_like_1, [4, 4]);  ones_like_1 = None
-    detach_5 = torch.ops.aten.detach.default(detach_4);  detach_4 = None
-    sigmoid_backward = torch.ops.aten.sigmoid_backward.default(expand_1, detach_5);  expand_1 = detach_5 = None
-    t_1 = torch.ops.aten.t.default(arg2_1);  arg2_1 = None
-    mm_4 = torch.ops.aten.mm.default(sigmoid_backward, t_1);  sigmoid_backward = t_1 = None
-    add = torch.ops.aten.add.Tensor(mm_3, mm_4);  mm_3 = mm_4 = None
-    detach_6 = torch.ops.aten.detach.default(add);  add = None
-    return (detach_6,)""",
+    expand_1 = torch.ops.aten.expand.default(ones_like_1, [2, 4]);  ones_like_1 = None
+    mm_recomputed_1 = torch.ops.aten.mm.default(arg0_1, arg1_1);  arg0_1 = None
+    cos_1 = torch.ops.aten.cos.default(mm_recomputed_1);  mm_recomputed_1 = None
+    mul_1 = torch.ops.aten.mul.Tensor(expand_1, cos_1);  expand_1 = cos_1 = None
+    t_1 = torch.ops.aten.t.default(arg1_1);  arg1_1 = None
+    mm_4 = torch.ops.aten.mm.default(mul_1, t_1);  mul_1 = t_1 = None
+    add = torch.ops.aten.add.Tensor(mm_2, mm_4);  mm_2 = mm_4 = None
+    detach_2 = torch.ops.aten.detach.default(add);  add = None
+    return (detach_2,)""",
         )
-
-    def test_chunked_loss_remat(self):
-        """Chunked loss pattern: multiple backward regions from chunk_loss.backward()
-        calls, but only the final x.backward() region needs remat. The pass should
-        skip the chunk backwards and only rematerialize for the final one."""
-        dim = 32
-        chunksz = 4
-
-        class Block(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.l1 = nn.Linear(dim, dim, bias=False)
-                self.l2 = nn.Linear(dim, dim, bias=False)
-
-            def _fn(self, x):
-                return self.l2(F.gelu(self.l1(x), approximate="tanh"))
-
-            def forward(self, x):
-                return checkpoint(self._fn, x, use_reentrant=False)
-
-        class ChunkedLoss(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.block = Block()
-                self.head = nn.Linear(dim, dim, bias=False)
-
-            def forward(self, x, y):
-                x = self.block(x)
-                x_detached = x.detach().requires_grad_()
-                total = 0
-                for start in range(0, x_detached.shape[0], chunksz):
-                    end = start + chunksz
-                    chunk_loss = (
-                        F.mse_loss(
-                            self.head(x_detached[start:end]),
-                            y[start:end],
-                            reduction="sum",
-                        )
-                        / x_detached.shape[0]
-                    )
-                    chunk_loss.backward()
-                    total = total + chunk_loss.detach()
-                x.backward(x_detached.grad)
-                return total
-
-        model = ChunkedLoss()
-        x = torch.randn(12, dim)
-        y = torch.randn(12, dim)
-
-        result_with, gm_with = self._compile_and_capture(model, True, (x, y))
-        result_without, gm_without = self._compile_and_capture(model, False, (x, y))
-
-        torch.testing.assert_close(result_with, result_without)
-
-        # Without remat, gelu appears once (forward only).
-        # With remat, gelu is duplicated into the backward region.
-        gelu_without = self.count_op(gm_without, torch.ops.aten.gelu.default)
-        gelu_with = self.count_op(gm_with, torch.ops.aten.gelu.default)
-        self.assertEqual(gelu_without, 1)
-        self.assertEqual(gelu_with, 2, "gelu should be recomputed in backward")
-
-    def test_two_backward_regions_needing_remat_errors(self):
-        """Two independent backward calls that both need recompute should error."""
-        dim = 32
-
-        class Block(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.l1 = nn.Linear(dim, dim, bias=False)
-                self.l2 = nn.Linear(dim, dim, bias=False)
-
-            def _fn(self, x):
-                return self.l2(F.gelu(self.l1(x), approximate="tanh"))
-
-            def forward(self, x):
-                return checkpoint(self._fn, x, use_reentrant=False)
-
-        class TwoBackwards(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.block1 = Block()
-                self.block2 = Block()
-
-            def forward(self, x):
-                y = self.block1(x)
-                z = self.block2(y)
-                z.sum().backward(retain_graph=True)
-                y.sum().backward()
-                return z.detach()
-
-        x = torch.randn(8, dim, requires_grad=True)
-
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.BackendCompilerFailed,
-            "require recomputation",
-        ):
-            self._compile_and_capture(TwoBackwards(), True, (x,))
 
 
 devices = ["cuda", "hpu"]

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -15,6 +15,7 @@ import torch._dynamo.test_case
 import torch._functorch.config
 import torch.distributed as dist
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.utils.checkpoint
 from functorch.compile import (
     default_partition,
@@ -2741,6 +2742,164 @@ def forward(self, arg0_1):
 
         self.assertEqual(ref, result)
         self.assertEqual(x_ref.grad, x_test.grad)
+
+    def test_two_checkpoints_two_grads_both_remat(self):
+        """Two checkpointed blocks with two autograd.grad calls — both backward
+        regions get independent rematerialization."""
+        x = torch.randn(4, 4, requires_grad=True)
+        w1 = torch.randn(4, 4, requires_grad=True)
+        w2 = torch.randn(4, 4, requires_grad=True)
+
+        def fn(x, w1, w2):
+            z1 = torch.utils.checkpoint.checkpoint(
+                lambda a, b: torch.sin(a @ b), x, w1, use_reentrant=False
+            )
+            z2 = torch.utils.checkpoint.checkpoint(
+                lambda a, b: torch.sigmoid(a @ b), x, w2, use_reentrant=False
+            )
+            loss1 = z1.sum()
+            loss2 = z2.sum()
+            dx1 = _grad(loss1, (x,), retain_graph=True)
+            dx2 = _grad(loss2, (x,))
+            return (dx1[0] + dx2[0]).detach()
+
+        _, gm_with = self._compile_and_capture(fn, True, (x, w1, w2))
+
+        # mm_recomputed for first grad (sin), mm_1_recomputed for second grad (sigmoid)
+        self.assertExpectedInline(
+            gm_with.code.strip(),
+            """\
+def forward(self, arg0_1, arg1_1, arg2_1):
+    mm = torch.ops.aten.mm.default(arg0_1, arg1_1)
+    sin = torch.ops.aten.sin.default(mm);  mm = None
+    mm_1 = torch.ops.aten.mm.default(arg0_1, arg2_1)
+    sigmoid = torch.ops.aten.sigmoid.default(mm_1);  mm_1 = None
+    sum_1 = torch.ops.aten.sum.default(sin);  sin = None
+    sum_2 = torch.ops.aten.sum.default(sigmoid);  sigmoid = None
+    ones_like = torch.ops.aten.ones_like.default(sum_1, pin_memory = False, memory_format = torch.preserve_format);  sum_1 = None
+    expand = torch.ops.aten.expand.default(ones_like, [4, 4]);  ones_like = None
+    mm_recomputed = torch.ops.aten.mm.default(arg0_1, arg1_1)
+    cos = torch.ops.aten.cos.default(mm_recomputed);  mm_recomputed = None
+    mul = torch.ops.aten.mul.Tensor(expand, cos);  expand = cos = None
+    t = torch.ops.aten.t.default(arg1_1);  arg1_1 = None
+    mm_3 = torch.ops.aten.mm.default(mul, t);  mul = t = None
+    ones_like_1 = torch.ops.aten.ones_like.default(sum_2, pin_memory = False, memory_format = torch.preserve_format);  sum_2 = None
+    expand_1 = torch.ops.aten.expand.default(ones_like_1, [4, 4]);  ones_like_1 = None
+    mm_1_recomputed = torch.ops.aten.mm.default(arg0_1, arg2_1);  arg0_1 = None
+    sigmoid_recomputed = torch.ops.aten.sigmoid.default(mm_1_recomputed);  mm_1_recomputed = None
+    detach_4_recomputed = torch.ops.aten.detach.default(sigmoid_recomputed);  sigmoid_recomputed = None
+    detach_6 = torch.ops.aten.detach.default(detach_4_recomputed);  detach_4_recomputed = None
+    sigmoid_backward = torch.ops.aten.sigmoid_backward.default(expand_1, detach_6);  expand_1 = detach_6 = None
+    t_1 = torch.ops.aten.t.default(arg2_1);  arg2_1 = None
+    mm_5 = torch.ops.aten.mm.default(sigmoid_backward, t_1);  sigmoid_backward = t_1 = None
+    add = torch.ops.aten.add.Tensor(mm_3, mm_5);  mm_3 = mm_5 = None
+    detach_7 = torch.ops.aten.detach.default(add);  add = None
+    return (detach_7,)""",
+        )
+
+    def test_chunked_loss_remat(self):
+        """Chunked loss: multiple backward regions from chunk_loss.backward(),
+        only the final x.backward() needs remat."""
+        dim = 32
+        chunksz = 4
+
+        class Block(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.l1 = nn.Linear(dim, dim, bias=False)
+                self.l2 = nn.Linear(dim, dim, bias=False)
+
+            def _fn(self, x):
+                return self.l2(F.gelu(self.l1(x), approximate="tanh"))
+
+            def forward(self, x):
+                return checkpoint(self._fn, x, use_reentrant=False)
+
+        class ChunkedLoss(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.block = Block()
+                self.head = nn.Linear(dim, dim, bias=False)
+
+            def forward(self, x, y):
+                x = self.block(x)
+                x_detached = x.detach().requires_grad_()
+                total = 0
+                for start in range(0, x_detached.shape[0], chunksz):
+                    end = start + chunksz
+                    chunk_loss = (
+                        F.mse_loss(
+                            self.head(x_detached[start:end]),
+                            y[start:end],
+                            reduction="sum",
+                        )
+                        / x_detached.shape[0]
+                    )
+                    chunk_loss.backward()
+                    total = total + chunk_loss.detach()
+                x.backward(x_detached.grad)
+                return total
+
+        model = ChunkedLoss()
+        x = torch.randn(12, dim)
+        y = torch.randn(12, dim)
+
+        result_with, gm_with = self._compile_and_capture(model, True, (x, y))
+        result_without, gm_without = self._compile_and_capture(model, False, (x, y))
+
+        torch.testing.assert_close(result_with, result_without)
+
+        gelu_without = self.count_op(gm_without, torch.ops.aten.gelu.default)
+        gelu_with = self.count_op(gm_with, torch.ops.aten.gelu.default)
+        self.assertEqual(gelu_without, 1)
+        self.assertEqual(gelu_with, 2, "gelu should be recomputed in backward")
+
+    def test_two_backward_regions_both_needing_remat(self):
+        """Two checkpointed blocks with two .backward() calls — both regions
+        get independent rematerialization."""
+        dim = 32
+
+        class Block(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.l1 = nn.Linear(dim, dim, bias=False)
+                self.l2 = nn.Linear(dim, dim, bias=False)
+
+            def _fn(self, x):
+                return self.l2(F.gelu(self.l1(x), approximate="tanh"))
+
+            def forward(self, x):
+                return checkpoint(self._fn, x, use_reentrant=False)
+
+        class TwoBackwards(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.block1 = Block()
+                self.block2 = Block()
+
+            def forward(self, x):
+                y = self.block1(x)
+                z = self.block2(y)
+                z.sum().backward(retain_graph=True)
+                y.sum().backward()
+                return z.detach()
+
+        model = TwoBackwards()
+        x = torch.randn(8, dim, requires_grad=True)
+
+        result_with, gm_with = self._compile_and_capture(model, True, (x,))
+
+        torch._dynamo.reset()
+        result_without, gm_without = self._compile_and_capture(model, False, (x,))
+
+        torch.testing.assert_close(result_with, result_without)
+
+        gelu_without = self.count_op(gm_without, torch.ops.aten.gelu.default)
+        gelu_with = self.count_op(gm_with, torch.ops.aten.gelu.default)
+        self.assertEqual(gelu_without, 2)
+        self.assertGreater(
+            gelu_with, gelu_without, "backward regions should recompute gelu"
+        )
 
     def test_two_autograd_grads_independent_recompute(self):
         """Two autograd.grad calls on the same checkpointed output produce

--- a/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
+++ b/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
@@ -1,7 +1,5 @@
 """AC rematerialize pass: Duplicates recompute nodes for backward, then DCE removes unused forward versions."""
 
-import dataclasses
-import itertools
 import logging
 from typing import Any, overload
 
@@ -19,7 +17,6 @@ from torch._functorch.partitioners import (
 
 
 log = logging.getLogger(__name__)
-_EMPTY_CUSTOM_META: dict[str, object] = {}
 
 
 def is_impure_node_for_dce(node: fx.Node) -> bool:
@@ -37,43 +34,19 @@ def is_impure_node_for_dce(node: fx.Node) -> bool:
     return node.is_impure(impure_random)
 
 
-def _is_backward_node(node: fx.Node, use_phase: bool = False) -> bool:
-    """Check if node is in backward region.
-
-    If use_phase is True, only checks custom["phase"] == "backward"
-    (user annotation). Otherwise falls back to node.meta["autograd_backward"],
-    which Dynamo adds when tracing torch.autograd.grad.
-    """
-    custom = node.meta.get("custom", _EMPTY_CUSTOM_META)
-    if use_phase:
-        return custom.get("phase") == "backward"
+def _is_backward_node(node: fx.Node) -> bool:
+    """Check if node is in a backward region via node.meta["autograd_backward"],
+    which Dynamo sets when tracing torch.autograd.grad."""
     return node.meta.get("autograd_backward", False)
 
 
-def _has_user_phase_annotation(gm: fx.GraphModule) -> bool:
-    """Check if any node has the user-level phase: backward annotation."""
-    return any(
-        node.meta.get("custom", _EMPTY_CUSTOM_META).get("phase") == "backward"
-        for node in gm.graph.nodes
-    )
-
-
-@dataclasses.dataclass
-class BackwardRegions:
-    use_phase: bool
-    nodes: list[fx.Node]
-    regions: list[tuple[int, int]]
-
-
-def _collect_backward_regions(gm: fx.GraphModule) -> BackwardRegions:
-    use_phase = _has_user_phase_annotation(gm)
+def _collect_backward_regions(gm: fx.GraphModule) -> list[tuple[int, int]]:
     nodes = list(gm.graph.nodes)
-    regions = []
+    regions: list[tuple[int, int]] = []
     bwd_start = None
 
     for idx, node in enumerate(nodes):
-        is_bwd = _is_backward_node(node, use_phase=use_phase)
-        if is_bwd:
+        if _is_backward_node(node):
             if bwd_start is None:
                 bwd_start = idx
         elif bwd_start is not None:
@@ -83,37 +56,28 @@ def _collect_backward_regions(gm: fx.GraphModule) -> BackwardRegions:
     if bwd_start is not None:
         regions.append((bwd_start, len(nodes)))
 
-    return BackwardRegions(use_phase=use_phase, nodes=nodes, regions=regions)
+    return regions
 
 
 def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModule:
     """
     Duplicate recompute nodes for backward use. DCE removes unused forward versions.
 
-    Backward regions are identified by custom["phase"] == "backward" (user
-    annotation) or node.meta["autograd_backward"] == True (set automatically when
-    Dynamo traces torch.autograd.grad). When the user provides phase
-    annotations, only those annotated regions are used.
+    Backward regions are identified by node.meta["autograd_backward"] == True,
+    set by Dynamo when tracing torch.autograd.grad or via make_fx.
 
     The graph may contain multiple disjoint backward regions (e.g. chunked
-    loss). Regions that do not depend on recomputable forward nodes are
-    skipped. Only one region may require remat; if multiple do, we error
-    and ask the user to annotate which region to rematerialize.
+    loss). Each region is processed independently: regions that do not
+    depend on recomputable forward nodes are copied through unchanged,
+    while regions that do get their own region-local recomputations.
+    This mimics the eager AC mechanism.
     """
     if not has_recomputable_ops(gm):
         return gm
 
-    bwd = _collect_backward_regions(gm)
-    if not bwd.regions:
+    regions = _collect_backward_regions(gm)
+    if not regions:
         return gm
-
-    # User-annotated phase regions: multiple annotations is always an error.
-    if bwd.use_phase and len(bwd.regions) > 1:
-        raise RuntimeError(
-            f"Detected {len(bwd.regions)} disjoint backward regions annotated with "
-            'phase: "backward" but remat only supports a single backward region. '
-            "Please ensure only one contiguous region is annotated."
-        )
 
     order = {node: idx for idx, node in enumerate(gm.graph.nodes)}
 
@@ -129,86 +93,86 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
 
     force_save_bw_mutation_src(gm)
 
-    def _region_needs_remat(start: int, end: int) -> bool:
-        return any(
-            must_recompute(inp)
-            for node in itertools.islice(gm.graph.nodes, start, end)
-            for inp in node.all_input_nodes
-        )
-
-    remat_regions = [
-        i for i, (s, e) in enumerate(bwd.regions) if _region_needs_remat(s, e)
-    ]
-
-    if len(remat_regions) > 1:
-        raise RuntimeError(
-            f"Detected {len(remat_regions)} disjoint backward regions that require recomputation, "
-            "but remat only supports one such region in a forward-loss-backward graph."
-        )
-
-    if not remat_regions:
-        return gm
-
-    bwd_start, bwd_end = bwd.regions[remat_regions[0]]
-
     new_graph = fx.Graph()
     env: dict[fx.Node, fx.Node] = {}
-    recomputed_nodes: dict[fx.Node, fx.Node] = {}
+    nodes = list(gm.graph.nodes)
 
-    # Insert forward nodes
-    for node in itertools.islice(gm.graph.nodes, 0, bwd_start):
-        env[node] = new_graph.node_copy(node, lambda x: env[x])
+    prev_end = 0
+    for region_idx, (bwd_start, bwd_end) in enumerate(regions):
+        # Copy non-backward nodes before this region
+        for node in nodes[prev_end:bwd_start]:
+            env[node] = new_graph.node_copy(node, lambda x: env[x])
 
-    @overload
-    def remat_input(x: fx.Node) -> fx.Node: ...
-    @overload
-    def remat_input(x: Any) -> Any: ...
+        # Check if this region needs remat at all
+        needs_remat = any(
+            must_recompute(inp)
+            for node in nodes[bwd_start:bwd_end]
+            for inp in node.all_input_nodes
+        )
+        if not needs_remat:
+            for node in nodes[bwd_start:bwd_end]:
+                env[node] = new_graph.node_copy(node, lambda x: env[x])
+            prev_end = bwd_end
+            continue
 
-    def remat_input(x: object) -> object:
-        # fx.Node can have args that are primitive types (e.g. int, float, bool)
-        if not isinstance(x, fx.Node):
-            return x
-        return recomputed_nodes.get(x, env[x])
+        # Region-local recomputed nodes so lifetimes don't bleed across regions
+        recomputed_nodes: dict[fx.Node, fx.Node] = {}
 
-    def gather_recompute_deps(node: fx.Node) -> set[fx.Node]:
-        deps: set[fx.Node] = set()
+        @overload
+        def remat_input(x: fx.Node) -> fx.Node: ...
+        @overload
+        def remat_input(x: Any) -> Any: ...
 
-        def _gather(n: fx.Node) -> None:
-            if n in deps or n in recomputed_nodes or not must_recompute(n):
-                return
-            deps.add(n)
-            for inp in n.all_input_nodes:
+        def remat_input(x: object) -> object:
+            # fx.Node can have args that are primitive types (e.g. int, float, bool)
+            if not isinstance(x, fx.Node):
+                return x
+            return recomputed_nodes.get(x, env[x])
+
+        def gather_recompute_deps(node: fx.Node) -> set[fx.Node]:
+            deps: set[fx.Node] = set()
+
+            def _gather(n: fx.Node) -> None:
+                if n in deps or n in recomputed_nodes or not must_recompute(n):
+                    return
+                deps.add(n)
+                for inp in n.all_input_nodes:
+                    _gather(inp)
+
+            # Can't call _gather(node) directly: node itself may not be must_recompute
+            # (e.g. backward nodes), so _gather would return early without visiting inputs.
+            for inp in node.all_input_nodes:
                 _gather(inp)
+            return deps
 
-        # Can't call _gather(node) directly: node itself may not be must_recompute
-        # (e.g. backward nodes), so _gather would return early without visiting inputs.
-        for inp in node.all_input_nodes:
-            _gather(inp)
-        return deps
+        # Insert backward nodes
+        for node in nodes[bwd_start:bwd_end]:
+            # Gather all deps that need to be recomputed for this node
+            deps = gather_recompute_deps(node)
 
-    # Insert backward nodes
-    for node in itertools.islice(gm.graph.nodes, bwd_start, bwd_end):
-        # Gather all deps that need to be recomputed for this node
-        deps = gather_recompute_deps(node)
+            # Insert deps in forward order (guaranteed disjoint from already-inserted)
+            # This is not as inefficient as it looks, because we only add fresh dependencies
+            # when they are not yet processed as recomputed nodes.
+            new_deps = sorted(deps, key=lambda n: order[n])
+            if new_deps:
+                log.debug(
+                    "To compute backward node %s, recomputing [%s]",
+                    node.name,
+                    ", ".join(dep.name for dep in new_deps),
+                )
+            for dep in new_deps:
+                dup = new_graph.node_copy(dep, remat_input)
+                suffix = (
+                    "_recomputed" if region_idx == 0 else f"_recomputed_{region_idx}"
+                )
+                dup.name = dep.name + suffix
+                recomputed_nodes[dep] = dup
 
-        # Insert deps in forward order (guaranteed disjoint from already-inserted)
-        # This is not as inefficient as it looks, because we only add fresh dependencies
-        # when they are not yet processed as recomputed nodes.
-        new_deps = sorted(deps, key=lambda n: order[n])
-        if new_deps:
-            log.debug(
-                "To compute backward node %s, recomputing [%s]",
-                node.name,
-                ", ".join(dep.name for dep in new_deps),
-            )
-        for dep in new_deps:
-            dup = new_graph.node_copy(dep, remat_input)
-            dup.name = dep.name + "_recomputed"
-            recomputed_nodes[dep] = dup
+            env[node] = new_graph.node_copy(node, remat_input)
+        prev_end = bwd_end
 
-        env[node] = new_graph.node_copy(node, remat_input)
-
-    for node in itertools.islice(gm.graph.nodes, bwd_end, None):
+    # Copy remaining nodes after the last region
+    for node in nodes[prev_end:]:
         env[node] = new_graph.node_copy(node, lambda x: env[x])
 
     new_gm = torch.fx.GraphModule(gm, new_graph)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180535
* #180534

Apply remat independently to each backward region that needs it, matching
eager AC behavior where each backward call triggers its own recomputation
via unpack hooks. Each region gets its own recomputed_nodes scope so
lifetimes don't bleed across regions.

Remove the user phase annotation mechanism (use_phase, _has_user_phase_annotation,
BackwardRegions dataclass) — no longer needed since we handle all backward
regions uniformly instead of requiring users to mark which one to rematerialize.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98