### PR TITLE
[fix][inductor] Fix _check_aoti_runtime_check_inputs_env undeclared in _const_run_impl

### DIFF
--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -532,6 +532,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
         if V.graph.aot_mode:
             self.codegen_additional_funcs()
 
+            if not V.graph.is_const_graph:
+                self.generate_input_output_runtime_checks()
+
             if V.graph.const_module:
                 self.header.splice(V.graph.const_module.wrapper_code.header)
 
@@ -581,7 +584,6 @@ class CppWrapperCpu(PythonWrapperCodegen):
                         __check_inputs_outputs(input_handles, output_handles);
                     """
 
-                self.generate_input_output_runtime_checks()
                 self.prefix.splice(run_impl_proto)
         else:
             # cpp entry function for JIT with cpp wrapper

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -176,6 +176,9 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
                     """
                 )
 
+            if not V.graph.is_const_graph:
+                self.generate_input_output_runtime_checks()
+
             if V.graph.const_module:
                 self.header.splice(V.graph.const_module.wrapper_code.header)
 
@@ -224,7 +227,6 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
                     ) {
                     """
 
-                self.generate_input_output_runtime_checks()
                 run_impl_proto += """
                     __check_inputs_outputs(input_handles, output_handles);
                 """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

### Motivation:
After #177535 and #177538 introduced assert_size_stride and
assert_alignment guarded by _check_aoti_runtime_check_inputs_env() in
AOT Inductor generated code, the _const_run_impl method in the constant
folding graph also emits these guarded assertions. However, the static
function _check_aoti_runtime_check_inputs_env is defined by
generate_input_output_runtime_checks(), which was called AFTER the
const wrapper code (containing _const_run_impl body) was spliced into
the prefix buffer. This caused a C++ compile error since the function
was used before being declared:
```
error: ‘_check_aoti_runtime_check_inputs_env’ was not declared in this scope
  593 |     if (_check_aoti_runtime_check_inputs_env()) { assert_size_stride(buf1, {8L, }, {1L, }, "torch.ops._quantized.wrapped_fbgemm_pack_gemm_matrix_fp16.default
"); }

```

### Solution:
Move generate_input_output_runtime_checks() to execute before the const
wrapper code splice in both cpp_wrapper_cpu.py and
cpp_wrapper_cpu_array_ref.py. Only called for non-const graphs (the
main graph), matching the original intent. The const graph body is then
spliced after, so it can reference the already-defined function.

### Test plan:
python test/inductor/test_aot_inductor.py AOTInductorTestABICompatibleCpu.test_quantized_linear_cpu
python test/inductor/test_aot_inductor.py AOTInductorTestABICompatibleCpu.test_duplicate_constant_folding_cpu

Authored-with: Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo