### PR TITLE
[torchelastic] Start health check server before remote_pre_launch in APF executor (#180543)

### DIFF
--- a/torch/distributed/elastic/agent/server/health_check_server.py
+++ b/torch/distributed/elastic/agent/server/health_check_server.py
@@ -53,6 +53,10 @@ class HealthCheckServer:
         """
         log.info("Stopping noop health check server.")
 
+    @property
+    def alive_callback(self) -> Callable[[], int]:
+        return self._alive_callback
+
 
 def create_healthcheck_server(
     alive_callback: Callable[[], int],

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -20,6 +20,7 @@ from torch.distributed.elastic import events, metrics
 from torch.distributed.elastic.agent.server.api import WorkerSpec
 from torch.distributed.elastic.agent.server.health_check_server import (
     create_healthcheck_server,
+    HealthCheckServer,
 )
 from torch.distributed.elastic.agent.server.local_elastic_agent import (
     _AliveCallbackProxy,
@@ -183,12 +184,19 @@ class elastic_launch:
         self,
         config: LaunchConfig,
         entrypoint: Callable | str | None,
+        health_check_server: HealthCheckServer | None = None,
     ):
         self._config = config
         self._entrypoint = entrypoint
+        self._health_check_server = health_check_server
 
     def __call__(self, *args):
-        return launch_agent(self._config, self._entrypoint, list(args))
+        return launch_agent(
+            self._config,
+            self._entrypoint,
+            list(args),
+            health_check_server=self._health_check_server,
+        )
 
 
 def _get_entrypoint_name(entrypoint: Callable | str | None, args: list[Any]) -> str:
@@ -234,6 +242,7 @@ def launch_agent(
     config: LaunchConfig,
     entrypoint: Callable | str | None,
     args: list[Any],
+    health_check_server: HealthCheckServer | None = None,
 ) -> dict[int, Any]:
     if not config.run_id:
         run_id = str(uuid.uuid4().int)
@@ -301,29 +310,30 @@ def launch_agent(
     # thrift port during the potentially long MAST rendezvous store barrier
     # (10-22+ min for large jobs).  The _AliveCallbackProxy returns
     # time.time() until wired to the agent after construction.
-    health_check_server = None
-    alive_callback_proxy = None
-    healthcheck_port = os.getenv(TORCHELASTIC_HEALTH_CHECK_PORT)
-    if healthcheck_port is not None and justknobs_check(
-        "ai_infra/pytorch_distributed:torchelastic_enable_healthcheck_before_rendezvous",
-        default=False,
-    ):
-        try:
-            alive_callback_proxy = _AliveCallbackProxy()
-            health_check_server = create_healthcheck_server(
-                alive_callback=alive_callback_proxy,
-                port=int(healthcheck_port),
-                timeout=60,
-            )
-            health_check_server.start()
-            logger.info(
-                "Started early health check server on port %s before rendezvous",
-                healthcheck_port,
-            )
-        except Exception:
-            logger.warning("Failed to start early health check server", exc_info=True)
-            health_check_server = None
-            alive_callback_proxy = None
+    # Skip if a server was already provided by the caller (e.g. started
+    # before remote_pre_launch in the APF executor).
+    if health_check_server is None:
+        healthcheck_port = os.getenv(TORCHELASTIC_HEALTH_CHECK_PORT)
+        if healthcheck_port is not None and justknobs_check(
+            "ai_infra/pytorch_distributed:torchelastic_enable_healthcheck_before_rendezvous",
+            default=False,
+        ):
+            try:
+                health_check_server = create_healthcheck_server(
+                    alive_callback=_AliveCallbackProxy(),
+                    port=int(healthcheck_port),
+                    timeout=60,
+                )
+                health_check_server.start()
+                logger.info(
+                    "Started early health check server on port %s before rendezvous",
+                    healthcheck_port,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to start early health check server", exc_info=True
+                )
+                health_check_server = None
 
     spec = WorkerSpec(
         role=config.role,
@@ -352,8 +362,10 @@ def launch_agent(
         health_check_server=health_check_server,
     )
 
-    if alive_callback_proxy is not None:
-        alive_callback_proxy.set_delegate(agent._get_alive_time)
+    if health_check_server is not None:
+        cb = health_check_server.alive_callback
+        if isinstance(cb, _AliveCallbackProxy):
+            cb.set_delegate(agent._get_alive_time)
 
     shutdown_rdzv = True
     try:


### PR DESCRIPTION
Summary:

This diff moves the health check server start even earlier — into the APF executor's `execute()` method, before `remote_pre_launch_func()` is called. The pre-created server is threaded through `ElasticScheduler` → `elastic_launch` → `launch_agent` → `LocalElasticAgent`. If a server is already provided, `launch_agent()` skips creating a new one. The `_AliveCallbackProxy` is retrieved from the server via the new `alive_callback` property, keeping the API surface to a single `health_check_server` parameters.

Test Plan:
Validated on MAST job `aps-aps-hc_before_prelaunch_test_v2-60625f29e1` (perevent_cvr model, 2 hosts x 8 GPUs, GRANDTETON cluster, entitlement oncall_ads_model_platform). Job completed successfully in 12m 49s.

Existing unit tests pass unchanged — all new params are optional with None defaults:
buck test fbcode//caffe2/test/distributed/elastic/agent/server/test/fb:local_elastic_agent_fb_internal_test

Reviewed By: d4l3k, sahshah-meta

Differential Revision: D100803807
