### PR TITLE
fix AOTInductor fails to compile dynamic-shape CUDA gather pattern with ValueError: The argument '((0)) + 48' is not comparable

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6354,6 +6354,72 @@ class AOTInductorTestsTemplate:
         example_inputs = (torch.randn(2, 128, 4096, device=self.device),)
         self.check_model(Model(), example_inputs, dynamic_shapes={"x": {0: bs}})
 
+    @skipIfRocm
+    def test_issue_179900(self):
+        if self.device != "cuda":
+            raise unittest.SkipTest("requires CUDA")
+
+        class Repro(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.refined_pattern_len = 3
+
+            def forward(self, seq_hidden, seq_lens, target_hidden):
+                batch_size, seq_len, hidden_dim = seq_hidden.shape
+                seq_lens = seq_lens.reshape(-1).clamp(min=0, max=seq_len)
+                start_pos = seq_len - seq_lens
+
+                hist_len = self.refined_pattern_len - 1
+                hist_offsets = (
+                    torch.arange(hist_len, device=seq_hidden.device) - hist_len
+                )
+                hist_idx = (seq_len + hist_offsets.view(1, -1)).expand(batch_size, -1)
+
+                hist_mask = (hist_idx >= start_pos.view(batch_size, 1)) & (
+                    hist_idx < seq_len
+                )
+                gather_idx = hist_idx.clamp(min=0, max=seq_len - 1)
+                hist_tokens = seq_hidden.gather(
+                    1, gather_idx.unsqueeze(-1).expand(-1, -1, hidden_dim)
+                )
+                hist_tokens = hist_tokens * hist_mask.unsqueeze(-1).to(
+                    hist_tokens.dtype
+                )
+
+                target_pattern = torch.cat(
+                    [hist_tokens, target_hidden.unsqueeze(1)], dim=1
+                )
+                target_mask = torch.cat(
+                    [
+                        hist_mask,
+                        torch.ones(
+                            batch_size,
+                            1,
+                            device=seq_hidden.device,
+                            dtype=torch.bool,
+                        ),
+                    ],
+                    dim=1,
+                )
+                out = target_pattern * target_mask.unsqueeze(-1).to(
+                    target_pattern.dtype
+                )
+                return out.sum(dim=(1, 2))
+
+        torch.manual_seed(20260415)
+        seq_hidden = torch.randn((8, 50, 64), device=self.device)
+        seq_lens = torch.randint(low=0, high=51, size=(8,), device=self.device)
+        target_hidden = torch.randn((8, 64), device=self.device)
+        example_inputs = (seq_hidden, seq_lens, target_hidden)
+
+        batch = Dim("batch", max=4096)
+        dynamic_shapes = {
+            "seq_hidden": {0: batch},
+            "seq_lens": {0: batch},
+            "target_hidden": {0: batch},
+        }
+        self.check_model(Repro(), example_inputs, dynamic_shapes=dynamic_shapes)
+
     @requires_gpu
     def test_d2h_copy(self):
         # device to copy host should always have the same stride

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6650,6 +6650,72 @@ class AOTInductorTestsTemplate:
         example_inputs = (torch.randn(2, 128, 4096, device=self.device),)
         self.check_model(Model(), example_inputs, dynamic_shapes={"x": {0: bs}})
 
+    @skipIfRocm
+    def test_issue_179900(self):
+        if self.device != "cuda":
+            raise unittest.SkipTest("requires CUDA")
+
+        class Repro(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.refined_pattern_len = 3
+
+            def forward(self, seq_hidden, seq_lens, target_hidden):
+                batch_size, seq_len, hidden_dim = seq_hidden.shape
+                seq_lens = seq_lens.reshape(-1).clamp(min=0, max=seq_len)
+                start_pos = seq_len - seq_lens
+
+                hist_len = self.refined_pattern_len - 1
+                hist_offsets = (
+                    torch.arange(hist_len, device=seq_hidden.device) - hist_len
+                )
+                hist_idx = (seq_len + hist_offsets.view(1, -1)).expand(batch_size, -1)
+
+                hist_mask = (hist_idx >= start_pos.view(batch_size, 1)) & (
+                    hist_idx < seq_len
+                )
+                gather_idx = hist_idx.clamp(min=0, max=seq_len - 1)
+                hist_tokens = seq_hidden.gather(
+                    1, gather_idx.unsqueeze(-1).expand(-1, -1, hidden_dim)
+                )
+                hist_tokens = hist_tokens * hist_mask.unsqueeze(-1).to(
+                    hist_tokens.dtype
+                )
+
+                target_pattern = torch.cat(
+                    [hist_tokens, target_hidden.unsqueeze(1)], dim=1
+                )
+                target_mask = torch.cat(
+                    [
+                        hist_mask,
+                        torch.ones(
+                            batch_size,
+                            1,
+                            device=seq_hidden.device,
+                            dtype=torch.bool,
+                        ),
+                    ],
+                    dim=1,
+                )
+                out = target_pattern * target_mask.unsqueeze(-1).to(
+                    target_pattern.dtype
+                )
+                return out.sum(dim=(1, 2))
+
+        torch.manual_seed(20260415)
+        seq_hidden = torch.randn((8, 50, 64), device=self.device)
+        seq_lens = torch.randint(low=0, high=51, size=(8,), device=self.device)
+        target_hidden = torch.randn((8, 64), device=self.device)
+        example_inputs = (seq_hidden, seq_lens, target_hidden)
+
+        batch = Dim("batch", max=4096)
+        dynamic_shapes = {
+            "seq_hidden": {0: batch},
+            "seq_lens": {0: batch},
+            "target_hidden": {0: batch},
+        }
+        self.check_model(Repro(), example_inputs, dynamic_shapes=dynamic_shapes)
+
     @requires_gpu
     def test_d2h_copy(self):
         # device to copy host should always have the same stride

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1116,6 +1116,8 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         {xindex: 512, rindex: 1024}
         """
         index_to_tile_indexes = {k: v.expr for k, v in self.range_tree_nodes.items()}
+        if isinstance(index, sympy.Expr):
+            index = index.expand(identity=True)
         index_in_tile_vars = sympy_subs(index, index_to_tile_indexes)  # type: ignore[arg-type]
         strides = {}
         for range_tree in self.range_trees:

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1117,6 +1117,8 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         {xindex: 512, rindex: 1024}
         """
         index_to_tile_indexes = {k: v.expr for k, v in self.range_tree_nodes.items()}
+        if isinstance(index, sympy.Expr):
+            index = index.expand(identity=True)
         index_in_tile_vars = sympy_subs(index, index_to_tile_indexes)  # type: ignore[arg-type]
         strides = {}
         for range_tree in self.range_trees:

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -898,6 +898,8 @@ class SizeVarAllocator:
         """
         strides = []
         index = self.simplify(index)
+        if isinstance(index, Expr):
+            index = index.expand(identity=True)
         # remove any offset
         index = index - sympy_subs(
             index, {v: sympy.S.Zero for v in support_vars if v != 0}

--- a/torch/_inductor/sizevars.py
+++ b/torch/_inductor/sizevars.py
@@ -924,6 +924,8 @@ class SizeVarAllocator:
         """
         strides = []
         index = self.simplify(index)
+        if isinstance(index, Expr):
+            index = index.expand(identity=True)
         # remove any offset
         index = index - sympy_subs(
             index, {v: sympy.S.Zero for v in support_vars if v != 0}


### PR DESCRIPTION
# GitHub comment draft for follow-up PR on issue #179900

Below is a ready-to-paste GitHub comment for your PR conversation.

---

Thanks for taking a look.

This PR is a follow-up to issue #179900:  
https://github.com/pytorch/pytorch/issues/179900

That issue was closed after it was reported that the original repro worked on `main`. I re-checked the situation on our side and the conclusion is:

- the original issue in #179900 is **not fully resolved on current `main`**
- `main` no longer fails at the **first** `ValueError: The argument '((0)) + 48' is not comparable` site from the original minimal repro
- however, after that first failure point is avoided, the same underlying symbolic comparability problem still appears at **later compilation stages**
- for our real AOTI model, this means the end-to-end compile is still broken unless we patch additional call sites

## What I found

Initially I also thought the fix might have come from:
- PR #175975

But after checking commit history more carefully, that is not the real reason the original failure path disappeared.

The key change is actually from:
- PR #174521
- commit: `037c0f4053b5136cb22f88b3cb4e18f0ab588cfd`

Patch:  
https://github.com/pytorch/pytorch/commit/037c0f4053b5136cb22f88b3cb4e18f0ab588cfd.patch

The important part is not mainly the `stride_hints()` change from:

```python
result.append(self.size_hint_or_throw(s))
```

to:

```python
result.append(self.optimization_hint(s, fallback=0))
```

The crucial part is that this commit added:

```python
if isinstance(expr, sympy.Expr):
    expr = expr.expand(identity=True)
```

That expansion is what avoids the original comparability failure in the first path.

## Why this PR is still needed

After understanding that, I tried applying the same idea to the later failing sites in the compilation pipeline.

With only the earlier fix in place, I was still able to reproduce new failures from the same model/test, still ending in:

```text
torch._inductor.exc.InductorError: ValueError: The argument '((0)) + 48' is not comparable.
```

In our case, after the first path is fixed, the next failures show up in:

1. `torch/_inductor/sizevars.py`
2. `torch/_inductor/codegen/simd.py`

More specifically, I found that applying the same `expand(identity=True)` handling at these two places fixes the remaining compile failure for this case:

### 1) `torch/_inductor/sizevars.py`

```python
@@ -616,6 +618,8 @@ class SizeVarAllocator:
         """
         strides = []
         index = self.simplify(index)
+        if isinstance(index, Expr):
+            index = index.expand(identity=True)
         # remove any offset
         index = index - sympy_subs(
             index, {v: sympy.S.Zero for v in support_vars if v != 0}
```

### 2) `torch/_inductor/codegen/simd.py`

```python
@@ -933,6 +933,8 @@ class SIMDKernel(Kernel[CSEVariableType], Generic[CSEVariableType]):
         {xindex: 512, rindex: 1024}
         """
         index_to_tile_indexes = {k: v.expr for k, v in self.range_tree_nodes.items()}
+        if isinstance(index, sympy.Expr):
+            index = index.expand(identity=True)
         index_in_tile_vars = sympy_subs(index, index_to_tile_indexes)  # type: ignore[arg-type]
         strides = {}
         for range_tree in self.range_trees:
```

With both of those changes applied, the model finally compiles successfully on my side.

## Result on my side

After patching those two call sites, I get:

```text
python3 repro_inductor_non_comparable_min.py --device cuda
[INFO] device=cuda api=aoti_compile_and_package
[OK] compile success: /tmp/non_comparable_min.pt2
```

## Test coverage

This PR includes a test based on the #179900 scenario.

I can reproduce the remaining failures with:

```bash
python3 test/inductor/test_aot_inductor.py -k test_issue_179900 -v
```

Without the two new `expand(identity=True)` additions, this test still hits the later-stage non-comparable failures on my side.

With the patch in this PR, the same case compiles successfully.

## Summary

So the current situation appears to be:

- issue #179900 exposed a real symbolic comparability problem
- one earlier path was effectively fixed by the `expand(identity=True)` handling introduced in PR #174521
- but that did **not** eliminate the problem globally
- the same class of failure still exists in later compilation/codegen paths
- this PR extends the same fix pattern to the remaining sites that still fail for this case

This is why I am sending this follow-up PR: from my testing, the issue is not fully gone on `main`; the failure just moved deeper into the pipeline.

Could you please take a look and confirm whether extending `expand(identity=True)` in these two additional places is the right upstream direction?

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @laithsakka @jansel @eellison @shunting314 @peterbell10
