### PR TITLE
Restrict x86 quantization engine to x86 builds

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -691,7 +691,7 @@ at::QEngine Context::qEngine() const {
     qengine = at::kONEDNN;
 #endif
 
-#ifdef USE_FBGEMM
+#if defined(USE_FBGEMM) && (defined(__x86_64__) || defined(_M_X64))
     if (fbgemm::fbgemmSupportedCPU()) {
       /* X86 is enabled if and only if fbgemm is available.
        * It combines goodness of fbgemm and onednn by dispatching.
@@ -730,9 +730,11 @@ const std::vector<at::QEngine>& Context::supportedQEngines() {
     engines.push_back(at::kONEDNN);
 #endif
 
-#ifdef USE_FBGEMM
+#if defined(USE_FBGEMM)
     if (fbgemm::fbgemmSupportedCPU()) {
+#if defined(__x86_64__) || defined(_M_X64)
       engines.push_back(at::kX86);
+#endif
       // The X86 qengine is available if and only if FBGEMM is available
       engines.push_back(at::kFBGEMM);
     }


### PR DESCRIPTION
This change disables the x86 quantization engine for non-x86 builds, which has been the default since the 2.11.0 release. This fixes pre-2.11.0 quantization workflows which relied on the prior default - oneDNN.