### PR TITLE
Improve error message for wrong number of arguments in CachingAutotuner

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -978,6 +978,17 @@ class CachingAutotuner(KernelInterface):
             # reset to zero before evaluating any config
             self.reset_to_zero_args(*args, **kwargs)
             kernel_name = self.inductor_meta.get("kernel_name", "triton kernel")
+
+            # Validate argument count to provide a clear error message instead of
+            # a confusing "got multiple values for argument" error
+            if len(cloned_args) > len(launcher.def_args):
+                raise TypeError(
+                    f"launcher() expected at most {len(launcher.def_args)} positional "
+                    f"argument(s) but got {len(cloned_args)}. If you are passing extra "
+                    f"arguments (e.g., grid values) as positional args, please pass "
+                    f"them as keyword arguments instead."
+                )
+
             if autograd_profiler._is_profiler_enabled:
                 profiler_kwargs = self.get_profiler_kwargs(stream, launcher)
                 with torch._C._profiler._RecordFunctionFast(
@@ -1742,6 +1753,16 @@ class CachingAutotuner(KernelInterface):
                 _dump_launch_tensors(
                     args, self.filename, self.kernel_hash, self.fn.__name__
                 )
+
+        # Validate argument count to provide a clear error message instead of
+        # a confusing "got multiple values for argument" error
+        if len(args) > len(launcher.def_args):
+            raise TypeError(
+                f"launcher() expected at most {len(launcher.def_args)} positional "
+                f"argument(s) but got {len(args)}. If you are passing extra "
+                f"arguments (e.g., grid values) as positional args, please pass "
+                f"them as keyword arguments instead."
+            )
 
         # it is faster than entering and exiting a context manager, even if the context
         # manager is a nullcontext.


### PR DESCRIPTION
Good day

This PR addresses issue #146018, which reports that when a Triton kernel receives more positional arguments than it expects, the error message is confusing: 'launcher() got multiple values for argument grid'.

## Changes

Added argument count validation in two locations:
1. In `CachingAutotuner.run()` method
2. In `CachingAutotuner.bench()` method (via `kernel_call()`)

Before calling the launcher, we now check if the number of positional arguments exceeds the expected count (`len(launcher.def_args)`). If so, we raise a clear `TypeError` with a helpful message explaining the issue and suggesting to pass extra arguments (like grid values) as keyword arguments instead.

## Testing

The change is defensive - it only affects the error path when incorrect arguments are passed. The validation helps developers quickly understand and fix argument passing issues instead of debugging the confusing 'multiple values' error.

## Related Issue

Fixes #146018

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo