### PR TITLE
[docs] Improve documentation of normalization layers

### DIFF
--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -429,9 +429,10 @@ class BatchNorm2d(_BatchNorm):
 
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
-    The mean and standard-deviation are calculated per-dimension over
-    the mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter vectors
-    of size `C` (where `C` is the input size). By default, the elements of :math:`\gamma` are set
+    The mean and standard-deviation are calculated per-dimension over the
+    mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter
+    vectors of size `C` (where `C` is the input number of channels). By default, the
+    elements of :math:`\gamma` are set
     to 1 and the elements of :math:`\beta` are set to 0. At train time in the forward pass, the
     standard-deviation is calculated via the biased estimator, equivalent to
     ``torch.var(input, correction=0)``. However, the value stored in the moving average of the
@@ -543,9 +544,10 @@ class BatchNorm3d(_BatchNorm):
 
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
-    The mean and standard-deviation are calculated per-dimension over
-    the mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter vectors
-    of size `C` (where `C` is the input size). By default, the elements of :math:`\gamma` are set
+    The mean and standard-deviation are calculated per-dimension over the
+    mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter
+    vectors of size `C` (where `C` is the input number of channels). By default, the
+    elements of :math:`\gamma` are set
     to 1 and the elements of :math:`\beta` are set to 0. At train time in the forward pass, the
     standard-deviation is calculated via the biased estimator, equivalent to
     ``torch.var(input, correction=0)``. However, the value stored in the moving average of the
@@ -648,7 +650,7 @@ class LazyBatchNorm3d(_LazyNormBase, _BatchNorm):
 
 
 class SyncBatchNorm(_BatchNorm):
-    r"""Applies Batch Normalization over a N-Dimensional input.
+    r"""Applies Batch Normalization over an N-Dimensional input.
 
     The N-D input is a mini-batch of [N-2]D inputs with additional channel dimension) as described in the paper
     `Batch Normalization: Accelerating Deep Network Training by Reducing
@@ -664,7 +666,7 @@ class SyncBatchNorm(_BatchNorm):
     By default, the elements of :math:`\gamma` are sampled from
     :math:`\mathcal{U}(0, 1)` and the elements of :math:`\beta` are set to 0.
     The standard-deviation is calculated via the biased estimator, equivalent to
-    `torch.var(input, correction=0)`.
+    ``torch.var(input, correction=0)``.
 
     Also by default, during training this layer keeps running estimates of its
     computed mean and variance, which are then used for normalization during

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -311,8 +311,18 @@ class BatchNorm1d(_BatchNorm):
     Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`__ .
 
     .. math::
-
         y = \frac{x - \mathrm{E}[x]}{\sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+
+    with
+
+    .. math::
+        \begin{alignat*}{2}
+          x               &=& x               &(n,c,t)  \\
+          \mathrm{E}[x]   &=& \mathrm{E}[x]   &(c)  \\
+          \mathrm{Var}[x] &=& \mathrm{Var}[x] &(c)  \\
+          \gamma          &=& \gamma          &(c)  \\
+          \beta           &=& \beta           &(c)
+        \end{alignat*}
 
     The mean and standard-deviation are calculated per-dimension over
     the mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter vectors
@@ -426,8 +436,18 @@ class BatchNorm2d(_BatchNorm):
     Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`__ .
 
     .. math::
-
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+
+    with
+
+    .. math::
+        \begin{alignat*}{2}
+          x               &=& x               &(n,c,h,w)  \\
+          \mathrm{E}[x]   &=& \mathrm{E}[x]   &(c)  \\
+          \mathrm{Var}[x] &=& \mathrm{Var}[x] &(c)  \\
+          \gamma          &=& \gamma          &(c)  \\
+          \beta           &=& \beta           &(c)
+        \end{alignat*}
 
     The mean and standard-deviation are calculated per-dimension over the
     mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter
@@ -541,8 +561,18 @@ class BatchNorm3d(_BatchNorm):
     Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`__ .
 
     .. math::
-
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+
+    with
+
+    .. math::
+        \begin{alignat*}{2}
+          x               &=& x               &(n,c,d,h,w)  \\
+          \mathrm{E}[x]   &=& \mathrm{E}[x]   &(c)  \\
+          \mathrm{Var}[x] &=& \mathrm{Var}[x] &(c)  \\
+          \gamma          &=& \gamma          &(c)  \\
+          \beta           &=& \beta           &(c)
+        \end{alignat*}
 
     The mean and standard-deviation are calculated per-dimension over the
     mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter
@@ -657,8 +687,18 @@ class SyncBatchNorm(_BatchNorm):
     Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`__ .
 
     .. math::
-
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+
+    with
+
+    .. math::
+        \begin{alignat*}{2}
+          x               &=& x               &(n,c,\dots)  \\
+          \mathrm{E}[x]   &=& \mathrm{E}[x]   &(c)  \\
+          \mathrm{Var}[x] &=& \mathrm{Var}[x] &(c)  \\
+          \gamma          &=& \gamma          &(c)  \\
+          \beta           &=& \beta           &(c)
+        \end{alignat*}
 
     The mean and standard-deviation are calculated per-dimension over all
     mini-batches of the same process groups. :math:`\gamma` and :math:`\beta`

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -311,7 +311,7 @@ class BatchNorm1d(_BatchNorm):
     Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`__ .
 
     .. math::
-        y = \frac{x - \mathrm{E}[x]}{\sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+        y = \frac{x - \mathrm{E}[x]}{\sqrt{\mathrm{Var}[x] + \epsilon}} \cdot \gamma + \beta
 
     with
 
@@ -436,7 +436,7 @@ class BatchNorm2d(_BatchNorm):
     Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`__ .
 
     .. math::
-        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} \cdot \gamma + \beta
 
     with
 
@@ -561,7 +561,7 @@ class BatchNorm3d(_BatchNorm):
     Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`__ .
 
     .. math::
-        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} \cdot \gamma + \beta
 
     with
 
@@ -687,7 +687,7 @@ class SyncBatchNorm(_BatchNorm):
     Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`__ .
 
     .. math::
-        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} \cdot \gamma + \beta
 
     with
 

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -452,8 +452,8 @@ class BatchNorm2d(_BatchNorm):
     The mean and standard-deviation are calculated per-dimension over the
     mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter
     vectors of size `C` (where `C` is the input number of channels). By default, the
-    elements of :math:`\gamma` are set
-    to 1 and the elements of :math:`\beta` are set to 0. At train time in the forward pass, the
+    elements of :math:`\gamma` are set to 1 and the elements of
+    :math:`\beta` are set to 0. At train time in the forward pass, the
     standard-deviation is calculated via the biased estimator, equivalent to
     ``torch.var(input, correction=0)``. However, the value stored in the moving average of the
     standard-deviation is calculated via the unbiased  estimator, equivalent to
@@ -577,8 +577,8 @@ class BatchNorm3d(_BatchNorm):
     The mean and standard-deviation are calculated per-dimension over the
     mini-batches and :math:`\gamma` and :math:`\beta` are learnable parameter
     vectors of size `C` (where `C` is the input number of channels). By default, the
-    elements of :math:`\gamma` are set
-    to 1 and the elements of :math:`\beta` are set to 0. At train time in the forward pass, the
+    elements of :math:`\gamma` are set to 1 and the elements of
+    :math:`\beta` are set to 0. At train time in the forward pass, the
     standard-deviation is calculated via the biased estimator, equivalent to
     ``torch.var(input, correction=0)``. However, the value stored in the moving average of the
     standard-deviation is calculated via the unbiased  estimator, equivalent to

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -142,7 +142,7 @@ class InstanceNorm1d(_InstanceNorm):
     <https://arxiv.org/abs/1607.08022>`__.
 
     .. math::
-        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} \cdot \gamma + \beta
 
     with
 
@@ -271,7 +271,7 @@ class InstanceNorm2d(_InstanceNorm):
     <https://arxiv.org/abs/1607.08022>`__.
 
     .. math::
-        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} \cdot \gamma + \beta
 
     with
 
@@ -401,7 +401,7 @@ class InstanceNorm3d(_InstanceNorm):
     <https://arxiv.org/abs/1607.08022>`__.
 
     .. math::
-        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} \cdot \gamma + \beta
 
     with
 

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -142,8 +142,18 @@ class InstanceNorm1d(_InstanceNorm):
     <https://arxiv.org/abs/1607.08022>`__.
 
     .. math::
-
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+
+    with
+
+    .. math::
+        \begin{alignat*}{2}
+          x               &=& x               &(n,c,t)  \\
+          \mathrm{E}[x]   &=& \mathrm{E}[x]   &(n,c \phantom{,t})  \\
+          \mathrm{Var}[x] &=& \mathrm{Var}[x] &(n,c \phantom{,t})  \\
+          \gamma          &=& \gamma          &(\phantom{n,} c \phantom{,t})  \\
+          \beta           &=& \beta           &(\phantom{n,} c \phantom{,t})
+        \end{alignat*}
 
     The mean and standard-deviation are calculated per-dimension separately
     for each object in a mini-batch. :math:`\gamma` and :math:`\beta` are learnable parameter vectors
@@ -261,8 +271,18 @@ class InstanceNorm2d(_InstanceNorm):
     <https://arxiv.org/abs/1607.08022>`__.
 
     .. math::
-
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+
+    with
+
+    .. math::
+        \begin{alignat*}{2}
+          x               &=& x               &(n,c,h,w)  \\
+          \mathrm{E}[x]   &=& \mathrm{E}[x]   &(n,c \phantom{,h,w})  \\
+          \mathrm{Var}[x] &=& \mathrm{Var}[x] &(n,c \phantom{,h,w})  \\
+          \gamma          &=& \gamma          &(\phantom{n,} c \phantom{,h,w})  \\
+          \beta           &=& \beta           &(\phantom{n,} c \phantom{,h,w})
+        \end{alignat*}
 
     The mean and standard-deviation are calculated per-dimension separately
     for each object in a mini-batch. :math:`\gamma` and :math:`\beta` are learnable parameter vectors
@@ -381,8 +401,18 @@ class InstanceNorm3d(_InstanceNorm):
     <https://arxiv.org/abs/1607.08022>`__.
 
     .. math::
-
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+
+    with
+
+    .. math::
+        \begin{alignat*}{2}
+          x               &=& x               &(n,c,d,h,w)  \\
+          \mathrm{E}[x]   &=& \mathrm{E}[x]   &(n,c \phantom{,d,h,w})  \\
+          \mathrm{Var}[x] &=& \mathrm{Var}[x] &(n,c \phantom{,d,h,w})  \\
+          \gamma          &=& \gamma          &(\phantom{n,} c \phantom{,d,h,w})  \\
+          \beta           &=& \beta           &(\phantom{n,} c \phantom{,d,h,w})
+        \end{alignat*}
 
     The mean and standard-deviation are calculated per-dimension separately
     for each object in a mini-batch. :math:`\gamma` and :math:`\beta` are learnable parameter vectors

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -149,7 +149,7 @@ class InstanceNorm1d(_InstanceNorm):
     for each object in a mini-batch. :math:`\gamma` and :math:`\beta` are learnable parameter vectors
     of size `C` (where `C` is the number of features or channels of the input) if :attr:`affine` is ``True``.
     The variance is calculated via the biased estimator, equivalent to
-    `torch.var(input, correction=0)`.
+    ``torch.var(input, correction=0)``.
 
     By default, this layer uses instance statistics computed from input data in
     both training and evaluation modes.
@@ -268,7 +268,7 @@ class InstanceNorm2d(_InstanceNorm):
     for each object in a mini-batch. :math:`\gamma` and :math:`\beta` are learnable parameter vectors
     of size `C` (where `C` is the input size) if :attr:`affine` is ``True``.
     The standard-deviation is calculated via the biased estimator, equivalent to
-    `torch.var(input, correction=0)`.
+    ``torch.var(input, correction=0)``.
 
     By default, this layer uses instance statistics computed from input data in
     both training and evaluation modes.
@@ -388,7 +388,7 @@ class InstanceNorm3d(_InstanceNorm):
     for each object in a mini-batch. :math:`\gamma` and :math:`\beta` are learnable parameter vectors
     of size C (where C is the input size) if :attr:`affine` is ``True``.
     The standard-deviation is calculated via the biased estimator, equivalent to
-    `torch.var(input, correction=0)`.
+    ``torch.var(input, correction=0)``.
 
     By default, this layer uses instance statistics computed from input data in
     both training and evaluation modes.

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -372,14 +372,19 @@ class RMSNorm(Module):
     the paper `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467.pdf>`__
 
     .. math::
-        y_{i,j} = \frac{x_{i,j}}{\mathrm{RMS}(x)_i} \cdot \gamma_j, \quad
-        \text{where} \quad \text{RMS}(x)_i =
-          \sqrt{\epsilon + \frac{1}{n} \sum_{\text{all }j} x_{i,j}^2}
+        y = \frac{x}{\mathrm{RMS}(x)} \cdot \gamma
 
-    where :math:`j=(i_{D-d}, i_{D-d+1}, \dots, i_{D-1})` are the last `d` dimension
-    indices of input `x`, :math:`i=(i_0, i_1, \dots, i_{D-d-1})` are all other
-    indices, `D` is the dimension of input `x`, and `n` is the number of terms in
-    the sum.
+    where
+
+    .. math::
+        \begin{alignat*}{2}
+          x               &=& x               &(i_0,\dots,i_{D-d-1}, i_{D-d},\dots,i_{D-1})  \\
+          \mathrm{RMS}[x] &=& \mathrm{RMS}[x] &(i_0,\dots,i_{D-d-1} \phantom{,i_{D-d},\dots,i_{D-1}}) =
+                                \sqrt{\epsilon + \frac{1}{n} \sum_{i_{D-d},\dots,i_{D-1}} x_{i_0,\dots,i_{D-1}}^2}  \\
+          \gamma          &=& \gamma          &(\phantom{i_0,\dots,i_{D-d-1},} i_{D-d},\dots,i_{D-1})
+        \end{alignat*}
+
+    and `n` is the number of terms in the sum.
 
     The RMS is taken over the last `d` dimensions, where `d`
     is the dimension of :attr:`normalized_shape`. For example, if :attr:`normalized_shape`

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -20,8 +20,9 @@ class LocalResponseNorm(Module):
     Applies normalization across channels.
 
     .. math::
-        b_{c} = a_{c}\left(k + \frac{\alpha}{n}
-        \sum_{c'=\max(0, c-n/2)}^{\min(N-1,c+n/2)}a_{c'}^2\right)^{-\beta}
+        y_c = x_c \cdot \left(k + \frac{\alpha}{n}
+          \sum_{c'=\max(0, c-\lfloor n/2 \rfloor)}^{\min(N,c+\lceil n/2 \rceil)-1}
+          x_{c'}^2 \right)^{-\beta}
 
     Args:
         size: amount of neighbouring channels used for normalization
@@ -111,7 +112,18 @@ class LayerNorm(Module):
     .. math::
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
-    The mean and standard-deviation are calculated over the last `D` dimensions, where `D`
+    with
+
+    .. math::
+        \begin{alignat*}{2}
+          x               &=& x               &(n,c,\dots,h,w,\dots)  \\
+          \mathrm{E}[x]   &=& \mathrm{E}[x]   &(n,c,\dots \phantom{,h,w,\dots\,})  \\
+          \mathrm{Var}[x] &=& \mathrm{Var}[x] &(n,c,\dots \phantom{,h,w,\dots\,})  \\
+          \gamma          &=& \gamma          &(\phantom{n,c,\dots,} h,w,\dots)  \\
+          \beta           &=& \beta           &(\underbrace{\phantom{n,c,\dots,}}_{D-d} \underbrace{h,w,\dots}_{d} \,)
+        \end{alignat*}
+
+    The mean and standard-deviation are calculated over the last `d` dimensions, where `d`
     is the dimension of :attr:`normalized_shape`. For example, if :attr:`normalized_shape`
     is ``(3, 5)`` (a 2-dimensional shape), the mean and standard-deviation are computed over
     the last 2 dimensions of the input (i.e. ``input.mean((-2, -1))``).
@@ -245,8 +257,21 @@ class GroupNorm(Module):
     .. math::
         y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
 
-    The input channels are separated into :attr:`num_groups` groups, each containing
-    ``num_channels / num_groups`` channels. :attr:`num_channels` must be divisible by
+    with
+
+    .. math::
+        \begin{alignat*}{2}
+          x               &=&    x  &(n, \phantom{g,}\mathclap{c\;\;}\phantom{s} ,i_2,i_3,\dots) =  \\
+                          & &  = x' &(n, \overbracket{g,s}^{\mathclap{c = g \cdot G/C + s}}\!\! ,i_2,i_3,\dots)  \\
+          \mathrm{E}[x]   &=& \mathrm{E}_{s,i_2,i_3,\dots}[x']   &(n,g\phantom{,s,i_2,i_3,\dots\,})  \\
+          \mathrm{Var}[x] &=& \mathrm{Var}_{s,i_2,i_3,\dots}[x'] &(n,g\phantom{,s,i_2,i_3,\dots\,})  \\
+          \gamma          &=& \gamma(c)=\quad  \gamma' &(\phantom{n,}g,s\phantom{,i_2,i_3,\dots\,})  \\
+          \beta           &=& \beta(c)=\quad    \beta' &(\phantom{n,}g,s\phantom{,i_2,i_3,\dots\,})
+        \end{alignat*}
+
+    The input `x` may be 2D or higher-dimensional. The input channels are separated
+    into `G =` :attr:`num_groups` groups, each containing ``num_channels / num_groups``
+    `= G/C` channels. `C =` :attr:`num_channels` must be divisible by
     :attr:`num_groups`. The mean and standard-deviation are calculated
     separately over each group. :math:`\gamma` and :math:`\beta` are learnable
     per-channel affine transform parameter vectors of size :attr:`num_channels` if
@@ -347,13 +372,20 @@ class RMSNorm(Module):
     the paper `Root Mean Square Layer Normalization <https://arxiv.org/pdf/1910.07467.pdf>`__
 
     .. math::
-        y_i = \frac{x_i}{\mathrm{RMS}(x)} * \gamma_i, \quad
-        \text{where} \quad \text{RMS}(x) = \sqrt{\epsilon + \frac{1}{n} \sum_{i=1}^{n} x_i^2}
+        y_{i,j} = \frac{x_{i,j}}{\mathrm{RMS}(x)_i} \cdot \gamma_j, \quad
+        \text{where} \quad \text{RMS}(x)_i =
+          \sqrt{\epsilon + \frac{1}{n} \sum_{\text{all }j} x_{i,j}^2}
 
-    The RMS is taken over the last ``D`` dimensions, where ``D``
+    where :math:`j=(i_{D-d}, i_{D-d+1}, \dots, i_{D-1})` are the last `d` dimension
+    indices of input `x`, :math:`i=(i_0, i_1, \dots, i_{D-d-1})` are all other
+    indices, `D` is the dimension of input `x`, and `n` is the number of terms in
+    the sum.
+
+    The RMS is taken over the last `d` dimensions, where `d`
     is the dimension of :attr:`normalized_shape`. For example, if :attr:`normalized_shape`
     is ``(3, 5)`` (a 2-dimensional shape), the RMS is computed over
-    the last 2 dimensions of the input.
+    the last 2 dimensions of the input. :math:`\gamma` is a learnable scaling
+    parameter of :attr:`normalized_shape` if :attr:`elementwise_affine` is ``True``.
 
     Args:
         normalized_shape (int or list or torch.Size): input shape from an expected input

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -262,7 +262,7 @@ class GroupNorm(Module):
     .. math::
         \begin{alignat*}{2}
           x               &=&    x  &(n, \phantom{g,}\mathclap{c\;\;}\phantom{s} ,i_2,i_3,\dots) =  \\
-                          & &  = x' &(n, \overbracket{g,s}^{\mathclap{c = g \cdot G/C + s}}\!\! ,i_2,i_3,\dots)  \\
+                          & &  = x' &(n, \overbracket{g,s}^{\mathclap{c = g \cdot C/G + s}}\!\! ,i_2,i_3,\dots)  \\
           \mathrm{E}[x]   &=& \mathrm{E}_{s,i_2,i_3,\dots}[x']   &(n,g\phantom{,s,i_2,i_3,\dots\,})  \\
           \mathrm{Var}[x] &=& \mathrm{Var}_{s,i_2,i_3,\dots}[x'] &(n,g\phantom{,s,i_2,i_3,\dots\,})  \\
           \gamma          &=& \gamma(c)=\quad  \gamma' &(\phantom{n,}g,s\phantom{,i_2,i_3,\dots\,})  \\
@@ -271,7 +271,7 @@ class GroupNorm(Module):
 
     The input `x` may be 2D or higher-dimensional. The input channels are separated
     into `G =` :attr:`num_groups` groups, each containing ``num_channels / num_groups``
-    `= G/C` channels. `C =` :attr:`num_channels` must be divisible by
+    `= C/G` channels. `C =` :attr:`num_channels` must be divisible by
     :attr:`num_groups`. The mean and standard-deviation are calculated
     separately over each group. :math:`\gamma` and :math:`\beta` are learnable
     per-channel affine transform parameter vectors of size :attr:`num_channels` if

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -278,7 +278,7 @@ class GroupNorm(Module):
         >>> m = nn.GroupNorm(3, 6)
         >>> # Separate 6 channels into 6 groups (equivalent with InstanceNorm)
         >>> m = nn.GroupNorm(6, 6)
-        >>> # Put all 6 channels into a single group (equivalent with LayerNorm)
+        >>> # Put all 6 channels into a single group
         >>> m = nn.GroupNorm(1, 6)
         >>> # Activating the module
         >>> output = m(input)

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -118,7 +118,7 @@ class LayerNorm(Module):
     :math:`\gamma` and :math:`\beta` are learnable affine transform parameters of
     :attr:`normalized_shape` if :attr:`elementwise_affine` is ``True``.
     The variance is calculated via the biased estimator, equivalent to
-    `torch.var(input, correction=0)`.
+    ``torch.var(input, correction=0)``.
 
     .. note::
         Unlike Batch Normalization and Instance Normalization, which applies
@@ -148,11 +148,11 @@ class LayerNorm(Module):
 
     Attributes:
         weight: the learnable weights of the module of shape
-            :math:`\text{normalized\_shape}` when :attr:`elementwise_affine` is set to ``True``.
+            :attr:`normalized_shape` when :attr:`elementwise_affine` is set to ``True``.
             The values are initialized to 1.
-        bias:   the learnable bias of the module of shape
-                :math:`\text{normalized\_shape}` when :attr:`elementwise_affine` is set to ``True``.
-                The values are initialized to 0.
+        bias: the learnable bias of the module of shape
+            :attr:`normalized_shape` when :attr:`elementwise_affine` is set to ``True``.
+            The values are initialized to 0.
 
     Shape:
         - Input: :math:`(N, *)`
@@ -252,7 +252,7 @@ class GroupNorm(Module):
     per-channel affine transform parameter vectors of size :attr:`num_channels` if
     :attr:`affine` is ``True``.
     The variance is calculated via the biased estimator, equivalent to
-    `torch.var(input, correction=0)`.
+    ``torch.var(input, correction=0)``.
 
     This layer uses statistics computed from input data in both training and
     evaluation modes.
@@ -370,7 +370,8 @@ class RMSNorm(Module):
             fp16/bf16 and fp32 inputs use ``torch.finfo(torch.float32).eps``, while fp64
             inputs use ``torch.finfo(torch.float64).eps``. Default: ``None``
         elementwise_affine: a boolean value that when set to ``True``, this module
-            has learnable per-element affine parameters initialized to ones (for weights). Default: ``True``.
+            has learnable per-element scaling parameters initialized to ones.
+            Default: ``True``.
 
     Shape:
         - Input: :math:`(N, *)`

--- a/torch/nn/modules/normalization.py
+++ b/torch/nn/modules/normalization.py
@@ -110,7 +110,7 @@ class LayerNorm(Module):
     the paper `Layer Normalization <https://arxiv.org/abs/1607.06450>`__
 
     .. math::
-        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} \cdot \gamma + \beta
 
     with
 
@@ -255,7 +255,7 @@ class GroupNorm(Module):
     the paper `Group Normalization <https://arxiv.org/abs/1803.08494>`__
 
     .. math::
-        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} * \gamma + \beta
+        y = \frac{x - \mathrm{E}[x]}{ \sqrt{\mathrm{Var}[x] + \epsilon}} \cdot \gamma + \beta
 
     with
 


### PR DESCRIPTION
Fixes #51455 (its documentation part, not the implementations; the impl part of that issue seems to be covered by #113750 )

Fixes #75862

This PR improves documentation for normalization layers.

Changes:
1. Clarify normalization layers' documentation by explicitly listing the remaining dimension indices of tensors after the reductions for means/variances and the list of indices for the learnable transformations using a visual but formal mathematical notation, that allows one to quickly find which tensor depends on which indices. Previously this information was scattered through the text and was sometimes ambiguous, which could confuse users. Layers covered: LayerNorm, GroupNorm, RMSNorm, InstanceNorm1d, InstanceNorm2d, InstanceNorm3d, BatchNorm1d, BatchNorm2d, BatchNorm3d, SyncBatchNorm.
2. Fix LocalResponseNorm doc to match its implementation and the input/output notation used with the other layers.
3. Remove/fix misleading statements in GroupNorm docs (equivalence to LayerNorm when num_gropus=1), RMSNorm (affine->scaling), BatchNorm2d and BatchNorm3d.
4. Fix few typos in the docstrings.