### PR TITLE
mxfp8 scaled_mm: enforce no swizzle inputs on ROCm

### DIFF
--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -1230,7 +1230,15 @@ void check_swizzle_lengths(ScaledGemmImplementation impl,
                            std::vector<SwizzleType>& swizzle_a,
                            std::vector<SwizzleType>& swizzle_b) {
 #ifdef USE_ROCM
-  // ROCM doesn't swizzle their formats - we don't care what's passed.
+  // ROCm doesn't swizzle scale formats - reject any non-NO_SWIZZLE values.
+  for (auto s : swizzle_a) {
+    TORCH_CHECK_VALUE(s == SwizzleType::NO_SWIZZLE,
+        "ROCm does not support swizzled scales, but swizzle_a has value ", static_cast<int>(s));
+  }
+  for (auto s : swizzle_b) {
+    TORCH_CHECK_VALUE(s == SwizzleType::NO_SWIZZLE,
+        "ROCm does not support swizzled scales, but swizzle_b has value ", static_cast<int>(s));
+  }
   return;
 #else
   // Store implementations that care about swizzling, and how many swizzle arguments

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -2250,6 +2250,78 @@ class TestFP8Matmul(TestCase):
             )
 
 
+    @onlyCUDA
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM or IS_WINDOWS, mx_skip_msg)
+    @unittest.skipIf(not torch.version.hip, "ROCm-only test")
+    def test_rocm_rejects_swizzle(self, device) -> None:
+        # On ROCm, scales are not swizzled. Passing SWIZZLE_32_4_4 should error.
+        M, N, K = 128, 128, 128
+
+        # MXFP8
+        x = torch.randn(M, K, device=device).to(torch.float8_e4m3fn)
+        w = torch.randn(N, K, device=device).to(torch.float8_e4m3fn)
+        x_scale = torch.full((M, K // 32), 1., dtype=torch.float8_e8m0fnu, device=device)
+        w_scale = torch.full((N, K // 32), 1., dtype=torch.float8_e8m0fnu, device=device)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "swizzle",
+        ):
+            _ = torch.nn.functional.scaled_mm(
+                x,
+                w.t(),
+                x_scale,
+                ScalingType.BlockWise1x32,
+                w_scale,
+                ScalingType.BlockWise1x32,
+                swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+                swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+            )
+
+        # Also test that only swizzle_a being wrong is caught
+        with self.assertRaisesRegex(
+            ValueError,
+            "swizzle",
+        ):
+            _ = torch.nn.functional.scaled_mm(
+                x,
+                w.t(),
+                x_scale,
+                ScalingType.BlockWise1x32,
+                w_scale,
+                ScalingType.BlockWise1x32,
+                swizzle_a=SwizzleType.SWIZZLE_32_4_4,
+                swizzle_b=SwizzleType.NO_SWIZZLE,
+            )
+
+        # And swizzle_b only
+        with self.assertRaisesRegex(
+            ValueError,
+            "swizzle",
+        ):
+            _ = torch.nn.functional.scaled_mm(
+                x,
+                w.t(),
+                x_scale,
+                ScalingType.BlockWise1x32,
+                w_scale,
+                ScalingType.BlockWise1x32,
+                swizzle_a=SwizzleType.NO_SWIZZLE,
+                swizzle_b=SwizzleType.SWIZZLE_32_4_4,
+            )
+
+        # NO_SWIZZLE for both should be accepted (no error)
+        _ = torch.nn.functional.scaled_mm(
+            x,
+            w.t(),
+            x_scale,
+            ScalingType.BlockWise1x32,
+            w_scale,
+            ScalingType.BlockWise1x32,
+            swizzle_a=SwizzleType.NO_SWIZZLE,
+            swizzle_b=SwizzleType.NO_SWIZZLE,
+        )
+
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM or IS_WINDOWS, mx_skip_msg)
     @parametrize("recipe", ["mxfp8", "mxfp4" if torch.version.hip else "nvfp4"])
     def test_blockwise_mxfp8_nvfp4_error_messages(self, device, recipe) -> None:


### PR DESCRIPTION
Summary:

MXFP8 gemm on ROCm requires unswizzled scales, enforce this instead of silently accepting swizzled scales. This will make workflow code using mxfp8 cleaner.

Test Plan:

```
// on an AMD MI350x
pytest test/test_scaled_matmul_cuda.py -x -k rejects_swizzle
```

Reviewers:

Subscribers:

Tasks:

Tags: