### PR TITLE
[inductor] Fix debug_sync_kernel error in cpp-wrapper

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -90,6 +90,20 @@ class TestGpuWrapper(InductorTestCase):
         result = compiled(x)
         self.assertEqual(result, x * 2)
 
+    def test_debug_sync_kernel(self):
+        if not RUN_GPU:
+            self.skipTest("GPU not available")
+
+        def test_fn(x):
+            return x * 2
+
+        compiled = torch.compile(
+            options={"cpp_wrapper": True, "triton.debug_sync_kernel": True}
+        )(test_fn)
+        x = torch.randn(8, device=self.device)
+        result = compiled(x)
+        self.assertEqual(result, x * 2)
+
     def test_non_tensor_args_wrapped_on_cpu(self):
         if not RUN_GPU:
             self.skipTest("GPU not available")

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -2300,7 +2300,7 @@ class SIMDScheduling(BaseScheduling):
                 return None
 
     def codegen_sync(self):
-        V.graph.wrapper_code.writeline(V.graph.device_ops.synchronize())
+        V.graph.wrapper_code.generate_debug_sync(V.graph.wrapper_code)
 
     def generate_combo_kernel_code(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180564
* #180563

Fixes https://github.com/pytorch/pytorch/issues/140220

`codegen_sync()` in `SIMDScheduling` wrote `torch.cuda.synchronize()`
(Python) into generated C++ code when `triton.debug_sync_kernel=True`
with `cpp_wrapper=True`. Route it through `generate_debug_sync` so the
C++ wrapper emits `cudaDeviceSynchronize()` instead.

Authored with: Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo