### PR TITLE
Fix torch.trapz documentation signature to match torch.trapezoid

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13129,7 +13129,7 @@ Examples::
 add_docstr(
     torch.trapz,
     r"""
-trapz(y, x, *, dim=-1) -> Tensor
+trapz(y, x=None, *, dim=-1) -> Tensor
 
 Alias for :func:`torch.trapezoid`.
 """,


### PR DESCRIPTION
Good day

The documentation for `torch.trapz` showed `x` as a required argument (signature: `trapz(y, x, *, dim=-1)`), but since `torch.trapz` is an alias of `torch.trapezoid` (signature: `trapezoid(y, x=None, *, dx=None, dim=-1)`), the `x` parameter should be optional.

This fix corrects the docstring signature to show `x=None` matching the actual implementation.

## Changes
- Line 13126: Changed `trapz(y, x, *, dim=-1)` to `trapz(y, x=None, *, dim=-1)`

## Testing
The actual `torch.trapz` function already works correctly with optional `x` - this is purely a documentation fix.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof