### PR TITLE
[BE] Skip submodule checkout in docker image build workflows

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -99,6 +99,8 @@ jobs:
 
       - name: Setup Linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main
+        with:
+          submodules: 'false'
 
       - name: Login to ECR
         uses: ./.github/actions/ecr-login

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -74,6 +74,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
           no-sudo: true
+          submodules: 'false'
 
       - name: Login to ECR
         uses: ./.github/actions/ecr-login

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -56,7 +56,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
           fetch-depth: 1
-          submodules: true
+          submodules: 'false'
       - name: Get docker release matrix
         id: generate-matrix
         run: |
@@ -89,6 +89,8 @@ jobs:
 
       - name: Setup Linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main
+        with:
+          submodules: 'false'
 
       - name: Login to ECR
         uses: ./.github/actions/ecr-login


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #180572

Docker image builds don't build PyTorch from source, so recursive submodule checkout is unnecessary overhead.
Pass submodules: 'false' to `setup-linux`->`checkout-pytorch` in all three docker workflows.