### PR TITLE
[Oncall][AutoFix] Fix TestFxSplitNodeFinder testMode2/testMode3 expectations

### DIFF
--- a/test/fx/test_fx_split_node_finder.py
+++ b/test/fx/test_fx_split_node_finder.py
@@ -165,16 +165,22 @@ class TestFxSplitNodeFinder(TestCase):
             self._assert_events_file(events_file)
             self._validate_file_content(
                 nodes_file,
-                ["|-sup_f_2: init_acc|callable_and_operator_supported #"],
+                [
+                    "===== Tracking node sup_f_2 =====",
+                    "|-sup_f_2: init_acc|callable_and_operator_supported #",
+                    "===== End of tracking node sup_f_2 =====",
+                ],
             )
         elif mode == 3:
             self._assert_events_file(events_file)
             self._validate_file_content(
                 nodes_file,
                 [
+                    "===== Tracking node sup_f_1 =====",
                     "|-sup_f_1: init_acc|callable_and_operator_supported #",
                     "|-sup_f_1: acc_del|non_tensor_output_with_cpu_user add",
                     "| |-add: init_cpu|operator_support #",
+                    "===== End of tracking node sup_f_1 =====",
                 ],
             )
 


### PR DESCRIPTION
Summary:
Tests were failing because D100986725 fixed a silent bug in
NodeEventTracker.dump() where header/footer lines ("===== Tracking node
... =====") were never actually written to the nodes file. The old code
called writeln(f"...") which created a closure but immediately discarded
it. The new code correctly uses writer(f"...") to write these lines.

Updated test expectations in testMode2 and testMode3 to include the
now-correctly-written header/footer lines.

Related to oncall task T265048734.

Test Plan:
buck2 test fbcode//caffe2/test:fx -- "testMode2 (fx.test_fx_split_node_finder.TestFxSplitNodeFinder)" "testMode3 (fx.test_fx_split_node_finder.TestFxSplitNodeFinder)" — PASSED (2/2)
TestInfra issues: 195553244, 195553247, 195653047, 195653056

Differential Revision: D101190456


