### PR TITLE
Fix GDS smoke test failure on CUDA 13.2

### DIFF
--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -196,10 +196,15 @@ def test_cuda_gds_errors_captured() -> None:
         print("Testing test_cuda_gds_errors_captured")
         with NamedTemporaryFile() as f:
             torch.cuda.gds.GdsFile(f.name, os.O_CREAT | os.O_RDWR)
+        # cuFile >= 1.17 (CUDA 13.2+) compat mode: registration succeeds
+        # without nvidia-fs driver, falling back to POSIX I/O
+        if major_version > 13 or (major_version == 13 and minor_version >= 2):
+            print("GDS handle registered successfully via compatibility mode")
+            cuda_exception_missed = False
     except RuntimeError as e:
         expected_error = "cuFileHandleRegister failed"
         if re.search(expected_error, f"{e}"):
-            print(f"Caught CUDA exception with success: {e}")
+            print(f"Caught expected CUDA exception: {e}")
             cuda_exception_missed = False
         else:
             raise e


### PR DESCRIPTION
## Summary

  Fixes: https://github.com/pytorch/pytorch/issues/180576 the nightly manywheel smoke test failure for CUDA 13.2 builds in test_cuda_gds_errors_captured(). 
   
  CI failure: https://github.com/pytorch/test-infra/actions/runs/24004820054/job/70006692110             
                                                                  
  CUDA 13.2 ships cuFile 1.17, which expanded compatibility mode so that cuFileHandleRegister succeeds   
  when the nvidia-fs kernel driver is absent — subsequent I/O silently falls back to POSIX. Previously
  (cuFile 1.11 in CUDA 12.6), registration would fail with "cuFileHandleRegister failed".                
                                                                  
  The smoke test assumed registration always fails without the GDS driver and would error with "Expected 
  cuFileHandleRegister failed RuntimeError but have not received!".
                                                                                                         
  ```
┌──────────────┬────────────────┬─────────────────────────────────────┐                                
  │ CUDA Toolkit │ cuFile Version │ cuFileHandleRegister without driver │
  ├──────────────┼────────────────┼─────────────────────────────────────┤                                
  │ 12.6         │ 1.11.0.17      │ Fails (error)                       │
  ├──────────────┼────────────────┼─────────────────────────────────────┤
  │ 13.0         │ 1.15.1.6       │ Unknown                             │
  ├──────────────┼────────────────┼─────────────────────────────────────┤                                
  │ 13.2         │ 1.17.1.22      │ Succeeds (compat mode)              │
  └──────────────┴────────────────┴─────────────────────────────────────┘                                
```
                                                                  
  The fix accepts both outcomes: exception with "cuFileHandleRegister failed" (older cuFile) and         
  successful registration via compatibility mode (cuFile >= 1.17).
                                                                                                         
  Note: the cuFile userspace library (libcufile.so) is closed-source so we cannot pinpoint the exact     
  version where this changed. The kernel driver is OSS at https://github.com/NVIDIA/gds-nvidia-fs but the
   compat mode logic lives in the userspace library.                                                     
                                                                  
 ## Test plan

  - Verify CUDA 13.2 nightly manywheel smoke test passes                                                 
  - Verify CUDA 12.6 smoke test still passes (exception path unchanged)