### PR TITLE
[bucketing] Move manual_bucket_node_type from node.meta to bucketer instance

### DIFF
--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -55,6 +55,9 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
     ):
         super().__init__(*args, **kwargs)
         self.node_to_wait_map: dict[fx.Node, fx.Node] = defaultdict()
+        # Maps bucketed nodes to their type string, scoped to this bucketer
+        # instance so metadata doesn't leak across separate invocations.
+        self.bucketed_node_types: dict[fx.Node, str] = {}
 
     def _bucket_group(self, coll_nodes: list[fx.Node]) -> None:
         assert len(coll_nodes) > 0, "bucketed coll_nodes should have nonzero node"
@@ -105,17 +108,19 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
         # Use last wait as the canonical wait for scheduling (same node when len == 1)
         new_wait = new_waits[-1]
 
-        # Set manual bucketing-specific metadata (generic metadata is preserved in bucketing.py)
+        # Track bucketed node types on this bucketer instance so it doesn't leak
+        # when the same graph is processed by multiple ManualOverlapScheduler
+        # invocations (e.g. separate forward and backward passes).
         node_type = (
             "bucketed_all_gather" if is_all_gather(first) else "bucketed_reduce_scatter"
         )
         wait_set = OrderedSet(new_waits)
         for n in new_nodes:
             if n in wait_set:
-                n.meta["manual_bucket_node_type"] = node_type + "_wait"
+                self.bucketed_node_types[n] = node_type + "_wait"
                 self.node_to_wait_map[n] = new_wait
             elif n is new_start:
-                n.meta["manual_bucket_node_type"] = node_type
+                self.bucketed_node_types[n] = node_type
 
     def manual_bucket_collectives(self, nodes: list[fx.Node]) -> None:
         """
@@ -259,7 +264,7 @@ class ManualOverlapScheduler(OverlapScheduler):
         # schedule reduce scatter normally in self._schedule
         while self.on_path_ready:
             _, node = heapq.heappop(self.on_path_ready)
-            node_type = node.meta.get("manual_bucket_node_type", "")
+            node_type = self.bucketer.bucketed_node_types.get(node, "")
 
             if node in self.scheduled:
                 continue
@@ -286,7 +291,7 @@ class ManualOverlapScheduler(OverlapScheduler):
         last_compute: fx.Node | None = None
 
         for node in self.scheduled:
-            node_type = node.meta.get("manual_bucket_node_type", "")
+            node_type = self.bucketer.bucketed_node_types.get(node, "")
             if node_type == "bucketed_all_gather":
                 picked_ag.append(node)
                 continue


### PR DESCRIPTION
Problem:
When `manual_overlap_bucketing` is called multiple times on the same GraphModule (e.g. separate forward and backward passes), the old implementation stored bucketed node types in node.meta, which persists on the graph nodes across calls. The second call's _manual_reorder_graph iterates all graph nodes and misclassifies nodes bucketed by the first call, building incorrect overlap dependency edges.

Fix:
Moved bucketed node type tracking from `node.meta["manual_bucket_node_type"]` to `ManualOverlapPreservingBucketer.bucketed_node_types` dict, preventing metadata leaking across multiple `manual_overlap_bucketing` calls on the same graph.

Test:
In https://github.com/pytorch/torchtitan/pull/2934
```
MODULE=graph_trainer.llama3 CONFIG=graph_trainer_llama3_debugmodel ./run_train.sh --compile.mode aot_fx_trace
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo