### PR TITLE
doc: clarify that torch.normal does not support integer dtypes

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8329,8 +8329,8 @@ total number of elements in each tensor need to be the same.
           its device with the CPU.
 
 Args:
-    mean (float or Tensor): the tensor of per-element means. Only floating point types are supported.
-    std (float or Tensor): the tensor of per-element standard deviations. Only floating point types are supported.
+    mean (float or Tensor): per-element mean(s). Only floating point types are supported.
+    std (float or Tensor): per-element standard deviation(s). Only floating point types are supported.
 
 Keyword args:
     {generator}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8328,18 +8328,9 @@ total number of elements in each tensor need to be the same.
 .. note:: When :attr:`std` is a CUDA tensor, this function synchronizes
           its device with the CPU.
 
-.. note:: This function only supports floating-point dtypes (e.g.,
-          ``torch.float32``, ``torch.float64``). Passing integer dtypes
-          such as ``torch.long`` will raise a ``NotImplementedError``
-          on both CPU and CUDA devices. Note that
-          :func:`torch.set_default_dtype` does **not** affect integer
-          tensor creation -- ``torch.tensor(1)`` always returns ``int64``
-          regardless of the default dtype. Use ``torch.tensor(1.0)``
-          to get a floating-point tensor.
-
 Args:
-    mean (Tensor): the tensor of per-element means
-    std (Tensor): the tensor of per-element standard deviations
+    mean (float or Tensor): the tensor of per-element means. Only floating point types are supported.
+    std (float or Tensor): the tensor of per-element standard deviations. Only floating point types are supported.
 
 Keyword args:
     {generator}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8328,6 +8328,15 @@ total number of elements in each tensor need to be the same.
 .. note:: When :attr:`std` is a CUDA tensor, this function synchronizes
           its device with the CPU.
 
+.. note:: This function only supports floating-point dtypes (e.g.,
+          ``torch.float32``, ``torch.float64``). Passing integer dtypes
+          such as ``torch.long`` will raise a ``NotImplementedError``
+          on both CPU and CUDA devices. Note that
+          :func:`torch.set_default_dtype` does **not** affect integer
+          tensor creation -- ``torch.tensor(1)`` always returns ``int64``
+          regardless of the default dtype. Use ``torch.tensor(1.0)``
+          to get a floating-point tensor.
+
 Args:
     mean (Tensor): the tensor of per-element means
     std (Tensor): the tensor of per-element standard deviations


### PR DESCRIPTION
## Description

The documentation page for `torch.normal` does not mention that integer 
dtypes (e.g., `torch.long`, `torch.int32`) are not supported. This causes 
a confusing `NotImplementedError` on both CPU and CUDA with no explanation 
in the docs.

## Error Reproduced

**CPU:**
torch.normal(mean=0, std=1, size=(5,), dtype=torch.long)
NotImplementedError: "normal_kernel_cpu" not implemented for 'Long'

**CUDA:**
torch.normal(mean=0, std=1, size=(5,), dtype=torch.long, device='cuda')
NotImplementedError: "normal_kernel_cuda" not implemented for 'Long'

## What This PR Does

Added a `.. note::` to the `torch.normal` docstring in `torch/_torch_docs.py` 
clarifying:
- Only floating-point dtypes are supported
- `torch.set_default_dtype()` does NOT affect integer tensor creation
- `torch.tensor(1)` always returns `int64` — use `torch.tensor(1.0)` instead

## How to Fix (for users)

# Wrong - raises NotImplementedError
torch.normal(mean=torch.tensor(1), std=1, size=(5,))

# Correct
torch.normal(mean=torch.tensor(1.0), std=1, size=(5,))

## Linked Issue

Fixes #180560

## Changes

- `torch/_torch_docs.py` — added dtype note to `torch.normal` docstring