### PR TITLE
Make DebugInfoKind extensible.

### DIFF
--- a/c10/test/util/ThreadLocalDebugInfo_test.cpp
+++ b/c10/test/util/ThreadLocalDebugInfo_test.cpp
@@ -1,0 +1,79 @@
+#include <c10/util/Exception.h>
+#include <c10/util/ThreadLocalDebugInfo.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string_view>
+
+namespace c10 {
+namespace {
+
+struct MyDebugInfo : public DebugInfoBase {
+  explicit MyDebugInfo(int v) : value(v) {}
+  int value;
+};
+
+TEST(ThreadLocalDebugInfo, GetCustomKind) {
+  static constexpr std::string_view kKindStr = "CustomKind_Push";
+  const DebugInfoKind kKind(&kKindStr);
+
+  auto info = std::make_shared<MyDebugInfo>(42);
+  ThreadLocalDebugInfo::_push(kKind, info);
+
+  EXPECT_EQ(ThreadLocalDebugInfo::get(kKind), info.get());
+
+  ThreadLocalDebugInfo::_pop(kKind);
+}
+
+TEST(ThreadLocalDebugInfo, PeekCustomKind) {
+  static constexpr std::string_view kKindStr = "CustomKind_Peek";
+  const DebugInfoKind kKind(&kKindStr);
+
+  auto info = std::make_shared<MyDebugInfo>(42);
+  ThreadLocalDebugInfo::_push(kKind, info);
+
+  EXPECT_EQ(ThreadLocalDebugInfo::_peek(kKind), info);
+
+  ThreadLocalDebugInfo::_pop(kKind);
+}
+
+TEST(ThreadLocalDebugInfo, PopCustomKind) {
+  static constexpr std::string_view kKindStr = "CustomKind_Pop";
+  const DebugInfoKind kKind(&kKindStr);
+
+  auto info = std::make_shared<MyDebugInfo>(42);
+  ThreadLocalDebugInfo::_push(kKind, info);
+
+  EXPECT_EQ(ThreadLocalDebugInfo::_pop(kKind), info);
+}
+
+TEST(ThreadLocalDebugInfo, PopThrowsOnMismatch) {
+  static constexpr std::string_view kKindStr1 = "CustomKind_PopMismatch1";
+  const DebugInfoKind kKind1(&kKindStr1);
+  static constexpr std::string_view kKindStr2 = "CustomKind_PopMismatch2";
+  const DebugInfoKind kKind2(&kKindStr2);
+
+  auto info = std::make_shared<MyDebugInfo>(42);
+  ThreadLocalDebugInfo::_push(kKind1, info);
+
+  EXPECT_THROW(ThreadLocalDebugInfo::_pop(kKind2), c10::Error);
+
+  ThreadLocalDebugInfo::_pop(kKind1);
+}
+
+TEST(ThreadLocalDebugInfo, PeekThrowsOnMismatch) {
+  static constexpr std::string_view kKindStr1 = "CustomKind_PeekMismatch1";
+  const DebugInfoKind kKind1(&kKindStr1);
+  static constexpr std::string_view kKindStr2 = "CustomKind_PeekMismatch2";
+  const DebugInfoKind kKind2(&kKindStr2);
+
+  auto info = std::make_shared<MyDebugInfo>(42);
+  ThreadLocalDebugInfo::_push(kKind1, info);
+
+  EXPECT_THROW(ThreadLocalDebugInfo::_peek(kKind2), c10::Error);
+
+  ThreadLocalDebugInfo::_pop(kKind1);
+}
+
+}  // namespace
+}  // namespace c10

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -1,10 +1,38 @@
 #include <c10/util/Exception.h>
+#include <c10/util/Logging.h>
 #include <c10/util/ThreadLocal.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
 
+#include <ostream>
+#include <string_view>
 #include <utility>
 
 namespace c10 {
+
+constexpr std::string_view kProducerInfoName = "PRODUCER_INFO";
+constexpr std::string_view kMobileRuntimeInfoName = "MOBILE_RUNTIME_INFO";
+constexpr std::string_view kProfilerStateName = "PROFILER_STATE";
+constexpr std::string_view kInferenceContextName = "INFERENCE_CONTEXT";
+constexpr std::string_view kParamCommsInfoName = "PARAM_COMMS_INFO";
+constexpr std::string_view kTestInfoName = "TEST_INFO";
+constexpr std::string_view kTestInfo2Name = "TEST_INFO_2";
+
+const DebugInfoKind DebugInfoKind::PRODUCER_INFO(&kProducerInfoName);
+const DebugInfoKind DebugInfoKind::MOBILE_RUNTIME_INFO(&kMobileRuntimeInfoName);
+const DebugInfoKind DebugInfoKind::PROFILER_STATE(&kProfilerStateName);
+const DebugInfoKind DebugInfoKind::INFERENCE_CONTEXT(&kInferenceContextName);
+const DebugInfoKind DebugInfoKind::PARAM_COMMS_INFO(&kParamCommsInfoName);
+const DebugInfoKind DebugInfoKind::TEST_INFO(&kTestInfoName);
+const DebugInfoKind DebugInfoKind::TEST_INFO_2(&kTestInfo2Name);
+
+DebugInfoKind::DebugInfoKind(DebugInfoKind::value_type value) : value_(value) {
+  CHECK(value_ != nullptr)  // Crash OK as this indicates a bug in C++ code.
+      << "DebugInfoKind must be initialized with a non-null pointer.";
+}
+
+std::ostream& operator<<(std::ostream& os, const DebugInfoKind& kind) {
+  return os << (kind.value_ == nullptr ? "<uninitialized>" : *kind.value_);
+}
 
 C10_DEFINE_TLS_static(std::shared_ptr<ThreadLocalDebugInfo>, tls_debug_info);
 #define debug_info (tls_debug_info.get())
@@ -45,10 +73,8 @@ void ThreadLocalDebugInfo::_push(
 
 /* static */
 std::shared_ptr<DebugInfoBase> ThreadLocalDebugInfo::_pop(DebugInfoKind kind) {
-  TORCH_CHECK(
-      debug_info && debug_info->kind_ == kind,
-      "Expected debug info of type ",
-      (size_t)kind);
+  TORCH_CHECK(debug_info && debug_info->kind_ == kind,
+              "Expected debug info of type ", kind);
   auto res = debug_info;
   debug_info = debug_info->parent_info_;
   return res->info_;
@@ -56,10 +82,8 @@ std::shared_ptr<DebugInfoBase> ThreadLocalDebugInfo::_pop(DebugInfoKind kind) {
 
 /* static */
 std::shared_ptr<DebugInfoBase> ThreadLocalDebugInfo::_peek(DebugInfoKind kind) {
-  TORCH_CHECK(
-      debug_info && debug_info->kind_ == kind,
-      "Expected debug info of type ",
-      (size_t)kind);
+  TORCH_CHECK(debug_info && debug_info->kind_ == kind,
+              "Expected debug info of type ", kind);
   return debug_info->info_;
 }
 

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -26,7 +26,8 @@ const DebugInfoKind DebugInfoKind::TEST_INFO(&kTestInfoName);
 const DebugInfoKind DebugInfoKind::TEST_INFO_2(&kTestInfo2Name);
 
 DebugInfoKind::DebugInfoKind(DebugInfoKind::value_type value) : value_(value) {
-  CHECK(value_ != nullptr)  // Crash OK as this indicates a bug in C++ code.
+  // Crash OK as this indicates a bug in C++ code.
+  TORCH_INTERNAL_ASSERT(value_ != nullptr)
       << "DebugInfoKind must be initialized with a non-null pointer.";
 }
 

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -2,20 +2,55 @@
 
 #include <c10/macros/Export.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <ostream>
+#include <string_view>
 
 namespace c10 {
 
-enum class C10_API_ENUM DebugInfoKind : uint8_t {
-  PRODUCER_INFO = 0,
-  MOBILE_RUNTIME_INFO,
-  PROFILER_STATE,
-  INFERENCE_CONTEXT, // for inference usage
-  PARAM_COMMS_INFO,
+// Identifies a slot in ThreadLocalDebugInfo for storing a specific type
+// of python-thread-local state.
+//
+// This class is trivial to copy and move, and is cheap to construct and
+// destroy. It mimics the behavior of an enum class for backward compatibility
+// with existing uses.
+class C10_API DebugInfoKind {
+ private:
+  // Must be a non-null pointer to a string literal with static storage
+  // duration. The pointer address is used as the identifier for the slot.
+  // The string itself is only used for debugging purposes and should be
+  // descriptive of the slot's purpose and ideally (but not required) be unique.
+  using value_type = const std::string_view*;  // Must be non-null.
 
-  TEST_INFO, // used only in tests
-  TEST_INFO_2, // used only in tests
+ public:
+  // Creates an uninitialized DebugInfoKind.
+  DebugInfoKind() = default;
+
+  // Creates a DebugInfoKind with the given identity.
+  explicit DebugInfoKind(value_type value);
+
+  // Predefined DebugInfoKinds for common use cases.
+  static const DebugInfoKind PRODUCER_INFO;
+  static const DebugInfoKind MOBILE_RUNTIME_INFO;
+  static const DebugInfoKind PROFILER_STATE;
+  static const DebugInfoKind INFERENCE_CONTEXT;  // for inference usage
+  static const DebugInfoKind PARAM_COMMS_INFO;
+  static const DebugInfoKind TEST_INFO;    // used only in tests
+  static const DebugInfoKind TEST_INFO_2;  // used only in tests
+
+  constexpr bool operator==(const DebugInfoKind& other) const {
+    return value_ == other.value_;
+  }
+  constexpr bool operator!=(const DebugInfoKind& other) const {
+    return value_ != other.value_;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const DebugInfoKind& kind);
+
+ private:
+  value_type value_ = nullptr;
 };
 
 class C10_API DebugInfoBase {

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -2,10 +2,9 @@
 
 #include <c10/macros/Export.h>
 
-#include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <ostream>
+#include <iosfwd>
 #include <string_view>
 
 namespace c10 {

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -3,8 +3,8 @@
 #include <c10/macros/Export.h>
 
 #include <cstdint>
-#include <memory>
 #include <iosfwd>
+#include <memory>
 #include <string_view>
 
 namespace c10 {


### PR DESCRIPTION
Ported from: https://github.com/pytorch/pytorch/pull/180001

This PR fixes https://github.com/pytorch/pytorch/issues/56027.

It changes the `DebugInfoKind` type from an `uint8_t`-based `enum class` to a thin wrapper of a pointer, where the pointer address is used to identify the kind. This allows defining new kinds freely.

To maintain backward compatibility with existing code, we add methods and member variables to this class to mimic the old `enum class` interface.