### PR TITLE
[PyTorch] Fix binary_cross_entropy SymInt error with dynamic shapes (#180583)

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -9103,9 +9103,6 @@ symbolic_aot_autograd_failures = {
         "nn.functional.batch_norm", ""
     ),  # '0 is not tracked with proxy for <torch.fx.experimental.proxy_te..
     xfail(
-        "nn.functional.binary_cross_entropy", ""
-    ),  # aten.fill_.Scalar - couldn't find symbolic meta funct...
-    xfail(
         "nn.functional.cross_entropy", ""
     ),  # Cannot call sizes() on tensor with symbolic sizes/strides
     xfail(
@@ -9318,8 +9315,6 @@ symbolic_aot_autograd_module_failures = {
     torch.nn.TransformerEncoder,  # DataDependentOutputException: aten.equal compares a mask input to a mask producing a bool
     torch.nn.GaussianNLLLoss,  # NotImplementedError: local_scalar_dense/item NYI for torch.bool
     torch.nn.FractionalMaxPool3d,  # int() argument must be a string, a bytes-like object or a number, not 'SymFloat'
-    torch.nn.BCELoss,  # new_size = _infer_size(target.size(), weight.size())
-    # RuntimeError: expected int at position 0, but got: SymInt
 }
 
 

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -2059,7 +2059,6 @@ symbolic_tensor_failures = {
     xfail('geqrf', ''),  # aten.geqrf.default - couldn't find symbolic meta function/decomposition
     xfail('histogram', ''),  # Could not run 'aten::histogram.bin_ct' with arguments from the 'Meta' backend. This c...
     xfail('histogramdd', ''),  # aten._histogramdd_bin_edges.default - couldn't find symbolic meta function/decomposition
-    xfail('nn.functional.binary_cross_entropy', ''),  # aten.new_empty.default - couldn't find symbolic meta function/decom...
     xfail('nn.functional.cross_entropy', ''),  # aten.size.default - couldn't find symbolic meta function/decomposition
     xfail('nn.functional.ctc_loss'),  # aten._ctc_loss.Tensor - couldn't find symbolic meta function/decomposition
 

--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -326,6 +326,15 @@ RegisterOperators reg({
         aliasAnalysisFromSchema()),
     OperatorGenerator(
         TORCH_SELECTIVE_SCHEMA(
+            "aten::broadcast_shapes(int[] a, int[] b) -> int[]"),
+        [](Stack& stack) {
+          auto a = pop(stack);
+          auto b = pop(stack);
+          push(stack, at::infer_size(a.toDimVector(), b.toDimVector()));
+        },
+        aliasAnalysisFromSchema()),
+    OperatorGenerator(
+        TORCH_SELECTIVE_SCHEMA(
             "aten::_no_grad_embedding_renorm_(Tensor weight, Tensor input, float max_norm, float norm_type) -> Tensor"),
         [](Stack& stack) {
           at::Tensor weight;

--- a/torch/jit/_builtins.py
+++ b/torch/jit/_builtins.py
@@ -101,6 +101,7 @@ _builtin_ops = [
     (torch.autograd.grad, "aten::grad"),
     (torch.autograd.backward, "aten::backward"),
     (torch._C._infer_size, "aten::_infer_size"),
+    (torch.broadcast_shapes, "aten::broadcast_shapes"),
     (
         torch.nn.functional._no_grad_embedding_renorm_,  # type: ignore[attr-defined]
         "aten::_no_grad_embedding_renorm_",

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -10,7 +10,6 @@ import torch
 from torch import _VF, sym_int as _sym_int, Tensor
 from torch._C import (
     _add_docstr,
-    _infer_size,
     _ScalingType as ScalingType,  # pyrefly: ignore [missing-module-attribute]
     _SwizzleType as SwizzleType,  # pyrefly: ignore [missing-module-attribute]
 )
@@ -3570,7 +3569,7 @@ def binary_cross_entropy(
         )
 
     if weight is not None:
-        new_size = _infer_size(target.size(), weight.size())
+        new_size = torch.broadcast_shapes(target.size(), weight.size())
         weight = weight.expand(new_size)
 
     # pyrefly: ignore [bad-argument-type]


### PR DESCRIPTION
Summary:

`F.binary_cross_entropy` uses `_infer_size` to broadcast the weight tensor shape against the target. `_infer_size` internally uses `THPUtils_unpackLongs` which can't handle SymInt values — it expects concrete `int64_t`. This causes `RuntimeError: expected int at position 0, but got: SymInt` when tracing with symbolic shapes.

This diff replaces `_infer_size` with `torch.broadcast_shapes` which natively supports SymInt and symbolic shape values. To maintain TorchScript compatibility, `aten::broadcast_shapes` is registered as a new JIT builtin op backed by the same `at::infer_size` implementation.

Changes:
- `torch/nn/functional.py`: Replace `_infer_size` with `torch.broadcast_shapes`, remove unused `_infer_size` import
- `torch/csrc/jit/runtime/register_special_ops.cpp`: Register `aten::broadcast_shapes(int[] a, int[] b) -> int[]` as a TorchScript op
- `torch/jit/_builtins.py`: Map `torch.broadcast_shapes` to `aten::broadcast_shapes` builtin
- `test/functorch/test_aotdispatch.py`: Remove BCELoss / binary_cross_entropy from symbolic xfail lists (now passing)
- `test/test_proxy_tensor.py`: Remove binary_cross_entropy from symbolic xfail list (now passing)

Test Plan:
```
python test/test_jit.py TestJitGeneratedModule.test_nn_BCELoss_no_batch_dim_mean
# PASS — verifies TorchScript can compile BCELoss with broadcast_shapes

python -m pytest test/functorch/test_aotdispatch.py -k test_aot_autograd_symbolic_module_exhaustive_nn_BCELoss_cpu_float32
# PASS — verifies symbolic shapes work with BCELoss module

python -m pytest test/functorch/test_aotdispatch.py -k test_aot_autograd_symbolic_exhaustive_nn_functional_binary_cross_entropy_cpu_float32
# PASS — verifies symbolic shapes work with F.binary_cross_entropy

python -m pytest test/test_proxy_tensor.py -k test_make_fx_symbolic_exhaustive_nn_functional_binary_cross_entropy_cpu_float32
# PASS — verifies make_fx symbolic tracing works
```

Reviewed By: slayton58

Differential Revision: D101206150


