### PR TITLE
[inductor][cutlass] Filter CUTLASS kernels by "fastaccum" only on Hopper

### DIFF
--- a/torch/_inductor/codegen/cutlass/gemm_template.py
+++ b/torch/_inductor/codegen/cutlass/gemm_template.py
@@ -442,6 +442,7 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
             beta (float): The scaling factor applied to the output matrix.
             input_reorder (Optional[List[int]]): Specifies the reordering of the input nodes. If not provided,
                             no reordering is performed. Defaults to None.
+            use_fast_accum (Optional[bool]): enable/disable tensor-core fast accumulation (only available in `CUTLASS3xGemmTemplate` and Hopper GPUs)
         """
         super().__init__(
             str(Placeholder.KERNEL_NAME), input_nodes, layout, input_reorder
@@ -979,7 +980,10 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
         # TODO: update epilogue functor according to epilogues.
         op.element_epilogue = op.accumulator_type()
 
-        if self.use_fast_accum is not None:
+        if (
+            self.use_fast_accum is not None
+            and cutlass_utils._normalize_cuda_arch(cuda_env.get_cuda_arch()) == 90
+        ):
             is_op_fast_accum = "fastaccum" in op.configuration_name()
             if self.use_fast_accum ^ is_op_fast_accum:
                 return None

--- a/torch/_inductor/codegen/cutlass/gemm_template.py
+++ b/torch/_inductor/codegen/cutlass/gemm_template.py
@@ -982,7 +982,7 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
 
         if (
             self.use_fast_accum is not None
-            and cutlass_utils._normalize_cuda_arch(cuda_env.get_cuda_arch()) == 90
+            and int(cutlass_utils._normalize_cuda_arch(cuda_env.get_cuda_arch())) == 90
         ):
             is_op_fast_accum = "fastaccum" in op.configuration_name()
             if self.use_fast_accum ^ is_op_fast_accum:


### PR DESCRIPTION
Mainly to avoid potentially surprising `NoValidChoicesError` on Blackwell.

When there's a program where `torch.compile` and `F.scaled_mm` and/or `F.scaled_grouped
_mm` with `use_fast_accum=True` and it's been used on Hopper GPUs, then we'd see `NoValidChoicesError` by running that program on Blackwell on a whim.

Signed-off-by: Masaki Kozuki <mkozuki@nvidia.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo