### PR TITLE
Add `CosineLR`: a composable, multiplicative cosine learning rate scheduler

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -535,10 +535,9 @@ class TestLRScheduler(TestCase):
         base_lr = 0.05
 
         def _factor(t):
-            return (
-                0.5 * (start_factor + end_factor)
-                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
-            )
+            return 0.5 * (start_factor + end_factor) + 0.5 * (
+                start_factor - end_factor
+            ) * math.cos(math.pi * t / iters)
 
         single_targets = [base_lr * _factor(min(t, iters)) for t in range(epochs)]
         targets = [single_targets, [x * epochs for x in single_targets]]
@@ -559,10 +558,9 @@ class TestLRScheduler(TestCase):
         base_lr = 0.05
 
         def _factor(t):
-            return (
-                0.5 * (start_factor + end_factor)
-                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
-            )
+            return 0.5 * (start_factor + end_factor) + 0.5 * (
+                start_factor - end_factor
+            ) * math.cos(math.pi * t / iters)
 
         single_targets = [base_lr * _factor(min(t, iters)) for t in range(epochs)]
         targets = [single_targets, [x * epochs for x in single_targets]]
@@ -594,10 +592,9 @@ class TestLRScheduler(TestCase):
         base_lr = 0.05
 
         def _factor(t):
-            return (
-                0.5 * (start_factor + end_factor)
-                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
-            )
+            return 0.5 * (start_factor + end_factor) + 0.5 * (
+                start_factor - end_factor
+            ) * math.cos(math.pi * t / iters)
 
         single_targets = [base_lr * _factor(min(t, iters)) for t in range(epochs)]
         targets = [single_targets, [x * 10 for x in single_targets]]
@@ -617,10 +614,9 @@ class TestLRScheduler(TestCase):
         base_lr = 0.05
 
         def _factor(t):
-            return (
-                0.5 * (start_factor + end_factor)
-                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
-            )
+            return 0.5 * (start_factor + end_factor) + 0.5 * (
+                start_factor - end_factor
+            ) * math.cos(math.pi * t / iters)
 
         single_targets = [base_lr * _factor(min(t, iters)) for t in range(epochs)]
         targets = [single_targets, [x * 10 for x in single_targets]]
@@ -678,9 +674,7 @@ class TestLRScheduler(TestCase):
         self._test_against_closed_form(scheduler, closed_form_scheduler, 20)
 
     def test_closed_form_cosinelr(self):
-        scheduler = CosineLR(
-            self.opt, start_factor=0.3, end_factor=0.7, total_iters=6
-        )
+        scheduler = CosineLR(self.opt, start_factor=0.3, end_factor=0.7, total_iters=6)
         closed_form_scheduler = CosineLR(
             self.opt, start_factor=0.3, end_factor=0.7, total_iters=6
         )
@@ -1139,10 +1133,9 @@ class TestLRScheduler(TestCase):
         base_lr = 0.05
 
         def _factor(t):
-            return (
-                0.5 * (start_factor + end_factor)
-                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
-            )
+            return 0.5 * (start_factor + end_factor) + 0.5 * (
+                start_factor - end_factor
+            ) * math.cos(math.pi * t / iters)
 
         schedulers = [None] * 2
         single_targets = [base_lr * (0.9**x) for x in range(epochs)]
@@ -1166,10 +1159,9 @@ class TestLRScheduler(TestCase):
         base_lr = 0.05
 
         def _factor(t):
-            return (
-                0.5 * (start_factor + end_factor)
-                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
-            )
+            return 0.5 * (start_factor + end_factor) + 0.5 * (
+                start_factor - end_factor
+            ) * math.cos(math.pi * t / iters)
 
         schedulers = [None] * 2
         # StepLR: decay by 0.1 every 3 steps

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -17,6 +17,7 @@ from torch.optim.lr_scheduler import (
     ConstantLR,
     CosineAnnealingLR,
     CosineAnnealingWarmRestarts,
+    CosineLR,
     CyclicLR,
     EPOCH_DEPRECATION_WARNING,
     ExponentialLR,
@@ -340,6 +341,10 @@ class TestLRScheduler(TestCase):
         scheduler = PolynomialLR(self.opt, power=0.9)
         self._test_lr_is_constant_for_constant_epoch(scheduler)
 
+    def test_cosinelr_is_constant_for_constant_epoch(self):
+        scheduler = CosineLR(self.opt)
+        self._test_lr_is_constant_for_constant_epoch(scheduler)
+
     def test_step_lr(self):
         # lr = 0.05     if epoch < 3
         # lr = 0.005    if 30 <= epoch < 6
@@ -519,6 +524,114 @@ class TestLRScheduler(TestCase):
         scheduler = PolynomialLR(self.opt, power=power, total_iters=total_iters)
         self._test(scheduler, targets, epochs)
 
+    def test_cosinelr(self):
+        # Cosine decay from start_factor=1.0 to end_factor=0.0 over 4 iters
+        # factor(t) = 0.5 * (1 + 0) + 0.5 * (1 - 0) * cos(pi * t / 4)
+        #           = 0.5 + 0.5 * cos(pi * t / 4)
+        epochs = 10
+        start_factor = 1.0
+        end_factor = 0.0
+        iters = 4
+        base_lr = 0.05
+
+        def _factor(t):
+            return (
+                0.5 * (start_factor + end_factor)
+                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
+            )
+
+        single_targets = [base_lr * _factor(min(t, iters)) for t in range(epochs)]
+        targets = [single_targets, [x * epochs for x in single_targets]]
+        scheduler = CosineLR(
+            self.opt,
+            start_factor=start_factor,
+            end_factor=end_factor,
+            total_iters=iters,
+        )
+        self._test(scheduler, targets, epochs)
+
+    def test_cosinelr_warmup(self):
+        # Cosine warmup from start_factor=0.1 to end_factor=1.0 over 5 iters
+        epochs = 10
+        start_factor = 0.1
+        end_factor = 1.0
+        iters = 5
+        base_lr = 0.05
+
+        def _factor(t):
+            return (
+                0.5 * (start_factor + end_factor)
+                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
+            )
+
+        single_targets = [base_lr * _factor(min(t, iters)) for t in range(epochs)]
+        targets = [single_targets, [x * epochs for x in single_targets]]
+        scheduler = CosineLR(
+            self.opt,
+            start_factor=start_factor,
+            end_factor=end_factor,
+            total_iters=iters,
+        )
+        self._test(scheduler, targets, epochs)
+
+    def test_cosinelr_start_factor_limits(self):
+        with self.assertRaises(ValueError):
+            CosineLR(self.opt, start_factor=0.0, total_iters=4)
+        with self.assertRaises(ValueError):
+            CosineLR(self.opt, start_factor=1.1, total_iters=4)
+
+    def test_cosinelr_end_factor_limits(self):
+        with self.assertRaises(ValueError):
+            CosineLR(self.opt, end_factor=-0.1, total_iters=4)
+        with self.assertRaises(ValueError):
+            CosineLR(self.opt, end_factor=1.1, total_iters=4)
+
+    def test_get_last_lr_cosinelr(self):
+        epochs = 10
+        start_factor = 0.5
+        end_factor = 0.1
+        iters = 4
+        base_lr = 0.05
+
+        def _factor(t):
+            return (
+                0.5 * (start_factor + end_factor)
+                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
+            )
+
+        single_targets = [base_lr * _factor(min(t, iters)) for t in range(epochs)]
+        targets = [single_targets, [x * 10 for x in single_targets]]
+        scheduler = CosineLR(
+            self.opt,
+            start_factor=start_factor,
+            end_factor=end_factor,
+            total_iters=iters,
+        )
+        self._test_get_last_lr(scheduler, targets, epochs)
+
+    def test_cosinelr_with_epoch(self):
+        epochs = 10
+        start_factor = 0.5
+        end_factor = 0.01
+        iters = 4
+        base_lr = 0.05
+
+        def _factor(t):
+            return (
+                0.5 * (start_factor + end_factor)
+                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
+            )
+
+        single_targets = [base_lr * _factor(min(t, iters)) for t in range(epochs)]
+        targets = [single_targets, [x * 10 for x in single_targets]]
+        scheduler = CosineLR(
+            self.opt,
+            start_factor=start_factor,
+            end_factor=end_factor,
+            total_iters=iters,
+        )
+        self._test_with_epoch(scheduler, targets, epochs)
+
     def test_cos_anneal_lr(self):
         epochs = 10
         eta_min = 1e-10
@@ -562,6 +675,15 @@ class TestLRScheduler(TestCase):
     def test_closed_form_poly_lr(self):
         scheduler = PolynomialLR(self.opt, power=0.9)
         closed_form_scheduler = PolynomialLR(self.opt, power=0.9)
+        self._test_against_closed_form(scheduler, closed_form_scheduler, 20)
+
+    def test_closed_form_cosinelr(self):
+        scheduler = CosineLR(
+            self.opt, start_factor=0.3, end_factor=0.7, total_iters=6
+        )
+        closed_form_scheduler = CosineLR(
+            self.opt, start_factor=0.3, end_factor=0.7, total_iters=6
+        )
         self._test_against_closed_form(scheduler, closed_form_scheduler, 20)
 
     def test_closed_form_cos_anneal_lr(self):
@@ -1007,6 +1129,62 @@ class TestLRScheduler(TestCase):
         targets = [single_targets, [x * epochs for x in single_targets]]
         schedulers[0] = MultiStepLR(self.opt, gamma=0.1, milestones=[2, 5, 9])
         schedulers[1] = LinearLR(self.opt, start_factor=start_factor, total_iters=iters)
+        self._test(schedulers, targets, epochs)
+
+    def test_compound_cosinelr_and_exp_lr(self):
+        epochs = 10
+        start_factor = 0.4
+        end_factor = 1.0
+        iters = 4
+        base_lr = 0.05
+
+        def _factor(t):
+            return (
+                0.5 * (start_factor + end_factor)
+                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
+            )
+
+        schedulers = [None] * 2
+        single_targets = [base_lr * (0.9**x) for x in range(epochs)]
+        for i in range(epochs):
+            single_targets[i] *= _factor(min(i, iters))
+        targets = [single_targets, [x * 10 for x in single_targets]]
+        schedulers[0] = CosineLR(
+            self.opt,
+            start_factor=start_factor,
+            end_factor=end_factor,
+            total_iters=iters,
+        )
+        schedulers[1] = ExponentialLR(self.opt, gamma=0.9)
+        self._test(schedulers, targets, epochs)
+
+    def test_compound_cosinelr_and_step_lr(self):
+        epochs = 10
+        start_factor = 0.5
+        end_factor = 0.1
+        iters = 6
+        base_lr = 0.05
+
+        def _factor(t):
+            return (
+                0.5 * (start_factor + end_factor)
+                + 0.5 * (start_factor - end_factor) * math.cos(math.pi * t / iters)
+            )
+
+        schedulers = [None] * 2
+        # StepLR: decay by 0.1 every 3 steps
+        step_targets = [base_lr * (0.1 ** (x // 3)) for x in range(epochs)]
+        single_targets = [
+            step_targets[i] * _factor(min(i, iters)) for i in range(epochs)
+        ]
+        targets = [single_targets, [x * 10 for x in single_targets]]
+        schedulers[0] = StepLR(self.opt, gamma=0.1, step_size=3)
+        schedulers[1] = CosineLR(
+            self.opt,
+            start_factor=start_factor,
+            end_factor=end_factor,
+            total_iters=iters,
+        )
         self._test(schedulers, targets, epochs)
 
     def test_compound_cosanneal_and_step_lr(self):
@@ -2114,7 +2292,13 @@ class TestLRScheduler(TestCase):
             lambda: ExponentialLR(self.opt, gamma=0.01),
         )
 
-    def test_cosine_lr_state_dict(self):
+    def test_cosinelr_state_dict(self):
+        self._check_scheduler_state_dict(
+            lambda: CosineLR(self.opt, start_factor=0.5, end_factor=0.1, total_iters=4),
+            lambda: CosineLR(self.opt, start_factor=0.9, end_factor=0.3, total_iters=8),
+        )
+
+    def test_cosine_annealing_lr_state_dict(self):
         epochs = 10
         eta_min = 1e-10
         self._check_scheduler_state_dict(

--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -582,7 +582,7 @@ class TestLRScheduler(TestCase):
 
     def test_cosinelr_end_factor_limits(self):
         with self.assertRaises(ValueError):
-            CosineLR(self.opt, end_factor=-0.1, total_iters=4)
+            CosineLR(self.opt, end_factor=0.0, total_iters=4)
         with self.assertRaises(ValueError):
             CosineLR(self.opt, end_factor=1.1, total_iters=4)
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1334,6 +1334,7 @@ class PolynomialLR(LRScheduler):
             for base_lr in self.base_lrs
         ]
 
+
 class CosineLR(LRScheduler):
     r"""Scale the learning rate of each parameter group using a cosine interpolation.
 
@@ -1438,11 +1439,9 @@ class CosineLR(LRScheduler):
             + \frac{\gamma_s - \gamma_e}{2}
             \cos \left(\frac{t \pi}{T}\right)
         """
-        return (
-            0.5 * (self.start_factor + self.end_factor)
-            + 0.5 * (self.start_factor - self.end_factor)
-            * math.cos(math.pi * step / max(1, self.total_iters))
-        )
+        return 0.5 * (self.start_factor + self.end_factor) + 0.5 * (
+            self.start_factor - self.end_factor
+        ) * math.cos(math.pi * step / max(1, self.total_iters))
 
     @override
     def get_lr(self) -> list[float | Tensor]:
@@ -1474,16 +1473,14 @@ class CosineLR(LRScheduler):
 
         if self.last_epoch == 0:
             return [
-                group["lr"] * self.start_factor
-                for group in self.optimizer.param_groups
+                group["lr"] * self.start_factor for group in self.optimizer.param_groups
             ]
 
         if self._is_initial or self.last_epoch > self.total_iters:
             return _param_groups_val_list(self.optimizer, "lr")
 
-        factor = (
-            self._compute_factor(self.last_epoch)
-            / self._compute_factor(self.last_epoch - 1)
+        factor = self._compute_factor(self.last_epoch) / self._compute_factor(
+            self.last_epoch - 1
         )
         return [group["lr"] * factor for group in self.optimizer.param_groups]
 
@@ -1504,10 +1501,10 @@ class CosineLR(LRScheduler):
             same types as their current ``group["lr"]``\s.
         """
         return [
-            base_lr
-            * self._compute_factor(min(self.total_iters, self.last_epoch))
+            base_lr * self._compute_factor(min(self.total_iters, self.last_epoch))
             for base_lr in self.base_lrs
         ]
+
 
 class CosineAnnealingLR(LRScheduler):
     r"""

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1347,10 +1347,20 @@ class CosineLR(LRScheduler):
     .. math::
         \gamma_t = \frac{\gamma_s + \gamma_e}{2}
         + \frac{\gamma_s - \gamma_e}{2}
-        \cos\!\left(\frac{t \, \pi}{T}\right)
+        \cos \left(\frac{t \pi}{T}\right)
 
     where :math:`\gamma_s` is ``start_factor``, :math:`\gamma_e` is
     ``end_factor``, and :math:`T` is ``total_iters``.
+
+    In particular:
+
+    .. math::
+        \forall t \gamma_t \in \left[ \gamma_{min}; \gamma_{max} \right] \\
+        \gamma_{min} = min(\gamma_s, \gamma_e) \\
+        \gamma_{max} = max(\gamma_s, \gamma_e)
+
+    Which guarantees that :math:`\gamma_t > 0` given the constraints on the
+    starting and ending factors.
 
     The learning rate is updated recursively as:
 
@@ -1423,9 +1433,9 @@ class CosineLR(LRScheduler):
         r"""Compute the multiplicative factor at step ``step``.
 
         .. math::
-            \gamma_t = \frac{1}{2}\left(\gamma_s + \gamma_e\right)
-            + \frac{1}{2}\left(\gamma_s - \gamma_e\right)
-            \cos\!\left(\frac{t \, \pi}{T}\right)
+            \gamma_t = \frac{\gamma_s + \gamma_e}{2}
+            + \frac{\gamma_s - \gamma_e}{2}
+            \cos \left(\frac{t \pi}{T}\right)
         """
         return (
             0.5 * (self.start_factor + self.end_factor)

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1333,6 +1333,170 @@ class PolynomialLR(LRScheduler):
             for base_lr in self.base_lrs
         ]
 
+class CosineLR(LRScheduler):
+    r"""Scale the learning rate of each parameter group using a cosine interpolation.
+
+    The multiplicative factor changes from ``start_factor`` to ``end_factor``
+    following a cosine curve over ``total_iters`` steps. Unlike
+    :class:`CosineAnnealingLR`, this scheduler applies a **relative** factor to
+    the current learning rate, making it fully composable with
+    :class:`ChainedScheduler` and other multiplicative schedulers.
+
+    The factor at step :math:`t` is defined as:
+
+    .. math::
+        \gamma_t = \frac{\gamma_s + \gamma_e}{2}
+        + \frac{\gamma_s - \gamma_e}{2}
+        \cos\!\left(\frac{t \, \pi}{T}\right)
+
+    where :math:`\gamma_s` is ``start_factor``, :math:`\gamma_e` is
+    ``end_factor``, and :math:`T` is ``total_iters``.
+
+    The learning rate is updated recursively as:
+
+    .. math::
+        \text{lr}_t = \text{lr}_{t-1} \cdot \frac{\gamma_t}{\gamma_{t-1}}
+
+    Notice that the factor can increase or decrease depending on the
+    relationship between ``start_factor`` and ``end_factor``. Such changes can
+    happen simultaneously with other changes to the learning rate from outside
+    this scheduler. When last_epoch=-1, sets initial lr as lr.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        start_factor (float): The number we multiply learning rate in the
+            first epoch. Default: 1.0.
+        end_factor (float): The number we multiply learning rate at the end
+            of the cosine interpolation. Default: 0.01.
+        total_iters (int): The number of iterations over which the
+            multiplicative factor interpolates from ``start_factor`` to
+            ``end_factor``. Default: 5.
+        last_epoch (int): The index of the last epoch. Default: -1.
+
+    Example:
+        >>> # xdoctest: +SKIP
+        >>> # Assuming optimizer uses lr = 0.05 for all groups
+        >>> # Cosine decay from lr to 0.01 * lr over 100 epochs
+        >>> scheduler = CosineLR(optimizer, start_factor=1.0, end_factor=0.01, total_iters=100)
+        >>> for epoch in range(100):
+        >>>     train(...)
+        >>>     validate(...)
+        >>>     scheduler.step()
+        >>>
+        >>> # Cosine warmup from 0.1 * lr to lr over 10 epochs
+        >>> scheduler = CosineLR(optimizer, start_factor=0.1, end_factor=1.0, total_iters=10)
+        >>> for epoch in range(100):
+        >>>     train(...)
+        >>>     validate(...)
+        >>>     scheduler.step()
+        >>>
+        >>> # Composable: cosine warmup + exponential decay
+        >>> scheduler1 = CosineLR(optimizer, start_factor=0.1, end_factor=1.0, total_iters=10)
+        >>> scheduler2 = ExponentialLR(optimizer, gamma=0.95)
+        >>> scheduler = ChainedScheduler([scheduler1, scheduler2])
+    """
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        start_factor: float = 1.0,
+        end_factor: float = 0.01,
+        total_iters: int = 5,
+        last_epoch: int = -1,
+    ) -> None:  # noqa: D107
+        if start_factor > 1.0 or start_factor <= 0:
+            raise ValueError(
+                "Starting multiplicative factor expected to be greater than 0 and less or equal to 1."
+            )
+
+        if end_factor > 1.0 or end_factor < 0:
+            raise ValueError(
+                "Ending multiplicative factor expected to be between 0 and 1."
+            )
+
+        self.start_factor = start_factor
+        self.end_factor = end_factor
+        self.total_iters = total_iters
+        super().__init__(optimizer, last_epoch)
+
+    def _compute_factor(self, step: int) -> float:
+        r"""Compute the multiplicative factor at step ``step``.
+
+        .. math::
+            \gamma_t = \frac{1}{2}\left(\gamma_s + \gamma_e\right)
+            + \frac{1}{2}\left(\gamma_s - \gamma_e\right)
+            \cos\!\left(\frac{t \, \pi}{T}\right)
+        """
+        return (
+            0.5 * (self.start_factor + self.end_factor)
+            + 0.5 * (self.start_factor - self.end_factor)
+            * math.cos(math.pi * step / self.total_iters)
+        )
+
+    @override
+    def get_lr(self) -> list[float | Tensor]:
+        r"""Compute the next learning rate for each of the optimizer's
+        :attr:`~torch.optim.Optimizer.param_groups`.
+
+        Scales the ``group["lr"]``\s in the optimizer's
+        :attr:`~torch.optim.Optimizer.param_groups` such that successive steps
+        interpolate along a cosine curve from :attr:`start_factor` to
+        :attr:`end_factor` across :attr:`total_iters` steps:
+
+        .. math::
+            \text{lr}_t = \text{lr}_{t-1} \cdot \frac{\gamma_t}{\gamma_{t-1}}
+
+        Returns:
+            list[float | Tensor]: A :class:`list` of learning rates for each of
+            the optimizer's :attr:`~torch.optim.Optimizer.param_groups` with the
+            same types as their current ``group["lr"]``\s.
+
+        .. note::
+            If you're trying to inspect the most recent learning rate, use
+            :meth:`get_last_lr()` instead.
+
+        .. note::
+            The returned :class:`~torch.Tensor`\s are copies, and never alias
+            the optimizer's ``group["lr"]``\s.
+        """
+        _warn_get_lr_called_within_step(self)
+
+        if self.last_epoch == 0:
+            return [
+                group["lr"] * self.start_factor
+                for group in self.optimizer.param_groups
+            ]
+
+        if self._is_initial or self.last_epoch > self.total_iters:
+            return _param_groups_val_list(self.optimizer, "lr")
+
+        factor = (
+            self._compute_factor(self.last_epoch)
+            / self._compute_factor(self.last_epoch - 1)
+        )
+        return [group["lr"] * factor for group in self.optimizer.param_groups]
+
+    def _get_closed_form_lr(self) -> list[float | Tensor]:
+        r"""Compute learning rates for each of the optimizer's
+        :attr:`~torch.optim.Optimizer.param_groups` at :attr:`last_epoch` using
+        a closed-form formula.
+
+        Uses :attr:`base_lrs` to compute learning rates. This method is called
+        when an epoch is passed to :meth:`step`.
+
+        .. math::
+            \text{lr}_t = \text{base\_lr} \cdot \gamma_t
+
+        Returns:
+            list[float | Tensor]: A :class:`list` of learning rates for each of
+            the optimizer's :attr:`~torch.optim.Optimizer.param_groups` with the
+            same types as their current ``group["lr"]``\s.
+        """
+        return [
+            base_lr
+            * self._compute_factor(min(self.total_iters, self.last_epoch))
+            for base_lr in self.base_lrs
+        ]
 
 class CosineAnnealingLR(LRScheduler):
     r"""

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -31,6 +31,7 @@ __all__ = [
     "LinearLR",
     "ExponentialLR",
     "SequentialLR",
+    "CosineLR",
     "CosineAnnealingLR",
     "ChainedScheduler",
     "ReduceLROnPlateau",

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -1419,9 +1419,9 @@ class CosineLR(LRScheduler):
                 "Starting multiplicative factor expected to be greater than 0 and less or equal to 1."
             )
 
-        if end_factor > 1.0 or end_factor < 0:
+        if end_factor > 1.0 or end_factor <= 0:
             raise ValueError(
-                "Ending multiplicative factor expected to be between 0 and 1."
+                "Ending multiplicative factor expected to be greater than 0 and less or equal to 1."
             )
 
         self.start_factor = start_factor
@@ -1440,7 +1440,7 @@ class CosineLR(LRScheduler):
         return (
             0.5 * (self.start_factor + self.end_factor)
             + 0.5 * (self.start_factor - self.end_factor)
-            * math.cos(math.pi * step / self.total_iters)
+            * math.cos(math.pi * step / max(1, self.total_iters))
         )
 
     @override


### PR DESCRIPTION
## Motivation

The existing `CosineAnnealingLR` scheduler computes **absolute** learning rates using `base_lr` and `eta_min`. This makes it difficult to compose with other schedulers via `ChainedScheduler`, because it overwrites the current learning rate rather than scaling it. Users who want a cosine warmup followed by exponential decay, for example, cannot simply chain the two - the cosine scheduler ignores whatever the exponential scheduler has done to `group["lr"]`.

This PR adds `CosineLR`, a **multiplicative** cosine scheduler that mirrors the design of `LinearLR`: it interpolates a scaling factor between `start_factor` and `end_factor` over `total_iters` steps, then holds steady. Because it applies a relative factor to the current learning rate, it composes correctly with any other scheduler.

This is a concrete step toward the internal consistency goals described in #168044.

## Design

`CosineLR` uses the same parameter names and conventions as `LinearLR`:

| Parameter | Meaning |
|---|---|
| `start_factor` | Multiplicative factor applied at epoch 0 (must be in `(0, 1]`) |
| `end_factor` | Multiplicative factor reached at `total_iters` (must be in `[0, 1]`) |
| `total_iters` | Number of steps over which the factor interpolates |

The factor at step $t$ follows:

$$\gamma_t = \frac{\gamma_s + \gamma_e}{2} + \frac{\gamma_s - \gamma_e}{2} \cos \left(\frac{t \cdot \pi}{T}\right)$$

The learning rate is updated recursively as:

$$\text{lr}\_t = \text{lr}\_{t-1} \cdot \frac{\gamma_t}{\gamma_{t-1}}$$

A closed-form path is provided for the deprecated `step(epoch)` interface:

$$\text{lr}\_t = \text{base\\_lr} \cdot \gamma_t$$

Unlike `CosineAnnealingLR`:
- The schedule is **relative** - it scales `group["lr"]` rather than replacing it
- It supports both **warmup** (`end_factor > start_factor`) and **decay** (`end_factor < start_factor`)
- It composes correctly with `ChainedScheduler`, `SequentialLR`, and compound scheduler lists

## Changes

**`torch/optim/lr_scheduler.py`**
- Added the `CosineLR` class with `get_lr`, `_compute_factor`, and `_get_closed_form_lr`
- Added `CosineLR` to `__all__`

**`test/optim/test_lrscheduler.py`**
- Added `CosineLR` to the imports
- Added dedicated tests:
  - `test_cosinelr` - basic cosine decay against closed-form targets
  - `test_cosinelr_warmup` - increasing schedule (`end_factor > start_factor`)
  - `test_cosinelr_start_factor_limits` / `test_cosinelr_end_factor_limits` - input validation
  - `test_get_last_lr_cosinelr` - `get_last_lr()` correctness
  - `test_cosinelr_with_epoch` - deprecated `step(epoch)` path
  - `test_closed_form_cosinelr` - recursive vs closed-form equivalence over 20 epochs
  - `test_cosinelr_is_constant_for_constant_epoch` - repeated `step(2)` doesn't drift
  - `test_cosinelr_state_dict` - save/load round-trip
  - `test_compound_cosinelr_and_exp_lr` - composition with `ExponentialLR`
  - `test_compound_cosinelr_and_step_lr` - composition with `StepLR`
- Added `CosineLR` to the parametrized test lists for `test_lr_scheduler_state_dict_load`, `test_constant_initial_lr`, and `test_lr_scheduler_checkpoint`