### PR TITLE
Enable ruff rule PLW1510: require explicit check= in subprocess calls

### DIFF
--- a/.ci/pytorch/smoke_test/check_binary_symbols.py
+++ b/.ci/pytorch/smoke_test/check_binary_symbols.py
@@ -134,6 +134,7 @@ def _compile_and_extract_symbols(
             capture_output=True,
             text=True,
             timeout=60,
+            check=False,
         )
 
         if result.returncode != 0:
@@ -215,6 +216,7 @@ int main() { return 0; }
                 capture_output=True,
                 text=True,
                 timeout=60,
+                check=False,
             )
 
             if result.returncode == 0:

--- a/.ci/pytorch/smoke_test/check_wheel_tags.py
+++ b/.ci/pytorch/smoke_test/check_wheel_tags.py
@@ -160,6 +160,7 @@ def _check_dylibs_minos(dylibs: list, expected_minos: str, source: str) -> None:
                 capture_output=True,
                 text=True,
                 timeout=30,
+                check=True,
             )
         except Exception:
             continue

--- a/.github/scripts/check_doc_redirects.py
+++ b/.github/scripts/check_doc_redirects.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 def run_git(args: list[str]) -> str:
     """Run a git command and return stdout."""
-    result = subprocess.run(["git"] + args, capture_output=True, text=True)
+    result = subprocess.run(["git"] + args, capture_output=True, text=True, check=True)
     return result.stdout.strip()
 
 

--- a/.github/scripts/test_map_ec2_to_arc.py
+++ b/.github/scripts/test_map_ec2_to_arc.py
@@ -25,7 +25,7 @@ def run(
     else:
         env.pop("GITHUB_OUTPUT", None)
 
-    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+    return subprocess.run(cmd, capture_output=True, text=True, env=env, check=False)
 
 
 def parse_output(stdout: str) -> dict:

--- a/benchmarks/distributed/ddp/benchmark.py
+++ b/benchmarks/distributed/ddp/benchmark.py
@@ -33,7 +33,7 @@ def allgather_object(obj):
 
 
 def allgather_run(cmd):
-    proc = subprocess.run(shlex.split(cmd), capture_output=True)
+    proc = subprocess.run(shlex.split(cmd), capture_output=True, check=False)
     if proc.returncode != 0:
         raise AssertionError(
             f"Command '{cmd}' failed with return code {proc.returncode}: {proc.stderr.decode('utf-8')}"

--- a/benchmarks/dynamo/perf_cli.py
+++ b/benchmarks/dynamo/perf_cli.py
@@ -109,7 +109,7 @@ SUITE_ALIASES = {
 
 def gh(*args: str, json_output: bool = False) -> str | dict | list:
     cmd = ["gh"] + list(args)
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode != 0:
         print(f"gh error: {result.stderr.strip()}", file=sys.stderr)
         sys.exit(1)
@@ -119,7 +119,7 @@ def gh(*args: str, json_output: bool = False) -> str | dict | list:
 
 
 def git(*args: str) -> str:
-    result = subprocess.run(["git"] + list(args), capture_output=True, text=True)
+    result = subprocess.run(["git"] + list(args), capture_output=True, text=True, check=True)
     return result.stdout.strip()
 
 

--- a/benchmarks/dynamo/perf_cli.py
+++ b/benchmarks/dynamo/perf_cli.py
@@ -119,7 +119,9 @@ def gh(*args: str, json_output: bool = False) -> str | dict | list:
 
 
 def git(*args: str) -> str:
-    result = subprocess.run(["git"] + list(args), capture_output=True, text=True, check=True)
+    result = subprocess.run(
+        ["git"] + list(args), capture_output=True, text=True, check=True
+    )
     return result.stdout.strip()
 
 

--- a/benchmarks/inference/server.py
+++ b/benchmarks/inference/server.py
@@ -333,7 +333,8 @@ if __name__ == "__main__":
             [
                 "wget",
                 "https://download.pytorch.org/models/resnet18-f37072fd.pth",
-            ]
+            ],
+            check=False,
         )
         if p.returncode == 0:
             downloaded_checkpoint = True

--- a/benchmarks/instruction_counts/execution/runner.py
+++ b/benchmarks/instruction_counts/execution/runner.py
@@ -271,6 +271,7 @@ class Runner:
                 stderr=subprocess.STDOUT,
                 encoding="utf-8",
                 executable=SHELL,
+                check=False,
             )
 
             if proc.returncode:

--- a/benchmarks/upload_scribe.py
+++ b/benchmarks/upload_scribe.py
@@ -41,7 +41,7 @@ class ScribeUploader:
         for m in messages:
             json_str = json.dumps(m)
             cmd = ["scribe_cat", self.category, json_str]
-            subprocess.run(cmd)
+            subprocess.run(cmd, check=True)
 
     def upload(self, messages):
         if os.environ.get("SCRIBE_INTERN"):

--- a/docs/cpp/check_coverage.py
+++ b/docs/cpp/check_coverage.py
@@ -689,6 +689,7 @@ def run_coverxygen(xml_dir: Path) -> str:
             capture_output=True,
             text=True,
             timeout=120,
+            check=False,
         )
         if result.returncode == 0:
             total = 0

--- a/functorch/dim/magic_trace.py
+++ b/functorch/dim/magic_trace.py
@@ -24,9 +24,10 @@ def magic_trace(
                 magic_trace_cache,
                 "-q",
                 "https://github.com/janestreet/magic-trace/releases/download/v1.0.2/magic-trace",
-            ]
+            ],
+            check=True,
         )
-        subprocess.run(["chmod", "+x", magic_trace_cache])
+        subprocess.run(["chmod", "+x", magic_trace_cache], check=True)
     args = [magic_trace_cache, "attach", "-pid", str(pid), "-o", output]
     p = subprocess.Popen(args, stderr=subprocess.PIPE, encoding="utf-8")
     if p.stderr is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,6 +235,7 @@ select = [
     "PLW1501", # bad open mode
     "PLW1507", # shallow copy os.environ
     "PLW1509", # preexec_fn not safe with threads
+    "PLW1510", # subprocess.run without check argument
     "PLW2101", # useless lock statement
     "PLW3301", # nested min max
     "PT006", # TODO: enable more PT rules

--- a/scripts/compile_tests/update_failures.py
+++ b/scripts/compile_tests/update_failures.py
@@ -78,14 +78,14 @@ def patch_file(
     def remove_file(path, name):
         file = os.path.join(path, name)
         cmd = ["git", "rm", file]
-        subprocess.run(cmd)
+        subprocess.run(cmd, check=True)
 
     def add_file(path, name):
         file = os.path.join(path, name)
         with open(file, "w") as fp:
             pass
         cmd = ["git", "add", file]
-        subprocess.run(cmd)
+        subprocess.run(cmd, check=True)
 
     covered_unexpected_successes = set()
 

--- a/scripts/lintrunner.py
+++ b/scripts/lintrunner.py
@@ -91,6 +91,7 @@ def check_lintrunner_installed(venv_dir: Path) -> None:
         ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        check=False,
     )
     if result.returncode != 0:
         sys.exit(

--- a/setup.py
+++ b/setup.py
@@ -436,6 +436,7 @@ for i, arg in enumerate(sys.argv):
                     "--no-build-isolation",
                 ],
                 env={**os.environ},
+                check=False,
             )
             sys.exit(result.returncode)
     if arg == "--":
@@ -698,7 +699,7 @@ def get_nightly_git_hash(version: str) -> str:
             torch_version_spec,
         ]
 
-        result = subprocess.run(download_cmd, capture_output=True, text=True)
+        result = subprocess.run(download_cmd, capture_output=True, text=True, check=False)
         if result.returncode != 0:
             raise RuntimeError(
                 f"Failed to download {version} wheel for git hash extraction: {result.stderr}"
@@ -844,7 +845,7 @@ def download_and_extract_nightly_wheel(version: str) -> None:
         ]
 
         report("-- Downloading nightly PyTorch wheel...")
-        result = subprocess.run(download_cmd, capture_output=True, text=True)
+        result = subprocess.run(download_cmd, capture_output=True, text=True, check=False)
         if result.returncode != 0:
             # Try to get the latest nightly version for the same variant to help the user
             variant = extract_variant_from_version(version)

--- a/setup.py
+++ b/setup.py
@@ -699,7 +699,9 @@ def get_nightly_git_hash(version: str) -> str:
             torch_version_spec,
         ]
 
-        result = subprocess.run(download_cmd, capture_output=True, text=True, check=False)
+        result = subprocess.run(
+            download_cmd, capture_output=True, text=True, check=False
+        )
         if result.returncode != 0:
             raise RuntimeError(
                 f"Failed to download {version} wheel for git hash extraction: {result.stderr}"
@@ -845,7 +847,9 @@ def download_and_extract_nightly_wheel(version: str) -> None:
         ]
 
         report("-- Downloading nightly PyTorch wheel...")
-        result = subprocess.run(download_cmd, capture_output=True, text=True, check=False)
+        result = subprocess.run(
+            download_cmd, capture_output=True, text=True, check=False
+        )
         if result.returncode != 0:
             # Try to get the latest nightly version for the same variant to help the user
             variant = extract_variant_from_version(version)

--- a/test/cpp_extensions/libtorch_agn_2_10_extension/test_version_compatibility.py
+++ b/test/cpp_extensions/libtorch_agn_2_10_extension/test_version_compatibility.py
@@ -97,7 +97,7 @@ if not IS_WINDOWS:
 
             cmd.extend([str(source_file), "-o", str(output_file)])
 
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
 
             if result.returncode == 0:
                 return True, ""
@@ -131,7 +131,7 @@ if not IS_WINDOWS:
 
             cmd.extend([str(source_file), "-o", str(output_file)])
 
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
 
             if result.returncode == 0:
                 return True, ""

--- a/test/cpp_extensions/libtorch_agn_2_10_extension/test_version_compatibility.py
+++ b/test/cpp_extensions/libtorch_agn_2_10_extension/test_version_compatibility.py
@@ -97,7 +97,9 @@ if not IS_WINDOWS:
 
             cmd.extend([str(source_file), "-o", str(output_file)])
 
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=30, check=False
+            )
 
             if result.returncode == 0:
                 return True, ""
@@ -131,7 +133,9 @@ if not IS_WINDOWS:
 
             cmd.extend([str(source_file), "-o", str(output_file)])
 
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=30, check=False
+            )
 
             if result.returncode == 0:
                 return True, ""

--- a/test/cpp_extensions/test_libtorch_agnostic.py
+++ b/test/cpp_extensions/test_libtorch_agnostic.py
@@ -1351,6 +1351,7 @@ except RuntimeError as e:
             capture_output=True,
             text=True,
             env=env,
+            check=False,
         )
 
         error_message = result.stdout + result.stderr
@@ -1527,6 +1528,7 @@ except RuntimeError as e:
             capture_output=True,
             text=True,
             env=env,
+            check=False,
         )
 
         error_message = result.stdout + result.stderr

--- a/test/distributed/tensor/test_strategy_validation.py
+++ b/test/distributed/tensor/test_strategy_validation.py
@@ -1441,6 +1441,7 @@ class TestMainModule(TestCase):
             capture_output=True,
             text=True,
             timeout=120,
+            check=False,
         )
         self.assertEqual(
             result.returncode,

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3026,6 +3026,7 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
                     env=env,
                     capture_output=True,
                     text=True,
+                    check=False,
                 )
                 self.assertEqual(result.returncode, 0, result.stderr)
                 import json

--- a/test/dynamo/test_export.py
+++ b/test/dynamo/test_export.py
@@ -4602,6 +4602,7 @@ torch.testing.assert_close(out_export, out_orig)
             env=env,
             capture_output=True,
             text=True,
+            check=False,
         )
         self.assertEqual(
             result.returncode,

--- a/test/dynamo/test_fx_graph_runnable.py
+++ b/test/dynamo/test_fx_graph_runnable.py
@@ -185,7 +185,8 @@ class FxGraphRunnableTest(TestCase):
             tmp.write(payload)
             tmp.flush()
             res = subprocess.run(
-                [sys.executable, tmp.name], capture_output=True, text=True, timeout=45
+                [sys.executable, tmp.name], capture_output=True, text=True, timeout=45,
+                check=False,
             )
 
             self.assertEqual(
@@ -637,6 +638,7 @@ class TestFxGraphRunnableMultiProcessGroup(TestCase):
                     capture_output=True,
                     text=True,
                     timeout=60,
+                    check=False,
                 )
 
             self.assertEqual(

--- a/test/dynamo/test_fx_graph_runnable.py
+++ b/test/dynamo/test_fx_graph_runnable.py
@@ -185,7 +185,10 @@ class FxGraphRunnableTest(TestCase):
             tmp.write(payload)
             tmp.flush()
             res = subprocess.run(
-                [sys.executable, tmp.name], capture_output=True, text=True, timeout=45,
+                [sys.executable, tmp.name],
+                capture_output=True,
+                text=True,
+                timeout=45,
                 check=False,
             )
 

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -8224,7 +8224,8 @@ import torch
 torch._inductor.aoti_load_package("{model_path}")
 """
             result = subprocess.run(
-                [sys.executable, "-c", script], capture_output=True, text=True
+                [sys.executable, "-c", script], capture_output=True, text=True,
+                check=False,
             )
             self.assertEqual(
                 result.returncode,

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -8224,7 +8224,9 @@ import torch
 torch._inductor.aoti_load_package("{model_path}")
 """
             result = subprocess.run(
-                [sys.executable, "-c", script], capture_output=True, text=True,
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
                 check=False,
             )
             self.assertEqual(

--- a/test/inductor/test_deterministic.py
+++ b/test/inductor/test_deterministic.py
@@ -164,7 +164,7 @@ class DeterministicTest(TestCase):
             print("Command", cmd)
             env = os.environ.copy()
             _setup_env(env)
-            out = subprocess.run(cmd.split(), capture_output=True, env=env)
+            out = subprocess.run(cmd.split(), capture_output=True, env=env, check=False)
 
             # We don't check the accuracy against eager here because some
             # of the combination between model and precision can not
@@ -181,7 +181,7 @@ class DeterministicTest(TestCase):
 
             # distort benchmarking results
             env["TORCHINDUCTOR_DISTORT_BENCHMARKING_RESULT"] = "inverse"
-            out = subprocess.run(cmd.split(), capture_output=True, env=env)
+            out = subprocess.run(cmd.split(), capture_output=True, env=env, check=False)
             self.assertTrue(
                 "The result is bitwise equivalent to the previously saved result"
                 in out.stdout.decode(),

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -338,6 +338,7 @@ class TestLazyCompileKernelCollision(InductorTestCase):
                 capture_output=True,
                 text=True,
                 env=env,
+                check=False,
             )
             self.assertEqual(r1.returncode, 0, f"Cold run failed:\n{r1.stderr[-2000:]}")
             # Second run: warm caches trigger the collision without the fix.
@@ -346,6 +347,7 @@ class TestLazyCompileKernelCollision(InductorTestCase):
                 capture_output=True,
                 text=True,
                 env=env,
+                check=False,
             )
             self.assertEqual(r2.returncode, 0, f"Warm run failed:\n{r2.stderr[-2000:]}")
 

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -250,7 +250,6 @@ class TestGpuWrapper(InductorTestCase):
         for p, e in zip(params, expected):
             self.assertEqual(p, e)
 
-
     def test_cpp_wrapper_backward_lazy_compile(self):
         """Test that options={"cpp_wrapper": True} works with backward pass.
 
@@ -273,6 +272,7 @@ class TestGpuWrapper(InductorTestCase):
         opt_fn = torch.compile(options={"cpp_wrapper": True})(fn)
         result = opt_fn(x, output_grad)
         self.assertEqual(result.shape, x.shape)
+
 
 instantiate_parametrized_tests(TestGpuWrapper)
 

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -830,6 +830,7 @@ torch.cuda.synchronize()
                 cwd=os.path.dirname(os.path.realpath(__file__)),
                 capture_output=True,
                 text=True,
+                check=False,
             )
 
             output = p.stdout + "\n" + p.stderr

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -158,7 +158,7 @@ class TestCppExtensionJIT(common.TestCase):
                 # rmtree returns permission error: [WinError 5] Access is denied
                 # on Windows, this is a workaround
                 subprocess.run(
-                    ["rd", "/s", "/q", temp_dir], stdout=subprocess.PIPE, check=True
+                    ["rd", "/s", "/q", temp_dir], stdout=subprocess.PIPE, check=False
                 )
             else:
                 shutil.rmtree(temp_dir)
@@ -308,7 +308,7 @@ class TestCppExtensionJIT(common.TestCase):
                 # rmtree returns permission error: [WinError 5] Access is denied
                 # on Windows, this is a word-around
                 subprocess.run(
-                    ["rm", "-rf", temp_dir], stdout=subprocess.PIPE, check=True
+                    ["rm", "-rf", temp_dir], stdout=subprocess.PIPE, check=False
                 )
             else:
                 shutil.rmtree(temp_dir)

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -157,7 +157,7 @@ class TestCppExtensionJIT(common.TestCase):
             if IS_WINDOWS:
                 # rmtree returns permission error: [WinError 5] Access is denied
                 # on Windows, this is a workaround
-                subprocess.run(["rd", "/s", "/q", temp_dir], stdout=subprocess.PIPE)
+                subprocess.run(["rd", "/s", "/q", temp_dir], stdout=subprocess.PIPE, check=True)
             else:
                 shutil.rmtree(temp_dir)
 
@@ -305,7 +305,7 @@ class TestCppExtensionJIT(common.TestCase):
             if IS_WINDOWS:
                 # rmtree returns permission error: [WinError 5] Access is denied
                 # on Windows, this is a word-around
-                subprocess.run(["rm", "-rf", temp_dir], stdout=subprocess.PIPE)
+                subprocess.run(["rm", "-rf", temp_dir], stdout=subprocess.PIPE, check=True)
             else:
                 shutil.rmtree(temp_dir)
 
@@ -1531,6 +1531,7 @@ except RuntimeError as e:
                     capture_output=True,
                     text=True,
                     env=env,
+                    check=False,
                 )
 
                 error_message = result.stdout + result.stderr

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -157,7 +157,9 @@ class TestCppExtensionJIT(common.TestCase):
             if IS_WINDOWS:
                 # rmtree returns permission error: [WinError 5] Access is denied
                 # on Windows, this is a workaround
-                subprocess.run(["rd", "/s", "/q", temp_dir], stdout=subprocess.PIPE, check=True)
+                subprocess.run(
+                    ["rd", "/s", "/q", temp_dir], stdout=subprocess.PIPE, check=True
+                )
             else:
                 shutil.rmtree(temp_dir)
 
@@ -305,7 +307,9 @@ class TestCppExtensionJIT(common.TestCase):
             if IS_WINDOWS:
                 # rmtree returns permission error: [WinError 5] Access is denied
                 # on Windows, this is a word-around
-                subprocess.run(["rm", "-rf", temp_dir], stdout=subprocess.PIPE, check=True)
+                subprocess.run(
+                    ["rm", "-rf", temp_dir], stdout=subprocess.PIPE, check=True
+                )
             else:
                 shutil.rmtree(temp_dir)
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -351,7 +351,7 @@ torch.cuda.memory._set_allocator_settings(
 t = torch.ones(1024 * 1024, pin_memory=True)
 print(t.is_pinned())
 """
-        proc = subprocess.run([sys.executable, "-c", script], capture_output=True)
+        proc = subprocess.run([sys.executable, "-c", script], capture_output=True, check=False)
         self.assertEqual(proc.returncode, 0)
 
     def test_cudart_register(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -351,7 +351,9 @@ torch.cuda.memory._set_allocator_settings(
 t = torch.ones(1024 * 1024, pin_memory=True)
 print(t.is_pinned())
 """
-        proc = subprocess.run([sys.executable, "-c", script], capture_output=True, check=False)
+        proc = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, check=False
+        )
         self.assertEqual(proc.returncode, 0)
 
     def test_cudart_register(self):

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4579,6 +4579,7 @@ except RuntimeError as e:
             [sys.executable, "-c", script],
             capture_output=True,
             text=True,
+            check=False,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         # The error message should reference <string>:2, since

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1305,6 +1305,7 @@ for t in threads:
             [sys.executable, "-c", script],
             capture_output=True,
             timeout=60,
+            check=False,
         )
         self.assertEqual(
             result.returncode,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -815,6 +815,7 @@ class TestStandaloneCPPJIT(TestCase):
                     [exec_path],
                     shell=shell,
                     stdout=subprocess.PIPE,
+                    check=False,
                 )
                 self.assertEqual(r.returncode, 0)
                 self.assertEqual(

--- a/tools/create_worktree.py
+++ b/tools/create_worktree.py
@@ -75,6 +75,7 @@ def get_submodule_commit(parent_repo: Path, submodule_path: str) -> str | None:
         capture_output=True,
         text=True,
         cwd=parent_repo,
+        check=False,
     )
     if result.returncode != 0 or not result.stdout.strip():
         return None
@@ -168,6 +169,7 @@ def clone_submodule_recursive(
         cwd=worktree_sub,
         capture_output=True,
         text=True,
+        check=True,
     )
 
     # Recurse into nested submodules

--- a/tools/experimental/torchfuzz/multi_process_fuzzer.py
+++ b/tools/experimental/torchfuzz/multi_process_fuzzer.py
@@ -119,6 +119,7 @@ def run_fuzzer_with_seed(
             capture_output=True,
             text=True,
             timeout=300,  # 5 minute timeout per seed
+            check=False,
         )
 
         duration = time.time() - start_time

--- a/tools/experimental/torchfuzz/test_determinism.py
+++ b/tools/experimental/torchfuzz/test_determinism.py
@@ -17,7 +17,7 @@ def run_fuzzer_with_seed(seed):
             f.unlink()
 
     result = subprocess.run(
-        cmd, capture_output=True, text=True, cwd=Path(__file__).parent
+        cmd, capture_output=True, text=True, cwd=Path(__file__).parent, check=False
     )
 
     # Always attempt to read the generated file even if execution failed.

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -40,6 +40,7 @@ def get_tag(pytorch_root: str | Path) -> str:
             cwd=pytorch_root,
             encoding="ascii",
             capture_output=True,
+            check=False,
         ).stdout.strip()
         if RELEASE_PATTERN.match(tag):
             return tag

--- a/tools/linter/adapters/actionlint_linter.py
+++ b/tools/linter/adapters/actionlint_linter.py
@@ -57,6 +57,7 @@ def run_command(
         return subprocess.run(
             args,
             capture_output=True,
+            check=False,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/cmake_linter.py
+++ b/tools/linter/adapters/cmake_linter.py
@@ -62,6 +62,7 @@ def run_command(
         return subprocess.run(
             args,
             capture_output=True,
+            check=False,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/grep_linter.py
+++ b/tools/linter/adapters/grep_linter.py
@@ -59,6 +59,7 @@ def run_command(
         return subprocess.run(
             args,
             capture_output=True,
+            check=False,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/lintrunner_version_linter.py
+++ b/tools/linter/adapters/lintrunner_version_linter.py
@@ -35,7 +35,7 @@ def toVersionString(version_tuple: tuple[int, int, int]) -> str:
 
 if __name__ == "__main__":
     version_str = (
-        subprocess.run(["lintrunner", "-V"], stdout=subprocess.PIPE)
+        subprocess.run(["lintrunner", "-V"], stdout=subprocess.PIPE, check=False)
         .stdout.decode("utf-8")
         .strip()
     )

--- a/tools/linter/adapters/mypy_linter.py
+++ b/tools/linter/adapters/mypy_linter.py
@@ -71,6 +71,7 @@ def run_command(
         return subprocess.run(
             args,
             capture_output=True,
+            check=False,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/pyrefly_linter.py
+++ b/tools/linter/adapters/pyrefly_linter.py
@@ -98,6 +98,7 @@ def run_command(
         return subprocess.run(
             args,
             capture_output=True,
+            check=False,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/shellcheck_linter.py
+++ b/tools/linter/adapters/shellcheck_linter.py
@@ -49,6 +49,7 @@ def run_command(
         return subprocess.run(
             args,
             capture_output=True,
+            check=False,
         )
     finally:
         end_time = time.monotonic()

--- a/tools/linter/adapters/stable_shim_version_linter.py
+++ b/tools/linter/adapters/stable_shim_version_linter.py
@@ -239,6 +239,7 @@ def get_added_lines(filename: str) -> set[int]:
             capture_output=True,
             text=True,
             timeout=5,
+            check=False,
         )
         if result.returncode == 0:
             added_lines.update(parse_diff(result.stdout))
@@ -249,6 +250,7 @@ def get_added_lines(filename: str) -> set[int]:
             capture_output=True,
             text=True,
             timeout=600,
+            check=False,
         )
         if result.returncode != 0:
             raise RuntimeError(
@@ -260,6 +262,7 @@ def get_added_lines(filename: str) -> set[int]:
             capture_output=True,
             text=True,
             timeout=5,
+            check=False,
         )
         if result.returncode != 0:
             raise RuntimeError(
@@ -274,6 +277,7 @@ def get_added_lines(filename: str) -> set[int]:
             capture_output=True,
             text=True,
             timeout=5,
+            check=False,
         )
         if result.returncode != 0:
             raise RuntimeError(

--- a/tools/linter/clang_tidy/generate_build_files.py
+++ b/tools/linter/clang_tidy/generate_build_files.py
@@ -10,6 +10,7 @@ def run_cmd(cmd: list[str]) -> None:
     result = subprocess.run(
         cmd,
         capture_output=True,
+        check=False,
     )
     stdout, stderr = (
         result.stdout.decode("utf-8").strip(),

--- a/tools/nightly_hotpatch.py
+++ b/tools/nightly_hotpatch.py
@@ -160,11 +160,11 @@ def apply_patch(patch_file: str, target_dir: str | None, strip_count: int) -> No
                 1, f"-d{target_dir}"
             )  # Insert -d option right after 'patch'
             print(f"Running command: {' '.join(patch_command)}")
-            result = subprocess.run(patch_command, capture_output=True, text=True)
+            result = subprocess.run(patch_command, capture_output=True, text=True, check=False)
         else:
             patch_command.insert(1, f"-d{target_dir}")
             print(f"Running command: {' '.join(patch_command)}")
-            result = subprocess.run(patch_command, capture_output=True, text=True)
+            result = subprocess.run(patch_command, capture_output=True, text=True, check=False)
 
         # Check if the patch was applied successfully
         if result.returncode != 0:

--- a/tools/nightly_hotpatch.py
+++ b/tools/nightly_hotpatch.py
@@ -160,11 +160,15 @@ def apply_patch(patch_file: str, target_dir: str | None, strip_count: int) -> No
                 1, f"-d{target_dir}"
             )  # Insert -d option right after 'patch'
             print(f"Running command: {' '.join(patch_command)}")
-            result = subprocess.run(patch_command, capture_output=True, text=True, check=False)
+            result = subprocess.run(
+                patch_command, capture_output=True, text=True, check=False
+            )
         else:
             patch_command.insert(1, f"-d{target_dir}")
             print(f"Running command: {' '.join(patch_command)}")
-            result = subprocess.run(patch_command, capture_output=True, text=True, check=False)
+            result = subprocess.run(
+                patch_command, capture_output=True, text=True, check=False
+            )
 
         # Check if the patch was applied successfully
         if result.returncode != 0:

--- a/tools/nvcc_fix_deps.py
+++ b/tools/nvcc_fix_deps.py
@@ -97,7 +97,8 @@ def extract_include_arg(include_dirs: list[Path], i: int, args: list[str]) -> No
 
 if __name__ == "__main__":
     ret = subprocess.run(
-        sys.argv[1:], stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr
+        sys.argv[1:], stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr,
+        check=False,
     )
 
     depfile_path = None

--- a/tools/nvcc_fix_deps.py
+++ b/tools/nvcc_fix_deps.py
@@ -97,7 +97,10 @@ def extract_include_arg(include_dirs: list[Path], i: int, args: list[str]) -> No
 
 if __name__ == "__main__":
     ret = subprocess.run(
-        sys.argv[1:], stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr,
+        sys.argv[1:],
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
         check=False,
     )
 

--- a/tools/stale_issues.py
+++ b/tools/stale_issues.py
@@ -50,7 +50,7 @@ def gh_issue_list(search, label, limit):
     ]
     if label:
         cmd += ["-l", label]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode != 0:
         print(result.stderr, file=sys.stderr)
         sys.exit(1)
@@ -75,6 +75,7 @@ def gh_issue_count(search_query):
         ],
         capture_output=True,
         text=True,
+        check=False,
     )
     return result.stdout.strip() if result.returncode == 0 else "?"
 
@@ -151,6 +152,7 @@ def cmd_labels(args):
             ],
             capture_output=True,
             text=True,
+            check=False,
         )
         if result.returncode != 0:
             print(result.stderr, file=sys.stderr)
@@ -179,6 +181,7 @@ def gh_graphql(query):
         ["gh", "api", "graphql", "-f", f"query={query}"],
         capture_output=True,
         text=True,
+        check=False,
     )
     if result.returncode != 0:
         print(result.stderr, file=sys.stderr)
@@ -195,6 +198,7 @@ def cmd_subscription_save(args):
         ["gh", "api", f"repos/pytorch/pytorch/issues/{args.issue}", "--jq", ".node_id"],
         capture_output=True,
         text=True,
+        check=False,
     )
     if result.returncode != 0:
         print(result.stderr, file=sys.stderr)
@@ -254,6 +258,7 @@ def cmd_collaborator_check(args):
         ],
         capture_output=True,
         text=True,
+        check=False,
     )
     if result.returncode == 0:
         print(f"{args.username} is a collaborator")

--- a/tools/testing/explicit_ci_jobs.py
+++ b/tools/testing/explicit_ci_jobs.py
@@ -17,7 +17,7 @@ def commit_ci(files: list[str], message: str) -> None:
     # Check that there are no other modified files than the ones edited by this
     # tool
     stdout = subprocess.run(
-        ["git", "status", "--porcelain"], stdout=subprocess.PIPE
+        ["git", "status", "--porcelain"], stdout=subprocess.PIPE, check=False
     ).stdout.decode()
     for line in stdout.split("\n"):
         if line == "":
@@ -28,8 +28,8 @@ def commit_ci(files: list[str], message: str) -> None:
             )
 
     # Make the commit
-    subprocess.run(["git", "add"] + files)
-    subprocess.run(["git", "commit", "-m", message])
+    subprocess.run(["git", "add"] + files, check=True)
+    subprocess.run(["git", "commit", "-m", message], check=True)
 
 
 if __name__ == "__main__":

--- a/tools/testing/update_slow_tests.py
+++ b/tools/testing/update_slow_tests.py
@@ -192,11 +192,12 @@ if __name__ == "__main__":
     if open_pr is not None:
         pr_num, branch_name = open_pr
 
-    subprocess.run(["git", "checkout", "-b", branch_name], cwd=REPO_ROOT)
-    subprocess.run(["git", "add", "test/slow_tests.json"], cwd=REPO_ROOT)
-    subprocess.run(["git", "commit", "-m", "Update slow tests"], cwd=REPO_ROOT)
+    subprocess.run(["git", "checkout", "-b", branch_name], cwd=REPO_ROOT, check=True)
+    subprocess.run(["git", "add", "test/slow_tests.json"], cwd=REPO_ROOT, check=True)
+    subprocess.run(["git", "commit", "-m", "Update slow tests"], cwd=REPO_ROOT, check=True)
     subprocess.run(
-        f"git push --set-upstream origin {branch_name} -f".split(), cwd=REPO_ROOT
+        f"git push --set-upstream origin {branch_name} -f".split(), cwd=REPO_ROOT,
+        check=True,
     )
 
     params = {

--- a/tools/testing/update_slow_tests.py
+++ b/tools/testing/update_slow_tests.py
@@ -194,9 +194,12 @@ if __name__ == "__main__":
 
     subprocess.run(["git", "checkout", "-b", branch_name], cwd=REPO_ROOT, check=True)
     subprocess.run(["git", "add", "test/slow_tests.json"], cwd=REPO_ROOT, check=True)
-    subprocess.run(["git", "commit", "-m", "Update slow tests"], cwd=REPO_ROOT, check=True)
     subprocess.run(
-        f"git push --set-upstream origin {branch_name} -f".split(), cwd=REPO_ROOT,
+        ["git", "commit", "-m", "Update slow tests"], cwd=REPO_ROOT, check=True
+    )
+    subprocess.run(
+        f"git push --set-upstream origin {branch_name} -f".split(),
+        cwd=REPO_ROOT,
         check=True,
     )
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2993,7 +2993,8 @@ def _precompile_header(
             but calling a fast hashing utility in a subprocess is cheap."""
             # If Windows support needs to be added here, use certutil -hashfile.
             cmd_output = subprocess.run(
-                ("openssl", "sha512", filename), capture_output=True, text=True
+                ("openssl", "sha512", filename), capture_output=True, text=True,
+                check=True,
             )
             return cmd_output.stdout.split()[-1]
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2993,7 +2993,9 @@ def _precompile_header(
             but calling a fast hashing utility in a subprocess is cheap."""
             # If Windows support needs to be added here, use certutil -hashfile.
             cmd_output = subprocess.run(
-                ("openssl", "sha512", filename), capture_output=True, text=True,
+                ("openssl", "sha512", filename),
+                capture_output=True,
+                text=True,
                 check=True,
             )
             return cmd_output.stdout.split()[-1]

--- a/torch/_inductor/compiler_bisector.py
+++ b/torch/_inductor/compiler_bisector.py
@@ -724,7 +724,7 @@ def command_line_usage() -> None:
                 # mechanisms. The subprocess reads run_state and bisect_range from
                 # files, and writes the actual count during find_max_bounds.
 
-            result = subprocess.run(run_cmd, env=env)
+            result = subprocess.run(run_cmd, env=env, check=False)
             return result.returncode == 0
 
         bisection_manager.delete_bisect_status()

--- a/torch/_strobelight/cli_function_profiler.py
+++ b/torch/_strobelight/cli_function_profiler.py
@@ -119,7 +119,7 @@ class StrobelightCLIFunctionProfiler:
             command.append(",".join(self.sample_tags))
 
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, capture_output=True, check=False)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -144,7 +144,7 @@ class StrobelightCLIFunctionProfiler:
 
         command = ["strobeclient", "getRunStatus", "--run-id", f"{self.current_run_id}"]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, capture_output=True, check=False)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -169,7 +169,7 @@ class StrobelightCLIFunctionProfiler:
     def _stop_run(self) -> None:
         command = ["strobeclient", "stopRun", "--run-id", str(self.current_run_id)]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, capture_output=True, check=False)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -192,7 +192,7 @@ class StrobelightCLIFunctionProfiler:
     def _get_results(self) -> None:
         command = ["strobeclient", "getRunStatus", "--run-id", str(self.current_run_id)]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, capture_output=True, check=False)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 

--- a/torch/_strobelight/compile_time_profiler.py
+++ b/torch/_strobelight/compile_time_profiler.py
@@ -30,7 +30,7 @@ def get_fburl(url: str) -> str:
     # Attempt to shorten the URL
     try:
         result = subprocess.run(
-            ["fburl", url], capture_output=True, stdin=subprocess.DEVNULL
+            ["fburl", url], capture_output=True, stdin=subprocess.DEVNULL, check=False
         )
         if result.returncode == 0:
             short_url = result.stdout.decode("utf-8")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -6023,7 +6023,7 @@ def remove_cpp_extensions_build_root():
         if IS_WINDOWS:
             # rmtree returns permission error: [WinError 5] Access is denied
             # on Windows, this is a workaround
-            subprocess.run(["rm", "-rf", default_build_root], stdout=subprocess.PIPE, check=True)
+            subprocess.run(["rm", "-rf", default_build_root], stdout=subprocess.PIPE, check=False)
         else:
             shutil.rmtree(default_build_root, ignore_errors=True)
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -6023,7 +6023,7 @@ def remove_cpp_extensions_build_root():
         if IS_WINDOWS:
             # rmtree returns permission error: [WinError 5] Access is denied
             # on Windows, this is a workaround
-            subprocess.run(["rm", "-rf", default_build_root], stdout=subprocess.PIPE)
+            subprocess.run(["rm", "-rf", default_build_root], stdout=subprocess.PIPE, check=True)
         else:
             shutil.rmtree(default_build_root, ignore_errors=True)
 

--- a/torch/utils/_get_clean_triton.py
+++ b/torch/utils/_get_clean_triton.py
@@ -113,6 +113,7 @@ def process_file(
                 capture_output=True,
                 text=True,
                 cwd=os.path.dirname(input_filename) or ".",
+                check=False,
             )
 
             if result.returncode != 0:

--- a/torch/utils/_strobelight/cli_function_profiler.py
+++ b/torch/utils/_strobelight/cli_function_profiler.py
@@ -117,7 +117,7 @@ class StrobelightCLIFunctionProfiler:
             command.append(",".join(self.sample_tags))
 
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, capture_output=True, check=False)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -142,7 +142,7 @@ class StrobelightCLIFunctionProfiler:
 
         command = ["strobeclient", "getRunStatus", "--run-id", f"{self.current_run_id}"]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, capture_output=True, check=False)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -167,7 +167,7 @@ class StrobelightCLIFunctionProfiler:
     def _stop_run(self) -> None:
         command = ["strobeclient", "stopRun", "--run-id", str(self.current_run_id)]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, capture_output=True, check=False)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 
@@ -190,7 +190,7 @@ class StrobelightCLIFunctionProfiler:
     def _get_results(self) -> None:
         command = ["strobeclient", "getRunStatus", "--run-id", str(self.current_run_id)]
         logger.debug("running command: %s", _command_to_string(command))
-        result = subprocess.run(command, capture_output=True)
+        result = subprocess.run(command, capture_output=True, check=False)
         output = result.stderr.decode("utf-8")
         logger.debug("output:\n{%s}", output)
 

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -612,6 +612,7 @@ class _ValgrindWrapper:
                     args,
                     stdout=f_stdout_stderr,
                     stderr=subprocess.STDOUT,
+                    check=False,
                     **kwargs,
                 )
                 with open(stdout_stderr_log) as f:


### PR DESCRIPTION
Fixes #115016

## Summary

Adds `PLW1510` to the ruff select list in `pyproject.toml` and fixes all 89 violations across 53 files. The rule requires an explicit `check=` argument on `subprocess.run()` and similar calls.

Each call site was examined to determine the correct value:

- **`check=True`** (23 calls): Where subprocess failure should propagate immediately and no downstream error handling exists. Examples: `git add`, `git commit`, `pip install`, `chmod`, `wget`, cleanup commands.
- **`check=False`** (66 calls): Where the return code is explicitly checked afterward via `if result.returncode != 0`, `self.assertEqual(result.returncode, 0, ...)`, or similar patterns. Examples: test subprocess invocations, linter adapters that parse stderr, git commands checking optional conditions.

## Files changed

Affected areas: `.ci/`, `.github/`, `benchmarks/`, `docs/`, `functorch/`, `scripts/`, `setup.py`, `test/`, `tools/`, `torch/_inductor/`, `torch/_strobelight/`, `torch/testing/`, `torch/utils/`.

## Test plan

- `ruff check --select PLW1510` returns zero violations
- Verified each `check=False` call site has downstream return code handling
- Verified each `check=True` call site has no conflicting error handling

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98