### PR TITLE
Add GitHub Action to auto-request PR reviewers from merge_rules.yaml

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -38,6 +38,21 @@
   - Lint
   - pull
 
+- name: OSS CI / Auto Reviewer Routing
+  # auto-request-reviewers operates under pull_request_target with write
+  # permissions; the compute/request job split is what keeps it safe.
+  # Restrict to a small set of security-aware approvers.
+  patterns:
+  - .github/workflows/auto-request-reviewers.yml
+  - .github/scripts/match_reviewers.py
+  approved_by:
+  - albanD
+  - pytorch/pytorch-dev-infra
+  mandatory_checks_name:
+  - EasyCLA
+  - Lint
+  - pull
+
 - name: OSS CI
   patterns:
   - .github/**

--- a/.github/scripts/match_reviewers.py
+++ b/.github/scripts/match_reviewers.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Match changed files against merge_rules.yaml and output reviewers to request.
+
+Reuses patterns_to_regex from gitutils.py to ensure matching semantics are
+identical to trymerge.
+
+Usage:
+    python match_reviewers.py --merge-rules PATH --changed-files f1 f2 ... --pr-author LOGIN
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from gitutils import patterns_to_regex
+
+
+def is_wildcard_only(patterns: list[str]) -> bool:
+    return all(p in ("*", "**") for p in patterns)
+
+
+KNOWN_BOTS = frozenset({
+    "pytorchbot",
+    "pytorchmergebot",
+    "facebook-github-bot",
+})
+
+
+def is_bot(username: str) -> bool:
+    return username.lower() in KNOWN_BOTS
+
+
+def match_reviewers(
+    rules: list[dict],
+    changed_files: list[str],
+    pr_author: str,
+) -> tuple[list[str], list[str]]:
+    """Return (reviewers, team_slugs) matched from merge rules."""
+    reviewers: set[str] = set()
+    teams: set[str] = set()
+    pr_author_lower = pr_author.lower()
+
+    for rule in rules:
+        patterns = rule.get("patterns", [])
+        approvers = rule.get("approved_by", [])
+
+        if is_wildcard_only(patterns):
+            continue
+
+        regex = patterns_to_regex(patterns)
+        matched = any(regex.match(f) for f in changed_files)
+
+        if matched:
+            for approver in approvers:
+                if is_bot(approver):
+                    continue
+                if approver.startswith("pytorch/"):
+                    teams.add(approver[len("pytorch/") :])
+                elif approver.lower() != pr_author_lower:
+                    reviewers.add(approver)
+
+    return sorted(reviewers), sorted(teams)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--merge-rules", required=True, type=Path)
+    parser.add_argument("--changed-files", nargs="*", default=[])
+    parser.add_argument("--changed-files-stdin", action="store_true",
+                        help="Read changed files as JSON array from stdin")
+    parser.add_argument("--pr-author", required=True)
+    args = parser.parse_args()
+
+    import yaml
+
+    with open(args.merge_rules) as f:
+        rules = yaml.safe_load(f)
+
+    if args.changed_files_stdin:
+        changed_files = json.load(sys.stdin)
+    else:
+        changed_files = args.changed_files
+
+    reviewers, teams = match_reviewers(rules, changed_files, args.pr_author)
+
+    result = {"reviewers": reviewers, "teams": teams}
+    json.dump(result, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/match_reviewers.py
+++ b/.github/scripts/match_reviewers.py
@@ -22,11 +22,13 @@ def is_wildcard_only(patterns: list[str]) -> bool:
     return all(p in ("*", "**") for p in patterns)
 
 
-KNOWN_BOTS = frozenset({
-    "pytorchbot",
-    "pytorchmergebot",
-    "facebook-github-bot",
-})
+KNOWN_BOTS = frozenset(
+    {
+        "pytorchbot",
+        "pytorchmergebot",
+        "facebook-github-bot",
+    }
+)
 
 
 def is_bot(username: str) -> bool:
@@ -69,8 +71,11 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--merge-rules", required=True, type=Path)
     parser.add_argument("--changed-files", nargs="*", default=[])
-    parser.add_argument("--changed-files-stdin", action="store_true",
-                        help="Read changed files as JSON array from stdin")
+    parser.add_argument(
+        "--changed-files-stdin",
+        action="store_true",
+        help="Read changed files as JSON array from stdin",
+    )
     parser.add_argument("--pr-author", required=True)
     args = parser.parse_args()
 

--- a/.github/scripts/match_reviewers.py
+++ b/.github/scripts/match_reviewers.py
@@ -4,14 +4,19 @@
 Reuses patterns_to_regex from gitutils.py to ensure matching semantics are
 identical to trymerge.
 
-Usage:
-    python match_reviewers.py --merge-rules PATH --changed-files f1 f2 ... --pr-author LOGIN
+Inputs (via env vars when run from CI):
+    CHANGED_FILES: JSON array of file paths
+    PR_AUTHOR:     PR author login
+
+Output:
+    Writes `result=<json>` to $GITHUB_OUTPUT if set, else stdout.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -70,13 +75,6 @@ def match_reviewers(
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--merge-rules", required=True, type=Path)
-    parser.add_argument("--changed-files", nargs="*", default=[])
-    parser.add_argument(
-        "--changed-files-stdin",
-        action="store_true",
-        help="Read changed files as JSON array from stdin",
-    )
-    parser.add_argument("--pr-author", required=True)
     args = parser.parse_args()
 
     import yaml
@@ -84,15 +82,18 @@ def main() -> None:
     with open(args.merge_rules) as f:
         rules = yaml.safe_load(f)
 
-    if args.changed_files_stdin:
-        changed_files = json.load(sys.stdin)
+    changed_files = json.loads(os.environ["CHANGED_FILES"])
+    pr_author = os.environ["PR_AUTHOR"]
+
+    reviewers, teams = match_reviewers(rules, changed_files, pr_author)
+    result_json = json.dumps({"reviewers": reviewers, "teams": teams})
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            f.write(f"result={result_json}\n")
     else:
-        changed_files = args.changed_files
-
-    reviewers, teams = match_reviewers(rules, changed_files, args.pr_author)
-
-    result = {"reviewers": reviewers, "teams": teams}
-    json.dump(result, sys.stdout)
+        sys.stdout.write(result_json)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/match_reviewers.py
+++ b/.github/scripts/match_reviewers.py
@@ -19,7 +19,7 @@ from gitutils import patterns_to_regex
 
 
 def is_wildcard_only(patterns: list[str]) -> bool:
-    return all(p in ("*", "**") for p in patterns)
+    return len(patterns) > 0 and all(p in ("*", "**") for p in patterns)
 
 
 KNOWN_BOTS = frozenset(

--- a/.github/scripts/match_reviewers.py
+++ b/.github/scripts/match_reviewers.py
@@ -23,8 +23,15 @@ from pathlib import Path
 from gitutils import patterns_to_regex
 
 
-def is_wildcard_only(patterns: list[str]) -> bool:
-    return len(patterns) > 0 and all(p in ("*", "**") for p in patterns)
+def has_catchall_pattern(patterns: list[str]) -> bool:
+    """A rule is a catch-all if any pattern is bare `*` or `**`.
+
+    Such rules match every file (the alternative regex `[^/]*` / `.*` matches
+    at position 0 of any path), so they're meant for superuser/maintainer
+    approval — not for file-path-based reviewer routing. Skip them entirely
+    rather than spamming their approver list on every PR.
+    """
+    return any(p in ("*", "**") for p in patterns)
 
 
 KNOWN_BOTS = frozenset(
@@ -54,7 +61,7 @@ def match_reviewers(
         patterns = rule.get("patterns", [])
         approvers = rule.get("approved_by", [])
 
-        if is_wildcard_only(patterns):
+        if has_catchall_pattern(patterns):
             continue
 
         regex = patterns_to_regex(patterns)

--- a/.github/scripts/match_reviewers.py
+++ b/.github/scripts/match_reviewers.py
@@ -4,12 +4,17 @@
 Reuses patterns_to_regex from gitutils.py to ensure matching semantics are
 identical to trymerge.
 
-Inputs (via env vars when run from CI):
+Two modes, selected by which env var is set. Result is written to stdout as
+JSON in both modes.
+
+Batch mode (BATCH set):
+    BATCH: JSON list of {"number": int, "files": [str], "author": str}
+    Output: list of {"number", "reviewers", "teams"}.
+
+Single-PR mode (CHANGED_FILES + PR_AUTHOR set):
     CHANGED_FILES: JSON array of file paths
     PR_AUTHOR:     PR author login
-
-Output:
-    Writes `result=<json>` to $GITHUB_OUTPUT if set, else stdout.
+    Output: {"reviewers", "teams"}.
 """
 
 from __future__ import annotations
@@ -89,18 +94,21 @@ def main() -> None:
     with open(args.merge_rules) as f:
         rules = yaml.safe_load(f)
 
-    changed_files = json.loads(os.environ["CHANGED_FILES"])
-    pr_author = os.environ["PR_AUTHOR"]
-
-    reviewers, teams = match_reviewers(rules, changed_files, pr_author)
-    result_json = json.dumps({"reviewers": reviewers, "teams": teams})
-
-    github_output = os.environ.get("GITHUB_OUTPUT")
-    if github_output:
-        with open(github_output, "a") as f:
-            f.write(f"result={result_json}\n")
+    if "BATCH" in os.environ:
+        batch = json.loads(os.environ["BATCH"])
+        out: list | dict = []
+        for entry in batch:
+            reviewers, teams = match_reviewers(rules, entry["files"], entry["author"])
+            out.append(
+                {"number": entry["number"], "reviewers": reviewers, "teams": teams}
+            )
     else:
-        sys.stdout.write(result_json)
+        changed_files = json.loads(os.environ["CHANGED_FILES"])
+        pr_author = os.environ["PR_AUTHOR"]
+        reviewers, teams = match_reviewers(rules, changed_files, pr_author)
+        out = {"reviewers": reviewers, "teams": teams}
+
+    json.dump(out, sys.stdout)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/match_reviewers.py
+++ b/.github/scripts/match_reviewers.py
@@ -4,14 +4,13 @@
 Reuses patterns_to_regex from gitutils.py to ensure matching semantics are
 identical to trymerge.
 
-Two modes, selected by which env var is set. Result is written to stdout as
-JSON in both modes.
+Result is written to stdout as JSON.
 
-Batch mode (BATCH set):
-    BATCH: JSON list of {"number": int, "files": [str], "author": str}
+Batch mode (--batch-file PATH):
+    Reads a JSON list of {"number": int, "files": [str], "author": str}.
     Output: list of {"number", "reviewers", "teams"}.
 
-Single-PR mode (CHANGED_FILES + PR_AUTHOR set):
+Single-PR mode (CHANGED_FILES + PR_AUTHOR env vars):
     CHANGED_FILES: JSON array of file paths
     PR_AUTHOR:     PR author login
     Output: {"reviewers", "teams"}.
@@ -87,6 +86,7 @@ def match_reviewers(
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--merge-rules", required=True, type=Path)
+    parser.add_argument("--batch-file", type=Path)
     args = parser.parse_args()
 
     import yaml
@@ -94,8 +94,9 @@ def main() -> None:
     with open(args.merge_rules) as f:
         rules = yaml.safe_load(f)
 
-    if "BATCH" in os.environ:
-        batch = json.loads(os.environ["BATCH"])
+    if args.batch_file is not None:
+        with open(args.batch_file) as f:
+            batch = json.load(f)
         out: list | dict = []
         for entry in batch:
             reviewers, teams = match_reviewers(rules, entry["files"], entry["author"])

--- a/.github/scripts/test_match_reviewers.py
+++ b/.github/scripts/test_match_reviewers.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+
+from unittest import main, TestCase
+
+from match_reviewers import is_bot, is_wildcard_only, match_reviewers
+
+
+SAMPLE_RULES = [
+    {
+        "name": "ONNX exporter",
+        "patterns": ["torch/onnx/**", "test/onnx/**"],
+        "approved_by": ["alice", "bob"],
+    },
+    {
+        "name": "Distributed",
+        "patterns": ["torch/distributed/**", "test/distributed/**"],
+        "approved_by": ["carol", "pytorch/dist-team"],
+    },
+    {
+        "name": "CI bot rule",
+        "patterns": [".ci/docker/ci_commit_pins/triton.txt"],
+        "approved_by": ["pytorchbot"],
+    },
+    {
+        "name": "superuser",
+        "patterns": ["*"],
+        "approved_by": ["superadmin"],
+    },
+    {
+        "name": "Core Maintainers",
+        "patterns": ["**"],
+        "approved_by": ["maintainer1"],
+    },
+    {
+        "name": "ROCm",
+        "patterns": ["**rocm**", "**hip**"],
+        "approved_by": ["rocm-dev", "facebook-github-bot"],
+    },
+]
+
+
+class TestIsWildcardOnly(TestCase):
+    def test_single_star(self) -> None:
+        self.assertTrue(is_wildcard_only(["*"]))
+
+    def test_double_star(self) -> None:
+        self.assertTrue(is_wildcard_only(["**"]))
+
+    def test_mixed_wildcards(self) -> None:
+        self.assertTrue(is_wildcard_only(["*", "**"]))
+
+    def test_real_pattern(self) -> None:
+        self.assertFalse(is_wildcard_only(["torch/onnx/**"]))
+
+    def test_empty(self) -> None:
+        self.assertTrue(is_wildcard_only([]))
+
+
+class TestIsBot(TestCase):
+    def test_pytorchbot(self) -> None:
+        self.assertTrue(is_bot("pytorchbot"))
+
+    def test_facebook_github_bot(self) -> None:
+        self.assertTrue(is_bot("facebook-github-bot"))
+
+    def test_pytorchmergebot(self) -> None:
+        self.assertTrue(is_bot("pytorchmergebot"))
+
+    def test_regular_user(self) -> None:
+        self.assertFalse(is_bot("alice"))
+
+    def test_bot_in_middle(self) -> None:
+        self.assertFalse(is_bot("bottleneck-dev"))
+
+    def test_not_a_bot_suffix(self) -> None:
+        self.assertFalse(is_bot("abbot"))
+
+
+class TestMatchReviewers(TestCase):
+    def test_onnx_files(self) -> None:
+        reviewers, teams = match_reviewers(
+            SAMPLE_RULES,
+            ["torch/onnx/export.py", "torch/onnx/utils.py"],
+            "someone",
+        )
+        self.assertEqual(reviewers, ["alice", "bob"])
+        self.assertEqual(teams, [])
+
+    def test_distributed_files_with_team(self) -> None:
+        reviewers, teams = match_reviewers(
+            SAMPLE_RULES,
+            ["torch/distributed/rpc/api.py"],
+            "someone",
+        )
+        self.assertEqual(reviewers, ["carol"])
+        self.assertEqual(teams, ["dist-team"])
+
+    def test_skips_wildcard_rules(self) -> None:
+        reviewers, teams = match_reviewers(
+            SAMPLE_RULES,
+            ["torch/onnx/export.py"],
+            "someone",
+        )
+        self.assertNotIn("superadmin", reviewers)
+        self.assertNotIn("maintainer1", reviewers)
+
+    def test_skips_bots(self) -> None:
+        reviewers, teams = match_reviewers(
+            SAMPLE_RULES,
+            [".ci/docker/ci_commit_pins/triton.txt"],
+            "someone",
+        )
+        self.assertNotIn("pytorchbot", reviewers)
+        self.assertEqual(reviewers, [])
+
+    def test_skips_pr_author(self) -> None:
+        reviewers, teams = match_reviewers(
+            SAMPLE_RULES,
+            ["torch/onnx/export.py"],
+            "Alice",  # case-insensitive
+        )
+        self.assertNotIn("alice", reviewers)
+        self.assertEqual(reviewers, ["bob"])
+
+    def test_no_matches(self) -> None:
+        reviewers, teams = match_reviewers(
+            SAMPLE_RULES,
+            ["some/unknown/file.py"],
+            "someone",
+        )
+        self.assertEqual(reviewers, [])
+        self.assertEqual(teams, [])
+
+    def test_multiple_rules_match(self) -> None:
+        reviewers, teams = match_reviewers(
+            SAMPLE_RULES,
+            ["torch/onnx/export.py", "torch/distributed/rpc/api.py"],
+            "someone",
+        )
+        self.assertEqual(reviewers, ["alice", "bob", "carol"])
+        self.assertEqual(teams, ["dist-team"])
+
+    def test_rocm_pattern_with_bot_filtering(self) -> None:
+        reviewers, teams = match_reviewers(
+            SAMPLE_RULES,
+            ["aten/src/ATen/hip/impl.cpp"],
+            "someone",
+        )
+        self.assertEqual(reviewers, ["rocm-dev"])
+        # facebook-github-bot should be filtered out
+        self.assertEqual(teams, [])
+
+    def test_deduplication(self) -> None:
+        rules = [
+            {
+                "name": "Rule A",
+                "patterns": ["torch/foo/**"],
+                "approved_by": ["alice"],
+            },
+            {
+                "name": "Rule B",
+                "patterns": ["torch/**"],
+                "approved_by": ["alice"],
+            },
+        ]
+        reviewers, teams = match_reviewers(
+            rules, ["torch/foo/bar.py"], "someone"
+        )
+        self.assertEqual(reviewers, ["alice"])
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_match_reviewers.py
+++ b/.github/scripts/test_match_reviewers.py
@@ -163,9 +163,7 @@ class TestMatchReviewers(TestCase):
                 "approved_by": ["alice"],
             },
         ]
-        reviewers, teams = match_reviewers(
-            rules, ["torch/foo/bar.py"], "someone"
-        )
+        reviewers, teams = match_reviewers(rules, ["torch/foo/bar.py"], "someone")
         self.assertEqual(reviewers, ["alice"])
 
 

--- a/.github/scripts/test_match_reviewers.py
+++ b/.github/scripts/test_match_reviewers.py
@@ -53,7 +53,8 @@ class TestIsWildcardOnly(TestCase):
         self.assertFalse(is_wildcard_only(["torch/onnx/**"]))
 
     def test_empty(self) -> None:
-        self.assertTrue(is_wildcard_only([]))
+        # Empty pattern list matches nothing — not a superuser/wildcard rule.
+        self.assertFalse(is_wildcard_only([]))
 
 
 class TestIsBot(TestCase):

--- a/.github/scripts/test_match_reviewers.py
+++ b/.github/scripts/test_match_reviewers.py
@@ -2,7 +2,7 @@
 
 from unittest import main, TestCase
 
-from match_reviewers import is_bot, is_wildcard_only, match_reviewers
+from match_reviewers import has_catchall_pattern, is_bot, match_reviewers
 
 
 SAMPLE_RULES = [
@@ -36,25 +36,39 @@ SAMPLE_RULES = [
         "patterns": ["**rocm**", "**hip**"],
         "approved_by": ["rocm-dev", "facebook-github-bot"],
     },
+    {
+        # Rule with `*` mixed with a `-prefix` "negation" pattern that the
+        # underlying glob compiler doesn't actually support. The `*`
+        # alternative makes this rule match every file, so it must be skipped.
+        "name": "Metamates",
+        "patterns": ["*", "-.ci/docker/**"],
+        "approved_by": ["metamate1"],
+    },
 ]
 
 
-class TestIsWildcardOnly(TestCase):
+class TestHasCatchallPattern(TestCase):
     def test_single_star(self) -> None:
-        self.assertTrue(is_wildcard_only(["*"]))
+        self.assertTrue(has_catchall_pattern(["*"]))
 
     def test_double_star(self) -> None:
-        self.assertTrue(is_wildcard_only(["**"]))
+        self.assertTrue(has_catchall_pattern(["**"]))
 
     def test_mixed_wildcards(self) -> None:
-        self.assertTrue(is_wildcard_only(["*", "**"]))
+        self.assertTrue(has_catchall_pattern(["*", "**"]))
 
     def test_real_pattern(self) -> None:
-        self.assertFalse(is_wildcard_only(["torch/onnx/**"]))
+        self.assertFalse(has_catchall_pattern(["torch/onnx/**"]))
 
     def test_empty(self) -> None:
-        # Empty pattern list matches nothing — not a superuser/wildcard rule.
-        self.assertFalse(is_wildcard_only([]))
+        self.assertFalse(has_catchall_pattern([]))
+
+    def test_wildcard_with_extra_pattern(self) -> None:
+        # The bug case: a rule mixing `*` with a "negation" pattern would
+        # previously slip through because not all patterns were wildcards.
+        # `*` alone is a catch-all (matches every file), so the rule must be
+        # skipped regardless of any other patterns.
+        self.assertTrue(has_catchall_pattern(["*", "-.ci/docker/**"]))
 
 
 class TestIsBot(TestCase):
@@ -104,6 +118,9 @@ class TestMatchReviewers(TestCase):
         )
         self.assertNotIn("superadmin", reviewers)
         self.assertNotIn("maintainer1", reviewers)
+        # Regression: a rule with `*` plus other patterns must also be
+        # skipped — the `*` alternative makes it match every file.
+        self.assertNotIn("metamate1", reviewers)
 
     def test_skips_bots(self) -> None:
         reviewers, teams = match_reviewers(

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -1,3 +1,8 @@
+# File-path-based reviewer auto-assignment using merge_rules.yaml.
+# This complements (not replaces) auto_request_review.yml, which does
+# author-based routing via necojackarc/auto-request-review. That workflow
+# assigns reviewers based on who authored the PR; this one assigns domain
+# owners based on which files the PR touches.
 name: Auto Request Reviewers
 
 on:
@@ -5,10 +10,14 @@ on:
     types: [opened, synchronize]
   workflow_dispatch:
     inputs:
-      pr_url:
-        description: "PR link (e.g. https://github.com/pytorch/pytorch/pull/12345)"
+      pr:
+        description: "PR number or link (e.g. 12345 or https://github.com/pytorch/pytorch/pull/12345)"
         type: string
         required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
 
 jobs:
   request-reviewers:
@@ -23,22 +32,37 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          sparse-checkout: .github/merge_rules.yaml
+          # Pin to base branch SHA to ensure we never check out PR head under pull_request_target
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          sparse-checkout: |
+            .github/merge_rules.yaml
+            .github/scripts/gitutils.py
+            .github/scripts/match_reviewers.py
 
       - name: Resolve PR and check eligibility
         id: pr
         uses: actions/github-script@v7
+        env:
+          PR_INPUT: ${{ inputs.pr }}
         with:
           script: |
             let prNumber;
-            const prUrl = '${{ inputs.pr_url }}';
-            if (prUrl) {
-              const match = prUrl.match(/\/pull\/(\d+)/);
-              if (!match) {
-                core.setFailed(`Invalid PR link: ${prUrl}. Expected format: https://github.com/pytorch/pytorch/pull/12345`);
-                return;
+            const prInput = process.env.PR_INPUT;
+            if (prInput) {
+              if (/^\d+$/.test(prInput)) {
+                prNumber = parseInt(prInput);
+              } else {
+                const match = prInput.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
+                if (!match) {
+                  core.setFailed('Invalid input. Expected a PR number or URL like https://github.com/pytorch/pytorch/pull/12345');
+                  return;
+                }
+                if (match[1] !== 'pytorch/pytorch') {
+                  core.setFailed(`URL must be for pytorch/pytorch, got ${match[1]}`);
+                  return;
+                }
+                prNumber = parseInt(match[2]);
               }
-              prNumber = parseInt(match[1]);
             } else {
               prNumber = context.payload.pull_request.number;
             }
@@ -66,14 +90,24 @@ jobs:
             if (labels.includes('triaged')) return skip('already has "triaged" label');
             if (title.includes('WIP') || title.includes('TESTING')) return skip('title contains WIP or TESTING');
 
-            // Check if PR already has an approving review
-            const reviews = await github.rest.pulls.listReviews({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-            const approved = reviews.data.some(r => r.state === 'APPROVED');
-            if (approved) return skip('PR already has an approving review');
+            // Skip if any reviewer has already approved or requested changes —
+            // the PR already has review activity and doesn't need auto-triage.
+            const allReviews = [];
+            for (let page = 1; ; page++) {
+              const resp = await github.rest.pulls.listReviews({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+                page,
+              });
+              allReviews.push(...resp.data);
+              if (resp.data.length < 100) break;
+            }
+            const hasReviewActivity = allReviews.some(
+              r => r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED'
+            );
+            if (hasReviewActivity) return skip('PR already has review activity');
 
             core.info(`PR #${prNumber} is eligible for auto reviewer request`);
             core.setOutput('eligible', 'true');
@@ -84,9 +118,11 @@ jobs:
         if: steps.pr.outputs.eligible == 'true'
         id: changed
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
-            const prNumber = ${{ steps.pr.outputs.number }};
+            const prNumber = parseInt(process.env.PR_NUMBER);
             const files = [];
             const per_page = 100;
             let page = 1;
@@ -106,63 +142,33 @@ jobs:
             }
             core.setOutput('files', JSON.stringify(files));
 
+      - name: Install PyYAML
+        if: steps.pr.outputs.eligible == 'true'
+        run: pip install PyYAML
+
       - name: Determine reviewers from merge rules
         if: steps.pr.outputs.eligible == 'true'
         id: reviewers
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const yaml = require('js-yaml');
-            const {minimatch} = require('minimatch');
-
-            const rules = yaml.load(fs.readFileSync('.github/merge_rules.yaml', 'utf8'));
-            const changedFiles = JSON.parse('${{ steps.changed.outputs.files }}');
-            const prAuthor = '${{ steps.pr.outputs.author }}'.toLowerCase();
-
-            // Skip wildcard-only rules and bot accounts
-            const SKIP_RULES = new Set(['superuser', 'Core Reviewers', 'Core Maintainers']);
-            const SKIP_USERS = new Set(['pytorchbot']);
-
-            const reviewers = new Set();
-            const teams = new Set();
-
-            for (const rule of rules) {
-              if (SKIP_RULES.has(rule.name)) continue;
-
-              const patterns = rule.patterns || [];
-              const approvers = rule.approved_by || [];
-
-              // Check if any changed file matches any pattern in this rule
-              const matched = changedFiles.some(file =>
-                patterns.some(pattern => minimatch(file, pattern, {matchBase: false}))
-              );
-
-              if (matched) {
-                for (const approver of approvers) {
-                  if (SKIP_USERS.has(approver)) continue;
-                  if (approver.startsWith('pytorch/')) {
-                    teams.add(approver.replace('pytorch/', ''));
-                  } else if (approver.toLowerCase() !== prAuthor) {
-                    reviewers.add(approver);
-                  }
-                }
-              }
-            }
-
-            core.info(`Matched reviewers: ${[...reviewers].join(', ')}`);
-            core.info(`Matched teams: ${[...teams].join(', ')}`);
-            core.setOutput('reviewers', JSON.stringify([...reviewers]));
-            core.setOutput('teams', JSON.stringify([...teams]));
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+          PR_AUTHOR: ${{ steps.pr.outputs.author }}
+        run: |
+          RESULT=$(echo "$CHANGED_FILES" | python3 .github/scripts/match_reviewers.py \
+            --merge-rules .github/merge_rules.yaml \
+            --pr-author "$PR_AUTHOR" \
+            --changed-files-stdin)
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
 
       - name: Request reviews
         if: steps.pr.outputs.eligible == 'true'
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          MATCH_RESULT: ${{ steps.reviewers.outputs.result }}
         with:
           script: |
-            const prNumber = ${{ steps.pr.outputs.number }};
-            const reviewers = JSON.parse('${{ steps.reviewers.outputs.reviewers }}');
-            const teams = JSON.parse('${{ steps.reviewers.outputs.teams }}');
+            const {reviewers, teams} = JSON.parse(process.env.MATCH_RESULT);
+            const prNumber = parseInt(process.env.PR_NUMBER);
 
             if (reviewers.length === 0 && teams.length === 0) {
               core.info('No reviewers to request.');

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -16,7 +16,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.event_name == 'workflow_dispatch' && format('{0}-dispatch-{1}', github.workflow, github.run_id) || format('{0}-{1}', github.workflow, github.event.pull_request.number) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -5,8 +5,8 @@ on:
     types: [opened, synchronize]
   workflow_dispatch:
     inputs:
-      pr_number:
-        description: "PR number to request reviewers for"
+      pr_url:
+        description: "PR link (e.g. https://github.com/pytorch/pytorch/pull/12345)"
         type: string
         required: true
 
@@ -30,7 +30,18 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = ${{ inputs.pr_number || 0 }} || context.payload.pull_request.number;
+            let prNumber;
+            const prUrl = '${{ inputs.pr_url }}';
+            if (prUrl) {
+              const match = prUrl.match(/\/pull\/(\d+)/);
+              if (!match) {
+                core.setFailed(`Invalid PR link: ${prUrl}. Expected format: https://github.com/pytorch/pytorch/pull/12345`);
+                return;
+              }
+              prNumber = parseInt(match[1]);
+            } else {
+              prNumber = context.payload.pull_request.number;
+            }
             const {data: pr} = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Install PyYAML
         if: steps.pr.outputs.eligible == 'true'
-        run: pip install PyYAML
+        run: pip install pyyaml==6.0.2
 
       - name: Determine reviewers from merge rules
         if: steps.pr.outputs.eligible == 'true'
@@ -175,15 +175,31 @@ jobs:
               return;
             }
 
-            try {
-              await github.rest.pulls.requestReviewers({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-                reviewers: reviewers,
-                team_reviewers: teams,
-              });
-              core.info(`Requested reviews from: ${reviewers.concat(teams.map(t => 'pytorch/' + t)).join(', ')}`);
-            } catch (error) {
-              core.warning(`Failed to request some reviewers: ${error.message}`);
+            // Request reviews individually so a single stale username doesn't
+            // prevent all other valid reviewers from being assigned.
+            for (const reviewer of reviewers) {
+              try {
+                await github.rest.pulls.requestReviewers({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                  reviewers: [reviewer],
+                });
+                core.info(`Requested review from ${reviewer}`);
+              } catch (error) {
+                core.warning(`Failed to request review from ${reviewer}: ${error.message}`);
+              }
+            }
+            for (const team of teams) {
+              try {
+                await github.rest.pulls.requestReviewers({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                  team_reviewers: [team],
+                });
+                core.info(`Requested review from team pytorch/${team}`);
+              } catch (error) {
+                core.warning(`Failed to request review from team pytorch/${team}: ${error.message}`);
+              }
             }

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -1,0 +1,172 @@
+name: Auto Request Reviewers
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to request reviewers for"
+        type: string
+        required: true
+
+jobs:
+  request-reviewers:
+    if: github.repository == 'pytorch/pytorch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/merge_rules.yaml
+
+      - name: Resolve PR and check eligibility
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ inputs.pr_number || 0 }} || context.payload.pull_request.number;
+            const {data: pr} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const labels = pr.labels.map(l => l.name);
+            const title = pr.title.toUpperCase();
+
+            // Filter criteria based on:
+            // is:open base:main draft:false label:"open source" -label:triaged
+            // -review:approved NOT WIP NOT TESTING in:title
+            const skip = (reason) => {
+              core.info(`Skipping PR #${prNumber}: ${reason}`);
+              core.setOutput('eligible', 'false');
+            };
+
+            if (pr.state !== 'open') return skip('PR is not open');
+            if (pr.base.ref !== 'main') return skip(`base branch is '${pr.base.ref}', not 'main'`);
+            if (pr.draft) return skip('PR is a draft');
+            if (!labels.includes('open source')) return skip('missing "open source" label');
+            if (labels.includes('triaged')) return skip('already has "triaged" label');
+            if (title.includes('WIP') || title.includes('TESTING')) return skip('title contains WIP or TESTING');
+
+            // Check if PR already has an approving review
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const approved = reviews.data.some(r => r.state === 'APPROVED');
+            if (approved) return skip('PR already has an approving review');
+
+            core.info(`PR #${prNumber} is eligible for auto reviewer request`);
+            core.setOutput('eligible', 'true');
+            core.setOutput('number', prNumber);
+            core.setOutput('author', pr.user.login);
+
+      - name: Get changed files
+        if: steps.pr.outputs.eligible == 'true'
+        id: changed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+            const files = [];
+            const per_page = 100;
+            let page = 1;
+            while (true) {
+              const resp = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page,
+                page,
+              });
+              for (const f of resp.data) {
+                files.push(f.filename);
+              }
+              if (resp.data.length < per_page) break;
+              page++;
+            }
+            core.setOutput('files', JSON.stringify(files));
+
+      - name: Determine reviewers from merge rules
+        if: steps.pr.outputs.eligible == 'true'
+        id: reviewers
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+            const {minimatch} = require('minimatch');
+
+            const rules = yaml.load(fs.readFileSync('.github/merge_rules.yaml', 'utf8'));
+            const changedFiles = JSON.parse('${{ steps.changed.outputs.files }}');
+            const prAuthor = '${{ steps.pr.outputs.author }}'.toLowerCase();
+
+            // Skip wildcard-only rules and bot accounts
+            const SKIP_RULES = new Set(['superuser', 'Core Reviewers', 'Core Maintainers']);
+            const SKIP_USERS = new Set(['pytorchbot']);
+
+            const reviewers = new Set();
+            const teams = new Set();
+
+            for (const rule of rules) {
+              if (SKIP_RULES.has(rule.name)) continue;
+
+              const patterns = rule.patterns || [];
+              const approvers = rule.approved_by || [];
+
+              // Check if any changed file matches any pattern in this rule
+              const matched = changedFiles.some(file =>
+                patterns.some(pattern => minimatch(file, pattern, {matchBase: false}))
+              );
+
+              if (matched) {
+                for (const approver of approvers) {
+                  if (SKIP_USERS.has(approver)) continue;
+                  if (approver.startsWith('pytorch/')) {
+                    teams.add(approver.replace('pytorch/', ''));
+                  } else if (approver.toLowerCase() !== prAuthor) {
+                    reviewers.add(approver);
+                  }
+                }
+              }
+            }
+
+            core.info(`Matched reviewers: ${[...reviewers].join(', ')}`);
+            core.info(`Matched teams: ${[...teams].join(', ')}`);
+            core.setOutput('reviewers', JSON.stringify([...reviewers]));
+            core.setOutput('teams', JSON.stringify([...teams]));
+
+      - name: Request reviews
+        if: steps.pr.outputs.eligible == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+            const reviewers = JSON.parse('${{ steps.reviewers.outputs.reviewers }}');
+            const teams = JSON.parse('${{ steps.reviewers.outputs.teams }}');
+
+            if (reviewers.length === 0 && teams.length === 0) {
+              core.info('No reviewers to request.');
+              return;
+            }
+
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                reviewers: reviewers,
+                team_reviewers: teams,
+              });
+              core.info(`Requested reviews from: ${reviewers.concat(teams.map(t => 'pytorch/' + t)).join(', ')}`);
+            } catch (error) {
+              core.warning(`Failed to request some reviewers: ${error.message}`);
+            }

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -76,14 +76,13 @@ jobs:
             const title = pr.title.toUpperCase();
 
             // Filter criteria based on:
-            // is:open base:main draft:false label:"open source" -label:triaged
+            // base:main draft:false label:"open source" -label:triaged
             // -review:approved NOT WIP NOT TESTING in:title
             const skip = (reason) => {
               core.info(`Skipping PR #${prNumber}: ${reason}`);
               core.setOutput('eligible', 'false');
             };
 
-            if (pr.state !== 'open') return skip('PR is not open');
             if (pr.base.ref !== 'main') return skip(`base branch is '${pr.base.ref}', not 'main'`);
             if (pr.draft) return skip('PR is a draft');
             if (!labels.includes('open source')) return skip('missing "open source" label');
@@ -92,18 +91,12 @@ jobs:
 
             // Skip if any reviewer has already approved or requested changes —
             // the PR already has review activity and doesn't need auto-triage.
-            const allReviews = [];
-            for (let page = 1; ; page++) {
-              const resp = await github.rest.pulls.listReviews({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-                per_page: 100,
-                page,
-              });
-              allReviews.push(...resp.data);
-              if (resp.data.length < 100) break;
-            }
+            const allReviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
             const hasReviewActivity = allReviews.some(
               r => r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED'
             );
@@ -123,23 +116,12 @@ jobs:
         with:
           script: |
             const prNumber = parseInt(process.env.PR_NUMBER);
-            const files = [];
-            const per_page = 100;
-            let page = 1;
-            while (true) {
-              const resp = await github.rest.pulls.listFiles({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-                per_page,
-                page,
-              });
-              for (const f of resp.data) {
-                files.push(f.filename);
-              }
-              if (resp.data.length < per_page) break;
-              page++;
-            }
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100,
+            }, (resp) => resp.data.map(f => f.filename));
             core.setOutput('files', JSON.stringify(files));
 
       - name: Install PyYAML

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -7,7 +7,7 @@ name: Auto Request Reviewers
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr:
@@ -21,7 +21,11 @@ concurrency:
 
 jobs:
   request-reviewers:
-    if: github.repository == 'pytorch/pytorch'
+    if: |
+      github.repository == 'pytorch/pytorch' && (
+        github.event_name == 'workflow_dispatch' ||
+        (!github.event.pull_request.draft && github.event.pull_request.base.ref == 'main')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -20,7 +20,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  request-reviewers:
+  # Read-only compute: resolve PR, check eligibility, run the matcher over
+  # attacker-controlled filenames. Cannot write to the PR even if compromised.
+  compute:
     if: |
       github.repository == 'pytorch/pytorch' && (
         github.event_name == 'workflow_dispatch' ||
@@ -29,15 +31,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      pull-requests: write
       contents: read
-
+      pull-requests: read
+    outputs:
+      eligible: ${{ steps.pr.outputs.eligible }}
+      number: ${{ steps.pr.outputs.number }}
+      match_result: ${{ steps.reviewers.outputs.result }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # Pin to base branch SHA to ensure we never check out PR head under pull_request_target
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
           sparse-checkout: |
             .github/merge_rules.yaml
             .github/scripts/gitutils.py
@@ -45,7 +51,7 @@ jobs:
 
       - name: Resolve PR and check eligibility
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           PR_INPUT: ${{ inputs.pr }}
         with:
@@ -113,7 +119,7 @@ jobs:
       - name: Get changed files
         if: steps.pr.outputs.eligible == 'true'
         id: changed
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
@@ -137,19 +143,24 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
           PR_AUTHOR: ${{ steps.pr.outputs.author }}
-        run: |
-          RESULT=$(echo "$CHANGED_FILES" | python3 .github/scripts/match_reviewers.py \
-            --merge-rules .github/merge_rules.yaml \
-            --pr-author "$PR_AUTHOR" \
-            --changed-files-stdin)
-          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+        run: python3 .github/scripts/match_reviewers.py --merge-rules .github/merge_rules.yaml
 
+  # Write-only requester: no checkout, no code execution over PR data, only
+  # consumes the JSON output from `compute` and calls requestReviewers.
+  request:
+    needs: compute
+    if: needs.compute.outputs.eligible == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: none
+      pull-requests: write
+    steps:
       - name: Request reviews
-        if: steps.pr.outputs.eligible == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          MATCH_RESULT: ${{ steps.reviewers.outputs.result }}
+          PR_NUMBER: ${{ needs.compute.outputs.number }}
+          MATCH_RESULT: ${{ needs.compute.outputs.match_result }}
         with:
           script: |
             const {reviewers, teams} = JSON.parse(process.env.MATCH_RESULT);

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -77,13 +77,14 @@ jobs:
 
             // Filter criteria based on:
             // base:main draft:false label:"open source" -label:triaged
-            // -review:approved NOT WIP NOT TESTING in:title
+            // -review:approved NOT WIP NOT TESTING in:title created:>=2019-06-06
             const skip = (reason) => {
               core.info(`Skipping PR #${prNumber}: ${reason}`);
               core.setOutput('eligible', 'false');
             };
 
             if (pr.base.ref !== 'main') return skip(`base branch is '${pr.base.ref}', not 'main'`);
+            if (new Date(pr.created_at) < new Date('2019-06-06')) return skip(`created before 2019-06-06 (${pr.created_at})`);
             if (pr.draft) return skip('PR is a draft');
             if (!labels.includes('open source')) return skip('missing "open source" label');
             if (labels.includes('triaged')) return skip('already has "triaged" label');

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -77,11 +77,10 @@ jobs:
             });
 
             const labels = pr.labels.map(l => l.name);
-            const title = pr.title.toUpperCase();
 
             // Filter criteria based on:
             // base:main draft:false label:"open source" -label:triaged
-            // -review:approved NOT WIP NOT TESTING in:title created:>=2019-06-06
+            // -review:approved created:>=2019-06-06
             const skip = (reason) => {
               core.info(`Skipping PR #${prNumber}: ${reason}`);
               core.setOutput('eligible', 'false');
@@ -92,7 +91,6 @@ jobs:
             if (pr.draft) return skip('PR is a draft');
             if (!labels.includes('open source')) return skip('missing "open source" label');
             if (labels.includes('triaged')) return skip('already has "triaged" label');
-            if (title.includes('WIP') || title.includes('TESTING')) return skip('title contains WIP or TESTING');
 
             // Skip if any reviewer has already approved or requested changes —
             // the PR already has review activity and doesn't need auto-triage.

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -3,158 +3,174 @@
 # author-based routing via necojackarc/auto-request-review. That workflow
 # assigns reviewers based on who authored the PR; this one assigns domain
 # owners based on which files the PR touches.
+#
+# Triggered on a 12h cron (and manually via workflow_dispatch). We do not use
+# pull_request_target — it requires "Approve and run" for first-time external
+# contributors, which is exactly the population this workflow is meant to
+# triage. The cron sweep finds eligible PRs via the GitHub Search API and
+# routes them in bulk, no approval gate.
 name: Auto Request Reviewers
 
 on:
-  pull_request_target:
-    types: [opened, ready_for_review]
+  schedule:
+    - cron: "0 */12 * * *"
   workflow_dispatch:
     inputs:
       pr:
-        description: "PR number or link (e.g. 12345 or https://github.com/pytorch/pytorch/pull/12345)"
+        description: "Optional: PR number or URL to triage. Empty = sweep all eligible PRs."
         type: string
-        required: true
+        required: false
 
 concurrency:
-  group: ${{ github.event_name == 'workflow_dispatch' && format('{0}-dispatch-{1}', github.workflow, github.run_id) || format('{0}-{1}', github.workflow, github.event.pull_request.number) }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
-  # Read-only compute: resolve PR, check eligibility, run the matcher over
-  # attacker-controlled filenames. Cannot write to the PR even if compromised.
+  # Read-only compute: discover eligible PRs, fetch files, run the matcher
+  # over attacker-controlled filenames. Cannot write to PRs even if compromised.
   compute:
-    if: |
-      github.repository == 'pytorch/pytorch' && (
-        github.event_name == 'workflow_dispatch' ||
-        (!github.event.pull_request.draft && github.event.pull_request.base.ref == 'main')
-      )
+    if: github.repository == 'pytorch/pytorch'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
     outputs:
-      eligible: ${{ steps.pr.outputs.eligible }}
-      number: ${{ steps.pr.outputs.number }}
-      match_result: ${{ steps.reviewers.outputs.result }}
+      results: ${{ steps.match.outputs.results }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # Under pull_request_target, pin to the PR base SHA so we never check out PR head.
-          # Under workflow_dispatch, github.event.pull_request is empty and we fall back to
-          # github.sha (the SHA of the branch the dispatcher selected, defaults to main).
-          # Triggering workflow_dispatch already requires repo write access.
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
           sparse-checkout: |
             .github/merge_rules.yaml
             .github/scripts/gitutils.py
             .github/scripts/match_reviewers.py
 
-      - name: Resolve PR and check eligibility
-        id: pr
+      - name: Discover eligible PRs and fetch files
+        id: discover
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           PR_INPUT: ${{ inputs.pr }}
         with:
           script: |
-            let prNumber;
-            const prInput = process.env.PR_INPUT;
-            if (prInput) {
-              if (/^\d+$/.test(prInput)) {
-                prNumber = parseInt(prInput);
-              } else {
-                const match = prInput.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
-                if (!match) {
-                  core.setFailed('Invalid input. Expected a PR number or URL like https://github.com/pytorch/pytorch/pull/12345');
-                  return;
-                }
-                if (match[1] !== 'pytorch/pytorch') {
-                  core.setFailed(`URL must be for pytorch/pytorch, got ${match[1]}`);
-                  return;
-                }
-                prNumber = parseInt(match[2]);
+            // Resolve a single PR number from a workflow_dispatch input.
+            // Returns null if no input was provided (sweep mode).
+            function resolveInputPr(input) {
+              if (!input) return null;
+              if (/^\d+$/.test(input)) return parseInt(input);
+              const m = input.match(/^https?:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)$/);
+              if (!m) {
+                core.setFailed('Invalid input. Expected a PR number or URL.');
+                return null;
               }
-            } else {
-              prNumber = context.payload.pull_request.number;
+              if (m[1] !== 'pytorch/pytorch') {
+                core.setFailed(`URL must be for pytorch/pytorch, got ${m[1]}`);
+                return null;
+              }
+              return parseInt(m[2]);
             }
-            const {data: pr} = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
 
-            const labels = pr.labels.map(l => l.name);
+            // Eligibility check applied to a fully-fetched PR object. Mirrors
+            // the search query qualifiers as defense in depth (especially for
+            // the workflow_dispatch single-PR path which doesn't go through
+            // search), and adds the "no pending review request" check that
+            // Search has no qualifier for.
+            function isEligible(pr) {
+              const labels = pr.labels.map(l => l.name);
+              const reasons = [];
+              if (pr.state !== 'open') reasons.push(`state=${pr.state}`);
+              if (pr.draft) reasons.push('draft');
+              if (pr.base.ref !== 'main') reasons.push(`base=${pr.base.ref}`);
+              if (new Date(pr.created_at) < new Date('2019-06-06')) reasons.push('created before 2019-06-06');
+              if (!labels.includes('open source')) reasons.push('no "open source" label');
+              if (labels.includes('triaged')) reasons.push('has "triaged" label');
+              if ((pr.requested_reviewers || []).length > 0) reasons.push('reviewers already requested');
+              if ((pr.requested_teams || []).length > 0) reasons.push('team reviewers already requested');
+              if (reasons.length) {
+                core.info(`Skip PR #${pr.number}: ${reasons.join(', ')}`);
+                return false;
+              }
+              return true;
+            }
 
-            // Filter criteria based on:
-            // base:main draft:false label:"open source" -label:triaged
-            // -review:approved created:>=2019-06-06
-            const skip = (reason) => {
-              core.info(`Skipping PR #${prNumber}: ${reason}`);
-              core.setOutput('eligible', 'false');
-            };
+            const inputPr = resolveInputPr(process.env.PR_INPUT);
+            let candidateNumbers;
 
-            if (pr.base.ref !== 'main') return skip(`base branch is '${pr.base.ref}', not 'main'`);
-            if (new Date(pr.created_at) < new Date('2019-06-06')) return skip(`created before 2019-06-06 (${pr.created_at})`);
-            if (pr.draft) return skip('PR is a draft');
-            if (!labels.includes('open source')) return skip('missing "open source" label');
-            if (labels.includes('triaged')) return skip('already has "triaged" label');
+            if (inputPr) {
+              candidateNumbers = [inputPr];
+              core.info(`Single-PR mode: #${inputPr}`);
+            } else {
+              // Sweep mode: search for plausibly-eligible PRs.
+              const q = [
+                'repo:pytorch/pytorch',
+                'is:pr',
+                'is:open',
+                'base:main',
+                'draft:false',
+                'label:"open source"',
+                '-label:triaged',
+                'created:>=2019-06-06',
+                '-review:approved',
+                '-review:changes_requested',
+              ].join(' ');
+              core.info(`Sweep query: ${q}`);
+              const items = await github.paginate(github.rest.search.issuesAndPullRequests, {
+                q,
+                sort: 'updated',
+                order: 'desc',
+                per_page: 100,
+              });
+              const all = items.map(i => i.number);
+              const MAX_CANDIDATES = 200;
+              candidateNumbers = all.slice(0, MAX_CANDIDATES);
+              core.info(`Search returned ${all.length} candidates; processing ${candidateNumbers.length}`);
+            }
 
-            // Skip if any reviewer has already approved or requested changes —
-            // the PR already has review activity and doesn't need auto-triage.
-            const allReviews = await github.paginate(github.rest.pulls.listReviews, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-              per_page: 100,
-            });
-            const hasReviewActivity = allReviews.some(
-              r => r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED'
-            );
-            if (hasReviewActivity) return skip('PR already has review activity');
+            // Fetch each candidate to apply the (b) check + collect files.
+            // Per-PR try/catch keeps one transient failure from killing the sweep.
+            const batch = [];
+            for (const number of candidateNumbers) {
+              try {
+                const {data: pr} = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: number,
+                });
+                if (!isEligible(pr)) continue;
+                const files = await github.paginate(github.rest.pulls.listFiles, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: number,
+                  per_page: 100,
+                }, (resp) => resp.data.map(f => f.filename));
+                batch.push({number, author: pr.user.login, files});
+                core.info(`Eligible: PR #${number} by ${pr.user.login} (${files.length} files)`);
+              } catch (error) {
+                core.warning(`Skip PR #${number}: ${error.message}`);
+              }
+            }
 
-            core.info(`PR #${prNumber} is eligible for auto reviewer request`);
-            core.setOutput('eligible', 'true');
-            core.setOutput('number', prNumber);
-            core.setOutput('author', pr.user.login);
-
-      - name: Get changed files
-        if: steps.pr.outputs.eligible == 'true'
-        id: changed
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-        with:
-          script: |
-            const prNumber = parseInt(process.env.PR_NUMBER);
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-              per_page: 100,
-            }, (resp) => resp.data.map(f => f.filename));
-            core.setOutput('files', JSON.stringify(files));
+            const fs = require('fs');
+            fs.writeFileSync('batch.json', JSON.stringify(batch));
+            core.info(`Eligible PRs: ${batch.length}`);
 
       - name: Install PyYAML
-        if: steps.pr.outputs.eligible == 'true'
         run: pip install pyyaml==6.0.2
 
-      - name: Determine reviewers from merge rules
-        if: steps.pr.outputs.eligible == 'true'
-        id: reviewers
-        env:
-          CHANGED_FILES: ${{ steps.changed.outputs.files }}
-          PR_AUTHOR: ${{ steps.pr.outputs.author }}
-        run: python3 .github/scripts/match_reviewers.py --merge-rules .github/merge_rules.yaml
+      - name: Run matcher over batch
+        id: match
+        run: |
+          RESULTS="$(BATCH="$(cat batch.json)" python3 .github/scripts/match_reviewers.py \
+            --merge-rules .github/merge_rules.yaml)"
+          echo "results=$RESULTS" >> "$GITHUB_OUTPUT"
 
-  # Write-only requester: no checkout, no code execution over PR data, only
-  # consumes the JSON output from `compute` and calls requestReviewers.
+  # Write-only requester: no checkout, only consumes the JSON output from compute.
   request:
     needs: compute
-    if: needs.compute.outputs.eligible == 'true'
+    if: needs.compute.outputs.results != '' && needs.compute.outputs.results != '[]'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: none
       pull-requests: write
@@ -162,43 +178,41 @@ jobs:
       - name: Request reviews
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
-          PR_NUMBER: ${{ needs.compute.outputs.number }}
-          MATCH_RESULT: ${{ needs.compute.outputs.match_result }}
+          RESULTS: ${{ needs.compute.outputs.results }}
         with:
           script: |
-            const {reviewers, teams} = JSON.parse(process.env.MATCH_RESULT);
-            const prNumber = parseInt(process.env.PR_NUMBER);
-
-            if (reviewers.length === 0 && teams.length === 0) {
-              core.info('No reviewers to request.');
-              return;
-            }
-
-            // Request reviews individually so a single stale username doesn't
-            // prevent all other valid reviewers from being assigned.
-            for (const reviewer of reviewers) {
-              try {
-                await github.rest.pulls.requestReviewers({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: prNumber,
-                  reviewers: [reviewer],
-                });
-                core.info(`Requested review from ${reviewer}`);
-              } catch (error) {
-                core.warning(`Failed to request review from ${reviewer}: ${error.message}`);
+            const results = JSON.parse(process.env.RESULTS);
+            for (const {number, reviewers, teams} of results) {
+              if (reviewers.length === 0 && teams.length === 0) {
+                core.info(`PR #${number}: no matching reviewers, skipping.`);
+                continue;
               }
-            }
-            for (const team of teams) {
-              try {
-                await github.rest.pulls.requestReviewers({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: prNumber,
-                  team_reviewers: [team],
-                });
-                core.info(`Requested review from team pytorch/${team}`);
-              } catch (error) {
-                core.warning(`Failed to request review from team pytorch/${team}: ${error.message}`);
+              // Request reviews individually so a single stale username doesn't
+              // prevent all other valid reviewers from being assigned.
+              for (const reviewer of reviewers) {
+                try {
+                  await github.rest.pulls.requestReviewers({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: number,
+                    reviewers: [reviewer],
+                  });
+                  core.info(`PR #${number}: requested review from ${reviewer}`);
+                } catch (error) {
+                  core.warning(`PR #${number}: failed to request ${reviewer}: ${error.message}`);
+                }
+              }
+              for (const team of teams) {
+                try {
+                  await github.rest.pulls.requestReviewers({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: number,
+                    team_reviewers: [team],
+                  });
+                  core.info(`PR #${number}: requested review from team pytorch/${team}`);
+                } catch (error) {
+                  core.warning(`PR #${number}: failed to request team pytorch/${team}: ${error.message}`);
+                }
               }
             }

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -158,9 +158,8 @@ jobs:
     permissions:
       contents: none
       pull-requests: write
-      issues: write  # required to add the "triaged" label
     steps:
-      - name: Request reviews and mark triaged
+      - name: Request reviews
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           PR_NUMBER: ${{ needs.compute.outputs.number }}
@@ -171,7 +170,7 @@ jobs:
             const prNumber = parseInt(process.env.PR_NUMBER);
 
             if (reviewers.length === 0 && teams.length === 0) {
-              core.info('No reviewers to request; skipping triaged label.');
+              core.info('No reviewers to request.');
               return;
             }
 
@@ -202,17 +201,4 @@ jobs:
               } catch (error) {
                 core.warning(`Failed to request review from team pytorch/${team}: ${error.message}`);
               }
-            }
-
-            // Mark the PR as triaged so future runs of this workflow skip it.
-            try {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                labels: ['triaged'],
-              });
-              core.info('Added "triaged" label');
-            } catch (error) {
-              core.warning(`Failed to add "triaged" label: ${error.message}`);
             }

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -41,7 +41,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # Pin to base branch SHA to ensure we never check out PR head under pull_request_target
+          # Under pull_request_target, pin to the PR base SHA so we never check out PR head.
+          # Under workflow_dispatch, github.event.pull_request is empty and we fall back to
+          # github.sha (the SHA of the branch the dispatcher selected, defaults to main).
+          # Triggering workflow_dispatch already requires repo write access.
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -161,8 +161,9 @@ jobs:
       - name: Run matcher over batch
         id: match
         run: |
-          RESULTS="$(BATCH="$(cat batch.json)" python3 .github/scripts/match_reviewers.py \
-            --merge-rules .github/merge_rules.yaml)"
+          RESULTS="$(python3 .github/scripts/match_reviewers.py \
+            --merge-rules .github/merge_rules.yaml \
+            --batch-file batch.json)"
           echo "results=$RESULTS" >> "$GITHUB_OUTPUT"
 
   # Write-only requester: no checkout, only consumes the JSON output from compute.

--- a/.github/workflows/auto-request-reviewers.yml
+++ b/.github/workflows/auto-request-reviewers.yml
@@ -158,8 +158,9 @@ jobs:
     permissions:
       contents: none
       pull-requests: write
+      issues: write  # required to add the "triaged" label
     steps:
-      - name: Request reviews
+      - name: Request reviews and mark triaged
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           PR_NUMBER: ${{ needs.compute.outputs.number }}
@@ -170,7 +171,7 @@ jobs:
             const prNumber = parseInt(process.env.PR_NUMBER);
 
             if (reviewers.length === 0 && teams.length === 0) {
-              core.info('No reviewers to request.');
+              core.info('No reviewers to request; skipping triaged label.');
               return;
             }
 
@@ -201,4 +202,17 @@ jobs:
               } catch (error) {
                 core.warning(`Failed to request review from team pytorch/${team}: ${error.message}`);
               }
+            }
+
+            // Mark the PR as triaged so future runs of this workflow skip it.
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: ['triaged'],
+              });
+              core.info('Added "triaged" label');
+            } catch (error) {
+              core.warning(`Failed to add "triaged" label: ${error.message}`);
             }

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,11 @@
 /docs/source/conf.py @albanD
 /aten/src/ATen/native/tags.yaml @ezyang
 /.github/merge_rules.yaml @albanD @malfet
+# auto-request-reviewers operates under pull_request_target with write
+# permissions; the compute/request job split is what keeps it safe.
+# Changes here need security-aware review.
+/.github/workflows/auto-request-reviewers.yml @albanD @pytorch/pytorch-dev-infra
+/.github/scripts/match_reviewers.py @albanD @pytorch/pytorch-dev-infra
 
 # Architecture Optimization (quantization, sparsity, etc.)
 /aten/src/ATen/native/ao_sparse @salilsdesai @kimishpatel @digantdesai @jianyuh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180605

Adds a workflow that automatically requests reviewers for open source PRs
based on file path patterns in `.github/merge_rules.yaml`. When a PR's
changed files match a rule's patterns, the corresponding `approved_by`
users/teams are requested as reviewers, automating PR triage oncall work.

The rule-matching logic in `.github/scripts/match_reviewers.py` reuses
`patterns_to_regex` from `gitutils.py` (the same function trymerge uses)
for identical matching semantics. Wildcard-only rules (e.g. superuser,
Core Maintainers) are detected by inspecting patterns rather than
hardcoded names. The workflow filters to eligible PRs (`open source`
label, not draft/triaged, no prior review activity, base=main, created
on/after 2019-06-06) and supports manual `workflow_dispatch` with a PR
number or URL for testing. Triggers on `opened` and `ready_for_review`
only — re-running on every push would re-request reviewers who already
declined, and the `triaged` label exists as a manual escape hatch.

Security hardening for this `pull_request_target` workflow:
- Split into a read-only `compute` job (resolves PR, runs the matcher
  over attacker-controlled filenames) and a write-only `request` job
  (consumes the matcher's JSON output and calls `requestReviewers`).
  The privileged `pull-requests: write` token never coexists with code
  that processes PR-controlled input.
- All attacker-controlled values are passed via env vars — never
  interpolated into JS with `${{ }}`. The Python matcher reads
  `CHANGED_FILES`/`PR_AUTHOR` from env and writes directly to
  `$GITHUB_OUTPUT`, eliminating the shell-as-JSON-transport layer.
- `actions/checkout` and `actions/github-script` pinned to full SHAs.
- `persist-credentials: false` on checkout.
- Checkout pinned to the base branch SHA so PR head code is never run.

This complements (not replaces) `auto_request_review.yml`, which does
author-based routing.

Test Plan:
- Run unit tests:
  `cd .github/scripts && python3 -m unittest test_match_reviewers -v`

The remaining items can only be exercised after this PR lands on `main`,
because `workflow_dispatch` requires the workflow file to exist on the
default branch (GitHub returns HTTP 404 otherwise). Once merged:

- Run manually via:
  `gh workflow run auto-request-reviewers.yml -f pr=12345`
  or:
  `gh workflow run auto-request-reviewers.yml -f pr=https://github.com/pytorch/pytorch/pull/12345`
  against an eligible open source PR and verify reviewers are requested.
- Test with a PR that has the "triaged" label or is a draft and verify
  the workflow skips with the appropriate log message.
- Test with a PR touching files in a known merge rule (e.g., torch/onnx/)
  and verify the correct reviewers from that rule are requested.

Authored with Claude.