### PR TITLE
[CI] Align vLLM wheel build CUDA versions with PyTorch nightly

### DIFF
--- a/.github/workflows/build-vllm-wheel.yml
+++ b/.github/workflows/build-vllm-wheel.yml
@@ -28,33 +28,24 @@ jobs:
       matrix:
         python-version: [ '3.12' ]
         platform: [ 'manylinux_2_28_x86_64', 'manylinux_2_28_aarch64' ]
-        device: [ 'cu128', 'cu129', 'cu130' ]
+        device: [ 'cu130', 'cu132' ]
         include:
-          - platform: manylinux_2_28_x86_64
-            device: cu128
-            manylinux-image: 'pytorch/manylinux2_28-builder:cuda12.8'
-            runner: linux.12xlarge.memory
-          - platform: manylinux_2_28_x86_64
-            device: cu129
-            manylinux-image: 'pytorch/manylinux2_28-builder:cuda12.9'
-            runner: linux.12xlarge.memory
           - platform: manylinux_2_28_x86_64
             device: cu130
             manylinux-image: 'pytorch/manylinux2_28-builder:cuda13.0'
             runner: linux.12xlarge.memory
-          - platform: manylinux_2_28_aarch64
-            device: cu128
-            manylinux-image: 'pytorch/manylinuxaarch64-builder:cuda12.8'
-            runner: linux.arm64.r7g.12xlarge.memory
-          - platform: manylinux_2_28_aarch64
-            device: cu129
-            manylinux-image: 'pytorch/manylinuxaarch64-builder:cuda12.9'
-            runner: linux.arm64.r7g.12xlarge.memory
-        exclude:
-          # TODO (huydhn): Add cu130 aarch64 once PyTorch is on 2.9+ and
-          # xformers is update to support 13.0
+          - platform: manylinux_2_28_x86_64
+            device: cu132
+            manylinux-image: 'pytorch/manylinux2_28-builder:cuda13.2'
+            runner: linux.12xlarge.memory
           - platform: manylinux_2_28_aarch64
             device: cu130
+            manylinux-image: 'pytorch/manylinuxaarch64-builder:cuda13.0'
+            runner: linux.arm64.r7g.12xlarge.memory
+          - platform: manylinux_2_28_aarch64
+            device: cu132
+            manylinux-image: 'pytorch/manylinuxaarch64-builder:cuda13.2'
+            runner: linux.arm64.r7g.12xlarge.memory
     name: "Build ${{ matrix.device }} vLLM wheel on ${{ matrix.platform }}"
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 480
@@ -177,12 +168,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ 'manylinux_2_28_x86_64', 'manylinux_2_28_aarch64' ]
-        device: [ 'cu128', 'cu129', 'cu130' ]
-        exclude:
-          # TODO (huydhn): Add cu130 aarch64 once PyTorch is on 2.9+ and
-          # xformers is update to support 13.0
-          - platform: manylinux_2_28_aarch64
-            device: cu130
+        device: [ 'cu130', 'cu132' ]
     env:
       PLATFORM: ${{ matrix.platform }}
       BUILD_DEVICE: ${{ matrix.device }}


### PR DESCRIPTION
Drop cu128/cu129 and add cu132 so the vLLM wheel build matrix matches the CUDA versions PyTorch nightly publishes (cu130, cu132). cu126 is intentionally omitted since vLLM does not release a cu126 wheel upstream. Also enables aarch64 cu130/cu132, removing the prior TODO.

### Testing

https://github.com/pytorch/pytorch/actions/runs/24533482175