### PR TITLE
[Inductor] Add batch-invariant accuracy mode for benchmark perf tests

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -936,6 +936,11 @@ test_perf_for_dashboard() {
             "${target_flag[@]}" --"$mode" --"$dtype" --backend "$backend" --disable-cudagraphs --deterministic "$@" \
             --output "$TEST_REPORTS_DIR/${backend}_deterministic_perf_${suite}_${dtype}_${mode}_${device}_${target}.csv"
       fi
+      if [[ "$DASHBOARD_TAG" == *batch_invariant_accuracy-true* ]] && [[ "$target" == "accuracy" ]]; then
+        $TASKSET python "benchmarks/dynamo/$suite.py" \
+            "${target_flag[@]}" --"$mode" --"$dtype" --backend "$backend" --disable-cudagraphs --batch-invariant "$@" \
+            --output "$TEST_REPORTS_DIR/${backend}_batch_invariant_accuracy_${suite}_${dtype}_${mode}_${device}_${target}.csv"
+      fi
     done
   done
 }

--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -142,7 +142,7 @@ jobs:
     if: github.event.schedule == '15 0 * * 1-6'
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
-      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-deterministic_perf-true-batch_invariant_accuracy-true
+      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-deterministic_perf-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       timeout-minutes: 720
@@ -161,7 +161,7 @@ jobs:
     if: github.event.schedule == '0 7 * * 0'
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
-      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true-deterministic_perf-true-batch_invariant_accuracy-true
+      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true-deterministic_perf-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       timeout-minutes: 1440

--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -56,6 +56,11 @@ on:
         required: false
         type: boolean
         default: false
+      batch_invariant_accuracy:
+        description: Run accuracy benchmarks with batch-invariant mode enabled?
+        required: false
+        type: boolean
+        default: false
       benchmark_configs:
         description: The list of configs used the benchmark
         required: false
@@ -137,7 +142,7 @@ jobs:
     if: github.event.schedule == '15 0 * * 1-6'
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
-      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-deterministic_perf-true
+      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-deterministic_perf-true-batch_invariant_accuracy-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       timeout-minutes: 720
@@ -156,7 +161,7 @@ jobs:
     if: github.event.schedule == '0 7 * * 0'
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
-      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true-deterministic_perf-true
+      dashboard-tag: training-true-inference-true-default-true-dynamic-true-cudagraphs-true-cppwrapper-true-aotinductor-true-freezing_cudagraphs-true-maxautotune-true-freeze_autotune_cudagraphs-true-deterministic_perf-true-batch_invariant_accuracy-true
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       timeout-minutes: 1440
@@ -177,7 +182,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
-      dashboard-tag: training-${{ inputs.training || 'true' }}-inference-${{ inputs.inference || 'true' }}-default-${{ inputs.default || 'true' }}-dynamic-${{ inputs.dynamic || 'true' }}-cudagraphs-${{ inputs.cudagraphs || 'true' }}-cppwrapper-${{ inputs.cppwrapper || 'false' }}-aotinductor-${{ inputs.aotinductor || 'false' }}-maxautotune-${{ inputs.maxautotune || 'false' }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs || 'false' }}-deterministic_perf-${{ inputs.deterministic_perf || 'false' }}
+      dashboard-tag: training-${{ inputs.training || 'true' }}-inference-${{ inputs.inference || 'true' }}-default-${{ inputs.default || 'true' }}-dynamic-${{ inputs.dynamic || 'true' }}-cudagraphs-${{ inputs.cudagraphs || 'true' }}-cppwrapper-${{ inputs.cppwrapper || 'false' }}-aotinductor-${{ inputs.aotinductor || 'false' }}-maxautotune-${{ inputs.maxautotune || 'false' }}-freezing_cudagraphs-${{ inputs.freezing_cudagraphs || 'false' }}-deterministic_perf-${{ inputs.deterministic_perf || 'false' }}-batch_invariant_accuracy-${{ inputs.batch_invariant_accuracy || 'false' }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
       timeout-minutes: 720

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2525,20 +2525,16 @@ class BenchmarkRunner:
         start_stats = get_dynamo_stats()
 
         def record_status(status, dynamo_start_stats):
-            # Flaky models can't be bitwise-compared. Mirror check_accuracy's
-            # relabel so they don't pollute the dashboard with false failures.
-            if current_name in self.non_deterministic_models and (
-                status == "pass" or status.startswith("fail_batch_invariance")
-            ):
-                status = "pass"
-
             self._write_accuracy_row(status, dynamo_start_stats, tag)
             return status
 
         if name in self.skip_accuracy_checks_large_models_dashboard:
             return record_status("pass_due_to_skip", dynamo_start_stats=start_stats)
 
-        if name in self.skip_accuracy_check_as_eager_non_deterministic:
+        if (
+            name in self.skip_accuracy_check_as_eager_non_deterministic
+            or name in self.non_deterministic_models
+        ):
             return record_status("pass_due_to_skip", dynamo_start_stats=start_stats)
 
         full_batch = current_batch_size
@@ -2628,13 +2624,8 @@ class BenchmarkRunner:
                 out_for_cmp = tree_map_only(torch.Tensor, keep_batch_first, out)
 
                 try:
-                    is_same = same(
-                        ref_for_cmp,
-                        out_for_cmp,
-                        fp64_ref=None,
-                        cos_similarity=False,
-                        tol=0,
-                        equal_nan=self.equal_nan,
+                    is_same = bitwise_same(
+                        ref_for_cmp, out_for_cmp, equal_nan=self.equal_nan
                     )
                 except Exception:
                     is_same = False
@@ -3881,7 +3872,10 @@ def parse_args(args=None):
     run_mode_group.add_argument(
         "--inference", action="store_true", help="Performs inference"
     )
-    return parser.parse_args(args)
+    parsed = parser.parse_args(args)
+    if parsed.batch_invariant and not parsed.accuracy:
+        parser.error("--batch-invariant requires --accuracy")
+    return parsed
 
 
 def process_caching_precompile():
@@ -4202,6 +4196,8 @@ def setup_determinism(args):
 def setup_batch_invariant(args):
     if not torch.cuda.is_available():
         return
+    setup_determinism(args)
+    inductor_config.triton.cudagraphs = False
     torch.backends.cuda.preferred_blas_library("cublaslt")
     torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (False, False)
     torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (False, False)
@@ -4268,9 +4264,6 @@ def run(runner, args, original_dir=None):
     if args.deterministic and not args.accuracy:
         setup_determinism(args)
 
-    if args.batch_invariant and not args.accuracy:
-        raise AssertionError("--batch-invariant requires --accuracy")
-
     if args.accuracy:
         # Use small batch size. We use >1 batch size to ensure we test
         # batch_norm type of operators that work on batch dims.
@@ -4282,10 +4275,6 @@ def run(runner, args, original_dir=None):
                 elif runner.suite_name == "torchbench":
                     args.batch_size = 8
                 else:
-                    if runner.suite_name != "timm_models":
-                        raise AssertionError(
-                            f"expected runner.suite_name to be 'timm_models', got {runner.suite_name}"
-                        )
                     args.batch_size = 16
             elif runner.suite_name == "huggingface":
                 args.batch_size = 1

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2166,6 +2166,38 @@ class BenchmarkRunner:
             )
         return model
 
+    def _write_accuracy_row(self, status, dynamo_start_stats, tag):
+        """
+        Shared CSV + signpost writer for accuracy checks.
+        """
+        headers = ["dev", "name", "batch_size", "accuracy"]
+        fields = [current_device, current_name, current_batch_size, status]
+
+        if tag is not None:
+            headers.insert(3, "tag")
+            fields.insert(3, tag)
+
+        o_headers = list(headers)
+        o_fields = list(fields)
+
+        dynamo_stats = get_dynamo_stats()
+        dynamo_stats.subtract(dynamo_start_stats)
+        for k, v in dynamo_stats.items():
+            headers.append(k)
+            fields.append(v)
+
+        total_wall_time = output_signpost(
+            dict(zip(o_headers, o_fields)),
+            self.args,
+            self.suite_name,
+        )
+        headers.append("compilation_latency")
+        fields.append(total_wall_time)
+        write_outputs(output_filename, headers, fields)
+
+        if self.args.print_compilation_time:
+            print(f"Compilation time (from dynamo_timed): {total_wall_time}")
+
     def check_accuracy(
         self, name, model, example_inputs, optimize_ctx, experiment, tag
     ):
@@ -2188,34 +2220,7 @@ class BenchmarkRunner:
                 ):
                     accuracy_status = "pass"
 
-            headers = ["dev", "name", "batch_size", "accuracy"]
-            fields = [current_device, current_name, current_batch_size, accuracy_status]
-
-            if tag is not None:
-                headers.insert(3, "tag")
-                fields.insert(3, tag)
-
-            o_headers = list(headers)
-            o_fields = list(fields)
-
-            dynamo_stats = get_dynamo_stats()
-            dynamo_stats.subtract(dynamo_start_stats)
-            for k, v in dynamo_stats.items():
-                headers.append(k)
-                fields.append(v)
-
-            total_wall_time = output_signpost(
-                dict(zip(o_headers, o_fields)),
-                self.args,
-                self.suite_name,
-            )
-            headers.append("compilation_latency")
-            fields.append(total_wall_time)
-            write_outputs(output_filename, headers, fields)
-
-            if self.args.print_compilation_time:
-                print(f"Compilation time (from dynamo_timed): {total_wall_time}")
-
+            self._write_accuracy_row(accuracy_status, dynamo_start_stats, tag)
             return accuracy_status
 
         if name in self.skip_accuracy_checks_large_models_dashboard:
@@ -2527,29 +2532,7 @@ class BenchmarkRunner:
             ):
                 status = "pass"
 
-            headers = ["dev", "name", "batch_size", "accuracy"]
-            fields = [current_device, current_name, current_batch_size, status]
-            if tag is not None:
-                headers.insert(3, "tag")
-                fields.insert(3, tag)
-
-            o_headers = list(headers)
-            o_fields = list(fields)
-
-            dynamo_stats = get_dynamo_stats()
-            dynamo_stats.subtract(dynamo_start_stats)
-            for k, v in dynamo_stats.items():
-                headers.append(k)
-                fields.append(v)
-
-            total_wall_time = output_signpost(
-                dict(zip(o_headers, o_fields)),
-                self.args,
-                self.suite_name,
-            )
-            headers.append("compilation_latency")
-            fields.append(total_wall_time)
-            write_outputs(output_filename, headers, fields)
+            self._write_accuracy_row(status, dynamo_start_stats, tag)
             return status
 
         if name in self.skip_accuracy_checks_large_models_dashboard:

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2508,12 +2508,25 @@ class BenchmarkRunner:
         self, name, model, example_inputs, optimize_ctx, experiment, tag
     ):
         """
-        Batch invariance check: run the compiled model at N, N/2, ..., 1 and
+        Batch invariance check: run the compiled forward at N, N/2, ..., 1 and
         verify each output matches the reference sliced to that range bitwise.
+
+        Always exercises forward-only, even under --training: batch invariance
+        is a property of the forward pass; backward and optimizer step
+        aggregate over the batch and are not batch-invariant by construction.
+        Models with batch-dependent forward ops (e.g. BatchNorm in train mode)
+        will still fail here -- that's inherent, not a harness bug.
         """
         start_stats = get_dynamo_stats()
 
         def record_status(status, dynamo_start_stats):
+            # Flaky models can't be bitwise-compared. Mirror check_accuracy's
+            # relabel so they don't pollute the dashboard with false failures.
+            if current_name in self.non_deterministic_models and (
+                status == "pass" or status.startswith("fail_batch_invariance")
+            ):
+                status = "pass"
+
             headers = ["dev", "name", "batch_size", "accuracy"]
             fields = [current_device, current_name, current_batch_size, status]
             if tag is not None:
@@ -2542,35 +2555,54 @@ class BenchmarkRunner:
         if name in self.skip_accuracy_checks_large_models_dashboard:
             return record_status("pass_due_to_skip", dynamo_start_stats=start_stats)
 
+        if name in self.skip_accuracy_check_as_eager_non_deterministic:
+            return record_status("pass_due_to_skip", dynamo_start_stats=start_stats)
+
         full_batch = current_batch_size
         if full_batch is None or full_batch < 2:
             return record_status("pass_due_to_skip", dynamo_start_stats=start_stats)
 
+        # If no input tensor has batch as its first dim, the slicer below is a
+        # no-op and the comparison would trivially pass without actually
+        # exercising batch invariance. Skip rather than report a misleading pass.
+        if not any(
+            isinstance(x, torch.Tensor) and x.dim() > 0 and x.shape[0] == full_batch
+            for x in pytree.tree_leaves(example_inputs)
+        ):
+            return record_status("pass_due_to_skip", dynamo_start_stats=start_stats)
+
         def make_slicer(target):
             def slicer(x):
-                if (
-                    isinstance(x, torch.Tensor)
-                    and x.dim() > 0
-                    and x.shape[0] == full_batch
-                ):
+                if x.dim() > 0 and x.shape[0] == full_batch:
                     return x[:target].contiguous()
                 return x
 
             return slicer
 
+        def run_fresh(inputs):
+            # Rebuild model for every run so parameter-mutating side effects
+            # (BN running stats, caches, etc.) from a prior run don't bleed
+            # into the next comparison. Force eval mode regardless of
+            # --training: dropout and train-mode BN are batch-size-dependent
+            # by construction. Forward-only: backward/optimizer aggregate
+            # over the batch and are not batch-invariant by construction.
+            reset_rng_state()
+            torch._dynamo.reset()
+            torch._dynamo.utils.counters.clear()
+            model_copy = self.deepcopy_and_maybe_parallelize(model)
+            model_copy.eval()
+            try:
+                optimized_iter_fn = optimize_ctx(self.forward_pass)
+                return self.run_n_iterations(model_copy, inputs, optimized_iter_fn)
+            finally:
+                del model_copy
+                empty_gpu_cache(current_device)
+
         with self.pick_grad(name, self.args.training):
             model, example_inputs = self.maybe_cast(model, example_inputs)
 
             try:
-                reset_rng_state()
-                torch._dynamo.reset()
-                torch._dynamo.utils.counters.clear()
-                model_copy = self.deepcopy_and_maybe_parallelize(model)
-                self.init_optimizer(name, current_device, model_copy.parameters())
-                optimized_model_iter_fn = optimize_ctx(self.model_iter_fn)
-                reference = self.run_n_iterations(
-                    model_copy, clone_inputs(example_inputs), optimized_model_iter_fn
-                )
+                reference = run_fresh(clone_inputs(example_inputs))
             except Exception as e:
                 log.exception("")
                 status = (
@@ -2581,52 +2613,60 @@ class BenchmarkRunner:
                 return record_status(status, dynamo_start_stats=start_stats)
 
             size = full_batch // 2
-            try:
-                while size >= 1:
-                    slicer = make_slicer(size)
-                    sliced_inputs = tree_map_only(
-                        torch.Tensor, slicer, clone_inputs(example_inputs)
-                    )
-                    reset_rng_state()
-                    out = self.run_n_iterations(
-                        model_copy, sliced_inputs, optimized_model_iter_fn
-                    )
-                    reference_sliced = tree_map_only(torch.Tensor, slicer, reference)
-
-                    try:
-                        is_same = same(
-                            reference_sliced,
-                            out,
-                            fp64_ref=None,
-                            cos_similarity=False,
-                            tol=0,
-                            equal_nan=self.equal_nan,
-                        )
-                    except Exception:
-                        is_same = False
-
-                    if not is_same:
-                        if self.args.skip_accuracy_check:
-                            return record_status(
-                                "pass_due_to_skip", dynamo_start_stats=start_stats
-                            )
-                        return record_status(
-                            f"fail_batch_invariance_at_{size}",
-                            dynamo_start_stats=start_stats,
-                        )
-
-                    size //= 2
-            except Exception as e:
-                log.exception("")
-                status = (
-                    "OOM"
-                    if isinstance(e, torch.cuda.OutOfMemoryError)
-                    else f"fail_to_run_at_batch_{size}"
+            while size >= 1:
+                slicer = make_slicer(size)
+                sliced_inputs = tree_map_only(
+                    torch.Tensor, slicer, clone_inputs(example_inputs)
                 )
-                return record_status(status, dynamo_start_stats=start_stats)
-            finally:
-                del model_copy
-                empty_gpu_cache(current_device)
+
+                try:
+                    out = run_fresh(sliced_inputs)
+                except Exception as e:
+                    log.exception("")
+                    status = (
+                        "OOM"
+                        if isinstance(e, torch.cuda.OutOfMemoryError)
+                        else f"fail_to_run_at_batch_{size}"
+                    )
+                    return record_status(status, dynamo_start_stats=start_stats)
+
+                reference_sliced = tree_map_only(torch.Tensor, slicer, reference)
+
+                # Only compare batch-first output tensors. Aggregated outputs
+                # (e.g. HuggingFace's MaskedLMOutput.loss) don't have a batch
+                # dim and legitimately differ between batch sizes; comparing
+                # them would produce misleading failures.
+                def keep_batch_first(x):
+                    return x if x.dim() > 0 and x.shape[0] == size else None
+
+                ref_for_cmp = tree_map_only(
+                    torch.Tensor, keep_batch_first, reference_sliced
+                )
+                out_for_cmp = tree_map_only(torch.Tensor, keep_batch_first, out)
+
+                try:
+                    is_same = same(
+                        ref_for_cmp,
+                        out_for_cmp,
+                        fp64_ref=None,
+                        cos_similarity=False,
+                        tol=0,
+                        equal_nan=self.equal_nan,
+                    )
+                except Exception:
+                    is_same = False
+
+                if not is_same:
+                    if self.args.skip_accuracy_check:
+                        return record_status(
+                            "pass_due_to_skip", dynamo_start_stats=start_stats
+                        )
+                    return record_status(
+                        f"fail_batch_invariance_at_{size}",
+                        dynamo_start_stats=start_stats,
+                    )
+
+                size //= 2
 
         return record_status("pass", dynamo_start_stats=start_stats)
 
@@ -3344,7 +3384,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--batch-invariant",
         action="store_true",
-        help="Check batch invariance: compare compiled model outputs at full vs half batch "
+        help="Check batch invariance: compare compiled forward outputs at full vs half batch "
         "size and verify they match bitwise. Only valid with --accuracy.",
     )
     parser.add_argument(
@@ -4177,7 +4217,6 @@ def setup_determinism(args):
 
 
 def setup_batch_invariant(args):
-    """Configure CUDA backend so matmul/reduction results do not depend on batch size."""
     if not torch.cuda.is_available():
         return
     torch.backends.cuda.preferred_blas_library("cublaslt")

--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2504,6 +2504,132 @@ class BenchmarkRunner:
 
         return record_status(accuracy_status, dynamo_start_stats=start_stats)
 
+    def check_batch_invariance(
+        self, name, model, example_inputs, optimize_ctx, experiment, tag
+    ):
+        """
+        Batch invariance check: run the compiled model at N, N/2, ..., 1 and
+        verify each output matches the reference sliced to that range bitwise.
+        """
+        start_stats = get_dynamo_stats()
+
+        def record_status(status, dynamo_start_stats):
+            headers = ["dev", "name", "batch_size", "accuracy"]
+            fields = [current_device, current_name, current_batch_size, status]
+            if tag is not None:
+                headers.insert(3, "tag")
+                fields.insert(3, tag)
+
+            o_headers = list(headers)
+            o_fields = list(fields)
+
+            dynamo_stats = get_dynamo_stats()
+            dynamo_stats.subtract(dynamo_start_stats)
+            for k, v in dynamo_stats.items():
+                headers.append(k)
+                fields.append(v)
+
+            total_wall_time = output_signpost(
+                dict(zip(o_headers, o_fields)),
+                self.args,
+                self.suite_name,
+            )
+            headers.append("compilation_latency")
+            fields.append(total_wall_time)
+            write_outputs(output_filename, headers, fields)
+            return status
+
+        if name in self.skip_accuracy_checks_large_models_dashboard:
+            return record_status("pass_due_to_skip", dynamo_start_stats=start_stats)
+
+        full_batch = current_batch_size
+        if full_batch is None or full_batch < 2:
+            return record_status("pass_due_to_skip", dynamo_start_stats=start_stats)
+
+        def make_slicer(target):
+            def slicer(x):
+                if (
+                    isinstance(x, torch.Tensor)
+                    and x.dim() > 0
+                    and x.shape[0] == full_batch
+                ):
+                    return x[:target].contiguous()
+                return x
+
+            return slicer
+
+        with self.pick_grad(name, self.args.training):
+            model, example_inputs = self.maybe_cast(model, example_inputs)
+
+            try:
+                reset_rng_state()
+                torch._dynamo.reset()
+                torch._dynamo.utils.counters.clear()
+                model_copy = self.deepcopy_and_maybe_parallelize(model)
+                self.init_optimizer(name, current_device, model_copy.parameters())
+                optimized_model_iter_fn = optimize_ctx(self.model_iter_fn)
+                reference = self.run_n_iterations(
+                    model_copy, clone_inputs(example_inputs), optimized_model_iter_fn
+                )
+            except Exception as e:
+                log.exception("")
+                status = (
+                    "OOM"
+                    if isinstance(e, torch.cuda.OutOfMemoryError)
+                    else "fail_to_run"
+                )
+                return record_status(status, dynamo_start_stats=start_stats)
+
+            size = full_batch // 2
+            try:
+                while size >= 1:
+                    slicer = make_slicer(size)
+                    sliced_inputs = tree_map_only(
+                        torch.Tensor, slicer, clone_inputs(example_inputs)
+                    )
+                    reset_rng_state()
+                    out = self.run_n_iterations(
+                        model_copy, sliced_inputs, optimized_model_iter_fn
+                    )
+                    reference_sliced = tree_map_only(torch.Tensor, slicer, reference)
+
+                    try:
+                        is_same = same(
+                            reference_sliced,
+                            out,
+                            fp64_ref=None,
+                            cos_similarity=False,
+                            tol=0,
+                            equal_nan=self.equal_nan,
+                        )
+                    except Exception:
+                        is_same = False
+
+                    if not is_same:
+                        if self.args.skip_accuracy_check:
+                            return record_status(
+                                "pass_due_to_skip", dynamo_start_stats=start_stats
+                            )
+                        return record_status(
+                            f"fail_batch_invariance_at_{size}",
+                            dynamo_start_stats=start_stats,
+                        )
+
+                    size //= 2
+            except Exception as e:
+                log.exception("")
+                status = (
+                    "OOM"
+                    if isinstance(e, torch.cuda.OutOfMemoryError)
+                    else f"fail_to_run_at_batch_{size}"
+                )
+                return record_status(status, dynamo_start_stats=start_stats)
+            finally:
+                del model_copy
+                empty_gpu_cache(current_device)
+
+        return record_status("pass", dynamo_start_stats=start_stats)
+
     def check_tolerance(
         self, name, model, example_inputs, optimize_ctx, base_device="cpu"
     ):
@@ -3022,9 +3148,14 @@ class BenchmarkRunner:
         start_stats = get_dynamo_stats()
 
         if self.args.accuracy:
-            status = self.check_accuracy(
-                name, model, example_inputs, optimize_ctx, experiment, tag
-            )
+            if self.args.batch_invariant:
+                status = self.check_batch_invariance(
+                    name, model, example_inputs, optimize_ctx, experiment, tag
+                )
+            else:
+                status = self.check_accuracy(
+                    name, model, example_inputs, optimize_ctx, experiment, tag
+                )
             print(status)
             if status == "fail_accuracy" and self.args.minify:
                 self.minify_model(
@@ -3209,6 +3340,12 @@ def parse_args(args=None):
         "--deterministic",
         action="store_true",
         help="Enable deterministic mode (torch.use_deterministic_algorithms, cudnn.deterministic, etc.)",
+    )
+    parser.add_argument(
+        "--batch-invariant",
+        action="store_true",
+        help="Check batch invariance: compare compiled model outputs at full vs half batch "
+        "size and verify they match bitwise. Only valid with --accuracy.",
     )
     parser.add_argument(
         "--inductor-config",
@@ -4039,6 +4176,15 @@ def setup_determinism(args):
     patch_torch_manual_seed()
 
 
+def setup_batch_invariant(args):
+    """Configure CUDA backend so matmul/reduction results do not depend on batch size."""
+    if not torch.cuda.is_available():
+        return
+    torch.backends.cuda.preferred_blas_library("cublaslt")
+    torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (False, False)
+    torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (False, False)
+
+
 def run(runner, args, original_dir=None):
     # Pass the parsed args object to benchmark runner object
     torch._dynamo.reset()
@@ -4100,12 +4246,26 @@ def run(runner, args, original_dir=None):
     if args.deterministic and not args.accuracy:
         setup_determinism(args)
 
+    if args.batch_invariant and not args.accuracy:
+        raise AssertionError("--batch-invariant requires --accuracy")
+
     if args.accuracy:
         # Use small batch size. We use >1 batch size to ensure we test
         # batch_norm type of operators that work on batch dims.
         # TODO - Go through the failures for batch size = 2
         if args.batch_size is None:
-            if runner.suite_name == "huggingface":
+            if args.batch_invariant:
+                if runner.suite_name == "huggingface":
+                    args.batch_size = 8
+                elif runner.suite_name == "torchbench":
+                    args.batch_size = 8
+                else:
+                    if runner.suite_name != "timm_models":
+                        raise AssertionError(
+                            f"expected runner.suite_name to be 'timm_models', got {runner.suite_name}"
+                        )
+                    args.batch_size = 16
+            elif runner.suite_name == "huggingface":
                 args.batch_size = 1
             elif runner.suite_name == "torchbench":
                 args.batch_size = 4
@@ -4124,6 +4284,8 @@ def run(runner, args, original_dir=None):
         inductor_config.fallback_random = True
 
         setup_determinism(args)
+        if args.batch_invariant:
+            setup_batch_invariant(args)
 
         if args.only is not None and args.only in {
             "nvidia_deeprecommender",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180610

Adds a new `--batch-invariant` accuracy mode to the dynamo benchmark harness and wires it into the nightly H100 inductor dashboard.                                                                                                                                                         
                                                                                                                                                                                                                         
For a model with full batch size N, the mode runs the compiled forward at N, N/2, N/4, ..., 1, and for each smaller size checks that the output is bitwise equal to the full-batch reference sliced down to that size. A
                                                                                                                                                                                                                         
The plan is to land this first so we have continuous dashboard signal, then drive model pass-rates up by fixing the underlying inductor issues model-by-model. 
                                      
CI:                                                                                                                                                                                                                    
                                                                  
- `.ci/pytorch/test.sh` dispatches the accuracy run whenever `DASHBOARD_TAG` contains `batch_invariant_accuracy-true`.
                                                                  
Co-authored-by: Claude


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98