### PR TITLE
[mem viz] Add summary blocks to pools

### DIFF
--- a/test/profiler/test_memory_viz.js
+++ b/test/profiler/test_memory_viz.js
@@ -1312,7 +1312,7 @@ function test_per_pool_summarization() {
   const gs_max = Math.max(...global_summary.size);
   assertEqual(gs_max, 5500, 'global summarized max = 5500 (all default pool allocs)');
 
-  assertEqual(result.max_pool_elements, 20, 'max_pool_elements = 20 (total elements)');
+  assertEqual(result.elements_length, 20, 'elements_length = 20 (total elements)');
 }
 
 function test_per_pool_summarization_with_frees() {

--- a/test/profiler/test_memory_viz.js
+++ b/test/profiler/test_memory_viz.js
@@ -1249,6 +1249,212 @@ function test_envelope_default_pool_unaffected() {
 }
 
 // ============================================================
+// Per-pool summarization tests
+// ============================================================
+
+function test_per_pool_summarization() {
+  console.log('test_per_pool_summarization');
+  // 10 allocs in default pool (sizes 100..1000), 10 allocs in private pool
+  // (sizes 200..2000). Limit to 5 entries per pool.
+  // Expect: 5 drawn + 5 summarized per pool.
+  const poolId = [1, 50];
+  const traces = [];
+  // Default pool: 10 allocs at 0x1000..0x1900, sizes 100,200,...,1000
+  for (let i = 0; i < 10; i++) {
+    traces.push({ action: 'alloc', addr: 0x1000 + i * 0x100, size: (i + 1) * 100,
+                  frames: [], stream: 0 });
+  }
+  // Private pool: 10 allocs at 0x5000..0x5900, sizes 200,400,...,2000
+  for (let i = 0; i < 10; i++) {
+    traces.push({ action: 'alloc', addr: 0x5000 + i * 0x100, size: (i + 1) * 200,
+                  frames: [], stream: 0 });
+  }
+
+  const snapshot = makeSnapshot({
+    traces,
+    segments: [
+      { device: 0, address: 0x1000, total_size: 0x1000, segment_pool_id: [0, 0],
+        stream: 0, blocks: [] },
+      { device: 0, address: 0x5000, total_size: 0x1000, segment_pool_id: poolId,
+        stream: 0, blocks: [] },
+    ],
+  });
+
+  // Global top 5: the 5 largest across all pools.
+  // Private pool sizes: 200,400,...,2000. Default pool sizes: 100,200,...,1000.
+  // Top 5 globally = 2000,1800,1600,1400,1200 (all from private pool).
+  // Default pool: all 10 go to global summarized band.
+  // Private pool: top 5 drawn, bottom 5 (200+400+600+800+1000=3000) in per-pool summary.
+  const result = process_alloc_data(snapshot, 0, false, 5, true);
+
+  const non_pool = result.allocations_over_time.filter(
+    d => typeof d.elem === 'number' && d.opacity === undefined);
+  assertEqual(non_pool.length, 0, 'default pool: 0 drawn (all smaller than top 5)');
+
+  const stripes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'number' && d.opacity === 0.5);
+  assertEqual(stripes.length, 5, 'private pool: 5 drawn stripes');
+
+  const envelopes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'string' && d.elem.startsWith('pool:'));
+  assertEqual(envelopes.length, 1, '1 pool envelope');
+
+  const pool_summaries = result.allocations_over_time.filter(
+    d => d.elem === 'summarized' && d.opacity === 0.3);
+  assertEqual(pool_summaries.length, 1, '1 per-pool summarized stripe');
+  const ps_max = Math.max(...pool_summaries[0].size);
+  assertEqual(ps_max, 3000, 'per-pool summarized max = 3000');
+
+  // Global summarized band has ALL default pool allocs (100+200+...+1000=5500)
+  const global_summary = result.allocations_over_time.find(
+    d => d.elem === 'summarized' && d.opacity === undefined);
+  assert(global_summary !== undefined, 'global summarized band exists');
+  const gs_max = Math.max(...global_summary.size);
+  assertEqual(gs_max, 5500, 'global summarized max = 5500 (all default pool allocs)');
+
+  assertEqual(result.max_pool_elements, 20, 'max_pool_elements = 20 (total elements)');
+}
+
+function test_per_pool_summarization_with_frees() {
+  console.log('test_per_pool_summarization_with_frees');
+  // 6 allocs in private pool, limit to 3. Then free 2 drawn and 2 non-drawn.
+  // Verify summarized stripe shrinks on non-drawn frees.
+  const poolId = [1, 60];
+  const snapshot = makeSnapshot({
+    traces: [
+      // 6 allocs: sizes 100,200,300,400,500,600
+      // Top 3 drawn: 400,500,600. Summarized: 100,200,300.
+      { action: 'alloc', addr: 0x8100, size: 100, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x8200, size: 200, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x8300, size: 300, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x8400, size: 400, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x8500, size: 500, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0x8600, size: 600, frames: [], stream: 0 },
+      // Free a drawn element (600)
+      { action: 'free_completed', addr: 0x8600, size: 600, frames: [], stream: 0 },
+      // Free a non-drawn element (100) — summarized should shrink
+      { action: 'free_completed', addr: 0x8100, size: 100, frames: [], stream: 0 },
+    ],
+    segments: [{
+      device: 0, address: 0x8000, total_size: 0x1000, segment_pool_id: poolId,
+      stream: 0, blocks: [],
+    }],
+  });
+
+  const result = process_alloc_data(snapshot, 0, false, 3, true);
+
+  // After all events: drawn active = 400+500 = 900, summarized active = 200+300 = 500
+  const stripes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'number' && d.opacity === 0.5);
+  // 3 drawn stripes created (400, 500, 600), 600 was freed (closed out)
+  assertEqual(stripes.length, 3, '3 pool stripes created (one freed)');
+
+  const pool_summaries = result.allocations_over_time.filter(
+    d => d.elem === 'summarized' && d.opacity === 0.3);
+  assertEqual(pool_summaries.length, 1, '1 per-pool summarized stripe');
+
+  // Summarized stripe should show the shrink: peak was 600 (100+200+300),
+  // then 100 was freed → final = 500 (200+300)
+  const ps = pool_summaries[0];
+  const ps_max = Math.max(...ps.size);
+  assertEqual(ps_max, 600, 'per-pool summarized peak = 600 (before non-drawn free)');
+  const ps_final = ps.size.at(-1);
+  assertEqual(ps_final, 500, 'per-pool summarized final = 500 (after non-drawn free)');
+}
+
+function test_per_pool_summarization_initially_allocated() {
+  console.log('test_per_pool_summarization_initially_allocated');
+  // 4 free_completed events in a private pool (no matching allocs).
+  // Limit to 2. The 2 largest should be drawn stripes, the 2 smallest
+  // should be in the per-pool summarized stripe.
+  const poolId = [1, 70];
+  const snapshot = makeSnapshot({
+    traces: [
+      { action: 'free_completed', addr: 0xa100, size: 100, frames: [], stream: 0 },
+      { action: 'free_completed', addr: 0xa200, size: 200, frames: [], stream: 0 },
+      { action: 'free_completed', addr: 0xa300, size: 300, frames: [], stream: 0 },
+      { action: 'free_completed', addr: 0xa400, size: 400, frames: [], stream: 0 },
+    ],
+    segments: [{
+      device: 0, address: 0xa000, total_size: 0x1000, segment_pool_id: poolId,
+      stream: 0, blocks: [],
+    }],
+  });
+
+  const result = process_alloc_data(snapshot, 0, false, 2, true);
+
+  // Top 2 by size: 300, 400 → drawn stripes (pre-loaded then freed)
+  const stripes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'number' && d.opacity === 0.5);
+  assertEqual(stripes.length, 2, '2 drawn stripes (largest initially_allocated)');
+  const stripe_sizes = stripes.map(s => s.size).sort((a, b) => a - b);
+  assertEqual(stripe_sizes[0], 300, 'drawn stripe 300');
+  assertEqual(stripe_sizes[1], 400, 'drawn stripe 400');
+
+  // Summarized: 100 + 200 = 300 initially, then freed to 0
+  const pool_summaries = result.allocations_over_time.filter(
+    d => d.elem === 'summarized' && d.opacity === 0.3);
+  assertEqual(pool_summaries.length, 1, '1 per-pool summarized stripe');
+  const ps_max = Math.max(...pool_summaries[0].size);
+  assertEqual(ps_max, 300, 'per-pool summarized peak = 300 (100+200)');
+  assertEqual(pool_summaries[0].size.at(-1), 0,
+    'per-pool summarized final = 0 (all freed)');
+}
+
+function test_per_pool_summarization_interleaved() {
+  console.log('test_per_pool_summarization_interleaved');
+  // Drawn and non-drawn allocs interleaved: drawn stripes must not overlap
+  // with the summarized region. Alloc order: 1800 (drawn), 200 (non-drawn),
+  // 1600 (drawn), 100 (non-drawn).
+  const poolId = [1, 80];
+  const snapshot = makeSnapshot({
+    traces: [
+      { action: 'alloc', addr: 0xc000, size: 1800, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0xc800, size: 200, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0xd000, size: 1600, frames: [], stream: 0 },
+      { action: 'alloc', addr: 0xd800, size: 100, frames: [], stream: 0 },
+    ],
+    segments: [{
+      device: 0, address: 0xc000, total_size: 0x2000, segment_pool_id: poolId,
+      stream: 0, blocks: [],
+    }],
+  });
+
+  // max_entries=2: drawn = 1800, 1600. Non-drawn = 200, 100.
+  const result = process_alloc_data(snapshot, 0, false, 2, true);
+
+  const stripes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'number' && d.opacity === 0.5);
+  assertEqual(stripes.length, 2, '2 drawn stripes');
+
+  const pool_summaries = result.allocations_over_time.filter(
+    d => d.elem === 'summarized' && d.opacity === 0.3);
+  assertEqual(pool_summaries.length, 1, '1 per-pool summarized stripe');
+
+  // Summarized sits on top of drawn stripes (like global summarized band).
+  // Drawn stripes start at envelope base, summarized is above them.
+  const envelopes = result.allocations_over_time.filter(
+    d => typeof d.elem === 'string' && d.elem.startsWith('pool:'));
+  const env_base = envelopes[0].offsets.at(-1);
+  const sum_final = pool_summaries[0].size.at(-1);
+  assertEqual(sum_final, 300, 'summarized final = 300 (200+100)');
+
+  // Drawn stripes should start at envelope base
+  for (const stripe of stripes) {
+    const final_offset = stripe.offsets.at(-1);
+    assert(final_offset >= env_base,
+      `stripe offset ${final_offset} must be >= env_base(${env_base})`);
+  }
+
+  // Summarized stripe offset should be at envelope_base + drawn_active
+  const sum_offset = pool_summaries[0].offsets.at(-1);
+  const drawn_tops = stripes.map(s => s.offsets.at(-1) + s.size);
+  const max_drawn_top = Math.max(...drawn_tops);
+  assert(sum_offset >= max_drawn_top - 1,
+    `summarized offset ${sum_offset} should be at or above top of drawn stripes ${max_drawn_top}`);
+}
+
+// ============================================================
 // Run all tests
 // ============================================================
 
@@ -1295,6 +1501,10 @@ test_envelope_from_initial_reserved();
 test_envelope_segment_map_no_double_count();
 test_envelope_active_exceeds_reserved();
 test_envelope_default_pool_unaffected();
+test_per_pool_summarization();
+test_per_pool_summarization_with_frees();
+test_per_pool_summarization_initially_allocated();
+test_per_pool_summarization_interleaved();
 
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -1118,7 +1118,7 @@ function create_trace_view(
   dst.selectAll('svg').remove();
   dst.selectAll('div').remove();
 
-  max_entries = Math.min(max_entries, data.max_pool_elements);
+  max_entries = Math.min(max_entries, data.elements_length);
   if (include_private_inactive) {
     dst.append('div')
       .attr('style', 'padding: 4px 8px; background: #fff3cd; border: 1px solid #ffc107; font-size: 13px; margin-bottom: 4px;')
@@ -1129,13 +1129,13 @@ function create_trace_view(
   d.append('input')
     .attr('type', 'range')
     .attr('min', 0)
-    .attr('max', data.max_pool_elements)
+    .attr('max', data.elements_length)
     .attr('value', max_entries)
     .on('change', function () {
       create_trace_view(dst, snapshot, device, plot_segments, this.value, include_private_inactive);
     });
   d.append('label').text(
-    `Detail: ${max_entries} of ${data.max_pool_elements} entries`,
+    `Detail: ${max_entries} of ${data.elements_length} entries`,
   );
 
   d.append('span').text('  |  ');

--- a/torch/utils/viz/MemoryViz.js
+++ b/torch/utils/viz/MemoryViz.js
@@ -1118,7 +1118,7 @@ function create_trace_view(
   dst.selectAll('svg').remove();
   dst.selectAll('div').remove();
 
-  max_entries = Math.min(max_entries, data.elements_length);
+  max_entries = Math.min(max_entries, data.max_pool_elements);
   if (include_private_inactive) {
     dst.append('div')
       .attr('style', 'padding: 4px 8px; background: #fff3cd; border: 1px solid #ffc107; font-size: 13px; margin-bottom: 4px;')
@@ -1129,13 +1129,13 @@ function create_trace_view(
   d.append('input')
     .attr('type', 'range')
     .attr('min', 0)
-    .attr('max', data.elements_length)
+    .attr('max', data.max_pool_elements)
     .attr('value', max_entries)
     .on('change', function () {
       create_trace_view(dst, snapshot, device, plot_segments, this.value, include_private_inactive);
     });
   d.append('label').text(
-    `Detail: ${max_entries} of ${data.elements_length} entries`,
+    `Detail: ${max_entries} of ${data.max_pool_elements} entries`,
   );
 
   d.append('span').text('  |  ');

--- a/torch/utils/viz/process_alloc_data.js
+++ b/torch/utils/viz/process_alloc_data.js
@@ -546,8 +546,10 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
     }
   }
 
-  // Only render the largest max_entries elements individually;
-  // everything else goes into the summarized band
+  // Only render the largest max_entries elements individually (across all
+  // pools). Pools with larger allocations naturally get more of the budget.
+  // Remaining pool elements go into per-pool summarized stripes; remaining
+  // non-pool elements go into the global summarized band.
   const sizes = elements
     .map((x, i) => [x.size, i])
     .sort(([x, _xi], [y, _yi]) => y - x);
@@ -599,7 +601,9 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
   function get_or_create_pool(pool_key) {
     if (!(pool_key in pools)) {
       pools[pool_key] = {
-        max: 0, active: 0, reserved: 0, envelope_data: null,
+        max: 0, active: 0, reserved: 0,
+        drawn_active: 0, summarized_active: 0,
+        envelope_data: null, summarized_data: null,
         block_stack: [],  // [{elem, size, inner_offset, stripe_data}]
       };
     }
@@ -620,6 +624,38 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
       s.offsets.push(s.offsets.at(-1));
       s.timesteps.push(timestep + 3);
       s.offsets.push(s.offsets.at(-1) + delta);
+    }
+    if (pool.summarized_data) {
+      const sd = pool.summarized_data;
+      sd.timesteps.push(timestep);
+      sd.offsets.push(sd.offsets.at(-1));
+      sd.size.push(sd.size.at(-1));
+      sd.timesteps.push(timestep + 3);
+      sd.offsets.push(sd.offsets.at(-1) + delta);
+      sd.size.push(sd.size.at(-1));
+    }
+  }
+
+  // Update or create the per-pool summarized stripe. Sits on top of drawn
+  // stripes (offset = envelope base + drawn_active), size = summarized_active.
+  function update_pool_summary(pool, ts) {
+    if (!pool.envelope_data) return;
+    const base = pool.envelope_data.offsets.at(-1) + pool.drawn_active;
+    if (pool.summarized_data === null) {
+      pool.summarized_data = {
+        elem: 'summarized',
+        timesteps: [ts],
+        offsets: [base],
+        size: [pool.summarized_active],
+        color: 0,
+        opacity: 0.3,
+      };
+      data.push(pool.summarized_data);
+    } else {
+      const sd = pool.summarized_data;
+      sd.timesteps.push(ts);
+      sd.offsets.push(base);
+      sd.size.push(pool.summarized_active);
     }
   }
 
@@ -691,7 +727,6 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
         data.push(env);
       }
 
-      const inner_offset = pool.active;
       pool.active += size;
 
       // Grow envelope directly without animation — these blocks pre-exist
@@ -711,17 +746,23 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
         }
       }
 
-      const stripe = {
-        elem,
-        timesteps: [0],
-        offsets: [pool.envelope_data.offsets.at(-1) + inner_offset],
-        size,
-        color: elem_color(elem),
-        opacity: 0.5,
-        ghost: elements[elem].ghost || false,
-      };
-      pool.block_stack.push({elem, size, inner_offset, stripe_data: stripe});
-      data.push(stripe);
+      if (elem in draw_elem) {
+        const inner_offset = pool.drawn_active;
+        pool.drawn_active += size;
+        const stripe = {
+          elem,
+          timesteps: [0],
+          offsets: [pool.envelope_data.offsets.at(-1) + inner_offset],
+          size,
+          color: elem_color(elem),
+          opacity: 0.5,
+          ghost: elements[elem].ghost || false,
+        };
+        pool.block_stack.push({elem, size, inner_offset, stripe_data: stripe});
+        data.push(stripe);
+      } else {
+        pool.summarized_active += size;
+      }
       continue;
     }
     if (elem in draw_elem) {
@@ -735,6 +776,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
   // Fix up pool stripe offsets — stripes are not in current_data so they
   // don't get shifted when other pools grow during initially_allocated
   // processing. Recompute from the envelope's final offset.
+  // Also create per-pool summarized data for initial non-drawn elements.
   for (const pk in pools) {
     const p = pools[pk];
     if (!p.envelope_data) continue;
@@ -744,6 +786,17 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
       for (let i = 0; i < s.offsets.length; i++) {
         s.offsets[i] = env_offset + block.inner_offset;
       }
+    }
+    if (p.summarized_active > 0) {
+      p.summarized_data = {
+        elem: 'summarized',
+        timesteps: [0],
+        offsets: [env_offset + p.drawn_active],
+        size: [p.summarized_active],
+        color: 0,
+        opacity: 0.3,
+      };
+      data.push(p.summarized_data);
     }
   }
 
@@ -850,7 +903,6 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
           data.push(env);
         }
 
-        const inner_offset = pool.active;
         pool.active += size;
 
         const envelope_target = Math.max(pool.active, pool.reserved);
@@ -858,16 +910,27 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
           grow_pool_envelope(pool, pool_key, envelope_target);
         }
 
-        const stripe = {
-          elem,
-          timesteps: [timestep],
-          offsets: [pool.envelope_data.offsets.at(-1) + inner_offset],
-          size,
-          color: elem_color(elem),
-          opacity: 0.5,
-        };
-        pool.block_stack.push({elem, size, inner_offset, stripe_data: stripe});
-        data.push(stripe);
+        if (elem in draw_elem) {
+          const inner_offset = pool.drawn_active;
+          pool.drawn_active += size;
+          const stripe = {
+            elem,
+            timesteps: [timestep],
+            offsets: [pool.envelope_data.offsets.at(-1) + inner_offset],
+            size,
+            color: elem_color(elem),
+            opacity: 0.5,
+          };
+          pool.block_stack.push({elem, size, inner_offset, stripe_data: stripe});
+          data.push(stripe);
+          // Shift summarized stripe up (it sits on top of drawn stripes)
+          if (pool.summarized_data) {
+            update_pool_summary(pool, timestep);
+          }
+        } else {
+          pool.summarized_active += size;
+          update_pool_summary(pool, timestep);
+        }
         advance(1);
         elements[elem].max_allocated_mem = total_mem + total_summarized_mem;
       } else {
@@ -876,6 +939,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
         const pool = pools[pool_key];
         const block_idx = pool.block_stack.findIndex(b => b.elem === elem);
         if (block_idx >= 0) {
+          // Drawn stripe freed
           advance(1);
           const block = pool.block_stack[block_idx];
           block.stripe_data.timesteps.push(timestep);
@@ -883,8 +947,11 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
 
           pool.block_stack.splice(block_idx, 1);
           pool.active -= size;
+          pool.drawn_active -= size;
 
-          if (block_idx < pool.block_stack.length) {
+          // Shift drawn stripes above and the summarized stripe down
+          const need_shift = block_idx < pool.block_stack.length || pool.summarized_data;
+          if (need_shift) {
             for (let j = block_idx; j < pool.block_stack.length; j++) {
               const b = pool.block_stack[j];
               b.inner_offset -= size;
@@ -894,10 +961,16 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
               s.timesteps.push(timestep + 3);
               s.offsets.push(pool.envelope_data.offsets.at(-1) + b.inner_offset);
             }
+            if (pool.summarized_data) {
+              update_pool_summary(pool, timestep);
+            }
             advance(3);
           }
         } else {
+          // Non-drawn element freed — summarized stripe shrinks on top
           pool.active -= size;
+          pool.summarized_active -= size;
+          update_pool_summary(pool, timestep);
           advance(1);
         }
         delete pool_active_elems[elem];
@@ -969,6 +1042,12 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
       s.timesteps.push(timestep);
       s.offsets.push(s.offsets.at(-1));
     }
+    if (pools[pk].summarized_data) {
+      const sd = pools[pk].summarized_data;
+      sd.timesteps.push(timestep);
+      sd.offsets.push(sd.offsets.at(-1));
+      sd.size.push(sd.size.at(-1));
+    }
   }
   data.push(summarized_mem);
 
@@ -978,6 +1057,7 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
     max_at_time,
     summarized_mem,
     elements_length: elements.length,
+    max_pool_elements: elements.length,
     context_for_id: id => {
       const elem = elements[id];
       let text = `Addr: ${formatAddr(elem)}`;

--- a/torch/utils/viz/process_alloc_data.js
+++ b/torch/utils/viz/process_alloc_data.js
@@ -1074,7 +1074,6 @@ function process_alloc_data(snapshot, device, plot_segments, max_entries, includ
     max_at_time,
     summarized_mem,
     elements_length: elements.length,
-    max_pool_elements: elements.length,
     context_for_id: id => {
       const elem = elements[id];
       let text = `Addr: ${formatAddr(elem)}`;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #180920
* __->__ #180613
* #180515


## PR #180613: [mem viz] Add summary blocks to pools

### Summary

The "Allocated Memory (incl. Private Pools)" tab was slow with large
snapshots because every pool allocation created an individual stripe polygon,
regardless of size. This PR adds per-pool summarization: only the largest
`max_entries` elements (globally, across all pools) get individual stripes.
Remaining pool elements are aggregated into a single per-pool summarized
stripe (rendered at 0.3 opacity on top of drawn stripes), matching the
existing global summarized band behavior for the default pool.

### Changes

**process_alloc_data.js:**
- Add `drawn_active`, `summarized_active`, `summarized_data` to pool state
- Gate stripe creation on `draw_elem` (both initially_allocated and action
  replay paths)
- `update_pool_summary()` creates/updates a per-pool summarized polygon
  sitting on top of drawn stripes
- When a non-drawn element is freed, the summarized stripe shrinks. When a
  drawn stripe is freed, the summarized stripe shifts down.
- `shift_pool_stripes` also shifts the summarized data when envelopes move
- Finalize per-pool summarized data at end of replay
- Return `max_pool_elements` (= `elements.length`) for the slider

**MemoryViz.js:**
- Slider range and label use `max_pool_elements`

**Tests (test_memory_viz.js):**
- `test_per_pool_summarization`: 10 allocs per pool, limit 5 globally. Top 5
  are private pool stripes, all default pool allocs go to global summary,
  bottom 5 private pool allocs go to per-pool summary.
- `test_per_pool_summarization_with_frees`: non-drawn frees shrink the
  per-pool summary (peak 600 → final 500)
- `test_per_pool_summarization_initially_allocated`: pre-loaded blocks respect
  draw_elem, with per-pool summary tracking non-drawn ones
- `test_per_pool_summarization_interleaved`: interleaved drawn/non-drawn allocs
  verify no overlap (summarized on top of drawn stripes)

Authored with Claude.

<img width="2924" height="956" alt="image" src="https://github.com/user-attachments/assets/62f68584-1981-4aeb-8189-741949250937" />

