### PR TITLE
[Pytorch][Kineto] Reland comm_id generation changes (#180615)

### DIFF
--- a/test/cpp/profiler/CMakeLists.txt
+++ b/test/cpp/profiler/CMakeLists.txt
@@ -22,4 +22,24 @@ if(USE_KINETO)
     set_target_properties(test_privateuse1_profiler PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${_rpath_portable_origin}/../lib")
     install(TARGETS test_privateuse1_profiler DESTINATION bin)
   endif()
+
+  if(USE_DISTRIBUTED)
+    add_executable(test_comms_id
+      ${TORCH_ROOT}/test/cpp/common/main.cpp
+      ${PROFILER_TEST_ROOT}/comms_id.cpp
+    )
+
+    target_compile_definitions(test_comms_id PRIVATE USE_GTEST USE_KINETO USE_DISTRIBUTED)
+
+    target_link_libraries(test_comms_id PRIVATE ${PROFILER_TEST_DEPENDENCIES})
+    target_include_directories(test_comms_id PRIVATE
+      ${ATen_CPU_INCLUDE}
+      ${KINETO_SOURCE_DIR}/include
+    )
+
+    if(INSTALL_TEST)
+      set_target_properties(test_comms_id PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${_rpath_portable_origin}/../lib")
+      install(TARGETS test_comms_id DESTINATION bin)
+    endif()
+  endif()
 endif()

--- a/test/cpp/profiler/comms_id.cpp
+++ b/test/cpp/profiler/comms_id.cpp
@@ -1,0 +1,155 @@
+#include <gtest/gtest.h>
+
+#include <c10/util/ThreadLocalDebugInfo.h>
+#include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
+#include <torch/csrc/profiler/util.h>
+
+using torch::ParamCommsDebugInfo;
+using namespace torch::profiler::impl;
+
+namespace {
+
+std::shared_ptr<ParamCommsDebugInfo> makeDebugInfo(
+    const std::string& pgName,
+    const std::string& pgDesc,
+    int rank,
+    std::string collName,
+    int worldSize,
+    int64_t seqNumber,
+    bool isP2P,
+    int globalRankStart = 0,
+    int globalRankStride = 1) {
+  auto info = std::make_shared<ParamCommsDebugInfo>(
+      std::make_tuple(pgName, pgDesc),
+      rank,
+      std::move(collName),
+      /*inNelems=*/1024,
+      /*outNelems=*/1024,
+      /*dType=*/at::kFloat,
+      /*inSplitSizes=*/std::vector<int64_t>{},
+      /*outSplitSizes=*/std::vector<int64_t>{},
+      globalRankStart,
+      globalRankStride,
+      worldSize);
+  info->setSequenceInfo(seqNumber, isP2P);
+  return info;
+}
+
+// Helper to get comms_id from saveNcclMeta for a given ParamCommsDebugInfo.
+std::string getCommsIdViaSaveNcclMeta(
+    const std::shared_ptr<ParamCommsDebugInfo>& debugInfo) {
+  c10::DebugInfoGuard guard(c10::DebugInfoKind::PARAM_COMMS_INFO, debugInfo);
+  at::RecordFunction fn(at::RecordScope::USER_SCOPE);
+  fn._setAsync();
+  auto meta = saveNcclMeta(fn);
+  if (meta.count(kCommsId) == 0) {
+    return "";
+  }
+  return meta.at(kCommsId);
+}
+
+} // namespace
+
+TEST(CommsIdTest, ParamCommsDebugInfoStoresSeqNumberAndIsP2P) {
+  auto info =
+      makeDebugInfo("pg_uid_123", "default_pg", 0, "allreduce", 8, 42, false);
+
+  EXPECT_EQ(info->getSequenceNumber(), 42);
+  EXPECT_FALSE(info->getIsP2P());
+  EXPECT_EQ(info->getProcessGroupName(), "pg_uid_123");
+  EXPECT_EQ(info->getCollectiveName(), "allreduce");
+  EXPECT_EQ(info->getWorldSize(), 8);
+}
+
+TEST(CommsIdTest, ParamCommsDebugInfoP2PFlag) {
+  auto info = makeDebugInfo("pg_uid_456", "custom_pg", 3, "send", 4, 7, true);
+
+  EXPECT_EQ(info->getSequenceNumber(), 7);
+  EXPECT_TRUE(info->getIsP2P());
+}
+
+TEST(CommsIdTest, ParamCommsDebugInfoDefaultSeqNumberAndIsP2P) {
+  auto info = std::make_shared<ParamCommsDebugInfo>(
+      std::make_tuple(std::string("pg_uid_789"), std::string("default_pg")),
+      /*rank=*/1,
+      /*collName=*/std::string("allgather"),
+      /*inNelems=*/256,
+      /*outNelems=*/512,
+      /*dType=*/at::kFloat,
+      /*inSplitSizes=*/std::vector<int64_t>{},
+      /*outSplitSizes=*/std::vector<int64_t>{},
+      /*globalRankStart=*/0,
+      /*globalRankStride=*/1,
+      /*worldSize=*/2);
+
+  EXPECT_EQ(info->getSequenceNumber(), -1);
+  EXPECT_FALSE(info->getIsP2P());
+}
+
+TEST(CommsIdTest, SaveNcclMetaEmitsCommsId) {
+  auto debugInfo =
+      makeDebugInfo("pg_uid_123", "default_pg", 0, "allreduce", 8, 42, false);
+
+  auto commsId = getCommsIdViaSaveNcclMeta(debugInfo);
+  EXPECT_FALSE(commsId.empty());
+
+  // Verify determinism: same input produces the same comms_id
+  auto commsId2 = getCommsIdViaSaveNcclMeta(debugInfo);
+  EXPECT_EQ(commsId, commsId2);
+}
+
+TEST(CommsIdTest, SaveNcclMetaOmitsCommsIdWhenSeqNotSet) {
+  auto debugInfo = std::make_shared<ParamCommsDebugInfo>(
+      std::make_tuple(std::string("pg_uid_no_seq"), std::string("default_pg")),
+      /*rank=*/0,
+      /*collName=*/std::string("allreduce"),
+      /*inNelems=*/1024,
+      /*outNelems=*/1024,
+      /*dType=*/at::kFloat,
+      /*inSplitSizes=*/std::vector<int64_t>{},
+      /*outSplitSizes=*/std::vector<int64_t>{},
+      /*globalRankStart=*/0,
+      /*globalRankStride=*/1,
+      /*worldSize=*/8);
+
+  auto commsId = getCommsIdViaSaveNcclMeta(debugInfo);
+  EXPECT_TRUE(commsId.empty());
+}
+
+TEST(CommsIdTest, CommsIdDiffersForDifferentSeqNumbers) {
+  auto id1 = getCommsIdViaSaveNcclMeta(
+      makeDebugInfo("pg", "desc", 0, "allreduce", 8, 1, false));
+  auto id2 = getCommsIdViaSaveNcclMeta(
+      makeDebugInfo("pg", "desc", 0, "allreduce", 8, 2, false));
+  EXPECT_NE(id1, id2);
+}
+
+TEST(CommsIdTest, CommsIdDiffersForDifferentPGNames) {
+  auto id1 = getCommsIdViaSaveNcclMeta(
+      makeDebugInfo("pg_A", "desc", 0, "allreduce", 8, 42, false));
+  auto id2 = getCommsIdViaSaveNcclMeta(
+      makeDebugInfo("pg_B", "desc", 0, "allreduce", 8, 42, false));
+  EXPECT_NE(id1, id2);
+}
+
+TEST(CommsIdTest, CommsIdDiffersForP2PvsCollective) {
+  auto id_collective = getCommsIdViaSaveNcclMeta(
+      makeDebugInfo("pg", "desc", 0, "allreduce", 8, 42, false));
+  auto id_p2p = getCommsIdViaSaveNcclMeta(
+      makeDebugInfo("pg", "desc", 0, "send", 8, 42, true));
+  EXPECT_NE(id_collective, id_p2p);
+}
+
+TEST(CommsIdTest, CommsIdDiffersForDifferentTopology) {
+  auto id1 = getCommsIdViaSaveNcclMeta(
+      makeDebugInfo("pg", "desc", 0, "allreduce", 8, 42, false, 0, 1));
+  auto id2 = getCommsIdViaSaveNcclMeta(
+      makeDebugInfo("pg", "desc", 0, "allreduce", 4, 42, false, 0, 1));
+  EXPECT_NE(id1, id2);
+
+  auto id3 = getCommsIdViaSaveNcclMeta(
+      makeDebugInfo("pg", "desc", 0, "allreduce", 4, 42, false, 0, 2));
+  auto id4 = getCommsIdViaSaveNcclMeta(
+      makeDebugInfo("pg", "desc", 0, "allreduce", 4, 42, false, 1, 2));
+  EXPECT_NE(id3, id4);
+}

--- a/torch/csrc/profiler/util.cpp
+++ b/torch/csrc/profiler/util.cpp
@@ -10,6 +10,7 @@
 #include <libkineto.h>
 #endif
 #ifdef USE_DISTRIBUTED
+#include <c10/util/hash.h>
 #include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
 #endif // USE_DISTRIBUTED
 
@@ -513,6 +514,15 @@ std::unordered_map<std::string, std::string> saveNcclMeta(
     auto seqNum = debugInfo->getSequenceNumber();
     if (seqNum >= 0) {
       map.emplace(kSeqNum, std::to_string(seqNum));
+
+      size_t comms_id = c10::get_hash(
+          debugInfo->getProcessGroupName(),
+          seqNum,
+          debugInfo->getIsP2P(),
+          globalRankStart,
+          globalRankStride,
+          debugInfo->getWorldSize());
+      map.emplace(kCommsId, std::to_string(comms_id));
     }
   }
 

--- a/torch/csrc/profiler/util.h
+++ b/torch/csrc/profiler/util.h
@@ -205,6 +205,7 @@ constexpr auto kSeqNum = "Seq";
 constexpr auto kInTensorsStart = "Input Tensors start";
 constexpr auto kOutTensorsStart = "Output Tensors start";
 constexpr auto kIsAsynchronizedOp = "Is asynchronized op";
+constexpr auto kCommsId = "Comms Id";
 #endif // USE_DISTRIBUTED
 
 } // namespace torch::profiler::impl


### PR DESCRIPTION
Summary:

# Context
The previous change to add comm_id generation has been reverted, since that seems to causing some tests to timeout, although whether this change is root cause is unclear. This diff reland D96499426. Note that because of recent change in trunk, this diff is a much simplified version for D96499426.

Test Plan: 1. added unit tests

Differential Revision: D101246039
