### PR TITLE
Make strides consistent for _scaled_dot_product_efficient_attention_backward

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -27,6 +27,7 @@
 #include <ATen/ops/zeros.h>
 #include <ATen/ops/zeros_like.h>
 #include <ATen/ops/empty_strided.h>
+#include <ATen/ops/empty_permuted.h>
 #include <ATen/ops/_cudnn_attention_backward.h>
 #include <ATen/ops/_cudnn_attention_backward_native.h>
 #include <ATen/ops/_flash_attention_backward.h>
@@ -1109,30 +1110,27 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> _scaled_dot_product_e
   if (batch_size > MAX_BATCH_SIZE) {
     Tensor final_grad_q, final_grad_k, final_grad_v, final_grad_bias;
 
-    auto create_strided_output = [batch_size](const Tensor& tensor) -> Tensor {
+    auto create_permuted_output = [batch_size](const Tensor& tensor) -> Tensor {
       if (!tensor.defined()) {
         return Tensor{};
       }
-      int dim = tensor.dim();
-      std::vector<int64_t> sizes;
-      sizes.reserve(dim);
-      sizes.push_back(batch_size);
-      for (int i = 1; i < dim; i++) {
-        sizes.push_back(tensor.size(i));
-      }
-      return at::empty_strided(std::move(sizes), tensor.strides(), tensor.options());
+      TORCH_INTERNAL_ASSERT(tensor.dim() == 4);
+      return at::empty_permuted(
+          {batch_size, tensor.size(1), tensor.size(2), tensor.size(3)},
+          {0, 2, 1, 3},
+          tensor.options());
     };
 
     if (grad_input_mask[0]) {
-      final_grad_q = create_strided_output(query);
+      final_grad_q = create_permuted_output(query);
     }
 
     if (grad_input_mask[1]) {
-      final_grad_k = create_strided_output(key);
+      final_grad_k = create_permuted_output(key);
     }
 
     if (grad_input_mask[2]) {
-      final_grad_v = create_strided_output(value);
+      final_grad_v = create_permuted_output(value);
     }
     if (grad_input_mask[3] && attn_bias.defined()) {
       final_grad_bias = at::zeros_like(attn_bias);

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -31,6 +31,7 @@ from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.testing import FileCheck
 from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
+    PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
     SM80OrLater,
     SM90OrLater,
     TEST_MULTIGPU,
@@ -286,6 +287,56 @@ class CudaReproTests(TestCase):
             ).run(code[0])
 
             self.assertEqual(out, f(*inputs))
+
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+        "Does not support mem_eff_attention",
+    )
+    def test_mha_mem_eff_attention_backward_large_batch_compile(self):
+        torch.manual_seed(0)
+
+        eager = nn.MultiheadAttention(
+            embed_dim=8,
+            num_heads=1,
+            batch_first=True,
+            device=device_type,
+            dtype=torch.float16,
+        )
+        compiled = copy.deepcopy(eager)
+        compiled = torch.compile(compiled)
+
+        q = torch.rand(2**16, 1, 8, device=device_type, dtype=torch.float16)
+        kv = torch.rand(2**16, 2, 8, device=device_type, dtype=torch.float16)
+        mask = torch.randint(0, 2, (2**16, 2), device=device_type, dtype=torch.bool)
+
+        eager_q = q.detach().clone().requires_grad_(True)
+        eager_kv = kv.detach().clone().requires_grad_(True)
+        compiled_q = q.detach().clone().requires_grad_(True)
+        compiled_kv = kv.detach().clone().requires_grad_(True)
+
+        eager_out = eager(
+            query=eager_q,
+            key=eager_kv,
+            value=eager_kv,
+            key_padding_mask=mask,
+            attn_mask=None,
+            need_weights=False,
+        )[0]
+        eager_out.sum().backward()
+
+        compiled_out = compiled(
+            query=compiled_q,
+            key=compiled_kv,
+            value=compiled_kv,
+            key_padding_mask=mask,
+            attn_mask=None,
+            need_weights=False,
+        )[0]
+        compiled_out.sum().backward()
+
+        self.assertEqual(compiled_out, eager_out)
+        self.assertEqual(compiled_q.grad, eager_q.grad)
+        self.assertEqual(compiled_kv.grad, eager_kv.grad)
 
     def test_input_channels_last(self):
         m = torch.nn.Sequential(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180617

Fixes #180445

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo