### PR TITLE
[torch] Fix duplicated-word typos in comments and docstrings

### DIFF
--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1577,7 +1577,7 @@ class CUDAGraphNode:
         return True
 
     def add_child(self, function_id: FunctionID, node: CUDAGraphNode) -> None:
-        "Adds node as a a child of self"
+        "Adds node as a child of self"
         self.children[function_id].append(node)
 
     @staticmethod

--- a/torch/_inductor/tiling_utils.py
+++ b/torch/_inductor/tiling_utils.py
@@ -786,7 +786,7 @@ def analyze_memory_coalescing(
                 continue
 
             # TODO - if a var is in the middle, such as [n0, n1, n2]
-            # n1 can can be split beyond range
+            # n1 can be split beyond range
 
             MIN_TILING_BLOCK = 8
             if not all(

--- a/torch/distributed/_mesh_layout.py
+++ b/torch/distributed/_mesh_layout.py
@@ -126,7 +126,7 @@ class _MeshLayout(Layout):
         - The composition only generates indices that the left layout could originally produce,
           but the right layout determines which indices to be picked.
         - The stride of the composition layout will not be smaller than the stride of the right layout,
-          because when picking the indices the composition will at least follow the the right layout's stride
+          because when picking the indices the composition will at least follow the right layout's stride
           to move forward.
 
         Example:

--- a/torch/distributed/_tools/mem_tracker.py
+++ b/torch/distributed/_tools/mem_tracker.py
@@ -794,7 +794,7 @@ class MemTracker(TorchDispatchMode):
         This method should be called before the ``MemTracker`` is used. Any tensors that are not module parameters, buffers,
         gradients activations, or optimizer states will be categorized as ``Other``. If you want them categorized with a
         custom name, please file a GitHub issue. Any tensors created outside the MemTracker and not supplied to this
-        method will not be be tracked by ``MemTracker``.
+        method will not be tracked by ``MemTracker``.
 
         Args:
             *external (Union[nn.Module, optim.Optimizer, torch.Tensor]): The external modules, optimizers, and

--- a/torch/distributed/_tools/sac_estimator.py
+++ b/torch/distributed/_tools/sac_estimator.py
@@ -582,7 +582,7 @@ class SACEstimator(TorchDispatchMode):
         # recomputation time to total runtime incurred.
         delta = 1e-2
         tradeoff_curve = OrderedDict()
-        # 4. Initialize the trade-off curve with the stats of of already chosen recomputed_ops
+        # 4. Initialize the trade-off curve with the stats of already chosen recomputed_ops
         tradeoff_curve[(discarded_mem / sac_memory) + delta] = (
             recomp_runtime / sac_runtime
         )

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1547,7 +1547,7 @@ def _allgather_orig_param_states(
     # flat_param (also sharded).
     # Then we perform an allgather_into_tensor to get the full flat_param state.
     # The full flat_param state is the result of concatenation of multiple states
-    # the order of of flat_param._fqns.
+    # the order of flat_param._fqns.
     # The final step is to split the flat_param state into original param states
     # and return the result.
     flat_param = fsdp_param_info.handle.flat_param

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -1353,7 +1353,7 @@ def _register_root_pre_forward_hook(
     FSDP root.
 
     NOTE: For the current composable FSDP design, we have each application of
-    ``fully_shard()`` to a module to indicate that that module is the local
+    ``fully_shard()`` to a module to indicate that module is the local
     FSDP root. We may remove this assumption in the future, in which case we
     will need to register this root pre-forward hook on any candidate module
     that may be the local FSDP root.

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -7853,7 +7853,7 @@ class ShapeEnv:
         fallback_value: bool | None = None,
     ) -> sympy.Basic:
         """
-        Given a a SymNode, evaluates sym_node.expr, adding guards if necessary.
+        Given a SymNode, evaluates sym_node.expr, adding guards if necessary.
         """
 
         self._expr_sym_node_id = id(sym_node)

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -281,7 +281,7 @@ class Buffer(torch.Tensor, metaclass=_BufferMeta):
 class UninitializedBuffer(UninitializedTensorMixin, torch.Tensor):
     r"""A buffer that is not initialized.
 
-    Uninitialized Buffer is a a special case of :class:`torch.Tensor`
+    Uninitialized Buffer is a special case of :class:`torch.Tensor`
     where the shape of the data is still unknown.
 
     Unlike a :class:`torch.Tensor`, uninitialized parameters

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -134,7 +134,7 @@ def _lazy_init() -> None:
     if is_initialized() or hasattr(_tls, "is_initializing"):
         return
     with _initialization_lock:
-        # This test was was protected via GIL. Double-check whether XPU has
+        # This test was protected via GIL. Double-check whether XPU has
         # already been initialized.
         if is_initialized():
             return


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180619

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo