### PR TITLE
custom_op: handle omitted optional mutated defaults

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -3061,6 +3061,7 @@ class TestCustomOpAPI(TestCase):
                 continue
             self.assertGreater(after, prev)
 
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_mutated_optional_arg_default_none(self):
         @torch.library.custom_op(
             "_torch_testing::copy_optional_out", mutates_args={"out"}

--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -3061,6 +3061,26 @@ class TestCustomOpAPI(TestCase):
                 continue
             self.assertGreater(after, prev)
 
+    def test_mutated_optional_arg_default_none(self):
+        @torch.library.custom_op(
+            "_torch_testing::copy_optional_out", mutates_args={"out"}
+        )
+        def copy_optional_out(x: Tensor, out: Optional[Tensor] = None) -> Tensor:
+            if out is not None:
+                out.copy_(x)
+                return x.new_empty(0)
+            return x.clone()
+
+        x = torch.randn(3)
+        self.assertEqual(copy_optional_out(x), x)
+
+        out = torch.empty_like(x)
+        version = out._version
+        result = copy_optional_out(x, out=out)
+        self.assertEqual(result.numel(), 0)
+        self.assertEqual(out, x)
+        self.assertGreater(out._version, version)
+
     def test_mutated_no_warning(self):
         # Run in subprocess since the warning is emitted only once
         script = """\

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -681,11 +681,12 @@ class CustomOpDef:
 
             def adinplaceorview_impl(keyset, *args, **kwargs):
                 # Handle the mutated idx the user gave us explicitly
+                all_args, all_kwargs = utils.fill_defaults(schema, args, kwargs)
 
                 for idx in mutated_idxs:
-                    increment_version(args[idx])
+                    increment_version(all_args[idx])
                 for key in mutated_keys:
-                    increment_version(kwargs[key])
+                    increment_version(all_kwargs[key])
                 # Handle view + mutation that are in the schema
                 return original_kernel.call_boxed(keyset, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
Fix a crash when `torch.library.custom_op` marks an optional argument as mutated and the caller omits that argument so it falls back to its default.

## Root cause problem
`CustomOpDef`'s `ADInplaceOrView` wrapper computes mutated positional and keyword argument locations from the schema, then indexes directly into the runtime `args` and `kwargs`. The dispatcher strips default-valued arguments before this Python wrapper runs, so an omitted `out: Optional[Tensor] = None` is not present in `args`, which causes `IndexError: tuple index out of range` during version bump bookkeeping.

## Proposed fix
Call `utils.fill_defaults(schema, args, kwargs)` inside the `ADInplaceOrView` wrapper before incrementing versions for mutated arguments. This materializes omitted default values only for the bookkeeping step, while leaving the original `args` and `kwargs` untouched for the actual kernel dispatch.

Also add a regression test covering a custom op with `mutates_args={"out"}` and `out: Optional[Tensor] = None`, verifying that the omitted-argument call succeeds and that the explicit `out` path still bumps the version counter.

## Why this is the right long term fix
`fill_defaults` is already the helper PyTorch uses when Python-side custom op wrappers need schema-aligned inputs. Reusing it keeps the `ADInplaceOrView` bookkeeping consistent with dispatcher semantics for default arguments and fixes both positional and keyword-only mutated defaults without changing dispatch behavior.

## Testing
- Reproduced the crash against `torch-2.13.0.dev20260416+cpu` nightly: `IndexError: tuple index out of range`
- Ran `TestCustomOpAPI.test_mutated_optional_arg_default_none` from `test/test_custom_ops.py` against the patched `torch._library.custom_ops` on the same nightly CPU wheel

Fix #180618

Drafted via Codex, published after manual review by @bobrenjc93