### PR TITLE
[pyrefly] Enable stricter type checking for torch/fx

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -110,6 +110,7 @@ ignore-missing-imports = [
     "onnxruntime.*",
     "onnxscript.*",
     "redis.*",
+    "tabulate.*",
 ]
 # By default, mypy does not check untyped definitions.
 # However, mypy has a configuration called check_untyped_defs which is used
@@ -158,3 +159,13 @@ matches = "torch/_functorch/**"
 [sub-config.errors]
 implicit-import = false
 implicit-any = true
+
+[[sub-config]]
+matches = "torch/fx/**"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true

--- a/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
@@ -61,7 +61,7 @@ torch.fx.node.Node.update_arg(self, idx: int, arg: torch.fx.node.Argument) -> No
 torch.fx.node.Node.update_kwarg(self, key: str, arg: torch.fx.node.Argument) -> None
 torch.fx.node.map_aggregate(a: torch.fx.node.Argument, fn: Callable[[torch.fx.node.Argument], torch.fx.node.Argument]) -> torch.fx.node.Argument
 torch.fx.node.map_arg(a: torch.fx.node.Argument, fn: Callable[[torch.fx.node.Node], torch.fx.node.Argument]) -> torch.fx.node.Argument
-torch.fx.passes.reinplace.reinplace(gm, *sample_args)
+torch.fx.passes.reinplace.reinplace(gm: torch.fx.graph_module.GraphModule, *sample_args: Any) -> torch.fx.graph_module.GraphModule
 torch.fx.passes.runtime_assert.insert_deferred_runtime_asserts(gm: torch.fx.graph_module.GraphModule, shape_env: Any, name: str, export: bool = False) -> None
 torch.fx.passes.split_module.split_module(m: torch.fx.graph_module.GraphModule, root_m: torch.nn.modules.module.Module, split_callback: Callable[[torch.fx.node.Node], int], qualname_map: Optional[Dict[str, str]] = None, keep_original_order: Optional[bool] = False, keep_original_node_name: Optional[bool] = False, keep_original_input_name: bool = True, partition_affix: Optional[str] = None, tuple_return: bool = False) -> torch.fx.graph_module.GraphModule
 torch.fx.proxy.Attribute.__init__(self, root: torch.fx.proxy.Proxy, attr: str) -> None

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -2578,11 +2578,21 @@ class GraphModuleDeserializer(metaclass=Final):
         output_node = self.graph.output(outputs)
 
         if serialized_graph.is_single_tensor_return:
-            output_node.meta["val"] = output_node.args[0].meta["val"]
+            first_arg = output_node.args[0]
+            if not isinstance(first_arg, torch.fx.Node):
+                raise AssertionError(
+                    f"Expected Node for single tensor return, got {type(first_arg)}"
+                )
+            output_node.meta["val"] = first_arg.meta["val"]
         else:
+            first_arg = output_node.args[0]
+            if not isinstance(first_arg, (tuple, list)):
+                raise AssertionError(
+                    f"Expected tuple/list for multi tensor return, got {type(first_arg)}"
+                )
             output_node.meta["val"] = tuple(
                 arg.meta["val"] if isinstance(arg, torch.fx.Node) else arg
-                for arg in output_node.args[0]
+                for arg in first_arg
             )
 
         # recompute unbacked bindings

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -845,6 +845,14 @@ def node_inline_(call_mod_node: torch.fx.Node) -> torch.fx.GraphModule | None:
         for node in body:
             new_node = gm.graph.node_copy(node)
             if node.op == "get_attr":
+                if not isinstance(new_node.target, str):
+                    raise AssertionError(
+                        f"Expected str target for get_attr, got {type(new_node.target)}"
+                    )
+                if not isinstance(node.target, str):
+                    raise AssertionError(
+                        f"Expected str target for get_attr, got {type(node.target)}"
+                    )
                 new_target_name = new_node.target
                 if hasattr(gm, new_target_name):
                     # Loop through and find the "submod_{i}" that have no name collision

--- a/torch/_export/utils.py
+++ b/torch/_export/utils.py
@@ -848,6 +848,14 @@ def node_inline_(call_mod_node: torch.fx.Node) -> torch.fx.GraphModule | None:
         for node in body:
             new_node = gm.graph.node_copy(node)
             if node.op == "get_attr":
+                if not isinstance(new_node.target, str):
+                    raise AssertionError(
+                        f"Expected str target for get_attr, got {type(new_node.target)}"
+                    )
+                if not isinstance(node.target, str):
+                    raise AssertionError(
+                        f"Expected str target for get_attr, got {type(node.target)}"
+                    )
                 new_target_name = new_node.target
                 if hasattr(gm, new_target_name):
                     # Loop through and find the "submod_{i}" that have no name collision

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -2524,7 +2524,7 @@ def solve_min_cut(
                 joint_module.print_readable(
                     print_output=False, include_stride=True, include_device=True
                 )
-                if joint_module
+                if joint_module is not None
                 else str(joint_graph)
             )
             # Always log to structured trace for production debugging

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -3141,7 +3141,9 @@ def choose_saved_values_set(
         joint_graph, node_info, aggressive_options
     )
 
-    aggressive_recomputation_saved_values_mem_ratio = get_mem_ratio(aggressive_recomputation_saved_values)
+    aggressive_recomputation_saved_values_mem_ratio = get_mem_ratio(
+        aggressive_recomputation_saved_values
+    )
     if aggressive_recomputation_saved_values_mem_ratio < memory_budget:
         return aggressive_recomputation_saved_values
 

--- a/torch/_inductor/fx_passes/b2b_gemm.py
+++ b/torch/_inductor/fx_passes/b2b_gemm.py
@@ -674,7 +674,10 @@ def b2b_gemm_handler(match: Match, mat1: torch.fx.Node, mat2: torch.fx.Node) -> 
     # i.e. they neither have other users nor have other inputs
 
     # original graph and module
-    graph, module = inner_mm.graph, inner_mm.graph.owning_module
+    graph = inner_mm.graph
+    module = graph.owning_module
+    if module is None:
+        raise AssertionError("graph.owning_module must not be None")
 
     # construct the new (sub)graph
     subgraph_node_list: list[

--- a/torch/_inductor/fx_passes/control_dependencies.py
+++ b/torch/_inductor/fx_passes/control_dependencies.py
@@ -226,6 +226,8 @@ def _create_subgraph_for_node(
     """
     # Get the owning module
     owning_module = graph.owning_module
+    if owning_module is None:
+        raise AssertionError("graph.owning_module must not be None")
 
     # Create a new graph for the subgraph
     subgraph = fx.Graph(owning_module)

--- a/torch/_inductor/fx_passes/ddp_fusion.py
+++ b/torch/_inductor/fx_passes/ddp_fusion.py
@@ -575,7 +575,8 @@ def fuse_ddp_communication(
 ) -> None:
     for i, pa in enumerate(passes):
         with GraphTransformObserver(
-            graph.owning_module, f"fuse_ddp_communication_pass_{i}"
+            graph.owning_module,  # pyrefly: ignore[bad-argument-type]
+            f"fuse_ddp_communication_pass_{i}",
         ):
             if isinstance(pa, str):
                 func = globals()[pa]

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -1445,7 +1445,7 @@ def group_batch_fusion_passes(graph: torch.fx.Graph, pre_grad=True):
 
     for i, rule in enumerate(fusions):
         with GraphTransformObserver(
-            graph.owning_module,
+            graph.owning_module,  # pyrefly: ignore[bad-argument-type]
             f"group_batch_fusion_{i}",
         ):
             apply_group_batch_fusion(graph, rule)  # type: ignore[arg-type]

--- a/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
+++ b/torch/_inductor/fx_passes/overlap_preserving_bucketer.py
@@ -396,6 +396,8 @@ class OverlapPreservingBucketer:
             from torch._inductor.fx_passes.fusion_regions import expand_fusion_regions
 
             gm = self.graph.owning_module
+            if gm is None:
+                raise AssertionError("graph.owning_module must not be None")
             replaced = expand_fusion_regions(gm, self.region_of)
 
         # Step 3: Transfer deps from erased fusion modules to inlined nodes

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -267,7 +267,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         )
         GraphTransformObserver(gm, "bucket_reduce_scatters").apply_graph_pass(
             lambda graph: p(
-                graph.owning_module,
+                gm,
                 config.bucket_reduce_scatters_fx_bucket_size_determinator,
                 config.bucket_reduce_scatters_bucket_mode,  # type: ignore[arg-type]
             )
@@ -279,7 +279,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
 
         GraphTransformObserver(gm, "bucket_all_reduce").apply_graph_pass(
             lambda graph: bucket_all_reduce(
-                graph.owning_module,
+                gm,
                 config.bucket_all_reduces_fx_bucket_size_determinator,
                 config.bucket_all_reduces_fx,  # type: ignore[arg-type]
             )
@@ -299,7 +299,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         )
         GraphTransformObserver(gm, "bucket_all_gathers").apply_graph_pass(
             lambda graph: p(
-                graph.owning_module,
+                gm,
                 config.bucket_all_gathers_fx_bucket_size_determinator,
                 config.bucket_all_gathers_bucket_mode,  # type: ignore[arg-type]
             )
@@ -361,7 +361,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         ):
             GraphTransformObserver(gm, "overlap_scheduling").apply_graph_pass(
                 lambda graph: schedule_overlap_bucketing_from_inductor_configs(
-                    graph.owning_module,
+                    gm,
                 )
             )
 

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -267,7 +267,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         )
         GraphTransformObserver(gm, "bucket_reduce_scatters").apply_graph_pass(
             lambda graph: p(
-                graph.owning_module,
+                graph.owning_module,  # pyrefly: ignore[bad-argument-type]
                 config.bucket_reduce_scatters_fx_bucket_size_determinator,
                 config.bucket_reduce_scatters_bucket_mode,  # type: ignore[arg-type]
             )
@@ -279,7 +279,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
 
         GraphTransformObserver(gm, "bucket_all_reduce").apply_graph_pass(
             lambda graph: bucket_all_reduce(
-                graph.owning_module,
+                graph.owning_module,  # pyrefly: ignore[bad-argument-type]
                 config.bucket_all_reduces_fx_bucket_size_determinator,
                 config.bucket_all_reduces_fx,  # type: ignore[arg-type]
             )
@@ -299,7 +299,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         )
         GraphTransformObserver(gm, "bucket_all_gathers").apply_graph_pass(
             lambda graph: p(
-                graph.owning_module,
+                graph.owning_module,  # pyrefly: ignore[bad-argument-type]
                 config.bucket_all_gathers_fx_bucket_size_determinator,
                 config.bucket_all_gathers_bucket_mode,  # type: ignore[arg-type]
             )
@@ -361,7 +361,7 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         ):
             GraphTransformObserver(gm, "overlap_scheduling").apply_graph_pass(
                 lambda graph: schedule_overlap_bucketing_from_inductor_configs(
-                    graph.owning_module,
+                    graph.owning_module,  # pyrefly: ignore[bad-argument-type]
                 )
             )
 

--- a/torch/_inductor/pattern_matcher.py
+++ b/torch/_inductor/pattern_matcher.py
@@ -2086,7 +2086,7 @@ class PatternMatcherPass:
             graph = gm.graph
         elif isinstance(gm, torch.fx.Graph):
             graph = gm
-            gm = graph.owning_module
+            gm = graph.owning_module  # type: ignore[assignment]
         else:
             raise RuntimeError(
                 f"The input to PatternMatcherPass must be a GraphModule or a Graph, but got {type(gm)}"
@@ -2491,5 +2491,7 @@ def extract_target(node: torch.fx.Node) -> torch.fx.node.Target:
     """
     if node.op == "call_module":
         assert isinstance(node.target, str)
+        if node.graph.owning_module is None:
+            raise AssertionError("node.graph.owning_module must not be None")
         return _get_attr(node.graph.owning_module, node.target).__class__
     return node.target

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -746,7 +746,7 @@ class Tracer(TracerBase):
 
             # TODO: annotate return type. inspect.get_annotations(flatten_fn)
             # leaks the return annotation into the generated forward() code.
-            def flatten_fn(*args: Any):  # pyrefly: ignore[unannotated-parameter]
+            def flatten_fn(*args: Any) -> Any:  # pyrefly: ignore[unannotated-parameter]
                 tree_args = pytree.tree_unflatten(list(args), in_spec)
                 tree_out = root_fn(*tree_args)
                 out_args, out_spec = pytree.tree_flatten(tree_out)

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -746,7 +746,9 @@ class Tracer(TracerBase):
 
             # TODO: annotate return type. inspect.get_annotations(flatten_fn)
             # leaks the return annotation into the generated forward() code.
-            def flatten_fn(*args: Any):  # pyrefly: ignore[unannotated-parameter]
+            def flatten_fn(  # pyrefly: ignore[unannotated-parameter, unannotated-return]
+                *args: Any,
+            ):
                 tree_args = pytree.tree_unflatten(list(args), in_spec)
                 tree_out = root_fn(*tree_args)
                 out_args, out_spec = pytree.tree_flatten(tree_out)

--- a/torch/fx/_utils.py
+++ b/torch/fx/_utils.py
@@ -7,7 +7,7 @@ from torch._logging import LazyString
 
 def lazy_format_graph_code(
     name: str, gm: torch.fx.GraphModule, maybe_id: int | None = None, **kwargs: Any
-) -> LazyString:
+) -> LazyString:  # pyrefly: ignore[implicit-any]
     """
     Returns a LazyString that formats the graph code.
     """

--- a/torch/fx/experimental/meta_tracer.py
+++ b/torch/fx/experimental/meta_tracer.py
@@ -158,7 +158,7 @@ class MetaAttribute(MetaProxy):
         self.root = root
         self.attr = attr
         self.tracer = root.tracer
-        self._node = None
+        self._node: Node | None = None
 
     @property
     def node(self):  # type: ignore[override]

--- a/torch/fx/experimental/optimization.py
+++ b/torch/fx/experimental/optimization.py
@@ -253,10 +253,14 @@ def gen_mkl_autotuner(
         input_nodes = graph.start_nodes
         if fx_model is None:
             fx_model = graph.fx_graph.owning_module
+            if fx_model is None:
+                raise AssertionError("fx_graph.owning_module must not be None")
             old_modules = graph.fx_graph.old_modules  # type: ignore[attr-defined]
             ShapeProp(fx_model).propagate(example_inputs)
         sample_inputs = [torch.randn(node.shape) for node in input_nodes]  # type: ignore[attr-defined]
         output_args = cast(list[fx.Node], [node.args[0] for node in graph.end_nodes])
+        if fx_model is None:
+            raise AssertionError("fx_model must not be None")
         submodule = extract_subgraph(fx_model, graph.nodes, input_nodes, output_args)
 
         def benchmark(f: Callable[[], object]) -> float:

--- a/torch/fx/experimental/sym_node.py
+++ b/torch/fx/experimental/sym_node.py
@@ -116,7 +116,7 @@ class SymNode:
         self.pytype = pytype
         self._optimized_summation = optimized_summation
         self._expr_ver = -1
-        self._expr_cache = None
+        self._expr_cache: object | None = None
 
         # What's the difference between hint and constant?
         #
@@ -690,7 +690,9 @@ class DynamicInt(_DynamicScalar, int):
     def __rfloordiv__(self, other: int) -> DynamicInt:
         return DynamicInt(other // self.real)
 
-    def __pow__(self, other, modulo=None):
+    def __pow__(  # pyrefly: ignore[bad-override]
+        self, other: int, modulo: int | None = None
+    ) -> DynamicInt | float:
         if modulo is not None:
             result = pow(self.real, other, modulo)
         else:
@@ -701,7 +703,7 @@ class DynamicInt(_DynamicScalar, int):
             return DynamicInt(result)
         return result
 
-    def __rpow__(self, other, modulo=None):
+    def __rpow__(self, other: int, modulo: int | None = None) -> DynamicInt | float:
         if modulo is not None:
             result = pow(other, self.real, modulo)
         else:

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1917,7 +1917,7 @@ def guard_float(a: FloatLikeType) -> float:
 
 
 # Given a GraphModule, return all the FakeTensors for all the placeholders
-def fx_placeholder_vals(gm: torch.fx.GraphModule) -> list[object]:
+def fx_placeholder_vals(gm: torch.fx.GraphModule) -> list[Any]:
     return [n.meta["val"] for n in gm.graph.nodes if n.op == "placeholder"]
 
 
@@ -1934,7 +1934,9 @@ def eval_guards(
     if gm.shape_env is None:
         raise AssertionError("gm.shape_env must not be None")
     return gm.shape_env.evaluate_guards_for_args(  # type: ignore[operator, union-attr]
-        fx_placeholder_vals(gm), args, ignore_static=ignore_static
+        fx_placeholder_vals(gm),
+        args,
+        ignore_static=ignore_static,
     )
 
 

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1908,7 +1908,7 @@ def guard_float(a: FloatLikeType) -> float:
 
 
 # Given a GraphModule, return all the FakeTensors for all the placeholders
-def fx_placeholder_vals(gm: torch.fx.GraphModule) -> list[object]:
+def fx_placeholder_vals(gm: torch.fx.GraphModule) -> list[Any]:
     return [n.meta["val"] for n in gm.graph.nodes if n.op == "placeholder"]
 
 
@@ -1925,7 +1925,9 @@ def eval_guards(
     if gm.shape_env is None:
         raise AssertionError("gm.shape_env must not be None")
     return gm.shape_env.evaluate_guards_for_args(  # type: ignore[operator, union-attr]
-        fx_placeholder_vals(gm), args, ignore_static=ignore_static
+        fx_placeholder_vals(gm),
+        args,
+        ignore_static=ignore_static,
     )
 
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1370,9 +1370,7 @@ class Graph:
         self._find_nodes_lookup_table = _FindNodesLookupTable()
 
     @property
-    # TODO: should return GraphModule | None, but causes downstream errors
-    # where callers pass it to functions expecting non-optional GraphModule
-    def owning_module(self):  # pyrefly: ignore[unannotated-return]
+    def owning_module(self) -> GraphModule | None:
         return self._owning_module
 
     @owning_module.setter

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Generator
     from typing import Self
 
+    from ._symbolic_trace import Tracer
+    from .experimental.symbolic_shapes import ShapeEnv
     from .node import Node
 
 import torch
@@ -602,7 +604,7 @@ class GraphModule(torch.nn.Module):
         # Locally defined Tracers are not pickleable. This is needed because torch.package will
         # serialize a GraphModule without retaining the Graph, and needs to use the correct Tracer
         # to re-create the Graph during deserialization.
-        self._tracer_cls = None
+        self._tracer_cls: type[Tracer] | None = None
         if (
             self.graph._tracer_cls
             and "<locals>" not in self.graph._tracer_cls.__qualname__
@@ -621,7 +623,7 @@ class GraphModule(torch.nn.Module):
         self._erase_node_hooks: list[Callable[[Node], object]] = []
         # Used to remove hooks from deepcopied graph modules within a context manager.
         self._deepcopy_hooks: list[Callable[[GraphModule], object]] = []
-        self.shape_env = None  # optional not always set even when dynamic shapes exist.
+        self.shape_env: ShapeEnv | None = None
 
     # TorchScript breaks trying to compile the graph setter because of the
     # continued string literal. Issue here: https://github.com/pytorch/pytorch/issues/44842
@@ -970,7 +972,7 @@ class {module_name}(torch.nn.Module):
 
         self._recompile_submodules()
 
-        def call_wrapped(self, *args: Any, **kwargs: Any) -> Any:
+        def call_wrapped(self: Any, *args: Any, **kwargs: Any) -> Any:
             return self._wrapped_call(self, *args, **kwargs)
 
         cls.__call__ = call_wrapped  # type: ignore[method-assign]

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Generator
     from typing import Self
 
+    from ._symbolic_trace import Tracer
+    from .experimental.symbolic_shapes import ShapeEnv
     from .node import Node
 
 import torch
@@ -607,7 +609,7 @@ class GraphModule(torch.nn.Module):
         # Locally defined Tracers are not pickleable. This is needed because torch.package will
         # serialize a GraphModule without retaining the Graph, and needs to use the correct Tracer
         # to re-create the Graph during deserialization.
-        self._tracer_cls = None
+        self._tracer_cls: type[Tracer] | None = None
         if (
             self.graph._tracer_cls
             and "<locals>" not in self.graph._tracer_cls.__qualname__
@@ -626,7 +628,7 @@ class GraphModule(torch.nn.Module):
         self._erase_node_hooks: list[Callable[[Node], object]] = []
         # Used to remove hooks from deepcopied graph modules within a context manager.
         self._deepcopy_hooks: list[Callable[[GraphModule], object]] = []
-        self.shape_env = None  # optional not always set even when dynamic shapes exist.
+        self.shape_env: ShapeEnv | None = None
 
     # TorchScript breaks trying to compile the graph setter because of the
     # continued string literal. Issue here: https://github.com/pytorch/pytorch/issues/44842
@@ -975,7 +977,7 @@ class {module_name}(torch.nn.Module):
 
         self._recompile_submodules()
 
-        def call_wrapped(self, *args: Any, **kwargs: Any) -> Any:
+        def call_wrapped(self: Any, *args: Any, **kwargs: Any) -> Any:
             return self._wrapped_call(self, *args, **kwargs)
 
         cls.__call__ = call_wrapped  # type: ignore[method-assign]

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -759,6 +759,10 @@ class Node(_NodeBase):
                 raise AssertionError(
                     "self.graph.owning_module not set for purity check"
                 )
+            if not isinstance(self.target, str):
+                raise AssertionError(
+                    f"Expected str target for call_module, got {type(self.target)}"
+                )
             target_mod = self.graph.owning_module.get_submodule(self.target)
             if target_mod is None:
                 raise AssertionError(

--- a/torch/fx/passes/infra/pass_base.py
+++ b/torch/fx/passes/infra/pass_base.py
@@ -18,7 +18,7 @@ class PassResult(namedtuple("PassResult", ["graph_module", "modified"])):
         modified: A flag for if the pass has modified the graph module
     """
 
-    __slots__ = ()
+    __slots__: tuple[str, ...] = ()
 
     def __new__(cls, graph_module: nn.Module, modified: bool) -> "PassResult":
         return super().__new__(cls, graph_module, modified)

--- a/torch/fx/passes/reinplace.py
+++ b/torch/fx/passes/reinplace.py
@@ -308,9 +308,7 @@ def _get_view_inverse_node_usages(
 
 
 @compatibility(is_backward_compatible=True)
-def reinplace(
-    gm, *sample_args
-):  # pyrefly: ignore[unannotated-parameter, unannotated-return]
+def reinplace(gm: torch.fx.GraphModule, *sample_args: Any) -> torch.fx.GraphModule:
     r"""
     Given an fx.GraphModule, modifies it to perform "reinplacing",
     mutating the nodes of the graph.

--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -35,7 +35,7 @@ class TensorMetadata(NamedTuple):
 # In such situation contiguity is not set. We could also make it a tri-state i.e: (def_contiguous,
 # def_not_contiguous and unknown).
 def _extract_tensor_metadata(
-    result: torch.Tensor, include_contiguity=True
+    result: torch.Tensor, include_contiguity: bool = True
 ) -> TensorMetadata:
     """
     Extract a TensorMetadata NamedTuple describing `result`.
@@ -133,7 +133,7 @@ class ShapeProp(torch.fx.Interpreter):
 
     """
 
-    def __init__(self, gm, fake_mode=None):
+    def __init__(self, gm: torch.fx.GraphModule, fake_mode: Any = None) -> None:
         super().__init__(gm)
         if fake_mode is None:
             fake_mode = detect_fake_mode()
@@ -185,7 +185,7 @@ class ShapeProp(torch.fx.Interpreter):
 
         found_tensor = False
 
-        def extract_tensor_meta(obj):
+        def extract_tensor_meta(obj: Any) -> Any:
             if isinstance(obj, torch.Tensor):
                 nonlocal found_tensor
                 found_tensor = True
@@ -206,7 +206,7 @@ class ShapeProp(torch.fx.Interpreter):
         n.meta["type"] = type(result)
         return result
 
-    def propagate(self, *args):
+    def propagate(self, *args: Any) -> Any:
         """
         Run `module` via interpretation and return the result and
         record the shape and type of each node.

--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -36,7 +36,7 @@ class TensorMetadata(NamedTuple):
 # In such situation contiguity is not set. We could also make it a tri-state i.e: (def_contiguous,
 # def_not_contiguous and unknown).
 def _extract_tensor_metadata(
-    result: torch.Tensor, include_contiguity=True
+    result: torch.Tensor, include_contiguity: bool = True
 ) -> TensorMetadata:
     """
     Extract a TensorMetadata NamedTuple describing `result`.
@@ -134,7 +134,7 @@ class ShapeProp(torch.fx.Interpreter):
 
     """
 
-    def __init__(self, gm, fake_mode=None):
+    def __init__(self, gm: torch.fx.GraphModule, fake_mode: Any = None) -> None:
         super().__init__(gm)
         if fake_mode is None:
             fake_mode = detect_fake_mode()
@@ -186,7 +186,7 @@ class ShapeProp(torch.fx.Interpreter):
 
         found_tensor = False
 
-        def extract_tensor_meta(obj):
+        def extract_tensor_meta(obj: Any) -> Any:
             if isinstance(obj, torch.Tensor):
                 nonlocal found_tensor
                 found_tensor = True
@@ -207,7 +207,7 @@ class ShapeProp(torch.fx.Interpreter):
         n.meta["type"] = type(result)
         return result
 
-    def propagate(self, *args):
+    def propagate(self, *args: Any) -> Any:
         """
         Run `module` via interpretation and return the result and
         record the shape and type of each node.

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -126,6 +126,10 @@ class SubgraphMatcher:
         if not isinstance(gn.target, str):
             raise AssertionError(f"gn.target {gn.target} must be a string.")
 
+        if pn.graph.owning_module is None:
+            raise AssertionError("pn.graph.owning_module must not be None")
+        if gn.graph.owning_module is None:
+            raise AssertionError("gn.graph.owning_module must not be None")
         pn_value = torch.fx.graph_module._get_attr(pn.graph.owning_module, pn.target)
         gn_value = torch.fx.graph_module._get_attr(gn.graph.owning_module, gn.target)
 

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -480,7 +480,7 @@ class TracerBase:
         )
 
     @compatibility(is_backward_compatible=True)
-    def iter(self, obj: "Proxy") -> Iterator:
+    def iter(self, obj: "Proxy") -> Iterator[Any]:
         """Called when a proxy object is being iterated over, such as
         when used in control flow.  Normally we don't know what to do because
         we don't know the value of the proxy, but a custom tracer can attach more

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -480,7 +480,7 @@ class TracerBase:
         )
 
     @compatibility(is_backward_compatible=True)
-    def iter(self, obj: "Proxy") -> Iterator:
+    def iter(self, obj: "Proxy") -> Iterator:  # pyrefly: ignore[implicit-any]
         """Called when a proxy object is being iterated over, such as
         when used in control flow.  Normally we don't know what to do because
         we don't know the value of the proxy, but a custom tracer can attach more


### PR DESCRIPTION
Add torch/fx/** sub-config to pyrefly.toml enabling implicit-any, unannotated-return, and unannotated-parameter checks. Add tabulate to ignore-missing-imports since it is not a strict requirement

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo