### PR TITLE
[WIP] Enable CUTLASS EVT epilogue fusion for reshape patterns

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -2339,6 +2339,36 @@ class TestCutlassBackend(TestCase):
         )
         torch.testing.assert_close(result, ref_result)
 
+    @skipXPUIf(not Xe2_Or_Later, "")
+    @skipCUDAIf(not SM90OrLater, "need sm_90")
+    @use_evt_config
+    @evt_un_ops
+    def test_evt_reshape(self, op):
+        # mm [M, N] -> view [batch, seq, N] -> pointwise op
+        class TestModel(torch.nn.Module):
+            def forward(self, a, b, extra_args):
+                # a is 3D [batch, seq, K], b is 2D [K, N]
+                batch, seq = a.shape[0], a.shape[1]
+                acc = a.view(-1, a.shape[-1]) @ b
+                acc = acc.view(batch, seq, -1)
+                return op(acc, *extra_args)
+
+        M, N = 1024, 512
+        # Use batch=2, seq=512 so that M=batch*seq=1024
+        a = torch.randn(2, 512, N).to(GPU_TYPE).half()
+        b = torch.randn(N, N).to(GPU_TYPE).half().t()
+        extra_args = gen_args(op, (2, 512, N))
+        model = TestModel().to(GPU_TYPE)
+
+        result = torch.compile(model)(a, b, extra_args)
+        ref_result = model(a, b, extra_args)
+
+        self.assertEqual(
+            counters["inductor"]["cutlass_epilogue_fusion_counter"],
+            1,
+        )
+        torch.testing.assert_close(result, ref_result)
+
     def _test_gemm_operation_serialization(
         self, arch: str, cuda_version: str, min_ops=1000
     ):

--- a/torch/_inductor/codegen/cutlass/gemm_template.py
+++ b/torch/_inductor/codegen/cutlass/gemm_template.py
@@ -1294,6 +1294,12 @@ class CUTLASSGemmTemplate(CUTLASSTemplate, ABC):
                 Y,
                 *extra_inputs,
             ]
+            # Extend input_reorder to cover the extra epilogue/output inputs
+            if input_reorder is not None:
+                base_len = len(input_reorder)
+                input_reorder = input_reorder + list(
+                    range(base_len, len(inputs))
+                )
             input_names = [evt_arg_renames.get(name) for name in input_names]
             output_names = [evt_arg_renames.get(name) for name in output_names]
 
@@ -1557,6 +1563,32 @@ class CUTLASS3xGemmTemplate(CUTLASSGemmTemplate):
             name_to_buffer,  # type: ignore[arg-type]
             V.graph.sizevars.optimization_hint,
         )
+
+        # When epilogue nodes have different ndim from the template (e.g., 3D
+        # [batch, seq, N] vs 2D [M, N] due to a view/reshape), override their
+        # example tensors to use the accumulator's 2D shape.  EVT operations
+        # are element-wise so the shape is immaterial as long as numel matches.
+        from math import prod
+
+        acc_example = examples.get("accum")
+        if acc_example is not None:
+            acc_ndim = len(acc_example.shape)
+            acc_numel = prod(acc_example.shape)
+            for key in list(examples.keys()):
+                if key == "accum":
+                    continue
+                ex = examples[key]
+                if len(ex.shape) != acc_ndim and prod(ex.shape) == acc_numel:
+                    from cutlass_cppgen.backend.evt.ir.tensor import (  # type: ignore[import-not-found]
+                        Tensor as CutlassTensor,
+                    )
+
+                    examples[key] = CutlassTensor(
+                        shape=acc_example.shape,
+                        stride=acc_example.stride,
+                        element=ex.element,
+                    )
+
         evt_name, evt_args, evt_code, arg_renames = trace(
             evt_py_code,
             examples,

--- a/torch/_inductor/codegen/cutlass/lib_extensions/evt_extensions.py
+++ b/torch/_inductor/codegen/cutlass/lib_extensions/evt_extensions.py
@@ -214,6 +214,18 @@ non-contiguous layout, received stride: {stride} and shape: {shape}"
             def render_argument_type(name: str, t: CutlassArgType) -> None:
                 if issubclass(t, ctypes.c_byte):
                     buffer.writeline(f"{{}}, /* {name} */")
+                elif name not in name_to_buffer:
+                    # Immediate/constant values (e.g., imm_3_0_k0) are baked
+                    # into the EVT type at compile time.  Their argument fields
+                    # are zero-initialized.
+                    fields = [
+                        (fname, _get_default_arg(ty))
+                        for fname, ty in t._fields_
+                    ]
+                    field_strs = [
+                        f"/* {fname} */ {str(field)}" for fname, field in fields
+                    ]
+                    buffer.writeline(f"{{{', '.join(field_strs)}}}, /* {name} */")
                 else:
                     fields = [
                         (
@@ -252,6 +264,25 @@ non-contiguous layout, received stride: {stride} and shape: {shape}"
                 buffer.writeline("}")
 
         return buffer.getvalue(), arg_renames
+
+    def _get_default_arg(arg_ty: type) -> str:
+        """Return a zero/default C++ literal for an EVT argument field type.
+
+        Used for immediate/constant nodes (e.g. imm_3_0_k0) whose values are
+        baked into the EVT at compile time and don't correspond to any buffer.
+        """
+        if hasattr(arg_ty, "_fields_") and all(
+            issubclass(ft, ctypes.c_int64) for _, ft in arg_ty._fields_
+        ):
+            stride_len = len(arg_ty._fields_)
+            return f"{{{', '.join(['_0{}'] * stride_len)}}}"
+        elif issubclass(arg_ty, ctypes.c_void_p):
+            return "nullptr"
+        elif arg_ty in _CUTLASS_C_DTYPES:
+            return "0"
+        elif issubclass(arg_ty, EmptyByte):
+            return "{}"
+        return "{}"
 
     def _get_arg_from_node(
         arg_ty: type,

--- a/torch/_inductor/codegen/cutlass/python_evt.py
+++ b/torch/_inductor/codegen/cutlass/python_evt.py
@@ -64,7 +64,7 @@ class CutlassEVTOpsMixIn:
 
     @staticmethod
     def constant(value: Any, dtype: Any) -> str:
-        raise NotImplementedError
+        return str(value)
 
     @staticmethod
     def mul(x0: str, x1: str) -> str:
@@ -287,7 +287,10 @@ class CutlassEVTCodegen(CutlassEVTOpsMixIn):
 
     def _check_indexing(self, name: str, index: sympy.Expr) -> None:
         # We only support indexing that matches the layout today because
-        # CUTLASS doesn't support arbitrary indexing
+        # CUTLASS doesn't support arbitrary indexing.
+        # However, we allow dimension-mismatched but numel-compatible cases
+        # (e.g., accumulator is 2D [M, N] but epilogue node indexes as 3D [batch, seq, N])
+        # as long as the flattened access pattern is equivalent.
         buffer_name = (
             self.accumulator_node_name if name == _ACCUMULATOR_ARG_NAME else name
         )
@@ -296,18 +299,78 @@ class CutlassEVTCodegen(CutlassEVTOpsMixIn):
             index, self._get_current_index_vars()
         )
         stride = buffer.get_layout().stride
+        if len(stride) != len(index_strides):
+            # Dimension mismatch (e.g., 2D accumulator [M, N] accessed via 3D
+            # index [batch, seq, N]).  This happens when a view/reshape sits
+            # between the GEMM output and the epilogue pointwise op.  EVT
+            # operates element-wise, so the reshape is safe as long as the
+            # flattened access pattern matches the buffer's contiguous layout.
+            # Verify by collapsing consecutive index dims whose product equals
+            # the corresponding layout dim.
+            if not self._stride_compatible_reshape(stride, index_strides):
+                raise NotImplementedError(
+                    f"Unsupported indexing for {name} with index {index}, "
+                    f"index strides {index_strides} (len={len(index_strides)}), "
+                    f"and layout stride {stride} (len={len(stride)})"
+                )
+            return
         if not self._stride_compatible(stride, index_strides):
             raise NotImplementedError(
                 f"Unsupported indexing for {name} with index {index}, index strides {index_strides}, and layout stride {stride}"
             )
 
+    @staticmethod
+    def _strides_equal(a: sympy.Expr, b: sympy.Expr) -> bool:
+        return V.graph.sizevars.statically_known_equals(a, b)
+
     def _stride_compatible(
         self, left: Iterable[sympy.Expr], right: Iterable[sympy.Expr]
     ) -> bool:
         return all(
-            sympy.Eq(l, r) or sympy.Eq(l, 0) or sympy.Eq(r, 0)
-            for l, r in (zip(left, right))
+            self._strides_equal(l, r)
+            or self._strides_equal(l, sympy.Integer(0))
+            or self._strides_equal(r, sympy.Integer(0))
+            for l, r in zip(left, right)
         )
+
+    def _stride_compatible_reshape(
+        self,
+        layout_stride: Sequence[sympy.Expr],
+        index_strides: Sequence[sympy.Expr],
+    ) -> bool:
+        """Check if index_strides (more dims) is a contiguous reshape of layout_stride (fewer dims).
+
+        For example, layout_stride=[16384, 1] and index_strides=[8388608, 16384, 1]
+        means the index has an extra batch dimension that can be collapsed with the
+        first layout dimension: 8388608 = 512 * 16384, making it a simple view.
+
+        We greedily match from the rightmost (innermost) dimension: each layout stride
+        must equal the current index stride, then we advance through index dims whose
+        strides are multiples of that layout stride until we reach the next layout dim.
+        """
+        if len(index_strides) < len(layout_stride):
+            return False
+
+        # Work right-to-left (innermost first)
+        idx_pos = len(index_strides) - 1
+        for lay_pos in range(len(layout_stride) - 1, -1, -1):
+            if idx_pos < 0:
+                return False
+            ls = layout_stride[lay_pos]
+            ist = index_strides[idx_pos]
+            if not (
+                self._strides_equal(ls, ist)
+                or self._strides_equal(ls, sympy.Integer(0))
+                or self._strides_equal(ist, sympy.Integer(0))
+            ):
+                return False
+            idx_pos -= 1
+
+        # Any remaining (leftmost) index dims are batch dims that were
+        # flattened into the GEMM's M dimension.  The numel equality check
+        # in scheduling already guarantees the reshape is valid, so no
+        # per-stride validation is needed here.
+        return True
 
     def _render_input_signature(self) -> str:
         arguments = ", ".join(

--- a/torch/_inductor/codegen/cutlass/scheduling.py
+++ b/torch/_inductor/codegen/cutlass/scheduling.py
@@ -236,10 +236,14 @@ class CUTLASSScheduling(BaseScheduling):
 
             name = node.get_computed_buffer_name()  # type: ignore[attr-defined]
             # dtype can differ, and strides can differ as long as they are broadcastable
-            if node.get_size() != cutlass_template_buffer.get_size():
+            # Shape can differ as long as the total number of elements is the same
+            # (e.g., GEMM outputs 2D [M, N] but epilogue node may be 3D [batch, seq, N] after a reshape)
+            node_numel = sympy_product(node.get_size())
+            template_numel = sympy_product(cutlass_template_buffer.get_size())
+            if V.graph.sizevars.statically_known_equals(node_numel, template_numel) is False:
                 why(
-                    f"{name}'s size: {node.get_size()} differs from {cutlass_template_buffer.get_name()}'s \
-size: {cutlass_template_buffer.get_size()}"
+                    f"{name}'s numel: {node_numel} (size: {node.get_size()}) differs from {cutlass_template_buffer.get_name()}'s \
+numel: {template_numel} (size: {cutlass_template_buffer.get_size()})"
                 )
                 return False
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180626
* #174958
* #178130

Allow CUTLASS epilogue fusion when a view/reshape sits between the GEMM
output and the pointwise op. Previously, the strict shape equality check
in scheduling rejected these cases even though the numel matched.

Changes:
- scheduling.py: relax size check from strict shape to numel comparison
- python_evt.py: implement constant(), add _stride_compatible_reshape()
  for dimension-mismatched but numel-compatible indexing
- gemm_template.py: reshape epilogue example tensors to match accumulator
  2D shape in _render_evt(); extend input_reorder for epilogue inputs
- evt_extensions.py: handle immediate/constant EVT nodes that have no
  backing buffer (e.g. imm_3_0_k0)
- test_cutlass_backend.py: add test_evt_reshape covering relu/tanh/exp/sigmoid

Co-authored-by: Claude <noreply@anthropic.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo