### PR TITLE
Add missing FP8 skip decorator to test_scaled_mm_pdl_handles_none_bias

### DIFF
--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -399,6 +399,7 @@ class TestFP8Types(TestCase):
             f"LN only Inductor: {ln_latency}ms."
         )
 
+    @skipCUDAIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @onlyOn(["cuda", "xpu", "cpu"])
     def test_scaled_mm_pdl_handles_none_bias(self, device):
         dtype_float8 = _fix_fp8_dtype_for_rocm(torch.float8_e4m3fn, device)


### PR DESCRIPTION
## Summary
- `test_scaled_mm_pdl_handles_none_bias` calls `torch._scaled_mm` which requires compute capability >= 8.9 (sm89+), but was missing the `@skipCUDAIf(not PLATFORM_SUPPORTS_FP8, f8_msg)` decorator that every other test in `TestFP8Types` has.
- This caused consistent failures on sm86 (A10G / g5) CI runners in the `periodic` workflow.

## Test plan
- CI should pass on `linux-jammy-cuda13.0-py3-gcc11-slow-gradcheck` g5 shards that were previously failing with `RuntimeError: torch._scaled_mm is only supported on CUDA devices with compute capability >= 9.0 or 8.9`

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo