### PR TITLE
Fix typo: emitDefautlArgsWithOutArgs -> emitDefaultArgsWithOutArgs

### DIFF
--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -966,13 +966,13 @@ void BytecodeEmitMode::set_default_value_for_unspecified_arg_enabled(
   emitBytecodeDefaultInputs = enabled;
 }
 
-static thread_local bool emitDefautlArgsWithOutArgs =
+static thread_local bool emitDefaultArgsWithOutArgs =
     caffe2::serialize::kProducedBytecodeVersion <= 6 ? false : true;
 bool BytecodeEmitMode::is_default_args_before_out_args_enabled() {
-  return emitDefautlArgsWithOutArgs;
+  return emitDefaultArgsWithOutArgs;
 }
 void BytecodeEmitMode::set_default_args_before_out_args_enabled(bool enabled) {
-  emitDefautlArgsWithOutArgs = enabled;
+  emitDefaultArgsWithOutArgs = enabled;
 }
 
 static thread_local bool emitDefaultEmitPromotedOps =


### PR DESCRIPTION
Good day,

This PR fixes a simple typo in `torch/csrc/jit/serialization/export_module.cpp`:

- `emitDefautlArgsWithOutArgs` → `emitDefaultArgsWithOutArgs`

This is a straightforward spelling correction that improves code readability and consistency with the naming convention used elsewhere in the same file (e.g., `emitDefaultEmitPromotedOps`).

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof