### PR TITLE
Prune binary size from flash

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -316,24 +316,7 @@ file(GLOB mem_eff_attention_cuda_kernels_cu "native/transformers/cuda/mem_eff_at
 file(GLOB mem_eff_attention_cuda_cpp "native/transformers/cuda/mem_eff_attention/*.cpp")
 
 if(USE_CUDA AND (USE_FLASH_ATTENTION OR USE_MEM_EFF_ATTENTION))
-  add_library(flash_attention OBJECT EXCLUDE_FROM_ALL ${flash_attention_cuda_kernels_cu} ${flash_attention_cuda_cpp})
-
-  target_include_directories(flash_attention SYSTEM PUBLIC
-    ${PROJECT_SOURCE_DIR}/third_party/flash-attention/csrc
-    ${PROJECT_SOURCE_DIR}/third_party/flash-attention/include
-    ${PROJECT_SOURCE_DIR}/third_party/cutlass/include
-    ${PROJECT_SOURCE_DIR}/third_party/flash-attention/csrc/flash_attn/src
-  )
-
-  target_compile_definitions(flash_attention PRIVATE
-    # Copied from https://github.com/pytorch/pytorch/blob/a10024d7dea47c52469059a47efe376eb20adca0/caffe2/CMakeLists.txt#L1431
-    FLASH_NAMESPACE=pytorch_flash
-    FLASHATTENTION_DISABLE_ALIBI
-    FLASHATTENTION_DISABLE_SOFTCAP
-    UNFUSE_FMA
-  )
-
-  set_target_properties(flash_attention PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  add_subdirectory(native/transformers/cuda/flash_attn)
 endif()
 
 if(USE_FLASH_ATTENTION)

--- a/aten/src/ATen/native/transformers/cuda/flash_attn/CMakeLists.txt
+++ b/aten/src/ATen/native/transformers/cuda/flash_attn/CMakeLists.txt
@@ -1,0 +1,49 @@
+function(filter_out_gencode_arch output_var arch_to_remove)
+  separate_arguments(_cuda_flags UNIX_COMMAND "${ARGN}")
+  set(_filtered_cuda_flags)
+  list(LENGTH _cuda_flags _cuda_flags_length)
+  set(_index 0)
+
+  while(_index LESS _cuda_flags_length)
+    list(GET _cuda_flags ${_index} _flag)
+    math(EXPR _value_index "${_index} + 1")
+
+    if(_flag STREQUAL "-gencode" AND _value_index LESS _cuda_flags_length)
+      list(GET _cuda_flags ${_value_index} _value)
+      if(_value STREQUAL "arch=compute_${arch_to_remove},code=sm_${arch_to_remove}" OR _value STREQUAL "arch=compute_${arch_to_remove},code=compute_${arch_to_remove}" OR _value STREQUAL "arch=compute_${arch_to_remove},code=[compute_${arch_to_remove},sm_${arch_to_remove}]" OR _value STREQUAL "arch=compute_${arch_to_remove},code=[sm_${arch_to_remove},compute_${arch_to_remove}]")
+        math(EXPR _index "${_index} + 2")
+        continue()
+      endif()
+    endif()
+
+    list(APPEND _filtered_cuda_flags "${_flag}")
+    math(EXPR _index "${_index} + 1")
+  endwhile()
+
+  list(JOIN _filtered_cuda_flags " " _filtered_cuda_flags_string)
+  set(${output_var} "${_filtered_cuda_flags_string}" PARENT_SCOPE)
+endfunction()
+
+file(GLOB flash_attention_cuda_kernels_cu ${PROJECT_SOURCE_DIR}/third_party/flash-attention/csrc/flash_attn/src/*.cu)
+file(GLOB flash_attention_cuda_cpp ${PROJECT_SOURCE_DIR}/third_party/flash-attention/csrc/flash_attn/src/*.cpp)
+
+filter_out_gencode_arch(CMAKE_CUDA_FLAGS 75 "${CMAKE_CUDA_FLAGS}")
+
+add_library(flash_attention OBJECT EXCLUDE_FROM_ALL ${flash_attention_cuda_kernels_cu} ${flash_attention_cuda_cpp})
+
+target_include_directories(flash_attention SYSTEM PUBLIC
+  ${PROJECT_SOURCE_DIR}/third_party/flash-attention/csrc
+  ${PROJECT_SOURCE_DIR}/third_party/flash-attention/include
+  ${PROJECT_SOURCE_DIR}/third_party/cutlass/include
+  ${PROJECT_SOURCE_DIR}/third_party/flash-attention/csrc/flash_attn/src
+)
+
+target_compile_definitions(flash_attention PRIVATE
+  # Copied from https://github.com/pytorch/pytorch/blob/a10024d7dea47c52469059a47efe376eb20adca0/caffe2/CMakeLists.txt#L1431
+  FLASH_NAMESPACE=pytorch_flash
+  FLASHATTENTION_DISABLE_ALIBI
+  FLASHATTENTION_DISABLE_SOFTCAP
+  UNFUSE_FMA
+)
+
+set_target_properties(flash_attention PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180641

Human Note:
I was doing some investigations with codex using cubloaty: https://gist.github.com/drisspg/d47f0de45a7ccdd9a27f2f7056cbef13 

this one feels like a no brainer

## Summary                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                              
   This PR stops building PyTorch’s vendored flash-attention CUDA kernels for `sm_75`.                                                                                                                                                        
                                                                                                                                                                                                                                              
   PyTorch already gates flash-attention to supported hardware in `sdp_utils.cpp`, so the `sm_75` flash kernel payload is unreachable at runtime. This change removes that dead CUDA payload without modifying upstream                       
 `third_party/flash-attention`.                                                                                                                                                                                                               
                                                                                                                                                                                                                                              
   ## What changed                                                                                                                                                                                                                            
                                                                                                                                                                                                                                              
   - Moved `flash_attention` target creation into:                                                                                                                                                                                            
     - `aten/src/ATen/native/transformers/cuda/flash_attn/CMakeLists.txt`                                                                                                                                                                     
   - Scoped `flash_attention` into its own CMake subdirectory                                                                                                                                                                                 
   - Filtered `CMAKE_CUDA_FLAGS` locally in that subdirectory before creating the target, removing only the `sm_75` `-gencode` pair for flash-attention                                                                                       
                                                                                                                                                                                                                                              
   This keeps the normal build flow and compiler launcher behavior intact (`ccache` etc.) while making flash-attention stop compiling for `sm_75`.                                                                                            
                                                                                                                                                                                                                                              
   ## Why this is correct                                                                                                                                                                                                                     
                                                                                                                                                                                                                                              
   - Flash-attention is already runtime-gated to supported hardware                                                                                                                                                                           
   - `sm_75` flash kernels were still present in the binary, but unreachable                                                                                                                                                                  
   - This change only prunes flash-attention’s `sm_75` build coverage                                                                                                                                                                         
   - Supported flash architectures such as `sm_80` are preserved                                                                                                                                                                              
                                                                                                                                                                                                                                              
   ## Validation                                                                                                                                                                                                                              
                                                                                                                                                                                                                                              
   Built with forced arch coverage to prove the effect:                                                                                                                                                                                       
                                                                                                                                                                                                                                              
   ```bash                                                                                                                                                                                                                                    
   source ~/dotfiles/scripts/_build_setup.sh                                                                                                                                                                                                  
   TORCH_CUDA_ARCH_LIST="7.5 8.0" pip install -e . -v --no-build-isolation                                                                                                                                                                    
 ```                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                              
 Generated flash compile rules after the change show only:                                                                                                                                                                                    
                                                                                                                                                                                                                                              
 ```text                                                                                                                                                                                                                                      
   -gencode arch=compute_80,code=sm_80                                                                                                                                                                                                        
 ```                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                              
 ### Binary validation                                                                                                                                                                                                                        
                                                                                                                                                                                                                                              
 Using cuobjdump --dump-elf, counting pytorch_flash text sections by architecture:                                                                                                                                                            
                                                                                                                                                                                                                                              
 - baseline:                                                                                                                                                                                                                                  
     - sm_75: 4248                                                                                                                                                                                                                            
     - sm_80: 4248                                                                                                                                                                                                                            
 - patched:                                                                                                                                                                                                                                   
     - sm_80: 4248                                                                                                                                                                                                                            
                                                                                                                                                                                                                                              
 So the patch removes flash sm_75 payload while preserving sm_80.                                                                                                                                                                             
                                                                                                                                                                                                                                              
 ### Size impact                                                                                                                                                                                                                              
                                                                                                                                                                                                                                              
 Using cubloaty on libtorch_cuda.so filtered to pytorch_flash:                                                                                                                                                                                
                                                                                                                                                                                                                                              
 - removed flash sm_75 kernel code: 8.2 MB                                                                                                                                                                                                    
 - sm_80 flash kernel code unchanged: 86.0 MB                                                                                                                                                                                                 
                                                                                                                                                                                                                                              
 The local validation build’s on-disk libtorch_cuda.so shrank by about 1.17 MiB.        

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia