### PR TITLE
[xpu][fix] Skip test_device_capability_supported_dtypes on XPU

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -535,6 +535,7 @@
   - aten/src/ATen/detail/PrivateUse1HooksInterface.*
   - docs/source/accelerator/**
   - test/cpp_extensions/open_registration_extension/torch_openreg/**
+  - test/test_accelerator.py
   approved_by:
   - albanD
   - fffrog

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -12,6 +12,7 @@ from torch.testing._internal.common_utils import (
     TEST_ACCELERATOR,
     TEST_MPS,
     TEST_MULTIACCELERATOR,
+    TEST_XPU,
     TestCase,
 )
 
@@ -261,6 +262,10 @@ class TestAccelerator(TestCase):
         self.assertGreaterEqual(free_bytes, 0)
         self.assertGreaterEqual(total_bytes, 0)
 
+    @unittest.skipIf(
+        TEST_XPU,
+        "bare-bones/opaque bit-field dtypes cause undefined behavior on XPU, see https://github.com/pytorch/pytorch/issues/179888",
+    )
     def test_device_capability_supported_dtypes(self):
         try:
             caps = torch.accelerator.get_device_capability()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180660
# Motivation
Some barebones data types (e.g., `uint1`–`uint7`) defined in
https://github.com/pytorch/pytorch/blob/3e5f3426e5aa858e5668a64bb06db0354e9d9f00/c10/core/ScalarType.h#L126-L132
and opaque bit-field types (e.g., `Bits1x8`, etc.) defined in
https://github.com/pytorch/pytorch/blob/3e5f3426e5aa858e5668a64bb06db0354e9d9f00/c10/core/ScalarType.h#L120-L124
are not supported by `cast_and_store`, see
https://github.com/pytorch/pytorch/blob/1dba3349d74d100f19a395ece143aa2474f53af6/c10/core/DynamicCast.h#L92-L106

When these data types are triggered via `t.to(dtype)`, they hit the `CUDA_KERNEL_ASSERT` in
https://github.com/pytorch/pytorch/blob/1dba3349d74d100f19a395ece143aa2474f53af6/c10/core/DynamicCast.h#L57

On XPU, this leads to problematic behavior:
- The CUDA-style kernel assert results in undefined behavior (e.g., segfaults or intermittent passes randomly), depending on the timing between kernel completion and the host.
- Even if `CUDA_KERNEL_ASSERT` is replaced with `SYCL_KERNEL_ASSERT`, subsequent tests may still fail due to a corrupted runtime context.

Given this, we plan to skip this UT for now. We already have basic coverage for `torch.accelerator.get_device_capability` in
https://github.com/pytorch/pytorch/blob/1dba3349d74d100f19a395ece143aa2474f53af6/test/test_xpu.py#L168-L180

# Additional Context
fix https://github.com/pytorch/pytorch/issues/179888
