### PR TITLE
[NCCL][Symmetric Memory] Fix groupName in IntraNodeComm

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cu
@@ -46,7 +46,7 @@ at::Tensor IntraNodeComm::oneShotAllReduce(
       at::TensorOptions().dtype(input.dtype()).device(input.device()));
 
   symmMemTensor.copy_(input);
-  op.call(symmMemTensor, "sum", "", input);
+  op.call(symmMemTensor, "sum", groupName_, input);
   return input;
 }
 
@@ -65,7 +65,7 @@ at::Tensor IntraNodeComm::twoShotAllReduce(
       at::TensorOptions().dtype(input.dtype()).device(input.device()));
 
   symmMemTensor.copy_(input);
-  op.call(symmMemTensor, "sum", "");
+  op.call(symmMemTensor, "sum", groupName_);
   input.copy_(symmMemTensor);
   return input;
 }


### PR DESCRIPTION
This PR fixes:
```
RuntimeError: Could not resolve the process group registered under the name 
```
in `python test/distributed/test_c10d_nccl.py CommTest.test_intra_node_comm_all_reduce`.

Just FYI: A quite similar error was attempted to be fixed in #177700, however the refactor #176506 partially fixed the original one by lazy pg registration, though missed the process group name.