### PR TITLE
Updating Assertion to Consider Gil-less Python Environments

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -552,10 +552,8 @@ class TORCH_API OperatorHandle {
   }
 
   template <typename F>
-  PyObject* getPythonOp(
-      c10::impl::PyInterpreter* self_interpreter,
-      F slow_accessor) const {
-    return operatorDef_->op.getPythonOp(self_interpreter, slow_accessor);
+  PyObject* getPythonOp(F slow_accessor) const {
+    return operatorDef_->op.getPythonOp(slow_accessor);
   }
 
   bool operator==(const OperatorHandle& other) const {

--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -224,9 +224,8 @@ class TORCH_API OperatorEntry final {
   void setReportErrorCallback_(std::unique_ptr<c10::SafePyObject> callback);
 
   template <typename F>
-  PyObject* getPythonOp(PyInterpreter* self_interpreter, F slow_accessor)
-      const {
-    return py_cache_.ptr_or(self_interpreter, slow_accessor);
+  PyObject* getPythonOp(F slow_accessor) const {
+    return py_cache_.ptr_or(slow_accessor);
   }
 
  private:

--- a/c10/core/PyHandleCache.h
+++ b/c10/core/PyHandleCache.h
@@ -2,6 +2,7 @@
 
 #include <c10/core/impl/PyInterpreter.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/DeadlockDetection.h>
 #include <c10/util/Exception.h>
 #include <c10/util/python_stub.h>
 
@@ -37,40 +38,27 @@ namespace c10 {
 // not be a way to conveniently index based on the object.)
 class PyHandleCache {
  public:
-  PyHandleCache() : pyinterpreter_(nullptr) {}
+  PyHandleCache() = default;
 
-  // Attempt to fetch the pointer from the cache, if the PyInterpreter
+  // Attempt to fetch the pointer from the cache, if the PyObject
   // matches.  If it doesn't exist, or the cache entry is not valid,
   // use slow_accessor to get the real pointer value and return that
   // (possibly writing it to the cache, if the cache entry is
   // available.)
   template <typename F>
-  PyObject* ptr_or(impl::PyInterpreter* self_interpreter, F slow_accessor)
-      const {
-    // Note [Memory ordering on Python interpreter tag]
-    impl::PyInterpreter* interpreter =
-        pyinterpreter_.load(std::memory_order_acquire);
-    if (C10_LIKELY(interpreter == self_interpreter)) {
-      return data_;
-    } else if (interpreter == nullptr) {
-      auto* r = slow_accessor();
-      impl::PyInterpreter* expected = nullptr;
-      // attempt to claim this cache entry with the specified interpreter tag
-      if (pyinterpreter_.compare_exchange_strong(
-              expected, self_interpreter, std::memory_order_acq_rel)) {
-        data_ = r;
-      }
-      // This shouldn't be possible, as you should be GIL protected
-      TORCH_INTERNAL_ASSERT(expected != self_interpreter);
-      return r;
-    } else {
-      return slow_accessor();
+  PyObject* ptr_or(F slow_accessor) const {
+    PyObject* d = data_.load(std::memory_order_acquire);
+    if (C10_LIKELY(d != nullptr)) {
+      return d;
     }
+    auto* r = slow_accessor();
+    PyObject* expected = nullptr;
+    data_.compare_exchange_strong(expected, r, std::memory_order_acq_rel);
+    return r;
   }
 
  private:
-  mutable std::atomic<impl::PyInterpreter*> pyinterpreter_;
-  mutable PyObject* data_{nullptr};
+  mutable std::atomic<PyObject*> data_{nullptr};
 };
 
 } // namespace c10

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -967,7 +967,7 @@ PyInterpreterHolder self_interpreter;
 } // anonymous namespace
 
 py::handle getTorchApiFunction(const c10::OperatorHandle& op) {
-  return op.getPythonOp(getPyInterpreter(), [&]() -> PyObject* {
+  return op.getPythonOp([&]() -> PyObject* {
     // Parse the name into namespace and name (no overload_name)
     // TODO: put this into the library
     const auto& schema = op.schema();

--- a/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
@@ -501,7 +501,7 @@ std::string AOTIPythonKernelHolder::produce_aoti_kernel_lib(
       qualified_name.end());
 
   py::gil_scoped_acquire gil;
-  py::handle op_py_func = op.getPythonOp(pyinterpreter_, [&]() -> PyObject* {
+  py::handle op_py_func = op.getPythonOp([&]() -> PyObject* {
     py::handle torch_api_function = py::module::import("torch")
                                         .attr("ops")
                                         .attr(ns_str.c_str())


### PR DESCRIPTION
Summary: Currently we have had some [unit tests failing](https://www.internalfb.com/intern/testinfra/diagnostics/19140298430691838.562950226310106.1776189975/?section=%22summary%22) for 3.14t builds because of `TORCH_INTERNAL_ASSERT(expected != self_interpreter);`.  The original comment said ` This shouldn't be possible, as you should be GIL protected` however we are now in a world where the same interpreter can be accessed by multiple threads. I have seen this [pattern](https://www.internalfb.com/code/search?q=repo%3Aall%20c10%3A%3Aimpl%3A%3Acheck_python_gil()) across the database so this seems like a continuation of previous work.

Test Plan: ci

Reviewed By: malfet

Differential Revision: D101009072


