### PR TITLE
[Profiler] Remove references to _KinetoProfile in public docs

### DIFF
--- a/docs/source/profiler.md
+++ b/docs/source/profiler.md
@@ -13,6 +13,7 @@
 ```{eval-rst}
 
 .. autoclass:: torch.profiler.profile
+  :members:
   :inherited-members:
 
 .. autoclass:: torch.profiler.ProfilerAction

--- a/docs/source/profiler.md
+++ b/docs/source/profiler.md
@@ -11,8 +11,6 @@
 
 ## API Reference
 ```{eval-rst}
-.. autoclass:: torch.profiler._KinetoProfile
-  :members:
 
 .. autoclass:: torch.profiler.profile
   :members:

--- a/docs/source/profiler.md
+++ b/docs/source/profiler.md
@@ -13,7 +13,7 @@
 ```{eval-rst}
 
 .. autoclass:: torch.profiler.profile
-  :members:
+  :inherited-members:
 
 .. autoclass:: torch.profiler.ProfilerAction
   :members:

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -401,6 +401,8 @@ class _KinetoProfile:
         """Averages events, grouping them by operator name and (optionally) input shapes, stack
         and overload name.
 
+        Returns an :class:`~torch.autograd.profiler_util.EventList` of the aggregated events.
+
         .. note::
             To use shape/stack functionality make sure to set record_shapes/with_stack
             when creating profiler context manager.
@@ -414,9 +416,8 @@ class _KinetoProfile:
         )
 
     def events(self):
-        """
-        Returns the list of unaggregated profiler events,
-        to be used in the trace callback or after the profiling is finished
+        """Return the list of unaggregated :class:`~torch.autograd.profiler_util.FunctionEvent`
+        objects, for use in the trace callback or after profiling has finished.
         """
         if self.profiler is None:
             raise AssertionError("Profiler must be initialized before accessing events")
@@ -665,8 +666,10 @@ class profile(_KinetoProfile):
             The same activity group must not appear more than once.
         schedule (Callable): callable that takes step (int) as a single parameter and returns
             ``ProfilerAction`` value that specifies the profiler action to perform at each step.
-        on_trace_ready (Callable): callable that is called at each step when ``schedule``
-            returns ``ProfilerAction.RECORD_AND_SAVE`` during the profiling.
+        on_trace_ready (Callable): callable invoked at the end of each profiling cycle
+            (when ``schedule`` returns ``ProfilerAction.RECORD_AND_SAVE``). Receives the
+            :class:`profile` instance as its only argument, typically used to export the
+            trace (e.g. via :meth:`export_chrome_trace`) or print a summary.
         record_shapes (bool): save information about operator's input shapes.
         profile_memory (bool): track tensor memory allocation/deallocation.
         with_stack (bool): record source information (file and line number) for the ops.
@@ -689,6 +692,9 @@ class profile(_KinetoProfile):
         post_processing_timeout_s (float): Optional timeout in seconds for post-processing profiler
             results. If specified, event parsing will stop after this duration and return partial
             results. Useful for handling large traces that may take too long to process.
+        custom_trace_id_callback (Callable[[], str], optional): User-supplied trace ID generator,
+            invoked once per profiling cycle. Defaults to a random UUID; retrieve via
+            :meth:`get_trace_id`.
         use_cuda (bool):
             .. deprecated:: 1.8.1
                 use ``activities`` instead.
@@ -947,8 +953,12 @@ class profile(_KinetoProfile):
         self._transit_action(self.current_action, None)
 
     def step(self) -> None:
-        """
-        Signals the profiler that the next profiling step has started.
+        """Signal the profiler that the next profiling step has started.
+
+        Advances the schedule by one step, which may start or stop tracing and may
+        invoke ``on_trace_ready`` at cycle boundaries. Call once per training
+        iteration when using a non-default ``schedule``; a no-op-like marker under
+        the default schedule.
         """
         if self.record_steps and self.step_rec_fn:
             self.step_rec_fn.__exit__(None, None, None)
@@ -969,15 +979,13 @@ class profile(_KinetoProfile):
             self.step_rec_fn.__enter__()
 
     def set_custom_trace_id_callback(self, callback) -> None:
-        """
-        Sets a callback to be called when a new trace ID is generated.
+        """Set the trace ID generator. Called at the start of each cycle, so updating
+        it between cycles yields distinct IDs per cycle.
         """
         self.custom_trace_id_callback = callback
 
     def get_trace_id(self):
-        """
-        Returns the current trace ID.
-        """
+        """Return the current cycle's trace ID, or ``None`` before the first cycle."""
         if self.profiler is None:
             return None
         return self.profiler.trace_id

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -955,7 +955,7 @@ class profile(_KinetoProfile):
 
     def step(self) -> None:
         """
-        Signal the profiler that the next profiling step has started.
+        Signals the profiler that the next profiling step has started.
         """
         if self.record_steps and self.step_rec_fn:
             self.step_rec_fn.__exit__(None, None, None)

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -416,7 +416,8 @@ class _KinetoProfile:
         )
 
     def events(self):
-        """Return the list of unaggregated :class:`~torch.autograd.profiler_util.FunctionEvent`
+        """
+        Return the list of unaggregated :class:`~torch.autograd.profiler_util.FunctionEvent`
         objects, for use in the trace callback or after profiling has finished.
         """
         if self.profiler is None:
@@ -953,12 +954,8 @@ class profile(_KinetoProfile):
         self._transit_action(self.current_action, None)
 
     def step(self) -> None:
-        """Signal the profiler that the next profiling step has started.
-
-        Advances the schedule by one step, which may start or stop tracing and may
-        invoke ``on_trace_ready`` at cycle boundaries. Call once per training
-        iteration when using a non-default ``schedule``; a no-op-like marker under
-        the default schedule.
+        """
+        Signal the profiler that the next profiling step has started.
         """
         if self.record_steps and self.step_rec_fn:
             self.step_rec_fn.__exit__(None, None, None)
@@ -979,13 +976,16 @@ class profile(_KinetoProfile):
             self.step_rec_fn.__enter__()
 
     def set_custom_trace_id_callback(self, callback) -> None:
-        """Set the trace ID generator. Called at the start of each cycle, so updating
+        """
+        Set the trace ID generator. Called at the start of each cycle, so updating
         it between cycles yields distinct IDs per cycle.
         """
         self.custom_trace_id_callback = callback
 
     def get_trace_id(self):
-        """Return the current cycle's trace ID, or ``None`` before the first cycle."""
+        """
+        Returns the current trace ID.
+        """
         if self.profiler is None:
             return None
         return self.profiler.trace_id


### PR DESCRIPTION
When I'm looking at the docs, the first reference is to `_KinetoProfile`, which is pretty confusing. This is just the internal base class for `torch.profiler.profile`. I remove that entry from the docs, and update `torch.profiler.profile` to contain all inherited members of the base class as well. 

Also taking this opportunity to improve some docstrings that I think could use more flavor and add some documentation for `custom_trace_id_callback`.

Demo:

Local build of the docs shows `torch.profiler.profile` as the top object

<img width="1296" height="804" alt="image" src="https://github.com/user-attachments/assets/c93a026f-1660-40cd-8a30-eec02a9f2b0f" />

