### PR TITLE
Fix torch.trapz documentation signature to match torch.trapezoid

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13129,7 +13129,7 @@ Examples::
 add_docstr(
     torch.trapz,
     r"""
-trapz(y, x, *, dim=-1) -> Tensor
+trapz(y, x=None, *, dx=None, dim=-1) -> Tensor
 
 Alias for :func:`torch.trapezoid`.
 """,


### PR DESCRIPTION
Good day

I am addressing issue #71392, which reports that the documentation signature for `torch.trapz` is inconsistent with its alias `torch.trapezoid`.

## Problem
- `torch.trapezoid(y, x=None, *, dx=None, dim=-1)`
- `torch.trapz(y, x, *, dim=-1)`  ← Missing `x=None`, `dx=None`

Since `torch.trapz` is an alias for `torch.trapezoid`, they should have consistent signatures.

## Fix
Changed the docstring signature from:
```
trapz(y, x, *, dim=-1) -> Tensor
```
To:
```
trapz(y, x=None, *, dx=None, dim=-1) -> Tensor
```

This makes `trapz`'s documentation consistent with `trapezoid`.

## Testing
- Code change is minimal (single line signature fix)
- No code logic changed, only documentation
- Consistent with `trapezoid` documentation

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof