### PR TITLE
Fix typo: overrideable -> overridden in torch.fx

### DIFF
--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -399,7 +399,7 @@ class TracerBase:
         A method that lowers the objects seen as arguments during symbolic evaluation
         into Argument types that can be stored in IR.
 
-        Can be override to support more trace-specific types.
+        Can be overridden to support more trace-specific types.
         """
         # IMPORTANT: Are you here because you are trying to proxy a new type into
         # the graph? Please Please Please contact someone on the PyTorch Compiler team;


### PR DESCRIPTION
Good day

## Issue
Fixes a typo in the torch.fx documentation. The word "overrideable" was misspelled and should be "overridden".

## Changes
- Updated docstring in torch/fx/proxy.py: "Can be override to support more trace-specific types." → "Can be overridden to support more trace-specific types."

## Testing
- No code changes, only docstring typo fix
- Verified with grep that the typo is no longer present

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof