### PR TITLE
AOTI: Only clone mutated buffers in _unlift_graph

### DIFF
--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -428,9 +428,12 @@ def _unlift_graph(
 
     # In AOTI, module parameters and buffers are not lifted as graph inputs.
     # As a result, mutation to buffers has side effect which makes their initial
-    # values different from Eager. So we clone them here as a copy.
+    # values different from Eager. So we clone mutated buffers here to preserve
+    # their original values. Non-mutated buffers don't need cloning since their
+    # values are unchanged after tracing.
     # We are not cloning for parameters, although it will be needed if we want to
     # support training.
+    mutated_buffer_names = set(graph_signature.buffers_to_mutate.values())
     for node in placeholder_nodes:
         node_name = node.name
         if node_name in graph_signature.inputs_to_parameters:
@@ -439,9 +442,10 @@ def _unlift_graph(
         elif node_name in graph_signature.inputs_to_buffers:
             buffer_name = graph_signature.inputs_to_buffers[node_name]
             lifted_inputs.append(buffer_name)
-            gm.meta[get_cloned_parameter_buffer_name(buffer_name)] = (
-                clone_preserve_strides(state_dict[buffer_name])
-            )
+            if buffer_name in mutated_buffer_names:
+                gm.meta[get_cloned_parameter_buffer_name(buffer_name)] = (
+                    clone_preserve_strides(state_dict[buffer_name])
+                )
         else:
             assert node_name in graph_signature.user_inputs
             lifted_inputs.append(None)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #180684
* #180683
* __->__ #180682

Previously, _unlift_graph cloned ALL buffers via clone_preserve_strides
to preserve their pre-tracing values. For large models with many
non-mutated buffer weights (e.g. quantized MoE with 256 experts),
this wastes ~20GB of memory by cloning read-only weight buffers.

Only clone buffers that appear in graph_signature.buffers_to_mutate.
Non-mutated buffers retain their correct values in self.constants,
so get_original_value_of_constant falls through to the right data.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo