### PR TITLE
[nativert][sigmoid] Fix None input values having incorrect producer pointer in graph deserialization (#180685)

### DIFF
--- a/test/cpp/nativert/test_serialization.cpp
+++ b/test/cpp/nativert/test_serialization.cpp
@@ -328,4 +328,90 @@ TEST(SerializationTest, ConstantToValueThrowsOnSymbolicTypes) {
   EXPECT_THROW(constantToValue(as_opt_tensor, false), std::exception);
 }
 
+// Verify that None-typed input values deserialized from JSON have nullptr
+// producer. Previously, they were incorrectly assigned the consuming node as
+// producer, which caused dangling pointer crashes in cleanupDeadNodes() when
+// graph passes like FuseListUnpack destroyed the consuming node.
+TEST(SerializationTest, NoneInputValueHasNullProducer) {
+  // Build a minimal JSON graph:
+  //   graph(%data):
+  //     %out = some.op(data=%data, optional_arg=None)
+  //     return (%out)
+  torch::_export::Graph jsonGraph;
+
+  // Graph input: a tensor named "data"
+  torch::_export::Argument graphInput;
+  graphInput.set_as_tensor(makeTensorArg("data"));
+  jsonGraph.set_inputs({graphInput});
+
+  // Node: some.op with a tensor input and a None input
+  torch::_export::Node node;
+  node.set_target("some.op.default");
+
+  torch::_export::NamedArgument dataInput;
+  dataInput.set_name("data");
+  torch::_export::Argument dataArg;
+  dataArg.set_as_tensor(makeTensorArg("data"));
+  dataInput.set_arg(dataArg);
+
+  torch::_export::NamedArgument noneInput;
+  noneInput.set_name("optional_arg");
+  torch::_export::Argument noneArg;
+  noneArg.set_as_none({});
+  noneInput.set_arg(noneArg);
+
+  node.set_inputs({dataInput, noneInput});
+
+  // Output: a tensor named "out"
+  torch::_export::Argument nodeOutput;
+  nodeOutput.set_as_tensor(makeTensorArg("out"));
+  node.set_outputs({nodeOutput});
+
+  jsonGraph.set_nodes({node});
+
+  // Graph output
+  torch::_export::Argument graphOutput;
+  graphOutput.set_as_tensor(makeTensorArg("out"));
+  jsonGraph.set_outputs({graphOutput});
+
+  // Build signature with proper input/output specs
+  torch::_export::GraphSignature sig;
+
+  torch::_export::UserInputSpec userInput;
+  userInput.set_arg(graphInput);
+  torch::_export::InputSpec inputSpec;
+  inputSpec.set_user_input(userInput);
+  sig.set_input_specs({inputSpec});
+
+  torch::_export::UserOutputSpec userOutput;
+  userOutput.set_arg(graphOutput);
+  torch::_export::OutputSpec outputSpec;
+  outputSpec.set_user_output(userOutput);
+  sig.set_output_specs({outputSpec});
+
+  torch::_export::GraphModule graphModule;
+  graphModule.set_graph(jsonGraph);
+  graphModule.set_signature(sig);
+
+  auto graph = jsonToGraph(graphModule);
+
+  // Find the deserialized node and check its None input
+  for (const auto& n : graph->nodes()) {
+    if (n.target() == "some.op.default") {
+      for (const auto& inp : n.inputs()) {
+        if (inp.name == "optional_arg") {
+          // The None value should have nullptr producer, not the consuming node
+          EXPECT_EQ(inp.value->type().kind(), Type::Kind::None);
+          EXPECT_EQ(inp.value->producer(), nullptr)
+              << "None input value should have nullptr producer, not the "
+                 "consuming node. This was fixed to prevent dangling pointer "
+                 "crashes in cleanupDeadNodes().";
+          return;
+        }
+      }
+    }
+  }
+  FAIL() << "Could not find the None input 'optional_arg' on 'some.op.default'";
+}
+
 } // namespace torch::nativert

--- a/torch/nativert/graph/Serialization.cpp
+++ b/torch/nativert/graph/Serialization.cpp
@@ -354,7 +354,7 @@ std::unique_ptr<Graph> jsonToSubgraph(
       } else if (arg.tag() == torch::_export::Argument::Tag::AS_NONE) {
         node->addInput(NamedArgument{
             input.get_name(),
-            graph->addValue(std::nullopt, Type::Kind::None, node)});
+            graph->addValue(std::nullopt, Type::Kind::None, nullptr)});
       } else {
         node->addAttribute(Attribute{
             input.get_name(),


### PR DESCRIPTION
Summary:

During graph deserialization, None-typed input values (e.g. optional parameters like the `key` argument to `gather_ranges_to_dense_v2`) were created with `producer_` set to the consuming node rather than `nullptr`. This created "detached" values that appeared in the graph values map with a producer pointer to a node that did not list them as outputs.

When graph passes like `FuseListUnpack` destroyed the consuming node (replacing it with a fused variant), these detached values retained dangling `producer_` pointers to freed memory. The subsequent `cleanupDeadNodes()` DFS traversal would follow these dangling producer pointers, causing a SIGSEGV.

The fix changes both the JSON (nativert) and Thrift (sigmoid) deserializers to pass `nullptr` as the producer for None input values, consistent with how None values are already handled in optional tensor lists.

Test Plan:
Unit test verifying None values get nullptr producer after deserialization:
```
buck2 test fbcode//caffe2/test/cpp/nativert:serialization_test -- SerializationTest.NoneInputValueHasNullProducer
```

End-to-end test: JSON deserialize graph with None inputs, run FuseListUnpack + cleanupDeadNodes (crashes without fix with P2277653379):
```
buck2 test fbcode//sigmoid/backend/passes:graph_passes_test -- SubgraphRewriterTest.FuseListUnpackWithNoneInputFromJsonDeser
```

Both production models load and benchmark successfully:
```
buck2 build -j 32 mode/opt //caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor

buck2 run -j 32 mode/opt //caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor -- \
  --inputNetFile=/tmp/benchmark_sig_1058907472_1/1058907472_1.predictor.disagg.gpu.local \
  --sampleInputFilePath=/tmp/benchmark_sig_1058907472_1/archive/data/sample_inputs/local.pt \
  --moduleName=local --loadMode=Benchmark --submodToDevice="local|cpu,local_request_only|cpu"

buck2 run -j 32 mode/opt //caffe2/torch/fb/model_transform/fx2trt/packaging:load_net_predictor -- \
  --inputNetFile=/tmp/1062014589/2/1062014589_2.predictor.disagg.gpu.local \
  --sampleInputFilePath=/tmp/1062014589/2/archive/data/sample_inputs/local.pt \
  --moduleName=local --loadMode=Benchmark --submodToDevice="local|cpu,local_request_only|cpu"
```

Reviewed By: nhanitvn

Differential Revision: D101289845
