### PR TITLE
test: relax error tolerances for complex64 tests with tan and tanh

### DIFF
--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -226,6 +226,19 @@ class TestUnaryUfuncs(TestCase):
                     rtol=1.2e-03,
                     atol=1e-03,
                 )
+            elif dtype is torch.complex64 and "tan" in op.name:
+                self.assertEqualHelper(
+                    actual,
+                    expected,
+                    msg,
+                    dtype=dtype,
+                    exact_dtype=exact_dtype,
+                    equal_nan=equal_nan,
+                    # Overriding for complex64 due to precision issues in
+                    # std::tanh/tan near poles
+                    rtol=1e-05,
+                    atol=1e-02,
+                )
             else:
                 self.assertEqualHelper(
                     actual,


### PR DESCRIPTION
There is an issue caused by precision limitations in the standard `std::tanh` (and `std::tan`) implementation used by PyTorch on CPU when evaluated near complex poles.

For example, `TestUnaryUfuncsCPU.test_reference_numerics_extremal__refs_nn_functional_tanhshrink_cpu_complex64`:
```
  File "/third_party/py/torch/test/test_unary_ufuncs.py", line 319, in test_reference_numerics_extremal
    self._test_reference_numerics(dtype, op, tensors)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/third_party/py/torch/test/test_unary_ufuncs.py", line 264, in _test_reference_numerics
    _helper_reference_numerics(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^
        expected, actual, msg, exact_dtype, equal_nan
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/third_party/py/torch/test/test_unary_ufuncs.py", line 230, in _helper_reference_numerics
    self.assertEqualHelper(
    ~~~~~~~~~~~~~~~~~~~~~~^
        actual,
        ^^^^^^^
    ...<4 lines>...
        exact_dtype=exact_dtype,
        ^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/third_party/py/torch/test/test_unary_ufuncs.py", line 175, in assertEqualHelper
    self.assertEqual(
    ~~~~~~~~~~~~~~~~^
        actual,
        ^^^^^^^
    ...<3 lines>...
        **kwargs,
        ^^^^^^^^^
    )
    ^
  File "/third_party/py/torch/testing/_internal/common_utils.py", line 4362, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
    ...<4 lines>...
    )
AssertionError: Tensor-likes are not close!

Mismatched elements: 5 / 16384 (0.0%)
Greatest absolute difference: 0.005777956917881966 at index (6, 112) (up to 1e-05 allowed)
Greatest relative difference: 8.628269279142842e-05 at index (6, 112) (up to 1.3e-06 allowed)
```
This change overrides the tolerance to the operations affected by this specific numerical stability issue.