### PR TITLE
[ROCm] Make foreach fastpath detection robust in test_foreach

### DIFF
--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -1,6 +1,9 @@
 #pragma once
 #include <ATen/core/Tensor.h>
 #include <ATen/cuda/CUDAContext.h>
+#if defined(USE_ROCM)
+#include <ATen/record_function.h>
+#endif
 #include <c10/cuda/CUDAGuard.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/MemoryAccess.cuh>
@@ -131,6 +134,12 @@ __global__ void multi_tensor_apply_kernel(
   callable(kChunkSize, tensorListMeta, args...);
 }
 
+inline void record_foreach_mta_launch() {
+#if defined(USE_ROCM)
+  RECORD_FUNCTION("aten::_foreach_mta_launch", {});
+#endif
+}
+
 } // namespace
 
 // multi_tensor_apply enables horizontal fusion across lists of tensors.
@@ -198,6 +207,7 @@ void multi_tensor_apply(
           (loc_block_info == depth_to_max_blocks[depth - 1]);
 
       if (tensors_full || blocks_full) {
+        record_foreach_mta_launch();
         multi_tensor_apply_kernel<<<
             loc_block_info,
             kBlockSize,
@@ -230,6 +240,7 @@ void multi_tensor_apply(
   // if there's remaining work to be done but the tensors/blocks aren't full
   // yet we are at the end, submit the kernel to do the work!
   if (loc_block_info != 0) {
+    record_foreach_mta_launch();
     multi_tensor_apply_kernel<<<
         loc_block_info,
         kBlockSize,
@@ -284,6 +295,7 @@ void multi_tensor_apply(
           (loc_block_info == depth_to_max_blocks[depth - 1]);
 
       if (tensors_full || blocks_full) {
+        record_foreach_mta_launch();
         multi_tensor_apply_kernel<<<
             loc_block_info,
             kBlockSize,
@@ -313,6 +325,7 @@ void multi_tensor_apply(
 
   // see note: [finishing what we started]
   if (loc_block_info != 0) {
+    record_foreach_mta_launch();
     multi_tensor_apply_kernel<<<
         loc_block_info,
         kBlockSize,
@@ -366,6 +379,7 @@ void multi_tensor_apply_for_fused_optimizer(
       const auto blocks_full = loc_block_info == depth_to_max_blocks[depth - 1];
 
       if (tensor_full || blocks_full) {
+        record_foreach_mta_launch();
         multi_tensor_apply_kernel<<<
             loc_block_info,
             kBlockSize,
@@ -395,6 +409,7 @@ void multi_tensor_apply_for_fused_optimizer(
 
   // see above note: [finishing what we've started]
   if (loc_block_info != 0) {
+    record_foreach_mta_launch();
     multi_tensor_apply_kernel<<<
         loc_block_info,
         kBlockSize,

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -103,11 +103,18 @@ class ForeachFuncWrapper:
                 # synchronize within the profiler context to make sure events happen before exiting
                 torch.cuda.synchronize()
             keys = tuple([e.key for e in p.key_averages()])
-            mta_called = any("multi_tensor_apply_kernel" in k for k in keys)
+            mta_kernel_called = any("multi_tensor_apply_kernel" in k for k in keys)
+            # Explicitly track MTA launch on ROCm via RECORD_FUNCTION in
+            # MultiTensorApply.cuh to avoid dependence on ROCm kernel
+            # symbolization.
+            mta_launch_marker_called = TEST_WITH_ROCM and any(
+                "_foreach_mta_launch" in k for k in keys
+            )
+            mta_called = mta_kernel_called or mta_launch_marker_called
 
             if mta_called != (expect_fastpath and (not zero_size)):
                 raise AssertionError(
-                    f"{mta_called=}, {expect_fastpath=}, {zero_size=}, {self.func.__name__=}, {keys=}"
+                    f"{mta_called=}, {mta_kernel_called=}, {mta_launch_marker_called=}, {expect_fastpath=}, {zero_size=}, {self.func.__name__=}, {keys=}"
                 )
         else:
             actual = self.func(*inputs, **kwargs)

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -96,11 +96,18 @@ class ForeachFuncWrapper:
                 # synchronize within the profiler context to make sure events happen before exiting
                 torch.cuda.synchronize()
             keys = tuple([e.key for e in p.key_averages()])
-            mta_called = any("multi_tensor_apply_kernel" in k for k in keys)
+            mta_kernel_called = any("multi_tensor_apply_kernel" in k for k in keys)
+            # Explicitly track MTA launch on ROCm via RECORD_FUNCTION in
+            # MultiTensorApply.cuh to avoid dependence on ROCm kernel
+            # symbolization.
+            mta_launch_marker_called = TEST_WITH_ROCM and any(
+                "_foreach_mta_launch" in k for k in keys
+            )
+            mta_called = mta_kernel_called or mta_launch_marker_called
 
             if mta_called != (expect_fastpath and (not zero_size)):
                 raise AssertionError(
-                    f"{mta_called=}, {expect_fastpath=}, {zero_size=}, {self.func.__name__=}, {keys=}"
+                    f"{mta_called=}, {mta_kernel_called=}, {mta_launch_marker_called=}, {expect_fastpath=}, {zero_size=}, {self.func.__name__=}, {keys=}"
                 )
         else:
             actual = self.func(*inputs, **kwargs)


### PR DESCRIPTION
`test/test_foreach.py` currently decides whether foreach fastpath was used by checking for the profiler key multi_tensor_apply_kernel. On ROCm, profiler traces can intermittently report generic HIP launch events without consistently preserving that specific kernel symbol, which produces false failures where the test reports mta_called=False even though fastpath execution is correct. 

This change adds a ROCm-only RECORD_FUNCTION("aten::_foreach_mta_launch", {}) marker at MultiTensorApply kernel launch points and updates the foreach test logic to accept either the original kernel symbol or this explicit marker as proof of fastpath. The change is intentionally scoped to ROCm (USE_ROCM / TEST_WITH_ROCM) to minimize behavior changes outside the affected platform while keeping the test strict against real fastpath regressions.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang