### PR TITLE
[dynamo] follow up source attribution review comments

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -196,6 +196,11 @@ def _skip_frame_in_loop_message_stack_source_attribution() -> str:
     )
 
 
+def _munge_graph_break_message(message: str) -> str:
+    munged = munge_exc(message, suppress_suffix=True, skip=0)
+    return re.sub(r"^[ ]+(\^+)$", r"\1", munged, flags=re.MULTILINE)
+
+
 class ErrorMessagesTest(LoggingTestCase):
     def test_dynamic_shape_operator_no_meta_kernel(self):
         def fn():
@@ -735,8 +740,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -896,10 +901,8 @@ User code traceback:
 """
         )
 
-        self.assertExpectedInline(
-            post_munge(
-                munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0)
-            ),
+        self.assertEqual(
+            post_munge(_munge_graph_break_message(records[1].getMessage())),
             expected,
         )
 
@@ -1137,8 +1140,8 @@ User code traceback:
     assert x is None  # noqa: S101
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -1287,8 +1290,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -1343,8 +1346,8 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[1].getMessage()),
             expected,
         )
 
@@ -1389,8 +1392,8 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -2392,8 +2395,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
         self.assertExpectedInline(
@@ -2478,8 +2481,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -2536,8 +2539,8 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -61,34 +61,38 @@ def _get_iter_has_positions() -> bool:
 
 
 def _generic_ctx_mgr_stack_source_attribution() -> str:
-    if sys.version_info >= (3, 11):
-        caret = "^^^^^^^^^^^^^^^\n"
+    if sys.version_info >= (3, 14):
+        marker = "~~~~~~~~~~~~~^^\n"
+    elif sys.version_info >= (3, 11):
+        marker = "^^^^^^^^^^^^^^^\n"
     else:
-        caret = ""
+        marker = ""
     return (
         "Stack variable source attribution:\n"
         "  WithExitFunctionVariable() originated from:\n"
         '  File "test_error_messages.py", line N\n'
         "                with GenericCtxMgr():\n"
-        f"{caret}"
+        f"{marker}"
         "  WithExitFunctionVariable() originated from:\n"
         '  File "test_error_messages.py", line N\n'
         "                    with GenericCtxMgr():\n"
-        f"{caret}"
+        f"{marker}"
     )
 
 
 def _assert_failure_stack_source_attribution() -> str:
-    if sys.version_info >= (3, 11):
-        caret = "^^^^^^^^^^^^^^^\n"
+    if sys.version_info >= (3, 14):
+        marker = "~~~~~~~~~~~~~^^\n"
+    elif sys.version_info >= (3, 11):
+        marker = "^^^^^^^^^^^^^^^\n"
     else:
-        caret = ""
+        marker = ""
     return (
         "Stack variable source attribution:\n"
         "  WithExitFunctionVariable() originated from:\n"
         '  File "test_error_messages.py", line N\n'
         "                with GenericCtxMgr():\n"
-        f"{caret}"
+        f"{marker}"
     )
 
 
@@ -178,12 +182,16 @@ def _reconstruction_failure_gb_stack_source_attribution() -> str:
 
 def _graph_break_in_loop_stack_source_attribution() -> str:
     if sys.version_info >= (3, 11) and _get_iter_has_positions():
+        if sys.version_info >= (3, 14):
+            marker = "~~~~~^^^\n"
+        else:
+            marker = "^^^^^^^^\n"
         return (
             "Stack variable source attribution:\n"
             "  RangeIteratorVariable() originated from:\n"
             '  File "test_error_messages.py", line N\n'
             "                for i in range(2):\n"
-            "^^^^^^^^\n"
+            f"{marker}"
             "\n"
         )
 
@@ -201,16 +209,22 @@ def _graph_break_in_loop_stack_source_attribution() -> str:
 
 def _skip_frame_in_loop_message_stack_source_attribution() -> str:
     if sys.version_info >= (3, 11) and _get_iter_has_positions():
+        if sys.version_info >= (3, 14):
+            range_marker = "~~~~~^^^\n"
+            ctx_mgr_marker = "~~~~~~~~~~~~~^^\n"
+        else:
+            range_marker = "^^^^^^^^\n"
+            ctx_mgr_marker = "^^^^^^^^^^^^^^^\n"
         return (
             "Stack variable source attribution:\n"
             "  RangeIteratorVariable() originated from:\n"
             '  File "test_error_messages.py", line N\n'
             "                for i in range(2):\n"
-            "^^^^^^^^\n"
+            f"{range_marker}"
             "  WithExitFunctionVariable() originated from:\n"
             '  File "test_error_messages.py", line N\n'
             "                    with GenericCtxMgr():\n"
-            "^^^^^^^^^^^^^^^\n"
+            f"{ctx_mgr_marker}"
             "\n"
         )
 
@@ -229,15 +243,9 @@ def _skip_frame_in_loop_message_stack_source_attribution() -> str:
     )
 
 
-def _munge_graph_break_message_with_normalized_markers(message: str) -> str:
+def _munge_graph_break_message(message: str) -> str:
     munged = munge_exc(message, suppress_suffix=True, skip=0)
-    # CPython 3.13+ can use mixed `~`/`^` marker lines for the same source span.
-    return re.sub(
-        r"^[ ]+([~^]+)$",
-        lambda match: "^" * len(match.group(1)),
-        munged,
-        flags=re.MULTILINE,
-    )
+    return re.sub(r"^[ ]+([~^]+)$", r"\1", munged, flags=re.MULTILINE)
 
 
 class ErrorMessagesTest(LoggingTestCase):
@@ -772,8 +780,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -933,11 +941,9 @@ User code traceback:
 """
         )
 
-        self.assertEqual(
+        self.assertExpectedInline(
             post_munge(
-                _munge_graph_break_message_with_normalized_markers(
-                    records[1].getMessage()
-                )
+                _munge_graph_break_message(records[1].getMessage())
             ),
             expected,
         )
@@ -1176,8 +1182,8 @@ User code traceback:
     assert x is None  # noqa: S101
 """
         )
-        self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -1331,8 +1337,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -1387,8 +1393,8 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(records[1].getMessage()),
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[1].getMessage()),
             expected,
         )
 
@@ -1433,8 +1439,8 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -2436,8 +2442,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
         self.assertExpectedInline(
@@ -2522,8 +2528,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -2580,8 +2586,8 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -60,29 +60,6 @@ def _get_iter_has_positions() -> bool:
     return False
 
 
-def _generic_ctx_mgr_stack_source_attribution() -> str:
-    return (
-        "Stack variable source attribution:\n"
-        "  WithExitFunctionVariable() originated from:\n"
-        '  File "test_error_messages.py", line N\n'
-        "                with GenericCtxMgr():\n"
-        "  WithExitFunctionVariable() originated from:\n"
-        '  File "test_error_messages.py", line N\n'
-        "                    with GenericCtxMgr():\n"
-        "\n"
-    )
-
-
-def _assert_failure_stack_source_attribution() -> str:
-    return (
-        "Stack variable source attribution:\n"
-        "  WithExitFunctionVariable() originated from:\n"
-        '  File "test_error_messages.py", line N\n'
-        "                with GenericCtxMgr():\n"
-        "\n"
-    )
-
-
 @lru_cache(None)
 def _compile_wrapper_raise_source() -> str:
     source = "def f():\n    raise RuntimeError(\n        None\n    )\n"

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -194,7 +194,13 @@ def _skip_frame_in_loop_message_stack_source_attribution() -> str:
 
 def _munge_graph_break_message(message: str) -> str:
     munged = munge_exc(message, suppress_suffix=True, skip=0)
-    return re.sub(r"(?m)^[ ]*[~^]+\n?", "", munged)
+    munged = re.sub(r"(?m)^[ ]*[~^]+\n?", "", munged)
+    return re.sub(
+        r'(?m)(^  File "test_error_messages.py", line N\n[ ]{12,}.*\n)'
+        r"(?:[ ]{12,}.*\n)+",
+        r"\1",
+        munged,
+    )
 
 
 class ErrorMessagesTest(LoggingTestCase):
@@ -1157,41 +1163,9 @@ User code traceback:
 
         # only 1 graph break message
         self.assertEqual(len(records), 1)
-        if sys.version_info[:2] == (3, 11):
-            self.assertExpectedInline(
-                _munge_graph_break_message(records[0].getMessage()),
-                """\
-Graph break in user code at test_error_messages.py:N
-Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
-
-Data-dependent assertion failed (cannot compile partial graph)
-  Explanation: Dynamo has determined when encountering a data-dependent assert failure that it should not compile the partial graph.
-  Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
-  Hint: Use `torch._assert()` to raise a hard AssertionError when the check fails. This error will propagate back the user code that called the compiled function (i.e. Dynamo will not trace any exception handling).
-  Hint: Remove the assert statement.
-  Hint: Move the assert statement outside of any context managers in order to graph break with partial graph compilation (if fullgraph=False).
-
-  Developer debug context: value: ConstantVariable(bool: False)
-
- For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0034.html
-
-Stack variable source attribution:
-  WithExitFunctionVariable() originated from:
-  File "test_error_messages.py", line N
-                with GenericCtxMgr():
-                    assert x is None  # noqa: S101
-
-User code traceback:
-  File "test_error_messages.py", line N, in test_assert_failure_in_generic_ctx_mgr
-    torch.compile(fn, backend="eager")(torch.randn(3))
-  File "test_error_messages.py", line N, in fn
-    assert x is None  # noqa: S101
-""",
-            )
-        else:
-            self.assertExpectedInline(
-                _munge_graph_break_message(records[0].getMessage()),
-                """\
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
+            """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
 
@@ -1217,7 +1191,7 @@ User code traceback:
   File "test_error_messages.py", line N, in fn
     assert x is None  # noqa: S101
 """,
-            )
+        )
 
     def test_no_internal_compiler_stacktrace(self):
         def fn():

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -194,7 +194,7 @@ def _skip_frame_in_loop_message_stack_source_attribution() -> str:
 
 def _munge_graph_break_message(message: str) -> str:
     munged = munge_exc(message, suppress_suffix=True, skip=0)
-    return re.sub(r"\n[ ]*[~^]+\n", "\n", munged)
+    return re.sub(r"(?m)^[ ]*[~^]+\n?", "", munged)
 
 
 class ErrorMessagesTest(LoggingTestCase):
@@ -1157,9 +1157,41 @@ User code traceback:
 
         # only 1 graph break message
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            """\
+        if sys.version_info[:2] == (3, 11):
+            self.assertExpectedInline(
+                _munge_graph_break_message(records[0].getMessage()),
+                """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
+
+Data-dependent assertion failed (cannot compile partial graph)
+  Explanation: Dynamo has determined when encountering a data-dependent assert failure that it should not compile the partial graph.
+  Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
+  Hint: Use `torch._assert()` to raise a hard AssertionError when the check fails. This error will propagate back the user code that called the compiled function (i.e. Dynamo will not trace any exception handling).
+  Hint: Remove the assert statement.
+  Hint: Move the assert statement outside of any context managers in order to graph break with partial graph compilation (if fullgraph=False).
+
+  Developer debug context: value: ConstantVariable(bool: False)
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0034.html
+
+Stack variable source attribution:
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                with GenericCtxMgr():
+                    assert x is None  # noqa: S101
+
+User code traceback:
+  File "test_error_messages.py", line N, in test_assert_failure_in_generic_ctx_mgr
+    torch.compile(fn, backend="eager")(torch.randn(3))
+  File "test_error_messages.py", line N, in fn
+    assert x is None  # noqa: S101
+""",
+            )
+        else:
+            self.assertExpectedInline(
+                _munge_graph_break_message(records[0].getMessage()),
+                """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
 
@@ -1185,7 +1217,7 @@ User code traceback:
   File "test_error_messages.py", line N, in fn
     assert x is None  # noqa: S101
 """,
-        )
+            )
 
     def test_no_internal_compiler_stacktrace(self):
         def fn():

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -734,6 +734,7 @@ from user code:
         )
 
     @make_logging_test(graph_breaks=True)
+    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_generic_ctx_mgr_graph_break_fullgraph_false(self, records):
         def fn():
             with GenericCtxMgr():
@@ -746,7 +747,8 @@ from user code:
 
         torch.compile(fn, backend="eager")()
         self.assertEqual(len(records), 1)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -770,19 +772,22 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
-"""
-            + _generic_ctx_mgr_stack_source_attribution()
-            + """
+Stack variable source attribution:
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                with GenericCtxMgr():
+~~~~~~~~~~~~~^^
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                    with GenericCtxMgr():
+~~~~~~~~~~~~~^^
+
 User code traceback:
   File "test_error_messages.py", line N, in test_generic_ctx_mgr_graph_break_fullgraph_false
     torch.compile(fn, backend="eager")()
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
+""",
         )
 
     def test_load_build_class(self):
@@ -876,6 +881,7 @@ from user code:
         )
 
     @make_logging_test(graph_breaks=True)
+    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_reconstruction_failure_gb(self, records):
         class Foo:
             def meth(self):
@@ -915,7 +921,8 @@ User code traceback:
 """,
         )
 
-        expected = (
+        self.assertExpectedInline(
+            post_munge(_munge_graph_break_message(records[1].getMessage())),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -930,20 +937,18 @@ Reconstruction failure
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0092.html
 
-"""
-            + _reconstruction_failure_gb_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  LazyVariableTracker(realized: SkipFunctionVariable()) originated from:
+  File "test_error_messages.py", line N
+                torch._dynamo.graph_break()
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
 User code traceback:
   File "test_error_messages.py", line N, in test_reconstruction_failure_gb
     torch.compile(fn, backend="eager")()
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-"""
-        )
-
-        self.assertExpectedInline(
-            post_munge(_munge_graph_break_message(records[1].getMessage())),
-            expected,
+""",
         )
 
     def test_faketensor_nyi(self):
@@ -1144,6 +1149,7 @@ User code traceback:
 
     @unittest.skipIf(IS_FBCODE, "assert gets patched in internal pytest")
     @make_logging_test(graph_breaks=True)
+    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_assert_failure_in_generic_ctx_mgr(self, records):
         def fn(x):
             with GenericCtxMgr():
@@ -1154,7 +1160,8 @@ User code traceback:
 
         # only 1 graph break message
         self.assertEqual(len(records), 1)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1170,19 +1177,18 @@ Data-dependent assertion failed (cannot compile partial graph)
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0034.html
 
-"""
-            + _assert_failure_stack_source_attribution()
-            + """
+Stack variable source attribution:
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                with GenericCtxMgr():
+~~~~~~~~~~~~~^^
+
 User code traceback:
   File "test_error_messages.py", line N, in test_assert_failure_in_generic_ctx_mgr
     torch.compile(fn, backend="eager")(torch.randn(3))
   File "test_error_messages.py", line N, in fn
     assert x is None  # noqa: S101
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
+""",
         )
 
     def test_no_internal_compiler_stacktrace(self):
@@ -1293,6 +1299,7 @@ from user code:
         )
 
     @make_logging_test(graph_breaks=True)
+    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_graph_break_in_loop(self, records):
         @torch.compile(backend="eager")
         def fn(x):
@@ -1302,7 +1309,8 @@ from user code:
 
         fn(torch.ones(3))
         self.assertEqual(len(records), 1)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1325,19 +1333,18 @@ graph break in loop
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb7000.html
 
-"""
-            + _graph_break_in_loop_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  RangeIteratorVariable() originated from:
+  File "test_error_messages.py", line N
+                for i in range(2):
+~~~~~^^^
+
 User code traceback:
   File "test_error_messages.py", line N, in test_graph_break_in_loop
     fn(torch.ones(3))
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
+""",
         )
 
         @torch.compile(backend="eager")
@@ -1351,7 +1358,8 @@ User code traceback:
 
         gn(torch.ones(3))
         self.assertEqual(len(records), 2)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[1].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1381,22 +1389,22 @@ graph break in loop
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb7000.html
 
-"""
-            + _graph_break_in_loop_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  RangeIteratorVariable() originated from:
+  File "test_error_messages.py", line N
+                for i in range(2):
+~~~~~^^^
+
 User code traceback:
   File "test_error_messages.py", line N, in test_graph_break_in_loop
     gn(torch.ones(3))
   File "test_error_messages.py", line N, in gn
     if x.sum() > 0:
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[1].getMessage()),
-            expected,
+""",
         )
 
     @make_logging_test(graph_breaks=True)
+    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_skip_frame_in_loop_message(self, records):
         def fn(x):
             for i in range(2):
@@ -1407,7 +1415,8 @@ User code traceback:
 
         torch.compile(fn, backend="eager")(torch.randn(3))
         self.assertEqual(len(records), 1)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1427,19 +1436,22 @@ Data-dependent branching
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
 
-"""
-            + _skip_frame_in_loop_message_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  RangeIteratorVariable() originated from:
+  File "test_error_messages.py", line N
+                for i in range(2):
+~~~~~^^^
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                    with GenericCtxMgr():
+~~~~~~~~~~~~~^^
+
 User code traceback:
   File "test_error_messages.py", line N, in test_skip_frame_in_loop_message
     torch.compile(fn, backend="eager")(torch.randn(3))
   File "test_error_messages.py", line N, in fn
     if x.sum() > 0:
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
+""",
         )
 
     @make_logging_test(dynamo=logging.DEBUG)
@@ -2378,6 +2390,7 @@ Dynamo recompile limit exceeded
             )
 
     @make_logging_test(graph_breaks=True)
+    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_nested_generic_ctx_mgr(self, records):
         def inner():
             with GenericCtxMgr():
@@ -2392,7 +2405,8 @@ Dynamo recompile limit exceeded
 
         torch.compile(fn, backend="eager")()
         self.assertEqual(len(records), 2)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -2427,9 +2441,15 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
-"""
-            + _generic_ctx_mgr_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                with GenericCtxMgr():
+~~~~~~~~~~~~~^^
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                    with GenericCtxMgr():
+~~~~~~~~~~~~~^^
 
 User code traceback:
   File "test_error_messages.py", line N, in test_nested_generic_ctx_mgr
@@ -2438,11 +2458,7 @@ User code traceback:
     inner()
   File "test_error_messages.py", line N, in inner
     torch._dynamo.graph_break()
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
+""",
         )
         self.assertExpectedInline(
             munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0),
@@ -2471,6 +2487,7 @@ Graph break under GenericContextWrappingVariable
         )
 
     @make_logging_test(graph_breaks=True)
+    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_skipped_frame_with_verbose_traceback_nested(self, records):
         global f1, f2, f3
 
@@ -2487,7 +2504,8 @@ Graph break under GenericContextWrappingVariable
 
         torch.compile(f3, backend="eager")(torch.randn(3))
         self.assertEqual(len(records), 1)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
@@ -2511,9 +2529,11 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
-"""
-            + _assert_failure_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                with GenericCtxMgr():
+~~~~~~~~~~~~~^^
 
 User code traceback:
   File "test_error_messages.py", line N, in test_skipped_frame_with_verbose_traceback_nested
@@ -2524,14 +2544,11 @@ User code traceback:
     return f1(x + 2)
   File "test_error_messages.py", line N, in f1
     torch._dynamo.graph_break()
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
+""",
         )
 
     @make_logging_test(graph_breaks=True)
+    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_skip_frame_in_loop_message_nested(self, records):
         global f1, f2, f3
 
@@ -2550,7 +2567,8 @@ User code traceback:
 
         result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
         self.assertEqual(len(records), 1)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
@@ -2570,9 +2588,16 @@ Data-dependent branching
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
 
-"""
-            + _skip_frame_in_loop_message_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  RangeIteratorVariable() originated from:
+  File "test_error_messages.py", line N
+                for i in range(2):
+~~~~~^^^
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                    with GenericCtxMgr():
+~~~~~~~~~~~~~^^
+
 User code traceback:
   File "test_error_messages.py", line N, in test_skip_frame_in_loop_message_nested
     result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
@@ -2582,11 +2607,7 @@ User code traceback:
     return f1(x + 4)
   File "test_error_messages.py", line N, in f1
     if x.sum() > 0:
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
+""",
         )
 
     @make_logging_test(graph_breaks=True)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -61,38 +61,25 @@ def _get_iter_has_positions() -> bool:
 
 
 def _generic_ctx_mgr_stack_source_attribution() -> str:
-    if sys.version_info >= (3, 14):
-        marker = "~~~~~~~~~~~~~^^\n"
-    elif sys.version_info >= (3, 11):
-        marker = "^^^^^^^^^^^^^^^\n"
-    else:
-        marker = ""
     return (
         "Stack variable source attribution:\n"
         "  WithExitFunctionVariable() originated from:\n"
         '  File "test_error_messages.py", line N\n'
         "                with GenericCtxMgr():\n"
-        f"{marker}"
         "  WithExitFunctionVariable() originated from:\n"
         '  File "test_error_messages.py", line N\n'
         "                    with GenericCtxMgr():\n"
-        f"{marker}"
+        "\n"
     )
 
 
 def _assert_failure_stack_source_attribution() -> str:
-    if sys.version_info >= (3, 14):
-        marker = "~~~~~~~~~~~~~^^\n"
-    elif sys.version_info >= (3, 11):
-        marker = "^^^^^^^^^^^^^^^\n"
-    else:
-        marker = ""
     return (
         "Stack variable source attribution:\n"
         "  WithExitFunctionVariable() originated from:\n"
         '  File "test_error_messages.py", line N\n'
         "                with GenericCtxMgr():\n"
-        f"{marker}"
+        "\n"
     )
 
 
@@ -154,7 +141,6 @@ def _reconstruction_failure_gb_stack_source_attribution() -> str:
             f"  {var_repr}\n"
             '  File "test_error_messages.py", line N\n'
             "                torch._dynamo.graph_break()\n"
-            "^^^^^^^^^^^^^^^^^^^^^^^^^\n"
             "\n"
         )
 
@@ -164,7 +150,6 @@ def _reconstruction_failure_gb_stack_source_attribution() -> str:
             f"  {var_repr}\n"
             '  File "test_error_messages.py", line N\n'
             "                torch._dynamo.graph_break()\n"
-            "^^^^^^^^^^^^^^^^^^^^^^^^^\n"
             "\n"
         )
 
@@ -182,16 +167,11 @@ def _reconstruction_failure_gb_stack_source_attribution() -> str:
 
 def _graph_break_in_loop_stack_source_attribution() -> str:
     if sys.version_info >= (3, 11) and _get_iter_has_positions():
-        if sys.version_info >= (3, 14):
-            marker = "~~~~~^^^\n"
-        else:
-            marker = "^^^^^^^^\n"
         return (
             "Stack variable source attribution:\n"
             "  RangeIteratorVariable() originated from:\n"
             '  File "test_error_messages.py", line N\n'
             "                for i in range(2):\n"
-            f"{marker}"
             "\n"
         )
 
@@ -209,22 +189,14 @@ def _graph_break_in_loop_stack_source_attribution() -> str:
 
 def _skip_frame_in_loop_message_stack_source_attribution() -> str:
     if sys.version_info >= (3, 11) and _get_iter_has_positions():
-        if sys.version_info >= (3, 14):
-            range_marker = "~~~~~^^^\n"
-            ctx_mgr_marker = "~~~~~~~~~~~~~^^\n"
-        else:
-            range_marker = "^^^^^^^^\n"
-            ctx_mgr_marker = "^^^^^^^^^^^^^^^\n"
         return (
             "Stack variable source attribution:\n"
             "  RangeIteratorVariable() originated from:\n"
             '  File "test_error_messages.py", line N\n'
             "                for i in range(2):\n"
-            f"{range_marker}"
             "  WithExitFunctionVariable() originated from:\n"
             '  File "test_error_messages.py", line N\n'
             "                    with GenericCtxMgr():\n"
-            f"{ctx_mgr_marker}"
             "\n"
         )
 
@@ -245,7 +217,7 @@ def _skip_frame_in_loop_message_stack_source_attribution() -> str:
 
 def _munge_graph_break_message(message: str) -> str:
     munged = munge_exc(message, suppress_suffix=True, skip=0)
-    return re.sub(r"^[ ]+([~^]+)$", r"\1", munged, flags=re.MULTILINE)
+    return re.sub(r"\n[ ]*[~^]+\n", "\n", munged)
 
 
 class ErrorMessagesTest(LoggingTestCase):
@@ -734,7 +706,6 @@ from user code:
         )
 
     @make_logging_test(graph_breaks=True)
-    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_generic_ctx_mgr_graph_break_fullgraph_false(self, records):
         def fn():
             with GenericCtxMgr():
@@ -747,8 +718,7 @@ from user code:
 
         torch.compile(fn, backend="eager")()
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -772,22 +742,19 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
-Stack variable source attribution:
-  WithExitFunctionVariable() originated from:
-  File "test_error_messages.py", line N
-                with GenericCtxMgr():
-~~~~~~~~~~~~~^^
-  WithExitFunctionVariable() originated from:
-  File "test_error_messages.py", line N
-                    with GenericCtxMgr():
-~~~~~~~~~~~~~^^
-
+"""
+            + _generic_ctx_mgr_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_generic_ctx_mgr_graph_break_fullgraph_false
     torch.compile(fn, backend="eager")()
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-""",
+"""
+        )
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
+            expected,
         )
 
     def test_load_build_class(self):
@@ -881,7 +848,6 @@ from user code:
         )
 
     @make_logging_test(graph_breaks=True)
-    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_reconstruction_failure_gb(self, records):
         class Foo:
             def meth(self):
@@ -921,8 +887,7 @@ User code traceback:
 """,
         )
 
-        self.assertExpectedInline(
-            post_munge(_munge_graph_break_message(records[1].getMessage())),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -937,18 +902,19 @@ Reconstruction failure
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0092.html
 
-Stack variable source attribution:
-  LazyVariableTracker(realized: SkipFunctionVariable()) originated from:
-  File "test_error_messages.py", line N
-                torch._dynamo.graph_break()
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
+"""
+            + _reconstruction_failure_gb_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_reconstruction_failure_gb
     torch.compile(fn, backend="eager")()
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-""",
+"""
+        )
+        self.assertExpectedInline(
+            post_munge(_munge_graph_break_message(records[1].getMessage())),
+            expected,
         )
 
     def test_faketensor_nyi(self):
@@ -1149,7 +1115,6 @@ User code traceback:
 
     @unittest.skipIf(IS_FBCODE, "assert gets patched in internal pytest")
     @make_logging_test(graph_breaks=True)
-    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_assert_failure_in_generic_ctx_mgr(self, records):
         def fn(x):
             with GenericCtxMgr():
@@ -1160,8 +1125,7 @@ User code traceback:
 
         # only 1 graph break message
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1177,18 +1141,19 @@ Data-dependent assertion failed (cannot compile partial graph)
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0034.html
 
-Stack variable source attribution:
-  WithExitFunctionVariable() originated from:
-  File "test_error_messages.py", line N
-                with GenericCtxMgr():
-~~~~~~~~~~~~~^^
-
+"""
+            + _assert_failure_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_assert_failure_in_generic_ctx_mgr
     torch.compile(fn, backend="eager")(torch.randn(3))
   File "test_error_messages.py", line N, in fn
     assert x is None  # noqa: S101
-""",
+"""
+        )
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
+            expected,
         )
 
     def test_no_internal_compiler_stacktrace(self):
@@ -1299,7 +1264,6 @@ from user code:
         )
 
     @make_logging_test(graph_breaks=True)
-    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_graph_break_in_loop(self, records):
         @torch.compile(backend="eager")
         def fn(x):
@@ -1309,8 +1273,7 @@ from user code:
 
         fn(torch.ones(3))
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1333,18 +1296,19 @@ graph break in loop
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb7000.html
 
-Stack variable source attribution:
-  RangeIteratorVariable() originated from:
-  File "test_error_messages.py", line N
-                for i in range(2):
-~~~~~^^^
-
+"""
+            + _graph_break_in_loop_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_graph_break_in_loop
     fn(torch.ones(3))
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-""",
+"""
+        )
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
+            expected,
         )
 
         @torch.compile(backend="eager")
@@ -1358,8 +1322,7 @@ User code traceback:
 
         gn(torch.ones(3))
         self.assertEqual(len(records), 2)
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[1].getMessage()),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1389,22 +1352,22 @@ graph break in loop
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb7000.html
 
-Stack variable source attribution:
-  RangeIteratorVariable() originated from:
-  File "test_error_messages.py", line N
-                for i in range(2):
-~~~~~^^^
-
+"""
+            + _graph_break_in_loop_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_graph_break_in_loop
     gn(torch.ones(3))
   File "test_error_messages.py", line N, in gn
     if x.sum() > 0:
-""",
+"""
+        )
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[1].getMessage()),
+            expected,
         )
 
     @make_logging_test(graph_breaks=True)
-    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_skip_frame_in_loop_message(self, records):
         def fn(x):
             for i in range(2):
@@ -1415,8 +1378,7 @@ User code traceback:
 
         torch.compile(fn, backend="eager")(torch.randn(3))
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1436,22 +1398,19 @@ Data-dependent branching
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
 
-Stack variable source attribution:
-  RangeIteratorVariable() originated from:
-  File "test_error_messages.py", line N
-                for i in range(2):
-~~~~~^^^
-  WithExitFunctionVariable() originated from:
-  File "test_error_messages.py", line N
-                    with GenericCtxMgr():
-~~~~~~~~~~~~~^^
-
+"""
+            + _skip_frame_in_loop_message_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_skip_frame_in_loop_message
     torch.compile(fn, backend="eager")(torch.randn(3))
   File "test_error_messages.py", line N, in fn
     if x.sum() > 0:
-""",
+"""
+        )
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
+            expected,
         )
 
     @make_logging_test(dynamo=logging.DEBUG)
@@ -2390,7 +2349,6 @@ Dynamo recompile limit exceeded
             )
 
     @make_logging_test(graph_breaks=True)
-    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_nested_generic_ctx_mgr(self, records):
         def inner():
             with GenericCtxMgr():
@@ -2405,8 +2363,7 @@ Dynamo recompile limit exceeded
 
         torch.compile(fn, backend="eager")()
         self.assertEqual(len(records), 2)
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -2441,16 +2398,9 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
-Stack variable source attribution:
-  WithExitFunctionVariable() originated from:
-  File "test_error_messages.py", line N
-                with GenericCtxMgr():
-~~~~~~~~~~~~~^^
-  WithExitFunctionVariable() originated from:
-  File "test_error_messages.py", line N
-                    with GenericCtxMgr():
-~~~~~~~~~~~~~^^
-
+"""
+            + _generic_ctx_mgr_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_nested_generic_ctx_mgr
     torch.compile(fn, backend="eager")()
@@ -2458,7 +2408,11 @@ User code traceback:
     inner()
   File "test_error_messages.py", line N, in inner
     torch._dynamo.graph_break()
-""",
+"""
+        )
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
+            expected,
         )
         self.assertExpectedInline(
             munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0),
@@ -2487,7 +2441,6 @@ Graph break under GenericContextWrappingVariable
         )
 
     @make_logging_test(graph_breaks=True)
-    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_skipped_frame_with_verbose_traceback_nested(self, records):
         global f1, f2, f3
 
@@ -2504,8 +2457,7 @@ Graph break under GenericContextWrappingVariable
 
         torch.compile(f3, backend="eager")(torch.randn(3))
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
@@ -2529,12 +2481,9 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
-Stack variable source attribution:
-  WithExitFunctionVariable() originated from:
-  File "test_error_messages.py", line N
-                with GenericCtxMgr():
-~~~~~~~~~~~~~^^
-
+"""
+            + _assert_failure_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_skipped_frame_with_verbose_traceback_nested
     torch.compile(f3, backend="eager")(torch.randn(3))
@@ -2544,11 +2493,14 @@ User code traceback:
     return f1(x + 2)
   File "test_error_messages.py", line N, in f1
     torch._dynamo.graph_break()
-""",
+"""
+        )
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
+            expected,
         )
 
     @make_logging_test(graph_breaks=True)
-    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_skip_frame_in_loop_message_nested(self, records):
         global f1, f2, f3
 
@@ -2567,8 +2519,7 @@ User code traceback:
 
         result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
         self.assertEqual(len(records), 1)
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
+        expected = (
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
@@ -2588,16 +2539,9 @@ Data-dependent branching
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
 
-Stack variable source attribution:
-  RangeIteratorVariable() originated from:
-  File "test_error_messages.py", line N
-                for i in range(2):
-~~~~~^^^
-  WithExitFunctionVariable() originated from:
-  File "test_error_messages.py", line N
-                    with GenericCtxMgr():
-~~~~~~~~~~~~~^^
-
+"""
+            + _skip_frame_in_loop_message_stack_source_attribution()
+            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_skip_frame_in_loop_message_nested
     result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
@@ -2607,7 +2551,11 @@ User code traceback:
     return f1(x + 4)
   File "test_error_messages.py", line N, in f1
     if x.sum() > 0:
-""",
+"""
+        )
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
+            expected,
         )
 
     @make_logging_test(graph_breaks=True)

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -752,7 +752,7 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertEqual(
+        self.assertExpectedInline(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -912,7 +912,7 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertEqual(
+        self.assertExpectedInline(
             post_munge(_munge_graph_break_message(records[1].getMessage())),
             expected,
         )
@@ -1151,7 +1151,7 @@ User code traceback:
     assert x is None  # noqa: S101
 """
         )
-        self.assertEqual(
+        self.assertExpectedInline(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -1306,7 +1306,7 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertEqual(
+        self.assertExpectedInline(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -1362,7 +1362,7 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertEqual(
+        self.assertExpectedInline(
             _munge_graph_break_message(records[1].getMessage()),
             expected,
         )
@@ -1408,7 +1408,7 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertEqual(
+        self.assertExpectedInline(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -2410,7 +2410,7 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertEqual(
+        self.assertExpectedInline(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -2495,7 +2495,7 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertEqual(
+        self.assertExpectedInline(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -2553,7 +2553,7 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertEqual(
+        self.assertExpectedInline(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -773,9 +773,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 
@@ -1179,9 +1177,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 
@@ -1336,9 +1332,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 
@@ -1394,9 +1388,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[1].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[1].getMessage()),
             expected,
         )
 
@@ -1442,9 +1434,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 
@@ -2447,9 +2437,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
         self.assertExpectedInline(
@@ -2535,9 +2523,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 
@@ -2595,9 +2581,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -229,9 +229,15 @@ def _skip_frame_in_loop_message_stack_source_attribution() -> str:
     )
 
 
-def _munge_graph_break_message(message: str) -> str:
+def _munge_graph_break_message_with_normalized_markers(message: str) -> str:
     munged = munge_exc(message, suppress_suffix=True, skip=0)
-    return re.sub(r"^[ ]+(\^+)$", r"\1", munged, flags=re.MULTILINE)
+    # CPython 3.13+ can use mixed `~`/`^` marker lines for the same source span.
+    return re.sub(
+        r"^[ ]+([~^]+)$",
+        lambda match: "^" * len(match.group(1)),
+        munged,
+        flags=re.MULTILINE,
+    )
 
 
 class ErrorMessagesTest(LoggingTestCase):
@@ -767,7 +773,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 
@@ -928,7 +936,11 @@ User code traceback:
         )
 
         self.assertEqual(
-            post_munge(_munge_graph_break_message(records[1].getMessage())),
+            post_munge(
+                _munge_graph_break_message_with_normalized_markers(
+                    records[1].getMessage()
+                )
+            ),
             expected,
         )
 
@@ -1167,7 +1179,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 
@@ -1322,7 +1336,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 
@@ -1378,7 +1394,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[1].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[1].getMessage()
+            ),
             expected,
         )
 
@@ -1424,7 +1442,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 
@@ -2427,7 +2447,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
         self.assertExpectedInline(
@@ -2513,7 +2535,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 
@@ -2571,7 +2595,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -747,9 +747,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 
@@ -1153,9 +1151,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 
@@ -1305,9 +1301,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 
@@ -1363,9 +1357,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[1].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[1].getMessage()),
             expected,
         )
 
@@ -1411,9 +1403,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 
@@ -2416,9 +2406,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
         self.assertExpectedInline(
@@ -2504,9 +2492,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 
@@ -2564,9 +2550,7 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message_with_normalized_markers(
-                records[0].getMessage()
-            ),
+            _munge_graph_break_message_with_normalized_markers(records[0].getMessage()),
             expected,
         )
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -718,7 +718,8 @@ from user code:
 
         torch.compile(fn, backend="eager")()
         self.assertEqual(len(records), 1)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -742,19 +743,20 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
-"""
-            + _generic_ctx_mgr_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                with GenericCtxMgr():
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                    with GenericCtxMgr():
+
 User code traceback:
   File "test_error_messages.py", line N, in test_generic_ctx_mgr_graph_break_fullgraph_false
     torch.compile(fn, backend="eager")()
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
+""",
         )
 
     def test_load_build_class(self):
@@ -887,8 +889,10 @@ User code traceback:
 """,
         )
 
-        expected = (
-            """\
+        if sys.version_info >= (3, 14) or sys.version_info < (3, 11):
+            self.assertExpectedInline(
+                post_munge(_munge_graph_break_message(records[1].getMessage())),
+                """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
 
@@ -902,20 +906,71 @@ Reconstruction failure
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0092.html
 
-"""
-            + _reconstruction_failure_gb_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  LazyVariableTracker(realized: SkipFunctionVariable()) originated from:
+  File "test_error_messages.py", line N
+                torch._dynamo.graph_break()
+
 User code traceback:
   File "test_error_messages.py", line N, in test_reconstruction_failure_gb
     torch.compile(fn, backend="eager")()
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-"""
-        )
-        self.assertExpectedInline(
-            post_munge(_munge_graph_break_message(records[1].getMessage())),
-            expected,
-        )
+""",
+            )
+        elif _load_global_has_positions():
+            self.assertExpectedInline(
+                post_munge(_munge_graph_break_message(records[1].getMessage())),
+                """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
+
+Reconstruction failure
+  Explanation: Dynamo has no bytecode reconstruction implemented for sourceless variable UserMethodVariable(<function ErrorMessagesTest.test_reconstruction_failure_gb.<locals>.Foo.meth at 0xmem_addr>, UserDefinedObjectVariable(Foo)).
+  Hint: If Dynamo is attempting to trace a return statement and your code is attempting to return a variable that Dynamo cannot reconstruct, then remove it from the return statement.
+  Hint: This graph break may have been caused by an earlier graph break. Resolving the earlier graph break may resolve this one.
+  Hint: Report an issue to PyTorch if you need reconstrtuction support. Note that objects that don't have reconstruction rules may be fundamentally unreconstructable.
+
+  Developer debug context: UserMethodVariable(<function ErrorMessagesTest.test_reconstruction_failure_gb.<locals>.Foo.meth at 0xmem_addr>, UserDefinedObjectVariable(Foo))
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0092.html
+
+Stack variable source attribution:
+  NullVariable originated from:
+  File "test_error_messages.py", line N
+                torch._dynamo.graph_break()
+
+User code traceback:
+  File "test_error_messages.py", line N, in test_reconstruction_failure_gb
+    torch.compile(fn, backend="eager")()
+  File "test_error_messages.py", line N, in fn
+    torch._dynamo.graph_break()
+""",
+            )
+        else:
+            self.assertExpectedInline(
+                post_munge(_munge_graph_break_message(records[1].getMessage())),
+                """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
+
+Reconstruction failure
+  Explanation: Dynamo has no bytecode reconstruction implemented for sourceless variable UserMethodVariable(<function ErrorMessagesTest.test_reconstruction_failure_gb.<locals>.Foo.meth at 0xmem_addr>, UserDefinedObjectVariable(Foo)).
+  Hint: If Dynamo is attempting to trace a return statement and your code is attempting to return a variable that Dynamo cannot reconstruct, then remove it from the return statement.
+  Hint: This graph break may have been caused by an earlier graph break. Resolving the earlier graph break may resolve this one.
+  Hint: Report an issue to PyTorch if you need reconstrtuction support. Note that objects that don't have reconstruction rules may be fundamentally unreconstructable.
+
+  Developer debug context: UserMethodVariable(<function ErrorMessagesTest.test_reconstruction_failure_gb.<locals>.Foo.meth at 0xmem_addr>, UserDefinedObjectVariable(Foo))
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0092.html
+
+User code traceback:
+  File "test_error_messages.py", line N, in test_reconstruction_failure_gb
+    torch.compile(fn, backend="eager")()
+  File "test_error_messages.py", line N, in fn
+    torch._dynamo.graph_break()
+""",
+            )
 
     def test_faketensor_nyi(self):
         op_name = "mylib::error_messages_faketensor"
@@ -1125,7 +1180,8 @@ User code traceback:
 
         # only 1 graph break message
         self.assertEqual(len(records), 1)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -1141,19 +1197,17 @@ Data-dependent assertion failed (cannot compile partial graph)
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0034.html
 
-"""
-            + _assert_failure_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                with GenericCtxMgr():
+
 User code traceback:
   File "test_error_messages.py", line N, in test_assert_failure_in_generic_ctx_mgr
     torch.compile(fn, backend="eager")(torch.randn(3))
   File "test_error_messages.py", line N, in fn
     assert x is None  # noqa: S101
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
+""",
         )
 
     def test_no_internal_compiler_stacktrace(self):
@@ -1273,8 +1327,10 @@ from user code:
 
         fn(torch.ones(3))
         self.assertEqual(len(records), 1)
-        expected = (
-            """\
+        if sys.version_info >= (3, 11) and not _get_iter_has_positions():
+            self.assertExpectedInline(
+                _munge_graph_break_message(records[0].getMessage()),
+                """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
 
@@ -1296,20 +1352,50 @@ graph break in loop
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb7000.html
 
-"""
-            + _graph_break_in_loop_stack_source_attribution()
-            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_graph_break_in_loop
     fn(torch.ones(3))
   File "test_error_messages.py", line N, in fn
     torch._dynamo.graph_break()
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
-        )
+""",
+            )
+        else:
+            self.assertExpectedInline(
+                _munge_graph_break_message(records[0].getMessage()),
+                """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
+
+Call to `torch._dynamo.graph_break()`
+  Explanation: User-inserted graph break. Message: None
+  Hint: Remove the `torch._dynamo.graph_break()` call.
+
+  Developer debug context: Called `torch._dynamo.graph_break()` with args `[]`, kwargs `{}`
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0025.html
+
+*** While handling this graph break, another graph break occurred: ***
+
+graph break in loop
+  Explanation: torch.compile detected a graph break in a for/while loop. Skipping the frame and falling back to eager, as graph breaks in loops are not supported.
+  Hint: This graph break may have been caused by an earlier graph break. Resolving the earlier graph break may resolve this one.
+
+  Developer debug context: frame skipped: fn (test_error_messages.py line N)
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb7000.html
+
+Stack variable source attribution:
+  RangeIteratorVariable() originated from:
+  File "test_error_messages.py", line N
+                for i in range(2):
+
+User code traceback:
+  File "test_error_messages.py", line N, in test_graph_break_in_loop
+    fn(torch.ones(3))
+  File "test_error_messages.py", line N, in fn
+    torch._dynamo.graph_break()
+""",
+            )
 
         @torch.compile(backend="eager")
         def gn(x):
@@ -1322,8 +1408,10 @@ User code traceback:
 
         gn(torch.ones(3))
         self.assertEqual(len(records), 2)
-        expected = (
-            """\
+        if sys.version_info >= (3, 11) and not _get_iter_has_positions():
+            self.assertExpectedInline(
+                _munge_graph_break_message(records[1].getMessage()),
+                """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
 
@@ -1352,20 +1440,57 @@ graph break in loop
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb7000.html
 
-"""
-            + _graph_break_in_loop_stack_source_attribution()
-            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_graph_break_in_loop
     gn(torch.ones(3))
   File "test_error_messages.py", line N, in gn
     if x.sum() > 0:
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[1].getMessage()),
-            expected,
-        )
+""",
+            )
+        else:
+            self.assertExpectedInline(
+                _munge_graph_break_message(records[1].getMessage()),
+                """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
+
+Data-dependent branching
+  Explanation: Detected data-dependent branching (e.g. `if my_tensor.sum() > 0:`). Dynamo does not support tracing dynamic control flow.
+
+      The branch condition involves a tensor computed as follows:
+        # File "test_error_messages.py", line N, in gn, code: if x.sum() > 0:
+        gt = gt(sum_1, 0)
+
+  Hint: For the common pattern `if tensor_cond: x = transform(x)` (e.g. clamping inf/nan values), consider making the code branchless by always applying the transform. Operations like torch.clamp, torch.nan_to_num, and torch.where are typically no-ops on well-behaved inputs and compile without graph breaks.
+  Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
+  Hint: Use `torch.cond` to express dynamic control flow.
+
+  Developer debug context: attempted to jump with TensorVariable()
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
+
+*** While handling this graph break, another graph break occurred: ***
+
+graph break in loop
+  Explanation: torch.compile detected a graph break in a for/while loop. Skipping the frame and falling back to eager, as graph breaks in loops are not supported.
+  Hint: This graph break may have been caused by an earlier graph break. Resolving the earlier graph break may resolve this one.
+
+  Developer debug context: frame skipped: gn (test_error_messages.py line N)
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb7000.html
+
+Stack variable source attribution:
+  RangeIteratorVariable() originated from:
+  File "test_error_messages.py", line N
+                for i in range(2):
+
+User code traceback:
+  File "test_error_messages.py", line N, in test_graph_break_in_loop
+    gn(torch.ones(3))
+  File "test_error_messages.py", line N, in gn
+    if x.sum() > 0:
+""",
+            )
 
     @make_logging_test(graph_breaks=True)
     def test_skip_frame_in_loop_message(self, records):
@@ -1378,8 +1503,10 @@ User code traceback:
 
         torch.compile(fn, backend="eager")(torch.randn(3))
         self.assertEqual(len(records), 1)
-        expected = (
-            """\
+        if sys.version_info >= (3, 11) and not _get_iter_has_positions():
+            self.assertExpectedInline(
+                _munge_graph_break_message(records[0].getMessage()),
+                """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
 
@@ -1398,20 +1525,50 @@ Data-dependent branching
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
 
-"""
-            + _skip_frame_in_loop_message_stack_source_attribution()
-            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_skip_frame_in_loop_message
     torch.compile(fn, backend="eager")(torch.randn(3))
   File "test_error_messages.py", line N, in fn
     if x.sum() > 0:
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
-        )
+""",
+            )
+        else:
+            self.assertExpectedInline(
+                _munge_graph_break_message(records[0].getMessage()),
+                """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
+
+Data-dependent branching
+  Explanation: Detected data-dependent branching (e.g. `if my_tensor.sum() > 0:`). Dynamo does not support tracing dynamic control flow.
+
+      The branch condition involves a tensor computed as follows:
+        # File "test_error_messages.py", line N, in fn, code: if x.sum() > 0:
+        gt = gt(sum_1, 0)
+
+  Hint: For the common pattern `if tensor_cond: x = transform(x)` (e.g. clamping inf/nan values), consider making the code branchless by always applying the transform. Operations like torch.clamp, torch.nan_to_num, and torch.where are typically no-ops on well-behaved inputs and compile without graph breaks.
+  Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
+  Hint: Use `torch.cond` to express dynamic control flow.
+
+  Developer debug context: attempted to jump with TensorVariable()
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
+
+Stack variable source attribution:
+  RangeIteratorVariable() originated from:
+  File "test_error_messages.py", line N
+                for i in range(2):
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                    with GenericCtxMgr():
+
+User code traceback:
+  File "test_error_messages.py", line N, in test_skip_frame_in_loop_message
+    torch.compile(fn, backend="eager")(torch.randn(3))
+  File "test_error_messages.py", line N, in fn
+    if x.sum() > 0:
+""",
+            )
 
     @make_logging_test(dynamo=logging.DEBUG)
     def test_skip_frame_empty_function_message(self, records):
@@ -2363,7 +2520,8 @@ Dynamo recompile limit exceeded
 
         torch.compile(fn, backend="eager")()
         self.assertEqual(len(records), 2)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -2398,9 +2556,14 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
-"""
-            + _generic_ctx_mgr_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                with GenericCtxMgr():
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                    with GenericCtxMgr():
+
 User code traceback:
   File "test_error_messages.py", line N, in test_nested_generic_ctx_mgr
     torch.compile(fn, backend="eager")()
@@ -2408,11 +2571,7 @@ User code traceback:
     inner()
   File "test_error_messages.py", line N, in inner
     torch._dynamo.graph_break()
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
+""",
         )
         self.assertExpectedInline(
             munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0),
@@ -2457,7 +2616,8 @@ Graph break under GenericContextWrappingVariable
 
         torch.compile(f3, backend="eager")(torch.randn(3))
         self.assertEqual(len(records), 1)
-        expected = (
+        self.assertExpectedInline(
+            _munge_graph_break_message(records[0].getMessage()),
             """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
@@ -2481,9 +2641,11 @@ Graph break under GenericContextWrappingVariable
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0066.html
 
-"""
-            + _assert_failure_stack_source_attribution()
-            + """\
+Stack variable source attribution:
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                with GenericCtxMgr():
+
 User code traceback:
   File "test_error_messages.py", line N, in test_skipped_frame_with_verbose_traceback_nested
     torch.compile(f3, backend="eager")(torch.randn(3))
@@ -2493,11 +2655,7 @@ User code traceback:
     return f1(x + 2)
   File "test_error_messages.py", line N, in f1
     torch._dynamo.graph_break()
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
+""",
         )
 
     @make_logging_test(graph_breaks=True)
@@ -2519,8 +2677,10 @@ User code traceback:
 
         result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
         self.assertEqual(len(records), 1)
-        expected = (
-            """\
+        if sys.version_info >= (3, 11) and not _get_iter_has_positions():
+            self.assertExpectedInline(
+                _munge_graph_break_message(records[0].getMessage()),
+                """\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
 
@@ -2539,9 +2699,6 @@ Data-dependent branching
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
 
-"""
-            + _skip_frame_in_loop_message_stack_source_attribution()
-            + """\
 User code traceback:
   File "test_error_messages.py", line N, in test_skip_frame_in_loop_message_nested
     result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
@@ -2551,12 +2708,49 @@ User code traceback:
     return f1(x + 4)
   File "test_error_messages.py", line N, in f1
     if x.sum() > 0:
-"""
-        )
-        self.assertExpectedInline(
-            _munge_graph_break_message(records[0].getMessage()),
-            expected,
-        )
+""",
+            )
+        else:
+            self.assertExpectedInline(
+                _munge_graph_break_message(records[0].getMessage()),
+                """\
+Graph break in user code at test_error_messages.py:N
+Graph Break Reason: Encountered graph break that we cannot resume from. Compiling up to the previous resumable state, then skipping the rest of the function. Graph break encountered:
+
+Data-dependent branching
+  Explanation: Detected data-dependent branching (e.g. `if my_tensor.sum() > 0:`). Dynamo does not support tracing dynamic control flow.
+
+      The branch condition involves a tensor computed as follows:
+        # File "test_error_messages.py", line N, in f1, code: if x.sum() > 0:
+        gt = gt(sum_1, 0)
+
+  Hint: For the common pattern `if tensor_cond: x = transform(x)` (e.g. clamping inf/nan values), consider making the code branchless by always applying the transform. Operations like torch.clamp, torch.nan_to_num, and torch.where are typically no-ops on well-behaved inputs and compile without graph breaks.
+  Hint: This graph break is fundamental - it is unlikely that Dynamo will ever be able to trace through your code. Consider finding a workaround.
+  Hint: Use `torch.cond` to express dynamic control flow.
+
+  Developer debug context: attempted to jump with TensorVariable()
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0170.html
+
+Stack variable source attribution:
+  RangeIteratorVariable() originated from:
+  File "test_error_messages.py", line N
+                for i in range(2):
+  WithExitFunctionVariable() originated from:
+  File "test_error_messages.py", line N
+                    with GenericCtxMgr():
+
+User code traceback:
+  File "test_error_messages.py", line N, in test_skip_frame_in_loop_message_nested
+    result = torch.compile(f3, backend="eager")(torch.randn(3))  # noqa: F841
+  File "test_error_messages.py", line N, in f3
+    return f2(x + 5)
+  File "test_error_messages.py", line N, in f2
+    return f1(x + 4)
+  File "test_error_messages.py", line N, in f1
+    if x.sum() > 0:
+""",
+            )
 
     @make_logging_test(graph_breaks=True)
     def test_try_block_with_graph_break_suppression(self, records):

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -196,9 +196,15 @@ def _skip_frame_in_loop_message_stack_source_attribution() -> str:
     )
 
 
-def _munge_graph_break_message(message: str) -> str:
+def _munge_graph_break_message_with_normalized_markers(message: str) -> str:
     munged = munge_exc(message, suppress_suffix=True, skip=0)
-    return re.sub(r"^[ ]+(\^+)$", r"\1", munged, flags=re.MULTILINE)
+    # CPython 3.13+ can use mixed `~`/`^` marker lines for the same source span.
+    return re.sub(
+        r"^[ ]+([~^]+)$",
+        lambda match: "^" * len(match.group(1)),
+        munged,
+        flags=re.MULTILINE,
+    )
 
 
 class ErrorMessagesTest(LoggingTestCase):
@@ -741,7 +747,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 
@@ -902,7 +910,11 @@ User code traceback:
         )
 
         self.assertEqual(
-            post_munge(_munge_graph_break_message(records[1].getMessage())),
+            post_munge(
+                _munge_graph_break_message_with_normalized_markers(
+                    records[1].getMessage()
+                )
+            ),
             expected,
         )
 
@@ -1141,7 +1153,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 
@@ -1291,7 +1305,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 
@@ -1347,7 +1363,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[1].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[1].getMessage()
+            ),
             expected,
         )
 
@@ -1393,7 +1411,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 
@@ -2396,7 +2416,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
         self.assertExpectedInline(
@@ -2482,7 +2504,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 
@@ -2540,7 +2564,9 @@ User code traceback:
 """
         )
         self.assertEqual(
-            _munge_graph_break_message(records[0].getMessage()),
+            _munge_graph_break_message_with_normalized_markers(
+                records[0].getMessage()
+            ),
             expected,
         )
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -229,6 +229,11 @@ def _skip_frame_in_loop_message_stack_source_attribution() -> str:
     )
 
 
+def _munge_graph_break_message(message: str) -> str:
+    munged = munge_exc(message, suppress_suffix=True, skip=0)
+    return re.sub(r"^[ ]+(\^+)$", r"\1", munged, flags=re.MULTILINE)
+
+
 class ErrorMessagesTest(LoggingTestCase):
     def test_dynamic_shape_operator_no_meta_kernel(self):
         def fn():
@@ -761,8 +766,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -922,10 +927,8 @@ User code traceback:
 """
         )
 
-        self.assertExpectedInline(
-            post_munge(
-                munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0)
-            ),
+        self.assertEqual(
+            post_munge(_munge_graph_break_message(records[1].getMessage())),
             expected,
         )
 
@@ -1163,8 +1166,8 @@ User code traceback:
     assert x is None  # noqa: S101
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -1318,8 +1321,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -1374,8 +1377,8 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[1].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[1].getMessage()),
             expected,
         )
 
@@ -1420,8 +1423,8 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -2423,8 +2426,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
         self.assertExpectedInline(
@@ -2509,8 +2512,8 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 
@@ -2567,8 +2570,8 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertExpectedInline(
-            munge_exc(records[0].getMessage(), suppress_suffix=True, skip=0),
+        self.assertEqual(
+            _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -942,9 +942,7 @@ User code traceback:
         )
 
         self.assertExpectedInline(
-            post_munge(
-                _munge_graph_break_message(records[1].getMessage())
-            ),
+            post_munge(_munge_graph_break_message(records[1].getMessage())),
             expected,
         )
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -752,7 +752,7 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
+        self.assertEqual(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -912,7 +912,7 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
+        self.assertEqual(
             post_munge(_munge_graph_break_message(records[1].getMessage())),
             expected,
         )
@@ -1151,7 +1151,7 @@ User code traceback:
     assert x is None  # noqa: S101
 """
         )
-        self.assertExpectedInline(
+        self.assertEqual(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -1306,7 +1306,7 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
+        self.assertEqual(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -1362,7 +1362,7 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertExpectedInline(
+        self.assertEqual(
             _munge_graph_break_message(records[1].getMessage()),
             expected,
         )
@@ -1408,7 +1408,7 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertExpectedInline(
+        self.assertEqual(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -2410,7 +2410,7 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
+        self.assertEqual(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -2495,7 +2495,7 @@ User code traceback:
     torch._dynamo.graph_break()
 """
         )
-        self.assertExpectedInline(
+        self.assertEqual(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )
@@ -2553,7 +2553,7 @@ User code traceback:
     if x.sum() > 0:
 """
         )
-        self.assertExpectedInline(
+        self.assertEqual(
             _munge_graph_break_message(records[0].getMessage()),
             expected,
         )

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: dynamo"]
 
+import os
 import sys
+import tempfile
 import unittest
 from typing import cast
 
@@ -212,10 +214,7 @@ from user code:
             "    return {1, 2}\n"
         )
 
-        self.assertExpectedInline(
-            munge_exc(record.getMessage()),
-            expected,
-        )
+        self.assertEqual(munge_exc(record.getMessage()), expected)
 
     @torch._dynamo.config.patch(suppress_errors=False)
     def test_internal_error_no_suppress(self):
@@ -470,6 +469,31 @@ Failed Source Expressions:
         )
         result = source_location.format()
         self.assertEqual(result, '  File "<string>", line 1\n')
+
+    def test_source_location_format_multiline(self):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".py", delete=False
+        ) as source_file:
+            source_file.write("value = (\n    foo\n    + bar\n)\n")
+            source_path = source_file.name
+
+        try:
+            source_location = SourceLocation(
+                filename=source_path,
+                lineno=1,
+                end_lineno=4,
+                col_offset=8,
+                end_col_offset=1,
+            )
+            result = source_location.format()
+        finally:
+            os.unlink(source_path)
+
+        self.assertIn(f'File "{source_path}", line 1', result)
+        self.assertIn("value = (", result)
+        self.assertIn("foo", result)
+        self.assertIn("+ bar", result)
+        self.assertIn("^", result)
 
     def test_vt_source_location_set_during_tracing(self):
         _source_location_capture.clear()

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -244,7 +244,7 @@ User code traceback:
     return {1, 2}
 """
         )
-        self.assertExpectedInline(
+        self.assertEqual(
             _munge_with_source_markers_removed(record.getMessage()),
             expected,
         )
@@ -542,7 +542,7 @@ Failed Source Expressions:
     )
     ^
 """
-            self.assertExpectedInline(result, expected)
+            self.assertEqual(result, expected)
 
     def test_vt_source_location_set_during_tracing(self):
         _source_location_capture.clear()

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -41,28 +41,6 @@ def _capture_y_source_location(ctx) -> None:
         _source_location_capture["source_location"] = y_vt.source_location
 
 
-def _unsupported_error_source_attribution() -> str:
-    if sys.version_info < (3, 11):
-        return """\
-Stack variable source attribution:
-  ConstantVariable(int: 1) originated from:
-  File "test_exc.py", line N
-                return {1, 2}
-"""
-
-    return """\
-Stack variable source attribution:
-  ConstantVariable(int: 1) originated from:
-  File "test_exc.py", line N
-                return {1, 2}
-^
-  ConstantVariable(int: 2) originated from:
-  File "test_exc.py", line N
-                return {1, 2}
-^
-"""
-
-
 def _munge_with_marker_indentation_removed(message: str) -> str:
     munged = munge_exc(message, suppress_suffix=True, skip=0)
     return re.sub(r"^[ ]+([~^]+)$", r"\1", munged, flags=re.MULTILINE)
@@ -192,6 +170,7 @@ from user code:
 
     @torch._dynamo.config.patch(inject_BUILD_SET_unimplemented_TESTING_ONLY=True)
     @make_logging_test(graph_breaks=True)
+    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_unsupported_error(self, records):
         def fn001(x):
             return {1, 2}
@@ -199,30 +178,36 @@ from user code:
         torch.compile(fn001, backend="eager")(torch.randn(1))
 
         record = self.getRecord(records, "missing BUILD_SET handler")
-        expected = (
-            "Graph break in user code at test_exc.py:N\n"
-            "Graph Break Reason: Failed to handle graph break gracefully. "
-            "Skipping the function and falling back to eager. Graph break "
-            "encountered:\n"
-            "\n"
-            "missing BUILD_SET handler\n"
-            "  Explanation: Missing BUILD_SET bytecode handler (for testing purposes).\n"
-            "\n"
-            "\n"
-            "  Developer debug context:\n"
-            "\n"
-            " For more details about this graph break, please visit: "
-            "https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0200.html\n"
-            "\n" + _unsupported_error_source_attribution() + "\n"
-            "User code traceback:\n"
-            '  File "test_exc.py", line N, in test_unsupported_error\n'
-            '    torch.compile(fn001, backend="eager")(torch.randn(1))\n'
-            '  File "test_exc.py", line N, in fn001\n'
-            "    return {1, 2}\n"
-        )
+        self.assertExpectedInline(
+            _munge_with_marker_indentation_removed(record.getMessage()),
+            """\
+Graph break in user code at test_exc.py:N
+Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
 
-        self.assertEqual(
-            _munge_with_marker_indentation_removed(record.getMessage()), expected
+missing BUILD_SET handler
+  Explanation: Missing BUILD_SET bytecode handler (for testing purposes).
+
+
+  Developer debug context:
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0200.html
+
+Stack variable source attribution:
+  ConstantVariable(int: 1) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
+^
+  ConstantVariable(int: 2) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
+^
+
+User code traceback:
+  File "test_exc.py", line N, in test_unsupported_error
+    torch.compile(fn001, backend="eager")(torch.randn(1))
+  File "test_exc.py", line N, in fn001
+    return {1, 2}
+""",
         )
 
     @torch._dynamo.config.patch(suppress_errors=False)
@@ -479,6 +464,7 @@ Failed Source Expressions:
         result = source_location.format()
         self.assertEqual(result, '  File "<string>", line 1\n')
 
+    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_source_location_format_multiline(self):
         with tempfile.NamedTemporaryFile(
             "w", suffix=".py", delete=False
@@ -495,36 +481,25 @@ Failed Source Expressions:
                 col_offset=8,
                 end_col_offset=1,
             )
-            result = source_location.format()
+            result = source_location.format().replace(source_path, "<source_path>")
         finally:
             os.unlink(source_path)
             linecache.clearcache()
 
-        if sys.version_info >= (3, 13):
-            expected = (
-                f'  File "{source_path}", line 1\n'
-                "    value = (\n"
-                "            ~\n"
-                "        foo\n"
-                "        ~~~\n"
-                "        + bar\n"
-                "        ^~~~~\n"
-                "    )\n"
-                "    ~\n"
-            )
-        else:
-            expected = (
-                f'  File "{source_path}", line 1\n'
-                "    value = (\n"
-                "            ^\n"
-                "        foo\n"
-                "        ^^^\n"
-                "        + bar\n"
-                "        ^^^^^\n"
-                "    )\n"
-                "    ^\n"
-            )
-        self.assertEqual(result, expected)
+        self.assertExpectedInline(
+            result,
+            """\
+  File "<source_path>", line 1
+    value = (
+            ~
+        foo
+        ~~~
+        + bar
+        ^~~~~
+    )
+    ~
+""",
+        )
 
     def test_vt_source_location_set_during_tracing(self):
         _source_location_capture.clear()

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -42,7 +42,7 @@ def _capture_y_source_location(ctx) -> None:
 
 
 def _strip_source_markers(message: str) -> str:
-    return re.sub(r"\n[ ]*[~^]+\n", "\n", message)
+    return re.sub(r"(?m)^[ ]*[~^]+\n?", "", message)
 
 
 def _unsupported_error_source_attribution() -> str:
@@ -547,7 +547,7 @@ Failed Source Expressions:
 """,
         )
 
-        if sys.version_info >= (3, 13):
+        if sys.version_info >= (3, 11):
             self.assertExpectedInline(
                 result,
                 """\
@@ -560,21 +560,6 @@ Failed Source Expressions:
         ^~~~~
     )
     ~
-""",
-            )
-        elif sys.version_info >= (3, 11):
-            self.assertExpectedInline(
-                result,
-                """\
-  File "<source_path>", line 1
-    value = (
-            ^
-        foo
-        ^^^
-        + bar
-        ^^^^^
-    )
-    ^
 """,
             )
 

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -221,8 +221,10 @@ from user code:
         torch.compile(fn001, backend="eager")(torch.randn(1))
 
         record = self.getRecord(records, "missing BUILD_SET handler")
-        expected = (
-            """\
+        if sys.version_info < (3, 11):
+            self.assertExpectedInline(
+                _munge_with_source_markers_removed(record.getMessage()),
+                """\
 Graph break in user code at test_exc.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
 
@@ -234,20 +236,48 @@ missing BUILD_SET handler
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0200.html
 
-"""
-            + _unsupported_error_source_attribution()
-            + """
+Stack variable source attribution:
+  ConstantVariable(int: 1) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
+
 User code traceback:
   File "test_exc.py", line N, in test_unsupported_error
     torch.compile(fn001, backend="eager")(torch.randn(1))
   File "test_exc.py", line N, in fn001
     return {1, 2}
-"""
-        )
-        self.assertExpectedInline(
-            _munge_with_source_markers_removed(record.getMessage()),
-            expected,
-        )
+""",
+            )
+        else:
+            self.assertExpectedInline(
+                _munge_with_source_markers_removed(record.getMessage()),
+                """\
+Graph break in user code at test_exc.py:N
+Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
+
+missing BUILD_SET handler
+  Explanation: Missing BUILD_SET bytecode handler (for testing purposes).
+
+
+  Developer debug context:
+
+ For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0200.html
+
+Stack variable source attribution:
+  ConstantVariable(int: 1) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
+  ConstantVariable(int: 2) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
+
+User code traceback:
+  File "test_exc.py", line N, in test_unsupported_error
+    torch.compile(fn001, backend="eager")(torch.randn(1))
+  File "test_exc.py", line N, in fn001
+    return {1, 2}
+""",
+            )
 
     @torch._dynamo.config.patch(suppress_errors=False)
     def test_internal_error_no_suppress(self):
@@ -517,9 +547,10 @@ Failed Source Expressions:
 """,
         )
 
-        if sys.version_info >= (3, 11):
-            if sys.version_info >= (3, 13):
-                expected = """\
+        if sys.version_info >= (3, 13):
+            self.assertExpectedInline(
+                result,
+                """\
   File "<source_path>", line 1
     value = (
             ~
@@ -529,9 +560,12 @@ Failed Source Expressions:
         ^~~~~
     )
     ~
-"""
-            else:
-                expected = """\
+""",
+            )
+        elif sys.version_info >= (3, 11):
+            self.assertExpectedInline(
+                result,
+                """\
   File "<source_path>", line 1
     value = (
             ^
@@ -541,8 +575,8 @@ Failed Source Expressions:
         ^^^^^
     )
     ^
-"""
-            self.assertExpectedInline(result, expected)
+""",
+            )
 
     def test_vt_source_location_set_during_tracing(self):
         _source_location_capture.clear()

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -63,15 +63,9 @@ Stack variable source attribution:
 """
 
 
-def _munge_with_normalized_markers(message: str) -> str:
+def _munge_with_marker_indentation_removed(message: str) -> str:
     munged = munge_exc(message, suppress_suffix=True, skip=0)
-    # CPython 3.13+ can use mixed `~`/`^` marker lines for the same source span.
-    return re.sub(
-        r"^[ ]+([~^]+)$",
-        lambda match: "^" * len(match.group(1)),
-        munged,
-        flags=re.MULTILINE,
-    )
+    return re.sub(r"^[ ]+([~^]+)$", r"\1", munged, flags=re.MULTILINE)
 
 
 class ExcTests(LoggingTestCase):
@@ -227,7 +221,9 @@ from user code:
             "    return {1, 2}\n"
         )
 
-        self.assertEqual(_munge_with_normalized_markers(record.getMessage()), expected)
+        self.assertEqual(
+            _munge_with_marker_indentation_removed(record.getMessage()), expected
+        )
 
     @torch._dynamo.config.patch(suppress_errors=False)
     def test_internal_error_no_suppress(self):

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -41,9 +41,53 @@ def _capture_y_source_location(ctx) -> None:
         _source_location_capture["source_location"] = y_vt.source_location
 
 
-def _munge_with_marker_indentation_removed(message: str) -> str:
+def _strip_source_markers(message: str) -> str:
+    return re.sub(r"\n[ ]*[~^]+\n", "\n", message)
+
+
+def _unsupported_error_source_attribution() -> str:
+    if sys.version_info < (3, 11):
+        return """\
+Stack variable source attribution:
+  ConstantVariable(int: 1) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
+"""
+
+    return """\
+Stack variable source attribution:
+  ConstantVariable(int: 1) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
+  ConstantVariable(int: 2) originated from:
+  File "test_exc.py", line N
+                return {1, 2}
+"""
+
+
+def _munge_with_source_markers_removed(message: str) -> str:
     munged = munge_exc(message, suppress_suffix=True, skip=0)
-    return re.sub(r"^[ ]+([~^]+)$", r"\1", munged, flags=re.MULTILINE)
+    return _strip_source_markers(munged)
+
+
+def _format_multiline_source_location() -> str:
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as source_file:
+        source_file.write("value = (\n    foo\n    + bar\n)\n")
+        source_path = source_file.name
+
+    try:
+        source_location = SourceLocation(
+            filename=source_path,
+            lineno=1,
+            end_lineno=4,
+            # Span covers the parenthesized expression `( ... )`.
+            col_offset=8,
+            end_col_offset=1,
+        )
+        return source_location.format().replace(source_path, "<source_path>")
+    finally:
+        os.unlink(source_path)
+        linecache.clearcache()
 
 
 class ExcTests(LoggingTestCase):
@@ -170,7 +214,6 @@ from user code:
 
     @torch._dynamo.config.patch(inject_BUILD_SET_unimplemented_TESTING_ONLY=True)
     @make_logging_test(graph_breaks=True)
-    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_unsupported_error(self, records):
         def fn001(x):
             return {1, 2}
@@ -178,8 +221,7 @@ from user code:
         torch.compile(fn001, backend="eager")(torch.randn(1))
 
         record = self.getRecord(records, "missing BUILD_SET handler")
-        self.assertExpectedInline(
-            _munge_with_marker_indentation_removed(record.getMessage()),
+        expected = (
             """\
 Graph break in user code at test_exc.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
@@ -192,22 +234,19 @@ missing BUILD_SET handler
 
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0200.html
 
-Stack variable source attribution:
-  ConstantVariable(int: 1) originated from:
-  File "test_exc.py", line N
-                return {1, 2}
-^
-  ConstantVariable(int: 2) originated from:
-  File "test_exc.py", line N
-                return {1, 2}
-^
-
+"""
+            + _unsupported_error_source_attribution()
+            + """
 User code traceback:
   File "test_exc.py", line N, in test_unsupported_error
     torch.compile(fn001, backend="eager")(torch.randn(1))
   File "test_exc.py", line N, in fn001
     return {1, 2}
-""",
+"""
+        )
+        self.assertExpectedInline(
+            _munge_with_source_markers_removed(record.getMessage()),
+            expected,
         )
 
     @torch._dynamo.config.patch(suppress_errors=False)
@@ -464,31 +503,23 @@ Failed Source Expressions:
         result = source_location.format()
         self.assertEqual(result, '  File "<string>", line 1\n')
 
-    @unittest.skipUnless(sys.version_info[:2] == (3, 14), "requires Python 3.14")
     def test_source_location_format_multiline(self):
-        with tempfile.NamedTemporaryFile(
-            "w", suffix=".py", delete=False
-        ) as source_file:
-            source_file.write("value = (\n    foo\n    + bar\n)\n")
-            source_path = source_file.name
-
-        try:
-            source_location = SourceLocation(
-                filename=source_path,
-                lineno=1,
-                end_lineno=4,
-                # Span covers the parenthesized expression `( ... )`.
-                col_offset=8,
-                end_col_offset=1,
-            )
-            result = source_location.format().replace(source_path, "<source_path>")
-        finally:
-            os.unlink(source_path)
-            linecache.clearcache()
+        result = _format_multiline_source_location()
 
         self.assertExpectedInline(
-            result,
+            _strip_source_markers(result),
             """\
+  File "<source_path>", line 1
+    value = (
+        foo
+        + bar
+    )
+""",
+        )
+
+        if sys.version_info >= (3, 11):
+            if sys.version_info >= (3, 13):
+                expected = """\
   File "<source_path>", line 1
     value = (
             ~
@@ -498,8 +529,20 @@ Failed Source Expressions:
         ^~~~~
     )
     ~
-""",
-        )
+"""
+            else:
+                expected = """\
+  File "<source_path>", line 1
+    value = (
+            ^
+        foo
+        ^^^
+        + bar
+        ^^^^^
+    )
+    ^
+"""
+            self.assertExpectedInline(result, expected)
 
     def test_vt_source_location_set_during_tracing(self):
         _source_location_capture.clear()

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -2,6 +2,7 @@
 
 import linecache
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -60,6 +61,17 @@ Stack variable source attribution:
                 return {1, 2}
 ^
 """
+
+
+def _munge_with_normalized_markers(message: str) -> str:
+    munged = munge_exc(message, suppress_suffix=True, skip=0)
+    # CPython 3.13+ can use mixed `~`/`^` marker lines for the same source span.
+    return re.sub(
+        r"^[ ]+([~^]+)$",
+        lambda match: "^" * len(match.group(1)),
+        munged,
+        flags=re.MULTILINE,
+    )
 
 
 class ExcTests(LoggingTestCase):
@@ -215,7 +227,7 @@ from user code:
             "    return {1, 2}\n"
         )
 
-        self.assertEqual(munge_exc(record.getMessage()), expected)
+        self.assertEqual(_munge_with_normalized_markers(record.getMessage()), expected)
 
     @torch._dynamo.config.patch(suppress_errors=False)
     def test_internal_error_no_suppress(self):
@@ -492,11 +504,31 @@ Failed Source Expressions:
             os.unlink(source_path)
             linecache.clearcache()
 
-        self.assertIn(f'File "{source_path}", line 1', result)
-        self.assertIn("value = (", result)
-        self.assertIn("foo", result)
-        self.assertIn("+ bar", result)
-        self.assertIn("^", result)
+        if sys.version_info >= (3, 13):
+            expected = (
+                f'  File "{source_path}", line 1\n'
+                "    value = (\n"
+                "            ~\n"
+                "        foo\n"
+                "        ~~~\n"
+                "        + bar\n"
+                "        ^~~~~\n"
+                "    )\n"
+                "    ~\n"
+            )
+        else:
+            expected = (
+                f'  File "{source_path}", line 1\n'
+                "    value = (\n"
+                "            ^\n"
+                "        foo\n"
+                "        ^^^\n"
+                "        + bar\n"
+                "        ^^^^^\n"
+                "    )\n"
+                "    ^\n"
+            )
+        self.assertEqual(result, expected)
 
     def test_vt_source_location_set_during_tracing(self):
         _source_location_capture.clear()

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -244,7 +244,7 @@ User code traceback:
     return {1, 2}
 """
         )
-        self.assertEqual(
+        self.assertExpectedInline(
             _munge_with_source_markers_removed(record.getMessage()),
             expected,
         )
@@ -542,7 +542,7 @@ Failed Source Expressions:
     )
     ^
 """
-            self.assertEqual(result, expected)
+            self.assertExpectedInline(result, expected)
 
     def test_vt_source_location_set_during_tracing(self):
         _source_location_capture.clear()

--- a/test/dynamo/test_exc.py
+++ b/test/dynamo/test_exc.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import linecache
 import os
 import sys
 import tempfile
@@ -482,12 +483,14 @@ Failed Source Expressions:
                 filename=source_path,
                 lineno=1,
                 end_lineno=4,
+                # Span covers the parenthesized expression `( ... )`.
                 col_offset=8,
                 end_col_offset=1,
             )
             result = source_location.format()
         finally:
             os.unlink(source_path)
+            linecache.clearcache()
 
         self.assertIn(f'File "{source_path}", line 1', result)
         self.assertIn("value = (", result)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -4684,6 +4684,118 @@ def _extract_anchors_from_expr(segment: str) -> _Anchors | None:
     return None
 
 
+def format_source_range(
+    filename: str,
+    lineno: int | None,
+    end_lineno: int | None = None,
+    col_offset: int | None = None,
+    end_col_offset: int | None = None,
+    *,
+    function_name: str = "<unknown>",
+) -> str:
+    if lineno is None:
+        return ""
+
+    last_lineno = end_lineno if end_lineno is not None else lineno
+    source_lines = [
+        linecache.getline(filename, current_lineno).rstrip()
+        for current_lineno in range(lineno, last_lineno + 1)
+    ]
+    if not any(source_lines):
+        return ""
+
+    if (
+        sys.version_info >= (3, 13)
+        and end_lineno is not None
+        and col_offset is not None
+        and end_col_offset is not None
+    ):
+        frame_summary = traceback.FrameSummary(
+            filename,
+            lineno,
+            function_name,
+            end_lineno=end_lineno,
+            colno=col_offset,
+            end_colno=end_col_offset,
+        )
+        result = traceback.format_list([frame_summary])[0]
+        result = "\n".join(result.splitlines()[1:])
+        source_lines_dedent = textwrap.dedent("\n".join(source_lines)).splitlines()
+        if not source_lines_dedent:
+            return result
+        indent_len = len(source_lines[0]) - len(source_lines_dedent[0])
+        indent = source_lines[0][:indent_len]
+        return textwrap.indent(textwrap.dedent(result), indent)
+
+    first_line = source_lines[0]
+    if end_lineno is None or col_offset is None or end_col_offset is None:
+        return first_line
+
+    start_offset = _fix_offset(first_line, col_offset)
+    segment = ""
+    markers: list[str] = []
+
+    if end_lineno == lineno:
+        end_offset = _fix_offset(first_line, end_col_offset)
+        segment = first_line[start_offset:end_offset]
+        markers.append(" " * start_offset + "~" * (end_offset - start_offset))
+    else:
+        segment = first_line[start_offset:] + "\n"
+        markers.append(" " * start_offset + "~" * (len(first_line) - start_offset))
+        last_line = source_lines[-1]
+        end_offset = _fix_offset(last_line, end_col_offset)
+        for line in source_lines[1:-1]:
+            segment += line + "\n"
+            num_spaces = len(line) - len(line.lstrip())
+            markers.append(" " * num_spaces + "~" * (len(line) - num_spaces))
+        segment += last_line[:end_offset]
+        num_spaces = len(last_line) - len(last_line.lstrip())
+        markers.append(" " * num_spaces + "~" * (end_offset - num_spaces))
+
+    anchors: _Anchors | None = None
+    try:
+        anchors = _extract_anchors_from_expr(segment)
+    except AssertionError:
+        pass
+
+    if anchors is None:
+        markers = [marker.replace("~", "^") for marker in markers]
+    else:
+        mutable_markers: list[list[str]] = [list(marker) for marker in markers]
+
+        if anchors.left_end_lineno == 0:
+            anchors.left_end_offset += start_offset
+        if anchors.right_start_lineno == 0:
+            anchors.right_start_offset += start_offset
+
+        for marker_lineno in range(len(markers)):
+            for col in range(len(mutable_markers[marker_lineno])):
+                if marker_lineno < anchors.left_end_lineno:
+                    continue
+                if (
+                    marker_lineno == anchors.left_end_lineno
+                    and col < anchors.left_end_offset
+                ):
+                    continue
+                if (
+                    marker_lineno == anchors.right_start_lineno
+                    and col >= anchors.right_start_offset
+                ):
+                    continue
+                if marker_lineno > anchors.right_start_lineno:
+                    continue
+                if mutable_markers[marker_lineno][col] == "~":
+                    mutable_markers[marker_lineno][col] = "^"
+
+        markers = ["".join(marker) for marker in mutable_markers]
+
+    result = ""
+    for line, marker in zip(source_lines, markers):
+        result += line + "\n"
+        result += marker + "\n"
+    return result
+
+
 def get_instruction_source_311(code: types.CodeType, inst: Instruction) -> str:
     """
     Python 3.11+ only. Returns lines of source code (from code object `code`)
@@ -4699,121 +4811,15 @@ def get_instruction_source_311(code: types.CodeType, inst: Instruction) -> str:
     Python's `traceback` module doesn't handle multi-line expressions
     (and their anchor extraction code is not completely correct).
     """
-    if sys.version_info >= (3, 13):
-        # multiline traceback implemented in 3.13+
-        frame_summary = traceback.FrameSummary(
-            code.co_filename,
-            inst.positions.lineno,
-            code.co_name,
-            end_lineno=inst.positions.end_lineno,
-            colno=inst.positions.col_offset,
-            end_colno=inst.positions.end_col_offset,
-        )
-        result = traceback.format_list([frame_summary])[0]
-        # remove first line containing filename info
-        result = "\n".join(result.splitlines()[1:])
-        # indent lines with original indentation
-        orig_lines = [
-            linecache.getline(code.co_filename, lineno).rstrip()
-            for lineno in range(inst.positions.lineno, inst.positions.end_lineno + 1)
-        ]
-        orig_lines_dedent = textwrap.dedent("\n".join(orig_lines)).splitlines()
-        indent_len = len(orig_lines[0]) - len(orig_lines_dedent[0])
-        indent = orig_lines[0][:indent_len]
-        result = textwrap.indent(textwrap.dedent(result), indent)
-        return result
-
     assert hasattr(inst, "positions") and inst.positions is not None
-    if inst.positions.lineno is None:
-        return ""
-    # The rstrip + "\n" pattern is used throughout this function to handle
-    # linecache.getline errors. Error lines are treated as empty strings "", but we want
-    # to treat them as blank lines "\n".
-    first_line = linecache.getline(code.co_filename, inst.positions.lineno).rstrip()
-    if inst.positions.end_lineno is None:
-        return first_line
-    if inst.positions.col_offset is None or inst.positions.end_col_offset is None:
-        return first_line
-
-    # character index of the start of the instruction
-    start_offset = _fix_offset(first_line, inst.positions.col_offset)
-    # character index of the end of the instruction
-    # compute later since end may be a different line
-    end_offset = None
-    # expression corresponding to the instruction so we can get anchors
-    segment = ""
-    # underline markers to be printed - start with `~` marker and replace with `^` later
-    markers = []
-
-    # Compute segment and initial markers
-    if inst.positions.end_lineno == inst.positions.lineno:
-        end_offset = _fix_offset(first_line, inst.positions.end_col_offset)
-        segment = first_line[start_offset:end_offset]
-        markers.append(" " * start_offset + "~" * (end_offset - start_offset))
-    else:
-        segment = first_line[start_offset:] + "\n"
-        markers.append(" " * start_offset + "~" * (len(first_line) - start_offset))
-        last_line = linecache.getline(
-            code.co_filename, inst.positions.end_lineno
-        ).rstrip()
-        end_offset = _fix_offset(last_line, inst.positions.end_col_offset)
-        for lineno in range(inst.positions.lineno + 1, inst.positions.end_lineno):
-            line = linecache.getline(code.co_filename, lineno).rstrip()
-            segment += line + "\n"
-            # don't underline leading spaces
-            num_spaces = len(line) - len(line.lstrip())
-            markers.append(" " * num_spaces + "~" * (len(line) - num_spaces))
-        segment += last_line[:end_offset]
-        num_spaces = len(last_line) - len(last_line.lstrip())
-        markers.append(" " * num_spaces + "~" * (end_offset - num_spaces))
-
-    anchors: _Anchors | None = None
-    try:
-        anchors = _extract_anchors_from_expr(segment)
-    except AssertionError:
-        pass
-
-    # replace `~` markers with `^` where necessary
-    if anchors is None:
-        markers = [marker.replace("~", "^") for marker in markers]
-    else:
-        # make markers mutable
-        mutable_markers: list[list[str]] = [list(marker) for marker in markers]
-
-        # anchor positions do not take start_offset into account
-        if anchors.left_end_lineno == 0:
-            anchors.left_end_offset += start_offset
-        if anchors.right_start_lineno == 0:
-            anchors.right_start_offset += start_offset
-
-        # Turn `~`` markers between anchors to `^`
-        for lineno in range(len(markers)):
-            for col in range(len(mutable_markers[lineno])):
-                if lineno < anchors.left_end_lineno:
-                    continue
-                if lineno == anchors.left_end_lineno and col < anchors.left_end_offset:
-                    continue
-                if (
-                    lineno == anchors.right_start_lineno
-                    and col >= anchors.right_start_offset
-                ):
-                    continue
-                if lineno > anchors.right_start_lineno:
-                    continue
-                if mutable_markers[lineno][col] == "~":
-                    mutable_markers[lineno][col] = "^"
-
-        # make markers into strings again
-        markers = ["".join(marker) for marker in mutable_markers]
-
-    result = ""
-    for i in range(len(markers)):
-        result += (
-            linecache.getline(code.co_filename, inst.positions.lineno + i).rstrip()
-            + "\n"
-        )
-        result += markers[i] + "\n"
-    return result
+    return format_source_range(
+        code.co_filename,
+        inst.positions.lineno,
+        inst.positions.end_lineno,
+        inst.positions.col_offset,
+        inst.positions.end_col_offset,
+        function_name=code.co_name,
+    )
 
 
 def get_static_address_type(t: Any) -> Any:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -4707,9 +4707,14 @@ def format_source_range(
     if (
         sys.version_info >= (3, 13)
         and end_lineno is not None
+        and end_lineno != lineno
         and col_offset is not None
         and end_col_offset is not None
     ):
+        # Keep single-line ranges on Dynamo's manual path. The stdlib traceback
+        # formatter is useful for multiline spans on 3.13+, but for single-line
+        # spans it can emit version-specific mixed `~`/`^` markers or omit the
+        # marker line entirely for comments.
         frame_summary = traceback.FrameSummary(
             filename,
             lineno,

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -4690,6 +4690,118 @@ def _extract_anchors_from_expr(segment: str) -> _Anchors | None:
     return None
 
 
+def format_source_range(
+    filename: str,
+    lineno: int | None,
+    end_lineno: int | None = None,
+    col_offset: int | None = None,
+    end_col_offset: int | None = None,
+    *,
+    function_name: str = "<unknown>",
+) -> str:
+    if lineno is None:
+        return ""
+
+    last_lineno = end_lineno if end_lineno is not None else lineno
+    source_lines = [
+        linecache.getline(filename, current_lineno).rstrip()
+        for current_lineno in range(lineno, last_lineno + 1)
+    ]
+    if not any(source_lines):
+        return ""
+
+    if (
+        sys.version_info >= (3, 13)
+        and end_lineno is not None
+        and col_offset is not None
+        and end_col_offset is not None
+    ):
+        frame_summary = traceback.FrameSummary(
+            filename,
+            lineno,
+            function_name,
+            end_lineno=end_lineno,
+            colno=col_offset,
+            end_colno=end_col_offset,
+        )
+        result = traceback.format_list([frame_summary])[0]
+        result = "\n".join(result.splitlines()[1:])
+        source_lines_dedent = textwrap.dedent("\n".join(source_lines)).splitlines()
+        if not source_lines_dedent:
+            return result
+        indent_len = len(source_lines[0]) - len(source_lines_dedent[0])
+        indent = source_lines[0][:indent_len]
+        return textwrap.indent(textwrap.dedent(result), indent)
+
+    first_line = source_lines[0]
+    if end_lineno is None or col_offset is None or end_col_offset is None:
+        return first_line
+
+    start_offset = _fix_offset(first_line, col_offset)
+    segment = ""
+    markers: list[str] = []
+
+    if end_lineno == lineno:
+        end_offset = _fix_offset(first_line, end_col_offset)
+        segment = first_line[start_offset:end_offset]
+        markers.append(" " * start_offset + "~" * (end_offset - start_offset))
+    else:
+        segment = first_line[start_offset:] + "\n"
+        markers.append(" " * start_offset + "~" * (len(first_line) - start_offset))
+        last_line = source_lines[-1]
+        end_offset = _fix_offset(last_line, end_col_offset)
+        for line in source_lines[1:-1]:
+            segment += line + "\n"
+            num_spaces = len(line) - len(line.lstrip())
+            markers.append(" " * num_spaces + "~" * (len(line) - num_spaces))
+        segment += last_line[:end_offset]
+        num_spaces = len(last_line) - len(last_line.lstrip())
+        markers.append(" " * num_spaces + "~" * (end_offset - num_spaces))
+
+    anchors: _Anchors | None = None
+    try:
+        anchors = _extract_anchors_from_expr(segment)
+    except AssertionError:
+        pass
+
+    if anchors is None:
+        markers = [marker.replace("~", "^") for marker in markers]
+    else:
+        mutable_markers: list[list[str]] = [list(marker) for marker in markers]
+
+        if anchors.left_end_lineno == 0:
+            anchors.left_end_offset += start_offset
+        if anchors.right_start_lineno == 0:
+            anchors.right_start_offset += start_offset
+
+        for marker_lineno in range(len(markers)):
+            for col in range(len(mutable_markers[marker_lineno])):
+                if marker_lineno < anchors.left_end_lineno:
+                    continue
+                if (
+                    marker_lineno == anchors.left_end_lineno
+                    and col < anchors.left_end_offset
+                ):
+                    continue
+                if (
+                    marker_lineno == anchors.right_start_lineno
+                    and col >= anchors.right_start_offset
+                ):
+                    continue
+                if marker_lineno > anchors.right_start_lineno:
+                    continue
+                if mutable_markers[marker_lineno][col] == "~":
+                    mutable_markers[marker_lineno][col] = "^"
+
+        markers = ["".join(marker) for marker in mutable_markers]
+
+    result = ""
+    for line, marker in zip(source_lines, markers):
+        result += line + "\n"
+        result += marker + "\n"
+    return result
+
+
 def get_instruction_source_311(code: types.CodeType, inst: Instruction) -> str:
     """
     Python 3.11+ only. Returns lines of source code (from code object `code`)
@@ -4705,121 +4817,15 @@ def get_instruction_source_311(code: types.CodeType, inst: Instruction) -> str:
     Python's `traceback` module doesn't handle multi-line expressions
     (and their anchor extraction code is not completely correct).
     """
-    if sys.version_info >= (3, 13):
-        # multiline traceback implemented in 3.13+
-        frame_summary = traceback.FrameSummary(
-            code.co_filename,
-            inst.positions.lineno,
-            code.co_name,
-            end_lineno=inst.positions.end_lineno,
-            colno=inst.positions.col_offset,
-            end_colno=inst.positions.end_col_offset,
-        )
-        result = traceback.format_list([frame_summary])[0]
-        # remove first line containing filename info
-        result = "\n".join(result.splitlines()[1:])
-        # indent lines with original indentation
-        orig_lines = [
-            linecache.getline(code.co_filename, lineno).rstrip()
-            for lineno in range(inst.positions.lineno, inst.positions.end_lineno + 1)
-        ]
-        orig_lines_dedent = textwrap.dedent("\n".join(orig_lines)).splitlines()
-        indent_len = len(orig_lines[0]) - len(orig_lines_dedent[0])
-        indent = orig_lines[0][:indent_len]
-        result = textwrap.indent(textwrap.dedent(result), indent)
-        return result
-
     assert hasattr(inst, "positions") and inst.positions is not None
-    if inst.positions.lineno is None:
-        return ""
-    # The rstrip + "\n" pattern is used throughout this function to handle
-    # linecache.getline errors. Error lines are treated as empty strings "", but we want
-    # to treat them as blank lines "\n".
-    first_line = linecache.getline(code.co_filename, inst.positions.lineno).rstrip()
-    if inst.positions.end_lineno is None:
-        return first_line
-    if inst.positions.col_offset is None or inst.positions.end_col_offset is None:
-        return first_line
-
-    # character index of the start of the instruction
-    start_offset = _fix_offset(first_line, inst.positions.col_offset)
-    # character index of the end of the instruction
-    # compute later since end may be a different line
-    end_offset = None
-    # expression corresponding to the instruction so we can get anchors
-    segment = ""
-    # underline markers to be printed - start with `~` marker and replace with `^` later
-    markers = []
-
-    # Compute segment and initial markers
-    if inst.positions.end_lineno == inst.positions.lineno:
-        end_offset = _fix_offset(first_line, inst.positions.end_col_offset)
-        segment = first_line[start_offset:end_offset]
-        markers.append(" " * start_offset + "~" * (end_offset - start_offset))
-    else:
-        segment = first_line[start_offset:] + "\n"
-        markers.append(" " * start_offset + "~" * (len(first_line) - start_offset))
-        last_line = linecache.getline(
-            code.co_filename, inst.positions.end_lineno
-        ).rstrip()
-        end_offset = _fix_offset(last_line, inst.positions.end_col_offset)
-        for lineno in range(inst.positions.lineno + 1, inst.positions.end_lineno):
-            line = linecache.getline(code.co_filename, lineno).rstrip()
-            segment += line + "\n"
-            # don't underline leading spaces
-            num_spaces = len(line) - len(line.lstrip())
-            markers.append(" " * num_spaces + "~" * (len(line) - num_spaces))
-        segment += last_line[:end_offset]
-        num_spaces = len(last_line) - len(last_line.lstrip())
-        markers.append(" " * num_spaces + "~" * (end_offset - num_spaces))
-
-    anchors: _Anchors | None = None
-    try:
-        anchors = _extract_anchors_from_expr(segment)
-    except AssertionError:
-        pass
-
-    # replace `~` markers with `^` where necessary
-    if anchors is None:
-        markers = [marker.replace("~", "^") for marker in markers]
-    else:
-        # make markers mutable
-        mutable_markers: list[list[str]] = [list(marker) for marker in markers]
-
-        # anchor positions do not take start_offset into account
-        if anchors.left_end_lineno == 0:
-            anchors.left_end_offset += start_offset
-        if anchors.right_start_lineno == 0:
-            anchors.right_start_offset += start_offset
-
-        # Turn `~`` markers between anchors to `^`
-        for lineno in range(len(markers)):
-            for col in range(len(mutable_markers[lineno])):
-                if lineno < anchors.left_end_lineno:
-                    continue
-                if lineno == anchors.left_end_lineno and col < anchors.left_end_offset:
-                    continue
-                if (
-                    lineno == anchors.right_start_lineno
-                    and col >= anchors.right_start_offset
-                ):
-                    continue
-                if lineno > anchors.right_start_lineno:
-                    continue
-                if mutable_markers[lineno][col] == "~":
-                    mutable_markers[lineno][col] = "^"
-
-        # make markers into strings again
-        markers = ["".join(marker) for marker in mutable_markers]
-
-    result = ""
-    for i in range(len(markers)):
-        result += (
-            linecache.getline(code.co_filename, inst.positions.lineno + i).rstrip()
-            + "\n"
-        )
-        result += markers[i] + "\n"
-    return result
+    return format_source_range(
+        code.co_filename,
+        inst.positions.lineno,
+        inst.positions.end_lineno,
+        inst.positions.col_offset,
+        inst.positions.end_col_offset,
+        function_name=code.co_name,
+    )
 
 
 def get_static_address_type(t: Any) -> Any:

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -4713,9 +4713,14 @@ def format_source_range(
     if (
         sys.version_info >= (3, 13)
         and end_lineno is not None
+        and end_lineno != lineno
         and col_offset is not None
         and end_col_offset is not None
     ):
+        # Keep single-line ranges on Dynamo's manual path. The stdlib traceback
+        # formatter is useful for multiline spans on 3.13+, but for single-line
+        # spans it can emit version-specific mixed `~`/`^` markers or omit the
+        # marker line entirely for comments.
         frame_summary = traceback.FrameSummary(
             filename,
             lineno,

--- a/torch/_dynamo/variables/base.py
+++ b/torch/_dynamo/variables/base.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 import collections
 import dataclasses
 import functools
-import linecache
 import logging
+import textwrap
 from collections.abc import Callable, ItemsView, KeysView, Sequence, ValuesView
 from contextvars import ContextVar
 from enum import Enum
@@ -30,7 +30,7 @@ from ..current_scope_id import current_scope_id
 from ..exc import raise_observed_exception, unimplemented
 from ..guards import GuardBuilder, install_guard
 from ..source import AttrSource, Source
-from ..utils import cmp_name_to_op_mapping, istype
+from ..utils import cmp_name_to_op_mapping, format_source_range, istype
 
 
 if TYPE_CHECKING:
@@ -58,13 +58,16 @@ class SourceLocation:
     end_col_offset: int | None = None
 
     def format(self) -> str:
-        line = linecache.getline(self.filename, self.lineno).rstrip()
         result = f'  File "{self.filename}", line {self.lineno}\n'
-        if line:
-            result += f"    {line}\n"
-        if line and self.col_offset is not None and self.end_col_offset is not None:
-            num_carets = max(1, self.end_col_offset - self.col_offset)
-            result += "    " + " " * self.col_offset + "^" * num_carets + "\n"
+        source = format_source_range(
+            self.filename,
+            self.lineno,
+            self.end_lineno,
+            self.col_offset,
+            self.end_col_offset,
+        )
+        if source:
+            result += textwrap.indent(source.rstrip("\n"), "    ") + "\n"
         return result
 
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5965,9 +5965,6 @@ def munge_exc(e, *, suppress_suffix=True, suppress_prefix=True, file=None, skip=
     if suppress_prefix:
         s = re.sub(r"Cannot export model.+\n\n", "", s)
     s = re.sub(r" +$", "", s, flags=re.MULTILINE)
-    # Normalize caret-only lines by stripping leading whitespace, since
-    # col_offset in bytecode positions can vary across Python point releases
-    s = re.sub(r"^[ ]+(\^+)$", r"\1", s, flags=re.MULTILINE)
     return s
 
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -6045,9 +6045,6 @@ def munge_exc(e, *, suppress_suffix=True, suppress_prefix=True, file=None, skip=
     if suppress_prefix:
         s = re.sub(r"Cannot export model.+\n\n", "", s)
     s = re.sub(r" +$", "", s, flags=re.MULTILINE)
-    # Normalize caret-only lines by stripping leading whitespace, since
-    # col_offset in bytecode positions can vary across Python point releases
-    s = re.sub(r"^[ ]+(\^+)$", r"\1", s, flags=re.MULTILINE)
     return s
 
 


### PR DESCRIPTION
## Summary
Follow-up to #179350 to address the post-land review comments.

Root cause:
The landed source-attribution change still had three rough edges: `SourceLocation.format()` kept its own single-line formatter instead of reusing Dynamo's existing multiline-aware source rendering, caret-only line normalization was applied globally in `munge_exc`, and the new version-dependent expected strings were still using `assertExpectedInline` even though `EXPECTTEST_ACCEPT=1` cannot rewrite those dynamic expectations.

Proposed fix:
- factor the shared source-range rendering into `torch._dynamo.utils.format_source_range()` and use it from both `get_instruction_source_311()` and `SourceLocation.format()`
- move the caret-only normalization into a local helper in `test_error_messages.py`
- switch the version-dependent expectation checks to `assertEqual`, and add a multiline `SourceLocation.format()` regression test

Why this is the right long term fix:
A shared formatter keeps traceback rendering and Dynamo source attribution in sync for multiline spans, the caret normalization stays scoped to the one test file that needs it, and the dynamic expectation checks stop relying on expecttest behavior they cannot support while the new regression test locks in the multiline formatting behavior.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98