### PR TITLE
Fix deadlock related to _stash_obj_in_tls

### DIFF
--- a/aten/src/ATen/ThreadLocalPythonObjects.cpp
+++ b/aten/src/ATen/ThreadLocalPythonObjects.cpp
@@ -29,5 +29,9 @@ const ThreadLocalPythonObjects& ThreadLocalPythonObjects::get_state() {
   return py_objects;
 }
 
+void ThreadLocalPythonObjects::clear_objs() {
+  obj_dict_.clear();
+}
+
 
 } // namespace at::impl

--- a/aten/src/ATen/ThreadLocalPythonObjects.h
+++ b/aten/src/ATen/ThreadLocalPythonObjects.h
@@ -13,6 +13,7 @@ struct TORCH_API ThreadLocalPythonObjects {
 
   static const ThreadLocalPythonObjects& get_state();
   static void set_state(ThreadLocalPythonObjects state);
+  void clear_objs();
 
  private:
   std::unordered_map<std::string, std::shared_ptr<c10::SafePyObject>> obj_dict_;

--- a/aten/src/ATen/ThreadLocalState.cpp
+++ b/aten/src/ATen/ThreadLocalState.cpp
@@ -36,6 +36,10 @@ void ThreadLocalState::set_multithreading_enabled(bool enabled) {
   autograd_tls_.set_multithreading_enabled(enabled);
 }
 
+void ThreadLocalState::clear_saved_py_objects() {
+  saved_objects_.clear_objs();
+}
+
 /* static */
 void ThreadLocalState::setThreadLocalState(
     const ThreadLocalState& state) {

--- a/aten/src/ATen/ThreadLocalState.h
+++ b/aten/src/ATen/ThreadLocalState.h
@@ -35,6 +35,11 @@ class TORCH_API ThreadLocalState {
   //  autograd engine.
   void set_multithreading_enabled(bool enabled);
 
+  // Manually clearing python objects is useful for device threads where we know
+  // the calling thread has a shared_ptr so we can drop our shared_ptr without
+  // needing to acquire the gil.
+  void clear_saved_py_objects();
+
   // Sets thread local variables in the current thread,
   // according to the thread boundary specified
   static void setThreadLocalState(const ThreadLocalState& state);

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -13674,6 +13674,31 @@ class TestAutogradDeviceType(TestCase):
         self.assertEqual(model.a.grad.device, torch.device("cpu"))
         self.assertEqual(model.b.grad.device, torch.device("cpu"))
 
+    @onlyCUDA
+    def test_tls_stash_not_destroyed_on_device_thread(self, device):
+        """SafePyObjects in GraphTask.thread_locals_ should be cleared in
+        exec_post_processing so they are never destroyed on a device thread
+        (where the GIL acquisition in the destructor can deadlock)."""
+        destroyed_on = []
+
+        class Ref:
+            def __del__(self):
+                destroyed_on.append(threading.current_thread())
+
+        main_thread = threading.current_thread()
+
+        for _ in range(20):
+            destroyed_on.clear()
+            torch._C._stash_obj_in_tls("test_obj", Ref())
+
+            x = torch.randn(10, device=device, requires_grad=True)
+            (x * x).sum().backward()
+
+            torch._C._stash_obj_in_tls("test_obj", None)
+
+            self.assertEqual(len(destroyed_on), 1)
+            self.assertIs(destroyed_on[0], main_thread)
+
 
 class TestAllowMutationOnSaved(TestCase):
     def assertClonedLenEqual(self, ctx, n):

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -778,6 +778,11 @@ void GraphTask::exec_post_processing() {
       cb_lock.lock();
     }
   }
+  // Clear saved Python objects so that when local_graph_task goes out of
+  // scope on the device thread, SafePyObject::~SafePyObject doesn't fire.
+  // The calling thread's TLS still holds its own shared_ptr, so it will
+  // handle destruction with the GIL held.
+  this->thread_locals_.clear_saved_py_objects();
 }
 
 void GraphTask::set_exception_without_signal(const std::shared_ptr<Node>& fn) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180700

There's potential deadlock related to _stash_obj_in_tls.  As of https://github.com/pytorch/pytorch/pull/173568 the
context object is stored in the calling thread TLS during _engine_run_backward.  Normally this object deallocated after
the backward pass completes, but there's a race where the autograd device thread can end up holding the last reference.
If this happens the context object gets deallocated by the device thread, which needs to acquire the GIL.  If another
thread happens to be holding the GIL while blocked on the device thread the result is a deadlock.  See
https://github.com/pytorch/pytorch/pull/173568 for more detail

The fix here avoids aquiring the GIL in the device thread by clearing the GraphTask's shared_ptr to the context object
during cleanup.  Since the TLS in the calling thread also has a shared_ptr, this avoids calling the SafePyObject
destructor (and therefore acquiring the GIL).  I'm not a huge fan of this approach since it introduces a manual cleanup
step, but I wasn't able to come up with something better.  Another option would be to use SafePyHandle instead of
SafePyObject and introduce a `_remove_obj_from_tls` python API.  But that makes the python side responsible for
refcounting, which feels wrong.

I'm also not sure exactly how we end up with a thread holding the GIL and also blocked on an autograd device thread.
That feels like a bug, but it seems to be triggered by Meta-internal code, so I'm not able to debug it.  All of which is
to say that this is the best approach I can come up with, but I'm very open to other suggestions.

Authored with Claude.