### PR TITLE
Back out "make `addmm` aware of cublas backend selection: a simple fix for #172231 (#172340)"

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -364,12 +364,6 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
   // if lt path fails, we recurse back into this function here and force the lt path to off
   // we cannot update variable disable_addmm_cuda_lt from above since it is static and would be permanent
   bool disable_addmm_cuda_lt = persistent_disable_addmm_cuda_lt || disable_addmm_cuda_lt_override;
-  // NOTE: See https://github.com/pytorch/pytorch/issues/172231
-  const auto preferred_cublas_backend = at::globalContext().blasPreferredBackend();
-  disable_addmm_cuda_lt = !(
-      preferred_cublas_backend == BlasBackend::Cublaslt
-      || preferred_cublas_backend == BlasBackend::Default // Lt is default
-  ) || disable_addmm_cuda_lt;
   #ifdef USE_ROCM
   // Conditioned on the device index, which is not persistent
   disable_addmm_cuda_lt = disable_addmm_cuda_lt || isGloballyDisabledAddmmCudaLt(self.device());

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -37,7 +37,6 @@ from torch.testing._internal.autocast_test_lists import AutocastTestLists, TestA
 from torch.testing._internal.common_cuda import (
     _create_scaling_case,
     _get_torch_cuda_version,
-    blas_library_context,
     PLATFORM_SUPPORTS_GREEN_CONTEXT,
     PLATFORM_SUPPORTS_WORKQUEUE_CONFIG,
     SM70OrLater,
@@ -747,9 +746,10 @@ print(t.is_pinned())
         IS_WINDOWS and SM89OrLater, "preferred_blas_library not supported on Windows"
     )
     @unittest.skipIf(TEST_CUDAMALLOCASYNC, "temporarily disabled for async")
+    @setBlasBackendsToDefaultFinally
     @serialTest()
-    @blas_library_context("cublas")
     def test_cublas_workspace_explicit_allocation(self):
+        torch.backends.cuda.preferred_blas_library("cublas")
         a = torch.randn(7, 7, device="cuda", requires_grad=False)
         if torch.version.hip:
             default_workspace_size = 1024 * 32 * 1024  # :1024:32  32MiB
@@ -2785,8 +2785,9 @@ exit(2)
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
     @serialTest()
-    @blas_library_context("cublas")
+    @setBlasBackendsToDefaultFinally
     def test_repeat_graph_capture_cublas_workspace_memory(self):
+        torch.backends.cuda.preferred_blas_library("cublas")
         (x, y, z) = 1024, 512, 64
         a = torch.rand((x, y), device="cuda")
         b = torch.rand((y, z), device="cuda")

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -66,7 +66,6 @@ from torch.fx._compatibility import _BACK_COMPAT_OBJECTS, _MARKED_WITH_COMPATIBI
 from torch.fx._symbolic_trace import PHBase, PHWithMeta
 
 from torch.fx.proxy import TraceError
-from torch.testing._internal.common_cuda import blas_library_context
 from torch.testing._internal.common_utils import (
     find_library_location,
     IS_FBCODE,
@@ -4434,7 +4433,6 @@ def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
     # This only fails on navi31
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     @torch.fx.experimental._config.patch("enrich_profiler_metadata", True)
-    @blas_library_context("cublaslt")
     def test_profiler_stack_trace_augmentation(self):
         """
         Test that map_recorded_events_to_aten_ops_with_stack_trace correctly

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -18,7 +18,6 @@ from torch.quantization._quantized_conversions import (
 
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import (
-    blas_library_context,
     PLATFORM_SUPPORTS_BF16,
     SM80OrLater,
     SM90OrLater,
@@ -76,6 +75,15 @@ def xfailIfSM100OrLaterNonRTXAndCondition(condition_fn):
         lambda params: computeCapabilityCheck and condition_fn(params)
     )
 
+
+@contextlib.contextmanager
+def blas_library_context(backend):
+    prev_backend = torch.backends.cuda.preferred_blas_library()
+    torch.backends.cuda.preferred_blas_library(backend)
+    try:
+        yield
+    finally:
+        torch.backends.cuda.preferred_blas_library(prev_backend)
 
 @contextlib.contextmanager
 def rocm_group_gemm_ck_env(value):

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -45,15 +45,6 @@ IS_SM90 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_ca
 IS_SM100 = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0))
 IS_SM12X = LazyVal(lambda: torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 12)
 
-@contextlib.contextmanager
-def blas_library_context(backend):
-    prev_backend = torch.backends.cuda.preferred_blas_library()
-    torch.backends.cuda.preferred_blas_library(backend)
-    try:
-        yield
-    finally:
-        torch.backends.cuda.preferred_blas_library(prev_backend)
-
 def evaluate_gfx_arch_within(arch_list):
     if not torch.cuda.is_available():
         return False


### PR DESCRIPTION
Summary:
Original commit changeset: 6042792e9f7d

Original Phabricator Diff: D95083507

Test Plan: existing unit tests

Differential Revision: D101390286


