### PR TITLE
[inductor][autotuning] add Launcher data structure for incremental autotuning (#180703)

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -1552,6 +1552,7 @@ exclusions = {
     "loop_tiling",
     "auto_chunker",
     "autotuning",
+    "incremental",
     "graph_region_expansion",
     "hierarchical_compile",
     "compute_dependencies",

--- a/test/inductor/test_incremental_autotune.py
+++ b/test/inductor/test_incremental_autotune.py
@@ -1,0 +1,104 @@
+# Owner(s): ["module: inductor"]
+
+import queue
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+from torch._inductor.test_case import run_tests, TestCase
+
+
+def _wait_until(predicate, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class ResolverTest(TestCase):
+    def setUp(self):
+        from torch._inductor.runtime.incremental import _resolver
+
+        self._resolver = _resolver
+        # Short idle timeout so the daemon exits quickly between tests.
+        self._timeout_patcher = patch.object(_resolver, "_IDLE_TIMEOUT_S", 0.05)
+        self._timeout_patcher.start()
+        _wait_until(self._daemon_stopped, timeout=10.0)
+
+    def tearDown(self):
+        while not self._resolver._global_event_queue.empty():
+            try:
+                self._resolver._global_event_queue.get_nowait()
+            except queue.Empty:
+                break
+        _wait_until(self._daemon_stopped, timeout=10.0)
+        self._timeout_patcher.stop()
+
+    def _daemon_stopped(self) -> bool:
+        with self._resolver._global_resolver_lock:
+            return self._resolver._global_resolver_thread is None
+
+    def test_submit_event_puts_then_ensures_daemon(self):
+        """Put-then-ensure ordering: item is visible when daemon checks empty()."""
+        with (
+            patch.object(self._resolver, "_ensure_daemon") as mock_ensure,
+            patch.object(self._resolver._global_event_queue, "put") as mock_put,
+        ):
+            call_order = []
+            mock_put.side_effect = lambda *a, **k: call_order.append("put")
+            mock_ensure.side_effect = lambda: call_order.append("ensure")
+
+            self._resolver.submit_event(MagicMock(), MagicMock(), MagicMock())
+
+        self.assertEqual(call_order, ["put", "ensure"])
+
+    def test_daemon_processes_event_and_invokes_callback(self):
+        """Submitted events are synchronized and the callback receives elapsed_ms."""
+        done = threading.Event()
+        received: list[float] = []
+
+        def callback(elapsed_ms: float) -> None:
+            received.append(elapsed_ms)
+            done.set()
+
+        start_event = MagicMock()
+        end_event = MagicMock()
+        start_event.elapsed_time.return_value = 42.0
+
+        self._resolver.submit_event(callback, start_event, end_event)
+
+        self.assertTrue(done.wait(timeout=5.0))
+        self.assertEqual(received, [42.0])
+        end_event.synchronize.assert_called_once()
+        start_event.elapsed_time.assert_called_once_with(end_event)
+
+    def test_daemon_idles_out_after_processing(self):
+        """After processing all events, the daemon exits and clears the global slot."""
+        done = threading.Event()
+        start_event = MagicMock()
+        start_event.elapsed_time.return_value = 1.0
+        self._resolver.submit_event(lambda _: done.set(), start_event, MagicMock())
+        self.assertTrue(done.wait(timeout=5.0))
+
+        self.assertTrue(_wait_until(self._daemon_stopped, timeout=5.0))
+
+    def test_daemon_restarts_after_idle_exit(self):
+        """A second submit_event after idle-out is processed by a fresh daemon."""
+        done1 = threading.Event()
+        ev_a = MagicMock()
+        ev_a.elapsed_time.return_value = 1.0
+        self._resolver.submit_event(lambda _: done1.set(), ev_a, MagicMock())
+        self.assertTrue(done1.wait(timeout=5.0))
+        self.assertTrue(_wait_until(self._daemon_stopped, timeout=5.0))
+
+        done2 = threading.Event()
+        ev_b = MagicMock()
+        ev_b.elapsed_time.return_value = 2.0
+        self._resolver.submit_event(lambda _: done2.set(), ev_b, MagicMock())
+        self.assertTrue(done2.wait(timeout=5.0))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_incremental_autotune.py
+++ b/test/inductor/test_incremental_autotune.py
@@ -1,10 +1,13 @@
 # Owner(s): ["module: inductor"]
 
+import gc
 import queue
 import threading
 import time
 from unittest.mock import MagicMock, patch
 
+from torch._inductor.runtime.incremental._launcher import Launcher
+from torch._inductor.runtime.incremental.config import TimingAggregation
 from torch._inductor.test_case import run_tests, TestCase
 
 
@@ -15,6 +18,177 @@ def _wait_until(predicate, timeout: float = 5.0) -> bool:
             return True
         time.sleep(0.01)
     return False
+
+
+def _make_launcher(name: str = "launcher") -> Launcher:
+    fn = MagicMock()
+    fn.return_value = f"result_{name}"
+    launcher = Launcher(fn=fn, metadata={"config": f"config:{name}"})
+    # Production keeps fn alive via CachingAutotuner.launchers; tests stash
+    # it on the launcher so the weakref doesn't die immediately.
+    launcher._fn_keepalive = fn  # pyrefly: ignore
+    return launcher
+
+
+class LauncherTest(TestCase):
+    def test_timing_empty(self):
+        launcher = _make_launcher()
+        self.assertEqual(launcher.timing, float("inf"))
+
+    def test_call_delegates_to_fn(self):
+        launcher = _make_launcher("test")
+        result = launcher(1, 2, stream=0)
+        self.assertEqual(result, "result_test")
+        launcher._fn_keepalive.assert_called_once_with(1, 2, stream=0)
+
+    def test_call_raises_when_fn_garbage_collected(self):
+        """fn is held weakly; once the only strong ref drops, __call__ asserts."""
+
+        class _Callable:
+            def __call__(self) -> str:
+                return "ok"
+
+        fn = _Callable()
+        launcher = Launcher(fn=fn)
+        del fn
+        gc.collect()
+        with self.assertRaises(AssertionError):
+            launcher(stream=0)
+
+    def test_set_fn_swaps_and_resets_warm(self):
+        original = MagicMock(return_value="orig")
+        launcher = Launcher(fn=original, metadata={"config": "c"})
+        launcher._fn_keepalive = original  # pyrefly: ignore
+        launcher(stream=0)
+        self.assertTrue(launcher.is_warm)
+
+        replacement = MagicMock(return_value="new")
+        launcher.set_fn(replacement)
+        launcher._fn_keepalive = replacement  # pyrefly: ignore
+        self.assertFalse(launcher.is_warm)
+        self.assertEqual(launcher(stream=0), "new")
+        self.assertTrue(launcher.is_warm)
+
+    def test_set_fn_preserves_timings(self):
+        """set_fn assumes fn is interchangeable, so timings must not be cleared."""
+        launcher = _make_launcher()
+        launcher.add_timing(1.0)
+        launcher.add_timing(2.0)
+        new_fn = MagicMock(return_value="new")
+        launcher.set_fn(new_fn)
+        launcher._fn_keepalive = new_fn  # pyrefly: ignore
+        self.assertEqual(launcher.num_available_timings, 2)
+        self.assertAlmostEqual(launcher.timing, 1.5)
+
+    def test_first_call_sets_warm(self):
+        launcher = _make_launcher()
+        self.assertFalse(launcher.is_warm)
+        launcher(stream=0)
+        self.assertTrue(launcher.is_warm)
+
+    def test_metadata(self):
+        launcher = Launcher(fn=lambda: None, metadata={"key": "value"})
+        self.assertEqual(launcher.metadata["key"], "value")
+
+    def test_metadata_default_is_empty(self):
+        launcher = Launcher(fn=lambda: None)
+        self.assertEqual(launcher.metadata, {})
+
+    def test_untimed_call_does_not_track_timing(self):
+        launcher = _make_launcher()
+        launcher(stream=0)
+        launcher(stream=0)
+        self.assertEqual(launcher.num_in_flight_timings, 0)
+        self.assertEqual(launcher.num_available_timings, 0)
+        self.assertEqual(launcher.num_total_timings, 0)
+
+    def test_timed_call_increments_in_flight_and_submits_event(self):
+        launcher = _make_launcher()
+        start_event = MagicMock()
+        end_event = MagicMock()
+        events = iter([start_event, end_event])
+        with (
+            patch("torch.cuda.Event", side_effect=lambda **_: next(events)),
+            patch(
+                "torch._inductor.runtime.incremental._launcher.submit_event"
+            ) as mock_submit,
+        ):
+            launcher(stream=0, timed=True)
+            self.assertEqual(launcher.num_in_flight_timings, 1)
+            mock_submit.assert_called_once_with(
+                launcher.add_timing, start_event, end_event
+            )
+
+    def test_add_timing_appends_to_available(self):
+        launcher = _make_launcher()
+        with launcher._lock:
+            launcher._num_timings_in_flight = 2
+        launcher.add_timing(1.0)
+        self.assertEqual(launcher.num_in_flight_timings, 1)
+        self.assertEqual(launcher.num_available_timings, 1)
+        launcher.add_timing(2.0)
+        self.assertEqual(launcher.num_in_flight_timings, 0)
+        self.assertEqual(launcher.num_available_timings, 2)
+
+    def test_num_total_timings_sums_in_flight_and_available(self):
+        launcher = _make_launcher()
+        with launcher._lock:
+            launcher._num_timings_in_flight = 3
+        self.assertEqual(launcher.num_total_timings, 3)
+        launcher.add_timing(1.0)
+        self.assertEqual(launcher.num_total_timings, 3)
+
+    def test_concurrent_add_timing_is_thread_safe(self):
+        """add_timing is called from the resolver thread; the lock must
+        protect _timings and _num_timings_in_flight against the main
+        thread's concurrent reads/writes.
+        """
+        launcher = _make_launcher()
+        n_threads = 4
+        per_thread = 250
+        total = n_threads * per_thread
+        with launcher._lock:
+            launcher._num_timings_in_flight = total
+
+        def worker() -> None:
+            for _ in range(per_thread):
+                launcher.add_timing(1.0)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(launcher.num_available_timings, total)
+        self.assertEqual(launcher.num_in_flight_timings, 0)
+
+    def test_timing_median_odd(self):
+        launcher = _make_launcher()
+        for v in [5.0, 1.0, 3.0]:
+            launcher.add_timing(v)
+        self.assertAlmostEqual(launcher.timing, 3.0)
+
+    def test_timing_median_even(self):
+        launcher = _make_launcher()
+        for v in [4.0, 2.0]:
+            launcher.add_timing(v)
+        self.assertAlmostEqual(launcher.timing, 3.0)
+
+    def test_timing_median_ignores_outliers(self):
+        launcher = _make_launcher()
+        for v in [1.0, 2.0, 3.0, 4.0, 100.0]:
+            launcher.add_timing(v)
+        self.assertAlmostEqual(launcher.timing, 3.0)
+
+    def test_timing_uses_mean_when_configured(self):
+        launcher = _make_launcher()
+        for v in [1.0, 2.0, 3.0, 4.0, 100.0]:
+            launcher.add_timing(v)
+        with patch(
+            "torch._inductor.runtime.incremental._launcher.timing_aggregation",
+            TimingAggregation.MEAN,
+        ):
+            self.assertAlmostEqual(launcher.timing, 22.0)
 
 
 class ResolverTest(TestCase):

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -47,6 +47,8 @@ from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
     autotune_hints_to_configs,
     CachingAutotuner,
+    CachingAutotunerPlugin,
+    DEFER,
     template,
     triton_config,
 )
@@ -302,6 +304,100 @@ class TestTritonHeuristics(TestCase):
                 config_heuristic.get_mm_configs()(3, 3, 3, dtype_size=4, op_name="mm")
             )
             self.assertEqual(len(configs), expected_count)
+
+
+_PLUGIN_FACTORY_PATH = (
+    "torch._inductor.runtime.triton_heuristics.get_caching_autotuner_plugins"
+)
+
+
+class TestCachingAutotunerPlugin(TestCase):
+    device_type = GPU_TYPE
+
+    @staticmethod
+    def _make_kernel_inputs():
+        in_ptr = torch.zeros(16, device=GPU_TYPE, dtype=torch.float32)
+        out_ptr = torch.zeros(16, device=GPU_TYPE, dtype=torch.float32)
+        return (in_ptr, out_ptr, 16)
+
+    def _make_autotuner(self, plugins, configs=None):
+        args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
+        args["inductor_meta"] = {**args["inductor_meta"], "grid_type": "Grid1D"}
+        if configs is not None:
+            args["configs"] = configs
+        with patch(_PLUGIN_FACTORY_PATH, return_value=list(plugins)):
+            return CachingAutotuner(**args)
+
+    def test_pre_dispatch_runs_before_precompile_and_autotune(self):
+        sentinel = object()
+
+        class _Plugin(CachingAutotunerPlugin):
+            def pre_dispatch(self, autotuner, *args, stream, **kwargs):
+                return sentinel
+
+        autotuner = self._make_autotuner([_Plugin()])
+        with (
+            patch.object(autotuner, "precompile") as mock_precompile,
+            patch.object(autotuner, "autotune_to_one_config") as mock_autotune,
+        ):
+            result = autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertIs(result, sentinel)
+        mock_precompile.assert_not_called()
+        mock_autotune.assert_not_called()
+
+    def test_pre_autotune_runs_before_default_autotune(self):
+        sentinel = object()
+
+        class _Plugin(CachingAutotunerPlugin):
+            def pre_autotune(self, autotuner, *args, stream, **kwargs):
+                return sentinel
+
+        autotuner = self._make_autotuner([_Plugin()])
+        with patch.object(autotuner, "autotune_to_one_config") as mock_autotune:
+            result = autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertIs(result, sentinel)
+        mock_autotune.assert_not_called()
+
+    def test_hooks_fire_in_registration_order(self):
+        sentinel = object()
+        seen = []
+
+        class _Plugin(CachingAutotunerPlugin):
+            def __init__(self, name, return_value=DEFER):
+                self.name = name
+                self.return_value = return_value
+
+            def pre_dispatch(self, autotuner, *args, stream, **kwargs):
+                seen.append(self.name)
+                return self.return_value
+
+        autotuner = self._make_autotuner(
+            [_Plugin("a"), _Plugin("b"), _Plugin("c", sentinel), _Plugin("d")]
+        )
+        result = autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertIs(result, sentinel)
+        self.assertEqual(seen, ["a", "b", "c"])
+
+    def test_defer_falls_through_to_default(self):
+        seen = []
+
+        class _Plugin(CachingAutotunerPlugin):
+            def pre_dispatch(self, autotuner, *args, stream, **kwargs):
+                seen.append("pre_dispatch")
+                return DEFER
+
+        # Single config so precompile produces one launcher and the kernel
+        # runs to completion without the autotune branch firing.
+        full_args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
+        autotuner = self._make_autotuner([_Plugin()], configs=full_args["configs"][:1])
+
+        autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertEqual(seen, ["pre_dispatch"])
+        self.assertEqual(len(autotuner.launchers), 1)
 
 
 class TestArgumentCloneAndRestore(TestCase):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -512,6 +512,11 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 # enable slow autotuning passes to select gemm algorithms
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 
+# When True, autotuning is spread across real kernel invocations instead of
+# blocking on the first call. Each run() call executes one config and records
+# timing via CUDA events, progressively eliminating underperforming configs.
+incremental_autotune: bool = os.environ.get("TORCHINDUCTOR_INCREMENTAL_AUTOTUNE") == "1"
+
 inductor_default_autotune_warmup = int(
     os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_WARMUP", 25)
 )

--- a/torch/_inductor/runtime/incremental/_launcher.py
+++ b/torch/_inductor/runtime/incremental/_launcher.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import bisect
+import threading
+import weakref
+from typing import TYPE_CHECKING
+
+import torch
+
+from ._resolver import submit_event
+from .config import timing_aggregation, TimingAggregation
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class Launcher:
+    """A callable kernel wrapper that collects timing samples.
+
+    Holds a weak reference to the wrapped function ``fn``, a metadata
+    dict, and a list of timing samples. Call the instance to dispatch
+    the kernel; pass ``timed=True`` to record a CUDA-event timed
+    dispatch (the daemon calls ``add_timing`` later when the events
+    resolve). Read ``timing`` for the aggregated representative latency
+    (median or mean, selected via ``config.timing_aggregation``).
+
+    fn lifecycle: ``fn`` is held via a weakref because Launchers are
+    cached for reuse across compilations. A single ``fn`` holds a
+    trivial amount of device memory, but a full set of fns for an
+    entire compiled graph adds up — keeping them pinned in the cache
+    after autotuning has converged would hold substantial device memory
+    indefinitely. The weakref lets ``fn`` be garbage-collected as soon
+    as nothing outside the Launcher references it. The contract is that
+    ``IncrementalAutotuneState`` owns ``fn``'s lifecycle: it holds the
+    strong reference while the launcher is in active use and drops it
+    once the launcher is filtered or convergence is reached.
+    ``set_fn`` swaps in a fresh ``fn`` when an existing cached launcher
+    is reused after its previous ``fn`` has been collected.
+
+    Threading: ``__call__`` and ``set_fn`` are only ever invoked from
+    the main (dispatch) thread, so they don't take ``_lock`` to read or
+    write ``_fn_ref`` / ``_warm``. ``add_timing`` and the timing-count
+    properties may be called concurrently from the resolver daemon
+    thread, so they take ``_lock`` to protect ``_timings`` and
+    ``_num_timings_in_flight``.
+    """
+
+    def __init__(
+        self,
+        fn: Callable[..., object],
+        metadata: dict[str, object] | None = None,
+    ) -> None:
+        self._fn_ref: weakref.ref[Callable[..., object]] = weakref.ref(fn)
+        self.metadata: dict[str, object] = metadata if metadata is not None else {}
+
+        self._timings: list[float] = []
+        self._num_timings_in_flight: int = 0
+        self._warm: bool = False
+        self._lock: threading.Lock = threading.Lock()
+
+    def set_fn(self, fn: Callable[..., object]) -> None:
+        """Refresh the underlying callable; resets the warm flag.
+
+        Assumes the new ``fn`` is interchangeable with the old (e.g., a
+        re-compiled equivalent of the same kernel/config), so the
+        accumulated timing samples remain meaningful and only ``_warm``
+        is reset to force the new fn to warm up before its next timed
+        dispatch. No lock — see the threading note in the class
+        docstring.
+        """
+        self._fn_ref = weakref.ref(fn)
+        self._warm = False
+
+    def __call__(
+        self,
+        *args: object,
+        timed: bool = False,
+        **kwargs: object,
+    ) -> object:
+        fn = self._fn_ref()
+        assert fn is not None, "Launcher's fn has been garbage-collected"
+        self._warm = True
+        if not timed:
+            return fn(*args, **kwargs)
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        # Two failure modes for fn under timed dispatch:
+        #   A) Launch failure (e.g., invalid configuration argument):
+        #      raises synchronously here, before we increment
+        #      _num_timings_in_flight, so the counter stays consistent
+        #      and the caller observes the error normally.
+        #   B) Execution failure (e.g., illegal memory access): is
+        #      asynchronous and only surfaces on the next device
+        #      sync (typically far away, on a different code path). We
+        #      don't reconcile the counter for this case — such failures
+        #      are assumed fatal to the entire program, so a small
+        #      bookkeeping desync on a Launcher that is about to be
+        #      discarded is moot.
+        result = fn(*args, **kwargs)
+        end_event.record()
+        with self._lock:
+            self._num_timings_in_flight += 1
+        submit_event(self.add_timing, start_event, end_event)
+        return result
+
+    def add_timing(self, elapsed_ms: float) -> None:
+        """Record a timing sample and decrement the in-flight counter."""
+        with self._lock:
+            bisect.insort(self._timings, elapsed_ms)
+            self._num_timings_in_flight -= 1
+
+    @property
+    def is_warm(self) -> bool:
+        return self._warm
+
+    @property
+    def num_available_timings(self) -> int:
+        with self._lock:
+            return len(self._timings)
+
+    @property
+    def num_in_flight_timings(self) -> int:
+        with self._lock:
+            return self._num_timings_in_flight
+
+    @property
+    def num_total_timings(self) -> int:
+        with self._lock:
+            return len(self._timings) + self._num_timings_in_flight
+
+    @property
+    def _median(self) -> float:
+        with self._lock:
+            if not self._timings:
+                return float("inf")
+            n = len(self._timings)
+            mid = n // 2
+            if n % 2 == 1:
+                return self._timings[mid]
+            return (self._timings[mid - 1] + self._timings[mid]) / 2
+
+    @property
+    def _mean(self) -> float:
+        with self._lock:
+            if not self._timings:
+                return float("inf")
+            return sum(self._timings) / len(self._timings)
+
+    @property
+    def timing(self) -> float:
+        """Representative timing aggregated per the configured strategy."""
+        match timing_aggregation:
+            case TimingAggregation.MEAN:
+                return self._mean
+            case TimingAggregation.MEDIAN:
+                return self._median
+            case _:
+                # Defensive: TimingAggregation is exhaustively matched
+                # above so this branch is currently unreachable. Keep it
+                # so that adding a new TimingAggregation member without
+                # a matching case fails loudly at dispatch time instead
+                # of silently returning the wrong aggregation.
+                raise ValueError(f"Unknown timing aggregation: {timing_aggregation!r}")

--- a/torch/_inductor/runtime/incremental/_resolver.py
+++ b/torch/_inductor/runtime/incremental/_resolver.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import queue
+import threading
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from ._utils import log
+from .config import _IDLE_TIMEOUT_S
+
+
+if TYPE_CHECKING:
+    import torch
+
+
+TimingCallback = Callable[[float], None]
+
+_QueueItem = tuple[TimingCallback, "torch.cuda.Event", "torch.cuda.Event"]
+
+_global_event_queue: queue.Queue[_QueueItem] = queue.Queue()
+_global_resolver_lock: threading.Lock = threading.Lock()
+_global_resolver_thread: threading.Thread | None = None
+
+
+def submit_event(
+    callback: TimingCallback,
+    start_event: torch.cuda.Event,
+    end_event: torch.cuda.Event,
+) -> None:
+    """Enqueue a CUDA event pair for async timing resolution.
+
+    The daemon synchronizes on ``end_event``, computes elapsed time, and
+    invokes ``callback(elapsed_ms)``. Starts the global resolver daemon
+    if it is not already running.
+    """
+    # Put-then-ensure ordering closes a termination race: if we ensured first
+    # and a daemon was idling out concurrently, it could exit between our
+    # ensure and our put, leaving the item orphaned. Putting first guarantees
+    # the daemon's empty()-check (also under _global_resolver_lock) sees it.
+    _global_event_queue.put((callback, start_event, end_event))
+    _ensure_daemon()
+
+
+def _ensure_daemon() -> None:
+    global _global_resolver_thread
+    with _global_resolver_lock:
+        if _global_resolver_thread is not None:
+            return
+        t = threading.Thread(
+            target=_global_event_resolver_loop,
+            daemon=True,
+            name="autotune-event-resolver",
+        )
+        t.start()
+        _global_resolver_thread = t
+        log.info(
+            "Incremental autotune event resolver started (thread id=%d)",
+            t.ident,
+        )
+
+
+def _global_event_resolver_loop() -> None:
+    global _global_resolver_thread
+
+    while True:
+        try:
+            item = _global_event_queue.get(timeout=_IDLE_TIMEOUT_S)
+        except queue.Empty:
+            # Consumer side of the put-then-ensure race close: a producer may
+            # have called put() between our get() raising Empty and our
+            # acquiring the lock. Re-check empty() under the lock so we don't
+            # exit while an item is sitting in the queue.
+            with _global_resolver_lock:
+                if _global_event_queue.empty():
+                    _global_resolver_thread = None
+                    log.info(
+                        "Incremental autotune event resolver stopped (idle timeout)"
+                    )
+                    return
+                continue
+
+        callback, start_event, end_event = item
+        try:
+            end_event.synchronize()
+            elapsed_ms: float = start_event.elapsed_time(end_event)
+            callback(elapsed_ms)
+        except Exception:
+            # Silently drop. We assume any underlying CUDA fault will
+            # resurface on the main thread's next CUDA op (e.g.
+            # ``torch.cuda.synchronize``) and would rather not surface it
+            # twice from a background thread with no clear ownership.
+            log.debug(
+                "Incremental autotune: timing resolution failed",
+                exc_info=True,
+            )

--- a/torch/_inductor/runtime/incremental/_utils.py
+++ b/torch/_inductor/runtime/incremental/_utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from torch._logging import getArtifactLogger
+
+
+if TYPE_CHECKING:
+    import logging
+
+
+log: logging.Logger = getArtifactLogger(__name__, "incremental")

--- a/torch/_inductor/runtime/incremental/config.py
+++ b/torch/_inductor/runtime/incremental/config.py
@@ -1,5 +1,18 @@
 from __future__ import annotations
 
+import os
+from enum import Enum
+
+
+class TimingAggregation(str, Enum):
+    MEAN = "MEAN"
+    MEDIAN = "MEDIAN"
+
+
+timing_aggregation: TimingAggregation = TimingAggregation(
+    os.environ.get("TORCHINDUCTOR_INCREMENTAL_TIMING_AGGREGATION", "MEDIAN").upper()
+)
+
 
 # The event resolver daemon exits after this many seconds with no events.
 _IDLE_TIMEOUT_S: int = 600

--- a/torch/_inductor/runtime/incremental/config.py
+++ b/torch/_inductor/runtime/incremental/config.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+# The event resolver daemon exits after this many seconds with no events.
+_IDLE_TIMEOUT_S: int = 600

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -19,7 +19,7 @@ import sys
 import threading
 import time
 from collections import namedtuple
-from typing import Any, Generic, Literal, TYPE_CHECKING, TypeVar
+from typing import Any, Final, Generic, Literal, TYPE_CHECKING, TypeVar
 
 import torch
 from torch._dynamo.utils import counters, set_feature_use
@@ -321,6 +321,51 @@ def check_autotune_cache(
     return configs, autotune_cache, autotune_cache_info
 
 
+# Sentinel returned by plugin hooks to defer to the next plugin or to the
+# default behavior. Tested with ``is DEFER``.
+DEFER: Final[object] = object()
+
+
+class CachingAutotunerPlugin:
+    """Base class for ``CachingAutotuner`` plugins.
+
+    Each hook returns ``DEFER`` to fall through to the next plugin / default
+    behavior, or any other value to short-circuit ``run()`` with that value.
+    """
+
+    def pre_dispatch(
+        self,
+        autotuner: CachingAutotuner,
+        *args: object,
+        stream: object,
+        **kwargs: object,
+    ) -> object:
+        """Fires before kernel dispatch, ahead of precompile or autotune."""
+        return DEFER
+
+    def pre_autotune(
+        self,
+        autotuner: CachingAutotuner,
+        *args: object,
+        stream: object,
+        **kwargs: object,
+    ) -> object:
+        """Fires after precompile when more than one launcher remains, in
+        place of ``autotune_to_one_config()``."""
+        return DEFER
+
+
+def get_caching_autotuner_plugins(
+    autotuner: CachingAutotuner,
+) -> list[CachingAutotunerPlugin]:
+    """Build the list of plugins active for ``autotuner``.
+
+    Each plugin adds an entry here, gated on its own config flag, with
+    imports kept inside the relevant branch.
+    """
+    return []
+
+
 class CachingAutotuner(KernelInterface):
     """
     Simplified version of Triton autotuner that has no invalidation
@@ -438,6 +483,8 @@ class CachingAutotuner(KernelInterface):
 
         self._debug_call: _TritonKernelCall | None = None
         self._profiler_ctx: _RecordFunctionFast | None = None
+
+        self._plugins = get_caching_autotuner_plugins(self)
 
         # Compile-time info included in runtime logginging
         self.compile_id: CompileId | None = None
@@ -741,11 +788,13 @@ class CachingAutotuner(KernelInterface):
         return {
             **self.__dict__,
             "lock": None,
+            "_plugins": [],
         }
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
         self.lock = threading.Lock()
+        self._plugins = get_caching_autotuner_plugins(self)
 
     def get_device_interface(self):
         # this code cannot run in compile workers, because it imports from torch
@@ -1737,13 +1786,28 @@ class CachingAutotuner(KernelInterface):
                 **self.configs[0].kwargs,
             )
 
+        for plugin in self._plugins:
+            if (
+                result := plugin.pre_dispatch(self, *args, stream=stream, **kwargs)
+            ) is not DEFER:
+                return result
+
         if len(self.launchers) != 1:
             if len(self.launchers) == 0:
                 start_time = time.time_ns()
                 self.precompile()
                 self.precompile_time_taken_ns = time.time_ns() - start_time
             if len(self.launchers) > 1:
-                self.autotune_to_one_config(*args, **kwargs)
+                for plugin in self._plugins:
+                    if (
+                        result := plugin.pre_autotune(
+                            self, *args, stream=stream, **kwargs
+                        )
+                    ) is not DEFER:
+                        return result
+                # Re-check: a plugin may have mutated launchers down to one.
+                if len(self.launchers) > 1:
+                    self.autotune_to_one_config(*args, **kwargs)
 
         if self.inductor_meta.get("combo_tuning_groups") and not getattr(
             self.launchers[0].config, "found_by_combo_autotune", False

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -257,6 +257,7 @@ def set_logs(
     cudagraph_static_inputs: bool = False,
     benchmarking: bool = False,
     autotuning: bool = False,
+    incremental: bool = False,
     graph_region_expansion: bool = False,
     inductor_metrics: bool = False,
     hierarchical_compile: bool = False,
@@ -457,6 +458,9 @@ def set_logs(
         autotuning (:class:`bool`):
             Autotuning choice logs, such as kernel source, perf, and tuning parameters. Default: ``False``
 
+        incremental (:class:`bool`):
+            Incremental autotuning logs. Default: ``False``
+
         graph_region_expansion (:class:`bool`):
             Whether to emit the detailed steps of the duplicate graph region tracker expansion algorithm. Default: ``False``
 
@@ -585,6 +589,7 @@ def set_logs(
         cudagraph_static_inputs=cudagraph_static_inputs,
         benchmarking=benchmarking,
         autotuning=autotuning,
+        incremental=incremental,
         graph_region_expansion=graph_region_expansion,
         inductor_metrics=inductor_metrics,
         hierarchical_compile=hierarchical_compile,

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -241,6 +241,11 @@ register_artifact(
     off_by_default=True,
 )
 register_artifact(
+    "incremental",
+    "Incremental autotuning logs.",
+    off_by_default=True,
+)
+register_artifact(
     "node_runtime_estimation",
     "Node runtime estimation for compile-time optimization decisions.",
     off_by_default=True,


### PR DESCRIPTION
Summary:

Introduces the `Launcher` class — a callable kernel wrapper that handle both timed and untimed kernel launches; integrates with the global event resolver daemon to asynchronously track and update timing values for prior timed launches.

The majority of the complexity here comes from the fact that `Launcher` holds only a weakref of the underlying kernel `fn`; `Launcher` instances are cached later on in this stack, such that equivalent kernels share their accumulated timings values. If we were to hold a strong reference to every kernel then they would never be gc'ed since the cache is alive for the duration of the program. We leave the lifecycle management up to the incremental state.

Authored with Claude.

Test Plan:
# Full test suite for the new test file
```
buck test fbcode//mode/opt -m ovr_config//triton:beta -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor:incremental_autotune
```

# Only the new test class
```
buck test fbcode//mode/opt -m ovr_config//triton:beta -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor:incremental_autotune -- LauncherTest
```

Differential Revision: D101329075




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98