### PR TITLE
[inductor][autotuning] register IncrementalAutotunePlugin in CachingAutotuner

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -1552,6 +1552,7 @@ exclusions = {
     "loop_tiling",
     "auto_chunker",
     "autotuning",
+    "incremental",
     "graph_region_expansion",
     "hierarchical_compile",
     "compute_dependencies",

--- a/test/inductor/test_incremental_autotune.py
+++ b/test/inductor/test_incremental_autotune.py
@@ -337,5 +337,88 @@ class ResolverTest(TestCase):
         self.assertEqual(call_order, ["put", "ensure"])
 
 
+class CacheTest(TestCase):
+    @staticmethod
+    def _make_autotuner_mock(name="triton_kernel", src="def triton_kernel():..."):
+        """Build a minimal CachingAutotuner-shaped mock for cache key tests."""
+        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+        autotuner = MagicMock(spec=CachingAutotuner)
+        autotuner.fn = MagicMock()
+        autotuner.fn.__name__ = name
+        autotuner.fn.src = src
+        autotuner.inductor_meta = {"a": 1}
+        autotuner.triton_meta = {"b": 2}
+        return autotuner
+
+    @staticmethod
+    def _make_raw_launcher(x_block: int):
+        raw = MagicMock()
+        raw.config = MagicMock(kwargs={"X": x_block}, num_warps=4, num_stages=1)
+        raw.cache_hash = f"hash:{x_block}"
+        return raw
+
+    def test_kernel_key_none_when_fn_has_no_src(self):
+        from torch._inductor.runtime.incremental import _cache
+
+        autotuner = self._make_autotuner_mock()
+        del autotuner.fn.src
+        self.assertIsNone(_cache._caching_autotuner_kernel_key(autotuner))
+
+    def test_kernel_key_normalizes_kernel_name(self):
+        """Two autotuners with different kernel names but identical structure share a key."""
+        from torch._inductor.runtime.incremental import _cache
+
+        a = self._make_autotuner_mock(name="triton_a", src="def triton_a():\n    pass")
+        b = self._make_autotuner_mock(name="triton_b", src="def triton_b():\n    pass")
+        self.assertEqual(
+            _cache._caching_autotuner_kernel_key(a),
+            _cache._caching_autotuner_kernel_key(b),
+        )
+
+    def test_get_launcher_pool_shared_across_identical_autotuners(self):
+        from torch._inductor.runtime.incremental import _cache
+
+        a = self._make_autotuner_mock()
+        b = self._make_autotuner_mock()
+        with patch.object(_cache, "_caching_autotuner_registry", {}):
+            self.assertIs(_cache.get_launcher_pool(a), _cache.get_launcher_pool(b))
+
+    def test_get_launcher_pool_none_for_non_autotuner(self):
+        from torch._inductor.runtime.incremental import _cache
+
+        with patch.object(_cache, "_caching_autotuner_registry", {}):
+            self.assertIsNone(_cache.get_launcher_pool("not an autotuner"))
+
+    def test_get_or_create_launcher_reuses_existing(self):
+        from torch._inductor.runtime.incremental import _cache
+        from torch._inductor.runtime.incremental._launcher import (
+            Launcher as RealLauncher,
+        )
+
+        pool: dict[object, RealLauncher] = {}
+        raw = self._make_raw_launcher(x_block=16)
+        first = _cache.get_or_create_launcher(pool, raw, RealLauncher)
+        second = _cache.get_or_create_launcher(pool, raw, RealLauncher)
+        self.assertIs(first, second)
+        self.assertEqual(len(pool), 1)
+
+    def test_get_or_create_launcher_creates_new_for_distinct_config(self):
+        from torch._inductor.runtime.incremental import _cache
+        from torch._inductor.runtime.incremental._launcher import (
+            Launcher as RealLauncher,
+        )
+
+        pool: dict[object, RealLauncher] = {}
+        a = _cache.get_or_create_launcher(
+            pool, self._make_raw_launcher(x_block=16), RealLauncher
+        )
+        b = _cache.get_or_create_launcher(
+            pool, self._make_raw_launcher(x_block=32), RealLauncher
+        )
+        self.assertIsNot(a, b)
+        self.assertEqual(len(pool), 2)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/inductor/test_incremental_autotune.py
+++ b/test/inductor/test_incremental_autotune.py
@@ -1,0 +1,71 @@
+# Owner(s): ["module: inductor"]
+
+from unittest.mock import MagicMock
+
+from torch._inductor.runtime.incremental._launcher import Launcher
+from torch._inductor.test_case import run_tests, TestCase
+
+
+def _make_launcher(name: str = "launcher") -> Launcher:
+    fn = MagicMock()
+    fn.return_value = f"result_{name}"
+    return Launcher(fn=fn, config=f"config:{name}")
+
+
+class LauncherTest(TestCase):
+    def test_timing_empty(self):
+        launcher = _make_launcher()
+        self.assertEqual(launcher.timing, float("inf"))
+
+    def test_sample_count(self):
+        launcher = _make_launcher()
+        launcher._add_timing(1.0)
+        launcher._add_timing(2.0)
+        self.assertEqual(launcher.sample_count, 2)
+
+    def test_add_timing_sorted(self):
+        launcher = _make_launcher()
+        launcher._add_timing(3.0)
+        launcher._add_timing(1.0)
+        launcher._add_timing(2.0)
+        self.assertEqual(launcher._timings, [1.0, 2.0, 3.0])
+
+    def test_timing_median_odd(self):
+        launcher = _make_launcher()
+        for v in [5.0, 1.0, 3.0]:
+            launcher._add_timing(v)
+        self.assertAlmostEqual(launcher.timing, 3.0)
+
+    def test_timing_median_even(self):
+        launcher = _make_launcher()
+        for v in [4.0, 2.0]:
+            launcher._add_timing(v)
+        self.assertAlmostEqual(launcher.timing, 3.0)
+
+    def test_timing_median_ignores_outliers(self):
+        launcher = _make_launcher()
+        for v in [1.0, 2.0, 3.0, 4.0, 100.0]:
+            launcher._add_timing(v)
+        self.assertAlmostEqual(launcher.timing, 3.0)
+
+    def test_dispatch_count_increments_on_call(self):
+        launcher = _make_launcher()
+        self.assertEqual(launcher.dispatch_count, 0)
+        launcher(stream=0)
+        self.assertEqual(launcher.dispatch_count, 1)
+        launcher(stream=0)
+        self.assertEqual(launcher.dispatch_count, 2)
+
+    def test_call_delegates_to_fn(self):
+        launcher = _make_launcher("test")
+        result = launcher(1, 2, stream=0)
+        self.assertEqual(result, "result_test")
+        launcher._fn.assert_called_once_with(1, 2, stream=0)
+
+    def test_metadata(self):
+        launcher = Launcher(fn=lambda: None, key="value")
+        self.assertEqual(launcher.metadata["key"], "value")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_incremental_autotune.py
+++ b/test/inductor/test_incremental_autotune.py
@@ -420,5 +420,97 @@ class CacheTest(TestCase):
         self.assertEqual(len(pool), 2)
 
 
+class PluginTest(TestCase):
+    """Coverage for IncrementalAutotunePlugin's activation gates and hook contracts."""
+
+    @staticmethod
+    def _make_autotuner_mock():
+        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+        autotuner = MagicMock(spec=CachingAutotuner)
+        autotuner.fn = MagicMock()
+        autotuner.fn.__name__ = "triton_kernel"
+        return autotuner
+
+    @staticmethod
+    def _patch_gates(
+        incremental: bool = True,
+        autotune_at_compile_time: bool = False,
+        cudagraphs: bool = False,
+        jk_passes: bool = True,
+    ):
+        """Combined patch for the four gates _should_apply consults."""
+        from torch._inductor import config as inductor_config
+        from torch._inductor.config import triton as inductor_triton_config
+        from torch._inductor.runtime.incremental import _plugin
+
+        return (
+            patch.object(inductor_config, "incremental_autotune", incremental),
+            patch.object(
+                inductor_triton_config,
+                "autotune_at_compile_time",
+                autotune_at_compile_time,
+            ),
+            patch.object(inductor_triton_config, "cudagraphs", cudagraphs),
+            patch.object(_plugin, "_jk_passes", lambda: jk_passes),
+        )
+
+    def _run_should_apply(self, **gate_kwargs) -> bool:
+        from torch._inductor.runtime.incremental import IncrementalAutotunePlugin
+
+        autotuner = self._make_autotuner_mock()
+        patches = self._patch_gates(**gate_kwargs)
+        for p in patches:
+            p.start()
+        try:
+            return IncrementalAutotunePlugin._should_apply(autotuner)
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_should_apply_false_when_config_disabled(self):
+        self.assertFalse(self._run_should_apply(incremental=False))
+
+    def test_should_apply_false_when_autotune_at_compile_time(self):
+        self.assertFalse(self._run_should_apply(autotune_at_compile_time=True))
+
+    def test_should_apply_false_when_cudagraphs(self):
+        self.assertFalse(self._run_should_apply(cudagraphs=True))
+
+    def test_should_apply_false_when_jk_blocks(self):
+        self.assertFalse(self._run_should_apply(jk_passes=False))
+
+    def test_should_apply_true_when_all_gates_pass(self):
+        self.assertTrue(self._run_should_apply())
+
+    def test_pre_dispatch_defers_when_no_state(self):
+        from torch._inductor.runtime.incremental import IncrementalAutotunePlugin
+        from torch._inductor.runtime.triton_heuristics import DEFER
+
+        plugin = IncrementalAutotunePlugin()
+        result = plugin.pre_dispatch(self._make_autotuner_mock(), stream=0)
+        self.assertIs(result, DEFER)
+
+    def test_pre_dispatch_delegates_to_state(self):
+        from torch._inductor.runtime.incremental import IncrementalAutotunePlugin
+
+        plugin = IncrementalAutotunePlugin()
+        plugin._state = MagicMock()
+        plugin._state.dispatch.return_value = "from_state"
+        result = plugin.pre_dispatch(self._make_autotuner_mock(), 1, 2, stream=0)
+        self.assertEqual(result, "from_state")
+        plugin._state.dispatch.assert_called_once_with(1, 2, stream=0)
+
+    def test_pre_autotune_defers_when_init_state_returns_none(self):
+        from torch._inductor.runtime.incremental import IncrementalAutotunePlugin
+        from torch._inductor.runtime.triton_heuristics import DEFER
+
+        plugin = IncrementalAutotunePlugin()
+        with patch.object(plugin, "_init_state", return_value=None):
+            result = plugin.pre_autotune(self._make_autotuner_mock(), stream=0)
+        self.assertIs(result, DEFER)
+        self.assertIsNone(plugin._state)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/inductor/test_incremental_autotune.py
+++ b/test/inductor/test_incremental_autotune.py
@@ -1,8 +1,10 @@
 # Owner(s): ["module: inductor"]
 
-from unittest.mock import MagicMock
+import threading
+from unittest.mock import MagicMock, patch
 
 from torch._inductor.runtime.incremental._launcher import Launcher
+from torch._inductor.runtime.incremental._state import IncrementalAutotuneState
 from torch._inductor.test_case import run_tests, TestCase
 
 
@@ -10,6 +12,13 @@ def _make_launcher(name: str = "launcher") -> Launcher:
     fn = MagicMock()
     fn.return_value = f"result_{name}"
     return Launcher(fn=fn, config=f"config:{name}")
+
+
+def _make_state(launchers: list[Launcher], **kwargs: object) -> IncrementalAutotuneState:
+    """Create an IncrementalAutotuneState with fresh stats for testing."""
+    state = IncrementalAutotuneState(**kwargs)
+    state.init_fresh(launchers)
+    return state
 
 
 class LauncherTest(TestCase):
@@ -65,6 +74,267 @@ class LauncherTest(TestCase):
     def test_metadata(self):
         launcher = Launcher(fn=lambda: None, key="value")
         self.assertEqual(launcher.metadata["key"], "value")
+
+
+class IncrementalAutotuneStateTest(TestCase):
+    def test_init_fresh_queue(self):
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state = _make_state([a, b])
+        self.assertIs(state._queue[0], a)
+        self.assertIs(state._queue[1], b)
+        self.assertEqual(len(state._queue), 2)
+        state.shutdown()
+
+    def test_next_launcher_skips_max_dispatched(self):
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state = _make_state([a, b])
+        with a._lock:
+            a.dispatch_count = 999
+        self.assertIs(state._next_launcher(), b)
+        state.shutdown()
+
+    def test_next_launcher_returns_none_when_exhausted(self):
+        a = _make_launcher("a")
+        state = _make_state([a])
+        with a._lock:
+            a.dispatch_count = 999
+        self.assertIsNone(state._next_launcher())
+        state.shutdown()
+
+    def test_should_skip_threshold(self):
+        best = _make_launcher("best")
+        slow = _make_launcher("slow")
+        state = _make_state([best, slow])
+        state.best_launcher = best
+        best._add_timing(1.0)
+        for _ in range(5):
+            slow._add_timing(2.0)
+        self.assertTrue(state._should_skip(slow))
+        state.shutdown()
+
+    def test_should_skip_below_threshold(self):
+        best = _make_launcher("best")
+        candidate = _make_launcher("candidate")
+        state = _make_state([best, candidate])
+        state.best_launcher = best
+        best._add_timing(1.0)
+        for _ in range(5):
+            candidate._add_timing(1.1)
+        self.assertFalse(state._should_skip(candidate))
+        state.shutdown()
+
+    def test_should_skip_not_enough_samples(self):
+        best = _make_launcher("best")
+        slow = _make_launcher("slow")
+        state = _make_state([best, slow])
+        state.best_launcher = best
+        best._add_timing(1.0)
+        slow._add_timing(10.0)
+        self.assertFalse(state._should_skip(slow))
+        state.shutdown()
+
+    def test_converged_true_single_launcher_pending_events(self):
+        launcher = _make_launcher()
+        state = _make_state([launcher])
+        state.best_launcher = launcher
+        state._queue.clear()
+        state._queue.clear()
+        state._pending_events = 1
+        self.assertTrue(state.converged)
+        state.shutdown()
+
+    def test_converged_false_pending_events_multiple_launchers(self):
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state = _make_state([a, b])
+        state.best_launcher = a
+        state._queue.clear()
+        state._queue.clear()
+        state._pending_events = 1
+        self.assertFalse(state.converged)
+        state.shutdown()
+
+    def test_converged_false_nonempty_deque(self):
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state = _make_state([a, b])
+        state.best_launcher = a
+        self.assertFalse(state.converged)
+        state.shutdown()
+
+    def test_converged_true(self):
+        launcher = _make_launcher()
+        state = _make_state([launcher])
+        state.best_launcher = launcher
+        state._queue.clear()
+        state._queue.clear()
+        self.assertTrue(state.converged)
+        state.shutdown()
+
+    def test_resolve_timing_updates_best(self):
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state = _make_state([a, b])
+        state._pending_events = 2
+        a._add_timing(5.0)
+        state.best_launcher = a
+
+        b.resolve_timing(2.0)
+        state.decrement_pending()
+
+        self.assertIs(state.best_launcher, b)
+        self.assertAlmostEqual(state.best_timing, 2.0)
+        self.assertEqual(state._pending_events, 1)
+        state.shutdown()
+
+    def test_resolve_timing_slower_does_not_replace_best(self):
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+        state = _make_state([a, b])
+        state._pending_events = 1
+        a._add_timing(1.0)
+        state.best_launcher = a
+
+        b.resolve_timing(5.0)
+        state.decrement_pending()
+
+        self.assertIs(state.best_launcher, a)
+        state.shutdown()
+
+    def test_init_fresh_multiple_launchers(self):
+        launchers = [_make_launcher(f"l{i}") for i in range(3)]
+        state = _make_state(launchers)
+        self.assertEqual(len(state._queue), 3)
+        state.shutdown()
+
+    def test_dispatch_round_robin_and_convergence(self):
+        """dispatch() iterates launchers round-robin and calls on_convergence when done."""
+        converged = threading.Event()
+        converged_launcher: list[Launcher | None] = [None]
+
+        def on_convergence(state: IncrementalAutotuneState) -> None:
+            converged_launcher[0] = state.best_launcher
+            converged.set()
+
+        a = _make_launcher("a")
+        b = _make_launcher("b")
+
+        state = _make_state([a, b], on_convergence_fn=on_convergence)
+
+        mock_event = MagicMock()
+
+        def fake_put(
+            s: IncrementalAutotuneState,
+            launcher: Launcher,
+            _start: object,
+            _end: object,
+        ) -> None:
+            launcher.resolve_timing(1.0)
+            s.decrement_pending()
+
+        with patch(
+            "torch._inductor.runtime.incremental._state._MAX_SAMPLES_PER_LAUNCHER", 2
+        ), patch(
+            "torch._inductor.runtime.incremental._state._FORCED_TIMING_ROUNDS", 1
+        ), patch(
+            "torch._inductor.runtime.incremental._state._SAMPLING_RATE", 1
+        ), patch(
+            "torch._inductor.runtime.incremental._state.torch.cuda.Event",
+            return_value=mock_event,
+        ), patch(
+            "torch._inductor.runtime.incremental._state.submit_event"
+        ) as mock_submit:
+            mock_submit.side_effect = fake_put
+            for _ in range(4):
+                state.dispatch(stream=0)
+            state.dispatch(stream=0)
+
+        self.assertTrue(converged.is_set())
+        self.assertIsNotNone(converged_launcher[0])
+
+    def test_on_cleanup_called_on_del(self):
+        cleanup_called = [False]
+
+        def on_cleanup(state: IncrementalAutotuneState) -> None:
+            cleanup_called[0] = True
+
+        state = IncrementalAutotuneState(on_cleanup_fn=on_cleanup)
+        state.__del__()
+        self.assertTrue(cleanup_called[0])
+
+    def test_init_fresh_seeds_best_from_existing_timings(self):
+        """A reused launcher with prior samples is immediately ``best_launcher``."""
+        fast = _make_launcher("fast")
+        slow = _make_launcher("slow")
+        fast._add_timing(1.0)
+        slow._add_timing(5.0)
+
+        state = _make_state([slow, fast])
+        self.assertIs(state.best_launcher, fast)
+        state.shutdown()
+
+    def test_should_skip_max_dispatches(self):
+        """Launcher with max dispatches is skipped."""
+        launcher = _make_launcher()
+        state = _make_state([launcher])
+        self.assertFalse(state._should_skip(launcher))
+        with launcher._lock:
+            launcher.dispatch_count = 999
+        self.assertTrue(state._should_skip(launcher))
+        state.shutdown()
+
+    def test_dispatch_drops_invalid_config_and_retries(self):
+        """RuntimeError("invalid configuration ...") prunes the launcher and retries."""
+        bad = _make_launcher("bad")
+        good = _make_launcher("good")
+        bad._fn.side_effect = RuntimeError(
+            "invalid configuration argument from CUDA launch"
+        )
+        state = _make_state([bad, good])
+
+        with patch(
+            "torch._inductor.runtime.incremental._state.torch.cuda.Event",
+            return_value=MagicMock(),
+        ), patch("torch._inductor.runtime.incremental._state.submit_event"):
+            result = state.dispatch(stream=0)
+
+        self.assertEqual(result, "result_good")
+        self.assertNotIn(bad, state._launchers)
+        state.shutdown()
+
+    def test_dispatch_propagates_background_error(self):
+        """Resolver-side errors stamp the state and surface on the next dispatch."""
+        launcher = _make_launcher()
+        state = _make_state([launcher])
+        sentinel = RuntimeError("resolver failed")
+        state.set_background_error(sentinel)
+        with self.assertRaises(RuntimeError) as ctx:
+            state.dispatch(stream=0)
+        self.assertIs(ctx.exception, sentinel)
+        state.shutdown()
+
+
+class ResolverTest(TestCase):
+    def test_submit_event_puts_then_ensures_daemon(self):
+        """Put-then-ensure ordering: item is visible when daemon checks empty()."""
+        from torch._inductor.runtime.incremental import _resolver
+
+        with patch.object(_resolver, "_ensure_daemon") as mock_ensure, patch.object(
+            _resolver._global_event_queue, "put"
+        ) as mock_put:
+            call_order = []
+            mock_put.side_effect = lambda *a, **k: call_order.append("put")
+            mock_ensure.side_effect = lambda: call_order.append("ensure")
+
+            mock_state = MagicMock()
+            mock_launcher = MagicMock()
+            _resolver.submit_event(
+                mock_state, mock_launcher, MagicMock(), MagicMock()
+            )
+
+        self.assertEqual(call_order, ["put", "ensure"])
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -47,6 +47,8 @@ from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
     autotune_hints_to_configs,
     CachingAutotuner,
+    CachingAutotunerPlugin,
+    DEFER,
     template,
     triton_config,
 )
@@ -302,6 +304,100 @@ class TestTritonHeuristics(TestCase):
                 config_heuristic.get_mm_configs()(3, 3, 3, dtype_size=4, op_name="mm")
             )
             self.assertEqual(len(configs), expected_count)
+
+
+_PLUGIN_FACTORY_PATH = (
+    "torch._inductor.runtime.triton_heuristics.get_caching_autotuner_plugins"
+)
+
+
+class TestCachingAutotunerPlugin(TestCase):
+    device_type = GPU_TYPE
+
+    @staticmethod
+    def _make_kernel_inputs():
+        in_ptr = torch.zeros(16, device=GPU_TYPE, dtype=torch.float32)
+        out_ptr = torch.zeros(16, device=GPU_TYPE, dtype=torch.float32)
+        return (in_ptr, out_ptr, 16)
+
+    def _make_autotuner(self, plugins, configs=None):
+        args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
+        args["inductor_meta"] = {**args["inductor_meta"], "grid_type": "Grid1D"}
+        if configs is not None:
+            args["configs"] = configs
+        with patch(_PLUGIN_FACTORY_PATH, return_value=list(plugins)):
+            return CachingAutotuner(**args)
+
+    def test_pre_dispatch_runs_before_precompile_and_autotune(self):
+        sentinel = object()
+
+        class _Plugin(CachingAutotunerPlugin):
+            def pre_dispatch(self, autotuner, *args, stream, **kwargs):
+                return sentinel
+
+        autotuner = self._make_autotuner([_Plugin()])
+        with (
+            patch.object(autotuner, "precompile") as mock_precompile,
+            patch.object(autotuner, "autotune_to_one_config") as mock_autotune
+        ):
+            result = autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertIs(result, sentinel)
+        mock_precompile.assert_not_called()
+        mock_autotune.assert_not_called()
+
+    def test_pre_autotune_runs_before_default_autotune(self):
+        sentinel = object()
+
+        class _Plugin(CachingAutotunerPlugin):
+            def pre_autotune(self, autotuner, *args, stream, **kwargs):
+                return sentinel
+
+        autotuner = self._make_autotuner([_Plugin()])
+        with patch.object(autotuner, "autotune_to_one_config") as mock_autotune:
+            result = autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertIs(result, sentinel)
+        mock_autotune.assert_not_called()
+
+    def test_hooks_fire_in_registration_order(self):
+        sentinel = object()
+        seen = []
+
+        class _Plugin(CachingAutotunerPlugin):
+            def __init__(self, name, return_value=DEFER):
+                self.name = name
+                self.return_value = return_value
+
+            def pre_dispatch(self, autotuner, *args, stream, **kwargs):
+                seen.append(self.name)
+                return self.return_value
+
+        autotuner = self._make_autotuner(
+            [_Plugin("a"), _Plugin("b"), _Plugin("c", sentinel), _Plugin("d")]
+        )
+        result = autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertIs(result, sentinel)
+        self.assertEqual(seen, ["a", "b", "c"])
+
+    def test_defer_falls_through_to_default(self):
+        seen = []
+
+        class _Plugin(CachingAutotunerPlugin):
+            def pre_dispatch(self, autotuner, *args, stream, **kwargs):
+                seen.append("pre_dispatch")
+                return DEFER
+
+        # Single config so precompile produces one launcher and the kernel
+        # runs to completion without the autotune branch firing.
+        full_args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
+        autotuner = self._make_autotuner([_Plugin()], configs=full_args["configs"][:1])
+
+        autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertEqual(seen, ["pre_dispatch"])
+        self.assertEqual(len(autotuner.launchers), 1)
 
 
 class TestArgumentCloneAndRestore(TestCase):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -512,6 +512,11 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 # enable slow autotuning passes to select gemm algorithms
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 
+# When True, autotuning is spread across real kernel invocations instead of
+# blocking on the first call. Each run() call executes one config and records
+# timing via CUDA events, progressively eliminating underperforming configs.
+incremental_autotune: bool = os.environ.get("TORCHINDUCTOR_INCREMENTAL_AUTOTUNE") == "1"
+
 inductor_default_autotune_warmup = int(
     os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_WARMUP", 25)
 )

--- a/torch/_inductor/runtime/incremental/__init__.py
+++ b/torch/_inductor/runtime/incremental/__init__.py
@@ -1,0 +1,1 @@
+from ._plugin import IncrementalAutotunePlugin  # noqa: F401

--- a/torch/_inductor/runtime/incremental/_cache.py
+++ b/torch/_inductor/runtime/incremental/_cache.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Hashable
+from typing import TYPE_CHECKING
+
+from ..runtime_utils import triton_config_to_hashable
+from ..triton_heuristics import CachingAutotuner
+
+if TYPE_CHECKING:
+    from ._launcher import Launcher
+
+# Per-kernel pool of Launcher objects, keyed by config. Two CachingAutotuner
+# instances with the same kernel (source + metadata) but overlapping-not-equal
+# config sets share Launchers for the configs they have in common; configs
+# unique to one autotuner are added to the same pool. Strong references on
+# purpose: a converged Launcher's accumulated timing is exactly what we want
+# the next autotuner to inherit.
+_caching_autotuner_registry: dict[str, dict[Hashable, Launcher]] = {}
+
+
+def _caching_autotuner_kernel_key(autotuner: CachingAutotuner) -> str | None:
+    """Compute a content-based key for a CachingAutotuner's kernel.
+
+    Returns a SHA-256 of the normalized source, inductor metadata, and Triton
+    compilation metadata. The config set is intentionally NOT part of the key
+    so that autotuners with overlapping config sets can share launchers.
+
+    NOTE: ``str(sorted(meta.items()))`` is used to canonicalize metadata for
+    hashing; values must therefore have a deterministic ``__repr__``. Built-in
+    types are fine; custom objects whose repr embeds ``id()`` would silently
+    make keys non-deterministic and defeat sharing.
+    """
+    if not hasattr(autotuner.fn, "src"):
+        return None
+
+    name: str = autotuner.fn.__name__
+    # Whole-word replace so a kernel named ``foo`` doesn't clobber substrings
+    # of unrelated identifiers like ``foobar``.
+    name_re = re.compile(rf"\b{re.escape(name)}\b")
+    normalized_src = name_re.sub("triton_", autotuner.fn.src)
+    normalized_inductor = name_re.sub(
+        "triton_", str(sorted(autotuner.inductor_meta.items()))
+    )
+    normalized_triton = name_re.sub(
+        "triton_", str(sorted(autotuner.triton_meta.items()))
+    )
+
+    hasher = hashlib.sha256()
+    hasher.update(normalized_src.encode("utf-8"))
+    hasher.update(normalized_inductor.encode("utf-8"))
+    hasher.update(normalized_triton.encode("utf-8"))
+    return hasher.hexdigest()
+
+
+def get_launcher_pool(obj: object) -> dict[Hashable, Launcher] | None:
+    """Return the shared per-config Launcher pool for ``obj``'s kernel.
+
+    Returns ``None`` if ``obj`` is not a CachingAutotuner or no key can be
+    computed (e.g. ``fn`` has no ``src``). Otherwise returns the existing
+    pool dict — or a fresh empty one, registered for future callers.
+    """
+    if (
+        isinstance(obj, CachingAutotuner)
+        and (key := _caching_autotuner_kernel_key(obj)) is not None
+    ):
+        return _caching_autotuner_registry.setdefault(key, {})
+    return None
+
+
+def get_or_create_launcher(
+    pool: dict[Hashable, Launcher],
+    raw_launcher: object,
+    launcher_factory: type[Launcher],
+) -> Launcher:
+    """Return ``pool[cfg_key]`` if present, else build it via ``launcher_factory``."""
+    cfg_key = triton_config_to_hashable(raw_launcher.config)  # pyrefly: ignore
+    if (launcher := pool.get(cfg_key)) is None:
+        launcher = launcher_factory(
+            fn=raw_launcher,
+            config=raw_launcher.config,  # pyrefly: ignore
+            cache_hash=raw_launcher.cache_hash,  # pyrefly: ignore
+        )
+        pool[cfg_key] = launcher
+    return launcher

--- a/torch/_inductor/runtime/incremental/_launcher.py
+++ b/torch/_inductor/runtime/incremental/_launcher.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import bisect
+import threading
+import weakref
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ._state import IncrementalAutotuneState
+
+
+class Launcher:
+    """A callable kernel wrapper with timing stats and arbitrary metadata.
+
+    Each call increments dispatch_count automatically.  Timing data is
+    accumulated via resolve_timing() (called by the resolver daemon), which
+    notifies all attached IncrementalAutotuneState instances.
+
+    Filtering (removing slow launchers) is handled per-state, not on the
+    launcher — different states may have different filtering thresholds.
+
+    Any extra keyword arguments to __init__ become metadata entries
+    (e.g. CachingAutotuner passes ``config=...`` and ``cache_hash=...``).
+    """
+
+    def __init__(self, fn: Callable[..., object], **metadata: object) -> None:
+        self._fn = fn
+        self.metadata: dict[str, object] = metadata
+
+        self._timings: list[float] = []
+        self.dispatch_count: int = 0
+        self._lock: threading.Lock = threading.Lock()
+        self._attached_states: weakref.WeakSet[IncrementalAutotuneState] = (
+            weakref.WeakSet()
+        )
+
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        with self._lock:
+            self.dispatch_count += 1
+        return self._fn(*args, **kwargs)
+
+    def attach(self, state: IncrementalAutotuneState) -> None:
+        self._attached_states.add(state)
+
+    def _add_timing(self, elapsed_ms: float) -> None:
+        with self._lock:
+            bisect.insort(self._timings, elapsed_ms)
+
+    def resolve_timing(self, elapsed_ms: float) -> None:
+        """Add a timing sample and notify all attached states."""
+        self._add_timing(elapsed_ms)
+        for state in list(self._attached_states):
+            state.maybe_update_best(self)
+
+    @property
+    def timing(self) -> float:
+        """Representative timing (median of all samples)."""
+        with self._lock:
+            if not self._timings:
+                return float("inf")
+            n = len(self._timings)
+            mid = n // 2
+            if n % 2 == 1:
+                return self._timings[mid]
+            return (self._timings[mid - 1] + self._timings[mid]) / 2
+
+    @property
+    def sample_count(self) -> int:
+        with self._lock:
+            return len(self._timings)

--- a/torch/_inductor/runtime/incremental/_plugin.py
+++ b/torch/_inductor/runtime/incremental/_plugin.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import functools
+import weakref
+from typing import TYPE_CHECKING
+
+import torch._utils_internal
+
+from ..triton_heuristics import CachingAutotunerPlugin, DEFER
+from . import _cache
+from ._launcher import Launcher
+from ._state import IncrementalAutotuneState
+from ._utils import log
+
+if TYPE_CHECKING:
+    from ..triton_heuristics import CachingAutotuner
+
+
+# Bump this to enable incremental autotuning for users who have
+# config.incremental_autotune = True (or the env var set to "1").
+# The JK "pytorch/inductor:incremental_autotune_version" must be
+# <= this value for the feature to activate.
+_INCREMENTAL_AUTOTUNE_VERSION: int = 1
+
+
+@functools.cache
+def _jk_passes() -> bool:
+    """Return True if the JK gate allows incremental autotuning."""
+    try:
+        val = torch._utils_internal.justknobs_getval_int(
+            "pytorch/inductor:incremental_autotune_version"
+        )
+    except AttributeError:
+        return True
+    return _INCREMENTAL_AUTOTUNE_VERSION >= val
+
+
+class IncrementalAutotunePlugin(CachingAutotunerPlugin):
+    """Plugin that drives incremental autotuning for a CachingAutotuner.
+
+    Holds the per-autotuner IncrementalAutotuneState. The state is created
+    lazily on the first ``pre_autotune`` call and cleared by the
+    on-convergence callback.
+    """
+
+    def __init__(self) -> None:
+        self._state: IncrementalAutotuneState | None = None
+
+    def pre_dispatch(
+        self,
+        autotuner: CachingAutotuner,
+        *args: object,
+        stream: object,
+        **kwargs: object,
+    ) -> object:
+        if self._state is not None:
+            return self._state.dispatch(*args, stream=stream, **kwargs)
+        return DEFER
+
+    def pre_autotune(
+        self,
+        autotuner: CachingAutotuner,
+        *args: object,
+        stream: object,
+        **kwargs: object,
+    ) -> object:
+        self._state = self._init_state(autotuner)
+        if self._state is not None:
+            return self._state.dispatch(*args, stream=stream, **kwargs)
+        return DEFER
+
+    @staticmethod
+    def _should_apply(autotuner: CachingAutotuner) -> bool:
+        """Check whether incremental autotuning applies to ``autotuner``."""
+        from torch._inductor import config as inductor_config
+        from torch._inductor.config import triton as inductor_triton_config
+
+        name: str = autotuner.fn.__name__
+        if not inductor_config.incremental_autotune:
+            return False
+        if inductor_triton_config.autotune_at_compile_time:
+            log.warning(
+                "Incremental autotune: skipping %s — autotune_at_compile_time=True",
+                name,
+            )
+            return False
+        if inductor_triton_config.cudagraphs:
+            log.warning(
+                "Incremental autotune: skipping %s — cudagraphs=True",
+                name,
+            )
+            return False
+        if not _jk_passes():
+            log.warning(
+                "Incremental autotune: skipping %s — JK gate blocked",
+                name,
+            )
+            return False
+        log.info("Incremental autotune: enabled for %s", name)
+        return True
+
+    def _init_state(
+        self, autotuner: CachingAutotuner
+    ) -> IncrementalAutotuneState | None:
+        """Create and seed an IncrementalAutotuneState for ``autotuner``.
+
+        Returns None if incremental autotuning does not apply, or if the state
+        immediately converged from shared stats (in which case the autotuner
+        already has its single launcher set).
+        """
+        if not IncrementalAutotunePlugin._should_apply(autotuner):
+            return None
+
+        # Capture plugin and autotuner via weakref so the closures held by
+        # ``state.on_convergence_fn`` / ``on_cleanup_fn`` don't form a cycle
+        # (plugin._state -> state -> closure -> plugin / autotuner) that would
+        # delay deterministic finalization of state.__del__ → on_cleanup.
+        plugin_ref = weakref.ref(self)
+        autotuner_ref = weakref.ref(autotuner)
+
+        def on_convergence(state: IncrementalAutotuneState) -> None:
+            plugin = plugin_ref()
+            owner = autotuner_ref()
+            if plugin is None or owner is None:
+                return
+            assert state.best_launcher is not None
+            best = state.best_launcher
+            owner.launchers = [best]
+            plugin._state = None
+            log.info(
+                "Incremental autotune converged for %s: %s (timing=%.3f ms)",
+                owner.fn.__name__,
+                best.metadata.get("config"),
+                state.best_timing,
+            )
+
+        def on_cleanup(state: IncrementalAutotuneState) -> None:
+            if state.best_launcher is None:
+                return
+            owner = autotuner_ref()
+            if owner is None:
+                return
+            best = state.best_launcher
+            # Incremental autotune does not track wall time the same way
+            # autotune_to_one_config does; report 0 to avoid skewing metrics.
+            owner.autotune_time_taken_ns = 0
+            if owner.save_cache_hook:
+                owner.save_cache_hook(
+                    best.metadata.get("config"),
+                    0,
+                    found_by_coordesc=getattr(
+                        best.metadata.get("config"), "found_by_coordesc", False
+                    ),
+                    triton_cache_hash=best.metadata.get("cache_hash"),
+                )
+
+        state = IncrementalAutotuneState(
+            on_convergence_fn=on_convergence,
+            on_cleanup_fn=on_cleanup,
+            pre_launch_fn=autotuner._pre_launch,
+            post_launch_fn=autotuner._post_launch,
+        )
+
+        # Build the per-state launcher list from the shared per-config pool:
+        # configs already seen by another autotuner reuse the existing Launcher
+        # (and its accumulated timings); novel configs add fresh Launchers to
+        # the pool. ``pool`` is None if the kernel can't be content-keyed.
+        pool = _cache.get_launcher_pool(autotuner)
+        if pool is None:
+            launchers = [
+                Launcher(
+                    fn=raw_launcher,
+                    config=raw_launcher.config,
+                    cache_hash=raw_launcher.cache_hash,
+                )
+                for raw_launcher in autotuner.launchers
+            ]
+        else:
+            launchers = [
+                _cache.get_or_create_launcher(pool, raw_launcher, Launcher)
+                for raw_launcher in autotuner.launchers
+            ]
+        state.init_fresh(launchers)
+        log.info(
+            "Incremental autotune: initializing %s with %d launchers "
+            "(state id=%d, pool size=%d)",
+            autotuner.fn.__name__,
+            len(launchers),
+            id(state),
+            len(pool) if pool is not None else 0,
+        )
+
+        autotuner.launchers = []
+
+        if state.converged and state.best_launcher:
+            best = state.best_launcher
+            autotuner.launchers = [best]
+            state.shutdown()
+            log.info(
+                "Incremental autotune: %s immediately converged from shared "
+                "stats (config=%s, timing=%.3f ms)",
+                autotuner.fn.__name__,
+                best.metadata.get("config"),
+                state.best_timing,
+            )
+            return None
+
+        return state

--- a/torch/_inductor/runtime/incremental/_resolver.py
+++ b/torch/_inductor/runtime/incremental/_resolver.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import queue
+import threading
+from typing import TYPE_CHECKING
+
+from ._utils import log
+from .config import _IDLE_TIMEOUT_S
+
+if TYPE_CHECKING:
+    import torch
+
+    from ._launcher import Launcher
+    from ._state import IncrementalAutotuneState
+
+_global_event_queue: queue.Queue[
+    tuple[IncrementalAutotuneState, Launcher, torch.cuda.Event, torch.cuda.Event]
+] = queue.Queue()
+_global_resolver_lock: threading.Lock = threading.Lock()
+_global_resolver_thread: threading.Thread | None = None
+
+
+def submit_event(
+    state: IncrementalAutotuneState,
+    launcher: Launcher,
+    start_event: torch.cuda.Event,
+    end_event: torch.cuda.Event,
+) -> None:
+    """Enqueue a CUDA event pair for async timing resolution.
+
+    Starts the global resolver daemon if it is not already running.
+    """
+    # Put-then-ensure ordering closes a termination race: if we ensured first
+    # and a daemon was idling out concurrently, it could exit between our
+    # ensure and our put, leaving the item orphaned. Putting first guarantees
+    # the daemon's empty()-check (also under _global_resolver_lock) sees it.
+    _global_event_queue.put((state, launcher, start_event, end_event))
+    _ensure_daemon()
+
+
+def _ensure_daemon() -> None:
+    global _global_resolver_thread
+    with _global_resolver_lock:
+        if _global_resolver_thread is not None:
+            return
+        t = threading.Thread(
+            target=_global_event_resolver_loop,
+            daemon=True,
+            name="autotune-event-resolver",
+        )
+        t.start()
+        _global_resolver_thread = t
+        log.info(
+            "Incremental autotune event resolver started (thread id=%d)",
+            t.ident,
+        )
+
+
+def _global_event_resolver_loop() -> None:
+    global _global_resolver_thread
+    background_error: Exception | None = None
+
+    while True:
+        try:
+            item = _global_event_queue.get(timeout=_IDLE_TIMEOUT_S)
+        except queue.Empty:
+            with _global_resolver_lock:
+                if _global_event_queue.empty():
+                    _global_resolver_thread = None
+                    log.info("Incremental autotune event resolver stopped (idle timeout)")
+                    return
+                continue
+
+        state, launcher, start_event, end_event = item
+        if background_error is not None:
+            state.set_background_error(background_error)
+            continue
+        try:
+            end_event.synchronize()
+            elapsed_ms: float = start_event.elapsed_time(end_event)
+            launcher.resolve_timing(elapsed_ms)
+            state.decrement_pending()
+        except RuntimeError as exc:
+            # CUDA event ops surface as RuntimeError. Stamp the originating
+            # state so the next dispatch raises; future items inherit
+            # background_error and skip event resolution.
+            log.debug(
+                "Incremental autotune: exception resolving timing"
+                " for state id=%d, launcher id=%d",
+                id(state),
+                id(launcher),
+                exc_info=True,
+            )
+            background_error = RuntimeError("Incremental autotune event resolver failed")
+            background_error.__cause__ = exc
+            state.set_background_error(background_error)

--- a/torch/_inductor/runtime/incremental/_state.py
+++ b/torch/_inductor/runtime/incremental/_state.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import threading
+from collections import deque
+from typing import TYPE_CHECKING
+
+import torch
+
+from ._launcher import Launcher
+from ._resolver import submit_event
+from .config import (
+    _FORCED_TIMING_ROUNDS,
+    _INITIAL_THRESHOLD,
+    _MAX_SAMPLES_PER_LAUNCHER,
+    _MIN_SAMPLES_BEFORE_FILTER,
+    _SAMPLING_RATE,
+    _THRESHOLD_MULTIPLIERS,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class IncrementalAutotuneState:
+    """Central state for incremental autotuning.
+
+    Manages a round-robin queue of Launcher candidates, CUDA event timing
+    via a daemon thread, progressive filtering, and convergence detection.
+
+    All filtering decisions (max dispatches, threshold, invalid config) are
+    made lazily in _next_launcher.  Launchers with fewer than
+    _FORCED_TIMING_ROUNDS dispatches are always timed; once past that
+    threshold, only 1 in _SAMPLING_RATE dispatches is timed.
+    """
+
+    def __init__(
+        self,
+        pre_launch_fn: Callable | None = None,
+        post_launch_fn: Callable[[], None] | None = None,
+        on_convergence_fn: Callable[[IncrementalAutotuneState], None] | None = None,
+        on_cleanup_fn: Callable[[IncrementalAutotuneState], None] | None = None,
+    ) -> None:
+        self._launchers: list[Launcher] = []
+        self._queue: deque[Launcher] = deque()
+        self.best_launcher: Launcher | None = None
+
+        self._lock = threading.RLock()
+        self._pre_launch_fn = pre_launch_fn
+        self._post_launch_fn = post_launch_fn
+        self._on_convergence_fn = on_convergence_fn
+        self._on_cleanup_fn = on_cleanup_fn
+
+        self._pending_events: int = 0
+        self._total_dispatch_count: int = 0
+
+        self._background_error: Exception | None = None
+
+    def init_fresh(self, launchers: list[Launcher]) -> None:
+        """Populate with launchers, seeding ``best_launcher`` from any
+        existing timings (so a launcher reused from another state with prior
+        samples is immediately the running best).
+        """
+        self._launchers = list(launchers)
+        best_timing = float("inf")
+        for launcher in launchers:
+            launcher.attach(self)
+            self._queue.append(launcher)
+            if (timing := launcher.timing) < best_timing:
+                self.best_launcher = launcher
+                best_timing = timing
+
+    def _should_skip(self, launcher: Launcher) -> bool:
+        """Check if a launcher should be skipped for timing."""
+        if launcher.dispatch_count >= _MAX_SAMPLES_PER_LAUNCHER:
+            return True
+        if self.best_launcher is not None and launcher is not self.best_launcher:
+            sample_count = launcher.sample_count
+            if sample_count >= _MIN_SAMPLES_BEFORE_FILTER:
+                clamped = min(sample_count, _MAX_SAMPLES_PER_LAUNCHER)
+                threshold = 1.0 + (_INITIAL_THRESHOLD - 1.0) * _THRESHOLD_MULTIPLIERS[clamped - 1]
+                if launcher.timing > threshold * self.best_timing:
+                    return True
+        return False
+
+    # -- Round-robin ----------------------------------------------------------
+
+    def _next_launcher(self) -> Launcher | None:
+        """Pop and return the next launcher eligible for timing, or None."""
+        while self._queue:
+            launcher = self._queue.popleft()
+            if not self._should_skip(launcher):
+                return launcher
+        return None
+
+    # -- Dispatch ----------------------------------------------------------
+
+    def dispatch(self, *args: object, stream: object, **kwargs: object) -> object:
+        with self._lock:
+            if self._background_error is not None:
+                raise self._background_error
+
+            if self.converged:
+                if self._on_convergence_fn is not None:
+                    self._on_convergence_fn(self)
+                if self.converged:
+                    self.shutdown()
+                return self._launch(self.best_launcher, *args, stream=stream, **kwargs)
+
+            # If we have a best launcher and it's past warmup, only time
+            # 1 in _SAMPLING_RATE dispatches — run the best untimed otherwise.
+            self._total_dispatch_count += 1
+            if (
+                self.best_launcher is not None
+                and self.best_launcher.dispatch_count >= _FORCED_TIMING_ROUNDS
+                and self._total_dispatch_count % _SAMPLING_RATE != 0
+            ):
+                return self._launch(
+                    self.best_launcher, *args, stream=stream, **kwargs
+                )
+
+            if (launcher := self._next_launcher()) is not None:
+                try:
+                    result = self._timed_launch(launcher, *args, stream=stream, **kwargs)
+                except RuntimeError as e:
+                    # Triton surfaces invalid kernel configs (e.g. requested
+                    # block size exceeds device limits) as a RuntimeError with
+                    # "invalid configuration" in the message. Drop the launcher
+                    # and retry on the same dispatch.
+                    if "invalid configuration" not in str(e).lower():
+                        raise
+                    self._launchers.remove(launcher)
+                    return self.dispatch(*args, stream=stream, **kwargs)
+                if self.best_launcher is None:
+                    self.best_launcher = launcher
+                return result
+
+            if self.best_launcher is not None:
+                return self._launch(
+                    self.best_launcher, *args, stream=stream, **kwargs
+                )
+            raise RuntimeError(
+                "No active launchers available for incremental autotune"
+            )
+
+    def _launch(self, launcher: Launcher | None, *args: object, stream: object, **kwargs: object) -> object:
+        """Launch a kernel without timing."""
+        assert launcher is not None
+        try:
+            if self._pre_launch_fn is not None:
+                self._pre_launch_fn(launcher, *args, stream=stream, **kwargs)
+            return launcher(*args, **kwargs, stream=stream)
+        finally:
+            if self._post_launch_fn is not None:
+                self._post_launch_fn()
+
+    def _timed_launch(self, launcher: Launcher, *args: object, stream: object, **kwargs: object) -> object:
+        """Launch a kernel with CUDA event timing."""
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        try:
+            if self._pre_launch_fn is not None:
+                self._pre_launch_fn(launcher, *args, stream=stream, **kwargs)
+            start_event.record()
+            result = launcher(*args, **kwargs, stream=stream)
+            end_event.record()
+        finally:
+            if self._post_launch_fn is not None:
+                self._post_launch_fn()
+        self._queue.append(launcher)
+        self._pending_events += 1
+        submit_event(self, launcher, start_event, end_event)
+        return result
+
+    # -- Event resolution -------------------------------------------------
+
+    @property
+    def best_timing(self) -> float:
+        if self.best_launcher is None:
+            return float("inf")
+        return self.best_launcher.timing
+
+    def maybe_update_best(self, launcher: Launcher) -> None:
+        """Update best_launcher if this launcher is now faster."""
+        with self._lock:
+            if launcher.timing < self.best_timing:
+                self.best_launcher = launcher
+
+    def decrement_pending(self) -> None:
+        with self._lock:
+            self._pending_events -= 1
+
+    def set_background_error(self, error: Exception) -> None:
+        """Stamp an error from the resolver daemon; the next dispatch raises it."""
+        with self._lock:
+            if self._background_error is None:
+                self._background_error = error
+
+    # -- Convergence -------------------------------------------------------
+
+    @property
+    def converged(self) -> bool:
+        if self.best_launcher is not None and all(
+            self._should_skip(launcher)
+            for launcher in self._launchers
+            if launcher is not self.best_launcher
+        ):
+            return True
+        if self._pending_events > 0:
+            return False
+        if not self._queue:
+            assert self.best_launcher is not None, (
+                "queue empty with no best launcher — all configs were rejected"
+            )
+            return True
+        return False
+
+    # -- Cleanup -----------------------------------------------------------
+
+    def __del__(self) -> None:
+        # Finalizers must not raise — log and continue. We narrow to Exception
+        # here (rather than letting it propagate) only because exceptions from
+        # __del__ are silently swallowed by CPython anyway, and a debug log is
+        # strictly more useful than the default.
+        try:
+            if self._on_cleanup_fn is not None:
+                self._on_cleanup_fn(self)
+                self._on_cleanup_fn = None
+        except Exception:
+            from ._utils import log
+
+            log.debug(
+                "IncrementalAutotuneState.__del__ cleanup callback raised",
+                exc_info=True,
+            )
+
+    def shutdown(self) -> None:
+        pass

--- a/torch/_inductor/runtime/incremental/_utils.py
+++ b/torch/_inductor/runtime/incremental/_utils.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+import logging
+
+from torch._logging import getArtifactLogger
+
+log: logging.Logger = getArtifactLogger(__name__, "incremental")

--- a/torch/_inductor/runtime/incremental/config.py
+++ b/torch/_inductor/runtime/incremental/config.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+_MIN_SAMPLES_BEFORE_FILTER: int = 5
+
+_INITIAL_THRESHOLD: float = 2.5
+_THRESHOLD_DECAY_EXP: float = 0.1
+
+_MAX_SAMPLES_PER_LAUNCHER: int = 15
+
+_FORCED_TIMING_ROUNDS: int = 3
+
+_SAMPLING_RATE: int = 5
+
+# The event resolver daemon exits after this many seconds with no events.
+_IDLE_TIMEOUT_S: int = 600
+
+# Precomputed threshold scale factors for sample counts 1.._MAX_SAMPLES_PER_LAUNCHER.
+# Index i corresponds to sample_count == i+1.  Avoids repeated pow() calls.
+_THRESHOLD_MULTIPLIERS: tuple[float, ...] = tuple(
+    1.0 - ((n - 1) / (_MAX_SAMPLES_PER_LAUNCHER - 1)) ** _THRESHOLD_DECAY_EXP
+    for n in range(1, _MAX_SAMPLES_PER_LAUNCHER + 1)
+)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -112,7 +112,9 @@ class NoTritonConfigsError(RuntimeError):
 if TYPE_CHECKING:
     from collections.abc import Callable, Container, Hashable
 
+    from torch._C._profiler import _RecordFunctionFast
     from torch._guards import CompileId
+    from torch.utils._debug_mode import _TritonKernelCall
 
     LauncherType = Any
 
@@ -433,6 +435,9 @@ class CachingAutotuner(KernelInterface):
         ).split(",")
 
         self.triton_interpret = os.environ.get("TRITON_INTERPRET", "0") == "1"
+
+        self._debug_call: _TritonKernelCall | None = None
+        self._profiler_ctx: _RecordFunctionFast | None = None
 
         # Compile-time info included in runtime logginging
         self.compile_id: CompileId | None = None
@@ -1662,6 +1667,42 @@ class CachingAutotuner(KernelInterface):
             ret["kernel_num_gb"] = self.inductor_meta["kernel_num_gb"]
         return ret
 
+    def _pre_launch(self, launcher, *args, stream, **kwargs):
+        """Pre-launch instrumentation: param/tensor dumping and profiler context entry."""
+        if self.dump_launch_params:
+            new_args, grid = self._interpret_args_grid(args, launcher.config)
+            _dump_launch_params(new_args, kwargs, launcher, self.fn.__name__, grid)
+
+        if self.dump_launch_tensors:
+            if not self.kernels_to_dump or any(
+                kernel_name in self.fn.__name__ for kernel_name in self.kernels_to_dump
+            ):
+                _dump_launch_tensors(
+                    args, self.filename, self.kernel_hash, self.fn.__name__
+                )
+
+        if autograd_profiler._is_profiler_enabled:
+            profiler_kwargs = self.get_profiler_kwargs(stream, launcher)
+            profiler_ctx = torch._C._profiler._RecordFunctionFast(
+                self.inductor_meta.get("kernel_name", "triton kernel"),
+                tuple(args),
+                profiler_kwargs,
+            )
+            profiler_ctx.__enter__()
+            # set ctx after enter succeeds
+            self._profiler_ctx = profiler_ctx
+        else:
+            self._profiler_ctx = None
+
+    def _post_launch(self) -> None:
+        """Post-launch instrumentation: profiler context exit and debug mode finalization."""
+        if (profiler_ctx := self._profiler_ctx) is not None:
+            self._profiler_ctx = None
+            profiler_ctx.__exit__(None, None, None)
+        if (debug_call := self._debug_call) is not None:
+            self._debug_call = None
+            debug_call.finalize(self.get_device_interface())
+
     def run(
         self,
         *args,
@@ -1671,12 +1712,11 @@ class CachingAutotuner(KernelInterface):
     ):  # type:ignore[override]
         """Launch triton kernel call and return result."""
         debug_mode = get_active_debug_mode()
-        debug_call = None
         if debug_mode:
             arg_names = list(self.triton_meta.get("signature", {}).keys())
             kernel_kwargs = dict(zip(arg_names, args))
             kernel_kwargs.update(kwargs)
-            debug_call = debug_mode.record_triton_kernel(
+            self._debug_call = debug_mode.record_triton_kernel(
                 kernel_name=self.fn.__name__, kwargs=kernel_kwargs
             )
 
@@ -1738,48 +1778,11 @@ class CachingAutotuner(KernelInterface):
         if launcher.store_cubin and (not benchmark_run or not self.cuda_kernel_saved):
             self.save_gpu_kernel(stream, launcher)
 
-        # PyTorch execution trace replay calls CachingAutotuner::run() instead of calls launcher
-        # so _RecordFunctionFast need to capture the args into CachingAutotuner::run()
-        # make a copy here to avoid mutating the original args
-        args_without_constexprs = tuple(args)
-
-        if self.dump_launch_params:
-            new_args, grid = self._interpret_args_grid(args, launcher.config)
-            _dump_launch_params(new_args, kwargs, launcher, self.fn.__name__, grid)
-
-        if self.dump_launch_tensors:
-            # Check the kernel name if the list was provided
-            if not self.kernels_to_dump or any(
-                kernel_name in self.fn.__name__ for kernel_name in self.kernels_to_dump
-            ):
-                _dump_launch_tensors(
-                    args, self.filename, self.kernel_hash, self.fn.__name__
-                )
-
-        # it is faster than entering and exiting a context manager, even if the context
-        # manager is a nullcontext.
-        if autograd_profiler._is_profiler_enabled:
-            profiler_kwargs = self.get_profiler_kwargs(stream, launcher)
-
-            with torch._C._profiler._RecordFunctionFast(
-                self.inductor_meta.get("kernel_name", "triton kernel"),
-                args_without_constexprs,
-                profiler_kwargs,
-            ):
-                result = launcher(
-                    *args,
-                    **kwargs,
-                    stream=stream,
-                )
-        else:
-            result = launcher(
-                *args,
-                **kwargs,
-                stream=stream,
-            )
-
-        if debug_call:
-            debug_call.finalize(self.get_device_interface())
+        try:
+            self._pre_launch(launcher, *args, stream=stream, **kwargs)
+            result = launcher(*args, **kwargs, stream=stream)
+        finally:
+            self._post_launch()
         return result
 
     def _interpret_args_grid(

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -19,7 +19,7 @@ import sys
 import threading
 import time
 from collections import namedtuple
-from typing import Any, Generic, Literal, TYPE_CHECKING, TypeVar
+from typing import Any, Final, Generic, Literal, TYPE_CHECKING, TypeVar
 
 import torch
 from torch._dynamo.utils import counters, set_feature_use
@@ -321,6 +321,51 @@ def check_autotune_cache(
     return configs, autotune_cache, autotune_cache_info
 
 
+# Sentinel returned by plugin hooks to defer to the next plugin or to the
+# default behavior. Tested with ``is DEFER``.
+DEFER: Final[object] = object()
+
+
+class CachingAutotunerPlugin:
+    """Base class for ``CachingAutotuner`` plugins.
+
+    Each hook returns ``DEFER`` to fall through to the next plugin / default
+    behavior, or any other value to short-circuit ``run()`` with that value.
+    """
+
+    def pre_dispatch(
+        self,
+        autotuner: CachingAutotuner,
+        *args: object,
+        stream: object,
+        **kwargs: object,
+    ) -> object:
+        """Fires before kernel dispatch, ahead of precompile or autotune."""
+        return DEFER
+
+    def pre_autotune(
+        self,
+        autotuner: CachingAutotuner,
+        *args: object,
+        stream: object,
+        **kwargs: object,
+    ) -> object:
+        """Fires after precompile when more than one launcher remains, in
+        place of ``autotune_to_one_config()``."""
+        return DEFER
+
+
+def get_caching_autotuner_plugins(
+    autotuner: CachingAutotuner,
+) -> list[CachingAutotunerPlugin]:
+    """Build the list of plugins active for ``autotuner``.
+
+    Each plugin adds an entry here, gated on its own config flag, with
+    imports kept inside the relevant branch.
+    """
+    return []
+
+
 class CachingAutotuner(KernelInterface):
     """
     Simplified version of Triton autotuner that has no invalidation
@@ -438,6 +483,8 @@ class CachingAutotuner(KernelInterface):
 
         self._debug_call: _TritonKernelCall | None = None
         self._profiler_ctx: _RecordFunctionFast | None = None
+
+        self._plugins = get_caching_autotuner_plugins(self)
 
         # Compile-time info included in runtime logginging
         self.compile_id: CompileId | None = None
@@ -741,11 +788,13 @@ class CachingAutotuner(KernelInterface):
         return {
             **self.__dict__,
             "lock": None,
+            "_plugins": [],
         }
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
         self.lock = threading.Lock()
+        self._plugins = get_caching_autotuner_plugins(self)
 
     def get_device_interface(self):
         # this code cannot run in compile workers, because it imports from torch
@@ -1737,13 +1786,28 @@ class CachingAutotuner(KernelInterface):
                 **self.configs[0].kwargs,
             )
 
+        for plugin in self._plugins:
+            if (
+                result := plugin.pre_dispatch(self, *args, stream=stream, **kwargs)
+            ) is not DEFER:
+                return result
+
         if len(self.launchers) != 1:
             if len(self.launchers) == 0:
                 start_time = time.time_ns()
                 self.precompile()
                 self.precompile_time_taken_ns = time.time_ns() - start_time
             if len(self.launchers) > 1:
-                self.autotune_to_one_config(*args, **kwargs)
+                for plugin in self._plugins:
+                    if (
+                        result := plugin.pre_autotune(
+                            self, *args, stream=stream, **kwargs
+                        )
+                    ) is not DEFER:
+                        return result
+                # Re-check: a plugin may have mutated launchers down to one.
+                if len(self.launchers) > 1:
+                    self.autotune_to_one_config(*args, **kwargs)
 
         if self.inductor_meta.get("combo_tuning_groups") and not getattr(
             self.launchers[0].config, "found_by_combo_autotune", False

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -363,7 +363,14 @@ def get_caching_autotuner_plugins(
     Each plugin adds an entry here, gated on its own config flag, with
     imports kept inside the relevant branch.
     """
-    return []
+    from torch._inductor import config
+
+    plugins: list[CachingAutotunerPlugin] = []
+    if config.incremental_autotune:
+        from .incremental import IncrementalAutotunePlugin
+
+        plugins.append(IncrementalAutotunePlugin())
+    return plugins
 
 
 class CachingAutotuner(KernelInterface):

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -257,6 +257,7 @@ def set_logs(
     cudagraph_static_inputs: bool = False,
     benchmarking: bool = False,
     autotuning: bool = False,
+    incremental: bool = False,
     graph_region_expansion: bool = False,
     inductor_metrics: bool = False,
     hierarchical_compile: bool = False,
@@ -457,6 +458,9 @@ def set_logs(
         autotuning (:class:`bool`):
             Autotuning choice logs, such as kernel source, perf, and tuning parameters. Default: ``False``
 
+        incremental (:class:`bool`):
+            Incremental autotuning logs. Default: ``False``
+
         graph_region_expansion (:class:`bool`):
             Whether to emit the detailed steps of the duplicate graph region tracker expansion algorithm. Default: ``False``
 
@@ -585,6 +589,7 @@ def set_logs(
         cudagraph_static_inputs=cudagraph_static_inputs,
         benchmarking=benchmarking,
         autotuning=autotuning,
+        incremental=incremental,
         graph_region_expansion=graph_region_expansion,
         inductor_metrics=inductor_metrics,
         hierarchical_compile=hierarchical_compile,

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -241,6 +241,11 @@ register_artifact(
     off_by_default=True,
 )
 register_artifact(
+    "incremental",
+    "Incremental autotuning logs.",
+    off_by_default=True,
+)
+register_artifact(
     "node_runtime_estimation",
     "Node runtime estimation for compile-time optimization decisions.",
     off_by_default=True,


### PR DESCRIPTION
Summary:
Wires incremental autotuning into `CachingAutotuner` via the plugin extension mechanism (`CachingAutotunerPlugin`). The plugin builds its per-autotuner `IncrementalAutotuneState` from the shared per-config `Launcher` pool (commit 4), intercepts `pre_autotune` to drive the round-robin in place of `autotune_to_one_config`, and intercepts `pre_dispatch` on subsequent calls until convergence. Activation is gated on `config.incremental_autotune` plus a JK version check (`pytorch/inductor:incremental_autotune_version`).

Closures held by the state weakref the plugin and autotuner so cleanup is not delayed by the plugin↔state reference cycle.

Authored with Claude.

Test Plan:
# Full test suites for the modules this commit wires together
buck test fbcode//mode/opt -m ovr_config//triton:beta -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor:incremental_autotune fbcode//caffe2/test/inductor:triton_heuristics

# Only the new test class
buck test fbcode//mode/opt -m ovr_config//triton:beta -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor:incremental_autotune -- PluginTest

Differential Revision: D101329073




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98