### PR TITLE
[MPS] Add complex support to `c10/metal/reduction_utils.h`

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -15,26 +15,27 @@ inline c10::metal::opmath_t<T> matmul_inner(
     constant T* mat2Data,
     constant array<ulong2, 3>& strides,
     constant uint3& sizes,
-    threadgroup T A_tile[TILE_DIM][TILE_DIM],
-    threadgroup T B_tile[TILE_DIM][TILE_DIM],
+    threadgroup c10::metal::opmath_t<T> A_tile[TILE_DIM][TILE_DIM],
+    threadgroup c10::metal::opmath_t<T> B_tile[TILE_DIM][TILE_DIM],
     uint2 tid,
     uint2 thread_id) {
-  c10::metal::opmath_t<T> sum = 0;
+  using TA = c10::metal::opmath_t<T>;
+  TA sum = 0;
 
   uint numTiles = (sizes.y + TILE_DIM - 1) / TILE_DIM;
   for (uint t = 0; t < numTiles; t++) {
     uint tiledCol = t * TILE_DIM + tid.x;
     if (thread_id.y < sizes.x && tiledCol < sizes.y) {
-      A_tile[tid.y][tid.x] =
-          mat1Data[thread_id.y * strides[0].x + tiledCol * strides[0].y];
+      A_tile[tid.y][tid.x] = static_cast<TA>(
+          mat1Data[thread_id.y * strides[0].x + tiledCol * strides[0].y]);
     } else {
       A_tile[tid.y][tid.x] = 0;
     }
 
     uint tiledRow = t * TILE_DIM + tid.y;
     if (tiledRow < sizes.y && thread_id.x < sizes.z) {
-      B_tile[tid.y][tid.x] =
-          mat2Data[tiledRow * strides[1].x + thread_id.x * strides[1].y];
+      B_tile[tid.y][tid.x] = static_cast<TA>(
+          mat2Data[tiledRow * strides[1].x + thread_id.x * strides[1].y]);
     } else {
       B_tile[tid.y][tid.x] = 0;
     }
@@ -58,12 +59,13 @@ inline c10::metal::opmath_t<T> batched_matmul_inner(
     uint batch,
     constant array<ulong, N>& strides,
     constant uint4& sizes,
-    threadgroup T A_tile[TILE_DIM][TILE_DIM],
-    threadgroup T B_tile[TILE_DIM][TILE_DIM],
+    threadgroup c10::metal::opmath_t<T> A_tile[TILE_DIM][TILE_DIM],
+    threadgroup c10::metal::opmath_t<T> B_tile[TILE_DIM][TILE_DIM],
     uint3 tid,
     uint row,
     uint col) {
-  c10::metal::opmath_t<T> sum = 0;
+  using TA = c10::metal::opmath_t<T>;
+  TA sum = 0;
 
   // Compute batch offsets
   uint batch1Offset = batch * strides[2];
@@ -73,16 +75,16 @@ inline c10::metal::opmath_t<T> batched_matmul_inner(
   for (uint t = 0; t < numTiles; t++) {
     uint tiledCol = t * TILE_DIM + tid.x;
     if (row < sizes.x && tiledCol < sizes.y) {
-      A_tile[tid.y][tid.x] =
-          mat1Data[batch1Offset + row * strides[1] + tiledCol * strides[0]];
+      A_tile[tid.y][tid.x] = static_cast<TA>(
+          mat1Data[batch1Offset + row * strides[1] + tiledCol * strides[0]]);
     } else {
       A_tile[tid.y][tid.x] = 0;
     }
 
     uint tiledRow = t * TILE_DIM + tid.y;
     if (tiledRow < sizes.y && col < sizes.z) {
-      B_tile[tid.y][tid.x] =
-          mat2Data[batch2Offset + tiledRow * strides[4] + col * strides[3]];
+      B_tile[tid.y][tid.x] = static_cast<TA>(
+          mat2Data[batch2Offset + tiledRow * strides[4] + col * strides[3]]);
     } else {
       B_tile[tid.y][tid.x] = 0;
     }
@@ -108,8 +110,8 @@ kernel void matmul(
     constant uint3& sizes [[buffer(4)]],
     uint2 tid [[thread_position_in_threadgroup]],
     uint2 thread_id [[thread_position_in_grid]]) {
-  threadgroup T A_tile[TILE_DIM][TILE_DIM];
-  threadgroup T B_tile[TILE_DIM][TILE_DIM];
+  threadgroup c10::metal::opmath_t<T> A_tile[TILE_DIM][TILE_DIM];
+  threadgroup c10::metal::opmath_t<T> B_tile[TILE_DIM][TILE_DIM];
 
   auto sum = matmul_inner(
       mat1Data, mat2Data, strides, sizes, A_tile, B_tile, tid, thread_id);
@@ -130,8 +132,8 @@ kernel void addmm(
     constant uint3& sizes [[buffer(6)]],
     uint2 tid [[thread_position_in_threadgroup]],
     uint2 thread_id [[thread_position_in_grid]]) {
-  threadgroup T A_tile[TILE_DIM][TILE_DIM];
-  threadgroup T B_tile[TILE_DIM][TILE_DIM];
+  threadgroup c10::metal::opmath_t<T> A_tile[TILE_DIM][TILE_DIM];
+  threadgroup c10::metal::opmath_t<T> B_tile[TILE_DIM][TILE_DIM];
 
   auto sum = matmul_inner<T>(
       mat1Data,
@@ -143,8 +145,9 @@ kernel void addmm(
       tid,
       thread_id);
   if (thread_id.y < sizes.x && thread_id.x < sizes.z) {
-    auto bias =
-        biasData[thread_id.y * strides[3].x + thread_id.x * strides[3].y];
+    using TA = c10::metal::opmath_t<T>;
+    auto bias = static_cast<TA>(
+        biasData[thread_id.y * strides[3].x + thread_id.x * strides[3].y]);
     outputData[thread_id.y * strides[2].x + thread_id.x * strides[2].y] =
         static_cast<T>(
             c10::metal::mul(alpha_beta[0], sum) +
@@ -165,8 +168,8 @@ kernel void naive_bmm(
   uint col = group_id.x * TILE_DIM + tid.x;
   uint row = group_id.y * TILE_DIM + tid.y;
 
-  threadgroup T A_tile[TILE_DIM][TILE_DIM];
-  threadgroup T B_tile[TILE_DIM][TILE_DIM];
+  threadgroup c10::metal::opmath_t<T> A_tile[TILE_DIM][TILE_DIM];
+  threadgroup c10::metal::opmath_t<T> B_tile[TILE_DIM][TILE_DIM];
 
   auto sum = batched_matmul_inner<T, 9>(
       mat1Data, mat2Data, batch, strides, sizes, A_tile, B_tile, tid, row, col);
@@ -192,15 +195,17 @@ kernel void naive_baddbmm(
   uint col = group_id.x * TILE_DIM + tid.x;
   uint row = group_id.y * TILE_DIM + tid.y;
 
-  threadgroup T A_tile[TILE_DIM][TILE_DIM];
-  threadgroup T B_tile[TILE_DIM][TILE_DIM];
+  threadgroup c10::metal::opmath_t<T> A_tile[TILE_DIM][TILE_DIM];
+  threadgroup c10::metal::opmath_t<T> B_tile[TILE_DIM][TILE_DIM];
 
   auto sum = batched_matmul_inner<T, 12>(
       mat1Data, mat2Data, batch, strides, sizes, A_tile, B_tile, tid, row, col);
 
   if (row < sizes.x && col < sizes.z) {
+    using TA = c10::metal::opmath_t<T>;
     uint biasOffset = batch * strides[11];
-    auto bias = biasData[biasOffset + row * strides[10] + col * strides[9]];
+    auto bias = static_cast<TA>(
+        biasData[biasOffset + row * strides[10] + col * strides[9]]);
     outputData[batch * strides[8] + col * strides[6] + row * strides[7]] =
         static_cast<T>(
             c10::metal::mul(alpha_beta[0], sum) +
@@ -224,8 +229,8 @@ kernel void naive_addbmm(
 
   c10::metal::opmath_t<T> sum = 0;
 
-  threadgroup T A_tile[TILE_DIM][TILE_DIM];
-  threadgroup T B_tile[TILE_DIM][TILE_DIM];
+  threadgroup c10::metal::opmath_t<T> A_tile[TILE_DIM][TILE_DIM];
+  threadgroup c10::metal::opmath_t<T> B_tile[TILE_DIM][TILE_DIM];
 
   // Iterate through all batches and accumulate
   for (uint batch = 0; batch < sizes.w; batch++) {
@@ -243,7 +248,8 @@ kernel void naive_addbmm(
   }
 
   if (row < sizes.x && col < sizes.z) {
-    auto bias = biasData[row * strides[10] + col * strides[9]];
+    using TA = c10::metal::opmath_t<T>;
+    auto bias = static_cast<TA>(biasData[row * strides[10] + col * strides[9]]);
     outputData[row * strides[7] + col * strides[6]] = static_cast<T>(
         c10::metal::mul(alpha_beta[0], sum) +
         c10::metal::mul(alpha_beta[1], bias));

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -22,13 +22,31 @@ struct simd_type<bfloat> {
 } // namespace detail
 
 template <typename T>
-inline ::metal::enable_if_t<!::metal::is_same_v<T, long>, T> simd_sum(T val) {
+inline ::metal::
+    enable_if_t<!::metal::is_same_v<T, long> && !c10::metal::is_complex_v<T>, T>
+    simd_sum(T val) {
   return T(::metal::simd_sum(detail::simd_type_t<T>(val)));
 }
 
+inline float2 simd_sum(float2 val) {
+  return float2(::metal::simd_sum(val.x), ::metal::simd_sum(val.y));
+}
+
 template <typename T>
-inline ::metal::enable_if_t<!::metal::is_same_v<T, long>, T> simd_prod(T val) {
+inline ::metal::
+    enable_if_t<!::metal::is_same_v<T, long> && !c10::metal::is_complex_v<T>, T>
+    simd_prod(T val) {
   return T(::metal::simd_product(detail::simd_type_t<T>(val)));
+}
+
+// Complex product reduction via shuffle, using c10::metal::mul for (a+bi)(c+di)
+// Uses simd_shuffle_and_fill_down with identity (1+0i) for inactive lanes.
+inline float2 simd_prod(float2 val) {
+  for (ushort i = simdgroup_size / 2; i > 0; i /= 2) {
+    val = c10::metal::mul(
+        val, ::metal::simd_shuffle_and_fill_down(val, float2(1, 0), i));
+  }
+  return val;
 }
 
 // Extend simd_broadcast to 64-bit integral types using int2 trick

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -82,6 +82,11 @@ struct OpMathType<bfloat> {
   using type = float;
 };
 
+template <>
+struct OpMathType<half2> {
+  using type = float2;
+};
+
 // Type promotion structure for higher precision accumulation
 template <typename T>
 struct AccumulationType {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -13452,6 +13452,45 @@ class TestMetalLibrary(TestCaseMPS):
         self.assertTrue(z0.isnan().all().item(), f"results are {z0}, but all elements should have been nan")
         self.assertTrue((z1 == idx).all().item(), f"results are {z1}, but all elements should have been {idx}")
 
+    def test_reduction_utils_complex(self):
+        """Test simd_sum and simd_prod for float2 (complex64)."""
+        lib = torch.mps.compile_shader("""
+            #include <c10/metal/reduction_utils.h>
+            kernel void do_sum(device float2* out,
+                               constant float2* inp,
+                               uint idx [[thread_position_in_grid]]) {
+                out[idx] = c10::metal::simd_sum(inp[idx]);
+            }
+
+            kernel void do_prod(device float2* out,
+                                constant float2* inp,
+                                uint idx [[thread_position_in_grid]]) {
+                out[idx] = c10::metal::simd_prod(inp[idx]);
+            }
+        """)
+
+        # Test simd_sum: all 32 lanes get the same total
+        x = torch.randn(28, device="mps", dtype=torch.complex64)
+        y = torch.empty_like(x)
+        lib.do_sum(y, x)
+        x_sum = x.sum()
+        max_err = (y - x_sum).abs().max().item()
+        self.assertLess(max_err, 1e-4, f"simd_sum error {max_err}, expected {x_sum}")
+
+        # Test simd_prod: product of a few small complex numbers
+        # Use only 4 non-unit values to keep the product numerically stable
+        x_prod = torch.ones(32, device="mps", dtype=torch.complex64)
+        x_prod[0] = 1 + 2j
+        x_prod[1] = 3 - 1j
+        x_prod[2] = -1 + 1j
+        x_prod[3] = 2 + 0j
+        y_prod = torch.empty_like(x_prod)
+        lib.do_prod(y_prod, x_prod, threads=(32,), group_size=(32,))
+        expected_prod = x_prod.prod()
+        # Only lane 0 has the final result for shuffle-down reduction
+        max_err = (y_prod[0] - expected_prod).abs().item()
+        self.assertLess(max_err, 1e-4, f"simd_prod error {max_err}, expected {expected_prod}")
+
     @parametrize("dtype", [torch.float32, torch.float16, torch.int32, torch.bfloat16])
     def test_atomic_add(self, dtype):
         from torch._inductor.codegen.mps import DTYPE_TO_METAL

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -25302,15 +25302,6 @@ python_ref_db = [
                 unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
                 dtypes=(torch.complex32,), device_type='cuda'
             ),
-            # TypeError: Trying to convert ComplexDouble to the MPS backend but it does not have support for that dtype
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref',
-                device_type='mps', dtypes=(torch.complex32,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex32,)
-            ),
         )
     ),
     ElementwiseBinaryPythonRefInfo(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #180709
* __->__ #180708

Add float2 `simd_sum` and `simd_prod` overloads to `c10/metal/reduction_utils.h` for complex reductions. `simd_sum` reduces real and imaginary parts independently; `simd_prod` simulates reduction using  `c10::metal::mul` and `simd_shuffle_and_fill_down`. 

Add `OpMathType<half2>` -> float2 specialization to `c10/metal/utils.h` so complex32 accumulation uses complex64 precision, that fixed prod op accuracy


Also fix a latent bug in `LinearAlgebra.metal`, when accumulation for `torch.half` (not used in prod yet) and `torch.complex32` matrices were done over lower precision dtypes 
Add test_reduction_utils_complex to `test/test_mps.py` covering simd_sum and simd_prod for float2 (complex64).