### PR TITLE
[ROCm][CI] Use env vars and clean up docker-cache-rocm.yml

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -58,7 +58,6 @@ self-hosted-runner:
     - linux.rocm.gpu.2
     - linux.rocm.gpu.4
     - linux.rocm.mi210.docker-cache
-    - linux.rocm.mi250.docker-cache
     # gfx942 runners
     - linux.rocm.gpu.gfx942.1
     - linux.rocm.gpu.gfx942.4

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux.rocm.mi250.docker-cache, linux.rocm.mi210.docker-cache]
+        runner: [linux.rocm.mi210.docker-cache]
         docker-image: [
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-jammy-rocm-n-py3 }}",
           "${{ needs.download-docker-builds-artifacts.outputs.pytorch-linux-noble-rocm-n-py3 }}"

--- a/.github/workflows/docker-cache-rocm.yml
+++ b/.github/workflows/docker-cache-rocm.yml
@@ -66,9 +66,10 @@ jobs:
     runs-on: "${{ matrix.runner }}"
     steps:
       - name: debug
+        env:
+          DOWNLOAD_OUTPUTS_JSON: ${{ toJSON(needs.download-docker-builds-artifacts.outputs) }}
         run: |
-          JSON_STRINGIFIED="${{ toJSON(needs.download-docker-builds-artifacts.outputs) }}"
-          echo "Outputs of download-docker-builds-artifacts job: ${JSON_STRINGIFIED}"
+          echo "Outputs of download-docker-builds-artifacts job: ${DOWNLOAD_OUTPUTS_JSON}"
 
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
@@ -81,8 +82,10 @@ jobs:
 
       - name: Generate ghrc.io tag
         id: ghcr-io-tag
+        env:
+          ECR_IMAGE: ${{ matrix.docker-image }}
         run: |
-            ecr_image="${{ matrix.docker-image }}"
+            ecr_image="${ECR_IMAGE}"
             ghcr_image="ghcr.io/pytorch/ci-image:${ecr_image##*:}"
             echo "ghcr_image=${ghcr_image}" >> "$GITHUB_OUTPUT"
 
@@ -92,11 +95,15 @@ jobs:
           docker-image: ${{ steps.ghcr-io-tag.outputs.ghcr_image }}
 
       - name: Save as tarball
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch || github.event.inputs.branch }}
+          ECR_IMAGE: ${{ matrix.docker-image }}
+          GHCR_IMAGE: ${{ steps.ghcr-io-tag.outputs.ghcr_image }}
         run: |
-          docker_image_tag=${{ matrix.docker-image }}
+          docker_image_tag=${ECR_IMAGE}
           docker_image_tag="${docker_image_tag#*:}" # Remove everything before and including first ":"
           docker_image_tag="${docker_image_tag%-*}" # Remove everything after and including last "-"
-          ref_name=${WORKFLOW_RUN_HEAD_BRANCH}
+          ref_name=${BRANCH}
           if [[ $ref_name =~ "release/" ]]; then
             ref_suffix="release"
           elif [[ $ref_name == "main" ]]; then
@@ -104,10 +111,7 @@ jobs:
           else
             echo "Unexpected branch in ref_name: ${ref_name}" && exit 1
           fi
-          docker tag ${{ steps.ghcr-io-tag.outputs.ghcr_image }} ${{ matrix.docker-image }}
+          docker tag "${GHCR_IMAGE}" "${ECR_IMAGE}"
           # mv is atomic operation, so we use intermediate tar.tmp file to prevent read-write contention
-          docker save -o ~/pytorch-data/docker/${docker_image_tag}.tar.tmp ${{ matrix.docker-image }}
+          docker save -o ~/pytorch-data/docker/${docker_image_tag}.tar.tmp "${ECR_IMAGE}"
           mv ~/pytorch-data/docker/${docker_image_tag}.tar.tmp ~/pytorch-data/docker/${docker_image_tag}_${ref_suffix}.tar
-
-        env:
-          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || github.event.inputs.branch }}


### PR DESCRIPTION
* Use env vars to evaluate expressions (safer)
* Remove mi250 runner docker caching since we do not use those runners currently

Validation: Ran workflow successfully with PR branch: https://github.com/pytorch/pytorch/actions/runs/24637015389

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang