### PR TITLE
Fix torch.compile addmm with beta=0 and mismatched bias

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -4225,6 +4225,27 @@ class CommonTemplate:
             ),
         )
 
+    @skipCPUIf(True, "CUDA-only: CPU eager doesn't skip shape check when beta=0")
+    def test_addmm_beta_zero_mismatched_bias(self):
+        # Test that addmm with beta=0 works even when bias shape doesn't match output
+        def fn(bias, x, weight):
+            # bias shape [512] doesn't match output [4, 10000]
+            # but beta=0 means bias is zeroed out, so shape shouldn't matter
+            return torch.addmm(bias, x, weight.t(), beta=0.0, alpha=0.1)
+
+        d_model = 512
+        vocab_size = 10000
+        batch_size = 4
+
+        self.common(
+            fn,
+            (
+                torch.randn(d_model, device=self.device),
+                torch.randn(batch_size, d_model, device=self.device),
+                torch.randn(vocab_size, d_model, device=self.device),
+            ),
+        )
+
     def test_addmv(self):
         def fn(a, b, c):
             return torch.addmv(a, b, c)

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -385,6 +385,12 @@ def addmm(
     beta: torch.types.Number = 1,
     alpha: torch.types.Number = 1,
 ) -> torch.Tensor:
+    # Handle beta=0 case early to avoid shape validation issues when bias shape
+    # doesn't match output shape
+    if beta == 0:
+        out = alpha * torch.mm(mat1, mat2)
+        return out
+
     if mat1.device.type not in ["cpu", "mps"]:
         if (
             statically_known_true(mat1.size(-1) == 1)


### PR DESCRIPTION
Fixes #178040 
Fixes torch.compile raising RuntimeError on torch.addmm  calls where beta=0 and bias shape doesn't match output shape. When beta=0 the bias term is zeroed out so its shape is irrelevant. This now matches eager

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos