### PR TITLE
Skip custom_op aliasing check under no_grad / inference_mode

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -3927,6 +3927,25 @@ Please use `add.register_fake` to add an fake impl.""",
         with self.assertRaisesRegex(RuntimeError, "may not alias"):
             numpy_sin_inplace(x)
 
+    def test_output_aliasing_allowed_under_no_grad(self):
+        # aliasing check should be skipped when autograd is disabled
+        @torch.library.custom_op("_torch_testing::f", mutates_args=("x",))
+        def f(x: Tensor) -> Tensor:
+            return x.view(-1)
+
+        x = torch.randn(3)
+        with self.assertRaisesRegex(RuntimeError, "may not alias"):
+            f(x)
+
+        with torch.no_grad():
+            out = f(x)
+            self.assertTrue(out.data_ptr() == x.data_ptr())
+
+        with torch.inference_mode():
+            x2 = torch.randn(3)
+            out2 = f(x2)
+            self.assertTrue(out2.data_ptr() == x2.data_ptr())
+
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_factory_function(self):
         @torch.library.custom_op(

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -379,7 +379,7 @@ class CustomOpDef:
                             return inspect.getmodule(fn)
 
                         schema = self._opoverload._schema
-                        if not schema._is_view_op():
+                        if not schema._is_view_op() and torch.is_grad_enabled():
                             utils._c_check_aliasing_constraint(
                                 self._name,
                                 args,


### PR DESCRIPTION
The aliasing check on custom op outputs is there to protect the autograd graph, but it fires unconditionally today, even when grad is disabled via torch.no_grad() or torch.inference_mode(). In those contexts there is no autograd graph being built, so returning a view of an input is perfectly fine. This fixes that by gating the check on torch.is_grad_enabled(). Fixes #180620.