### PR TITLE
[ROCm] Fix FlexAttention fp16 default num_warps (8 -> 4) on AMD GPUs

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1561,8 +1561,8 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             (torch.bfloat16, 64): ROCmFlexConfig(128, 64, 2, 4, kpack=default_kpack),
             (torch.bfloat16, 128): ROCmFlexConfig(128, 64, 2, 4, kpack=default_kpack),
             (torch.bfloat16, 256): ROCmFlexConfig(32, 64, 2, 4, kpack=default_kpack),
-            (torch.float16, 64): ROCmFlexConfig(128, 64, 2, 8, kpack=default_kpack),
-            (torch.float16, 128): ROCmFlexConfig(128, 64, 2, 8, kpack=default_kpack),
+            (torch.float16, 64): ROCmFlexConfig(128, 64, 2, 4, kpack=default_kpack),
+            (torch.float16, 128): ROCmFlexConfig(128, 64, 2, 4, kpack=default_kpack),
             (torch.float16, 256): ROCmFlexConfig(32, 64, 2, 4, kpack=default_kpack),
         }
 
@@ -1753,7 +1753,7 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             if dtype == torch.float32:
                 default_config = ROCmFlexConfig(64, 64, 1, 4, kpack=default_kpack)
             else:
-                default_config = ROCmFlexConfig(128, 64, 2, 8, kpack=default_kpack)
+                default_config = ROCmFlexConfig(128, 64, 2, 4, kpack=default_kpack)
             default_config = self.default_flex_config.get(
                 (dtype, head_dim), default_config
             )


### PR DESCRIPTION
The default ROCmFlexConfig for float16 with head_dim 64 and 128 used num_warps=8, which is suboptimal on gfx950. Benchmarks on MI350X show that num_warps=4 provides a consistent ~2x speedup for fp16 FlexAttention, bringing it to parity with an optimized standalone Flash Attention kernel.

Also fixes the fallback default for non-float32 dtypes (head_dim <=256) to use num_warps=4, consistent with the explicit bf16 defaults.

As the next step, I will rework Inductor default heuristics to be target dependent which will help sort these issues.

## Benchmark
  MI350X, D=128, H=64, fwd only, `torch.compile`, single GPU
  ### FP16 Non-Causal
  | B | S | `num_warps=8` (us) | `num_warps=4` (us) | Speedup | `num_warps=8` (TFLOPS) | `num_warps=4` (TFLOPS) |
  |--:|--:|---:|---:|---:|---:|---:|
  | 32 | 512 | 1115 | 673 | 1.66x | 247 | 409 |
  | 16 | 1024 | 1973 | 1095 | 1.80x | 280 | 502 |
  | 8 | 2048 | 3543 | 1883 | 1.88x | 310 | 584 |
  | 4 | 4096 | 6640 | 3402 | 1.95x | 332 | 646 |
  | 2 | 8192 | 12902 | 6425 | 2.01x | 341 | 685 |
  | 1 | 16384 | 25177 | 12409 | 2.03x | 349 | 709 |
  ### FP16 Causal
  | B | S | `num_warps=8` (us) | `num_warps=4` (us) | Speedup | `num_warps=8` (TFLOPS) | `num_warps=4` (TFLOPS) |
  |--:|--:|---:|---:|---:|---:|---:|
  | 32 | 512 | 948 | 588 | 1.61x | 145 | 234 |
  | 16 | 1024 | 1663 | 912 | 1.82x | 165 | 301 |
  | 8 | 2048 | 2990 | 1499 | 1.99x | 184 | 367 |
  | 4 | 4096 | 5583 | 2690 | 2.08x | 197 | 409 |
  | 2 | 8192 | 8680 | 4347 | 2.00x | 253 | 506 |
  | 1 | 16384 | 15062 | 7777 | 1.94x | 292 | 566 |
  > BF16 is unaffected by this change (already uses `num_warps=4`).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben