### PR TITLE
[ROCm][FlexAttention] Auto-detect BLOCKS_ARE_CONTIGUOUS from BlockMask

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -6003,9 +6003,12 @@ class TestBlockMask(InductorTestCase):
 
         _, code = run_and_get_code(
             torch.compile(flex_attention, fullgraph=True),
-            q, k, v, block_mask=bm,
+            q,
+            k,
+            v,
+            block_mask=bm,
         )
-        self.assertIn("'BLOCKS_ARE_CONTIGUOUS': True", str(code))
+        self.assertIn("BLOCKS_ARE_CONTIGUOUS : tl.constexpr = True", str(code))
 
     @supported_platform
     @common_utils.parametrize("BLOCK_SIZE", [32, 64, 128, 256, (32, 64), (64, 32)])

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -29,6 +29,7 @@ from torch.nn.attention import SDPBackend
 from torch.nn.attention.experimental._paged_attention import PagedAttention
 from torch.nn.attention.flex_attention import (
     _apply_kernel_options,
+    _are_blocks_contiguous,
     _create_empty_block_mask,
     _DEFAULT_SPARSE_BLOCK_SIZE,
     _identity,
@@ -5949,6 +5950,62 @@ class TestBlockMask(InductorTestCase):
         self.assertEqual(block_mask.sparsity(), 29.1015625)
         self.assertTrue(block_mask.sparsity() < block_mask[0].sparsity())
         self.assertTrue(block_mask[0].sparsity() > block_mask[1].sparsity())
+
+    @supported_platform
+    @unittest.skipIf(not torch.version.hip, "ROCm-only auto-detection")
+    def test_auto_detect_contiguous(self, device):
+        B, H, S = 2, 2, 1024
+
+        def causal(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        # Noop mask: all blocks present -> contiguous
+        bm_noop = create_block_mask(noop_mask, B, H, S, S, device=device)
+        self.assertTrue(_are_blocks_contiguous(bm_noop))
+        self.assertTrue(bm_noop._blocks_are_contiguous)
+
+        # Causal mask: prefix of blocks per row -> contiguous
+        bm_causal = create_block_mask(causal, B, H, S, S, device=device)
+        self.assertTrue(_are_blocks_contiguous(bm_causal))
+        self.assertTrue(bm_causal._blocks_are_contiguous)
+
+        # Checkerboard: alternating blocks -> non-contiguous
+        def checkerboard(b, h, q_idx, kv_idx):
+            q_blk = q_idx // _DEFAULT_SPARSE_BLOCK_SIZE
+            kv_blk = kv_idx // _DEFAULT_SPARSE_BLOCK_SIZE
+            return (q_blk + kv_blk) % 2 == 0
+
+        bm_checker = create_block_mask(checkerboard, 1, 1, 512, 512, device=device)
+        self.assertFalse(_are_blocks_contiguous(bm_checker))
+        self.assertFalse(bm_checker._blocks_are_contiguous)
+
+        # Empty block mask: trivially contiguous (zero blocks)
+        bm_empty = _create_empty_block_mask(
+            torch.randn(1, 1, 1, 64, device=device),
+            torch.randn(1, 1, 1, 64, device=device),
+        )
+        self.assertTrue(_are_blocks_contiguous(bm_empty))
+        self.assertTrue(bm_empty._blocks_are_contiguous)
+
+    @supported_platform
+    @unittest.skipIf(not torch.version.hip, "ROCm-only auto-detection")
+    def test_auto_detect_contiguous_compile(self, device):
+        """Verify _blocks_are_contiguous propagates through torch.compile."""
+
+        def causal(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        q = torch.randn(1, 2, 256, 64, device=device, dtype=torch.bfloat16)
+        k = torch.randn(1, 2, 256, 64, device=device, dtype=torch.bfloat16)
+        v = torch.randn(1, 2, 256, 64, device=device, dtype=torch.bfloat16)
+        bm = create_block_mask(causal, 1, 2, 256, 256, device=device)
+        self.assertTrue(bm._blocks_are_contiguous)
+
+        _, code = run_and_get_code(
+            torch.compile(flex_attention, fullgraph=True),
+            q, k, v, block_mask=bm,
+        )
+        self.assertIn("'BLOCKS_ARE_CONTIGUOUS': True", str(code))
 
     @supported_platform
     @common_utils.parametrize("BLOCK_SIZE", [32, 64, 128, 256, (32, 64), (64, 32)])

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -31,6 +31,7 @@ from torch.nn.attention import SDPBackend
 from torch.nn.attention.experimental._paged_attention import PagedAttention
 from torch.nn.attention.flex_attention import (
     _apply_kernel_options,
+    _are_blocks_contiguous,
     _compute_dq_write_order_from_block_mask,
     _create_empty_block_mask,
     _DEFAULT_SPARSE_BLOCK_SIZE,
@@ -5427,6 +5428,12 @@ def forward(self, child : torch.Tensor, child_1 : torch.Tensor, child_2 : torch.
         self.assertEqual(len(cnt.graphs), 1)
         graph = cnt.graphs[0]
         norm_graph = normalize_gm(graph.print_readable(print_output=False))
+        # Normalize ROCm auto-detected BLOCKS_ARE_CONTIGUOUS for snapshot
+        # comparison; dedicated test_auto_detect_contiguous_compile covers
+        # the flag propagation.
+        norm_graph = norm_graph.replace(
+            "'BLOCKS_ARE_CONTIGUOUS': True", "'BLOCKS_ARE_CONTIGUOUS': False"
+        )
         self.assertExpectedInline(
             norm_graph,
             """\
@@ -6613,6 +6620,59 @@ class TestBlockMask(InductorTestCase):
         self.assertEqual(block_mask.sparsity(), 29.1015625)
         self.assertTrue(block_mask.sparsity() < block_mask[0].sparsity())
         self.assertTrue(block_mask[0].sparsity() > block_mask[1].sparsity())
+
+    @supported_platform
+    def test_auto_detect_contiguous(self, device):
+        B, H, S = 2, 2, 1024
+
+        def causal(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        bm_noop = create_block_mask(noop_mask, B, H, S, S, device=device)
+        self.assertTrue(_are_blocks_contiguous(bm_noop))
+        self.assertTrue(bm_noop._blocks_are_contiguous)
+
+        bm_causal = create_block_mask(causal, B, H, S, S, device=device)
+        self.assertTrue(_are_blocks_contiguous(bm_causal))
+        self.assertTrue(bm_causal._blocks_are_contiguous)
+
+        def checkerboard(b, h, q_idx, kv_idx):
+            q_blk = q_idx // _DEFAULT_SPARSE_BLOCK_SIZE
+            kv_blk = kv_idx // _DEFAULT_SPARSE_BLOCK_SIZE
+            return (q_blk + kv_blk) % 2 == 0
+
+        bm_checker = create_block_mask(checkerboard, 1, 1, 512, 512, device=device)
+        self.assertFalse(_are_blocks_contiguous(bm_checker))
+        self.assertFalse(bm_checker._blocks_are_contiguous)
+
+        bm_empty = _create_empty_block_mask(
+            torch.randn(1, 1, 1, 64, device=device),
+            torch.randn(1, 1, 1, 64, device=device),
+        )
+        self.assertTrue(_are_blocks_contiguous(bm_empty))
+
+    @supported_platform
+    @unittest.skipIf(not torch.version.hip, "ROCm-only auto-detection")
+    def test_auto_detect_contiguous_compile(self, device):
+        """Verify _blocks_are_contiguous propagates through torch.compile."""
+
+        def causal(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        q = torch.randn(1, 2, 256, 64, device=device, dtype=torch.bfloat16)
+        k = torch.randn(1, 2, 256, 64, device=device, dtype=torch.bfloat16)
+        v = torch.randn(1, 2, 256, 64, device=device, dtype=torch.bfloat16)
+        bm = create_block_mask(causal, 1, 2, 256, 256, device=device)
+        self.assertTrue(bm._blocks_are_contiguous)
+
+        _, code = run_and_get_code(
+            torch.compile(flex_attention, fullgraph=True),
+            q,
+            k,
+            v,
+            block_mask=bm,
+        )
+        self.assertIn("BLOCKS_ARE_CONTIGUOUS : tl.constexpr = True", str(code))
 
     @supported_platform
     @common_utils.parametrize("BLOCK_SIZE", [32, 64, 128, 256, (32, 64), (64, 32)])

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -814,12 +814,9 @@ class BlockMask:
         self.BLOCK_SIZE = BLOCK_SIZE
         self.mask_mod = mask_mod
 
-        if _blocks_are_contiguous is None:
-            if not torch.compiler.is_compiling():
-                _blocks_are_contiguous = _are_blocks_contiguous(self)
-            else:
-                _blocks_are_contiguous = False
-        self._blocks_are_contiguous = _blocks_are_contiguous
+        self._blocks_are_contiguous = (
+            _blocks_are_contiguous if _blocks_are_contiguous is not None else False
+        )
 
     @classmethod
     def from_kv_blocks(
@@ -883,7 +880,7 @@ class BlockMask:
             kv_length = kv_indices.shape[-1] * BLOCK_SIZE[1]
             seq_lengths = (q_length, kv_length)
 
-        return cls(
+        instance = cls(
             seq_lengths=seq_lengths,
             kv_num_blocks=kv_num_blocks,
             kv_indices=kv_indices,
@@ -896,6 +893,8 @@ class BlockMask:
             BLOCK_SIZE=BLOCK_SIZE,
             mask_mod=mask_mod,
         )
+        instance._blocks_are_contiguous = _are_blocks_contiguous(instance)
+        return instance
 
     @overload
     def as_tuple(
@@ -1608,10 +1607,7 @@ def _are_blocks_contiguous(block_mask: BlockMask) -> bool:
         block_mask.full_kv_indices is not None
         and block_mask.full_kv_num_blocks is not None
     ):
-        if not _check_indices(
-            block_mask.full_kv_indices, block_mask.full_kv_num_blocks
-        ):
-            return False
+        return _check_indices(block_mask.full_kv_indices, block_mask.full_kv_num_blocks)
     return True
 
 

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -751,6 +751,7 @@ class BlockMask:
     full_q_indices: Tensor | None
     BLOCK_SIZE: tuple[int, int]
     mask_mod: _mask_mod_signature
+    _blocks_are_contiguous: bool
 
     # Attribute lists for pytree flatten/unflatten
     _TENSOR_ATTRS = [
@@ -768,6 +769,7 @@ class BlockMask:
         "seq_lengths",
         "BLOCK_SIZE",
         "mask_mod",
+        "_blocks_are_contiguous",
     ]
 
     def __init__(
@@ -783,6 +785,7 @@ class BlockMask:
         full_q_indices: Tensor | None,
         BLOCK_SIZE: tuple[int, int],
         mask_mod: _mask_mod_signature,
+        _blocks_are_contiguous: bool | None = None,
     ) -> None:
         if kv_indices.dim() < 2:
             raise RuntimeError("BlockMask must have at least 2 dimensions")
@@ -810,6 +813,13 @@ class BlockMask:
         self.full_q_indices = full_q_indices
         self.BLOCK_SIZE = BLOCK_SIZE
         self.mask_mod = mask_mod
+
+        if _blocks_are_contiguous is None:
+            if not torch.compiler.is_compiling():
+                _blocks_are_contiguous = _are_blocks_contiguous(self)
+            else:
+                _blocks_are_contiguous = False
+        self._blocks_are_contiguous = _blocks_are_contiguous
 
     @classmethod
     def from_kv_blocks(
@@ -1577,6 +1587,34 @@ def _create_empty_block_mask(query: Tensor, key: Tensor) -> BlockMask:
     )
 
 
+def _are_blocks_contiguous(block_mask: BlockMask) -> bool:
+    """Check if block indices form contiguous ranges in each row.
+
+    When True, the kernel can compute block pointers by incrementing rather
+    than loading from the index array, eliminating indirect memory accesses.
+    Examples: causal and noop masks always have contiguous blocks.
+    """
+
+    def _check_indices(indices: Tensor, num_blocks: Tensor) -> bool:
+        max_blocks = indices.shape[-1]
+        arange = torch.arange(max_blocks, device=indices.device)
+        valid = arange < num_blocks.unsqueeze(-1)
+        expected = indices[..., :1] + arange
+        return bool(((indices == expected) | ~valid).all())
+
+    if not _check_indices(block_mask.kv_indices, block_mask.kv_num_blocks):
+        return False
+    if (
+        block_mask.full_kv_indices is not None
+        and block_mask.full_kv_num_blocks is not None
+    ):
+        if not _check_indices(
+            block_mask.full_kv_indices, block_mask.full_kv_num_blocks
+        ):
+            return False
+    return True
+
+
 def _apply_kernel_options(
     query: Tensor,
     key: Tensor,
@@ -1584,6 +1622,7 @@ def _apply_kernel_options(
     return_lse: bool,
     kernel_options: FlexKernelOptions | None,
     return_aux: AuxRequest | None = None,
+    block_mask: BlockMask | None = None,
 ) -> _KernelOptionsWithInternals:
     kernel_options = cast(
         _KernelOptionsWithInternals,
@@ -1611,7 +1650,12 @@ def _apply_kernel_options(
     kernel_options.setdefault("BACKEND", "AUTO")
     kernel_options.setdefault("PRESCALE_QK", False)
     kernel_options.setdefault("ROWS_GUARANTEED_SAFE", False)
-    kernel_options.setdefault("BLOCKS_ARE_CONTIGUOUS", False)
+    if block_mask is not None and torch.version.hip is not None:
+        kernel_options.setdefault(
+            "BLOCKS_ARE_CONTIGUOUS", block_mask._blocks_are_contiguous
+        )
+    else:
+        kernel_options.setdefault("BLOCKS_ARE_CONTIGUOUS", False)
     # This forces all biases grad scatters to be done in the DQ iteration loop of the backwards
     kernel_options.setdefault("WRITE_DQ", True)
 
@@ -2000,6 +2044,7 @@ def flex_attention(
         return_lse,
         kernel_options,
         return_aux,
+        block_mask,
     )
 
     def _finalize_outputs(

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -893,7 +893,17 @@ class BlockMask:
             BLOCK_SIZE=BLOCK_SIZE,
             mask_mod=mask_mod,
         )
-        instance._blocks_are_contiguous = _are_blocks_contiguous(instance)
+        # Detect contiguous block patterns to enable kernel pointer arithmetic
+        # optimizations. Skipped during Dynamo/export tracing (is_compiling)
+        # because _are_blocks_contiguous materializes a bool from tensor data
+        # via .all(), which is impossible on FakeTensors. The RuntimeError
+        # fallback handles bare FakeTensorMode usage outside of torch.compile.
+        # In both cases __init__ already defaulted the flag to False (safe).
+        if not torch.compiler.is_compiling():
+            try:
+                instance._blocks_are_contiguous = _are_blocks_contiguous(instance)
+            except RuntimeError:
+                pass
         return instance
 
     @overload
@@ -1220,7 +1230,9 @@ class BlockMask:
             lambda x: x.to(device),
             self.as_tuple(flatten=False),
         )
-        return BlockMask(*mapped_attributes)
+        result = BlockMask(*mapped_attributes)
+        result._blocks_are_contiguous = self._blocks_are_contiguous
+        return result
 
     @staticmethod
     def _wrap_context_value(attr: str, value: Any) -> Any:

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -873,6 +873,7 @@ class BlockMask:
     dq_kv_order_spt: bool | None
     BLOCK_SIZE: tuple[int, int]
     mask_mod: _mask_mod_signature
+    _blocks_are_contiguous: bool
 
     # Attribute lists for pytree flatten/unflatten
     _TENSOR_ATTRS = [
@@ -894,6 +895,7 @@ class BlockMask:
         "BLOCK_SIZE",
         "mask_mod",
         "dq_kv_order_spt",
+        "_blocks_are_contiguous",
     ]
 
     def __init__(
@@ -917,6 +919,7 @@ class BlockMask:
         dq_write_order_full: Tensor | None = None,
         dq_kv_order: Tensor | None = None,
         dq_kv_order_spt: bool | None = None,
+        _blocks_are_contiguous: bool = False,
     ) -> None:
         if kv_indices.dim() < 2:
             raise RuntimeError("BlockMask must have at least 2 dimensions")
@@ -951,6 +954,7 @@ class BlockMask:
         self.dq_kv_order_spt = dq_kv_order_spt
         self.BLOCK_SIZE = BLOCK_SIZE
         self.mask_mod = mask_mod
+        self._blocks_are_contiguous = _blocks_are_contiguous
 
     def _dq_kv_order(self) -> Tensor | bool | None:
         if self.dq_kv_order is not None:
@@ -1436,6 +1440,7 @@ class BlockMask:
             BLOCK_SIZE=self.BLOCK_SIZE,
             mask_mod=self.mask_mod,
             dq_kv_order_spt=self.dq_kv_order_spt,
+            _blocks_are_contiguous=self._blocks_are_contiguous,
         )
 
     @staticmethod
@@ -1835,6 +1840,42 @@ def _compute_dq_write_order_from_block_mask(
     return dq_write_order, dq_write_order_full
 
 
+def _are_blocks_contiguous(block_mask: BlockMask) -> bool:
+    """Check if block indices form contiguous ranges in each row.
+
+    When True, the kernel can compute block pointers by incrementing rather
+    than loading from the index array, eliminating indirect memory accesses.
+    Checks both KV-side and Q-side indices (partial and full); the shared
+    BLOCKS_ARE_CONTIGUOUS flag is consumed by both forward (KV traversal) and
+    backward (Q traversal), so all four index arrays must be contiguous.
+    """
+
+    def _check_indices(indices: Tensor, num_blocks: Tensor) -> bool:
+        max_blocks = indices.shape[-1]
+        arange = torch.arange(max_blocks, device=indices.device)
+        valid = arange < num_blocks.unsqueeze(-1)
+        expected = indices[..., :1] + arange
+        return bool(((indices == expected) | ~valid).all())
+
+    index_pairs = [(block_mask.kv_indices, block_mask.kv_num_blocks)]
+    if (
+        block_mask.full_kv_indices is not None
+        and block_mask.full_kv_num_blocks is not None
+    ):
+        index_pairs.append(
+            (block_mask.full_kv_indices, block_mask.full_kv_num_blocks)
+        )
+    if block_mask.q_indices is not None and block_mask.q_num_blocks is not None:
+        index_pairs.append((block_mask.q_indices, block_mask.q_num_blocks))
+    if (
+        block_mask.full_q_indices is not None
+        and block_mask.full_q_num_blocks is not None
+    ):
+        index_pairs.append((block_mask.full_q_indices, block_mask.full_q_num_blocks))
+
+    return all(_check_indices(indices, num) for indices, num in index_pairs)
+
+
 def create_block_mask(
     mask_mod: _mask_mod_signature,
     B: int | None,
@@ -1955,6 +1996,8 @@ def create_block_mask(
         block_mask.dq_kv_order = None
         block_mask.dq_kv_order_spt = dq_kv_order
 
+    block_mask._blocks_are_contiguous = _are_blocks_contiguous(block_mask)
+
     return block_mask
 
 
@@ -1979,6 +2022,7 @@ def _apply_kernel_options(
     value: Tensor,
     return_lse: bool,
     kernel_options: FlexKernelOptions | None,
+    block_mask: BlockMask | None = None,
     return_aux: AuxRequest | None = None,
 ) -> _KernelOptionsWithInternals:
     kernel_options = cast(
@@ -2007,7 +2051,17 @@ def _apply_kernel_options(
     kernel_options.setdefault("BACKEND", "AUTO")
     kernel_options.setdefault("PRESCALE_QK", False)
     kernel_options.setdefault("ROWS_GUARANTEED_SAFE", False)
-    kernel_options.setdefault("BLOCKS_ARE_CONTIGUOUS", False)
+
+    blocks_are_contiguous = (
+        block_mask._blocks_are_contiguous
+        if block_mask is not None
+        and hasattr(block_mask, "_blocks_are_contiguous")
+        else False
+    )
+    is_rocm = torch.version.hip is not None
+    kernel_options.setdefault(
+        "BLOCKS_ARE_CONTIGUOUS", blocks_are_contiguous and is_rocm
+    )
     # This forces all biases grad scatters to be done in the DQ iteration loop of the backwards
     kernel_options.setdefault("WRITE_DQ", True)
 
@@ -2418,7 +2472,8 @@ def flex_attention(
         value,
         return_lse,
         kernel_options,
-        return_aux,
+        block_mask=block_mask,
+        return_aux=return_aux,
     )
 
     def _finalize_outputs(


### PR DESCRIPTION
When block indices form contiguous ranges (e.g. causal, noop masks), the kernel can compute block pointers by incrementing rather than loading from the index array, eliminating indirect memory accesses.

This change:
1. Adds _are_blocks_contiguous() to detect contiguous block patterns
2. Precomputes the flag at BlockMask creation time and stores it as _blocks_are_contiguous (a pytree context attr, so it survives torch.compile flatten/unflatten)
3. On ROCm, _apply_kernel_options reads this flag to set the Triton kernel constexpr; on CUDA the default (False) is preserved

User-provided kernel_options override auto-detection via setdefault.

Verified end-to-end:
- Flag propagates correctly through torch.compile as tl.constexpr
- Numerical output is bitwise identical with and without the flag
- Auto-detect correctly returns True for causal/noop, False for checkerboard/sliding-window

## Benchmark
  MI350X, D=128, H=64, fwd only, `torch.compile`, single GPU.
  Baseline = `BLOCKS_ARE_CONTIGUOUS=False` (default). Auto-detect sets it to `True` for causal/noop masks.
  ### BF16 Causal
  | B | S | Baseline (us) | Auto-detect (us) | Speedup | Baseline (TFLOPS) | Auto-detect (TFLOPS) |
  |--:|--:|---:|---:|---:|---:|---:|
  | 1 | 4096 | 690 | 620 | 1.11x | 635 | 707 |
  | 4 | 4096 | 2650 | 2410 | 1.10x | 415 | 456 |
  | 8 | 4096 | 5310 | 4850 | 1.09x | 414 | 453 |
  | 1 | 8192 | 2150 | 1970 | 1.09x | 512 | 559 |
  | 4 | 8192 | 8290 | 8020 | 1.03x | 530 | 547 |
  ### FP16 Causal
  | B | S | Baseline (us) | Auto-detect (us) | Speedup | Baseline (TFLOPS) | Auto-detect (TFLOPS) |
  |--:|--:|---:|---:|---:|---:|---:|
  | 1 | 4096 | 1420 | 1370 | 1.04x | 309 | 320 |
  | 4 | 4096 | 5550 | 5340 | 1.04x | 198 | 206 |
  > Non-causal masks are unaffected (noop mask blocks are already trivially contiguous, no indirect indexing overhead).
  > CUDA behavior is unchanged (auto-detection is gated to ROCm).

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @azahed98