### PR TITLE
Friendler error messages

### DIFF
--- a/aten/src/ATen/BlasBackend.h
+++ b/aten/src/ATen/BlasBackend.h
@@ -39,6 +39,31 @@ enum class ScalingType : std::uint8_t {
   BlockWise128x128, // fp32 scales
 };
 
+inline std::string ScalingTypeToString(ScalingType scaling_type) {
+  switch (scaling_type) {
+    case ScalingType::TensorWise:
+      return "TensorWise";
+    case ScalingType::RowWise:
+      return "RowWise";
+    case ScalingType::BlockWise1x16:
+      return "BlockWise1x16";
+    case ScalingType::BlockWise1x32:
+      return "BlockWise1x32";
+    case ScalingType::BlockWise1x128:
+      return "BlockWise1x128";
+    case ScalingType::BlockWise128x128:
+      return "BlockWise128x128";
+    default:
+      TORCH_CHECK(false, "Unknown scaling type");
+  }
+}
+
+inline std::ostream& operator<<(
+    std::ostream& stream,
+    ScalingType scaling_type) {
+  return stream << ScalingTypeToString(scaling_type);
+}
+
 enum class SwizzleType : std::uint8_t { NO_SWIZZLE = 0, SWIZZLE_32_4_4 = 1 };
 
 } // namespace blas

--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -18,6 +18,7 @@
 #include <ATen/cuda/tunable/TunableGemm.h>
 #include <ATen/native/Resize.h>
 #include <c10/util/MaybeOwned.h>
+#include <c10/util/StringUtil.h>
 #include <ATen/native/GroupedMMUtils.h>
 #include <ATen/native/cuda/RowwiseScaledMM.h>
 #include <ATen/native/cuda/ScaledGroupMM.h>
@@ -91,6 +92,35 @@ bool _scaled_mm_allowed_device(bool sm90_only=false, bool sm100_only=false) {
     return dprops->major >= 9 || (dprops->major == 8 && dprops->minor == 9);
   }
 #endif
+}
+
+// Per-impl availability for grouped GEMM only. Non-grouped _scaled_mm checks
+// device support once up front, but grouped impls have different HW requirements
+// (rowwise: SM89+/ROCm, mxfp/fp4: SM100 + MSLK) so we filter per-entry.
+// Keyed on ScaledGemmImplementation so the compiler warns on unhandled cases.
+bool _is_grouped_impl_available(ScaledGemmImplementation impl) {
+  switch (impl) {
+    case ScaledGemmImplementation::ROWWISE_ROWWISE:
+#ifdef USE_ROCM
+#ifdef USE_MSLK
+      return at::detail::getCUDAHooks().isGPUArch({"gfx942", "gfx950"});
+#else
+      return false;
+#endif
+#else
+      return true;
+#endif
+    case ScaledGemmImplementation::MXFP8_MXFP8:
+    case ScaledGemmImplementation::MXFP4_MXFP4:
+    case ScaledGemmImplementation::NVFP4_NVFP4:
+#if defined(USE_MSLK) && !defined(USE_ROCM)
+      return _scaled_mm_allowed_device(/*sm90_only*/false, /*sm100_only*/true);
+#else
+      return false;
+#endif
+    default:
+      return false;
+  }
 }
 
 // 2d-2d and 2d-3d
@@ -520,11 +550,54 @@ namespace {
 
 using acceptance_fn = std::function<bool(c10::ScalarType, std::vector<ScalingType>&, ArrayRef<Tensor>&, c10::ScalarType, std::vector<ScalingType>&, ArrayRef<Tensor>&)>;
 
-std::array<std::tuple<std::string, acceptance_fn, ScaledGemmImplementation>, 4> scale_grouped_kernel_dispatch = {{
-  { "rowwise_rowwise", scaled_blas::check_rowwise_recipe, ScaledGemmImplementation::ROWWISE_ROWWISE},
-  { "mxfp8_mxfp8", scaled_blas::check_mxfp8_recipe, ScaledGemmImplementation::MXFP8_MXFP8},
-  { "mxfp4_mxfp4", scaled_blas::check_mxfp4_recipe, ScaledGemmImplementation::MXFP4_MXFP4},
-  { "nvfp4_nvfp4", scaled_blas::check_nvfp4_recipe, ScaledGemmImplementation::NVFP4_NVFP4}}};
+// Each entry carries a human-readable description of its expected inputs
+// for error reporting. The accept_fn is the source of truth for matching;
+// the description is only used when no implementation matched.
+struct dispatch_entry {
+  std::string_view name;
+  std::string_view mat_a_dtype;
+  std::string_view mat_b_dtype;
+  std::string_view scale_recipe_a;
+  std::string_view scale_recipe_b;
+  std::string_view scale_dtypes_a;
+  std::string_view scale_dtypes_b;
+  acceptance_fn accept_fn;
+  ScaledGemmImplementation scaled_gemm_impl;
+};
+
+const std::array<dispatch_entry, 4> scale_grouped_kernel_dispatch = {{
+  {"rowwise_rowwise",
+   "[Float8_e4m3fn, Float8_e4m3fnuz]",
+   "[Float8_e4m3fn, Float8_e4m3fnuz]",
+   "[RowWise]",
+   "[RowWise]",
+   "[Float]",
+   "[Float]",
+   scaled_blas::check_rowwise_recipe, ScaledGemmImplementation::ROWWISE_ROWWISE},
+  {"mxfp8_mxfp8",
+   "[Float8_e4m3fn]",
+   "[Float8_e4m3fn]",
+   "[BlockWise1x32]",
+   "[BlockWise1x32]",
+   "[Float8_e8m0fnu]",
+   "[Float8_e8m0fnu]",
+   scaled_blas::check_mxfp8_recipe, ScaledGemmImplementation::MXFP8_MXFP8},
+  {"mxfp4_mxfp4",
+   "[Float4_e2m1fn_x2]",
+   "[Float4_e2m1fn_x2]",
+   "[BlockWise1x32]",
+   "[BlockWise1x32]",
+   "[Float8_e8m0fnu]",
+   "[Float8_e8m0fnu]",
+   scaled_blas::check_mxfp4_recipe, ScaledGemmImplementation::MXFP4_MXFP4},
+  {"nvfp4_nvfp4",
+   "[Float4_e2m1fn_x2]",
+   "[Float4_e2m1fn_x2]",
+   "[BlockWise1x16, TensorWise]",
+   "[BlockWise1x16, TensorWise]",
+   "[Float8_e4m3fn, Float]",
+   "[Float8_e4m3fn, Float]",
+   scaled_blas::check_nvfp4_recipe, ScaledGemmImplementation::NVFP4_NVFP4}}};
 
 } // anonymous namespace
 
@@ -602,23 +675,74 @@ _scaled_grouped_mm_cuda_v2(
   // at this point we can start working out what we want to be doing
   // Try to do as few steps as possible.
   // NOTE: support is deliberately sparse, can explicitly enumerate all combinations allowed.
-  // Do this via a list of defined (name, acceptance, concrete_impl) tuples.
+  // Do this via the grouped dispatch table shared by matching and error reporting.
   ScaledGemmImplementation gemm_impl = ScaledGemmImplementation::NONE;
   for (const auto& fn_entry : scale_grouped_kernel_dispatch) {
-    const auto [name, accept_fn, scaled_gemm_impl] = fn_entry;
-    bool ok = accept_fn(mat_a.scalar_type(),
-                        scale_recipe_a_enum,
-                        scale_a,
-                        mat_b.scalar_type(),
-                        scale_recipe_b_enum,
-                        scale_b);
+    if (!_is_grouped_impl_available(fn_entry.scaled_gemm_impl)) {
+      continue;
+    }
+    bool ok = fn_entry.accept_fn(mat_a.scalar_type(),
+                                 scale_recipe_a_enum,
+                                 scale_a,
+                                 mat_b.scalar_type(),
+                                 scale_recipe_b_enum,
+                                 scale_b);
     if (ok) {
-      gemm_impl = scaled_gemm_impl;
+      gemm_impl = fn_entry.scaled_gemm_impl;
       break;
     }
   }
-  TORCH_CHECK_VALUE(gemm_impl != ScaledGemmImplementation::NONE,
-      "No gemm implementation was found");
+  if (gemm_impl == ScaledGemmImplementation::NONE) {
+    std::string available_impls = "Available grouped implementations for this build/runtime:\n";
+    bool any_available_impl = false;
+    for (const auto& entry : scale_grouped_kernel_dispatch) {
+      if (!_is_grouped_impl_available(entry.scaled_gemm_impl)) {
+        continue;
+      }
+      any_available_impl = true;
+      available_impls += c10::str(
+          "- ", entry.name,
+          ": mat_a.dtype=", entry.mat_a_dtype,
+          ", mat_b.dtype=", entry.mat_b_dtype,
+          ", scale_recipe_a=", entry.scale_recipe_a,
+          ", scale_recipe_b=", entry.scale_recipe_b,
+          ", scale_dtypes_a=", entry.scale_dtypes_a,
+          ", scale_dtypes_b=", entry.scale_dtypes_b,
+          "\n");
+    }
+    if (!any_available_impl) {
+      available_impls += "- none\n";
+    }
+
+    auto format_recipes = [](const std::vector<ScalingType>& recipes) {
+      std::string r = "[";
+      for (const auto i : c10::irange(recipes.size())) {
+        if (i > 0) r += ", ";
+        r += at::blas::ScalingTypeToString(recipes[i]);
+      }
+      return r + "]";
+    };
+    auto format_scale_dtypes = [](ArrayRef<Tensor> scales) {
+      std::string r = "[";
+      for (const auto i : c10::irange(scales.size())) {
+        if (i > 0) r += ", ";
+        r += c10::str(scales[i].scalar_type());
+      }
+      return r + "]";
+    };
+
+    TORCH_CHECK_VALUE(
+        false,
+        c10::str(
+            "No grouped GEMM implementation matched this invocation. Got:\n",
+            "- mat_a.dtype=", mat_a.scalar_type(), "\n",
+            "- mat_b.dtype=", mat_b.scalar_type(), "\n",
+            "- scale_recipe_a=", format_recipes(scale_recipe_a_enum), "\n",
+            "- scale_recipe_b=", format_recipes(scale_recipe_b_enum), "\n",
+            "- len(scale_a)=", scale_a.size(), ", scale dtypes A=", format_scale_dtypes(scale_a), "\n",
+            "- len(scale_b)=", scale_b.size(), ", scale dtypes B=", format_scale_dtypes(scale_b), "\n",
+            available_impls));
+  }
 
   switch (gemm_impl) {
     case ScaledGemmImplementation::ROWWISE_ROWWISE: {

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -593,6 +593,81 @@ def _2d_grouped_tensor_to_blocked_scaled(t, MN, G, offs, format='mxfp8'):
 
     return th, tq, t_blocked_scales, t_global_scales
 
+def _3d_grouped_tensor_to_blocked_scaled(t, G, format):
+    th_list = []
+    tq_list = []
+    t_scale_list = []
+    t_global_scale_list = []
+
+    for i in range(G):
+        if format == "mxfp8":
+            th, tq, t_scale = _convert_to_mxfp8_with_hp_ref(t[i])
+        elif format == "nvfp4":
+            th, tq, t_scale, t_global_scale = _convert_to_nvfp4_with_hp_ref(t[i])
+            t_global_scale_list.append(t_global_scale)
+        elif format == "mxfp4":
+            th, tq, t_scale = _convert_to_mxfp4_with_hp_ref(t[i])
+        else:
+            raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
+
+        if torch.version.cuda:
+            t_scale = to_blocked(t_scale)
+
+        th_list.append(th)
+        tq_list.append(tq)
+        t_scale_list.append(t_scale)
+
+    t_global_scales = None
+    if len(t_global_scale_list) > 0:
+        t_global_scales = torch.stack(t_global_scale_list)
+
+    return (
+        torch.stack(th_list, dim=0).contiguous(),
+        torch.stack(tq_list, dim=0).contiguous(),
+        torch.stack(t_scale_list, dim=0).contiguous(),
+        t_global_scales,
+    )
+
+
+def _2d_grouped_rows_to_blocked_scaled(t, K, G, offs, format):
+    th_list = []
+    tq_list = []
+    t_scale_list = []
+    t_global_scale_list = []
+
+    for i in range(G):
+        prev_group_end = 0 if i == 0 else offs[i - 1]
+        curr_group_end = offs[i]
+        group_size = curr_group_end - prev_group_end
+        if group_size > 0:
+            t_slice = t[prev_group_end:curr_group_end, :]
+            if format == "mxfp8":
+                th, tq, t_scale = _convert_to_mxfp8_with_hp_ref(t_slice)
+            elif format == "nvfp4":
+                th, tq, t_scale, t_global_scale = _convert_to_nvfp4_with_hp_ref(t_slice)
+                t_global_scale_list.append(t_global_scale)
+            elif format == "mxfp4":
+                th, tq, t_scale = _convert_to_mxfp4_with_hp_ref(t_slice)
+            else:
+                raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
+
+            if torch.version.cuda:
+                t_scale = to_blocked(t_scale)
+            th_list.append(th)
+            tq_list.append(tq)
+            t_scale_list.append(t_scale)
+
+    t_global_scales = None
+    if len(t_global_scale_list) > 0:
+        t_global_scales = torch.stack(t_global_scale_list)
+
+    tq = torch.cat(tq_list, dim=0).contiguous()
+    th = torch.cat(th_list, dim=0).contiguous()
+    t_scale = torch.cat(t_scale_list, dim=0).contiguous().reshape(-1, K // 32)
+
+    return th, tq, t_scale, t_global_scales
+
+
 def _build_scaled_grouped_mm_kwargs(scale_a, scale_b, offs, format):
     # Build some standard args that are wordy
     swizzle = SwizzleType.NO_SWIZZLE
@@ -822,7 +897,6 @@ class TestFP8Matmul(TestCase):
 
         # Simulate 2d-3d grouped gemm `out = input @ weight.t()`
         # 2D inputs with groups along M, 3D weights.
-        block_size = 32
         total_M = M  # Alias for clarity that M dim contains groups.
         X = torch.randn((total_M, K), dtype=torch.bfloat16, device="cuda") * 0.1
         W = torch.randn((G, N, K), dtype=torch.bfloat16, device="cuda") * 0.01
@@ -830,86 +904,10 @@ class TestFP8Matmul(TestCase):
             G, total_M, multiple_of=32, device="cuda"
         )
 
-        # For each constituent 2d subtensor in the 3d weights, quantize and convert scale to blocked format separately,
-        # as they each used for independent gemm in the grouped gemm.
-        def _3d_to_blocked_scaled(W, G, format):
-            wh_list = []
-            wq_list = []
-            w_scale_list = []
-            w_global_scale_list = []
-            for i in range(G):
-                if format == "mxfp8":
-                    wh, wq, w_scale = _convert_to_mxfp8_with_hp_ref(W[i])
-                elif format == "nvfp4":
-                    w_scale, wq = to_mxfp(W[i], format="mxfp8")
-                    wh, wq, w_scale, w_global_scale = _convert_to_nvfp4_with_hp_ref(W[i])
-                    w_global_scale_list.append(w_global_scale)
-                elif format == "mxfp4":
-                    wh, wq, w_scale = _convert_to_mxfp4_with_hp_ref(W[i])
-                else:
-                    raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
-
-                # Swizzle scaled
-                if torch.version.cuda:
-                    w_scale = to_blocked(w_scale)
-
-                wh_list.append(wh)
-                wq_list.append(wq)
-                w_scale_list.append(w_scale)
-            wh = torch.stack(wh_list, dim=0).contiguous()
-            wq = torch.stack(wq_list, dim=0).contiguous()
-            w_scale = torch.stack(w_scale_list, dim=0).contiguous()
-            # Global scales only exist for nvfp4
-            if len(w_global_scale_list) > 0:
-                w_global_scales = torch.stack(w_global_scale_list)
-            else:
-                w_global_scales = None
-            return wh, wq, w_scale, w_global_scales
-
-        wh, wq, w_blocked_scales, w_global_scales = _3d_to_blocked_scaled(W, G, format)
-
-        # For each group along `total_M` in the 2D tensor, quantize and convert scale to blocked format separately,
-        # as they each used for independent gemm in the grouped gemm.
-        def _2d_to_blocked_scaled(X, K, G, offs, format):
-            xh_list = []
-            xq_list = []
-            x_scale_list = []
-            x_global_scale_list = []
-            for i in range(G):
-                prev_group_end = 0 if i == 0 else input_group_end_offsets[i - 1]
-                curr_group_end = input_group_end_offsets[i]
-                group_size = curr_group_end - prev_group_end
-                if group_size > 0:
-                    x_slice = X[prev_group_end:curr_group_end, :]
-                    if format == "mxfp8":
-                        xh, xq, x_scale = _convert_to_mxfp8_with_hp_ref(x_slice)
-                    elif format == "nvfp4":
-                        xh, xq, x_scale, x_global_scale = _convert_to_nvfp4_with_hp_ref(x_slice)
-                        x_global_scale_list.append(x_global_scale)
-                    elif format == "mxfp4":
-                        xh, xq, x_scale = _convert_to_mxfp4_with_hp_ref(x_slice)
-                    else:
-                        raise ValueError(f'format must be mxfp8|nvfp4|mxfp4, got "{format}"')
-
-                    if torch.version.cuda:
-                        x_scale = to_blocked(x_scale)
-                    xh_list.append(xh)
-                    xq_list.append(xq)
-                    x_scale_list.append(x_scale)
-            xh = torch.cat(xh_list, dim=0).contiguous()
-            xq = torch.cat(xq_list, dim=0).contiguous()
-            x_scale = torch.cat(x_scale_list, dim=0).contiguous()
-            x_scale = x_scale.reshape(-1, K // block_size)
-            xq = xq.view(-1, xq.shape[-1])
-            xh = xh.view(-1, xh.shape[-1])
-
-            x_global_scales = None
-            if len(x_global_scale_list) > 0:
-                x_global_scales = torch.stack(x_global_scale_list)
-
-            return xh, xq, x_scale, x_global_scales
-
-        xh, xq, x_blocked_scales, x_global_scales = _2d_to_blocked_scaled(X, K, G, input_group_end_offsets, format)
+        wh, wq, w_blocked_scales, w_global_scales = _3d_grouped_tensor_to_blocked_scaled(W, G, format)
+        xh, xq, x_blocked_scales, x_global_scales = _2d_grouped_rows_to_blocked_scaled(
+            X, K, G, input_group_end_offsets, format
+        )
 
         if format in ["mxfp8", "mxfp4"]:
             kwargs = _build_scaled_grouped_mm_kwargs(
@@ -953,6 +951,65 @@ class TestFP8Matmul(TestCase):
 
         # Assert outputs are close.
         torch.testing.assert_close(y_lp, y_bf16, atol=8.0e-2, rtol=8.0e-2)
+
+    def _make_mxfp8_grouped_mm_2d_3d_inputs(self, G=4, M=256, N=512, K=4096):
+        X = torch.randn((M, K), dtype=torch.bfloat16, device="cuda") * 0.1
+        W = torch.randn((G, N, K), dtype=torch.bfloat16, device="cuda") * 0.01
+        offs = generate_jagged_offs(G, M, multiple_of=32, device="cuda")
+
+        _, mat_b, scale_b, _ = _3d_grouped_tensor_to_blocked_scaled(W, G, "mxfp8")
+        _, mat_a, scale_a, _ = _2d_grouped_rows_to_blocked_scaled(X, K, G, offs, "mxfp8")
+        kwargs = _build_scaled_grouped_mm_kwargs(scale_a, scale_b, offs, "mxfp8")
+        kwargs["mat_a"] = mat_a
+        kwargs["mat_b"] = mat_b.transpose(-2, -1)
+        kwargs["output_dtype"] = kwargs.pop("out_dtype")
+        kwargs.pop("wrap_v2")
+        return kwargs, X
+
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MXFP8_GROUPED_GEMM, mxfp8_grouped_mm_skip_msg)
+    def test_scaled_grouped_mm_invalid_inputs_raise_descriptive_errors(self, device):
+        kwargs, x = self._make_mxfp8_grouped_mm_2d_3d_inputs()
+
+        with self.assertRaisesRegex(ValueError, "pre-quantized low-precision inputs"):
+            scaled_grouped_mm(**{**kwargs, "mat_a": x})
+
+        with self.assertRaisesRegex(
+            ValueError, "scale_a and scale_recipe_a must describe the same number"
+        ):
+            scaled_grouped_mm(
+                **{
+                    **kwargs,
+                    "scale_recipe_a": [ScalingType.BlockWise1x32, ScalingType.TensorWise],
+                }
+            )
+
+        with self.assertRaisesRegex(
+            ValueError, "scale_b and scale_recipe_b must describe the same number"
+        ):
+            scaled_grouped_mm(
+                **{
+                    **kwargs,
+                    "scale_recipe_b": [ScalingType.BlockWise1x32, ScalingType.TensorWise],
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, "offs must contain one group end offset"):
+            scaled_grouped_mm(**{**kwargs, "offs": kwargs["offs"][:-1]})
+
+        with self.assertRaisesRegex(
+            ValueError, "No grouped GEMM implementation matched this invocation"
+        ) as ctx:
+            scaled_grouped_mm(
+                **{
+                    **kwargs,
+                    "scale_recipe_a": [ScalingType.RowWise],
+                }
+            )
+        self.assertIn("- scale_recipe_a=[RowWise]", str(ctx.exception))
+        self.assertIn(
+            "Available grouped implementations for this build/runtime:",
+            str(ctx.exception),
+        )
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6919,6 +6919,51 @@ def scaled_grouped_mm(
     swizzle_a = expand_single_value(swizzle_a)
     swizzle_b = expand_single_value(swizzle_b)
 
+    low_precision_dtypes = {
+        torch.float8_e4m3fn,
+        torch.float8_e5m2,
+        torch.float4_e2m1fn_x2,
+        getattr(torch, "float8_e4m3fnuz", None),
+        getattr(torch, "float8_e5m2fnuz", None),
+    }
+    low_precision_dtypes.discard(None)
+
+    if (
+        mat_a.dtype not in low_precision_dtypes
+        or mat_b.dtype not in low_precision_dtypes
+    ):
+        raise ValueError(
+            "scaled_grouped_mm expects pre-quantized low-precision inputs for "
+            f"mat_a and mat_b, but got mat_a.dtype={mat_a.dtype} and "
+            f"mat_b.dtype={mat_b.dtype}. If your inputs are bf16/fp16/fp32, "
+            "use grouped_mm instead."
+        )
+
+    if len(scale_a) != len(scale_recipe_a):
+        raise ValueError(
+            "scale_a and scale_recipe_a must describe the same number of scale "
+            f"tensors, but got len(scale_a)={len(scale_a)} and "
+            f"len(scale_recipe_a)={len(scale_recipe_a)}."
+        )
+    if len(scale_b) != len(scale_recipe_b):
+        raise ValueError(
+            "scale_b and scale_recipe_b must describe the same number of scale "
+            f"tensors, but got len(scale_b)={len(scale_b)} and "
+            f"len(scale_recipe_b)={len(scale_recipe_b)}."
+        )
+
+    if (
+        offs is not None
+        and mat_a.dim() == 2
+        and mat_b.dim() == 3
+        and offs.numel() != mat_b.shape[0]
+    ):
+        raise ValueError(
+            "For 2D x 3D grouped GEMM, offs must contain one group end offset "
+            f"per matrix in mat_b, but got len(offs)={offs.numel()} and "
+            f"mat_b.shape[0]={mat_b.shape[0]}."
+        )
+
     # native_functions has restrictions on what can be defined
     # & passed through - std::optional<ArrayRef<Tensor>> for instance
     # *cannot* be passed, but an empty vector (list) can.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180722


More helpful error messages:

```Py
#!/usr/bin/env python3

import argparse
import traceback
from collections.abc import Callable

import torch
from torch.nn.functional import ScalingType, scaled_grouped_mm


def make_low_precision(shape: tuple[int, ...], *, transpose_last_two: bool = False) -> torch.Tensor:
    tensor = torch.randn(*shape, device="cuda", dtype=torch.bfloat16).mul_(0.1)
    tensor = tensor.to(torch.float8_e4m3fn)
    if transpose_last_two:
        return tensor.transpose(-2, -1)
    return tensor.contiguous()


def run_case(name: str, fn: Callable[[], object]) -> None:
    print(f"\n=== {name} ===")
    try:
        result = fn()
    except Exception as exc:
        print(f"{type(exc).__name__}: {exc}")
        if args.traceback:
            print("\n--- traceback ---")
            print("".join(traceback.format_exception(exc)).rstrip())
    else:
        if isinstance(result, torch.Tensor):
            print(
                "success:",
                {
                    "shape": tuple(result.shape),
                    "dtype": str(result.dtype),
                    "device": str(result.device),
                },
            )
        else:
            print(f"success: {result}")


def case_non_low_precision_inputs() -> None:
    mat_a = torch.randn(32, 64, device="cuda", dtype=torch.bfloat16)
    mat_b = torch.randn(2, 48, 64, device="cuda", dtype=torch.bfloat16).transpose(-2, -1)
    offs = torch.tensor([16, 32], device="cuda", dtype=torch.int32)
    scale = torch.ones(1, device="cuda", dtype=torch.float32)
    scaled_grouped_mm(
        mat_a=mat_a,
        mat_b=mat_b,
        scale_a=scale,
        scale_recipe_a=ScalingType.BlockWise1x32,
        scale_b=scale,
        scale_recipe_b=ScalingType.BlockWise1x32,
        offs=offs,
    )


def case_scale_a_length_mismatch() -> None:
    mat_a = make_low_precision((32, 64))
    mat_b = make_low_precision((2, 48, 64), transpose_last_two=True)
    offs = torch.tensor([16, 32], device="cuda", dtype=torch.int32)
    scale = torch.ones(1, device="cuda", dtype=torch.float32)
    scaled_grouped_mm(
        mat_a=mat_a,
        mat_b=mat_b,
        scale_a=[scale],
        scale_recipe_a=[ScalingType.BlockWise1x32, ScalingType.TensorWise],
        scale_b=[scale],
        scale_recipe_b=[ScalingType.BlockWise1x32],
        offs=offs,
    )


def case_scale_b_length_mismatch() -> None:
    mat_a = make_low_precision((32, 64))
    mat_b = make_low_precision((2, 48, 64), transpose_last_two=True)
    offs = torch.tensor([16, 32], device="cuda", dtype=torch.int32)
    scale = torch.ones(1, device="cuda", dtype=torch.float32)
    scaled_grouped_mm(
        mat_a=mat_a,
        mat_b=mat_b,
        scale_a=[scale],
        scale_recipe_a=[ScalingType.BlockWise1x32],
        scale_b=[scale],
        scale_recipe_b=[ScalingType.BlockWise1x32, ScalingType.TensorWise],
        offs=offs,
    )


def case_offs_length_mismatch() -> None:
    mat_a = make_low_precision((32, 64))
    mat_b = make_low_precision((2, 48, 64), transpose_last_two=True)
    offs = torch.tensor([32], device="cuda", dtype=torch.int32)
    scale = torch.ones(1, device="cuda", dtype=torch.float32)
    scaled_grouped_mm(
        mat_a=mat_a,
        mat_b=mat_b,
        scale_a=[scale],
        scale_recipe_a=[ScalingType.BlockWise1x32],
        scale_b=[scale],
        scale_recipe_b=[ScalingType.BlockWise1x32],
        offs=offs,
    )


def case_no_backend_match() -> None:
    mat_a = make_low_precision((32, 64))
    mat_b = make_low_precision((2, 48, 64), transpose_last_two=True)
    offs = torch.tensor([16, 32], device="cuda", dtype=torch.int32)
    scale = torch.ones(1, device="cuda", dtype=torch.float32)
    scaled_grouped_mm(
        mat_a=mat_a,
        mat_b=mat_b,
        scale_a=[scale],
        scale_recipe_a=[ScalingType.RowWise],
        scale_b=[scale],
        scale_recipe_b=[ScalingType.BlockWise1x32],
        offs=offs,
    )


def case_rowwise_success() -> torch.Tensor:
    group_rows = 16
    groups = 2
    mat_a = make_low_precision((group_rows * groups, 64))
    mat_b = make_low_precision((groups, 48, 64), transpose_last_two=True)
    offs = torch.tensor([group_rows, group_rows * groups], device="cuda", dtype=torch.int32)
    scale_a = torch.ones(group_rows * groups, device="cuda", dtype=torch.float32)
    scale_b = torch.ones(groups, 48, device="cuda", dtype=torch.float32)
    return scaled_grouped_mm(
        mat_a=mat_a,
        mat_b=mat_b,
        scale_a=[scale_a],
        scale_recipe_a=[ScalingType.RowWise],
        scale_b=[scale_b],
        scale_recipe_b=[ScalingType.RowWise],
        offs=offs,
    )


CASES: dict[str, Callable[[], object]] = {
    "non_low_precision_inputs": case_non_low_precision_inputs,
    "scale_a_length_mismatch": case_scale_a_length_mismatch,
    "scale_b_length_mismatch": case_scale_b_length_mismatch,
    "offs_length_mismatch": case_offs_length_mismatch,
    "no_backend_match": case_no_backend_match,
    "rowwise_success": case_rowwise_success,
}


parser = argparse.ArgumentParser(
    description="Show the new scaled_grouped_mm error handling from the staged changes."
)
parser.add_argument(
    "cases",
    nargs="*",
    default=["non_low_precision_inputs", "scale_a_length_mismatch", "scale_b_length_mismatch", "offs_length_mismatch", "no_backend_match"],
    help=f"Cases to run. Available: {', '.join(CASES)}",
)
parser.add_argument("--traceback", action="store_true", help="Print full tracebacks")
args = parser.parse_args()

if not torch.cuda.is_available():
    raise SystemExit("CUDA is required for this demo script.")

print("torch:", torch.__version__)
print("torch file:", torch.__file__)
print("cuda capability:", torch.cuda.get_device_capability())
print("requested cases:", args.cases)

for case_name in args.cases:
    try:
        case_fn = CASES[case_name]
    except KeyError as exc:
        raise SystemExit(f"Unknown case '{case_name}'. Available: {', '.join(CASES)}") from exc
    run_case(case_name, case_fn)



```


```Shell
 python agent_space/show_scaled_grouped_mm_error_handling.py
torch: 2.13.0a0+git05550c3
torch file: /home/dev/meta/pytorch/torch/__init__.py
cuda capability: (10, 0)
requested cases: ['non_low_precision_inputs', 'scale_a_length_mismatch', 'scale_b_length_mismatch', 'offs_length_mismatch', 'no_backend_match']

=== non_low_precision_inputs ===
ValueError: scaled_grouped_mm expects pre-quantized low-precision inputs for mat_a and mat_b, but got mat_a.dtype=torch.bfloat16 and mat_b.dtype=torch.bfloat16. If your inputs are bf16/fp16/fp32, use grouped_mm instead.

=== scale_a_length_mismatch ===
ValueError: scale_a and scale_recipe_a must describe the same number of scale tensors, but got len(scale_a)=1 and len(scale_recipe_a)=2.

=== scale_b_length_mismatch ===
ValueError: scale_b and scale_recipe_b must describe the same number of scale tensors, but got len(scale_b)=1 and len(scale_recipe_b)=2.

=== offs_length_mismatch ===
ValueError: For 2D x 3D grouped GEMM, offs must contain one group end offset per matrix in mat_b, but got len(offs)=1 and mat_b.shape[0]=2.

=== no_backend_match ===
ValueError: No grouped GEMM implementation matched this invocation. Got:
- mat_a.dtype=Float8_e4m3fn
- mat_b.dtype=Float8_e4m3fn
- scale_recipe_a=[RowWise]
- scale_recipe_b=[BlockWise1x32]
- len(scale_a)=1, scale dtypes A=[Float]
- len(scale_b)=1, scale dtypes B=[Float]
Available grouped implementations for this build/runtime:
- rowwise_rowwise: mat_a.dtype=[Float8_e4m3fn, Float8_e4m3fnuz], mat_b.dtype=[Float8_e4m3fn, Float8_e4m3fnuz], scale_recipe_a=[RowWise], scale_recipe_b=[RowWise], scale_dtypes_a=[Float], scale_dtypes_b=[Float]
- mxfp8_mxfp8: mat_a.dtype=[Float8_e4m3fn], mat_b.dtype=[Float8_e4m3fn], scale_recipe_a=[BlockWise1x32], scale_recipe_b=[BlockWise1x32], scale_dtypes_a=[Float8_e8m0fnu], scale_dtypes_b=[Float8_e8m0fnu]
- mxfp4_mxfp4: mat_a.dtype=[Float4_e2m1fn_x2], mat_b.dtype=[Float4_e2m1fn_x2], scale_recipe_a=[BlockWise1x32], scale_recipe_b=[BlockWise1x32], scale_dtypes_a=[Float8_e8m0fnu], scale_dtypes_b=[Float8_e8m0fnu]
- nvfp4_nvfp4: mat_a.dtype=[Float4_e2m1fn_x2], mat_b.dtype=[Float4_e2m1fn_x2], scale_recipe_a=[BlockWise1x16, TensorWise], scale_recipe_b=[BlockWise1x16, TensorWise], scale_dtypes_a=[Float8_e4m3fn, Float], scale_dtypes_b=[Float8_e4m3fn, Float]
```