### PR TITLE
[2/N] Use const_data_ptr

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -2586,7 +2586,7 @@ static Tensor& masked_select_out_impl_cpu(
   auto mask_long =
       at::empty(shape, self.options().dtype(at::kLong)).copy_(*_mask);
   auto mask_prefix_sum = at::empty(shape, self.options().dtype(at::kLong));
-  auto mask_long_data = mask_long.data_ptr<int64_t>();
+  auto mask_long_data = mask_long.const_data_ptr<int64_t>();
   auto mask_prefix_sum_data = mask_prefix_sum.data_ptr<int64_t>();
   // TODO: Here can only use std::partial_sum for C++14,
   // use std::exclusive_scan when PyTorch upgrades to C++17, which have better

--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -124,7 +124,7 @@ struct IsUnique {};
 
 template <typename scalar_t>
 struct IsUnique<scalar_t, false> {
-  bool operator() (scalar_t* data_ptr, int64_t i) {
+  bool operator() (const scalar_t* data_ptr, int64_t i) {
     if (i == 0) { return true; }
     return c10::load(&data_ptr[i]) != c10::load(&data_ptr[i - 1]);
   }
@@ -132,7 +132,7 @@ struct IsUnique<scalar_t, false> {
 
 template <typename scalar_t>
 struct IsUnique<scalar_t, true> {
-  bool operator() (scalar_t* data_ptr, int64_t i) {
+  bool operator() (const scalar_t* data_ptr, int64_t i) {
     if (i == 0) { return true; }
     return (c10::load(&data_ptr[i]) != c10::load(&data_ptr[i - 1]))
         && !(_isnan(data_ptr[i]) && _isnan(data_ptr[i - 1]));
@@ -184,8 +184,8 @@ std::tuple<Tensor, Tensor, Tensor> unique_cpu_sorted_template(
 
   auto [input_sorted, indices] = input_flattened.sort();
 
-  scalar_t* input_sorted_data = input_sorted.data_ptr<scalar_t>();
-  int64_t* indices_data = indices.data_ptr<int64_t>();
+  const scalar_t* input_sorted_data = input_sorted.const_data_ptr<scalar_t>();
+  const int64_t* indices_data = indices.const_data_ptr<int64_t>();
 
   int num_threads = at::get_num_threads();
   std::vector<int64_t> unique_count_thread(num_threads, 0);

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -233,7 +233,7 @@ Tensor nested_from_padded_generic(
   std::vector<at::Tensor> all_sizes = sizes.unbind();
   for (const auto& size : all_sizes) {
     IntArrayRef sizes_i(
-        size.data_ptr<int64_t>(), size.data_ptr<int64_t>() + size.numel());
+        size.const_data_ptr<int64_t>(), size.const_data_ptr<int64_t>() + size.numel());
     at::Tensor mask_i = padded_transformed.new_full(
         sizes_i, true, kBool, std::nullopt, std::nullopt, std::nullopt);
     masks.push_back(pad_tensor_to_shape(mask_i, target_size_arr));
@@ -273,7 +273,7 @@ Tensor NestedTensor_to_padded_tensor_generic(
 
   const auto sizes_num_rows = sizes.sizes()[0];
   const auto sizes_num_columns = sizes.sizes()[1];
-  const auto sizes_data_start = sizes.data_ptr<int64_t>();
+  const auto sizes_data_start = sizes.const_data_ptr<int64_t>();
   const auto sizes_data_end = sizes_data_start + sizes.numel();
   std::vector<int64_t> split_sizes;
   split_sizes.reserve(sizes_num_rows);
@@ -993,8 +993,8 @@ static bool can_cat_nested_sizes(const Tensor& nested_sizes1, const Tensor& nest
     return false;
   }
 
-  auto nested_sizes1_ptr = nested_sizes1.data_ptr<int64_t>();
-  auto nested_sizes2_ptr = nested_sizes2.data_ptr<int64_t>();
+  auto nested_sizes1_ptr = nested_sizes1.const_data_ptr<int64_t>();
+  auto nested_sizes2_ptr = nested_sizes2.const_data_ptr<int64_t>();
   const auto num_components = nested_sizes1.size(0);
   const auto num_dims = nested_sizes1.size(1);
   for (auto c : c10::irange(num_components)) {

--- a/aten/src/ATen/native/nested/NestedTensorMatmul.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMatmul.cpp
@@ -79,15 +79,15 @@ static Tensor matmul_with_bmm_nested(const Tensor& self, const Tensor& mat2) {
   // metadata for self
   std::vector<IntArrayRef> self_sizes = NestedTensor_get_sizes(self_ptr);
   std::vector<IntArrayRef> self_strides = NestedTensor_get_strides(self_ptr);
-  int64_t* self_offsets_ptr =
-      self_ptr->get_storage_offsets().data_ptr<int64_t>();
+  const int64_t* self_offsets_ptr =
+      self_ptr->get_storage_offsets().const_data_ptr<int64_t>();
   auto opt = self_ptr->get_nested_sizes().options();
 
   // metadata for mat2
   std::vector<IntArrayRef> mat2_sizes = NestedTensor_get_sizes(mat2_ptr);
   std::vector<IntArrayRef> mat2_strides = NestedTensor_get_strides(mat2_ptr);
-  int64_t* mat2_offsets_ptr =
-      mat2_ptr->get_storage_offsets().data_ptr<int64_t>();
+  const int64_t* mat2_offsets_ptr =
+      mat2_ptr->get_storage_offsets().const_data_ptr<int64_t>();
   auto opt2 = mat2_ptr->get_nested_sizes().options();
 
   int64_t N = static_cast<int64_t>(self_sizes.size());

--- a/aten/src/ATen/native/nested/NestedTensorUtils.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorUtils.cpp
@@ -37,7 +37,7 @@ std::vector<int64_t> NestedTensor_get_max_size_from_size_tensor(
   if (sizes.dim() == 0) {
     return {};
   }
-  const auto sizes_ptr = sizes.data_ptr<int64_t>();
+  const auto sizes_ptr = sizes.const_data_ptr<int64_t>();
   const auto sizes_size_0 = sizes.sizes()[0];
   const auto sizes_size_1 = sizes.sizes()[1];
   TORCH_INTERNAL_ASSERT(sizes_size_1 > 0);
@@ -88,7 +88,7 @@ std::vector<Tensor> chunk_nested_tensor(const Tensor& self, int64_t chunks, int6
   const auto& sizes = self_impl->get_nested_sizes();
   const auto& strides = self_impl->get_nested_strides();
   const auto offsets = self_impl->get_storage_offsets();
-  int64_t *offsets_ptr = offsets.data_ptr<int64_t>();
+  const int64_t *offsets_ptr = offsets.const_data_ptr<int64_t>();
   // Account for the implicit batch dim
   --dim;
   int64_t tensor_dim = sizes.size(1);
@@ -143,7 +143,7 @@ std::vector<Tensor> split_with_sizes_nested(
   const auto& sizes = self_impl->get_nested_sizes();
   const auto& strides = self_impl->get_nested_strides();
   const auto offsets = self_impl->get_storage_offsets();
-  int64_t *offsets_ptr = offsets.data_ptr<int64_t>();
+  const int64_t *offsets_ptr = offsets.const_data_ptr<int64_t>();
   // Account for the implicit batch dim
   --dim;
   int64_t tensor_dim = sizes.size(1);


### PR DESCRIPTION
This PR converts `.data_ptr` to `.const_data_ptr` to reduce costs.