### PR TITLE
Use PyModule_AddType for Dtype and Size

### DIFF
--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -192,12 +192,7 @@ void THPDtype_init(PyObject* module) {
   }
   THPDtypeType.tp_dict = dict.release();
 
-  if (PyType_Ready(&THPDtypeType) < 0) {
-    throw python_error();
-  }
-  Py_INCREF(&THPDtypeType);
-  if (PyModule_AddObject(
-          module, "dtype", reinterpret_cast<PyObject*>(&THPDtypeType)) != 0) {
+  if (PyModule_AddType(module, &THPDtypeType) < 0) {
     throw python_error();
   }
 }

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -205,12 +205,7 @@ void THPDtype_init(PyObject* module) {
   }
   THPDtypeType.tp_dict = dict.release();
 
-  if (PyType_Ready(&THPDtypeType) < 0) {
-    throw python_error();
-  }
-  Py_INCREF(&THPDtypeType);
-  if (PyModule_AddObject(
-          module, "dtype", reinterpret_cast<PyObject*>(&THPDtypeType)) != 0) {
+  if (PyModule_AddType(module, &THPDtypeType) < 0) {
     throw python_error();
   }
 }

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -338,12 +338,7 @@ PyTypeObject THPSizeType = {
 };
 
 void THPSize_init(PyObject* module) {
-  if (PyType_Ready(&THPSizeType) < 0) {
-    throw python_error();
-  }
-  Py_INCREF(&THPSizeType);
-  if (PyModule_AddObject(
-          module, "Size", reinterpret_cast<PyObject*>(&THPSizeType)) < 0) {
+  if (PyModule_AddType(module, &THPSizeType) < 0) {
     throw python_error();
   }
 }


### PR DESCRIPTION
Bisect subset of #179542 to isolate the `import torch` segfault. Dtype pre-populates `tp_dict` with `__module__` before `PyType_Ready`; Size inherits from `PyTuple_Type`. eval_frame.c split to companion branch.