### PR TITLE
[Inductor] Fix flaky epilogue fusion tests by adding missing tearDownClass

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -3577,6 +3577,11 @@ class TestPrologueFusion(TestCase):
             )
         )
 
+    @classmethod
+    def tearDownClass(cls):
+        cls._stack.close()
+        super().tearDownClass()
+
     def check_code(self, code_str, num_kernels, num_allocs, num_deallocs):
         FileCheck().check(get_func_call()).check_count(
             get_kernel_launch(),
@@ -4069,6 +4074,11 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                 }
             )
         )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._stack.close()
+        super().tearDownClass()
 
     @contextlib.contextmanager
     def get_common_patches(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180736

TestPrologueFusion and TestEpilogueFusionStaticAnalysis both use
ExitStack in setUpClass to apply config.patch(), but neither defined
tearDownClass to close the stack. When TestPrologueFusion runs before
TestEpilogueFusionStaticAnalysis in the same process, config values
like max_autotune_gemm_backends="TRITON" leak through, removing the
aten kernel choice from autotuning and causing test failures.

Fixes #179693

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo