### PR TITLE
[autograd] lazily start worker threads in the autograd engine

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_autograd.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_autograd.py
@@ -34,8 +34,11 @@ class TestAutograd(TestCase):
                 thread_name = file.read().strip()
             all_thread_names.add(thread_name)
 
-        for i in range(torch.accelerator.device_count()):
-            self.assertIn(f"pt_autograd_{i}", all_thread_names)
+        # Device threads are initialized lazily: only the device used in
+        # backward should have a thread, not all registered devices.
+        self.assertIn("pt_autograd_0", all_thread_names)
+        for i in range(1, torch.accelerator.device_count()):
+            self.assertNotIn(f"pt_autograd_{i}", all_thread_names)
 
     def test_autograd_backward(self):
         """Test backward propagation on openreg device"""

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6,6 +6,7 @@ import contextlib
 import functools
 import gc
 import io
+import json
 import math
 import operator
 import os
@@ -16580,6 +16581,163 @@ instantiate_device_type_tests(
 
 instantiate_parametrized_tests(TestAutograd)
 instantiate_parametrized_tests(TestNestedCheckpoint)
+
+
+class TestLazyAutogradEngineInit(TestCase):
+    """Tests verifying that autograd device threads are initialized lazily."""
+
+    def test_no_device_threads_before_backward(self):
+        """Importing torch must not start any device threads."""
+        code = """import torch
+"""
+        s = TestCase.runWithPytorchAPIUsageStderr(code)
+        self.assertNotRegex(s, r"torch\.autograd\.thread_start")
+
+    def test_cpu_backward_creates_no_device_threads(self):
+        """CPU-only backward must not start any device threads."""
+        code = """import torch
+x = torch.randn(4, 4, requires_grad=True)
+(x @ x.T).sum().backward()
+"""
+        s = TestCase.runWithPytorchAPIUsageStderr(code)
+        self.assertNotRegex(s, r"torch\.autograd\.thread_start")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    def test_gpu_backward_starts_only_used_device_thread(self):
+        """Backward on cuda:0 starts thread 0 but no other device threads."""
+        code = """import torch
+x = torch.randn(4, 4, device="cuda:0", requires_grad=True)
+(x @ x.T).sum().backward()
+"""
+        s = TestCase.runWithPytorchAPIUsageStderr(code)
+        self.assertRegex(s, r"torch\.autograd\.thread_start\.0\b")
+        for i in range(1, torch.cuda.device_count()):
+            self.assertNotRegex(s, rf"torch\.autograd\.thread_start\.{i}\b")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2 if TEST_CUDA else True,
+        "requires 2+ GPUs",
+    )
+    def test_gpu_backward_on_non_zero_device(self):
+        """Backward on cuda:1 starts thread 1 only, not thread 0 or others."""
+        code = """import torch
+x = torch.randn(4, 4, device="cuda:1", requires_grad=True)
+(x @ x.T).sum().backward()
+"""
+        s = TestCase.runWithPytorchAPIUsageStderr(code)
+        self.assertRegex(s, r"torch\.autograd\.thread_start\.1\b")
+        self.assertNotRegex(s, r"torch\.autograd\.thread_start\.0\b")
+        for i in range(2, torch.cuda.device_count()):
+            self.assertNotRegex(s, rf"torch\.autograd\.thread_start\.{i}\b")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(IS_WINDOWS, "requires /proc filesystem")
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2 if TEST_CUDA else True,
+        "requires 2+ GPUs",
+    )
+    def test_multi_device_backward_starts_both_threads(self):
+        """Backward on cuda:0 then cuda:1 starts both device threads."""
+        code = """import torch
+import os
+import json
+
+x = torch.randn(4, 4, device="cuda:0", requires_grad=True)
+(x @ x.T).sum().backward()
+y = torch.randn(4, 4, device="cuda:1", requires_grad=True)
+(y @ y.T).sum().backward()
+
+pid = os.getpid()
+task_path = f"/proc/{pid}/task"
+thread_names = set()
+for tid in os.listdir(task_path):
+    try:
+        with open(f"{task_path}/{tid}/comm") as f:
+            thread_names.add(f.read().strip())
+    except FileNotFoundError:
+        pass
+print(json.dumps(sorted(thread_names)))
+"""
+        stdout, _ = TestCase.run_process_no_exception(code)
+        thread_names = set(json.loads(stdout.decode()))
+        self.assertIn("pt_autograd_0", thread_names)
+        self.assertIn("pt_autograd_1", thread_names)
+        for i in range(2, torch.cuda.device_count()):
+            self.assertNotIn(f"pt_autograd_{i}", thread_names)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(IS_WINDOWS, "requires /proc filesystem")
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2 if TEST_CUDA else True,
+        "requires 2+ GPUs",
+    )
+    def test_concurrent_backward_starts_both_threads(self):
+        """Concurrent backward on cuda:0 and cuda:1 initializes both threads safely."""
+        code = """import torch
+import os
+import json
+import threading
+
+barrier = threading.Barrier(2)
+
+def backward_on_device(device):
+    x = torch.randn(4, 4, device=device, requires_grad=True)
+    loss = (x @ x.T).sum()
+    barrier.wait()
+    loss.backward()
+
+t0 = threading.Thread(target=backward_on_device, args=("cuda:0",))
+t1 = threading.Thread(target=backward_on_device, args=("cuda:1",))
+t0.start()
+t1.start()
+t0.join()
+t1.join()
+
+pid = os.getpid()
+task_path = f"/proc/{pid}/task"
+thread_names = set()
+for tid in os.listdir(task_path):
+    try:
+        with open(f"{task_path}/{tid}/comm") as f:
+            thread_names.add(f.read().strip())
+    except FileNotFoundError:
+        pass
+print(json.dumps(sorted(thread_names)))
+"""
+        stdout, _ = TestCase.run_process_no_exception(code)
+        thread_names = set(json.loads(stdout.decode()))
+        self.assertIn("pt_autograd_0", thread_names)
+        self.assertIn("pt_autograd_1", thread_names)
+        for i in range(2, torch.cuda.device_count()):
+            self.assertNotIn(f"pt_autograd_{i}", thread_names)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(IS_WINDOWS, "fork not supported on Windows")
+    def test_fork_after_backward_prevents_new_threads(self):
+        """After backward + fork, child cannot start new device threads."""
+        code = """import torch
+import os
+import sys
+
+x = torch.randn(4, 4, device="cuda:0", requires_grad=True)
+(x @ x.T).sum().backward()
+
+pid = os.fork()
+if pid == 0:
+    try:
+        y = torch.randn(4, 4, device="cuda:0", requires_grad=True)
+        (y @ y.T).sum().backward()
+    except RuntimeError as e:
+        if "fork" in str(e).lower():
+            print("FORK_ERROR_CAUGHT", file=sys.stderr)
+    os._exit(0)
+else:
+    os.waitpid(pid, 0)
+"""
+        s = TestCase.runWithPytorchAPIUsageStderr(code)
+        self.assertIn("FORK_ERROR_CAUGHT", s)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -18294,9 +18294,6 @@ instantiate_device_type_tests(
     TestAutogradStreamSynchronization, globals(), except_for=None
 )
 
-instantiate_parametrized_tests(TestAutograd)
-instantiate_parametrized_tests(TestNestedCheckpoint)
-
 
 class TestLazyAutogradEngineInit(TestCase):
     """Tests verifying that autograd device threads are initialized lazily."""
@@ -18374,8 +18371,11 @@ for tid in os.listdir(task_path):
         pass
 print(json.dumps(sorted(thread_names)))
 """
-        stdout, _ = TestCase.run_process_no_exception(code)
-        thread_names = set(json.loads(stdout.decode()))
+        stdout, stderr = TestCase.run_process_no_exception(code)
+        try:
+            thread_names = set(json.loads(stdout.decode()))
+        except json.JSONDecodeError:
+            self.fail(f"Subprocess produced invalid output.\nstdout: {stdout.decode()}\nstderr: {stderr.decode()}")
         self.assertIn("pt_autograd_0", thread_names)
         self.assertIn("pt_autograd_1", thread_names)
         for i in range(2, torch.cuda.device_count()):
@@ -18420,8 +18420,11 @@ for tid in os.listdir(task_path):
         pass
 print(json.dumps(sorted(thread_names)))
 """
-        stdout, _ = TestCase.run_process_no_exception(code)
-        thread_names = set(json.loads(stdout.decode()))
+        stdout, stderr = TestCase.run_process_no_exception(code)
+        try:
+            thread_names = set(json.loads(stdout.decode()))
+        except json.JSONDecodeError:
+            self.fail(f"Subprocess produced invalid output.\nstdout: {stdout.decode()}\nstderr: {stderr.decode()}")
         self.assertIn("pt_autograd_0", thread_names)
         self.assertIn("pt_autograd_1", thread_names)
         for i in range(2, torch.cuda.device_count()):
@@ -18429,6 +18432,10 @@ print(json.dumps(sorted(thread_names)))
 
     @unittest.skipIf(not TEST_CUDA, "requires CUDA")
     @unittest.skipIf(IS_WINDOWS, "fork not supported on Windows")
+    @unittest.skipIf(
+        (torch.cuda.device_count() < 2) if TEST_CUDA else True,
+        "requires 2+ GPUs",
+    )
     def test_fork_after_backward_prevents_new_threads(self):
         """After backward + fork, child cannot start new device threads."""
         code = """import torch
@@ -18441,7 +18448,7 @@ x = torch.randn(4, 4, device="cuda:0", requires_grad=True)
 pid = os.fork()
 if pid == 0:
     try:
-        y = torch.randn(4, 4, device="cuda:0", requires_grad=True)
+        y = torch.randn(4, 4, device="cuda:1", requires_grad=True)
         (y @ y.T).sum().backward()
     except RuntimeError as e:
         if "fork" in str(e).lower():
@@ -18450,9 +18457,12 @@ if pid == 0:
 else:
     os.waitpid(pid, 0)
 """
-        s = TestCase.runWithPytorchAPIUsageStderr(code)
-        self.assertIn("FORK_ERROR_CAUGHT", s)
+        _, stderr = TestCase.run_process_no_exception(code)
+        self.assertIn("FORK_ERROR_CAUGHT", stderr.decode())
 
+
+instantiate_parametrized_tests(TestAutograd)
+instantiate_parametrized_tests(TestNestedCheckpoint)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7,6 +7,7 @@ import contextvars
 import functools
 import gc
 import io
+import json
 import math
 import operator
 import os
@@ -18295,6 +18296,163 @@ instantiate_device_type_tests(
 
 instantiate_parametrized_tests(TestAutograd)
 instantiate_parametrized_tests(TestNestedCheckpoint)
+
+
+class TestLazyAutogradEngineInit(TestCase):
+    """Tests verifying that autograd device threads are initialized lazily."""
+
+    def test_no_device_threads_before_backward(self):
+        """Importing torch must not start any device threads."""
+        code = """import torch
+"""
+        s = TestCase.runWithPytorchAPIUsageStderr(code)
+        self.assertNotRegex(s, r"torch\.autograd\.thread_start")
+
+    def test_cpu_backward_creates_no_device_threads(self):
+        """CPU-only backward must not start any device threads."""
+        code = """import torch
+x = torch.randn(4, 4, requires_grad=True)
+(x @ x.T).sum().backward()
+"""
+        s = TestCase.runWithPytorchAPIUsageStderr(code)
+        self.assertNotRegex(s, r"torch\.autograd\.thread_start")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    def test_gpu_backward_starts_only_used_device_thread(self):
+        """Backward on cuda:0 starts thread 0 but no other device threads."""
+        code = """import torch
+x = torch.randn(4, 4, device="cuda:0", requires_grad=True)
+(x @ x.T).sum().backward()
+"""
+        s = TestCase.runWithPytorchAPIUsageStderr(code)
+        self.assertRegex(s, r"torch\.autograd\.thread_start\.0\b")
+        for i in range(1, torch.cuda.device_count()):
+            self.assertNotRegex(s, rf"torch\.autograd\.thread_start\.{i}\b")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2 if TEST_CUDA else True,
+        "requires 2+ GPUs",
+    )
+    def test_gpu_backward_on_non_zero_device(self):
+        """Backward on cuda:1 starts thread 1 only, not thread 0 or others."""
+        code = """import torch
+x = torch.randn(4, 4, device="cuda:1", requires_grad=True)
+(x @ x.T).sum().backward()
+"""
+        s = TestCase.runWithPytorchAPIUsageStderr(code)
+        self.assertRegex(s, r"torch\.autograd\.thread_start\.1\b")
+        self.assertNotRegex(s, r"torch\.autograd\.thread_start\.0\b")
+        for i in range(2, torch.cuda.device_count()):
+            self.assertNotRegex(s, rf"torch\.autograd\.thread_start\.{i}\b")
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(IS_WINDOWS, "requires /proc filesystem")
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2 if TEST_CUDA else True,
+        "requires 2+ GPUs",
+    )
+    def test_multi_device_backward_starts_both_threads(self):
+        """Backward on cuda:0 then cuda:1 starts both device threads."""
+        code = """import torch
+import os
+import json
+
+x = torch.randn(4, 4, device="cuda:0", requires_grad=True)
+(x @ x.T).sum().backward()
+y = torch.randn(4, 4, device="cuda:1", requires_grad=True)
+(y @ y.T).sum().backward()
+
+pid = os.getpid()
+task_path = f"/proc/{pid}/task"
+thread_names = set()
+for tid in os.listdir(task_path):
+    try:
+        with open(f"{task_path}/{tid}/comm") as f:
+            thread_names.add(f.read().strip())
+    except FileNotFoundError:
+        pass
+print(json.dumps(sorted(thread_names)))
+"""
+        stdout, _ = TestCase.run_process_no_exception(code)
+        thread_names = set(json.loads(stdout.decode()))
+        self.assertIn("pt_autograd_0", thread_names)
+        self.assertIn("pt_autograd_1", thread_names)
+        for i in range(2, torch.cuda.device_count()):
+            self.assertNotIn(f"pt_autograd_{i}", thread_names)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(IS_WINDOWS, "requires /proc filesystem")
+    @unittest.skipIf(
+        torch.cuda.device_count() < 2 if TEST_CUDA else True,
+        "requires 2+ GPUs",
+    )
+    def test_concurrent_backward_starts_both_threads(self):
+        """Concurrent backward on cuda:0 and cuda:1 initializes both threads safely."""
+        code = """import torch
+import os
+import json
+import threading
+
+barrier = threading.Barrier(2)
+
+def backward_on_device(device):
+    x = torch.randn(4, 4, device=device, requires_grad=True)
+    loss = (x @ x.T).sum()
+    barrier.wait()
+    loss.backward()
+
+t0 = threading.Thread(target=backward_on_device, args=("cuda:0",))
+t1 = threading.Thread(target=backward_on_device, args=("cuda:1",))
+t0.start()
+t1.start()
+t0.join()
+t1.join()
+
+pid = os.getpid()
+task_path = f"/proc/{pid}/task"
+thread_names = set()
+for tid in os.listdir(task_path):
+    try:
+        with open(f"{task_path}/{tid}/comm") as f:
+            thread_names.add(f.read().strip())
+    except FileNotFoundError:
+        pass
+print(json.dumps(sorted(thread_names)))
+"""
+        stdout, _ = TestCase.run_process_no_exception(code)
+        thread_names = set(json.loads(stdout.decode()))
+        self.assertIn("pt_autograd_0", thread_names)
+        self.assertIn("pt_autograd_1", thread_names)
+        for i in range(2, torch.cuda.device_count()):
+            self.assertNotIn(f"pt_autograd_{i}", thread_names)
+
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @unittest.skipIf(IS_WINDOWS, "fork not supported on Windows")
+    def test_fork_after_backward_prevents_new_threads(self):
+        """After backward + fork, child cannot start new device threads."""
+        code = """import torch
+import os
+import sys
+
+x = torch.randn(4, 4, device="cuda:0", requires_grad=True)
+(x @ x.T).sum().backward()
+
+pid = os.fork()
+if pid == 0:
+    try:
+        y = torch.randn(4, 4, device="cuda:0", requires_grad=True)
+        (y @ y.T).sum().backward()
+    except RuntimeError as e:
+        if "fork" in str(e).lower():
+            print("FORK_ERROR_CAUGHT", file=sys.stderr)
+    os._exit(0)
+else:
+    os.waitpid(pid, 0)
+"""
+        s = TestCase.runWithPytorchAPIUsageStderr(code)
+        self.assertIn("FORK_ERROR_CAUGHT", s)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -293,12 +293,13 @@ void Engine::stop() {
   auto wait_duration =
       wait_duration_str ? std::atof(wait_duration_str->c_str()) : 10.0;
   bool noBackward = true;
-  for (auto& queue : device_ready_queues_) {
-    noBackward = noBackward && queue->empty();
+  auto num_queues = device_queues_size_.load(std::memory_order_acquire);
+  for (c10::DeviceIndex i = 0; i < num_queues; ++i) {
+    noBackward = noBackward && device_ready_queues_[i]->empty();
   }
   if (noBackward && wait_duration > 0.0f) {
-    for (auto& queue : device_ready_queues_) {
-      queue->pushShutdownTask();
+    for (c10::DeviceIndex i = 0; i < num_queues; ++i) {
+      device_ready_queues_[i]->pushShutdownTask();
     }
     // Do not wait for termination of global threads on Windows
     // Because CRT terminates DLL threads before calling
@@ -1614,8 +1615,12 @@ void Engine::ensure_device_queues_allocated(c10::DeviceIndex required_size) {
 void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
   TORCH_INTERNAL_ASSERT(
       device_index >= 0 &&
-      device_index < device_queues_size_.load(std::memory_order_acquire),
+          device_index < device_queues_size_.load(std::memory_order_acquire),
       "Device index out of bounds");
+
+  if (stopped_) {
+    return;
+  }
 
   if (device_thread_ready_[device_index].load(std::memory_order_acquire)) {
     return;
@@ -1639,6 +1644,9 @@ void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
       track_bad_autograd_forks();
       ensure_thread_pool_initialized();
 
+      C10_LOG_API_USAGE_ONCE(
+          "torch.autograd.thread_start." + std::to_string(device_index));
+
       try {
         std::thread t(
             &Engine::thread_init,
@@ -1651,13 +1659,17 @@ void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
         // Reset so future callers can retry thread creation.
         device_thread_started_[device_index].store(
             false, std::memory_order_release);
-        throw;
+        throw; // @allow-raw-throw
       }
     }
   }
 
   while (!device_thread_ready_[device_index].load(std::memory_order_acquire)) {
     std::this_thread::yield();
+  }
+
+  if (stopped_) {
+    device_ready_queues_[device_index]->pushShutdownTask();
   }
 }
 

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1535,14 +1535,12 @@ auto Engine::ready_queue(
     return cpu_ready_queue;
   } else {
     c10::DeviceIndex device_index = device.index();
+    TORCH_INTERNAL_ASSERT(
+        device_index >= 0, "Expected non-negative device index");
 
     ensure_device_queues_allocated(device_index + 1);
     ensure_device_thread_started(device_index);
 
-    TORCH_INTERNAL_ASSERT(
-        0 <= device_index &&
-        device_index <
-            static_cast<c10::DeviceIndex>(device_ready_queues_.size()));
     // See Note [Allocating GPUs to autograd threads]
     return device_ready_queues_.at(device_index);
   }
@@ -1555,13 +1553,12 @@ auto Engine::ready_queue_by_index(
     TORCH_INTERNAL_ASSERT(cpu_ready_queue);
     return cpu_ready_queue;
   } else {
+    TORCH_INTERNAL_ASSERT(
+        device_index >= 0, "Expected non-negative device index");
+
     ensure_device_queues_allocated(device_index + 1);
     ensure_device_thread_started(device_index);
 
-    TORCH_INTERNAL_ASSERT(
-        0 <= device_index &&
-        device_index <
-            static_cast<c10::DeviceIndex>(device_ready_queues_.size()));
     return device_ready_queues_.at(device_index);
   }
 }
@@ -1607,23 +1604,25 @@ void Engine::ensure_device_queues_allocated(c10::DeviceIndex required_size) {
 
   for (c10::DeviceIndex i = old_size; i < new_size; ++i) {
     device_ready_queues_[i] = std::make_shared<ReadyQueue>();
+    device_thread_started_[i].store(false, std::memory_order_relaxed);
+    device_thread_ready_[i].store(false, std::memory_order_relaxed);
   }
 
   device_queues_size_.store(new_size, std::memory_order_release);
 }
 
 void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
+  TORCH_INTERNAL_ASSERT(
+      device_index >= 0 &&
+      device_index < device_queues_size_.load(std::memory_order_acquire),
+      "Device index out of bounds");
+
   if (device_thread_ready_[device_index].load(std::memory_order_acquire)) {
     return;
   }
 
   {
     std::lock_guard<std::mutex> lock(device_queues_init_mutex_);
-
-    TORCH_INTERNAL_ASSERT(
-        device_index >= 0 &&
-        device_index < static_cast<c10::DeviceIndex>(device_thread_ready_.size()),
-        "Device index out of bounds");
 
     if (device_thread_ready_[device_index].load(std::memory_order_acquire)) {
       return;

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -378,6 +378,8 @@ void Engine::thread_init(
   // queue that is created before the thread initialization
   init_local_ready_queue(ready_queue);
 
+  device_thread_ready_[device].store(true, std::memory_order_release);
+
   std::shared_ptr<GraphTask> graph_task = nullptr;
   thread_main(graph_task);
   if (should_increment) {
@@ -1392,23 +1394,10 @@ auto Engine::execute(
   return fut->value().toTensorVector();
 }
 
-void Engine::initialize_device_threads_pool() {
-  TORCH_CHECK(
-      !in_bad_autograd_fork,
-      "Unable to handle autograd's threading in combination with fork-based multiprocessing. "
-      "See https://github.com/pytorch/pytorch/wiki/Autograd-and-Fork");
-  // Ensures device_ready_queues_ are initialized only once
-  static bool start_device_threads_flag_ [[maybe_unused]] = [this]() {
-    this->start_device_threads();
-    return true;
-  }();
-}
-
 c10::intrusive_ptr<at::ivalue::Future> Engine::execute_with_graph_task(
     const std::shared_ptr<GraphTask>& graph_task,
     std::shared_ptr<Node> graph_root,
     InputBuffer&& input_buffer) {
-  initialize_device_threads_pool();
   // Lock mutex for GraphTask.
   std::unique_lock<std::mutex> lock(graph_task->mutex_);
 
@@ -1545,12 +1534,17 @@ auto Engine::ready_queue(
     TORCH_INTERNAL_ASSERT(cpu_ready_queue);
     return cpu_ready_queue;
   } else {
+    c10::DeviceIndex device_index = device.index();
+
+    ensure_device_queues_allocated(device_index + 1);
+    ensure_device_thread_started(device_index);
+
     TORCH_INTERNAL_ASSERT(
-        0 <= device.index() &&
-        device.index() <
+        0 <= device_index &&
+        device_index <
             static_cast<c10::DeviceIndex>(device_ready_queues_.size()));
     // See Note [Allocating GPUs to autograd threads]
-    return device_ready_queues_.at(device.index());
+    return device_ready_queues_.at(device_index);
   }
 }
 
@@ -1558,68 +1552,127 @@ auto Engine::ready_queue_by_index(
     std::shared_ptr<ReadyQueue> cpu_ready_queue,
     int device_index) -> std::shared_ptr<ReadyQueue> {
   if (device_index == CPU_DEVICE) {
-    // return the cpu ready queue passed in
     TORCH_INTERNAL_ASSERT(cpu_ready_queue);
     return cpu_ready_queue;
   } else {
+    ensure_device_queues_allocated(device_index + 1);
+    ensure_device_thread_started(device_index);
+
     TORCH_INTERNAL_ASSERT(
         0 <= device_index &&
         device_index <
             static_cast<c10::DeviceIndex>(device_ready_queues_.size()));
-    // See Note [Allocating GPUs to autograd threads]
-    // NB: This function would become obsolete if we truly allocated a CPU
-    // thread per device, rather than colocate.
     return device_ready_queues_.at(device_index);
   }
 }
 
-auto Engine::start_device_threads() -> void {
-  // First always initialize the thread pool for re-entrant threads
-  thread_pool_shared_ = std::make_shared<ThreadPoolShared>();
+c10::DeviceIndex Engine::compute_max_device_count() {
+  if (global_device_count_computed_) {
+    return max_device_count_;
+  }
 
-  // Second, create special threads for each non-CPU device
-  // See Note [Allocating GPUs to autograd threads]
   c10::DeviceIndex num_devices = 0;
   for (const auto& impl_atomic : c10::impl::device_guard_impl_registry) {
     auto* impl = impl_atomic.load();
-    // Only record the number of devices for device that don't run on the
-    // cpu ready queue.
     if (impl && !should_run_in_cpu_ready_queue(impl->type())) {
       num_devices = std::max(num_devices, impl->deviceCount());
     }
   }
 
-  // If there are no device except cpu, no need to create worker threads
-  if (num_devices == 0) {
+  max_device_count_ = num_devices;
+  global_device_count_computed_ = true;
+
+  return num_devices;
+}
+
+void Engine::ensure_device_queues_allocated(c10::DeviceIndex required_size) {
+  if (device_queues_size_.load(std::memory_order_acquire) >= required_size) {
     return;
   }
 
-  // Since we're about to create threads, forking is not possible anymore
-  track_bad_autograd_forks();
+  std::lock_guard<std::mutex> lock(device_queues_init_mutex_);
 
-  // allocate one thread for every GPU device (but colocate GPUs of different
-  // types), and pre-allocate the device_ready_queues_ to ensure safe reading on
-  // it.
-  device_ready_queues_ = std::vector<std::shared_ptr<ReadyQueue>>(num_devices);
-  for (auto& queue : device_ready_queues_) {
-    queue = std::make_shared<ReadyQueue>();
+  if (static_cast<c10::DeviceIndex>(device_ready_queues_.size()) >=
+      required_size) {
+    return;
   }
 
-  for (const auto i : c10::irange(num_devices)) {
-    std::thread t(&Engine::thread_init, this, i, device_ready_queues_[i], true);
-    t.detach();
+  c10::DeviceIndex max_devices = compute_max_device_count();
+  c10::DeviceIndex new_size = std::max(required_size, max_devices);
+
+  c10::DeviceIndex old_size = device_ready_queues_.size();
+  device_ready_queues_.resize(new_size);
+  device_thread_started_.resize(new_size);
+  device_thread_ready_.resize(new_size);
+
+  for (c10::DeviceIndex i = old_size; i < new_size; ++i) {
+    device_ready_queues_[i] = std::make_shared<ReadyQueue>();
   }
-  // Wait for the threads to start
+
+  device_queues_size_.store(new_size, std::memory_order_release);
+}
+
+void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
+  if (device_thread_ready_[device_index].load(std::memory_order_acquire)) {
+    return;
+  }
+
   {
-    std::unique_lock<std::mutex> lk(non_reentrant_device_thread_mutex_);
-    while (non_reentrant_device_thread_count_.load() !=
-           static_cast<uint32_t>(num_devices)) {
-      non_reentrant_device_thread_condvar_.wait(lk);
+    std::lock_guard<std::mutex> lock(device_queues_init_mutex_);
+
+    TORCH_INTERNAL_ASSERT(
+        device_index >= 0 &&
+        device_index < static_cast<c10::DeviceIndex>(device_thread_ready_.size()),
+        "Device index out of bounds");
+
+    if (device_thread_ready_[device_index].load(std::memory_order_acquire)) {
+      return;
     }
+
+    bool expected = false;
+    if (device_thread_started_[device_index].compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel)) {
+      TORCH_CHECK(
+          !in_bad_autograd_fork,
+          "Unable to handle autograd's threading in combination with fork-based multiprocessing. "
+          "See https://github.com/pytorch/pytorch/wiki/Autograd-and-Fork");
+
+      track_bad_autograd_forks();
+      ensure_thread_pool_initialized();
+
+      try {
+        std::thread t(
+            &Engine::thread_init,
+            this,
+            device_index,
+            device_ready_queues_[device_index],
+            true);
+        t.detach();
+      } catch (...) {
+        // Reset so future callers can retry thread creation.
+        device_thread_started_[device_index].store(
+            false, std::memory_order_release);
+        throw;
+      }
+    }
+  }
+
+  while (!device_thread_ready_[device_index].load(std::memory_order_acquire)) {
+    std::this_thread::yield();
   }
 }
 
+void Engine::ensure_thread_pool_initialized() {
+  static bool initialized [[maybe_unused]] = [this]() {
+    if (!thread_pool_shared_) {
+      thread_pool_shared_ = std::make_shared<ThreadPoolShared>();
+    }
+    return true;
+  }();
+}
+
 void Engine::add_thread_pool_task(const std::weak_ptr<GraphTask>& graph_task) {
+  ensure_thread_pool_initialized();
   std::unique_lock<std::mutex> lck(thread_pool_shared_->mutex_);
   // There may already be some items on the graphtasks_queue_ added by other
   // threads but not enough workers to get to the new task that will be

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -382,6 +382,8 @@ void Engine::thread_init(
   // queue that is created before the thread initialization
   init_local_ready_queue(ready_queue);
 
+  device_thread_ready_[device].store(true, std::memory_order_release);
+
   std::shared_ptr<GraphTask> graph_task = nullptr;
   thread_main(graph_task);
   if (should_increment) {
@@ -1478,23 +1480,10 @@ auto Engine::execute(
   return fut->value().toTensorVector();
 }
 
-void Engine::initialize_device_threads_pool() {
-  TORCH_CHECK(
-      !in_bad_autograd_fork,
-      "Unable to handle autograd's threading in combination with fork-based multiprocessing. "
-      "See https://github.com/pytorch/pytorch/wiki/Autograd-and-Fork");
-  // Ensures device_ready_queues_ are initialized only once
-  static bool start_device_threads_flag_ [[maybe_unused]] = [this]() {
-    this->start_device_threads();
-    return true;
-  }();
-}
-
 c10::intrusive_ptr<at::ivalue::Future> Engine::execute_with_graph_task(
     const std::shared_ptr<GraphTask>& graph_task,
     c10::intrusive_ptr<Node> graph_root,
     InputBuffer&& input_buffer) {
-  initialize_device_threads_pool();
   // Lock mutex for GraphTask.
   std::unique_lock<std::mutex> lock(graph_task->mutex_);
 
@@ -1631,12 +1620,17 @@ auto Engine::ready_queue(
     TORCH_INTERNAL_ASSERT(cpu_ready_queue);
     return cpu_ready_queue;
   } else {
+    c10::DeviceIndex device_index = device.index();
+
+    ensure_device_queues_allocated(device_index + 1);
+    ensure_device_thread_started(device_index);
+
     TORCH_INTERNAL_ASSERT(
-        0 <= device.index() &&
-        device.index() <
+        0 <= device_index &&
+        device_index <
             static_cast<c10::DeviceIndex>(device_ready_queues_.size()));
     // See Note [Allocating GPUs to autograd threads]
-    return device_ready_queues_.at(device.index());
+    return device_ready_queues_.at(device_index);
   }
 }
 
@@ -1644,68 +1638,127 @@ auto Engine::ready_queue_by_index(
     std::shared_ptr<ReadyQueue> cpu_ready_queue,
     int device_index) -> std::shared_ptr<ReadyQueue> {
   if (device_index == CPU_DEVICE) {
-    // return the cpu ready queue passed in
     TORCH_INTERNAL_ASSERT(cpu_ready_queue);
     return cpu_ready_queue;
   } else {
+    ensure_device_queues_allocated(device_index + 1);
+    ensure_device_thread_started(device_index);
+
     TORCH_INTERNAL_ASSERT(
         0 <= device_index &&
         device_index <
             static_cast<c10::DeviceIndex>(device_ready_queues_.size()));
-    // See Note [Allocating GPUs to autograd threads]
-    // NB: This function would become obsolete if we truly allocated a CPU
-    // thread per device, rather than colocate.
     return device_ready_queues_.at(device_index);
   }
 }
 
-auto Engine::start_device_threads() -> void {
-  // First always initialize the thread pool for re-entrant threads
-  thread_pool_shared_ = std::make_shared<ThreadPoolShared>();
+c10::DeviceIndex Engine::compute_max_device_count() {
+  if (global_device_count_computed_) {
+    return max_device_count_;
+  }
 
-  // Second, create special threads for each non-CPU device
-  // See Note [Allocating GPUs to autograd threads]
   c10::DeviceIndex num_devices = 0;
   for (const auto& impl_atomic : c10::impl::device_guard_impl_registry) {
     auto* impl = impl_atomic.load();
-    // Only record the number of devices for device that don't run on the
-    // cpu ready queue.
     if (impl && !should_run_in_cpu_ready_queue(impl->type())) {
       num_devices = std::max(num_devices, impl->deviceCount());
     }
   }
 
-  // If there are no device except cpu, no need to create worker threads
-  if (num_devices == 0) {
+  max_device_count_ = num_devices;
+  global_device_count_computed_ = true;
+
+  return num_devices;
+}
+
+void Engine::ensure_device_queues_allocated(c10::DeviceIndex required_size) {
+  if (device_queues_size_.load(std::memory_order_acquire) >= required_size) {
     return;
   }
 
-  // Since we're about to create threads, forking is not possible anymore
-  track_bad_autograd_forks();
+  std::lock_guard<std::mutex> lock(device_queues_init_mutex_);
 
-  // allocate one thread for every GPU device (but colocate GPUs of different
-  // types), and pre-allocate the device_ready_queues_ to ensure safe reading on
-  // it.
-  device_ready_queues_ = std::vector<std::shared_ptr<ReadyQueue>>(num_devices);
-  for (auto& queue : device_ready_queues_) {
-    queue = std::make_shared<ReadyQueue>();
+  if (static_cast<c10::DeviceIndex>(device_ready_queues_.size()) >=
+      required_size) {
+    return;
   }
 
-  for (const auto i : c10::irange(num_devices)) {
-    std::thread t(&Engine::thread_init, this, i, device_ready_queues_[i], true);
-    t.detach();
+  c10::DeviceIndex max_devices = compute_max_device_count();
+  c10::DeviceIndex new_size = std::max(required_size, max_devices);
+
+  c10::DeviceIndex old_size = device_ready_queues_.size();
+  device_ready_queues_.resize(new_size);
+  device_thread_started_.resize(new_size);
+  device_thread_ready_.resize(new_size);
+
+  for (c10::DeviceIndex i = old_size; i < new_size; ++i) {
+    device_ready_queues_[i] = std::make_shared<ReadyQueue>();
   }
-  // Wait for the threads to start
+
+  device_queues_size_.store(new_size, std::memory_order_release);
+}
+
+void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
+  if (device_thread_ready_[device_index].load(std::memory_order_acquire)) {
+    return;
+  }
+
   {
-    std::unique_lock<std::mutex> lk(non_reentrant_device_thread_mutex_);
-    while (non_reentrant_device_thread_count_.load() !=
-           static_cast<uint32_t>(num_devices)) {
-      non_reentrant_device_thread_condvar_.wait(lk);
+    std::lock_guard<std::mutex> lock(device_queues_init_mutex_);
+
+    TORCH_INTERNAL_ASSERT(
+        device_index >= 0 &&
+        device_index < static_cast<c10::DeviceIndex>(device_thread_ready_.size()),
+        "Device index out of bounds");
+
+    if (device_thread_ready_[device_index].load(std::memory_order_acquire)) {
+      return;
     }
+
+    bool expected = false;
+    if (device_thread_started_[device_index].compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel)) {
+      TORCH_CHECK(
+          !in_bad_autograd_fork,
+          "Unable to handle autograd's threading in combination with fork-based multiprocessing. "
+          "See https://github.com/pytorch/pytorch/wiki/Autograd-and-Fork");
+
+      track_bad_autograd_forks();
+      ensure_thread_pool_initialized();
+
+      try {
+        std::thread t(
+            &Engine::thread_init,
+            this,
+            device_index,
+            device_ready_queues_[device_index],
+            true);
+        t.detach();
+      } catch (...) {
+        // Reset so future callers can retry thread creation.
+        device_thread_started_[device_index].store(
+            false, std::memory_order_release);
+        throw;
+      }
+    }
+  }
+
+  while (!device_thread_ready_[device_index].load(std::memory_order_acquire)) {
+    std::this_thread::yield();
   }
 }
 
+void Engine::ensure_thread_pool_initialized() {
+  static bool initialized [[maybe_unused]] = [this]() {
+    if (!thread_pool_shared_) {
+      thread_pool_shared_ = std::make_shared<ThreadPoolShared>();
+    }
+    return true;
+  }();
+}
+
 void Engine::add_thread_pool_task(std::weak_ptr<GraphTask> graph_task) {
+  ensure_thread_pool_initialized();
   std::unique_lock<std::mutex> lck(thread_pool_shared_->mutex_);
   // There may already be some items on the graphtasks_queue_ added by other
   // threads but not enough workers to get to the new task that will be

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -286,10 +286,10 @@ Engine::~Engine() {
 // running Even though readyQueue should be empty, shutdown tasks have the
 // highest priority
 void Engine::stop() {
-  if (stopped_) {
+  if (stopped_.load(std::memory_order_acquire)) {
     return;
   }
-  stopped_ = true;
+  stopped_.store(true, std::memory_order_release);
   // Under some conditions, autograd threads can hang on shutdown
   // Do not wait for them to shutdown indefinitely but rely on timeout
   auto wait_duration_str =
@@ -1704,7 +1704,7 @@ void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
           device_index < device_queues_size_.load(std::memory_order_acquire),
       "Device index out of bounds");
 
-  if (stopped_) {
+  if (stopped_.load(std::memory_order_acquire)) {
     return;
   }
 
@@ -1730,7 +1730,7 @@ void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
       track_bad_autograd_forks();
       ensure_thread_pool_initialized();
 
-      C10_LOG_API_USAGE_ONCE(
+      c10::LogAPIUsage(
           "torch.autograd.thread_start." + std::to_string(device_index));
 
       try {
@@ -1751,10 +1751,13 @@ void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
   }
 
   while (!device_thread_ready_[device_index].load(std::memory_order_acquire)) {
+    if (stopped_.load(std::memory_order_acquire)) {
+      return;
+    }
     std::this_thread::yield();
   }
 
-  if (stopped_) {
+  if (stopped_.load(std::memory_order_acquire)) {
     device_ready_queues_[device_index]->pushShutdownTask();
   }
 }

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1621,14 +1621,12 @@ auto Engine::ready_queue(
     return cpu_ready_queue;
   } else {
     c10::DeviceIndex device_index = device.index();
+    TORCH_INTERNAL_ASSERT(
+        device_index >= 0, "Expected non-negative device index");
 
     ensure_device_queues_allocated(device_index + 1);
     ensure_device_thread_started(device_index);
 
-    TORCH_INTERNAL_ASSERT(
-        0 <= device_index &&
-        device_index <
-            static_cast<c10::DeviceIndex>(device_ready_queues_.size()));
     // See Note [Allocating GPUs to autograd threads]
     return device_ready_queues_.at(device_index);
   }
@@ -1641,13 +1639,12 @@ auto Engine::ready_queue_by_index(
     TORCH_INTERNAL_ASSERT(cpu_ready_queue);
     return cpu_ready_queue;
   } else {
+    TORCH_INTERNAL_ASSERT(
+        device_index >= 0, "Expected non-negative device index");
+
     ensure_device_queues_allocated(device_index + 1);
     ensure_device_thread_started(device_index);
 
-    TORCH_INTERNAL_ASSERT(
-        0 <= device_index &&
-        device_index <
-            static_cast<c10::DeviceIndex>(device_ready_queues_.size()));
     return device_ready_queues_.at(device_index);
   }
 }
@@ -1693,23 +1690,25 @@ void Engine::ensure_device_queues_allocated(c10::DeviceIndex required_size) {
 
   for (c10::DeviceIndex i = old_size; i < new_size; ++i) {
     device_ready_queues_[i] = std::make_shared<ReadyQueue>();
+    device_thread_started_[i].store(false, std::memory_order_relaxed);
+    device_thread_ready_[i].store(false, std::memory_order_relaxed);
   }
 
   device_queues_size_.store(new_size, std::memory_order_release);
 }
 
 void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
+  TORCH_INTERNAL_ASSERT(
+      device_index >= 0 &&
+      device_index < device_queues_size_.load(std::memory_order_acquire),
+      "Device index out of bounds");
+
   if (device_thread_ready_[device_index].load(std::memory_order_acquire)) {
     return;
   }
 
   {
     std::lock_guard<std::mutex> lock(device_queues_init_mutex_);
-
-    TORCH_INTERNAL_ASSERT(
-        device_index >= 0 &&
-        device_index < static_cast<c10::DeviceIndex>(device_thread_ready_.size()),
-        "Device index out of bounds");
 
     if (device_thread_ready_[device_index].load(std::memory_order_acquire)) {
       return;

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -297,12 +297,13 @@ void Engine::stop() {
   auto wait_duration =
       wait_duration_str ? std::atof(wait_duration_str->c_str()) : 10.0;
   bool noBackward = true;
-  for (auto& queue : device_ready_queues_) {
-    noBackward = noBackward && queue->empty();
+  auto num_queues = device_queues_size_.load(std::memory_order_acquire);
+  for (c10::DeviceIndex i = 0; i < num_queues; ++i) {
+    noBackward = noBackward && device_ready_queues_[i]->empty();
   }
   if (noBackward && wait_duration > 0.0f) {
-    for (auto& queue : device_ready_queues_) {
-      queue->pushShutdownTask();
+    for (c10::DeviceIndex i = 0; i < num_queues; ++i) {
+      device_ready_queues_[i]->pushShutdownTask();
     }
     // Do not wait for termination of global threads on Windows
     // Because CRT terminates DLL threads before calling
@@ -1700,8 +1701,12 @@ void Engine::ensure_device_queues_allocated(c10::DeviceIndex required_size) {
 void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
   TORCH_INTERNAL_ASSERT(
       device_index >= 0 &&
-      device_index < device_queues_size_.load(std::memory_order_acquire),
+          device_index < device_queues_size_.load(std::memory_order_acquire),
       "Device index out of bounds");
+
+  if (stopped_) {
+    return;
+  }
 
   if (device_thread_ready_[device_index].load(std::memory_order_acquire)) {
     return;
@@ -1725,6 +1730,9 @@ void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
       track_bad_autograd_forks();
       ensure_thread_pool_initialized();
 
+      C10_LOG_API_USAGE_ONCE(
+          "torch.autograd.thread_start." + std::to_string(device_index));
+
       try {
         std::thread t(
             &Engine::thread_init,
@@ -1737,13 +1745,17 @@ void Engine::ensure_device_thread_started(c10::DeviceIndex device_index) {
         // Reset so future callers can retry thread creation.
         device_thread_started_[device_index].store(
             false, std::memory_order_release);
-        throw;
+        throw; // @allow-raw-throw
       }
     }
   }
 
   while (!device_thread_ready_[device_index].load(std::memory_order_acquire)) {
     std::this_thread::yield();
+  }
+
+  if (stopped_) {
+    device_ready_queues_[device_index]->pushShutdownTask();
   }
 }
 

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -183,7 +183,6 @@ struct TORCH_API Engine {
       InputBuffer& inputs,
       const std::shared_ptr<ReadyQueue>& cpu_ready_queue);
 
-  void initialize_device_threads_pool();
   virtual void thread_on_exception(
       const std::shared_ptr<GraphTask>& graph_task,
       const std::shared_ptr<Node>& fn,
@@ -221,17 +220,17 @@ struct TORCH_API Engine {
   std::shared_ptr<ReadyQueue> ready_queue_by_index(
       std::shared_ptr<ReadyQueue> cpu_ready_queue,
       int device_index);
-  // start device threads (CUDA, XLA, etc.) in Engine,
-  // note that it does NOT start CPU thread.
-  void start_device_threads();
   void increment_non_reentrant_thread_count();
   void decrement_non_reentrant_thread_count();
   virtual void thread_main(const std::shared_ptr<GraphTask>& task);
   void reentrant_thread_init();
   void add_thread_pool_task(const std::weak_ptr<GraphTask>& graph_task);
 
-  // Safe to read device_ready_queues_ without synchronization after
-  // initialization
+  c10::DeviceIndex compute_max_device_count();
+  void ensure_device_queues_allocated(c10::DeviceIndex required_size);
+  void ensure_device_thread_started(c10::DeviceIndex device_index);
+  void ensure_thread_pool_initialized();
+
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::vector<std::shared_ptr<ReadyQueue>> device_ready_queues_;
 
@@ -275,6 +274,14 @@ struct TORCH_API Engine {
   // Destructor will wait for non-reentrant threads to finish
   std::condition_variable non_reentrant_device_thread_condvar_;
   std::mutex non_reentrant_device_thread_mutex_;
+
+  std::deque<std::atomic<bool>> device_thread_started_;
+  std::deque<std::atomic<bool>> device_thread_ready_;
+  std::mutex device_queues_init_mutex_;
+  std::atomic<c10::DeviceIndex> device_queues_size_{0};
+  c10::DeviceIndex max_device_count_{0};
+  bool global_device_count_computed_{false};
+
   // stop() must be called before the destruction path goes down to the base
   // class, in order to avoid a data-race-on-vptr. Use this boolean to guard
   // whether stop() has already been called, so we can call this in every

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -193,7 +193,6 @@ struct TORCH_API Engine {
       InputBuffer& inputs,
       const std::shared_ptr<ReadyQueue>& cpu_ready_queue);
 
-  void initialize_device_threads_pool();
   virtual void thread_on_exception(
       const std::shared_ptr<GraphTask>& graph_task,
       const c10::intrusive_ptr<Node>& fn,
@@ -231,17 +230,17 @@ struct TORCH_API Engine {
   std::shared_ptr<ReadyQueue> ready_queue_by_index(
       std::shared_ptr<ReadyQueue> cpu_ready_queue,
       int device_index);
-  // start device threads (CUDA, XLA, etc.) in Engine,
-  // note that it does NOT start CPU thread.
-  void start_device_threads();
   void increment_non_reentrant_thread_count();
   void decrement_non_reentrant_thread_count();
   virtual void thread_main(const std::shared_ptr<GraphTask>& task);
   void reentrant_thread_init();
   void add_thread_pool_task(std::weak_ptr<GraphTask> graph_task);
 
-  // Safe to read device_ready_queues_ without synchronization after
-  // initialization
+  c10::DeviceIndex compute_max_device_count();
+  void ensure_device_queues_allocated(c10::DeviceIndex required_size);
+  void ensure_device_thread_started(c10::DeviceIndex device_index);
+  void ensure_thread_pool_initialized();
+
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::vector<std::shared_ptr<ReadyQueue>> device_ready_queues_;
 
@@ -285,6 +284,14 @@ struct TORCH_API Engine {
   // Destructor will wait for non-reentrant threads to finish
   std::condition_variable non_reentrant_device_thread_condvar_;
   std::mutex non_reentrant_device_thread_mutex_;
+
+  std::deque<std::atomic<bool>> device_thread_started_;
+  std::deque<std::atomic<bool>> device_thread_ready_;
+  std::mutex device_queues_init_mutex_;
+  std::atomic<c10::DeviceIndex> device_queues_size_{0};
+  c10::DeviceIndex max_device_count_{0};
+  bool global_device_count_computed_{false};
+
   // stop() must be called before the destruction path goes down to the base
   // class, in order to avoid a data-race-on-vptr. Use this boolean to guard
   // whether stop() has already been called, so we can call this in every

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -242,7 +242,7 @@ struct TORCH_API Engine {
   void ensure_thread_pool_initialized();
 
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
-  std::vector<std::shared_ptr<ReadyQueue>> device_ready_queues_;
+  std::deque<std::shared_ptr<ReadyQueue>> device_ready_queues_;
 
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::vector<std::function<void()>> final_callbacks_;
@@ -296,7 +296,7 @@ struct TORCH_API Engine {
   // class, in order to avoid a data-race-on-vptr. Use this boolean to guard
   // whether stop() has already been called, so we can call this in every
   // destructor of the class hierarchy.
-  bool stopped_{false};
+  std::atomic<bool> stopped_{false};
 };
 
 // allow python_engine to override the default engine when it loads

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -348,7 +348,6 @@ void DistEngine::computeDependencies(
 void DistEngine::execute_graph_task_until_ready_queue_empty(
     NodeTask&& node_task,
     bool incrementOutstandingTasks) {
-  engine_.initialize_device_threads_pool();
   // Create a ready queue per call to traverse the graph_task from
   // root_to_execute This allow concurrent execution of the same GraphTask from
   // different threads


### PR DESCRIPTION
Before this change, the first call to backward() would spawn one OS thread per GPU device, even if only one GPU was ever used. On an 8-GPU machine, a single-GPU job created 8 device threads with 7 sitting idle for the entire run, wasting resources and adding latency to the first backward pass.

This PR fixes that by making device thread creation lazy. Threads are now spawned when `ready_queue()` is first called for a device during graph execution, the natural point where the engine discovers it needs that device. `start_device_threads()` and `initialize_device_threads_pool()` are removed entirely.

The implementation uses a lock-free atomic fast path for the common case (device already initialized) and a mutex-guarded slow path for actual allocation and thread spawning. `std::deque` is used for both `device_ready_queues_` and the per-device atomic flags since `std::atomic` is non-movable and `std::deque` guarantees reference stability on resize (unlike `std::vector`, which can invalidate element pointers during reallocation). The mutex is released before the spin-wait so multiple devices can initialize concurrently. `dist_engine.cpp` drops its explicit `initialize_device_threads_pool()` call since lazy init now happens automatically through `ready_queue()`.

**BC note:** `Engine::initialize_device_threads_pool()` was a public method on a `TORCH_API` class. Out-of-tree C++ code that called it will get a compile error. The fix is to delete the call — lazy initialization makes it unnecessary.

**Commit walkthrough:**
1. `Lazily start worker threads in autograd engine` — core implementation: replaces `start_device_threads()` / `initialize_device_threads_pool()` with `ensure_device_queues_allocated()`, `ensure_device_thread_started()`, `ensure_thread_pool_initialized()`.
2. `Input validation and atomic initialization for lazy thread startup` — validates device_index bounds, explicitly initializes new atomic slots after deque resize.
3. `Add tests verifying lazy autograd device thread initialization` — subprocess-based tests using `C10_LOG_API_USAGE` events and `/proc` thread names. Tests cover: no threads before backward, no threads after CPU backward, only the used device's thread after GPU backward, concurrent multi-device init, and fork safety.
4. `Fix thread safety, logging, and test correctness issues` — changes `device_ready_queues_` from `std::vector` to `std::deque` to prevent use-after-free on concurrent resize; makes `stopped_` atomic; adds `stopped_` check in the spin-yield loop to prevent shutdown hangs; replaces `C10_LOG_API_USAGE_ONCE` with `c10::LogAPIUsage` (the ONCE macro uses a per-call-site static, only logging the first device); fixes fork test to use an uninitialized device in the child process.

Fixes #91898

Test plan: `python test/test_autograd.py`