### PR TITLE
[caffe2/tensorexpr] Add LLVM 23+ branch for `ObjectLinkingLayerCreator`

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -180,11 +180,19 @@ class TORCH_API PytorchLLVMJITImpl {
 #if LLVM_VERSION_MAJOR < 21
                                                   ,
                                                   const Triple& TT
+#elif LLVM_VERSION_MAJOR >= 23
+                                                  ,
+                                                  jitlink::JITLinkMemoryManager&
+                                                      JLMM
 #endif
                                               ) {
+#if LLVM_VERSION_MAJOR >= 23
+                  return std::make_unique<ObjectLinkingLayer>(ES, JLMM);
+#else
                   return std::make_unique<ObjectLinkingLayer>(
                       ES,
                       assertSuccess(jitlink::InProcessMemoryManager::Create()));
+#endif
                 })
 #endif
                 .create())) {


### PR DESCRIPTION
Summary:
LLVM 23 changed `LLJITBuilderState::ObjectLinkingLayerCreator` to take a `jitlink::JITLinkMemoryManager&` as the second parameter instead of `const Triple&` (the LLVM <21 form) or no second parameter at all (the LLVM 21–22 form). Without this branch, `caffe2/torch/csrc/jit/tensorexpr/llvm_jit.cpp` fails to compile against the LLVM 23 headers shipped in the latest staging toolchain:

```
error: no viable conversion from '(lambda at .../llvm_jit.cpp:179:47)' to 'LLJITBuilderState::ObjectLinkingLayerCreator' (aka 'std::function<Expected<std::unique_ptr<ObjectLayer>> (ExecutionSession &, jitlink::JITLinkMemoryManager &)>')
```

This change adds an `#elif LLVM_VERSION_MAJOR >= 23` branch that takes the supplied `JITLinkMemoryManager&` and forwards it to `ObjectLinkingLayer`. The pre-23 branches are unchanged.

Test Plan:
- Local source-only review against the LLVM 23 `LLJIT.h` shipped in the staging branch confirms the new lambda signature matches `ObjectLinkingLayerCreator`.
- Pre-existing branches for LLVM 17–20 (with `const Triple&`) and LLVM 21–22 (single-parameter) are unchanged, so other supported toolchains are unaffected.
- Will be verified end-to-end by the daily fbcode staging build (`llvm_fb_staging_fbcode_buildtest`).

Reviewed By: grigorypas

Differential Revision: D101383374




cc @EikanWang @jgong5