### PR TITLE
Fix NumPy 2 deprecation warning in __array_wrap__

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1256,7 +1256,7 @@ class Tensor(torch._C.TensorBase):
 
     # Wrap Numpy array again in a suitable tensor when done, to support e.g.
     # `numpy.sin(tensor) -> tensor` or `numpy.greater(tensor, 0) -> ByteTensor`
-    def __array_wrap__(self, array):
+    def __array_wrap__(self, array, context=None, return_scalar=None):
         if has_torch_function_unary(self):
             return handle_torch_function(
                 Tensor.__array_wrap__, (self,), self, array=array

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1256,20 +1256,21 @@ class Tensor(torch._C.TensorBase):
 
     # Wrap Numpy array again in a suitable tensor when done, to support e.g.
     # `numpy.sin(tensor) -> tensor` or `numpy.greater(tensor, 0) -> ByteTensor`
-    def __array_wrap__(self, array, context=None, return_scalar=None):
+    def __array_wrap__(self, array, context=None, return_scalar=False):
         if has_torch_function_unary(self):
-            kwargs = {"array": array}
-            if context is not None:
-                kwargs["context"] = context
-            if return_scalar is not None:
-                kwargs["return_scalar"] = return_scalar
             return handle_torch_function(
-                Tensor.__array_wrap__, (self,), self, **kwargs
+                Tensor.__array_wrap__,
+                (self,),
+                self,
+                array=array,
+                context=context,
+                return_scalar=return_scalar,
             )
         if array.dtype == bool:
             # Workaround, torch has no built-in bool tensor
             array = array.astype("uint8")
-        return torch.from_numpy(array)
+        result = torch.from_numpy(array)
+        return result.item() if return_scalar else result
 
     def __contains__(self, element: Any, /) -> bool:
         r"""Check if `element` is present in tensor

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1258,8 +1258,13 @@ class Tensor(torch._C.TensorBase):
     # `numpy.sin(tensor) -> tensor` or `numpy.greater(tensor, 0) -> ByteTensor`
     def __array_wrap__(self, array, context=None, return_scalar=None):
         if has_torch_function_unary(self):
+            kwargs = {"array": array}
+            if context is not None:
+                kwargs["context"] = context
+            if return_scalar is not None:
+                kwargs["return_scalar"] = return_scalar
             return handle_torch_function(
-                Tensor.__array_wrap__, (self,), self, array=array
+                Tensor.__array_wrap__, (self,), self, **kwargs
             )
         if array.dtype == bool:
             # Workaround, torch has no built-in bool tensor

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1336,7 +1336,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         Tensor.__mod__: lambda self, other: -1,
         Tensor.__rmod__: lambda self, other: -1,
         Tensor.__imod__: lambda self, other: -1,
-        Tensor.__array_wrap__: lambda self, array: -1,
+        Tensor.__array_wrap__: lambda self, array, context=None, return_scalar=None: -1,
         Tensor.__getitem__: lambda self, idx: -1,
         Tensor.__deepcopy__: lambda self, memo: -1,
         Tensor.__int__: lambda self: -1,

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1336,7 +1336,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         Tensor.__mod__: lambda self, other: -1,
         Tensor.__rmod__: lambda self, other: -1,
         Tensor.__imod__: lambda self, other: -1,
-        Tensor.__array_wrap__: lambda self, array, context=None, return_scalar=None: -1,
+        Tensor.__array_wrap__: lambda self, array, context=None, return_scalar=False: -1,
         Tensor.__getitem__: lambda self, idx: -1,
         Tensor.__deepcopy__: lambda self, memo: -1,
         Tensor.__int__: lambda self: -1,


### PR DESCRIPTION
NumPy 2 introduces a deprecation warning for __array_wrap__ requiring additional arguments (context and return_scalar).

This PR updates the __array_wrap__ signature to accept these arguments while preserving existing behavior, ensuring compatibility with NumPy 2.

Verified locally by reproducing the warning with NumPy 2 and confirming it is resolved after the change.
Fixes #180657