### PR TITLE
Fix torch.trapz docstring signature to match torch.trapezoid

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13129,9 +13129,11 @@ Examples::
 add_docstr(
     torch.trapz,
     r"""
-trapz(y, x, *, dim=-1) -> Tensor
+trapz(y, x=None, *, dx=None, dim=-1) -> Tensor
 
 Alias for :func:`torch.trapezoid`.
+
+See :func:`torch.trapezoid` for more details.
 """,
 )
 


### PR DESCRIPTION
Good day,

## Summary
This PR fixes the docstring signature for `torch.trapz` to accurately reflect that it is an alias of `torch.trapezoid`.

## Problem
The docstring for `torch.trapz` showed `x` as a required positional argument:
```
trapz(y, x, *, dim=-1) -> Tensor
```

However, `torch.trapezoid` (which `torch.trapz` aliases) has:
```
trapezoid(y, x=None, *, dx=None, dim=-1) -> Tensor
```

The `x` parameter being marked as required in `trapz` is incorrect — it should be `x=None`. Additionally, `trapz` was missing the `dx` keyword argument.

## Fix
Updated the signature in the docstring from:
```
trapz(y, x, *, dim=-1)
```
to:
```
trapz(y, x=None, *, dx=None, dim=-1)
```

Also added a reference to `torch.trapezoid` for full details.

## Testing
- Verified the change is a pure documentation fix (no code logic changed)
- Compared the `trapz` and `trapezoid` signatures to ensure consistency

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof