### PR TITLE
[ROCm][CI] Update permissions in rocm-mi200.yml for build-osdc step

### DIFF
--- a/.github/workflows/rocm-mi200.yml
+++ b/.github/workflows/rocm-mi200.yml
@@ -15,7 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  id-token: write
+  contents: read
+  actions: read
 
 jobs:
   target-determination:


### PR DESCRIPTION
Fixes startup failures like: https://github.com/pytorch/pytorch/actions/runs/24619586312

```
Invalid workflow file: .github/workflows/rocm-mi200.yml#L39
The workflow is not valid. .github/workflows/rocm-mi200.yml (Line: 39, Col: 3): Error calling workflow 'pytorch/pytorch/.github/workflows/_linux-build.yml@81314d9a19c55caf0273a087d76fc0901ffbd0ae'. The nested job 'build-osdc' is requesting 'id-token: write', but is only allowed 'id-token: read'.
```

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang