### PR TITLE
Fix torch.trapz documentation to match torch.trapezoid signature

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13129,9 +13129,21 @@ Examples::
 add_docstr(
     torch.trapz,
     r"""
-trapz(y, x, *, dim=-1) -> Tensor
+trapz(y, x=None, *, dx=None, dim=-1) -> Tensor
 
 Alias for :func:`torch.trapezoid`.
+
+For more details, please read :func:`torch.trapezoid`.
+
+Arguments:
+    y (Tensor): Values to use when computing the trapezoidal rule.
+    x (Tensor): If specified, defines spacing between values as specified above.
+
+Keyword arguments:
+    dx (float): constant spacing between values. If neither :attr:`x` or :attr:`dx`
+        are specified then this defaults to 1. Effectively multiplies the result by its value.
+    dim (int): The dimension along which to compute the trapezoidal rule.
+        The last (inner-most) dimension by default.
 """,
 )
 


### PR DESCRIPTION
Good day

## Description

This PR fixes issue #71392, which reported that the documentation signature for `torch.trapz` does not match its actual implementation or the signature of its alias target `torch.trapezoid`.

### The Problem

The `torch.trapz` docstring stated:
```
trapz(y, x, *, dim=-1)
```

But `torch.trapezoid` actually has:
```
trapezoid(y, x=None, *, dx=None, dim=-1)
```

The `trapz` docstring was missing the `x=None`, `dx=None` parameters and the corresponding documentation sections.

### The Fix

This PR updates the `torch.trapz` docstring to:
1. Correct the signature to `trapz(y, x=None, *, dx=None, dim=-1)`
2. Add the same `Arguments` and `Keyword arguments` sections as `torch.trapezoid`
3. Add a reference to `torch.trapezoid` for full usage details

### Testing

The fix was verified by cross-referencing the actual `torch.trapezoid` documentation and the `torch/overrides.py` file which defines the `trapz` lambda with signature `lambda y, x=None, dim=-1: -1`.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof