### PR TITLE
[ROCm] Remove dead TORCH_HIP_VERSION guards

### DIFF
--- a/aten/src/ATen/cuda/nvrtc_stub/ATenNVRTC.h
+++ b/aten/src/ATen/cuda/nvrtc_stub/ATenNVRTC.h
@@ -97,18 +97,6 @@ namespace at::cuda {
 //
 // The macro below strips out certain unsupported operations on HIP from the full
 // list above.
-//
-// HIP doesn't have
-//   cuGetErrorString  (maps to non-functional hipGetErrorString___)
-//
-// HIP from ROCm 3.5 on renamed hipOccupancyMaxActiveBlocksPerMultiprocessor
-// to hipModuleOccupancyMaxActiveBlocksPerMultiprocessor.
-#if TORCH_HIP_VERSION < 305
-#define HIPOCCUPANCYMAXACTIVEBLOCKSPERMULTIPROCESSOR hipOccupancyMaxActiveBlocksPerMultiprocessor
-#else
-#define HIPOCCUPANCYMAXACTIVEBLOCKSPERMULTIPROCESSOR cuOccupancyMaxActiveBlocksPerMultiprocessor
-#endif
-
 #define AT_FORALL_NVRTC(_)                        \
   _(nvrtcVersion)                                 \
   _(nvrtcCreateProgram)                           \
@@ -120,7 +108,7 @@ namespace at::cuda {
   _(cuModuleLoad)                                 \
   _(cuGetErrorString)                             \
   _(cuModuleGetFunction)                          \
-  _(HIPOCCUPANCYMAXACTIVEBLOCKSPERMULTIPROCESSOR) \
+  _(cuOccupancyMaxActiveBlocksPerMultiprocessor)  \
   _(nvrtcGetErrorString)                          \
   _(nvrtcGetProgramLogSize)                       \
   _(nvrtcGetProgramLog)                           \

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -7,12 +7,8 @@
 #include <optional>
 #include <vector>
 
-// NCCL BFloat16 is enabled only for CUDA 11+ and NCCL versions 2.10+, or for
-// HIP 3.1+
-#if defined(__CUDA_BF16_TYPES_EXIST__)
-#define HAS_NCCL_BF16_DATATYPE \
-  ((NCCL_MAJOR > 2) || (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
-#elif defined(USE_ROCM) && (TORCH_HIP_VERSION >= 301)
+// NCCL BFloat16 is enabled on CUDA (via cuda_bf16.h) and HIP builds.
+#if defined(__CUDA_BF16_TYPES_EXIST__) || defined(USE_ROCM)
 #define HAS_NCCL_BF16_DATATYPE 1
 #else
 #define HAS_NCCL_BF16_DATATYPE 0

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -8,10 +8,10 @@
 #include <vector>
 
 // NCCL BFloat16 is enabled for CUDA builds where the bf16 type exists and NCCL
-// is present (NCCL is required to be 2.23+), or for HIP 3.1+
+// is present (NCCL is required to be 2.23+), or on HIP builds.
 #if defined(__CUDA_BF16_TYPES_EXIST__)
 #define HAS_NCCL_BF16_DATATYPE (NCCL_MAJOR >= 2)
-#elif defined(USE_ROCM) && (TORCH_HIP_VERSION >= 301)
+#elif defined(USE_ROCM)
 #define HAS_NCCL_BF16_DATATYPE 1
 #else
 #define HAS_NCCL_BF16_DATATYPE 0


### PR DESCRIPTION
TORCH_HIP_VERSION is defined by cmake as HIP major*100+minor (currently 7xx), so `< 305` in ATenNVRTC.h and `>= 301` in nccl.h always resolve to the modern branch; hardcode it. The surviving `cuOccupancyMaxActiveBlocksPerMultiprocessor` entry hipifies to `hipModuleOccupancyMaxActiveBlocksPerMultiprocessor`, same as before. `HAS_NCCL_BF16_DATATYPE` is now unconditionally 1 on ROCm, which RCCL has long supported.

Side benefit: cpp_extension.py never defines TORCH_HIP_VERSION, so extension TUs saw 0 and took the legacy branches, diverging from libtorch. Removing the guards makes them agree. Still-live guards (e.g. `>= 702` in BFloat16.h) are untouched.

Test plan: no in-tree behavior change; covered by ROCm CI build/test lanes.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang