### PR TITLE
[dynamo] Unwrap tl.constexpr objects in triton kernel args

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -2748,6 +2748,32 @@ def forward(self, arg0_1, arg1_1):
         self.assertEqual(expected, actual)
 
     @requires_gpu
+    def test_triton_kernel_constexpr_arg(self):
+        @triton.jit
+        def kernel(in_ptr, out_ptr, n, MODE: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+            pid = tl.program_id(0)
+            offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n
+            x = tl.load(in_ptr + offsets, mask=mask)
+            if MODE == 0:
+                out = tl.abs(x)
+            else:
+                out = x * x
+            tl.store(out_ptr + offsets, out, mask=mask)
+
+        def fn(x):
+            out = torch.empty_like(x)
+            n = x.numel()
+            grid = (triton.cdiv(n, 1024),)
+            kernel[grid](x, out, n, MODE=CONSTANT_C, BLOCK_SIZE=1024)
+            return out
+
+        x = torch.randn(2048, device=GPU_TYPE)
+        expected = fn(x)
+        actual = torch.compile(fn, fullgraph=True)(x)
+        self.assertEqual(expected, actual)
+
+    @requires_gpu
     @unittest.skipIf(
         not triton_version_uses_attrs_dict(),
         "Test is only valid for new triton versions where attrs is represented by a raw dict",

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3182,6 +3182,19 @@ class DynamoTritonHOPifier(TritonHOPifier):
                 tma_descriptor_metadata[k] = v.to_metadata()
                 combined_args[k] = v.get_tensor()
 
+        # Unwrap tl.constexpr wrapper objects to their underlying values
+        try:
+            from triton.language.core import constexpr as tl_constexpr
+
+            for k, v in combined_args.items():
+                if (
+                    isinstance(v, variables.UserDefinedObjectVariable)
+                    and isinstance(v.value, tl_constexpr)
+                ):
+                    combined_args[k] = variables.ConstantVariable.create(v.value.value)
+        except ImportError:
+            pass
+
         combined_args_vt = {
             VariableTracker.build(tx, k): v for k, v in combined_args.items()
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180759
* #180628
* #180631

When a module-level constant is defined as `tl.constexpr(value)` and
passed to a triton kernel, dynamo sees a UserDefinedObjectVariable
wrapping the constexpr and fails because it's neither a tensor nor a
symnode. Unwrap these to ConstantVariable in DynamoTritonHOPifier.call_HOP,
following the same pattern used for TMA descriptor unwrapping.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98