### PR TITLE
[dynamo] Skip pybind11 enum tests when distributed is unavailable

### DIFF
--- a/test/dynamo/test_enum.py
+++ b/test/dynamo/test_enum.py
@@ -569,6 +569,10 @@ class EnumTests(torch._dynamo.test_case.TestCase):
         res = compiled_fn(x, 1)
         self.assertEqual(ref, res)
 
+    @unittest.skipIf(
+        not torch.distributed.is_available(),
+        "torch.distributed not available",
+    )
     def test_pybind11_enum_as_dict_key(self):
         """Test pybind11 enum (RedOpType) works as dict key without graph break."""
         import torch.distributed as dist
@@ -590,6 +594,10 @@ class EnumTests(torch._dynamo.test_case.TestCase):
             res = opt_fn(x, op)
             self.assertEqual(ref, res)
 
+    @unittest.skipIf(
+        not torch.distributed.is_available(),
+        "torch.distributed not available",
+    )
     def test_pybind11_enum_equality(self):
         """Test pybind11 enum comparison without graph break."""
         import torch.distributed as dist
@@ -612,6 +620,10 @@ class EnumTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x, dist.ReduceOp.PREMUL_SUM)
         self.assertEqual(ref, res)
 
+    @unittest.skipIf(
+        not torch.distributed.is_available(),
+        "torch.distributed not available",
+    )
     def test_pybind11_enum_identity(self):
         """Test pybind11 enum identity check without graph break."""
         import torch.distributed as dist


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180760
* #180759
* #180628
* #180631

The pybind11 enum tests use torch.distributed.ReduceOp which isn't
available on all platforms (e.g., macOS). Skip them when distributed
is not available.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98