### PR TITLE
cpp_extension: add CUDA dlink flags to JIT load APIs

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -119,6 +119,27 @@ class TestCppExtensionJIT(common.TestCase):
         # 2 * sigmoid(0) = 2 * 0.5 = 1
         self.assertEqual(z, torch.ones_like(z))
 
+    @common.skipIfRocm
+    @unittest.skipIf(IS_WINDOWS, "Windows not supported")
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_jit_cuda_extension_dlink(self):
+        module = torch.utils.cpp_extension.load(
+            name="torch_test_cuda_extension_dlink_jit",
+            sources=[
+                "cpp_extensions/cuda_dlink_extension.cpp",
+                "cpp_extensions/cuda_dlink_extension_kernel.cu",
+                "cpp_extensions/cuda_dlink_extension_add.cu",
+            ],
+            extra_cuda_cflags=["-O2", "-dc"],
+            extra_cuda_dlink_cflags=[],
+            verbose=True,
+            keep_intermediates=False,
+        )
+
+        a = torch.randn(8, dtype=torch.float, device="cuda")
+        b = torch.randn(8, dtype=torch.float, device="cuda")
+        self.assertEqual(module.add(a, b), a + b)
+
     def _test_jit_xpu_extension(self, extra_sycl_cflags):
         # randomizing extension name and names of extension methods
         # for the case when we test building few extensions in a row

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1710,6 +1710,7 @@ def load(name,
          sources: str | list[str],
          extra_cflags=None,
          extra_cuda_cflags=None,
+         extra_cuda_dlink_cflags=None,
          extra_sycl_cflags=None,
          extra_ldflags=None,
          extra_include_paths=None,
@@ -1754,6 +1755,10 @@ def load(name,
     heuristics for finding the CUDA install directory are used, which usually
     work fine. If not, setting the ``CUDA_HOME`` environment variable is the
     safest option.
+    When a CUDA extension requires an explicit device link step, passing
+    ``extra_cuda_dlink_cflags`` (including an empty list) will enable that
+    step and forward any additional flags to the corresponding ``nvcc``
+    invocation.
 
     SYCL support with mixed compilation is provided. Simply pass SYCL source
     files (``.sycl``) along with other sources. Such files will be detected
@@ -1770,6 +1775,9 @@ def load(name,
         extra_cflags: optional list of compiler flags to forward to the build.
         extra_cuda_cflags: optional list of compiler flags to forward to nvcc
             when building CUDA sources.
+        extra_cuda_dlink_cflags: optional list of compiler flags to forward to
+            nvcc when device-linking CUDA sources. Passing an empty list
+            enables the device link step with default flags.
         extra_sycl_cflags: optional list of compiler flags to forward to SYCL
             compiler when building SYCL sources.
         extra_ldflags: optional list of linker flags to forward to the build.
@@ -1820,6 +1828,7 @@ def load(name,
         [sources] if isinstance(sources, str) else sources,
         extra_cflags,
         extra_cuda_cflags,
+        extra_cuda_dlink_cflags,
         extra_sycl_cflags,
         extra_ldflags,
         extra_include_paths,
@@ -1993,6 +2002,7 @@ def load_inline(name,
                 functions=None,
                 extra_cflags=None,
                 extra_cuda_cflags=None,
+                extra_cuda_dlink_cflags=None,
                 extra_sycl_cflags=None,
                 extra_ldflags=None,
                 extra_include_paths=None,
@@ -2058,6 +2068,8 @@ def load_inline(name,
         functions: A list of function names for which to generate function
             bindings. If a dictionary is given, it should map function names to
             docstrings (which are otherwise just the function names).
+        extra_cuda_dlink_cflags: See :func:`load`. When provided, enables a
+            CUDA device link step for the JIT build.
         with_cuda: Determines whether CUDA headers and libraries are added to
             the build. If set to ``None`` (default), this value is
             automatically determined based on whether ``cuda_sources`` is
@@ -2176,6 +2188,7 @@ def load_inline(name,
         sources,
         extra_cflags,
         extra_cuda_cflags,
+        extra_cuda_dlink_cflags,
         extra_sycl_cflags,
         extra_ldflags,
         extra_include_paths,
@@ -2192,6 +2205,7 @@ def _jit_compile(name,
                  sources,
                  extra_cflags,
                  extra_cuda_cflags,
+                 extra_cuda_dlink_cflags,
                  extra_sycl_cflags,
                  extra_ldflags,
                  extra_include_paths,
@@ -2218,7 +2232,7 @@ def _jit_compile(name,
     version = JIT_EXTENSION_VERSIONER.bump_version_if_changed(
         name,
         sources,
-        build_arguments=[extra_cflags, extra_cuda_cflags, extra_ldflags, extra_include_paths],
+        build_arguments=[extra_cflags, extra_cuda_cflags, extra_cuda_dlink_cflags, extra_ldflags, extra_include_paths],
         build_directory=build_directory,
         with_cuda=with_cuda,
         with_sycl=with_sycl,
@@ -2273,6 +2287,7 @@ def _jit_compile(name,
                         sources=sources,
                         extra_cflags=extra_cflags or [],
                         extra_cuda_cflags=extra_cuda_cflags or [],
+                        extra_cuda_dlink_cflags=extra_cuda_dlink_cflags,
                         extra_sycl_cflags=extra_sycl_cflags or [],
                         extra_ldflags=extra_ldflags or [],
                         extra_include_paths=extra_include_paths or [],
@@ -2374,6 +2389,7 @@ def _write_ninja_file_and_build_library(
         sources: list[str],
         extra_cflags,
         extra_cuda_cflags,
+        extra_cuda_dlink_cflags,
         extra_sycl_cflags,
         extra_ldflags,
         extra_include_paths,
@@ -2420,6 +2436,7 @@ def _write_ninja_file_and_build_library(
         sources=sources,
         extra_cflags=extra_cflags or [],
         extra_cuda_cflags=extra_cuda_cflags or [],
+        extra_cuda_dlink_cflags=extra_cuda_dlink_cflags,
         extra_sycl_cflags=extra_sycl_cflags or [],
         extra_ldflags=extra_ldflags or [],
         extra_include_paths=extra_include_paths or [],
@@ -2449,6 +2466,36 @@ def verify_ninja_availability() -> None:
     """Raise ``RuntimeError`` if `ninja <https://ninja-build.org/>`_ build system is not available on the system, does nothing otherwise."""
     if not is_ninja_available():
         raise RuntimeError("Ninja is required to load C++ extensions (pip install ninja to get it)")
+
+
+def _prepare_jit_cuda_dlink_flags(extra_cuda_cflags, extra_cuda_dlink_cflags):
+    if extra_cuda_dlink_cflags is None:
+        return None
+    if IS_HIP_EXTENSION:
+        raise RuntimeError("extra_cuda_dlink_cflags is only supported for CUDA builds")
+
+    cuda_dlink_flags = list(extra_cuda_dlink_cflags)
+    if '-dlink' not in cuda_dlink_flags:
+        cuda_dlink_flags.insert(0, '-dlink')
+
+    if IS_WINDOWS:
+        return COMMON_NVCC_FLAGS + cuda_dlink_flags + _get_cuda_arch_flags(extra_cuda_cflags)
+
+    cuda_dlink_flags = (
+        COMMON_NVCC_FLAGS +
+        ['--compiler-options', "'-fPIC'"] +
+        cuda_dlink_flags +
+        _get_cuda_arch_flags(extra_cuda_cflags)
+    )
+
+    cc_env = os.getenv("CC")
+    if (
+        cc_env is not None
+        and not any(flag.startswith(('-ccbin', '--compiler-bindir')) for flag in cuda_dlink_flags)
+    ):
+        cuda_dlink_flags.extend(['-ccbin', cc_env])
+
+    return cuda_dlink_flags
 
 
 def _prepare_ldflags(extra_ldflags, with_cuda, with_sycl, verbose, is_standalone):
@@ -2832,6 +2879,7 @@ def _write_ninja_file_to_build_library(path,
                                        sources,
                                        extra_cflags,
                                        extra_cuda_cflags,
+                                       extra_cuda_dlink_cflags,
                                        extra_sycl_cflags,
                                        extra_ldflags,
                                        extra_include_paths,
@@ -2840,6 +2888,8 @@ def _write_ninja_file_to_build_library(path,
                                        is_standalone) -> None:
     extra_cflags = [flag.strip() for flag in extra_cflags]
     extra_cuda_cflags = [flag.strip() for flag in extra_cuda_cflags]
+    if extra_cuda_dlink_cflags is not None:
+        extra_cuda_dlink_cflags = [flag.strip() for flag in extra_cuda_dlink_cflags]
     extra_sycl_cflags = [flag.strip() for flag in extra_sycl_cflags]
     extra_ldflags = [flag.strip() for flag in extra_ldflags]
     extra_include_paths = [flag.strip() for flag in extra_include_paths]
@@ -2911,6 +2961,8 @@ def _write_ninja_file_to_build_library(path,
     else:
         cuda_flags = None
 
+    cuda_dlink_flags = _prepare_jit_cuda_dlink_flags(extra_cuda_cflags, extra_cuda_dlink_cflags)
+
     if with_sycl:
         sycl_cflags = cflags + _COMMON_SYCL_FLAGS
         sycl_cflags += extra_sycl_cflags
@@ -2960,7 +3012,7 @@ def _write_ninja_file_to_build_library(path,
         post_cflags=None,
         cuda_cflags=cuda_flags,
         cuda_post_cflags=None,
-        cuda_dlink_post_cflags=None,
+        cuda_dlink_post_cflags=cuda_dlink_flags,
         sycl_cflags=sycl_cflags,
         sycl_post_cflags=[],
         sycl_dlink_post_cflags=sycl_dlink_post_cflags,


### PR DESCRIPTION
## Summary

This PR adds an opt-in CUDA device-link path for JIT cpp extension builds.

Today, `torch.utils.cpp_extension.CUDAExtension` supports RDC/device-link workflows, but `torch.utils.cpp_extension.load()` and `load_inline()` do not expose an equivalent capability. This change adds a JIT-side API for forwarding CUDA device-link flags through the ninja generation path.

## Changes

- add `extra_cuda_dlink_cflags` to `torch.utils.cpp_extension.load()`
- add `extra_cuda_dlink_cflags` to `torch.utils.cpp_extension.load_inline()`
- include the new argument in JIT extension versioning
- plumb CUDA device-link flags through the JIT ninja build path
- add a JIT test for a multi-CU CUDA extension that requires a device-link step

## Notes

- this is intentionally opt-in, so existing JIT extension behavior remains unchanged by default
- the device-link arch flags follow `extra_cuda_cflags` so compile and dlink steps use consistent CUDA arch semantics
- this is a lower-level flags-based API, analogous to the existing `nvcc_dlink` pathway in `CUDAExtension`

## Why draft

I wanted feedback on whether the JIT-side API should stay as a low-level flags entry point (`extra_cuda_dlink_cflags`) or be reshaped into a higher-level `dlink=True` style API in a follow-up.

## Related

Refs pytorch/pytorch#180762