### PR TITLE
[inductor][autotuning] add CUDA event resolver (#180765)

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -1552,6 +1552,7 @@ exclusions = {
     "loop_tiling",
     "auto_chunker",
     "autotuning",
+    "incremental",
     "graph_region_expansion",
     "hierarchical_compile",
     "compute_dependencies",

--- a/test/inductor/test_incremental_autotune.py
+++ b/test/inductor/test_incremental_autotune.py
@@ -1,0 +1,104 @@
+# Owner(s): ["module: inductor"]
+
+import queue
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+from torch._inductor.test_case import run_tests, TestCase
+
+
+def _wait_until(predicate, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class ResolverTest(TestCase):
+    def setUp(self):
+        from torch._inductor.runtime.incremental import _resolver
+
+        self._resolver = _resolver
+        # Short idle timeout so the daemon exits quickly between tests.
+        self._timeout_patcher = patch.object(_resolver, "_IDLE_TIMEOUT_S", 0.05)
+        self._timeout_patcher.start()
+        _wait_until(self._daemon_stopped, timeout=10.0)
+
+    def tearDown(self):
+        while not self._resolver._global_event_queue.empty():
+            try:
+                self._resolver._global_event_queue.get_nowait()
+            except queue.Empty:
+                break
+        _wait_until(self._daemon_stopped, timeout=10.0)
+        self._timeout_patcher.stop()
+
+    def _daemon_stopped(self) -> bool:
+        with self._resolver._global_resolver_lock:
+            return self._resolver._global_resolver_thread is None
+
+    def test_submit_event_puts_then_ensures_daemon(self):
+        """Put-then-ensure ordering: item is visible when daemon checks empty()."""
+        with (
+            patch.object(self._resolver, "_ensure_daemon") as mock_ensure,
+            patch.object(self._resolver._global_event_queue, "put") as mock_put,
+        ):
+            call_order = []
+            mock_put.side_effect = lambda *a, **k: call_order.append("put")
+            mock_ensure.side_effect = lambda: call_order.append("ensure")
+
+            self._resolver.submit_event(MagicMock(), MagicMock(), MagicMock())
+
+        self.assertEqual(call_order, ["put", "ensure"])
+
+    def test_daemon_processes_event_and_invokes_callback(self):
+        """Submitted events are synchronized and the callback receives elapsed_ms."""
+        done = threading.Event()
+        received: list[float] = []
+
+        def callback(elapsed_ms: float) -> None:
+            received.append(elapsed_ms)
+            done.set()
+
+        start_event = MagicMock()
+        end_event = MagicMock()
+        start_event.elapsed_time.return_value = 42.0
+
+        self._resolver.submit_event(callback, start_event, end_event)
+
+        self.assertTrue(done.wait(timeout=5.0))
+        self.assertEqual(received, [42.0])
+        end_event.synchronize.assert_called_once()
+        start_event.elapsed_time.assert_called_once_with(end_event)
+
+    def test_daemon_idles_out_after_processing(self):
+        """After processing all events, the daemon exits and clears the global slot."""
+        done = threading.Event()
+        start_event = MagicMock()
+        start_event.elapsed_time.return_value = 1.0
+        self._resolver.submit_event(lambda _: done.set(), start_event, MagicMock())
+        self.assertTrue(done.wait(timeout=5.0))
+
+        self.assertTrue(_wait_until(self._daemon_stopped, timeout=5.0))
+
+    def test_daemon_restarts_after_idle_exit(self):
+        """A second submit_event after idle-out is processed by a fresh daemon."""
+        done1 = threading.Event()
+        ev_a = MagicMock()
+        ev_a.elapsed_time.return_value = 1.0
+        self._resolver.submit_event(lambda _: done1.set(), ev_a, MagicMock())
+        self.assertTrue(done1.wait(timeout=5.0))
+        self.assertTrue(_wait_until(self._daemon_stopped, timeout=5.0))
+
+        done2 = threading.Event()
+        ev_b = MagicMock()
+        ev_b.elapsed_time.return_value = 2.0
+        self._resolver.submit_event(lambda _: done2.set(), ev_b, MagicMock())
+        self.assertTrue(done2.wait(timeout=5.0))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -47,6 +47,8 @@ from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
     autotune_hints_to_configs,
     CachingAutotuner,
+    CachingAutotunerPlugin,
+    DEFER,
     template,
     triton_config,
 )
@@ -302,6 +304,100 @@ class TestTritonHeuristics(TestCase):
                 config_heuristic.get_mm_configs()(3, 3, 3, dtype_size=4, op_name="mm")
             )
             self.assertEqual(len(configs), expected_count)
+
+
+_PLUGIN_FACTORY_PATH = (
+    "torch._inductor.runtime.triton_heuristics.get_caching_autotuner_plugins"
+)
+
+
+class TestCachingAutotunerPlugin(TestCase):
+    device_type = GPU_TYPE
+
+    @staticmethod
+    def _make_kernel_inputs():
+        in_ptr = torch.zeros(16, device=GPU_TYPE, dtype=torch.float32)
+        out_ptr = torch.zeros(16, device=GPU_TYPE, dtype=torch.float32)
+        return (in_ptr, out_ptr, 16)
+
+    def _make_autotuner(self, plugins, configs=None):
+        args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
+        args["inductor_meta"] = {**args["inductor_meta"], "grid_type": "Grid1D"}
+        if configs is not None:
+            args["configs"] = configs
+        with patch(_PLUGIN_FACTORY_PATH, return_value=list(plugins)):
+            return CachingAutotuner(**args)
+
+    def test_pre_dispatch_runs_before_precompile_and_autotune(self):
+        sentinel = object()
+
+        class _Plugin(CachingAutotunerPlugin):
+            def pre_dispatch(self, autotuner, *args, stream, **kwargs):
+                return sentinel
+
+        autotuner = self._make_autotuner([_Plugin()])
+        with (
+            patch.object(autotuner, "precompile") as mock_precompile,
+            patch.object(autotuner, "autotune_to_one_config") as mock_autotune,
+        ):
+            result = autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertIs(result, sentinel)
+        mock_precompile.assert_not_called()
+        mock_autotune.assert_not_called()
+
+    def test_pre_autotune_runs_before_default_autotune(self):
+        sentinel = object()
+
+        class _Plugin(CachingAutotunerPlugin):
+            def pre_autotune(self, autotuner, *args, stream, **kwargs):
+                return sentinel
+
+        autotuner = self._make_autotuner([_Plugin()])
+        with patch.object(autotuner, "autotune_to_one_config") as mock_autotune:
+            result = autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertIs(result, sentinel)
+        mock_autotune.assert_not_called()
+
+    def test_hooks_fire_in_registration_order(self):
+        sentinel = object()
+        seen = []
+
+        class _Plugin(CachingAutotunerPlugin):
+            def __init__(self, name, return_value=DEFER):
+                self.name = name
+                self.return_value = return_value
+
+            def pre_dispatch(self, autotuner, *args, stream, **kwargs):
+                seen.append(self.name)
+                return self.return_value
+
+        autotuner = self._make_autotuner(
+            [_Plugin("a"), _Plugin("b"), _Plugin("c", sentinel), _Plugin("d")]
+        )
+        result = autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertIs(result, sentinel)
+        self.assertEqual(seen, ["a", "b", "c"])
+
+    def test_defer_falls_through_to_default(self):
+        seen = []
+
+        class _Plugin(CachingAutotunerPlugin):
+            def pre_dispatch(self, autotuner, *args, stream, **kwargs):
+                seen.append("pre_dispatch")
+                return DEFER
+
+        # Single config so precompile produces one launcher and the kernel
+        # runs to completion without the autotune branch firing.
+        full_args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
+        autotuner = self._make_autotuner([_Plugin()], configs=full_args["configs"][:1])
+
+        autotuner.run(*self._make_kernel_inputs(), stream=0)
+
+        self.assertEqual(seen, ["pre_dispatch"])
+        self.assertEqual(len(autotuner.launchers), 1)
 
 
 class TestArgumentCloneAndRestore(TestCase):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -512,6 +512,11 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 # enable slow autotuning passes to select gemm algorithms
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 
+# When True, autotuning is spread across real kernel invocations instead of
+# blocking on the first call. Each run() call executes one config and records
+# timing via CUDA events, progressively eliminating underperforming configs.
+incremental_autotune: bool = os.environ.get("TORCHINDUCTOR_INCREMENTAL_AUTOTUNE") == "1"
+
 inductor_default_autotune_warmup = int(
     os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_WARMUP", 25)
 )

--- a/torch/_inductor/runtime/incremental/_resolver.py
+++ b/torch/_inductor/runtime/incremental/_resolver.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import queue
+import threading
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from ._utils import log
+from .config import _IDLE_TIMEOUT_S
+
+
+if TYPE_CHECKING:
+    import torch
+
+
+TimingCallback = Callable[[float], None]
+
+_QueueItem = tuple[TimingCallback, "torch.cuda.Event", "torch.cuda.Event"]
+
+_global_event_queue: queue.Queue[_QueueItem] = queue.Queue()
+_global_resolver_lock: threading.Lock = threading.Lock()
+_global_resolver_thread: threading.Thread | None = None
+
+
+def submit_event(
+    callback: TimingCallback,
+    start_event: torch.cuda.Event,
+    end_event: torch.cuda.Event,
+) -> None:
+    """Enqueue a CUDA event pair for async timing resolution.
+
+    The daemon synchronizes on ``end_event``, computes elapsed time, and
+    invokes ``callback(elapsed_ms)``. Starts the global resolver daemon
+    if it is not already running.
+    """
+    # Put-then-ensure ordering closes a termination race: if we ensured first
+    # and a daemon was idling out concurrently, it could exit between our
+    # ensure and our put, leaving the item orphaned. Putting first guarantees
+    # the daemon's empty()-check (also under _global_resolver_lock) sees it.
+    _global_event_queue.put((callback, start_event, end_event))
+    _ensure_daemon()
+
+
+def _ensure_daemon() -> None:
+    global _global_resolver_thread
+    with _global_resolver_lock:
+        if _global_resolver_thread is not None:
+            return
+        t = threading.Thread(
+            target=_global_event_resolver_loop,
+            daemon=True,
+            name="autotune-event-resolver",
+        )
+        t.start()
+        _global_resolver_thread = t
+        log.info(
+            "Incremental autotune event resolver started (thread id=%d)",
+            t.ident,
+        )
+
+
+def _global_event_resolver_loop() -> None:
+    global _global_resolver_thread
+
+    while True:
+        try:
+            item = _global_event_queue.get(timeout=_IDLE_TIMEOUT_S)
+        except queue.Empty:
+            # Consumer side of the put-then-ensure race close: a producer may
+            # have called put() between our get() raising Empty and our
+            # acquiring the lock. Re-check empty() under the lock so we don't
+            # exit while an item is sitting in the queue.
+            with _global_resolver_lock:
+                if _global_event_queue.empty():
+                    _global_resolver_thread = None
+                    log.info(
+                        "Incremental autotune event resolver stopped (idle timeout)"
+                    )
+                    return
+                continue
+
+        callback, start_event, end_event = item
+        try:
+            end_event.synchronize()
+            elapsed_ms: float = start_event.elapsed_time(end_event)
+            callback(elapsed_ms)
+        except Exception:
+            # Silently drop. We assume any underlying CUDA fault will
+            # resurface on the main thread's next CUDA op (e.g.
+            # ``torch.cuda.synchronize``) and would rather not surface it
+            # twice from a background thread with no clear ownership.
+            log.debug(
+                "Incremental autotune: timing resolution failed",
+                exc_info=True,
+            )

--- a/torch/_inductor/runtime/incremental/_utils.py
+++ b/torch/_inductor/runtime/incremental/_utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from torch._logging import getArtifactLogger
+
+
+if TYPE_CHECKING:
+    import logging
+
+
+log: logging.Logger = getArtifactLogger(__name__, "incremental")

--- a/torch/_inductor/runtime/incremental/config.py
+++ b/torch/_inductor/runtime/incremental/config.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+# The event resolver daemon exits after this many seconds with no events.
+_IDLE_TIMEOUT_S: int = 600

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -19,7 +19,7 @@ import sys
 import threading
 import time
 from collections import namedtuple
-from typing import Any, Generic, Literal, TYPE_CHECKING, TypeVar
+from typing import Any, Final, Generic, Literal, TYPE_CHECKING, TypeVar
 
 import torch
 from torch._dynamo.utils import counters, set_feature_use
@@ -321,6 +321,51 @@ def check_autotune_cache(
     return configs, autotune_cache, autotune_cache_info
 
 
+# Sentinel returned by plugin hooks to defer to the next plugin or to the
+# default behavior. Tested with ``is DEFER``.
+DEFER: Final[object] = object()
+
+
+class CachingAutotunerPlugin:
+    """Base class for ``CachingAutotuner`` plugins.
+
+    Each hook returns ``DEFER`` to fall through to the next plugin / default
+    behavior, or any other value to short-circuit ``run()`` with that value.
+    """
+
+    def pre_dispatch(
+        self,
+        autotuner: CachingAutotuner,
+        *args: object,
+        stream: object,
+        **kwargs: object,
+    ) -> object:
+        """Fires before kernel dispatch, ahead of precompile or autotune."""
+        return DEFER
+
+    def pre_autotune(
+        self,
+        autotuner: CachingAutotuner,
+        *args: object,
+        stream: object,
+        **kwargs: object,
+    ) -> object:
+        """Fires after precompile when more than one launcher remains, in
+        place of ``autotune_to_one_config()``."""
+        return DEFER
+
+
+def get_caching_autotuner_plugins(
+    autotuner: CachingAutotuner,
+) -> list[CachingAutotunerPlugin]:
+    """Build the list of plugins active for ``autotuner``.
+
+    Each plugin adds an entry here, gated on its own config flag, with
+    imports kept inside the relevant branch.
+    """
+    return []
+
+
 class CachingAutotuner(KernelInterface):
     """
     Simplified version of Triton autotuner that has no invalidation
@@ -438,6 +483,8 @@ class CachingAutotuner(KernelInterface):
 
         self._debug_call: _TritonKernelCall | None = None
         self._profiler_ctx: _RecordFunctionFast | None = None
+
+        self._plugins = get_caching_autotuner_plugins(self)
 
         # Compile-time info included in runtime logginging
         self.compile_id: CompileId | None = None
@@ -741,11 +788,13 @@ class CachingAutotuner(KernelInterface):
         return {
             **self.__dict__,
             "lock": None,
+            "_plugins": [],
         }
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
         self.lock = threading.Lock()
+        self._plugins = get_caching_autotuner_plugins(self)
 
     def get_device_interface(self):
         # this code cannot run in compile workers, because it imports from torch
@@ -1737,13 +1786,28 @@ class CachingAutotuner(KernelInterface):
                 **self.configs[0].kwargs,
             )
 
+        for plugin in self._plugins:
+            if (
+                result := plugin.pre_dispatch(self, *args, stream=stream, **kwargs)
+            ) is not DEFER:
+                return result
+
         if len(self.launchers) != 1:
             if len(self.launchers) == 0:
                 start_time = time.time_ns()
                 self.precompile()
                 self.precompile_time_taken_ns = time.time_ns() - start_time
             if len(self.launchers) > 1:
-                self.autotune_to_one_config(*args, **kwargs)
+                for plugin in self._plugins:
+                    if (
+                        result := plugin.pre_autotune(
+                            self, *args, stream=stream, **kwargs
+                        )
+                    ) is not DEFER:
+                        return result
+                # Re-check: a plugin may have mutated launchers down to one.
+                if len(self.launchers) > 1:
+                    self.autotune_to_one_config(*args, **kwargs)
 
         if self.inductor_meta.get("combo_tuning_groups") and not getattr(
             self.launchers[0].config, "found_by_combo_autotune", False

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -257,6 +257,7 @@ def set_logs(
     cudagraph_static_inputs: bool = False,
     benchmarking: bool = False,
     autotuning: bool = False,
+    incremental: bool = False,
     graph_region_expansion: bool = False,
     inductor_metrics: bool = False,
     hierarchical_compile: bool = False,
@@ -457,6 +458,9 @@ def set_logs(
         autotuning (:class:`bool`):
             Autotuning choice logs, such as kernel source, perf, and tuning parameters. Default: ``False``
 
+        incremental (:class:`bool`):
+            Incremental autotuning logs. Default: ``False``
+
         graph_region_expansion (:class:`bool`):
             Whether to emit the detailed steps of the duplicate graph region tracker expansion algorithm. Default: ``False``
 
@@ -585,6 +589,7 @@ def set_logs(
         cudagraph_static_inputs=cudagraph_static_inputs,
         benchmarking=benchmarking,
         autotuning=autotuning,
+        incremental=incremental,
         graph_region_expansion=graph_region_expansion,
         inductor_metrics=inductor_metrics,
         hierarchical_compile=hierarchical_compile,

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -241,6 +241,11 @@ register_artifact(
     off_by_default=True,
 )
 register_artifact(
+    "incremental",
+    "Incremental autotuning logs.",
+    off_by_default=True,
+)
+register_artifact(
     "node_runtime_estimation",
     "Node runtime estimation for compile-time optimization decisions.",
     off_by_default=True,


### PR DESCRIPTION
Summary:

Introduces the global event resolver daemon, with `submit_event(callback, start_event, end_event)` entrypoint. Calls to `submit_event` ensure that the daemon is started; the daemon times out automatically (after 600s by default) after a period of inactivity, and will restart automatically on future event submission.

We utilize a single queue for all events rather than a per-state (per-CachingAutotuner instance) queue since events are guaranteed to finish in the order they are submitted; which also means we only need to spawn one daemon at a time.

The attached callback serves as a notification mechanism that allows future changes in this stack to process the results of events asynchronously.

Authored with Claude.

Test Plan:
```
buck test fbcode//mode/opt -m ovr_config//triton:beta -c fbcode.platform010_cuda_version=12.8 fbcode//caffe2/test/inductor:incremental_autotune
```

Differential Revision: D101461127




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98