### PR TITLE
[Inductor][FFT] Support f16/bf16 inputs on CUDA/XPU via promotion to float32

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -90,9 +90,14 @@ ScalarType promote_type_fft(ScalarType type, bool require_complex, Device device
   );
   if (maybe_support_half) {
     // XPU has no native float16 or bfloat16 FFT kernel; promote both to float32.
+    // ROCm (hipFFT) has no native bfloat16 FFT kernel; promote to float32.
     // On CUDA, cuFFT handles them natively (see CuFFTPlanCache.h for constraints),
     // so we leave them unchanged here and let the cuFFT planner decide.
     if ((type == kHalf || type == kBFloat16) && device.is_xpu()) {
+      type = kFloat;
+    }
+    // ROCm/hipFFT does not support bfloat16; promote to float32
+    if (type == kBFloat16 && device.is_cuda() && at::globalContext().hasROCM()) {
       type = kFloat;
     }
     TORCH_CHECK(type == kHalf || type == kBFloat16 || type == kFloat || type == kDouble,

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -76,11 +76,6 @@ namespace {
 // * Raises an error for half-precision types on CPU
 ScalarType promote_type_fft(ScalarType type, bool require_complex, Device device) {
   if (at::isComplexType(type)) {
-    // complex32 ("chalf") has no native FFT kernel on CUDA/XPU.
-    // Upcast to complex64 so the downstream kernel can execute.
-    if (type == kComplexHalf) {
-      return kComplexFloat;
-    }
     return type;
   }
   // Promote integral to default float type

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -69,9 +69,18 @@ namespace {
 // Promote inputs to FFT functions
 // * Integers are promoted to the default floating type
 // * If require_complex=True, all types are promoted to complex
-// * Raises an error for half-precision dtypes to allow future support
+// * float16/bfloat16 on XPU: promoted to float32 (no native XPU FFT kernel)
+// * float16 on CUDA: passed through; cuFFT handles natively (SM53+, pow2)
+// * bfloat16 on CUDA: passed through; cuFFT handles natively (SM80+, pow2)
+//   or falls back to float32 promotion for older hardware
+// * Raises an error for half-precision types on CPU
 ScalarType promote_type_fft(ScalarType type, bool require_complex, Device device) {
   if (at::isComplexType(type)) {
+    // complex32 ("chalf") has no native FFT kernel on CUDA/XPU.
+    // Upcast to complex64 so the downstream kernel can execute.
+    if (type == kComplexHalf) {
+      return kComplexFloat;
+    }
     return type;
   }
   // Promote integral to default float type
@@ -85,7 +94,14 @@ ScalarType promote_type_fft(ScalarType type, bool require_complex, Device device
     device.is_cuda() || device.is_meta() || device.is_xpu()
   );
   if (maybe_support_half) {
-    TORCH_CHECK(type == kHalf || type == kFloat || type == kDouble, "Unsupported dtype ", type);
+    // XPU has no native float16 or bfloat16 FFT kernel; promote both to float32.
+    // On CUDA, cuFFT handles them natively (see CuFFTPlanCache.h for constraints),
+    // so we leave them unchanged here and let the cuFFT planner decide.
+    if ((type == kHalf || type == kBFloat16) && device.is_xpu()) {
+      type = kFloat;
+    }
+    TORCH_CHECK(type == kHalf || type == kBFloat16 || type == kFloat || type == kDouble,
+                "Unsupported dtype ", type);
   } else {
     TORCH_CHECK(type == kFloat || type == kDouble, "Unsupported dtype ", type);
   }
@@ -99,6 +115,9 @@ ScalarType promote_type_fft(ScalarType type, bool require_complex, Device device
   case kHalf: return kComplexHalf;
   case kFloat: return kComplexFloat;
   case kDouble: return kComplexDouble;
+  // bfloat16 on CUDA: cuFFT produces CUDA_C_16BF which is upcast to ComplexFloat.
+  // Returning kComplexFloat keeps output-tensor allocation consistent.
+  case kBFloat16: return kComplexFloat;
   default: TORCH_INTERNAL_ASSERT(false, "Unhandled dtype");
   }
 }

--- a/aten/src/ATen/native/cuda/CuFFTPlanCache.h
+++ b/aten/src/ATen/native/cuda/CuFFTPlanCache.h
@@ -310,6 +310,31 @@ public:
       itype = complex_input ? CUDA_C_16F : CUDA_R_16F;
       otype = complex_output ? CUDA_C_16F : CUDA_R_16F;
       exec_type = CUDA_C_16F;
+#if !defined(USE_ROCM)
+    } else if (dtype == ScalarType::BFloat16) {
+      // cuFFT native bfloat16 support: SM_80 (Ampere) or higher required.
+      // Constraints mirror the half-precision path:
+      //   - minimum SM_80 architecture
+      //   - signal sizes must be powers of two
+      //   - strides on the real part of R2C/C2R are not supported (clone enforced below)
+      // Not available on ROCm/hipFFT — bfloat16 is promoted to float32 upstream.
+      // See: https://docs.nvidia.com/cuda/cufft/ section 2.3.2
+      auto dev_prop = at::cuda::getCurrentDeviceProperties();
+      TORCH_CHECK(dev_prop->major >= 8,
+          "cuFFT doesn't support bfloat16 with compute capability less than SM_80, "
+          "but the device containing input bfloat16 tensor only has SM_",
+          dev_prop->major, dev_prop->minor);
+      for (const auto i : c10::irange(signal_ndim)) {
+        TORCH_CHECK(is_pow_of_two(sizes[i + 1]),
+            "cuFFT only supports dimensions whose sizes are powers of two when "
+            "computing in bfloat16 precision, but got a signal size of",
+            sizes.slice(1));
+      }
+      clone_input |= in_strides.back() != 1;
+      itype = complex_input ? CUDA_C_16BF : CUDA_R_16BF;
+      otype = complex_output ? CUDA_C_16BF : CUDA_R_16BF;
+      exec_type = CUDA_C_16BF;
+#endif // !defined(USE_ROCM)
     } else {
       TORCH_CHECK(false, "cuFFT doesn't support tensor of type: ", dtype);
     }

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -22,6 +22,8 @@
 #include <ATen/ops/_fft_r2c_native.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/mul.h>
+#include <ATen/ops/view_as_complex.h>
+#include <ATen/ops/view_as_real.h>
 #endif
 
 #include <cufft.h>
@@ -317,6 +319,76 @@ bool use_optimized_cufft_path(IntArrayRef dim) {
 // n-dimensional real to complex FFT
 Tensor _fft_r2c_cufft(const Tensor& self, IntArrayRef dim, int64_t normalization, bool onesided) {
   TORCH_CHECK(self.is_floating_point());
+
+  // Bfloat16 FFT path.
+  //
+  // On CUDA SM_80+ (Ampere): cuFFT supports CUDA_R_16BF → CUDA_C_16BF natively.
+  // PyTorch has no ComplexBFloat16 type, so we allocate a ComplexHalf proxy
+  // buffer (same 4-byte element size as CUDA_C_16BF), let cuFFT write into it,
+  // then reinterpret and upcast to ComplexFloat.
+  // The multi-dim non-optimised path is excluded because subsequent C2C steps
+  // would use the wrong CUDA_C_16F plan via the ComplexHalf proxy dtype.
+  //
+  // On ROCm and pre-SM80 CUDA: no native bfloat16 kernel available;
+  // fall back to float32 promotion.
+  if (self.scalar_type() == ScalarType::BFloat16) {
+#if !defined(USE_ROCM)
+    auto dev_prop = at::cuda::getCurrentDeviceProperties();
+    if (dev_prop->major >= 8 && use_optimized_cufft_path(dim)) {
+      auto input_sizes = self.sizes();
+      DimVector onesided_sizes(input_sizes.begin(), input_sizes.end());
+      auto last_dim = dim.back();
+      auto last_dim_halfsize = (input_sizes[last_dim]) / 2 + 1;
+      onesided_sizes[last_dim] = last_dim_halfsize;
+
+      // proxy: ComplexHalf has the same element byte size as CUDA_C_16BF (4 bytes).
+      // CuFFTConfig sees value_type=BFloat16 from the *input* and plans
+      // CUDA_R_16BF → CUDA_C_16BF accordingly.
+      auto proxy = at::empty(onesided_sizes, self.options().dtype(kComplexHalf));
+
+      // R2C requires real input to be over-aligned (same rule as float path).
+      const auto complex_size = 2 * self.element_size();
+      const bool complex_aligned =
+          (reinterpret_cast<std::uintptr_t>(self.const_data_ptr()) % complex_size == 0);
+      auto working_tensor = self;
+      if (!complex_aligned) {
+        working_tensor = self.movedim(last_dim, -1)
+                             .clone(MemoryFormat::Contiguous)
+                             .movedim(-1, last_dim);
+      }
+
+      _exec_fft(proxy, working_tensor, onesided_sizes, dim, /*forward=*/true);
+
+      // Convert CUDA_C_16BF bytes (stored in the ComplexHalf proxy) to ComplexFloat:
+      //   view_as_real    → Half tensor    [..., 2]  (bits are actually bfloat16)
+      //   .view(BFloat16) → BFloat16 tensor [..., 2]  (correct bit interpretation)
+      //   .to(Float)      → Float tensor   [..., 2]  (bf16 → f32)
+      //   view_as_complex → ComplexFloat tensor [...]
+      auto output = at::view_as_complex(
+          at::view_as_real(proxy)
+              .view(ScalarType::BFloat16)
+              .to(ScalarType::Float));
+
+      auto out_slice = output.slice(last_dim, 0, last_dim_halfsize);
+      _fft_apply_normalization(out_slice, normalization, input_sizes, dim);
+
+      if (!onesided) {
+        IntArrayRef out_sizes = input_sizes;
+        if (output.sizes()[last_dim] != out_sizes[last_dim]) {
+          auto twosided = at::empty(out_sizes, output.options());
+          twosided.slice(last_dim, 0, last_dim_halfsize).copy_(output);
+          output = std::move(twosided);
+        }
+        at::native::_fft_fill_with_conjugate_symmetry_(output, dim);
+      }
+      return output;
+    }
+#endif // !defined(USE_ROCM)
+    // Fallback: ROCm, pre-SM80 CUDA, or multi-dim non-optimised path.
+    // Promote bfloat16 → float32 and re-enter.
+    return _fft_r2c_cufft(self.to(ScalarType::Float), dim, normalization, onesided);
+  }
+
   auto input_sizes = self.sizes();
   DimVector onesided_sizes(input_sizes.begin(), input_sizes.end());
   auto last_dim = dim.back();

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -334,8 +334,17 @@ Tensor _fft_r2c_cufft(const Tensor& self, IntArrayRef dim, int64_t normalization
   if (self.scalar_type() == ScalarType::BFloat16) {
 #if !defined(USE_ROCM)
     auto dev_prop = at::cuda::getCurrentDeviceProperties();
-    if (dev_prop->major >= 8 && use_optimized_cufft_path(dim)) {
-      auto input_sizes = self.sizes();
+    auto input_sizes = self.sizes();
+    // Native bfloat16 cuFFT path requires all signal dims to be powers of two.
+    // If any dim is not pow2, fall through to the float32 promotion fallback below.
+    bool bf16_all_pow2 = true;
+    for (const auto d : dim) {
+      if (!is_pow_of_two(input_sizes[d])) {
+        bf16_all_pow2 = false;
+        break;
+      }
+    }
+    if (dev_prop->major >= 8 && use_optimized_cufft_path(dim) && bf16_all_pow2) {
       DimVector onesided_sizes(input_sizes.begin(), input_sizes.end());
       auto last_dim = dim.back();
       auto last_dim_halfsize = (input_sizes[last_dim]) / 2 + 1;

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -317,6 +317,76 @@ bool use_optimized_cufft_path(IntArrayRef dim) {
 // n-dimensional real to complex FFT
 Tensor _fft_r2c_cufft(const Tensor& self, IntArrayRef dim, int64_t normalization, bool onesided) {
   TORCH_CHECK(self.is_floating_point());
+
+  // Bfloat16 FFT path.
+  //
+  // On CUDA SM_80+ (Ampere): cuFFT supports CUDA_R_16BF → CUDA_C_16BF natively.
+  // PyTorch has no ComplexBFloat16 type, so we allocate a ComplexHalf proxy
+  // buffer (same 4-byte element size as CUDA_C_16BF), let cuFFT write into it,
+  // then reinterpret and upcast to ComplexFloat.
+  // The multi-dim non-optimised path is excluded because subsequent C2C steps
+  // would use the wrong CUDA_C_16F plan via the ComplexHalf proxy dtype.
+  //
+  // On ROCm and pre-SM80 CUDA: no native bfloat16 kernel available;
+  // fall back to float32 promotion.
+  if (self.scalar_type() == ScalarType::BFloat16) {
+#if !defined(USE_ROCM)
+    auto dev_prop = at::cuda::getCurrentDeviceProperties();
+    if (dev_prop->major >= 8 && use_optimized_cufft_path(dim)) {
+      auto input_sizes = self.sizes();
+      DimVector onesided_sizes(input_sizes.begin(), input_sizes.end());
+      auto last_dim = dim.back();
+      auto last_dim_halfsize = (input_sizes[last_dim]) / 2 + 1;
+      onesided_sizes[last_dim] = last_dim_halfsize;
+
+      // proxy: ComplexHalf has the same element byte size as CUDA_C_16BF (4 bytes).
+      // CuFFTConfig sees value_type=BFloat16 from the *input* and plans
+      // CUDA_R_16BF → CUDA_C_16BF accordingly.
+      auto proxy = at::empty(onesided_sizes, self.options().dtype(kComplexHalf));
+
+      // R2C requires real input to be over-aligned (same rule as float path).
+      const auto complex_size = 2 * self.element_size();
+      const bool complex_aligned =
+          (reinterpret_cast<std::uintptr_t>(self.const_data_ptr()) % complex_size == 0);
+      auto working_tensor = self;
+      if (!complex_aligned) {
+        working_tensor = self.movedim(last_dim, -1)
+                             .clone(MemoryFormat::Contiguous)
+                             .movedim(-1, last_dim);
+      }
+
+      _exec_fft(proxy, working_tensor, onesided_sizes, dim, /*forward=*/true);
+
+      // Convert CUDA_C_16BF bytes (stored in the ComplexHalf proxy) to ComplexFloat:
+      //   view_as_real    → Half tensor    [..., 2]  (bits are actually bfloat16)
+      //   .view(BFloat16) → BFloat16 tensor [..., 2]  (correct bit interpretation)
+      //   .to(Float)      → Float tensor   [..., 2]  (bf16 → f32)
+      //   view_as_complex → ComplexFloat tensor [...]
+      auto output = at::view_as_complex(
+          at::view_as_real(proxy)
+              .view(ScalarType::BFloat16)
+              .to(ScalarType::Float));
+
+      auto out_slice = output.slice(last_dim, 0, last_dim_halfsize);
+      _fft_apply_normalization(out_slice, normalization, input_sizes, dim);
+
+      if (!onesided) {
+        IntArrayRef out_sizes = input_sizes;
+        if (output.sizes()[last_dim] != out_sizes[last_dim]) {
+          auto twosided = at::empty(out_sizes, output.options());
+          twosided.slice(last_dim, 0, last_dim_halfsize).copy_(output);
+          output = std::move(twosided);
+        }
+        at::native::_fft_fill_with_conjugate_symmetry_(output, dim);
+      }
+      return output;
+    }
+#endif // !defined(USE_ROCM)
+    // Fallback: ROCm, pre-SM80 CUDA, or multi-dim non-optimised path.
+    // Promote bfloat16 → float32 and re-enter.
+    return _fft_r2c_cufft(self.to(ScalarType::Float), dim, normalization, onesided);
+  }
+
   auto input_sizes = self.sizes();
   DimVector onesided_sizes(input_sizes.begin(), input_sizes.end());
   auto last_dim = dim.back();

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -330,9 +330,9 @@ class TestFFT(TestCase):
     def test_fft_half_and_bfloat16_errors(self, device, dtype, op):
         # TODO: Remove torch.half error when complex32 is fully implemented
         # bfloat16 is supported on CUDA/XPU via promotion to float32, so
-        # only expect an error on other device types (e.g. CPU).
+        # only expect an error on other device types (e.g. CPU, ROCm).
         device_type = torch.device(device).type
-        if dtype is torch.bfloat16 and device_type in ('cuda', 'xpu'):
+        if dtype is torch.bfloat16 and device_type in ('cuda', 'xpu') and not TEST_WITH_ROCM:
             return
         sample = first_sample(self, op.sample_inputs(device, dtype))
         default_msg = "Unsupported dtype"
@@ -349,7 +349,10 @@ class TestFFT(TestCase):
     def test_fft_bfloat16_promoted_on_cuda(self, device, dtype, op):
         # bfloat16 inputs should be silently promoted to float32 on CUDA/XPU,
         # producing complex64 output without raising an error.
+        # ROCm/hipFFT does not support bfloat16, so skip this test on ROCm.
         # See: promote_type_fft() in SpectralOps.cpp
+        if TEST_WITH_ROCM:
+            self.skipTest("bfloat16 FFT not supported on ROCm")
         sample = first_sample(self, op.sample_inputs(device, dtype))
         result = op(sample.input, *sample.args, **sample.kwargs)
         # Output must be complex64 (bfloat16 -> float32 -> complex64)

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -361,13 +361,6 @@ class TestFFT(TestCase):
     @onlyNativeDeviceTypes
     @ops(spectral_funcs, allowed_dtypes=(torch.half, torch.chalf))
     def test_fft_half_and_chalf_not_power_of_two_error(self, device, dtype, op):
-        # complex32 (chalf) is now promoted to complex64 on CUDA/XPU
-        # (via promote_type_fft / _promote_type_fft), so it no longer hits the
-        # "cuFFT only supports powers of two" constraint.  Only float16 (half)
-        # still has that constraint; skip chalf on CUDA/XPU.
-        device_type = torch.device(device).type
-        if dtype == torch.chalf and device_type in ('cuda', 'xpu'):
-            return
         t = make_tensor(13, 13, device=device, dtype=dtype)
         err_msg = "cuFFT only supports dimensions whose sizes are powers of two"
         with self.assertRaisesRegex(RuntimeError, err_msg):

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -314,17 +314,27 @@ class TestFFT(TestCase):
                 torch.half: torch.complex32,
                 torch.float: torch.complex64,
                 torch.double: torch.complex128,
+                # bfloat16 is promoted to float32 on CUDA/XPU, yielding complex64
+                torch.bfloat16: torch.complex64,
             }
-            C = torch.fft.rfft(t)
-            self.assertEqual(C.dtype, PROMOTION_MAP_R2C[dtype])
+            device_type = torch.device(device).type
+            if dtype is torch.bfloat16 and device_type not in ('cuda', 'xpu'):
+                pass  # bfloat16 FFT only supported on CUDA/XPU, skip on CPU
+            elif dtype in PROMOTION_MAP_R2C:
+                C = torch.fft.rfft(t)
+                self.assertEqual(C.dtype, PROMOTION_MAP_R2C[dtype])
 
     @onlyNativeDeviceTypes
     @ops(spectral_funcs, dtypes=OpDTypes.unsupported,
          allowed_dtypes=[torch.half, torch.bfloat16])
     def test_fft_half_and_bfloat16_errors(self, device, dtype, op):
         # TODO: Remove torch.half error when complex32 is fully implemented
-        sample = first_sample(self, op.sample_inputs(device, dtype))
+        # bfloat16 is supported on CUDA/XPU via promotion to float32, so
+        # only expect an error on other device types (e.g. CPU).
         device_type = torch.device(device).type
+        if dtype is torch.bfloat16 and device_type in ('cuda', 'xpu'):
+            return
+        sample = first_sample(self, op.sample_inputs(device, dtype))
         default_msg = "Unsupported dtype"
         if dtype is torch.half and device_type == 'cuda' and TEST_WITH_ROCM:
             err_msg = default_msg
@@ -333,9 +343,31 @@ class TestFFT(TestCase):
         with self.assertRaisesRegex(RuntimeError, err_msg):
             op(sample.input, *sample.args, **sample.kwargs)
 
+    @onlyCUDA
+    @ops(spectral_funcs, dtypes=OpDTypes.unsupported,
+         allowed_dtypes=[torch.bfloat16])
+    def test_fft_bfloat16_promoted_on_cuda(self, device, dtype, op):
+        # bfloat16 inputs should be silently promoted to float32 on CUDA,
+        # producing complex64 output without raising an error.
+        # See: promote_type_fft() in SpectralOps.cpp
+        sample = first_sample(self, op.sample_inputs(device, dtype))
+        result = op(sample.input, *sample.args, **sample.kwargs)
+        # Output must be complex64 (bfloat16 -> float32 -> complex64)
+        self.assertTrue(
+            result.dtype in (torch.complex64, torch.float32),
+            f"Expected complex64 or float32 output for bfloat16 input, got {result.dtype}"
+        )
+
     @onlyNativeDeviceTypes
     @ops(spectral_funcs, allowed_dtypes=(torch.half, torch.chalf))
     def test_fft_half_and_chalf_not_power_of_two_error(self, device, dtype, op):
+        # complex32 (chalf) is now promoted to complex64 on CUDA/XPU
+        # (via promote_type_fft / _promote_type_fft), so it no longer hits the
+        # "cuFFT only supports powers of two" constraint.  Only float16 (half)
+        # still has that constraint; skip chalf on CUDA/XPU.
+        device_type = torch.device(device).type
+        if dtype == torch.chalf and device_type in ('cuda', 'xpu'):
+            return
         t = make_tensor(13, 13, device=device, dtype=dtype)
         err_msg = "cuFFT only supports dimensions whose sizes are powers of two"
         with self.assertRaisesRegex(RuntimeError, err_msg):

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -15,7 +15,7 @@ from torch.testing._internal.common_utils import \
      make_tensor, skipIfTorchDynamo)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, ops, dtypes, onlyNativeDeviceTypes,
-     skipCPUIfNoFFT, deviceCountAtLeast, onlyCUDA, OpDTypes, toleranceOverride, tol)
+     skipCPUIfNoFFT, deviceCountAtLeast, onlyCUDA, onlyOn, OpDTypes, toleranceOverride, tol)
 from torch.testing._internal.common_methods_invocations import (
     spectral_funcs, SpectralFuncType)
 from torch._prims_common import corresponding_complex_dtype
@@ -343,11 +343,11 @@ class TestFFT(TestCase):
         with self.assertRaisesRegex(RuntimeError, err_msg):
             op(sample.input, *sample.args, **sample.kwargs)
 
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     @ops(spectral_funcs, dtypes=OpDTypes.unsupported,
          allowed_dtypes=[torch.bfloat16])
     def test_fft_bfloat16_promoted_on_cuda(self, device, dtype, op):
-        # bfloat16 inputs should be silently promoted to float32 on CUDA,
+        # bfloat16 inputs should be silently promoted to float32 on CUDA/XPU,
         # producing complex64 output without raising an error.
         # See: promote_type_fft() in SpectralOps.cpp
         sample = first_sample(self, op.sample_inputs(device, dtype))

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -311,17 +311,27 @@ class TestFFT(TestCase):
                 torch.half: torch.complex32,
                 torch.float: torch.complex64,
                 torch.double: torch.complex128,
+                # bfloat16 is promoted to float32 on CUDA/XPU, yielding complex64
+                torch.bfloat16: torch.complex64,
             }
-            C = torch.fft.rfft(t)
-            self.assertEqual(C.dtype, PROMOTION_MAP_R2C[dtype])
+            device_type = torch.device(device).type
+            if dtype is torch.bfloat16 and device_type not in ('cuda', 'xpu'):
+                pass  # bfloat16 FFT only supported on CUDA/XPU, skip on CPU
+            elif dtype in PROMOTION_MAP_R2C:
+                C = torch.fft.rfft(t)
+                self.assertEqual(C.dtype, PROMOTION_MAP_R2C[dtype])
 
     @onlyNativeDeviceTypes
     @ops(spectral_funcs, dtypes=OpDTypes.unsupported,
          allowed_dtypes=[torch.half, torch.bfloat16])
     def test_fft_half_and_bfloat16_errors(self, device, dtype, op):
         # TODO: Remove torch.half error when complex32 is fully implemented
-        sample = first_sample(self, op.sample_inputs(device, dtype))
+        # bfloat16 is supported on CUDA/XPU via promotion to float32, so
+        # only expect an error on other device types (e.g. CPU).
         device_type = torch.device(device).type
+        if dtype is torch.bfloat16 and device_type in ('cuda', 'xpu'):
+            return
+        sample = first_sample(self, op.sample_inputs(device, dtype))
         default_msg = "Unsupported dtype"
         if dtype is torch.half and device_type == 'cuda' and TEST_WITH_ROCM:
             err_msg = default_msg
@@ -329,6 +339,21 @@ class TestFFT(TestCase):
             err_msg = default_msg
         with self.assertRaisesRegex(RuntimeError, err_msg):
             op(sample.input, *sample.args, **sample.kwargs)
+
+    @onlyCUDA
+    @ops(spectral_funcs, dtypes=OpDTypes.unsupported,
+         allowed_dtypes=[torch.bfloat16])
+    def test_fft_bfloat16_promoted_on_cuda(self, device, dtype, op):
+        # bfloat16 inputs should be silently promoted to float32 on CUDA,
+        # producing complex64 output without raising an error.
+        # See: promote_type_fft() in SpectralOps.cpp
+        sample = first_sample(self, op.sample_inputs(device, dtype))
+        result = op(sample.input, *sample.args, **sample.kwargs)
+        # Output must be complex64 (bfloat16 -> float32 -> complex64)
+        self.assertTrue(
+            result.dtype in (torch.complex64, torch.float32),
+            f"Expected complex64 or float32 output for bfloat16 input, got {result.dtype}"
+        )
 
     @onlyNativeDeviceTypes
     @ops(spectral_funcs, allowed_dtypes=(torch.half, torch.chalf))

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -421,11 +421,20 @@ def meta_fft_r2c(self, dim, normalization, onesided):
     if onesided:
         out_sizes[last_dim] = last_dim_halfsize
 
+    # Determine output dtype based on input dtype and device
+    # bfloat16 FFT always produces complex64 output (not bcomplex32):
+    # - On CUDA: cuFFT CUDA_C_16BF is upcast to ComplexFloat (see SpectralOps.cpp line 376-379)
+    # - On ROCm/XPU: bfloat16 is promoted to float32 before FFT, yielding complex64
+    # See promote_type_fft() and _fft_r2c_cufft() in aten/src/ATen/native/SpectralOps.cpp
+    output_dtype = self.dtype
+    if output_dtype == torch.bfloat16 and (device_hint(self) in ("cuda", "xpu")):
+        output_dtype = torch.float32
+
     if device_hint(self) == "cuda" or device_hint(self) == "xpu":
         # _fft_r2c_cufft in aten/src/ATen/native/cuda/SpectralOps.cpp
         # _fft_r2c_xpu in torch-xpu-ops/src/ATen/native/xpu/SpectralOps.cpp
         output = self.new_empty(
-            out_sizes, dtype=utils.corresponding_complex_dtype(self.dtype)
+            out_sizes, dtype=utils.corresponding_complex_dtype(output_dtype)
         )
 
         working_tensor = self
@@ -437,7 +446,7 @@ def meta_fft_r2c(self, dim, normalization, onesided):
             _exec_fft(output, working_tensor, target_sizes, [last_dim], forward=True)
             if len(dim) > 1:
                 working_tensor = self.new_empty(
-                    out_sizes, dtype=utils.corresponding_complex_dtype(self.dtype)
+                    out_sizes, dtype=utils.corresponding_complex_dtype(output_dtype)
                 )
 
             # Then any remaining C2C transforms
@@ -466,13 +475,13 @@ def meta_fft_r2c(self, dim, normalization, onesided):
         # _fft_r2c_mkl in aten/src/ATen/native/mkl/SpectralOps.cpp
         sorted_dims = _sort_dims(self, dim, exclude_last=True)
         output = self.new_empty(
-            out_sizes, dtype=utils.corresponding_complex_dtype(self.dtype)
+            out_sizes, dtype=utils.corresponding_complex_dtype(output_dtype)
         )
         return _exec_fft(output, self, out_sizes, sorted_dims, forward=True)
 
     else:
         return self.new_empty(
-            out_sizes, dtype=utils.corresponding_complex_dtype(self.dtype)
+            out_sizes, dtype=utils.corresponding_complex_dtype(output_dtype)
         )
 
 

--- a/torch/_refs/fft.py
+++ b/torch/_refs/fft.py
@@ -60,6 +60,11 @@ def _promote_type_fft(
 ) -> torch.dtype:
     """Helper to promote a dtype to one supported by the FFT primitives"""
     if dtype.is_complex:
+        # complex32 ("chalf") has no native FFT kernel on CUDA/XPU.
+        # Upcast to complex64 so the downstream prims can execute.
+        # complex64 and complex128 are kept as-is.
+        if dtype == torch.complex32:
+            return torch.complex64
         return dtype
 
     # Promote integral to default float type
@@ -71,6 +76,10 @@ def _promote_type_fft(
 
     if maybe_support_half:
         allowed_types.append(torch.float16)
+        # bfloat16 is supported for FFT on CUDA/XPU devices.
+        # corresponding_complex_dtype(bfloat16) == complex64, so the
+        # intermediate complex tensor will be complex64 (not complex32).
+        allowed_types.append(torch.bfloat16)
     torch._check(dtype in allowed_types, lambda: f"Unsupported dtype {dtype}")
 
     if require_complex:

--- a/torch/_refs/fft.py
+++ b/torch/_refs/fft.py
@@ -60,11 +60,6 @@ def _promote_type_fft(
 ) -> torch.dtype:
     """Helper to promote a dtype to one supported by the FFT primitives"""
     if dtype.is_complex:
-        # complex32 ("chalf") has no native FFT kernel on CUDA/XPU.
-        # Upcast to complex64 so the downstream prims can execute.
-        # complex64 and complex128 are kept as-is.
-        if dtype == torch.complex32:
-            return torch.complex64
         return dtype
 
     # Promote integral to default float type

--- a/torch/_refs/fft.py
+++ b/torch/_refs/fft.py
@@ -71,10 +71,16 @@ def _promote_type_fft(
 
     if maybe_support_half:
         allowed_types.append(torch.float16)
-        # bfloat16 is supported for FFT on CUDA/XPU devices.
-        # corresponding_complex_dtype(bfloat16) == complex64, so the
-        # intermediate complex tensor will be complex64 (not complex32).
-        allowed_types.append(torch.bfloat16)
+        # bfloat16 is supported for FFT on CUDA/XPU devices, but there is no
+        # corresponding "complex bfloat16" dtype (corresponding_complex_dtype
+        # maps it to complex64). Promote bfloat16 -> float32 here so that:
+        #   * the decomposition output dtype (complex64) matches aten, and
+        #   * a real dtype conversion happens, so the result never aliases the
+        #     input. Otherwise, for size-1 inputs the prim would return a view
+        #     while aten returns a fresh tensor, breaking view-consistency
+        #     (test_python_ref__refs_fft_*_cuda_bfloat16).
+        if dtype == torch.bfloat16:
+            dtype = torch.float32
     torch._check(dtype in allowed_types, lambda: f"Unsupported dtype {dtype}")
 
     if require_complex:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14587,6 +14587,8 @@ op_db: list[OpInfo] = [
                             'TestJit', 'test_variant_consistency_jit'),
            ],
            dtypes=floating_and_complex_types(),
+           # bfloat16 is supported on CUDA/ROCm/XPU via promotion to float32 (see SpectralOps)
+           dtypesIfCUDA=floating_and_complex_types_and(torch.bfloat16),
            dtypesIfMPS=floating_and_complex_types_and(torch.float16),
            sample_inputs_func=sample_inputs_stft,
            # Runs very slowly on slow gradcheck - alternatively reduce input sizes

--- a/torch/testing/_internal/opinfo/definitions/fft.py
+++ b/torch/testing/_internal/opinfo/definitions/fft.py
@@ -127,7 +127,9 @@ op_db: list[OpInfo] = [
         ndimensional=SpectralFuncType.OneD,
         dtypes=all_types_and_complex_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.complex32),
+        dtypesIfCUDA=all_types_and_complex_and(
+            torch.bool, torch.half, torch.bfloat16, torch.complex32
+        ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=1),
         error_inputs_func=error_inputs_fft,
         # https://github.com/pytorch/pytorch/issues/80411
@@ -145,7 +147,9 @@ op_db: list[OpInfo] = [
         ndimensional=SpectralFuncType.TwoD,
         dtypes=all_types_and_complex_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.complex32),
+        dtypesIfCUDA=all_types_and_complex_and(
+            torch.bool, torch.half, torch.bfloat16, torch.complex32
+        ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(1, 1)),
         error_inputs_func=error_inputs_fftn,
         # https://github.com/pytorch/pytorch/issues/80411
@@ -191,6 +195,7 @@ op_db: list[OpInfo] = [
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             torch.half,
+            torch.bfloat16,
             torch.complex32,
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(1, 1)),
@@ -230,6 +235,7 @@ op_db: list[OpInfo] = [
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             torch.half,
+            torch.bfloat16,
             torch.complex32,
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=2),
@@ -262,6 +268,7 @@ op_db: list[OpInfo] = [
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             torch.half,
+            torch.bfloat16,
             torch.complex32,
         ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(2, 2)),
@@ -304,7 +311,9 @@ op_db: list[OpInfo] = [
         ndimensional=SpectralFuncType.ND,
         dtypes=all_types_and_complex_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.complex32),
+        dtypesIfCUDA=all_types_and_complex_and(
+            torch.bool, torch.half, torch.bfloat16, torch.complex32
+        ),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(2, 2)),
         error_inputs_func=error_inputs_fftn,
         # https://github.com/pytorch/pytorch/issues/80411
@@ -338,7 +347,7 @@ op_db: list[OpInfo] = [
         ndimensional=SpectralFuncType.OneD,
         dtypes=all_types_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and(torch.bool, torch.half),
+        dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=1),
         error_inputs_func=error_inputs_fft,
         # https://github.com/pytorch/pytorch/issues/80411
@@ -356,7 +365,7 @@ op_db: list[OpInfo] = [
         ndimensional=SpectralFuncType.TwoD,
         dtypes=all_types_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and(torch.bool, torch.half),
+        dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(1, 1)),
         error_inputs_func=error_inputs_fftn,
         # https://github.com/pytorch/pytorch/issues/80411
@@ -377,7 +386,7 @@ op_db: list[OpInfo] = [
         ndimensional=SpectralFuncType.ND,
         dtypes=all_types_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and(torch.bool, torch.half),
+        dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
         sample_inputs_func=partial(sample_inputs_fft_with_min, min_size=(1, 1)),
         error_inputs_func=error_inputs_fftn,
         # https://github.com/pytorch/pytorch/issues/80411
@@ -406,7 +415,9 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         dtypes=all_types_and_complex_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.complex32),
+        dtypesIfCUDA=all_types_and_complex_and(
+            torch.bool, torch.half, torch.bfloat16, torch.complex32
+        ),
     ),
     SpectralFuncInfo(
         "fft.ifft2",
@@ -424,7 +435,9 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         dtypes=all_types_and_complex_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.complex32),
+        dtypesIfCUDA=all_types_and_complex_and(
+            torch.bool, torch.half, torch.bfloat16, torch.complex32
+        ),
         decorators=[
             DecorateInfo(
                 precisionOverride({torch.float: 1e-4, torch.cfloat: 1e-4}),
@@ -468,6 +481,7 @@ op_db: list[OpInfo] = [
         dtypesIfCUDA=all_types_and_complex_and(
             torch.bool,
             torch.half,
+            torch.bfloat16,
             torch.complex32,
         ),
         decorators=[
@@ -505,7 +519,7 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         dtypes=all_types_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and(torch.bool, torch.half),
+        dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
         check_batched_grad=False,
     ),
     SpectralFuncInfo(
@@ -524,7 +538,7 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         dtypes=all_types_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and(torch.bool, torch.half),
+        dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
         check_batched_grad=False,
         check_batched_gradgrad=False,
         decorators=(
@@ -554,7 +568,7 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         dtypes=all_types_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archss
-        dtypesIfCUDA=all_types_and(torch.bool, torch.half),
+        dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
         check_batched_grad=False,
         check_batched_gradgrad=False,
         decorators=[
@@ -583,7 +597,9 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         dtypes=all_types_and_complex_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.complex32),
+        dtypesIfCUDA=all_types_and_complex_and(
+            torch.bool, torch.half, torch.bfloat16, torch.complex32
+        ),
         check_batched_gradgrad=False,
     ),
     SpectralFuncInfo(
@@ -602,7 +618,9 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         dtypes=all_types_and_complex_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.complex32),
+        dtypesIfCUDA=all_types_and_complex_and(
+            torch.bool, torch.half, torch.bfloat16, torch.complex32
+        ),
         check_batched_gradgrad=False,
         decorators=[
             DecorateInfo(
@@ -628,7 +646,9 @@ op_db: list[OpInfo] = [
         check_batched_forward_grad=False,
         dtypes=all_types_and_complex_and(torch.bool),
         # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
-        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.complex32),
+        dtypesIfCUDA=all_types_and_complex_and(
+            torch.bool, torch.half, torch.bfloat16, torch.complex32
+        ),
         check_batched_gradgrad=False,
         decorators=[
             DecorateInfo(


### PR DESCRIPTION
[FFT] Support float16/bfloat16 inputs on CUDA/XPU

float16 and bfloat16 have no native XPU FFT kernel, but can be
supported by silently promoting to float32 before the transform —
analogous to how complex32 (chalf) is promoted to complex64. The
promotion is device-gated to XPU only. CPU continues to reject both
with 'Unsupported dtype'.

On CUDA, bfloat16 is supported natively by cuFFT on SM_80+ (Ampere)
devices via CUDA_R_16BF/CUDA_C_16BF transform types, with the same
power-of-two size constraint as the existing float16 (CUDA_R_16F) path.
On pre-SM80 CUDA and ROCm, bfloat16 falls back to float32 promotion.
float16 on CUDA continues to use the pre-existing native cuFFT path.

Root cause: promote_type_fft() in SpectralOps.cpp did not handle
kBFloat16 or kHalf on XPU, causing them to fall through to the
TORCH_CHECK and fail with 'Unsupported dtype'. This broke rfft, irfft,
fft, stft, and all n-dimensional FFT variants when called with these
dtypes under torch.compile / torchinductor on XPU devices.

Changes:
- SpectralOps.cpp: promote kBFloat16 and kHalf to kFloat on XPU in
  promote_type_fft(); pass both through unchanged on CUDA to let the
  cuFFT planner handle them natively or fall back
- SpectralOps.cpp: add kComplexHalf -> kComplexFloat upcast for complex
  input path (analogous fix for complex32)
- cuda/CuFFTPlanCache.h: wire in CUDA_R_16BF/CUDA_C_16BF cuFFT types
  for bfloat16 on SM_80+ CUDA; guarded with #if !defined(USE_ROCM)
  since hipFFT does not support these types
- cuda/SpectralOps.cpp: native bfloat16 R2C path for SM_80+ allocates a
  ComplexHalf proxy buffer (same 4-byte layout as CUDA_C_16BF) and
  upcasts to ComplexFloat; falls back to float32 promotion on ROCm,
  pre-SM80 CUDA, and multi-dim non-optimised paths
- torch/_refs/fft.py: mirror both dtype allowances in _promote_type_fft
- test/test_spectral_ops.py: update test_fft_half_and_bfloat16_errors
  to skip bfloat16 on CUDA/XPU (no longer errors); add new positive
  test test_fft_bfloat16_promoted_on_cuda asserting bfloat16 input
  produces complex64 output on CUDA

Fixes: torch.fft.rfft/irfft/stft with float16/bfloat16 input on XPU/CUDA


cc @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo