### PR TITLE
Fix torch.trapz documentation signature to match torch.trapezoid

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13129,7 +13129,7 @@ Examples::
 add_docstr(
     torch.trapz,
     r"""
-trapz(y, x, *, dim=-1) -> Tensor
+trapz(y, x=None, *, dx=None, dim=-1) -> Tensor
 
 Alias for :func:`torch.trapezoid`.
 """,


### PR DESCRIPTION
Good day

## Summary
This PR fixes the documentation signature for `torch.trapz`, which is documented as:

```
trapz(y, x, *, dim=-1)
```

However, `torch.trapz` is an alias of `torch.trapezoid`, whose signature is:

```
trapezoid(y, x=None, *, dx=None, dim=-1)
```

The fix aligns `torch.trapz` signature with `torch.trapezoid`, including:
- Adding `x=None`
- Adding `dx=None` parameter
- Correcting keyword argument style to `*, dx=None, dim=-1`

## Changes
- `torch/_torch_docs.py`: Updated `torch.trapz` docstring signature from `trapz(y, x, *, dim=-1)` to `trapz(y, x=None, *, dx=None, dim=-1)`

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof