### PR TITLE
Fix torch.trapz doc signature to match torch.trapezoid

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13129,7 +13129,7 @@ Examples::
 add_docstr(
     torch.trapz,
     r"""
-trapz(y, x, *, dim=-1) -> Tensor
+trapz(y, x=None, *, dx=None, dim=-1) -> Tensor
 
 Alias for :func:`torch.trapezoid`.
 """,


### PR DESCRIPTION
Good day

## Problem
The documentation signature for `torch.trapz` was `trapz(y, x, *, dim=-1)`, but since `torch.trapz` is an alias for `torch.trapezoid`, the signature should match: `trapz(y, x=None, *, dx=None, dim=-1)`.

This inconsistency was reported in issue #71392.

## Solution
Updated the doc signature in `torch/_torch_docs.py` to align with `torch.trapezoid`:
- Added `x=None` (was missing)
- Added `dx=None` (was missing)

## Verification
`torch.trapz` is documented as an alias for `torch.trapezoid`, so the signatures must be consistent.

Closes #71392

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof