### PR TITLE
Fix tearDown leak in TestOpaqueObject under PYTORCH_TEST_SKIP_FAST

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -439,6 +439,11 @@ class TensorWithCounter(torch.Tensor):
 
 class TestOpaqueObject(TestCase):
     def setUp(self):
+        # Must run first: super().setUp() can raise SkipTest (e.g. under
+        # PYTORCH_TEST_SKIP_FAST), and unittest skips tearDown when setUp
+        # raises. Any registrations before this would leak into the next test.
+        super().setUp()
+
         self.lib = torch.library.Library("_TestOpaqueObject", "FRAGMENT")  # noqa: TOR901
         self._opaque_types_before_test = set(_OPAQUE_TYPES_BY_NAME.keys())
 
@@ -881,8 +886,6 @@ class TestOpaqueObject(TestCase):
         @torch.library.register_fake("_TestOpaqueObject::counter_start", lib=self.lib)
         def counter_start_fake(a: Counter) -> torch.Tensor:
             return torch.scalar_tensor(0, dtype=torch.int64)
-
-        super().setUp()
 
     def tearDown(self):
         self.lib._destroy()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180774

setUp registered library ops before calling super().setUp(). Under the
slow shard, super().setUp() raises SkipTest for fast tests, and unittest
skips tearDown when setUp raises, so the Library and its op registrations
leaked into the next test. The next test's setUp then tripped the
duplicate-registration check, producing errors like:

    RuntimeError: Tried to register an operator
    (_TestOpaqueObject::queue_push...) with the same name and overload
    name multiple times.

Move super().setUp() to the top so any skip fires before registration.

Authored with Claude.