### PR TITLE
[BE]: Enable clang-tidy on c10::SmallVector reserves to reduce reallocs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -78,4 +78,5 @@ CheckOptions:
   cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: true
   cppcoreguidelines-special-member-functions.AllowImplicitlyDeletedCopyOrMove: true
   misc-header-include-cycle.IgnoredFilesList: 'format.h;ivalue.h;custom_class.h;Dict.h;List.h;IListRef.h'
+  performance-inefficient-vector-operation.VectorLikeClasses: '::std::vector;::c10::SmallVector'
 ...

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -456,7 +456,6 @@ inline Tensor _sum_to(
 
   auto sizes = at::symint::sizes<T>(tensor);
   c10::SmallVector<int64_t, 8> reduce_dims;
-  reduce_dims.reserve(sizes.size());
   const int64_t leading_dims = sizes.size() - shape.size();
   for (const auto i : c10::irange(leading_dims)) {
     reduce_dims.push_back(i);

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -456,6 +456,7 @@ inline Tensor _sum_to(
 
   auto sizes = at::symint::sizes<T>(tensor);
   c10::SmallVector<int64_t, 8> reduce_dims;
+  reduce_dims.reserve(sizes.size());
   const int64_t leading_dims = sizes.size() - shape.size();
   for (const auto i : c10::irange(leading_dims)) {
     reduce_dims.push_back(i);

--- a/aten/src/ATen/cuda/jiterator.cu
+++ b/aten/src/ATen/cuda/jiterator.cu
@@ -356,6 +356,7 @@ c10::SmallVector<at::Tensor> CompileAndLaunchKernel(
   at::native::jitted_gpu_kernel_dynamic(kernel_name, iter, code_string, extra_args, return_by_ref);
 
   c10::SmallVector<at::Tensor> outputs;
+  outputs.reserve(num_outputs);
   for (int i = 0; i < num_outputs; ++i) {
     outputs.emplace_back(iter.output(i));
   }

--- a/aten/src/ATen/cuda/jiterator.cu
+++ b/aten/src/ATen/cuda/jiterator.cu
@@ -356,7 +356,9 @@ c10::SmallVector<at::Tensor> CompileAndLaunchKernel(
   at::native::jitted_gpu_kernel_dynamic(kernel_name, iter, code_string, extra_args, return_by_ref);
 
   c10::SmallVector<at::Tensor> outputs;
-  outputs.reserve(num_outputs);
+  if (num_outputs > 0) {
+    outputs.reserve(num_outputs);
+  }
   for (int i = 0; i < num_outputs; ++i) {
     outputs.emplace_back(iter.output(i));
   }

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -2469,9 +2469,11 @@ create_native_op_schema(
     // way; the C++ fast path must match. Without this filter, step-varying
     // scalar kwargs (e.g. the `value` arg of addcdiv_ used by AdamW bias
     // corrections) cause unbounded cache growth.
+    py::list static_kwargkey =
+        py::reinterpret_borrow<py::list>(native_info.static_kwargkey);
     c10::SmallVector<std::string, 2> static_kwarg_names;
-    for (const auto& key :
-         py::reinterpret_borrow<py::list>(native_info.static_kwargkey)) {
+    static_kwarg_names.reserve(static_kwargkey.size());
+    for (const auto& key : static_kwargkey) {
       static_kwarg_names.push_back(py::cast<std::string>(key));
     }
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -372,6 +372,7 @@ PyObject* THCPModule_cudaJiteratorCompileAndLaunchKernel(
   Py_ssize_t num_tensors = PyTuple_GET_SIZE(tensors_o);
 
   c10::SmallVector<at::Tensor> tensors;
+  tensors.reserve(static_cast<size_t>(num_tensors));
   for (const auto i : c10::irange(num_tensors)) {
     PyObject* _tensor = PyTuple_GET_ITEM(tensors_o, i);
     TORCH_CHECK(
@@ -383,6 +384,10 @@ PyObject* THCPModule_cudaJiteratorCompileAndLaunchKernel(
   }
 
   c10::SmallVector<at::Scalar> extra_args;
+  const Py_ssize_t num_extra_args = kwargs_o ? PyDict_Size(kwargs_o) : 0;
+  if (num_extra_args > 0) {
+    extra_args.reserve(static_cast<size_t>(num_extra_args));
+  }
   PyObject* key = nullptr;
   PyObject* value = nullptr;
   Py_ssize_t pos = 0;

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -372,7 +372,9 @@ PyObject* THCPModule_cudaJiteratorCompileAndLaunchKernel(
   Py_ssize_t num_tensors = PyTuple_GET_SIZE(tensors_o);
 
   c10::SmallVector<at::Tensor> tensors;
-  tensors.reserve(static_cast<size_t>(num_tensors));
+  if (num_tensors > 0) {
+    tensors.reserve(static_cast<size_t>(num_tensors));
+  }
   for (const auto i : c10::irange(num_tensors)) {
     PyObject* _tensor = PyTuple_GET_ITEM(tensors_o, i);
     TORCH_CHECK(


### PR DESCRIPTION
We can extend clang-tidy to properly consider this VectorLIke class. Fixes authored by Claude improved by me