### PR TITLE
Fix torch.trapz documentation signature to match torch.trapezoid

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13123,7 +13123,7 @@ Examples::
 add_docstr(
     torch.trapz,
     r"""
-trapz(y, x, *, dim=-1) -> Tensor
+trapz(y, x=None, *, dx=None, dim=-1) -> Tensor
 
 Alias for :func:`torch.trapezoid`.
 """,


### PR DESCRIPTION
Good day

This PR fixes issue #71392 - the documentation signature for `torch.trapz` was incorrect.

## Problem
The documented signature for `torch.trapz` was:
```
torch.trapz(y, x, *, dim=-1)
```

However, `torch.trapezoid` (its alias) has signature:
```
torch.trapezoid(y, x=None, *, dx=None, dim=-1)
```

The issue is that `x` is marked as required in the `trapz` docs but should be optional (with default `None`) to match the actual `trapezoid` behavior.

## Fix
Updated the signature in `torch/_torch_docs.py` from:
```
trapz(y, x, *, dim=-1)
```
to:
```
trapz(y, x=None, *, dx=None, dim=-1)
```

This correctly reflects that `x` is optional and adds the missing `dx` parameter which is supported by the alias.

## Verification
The fix aligns the documented signature with the actual `trapezoid` function signature. The `trapz` function is documented as an alias for `torch.trapezoid`, so its signature should match.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof