### PR TITLE
Fix integer divide-by-zero UB in CUDA binary kernels

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryDivTruncKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryDivTruncKernel.cu
@@ -21,7 +21,12 @@ void div_trunc_kernel_cuda(TensorIteratorBase& iter) {
     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_trunc_cuda", [&]() {
       gpu_kernel_with_scalars(
           iter,
-          [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t { return a / b; });
+          [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+            if (b == 0) {
+              return static_cast<scalar_t>(0);
+            }
+            return a / b;
+          });
     });
   } else if (iter.is_cpu_scalar(2)) {
     // optimization for floating-point types: if the second operand is a CPU

--- a/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryRemainderKernel.cu
@@ -26,6 +26,10 @@ void remainder_kernel_cuda(TensorIteratorBase& iter) {
           if (b == 0) {
             return std::numeric_limits<uint8_t>::max();
           }
+        } else {
+          if (b == 0) {
+            return static_cast<scalar_t>(0);
+          }
         }
         scalar_t r = a % b;
         if (r != 0 && c10::signs_differ(r, b)) {
@@ -37,6 +41,9 @@ void remainder_kernel_cuda(TensorIteratorBase& iter) {
 #else
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "remainder_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+        if (b == 0) {
+          return static_cast<scalar_t>(0);
+        }
         scalar_t r = a % b;
         if (r != 0 && c10::signs_differ(r, b)) {
           r += b;
@@ -63,6 +70,9 @@ void fmod_kernel_cuda(TensorIteratorBase& iter) {
   if (isIntegralType(iter.common_dtype(), /*includeBool*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "fmod_cuda", [&]() {
       gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+        if (b == 0) {
+          return static_cast<scalar_t>(0);
+        }
         return a % b;
       });
     });

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2754,22 +2754,33 @@ class TestBinaryUfuncs(TestCase):
             if self.device_type == "cpu":
                 with self.assertRaisesRegex(RuntimeError, "ZeroDivisionError"):
                     fn(x, zero)
-            elif torch.version.hip is not None:
-                # ROCm behavior: x % 0 is a no-op; x is returned
-                self.assertEqual(fn(x, zero), x)
             else:
-                # CUDA behavior: Different value for different dtype
-                # Due to it's an undefined behavior, CUDA returns a pattern of all 1s
-                # for integral dividend (other than int64) divided by zero. For int64,
-                # CUDA returns all 1s for negative dividend, half 1s for positive dividend.
-                # uint8: 0xff -> 255
-                # int32: 0xffffffff -> -1
-                if dtype == torch.int64:
-                    self.assertEqual(fn(x, zero) == 4294967295, x >= 0)
-                    self.assertEqual(fn(x, zero) == -1, x < 0)
+                # CUDA/ROCm: fmod always returns 0 for divide-by-zero.
+                # remainder returns 0 for all types except uint8 on
+                # non-ROCm CUDA, where it returns 255.
+                if (
+                    fn is torch.remainder
+                    and dtype == torch.uint8
+                    and torch.version.hip is None
+                ):
+                    expected_val = 255
                 else:
-                    value = 255 if dtype == torch.uint8 else -1
-                    self.assertTrue(torch.all(fn(x, zero) == value))
+                    expected_val = 0
+                expected = torch.full_like(x, expected_val)
+                self.assertEqual(fn(x, zero), expected)
+
+    @onlyNativeDeviceTypes
+    @dtypes(*integral_types())
+    def test_div_trunc_by_zero_integral(self, device, dtype):
+        x = make_tensor((10, 10), device=device, dtype=dtype, low=-9, high=9)
+        zero = torch.zeros_like(x)
+        if self.device_type == "cpu":
+            with self.assertRaisesRegex(RuntimeError, "ZeroDivisionError"):
+                torch.div(x, zero, rounding_mode="trunc")
+        else:
+            expected = torch.zeros_like(x)
+            self.assertEqual(torch.div(x, zero, rounding_mode="trunc"), expected)
+            self.assertEqual(torch.div(x, 0, rounding_mode="trunc"), expected)
 
     @onlyNativeDeviceTypes
     @dtypes(*integral_types())


### PR DESCRIPTION
Integer div_trunc, remainder, and fmod on CUDA previously relied on hardware behavior for division by zero, which is undefined and produced inconsistent results across dtypes and platforms (e.g. -1 for int32, mixed values for int64, different behavior on ROCm vs NVIDIA).

Guard all three kernels to return 0 when the divisor is zero, except for uint8 remainder on NVIDIA which preserves the existing 255 return value. Update the corresponding test to assert deterministic results instead of documenting UB, and add a new test for div_trunc by zero.

Co-authored-by: Claude <noreply@anthropic.com>

Fixes: #165650 

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia