### PR TITLE
docs: remove unsupported out= from torch.linalg._powsum docstring

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -3018,7 +3018,7 @@ Examples::
 _powsum = _add_docstr(
     _linalg.linalg__powsum,
     r"""
-linalg._powsum(x, ord, dim=None, keepdim=False, *, dtype=None, out=None) -> Tensor
+linalg._powsum(x, ord, dim=None, keepdim=False, *, dtype=None) -> Tensor
 
 Computes the sum of the absolute values raised to the power ``ord``.
 
@@ -3040,7 +3040,6 @@ Keyword args:
     dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
           If specified, the input tensor is cast to :attr:`dtype` before the operation
           is performed. Default: ``None``.
-    out (Tensor, optional): output tensor. Ignored if ``None``. Default: ``None``.
 
 Returns:
     A real-valued tensor, even when :attr:`x` is complex.


### PR DESCRIPTION
## Summary

Fixes #180649.

`torch.linalg._powsum`'s Python docstring advertises an `out=None` keyword argument in both the signature line and the `Keyword args` section, but the underlying aten schema has no `out` parameter:

```
- func: linalg__powsum(Tensor self, Scalar ord=2, int[1]? dim=None,
                      bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
```

So calls like `torch.linalg._powsum(x, 2.0, out=out)` raise `TypeError: linalg__powsum() got an unexpected keyword argument 'out'`.

This PR drops the `out=` reference from the docstring only — no runtime behavior change. I followed the doc-fix-only approach; if the preference is to instead add an `out` overload to the aten schema, happy to close this and let someone wire that up.

(Previous attempt was #180768, which was closed for unrelated reasons — CLA co-author issue and a bad rebase that touched 205 files. This PR is a minimal 1-file / 1-insertion / 2-deletion diff.)

## Testing

- Reproduced the reported `TypeError` from the issue against `main`; confirmed the call signature the docstring advertised did not work.
- No Python import or behavior change — only the string passed to `_add_docstr` is edited.