### PR TITLE
docs: fix index_add_ `index` description (points into self, not source)

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2420,7 +2420,7 @@ Note:
 
 Args:
     dim (int): dimension along which to index
-    index (Tensor): indices of ``source`` to select from,
+    index (Tensor): indices of :attr:`self` to add into,
             should have dtype either `torch.int64` or `torch.int32`
     source (Tensor): the tensor containing values to add
 


### PR DESCRIPTION
## Summary

Fixes #180119.

`torch.Tensor.index_add_`'s docstring currently describes the `index` argument as:

```
index (Tensor): indices of ``source`` to select from,
        should have dtype either `torch.int64` or `torch.int32`
```

That's backwards. As the docstring's own 3-D indexing block makes clear:

```
self[index[i], :, :] += alpha * src[i, :, :]  # if dim == 0
```

`i` iterates through rows of `source` linearly, and `index[i]` is the row of `self` being written into. So the indices point into `self`, not `source`.

This PR rewords the description to match — and follows the phrasing style already used by sibling methods like `index_fill_` (`indices of :attr:\`self\` tensor to fill in`):

```
index (Tensor): indices of :attr:`self` to add into,
```

## Testing

Docstring-only change; no tests added. Verified the new phrasing matches the `index_fill_` pattern in the same file and the "self[index[i], :, :] += ..." block immediately above it in `index_add_`.