### PR TITLE
Fix test_hf_logging_logger CI hang by dropping transformers import

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -80,7 +80,6 @@ from torch.testing._internal.common_utils import (
     skipIfCrossRef,
     skipIfRocm,
     skipIfXpu,
-    TEST_TRANSFORMERS,
     TEST_WITH_CROSSREF,
     TestCase as TorchTestCase,
 )
@@ -17877,30 +17876,35 @@ add: USER_INPUT_MUTATION target='x'
 add_2: USER_OUTPUT""",
         )
 
-    @unittest.skipIf(not TEST_TRANSFORMERS, "No transformers")
     def test_hf_logging_logger(self):
-        import transformers
+        # Replicate the HF transformers logging pattern (stdlib logging.Logger
+        # with a monkey-patched warning_once) without importing transformers,
+        # whose import can hang in CI on HF Hub I/O.
+        @functools.lru_cache(None)
+        def warning_once(self, *args, **kwargs):
+            self.warning(*args, **kwargs)
 
-        logger = transformers.utils.logging.get_logger(__name__)
+        with patch.object(logging.Logger, "warning_once", warning_once, create=True):
+            logger = logging.getLogger(__name__)
 
-        class M(torch.nn.Module):
-            def forward(self, x):
-                logger.warning_once("start")
-                x1 = x + x
-                x2 = x1 * x1
-                x3 = x2 + x2
-                return (x1, x3)
+            class M(torch.nn.Module):
+                def forward(self, x):
+                    logger.warning_once("start")
+                    x1 = x + x
+                    x2 = x1 * x1
+                    x3 = x2 + x2
+                    return (x1, x3)
 
-        gm = export(M(), (torch.randn(3, 3),)).graph_module
-        self.assertExpectedInline(
-            gm.code.strip(),
-            """\
+            gm = export(M(), (torch.randn(3, 3),)).graph_module
+            self.assertExpectedInline(
+                gm.code.strip(),
+                """\
 def forward(self, x):
     add = torch.ops.aten.add.Tensor(x, x);  x = None
     mul = torch.ops.aten.mul.Tensor(add, add)
     add_1 = torch.ops.aten.add.Tensor(mul, mul);  mul = None
     return (add, add_1)""",
-        )
+            )
 
     def test_warning(self):
         class M(torch.nn.Module):


### PR DESCRIPTION
## Summary

`test/export/test_export.py::TestOneOffModelExportResult::test_hf_logging_logger` has been intermittently hanging in CI for >30 minutes (SIGTERM exit code 124, both retries hit the same wall-clock timeout).

Root cause: the test imports `transformers` inside its body. Transformers v5 transitively imports `huggingface_hub`, and with a cold CI cache the import can stall on HF Hub I/O.

The test doesn't actually exercise any `transformers`-specific behavior — `transformers.utils.logging.get_logger` just returns a stdlib `logging.Logger` with a monkey-patched `warning_once` method (see `transformers/utils/logging.py` in v5). This PR replicates that pattern directly with `unittest.mock.patch.object` and drops both the `transformers` import and the `TEST_TRANSFORMERS` skip gate. The regression guard — that `logger.warning_once` calls don't produce tensor ops in the exported graph — is preserved.

## Test plan

- [ ] CI: `pull / linux-jammy-py3.10-gcc11 / test (default, 3, 5)` should no longer time out on this test.
- [x] Locally: `pytest test/export/test_export.py::TestOneOffModelExportResult::test_hf_logging_logger -v` passes.

Authored with Claude.