### PR TITLE
Correct the Repo Name in allowlist.yaml

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -36,4 +36,4 @@
 #   - org4/downstream-repo4: @oncall1,oncall2
 
 L1:
-  - ascend/pytorch
+  - Ascend/pytorch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180794

Plugin repo address of Ascend NPU should be `Ascend/pytorch` rather than `ascend/pytorch`
The link is [here](https://github.com/Ascend/pytorch)