### PR TITLE
Centralize FX graph cacheability validation

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -2545,10 +2545,8 @@ class TestCustomPartitionerFn(CustomPartitionerFn):
 
 
 class TestFxGraphCacheHashing(TestCase):
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "requires MKLDNN")
     def test_cacheability_validator_checks_mkldnn_constant(self):
-        if not torch.backends.mkldnn.is_available():
-            raise unittest.SkipTest("requires MKLDNN")
-
         graph = torch.fx.Graph()
         output = graph.get_attr("mkldnn_weight")
         graph.output(output)
@@ -2559,10 +2557,8 @@ class TestFxGraphCacheHashing(TestCase):
         with self.assertRaisesRegex(BypassFxGraphCache, "mkldnn tensors unpickleable"):
             CacheabilityValidator(gm, require_shape_env=False).validate()
 
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "requires MKLDNN")
     def test_check_for_hop_skips_constants(self):
-        if not torch.backends.mkldnn.is_available():
-            raise unittest.SkipTest("requires MKLDNN")
-
         graph = torch.fx.Graph()
         output = graph.get_attr("mkldnn_weight")
         graph.output(output)
@@ -2582,10 +2578,8 @@ class TestFxGraphCacheHashing(TestCase):
                 require_shape_env=False,
             )
 
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "requires MKLDNN")
     def test_check_can_cache_checks_nested_fx_kwargs_tensor(self):
-        if not torch.backends.mkldnn.is_available():
-            raise unittest.SkipTest("requires MKLDNN")
-
         gm = torch.fx.GraphModule({}, torch.fx.Graph())
         fx_kwargs = cast(
             Any, {"nested": {"mkldnn_weight": torch.randn(2, 2).to_mkldnn()}}

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -2585,6 +2585,18 @@ class TestFxGraphCacheHashing(TestCase):
                 require_shape_env=False,
             )
 
+    def test_bypass_for_pickle_error_logs_traceback(self):
+        with self.assertLogs("torch._inductor.codecache", level="WARNING") as logs:
+            with self.assertRaisesRegex(BypassFxGraphCache, "Failed to pickle cache key"):
+                try:
+                    raise RuntimeError("pickle failed")
+                except RuntimeError as e:
+                    CacheabilityValidator.bypass_for_pickle_error(e)
+
+        self.assertEqual(len(logs.records), 1)
+        self.assertIn("Failed to pickle cache key", logs.records[0].getMessage())
+        self.assertIsNotNone(logs.records[0].exc_info)
+
     def test_parameter_constants(self):
         """
         Test the hashing of parameter constants.

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -23,6 +23,7 @@ from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
 from torch._inductor import config, metrics
 from torch._inductor.codecache import (
     BypassFxGraphCache,
+    CacheabilityValidator,
     CUDACodeCache,
     FxGraphCachePickler,
     FxGraphHashDetails,
@@ -2542,6 +2543,22 @@ class TestCustomPartitionerFn(CustomPartitionerFn):
 
 
 class TestFxGraphCacheHashing(TestCase):
+    def test_cacheability_validator_checks_mkldnn_constant(self):
+        if not torch.backends.mkldnn.is_available():
+            raise unittest.SkipTest("requires MKLDNN")
+
+        graph = torch.fx.Graph()
+        output = graph.get_attr("mkldnn_weight")
+        graph.output(output)
+        gm = torch.fx.GraphModule(
+            {"mkldnn_weight": torch.randn(2, 2).to_mkldnn()}, graph
+        )
+
+        with self.assertRaisesRegex(
+            BypassFxGraphCache, "mkldnn tensors unpickleable"
+        ):
+            CacheabilityValidator(gm, require_shape_env=False).validate()
+
     def test_parameter_constants(self):
         """
         Test the hashing of parameter constants.

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -2559,6 +2559,19 @@ class TestFxGraphCacheHashing(TestCase):
         with self.assertRaisesRegex(BypassFxGraphCache, "mkldnn tensors unpickleable"):
             CacheabilityValidator(gm, require_shape_env=False).validate()
 
+    def test_check_for_hop_skips_constants(self):
+        if not torch.backends.mkldnn.is_available():
+            raise unittest.SkipTest("requires MKLDNN")
+
+        graph = torch.fx.Graph()
+        output = graph.get_attr("mkldnn_weight")
+        graph.output(output)
+        gm = torch.fx.GraphModule(
+            {"mkldnn_weight": torch.randn(2, 2).to_mkldnn()}, graph
+        )
+
+        FxGraphCache._check_for_hop(gm)
+
     def test_check_can_cache_checks_backward_state_example_inputs(self):
         gm = torch.fx.GraphModule({}, torch.fx.Graph())
 
@@ -2587,7 +2600,9 @@ class TestFxGraphCacheHashing(TestCase):
 
     def test_bypass_for_pickle_error_logs_traceback(self):
         with self.assertLogs("torch._inductor.codecache", level="WARNING") as logs:
-            with self.assertRaisesRegex(BypassFxGraphCache, "Failed to pickle cache key"):
+            with self.assertRaisesRegex(
+                BypassFxGraphCache, "Failed to pickle cache key"
+            ):
                 try:
                     raise RuntimeError("pickle failed")
                 except RuntimeError as e:

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -10,6 +10,7 @@ import tempfile
 import textwrap
 import unittest
 from contextlib import contextmanager
+from typing import Any, cast
 from typing_extensions import override
 from unittest import mock
 
@@ -25,6 +26,7 @@ from torch._inductor.codecache import (
     BypassFxGraphCache,
     CacheabilityValidator,
     CUDACodeCache,
+    FxGraphCache,
     FxGraphCachePickler,
     FxGraphHashDetails,
     PyCodeCache,
@@ -2554,10 +2556,34 @@ class TestFxGraphCacheHashing(TestCase):
             {"mkldnn_weight": torch.randn(2, 2).to_mkldnn()}, graph
         )
 
-        with self.assertRaisesRegex(
-            BypassFxGraphCache, "mkldnn tensors unpickleable"
-        ):
+        with self.assertRaisesRegex(BypassFxGraphCache, "mkldnn tensors unpickleable"):
             CacheabilityValidator(gm, require_shape_env=False).validate()
+
+    def test_check_can_cache_checks_backward_state_example_inputs(self):
+        gm = torch.fx.GraphModule({}, torch.fx.Graph())
+
+        with self.assertRaisesRegex(BypassFxGraphCache, "Reduce unsupported"):
+            FxGraphCache._check_can_cache(
+                gm,
+                [torch.fx.experimental._backward_state.BackwardState()],
+                require_shape_env=False,
+            )
+
+    def test_check_can_cache_checks_nested_fx_kwargs_tensor(self):
+        if not torch.backends.mkldnn.is_available():
+            raise unittest.SkipTest("requires MKLDNN")
+
+        gm = torch.fx.GraphModule({}, torch.fx.Graph())
+        fx_kwargs = cast(
+            Any, {"nested": {"mkldnn_weight": torch.randn(2, 2).to_mkldnn()}}
+        )
+
+        with self.assertRaisesRegex(BypassFxGraphCache, "mkldnn tensors unpickleable"):
+            FxGraphCache._check_can_cache(
+                gm,
+                fx_kwargs=fx_kwargs,
+                require_shape_env=False,
+            )
 
     def test_parameter_constants(self):
         """

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -2698,6 +2698,19 @@ class TestFxGraphCacheHashing(TestCase):
         with self.assertRaisesRegex(BypassFxGraphCache, "mkldnn tensors unpickleable"):
             CacheabilityValidator(gm, require_shape_env=False).validate()
 
+    def test_check_for_hop_skips_constants(self):
+        if not torch.backends.mkldnn.is_available():
+            raise unittest.SkipTest("requires MKLDNN")
+
+        graph = torch.fx.Graph()
+        output = graph.get_attr("mkldnn_weight")
+        graph.output(output)
+        gm = torch.fx.GraphModule(
+            {"mkldnn_weight": torch.randn(2, 2).to_mkldnn()}, graph
+        )
+
+        FxGraphCache._check_for_hop(gm)
+
     def test_check_can_cache_checks_backward_state_example_inputs(self):
         gm = torch.fx.GraphModule({}, torch.fx.Graph())
 
@@ -2726,7 +2739,9 @@ class TestFxGraphCacheHashing(TestCase):
 
     def test_bypass_for_pickle_error_logs_traceback(self):
         with self.assertLogs("torch._inductor.codecache", level="WARNING") as logs:
-            with self.assertRaisesRegex(BypassFxGraphCache, "Failed to pickle cache key"):
+            with self.assertRaisesRegex(
+                BypassFxGraphCache, "Failed to pickle cache key"
+            ):
                 try:
                     raise RuntimeError("pickle failed")
                 except RuntimeError as e:

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -37,8 +37,8 @@ from torch._inductor.cache_key import (
 )
 from torch._inductor.codecache import (
     BypassFxGraphCache,
-    CacheBase,
     CacheabilityValidator,
+    CacheBase,
     CUDACodeCache,
     FxGraphCache,
     FxGraphCachePickler,

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -2684,10 +2684,8 @@ class TestCustomPartitionerFn(CustomPartitionerFn):
 
 
 class TestFxGraphCacheHashing(TestCase):
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "requires MKLDNN")
     def test_cacheability_validator_checks_mkldnn_constant(self):
-        if not torch.backends.mkldnn.is_available():
-            raise unittest.SkipTest("requires MKLDNN")
-
         graph = torch.fx.Graph()
         output = graph.get_attr("mkldnn_weight")
         graph.output(output)
@@ -2698,10 +2696,8 @@ class TestFxGraphCacheHashing(TestCase):
         with self.assertRaisesRegex(BypassFxGraphCache, "mkldnn tensors unpickleable"):
             CacheabilityValidator(gm, require_shape_env=False).validate()
 
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "requires MKLDNN")
     def test_check_for_hop_skips_constants(self):
-        if not torch.backends.mkldnn.is_available():
-            raise unittest.SkipTest("requires MKLDNN")
-
         graph = torch.fx.Graph()
         output = graph.get_attr("mkldnn_weight")
         graph.output(output)
@@ -2721,10 +2717,8 @@ class TestFxGraphCacheHashing(TestCase):
                 require_shape_env=False,
             )
 
+    @unittest.skipIf(not torch.backends.mkldnn.is_available(), "requires MKLDNN")
     def test_check_can_cache_checks_nested_fx_kwargs_tensor(self):
-        if not torch.backends.mkldnn.is_available():
-            raise unittest.SkipTest("requires MKLDNN")
-
         gm = torch.fx.GraphModule({}, torch.fx.Graph())
         fx_kwargs = cast(
             Any, {"nested": {"mkldnn_weight": torch.randn(2, 2).to_mkldnn()}}

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -15,6 +15,7 @@ import textwrap
 import types
 import unittest
 from contextlib import contextmanager
+from typing import Any, cast
 from typing_extensions import override
 from unittest import mock
 
@@ -39,6 +40,7 @@ from torch._inductor.codecache import (
     CacheBase,
     CacheabilityValidator,
     CUDACodeCache,
+    FxGraphCache,
     FxGraphCachePickler,
     FxGraphHashDetails,
     PyCodeCache,
@@ -2693,10 +2695,34 @@ class TestFxGraphCacheHashing(TestCase):
             {"mkldnn_weight": torch.randn(2, 2).to_mkldnn()}, graph
         )
 
-        with self.assertRaisesRegex(
-            BypassFxGraphCache, "mkldnn tensors unpickleable"
-        ):
+        with self.assertRaisesRegex(BypassFxGraphCache, "mkldnn tensors unpickleable"):
             CacheabilityValidator(gm, require_shape_env=False).validate()
+
+    def test_check_can_cache_checks_backward_state_example_inputs(self):
+        gm = torch.fx.GraphModule({}, torch.fx.Graph())
+
+        with self.assertRaisesRegex(BypassFxGraphCache, "Reduce unsupported"):
+            FxGraphCache._check_can_cache(
+                gm,
+                [torch.fx.experimental._backward_state.BackwardState()],
+                require_shape_env=False,
+            )
+
+    def test_check_can_cache_checks_nested_fx_kwargs_tensor(self):
+        if not torch.backends.mkldnn.is_available():
+            raise unittest.SkipTest("requires MKLDNN")
+
+        gm = torch.fx.GraphModule({}, torch.fx.Graph())
+        fx_kwargs = cast(
+            Any, {"nested": {"mkldnn_weight": torch.randn(2, 2).to_mkldnn()}}
+        )
+
+        with self.assertRaisesRegex(BypassFxGraphCache, "mkldnn tensors unpickleable"):
+            FxGraphCache._check_can_cache(
+                gm,
+                fx_kwargs=fx_kwargs,
+                require_shape_env=False,
+            )
 
     def test_parameter_constants(self):
         """

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -37,6 +37,7 @@ from torch._inductor.cache_key import (
 from torch._inductor.codecache import (
     BypassFxGraphCache,
     CacheBase,
+    CacheabilityValidator,
     CUDACodeCache,
     FxGraphCachePickler,
     FxGraphHashDetails,
@@ -2681,6 +2682,22 @@ class TestCustomPartitionerFn(CustomPartitionerFn):
 
 
 class TestFxGraphCacheHashing(TestCase):
+    def test_cacheability_validator_checks_mkldnn_constant(self):
+        if not torch.backends.mkldnn.is_available():
+            raise unittest.SkipTest("requires MKLDNN")
+
+        graph = torch.fx.Graph()
+        output = graph.get_attr("mkldnn_weight")
+        graph.output(output)
+        gm = torch.fx.GraphModule(
+            {"mkldnn_weight": torch.randn(2, 2).to_mkldnn()}, graph
+        )
+
+        with self.assertRaisesRegex(
+            BypassFxGraphCache, "mkldnn tensors unpickleable"
+        ):
+            CacheabilityValidator(gm, require_shape_env=False).validate()
+
     def test_parameter_constants(self):
         """
         Test the hashing of parameter constants.

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -2724,6 +2724,18 @@ class TestFxGraphCacheHashing(TestCase):
                 require_shape_env=False,
             )
 
+    def test_bypass_for_pickle_error_logs_traceback(self):
+        with self.assertLogs("torch._inductor.codecache", level="WARNING") as logs:
+            with self.assertRaisesRegex(BypassFxGraphCache, "Failed to pickle cache key"):
+                try:
+                    raise RuntimeError("pickle failed")
+                except RuntimeError as e:
+                    CacheabilityValidator.bypass_for_pickle_error(e)
+
+        self.assertEqual(len(logs.records), 1)
+        self.assertIn("Failed to pickle cache key", logs.records[0].getMessage())
+        self.assertIsNotNone(logs.records[0].exc_info)
+
     def test_parameter_constants(self):
         """
         Test the hashing of parameter constants.

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -524,7 +524,7 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
             # FXGraphCache has constraints on what can be pickled in its inductor
             # config. Check that the gm is cacheable by inductor first,
             # and if it raises an exception, also bypass on our end.
-            FxGraphCache._check_can_cache(gm)
+            FxGraphCache._check_can_cache(gm, example_inputs, fx_config)
             super().__init__(gm, example_inputs, fx_config, [])
         except BypassFxGraphCache as e:
             # Sometimes inductor configs are unpickleable and can fail

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -525,7 +525,7 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
             # FXGraphCache has constraints on what can be pickled in its inductor
             # config. Check that the gm is cacheable by inductor first,
             # and if it raises an exception, also bypass on our end.
-            FxGraphCache._check_can_cache(gm)
+            FxGraphCache._check_can_cache(gm, example_inputs, fx_config)
             super().__init__(gm, example_inputs, fx_config, [])
         except BypassFxGraphCache as e:
             # Sometimes inductor configs are unpickleable and can fail

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -874,7 +874,7 @@ class CacheabilityValidator:
 
     @staticmethod
     def bypass_for_pickle_error(e: Exception) -> NoReturn:
-        log.warning("Failed to pickle cache key: %s", e)
+        log.warning("Failed to pickle cache key", exc_info=True)
         raise BypassFxGraphCache("Failed to pickle cache key") from e
 
     @staticmethod

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -566,7 +566,7 @@ class FxGraphCachePickler(pickle.Pickler):
             # TODO: These tensors don't currently pickle, so we can't cache a compiled
             # graph containing them. Just fail now. If mkldnn tensors get pickling
             # support, we can remove this.
-            raise BypassFxGraphCache("mkldnn tensors unpickleable")
+            CacheabilityValidator.check_tensor(t)
 
         metadata = extract_tensor_metadata_for_cache_key(t)
         if self._device_id_agnostic:
@@ -613,7 +613,7 @@ class FxGraphCachePickler(pickle.Pickler):
         Custom reducer to handle any objects that we don't support and therefore
         raise to bypass caching.
         """
-        raise BypassFxGraphCache("Reduce unsupported")
+        CacheabilityValidator.bypass("Reduce unsupported")
 
     def _reduce_graph_module(
         self, gm: torch.fx.GraphModule
@@ -659,14 +659,12 @@ class FxGraphCachePickler(pickle.Pickler):
             return self._stream.getvalue()
         except (TypeError, AttributeError, pickle.PicklingError, ValueError) as e:
             # Some configs options may not pickle.
-            log.warning("Failed to pickle cache key", exc_info=True)
-            raise BypassFxGraphCache("Failed to pickle cache key") from e
+            CacheabilityValidator.bypass_for_pickle_error(e)
         except RuntimeError as e:
             # pybind11 raises RuntimeError with message like:
             # "<pybind11_builtins... object at 0x...> is not pickleable."
             if "pybind11" in str(e) and "is not pickleable" in str(e):
-                log.warning("Failed to pickle cache key", exc_info=True)
-                raise BypassFxGraphCache("Failed to pickle cache key") from e
+                CacheabilityValidator.bypass_for_pickle_error(e)
             raise
         finally:
             # Reset our stream for the next dump.
@@ -808,6 +806,156 @@ class BypassFxGraphCache(Exception):
     """
     Exception to indicate that the FxGraphCache should be bypassed.
     """
+
+
+@dataclasses.dataclass(frozen=True)
+class CacheabilityValidator:
+    """
+    Centralized validation for deciding whether an FX graph can use the cache.
+
+    The cache key pickler still defends itself when serializing arbitrary objects,
+    but non-cacheable inputs should be rejected here before hashing starts.
+    """
+
+    gm: torch.fx.GraphModule
+    example_inputs: Sequence[InputType] = ()
+    fx_kwargs: _CompileFxKwargs | None = None
+    require_shape_env: bool = True
+
+    def validate(self) -> None:
+        self._check_custom_passes()
+        self._check_frozen_params()
+        self._check_runtime_constant_folding()
+        self._check_compiler_bisector()
+        self._check_shape_env()
+        self.validate_graph(include_constants=True)
+        self._check_cache_key_object(self.example_inputs)
+        if self.fx_kwargs is not None:
+            self._check_cache_key_object(self.fx_kwargs)
+
+    def validate_graph(self, include_constants: bool) -> None:
+        for module in self.gm.modules():
+            if not isinstance(module, torch.fx.GraphModule):
+                continue
+            for node in module.graph.nodes:
+                if (
+                    isinstance(node.target, torch._ops.HigherOrderOperator)
+                    and not node.target.cacheable()
+                ):
+                    self.bypass(
+                        f"Can't cache HigherOrderOperator: {node.target.name()}"
+                    )
+                # TODO: this check is broken in two ways:
+                # 1. FX uses "get_attr" (with underscore), not "getattr"
+                # 2. It only checks for ScriptObject, not FakeScriptObject
+                # Fixing it would also bypass AOTAutogradCache (which calls
+                # _check_can_cache), so we'd need to decouple the two first.
+                if node.op == "getattr" and isinstance(
+                    getattr(self.gm, node.target), torch._C.ScriptObject
+                ):
+                    self.bypass("Can't cache torchbind objects")
+                if include_constants and node.op == "get_attr":
+                    try:
+                        attr = self._get_attr(module, node.target)
+                    except AttributeError:
+                        continue
+                    self._check_cache_key_object(attr)
+
+    @staticmethod
+    def check_tensor(t: Tensor) -> None:
+        if t.is_mkldnn:
+            CacheabilityValidator.bypass("mkldnn tensors unpickleable")
+
+    @staticmethod
+    def bypass(reason: str) -> NoReturn:
+        raise BypassFxGraphCache(reason)
+
+    @staticmethod
+    def bypass_for_pickle_error(e: Exception) -> NoReturn:
+        log.warning("Failed to pickle cache key", exc_info=True)
+        raise BypassFxGraphCache("Failed to pickle cache key") from e
+
+    @staticmethod
+    def _get_attr(module: torch.fx.GraphModule, target: str) -> Any:
+        from torch.fx.graph_module import _get_attr
+
+        return _get_attr(module, target)
+
+    def _check_custom_passes(self) -> None:
+        # Custom passes must implement the CustomGraphPass or we don't
+        # know how to include them in the cache key calculation.
+        # When timing is EARLY, pre-grad passes already ran before the cache
+        # lookup so there's nothing to validate here.
+        if resolve_pre_grad_pass_timing() != "early":
+            assert not config.pre_grad_custom_pass or (
+                isinstance(config.pre_grad_custom_pass, CustomGraphPass)
+                and config.pre_grad_custom_pass.uuid()
+            ), "Unsupported pre grad custom pass"
+        for p in (config.post_grad_custom_pre_pass, config.post_grad_custom_post_pass):
+            if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
+                self.bypass("Unsupported post grad custom pass")
+        # Same with the joint custom passes
+        for p in (config.joint_custom_pre_pass, config.joint_custom_post_pass):
+            if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
+                self.bypass("Unsupported joint custom pass")
+        # We should find any users of _pre_fusion_custom_pass and _fuse_ddp_communication_passes
+        # and ensure they are not passing us raw callables
+        if config._pre_fusion_custom_pass is not None:
+            if not isinstance(config._pre_fusion_custom_pass, CustomGraphPass):
+                self.bypass("Unsupported _pre_fusion_custom_pass")
+        for p in config._fuse_ddp_communication_passes:
+            if callable(p) and not isinstance(p, CustomGraphPass):
+                self.bypass("Unsupported _fuse_ddp_communication_pass")
+
+    def _check_frozen_params(self) -> None:
+        # Freezing can embed constants that wouldn't be static across runs.
+        if has_frozen_params(self.gm) and not torch._utils_internal.justknobs_check(
+            "pytorch/inductor:allow_freezing_with_caching"
+        ):
+            self.bypass("Skipping graph with frozen constants")
+
+    def _check_runtime_constant_folding(self) -> None:
+        if config.aot_inductor.use_runtime_constant_folding:
+            self.bypass(
+                "Runtime constant folding can introduce constants that aren't "
+                "static across runs"
+            )
+
+    def _check_compiler_bisector(self) -> None:
+        from torch._inductor.compiler_bisector import CompilerBisector
+
+        if CompilerBisector.bisection_enabled:
+            log.debug("dont cache graph when bisect enabled")
+            self.bypass("")
+
+    def _check_shape_env(self) -> None:
+        # The treatment of guards in the caching implementation requires that
+        # we have a shape env.
+        if self.require_shape_env and FxGraphCache._get_shape_env() is None:
+            log.debug("fx graph cache no shape env")
+            self.bypass("No shape env")
+
+    def _check_cache_key_object(self, obj: Any, seen: set[int] | None = None) -> None:
+        if seen is None:
+            seen = set()
+
+        obj_id = id(obj)
+        if obj_id in seen:
+            return
+        seen.add(obj_id)
+
+        if isinstance(obj, torch.Tensor):
+            self.check_tensor(obj)
+            return
+        if isinstance(obj, torch.fx.experimental._backward_state.BackwardState):
+            self.bypass("Reduce unsupported")
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                self._check_cache_key_object(key, seen)
+                self._check_cache_key_object(value, seen)
+        elif isinstance(obj, (list, tuple, set, frozenset, OrderedSet)):
+            for item in obj:
+                self._check_cache_key_object(item, seen)
 
 
 _warned_pre_grad_pass_missing_uuid: OrderedSet[str] = OrderedSet()
@@ -1668,84 +1816,27 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
 
     @staticmethod
     def _check_for_hop(gm: torch.fx.GraphModule) -> None:
-        for module in gm.modules():
-            if not isinstance(module, torch.fx.GraphModule):
-                continue
-            for node in module.graph.nodes:
-                if (
-                    isinstance(node.target, torch._ops.HigherOrderOperator)
-                    and not node.target.cacheable()
-                ):
-                    raise BypassFxGraphCache(
-                        f"Can't cache HigherOrderOperator: {node.target.name()}"
-                    )
-                # TODO: this check is broken in two ways:
-                # 1. FX uses "get_attr" (with underscore), not "getattr"
-                # 2. It only checks for ScriptObject, not FakeScriptObject
-                # Fixing it would also bypass AOTAutogradCache (which calls
-                # _check_can_cache), so we'd need to decouple the two first.
-                if node.op == "getattr" and isinstance(
-                    getattr(gm, node.target), torch._C.ScriptObject
-                ):
-                    raise BypassFxGraphCache("Can't cache torchbind objects")
+        CacheabilityValidator(gm, require_shape_env=False).validate_graph(
+            include_constants=False
+        )
 
     @staticmethod
-    def _check_can_cache(gm: torch.fx.GraphModule) -> None:
+    def _check_can_cache(
+        gm: torch.fx.GraphModule,
+        example_inputs: Sequence[InputType] = (),
+        fx_kwargs: _CompileFxKwargs | None = None,
+        require_shape_env: bool = True,
+    ) -> None:
         """
         Check some conditions that would preclude caching and raise BypassFxGraphCache
         to bypass in case caching is not possible.
         """
-        # Custom passes must implement the CustomGraphPass or we don't
-        # know how to include them in the cache key calculation.
-        # When timing is EARLY, pre-grad passes already ran before the cache
-        # lookup so there's nothing to validate here.
-        if resolve_pre_grad_pass_timing() != "early":
-            assert not config.pre_grad_custom_pass or (
-                isinstance(config.pre_grad_custom_pass, CustomGraphPass)
-                and config.pre_grad_custom_pass.uuid()
-            ), "Unsupported pre grad custom pass"
-        for p in (config.post_grad_custom_pre_pass, config.post_grad_custom_post_pass):
-            if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
-                raise BypassFxGraphCache("Unsupported post grad custom pass")
-        # Same with the joint custom passes
-        for p in (config.joint_custom_pre_pass, config.joint_custom_post_pass):
-            if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
-                raise BypassFxGraphCache("Unsupported joint custom pass")
-        # We should find any users of _pre_fusion_custom_pass and _fuse_ddp_communication_passes
-        # and ensure they are not passing us raw callables
-        if config._pre_fusion_custom_pass is not None:
-            if not isinstance(config._pre_fusion_custom_pass, CustomGraphPass):
-                raise BypassFxGraphCache("Unsupported _pre_fusion_custom_pass")
-        for p in config._fuse_ddp_communication_passes:
-            if callable(p) and not isinstance(p, CustomGraphPass):
-                raise BypassFxGraphCache("Unsupported _fuse_ddp_communication_pass")
-
-        # Freezing can embed constants that wouldn't be static across runs.
-        if has_frozen_params(gm) and not torch._utils_internal.justknobs_check(
-            "pytorch/inductor:allow_freezing_with_caching"
-        ):
-            raise BypassFxGraphCache("Skipping graph with frozen constants")
-
-        if config.aot_inductor.use_runtime_constant_folding:
-            raise BypassFxGraphCache(
-                "Runtime constant folding can introduce constants that aren't "
-                "static across runs"
-            )
-
-        from torch._inductor.compiler_bisector import CompilerBisector
-
-        if CompilerBisector.bisection_enabled:
-            log.debug("dont cache graph when bisect enabled")
-            raise BypassFxGraphCache
-
-        # The treatment of guards in the caching implementation requires that
-        # we have a shape env.
-        if FxGraphCache._get_shape_env() is None:
-            log.debug("fx graph cache no shape env")
-            raise BypassFxGraphCache("No shape env")
-
-        # We skip caching if there are any HOPs or torchbind objects.
-        FxGraphCache._check_for_hop(gm)
+        CacheabilityValidator(
+            gm,
+            example_inputs=example_inputs,
+            fx_kwargs=fx_kwargs,
+            require_shape_env=require_shape_env,
+        ).validate()
 
     @staticmethod
     def prepare_key(
@@ -1766,7 +1857,7 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
         I personally believe it is more annoying/difficult to read in that format.
         """
         try:
-            FxGraphCache._check_can_cache(gm)
+            FxGraphCache._check_can_cache(gm, example_inputs, fx_kwargs)
             key, debug_lines = compiled_fx_graph_hash(
                 gm, example_inputs, fx_kwargs, inputs_to_check
             )

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -26,6 +26,7 @@ import textwrap
 import threading
 import warnings
 from bisect import bisect_right
+from collections.abc import Set as AbstractSet
 from copy import copy
 from ctypes import c_void_p, CDLL, cdll
 from datetime import timedelta
@@ -831,6 +832,7 @@ class CacheabilityValidator:
     example_inputs: Sequence[InputType] = ()
     fx_kwargs: _CompileFxKwargs | None = None
     require_shape_env: bool = True
+    shape_env: ShapeEnv | None = None
 
     def validate(self) -> None:
         self._check_custom_passes()
@@ -882,7 +884,7 @@ class CacheabilityValidator:
 
     @staticmethod
     def bypass_for_pickle_error(e: Exception) -> NoReturn:
-        log.warning("Failed to pickle cache key", exc_info=True)
+        log.warning("Failed to pickle cache key: %s", e)
         raise BypassFxGraphCache("Failed to pickle cache key") from e
 
     @staticmethod
@@ -897,10 +899,11 @@ class CacheabilityValidator:
         # When timing is EARLY, pre-grad passes already ran before the cache
         # lookup so there's nothing to validate here.
         if resolve_pre_grad_pass_timing() != "early":
-            assert not config.pre_grad_custom_pass or (
-                isinstance(config.pre_grad_custom_pass, CustomGraphPass)
-                and config.pre_grad_custom_pass.uuid()
-            ), "Unsupported pre grad custom pass"
+            if config.pre_grad_custom_pass and (
+                not isinstance(config.pre_grad_custom_pass, CustomGraphPass)
+                or not config.pre_grad_custom_pass.uuid()
+            ):
+                self.bypass("Unsupported pre grad custom pass")
         for p in (config.post_grad_custom_pre_pass, config.post_grad_custom_post_pass):
             if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
                 self.bypass("Unsupported post grad custom pass")
@@ -936,18 +939,20 @@ class CacheabilityValidator:
 
         if CompilerBisector.bisection_enabled:
             log.debug("dont cache graph when bisect enabled")
-            self.bypass("")
+            self.bypass("compiler bisector enabled")
 
     def _check_shape_env(self) -> None:
         # The treatment of guards in the caching implementation requires that
         # we have a shape env.
-        if self.require_shape_env and FxGraphCache._get_shape_env() is None:
+        if self.require_shape_env and self.shape_env is None:
             log.debug("fx graph cache no shape env")
             self.bypass("No shape env")
 
-    def _check_cache_key_object(self, obj: Any, seen: set[int] | None = None) -> None:
+    def _check_cache_key_object(
+        self, obj: Any, seen: OrderedSet[int] | None = None
+    ) -> None:
         if seen is None:
-            seen = set()
+            seen = OrderedSet()
 
         obj_id = id(obj)
         if obj_id in seen:
@@ -957,13 +962,13 @@ class CacheabilityValidator:
         if isinstance(obj, torch.Tensor):
             self.check_tensor(obj)
             return
-        if isinstance(obj, torch.fx.experimental._backward_state.BackwardState):
+        elif isinstance(obj, torch.fx.experimental._backward_state.BackwardState):
             self.bypass("Reduce unsupported")
-        if isinstance(obj, dict):
+        elif isinstance(obj, dict):
             for key, value in obj.items():
                 self._check_cache_key_object(key, seen)
                 self._check_cache_key_object(value, seen)
-        elif isinstance(obj, (list, tuple, set, frozenset, OrderedSet)):
+        elif isinstance(obj, (list, tuple, AbstractSet)):
             for item in obj:
                 self._check_cache_key_object(item, seen)
 
@@ -1841,11 +1846,13 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
         Check some conditions that would preclude caching and raise BypassFxGraphCache
         to bypass in case caching is not possible.
         """
+        shape_env = FxGraphCache._get_shape_env() if require_shape_env else None
         CacheabilityValidator(
             gm,
             example_inputs=example_inputs,
             fx_kwargs=fx_kwargs,
             require_shape_env=require_shape_env,
+            shape_env=shape_env,
         ).validate()
 
     @staticmethod

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -569,7 +569,7 @@ class FxGraphCachePickler(pickle.Pickler):
             # TODO: These tensors don't currently pickle, so we can't cache a compiled
             # graph containing them. Just fail now. If mkldnn tensors get pickling
             # support, we can remove this.
-            raise BypassFxGraphCache("mkldnn tensors unpickleable")
+            CacheabilityValidator.check_tensor(t)
 
         metadata = extract_tensor_metadata_for_cache_key(t)
         if self._device_id_agnostic:
@@ -616,7 +616,7 @@ class FxGraphCachePickler(pickle.Pickler):
         Custom reducer to handle any objects that we don't support and therefore
         raise to bypass caching.
         """
-        raise BypassFxGraphCache("Reduce unsupported")
+        CacheabilityValidator.bypass("Reduce unsupported")
 
     def _reduce_graph_module(
         self, gm: torch.fx.GraphModule
@@ -662,14 +662,12 @@ class FxGraphCachePickler(pickle.Pickler):
             return self._stream.getvalue()
         except (TypeError, AttributeError, pickle.PicklingError, ValueError) as e:
             # Some configs options may not pickle.
-            log.warning("Failed to pickle cache key", exc_info=True)
-            raise BypassFxGraphCache("Failed to pickle cache key") from e
+            CacheabilityValidator.bypass_for_pickle_error(e)
         except RuntimeError as e:
             # pybind11 raises RuntimeError with message like:
             # "<pybind11_builtins... object at 0x...> is not pickleable."
             if "pybind11" in str(e) and "is not pickleable" in str(e):
-                log.warning("Failed to pickle cache key", exc_info=True)
-                raise BypassFxGraphCache("Failed to pickle cache key") from e
+                CacheabilityValidator.bypass_for_pickle_error(e)
             raise
         finally:
             # Reset our stream for the next dump.
@@ -818,6 +816,156 @@ class BypassFxGraphCache(Exception):
     """
     Exception to indicate that the FxGraphCache should be bypassed.
     """
+
+
+@dataclasses.dataclass(frozen=True)
+class CacheabilityValidator:
+    """
+    Centralized validation for deciding whether an FX graph can use the cache.
+
+    The cache key pickler still defends itself when serializing arbitrary objects,
+    but non-cacheable inputs should be rejected here before hashing starts.
+    """
+
+    gm: torch.fx.GraphModule
+    example_inputs: Sequence[InputType] = ()
+    fx_kwargs: _CompileFxKwargs | None = None
+    require_shape_env: bool = True
+
+    def validate(self) -> None:
+        self._check_custom_passes()
+        self._check_frozen_params()
+        self._check_runtime_constant_folding()
+        self._check_compiler_bisector()
+        self._check_shape_env()
+        self.validate_graph(include_constants=True)
+        self._check_cache_key_object(self.example_inputs)
+        if self.fx_kwargs is not None:
+            self._check_cache_key_object(self.fx_kwargs)
+
+    def validate_graph(self, include_constants: bool) -> None:
+        for module in self.gm.modules():
+            if not isinstance(module, torch.fx.GraphModule):
+                continue
+            for node in module.graph.nodes:
+                if (
+                    isinstance(node.target, torch._ops.HigherOrderOperator)
+                    and not node.target.cacheable()
+                ):
+                    self.bypass(
+                        f"Can't cache HigherOrderOperator: {node.target.name()}"
+                    )
+                # TODO: this check is broken in two ways:
+                # 1. FX uses "get_attr" (with underscore), not "getattr"
+                # 2. It only checks for ScriptObject, not FakeScriptObject
+                # Fixing it would also bypass AOTAutogradCache (which calls
+                # _check_can_cache), so we'd need to decouple the two first.
+                if node.op == "getattr" and isinstance(
+                    getattr(self.gm, node.target), torch._C.ScriptObject
+                ):
+                    self.bypass("Can't cache torchbind objects")
+                if include_constants and node.op == "get_attr":
+                    try:
+                        attr = self._get_attr(module, node.target)
+                    except AttributeError:
+                        continue
+                    self._check_cache_key_object(attr)
+
+    @staticmethod
+    def check_tensor(t: Tensor) -> None:
+        if t.is_mkldnn:
+            CacheabilityValidator.bypass("mkldnn tensors unpickleable")
+
+    @staticmethod
+    def bypass(reason: str) -> NoReturn:
+        raise BypassFxGraphCache(reason)
+
+    @staticmethod
+    def bypass_for_pickle_error(e: Exception) -> NoReturn:
+        log.warning("Failed to pickle cache key", exc_info=True)
+        raise BypassFxGraphCache("Failed to pickle cache key") from e
+
+    @staticmethod
+    def _get_attr(module: torch.fx.GraphModule, target: str) -> Any:
+        from torch.fx.graph_module import _get_attr
+
+        return _get_attr(module, target)
+
+    def _check_custom_passes(self) -> None:
+        # Custom passes must implement the CustomGraphPass or we don't
+        # know how to include them in the cache key calculation.
+        # When timing is EARLY, pre-grad passes already ran before the cache
+        # lookup so there's nothing to validate here.
+        if resolve_pre_grad_pass_timing() != "early":
+            assert not config.pre_grad_custom_pass or (
+                isinstance(config.pre_grad_custom_pass, CustomGraphPass)
+                and config.pre_grad_custom_pass.uuid()
+            ), "Unsupported pre grad custom pass"
+        for p in (config.post_grad_custom_pre_pass, config.post_grad_custom_post_pass):
+            if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
+                self.bypass("Unsupported post grad custom pass")
+        # Same with the joint custom passes
+        for p in (config.joint_custom_pre_pass, config.joint_custom_post_pass):
+            if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
+                self.bypass("Unsupported joint custom pass")
+        # We should find any users of _pre_fusion_custom_pass and _fuse_ddp_communication_passes
+        # and ensure they are not passing us raw callables
+        if config._pre_fusion_custom_pass is not None:
+            if not isinstance(config._pre_fusion_custom_pass, CustomGraphPass):
+                self.bypass("Unsupported _pre_fusion_custom_pass")
+        for p in config._fuse_ddp_communication_passes:
+            if callable(p) and not isinstance(p, CustomGraphPass):
+                self.bypass("Unsupported _fuse_ddp_communication_pass")
+
+    def _check_frozen_params(self) -> None:
+        # Freezing can embed constants that wouldn't be static across runs.
+        if has_frozen_params(self.gm) and not torch._utils_internal.justknobs_check(
+            "pytorch/inductor:allow_freezing_with_caching"
+        ):
+            self.bypass("Skipping graph with frozen constants")
+
+    def _check_runtime_constant_folding(self) -> None:
+        if config.aot_inductor.use_runtime_constant_folding:
+            self.bypass(
+                "Runtime constant folding can introduce constants that aren't "
+                "static across runs"
+            )
+
+    def _check_compiler_bisector(self) -> None:
+        from torch._inductor.compiler_bisector import CompilerBisector
+
+        if CompilerBisector.bisection_enabled:
+            log.debug("dont cache graph when bisect enabled")
+            self.bypass("")
+
+    def _check_shape_env(self) -> None:
+        # The treatment of guards in the caching implementation requires that
+        # we have a shape env.
+        if self.require_shape_env and FxGraphCache._get_shape_env() is None:
+            log.debug("fx graph cache no shape env")
+            self.bypass("No shape env")
+
+    def _check_cache_key_object(self, obj: Any, seen: set[int] | None = None) -> None:
+        if seen is None:
+            seen = set()
+
+        obj_id = id(obj)
+        if obj_id in seen:
+            return
+        seen.add(obj_id)
+
+        if isinstance(obj, torch.Tensor):
+            self.check_tensor(obj)
+            return
+        if isinstance(obj, torch.fx.experimental._backward_state.BackwardState):
+            self.bypass("Reduce unsupported")
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                self._check_cache_key_object(key, seen)
+                self._check_cache_key_object(value, seen)
+        elif isinstance(obj, (list, tuple, set, frozenset, OrderedSet)):
+            for item in obj:
+                self._check_cache_key_object(item, seen)
 
 
 _warned_pre_grad_pass_missing_uuid: OrderedSet[str] = OrderedSet()
@@ -1678,84 +1826,27 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
 
     @staticmethod
     def _check_for_hop(gm: torch.fx.GraphModule) -> None:
-        for module in gm.modules():
-            if not isinstance(module, torch.fx.GraphModule):
-                continue
-            for node in module.graph.nodes:
-                if (
-                    isinstance(node.target, torch._ops.HigherOrderOperator)
-                    and not node.target.cacheable()
-                ):
-                    raise BypassFxGraphCache(
-                        f"Can't cache HigherOrderOperator: {node.target.name()}"
-                    )
-                # TODO: this check is broken in two ways:
-                # 1. FX uses "get_attr" (with underscore), not "getattr"
-                # 2. It only checks for ScriptObject, not FakeScriptObject
-                # Fixing it would also bypass AOTAutogradCache (which calls
-                # _check_can_cache), so we'd need to decouple the two first.
-                if node.op == "getattr" and isinstance(
-                    getattr(gm, node.target), torch._C.ScriptObject
-                ):
-                    raise BypassFxGraphCache("Can't cache torchbind objects")
+        CacheabilityValidator(gm, require_shape_env=False).validate_graph(
+            include_constants=False
+        )
 
     @staticmethod
-    def _check_can_cache(gm: torch.fx.GraphModule) -> None:
+    def _check_can_cache(
+        gm: torch.fx.GraphModule,
+        example_inputs: Sequence[InputType] = (),
+        fx_kwargs: _CompileFxKwargs | None = None,
+        require_shape_env: bool = True,
+    ) -> None:
         """
         Check some conditions that would preclude caching and raise BypassFxGraphCache
         to bypass in case caching is not possible.
         """
-        # Custom passes must implement the CustomGraphPass or we don't
-        # know how to include them in the cache key calculation.
-        # When timing is EARLY, pre-grad passes already ran before the cache
-        # lookup so there's nothing to validate here.
-        if resolve_pre_grad_pass_timing() != "early":
-            assert not config.pre_grad_custom_pass or (
-                isinstance(config.pre_grad_custom_pass, CustomGraphPass)
-                and config.pre_grad_custom_pass.uuid()
-            ), "Unsupported pre grad custom pass"
-        for p in (config.post_grad_custom_pre_pass, config.post_grad_custom_post_pass):
-            if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
-                raise BypassFxGraphCache("Unsupported post grad custom pass")
-        # Same with the joint custom passes
-        for p in (config.joint_custom_pre_pass, config.joint_custom_post_pass):
-            if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
-                raise BypassFxGraphCache("Unsupported joint custom pass")
-        # We should find any users of _pre_fusion_custom_pass and _fuse_ddp_communication_passes
-        # and ensure they are not passing us raw callables
-        if config._pre_fusion_custom_pass is not None:
-            if not isinstance(config._pre_fusion_custom_pass, CustomGraphPass):
-                raise BypassFxGraphCache("Unsupported _pre_fusion_custom_pass")
-        for p in config._fuse_ddp_communication_passes:
-            if callable(p) and not isinstance(p, CustomGraphPass):
-                raise BypassFxGraphCache("Unsupported _fuse_ddp_communication_pass")
-
-        # Freezing can embed constants that wouldn't be static across runs.
-        if has_frozen_params(gm) and not torch._utils_internal.justknobs_check(
-            "pytorch/inductor:allow_freezing_with_caching"
-        ):
-            raise BypassFxGraphCache("Skipping graph with frozen constants")
-
-        if config.aot_inductor.use_runtime_constant_folding:
-            raise BypassFxGraphCache(
-                "Runtime constant folding can introduce constants that aren't "
-                "static across runs"
-            )
-
-        from torch._inductor.compiler_bisector import CompilerBisector
-
-        if CompilerBisector.bisection_enabled:
-            log.debug("dont cache graph when bisect enabled")
-            raise BypassFxGraphCache
-
-        # The treatment of guards in the caching implementation requires that
-        # we have a shape env.
-        if FxGraphCache._get_shape_env() is None:
-            log.debug("fx graph cache no shape env")
-            raise BypassFxGraphCache("No shape env")
-
-        # We skip caching if there are any HOPs or torchbind objects.
-        FxGraphCache._check_for_hop(gm)
+        CacheabilityValidator(
+            gm,
+            example_inputs=example_inputs,
+            fx_kwargs=fx_kwargs,
+            require_shape_env=require_shape_env,
+        ).validate()
 
     @staticmethod
     def prepare_key(
@@ -1776,7 +1867,7 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
         I personally believe it is more annoying/difficult to read in that format.
         """
         try:
-            FxGraphCache._check_can_cache(gm)
+            FxGraphCache._check_can_cache(gm, example_inputs, fx_kwargs)
             key, debug_lines = compiled_fx_graph_hash(
                 gm, example_inputs, fx_kwargs, inputs_to_check
             )

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -26,6 +26,7 @@ import textwrap
 import threading
 import warnings
 from bisect import bisect_right
+from collections.abc import Set as AbstractSet
 from copy import copy
 from ctypes import c_void_p, CDLL, cdll
 from datetime import timedelta
@@ -821,6 +822,7 @@ class CacheabilityValidator:
     example_inputs: Sequence[InputType] = ()
     fx_kwargs: _CompileFxKwargs | None = None
     require_shape_env: bool = True
+    shape_env: ShapeEnv | None = None
 
     def validate(self) -> None:
         self._check_custom_passes()
@@ -872,7 +874,7 @@ class CacheabilityValidator:
 
     @staticmethod
     def bypass_for_pickle_error(e: Exception) -> NoReturn:
-        log.warning("Failed to pickle cache key", exc_info=True)
+        log.warning("Failed to pickle cache key: %s", e)
         raise BypassFxGraphCache("Failed to pickle cache key") from e
 
     @staticmethod
@@ -887,10 +889,11 @@ class CacheabilityValidator:
         # When timing is EARLY, pre-grad passes already ran before the cache
         # lookup so there's nothing to validate here.
         if resolve_pre_grad_pass_timing() != "early":
-            assert not config.pre_grad_custom_pass or (
-                isinstance(config.pre_grad_custom_pass, CustomGraphPass)
-                and config.pre_grad_custom_pass.uuid()
-            ), "Unsupported pre grad custom pass"
+            if config.pre_grad_custom_pass and (
+                not isinstance(config.pre_grad_custom_pass, CustomGraphPass)
+                or not config.pre_grad_custom_pass.uuid()
+            ):
+                self.bypass("Unsupported pre grad custom pass")
         for p in (config.post_grad_custom_pre_pass, config.post_grad_custom_post_pass):
             if p and (not isinstance(p, CustomGraphPass) or not p.uuid()):
                 self.bypass("Unsupported post grad custom pass")
@@ -926,18 +929,20 @@ class CacheabilityValidator:
 
         if CompilerBisector.bisection_enabled:
             log.debug("dont cache graph when bisect enabled")
-            self.bypass("")
+            self.bypass("compiler bisector enabled")
 
     def _check_shape_env(self) -> None:
         # The treatment of guards in the caching implementation requires that
         # we have a shape env.
-        if self.require_shape_env and FxGraphCache._get_shape_env() is None:
+        if self.require_shape_env and self.shape_env is None:
             log.debug("fx graph cache no shape env")
             self.bypass("No shape env")
 
-    def _check_cache_key_object(self, obj: Any, seen: set[int] | None = None) -> None:
+    def _check_cache_key_object(
+        self, obj: Any, seen: OrderedSet[int] | None = None
+    ) -> None:
         if seen is None:
-            seen = set()
+            seen = OrderedSet()
 
         obj_id = id(obj)
         if obj_id in seen:
@@ -947,13 +952,13 @@ class CacheabilityValidator:
         if isinstance(obj, torch.Tensor):
             self.check_tensor(obj)
             return
-        if isinstance(obj, torch.fx.experimental._backward_state.BackwardState):
+        elif isinstance(obj, torch.fx.experimental._backward_state.BackwardState):
             self.bypass("Reduce unsupported")
-        if isinstance(obj, dict):
+        elif isinstance(obj, dict):
             for key, value in obj.items():
                 self._check_cache_key_object(key, seen)
                 self._check_cache_key_object(value, seen)
-        elif isinstance(obj, (list, tuple, set, frozenset, OrderedSet)):
+        elif isinstance(obj, (list, tuple, AbstractSet)):
             for item in obj:
                 self._check_cache_key_object(item, seen)
 
@@ -1831,11 +1836,13 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
         Check some conditions that would preclude caching and raise BypassFxGraphCache
         to bypass in case caching is not possible.
         """
+        shape_env = FxGraphCache._get_shape_env() if require_shape_env else None
         CacheabilityValidator(
             gm,
             example_inputs=example_inputs,
             fx_kwargs=fx_kwargs,
             require_shape_env=require_shape_env,
+            shape_env=shape_env,
         ).validate()
 
     @staticmethod

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -874,7 +874,10 @@ class CacheabilityValidator:
 
     @staticmethod
     def bypass_for_pickle_error(e: Exception) -> NoReturn:
-        log.warning("Failed to pickle cache key", exc_info=True)
+        log.warning(
+            "Failed to pickle cache key",
+            exc_info=(type(e), e, e.__traceback__),
+        )
         raise BypassFxGraphCache("Failed to pickle cache key") from e
 
     @staticmethod
@@ -939,10 +942,12 @@ class CacheabilityValidator:
             self.bypass("No shape env")
 
     def _check_cache_key_object(
-        self, obj: Any, seen: OrderedSet[int] | None = None
+        self,
+        obj: Any,
+        seen: set[int] | None = None,  # noqa: set_linter
     ) -> None:
         if seen is None:
-            seen = OrderedSet()
+            seen = set()  # noqa: set_linter
 
         obj_id = id(obj)
         if obj_id in seen:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -884,7 +884,7 @@ class CacheabilityValidator:
 
     @staticmethod
     def bypass_for_pickle_error(e: Exception) -> NoReturn:
-        log.warning("Failed to pickle cache key: %s", e)
+        log.warning("Failed to pickle cache key", exc_info=True)
         raise BypassFxGraphCache("Failed to pickle cache key") from e
 
     @staticmethod

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -884,7 +884,10 @@ class CacheabilityValidator:
 
     @staticmethod
     def bypass_for_pickle_error(e: Exception) -> NoReturn:
-        log.warning("Failed to pickle cache key", exc_info=True)
+        log.warning(
+            "Failed to pickle cache key",
+            exc_info=(type(e), e, e.__traceback__),
+        )
         raise BypassFxGraphCache("Failed to pickle cache key") from e
 
     @staticmethod
@@ -949,10 +952,12 @@ class CacheabilityValidator:
             self.bypass("No shape env")
 
     def _check_cache_key_object(
-        self, obj: Any, seen: OrderedSet[int] | None = None
+        self,
+        obj: Any,
+        seen: set[int] | None = None,  # noqa: set_linter
     ) -> None:
         if seen is None:
-            seen = OrderedSet()
+            seen = set()  # noqa: set_linter
 
         obj_id = id(obj)
         if obj_id in seen:

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -743,9 +743,9 @@ class _OpPickleData:
         options: Options,
     ) -> "_OpPickleData":
         if (ops_filter := options.ops_filter) and not ops_filter(name):
-            from torch._inductor.codecache import BypassFxGraphCache
+            from torch._inductor.codecache import CacheabilityValidator
 
-            raise BypassFxGraphCache(f"Unable to pickle non-standard op: {name}")
+            CacheabilityValidator.bypass(f"Unable to pickle non-standard op: {name}")
         return datacls(name)
 
     @abstractmethod


### PR DESCRIPTION
## Summary
- Add CacheabilityValidator as the central owner for FX graph cache bypass validation.
- Route FxGraphCache, AOTAutogradCacheDetails, FxGraphCachePickler, and GraphPickler bypass decisions through the validator.
- Add a focused regression test for upfront MKLDNN constant rejection.

## Root cause problem
Cacheability decisions were split between upfront cache checks and serialization-time pickler reducers. That made the cacheability policy hard to audit and meant some non-cacheable inputs were only rejected while constructing the cache key.

## Proposed fix
Introduce CacheabilityValidator and have FxGraphCache._check_can_cache run it before hashing. The validator keeps existing custom-pass, frozen-constant, runtime constant folding, compiler bisector, shape env, HOP, torchbind, tensor, and unsupported-reducer bypass reasons in one place. Pickler fallback paths still route through validator helpers for defensive serialization failures.

## Why this is the right long term fix
Centralizing cacheability policy separates eligibility checks from serialization mechanics. Future cacheability rules can be added in one place, callers can run the same validation before hashing, and the picklers can stay focused on stable serialization.

## Testing
- python3 -m py_compile torch/_inductor/codecache.py torch/fx/_graph_pickler.py torch/_functorch/_aot_autograd/autograd_cache.py test/inductor/test_codecache.py
- git diff --check
- Attempted: PYTHONPATH=. python3 test/inductor/test_codecache.py TestFxGraphCacheHashing.test_cacheability_validator_checks_mkldnn_constant
  - Blocked in this checkout before test collection because generated or built source artifacts are missing: ModuleNotFoundError: No module named torch.version.
- Added the regression test before implementation; runtime failure confirmation was blocked by the same missing local torch build.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo