### PR TITLE
Refactor autotune cached config serialization

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3765,6 +3765,12 @@ class TestAutotuneCacheExtraOptions(TestCase):
     extra_options is correctly preserved when saving and loading from cache.
     """
 
+    class FakeConfig:
+        def __init__(self, kwargs, num_warps, num_stages):
+            self.kwargs = kwargs
+            self.num_warps = num_warps
+            self.num_stages = num_stages
+
     @requires_triton()
     def test_load_cached_autotuning_preserves_extra_options_with_coordesc(self):
         """
@@ -3873,6 +3879,58 @@ class TestAutotuneCacheExtraOptions(TestCase):
         self.assertIsNotNone(result)
         # extra_options should be None when not in cache
         self.assertIsNone(result.extra_options)
+
+    def test_load_cached_autotuning_reports_corrupt_unmatched_config(self):
+        from torch._inductor.runtime.autotune_cache import _load_cached_autotuning
+
+        configs = [self.FakeConfig({"BLOCK_M": 32, "BLOCK_N": 32}, 4, 2)]
+        best_config = {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "num_warps": 4,
+            "num_stages": 2,
+            "configs_hash": "test_hash",
+        }
+
+        with self.assertLogs(
+            "torch._inductor.runtime.autotune_cache", level="WARNING"
+        ) as log:
+            result = _load_cached_autotuning(
+                best_config.copy(),
+                "test_hash",
+                configs,
+                {"coordinate_descent_tuning": False},
+            )
+
+        self.assertIsNone(result)
+        self.assertIn(
+            "cached config did not match any config",
+            "\n".join(log.output),
+        )
+
+    def test_load_cached_autotuning_reports_missing_required_field(self):
+        from torch._inductor.runtime.autotune_cache import _load_cached_autotuning
+
+        configs = [self.FakeConfig({"BLOCK_M": 64, "BLOCK_N": 64}, 4, 2)]
+        best_config = {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "num_stages": 2,
+            "configs_hash": "test_hash",
+        }
+
+        with self.assertLogs(
+            "torch._inductor.runtime.autotune_cache", level="WARNING"
+        ) as log:
+            result = _load_cached_autotuning(
+                best_config.copy(),
+                "test_hash",
+                configs,
+                {"coordinate_descent_tuning": False},
+            )
+
+        self.assertIsNone(result)
+        self.assertIn("missing num_warps", "\n".join(log.output))
 
     @requires_triton()
     def test_autotune_cache_save_includes_extra_options(self):

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3766,6 +3766,7 @@ class TestAutotuneCacheExtraOptions(TestCase):
     """
 
     class FakeConfig:
+        # Minimal Config-like object for CPU-only cache validation tests.
         def __init__(self, kwargs, num_warps, num_stages):
             self.kwargs = kwargs
             self.num_warps = num_warps
@@ -3931,6 +3932,59 @@ class TestAutotuneCacheExtraOptions(TestCase):
 
         self.assertIsNone(result)
         self.assertIn("missing num_warps", "\n".join(log.output))
+
+    def test_load_cached_autotuning_reports_invalid_found_by_coordesc(self):
+        from torch._inductor.runtime.autotune_cache import _load_cached_autotuning
+
+        configs = [self.FakeConfig({"BLOCK_M": 64, "BLOCK_N": 64}, 4, 2)]
+        best_config = {
+            "BLOCK_M": 64,
+            "BLOCK_N": 64,
+            "num_warps": 4,
+            "num_stages": 2,
+            "configs_hash": "test_hash",
+            "found_by_coordesc": "yes",
+        }
+
+        with self.assertLogs(
+            "torch._inductor.runtime.autotune_cache", level="WARNING"
+        ) as log:
+            result = _load_cached_autotuning(
+                best_config.copy(),
+                "test_hash",
+                configs,
+                {"coordinate_descent_tuning": False},
+            )
+
+        self.assertIsNone(result)
+        self.assertIn("found_by_coordesc must be a bool", "\n".join(log.output))
+
+    def test_cached_config_round_trips_with_extra_options(self):
+        from torch._inductor.runtime.autotune_cache import CachedConfig
+
+        original_config = self.FakeConfig({"BLOCK_M": 64, "BLOCK_N": 64}, 4, 2)
+        original_config.extra_options = {"backend_specific": "option"}
+        cached_config = CachedConfig(
+            config=original_config,
+            configs_hash="test_hash",
+            found_by_coordesc=False,
+            time_taken_ms=7,
+            triton_cache_hash="triton_hash",
+        )
+
+        data = cached_config.to_dict()
+        loaded = CachedConfig.from_dict(
+            data.copy(),
+            "test_hash",
+            [original_config],
+            {"coordinate_descent_tuning": False},
+        )
+
+        self.assertIsNotNone(loaded)
+        self.assertIs(loaded.config, original_config)
+        self.assertEqual(loaded.config.extra_options, {"backend_specific": "option"})
+        self.assertEqual(loaded.time_taken_ms, 7)
+        self.assertEqual(loaded.triton_cache_hash, "triton_hash")
 
     @requires_triton()
     def test_autotune_cache_save_includes_extra_options(self):

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -62,10 +62,6 @@ log = logging.getLogger(__name__)
 _InductorMetaTy = dict[str, object]
 
 
-class InvalidCachedConfig(ValueError):
-    pass
-
-
 def inductor_meta_from_config() -> _InductorMetaTy:
     from torch._inductor import config
 
@@ -124,22 +120,8 @@ class CachedConfig:
     time_taken_ms: int | None = None
     triton_cache_hash: str | None = None
 
-    @classmethod
-    def from_config(
-        cls,
-        config: Config,
-        configs_hash: str,
-        time_taken_ns: int,
-        found_by_coordesc: bool = False,
-        triton_cache_hash: str | None = None,
-    ) -> CachedConfig:
-        return cls(
-            config=config,
-            configs_hash=configs_hash,
-            found_by_coordesc=found_by_coordesc,
-            time_taken_ms=time_taken_ns // 1000000,  # Convert from NS to MS
-            triton_cache_hash=triton_cache_hash,
-        )
+    class Invalid(ValueError):
+        pass
 
     def to_dict(self) -> dict[str, JsonDataTy]:
         data: dict[str, JsonDataTy] = {
@@ -191,7 +173,7 @@ class CachedConfig:
 
         try:
             return cls._from_dict(data, expected_configs_hash, configs, inductor_meta)
-        except InvalidCachedConfig as exc:
+        except CachedConfig.Invalid as exc:
             log.warning(
                 "Ignoring corrupt autotune cache entry for configs_hash %s: %s",
                 expected_configs_hash,
@@ -239,9 +221,7 @@ class CachedConfig:
             # pyrefly: ignore [missing-attribute]
             triton_config.found_by_coordesc = True
         else:
-            triton_config = cls._match_config(
-                configs, remaining, num_warps, num_stages
-            )
+            triton_config = cls._match_config(configs, remaining, num_warps, num_stages)
 
         # Restore extra_options (may be None if not used by backend).
         # pyrefly: ignore [missing-attribute]
@@ -276,8 +256,8 @@ class CachedConfig:
         if len(matching_configs) == 1:
             return matching_configs[0]
         if not matching_configs:
-            raise InvalidCachedConfig("cached config did not match any config")
-        raise InvalidCachedConfig("cached config matched multiple configs")
+            raise CachedConfig.Invalid("cached config did not match any config")
+        raise CachedConfig.Invalid("cached config matched multiple configs")
 
     @staticmethod
     def _pop_int(
@@ -288,21 +268,19 @@ class CachedConfig:
         elif default is not None:
             return default
         else:
-            raise InvalidCachedConfig(f"missing {key}")
+            raise CachedConfig.Invalid(f"missing {key}")
         if isinstance(value, bool) or not isinstance(value, int):
-            raise InvalidCachedConfig(f"{key} must be an int")
+            raise CachedConfig.Invalid(f"{key} must be an int")
         return value
 
     @staticmethod
-    def _pop_bool(
-        data: dict[str, JsonDataTy], key: str, default: bool = False
-    ) -> bool:
+    def _pop_bool(data: dict[str, JsonDataTy], key: str, default: bool = False) -> bool:
         if key in data:
             value = data.pop(key)
         else:
             return default
         if not isinstance(value, bool):
-            raise InvalidCachedConfig(f"{key} must be a bool")
+            raise CachedConfig.Invalid(f"{key} must be a bool")
         return value
 
 
@@ -468,12 +446,12 @@ class AutotuneCache:
         found_by_coordesc: bool = False,
         triton_cache_hash: str | None = None,
     ) -> None:
-        data = CachedConfig.from_config(
-            config,
-            self.configs_hash,
-            time_taken_ns,
-            found_by_coordesc,
-            triton_cache_hash,
+        data = CachedConfig(
+            config=config,
+            configs_hash=self.configs_hash,
+            found_by_coordesc=found_by_coordesc,
+            time_taken_ms=time_taken_ns // 1000000,  # Convert from NS to MS
+            triton_cache_hash=triton_cache_hash,
         ).to_dict()
 
         if local_cache := self.local_cache:
@@ -718,7 +696,7 @@ def _should_use_remote_autotune_cache(inductor_meta: _InductorMetaTy) -> bool:
 
 
 def _load_cached_autotuning(
-    best_config: dict[str, JsonDataTy],
+    best_config: dict[str, JsonDataTy] | None,
     configs_hash: str,
     configs: list[Config],
     inductor_meta: _InductorMetaTy,

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -62,6 +62,10 @@ log = logging.getLogger(__name__)
 _InductorMetaTy = dict[str, object]
 
 
+class InvalidCachedConfig(ValueError):
+    pass
+
+
 def inductor_meta_from_config() -> _InductorMetaTy:
     from torch._inductor import config
 
@@ -110,6 +114,196 @@ class AutotuneCacheArtifact(CacheArtifact):
         content_bytes = serde.encode(content)
         assert isinstance(content_bytes, bytes)
         return content_bytes
+
+
+@dataclasses.dataclass
+class CachedConfig:
+    config: Config
+    configs_hash: str
+    found_by_coordesc: bool = False
+    time_taken_ms: int | None = None
+    triton_cache_hash: str | None = None
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Config,
+        configs_hash: str,
+        time_taken_ns: int,
+        found_by_coordesc: bool = False,
+        triton_cache_hash: str | None = None,
+    ) -> CachedConfig:
+        return cls(
+            config=config,
+            configs_hash=configs_hash,
+            found_by_coordesc=found_by_coordesc,
+            time_taken_ms=time_taken_ns // 1000000,  # Convert from NS to MS
+            triton_cache_hash=triton_cache_hash,
+        )
+
+    def to_dict(self) -> dict[str, JsonDataTy]:
+        data: dict[str, JsonDataTy] = {
+            # pyrefly: ignore [missing-attribute]
+            **self.config.kwargs,
+            # pyrefly: ignore [missing-attribute]
+            "num_warps": self.config.num_warps,
+            # pyrefly: ignore [missing-attribute]
+            "num_stages": self.config.num_stages,
+            "configs_hash": self.configs_hash,
+            "found_by_coordesc": self.found_by_coordesc,
+            "time_taken_ms": self.time_taken_ms,
+            "triton_cache_hash": self.triton_cache_hash,
+        }
+        # Save extra_options if present on the config. This allows third-party
+        # backends to store custom tuned options alongside the standard config.
+        if extra_options := getattr(self.config, "extra_options", None):
+            data["extra_options"] = extra_options
+        if HAS_WARP_SPEC:
+            data.update(
+                {
+                    "num_consumer_groups": getattr(
+                        self.config, "num_consumer_groups", 0
+                    ),
+                    "num_buffers_warp_spec": getattr(
+                        self.config, "num_buffers_warp_spec", 0
+                    ),
+                }
+            )
+        return data
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict[str, JsonDataTy],
+        expected_configs_hash: str,
+        configs: list[Config],
+        inductor_meta: _InductorMetaTy,
+    ) -> CachedConfig | None:
+        if "configs_hash" not in data:
+            log.warning(
+                "Ignoring corrupt autotune cache entry for configs_hash %s: "
+                "missing configs_hash",
+                expected_configs_hash,
+            )
+            return None
+        if data["configs_hash"] != expected_configs_hash:
+            return None
+
+        try:
+            return cls._from_dict(data, expected_configs_hash, configs, inductor_meta)
+        except InvalidCachedConfig as exc:
+            log.warning(
+                "Ignoring corrupt autotune cache entry for configs_hash %s: %s",
+                expected_configs_hash,
+                exc,
+            )
+            return None
+
+    @classmethod
+    def _from_dict(
+        cls,
+        data: dict[str, JsonDataTy],
+        expected_configs_hash: str,
+        configs: list[Config],
+        inductor_meta: _InductorMetaTy,
+    ) -> CachedConfig:
+        remaining = dict(data)
+        remaining.pop("configs_hash")
+        time_taken_ms = remaining.pop("time_taken_ms", None)
+        triton_cache_hash = remaining.pop("triton_cache_hash", None)
+        extra_options = remaining.pop("extra_options", None)
+        found_by_coordesc = cls._pop_bool(remaining, "found_by_coordesc", False)
+
+        num_warps = cls._pop_int(remaining, "num_warps")
+        num_stages = cls._pop_int(remaining, "num_stages")
+        config_args = {
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+        }
+
+        if HAS_WARP_SPEC:
+            config_args.update(
+                {
+                    "num_consumer_groups": cls._pop_int(
+                        remaining, "num_consumer_groups", 0
+                    ),
+                    "num_buffers_warp_spec": cls._pop_int(
+                        remaining, "num_buffers_warp_spec", 0
+                    ),
+                }
+            )
+
+        if inductor_meta.get("coordinate_descent_tuning") and found_by_coordesc:
+            # pyrefly: ignore [bad-argument-count, unexpected-keyword]
+            triton_config = Config(remaining, **config_args)
+            # pyrefly: ignore [missing-attribute]
+            triton_config.found_by_coordesc = True
+        else:
+            triton_config = cls._match_config(
+                configs, remaining, num_warps, num_stages
+            )
+
+        # Restore extra_options (may be None if not used by backend).
+        # pyrefly: ignore [missing-attribute]
+        triton_config.extra_options = extra_options
+        return cls(
+            config=triton_config,
+            configs_hash=expected_configs_hash,
+            found_by_coordesc=found_by_coordesc,
+            time_taken_ms=time_taken_ms if isinstance(time_taken_ms, int) else None,
+            triton_cache_hash=(
+                triton_cache_hash if isinstance(triton_cache_hash, str) else None
+            ),
+        )
+
+    @staticmethod
+    def _match_config(
+        configs: list[Config],
+        kwargs: dict[str, JsonDataTy],
+        num_warps: int,
+        num_stages: int,
+    ) -> Config:
+        matching_configs = [
+            cfg
+            for cfg in configs
+            # pyrefly: ignore [missing-attribute]
+            if all(val == kwargs.get(key) for key, val in cfg.kwargs.items())
+            # pyrefly: ignore [missing-attribute]
+            and cfg.num_warps == num_warps
+            # pyrefly: ignore [missing-attribute]
+            and cfg.num_stages == num_stages
+        ]
+        if len(matching_configs) == 1:
+            return matching_configs[0]
+        if not matching_configs:
+            raise InvalidCachedConfig("cached config did not match any config")
+        raise InvalidCachedConfig("cached config matched multiple configs")
+
+    @staticmethod
+    def _pop_int(
+        data: dict[str, JsonDataTy], key: str, default: int | None = None
+    ) -> int:
+        if key in data:
+            value = data.pop(key)
+        elif default is not None:
+            return default
+        else:
+            raise InvalidCachedConfig(f"missing {key}")
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise InvalidCachedConfig(f"{key} must be an int")
+        return value
+
+    @staticmethod
+    def _pop_bool(
+        data: dict[str, JsonDataTy], key: str, default: bool = False
+    ) -> bool:
+        if key in data:
+            value = data.pop(key)
+        else:
+            return default
+        if not isinstance(value, bool):
+            raise InvalidCachedConfig(f"{key} must be a bool")
+        return value
 
 
 @dataclasses.dataclass
@@ -274,31 +468,13 @@ class AutotuneCache:
         found_by_coordesc: bool = False,
         triton_cache_hash: str | None = None,
     ) -> None:
-        data = {
-            # pyrefly: ignore [missing-attribute]
-            **config.kwargs,
-            # pyrefly: ignore [missing-attribute]
-            "num_warps": config.num_warps,
-            # pyrefly: ignore [missing-attribute]
-            "num_stages": config.num_stages,
-            "configs_hash": self.configs_hash,
-            "found_by_coordesc": found_by_coordesc,
-            "time_taken_ms": time_taken_ns // 1000000,  # Convert from NS to MS
-            "triton_cache_hash": triton_cache_hash,
-        }
-        # Save extra_options if present on the config. This allows third-party
-        # backends to store custom tuned options alongside the standard config.
-        if extra_options := getattr(config, "extra_options", None):
-            data["extra_options"] = extra_options
-        if HAS_WARP_SPEC:
-            data.update(
-                {
-                    "num_consumer_groups": getattr(config, "num_consumer_groups", 0),
-                    "num_buffers_warp_spec": getattr(
-                        config, "num_buffers_warp_spec", 0
-                    ),
-                }
-            )
+        data = CachedConfig.from_config(
+            config,
+            self.configs_hash,
+            time_taken_ns,
+            found_by_coordesc,
+            triton_cache_hash,
+        ).to_dict()
 
         if local_cache := self.local_cache:
             cache, key = local_cache
@@ -549,68 +725,12 @@ def _load_cached_autotuning(
 ) -> Config | None:
     if best_config is None:
         return None
-    if best_config.pop("configs_hash", None) != configs_hash:
+    cached_config = CachedConfig.from_dict(
+        best_config, configs_hash, configs, inductor_meta
+    )
+    if cached_config is None:
         return None
-
-    # Remove time taken for comparison
-    best_config.pop("time_taken_ms", None)
-
-    best_config.pop("triton_cache_hash", None)
-
-    # Extract extra_options if present. This allows third-party backends
-    # to restore custom tuned options from the cache.
-    extra_options = best_config.pop("extra_options", None)
-
-    if inductor_meta.get("coordinate_descent_tuning") and best_config.pop(
-        "found_by_coordesc", False
-    ):
-        num_warps = best_config.pop("num_warps")
-        num_stages = best_config.pop("num_stages")
-
-        # Extract common arguments
-        config_args = {
-            "num_warps": num_warps,
-            "num_stages": num_stages,
-        }
-
-        if HAS_WARP_SPEC:
-            config_args.update(
-                {
-                    "num_consumer_groups": best_config.pop("num_consumer_groups", 0),
-                    "num_buffers_warp_spec": best_config.pop(
-                        "num_buffers_warp_spec", 0
-                    ),
-                }
-            )
-
-        # Create the triton_config with the appropriate arguments
-        # pyrefly: ignore [bad-argument-count, unexpected-keyword]
-        triton_config = Config(best_config, **config_args)
-        # pyrefly: ignore [missing-attribute]
-        triton_config.found_by_coordesc = True
-        # Restore extra_options (may be None if not used by backend)
-        # pyrefly: ignore [missing-attribute]
-        triton_config.extra_options = extra_options
-        return triton_config
-
-    matching_configs = [
-        cfg
-        for cfg in configs
-        # pyrefly: ignore [missing-attribute]
-        if all(val == best_config.get(key) for key, val in cfg.kwargs.items())
-        # pyrefly: ignore [missing-attribute]
-        and cfg.num_warps == best_config.get("num_warps")
-        # pyrefly: ignore [missing-attribute]
-        and cfg.num_stages == best_config.get("num_stages")
-    ]
-    if len(matching_configs) != 1:
-        return None
-
-    matched_config = matching_configs[0]
-    # Restore extra_options (may be None if not used by backend)
-    # pyrefly: ignore [missing-attribute]
-    matched_config.extra_options = extra_options
-    return matched_config
+    return cached_config.config
 
 
 class _LocalAutotuneCacheBackend(RemoteCacheBackend[bytes]):

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -114,6 +114,8 @@ class AutotuneCacheArtifact(CacheArtifact):
 
 @dataclasses.dataclass
 class CachedConfig:
+    """Serialize and validate a single autotune cache entry."""
+
     config: Config
     configs_hash: str
     found_by_coordesc: bool = False


### PR DESCRIPTION
Root cause problem:
_load_cached_autotuning() had separate restoration paths for coordinate descent and regular config matches. That duplicated extra_options handling and let corrupt cache entries, such as missing required fields or no matching config, degrade to an unexplained cache miss.

Proposed fix:
Add a CachedConfig dataclass that owns the flattened cache dictionary format. AutotuneCache.save() now serializes through CachedConfig.to_dict(), and _load_cached_autotuning() deserializes and matches through CachedConfig.from_dict(). Corrupt cache entries now log warnings before returning None, while hash mismatches remain quiet cache misses.

Why this is the right long term fix:
Keeping serialization, validation, matching, and error reporting in one place makes future cache fields easier to add without duplicating restoration logic or changing the existing cache format.

Testing:
- Added focused corrupt-cache logging tests in test/inductor/test_codecache.py.
- Verified the new tests fail without the implementation: standalone import harness reports no warning from the old loader.
- python3 -m py_compile torch/_inductor/runtime/autotune_cache.py test/inductor/test_codecache.py
- git diff --check
- Standalone import harness covering corrupt entries, CachedConfig.to_dict(), and extra_options restoration passed.
- Attempted: python3 -m pytest -q test/inductor/test_codecache.py::TestAutotuneCacheExtraOptions::test_load_cached_autotuning_reports_corrupt_unmatched_config test/inductor/test_codecache.py::TestAutotuneCacheExtraOptions::test_load_cached_autotuning_reports_missing_required_field
  Blocked because this source checkout is not built/generated and test collection fails at ModuleNotFoundError: No module named 'torch.version'.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo