### PR TITLE
Consolidate local autotune cache backend

### DIFF
--- a/test/inductor/test_remote_cache.py
+++ b/test/inductor/test_remote_cache.py
@@ -1,7 +1,10 @@
 # Owner(s): ["module: inductor"]
+import os
+import tempfile
 from dataclasses import dataclass
 
 from torch._inductor.remote_cache import (
+    create_cache,
     RemoteCache,
     RemoteCacheBackend,
     RemoteCachePassthroughSerde,
@@ -68,6 +71,21 @@ class TestRemoteCache(TestCase):
         with self.assertRaises(AssertionError):
             c.get("test")
         self.assertEqual(c.sample.fail_reason, "testget")
+
+    def test_create_local_autotune_cache(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            key = os.path.join(tmpdir, "cache", "entry.best_config")
+            c = create_cache("local-autotune", local_cache_cls="LocalAutotuneCache")
+            self.assertIsNotNone(c)
+            assert c is not None
+
+            expected = {"value": 1}
+            c.put(key, expected)
+
+            self.assertTrue(os.path.exists(key))
+            self.assertEqual(c.get(key), expected)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_remote_cache.py
+++ b/test/inductor/test_remote_cache.py
@@ -78,8 +78,8 @@ class TestRemoteCache(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             key = os.path.join(tmpdir, "cache", "entry.best_config")
             c = create_cache("local-autotune", local_cache_cls="LocalAutotuneCache")
-            self.assertIsNotNone(c)
-            assert c is not None
+            if c is None:
+                self.fail("Expected local autotune cache")
 
             expected = {"value": 1}
             c.put(key, expected)

--- a/torch/_inductor/mock_cache.py
+++ b/torch/_inductor/mock_cache.py
@@ -191,7 +191,7 @@ class PatchCaches(contextlib.AbstractContextManager):
         self._stack.__enter__()
 
         ctx = patch(
-            "torch._inductor.runtime.autotune_cache.LocalAutotuneCache.backend_override_cls",
+            "torch._inductor.remote_cache.LocalAutotuneCache.backend_override_cls",
             MockBackend.with_name("autotune_local"),
         )
         self._stack.enter_context(ctx)

--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -65,8 +65,9 @@ remote_fx_cache_put_timed = functools.partial(
 
 class RemoteCacheBackend(Generic[_T]):
     """
-    A backend implementation for accessing a remote/distributed cache.  Only
-    works with bytes in/out.  For structured data use a RemoteCache.
+    A backend implementation for cache storage. Most backends are remote, but
+    local filesystem backends use the same bytes-oriented interface. For
+    structured data use a RemoteCache.
     """
 
     def __init__(self) -> None:
@@ -128,6 +129,27 @@ class RemoteCachePassthroughSerde(RemoteCacheSerde[_T, _T]):
 
     def decode(self, data: _T) -> _T:
         return data
+
+
+class LocalCacheBackend(RemoteCacheBackend[bytes]):
+    """
+    A local filesystem implementation of the cache backend interface.
+    """
+
+    @override
+    def _get(self, key: str) -> bytes | None:
+        try:
+            with open(key, "rb") as fd:
+                return fd.read()
+        except FileNotFoundError:
+            return None
+
+    @override
+    def _put(self, key: str, data: bytes) -> None:
+        os.makedirs(os.path.dirname(key), exist_ok=True)
+        from torch._inductor import codecache
+
+        codecache.write_atomic(key, data)
 
 
 # This class is the top of a RemoteCache. A RemoteCache is fundamentally made of
@@ -330,6 +352,21 @@ class RedisRemoteCache(RemoteCache[JsonDataTy]):
         super()._put(key, value, sample)
 
 
+class LocalCache(RemoteCache[JsonDataTy]):
+    def __init__(self, cache_id: str) -> None:
+        # Local caches use the per-operation key as the filesystem path. Accept
+        # cache_id so they can be constructed through create_cache like remote
+        # caches.
+        backend = LocalCacheBackend()
+        serde = RemoteCacheJsonSerde()
+        super().__init__(backend, serde)
+
+
+class LocalAutotuneCache(LocalCache):
+    # Keep a distinct cache type for cache stats and test backend overrides.
+    pass
+
+
 class RemoteAutotuneCache(RedisRemoteCache):
     pass
 
@@ -352,24 +389,30 @@ class RemoteDynamoPGOCache(RedisRemoteCache):
 
 def create_cache(
     key: str,
-    is_fbcode: bool,
-    fb_cache_cls: str,
-    oss_cache_cls: str,
+    is_fbcode: bool = False,
+    fb_cache_cls: str | None = None,
+    oss_cache_cls: str | None = None,
+    *,
+    local_cache_cls: str | None = None,
 ) -> RemoteCache[JsonDataTy] | None:
     try:
-        if is_fbcode:
+        this_module = sys.modules[__name__]
+        if local_cache_cls is not None:
+            cache_cls = getattr(this_module, local_cache_cls)
+            return cache_cls(key)
+        elif is_fbcode:
+            assert fb_cache_cls is not None
             import torch._inductor.fb.remote_cache
 
             cache_cls = getattr(torch._inductor.fb.remote_cache, fb_cache_cls)
             return cache_cls(key)
         else:
-            this_module = sys.modules[__name__]
-
+            assert oss_cache_cls is not None
             cache_cls = getattr(this_module, oss_cache_cls)
             return cache_cls(key)
 
     except Exception:
-        log.warning("Unable to create a remote cache", exc_info=True)
+        log.warning("Unable to create cache", exc_info=True)
         return None
 
 

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -111,6 +111,8 @@ class AutotuneCacheArtifact(CacheArtifact):
 
 @dataclasses.dataclass
 class AutotuneCache:
+    """Coordinates local and remote autotune cache lookups for one kernel."""
+
     configs_hash: str
     local_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
     remote_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
@@ -146,6 +148,10 @@ class AutotuneCache:
             best_config = cache.get(key)
             if best_config is not None:
                 assert isinstance(best_config, dict)
+                # Imagine we have a new model that reuses some existing kernels that
+                # have already been compiled. If we didn't put() here on cache hit,
+                # then the new model would only bundle newly compiled kernels, not
+                # existing kernels that were already compiled and cached.
                 AutotuneCacheBundler.put(key, best_config)
                 autotune_artifact_key = os.path.join(*key.split(os.sep)[-2:])
                 CacheArtifactManager.record_artifact(
@@ -408,16 +414,16 @@ class _AutotuneCacheBundlerImpl:
 
         # Go through the entries we got from the cache and save them locally.
         time_saved_ns = 0
+        local_cache = create_cache(
+            "local-autotune",
+            local_cache_cls=LocalAutotuneCache.__name__,
+        )
         for basename, data in entries.items():
             # Reconstruct the final filename (see put())
             root, ext = _splitext_nodot(basename)
             _, _, filename = codecache.get_path(root, ext)
             if isinstance(data, dict) and (tsns := data.get("time_saved_ns")):
                 time_saved_ns += int(tsns)  # type: ignore[arg-type]
-            local_cache = create_cache(
-                "local-autotune",
-                local_cache_cls=LocalAutotuneCache.__name__,
-            )
             if local_cache is not None:
                 local_cache.put(filename, data)
 

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -15,8 +15,7 @@ The caching system includes:
 Key components:
 - AutotuneCache: Main class for managing cache access and storage
 - AutotuneCacheBundler: Bundles multiple cache entries for efficient storage
-- LocalAutotuneCache: Handles filesystem-based caching
-- _LocalAutotuneCacheBackend: Low-level file operations for cache storage
+- LocalCacheBackend: Low-level file operations for cache storage
 - AutotuneCacheArtifact: Integration with PyTorch's artifact system
 
 This caching system is critical for performance as it eliminates the need to re-run
@@ -31,7 +30,7 @@ import logging
 import os
 import os.path
 import re
-from typing import Any, TYPE_CHECKING
+from typing import Any
 from typing_extensions import override
 
 import torch
@@ -46,15 +45,13 @@ from torch.utils._triton import has_triton
 from ..remote_cache import (
     create_cache,
     JsonDataTy,
+    LocalAutotuneCache,
+    LocalCacheBackend,
     RemoteCache,
-    RemoteCacheBackend,
     RemoteCacheJsonSerde,
 )
 from .triton_compat import Config, HAS_WARP_SPEC
 
-
-if TYPE_CHECKING:
-    from ..remote_cache import Sample
 
 log = logging.getLogger(__name__)
 
@@ -93,7 +90,7 @@ def inductor_meta_from_config() -> _InductorMetaTy:
 class AutotuneCacheArtifact(CacheArtifact):
     @override
     def populate_cache(self) -> None:
-        autotune_cache = _LocalAutotuneCacheBackend()
+        autotune_cache = LocalCacheBackend()
         key = os.path.join(cache_dir(), self.key)
         autotune_cache._put(key, self.content)
 
@@ -145,8 +142,16 @@ class AutotuneCache:
     def _read(self) -> dict[str, JsonDataTy] | None:
         if local_cache := self.local_cache:
             cache, key = local_cache
-            if best_config := cache.get(key):
-                if isinstance(best_config, dict):
+            AutotuneCacheBundler.sync()
+            best_config = cache.get(key)
+            if best_config is not None:
+                assert isinstance(best_config, dict)
+                AutotuneCacheBundler.put(key, best_config)
+                autotune_artifact_key = os.path.join(*key.split(os.sep)[-2:])
+                CacheArtifactManager.record_artifact(
+                    AutotuneCacheArtifact.type(), autotune_artifact_key, best_config
+                )
+                if best_config:
                     return best_config
 
         if remote_cache := self.remote_cache:
@@ -190,7 +195,12 @@ class AutotuneCache:
         updated_cache_key = hasher.hexdigest()
 
         cache_filename = f"{dirname}/{updated_cache_key}.best_config"
-        local_cache = LocalAutotuneCache()
+        local_cache = create_cache(
+            "local-autotune",
+            local_cache_cls=LocalAutotuneCache.__name__,
+        )
+        if local_cache is None:
+            return
         self.local_cache = (local_cache, cache_filename)
 
     # Set up remote caching information
@@ -323,14 +333,13 @@ class AutotuneCache:
 
 class _AutotuneCacheBundlerImpl:
     """
-    Caches a set of LocalAutotuneCacheBackend entries together in a single
-    cache.
+    Caches a set of local autotune entries together in a single cache.
     """
 
     _key: str
     _cache: RemoteCache[JsonDataTy]
 
-    # All known entries from LocalAutotuneCache.put()
+    # All known entries from local autotune cache writes.
     _entries: dict[str, JsonDataTy]
 
     def end_compile(self) -> None:
@@ -405,8 +414,12 @@ class _AutotuneCacheBundlerImpl:
             _, _, filename = codecache.get_path(root, ext)
             if isinstance(data, dict) and (tsns := data.get("time_saved_ns")):
                 time_saved_ns += int(tsns)  # type: ignore[arg-type]
-            local_cache = LocalAutotuneCache()
-            local_cache.put(filename, data)
+            local_cache = create_cache(
+                "local-autotune",
+                local_cache_cls=LocalAutotuneCache.__name__,
+            )
+            if local_cache is not None:
+                local_cache.put(filename, data)
 
         codecache.add_ephemeral_timeout_increase_for_distributed(time_saved_ns)
 
@@ -611,53 +624,6 @@ def _load_cached_autotuning(
     # pyrefly: ignore [missing-attribute]
     matched_config.extra_options = extra_options
     return matched_config
-
-
-class _LocalAutotuneCacheBackend(RemoteCacheBackend[bytes]):
-    @override
-    def _get(self, key: str) -> bytes | None:
-        try:
-            with open(key, "rb") as fd:
-                return fd.read()
-        except FileNotFoundError:
-            return None
-
-    @override
-    def _put(self, key: str, data: bytes) -> None:
-        os.makedirs(os.path.dirname(key), exist_ok=True)
-        from torch._inductor import codecache
-
-        codecache.write_atomic(key, data)
-
-
-class LocalAutotuneCache(RemoteCache[JsonDataTy]):
-    def __init__(self) -> None:
-        backend = _LocalAutotuneCacheBackend()
-        serde = RemoteCacheJsonSerde()
-        super().__init__(backend, serde)
-
-    @override
-    def _get(self, key: str, sample: Sample | None) -> JsonDataTy | None:
-        AutotuneCacheBundler.sync()
-        result = super()._get(key, sample)
-        if result is not None:
-            assert isinstance(result, dict)
-            # What? Why are we doing a put() here? Imagine we have a new model
-            # that reuses some existing kernels that have already been
-            # compiled. If we didn't do a `put` here (on cache hit) then the new
-            # model would only bundle *newly* compiled kernels, not existing
-            # kernels that were already compiled and cached.
-            AutotuneCacheBundler.put(key, result)
-            autotune_artifact_key = os.path.join(*key.split(os.sep)[-2:])
-            CacheArtifactManager.record_artifact(
-                AutotuneCacheArtifact.type(), autotune_artifact_key, result
-            )
-        return result
-
-    @override
-    def _put(self, key: str, value: JsonDataTy, sample: Sample | None) -> None:
-        AutotuneCacheBundler.put(key, value)
-        super()._put(key, value, sample)
 
 
 def _splitext_nodot(basename: str) -> tuple[str, str]:

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -15,8 +15,7 @@ The caching system includes:
 Key components:
 - AutotuneCache: Main class for managing cache access and storage
 - AutotuneCacheBundler: Bundles multiple cache entries for efficient storage
-- LocalAutotuneCache: Handles filesystem-based caching
-- _LocalAutotuneCacheBackend: Low-level file operations for cache storage
+- LocalCacheBackend: Low-level file operations for cache storage
 - AutotuneCacheArtifact: Integration with PyTorch's artifact system
 
 This caching system is critical for performance as it eliminates the need to re-run
@@ -30,7 +29,7 @@ import logging
 import os
 import os.path
 import re
-from typing import Any, TYPE_CHECKING
+from typing import Any
 from typing_extensions import override
 
 import torch
@@ -46,15 +45,13 @@ from ..cache_key import AUTOTUNE_CACHE_KEY_STRATEGY
 from ..remote_cache import (
     create_cache,
     JsonDataTy,
+    LocalAutotuneCache,
+    LocalCacheBackend,
     RemoteCache,
-    RemoteCacheBackend,
     RemoteCacheJsonSerde,
 )
 from .triton_compat import Config, HAS_WARP_SPEC
 
-
-if TYPE_CHECKING:
-    from ..remote_cache import Sample
 
 log = logging.getLogger(__name__)
 
@@ -93,7 +90,7 @@ def inductor_meta_from_config() -> _InductorMetaTy:
 class AutotuneCacheArtifact(CacheArtifact):
     @override
     def populate_cache(self) -> None:
-        autotune_cache = _LocalAutotuneCacheBackend()
+        autotune_cache = LocalCacheBackend()
         key = os.path.join(cache_dir(), self.key)
         autotune_cache._put(key, self.content)
 
@@ -180,9 +177,17 @@ class AutotuneCache:
     def _read(self) -> dict[str, JsonDataTy] | None:
         if local_cache := self.local_cache:
             cache, key = local_cache
-            if best_config := cache.get(key):
-                if isinstance(best_config, dict):
-                    self._record_artifact(best_config)
+            AutotuneCacheBundler.sync()
+            best_config = cache.get(key)
+            if best_config is not None:
+                assert isinstance(best_config, dict)
+                # Imagine we have a new model that reuses some existing kernels that
+                # have already been compiled. If we didn't put() here on cache hit,
+                # then the new model would only bundle newly compiled kernels, not
+                # existing kernels that were already compiled and cached.
+                AutotuneCacheBundler.put(key, best_config)
+                self._record_artifact(best_config)
+                if best_config:
                     return best_config
 
         if remote_cache := self.remote_cache:
@@ -212,7 +217,12 @@ class AutotuneCache:
         if not inductor_meta.get("autotune_local_cache", True):
             return
 
-        local_cache = LocalAutotuneCache()
+        local_cache = create_cache(
+            "local-autotune",
+            local_cache_cls=LocalAutotuneCache.__name__,
+        )
+        if local_cache is None:
+            return
         self.local_cache = (local_cache, cache_key)
 
     # Set up remote caching information
@@ -344,14 +354,13 @@ class AutotuneCache:
 
 class _AutotuneCacheBundlerImpl:
     """
-    Caches a set of LocalAutotuneCacheBackend entries together in a single
-    cache.
+    Caches a set of local autotune entries together in a single cache.
     """
 
     _key: str
     _cache: RemoteCache[JsonDataTy]
 
-    # All known entries from LocalAutotuneCache.put()
+    # All known entries from local autotune cache writes.
     _entries: dict[str, JsonDataTy]
 
     def end_compile(self) -> None:
@@ -426,8 +435,12 @@ class _AutotuneCacheBundlerImpl:
             _, _, filename = codecache.get_path(root, ext)
             if isinstance(data, dict) and (tsns := data.get("time_saved_ns")):
                 time_saved_ns += int(tsns)  # type: ignore[arg-type]
-            local_cache = LocalAutotuneCache()
-            local_cache.put(filename, data)
+            local_cache = create_cache(
+                "local-autotune",
+                local_cache_cls=LocalAutotuneCache.__name__,
+            )
+            if local_cache is not None:
+                local_cache.put(filename, data)
 
         codecache.add_ephemeral_timeout_increase_for_distributed(time_saved_ns)
 
@@ -631,49 +644,6 @@ def _load_cached_autotuning(
     # pyrefly: ignore [missing-attribute]
     matched_config.extra_options = extra_options
     return matched_config
-
-
-class _LocalAutotuneCacheBackend(RemoteCacheBackend[bytes]):
-    @override
-    def _get(self, key: str) -> bytes | None:
-        try:
-            with open(key, "rb") as fd:
-                return fd.read()
-        except FileNotFoundError:
-            return None
-
-    @override
-    def _put(self, key: str, data: bytes) -> None:
-        os.makedirs(os.path.dirname(key), exist_ok=True)
-        from torch._inductor import codecache
-
-        codecache.write_atomic(key, data)
-
-
-class LocalAutotuneCache(RemoteCache[JsonDataTy]):
-    def __init__(self) -> None:
-        backend = _LocalAutotuneCacheBackend()
-        serde = RemoteCacheJsonSerde()
-        super().__init__(backend, serde)
-
-    @override
-    def _get(self, key: str, sample: Sample | None) -> JsonDataTy | None:
-        AutotuneCacheBundler.sync()
-        result = super()._get(key, sample)
-        if result is not None:
-            assert isinstance(result, dict)
-            # What? Why are we doing a put() here? Imagine we have a new model
-            # that reuses some existing kernels that have already been
-            # compiled. If we didn't do a `put` here (on cache hit) then the new
-            # model would only bundle *newly* compiled kernels, not existing
-            # kernels that were already compiled and cached.
-            AutotuneCacheBundler.put(key, result)
-        return result
-
-    @override
-    def _put(self, key: str, value: JsonDataTy, sample: Sample | None) -> None:
-        AutotuneCacheBundler.put(key, value)
-        super()._put(key, value, sample)
 
 
 def _splitext_nodot(basename: str) -> tuple[str, str]:

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -111,9 +111,7 @@ class AutotuneCacheArtifact(CacheArtifact):
 
 @dataclasses.dataclass
 class AutotuneCache:
-    """
-    Coordinates local and remote autotune cache access for a single kernel.
-    """
+    """Coordinates local and remote autotune cache lookups for one kernel."""
 
     configs_hash: str
     local_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
@@ -429,16 +427,16 @@ class _AutotuneCacheBundlerImpl:
 
         # Go through the entries we got from the cache and save them locally.
         time_saved_ns = 0
+        local_cache = create_cache(
+            "local-autotune",
+            local_cache_cls=LocalAutotuneCache.__name__,
+        )
         for basename, data in entries.items():
             # Reconstruct the final filename (see put())
             root, ext = _splitext_nodot(basename)
             _, _, filename = codecache.get_path(root, ext)
             if isinstance(data, dict) and (tsns := data.get("time_saved_ns")):
                 time_saved_ns += int(tsns)  # type: ignore[arg-type]
-            local_cache = create_cache(
-                "local-autotune",
-                local_cache_cls=LocalAutotuneCache.__name__,
-            )
             if local_cache is not None:
                 local_cache.put(filename, data)
 


### PR DESCRIPTION
## Summary

Consolidates the local autotune cache into the shared cache construction path by adding a local cache option to `create_cache()` and moving the filesystem backend into `torch._inductor.remote_cache`.

## Root Cause Problem

The local autotune cache lived in `runtime/autotune_cache.py` as `LocalAutotuneCache` plus `_LocalAutotuneCacheBackend`, even though it implemented the same `RemoteCache`/`RemoteCacheBackend` interface as the remote caches. That made the architecture work, but left the local cache outside the shared factory and made the naming harder to follow.

## Proposed Fix

- Add `LocalCacheBackend`, `LocalCache`, and `LocalAutotuneCache` to `torch._inductor.remote_cache`.
- Extend `create_cache()` with `local_cache_cls` so local caches are a first-class factory option.
- Instantiate local autotune caches through `create_cache()` while keeping autotune-specific bundler and artifact recording behavior in `runtime/autotune_cache.py`.
- Update cache test patching to target the shared `LocalAutotuneCache` class.

## Why This Is The Right Long Term Fix

This keeps the backend abstraction as the single cache construction path for both local and remote storage without renaming the larger internal API. The generic filesystem behavior now lives next to the other backend implementations, while autotune-specific side effects stay with the autotune cache controller that owns them.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo