### PR TITLE
Scope autotune cache bundler to compile context

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3223,7 +3223,7 @@ class TestAutotuneCache(TestCase):
 
     @config.patch({"bundled_autotune_remote_cache": True})
     def test_autotune_cache_bundler_is_compile_context_scoped(self):
-        from torch._guards import CompileContext, compile_context
+        from torch._guards import compile_context, CompileContext
         from torch._inductor.runtime.autotune_cache import AutotuneCacheBundler
 
         class FakeBundledCache:
@@ -3278,7 +3278,7 @@ class TestAutotuneCache(TestCase):
 
     @config.patch({"bundled_autotune_remote_cache": True})
     def test_autotune_cache_bundler_runs_in_saved_compile_context(self):
-        from torch._guards import CompileContext, compile_context
+        from torch._guards import compile_context, CompileContext
         from torch._inductor.output_code import CompiledFxGraph
         from torch._inductor.runtime.autotune_cache import AutotuneCacheBundler
 

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3221,6 +3221,111 @@ class TestAutotuneCache(TestCase):
         torch._dynamo.reset()
         clear_caches()
 
+    @config.patch({"bundled_autotune_remote_cache": True})
+    def test_autotune_cache_bundler_is_compile_context_scoped(self):
+        from torch._guards import CompileContext, compile_context
+        from torch._inductor.runtime.autotune_cache import AutotuneCacheBundler
+
+        class FakeBundledCache:
+            def __init__(self):
+                self.puts = []
+
+            def get(self, key):
+                return None
+
+            def put(self, key, data):
+                self.puts.append((key, data))
+
+        cache1 = FakeBundledCache()
+        cache2 = FakeBundledCache()
+        inductor_meta = {
+            "autotune_local_cache": True,
+            "backend_hash": "backend",
+            "bundled_autotune_remote_cache": True,
+            "is_fbcode": False,
+        }
+
+        ctx1 = CompileContext(None)
+        ctx2 = CompileContext(None)
+        with mock.patch(
+            "torch._inductor.runtime.autotune_cache.create_cache",
+            side_effect=[cache1, cache2],
+        ):
+            with compile_context(ctx1):
+                AutotuneCacheBundler.begin_compile(inductor_meta, code_hash="code1")
+                AutotuneCacheBundler.put("/tmp/cache/aa/entry1.best_config", {"ctx": 1})
+
+                with compile_context(ctx2):
+                    AutotuneCacheBundler.begin_compile(inductor_meta, code_hash="code2")
+                    AutotuneCacheBundler.put(
+                        "/tmp/cache/bb/entry2.best_config", {"ctx": 2}
+                    )
+                    AutotuneCacheBundler.end_compile()
+
+                AutotuneCacheBundler.put("/tmp/cache/aa/entry3.best_config", {"ctx": 1})
+                AutotuneCacheBundler.end_compile()
+
+        self.assertEqual(len(cache1.puts), 1)
+        self.assertEqual(
+            cache1.puts[0][1],
+            {
+                "entry1.best_config": {"ctx": 1},
+                "entry3.best_config": {"ctx": 1},
+            },
+        )
+        self.assertEqual(len(cache2.puts), 1)
+        self.assertEqual(cache2.puts[0][1], {"entry2.best_config": {"ctx": 2}})
+
+    @config.patch({"bundled_autotune_remote_cache": True})
+    def test_autotune_cache_bundler_runs_in_saved_compile_context(self):
+        from torch._guards import CompileContext, compile_context
+        from torch._inductor.output_code import CompiledFxGraph
+        from torch._inductor.runtime.autotune_cache import AutotuneCacheBundler
+
+        class FakeBundledCache:
+            def __init__(self):
+                self.puts = []
+
+            def get(self, key):
+                return None
+
+            def put(self, key, data):
+                self.puts.append((key, data))
+
+        cache = FakeBundledCache()
+        inductor_meta = {
+            "autotune_local_cache": True,
+            "backend_hash": "backend",
+            "bundled_autotune_remote_cache": True,
+            "is_fbcode": False,
+        }
+
+        graph = CompiledFxGraph.__new__(CompiledFxGraph)
+        graph.fx_kwargs = {}
+        graph._compile_context = None
+
+        def current_callable(inputs):
+            AutotuneCacheBundler.put(
+                "/tmp/cache/aa/entry.best_config", {"ctx": "saved"}
+            )
+            return inputs
+
+        graph.current_callable = current_callable
+
+        with mock.patch(
+            "torch._inductor.runtime.autotune_cache.create_cache",
+            return_value=cache,
+        ):
+            with compile_context(CompileContext(None)):
+                AutotuneCacheBundler.begin_compile(inductor_meta, code_hash="code")
+                graph._set_compile_context_for_autotune_cache()
+
+            self.assertEqual(graph(["result"]), ["result"])
+
+        self.assertEqual(len(cache.puts), 1)
+        self.assertEqual(cache.puts[0][1], {"entry.best_config": {"ctx": "saved"}})
+        self.assertIsNone(graph._compile_context)
+
     @requires_cuda_and_triton
     @unittest.skipIf(not SM80OrLater, "Requires SM80+")
     @config.patch({"use_static_triton_launcher": True})

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3525,6 +3525,111 @@ class TestAutotuneCache(TestCase):
         _, cache_info = artifacts
         self.assertEqual(cache_info.autotune_artifacts, [expected_artifact_key])
 
+    @config.patch({"bundled_autotune_remote_cache": True})
+    def test_autotune_cache_bundler_is_compile_context_scoped(self):
+        from torch._guards import CompileContext, compile_context
+        from torch._inductor.runtime.autotune_cache import AutotuneCacheBundler
+
+        class FakeBundledCache:
+            def __init__(self):
+                self.puts = []
+
+            def get(self, key):
+                return None
+
+            def put(self, key, data):
+                self.puts.append((key, data))
+
+        cache1 = FakeBundledCache()
+        cache2 = FakeBundledCache()
+        inductor_meta = {
+            "autotune_local_cache": True,
+            "backend_hash": "backend",
+            "bundled_autotune_remote_cache": True,
+            "is_fbcode": False,
+        }
+
+        ctx1 = CompileContext(None)
+        ctx2 = CompileContext(None)
+        with mock.patch(
+            "torch._inductor.runtime.autotune_cache.create_cache",
+            side_effect=[cache1, cache2],
+        ):
+            with compile_context(ctx1):
+                AutotuneCacheBundler.begin_compile(inductor_meta, code_hash="code1")
+                AutotuneCacheBundler.put("/tmp/cache/aa/entry1.best_config", {"ctx": 1})
+
+                with compile_context(ctx2):
+                    AutotuneCacheBundler.begin_compile(inductor_meta, code_hash="code2")
+                    AutotuneCacheBundler.put(
+                        "/tmp/cache/bb/entry2.best_config", {"ctx": 2}
+                    )
+                    AutotuneCacheBundler.end_compile()
+
+                AutotuneCacheBundler.put("/tmp/cache/aa/entry3.best_config", {"ctx": 1})
+                AutotuneCacheBundler.end_compile()
+
+        self.assertEqual(len(cache1.puts), 1)
+        self.assertEqual(
+            cache1.puts[0][1],
+            {
+                "entry1.best_config": {"ctx": 1},
+                "entry3.best_config": {"ctx": 1},
+            },
+        )
+        self.assertEqual(len(cache2.puts), 1)
+        self.assertEqual(cache2.puts[0][1], {"entry2.best_config": {"ctx": 2}})
+
+    @config.patch({"bundled_autotune_remote_cache": True})
+    def test_autotune_cache_bundler_runs_in_saved_compile_context(self):
+        from torch._guards import CompileContext, compile_context
+        from torch._inductor.output_code import CompiledFxGraph
+        from torch._inductor.runtime.autotune_cache import AutotuneCacheBundler
+
+        class FakeBundledCache:
+            def __init__(self):
+                self.puts = []
+
+            def get(self, key):
+                return None
+
+            def put(self, key, data):
+                self.puts.append((key, data))
+
+        cache = FakeBundledCache()
+        inductor_meta = {
+            "autotune_local_cache": True,
+            "backend_hash": "backend",
+            "bundled_autotune_remote_cache": True,
+            "is_fbcode": False,
+        }
+
+        graph = CompiledFxGraph.__new__(CompiledFxGraph)
+        graph.fx_kwargs = {}
+        graph._compile_context = None
+
+        def current_callable(inputs):
+            AutotuneCacheBundler.put(
+                "/tmp/cache/aa/entry.best_config", {"ctx": "saved"}
+            )
+            return inputs
+
+        graph.current_callable = current_callable
+
+        with mock.patch(
+            "torch._inductor.runtime.autotune_cache.create_cache",
+            return_value=cache,
+        ):
+            with compile_context(CompileContext(None)):
+                AutotuneCacheBundler.begin_compile(inductor_meta, code_hash="code")
+                graph._set_compile_context_for_autotune_cache()
+
+            self.assertEqual(graph(["result"]), ["result"])
+
+        self.assertEqual(len(cache.puts), 1)
+        self.assertEqual(cache.puts[0][1], {"entry.best_config": {"ctx": "saved"}})
+        self.assertIsNone(graph._compile_context)
+
     @requires_cuda_and_triton
     @unittest.skipIf(not SM80OrLater, "Requires SM80+")
     @config.patch({"use_static_triton_launcher": True})

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3527,7 +3527,7 @@ class TestAutotuneCache(TestCase):
 
     @config.patch({"bundled_autotune_remote_cache": True})
     def test_autotune_cache_bundler_is_compile_context_scoped(self):
-        from torch._guards import CompileContext, compile_context
+        from torch._guards import compile_context, CompileContext
         from torch._inductor.runtime.autotune_cache import AutotuneCacheBundler
 
         class FakeBundledCache:
@@ -3582,7 +3582,7 @@ class TestAutotuneCache(TestCase):
 
     @config.patch({"bundled_autotune_remote_cache": True})
     def test_autotune_cache_bundler_runs_in_saved_compile_context(self):
-        from torch._guards import CompileContext, compile_context
+        from torch._guards import compile_context, CompileContext
         from torch._inductor.output_code import CompiledFxGraph
         from torch._inductor.runtime.autotune_cache import AutotuneCacheBundler
 

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1019,6 +1019,7 @@ class CompileContext:
         self.attempt = 0
         # Verbose ShapeEnv guards produced.
         self.shape_env_guards: list[str] = []
+        self.autotune_cache_bundler: Any | None = None
 
     @staticmethod
     def current_compile_id() -> CompileId | None:

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from torch._dynamo.guards import GuardCheckSpec
     from torch._functorch._aot_autograd.schemas import ViewAndMutationMeta
     from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
+    from torch._inductor.runtime.autotune_cache import AutotuneCacheBundler
     from torch._subclasses.fake_tensor import FakeTensorMode
 
 
@@ -1019,7 +1020,7 @@ class CompileContext:
         self.attempt = 0
         # Verbose ShapeEnv guards produced.
         self.shape_env_guards: list[str] = []
-        self.autotune_cache_bundler: Any | None = None
+        self.autotune_cache_bundler: AutotuneCacheBundler | None = None
 
     @staticmethod
     def current_compile_id() -> CompileId | None:

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -39,7 +39,6 @@ if TYPE_CHECKING:
     from torch._dynamo.guards import GuardCheckSpec
     from torch._functorch._aot_autograd.schemas import ViewAndMutationMeta
     from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
-    from torch._inductor.runtime.autotune_cache import AutotuneCacheBundler
     from torch._subclasses.fake_tensor import FakeTensorMode
 
 
@@ -1020,7 +1019,6 @@ class CompileContext:
         self.attempt = 0
         # Verbose ShapeEnv guards produced.
         self.shape_env_guards: list[str] = []
-        self.autotune_cache_bundler: AutotuneCacheBundler | None = None
 
     @staticmethod
     def current_compile_id() -> CompileId | None:

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1463,6 +1463,7 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
         inductor_meta = autotune_cache.inductor_meta_from_config()
         code = graph.source_code
         AutotuneCacheBundler.begin_compile(inductor_meta, code=code)
+        graph._set_compile_context_for_autotune_cache()
 
         # Increment the cached metrics/counters by the amounts recorded when the FX
         # graph was compiled for this cache entry. Pretending these counters

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1635,6 +1635,7 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
         inductor_meta = autotune_cache.inductor_meta_from_config()
         code = graph.source_code
         AutotuneCacheBundler.begin_compile(inductor_meta, code=code)
+        graph._set_compile_context_for_autotune_cache()
 
         # Increment the cached metrics/counters by the amounts recorded when the FX
         # graph was compiled for this cache entry. Pretending these counters

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -31,7 +31,7 @@ from typing import Any, TYPE_CHECKING, TypeAlias
 
 import torch
 from torch._dynamo.utils import counters, get_runtime_metrics_context
-from torch._guards import CompileContext, compile_context
+from torch._guards import compile_context, CompileContext
 from torch._higher_order_ops.wrap import inductor_compiled_code
 from torch._inductor.cudagraph_utils import (
     BoxedDeviceIndex,
@@ -537,7 +537,6 @@ class CompiledFxGraph(OutputCode):
         inductor_provenance_mapping_str: str | None = None,
         inductor_provenance_stack_traces_str: str | None = None,
     ) -> None:
-        self._set_compile_context_for_autotune_cache()
         self.current_callable = current_callable
         self.compiled_fn_runner = compiled_fn_runner
         self.recursively_apply_fns = (
@@ -672,6 +671,7 @@ class CompiledFxGraph(OutputCode):
         self.compile_region_name = compile_region_name
         self.inputs_to_check = inputs_to_check
         self.fx_kwargs = fx_kwargs
+        self._set_compile_context_for_autotune_cache()
 
         # aot autograd needs to know to pass in inputs as a list
         self._boxed_call = True
@@ -738,6 +738,9 @@ class CompiledFxGraph(OutputCode):
             if has_active_autotune_cache_bundler
             else contextlib.nullcontext()
         )
+        # Autotune cache writes happen during the first call. End the bundler
+        # while its saved compile context is restored, then clear the saved
+        # context after leaving the compile_context manager.
         try:
             with autotune_cache_context:
                 try:

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -22,6 +22,7 @@ serialized format:
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import logging
 import os
@@ -30,6 +31,7 @@ from typing import Any, TYPE_CHECKING, TypeAlias
 
 import torch
 from torch._dynamo.utils import counters, get_runtime_metrics_context
+from torch._guards import CompileContext, compile_context
 from torch._higher_order_ops.wrap import inductor_compiled_code
 from torch._inductor.cudagraph_utils import (
     BoxedDeviceIndex,
@@ -506,6 +508,9 @@ class CompiledFxGraph(OutputCode):
     _triton_bundle: TritonBundle | None = None
     _wrap_compiled_regions: bool = False
     _defers_input_alignment: bool = False
+    _compile_context: CompileContext | None = dataclasses.field(
+        default=None, init=False, repr=False, compare=False
+    )
     # Metadata-stripped copy of the FX graph for fake tensor propagation.
     # Running this graph under FakeTensorMode re-derives output shapes
     # (including aliasing) from the input shapes.
@@ -532,6 +537,7 @@ class CompiledFxGraph(OutputCode):
         inductor_provenance_mapping_str: str | None = None,
         inductor_provenance_stack_traces_str: str | None = None,
     ) -> None:
+        self._set_compile_context_for_autotune_cache()
         self.current_callable = current_callable
         self.compiled_fn_runner = compiled_fn_runner
         self.recursively_apply_fns = (
@@ -694,6 +700,16 @@ class CompiledFxGraph(OutputCode):
             # should also delete these partitions.
             del self.compiled_fn_runner.partitions
 
+    def _set_compile_context_for_autotune_cache(self) -> None:
+        compile_context_for_autotune_cache = CompileContext.try_get()
+        self._compile_context = (
+            compile_context_for_autotune_cache
+            if AutotuneCacheBundler.has_active_compile(
+                compile_context_for_autotune_cache
+            )
+            else None
+        )
+
     def __call__(self, inputs: Sequence[Any]) -> Any:
         assert self.current_callable is not None
 
@@ -713,19 +729,39 @@ class CompiledFxGraph(OutputCode):
                     "compile_id": compile_id,
                 }
             )
+        compile_context_for_autotune_cache = self._compile_context
+        has_active_autotune_cache_bundler = AutotuneCacheBundler.has_active_compile(
+            compile_context_for_autotune_cache
+        )
+        autotune_cache_context = (
+            compile_context(compile_context_for_autotune_cache)
+            if has_active_autotune_cache_bundler
+            else contextlib.nullcontext()
+        )
         try:
-            # Checking the profiler directly is faster than nullcontext
-            if torch.autograd.profiler._is_profiler_enabled:
-                with torch._C._profiler._RecordFunctionFast(
-                    f"## Call CompiledFxGraph {self._fx_graph_cache_key} ##",
-                    keyword_values={"scope": "user_scope"},
-                ):
-                    return self.current_callable(inputs)
-            else:
-                return self.current_callable(inputs)
+            with autotune_cache_context:
+                try:
+                    # Checking the profiler directly is faster than nullcontext
+                    if torch.autograd.profiler._is_profiler_enabled:
+                        with torch._C._profiler._RecordFunctionFast(
+                            f"## Call CompiledFxGraph {self._fx_graph_cache_key} ##",
+                            keyword_values={"scope": "user_scope"},
+                        ):
+                            return self.current_callable(inputs)
+                    else:
+                        return self.current_callable(inputs)
+                finally:
+                    get_runtime_metrics_context().finish()
+                    if has_active_autotune_cache_bundler:
+                        AutotuneCacheBundler.end_compile()
         finally:
-            get_runtime_metrics_context().finish()
-            AutotuneCacheBundler.end_compile()
+            if (
+                has_active_autotune_cache_bundler
+                and not AutotuneCacheBundler.has_active_compile(
+                    compile_context_for_autotune_cache
+                )
+            ):
+                self._compile_context = None
 
     def post_compile(
         self,
@@ -865,6 +901,7 @@ class CompiledFxGraph(OutputCode):
         # so we serialize their PyCodeCache disk cache location instead.
         # TODO: This could be better if we're ever able to serialize compiled
         # models to disk.
+        self._compile_context = None
         self.current_callable = None
         self.recursively_apply_fns = None
         self.compiled_fn_runner = None

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -425,23 +425,25 @@ class _AutotuneCacheBundlerImpl:
 
 
 class AutotuneCacheBundler:
+    """Manages one bundled autotune cache write scope for a compile context."""
+
     def __init__(self) -> None:
         self._bundler: _AutotuneCacheBundlerImpl | None = None
 
     @classmethod
     def _get_context_bundler(
         cls,
-        compile_context: CompileContext | None = None,
+        ctx: CompileContext | None = None,
         *,
         create: bool,
     ) -> AutotuneCacheBundler | None:
-        if compile_context is None:
+        if ctx is None:
             return None
 
-        bundler = compile_context.autotune_cache_bundler
+        bundler = ctx.autotune_cache_bundler
         if bundler is None and create:
             bundler = cls()
-            compile_context.autotune_cache_bundler = bundler
+            ctx.autotune_cache_bundler = bundler
         assert bundler is None or isinstance(bundler, cls)
         return bundler
 

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -35,6 +35,7 @@ from typing import Any, TYPE_CHECKING
 from typing_extensions import override
 
 import torch
+from torch._guards import CompileContext
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.compiler._cache import (
     CacheArtifact,
@@ -424,10 +425,30 @@ class _AutotuneCacheBundlerImpl:
 
 
 class AutotuneCacheBundler:
-    _bundler: _AutotuneCacheBundlerImpl | None = None
-
     def __init__(self) -> None:
-        pass
+        self._bundler: _AutotuneCacheBundlerImpl | None = None
+
+    @classmethod
+    def _get_context_bundler(
+        cls,
+        compile_context: CompileContext | None = None,
+        *,
+        create: bool,
+    ) -> AutotuneCacheBundler | None:
+        if compile_context is None:
+            return None
+
+        bundler = compile_context.autotune_cache_bundler
+        if bundler is None and create:
+            bundler = cls()
+            compile_context.autotune_cache_bundler = bundler
+        assert bundler is None or isinstance(bundler, cls)
+        return bundler
+
+    @classmethod
+    def has_active_compile(cls, compile_context: CompileContext | None) -> bool:
+        context_bundler = cls._get_context_bundler(compile_context, create=False)
+        return context_bundler is not None and context_bundler._bundler is not None
 
     # Call this before we start any autotune computation for an inductor python
     # file. On a cache hit it copies the individual results into the local
@@ -440,8 +461,6 @@ class AutotuneCacheBundler:
         code: str | None = None,
         code_hash: str | None = None,
     ) -> None:
-        assert cls._bundler is None
-
         if code is not None:
             assert code_hash is None, "Cannot specify both code and code_hash"
             code_hash = _comment_stripped_hash(code)
@@ -451,6 +470,16 @@ class AutotuneCacheBundler:
             inductor_meta
         ):
             return
+
+        context_bundler = cls._get_context_bundler(
+            CompileContext.try_get(), create=True
+        )
+        if context_bundler is None:
+            log.debug(
+                "Skipping bundled autotune cache because compile_context is not set"
+            )
+            return
+        assert context_bundler._bundler is None
 
         cache = create_cache(
             "bundled-autotune-v1",
@@ -481,7 +510,7 @@ class AutotuneCacheBundler:
         if not bundler._load_cache():
             # We couldn't load from the cache - so save the data so we can store
             # the saved autotunes.
-            cls._bundler = bundler
+            context_bundler._bundler = bundler
 
         # If we get a cache hit don't bother saving any of the individual
         # autotune results.
@@ -491,18 +520,36 @@ class AutotuneCacheBundler:
     # those and put it into the cache.
     @classmethod
     def end_compile(cls) -> None:
-        if bundler := cls._bundler:
-            cls._bundler = None
+        if not (
+            context_bundler := cls._get_context_bundler(
+                CompileContext.try_get(), create=False
+            )
+        ):
+            return
+        if bundler := context_bundler._bundler:
+            context_bundler._bundler = None
             bundler.end_compile()
 
     @classmethod
     def sync(cls) -> None:
-        if bundler := cls._bundler:
+        if not (
+            context_bundler := cls._get_context_bundler(
+                CompileContext.try_get(), create=False
+            )
+        ):
+            return
+        if bundler := context_bundler._bundler:
             bundler.sync()
 
     @classmethod
     def put(cls, filename: str, data: JsonDataTy) -> None:
-        if bundler := cls._bundler:
+        if not (
+            context_bundler := cls._get_context_bundler(
+                CompileContext.try_get(), create=False
+            )
+        ):
+            return
+        if bundler := context_bundler._bundler:
             # The filename comes in as something like
             # "/tmp/tmp{random}/{aa}/{basename}.py" (where aa is
             # basename[1:3]). Strip it down and make sure that it looks like a path

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -33,6 +33,7 @@ from typing import Any
 from typing_extensions import override
 
 import torch
+from torch._guards import CompileContext
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.compiler._cache import (
     CacheArtifact,
@@ -456,10 +457,30 @@ class _AutotuneCacheBundlerImpl:
 
 
 class AutotuneCacheBundler:
-    _bundler: _AutotuneCacheBundlerImpl | None = None
-
     def __init__(self) -> None:
-        pass
+        self._bundler: _AutotuneCacheBundlerImpl | None = None
+
+    @classmethod
+    def _get_context_bundler(
+        cls,
+        compile_context: CompileContext | None = None,
+        *,
+        create: bool,
+    ) -> AutotuneCacheBundler | None:
+        if compile_context is None:
+            return None
+
+        bundler = compile_context.autotune_cache_bundler
+        if bundler is None and create:
+            bundler = cls()
+            compile_context.autotune_cache_bundler = bundler
+        assert bundler is None or isinstance(bundler, cls)
+        return bundler
+
+    @classmethod
+    def has_active_compile(cls, compile_context: CompileContext | None) -> bool:
+        context_bundler = cls._get_context_bundler(compile_context, create=False)
+        return context_bundler is not None and context_bundler._bundler is not None
 
     # Call this before we start any autotune computation for an inductor python
     # file. On a cache hit it copies the individual results into the local
@@ -472,8 +493,6 @@ class AutotuneCacheBundler:
         code: str | None = None,
         code_hash: str | None = None,
     ) -> None:
-        assert cls._bundler is None
-
         if code is not None:
             assert code_hash is None, "Cannot specify both code and code_hash"
             code_hash = _comment_stripped_hash(code)
@@ -483,6 +502,16 @@ class AutotuneCacheBundler:
             inductor_meta
         ):
             return
+
+        context_bundler = cls._get_context_bundler(
+            CompileContext.try_get(), create=True
+        )
+        if context_bundler is None:
+            log.debug(
+                "Skipping bundled autotune cache because compile_context is not set"
+            )
+            return
+        assert context_bundler._bundler is None
 
         cache = create_cache(
             "bundled-autotune-v1",
@@ -512,7 +541,7 @@ class AutotuneCacheBundler:
         if not bundler._load_cache():
             # We couldn't load from the cache - so save the data so we can store
             # the saved autotunes.
-            cls._bundler = bundler
+            context_bundler._bundler = bundler
 
         # If we get a cache hit don't bother saving any of the individual
         # autotune results.
@@ -522,18 +551,36 @@ class AutotuneCacheBundler:
     # those and put it into the cache.
     @classmethod
     def end_compile(cls) -> None:
-        if bundler := cls._bundler:
-            cls._bundler = None
+        if not (
+            context_bundler := cls._get_context_bundler(
+                CompileContext.try_get(), create=False
+            )
+        ):
+            return
+        if bundler := context_bundler._bundler:
+            context_bundler._bundler = None
             bundler.end_compile()
 
     @classmethod
     def sync(cls) -> None:
-        if bundler := cls._bundler:
+        if not (
+            context_bundler := cls._get_context_bundler(
+                CompileContext.try_get(), create=False
+            )
+        ):
+            return
+        if bundler := context_bundler._bundler:
             bundler.sync()
 
     @classmethod
     def put(cls, filename: str, data: JsonDataTy) -> None:
-        if bundler := cls._bundler:
+        if not (
+            context_bundler := cls._get_context_bundler(
+                CompileContext.try_get(), create=False
+            )
+        ):
+            return
+        if bundler := context_bundler._bundler:
             # The filename comes in as something like
             # "/tmp/tmp{random}/{aa}/{basename}.py" (where aa is
             # basename[1:3]). Strip it down and make sure that it looks like a path

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -29,6 +29,8 @@ import logging
 import os
 import os.path
 import re
+import threading
+import weakref
 from typing import Any
 from typing_extensions import override
 
@@ -459,6 +461,11 @@ class _AutotuneCacheBundlerImpl:
 class AutotuneCacheBundler:
     """Manages one bundled autotune cache write scope for a compile context."""
 
+    _context_bundlers: weakref.WeakKeyDictionary[
+        CompileContext, AutotuneCacheBundler
+    ] = weakref.WeakKeyDictionary()
+    _context_bundlers_lock = threading.Lock()
+
     def __init__(self) -> None:
         self._bundler: _AutotuneCacheBundlerImpl | None = None
 
@@ -472,12 +479,13 @@ class AutotuneCacheBundler:
         if ctx is None:
             return None
 
-        bundler = ctx.autotune_cache_bundler
-        if bundler is None and create:
-            bundler = cls()
-            ctx.autotune_cache_bundler = bundler
-        assert bundler is None or isinstance(bundler, cls)
-        return bundler
+        with cls._context_bundlers_lock:
+            bundler = cls._context_bundlers.get(ctx)
+            if bundler is None and create:
+                bundler = cls()
+                cls._context_bundlers[ctx] = bundler
+            assert bundler is None or isinstance(bundler, cls)
+            return bundler
 
     @classmethod
     def has_active_compile(cls, compile_context: CompileContext | None) -> bool:

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -457,23 +457,25 @@ class _AutotuneCacheBundlerImpl:
 
 
 class AutotuneCacheBundler:
+    """Manages one bundled autotune cache write scope for a compile context."""
+
     def __init__(self) -> None:
         self._bundler: _AutotuneCacheBundlerImpl | None = None
 
     @classmethod
     def _get_context_bundler(
         cls,
-        compile_context: CompileContext | None = None,
+        ctx: CompileContext | None = None,
         *,
         create: bool,
     ) -> AutotuneCacheBundler | None:
-        if compile_context is None:
+        if ctx is None:
             return None
 
-        bundler = compile_context.autotune_cache_bundler
+        bundler = ctx.autotune_cache_bundler
         if bundler is None and create:
             bundler = cls()
-            compile_context.autotune_cache_bundler = bundler
+            ctx.autotune_cache_bundler = bundler
         assert bundler is None or isinstance(bundler, cls)
         return bundler
 


### PR DESCRIPTION
## Summary

### Root cause problem

`AutotuneCacheBundler._bundler` was a process-global implicit state machine for the bundled autotune lifecycle (`begin_compile` -> `put` -> `end_compile`). Nested or concurrent compilations could conflict because each compile shared the same active bundler slot.

### Proposed fix

Store the active autotune cache bundler on `CompileContext` instead of on the `AutotuneCacheBundler` class. `CompiledFxGraph` captures the compile context only when it has an active autotune cache bundler and temporarily restores that context for the first compiled call, where runtime autotune cache `put()` calls occur. FX graph cache hits refresh the saved context after `begin_compile()`.

### Why this is the right long term fix

The bundler lifecycle is now owned by the same compile context that owns the compilation, so separate compile contexts get independent bundler state. This keeps the existing call sites working while removing the global singleton conflict and preserving the runtime handoff needed to collect autotune entries during the first compiled graph call.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo