### PR TITLE
Unify Inductor cache key strategies

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 import base64
+import copy
 import functools
 import hashlib
 import json
@@ -11,6 +12,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import types
 import unittest
 from contextlib import contextmanager
 from typing_extensions import override
@@ -34,6 +36,7 @@ from torch._inductor.cache_key import (
 )
 from torch._inductor.codecache import (
     BypassFxGraphCache,
+    CacheBase,
     CUDACodeCache,
     FxGraphCachePickler,
     FxGraphHashDetails,
@@ -164,6 +167,50 @@ class TestCacheKeyStrategy(TestCase):
                 json.dumps(system, sort_keys=True).encode("utf-8")
             ).hexdigest(),
         )
+
+    def test_cache_base_get_system_uses_system_strategy(self):
+        class FakeStrategy:
+            value = None
+            sort_keys = None
+
+            def key_from_json(self, value, *, sort_keys=True):
+                self.value = copy.deepcopy(value)
+                self.sort_keys = sort_keys
+                return "sentinel"
+
+        fake_strategy = FakeStrategy()
+        device_properties = types.SimpleNamespace(
+            name="test-gpu", gcnArchName="test-gcn"
+        )
+
+        CacheBase.get_system.cache_clear()
+        try:
+            with (
+                mock.patch(
+                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
+                    fake_strategy,
+                ),
+                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
+                mock.patch.object(torch.cuda, "current_device", return_value=0),
+                mock.patch.object(
+                    torch.cuda,
+                    "get_device_properties",
+                    return_value=device_properties,
+                ),
+                mock.patch.object(torch.version, "cuda", "test-cuda"),
+            ):
+                self.assertEqual(CacheBase.get_system()["hash"], "sentinel")
+        finally:
+            CacheBase.get_system.cache_clear()
+
+        self.assertEqual(
+            fake_strategy.value,
+            {
+                "device": {"name": "test-gpu"},
+                "version": {"triton": None, "cuda": "test-cuda"},
+            },
+        )
+        self.assertTrue(fake_strategy.sort_keys)
 
     def test_autotune_prepare_key_uses_strategy(self):
         from torch._inductor.runtime.autotune_cache import AutotuneCache

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -1,5 +1,8 @@
 # Owner(s): ["module: inductor"]
+import base64
 import functools
+import hashlib
+import json
 import logging
 import os
 import pickle
@@ -21,6 +24,14 @@ from torch._dynamo.utils import counters
 from torch._functorch import config as functorch_config
 from torch._functorch._aot_autograd.autograd_cache import AOTAutogradCache
 from torch._inductor import config, metrics
+from torch._inductor.cache_key import (
+    AUTOTUNE_CACHE_KEY_STRATEGY,
+    CacheKeyStrategy,
+    CODE_CACHE_KEY_STRATEGY,
+    COMPACT_CACHE_KEY_STRATEGY,
+    FX_GRAPH_CACHE_KEY_STRATEGY,
+    SYSTEM_CACHE_KEY_STRATEGY,
+)
 from torch._inductor.codecache import (
     BypassFxGraphCache,
     CUDACodeCache,
@@ -94,6 +105,87 @@ torch._dynamo.config.fake_tensor_cache_crosscheck_enabled = True
 
 
 STATIC_LAUNCHER_DEVICES = ("cuda", "xpu")
+
+
+class TestCacheKeyStrategy(TestCase):
+    def _compact_sha256(self, data: bytes) -> str:
+        return (
+            base64.b32encode(hashlib.sha256(data).digest())[:51].decode("utf-8").lower()
+        )
+
+    def test_strategy_formats_existing_key_shapes(self):
+        self.assertEqual(
+            COMPACT_CACHE_KEY_STRATEGY.key(b"kernel"),
+            self._compact_sha256(b"kernel"),
+        )
+        self.assertEqual(
+            CODE_CACHE_KEY_STRATEGY.key("kernel", "extra"),
+            "c" + self._compact_sha256(b"kernel||extra"),
+        )
+        self.assertEqual(
+            FX_GRAPH_CACHE_KEY_STRATEGY.key(b"graph"),
+            "f" + self._compact_sha256(b"graph"),
+        )
+        self.assertEqual(
+            AUTOTUNE_CACHE_KEY_STRATEGY.key("kernel", b"torch"),
+            hashlib.sha256(b"kerneltorch").hexdigest(),
+        )
+
+    def test_custom_strategy_composes_components(self):
+        strategy = CacheKeyStrategy(
+            name="test",
+            digest_format="hex",
+            prefix="x",
+            separator=b":",
+        )
+
+        self.assertEqual(
+            strategy.key("left", b"right"),
+            "x" + hashlib.sha256(b"left:right").hexdigest(),
+        )
+
+    def test_code_hash_uses_code_strategy(self):
+        from torch._inductor.codecache import code_hash, sha256_hash
+
+        self.assertEqual(
+            sha256_hash(b"kernel"), COMPACT_CACHE_KEY_STRATEGY.key(b"kernel")
+        )
+        self.assertEqual(
+            code_hash("kernel", extra="extra"),
+            CODE_CACHE_KEY_STRATEGY.key("kernel", "extra"),
+        )
+
+    def test_system_strategy_hashes_sorted_json(self):
+        system = {"version": {"triton": "abc"}, "device": {"name": "gpu"}}
+
+        self.assertEqual(
+            SYSTEM_CACHE_KEY_STRATEGY.key_from_json(system),
+            hashlib.sha256(
+                json.dumps(system, sort_keys=True).encode("utf-8")
+            ).hexdigest(),
+        )
+
+    def test_autotune_prepare_key_uses_strategy(self):
+        from torch._inductor.runtime.autotune_cache import AutotuneCache
+
+        class FakeStrategy:
+            components = None
+
+            def key(self, *components):
+                self.components = components
+                return "sentinel"
+
+        fake_strategy = FakeStrategy()
+        with (
+            mock.patch(
+                "torch._inductor.runtime.autotune_cache.AUTOTUNE_CACHE_KEY_STRATEGY",
+                fake_strategy,
+            ),
+            torch.compiler.config.patch({"cache_key_tag": "tag"}),
+        ):
+            self.assertEqual(AutotuneCache._prepare_key("/tmp/cabcdef.py"), "sentinel")
+
+        self.assertEqual(fake_strategy.components, ("cabcdef.py:tag",))
 
 
 class LogCaptureHandler(logging.Handler):

--- a/torch/_inductor/cache_key.py
+++ b/torch/_inductor/cache_key.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import base64
+import dataclasses
+import hashlib
+import json
+from typing import Any, Literal
+
+
+CacheKeyComponent = str | bytes | bytearray | memoryview
+
+
+@dataclasses.dataclass(frozen=True)
+class CacheKeyStrategy:
+    """
+    Describes how an Inductor cache turns stable components into a cache key.
+
+    Different caches intentionally use different key formats for compatibility
+    with existing on-disk and remote cache layouts. Keeping those choices in
+    named strategies makes the composition explicit at the call site.
+    """
+
+    name: str
+    digest_format: Literal["base32", "hex"]
+    prefix: str = ""
+    separator: bytes | None = None
+    base32_length: int = 51
+
+    @staticmethod
+    def _to_bytes(component: CacheKeyComponent) -> bytes:
+        if isinstance(component, str):
+            return component.encode("utf-8")
+        if isinstance(component, bytes):
+            return component
+        if isinstance(component, bytearray):
+            return bytes(component)
+        if isinstance(component, memoryview):
+            return component.tobytes()
+        raise TypeError(f"Unsupported cache key component: {type(component)!r}")
+
+    def _hasher(self, components: tuple[CacheKeyComponent, ...]) -> hashlib._Hash:
+        hasher = hashlib.sha256()
+        for idx, component in enumerate(components):
+            if idx > 0 and self.separator is not None:
+                hasher.update(self.separator)
+            hasher.update(self._to_bytes(component))
+        return hasher
+
+    def digest(self, *components: CacheKeyComponent) -> str:
+        hasher = self._hasher(components)
+        if self.digest_format == "hex":
+            return hasher.hexdigest()
+        if self.digest_format == "base32":
+            # [:51] strips the "Q====" suffix common to every SHA256 base32 digest.
+            return (
+                base64.b32encode(hasher.digest())[: self.base32_length]
+                .decode("utf-8")
+                .lower()
+            )
+        raise AssertionError(f"Unknown digest format {self.digest_format}")
+
+    def key(self, *components: CacheKeyComponent) -> str:
+        return f"{self.prefix}{self.digest(*components)}"
+
+    def key_from_json(self, value: Any, *, sort_keys: bool = True) -> str:
+        return self.key(json.dumps(value, sort_keys=sort_keys))
+
+
+COMPACT_CACHE_KEY_STRATEGY = CacheKeyStrategy(
+    name="compact",
+    digest_format="base32",
+)
+
+CODE_CACHE_KEY_STRATEGY = CacheKeyStrategy(
+    name="code",
+    digest_format="base32",
+    prefix="c",
+    separator=b"||",
+)
+
+FX_GRAPH_CACHE_KEY_STRATEGY = CacheKeyStrategy(
+    name="fx_graph",
+    digest_format="base32",
+    prefix="f",
+)
+
+SYSTEM_CACHE_KEY_STRATEGY = CacheKeyStrategy(
+    name="system",
+    digest_format="hex",
+)
+
+AUTOTUNE_CACHE_KEY_STRATEGY = CacheKeyStrategy(
+    name="autotune",
+    digest_format="hex",
+)

--- a/torch/_inductor/cache_key.py
+++ b/torch/_inductor/cache_key.py
@@ -4,10 +4,17 @@ import base64
 import dataclasses
 import hashlib
 import json
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
+from typing_extensions import assert_never
 
 
 CacheKeyComponent = str | bytes | bytearray | memoryview
+
+
+class _HashLike(Protocol):
+    def update(self, data: bytes, /) -> None: ...
+    def digest(self) -> bytes: ...
+    def hexdigest(self) -> str: ...
 
 
 @dataclasses.dataclass(frozen=True)
@@ -20,6 +27,7 @@ class CacheKeyStrategy:
     named strategies makes the composition explicit at the call site.
     """
 
+    # Human-readable label for repr/debugging; it is not part of the cache key.
     name: str
     digest_format: Literal["base32", "hex"]
     prefix: str = ""
@@ -38,7 +46,7 @@ class CacheKeyStrategy:
             return component.tobytes()
         raise TypeError(f"Unsupported cache key component: {type(component)!r}")
 
-    def _hasher(self, components: tuple[CacheKeyComponent, ...]) -> hashlib._Hash:
+    def _hasher(self, components: tuple[CacheKeyComponent, ...]) -> _HashLike:
         hasher = hashlib.sha256()
         for idx, component in enumerate(components):
             if idx > 0 and self.separator is not None:
@@ -57,7 +65,7 @@ class CacheKeyStrategy:
                 .decode("utf-8")
                 .lower()
             )
-        raise AssertionError(f"Unknown digest format {self.digest_format}")
+        assert_never(self.digest_format)
 
     def key(self, *components: CacheKeyComponent) -> str:
         return f"{self.prefix}{self.digest(*components)}"
@@ -92,4 +100,6 @@ SYSTEM_CACHE_KEY_STRATEGY = CacheKeyStrategy(
 AUTOTUNE_CACHE_KEY_STRATEGY = CacheKeyStrategy(
     name="autotune",
     digest_format="hex",
+    # Preserve the existing autotune cache format, which concatenates components.
+    separator=None,
 )

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -158,6 +158,9 @@ output_code_log = torch._logging.getArtifactLogger(__name__, "output_code")
 autotuning_log = torch._logging.getArtifactLogger(__name__, "autotuning")
 log = logging.getLogger(__name__)
 
+AOTAUTOGRAD_CACHE_PREFIX = "a"
+
+
 def get_cpp_wrapper_cubin_path_name() -> str:
     return "cubin_path" if torch.version.hip is None else "hsaco_path"
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -120,6 +120,12 @@ from torch.fx.experimental.symbolic_shapes import (
 )
 from torch.utils._ordered_set import OrderedSet
 
+from .cache_key import (
+    CODE_CACHE_KEY_STRATEGY,
+    COMPACT_CACHE_KEY_STRATEGY,
+    FX_GRAPH_CACHE_KEY_STRATEGY,
+    SYSTEM_CACHE_KEY_STRATEGY,
+)
 from .output_code import CompiledFxGraph
 from .remote_cache import create_cache
 from .runtime import autotune_cache
@@ -151,11 +157,6 @@ LOCK_TIMEOUT = config.file_lock_timeout
 output_code_log = torch._logging.getArtifactLogger(__name__, "output_code")
 autotuning_log = torch._logging.getArtifactLogger(__name__, "autotuning")
 log = logging.getLogger(__name__)
-
-FXGRAPH_CACHE_PREFIX = "c"
-AOTAUTOGRAD_CACHE_PREFIX = "a"
-COMPILED_FX_GRAPH_CACHE_PREFIX = "f"
-
 
 def get_cpp_wrapper_cubin_path_name() -> str:
     return "cubin_path" if torch.version.hip is None else "hsaco_path"
@@ -218,9 +219,7 @@ class CacheBase:
             # If cuda is not installed, none of the above config is relevant.
             system = {}
 
-        system["hash"] = hashlib.sha256(
-            json.dumps(system, sort_keys=True).encode("utf-8")
-        ).hexdigest()
+        system["hash"] = SYSTEM_CACHE_KEY_STRATEGY.key_from_json(system)
 
         return system
 
@@ -338,16 +337,13 @@ def get_lock_dir() -> str:
 
 
 def sha256_hash(data: bytes) -> str:
-    # [:51] to strip off the "Q====" suffix common to every hash value.
-    return base64.b32encode(hashlib.sha256(data).digest())[:51].decode("utf-8").lower()
+    return COMPACT_CACHE_KEY_STRATEGY.key(data)
 
 
 def code_hash(code: str | bytes, extra: str | bytes = "") -> str:
-    hashing_str = code if isinstance(code, bytes) else code.encode("utf-8")
     if extra:
-        extra_b = extra if isinstance(extra, bytes) else extra.encode("utf-8")
-        hashing_str = hashing_str + b"||" + extra_b
-    return FXGRAPH_CACHE_PREFIX + sha256_hash(hashing_str)
+        return CODE_CACHE_KEY_STRATEGY.key(code, extra)
+    return CODE_CACHE_KEY_STRATEGY.key(code)
 
 
 def get_path(
@@ -682,7 +678,14 @@ class FxGraphCachePickler(pickle.Pickler):
         Serialize an object and return a hash of the bytes.
         """
         serialized_data = self.dumps(obj)
-        return sha256_hash(serialized_data)
+        return COMPACT_CACHE_KEY_STRATEGY.key(serialized_data)
+
+    def get_key(self, obj: Any) -> str:
+        """
+        Serialize an object and return an FX graph cache key.
+        """
+        serialized_data = self.dumps(obj)
+        return FX_GRAPH_CACHE_KEY_STRATEGY.key(serialized_data)
 
     def debug_lines(self, inp: FxGraphHashDetails) -> list[str]:
         """
@@ -1128,7 +1131,7 @@ def compiled_fx_graph_hash(
 
     # The prefix distinguishes among the other kinds of objects we
     # cache in this module.
-    key = COMPILED_FX_GRAPH_CACHE_PREFIX + pickler.get_hash(details)
+    key = pickler.get_key(details)
     debug_lines = pickler.debug_lines(details)
     debug_str = "\n".join(debug_lines)
     log.debug(f"FX graph cache hash details for key {key}:\n{debug_str}")  # noqa: G004

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -26,7 +26,6 @@ expensive autotuning operations when the same kernels are compiled multiple time
 from __future__ import annotations
 
 import dataclasses
-import hashlib
 import logging
 import os
 import os.path
@@ -43,6 +42,7 @@ from torch.compiler._cache import (
 )
 from torch.utils._triton import has_triton
 
+from ..cache_key import AUTOTUNE_CACHE_KEY_STRATEGY
 from ..remote_cache import (
     create_cache,
     JsonDataTy,
@@ -139,7 +139,7 @@ class AutotuneCache:
 
         # base of filename is already sha256 hash the source contents
         key = f"{os.path.basename(filename)}:{cconfig.cache_key_tag}"
-        return hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return AUTOTUNE_CACHE_KEY_STRATEGY.key(key)
 
     # Read the best config options from the most local cache and return it.
     def _read(self) -> dict[str, JsonDataTy] | None:
@@ -184,10 +184,7 @@ class AutotuneCache:
         of changes to the best_config format or other code changes that
         are not backward compatible w.r.t. the cache.
         """
-        hasher = hashlib.sha256()
-        hasher.update(cache_key.encode("utf-8"))
-        hasher.update(torch_key())
-        updated_cache_key = hasher.hexdigest()
+        updated_cache_key = AUTOTUNE_CACHE_KEY_STRATEGY.key(cache_key, torch_key())
 
         cache_filename = f"{dirname}/{updated_cache_key}.best_config"
         local_cache = LocalAutotuneCache()
@@ -213,8 +210,9 @@ class AutotuneCache:
 
         salt = "autotune-best-config-v2"
         # re: torch_key - see [Note: torch_key in autotune cache key]
-        key = torch_key().hex() + backend_hash + self.configs_hash + salt
-        key = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        key = AUTOTUNE_CACHE_KEY_STRATEGY.key(
+            torch_key().hex(), backend_hash, self.configs_hash, salt
+        )
 
         remote_cache = create_cache(
             key,
@@ -474,8 +472,7 @@ class AutotuneCacheBundler:
         # that info is basically present in the `code_hash` (since it's a
         # parameter to the pointwise decorator) - but is there other info we
         # need to include from inductor_meta?
-        key = code_hash + backend_hash + salt
-        key = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        key = AUTOTUNE_CACHE_KEY_STRATEGY.key(code_hash, backend_hash, salt)
 
         bundler = _AutotuneCacheBundlerImpl(key, cache)
         if not bundler._load_cache():


### PR DESCRIPTION
## Summary
This introduces a shared `CacheKeyStrategy` abstraction for Inductor cache keys and routes the FxGraph, code, autotune, and system cache key paths through named strategies while preserving their existing digest formats.

## Root Cause Problem
FxGraph, autotune, code, and system caches each composed and formatted SHA256-derived keys inline. That made it hard to see which key format each cache intended to use and duplicated details like compact base32 formatting, hex formatting, prefixes, and component joining.

## Proposed Fix
Add `torch._inductor.cache_key.CacheKeyStrategy` with explicit strategies for compact, code, FxGraph, system, and autotune keys. Existing call sites now use those strategies for key construction instead of open-coded hashing.

## Why This Is The Right Long Term Fix
A single strategy interface keeps cache compatibility decisions centralized without forcing all caches into one digest format. New cache keys can make their component composition and output format explicit, and existing caches retain their on-disk and remote key shapes.

## Tests
- `PYTHONPATH=. python3 test/inductor/test_codecache.py TestCacheKeyStrategy -v`
- `PYTHONPATH=. python3 test/inductor/test_codecache.py TestFxGraphCacheHashing -v`
- `PYTHONPATH=. python3 test/inductor/test_codecache.py TestPyCodeCache -v`
- `python3 -m py_compile torch/_inductor/cache_key.py torch/_inductor/codecache.py torch/_inductor/runtime/autotune_cache.py test/inductor/test_codecache.py`
- `git diff --check`
- `lintrunner --take PYFMT torch/_inductor/cache_key.py torch/_inductor/codecache.py torch/_inductor/runtime/autotune_cache.py test/inductor/test_codecache.py`
- `lintrunner --take PYFMT,RUFF,FLAKE8,IMPORT_LINTER torch/_inductor/cache_key.py torch/_inductor/codecache.py torch/_inductor/runtime/autotune_cache.py test/inductor/test_codecache.py`

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo