### PR TITLE
Consolidate cache artifact recording

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3449,6 +3449,7 @@ class TestAutotuneCache(TestCase):
         super().setUp()
         counters.clear()
         PatchCaches.setUp()
+        CacheArtifactManager.clear()
 
     def tearDown(self):
         super().tearDown()
@@ -3458,6 +3459,67 @@ class TestAutotuneCache(TestCase):
         PyCodeCache.cache_clear(purge=True)
         torch._dynamo.reset()
         clear_caches()
+
+    def test_remote_only_autotune_records_cache_artifacts(self):
+        from torch._inductor.runtime.autotune_cache import AutotuneCache
+
+        class RemoteCacheStub:
+            def __init__(self) -> None:
+                self.cache = {}
+
+            def get(self, key):
+                return self.cache.get(key)
+
+            def put(self, key, value) -> None:
+                self.cache[key] = value
+
+        class ConfigStub:
+            kwargs = {"BLOCK_M": 16, "BLOCK_N": 16}
+            num_warps = 4
+            num_stages = 3
+
+        remote_cache = RemoteCacheStub()
+        inductor_meta = {
+            "autotune_local_cache": False,
+            "autotune_remote_cache": True,
+            "backend_hash": "backend_hash",
+            "is_fbcode": False,
+        }
+
+        with mock.patch(
+            "torch._inductor.runtime.autotune_cache.create_cache",
+            return_value=remote_cache,
+        ):
+            autotune_cache = AutotuneCache.create(
+                inductor_meta,
+                os.path.join(cache_dir(), "aa", "kernel.py"),
+                "configs_hash",
+            )
+
+        self.assertIsNotNone(autotune_cache)
+        if autotune_cache is None:
+            raise AssertionError("Expected AutotuneCache.create() to return a cache")
+        self.assertIsNone(autotune_cache.local_cache)
+        self.assertIsNotNone(autotune_cache.remote_cache)
+
+        CacheArtifactManager.clear()
+        autotune_cache.save(ConfigStub(), time_taken_ns=1_000_000)
+
+        artifacts = torch.compiler.save_cache_artifacts()
+        self.assertIsNotNone(artifacts)
+        if artifacts is None:
+            raise AssertionError("Expected autotune save to record a cache artifact")
+        _, cache_info = artifacts
+        self.assertEqual(len(cache_info.autotune_artifacts), 1)
+
+        CacheArtifactManager.clear()
+        self.assertIsNotNone(autotune_cache._read())
+        artifacts = torch.compiler.save_cache_artifacts()
+        self.assertIsNotNone(artifacts)
+        if artifacts is None:
+            raise AssertionError("Expected autotune read to record a cache artifact")
+        _, cache_info = artifacts
+        self.assertEqual(len(cache_info.autotune_artifacts), 1)
 
     @requires_cuda_and_triton
     @unittest.skipIf(not SM80OrLater, "Requires SM80+")
@@ -4140,11 +4202,7 @@ class TestAutotuneCacheExtraOptions(TestCase):
         cache.local_cache = (mock_local_backend, "test_key")
         cache.remote_cache = None
 
-        # Mock AutotuneCacheBundler and CacheArtifactManager
-        with (
-            mock.patch("torch._inductor.runtime.autotune_cache.AutotuneCacheBundler"),
-            mock.patch("torch._inductor.runtime.autotune_cache.CacheArtifactManager"),
-        ):
+        with mock.patch("torch._inductor.runtime.autotune_cache.AutotuneCacheBundler"):
             cache.save(config_with_extra, time_taken_ns=1000000)
 
         # Verify extra_options was included in the saved data
@@ -4180,11 +4238,7 @@ class TestAutotuneCacheExtraOptions(TestCase):
         cache.local_cache = (mock_local_backend, "test_key")
         cache.remote_cache = None
 
-        # Mock AutotuneCacheBundler and CacheArtifactManager
-        with (
-            mock.patch("torch._inductor.runtime.autotune_cache.AutotuneCacheBundler"),
-            mock.patch("torch._inductor.runtime.autotune_cache.CacheArtifactManager"),
-        ):
+        with mock.patch("torch._inductor.runtime.autotune_cache.AutotuneCacheBundler"):
             cache.save(config_without_extra, time_taken_ns=1000000)
 
         # Verify extra_options was NOT included in the saved data

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -10,6 +10,7 @@ import tempfile
 import textwrap
 import unittest
 from contextlib import contextmanager
+from typing import cast
 from typing_extensions import override
 from unittest import mock
 
@@ -48,6 +49,8 @@ from torch.compiler._cache import (
     CacheArtifact,
     CacheArtifactFactory,
     CacheArtifactManager,
+    CacheArtifactRecorder,
+    CacheInfo,
 )
 from torch.testing._internal.common_cuda import (
     SM80OrLater,
@@ -3259,29 +3262,31 @@ class TestAutotuneCache(TestCase):
             )
 
         self.assertIsNotNone(autotune_cache)
-        if autotune_cache is None:
-            raise AssertionError("Expected AutotuneCache.create() to return a cache")
+        autotune_cache = cast(AutotuneCache, autotune_cache)
         self.assertIsNone(autotune_cache.local_cache)
         self.assertIsNotNone(autotune_cache.remote_cache)
+        self.assertIsNotNone(autotune_cache.artifact_recorder)
+        artifact_recorder = cast(
+            CacheArtifactRecorder, autotune_cache.artifact_recorder
+        )
+        expected_artifact_key = artifact_recorder.key
 
         CacheArtifactManager.clear()
         autotune_cache.save(ConfigStub(), time_taken_ns=1_000_000)
 
         artifacts = torch.compiler.save_cache_artifacts()
         self.assertIsNotNone(artifacts)
-        if artifacts is None:
-            raise AssertionError("Expected autotune save to record a cache artifact")
+        artifacts = cast(tuple[bytes, CacheInfo], artifacts)
         _, cache_info = artifacts
-        self.assertEqual(len(cache_info.autotune_artifacts), 1)
+        self.assertEqual(cache_info.autotune_artifacts, [expected_artifact_key])
 
         CacheArtifactManager.clear()
         self.assertIsNotNone(autotune_cache._read())
         artifacts = torch.compiler.save_cache_artifacts()
         self.assertIsNotNone(artifacts)
-        if artifacts is None:
-            raise AssertionError("Expected autotune read to record a cache artifact")
+        artifacts = cast(tuple[bytes, CacheInfo], artifacts)
         _, cache_info = artifacts
-        self.assertEqual(len(cache_info.autotune_artifacts), 1)
+        self.assertEqual(cache_info.autotune_artifacts, [expected_artifact_key])
 
     @requires_cuda_and_triton
     @unittest.skipIf(not SM80OrLater, "Requires SM80+")

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -65,6 +65,8 @@ from torch.compiler._cache import (
     CacheArtifact,
     CacheArtifactFactory,
     CacheArtifactManager,
+    CacheArtifactRecorder,
+    CacheInfo,
 )
 from torch.testing._internal.common_cuda import (
     SM80OrLater,
@@ -3497,29 +3499,31 @@ class TestAutotuneCache(TestCase):
             )
 
         self.assertIsNotNone(autotune_cache)
-        if autotune_cache is None:
-            raise AssertionError("Expected AutotuneCache.create() to return a cache")
+        autotune_cache = cast(AutotuneCache, autotune_cache)
         self.assertIsNone(autotune_cache.local_cache)
         self.assertIsNotNone(autotune_cache.remote_cache)
+        self.assertIsNotNone(autotune_cache.artifact_recorder)
+        artifact_recorder = cast(
+            CacheArtifactRecorder, autotune_cache.artifact_recorder
+        )
+        expected_artifact_key = artifact_recorder.key
 
         CacheArtifactManager.clear()
         autotune_cache.save(ConfigStub(), time_taken_ns=1_000_000)
 
         artifacts = torch.compiler.save_cache_artifacts()
         self.assertIsNotNone(artifacts)
-        if artifacts is None:
-            raise AssertionError("Expected autotune save to record a cache artifact")
+        artifacts = cast(tuple[bytes, CacheInfo], artifacts)
         _, cache_info = artifacts
-        self.assertEqual(len(cache_info.autotune_artifacts), 1)
+        self.assertEqual(cache_info.autotune_artifacts, [expected_artifact_key])
 
         CacheArtifactManager.clear()
         self.assertIsNotNone(autotune_cache._read())
         artifacts = torch.compiler.save_cache_artifacts()
         self.assertIsNotNone(artifacts)
-        if artifacts is None:
-            raise AssertionError("Expected autotune read to record a cache artifact")
+        artifacts = cast(tuple[bytes, CacheInfo], artifacts)
         _, cache_info = artifacts
-        self.assertEqual(len(cache_info.autotune_artifacts), 1)
+        self.assertEqual(cache_info.autotune_artifacts, [expected_artifact_key])
 
     @requires_cuda_and_triton
     @unittest.skipIf(not SM80OrLater, "Requires SM80+")

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3211,6 +3211,7 @@ class TestAutotuneCache(TestCase):
         super().setUp()
         counters.clear()
         PatchCaches.setUp()
+        CacheArtifactManager.clear()
 
     def tearDown(self):
         super().tearDown()
@@ -3220,6 +3221,67 @@ class TestAutotuneCache(TestCase):
         PyCodeCache.cache_clear(purge=True)
         torch._dynamo.reset()
         clear_caches()
+
+    def test_remote_only_autotune_records_cache_artifacts(self):
+        from torch._inductor.runtime.autotune_cache import AutotuneCache
+
+        class RemoteCacheStub:
+            def __init__(self) -> None:
+                self.cache = {}
+
+            def get(self, key):
+                return self.cache.get(key)
+
+            def put(self, key, value) -> None:
+                self.cache[key] = value
+
+        class ConfigStub:
+            kwargs = {"BLOCK_M": 16, "BLOCK_N": 16}
+            num_warps = 4
+            num_stages = 3
+
+        remote_cache = RemoteCacheStub()
+        inductor_meta = {
+            "autotune_local_cache": False,
+            "autotune_remote_cache": True,
+            "backend_hash": "backend_hash",
+            "is_fbcode": False,
+        }
+
+        with mock.patch(
+            "torch._inductor.runtime.autotune_cache.create_cache",
+            return_value=remote_cache,
+        ):
+            autotune_cache = AutotuneCache.create(
+                inductor_meta,
+                os.path.join(cache_dir(), "aa", "kernel.py"),
+                "configs_hash",
+            )
+
+        self.assertIsNotNone(autotune_cache)
+        if autotune_cache is None:
+            raise AssertionError("Expected AutotuneCache.create() to return a cache")
+        self.assertIsNone(autotune_cache.local_cache)
+        self.assertIsNotNone(autotune_cache.remote_cache)
+
+        CacheArtifactManager.clear()
+        autotune_cache.save(ConfigStub(), time_taken_ns=1_000_000)
+
+        artifacts = torch.compiler.save_cache_artifacts()
+        self.assertIsNotNone(artifacts)
+        if artifacts is None:
+            raise AssertionError("Expected autotune save to record a cache artifact")
+        _, cache_info = artifacts
+        self.assertEqual(len(cache_info.autotune_artifacts), 1)
+
+        CacheArtifactManager.clear()
+        self.assertIsNotNone(autotune_cache._read())
+        artifacts = torch.compiler.save_cache_artifacts()
+        self.assertIsNotNone(artifacts)
+        if artifacts is None:
+            raise AssertionError("Expected autotune read to record a cache artifact")
+        _, cache_info = artifacts
+        self.assertEqual(len(cache_info.autotune_artifacts), 1)
 
     @requires_cuda_and_triton
     @unittest.skipIf(not SM80OrLater, "Requires SM80+")
@@ -3902,11 +3964,7 @@ class TestAutotuneCacheExtraOptions(TestCase):
         cache.local_cache = (mock_local_backend, "test_key")
         cache.remote_cache = None
 
-        # Mock AutotuneCacheBundler and CacheArtifactManager
-        with (
-            mock.patch("torch._inductor.runtime.autotune_cache.AutotuneCacheBundler"),
-            mock.patch("torch._inductor.runtime.autotune_cache.CacheArtifactManager"),
-        ):
+        with mock.patch("torch._inductor.runtime.autotune_cache.AutotuneCacheBundler"):
             cache.save(config_with_extra, time_taken_ns=1000000)
 
         # Verify extra_options was included in the saved data
@@ -3942,11 +4000,7 @@ class TestAutotuneCacheExtraOptions(TestCase):
         cache.local_cache = (mock_local_backend, "test_key")
         cache.remote_cache = None
 
-        # Mock AutotuneCacheBundler and CacheArtifactManager
-        with (
-            mock.patch("torch._inductor.runtime.autotune_cache.AutotuneCacheBundler"),
-            mock.patch("torch._inductor.runtime.autotune_cache.CacheArtifactManager"),
-        ):
+        with mock.patch("torch._inductor.runtime.autotune_cache.AutotuneCacheBundler"):
             cache.save(config_without_extra, time_taken_ns=1000000)
 
         # Verify extra_options was NOT included in the saved data

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -469,7 +469,7 @@ class _DynamoCacheEntry:
 from torch.compiler._cache import (
     CacheArtifact,
     CacheArtifactFactory,
-    CacheArtifactManager,
+    CacheArtifactRecorder,
 )
 
 
@@ -1116,8 +1116,8 @@ class DiskDynamoStore(DynamoStore):
         """
         try:
             pickled_content: bytes = pickle.dumps(cache_entry)
-            CacheArtifactManager.record_artifact(
-                PrecompileCacheArtifact.type(), path, pickled_content
+            CacheArtifactRecorder(PrecompileCacheArtifact.type(), path).record(
+                pickled_content
             )
             self._write_to_local_cache(pickled_content, path)
         except Exception as e:

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -40,7 +40,7 @@ from torch._logging._internal import trace_structured_artifact
 from torch.compiler._cache import (
     CacheArtifact,
     CacheArtifactFactory,
-    CacheArtifactManager,
+    CacheArtifactRecorder,
 )
 from torch.utils._ordered_set import OrderedSet
 
@@ -810,8 +810,8 @@ def get_local_code_state(cache_key: str) -> defaultdict[CodeId, CodeState] | Non
                         "get_code_state failed while reading %s", path, exc_info=True
                     )
                 else:
-                    CacheArtifactManager.record_artifact(
-                        PGOCacheArtifact.type(), cache_key, content
+                    CacheArtifactRecorder(PGOCacheArtifact.type(), cache_key).record(
+                        content
                     )
                     return hit(path, "local")
     return None
@@ -846,8 +846,8 @@ def lookup_remote_cache_entry(
                     exc_info=True,
                 )
             else:
-                CacheArtifactManager.record_artifact(
-                    PGOCacheArtifact.type(), cache_key, payload
+                CacheArtifactRecorder(PGOCacheArtifact.type(), cache_key).record(
+                    payload
                 )
         else:
             log.info("get_code_state remote miss on %s", cache_key)
@@ -991,9 +991,7 @@ def put_local_code_state(cache_key: str) -> None:
 
         pickled_code = pickle.dumps(_CODE_STATE)
 
-        CacheArtifactManager.record_artifact(
-            PGOCacheArtifact.type(), cache_key, pickled_code
-        )
+        CacheArtifactRecorder(PGOCacheArtifact.type(), cache_key).record(pickled_code)
 
         meta = write_local_impl(cache_key, pickled_code)
         if meta is None:

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -56,7 +56,7 @@ from torch._utils_internal import log_cache_bypass
 from torch.compiler._cache import (
     CacheArtifact,
     CacheArtifactFactory,
-    CacheArtifactManager,
+    CacheArtifactRecorder,
 )
 from torch.fx.experimental.symbolic_shapes import guarding_hint_or_throw
 from torch.fx.node import Node
@@ -1163,10 +1163,10 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
             if entry is None and guard_info["cache_status_detailed"] == "guard_miss":
                 counters["aot_autograd"]["autograd_cache_guard_miss"] += 1
             cache_info.update(guard_info)
+            CacheArtifactRecorder(
+                AOTAutogradCacheArtifact.type(), key
+            ).record_if_present(pickled_content)
             if pickled_content is not None:
-                CacheArtifactManager.record_artifact(
-                    AOTAutogradCacheArtifact.type(), key, pickled_content
-                )
                 if (
                     should_bundle_autograd_cache()
                     and aot_config is not None
@@ -1277,9 +1277,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
             content = AOTAutogradCache._pickle_entry(entry, remote)
             if content is None:
                 return None
-            CacheArtifactManager.record_artifact(
-                AOTAutogradCacheArtifact.type(), key, content
-            )
+            CacheArtifactRecorder(AOTAutogradCacheArtifact.type(), key).record(content)
             if (
                 should_bundle_autograd_cache()
                 and entry.sanitized_aot_config.precompile_backend_id is not None

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -57,7 +57,7 @@ from torch._utils_internal import log_cache_bypass
 from torch.compiler._cache import (
     CacheArtifact,
     CacheArtifactFactory,
-    CacheArtifactManager,
+    CacheArtifactRecorder,
 )
 from torch.fx.experimental.symbolic_shapes import guarding_hint_or_throw
 from torch.fx.node import Node
@@ -1164,10 +1164,10 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
             if entry is None and guard_info["cache_status_detailed"] == "guard_miss":
                 counters["aot_autograd"]["autograd_cache_guard_miss"] += 1
             cache_info.update(guard_info)
+            CacheArtifactRecorder(
+                AOTAutogradCacheArtifact.type(), key
+            ).record_if_present(pickled_content)
             if pickled_content is not None:
-                CacheArtifactManager.record_artifact(
-                    AOTAutogradCacheArtifact.type(), key, pickled_content
-                )
                 if (
                     should_bundle_autograd_cache()
                     and aot_config is not None
@@ -1279,9 +1279,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
             content = AOTAutogradCache._pickle_entry(entry, remote)
             if content is None:
                 return None
-            CacheArtifactManager.record_artifact(
-                AOTAutogradCacheArtifact.type(), key, content
-            )
+            CacheArtifactRecorder(AOTAutogradCacheArtifact.type(), key).record(content)
             if (
                 should_bundle_autograd_cache()
                 and entry.sanitized_aot_config.precompile_backend_id is not None

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -109,7 +109,7 @@ from torch.compiler import config as cconfig
 from torch.compiler._cache import (
     CacheArtifact,
     CacheArtifactFactory,
-    CacheArtifactManager,
+    CacheArtifactRecorder,
 )
 from torch.export.pt2_archive._package_weights import TensorProperties, Weights
 from torch.export.pt2_archive.constants import CUSTOM_OBJ_FILENAME_PREFIX
@@ -1573,10 +1573,9 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
                 cache_info["cache_status_detailed"] = "guard_miss"
                 return None, cache_info
 
-        if pickled_content is not None:
-            CacheArtifactManager.record_artifact(
-                InductorCacheArtifact.type(), key, pickled_content
-            )
+        CacheArtifactRecorder(InductorCacheArtifact.type(), key).record_if_present(
+            pickled_content
+        )
 
         # Now re-evaluate with the symints to add any guards to the current env.
         if graph.guards_expr:
@@ -1649,9 +1648,7 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
             return
 
         try:
-            CacheArtifactManager.record_artifact(
-                InductorCacheArtifact.type(), key, content
-            )
+            CacheArtifactRecorder(InductorCacheArtifact.type(), key).record(content)
             if local:
                 FxGraphCache._write_to_local_cache(key, content)
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -110,7 +110,7 @@ from torch.compiler import config as cconfig
 from torch.compiler._cache import (
     CacheArtifact,
     CacheArtifactFactory,
-    CacheArtifactManager,
+    CacheArtifactRecorder,
 )
 from torch.export.pt2_archive._package_weights import TensorProperties, Weights
 from torch.export.pt2_archive.constants import CUSTOM_OBJ_FILENAME_PREFIX
@@ -1745,10 +1745,9 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
                 cache_info["cache_status_detailed"] = "guard_miss"
                 return None, cache_info
 
-        if pickled_content is not None:
-            CacheArtifactManager.record_artifact(
-                InductorCacheArtifact.type(), key, pickled_content
-            )
+        CacheArtifactRecorder(InductorCacheArtifact.type(), key).record_if_present(
+            pickled_content
+        )
 
         # Now re-evaluate with the symints to add any guards to the current env.
         if graph.guards_expr:
@@ -1821,9 +1820,7 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
             return
 
         try:
-            CacheArtifactManager.record_artifact(
-                InductorCacheArtifact.type(), key, content
-            )
+            CacheArtifactRecorder(InductorCacheArtifact.type(), key).record(content)
             if local:
                 FxGraphCache._write_to_local_cache(key, content)
 

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -38,7 +38,7 @@ from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.compiler._cache import (
     CacheArtifact,
     CacheArtifactFactory,
-    CacheArtifactManager,
+    CacheArtifactRecorder,
 )
 from torch.utils._triton import has_triton
 
@@ -117,6 +117,7 @@ class AutotuneCache:
     configs_hash: str
     local_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
     remote_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
+    artifact_recorder: CacheArtifactRecorder | None = None
 
     # Create a AutotuneCache. Returns None if none of the caches can be used.
     @staticmethod
@@ -125,8 +126,15 @@ class AutotuneCache:
     ) -> AutotuneCache | None:
         cache = AutotuneCache(configs_hash)
         key = AutotuneCache._prepare_key(filename)
+        local_cache_key = AutotuneCache._make_local_cache_key(
+            os.path.dirname(filename), key
+        )
+        cache.artifact_recorder = CacheArtifactRecorder(
+            AutotuneCacheArtifact.type(),
+            AutotuneCache._artifact_key_from_local_cache_key(local_cache_key),
+        )
 
-        cache._setup_local_cache(inductor_meta, os.path.dirname(filename), key)
+        cache._setup_local_cache(inductor_meta, local_cache_key)
         cache._setup_remote_autotune_cache(inductor_meta, key)
         if cache.local_cache or cache.remote_cache:
             return cache
@@ -141,18 +149,42 @@ class AutotuneCache:
         key = f"{os.path.basename(filename)}:{cconfig.cache_key_tag}"
         return AUTOTUNE_CACHE_KEY_STRATEGY.key(key)
 
+    @staticmethod
+    def _make_local_cache_key(dirname: str, cache_key: str) -> str:
+        """
+        [Note: torch_key in autotune cache key]
+        Include torch_key() in the cache key so that different versions
+        of torch result in cache invalidation. This is important in case
+        of changes to the best_config format or other code changes that
+        are not backward compatible w.r.t. the cache.
+        """
+        from ..codecache import torch_key
+
+        updated_cache_key = AUTOTUNE_CACHE_KEY_STRATEGY.key(cache_key, torch_key())
+        return f"{dirname}/{updated_cache_key}.best_config"
+
+    @staticmethod
+    def _artifact_key_from_local_cache_key(local_cache_key: str) -> str:
+        return os.path.join(*local_cache_key.split(os.sep)[-2:])
+
+    def _record_artifact(self, data: JsonDataTy) -> None:
+        if recorder := getattr(self, "artifact_recorder", None):
+            recorder.record(data)
+
     # Read the best config options from the most local cache and return it.
     def _read(self) -> dict[str, JsonDataTy] | None:
         if local_cache := self.local_cache:
             cache, key = local_cache
             if best_config := cache.get(key):
                 if isinstance(best_config, dict):
+                    self._record_artifact(best_config)
                     return best_config
 
         if remote_cache := self.remote_cache:
             cache, key = remote_cache
             if best_config := cache.get(key):
                 if isinstance(best_config, dict):
+                    self._record_artifact(best_config)
                     return best_config
 
         return None
@@ -170,25 +202,13 @@ class AutotuneCache:
 
     # Set up local filesystem caching information
     def _setup_local_cache(
-        self, inductor_meta: _InductorMetaTy, dirname: str, cache_key: str
+        self, inductor_meta: _InductorMetaTy, cache_key: str
     ) -> None:
         if not inductor_meta.get("autotune_local_cache", True):
             return
 
-        from ..codecache import torch_key
-
-        """
-        [Note: torch_key in autotune cache key]
-        Include torch_key() in the cache key so that different versions
-        of torch result in cache invalidation. This is important in case
-        of changes to the best_config format or other code changes that
-        are not backward compatible w.r.t. the cache.
-        """
-        updated_cache_key = AUTOTUNE_CACHE_KEY_STRATEGY.key(cache_key, torch_key())
-
-        cache_filename = f"{dirname}/{updated_cache_key}.best_config"
         local_cache = LocalAutotuneCache()
-        self.local_cache = (local_cache, cache_filename)
+        self.local_cache = (local_cache, cache_key)
 
     # Set up remote caching information
     def _setup_remote_autotune_cache(
@@ -298,16 +318,14 @@ class AutotuneCache:
                 }
             )
 
+        self._record_artifact(data)
+
         if local_cache := self.local_cache:
             cache, key = local_cache
             # pyrefly: ignore [bad-argument-type]
             cache.put(key, data)
             # pyrefly: ignore [bad-argument-type]
             AutotuneCacheBundler.put(key, data)
-            autotune_artifact_key = os.path.join(*key.split(os.sep)[-2:])
-            CacheArtifactManager.record_artifact(
-                AutotuneCacheArtifact.type(), autotune_artifact_key, data
-            )
 
             if log.isEnabledFor(logging.DEBUG):
                 type_str = "coordesc" if found_by_coordesc else "heuristic"
@@ -645,10 +663,6 @@ class LocalAutotuneCache(RemoteCache[JsonDataTy]):
             # model would only bundle *newly* compiled kernels, not existing
             # kernels that were already compiled and cached.
             AutotuneCacheBundler.put(key, result)
-            autotune_artifact_key = os.path.join(*key.split(os.sep)[-2:])
-            CacheArtifactManager.record_artifact(
-                AutotuneCacheArtifact.type(), autotune_artifact_key, result
-            )
         return result
 
     @override

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -39,7 +39,7 @@ from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.compiler._cache import (
     CacheArtifact,
     CacheArtifactFactory,
-    CacheArtifactManager,
+    CacheArtifactRecorder,
 )
 from torch.utils._triton import has_triton
 
@@ -117,6 +117,7 @@ class AutotuneCache:
     configs_hash: str
     local_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
     remote_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
+    artifact_recorder: CacheArtifactRecorder | None = None
 
     # Create a AutotuneCache. Returns None if none of the caches can be used.
     @staticmethod
@@ -125,8 +126,15 @@ class AutotuneCache:
     ) -> AutotuneCache | None:
         cache = AutotuneCache(configs_hash)
         key = AutotuneCache._prepare_key(filename)
+        local_cache_key = AutotuneCache._make_local_cache_key(
+            os.path.dirname(filename), key
+        )
+        cache.artifact_recorder = CacheArtifactRecorder(
+            AutotuneCacheArtifact.type(),
+            AutotuneCache._artifact_key_from_local_cache_key(local_cache_key),
+        )
 
-        cache._setup_local_cache(inductor_meta, os.path.dirname(filename), key)
+        cache._setup_local_cache(inductor_meta, local_cache_key)
         cache._setup_remote_autotune_cache(inductor_meta, key)
         if cache.local_cache or cache.remote_cache:
             return cache
@@ -141,18 +149,45 @@ class AutotuneCache:
         key = f"{os.path.basename(filename)}:{cconfig.cache_key_tag}"
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
+    @staticmethod
+    def _make_local_cache_key(dirname: str, cache_key: str) -> str:
+        """
+        [Note: torch_key in autotune cache key]
+        Include torch_key() in the cache key so that different versions
+        of torch result in cache invalidation. This is important in case
+        of changes to the best_config format or other code changes that
+        are not backward compatible w.r.t. the cache.
+        """
+        from ..codecache import torch_key
+
+        hasher = hashlib.sha256()
+        hasher.update(cache_key.encode("utf-8"))
+        hasher.update(torch_key())
+        updated_cache_key = hasher.hexdigest()
+        return f"{dirname}/{updated_cache_key}.best_config"
+
+    @staticmethod
+    def _artifact_key_from_local_cache_key(local_cache_key: str) -> str:
+        return os.path.join(*local_cache_key.split(os.sep)[-2:])
+
+    def _record_artifact(self, data: JsonDataTy) -> None:
+        if recorder := getattr(self, "artifact_recorder", None):
+            recorder.record(data)
+
     # Read the best config options from the most local cache and return it.
     def _read(self) -> dict[str, JsonDataTy] | None:
         if local_cache := self.local_cache:
             cache, key = local_cache
             if best_config := cache.get(key):
                 if isinstance(best_config, dict):
+                    self._record_artifact(best_config)
                     return best_config
 
         if remote_cache := self.remote_cache:
             cache, key = remote_cache
             if best_config := cache.get(key):
                 if isinstance(best_config, dict):
+                    self._record_artifact(best_config)
                     return best_config
 
         return None
@@ -170,28 +205,13 @@ class AutotuneCache:
 
     # Set up local filesystem caching information
     def _setup_local_cache(
-        self, inductor_meta: _InductorMetaTy, dirname: str, cache_key: str
+        self, inductor_meta: _InductorMetaTy, cache_key: str
     ) -> None:
         if not inductor_meta.get("autotune_local_cache", True):
             return
 
-        from ..codecache import torch_key
-
-        """
-        [Note: torch_key in autotune cache key]
-        Include torch_key() in the cache key so that different versions
-        of torch result in cache invalidation. This is important in case
-        of changes to the best_config format or other code changes that
-        are not backward compatible w.r.t. the cache.
-        """
-        hasher = hashlib.sha256()
-        hasher.update(cache_key.encode("utf-8"))
-        hasher.update(torch_key())
-        updated_cache_key = hasher.hexdigest()
-
-        cache_filename = f"{dirname}/{updated_cache_key}.best_config"
         local_cache = LocalAutotuneCache()
-        self.local_cache = (local_cache, cache_filename)
+        self.local_cache = (local_cache, cache_key)
 
     # Set up remote caching information
     def _setup_remote_autotune_cache(
@@ -300,16 +320,14 @@ class AutotuneCache:
                 }
             )
 
+        self._record_artifact(data)
+
         if local_cache := self.local_cache:
             cache, key = local_cache
             # pyrefly: ignore [bad-argument-type]
             cache.put(key, data)
             # pyrefly: ignore [bad-argument-type]
             AutotuneCacheBundler.put(key, data)
-            autotune_artifact_key = os.path.join(*key.split(os.sep)[-2:])
-            CacheArtifactManager.record_artifact(
-                AutotuneCacheArtifact.type(), autotune_artifact_key, data
-            )
 
             if log.isEnabledFor(logging.DEBUG):
                 type_str = "coordesc" if found_by_coordesc else "heuristic"
@@ -648,10 +666,6 @@ class LocalAutotuneCache(RemoteCache[JsonDataTy]):
             # model would only bundle *newly* compiled kernels, not existing
             # kernels that were already compiled and cached.
             AutotuneCacheBundler.put(key, result)
-            autotune_artifact_key = os.path.join(*key.split(os.sep)[-2:])
-            CacheArtifactManager.record_artifact(
-                AutotuneCacheArtifact.type(), autotune_artifact_key, result
-            )
         return result
 
     @override

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -114,6 +114,10 @@ class AutotuneCacheArtifact(CacheArtifact):
 
 @dataclasses.dataclass
 class AutotuneCache:
+    """
+    Coordinates local and remote autotune cache access for a single kernel.
+    """
+
     configs_hash: str
     local_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
     remote_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
@@ -161,13 +165,14 @@ class AutotuneCache:
         from ..codecache import torch_key
 
         updated_cache_key = AUTOTUNE_CACHE_KEY_STRATEGY.key(cache_key, torch_key())
-        return f"{dirname}/{updated_cache_key}.best_config"
+        return os.path.join(dirname, f"{updated_cache_key}.best_config")
 
     @staticmethod
     def _artifact_key_from_local_cache_key(local_cache_key: str) -> str:
         return os.path.join(*local_cache_key.split(os.sep)[-2:])
 
     def _record_artifact(self, data: JsonDataTy) -> None:
+        # Older pickled AutotuneCache instances may not have this field.
         if recorder := getattr(self, "artifact_recorder", None):
             recorder.record(data)
 
@@ -292,7 +297,7 @@ class AutotuneCache:
         found_by_coordesc: bool = False,
         triton_cache_hash: str | None = None,
     ) -> None:
-        data = {
+        data: dict[str, JsonDataTy] = {
             # pyrefly: ignore [missing-attribute]
             **config.kwargs,
             # pyrefly: ignore [missing-attribute]

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -114,6 +114,10 @@ class AutotuneCacheArtifact(CacheArtifact):
 
 @dataclasses.dataclass
 class AutotuneCache:
+    """
+    Coordinates local and remote autotune cache access for a single kernel.
+    """
+
     configs_hash: str
     local_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
     remote_cache: tuple[RemoteCache[JsonDataTy], str] | None = None
@@ -164,13 +168,14 @@ class AutotuneCache:
         hasher.update(cache_key.encode("utf-8"))
         hasher.update(torch_key())
         updated_cache_key = hasher.hexdigest()
-        return f"{dirname}/{updated_cache_key}.best_config"
+        return os.path.join(dirname, f"{updated_cache_key}.best_config")
 
     @staticmethod
     def _artifact_key_from_local_cache_key(local_cache_key: str) -> str:
         return os.path.join(*local_cache_key.split(os.sep)[-2:])
 
     def _record_artifact(self, data: JsonDataTy) -> None:
+        # Older pickled AutotuneCache instances may not have this field.
         if recorder := getattr(self, "artifact_recorder", None):
             recorder.record(data)
 
@@ -294,7 +299,7 @@ class AutotuneCache:
         found_by_coordesc: bool = False,
         triton_cache_hash: str | None = None,
     ) -> None:
-        data = {
+        data: dict[str, JsonDataTy] = {
             # pyrefly: ignore [missing-attribute]
             **config.kwargs,
             # pyrefly: ignore [missing-attribute]

--- a/torch/compiler/_cache.py
+++ b/torch/compiler/_cache.py
@@ -171,6 +171,23 @@ def _deserialize_single_cache(
 CacheArtifactsResult = dict[str, list[CacheArtifact]]
 
 
+@dataclasses.dataclass(frozen=True)
+class CacheArtifactRecorder:
+    """
+    Shared entry point for cache implementations to record artifacts.
+    """
+
+    artifact_type: str
+    key: str
+
+    def record(self, content: Any) -> None:
+        CacheArtifactManager.record_artifact(self.artifact_type, self.key, content)
+
+    def record_if_present(self, content: Any | None) -> None:
+        if content is not None:
+            self.record(content)
+
+
 class CacheArtifactManager:
     """
     Lightweight manager class for collecting and processing cache artifacts for
@@ -178,7 +195,7 @@ class CacheArtifactManager:
 
     Intended Lifecycle:
     - Execute code via torch.compile, this will call
-        CacheArtifactManager.record_artifact on each cache artifact
+        CacheArtifactRecorder.record on each cache artifact
     - Call CacheArtifactManager.serialize to convert all the cache artifacts
         to portable format
     - Call CacheArtifactManager.deserialize to hot load the cache artifacts on


### PR DESCRIPTION
## Summary
- Add CacheArtifactRecorder as the common artifact recording entry point.
- Route existing cache artifact recording call sites through the recorder.
- Move autotune artifact recording into AutotuneCache so local and remote read/write paths share one policy.
- Add a regression for remote-only autotune artifact recording on save and read.

## Root cause problem
Artifact recording was spread across individual cache read/write paths. Autotune recorded artifacts in the local-cache save and local-cache hit paths, but remote-only autotune cache entries did not record artifacts because the policy lived inside the local cache implementation.

## Proposed fix
Introduce CacheArtifactRecorder and use it from cache implementations. Autotune now constructs one recorder from the local artifact key, records through AutotuneCache on successful read/write data, and leaves LocalAutotuneCache focused on local cache I/O and bundling.

## Why this is the right long term fix
The artifact recording decision is now explicit and shared at the cache level instead of being duplicated in backend-specific paths. New cache backends can reuse the same recorder without adding another bespoke CacheArtifactManager.record_artifact call or accidentally changing the local-vs-remote policy.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98