### PR TITLE
Refactor AOT compile entrypoints

### DIFF
--- a/test/inductor/test_aot_compile_entrypoints.py
+++ b/test/inductor/test_aot_compile_entrypoints.py
@@ -1,0 +1,117 @@
+# Owner(s): ["module: inductor"]
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import torch
+import torch._inductor
+from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_utils import run_tests
+
+
+class TestAOTCompileEntrypoints(TestCase):
+    def test_aot_compile_dispatches_to_compile_aot_core(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return (x + 1,)
+
+        args = (torch.ones(2),)
+        gm = torch.export.export(Model(), args, strict=True).module()
+        options = {"aot_inductor.package": True}
+        sentinel = object()
+        calls = []
+
+        def fake_compile_aot_core(gm_arg, args_arg, kwargs_arg, *, options=None):
+            calls.append((gm_arg, args_arg, kwargs_arg, options))
+            return sentinel
+
+        with patch(
+            "torch._inductor._compile_aot_core",
+            side_effect=fake_compile_aot_core,
+        ):
+            result = torch._inductor.aot_compile(gm, args, options=options)
+
+        self.assertIs(result, sentinel)
+        self.assertEqual(len(calls), 1)
+        gm_arg, args_arg, kwargs_arg, options_arg = calls[0]
+        self.assertIs(gm_arg, gm)
+        self.assertIs(args_arg, args)
+        self.assertIsNone(kwargs_arg)
+        self.assertIs(options_arg, options)
+
+    def test_aoti_compile_and_package_dispatches_to_compile_aot_core(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return (x + 1,)
+
+        args = (torch.ones(2),)
+        exported_program = torch.export.export(Model(), args, strict=True)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            package_path = os.path.join(temp_dir, "model.pt2")
+            so_path = os.path.join(temp_dir, "model.so")
+            options = {"max_autotune": False}
+            compile_aot_core_calls = []
+            package_aoti_calls = []
+
+            def fake_compile_aot_core(gm, args, kwargs, *, options=None):
+                compile_aot_core_calls.append((gm, args, kwargs, options))
+                return [so_path]
+
+            def fake_minifier_wrapper(
+                func,
+                exported_program,
+                *,
+                inductor_configs,
+                package_path=None,
+            ):
+                gm = exported_program.module(check_guards=False)
+                args, kwargs = exported_program.example_inputs
+                return func(
+                    gm,
+                    args,
+                    kwargs,
+                    inductor_configs=inductor_configs,
+                    package_path=package_path,
+                )
+
+            def fake_package_aoti(path, files):
+                package_aoti_calls.append((path, files))
+                return path
+
+            with (
+                patch(
+                    "torch._inductor._compile_aot_core",
+                    side_effect=fake_compile_aot_core,
+                ),
+                patch(
+                    "torch._inductor.aot_compile",
+                    side_effect=AssertionError(
+                        "package entry point called aot_compile"
+                    ),
+                ),
+                patch(
+                    "torch._inductor.debug.aot_inductor_minifier_wrapper",
+                    side_effect=fake_minifier_wrapper,
+                ),
+                patch(
+                    "torch._inductor.package.package_aoti",
+                    side_effect=fake_package_aoti,
+                ),
+            ):
+                result = torch._inductor.aoti_compile_and_package(
+                    exported_program,
+                    package_path=package_path,
+                    inductor_configs=options,
+                )
+
+        self.assertEqual(result, package_path)
+        self.assertEqual(len(compile_aot_core_calls), 1)
+        self.assertEqual(package_aoti_calls, [(package_path, [so_path])])
+        self.assertIs(compile_aot_core_calls[0][3], options)
+        self.assertTrue(options["aot_inductor.package"])
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_aot_compile_entrypoints.py
+++ b/test/inductor/test_aot_compile_entrypoints.py
@@ -52,6 +52,8 @@ class TestAOTCompileEntrypoints(TestCase):
             package_path = os.path.join(temp_dir, "model.pt2")
             so_path = os.path.join(temp_dir, "model.so")
             options = {"max_autotune": False}
+            expected_exported_program = exported_program
+            expected_package_path = package_path
             compile_aot_core_calls = []
             package_aoti_calls = []
 
@@ -66,6 +68,9 @@ class TestAOTCompileEntrypoints(TestCase):
                 inductor_configs,
                 package_path=None,
             ):
+                self.assertIs(exported_program, expected_exported_program)
+                self.assertIs(inductor_configs, options)
+                self.assertEqual(package_path, expected_package_path)
                 gm = exported_program.module(check_guards=False)
                 args, kwargs = exported_program.example_inputs
                 return func(
@@ -87,6 +92,8 @@ class TestAOTCompileEntrypoints(TestCase):
                 ),
                 patch(
                     "torch._inductor.aot_compile",
+                    # Tripwire: the package entry point should use the shared
+                    # core directly instead of recursing through aot_compile().
                     side_effect=AssertionError(
                         "package entry point called aot_compile"
                     ),

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -159,8 +159,7 @@ def aoti_compile_and_package(
 
 def _aoti_compile_and_package_inner(
     gm: torch.nn.Module,
-    # flat_example_inputs: List[Any],
-    args: tuple[Any],
+    args: tuple[Any, ...],
     kwargs: dict[str, Any] | None = None,
     *,
     load_and_run: bool = False,
@@ -192,7 +191,12 @@ def _aoti_compile_and_package_inner(
 
     kwargs = kwargs or {}
 
-    aoti_files = aot_compile(gm, args, kwargs, options=inductor_configs)
+    aoti_files = _compile_aot_core(
+        gm,
+        args,
+        kwargs,
+        options=inductor_configs,
+    )
     assert isinstance(aoti_files, list)
 
     if package_path is None:
@@ -235,6 +239,38 @@ def _aoti_compile_and_package_inner(
             compiled_model(*args, **kwargs)
 
     return package_path
+
+
+def _compile_aot_core(
+    gm: torch.fx.GraphModule,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any] | None = None,
+    *,
+    options: dict[str, Any] | None = None,
+) -> str | list[str | Weights] | torch.fx.GraphModule:
+    """Shared AOTInductor compile path for compile-only and package entry points."""
+    from .compile_fx import _aoti_flatten_inputs, compile_fx_aot
+
+    if hasattr(gm, "_guards_fn"):
+        # Do not compile the guards function, since it may contain checks
+        # that are not currently supported by AOTI. In particular, non-Tensor
+        # arguments are converted to None and will fail specialization checks.
+        node = next(iter(gm.graph.find_nodes(op="call_module", target="_guards_fn")))
+        gm.graph.erase_node(node)
+        delattr(gm, "_guards_fn")
+        gm.recompile()
+
+    flat_example_inputs, options = _aoti_flatten_inputs(
+        gm, args, kwargs, options=options
+    )
+    from torch._export.utils import _compiling_state_context
+
+    with _compiling_state_context():
+        return compile_fx_aot(
+            gm,
+            flat_example_inputs,  # type: ignore[arg-type]
+            config_patches=options,
+        )
 
 
 def aoti_load_package(
@@ -291,28 +327,7 @@ def aot_compile(
         AOTI if aot_inductor.package=True.
         TODO: make it return a list by default
     """
-    from .compile_fx import _aoti_flatten_inputs, compile_fx_aot
-
-    if hasattr(gm, "_guards_fn"):
-        # Do not compile the guards function, since it may contain checks
-        # that are not currently supported by AOTI. In particular, non-Tensor
-        # arguments are converted to None and will fail specialization checks.
-        node = next(iter(gm.graph.find_nodes(op="call_module", target="_guards_fn")))
-        gm.graph.erase_node(node)
-        delattr(gm, "_guards_fn")
-        gm.recompile()
-
-    flat_example_inputs, options = _aoti_flatten_inputs(
-        gm, args, kwargs, options=options
-    )
-    from torch._export.utils import _compiling_state_context
-
-    with _compiling_state_context():
-        return compile_fx_aot(
-            gm,
-            flat_example_inputs,  # type: ignore[arg-type]
-            config_patches=options,
-        )
+    return _compile_aot_core(gm, args, kwargs, options=options)
 
 
 lite_mode_options = {


### PR DESCRIPTION
## Summary
- Extract shared AOTInductor compile setup into `_compile_aot_core()`.
- Route `aot_compile()` and `_aoti_compile_and_package_inner()` through the shared core instead of having the package path call public `aot_compile()`.
- Add focused entry-point regression coverage with compiler/package work patched out.

## Root Cause Problem
`aoti_compile_and_package()` reached the common AOT compile logic indirectly through `_aoti_compile_and_package_inner()` calling public `aot_compile()`. That made the package entry point and compile-only entry point share behavior through a deeper call chain where each layer handled a small part of config and compile setup.

## Proposed Fix
Move guard stripping, input flattening, compiling-state setup, and `compile_fx_aot()` invocation into `_compile_aot_core()`. Keep `aot_compile()` as the compile-only wrapper and keep `_aoti_compile_and_package_inner()` as the compile-and-package wrapper used by the minifier.

## Why This Is The Right Long Term Fix
The public entry points now share the same internal compile primitive directly, so future AOT compile setup changes have one implementation point while package-specific behavior remains isolated in the package wrapper.

## Tests
- `python3 -m py_compile torch/_inductor/__init__.py test/inductor/test_aot_compile_entrypoints.py`
- `git diff --check`
- Stub-harness execution of `test/inductor/test_aot_compile_entrypoints.py` passed after the refactor and failed before the refactor with missing `_compile_aot_core`, as expected.
- `PYTHONPATH=. python3 test/inductor/test_aot_compile_entrypoints.py` is blocked in this checkout because Python cannot import the source tree without `typing_extensions` installed.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo