### PR TITLE
Consolidate AOT mode state in Inductor

### DIFF
--- a/test/inductor/test_aot_mode.py
+++ b/test/inductor/test_aot_mode.py
@@ -4,10 +4,7 @@ from unittest import mock
 
 import torch
 from torch._inductor import config
-from torch._inductor.compile_fx import (
-    _compile_fx_inner,
-    get_cpp_wrapper_config,
-)
+from torch._inductor.compile_fx import _compile_fx_inner, get_cpp_wrapper_config
 from torch._inductor.test_case import TestCase as InductorTestCase
 
 

--- a/test/inductor/test_aot_mode.py
+++ b/test/inductor/test_aot_mode.py
@@ -1,0 +1,78 @@
+# Owner(s): ["module: inductor"]
+
+from unittest import mock
+
+import torch
+from torch._inductor import config
+from torch._inductor.compile_fx import (
+    _compile_fx_inner,
+    get_cpp_wrapper_config,
+)
+from torch._inductor.test_case import TestCase as InductorTestCase
+
+
+class DummyOutput:
+    def post_compile(self, example_inputs, constants, graph_kwargs) -> None:
+        self.graph_kwargs = graph_kwargs
+
+
+class AotModeTest(InductorTestCase):
+    def test_compile_fx_inner_uses_explicit_aot_mode(self):
+        def fn(x):
+            return (x,)
+
+        gm = torch.fx.symbolic_trace(fn)
+        gm.shape_env = None
+        example_inputs = (torch.randn(2),)
+        dummy_output = DummyOutput()
+        seen_kwargs = None
+
+        def fake_codegen_and_compile(*args, **kwargs):
+            nonlocal seen_kwargs
+            seen_kwargs = kwargs
+            return dummy_output
+
+        with (
+            config.patch(
+                {
+                    "force_disable_caches": False,
+                    "fx_graph_cache": False,
+                    "fx_graph_remote_cache": False,
+                }
+            ),
+            mock.patch(
+                "torch._inductor.compile_fx.fx_codegen_and_compile",
+                side_effect=fake_codegen_and_compile,
+            ),
+        ):
+            result = _compile_fx_inner(gm, example_inputs, aot_mode=True)
+
+        self.assertIs(result, dummy_output)
+        self.assertIsNotNone(seen_kwargs)
+        self.assertTrue(seen_kwargs["aot_mode"])
+        self.assertTrue(dummy_output.graph_kwargs["aot_mode"])
+
+    def test_cpp_wrapper_config_uses_explicit_aot_mode(self):
+        with (
+            config.patch(
+                {
+                    "graph_partition": False,
+                    "triton.autotune_at_compile_time": None,
+                    "triton.cudagraphs": True,
+                }
+            ),
+            mock.patch("torch._inductor.compile_fx.has_triton", return_value=True),
+        ):
+            aot_config = get_cpp_wrapper_config(aot_mode=True)
+            jit_config = get_cpp_wrapper_config(aot_mode=False)
+
+        self.assertTrue(aot_config["triton.autotune_at_compile_time"])
+        self.assertFalse(aot_config["triton.cudagraphs"])
+        self.assertFalse(jit_config["triton.autotune_at_compile_time"])
+        self.assertTrue(jit_config["triton.cudagraphs"])
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests()

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2514,7 +2514,7 @@ class _TorchCompileAOTInductorWrapper(_TorchCompileInductorWrapper):
         from unittest import mock
 
         from torch._guards import detect_fake_mode
-        from torch._inductor.virtualized import V
+        from torch._inductor.compile_fx import compile_fx
 
         fake_mode = detect_fake_mode(inputs_)
         ctx = (
@@ -2522,12 +2522,15 @@ class _TorchCompileAOTInductorWrapper(_TorchCompileInductorWrapper):
             if fake_mode
             else nullcontext()
         )
-        with (
-            V.set_aot_compilation(True),
-            ctx,
-            torch._inductor.config.patch("enable_autograd_for_aot", True),
-        ):
-            return super().__call__(model_, inputs_, config_patches=config_patches)
+        all_patches = {**self.config, **(config_patches or {})}
+        with ctx, torch._inductor.config.patch("enable_autograd_for_aot", True):
+            return compile_fx(
+                model_,
+                inputs_,
+                config_patches=all_patches,
+                compile_region_name=self.name,
+                aot_mode=True,
+            )
 
 
 class _TorchCompileWrapper:

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -186,7 +186,7 @@ class WrapperFxCodegen(PythonWrapperCodegen):
         Get the input nodes corresponding to FX graph placeholders.
         """
 
-        if V.aot_compilation and not self.is_subgraph:
+        if V.graph.aot_mode and not self.is_subgraph:
             # AOT graphs must match the signature of the input module.
             return {
                 node.name: V.graph.graph_inputs.get(node.name)

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -813,7 +813,12 @@ def compile_fx_inner(
         # Suppress cudagraph skip logging here; compile_fx already logged it.
         if kwargs["cpp_wrapper"]:
             stack.enter_context(
-                config.patch(get_cpp_wrapper_config(log_cudagraph_skip=False))
+                config.patch(
+                    get_cpp_wrapper_config(
+                        log_cudagraph_skip=False,
+                        aot_mode=kwargs.get("aot_mode", False),
+                    )
+                )
             )
         stack.enter_context(torch.utils._python_dispatch._disable_current_modes())
         stack.enter_context(_use_lazy_graph_module(dynamo_config.use_lazy_graph_module))
@@ -854,7 +859,7 @@ def _compile_fx_inner(
     If you change the argument list for this function, make sure you
     also update the call to save_args_for_compile_fx_inner below accordingly.
     """
-    aot_mode: bool = V.aot_compilation
+    aot_mode: bool = graph_kwargs.get("aot_mode", False)
 
     from torch._inductor.autotune_process import use_pipelined_autotuning
 
@@ -1268,7 +1273,7 @@ class _InProcessFxCompile(FxCompile):
         graph_id: int | None = graph_kwargs.get("graph_id", None)
         cpp_wrapper: bool = graph_kwargs.get("cpp_wrapper", False)
         fx_wrapper: bool = graph_kwargs.get("fx_wrapper", False)
-        aot_mode: bool = V.aot_compilation
+        aot_mode: bool = graph_kwargs.get("aot_mode", False)
         is_inference: bool = graph_kwargs.get("is_inference", False)
         extern_node_serializer: Callable[[list[ExternKernelNode]], Any] | None = (
             graph_kwargs.get("extern_node_serializer", None)
@@ -1715,7 +1720,7 @@ class _InProcessFxCompile(FxCompile):
                             V.graph.disable_cudagraphs_reason = disable
 
                     # pyrefly: ignore [unbound-name]
-                    if V.aot_compilation:
+                    if graph.aot_mode:
                         assert isinstance(
                             compiled_fn,
                             # pyrefly: ignore [unbound-name]
@@ -1725,7 +1730,7 @@ class _InProcessFxCompile(FxCompile):
                             filename=compiled_fn, device_type=graph.device_type
                         )
 
-                    # TODO: Hoist this above V.aot_compilation
+                    # TODO: Hoist this above the AOT mode return.
                     # pyrefly: ignore [unbound-name]
                     if cudagraphs and not V.graph.disable_cudagraphs_reason:
                         from torch._inductor.cudagraph_utils import (
@@ -2083,7 +2088,6 @@ def compile_fx_aot(
     saved_compile_id = model_.meta.get("dynamo_compile_id", None)
     saved_compile_context = torch._guards.CompileContext(saved_compile_id)
     with (
-        V.set_aot_compilation(True),
         torch._guards.compile_context(saved_compile_context),
         chromium_event_timed(
             "compile_fx_aot",
@@ -2100,6 +2104,7 @@ def compile_fx_aot(
                 extern_node_serializer=extern_node_serializer,
             ),
             config_patches=config_patches,
+            aot_mode=True,
         )
 
         assert isinstance(compiled_artifacts, CompiledAOTI)
@@ -2120,6 +2125,7 @@ def fw_compiler_freezing(
     cudagraphs: BoxedBool,
     graph_id: int,
     forward_device: BoxedDeviceIndex,
+    aot_mode: bool,
 ) -> Callable[[list[object]], Sequence[torch.Tensor]]:
     from torch._inductor.freezing import convert_conv_weights_to_channels_last, freeze
 
@@ -2140,6 +2146,7 @@ def fw_compiler_freezing(
         dynamo_model,
         aot_autograd_model,
         aot_example_inputs,  # type: ignore[arg-type]
+        aot_mode=aot_mode,
     )
 
     aot_example_inputs = [aot_example_inputs[ind] for ind in preserved_arg_indices]
@@ -2188,6 +2195,7 @@ def fw_compiler_freezing(
             static_input_idxs = tracing_context.fw_metadata.static_input_indices
 
     with mock.patch.object(fake_mode, "allow_non_fake_inputs", True):
+        aot_mode_kwargs = {"aot_mode": True} if aot_mode else {}
         optimized_function = inner_compile(
             opt_model,
             aot_example_inputs,
@@ -2197,11 +2205,12 @@ def fw_compiler_freezing(
             is_inference=True,
             boxed_forward_device_index=forward_device,
             layout_opt=layout_opt,
+            **aot_mode_kwargs,
         )
 
     # aot_inductor codegens a call that takes in just the inputs, so we don't return a wrapper
     # that drops constant-ified params
-    if V.aot_compilation:
+    if aot_mode:
         return optimized_function
 
     def wrapper(args: list[object]) -> Sequence[torch.Tensor]:
@@ -2217,7 +2226,9 @@ def fw_compiler_freezing(
     return wrapper
 
 
-def get_cpp_wrapper_config(log_cudagraph_skip: bool = True) -> dict[str, object]:
+def get_cpp_wrapper_config(
+    log_cudagraph_skip: bool = True, *, aot_mode: bool = False
+) -> dict[str, object]:
     if log_cudagraph_skip and config.triton.cudagraphs and config.graph_partition:
         log_cudagraph_skip_and_bump_counter(
             format_default_skip_message(
@@ -2229,14 +2240,14 @@ def get_cpp_wrapper_config(log_cudagraph_skip: bool = True) -> dict[str, object]
         config.triton.autotune_at_compile_time
         if config.triton.autotune_at_compile_time is not None
         # Default to True for AOTI. Subject to change in future.
-        else has_triton() and V.aot_compilation
+        else has_triton() and aot_mode
     )
     return {
         "triton.autotune_at_compile_time": autotune_at_compile_time,
         "triton.autotune_cublasLt": not autotune_at_compile_time,
         "triton.cudagraphs": (
             config.triton.cudagraphs
-            and not V.aot_compilation
+            and not aot_mode
             and not config.graph_partition
         ),
         "triton.store_cubin": True,
@@ -2332,11 +2343,13 @@ class CompilerConfigExtra:
     graph_id: int
     forward_device: BoxedDeviceIndex
     forward_is_partitioned: BoxedBool
+    aot_mode: bool
     cudagraphs_bwd_override: bool | None = None
 
 
 def create_compiler_config_extra(
     gm: GraphModule | GmWrapper,
+    aot_mode: bool = False,
 ) -> CompilerConfigExtra:
     gm_meta = gm.meta if isinstance(gm, GraphModule) else None
 
@@ -2392,6 +2405,7 @@ def create_compiler_config_extra(
         cudagraphs=cudagraphs,
         graph_id=graph_id,
         forward_device=forward_device,
+        aot_mode=aot_mode,
         cudagraphs_bwd_override=cudagraphs_bwd_override,
         forward_is_partitioned=forward_is_partitioned,
     )
@@ -2510,6 +2524,9 @@ def compile_fx_forward(
     _recursive_record_user_visible_output_idxs(gm)
 
     with cudagraph_annotation_context(compiler_config_extra.cudagraphs):
+        aot_mode_kwargs = (
+            {"aot_mode": True} if compiler_config_extra.aot_mode else {}
+        )
         result = inner_compile(
             gm,
             example_inputs,
@@ -2518,6 +2535,7 @@ def compile_fx_forward(
             graph_id=compiler_config_extra.graph_id,
             is_inference=is_inference,
             boxed_forward_device_index=compiler_config_extra.forward_device,
+            **aot_mode_kwargs,
         )
 
         if (
@@ -2576,12 +2594,17 @@ def compile_fx_backward(
             static_input_idxs = list(range(fixed))
         with (
             (
-                config.patch(get_cpp_wrapper_config())
+                config.patch(
+                    get_cpp_wrapper_config(aot_mode=compiler_config_extra.aot_mode)
+                )
                 if config.cpp_wrapper
                 else contextlib.nullcontext()
             ),
             cudagraph_annotation_context(cudagraphs),
         ):
+            aot_mode_kwargs = (
+                {"aot_mode": True} if compiler_config_extra.aot_mode else {}
+            )
             return inner_compile(
                 gm,
                 example_inputs,
@@ -2590,6 +2613,7 @@ def compile_fx_backward(
                 is_backward=True,
                 graph_id=compiler_config_extra.graph_id,
                 boxed_forward_device_index=compiler_config_extra.forward_device,
+                **aot_mode_kwargs,
             )
 
 
@@ -2651,6 +2675,7 @@ def compile_fx(
     decompositions: dict[OpOverload, Callable[..., Any]] | None = None,
     ignore_shape_env: bool = False,
     compile_region_name: str | None = None,
+    aot_mode: bool = False,
 ) -> CompileFxOutput:
     """
     Main entry point for compiling given FX graph.  Despite the fact that this
@@ -2689,6 +2714,7 @@ def compile_fx(
                 decompositions=decompositions,
                 ignore_shape_env=ignore_shape_env,
                 compile_region_name=compile_region_name,
+                aot_mode=aot_mode,
             )
 
     # Keep region names out of graph_kwargs so they don't perturb FX cache keys.
@@ -2711,7 +2737,7 @@ def compile_fx(
         fx_wrapper_config = config.fx_wrapper
 
         with (
-            config.patch(get_cpp_wrapper_config()),
+            config.patch(get_cpp_wrapper_config(aot_mode=aot_mode)),
             V.set_real_inputs(example_inputs_),
         ):
             inputs_: Sequence[InputType] = (
@@ -2736,6 +2762,7 @@ def compile_fx(
                         fx_wrapper=fx_wrapper_config,
                     ),
                     ignore_shape_env=ignore_shape_env,
+                    aot_mode=aot_mode,
                     get_decomp_fn=get_decomp_fn,
                     compile_region_name=compile_region_name,
                 )
@@ -2745,6 +2772,7 @@ def compile_fx(
         example_inputs_,
         inner_compile,
         ignore_shape_env,
+        aot_mode=aot_mode,
         get_decomp_fn=get_decomp_fn,
         compile_region_name=compile_region_name,
     )
@@ -2787,6 +2815,7 @@ def _maybe_wrap_and_compile_fx_main(
     inner_compile: Callable[..., OutputCode],
     ignore_shape_env: bool,
     *,
+    aot_mode: bool = False,
     get_decomp_fn: Callable[..., dict[Any, Callable[..., Any]]] = select_decomp_table,
     compile_region_name: str | None = None,
 ) -> CompileFxOutput:
@@ -2803,6 +2832,7 @@ def _maybe_wrap_and_compile_fx_main(
         _maybe_wrap_and_compile_fx_main,
         inner_compile=inner_compile,
         ignore_shape_env=ignore_shape_env,
+        aot_mode=aot_mode,
         get_decomp_fn=get_decomp_fn,
         compile_region_name=compile_region_name,
     )
@@ -2826,6 +2856,7 @@ def _maybe_wrap_and_compile_fx_main(
         example_inputs_,
         inner_compile,
         ignore_shape_env,
+        aot_mode=aot_mode,
         get_decomp_fn=get_decomp_fn,
         compile_region_name=compile_region_name,
     )
@@ -2837,6 +2868,7 @@ def _compile_fx_main(
     inner_compile: Callable[..., OutputCode],
     ignore_shape_env: bool,
     *,
+    aot_mode: bool = False,
     get_decomp_fn: Callable[..., dict[Any, Callable[..., Any]]] = select_decomp_table,
     compile_region_name: str | None = None,
 ) -> CompileFxOutput:
@@ -2867,7 +2899,7 @@ def _compile_fx_main(
 
         num_example_inputs = len(example_inputs_)
 
-        compiler_config_extra = create_compiler_config_extra(model_)
+        compiler_config_extra = create_compiler_config_extra(model_, aot_mode=aot_mode)
 
         decompositions = get_decomp_fn()
         inner_compile = functools.partial(inner_compile, get_decomp_fn=get_decomp_fn)
@@ -2906,6 +2938,7 @@ def _compile_fx_main(
                 cudagraphs=compiler_config_extra.cudagraphs,
                 graph_id=compiler_config_extra.graph_id,
                 forward_device=compiler_config_extra.forward_device,
+                aot_mode=aot_mode,
             )
         else:
             inference_compiler = functools.partial(fw_compiler_base, is_inference=True)
@@ -2937,7 +2970,7 @@ def _compile_fx_main(
             or torch._guards.TracingContext(fake_mode)
         )
 
-        if V.aot_compilation and not config.enable_autograd_for_aot:
+        if aot_mode and not config.enable_autograd_for_aot:
             from .utils import is_valid_aoti_model_name
 
             is_valid_aoti_model_name()

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -784,6 +784,12 @@ class _CompileFxCallable(Protocol):
     ) -> OutputCode: ...
 
 
+def _maybe_aot_mode_kwargs(aot_mode: bool) -> _CompileFxKwargs:
+    # Keep the default False value out of graph_kwargs so non-AOT cache keys
+    # match the pre-existing representation.
+    return {"aot_mode": True} if aot_mode else {}
+
+
 def compile_fx_inner(
     gm: GraphModule,
     example_inputs: Sequence[InputType],
@@ -1208,8 +1214,8 @@ def _compile_fx_inner(
     _step_logger()(
         logging.INFO,
         "torchinductor done compiling "
-        f"{'BACKWARDS' if graph_kwargs['is_backward'] else 'FORWARDS'} "
-        f"graph {graph_kwargs['graph_id']}",
+        f"{'BACKWARDS' if graph_kwargs.get('is_backward', False) else 'FORWARDS'} "
+        f"graph {graph_kwargs.get('graph_id')}",
     )
     return compiled_graph
 
@@ -2195,7 +2201,6 @@ def fw_compiler_freezing(
             static_input_idxs = tracing_context.fw_metadata.static_input_indices
 
     with mock.patch.object(fake_mode, "allow_non_fake_inputs", True):
-        aot_mode_kwargs = {"aot_mode": True} if aot_mode else {}
         optimized_function = inner_compile(
             opt_model,
             aot_example_inputs,
@@ -2205,7 +2210,7 @@ def fw_compiler_freezing(
             is_inference=True,
             boxed_forward_device_index=forward_device,
             layout_opt=layout_opt,
-            **aot_mode_kwargs,
+            **_maybe_aot_mode_kwargs(aot_mode),
         )
 
     # aot_inductor codegens a call that takes in just the inputs, so we don't return a wrapper
@@ -2246,9 +2251,7 @@ def get_cpp_wrapper_config(
         "triton.autotune_at_compile_time": autotune_at_compile_time,
         "triton.autotune_cublasLt": not autotune_at_compile_time,
         "triton.cudagraphs": (
-            config.triton.cudagraphs
-            and not aot_mode
-            and not config.graph_partition
+            config.triton.cudagraphs and not aot_mode and not config.graph_partition
         ),
         "triton.store_cubin": True,
     }
@@ -2524,9 +2527,6 @@ def compile_fx_forward(
     _recursive_record_user_visible_output_idxs(gm)
 
     with cudagraph_annotation_context(compiler_config_extra.cudagraphs):
-        aot_mode_kwargs = (
-            {"aot_mode": True} if compiler_config_extra.aot_mode else {}
-        )
         result = inner_compile(
             gm,
             example_inputs,
@@ -2535,7 +2535,7 @@ def compile_fx_forward(
             graph_id=compiler_config_extra.graph_id,
             is_inference=is_inference,
             boxed_forward_device_index=compiler_config_extra.forward_device,
-            **aot_mode_kwargs,
+            **_maybe_aot_mode_kwargs(compiler_config_extra.aot_mode),
         )
 
         if (
@@ -2602,9 +2602,6 @@ def compile_fx_backward(
             ),
             cudagraph_annotation_context(cudagraphs),
         ):
-            aot_mode_kwargs = (
-                {"aot_mode": True} if compiler_config_extra.aot_mode else {}
-            )
             return inner_compile(
                 gm,
                 example_inputs,
@@ -2613,7 +2610,7 @@ def compile_fx_backward(
                 is_backward=True,
                 graph_id=compiler_config_extra.graph_id,
                 boxed_forward_device_index=compiler_config_extra.forward_device,
-                **aot_mode_kwargs,
+                **_maybe_aot_mode_kwargs(compiler_config_extra.aot_mode),
             )
 
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -786,7 +786,9 @@ class _CompileFxCallable(Protocol):
 
 def _maybe_aot_mode_kwargs(aot_mode: bool) -> _CompileFxKwargs:
     # Keep the default False value out of graph_kwargs so non-AOT cache keys
-    # match the pre-existing representation.
+    # match the pre-existing representation. Use this only when forwarding
+    # graph_kwargs to inner_compile; direct aot_mode parameters are ordinary
+    # function arguments and do not affect that cache key shape.
     return {"aot_mode": True} if aot_mode else {}
 
 

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -75,7 +75,6 @@ class _VirtualizedSerializer:
 
     # The values here get serialized. We don't grab everything because some of
     # the fields can't be serialized.
-    aot_compilation: Any = None
     choices: Any = None
     local_buffer_context: Any = None
     ops: Any = None

--- a/torch/_inductor/freezing.py
+++ b/torch/_inductor/freezing.py
@@ -75,6 +75,8 @@ def freeze(
     dynamo_gm: torch.fx.GraphModule,
     aot_autograd_gm: torch.fx.GraphModule,
     example_inputs: list[torch._subclasses.FakeTensor],
+    *,
+    aot_mode: bool = False,
 ) -> tuple[torch.fx.GraphModule, list[int]]:
     """
     Inlines parameters that are not mutated into constants and optimizes the graph through constant propagation
@@ -92,13 +94,15 @@ def freeze(
         of the inputs that were preserved (not turned into constants).
     """
     with enter_freezing():
-        return _freeze(dynamo_gm, aot_autograd_gm, example_inputs)
+        return _freeze(dynamo_gm, aot_autograd_gm, example_inputs, aot_mode=aot_mode)
 
 
 def _freeze(
     dynamo_gm: torch.fx.GraphModule,
     aot_autograd_gm: torch.fx.GraphModule,
     example_inputs: list[torch._subclasses.FakeTensor],
+    *,
+    aot_mode: bool = False,
 ) -> tuple[torch.fx.GraphModule, list[int]]:
     # We have convert conv's weight to channels last which may meet error for .view
     # when doing fake_tensor_prop. So we need to convert view to reshape first.
@@ -124,7 +128,7 @@ def _freeze(
     aot_autograd_gm.recompile()
 
     aot_example_inputs = [example_inputs[ind] for ind in preserved_arg_indices]
-    freezing_passes(aot_autograd_gm, aot_example_inputs)
+    freezing_passes(aot_autograd_gm, aot_example_inputs, aot_mode=aot_mode)
 
     constant_fold(aot_autograd_gm)
     # invalidate nn Modules

--- a/torch/_inductor/fx_passes/freezing_patterns.py
+++ b/torch/_inductor/fx_passes/freezing_patterns.py
@@ -71,6 +71,8 @@ def freezing_passes(
     constant_fold(gm)
     fake_tensor_prop(gm, aot_example_inputs, True)
 
+    # Freezing weight-pack patterns run before GraphLowering exists, so use
+    # graph-scoped metadata to expose AOT mode only while those patterns run.
     sentinel = object()
     old_aot_mode = gm.meta.get("_inductor_aot_mode", sentinel)
     gm.meta["_inductor_aot_mode"] = aot_mode

--- a/torch/_inductor/fx_passes/freezing_patterns.py
+++ b/torch/_inductor/fx_passes/freezing_patterns.py
@@ -34,7 +34,9 @@ pass_patterns = [
 binary_folding_pass = PatternMatcherPass()
 
 
-def freezing_passes(gm: torch.fx.GraphModule, aot_example_inputs):
+def freezing_passes(
+    gm: torch.fx.GraphModule, aot_example_inputs, *, aot_mode: bool = False
+):
     """
     Passes that are applied to the graph to freeze pass.
     """
@@ -69,8 +71,17 @@ def freezing_passes(gm: torch.fx.GraphModule, aot_example_inputs):
     constant_fold(gm)
     fake_tensor_prop(gm, aot_example_inputs, True)
 
-    for pattern in pass_patterns:
-        pattern.apply(gm.graph)  # type: ignore[arg-type]
+    sentinel = object()
+    old_aot_mode = gm.meta.get("_inductor_aot_mode", sentinel)
+    gm.meta["_inductor_aot_mode"] = aot_mode
+    try:
+        for pattern in pass_patterns:
+            pattern.apply(gm.graph)  # type: ignore[arg-type]
+    finally:
+        if old_aot_mode is sentinel:
+            gm.meta.pop("_inductor_aot_mode", None)
+        else:
+            gm.meta["_inductor_aot_mode"] = old_aot_mode
 
     # The CPU weight packing always assume the conv's weight is channels last,
     # So make sure the layout_optimization is on when doing it.

--- a/torch/_inductor/fx_passes/freezing_patterns.py
+++ b/torch/_inductor/fx_passes/freezing_patterns.py
@@ -71,8 +71,10 @@ def freezing_passes(
     constant_fold(gm)
     fake_tensor_prop(gm, aot_example_inputs, True)
 
-    # Freezing weight-pack patterns run before GraphLowering exists, so use
-    # graph-scoped metadata to expose AOT mode only while those patterns run.
+    # Freezing weight-pack patterns run before GraphLowering exists, so
+    # GraphModule metadata is the only graph-scoped carrier available to
+    # expose AOT mode during this pass. Restore the previous value below to
+    # avoid leaking the temporary metadata to later passes.
     sentinel = object()
     old_aot_mode = gm.meta.get("_inductor_aot_mode", sentinel)
     gm.meta["_inductor_aot_mode"] = aot_mode

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -73,6 +73,15 @@ if torch._C._has_mkldnn:
             raise NotImplementedError
 
     class CpuMkldnnDeviceOp(MkldnnDeviceOpBase):
+        @staticmethod
+        def _graph_aot_mode(graph):
+            # Freezing weight-pack patterns run before GraphLowering exists.
+            owning_module = graph.owning_module
+            return bool(
+                owning_module is not None
+                and owning_module.meta.get("_inductor_aot_mode", False)
+            )
+
         def get_linear_transpose_weight(self, weight_node):
             packed_weight_node = weight_node
             assert packed_weight_node.target == mkldnn._reorder_linear_weight
@@ -120,7 +129,7 @@ if torch._C._has_mkldnn:
                 if (
                     is_lp_weight
                     or mkldnn._is_mkldnn_acl_supported()
-                    or V.aot_compilation
+                    or self._graph_aot_mode(graph)
                     or has_free_symbols(batch_size)
                 )
                 else torch.ops.mkl._mkl_reorder_linear_weight
@@ -137,7 +146,7 @@ if torch._C._has_mkldnn:
             if (
                 is_lp_weight
                 or mkldnn._is_mkldnn_acl_supported()
-                or V.aot_compilation
+                or self._graph_aot_mode(graph)
                 or has_free_symbols(batch_size)
             ):
                 packed_linear_inputs += (bias, "none", [], "")

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2264,7 +2264,7 @@ def use_nv_universal_gemm_template(
 
     from .virtualized import V
 
-    if V.aot_compilation:
+    if V.graph.aot_mode:
         return False
 
     if layout.device.type != "cuda" or torch.version.hip:
@@ -3605,7 +3605,7 @@ def expr_fits_within_32bit(e: sympy.Expr) -> bool:
     #   - If allowed range does have an upper bound, then obey the upper bound
     #       (check whether upper bound < int32_max) without checking the hint.
 
-    if V.aot_compilation:
+    if V.graph.aot_mode:
         # check whether value has an upper bound (1e20 is > INT64_MAX, assume
         # there is no upper bound if it can be larger than 1e20)
         if V.graph.sizevars.statically_known_true(e < 1e20):

--- a/torch/_inductor/virtualized.py
+++ b/torch/_inductor/virtualized.py
@@ -15,7 +15,7 @@ associated with a symbolic expression.
 
 There are a few distinct usage patterns for virtualized global variables:
 
-1. Implicit argument passing.  Examples: ``V.current_node``, ``V.aot_compilation``.
+1. Implicit argument passing.  Examples: ``V.current_node``, ``V.graph``.
    Use ``V.set_current_node`` to change what the current node is while we're
    executing some region of code, so code inside that region can query ``V.current_node``
    to find out what it is.  This is often more convenient than manually threading
@@ -198,7 +198,6 @@ _kernel: Virtualized[NullKernelHandler] = Virtualized(
 )  # TODO: improve type
 _debug: Virtualized[DebugContext] = Virtualized("debug", NullHandler)
 _interpreter: Virtualized[InterpreterShim] = Virtualized("interpreter", NullHandler)
-_aot_compilation: Virtualized[bool] = Virtualized("aot_compilation", NullHandler)
 _current_node: Virtualized[torch.fx.Node] = Virtualized("current_node", NullHandler)
 _local_buffer_context: Virtualized[LocalBufferContext] = Virtualized(
     "local_buffer_context", NullHandler
@@ -381,8 +380,6 @@ class _V:
     set_kernel_handler: Callable[[Any], Any] = _kernel._set_handler
     set_debug_handler: Callable[[Any], Any] = _debug._set_handler
     set_interpreter_handler: Callable[[Any], Any] = _interpreter._set_handler
-    set_aot_compilation: Callable[[bool], Any] = _aot_compilation._set_handler
-    get_aot_compilation: Callable[[], Any] = _aot_compilation._get_handler
     set_current_node: Callable[[Any], Any] = _current_node._set_handler
     get_current_node: Callable[[], Any] = _current_node._get_handler
     set_local_buffer_context: Callable[[Any], Any] = _local_buffer_context._set_handler
@@ -442,10 +439,6 @@ class _V:
     @property
     def interpreter(self):
         return _interpreter._get_handler()
-
-    @property
-    def aot_compilation(self):
-        return _aot_compilation._get_handler() is True
 
     @property
     def current_node(self):


### PR DESCRIPTION
## Summary

Consolidate Inductor AOT mode state so the compile pipeline passes `aot_mode` explicitly until `GraphLowering` exists, then uses `graph.aot_mode` for lowering/codegen decisions. Remove the `V.aot_compilation` virtualized thread-local and its serialization.

## Root cause problem

`V.aot_compilation` and `GraphLowering.aot_mode` represented the same AOT state at different layers. `GraphLowering.aot_mode` was derived from the virtualized thread-local, but call sites read either source, which made behavior harder to reason about and required out-of-process compile serialization to preserve redundant virtualized state.

## Proposed fix

Thread `aot_mode` through `compile_fx`/`compile_fx_inner` kwargs and `CompilerConfigExtra`, pass it into AOT and freezing setup explicitly, and initialize `GraphLowering.aot_mode` from that value. Lowering/codegen paths now read `V.graph.aot_mode`; the pre-GraphLowering MKLDNN freezing weight-pack path reads an explicit temporary graph-module metadata value instead of the removed thread-local.

## Why this is the right long term fix

AOT mode becomes explicit before graph lowering and graph-scoped once codegen decisions are made. This removes hidden thread-local state, avoids serializing a redundant virtualized flag for subprocess compilation, and makes new AOT-sensitive code choose between an explicit setup argument or `graph.aot_mode` based on where it runs.

## Tests

- `python3 -m py_compile torch/_inductor/compile_fx.py torch/_inductor/virtualized.py torch/_inductor/compile_fx_ext.py torch/_inductor/utils.py torch/_inductor/codegen/wrapper_fxir.py torch/_inductor/fx_passes/mkldnn_fusion.py torch/_inductor/fx_passes/freezing_patterns.py torch/_inductor/freezing.py torch/__init__.py test/inductor/test_aot_mode.py`
- `git diff --check`
- `PYTHONPATH=. python3 test/inductor/test_aot_mode.py` was attempted for both the fail-first check and final run, but this local checkout is not importable: Python fails before test collection with `ModuleNotFoundError: No module named 'typing_extensions'`. The environment also has no `pip` or `ensurepip` to install missing test dependencies.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo