### PR TITLE
Resolve fake tensor import cycle

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1270,6 +1270,86 @@ if "torch._subclasses.fake_impls" not in sys.modules:
             msg=f"subprocess failed:\n{result.stderr.decode()}",
         )
 
+    def test_concurrent_fake_impls_load_waits_for_registrations(self):
+        script = """\
+import builtins
+import sys
+import threading
+
+import torch
+from torch._subclasses import fake_impls_registry
+
+if "torch._subclasses.fake_impls" in sys.modules:
+    raise AssertionError("fake_impls imported before the test")
+
+original_import = builtins.__import__
+import_started = threading.Event()
+release_import = threading.Event()
+
+
+def slow_fake_impls_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "torch._subclasses.fake_impls" and not import_started.is_set():
+        import_started.set()
+        if not release_import.wait(timeout=60):
+            raise AssertionError("timed out waiting to release fake_impls import")
+    return original_import(name, globals, locals, fromlist, level)
+
+
+builtins.__import__ = slow_fake_impls_import
+try:
+    first_error = []
+    second_error = []
+    second_returned = threading.Event()
+
+    def first_load():
+        try:
+            fake_impls_registry.ensure_fake_impls_loaded()
+        except Exception as exc:
+            first_error.append(exc)
+
+    def second_load():
+        try:
+            fake_impls_registry.get_op_implementations_checks()
+        except Exception as exc:
+            second_error.append(exc)
+        finally:
+            second_returned.set()
+
+    first_thread = threading.Thread(target=first_load)
+    first_thread.start()
+    if not import_started.wait(timeout=60):
+        raise AssertionError("fake_impls import did not start")
+
+    second_thread = threading.Thread(target=second_load)
+    second_thread.start()
+    if second_returned.wait(timeout=1):
+        raise AssertionError("concurrent fake_impls load returned partial registry state")
+
+    release_import.set()
+    first_thread.join(timeout=60)
+    second_thread.join(timeout=60)
+
+    if first_thread.is_alive() or second_thread.is_alive():
+        raise AssertionError("fake_impls loader threads did not finish")
+    if first_error:
+        raise first_error[0]
+    if second_error:
+        raise second_error[0]
+finally:
+    release_import.set()
+    builtins.__import__ = original_import
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"subprocess failed:\n{result.stderr.decode()}",
+        )
+
     def test_nanmean_out(self):
         # Regression test to ensure we don't error out.
         with torch._subclasses.fake_tensor.FakeTensorMode() as mode:

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -1241,6 +1241,35 @@ class FakeTensorTest(TestCase):
         y = fast_div(mode, x, 2)
         self.assertEqual(y.dtype, torch.float32)
 
+    def test_fake_tensor_import_does_not_import_fake_impls(self):
+        script = """\
+import sys
+import torch
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+if "torch._subclasses.fake_impls" in sys.modules:
+    raise AssertionError("fake_impls imported with fake_tensor")
+
+with FakeTensorMode():
+    x = torch.empty(2, 2)
+
+if not isinstance(x, FakeTensor):
+    raise AssertionError(type(x))
+
+if "torch._subclasses.fake_impls" not in sys.modules:
+    raise AssertionError("fake_impls were not loaded for dispatch")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            timeout=60,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"subprocess failed:\n{result.stderr.decode()}",
+        )
+
     def test_nanmean_out(self):
         # Regression test to ensure we don't error out.
         with torch._subclasses.fake_tensor.FakeTensorMode() as mode:

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -50,6 +50,7 @@ from torch._prims_common.wrappers import (
     elementwise_unary_scalar_wrapper,
     out_wrapper,
 )
+from torch._subclasses.fake_impls_registry import register_op_impl
 from torch.testing._internal.common_dtype import highest_precision_float
 
 
@@ -3505,7 +3506,7 @@ def native_layer_norm(
     return (out, mean, rstd)
 
 
-@torch._subclasses.fake_impls.register_op_impl(aten.native_layer_norm.default)
+@register_op_impl(aten.native_layer_norm.default)
 def native_layer_norm_fake(fake_mode, func, *args, **kwargs):
     return native_layer_norm(*args)
 

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -1570,6 +1570,8 @@ def fast_detach(
 
 @functools.cache
 def get_fast_op_impls() -> dict[OpOverload, Callable[..., Any]]:
+    # fake_impls_registry.get_fast_op_impls delegates here after lazy-loading
+    # this module; keep the fast-op table construction local to fake_impls.
     import torch._refs
 
     register_fast_op_impl(torch.ops.aten.add.Tensor)(

--- a/torch/_subclasses/fake_impls.py
+++ b/torch/_subclasses/fake_impls.py
@@ -14,7 +14,6 @@ import torch._custom_op
 import torch._logging
 import torch._prims_common as utils
 from torch._dispatch.python import no_python_dispatcher
-from torch._ops import OpOverload
 from torch._prims_common import (
     canonicalize_dim,
     elementwise_dtypes,
@@ -27,6 +26,20 @@ from torch._prims_common import (
     is_integer_dtype,
     make_contiguous_strides_for,
     ShapeType,
+)
+from torch._subclasses.fake_impls_registry import (  # noqa: F401
+    _deregister_op_impl,
+    _device_not_kwarg_ops,
+    _is_op_registered_to_fake_rule,
+    _is_tensor_constructor,
+    _like_tensor_constructors,
+    contains_tensor_types,
+    has_meta,
+    op_implementations_checks,
+    op_implementations_dict,
+    ordered_set,
+    register_op_impl,
+    stride_incorrect_op,
 )
 from torch._subclasses.fake_tensor import (
     DataDependentOutputException,
@@ -43,6 +56,7 @@ from torch.utils._stats import count_label
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
+    from torch._ops import OpOverload
     from torch._subclasses.fake_tensor import FakeTensorMode
     from torch.types import IntLikeType
 
@@ -50,7 +64,6 @@ if TYPE_CHECKING:
 FakeTensorLike = FakeTensor | torch.Tensor
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
-_T = TypeVar("_T")
 
 pytree = torch.utils._pytree
 
@@ -61,17 +74,7 @@ __all__ = [
     "has_meta",
 ]
 
-# pyrefly: ignore [implicit-any]
-op_implementations_dict = {}
-# pyrefly: ignore [implicit-any]
-op_implementations_checks = []
-
-
 aten = torch._ops.ops.aten
-
-
-def ordered_set(*items: _T) -> dict[_T, bool]:
-    return dict.fromkeys(items, True)
 
 
 # This function indicates if the backend device
@@ -80,122 +83,8 @@ def is_noncontiguous_supported(device: torch.device) -> bool:
     return device.type != "hpu"
 
 
-_like_tensor_constructors = ordered_set(
-    aten.empty_like.default,
-    aten.empty_like.out,
-    aten.full_like.default,
-    aten.full_like.out,
-    aten.ones_like.default,
-    aten.ones_like.out,
-    aten.rand_like.default,
-    aten.rand_like.generator,
-    aten.rand_like.out,
-    aten.rand_like.generator_out,
-    aten.randn_like.default,
-    aten.randn_like.generator,
-    aten.randn_like.out,
-    aten.randn_like.generator_out,
-    aten.randint_like.default,
-    aten.randint_like.generator,
-    aten.randint_like.Tensor,
-    aten.randint_like.Tensor_generator,
-    aten.randint_like.Tensor_out,
-    aten.randint_like.Tensor_generator_out,
-    aten.randint_like.out,
-    aten.randint_like.generator_out,
-    aten.randint_like.low_dtype,
-    aten.randint_like.low_generator_dtype,
-    aten.randint_like.low_dtype_out,
-    aten.randint_like.low_generator_dtype_out,
-    aten.zeros_like.default,
-    aten.zeros_like.out,
-    aten.new_empty.default,
-    aten.new_empty.out,
-    aten.new_empty_strided.default,
-    aten.new_empty_strided.out,
-    aten.new_full.default,
-    aten.new_full.out,
-    aten.new_zeros.default,
-    aten.new_zeros.out,
-    aten.new_ones.default,
-    aten.new_ones.out,
-)
-
-
-_device_not_kwarg_ops = ordered_set(
-    aten._resize_output_.default,
-    aten._nested_tensor_from_tensor_list.default,
-    aten._nested_tensor_from_tensor_list.out,
-    aten.pin_memory.default,
-    aten.to.device,
-    aten.to.prim_Device,
-    aten.is_pinned.default,
-    aten._pin_memory.default,
-    aten._pin_memory.out,
-    aten._resize_output.default,
-    aten._resize_output.out,
-)
-
 # this op is never actually used
 _non_kwarg_device_constructors = (aten._list_to_tensor,)
-
-
-def contains_tensor_types(type_: Any) -> bool:
-    tensor_type = torch._C.TensorType.get()
-    return type_.isSubtypeOf(tensor_type) or any(
-        contains_tensor_types(e) for e in type_.containedTypes()
-    )
-
-
-@functools.cache
-def _is_tensor_constructor(func: OpOverload) -> bool:
-    if not isinstance(func, OpOverload):
-        raise AssertionError(f"func must be an OpOverload, got {type(func)}")
-    schema = func._schema
-    if any(contains_tensor_types(arg.type) for arg in schema.arguments):
-        return False
-    # TODO: no real reason to restrict multiple outputs
-    return (
-        len(schema.returns) == 1 and schema.returns[0].type is torch._C.TensorType.get()
-    )
-
-
-def register_op_impl(
-    run_impl_check: Callable[[OpOverload], bool]
-    | OpOverload
-    | list[OpOverload]
-    | tuple[OpOverload, ...],
-) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
-    def impl_decorator(op_impl: Callable[_P, _R]) -> Callable[_P, _R]:
-        if isinstance(run_impl_check, OpOverload):
-            if run_impl_check in op_implementations_dict:
-                raise AssertionError(f"duplicate registration: {run_impl_check}")
-            op_implementations_dict[run_impl_check] = op_impl
-        elif isinstance(run_impl_check, (list, tuple)):
-            for op in run_impl_check:
-                register_op_impl(op)(op_impl)
-        else:
-            if not callable(run_impl_check):
-                raise AssertionError(
-                    f"run_impl_check must be callable, got {type(run_impl_check)}"
-                )
-            op_implementations_checks.append((run_impl_check, op_impl))
-
-        return op_impl
-
-    return impl_decorator
-
-
-def _is_op_registered_to_fake_rule(op: OpOverload) -> bool:
-    return op in op_implementations_dict
-
-
-def _deregister_op_impl(op: OpOverload) -> None:
-    op_implementations_dict.pop(op, None)
-    for check, impl in op_implementations_checks:
-        if check is op:
-            op_implementations_checks.remove((check, impl))
-            break
 
 
 @register_op_impl(op_implementations_dict.__contains__)
@@ -306,10 +195,6 @@ def non_kwarg_to(
     return fake_mode.fake_tensor_converter.from_meta_and_device(
         fake_mode, r, out_device
     )
-
-
-def stride_incorrect_op(op: OpOverload) -> bool:
-    return False
 
 
 # These operators have meta implementations with incorrect strides
@@ -1178,10 +1063,6 @@ _is_builtin_namespaces = ordered_set("aten", "prims", "prim")
 
 def is_builtin(op: OpOverload) -> bool:
     return op.namespace in _is_builtin_namespaces
-
-
-def has_meta(func: OpOverload) -> bool:
-    return torch._C._dispatch_has_computed_kernel_for_dispatch_key(func.name(), "Meta")
 
 
 # These are for the `torch._foreach_...` ops like `torch._foreach_add`.

--- a/torch/_subclasses/fake_impls_registry.py
+++ b/torch/_subclasses/fake_impls_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import threading
 from typing import Any, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
 
@@ -25,6 +26,7 @@ op_implementations_checks = []
 
 _fake_impls_loaded = False
 _fake_impls_loading = False
+_fake_impls_lock = threading.RLock()
 
 
 def ordered_set(*items: _T) -> dict[_T, bool]:
@@ -34,21 +36,33 @@ def ordered_set(*items: _T) -> dict[_T, bool]:
 def ensure_fake_impls_loaded() -> None:
     global _fake_impls_loaded, _fake_impls_loading
 
-    if _fake_impls_loaded or _fake_impls_loading:
+    if _fake_impls_loaded:
         return
 
-    # Python's import lock serializes concurrent imports of fake_impls. This
-    # flag only prevents re-entering the loader through the intentional
-    # fake_tensor -> registry -> fake_impls -> fake_tensor import cycle. If the
-    # import fails, leave _fake_impls_loaded false so future calls retry instead
-    # of caching a partially initialized registry.
-    _fake_impls_loading = True
-    try:
-        import torch._subclasses.fake_impls  # noqa: F401
-    finally:
-        _fake_impls_loading = False
+    with _fake_impls_lock:
+        if _fake_impls_loaded:
+            return
+        if _fake_impls_loading:
+            return
 
-    _fake_impls_loaded = True
+        # The lock keeps concurrent callers from observing partially registered
+        # fake impls while Python's import lock serializes module execution.
+        # _fake_impls_loading only handles same-thread reentry through the
+        # fake_tensor -> registry -> fake_impls -> fake_tensor import cycle.
+        dict_snapshot = op_implementations_dict.copy()
+        checks_snapshot = list(op_implementations_checks)
+        _fake_impls_loading = True
+        try:
+            import torch._subclasses.fake_impls  # noqa: F401
+        except Exception:
+            op_implementations_dict.clear()
+            op_implementations_dict.update(dict_snapshot)
+            op_implementations_checks[:] = checks_snapshot
+            raise
+        else:
+            _fake_impls_loaded = True
+        finally:
+            _fake_impls_loading = False
 
 
 def get_op_implementations_checks() -> list[tuple[Callable[[OpOverload], bool], Any]]:

--- a/torch/_subclasses/fake_impls_registry.py
+++ b/torch/_subclasses/fake_impls_registry.py
@@ -37,6 +37,11 @@ def ensure_fake_impls_loaded() -> None:
     if _fake_impls_loaded or _fake_impls_loading:
         return
 
+    # Python's import lock serializes concurrent imports of fake_impls. This
+    # flag only prevents re-entering the loader through the intentional
+    # fake_tensor -> registry -> fake_impls -> fake_tensor import cycle. If the
+    # import fails, leave _fake_impls_loaded false so future calls retry instead
+    # of caching a partially initialized registry.
     _fake_impls_loading = True
     try:
         import torch._subclasses.fake_impls  # noqa: F401
@@ -53,6 +58,9 @@ def get_op_implementations_checks() -> list[tuple[Callable[[OpOverload], bool], 
 
 def get_fast_op_impls() -> dict[OpOverload, Callable[..., Any]]:
     ensure_fake_impls_loaded()
+    # The fast implementations depend on FakeTensor helpers and still live in
+    # fake_impls; after ensure_fake_impls_loaded(), this import is a sys.modules
+    # lookup that preserves the lazy-loading boundary for fake_tensor.py.
     from torch._subclasses.fake_impls import get_fast_op_impls as _get_fast_op_impls
 
     return _get_fast_op_impls()

--- a/torch/_subclasses/fake_impls_registry.py
+++ b/torch/_subclasses/fake_impls_registry.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import functools
+from typing import Any, TYPE_CHECKING, TypeVar
+from typing_extensions import ParamSpec
+
+import torch
+from torch._ops import OpOverload
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_T = TypeVar("_T")
+
+aten = torch._ops.ops.aten
+
+# pyrefly: ignore [implicit-any]
+op_implementations_dict = {}
+# pyrefly: ignore [implicit-any]
+op_implementations_checks = []
+
+_fake_impls_loaded = False
+_fake_impls_loading = False
+
+
+def ordered_set(*items: _T) -> dict[_T, bool]:
+    return dict.fromkeys(items, True)
+
+
+def ensure_fake_impls_loaded() -> None:
+    global _fake_impls_loaded, _fake_impls_loading
+
+    if _fake_impls_loaded or _fake_impls_loading:
+        return
+
+    _fake_impls_loading = True
+    try:
+        import torch._subclasses.fake_impls  # noqa: F401
+    finally:
+        _fake_impls_loading = False
+
+    _fake_impls_loaded = True
+
+
+def get_op_implementations_checks() -> list[tuple[Callable[[OpOverload], bool], Any]]:
+    ensure_fake_impls_loaded()
+    return op_implementations_checks
+
+
+def get_fast_op_impls() -> dict[OpOverload, Callable[..., Any]]:
+    ensure_fake_impls_loaded()
+    from torch._subclasses.fake_impls import get_fast_op_impls as _get_fast_op_impls
+
+    return _get_fast_op_impls()
+
+
+def contains_tensor_types(type_: Any) -> bool:
+    tensor_type = torch._C.TensorType.get()
+    return type_.isSubtypeOf(tensor_type) or any(
+        contains_tensor_types(e) for e in type_.containedTypes()
+    )
+
+
+@functools.cache
+def _is_tensor_constructor(func: OpOverload) -> bool:
+    if not isinstance(func, OpOverload):
+        raise AssertionError(f"func must be an OpOverload, got {type(func)}")
+    schema = func._schema
+    if any(contains_tensor_types(arg.type) for arg in schema.arguments):
+        return False
+    # TODO: no real reason to restrict multiple outputs
+    return (
+        len(schema.returns) == 1 and schema.returns[0].type is torch._C.TensorType.get()
+    )
+
+
+def register_op_impl(
+    run_impl_check: Callable[[OpOverload], bool]
+    | OpOverload
+    | list[OpOverload]
+    | tuple[OpOverload, ...],
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    def impl_decorator(op_impl: Callable[_P, _R]) -> Callable[_P, _R]:
+        if isinstance(run_impl_check, OpOverload):
+            if run_impl_check in op_implementations_dict:
+                raise AssertionError(f"duplicate registration: {run_impl_check}")
+            op_implementations_dict[run_impl_check] = op_impl
+        elif isinstance(run_impl_check, (list, tuple)):
+            for op in run_impl_check:
+                register_op_impl(op)(op_impl)
+        else:
+            if not callable(run_impl_check):
+                raise AssertionError(
+                    f"run_impl_check must be callable, got {type(run_impl_check)}"
+                )
+            op_implementations_checks.append((run_impl_check, op_impl))
+
+        return op_impl
+
+    return impl_decorator
+
+
+def _is_op_registered_to_fake_rule(op: OpOverload) -> bool:
+    ensure_fake_impls_loaded()
+    return op in op_implementations_dict
+
+
+def _deregister_op_impl(op: OpOverload) -> None:
+    op_implementations_dict.pop(op, None)
+    for check, impl in op_implementations_checks:
+        if check is op:
+            op_implementations_checks.remove((check, impl))
+            break
+
+
+_like_tensor_constructors = ordered_set(
+    aten.empty_like.default,
+    aten.empty_like.out,
+    aten.full_like.default,
+    aten.full_like.out,
+    aten.ones_like.default,
+    aten.ones_like.out,
+    aten.rand_like.default,
+    aten.rand_like.generator,
+    aten.rand_like.out,
+    aten.rand_like.generator_out,
+    aten.randn_like.default,
+    aten.randn_like.generator,
+    aten.randn_like.out,
+    aten.randn_like.generator_out,
+    aten.randint_like.default,
+    aten.randint_like.generator,
+    aten.randint_like.Tensor,
+    aten.randint_like.Tensor_generator,
+    aten.randint_like.Tensor_out,
+    aten.randint_like.Tensor_generator_out,
+    aten.randint_like.out,
+    aten.randint_like.generator_out,
+    aten.randint_like.low_dtype,
+    aten.randint_like.low_generator_dtype,
+    aten.randint_like.low_dtype_out,
+    aten.randint_like.low_generator_dtype_out,
+    aten.zeros_like.default,
+    aten.zeros_like.out,
+    aten.new_empty.default,
+    aten.new_empty.out,
+    aten.new_empty_strided.default,
+    aten.new_empty_strided.out,
+    aten.new_full.default,
+    aten.new_full.out,
+    aten.new_zeros.default,
+    aten.new_zeros.out,
+    aten.new_ones.default,
+    aten.new_ones.out,
+)
+
+
+_device_not_kwarg_ops = ordered_set(
+    aten._resize_output_.default,
+    aten._nested_tensor_from_tensor_list.default,
+    aten._nested_tensor_from_tensor_list.out,
+    aten.pin_memory.default,
+    aten.to.device,
+    aten.to.prim_Device,
+    aten.is_pinned.default,
+    aten._pin_memory.default,
+    aten._pin_memory.out,
+    aten._resize_output.default,
+    aten._resize_output.out,
+)
+
+
+def stride_incorrect_op(op: OpOverload) -> bool:
+    return False
+
+
+def has_meta(func: OpOverload) -> bool:
+    return torch._C._dispatch_has_computed_kernel_for_dispatch_key(func.name(), "Meta")

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2924,7 +2924,7 @@ class FakeTensorMode(TorchDispatchMode):
         # special handling for funcs registered through `register_op_impl`,
         # e.g., manipulating args on constructor calls to construct meta tensors
         # and then afterwards wrapping them to a FakeTensor
-        for run_impl_check, op_impl in op_implementations_checks:
+        for run_impl_check, op_impl in get_op_implementations_checks():
             if run_impl_check(func):
                 # pyrefly: ignore [bad-argument-count]
                 op_impl_out = op_impl(self, func, *args, **kwargs)
@@ -3466,14 +3466,14 @@ _DISPATCH_HANDLE_DIRECTLY = ordered_set(
     torch.ops.profiler._record_function_exit._RecordFunction,
 )
 
-from torch._subclasses.fake_impls import (  # noqa: F401
+from torch._subclasses.fake_impls_registry import (  # noqa: F401
     _device_not_kwarg_ops,
     _is_tensor_constructor,
     _like_tensor_constructors,
     contains_tensor_types,
     get_fast_op_impls,
+    get_op_implementations_checks,
     has_meta,
-    op_implementations_checks,
     stride_incorrect_op,
 )
 

--- a/torch/_subclasses/fake_utils.py
+++ b/torch/_subclasses/fake_utils.py
@@ -6,6 +6,7 @@ from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.utils._pytree as pytree
+from torch._subclasses.fake_impls_registry import has_meta
 from torch._subclasses.fake_tensor import (
     FakeTensor,
     FakeTensorMode,
@@ -254,10 +255,7 @@ class CrossRefFakeMode(TorchDispatchMode):
                 aten.set_.source_Storage_storage_offset,
             )
             and not self.ignore_op_fn(func)
-            and (
-                not self.only_check_ops_with_meta
-                or torch._subclasses.fake_impls.has_meta(func)
-            )
+            and (not self.only_check_ops_with_meta or has_meta(func))
             and torch.Tag.dynamic_output_shape not in func.tags
             and torch.Tag.inplace_view not in func.tags
             and torch.Tag.data_dependent_output not in func.tags

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -15,7 +15,7 @@ from typing import Any, final, NamedTuple, TYPE_CHECKING
 from torch._guards import tracing, TracingContext
 from torch._higher_order_ops.utils import autograd_not_implemented
 from torch._library.fake_class_registry import FakeScriptObject
-from torch._subclasses.fake_impls import (
+from torch._subclasses.fake_impls_registry import (
     _deregister_op_impl,
     _is_op_registered_to_fake_rule,
     register_op_impl,

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -50,7 +50,6 @@ from torch._library.opaque_object import (
 )
 from torch._logging import trace_structured
 from torch._ops import HigherOrderOperator, OpOverload
-from torch._subclasses.fake_impls import fast_detach
 from torch._subclasses.fake_tensor import (
     FakeTensor,
     FakeTensorMode,
@@ -661,6 +660,8 @@ def snapshot_fake(val: Tensor, include_real: bool = False) -> Tensor | None:
     # but this saves us a full trip into __torch_dispatch__
     # (snapshot_fake is called a lot)
     if isinstance(val, FakeTensor):
+        from torch._subclasses.fake_impls import fast_detach
+
         return fast_detach(val.fake_mode, val, include_real)
     else:
         return val.detach()


### PR DESCRIPTION
## Summary

Resolve the `fake_tensor.py` <-> `fake_impls.py` import cycle by moving the fake op registration tables and registration-only helpers into `torch._subclasses.fake_impls_registry`.

## Root cause problem

`fake_impls.py` needs public fake tensor types and helpers from `fake_tensor.py`, while `fake_tensor.py` imported `fake_impls.py` at module import time to access registration tables and predicates. That made importing either module depend on the other module's partial initialization.

## Proposed fix

Move the registration machinery, constructor predicates, and meta/stride predicates into a standalone registry module. `fake_tensor.py` now depends on that registry and lazily loads `fake_impls.py` only when fake dispatch needs the registered implementations. Registration-only callers now import the registry directly, and `proxy_tensor` lazily imports `fast_detach` to avoid pulling in fake implementations during top-level import.

## Why this is the right long term fix

The fake tensor public API and fake op implementation registrations now have a one-way dependency: implementation code can depend on fake tensor types, while fake tensor dispatch depends only on the registry boundary. This keeps registration state shared, preserves existing `fake_impls.py` explicit imports for compatibility, and avoids relying on partially initialized modules.

## Tests

- `python3 -m py_compile torch/_subclasses/fake_impls_registry.py torch/_subclasses/fake_impls.py torch/_subclasses/fake_tensor.py torch/_subclasses/fake_utils.py torch/export/exported_program.py torch/_refs/__init__.py torch/fx/experimental/proxy_tensor.py test/test_fake_tensor.py`
- `PYTHONPATH=/tmp/repos/pytorch/pytorch:/tmp/repos/pytorch/pytorch/test pytest -q --import-mode=importlib test/test_fake_tensor.py`
- Verified the new regression check fails without the implementation patch: `AssertionError: fake_impls imported with fake_tensor`
- `lintrunner --take RUFF torch/_subclasses/fake_impls_registry.py torch/_subclasses/fake_impls.py torch/_subclasses/fake_tensor.py torch/_subclasses/fake_utils.py torch/export/exported_program.py torch/_refs/__init__.py torch/fx/experimental/proxy_tensor.py test/test_fake_tensor.py`

Drafted via Codex, published after manual review by @bobrenjc93