### PR TITLE
[inductor][static launcher] validate pointer arg dtypes before launch

### DIFF
--- a/test/inductor/test_static_triton_launcher.py
+++ b/test/inductor/test_static_triton_launcher.py
@@ -482,6 +482,35 @@ class TestStaticTritonCompileResult(TestCase):
         x2 = x.clone().detach_()
         self.assertEqual(foo(x), x2 + 5)
 
+    @skipIfXpu(msg="Tests CUDA static launcher dtype validation")
+    @torch._inductor.config.patch({"compile_threads": 1, "fx_graph_cache": False})
+    def test_custom_op_bad_fake_dtype_fails_fast(self):
+        namespace = f"test_static_launcher_dtype_validation_{random.randint(0, 2**32)}"
+
+        @torch.library.custom_op(f"{namespace}::bad_meta_mul", mutates_args=())
+        def bad_meta_mul(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            return a * b
+
+        @bad_meta_mul.register_fake
+        def _(a, b):
+            return torch.empty_like(a, dtype=torch.bfloat16)
+
+        op = getattr(torch.ops, namespace).bad_meta_mul
+
+        @torch.compile(fullgraph=True)
+        def f(a, b):
+            x = op(a, b)
+            return x + 1
+
+        a = torch.randn(1 << 20, device=GPU_TYPE, dtype=torch.float32)
+        b = torch.randn(1 << 20, device=GPU_TYPE, dtype=torch.float32)
+
+        self.assertRaisesRegex(
+            TypeError,
+            r"expected Triton pointer type \*bf16 .* got tensor dtype torch.float32",
+            lambda: f(a, b),
+        )
+
     def test_empty_tensor(self):
         @torch.compile()
         def foo(x, y):

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -4,6 +4,8 @@ from functools import cached_property
 from typing import Any
 from typing_extensions import Unpack
 
+import torch
+
 from ..utils import is_rocm
 from .triton_compat import ASTSource, CompiledKernel, knobs as triton_knobs
 from .triton_helpers import get_constexprs
@@ -109,7 +111,9 @@ class StaticallyLaunchedTritonKernel:
         self.has_profile_scratch = needs_scratch_arg("Profile", "profile_scratch_size")
 
         # pyrefly: ignore [missing-attribute]
-        self.arg_tys = self.arg_ty_from_signature(kernel.src)
+        self.arg_tys, self.pointer_arg_validation = self.arg_ty_from_signature(
+            kernel.src
+        )
         self.function: int | None = None  # Loaded by load_kernel(on the parent process)
         num_ctas = 1
         if hasattr(kernel, "num_ctas"):
@@ -170,6 +174,27 @@ class StaticallyLaunchedTritonKernel:
             # TODO handle nvTmaDesc/CUtensormap
         }
 
+    @staticmethod
+    @functools.lru_cache
+    def pointer_type_mappings() -> dict[str, torch.dtype]:
+        return {
+            "*i1": torch.bool,
+            "*u1": torch.bool,
+            "*i8": torch.int8,
+            "*i16": torch.int16,
+            "*i32": torch.int32,
+            "*i64": torch.int64,
+            "*u8": torch.uint8,
+            "*u16": torch.uint16,
+            "*u32": torch.uint32,
+            "*u64": torch.uint64,
+            "*fp16": torch.float16,
+            "*bf16": torch.bfloat16,
+            "*fp32": torch.float32,
+            "*f32": torch.float32,
+            "*fp64": torch.float64,
+        }
+
     def extract_type(self, ty: str) -> str:
         """
         Takes a triton type from CompiledKernel.signature and
@@ -183,7 +208,9 @@ class StaticallyLaunchedTritonKernel:
             raise NotImplementedError("nvTmaDesc kernels are not yet supported")
         return StaticallyLaunchedTritonKernel.type_mappings()[ty]
 
-    def arg_ty_from_signature(self, src: ASTSource) -> str:
+    def arg_ty_from_signature(
+        self, src: ASTSource
+    ) -> tuple[str, tuple[tuple[int, str, torch.dtype], ...]]:
         def index_key(i: Any) -> int:
             if isinstance(i, str):
                 # pyrefly: ignore [missing-attribute]
@@ -207,6 +234,7 @@ class StaticallyLaunchedTritonKernel:
         # completely ignores the constexprs passed into it when generating code.
         # So we can ignore them here too
         params = []
+        pointer_arg_validation = []
 
         for i in sorted(signature.keys()):
             ty = signature[i]
@@ -217,8 +245,23 @@ class StaticallyLaunchedTritonKernel:
                 pass
             else:
                 # pyrefly: ignore [bad-argument-type]
+                expected_dtype = self.pointer_type_mappings().get(ty)
+                if expected_dtype is not None:
+                    pointer_arg_validation.append((len(params), ty, expected_dtype))
                 params.append(self.extract_type(ty))
-        return "".join(params)
+        return "".join(params), tuple(pointer_arg_validation)
+
+    def validate_pointer_arg_dtypes(self, args: tuple[object, ...]) -> None:
+        for arg_idx, triton_ty, expected_dtype in self.pointer_arg_validation:
+            arg = args[arg_idx]
+            if not isinstance(arg, torch.Tensor):
+                continue
+            if arg.dtype != expected_dtype:
+                raise TypeError(
+                    "Static Triton launcher argument "
+                    f"{arg_idx} expected Triton pointer type {triton_ty} "
+                    f"(tensor dtype {expected_dtype}), but got tensor dtype {arg.dtype}"
+                )
 
     def __getstate__(self) -> dict[str, Any]:
         # Remove objects that are no longer valid for pickling
@@ -246,6 +289,9 @@ class StaticallyLaunchedTritonKernel:
         # throw an exception. But if inductor is the only one calling this
         # thing, it should always match.
         # Get rid of constants before passing to cubin launcher
+
+        if self.pointer_arg_validation:
+            self.validate_pointer_arg_dtypes(args)
 
         arg_tys = self.arg_tys
 


### PR DESCRIPTION
## Summary

This PR adds runtime dtype validation for pointer-typed Triton arguments in the static launcher path.

Previously, the static launcher compressed pointer-typed Triton args to `"O"` and did not preserve enough information to validate the runtime tensor dtype before launch. As a result, if compile-time metadata/fake propagation caused a Triton kernel to be compiled for one pointer dtype but a tensor with a different dtype was passed at runtime, the kernel could still launch and silently produce incorrect results.

This change preserves the original Triton pointer types for non-constexpr args and validates tensor dtypes before calling `_launch_kernel`, so mismatches now fail fast with a clear error.

Fixes #180807.
## Test Plan

- Added a regression test in `test/inductor/test_static_triton_launcher.py` covering a bad fake/meta dtype on a custom op that previously allowed the static launcher path to silently produce wrong results.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo