### PR TITLE
[xpu][fix] Include lazy_triton_compile.h in XPU cpp_wrapper header

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -227,6 +227,8 @@ class TestGpuWrapper(InductorTestCase):
     def test_many_args_fold_expression_nesting(self):
         if not RUN_GPU:
             self.skipTest("GPU not available")
+        if GPU_TYPE == "xpu":
+            self.skipTest("ocloc backend compiler crashes with too many kernel args")
 
         num_params = 130
         params = [torch.randn(64, device=self.device) for _ in range(num_params)]

--- a/torch/csrc/inductor/cpp_wrapper/xpu.h
+++ b/torch/csrc/inductor/cpp_wrapper/xpu.h
@@ -2,3 +2,4 @@
 
 #include <torch/csrc/inductor/cpp_wrapper/common.h>
 #include <torch/csrc/inductor/cpp_wrapper/device_internal/xpu.h>
+#include <torch/csrc/inductor/cpp_wrapper/lazy_triton_compile.h>


### PR DESCRIPTION
Cherry-pick https://github.com/pytorch/pytorch/pull/180440 to release 2.12 to fix the XPU AOT Inductor basic functionality.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo