### PR TITLE
[WIP][XPU][Test]Port 4 UT test suites to Intel GPU

### DIFF
--- a/test/complex_tensor/test_complex_tensor.py
+++ b/test/complex_tensor/test_complex_tensor.py
@@ -156,8 +156,12 @@ class TestComplexBwdGradients(TestCase):
         self.check_grad(device, dtype, op)
 
 
-instantiate_device_type_tests(TestComplexTensor, globals())
-instantiate_device_type_tests(TestComplexBwdGradients, globals())
+instantiate_device_type_tests(
+    TestComplexTensor, globals(), allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestComplexBwdGradients, globals(), allow_xpu=True
+)
 
 
 if dist.is_available():

--- a/test/export/test_hop.py
+++ b/test/export/test_hop.py
@@ -128,7 +128,9 @@ class TestHOP(TestCase):
         torchdynamo._reset_guarded_backend_cache()
 
 
-instantiate_device_type_tests(TestHOP, globals())
+instantiate_device_type_tests(
+    TestHOP, globals(), allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -5808,9 +5808,9 @@ class TestSparseAny(TestCase):
             self.assertEqual(torch.view_as_real(torch.view_as_complex(xs)), xs)
 
 # e.g., TestSparseUnaryUfuncsCPU and TestSparseUnaryUfuncsCUDA
-instantiate_device_type_tests(TestSparseUnaryUfuncs, globals(), allow_mps=True, except_for='meta')
+instantiate_device_type_tests(TestSparseUnaryUfuncs, globals(), allow_xpu=True, allow_mps=True, except_for='meta')
 
-instantiate_device_type_tests(TestSparseMaskedReductions, globals(), except_for='meta')
+instantiate_device_type_tests(TestSparseMaskedReductions, globals(), allow_xpu=True, except_for='meta')
 
 # e.g., TestSparseCPU and TestSparseCUDA
 instantiate_device_type_tests(TestSparse, globals(), allow_mps=True, except_for='meta')

--- a/test/test_sparse_semi_structured.py
+++ b/test/test_sparse_semi_structured.py
@@ -1661,7 +1661,7 @@ class TestSparseSemiStructuredCUSPARSELT(TestCase):
             torch._cslt_sparse_mm(compressed, B_fp8, out_dtype=out_dtype)
 
 if len(SEMI_STRUCTURED_SUPPORTED_BACKENDS) > 0:
-    instantiate_device_type_tests(TestSparseSemiStructured, globals(), only_for="cuda")
+    instantiate_device_type_tests(TestSparseSemiStructured, globals(), only_for=("cuda", "xpu"))
 if "cutlass" in SEMI_STRUCTURED_SUPPORTED_BACKENDS:
     instantiate_device_type_tests(
         TestSparseSemiStructuredCUTLASS, globals(), only_for="cuda"


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port 4 UT test suites to Intel GPU. We could enable Intel GPU with following methods and try the best to keep the original code styles:


- Added allow_xpu=True for supported test class in test parameterization.