### PR TITLE
[Test] Support skipping test classes and methods in device-type tests

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -146,7 +146,6 @@ PrivateUse1TestBase.op_overrides = {
 
 
 class TestSkippedSpecificTestCases(TestCase):
-
     executed_count = 0
 
     @classmethod
@@ -167,6 +166,7 @@ class TestSkippedSpecificTestCases(TestCase):
         type(self).executed_count += 1
         self.assertEqual(torch.device(device).type, "openreg")
         self.fail("This test should not be instantiated for openreg")
+
 
 class TestSkippedWholeTestClass(TestCase):
     def test_skipped_class_member(self, device):

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 
 import torch
 from torch.testing._internal.common_device_type import (
-    DeviceTypeTestBase,
     instantiate_device_type_tests,
     onlyCUDA,
     onlyOn,
@@ -145,65 +144,50 @@ PrivateUse1TestBase.op_overrides = {
     "op_precision": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
 }
 
-instantiate_device_type_tests(TestDeviceTypeOpenReg, globals(), only_for=("openreg",))
-class TestSkippedTestcases(TestCase):
-    """Covers skipped_testcases lookup and instantiation-time skip behavior."""
 
-    def test_missing_config(self):
-        class NoSkippedConfig(DeviceTypeTestBase):
-            device_type = "dummy"
+class TestSkippedSpecificTestCases(TestCase):
 
-        self.assertEqual(NoSkippedConfig.get_skipped_testcases("AnyTest"), [])
+    executed_count = 0
 
-    def test_configured_mapping(self):
-        class WithSkippedConfig(DeviceTypeTestBase):
-            device_type = "dummy"
-            skipped_testcases = {"SomeTest": ["test_one"]}
-
-        self.assertEqual(
-            WithSkippedConfig.get_skipped_testcases("SomeTest"), ["test_one"]
-        )
-
-    def test_method_skip(self):
-        backend_name = torch._C._get_privateuse1_backend_name()
-        generated_cls = globals()["TestSkippedMethodInstantiationOPENREG"]
-        # The unskipped method is still materialized under the backend-specific
-        # test name, while the configured skipped method is never added.
-        self.assertTrue(hasattr(generated_cls, f"test_runs_{backend_name}"))
-        self.assertFalse(hasattr(generated_cls, f"test_skipped_{backend_name}"))
-
-    def test_class_skip(self):
-        self.assertNotIn("TestSkippedClassInstantiationPRIVATEUSE1", globals())
-
-
-class TestSkippedMethodInstantiation(TestCase):
     def test_runs(self, device):
+        type(self).executed_count += 1
         self.assertEqual(torch.device(device).type, "openreg")
 
     def test_skipped(self, device):
+        type(self).executed_count += 1
+        self.assertEqual(torch.device(device).type, "openreg")
         self.fail("This test should not be instantiated for openreg")
 
+    def test_vaildate_execution(self, device):
+        expected_runs = 1
+        actual_runs = type(self).executed_count
+        self.assertEqual(
+            actual_runs,
+            expected_runs,
+            f"Skip logic failed! "
+            f"Expected {expected_runs} tests to run, "
+            f"but {actual_runs} executed.",
+        )
 
-class TestSkippedClassInstantiation(TestCase):
+class TestSkippedWholeTestClass(TestCase):
     def test_skipped_class_member(self, device):
         self.fail("This class should not be instantiated for openreg")
 
 
 # PrivateUse1 can skip individual methods or an entire instantiated class.
-PrivateUse1TestBase.skipped_testcases = {
-    "TestSkippedMethodInstantiation": ["test_skipped"],
-    "TestSkippedClassInstantiation": ["*"],
+PrivateUse1TestBase.test_exclusions = {
+    "TestSkippedSpecificTestCases": ["test_skipped"],
+    "TestSkippedWholeTestClass": "*",
 }
 
+instantiate_device_type_tests(TestDeviceTypeOpenReg, globals(), only_for=("openreg",))
 instantiate_device_type_tests(
     TestBypassDeviceRestrictions, globals(), only_for="openreg"
 )
 instantiate_device_type_tests(
-    TestSkippedMethodInstantiation, globals(), only_for="openreg"
+    TestSkippedSpecificTestCases, globals(), only_for="openreg"
 )
-instantiate_device_type_tests(
-    TestSkippedClassInstantiation, globals(), only_for="openreg"
-)
+instantiate_device_type_tests(TestSkippedWholeTestClass, globals(), only_for="openreg")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 import torch
 from torch.testing._internal.common_device_type import (
+    DeviceTypeTestBase,
     instantiate_device_type_tests,
     onlyCUDA,
     onlyOn,
@@ -145,8 +146,63 @@ PrivateUse1TestBase.op_overrides = {
 }
 
 instantiate_device_type_tests(TestDeviceTypeOpenReg, globals(), only_for=("openreg",))
+class TestSkippedTestcases(TestCase):
+    """Covers skipped_testcases lookup and instantiation-time skip behavior."""
+
+    def test_missing_config(self):
+        class NoSkippedConfig(DeviceTypeTestBase):
+            device_type = "dummy"
+
+        self.assertEqual(NoSkippedConfig.get_skipped_testcases("AnyTest"), [])
+
+    def test_configured_mapping(self):
+        class WithSkippedConfig(DeviceTypeTestBase):
+            device_type = "dummy"
+            skipped_testcases = {"SomeTest": ["test_one"]}
+
+        self.assertEqual(
+            WithSkippedConfig.get_skipped_testcases("SomeTest"), ["test_one"]
+        )
+
+    def test_method_skip(self):
+        backend_name = torch._C._get_privateuse1_backend_name()
+        generated_cls = globals()["TestSkippedMethodInstantiationOPENREG"]
+        # The unskipped method is still materialized under the backend-specific
+        # test name, while the configured skipped method is never added.
+        self.assertTrue(hasattr(generated_cls, f"test_runs_{backend_name}"))
+        self.assertFalse(hasattr(generated_cls, f"test_skipped_{backend_name}"))
+
+    def test_class_skip(self):
+        self.assertNotIn("TestSkippedClassInstantiationPRIVATEUSE1", globals())
+
+
+class TestSkippedMethodInstantiation(TestCase):
+    def test_runs(self, device):
+        self.assertEqual(torch.device(device).type, "openreg")
+
+    def test_skipped(self, device):
+        self.fail("This test should not be instantiated for openreg")
+
+
+class TestSkippedClassInstantiation(TestCase):
+    def test_skipped_class_member(self, device):
+        self.fail("This class should not be instantiated for openreg")
+
+
+# PrivateUse1 can skip individual methods or an entire instantiated class.
+PrivateUse1TestBase.skipped_testcases = {
+    "TestSkippedMethodInstantiation": ["test_skipped"],
+    "TestSkippedClassInstantiation": ["*"],
+}
+
 instantiate_device_type_tests(
     TestBypassDeviceRestrictions, globals(), only_for="openreg"
+)
+instantiate_device_type_tests(
+    TestSkippedMethodInstantiation, globals(), only_for="openreg"
+)
+instantiate_device_type_tests(
+    TestSkippedClassInstantiation, globals(), only_for="openreg"
 )
 
 if __name__ == "__main__":

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -149,6 +149,16 @@ class TestSkippedSpecificTestCases(TestCase):
 
     executed_count = 0
 
+    @classmethod
+    def tearDownClass(cls):
+        expected_runs = 1
+        if cls.executed_count != expected_runs:
+            raise AssertionError(
+                f"Skip logic failed! Expected {expected_runs} tests to run, "
+                f"but {cls.executed_count} executed."
+            )
+        super().tearDownClass()
+
     def test_runs(self, device):
         type(self).executed_count += 1
         self.assertEqual(torch.device(device).type, "openreg")
@@ -157,17 +167,6 @@ class TestSkippedSpecificTestCases(TestCase):
         type(self).executed_count += 1
         self.assertEqual(torch.device(device).type, "openreg")
         self.fail("This test should not be instantiated for openreg")
-
-    def test_vaildate_execution(self, device):
-        expected_runs = 1
-        actual_runs = type(self).executed_count
-        self.assertEqual(
-            actual_runs,
-            expected_runs,
-            f"Skip logic failed! "
-            f"Expected {expected_runs} tests to run, "
-            f"but {actual_runs} executed.",
-        )
 
 class TestSkippedWholeTestClass(TestCase):
     def test_skipped_class_member(self, device):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -9,7 +9,7 @@ import sys
 import threading
 import unittest
 from collections import namedtuple
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Collection, Iterable, Sequence
 from enum import Enum
 from functools import partial, wraps
 from typing import Any, ClassVar, TypeVar
@@ -347,18 +347,19 @@ class DeviceTypeTestBase(TestCase):
 
     # Optional skip mechanism built on top of instantiate_device_type_tests()
     # and DeviceTypeTestBase. A class-level configuration field
-    # (skipped_testcases) is read during instantiation to skip tests.
+    # (test_exclusions) is read during instantiation to skip tests.
     #
     # Format:
-    #   {
-    #       "<TestClassName>": ["test_method", ...] | ["*"]
+    #   test_exclusions = {
+    #       "TestClassA": ["test_a", "test_b"],   # skip specific methods
+    #       "TestClassB": "*",                    # skip entire class
     #   }
     #
     # Behavior:
     #   - If a class is not listed, it is unaffected by this configuration.
     #   - ["test_method", ...]: skip only the specified methods.
-    #   - ["*"]: skip all tests from the class.
-    skipped_testcases: ClassVar[dict[str, Sequence[str]]]
+    #   - "*": skip all tests from the class.
+    test_exclusions: ClassVar[dict[str, Collection[str]]]
 
     @property
     def precision(self):
@@ -404,10 +405,10 @@ class DeviceTypeTestBase(TestCase):
         return cls.device_type
 
     @classmethod
-    def get_skipped_testcases(cls, test_class_name):
-        skipped_testcases = getattr(cls, "skipped_testcases", None)
-        if skipped_testcases is not None and test_class_name in skipped_testcases:
-            return skipped_testcases[test_class_name]
+    def _get_test_exclusions(cls, test_class_name):
+        test_exclusions = getattr(cls, "test_exclusions", None)
+        if test_exclusions is not None and test_class_name in test_exclusions:
+            return test_exclusions[test_class_name]
         return []
 
     @classmethod
@@ -968,7 +969,7 @@ def instantiate_device_type_tests(
     for base in get_desired_device_type_test_bases(
         except_for, only_for, include_lazy, allow_mps, allow_xpu
     ):
-        skipped = base.get_skipped_testcases(generic_test_class.__name__)
+        skipped = base._get_test_exclusions(generic_test_class.__name__)
         # Skip the entire class
         if "*" in skipped:
             continue

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -345,6 +345,21 @@ class DeviceTypeTestBase(TestCase):
     _tls.precision = TestCase._precision
     _tls.rel_tol = TestCase._rel_tol
 
+    # Optional skip mechanism built on top of instantiate_device_type_tests()
+    # and DeviceTypeTestBase. A class-level configuration field
+    # (skipped_testcases) is read during instantiation to skip tests.
+    #
+    # Format:
+    #   {
+    #       "<TestClassName>": ["test_method", ...] | ["*"]
+    #   }
+    #
+    # Behavior:
+    #   - If a class is not listed, it is unaffected by this configuration.
+    #   - ["test_method", ...]: skip only the specified methods.
+    #   - ["*"]: skip all tests from the class.
+    skipped_testcases: ClassVar[dict[str, Sequence[str]]]
+
     @property
     def precision(self):
         return self._tls.precision
@@ -387,6 +402,13 @@ class DeviceTypeTestBase(TestCase):
     @classmethod
     def get_primary_device(cls):
         return cls.device_type
+
+    @classmethod
+    def get_skipped_testcases(cls, test_class_name):
+        skipped_testcases = getattr(cls, "skipped_testcases", None)
+        if skipped_testcases is not None and test_class_name in skipped_testcases:
+            return skipped_testcases[test_class_name]
+        return []
 
     @classmethod
     def _init_and_get_primary_device(cls):
@@ -946,6 +968,11 @@ def instantiate_device_type_tests(
     for base in get_desired_device_type_test_bases(
         except_for, only_for, include_lazy, allow_mps, allow_xpu
     ):
+        skipped = base.get_skipped_testcases(generic_test_class.__name__)
+        # Skip the entire class
+        if "*" in skipped:
+            continue
+
         class_name = generic_test_class.__name__ + base.device_type.upper()
 
         # type set to Any and suppressed due to unsupported runtime class:
@@ -977,6 +1004,9 @@ def instantiate_device_type_tests(
 
         for name in generic_members:
             if name in generic_tests:  # Instantiates test member
+                # Skip the specified methods.
+                if name in skipped:
+                    continue
                 test = getattr(generic_test_class, name)
                 # XLA-compat shim (XLA's instantiate_test takes doesn't take generic_cls)
                 sig = inspect.signature(device_type_test_class.instantiate_test)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -337,6 +337,17 @@ class DeviceTypeTestBase(TestCase):
     # in the future.
     op_overrides = None  # type: Optional[dict[str, list[DecorateInfo]]]
 
+    # An optional skip mechanism built upon instantiate_device_type_tests(),
+    # designed to facilitate skipping either an entire class or specific test cases
+    # within a class.
+    #
+    # Format:
+    #   test_exclusions = {
+    #       "TestClassA": ["test_a", "test_b"],   # Selective: Skips specific
+    #       "TestClassB": "*",                    # Global: Skips the entire class
+    #   }
+    test_exclusions: ClassVar[dict[str, Collection[str]]]
+
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
 
@@ -345,21 +356,6 @@ class DeviceTypeTestBase(TestCase):
     _tls.precision = TestCase._precision
     _tls.rel_tol = TestCase._rel_tol
 
-    # Optional skip mechanism built on top of instantiate_device_type_tests()
-    # and DeviceTypeTestBase. A class-level configuration field
-    # (test_exclusions) is read during instantiation to skip tests.
-    #
-    # Format:
-    #   test_exclusions = {
-    #       "TestClassA": ["test_a", "test_b"],   # skip specific methods
-    #       "TestClassB": "*",                    # skip entire class
-    #   }
-    #
-    # Behavior:
-    #   - If a class is not listed, it is unaffected by this configuration.
-    #   - ["test_method", ...]: skip only the specified methods.
-    #   - "*": skip all tests from the class.
-    test_exclusions: ClassVar[dict[str, Collection[str]]]
 
     @property
     def precision(self):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -356,7 +356,6 @@ class DeviceTypeTestBase(TestCase):
     _tls.precision = TestCase._precision
     _tls.rel_tol = TestCase._rel_tol
 
-
     @property
     def precision(self):
         return self._tls.precision


### PR DESCRIPTION
Fixes #177253
## Summary
Introduces a mechanism to selectively skip test classes and test methods during device-specific test instantiation, built on top of `instantiate_device_type_tests` and `DeviceTypeTestBase`.

Backends can now declaratively specify which tests to skip without modifying upstream test files.

## Changes
- Adds `skipped_testcases` to `DeviceTypeTestBase`.
- Device-specific test class can define this field to control which test classes or methods are skipped.