### PR TITLE
[fix] FakeTensor dispatch cache breaks storage aliasing for view on zero-element tensors

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4017,7 +4017,7 @@ def _reshape_view_helper(a: TensorLikeType, *shape, allow_copy: bool) -> TensorL
 
     # Special-cases tensors with no elements
     if a.numel() == 0:
-        return as_strided(a, shape, utils.make_contiguous_strides_for(shape))
+        return torch.as_strided(a, shape, utils.make_contiguous_strides_for(shape))
 
     # Special-cases reshaping zero dim tensors
     if a.ndim == 0:


### PR DESCRIPTION
Fixes #159151
## Summary

`_reshape_view_helper` uses `prims.as_strided` for zero-element tensor views, but `prims.as_strided` is not registered as a view op (`is_view=False`). When the FakeTensor dispatch cache serves a cache hit for this op, it creates a new storage instead of preserving the input's storage alias. This causes `CrossRefFakeMode` aliasing checks to fail.
## Reproduction

```python
import torch
from torch._subclasses.fake_utils import CrossRefFakeMode

input1 = torch.randn(0, 8, requires_grad=True)
input2 = torch.randn(0, 8, requires_grad=True)
weight = torch.randn(8, 8, 8, requires_grad=True)
bias = torch.randn(8, requires_grad=True)

with CrossRefFakeMode():
    out = torch.nn.functional.bilinear(input1, input2, weight, bias)
    out.sum().backward()
```
## Root Cause Analysis

### Call chain

```
aten.view.default (dispatch_impl, cache miss)
  → _view_meta (registered fake impl)
    → _reshape_view_helper
      → [line 4020] as_strided(a, shape, strides)   # this is torch._refs.as_strided
        → prims.as_strided.default (dispatch into FakeTensorMode._cached_dispatch_impl)
          → [1st call] cache miss → aten.as_strided.default → correct (storage shared)
          → [2nd call] cache hit  → _output_from_cache_entry → BUG (new storage)
```

### Why the cache hit fails

In `FakeTensorMode._get_output_tensor_from_cache_entry` (`fake_tensor.py` ~line 2123):

```python
if isinstance(func, torch._ops.OpOverload) and func.is_view:
    # For view ops, the storage should be the same as the tensor input.
    view_arg = args[cast(int, entry.view_idx)]
    storage = view_arg.untyped_storage()
    empty.set_(storage, storage_offset, shape, stride)
```

This storage-sharing logic **only fires when `func.is_view == True`**.

```python
>>> torch.ops.aten.as_strided.default.is_view
True
>>> torch.ops.prims.as_strided.default.is_view
False
```

So when `prims.as_strided` hits cache:
- `_make_cache_entry` sets `view_idx = None` (because `is_view=False`)
- `_get_output_tensor_from_cache_entry` skips the storage alias code
- Result gets a **fresh storage**, breaking the view invariant

### Why it only fails on the 2nd backward view call

The FakeTensor dispatch cache is per-`ShapeEnv`. `CrossRefFakeMode.__torch_dispatch__` creates a new `FakeTensorMode(shape_env=ShapeEnv())` per outer op dispatch. During `backward`, the first `aten.view.default` on a zero-element tensor triggers `prims.as_strided` (cache miss → correct). The second `aten.view.default` (same ShapeEnv) triggers `prims.as_strided` again — this time it's a **cache hit** with broken aliasing.

Authored with Claude.