### PR TITLE
Remove deprecated `set_group_info`, `get_group_info` and `enable_symm_mem_for_group`

### DIFF
--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -774,13 +774,6 @@ def _is_nvshmem_available() -> bool: ...
 
 class _SymmetricMemory:
     @staticmethod
-    def set_group_info(
-        group_name: str,
-        rank: int,
-        world_size: int,
-        store: Store,
-    ) -> None: ...
-    @staticmethod
     def empty_strided_p2p(
         size: torch.types._size,
         stride: torch.types._size,

--- a/torch/_inductor/fx_passes/low_contention_collectives.py
+++ b/torch/_inductor/fx_passes/low_contention_collectives.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import logging
+import typing
 
 import torch
 from torch.utils._ordered_set import OrderedSet
-import typing
 
 
 log = logging.getLogger(__name__)

--- a/torch/_inductor/fx_passes/low_contention_collectives.py
+++ b/torch/_inductor/fx_passes/low_contention_collectives.py
@@ -4,6 +4,7 @@ import logging
 
 import torch
 from torch.utils._ordered_set import OrderedSet
+import typing
 
 
 log = logging.getLogger(__name__)
@@ -45,10 +46,12 @@ def replace_collectives_with_low_contention(
 
     # Some group names can't be resolved at compile time — skip them.
     from torch.distributed._symmetric_memory import is_symm_mem_enabled_for_group
+    from torch.distributed.distributed_c10d import GroupName
 
     valid_groups: OrderedSet[str] = OrderedSet()
     for group_name in groups:
-        if is_symm_mem_enabled_for_group(group_name):
+        group_name_ = typing.cast(GroupName, group_name)
+        if is_symm_mem_enabled_for_group(group_name_):
             valid_groups.add(group_name)
 
     # Filter to collectives whose groups we can actually resolve

--- a/torch/_inductor/fx_passes/low_contention_collectives.py
+++ b/torch/_inductor/fx_passes/low_contention_collectives.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 
 import torch
 from torch.utils._ordered_set import OrderedSet
@@ -45,9 +44,11 @@ def replace_collectives_with_low_contention(
         return
 
     # Some group names can't be resolved at compile time — skip them.
+    from torch.distributed._symmetric_memory import is_symm_mem_enabled_for_group
+
     valid_groups: OrderedSet[str] = OrderedSet()
     for group_name in groups:
-        if _enable_symm_mem(group_name):
+        if is_symm_mem_enabled_for_group(group_name):
             valid_groups.add(group_name)
 
     # Filter to collectives whose groups we can actually resolve
@@ -114,25 +115,6 @@ def replace_collectives_with_low_contention(
         skipped_nvlink_contention,
         min_bytes,
     )
-
-
-def _enable_symm_mem(group_name):
-    """Try to enable symmetric memory for a group. Returns True on success."""
-    from torch.distributed._symmetric_memory import (
-        enable_symm_mem_for_group,
-        is_symm_mem_enabled_for_group,
-    )
-
-    if is_symm_mem_enabled_for_group(group_name):
-        return True
-    try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            enable_symm_mem_for_group(group_name)
-        return True
-    except (TypeError, RuntimeError, KeyError) as e:
-        log.debug("LC: cannot enable symm_mem for group %s: %s", group_name, e)  # noqa: G200
-        return False
 
 
 def _replace_collective(node, graph, symm_mem, is_ag, group_name):

--- a/torch/_inductor/fx_passes/low_contention_collectives.py
+++ b/torch/_inductor/fx_passes/low_contention_collectives.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 
 import torch
 from torch.utils._ordered_set import OrderedSet
@@ -45,9 +44,11 @@ def replace_collectives_with_low_contention(
         return
 
     # Some group names can't be resolved at compile time — skip them.
+    from torch.distributed._symmetric_memory import is_symm_mem_enabled_for_group
+
     valid_groups: OrderedSet[str] = OrderedSet()
     for group_name in groups:
-        if _enable_symm_mem(group_name):
+        if is_symm_mem_enabled_for_group(group_name):
             valid_groups.add(group_name)
 
     # Filter to collectives whose groups we can actually resolve
@@ -114,25 +115,6 @@ def replace_collectives_with_low_contention(
         skipped_nvlink_contention,
         min_bytes,
     )
-
-
-def _enable_symm_mem(group_name):
-    """Try to enable symmetric memory for a group. Returns True on success."""
-    from torch.distributed._symmetric_memory import (
-        enable_symm_mem_for_group,
-        is_symm_mem_enabled_for_group,
-    )
-
-    if is_symm_mem_enabled_for_group(group_name):
-        return True
-    try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            enable_symm_mem_for_group(group_name)
-        return True
-    except (TypeError, RuntimeError, KeyError) as e:
-        log.debug("LC: cannot enable symm_mem for group %s: %s", group_name, e)
-        return False
 
 
 def _replace_collective(node, graph, symm_mem, is_ag, group_name):

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1150,7 +1150,6 @@ Example:
   using SymmetricMemory = ::c10d::symmetric_memory::SymmetricMemory;
   py::class_<SymmetricMemory, c10::intrusive_ptr<SymmetricMemory>>(
       module, "_SymmetricMemory")
-      .def_static("set_group_info", &::c10d::symmetric_memory::set_group_info)
       .def_static(
           "empty_strided_p2p",
           ::c10d::symmetric_memory::empty_strided_p2p,

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -121,9 +121,6 @@ class AllocatorMap {
   bool in_use_ = false;
 };
 
-static std::mutex group_info_mutex;
-static std::unordered_map<std::string, GroupInfo> group_info_map{};
-
 // Data structures for tracking persistent allocations
 static std::mutex persistent_alloc_mutex;
 static std::unordered_map<uint64_t, void*> alloc_id_to_dev_ptr{};
@@ -231,29 +228,6 @@ bool has_allocator(c10::DeviceType device_type) {
 c10::intrusive_ptr<SymmetricMemoryAllocator> get_allocator(
     c10::DeviceType device_type) {
   return AllocatorMap::get().get_allocator(device_type);
-}
-
-void set_group_info(
-    const std::string& group_name,
-    int rank,
-    int world_size,
-    c10::intrusive_ptr<Store> store) {
-  std::lock_guard<std::mutex> lock(group_info_mutex);
-  TORCH_CHECK(group_info_map.find(group_name) == group_info_map.end());
-  GroupInfo group_info;
-  group_info.rank = rank;
-  group_info.world_size = world_size;
-  group_info.store = std::move(store);
-  group_info_map.emplace(group_name, std::move(group_info));
-}
-
-GroupInfo& get_group_info(const std::string& group_name) {
-  std::lock_guard<std::mutex> lock(group_info_mutex);
-  TORCH_CHECK(
-      group_info_map.find(group_name) != group_info_map.end(),
-      "get_group_info: no group info associated with the group name ",
-      group_name);
-  return group_info_map[group_name];
 }
 
 at::Tensor empty_strided_p2p(

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp
@@ -133,26 +133,6 @@ C10_EXPORT bool has_allocator(c10::DeviceType device_type);
 C10_EXPORT c10::intrusive_ptr<SymmetricMemoryAllocator> get_allocator(
     c10::DeviceType device_type);
 
-// Set a store for rendezvousing symmetric allocations on a group of devices
-// identified by `group_name`. The concept of groups is logical; users can
-// utilize predefined groups (e.g., a group of device identified by a
-// ProcessGroup) or create custom ones. Note that a SymmetricMemoryAllocator
-// backends might employ a more efficient communication channel for the actual
-// rendezvous process and only use the store for bootstrapping purposes.
-TORCH_API void set_group_info(
-    const std::string& group_name,
-    int rank,
-    int world_size,
-    c10::intrusive_ptr<Store> store);
-
-struct GroupInfo {
-  int rank;
-  int world_size;
-  c10::intrusive_ptr<c10d::Store> store;
-};
-
-C10_EXPORT GroupInfo& get_group_info(const std::string& group_name);
-
 // Identical to empty_strided, but allows symmetric memory access to be
 // established for the allocated tensor via SymmetricMemory::rendezvous(). This
 // function itself is not a collective operation. It invokes

--- a/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp
@@ -317,8 +317,6 @@ bool IntraNodeComm::rendezvous() {
   const std::string name = groupName_.empty()
       ? "IntraNodeComm" + std::to_string(intraNodeCommIdx++)
       : groupName_;
-  set_group_info(
-      name, static_cast<int>(rank_), static_cast<int>(worldSize_), store_);
   auto allocator = get_allocator(c10::DeviceType::CUDA);
   symmetricMemoryPtr_ = allocator->alloc(bufferSize_, deviceIdx_, name);
   symmetricMemory_ = allocator->rendezvous(symmetricMemoryPtr_, std::nullopt);

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -10,47 +10,12 @@ from datetime import timedelta
 from enum import Enum
 from functools import partial
 from typing import Any, Literal
-from typing_extensions import deprecated
 
 import torch
 import torch.distributed._functional_collectives as funcol
 import torch.distributed.distributed_c10d as c10d
 from torch._C._autograd import DeviceType
 from torch._C._distributed_c10d import _SymmetricMemory, Work as _Work
-
-
-_group_name_to_store: dict[str, c10d.Store] = {}
-
-
-@deprecated(
-    "`enable_symm_mem_for_group` is deprecated. There is no need to call this function anymore.",
-    category=FutureWarning,
-)
-def enable_symm_mem_for_group(group_name: c10d.GroupName) -> None:
-    """
-    Enables symmetric memory for a process group.
-
-    Args:
-        group_name (str): the name of the process group.
-    """
-    if group_name in _group_name_to_store:
-        return
-
-    group = c10d._resolve_process_group(group_name)
-    global_ranks = sorted(c10d._world.pg_group_ranks[group].keys())
-    # Different subgroups with the same name should use different stores
-    global_ranks_str = "_".join(map(str, global_ranks))
-    store = c10d.PrefixStore(
-        f"symmetric_memory-{global_ranks_str}",
-        c10d._get_process_group_store(group),
-    )
-    _group_name_to_store[group_name] = store
-    _SymmetricMemory.set_group_info(
-        group_name,
-        group.rank(),
-        group.size(),
-        store,
-    )
 
 
 _is_test_mode: bool = False
@@ -87,7 +52,11 @@ def is_symm_mem_enabled_for_group(group_name: c10d.GroupName) -> bool:
     """
     if _is_test_mode:
         return _mocked_group_names is None or group_name in _mocked_group_names
-    return group_name in _group_name_to_store
+    try:
+        c10d._resolve_process_group(group_name)
+        return True
+    except Exception:
+        return False
 
 
 _group_name_to_workspace_tensor: dict[str, torch.Tensor | None] = {}


### PR DESCRIPTION
The methods `set_group_info`, `get_group_info` and `enable_symm_mem_for_group` have been deprecated (https://github.com/pytorch/pytorch/pull/177700#issuecomment-4078523480). This PR removes these methods and calls to them.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy 