### PR TITLE
MHA: allow fastpath multi-head attention for XPU

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1058,6 +1058,7 @@ def _check_arg_device(x: torch.Tensor | None) -> bool:
         return x.device.type in [
             "cpu",
             "cuda",
+            "xpu",
             torch.utils.backend_registration._privateuse1_backend_name,
         ]
     return True
@@ -1412,7 +1413,7 @@ class MultiheadAttention(Module):
             elif not all(_check_arg_device(x) for x in tensor_args):
                 why_not_fast_path = (
                     "some Tensor argument's device is neither one of "
-                    f"cpu, cuda or {torch.utils.backend_registration._privateuse1_backend_name}"
+                    f"cpu, cuda, xpu or {torch.utils.backend_registration._privateuse1_backend_name}"
                 )
             elif torch.is_grad_enabled() and any(
                 _arg_requires_grad(x) for x in tensor_args


### PR DESCRIPTION
MultiheadAttention fastpath device validation did not recognize XPU in _check_arg_device(). As a result, otherwise eligible XPU inputs were forced onto the slow path and fastpath call expectations could fail in transformer tests.

Fixes:
op_ut,third_party.torch-xpu-ops.test.xpu.test_transformers_xpu.TestTransformersXPU,test_disable_fastpath_xpu
in:
https://github.com/intel/torch-xpu-ops/issues/2529

Also in pytorch tree with PR along with following change:
```
diff --git a/test/test_transformers.py b/test/test_transformers.py
index 5a66e0a5452..d538b39de29 100644
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -5248,7 +5248,7 @@ else:
 if TEST_XPU:
     device_types += ("xpu", )
 
-instantiate_device_type_tests(TestTransformers, globals(), only_for=device_types)
+instantiate_device_type_tests(TestTransformers, globals(), only_for=device_types, allow_xpu=True)
 instantiate_device_type_tests(TestSDPAFailureModes, globals(), only_for=device_types, allow_mps=True)
 instantiate_device_type_tests(TestSDPA, globals(), only_for=device_types, allow_mps=True, allow_xpu=True)
 instantiate_device_type_tests(TestSDPACudaOnly, globals(), only_for=("cuda"))
```

Test:
```
~/pytorch$ PYTORCH_TEST_WITH_SLOW=1 python -m pytest -v test/test_transformers.py::TestTransformersXPU::test_disable_fastpath_xpu
```
is passing:
```
test/test_transformers.py::TestTransformersXPU::test_disable_fastpath_xpu PASSED [0.8449s]                       [100%]

================================================== 1 passed in 6.85s ===================================================
```