### PR TITLE
[BE] Refactor grid_sampler_3d backward to reuse shared backward helpers

### DIFF
--- a/aten/src/ATen/native/mps/kernels/GridSampler.h
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.h
@@ -17,6 +17,7 @@ enum class GridSamplerPadding : int32_t {
 };
 #else
 #include <ATen/native/GridSamplerUtils.h>
+#include <ATen/native/Pool.h>
 using at::native::GridSamplerInterpolation;
 using at::native::GridSamplerPadding;
 #endif
@@ -31,6 +32,26 @@ struct GridSamplerParams {
   ::c10::metal::array<idx_type_t, N> grid_sizes;
   ::c10::metal::array<idx_type_t, N> grid_strides;
   bool align_corners;
+
+#ifndef __METAL_VERSION__
+  GridSamplerParams() = default;
+  GridSamplerParams(
+      const at::TensorBase& output,
+      const at::TensorBase& input,
+      const at::TensorBase& grid,
+      bool align_corners_)
+      : sampler_dims(N - 2), align_corners(align_corners_) {
+    using at::native::safe_downcast;
+    for (unsigned dim = 0; dim < N; dim++) {
+      output_sizes[dim] = safe_downcast<idx_type_t>(output.size(dim));
+      output_strides[dim] = safe_downcast<idx_type_t>(output.stride(dim));
+      input_sizes[dim] = safe_downcast<idx_type_t>(input.size(dim));
+      input_strides[dim] = safe_downcast<idx_type_t>(input.stride(dim));
+      grid_sizes[dim] = safe_downcast<idx_type_t>(grid.size(dim));
+      grid_strides[dim] = safe_downcast<idx_type_t>(grid.stride(dim));
+    }
+  }
+#endif
 };
 
 template <unsigned N = 5, typename idx_type_t = int32_t>

--- a/aten/src/ATen/native/mps/kernels/GridSampler.h
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.h
@@ -1,6 +1,26 @@
 #pragma once
 #include <c10/metal/common.h>
 
+#ifdef __METAL_VERSION__
+// Must match at::native::detail::GridSamplerInterpolation
+enum class GridSamplerInterpolation : int32_t {
+  Bilinear = 0,
+  Nearest = 1,
+  Bicubic = 2,
+};
+
+// Must match at::native::detail::GridSamplerPadding
+enum class GridSamplerPadding : int32_t {
+  Zeros = 0,
+  Border = 1,
+  Reflection = 2,
+};
+#else
+#include <ATen/native/GridSamplerUtils.h>
+using at::native::GridSamplerInterpolation;
+using at::native::GridSamplerPadding;
+#endif
+
 template <unsigned N = 5, typename idx_type_t = int32_t>
 struct GridSamplerParams {
   int32_t sampler_dims;
@@ -19,12 +39,12 @@ struct GridSamplerBackwardParams {
   ::c10::metal::array<idx_type_t, N> grad_output_strides;
   ::c10::metal::array<idx_type_t, N> grad_input_strides;
   idx_type_t grad_grid_sW;
-  int32_t padding_mode;
+  GridSamplerPadding padding_mode;
 };
 
 struct GridSampler3DBackwardParams {
-  int32_t interpolation_mode;
-  int32_t padding_mode;
+  GridSamplerInterpolation interpolation_mode;
+  GridSamplerPadding padding_mode;
   bool align_corners;
   bool compute_grad_input;
   bool compute_grad_grid;

--- a/aten/src/ATen/native/mps/kernels/GridSampler.h
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.h
@@ -34,7 +34,6 @@ struct GridSamplerParams {
   bool align_corners;
 
 #ifndef __METAL_VERSION__
-  GridSamplerParams() = default;
   GridSamplerParams(
       const at::TensorBase& output,
       const at::TensorBase& input,
@@ -59,21 +58,37 @@ struct GridSamplerBackwardParams {
   GridSamplerParams<N, idx_type_t> forward;
   ::c10::metal::array<idx_type_t, N> grad_output_strides;
   ::c10::metal::array<idx_type_t, N> grad_input_strides;
-  idx_type_t grad_grid_sW;
+  ::c10::metal::array<idx_type_t, N> grad_grid_strides;
   GridSamplerPadding padding_mode;
-};
-
-struct GridSampler3DBackwardParams {
   GridSamplerInterpolation interpolation_mode;
-  GridSamplerPadding padding_mode;
-  bool align_corners;
   bool compute_grad_input;
   bool compute_grad_grid;
-  ::c10::metal::array<int32_t, 5> input_sizes;
-  ::c10::metal::array<int32_t, 5> output_sizes;
-  ::c10::metal::array<int32_t, 5> input_strides;
-  ::c10::metal::array<int32_t, 5> grad_input_strides;
-  ::c10::metal::array<int32_t, 5> grad_grid_strides;
-  ::c10::metal::array<int32_t, 5> grid_strides;
-  ::c10::metal::array<int32_t, 5> grad_output_strides;
+
+#ifndef __METAL_VERSION__
+  GridSamplerBackwardParams(
+      const at::TensorBase& grad_output,
+      const at::TensorBase& input,
+      const at::TensorBase& grid,
+      const at::TensorBase& grad_input,
+      const at::TensorBase& grad_grid,
+      bool align_corners,
+      GridSamplerPadding padding_mode_,
+      GridSamplerInterpolation interpolation_mode_)
+      : forward(grad_output, input, grid, align_corners),
+        padding_mode(padding_mode_),
+        interpolation_mode(interpolation_mode_),
+        compute_grad_input(grad_input.defined()),
+        compute_grad_grid(
+            interpolation_mode_ != GridSamplerInterpolation::Nearest) {
+    using at::native::safe_downcast;
+    for (unsigned dim = 0; dim < N; dim++) {
+      grad_output_strides[dim] =
+          safe_downcast<idx_type_t>(grad_output.stride(dim));
+      grad_input_strides[dim] = grad_input.defined()
+          ? safe_downcast<idx_type_t>(grad_input.stride(dim))
+          : 0;
+      grad_grid_strides[dim] = safe_downcast<idx_type_t>(grad_grid.stride(dim));
+    }
+  }
+#endif
 };

--- a/aten/src/ATen/native/mps/kernels/GridSampler.metal
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.metal
@@ -620,351 +620,6 @@ kernel void grid_sampler_3d(
       result;
 }
 
-// Padding mode constants (must match GridSamplerPadding enum)
-constant int32_t kPaddingZeros = 0;
-constant int32_t kPaddingBorder = 1;
-constant int32_t kPaddingReflection = 2;
-
-// Uses opmath_t<T> for intermediate computations to avoid overflow with
-// half/bfloat
-template <typename T>
-T grid_sampler_compute_source_index_set_grad(
-    T coord,
-    int32_t size,
-    int32_t padding_mode,
-    bool align_corners,
-    thread T* grad_in) {
-  using U = opmath_t<T>;
-  U u_coord = static_cast<U>(coord);
-  U u_grad_in = static_cast<U>(*grad_in);
-  U u_size = static_cast<U>(size);
-
-  // Unnormalize
-  if (align_corners) {
-    u_coord = ((u_coord + U(1.0)) / U(2.0)) * (u_size - U(1.0));
-    u_grad_in = (u_size - U(1.0)) / U(2.0);
-  } else {
-    u_coord = ((u_coord + U(1.0)) * u_size - U(1.0)) / U(2.0);
-    u_grad_in = u_size / U(2.0);
-  }
-
-  if (padding_mode == kPaddingBorder) {
-    // Borders are considered out of bounds for gradient calculation
-    // (matching CUDA clip_coordinates_set_grad behavior).
-    U grad_clip = U(1.0);
-    if (u_coord <= U(0.0)) {
-      u_coord = U(0.0);
-      grad_clip = U(0.0);
-    } else if (u_coord >= u_size - U(1.0)) {
-      u_coord = u_size - U(1.0);
-      grad_clip = U(0.0);
-    }
-    u_grad_in = u_grad_in * grad_clip;
-  } else if (padding_mode == kPaddingReflection) {
-    U grad_refl = U(1.0);
-    U twice_low, twice_high;
-    if (align_corners) {
-      twice_low = U(0.0);
-      twice_high = U(2 * (size - 1));
-    } else {
-      twice_low = U(-1.0);
-      twice_high = U(2 * size - 1);
-    }
-
-    if (twice_low != twice_high) {
-      U min_val = twice_low / U(2.0);
-      U span = (twice_high - twice_low) / U(2.0);
-      u_coord = u_coord - min_val;
-
-      if (u_coord < U(0.0)) {
-        u_coord = -u_coord;
-        grad_refl = -grad_refl;
-      }
-
-      U extra = u_coord - span * floor(u_coord / span);
-      int32_t flips = static_cast<int32_t>(floor(u_coord / span));
-
-      if (flips % 2 == 0) {
-        u_coord = extra + min_val;
-      } else {
-        u_coord = span - extra + min_val;
-        grad_refl = -grad_refl;
-      }
-    } else {
-      u_coord = U(0.0);
-    }
-
-    // Clip after reflection (borders out of bounds for gradient)
-    U grad_clip = U(1.0);
-    if (u_coord <= U(0.0)) {
-      u_coord = U(0.0);
-      grad_clip = U(0.0);
-    } else if (u_coord >= u_size - U(1.0)) {
-      u_coord = u_size - U(1.0);
-      grad_clip = U(0.0);
-    }
-    u_grad_in = u_grad_in * grad_refl * grad_clip;
-  }
-
-  coord = static_cast<T>(u_coord);
-  *grad_in = static_cast<T>(u_grad_in);
-  return coord;
-}
-
-inline bool within_bounds_3d(
-    int32_t z,
-    int32_t y,
-    int32_t x,
-    int32_t D,
-    int32_t H,
-    int32_t W) {
-  return z >= 0 && z < D && y >= 0 && y < H && x >= 0 && x < W;
-}
-
-template <typename T>
-kernel void grid_sampler_3d_backward(
-    constant T* grad_output [[buffer(0)]],
-    constant T* input [[buffer(1)]],
-    constant T* grid [[buffer(2)]],
-    device AtomicType_t<T>* grad_input [[buffer(3)]],
-    device T* grad_grid [[buffer(4)]],
-    constant GridSampler3DBackwardParams& params [[buffer(5)]],
-    uint3 thread_index [[thread_position_in_grid]]) {
-  const auto out_w = thread_index.x;
-  const auto out_d_h_combined = thread_index.y;
-  const auto n = thread_index.z;
-
-  const auto out_d = out_d_h_combined / params.output_sizes[3];
-  const auto out_h = out_d_h_combined % params.output_sizes[3];
-
-  if (n >= params.input_sizes[0] || out_d >= params.output_sizes[2] ||
-      out_h >= params.output_sizes[3] || out_w >= params.output_sizes[4]) {
-    return;
-  }
-
-  const auto C = params.input_sizes[1];
-  const auto inp_D = params.input_sizes[2];
-  const auto inp_H = params.input_sizes[3];
-  const auto inp_W = params.input_sizes[4];
-
-  const auto grid_offset = n * params.grid_strides[0] +
-      out_d * params.grid_strides[1] + out_h * params.grid_strides[2] +
-      out_w * params.grid_strides[3];
-
-  const opmath_t<T> grid_x = grid[grid_offset];
-  const opmath_t<T> grid_y = grid[grid_offset + params.grid_strides[4]];
-  const opmath_t<T> grid_z = grid[grid_offset + 2 * params.grid_strides[4]];
-
-  opmath_t<T> gix_mult, giy_mult, giz_mult;
-  opmath_t<T> ix = grid_sampler_compute_source_index_set_grad(
-      grid_x,
-      static_cast<int32_t>(inp_W),
-      params.padding_mode,
-      params.align_corners,
-      &gix_mult);
-  opmath_t<T> iy = grid_sampler_compute_source_index_set_grad(
-      grid_y,
-      static_cast<int32_t>(inp_H),
-      params.padding_mode,
-      params.align_corners,
-      &giy_mult);
-  opmath_t<T> iz = grid_sampler_compute_source_index_set_grad(
-      grid_z,
-      static_cast<int32_t>(inp_D),
-      params.padding_mode,
-      params.align_corners,
-      &giz_mult);
-
-  if (params.interpolation_mode == 0) { // trilinear
-    const int ix_0 = static_cast<int>(floor(ix));
-    const int iy_0 = static_cast<int>(floor(iy));
-    const int iz_0 = static_cast<int>(floor(iz));
-    const opmath_t<T> dx = ix - ix_0;
-    const opmath_t<T> dy = iy - iy_0;
-    const opmath_t<T> dz = iz - iz_0;
-    const opmath_t<T> wx[2] = {1 - dx, dx};
-    const opmath_t<T> wy[2] = {1 - dy, dy};
-    const opmath_t<T> wz[2] = {1 - dz, dz};
-
-    opmath_t<T> gix = 0, giy = 0, giz = 0;
-
-    for (uint32_t c = 0; c < C; c++) {
-      const auto grad_out_offset = n * params.grad_output_strides[0] +
-          c * params.grad_output_strides[1] +
-          out_d * params.grad_output_strides[2] +
-          out_h * params.grad_output_strides[3] +
-          out_w * params.grad_output_strides[4];
-      const opmath_t<T> gOut = grad_output[grad_out_offset];
-      const auto base_grad_input_offset =
-          n * params.grad_input_strides[0] + c * params.grad_input_strides[1];
-      const auto input_base_offset =
-          n * params.input_strides[0] + c * params.input_strides[1];
-
-      for (int i = 0; i < 8; i++) {
-        const int xi = i & 1;
-        const int yi = (i >> 1) & 1;
-        const int zi = (i >> 2) & 1;
-        const int cx = ix_0 + xi;
-        const int cy = iy_0 + yi;
-        const int cz = iz_0 + zi;
-
-        if (within_bounds_3d(
-                cz,
-                cy,
-                cx,
-                static_cast<int32_t>(inp_D),
-                static_cast<int32_t>(inp_H),
-                static_cast<int32_t>(inp_W))) {
-          const opmath_t<T> w = wx[xi] * wy[yi] * wz[zi];
-
-          if (params.compute_grad_input) {
-            AtomicType<T>::atomic_add(
-                grad_input,
-                base_grad_input_offset + cz * params.grad_input_strides[2] +
-                    cy * params.grad_input_strides[3] +
-                    cx * params.grad_input_strides[4],
-                static_cast<T>(w * gOut));
-          }
-
-          if (params.compute_grad_grid) {
-            const opmath_t<T> val = input
-                [input_base_offset + cz * params.input_strides[2] +
-                 cy * params.input_strides[3] + cx * params.input_strides[4]];
-            const opmath_t<T> sign_x = xi ? 1 : -1;
-            const opmath_t<T> sign_y = yi ? 1 : -1;
-            const opmath_t<T> sign_z = zi ? 1 : -1;
-            gix += sign_x * val * wy[yi] * wz[zi] * gOut;
-            giy += sign_y * val * wx[xi] * wz[zi] * gOut;
-            giz += sign_z * val * wx[xi] * wy[yi] * gOut;
-          }
-        }
-      }
-    }
-
-    if (params.compute_grad_grid) {
-      const auto grad_grid_base_offset = n * params.grad_grid_strides[0] +
-          out_d * params.grad_grid_strides[1] +
-          out_h * params.grad_grid_strides[2] +
-          out_w * params.grad_grid_strides[3];
-      grad_grid[grad_grid_base_offset] = static_cast<T>(gix_mult * gix);
-      grad_grid[grad_grid_base_offset + params.grid_strides[4]] =
-          static_cast<T>(giy_mult * giy);
-      grad_grid[grad_grid_base_offset + 2 * params.grid_strides[4]] =
-          static_cast<T>(giz_mult * giz);
-    }
-  } else if (params.compute_grad_input) { // nearest
-    int32_t ix_n = static_cast<int32_t>(rint(ix));
-    int32_t iy_n = static_cast<int32_t>(rint(iy));
-    int32_t iz_n = static_cast<int32_t>(rint(iz));
-
-    if (params.padding_mode == kPaddingBorder) {
-      ix_n = clamp(ix_n, 0, static_cast<int32_t>(inp_W - 1));
-      iy_n = clamp(iy_n, 0, static_cast<int32_t>(inp_H - 1));
-      iz_n = clamp(iz_n, 0, static_cast<int32_t>(inp_D - 1));
-    } else if (params.padding_mode == kPaddingReflection) {
-      if (params.align_corners) {
-        ix_n = static_cast<int32_t>(rint(reflect_coordinates(
-            static_cast<float>(ix_n), 0.0f, 2.0f * (inp_W - 1))));
-        iy_n = static_cast<int32_t>(rint(reflect_coordinates(
-            static_cast<float>(iy_n), 0.0f, 2.0f * (inp_H - 1))));
-        iz_n = static_cast<int32_t>(rint(reflect_coordinates(
-            static_cast<float>(iz_n), 0.0f, 2.0f * (inp_D - 1))));
-      } else {
-        ix_n = static_cast<int32_t>(rint(reflect_coordinates(
-            static_cast<float>(ix_n), -1.0f, 2.0f * inp_W - 1)));
-        iy_n = static_cast<int32_t>(rint(reflect_coordinates(
-            static_cast<float>(iy_n), -1.0f, 2.0f * inp_H - 1)));
-        iz_n = static_cast<int32_t>(rint(reflect_coordinates(
-            static_cast<float>(iz_n), -1.0f, 2.0f * inp_D - 1)));
-      }
-      ix_n = clamp(ix_n, 0, static_cast<int32_t>(inp_W - 1));
-      iy_n = clamp(iy_n, 0, static_cast<int32_t>(inp_H - 1));
-      iz_n = clamp(iz_n, 0, static_cast<int32_t>(inp_D - 1));
-    }
-
-    bool in_bounds = params.padding_mode != kPaddingZeros ||
-        within_bounds_3d(iz_n,
-                         iy_n,
-                         ix_n,
-                         static_cast<int32_t>(inp_D),
-                         static_cast<int32_t>(inp_H),
-                         static_cast<int32_t>(inp_W));
-
-    if (in_bounds) {
-      const auto base_offset = n * params.grad_input_strides[0] +
-          iz_n * params.grad_input_strides[2] +
-          iy_n * params.grad_input_strides[3] +
-          ix_n * params.grad_input_strides[4];
-
-      for (uint32_t c = 0; c < C; c++) {
-        const auto grad_out_offset = n * params.grad_output_strides[0] +
-            c * params.grad_output_strides[1] +
-            out_d * params.grad_output_strides[2] +
-            out_h * params.grad_output_strides[3] +
-            out_w * params.grad_output_strides[4];
-        const opmath_t<T> gOut = grad_output[grad_out_offset];
-        AtomicType<T>::atomic_add(
-            grad_input,
-            base_offset + c * params.grad_input_strides[1],
-            static_cast<T>(gOut));
-      }
-    }
-  }
-}
-
-#define REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PAD, PNAME)      \
-  template [[host_name("grid_sampler_2d_" INAME "_" PNAME "_" #DTYPE)]] \
-  kernel void grid_sampler_2d<INTERP<PAD>, DTYPE>(                      \
-      device DTYPE * output [[buffer(0)]],                              \
-      constant DTYPE * input [[buffer(1)]],                             \
-      constant DTYPE * grid [[buffer(2)]],                              \
-      constant GridSamplerParams<4> & params [[buffer(3)]],             \
-      uint tid [[thread_position_in_grid]]);
-
-#define REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, INTERP, INAME)         \
-  REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PadZeros, "zeros")   \
-  REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PadBorder, "border") \
-  REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PadReflection, "reflection")
-
-#define REGISTER_GRID_SAMPLER_3D(DTYPE, INTERP, INAME, PAD, PNAME)      \
-  template [[host_name("grid_sampler_3d_" INAME "_" PNAME "_" #DTYPE)]] \
-  kernel void grid_sampler_3d<INTERP<PAD>, DTYPE>(                      \
-      device DTYPE * output [[buffer(0)]],                              \
-      constant DTYPE * input [[buffer(1)]],                             \
-      constant DTYPE * grid [[buffer(2)]],                              \
-      constant GridSamplerParams<5> & params [[buffer(3)]],             \
-      uint tid [[thread_position_in_grid]]);
-
-#define REGISTER_GRID_SAMPLER_3D_INTERP(DTYPE, INTERP, INAME)         \
-  REGISTER_GRID_SAMPLER_3D(DTYPE, INTERP, INAME, PadZeros, "zeros")   \
-  REGISTER_GRID_SAMPLER_3D(DTYPE, INTERP, INAME, PadBorder, "border") \
-  REGISTER_GRID_SAMPLER_3D(DTYPE, INTERP, INAME, PadReflection, "reflection")
-
-#define REGISTER_GRID_SAMPLER_BACKWARD(DTYPE)                      \
-  template [[host_name("grid_sampler_3d_backward_" #DTYPE)]]       \
-  kernel void grid_sampler_3d_backward<DTYPE>(                     \
-      constant DTYPE * grad_output [[buffer(0)]],                  \
-      constant DTYPE * input [[buffer(1)]],                        \
-      constant DTYPE * grid [[buffer(2)]],                         \
-      device AtomicType_t<DTYPE> * grad_input [[buffer(3)]],       \
-      device DTYPE * grad_grid [[buffer(4)]],                      \
-      constant GridSampler3DBackwardParams & params [[buffer(5)]], \
-      uint3 thread_index [[thread_position_in_grid]]);
-
-#define REGISTER_GRID_SAMPLER_OPS(DTYPE)                         \
-  REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, Bilinear2D, "bilinear") \
-  REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, Nearest2D, "nearest")   \
-  REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, Bicubic2D, "bicubic")   \
-  REGISTER_GRID_SAMPLER_3D_INTERP(DTYPE, Bilinear3D, "bilinear") \
-  REGISTER_GRID_SAMPLER_3D_INTERP(DTYPE, Nearest3D, "nearest")   \
-  REGISTER_GRID_SAMPLER_BACKWARD(DTYPE)
-
-REGISTER_GRID_SAMPLER_OPS(float);
-REGISTER_GRID_SAMPLER_OPS(half);
-REGISTER_GRID_SAMPLER_OPS(bfloat);
-
-// ========== Backward kernels ==========
-
 // Each _set_grad function returns float2{coord, grad} where grad is
 // d(output_coord)/d(input_coord), used to chain-rule through the
 // coordinate transform in the backward pass.
@@ -1081,6 +736,250 @@ static float compute_source(
       return PadZeros::compute_source(coord, size, align_corners);
   }
 }
+
+inline bool within_bounds_3d(
+    int32_t z,
+    int32_t y,
+    int32_t x,
+    int32_t D,
+    int32_t H,
+    int32_t W) {
+  return z >= 0 && z < D && y >= 0 && y < H && x >= 0 && x < W;
+}
+
+template <typename T>
+kernel void grid_sampler_3d_backward(
+    constant T* grad_output [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant T* grid [[buffer(2)]],
+    device AtomicType_t<T>* grad_input [[buffer(3)]],
+    device T* grad_grid [[buffer(4)]],
+    constant GridSampler3DBackwardParams& params [[buffer(5)]],
+    uint3 thread_index [[thread_position_in_grid]]) {
+  const int32_t out_w = thread_index.x;
+  const int32_t out_d_h_combined = thread_index.y;
+  const int32_t n = thread_index.z;
+
+  const int32_t out_d = out_d_h_combined / params.output_sizes[3];
+  const int32_t out_h = out_d_h_combined % params.output_sizes[3];
+
+  if (n >= params.input_sizes[0] || out_d >= params.output_sizes[2] ||
+      out_h >= params.output_sizes[3] || out_w >= params.output_sizes[4]) {
+    return;
+  }
+
+  const auto C = params.input_sizes[1];
+  const auto inp_D = params.input_sizes[2];
+  const auto inp_H = params.input_sizes[3];
+  const auto inp_W = params.input_sizes[4];
+
+  const auto grid_offset = n * params.grid_strides[0] +
+      out_d * params.grid_strides[1] + out_h * params.grid_strides[2] +
+      out_w * params.grid_strides[3];
+
+  const float grid_x = grid[grid_offset];
+  const float grid_y = grid[grid_offset + params.grid_strides[4]];
+  const float grid_z = grid[grid_offset + 2 * params.grid_strides[4]];
+
+  float2 ix_grad = compute_source_index_set_grad(
+      grid_x,
+      static_cast<int32_t>(inp_W),
+      params.align_corners,
+      params.padding_mode);
+  float2 iy_grad = compute_source_index_set_grad(
+      grid_y,
+      static_cast<int32_t>(inp_H),
+      params.align_corners,
+      params.padding_mode);
+  float2 iz_grad = compute_source_index_set_grad(
+      grid_z,
+      static_cast<int32_t>(inp_D),
+      params.align_corners,
+      params.padding_mode);
+  float ix = ix_grad.x, gix_mult = ix_grad.y;
+  float iy = iy_grad.x, giy_mult = iy_grad.y;
+  float iz = iz_grad.x, giz_mult = iz_grad.y;
+
+  if (params.interpolation_mode == 0) { // trilinear
+    const int ix_0 = static_cast<int>(floor(ix));
+    const int iy_0 = static_cast<int>(floor(iy));
+    const int iz_0 = static_cast<int>(floor(iz));
+    const float dx = ix - ix_0;
+    const float dy = iy - iy_0;
+    const float dz = iz - iz_0;
+    const float wx[2] = {1 - dx, dx};
+    const float wy[2] = {1 - dy, dy};
+    const float wz[2] = {1 - dz, dz};
+
+    float gix = 0, giy = 0, giz = 0;
+
+    for (int32_t c = 0; c < C; c++) {
+      const auto grad_out_offset = n * params.grad_output_strides[0] +
+          c * params.grad_output_strides[1] +
+          out_d * params.grad_output_strides[2] +
+          out_h * params.grad_output_strides[3] +
+          out_w * params.grad_output_strides[4];
+      const float gOut = grad_output[grad_out_offset];
+      const auto base_grad_input_offset =
+          n * params.grad_input_strides[0] + c * params.grad_input_strides[1];
+      const auto input_base_offset =
+          n * params.input_strides[0] + c * params.input_strides[1];
+
+      for (int i = 0; i < 8; i++) {
+        const int xi = i & 1;
+        const int yi = (i >> 1) & 1;
+        const int zi = (i >> 2) & 1;
+        const int cx = ix_0 + xi;
+        const int cy = iy_0 + yi;
+        const int cz = iz_0 + zi;
+
+        if (within_bounds_3d(
+                cz,
+                cy,
+                cx,
+                static_cast<int32_t>(inp_D),
+                static_cast<int32_t>(inp_H),
+                static_cast<int32_t>(inp_W))) {
+          const float w = wx[xi] * wy[yi] * wz[zi];
+
+          if (params.compute_grad_input) {
+            AtomicType<T>::atomic_add(
+                grad_input,
+                base_grad_input_offset + cz * params.grad_input_strides[2] +
+                    cy * params.grad_input_strides[3] +
+                    cx * params.grad_input_strides[4],
+                static_cast<T>(w * gOut));
+          }
+
+          if (params.compute_grad_grid) {
+            const float val = input
+                [input_base_offset + cz * params.input_strides[2] +
+                 cy * params.input_strides[3] + cx * params.input_strides[4]];
+            const float sign_x = xi ? 1 : -1;
+            const float sign_y = yi ? 1 : -1;
+            const float sign_z = zi ? 1 : -1;
+            gix += sign_x * val * wy[yi] * wz[zi] * gOut;
+            giy += sign_y * val * wx[xi] * wz[zi] * gOut;
+            giz += sign_z * val * wx[xi] * wy[yi] * gOut;
+          }
+        }
+      }
+    }
+
+    if (params.compute_grad_grid) {
+      const auto grad_grid_base_offset = n * params.grad_grid_strides[0] +
+          out_d * params.grad_grid_strides[1] +
+          out_h * params.grad_grid_strides[2] +
+          out_w * params.grad_grid_strides[3];
+      grad_grid[grad_grid_base_offset] = static_cast<T>(gix_mult * gix);
+      grad_grid[grad_grid_base_offset + params.grid_strides[4]] =
+          static_cast<T>(giy_mult * giy);
+      grad_grid[grad_grid_base_offset + 2 * params.grid_strides[4]] =
+          static_cast<T>(giz_mult * giz);
+    }
+  } else if (params.compute_grad_input) { // nearest
+    float src_x = compute_source(
+        grid_x,
+        static_cast<int32_t>(inp_W),
+        params.align_corners,
+        params.padding_mode);
+    float src_y = compute_source(
+        grid_y,
+        static_cast<int32_t>(inp_H),
+        params.align_corners,
+        params.padding_mode);
+    float src_z = compute_source(
+        grid_z,
+        static_cast<int32_t>(inp_D),
+        params.align_corners,
+        params.padding_mode);
+
+    int32_t ix_n = static_cast<int32_t>(rint(src_x));
+    int32_t iy_n = static_cast<int32_t>(rint(src_y));
+    int32_t iz_n = static_cast<int32_t>(rint(src_z));
+
+    bool in_bounds = within_bounds_3d(
+        iz_n,
+        iy_n,
+        ix_n,
+        static_cast<int32_t>(inp_D),
+        static_cast<int32_t>(inp_H),
+        static_cast<int32_t>(inp_W));
+
+    if (in_bounds) {
+      const auto base_offset = n * params.grad_input_strides[0] +
+          iz_n * params.grad_input_strides[2] +
+          iy_n * params.grad_input_strides[3] +
+          ix_n * params.grad_input_strides[4];
+
+      for (int32_t c = 0; c < C; c++) {
+        const auto grad_out_offset = n * params.grad_output_strides[0] +
+            c * params.grad_output_strides[1] +
+            out_d * params.grad_output_strides[2] +
+            out_h * params.grad_output_strides[3] +
+            out_w * params.grad_output_strides[4];
+        const float gOut = grad_output[grad_out_offset];
+        AtomicType<T>::atomic_add(
+            grad_input,
+            base_offset + c * params.grad_input_strides[1],
+            static_cast<T>(gOut));
+      }
+    }
+  }
+}
+
+#define REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PAD, PNAME)      \
+  template [[host_name("grid_sampler_2d_" INAME "_" PNAME "_" #DTYPE)]] \
+  kernel void grid_sampler_2d<INTERP<PAD>, DTYPE>(                      \
+      device DTYPE * output [[buffer(0)]],                              \
+      constant DTYPE * input [[buffer(1)]],                             \
+      constant DTYPE * grid [[buffer(2)]],                              \
+      constant GridSamplerParams<4> & params [[buffer(3)]],             \
+      uint tid [[thread_position_in_grid]]);
+
+#define REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, INTERP, INAME)         \
+  REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PadZeros, "zeros")   \
+  REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PadBorder, "border") \
+  REGISTER_GRID_SAMPLER_2D(DTYPE, INTERP, INAME, PadReflection, "reflection")
+
+#define REGISTER_GRID_SAMPLER_3D(DTYPE, INTERP, INAME, PAD, PNAME)      \
+  template [[host_name("grid_sampler_3d_" INAME "_" PNAME "_" #DTYPE)]] \
+  kernel void grid_sampler_3d<INTERP<PAD>, DTYPE>(                      \
+      device DTYPE * output [[buffer(0)]],                              \
+      constant DTYPE * input [[buffer(1)]],                             \
+      constant DTYPE * grid [[buffer(2)]],                              \
+      constant GridSamplerParams<5> & params [[buffer(3)]],             \
+      uint tid [[thread_position_in_grid]]);
+
+#define REGISTER_GRID_SAMPLER_3D_INTERP(DTYPE, INTERP, INAME)         \
+  REGISTER_GRID_SAMPLER_3D(DTYPE, INTERP, INAME, PadZeros, "zeros")   \
+  REGISTER_GRID_SAMPLER_3D(DTYPE, INTERP, INAME, PadBorder, "border") \
+  REGISTER_GRID_SAMPLER_3D(DTYPE, INTERP, INAME, PadReflection, "reflection")
+
+#define REGISTER_GRID_SAMPLER_BACKWARD(DTYPE)                      \
+  template [[host_name("grid_sampler_3d_backward_" #DTYPE)]]       \
+  kernel void grid_sampler_3d_backward<DTYPE>(                     \
+      constant DTYPE * grad_output [[buffer(0)]],                  \
+      constant DTYPE * input [[buffer(1)]],                        \
+      constant DTYPE * grid [[buffer(2)]],                         \
+      device AtomicType_t<DTYPE> * grad_input [[buffer(3)]],       \
+      device DTYPE * grad_grid [[buffer(4)]],                      \
+      constant GridSampler3DBackwardParams & params [[buffer(5)]], \
+      uint3 thread_index [[thread_position_in_grid]]);
+
+#define REGISTER_GRID_SAMPLER_OPS(DTYPE)                         \
+  REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, Bilinear2D, "bilinear") \
+  REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, Nearest2D, "nearest")   \
+  REGISTER_GRID_SAMPLER_2D_INTERP(DTYPE, Bicubic2D, "bicubic")   \
+  REGISTER_GRID_SAMPLER_3D_INTERP(DTYPE, Bilinear3D, "bilinear") \
+  REGISTER_GRID_SAMPLER_3D_INTERP(DTYPE, Nearest3D, "nearest")   \
+  REGISTER_GRID_SAMPLER_BACKWARD(DTYPE)
+
+REGISTER_GRID_SAMPLER_OPS(float);
+REGISTER_GRID_SAMPLER_OPS(half);
+REGISTER_GRID_SAMPLER_OPS(bfloat);
+
+// ========== 2D Backward kernels ==========
 
 static bool within_bounds_2d(int2 pos, int2 size) {
   return pos.x >= 0 && pos.x < size.x && pos.y >= 0 && pos.y < size.y;

--- a/aten/src/ATen/native/mps/kernels/GridSampler.metal
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.metal
@@ -708,12 +708,12 @@ static float2 compute_source_index_set_grad(
     float coord,
     int32_t size,
     bool align_corners,
-    int32_t padding_mode) {
+    GridSamplerPadding padding_mode) {
   switch (padding_mode) {
-    case 1:
+    case GridSamplerPadding::Border:
       return compute_source_index_set_grad<PadBorder>(
           coord, size, align_corners);
-    case 2:
+    case GridSamplerPadding::Reflection:
       return compute_source_index_set_grad<PadReflection>(
           coord, size, align_corners);
     default:
@@ -726,11 +726,11 @@ static float compute_source(
     float coord,
     int32_t size,
     bool align_corners,
-    int32_t padding_mode) {
+    GridSamplerPadding padding_mode) {
   switch (padding_mode) {
-    case 1:
+    case GridSamplerPadding::Border:
       return PadBorder::compute_source(coord, size, align_corners);
-    case 2:
+    case GridSamplerPadding::Reflection:
       return PadReflection::compute_source(coord, size, align_corners);
     default:
       return PadZeros::compute_source(coord, size, align_corners);
@@ -800,7 +800,7 @@ kernel void grid_sampler_3d_backward(
   float iy = iy_grad.x, giy_mult = iy_grad.y;
   float iz = iz_grad.x, giz_mult = iz_grad.y;
 
-  if (params.interpolation_mode == 0) { // trilinear
+  if (params.interpolation_mode == GridSamplerInterpolation::Bilinear) {
     const int ix_0 = static_cast<int>(floor(ix));
     const int iy_0 = static_cast<int>(floor(iy));
     const int iz_0 = static_cast<int>(floor(iz));

--- a/aten/src/ATen/native/mps/kernels/GridSampler.metal
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.metal
@@ -754,47 +754,50 @@ kernel void grid_sampler_3d_backward(
     constant T* grid [[buffer(2)]],
     device AtomicType_t<T>* grad_input [[buffer(3)]],
     device T* grad_grid [[buffer(4)]],
-    constant GridSampler3DBackwardParams& params [[buffer(5)]],
+    constant GridSamplerBackwardParams<5>& params [[buffer(5)]],
     uint3 thread_index [[thread_position_in_grid]]) {
   const int32_t out_w = thread_index.x;
   const int32_t out_d_h_combined = thread_index.y;
   const int32_t n = thread_index.z;
 
-  const int32_t out_d = out_d_h_combined / params.output_sizes[3];
-  const int32_t out_h = out_d_h_combined % params.output_sizes[3];
+  const int32_t out_d = out_d_h_combined / params.forward.output_sizes[3];
+  const int32_t out_h = out_d_h_combined % params.forward.output_sizes[3];
 
-  if (n >= params.input_sizes[0] || out_d >= params.output_sizes[2] ||
-      out_h >= params.output_sizes[3] || out_w >= params.output_sizes[4]) {
+  if (n >= params.forward.input_sizes[0] ||
+      out_d >= params.forward.output_sizes[2] ||
+      out_h >= params.forward.output_sizes[3] ||
+      out_w >= params.forward.output_sizes[4]) {
     return;
   }
 
-  const auto C = params.input_sizes[1];
-  const auto inp_D = params.input_sizes[2];
-  const auto inp_H = params.input_sizes[3];
-  const auto inp_W = params.input_sizes[4];
+  const auto C = params.forward.input_sizes[1];
+  const auto inp_D = params.forward.input_sizes[2];
+  const auto inp_H = params.forward.input_sizes[3];
+  const auto inp_W = params.forward.input_sizes[4];
 
-  const auto grid_offset = n * params.grid_strides[0] +
-      out_d * params.grid_strides[1] + out_h * params.grid_strides[2] +
-      out_w * params.grid_strides[3];
+  const auto grid_offset = n * params.forward.grid_strides[0] +
+      out_d * params.forward.grid_strides[1] +
+      out_h * params.forward.grid_strides[2] +
+      out_w * params.forward.grid_strides[3];
 
   const float grid_x = grid[grid_offset];
-  const float grid_y = grid[grid_offset + params.grid_strides[4]];
-  const float grid_z = grid[grid_offset + 2 * params.grid_strides[4]];
+  const float grid_y = grid[grid_offset + params.forward.grid_strides[4]];
+  const float grid_z = grid[grid_offset + 2 * params.forward.grid_strides[4]];
 
   float2 ix_grad = compute_source_index_set_grad(
       grid_x,
       static_cast<int32_t>(inp_W),
-      params.align_corners,
+      params.forward.align_corners,
       params.padding_mode);
   float2 iy_grad = compute_source_index_set_grad(
       grid_y,
       static_cast<int32_t>(inp_H),
-      params.align_corners,
+      params.forward.align_corners,
       params.padding_mode);
   float2 iz_grad = compute_source_index_set_grad(
       grid_z,
       static_cast<int32_t>(inp_D),
-      params.align_corners,
+      params.forward.align_corners,
       params.padding_mode);
   float ix = ix_grad.x, gix_mult = ix_grad.y;
   float iy = iy_grad.x, giy_mult = iy_grad.y;
@@ -822,8 +825,8 @@ kernel void grid_sampler_3d_backward(
       const float gOut = grad_output[grad_out_offset];
       const auto base_grad_input_offset =
           n * params.grad_input_strides[0] + c * params.grad_input_strides[1];
-      const auto input_base_offset =
-          n * params.input_strides[0] + c * params.input_strides[1];
+      const auto input_base_offset = n * params.forward.input_strides[0] +
+          c * params.forward.input_strides[1];
 
       for (int i = 0; i < 8; i++) {
         const int xi = i & 1;
@@ -853,8 +856,9 @@ kernel void grid_sampler_3d_backward(
 
           if (params.compute_grad_grid) {
             const float val = input
-                [input_base_offset + cz * params.input_strides[2] +
-                 cy * params.input_strides[3] + cx * params.input_strides[4]];
+                [input_base_offset + cz * params.forward.input_strides[2] +
+                 cy * params.forward.input_strides[3] +
+                 cx * params.forward.input_strides[4]];
             const float sign_x = xi ? 1 : -1;
             const float sign_y = yi ? 1 : -1;
             const float sign_z = zi ? 1 : -1;
@@ -872,26 +876,26 @@ kernel void grid_sampler_3d_backward(
           out_h * params.grad_grid_strides[2] +
           out_w * params.grad_grid_strides[3];
       grad_grid[grad_grid_base_offset] = static_cast<T>(gix_mult * gix);
-      grad_grid[grad_grid_base_offset + params.grid_strides[4]] =
+      grad_grid[grad_grid_base_offset + params.forward.grid_strides[4]] =
           static_cast<T>(giy_mult * giy);
-      grad_grid[grad_grid_base_offset + 2 * params.grid_strides[4]] =
+      grad_grid[grad_grid_base_offset + 2 * params.forward.grid_strides[4]] =
           static_cast<T>(giz_mult * giz);
     }
   } else if (params.compute_grad_input) { // nearest
     float src_x = compute_source(
         grid_x,
         static_cast<int32_t>(inp_W),
-        params.align_corners,
+        params.forward.align_corners,
         params.padding_mode);
     float src_y = compute_source(
         grid_y,
         static_cast<int32_t>(inp_H),
-        params.align_corners,
+        params.forward.align_corners,
         params.padding_mode);
     float src_z = compute_source(
         grid_z,
         static_cast<int32_t>(inp_D),
-        params.align_corners,
+        params.forward.align_corners,
         params.padding_mode);
 
     int32_t ix_n = static_cast<int32_t>(rint(src_x));
@@ -956,15 +960,15 @@ kernel void grid_sampler_3d_backward(
   REGISTER_GRID_SAMPLER_3D(DTYPE, INTERP, INAME, PadBorder, "border") \
   REGISTER_GRID_SAMPLER_3D(DTYPE, INTERP, INAME, PadReflection, "reflection")
 
-#define REGISTER_GRID_SAMPLER_BACKWARD(DTYPE)                      \
-  template [[host_name("grid_sampler_3d_backward_" #DTYPE)]]       \
-  kernel void grid_sampler_3d_backward<DTYPE>(                     \
-      constant DTYPE * grad_output [[buffer(0)]],                  \
-      constant DTYPE * input [[buffer(1)]],                        \
-      constant DTYPE * grid [[buffer(2)]],                         \
-      device AtomicType_t<DTYPE> * grad_input [[buffer(3)]],       \
-      device DTYPE * grad_grid [[buffer(4)]],                      \
-      constant GridSampler3DBackwardParams & params [[buffer(5)]], \
+#define REGISTER_GRID_SAMPLER_BACKWARD(DTYPE)                       \
+  template [[host_name("grid_sampler_3d_backward_" #DTYPE)]]        \
+  kernel void grid_sampler_3d_backward<DTYPE>(                      \
+      constant DTYPE * grad_output [[buffer(0)]],                   \
+      constant DTYPE * input [[buffer(1)]],                         \
+      constant DTYPE * grid [[buffer(2)]],                          \
+      device AtomicType_t<DTYPE> * grad_input [[buffer(3)]],        \
+      device DTYPE * grad_grid [[buffer(4)]],                       \
+      constant GridSamplerBackwardParams<5> & params [[buffer(5)]], \
       uint3 thread_index [[thread_position_in_grid]]);
 
 #define REGISTER_GRID_SAMPLER_OPS(DTYPE)                         \
@@ -1179,7 +1183,7 @@ kernel void grid_sampler_2d_backward_bilinear_grid(
   auto gOut_sC = params.grad_output_strides[1];
   auto gOut_sH = params.grad_output_strides[2];
   auto gOut_sW = params.grad_output_strides[3];
-  auto gGrid_sW = params.grad_grid_sW;
+  auto gGrid_sW = params.grad_grid_strides[2];
 
   // .x = source index, .y = gradient multiplier from coordinate transform
   float2 ix = compute_source_index_set_grad(
@@ -1352,7 +1356,7 @@ kernel void grid_sampler_2d_backward_bicubic_grid(
   auto gOut_sC = params.grad_output_strides[1];
   auto gOut_sH = params.grad_output_strides[2];
   auto gOut_sW = params.grad_output_strides[3];
-  auto gGrid_sW = params.grad_grid_sW;
+  auto gGrid_sW = params.grad_grid_strides[2];
   auto align_corners = params.forward.align_corners;
 
   float2 ix = grid_sampler_unnormalize_set_grad(p.x, inp_size.x, align_corners);

--- a/aten/src/ATen/native/mps/kernels/GridSampler.metal
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.metal
@@ -891,7 +891,8 @@ kernel void grid_sampler_3d_backward(
     int32_t iy_n = static_cast<int32_t>(rint(src_y));
     int32_t iz_n = static_cast<int32_t>(rint(src_z));
 
-    bool in_bounds = within_bounds(int3(ix_n, iy_n, iz_n), int3(inp_W, inp_H, inp_D));
+    bool in_bounds =
+        within_bounds(int3(ix_n, iy_n, iz_n), int3(inp_W, inp_H, inp_D));
 
     if (in_bounds) {
       const auto base_offset = n * params.grad_input_strides[0] +
@@ -967,7 +968,6 @@ REGISTER_GRID_SAMPLER_OPS(half);
 REGISTER_GRID_SAMPLER_OPS(bfloat);
 
 // ========== 2D Backward kernels ==========
-
 
 // Atomic safe add for grad_input
 template <typename T>

--- a/aten/src/ATen/native/mps/kernels/GridSampler.metal
+++ b/aten/src/ATen/native/mps/kernels/GridSampler.metal
@@ -716,7 +716,7 @@ static float2 compute_source_index_set_grad(
     case GridSamplerPadding::Reflection:
       return compute_source_index_set_grad<PadReflection>(
           coord, size, align_corners);
-    default:
+    case GridSamplerPadding::Zeros:
       return compute_source_index_set_grad<PadZeros>(
           coord, size, align_corners);
   }
@@ -732,19 +732,14 @@ static float compute_source(
       return PadBorder::compute_source(coord, size, align_corners);
     case GridSamplerPadding::Reflection:
       return PadReflection::compute_source(coord, size, align_corners);
-    default:
+    case GridSamplerPadding::Zeros:
       return PadZeros::compute_source(coord, size, align_corners);
   }
 }
 
-inline bool within_bounds_3d(
-    int32_t z,
-    int32_t y,
-    int32_t x,
-    int32_t D,
-    int32_t H,
-    int32_t W) {
-  return z >= 0 && z < D && y >= 0 && y < H && x >= 0 && x < W;
+template <typename T>
+static bool within_bounds(T pos, T size) {
+  return all(pos >= 0 & pos < size);
 }
 
 template <typename T>
@@ -836,13 +831,7 @@ kernel void grid_sampler_3d_backward(
         const int cy = iy_0 + yi;
         const int cz = iz_0 + zi;
 
-        if (within_bounds_3d(
-                cz,
-                cy,
-                cx,
-                static_cast<int32_t>(inp_D),
-                static_cast<int32_t>(inp_H),
-                static_cast<int32_t>(inp_W))) {
+        if (within_bounds(int3(cx, cy, cz), int3(inp_W, inp_H, inp_D))) {
           const float w = wx[xi] * wy[yi] * wz[zi];
 
           if (params.compute_grad_input) {
@@ -902,13 +891,7 @@ kernel void grid_sampler_3d_backward(
     int32_t iy_n = static_cast<int32_t>(rint(src_y));
     int32_t iz_n = static_cast<int32_t>(rint(src_z));
 
-    bool in_bounds = within_bounds_3d(
-        iz_n,
-        iy_n,
-        ix_n,
-        static_cast<int32_t>(inp_D),
-        static_cast<int32_t>(inp_H),
-        static_cast<int32_t>(inp_W));
+    bool in_bounds = within_bounds(int3(ix_n, iy_n, iz_n), int3(inp_W, inp_H, inp_D));
 
     if (in_bounds) {
       const auto base_offset = n * params.grad_input_strides[0] +
@@ -985,9 +968,6 @@ REGISTER_GRID_SAMPLER_OPS(bfloat);
 
 // ========== 2D Backward kernels ==========
 
-static bool within_bounds_2d(int2 pos, int2 size) {
-  return pos.x >= 0 && pos.x < size.x && pos.y >= 0 && pos.y < size.y;
-}
 
 // Atomic safe add for grad_input
 template <typename T>
@@ -998,7 +978,7 @@ static void safe_add_2d_atomic(
     int2 size,
     opmath_t<T> delta,
     long NC_offset) {
-  if (within_bounds_2d(pos, size)) {
+  if (within_bounds(pos, size)) {
     AtomicType<T>::atomic_add(
         data,
         NC_offset + pos.y * stride.y + pos.x * stride.x,
@@ -1025,7 +1005,7 @@ static opmath_t<T> get_value_bounded_backward(
     int2 stride,
     bool align_corners) {
   int2 pos = apply_padding_2d<Pad>(x, y, size, align_corners);
-  if (within_bounds_2d(pos, size)) {
+  if (within_bounds(pos, size)) {
     return static_cast<opmath_t<T>>(data[pos.y * stride.y + pos.x * stride.x]);
   }
   return 0;
@@ -1203,25 +1183,25 @@ kernel void grid_sampler_2d_backward_bilinear_grid(
        ++c, inp_ptr_NC += inp_sC, gOut_ptr_NCHW += gOut_sC) {
     opmath_t<T> gOut = static_cast<opmath_t<T>>(*gOut_ptr_NCHW);
 
-    if (within_bounds_2d({ix_nw, iy_nw}, inp_size)) {
+    if (within_bounds({ix_nw, iy_nw}, inp_size)) {
       opmath_t<T> nw_val =
           inp_ptr_NC[iy_nw * inp_stride.y + ix_nw * inp_stride.x];
       gix -= nw_val * (iy_nw + 1 - iy.x) * gOut;
       giy -= nw_val * (ix_nw + 1 - ix.x) * gOut;
     }
-    if (within_bounds_2d({ix_nw + 1, iy_nw}, inp_size)) {
+    if (within_bounds({ix_nw + 1, iy_nw}, inp_size)) {
       opmath_t<T> ne_val =
           inp_ptr_NC[iy_nw * inp_stride.y + (ix_nw + 1) * inp_stride.x];
       gix += ne_val * (iy_nw + 1 - iy.x) * gOut;
       giy -= ne_val * (ix.x - ix_nw) * gOut;
     }
-    if (within_bounds_2d({ix_nw, iy_nw + 1}, inp_size)) {
+    if (within_bounds({ix_nw, iy_nw + 1}, inp_size)) {
       opmath_t<T> sw_val =
           inp_ptr_NC[(iy_nw + 1) * inp_stride.y + ix_nw * inp_stride.x];
       gix -= sw_val * (iy.x - iy_nw) * gOut;
       giy += sw_val * (ix_nw + 1 - ix.x) * gOut;
     }
-    if (within_bounds_2d({ix_nw + 1, iy_nw + 1}, inp_size)) {
+    if (within_bounds({ix_nw + 1, iy_nw + 1}, inp_size)) {
       opmath_t<T> se_val =
           inp_ptr_NC[(iy_nw + 1) * inp_stride.y + (ix_nw + 1) * inp_stride.x];
       gix += se_val * (iy.x - iy_nw) * gOut;

--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -237,26 +237,8 @@ std::tuple<Tensor, Tensor> grid_sampler_2d_backward_mps(const Tensor& grad_outpu
     return std::make_tuple(grad_input, grad_grid);
   }
 
-  GridSamplerBackwardParams<4> params;
-  params.forward.sampler_dims = 2;
-  params.forward.align_corners = align_corners;
-
-  // Forward output shape is [N, C, out_H, out_W]
-  params.forward.output_sizes[0] = safe_downcast<int32_t, int64_t>(N);
-  params.forward.output_sizes[1] = safe_downcast<int32_t, int64_t>(input.size(1));
-  params.forward.output_sizes[2] = safe_downcast<int32_t, int64_t>(out_H);
-  params.forward.output_sizes[3] = safe_downcast<int32_t, int64_t>(out_W);
-
-  for (const auto dim : c10::irange(input.dim())) {
-    params.forward.input_sizes[dim] = safe_downcast<int32_t, int64_t>(input.size(dim));
-    params.forward.input_strides[dim] = safe_downcast<int32_t, int64_t>(input.stride(dim));
-    params.forward.grid_sizes[dim] = safe_downcast<int32_t, int64_t>(grid.size(dim));
-    params.forward.grid_strides[dim] = safe_downcast<int32_t, int64_t>(grid.stride(dim));
-    params.grad_output_strides[dim] = safe_downcast<int32_t, int64_t>(grad_output.stride(dim));
-    params.grad_input_strides[dim] = input_requires_grad ? safe_downcast<int32_t, int64_t>(grad_input.stride(dim)) : 0;
-  }
-  params.grad_grid_sW = safe_downcast<int32_t, int64_t>(grad_grid.stride(2));
-  params.padding_mode = padding_mode;
+  GridSamplerBackwardParams<4> params(
+      grad_output, input, grid, grad_input, grad_grid, align_corners, padding_mode, interpolation_mode);
 
   using namespace mps;
   auto interp_str = mps::interp_to_string(interpolation_mode);
@@ -337,10 +319,6 @@ std::tuple<Tensor, Tensor> grid_sampler_3d_backward_mps(const Tensor& grad_outpu
   const auto& grad_output_contiguous = grad_output.contiguous();
 
   auto N = input_contiguous.size(0);
-  auto C = input_contiguous.size(1);
-  auto in_D = input_contiguous.size(2);
-  auto in_H = input_contiguous.size(3);
-  auto in_W = input_contiguous.size(4);
   auto out_D = grid_contiguous.size(1);
   auto out_H = grid_contiguous.size(2);
   auto out_W = grid_contiguous.size(3);
@@ -357,29 +335,14 @@ std::tuple<Tensor, Tensor> grid_sampler_3d_backward_mps(const Tensor& grad_outpu
   // queries below remain in range.
   auto grad_input_buf = run_grad_input ? grad_input : at::zeros({1, 1, 1, 1, 1}, input.options());
 
-  GridSampler3DBackwardParams params;
-  params.interpolation_mode = interp_mode;
-  params.padding_mode = pad_mode;
-  params.align_corners = align_corners;
-  params.compute_grad_input = run_grad_input;
-  params.compute_grad_grid = run_grad_grid;
-  params.input_sizes = {safe_downcast<int32_t, int64_t>(N),
-                        safe_downcast<int32_t, int64_t>(C),
-                        safe_downcast<int32_t, int64_t>(in_D),
-                        safe_downcast<int32_t, int64_t>(in_H),
-                        safe_downcast<int32_t, int64_t>(in_W)};
-  params.output_sizes = {safe_downcast<int32_t, int64_t>(N),
-                         safe_downcast<int32_t, int64_t>(C),
-                         safe_downcast<int32_t, int64_t>(out_D),
-                         safe_downcast<int32_t, int64_t>(out_H),
-                         safe_downcast<int32_t, int64_t>(out_W)};
-  for (int i = 0; i < 5; i++) {
-    params.grid_strides[i] = safe_downcast<int32_t, int64_t>(grid_contiguous.stride(i));
-    params.grad_output_strides[i] = safe_downcast<int32_t, int64_t>(grad_output_contiguous.stride(i));
-    params.input_strides[i] = safe_downcast<int32_t, int64_t>(input_contiguous.stride(i));
-    params.grad_input_strides[i] = safe_downcast<int32_t, int64_t>(grad_input_buf.stride(i));
-    params.grad_grid_strides[i] = safe_downcast<int32_t, int64_t>(grad_grid.stride(i));
-  }
+  GridSamplerBackwardParams<5> params(grad_output_contiguous,
+                                      input_contiguous,
+                                      grid_contiguous,
+                                      grad_input,
+                                      grad_grid,
+                                      align_corners,
+                                      pad_mode,
+                                      interp_mode);
 
   MPSStream* mpsStream = getCurrentMPSStream();
 

--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -76,20 +76,7 @@ static void grid_sampler_2d_mps_impl(Tensor& output,
   auto interpolation_mode = static_cast<GridSamplerInterpolation>(_interpolation_mode);
   auto padding_mode = static_cast<GridSamplerPadding>(_padding_mode);
 
-  auto dims = input.dim();
-
-  GridSamplerParams<4> params;
-  params.sampler_dims = 2;
-  params.align_corners = align_corners;
-
-  for (const auto dim : c10::irange(dims)) {
-    params.output_sizes[dim] = safe_downcast<int32_t, int64_t>(output.size(dim));
-    params.output_strides[dim] = safe_downcast<int32_t, int64_t>(output.stride(dim));
-    params.input_sizes[dim] = safe_downcast<int32_t, int64_t>(input.size(dim));
-    params.input_strides[dim] = safe_downcast<int32_t, int64_t>(input.stride(dim));
-    params.grid_sizes[dim] = safe_downcast<int32_t, int64_t>(grid.size(dim));
-    params.grid_strides[dim] = safe_downcast<int32_t, int64_t>(grid.stride(dim));
-  }
+  GridSamplerParams<4> params(output, input, grid, align_corners);
 
   auto N = output.size(0);
   auto out_H = output.size(2);
@@ -159,20 +146,7 @@ static void grid_sampler_3d_mps_impl(Tensor& output,
   auto grid_size = grid.sizes();
   output.resize_({input_size[0], input_size[1], grid_size[1], grid_size[2], grid_size[3]}, MemoryFormat::Contiguous);
 
-  auto dims = input.dim();
-
-  GridSamplerParams<5> params;
-  params.sampler_dims = sampler_dims;
-  params.align_corners = align_corners;
-
-  for (const auto dim : c10::irange(dims)) {
-    params.output_sizes[dim] = safe_downcast<int32_t, int64_t>(output.size(dim));
-    params.output_strides[dim] = safe_downcast<int32_t, int64_t>(output.stride(dim));
-    params.input_sizes[dim] = safe_downcast<int32_t, int64_t>(input.size(dim));
-    params.input_strides[dim] = safe_downcast<int32_t, int64_t>(input.stride(dim));
-    params.grid_sizes[dim] = safe_downcast<int32_t, int64_t>(grid.size(dim));
-    params.grid_strides[dim] = safe_downcast<int32_t, int64_t>(grid.stride(dim));
-  }
+  GridSamplerParams<5> params(output, input, grid, align_corners);
 
   auto num_threads = output.numel();
   MPSStream* mpsStream = getCurrentMPSStream();

--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -282,7 +282,7 @@ std::tuple<Tensor, Tensor> grid_sampler_2d_backward_mps(const Tensor& grad_outpu
     params.grad_input_strides[dim] = input_requires_grad ? safe_downcast<int32_t, int64_t>(grad_input.stride(dim)) : 0;
   }
   params.grad_grid_sW = safe_downcast<int32_t, int64_t>(grad_grid.stride(2));
-  params.padding_mode = static_cast<int32_t>(padding_mode);
+  params.padding_mode = padding_mode;
 
   using namespace mps;
   auto interp_str = mps::interp_to_string(interpolation_mode);
@@ -345,8 +345,8 @@ std::tuple<Tensor, Tensor> grid_sampler_3d_backward_mps(const Tensor& grad_outpu
               grid.scalar_type());
 
   auto input_requires_grad = output_mask[0];
-  int32_t interp_mode = static_cast<int32_t>(interpolation_mode);
-  int32_t pad_mode = static_cast<int32_t>(padding_mode);
+  auto interp_mode = static_cast<GridSamplerInterpolation>(interpolation_mode);
+  auto pad_mode = static_cast<GridSamplerPadding>(padding_mode);
 
   Tensor grad_input;
   if (input_requires_grad) {
@@ -355,8 +355,8 @@ std::tuple<Tensor, Tensor> grid_sampler_3d_backward_mps(const Tensor& grad_outpu
   // Always allocate grad_grid, matching CPU/CUDA and the 2D MPS backward.
   // Autograd requires a defined tensor for every output declared in the
   // derivative, even when the corresponding input doesn't require grad.
-  auto grad_grid = interp_mode == 1 ? at::zeros_like(grid, MemoryFormat::Contiguous)
-                                    : at::empty_like(grid, MemoryFormat::Contiguous);
+  auto grad_grid = interp_mode == GridSamplerInterpolation::Nearest ? at::zeros_like(grid, MemoryFormat::Contiguous)
+                                                                    : at::empty_like(grid, MemoryFormat::Contiguous);
 
   const auto& input_contiguous = input.contiguous();
   const auto& grid_contiguous = grid.contiguous();
@@ -372,7 +372,7 @@ std::tuple<Tensor, Tensor> grid_sampler_3d_backward_mps(const Tensor& grad_outpu
   auto out_W = grid_contiguous.size(3);
 
   bool run_grad_input = input_requires_grad;
-  bool run_grad_grid = interp_mode != 1;
+  bool run_grad_grid = interp_mode != GridSamplerInterpolation::Nearest;
 
   if (!run_grad_input && !run_grad_grid) {
     return std::make_tuple(std::move(grad_input), std::move(grad_grid));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180849

The 3D backward kernel was written independently from the 2D backward, reimplementing coordinate mapping, gradient computation, and padding logic from scratch rather than reusing the composable helpers already
established by the 2D backward (`compute_source_index_set_grad`, `compute_source`, etc.).

This moves those shared helpers earlier in the file so both 2D and 3D backward kernels can use them, deletes the redundant 3D-specific `grid_sampler_compute_source_index_set_grad`, and simplifies the nearest-neighbor backward padding to a single `compute_source` call.

Also fixes 24 signed-unsigned comparison warnings in the 3D backward kernel by using `int32_t` for thread index variables and loop counters that are compared against `int32_t` params fields.

Authored with Claude.