### PR TITLE
[PyTorch] Fix broadcast_shapes op missing in selective builds (#180860)

### DIFF
--- a/torch/csrc/jit/runtime/register_special_ops.cpp
+++ b/torch/csrc/jit/runtime/register_special_ops.cpp
@@ -324,9 +324,10 @@ RegisterOperators reg({
           push(stack, at::infer_size(a.toDimVector(), b.toDimVector()));
         },
         aliasAnalysisFromSchema()),
-    OperatorGenerator(
-        TORCH_SELECTIVE_SCHEMA(
-            "aten::broadcast_shapes(int[] a, int[] b) -> int[]"),
+    // Not gated by TORCH_SELECTIVE_SCHEMA because selective build
+    // allowlists won't include this op until models are re-traced.
+    Operator(
+        "aten::broadcast_shapes(int[] a, int[] b) -> int[]",
         [](Stack& stack) {
           auto a = pop(stack);
           auto b = pop(stack);


### PR DESCRIPTION
Summary:

D101206150 replaced `_infer_size` with `torch.broadcast_shapes` in `F.binary_cross_entropy` and registered `aten::broadcast_shapes` as a new JIT builtin using `TORCH_SELECTIVE_SCHEMA`. This causes `Unknown builtin op: aten::broadcast_shapes` when loading serialized TorchScript models in selective/mobile builds, because the new op is not in their compile-time allowlist.

Root cause: `TORCH_SELECTIVE_SCHEMA` gates op registration at compile time via `schema_allowlist_check()`. New ops not in the allowlist are compiled out entirely, so models serialized with the new `broadcast_shapes` call fail to load.

Fix: use bare `Operator(...)` constructor instead of `OperatorGenerator(TORCH_SELECTIVE_SCHEMA(...))` so the op is always registered regardless of selective build configuration. This matches the pattern used by other always-required ops like `aten::is_grad_enabled`.

Changes:
- `torch/csrc/jit/runtime/register_special_ops.cpp` (fbcode + xplat): Change `aten::broadcast_shapes` registration from selective to always-on

Test Plan:
python test/test_jit.py TestJitGeneratedModule.test_nn_BCELoss_no_batch_dim_mean
# Verifies TorchScript can compile and run BCELoss with broadcast_shapes

python -m pytest test/functorch/test_aotdispatch.py -k test_aot_autograd_symbolic_module_exhaustive_nn_BCELoss_cpu_float32
# Verifies symbolic shapes still work with BCELoss module

Differential Revision: D101640090
