### PR TITLE
Fix duplicated-word typos in comments and docstrings

### DIFF
--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -420,7 +420,7 @@ class InductorChoices:
             lower = next_power_of_2(int(lower))
             upper = next_power_of_2(int(upper))
 
-            # If we are are coalescing on xblock (not ReductionHint.INNER) and this is not a tiny kernel
+            # If we are coalescing on xblock (not ReductionHint.INNER) and this is not a tiny kernel
             # (not ReductionHint.OUTER_TINY), do not use persistent reduction if it induces tile
             # quantization. Persistent reduction forces rblock == rnumel, if the bounds between lower
             # and upper are large, for the lower values we will be masking off large % of read/writes,

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -334,7 +334,7 @@ qconfig.
     * This qconfig uses signed activations and weights. Weights have added
     restrictions such as zero point is forced to be 0, making the weights
     symmetric, hence the name. And the 8-bit quantized values are
-    restricting to to [-127, +127], excluding -128.
+    restricting to [-127, +127], excluding -128.
 
     * xnnpack has a requantization scale value restriction, 0x1p-32 <=
     requantization_scale < 256.0 where, `requantization_scale = (input_scale

--- a/torch/distributed/_mesh_layout.py
+++ b/torch/distributed/_mesh_layout.py
@@ -111,7 +111,7 @@ class _FlatLayout:
         - The composition only generates indices that the left layout could originally produce,
           but the right layout determines which indices to be picked.
         - The stride of the composition layout will not be smaller than the stride of the right layout,
-          because when picking the indices the composition will at least follow the the right layout's stride
+          because when picking the indices the composition will at least follow the right layout's stride
           to move forward.
 
         Example:

--- a/torch/distributed/_tools/mem_tracker.py
+++ b/torch/distributed/_tools/mem_tracker.py
@@ -794,7 +794,7 @@ class MemTracker(TorchDispatchMode):
         This method should be called before the ``MemTracker`` is used. Any tensors that are not module parameters, buffers,
         gradients activations, or optimizer states will be categorized as ``Other``. If you want them categorized with a
         custom name, please file a GitHub issue. Any tensors created outside the MemTracker and not supplied to this
-        method will not be be tracked by ``MemTracker``.
+        method will not be tracked by ``MemTracker``.
 
         Args:
             *external (Union[nn.Module, optim.Optimizer, torch.Tensor]): The external modules, optimizers, and

--- a/torch/distributed/_tools/sac_estimator.py
+++ b/torch/distributed/_tools/sac_estimator.py
@@ -582,7 +582,7 @@ class SACEstimator(TorchDispatchMode):
         # recomputation time to total runtime incurred.
         delta = 1e-2
         tradeoff_curve = OrderedDict()
-        # 4. Initialize the trade-off curve with the stats of of already chosen recomputed_ops
+        # 4. Initialize the trade-off curve with the stats of already chosen recomputed_ops
         tradeoff_curve[(discarded_mem / sac_memory) + delta] = (
             recomp_runtime / sac_runtime
         )

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -7856,7 +7856,7 @@ class ShapeEnv:
         fallback_value: bool | None = None,
     ) -> sympy.Basic:
         """
-        Given a a SymNode, evaluates sym_node.expr, adding guards if necessary.
+        Given a SymNode, evaluates sym_node.expr, adding guards if necessary.
         """
 
         self._expr_sym_node_id = id(sym_node)

--- a/torch/mtia/_utils.py
+++ b/torch/mtia/_utils.py
@@ -21,7 +21,7 @@ def _get_device_index(
     """
 
     if device is None and optional:
-        # If device is None (frequent), then we can can short-circuit the logic
+        # If device is None (frequent), then we can short-circuit the logic
         return torch._C._mtia_getDevice()
     if isinstance(device, int):
         return device

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -281,7 +281,7 @@ class Buffer(torch.Tensor, metaclass=_BufferMeta):
 class UninitializedBuffer(UninitializedTensorMixin, torch.Tensor):
     r"""A buffer that is not initialized.
 
-    Uninitialized Buffer is a a special case of :class:`torch.Tensor`
+    Uninitialized Buffer is a special case of :class:`torch.Tensor`
     where the shape of the data is still unknown.
 
     Unlike a :class:`torch.Tensor`, uninitialized parameters

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -115,7 +115,7 @@ class FSDPTestModel(nn.Module, ABC):
 
     @abstractmethod
     def get_input(self, device) -> tuple[torch.Tensor, ...]:
-        """Returns an input for the model as as tuple."""
+        """Returns an input for the model as a tuple."""
         ...
 
     @abstractmethod

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -299,7 +299,7 @@ def _lazy_init() -> None:
     if is_initialized() or hasattr(_tls, "is_initializing"):
         return
     with _initialization_lock:
-        # This test was was protected via GIL. Double-check whether XPU has
+        # This test was protected via GIL. Double-check whether XPU has
         # already been initialized.
         if is_initialized():
             return


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180861
* #180609

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo