### PR TITLE
Add save_tensor() API for selective activation checkpointing

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -92,6 +92,7 @@ from torch.utils.checkpoint import (
     checkpoint_sequential,
     CheckpointPolicy,
     create_selective_checkpoint_contexts,
+    save_tensor,
 )
 from torch.utils.flop_counter import FlopCounterMode
 from torch.utils.weak import WeakTensorKeyDictionary
@@ -16124,6 +16125,39 @@ class TestSelectiveActivationCheckpoint(TestCase):
                 },
             )
             self.assertEqual(my_count[0], 9)
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_save_tensor(self):
+        recomputed_ops = []
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            if ctx.is_recompute:
+                recomputed_ops.append(op)
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def fn(x):
+            a = torch.sin(x)
+            save_tensor(a)
+            b = torch.cos(a)
+            return b
+
+        x = torch.randn(3, requires_grad=True)
+        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+        out = checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
+        out.sum().backward()
+
+        self.assertNotIn(torch.ops.aten.sin.default, recomputed_ops)
+        self.assertIn(torch.ops.aten.cos.default, recomputed_ops)
+
+        x2 = x.detach().clone().requires_grad_(True)
+        torch.cos(torch.sin(x2)).sum().backward()
+        self.assertEqual(x.grad, x2.grad)
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_save_tensor_noop_outside_context(self):
+        x = torch.randn(3, requires_grad=True)
+        a = torch.sin(x)
+        save_tensor(a)
 
 
 class TestAutogradMultipleDispatch(TestCase):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1321,7 +1321,7 @@ SAC_IGNORED_OPS = {
 } | set(torch._subclasses.functional_tensor.FunctionalTensor.metadata_fns)  # type: ignore[has-type]
 
 
-def _get_active_caching_mode() -> Optional["_CachingTorchDispatchMode"]:
+def _get_active_caching_mode() -> Optional[_CachingTorchDispatchMode]:
     from torch.utils._python_dispatch import _get_current_dispatch_mode_stack
     for mode in reversed(_get_current_dispatch_mode_stack()):
         if isinstance(mode, _CachingTorchDispatchMode):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -19,6 +19,7 @@ from torch.utils._pytree import tree_map
 from torch.testing._internal.logging_tensor import capture_logs, LoggingTensorMode
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch._C._autograd import _make_saved_tensor, SavedTensor
+from torch.utils.weak import WeakTensorKeyDictionary
 from typing import NoReturn
 
 __all__ = [
@@ -38,6 +39,7 @@ __all__ = [
     "SelectiveCheckpointContext",
     "create_selective_checkpoint_contexts",
     "SAC_IGNORED_OPS",
+    "save_tensor",
     "GraphExecGroup",
 ]
 
@@ -1319,6 +1321,34 @@ SAC_IGNORED_OPS = {
 } | set(torch._subclasses.functional_tensor.FunctionalTensor.metadata_fns)  # type: ignore[has-type]
 
 
+def _get_active_caching_mode() -> Optional["_CachingTorchDispatchMode"]:
+    from torch.utils._python_dispatch import _get_current_dispatch_mode_stack
+    for mode in reversed(_get_current_dispatch_mode_stack()):
+        if isinstance(mode, _CachingTorchDispatchMode):
+            return mode
+    return None
+
+
+def save_tensor(tensor: torch.Tensor) -> None:
+    """Save a tensor for selective activation checkpointing, bypassing the policy.
+
+    Call this inside a checkpointed function to unconditionally save a tensor
+    so it is not recomputed during backward.  Outside of a selective activation
+    checkpoint context this is a no-op.
+    """
+    mode = _get_active_caching_mode()
+    if mode is None:
+        return
+    info = mode.tensor_tracker.get(tensor)
+    if info is None:
+        return
+    func, idx, any_ret_has_alias_info = info
+    mode.storage[func][idx] = tree_map(
+        lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)),
+        tensor,
+    )
+
+
 class _CachingTorchDispatchMode(TorchDispatchMode):
     @classmethod
     def ignore_compile_internals(cls):
@@ -1330,6 +1360,7 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
         self.storage = storage
         self.ac_graph_id = ac_graph_id
         self.func_counter: Dict[Any, int] = defaultdict(int)
+        self.tensor_tracker: WeakTensorKeyDictionary = WeakTensorKeyDictionary()
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         kwargs = {} if kwargs is None else kwargs
@@ -1362,6 +1393,14 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
 
         idx = self.func_counter[func]
         self.func_counter[func] += 1
+
+        # Track outputs so save_tensor() can retroactively save them.
+        if isinstance(out, torch.Tensor):
+            self.tensor_tracker[out] = (func, idx, any_ret_has_alias_info)
+        elif isinstance(out, (tuple, list)):
+            for o in out:
+                if isinstance(o, torch.Tensor):
+                    self.tensor_tracker[o] = (func, idx, any_ret_has_alias_info)
 
         policy = self.policy_fn(SelectiveCheckpointContext(is_recompute=False, op_output=out),
                                 func, *args, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #180874
* #180867
* __->__ #180866
* #180919
* #176455

Adds a save_tensor() function that can be called inside a checkpointed
function to unconditionally save a tensor, bypassing the policy function.
This is useful when the user knows at tensor-creation time that a tensor
should be saved, without needing to express this through the policy.

The implementation finds the active _CachingTorchDispatchMode by walking
the dispatch mode stack and uses a WeakTensorKeyDictionary to track
which (func, idx) produced each output tensor.

Authored with Claude.

