### PR TITLE
Use SavedTensor for SAC cached tensors to enable saved tensor hooks

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16127,31 +16127,49 @@ class TestSelectiveActivationCheckpoint(TestCase):
             self.assertEqual(my_count[0], 9)
 
     @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
     def test_save_tensor(self):
-        recomputed_ops = []
-
         def policy_fn(ctx, op, *args, **kwargs):
-            if ctx.is_recompute:
-                recomputed_ops.append(op)
             return CheckpointPolicy.PREFER_RECOMPUTE
 
-        def fn(x):
-            a = torch.sin(x)
+        x = torch.randn(512, 512, requires_grad=True, device="cuda")
+        y = torch.randn(512, 512, device="cuda")
+
+        def fn_save(x, y):
+            a = torch.mm(x, y)
             save_tensor(a)
-            b = torch.cos(a)
-            return b
+            return a.sin().sum()
 
-        x = torch.randn(3, requires_grad=True)
-        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
-        out = checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
-        out.sum().backward()
+        def fn_no_save(x, y):
+            return torch.mm(x, y).sin().sum()
 
-        self.assertNotIn(torch.ops.aten.sin.default, recomputed_ops)
-        self.assertIn(torch.ops.aten.cos.default, recomputed_ops)
+        def get_bw_flops(f):
+            f().backward()
+            out = f()
+            with FlopCounterMode(display=False) as mode:
+                out.backward()
+            return mode.get_total_flops() / (512**3 * 2)
 
-        x2 = x.detach().clone().requires_grad_(True)
-        torch.cos(torch.sin(x2)).sum().backward()
-        self.assertEqual(x.grad, x2.grad)
+        ctx = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+
+        bw_no_save = get_bw_flops(
+            lambda: checkpoint(fn_no_save, x, y, use_reentrant=False, context_fn=ctx))
+        bw_save = get_bw_flops(
+            lambda: checkpoint(fn_save, x, y, use_reentrant=False, context_fn=ctx))
+
+        # Without save_tensor, mm is recomputed during backward: 2 flops
+        # With save_tensor, mm is cached: 1 flop
+        self.assertEqual(bw_no_save, 2.0)
+        self.assertEqual(bw_save, 1.0)
+
+        # Gradient correctness
+        x3 = torch.randn_like(x, requires_grad=True)
+        out = checkpoint(fn_save, x3, y, use_reentrant=False, context_fn=ctx)
+        out.backward()
+        x4 = x3.detach().clone().requires_grad_(True)
+        torch.mm(x4, y).sin().sum().backward()
+        self.assertEqual(x3.grad, x4.grad)
 
     @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
     def test_save_tensor_noop_outside_context(self):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16159,6 +16159,40 @@ class TestSelectiveActivationCheckpoint(TestCase):
         a = torch.sin(x)
         save_tensor(a)
 
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_sac_saved_tensor_hooks(self):
+        packed = []
+        unpacked = []
+
+        def pack(t):
+            packed.append(t)
+            return t
+
+        def unpack(t):
+            unpacked.append(t)
+            return t
+
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op == torch.ops.aten.sin.default:
+                return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def fn(x):
+            return torch.cos(torch.sin(x))
+
+        x = torch.randn(3, requires_grad=True)
+        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+        with torch.autograd.graph.saved_tensors_hooks(pack, unpack):
+            out = checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
+            out.sum().backward()
+
+        self.assertTrue(len(packed) > 0, "pack hook should have been called")
+        self.assertTrue(len(unpacked) > 0, "unpack hook should have been called")
+
+        x2 = x.detach().clone().requires_grad_(True)
+        torch.cos(torch.sin(x2)).sum().backward()
+        self.assertEqual(x.grad, x2.grad)
+
 
 class TestAutogradMultipleDispatch(TestCase):
     def test_autograd_multiple_dispatch_registrations(self, device):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1214,7 +1214,10 @@ def _is_compiling(func, args, kwargs):
 class _VersionWrapper:
     def __init__(self, val, hooks=None) -> None:
         if isinstance(val, torch.Tensor):
-            self.version: int | None = val._version
+            # Skip version tracking when hooks are present, since hooks
+            # transform the tensor and the packed representation's version
+            # counter has no relationship to the original.
+            self.version: int | None = val._version if hooks is None else None
             if hooks is not None:
                 pack_hook, _ = hooks
                 val = pack_hook(val)

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1212,19 +1212,28 @@ def _is_compiling(func, args, kwargs):
 
 
 class _VersionWrapper:
-    # Check that cached tensors are not mutated.
-    def __init__(self, val) -> None:
+    def __init__(self, val, hooks=None) -> None:
+        if isinstance(val, torch.Tensor):
+            self.version: int | None = val._version
+            if hooks is not None:
+                pack_hook, _ = hooks
+                val = pack_hook(val)
+        else:
+            self.version = None
         self.val: torch.Tensor | Any = val
-        self.version: int | None = val._version if isinstance(val, torch.Tensor) else None
+        self.hooks = hooks
 
     def get_val(self, allow_cache_entry_mutation):
+        val = self.val
+        if self.hooks is not None:
+            _, unpack_hook = self.hooks
+            val = unpack_hook(val)
         if self.version is not None and not allow_cache_entry_mutation:
-            if self.val._version != self.version:
-                # Can we give user a stack trace of where the mutation happened?
+            if val._version != self.version:
                 raise RuntimeError(
                     "Tensor cached during selective activation checkpoint has been mutated"
                 )
-        return self.val
+        return val
 
 
 def _maybe_detach(x, any_ret_has_alias_info):
@@ -1246,17 +1255,17 @@ def _maybe_detach(x, any_ret_has_alias_info):
     return x
 
 
-def _detach_and_save(x, any_ret_has_alias_info):
-    x = _maybe_detach(x, any_ret_has_alias_info)
-    if isinstance(x, torch.Tensor):
-        return _make_saved_tensor(x, is_output=False)
-    return x
-
-
-def _unpack_saved(x):
-    if isinstance(x, SavedTensor):
-        return x.unpack()
-    return x
+def _get_user_hooks():
+    """Get user-registered saved tensor hooks, skipping checkpoint's own hooks."""
+    top = torch._C._autograd._top_saved_tensors_default_hooks(True)
+    if top is None:
+        return None
+    # Pop checkpoint's hooks to see if there are user hooks underneath
+    torch._C._autograd._pop_saved_tensors_default_hooks()
+    user_hooks = torch._C._autograd._top_saved_tensors_default_hooks(True)
+    # Restore checkpoint's hooks
+    torch._C._autograd._push_saved_tensors_default_hooks(*top)
+    return user_hooks
 
 
 class SelectiveCheckpointContext:
@@ -1356,16 +1365,11 @@ def save_tensor(tensor: torch.Tensor) -> None:
     if info is None:
         return
     func, idx, any_ret_has_alias_info = info
-    if mode.allow_cache_entry_mutation:
-        mode.storage[func][idx] = tree_map(
-            lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)),
-            tensor,
-        )
-    else:
-        mode.storage[func][idx] = tree_map(
-            lambda x: _detach_and_save(x, any_ret_has_alias_info),
-            tensor,
-        )
+    hooks = mode.user_hooks
+    mode.storage[func][idx] = tree_map(
+        lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info), hooks),
+        tensor,
+    )
 
 
 class _CachingTorchDispatchMode(TorchDispatchMode):
@@ -1374,13 +1378,17 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
         return True
 
     # Used together with _CachedTorchDispatchMode to implement SAC.
-    def __init__(self, policy_fn, storage, ac_graph_id=None, allow_cache_entry_mutation=False) -> None:
+    def __init__(self, policy_fn, storage, ac_graph_id=None) -> None:
         self.policy_fn = policy_fn
         self.storage = storage
         self.ac_graph_id = ac_graph_id
-        self.allow_cache_entry_mutation = allow_cache_entry_mutation
         self.func_counter: Dict[Any, int] = defaultdict(int)
         self.tensor_tracker: WeakTensorKeyDictionary = WeakTensorKeyDictionary()
+        self.user_hooks = None
+
+    def __enter__(self):
+        self.user_hooks = _get_user_hooks()
+        return super().__enter__()
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
         kwargs = {} if kwargs is None else kwargs
@@ -1435,10 +1443,9 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
                     node.meta["recompute"] = policy
 
         if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
-            if self.allow_cache_entry_mutation:
-                self.storage[func][idx] = tree_map(lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)), out)
-            else:
-                self.storage[func][idx] = tree_map(lambda x: _detach_and_save(x, any_ret_has_alias_info), out)
+            hooks = self.user_hooks
+            self.storage[func][idx] = tree_map(
+                lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info), hooks), out)
         return out
 
 class _CachedTorchDispatchMode(TorchDispatchMode):
@@ -1470,10 +1477,7 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
 
         cached = self.storage.get(func, {}).pop(idx, None)
         if cached is not None:
-            if self.allow_cache_entry_mutation:
-                out = tree_map(lambda x: x.get_val(True), cached)
-            else:
-                out = tree_map(_unpack_saved, cached)
+            out = tree_map(lambda x: x.get_val(self.allow_cache_entry_mutation), cached)
         elif policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
             if func not in self.storage:
                 raise RuntimeError(f"{func} encountered during backward, but not found in storage")
@@ -1567,7 +1571,7 @@ def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mu
 
     storage: Dict[Any, Dict[int, Any]] = defaultdict(dict)
     return (
-        _CachingTorchDispatchMode(policy_fn, storage, allow_cache_entry_mutation=allow_cache_entry_mutation),
+        _CachingTorchDispatchMode(policy_fn, storage),
         _CachedTorchDispatchMode(policy_fn, storage, allow_cache_entry_mutation),
     )
 

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1246,6 +1246,19 @@ def _maybe_detach(x, any_ret_has_alias_info):
     return x
 
 
+def _detach_and_save(x, any_ret_has_alias_info):
+    x = _maybe_detach(x, any_ret_has_alias_info)
+    if isinstance(x, torch.Tensor):
+        return _make_saved_tensor(x, is_output=False)
+    return x
+
+
+def _unpack_saved(x):
+    if isinstance(x, SavedTensor):
+        return x.unpack()
+    return x
+
+
 class SelectiveCheckpointContext:
     """
     Context passed to policy function during selective checkpointing.
@@ -1343,10 +1356,16 @@ def save_tensor(tensor: torch.Tensor) -> None:
     if info is None:
         return
     func, idx, any_ret_has_alias_info = info
-    mode.storage[func][idx] = tree_map(
-        lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)),
-        tensor,
-    )
+    if mode.allow_cache_entry_mutation:
+        mode.storage[func][idx] = tree_map(
+            lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)),
+            tensor,
+        )
+    else:
+        mode.storage[func][idx] = tree_map(
+            lambda x: _detach_and_save(x, any_ret_has_alias_info),
+            tensor,
+        )
 
 
 class _CachingTorchDispatchMode(TorchDispatchMode):
@@ -1355,10 +1374,11 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
         return True
 
     # Used together with _CachedTorchDispatchMode to implement SAC.
-    def __init__(self, policy_fn, storage, ac_graph_id=None) -> None:
+    def __init__(self, policy_fn, storage, ac_graph_id=None, allow_cache_entry_mutation=False) -> None:
         self.policy_fn = policy_fn
         self.storage = storage
         self.ac_graph_id = ac_graph_id
+        self.allow_cache_entry_mutation = allow_cache_entry_mutation
         self.func_counter: Dict[Any, int] = defaultdict(int)
         self.tensor_tracker: WeakTensorKeyDictionary = WeakTensorKeyDictionary()
 
@@ -1415,7 +1435,10 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
                     node.meta["recompute"] = policy
 
         if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
-            self.storage[func][idx] = tree_map(lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)), out)
+            if self.allow_cache_entry_mutation:
+                self.storage[func][idx] = tree_map(lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)), out)
+            else:
+                self.storage[func][idx] = tree_map(lambda x: _detach_and_save(x, any_ret_has_alias_info), out)
         return out
 
 class _CachedTorchDispatchMode(TorchDispatchMode):
@@ -1447,7 +1470,10 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
 
         cached = self.storage.get(func, {}).pop(idx, None)
         if cached is not None:
-            out = tree_map(lambda x: x.get_val(self.allow_cache_entry_mutation), cached)
+            if self.allow_cache_entry_mutation:
+                out = tree_map(lambda x: x.get_val(True), cached)
+            else:
+                out = tree_map(_unpack_saved, cached)
         elif policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
             if func not in self.storage:
                 raise RuntimeError(f"{func} encountered during backward, but not found in storage")
@@ -1541,7 +1567,7 @@ def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mu
 
     storage: Dict[Any, Dict[int, Any]] = defaultdict(dict)
     return (
-        _CachingTorchDispatchMode(policy_fn, storage),
+        _CachingTorchDispatchMode(policy_fn, storage, allow_cache_entry_mutation=allow_cache_entry_mutation),
         _CachedTorchDispatchMode(policy_fn, storage, allow_cache_entry_mutation),
     )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #180874
* __->__ #180867
* #180866
* #180919
* #176455

SAC previously stored cached tensors using a custom _VersionWrapper.
This switches to using _make_saved_tensor / SavedTensor so that
saved tensor default hooks (pack/unpack) are applied to SAC-cached
tensors. This enables composing SAC with features built on saved
tensor hooks (e.g. offloading).

When allow_cache_entry_mutation=True, the old _VersionWrapper path is
preserved for backward compatibility, since SavedTensor.unpack()
always performs a version check.

Authored with Claude.

