### PR TITLE
Add release-blog-features skill

### DIFF
--- a/.claude/skills/release-blog-features/SKILL.md
+++ b/.claude/skills/release-blog-features/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: release-blog-features
+description: Produce a draft "Features" section for a PyTorch release blog post by comparing two release branches (e.g., release/2.11 vs release/2.12). Use when the user asks to generate a release blog, list new features for a release, compare release branches, or draft content for pytorch.org/blog. Organizes features similar to https://pytorch.org/blog/pytorch-2-11-release-blog/ with Highlights and per-component sections (Dynamo, Inductor, Distributed, Export, MPS, ROCm, XPU, CPU, etc.), each tagged with stability (Stable / Beta / Prototype / API-Unstable).
+---
+
+# PyTorch Release Blog Features Skill
+
+Produce a draft list of features for a PyTorch release blog post by diffing
+two release branches and organizing the noteworthy changes into the format
+used on pytorch.org/blog.
+
+## Usage
+
+The user invokes the skill with two release branches (a "base" and a
+"target"), for example:
+
+```
+Generate features for the 2.12 release blog (release/2.11 → release/2.12)
+```
+
+Default behavior when the user only gives the target version:
+- base = `release/<previous-minor>` (e.g. `release/2.11` for target 2.12)
+- target = `release/<target>` (e.g. `release/2.12`)
+
+Always confirm the two refs you'll compare before doing any heavy work.
+
+## What to produce
+
+A Markdown document with the same structure as recent release blogs
+(see [reference-structure.md](reference-structure.md) for a template and an
+example based on the 2.11 blog). At a high level:
+
+1. **Header** — version, link to release notes, commit/contributor stats.
+2. **Highlights** — 5-10 bullet points of the most notable features.
+3. **Feature sections** — one subsection per feature, tagged with
+   `[Stable]`, `[Beta]`, `[Prototype]`, or `[API-Unstable]`, and grouped
+   by component (Dynamo, Inductor, Distributed, Export, Quantization,
+   MPS, ROCm, XPU, CPU, Arm, Release Engineering, etc.).
+4. **Deprecations / BC-breaking** — only if any are found.
+5. **Non-feature updates** — version bumps (CUDA default, Python min),
+   release-cadence changes, etc.
+
+Each feature entry should contain:
+- Short title and stability tag
+- 1-3 sentence description written for a blog audience (not a commit log)
+- Links to representative PRs (`#12345`) and docs where relevant
+- Platform/backend notes if applicable
+
+Do **not** invent features, metrics, or API names. If something is
+ambiguous, mark it with `TODO:` so the release manager can resolve it.
+
+## Workflow
+
+### Step 1 — Resolve the refs
+
+```bash
+# Make sure we have both release branches locally
+git fetch origin release/<base> release/<target> --no-tags
+
+# Determine the merge-base — this is the effective "cut point"
+git merge-base origin/release/<base> origin/release/<target>
+```
+
+Prefer `origin/release/<x>` over bare `release/<x>` when fetching, and use
+the actual tag (e.g. `v2.11.0`) over the branch when it exists, because
+the branch may contain post-release cherry-picks.
+
+### Step 2 — Collect the commit list
+
+Two viable options — pick based on what is available:
+
+**Option A: reuse existing tooling (preferred if `scripts/release_notes/`
+already has a commitlist for this release).**
+
+```bash
+cd scripts/release_notes
+python commitlist.py --create_new v<base>.0 <target-commit-hash>
+# Produces results/commitlist.csv with labels, categories, files changed.
+```
+
+See `scripts/release_notes/README.md` for details on cherry-pick handling
+and the classifier.
+
+**Option B: lightweight `git log` + `gh` lookup** (use when the tooling is
+not set up or when a quick draft is enough):
+
+```bash
+# Titles + PR numbers, one per commit
+git log --pretty=format:'%H %s' \
+    origin/release/<base>..origin/release/<target> \
+    > /tmp/release-commits.txt
+
+# For any commit, pull the PR metadata including labels
+gh pr view <num> --json number,title,labels,body,author,files
+```
+
+### Step 3 — Filter to "blog-worthy" changes
+
+A release has thousands of commits. The blog only highlights a small
+fraction. Use these signals, in order:
+
+1. **`release notes:` labels** — PRs labelled `release notes: <area>` are
+   the canonical source of user-facing changes. Prefer these.
+2. **"New feature" / "Beta" / "Prototype" labels** and wording in the PR
+   body (e.g. `## Summary` mentions a new public API).
+3. **New public APIs** — PRs that add to `torch/`, `torch/nn/`,
+   `torch/distributed/`, `torch/export/`, etc., especially new `.py`
+   modules or new entries in `__all__`.
+4. **Dashboard / perf callouts** — PRs referencing the PyTorch HUD or
+   numerical speedups.
+5. **Platform enablement** — new backends, new hardware, new wheel
+   variants (ROCm, XPU, CUDA major bump, aarch64).
+
+Ignore: pure refactors, test infra, lint fixes, typo fixes, internal
+dispatcher churn, reverts, and cherry-picks that land on both branches.
+
+### Step 4 — Categorize
+
+Group the survivors into components. The canonical set used by recent
+blogs (use these exact names when they apply):
+
+- **Dynamo / torch.compile**
+- **Inductor**
+- **Distributed** (FSDP, DTensor, DeviceMesh, symmetric memory,
+  pipelining, collectives)
+- **Export** (`torch.export`, AOTInductor)
+- **Quantization**
+- **Profiler**
+- **ONNX**
+- **NN / Frontend** (FlexAttention, SDPA, new modules)
+- **MPS** (Apple Silicon)
+- **ROCm** (AMD)
+- **XPU** (Intel)
+- **CPU / Arm**
+- **CUDA** (default version change, cuDNN, CUTLASS integrations)
+- **libtorch / C++ ABI** (`torch::stable`)
+- **Release Engineering** (wheel variants, Python/CUDA support matrix)
+
+Tag each entry with a stability level. If the PR body explicitly says
+"prototype" or "experimental", use `[Prototype]` / `[API-Unstable]`.
+Otherwise, infer from the PR's release-notes label and from whether the
+API is gated behind a private namespace (`torch._*`).
+
+### Step 5 — Draft the blog
+
+Open [reference-structure.md](reference-structure.md) and follow the
+template. Keep descriptions blog-voice, not commit-voice: write for a
+PyTorch user deciding whether to upgrade, not for a reviewer.
+
+### Step 6 — Gather stats for the header
+
+```bash
+# Commit count between the two refs (excludes merges)
+git log --no-merges --oneline \
+    origin/release/<base>..origin/release/<target> | wc -l
+
+# Unique contributors
+git log --format='%an' \
+    origin/release/<base>..origin/release/<target> | sort -u | wc -l
+```
+
+## Output
+
+Save the draft to `agent_space/release-<version>-blog-draft.md` (per
+CLAUDE.md, `agent_space/` is the git-ignored scratch directory). Do not
+commit the draft — the release manager will review and move it into the
+pytorch.org blog repo.
+
+## Best practices
+
+- **Confirm scope before you dig in.** Thousands of commits; the user
+  cares about ~30 features.
+- **Let the PR author's words do the work.** Lift phrasing from the PR
+  body's "Summary" section rather than re-describing the change from the
+  diff.
+- **Flag uncertainty.** `TODO(release-manager): is this beta or
+  prototype?` is more useful than a confident guess.
+- **Don't overclaim performance.** Only cite speedups that appear in the
+  PR body or linked dashboard — never invent numbers.
+- **Deduplicate ghstack.** A feature often lands as 5-15 ghstack PRs.
+  Collapse them to one blog entry citing the user-facing PR (usually the
+  top of the stack, which adds the public API or docs).
+- **Skip reverts and follow-ups.** If PR #A landed and PR #B reverted it
+  before the release branch was cut, neither belongs in the blog.

--- a/.claude/skills/release-blog-features/reference-structure.md
+++ b/.claude/skills/release-blog-features/reference-structure.md
@@ -1,0 +1,165 @@
+# PyTorch Release Blog — Output Template & Examples
+
+Use this template when drafting a release blog. It mirrors the structure
+of recent posts on pytorch.org/blog (2.9, 2.10, 2.11).
+
+## Template
+
+```markdown
+# PyTorch <VERSION> Release Blog
+
+We are excited to announce the release of PyTorch® <VERSION>
+([release notes](https://github.com/pytorch/pytorch/releases/tag/v<VERSION>.0))!
+This release features <N> commits from <M> contributors since PyTorch
+<PREV_VERSION>.
+
+## Highlights
+
+- <Feature 1 — one line>
+- <Feature 2 — one line>
+- <Feature 3 — one line>
+- ...
+
+Along with <VERSION>, we are also releasing updates to the PyTorch
+domain libraries. See the blog posts for [TorchAudio](#), [TorchVision](#),
+and [ExecuTorch](#).
+
+---
+
+## Beta Features
+
+### [Beta] <Feature name> — <component>
+
+<1-3 sentences describing what it does, who should care, and what
+changed vs. the previous release.>
+
+See [#<PR>](https://github.com/pytorch/pytorch/pull/<PR>) and the
+[documentation](<link>).
+
+### [Beta] <Feature name> — <component>
+...
+
+---
+
+## Prototype Features
+
+### [Prototype] <Feature name> — <component>
+<description>
+
+### [Prototype] <Feature name> — <component>
+...
+
+---
+
+## Performance Improvements
+
+### <component> — <short title>
+<description, with any benchmark numbers lifted directly from the PR>
+
+---
+
+## Deprecations and Backwards-Incompatible Changes
+
+- <Change + migration path>. See [#<PR>](...).
+
+---
+
+## Non-Feature Updates
+
+- **CUDA default**: <old> → <new>
+- **Python support**: <range>
+- **Release cadence**: <note if it changed>
+```
+
+## Example (filled in, abbreviated — based on the 2.11 blog)
+
+```markdown
+# PyTorch 2.11 Release Blog
+
+We are excited to announce the release of PyTorch® 2.11
+([release notes](https://github.com/pytorch/pytorch/releases/tag/v2.11.0))!
+This release features 2,723 commits from 432 contributors since PyTorch 2.10.
+
+## Highlights
+
+- Differentiable collectives enable backprop through distributed ops.
+- FlexAttention gets a FlashAttention-4 backend on Hopper/Blackwell
+  with 1.2×-3.2× speedups over Triton.
+- MPS adds async error reporting and new distributions.
+- RNN/LSTM export to GPU via `torch.export`.
+- ROCm gains device-side asserts and TopK wins.
+- XPU adds CUDA-graph-style capture/replay.
+- FP16 half-precision GEMM on CPU via OpenBLAS.
+- CUDA 13 is now the default build; TorchScript is deprecated.
+
+## API-Unstable Features
+
+### [API-Unstable] Differentiable Collectives for Distributed Training
+
+Collective operations (all_reduce, all_gather, reduce_scatter) now
+support backpropagation, enabling new distributed-training research
+patterns that previously required manual gradient plumbing.
+
+See [#<TODO>] and the [distributed docs](...).
+
+### [API-Unstable] FlexAttention with FlashAttention-4 Backend
+
+FlexAttention now targets FlashAttention-4 on Hopper and Blackwell GPUs,
+with auto-generated CuTeDSL score/mask functions. Reported speedups are
+1.2×-3.2× over the Triton backend.
+
+...
+
+## Non-Feature Updates
+
+- **CUDA default**: CUDA 12.x → CUDA 13 (x86_64 and ARM). CPU-only and
+  CUDA 12.8 builds remain available.
+- **TorchScript**: deprecated since 2.10 — migrate to `torch.export` or
+  ExecuTorch.
+- **Release cadence**: moving to one release every 2 months in 2026.
+```
+
+## Stability tags — how to pick
+
+| Tag                | When to use                                                                  |
+|--------------------|------------------------------------------------------------------------------|
+| `[Stable]`         | API is public, documented, covered by BC policy. Rarely tagged explicitly.   |
+| `[Beta]`           | Public API, usable in production, minor signature changes still possible.    |
+| `[Prototype]`      | Public API, but the team reserves the right to remove or redesign it.        |
+| `[API-Unstable]`   | Equivalent to Prototype in recent (2.9+) blogs — use this for consistency.   |
+
+When in doubt, match the tag the PR author used in the PR body. If the
+PR body has no tag, default to `[Prototype]` for new features and flag it
+for the release manager.
+
+## Component names — canonical list
+
+Use these exactly when they apply (matches recent blog posts):
+
+- Dynamo / torch.compile
+- Inductor
+- Distributed
+- Export / AOTInductor
+- Quantization
+- Profiler
+- ONNX
+- NN / Frontend
+- MPS
+- ROCm
+- XPU
+- CPU / Arm
+- CUDA
+- libtorch / C++ ABI
+- Release Engineering
+
+## Things to avoid
+
+- **Don't invent speedup numbers.** Only cite numbers that appear in the
+  PR body or on a linked dashboard.
+- **Don't list ghstack sub-PRs.** Collapse a stack to one entry.
+- **Don't include reverts.** If `#A` was reverted by `#B` before the
+  branch cut, neither belongs in the blog.
+- **Don't include internal refactors.** If a PR only moves code around
+  without changing a user-visible API or perf number, skip it.
+- **Don't write commit-style descriptions.** "Fix segfault in foo when
+  bar" belongs in release notes, not the blog.


### PR DESCRIPTION
Drafts a PyTorch release blog "Features" section by diffing two release branches and organizing noteworthy PRs in the pytorch.org/blog format (Highlights, Beta, Prototype, Platform Enablement), with canonical component names and a reference template based on the 2.11 post.

Here is the example:

# PyTorch 2.12 — Major Features

##  Compile & Tracing

###  User-Stream Support in Inductor (~40 commits) 
  torch.compile now traces and respects user-created CUDA streams. Includes support for
  stream.synchronize(), stream.record_event(), stream.wait_event(), multi-stream buffer reuse, and combokernel fusion across stream boundaries.

###  Helion + torch.compile Integration (~14 commits) 
Codegen hooks for fusion-aware autotuning in external Triton template backends, with
  per-template prologue/epilogue fusion flags, enabling the Helion compiler to participate in Inductor's scheduling and fusion pipeline.

###  Opaque Object Tracing (~12 commits)
Objects like Generator, DeviceMesh, and ProcessGroup can now be traced through Dynamo, AOT Autograd, and
   Inductor as "opaque objects" — they can be graph inputs/outputs and survive partitioning, which is critical for compiling distributed and
  RNG-dependent code.

##  Distributed

###  DTensor Pipeline Parallelism (~105 commits, PP series plus DTensor sharding work) 
First-class pipeline parallelism built on DTensor:
  metadata foundation, DTensor-aware stage/schedule refactoring, and integration tests. Also includes expanded sharding propagation rules for
  conv, LayerNorm, RMSNorm, interpolate, and index ops.

 ## Attention & Inference

###  Variable-Length Attention for Inference (~23 commits) 
Adds paged attention support (page_table, seqused_k), an out-variant, a GQA flag, flop
   registration, and AOTInductor integration for variable-length attention, targeting inference serving workloads.

##  Accelerator Frontend

### Unified torch.accelerator Graph/Stream API (4 commits)
 New torch.accelerator.Graph for device-agnostic capture/replay, is_capturing() on
  c10::Stream / torch.Stream, and XPU coverage of the same surface — bringing cross-backend parity to stream and graph management.

##  Inductor Backends

###  Inductor CUTLASS FP8 / FP4 (4 commits)
CUTLASS backend gains float8_e5m2 support, and FP4 block-scaled GEMM now uses nvMatmulHeuristics for
  kernel selection.

##  Platform Enablement

###  ROCm: Expandable Segments + rocSHMEM (6 commits) 
Expandable memory segments on AMD GPUs (ROCm ≥ 7.02, via ROCM_VERSION gating) and rocSHMEM
  enablement for on-GPU communication.