### PR TITLE
Add CPU offload support for selective activation checkpointing

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16211,6 +16211,42 @@ class TestSelectiveActivationCheckpoint(TestCase):
         torch.cos(torch.sin(x2)).sum().backward()
         self.assertEqual(x.grad, x2.grad)
 
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    def test_sac_cpu_offload(self):
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op == torch.ops.aten.mm.default:
+                return CheckpointPolicy.MUST_CPU_OFFLOAD
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        x = torch.randn(512, 512, requires_grad=True, device="cuda")
+        y = torch.randn(512, 512, device="cuda")
+
+        def fn(x, y):
+            return torch.mm(x, y).sin().sum()
+
+        def get_bw_flops(f):
+            f().backward()
+            out = f()
+            with FlopCounterMode(display=False) as mode:
+                out.backward()
+            return mode.get_total_flops() / (512**3 * 2)
+
+        ctx = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+        bw_flops = get_bw_flops(
+            lambda: checkpoint(fn, x, y, use_reentrant=False, context_fn=ctx))
+
+        # mm is offloaded and restored, not recomputed: 1 bw flop (just the mm backward)
+        self.assertEqual(bw_flops, 1.0)
+
+        # Gradient correctness
+        x2 = torch.randn_like(x, requires_grad=True)
+        out = checkpoint(fn, x2, y, use_reentrant=False, context_fn=ctx)
+        out.backward()
+        x3 = x2.detach().clone().requires_grad_(True)
+        torch.mm(x3, y).sin().sum().backward()
+        self.assertEqual(x2.grad, x3.grad)
+
 
 class TestAutogradMultipleDispatch(TestCase):
     def test_autograd_multiple_dispatch_registrations(self, device):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1236,6 +1236,23 @@ class _VersionWrapper:
         return val
 
 
+class _OffloadWrapper:
+    def __init__(self, val) -> None:
+        if isinstance(val, torch.Tensor) and val.device.type != "cpu":
+            self.device = val.device
+            cpu = torch.empty(val.shape, dtype=val.dtype, layout=val.layout, pin_memory=True)
+            cpu.copy_(val)
+            self.val = cpu
+        else:
+            self.device = None
+            self.val = val
+
+    def get_val(self, allow_cache_entry_mutation):
+        if self.device is not None:
+            return self.val.to(self.device, non_blocking=True)
+        return self.val
+
+
 def _maybe_detach(x, any_ret_has_alias_info):
     # We detach for two separate reasons:
     # - For view ops, we need to ensure that when the tensor is returned from
@@ -1446,6 +1463,9 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
             hooks = self.user_hooks
             self.storage[func][idx] = tree_map(
                 lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info), hooks), out)
+        elif policy in (CheckpointPolicy.MUST_CPU_OFFLOAD, CheckpointPolicy.PREFER_CPU_OFFLOAD):
+            self.storage[func][idx] = tree_map(
+                lambda x: _OffloadWrapper(_maybe_detach(x, any_ret_has_alias_info)), out)
         return out
 
 class _CachedTorchDispatchMode(TorchDispatchMode):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #180874
* #180867
* #180866
* #180919
* #176455

When the policy function returns MUST_CPU_OFFLOAD or PREFER_CPU_OFFLOAD,
SAC now automatically copies the op's output to pinned CPU memory during
forward and restores it to the original device during backward. This
avoids both recomputation and GPU memory usage for the cached tensor.

Authored with Claude.

