### PR TITLE
Revert "[CI] Remove runtime Chocolatey installs from Windows CI"

### DIFF
--- a/.ci/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.ci/pytorch/win-test-helpers/build_pytorch.bat
@@ -37,8 +37,11 @@ call %INSTALLER_DIR%\activate_miniconda3.bat
 if errorlevel 1 goto fail
 if not errorlevel 0 goto fail
 
-:: cmake 3.27.9 with ADD_CMAKE_TO_PATH=System is pre-installed on the AMI
-:: (see pytorch/test-infra#7986). This is required for MKL detection.
+:: Update CMake
+:: TODO: Investigate why this helps MKL detection, even when CMake from choco is not used
+call choco upgrade -y cmake --no-progress --installargs 'ADD_CMAKE_TO_PATH=System' --apply-install-arguments-to-dependencies --version=3.27.9
+if errorlevel 1 goto fail
+if not errorlevel 0 goto fail
 
 :: TODO: Move to .ci/docker/requirements-ci.txt
 call pip install mkl==2024.2.0 mkl-static==2024.2.0 mkl-include==2024.2.0

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -109,9 +109,9 @@ runs:
         # that it doesn't interfere
         Set-MpPreference -DisableRealtimeMonitoring $True -ErrorAction Ignore
 
-    - name: Print file locks on runner workspace
+    - name: Install sysinternals handle tool
       continue-on-error: true
       shell: powershell
       run: |
-        # handle.exe is pre-installed on the AMI (pytorch/test-infra#7986)
+        choco install handle -y
         handle C:\actions-runner\_work\


### PR DESCRIPTION
## Summary

Reverts commit 3a893377d9a which was accidentally pushed directly to main. That commit removed the runtime `choco upgrade cmake` and `choco install handle` calls before the new AMI (pytorch/test-infra#7986) with these tools pre-installed was built and rolled out.

Without the choco cmake install, MKL detection fails — causing CUDA build linker errors and CPU builds without MKL support.

## Test plan

- Windows CI should pass (restores the previous working state)