### PR TITLE
[pyrefly] Add type annotations to torch/fx graph and graph_module

### DIFF
--- a/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
@@ -7,30 +7,30 @@ torch.fx._symbolic_trace.Tracer.path_of_module(self, mod: torch.nn.modules.modul
 torch.fx._symbolic_trace.Tracer.trace(self, root: Union[torch.nn.modules.module.Module, Callable[..., Any]], concrete_args: Optional[Dict[str, Any]] = None) -> torch.fx.graph.Graph
 torch.fx._symbolic_trace.symbolic_trace(root: Union[torch.nn.modules.module.Module, Callable[..., Any]], concrete_args: Optional[Dict[str, Any]] = None) -> torch.fx.graph_module.GraphModule
 torch.fx._symbolic_trace.wrap(fn_or_name: torch.fx.node.Target) -> torch.fx.node.Target
-torch.fx.graph.Graph.__init__(self, owning_module: Optional[GraphModule] = None, tracer_cls: Optional[Type[Tracer]] = None, tracer_extras: Optional[Dict[str, Any]] = None)
-torch.fx.graph.Graph.call_function(self, the_function: Callable[..., Any], args: Optional[Tuple[Argument, ...]] = None, kwargs: Optional[Dict[str, Argument]] = None, type_expr: Optional[Any] = None, name: Optional[str] = None) -> torch.fx.node.Node
-torch.fx.graph.Graph.call_method(self, method_name: str, args: Optional[Tuple[Argument, ...]] = None, kwargs: Optional[Dict[str, Argument]] = None, type_expr: Optional[Any] = None) -> torch.fx.node.Node
-torch.fx.graph.Graph.call_module(self, module_name: str, args: Optional[Tuple[Argument, ...]] = None, kwargs: Optional[Dict[str, Argument]] = None, type_expr: Optional[Any] = None) -> torch.fx.node.Node
-torch.fx.graph.Graph.create_node(self, op: str, target: 'Target', args: Optional[Tuple[Argument, ...]] = None, kwargs: Optional[Dict[str, Argument]] = None, name: Optional[str] = None, type_expr: Optional[Any] = None) -> torch.fx.node.Node
-torch.fx.graph.Graph.eliminate_dead_code(self, is_impure_node: Optional[Callable[[torch.fx.node.Node], bool]] = None) -> bool
-torch.fx.graph.Graph.erase_node(self, to_erase: torch.fx.node.Node) -> None
-torch.fx.graph.Graph.get_attr(self, qualified_name: str, type_expr: Optional[Any] = None) -> torch.fx.node.Node
-torch.fx.graph.Graph.graph_copy(self, g: 'Graph', val_map: Dict[torch.fx.node.Node, torch.fx.node.Node], return_output_node = False) -> 'Optional[Argument]'
-torch.fx.graph.Graph.inserting_after(self, n: Optional[torch.fx.node.Node] = None)
-torch.fx.graph.Graph.inserting_before(self, n: Optional[torch.fx.node.Node] = None)
-torch.fx.graph.Graph.lint(self)
-torch.fx.graph.Graph.node_copy(self, node: torch.fx.node.Node, arg_transform: Callable[[torch.fx.node.Node], Argument] = <function <lambda>>) -> torch.fx.node.Node
-torch.fx.graph.Graph.output(self, result: 'Argument', type_expr: Optional[Any] = None)
-torch.fx.graph.Graph.placeholder(self, name: str, type_expr: Optional[Any] = None, default_value: Any) -> torch.fx.node.Node
-torch.fx.graph.Graph.print_tabular(self)
-torch.fx.graph.Graph.python_code(self, root_module: str, verbose: bool = False, include_stride: bool = False, include_device: bool = False, colored: bool = False, expanded_def: bool = False, record_func: bool = False, additional_meta: Optional[List[str]] = None) -> torch.fx.graph.PythonCode
-torch.fx.graph_module.GraphModule.__init__(self, root: Union[torch.nn.modules.module.Module, Dict[str, Any]], graph: torch.fx.graph.Graph, class_name: str = 'GraphModule')
-torch.fx.graph_module.GraphModule.add_submodule(self, target: str, m: torch.nn.modules.module.Module) -> bool
-torch.fx.graph_module.GraphModule.delete_all_unused_submodules(self) -> None
-torch.fx.graph_module.GraphModule.delete_submodule(self, target: str) -> bool
-torch.fx.graph_module.GraphModule.recompile(self) -> torch.fx.graph.PythonCode
-torch.fx.graph_module.reduce_graph_module(body: Dict[Any, Any], import_block: str) -> torch.nn.modules.module.Module
-torch.fx.graph_module.reduce_package_graph_module(importer: Callable, body: Dict[Any, Any], generated_module_name: str) -> torch.nn.modules.module.Module
+torch.fx.graph.Graph.__init__(self, owning_module: 'Optional[GraphModule]' = None, tracer_cls: 'Optional[type[Tracer]]' = None, tracer_extras: 'Optional[dict[str, Any]]' = None) -> 'None'
+torch.fx.graph.Graph.call_function(self, the_function: 'Callable[..., Any]', args: 'Optional[tuple[Argument, ...]]' = None, kwargs: 'Optional[dict[str, Argument]]' = None, type_expr: 'Optional[Any]' = None, name: 'Optional[str]' = None) -> 'Node'
+torch.fx.graph.Graph.call_method(self, method_name: 'str', args: 'Optional[tuple[Argument, ...]]' = None, kwargs: 'Optional[dict[str, Argument]]' = None, type_expr: 'Optional[Any]' = None) -> 'Node'
+torch.fx.graph.Graph.call_module(self, module_name: 'str', args: 'Optional[tuple[Argument, ...]]' = None, kwargs: 'Optional[dict[str, Argument]]' = None, type_expr: 'Optional[Any]' = None) -> 'Node'
+torch.fx.graph.Graph.create_node(self, op: 'str', target: 'Target', args: 'Optional[tuple[Argument, ...]]' = None, kwargs: 'Optional[dict[str, Argument]]' = None, name: 'Optional[str]' = None, type_expr: 'Optional[Any]' = None) -> 'Node'
+torch.fx.graph.Graph.eliminate_dead_code(self, is_impure_node: 'Optional[Callable[[Node], bool]]' = None) -> 'bool'
+torch.fx.graph.Graph.erase_node(self, to_erase: 'Node') -> 'None'
+torch.fx.graph.Graph.get_attr(self, qualified_name: 'str', type_expr: 'Optional[Any]' = None) -> 'Node'
+torch.fx.graph.Graph.graph_copy(self, g: 'Graph', val_map: 'dict[Node, Node]', return_output_node: 'bool' = False) -> 'Optional[Argument]'
+torch.fx.graph.Graph.inserting_after(self, n: 'Optional[Node]' = None) -> '_InsertPoint'
+torch.fx.graph.Graph.inserting_before(self, n: 'Optional[Node]' = None) -> '_InsertPoint'
+torch.fx.graph.Graph.lint(self) -> 'None'
+torch.fx.graph.Graph.node_copy(self, node: 'Node', arg_transform: 'Callable[[Node], Argument]' = <function <lambda>>) -> 'Node'
+torch.fx.graph.Graph.output(self, result: 'Argument', type_expr: 'Optional[Any]' = None)
+torch.fx.graph.Graph.placeholder(self, name: 'str', type_expr: 'Optional[Any]' = None, default_value: 'Any') -> 'Node'
+torch.fx.graph.Graph.print_tabular(self) -> 'None'
+torch.fx.graph.Graph.python_code(self, root_module: 'str', verbose: 'bool' = False, include_stride: 'bool' = False, include_device: 'bool' = False, colored: 'bool' = False, expanded_def: 'bool' = False, record_func: 'bool' = False, additional_meta: 'Optional[list[str]]' = None) -> 'PythonCode'
+torch.fx.graph_module.GraphModule.__init__(self, root: 'torch.nn.Module | dict[str, Any]', graph: 'Graph', class_name: 'str' = 'GraphModule') -> 'None'
+torch.fx.graph_module.GraphModule.add_submodule(self, target: 'str', m: 'torch.nn.Module') -> 'bool'
+torch.fx.graph_module.GraphModule.delete_all_unused_submodules(self) -> 'None'
+torch.fx.graph_module.GraphModule.delete_submodule(self, target: 'str') -> 'bool'
+torch.fx.graph_module.GraphModule.recompile(self) -> 'PythonCode'
+torch.fx.graph_module.reduce_graph_module(body: 'dict[str, Any]', import_block: 'str') -> 'torch.nn.Module'
+torch.fx.graph_module.reduce_package_graph_module(importer: 'PackageImporter', body: 'dict[str, Any]', generated_module_name: 'str') -> 'torch.nn.Module'
 torch.fx.interpreter.Interpreter.__init__(self, module: torch.nn.modules.module.Module, garbage_collect_values: bool = True, graph: Optional[torch.fx.graph.Graph] = None) -> None
 torch.fx.interpreter.Interpreter.boxed_run(self, args_list: List[Any]) -> Any
 torch.fx.interpreter.Interpreter.call_function(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any

--- a/torch/_functorch/compile_utils.py
+++ b/torch/_functorch/compile_utils.py
@@ -219,7 +219,7 @@ def strip_overloads(gm: fx.GraphModule) -> None:
     gm.recompile()
 
 
-def get_placeholders(graph: fx.Graph) -> fx.graph._node_list:
+def get_placeholders(graph: fx.Graph) -> list[Any]:
     return graph.find_nodes(op="placeholder")
 
 

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -163,8 +163,10 @@ class LoopBody:
         self.memory_usage = {t: [] for t in MemoryUsageType}
         self.op_counts = collections.Counter()
         self.root_block = LoopBodyBlock(self, fn, args)  # traces
-        self.has_partial_accumulate = self.root_block.graph.find_nodes(
-            op="call_method", target="partial_accumulate"
+        self.has_partial_accumulate = bool(
+            self.root_block.graph.find_nodes(
+                op="call_method", target="partial_accumulate"
+            )
         )
         del self.indexing_exprs_name  # not used after _init_with_tracing
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1,4 +1,5 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 import builtins
 import contextlib
 import copy
@@ -15,10 +16,10 @@ import types
 import typing
 import warnings
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Literal, NamedTuple, Optional, TYPE_CHECKING
+from typing import Any, Literal, NamedTuple, TYPE_CHECKING
 
 import torch
 import torch.utils._pytree as pytree
@@ -72,7 +73,7 @@ class _CustomBuiltin(NamedTuple):
     # How to import this object from the standard library.
     import_str: str
     # The actual object, produced from that import string.
-    obj: Any
+    obj: object
 
 
 # Combined dict of disallowed variable names so we can check with one lookup
@@ -82,7 +83,7 @@ _illegal_names.update(builtins.__dict__)  # can't shadow a builtin name
 _custom_builtins: dict[str, _CustomBuiltin] = {}
 
 
-def _register_custom_builtin(name: str, import_str: str, obj: Any):
+def _register_custom_builtin(name: str, import_str: str, obj: object) -> None:
     _custom_builtins[name] = _CustomBuiltin(import_str, obj)
     _illegal_names[name] = obj
 
@@ -131,7 +132,7 @@ _torch_but_not_dynamo = re.compile(
 ).fullmatch
 
 
-def _is_from_torch(obj: Any) -> bool:
+def _is_from_torch(obj: object) -> bool:
     module_name = getattr(obj, "__module__", None)
     if module_name is not None:
         return _torch_but_not_dynamo(module_name) is not None
@@ -155,12 +156,12 @@ class _Namespace:
     - Names generated do not shadow builtins, unless the object is indeed that builtin.
     """
 
-    def __init__(self):
-        self._obj_to_name: dict[Any, str] = {}
+    def __init__(self) -> None:
+        self._obj_to_name: dict[object, str] = {}
         self._used_names: set[str] = set()
         self._base_count: dict[str, int] = {}
 
-    def create_name(self, candidate: str, obj: Any | None) -> str:
+    def create_name(self, candidate: str, obj: object | None) -> str:
         """Create a unique name.
 
         Arguments:
@@ -211,7 +212,7 @@ class _Namespace:
             self._obj_to_name[obj] = candidate
         return candidate
 
-    def associate_name_with_obj(self, name: str, obj: Any):
+    def associate_name_with_obj(self, name: str, obj: object) -> None:
         """Associate a unique name with an object.
 
         Neither `name` nor `obj` should be associated already.
@@ -220,7 +221,7 @@ class _Namespace:
         if maybe_existing is not name:
             raise AssertionError("obj is already associated")
 
-    def _rename_object(self, obj: Any, name: str):
+    def _rename_object(self, obj: object, name: str) -> None:
         if obj not in self._obj_to_name:
             raise AssertionError(f"Object {obj} is not in _obj_to_name")
         self._obj_to_name[obj] = name
@@ -257,19 +258,26 @@ def _format_target(base: str, target: str) -> str:
 
 
 class _InsertPoint:
-    def __init__(self, graph, new_insert):
+    def __init__(self, graph: Graph, new_insert: Callable[..., None]) -> None:
         self.graph = graph
         self.orig_insert, graph._insert = graph._insert, new_insert
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         pass
 
-    def __exit__(self, type, value, tb):
+    def __exit__(
+        self,
+        type: type[BaseException] | None,
+        value: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
         self.graph._insert = self.orig_insert
 
 
 class _node_list:
-    def __init__(self, graph: "Graph", direction: Literal["_prev", "_next"] = "_next"):
+    def __init__(
+        self, graph: Graph, direction: Literal["_prev", "_next"] = "_next"
+    ) -> None:
         if direction not in ("_next", "_prev"):
             raise AssertionError(
                 f"direction must be '_next' or '_prev', got {direction}"
@@ -277,14 +285,19 @@ class _node_list:
         self.graph = graph
         self.direction = direction
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.graph._len
 
-    def __iter__(self):
+    # TODO: These should return Iterator[Node], but doing so causes ~350
+    # downstream pyrefly errors because Node.target is typed as
+    # Callable[..., Any] | str and pyrefly can't narrow it based on
+    # node.op checks (e.g. `if node.op == "call_module": node.target`
+    # should be str but pyrefly doesn't support that narrowing).
+    def __iter__(self) -> Iterator[Any]:
         return _NodeIter(self.graph._root, self.direction == "_prev")
 
-    def __reversed__(self):
-        return _node_list(self.graph, "_next" if self.direction == "_prev" else "_prev")
+    def __reversed__(self) -> Iterator[Any]:
+        return _NodeIter(self.graph._root, self.direction == "_next")
 
 
 class _PyTreeInfo(NamedTuple):
@@ -308,14 +321,14 @@ class _ParsedStackTrace:
     name: str
     code: str
 
-    def get_summary_str(self):
+    def get_summary_str(self) -> str:
         return f"File: {self.file}:{self.lineno} in {self.name}, code: {self.code}"
 
 
 # get File:lineno code from stack_trace
 def _parse_stack_trace(
     stack_trace: str, filter_fn: Callable[[str, str, str], bool] | None = None
-):
+) -> _ParsedStackTrace | None:
     if stack_trace is None:
         return None
     pattern = re.compile(r"^File \"(.+)\", line (\d+), in (.+)$")
@@ -341,9 +354,9 @@ def _parse_stack_trace(
 @compatibility(is_backward_compatible=False)
 class CodeGen:
     # This is an override hook so we can customize the SymNode printer.
-    _sym_repr: Callable[["torch.types.PySymType"], str] = lambda x: repr(x)
+    _sym_repr: Callable[[torch.types.PySymType], str] = lambda x: repr(x)
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._body_transformer: TransformCodeFunc | None = None
         self._func_name: str = "forward"
 
@@ -359,12 +372,16 @@ class CodeGen:
         else:
             return f"    {arg},\n"
 
-    def _get_delimiters(self, container) -> tuple[str, str]:
+    def _get_delimiters(self, container: Sequence[object]) -> tuple[str, str]:
         """Helper to get opening and closing delimiters for containers."""
         return ("(", ")") if isinstance(container, tuple) else ("[", "]")
 
     def _format_multiline_container(
-        self, items, descs=None, prefix="", repr_fn=None
+        self,
+        items: Sequence[object],
+        descs: Sequence[str] | None = None,
+        prefix: str = "",
+        repr_fn: Callable[[object], str] | None = None,
     ) -> str:
         """Helper to format containers (lists/tuples) in multiline format."""
         ldelim, rdelim = self._get_delimiters(items)
@@ -381,13 +398,17 @@ class CodeGen:
             + f"{rdelim}"
         )
 
-    def _get_desc_trailers(self, items, descs):
+    def _get_desc_trailers(
+        self, items: Sequence[object], descs: Sequence[str] | None
+    ) -> list[str]:
         """Helper to generate description trailers for items."""
         if descs is None:
             return [""] * len(items)
         return [f"  # {desc}" for desc in descs]
 
-    def _call_method_with_signature_check(self, method, *args, **kwargs):
+    def _call_method_with_signature_check(
+        self, method: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> Any:
         """Helper to call a method with optional parameters based on signature."""
         sig = inspect.signature(method)
         # Filter kwargs to only include parameters that exist in the method signature
@@ -422,8 +443,8 @@ class CodeGen:
         self,
         output_args: Argument,
         *,
-        descs: Any | None = None,
-        repr_fn: Any | None = None,
+        descs: Sequence[str] | None = None,
+        repr_fn: Callable[[object], str] | None = None,
     ) -> str:
         """
         Given the output arguments, generates the return statement of the FX function.
@@ -466,7 +487,7 @@ class CodeGen:
 
     def _gen_python_code(
         self,
-        nodes,
+        nodes: _node_list,
         root_module: str,
         namespace: _Namespace,
         *,
@@ -494,7 +515,7 @@ class CodeGen:
         )
         include_meta = os.environ.get("FX_GRAPH_SHOW_META", "0") == "1"
 
-        def add_global(name_hint: str, obj: Any):
+        def add_global(name_hint: str, obj: Any) -> str:
             """Add an obj to be tracked as a global.
 
             We call this for names that reference objects external to the
@@ -526,7 +547,7 @@ class CodeGen:
         for name, (_, obj) in _custom_builtins.items():
             add_global(name, obj)
 
-        def type_repr(o: Any):
+        def type_repr(o: object) -> str:
             if o == ():
                 # Empty tuple is used for empty tuple type annotation Tuple[()]
                 return "()"
@@ -568,7 +589,7 @@ class CodeGen:
             dim_blue = _identity
             blue = _identity
 
-        def _get_repr(arg: Any) -> str:
+        def _get_repr(arg: object) -> str:
             if isinstance(arg, Node):  # first because common
                 return repr(arg)
             elif isinstance(arg, tuple) and hasattr(arg, "_fields"):
@@ -621,7 +642,7 @@ class CodeGen:
         node_to_last_use: dict[Node, Node] = {}
         user_to_last_uses: dict[Node, list[Node]] = {}
 
-        def register_last_uses(n: Node, user: Node):
+        def register_last_uses(n: Node, user: Node) -> None:
             if n not in node_to_last_use:
                 node_to_last_use[n] = user
                 user_to_last_uses.setdefault(user, []).append(n)
@@ -630,7 +651,7 @@ class CodeGen:
             for input_node in node._input_nodes:
                 register_last_uses(input_node, node)
 
-        def delete_unused_values(user: Node):
+        def delete_unused_values(user: Node) -> None:
             """
             Delete values after their last use. This ensures that values that are
             not used in the remainder of the code are freed and the memory usage
@@ -659,7 +680,7 @@ class CodeGen:
 
         prev_summary_str = None
 
-        def append_stacktrace_summary(node: Node):
+        def append_stacktrace_summary(node: Node) -> None:
             """
             Append a summary of the stacktrace to the generated code. This is
             useful for debugging.
@@ -669,7 +690,7 @@ class CodeGen:
             if node.op not in {"placeholder", "output"}:
                 additional_meta_str = ""
                 if additional_meta:
-                    parts = []
+                    parts: list[str] = []
                     for key in additional_meta:
                         if key in node.meta:
                             parts.append(f"{key}: {node.meta[key]}")
@@ -716,10 +737,10 @@ class CodeGen:
                     prev_summary_str = summary_str
                     body.append(summary_str)
 
-        def stringify_shape(shape: Iterable) -> str:
+        def stringify_shape(shape: Iterable[object]) -> str:
             return f"[{', '.join([str(x) for x in shape])}]"
 
-        def emit_node(node: Node):
+        def emit_node(node: Node) -> None:
             maybe_type_annotation = (
                 "" if node.type is None else f" : {type_repr(node.type)}"
             )
@@ -1021,8 +1042,12 @@ class _BoxedCodeGen(CodeGen):
     """
 
     def gen_fn_def(
-        self, free_vars, maybe_return_annotation, *, expanded_def: bool = False
-    ):
+        self,
+        free_vars: list[str],
+        maybe_return_annotation: str,
+        *,
+        expanded_def: bool = False,
+    ) -> str:
         """
         Generate function definition for boxed calling convention.
 
@@ -1050,7 +1075,7 @@ class _BoxedCodeGen(CodeGen):
 
 
 class _PyTreeCodeGen(CodeGen):
-    def __init__(self, pytree_info: _PyTreeInfo):
+    def __init__(self, pytree_info: _PyTreeInfo) -> None:
         super().__init__()
         self.pytree_info: _PyTreeInfo = pytree_info
 
@@ -1081,7 +1106,9 @@ class _PyTreeCodeGen(CodeGen):
         else:
             return "\n    " + "".join(x + "; " for x in has_annotation) + "\n"
 
-    def gen_var_bindings(self, fn_args, free_vars, expanded_def) -> str:
+    def gen_var_bindings(
+        self, fn_args: list[str], free_vars: list[str], expanded_def: bool
+    ) -> str:
         in_spec = self.pytree_info.in_spec
         # when kwargs is present, in_spec is tuple(args, kwargs)
         has_args_kwargs_tuple = (
@@ -1119,8 +1146,12 @@ class _PyTreeCodeGen(CodeGen):
         return bindings
 
     def gen_fn_def(
-        self, free_vars, maybe_return_annotation, *, expanded_def: bool = False
-    ):
+        self,
+        free_vars: list[str],
+        maybe_return_annotation: str,
+        *,
+        expanded_def: bool = False,
+    ) -> str:
         # Given a user function/model:
         #   myargs = [myargs0, myargs1]
         #   mykwargs = {'mykwargs0': ..., 'mykwargs1': ...}
@@ -1154,8 +1185,12 @@ class _PyTreeCodeGen(CodeGen):
         return fn_definition
 
     def generate_output(
-        self, output_args, *, descs: Any | None = None, repr_fn: Any | None = None
-    ):
+        self,
+        output_args: Argument,
+        *,
+        descs: Sequence[str] | None = None,
+        repr_fn: Callable[[object], str] | None = None,
+    ) -> str:
         if repr_fn is None:
             repr_fn = repr
         if self.pytree_info and self.pytree_info.out_spec:
@@ -1179,11 +1214,11 @@ class _ExportCodeGen(_PyTreeCodeGen):
     def __init__(
         self,
         pytree_info: _PyTreeInfo,
-        in_shuffle_graph: "GraphModule",
-        out_shuffle_graph: "GraphModule",
+        in_shuffle_graph: GraphModule,
+        out_shuffle_graph: GraphModule,
         tree_leaf_names: list[str],
         root: torch.nn.Module | None,
-    ):
+    ) -> None:
         super().__init__(pytree_info)
         self.in_shuffle_graph = in_shuffle_graph
         self.out_shuffle_graph = out_shuffle_graph
@@ -1203,11 +1238,13 @@ class _ExportCodeGen(_PyTreeCodeGen):
         ret = super().process_outputs(flat_outs)
         return ret
 
-    def gen_fn_def(self, *args, **kwargs) -> str:
+    def gen_fn_def(self, *args: Any, **kwargs: Any) -> str:
         fn_def = super().gen_fn_def(*args, **kwargs)
         return fn_def
 
-    def gen_var_bindings(self, fn_args, free_vars, expanded_def) -> str:
+    def gen_var_bindings(
+        self, fn_args: list[str], free_vars: list[str], expanded_def: bool
+    ) -> str:
         without_annotation = [x.split(":")[0].split("#")[0] for x in free_vars]
         fn_signature: str = f"{', '.join(fn_args)}"
         if self.root is not None:
@@ -1216,7 +1253,11 @@ class _ExportCodeGen(_PyTreeCodeGen):
     {", ".join(self.tree_leaf_names)}, = pytree.tree_leaves(({fn_signature},))
     {", ".join(without_annotation)}, = self._in_shuffle_graph({", ".join(self.tree_leaf_names)})"""
 
-    def generate_output(self, output_args, *args, **kwargs) -> str:
+    def generate_output(self, output_args: Argument, *args: Any, **kwargs: Any) -> str:
+        if not isinstance(output_args, (list, tuple)):
+            raise TypeError(
+                f"Expected list or tuple for output_args, got {type(output_args)}"
+            )
         output = f"self._out_shuffle_graph({', '.join(self.tree_leaf_names)}, {', '.join([str(a) for a in output_args])})"
         return f"return pytree.tree_unflatten({output}, self._out_spec)"
 
@@ -1226,15 +1267,15 @@ class _FindNodesLookupTable:
     Side table for the graph for the purpose of doing fast queries
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.table: dict[tuple[str, Target | None], dict[Node, None]] = defaultdict(
             dict
         )
 
-    def _key(self, node) -> tuple[str, Target | None]:
+    def _key(self, node: Node) -> tuple[str, Target | None]:
         return (node.op, node.target if node.op == "call_function" else None)
 
-    def __contains__(self, node) -> bool:
+    def __contains__(self, node: Node) -> bool:
         return node in self.table[self._key(node)]
 
     def insert(self, node: Node) -> None:
@@ -1243,7 +1284,8 @@ class _FindNodesLookupTable:
     def remove(self, node: Node) -> None:
         self.table[self._key(node)].pop(node)
 
-    def find_nodes(self, *, op: str, target: Optional["Target"] = None):
+    # TODO: should return list[Node], see _node_list.__iter__ comment
+    def find_nodes(self, *, op: str, target: Target | None = None) -> list[Any]:
         if op == "call_function":
             if target is None:
                 raise AssertionError("target must not be None for call_function op")
@@ -1308,10 +1350,10 @@ class Graph:
     @compatibility(is_backward_compatible=True)
     def __init__(
         self,
-        owning_module: Optional["GraphModule"] = None,
-        tracer_cls: type["Tracer"] | None = None,
+        owning_module: GraphModule | None = None,
+        tracer_cls: type[Tracer] | None = None,
         tracer_extras: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """
         Construct an empty Graph.
         """
@@ -1328,11 +1370,13 @@ class Graph:
         self._find_nodes_lookup_table = _FindNodesLookupTable()
 
     @property
-    def owning_module(self):
+    # TODO: should return GraphModule | None, but causes downstream errors
+    # where callers pass it to functions expecting non-optional GraphModule
+    def owning_module(self):  # pyrefly: ignore[unannotated-return]
         return self._owning_module
 
     @owning_module.setter
-    def owning_module(self, mod: Optional["GraphModule"]):
+    def owning_module(self, mod: GraphModule | None) -> None:
         self._owning_module = mod
 
     @property
@@ -1358,9 +1402,10 @@ class Graph:
         return output_node
 
     @compatibility(is_backward_compatible=False)
+    # TODO: should return list[Node], see _node_list.__iter__ comment
     def find_nodes(
-        self, *, op: str, target: Optional["Target"] = None, sort: bool = True
-    ):
+        self, *, op: str, target: Target | None = None, sort: bool = True
+    ) -> list[Any]:
         """
         Allows for fast query of nodes
 
@@ -1385,8 +1430,8 @@ class Graph:
 
     @compatibility(is_backward_compatible=True)
     def graph_copy(
-        self, g: "Graph", val_map: dict[Node, Node], return_output_node=False
-    ) -> "Argument | None":
+        self, g: Graph, val_map: dict[Node, Node], return_output_node: bool = False
+    ) -> Argument | None:
         """
         Copy all nodes from a given graph into ``self``.
 
@@ -1412,7 +1457,7 @@ class Graph:
             val_map[node] = self.node_copy(node, lambda n: val_map[n])
         return None
 
-    def __deepcopy__(self, memo=None) -> "Graph":
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Graph:
         """
         Explicitly implement __deepcopy__ to prevent excessive recursion depth
         from the default implementation. This uses graph_copy to copy the nodes
@@ -1422,7 +1467,11 @@ class Graph:
         """
         memo = memo if memo else {}
         g = Graph(tracer_cls=self._tracer_cls)
-        output_vals = g.graph_copy(self, val_map=memo, return_output_node=True)
+        output_vals = g.graph_copy(
+            self,
+            val_map=memo,  # pyrefly: ignore[bad-argument-type]
+            return_output_node=True,
+        )
         g._codegen = copy.deepcopy(self._codegen)
         if output_vals is not None:
             if not isinstance(output_vals, tuple):
@@ -1443,9 +1492,9 @@ class Graph:
     def create_node(
         self,
         op: str,
-        target: "Target",
-        args: tuple["Argument", ...] | None = None,
-        kwargs: dict[str, "Argument"] | None = None,
+        target: Target,
+        args: tuple[Argument, ...] | None = None,
+        kwargs: dict[str, Argument] | None = None,
         name: str | None = None,
         type_expr: Any | None = None,
     ) -> Node:
@@ -1505,14 +1554,14 @@ class Graph:
         return n
 
     @compatibility(is_backward_compatible=False)
-    def process_inputs(self, *args):
+    def process_inputs(self, *args: Any) -> Any:
         """
         Processes args so that they can be passed to the FX graph.
         """
         return self._codegen.process_inputs(*args)
 
     @compatibility(is_backward_compatible=False)
-    def process_outputs(self, out):
+    def process_outputs(self, out: Any) -> Any:
         return self._codegen.process_outputs(out)
 
     @compatibility(is_backward_compatible=True)
@@ -1557,7 +1606,7 @@ class Graph:
         )
 
     @compatibility(is_backward_compatible=True)
-    def inserting_before(self, n: Node | None = None):
+    def inserting_before(self, n: Node | None = None) -> _InsertPoint:
         """Set the point at which create_node and companion methods will insert into the graph.
         When used within a 'with' statement, this will temporary set the insert point and
         then restore it when the with statement exits::
@@ -1582,7 +1631,7 @@ class Graph:
         return _InsertPoint(self, n.prepend)
 
     @compatibility(is_backward_compatible=True)
-    def inserting_after(self, n: Node | None = None):
+    def inserting_after(self, n: Node | None = None) -> _InsertPoint:
         """Set the point at which create_node and companion methods will insert into the graph.
         When used within a 'with' statement, this will temporary set the insert point and
         then restore it when the with statement exits::
@@ -1690,7 +1739,7 @@ class Graph:
 
             return True
 
-        if self.owning_module and not _get_attr_reference_exists(
+        if self.owning_module is not None and not _get_attr_reference_exists(
             self.owning_module, qualified_name
         ):
             warnings.warn(
@@ -1711,8 +1760,8 @@ class Graph:
     def call_module(
         self,
         module_name: str,
-        args: tuple["Argument", ...] | None = None,
-        kwargs: dict[str, "Argument"] | None = None,
+        args: tuple[Argument, ...] | None = None,
+        kwargs: dict[str, Argument] | None = None,
         type_expr: Any | None = None,
     ) -> Node:
         """
@@ -1745,7 +1794,10 @@ class Graph:
             The same insertion point and type expression rules apply for this method
             as :meth:`Graph.create_node`.
         """
-        if self.owning_module and self.owning_module.get_submodule(module_name) is None:
+        if (
+            self.owning_module is not None
+            and self.owning_module.get_submodule(module_name) is None
+        ):
             warnings.warn(
                 "Attempted to insert a call_module Node with "
                 "no underlying reference in the owning "
@@ -1761,8 +1813,8 @@ class Graph:
     def call_method(
         self,
         method_name: str,
-        args: tuple["Argument", ...] | None = None,
-        kwargs: dict[str, "Argument"] | None = None,
+        args: tuple[Argument, ...] | None = None,
+        kwargs: dict[str, Argument] | None = None,
         type_expr: Any | None = None,
     ) -> Node:
         """
@@ -1800,8 +1852,8 @@ class Graph:
     def call_function(
         self,
         the_function: Callable[..., Any],
-        args: tuple["Argument", ...] | None = None,
-        kwargs: dict[str, "Argument"] | None = None,
+        args: tuple[Argument, ...] | None = None,
+        kwargs: dict[str, Argument] | None = None,
         type_expr: Any | None = None,
         name: str | None = None,
     ) -> Node:
@@ -1840,7 +1892,7 @@ class Graph:
 
     @compatibility(is_backward_compatible=True)
     def node_copy(
-        self, node: Node, arg_transform: Callable[[Node], "Argument"] = lambda x: x
+        self, node: Node, arg_transform: Callable[[Node], Argument] = lambda x: x
     ) -> Node:
         """
         Copy a node from one graph into another. ``arg_transform`` needs to transform arguments from
@@ -1876,7 +1928,10 @@ class Graph:
         return result_node
 
     @compatibility(is_backward_compatible=True)
-    def output(self, result: "Argument", type_expr: Any | None = None):
+    # TODO: should return Node, see _node_list.__iter__ comment
+    def output(  # pyrefly: ignore[unannotated-return]
+        self, result: Argument, type_expr: Any | None = None
+    ):
         """
         Insert an ``output`` ``Node`` into the ``Graph``. An ``output`` node represents
         a ``return`` statement in Python code. ``result`` is the value that should
@@ -1964,11 +2019,11 @@ class Graph:
         # makes sense to reuse it. This way, it's easy to print something like
         # Tuple[Node, Node] by simply calling repr() on it. Node's __repr__ is
         # implemented cooperatively to allow this.
-        def node_repr(n: Node):
+        def node_repr(n: Node) -> str:
             return namespace.create_name(n.name, n)
 
         @contextmanager
-        def override_node_repr(graph: Graph):
+        def override_node_repr(graph: Graph) -> Generator[None, None, None]:
             orig_repr_fns = {}
             for node in graph.nodes:
                 orig_repr_fns[node] = node._repr_fn
@@ -2038,14 +2093,14 @@ class Graph:
         return s
 
     @compatibility(is_backward_compatible=True)
-    def print_tabular(self):
+    def print_tabular(self) -> None:
         """
         Prints the intermediate representation of the graph in tabular
         format. Note that this API requires the ``tabulate`` module to be
         installed.
         """
         try:
-            from tabulate import tabulate
+            from tabulate import tabulate  # pyrefly: ignore[missing-import]
         except ImportError:
             print(
                 "`print_tabular` relies on the library `tabulate`, "
@@ -2060,7 +2115,7 @@ class Graph:
         )
 
     @compatibility(is_backward_compatible=True)
-    def lint(self):
+    def lint(self) -> None:
         """
         Runs various checks on this Graph to make sure it is well-formed. In
         particular:
@@ -2194,7 +2249,7 @@ class Graph:
         if torch._guards.TracingContext.try_get():
             impure_random = torch._inductor.config.fallback_random
 
-        def has_side_effect(node):
+        def has_side_effect(node: Node) -> bool:
             if is_impure_node is not None:
                 return is_impure_node(node)
             return node.is_impure(impure_random)
@@ -2229,14 +2284,14 @@ class Graph:
         return changed
 
     @compatibility(is_backward_compatible=False)
-    def set_codegen(self, codegen: CodeGen):
+    def set_codegen(self, codegen: CodeGen) -> None:
         self._codegen = codegen
 
     @compatibility(is_backward_compatible=False)
     def on_generate_code(
         self,
         make_transformer: Callable[[TransformCodeFunc | None], TransformCodeFunc],
-    ):
+    ) -> contextlib.AbstractContextManager[None]:
         """Register a transformer function when python code is generated
 
         Args:
@@ -2309,7 +2364,7 @@ class Graph:
         self._codegen._body_transformer = make_transformer(on_gen_code_old)
 
         @contextlib.contextmanager
-        def on_generate_code_context_manager():
+        def on_generate_code_context_manager() -> Generator[None, None, None]:
             try:
                 yield
             finally:
@@ -2325,8 +2380,8 @@ class Graph:
 
 @contextmanager
 def _override_sym_repr(
-    override: Callable[["torch.types.PySymType"], str],
-) -> Iterator[None]:
+    override: Callable[[torch.types.PySymType], str],
+) -> Generator[None, None, None]:
     tmp = CodeGen._sym_repr
     try:
         CodeGen._sym_repr = override
@@ -2335,12 +2390,12 @@ def _override_sym_repr(
         CodeGen._sym_repr = tmp
 
 
-def _identity(x):
+def _identity(x: str) -> str:
     return x
 
 
-def _make_color_fn(code):
-    def f(s):
+def _make_color_fn(code: str) -> Callable[[str], str]:
+    def f(s: str) -> str:
         reset = "\033[0m"
         return f"{code}{s}{reset}"
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -1,17 +1,24 @@
-# mypy: allow-untyped-defs
+from __future__ import annotations
+
 import base64
 import contextlib
 import copy
 import hashlib
 import itertools
 import linecache
-import os
 import sys
 import traceback
 import warnings
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    import os
+    from collections.abc import Callable, Generator
+    from typing import Self
+
+    from .node import Node
 
 import torch
 import torch.nn as nn
@@ -47,11 +54,13 @@ FX_GRAPH_MODULE_FILE_PREFIX = "fx_generated_"
 # Using _exec_with_source will add it to our local cache
 # and then tools like TorchScript will be able to get source info.
 class _EvalCacheLoader:
-    def __init__(self):
+    def __init__(self) -> None:
         self.eval_cache = {}
         self.next_id = 0
 
-    def cache(self, src: str, globals: dict[str, Any], co_fields=None):
+    def cache(
+        self, src: str, globals: dict[str, Any], co_fields: dict[str, Any] | None = None
+    ) -> str:
         """Store the source in a private cache, and add a lazy entry in linecache
         that allows the source to be retrieved by 'filename'.
 
@@ -87,12 +96,12 @@ class _EvalCacheLoader:
 
     # Part of the loader protocol (PEP 302)
     # linecache will use this method when trying to find source code
-    def get_source(self, module_name) -> str | None:
+    def get_source(self, module_name: str) -> str | None:
         if module_name in self.eval_cache:
             return self.eval_cache[module_name]
         return None
 
-    def _get_key(self):
+    def _get_key(self) -> str:
         key = f"<eval_with_key>.{self.next_id}"
         self.next_id += 1
         return key
@@ -101,20 +110,31 @@ class _EvalCacheLoader:
 _loader = _EvalCacheLoader()
 
 
-def _exec_with_source(src: str, globals: dict[str, Any], co_fields=None):
+def _exec_with_source(
+    src: str, globals: dict[str, Any], co_fields: dict[str, Any] | None = None
+) -> None:
     key = _loader.cache(src, globals, co_fields)
-    exec(compile(src, key, "exec"), globals)
+    # dont_inherit=True prevents this module's `from __future__ import
+    # annotations` from leaking into the generated code, which would turn
+    # type annotations into strings and break downstream consumers like
+    # TorchScript that expect real type objects.
+    exec(compile(src, key, "exec", dont_inherit=True), globals)
 
 
-def _forward_from_src(src: str, globals: dict[str, Any], co_fields=None):
+def _forward_from_src(
+    src: str, globals: dict[str, Any], co_fields: dict[str, Any] | None = None
+) -> Callable[..., Any]:
     return _method_from_src(
         method_name="forward", src=src, globals=globals, co_fields=co_fields
     )
 
 
 def _method_from_src(
-    method_name: str, src: str, globals: dict[str, Any], co_fields=None
-) -> Callable:
+    method_name: str,
+    src: str,
+    globals: dict[str, Any],
+    co_fields: dict[str, Any] | None = None,
+) -> Callable[..., Any]:
     # avoid mutating the passed in dict
     globals_copy = globals.copy()
     _exec_with_source(src, globals_copy, co_fields)
@@ -123,7 +143,7 @@ def _method_from_src(
     return fn
 
 
-def _format_import_statement(name: str, obj: Any, importer: Importer) -> str:
+def _format_import_statement(name: str, obj: object, importer: Importer) -> str:
     if name in _custom_builtins:
         return _custom_builtins[name].import_str
     if _is_from_torch(name):
@@ -132,7 +152,7 @@ def _format_import_statement(name: str, obj: Any, importer: Importer) -> str:
     return f"from {module_name} import {attr_name} as {name}"
 
 
-def _format_import_block(globals: dict[str, Any], importer: Importer):
+def _format_import_block(globals: dict[str, Any], importer: Importer) -> str:
     import_strs: set[str] = {
         _format_import_statement(name, obj, importer) for name, obj in globals.items()
     }
@@ -142,7 +162,7 @@ def _format_import_block(globals: dict[str, Any], importer: Importer):
 
 
 @compatibility(is_backward_compatible=True)
-def reduce_graph_module(body: dict[Any, Any], import_block: str) -> torch.nn.Module:
+def reduce_graph_module(body: dict[str, Any], import_block: str) -> torch.nn.Module:
     # BC: attribute name was changed from `code` to `_code` to facilitate
     # making `code` into a property and adding a docstring to it
     fn_src = body.get("_code") or body["code"]
@@ -152,7 +172,7 @@ def reduce_graph_module(body: dict[Any, Any], import_block: str) -> torch.nn.Mod
 
 @compatibility(is_backward_compatible=True)
 def reduce_package_graph_module(
-    importer: PackageImporter, body: dict[Any, Any], generated_module_name: str
+    importer: PackageImporter, body: dict[str, Any], generated_module_name: str
 ) -> torch.nn.Module:
     forward = importer.import_module(generated_module_name).forward
     return _deserialize_graph_module(forward, body)
@@ -162,13 +182,15 @@ def reduce_package_graph_module(
 # function off of the class, rather than the instance. This class is used
 # in _deserialize_graph_module() below.
 class _CodeOnlyModule(torch.nn.Module):
-    def __init__(self, body):
+    def __init__(self, body: dict[str, Any]) -> None:
         super().__init__()
         self.__dict__ = body
 
 
 def _deserialize_graph_module(
-    forward, body: dict[Any, Any], graph_module_cls=None
+    forward: Callable[..., Any],
+    body: dict[str, Any],
+    graph_module_cls: type | None = None,
 ) -> torch.nn.Module:
     """
     Deserialize a GraphModule given the dictionary of the original module,
@@ -232,7 +254,9 @@ def _deserialize_graph_module(
 
 # copy an attribute value with qualified name 'target' from 'from_module' to 'to_module'
 # This installs empty Modules where none exist yet if they are subpaths of target
-def _copy_attr(from_module: torch.nn.Module, to_module: torch.nn.Module, target: str):
+def _copy_attr(
+    from_module: torch.nn.Module, to_module: torch.nn.Module, target: str
+) -> None:
     *prefix, field = target.split(".")
     for item in prefix:
         f = getattr(from_module, item)
@@ -260,7 +284,7 @@ def _copy_attr(from_module: torch.nn.Module, to_module: torch.nn.Module, target:
 
 # Assign attribute 'from_obj' to the qualified name 'target' on 'to_module
 # This installs empty Modules where none exist yet if they are subpaths of target
-def _assign_attr(from_obj: Any, to_module: torch.nn.Module, target: str):
+def _assign_attr(from_obj: object, to_module: torch.nn.Module, target: str) -> None:
     *prefix, field = target.split(".")
     for item in prefix:
         t = getattr(to_module, item, None)
@@ -281,17 +305,17 @@ def _assign_attr(from_obj: Any, to_module: torch.nn.Module, target: str):
 
 
 # Recursively look up target from a graph module.
-def _get_attr(model: torch.nn.Module, attr_name: str):
+def _get_attr(model: torch.nn.Module, attr_name: str) -> Any:
     return _get_attr_via_attr_list(model, attr_name.split("."))
 
 
-def _del_attr(model: torch.nn.Module, attr_name: str):
+def _del_attr(model: torch.nn.Module, attr_name: str) -> None:
     attr_names = attr_name.split(".")
     t = _get_attr_via_attr_list(model, attr_names[:-1])
     return delattr(t, attr_names[-1])
 
 
-def _get_attr_via_attr_list(model: torch.nn.Module, attr_list: list[str]):
+def _get_attr_via_attr_list(model: torch.nn.Module, attr_list: list[str]) -> Any:
     if len(attr_list) == 0:
         return model
     *prefix, field = attr_list
@@ -304,7 +328,7 @@ def _get_attr_via_attr_list(model: torch.nn.Module, attr_list: list[str]):
     return getattr(t, field)
 
 
-def _has_attr(model: torch.nn.Module, attr_name: str):
+def _has_attr(model: torch.nn.Module, attr_name: str) -> bool:
     *prefix, field = attr_name.split(".")
     t = model
     for item in prefix:
@@ -316,15 +340,15 @@ def _has_attr(model: torch.nn.Module, attr_name: str):
 
 
 def _print_readable(
-    module,
-    module_name,
-    print_output=True,
-    include_stride=False,
-    include_device=False,
-    colored=False,
-    expanded_def=False,
-    additional_meta=None,
-):
+    module: torch.nn.Module,
+    module_name: str,
+    print_output: bool = True,
+    include_stride: bool = False,
+    include_device: bool = False,
+    colored: bool = False,
+    expanded_def: bool = False,
+    additional_meta: list[str] | None = None,
+) -> str:
     graph = module.graph
     if graph is None or not isinstance(graph, torch.fx.Graph):
         raise AssertionError("print_readable must be used on a module with a graph")
@@ -345,7 +369,7 @@ def _print_readable(
 
     submodule_code_list = [""]
     for submodule_name, submodule in module.named_children():
-        if hasattr(submodule, "graph"):
+        if isinstance(submodule, GraphModule):
             submodule_code_list.append(
                 _print_readable(
                     submodule,
@@ -366,7 +390,7 @@ def _print_readable(
     return output
 
 
-def _metadata_hash(code: str, node_metadata: dict) -> str:
+def _metadata_hash(code: str, node_metadata: dict[int, dict[str, Any]]) -> str:
     """
     Create a content-addressed hash from code and metadata.
 
@@ -397,7 +421,7 @@ def _metadata_hash(code: str, node_metadata: dict) -> str:
 
 
 class _WrappedCall:
-    def __init__(self, cls, cls_call):
+    def __init__(self, cls: type, cls_call: Callable[..., Any] | None) -> None:
         self.cls = cls
         self.cls_call = cls_call
 
@@ -439,7 +463,7 @@ class _WrappedCall:
         # joined message
         return "\n".join([tb_repr, custom_msg, before_err, marker, err_and_after_err])
 
-    def __call__(self, obj, *args, **kwargs):
+    def __call__(self, obj: Any, *args: Any, **kwargs: Any) -> Any:
         try:
             if self.cls_call is not None:
                 return self.cls_call(obj, *args, **kwargs)
@@ -476,7 +500,7 @@ class GraphModule(torch.nn.Module):
         code.
     """
 
-    def __new__(cls: "type[GraphModule]", *args, **kwargs):
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         # each instance of a graph module needs its own forward method
         # so create a new singleton class for each instance.
         # it is a subclass of the user-defined class, the only difference
@@ -501,7 +525,7 @@ class GraphModule(torch.nn.Module):
         root: torch.nn.Module | dict[str, Any],
         graph: Graph,
         class_name: str = "GraphModule",
-    ):
+    ) -> None:
         """
         Construct a GraphModule.
 
@@ -596,11 +620,11 @@ class GraphModule(torch.nn.Module):
 
         # Dictionary to store metadata
         self.meta: dict[str, Any] = {}
-        self._replace_hooks: list[Callable] = []
-        self._create_node_hooks: list[Callable] = []
-        self._erase_node_hooks: list[Callable] = []
+        self._replace_hooks: list[Callable[[Node, str, Node], object]] = []
+        self._create_node_hooks: list[Callable[[Node], object]] = []
+        self._erase_node_hooks: list[Callable[[Node], object]] = []
         # Used to remove hooks from deepcopied graph modules within a context manager.
-        self._deepcopy_hooks: list[Callable] = []
+        self._deepcopy_hooks: list[Callable[[GraphModule], object]] = []
         self.shape_env = None  # optional not always set even when dynamic shapes exist.
 
     # TorchScript breaks trying to compile the graph setter because of the
@@ -634,7 +658,9 @@ class GraphModule(torch.nn.Module):
         self.recompile()
 
     @compatibility(is_backward_compatible=False)
-    def to_folder(self, folder: str | os.PathLike, module_name: str = "FxModule"):
+    def to_folder(
+        self, folder: str | os.PathLike[str], module_name: str = "FxModule"
+    ) -> None:
         """Dumps out module to ``folder`` with ``module_name`` so that it can be
         imported with ``from <folder> import <module_name>``
 
@@ -675,7 +701,7 @@ class {module_name}(torch.nn.Module):
             else:
                 return None
 
-        blobified_modules = []
+        blobified_modules: list[str] = []
         for module_name, module in self.named_children():
             module_str = _gen_model_repr(module_name, module)
             if module_str is None:
@@ -816,7 +842,7 @@ class {module_name}(torch.nn.Module):
         used: list[str] = []
 
         for node in self.graph.nodes:
-            if node.op == "call_module" or node.op == "get_attr":
+            if node.op in ("call_module", "get_attr") and isinstance(node.target, str):
                 # A list of strings representing the different parts
                 # of the path. For example, `foo.bar.baz` gives us
                 # ["foo", "bar", "baz"]
@@ -838,11 +864,12 @@ class {module_name}(torch.nn.Module):
                 # as used
                 if node.op == "call_module":
                     try:
-                        submod = self.get_submodule(node.target)
+                        str_target = cast(str, node.target)
+                        submod = self.get_submodule(str_target)
 
                         for submod_name, _ in submod.named_modules():
                             if submod_name != "":
-                                used.append(".".join([node.target, submod_name]))
+                                used.append(".".join([str_target, submod_name]))
                     except AttributeError:
                         # Node referenced nonexistent submodule, don't need to
                         # worry about GCing anything
@@ -887,7 +914,9 @@ class {module_name}(torch.nn.Module):
         self._prologue_start = python_code._prologue_start
 
         cls = type(self)
-        co_fields = self._graph._co_fields if hasattr(self._graph, "_co_fields") else {}
+        co_fields: dict[str, Any] = (
+            self._graph._co_fields if hasattr(self._graph, "_co_fields") else {}
+        )
 
         if fx_experimental_config.enrich_profiler_metadata:
             # Generate metadata and register for profiler augmentation
@@ -945,7 +974,7 @@ class {module_name}(torch.nn.Module):
 
         self._recompile_submodules()
 
-        def call_wrapped(self, *args, **kwargs):
+        def call_wrapped(self, *args: Any, **kwargs: Any) -> Any:
             return self._wrapped_call(self, *args, **kwargs)
 
         cls.__call__ = call_wrapped  # type: ignore[method-assign]
@@ -966,7 +995,7 @@ class {module_name}(torch.nn.Module):
     # Passing Tracer as argument allows subclasses extending fx.GraphModule
     # define their own Tracer (extending fx.Tracer).
 
-    def __reduce_package__(self, exporter: PackageExporter):
+    def __reduce_package__(self, exporter: PackageExporter) -> tuple[Any, ...]:
         dict_without_graph = self.__dict__.copy()
         dict_without_graph["_graphmodule_cls_name"] = self.__class__.__name__
         del dict_without_graph["_graph"]
@@ -991,7 +1020,7 @@ class {module_name}(torch.nn.Module):
             (dict_without_graph, generated_module_name),
         )
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple[Any, ...]:
         """
         Serialization of GraphModule. We serialize only the generated code, not
         the underlying ``Graph``. This is because ``Graph`` does not have on-disk
@@ -1006,13 +1035,13 @@ class {module_name}(torch.nn.Module):
         del dict_without_graph["_graph"]
         return (reduce_graph_module, (dict_without_graph, import_block))
 
-    def _deepcopy_init(self):
+    def _deepcopy_init(self) -> Callable[..., None]:
         return GraphModule.__init__
 
     # because __reduce__ is defined for serialization,
     # we need to define deepcopy otherwise it will call __reduce__
     # and cause symbolic tracing to occur every time we try to copy the object
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: dict[int, Any]) -> GraphModule:
         res = type(self).__new__(type(self))
         memo[id(self)] = res
         fake_mod = _CodeOnlyModule(copy.deepcopy(self.__dict__, memo))
@@ -1042,7 +1071,7 @@ class {module_name}(torch.nn.Module):
                 hook(res)
         return res
 
-    def __copy__(self):
+    def __copy__(self) -> GraphModule:
         from ._lazy_graph_module import _make_graph_module
 
         res = _make_graph_module(self, self.graph)
@@ -1052,17 +1081,17 @@ class {module_name}(torch.nn.Module):
     @compatibility(is_backward_compatible=False)
     def print_readable(
         self,
-        print_output=True,
-        include_stride=False,
-        include_device=False,
-        colored=False,
+        print_output: bool = True,
+        include_stride: bool = False,
+        include_device: bool = False,
+        colored: bool = False,
         *,
         # If `fast_sympy_print` is True then we use a sympy printer which is faster
         # but may result in less-readable output.
         fast_sympy_print: bool = False,
         expanded_def: bool = False,
         additional_meta: list[str] | None = None,
-    ):
+    ) -> str:
         """
         Return the Python code generated for current GraphModule and its children GraphModules.
 
@@ -1101,13 +1130,15 @@ class {module_name}(torch.nn.Module):
         )
         return "\n".join([orig_str, self._code, print_readable_reminder])
 
-    def _replicate_for_data_parallel(self):
+    def _replicate_for_data_parallel(self) -> GraphModule:
         new_gm = self.__copy__()
-        new_gm._is_replica = True
+        object.__setattr__(new_gm, "_is_replica", True)
         return new_gm
 
     @contextlib.contextmanager
-    def _set_replace_hook(self, f):
+    def _set_replace_hook(
+        self, f: Callable[[Node, str, Node], object]
+    ) -> Generator[None, None, None]:
         """
         Takes a callable which will be called every time when we replace a node
         to a new node, or change the node's name. Callable takes three arguments:
@@ -1122,7 +1153,9 @@ class {module_name}(torch.nn.Module):
         finally:
             self._unregister_replace_node_hook(f)
 
-    def _register_replace_node_hook(self, f):
+    def _register_replace_node_hook(
+        self, f: Callable[[Node, str, Node], object]
+    ) -> None:
         """
         Takes a callable which will be called every time when we replace a node
         to a new node, or change the node's name. Callable takes three arguments:
@@ -1133,7 +1166,9 @@ class {module_name}(torch.nn.Module):
             raise AssertionError("create_node hook must be a callable.")
         self._replace_hooks.append(f)
 
-    def _unregister_replace_node_hook(self, f):
+    def _unregister_replace_node_hook(
+        self, f: Callable[[Node, str, Node], object]
+    ) -> None:
         """
         Takes a callable which was previously registered to be called every time when we replace a node.
         This function will unregister that callable so it is no longer invoked on node replacement.
@@ -1142,7 +1177,7 @@ class {module_name}(torch.nn.Module):
             raise AssertionError("create_node hook must be a callable.")
         self._replace_hooks.remove(f)
 
-    def _register_create_node_hook(self, f):
+    def _register_create_node_hook(self, f: Callable[[Node], object]) -> None:
         """
         Takes a callable which will be called after we create a new node. The
         callable takes the newly created node as input and returns None.
@@ -1151,7 +1186,7 @@ class {module_name}(torch.nn.Module):
             raise AssertionError("create_node hook must be a callable.")
         self._create_node_hooks.append(f)
 
-    def _unregister_create_node_hook(self, f):
+    def _unregister_create_node_hook(self, f: Callable[[Node], object]) -> None:
         """
         Takes a callable which was previously registered to be called after we create a node.
         This function will unregister that callable so it is no longer invoked on node creation.
@@ -1160,7 +1195,7 @@ class {module_name}(torch.nn.Module):
             raise AssertionError("create_node hook must be a callable.")
         self._create_node_hooks.remove(f)
 
-    def _register_erase_node_hook(self, f):
+    def _register_erase_node_hook(self, f: Callable[[Node], object]) -> None:
         """
         Takes a callable which will be called after we erase a node. The
         callable takes the node that is being erased as input and returns None.
@@ -1169,7 +1204,7 @@ class {module_name}(torch.nn.Module):
             raise AssertionError("erase_node hook must be a callable.")
         self._erase_node_hooks.append(f)
 
-    def _unregister_erase_node_hook(self, f):
+    def _unregister_erase_node_hook(self, f: Callable[[Node], object]) -> None:
         """
         Takes a callable which was previously registered to be called after we erase a node.
         This function will unregister that callable so it is no longer invoked on node erasure.
@@ -1178,7 +1213,7 @@ class {module_name}(torch.nn.Module):
             raise AssertionError("erase_node hook must be a callable.")
         self._erase_node_hooks.remove(f)
 
-    def _register_deepcopy_hook(self, f):
+    def _register_deepcopy_hook(self, f: Callable[[GraphModule], object]) -> None:
         """
         Takes a callable which will be called when we deepcopy this graph module. The
         callable takes the resulting deepcopied graph module.
@@ -1187,7 +1222,7 @@ class {module_name}(torch.nn.Module):
             raise AssertionError("deepcopy hook must be a callable.")
         self._deepcopy_hooks.append(f)
 
-    def _unregister_deepcopy_hook(self, f):
+    def _unregister_deepcopy_hook(self, f: Callable[[GraphModule], object]) -> None:
         """
         Takes a callable which was previously registered to be called after deepcopy.
         This function will unregister that callable so it is no longer invoked on deepcopy.
@@ -1195,19 +1230,3 @@ class {module_name}(torch.nn.Module):
         if not callable(f):
             raise AssertionError("deepcopy hook must be a callable.")
         self._deepcopy_hooks.remove(f)
-
-
-# workarounds for issues in __torch_function__
-
-# WAR for __torch_function__ not handling tensor lists,
-# fix is in https://github.com/pytorch/pytorch/pull/34725
-# orig_cat = torch.cat
-# def patched_cat(*args, **kwargs):
-#     tensors = args[0]
-#     for t in tensors:
-#         if isinstance(t, Proxy):
-#             return t.__torch_function__(patched_cat, (), args, kwargs)
-#     return orig_cat(*args, **kwargs)
-# patched_cat.__module__ = 'torch'
-# patched_cat.__name__ = 'cat'
-# torch.cat = patched_cat

--- a/torch/fx/passes/graph_drawer.py
+++ b/torch/fx/passes/graph_drawer.py
@@ -301,11 +301,12 @@ if HAS_PYDOT:
             # print file:lineno code
             if parse_stack_trace and node.stack_trace is not None:
                 parsed_stack_trace = _parse_stack_trace(node.stack_trace)
-                fname = self._shorten_file_name(parsed_stack_trace.file)
-                label += (
-                    f"|file={fname}:{parsed_stack_trace.lineno} {parsed_stack_trace.code}"
-                    + r"\n"
-                )
+                if parsed_stack_trace is not None:
+                    fname = self._shorten_file_name(parsed_stack_trace.file)
+                    label += (
+                        f"|file={fname}:{parsed_stack_trace.lineno} {parsed_stack_trace.code}"
+                        + r"\n"
+                    )
 
             return label + "}"
 


### PR DESCRIPTION
Reland of https://github.com/pytorch/pytorch/pull/179622

**CRITICAL FIX**: in graph_module, we pass `dont_inherit=True` to the exec call; this prevents future annotations leaking and stringifying types breaking downstream consumers like torchscript

### Summary of changes
  - Removed # mypy: allow-untyped-defs, added from __future__ import annotations
  - Added return types and parameter types to ~50 functions/methods across Graph, CodeGen, _PyTreeCodeGen, _ExportCodeGen, _Namespace,
  - Replaced Any with more specific types where appropriate (object instead of Any for opaque params, Sequence for list-like params)

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo