### PR TITLE
[Dynamo]Add python_type() to TritonKernelVariable

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3249,6 +3249,9 @@ class TritonKernelVariable(VariableTracker):
         super().__init__(**kwargs)
         dynamo_triton_hopifier_singleton.init_variable(self, kernel, kernel_idx, grid)
 
+    def python_type(self) -> type:
+        return type(self.kernel)
+
     def call_function(
         self,
         tx: "InstructionTranslator",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180882

## Summary                                                                                                            
                                                                                                                     
TritonKernelVariable is missing a python_type() override, so any code path that calls python_type() on it hits the  base class NotImplementedError. This adds the method, returning type(self.kernel) (either JITFunction or Autotuner).                                               
                                                                                                                     
## Test plan                                                 

  - Existing triton kernel tests in test/inductor/test_triton_kernels.py cover TritonKernelVariable usage            
  - This is a one-liner that delegates to type() on the already-stored kernel object

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98