### PR TITLE
CUDA: unrolled kernels for upsample_linear1d forward/backward when grid is small

### DIFF
--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -68,6 +68,59 @@ __global__ void upsample_linear1d_out_frame(
   }
 }
 
+
+// Unrolled version for upsample_linear1d_out_frame
+// This version exposes more parallelism by launching more threads.
+// Instead of each thread looping over "batchsize" and "channels", 
+// more threads are launched and each thread does only one interpolation
+template <typename scalar_t, typename accscalar_t>
+C10_LAUNCH_BOUNDS_1(512)
+__global__ void upsample_linear1d_out_frame_unrolled(
+    const int num_kernels,  
+    const accscalar_t rwidth,
+    const bool align_corners,
+    const PackedTensorAccessor64<const scalar_t, 3> idata,
+    PackedTensorAccessor64<scalar_t, 3> odata) {
+  
+  const int batchsize = idata.size(0);
+  const int channels = idata.size(1);
+  const int width1 = idata.size(2);
+  const int width2 = odata.size(2);
+
+  const int thread_id = threadIdx.x + blockIdx.x * blockDim.x;
+  const int num_total = batchsize * channels * width2;
+  if (thread_id >= num_total) return;
+  
+  // Get a unique (n, c, index) from thread_id
+  const int n = thread_id / (channels * width2); 
+  const int c = (thread_id - n*(channels * width2)) / width2;
+  const int index = thread_id - n*(channels * width2) - c*width2;
+
+  // Do only one interpolation for the (n, c, index) coordinate
+  if (index < num_kernels) {
+    const int w2 = index % width2;
+    // special case: just copy
+    if (width1 == width2) {
+      const int w1 = w2;
+      const scalar_t val = idata[n][c][w1];
+      odata[n][c][w2] = val;
+      return;
+    }
+    //
+    const accscalar_t w1r = area_pixel_compute_source_index<accscalar_t>(
+        rwidth, w2, align_corners, /*cubic=*/false);
+    const int w1 = w1r;
+    const int w1p = (w1 < width1 - 1) ? 1 : 0;
+    const accscalar_t w1lambda = w1r - w1;
+    const accscalar_t w0lambda = static_cast<accscalar_t>(1) - w1lambda;
+    //
+    const accscalar_t val =
+        w0lambda * idata[n][c][w1] + w1lambda * idata[n][c][w1 + w1p];
+    odata[n][c][w2] = static_cast<scalar_t>(val);
+  }
+}
+
+
 // Backward (adjoint) operation 1 <- 2 (accumulates)
 template <typename scalar_t, typename accscalar_t>
 C10_LAUNCH_BOUNDS_1(512)
@@ -116,6 +169,59 @@ __global__ void upsample_linear1d_out_frame_backward(
   }
 }
 
+
+// Backward (adjoint) operation 1 <- 2 (accumulates)
+// Unrolled version for upsample_linear1d_out_frame_backward
+// This version exposes more parallelism by launching more threads
+// and each thread does only one backward interpolation.
+template <typename scalar_t, typename accscalar_t>
+C10_LAUNCH_BOUNDS_1(512)
+__global__ void upsample_linear1d_out_frame_backward_unrolled(
+    const int num_kernels, 
+    const accscalar_t rwidth,
+    const bool align_corners,
+    PackedTensorAccessor64<scalar_t, 3> idata,
+    const PackedTensorAccessor64<const scalar_t, 3> odata) {
+  
+  const int batchsize = idata.size(0);
+  const int channels = idata.size(1);
+  const int width1 = idata.size(2);
+  const int width2 = odata.size(2);
+
+  const int thread_id = threadIdx.x + blockIdx.x * blockDim.x;
+  const int num_total = batchsize * channels * width2;
+  if (thread_id >= num_total) return;
+
+  // Get a unique (n, c, index) from thread_id
+  const int n = thread_id / (channels * width2); 
+  const int c = (thread_id - n*(channels * width2)) / width2;
+  const int index = thread_id - n*(channels * width2) - c*width2;
+  
+  // Do only one backward interpolation for the (n, c, index) coordinate
+  if (index < num_kernels) {
+    const int w2 = index % width2;
+    // special case: just copy
+    if (width1 == width2) {
+      const int w1 = w2;
+      const scalar_t val = odata[n][c][w1];
+      idata[n][c][w2] = val;
+      return;
+    }
+    //
+    const accscalar_t w1r = area_pixel_compute_source_index<accscalar_t>(
+        rwidth, w2, align_corners, /*cubic=*/false);
+    const int w1 = w1r;
+    const int w1p = (w1 < width1 - 1) ? 1 : 0;
+    const accscalar_t w1lambda = w1r - w1;
+    const accscalar_t w0lambda = static_cast<accscalar_t>(1) - w1lambda;
+    //
+    const scalar_t d2val = odata[n][c][w2];
+    gpuAtomicAddNoReturn(&idata[n][c][w1], static_cast<scalar_t>(w0lambda * d2val));
+    gpuAtomicAddNoReturn(
+        &idata[n][c][w1 + w1p], static_cast<scalar_t>(w1lambda * d2val));
+  }
+}
+
 static void upsample_linear1d_out_cuda_template(
     const Tensor& output,
     const Tensor& input,
@@ -135,8 +241,38 @@ static void upsample_linear1d_out_cuda_template(
 
   const int num_kernels = output_width;
   const int num_threads = 512;
+  const int num_blocks = ceil_div(num_kernels, num_threads);
+  const int num_blocks_threshold = 128;
       //at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  // Use unrolled version if the number of blocks is small
+  if (num_blocks < num_blocks_threshold){
+
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16,
+      input.scalar_type(), "upsample_linear1d_out_frame_unrolled", [&] {
+        using accscalar_t = at::acc_type<scalar_t, true>;
+
+        auto idata = input.packed_accessor64<const scalar_t, 3>();
+        auto odata = output.packed_accessor64<scalar_t, 3>();
+
+        const accscalar_t rwidth = area_pixel_compute_scale<accscalar_t>(
+          input_width, output_width, align_corners, scales);
+        
+        const int batchsize = idata.size(0);
+        const int channels  = idata.size(1);
+        const size_t num_total = batchsize * channels * output_width;
+
+        upsample_linear1d_out_frame_unrolled<scalar_t, accscalar_t>
+            <<<ceil_div(num_total, (size_t)num_threads),
+               num_threads,
+               0,
+               stream>>>(num_kernels, rwidth, align_corners, idata, odata);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+    return;    
+  }
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half, at::ScalarType::BFloat16,
@@ -179,8 +315,37 @@ static void upsample_linear1d_backward_out_cuda_template(
 
   const int num_kernels = output_width;
   const int num_threads = 512;
+  const int num_blocks = ceil_div(num_kernels, num_threads);
+  const int num_blocks_threshold = 128;
       //at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  // Use unrolled version if the number of blocks is small
+  if (num_blocks < num_blocks_threshold){
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16,
+      grad_output.scalar_type(), "upsample_linear1d_out_frame_backward_unrolled", [&] {
+        using accscalar_t = at::acc_type<scalar_t, true>;
+
+        auto idata = grad_input.packed_accessor64<scalar_t, 3>();
+        auto odata = grad_output.packed_accessor64<const scalar_t, 3>();
+
+        const accscalar_t rwidth = area_pixel_compute_scale<accscalar_t>(
+            input_width, output_width, align_corners, scales);
+
+        const int batchsize = idata.size(0);
+        const int channels  = idata.size(1);
+        const size_t num_total = batchsize * channels * output_width;    
+
+        upsample_linear1d_out_frame_backward_unrolled<scalar_t, accscalar_t>
+            <<<ceil_div(num_total, (size_t)num_threads),
+               num_threads,
+               0,
+               stream>>>(num_kernels, rwidth, align_corners, idata, odata);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+    return;
+  }  
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half, at::ScalarType::BFloat16,

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -316,7 +316,7 @@ static void upsample_linear1d_backward_out_cuda_template(
   const int num_kernels = output_width;
   const int num_threads = 512;
   const int num_blocks = ceil_div(num_kernels, num_threads);
-  const int num_blocks_threshold = 128;
+  constexpr int num_blocks_threshold = 128;
       //at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -71,17 +71,17 @@ __global__ void upsample_linear1d_out_frame(
 
 // Unrolled version for upsample_linear1d_out_frame
 // This version exposes more parallelism by launching more threads.
-// Instead of each thread looping over "batchsize" and "channels", 
+// Instead of each thread looping over "batchsize" and "channels",
 // more threads are launched and each thread does only one interpolation
 template <typename scalar_t, typename accscalar_t>
 C10_LAUNCH_BOUNDS_1(512)
 __global__ void upsample_linear1d_out_frame_unrolled(
-    const int num_kernels,  
+    const int num_kernels,
     const accscalar_t rwidth,
     const bool align_corners,
     const PackedTensorAccessor64<const scalar_t, 3> idata,
     PackedTensorAccessor64<scalar_t, 3> odata) {
-  
+
   const int batchsize = idata.size(0);
   const int channels = idata.size(1);
   const int width1 = idata.size(2);
@@ -90,9 +90,9 @@ __global__ void upsample_linear1d_out_frame_unrolled(
   const int thread_id = threadIdx.x + blockIdx.x * blockDim.x;
   const int num_total = batchsize * channels * width2;
   if (thread_id >= num_total) return;
-  
+
   // Get a unique (n, c, index) from thread_id
-  const int n = thread_id / (channels * width2); 
+  const int n = thread_id / (channels * width2);
   const int c = (thread_id - n*(channels * width2)) / width2;
   const int index = thread_id - n*(channels * width2) - c*width2;
 
@@ -177,12 +177,12 @@ __global__ void upsample_linear1d_out_frame_backward(
 template <typename scalar_t, typename accscalar_t>
 C10_LAUNCH_BOUNDS_1(512)
 __global__ void upsample_linear1d_out_frame_backward_unrolled(
-    const int num_kernels, 
+    const int num_kernels,
     const accscalar_t rwidth,
     const bool align_corners,
     PackedTensorAccessor64<scalar_t, 3> idata,
     const PackedTensorAccessor64<const scalar_t, 3> odata) {
-  
+
   const int batchsize = idata.size(0);
   const int channels = idata.size(1);
   const int width1 = idata.size(2);
@@ -193,10 +193,10 @@ __global__ void upsample_linear1d_out_frame_backward_unrolled(
   if (thread_id >= num_total) return;
 
   // Get a unique (n, c, index) from thread_id
-  const int n = thread_id / (channels * width2); 
+  const int n = thread_id / (channels * width2);
   const int c = (thread_id - n*(channels * width2)) / width2;
   const int index = thread_id - n*(channels * width2) - c*width2;
-  
+
   // Do only one backward interpolation for the (n, c, index) coordinate
   if (index < num_kernels) {
     const int w2 = index % width2;
@@ -240,7 +240,7 @@ static void upsample_linear1d_out_cuda_template(
   const int num_kernels = output_width;
   const int num_threads = 512;
   const int num_blocks = ceil_div(num_kernels, num_threads);
-  const int num_blocks_threshold = 128;
+  constexpr int num_blocks_threshold = 128;
       //at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
@@ -257,7 +257,7 @@ static void upsample_linear1d_out_cuda_template(
 
         const accscalar_t rwidth = area_pixel_compute_scale<accscalar_t>(
           input_width, output_width, align_corners, scales);
-        
+
         const int batchsize = idata.size(0);
         const int channels  = idata.size(1);
         const size_t num_total = batchsize * channels * output_width;
@@ -269,7 +269,7 @@ static void upsample_linear1d_out_cuda_template(
                stream>>>(num_kernels, rwidth, align_corners, idata, odata);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
-    return;    
+    return;
   }
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
@@ -333,7 +333,7 @@ static void upsample_linear1d_backward_out_cuda_template(
 
         const int batchsize = idata.size(0);
         const int channels  = idata.size(1);
-        const size_t num_total = batchsize * channels * output_width;    
+        const size_t num_total = batchsize * channels * output_width;
 
         upsample_linear1d_out_frame_backward_unrolled<scalar_t, accscalar_t>
             <<<ceil_div(num_total, (size_t)num_threads),
@@ -343,7 +343,7 @@ static void upsample_linear1d_backward_out_cuda_template(
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
     return;
-  }  
+  }
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half, at::ScalarType::BFloat16,

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -68,6 +68,59 @@ __global__ void upsample_linear1d_out_frame(
   }
 }
 
+
+// Unrolled version for upsample_linear1d_out_frame
+// This version exposes more parallelism by launching more threads.
+// Instead of each thread looping over "batchsize" and "channels", 
+// more threads are launched and each thread does only one interpolation
+template <typename scalar_t, typename accscalar_t>
+C10_LAUNCH_BOUNDS_1(512)
+__global__ void upsample_linear1d_out_frame_unrolled(
+    const int num_kernels,  
+    const accscalar_t rwidth,
+    const bool align_corners,
+    const PackedTensorAccessor64<const scalar_t, 3> idata,
+    PackedTensorAccessor64<scalar_t, 3> odata) {
+  
+  const int batchsize = idata.size(0);
+  const int channels = idata.size(1);
+  const int width1 = idata.size(2);
+  const int width2 = odata.size(2);
+
+  const int thread_id = threadIdx.x + blockIdx.x * blockDim.x;
+  const int num_total = batchsize * channels * width2;
+  if (thread_id >= num_total) return;
+  
+  // Get a unique (n, c, index) from thread_id
+  const int n = thread_id / (channels * width2); 
+  const int c = (thread_id - n*(channels * width2)) / width2;
+  const int index = thread_id - n*(channels * width2) - c*width2;
+
+  // Do only one interpolation for the (n, c, index) coordinate
+  if (index < num_kernels) {
+    const int w2 = index % width2;
+    // special case: just copy
+    if (width1 == width2) {
+      const int w1 = w2;
+      const scalar_t val = idata[n][c][w1];
+      odata[n][c][w2] = val;
+      return;
+    }
+    //
+    const accscalar_t w1r = area_pixel_compute_source_index<accscalar_t>(
+        rwidth, w2, align_corners, /*cubic=*/false);
+    const int w1 = w1r;
+    const int w1p = (w1 < width1 - 1) ? 1 : 0;
+    const accscalar_t w1lambda = w1r - w1;
+    const accscalar_t w0lambda = static_cast<accscalar_t>(1) - w1lambda;
+    //
+    const accscalar_t val =
+        w0lambda * idata[n][c][w1] + w1lambda * idata[n][c][w1 + w1p];
+    odata[n][c][w2] = static_cast<scalar_t>(val);
+  }
+}
+
+
 // Backward (adjoint) operation 1 <- 2 (accumulates)
 template <typename scalar_t, typename accscalar_t>
 C10_LAUNCH_BOUNDS_1(512)
@@ -116,6 +169,59 @@ __global__ void upsample_linear1d_out_frame_backward(
   }
 }
 
+
+// Backward (adjoint) operation 1 <- 2 (accumulates)
+// Unrolled version for upsample_linear1d_out_frame_backward
+// This version exposes more parallelism by launching more threads
+// and each thread does only one backward interpolation.
+template <typename scalar_t, typename accscalar_t>
+C10_LAUNCH_BOUNDS_1(512)
+__global__ void upsample_linear1d_out_frame_backward_unrolled(
+    const int num_kernels, 
+    const accscalar_t rwidth,
+    const bool align_corners,
+    PackedTensorAccessor64<scalar_t, 3> idata,
+    const PackedTensorAccessor64<const scalar_t, 3> odata) {
+  
+  const int batchsize = idata.size(0);
+  const int channels = idata.size(1);
+  const int width1 = idata.size(2);
+  const int width2 = odata.size(2);
+
+  const int thread_id = threadIdx.x + blockIdx.x * blockDim.x;
+  const int num_total = batchsize * channels * width2;
+  if (thread_id >= num_total) return;
+
+  // Get a unique (n, c, index) from thread_id
+  const int n = thread_id / (channels * width2); 
+  const int c = (thread_id - n*(channels * width2)) / width2;
+  const int index = thread_id - n*(channels * width2) - c*width2;
+  
+  // Do only one backward interpolation for the (n, c, index) coordinate
+  if (index < num_kernels) {
+    const int w2 = index % width2;
+    // special case: just copy
+    if (width1 == width2) {
+      const int w1 = w2;
+      const scalar_t val = odata[n][c][w1];
+      idata[n][c][w2] = val;
+      return;
+    }
+    //
+    const accscalar_t w1r = area_pixel_compute_source_index<accscalar_t>(
+        rwidth, w2, align_corners, /*cubic=*/false);
+    const int w1 = w1r;
+    const int w1p = (w1 < width1 - 1) ? 1 : 0;
+    const accscalar_t w1lambda = w1r - w1;
+    const accscalar_t w0lambda = static_cast<accscalar_t>(1) - w1lambda;
+    //
+    const scalar_t d2val = odata[n][c][w2];
+    gpuAtomicAddNoReturn(&idata[n][c][w1], static_cast<scalar_t>(w0lambda * d2val));
+    gpuAtomicAddNoReturn(
+        &idata[n][c][w1 + w1p], static_cast<scalar_t>(w1lambda * d2val));
+  }
+}
+
 static void upsample_linear1d_out_cuda_template(
     const Tensor& output,
     const Tensor& input,
@@ -133,8 +239,38 @@ static void upsample_linear1d_out_cuda_template(
 
   const int num_kernels = output_width;
   const int num_threads = 512;
+  const int num_blocks = ceil_div(num_kernels, num_threads);
+  const int num_blocks_threshold = 128;
       //at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  // Use unrolled version if the number of blocks is small
+  if (num_blocks < num_blocks_threshold){
+
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16,
+      input.scalar_type(), "upsample_linear1d_out_frame_unrolled", [&] {
+        using accscalar_t = at::acc_type<scalar_t, true>;
+
+        auto idata = input.packed_accessor64<const scalar_t, 3>();
+        auto odata = output.packed_accessor64<scalar_t, 3>();
+
+        const accscalar_t rwidth = area_pixel_compute_scale<accscalar_t>(
+          input_width, output_width, align_corners, scales);
+        
+        const int batchsize = idata.size(0);
+        const int channels  = idata.size(1);
+        const size_t num_total = batchsize * channels * output_width;
+
+        upsample_linear1d_out_frame_unrolled<scalar_t, accscalar_t>
+            <<<ceil_div(num_total, (size_t)num_threads),
+               num_threads,
+               0,
+               stream>>>(num_kernels, rwidth, align_corners, idata, odata);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+    return;    
+  }
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half, at::ScalarType::BFloat16,
@@ -177,8 +313,37 @@ static void upsample_linear1d_backward_out_cuda_template(
 
   const int num_kernels = output_width;
   const int num_threads = 512;
+  const int num_blocks = ceil_div(num_kernels, num_threads);
+  const int num_blocks_threshold = 128;
       //at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  // Use unrolled version if the number of blocks is small
+  if (num_blocks < num_blocks_threshold){
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16,
+      grad_output.scalar_type(), "upsample_linear1d_out_frame_backward_unrolled", [&] {
+        using accscalar_t = at::acc_type<scalar_t, true>;
+
+        auto idata = grad_input.packed_accessor64<scalar_t, 3>();
+        auto odata = grad_output.packed_accessor64<const scalar_t, 3>();
+
+        const accscalar_t rwidth = area_pixel_compute_scale<accscalar_t>(
+            input_width, output_width, align_corners, scales);
+
+        const int batchsize = idata.size(0);
+        const int channels  = idata.size(1);
+        const size_t num_total = batchsize * channels * output_width;    
+
+        upsample_linear1d_out_frame_backward_unrolled<scalar_t, accscalar_t>
+            <<<ceil_div(num_total, (size_t)num_threads),
+               num_threads,
+               0,
+               stream>>>(num_kernels, rwidth, align_corners, idata, odata);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+    return;
+  }  
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half, at::ScalarType::BFloat16,

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -314,7 +314,7 @@ static void upsample_linear1d_backward_out_cuda_template(
   const int num_kernels = output_width;
   const int num_threads = 512;
   const int num_blocks = ceil_div(num_kernels, num_threads);
-  const int num_blocks_threshold = 128;
+  constexpr int num_blocks_threshold = 128;
       //at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 


### PR DESCRIPTION
**Summary**
Adds alternative CUDA implementations for upsample_linear1d forward and backward that map each output sample to its own thread (unrolled over batch × channel × output width). The existing kernels parallelize only over output_width and loop over batch and channels inside each thread; the new path improves occupancy when ceil_div(output_width, block_size) is small by launching enough blocks to cover all (n, c, w) samples.

**Implementation**
`upsample_linear1d_out_frame_unrolled`: same math as `upsample_linear1d_out_frame`, but one interpolation per thread for a unique (batch, channel, output_index).
`upsample_linear1d_out_frame_backward_unrolled`: same adjoint logic as the original backward kernel, with atomic adds into grad_input preserved for overlapping source pixels.

**Heuristic**
If ceil_div(output_width, 512) < 128, the launch uses the unrolled kernels with grid size ceil_div(batch × channels × output_width, 512). Otherwise behavior is unchanged, and the original kernels are used.

**Motivation**
Wide, shallow launches (few blocks × 512 threads) often leave GPU underutilized; expanding parallelism across batch and channels targets those cases without changing numerics on the default path.

**Testing**
Performance has been measured to improve by a factor of 5-25x, depending on the size of the arrays.
Outputs have been tested to give the same numerical results.  
