### PR TITLE
Fix pad_tensor/unpad_tensor creating unnecessary guards on symbolic pad sizes during tracing

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -2406,6 +2406,62 @@ class outer_fn(torch.nn.Module):
         compiled_step = torch.compile(opt.step, backend="aot_eager")
         compiled_step()
 
+    def test_pad_tensor_no_guard_on_symbolic_pad_size(self):
+        """pad_tensor must not create a guard that concretizes symbolic pad sizes.
+
+        When tracing with make_fx in symbolic mode, pad_size may be a SymInt
+        (e.g., for uneven DTensor sharding where local shard sizes vary by
+        rank). guard_or_false(pad_size == 0) must not be evaluated during
+        tracing, otherwise it creates a guard that collapses the SymInt to its
+        hint value, making the graph rank-specific instead of rank-independent.
+        """
+        from torch._subclasses.fake_tensor import FakeTensorMode, unset_fake_temporarily
+        from torch.distributed.tensor._collective_utils import pad_tensor
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch.fx.experimental.symbolic_shapes import (
+            DimDynamic,
+            ShapeEnv,
+            StatelessSymbolicContext,
+        )
+
+        shape_env = ShapeEnv()
+        fake_mode = FakeTensorMode(shape_env=shape_env, static_shapes=False)
+
+        with unset_fake_temporarily():
+            real = torch.empty(400, 15, device="meta")
+        sym_ctx = StatelessSymbolicContext(
+            dynamic_sizes=[DimDynamic.STATIC, DimDynamic.DYNAMIC]
+        )
+        x = fake_mode.from_tensor(real, symbolic_context=sym_ctx)
+        with fake_mode:
+            x = x.to("cpu")
+
+        # Verify the symbol is alive before tracing
+        self.assertTrue(isinstance(x.shape[1], torch.SymInt))
+        self.assertFalse(x.shape[1].node.expr.is_number)
+
+        def fn(t):
+            pad_size = 15 - t.size(1)
+            return pad_tensor(t, 1, pad_size)
+
+        with fake_mode:
+            gm = make_fx(fn, tracing_mode="symbolic")(x)
+
+        # The symbol must survive — not be guarded to a concrete value
+        self.assertFalse(
+            x.shape[1].node.expr.is_number,
+            f"pad_tensor created a guard that concretized the symbolic dim: "
+            f"expr={x.shape[1].node.expr}",
+        )
+
+        # The traced graph should have a symbolic pad size, not concrete 0
+        placeholder = next(n for n in gm.graph.nodes if n.op == "placeholder")
+        val = placeholder.meta["val"]
+        self.assertTrue(
+            isinstance(val.shape[1], torch.SymInt),
+            "Placeholder dim should be symbolic",
+        )
+
 
 @instantiate_parametrized_tests
 class TestDTensorCompileE2E(DTensorTestBase):

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -217,10 +217,11 @@ def pad_tensor(
 ) -> torch.Tensor:
     # During tracing, always emit the pad op even when pad_size=0 so all
     # ranks produce identical FX graph structure (SPMD).
-    # guard_or_false returns False for symbolic sizes, so the pad is always
-    # emitted during tracing. In eager with concrete pad_size=0, it returns
-    # True and we skip the no-op pad.
-    if guard_or_false(pad_size == 0) and not _are_we_tracing():
+    # In eager with concrete pad_size=0, guard_or_false returns True and we
+    # skip the no-op pad. Check _are_we_tracing() first to avoid
+    # guard_or_false creating a guard that concretizes symbolic pad sizes
+    # during make_fx tracing.
+    if not _are_we_tracing() and guard_or_false(pad_size == 0):
         return tensor
     pad = [0, 0] * (tensor.ndim - pad_dim)
     pad[-1] = pad_size  # pyrefly: ignore[unsupported-operation]
@@ -233,7 +234,11 @@ def unpad_tensor(
 ) -> torch.Tensor:
     # During tracing, always emit the narrow op even when pad_size=0 so all
     # ranks produce identical FX graph structure (SPMD).
-    if guard_or_false(pad_size == 0) and not _are_we_tracing():
+    # In eager with concrete pad_size=0, guard_or_false returns True and we
+    # skip the no-op narrow. Check _are_we_tracing() first to avoid
+    # guard_or_false creating a guard that concretizes symbolic pad sizes
+    # during make_fx tracing.
+    if not _are_we_tracing() and guard_or_false(pad_size == 0):
         return tensor
     return tensor.narrow(
         pad_dim,


### PR DESCRIPTION
`pad_tensor` and `unpad_tensor` in `torch/distributed/tensor/_collective_utils.py` evaluate `guard_or_false(pad_size == 0)` before checking `_are_we_tracing()`. For backed `SymInts`, `guard_or_false` calls `shape_env.evaluate_sym_node(...)` which creates a guard as a side effect — even though the result is discarded when `_are_we_tracing()` returns True.

This causes symbolic pad sizes (e.g., `15 - s_param` for uneven DTensor sharding) to be guarded to their hint values during `make_fx` tracing, making the traced graph rank-specific instead of rank-independent.

The fix swaps the evaluation order so `_are_we_tracing()` is checked first, short-circuiting before `guard_or_false` can create the guard. This is a behavior-preserving change — the original commit (4723e121c63) intended for `guard_or_false` to only take effect in eager mode, but Python's left-to-right and evaluation meant the guard was always created.

Authored with Claude.