### PR TITLE
[FSDP2] Alternative fix (REGRESSION — DO NOT MERGE): implicit release of HSDP AR buffer via cast rebind

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_comm.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_comm.py
@@ -292,8 +292,6 @@ class TestFullyShardCollectiveOps(FSDPTestMultiThread):
             _,
             post_reduce_event,
             _,
-            _,
-            _,
         ) = foreach_reduce(
             fsdp_params,
             unsharded_grads,

--- a/test/distributed/_composable/fsdp/test_fully_shard_memory.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_memory.py
@@ -5,7 +5,13 @@ import gc
 import unittest
 
 import torch
-from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard, OffloadPolicy
+from torch.distributed.fsdp import (
+    CPUOffloadPolicy,
+    fully_shard,
+    MixedPrecisionPolicy,
+    OffloadPolicy,
+)
+from torch.distributed.tensor import init_device_mesh
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest, get_devtype
 from torch.testing._internal.common_utils import (
@@ -22,6 +28,22 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
 
 
 device_type = torch.device(get_devtype())
+
+
+def _get_peak_active_memory_mb() -> int:
+    mem_stats = torch.get_device_module(device_type).memory_stats()
+    if TEST_CUDA or TEST_XPU:
+        return round(mem_stats["active_bytes.all.peak"] / 1e6)
+    if TEST_HPU:
+        return round(mem_stats["MaxInUse"] / 1e6)
+
+
+def _get_curr_active_memory_mb() -> int:
+    mem_stats = torch.get_device_module(device_type).memory_stats()
+    if TEST_CUDA or TEST_XPU:
+        return round(mem_stats["active_bytes.all.current"] / 1e6)
+    if TEST_HPU:
+        return round(mem_stats["InUse"] / 1e6)
 
 
 class TestFullyShardMemory(FSDPTest):
@@ -343,6 +365,97 @@ class TestFullyShardMemory(FSDPTest):
 
         for param in model.parameters():
             param.register_post_accumulate_grad_hook(optim_hook)
+
+
+class TestFullyShardHSDPMemory(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return min(4, torch.get_device_module(device_type).device_count())
+
+    @skip_if_lt_x_gpu(4)
+    @unittest.skipIf(
+        TEST_HPU or TEST_XPU, "HSDP mixed-precision memory test is CUDA-only"
+    )
+    def test_hsdp_mixed_precision_no_buffer_accumulation(self):
+        """Regression guard for https://github.com/pytorch/pytorch/issues/179128:
+        under HSDP with bf16 params + fp32 reduce, the fp32 reduce-scatter
+        output buffers must not accumulate across layers within a single
+        backward pass. The buggy path held O(n_layers) fp32 buffers; the fix
+        limits it to at most 2 simultaneously. Each extra live buffer is
+        ``block_numel / dp_shard_size * 4`` bytes, so peak active GPU memory
+        during backward distinguishes the two paths.
+        """
+        torch.manual_seed(42)
+        # Warm up cuBLAS workspaces before measuring the baseline.
+        lin = torch.nn.Linear(768, 768, device=device_type)
+        lin(torch.randn(2, 768, device=device_type)).sum().backward()
+        del lin
+        torch.get_device_module(device_type).empty_cache()
+        torch.get_device_module(device_type).reset_peak_memory_stats()
+        base_mem_mb = _get_peak_active_memory_mb()
+
+        mesh = init_device_mesh(
+            device_type.type, (2, 2), mesh_dim_names=("dp_replicate", "dp_shard")
+        )
+        dp_shard_size = mesh["dp_shard"].size()
+        mp = MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16, reduce_dtype=torch.float32
+        )
+
+        n_layers = 8
+        # bf16 params with fp32 reduce: orig_dtype != reduce_dtype, so the
+        # post-reduce cast allocates a new tensor and orphans the fp32
+        # reduce-scatter output — the path under test.
+        model = Transformer(
+            ModelArgs(
+                vocab_size=32,
+                n_layers=n_layers,
+                dim=768,
+                n_heads=12,
+                weight_tying=False,
+            )
+        ).to(device_type, dtype=torch.bfloat16)
+        model_numel = sum(p.numel() for p in model.parameters())
+        block_numel = sum(p.numel() for p in model.layers[0].parameters())
+        for m in model.modules():
+            if isinstance(m, TransformerBlock):
+                fully_shard(m, mesh=mesh, mp_policy=mp)
+        fully_shard(model, mesh=mesh, mp_policy=mp)
+
+        inp = torch.randint(0, 32, (1, 4), device=device_type.type)
+        torch.get_device_module(device_type).reset_peak_memory_stats()
+        model(inp).sum().backward()
+        peak_delta_mb = _get_peak_active_memory_mb() - base_mem_mb
+
+        # Breakdown of the expected peak during HSDP + MP backward (all bf16
+        # params, fp32 reduce). Under the fix, the following components are
+        # simultaneously alive at the peak instant (during a mid-backward
+        # layer's post-reduce):
+        #   - 1x sharded bf16 params (resident for the whole step)
+        #   - 1x sharded bf16 grads (fully accumulated at peak)
+        #   - 1x unsharded bf16 block params (prefetched all-gather for the
+        #     next block's backward compute)
+        #   - 2x fp32 reduce-scatter input (current block + previous block
+        #     still held in reduce_scatter_states)
+        #   - 2x fp32 all-reduce output (current block + previous block's
+        #     orphaned buffer held by comm_ctx.all_reduce_state).
+        #     THIS is the term the fix bounds at 2; the bug made it O(n_layers).
+        per_layer_fp32_mb = block_numel * 4 / dp_shard_size / 1e6
+        expected_peak_mb = (
+            2 * model_numel * 2 / dp_shard_size
+            + 1 * block_numel * 2
+            + 2 * block_numel * 4
+            + 2 * block_numel * 4 / dp_shard_size
+        ) / 1e6
+
+        self.assertLessEqual(
+            peak_delta_mb,
+            expected_peak_mb,
+            f"peak backward memory delta {peak_delta_mb} MB exceeds bound "
+            f"{expected_peak_mb:.1f} MB. fp32 reduce-scatter output buffers "
+            f"may be accumulating across layers (each ~{per_layer_fp32_mb:.1f} "
+            f"MB, n_layers={n_layers}).",
+        )
 
 
 if __name__ == "__main__":

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -555,8 +555,6 @@ def foreach_reduce(
     torch.Event,
     torch.Event,
     torch.Tensor | None,
-    torch.Event | None,
-    torch.Tensor | None,
 ]:
     """
     ``unsharded_grads`` owns the references to the gradients computed by
@@ -619,8 +617,6 @@ def foreach_reduce(
     # Only after the copy-in finishes can we free the gradients
     unsharded_grads.clear()
     reduce_scatter_stream.wait_stream(current_stream)
-    all_reduce_input = None
-    all_reduce_event = None
 
     with device_handle.stream(reduce_scatter_stream):
         reduce_output = reduce_scatter_comm.allocate(
@@ -659,8 +655,6 @@ def foreach_reduce(
                     reduce_scatter_input,
                     reduce_scatter_event,
                     post_reduce_stream.record_event(),
-                    all_reduce_input,
-                    all_reduce_event,
                     partial_reduce_output,
                 )
             if partial_reduce_output is not None:
@@ -679,8 +673,6 @@ def foreach_reduce(
                         group=all_reduce_group,
                         op=all_reduce_op,
                     )
-                all_reduce_input = reduce_output
-                all_reduce_event = all_reduce_stream.record_event()
     # -- END: ops in reduce_scatter stream
 
     if all_reduce_hook is not None:
@@ -695,6 +687,15 @@ def foreach_reduce(
 
     with device_handle.stream(post_reduce_stream):
         _div_if_needed(reduce_output, postdivide_factor)
+        # Rebind reduce_output to a new tensor when reduce_dtype != orig_dtype.
+        # The old tensor (e.g. bf16 AR buffer in HSDP+bf16-reduce+fp32-params)
+        # drops its last ref here. Because we're inside the
+        # `with device_handle.stream(post_reduce_stream)` context, the caching
+        # allocator's free-event lands on post_reduce_stream (= AR stream in
+        # HSDP+AR). Stream FIFO orders the free-event after the just-enqueued
+        # cast kernel, so the buffer is safely reclaimable only after the cast
+        # completes reading it. No explicit wait_event needed; this is the
+        # minimum-lifetime release point for the AR buffer.
         reduce_output = _to_dtype_if_needed(reduce_output, orig_dtype)
         # View out and accumulate sharded gradients
         flat_grad_offset = 0  # [0, reduce_scatter_output_numel - 1]
@@ -752,8 +753,6 @@ def foreach_reduce(
         reduce_scatter_input,
         reduce_scatter_event,
         post_reduce_event,
-        all_reduce_input,
-        all_reduce_event,
         None,
     )
 

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -123,11 +123,6 @@ class ReduceScatterState(NamedTuple):
     event: torch.Event | None  # reduce-scatter event
 
 
-class AllReduceState(NamedTuple):
-    all_reduce_input: torch.Tensor
-    event: torch.Event | None  # all-reduce event
-
-
 class FSDPParamGroup:
     """This class represents a parameter group to communicate together."""
 
@@ -219,9 +214,11 @@ class FSDPParamGroup:
         # - CUDA events for stream synchronization
         # Holds the all-gather output buffer, sync objects, and metadata
         self._all_gather_result: AllGatherResult | None = None
-        # Holds the reduce-scatter/all-reduce view-out CUDA event that marks the end of
-        # the group's post-backward (e.g. reduce-scatter, all-reduce and div), which
-        # should be waited on at the end of backward
+        # Marks completion of the post-reduce pipeline (postdivide + dtype cast
+        # + view-out writes into sharded_param.grad). Guards the sharded grad's
+        # visibility to the default-stream optimizer: default stream waits on
+        # this event before reading sharded_param.grad. Recorded on the RS
+        # stream (1D) or AR stream (HSDP+AR) after the view-out loop completes.
         self._post_reduce_event: torch.Event | None = None
         # Holds the reshard-after-forward CUDA event when resharding to a
         # different world size, which should be waited on in the next unshard
@@ -230,11 +227,6 @@ class FSDPParamGroup:
         # Only for HSDP, if accumulating gradients without all-reduce, save the
         # partial reduce output (only reduce-scattered but not all-reduced)
         self._partial_reduce_output: torch.Tensor | None = None
-        # Holds the all-reduce input and all-reduce event to keep it alive
-        # until the end of backward (critical when doing bf16 reduction with
-        # fp32 parameters since the all-reduce input is allocated in the RS
-        # stream and will have no refs to it after being upcast to fp32)
-        self._all_reduce_state: AllReduceState | None = None
 
     # Initialization #
     def _init_mp_dtypes(self) -> None:
@@ -585,8 +577,6 @@ class FSDPParamGroup:
                 reduce_scatter_input,
                 reduce_scatter_event,
                 self._post_reduce_event,
-                all_reduce_input,
-                all_reduce_event,
                 self._partial_reduce_output,
             ) = foreach_reduce(
                 fsdp_params_with_grad,
@@ -618,15 +608,6 @@ class FSDPParamGroup:
             self.comm_ctx.reduce_scatter_states.append(
                 ReduceScatterState(reduce_scatter_input, reduce_scatter_event)
             )
-            if all_reduce_input is not None:
-                if self.device.type != "cpu":
-                    if all_reduce_event is None:
-                        raise AssertionError(
-                            "Expected all_reduce_event to be set for non-CPU device"
-                        )
-                self._all_reduce_state = AllReduceState(
-                    all_reduce_input, all_reduce_event
-                )
 
     def finalize_backward(self):
         self._wait_for_post_backward()
@@ -646,15 +627,17 @@ class FSDPParamGroup:
         self._post_forward_indices.clear()
 
     def _wait_for_post_backward(self):
+        # _post_reduce_event guards sharded_param.grad: fires when view-out
+        # writes into the new (fp32) reduce_output are complete, so the
+        # default-stream optimizer can safely read the sharded grad.
+        #
+        # For HSDP+AR, the AR buffer (bf16 when reduce_dtype != orig_dtype) is
+        # released inside foreach_reduce via the dtype cast's rebind (see
+        # _fsdp_collectives.py around the `_to_dtype_if_needed` call); no
+        # separate event/ref tracking is needed here.
         if self._post_reduce_event is not None:
             self.device_handle.current_stream().wait_event(self._post_reduce_event)
             self._post_reduce_event = None
-        if (
-            self._all_reduce_state is not None
-            and self._all_reduce_state.event is not None
-        ):
-            self.device_handle.current_stream().wait_event(self._all_reduce_state.event)
-        self._all_reduce_state = None
 
     def _backward_prefetch(self) -> None:
         if self._training_state == TrainingState.PRE_BACKWARD:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180889

**⚠️ DO NOT MERGE — regression confirmed. Land #179443 instead.**

Summary:
This PR was an attempted alternative to #179443 for the O(n_layers) fp32
reduce-scatter output buffer accumulation in HSDP+AR when reduce_dtype !=
orig_dtype (canonically `MixedPrecisionPolicy(param_dtype=bf16)` with
fp32-stored params).

The approach was to remove `_all_reduce_state` / `AllReduceState` entirely
and rely on the dtype cast at `_fsdp_collectives.py:698` to drop the bf16
AR buffer's ref inside the `with device_handle.stream(post_reduce_stream):`
context. The claim was that the caching allocator's free-event-on-current-
stream behavior would handle cross-stream reuse safety without needing
explicit tracking.

**The approach is incorrect.** A targeted stress test (HSDP+bf16+fp32 params
with `torch.cuda._sleep` injected before `dist.all_reduce` + ~200 bf16
default-stream tensor allocations after backward) shows that under allocator
pressure, the fp32 `reduce_output` buffer is reused across layers. All
`sharded_param.grad` views end up aliased to the same physical storage, and
every layer's sharded gradient collapses to the last-executed layer's value.

Reference (fast AR, no stress): `{0.w: sum=+18, 2.w: sum=-1222, 4.w: sum=+51117}`.
This PR (slow AR + allocator stress): `{0.w: sum=+18, 2.w: sum=+18, 4.w: sum=+18}`.

The targeted regression test is added in #180900. It passes on the base
commit (with #140044's `_all_reduce_state` tracking) and fails on this PR.

The findings confirm that PR #140044 was fixing a real cross-layer
buffer-aliasing race, not defensive over-engineering. #179443 inherits
that fix's explicit ref-tracking pattern and correctly preserves the
sync-correctness guarantee while fixing the memory-accumulation consequence.

**Recommendation**: close this PR; land #179443; merge the regression test
in #180900 so future changes have a safety check.

See `agent_space/fsdp2_early_release_ar_buffer.md` for the full writeup
including test results and why the simpler approach fails.

Test Plan:
- Regression test in #180900: passes on base commit, **fails on this PR** —
  exactly the behavior needed to document the bug this PR introduces.
- Standard test suite: passes. The existing tests don't exercise the race.
  That gap (tests passing while a real bug exists) is why #140044's fix
  was load-bearing.

This PR was authored with Claude.

Reviewers:

Subscribers:

Tasks:

Tags:
