### PR TITLE
[aot_autograd] Cache and replay min_cut_information on AOTAutograd cache hit

### DIFF
--- a/torch/_functorch/_activation_checkpointing/ac_logging_utils.py
+++ b/torch/_functorch/_activation_checkpointing/ac_logging_utils.py
@@ -182,10 +182,13 @@ def create_structured_trace_for_min_cut_info(
     )
 
     # Create structured trace
+    payload_str = json.dumps(activation_checkpointing_logging_structure_payload)
+
+    # Store on graph for AOTAutograd cache replay
+    joint_graph._min_cut_info_str = payload_str  # type: ignore[attr-defined]
+
     trace_structured(
         "artifact",
         metadata_fn=lambda: {"name": "min_cut_information", "encoding": "json"},
-        payload_fn=lambda: json.dumps(
-            activation_checkpointing_logging_structure_payload
-        ),
+        payload_fn=lambda: payload_str,
     )

--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -360,6 +360,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
     aot_joint_graph_str: str | None
     aot_forward_graph_str: str | None
     aot_backward_graph_str: str | None
+    min_cut_info_str: str | None
 
     # Runtime_metadata saved right before compilation
     runtime_metadata: ViewAndMutationMeta
@@ -447,6 +448,16 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
             aot_graphs_log.info(
                 "Backward graph (from cache)\n\n%s",
                 self.aot_backward_graph_str,
+            )
+
+        if self.min_cut_info_str is not None:
+            torch._logging.trace_structured(
+                "artifact",
+                metadata_fn=lambda: {
+                    "name": "min_cut_information",
+                    "encoding": "json",
+                },
+                payload_fn=lambda: self.min_cut_info_str,
             )
 
     def _load_and_post_compile(

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -1343,6 +1343,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
         backward_state_indices: list[int] | None,
         num_symints_saved_for_bw: int | None,
         serialized_bw_module: SerializedGraphModule | None,
+        min_cut_info_str: str | None,
     ) -> GenericAOTAutogradResult[Any, Any]:
         if should_bundle_autograd_cache():
             # Helper function to unwrap all the wrappers we added during aotdispatch
@@ -1373,6 +1374,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
                 aot_joint_graph_str=aot_joint_graph_str,
                 aot_forward_graph_str=aot_forward_graph_str,
                 aot_backward_graph_str=aot_backward_graph_str,
+                min_cut_info_str=min_cut_info_str,
                 runtime_metadata=runtime_metadata,
                 dispatch_wrappers=dispatch_wrappers,
                 maybe_subclass_meta=maybe_subclass_meta,
@@ -1422,6 +1424,7 @@ class AOTAutogradCache(GuardedCache[GenericAOTAutogradResult[Any, Any]]):
                 aot_joint_graph_str=aot_joint_graph_str,
                 aot_forward_graph_str=aot_forward_graph_str,
                 aot_backward_graph_str=aot_backward_graph_str,
+                min_cut_info_str=min_cut_info_str,
                 runtime_metadata=runtime_metadata,
                 dispatch_wrappers=dispatch_wrappers,
                 maybe_subclass_meta=maybe_subclass_meta,

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -521,6 +521,7 @@ def _cache_inference_info(
             backward_state_indices=None,
             num_symints_saved_for_bw=None,
             serialized_bw_module=None,
+            min_cut_info_str=None,
         )
         AOTAutogradCache.save(
             cache_info.cache_key,
@@ -2279,6 +2280,8 @@ def aot_stage2_autograd(
         aot_config,
     )
 
+    min_cut_info_str = getattr(fx_g.graph, "_min_cut_info_str", None)
+
     fw_module_str, bw_module_str = _log_fw_bw_graphs(
         fw_module, bw_module, maybe_subclass_meta, fw_metadata, aot_config
     )
@@ -2316,6 +2319,7 @@ def aot_stage2_autograd(
         _indices_of_inps_to_detach,
         num_symints_saved_for_bw,
         bw_module,
+        min_cut_info_str,
     )
 
     return _aot_stage2c_make_autograd_function(
@@ -2407,6 +2411,7 @@ def _cache_autograd_info(
     _indices_of_inps_to_detach: list[int],
     num_symints_saved_for_bw: int,
     bw_module: torch.fx.GraphModule | None,
+    min_cut_info_str: str | None,
 ) -> tuple[
     GenericAOTAutogradResult[Any, Any] | None,
     Callable[..., Any],
@@ -2474,6 +2479,7 @@ def _cache_autograd_info(
                     backward_state_indices=backward_state_indices,
                     num_symints_saved_for_bw=num_symints_saved_for_bw,
                     serialized_bw_module=serialize_graph_module(bw_module),
+                    min_cut_info_str=min_cut_info_str,
                 )
                 AOTAutogradCache.save(
                     cache_info.cache_key,


### PR DESCRIPTION
Summary:
`min_cut_information` JSON was missing from tlparse in many compiled regions.
The root cause: on AOTAutograd cache hit, the partitioner is skipped entirely,
so `create_structured_trace_for_min_cut_info` never runs.

This follows the same pattern used by `aot_forward_graph_str` — save the
payload string in the cache entry during cache miss, replay the
`trace_structured` call on cache hit via `wrap_post_compile`.

```
Cache miss path:
  partitioner → create_structured_trace_for_min_cut_info
    → json.dumps(payload) → store on joint_graph._min_cut_info_str
    → trace_structured("min_cut_information")
  aot_stage2_autograd
    → capture from fx_g.graph._min_cut_info_str
    → pass to make_entry → saved in GenericAOTAutogradResult

Cache hit path:
  wrap_post_compile
    → if self.min_cut_info_str is not None:
        trace_structured("min_cut_information")  ← replayed
```

Test Plan:
```
buck2 test fbcode//caffe2/test/functorch:test_ac_logging
buck2 test 'fbcode//mode/opt' fbcode//caffe2/test/dynamo:test_dynamo -- --run-disabled --regex test_structured_trace.py
```

Reviewed By: soulitzer

Differential Revision: D96648578


