### PR TITLE
Skip llms-full.txt during Sphinx build, generate in nightly push

### DIFF
--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -2,9 +2,9 @@ sphinx==7.2.6
 #Description: This is used to generate PyTorch docs
 #Pinned versions: 7.2.6
 
-pytorch_sphinx_theme2==0.4.6
+git+https://github.com/pytorch/pytorch_sphinx_theme.git@4fbca377284202dc2d464400257c4f00e98caf9e#egg=pytorch_sphinx_theme2
 #Description: This is needed to generate PyTorch docs
-#Pinned versions: 0.4.6
+#Pinned versions: testing against commit 4fbca37 for llm_generate_full support
 
 sphinxcontrib.katex==0.9.11
 #Description: This is used to generate PyTorch docs

--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -2,7 +2,7 @@ sphinx==7.2.6
 #Description: This is used to generate PyTorch docs
 #Pinned versions: 7.2.6
 
-git+https://github.com/pytorch/pytorch_sphinx_theme.git@1062045d6b9f1471dff34484acfa142de7ed90ac#egg=pytorch_sphinx_theme2
+git+https://github.com/pytorch/pytorch_sphinx_theme.git@22730497eb039c69466fa5fd8fe2b76649dfdfa0#egg=pytorch_sphinx_theme2
 #Description: This is needed to generate PyTorch docs
 #Pinned versions: testing against commit 4fbca37 for llm_generate_full support
 

--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -2,7 +2,7 @@ sphinx==7.2.6
 #Description: This is used to generate PyTorch docs
 #Pinned versions: 7.2.6
 
-git+https://github.com/pytorch/pytorch_sphinx_theme.git@d6b469e679fa33fbb014a62a90691a67ae343335#egg=pytorch_sphinx_theme2
+git+https://github.com/pytorch/pytorch_sphinx_theme.git@1062045d6b9f1471dff34484acfa142de7ed90ac#egg=pytorch_sphinx_theme2
 #Description: This is needed to generate PyTorch docs
 #Pinned versions: testing against commit 4fbca37 for llm_generate_full support
 

--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -2,7 +2,7 @@ sphinx==7.2.6
 #Description: This is used to generate PyTorch docs
 #Pinned versions: 7.2.6
 
-git+https://github.com/pytorch/pytorch_sphinx_theme.git@4fbca377284202dc2d464400257c4f00e98caf9e#egg=pytorch_sphinx_theme2
+git+https://github.com/pytorch/pytorch_sphinx_theme.git@d6b469e679fa33fbb014a62a90691a67ae343335#egg=pytorch_sphinx_theme2
 #Description: This is needed to generate PyTorch docs
 #Pinned versions: testing against commit 4fbca37 for llm_generate_full support
 

--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -2,9 +2,9 @@ sphinx==7.2.6
 #Description: This is used to generate PyTorch docs
 #Pinned versions: 7.2.6
 
-git+https://github.com/pytorch/pytorch_sphinx_theme.git@22730497eb039c69466fa5fd8fe2b76649dfdfa0#egg=pytorch_sphinx_theme2
+pytorch-sphinx-theme2==0.4.9
 #Description: This is needed to generate PyTorch docs
-#Pinned versions: testing against commit 4fbca37 for llm_generate_full support
+#Pinned versions: 0.4.9
 
 sphinxcontrib.katex==0.9.11
 #Description: This is used to generate PyTorch docs

--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -2,7 +2,7 @@ sphinx==7.2.6
 #Description: This is used to generate PyTorch docs
 #Pinned versions: 7.2.6
 
-pytorch-sphinx-theme2==0.4.9
+pytorch_sphinx_theme2==0.4.9
 #Description: This is needed to generate PyTorch docs
 #Pinned versions: 0.4.9
 

--- a/.ci/pytorch/python_doc_push_script.sh
+++ b/.ci/pytorch/python_doc_push_script.sh
@@ -140,6 +140,59 @@ else
   build_docs html-stable || exit $?
 fi
 
+# Generate llms-full.txt from built HTML (nightly/release only).
+# This is done as a separate step because converting ~2800 HTML pages
+# to markdown is too slow to run inside the Sphinx build itself.
+if [[ "${WITH_PUSH:-}" == true ]]; then
+  echo "Generating llms-full.txt from built HTML pages..."
+  python -c "
+import sys
+sys.path.insert(0, '$(python -c "import pytorch_sphinx_theme2; import os; print(os.path.dirname(pytorch_sphinx_theme2.__file__))")')
+from llm_generation import _html_to_markdown
+from pathlib import Path
+from concurrent.futures import ProcessPoolExecutor, as_completed
+import os
+
+outdir = Path('build/html')
+html_files = sorted(outdir.rglob('*.html'))
+total = len(html_files)
+print(f'Converting {total} HTML files to markdown...')
+
+def convert(html_path):
+    try:
+        content = html_path.read_text(encoding='utf-8')
+        md = _html_to_markdown(content)
+        if md.strip():
+            md_path = html_path.with_suffix('.md')
+            md_path.write_text(md, encoding='utf-8')
+            return (html_path.stem, md)
+    except Exception as e:
+        print(f'Warning: {html_path}: {e}')
+    return (html_path.stem, None)
+
+results = {}
+max_workers = min(os.cpu_count() or 4, 8)
+with ProcessPoolExecutor(max_workers=max_workers) as executor:
+    futures = {executor.submit(convert, p): p for p in html_files}
+    done = 0
+    interval = max(1, total // 10)
+    for f in as_completed(futures):
+        name, md = f.result()
+        if md:
+            results[name] = md
+        done += 1
+        if done % interval == 0 or done == total:
+            print(f'  {done}/{total} files processed')
+
+sections = ['# PyTorch\n\n> PyTorch documentation.\n']
+for name, md in sorted(results.items()):
+    sections.append(f'\n---\n\n{md}')
+full_path = outdir / 'llms-full.txt'
+full_path.write_text('\n'.join(sections), encoding='utf-8')
+print(f'Generated llms-full.txt ({len(results)} pages) at: {full_path}')
+"
+fi
+
 # Move them into the docs repo
 popd
 popd

--- a/.ci/pytorch/python_doc_push_script.sh
+++ b/.ci/pytorch/python_doc_push_script.sh
@@ -140,59 +140,6 @@ else
   build_docs html-stable || exit $?
 fi
 
-# Generate llms-full.txt from built HTML (nightly/release only).
-# This is done as a separate step because converting ~2800 HTML pages
-# to markdown is too slow to run inside the Sphinx build itself.
-if [[ "${WITH_PUSH:-}" == true ]]; then
-  echo "Generating llms-full.txt from built HTML pages..."
-  python -c "
-import sys
-sys.path.insert(0, '$(python -c "import pytorch_sphinx_theme2; import os; print(os.path.dirname(pytorch_sphinx_theme2.__file__))")')
-from llm_generation import _html_to_markdown
-from pathlib import Path
-from concurrent.futures import ProcessPoolExecutor, as_completed
-import os
-
-outdir = Path('build/html')
-html_files = sorted(outdir.rglob('*.html'))
-total = len(html_files)
-print(f'Converting {total} HTML files to markdown...')
-
-def convert(html_path):
-    try:
-        content = html_path.read_text(encoding='utf-8')
-        md = _html_to_markdown(content)
-        if md.strip():
-            md_path = html_path.with_suffix('.md')
-            md_path.write_text(md, encoding='utf-8')
-            return (html_path.stem, md)
-    except Exception as e:
-        print(f'Warning: {html_path}: {e}')
-    return (html_path.stem, None)
-
-results = {}
-max_workers = min(os.cpu_count() or 4, 8)
-with ProcessPoolExecutor(max_workers=max_workers) as executor:
-    futures = {executor.submit(convert, p): p for p in html_files}
-    done = 0
-    interval = max(1, total // 10)
-    for f in as_completed(futures):
-        name, md = f.result()
-        if md:
-            results[name] = md
-        done += 1
-        if done % interval == 0 or done == total:
-            print(f'  {done}/{total} files processed')
-
-sections = ['# PyTorch\n\n> PyTorch documentation.\n']
-for name, md in sorted(results.items()):
-    sections.append(f'\n---\n\n{md}')
-full_path = outdir / 'llms-full.txt'
-full_path.write_text('\n'.join(sections), encoding='utf-8')
-print(f'Generated llms-full.txt ({len(results)} pages) at: {full_path}')
-"
-fi
-
 # Move them into the docs repo
 popd
 popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -157,6 +157,7 @@ html_theme_options = {
     ],
     "show_version_warning_banner": True,
     "llm_disabled": False,
+    "llm_generate_full": "false",
     "icon_links": [
         {
             "name": "X",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -156,8 +156,7 @@ html_theme_options = {
         },
     ],
     "show_version_warning_banner": True,
-    "llm_disabled": False,
-    "llm_generate_full": "false",
+    "llm_disabled": os.environ.get("CI") and os.environ.get("WITH_PUSH") != "true",
     "icon_links": [
         {
             "name": "X",


### PR DESCRIPTION
- Set `llm_generate_full = "false"` in `conf.py` to skip llms-full.txt generation during the Sphinx build to avoid long build
- Add a post-build step in `python_doc_push_script.sh` that generates llms-full.txt and markdown files only during nightly/release pushes (`WITH_PUSH=true`), after Sphinx has finished

## Motivation

- The llms-full.txt generation converts all HTML pages to markdown and concatenates them into a single file. On a build this large (~2800 pages), whih may cause CI timeouts. Since llms-full.txt only needs to be updated once per nightly push (not on every PR), we can decouple it from Sphinx and run it as a separate step.