### PR TITLE
Always detach op outputs saved by SAC

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -7462,6 +7462,21 @@ torch.cuda.synchronize()
 
         self.assertEqual(get_flops(nt), get_flops(nt_meta))
 
+    @skipIfTorchDynamo()
+    def test_nested_tensor_activation_checkpoint(self, device):
+        values = torch.randn(
+            9, 3, 256, requires_grad=True, device=device, dtype=torch.float32
+        )
+        lengths = torch.tensor([1, 2, 3, 3], device=device, dtype=torch.int64)
+        offsets = F.pad(lengths, pad=(1, 0)).cumsum(dim=0)
+
+        def fn(values, offsets):
+            nt = convert_jagged_to_nested_tensor(values, offsets, max_length=4)
+            return convert_nt_to_jagged(nt).sum()
+
+        checkpoint(fn, values, offsets, use_reentrant=False).backward()
+        self.assertIsNotNone(values.grad)
+
     # Internally-defined NT use cases are lifted to here for maximum test realism.
     # TODO: Remove these when ViewNestedFromBuffer, etc. are deprecated.
     @skipCUDAIfRocm  # not needed

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -72,7 +72,7 @@ from torch.testing._internal.opinfo.core import (
 )
 from torch.testing._internal.opinfo.definitions.nested import _sample_njts, njt_op_db
 from torch.utils._pytree import tree_flatten, tree_map_only
-from torch.utils.checkpoint import checkpoint, create_selective_checkpoint_contexts
+from torch.utils.checkpoint import checkpoint
 
 
 # Tests are ported from pytorch/nestedtensor.

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -7462,37 +7462,6 @@ torch.cuda.synchronize()
 
         self.assertEqual(get_flops(nt), get_flops(nt_meta))
 
-    @skipIfTorchDynamo()
-    def test_nested_tensor_activation_checkpoint(self, device):
-        values = torch.randn(
-            9, 3, 256, requires_grad=True, device=device, dtype=torch.float32
-        )
-        lengths = torch.tensor([1, 2, 3, 3], device=device, dtype=torch.int64)
-        offsets = F.pad(lengths, pad=(1, 0)).cumsum(dim=0)
-
-        def fn(values, offsets):
-            nt = convert_jagged_to_nested_tensor(values, offsets, max_length=4)
-            return convert_nt_to_jagged(nt).sum()
-
-        checkpoint(fn, values, offsets, use_reentrant=False).backward()
-        self.assertIsNotNone(values.grad)
-
-        context_fn = partial(
-            create_selective_checkpoint_contexts, [torch.ops.aten.cumsum.default]
-        )
-
-        values.grad = None
-
-        def fn(values, lengths):
-            offsets = F.pad(lengths, pad=(1, 0)).cumsum(dim=0)
-            nt = convert_jagged_to_nested_tensor(values, offsets, max_length=4)
-            return convert_nt_to_jagged(nt).sum()
-
-        checkpoint(
-            fn, values, lengths, use_reentrant=False, context_fn=context_fn
-        ).backward()
-        self.assertIsNotNone(values.grad)
-
     # Internally-defined NT use cases are lifted to here for maximum test realism.
     # TODO: Remove these when ViewNestedFromBuffer, etc. are deprecated.
     @skipCUDAIfRocm  # not needed

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1226,10 +1226,20 @@ class _VersionWrapper:
 
 
 def _detach_with_unexclude(x):
+    # We detach for two separate reasons:
+    # - For view ops, we need to ensure that when the tensor is returned from
+    #   CachedDispatchMode, as_view sees that the AutogradMeta is nullptr
+    # - Avoid reference cycles
+    # For case 1, it is not enough to check whether x has differentiable dtype
+    # because non-differentiable dtype can have non-nullptr AutogradMeta, e.g.
+    # when the tensor is a view.
     if isinstance(x, torch.Tensor):
         with torch._C._SetExcludeDispatchKeyGuard(torch._C.DispatchKey.ADInplaceOrView, False):
             # Ensure that view performed beneath autograd properly propagates
-            # version counter.
+            # version counter. TODO: Use reentrant_dispatch instead of
+            # manually manipulating dispatch keys. Using reentrant_dispatch
+            # would respect inference_mode, though that is not relevant for
+            # this case.
             x = x.detach()
     return x
 

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1225,21 +1225,11 @@ class _VersionWrapper:
         return self.val
 
 
-def _maybe_detach(x, any_ret_has_alias_info):
-    # We detach for two separate reasons:
-    # - For view ops, we need to ensure that when the tensor is returned from
-    #   CachedDispatchMode, as_view sees that the AutogradMeta is nullptr
-    # - Avoid reference cycles
-    # For case 1, it is not enough to check whether x has differentiable dtype
-    # because non-differentiable dtype can have non-nullptr AutogradMeta, e.g.
-    # when the tensor is a view.
-    if isinstance(x, torch.Tensor) and (x.is_floating_point() or x.is_complex() or any_ret_has_alias_info):
+def _maybe_detach(x):
+    if isinstance(x, torch.Tensor):
         with torch._C._SetExcludeDispatchKeyGuard(torch._C.DispatchKey.ADInplaceOrView, False):
             # Ensure that view performed beneath autograd properly propagates
-            # version counter. TODO: Use reentrant_dispatch instead of
-            # manually manipulating dispatch keys. Using reentrant_dispatch
-            # would respect inference_mode, though that is not relevant for
-            # this case.
+            # version counter.
             x = x.detach()
     return x
 
@@ -1352,14 +1342,6 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
 
         out = func(*args, **kwargs)
 
-        # HOPs don't support func._schema
-        # HOPs don't alias -> this is always true today and will be always true for a long time
-        # TODO HOPs don't mutate -> this is always true today but will not be true forever
-        if isinstance(func, torch._ops.HigherOrderOperator):
-            any_ret_has_alias_info = False
-        else:
-            any_ret_has_alias_info = any(ret.alias_info is not None for ret in func._schema.returns)
-
         idx = self.func_counter[func]
         self.func_counter[func] += 1
 
@@ -1376,7 +1358,7 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
                     node.meta["recompute"] = policy
 
         if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
-            self.storage[func][idx] = tree_map(lambda x: _VersionWrapper(_maybe_detach(x, any_ret_has_alias_info)), out)
+            self.storage[func][idx] = tree_map(lambda x: _VersionWrapper(_maybe_detach(x)), out)
         return out
 
 class _CachedTorchDispatchMode(TorchDispatchMode):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1225,7 +1225,7 @@ class _VersionWrapper:
         return self.val
 
 
-def _maybe_detach(x):
+def _detach_with_unexclude(x):
     if isinstance(x, torch.Tensor):
         with torch._C._SetExcludeDispatchKeyGuard(torch._C.DispatchKey.ADInplaceOrView, False):
             # Ensure that view performed beneath autograd properly propagates
@@ -1358,7 +1358,7 @@ class _CachingTorchDispatchMode(TorchDispatchMode):
                     node.meta["recompute"] = policy
 
         if policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
-            self.storage[func][idx] = tree_map(lambda x: _VersionWrapper(_maybe_detach(x)), out)
+            self.storage[func][idx] = tree_map(lambda x: _VersionWrapper(_detach_with_unexclude(x)), out)
         return out
 
 class _CachedTorchDispatchMode(TorchDispatchMode):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #180874
* #180867
* #180866
* __->__ #180919
* #176455

Previously, we want to avoid detaching for non-floating, non-views in case someone saved a NJT offsets for backward. Since no one actually uses that (verified by looking at all SAC policies internally and checking that no one saves an op that could produce offsets, e.g. cumsum), we can remove it and simplify the code.

Authored with Claude.

