### PR TITLE
Remove allow_cache_entry_mutation from SAC

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -15862,7 +15862,6 @@ class TestSelectiveActivationCheckpoint(TestCase):
         context_fn = functools.partial(
             create_selective_checkpoint_contexts,
             Policy(),
-            allow_cache_entry_mutation=True,
         )
         out = checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
         out.sum().backward()
@@ -15930,36 +15929,6 @@ class TestSelectiveActivationCheckpoint(TestCase):
             # The dispatch mode's storage should still be alive, but the entries should've
             # been cleared.
             self.assertIsNone(ref())
-
-    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
-    def test_version_counter(self):
-        def policy_fn(ctx, op, *args, **kwargs):
-            if op == torch.ops.aten.sin.default:
-                return CheckpointPolicy.MUST_SAVE
-            else:
-                return CheckpointPolicy.PREFER_RECOMPUTE
-
-        def fn(x):
-            return x.sin().mul_(2).cos().exp()
-
-        x = torch.randn(3, requires_grad=True)
-        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
-        out = checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
-
-        # 1) Error because the output of sin is saved and mutated by mul_
-        with self.assertRaisesRegex(RuntimeError, "has been mutated"):
-            out.sum().backward()
-
-        x = torch.randn(3, requires_grad=True)
-        context_fn = functools.partial(
-            create_selective_checkpoint_contexts,
-            policy_fn,
-            allow_cache_entry_mutation=True,
-        )
-        out = checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
-
-        # 2) No longer should be an error because of allow_cache_entry_mutation
-        out.sum().backward()
 
     @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
     def test_function_with_more_than_one_output(self):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -15931,6 +15931,35 @@ class TestSelectiveActivationCheckpoint(TestCase):
             self.assertIsNone(ref())
 
     @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_version_counter(self):
+        def policy_fn(ctx, op, *args, **kwargs):
+            if op == torch.ops.aten.sin.default:
+                return CheckpointPolicy.MUST_SAVE
+            else:
+                return CheckpointPolicy.PREFER_RECOMPUTE
+
+        def fn(x):
+            return x.sin().mul_(2).cos().exp()
+
+        x = torch.randn(3, requires_grad=True)
+        context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+        out = checkpoint(fn, x, use_reentrant=False, context_fn=context_fn)
+
+        with self.assertRaisesRegex(RuntimeError, "has been mutated"):
+            out.sum().backward()
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
+    def test_allow_cache_entry_mutation_error(self):
+        def policy_fn(ctx, op, *args, **kwargs):
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        with self.assertRaisesRegex(ValueError, "allow_cache_entry_mutation is no longer supported"):
+            create_selective_checkpoint_contexts(
+                policy_fn,
+                allow_cache_entry_mutation=True,
+            )
+
+    @skipIfTorchDynamo("compile tested in test/dynamo/test_activation_checkpointing.py")
     def test_function_with_more_than_one_output(self):
         # maybe there is a more systematic way:
         counter = [0]

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1210,18 +1210,10 @@ def _is_compiling(func, args, kwargs):
 
 
 class _VersionWrapper:
-    # Check that cached tensors are not mutated.
     def __init__(self, val) -> None:
         self.val: torch.Tensor | Any = val
-        self.version: int | None = val._version if isinstance(val, torch.Tensor) else None
 
-    def get_val(self, allow_cache_entry_mutation):
-        if self.version is not None and not allow_cache_entry_mutation:
-            if self.val._version != self.version:
-                # Can we give user a stack trace of where the mutation happened?
-                raise RuntimeError(
-                    "Tensor cached during selective activation checkpoint has been mutated"
-                )
+    def get_val(self):
         return self.val
 
 
@@ -1377,10 +1369,9 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
         return True
 
     # Used together with _CachedTorchDispatchMode to implement SAC.
-    def __init__(self, policy_fn, storage, allow_cache_entry_mutation) -> None:
+    def __init__(self, policy_fn, storage) -> None:
         self.policy_fn = policy_fn
         self.storage = storage
-        self.allow_cache_entry_mutation = allow_cache_entry_mutation
         self.func_counter: Dict[Any, int] = defaultdict(int)
 
     def __torch_dispatch__(self, func, types, args=(), kwargs=None):
@@ -1400,7 +1391,7 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
 
         cached = self.storage.get(func, {}).pop(idx, None)
         if cached is not None:
-            out = tree_map(lambda x: x.get_val(self.allow_cache_entry_mutation), cached)
+            out = tree_map(lambda x: x.get_val(), cached)
         elif policy in (CheckpointPolicy.MUST_SAVE, CheckpointPolicy.PREFER_SAVE) or is_compiling:
             if func not in self.storage:
                 raise RuntimeError(f"{func} encountered during backward, but not found in storage")
@@ -1413,7 +1404,7 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
         return out
 
 
-def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mutation=False):
+def create_selective_checkpoint_contexts(policy_fn_or_list):
     """
     Helper to avoid recomputing certain ops during activation checkpointing.
 
@@ -1430,10 +1421,6 @@ def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mu
             returning `CheckpointPolicy.MUST_SAVE` for the specified
             operations and `CheckpointPolicy.PREFER_RECOMPUTE` for all other
             operations.
-        allow_cache_entry_mutation (bool, optional): By default, an error is
-            raised if any tensors cached by selective activation checkpoint are
-            mutated in order to ensure correctness. If set to `True`, this check
-            is disabled.
     Returns:
         A tuple of two context managers.
 
@@ -1495,7 +1482,7 @@ def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mu
     storage: Dict[Any, Dict[int, Any]] = defaultdict(dict)
     return (
         _CachingTorchDispatchMode(policy_fn, storage),
-        _CachedTorchDispatchMode(policy_fn, storage, allow_cache_entry_mutation),
+        _CachedTorchDispatchMode(policy_fn, storage),
     )
 
 # NB: this helper wraps fn before calling checkpoint_impl. kwargs and

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1212,8 +1212,13 @@ def _is_compiling(func, args, kwargs):
 class _VersionWrapper:
     def __init__(self, val) -> None:
         self.val: torch.Tensor | Any = val
+        self.version: int | None = val._version if isinstance(val, torch.Tensor) else None
 
     def get_val(self):
+        if self.version is not None and self.val._version != self.version:
+            raise RuntimeError(
+                "Tensor cached during selective activation checkpoint has been mutated"
+            )
         return self.val
 
 
@@ -1404,7 +1409,7 @@ class _CachedTorchDispatchMode(TorchDispatchMode):
         return out
 
 
-def create_selective_checkpoint_contexts(policy_fn_or_list):
+def create_selective_checkpoint_contexts(policy_fn_or_list, *, allow_cache_entry_mutation=False):
     """
     Helper to avoid recomputing certain ops during activation checkpointing.
 
@@ -1455,6 +1460,12 @@ def create_selective_checkpoint_contexts(policy_fn_or_list):
         >>>     context_fn=context_fn,
         >>> )
     """
+    if allow_cache_entry_mutation:
+        raise ValueError(
+            "allow_cache_entry_mutation is no longer supported. Cached tensors are "
+            "always checked for mutation to ensure correctness. If your use case "
+            "requires caching a tensor that is mutated afterwards, please file an issue."
+        )
     # NB: If grad_mode is disabled, checkpoint would not run forward under
     #     context_fn anyway, so proceed as usual.
     if isinstance(policy_fn_or_list, list):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #180874
* #180867
* #180866
* __->__ #180924
* #180919
* #176455

I'm considering deleting this, because from internal and external search, no one is actually using it and it a piece of complexity that limits the design of the rest of the system.

This is theoretically useful if you saved an op, and then ALSO want to save the inplace op that came after it, but we if anyone requests for this explicitly we may be able to provide this in a safer way.



Authored with Claude.