### PR TITLE
[ROCm][RELEASE_ONLY] skip test_autoheuristic in-code (already disabled via issue)

### DIFF
--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -11,7 +11,7 @@ from torch._inductor.autoheuristic.autoheuristic_utils import AHContext
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import get_gpu_shared_memory
-from torch.testing._internal.common_utils import skipIfXpu
+from torch.testing._internal.common_utils import skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, IS_A100, IS_H100
 
 
@@ -70,6 +70,7 @@ class AutoHeuristicTest(TestCase):
         # this test ensures that data is collected for pad_mm when autoheuristic_collect.pad_mm=True
         self.assert_autoheuristic_collected_data()
 
+    @skipIfRocm(msg="AutoHeuristic doesn't currently work on the ROCm stack")
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @patch.dict(os.environ, {"TORCHINDUCTOR_AUTOHEURISTIC_COLLECT": "test"})
     def test_autoheuristic(self):


### PR DESCRIPTION
DISABLED Issue: https://github.com/pytorch/pytorch/issues/180475

Need to disable this in-code because disabled.json seems to fixed to a specific commit in 2.12 and this UT was disabled after branching, so it's still failing in release/2.12 branch.

<img width="1713" height="768" alt="Screenshot_20260421-075941" src="https://github.com/user-attachments/assets/d5870f0d-d3ca-42a8-9c83-44393a0b0832" />

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben