### PR TITLE
[Inductor] Lower MAX_COMPLEX_POINTWISE_CAT from 8 to 5

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2163,7 +2163,10 @@ def cat(inputs, dim=0):
     # past a certain threshold of inputs we only fuse if the if the input kernels
     # are simple
     # not sure if we want to expose to users via config since logic may change in future
-    MAX_COMPLEX_POINTWISE_CAT = 8
+    # Lowered from 8 to 5: cat with >= 6 inputs generates excessive branching
+    # (7+ comparisons per element) that destroys warp coherence and memory
+    # coalescing when fused into reduction inner loops (e.g., cat + layer_norm).
+    MAX_COMPLEX_POINTWISE_CAT = 5
     MAX_SIMPLE_OP_COUNT = 2
 
     def additional_pointwise_ops(op: torch._ops.OpOverload):


### PR DESCRIPTION
Summary:
Reduces the threshold for pointwise cat fusion from 8 to 5 inputs.
When cat has >= 6 inputs and is fused into a reduction kernel (e.g.,
layer_norm), the generated code has 5+ conditional branches per element
in the reduction inner loop to select the source tensor. This destroys
warp coherence and memory coalescing on AMD GPUs, causing 3-33x
slowdown vs roofline.

By lowering the threshold, cats with >= 6 inputs use ConcatKernel
(materialized output) instead of pointwise_cat (inlined conditionals).
The separate cat + reduction kernels each run near roofline.

Benchmark (MI350X):
- triton_red_fused_cat_native_layer_norm_view_201: 1,149 us → 412 us (2.8x faster)
- Memory Bound Others total: 6,589 us → 5,216 us (-20.8%)
- Total GPU latency: 25,676 us → 24,745 us (-3.6%)

The affected kernel fuses cat(8 tensors along dim=21568) + layer_norm.
With pointwise_cat, each element in the 21,568-element reduction
requires 7 comparisons + conditional loads from 8 different memory
regions. After unfusing, the cat materializes via ConcatKernel and
layer_norm reduces over contiguous memory.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo