### PR TITLE
[FSDP2] Document HSDP AR buffer lifetime invariant in _all_reduce_state

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -679,6 +679,13 @@ def foreach_reduce(
                         group=all_reduce_group,
                         op=all_reduce_op,
                     )
+                # Keep refs to the bf16 AR buffer + completion event so
+                # FSDPParamGroup._all_reduce_state can hold them across
+                # layers. This keeps the buffer off the caching allocator's
+                # free list; otherwise the next layer's reduce-scatter can
+                # reuse the same physical block while this layer's AR is
+                # still in flight, causing cross-layer gradient aliasing
+                # under slow AR. See PR #140044, regression test PR #180900.
                 all_reduce_input = reduce_output
                 all_reduce_event = all_reduce_stream.record_event()
     # -- END: ops in reduce_scatter stream
@@ -695,6 +702,15 @@ def foreach_reduce(
 
     with device_handle.stream(post_reduce_stream):
         _div_if_needed(reduce_output, postdivide_factor)
+        # Rebinds to a new fp32 tensor when reduce_dtype != orig_dtype.
+        # Do NOT rely on this stream-scoped rebind to manage the old bf16
+        # buffer's lifetime: the rebind orders the cast before the
+        # free-event on AR stream, but the freed block lands on the
+        # caching allocator's free list and the next layer's RS on RS
+        # stream can reuse it without waiting for this layer's AR to
+        # finish. The bf16 buffer is held across layers by
+        # FSDPParamGroup._all_reduce_state (captured above) to prevent
+        # this. See PR #140044, regression test PR #180900.
         reduce_output = _to_dtype_if_needed(reduce_output, orig_dtype)
         # View out and accumulate sharded gradients
         flat_grad_offset = 0  # [0, reduce_scatter_output_numel - 1]

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -124,6 +124,11 @@ class ReduceScatterState(NamedTuple):
 
 
 class AllReduceState(NamedTuple):
+    # Holding all_reduce_input (the bf16 AR buffer) keeps the caching
+    # allocator from reusing the block across layers. This is a structural
+    # invariant, not bookkeeping: without it, the next layer's RS can
+    # reuse the same physical block before this layer's AR finishes under
+    # slow AR, causing gradient aliasing. See PR #140044, PR #180900.
     all_reduce_input: torch.Tensor
     event: torch.Event | None  # all-reduce event
 
@@ -230,10 +235,13 @@ class FSDPParamGroup:
         # Only for HSDP, if accumulating gradients without all-reduce, save the
         # partial reduce output (only reduce-scattered but not all-reduced)
         self._partial_reduce_output: torch.Tensor | None = None
-        # Holds the all-reduce input and all-reduce event to keep it alive
-        # until the end of backward (critical when doing bf16 reduction with
-        # fp32 parameters since the all-reduce input is allocated in the RS
-        # stream and will have no refs to it after being upcast to fp32)
+        # Holds the bf16 AR buffer + completion event across layers in
+        # HSDP+AR with reduce_dtype != orig_dtype (e.g., bf16 reduce +
+        # fp32 params). Structural invariant: the live Python ref keeps
+        # the buffer off the caching allocator's free list, preventing
+        # the next layer's RS from reusing the same physical block while
+        # this layer's AR is still in flight. See AllReduceState docstring
+        # and regression test PR #180900.
         self._all_reduce_state: AllReduceState | None = None
 
     # Initialization #


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #180931
* #180900

Summary:
Adds load-bearing comments to `_fsdp_collectives.py` and
`_fsdp_param_group.py` explaining why `FSDPParamGroup._all_reduce_state`
has to keep the bf16 AR buffer alive across layers in HSDP+AR. Without
the comment, the rebind pattern at the dtype cast looks like a safe
orphan-on-AR-stream drop — a natural simplification target. In reality,
dropping the ref there lets the caching allocator reuse the same
physical bf16 block across layers, which under slow AR causes all
layers' sharded grads to alias the same storage and collapse to the
last-executed layer's value.

Three sites updated:
- `_fsdp_collectives.py` (cast line): warns against relying on the
  stream-scoped rebind for lifetime management; points at
  `_all_reduce_state` as the actual guard.
- `_fsdp_collectives.py` (capture site for `all_reduce_input`): explains
  what keeping the ref prevents (cross-layer block reuse).
- `_fsdp_param_group.py` (`AllReduceState` NamedTuple + `_all_reduce_state`
  field init): frames it as a structural invariant, not bookkeeping;
  points to regression test PR #180900.

No behavior change; comments only. The regression test in PR #180900
covers the invariant these comments describe.

This PR was authored with Claude.

Test Plan: Comments only. Existing tests apply.

Reviewers:

Subscribers:

Tasks:

Tags: