### PR TITLE
Allow pytorch-bot to trigger Claude Autorevert Advisor workflow

### DIFF
--- a/.github/workflows/claude-autorevert-advisor.yml
+++ b/.github/workflows/claude-autorevert-advisor.yml
@@ -47,7 +47,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
         with:
-          allowed_bots: "pytorch-auto-revert[bot]"
+          allowed_bots: "pytorch-auto-revert[bot],pytorch-bot[bot]"
           use_bedrock: "true"
           claude_args: |
             --model global.anthropic.claude-opus-4-6-v1


### PR DESCRIPTION
## Summary

`pytorch-bot[bot]` dispatches the autorevert advisor workflow via `workflow_dispatch`, but it was not in the `allowed_bots` list. This caused claude-code-action to reject the run with:

```
Workflow initiated by non-human actor: pytorch-bot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

Example failure: https://github.com/pytorch/pytorch/actions/runs/24693412117/job/72220539521

This adds `pytorch-bot[bot]` alongside the existing `pytorch-auto-revert[bot]` entry.

## Test plan

- The linked failed run should succeed after this change lands.

Authored with Claude.