### PR TITLE
[CUDACachingAllocator] Add OOM warning log and stat for expandable segments (#180946)

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -490,6 +490,16 @@ struct ExpandableSegment {
 #endif
       if (status != CUDA_SUCCESS) {
         if (status == CUDA_ERROR_OUT_OF_MEMORY) {
+          {
+            size_t device_free = 0;
+            size_t device_total = 0;
+            (void)cudaMemGetInfo(&device_free, &device_total);
+            LOG(WARNING) << "expandable_segments: memory mapping failed with OOM on device "
+                        << static_cast<int>(device_)
+                        << " while trying to map " << segment_size_
+                        << " bytes (free: " << device_free
+                        << ", total: " << device_total << ").";
+          }
 #ifdef USE_ROCM
           // hipMemCreate above returned hipErrorOutOfMemory and treated it
           // like a sticky runtime error. Which means we need to clear it.
@@ -3670,6 +3680,16 @@ class DeviceCachingAllocator {
 
       if (p.err != cudaSuccess) {
         if (p.err == cudaErrorMemoryAllocation) {
+          {
+            size_t device_free = 0;
+            size_t device_total = 0;
+            (void)cudaMemGetInfo(&device_free, &device_total);
+            LOG(WARNING) << "memory allocation failed with OOM on device "
+                        << static_cast<int>(device_id)
+                        << " while trying to allocate " << size
+                        << " bytes (free: " << device_free
+                        << ", total: " << device_total << ").";
+          }
           // If this is the first attempt (!isRetry), we can forgive and clear
           // CUDA's internal error state.
           //

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -494,11 +494,11 @@ struct ExpandableSegment {
             size_t device_free = 0;
             size_t device_total = 0;
             (void)cudaMemGetInfo(&device_free, &device_total);
-            LOG(WARNING) << "expandable_segments: memory mapping failed with OOM on device "
-                        << static_cast<int>(device_)
-                        << " while trying to map " << segment_size_
-                        << " bytes (free: " << device_free
-                        << ", total: " << device_total << ").";
+            LOG(WARNING)
+                << "expandable_segments: memory mapping failed with OOM on device "
+                << static_cast<int>(device_) << " while trying to map "
+                << segment_size_ << " bytes (free: " << device_free
+                << ", total: " << device_total << ").";
           }
 #ifdef USE_ROCM
           // hipMemCreate above returned hipErrorOutOfMemory and treated it
@@ -3685,10 +3685,10 @@ class DeviceCachingAllocator {
             size_t device_total = 0;
             (void)cudaMemGetInfo(&device_free, &device_total);
             LOG(WARNING) << "memory allocation failed with OOM on device "
-                        << static_cast<int>(device_id)
-                        << " while trying to allocate " << size
-                        << " bytes (free: " << device_free
-                        << ", total: " << device_total << ").";
+                         << static_cast<int>(device_id)
+                         << " while trying to allocate " << size
+                         << " bytes (free: " << device_free
+                         << ", total: " << device_total << ").";
           }
           // If this is the first attempt (!isRetry), we can forgive and clear
           // CUDA's internal error state.


### PR DESCRIPTION
Summary:

When expandable segments fail to map physical memory (cuMemCreate returns
CUDA_ERROR_OUT_OF_MEMORY), the allocator currently returns silently with no
diagnostic signal. This makes it hard to debug GPU memory exhaustion in
expandable segment mode.

This diff adds:
A LOG(WARNING) in CudaMalloc() and cuMemCreate() fails with OOM, logging device ID and requested segment size.

Differential Revision: D101708862


