### PR TITLE
[CUDACachingAllocator] Add test for expandable segment OOM stat

### DIFF
--- a/c10/core/CachingDeviceAllocator.h
+++ b/c10/core/CachingDeviceAllocator.h
@@ -59,6 +59,9 @@ struct DeviceStats {
   // COUNT: total number of allocations rejected by OOM preemption policy
   int64_t num_oom_rejections = 0;
 
+  // COUNT: total number of OOM failures when mapping expandable segments
+  int64_t num_expandable_segment_map_oom = 0;
+
   // SIZE: maximum block size that is allowed to be split.
   int64_t max_split_size = 0;
 };

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -381,12 +381,14 @@ struct ExpandableSegment {
       c10::DeviceIndex device,
       std::optional<cudaStream_t> stream,
       size_t segment_size,
-      std::vector<c10::DeviceIndex> peers)
+      std::vector<c10::DeviceIndex> peers,
+      int64_t* num_map_oom = nullptr)
       : device_(device),
         stream_(stream),
         // 2MB for small pool, 20MB for large pool
         segment_size_(segment_size),
-        peers_(std::move(peers)) {
+        peers_(std::move(peers)),
+        num_map_oom_(num_map_oom) {
     cudaDeviceProp prop{};
     C10_CUDA_CHECK(cudaGetDeviceProperties(&prop, device_));
     mapped_size_ = 0;
@@ -494,6 +496,15 @@ struct ExpandableSegment {
 #endif
       if (status != CUDA_SUCCESS) {
         if (status == CUDA_ERROR_OUT_OF_MEMORY) {
+          if (num_map_oom_) {
+            ++(*num_map_oom_);
+          }
+          LOG(WARNING)
+              << "expandable_segments: cuMemCreate failed with OOM on device "
+              << device_ << " while trying to map " << segment_size_
+              << " bytes (OOM count: "
+              << (num_map_oom_ ? *num_map_oom_ : 0)
+              << "). GPU memory may be exhausted.";
 #ifdef USE_ROCM
           // hipMemCreate above returned hipErrorOutOfMemory and treated it
           // like a sticky runtime error. Which means we need to clear it.
@@ -922,6 +933,7 @@ struct ExpandableSegment {
   // devices on which this memory should be mapped in addition
   // to the device where the physical memory lives (device_).
   std::vector<c10::DeviceIndex> peers_;
+  int64_t* num_map_oom_;
 };
 #else
 struct ExpandableSegment {
@@ -929,7 +941,8 @@ struct ExpandableSegment {
       c10::DeviceIndex device,
       std::optional<cudaStream_t> stream,
       size_t segment_size,
-      std::vector<c10::DeviceIndex> peers) {
+      std::vector<c10::DeviceIndex> peers,
+      int64_t* /*num_map_oom*/ = nullptr) {
     TORCH_INTERNAL_ASSERT(false, "expandable segment not supported");
   }
   SegmentRange map(SegmentRange range) {
@@ -2386,6 +2399,7 @@ class DeviceCachingAllocator {
     stats.num_device_alloc = 0;
     stats.num_device_free = 0;
     stats.num_oom_rejections = 0;
+    stats.num_expandable_segment_map_oom = 0;
     stats.oversize_allocations.reset_accumulated();
     stats.oversize_segments.reset_accumulated();
   }
@@ -3098,7 +3112,8 @@ class DeviceCachingAllocator {
         ? kSmallBuffer
         : AcceleratorAllocatorConfig::large_segment_size();
     expandable_segments_.emplace_back(new ExpandableSegment(
-        device, stream, segment_size, devices_with_peer_access_));
+        device, stream, segment_size, devices_with_peer_access_,
+        &stats.num_expandable_segment_map_oom));
 
     ExpandableSegment* es = expandable_segments_.back();
     Block* candidate = new Block(device, stream, es->size(), pool, es->ptr());

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5398,6 +5398,26 @@ print(value, end="")
             torch.empty(1024 * 1024 * 1024 * 1024, device="cuda")
         self.assertTrue(x)
 
+    @serialTest()
+    def test_expandable_segment_map_oom_stat(self):
+        torch.cuda.empty_cache()
+        device = torch._C._cuda_getDevice()
+        torch._C._cuda_resetAccumulatedMemoryStats(device)
+        prev_settings = torch._C._accelerator_getAllocatorSettings()
+
+        try:
+            torch._C._accelerator_setAllocatorSettings(
+                "expandable_segments:True"
+            )
+            with self.assertRaises(torch.cuda.OutOfMemoryError):
+                torch.empty(1024 * 1024 * 1024 * 1024, dtype=torch.int8, device="cuda")
+
+            stats = torch.cuda.memory_stats()
+            self.assertGreater(stats["num_expandable_segment_map_oom"], 0)
+        finally:
+            torch.cuda.empty_cache()
+            torch._C._accelerator_setAllocatorSettings(prev_settings)
+
     def test_allocator_fuzz(self):
         # fuzz
         if (

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -613,6 +613,7 @@ PyObject* THCPModule_memoryStats(PyObject* _unused, PyObject* arg) {
   result["num_device_alloc"] = stats.num_device_alloc;
   result["num_device_free"] = stats.num_device_free;
   result["num_oom_rejections"] = stats.num_oom_rejections;
+  result["num_expandable_segment_map_oom"] = stats.num_expandable_segment_map_oom;
   result["allocation"] = statArrayToDict(stats.allocation);
   result["segment"] = statArrayToDict(stats.segment);
   result["active"] = statArrayToDict(stats.active);


### PR DESCRIPTION
Summary:
Adds test_expandable_segment_map_oom_stat to TestCudaAllocator that verifies
the num_expandable_segment_map_oom stat counter is incremented when GPU memory
is exhausted during expandable segment mapping.

The test enables expandable_segments, triggers OOM by allocating 1TB, and
asserts the stat is > 0.

Test Plan: buck2 test fbcode//caffe2/test:test_cuda -- -r test_expandable_segment_map_oom_stat

Differential Revision: D101708861


