### PR TITLE
[Inductor] Skip test_template_epilogue_fusion_static_analysis on ROCm

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -4907,6 +4907,7 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
     @unittest.skipIf(
         config.cpp_wrapper, "Skip static analysis codegen checks on cpp_wrapper"
     )
+    @skipIfRocm(msg="Scheduler static analysis needs investigation on ROCm")
     @parametrize(
         "test_case",
         [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180950

This test uses FileCheck assertions (e.g. "triton_poi_fused__to_copy") that only
match nvidia triton codegen not rocm.                                                                                                                         
                                                                                                                                                                                                   
Sibling tests in the same class `test_template_epilogue_fusion_extra_reads` already have `@skipIfRocm`; adding it here too for consistency.                                                                                                                                                                                   
                                                                                                                                                                                                   
Fixes #176116      


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @mlazos