### PR TITLE
Add torch.compiler.generate_kernel

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -14,6 +14,7 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
     :nosignatures:
 
      compile
+     generate_kernel
      reset
      allow_in_graph
      substitute_in_graph

--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -4,11 +4,13 @@ import inspect
 import io
 import os
 import tempfile
+from typing import NamedTuple
 from unittest.mock import patch
 
 import torch
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import CompileCounter
+from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
 
 class ToyModel(torch.nn.Module):
@@ -320,14 +322,55 @@ class PublicTorchCompilerTests(TestCase):
             ) as get_kernels_mock,
         ):
             self.assertEqual(
-                torch.compiler.generate_kernel(fn, ("x", "y")),
+                torch.compiler.generate_kernel(
+                    fn, ("x", "y"), fullgraph=True, dynamic=False
+                ),
                 "triton kernel",
             )
 
-        compile_mock.assert_called_once_with(fn)
+        compile_mock.assert_called_once_with(fn, fullgraph=True, dynamic=False)
         get_kernels_mock.assert_called_once_with(
             compiled_fn, "x", "y", remove_quote=True
         )
+
+    def test_generate_kernel_accepts_list_example_inputs(self):
+        def fn(x, y):
+            return x + y
+
+        compiled_fn = object()
+        with (
+            patch("torch.compile", return_value=compiled_fn),
+            patch(
+                "torch._inductor.utils.run_and_get_kernels",
+                return_value=(None, ["triton kernel"]),
+            ) as get_kernels_mock,
+        ):
+            torch.compiler.generate_kernel(fn, ["x", "y"])
+
+        get_kernels_mock.assert_called_once_with(
+            compiled_fn, "x", "y", remove_quote=True
+        )
+
+    def test_generate_kernel_preserves_namedtuple_input(self):
+        class Inputs(NamedTuple):
+            x: object
+            y: object
+
+        def fn(inputs):
+            return inputs.x + inputs.y
+
+        compiled_fn = object()
+        inputs = Inputs(object(), object())
+        with (
+            patch("torch.compile", return_value=compiled_fn),
+            patch(
+                "torch._inductor.utils.run_and_get_kernels",
+                return_value=(None, ["triton kernel"]),
+            ) as get_kernels_mock,
+        ):
+            torch.compiler.generate_kernel(fn, inputs)
+
+        get_kernels_mock.assert_called_once_with(compiled_fn, inputs, remove_quote=True)
 
     def test_generate_kernel_wraps_single_example_input(self):
         def fn(x):
@@ -365,6 +408,19 @@ class PublicTorchCompilerTests(TestCase):
                     f"expected exactly one Triton kernel.*generated {len(kernels)}",
                 ):
                     torch.compiler.generate_kernel(fn, ("x",))
+
+    @requires_cuda_and_triton
+    def test_generate_kernel_cuda_integration(self):
+        def fn(x, y):
+            return x + y
+
+        x = torch.randn(4, device="cuda")
+        y = torch.randn(4, device="cuda")
+
+        kernel = torch.compiler.generate_kernel(fn, (x, y), fullgraph=True)
+
+        self.assertIn("def triton_", kernel)
+        self.assertIn("tl.load", kernel)
 
 
 class FullgraphTests(TestCase):

--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -307,6 +307,65 @@ class PublicTorchCompilerTests(TestCase):
         for fn_name in function_names:
             self.check_signature(fn_name, fn_name, torch._dynamo)
 
+    def test_generate_kernel_returns_single_kernel(self):
+        def fn(x, y):
+            return x + y
+
+        compiled_fn = object()
+        with (
+            patch("torch.compile", return_value=compiled_fn) as compile_mock,
+            patch(
+                "torch._inductor.utils.run_and_get_kernels",
+                return_value=(None, ["triton kernel"]),
+            ) as get_kernels_mock,
+        ):
+            self.assertEqual(
+                torch.compiler.generate_kernel(fn, ("x", "y")),
+                "triton kernel",
+            )
+
+        compile_mock.assert_called_once_with(fn)
+        get_kernels_mock.assert_called_once_with(
+            compiled_fn, "x", "y", remove_quote=True
+        )
+
+    def test_generate_kernel_wraps_single_example_input(self):
+        def fn(x):
+            return x + 1
+
+        compiled_fn = object()
+        input_arg = object()
+        with (
+            patch("torch.compile", return_value=compiled_fn),
+            patch(
+                "torch._inductor.utils.run_and_get_kernels",
+                return_value=(None, ["triton kernel"]),
+            ) as get_kernels_mock,
+        ):
+            torch.compiler.generate_kernel(fn, input_arg)
+
+        get_kernels_mock.assert_called_once_with(
+            compiled_fn, input_arg, remove_quote=True
+        )
+
+    def test_generate_kernel_rejects_zero_or_multiple_kernels(self):
+        def fn(x):
+            return x + 1
+
+        for kernels in ([], ["kernel 0", "kernel 1"]):
+            with (
+                patch("torch.compile", return_value=object()),
+                patch(
+                    "torch._inductor.utils.run_and_get_kernels",
+                    return_value=(None, kernels),
+                ),
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    f"expected exactly one Triton kernel.*generated {len(kernels)}",
+                ):
+                    torch.compiler.generate_kernel(fn, ("x",))
+
 
 class FullgraphTests(TestCase):
     def test_fullgraph_errors_on_frame_skip_with_dispatch_mode(self):

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -53,6 +53,10 @@ class TestUtils(TestCase):
             _extract_triton_kernel_sources(code, remove_quote=True),
             ["kernel 0", "kernel 1"],
         )
+        self.assertEqual(
+            _extract_triton_kernel_sources(code, remove_quote=False),
+            ["kernel 0", "kernel 1"],
+        )
 
     def test_zip_schema(self):
         def foo(x: torch.Tensor) -> None:

--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -6,8 +6,14 @@ import unittest
 from sympy import I, Max, Min, Symbol, sympify
 
 import torch
+from torch._inductor import config as inductor_config
 from torch._inductor.fx_utils import count_flops_fx, countable_fx
-from torch._inductor.utils import get_device_tflops, sympy_str, sympy_subs
+from torch._inductor.utils import (
+    _extract_triton_kernel_sources,
+    get_device_tflops,
+    sympy_str,
+    sympy_subs,
+)
 from torch._inductor.virtualized import V
 from torch.testing._internal.common_device_type import (
     dtypes,
@@ -18,6 +24,36 @@ from torch.utils._sympy.functions import Identity
 
 
 class TestUtils(TestCase):
+    @inductor_config.patch({"cpp_wrapper": False})
+    def test_extract_triton_kernel_sources_python_wrapper(self):
+        code = """
+            triton_kernel_0 = async_compile.triton('triton_kernel_0', '''kernel 0''')
+            triton_kernel_1 = async_compile.triton('triton_kernel_1', '''kernel 1''')
+        """
+
+        self.assertEqual(
+            _extract_triton_kernel_sources(code, remove_quote=True),
+            ["kernel 0", "kernel 1"],
+        )
+        self.assertEqual(
+            _extract_triton_kernel_sources(code),
+            ["'''kernel 0'''", "'''kernel 1'''"],
+        )
+
+    @inductor_config.patch(
+        {"cpp_wrapper": True, "triton.autotune_at_compile_time": False}
+    )
+    def test_extract_triton_kernel_sources_cpp_wrapper(self):
+        code = """
+            auto triton_kernel_0 = R"TRITON(kernel 0)TRITON";
+            auto triton_kernel_1 = R"TRITON(kernel 1)TRITON";
+        """
+
+        self.assertEqual(
+            _extract_triton_kernel_sources(code, remove_quote=True),
+            ["kernel 0", "kernel 1"],
+        )
+
     def test_zip_schema(self):
         def foo(x: torch.Tensor) -> None:
             pass

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2646,15 +2646,20 @@ def run_and_get_kernels(
     result, source_codes = run_and_get_code(fn, *args, **kwargs)
     kernels = []
     for code in source_codes:
-        if config.cpp_wrapper and config.triton.autotune_at_compile_time is not True:
-            # With lazy Triton kernel compilation, kernel sources are embedded
-            # inside C++ R"TRITON(...)TRITON" raw strings.
-            kernels.extend(re.findall(r'R"TRITON\((.*?)\)TRITON"', code, re.DOTALL))
-        else:
-            kernels.extend(re.findall(r"'''.*?'''", code, re.DOTALL))
-        if remove_quote:
-            kernels = [kernel[3:-3] for kernel in kernels]
+        kernels.extend(_extract_triton_kernel_sources(code, remove_quote))
     return result, kernels
+
+
+def _extract_triton_kernel_sources(code: str, remove_quote: bool = False) -> list[str]:
+    if config.cpp_wrapper and config.triton.autotune_at_compile_time is not True:
+        # With lazy Triton kernel compilation, kernel sources are embedded
+        # inside C++ R"TRITON(...)TRITON" raw strings.
+        return re.findall(r'R"TRITON\((.*?)\)TRITON"', code, re.DOTALL)
+
+    kernels = re.findall(r"'''.*?'''", code, re.DOTALL)
+    if remove_quote:
+        return [kernel[3:-3] for kernel in kernels]
+    return kernels
 
 
 def run_fw_bw_and_get_code(fn: Callable[..., Any]) -> tuple[Any, list[str]]:

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2641,7 +2641,7 @@ def run_and_get_code(
 def run_and_get_kernels(
     fn: Callable[P, _T], *args: P.args, **kwargs: P.kwargs
 ) -> tuple[_T, list[str]]:
-    remove_quote = kwargs.pop("remove_quote", False)
+    remove_quote = cast(bool, kwargs.pop("remove_quote", False))
     # pyrefly: ignore [bad-argument-type]
     result, source_codes = run_and_get_code(fn, *args, **kwargs)
     kernels = []

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -58,25 +58,43 @@ def compile(*args, **kwargs):
     return torch.compile(*args, **kwargs)
 
 
-def generate_kernel(fn: Callable[..., Any], example_inputs: Any) -> str:
+def generate_kernel(
+    fn: Callable[..., Any],
+    example_inputs: Any,
+    **compile_kwargs: Any,
+) -> str:
     """
     Compile ``fn`` with ``torch.compile`` and return its generated Triton kernel.
 
     Args:
         fn: Callable to compile.
-        example_inputs: Example positional inputs. Pass a tuple for multiple
-            inputs.
+        example_inputs: Example positional inputs. Pass a tuple or list for
+            multiple inputs. NamedTuples are treated as a single input.
+        compile_kwargs: Additional keyword arguments to forward to
+            ``torch.compile``.
 
     Returns:
         The generated Triton kernel source.
 
     Raises:
         RuntimeError: If compilation generates zero or multiple Triton kernels.
+
+    .. note::
+        This helper resets Dynamo compilation state internally when collecting
+        generated code.
     """
     from torch._inductor.utils import run_and_get_kernels
+    from torch.utils import _pytree as pytree
 
-    args = example_inputs if isinstance(example_inputs, tuple) else (example_inputs,)
-    _, kernels = run_and_get_kernels(torch.compile(fn), *args, remove_quote=True)
+    args = (
+        tuple(example_inputs)
+        if isinstance(example_inputs, (tuple, list))
+        and not pytree.is_namedtuple_instance(example_inputs)
+        else (example_inputs,)
+    )
+    _, kernels = run_and_get_kernels(
+        torch.compile(fn, **compile_kwargs), *args, remove_quote=True
+    )
 
     if len(kernels) != 1:
         raise RuntimeError(

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -15,6 +15,7 @@ from ._cache import CacheInfo
 __all__ = [
     "compile",
     "config",
+    "generate_kernel",
     "assume_constant_result",
     "reset",
     "allow_in_graph",
@@ -55,6 +56,35 @@ def compile(*args, **kwargs):
     """
     # pyrefly: ignore [not-iterable]
     return torch.compile(*args, **kwargs)
+
+
+def generate_kernel(fn: Callable[..., Any], example_inputs: Any) -> str:
+    """
+    Compile ``fn`` with ``torch.compile`` and return its generated Triton kernel.
+
+    Args:
+        fn: Callable to compile.
+        example_inputs: Example positional inputs. Pass a tuple for multiple
+            inputs.
+
+    Returns:
+        The generated Triton kernel source.
+
+    Raises:
+        RuntimeError: If compilation generates zero or multiple Triton kernels.
+    """
+    from torch._inductor.utils import run_and_get_kernels
+
+    args = example_inputs if isinstance(example_inputs, tuple) else (example_inputs,)
+    _, kernels = run_and_get_kernels(torch.compile(fn), *args, remove_quote=True)
+
+    if len(kernels) != 1:
+        raise RuntimeError(
+            "torch.compiler.generate_kernel expected exactly one Triton kernel, "
+            f"but torch.compile generated {len(kernels)} kernels."
+        )
+
+    return kernels[0]
 
 
 def reset() -> None:


### PR DESCRIPTION
Summary:
- Add `torch.compiler.generate_kernel(fn, example_inputs, **compile_kwargs)` to compile a callable with `torch.compile` and return the single generated Triton kernel source.
- Raise a `RuntimeError` when compilation produces zero or multiple Triton kernels.
- Share Triton kernel extraction between the public API and Inductor test helpers, including C++ wrapper raw-string handling.
- Preserve NamedTuple inputs as a single argument and accept lists as multiple example inputs.
- Cover the C++ wrapper extraction path with both `remove_quote=True` and `remove_quote=False` assertions.

Problem:
Users currently need to enable `TORCH_LOGS=output_code` or inspect tlparse artifacts and manually copy the generated Triton kernel source. The initial API also did not forward `torch.compile` kwargs, treated lists as one input, and unpacked NamedTuple inputs because they subclass tuple. The C++ wrapper extraction tests also did not explicitly assert that `remove_quote=False` is a no-op for raw-string matches.

Proposed fix:
Expose a small public `torch.compiler.generate_kernel` helper that reuses Inductor generated-code capture, forwards compile kwargs, normalizes tuple/list example inputs, preserves NamedTuple inputs, and validates that exactly one Triton kernel was emitted. Add a focused regression assertion for the C++ wrapper raw-string extraction invariant.

Why this is the right long term fix:
The API is a narrow wrapper over the same output-code path users already inspect, so it avoids introducing a parallel codegen path while making the single-kernel invariant explicit and testable. The argument handling matches the expected public API shape without special cases leaking into callers, and the extraction tests now document both Python and C++ wrapper quoting behavior directly.

Additional note:
The shared extraction helper keeps C++ wrapper raw-string kernel sources unquoted. This means `remove_quote=True` no longer slices C++ raw-string matches that do not include Python triple-quote delimiters, fixing a latent bug in that path.

Testing:
- `git diff --check`
- `python3 -m py_compile torch/compiler/__init__.py torch/_inductor/utils.py test/dynamo/test_compile.py`
- `python3 -m py_compile test/inductor/test_utils.py`
- Isolated stub harness: previous PR HEAD fails for compile kwargs, list inputs, and NamedTuple inputs; current working tree passes those cases.
- Investigated current CI failure: `linux-jammy-py3.10-gcc11 / test (distributed, 1, 3, linux.2xlarge.amx)` fails in `test/distributed/tensor/test_dtensor_ops.py::TestMultiThreadedDTensorOpsCPU::test_dtensor_op_db_index_fill_cpu_float32` with `Unexpected success`; Dr. CI classifies it as an unrelated trunk flaky failure.
- Not run: targeted repo tests (`PYTHONPATH=. python3 test/dynamo/test_compile.py -k generate_kernel`, `PYTHONPATH=. python3 test/inductor/test_utils.py -k extract_triton_kernel_sources`, `PYTHONPATH=. python3 test/inductor/test_utils.py TestUtils.test_extract_triton_kernel_sources_cpp_wrapper`) because this container is missing Python dependencies (`typing_extensions`, `sympy`).
- Not run: local pyrefly via `.github/scripts/lintrunner.sh` because this container is missing `spin`.
- Not run: CPU build via `MAX_JOBS=2 USE_CUDA=0 python3 setup.py develop` because this container is missing `setuptools.command.bdist_wheel`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98 @mlazos

Drafted via Codex, published after manual review by @bobrenjc93