### PR TITLE
[ROCm] Normalize AMDSMI UUID matching

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5518,13 +5518,15 @@ print(value, end="")
         """
         cmd = "rocminfo | grep -o 'Uuid:.*GPU-.*' | sed 's/Uuid:.*GPU-//'"
         uuids = subprocess.check_output(cmd, shell=True, text=True).strip().split("\n")
-        uuids = [s.strip() for s in uuids]
+        uuids = [s.strip().lower() for s in uuids if s.strip()]
         raw_uuids = torch.cuda._raw_device_uuid_amdsmi()
+        self.assertIsNotNone(raw_uuids)
+        raw_uuids = [s.lower() for s in raw_uuids or []]
         for uuid in uuids:
-            matching = True
-            if not any(uuid in raw_id for raw_id in raw_uuids):
-                matching = False
-        self.assertEqual(True, matching)
+            self.assertTrue(
+                any(uuid in raw_id for raw_id in raw_uuids),
+                f"{uuid} not found in {raw_uuids}",
+            )
 
     @unittest.skipIf(not TEST_PYNVML, "pynvml/amdsmi is not available")
     @unittest.skipIf(not TEST_WITH_ROCM, "amdsmi specific test")

--- a/test/test_cuda_nvml_based_avail.py
+++ b/test/test_cuda_nvml_based_avail.py
@@ -149,6 +149,14 @@ class TestVisibleDeviceParses(TestCase):
             [],
         )
 
+    def test_rocm_uuid_resolver_is_case_insensitive(self):
+        from torch.cuda import _transform_uuid_to_ordinals
+
+        with patch.object(torch.version, "hip", "7.0"):
+            self.assertEqual(
+                _transform_uuid_to_ordinals(["GPU-ABCDEF"], ["abcdef"]), [0]
+            )
+
     def test_ordinal_parse_visible_devices(self):
         def _device_count_nvml(val):
             from torch.cuda import _device_count_nvml as _dc

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1008,7 +1008,7 @@ def _transform_uuid_to_ordinals(candidates: list[str], uuids: list[str]) -> list
         if torch.version.hip:
             candidate = candidate.replace(
                 "GPU-", "", 1
-            )  # Remove GPU-prefix to match amdsmi asic serial
+            ).lower()  # Remove GPU-prefix to match amdsmi asic serial
         idx = uuid_to_ordinal(candidate, uuids)
         # First invalid ordinal stops parsing
         if idx < 0:


### PR DESCRIPTION
Summary:
- Normalize ROCm UUID candidates before matching them against AMDSMI ASIC serials.
- Normalize `rocminfo` UUID output in `test_raw_amdsmi_device_uuids` and assert every UUID is found.
- Add regression coverage for uppercase ROCm `GPU-...` UUID candidates.

Root cause:
`_raw_device_uuid_amdsmi()` returns lower-case ASIC serials, while ROCm UUID text from `rocminfo` / `HIP_VISIBLE_DEVICES` can include uppercase hex characters. `_transform_uuid_to_ordinals()` removed the `GPU-` prefix on ROCm but then compared the candidate case-sensitively, so uppercase UUIDs were rejected even when they referred to a valid device.

The AMDSMI raw UUID test also only asserted the last UUID from `rocminfo`, because the `matching` flag was reset inside the loop and checked after the loop. This updates the test to check each discovered UUID independently.

Fixes #180123
Fixes #180227

Test Plan:
- `python -m py_compile torch/cuda/__init__.py test/test_cuda.py test/test_cuda_nvml_based_avail.py`
- `git diff --check`

I could not run the ROCm-focused runtime tests locally because this source checkout does not have the generated `torch/version.py` import target and the machine does not have a ROCm device attached.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang