### PR TITLE
Fix fbgemm check from #180679

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -722,7 +722,7 @@ at::QEngine Context::qEngine() const {
     qengine = at::kONEDNN;
 #endif
 
-#if defined(USE_FBGEMM) && defined(__x86_64__)
+#if defined(USE_FBGEMM) && (defined(__x86_64__) || defined(_M_X64))
     if (fbgemm::fbgemmSupportedCPU()) {
       /* X86 is enabled if and only if fbgemm is available.
        * It combines goodness of fbgemm and onednn by dispatching.
@@ -761,7 +761,7 @@ const std::vector<at::QEngine>& Context::supportedQEngines() {
     engines.push_back(at::kONEDNN);
 #endif
 
-#if defined(USE_FBGEMM) && defined(__x86_64__)
+#if defined(USE_FBGEMM) && (defined(__x86_64__) || defined(_M_X64))
     if (fbgemm::fbgemmSupportedCPU()) {
       engines.push_back(at::kX86);
       // The X86 qengine is available if and only if FBGEMM is available


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180958

#180679 gated FBGEMM quantized engine registration on defined(__x86_64__), which 
is a GCC/Clang-only macro. On Windows x86_64 (MSVC), the equivalent is _M_X64.
Without it, FBGEMM never registered on Windows, causing the model container test
to crash (signal 9). Fixed by changing the guard to defined(__x86_64__) || defined(_M_X64),
consistent with the pattern used elsewhere in the codebase.

(See D101610650)