### PR TITLE
Fix autograd bogus registration UTs for xpu

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -16135,11 +16135,11 @@ class TestAutogradMultipleDispatch(TestCase):
         grad = torch.randn(3, 3, device=device)
         out.backward(grad)
 
-        if "cuda" not in device:
+        if "cuda" not in device and "xpu" not in device:
             # bogus default gradient registered for Autograd is grad + 1
             self.assertEqual(t.grad, grad + 1)
         else:
-            # bogus gradient registered for AutogradCUDA is grad * 2
+            # bogus gradient registered for AutogradCUDA/AutogradXPU is grad * 2
             self.assertEqual(t.grad, grad * 2)
 
         # test registered AutogradNestedTensor formula
@@ -16212,7 +16212,7 @@ class TestAutogradMultipleDispatch(TestCase):
             err_msg = r"Trying to use forward AD with .* that does not support it"
             hint_msg = "Running forward AD for an OP that does not implement it should raise a NotImplementedError"
 
-            if "cuda" in device:
+            if "cuda" in device or "xpu" in device:
                 with self.assertRaisesRegex(NotImplementedError, err_msg, msg=hint_msg):
                     torch._test_autograd_multiple_dispatch(dual_input)
             else:
@@ -16235,8 +16235,8 @@ class TestAutogradMultipleDispatch(TestCase):
         self.assertEqual(t_view_copy, t_view)
         self.assertEqual(t.grad, t_ref.grad)
         # backward results are per-dispatch-key in derivatives.yaml
-        if "cuda" in device:
-            # gradient registered to AutogradCUDA is grad.reshape_as(self) + 1
+        if "cuda" in device or "xpu" in device:
+            # gradient registered to AutogradCUDA/AutogradXPU is grad.reshape_as(self) + 1
             self.assertEqual(t.grad, grad.reshape_as(t) + 1)
         else:
             # Default gradient registered is grad.reshape_as(self)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -3055,6 +3055,8 @@
       self: grad.mul(grad)
     AutogradCUDA:
       self: grad.expand_symint(self.sym_sizes()) * 2
+    AutogradXPU:
+      self: grad.expand_symint(self.sym_sizes()) * 2
 
 - name: _test_autograd_multiple_dispatch.ntonly(Tensor self, bool b) -> Tensor
   dispatch:
@@ -3066,6 +3068,8 @@
     Default:
       self: grad.reshape_as(self)
     AutogradCUDA:
+      self: grad.reshape_as(self) + 1
+    AutogradXPU:
       self: grad.reshape_as(self) + 1
 
 - name: _efficientzerotensor(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor


### PR DESCRIPTION
Fixes https://github.com/intel/torch-xpu-ops/issues/2914.

Once https://github.com/pytorch/pytorch/pull/169798 merges this PR can be merged and fix relevant test failures while aligning XPU behavior with CUDA. Adds bogus autograd registration for `_test_autograd_multiple_dispatch.fullcoverage` and `_test_autograd_multiple_dispatch_view` just like CUDA and relevant checks in UTs for XPU.