### PR TITLE
[inductor] Using is_gpu() instead of hardcoded "cuda" check

### DIFF
--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -49,6 +49,7 @@ from torch._inductor.utils import (
     InputType,
     output_node,
     set_tracing_context_output_strides,
+    is_gpu,
 )
 from torch.autograd.profiler import record_function
 from torch.utils._ordered_set import OrderedSet
@@ -245,8 +246,8 @@ def cudagraph_post_compile(
     else:
         BoxedBool.disable(cudagraphs)
         maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
-
-        if "cuda" in compiled_graph.device_types:
+        has_gpu_devices = any(is_gpu(device) for device in compiled_graph.device_types)
+        if has_gpu_devices:
             # prefer better disable_cudagraphs_reason bc stack trace
             # TODO: migrate all disable reasons to stack trace, refactor
             if compiled_graph.disabled_cudagraphs_reason:
@@ -528,7 +529,8 @@ class CompiledFxGraph(OutputCode):
         if cudagraphs:
             # check cudagraph disabling reasons from inductor lowering
             if self.disabled_cudagraphs_reason:
-                if "cuda" in self.device_types:
+                has_gpu_devices = any(is_gpu(device) for device in self.device_types)
+                if has_gpu_devices:
                     log_cudagraph_skip_and_bump_counter(
                         f"skipping cudagraphs due to {self.disabled_cudagraphs_reason}"
                     )
@@ -682,7 +684,8 @@ class CompiledFxGraph(OutputCode):
             # during a previous compilation we're loading from the cache.
             # If so, we need to disable it on this new process too.
             if self.disabled_cudagraphs_reason:
-                if "cuda" in self.device_types:
+                has_gpu_device = any(is_gpu(device) for device in self.device_types)
+                if has_gpu_device:
                     log_cudagraph_skip_and_bump_counter(
                         f"skipping cudagraphs due to {self.disabled_cudagraphs_reason}"
                     )

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -53,6 +53,7 @@ from torch._inductor.utils import (
     InputType,
     output_node,
     set_tracing_context_output_strides,
+    is_gpu,
 )
 from torch._opaque_base import OpaqueBase
 from torch.fx._graph_pickler import _node_metadata_key_filter_safe, _ops_filter_safe
@@ -277,8 +278,8 @@ def cudagraph_post_compile(
     else:
         BoxedBool.disable(cudagraphs)
         maybe_handle_backward_generation(compiled_graph, boxed_forward_device_index)
-
-        if "cuda" in compiled_graph.device_types:
+        has_gpu_devices = any(is_gpu(device) for device in compiled_graph.device_types)
+        if has_gpu_devices:
             # prefer better disable_cudagraphs_reason bc stack trace
             # TODO: migrate all disable reasons to stack trace, refactor
             if compiled_graph.disabled_cudagraphs_reason:
@@ -600,7 +601,8 @@ class CompiledFxGraph(OutputCode):
         if cudagraphs:
             # check cudagraph disabling reasons from inductor lowering
             if self.disabled_cudagraphs_reason:
-                if "cuda" in self.device_types:
+                has_gpu_devices = any(is_gpu(device) for device in self.device_types)
+                if has_gpu_devices:
                     log_cudagraph_skip_and_bump_counter(
                         f"skipping cudagraphs due to {self.disabled_cudagraphs_reason}"
                     )
@@ -827,7 +829,8 @@ class CompiledFxGraph(OutputCode):
             # during a previous compilation we're loading from the cache.
             # If so, we need to disable it on this new process too.
             if self.disabled_cudagraphs_reason:
-                if "cuda" in self.device_types:
+                has_gpu_device = any(is_gpu(device) for device in self.device_types)
+                if has_gpu_device:
                     log_cudagraph_skip_and_bump_counter(
                         f"skipping cudagraphs due to {self.disabled_cudagraphs_reason}"
                     )


### PR DESCRIPTION
Resolves: https://github.com/pytorch/pytorch/issues/180951

Issue:
- In the pytorch/torch/_inductor/output_code.py file, the logging of cudagraph skip reasons happens only when the device_types has "cuda".
- This check occurs in three locations in the file, that are fixed with this pr
- This hard coded "cuda" check is inconsistent with that of done in pytorch/torch/_inductor/scheduler.py

Fix:
- Wherever the hard coded "cuda" check is used, this pr replaces them with is_gpu() api, which also checks for other targets like {mps, xpu, mtia, cuda}

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo