### PR TITLE
[AOTInductor] Preserve CUDA error messages across C ABI boundary

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -4,15 +4,26 @@
 #include <torch/csrc/inductor/aoti_runtime/model_container.h>
 
 #include <iostream>
+#include <string>
 #include <vector>
+
+// Stores the last error message from a failed AOTI runtime call so that
+// callers on the other side of the C ABI boundary can retrieve it via
+// AOTInductorGetLastError(). Without this, exception messages (e.g.
+// "CUDA error: an illegal memory access was encountered") are lost when
+// CONVERT_EXCEPTION_TO_ERROR_CODE catches them and returns an error code.
+static thread_local std::string g_aoti_last_error;
 
 #define CONVERT_EXCEPTION_TO_ERROR_CODE(...)      \
   try {                                           \
+    g_aoti_last_error.clear();                    \
     __VA_ARGS__                                   \
   } catch (const std::exception& e) {             \
+    g_aoti_last_error = e.what();                 \
     std::cerr << "Error: " << e.what() << '\n';   \
     return AOTI_RUNTIME_FAILURE;                  \
   } catch (...) {                                 \
+    g_aoti_last_error = "Unknown exception";      \
     std::cerr << "Unknown exception occurred.\n"; \
     return AOTI_RUNTIME_FAILURE;                  \
   }                                               \
@@ -484,5 +495,11 @@ AOTIRuntimeError AOTInductorModelUpdateConstantsFromBlob(
       {container->update_constants_from_blob(weight_blob_ptr); })
     }
 
+
+AOTIRuntimeError AOTInductorGetLastError(
+    const char** error_msg) {
+  *error_msg = g_aoti_last_error.c_str();
+  return AOTI_RUNTIME_SUCCESS;
+}
 
 } // extern "C"

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -311,6 +311,12 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
     const char** in_spec,
     const char** out_spec);
 
+// Retrieves the error message from the last failed AOTI runtime call on the
+// current thread. The returned pointer is valid until the next AOTI runtime
+// call on the same thread. Returns an empty string if the last call succeeded.
+AOTI_API AOTIRuntimeError AOTInductorGetLastError(
+    const char** error_msg);
+
 // ---------------------------------------------------------------------------
 // C-ABI-safe variant of AOTInductorModelRunMinimalArrayrefInterface.
 //

--- a/torch/csrc/inductor/aoti_torch/utils.h
+++ b/torch/csrc/inductor/aoti_torch/utils.h
@@ -11,13 +11,22 @@
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <optional>
 
+// Stores the last error from a failed AOTI torch shim call. Lives in the
+// host binary so rebuilding the predictor is sufficient (no model rebuild).
+inline std::string& aoti_torch_last_error() {
+  static thread_local std::string last_error;
+  return last_error;
+}
+
 #define AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE(...)    \
   try {                                                    \
     __VA_ARGS__                                            \
   } catch (const std::exception& e) {                      \
+    aoti_torch_last_error() = e.what();                    \
     LOG(ERROR) << "Exception in aoti_torch: " << e.what(); \
     return AOTI_TORCH_FAILURE;                             \
   } catch (...) {                                          \
+    aoti_torch_last_error() = "Unknown exception";         \
     LOG(ERROR) << "Exception in aoti_torch: UNKNOWN";      \
     return AOTI_TORCH_FAILURE;                             \
   }                                                        \


### PR DESCRIPTION
Summary:
When a CUDA error (e.g. illegal memory access) occurs inside an
AOTInductor-compiled model, the exception is caught by
CONVERT_EXCEPTION_TO_ERROR_CODE at the C ABI boundary and converted to
an error code. The original exception message is printed to stderr but
discarded. The caller (AOTInductorModelImpl) then throws a new exception
with only the input spec, losing the "CUDA error" text entirely.

This causes the sigrid predictor's sticky GPU error detection
(checkStickyGPUError) to fail — it searches for "CUDA error" in the
exception message but never finds it. The predictor stays alive as a
zombie, accepting and failing requests indefinitely instead of crashing
cleanly.

Fix: Store the exception message in a thread-local string inside the
.wrapper.so and expose it via a new AOTInductorGetLastError() C API.
The Sigmoid runtime retrieves it and includes the original error in the
rethrown exception.

Test Plan:
Manual repro: send a request that triggers cudaErrorIllegalAddress,
verify the predictor now self-terminates via checkStickyGPUError within
the 2-minute upload timeout.

Oncall Short Name: sensa_temp

Differential Revision: D101443735




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo