### PR TITLE
[docs] Force serial writes in Sphinx build to match reads (#180177 follow-up) 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2437,11 +2437,12 @@ def setup(app):
     app.connect("html-page-context", hide_edit_button_for_pages)
     app.config.add_last_updated = True
 
-    # Force serial reads to avoid pipe congestion from large env pickles.
-    # Sphinx's parallel read sends the entire environment (100s of MB for
-    # PyTorch) through a 64KB OS pipe per worker, which causes extreme
-    # slowdowns with many workers. Serial reads avoid this overhead while
-    # parallel writes (which send trivial payloads) remain enabled.
+    # Force serial reads and writes to avoid pipe congestion. Sphinx's
+    # parallel phases ship serialized state (env on read, doctrees on write)
+    # through 64KB OS pipes per worker. At PyTorch scale (100s of MB of env,
+    # ~2946 autodoc-heavy pages) the parent can only drain one pipe at a time
+    # while workers block on send, which deadlocks the build. Serial avoids
+    # the pipe entirely.
     from sphinx.builders import Builder
 
     _orig_read_serial = Builder._read_serial
@@ -2450,6 +2451,13 @@ def setup(app):
         return _orig_read_serial(self, docnames)
 
     Builder._read_parallel = _serial_read_ignoring_nproc
+
+    _orig_write_serial = Builder._write_serial
+
+    def _serial_write_ignoring_nproc(self, docnames, nproc=1):
+        return _orig_write_serial(self, docnames)
+
+    Builder._write_parallel = _serial_write_ignoring_nproc
 
     # Skip pickling doctrees to disk for the HTML builder. This is only used
     # for incremental rebuilds which don't apply in CI clean builds. Saves


### PR DESCRIPTION
## Summary

  Follow-up to #180177. That PR made Sphinx's parallel *read* phase
  serial because the parent was deadlocking on 64KB pipe buffers while
  workers shipped the 100s-of-MB autodoc environment back. It left
  parallel *writes* enabled on the assumption that write payloads were
  "trivial."

  The Apr 20 nightly proves that assumption wrong. After #178615
  expanded docs coverage to ~2946 pages, the write phase is serializing
  doctrees of comparable size and deadlocks the same way. The docs
  build hits 45-minute timeouts consistently since Apr 12 even with
  #180177 applied — including after #180509 bumped the timeout from
  30m to 45m.

  This PR applies the same monkey-patch pattern to `_write_parallel`.

  ## Evidence the hang is in writes, not reads

  From [nightly run #2200 logs][run]
  (commit `0951ec0`, Apr 20, `build-docs-python-true` job):

  01:41:43  reading sources... [  0%]     ← read phase begins
  01:43:22  reading sources... [100%]     ← read phase done (1m40s — fix #180177 works)
  01:43:25  copying extra files... done
  01:43:25  done                          ← last Sphinx output
  ...40 minutes of silence...
  02:23:47  ##[error] 'Build python docs' timed out after 45 minutes

  `grep -c 'writing output' run2200.log` returns `1`, and that one line
  is the `[mo]` (gettext) builder's no-op for 0 `.po` files. The
  `[html]` builder never prints `writing output...` at all — the write
  phase forks workers and hangs before any progress.

  No OOM, no tracebacks, no katex errors in the log. Classic pipe
  deadlock.

  ## Change

  `docs/source/conf.py`:

  ```python
  # before
  Builder._read_parallel = _serial_read_ignoring_nproc

  # after
  Builder._read_parallel = _serial_read_ignoring_nproc
  Builder._write_parallel = _serial_write_ignoring_nproc   # new                                                                        
   ```
  Same two-line wrapper pattern #180177 used for reads. Updated the                                                                     
  adjacent comment so it no longer asserts writes are safe.       
                                                                                                                                        
  ## Test plan                                                                                                                             
   
  - CI build-docs-python-true completes under 30 min on this PR                                                                         
  - After merge, revert #180509 (the 30→45m timeout bump) in a    
  follow-up — it was masking this bug and should return to 30m                                                                          
  once the fix lands                                                                                                                    
  - Manually reproduced locally: cd docs && make html with the                                                                          
  patch applied still produces identical HTML output, just without                                                                      
  parallel fork contention                                                                                                              
                                                                                                                                        
  ## Refs                                                                                                                                  
                                                                  
  - #180177 — original "Fix python docs build hanging in CI" (reads only)                                                               
  - #180509 — timeout bump 30m → 45m (workaround, should be reverted)
  - #178615 — coverage expansion that made the write-phase payload                                                                      
        large enough to trigger the deadlock 