### PR TITLE
[CI] Use portable jemalloc path lookup in build.sh

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -25,7 +25,10 @@ env
 
 if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
   # Use jemalloc during compilation to mitigate https://github.com/pytorch/pytorch/issues/116289
-  export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+  JEMALLOC_LIB=$(find /usr/lib* -name "libjemalloc.so.2" 2>/dev/null | head -1)
+  if [[ -n "${JEMALLOC_LIB}" ]]; then
+    export LD_PRELOAD="${JEMALLOC_LIB}"
+  fi
   echo "NVCC version:"
   nvcc --version
 fi


### PR DESCRIPTION
## Summary

The jemalloc `LD_PRELOAD` path in `build.sh` is hardcoded to `/usr/lib/x86_64-linux-gnu/libjemalloc.so.2` which is Ubuntu-specific. On RHEL/CentOS/Fedora, jemalloc is at `/usr/lib64/libjemalloc.so.2`. When the path doesn't exist, the `LD_PRELOAD` error message gets mixed into cmake's CUDA version detection, breaking the build:

```
FindCUDA says CUDA version is 12.8, but the CUDA headers say the version is
ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libjemalloc.so.2' from LD_PRELOAD
cannot be preloaded
```

Replaced with a dynamic `find` lookup that works on any distro. Tested on RHEL 9.6 (`/usr/lib64/libjemalloc.so.2`) — picks up the correct path. No behavior change on Ubuntu.

Fixes #180963