### PR TITLE
Fix addmm error on XPU when self tensor has more dimensions than result

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -85,6 +85,15 @@ Tensor& addmm_out(
       " but got:",
       self.sizes());
 
+  TORCH_CHECK(
+      result_shape.size() >= (size_t)self.dim(),
+      "The number of sizes provided (",
+      result_shape.size(),
+      ") ",
+      "must be greater or equal to the number of dimensions in the tensor (",
+      self.dim(),
+      ")");
+
   // Bypass OneDNN optimization path for float64 due to lack of full double
   // precision support.
   if (mat1.scalar_type() == at::kDouble) {

--- a/test/xpu/test_gemm.py
+++ b/test/xpu/test_gemm.py
@@ -946,6 +946,17 @@ class TestBasicGEMM(TestCase):
                         RuntimeError, f"{n}x{k + 1}.*{k}x{m}", lambda: torch.mm(m1, m2)
                     )
 
+    @dtypes(torch.float)
+    def test_addmm_expanded_errors(self, device, dtype):
+        mat1 = torch.randn(3, 3, device=device, dtype=dtype)
+        mat2 = torch.randn(3, 3, device=device, dtype=dtype)
+        self_ = torch.randn(3, 3, device=device, dtype=dtype)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "must be greater or equal to the number of dimensions",
+            lambda: torch.addmm(self_.unsqueeze(0), mat1, mat2),
+        )
+
     @precisionOverride(
         {
             torch.float: 1e-4,


### PR DESCRIPTION
This PR introduces an additional input validation check to the `addmm_out` implementation for XPU and adds a corresponding unit test to ensure that the function raises an appropriate error when the input tensor's dimensions are incompatible. The main goal is to improve error handling and test coverage for dimension mismatches.

**Input validation improvements:**

* [`aten/src/ATen/native/mkldnn/xpu/Blas.cpp`](diffhunk://#diff-9ae74b4a8990350760237cc09e715cc25a333f1d0655bd13cddb71c62cea2a39R88-R96): Added a `TORCH_CHECK` to ensure that the output tensor's number of dimensions is greater than or equal to the input tensor's number of dimensions, raising a clear error message if not and preventing oneDNN error "could not create a primitive descriptor for the matmul primitive".

**Test coverage:**

* [`test/xpu/test_gemm.py`](diffhunk://#diff-9fc5ebfdff6f3ed35c6ff19982103bbf92503ac16a52d00664a41c177271c83eR949-R959): Added a new test case `test_addmm_expanded_errors` to verify that `torch.addmm` raises a `RuntimeError` with the expected message when the input tensor has more dimensions than allowed.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01