### PR TITLE
Enable nested_compile_region for AOTInductor + tensor-subclass params

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -182,6 +182,7 @@ try:
         )
         from .test_control_flow import (
             CondModels,
+            InvokeSubgraphModels,
             prepend_counters,
             prepend_predicates,
             WhileLoopModels,
@@ -196,6 +197,7 @@ try:
         )
         from test_control_flow import (  # @manual=fbcode//caffe2/test/inductor:control_flow-library
             CondModels,
+            InvokeSubgraphModels,
             prepend_counters,
             prepend_predicates,
             WhileLoopModels,
@@ -2706,6 +2708,24 @@ class AOTInductorTestsTemplate:
                 Model().to(self.device),
                 example_inputs=example_inputs,
             )
+
+    def test_invoke_subgraph_simple(self):
+        inputs = (
+            torch.randn((10, 20), device=self.device),
+            torch.randn((10, 20), device=self.device),
+        )
+        self.check_model(InvokeSubgraphModels.Simple(), inputs)
+
+    def test_invoke_subgraph_multiple_outputs(self):
+        inputs = (
+            torch.randn((10, 20), device=self.device),
+            torch.randn((10, 20), device=self.device),
+        )
+        self.check_model(InvokeSubgraphModels.MultipleOutputs(), inputs)
+
+    def test_invoke_subgraph_stacked(self):
+        inputs = (torch.randn((10, 20), device=self.device),)
+        self.check_model(InvokeSubgraphModels.Stacked(num_blocks=3), inputs)
 
     def test_while_loop_simple(self):
         inputs = (

--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -187,6 +187,12 @@ CPU_TEST_FAILURES = {
     "test_while_loop_with_outer_code": fail_stack_allocation(is_skip=True),
     # TODO: error: cannot convert ArrayRefTensor<float> to AtenTensorHandle
     "test_while_loop_with_outer_buffers": fail_stack_allocation(is_skip=True),
+    # Same ArrayRefTensor vs RAIIAtenTensorHandle mismatch as while_loop:
+    # the subgraph's stack-allocated output can't be std::move-assigned into
+    # the outer RAIIAtenTensorHandle pre-declared in codegen_invoke_subgraph.
+    "test_invoke_subgraph_simple": fail_stack_allocation(is_skip=True),
+    "test_invoke_subgraph_multiple_outputs": fail_stack_allocation(is_skip=True),
+    "test_invoke_subgraph_stacked": fail_stack_allocation(is_skip=True),
     # TODO: use of undeclared identifier 'float8_e4m3fn' and 'half'
     "test_fp8": fail_minimal_arrayref_interface(is_skip=True),
     "test_size_from_multi_output": fail_stack_allocation(is_skip=True),

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -811,6 +811,55 @@ class CondTests(TestCase):
         )
 
 
+# nested_compile_region-decorated helpers must live at module scope, not
+# inside forward -- Dynamo refuses to trace into the decorator call itself
+# when it is applied on a local function each call.
+@torch.compiler.nested_compile_region
+def _invoke_subgraph_gn_simple(x, y):
+    return x * y + x - y
+
+
+@torch.compiler.nested_compile_region
+def _invoke_subgraph_gn_multi_out(x, y):
+    return x * y, x + y, x - y
+
+
+class InvokeSubgraphModels:
+    class Simple(torch.nn.Module):
+        """Minimal single-call nested_compile_region invocation."""
+
+        def forward(self, a, b):
+            return _invoke_subgraph_gn_simple(a, b)
+
+    class MultipleOutputs(torch.nn.Module):
+        """Subgraph returning a tuple of tensors -- exercises per-output
+        RAIIAtenTensorHandle declaration and std::move suffix in cpp wrapper."""
+
+        def forward(self, a, b):
+            return _invoke_subgraph_gn_multi_out(a, b)
+
+    class Stacked(torch.nn.Module):
+        """N identical Blocks whose forward is wrapped with nested_compile_region.
+        Analogous to a stack of transformer layers; exercises subgraph reuse
+        across multiple invoke_subgraph call sites."""
+
+        class Block(torch.nn.Module):
+            @torch.compiler.nested_compile_region
+            def forward(self, x):
+                return (x * x + x).sin()
+
+        def __init__(self, num_blocks=3):
+            super().__init__()
+            self.blocks = torch.nn.ModuleList(
+                [InvokeSubgraphModels.Stacked.Block() for _ in range(num_blocks)]
+            )
+
+        def forward(self, x):
+            for b in self.blocks:
+                x = b(x)
+            return x
+
+
 class WhileLoopModels:
     class Simple(torch.nn.Module):
         def forward(self, ci, a, b):

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -465,8 +465,9 @@ def get_tensor_storages(tensor: torch.Tensor) -> set[StorageWeakRef]:
     """
     Get storage references from a tensor.
 
-    Handles regular tensors. Raises NotImplementedError for sparse tensors
-    and traceable wrapper subclasses.
+    For traceable wrapper subclasses, unions the storages of all inner
+    tensors reachable via ``__tensor_flatten__``. Raises NotImplementedError
+    for sparse tensors.
 
     Args:
         tensor: The tensor to extract storages from
@@ -486,9 +487,9 @@ def get_tensor_storages(tensor: torch.Tensor) -> set[StorageWeakRef]:
         raise NotImplementedError("get_tensor_storages does not support sparse tensors")
 
     if is_traceable_wrapper_subclass(tensor):
-        raise NotImplementedError(
-            "get_tensor_storages does not support traceable wrapper subclasses"
-        )
+        attrs, _ = tensor.__tensor_flatten__()
+        for attr in attrs:
+            storages |= get_tensor_storages(getattr(tensor, attr))
     else:
         storages.add(StorageWeakRef(tensor._typed_storage()))
 

--- a/torch/_higher_order_ops/utils.py
+++ b/torch/_higher_order_ops/utils.py
@@ -435,7 +435,7 @@ def has_potential_input_alias_or_mutation(gm, inputs, pre_dispatch=False):
 
 
 def _collect_fake_inputs(inputs):
-    from torch._subclasses.fake_tensor import FakeTensor
+    from torch._subclasses.fake_tensor import FakeTensor, is_fake
 
     # Get the example values of the inputs.
     inputs_fake: list[FakeTensor | torch.Tensor | int] = []
@@ -454,14 +454,20 @@ def _collect_fake_inputs(inputs):
                             val
                         ) or torch._C._functorch.is_functionaltensor(val):
                             val = torch._C._functorch.get_unwrapped(val)
-                        if not isinstance(val, FakeTensor):
+                        # is_fake also accepts traceable wrapper subclasses
+                        # whose inner tensors are FakeTensors (e.g. torchao
+                        # quantized parameter subclasses).
+                        if not is_fake(val):
                             raise AssertionError(
                                 f"Expected FakeTensor after unwrapping, got {type(val)}"
                             )
                         inputs_fake.append(val)
                     else:
-                        # This is the standard case of a TensorVariable
-                        if not isinstance(val, FakeTensor):
+                        # This is the standard case of a TensorVariable.
+                        # is_fake also accepts traceable wrapper subclasses
+                        # whose inner tensors are FakeTensors (e.g. torchao
+                        # quantized parameter subclasses).
+                        if not is_fake(val):
                             raise AssertionError(
                                 f"Expected FakeTensor, got {type(val)}"
                             )

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2069,9 +2069,17 @@ class CppWrapperCpu(PythonWrapperCodegen):
             self.writeline(f"{outer_output} = {src};")
 
     def codegen_invoke_subgraph(self, invoke_subgraph):
-        raise NotImplementedError(
-            "codegen invoke_subgraph is not implemented for cpp wrapper"
-        )
+        outer_inputs = [buf.codegen_reference() for buf in invoke_subgraph.inputs]
+        outer_outputs = []
+        for out in invoke_subgraph.outputs:
+            # in ABI-compatible mode, ir.MultiOutput is not codegened,
+            # hence pre-declare output variables directly and separately
+            self.writeline(f"RAIIAtenTensorHandle {out.get_name()};")
+            outer_outputs.append(out.get_name())
+
+        self.writeline(EnterSubgraphLine(self, invoke_subgraph.subgraph.graph))
+        self.codegen_subgraph(invoke_subgraph.subgraph, outer_inputs, outer_outputs)
+        self.writeline(ExitSubgraphLine(self))
 
     def codegen_conditional(self, conditional):
         outer_inputs = [f"{buf.codegen_reference()}" for buf in conditional.operands]


### PR DESCRIPTION
Enable nested_compile_region for AOTInductor + widen tensor-subclass support

Three small, independent fixes that together make
torch.compiler.nested_compile_region work with AOTInductor and
incrementally widen the invoke_subgraph codepath's handling of
traceable wrapper tensor subclasses (e.g. the torchao-quantized Linear
weights emitted by quantized transformer models).

1. invoke_subgraph: accept tensor subclass params in _collect_fake_inputs

   torch/_higher_order_ops/utils.py::_collect_fake_inputs hard-asserts
   isinstance(val, FakeTensor) on every TensorVariable operand. This
   rejects traceable wrapper subclasses (e.g. Int4TilePackedTo4dTensor)
   even when their inner tensors are FakeTensors, because the outer
   subclass object is not itself a FakeTensor. The canonical check for
   this is torch._subclasses.fake_tensor.is_fake, which recurses through
   __tensor_flatten__ and handles FunctionalTensor / functorch wrappers
   too. Replace both isinstance(val, FakeTensor) checks with
   is_fake(val).

2. StorageAliasingTracker: support traceable wrapper subclasses

   torch/_dynamo/variables/higher_order_ops.py::get_tensor_storages
   raised NotImplementedError for any traceable wrapper subclass.
   Recurse through the subclass's __tensor_flatten__ inner tensors and
   union their storages instead. This is the second gate subclass params
   hit during invoke_subgraph subgraph speculation, immediately after
   _collect_fake_inputs.

   Both (1) and (2) are preparatory: full end-to-end subclass support
   via invoke_subgraph still needs HOP dispatch rules for subclasses
   and a few other pieces, tracked separately.

3. inductor/cpp_wrapper: implement codegen_invoke_subgraph

   CppWrapperCpu.codegen_invoke_subgraph was a hard NotImplementedError,
   so any AOTInductor compilation of a graph containing an
   invoke_subgraph HOP -- i.e. any torch.export graph from a model
   decorated with @nested_compile_region -- crashed in the cpp_wrapper
   path.

   The C++ wrapper already implements subgraph codegen for torch.cond
   via codegen_subgraph_prefix / codegen_subgraph / codegen_subgraph_suffix.
   Reuse that machinery: for each invoke_subgraph output pre-declare a
   RAIIAtenTensorHandle by name (MultiOutput is a no-op in
   ABI-compatible mode), emit EnterSubgraphLine / ExitSubgraphLine
   markers, and call codegen_subgraph with the operand references as
   outer_inputs. This mirrors codegen_conditional minus the predicate
   branching, since invoke_subgraph has a single unconditional body.

   This is the inlining-based strategy the C++ wrapper uses today;
   lifting subgraphs as reusable C++ functions (as the Python wrapper's
   codegen_subgraph does) remains a separate follow-up noted in the
   existing codegen_subgraph TODO.

Tests

  InvokeSubgraphModels in test_control_flow.py mirrors CondModels with
  Simple / MultipleOutputs / Stacked variants, using module-scope
  nested_compile_region-decorated helpers (Dynamo refuses to trace a
  decorator applied on a per-call local function). Paired
  test_invoke_subgraph_{simple,multiple_outputs,stacked} tests in
  AOTInductorTestsTemplate run through check_model / AOTIRunnerUtil,
  exercising the new cpp_wrapper codegen path. The Stacked variant
  covers multi-call subgraph reuse -- the transformer-layer use case
  that motivates nested_compile_region.

  Validated locally: all three AOTInductorTestABICompatibleCpu cases
  (simple / multiple_outputs / stacked) pass with AOTIRunnerUtil end-to-
  end on CPU.

Motivating downstream use case: enables the ExecuTorch CUDA backend to
lower transformer models that stack N structurally identical Block
modules (e.g. Qwen 3.5 MoE, 40 layers) with @nested_compile_region on
the block's forward. Block-level dedup cuts Inductor's in-memory FX
graph during lowering and reduces wrapper codegen to one inlined body
reused across layers.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98