### PR TITLE
[MPS] Fix sliced channels_last tensors handling

### DIFF
--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -471,9 +471,14 @@ inline bool mps_conv_use_channels_last(const at::Tensor& input, const at::Tensor
     return false;
   }
 
+  // A tensor whose strides merely *look* like channels-last (e.g. a
+  // channel-slice of a channels-last tensor) is not necessarily contiguous in
+  // that layout; the MPS backend reads raw buffers assuming packed NHWC data,
+  // so require actual channels-last contiguity here.
+  // See https://github.com/pytorch/pytorch/issues/180984
   auto is_channel_last = [](const at::Tensor& t) {
-    auto fmt = t.suggest_memory_format();
-    return fmt == at::MemoryFormat::ChannelsLast || fmt == at::MemoryFormat::ChannelsLast3d;
+    return t.is_contiguous(at::MemoryFormat::ChannelsLast) ||
+           t.is_contiguous(at::MemoryFormat::ChannelsLast3d);
   };
   return is_channel_last(input) || is_channel_last(weight);
 }

--- a/aten/src/ATen/native/ConvUtils.h
+++ b/aten/src/ATen/native/ConvUtils.h
@@ -471,14 +471,15 @@ inline bool mps_conv_use_channels_last(const at::Tensor& input, const at::Tensor
     return false;
   }
 
-  // A tensor whose strides merely *look* like channels-last (e.g. a
-  // channel-slice of a channels-last tensor) is not necessarily contiguous in
-  // that layout; the MPS backend reads raw buffers assuming packed NHWC data,
-  // so require actual channels-last contiguity here.
+  // Use exact-match so a tensor whose strides merely *look* like channels-last
+  // (e.g. a channel-slice of a channels-last tensor) is not misclassified --
+  // MPS reads raw buffers assuming packed NHWC, which would be incorrect for
+  // such views. exact_match also correctly excludes degenerate 1x1 weights
+  // whose NCHW-contiguous strides happen to also satisfy is_contiguous(CL).
   // See https://github.com/pytorch/pytorch/issues/180984
   auto is_channel_last = [](const at::Tensor& t) {
-    return t.is_contiguous(at::MemoryFormat::ChannelsLast) ||
-           t.is_contiguous(at::MemoryFormat::ChannelsLast3d);
+    auto fmt = t.suggest_memory_format(/*channels_last_strides_exact_match=*/true);
+    return fmt == at::MemoryFormat::ChannelsLast || fmt == at::MemoryFormat::ChannelsLast3d;
   };
   return is_channel_last(input) || is_channel_last(weight);
 }

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -114,15 +114,11 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
   const bool is_macos_15_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
 
   const bool is3DConv = input_t.dim() == 5;
-  // Use exact-match check for channels-last strides: a tensor with
-  // channels-last-like stride pattern but whose strides do not exactly equal
-  // the canonical channels-last strides (e.g. a channel-slice of a CL tensor)
-  // is NOT packed NHWC in memory, so the raw-buffer NHWC path would misread it.
-  // See https://github.com/pytorch/pytorch/issues/180984
-  const auto input_suggested_layout =
-      input_t.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == kChannelsLast && is_macos_15_plus
-      ? kChannelsLast
-      : kContiguous;
+  // Use exact-match: a channel-slice of a channels-last tensor has CL-like
+  // strides but is not NHWC-packed, so the raw-buffer NHWC path would misread
+  // it. See https://github.com/pytorch/pytorch/issues/180984
+  const auto memory_format = input_t.suggest_memory_format(/*channels_last_strides_exact_match=*/true);
+  const auto input_suggested_layout = memory_format == kChannelsLast && is_macos_15_plus ? kChannelsLast : kContiguous;
   const bool is_channels_last = mps_conv_use_channels_last(input_t, weight_t) && !is3DConv;
   const bool bias_defined = bias_opt ? bias_opt->defined() : false;
 

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -114,8 +114,13 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
   const bool is_macos_15_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
 
   const bool is3DConv = input_t.dim() == 5;
-  const auto memory_format = input_t.suggest_memory_format();
-  const auto input_suggested_layout = memory_format == kChannelsLast && is_macos_15_plus ? kChannelsLast : kContiguous;
+  // getMPSNDArray reads the raw MTLBuffer as packed NHWC when using the
+  // channels-last path, so we must ensure the input is actually contiguous in
+  // that layout -- a channel-slice of a channels-last tensor has
+  // channels-last-like strides but is not packed.
+  // See https://github.com/pytorch/pytorch/issues/180984
+  const auto input_suggested_layout =
+      input_t.is_contiguous(kChannelsLast) && is_macos_15_plus ? kChannelsLast : kContiguous;
   const bool is_channels_last = mps_conv_use_channels_last(input_t, weight_t) && !is3DConv;
   const bool bias_defined = bias_opt ? bias_opt->defined() : false;
 

--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -114,13 +114,15 @@ static Tensor _mps_convolution_impl(const Tensor& input_t,
   const bool is_macos_15_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
 
   const bool is3DConv = input_t.dim() == 5;
-  // getMPSNDArray reads the raw MTLBuffer as packed NHWC when using the
-  // channels-last path, so we must ensure the input is actually contiguous in
-  // that layout -- a channel-slice of a channels-last tensor has
-  // channels-last-like strides but is not packed.
+  // Use exact-match check for channels-last strides: a tensor with
+  // channels-last-like stride pattern but whose strides do not exactly equal
+  // the canonical channels-last strides (e.g. a channel-slice of a CL tensor)
+  // is NOT packed NHWC in memory, so the raw-buffer NHWC path would misread it.
   // See https://github.com/pytorch/pytorch/issues/180984
   const auto input_suggested_layout =
-      input_t.is_contiguous(kChannelsLast) && is_macos_15_plus ? kChannelsLast : kContiguous;
+      input_t.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == kChannelsLast && is_macos_15_plus
+      ? kChannelsLast
+      : kContiguous;
   const bool is_channels_last = mps_conv_use_channels_last(input_t, weight_t) && !is3DConv;
   const bool bias_defined = bias_opt ? bias_opt->defined() : false;
 

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -124,14 +124,10 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
   const bool has_weight = (weight_opt.has_value() && weight_opt->defined());
   const bool has_bias = (bias_opt.has_value() && bias_opt->defined());
 
-  // Use exact-match channels-last strides so a tensor with channels-last-like
-  // strides but non-packed storage is not treated as CL (would be read as
-  // packed NHWC via the skipped gather path).
+  // Use exact-match: a channel-slice of a channels-last tensor has CL-like
+  // strides but is not NHWC-packed.
   // See https://github.com/pytorch/pytorch/issues/180984
-  auto memory_format =
-      self.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == MemoryFormat::ChannelsLast
-      ? MemoryFormat::ChannelsLast
-      : MemoryFormat::Contiguous;
+  auto memory_format = self.suggest_memory_format(/*channels_last_strides_exact_match=*/true);
 
   if (output.numel() == 0) {
     return std::tuple<Tensor&, Tensor&, Tensor&>(output, save_mean, save_var);
@@ -400,13 +396,8 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_mps(const Tensor& self,
                                                   bool train,
                                                   double momentum,
                                                   double epsilon) {
-  // Match the layout we will actually use inside batch_norm_mps_out so that
-  // the allocated output is consistent with the kernel path.
   // See https://github.com/pytorch/pytorch/issues/180984
-  const auto memory_format =
-      self.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == MemoryFormat::ChannelsLast
-      ? MemoryFormat::ChannelsLast
-      : MemoryFormat::Contiguous;
+  const auto memory_format = self.suggest_memory_format(/*channels_last_strides_exact_match=*/true);
 
   auto output = at::empty(self.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, memory_format);
 
@@ -559,10 +550,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
   Tensor grad_bias;
 
   // See https://github.com/pytorch/pytorch/issues/180984
-  const auto memory_format =
-      input.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == MemoryFormat::ChannelsLast
-      ? MemoryFormat::ChannelsLast
-      : MemoryFormat::Contiguous;
+  const auto memory_format = input.suggest_memory_format(/*channels_last_strides_exact_match=*/true);
 
   if (grad_input_mask[0]) {
     grad_input = at::empty(input.sizes(), input.scalar_type(), std::nullopt, kMPS, std::nullopt, memory_format);

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -124,7 +124,12 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
   const bool has_weight = (weight_opt.has_value() && weight_opt->defined());
   const bool has_bias = (bias_opt.has_value() && bias_opt->defined());
 
-  auto memory_format = self.suggest_memory_format();
+  // Use actual channels-last contiguity: a tensor with channels-last-like
+  // strides but non-packed storage would otherwise be read as packed NHWC via
+  // the skipped gather path, yielding wrong results.
+  // See https://github.com/pytorch/pytorch/issues/180984
+  auto memory_format =
+      self.is_contiguous(MemoryFormat::ChannelsLast) ? MemoryFormat::ChannelsLast : MemoryFormat::Contiguous;
 
   if (output.numel() == 0) {
     return std::tuple<Tensor&, Tensor&, Tensor&>(output, save_mean, save_var);
@@ -393,7 +398,11 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_mps(const Tensor& self,
                                                   bool train,
                                                   double momentum,
                                                   double epsilon) {
-  const auto memory_format = self.suggest_memory_format();
+  // Match the layout we will actually use inside batch_norm_mps_out so that
+  // the allocated output is consistent with the kernel path.
+  // See https://github.com/pytorch/pytorch/issues/180984
+  const auto memory_format =
+      self.is_contiguous(MemoryFormat::ChannelsLast) ? MemoryFormat::ChannelsLast : MemoryFormat::Contiguous;
 
   auto output = at::empty(self.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, memory_format);
 
@@ -545,7 +554,10 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
   Tensor grad_weight;
   Tensor grad_bias;
 
-  const auto memory_format = input.suggest_memory_format();
+  // Use actual channels-last contiguity -- see
+  // https://github.com/pytorch/pytorch/issues/180984
+  const auto memory_format =
+      input.is_contiguous(MemoryFormat::ChannelsLast) ? MemoryFormat::ChannelsLast : MemoryFormat::Contiguous;
 
   if (grad_input_mask[0]) {
     grad_input = at::empty(input.sizes(), input.scalar_type(), std::nullopt, kMPS, std::nullopt, memory_format);

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -124,12 +124,14 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
   const bool has_weight = (weight_opt.has_value() && weight_opt->defined());
   const bool has_bias = (bias_opt.has_value() && bias_opt->defined());
 
-  // Use actual channels-last contiguity: a tensor with channels-last-like
-  // strides but non-packed storage would otherwise be read as packed NHWC via
-  // the skipped gather path, yielding wrong results.
+  // Use exact-match channels-last strides so a tensor with channels-last-like
+  // strides but non-packed storage is not treated as CL (would be read as
+  // packed NHWC via the skipped gather path).
   // See https://github.com/pytorch/pytorch/issues/180984
   auto memory_format =
-      self.is_contiguous(MemoryFormat::ChannelsLast) ? MemoryFormat::ChannelsLast : MemoryFormat::Contiguous;
+      self.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == MemoryFormat::ChannelsLast
+      ? MemoryFormat::ChannelsLast
+      : MemoryFormat::Contiguous;
 
   if (output.numel() == 0) {
     return std::tuple<Tensor&, Tensor&, Tensor&>(output, save_mean, save_var);
@@ -402,7 +404,9 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_mps(const Tensor& self,
   // the allocated output is consistent with the kernel path.
   // See https://github.com/pytorch/pytorch/issues/180984
   const auto memory_format =
-      self.is_contiguous(MemoryFormat::ChannelsLast) ? MemoryFormat::ChannelsLast : MemoryFormat::Contiguous;
+      self.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == MemoryFormat::ChannelsLast
+      ? MemoryFormat::ChannelsLast
+      : MemoryFormat::Contiguous;
 
   auto output = at::empty(self.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, memory_format);
 
@@ -554,10 +558,11 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
   Tensor grad_weight;
   Tensor grad_bias;
 
-  // Use actual channels-last contiguity -- see
-  // https://github.com/pytorch/pytorch/issues/180984
+  // See https://github.com/pytorch/pytorch/issues/180984
   const auto memory_format =
-      input.is_contiguous(MemoryFormat::ChannelsLast) ? MemoryFormat::ChannelsLast : MemoryFormat::Contiguous;
+      input.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == MemoryFormat::ChannelsLast
+      ? MemoryFormat::ChannelsLast
+      : MemoryFormat::Contiguous;
 
   if (grad_input_mask[0]) {
     grad_input = at::empty(input.sizes(), input.scalar_type(), std::nullopt, kMPS, std::nullopt, memory_format);

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -69,16 +69,10 @@ static void pool2d_template(const Tensor& input,
   const bool is_backward_pass = grad_output.defined();
   const bool has_indices = indices.defined();
   const bool has_divisor = divisor_override.has_value() && divisor_override.value() != 0;
-  // Use exact-match channels-last strides so a tensor with channels-last-like
-  // strides but non-packed storage (e.g. a channel slice of a channels_last
-  // tensor) is not treated as CL -- MPS would otherwise read it as packed
-  // NHWC. exact_match also preserves the pre-existing behavior for degenerate
-  // N-C-1-1 tensors whose strides happen to also satisfy is_contiguous(CL).
-  // See https://github.com/pytorch/pytorch/issues/180984
-  const auto suggested_memory_format =
-      input.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == MemoryFormat::ChannelsLast
-      ? MemoryFormat::ChannelsLast
-      : MemoryFormat::Contiguous;
+  // Use exact-match: a channel-slice of a channels-last tensor has CL-like
+  // strides but is not NHWC-packed, so the raw-buffer NHWC path would misread
+  // it. See https://github.com/pytorch/pytorch/issues/180984
+  const auto suggested_memory_format = input.suggest_memory_format(/*channels_last_strides_exact_match=*/true);
   // for max_pool2d_with_indices() we cannot pass ChannelsLast (i.e., NHWC) to 'desc.dataLayout' in MPSGraph.
   // Because the returned indices will be selected based on NHWC memory layout which will
   // be incompatible with the PyTorch's global NCHW layout.

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -69,7 +69,12 @@ static void pool2d_template(const Tensor& input,
   const bool is_backward_pass = grad_output.defined();
   const bool has_indices = indices.defined();
   const bool has_divisor = divisor_override.has_value() && divisor_override.value() != 0;
-  const auto suggested_memory_format = input.suggest_memory_format();
+  // Use actual channels-last contiguity here: a tensor with channels-last-like
+  // strides but non-packed storage (e.g. a channel slice of a channels_last
+  // tensor) would otherwise be read as packed NHWC below, yielding wrong
+  // results. See https://github.com/pytorch/pytorch/issues/180984
+  const auto suggested_memory_format =
+      input.is_contiguous(MemoryFormat::ChannelsLast) ? MemoryFormat::ChannelsLast : MemoryFormat::Contiguous;
   // for max_pool2d_with_indices() we cannot pass ChannelsLast (i.e., NHWC) to 'desc.dataLayout' in MPSGraph.
   // Because the returned indices will be selected based on NHWC memory layout which will
   // be incompatible with the PyTorch's global NCHW layout.

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -69,12 +69,16 @@ static void pool2d_template(const Tensor& input,
   const bool is_backward_pass = grad_output.defined();
   const bool has_indices = indices.defined();
   const bool has_divisor = divisor_override.has_value() && divisor_override.value() != 0;
-  // Use actual channels-last contiguity here: a tensor with channels-last-like
+  // Use exact-match channels-last strides so a tensor with channels-last-like
   // strides but non-packed storage (e.g. a channel slice of a channels_last
-  // tensor) would otherwise be read as packed NHWC below, yielding wrong
-  // results. See https://github.com/pytorch/pytorch/issues/180984
+  // tensor) is not treated as CL -- MPS would otherwise read it as packed
+  // NHWC. exact_match also preserves the pre-existing behavior for degenerate
+  // N-C-1-1 tensors whose strides happen to also satisfy is_contiguous(CL).
+  // See https://github.com/pytorch/pytorch/issues/180984
   const auto suggested_memory_format =
-      input.is_contiguous(MemoryFormat::ChannelsLast) ? MemoryFormat::ChannelsLast : MemoryFormat::Contiguous;
+      input.suggest_memory_format(/*channels_last_strides_exact_match=*/true) == MemoryFormat::ChannelsLast
+      ? MemoryFormat::ChannelsLast
+      : MemoryFormat::Contiguous;
   // for max_pool2d_with_indices() we cannot pass ChannelsLast (i.e., NHWC) to 'desc.dataLayout' in MPSGraph.
   // Because the returned indices will be selected based on NHWC memory layout which will
   // be incompatible with the PyTorch's global NCHW layout.

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9354,15 +9354,24 @@ class TestNNMPS(NNTestCase):
         # This used to crash with MPSNDArrayConvolutionA14.mm:4352: failed assertion
         y2.sum().backward()
 
-    def test_conv2d_channels_last_channel_slice(self):
+    def test_channels_last_channel_slice(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/180984
         # A channel-slice view of a channels_last tensor has channels-last-like
-        # strides but is not packed NHWC in memory.
-        shared = torch.randn(1, 2, 1, 2, device="mps").contiguous(memory_format=torch.channels_last)
-        weight = torch.randn(1, 1, 1, 1, device="mps")
-        mps_out = F.conv2d(shared[:, :1], weight)
-        cpu_out = F.conv2d(shared[:, :1].cpu(), weight.cpu())
-        self.assertEqual(cpu_out, mps_out.cpu())
+        # strides but is not packed NHWC in memory. MPSGraph ops that support NHWC
+        # are only work with packed NHWC buffer, giving wrong results.
+        shared = torch.randn(2, 4, 8, 8, device="mps").contiguous(memory_format=torch.channels_last)
+        mps_slice = shared[:, :2]
+
+        weight = torch.randn(3, 2, 3, 3, device="mps")
+        self.assertEqual(F.conv2d(mps_slice.cpu(), weight.cpu()), F.conv2d(mps_slice, weight).cpu())
+
+        self.assertEqual(F.avg_pool2d(mps_slice.cpu(), 2), F.avg_pool2d(mps_slice, 2).cpu())
+        self.assertEqual(F.adaptive_avg_pool2d(mps_slice.cpu(), 2), F.adaptive_avg_pool2d(mps_slice, 2).cpu())
+
+        bn = nn.BatchNorm2d(2).eval()
+        bn_mps = nn.BatchNorm2d(2).to("mps").eval()
+        bn_mps.load_state_dict(bn.state_dict())
+        self.assertEqual(bn(mps_slice.cpu()), bn_mps(mps_slice).cpu())
 
     # Regression test for https://github.com/pytorch/pytorch/issues/141471
     def test_conv3d_channels_last_3d(self):

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9354,6 +9354,16 @@ class TestNNMPS(NNTestCase):
         # This used to crash with MPSNDArrayConvolutionA14.mm:4352: failed assertion
         y2.sum().backward()
 
+    def test_conv2d_channels_last_channel_slice(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/180984
+        # A channel-slice view of a channels_last tensor has channels-last-like
+        # strides but is not packed NHWC in memory.
+        shared = torch.randn(1, 2, 1, 2, device="mps").contiguous(memory_format=torch.channels_last)
+        weight = torch.randn(1, 1, 1, 1, device="mps")
+        mps_out = F.conv2d(shared[:, :1], weight)
+        cpu_out = F.conv2d(shared[:, :1].cpu(), weight.cpu())
+        self.assertEqual(cpu_out, mps_out.cpu())
+
     # Regression test for https://github.com/pytorch/pytorch/issues/141471
     def test_conv3d_channels_last_3d(self):
         m_cpu = nn.Conv3d(16, 33, (3, 5, 2), stride=(2, 1, 1), padding=(4, 2, 0), device="cpu")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #180992

By calling `Tensor::suggest_memory_format(/*channels_last_strides_exact_match=*/true)`, that not only checks that slices look like channels last, but also that they are contiguously channels last


Fixed incorrect channels last slicing handling in `conv2d`, `batch_norm` and `[adaptive_]avg_pool2d`

Fixes https://github.com/pytorch/pytorch/issues/180984