### PR TITLE
Couple naming updates

### DIFF
--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -198,7 +198,7 @@ typename List<T>::internal_const_reference_type List<T>::operator[](size_type po
 template<class T>
 typename List<T>::internal_reference_type List<T>::operator[](size_type pos) {
   static_cast<void>(impl_->list.at(pos)); // Throw the exception if it is out of range.
-  return {impl_->list.begin() + static_cast<typename decltype(impl_->list)::difference_type>(pos)};
+  return {impl_->list.begin() + static_cast<typename c10::detail::ListImpl::list_type::difference_type>(pos)};
 }
 
 template<class T>

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1941,7 +1941,7 @@ Tuple generic_to_tuple_impl(
     const ivalue::TupleElements& t,
     std::index_sequence<INDEX...> /*unused*/) {
   return std::make_tuple(
-      t[INDEX].to<std::tuple_element_t<INDEX, Tuple>>()...);
+      t[INDEX].template to<std::tuple_element_t<INDEX, Tuple>>()...);
 }
 } // namespace detail
 


### PR DESCRIPTION
The template keyword in ivalue_inl.h is technically required for a correct parse; better to fix it now, before compilers start getting strict about it.

The 'List' commit is just a consistency with surrounding code change.