### PR TITLE
[cuDNN][SDPA] Simplify SM / compute-capability check for CUDA > 13

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -88,7 +88,11 @@ bool check_prefer_cudnn_attention() {
     auto dprops = at::cuda::getCurrentDeviceProperties();
     auto major = dprops->major;
     auto minor = dprops->minor;
+#if defined(CUDA_VERSION) && (CUDA_VERSION < 13000)
     return cudnn_version > 91500 && (major == 9 || major == 10) && (!minor || minor == 3);
+#else
+    return cudnn_version > 91500 && (major == 9 || major == 10);
+#endif
   } catch ([[maybe_unused]] c10::Error const& e) {
 #ifdef DEBUG
     TORCH_WARN("check_prefer_cudnn_attention() caught exception ", e.what());

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -87,8 +87,8 @@ bool check_prefer_cudnn_attention() {
   try {
     auto dprops = at::cuda::getCurrentDeviceProperties();
     auto major = dprops->major;
-    auto minor = dprops->minor;
 #if defined(CUDA_VERSION) && (CUDA_VERSION < 13000)
+    auto minor = dprops->minor;
     return cudnn_version > 91500 && (major == 9 || major == 10) && (!minor || minor == 3);
 #else
     return cudnn_version > 91500 && (major == 9 || major == 10);


### PR DESCRIPTION
Previously we only had the `!minor` check pre SM 10.1 -> 11.0 rename. Can be dropped once CUDA 12.9 wheels are gone (10.1 doesn't exist on 12.6).

cc @csarofeen @ptrblck @nWEIdia