### PR TITLE
Support functools.partial mask_mod serialization

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -1597,8 +1597,24 @@ def forward(self, arg0_1):
             document_ids=document_ids,
         )
 
-        self.assertEqual(wrap(partial_a), wrap(partial_b))
-        self.assertEqual(wrap(recursive_partial_a), wrap(recursive_partial_b))
+        wrapped_partial_a = wrap(partial_a)
+        wrapped_partial_b = wrap(partial_b)
+        wrapped_recursive_partial_a = wrap(recursive_partial_a)
+        wrapped_recursive_partial_b = wrap(recursive_partial_b)
+
+        self.assertEqual(wrapped_partial_a, wrapped_partial_b)
+        self.assertEqual(hash(wrapped_partial_a), hash(wrapped_partial_b))
+        self.assertEqual(wrapped_recursive_partial_a, wrapped_recursive_partial_b)
+        self.assertEqual(
+            hash(wrapped_recursive_partial_a), hash(wrapped_recursive_partial_b)
+        )
+        with self.assertRaisesRegex(RuntimeError, "stripped callable is not callable"):
+            wrapped_partial_a(
+                torch.tensor(0),
+                torch.tensor(0),
+                torch.tensor(0),
+                torch.tensor(0),
+            )
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_blockmask_and_masks_closure_extraction(self):

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -2,6 +2,7 @@
 # flake8: noqa
 import contextlib
 import copy
+import functools
 import types
 import unittest
 import warnings
@@ -1488,12 +1489,123 @@ def forward(self, arg0_1):
         _, spec_c = pytree.tree_flatten(mask_c)
         self.assertNotEqual(spec_a, spec_c)
 
+    def _assert_blockmask_partial_replays_bound_tensors(self, make_mask_mod):
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch.nn.attention.flex_attention import BlockMask, create_block_mask
+
+        query_indices = torch.arange(8, dtype=torch.int32)[:, None]
+        key_indices = torch.arange(8, dtype=torch.int32)[None, :]
+        document_ids = torch.zeros(8, dtype=torch.int64)
+        batch0_attn_regions = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1], dtype=torch.int32)
+        batch1_attn_regions = torch.tensor([0, 0, 1, 1, 0, 0, 1, 1], dtype=torch.int32)
+
+        def mask_rule(batch, head, query_idx, key_idx, attn_regions, document_ids):
+            return (
+                (query_idx >= key_idx)
+                & (attn_regions[query_idx] == attn_regions[key_idx])
+                & (document_ids[query_idx] == document_ids[key_idx])
+            )
+
+        def build_block_mask(attn_regions):
+            return create_block_mask(
+                make_mask_mod(mask_rule, attn_regions, document_ids),
+                B=1,
+                H=1,
+                Q_LEN=8,
+                KV_LEN=8,
+                device="cpu",
+                BLOCK_SIZE=4,
+            )
+
+        def trace_mask_mod(attn_regions):
+            block_mask = build_block_mask(attn_regions)
+            flat_leaves, spec = block_mask._flatten()
+            return make_fx(
+                lambda *flat_leaves: BlockMask._unflatten(flat_leaves, spec).mask_mod(
+                    0, 0, query_indices, key_indices
+                )
+            )(*flat_leaves)
+
+        traced_mask_mod = trace_mask_mod(batch0_attn_regions)
+        replayed_batch1 = traced_mask_mod(
+            *build_block_mask(batch1_attn_regions)._flatten()[0]
+        )
+        expected_batch0 = build_block_mask(batch0_attn_regions).mask_mod(
+            0, 0, query_indices, key_indices
+        )
+        expected_batch1 = build_block_mask(batch1_attn_regions).mask_mod(
+            0, 0, query_indices, key_indices
+        )
+
+        self.assertFalse(torch.equal(replayed_batch1, expected_batch0))
+        self.assertTrue(torch.equal(replayed_batch1, expected_batch1))
+
+    def test_blockmask_partial_extraction_replays_bound_tensors(self):
+        self._assert_blockmask_partial_replays_bound_tensors(
+            lambda mask_rule, attn_regions, document_ids: functools.partial(
+                mask_rule,
+                attn_regions=attn_regions,
+                document_ids=document_ids,
+            )
+        )
+
+    def test_blockmask_recursive_partial_extraction_replays_bound_tensors(self):
+        self._assert_blockmask_partial_replays_bound_tensors(
+            lambda mask_rule, attn_regions, document_ids: functools.partial(
+                functools.partial(mask_rule, attn_regions=attn_regions),
+                document_ids=document_ids,
+            )
+        )
+
+    def test_mask_mod_wrapper_eq_for_partials(self):
+        from torch.nn.attention.flex_attention import (
+            _extract_callable_pytree,
+            _MaskModWrapper,
+        )
+
+        def mask_rule(batch, head, query_idx, key_idx, attn_regions, document_ids):
+            return (
+                (query_idx >= key_idx)
+                & (attn_regions[query_idx] == attn_regions[key_idx])
+                & (document_ids[query_idx] == document_ids[key_idx])
+            )
+
+        document_ids = torch.zeros(8, dtype=torch.int64)
+        batch0_attn_regions = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1], dtype=torch.int32)
+        batch1_attn_regions = torch.tensor([0, 0, 1, 1, 0, 0, 1, 1], dtype=torch.int32)
+
+        def wrap(mask_mod):
+            _, spec, stripped = _extract_callable_pytree(mask_mod)
+            return _MaskModWrapper(stripped, spec)
+
+        partial_a = functools.partial(
+            mask_rule,
+            attn_regions=batch0_attn_regions,
+            document_ids=document_ids,
+        )
+        partial_b = functools.partial(
+            mask_rule,
+            attn_regions=batch1_attn_regions,
+            document_ids=document_ids,
+        )
+        recursive_partial_a = functools.partial(
+            functools.partial(mask_rule, attn_regions=batch0_attn_regions),
+            document_ids=document_ids,
+        )
+        recursive_partial_b = functools.partial(
+            functools.partial(mask_rule, attn_regions=batch1_attn_regions),
+            document_ids=document_ids,
+        )
+
+        self.assertEqual(wrap(partial_a), wrap(partial_b))
+        self.assertEqual(wrap(recursive_partial_a), wrap(recursive_partial_b))
+
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_blockmask_and_masks_closure_extraction(self):
         """and_masks closure tensors are recursively extracted into pytree leaves.
 
         and_masks(fn1, fn2) returns a closure capturing a tuple of functions.
-        _extract_closure_pytree must recursively process these functions
+        _extract_callable_pytree must recursively process these functions
         (extracting their closure tensors) rather than emitting the functions
         themselves as leaves, since functions are not supported export input
         types.

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -1616,6 +1616,29 @@ def forward(self, arg0_1):
                 torch.tensor(0),
             )
 
+    def test_mask_mod_wrapper_eq_for_plain_functions(self):
+        from torch.nn.attention.flex_attention import (
+            _extract_callable_pytree,
+            _MaskModWrapper,
+        )
+
+        def make_mask_mod():
+            def mask_mod(batch, head, query_idx, key_idx):
+                del batch, head
+                return query_idx >= key_idx
+
+            return mask_mod
+
+        def wrap(mask_mod):
+            _, spec, stripped = _extract_callable_pytree(mask_mod)
+            return _MaskModWrapper(stripped, spec)
+
+        wrapped_a = wrap(make_mask_mod())
+        wrapped_b = wrap(make_mask_mod())
+
+        self.assertEqual(wrapped_a, wrapped_b)
+        self.assertEqual(hash(wrapped_a), hash(wrapped_b))
+
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_blockmask_and_masks_closure_extraction(self):
         """and_masks closure tensors are recursively extracted into pytree leaves.

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -1639,6 +1639,46 @@ def forward(self, arg0_1):
         self.assertEqual(wrapped_a, wrapped_b)
         self.assertEqual(hash(wrapped_a), hash(wrapped_b))
 
+    def test_blockmask_self_referential_function_closure_extraction(self):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_mod():
+            def helper():
+                return helper
+
+            def mask_mod(batch, head, query_idx, key_idx):
+                del batch, head
+                _ = helper
+                return query_idx >= key_idx
+
+            return mask_mod
+
+        mask_a = create_block_mask(
+            make_mask_mod(), B=1, H=1, Q_LEN=8, KV_LEN=8, device="cpu", BLOCK_SIZE=4
+        )
+        mask_b = create_block_mask(
+            make_mask_mod(), B=1, H=1, Q_LEN=8, KV_LEN=8, device="cpu", BLOCK_SIZE=4
+        )
+
+        leaves_a, spec_a = pytree.tree_flatten(mask_a)
+        leaves_b, spec_b = pytree.tree_flatten(mask_b)
+
+        self.assertEqual(spec_a, spec_b)
+
+        restored = pytree.tree_unflatten(leaves_a, spec_a)
+        self.assertTrue(
+            torch.equal(
+                restored.mask_mod(
+                    0, 0, torch.arange(8)[:, None], torch.arange(8)[None, :]
+                ),
+                mask_a.mask_mod(
+                    0, 0, torch.arange(8)[:, None], torch.arange(8)[None, :]
+                ),
+            )
+        )
+
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_blockmask_and_masks_closure_extraction(self):
         """and_masks closure tensors are recursively extracted into pytree leaves.

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -471,7 +471,7 @@ class _FunctionLeaf(typing.NamedTuple):
     function.  Stores enough information to reconstruct the function from
     the extracted leaves during unflattening."""
 
-    stripped: _StrippedClosure | Callable[..., Any]
+    stripped: _StrippedClosure | _StrippedPartial | Callable[..., Any]
     closure_spec: TreeSpec
     n_extracted: int  # number of extracted leaves this function contributes
 
@@ -479,7 +479,7 @@ class _FunctionLeaf(typing.NamedTuple):
 class _StrippedClosure(typing.NamedTuple):
     """Data container holding the parts of a function needed for reconstruction.
 
-    Created by _extract_closure_pytree when closure tensors are lifted into
+    Created by _extract_callable_pytree when closure tensors are lifted into
     pytree leaves.  Unlike a FunctionType with None-filled cells, this is not
     callable — it is pure data stored in the pytree context.
     """
@@ -497,34 +497,45 @@ class _StrippedClosure(typing.NamedTuple):
     leaf_entries: tuple[_ExtractedLeaf | _FunctionLeaf, ...]
 
 
-def _extract_closure_pytree(
+class _StrippedPartial(typing.NamedTuple):
+    """Data container holding the parts of a functools.partial needed for reconstruction."""
+
+    leaf_entries: tuple[_ExtractedLeaf | _FunctionLeaf, ...]
+
+
+def _extract_callable_pytree(
     fn, _seen: set[int] | None = None
 ) -> tuple[
-    tuple[BaseArgumentTypes, ...], TreeSpec, _StrippedClosure | Callable[..., Any]
+    tuple[BaseArgumentTypes, ...],
+    TreeSpec,
+    _StrippedClosure | _StrippedPartial | Callable[..., Any],
 ]:
     """Extract closure contents as a flattened sub-pytree.
 
     Returns (extracted_leaves, closure_spec, fn_or_stripped) where:
     - extracted_leaves: flattened non-function contents from the closure,
-      plus any tensors/scalars recursively extracted from nested function
-      closures
+      functools.partial payload, plus any tensors/scalars recursively extracted
+      from nested function closures
     - closure_spec: TreeSpec describing how to reconstruct the closure contents
     - fn_or_stripped: either the original fn (no extraction) or a
-      _StrippedClosure carrying the function parts needed for reconstruction
+      stripped callable carrying the parts needed for reconstruction
 
-    Functions found among the closure leaves are recursively processed: their
-    own closure tensors are extracted into the leaves list, and their skeleton
-    is stored in _StrippedClosure.leaf_entries as a _FunctionLeaf.  All other
-    values (tensors, scalars, None, etc.) remain as extracted leaves.
+    Functions found among the closure or partial leaves are recursively
+    processed: their own closure tensors are extracted into the leaves list,
+    and their skeleton is stored in the stripped metadata. All other values
+    (tensors, scalars, None, etc.) remain as extracted leaves.
 
-    If fn is not a plain function, has no closure, or has empty cells, returns
+    If fn is not a plain function or functools.partial, has no closure, or has
+    empty cells, returns
     the original function unchanged with no closure leaves.
 
     Skipped under Dynamo tracing (torch.compiler.is_compiling) because Dynamo
     can't trace through closure cell introspection and handles freevars via its
     own lifting mechanism.
     """
-    if not inspect.isfunction(fn) or torch.compiler.is_compiling():
+    if torch.compiler.is_compiling() or not (
+        inspect.isfunction(fn) or isinstance(fn, functools.partial)
+    ):
         return (), _EMPTY_CLOSURE_SPEC, fn
 
     # Cycle detection for self-referencing closures.
@@ -533,6 +544,26 @@ def _extract_closure_pytree(
     if id(fn) in _seen:
         return (), _EMPTY_CLOSURE_SPEC, fn
     _seen.add(id(fn))
+
+    if isinstance(fn, functools.partial):
+        partial_leaves, partial_spec = tree_flatten(
+            (fn.func, fn.args, fn.keywords or {})
+        )
+        extracted: list[BaseArgumentTypes] = []
+        leaf_entries: list[_ExtractedLeaf | _FunctionLeaf] = []
+        for leaf in partial_leaves:
+            if inspect.isfunction(leaf) or isinstance(leaf, functools.partial):
+                child_extracted, child_spec, child_stripped = _extract_callable_pytree(
+                    leaf, _seen
+                )
+                extracted.extend(child_extracted)
+                leaf_entries.append(
+                    _FunctionLeaf(child_stripped, child_spec, len(child_extracted))
+                )
+            else:
+                extracted.append(leaf)
+                leaf_entries.append(_EXTRACTED_LEAF)
+        return tuple(extracted), partial_spec, _StrippedPartial(tuple(leaf_entries))
 
     closure = fn.__closure__
     if not closure:
@@ -549,8 +580,8 @@ def _extract_closure_pytree(
     extracted: list[BaseArgumentTypes] = []
     leaf_entries: list[_ExtractedLeaf | _FunctionLeaf] = []
     for leaf in closure_leaves:
-        if inspect.isfunction(leaf):
-            child_extracted, child_spec, child_stripped = _extract_closure_pytree(
+        if inspect.isfunction(leaf) or isinstance(leaf, functools.partial):
+            child_extracted, child_spec, child_stripped = _extract_callable_pytree(
                 leaf, _seen
             )
             extracted.extend(child_extracted)
@@ -576,8 +607,8 @@ def _extract_closure_pytree(
 
 
 def _reconstruct_closure_fn(stripped, extracted_leaves, closure_spec):
-    """Rebuild a function from a _StrippedClosure and flattened extracted leaves."""
-    if not isinstance(stripped, _StrippedClosure):
+    """Rebuild a stripped callable from flattened extracted leaves."""
+    if not isinstance(stripped, (_StrippedClosure, _StrippedPartial)):
         return stripped
 
     all_leaves: list[BaseArgumentTypes | Callable[..., Any]] = []
@@ -595,6 +626,10 @@ def _reconstruct_closure_fn(stripped, extracted_leaves, closure_spec):
             # _EXTRACTED_LEAF — take from extracted leaves
             all_leaves.append(extracted_leaves[idx])
             idx += 1
+
+    if isinstance(stripped, _StrippedPartial):
+        fn, args, keywords = tree_unflatten(all_leaves, closure_spec)
+        return functools.partial(fn, *args, **keywords)
 
     contents = tree_unflatten(all_leaves, closure_spec)
     new_cells = tuple(types.CellType(v) for v in contents)
@@ -615,6 +650,61 @@ def _reconstruct_closure_fn(stripped, extracted_leaves, closure_spec):
     return restored
 
 
+def _leaf_entries_eq(
+    a: tuple[_ExtractedLeaf | _FunctionLeaf, ...],
+    b: tuple[_ExtractedLeaf | _FunctionLeaf, ...],
+) -> bool:
+    if len(a) != len(b):
+        return False
+    for lhs, rhs in zip(a, b):
+        if type(lhs) is not type(rhs):
+            return False
+        if not isinstance(lhs, _FunctionLeaf):
+            continue
+        if not isinstance(rhs, _FunctionLeaf):
+            raise AssertionError
+        if lhs.closure_spec != rhs.closure_spec or lhs.n_extracted != rhs.n_extracted:
+            return False
+        if isinstance(lhs.stripped, _StrippedClosure):
+            if (
+                not isinstance(rhs.stripped, _StrippedClosure)
+                or lhs.stripped.code != rhs.stripped.code
+            ):
+                return False
+        elif isinstance(lhs.stripped, _StrippedPartial):
+            if not isinstance(rhs.stripped, _StrippedPartial) or not _leaf_entries_eq(
+                lhs.stripped.leaf_entries, rhs.stripped.leaf_entries
+            ):
+                return False
+        elif lhs.stripped != rhs.stripped:
+            return False
+    return True
+
+
+def _stripped_callable_hash(stripped: Any) -> int:
+    if isinstance(stripped, _StrippedClosure):
+        return hash(stripped.code)
+    if isinstance(stripped, _StrippedPartial):
+        return _leaf_entries_hash(stripped.leaf_entries)
+    return hash(stripped)
+
+
+def _leaf_entries_hash(entries: tuple[_ExtractedLeaf | _FunctionLeaf, ...]) -> int:
+    return hash(
+        tuple(
+            (
+                type(entry),
+                entry.closure_spec,
+                entry.n_extracted,
+                _stripped_callable_hash(entry.stripped),
+            )
+            if isinstance(entry, _FunctionLeaf)
+            else type(entry)
+            for entry in entries
+        )
+    )
+
+
 class _MaskModWrapper:
     """Wraps a mask_mod or _StrippedClosure with value-based equality.
 
@@ -622,7 +712,7 @@ class _MaskModWrapper:
     The default __eq__ for functions uses identity comparison, which is too
     strict when the same closure is recreated (e.g., defined inside forward()).
 
-    When closure tensors have been extracted (by _extract_closure_pytree), fn
+    When closure tensors have been extracted (by _extract_callable_pytree), fn
     is a _StrippedClosure (pure data, not callable).  Equality compares the
     code objects + closure_spec — no tensor dispatch is triggered.
 
@@ -650,13 +740,19 @@ class _MaskModWrapper:
             return False
         if self.fn is other.fn and self.closure_spec is other.closure_spec:
             return True
-        # Extracted case: _StrippedClosure — compare code + closure_spec
+        # Extracted case: stripped callable — compare structure + closure_spec
         if isinstance(self.fn, _StrippedClosure) and isinstance(
             other.fn, _StrippedClosure
         ):
             return (
                 self.fn.code == other.fn.code
                 and self.closure_spec == other.closure_spec
+            )
+        if isinstance(self.fn, _StrippedPartial) and isinstance(
+            other.fn, _StrippedPartial
+        ):
+            return _leaf_entries_eq(self.fn.leaf_entries, other.fn.leaf_entries) and (
+                self.closure_spec == other.closure_spec
             )
         # Non-extracted plain functions: compare code + closure contents
         if inspect.isfunction(self.fn) and inspect.isfunction(other.fn):
@@ -671,6 +767,8 @@ class _MaskModWrapper:
     def __hash__(self) -> int:
         if isinstance(self.fn, _StrippedClosure):
             return hash(self.fn.code)
+        if isinstance(self.fn, _StrippedPartial):
+            return hash((_stripped_callable_hash(self.fn), self.closure_spec))
         if inspect.isfunction(self.fn):
             return hash(self.fn.__code__)
         return hash(self.fn)
@@ -1233,11 +1331,11 @@ class BlockMask:
         """Flatten BlockMask into a list of tensors and context.
 
         Closure tensors from mask_mod are extracted into the leaves via
-        _extract_closure_pytree so they are visible to the tracing
+        _extract_callable_pytree so they are visible to the tracing
         infrastructure (instead of being hidden in the pytree context).
         """
         tensors = tuple(getattr(self, attr) for attr in self._TENSOR_ATTRS)
-        closure_leaves, closure_spec, stripped = _extract_closure_pytree(self.mask_mod)
+        closure_leaves, closure_spec, stripped = _extract_callable_pytree(self.mask_mod)
         all_leaves = tensors + closure_leaves
         context = tuple(
             self._wrap_context_value(attr, getattr(self, attr))
@@ -1274,13 +1372,13 @@ class BlockMask:
         """Flatten BlockMask with keys for better tracing.
 
         Closure tensors from mask_mod are extracted into the leaves via
-        _extract_closure_pytree so they are visible to the tracing
+        _extract_callable_pytree so they are visible to the tracing
         infrastructure (instead of being hidden in the pytree context).
         """
         tensors = tuple(
             (GetAttrKey(attr), getattr(self, attr)) for attr in self._TENSOR_ATTRS
         )
-        closure_leaves, closure_spec, stripped = _extract_closure_pytree(self.mask_mod)
+        closure_leaves, closure_spec, stripped = _extract_callable_pytree(self.mask_mod)
         closure_with_keys = tuple(
             (GetAttrKey(f"_closure_{i}"), leaf) for i, leaf in enumerate(closure_leaves)
         )

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -662,7 +662,7 @@ def _leaf_entries_eq(
         if not isinstance(lhs, _FunctionLeaf):
             continue
         if not isinstance(rhs, _FunctionLeaf):
-            raise AssertionError
+            raise AssertionError("expected matching _FunctionLeaf entries")
         if lhs.closure_spec != rhs.closure_spec or lhs.n_extracted != rhs.n_extracted:
             return False
         if isinstance(lhs.stripped, _StrippedClosure):
@@ -728,9 +728,9 @@ class _MaskModWrapper:
         self.closure_spec = closure_spec
 
     def __call__(self, b: Tensor, h: Tensor, q_idx: Tensor, kv_idx: Tensor) -> Tensor:
-        if isinstance(self.fn, _StrippedClosure):
+        if isinstance(self.fn, (_StrippedClosure, _StrippedPartial)):
             raise RuntimeError(
-                "_MaskModWrapper with _StrippedClosure is not callable — "
+                "_MaskModWrapper with stripped callable is not callable — "
                 "use _reconstruct_closure_fn to rebuild the function first"
             )
         return self.fn(b, h, q_idx, kv_idx)

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -471,7 +471,7 @@ class _FunctionLeaf(typing.NamedTuple):
     function.  Stores enough information to reconstruct the function from
     the extracted leaves during unflattening."""
 
-    stripped: _StrippedClosure | _StrippedPartial | Callable[..., Any]
+    stripped: _StrippedClosure | _StrippedPartial | _PlainFunction
     closure_spec: TreeSpec
     n_extracted: int  # number of extracted leaves this function contributes
 
@@ -496,11 +496,39 @@ class _StrippedClosure(typing.NamedTuple):
     # _FunctionLeaf   → recursively processed function (not a valid pytree leaf).
     leaf_entries: tuple[_ExtractedLeaf | _FunctionLeaf, ...]
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _StrippedClosure):
+            return False
+        return self.code == other.code
+
+    def __hash__(self) -> int:
+        return hash(self.code)
+
 
 class _StrippedPartial(typing.NamedTuple):
     """Data container holding the parts of a functools.partial needed for reconstruction."""
 
     leaf_entries: tuple[_ExtractedLeaf | _FunctionLeaf, ...]
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _StrippedPartial):
+            return False
+        return _leaf_entries_eq(self.leaf_entries, other.leaf_entries)
+
+    def __hash__(self) -> int:
+        return _leaf_entries_hash(self.leaf_entries)
+
+
+class _PlainFunction(typing.NamedTuple):
+    fn: Callable[..., Any]
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _PlainFunction):
+            return False
+        return self.fn.__code__ == other.fn.__code__
+
+    def __hash__(self) -> int:
+        return hash(self.fn.__code__)
 
 
 def _extract_callable_leaves(
@@ -528,7 +556,7 @@ def _extract_callable_pytree(
 ) -> tuple[
     tuple[BaseArgumentTypes, ...],
     TreeSpec,
-    _StrippedClosure | _StrippedPartial | Callable[..., Any],
+    _StrippedClosure | _StrippedPartial | _PlainFunction | Callable[..., Any],
 ]:
     """Extract closure contents as a flattened sub-pytree.
 
@@ -537,7 +565,7 @@ def _extract_callable_pytree(
       functools.partial payload, plus any tensors/scalars recursively extracted
       from nested function closures
     - closure_spec: TreeSpec describing how to reconstruct the closure contents
-    - fn_or_stripped: either the original fn (no extraction) or a
+    - fn_or_stripped: either the original fn (skipped extraction) or a
       stripped callable carrying the parts needed for reconstruction
 
     Functions found among the closure or partial leaves are recursively
@@ -545,9 +573,10 @@ def _extract_callable_pytree(
     and their skeleton is stored in the stripped metadata. All other values
     (tensors, scalars, None, etc.) remain as extracted leaves.
 
-    If fn is not a plain function or functools.partial, has no closure, or has
-    empty cells, returns
-    the original function unchanged with no closure leaves.
+    If fn is not a plain function or functools.partial, returns the original
+    function unchanged with no closure leaves. Plain functions without a
+    closure are wrapped as _PlainFunction so structural equality/hash can use
+    their __code__.
 
     Skipped under Dynamo tracing (torch.compiler.is_compiling) because Dynamo
     can't trace through closure cell introspection and handles freevars via its
@@ -562,7 +591,7 @@ def _extract_callable_pytree(
     if _seen is None:
         _seen = set()
     if id(fn) in _seen:
-        return (), _EMPTY_CLOSURE_SPEC, fn
+        return (), _EMPTY_CLOSURE_SPEC, _PlainFunction(fn)
     _seen.add(id(fn))
 
     if isinstance(fn, functools.partial):
@@ -572,13 +601,13 @@ def _extract_callable_pytree(
 
     closure = fn.__closure__
     if not closure:
-        return (), _EMPTY_CLOSURE_SPEC, fn
+        return (), _EMPTY_CLOSURE_SPEC, _PlainFunction(fn)
 
     try:
         contents = tuple(cell.cell_contents for cell in closure)
     except ValueError:
         # Empty cell (created but not yet assigned) — can't extract
-        return (), _EMPTY_CLOSURE_SPEC, fn
+        return (), _EMPTY_CLOSURE_SPEC, _PlainFunction(fn)
 
     closure_leaves, closure_spec = tree_flatten(contents)
 
@@ -600,6 +629,8 @@ def _extract_callable_pytree(
 
 def _reconstruct_closure_fn(stripped, extracted_leaves, closure_spec):
     """Rebuild a stripped callable from flattened extracted leaves."""
+    if isinstance(stripped, _PlainFunction):
+        return stripped.fn
     if not isinstance(stripped, (_StrippedClosure, _StrippedPartial)):
         return stripped
 
@@ -657,35 +688,14 @@ def _leaf_entries_eq(
             raise AssertionError("expected matching _FunctionLeaf entries")
         if lhs.closure_spec != rhs.closure_spec or lhs.n_extracted != rhs.n_extracted:
             return False
-        if isinstance(lhs.stripped, _StrippedClosure):
-            if (
-                not isinstance(rhs.stripped, _StrippedClosure)
-                or lhs.stripped.code != rhs.stripped.code
-            ):
-                return False
-        elif isinstance(lhs.stripped, _StrippedPartial):
-            if not isinstance(rhs.stripped, _StrippedPartial) or not _leaf_entries_eq(
-                lhs.stripped.leaf_entries, rhs.stripped.leaf_entries
-            ):
-                return False
-        elif (
-            not inspect.isfunction(lhs.stripped)
-            or not inspect.isfunction(rhs.stripped)
-            or lhs.stripped.__code__ != rhs.stripped.__code__
-        ):
+        if lhs.stripped != rhs.stripped:
             return False
     return True
 
 
 def _stripped_callable_hash(
-    stripped: _StrippedClosure | _StrippedPartial | Callable[..., Any],
+    stripped: _StrippedClosure | _StrippedPartial | _PlainFunction,
 ) -> int:
-    if isinstance(stripped, _StrippedClosure):
-        return hash(stripped.code)
-    if isinstance(stripped, _StrippedPartial):
-        return _leaf_entries_hash(stripped.leaf_entries)
-    if inspect.isfunction(stripped):
-        return hash(stripped.__code__)
     return hash(stripped)
 
 
@@ -706,15 +716,15 @@ def _leaf_entries_hash(entries: tuple[_ExtractedLeaf | _FunctionLeaf, ...]) -> i
 
 
 class _MaskModWrapper:
-    """Wraps a mask_mod or _StrippedClosure with value-based equality.
+    """Wraps a mask_mod or stripped callable metadata with value-based equality.
 
     BlockMask stores an arbitrary callable (mask_mod) in its pytree context.
     The default __eq__ for functions uses identity comparison, which is too
     strict when the same closure is recreated (e.g., defined inside forward()).
 
-    When closure tensors have been extracted (by _extract_callable_pytree), fn
-    is a _StrippedClosure (pure data, not callable).  Equality compares the
-    code objects + closure_spec — no tensor dispatch is triggered.
+    When callable state has been extracted (by _extract_callable_pytree), fn is
+    stripped metadata (pure data, not callable). Equality compares the stripped
+    callable structure + closure_spec without triggering tensor dispatch.
 
     When extraction is skipped (e.g., under Dynamo), fn is the original
     callable and equality compares code objects for plain functions or
@@ -728,7 +738,7 @@ class _MaskModWrapper:
         self.closure_spec = closure_spec
 
     def __call__(self, b: Tensor, h: Tensor, q_idx: Tensor, kv_idx: Tensor) -> Tensor:
-        if isinstance(self.fn, (_StrippedClosure, _StrippedPartial)):
+        if isinstance(self.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)):
             raise RuntimeError(
                 "_MaskModWrapper with stripped callable is not callable — "
                 "use _reconstruct_closure_fn to rebuild the function first"
@@ -740,35 +750,23 @@ class _MaskModWrapper:
             return False
         if self.fn is other.fn and self.closure_spec is other.closure_spec:
             return True
-        # Extracted case: stripped callable — compare structure + closure_spec
-        if isinstance(self.fn, _StrippedClosure) and isinstance(
-            other.fn, _StrippedClosure
-        ):
-            return (
-                self.fn.code == other.fn.code
-                and self.closure_spec == other.closure_spec
-            )
-        if isinstance(self.fn, _StrippedPartial) and isinstance(
-            other.fn, _StrippedPartial
-        ):
-            return _leaf_entries_eq(self.fn.leaf_entries, other.fn.leaf_entries) and (
-                self.closure_spec == other.closure_spec
-            )
+        if isinstance(
+            self.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)
+        ) and isinstance(other.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)):
+            return self.fn == other.fn and self.closure_spec == other.closure_spec
         # Non-extracted plain functions: compare code objects
         if inspect.isfunction(self.fn) and inspect.isfunction(other.fn):
             return self.fn.__code__ == other.fn.__code__
         # Callable objects: delegate to their __eq__
-        if not isinstance(self.fn, _StrippedClosure) and not isinstance(
-            other.fn, _StrippedClosure
-        ):
+        if not isinstance(
+            self.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)
+        ) and not isinstance(other.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)):
             return self.fn == other.fn
         return False
 
     def __hash__(self) -> int:
-        if isinstance(self.fn, _StrippedClosure):
-            return hash(self.fn.code)
-        if isinstance(self.fn, _StrippedPartial):
-            return hash((_stripped_callable_hash(self.fn), self.closure_spec))
+        if isinstance(self.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)):
+            return hash((self.fn, self.closure_spec))
         if inspect.isfunction(self.fn):
             return hash(self.fn.__code__)
         return hash(self.fn)

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -471,7 +471,7 @@ class _FunctionLeaf(typing.NamedTuple):
     function.  Stores enough information to reconstruct the function from
     the extracted leaves during unflattening."""
 
-    stripped: _StrippedClosure | _StrippedPartial | _PlainFunction
+    stripped: _CallableMetadata
     closure_spec: TreeSpec
     n_extracted: int  # number of extracted leaves this function contributes
 
@@ -531,6 +531,9 @@ class _PlainFunction(typing.NamedTuple):
         return hash(self.fn.__code__)
 
 
+_CallableMetadata: TypeAlias = _StrippedClosure | _StrippedPartial | _PlainFunction
+
+
 def _extract_callable_leaves(
     leaves: list[Any], _seen: set[int]
 ) -> tuple[tuple[BaseArgumentTypes, ...], tuple[_ExtractedLeaf | _FunctionLeaf, ...]]:
@@ -541,6 +544,12 @@ def _extract_callable_leaves(
             child_extracted, child_spec, child_stripped = _extract_callable_pytree(
                 leaf, _seen
             )
+            if not isinstance(
+                child_stripped, (_StrippedClosure, _StrippedPartial, _PlainFunction)
+            ):
+                raise AssertionError(
+                    "expected nested callable extraction to produce callable metadata"
+                )
             extracted.extend(child_extracted)
             leaf_entries.append(
                 _FunctionLeaf(child_stripped, child_spec, len(child_extracted))
@@ -556,7 +565,7 @@ def _extract_callable_pytree(
 ) -> tuple[
     tuple[BaseArgumentTypes, ...],
     TreeSpec,
-    _StrippedClosure | _StrippedPartial | _PlainFunction | Callable[..., Any],
+    _CallableMetadata | Callable[..., Any],
 ]:
     """Extract closure contents as a flattened sub-pytree.
 
@@ -694,7 +703,7 @@ def _leaf_entries_eq(
 
 
 def _stripped_callable_hash(
-    stripped: _StrippedClosure | _StrippedPartial | _PlainFunction,
+    stripped: _CallableMetadata,
 ) -> int:
     return hash(stripped)
 
@@ -752,7 +761,9 @@ class _MaskModWrapper:
             return True
         if isinstance(
             self.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)
-        ) and isinstance(other.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)):
+        ) and isinstance(
+            other.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)
+        ):
             return self.fn == other.fn and self.closure_spec == other.closure_spec
         # Non-extracted plain functions: compare code objects
         if inspect.isfunction(self.fn) and inspect.isfunction(other.fn):
@@ -760,7 +771,9 @@ class _MaskModWrapper:
         # Callable objects: delegate to their __eq__
         if not isinstance(
             self.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)
-        ) and not isinstance(other.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)):
+        ) and not isinstance(
+            other.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)
+        ):
             return self.fn == other.fn
         return False
 

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -503,6 +503,26 @@ class _StrippedPartial(typing.NamedTuple):
     leaf_entries: tuple[_ExtractedLeaf | _FunctionLeaf, ...]
 
 
+def _extract_callable_leaves(
+    leaves: list[Any], _seen: set[int]
+) -> tuple[tuple[BaseArgumentTypes, ...], tuple[_ExtractedLeaf | _FunctionLeaf, ...]]:
+    extracted: list[BaseArgumentTypes] = []
+    leaf_entries: list[_ExtractedLeaf | _FunctionLeaf] = []
+    for leaf in leaves:
+        if inspect.isfunction(leaf) or isinstance(leaf, functools.partial):
+            child_extracted, child_spec, child_stripped = _extract_callable_pytree(
+                leaf, _seen
+            )
+            extracted.extend(child_extracted)
+            leaf_entries.append(
+                _FunctionLeaf(child_stripped, child_spec, len(child_extracted))
+            )
+        else:
+            extracted.append(leaf)
+            leaf_entries.append(_EXTRACTED_LEAF)
+    return tuple(extracted), tuple(leaf_entries)
+
+
 def _extract_callable_pytree(
     fn, _seen: set[int] | None = None
 ) -> tuple[
@@ -546,23 +566,8 @@ def _extract_callable_pytree(
     _seen.add(id(fn))
 
     if isinstance(fn, functools.partial):
-        partial_leaves, partial_spec = tree_flatten(
-            (fn.func, fn.args, fn.keywords or {})
-        )
-        extracted: list[BaseArgumentTypes] = []
-        leaf_entries: list[_ExtractedLeaf | _FunctionLeaf] = []
-        for leaf in partial_leaves:
-            if inspect.isfunction(leaf) or isinstance(leaf, functools.partial):
-                child_extracted, child_spec, child_stripped = _extract_callable_pytree(
-                    leaf, _seen
-                )
-                extracted.extend(child_extracted)
-                leaf_entries.append(
-                    _FunctionLeaf(child_stripped, child_spec, len(child_extracted))
-                )
-            else:
-                extracted.append(leaf)
-                leaf_entries.append(_EXTRACTED_LEAF)
+        partial_leaves, partial_spec = tree_flatten((fn.func, fn.args, fn.keywords))
+        extracted, leaf_entries = _extract_callable_leaves(partial_leaves, _seen)
         return tuple(extracted), partial_spec, _StrippedPartial(tuple(leaf_entries))
 
     closure = fn.__closure__
@@ -577,20 +582,7 @@ def _extract_callable_pytree(
 
     closure_leaves, closure_spec = tree_flatten(contents)
 
-    extracted: list[BaseArgumentTypes] = []
-    leaf_entries: list[_ExtractedLeaf | _FunctionLeaf] = []
-    for leaf in closure_leaves:
-        if inspect.isfunction(leaf) or isinstance(leaf, functools.partial):
-            child_extracted, child_spec, child_stripped = _extract_callable_pytree(
-                leaf, _seen
-            )
-            extracted.extend(child_extracted)
-            leaf_entries.append(
-                _FunctionLeaf(child_stripped, child_spec, len(child_extracted))
-            )
-        else:
-            extracted.append(leaf)
-            leaf_entries.append(_EXTRACTED_LEAF)
+    extracted, leaf_entries = _extract_callable_leaves(closure_leaves, _seen)
 
     stripped = _StrippedClosure(
         code=fn.__code__,
@@ -676,16 +668,24 @@ def _leaf_entries_eq(
                 lhs.stripped.leaf_entries, rhs.stripped.leaf_entries
             ):
                 return False
-        elif lhs.stripped != rhs.stripped:
+        elif (
+            not inspect.isfunction(lhs.stripped)
+            or not inspect.isfunction(rhs.stripped)
+            or lhs.stripped.__code__ != rhs.stripped.__code__
+        ):
             return False
     return True
 
 
-def _stripped_callable_hash(stripped: Any) -> int:
+def _stripped_callable_hash(
+    stripped: _StrippedClosure | _StrippedPartial | Callable[..., Any],
+) -> int:
     if isinstance(stripped, _StrippedClosure):
         return hash(stripped.code)
     if isinstance(stripped, _StrippedPartial):
         return _leaf_entries_hash(stripped.leaf_entries)
+    if inspect.isfunction(stripped):
+        return hash(stripped.__code__)
     return hash(stripped)
 
 
@@ -717,8 +717,8 @@ class _MaskModWrapper:
     code objects + closure_spec — no tensor dispatch is triggered.
 
     When extraction is skipped (e.g., under Dynamo), fn is the original
-    callable and equality compares code objects + closure contents (for plain
-    functions) or delegates to __eq__ (for callable objects).
+    callable and equality compares code objects for plain functions or
+    delegates to __eq__ for callable objects.
     """
 
     __slots__ = ("fn", "closure_spec")
@@ -754,7 +754,7 @@ class _MaskModWrapper:
             return _leaf_entries_eq(self.fn.leaf_entries, other.fn.leaf_entries) and (
                 self.closure_spec == other.closure_spec
             )
-        # Non-extracted plain functions: compare code + closure contents
+        # Non-extracted plain functions: compare code objects
         if inspect.isfunction(self.fn) and inspect.isfunction(other.fn):
             return self.fn.__code__ == other.fn.__code__
         # Callable objects: delegate to their __eq__

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -466,13 +466,13 @@ class _ExtractedLeaf:
 _EXTRACTED_LEAF = _ExtractedLeaf()
 
 
-class _FunctionLeaf(typing.NamedTuple):
-    """Entry in _StrippedClosure.leaf_entries for a recursively processed
-    function.  Stores enough information to reconstruct the function from
-    the extracted leaves during unflattening."""
+class _CallableLeaf(typing.NamedTuple):
+    """Entry in stripped callable metadata for a recursively processed
+    nested callable. Stores enough information to reconstruct it from the
+    extracted leaves during unflattening."""
 
     stripped: _CallableMetadata
-    closure_spec: TreeSpec
+    callable_spec: TreeSpec
     n_extracted: int  # number of extracted leaves this function contributes
 
 
@@ -493,8 +493,8 @@ class _StrippedClosure(typing.NamedTuple):
     extra_dict: dict[str, Any]
     # Per-position info for the closure's flattened leaves.
     # _EXTRACTED_LEAF → position filled from the extracted leaves list.
-    # _FunctionLeaf   → recursively processed function (not a valid pytree leaf).
-    leaf_entries: tuple[_ExtractedLeaf | _FunctionLeaf, ...]
+    # _CallableLeaf   → recursively processed nested callable.
+    leaf_entries: tuple[_ExtractedLeaf | _CallableLeaf, ...]
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, _StrippedClosure):
@@ -508,7 +508,7 @@ class _StrippedClosure(typing.NamedTuple):
 class _StrippedPartial(typing.NamedTuple):
     """Data container holding the parts of a functools.partial needed for reconstruction."""
 
-    leaf_entries: tuple[_ExtractedLeaf | _FunctionLeaf, ...]
+    leaf_entries: tuple[_ExtractedLeaf | _CallableLeaf, ...]
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, _StrippedPartial):
@@ -536,9 +536,9 @@ _CallableMetadata: TypeAlias = _StrippedClosure | _StrippedPartial | _PlainFunct
 
 def _extract_callable_leaves(
     leaves: list[Any], _seen: set[int]
-) -> tuple[tuple[BaseArgumentTypes, ...], tuple[_ExtractedLeaf | _FunctionLeaf, ...]]:
+) -> tuple[tuple[BaseArgumentTypes, ...], tuple[_ExtractedLeaf | _CallableLeaf, ...]]:
     extracted: list[BaseArgumentTypes] = []
-    leaf_entries: list[_ExtractedLeaf | _FunctionLeaf] = []
+    leaf_entries: list[_ExtractedLeaf | _CallableLeaf] = []
     for leaf in leaves:
         if inspect.isfunction(leaf) or isinstance(leaf, functools.partial):
             child_extracted, child_spec, child_stripped = _extract_callable_pytree(
@@ -552,7 +552,7 @@ def _extract_callable_leaves(
                 )
             extracted.extend(child_extracted)
             leaf_entries.append(
-                _FunctionLeaf(child_stripped, child_spec, len(child_extracted))
+                _CallableLeaf(child_stripped, child_spec, len(child_extracted))
             )
         else:
             extracted.append(leaf)
@@ -569,11 +569,11 @@ def _extract_callable_pytree(
 ]:
     """Extract closure contents as a flattened sub-pytree.
 
-    Returns (extracted_leaves, closure_spec, fn_or_stripped) where:
+    Returns (extracted_leaves, callable_spec, fn_or_stripped) where:
     - extracted_leaves: flattened non-function contents from the closure,
       functools.partial payload, plus any tensors/scalars recursively extracted
       from nested function closures
-    - closure_spec: TreeSpec describing how to reconstruct the closure contents
+    - callable_spec: TreeSpec describing how to reconstruct the callable state
     - fn_or_stripped: either the original fn (skipped extraction) or a
       stripped callable carrying the parts needed for reconstruction
 
@@ -618,7 +618,7 @@ def _extract_callable_pytree(
         # Empty cell (created but not yet assigned) — can't extract
         return (), _EMPTY_CLOSURE_SPEC, _PlainFunction(fn)
 
-    closure_leaves, closure_spec = tree_flatten(contents)
+    closure_leaves, callable_spec = tree_flatten(contents)
 
     extracted, leaf_entries = _extract_callable_leaves(closure_leaves, _seen)
 
@@ -633,10 +633,10 @@ def _extract_callable_pytree(
         leaf_entries=tuple(leaf_entries),
     )
 
-    return tuple(extracted), closure_spec, stripped
+    return tuple(extracted), callable_spec, stripped
 
 
-def _reconstruct_closure_fn(stripped, extracted_leaves, closure_spec):
+def _reconstruct_closure_fn(stripped, extracted_leaves, callable_spec):
     """Rebuild a stripped callable from flattened extracted leaves."""
     if isinstance(stripped, _PlainFunction):
         return stripped.fn
@@ -646,11 +646,11 @@ def _reconstruct_closure_fn(stripped, extracted_leaves, closure_spec):
     all_leaves: list[BaseArgumentTypes | Callable[..., Any]] = []
     idx = 0
     for entry in stripped.leaf_entries:
-        if isinstance(entry, _FunctionLeaf):
+        if isinstance(entry, _CallableLeaf):
             child_fn = _reconstruct_closure_fn(
                 entry.stripped,
                 extracted_leaves[idx : idx + entry.n_extracted],
-                entry.closure_spec,
+                entry.callable_spec,
             )
             all_leaves.append(child_fn)
             idx += entry.n_extracted
@@ -660,10 +660,10 @@ def _reconstruct_closure_fn(stripped, extracted_leaves, closure_spec):
             idx += 1
 
     if isinstance(stripped, _StrippedPartial):
-        fn, args, keywords = tree_unflatten(all_leaves, closure_spec)
+        fn, args, keywords = tree_unflatten(all_leaves, callable_spec)
         return functools.partial(fn, *args, **keywords)
 
-    contents = tree_unflatten(all_leaves, closure_spec)
+    contents = tree_unflatten(all_leaves, callable_spec)
     new_cells = tuple(types.CellType(v) for v in contents)
 
     restored = types.FunctionType(
@@ -683,41 +683,33 @@ def _reconstruct_closure_fn(stripped, extracted_leaves, closure_spec):
 
 
 def _leaf_entries_eq(
-    a: tuple[_ExtractedLeaf | _FunctionLeaf, ...],
-    b: tuple[_ExtractedLeaf | _FunctionLeaf, ...],
+    a: tuple[_ExtractedLeaf | _CallableLeaf, ...],
+    b: tuple[_ExtractedLeaf | _CallableLeaf, ...],
 ) -> bool:
     if len(a) != len(b):
         return False
     for lhs, rhs in zip(a, b):
         if type(lhs) is not type(rhs):
             return False
-        if not isinstance(lhs, _FunctionLeaf):
+        if not isinstance(lhs, _CallableLeaf):
             continue
-        if not isinstance(rhs, _FunctionLeaf):
-            raise AssertionError("expected matching _FunctionLeaf entries")
-        if lhs.closure_spec != rhs.closure_spec or lhs.n_extracted != rhs.n_extracted:
-            return False
-        if lhs.stripped != rhs.stripped:
+        if not isinstance(rhs, _CallableLeaf):
+            raise AssertionError("expected matching _CallableLeaf entries")
+        if lhs != rhs:
             return False
     return True
 
 
-def _stripped_callable_hash(
-    stripped: _CallableMetadata,
-) -> int:
-    return hash(stripped)
-
-
-def _leaf_entries_hash(entries: tuple[_ExtractedLeaf | _FunctionLeaf, ...]) -> int:
+def _leaf_entries_hash(entries: tuple[_ExtractedLeaf | _CallableLeaf, ...]) -> int:
     return hash(
         tuple(
             (
                 type(entry),
-                entry.closure_spec,
+                entry.callable_spec,
                 entry.n_extracted,
-                _stripped_callable_hash(entry.stripped),
+                hash(entry.stripped),
             )
-            if isinstance(entry, _FunctionLeaf)
+            if isinstance(entry, _CallableLeaf)
             else type(entry)
             for entry in entries
         )
@@ -733,18 +725,18 @@ class _MaskModWrapper:
 
     When callable state has been extracted (by _extract_callable_pytree), fn is
     stripped metadata (pure data, not callable). Equality compares the stripped
-    callable structure + closure_spec without triggering tensor dispatch.
+    callable structure + callable_spec without triggering tensor dispatch.
 
     When extraction is skipped (e.g., under Dynamo), fn is the original
     callable and equality compares code objects for plain functions or
     delegates to __eq__ for callable objects.
     """
 
-    __slots__ = ("fn", "closure_spec")
+    __slots__ = ("fn", "callable_spec")
 
-    def __init__(self, fn, closure_spec=None) -> None:
+    def __init__(self, fn, callable_spec=None) -> None:
         self.fn = fn
-        self.closure_spec = closure_spec
+        self.callable_spec = callable_spec
 
     def __call__(self, b: Tensor, h: Tensor, q_idx: Tensor, kv_idx: Tensor) -> Tensor:
         if isinstance(self.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)):
@@ -757,14 +749,14 @@ class _MaskModWrapper:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, _MaskModWrapper):
             return False
-        if self.fn is other.fn and self.closure_spec is other.closure_spec:
+        if self.fn is other.fn and self.callable_spec is other.callable_spec:
             return True
         if isinstance(
             self.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)
         ) and isinstance(
             other.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)
         ):
-            return self.fn == other.fn and self.closure_spec == other.closure_spec
+            return self.fn == other.fn and self.callable_spec == other.callable_spec
         # Non-extracted plain functions: compare code objects
         if inspect.isfunction(self.fn) and inspect.isfunction(other.fn):
             return self.fn.__code__ == other.fn.__code__
@@ -779,7 +771,7 @@ class _MaskModWrapper:
 
     def __hash__(self) -> int:
         if isinstance(self.fn, (_StrippedClosure, _StrippedPartial, _PlainFunction)):
-            return hash((self.fn, self.closure_spec))
+            return hash((self.fn, self.callable_spec))
         if inspect.isfunction(self.fn):
             return hash(self.fn.__code__)
         return hash(self.fn)
@@ -1346,12 +1338,14 @@ class BlockMask:
         infrastructure (instead of being hidden in the pytree context).
         """
         tensors = tuple(getattr(self, attr) for attr in self._TENSOR_ATTRS)
-        closure_leaves, closure_spec, stripped = _extract_callable_pytree(self.mask_mod)
+        closure_leaves, callable_spec, stripped = _extract_callable_pytree(
+            self.mask_mod
+        )
         all_leaves = tensors + closure_leaves
         context = tuple(
             self._wrap_context_value(attr, getattr(self, attr))
             if attr != "mask_mod"
-            else _MaskModWrapper(stripped, closure_spec)
+            else _MaskModWrapper(stripped, callable_spec)
             for attr in self._CONTEXT_ATTRS
         )
         return all_leaves, context
@@ -1370,7 +1364,7 @@ class BlockMask:
         for attr, val in zip(cls._CONTEXT_ATTRS, context):
             if attr == "mask_mod" and isinstance(val, _MaskModWrapper):
                 kwargs[attr] = _reconstruct_closure_fn(
-                    val.fn, closure_leaves, val.closure_spec
+                    val.fn, closure_leaves, val.callable_spec
                 )
             else:
                 kwargs[attr] = cls._unwrap_context_value(attr, val)
@@ -1389,7 +1383,9 @@ class BlockMask:
         tensors = tuple(
             (GetAttrKey(attr), getattr(self, attr)) for attr in self._TENSOR_ATTRS
         )
-        closure_leaves, closure_spec, stripped = _extract_callable_pytree(self.mask_mod)
+        closure_leaves, callable_spec, stripped = _extract_callable_pytree(
+            self.mask_mod
+        )
         closure_with_keys = tuple(
             (GetAttrKey(f"_closure_{i}"), leaf) for i, leaf in enumerate(closure_leaves)
         )
@@ -1397,7 +1393,7 @@ class BlockMask:
         context = tuple(
             (GetAttrKey(attr), self._wrap_context_value(attr, getattr(self, attr)))
             if attr != "mask_mod"
-            else (GetAttrKey(attr), _MaskModWrapper(stripped, closure_spec))
+            else (GetAttrKey(attr), _MaskModWrapper(stripped, callable_spec))
             for attr in self._CONTEXT_ATTRS
         )
         return all_leaves, context

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -471,9 +471,27 @@ class _CallableLeaf(typing.NamedTuple):
     nested callable. Stores enough information to reconstruct it from the
     extracted leaves during unflattening."""
 
-    stripped: _CallableMetadata
+    stripped: _CallableMetadata | Callable[..., Any]
     callable_spec: TreeSpec
     n_extracted: int  # number of extracted leaves this function contributes
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _CallableLeaf):
+            return False
+        return (
+            _callable_entry_eq(self.stripped, other.stripped)
+            and self.callable_spec == other.callable_spec
+            and self.n_extracted == other.n_extracted
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                _callable_entry_hash(self.stripped),
+                self.callable_spec,
+                self.n_extracted,
+            )
+        )
 
 
 class _StrippedClosure(typing.NamedTuple):
@@ -499,10 +517,10 @@ class _StrippedClosure(typing.NamedTuple):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, _StrippedClosure):
             return False
-        return self.code == other.code
+        return self.code == other.code and self.leaf_entries == other.leaf_entries
 
     def __hash__(self) -> int:
-        return hash(self.code)
+        return hash((self.code, self.leaf_entries))
 
 
 class _StrippedPartial(typing.NamedTuple):
@@ -513,10 +531,10 @@ class _StrippedPartial(typing.NamedTuple):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, _StrippedPartial):
             return False
-        return _leaf_entries_eq(self.leaf_entries, other.leaf_entries)
+        return self.leaf_entries == other.leaf_entries
 
     def __hash__(self) -> int:
-        return _leaf_entries_hash(self.leaf_entries)
+        return hash(self.leaf_entries)
 
 
 class _PlainFunction(typing.NamedTuple):
@@ -534,6 +552,21 @@ class _PlainFunction(typing.NamedTuple):
 _CallableMetadata: TypeAlias = _StrippedClosure | _StrippedPartial | _PlainFunction
 
 
+def _callable_entry_eq(
+    lhs: _CallableMetadata | types.FunctionType,
+    rhs: _CallableMetadata | types.FunctionType,
+) -> bool:
+    if inspect.isfunction(lhs) and inspect.isfunction(rhs):
+        return lhs.__code__ == rhs.__code__
+    return lhs == rhs
+
+
+def _callable_entry_hash(value: _CallableMetadata | types.FunctionType) -> int:
+    if inspect.isfunction(value):
+        return hash(value.__code__)
+    return hash(value)
+
+
 def _extract_callable_leaves(
     leaves: list[Any], _seen: set[int]
 ) -> tuple[tuple[BaseArgumentTypes, ...], tuple[_ExtractedLeaf | _CallableLeaf, ...]]:
@@ -546,7 +579,7 @@ def _extract_callable_leaves(
             )
             if not isinstance(
                 child_stripped, (_StrippedClosure, _StrippedPartial, _PlainFunction)
-            ):
+            ) and not inspect.isfunction(child_stripped):
                 raise AssertionError(
                     "expected nested callable extraction to produce callable metadata"
                 )
@@ -600,7 +633,7 @@ def _extract_callable_pytree(
     if _seen is None:
         _seen = set()
     if id(fn) in _seen:
-        return (), _EMPTY_CLOSURE_SPEC, _PlainFunction(fn)
+        return (), _EMPTY_CLOSURE_SPEC, fn
     _seen.add(id(fn))
 
     if isinstance(fn, functools.partial):
@@ -680,40 +713,6 @@ def _reconstruct_closure_fn(stripped, extracted_leaves, callable_spec):
         restored.__dict__.update(stripped.extra_dict)
 
     return restored
-
-
-def _leaf_entries_eq(
-    a: tuple[_ExtractedLeaf | _CallableLeaf, ...],
-    b: tuple[_ExtractedLeaf | _CallableLeaf, ...],
-) -> bool:
-    if len(a) != len(b):
-        return False
-    for lhs, rhs in zip(a, b):
-        if type(lhs) is not type(rhs):
-            return False
-        if not isinstance(lhs, _CallableLeaf):
-            continue
-        if not isinstance(rhs, _CallableLeaf):
-            raise AssertionError("expected matching _CallableLeaf entries")
-        if lhs != rhs:
-            return False
-    return True
-
-
-def _leaf_entries_hash(entries: tuple[_ExtractedLeaf | _CallableLeaf, ...]) -> int:
-    return hash(
-        tuple(
-            (
-                type(entry),
-                entry.callable_spec,
-                entry.n_extracted,
-                hash(entry.stripped),
-            )
-            if isinstance(entry, _CallableLeaf)
-            else type(entry)
-            for entry in entries
-        )
-    )
 
 
 class _MaskModWrapper:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #180999

BlockMask._flatten() already lifts closure-captured values into pytree leaves so traced
mask_mod callables can be replayed with new bound tensors. functools.partial stored its bound
state outside __closure__, so those tensors stayed hidden in the callable and traces reused
stale values.

 Handle functools.partial in the same serialization path by extracting its bound func/args/
 keywords, reconstructing it during unflatten, and keeping the original closure equality
 behavior unchanged. Add focused regressions for simple partials, recursive partials, and
 wrapper equality on stripped partials.
 
Fixes: https://github.com/pytorch/pytorch/issues/179825

Authored with Claude and Codex.