### PR TITLE
[s390x CI] Mark runner container with /.incontainer to prevent image prune

### DIFF
--- a/.github/scripts/s390x-ci/self-hosted-builder/actions-runner.Dockerfile
+++ b/.github/scripts/s390x-ci/self-hosted-builder/actions-runner.Dockerfile
@@ -95,6 +95,12 @@ RUN chmod +x /usr/bin/actions-runner /usr/bin/entrypoint
 COPY --from=podman /tmp/podman /tmp/podman
 RUN apt-get update && apt -y install /tmp/podman/*.deb && /bin/rm -rfv /tmp/podman
 
+# Marker file so that pytorch/pytorch's setup-linux composite action detects
+# this as a container runner (see .github/actions/setup-linux/action.yml).
+# Without this, setup-linux runs `docker system prune -af`, which wipes the
+# manylinuxs390x-builder image that is preloaded below from manywheel-s390x.tar.
+RUN touch /.incontainer
+
 # amd64 Github Actions Runner.
 RUN useradd -m actions-runner
 USER actions-runner


### PR DESCRIPTION
## Summary

Fixes the `s390x-periodic` workflow, which has been failing since Apr 1, 2026 with:

```
Error: initializing source docker://pytorch/manylinuxs390x-builder:cpu-s390x:
reading manifest cpu-s390x in docker.io/pytorch/manylinuxs390x-builder:
requested access to the resource is denied
```

## Root cause

The `pytorch/manylinuxs390x-builder:cpu-s390x` image is never pulled from a remote registry. It is built locally, saved as `manywheel-s390x.tar`, baked into the `actions-runner` container image via `COPY`, and loaded at runner startup by `/usr/bin/actions-runner` via `docker image load`.

[#178831 "[Bugfix] Use setup-linux everywhere"](https://github.com/pytorch/pytorch/pull/178831) (landed Mar 31) enabled the `setup-linux` composite action for the s390x build. That action contains:

```yaml
- name: Kill any existing containers, clean up images
  if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
  run: |
    docker stop $(docker ps -q) || true
    docker system prune -af
```

`IN_CONTAINER_RUNNER` is detected via ``[ -f /.inarc ] || [ -f /.incontainer ]``. The s390x ephemeral runner container had neither marker file, so the check returned `false` and `docker system prune -af` ran, deleting the pre-loaded `manylinuxs390x-builder` image. The subsequent `docker run` then fell back to pulling from Docker Hub, which fails because the image was never published there.

## Fix

Add `RUN touch /.incontainer` to `actions-runner.Dockerfile` so `setup-linux` detects the s390x runner as a container runner and skips the destructive prune step (along with the other EC2-only steps, like EC2 metadata queries and docker daemon startup, which were never applicable on s390x).

## Test plan

- [ ] Add `ciflow/s390` label to trigger the `s390x-periodic` workflow on this PR
- [ ] Verify build step completes past image resolution and begins compiling PyTorch

Tracking issue: meta-pytorch/pytorch-gha-infra#1107

Note: This change only takes effect after the `actions-runner` Docker image is rebuilt and redeployed to the s390x runner fleet. Maintainers of the s390x runner infra should coordinate that rebuild.