### PR TITLE
Fix UnaryUfuncInfo ref lambda syntax

### DIFF
--- a/torch/testing/_internal/opinfo/definitions/special.py
+++ b/torch/testing/_internal/opinfo/definitions/special.py
@@ -366,7 +366,7 @@ op_db: list[OpInfo] = [
         ),
         dtypes=all_types_and(torch.bool, *_unsigned_int_types),
         dtypesIfMPS=all_types_and(torch.bool),
-        ref=lambda x: scipy.special.airy(x)[0] if TEST_SCIPY else None,
+        ref=(lambda x: scipy.special.airy(x)[0]) if TEST_SCIPY else None,
         skips=(
             DecorateInfo(
                 unittest.skip("Skipped!"),
@@ -847,7 +847,7 @@ op_db: list[OpInfo] = [
         ),
         dtypes=all_types_and(torch.bool, *_unsigned_int_types),
         dtypesIfMPS=all_types_and(torch.bool, torch.float16, torch.bfloat16),
-        ref=lambda x: scipy.special.spherical_jn(0, x) if TEST_SCIPY else None,
+        ref=(lambda x: scipy.special.spherical_jn(0, x)) if TEST_SCIPY else None,
         supports_autograd=False,
         skips=(
             DecorateInfo(


### PR DESCRIPTION
Fix ref lambda syntax error on `special.spherical_bessel_j0` and `special.airy_ai`, resulting in `ref=lambda x: None` instead of `ref=None` when scipy is not available.
Currently these ops are not filtered out properly when scipy is not installed and can break `TestUnaryUfuncsCUDA::test_reference_numerics_large*` tests.