### PR TITLE
[s390x CI] Disable scheduled s390x-periodic runs

### DIFF
--- a/.github/workflows/s390x-periodic.yml
+++ b/.github/workflows/s390x-periodic.yml
@@ -1,7 +1,7 @@
 name: s390x-periodic
 
 # DISABLED: this workflow has been failing for months and not providing a useful
-# signal. 
+# signal.
 # Details in the PR description for https://github.com/pytorch/pytorch/pull/181005
 # Re-enable once workflow has been fully fixed and someone is willing to maintain it.
 on:

--- a/.github/workflows/s390x-periodic.yml
+++ b/.github/workflows/s390x-periodic.yml
@@ -1,13 +1,17 @@
 name: s390x-periodic
 
+# TEMPORARILY DISABLED: the s390x runner fleet is serving a stale actions-runner
+# image that doesn't play well with the setup-linux composite action — setup-linux
+# runs `docker system prune -af`, which deletes the preloaded manylinuxs390x-builder
+# image (it is only baked into the runner; it was never published to Docker Hub).
+# See meta-pytorch/pytorch-gha-infra#1107 and PR #181002 for the root cause and fix.
+# The scheduled and ciflow/periodic triggers are removed so this workflow stops
+# failing on every periodic run. Manual dispatch and the ciflow/s390 tag remain
+# available so the IBM s390x maintainer can re-enable testing once the runner
+# image is rebuilt and redeployed.
 on:
-  schedule:
-    # We have several schedules so jobs can check github.event.schedule to activate only for a fraction of the runs.
-    # Also run less frequently on weekends.
-    - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
   push:
     tags:
-      - ciflow/periodic/*
       - ciflow/s390/*
   workflow_dispatch:
 

--- a/.github/workflows/s390x-periodic.yml
+++ b/.github/workflows/s390x-periodic.yml
@@ -1,14 +1,9 @@
 name: s390x-periodic
 
-# TEMPORARILY DISABLED: the s390x runner fleet is serving a stale actions-runner
-# image that doesn't play well with the setup-linux composite action — setup-linux
-# runs `docker system prune -af`, which deletes the preloaded manylinuxs390x-builder
-# image (it is only baked into the runner; it was never published to Docker Hub).
-# See meta-pytorch/pytorch-gha-infra#1107 and PR #181002 for the root cause and fix.
-# The scheduled and ciflow/periodic triggers are removed so this workflow stops
-# failing on every periodic run. Manual dispatch and the ciflow/s390 tag remain
-# available so the IBM s390x maintainer can re-enable testing once the runner
-# image is rebuilt and redeployed.
+# DISABLED: this workflow has been failing for months and not providing a useful
+# signal. 
+# Details in the PR description for https://github.com/pytorch/pytorch/pull/181005
+# Re-enable once workflow has been fully fixed and someone is willing to maintain it.
 on:
   push:
     tags:


### PR DESCRIPTION
## Summary

Goal: Remove a workflow that hasn't provided useful signal in months.

Disables the scheduled and `ciflow/periodic` triggers of `s390x-periodic`. The workflow has been failing on every run since Feb 2nd.


## Failure timeline

The workflow had three distinct failure eras this year:

| Date range | Failure mode |
|---|---|
| Feb 2 – Mar 28 | **Compilation error**: `torch/csrc/distributed/rpc/rpc_agent.cpp` — `std::atomic_load`/`atomic_exchange` deprecated, `-Werror=deprecated-declarations`, exit 1. Unrelated source issue. |
| Mar 29 – Mar 31 | **Missing action**: `Can't find 'action.yml' ... under '.github/actions/reuse-old-whl'. Did you forget to run actions/checkout...` |
| **Apr 1 – present** | **Docker registry access denied**: `Error: initializing source docker://pytorch/manylinuxs390x-builder:cpu-s390x: reading manifest cpu-s390x in docker.io/pytorch/manylinuxs390x-builder: requested access to the resource is denied`, exit 125 |

#### Root cause of the current (Apr 1+) failure described in details below

<details>

The `pytorch/manylinuxs390x-builder:cpu-s390x` image was never meant to be pulled from Docker Hub at runtime. It's built locally on an s390x machine, saved as `manywheel-s390x.tar`, baked into the `actions-runner` container image via `COPY` ([.github/scripts/s390x-ci/self-hosted-builder/actions-runner.Dockerfile](https://github.com/pytorch/pytorch/blob/main/.github/scripts/s390x-ci/self-hosted-builder/actions-runner.Dockerfile)), and loaded at runner startup by `/usr/bin/actions-runner` via `docker image load`. Previously, subsequent `docker run` calls just used the locally-loaded image.

Two commits in pytorch/pytorch shifted the behavior:

1. **Mar 28** — [#177953](https://github.com/pytorch/pytorch/pull/177953) "[OSDC] Update _linux-build workflow for OSDC ARC runners" refactored `_linux-build.yml` to use the `setup-linux` composite action, guarded by `if: build-environment != 'linux-s390x-binary-manywheel'`. Side effect: s390x no longer got a checkout step → Mar 29–31 "missing action" failures.
2. **Mar 31** — [#178831](https://github.com/pytorch/pytorch/pull/178831) "[Bugfix] Use setup-linux everywhere" removed the guard. s390x now runs `setup-linux`, which fixes checkout **but** also triggers this step which fails:

```yaml
# .github/actions/setup-linux/action.yml
- name: Kill any existing containers, clean up images
  if: ${{ steps.check_container_runner.outputs.IN_CONTAINER_RUNNER == 'false' }}
  run: |
    docker stop $(docker ps -q) || true
    docker system prune -af
```

</details>

## This PR

Disables this job's failing noise by removing:

- the `schedule:` cron trigger
- the `ciflow/periodic/*` tag trigger

Keeps:

- `workflow_dispatch` for manual runs
- the `ciflow/s390/*` tag trigger so the s390x maintainer can still invoke it intentionally

cc @AlekseiNikiforovIBM (IBM, s390x CI maintainer) fyi, in case there's interest in maintaining this workflow going forward.