### PR TITLE
[inductor][comms] Optional use of process_group alloc_tensor for collectives

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -973,6 +973,20 @@ class AllocateLine(MemoryPlanningLine):
                 f'group_name="{group_name}", '
                 f"alloc_id={random.randint(0, 2**64 - 1)})"
             )
+        elif comm_buffer_type == ir.CommBufferType.PG_ALLOC:
+            storage_size = V.graph.sizevars.optimization_hint(
+                V.graph.get_allocation_storage_size(self.node)
+            )
+            line = (
+                f"{name} = _pg_alloc_tensor("
+                f"{storage_size}, "
+                f"{dtype}, "
+                f'torch.device("cuda:{device.index}"), '
+                f'"{group_name}")'
+            )
+            # _pg_alloc_tensor returns a 1D flat tensor; reshape if needed
+            if len(shape) > 1:
+                line += f".view({self.wrapper.codegen_shape_tuple(shape)})"
         else:
             raise NotImplementedError(
                 f"Unsupported comm buffer type: {comm_buffer_type}"
@@ -1006,8 +1020,8 @@ class FreeIfNotReusedLine(MemoryPlanningLine):
         if self.node.get_name() in V.graph.removed_buffers:
             return NullLine(self.wrapper)
         if config.allow_buffer_reuse:
-            if self.comm_buffer:
-                # Comm buffers use separate pool (comm-comm reuse only)
+            layout = self.node.get_output_spec()
+            if isinstance(layout, ir.CommBufferLayout):
                 key = comm_buffer_reuse_key(self.node)
                 state.comm_buffer_push(key, self)
             else:
@@ -1019,15 +1033,14 @@ class FreeIfNotReusedLine(MemoryPlanningLine):
         assert self.node.get_name() not in V.graph.removed_buffers
         if not self.is_reused:
             line = self.wrapper.make_buffer_free(self.node)
-            if self.comm_buffer:
-                layout = self.node.get_output_spec()
-                assert isinstance(layout, ir.CommBufferLayout)
+            layout = self.node.get_output_spec()
+            if isinstance(layout, ir.CommBufferLayout):
                 code.writeline(f"{line} # {layout.comm_buffer_type.value} buffer free")
             else:
                 code.writeline(line)
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
-        if self.comm_buffer:
+        if isinstance(self.node.get_output_spec(), ir.CommBufferLayout):
             return converter._generate_comm_buffer_free
         return converter._generate_free_if_not_reused
 
@@ -1407,6 +1420,26 @@ class PythonWrapperCodegen(CodeGen):
             self.header.splice(
                 """
                 empty_strided_p2p = torch._C._distributed_c10d._SymmetricMemory.empty_strided_p2p
+                """,
+                strip=True,
+            )
+        except (AttributeError, ImportError):
+            pass
+        try:
+            # Add _pg_alloc_tensor() for process group-based buffer allocation
+            from torch.distributed.distributed_c10d import (  # noqa: F401
+                _resolve_process_group,
+            )
+
+            self.header.splice(
+                """
+                def _pg_alloc_tensor(numel, dtype, device, group_name):
+                    from torch.distributed.distributed_c10d import _resolve_process_group
+                    _pg = _resolve_process_group(group_name)
+                    _backend = _pg._get_backend(device)
+                    if _backend.supports_tensor_alloc(device) and _backend.is_initialized():
+                        return _backend.allocate_tensor(numel, dtype=dtype, device=device)
+                    return torch.empty(numel, dtype=dtype, device=device)
                 """,
                 strip=True,
             )
@@ -2236,7 +2269,6 @@ class PythonWrapperCodegen(CodeGen):
         _total_allocated_buffer_size = sum(
             s.total_allocated_buffer_size for s in past_planning_states
         )
-
     def run_wrapper_ir_passes(self, is_inference: bool):
         # We disable planning during training because it presently increases peak memory consumption.
         if is_inference and config.memory_planning:

--- a/torch/_inductor/comm_lowering.py
+++ b/torch/_inductor/comm_lowering.py
@@ -189,6 +189,25 @@ def _create_out_of_place(kernel, inputs, *args) -> ir.IRNode:
     return ir.TensorBox.create(node)
 
 
+def _maybe_realize_as_pg_alloc(
+    x: ir.TensorBox,
+    group_name: "torch.distributed.distributed_c10d.GroupName",
+) -> None:
+    """
+    If the current FX node was annotated by the bucketing pass for pg_alloc,
+    realize the buffer as a PG_ALLOC comm buffer. This makes inductor's memory
+    planning allocate the buffer via backend.allocate_tensor() instead of
+    torch.empty().
+    """
+    current_node = getattr(V.graph, "current_node", None)
+    if current_node is None:
+        return
+    if not current_node.meta.get("pg_alloc_group_name"):
+        return
+    if can_realize_as_comm_buffer(x, ir.CommBufferType.PG_ALLOC):
+        realize_as_comm_buffer(x, ir.CommBufferType.PG_ALLOC, group_name)
+
+
 def register_comm_lowerings():
     """
     Register lowerings for the comm subsystem.
@@ -227,6 +246,7 @@ def register_comm_lowerings():
 
         # Lower as c10d.all_reduce_
         inp = clone(inp)
+        _maybe_realize_as_pg_alloc(inp, group_name)
         if config.reorder_for_compute_comm_overlap:
             # The horizontal fusion of this clone often severely delays the
             # scheduling of the all_reduce_ node. Horizontally fusing this
@@ -316,6 +336,7 @@ def register_comm_lowerings():
 
     @register_comm_lowering(c10d.all_gather_into_tensor_out)
     def _all_gather_into_tensor_out(inp, group_size, group_name, *, out):
+        _maybe_realize_as_pg_alloc(out, group_name)
         ir._CollectiveKernel.create_inplace(
             c10d.all_gather_into_tensor_out.default,
             inp,
@@ -327,6 +348,7 @@ def register_comm_lowerings():
 
     @register_comm_lowering(c10d.reduce_scatter_tensor)
     def _reduce_scatter_tensor(inp, reduce_op, group_size, group_name):
+        _maybe_realize_as_pg_alloc(inp, group_name)
         return _create_out_of_place(
             c10d.reduce_scatter_tensor.default,
             inp,
@@ -337,6 +359,8 @@ def register_comm_lowerings():
 
     @register_comm_lowering(c10d.reduce_scatter_tensor_out)
     def _reduce_scatter_tensor_out(inp, reduce_op, group_size, group_name, *, out):
+        _maybe_realize_as_pg_alloc(inp, group_name)
+        _maybe_realize_as_pg_alloc(out, group_name)
         ir._CollectiveKernel.create_inplace(
             c10d.reduce_scatter_tensor_out.default,
             inp,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -462,6 +462,12 @@ bucket_all_reduces_fx: Literal["none", "all"] = "none"
 # By default torch._inductor.fx_passes.bucketing.bucket_size_determinator is used
 bucket_all_reduces_fx_bucket_size_determinator: Callable[[int], int] | None = None
 
+# Use process group allocator for bucketed collective operations.
+# When enabled, allocates memory from the process group's registered allocator
+# (e.g., NCCL's multicast-compatible allocator) which can improve communication
+# performance. Set via config or USE_PG_ALLOC env var.
+comms_use_pg_alloc: bool = os.environ.get("USE_PG_ALLOC", "0") == "1"
+
 # runtime estimation function for ops
 # for built-in estimation function, pass in "default"; for user-defined estimation function, pass in the function handle
 estimate_op_runtime = "default"

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -1,11 +1,13 @@
 import collections
 import logging
+import math
 import operator
 from collections import defaultdict
 from collections.abc import Callable
 from typing import Any, Literal, TypeAlias
 
 import torch
+import torch._inductor.config
 import torch.distributed as dist
 import torch.utils._pytree as pytree
 from torch._dispatch.python import enable_python_dispatcher
@@ -16,6 +18,7 @@ from torch._inductor.comm_analysis import (
 )
 from torch._inductor.runtime.runtime_utils import dynamo_timed
 from torch._logging import trace_structured
+from torch.distributed.distributed_c10d import _resolve_process_group
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.traceback import NodeSource, NodeSourceAction
 from torch.utils._ordered_set import OrderedSet
@@ -582,15 +585,25 @@ def bucket_all_reduce(
 def _pre_bucket_reduce_scatter(
     rs_ins: list[torch.Tensor],
     group_size: int,
+    group_name: str,
 ) -> torch.Tensor:
     rs_ins_flattened = [x.view(group_size, -1) for x in rs_ins]
-    new_rs_in = torch.cat(rs_ins_flattened, dim=1).flatten()
+    x = rs_ins[0]
+    size = sum(t.numel() for t in rs_ins)
+    if torch._inductor.config.comms_use_pg_alloc:
+        pg = _resolve_process_group(group_name)  # type: ignore[arg-type]
+        backend = pg._get_backend(x.device)
+        out = backend.allocate_tensor(size, dtype=x.dtype, device=x.device)
+        new_rs_in = torch.cat(rs_ins_flattened, dim=1, out=out).flatten()
+    else:
+        new_rs_in = torch.cat(rs_ins_flattened, dim=1).flatten()
     return new_rs_in
 
 
 def _pre_bucket_reduce_scatter_fake(
     rs_ins: list[torch.Tensor],
     group_size: int,
+    group_name: str,
 ) -> torch.Tensor:
     out_numel = sum(rs_in.numel() for rs_in in rs_ins)
     return torch.empty((out_numel,), device=rs_ins[0].device, dtype=rs_ins[0].dtype)
@@ -610,15 +623,29 @@ def reduce_scatter_merge_fn_to_trace_custom_ops(
     new_out_sizes = [(x.shape[0] // group_size,) + x.shape[1:] for x in rs_ins]
     new_out_numels = [x.numel() // group_size for x in rs_ins]
 
-    new_rs_in = torch.ops.bucketing._pre_bucket_reduce_scatter(rs_ins, group_size)
-
-    # TODO - either use torch.cat or make sure inductor foreach codegen
-    # fires more reliably
-    new_rs_out = torch.ops.c10d_functional.wait_tensor(
-        torch.ops._c10d_functional.reduce_scatter_tensor.default(
-            new_rs_in, reduce_op, group_size, group_name
-        )
+    new_rs_in = torch.ops.bucketing._pre_bucket_reduce_scatter(
+        rs_ins, group_size, group_name
     )
+
+    if torch._inductor.config.comms_use_pg_alloc:
+        pg = _resolve_process_group(group_name)  # type: ignore[arg-type]
+        backend = pg._get_backend(new_rs_in.device)
+        size = list(new_rs_in.shape)
+        size[0] //= group_size
+        new_rs_out = backend.allocate_tensor(
+            math.prod(size), dtype=new_rs_in.dtype, device=new_rs_in.device
+        ).view(size)
+        torch.ops.c10d_functional.wait_tensor(
+            torch.ops._c10d_functional.reduce_scatter_tensor_out.default(
+                new_rs_in, reduce_op, group_size, group_name, out=new_rs_out
+            )
+        )
+    else:
+        new_rs_out = torch.ops.c10d_functional.wait_tensor(
+            torch.ops._c10d_functional.reduce_scatter_tensor.default(
+                new_rs_in, reduce_op, group_size, group_name
+            )
+        )
     new_out_flat = new_rs_out.split(new_out_numels, 0)
     new_outs = [x.view(s) for x, s in zip(new_out_flat, new_out_sizes)]
     return new_outs
@@ -638,10 +665,13 @@ def reduce_scatter_merge_fn_to_trace(
     new_out_numels = [x.numel() // group_size for x in rs_ins]
 
     new_rs_in = torch.cat(rs_ins_flattened, dim=1).flatten()
+    new_rs_out = torch.empty(
+        new_rs_in.numel() // group_size, dtype=new_rs_in.dtype, device=device
+    )
 
     new_rs_out = torch.ops.c10d_functional.wait_tensor(
-        torch.ops._c10d_functional.reduce_scatter_tensor.default(
-            new_rs_in, reduce_op, group_size, group_name
+        torch.ops._c10d_functional.reduce_scatter_tensor_out.default(
+            new_rs_in, reduce_op, group_size, group_name, out=new_rs_out
         )
     )
     new_out_flat = new_rs_out.split(new_out_numels, 0)
@@ -738,7 +768,18 @@ def _pre_bucket_all_gather(
     ]
     ag_input_numel = sum(ins_split_sizes)
     device = ag_ins[0].device
-    new_ag_out = torch.empty(ag_input_numel * group_size, dtype=dtype, device=device)
+    total_size_bytes = sum(ins_split_sizes_bytes) * group_size
+
+    if torch._inductor.config.comms_use_pg_alloc:
+        pg = _resolve_process_group(group_name)  # type: ignore[arg-type]
+        backend = pg._get_backend(device)
+        size = ag_input_numel * group_size
+        new_ag_out = backend.allocate_tensor(size, dtype=dtype, device=device)
+    else:
+        new_ag_out = torch.empty(
+            ag_input_numel * group_size, dtype=dtype, device=device
+        )
+
     new_ag_in = new_ag_out.narrow(0, ag_input_numel * rank, ag_input_numel)
     foreach_copy_dsts = torch.split(new_ag_in, ins_split_sizes)
     # View each destination slice as its output dtype, then copy
@@ -1113,6 +1154,19 @@ def process_collective_bucket(
     return new_nodes, replacements
 
 
+def _annotate_pg_alloc(
+    new_nodes: list[torch.fx.Node],
+    group_name: str,
+) -> None:
+    """Tag collective nodes with pg_alloc_group_name for PG-based allocation."""
+    if torch._inductor.config.comms_use_pg_alloc:
+        for node in new_nodes:
+            if is_wait_tensor(node):
+                coll_node = node.args[0]
+                assert isinstance(coll_node, torch.fx.Node)
+                coll_node.meta["pg_alloc_group_name"] = group_name
+
+
 def merge_reduce_scatter_bucket(
     g: torch.fx.Graph,
     rs_nodes: list[torch.fx.Node],
@@ -1156,7 +1210,7 @@ def merge_reduce_scatter_bucket(
             device,
         )
 
-    return process_collective_bucket(
+    new_nodes, replacements = process_collective_bucket(
         g,
         rs_nodes,
         rs_merge_fn,
@@ -1164,6 +1218,10 @@ def merge_reduce_scatter_bucket(
         insert_before=insert_before,
         wait_insertion_point=wait_insertion_point,
     )
+
+    _annotate_pg_alloc(new_nodes, group_name)
+
+    return new_nodes, replacements
 
 
 def merge_all_reduce_bucket(
@@ -1199,7 +1257,7 @@ def merge_all_reduce_bucket(
             device,
         )
 
-    return process_collective_bucket(
+    new_nodes, replacements = process_collective_bucket(
         g,
         ar_nodes,
         ar_merge_fn,
@@ -1207,6 +1265,10 @@ def merge_all_reduce_bucket(
         insert_before=insert_before,
         wait_insertion_point=wait_insertion_point,
     )
+
+    _annotate_pg_alloc(new_nodes, group_name)
+
+    return new_nodes, replacements
 
 
 def merge_all_gather_bucket(
@@ -1251,13 +1313,17 @@ def merge_all_gather_bucket(
             rank,
         )
 
-    return process_collective_bucket(
+    new_nodes, replacements = process_collective_bucket(
         g,
         ag_nodes,
         ag_merge_fn,
         create_trace_args,
         wait_insertion_point=wait_insertion_point,
     )
+
+    _annotate_pg_alloc(new_nodes, group_name)
+
+    return new_nodes, replacements
 
 
 def merge_reduce_scatter(

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -4441,6 +4441,7 @@ class NonOwningLayout(Layout):
 
 class CommBufferType(Enum):
     SYMM_MEM = "symm_mem"
+    PG_ALLOC = "pg_alloc"
 
 
 class CommBufferLayout(FixedLayout):

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -503,6 +503,12 @@ class TORCH_API Backend : public torch::CustomClassHolder {
     return false;
   }
 
+  // Returns true if backend is fully initialized and ready for allocateTensor.
+  // Backends with lazy initialization (e.g. NCCL) should override this.
+  virtual bool isInitialized() {
+    return true;
+  }
+
   // Aborts all pending operations and connections in the backend if the backend
   // supports it.
   virtual void abort() {}

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -996,7 +996,7 @@ class TORCH_API ProcessGroupNCCL : public Backend {
   void performNocolorSplit(at::Device device);
 
   // If all comms on this PG are fully initialized, return true.
-  bool isInitialized();
+  bool isInitialized() override;
 
   ErrorType getError() override;
 

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3183,6 +3183,10 @@ Arguments:
               py::arg("device"),
               py::call_guard<py::gil_scoped_release>())
           .def(
+              "is_initialized",
+              &::c10d::Backend::isInitialized,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
               "allocate_tensor",
               [](::c10d::Backend& self,
                  long size,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181010
* #181009
* #181008
* __->__ #181007

  C++ backend (Backend.hpp, ProcessGroupNCCL.hpp, init.cpp)

  - Adds isInitialized() virtual method to Backend base class (default: true). ProcessGroupNCCL overrides it (already had the method, now marked override) since NCCL initializes lazily.
  - Exposes is_initialized() to Python via pybind. The existing allocate_tensor() and supports_tensor_alloc() bindings were already present.

  FX bucketing pass (bucketing.py)

  Two-part change: (1) pre-allocate merged buffers via the backend, and (2) annotate nodes for the lowering pass.

  Pre-allocation in bucketing: When pg_alloc is enabled, the three merge functions resolve the process group and allocate merged buffers through backend.allocate_tensor():
  - _pre_bucket_all_gather: allocates the all-gather output buffer via the backend instead of torch.empty().
  - _pre_bucket_reduce_scatter / reduce_scatter_merge_fn_to_trace_custom_ops: allocates both the concatenated input buffer (via torch.cat(..., out=backend_tensor)) and the reduce-scatter output buffer via the backend. Uses reduce_scatter_tensor_out variant to write into the pre-allocated output.
  - reduce_scatter_merge_fn_to_trace (non-custom-ops path): switches to reduce_scatter_tensor_out to support pre-allocated output buffers.

  Node annotation: _annotate_pg_alloc() is called after each process_collective_bucket() in merge_reduce_scatter_bucket, merge_all_reduce_bucket, and merge_all_gather_bucket. It walks the newly created nodes, finds wait tensors, and sets coll_node.meta["pg_alloc_group_name"] = group_name on the underlying collective node. This metadata signals to the lowering
  pass that the buffer should use pg_alloc.

  Inductor lowering (comm_lowering.py)

  _maybe_realize_as_pg_alloc() is called from each collective lowering (_all_reduce, _all_gather_into_tensor_out, _reduce_scatter_tensor, _reduce_scatter_tensor_out). It checks if the current FX node was annotated with pg_alloc_group_name by the bucketing pass, and if the buffer is eligible (via the existing can_realize_as_comm_buffer check), realizes it as a
  PG_ALLOC comm buffer. This changes the buffer's layout to CommBufferLayout, which tells the memory planner to use persistent allocation and the codegen to emit backend-allocated code.

  Codegen (wrapper.py)

  - PythonWrapperCodegen injects a _pg_alloc_tensor() helper into the generated code header. At runtime, it resolves the process group, gets the backend, and calls backend.allocate_tensor() if supported and initialized, otherwise falls back to torch.empty().
  - AllocateLine._codegen_comm_buffer() handles PG_ALLOC buffers by emitting _pg_alloc_tensor(numel, dtype, device, group_name) calls. Since the backend returns a flat 1D tensor, a .view() is appended for multi-dimensional shapes.
  - FreeIfNotReusedLine is updated to check the node's layout type (CommBufferLayout) instead of the comm_buffer flag, so PG_ALLOC buffers participate correctly in comm buffer reuse planning and free codegen.

  IR (ir.py)

  Adds PG_ALLOC = "pg_alloc" to the CommBufferType enum alongside the existing SYMM_MEM.

  Config (config.py)

  Adds comms_use_pg_alloc: bool config, controlled by USE_PG_ALLOC env var (default: disabled).



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo