### PR TITLE
[inductor][comms] memory budget for pg allocs

### DIFF
--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -449,6 +449,9 @@ class MemoryPlanningState:
             CommBufferReuseKey, list[FreeIfNotReusedLine]
         ] = collections.defaultdict(list)
         self.total_allocated_buffer_size: int = 0
+        self.total_pg_alloc_bytes: int = 0
+        # Buffers that fell back from pg_alloc due to budget — freed as regular
+        self.pg_alloc_fallback_bufs: OrderedSet[str] = OrderedSet()
 
     def __contains__(self, key: ReuseKey) -> bool:
         return bool(self.reuse_pool.get(key, None))
@@ -913,7 +916,36 @@ class AllocateLine(MemoryPlanningLine):
                 return ReuseLine(
                     self.wrapper, free_line.node, self.node, comm_buffer=True
                 )
-            return self
+
+            # Only PG_ALLOC buffers have a budget limit
+            layout = self.node.get_output_spec()
+            if not isinstance(layout, ir.CommBufferLayout):
+                return self
+            if layout.comm_buffer_type != ir.CommBufferType.PG_ALLOC:
+                return self
+
+            exceeds, alloc_bytes = self._pg_alloc_exceeds_budget(state)
+            if not exceeds:
+                state.total_pg_alloc_bytes += alloc_bytes
+                log.debug(
+                    "pg_alloc new buffer: %s, size=%.2f MB, total_pg_alloc=%.2f MB",
+                    self.node.get_name(),
+                    alloc_bytes / (1024 * 1024),
+                    state.total_pg_alloc_bytes / (1024 * 1024),
+                )
+                return self
+
+            # Budget exceeded — fallback to regular alloc and fall through
+            log.debug(
+                "pg_alloc budget exceeded, fallback: %s, size=%.2f MB, "
+                "total_pg_alloc=%.2f MB, max=%s GB",
+                self.node.get_name(),
+                alloc_bytes / (1024 * 1024),
+                state.total_pg_alloc_bytes / (1024 * 1024),
+                config.comms_pg_alloc_max_gb,
+            )
+            self.comm_buffer = False
+            state.pg_alloc_fallback_bufs.add(self.node.get_name())
 
         # Regular buffer reuse
         # Stream is part of the key, so cross-stream reuse is naturally prevented.
@@ -939,6 +971,16 @@ class AllocateLine(MemoryPlanningLine):
                 )
 
         return self
+
+    def _pg_alloc_exceeds_budget(self, state: MemoryPlanningState) -> tuple[bool, int]:
+        alloc_bytes = V.graph.sizevars.optimization_hint(
+            V.graph.get_allocation_storage_size(self.node), fallback=0
+        ) * get_dtype_size(self.node.get_dtype())
+        max_gb = config.comms_pg_alloc_max_gb
+        exceeds = max_gb is not None and (
+            state.total_pg_alloc_bytes + alloc_bytes > int(max_gb * (1024**3))
+        )
+        return exceeds, alloc_bytes
 
     def codegen(self, code: IndentedBuffer) -> None:
         assert self.node.get_name() not in V.graph.removed_buffers
@@ -1020,8 +1062,11 @@ class FreeIfNotReusedLine(MemoryPlanningLine):
         if self.node.get_name() in V.graph.removed_buffers:
             return NullLine(self.wrapper)
         if config.allow_buffer_reuse:
-            layout = self.node.get_output_spec()
-            if isinstance(layout, ir.CommBufferLayout):
+            buf_name = self.node.get_name()
+            if (
+                isinstance(self.node.get_output_spec(), ir.CommBufferLayout)
+                and buf_name not in state.pg_alloc_fallback_bufs
+            ):
                 key = comm_buffer_reuse_key(self.node)
                 state.comm_buffer_push(key, self)
             else:
@@ -2269,6 +2314,7 @@ class PythonWrapperCodegen(CodeGen):
         _total_allocated_buffer_size = sum(
             s.total_allocated_buffer_size for s in past_planning_states
         )
+
     def run_wrapper_ir_passes(self, is_inference: bool):
         # We disable planning during training because it presently increases peak memory consumption.
         if is_inference and config.memory_planning:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -468,6 +468,12 @@ bucket_all_reduces_fx_bucket_size_determinator: Callable[[int], int] | None = No
 # performance. Set via config or USE_PG_ALLOC env var.
 comms_use_pg_alloc: bool = os.environ.get("USE_PG_ALLOC", "0") == "1"
 
+# Max pg_alloc memory (GB). Allocations exceeding this fall back to torch.empty().
+# None means no limit.
+comms_pg_alloc_max_gb: float | None = (
+    float(v) if (v := os.environ.get("USE_PG_ALLOC_MAX_GB")) else None
+)
+
 # runtime estimation function for ops
 # for built-in estimation function, pass in "default"; for user-defined estimation function, pass in the function handle
 estimate_op_runtime = "default"

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -768,8 +768,6 @@ def _pre_bucket_all_gather(
     ]
     ag_input_numel = sum(ins_split_sizes)
     device = ag_ins[0].device
-    total_size_bytes = sum(ins_split_sizes_bytes) * group_size
-
     if torch._inductor.config.comms_use_pg_alloc:
         pg = _resolve_process_group(group_name)  # type: ignore[arg-type]
         backend = pg._get_backend(device)
@@ -1179,6 +1177,7 @@ def merge_reduce_scatter_bucket(
     rs0 = rs_nodes[0]
     rs0_val = rs0.meta["val"]
     _, reduce_op, group_size, group_name = rs0.args
+    assert isinstance(group_name, str)
     reduce_dtype = rs0_val.dtype
     device = rs0_val.device
 
@@ -1234,6 +1233,7 @@ def merge_all_reduce_bucket(
     ar0 = ar_nodes[0]
     ar0_val = ar0.meta["val"]
     _, reduce_op, group_name = ar0.args
+    assert isinstance(group_name, str)
     reduce_dtype = ar0_val.dtype
     device = ar0_val.device
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181010
* #181009
* __->__ #181008
* #181007

  Summary

  Adds a configurable memory budget for pg_alloc allocations. When the cumulative pg_alloc memory exceeds the budget, new allocations fall back to regular torch.empty(), preventing over-commitment to NCCL-registered memory on large models.

  Gated behind USE_PG_ALLOC_MAX_GB / torch._inductor.config.comms_pg_alloc_max_gb (default: None = no limit).

  Implementation

  Memory planning budget check (wrapper.py — AllocateLine.plan())

  After the existing comm-comm reuse check, the plan method now inspects whether the buffer is a PG_ALLOC type (non-PG_ALLOC comm buffers like SYMM_MEM are unaffected and return early). For PG_ALLOC buffers, _pg_alloc_exceeds_budget() computes the allocation size in bytes and compares state.total_pg_alloc_bytes + alloc_bytes against the configured limit.

  - Within budget: increments state.total_pg_alloc_bytes and returns the allocation as a comm buffer (allocated via the backend).
  - Budget exceeded: sets self.comm_buffer = False so the codegen emits a regular torch.empty() instead of _pg_alloc_tensor(), and falls through to the regular buffer reuse logic.

  Correct free-pool routing for fallback buffers (wrapper.py — FreeIfNotReusedLine.plan())

  When a PG_ALLOC buffer falls back to regular allocation, the node still carries a CommBufferLayout (the layout is set at lowering time, before memory planning). Without correction, FreeIfNotReusedLine.plan() would see the CommBufferLayout and push the freed buffer into the comm reuse pool, where it would never be matched by future regular allocations —
  effectively leaking it from the reuse system.

  To fix this, MemoryPlanningState tracks fallen-back buffer names in pg_alloc_fallback_bufs. When AllocateLine.plan() triggers a budget fallback, it adds the buffer name to this set. FreeIfNotReusedLine.plan() checks the set and routes fallback buffers to the regular reuse pool instead of the comm pool.

  Config (config.py)

  Adds comms_pg_alloc_max_gb: float | None, read from USE_PG_ALLOC_MAX_GB env var. None means no limit.

  Bucketing cleanup (bucketing.py)

  Removes unused total_size_bytes variable in _pre_bucket_all_gather. Adds assert isinstance(group_name, str) in merge_reduce_scatter_bucket and merge_all_reduce_bucket for type safety.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo