### PR TITLE
[inductor][comms] pg_alloc config for strategies

### DIFF
--- a/torch/_inductor/comm_lowering.py
+++ b/torch/_inductor/comm_lowering.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import logging
+from typing import Literal
 
 import torch
 import torch.utils._pytree as pytree
@@ -189,6 +190,32 @@ def _create_out_of_place(kernel, inputs, *args) -> ir.IRNode:
     return ir.TensorBox.create(node)
 
 
+def _should_pg_alloc(
+    collective_type: str,
+    buffer_role: Literal["input", "output"],
+) -> bool:
+    if not config.comms_use_pg_alloc:
+        return False
+    if collective_type not in ("all_gather", "reduce_scatter", "all_reduce"):
+        return False
+    strategy = config.comms_use_pg_alloc_strategy
+    if strategy is None:
+        return True
+    tokens = OrderedSet([t.strip() for t in strategy.split(",")])
+    if "only_all_gather" in tokens and collective_type != "all_gather":
+        return False
+    if "only_reduce" in tokens and collective_type not in (
+        "reduce_scatter",
+        "all_reduce",
+    ):
+        return False
+    if "only_inputs" in tokens and buffer_role != "input":
+        return False
+    if "only_outputs" in tokens and buffer_role != "output":
+        return False
+    return True
+
+
 def _maybe_realize_as_pg_alloc(
     x: ir.TensorBox,
     group_name: "torch.distributed.distributed_c10d.GroupName",
@@ -246,7 +273,8 @@ def register_comm_lowerings():
 
         # Lower as c10d.all_reduce_
         inp = clone(inp)
-        _maybe_realize_as_pg_alloc(inp, group_name)
+        if _should_pg_alloc("all_reduce", "input"):
+            _maybe_realize_as_pg_alloc(inp, group_name)
         if config.reorder_for_compute_comm_overlap:
             # The horizontal fusion of this clone often severely delays the
             # scheduling of the all_reduce_ node. Horizontally fusing this
@@ -336,7 +364,8 @@ def register_comm_lowerings():
 
     @register_comm_lowering(c10d.all_gather_into_tensor_out)
     def _all_gather_into_tensor_out(inp, group_size, group_name, *, out):
-        _maybe_realize_as_pg_alloc(out, group_name)
+        if _should_pg_alloc("all_gather", "output"):
+            _maybe_realize_as_pg_alloc(out, group_name)
         ir._CollectiveKernel.create_inplace(
             c10d.all_gather_into_tensor_out.default,
             inp,
@@ -348,7 +377,8 @@ def register_comm_lowerings():
 
     @register_comm_lowering(c10d.reduce_scatter_tensor)
     def _reduce_scatter_tensor(inp, reduce_op, group_size, group_name):
-        _maybe_realize_as_pg_alloc(inp, group_name)
+        if _should_pg_alloc("reduce_scatter", "input"):
+            _maybe_realize_as_pg_alloc(inp, group_name)
         return _create_out_of_place(
             c10d.reduce_scatter_tensor.default,
             inp,
@@ -359,8 +389,10 @@ def register_comm_lowerings():
 
     @register_comm_lowering(c10d.reduce_scatter_tensor_out)
     def _reduce_scatter_tensor_out(inp, reduce_op, group_size, group_name, *, out):
-        _maybe_realize_as_pg_alloc(inp, group_name)
-        _maybe_realize_as_pg_alloc(out, group_name)
+        if _should_pg_alloc("reduce_scatter", "input"):
+            _maybe_realize_as_pg_alloc(inp, group_name)
+        if _should_pg_alloc("reduce_scatter", "output"):
+            _maybe_realize_as_pg_alloc(out, group_name)
         ir._CollectiveKernel.create_inplace(
             c10d.reduce_scatter_tensor_out.default,
             inp,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -474,6 +474,11 @@ comms_pg_alloc_max_gb: float | None = (
     float(v) if (v := os.environ.get("USE_PG_ALLOC_MAX_GB")) else None
 )
 
+# Strategy for pg_alloc. None = inductor decides where to apply pg_alloc (all buffers for now).
+# Tokens: "only_all_gather", "only_reduce", "only_inputs", "only_outputs"
+# Combine with comma: "only_all_gather,only_outputs"
+comms_use_pg_alloc_strategy: str | None = os.environ.get("USE_PG_ALLOC_STRATEGY", None)
+
 # runtime estimation function for ops
 # for built-in estimation function, pass in "default"; for user-defined estimation function, pass in the function handle
 estimate_op_runtime = "default"

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -16,6 +16,7 @@ from torch._inductor.comm_analysis import (
     get_collective_type_from_kernel_name,
     NCCL_COLL,
 )
+from torch._inductor.comm_lowering import _should_pg_alloc
 from torch._inductor.runtime.runtime_utils import dynamo_timed
 from torch._logging import trace_structured
 from torch.distributed.distributed_c10d import _resolve_process_group
@@ -262,9 +263,9 @@ def is_all_gather_into_tensor(node: torch.fx.Node) -> bool:  # type: ignore[arg-
 
 
 def is_reduce_scatter_tensor(node: torch.fx.Node) -> bool:
-    return (
-        node.op == "call_function"
-        and node.target is torch.ops._c10d_functional.reduce_scatter_tensor.default
+    return node.op == "call_function" and (
+        node.target is torch.ops._c10d_functional.reduce_scatter_tensor.default
+        or node.target is torch.ops._c10d_functional.reduce_scatter_tensor_out.default
     )
 
 
@@ -590,7 +591,7 @@ def _pre_bucket_reduce_scatter(
     rs_ins_flattened = [x.view(group_size, -1) for x in rs_ins]
     x = rs_ins[0]
     size = sum(t.numel() for t in rs_ins)
-    if torch._inductor.config.comms_use_pg_alloc:
+    if _should_pg_alloc("reduce_scatter", "input"):
         pg = _resolve_process_group(group_name)  # type: ignore[arg-type]
         backend = pg._get_backend(x.device)
         out = backend.allocate_tensor(size, dtype=x.dtype, device=x.device)
@@ -627,7 +628,7 @@ def reduce_scatter_merge_fn_to_trace_custom_ops(
         rs_ins, group_size, group_name
     )
 
-    if torch._inductor.config.comms_use_pg_alloc:
+    if _should_pg_alloc("reduce_scatter", "output"):
         pg = _resolve_process_group(group_name)  # type: ignore[arg-type]
         backend = pg._get_backend(new_rs_in.device)
         size = list(new_rs_in.shape)
@@ -768,7 +769,7 @@ def _pre_bucket_all_gather(
     ]
     ag_input_numel = sum(ins_split_sizes)
     device = ag_ins[0].device
-    if torch._inductor.config.comms_use_pg_alloc:
+    if _should_pg_alloc("all_gather", "output"):
         pg = _resolve_process_group(group_name)  # type: ignore[arg-type]
         backend = pg._get_backend(device)
         size = ag_input_numel * group_size
@@ -1157,11 +1158,16 @@ def _annotate_pg_alloc(
     group_name: str,
 ) -> None:
     """Tag collective nodes with pg_alloc_group_name for PG-based allocation."""
-    if torch._inductor.config.comms_use_pg_alloc:
-        for node in new_nodes:
-            if is_wait_tensor(node):
-                coll_node = node.args[0]
-                assert isinstance(coll_node, torch.fx.Node)
+    if not torch._inductor.config.comms_use_pg_alloc:
+        return
+    for node in new_nodes:
+        if is_wait_tensor(node):
+            coll_node = node.args[0]
+            assert isinstance(coll_node, torch.fx.Node)
+            coll_type = get_collective_type(coll_node)
+            if _should_pg_alloc(coll_type, "input") or _should_pg_alloc(
+                coll_type, "output"
+            ):
                 coll_node.meta["pg_alloc_group_name"] = group_name
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

  Summary

  Adds fine-grained control over which collective types and buffer roles use pg_alloc. Instead of the all-or-nothing comms_use_pg_alloc toggle, users can now selectively enable pg_alloc for specific combinations (e.g., only all-gather outputs, only reduce-scatter inputs).

  Configured via USE_PG_ALLOC_STRATEGY / torch._inductor.config.comms_use_pg_alloc_strategy (default: None = all eligible buffers).

  Implementation

  Central strategy check (comm_lowering.py — _should_pg_alloc())

  Introduces _should_pg_alloc(collective_type, buffer_role) as the single entry point for all pg_alloc decisions. It takes a collective type ("all_gather", "reduce_scatter", "all_reduce") and a buffer role ("input", "output").

  The function first checks the global comms_use_pg_alloc toggle, then rejects unknown collective types. If a strategy string is configured, it splits it on commas into an OrderedSet of tokens and applies exclusion filters:
  - only_all_gather — disables pg_alloc for reduce_scatter and all_reduce
  - only_reduce — disables pg_alloc for all_gather
  - only_inputs — disables pg_alloc for output buffers
  - only_outputs — disables pg_alloc for input buffers

  Tokens compose: "only_all_gather,only_outputs" means only all-gather output buffers use pg_alloc.

  Lowering callsites (comm_lowering.py)

  Each collective lowering now wraps the _maybe_realize_as_pg_alloc() call with _should_pg_alloc():
  - _all_reduce: guarded with _should_pg_alloc("all_reduce", "input")
  - _all_gather_into_tensor_out: guarded with _should_pg_alloc("all_gather", "output")
  - _reduce_scatter_tensor: guarded with _should_pg_alloc("reduce_scatter", "input")
  - _reduce_scatter_tensor_out: input and output guarded separately

  Bucketing callsites (bucketing.py)

  The bucketing pass had three sites using torch._inductor.config.comms_use_pg_alloc directly to decide whether to pre-allocate merged buffers via the backend. These are replaced with _should_pg_alloc() calls with the appropriate collective type and buffer role:
  - _pre_bucket_reduce_scatter: _should_pg_alloc("reduce_scatter", "input")
  - reduce_scatter_merge_fn_to_trace_custom_ops: _should_pg_alloc("reduce_scatter", "output")
  - _pre_bucket_all_gather: _should_pg_alloc("all_gather", "output")

  Node annotation (bucketing.py — _annotate_pg_alloc())

  Previously annotated all collective nodes unconditionally when pg_alloc was enabled. Now adds an early return when comms_use_pg_alloc is False (avoids unnecessary iteration in the common case), and for each collective node calls _should_pg_alloc() with both "input" and "output" roles — the node is annotated only if at least one role applies. Uses
  get_collective_type() to determine the collective type from the node.

  is_reduce_scatter_tensor() (bucketing.py)

  Extended to also match reduce_scatter_tensor_out nodes, which are used when pg_alloc pre-allocates the output buffer.

  Config (config.py)

  Adds comms_use_pg_alloc_strategy: str | None, read from USE_PG_ALLOC_STRATEGY env var.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo