### PR TITLE
[inductor][comms] allow compute to borrow memory from pg_alloc mempool

### DIFF
--- a/test/inductor/test_pg_alloc_borrow.py
+++ b/test/inductor/test_pg_alloc_borrow.py
@@ -1,0 +1,252 @@
+# Owner(s): ["module: inductor"]
+
+from unittest.mock import MagicMock
+
+import torch
+from torch._inductor import ir
+from torch._inductor.codegen.wrapper import (
+    BorrowMatchKey,
+    CommBufferReuseKey,
+    FreeIfNotReusedLine,
+    MemoryPlanningState,
+)
+from torch._inductor.test_case import run_tests, TestCase
+
+
+class TestPgAllocBorrowState(TestCase):
+    def _make_comm_key(
+        self, size_str: str = "1024", group: str = "default_pg"
+    ) -> CommBufferReuseKey:
+        return (
+            torch.device("cuda:0"),
+            torch.bfloat16,
+            size_str,
+            ir.CommBufferType.PG_ALLOC,
+            group,
+        )
+
+    def _make_mock_free_line(self, name: str = "buf") -> FreeIfNotReusedLine:
+        line = MagicMock(spec=FreeIfNotReusedLine)
+        line.is_reused = False
+        line.node = MagicMock()
+        line.node.get_name.return_value = name
+        return line
+
+    def test_comm_pool_match_key_index_push(self):
+        """Push updates comm_pool_by_match_key."""
+        state = MemoryPlanningState()
+        comm_key = self._make_comm_key()
+        match_key: BorrowMatchKey = (
+            torch.device("cuda:0"),
+            torch.bfloat16,
+            "1024",
+        )
+
+        free_line = self._make_mock_free_line("comm_0")
+        state.comm_buffer_push(comm_key, free_line)
+
+        self.assertIn(match_key, state.comm_pool_by_match_key)
+        self.assertEqual(len(state.comm_pool_by_match_key[match_key]), 1)
+        self.assertTrue(state.comm_buffer_contains(comm_key))
+
+    def test_comm_pool_match_key_index_pop(self):
+        """Pop updates comm_pool_by_match_key."""
+        state = MemoryPlanningState()
+        comm_key = self._make_comm_key()
+        match_key: BorrowMatchKey = (
+            torch.device("cuda:0"),
+            torch.bfloat16,
+            "1024",
+        )
+
+        free_line = self._make_mock_free_line("comm_0")
+        state.comm_buffer_push(comm_key, free_line)
+        popped = state.comm_buffer_pop(comm_key)
+
+        self.assertIs(popped, free_line)
+        self.assertEqual(len(state.comm_pool_by_match_key[match_key]), 0)
+        self.assertFalse(state.comm_buffer_contains(comm_key))
+
+    def test_borrowed_comm_keys_roundtrip(self):
+        """borrowed_comm_keys tracks borrows and returns."""
+        state = MemoryPlanningState()
+        comm_key = self._make_comm_key()
+
+        state.borrowed_comm_keys["regular_buf_0"] = comm_key
+        self.assertIn("regular_buf_0", state.borrowed_comm_keys)
+
+        key = state.borrowed_comm_keys.pop("regular_buf_0")
+        self.assertEqual(key, comm_key)
+        self.assertNotIn("regular_buf_0", state.borrowed_comm_keys)
+
+    def test_borrow_return_to_comm_pool(self):
+        """Buffer borrowed from comm pool is returned there on free."""
+        state = MemoryPlanningState()
+        comm_key = self._make_comm_key()
+
+        # Simulate: comm buffer freed -> in comm pool
+        comm_free = self._make_mock_free_line("comm_0")
+        state.comm_buffer_push(comm_key, comm_free)
+
+        # Simulate borrow: pop from comm pool, record in borrowed_comm_keys
+        popped = state.comm_buffer_pop(comm_key)
+        popped.is_reused = True
+        state.borrowed_comm_keys["regular_buf"] = comm_key
+
+        # Comm pool should be empty now
+        self.assertFalse(state.comm_buffer_contains(comm_key))
+
+        # Simulate regular buffer free -> should return to comm pool
+        regular_free = self._make_mock_free_line("regular_buf")
+        borrowed_key = state.borrowed_comm_keys.pop("regular_buf")
+        state.comm_buffer_push(borrowed_key, regular_free)
+
+        # Comm pool should have it back
+        self.assertTrue(state.comm_buffer_contains(comm_key))
+
+    def test_multiple_borrows_same_key(self):
+        """Multiple sequential borrows from the same comm key work."""
+        state = MemoryPlanningState()
+        comm_key = self._make_comm_key()
+
+        # Initial comm buffer in pool
+        comm_free = self._make_mock_free_line("comm_0")
+        state.comm_buffer_push(comm_key, comm_free)
+
+        # First borrow
+        popped = state.comm_buffer_pop(comm_key)
+        popped.is_reused = True
+        state.borrowed_comm_keys["reg_0"] = comm_key
+        self.assertFalse(state.comm_buffer_contains(comm_key))
+
+        # Return first borrow
+        reg_free_0 = self._make_mock_free_line("reg_0")
+        key = state.borrowed_comm_keys.pop("reg_0")
+        state.comm_buffer_push(key, reg_free_0)
+        self.assertTrue(state.comm_buffer_contains(comm_key))
+
+        # Second borrow
+        popped2 = state.comm_buffer_pop(comm_key)
+        popped2.is_reused = True
+        state.borrowed_comm_keys["reg_1"] = comm_key
+        self.assertFalse(state.comm_buffer_contains(comm_key))
+
+        # Return second borrow
+        reg_free_1 = self._make_mock_free_line("reg_1")
+        key = state.borrowed_comm_keys.pop("reg_1")
+        state.comm_buffer_push(key, reg_free_1)
+        self.assertTrue(state.comm_buffer_contains(comm_key))
+
+    def test_different_groups_not_mixed(self):
+        """Buffers from different process groups stay separate."""
+        state = MemoryPlanningState()
+        key_g1 = self._make_comm_key(group="group_1")
+        key_g2 = self._make_comm_key(group="group_2")
+
+        state.comm_buffer_push(key_g1, self._make_mock_free_line("c1"))
+        state.comm_buffer_push(key_g2, self._make_mock_free_line("c2"))
+
+        self.assertTrue(state.comm_buffer_contains(key_g1))
+        self.assertTrue(state.comm_buffer_contains(key_g2))
+
+        state.comm_buffer_pop(key_g1)
+        self.assertFalse(state.comm_buffer_contains(key_g1))
+        self.assertTrue(state.comm_buffer_contains(key_g2))
+
+    def test_symm_mem_not_borrowed(self):
+        """SYMM_MEM buffers should not be candidates for borrowing."""
+        state = MemoryPlanningState()
+        symm_key: CommBufferReuseKey = (
+            torch.device("cuda:0"),
+            torch.bfloat16,
+            "1024",
+            ir.CommBufferType.SYMM_MEM,
+            "default_pg",
+        )
+        match_key: BorrowMatchKey = (
+            torch.device("cuda:0"),
+            torch.bfloat16,
+            "1024",
+        )
+
+        state.comm_buffer_push(symm_key, self._make_mock_free_line("s0"))
+
+        # Match key index should have it
+        self.assertIn(match_key, state.comm_pool_by_match_key)
+
+        # But the key type is SYMM_MEM, which _try_borrow_from_comm_pool
+        # should skip (checked in AllocateLine._try_borrow_from_comm_pool)
+        # Here we just verify the key is present but type is SYMM_MEM
+        keys_for_match = state.comm_pool_by_match_key[match_key]
+        self.assertEqual(len(keys_for_match), 1)
+        self.assertEqual(keys_for_match[0][3], ir.CommBufferType.SYMM_MEM)
+
+    def test_demand_schedule_bisect(self):
+        """Verify bisect logic for finding next comm demand."""
+        import bisect
+
+        demand_snis = [5, 15, 25, 35]
+
+        # At sni=3, next demand is at 5
+        idx = bisect.bisect_right(demand_snis, 3)
+        self.assertEqual(demand_snis[idx], 5)
+
+        # At sni=5, next demand is at 15
+        idx = bisect.bisect_right(demand_snis, 5)
+        self.assertEqual(demand_snis[idx], 15)
+
+        # At sni=10, next demand is at 15
+        idx = bisect.bisect_right(demand_snis, 10)
+        self.assertEqual(demand_snis[idx], 15)
+
+        # At sni=35, no next demand
+        idx = bisect.bisect_right(demand_snis, 35)
+        self.assertEqual(idx, len(demand_snis))
+
+    def test_borrow_safe_when_freed_before_demand(self):
+        """Borrow is safe: free_sni < next_comm_sni."""
+        # This tests the condition checked in _try_borrow_from_comm_pool
+        import bisect
+
+        demand_snis = [5, 20, 40]
+        current_sni = 7  # Borrowing at step 7
+        free_sni = 15  # Buffer freed at step 15
+
+        # Next demand after current (7) is at 20
+        idx = bisect.bisect_right(demand_snis, current_sni)
+        next_comm_sni = demand_snis[idx]
+        self.assertEqual(next_comm_sni, 20)
+
+        # free_sni (15) < next_comm_sni (20) -> safe
+        self.assertTrue(free_sni < next_comm_sni)
+
+    def test_borrow_unsafe_when_freed_after_demand(self):
+        """Borrow is unsafe: free_sni >= next_comm_sni."""
+        import bisect
+
+        demand_snis = [5, 20, 40]
+        current_sni = 7
+        free_sni = 25  # Freed AFTER next demand at 20
+
+        idx = bisect.bisect_right(demand_snis, current_sni)
+        next_comm_sni = demand_snis[idx]
+        self.assertEqual(next_comm_sni, 20)
+
+        # free_sni (25) >= next_comm_sni (20) -> unsafe
+        self.assertFalse(free_sni < next_comm_sni)
+
+    def test_borrow_safe_no_future_demand(self):
+        """Borrow is always safe when no future comm demand exists."""
+        import bisect
+
+        demand_snis = [5]
+        current_sni = 10
+
+        idx = bisect.bisect_right(demand_snis, current_sni)
+        # No more demands
+        self.assertEqual(idx, len(demand_snis))
+        # next_comm_sni is None -> always safe
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+import bisect
 import collections
 import contextlib
 import dataclasses
@@ -95,6 +96,8 @@ pexpr = PythonPrinter().doprint
 
 ReuseKey = tuple[torch.device, torch.dtype, str, bool, int]
 CommBufferReuseKey = tuple[torch.device, torch.dtype, str, "ir.CommBufferType", str]
+# Key for matching regular buffers to comm buffers: (device, dtype, size_str)
+BorrowMatchKey = tuple[torch.device, torch.dtype, str]
 BufferLike = ir.Buffer | WorkspaceArg
 FxConversionFunc = Callable[["WrapperLine"], None]
 
@@ -453,6 +456,19 @@ class MemoryPlanningState:
         # Buffers that fell back from pg_alloc due to budget — freed as regular
         self.pg_alloc_fallback_bufs: OrderedSet[str] = OrderedSet()
 
+        # Cross-pool borrowing state
+        self.borrowed_comm_keys: dict[str, CommBufferReuseKey] = {}
+        self.comm_pool_by_match_key: dict[BorrowMatchKey, list[CommBufferReuseKey]] = (
+            collections.defaultdict(list)
+        )
+        # Pre-computed schedules (populated by _prescan_borrow_schedules)
+        self.comm_demand_schedule: dict[CommBufferReuseKey, list[int]] = {}
+        self.comm_free_schedule: dict[CommBufferReuseKey, list[int]] = {}
+        self.buffer_free_sni: dict[str, int] = {}
+        self.regular_alloc_schedule: dict[ReuseKey, list[int]] = {}
+        self.peak_live_buffers: OrderedSet[str] | None = None
+        self.borrow_plan: dict[str, CommBufferReuseKey] | None = None
+
     def __contains__(self, key: ReuseKey) -> bool:
         return bool(self.reuse_pool.get(key, None))
 
@@ -471,6 +487,10 @@ class MemoryPlanningState:
     def comm_buffer_pop(self, key: CommBufferReuseKey) -> FreeIfNotReusedLine:
         item = self.comm_buffer_reuse_pool[key].pop()
         assert not item.is_reused
+        match_key: BorrowMatchKey = (key[0], key[1], key[2])
+        keys_list = self.comm_pool_by_match_key[match_key]
+        if key in keys_list:
+            keys_list.remove(key)
         return item
 
     def comm_buffer_push(
@@ -478,6 +498,8 @@ class MemoryPlanningState:
     ) -> None:
         assert not item.is_reused
         self.comm_buffer_reuse_pool[key].append(item)
+        match_key: BorrowMatchKey = (key[0], key[1], key[2])
+        self.comm_pool_by_match_key[match_key].append(key)
 
 
 class WrapperLine:
@@ -963,6 +985,16 @@ class AllocateLine(MemoryPlanningLine):
                 state.push(key, free_line)
                 return self
 
+        # Try borrowing from pg_alloc comm pool if enabled
+        if (
+            config.comms_pg_alloc_allow_borrow
+            and config.allow_buffer_reuse
+            and not self.comm_buffer
+        ):
+            borrowed = self._try_borrow_from_comm_pool(state)
+            if borrowed is not None:
+                return borrowed
+
         if self.node.get_device_or_error().type == "cpu":
             static_shape = self.wrapper.static_shape_for_buffer_or_none(self.node)
             if static_shape is not None:
@@ -981,6 +1013,97 @@ class AllocateLine(MemoryPlanningLine):
             state.total_pg_alloc_bytes + alloc_bytes > int(max_gb * (1024**3))
         )
         return exceeds, alloc_bytes
+
+    def _try_borrow_from_comm_pool(
+        self, state: MemoryPlanningState
+    ) -> MemoryPlanningLine | None:
+        """Try to borrow an idle pg_alloc buffer for a regular (non-comm) op."""
+        buf_name = self.node.get_name()
+        free_sni = state.buffer_free_sni.get(buf_name)
+        if free_sni is None:
+            return None
+
+        strategy = config.comms_pg_alloc_borrow_strategy
+
+        # Peak-aware: only borrow buffers live at peak
+        if strategy == "peak_aware" and state.peak_live_buffers is not None:
+            if buf_name not in state.peak_live_buffers:
+                return None
+
+        # Greedy matching: use pre-computed plan
+        if strategy == "greedy_matching" and state.borrow_plan is not None:
+            planned_comm_key = state.borrow_plan.get(buf_name)
+            if planned_comm_key is None:
+                return None
+            if not state.comm_buffer_contains(planned_comm_key):
+                return None
+            free_line = state.comm_buffer_pop(planned_comm_key)
+            free_line.is_reused = True
+            state.borrowed_comm_keys[buf_name] = planned_comm_key
+            log.debug(
+                "pg_alloc borrow (greedy_matching): %s borrows comm buffer %s",
+                buf_name,
+                planned_comm_key,
+            )
+            return ReuseLine(self.wrapper, free_line.node, self.node)
+
+        # Check reuse chain: if a future regular allocation with the same key
+        # exists after this buffer is freed, borrowing would break the chain
+        # (freed buffer returns to comm pool, not regular pool).
+        regular_key = buffer_reuse_key(self.node)
+        future_allocs = state.regular_alloc_schedule.get(regular_key, [])
+        idx = bisect.bisect_right(future_allocs, free_sni)
+        if idx < len(future_allocs):
+            return None
+
+        # Build match key: (device, dtype, size_str) — ignoring alignment
+        storage_size = V.graph.get_allocation_storage_size(self.node)
+        match_key: BorrowMatchKey = (
+            self.node.get_device_or_error(),
+            self.node.get_dtype(),
+            sympy_str(V.graph.sizevars.simplify(storage_size)),
+        )
+
+        # Find matching comm buffers in the pool
+        comm_keys = state.comm_pool_by_match_key.get(match_key)
+        if not comm_keys:
+            return None
+
+        # Try each matching comm key
+        for comm_key in list(comm_keys):
+            if not state.comm_buffer_contains(comm_key):
+                continue
+
+            # Only borrow PG_ALLOC buffers (not SYMM_MEM)
+            if comm_key[3] != ir.CommBufferType.PG_ALLOC:
+                continue
+
+            # Lookahead: find next comm demand for this key
+            demand_snis = state.comm_demand_schedule.get(comm_key, [])
+            idx = bisect.bisect_right(demand_snis, self.scheduler_node_index)
+            next_comm_sni = demand_snis[idx] if idx < len(demand_snis) else None
+
+            # Safe to borrow if buffer is freed before next comm demand
+            if next_comm_sni is not None and free_sni >= next_comm_sni:
+                continue  # Not safe — buffer would still be held when comm needs it
+
+            # Borrow: pop from comm pool, track for return
+            free_line = state.comm_buffer_pop(comm_key)
+            free_line.is_reused = True
+            state.borrowed_comm_keys[buf_name] = comm_key
+
+            log.debug(
+                "pg_alloc borrow: %s borrows comm buffer %s (key=%s), "
+                "free_sni=%d, next_comm_sni=%s",
+                buf_name,
+                free_line.node.get_name(),
+                comm_key,
+                free_sni,
+                next_comm_sni,
+            )
+            return ReuseLine(self.wrapper, free_line.node, self.node)
+
+        return None
 
     def codegen(self, code: IndentedBuffer) -> None:
         assert self.node.get_name() not in V.graph.removed_buffers
@@ -1063,7 +1186,15 @@ class FreeIfNotReusedLine(MemoryPlanningLine):
             return NullLine(self.wrapper)
         if config.allow_buffer_reuse:
             buf_name = self.node.get_name()
-            if (
+            borrowed_key = state.borrowed_comm_keys.pop(buf_name, None)
+            if borrowed_key is not None:
+                state.comm_buffer_push(borrowed_key, self)
+                log.debug(
+                    "pg_alloc borrow return: %s -> comm pool (key=%s)",
+                    buf_name,
+                    borrowed_key,
+                )
+            elif (
                 isinstance(self.node.get_output_spec(), ir.CommBufferLayout)
                 and buf_name not in state.pg_alloc_fallback_bufs
             ):
@@ -2281,6 +2412,194 @@ class PythonWrapperCodegen(CodeGen):
 
         self.lines = MemoryPlanner(self).plan(self.lines)
 
+    def _prescan_borrow_schedules(self, state: MemoryPlanningState) -> None:
+        """Pre-scan lines to build comm/buffer schedules for cross-pool borrowing."""
+        for line in self.lines:
+            if isinstance(line, AllocateLine) and line.comm_buffer:
+                layout = line.node.get_output_spec()
+                if isinstance(layout, ir.CommBufferLayout):
+                    key = comm_buffer_reuse_key(line.node)
+                    state.comm_demand_schedule.setdefault(key, []).append(
+                        line.scheduler_node_index
+                    )
+            elif isinstance(line, AllocateLine) and not line.comm_buffer:
+                key = buffer_reuse_key(line.node)
+                state.regular_alloc_schedule.setdefault(key, []).append(
+                    line.scheduler_node_index
+                )
+            elif isinstance(line, FreeIfNotReusedLine) and line.comm_buffer:
+                layout = line.node.get_output_spec()
+                if isinstance(layout, ir.CommBufferLayout):
+                    key = comm_buffer_reuse_key(line.node)
+                    state.comm_free_schedule.setdefault(key, []).append(
+                        line.scheduler_node_index
+                    )
+            elif isinstance(line, FreeIfNotReusedLine) and not line.comm_buffer:
+                state.buffer_free_sni[line.node.get_name()] = line.scheduler_node_index
+
+        # Sort schedules for binary search
+        for key in state.comm_demand_schedule:
+            state.comm_demand_schedule[key].sort()
+        for key in state.comm_free_schedule:
+            state.comm_free_schedule[key].sort()
+        for key in state.regular_alloc_schedule:
+            state.regular_alloc_schedule[key].sort()
+
+    def _simulate_peak_without_borrow(self) -> OrderedSet[str]:
+        """Simulate memory planning without borrowing to find buffers live at peak."""
+        sim_pool: dict[ReuseKey, list[str]] = collections.defaultdict(list)
+        live_bufs: dict[str, int] = {}  # buf_name -> size_bytes
+        current_mem = 0
+        peak_mem = 0
+        peak_live: OrderedSet[str] = OrderedSet()
+
+        for line in self.lines:
+            if isinstance(line, AllocateLine) and not line.comm_buffer:
+                if line.node.get_name() in V.graph.removed_buffers:
+                    continue
+                key = buffer_reuse_key(line.node)
+                buf_name = line.node.get_name()
+                size = V.graph.sizevars.optimization_hint(
+                    V.graph.get_allocation_storage_size(line.node), fallback=0
+                ) * get_dtype_size(line.node.get_dtype())
+                if sim_pool.get(key):
+                    # Reuse from pool — no memory cost
+                    sim_pool[key].pop()
+                    live_bufs[buf_name] = size
+                else:
+                    # Fresh alloc
+                    current_mem += size
+                    live_bufs[buf_name] = size
+                if current_mem > peak_mem:
+                    peak_mem = current_mem
+                    peak_live = OrderedSet(live_bufs.keys())
+            elif isinstance(line, FreeIfNotReusedLine) and not line.comm_buffer:
+                buf_name = line.node.get_name()
+                if buf_name in live_bufs:
+                    key = buffer_reuse_key(line.node)
+                    sim_pool[key].append(buf_name)
+                    current_mem -= live_bufs.pop(buf_name)
+
+        return peak_live
+
+    def _plan_borrow_greedy_matching(
+        self, state: MemoryPlanningState
+    ) -> dict[str, CommBufferReuseKey]:
+        """Compute borrow assignments via greedy maximum-weight bipartite matching."""
+        peak_live = self._simulate_peak_without_borrow()
+        if not peak_live:
+            return {}
+
+        # Collect borrowable candidates: regular buffers live at peak with
+        # a matching comm buffer size and safe timing.
+        candidates: list[
+            tuple[str, BorrowMatchKey, int, int, int]
+        ] = []  # (name, match_key, alloc_sni, free_sni, size_bytes)
+        for line in self.lines:
+            if not isinstance(line, AllocateLine) or line.comm_buffer:
+                continue
+            buf_name = line.node.get_name()
+            if buf_name not in peak_live:
+                continue
+            if buf_name in V.graph.removed_buffers:
+                continue
+            free_sni = state.buffer_free_sni.get(buf_name)
+            if free_sni is None:
+                continue
+            # Check reuse chain guard
+            regular_key = buffer_reuse_key(line.node)
+            future_allocs = state.regular_alloc_schedule.get(regular_key, [])
+            idx = bisect.bisect_right(future_allocs, free_sni)
+            if idx < len(future_allocs):
+                continue
+            storage_size = V.graph.get_allocation_storage_size(line.node)
+            match_key: BorrowMatchKey = (
+                line.node.get_device_or_error(),
+                line.node.get_dtype(),
+                sympy_str(V.graph.sizevars.simplify(storage_size)),
+            )
+            size = V.graph.sizevars.optimization_hint(
+                storage_size, fallback=0
+            ) * get_dtype_size(line.node.get_dtype())
+            if size <= 0:
+                continue
+            candidates.append(
+                (buf_name, match_key, line.scheduler_node_index, free_sni, size)
+            )
+
+        if not candidates:
+            return {}
+
+        # Build idle windows from comm free/demand schedules:
+        # A comm buffer is idle from its free SNI until the next alloc SNI.
+        # Window [idle_start, idle_end) means the comm buffer is available for borrowing.
+        _INF_SNI = 2**31
+        idle_windows: list[
+            tuple[CommBufferReuseKey, int, int]
+        ] = []  # (comm_key, idle_start, idle_end)
+        for comm_key, demand_snis in state.comm_demand_schedule.items():
+            if comm_key[3] != ir.CommBufferType.PG_ALLOC:
+                continue
+            free_snis = state.comm_free_schedule.get(comm_key, [])
+            for i in range(len(free_snis)):
+                idle_start = free_snis[i]
+                # Next demand after this free marks end of idle window
+                idx = bisect.bisect_right(demand_snis, idle_start)
+                idle_end = demand_snis[idx] if idx < len(demand_snis) else _INF_SNI
+                idle_windows.append((comm_key, idle_start, idle_end))
+
+        if not idle_windows:
+            return {}
+
+        # Build match key for each comm_key
+        comm_key_match: dict[CommBufferReuseKey, BorrowMatchKey] = {}
+        for line in self.lines:
+            if isinstance(line, AllocateLine) and line.comm_buffer:
+                layout = line.node.get_output_spec()
+                if isinstance(layout, ir.CommBufferLayout):
+                    ck = comm_buffer_reuse_key(line.node)
+                    if ck not in comm_key_match:
+                        storage_size = V.graph.get_allocation_storage_size(line.node)
+                        comm_key_match[ck] = (
+                            line.node.get_device_or_error(),
+                            line.node.get_dtype(),
+                            sympy_str(V.graph.sizevars.simplify(storage_size)),
+                        )
+
+        # Build bipartite adjacency: candidate_idx -> list of (window_idx, weight)
+        adj: dict[int, list[tuple[int, int]]] = collections.defaultdict(list)
+        for ci, (buf_name, mk, alloc_sni, free_sni, size) in enumerate(candidates):
+            for wi, (comm_key, idle_start, idle_end) in enumerate(idle_windows):
+                cmk = comm_key_match.get(comm_key)
+                if cmk != mk:
+                    continue
+                # Buffer lifetime [alloc_sni, free_sni] must fit in [idle_start, idle_end)
+                if alloc_sni >= idle_start and free_sni < idle_end:
+                    adj[ci].append((wi, size))
+
+        # Greedy maximum-weight matching: sort edges by weight desc, greedily pick
+        # non-conflicting edges. Not optimal but effective for typical graph sizes.
+        edges: list[tuple[int, int, int]] = []  # (weight, candidate_idx, window_idx)
+        for ci, neighbors in adj.items():
+            for wi, weight in neighbors:
+                edges.append((weight, ci, wi))
+        edges.sort(reverse=True)
+
+        matched_candidates: OrderedSet[int] = OrderedSet()
+        matched_windows: OrderedSet[int] = OrderedSet()
+        plan: dict[str, CommBufferReuseKey] = {}
+
+        for weight, ci, wi in edges:
+            if ci in matched_candidates or wi in matched_windows:
+                continue
+            matched_candidates.add(ci)
+            matched_windows.add(wi)
+            buf_name = candidates[ci][0]
+            comm_key = idle_windows[wi][0]
+            plan[buf_name] = comm_key
+
+        return plan
+
     def memory_plan_reuse(self):
         outputs = self.get_graph_outputs()
         out_names = V.graph._get_output_names(outputs)
@@ -2297,6 +2616,20 @@ class PythonWrapperCodegen(CodeGen):
         # codegen allocations in two passes
         planning_states = [MemoryPlanningState()]
         past_planning_states = []
+
+        # Pre-scan for cross-pool borrowing if enabled
+        if config.comms_pg_alloc_allow_borrow and config.comms_use_pg_alloc:
+            self._prescan_borrow_schedules(planning_states[-1])
+            strategy = config.comms_pg_alloc_borrow_strategy
+            if strategy == "peak_aware":
+                planning_states[
+                    -1
+                ].peak_live_buffers = self._simulate_peak_without_borrow()
+            elif strategy == "greedy_matching":
+                planning_states[-1].borrow_plan = self._plan_borrow_greedy_matching(
+                    planning_states[-1]
+                )
+
         for i in range(len(self.lines)):
             line = self.lines[i]
             if isinstance(line, MemoryPlanningLine):

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -479,6 +479,19 @@ comms_pg_alloc_max_gb: float | None = (
 # Combine with comma: "only_all_gather,only_outputs"
 comms_use_pg_alloc_strategy: str | None = os.environ.get("USE_PG_ALLOC_STRATEGY", None)
 
+# Allow non-comm ops to borrow idle pg_alloc buffers. Reduces CUDA caching
+# allocator fragmentation by reusing NCCL-registered memory for compute when
+# the buffer won't be needed for comms. Requires comms_use_pg_alloc=True.
+comms_pg_alloc_allow_borrow: bool = os.environ.get("USE_PG_ALLOC_BORROW", "0") == "1"
+
+# Strategy for cross-pool borrowing. Requires comms_pg_alloc_allow_borrow=True.
+# "greedy": single-pass, borrow first safe match (with reuse chain guard).
+# "peak_aware": two-pass — simulate to find peak, only borrow buffers live at peak.
+# "greedy_matching": greedy bipartite matching for borrow assignment minimizing peak.
+comms_pg_alloc_borrow_strategy: str = os.environ.get(
+    "USE_PG_ALLOC_BORROW_STRATEGY", "greedy"
+)
+
 # runtime estimation function for ops
 # for built-in estimation function, pass in "default"; for user-defined estimation function, pass in the function handle
 estimate_op_runtime = "default"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181010
* #181009
* #181008
* #181007


 Summary

  Allows regular compute operations to temporarily borrow idle pg_alloc buffers during memory planning. When a comm buffer is sitting idle between two collective uses, a regular allocation with matching size can reuse that memory instead of requesting a new allocation from the CUDA caching allocator. This reduces peak memory and allocator fragmentation in models
   with large comm buffers that are idle for significant portions of the schedule.

  Gated behind USE_PG_ALLOC_BORROW=1 / torch._inductor.config.comms_pg_alloc_allow_borrow. Requires comms_use_pg_alloc=True.

  Implementation

  Pre-scan phase (wrapper.py — _prescan_borrow_schedules())

  Before the main memory planning loop, memory_plan_reuse() calls _prescan_borrow_schedules() to build four sorted schedules from a single pass over self.lines:

  - comm_demand_schedule: for each CommBufferReuseKey, the sorted list of scheduler node indices (SNIs) where a comm AllocateLine needs that key.
  - comm_free_schedule: for each CommBufferReuseKey, the sorted SNIs where a comm FreeIfNotReusedLine releases that key.
  - buffer_free_sni: maps each regular buffer name to the SNI where it is freed.
  - regular_alloc_schedule: for each regular ReuseKey, the sorted SNIs of allocations.

  These schedules enable O(log n) lookahead via bisect.bisect_right during the main planning pass.

  Borrowing during planning (wrapper.py — AllocateLine._try_borrow_from_comm_pool())

  After the regular reuse pool misses, AllocateLine.plan() calls _try_borrow_from_comm_pool() if borrowing is enabled. The method performs two safety checks before borrowing:

  1. Reuse chain guard: If a future regular allocation with the same ReuseKey exists after this buffer's free point, borrowing is skipped. Otherwise, that future allocation would expect to find this buffer in the regular pool on free, but it would be returned to the comm pool instead.
  2. Comm demand lookahead: For each candidate comm buffer in the pool (matched by device, dtype, and size), binary search finds the next comm demand SNI. The borrow is only safe if the regular buffer's free SNI is strictly before the next comm demand — guaranteeing the comm buffer is returned before the next collective needs it.

  The method builds a BorrowMatchKey = (device, dtype, size_str) — a relaxed version of CommBufferReuseKey that drops the comm buffer type and group name — to find candidates in the comm pool. Only PG_ALLOC buffers are eligible (not SYMM_MEM). The pool is indexed by comm_pool_by_match_key, updated on every comm_buffer_push/comm_buffer_pop.

  When a match is found, the comm buffer is popped from the comm pool and the mapping buf_name -> comm_key is recorded in state.borrowed_comm_keys.

  Returning borrowed buffers (wrapper.py — FreeIfNotReusedLine.plan())

  When a buffer is freed, FreeIfNotReusedLine.plan() first checks state.borrowed_comm_keys. If the buffer was borrowed, it is returned to the comm pool under the original CommBufferReuseKey (not the regular pool), making it available for the next comm allocation or another borrow.

  Borrow strategies (wrapper.py, config.py)

  Three strategies are available via comms_pg_alloc_borrow_strategy (USE_PG_ALLOC_BORROW_STRATEGY, default: "greedy"):

  - greedy: During the main planning pass, borrows the first safe match. Single-pass, no pre-computation beyond the schedules.
  - peak_aware: Two-pass approach. _simulate_peak_without_borrow() simulates regular memory planning (tracking alloc/free/reuse) to find the set of buffer names live at the peak memory point. Only buffers in that set are eligible for borrowing. This avoids wasting borrow capacity on buffers that don't contribute to peak.
  - greedy_matching: Pre-computes borrow assignments via _plan_borrow_greedy_matching(). Builds a bipartite graph between borrowable regular buffers (peak-live, reuse-chain-safe) and idle comm windows (intervals between comm free and next comm demand). Edges are weighted by buffer size. A greedy maximum-weight matching selects non-conflicting assignments to
  maximize memory savings. During the main pass, _try_borrow_from_comm_pool() simply looks up the pre-computed plan.

  Match key index on MemoryPlanningState

  comm_pool_by_match_key maps BorrowMatchKey -> list[CommBufferReuseKey] and is updated on every comm_buffer_push (append) and comm_buffer_pop (remove). This avoids scanning the entire comm pool for matching sizes during each borrow attempt.

  Tests (test/inductor/test_pg_alloc_borrow.py)

  Unit tests for MemoryPlanningState borrowing mechanics using mock objects (no GPU required):
  - Push/pop correctly updates the match key index
  - Borrowed buffer roundtrip: borrow from comm pool, return on free
  - Multiple sequential borrows from the same comm key
  - Different process groups stay separate


  Config (config.py)

  - comms_pg_alloc_allow_borrow: bool — master toggle, read from USE_PG_ALLOC_BORROW env var.
  - comms_pg_alloc_borrow_strategy: str — strategy selection, read from USE_PG_ALLOC_BORROW_STRATEGY env var.
  - 
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo