### PR TITLE
Add non-strict backward patching helper

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2977,6 +2977,18 @@ class ActivationCheckpointingNonStrictTracerTests(torch._dynamo.test_case.TestCa
             ):
                 torch.autograd.grad(loss, (x,))
 
+    def test_patch_engine_backward_requires_non_strict_tracing(self):
+        x = torch.randn(2, 4, requires_grad=True)
+        loss = torch.sin(x).sum()
+
+        with torch.compiler._patch_engine_backward():
+            with self.assertRaisesRegex(
+                AssertionError,
+                "_patch_engine_backward\\(\\) must be used under "
+                "_non_strict_tracing_context\\(\\)",
+            ):
+                loss.backward()
+
     def test_patch_autograd_grad_does_not_leak_backward_tag(self):
         from torch.fx.experimental.proxy_tensor import make_fx
         from torch.fx.traceback import preserve_node_meta
@@ -2992,6 +3004,37 @@ class ActivationCheckpointingNonStrictTracerTests(torch._dynamo.test_case.TestCa
         with (
             torch.compiler._non_strict_tracing_context(),
             torch.compiler._patch_autograd_grad(),
+            preserve_node_meta(),
+        ):
+            gm = make_fx(fn)(x)
+
+        backward_nodes = [
+            node for node in gm.graph.nodes if node.meta.get("autograd_backward", False)
+        ]
+        self.assertTrue(backward_nodes)
+
+        neg_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.neg.default
+        )
+        self.assertEqual(len(neg_nodes), 1)
+        self.assertNotIn("autograd_backward", neg_nodes[0].meta)
+        self.assertEqual(neg_nodes[0].meta.get("custom", {}), {"ac_region_id": 0})
+
+    def test_patch_engine_backward_does_not_leak_backward_tag(self):
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch.fx.traceback import preserve_node_meta
+
+        x = torch.randn(2, 4, requires_grad=True)
+
+        def fn(x):
+            with torch.fx.traceback.annotate({"ac_region_id": 0}):
+                y = torch.sin(x)
+                y.sum().backward()
+                return torch.neg(y)
+
+        with (
+            torch.compiler._non_strict_tracing_context(),
+            torch.compiler._patch_engine_backward(),
             preserve_node_meta(),
         ):
             gm = make_fx(fn)(x)

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -524,9 +524,16 @@ def _patch_autograd_grad():
     import functools
 
     import torch.autograd
+    from torch._dynamo.utils import warn_once
     from torch._functorch._aot_autograd.logging_utils import (
         setup_stacktrace_preservation_hooks_from_tensors,
     )
+
+    warn_once(
+        "torch.compiler._patch_autograd_grad() is deprecated; "
+        "use torch.compiler._patch_engine_backward() instead."
+    )
+    # TODO: Remove this helper once Titan no longer depends on it.
 
     _orig_grad = torch.autograd.grad
 
@@ -546,6 +553,44 @@ def _patch_autograd_grad():
         yield
     finally:
         torch.autograd.grad = _orig_grad
+
+
+@contextlib.contextmanager
+def _patch_engine_backward():
+    """Patch _engine_run_backward for non-strict make_fx tracing.
+
+    This patch installs autograd hooks so traced backward nodes preserve
+    stack trace, seq_nr, and autograd_backward metadata before delegating to
+    the real autograd engine entrypoint used by backward().
+    """
+    import functools
+
+    import torch.autograd
+    import torch.autograd.graph
+    from torch._functorch._aot_autograd.logging_utils import (
+        setup_stacktrace_preservation_hooks_from_tensors,
+    )
+
+    _orig_engine_run_backward = torch.autograd.graph._engine_run_backward
+
+    @functools.wraps(_orig_engine_run_backward)
+    def _patched_engine_backward(outputs, *args, **kwargs):
+        if not _is_non_strict_tracing():
+            raise AssertionError(
+                "_patch_engine_backward() must be used under "
+                "_non_strict_tracing_context()"
+            )
+
+        setup_stacktrace_preservation_hooks_from_tensors(outputs)
+        return _orig_engine_run_backward(outputs, *args, **kwargs)
+
+    torch.autograd.graph._engine_run_backward = _patched_engine_backward
+    torch.autograd._engine_run_backward = _patched_engine_backward
+    try:
+        yield
+    finally:
+        torch.autograd.graph._engine_run_backward = _orig_engine_run_backward
+        torch.autograd._engine_run_backward = _orig_engine_run_backward
 
 
 def is_dynamo_compiling() -> bool:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181012

Add torch.compiler._patch_engine_backward() so non-strict make_fx tracing installs the same stack trace, seq_nr, and autograd_backward preservation hooks for loss.backward() that we already rely on for torch.autograd.grad(). This extends the tagging path to backward()-driven traces without changing the eager autograd behavior outside the helper.

Keep torch.compiler._patch_autograd_grad() for existing users, but deprecate it with a once-only warning and leave a TODO to remove it once TorchTitan stops depending on the helper. The non-strict activation checkpointing tests now cover both the guard and the metadata leak boundary for backward().

Authored with Codex, continuing earlier Claude-assisted work.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98