### PR TITLE
[release/2.12][ROCm][inductor] Cherry-pick combo-kernel HIP compile options fix

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -44,6 +44,13 @@ except (unittest.SkipTest, ImportError) as e:
         sys.exit(0)
     raise
 
+if torch.version.hip:
+    if __name__ == "__main__":
+        sys.exit(0)
+    raise unittest.SkipTest(
+        "PR180277 will fix the combo-kernel hip config issue on ROCm"
+    )
+
 
 @instantiate_parametrized_tests
 class ComboKernelTests(TestCase):
@@ -1432,11 +1439,13 @@ class ComboKernelTestsMaxAutotune(TestCase):
             for line in group_lines
             if re.search(r"group (\d+)", line)
         }
-        # 2 groups (not 4) — identical configs are grouped together
-        self.assertEqual(
+        # Exact grouping count is hardware-dependent because pointwise candidate
+        # config sets can differ across environments. The stable regression for
+        # the new grouping key lives in the mocked test below.
+        self.assertGreater(
             len(group_indices),
-            2,
-            f"Expected 2 groups, got {len(group_indices)}: {group_lines}",
+            0,
+            f"Expected at least one autotune group, got {group_lines}",
         )
         self.assertEqual(out_eager, out_compiled)
         self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -44,13 +44,6 @@ except (unittest.SkipTest, ImportError) as e:
         sys.exit(0)
     raise
 
-if torch.version.hip:
-    if __name__ == "__main__":
-        sys.exit(0)
-    raise unittest.SkipTest(
-        "PR180277 will fix the combo-kernel hip config issue on ROCm"
-    )
-
 
 @instantiate_parametrized_tests
 class ComboKernelTests(TestCase):

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1454,6 +1454,65 @@ class ComboKernelTestsMaxAutotune(TestCase):
         self.assertEqual(len(groups), 2)
         self.assertEqual([[0], [1]], [g["member_indices"] for g in groups])
 
+    @requires_gpu_and_triton
+    def test_combo_kernel_coordesc_tunes_largest_subkernel_first(self):
+        def fn(a, b, c):
+            return (
+                torch.nn.functional.relu(a),
+                torch.nn.functional.sigmoid(b),
+                torch.nn.functional.tanh(c),
+            )
+
+        inps = [
+            torch.rand(32, 1024, device=GPU_TYPE),
+            torch.rand(256, 256, device=GPU_TYPE),
+            torch.rand(16, 128, device=GPU_TYPE),
+        ]
+
+        out_eager = fn(*inps)
+
+        def parse_block_cfg(msg: str) -> dict[str, int]:
+            return {
+                m.group(1): int(m.group(2))
+                for m in re.finditer(r"(\w+BLOCK_\d+): (\d+)", msg)
+            }
+
+        logger = logging.getLogger("torch._inductor.runtime.coordinate_descent_tuner")
+        with torch._inductor.config.patch(coordinate_descent_tuning=True):
+            with self.assertLogs(logger, level=logging.DEBUG) as cm:
+                out_compiled = torch.compile(fn)(*inps)
+
+        self.assertEqual(out_eager, out_compiled)
+
+        baseline_log = next(
+            msg for msg in cm.output if "Baseline Config" in msg and "XBLOCK_" in msg
+        )
+        baseline_cfg = parse_block_cfg(baseline_log)
+        try_logs = [
+            msg for msg in cm.output if "Try config" in msg and "XBLOCK_" in msg
+        ]
+        self.assertGreater(
+            len(try_logs), 0, "Coordinate descent did not try combo fields"
+        )
+        distinct_block_cfgs = {
+            tuple(sorted(parse_block_cfg(msg).items())) for msg in try_logs
+        }
+        self.assertGreater(
+            len(distinct_block_cfgs),
+            1,
+            "Coordinate descent did not explore different suffixed block sizes.",
+        )
+
+        first_cfg = parse_block_cfg(try_logs[0])
+        changed_fields = {
+            key for key, value in first_cfg.items() if baseline_cfg.get(key) != value
+        }
+        self.assertEqual(
+            changed_fields,
+            {"XBLOCK_1"},
+            f"Expected the first combo coordesc step to tune the largest subkernel first, got {changed_fields}",
+        )
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -610,6 +610,32 @@ class ComboKernelTests(TestCase):
                 torch._inductor.metrics.generated_kernel_count, expected_kernel_count
             )
 
+    # waves_per_eu, matrix_instr_nonkdim, and kpack are HIP-only Triton
+    # compile options, so only ROCm exercises this combo-kernel rewrite path.
+    @unittest.skipIf(not torch.version.hip, "ROCm only")
+    @requires_gpu_and_triton
+    @parametrize("max_autotune", [False, True])
+    def test_combo_kernel_amd_special_config_args(self, max_autotune):
+        if not torch._inductor.config.combo_kernel_per_subkernel_blocks:
+            self.skipTest("requires combo_kernel_per_subkernel_blocks")
+
+        def fn(a, b):
+            return a * 2.0, b + 1.0
+
+        inps = [
+            torch.rand(1024, device=GPU_TYPE),
+            torch.rand(1024, device=GPU_TYPE),
+        ]
+        out_eager = fn(*inps)
+
+        torch._inductor.metrics.reset()
+        with torch._inductor.config.patch("max_autotune", max_autotune):
+            fn_c = torch.compile(fn)
+            out_compiled, _ = run_and_get_code(fn_c, *inps)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
     @skipIfXpu(msg="Profiler JSON traceEvents is not supported on XPU")
     @requires_gpu_and_triton
     @unittest.skipIf(not SM90OrLater, "Avoid oom on CI")

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -574,6 +574,42 @@ class ComboKernelTests(TestCase):
                 torch._inductor.metrics.generated_kernel_count, expected_kernel_count
             )
 
+    @requires_gpu_and_triton
+    @parametrize(
+        "max_num_nodes,expected_kernel_count",
+        [(8, 1), (3, 2), (2, 3)],
+    )
+    def test_combo_kernel_max_num_nodes(self, max_num_nodes, expected_kernel_count):
+        def fn(a, b, c, d, e, f):
+            return (
+                a * 2.0,
+                b + 1.0,
+                c.sin(),
+                d.cos(),
+                e.exp(),
+                f.neg(),
+            )
+
+        inps = [
+            torch.rand(1024, device=GPU_TYPE),
+            torch.rand(1024, device=GPU_TYPE),
+            torch.rand(1024, device=GPU_TYPE),
+            torch.rand(1024, device=GPU_TYPE),
+            torch.rand(1024, device=GPU_TYPE),
+            torch.rand(1024, device=GPU_TYPE),
+        ]
+
+        out_eager = fn(*inps)
+
+        torch._inductor.metrics.reset()
+        with torch._inductor.config.patch("combo_kernel_max_num_nodes", max_num_nodes):
+            fn_c = torch.compile(fn)
+            out_compiled, _ = run_and_get_code(fn_c, *inps)
+            self.assertEqual(out_eager, out_compiled)
+            self.assertEqual(
+                torch._inductor.metrics.generated_kernel_count, expected_kernel_count
+            )
+
     @skipIfXpu(msg="Profiler JSON traceEvents is not supported on XPU")
     @requires_gpu_and_triton
     @unittest.skipIf(not SM90OrLater, "Avoid oom on CI")

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1339,6 +1339,85 @@ class ComboKernelTestsMaxAutotune(TestCase):
         self.assertEqual(found_hints["reduction_hint_0"], "INNER")
         self.assertEqual(found_hints["reduction_hint_1"], "OUTER")
 
+    @requires_gpu_and_triton
+    @torch._inductor.config.patch("combo_kernel_autotune_grouping", True)
+    def test_combo_autotune_grouping(self):
+        def fn(a, b, c, d):
+            return a.cos(), b.sin(), c.exp(), d.neg()
+
+        # a,b: numel=262144 → bs=1024, c,d: numel=32 → bs=256
+        # Different bs → different configs → separate groups
+        inps = [
+            torch.rand(4, 65536, device=GPU_TYPE),
+            torch.rand(4, 65536, device=GPU_TYPE),
+            torch.rand(4, 8, device=GPU_TYPE),
+            torch.rand(4, 8, device=GPU_TYPE),
+        ]
+
+        out_eager = fn(*inps)
+        fn_c = torch.compile(fn)
+
+        logger = logging.getLogger("torch._inductor.runtime.triton_heuristics")
+        with self.assertLogs(logger, level=logging.DEBUG) as cm:
+            out_compiled, code = run_and_get_code(fn_c, *inps)
+
+        # Parse "Phase 1 group N SK[...]" lines to check grouping
+        group_lines = [
+            msg for msg in cm.output if "Phase 1 group" in msg and "SK[" in msg
+        ]
+        group_indices = {
+            int(re.search(r"group (\d+)", line).group(1))
+            for line in group_lines
+            if re.search(r"group (\d+)", line)
+        }
+        # 2 groups (not 4) — identical configs are grouped together
+        self.assertEqual(
+            len(group_indices),
+            2,
+            f"Expected 2 groups, got {len(group_indices)}: {group_lines}",
+        )
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 1)
+
+    @requires_gpu_and_triton
+    @torch._inductor.config.patch("combo_kernel_autotune_grouping", True)
+    def test_combo_autotune_grouping_uses_tiling_signature(self):
+        import triton
+
+        inductor_meta = {
+            "combo_grid_meta": {
+                "num_kernels": 2,
+                "heuristic_0": "pointwise",
+                "heuristic_1": "pointwise",
+                "size_hints_0": {"x": 256, "y": 256},
+                "size_hints_1": {"x": 256, "y": 256},
+                "tile_hint_0": "TileHint.SQUARE",
+                "tile_hint_1": "TileHint.SQUARE",
+                "tiling_scores_0": {"x": 8, "y": 1},
+                "tiling_scores_1": {"x": 1, "y": 8},
+            }
+        }
+
+        def pointwise_configs(*args, **kwargs):
+            return [
+                triton.Config({"XBLOCK": 64, "YBLOCK": 32}, num_warps=4, num_stages=1),
+                triton.Config({"XBLOCK": 128, "YBLOCK": 32}, num_warps=4, num_stages=1),
+            ]
+
+        with unittest.mock.patch(
+            "torch._inductor.runtime.triton_heuristics.pointwise",
+            side_effect=pointwise_configs,
+        ):
+            torch._inductor.runtime.triton_heuristics._handle_combo_kernel_per_subkernel_blocks(
+                {"x": 256, "y": 256},
+                inductor_meta,
+                triton_meta={},
+            )
+
+        groups = inductor_meta["combo_tuning_groups"]
+        self.assertEqual(len(groups), 2)
+        self.assertEqual([[0], [1]], [g["member_indices"] for g in groups])
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/inductor/test_coordinate_descent_tuner.py
+++ b/test/inductor/test_coordinate_descent_tuner.py
@@ -5,6 +5,7 @@ import unittest
 from unittest import mock
 
 import torch
+from torch._inductor.runtime import triton_heuristics
 from torch._inductor.runtime.hints import TRITON_MAX_BLOCK
 from torch._inductor.test_case import run_tests, TestCase
 from torch.testing._internal.common_utils import IS_LINUX
@@ -112,6 +113,97 @@ class TestCoordinateDescentTuner(TestCase):
         self.assertTrue(tuner.value_too_large("XBLOCK", max_block["X"] * 2))
         self.assertFalse(tuner.value_too_large("R0_BLOCK", max_block["R0_"]))
         self.assertTrue(tuner.value_too_large("R0_BLOCK", max_block["R0_"] * 2))
+
+    def test_value_too_large_combo_field_limits(self):
+        tuner = CoordescTuner(
+            size_hints={"x": 2**20, "r0_": 2**20},
+            inductor_meta={
+                "combo_coordesc_field_limits": {
+                    "XBLOCK_0": 64,
+                    "XBLOCK_1": 256,
+                    "R0_BLOCK_1": 128,
+                }
+            },
+        )
+
+        self.assertFalse(tuner.value_too_large("XBLOCK_0", 64))
+        self.assertTrue(tuner.value_too_large("XBLOCK_0", 128))
+        self.assertFalse(tuner.value_too_large("XBLOCK_1", 256))
+        self.assertTrue(tuner.value_too_large("XBLOCK_1", 512))
+        self.assertFalse(tuner.value_too_large("R0_BLOCK_1", 128))
+        self.assertTrue(tuner.value_too_large("R0_BLOCK_1", 256))
+
+    def test_combo_metadata_orders_larger_subkernels_first_for_coordesc(self):
+        def make_configs(xblock, yblock):
+            return [
+                triton.Config(
+                    {"XBLOCK": xblock, "YBLOCK": yblock},
+                    num_warps=4,
+                    num_stages=1,
+                )
+            ]
+
+        inductor_meta = {
+            "combo_grid_meta": {
+                "num_kernels": 3,
+                "heuristic_0": "pointwise",
+                "heuristic_1": "pointwise",
+                "heuristic_2": "pointwise",
+                "size_hints_0": {"x": 64, "y": 64},
+                "size_hints_1": {"x": 256, "y": 256},
+                "size_hints_2": {"x": 128, "y": 16},
+                "tile_hint_0": "TileHint.SQUARE",
+                "tile_hint_1": "TileHint.SQUARE",
+                "tile_hint_2": "TileHint.SQUARE",
+                "no_x_dim_0": False,
+                "no_x_dim_1": False,
+                "no_x_dim_2": False,
+            }
+        }
+
+        configs_by_size = {
+            (64, 64): make_configs(64, 32),
+            (256, 256): make_configs(256, 64),
+            (128, 16): make_configs(128, 16),
+        }
+
+        def pointwise_side_effect(size_hints, *args, **kwargs):
+            return configs_by_size[(size_hints["x"], size_hints["y"])]
+
+        with mock.patch.object(
+            triton_heuristics,
+            "pointwise",
+            side_effect=pointwise_side_effect,
+        ):
+            configs = triton_heuristics._handle_combo_kernel_per_subkernel_blocks(
+                {"x": 256, "y": 256},
+                inductor_meta,
+                triton_meta={},
+            )
+
+        self.assertIsNotNone(configs)
+        self.assertEqual(
+            inductor_meta["combo_coordesc_field_order"],
+            [
+                "XBLOCK_1",
+                "YBLOCK_1",
+                "XBLOCK_0",
+                "YBLOCK_0",
+                "XBLOCK_2",
+                "YBLOCK_2",
+            ],
+        )
+        self.assertEqual(
+            inductor_meta["combo_coordesc_field_limits"],
+            {
+                "XBLOCK_0": 64,
+                "YBLOCK_0": 64,
+                "XBLOCK_1": 256,
+                "YBLOCK_1": 256,
+                "XBLOCK_2": 128,
+                "YBLOCK_2": 16,
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -1206,6 +1206,11 @@ class ComboKernel(Kernel):
                         meta[f"tile_hint_{num}"] = "TileHint.SQUARE"
                     else:
                         meta[f"tile_hint_{num}"] = "TileHint.DEFAULT"
+                    if sub_kernel.tiling_scores:
+                        meta[f"tiling_scores_{num}"] = {
+                            dim: V.graph.sizevars.optimization_hint(score, fallback=1)
+                            for dim, score in sub_kernel.tiling_scores.items()
+                        }
                 else:
                     meta[f"reduction_hint_{num}"] = (
                         sub_kernel.features.get_reduction_hint().name

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1007,6 +1007,8 @@ combo_kernel_allow_mixed_sizes = 1
 combo_kernel_foreach_dynamic_shapes = True
 # Maximum number of arguments (read/write buffers) allowed in a combo kernel
 combo_kernel_max_num_args = 250
+# Maximum number of sub-kernels allowed in a single combo kernel
+combo_kernel_max_num_nodes = 8
 # When True, each combo sub-kernel gets its own block sizes (XBLOCK_0, YBLOCK_0, etc.)
 # allowing different sub-kernels to use different tile sizes based on their heuristics.
 # When False, all sub-kernels share block sizes (XBLOCK, YBLOCK, etc.)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1011,6 +1011,9 @@ combo_kernel_max_num_args = 250
 # allowing different sub-kernels to use different tile sizes based on their heuristics.
 # When False, all sub-kernels share block sizes (XBLOCK, YBLOCK, etc.)
 combo_kernel_per_subkernel_blocks = False
+# When True, combo-kernel autotuning groups sub-kernels that share the same
+# candidate config set and kernel-analysis signature. Disabled by default.
+combo_kernel_autotune_grouping = False
 # When True, only pointwise kernels are eligible for combo kernel fusion.
 combo_kernels_pointwise_only = False
 

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -75,6 +75,7 @@ class CoordescTuner:
         self.frozen_fields: OrderedSet[str] = (
             OrderedSet(frozen_fields) if frozen_fields is not None else OrderedSet()
         )
+        self._combo_tunable_fields: list[str] = []
 
     def get_config_max(self, prefix: str) -> int:
         max_block = TRITON_MAX_BLOCK[prefix.upper()]
@@ -136,9 +137,14 @@ class CoordescTuner:
             # control the stage of pipelining of tl.range.
             out.append("NUM_STAGES")
 
+        out = self._combo_tunable_fields + out
         return [f for f in out if f not in self.frozen_fields]
 
     def value_too_large(self, name: str, val: int) -> bool:
+        field_limits = self.inductor_meta.get("combo_coordesc_field_limits")
+        if isinstance(field_limits, dict) and name in field_limits:
+            return val > field_limits[name]
+
         block_suffix = "BLOCK"
         if name.endswith(block_suffix):
             prefix = name.strip(block_suffix).lower()
@@ -302,6 +308,9 @@ class CoordescTuner:
         baseline_config: "triton.Config",
         baseline_timing: float | None = None,
     ) -> "triton.Config":  # pyrefly: ignore  # missing-attribute
+        """
+        Perform coordinate descent autotuning starting from a baseline configuration.
+        """
         if baseline_timing is None:
             baseline_timing = self.call_func(func, baseline_config)
 
@@ -315,6 +324,11 @@ class CoordescTuner:
         improved = True
         best_config = baseline_config
         best_timing = baseline_timing
+
+        self._combo_tunable_fields = self.inductor_meta.get(
+            "combo_coordesc_field_order", []
+        )
+
         tunable_fields = self.tunable_fields
 
         while improved:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1322,6 +1322,7 @@ class CachingAutotuner(KernelInterface):
         start_time = time.time_ns()
         best_time = self.bench(launcher, *args, **kwargs)
         counters["inductor"]["combo_autotune_bench"] += 1
+        self.coordesc_tuner.cache_benchmark_result(launcher.config, best_time)
         log.debug(
             "  Phase 1 baseline: %s warps=%d time=%f",
             dict(current_kwargs),
@@ -1371,6 +1372,7 @@ class CachingAutotuner(KernelInterface):
                     ).make_launcher()
                 trial_time = self.bench(trial_launcher, *args, **kwargs)
                 counters["inductor"]["combo_autotune_bench"] += 1
+                self.coordesc_tuner.cache_benchmark_result(trial_config, trial_time)
 
                 improved = trial_time < best_time
                 log.debug(
@@ -1419,6 +1421,7 @@ class CachingAutotuner(KernelInterface):
                 trial_launcher = self._precompile_config(trial_config).make_launcher()
             trial_time = self.bench(trial_launcher, *args, **kwargs)
             counters["inductor"]["combo_autotune_bench"] += 1
+            self.coordesc_tuner.cache_benchmark_result(trial_config, trial_time)
 
             improved = trial_time < best_time
             log.debug(
@@ -2958,6 +2961,7 @@ def _handle_combo_kernel_per_subkernel_blocks(
     all_num_warps: list[int] = []
     all_num_stages: list[int] = []
     unique_warp_stage_pairs: OrderedSet[tuple[int, int]] = OrderedSet()
+    combo_coordesc_field_limits: dict[str, int] = {}
 
     # Group sub-kernels with identical config kwargs to skip redundant tuning.
     group_map: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -3006,11 +3010,22 @@ def _handle_combo_kernel_per_subkernel_blocks(
         else:
             raise ValueError(f"Unknown heuristic: {subkernel_heuristic}")
 
+        group_coordesc_fields: OrderedSet[str] = OrderedSet()
         cfg = cfgs[0]
         for key, value in cfg.kwargs.items():
             if skip_rblock and key.startswith("R") and "BLOCK" in key:
                 continue
-            combined_kwargs[f"{key}_{i}"] = value
+
+            combined_key = f"{key}_{i}"
+            combined_kwargs[combined_key] = value
+            if key.endswith("BLOCK"):
+                group_coordesc_fields.add(combined_key)
+                prefix = key.removesuffix("BLOCK").lower()
+                if prefix in size_hints_i:
+                    combo_coordesc_field_limits[combined_key] = min(
+                        TRITON_MAX_BLOCK[prefix.upper()],
+                        size_hints_i[prefix],
+                    )
 
         all_num_warps.append(cfg.num_warps)
         all_num_stages.append(cfg.num_stages)
@@ -3036,6 +3051,7 @@ def _handle_combo_kernel_per_subkernel_blocks(
                 "configs": cfgs,
                 "skip_rblock": skip_rblock,
                 "size_hints": size_hints_i,
+                "coordesc_fields": list(group_coordesc_fields),
             }
 
     unique_warp_stage_pairs.add((max(all_num_warps), max(all_num_stages)))
@@ -3046,6 +3062,10 @@ def _handle_combo_kernel_per_subkernel_blocks(
         key=lambda g: -functools.reduce(operator.mul, g["size_hints"].values())
     )
     inductor_meta["combo_tuning_groups"] = combo_tuning_groups
+    inductor_meta["combo_coordesc_field_order"] = [
+        field for group in combo_tuning_groups for field in group["coordesc_fields"]
+    ]
+    inductor_meta["combo_coordesc_field_limits"] = combo_coordesc_field_limits
     # Candidates for num_warps/num_stages re-tuning after block sizes are finalized
     inductor_meta["combo_warp_stage_candidates"] = list(unique_warp_stage_pairs)
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -759,12 +759,28 @@ class CachingAutotuner(KernelInterface):
         compile_meta["num_warps"] = cfg.num_warps
         compile_meta["num_stages"] = cfg.num_stages
 
-        cfg_kwargs = cfg.kwargs
+        cfg_kwargs = {**cfg.kwargs}
         if self.device_props.type == "hip":
-            cfg_kwargs = {**cfg_kwargs}
-            for k in ("matrix_instr_nonkdim", "waves_per_eu", "kpack"):
-                if k in cfg_kwargs:
-                    compile_meta[k] = cfg_kwargs.pop(k)
+            # `compile_meta["signature"]` contains the actual Triton kernel argument
+            # names, including constexprs such as XBLOCK_0/XBLOCK_1 for combo kernels.
+            # Any HIP config kwarg that is *not* in that signature is not a kernel
+            # argument at all; it is a backend compile option that should be forwarded
+            # to triton.compile via `options`, not materialized as a constexpr.
+            signature_arg_names = OrderedSet(compile_meta["signature"])
+            backend_options = {
+                key: value
+                for key, value in cfg_kwargs.items()
+                if key not in signature_arg_names
+            }
+            cfg_kwargs = {
+                key: value
+                for key, value in cfg_kwargs.items()
+                if key in signature_arg_names
+            }
+            if backend_options:
+                # Stash backend-only options separately so they do not get mixed into
+                # `constants`, which are interpreted as signature-bound constexpr args.
+                compile_meta["backend_options"] = backend_options
         compile_meta["constants"].update(cfg_kwargs)
 
         for i in get_constexprs(self.fn):
@@ -832,12 +848,9 @@ class CachingAutotuner(KernelInterface):
                 if v := getattr(cfg, k, None):
                     options[k] = v
         if self.device_props.type == "hip":
-            if "waves_per_eu" in compile_meta:
-                options["waves_per_eu"] = compile_meta["waves_per_eu"]
-            if "matrix_instr_nonkdim" in compile_meta:
-                options["matrix_instr_nonkdim"] = compile_meta["matrix_instr_nonkdim"]
-            if "kpack" in compile_meta:
-                options["kpack"] = compile_meta["kpack"]
+            # HIP backend options are consumed by Triton out-of-band from the kernel
+            # signature. They are intentionally *not* present in `constants`.
+            options.update(compile_meta.get("backend_options", {}))
 
         if self.device_props.type == "xpu" and XPU_KERNEL_FORMAT == "zebin":
             options["generate_native_code"] = True
@@ -1314,6 +1327,7 @@ class CachingAutotuner(KernelInterface):
             assert hasattr(self, "_reload_kernel")
             self.fn = self._reload_kernel().fn
 
+        signature_keys = OrderedSet(self.triton_meta["signature"])
         best_config = launcher.config
         current_kwargs = dict(best_config.kwargs)
         base_num_warps = best_config.num_warps
@@ -1351,10 +1365,9 @@ class CachingAutotuner(KernelInterface):
             for ci, cfg in enumerate(cfgs):
                 trial_kwargs = dict(current_kwargs)
                 for idx in member_indices:
-                    for key, value in cfg.kwargs.items():
-                        if skip_rblock and key.startswith("R") and "BLOCK" in key:
-                            continue
-                        trial_kwargs[f"{key}_{idx}"] = value
+                    _update_combo_kernel_kwargs(
+                        trial_kwargs, cfg.kwargs, idx, skip_rblock, signature_keys
+                    )
 
                 if trial_kwargs == current_kwargs:
                     log.debug("    cfg[%d] skip (same as current)", ci)
@@ -2924,6 +2937,24 @@ def _combo_tiling_signature(
     )
 
 
+def _update_combo_kernel_kwargs(
+    kwargs: dict[str, Any],
+    cfg_kwargs: dict[str, Any],
+    subkernel_idx: int,
+    skip_rblock: bool,
+    signature_keys: OrderedSet[str],
+) -> None:
+    for key, value in cfg_kwargs.items():
+        if skip_rblock and key.startswith("R") and "BLOCK" in key:
+            continue
+        suffixed_key = f"{key}_{subkernel_idx}"
+        # Only suffix keys that actually exist in the combo kernel signature.
+        # Signature keys are real per-subkernel constexpr args such as XBLOCK_0.
+        # Everything else must stay unsuffixed so HIP-specific compile options like
+        # waves_per_eu continue to flow through the backend-options path above.
+        kwargs[suffixed_key if suffixed_key in signature_keys else key] = value
+
+
 def _handle_combo_kernel_per_subkernel_blocks(
     size_hints: dict[str, int],
     inductor_meta: dict[str, Any],
@@ -2962,6 +2993,7 @@ def _handle_combo_kernel_per_subkernel_blocks(
     all_num_stages: list[int] = []
     unique_warp_stage_pairs: OrderedSet[tuple[int, int]] = OrderedSet()
     combo_coordesc_field_limits: dict[str, int] = {}
+    signature_keys = OrderedSet(triton_meta.get("signature", ()))
 
     # Group sub-kernels with identical config kwargs to skip redundant tuning.
     group_map: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -3012,20 +3044,22 @@ def _handle_combo_kernel_per_subkernel_blocks(
 
         group_coordesc_fields: OrderedSet[str] = OrderedSet()
         cfg = cfgs[0]
-        for key, value in cfg.kwargs.items():
+        _update_combo_kernel_kwargs(
+            combined_kwargs, cfg.kwargs, i, skip_rblock, signature_keys
+        )
+        for key in cfg.kwargs:
             if skip_rblock and key.startswith("R") and "BLOCK" in key:
                 continue
-
+            if not key.endswith("BLOCK"):
+                continue
             combined_key = f"{key}_{i}"
-            combined_kwargs[combined_key] = value
-            if key.endswith("BLOCK"):
-                group_coordesc_fields.add(combined_key)
-                prefix = key.removesuffix("BLOCK").lower()
-                if prefix in size_hints_i:
-                    combo_coordesc_field_limits[combined_key] = min(
-                        TRITON_MAX_BLOCK[prefix.upper()],
-                        size_hints_i[prefix],
-                    )
+            group_coordesc_fields.add(combined_key)
+            prefix = key.removesuffix("BLOCK").lower()
+            if prefix in size_hints_i:
+                combo_coordesc_field_limits[combined_key] = min(
+                    TRITON_MAX_BLOCK[prefix.upper()],
+                    size_hints_i[prefix],
+                )
 
         all_num_warps.append(cfg.num_warps)
         all_num_stages.append(cfg.num_stages)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -2897,6 +2897,30 @@ def _get_config(numels: dict[str, int]) -> dict[str, int]:
     return {prefix.upper() + "BLOCK": numel for prefix, numel in numels.items()}
 
 
+def _combo_tiling_signature(
+    tiling_scores: dict[str, Any] | None,
+) -> tuple[tuple[str, float], ...] | None:
+    """
+    Build a grouping signature from tiling scores.
+
+    Normalize scores so proportional patterns (e.g. {x: 8, y: 1} vs {x: 16, y: 2})
+    end up in the same group, while kernels with different coalescing preference do not.
+    """
+    if not tiling_scores:
+        return None
+
+    total = sum(float(score) for score in tiling_scores.values())
+    if total == 0:
+        return tuple(sorted((dim, 0.0) for dim in tiling_scores))
+
+    return tuple(
+        sorted(
+            (dim, round(float(score) / total, 2))
+            for dim, score in tiling_scores.items()
+        )
+    )
+
+
 def _handle_combo_kernel_per_subkernel_blocks(
     size_hints: dict[str, int],
     inductor_meta: dict[str, Any],
@@ -2935,11 +2959,16 @@ def _handle_combo_kernel_per_subkernel_blocks(
     all_num_stages: list[int] = []
     unique_warp_stage_pairs: OrderedSet[tuple[int, int]] = OrderedSet()
 
-    combo_tuning_groups: list[dict[str, Any]] = []
+    # Group sub-kernels with identical config kwargs to skip redundant tuning.
+    group_map: dict[tuple[Any, ...], dict[str, Any]] = {}
 
     for i in range(num_kernels):
         subkernel_heuristic = combo_meta[f"heuristic_{i}"]
         size_hints_i = combo_meta[f"size_hints_{i}"]
+        tiling_scores_i = combo_meta.get(f"tiling_scores_{i}")
+        inductor_meta_i = dict(inductor_meta_clean)
+        if tiling_scores_i is not None:
+            inductor_meta_i["tiling_scores"] = tiling_scores_i
 
         if subkernel_heuristic == "pointwise":
             cfgs = pointwise(
@@ -2950,7 +2979,7 @@ def _handle_combo_kernel_per_subkernel_blocks(
                 else TileHint.DEFAULT,
                 filename=filename,
                 min_elem_per_thread=min_elem_per_thread,
-                inductor_meta=inductor_meta_clean,
+                inductor_meta=inductor_meta_i,
                 return_configs=True,
             )
             skip_rblock = False
@@ -2960,7 +2989,7 @@ def _handle_combo_kernel_per_subkernel_blocks(
                 reduction_hint=ReductionHint[combo_meta[f"reduction_hint_{i}"]],
                 triton_meta=triton_meta,
                 filename=filename,
-                inductor_meta=inductor_meta_clean,
+                inductor_meta=inductor_meta_i,
                 return_configs=True,
             )
             skip_rblock = False
@@ -2970,7 +2999,7 @@ def _handle_combo_kernel_per_subkernel_blocks(
                 reduction_hint=ReductionHint[combo_meta[f"reduction_hint_{i}"]],
                 triton_meta=triton_meta,
                 filename=filename,
-                inductor_meta=inductor_meta_clean,
+                inductor_meta=inductor_meta_i,
                 return_configs=True,
             )
             skip_rblock = True  # persistent reduction embeds RBLOCK in kernel body
@@ -2988,17 +3017,30 @@ def _handle_combo_kernel_per_subkernel_blocks(
         for c in cfgs:
             unique_warp_stage_pairs.add((c.num_warps, c.num_stages))
 
-        combo_tuning_groups.append(
-            {
+        cfg_key = tuple(item for c in cfgs for item in sorted(c.kwargs.items()))
+        group_key = (
+            (
+                subkernel_heuristic,
+                skip_rblock,
+                cfg_key,
+                _combo_tiling_signature(tiling_scores_i),
+            )
+            if torch._inductor.config.combo_kernel_autotune_grouping
+            else (i,)
+        )
+        if group_key in group_map:
+            group_map[group_key]["member_indices"].append(i)
+        else:
+            group_map[group_key] = {
                 "member_indices": [i],
                 "configs": cfgs,
                 "skip_rblock": skip_rblock,
                 "size_hints": size_hints_i,
             }
-        )
 
     unique_warp_stage_pairs.add((max(all_num_warps), max(all_num_stages)))
 
+    combo_tuning_groups = list(group_map.values())
     # Largest sub-kernels tuned first — they dominate runtime and get most freedom
     combo_tuning_groups.sort(
         key=lambda g: -functools.reduce(operator.mul, g["size_hints"].values())

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2613,7 +2613,7 @@ class ForeachKernelSchedulerNode(FusedSchedulerNode):
         """
         sorted_nodes = scheduler._topological_sort_nodes()
         grouped_nodes = []
-        max_num_nodes = 8
+        max_num_nodes = config.combo_kernel_max_num_nodes
 
         excluded_buffer_names: OrderedSet[str] = OrderedSet(
             [


### PR DESCRIPTION
## CI Fixes

Fixes #180011
Fixes #180012
Fixes #180013
Fixes #180014
Fixes #180015
Fixes #180016
Fixes #180021
Fixes #179952
Fixes #180022
Fixes #180025
Fixes #180027
Fixes #180028
Fixes #180029
Fixes #180549

Cherry-picks into `release/2.12` to fix the ROCm combo-kernel HIP compile-option regression introduced by #177715. The target fix is #180277; this PR also brings in the upstream prerequisites required for a clean apply and the follow-ups that re-enable the ROCm combo-kernel tests.

## Commits (6, in order)

1. #179041 - [Inductor] Group identical sub-kernels in combo kernel autotuning
2. #180526 - [Inductor] Make combo kernel max sub-kernel count configurable
3. #177725 - [Inductor] Add coordinate descent tuning for combo kernels (re-land)
4. #180277 - [ROCm][inductor][UT] Preserve combo kernel HIP compile options (target)
5. #180554 - [Inductor] Relax hardware-sensitive combo autotune grouping test
6. #180648 - [Inductor] remove skiprocm from combo kernels combokernel tests

Why the prerequisites are needed:
- #179041 introduces `_combo_tiling_signature` / `_update_combo_kernel_kwargs` that #180277 edits.
- #180526 adds `test_combo_kernel_max_num_nodes`, which #180277's new test sits adjacent to.
- #177725 adds `combo_coordesc_field_limits` / `group_coordesc_fields` that #180277 edits.
- #180554 relaxes the hardware-sensitive `test_combo_autotune_grouping` assertion (matches upstream `main`).
- #180648 removes the temporary file-wide ROCm `SkipTest` so the ROCm combo-kernel tests actually run.

## Validation on MI300X (AMD Instinct)

Built from this branch: `torch-2.12.0a0+git01122f1` with ROCm 7.2 + Triton 3.7.0.

All 10 previously-disabled tests listed in #180277 (which close issues #180011, #180012, #180013, #180014, #180015, #180016, #180021, #179952, #180022, #180025, #180027, #180028, #180029, #180549) now pass:
- `ComboKernelTestsPerSubkernelBlocks.test_activation_functions`
- `ComboKernelTestsPerSubkernelBlocks.test_combo_kernel_per_config_subkernel_poi`
- `ComboKernelBenchmarkTestsPerSubkernelBlocks.test_activation_benchmark`
- `ComboKernelBenchmarkTestsPerSubkernelBlocks.test_mutated_benchmark`
- `ComboKernelBenchmarkTestsPerSubkernelBlocks.test_round_robin_dispatch`
- `ComboKernelDynamicShapesTestsPerSubkernelBlocks.test_dynamic_shapes_activations`
- `ComboKernelDynamicShapesTestsPerSubkernelBlocks.test_dynamic_shapes_reduce`
- `ComboKernelDynamicShapesTestsPerSubkernelBlocks.test_dynamic_shapes_mutated`
- `ComboKernelTestsMaxAutotune.test_combo_kernel_max_autotune`
- `ComboKernelTestsMaxAutotune.test_combo_autotune_many_subkernels`

All new regression tests added by the cherry-picks also pass:
- `ComboKernelTestsMaxAutotune.test_combo_autotune_grouping` (from #179041)
- `ComboKernelTestsMaxAutotune.test_combo_autotune_grouping_uses_tiling_signature` (from #179041)
- `ComboKernelTests.test_combo_kernel_max_num_nodes_*` (3 parametrizations, from #180526)
- `ComboKernelTestsMaxAutotune.test_combo_kernel_coordesc_tunes_largest_subkernel_first` (from #177725)
- `ComboKernelTestsPerSubkernelBlocks.test_combo_kernel_amd_special_config_args_max_autotune_{False,True}` (from #180277 - new ROCm-only regression test)

## Notes

- The automated `@pytorchbot cherry-pick --onto release/2.12 -c critical` request on #180277 failed because release/2.12 lacks the prerequisites above - hence this manual cherry-pick PR.

These changes were enabled by Cursor.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @karthickai @naromero77amd
