### PR TITLE
[fbandroid][buckconfig removal] removal of unused method in caffe

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -11,7 +11,6 @@ load("//tools/build_defs:fbsource_utils.bzl", "is_arvr_mode")
 load("//tools/build_defs:glob_defs.bzl", "subdir_glob")
 load("//tools/build_defs:platform_defs.bzl", "IOS", "MACOSX")
 load("//tools/build_defs:type_defs.bzl", "is_list", "is_string")
-load("//tools/build_defs/android:build_mode_defs.bzl", is_production_build_android = "is_production_build")
 load("//tools/build_defs/apple:build_mode_defs.bzl", is_production_build_ios = "is_production_build", is_profile_build_ios = "is_profile_build")
 load(
     ":build_variables.bzl",


### PR DESCRIPTION
Summary: load("//tools/build_defs/android:build_mode_defs.bzl", is_production_build_android = "is_production_build") is unused

Test Plan: CI pases

Reviewed By: 8Keep

Differential Revision: D101848808


