### PR TITLE
Add TLS stack_bounds so we dont pay expensive reads

### DIFF
--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -526,20 +526,49 @@ Stats stats() {
 // No cache_mutex_ needed: frame-pointer walking reads only the stack,
 // unlike the x86 path which queries the DWARF FDE cache.
 
+// Stack bounds are essentially immutable over a thread's lifetime (base and
+// size are fixed at pthread_create for spawned threads).  On glibc aarch64
+// the main thread is the pathological case: pthread_getattr_np() parses
+// /proc/self/maps on every call because the main-thread stack isn't recorded
+// in TLS at pthread_create.  Cache once per thread to avoid that parse on
+// every unwind.  This mirrors the process-global caches the x86 unwinder
+// uses for /proc-derived data (library list, exe path); here the data is
+// per-thread, so thread_local is the right scope.
+//
+// Edge case: main thread's stack can grow up to RLIMIT_STACK, and this cache
+// freezes the bounds at first observation.  If the stack later grows past
+// cached lo, unwind_c will terminate early on those frames rather than
+// follow them - truncated backtrace, not incorrect.  In practice main-thread
+// stack reaches steady-state depth during init, long before heavy unwinding.
+namespace {
+struct StackBounds {
+  uintptr_t lo = 0;
+  uintptr_t hi = 0;
+  bool initialized = false;
+};
+thread_local StackBounds tls_stack_bounds;
+} // namespace
+
 static bool get_stack_bounds(uintptr_t& lo, uintptr_t& hi) {
-  pthread_attr_t attr;
-  if (pthread_getattr_np(pthread_self(), &attr) != 0) {
-    return false;
+  auto& b = tls_stack_bounds;
+  if (!b.initialized) {
+    pthread_attr_t attr;
+    if (pthread_getattr_np(pthread_self(), &attr) != 0) {
+      return false;
+    }
+    void* base = nullptr;
+    size_t size = 0;
+    int rc = pthread_attr_getstack(&attr, &base, &size);
+    pthread_attr_destroy(&attr);
+    if (rc != 0) {
+      return false;
+    }
+    b.lo = reinterpret_cast<uintptr_t>(base);
+    b.hi = b.lo + size;
+    b.initialized = true;
   }
-  void* base = nullptr;
-  size_t size = 0;
-  int rc = pthread_attr_getstack(&attr, &base, &size);
-  pthread_attr_destroy(&attr);
-  if (rc != 0) {
-    return false;
-  }
-  lo = reinterpret_cast<uintptr_t>(base);
-  hi = lo + size;
+  lo = b.lo;
+  hi = b.hi;
   return true;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181018



Before this PR
```Shell
 python /home/drisspg/meta/pytorch/agent_space/unwind_repro/bench_unwind.py
platform        : aarch64 / Linux
torch           : 2.12.0.dev20260414+cu130
git             : 1b7d09a58cbfce144ac9c429a169ef3d693351a0
TORCH_SHOW_CPP  : 0
cuda available  : True
iters           : 20000 (warmup 500)

direct      20000 iters     3.740s    187.02 us/call
worker      20000 iters     0.018s      0.88 us/call
alloc       20000 iters     9.568s    478.39 us/call

```

After:

```Shell
 python /home/drisspg/meta/pytorch/agent_space/unwind_repro/bench_unwind.py
platform        : aarch64 / Linux
torch           : 2.13.0a0+git446033e
git             : 446033e622b25fea5fb72c3b1c5d9f9da2a11ef3
TORCH_SHOW_CPP  : 0
cuda available  : True
iters           : 20000 (warmup 500)

direct      20000 iters     0.008s      0.39 us/call
worker      20000 iters     0.007s      0.36 us/call
alloc       20000 iters     0.082s      4.08 us/call
```




Script I worked on with claude as a proxy:
```Py
"""
Microbenchmark for the aarch64 C++ unwinder regression.

Background: on aarch64, torch::unwind::unwind() now does real frame-pointer
walking. Its get_stack_bounds() calls pthread_getattr_np() per invocation,
which on the *main thread* parses /proc/self/maps every time. Non-main
threads cache stack bounds in TLS at pthread_create, so they should be fast.

Three modes:
  direct  -- gather_traceback() in a tight loop on the main thread
  worker  -- same loop on a spawned thread (expected: much faster on aarch64)
  alloc   -- allocate many small CUDA tensors with _record_memory_history on,
             exercising the full CachingAllocator -> CapturedTraceback path

Usage:
  python bench_unwind.py --mode direct --iters 20000
  python bench_unwind.py --mode worker --iters 20000
  python bench_unwind.py --mode alloc  --iters 20000
  python bench_unwind.py --mode all    --iters 20000
"""

import argparse
import os
import platform
import threading
import time

import torch
from torch._C._profiler import gather_traceback


def bench_direct(iters: int) -> float:
    t0 = time.perf_counter()
    for _ in range(iters):
        gather_traceback(python=False, script=False, cpp=True)
    return time.perf_counter() - t0


def bench_worker(iters: int) -> float:
    elapsed: list[float] = []

    def run():
        t0 = time.perf_counter()
        for _ in range(iters):
            gather_traceback(python=False, script=False, cpp=True)
        elapsed.append(time.perf_counter() - t0)

    th = threading.Thread(target=run)
    th.start()
    th.join()
    return elapsed[0]


def bench_alloc(iters: int) -> float:
    if not torch.cuda.is_available():
        raise RuntimeError("alloc mode requires CUDA")
    torch.cuda.memory._record_memory_history(enabled="all", max_entries=iters * 2)
    try:
        torch.cuda.synchronize()
        t0 = time.perf_counter()
        for _ in range(iters):
            torch.empty(16, device="cuda")
        torch.cuda.synchronize()
        return time.perf_counter() - t0
    finally:
        torch.cuda.memory._record_memory_history(enabled=None)


def report(label: str, iters: int, seconds: float) -> None:
    us_per_call = seconds * 1e6 / iters
    print(f"{label:<8} {iters:>8} iters  {seconds:8.3f}s  {us_per_call:8.2f} us/call")


def main() -> None:
    ap = argparse.ArgumentParser()
    ap.add_argument("--mode", choices=["direct", "worker", "alloc", "all"], default="all")
    ap.add_argument("--iters", type=int, default=20000)
    ap.add_argument("--warmup", type=int, default=500)
    args = ap.parse_args()

    print(f"platform        : {platform.machine()} / {platform.system()}")
    print(f"torch           : {torch.__version__}")
    print(f"git             : {torch.version.git_version}")
    print(f"TORCH_SHOW_CPP  : {os.environ.get('TORCH_SHOW_CPP_STACKTRACES', '<unset>')}")
    print(f"cuda available  : {torch.cuda.is_available()}")
    print(f"iters           : {args.iters} (warmup {args.warmup})")
    print()

    for _ in range(args.warmup):
        gather_traceback(python=False, script=False, cpp=True)

    if args.mode in ("direct", "all"):
        report("direct", args.iters, bench_direct(args.iters))
    if args.mode in ("worker", "all"):
        report("worker", args.iters, bench_worker(args.iters))
    if args.mode in ("alloc", "all"):
        if torch.cuda.is_available():
            report("alloc", args.iters, bench_alloc(args.iters))
        else:
            print("alloc    skipped (no CUDA)")


if __name__ == "__main__":
    main()

```

cc @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01 @robert-hardwick @nWEIdia