### PR TITLE
Fix: proper dtype validation error for nanmean() with integral or Bool dtype

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1465,6 +1465,11 @@ Tensor& nanmean_out(
   TORCH_CHECK(
     !at::isIntegralType(self.scalar_type(), /*includeBool=*/true),
     "nanmean(): integral types and 'Bool' are not supported for nanmean, even for empty tensors.");
+  if (opt_dtype.has_value()) {
+    TORCH_CHECK(
+      !at::isIntegralType(*opt_dtype, /*includeBool=*/true),
+      "nanmean(): integral types and 'Bool' are not supported for nanmean output dtype.");
+  }
   TORCH_CHECK(
       self.is_floating_point() || self.is_complex(),
       "nanmean(): expected input to have floating point or complex dtype but got ",
@@ -1483,6 +1488,11 @@ Tensor nanmean(
       self.is_floating_point() || self.is_complex(),
       "nanmean(): expected input to have floating point or complex dtype but got ",
       self.scalar_type());
+  if (opt_dtype.has_value()) {
+    TORCH_CHECK(
+      !at::isIntegralType(*opt_dtype, /*includeBool=*/true),
+      "nanmean(): integral types and 'Bool' are not supported for nanmean output dtype.");
+  }
   const auto factor =
       at::native::isnan(self.detach()).logical_not_().sum(dim, keepdim);
   return at::nansum(self, dim, keepdim, opt_dtype).div(factor);


### PR DESCRIPTION
Good day

## Description

When calling `torch.nanmean(input=tensor, dtype=torch.int64)` or `dtype=torch.bool` on a non-empty tensor, the previous code threw a low-level `RuntimeError: "nansum_cpu" not implemented for 'Long'` or similar, because the `nansum` kernel at a lower level doesn't support those dtypes.

This fix adds proper `TORCH_CHECK` validation at the `nanmean` level (before calling `nansum`) to raise a clear, user-friendly error message:

> **"nanmean(): integral types and 'Bool' are not supported for nanmean output dtype."**

This is consistent with the existing error message for empty tensors and provides early, clear feedback to users.

## Root Cause

In `aten/src/ATen/native/ReduceOps.cpp`, both `nanmean()` and `nanmean_out()` checked the input tensor type but did **not** validate the `dtype` parameter. When an integral or `Bool` `dtype` was passed, it was forwarded to `nansum_out()` / `nansum()`, which dispatched to a kernel (`nansum_cpu`) that only supports floating-point and complex types — resulting in the confusing "not implemented" error.

## Fix

Added `dtype` parameter validation in both `nanmean()` and `nanmean_out()`:

```cpp
if (opt_dtype.has_value()) {
  TORCH_CHECK(
    !at::isIntegralType(*opt_dtype, /*includeBool=*/true),
    "nanmean(): integral types and 'Bool' are not supported for nanmean output dtype.");
}
```

## Testing

- `torch.nanmean(input=tensor, dtype=torch.int64)` → clear error about unsupported dtype
- `torch.nanmean(input=tensor, dtype=torch.bool)` → clear error about unsupported dtype
- `torch.nanmean(input=tensor, dtype=torch.float32)` → works correctly
- `torch.nanmean(input=tensor)` → works correctly (no dtype change)

## Links

Fixes: pytorch/pytorch#131043