### PR TITLE
[PP] Support extra loss_fn kwargs in pipeline schedules

### DIFF
--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -280,6 +280,11 @@ class _PipelineSchedule(ABC):
         # Derived
         self._has_backward = self._loss_fn is not None
 
+        # Extra keyword arguments forwarded to the loss function. Callers
+        # can set this dict before ``step()`` to pass additional kwargs
+        # (e.g. ``global_valid_tokens`` for chunked cross-entropy loss).
+        self._loss_kwargs: dict[str, Any] = {}
+
         # Holds the losses for each microbatch.
         self._internal_losses: list[torch.Tensor] = []
         logger.info("Using %s", self.__class__.__name__)
@@ -444,6 +449,7 @@ class _PipelineSchedule(ABC):
                         loss_fn=self._loss_fn,
                         target=target,
                         received_grad_meta=prev_stage_grad_meta,
+                        loss_kwargs=self._loss_kwargs,
                     )
                 bwd_initialized = True
 
@@ -554,7 +560,7 @@ class _PipelineSchedule(ABC):
         return arg_mbs, kwarg_mbs
 
     def _compute_loss(self, output, target):
-        return self._loss_fn(output, target)  # type: ignore[misc]
+        return self._loss_fn(output, target, **self._loss_kwargs)  # type: ignore[misc]
 
     def _split_inputs(
         self,

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -1920,6 +1920,7 @@ class PipelineStage(_PipelineStageBase):
         loss_fn: Callable[..., torch.Tensor] | None = None,
         target: torch.Tensor | None = None,
         received_grad_meta: _StageBackwardMeta | None = None,
+        loss_kwargs: dict[str, Any] | None = None,
     ) -> _StageBackwardMeta | None:
         """Run backward metadata inference (Stage N → 0).
 
@@ -1928,6 +1929,8 @@ class PipelineStage(_PipelineStageBase):
             target: Target tensor (required for the last stage).
             received_grad_meta: Grad metadata from next same-rank stage
                 (V-schedule only).
+            loss_kwargs: Extra keyword arguments forwarded to the loss
+                function (e.g. ``global_valid_tokens``).
 
         Returns:
             ``_StageBackwardMeta`` for the previous stage, or ``None`` if sent via P2P.
@@ -1954,6 +1957,7 @@ class PipelineStage(_PipelineStageBase):
             loss = loss_fn(
                 fwd_outputs[0] if len(fwd_outputs) == 1 else fwd_outputs,
                 inference_target,
+                **(loss_kwargs or {}),
             )
             self._stage_meta.output_grads = None
             all_input_grads = self._compute_input_grads(
@@ -2062,6 +2066,7 @@ class PipelineStage(_PipelineStageBase):
         loss_fn: Callable[..., torch.Tensor] | None = None,
         target: torch.Tensor | None = None,
         received_grad_meta: "_StageBackwardMeta | None" = None,
+        loss_kwargs: dict[str, Any] | None = None,
     ) -> "_StageBackwardMeta | None":
         """Run backward metadata inference and prepare backward infrastructure.
 
@@ -2076,6 +2081,7 @@ class PipelineStage(_PipelineStageBase):
                 loss_fn=loss_fn,
                 target=target,
                 received_grad_meta=received_grad_meta,
+                loss_kwargs=loss_kwargs,
             )
             # Validate dynamically inferred metadata against user-provided metadata
             self._validate_inferred_metadata()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181023

Add `_loss_kwargs` dict to `_PipelineSchedule` that is forwarded to the
loss function in both `_compute_loss` and `_backward_metadata_inference`.

This enables loss functions that require additional arguments beyond
`(output, target)`, such as chunked cross-entropy loss which needs
`global_valid_tokens` for proper scaling. Callers set the dict before
`step()`:

    schedule._loss_kwargs = {"global_valid_tokens": tokens}

Without this, `_backward_metadata_inference` calls `loss_fn(output,
target)` with only 2 args, causing a TypeError when the loss function
requires additional keyword arguments.