### PR TITLE
[CUDA] Use torch.cuda.device in dlpack test

### DIFF
--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -368,13 +368,16 @@ class TestTorchDlPack(TestCase):
     def test_dlpack_tensor_on_different_device(self, devices):
         dev0, dev1 = devices[:2]
 
-        with torch.device(dev0):
-            x = make_tensor((5,), dtype=torch.float32, device=dev0)
+        x = make_tensor((5,), dtype=torch.float32, device=dev0)
 
+        if self.device_type == "cuda":
+            ctx = torch.cuda.device(dev1)
+        else:
+            ctx = torch.device(dev1)
         with self.assertRaisesRegex(
             BufferError, r"Can't export tensors on a different CUDA device"
         ):
-            with torch.device(dev1):
+            with ctx:
                 x.__dlpack__()
 
     # TODO: add interchange tests once NumPy 1.22 (dlpack support) is required


### PR DESCRIPTION
Fixes #181024 by using `torch.cuda.device` on CUDA and retaining `torch.device` for XPU. @shangerxin can you or somebody else please confirm that this change doesn't break this test on XPU?

cc @eqy