### PR TITLE
Factor nanmean dtype checks into a helper + add kwarg coverage

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1475,6 +1475,21 @@ Tensor& mean_dtype_out(const Tensor &self, std::optional<ScalarType> dtype, Tens
   return at::mean_out(result, self, IntArrayRef{}, false, dtype);
 }
 
+static void check_nanmean_dtype(
+    const Tensor& self,
+    const std::optional<ScalarType>& opt_dtype) {
+  TORCH_CHECK(
+      self.is_floating_point() || self.is_complex(),
+      "nanmean(): expected input to have floating point or complex dtype but got ",
+      self.scalar_type());
+  if (opt_dtype.has_value()) {
+    TORCH_CHECK(
+        at::isFloatingType(*opt_dtype) || at::isComplexType(*opt_dtype),
+        "nanmean(): could not infer output dtype. Optional dtype must be either a floating point or complex dtype. Got: ",
+        *opt_dtype);
+  }
+}
+
 // TODO(@heitorschueroff) implement custom kernels for nanmean
 Tensor& nanmean_out(
     const Tensor& self,
@@ -1482,21 +1497,7 @@ Tensor& nanmean_out(
     bool keepdim,
     std::optional<ScalarType> opt_dtype,
     Tensor& result) {
-  // Check if input dtype is an integral type or Bool and raise an error
-  TORCH_CHECK(
-    !at::isIntegralType(self.scalar_type(), /*includeBool=*/true),
-    "nanmean(): integral types and 'Bool' are not supported for nanmean, even for empty tensors.");
-  TORCH_CHECK(
-      self.is_floating_point() || self.is_complex(),
-      "nanmean(): expected input to have floating point or complex dtype but got ",
-      self.scalar_type());
-  // Check if opt_dtype (output dtype) is valid - must be floating point or complex
-  if (opt_dtype.has_value()) {
-    TORCH_CHECK(
-        at::isFloatingType(opt_dtype.value()) || at::isComplexType(opt_dtype.value()),
-        "nanmean(): could not infer output dtype. Optional dtype must be either a floating point or complex dtype. Got: ",
-        opt_dtype.value());
-  }
+  check_nanmean_dtype(self, opt_dtype);
   const auto factor = at::native::isnan(self).logical_not_().sum(dim, keepdim);
   at::nansum_out(result, self, dim, keepdim, opt_dtype).div_(factor);
   return result;
@@ -1507,17 +1508,7 @@ Tensor nanmean(
     at::OptionalIntArrayRef dim,
     bool keepdim,
     std::optional<ScalarType> opt_dtype) {
-  TORCH_CHECK(
-      self.is_floating_point() || self.is_complex(),
-      "nanmean(): expected input to have floating point or complex dtype but got ",
-      self.scalar_type());
-  // Check if opt_dtype (output dtype) is valid - must be floating point or complex
-  if (opt_dtype.has_value()) {
-    TORCH_CHECK(
-        at::isFloatingType(opt_dtype.value()) || at::isComplexType(opt_dtype.value()),
-        "nanmean(): could not infer output dtype. Optional dtype must be either a floating point or complex dtype. Got: ",
-        opt_dtype.value());
-  }
+  check_nanmean_dtype(self, opt_dtype);
   const auto factor =
       at::native::isnan(self.detach()).logical_not_().sum(dim, keepdim);
   return at::nansum(self, dim, keepdim, opt_dtype).div(factor);

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1493,6 +1493,21 @@ Tensor& mean_dtype_out(const Tensor &self, std::optional<ScalarType> dtype, Tens
   return at::mean_out(result, self, IntArrayRef{}, false, dtype);
 }
 
+static void check_nanmean_dtype(
+    const Tensor& self,
+    const std::optional<ScalarType>& opt_dtype) {
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      self.is_floating_point() || self.is_complex(),
+      "nanmean(): expected input to have floating point or complex dtype but got ",
+      self.scalar_type());
+  if (opt_dtype.has_value()) {
+    TORCH_CHECK(
+        at::isFloatingType(*opt_dtype) || at::isComplexType(*opt_dtype),
+        "nanmean(): could not infer output dtype. Optional dtype must be either a floating point or complex dtype. Got: ",
+        *opt_dtype);
+  }
+}
+
 // TODO(@heitorschueroff) implement custom kernels for nanmean
 Tensor& nanmean_out(
     const Tensor& self,
@@ -1500,21 +1515,7 @@ Tensor& nanmean_out(
     bool keepdim,
     std::optional<ScalarType> opt_dtype,
     Tensor& result) {
-  // Check if input dtype is an integral type or Bool and raise an error
-  TORCH_CHECK_NOT_IMPLEMENTED(
-    !at::isIntegralType(self.scalar_type(), /*includeBool=*/true),
-    "nanmean(): integral types and 'Bool' are not supported for nanmean, even for empty tensors.");
-  TORCH_CHECK_NOT_IMPLEMENTED(
-      self.is_floating_point() || self.is_complex(),
-      "nanmean(): expected input to have floating point or complex dtype but got ",
-      self.scalar_type());
-  // Check if opt_dtype (output dtype) is valid - must be floating point or complex
-  if (opt_dtype.has_value()) {
-    TORCH_CHECK(
-        at::isFloatingType(opt_dtype.value()) || at::isComplexType(opt_dtype.value()),
-        "nanmean(): could not infer output dtype. Optional dtype must be either a floating point or complex dtype. Got: ",
-        opt_dtype.value());
-  }
+  check_nanmean_dtype(self, opt_dtype);
   const auto factor = at::native::isnan(self).logical_not_().sum(dim, keepdim);
   at::nansum_out(result, self, dim, keepdim, opt_dtype).div_(factor);
   return result;
@@ -1525,17 +1526,7 @@ Tensor nanmean(
     at::OptionalIntArrayRef dim,
     bool keepdim,
     std::optional<ScalarType> opt_dtype) {
-  TORCH_CHECK_NOT_IMPLEMENTED(
-      self.is_floating_point() || self.is_complex(),
-      "nanmean(): expected input to have floating point or complex dtype but got ",
-      self.scalar_type());
-  // Check if opt_dtype (output dtype) is valid - must be floating point or complex
-  if (opt_dtype.has_value()) {
-    TORCH_CHECK(
-        at::isFloatingType(opt_dtype.value()) || at::isComplexType(opt_dtype.value()),
-        "nanmean(): could not infer output dtype. Optional dtype must be either a floating point or complex dtype. Got: ",
-        opt_dtype.value());
-  }
+  check_nanmean_dtype(self, opt_dtype);
   const auto factor =
       at::native::isnan(self.detach()).logical_not_().sum(dim, keepdim);
   return at::nansum(self, dim, keepdim, opt_dtype).div(factor);

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2355,6 +2355,21 @@ class TestReductions(TestCase):
             ):
                 torch.nanmean(t)
 
+    @onlyCPU
+    @dtypes(*integral_types_and(torch.bool))
+    def test_nanmean_opt_dtype_integral(self, device, dtype):
+        # Regression test for #131043: nanmean(empty_tensor, dtype=int) used to
+        # silently return nan while the non-empty case errored cryptically. Both
+        # paths should raise the same dtype-validation error, matching mean().
+        for shape in [(0,), (0, 3), (3,), (2, 3)]:
+            t = make_tensor(shape, dtype=torch.float32, device=device)
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"nanmean\(\): could not infer output dtype\. Optional dtype must be "
+                r"either a floating point or complex dtype\. Got: \w+"
+            ):
+                torch.nanmean(t, dtype=dtype)
+
     @skipIfMPS
     @precisionOverride({torch.float16: 1e-2, torch.bfloat16: 1e-2})
     @dtypes(*set(all_types_and(torch.half, torch.bfloat16)) - {torch.uint8})

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2297,6 +2297,21 @@ class TestReductions(TestCase):
             ):
                 torch.nanmean(t)
 
+    @onlyCPU
+    @dtypes(*integral_types_and(torch.bool))
+    def test_nanmean_opt_dtype_integral(self, device, dtype):
+        # Regression test for #131043: nanmean(empty_tensor, dtype=int) used to
+        # silently return nan while the non-empty case errored cryptically. Both
+        # paths should raise the same dtype-validation error, matching mean().
+        for shape in [(0,), (0, 3), (3,), (2, 3)]:
+            t = make_tensor(shape, dtype=torch.float32, device=device)
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"nanmean\(\): could not infer output dtype\. Optional dtype must be "
+                r"either a floating point or complex dtype\. Got: \w+"
+            ):
+                torch.nanmean(t, dtype=dtype)
+
     @skipIfMPS
     @precisionOverride({torch.float16: 1e-2, torch.bfloat16: 1e-2})
     @dtypes(*set(all_types_and(torch.half, torch.bfloat16)) - {torch.uint8})


### PR DESCRIPTION
## Summary

This PR was originally a duplicate of #172809, which was merged to main on
2026-05-03 and closed #131043. Rebased and refocused as a small follow-up:

1. **Refactor.** #172809 added `opt_dtype` validation to both `nanmean` and
   `nanmean_out`, leaving identical 14-line check blocks in each. Pull them
   into a single `check_nanmean_dtype` helper. Also drops the redundant
   integral-type check in `nanmean_out`; it fires a strictly narrower
   subset of the floating/complex check that immediately follows.

2. **Test.** Add `test_nanmean_opt_dtype_integral` covering
   `torch.nanmean(t, dtype=int_dtype)` over empty and non-empty inputs.
   The existing `test_nanmean_integral_types` only exercises integer
   *inputs*, not the `dtype=` kwarg path that motivated #131043.

No behavior change except one message: `nanmean.out` with an integral or bool input still raises `NotImplementedError`, but now with the same `expected input to have floating point or complex dtype` text as `nanmean` instead of the old `integral types and 'Bool' are not supported` text (no test asserted the old text). All other paths are byte-identical to main.

## Test plan

- `python test/test_reductions.py -k test_nanmean` (existing
  `test_nanmean_integral_types` continues to pass; new
  `test_nanmean_opt_dtype_integral` covers the kwarg path).

