### PR TITLE
[misc] Fix duplicated-word typos in comments and docstrings

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -3430,7 +3430,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--distributed-master-port",
         default="6789",
-        help="Port to bind for for torch.distributed.  Use the default unless it's conflicting with another user",
+        help="Port to bind for torch.distributed.  Use the default unless it's conflicting with another user",
     )
     parser.add_argument(
         "--dynamic-shapes",

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -174,7 +174,7 @@ def load_derivatives(
 
         add_view_copy_derivatives(infos, view_groups)
 
-        # cache both loaded infos as well a a set of all the dispatch_keys/aliases
+        # cache both loaded infos as well as a set of all the dispatch_keys/aliases
         # that appear in derivatives.yaml. used_dispatch_keys is useful for generating
         # VariableType.cpp where we need a TORCH_LIBRARY_IMPL for every autograd dispatch key used
         _GLOBAL_LOAD_DERIVATIVE_CACHE[key] = infos, used_dispatch_keys

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -3989,7 +3989,7 @@ class SubgraphTracer(fx.Tracer):
             #
             #  1. When create_graph_input for a tensor that has symbolic shapes,
             #     we look for basic symbols in its size and stride, we check if the symbol is bound
-            #     in current graph (i.e. bound_symbols), it it's not bound, we'll create a placeholder
+            #     in current graph (i.e. bound_symbols), if it's not bound, we'll create a placeholder
             #     for it then recursively check its parent, creates ph if not bound at parent until.
             #     reachting the top-level, where we require a source is attached to the proxy.
             #

--- a/torch/mtia/_utils.py
+++ b/torch/mtia/_utils.py
@@ -21,7 +21,7 @@ def _get_device_index(
     """
 
     if device is None and optional:
-        # If device is None (frequent), then we can can short-circuit the logic
+        # If device is None (frequent), then we can short-circuit the logic
         return torch._C._mtia_getDevice()
     if isinstance(device, int):
         return device

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -281,7 +281,7 @@ class Buffer(torch.Tensor, metaclass=_BufferMeta):
 class UninitializedBuffer(UninitializedTensorMixin, torch.Tensor):
     r"""A buffer that is not initialized.
 
-    Uninitialized Buffer is a a special case of :class:`torch.Tensor`
+    Uninitialized Buffer is a special case of :class:`torch.Tensor`
     where the shape of the data is still unknown.
 
     Unlike a :class:`torch.Tensor`, uninitialized parameters

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -115,7 +115,7 @@ class FSDPTestModel(nn.Module, ABC):
 
     @abstractmethod
     def get_input(self, device) -> tuple[torch.Tensor, ...]:
-        """Returns an input for the model as as tuple."""
+        """Returns an input for the model as a tuple."""
         ...
 
     @abstractmethod

--- a/torchgen/api/autograd.py
+++ b/torchgen/api/autograd.py
@@ -240,7 +240,7 @@ class DifferentiableInput:
 
 
 # Represents a differentiable `Return`.
-# How it it different from the `Return` type?
+# How is it different from the `Return` type?
 # - The name in `Return` is optional. Here it is always populated using the same
 #   `cpp.return_names()` method.
 #   TODO: some cpp naming logic (e.g. resolving name conflict) might be irrelevant?


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181028

Authored with Claude (Typo Terminator).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98