### PR TITLE
Validate inputs in math_channel_shuffle

### DIFF
--- a/aten/src/ATen/native/ChanelShuffle.cpp
+++ b/aten/src/ATen/native/ChanelShuffle.cpp
@@ -73,8 +73,17 @@ Tensor channel_shuffle(const Tensor& self, int64_t groups) {
 }
 
 Tensor math_channel_shuffle(const Tensor& self, int64_t groups) {
+  TORCH_CHECK(self.dim() > 2,
+              "channel_shuffle expects input with > 2 dims, but got input with sizes ",
+              self.sizes());
   int64_t b = self.size(0);
   int64_t c = self.size(1);
+  TORCH_CHECK(groups > 0,
+              "Number of groups to divide channels in must be positive.",
+              " Value of groups:", groups);
+  TORCH_CHECK((c % groups) == 0,
+              "Number of channels must be divisible by groups. Got ",
+              c, " channels and ", groups, " groups.");
   int64_t oc = c / groups;
 
   auto input_reshaped = self.view({b, groups, oc, -1});

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6740,6 +6740,21 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             groups = 2
             torch.native_channel_shuffle(input_tensor, groups)
 
+        # Regression test for #173500: the CompositeImplicitAutograd fallback
+        # (used by non-CPU backends like CUDA/MPS) used to skip validation and
+        # crash with a floating-point exception on groups=0. The meta device
+        # also routes through this fallback.
+        meta_tensor = torch.empty([1, 3, 2, 2], device="meta")
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Number of groups to divide channels in must be positive.*"):
+            torch.native_channel_shuffle(meta_tensor, 0)
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Number of channels must be divisible by groups.*"):
+            torch.native_channel_shuffle(meta_tensor, 2)
+        with self.assertRaisesRegex(RuntimeError,
+                                    "channel_shuffle expects input with > 2 dims,.*"):
+            torch.native_channel_shuffle(torch.empty([1, 2], device="meta"), 2)
+
     @skipIfTorchDynamo("TorchDynamo fails here for unknown reasons")
     def test_native_channel_shuffle_return_alias_of_self(self):
         groups = 3


### PR DESCRIPTION
Fixes #173500.

`torch.native_channel_shuffle(cuda_tensor, 0)` crashes with a floating-point exception. `native_channel_shuffle` has `CPU: channel_shuffle_cpu` as its only device-specific dispatch, so CUDA (and every other non-CPU backend — MPS, meta, XPU, etc.) falls through to the `CompositeImplicitAutograd` fallback `math_channel_shuffle`, which does no input validation before computing `c / groups`.

Mirror the CPU path's existing `dim > 2` / `groups > 0` / `c % groups == 0` checks in `math_channel_shuffle` so the same clear `RuntimeError` is raised on all backends instead of an FPE.

Test uses the `meta` device since it routes through the same fallback and runs in CI without a GPU.