### PR TITLE
[MPS] Migrate SDPA from MPSGraph to Metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Attention.h
+++ b/aten/src/ATen/native/mps/kernels/Attention.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <c10/metal/common.h>
+
+// Tile size for shared memory blocking. 32 x 32 = 1024 threads per threadgroup.
+#define TILE_SIZE 32
+
+template <unsigned N = 4, typename idx_type_t = uint32_t>
+struct SDPAParams {
+  ::c10::metal::array<idx_type_t, N> q_strides;
+  ::c10::metal::array<idx_type_t, N> k_strides;
+  ::c10::metal::array<idx_type_t, N> v_strides;
+  ::c10::metal::array<idx_type_t, N> mask_strides;
+  ::c10::metal::array<idx_type_t, N> out_strides;
+  ::c10::metal::array<idx_type_t, N> attn_strides;
+  uint32_t batch_size;
+  uint32_t num_heads;
+  uint32_t L;
+  uint32_t E;
+  uint32_t S;
+  uint32_t Ev;
+  float scale;
+};

--- a/aten/src/ATen/native/mps/kernels/Attention.metal
+++ b/aten/src/ATen/native/mps/kernels/Attention.metal
@@ -1,5 +1,6 @@
 // Largely influeneced by
 // https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/kernels/scaled_dot_product_attention.metal
+#include <ATen/native/mps/kernels/Attention.h>
 #include <c10/metal/utils.h>
 #include <metal_simdgroup>
 #include <metal_stdlib>
@@ -524,6 +525,425 @@ kernel void attention(
   }
 }
 
+// simdgroup_multiply_accumulate operates on 8x8 sub-tiles
+#define SUBTILE_SIZE 8
+// number of 8-wide sub-tiles across one tile dimension
+#define SUBTILE_GRID_SIZE (TILE_SIZE / SUBTILE_SIZE)
+// Threadgroup memory needed: two TILE_SIZExTILE_SIZE buffers. For 32x32 tiles,
+// this is 8 KB
+#define SMEM_FLOATS (2 * TILE_SIZE * TILE_SIZE)
+
+// Scaled matrix multiplication `r = scale * a @ b`.
+// `a` is size (M, N)
+// `b` is size (N, K)
+// `r` is size (M, K)
+//
+// For performance, this function uses a tiled matmul algorithm where each
+// threadgroup operates on one pair of TILE_SIZExTILE_SIZE tiles of the inputs
+// at a time, so that work can be done in `threadgroup` memory, which is faster
+// than `device` or `constant` memory.
+//
+// Each pair of threadgroup tiles is further broken up into 8x8 sub-tiles, whose
+// partial results are calculated with `simdgroup_multiply_accumulate`, which is
+// a performant way to calculate a matmul between two 8x8 matrices and
+// accumulate with previous results.
+//
+// Note: the pointer type for `a` is templated because both `constant` and
+// `device` pointer types need to be supported for this argument.
+template <typename T, typename A_ptr>
+static void mm_simdgroup(
+    device T* r,
+    uint32_t r_stride0,
+    uint32_t r_stride1,
+    A_ptr a,
+    uint32_t a_stride0,
+    uint32_t a_stride1,
+    constant T* b,
+    uint32_t b_stride0,
+    uint32_t b_stride1,
+    uint32_t M,
+    uint32_t N,
+    uint32_t K,
+    float scale,
+    uint32_t threadgroup_row,
+    uint32_t threadgroup_col,
+    uint simdgroup_idx,
+    threadgroup float* smem) {
+  threadgroup float* tile_a = smem;
+  threadgroup float* tile_b = smem + TILE_SIZE * TILE_SIZE;
+
+  const uint32_t num_M = (M + TILE_SIZE - 1) / TILE_SIZE;
+  const uint32_t num_K = (K + TILE_SIZE - 1) / TILE_SIZE;
+  const uint32_t num_N = (N + TILE_SIZE - 1) / TILE_SIZE;
+
+  // simdgroup_idx 0..15 are active, one for each 4x4 grid position of 8x8
+  // output sub-tiles.
+  // simdgroup_idx 16..31 are inactive of the simd multiply-accumulate, but they
+  // still help load tile data.
+  const bool simd_active =
+      (simdgroup_idx < (uint32_t)(SUBTILE_GRID_SIZE * SUBTILE_GRID_SIZE));
+  const uint32_t subtile_m =
+      simdgroup_idx / SUBTILE_GRID_SIZE; // 0..3 are active
+  const uint32_t subtile_k =
+      simdgroup_idx % SUBTILE_GRID_SIZE; // 0..3 are active
+
+  for (uint32_t tile_m = 0; tile_m < num_M; tile_m++) {
+    for (uint32_t tile_k = 0; tile_k < num_K; tile_k++) {
+      simdgroup_float8x8 subtile_r =
+          make_filled_simdgroup_matrix<float, 8, 8>(0.f);
+
+      for (uint32_t tile_n = 0; tile_n < num_N; tile_n++) {
+        // All 1024 threads cooperatively fill tile_a and tile_b
+        uint32_t a_row = tile_m * TILE_SIZE + threadgroup_row,
+                 a_col = tile_n * TILE_SIZE + threadgroup_col;
+        tile_a[threadgroup_row * TILE_SIZE + threadgroup_col] =
+            (a_row < M && a_col < N)
+            ? float(a[a_row * a_stride0 + a_col * a_stride1])
+            : 0.f;
+        uint32_t b_row = tile_n * TILE_SIZE + threadgroup_row,
+                 b_col = tile_k * TILE_SIZE + threadgroup_col;
+        tile_b[threadgroup_row * TILE_SIZE + threadgroup_col] =
+            (b_row < N && b_col < K)
+            ? float(b[b_row * b_stride0 + b_col * b_stride1])
+            : 0.f;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // Active simdgroups compute their 8x8 sub-tile and accumulate into
+        // subtile_r.
+        if (simd_active) {
+          for (uint32_t subtile_n = 0; subtile_n < (uint32_t)SUBTILE_GRID_SIZE;
+               subtile_n++) {
+            simdgroup_float8x8 subtile_a, subtile_b;
+            // subtile_a <-- tile_a[subtile_m*8 .. subtile_m*8+7][subtile_n*8
+            // .. subtile_n*8+7]
+            simdgroup_load(
+                subtile_a,
+                tile_a,
+                TILE_SIZE,
+                ulong2(subtile_n * SUBTILE_SIZE, subtile_m * SUBTILE_SIZE));
+            // subtile_b <-- tile_b[subtile_n*8 .. subtile_n*8+7][subtile_k*8 ..
+            // subtile_k*8+7]
+            simdgroup_load(
+                subtile_b,
+                tile_b,
+                TILE_SIZE,
+                ulong2(subtile_k * SUBTILE_SIZE, subtile_n * SUBTILE_SIZE));
+            simdgroup_multiply_accumulate(
+                subtile_r, subtile_a, subtile_b, subtile_r);
+          }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+      }
+
+      // Scatter result back through smem, then write to r. The active
+      // simdgroups cover all sub-tiles of the output tile, so every position in
+      // tile_a is written.
+      if (simd_active) {
+        simdgroup_store(
+            subtile_r,
+            tile_a,
+            TILE_SIZE,
+            ulong2(subtile_k * SUBTILE_SIZE, subtile_m * SUBTILE_SIZE));
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      uint32_t r_row = tile_m * TILE_SIZE + threadgroup_row;
+      uint32_t r_col = tile_k * TILE_SIZE + threadgroup_col;
+      if (r_row < M && r_col < K) {
+        r[r_row * r_stride0 + r_col * r_stride1] =
+            T(tile_a[threadgroup_row * TILE_SIZE + threadgroup_col] * scale);
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  }
+}
+
+// Find the batch and head offset of `mask` only if the mask is enabled for the
+// kernel.
+struct MaskBatchOffset {
+  template <typename T_MASK>
+  inline static constant T_MASK* apply(
+      constant T_MASK* mask,
+      uint32_t stride0,
+      uint32_t stride1,
+      uint32_t batch_idx,
+      uint32_t head_idx) {
+    return mask + stride0 * batch_idx + stride1 * head_idx;
+  }
+
+  template <>
+  inline constant void* apply(
+      constant void* mask,
+      uint32_t stride0,
+      uint32_t stride1,
+      uint32_t batch_idx,
+      uint32_t head_idx) {
+    return mask;
+  }
+};
+
+// Apply the attention mask if enabled for the kernel. The mask can either be a
+// float or a bool. void indicates that the mask is disabled.
+struct AttnMask {
+  template <typename T_MASK>
+  inline static float apply(float value, constant T_MASK* mask, uint32_t idx) {
+    auto masked_value = value + mask[idx];
+    return ::metal::isnan(masked_value) ? -INFINITY : masked_value;
+  }
+
+  template <>
+  inline float apply(float value, constant bool* mask, uint32_t idx) {
+    return mask[idx] ? value : -INFINITY;
+  }
+
+  template <>
+  inline float apply(float value, constant void* mask, uint32_t idx) {
+    return value;
+  }
+};
+
+// Apply the causal mask if enabled for the kernel. If enabled, the upper right
+// elements are masked out.
+struct CausalMask {
+  template <bool is_causal, enable_if_t<is_causal, bool> = true>
+  inline static float apply(float value, uint32_t row, uint32_t col) {
+    return (col <= row) ? value : -INFINITY;
+  }
+
+  template <bool is_causal, enable_if_t<!is_causal, bool> = true>
+  inline static float apply(float value, uint32_t row, uint32_t col) {
+    return value;
+  }
+};
+
+// Load a value from `attn` and apply masks
+template <typename T, typename T_MASK, bool is_causal>
+inline float load_attn_value(
+    device T* attn,
+    uint32_t attn_stride0,
+    uint32_t attn_stride1,
+    constant T_MASK* mask,
+    uint32_t mask_stride0,
+    uint32_t mask_stride1,
+    uint32_t row,
+    uint32_t col) {
+  auto attn_idx = row * attn_stride0 + col * attn_stride1;
+  auto mask_idx = row * mask_stride0 + col * mask_stride1;
+  return CausalMask::apply<is_causal>(
+      AttnMask::apply(static_cast<float>(attn[attn_idx]), mask, mask_idx),
+      row,
+      col);
+}
+
+// In-place softmax `attn = softmax(attn, dim=-1)`.
+// `attn` is size (L, S)
+//
+// Within each row of the input, the following steps are performed:
+//  1) Find `row_max`, the maximum value in the row
+//  2) Find `row_sum`, sum of `exp(value - row_max)` for each value.
+//  3) Write normalized `exp(value - row_max) / row_sum` to each value in place.
+//
+// The `mask` is applied when values are read from `attn`.
+//
+// For performance, the input is broken up into TILE_SIZE x TILE_SIZE tiles.
+// During step 1 and 2, each threadgroup operates on one tile of the input at a
+// time, so that the reduction work can be performed in threadgroup memory.
+// First, each thread in the threadgroup accumulates the max/sum of the values
+// in its assigned position in the tile and writes it into its spot in
+// threadgroup memory. Then, a binary reduction is performed on the rows of the
+// tile.
+template <typename T, typename T_MASK, bool is_causal>
+static void softmax_rows(
+    device T* attn,
+    uint32_t attn_stride0,
+    uint32_t attn_stride1,
+    constant T_MASK* mask,
+    uint32_t mask_stride0,
+    uint32_t mask_stride1,
+    uint32_t L,
+    uint32_t S,
+    uint32_t threadgroup_row,
+    uint32_t threadgroup_col,
+    threadgroup float* smem) {
+  const uint32_t num_tile_rows = (L + TILE_SIZE - 1) / TILE_SIZE;
+
+  // Iterate over each row of tiles.
+  for (uint32_t tile_row_idx = 0; tile_row_idx < num_tile_rows;
+       tile_row_idx++) {
+    const uint32_t row = tile_row_idx * TILE_SIZE + threadgroup_row;
+    const bool valid = row < L;
+
+    // Step 1- Find the max value in each row
+    float local_max = -INFINITY;
+    if (valid) {
+      for (uint32_t col = threadgroup_col; col < S; col += TILE_SIZE) {
+        float value = load_attn_value<T, T_MASK, is_causal>(
+            attn,
+            attn_stride0,
+            attn_stride1,
+            mask,
+            mask_stride0,
+            mask_stride1,
+            row,
+            col);
+        local_max = max(local_max, value);
+      }
+    }
+    smem[threadgroup_row * TILE_SIZE + threadgroup_col] = local_max;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    // Reduce the partial max values in threadgroup memory
+    for (uint32_t stride = TILE_SIZE / 2; stride > 0; stride >>= 1) {
+      if (threadgroup_col < stride)
+        smem[threadgroup_row * TILE_SIZE + threadgroup_col] =
+            max(smem[threadgroup_row * TILE_SIZE + threadgroup_col],
+                smem[threadgroup_row * TILE_SIZE + threadgroup_col + stride]);
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const float row_max = smem[threadgroup_row * TILE_SIZE];
+
+    // Step 2 - Find the exp sum in each row
+    float local_sum = 0.f;
+    if (valid) {
+      for (uint32_t col = threadgroup_col; col < S; col += TILE_SIZE) {
+        float value = load_attn_value<T, T_MASK, is_causal>(
+            attn,
+            attn_stride0,
+            attn_stride1,
+            mask,
+            mask_stride0,
+            mask_stride1,
+            row,
+            col);
+        float e = precise::exp(value - row_max);
+        local_sum += ::metal::isnan(e) ? 0 : e;
+      }
+    }
+    smem[threadgroup_row * TILE_SIZE + threadgroup_col] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    // Reduce the partial sum values in threadgroup memory
+    for (uint32_t stride = TILE_SIZE / 2; stride > 0; stride >>= 1) {
+      if (threadgroup_col < stride)
+        smem[threadgroup_row * TILE_SIZE + threadgroup_col] +=
+            smem[threadgroup_row * TILE_SIZE + threadgroup_col + stride];
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const float row_sum = smem[threadgroup_row * TILE_SIZE];
+
+    // Step 3 - Normalize in place
+    if (valid) {
+      for (uint32_t col = threadgroup_col; col < S; col += TILE_SIZE) {
+        float value = load_attn_value<T, T_MASK, is_causal>(
+            attn,
+            attn_stride0,
+            attn_stride1,
+            mask,
+            mask_stride0,
+            mask_stride1,
+            row,
+            col);
+        float e = precise::exp(value - row_max);
+        auto attn_idx = row * attn_stride0 + col * attn_stride1;
+        attn[attn_idx] = row_sum == 0 ? 0 : T(e / row_sum);
+      }
+    }
+  }
+}
+
+template <typename T, typename T_MASK, bool is_causal>
+kernel void sdpa(
+    device T* out [[buffer(0)]],
+    device T* attn [[buffer(1)]],
+    constant T* q [[buffer(2)]],
+    constant T* k [[buffer(3)]],
+    constant T* v [[buffer(4)]],
+    constant T_MASK* mask [[buffer(5)]],
+    constant SDPAParams<>& params [[buffer(6)]],
+    uint2 lid [[thread_position_in_threadgroup]], // (x=col, y=row)
+    uint2 tgid [[threadgroup_position_in_grid]], // one group per (batch, head)
+    uint simdgroup_idx [[simdgroup_index_in_threadgroup]] // 0..31
+) {
+  threadgroup float smem[SMEM_FLOATS];
+
+  // Find the batch and head offsets of each of the inputs and outputs
+  const uint32_t head_idx = tgid.x % params.num_heads;
+  const uint32_t batch_idx = tgid.x / params.num_heads;
+  out += params.out_strides[0] * batch_idx + params.out_strides[1] * head_idx;
+  attn +=
+      params.attn_strides[0] * batch_idx + params.attn_strides[1] * head_idx;
+  q += params.q_strides[0] * batch_idx + params.q_strides[1] * head_idx;
+  k += params.k_strides[0] * batch_idx + params.k_strides[1] * head_idx;
+  v += params.v_strides[0] * batch_idx + params.v_strides[1] * head_idx;
+  mask = MaskBatchOffset::apply(
+      mask,
+      params.mask_strides[0],
+      params.mask_strides[1],
+      batch_idx,
+      head_idx);
+
+  const uint32_t threadgroup_row = lid.y, threadgroup_col = lid.x;
+
+  // Matmul `q`, size (L, E), and `k^T`, size (E, S), then multiply by `scale`,
+  // and write output to `attn`.
+  mm_simdgroup<T, constant T*>(
+      attn,
+      params.attn_strides[2],
+      params.attn_strides[3],
+      q,
+      params.q_strides[2],
+      params.q_strides[3],
+      k,
+      // k needs to be transposed, which is accomplished by swapping the strides
+      params.k_strides[3],
+      params.k_strides[2],
+      params.L,
+      params.E,
+      params.S,
+      params.scale,
+      threadgroup_row,
+      threadgroup_col,
+      simdgroup_idx,
+      smem);
+
+  threadgroup_barrier(mem_flags::mem_device);
+
+  // Perform softmax to `attn` in-place.
+  softmax_rows<T, T_MASK, is_causal>(
+      attn,
+      params.attn_strides[2],
+      params.attn_strides[3],
+      mask,
+      params.mask_strides[2],
+      params.mask_strides[3],
+      params.L,
+      params.S,
+      threadgroup_row,
+      threadgroup_col,
+      smem);
+
+  threadgroup_barrier(mem_flags::mem_device);
+
+  // Matmul `attn`, size (L, S), and `v`, size (S, Ev), and write output to
+  // `out`.
+  mm_simdgroup<T, device T*>(
+      out,
+      params.out_strides[2],
+      params.out_strides[3],
+      attn,
+      params.attn_strides[2],
+      params.attn_strides[3],
+      v,
+      params.v_strides[2],
+      params.v_strides[3],
+      params.L,
+      params.S,
+      params.Ev,
+      /*scale=*/1.f,
+      threadgroup_row,
+      threadgroup_col,
+      simdgroup_idx,
+      smem);
+}
+
 #define INSTANTIATE_SDPA_VECTOR(DTYPE, QK_DIM, VALUE_DIM)   \
   template [[host_name("sdpa_vector_" #DTYPE "_" #QK_DIM    \
                        "_" #VALUE_DIM)]] kernel void        \
@@ -624,3 +1044,31 @@ INSTANTIATE_SDPA_VECTOR_HEADS(bfloat);
 INSTANTIATE_ATTN_SHAPES_HELPER(float);
 INSTANTIATE_ATTN_SHAPES_HELPER(half);
 INSTANTIATE_ATTN_SHAPES_HELPER(bfloat);
+
+#define CAUSAL_SUFFIX_true "_causal"
+#define CAUSAL_SUFFIX_false ""
+
+#define REGISTER_SDPA(T, T_MASK, IS_CAUSAL)                                \
+  template[[host_name("sdpa_" #T                                           \
+                      "_" #T_MASK CAUSAL_SUFFIX_##IS_CAUSAL)]] kernel void \
+  sdpa<T, T_MASK, IS_CAUSAL>(                                              \
+      device T * out [[buffer(0)]],                                        \
+      device T * attn [[buffer(1)]],                                       \
+      constant T * q [[buffer(2)]],                                        \
+      constant T * k [[buffer(3)]],                                        \
+      constant T * v [[buffer(4)]],                                        \
+      constant T_MASK * mask [[buffer(5)]],                                \
+      constant SDPAParams<> & params [[buffer(6)]],                        \
+      uint2 lid [[thread_position_in_threadgroup]],                        \
+      uint2 tgid [[threadgroup_position_in_grid]],                         \
+      uint simdgroup_idx [[simdgroup_index_in_threadgroup]]);
+
+#define REGISTER_SDPA_MASK_TYPES(T) \
+  REGISTER_SDPA(T, void, false);    \
+  REGISTER_SDPA(T, void, true);     \
+  REGISTER_SDPA(T, bool, false);    \
+  REGISTER_SDPA(T, T, false);
+
+REGISTER_SDPA_MASK_TYPES(float);
+REGISTER_SDPA_MASK_TYPES(half);
+REGISTER_SDPA_MASK_TYPES(bfloat);

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -4,8 +4,10 @@
 #include <iostream>
 #include <optional>
 
+#include <ATen/ExpandUtils.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/Attention.h>
 #include <ATen/native/transformers/attention.h>
 #include <ATen/native/transformers/sdp_utils_cpp.h>
 
@@ -27,149 +29,50 @@ static auto& lib = mps::MetalShaderLibrary::getBundledLibrary();
 
 static constexpr int SIMD_SIZE = 32;
 
-// expand potential 3d to 4d tensor
-static inline std::tuple<Tensor, bool> ensure_4d(const Tensor& x) {
+static inline Tensor ensure_4d(const Tensor& x) {
   if (x.dim() == 3) {
-    return {x.unsqueeze(0), true};
+    return x.unsqueeze(0);
+  } else if (x.dim() == 2) {
+    return x.view({1, 1, x.size(-2), x.size(-1)});
   } else if (x.dim() > 4) {
     auto batchSize = c10::multiply_integers(x.sizes().begin(), x.sizes().end() - 3);
-    return {x.view({batchSize, x.size(-3), x.size(-2), x.size(-1)}), true};
+    return x.reshape({batchSize, x.size(-3), x.size(-2), x.size(-1)});
   } else {
-    return {x, false};
+    return x;
   }
 }
 
-// general version
-static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
-                                                   const Tensor& key,
-                                                   const Tensor& value,
-                                                   const std::optional<Tensor>& attn_mask,
-                                                   double dropout_p,
-                                                   bool is_causal,
-                                                   const std::optional<Tensor>& dropout_mask,
-                                                   std::optional<double> scale,
-                                                   const Tensor& orig_query,
-                                                   bool unsqueezed) {
-  using namespace mps;
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* qTensor = nil;
-    MPSGraphTensor* kTensor = nil;
-    MPSGraphTensor* vTensor = nil;
-    MPSGraphTensor* maskTensor = nil;
-    MPSGraphTensor* outputTensor = nil;
-    MPSGraphTensor* attnTensor = nil;
-  };
-  const auto macOS15_0_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
-  int64_t batchSize = query.size(0);
-  int64_t num_head = query.size(1);
-  int64_t qSize = query.size(2);
-  int64_t valueHeadSize = value.size(3);
-  int64_t maxSeqLength = key.size(2);
-  auto out = at::empty({batchSize, num_head, qSize, valueHeadSize}, query.options());
-  auto attn = at::empty({batchSize, num_head, qSize, maxSeqLength}, query.options());
-  auto scale_factor = sdp::calculate_scale(query, scale).expect_float();
-  @autoreleasepool {
-    auto mkey = __func__ + getTensorsStringKey({query, key, value}) + ":" + std::to_string(is_causal) + ":" +
-        std::to_string(attn_mask.has_value());
-    auto cachedGraph =
-        LookUpOrCreateCachedGraph<CachedGraph>(mkey, [&, q_ = query, k_ = key, v_ = value](auto mpsGraph, auto graph) {
-          auto qTensor = mpsGraphRankedPlaceHolder(mpsGraph, q_);
-          auto kTensor = mpsGraphRankedPlaceHolder(mpsGraph, k_);
-          auto vTensor = mpsGraphRankedPlaceHolder(mpsGraph, v_);
-          auto kT = [mpsGraph transposeTensor:kTensor dimension:2 withDimension:3 name:nil];
-          auto scaleTensor = [mpsGraph constantWithScalar:scale_factor
-                                                    shape:getMPSShape({1})
-                                                 dataType:MPSDataTypeFloat32];
+static inline std::tuple<Tensor, Tensor, Tensor, std::vector<int64_t>, std::vector<int64_t>> broadcast_sdpa_batch_dims(
+    const Tensor& query,
+    const Tensor& key,
+    const Tensor& value) {
+  auto L = query.size(-2);
+  auto S = key.size(-2);
+  auto Ev = value.size(-1);
 
-          auto maskedMM = [mpsGraph matrixMultiplicationWithPrimaryTensor:qTensor secondaryTensor:kT name:nil];
+  std::vector<int64_t> query_batch(query.sizes().begin(), query.sizes().end() - 2);
+  std::vector<int64_t> key_batch(key.sizes().begin(), key.sizes().end() - 2);
+  std::vector<int64_t> value_batch(value.sizes().begin(), value.sizes().end() - 2);
 
-          if (macOS15_0_plus && [maskedMM dataType] == MPSDataTypeFloat32) {
-            // bug in MacOS15, without this trick SDPA leaks memory, adding 0.0f gets ignored(still takes SDPA sequence
-            // path which leaks)
-            auto oneTensor = [mpsGraph constantWithScalar:1e-20f shape:getMPSShape({1}) dataType:MPSDataTypeFloat32];
-            maskedMM = [mpsGraph additionWithPrimaryTensor:maskedMM secondaryTensor:oneTensor name:nil];
-          }
+  auto batch_sizes = at::infer_size(at::infer_size(query_batch, key_batch), value_batch);
 
-          // upcasting to float32 if needed to improve precision when multiplying by the scale factor
-          maskedMM = castMPSTensor(mpsGraph, maskedMM, MPSDataTypeFloat32);
-          maskedMM = [mpsGraph multiplicationWithPrimaryTensor:maskedMM secondaryTensor:scaleTensor name:nil];
+  std::vector<int64_t> query_sizes(batch_sizes);
+  std::vector<int64_t> key_sizes(batch_sizes);
+  std::vector<int64_t> value_sizes(batch_sizes);
+  std::vector<int64_t> attn_sizes(batch_sizes);
+  std::vector<int64_t> out_sizes(batch_sizes);
 
-          if (is_causal) {
-            auto causalMask = [mpsGraph constantWithScalar:1.0f
-                                                     shape:getMPSShape({qSize, maxSeqLength})
-                                                  dataType:MPSDataTypeBool];
-            causalMask = [mpsGraph bandPartWithTensor:causalMask numLower:-1 numUpper:0 name:nil];
-            auto minusInf = [mpsGraph constantWithScalar:-1e20 shape:maskedMM.shape dataType:maskedMM.dataType];
-            maskedMM = [mpsGraph selectWithPredicateTensor:causalMask
-                                       truePredicateTensor:maskedMM
-                                      falsePredicateTensor:minusInf
-                                                      name:nil];
-          } else if (attn_mask) {
-            graph->maskTensor = mpsGraphRankedPlaceHolder(mpsGraph, *attn_mask);
-            maskedMM = [mpsGraph additionWithPrimaryTensor:maskedMM
-                                           secondaryTensor:castMPSTensor(mpsGraph, graph->maskTensor, maskedMM.dataType)
-                                                      name:nil];
-          }
+  query_sizes.insert(query_sizes.end(), {query.size(-2), query.size(-1)});
+  key_sizes.insert(key_sizes.end(), {key.size(-2), key.size(-1)});
+  value_sizes.insert(value_sizes.end(), {value.size(-2), value.size(-1)});
+  attn_sizes.insert(attn_sizes.end(), {L, S});
+  out_sizes.insert(out_sizes.end(), {L, Ev});
 
-          // Account for case where all values were masked causing division by 0 in softmax (issue:#156707)
-          // Overwrites expected NANs in sm with zeros.
-          auto negInfTensor = [mpsGraph constantWithScalar:-INFINITY shape:maskedMM.shape dataType:maskedMM.dataType];
-          auto elem_neg_inf = [mpsGraph equalWithPrimaryTensor:maskedMM secondaryTensor:negInfTensor name:nil];
-          auto all_neg_infs_along_axis = [mpsGraph reductionAndWithTensor:elem_neg_inf axis:3 name:nil];
-          auto zero_mask = [mpsGraph broadcastTensor:all_neg_infs_along_axis toShape:maskedMM.shape name:nil];
-          auto zeroTensor = [mpsGraph constantWithScalar:0.0 shape:maskedMM.shape dataType:maskedMM.dataType];
+  auto q_ = ensure_4d(query.expand(query_sizes));
+  auto k_ = ensure_4d(key.expand(key_sizes));
+  auto v_ = ensure_4d(value.expand(value_sizes));
 
-          auto sm = [mpsGraph softMaxWithTensor:maskedMM axis:3 name:nil];
-          MPSGraphTensor* correctedSM = [mpsGraph selectWithPredicateTensor:zero_mask
-                                                        truePredicateTensor:zeroTensor
-                                                       falsePredicateTensor:sm
-                                                                       name:nil];
-
-          auto output = [mpsGraph matrixMultiplicationWithPrimaryTensor:correctedSM secondaryTensor:vTensor name:nil];
-          graph->qTensor = qTensor;
-          graph->kTensor = kTensor;
-          graph->vTensor = vTensor;
-          graph->outputTensor = castMPSTensor(mpsGraph, output, qTensor.dataType);
-          graph->attnTensor = castMPSTensor(mpsGraph, sm, qTensor.dataType);
-        });
-    auto qPlaceholder = Placeholder(cachedGraph->qTensor, query);
-    auto kPlaceholder = Placeholder(cachedGraph->kTensor, key);
-    auto vPlaceholder = Placeholder(cachedGraph->vTensor, value);
-    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor, out);
-    auto attnPlaceholder = Placeholder(cachedGraph->attnTensor, attn);
-    NSDictionary* feeds = nil;
-    if (!attn_mask) {
-      feeds = dictionaryFromPlaceholders(qPlaceholder, kPlaceholder, vPlaceholder);
-    } else {
-      auto mPlaceholder = Placeholder(cachedGraph->maskTensor, *attn_mask);
-      feeds = dictionaryFromPlaceholders(qPlaceholder, kPlaceholder, vPlaceholder, mPlaceholder);
-    }
-    NSDictionary* outs = dictionaryFromPlaceholders(outputPlaceholder, attnPlaceholder);
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outs);
-  }
-
-  auto final_out = out;
-  auto final_attn = attn;
-  if (unsqueezed) {
-    if (orig_query.dim() == 3) {
-      final_out = out.squeeze(0);
-      final_attn = attn.squeeze(0);
-    } else {
-      std::vector<int64_t> prefix_shape(orig_query.sizes().begin(), orig_query.sizes().end() - 3);
-
-      auto out_shape = prefix_shape;
-      auto attn_shape = prefix_shape;
-
-      out_shape.insert(out_shape.end(), {out.size(1), out.size(2), out.size(3)});
-      attn_shape.insert(attn_shape.end(), {attn.size(1), attn.size(2), attn.size(3)});
-
-      final_out = out.view(out_shape);
-      final_attn = attn.view(attn_shape);
-    }
-  }
-
-  return {std::move(final_out), std::move(final_attn)};
+  return {std::move(q_), std::move(k_), std::move(v_), std::move(attn_sizes), std::move(out_sizes)};
 }
 
 // Vector mode (One–pass variant)
@@ -181,8 +84,8 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
                                                        bool is_causal,
                                                        const std::optional<Tensor>& dropout_mask,
                                                        std::optional<double> scale,
-                                                       const Tensor& orig_query,
-                                                       bool unsqueezed) {
+                                                       IntArrayRef out_sizes,
+                                                       IntArrayRef attn_sizes) {
   TORCH_CHECK(q_.size(3) == k_.size(3) && q_.size(3) == v_.size(3),
               "sdpa_vector_fast_mps expects query, key, and value to have the same head dimension");
   const auto macOS15_0_plus = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
@@ -240,13 +143,8 @@ static std::tuple<Tensor, Tensor> sdpa_vector_fast_mps(const Tensor& q_,
     }
   });
   // reshape back to original dimension
-  auto final_out = unsqueezed ? out.view_as(orig_query) : out;
-  auto final_attn = unsqueezed ? (orig_query.dim() == 3 ? attn.squeeze(0) : [&]{
-    std::vector<int64_t> shape(orig_query.sizes().begin(), orig_query.sizes().end() - 3);
-    shape.insert(shape.end(), {attn.size(1), attn.size(2), attn.size(3)});
-    return attn.view(shape);
-  }()) : attn;
-
+  auto final_out = out.view(out_sizes);
+  auto final_attn = attn.view(attn_sizes);
   return {std::move(final_out), std::move(final_attn)};
 }
 
@@ -259,8 +157,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
                                                         bool is_causal,
                                                         const std::optional<Tensor>& dropout_mask,
                                                         std::optional<double> scale,
-                                                        const Tensor& orig_query,
-                                                        bool unsqueezed) {
+                                                        IntArrayRef out_sizes) {
   TORCH_CHECK(q_.size(3) == k_.size(3) && q_.size(3) == v_.size(3),
               "sdpa_vector_2pass_mps expects query, key, and value to have the same head dimension");
   using namespace mps;
@@ -285,7 +182,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
   auto sums = at::empty({batchSize, num_heads, seq_len_q, blocks}, q_.options().dtype(kFloat));
   auto maxs = at::empty({batchSize, num_heads, seq_len_q, blocks}, q_.options().dtype(kFloat));
 
-  auto scale_factor = sdp::calculate_scale(orig_query, scale).expect_float();
+  auto scale_factor = sdp::calculate_scale(q_, scale).expect_float();
   bool has_mask = mask_.has_value();
 
   MPSStream* mpsStream = getCurrentMPSStream();
@@ -333,7 +230,7 @@ static std::tuple<Tensor, Tensor> sdpa_vector_2pass_mps(const Tensor& q_,
     }
   });
 
-  auto final_out = unsqueezed ? out.view_as(orig_query) : out;
+  auto final_out = out.view(out_sizes);
   return {std::move(final_out), std::move(intermediate)};
 }
 
@@ -438,6 +335,78 @@ static std::tuple<Tensor, Tensor> sdpa_full_attention_mps(const Tensor& q_,
   return {std::move(final_out), std::move(final_out)};
 }
 
+static std::tuple<Tensor, Tensor> sdpa(const Tensor& q,
+                                       const Tensor& k,
+                                       const Tensor& v,
+                                       const std::optional<Tensor>& attn_mask,
+                                       bool is_causal,
+                                       std::optional<double> scale,
+                                       IntArrayRef out_sizes,
+                                       IntArrayRef attn_sizes) {
+  using namespace mps;
+
+  TORCH_INTERNAL_ASSERT(!(is_causal && attn_mask.has_value()));
+
+  auto batch_size = q.size(0);
+  auto num_heads = q.size(1);
+  auto L = q.size(2);
+  auto E = q.size(3);
+  auto S = v.size(2);
+  auto Ev = v.size(3);
+
+  auto out = at::empty({batch_size, num_heads, L, Ev}, q.options());
+  auto attn = at::empty({batch_size, num_heads, L, S}, q.options());
+  auto scale_factor = sdp::calculate_scale(q, scale).expect_float();
+
+  SDPAParams params;
+
+  params.batch_size = batch_size;
+  params.num_heads = num_heads;
+  params.L = L;
+  params.E = E;
+  params.S = S;
+  params.Ev = Ev;
+  params.scale = scale_factor;
+
+  for (const auto dim : c10::irange(4)) {
+    params.q_strides[dim] = q.stride(dim);
+    params.k_strides[dim] = k.stride(dim);
+    params.v_strides[dim] = v.stride(dim);
+    params.mask_strides[dim] = attn_mask.has_value() ? attn_mask->stride(dim) : 0;
+    params.out_strides[dim] = out.stride(dim);
+    params.attn_strides[dim] = attn.stride(dim);
+  }
+
+  MPSStream* mpsStream = getCurrentMPSStream();
+
+  dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> compute_encoder = mpsStream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc(
+          fmt::format("sdpa_{}_{}{}",
+                      scalarToMetalTypeString(q),
+                      // `void` type mask indicates not to apply the mask
+                      attn_mask.has_value() ? scalarToMetalTypeString(attn_mask.value()) : "void",
+                      is_causal ? "_causal" : ""));
+
+      getMPSProfiler().beginProfileKernel(pso, "scaled_dot_product_attention", {q, k, v});
+      [compute_encoder setComputePipelineState:pso];
+      mtl_setArgs(compute_encoder, out, attn, q, k, v, attn_mask, params);
+
+      // Execute one threadgroup per (batch, head) pair, and TILE_SIZE×TILE_SIZE
+      // threads within each group
+      [compute_encoder dispatchThreadgroups:MTLSizeMake(batch_size * num_heads, 1, 1)
+                      threadsPerThreadgroup:MTLSizeMake(TILE_SIZE, TILE_SIZE, 1)];
+
+      getMPSProfiler().endProfileKernel(pso);
+    }
+  });
+
+  auto final_out = out.view(out_sizes);
+  auto final_attn = attn.view(attn_sizes);
+  return {std::move(final_out), std::move(final_attn)};
+}
+
 std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& query,
                                                                   const Tensor& key_,
                                                                   const Tensor& value_,
@@ -475,22 +444,14 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
     }
   }
 
-  auto query_tuple = ensure_4d(query);
-  Tensor q_ = std::get<0>(query_tuple);
-  bool unsqueezed = std::get<1>(query_tuple);
-
-  auto key_tuple = ensure_4d(key);
-  Tensor k_ = std::get<0>(key_tuple);
-
-  auto value_tuple = ensure_4d(value);
-  Tensor v_ = std::get<0>(value_tuple);
+  auto [q_, k_, v_, attn_sizes, out_sizes] = broadcast_sdpa_batch_dims(query, key, value);
 
   std::optional<Tensor> mask_;
   if (attn_mask) {
     auto maskExpandedDims = query.sizes().vec();
     maskExpandedDims[maskExpandedDims.size() - 1] = k_.size(2);
     mask_ = attn_mask->expand(maskExpandedDims);
-    std::tie(*mask_, std::ignore) = ensure_4d(*mask_);
+    *mask_ = ensure_4d(*mask_);
   }
 
   int query_head_dim = q_.size(3);
@@ -512,7 +473,7 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
 
   // if none of the fast paths apply, fall back to the generic mps graph solution
   if (!supports_fast_sdpa) {
-    return sdpa_general_mps(q_, k_, v_, mask_, dropout_p, is_causal, dropout_mask, scale, query, unsqueezed);
+    return sdpa(q_, k_, v_, mask_, is_causal, scale, out_sizes, attn_sizes);
   }
 
   // dispatch to the fast SDPA implementation
@@ -532,10 +493,10 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
   // for short sequences, differentiate based on key sequence length
   if ((k_.size(2) >= 1024) || (k_.size(1) < q_.size(1) && k_.size(2) >= 4096)) {
     return sdpa_vector_2pass_mps(
-        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, query, unsqueezed);
+        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, out_sizes);
   } else {
     return sdpa_vector_fast_mps(
-        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, query, unsqueezed);
+        q_contig, k_contig, v_contig, mask_, dropout_p, is_causal, dropout_mask, scale, out_sizes, attn_sizes);
   }
 }
 } // namespace native

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9976,11 +9976,15 @@ class TestSDPA(TestCaseMPS):
 
     # Regression test from: https://github.com/pytorch/pytorch/issues/156707
     @parametrize("dtype", [torch.float16, torch.float32])
-    def test_sdpa_full_mask(self, dtype):
+    @parametrize("bool_mask", [True, False])
+    def test_sdpa_full_mask(self, dtype, bool_mask):
         q = torch.randn(1, 1, 2, 4, dtype=dtype)
         k = torch.randn(1, 1, 2, 4, dtype=dtype)
         v = torch.randn(1, 1, 2, 4, dtype=dtype)
-        mask = torch.tensor([[[[False, False], [True, True]]]], dtype=torch.bool)
+        if bool_mask:
+            mask = torch.tensor([[[[False, False], [True, True]]]], dtype=torch.bool)
+        else:
+            mask = torch.randn(1, 1, 2, 2, dtype=dtype)
 
         out_cpu = F.scaled_dot_product_attention(q, k, v, attn_mask=mask)
         out_mps = F.scaled_dot_product_attention(q.to('mps'), k.to('mps'), v.to('mps'), attn_mask=mask.to('mps'))
@@ -10032,6 +10036,35 @@ class TestSDPA(TestCaseMPS):
 
             self._compare_tensors(y.cpu(), y_ref)
 
+    @parametrize("dtype", [torch.float32])
+    @parametrize("q_batch", [(), (1,), (1, 1), (1, 1, 1), (2,), (3, 2), (4, 3, 2)])
+    @parametrize("k_batch", [(), (1,), (1, 1), (1, 1, 1), (2,), (3, 2), (4, 3, 2)])
+    @parametrize("v_batch", [(), (1,), (1, 1), (1, 1, 1), (2,), (3, 2), (4, 3, 2)])
+    def test_sdpa_broadcasting(self, dtype, q_batch, k_batch, v_batch):
+        S = 18
+        E = 64
+        Ev = 64
+        L = 15
+
+        q = torch.randn(*q_batch, L, E, dtype=dtype)
+        k = torch.randn(*k_batch, S, E, dtype=dtype)
+        v = torch.randn(*v_batch, S, Ev, dtype=dtype)
+
+        with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
+            y_ref = F.scaled_dot_product_attention(
+                q.to("cpu"),
+                k.to("cpu"),
+                v.to("cpu"),
+            )
+
+            y = F.scaled_dot_product_attention(
+                q.to("mps"),
+                k.to("mps"),
+                v.to("mps"),
+            )
+
+            self._compare_tensors(y.cpu(), y_ref)
+
     @parametrize("dtype", [torch.float16, torch.float32])
     def test_sdpa_no_mask_5d(
         self,
@@ -10059,9 +10092,11 @@ class TestSDPA(TestCaseMPS):
             self._compare_tensors(q.grad.cpu(), q.cpu().grad)
 
     @parametrize('dtype', [torch.float16, torch.float32])
+    @parametrize('bool_mask', [True, False])
     def test_sdpa_mask_5d(
         self,
         dtype: torch.dtype,
+        bool_mask: bool,
         B: int = 2,
         extra: int = 3,
         NH: int = 4,
@@ -10072,7 +10107,10 @@ class TestSDPA(TestCaseMPS):
         q = torch.randn(B, extra, NH, L, HS, dtype=dtype, device="mps")
         k = torch.randn(B, extra, NH, L, HS, dtype=dtype, device="mps")
         v = torch.randn(B, extra, NH, L, HS, dtype=dtype, device="mps")
-        mask = torch.tril(torch.ones(L, L, dtype=torch.bool, device="mps")).unsqueeze(0).unsqueeze(0)
+        if bool_mask:
+            mask = torch.tril(torch.ones(L, L, dtype=torch.bool, device="mps")).unsqueeze(0).unsqueeze(0)
+        else:
+            mask = torch.randn(B, extra, NH, L, L, dtype=dtype, device="mps")
 
         with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
             y = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181030

Also fixes input broadcasting behavior.

Claude was used to co-author the `mm_simdgroup` and `softmax_rows`
functions of the Metal kernel.

Performance was measured using the following script:

<details><summary>Click to expand</summary>

```python
import torch
import torch.utils.benchmark as benchmark
import itertools

cases = [
    # (batch, heads, E, Ev, L, S, num_iters)
    (1, 8, 32, 32, 128, 128, 1000),
    (4, 12, 32, 32, 256, 256, 300),
    (8, 16, 32, 32, 512, 512, 10),
    (16, 16, 32, 32, 1024, 1024, 5),

    (1, 8, 64, 64, 128, 128, 1000),
    (4, 12, 64, 64, 256, 256, 300),
    (8, 16, 64, 64, 512, 512, 10),
    (16, 16, 64, 64, 1024, 1024, 5),

    (1, 8, 128, 128, 128, 128, 1000),
    (4, 12, 128, 128, 256, 256, 300),
    (8, 16, 128, 128, 512, 512, 10),
    (16, 16, 128, 128, 1024, 1024, 5),


    (8, 8, 64, 64, 1024, 1024, 3),

    # S doesn't scale well, because it is serialized in softmax
    (8, 8, 64, 64, 1024, 2 * 1024, 3),
    (8, 8, 64, 64, 1024, 4 * 1024, 3),
    (8, 8, 64, 64, 1024, 8 * 1024, 3),

    # L scales well
    (8, 8, 64, 64, 2 * 1024, 1024, 3),
    (8, 8, 64, 64, 4 * 1024, 1024, 3),
    (8, 8, 64, 64, 8 * 1024, 1024, 3),

    # Ev doesn't scale well, because it is iterated serially in mm
    (8, 8, 64, 2 * 64, 1024, 1024, 3),
    (8, 8, 64, 4 * 64, 1024, 1024, 3),
    (8, 8, 64, 8 * 64, 1024, 1024, 3),

    # E doesn't scale well, because it is iterated serially in mm
    (8, 8, 2 * 64, 64, 1024, 1024, 3),
    (8, 8, 4 * 64, 64, 1024, 1024, 3),
    (8, 8, 8 * 64, 64, 1024, 1024, 3),
]

dtypes = [torch.float]

def run_benchmark(device):
    print(f'dtype, batch, heads, E, Ev, L, S, baseline-time, metal-time, speedup')
    for dtype, (batch, heads, E, Ev, L, S, num_iters) in itertools.product(dtypes, cases):
        q = torch.randn(batch, heads, L, E, dtype=dtype, device='mps')
        k = torch.randn(batch, heads, S, E, dtype=dtype, device='mps')
        v = torch.randn(batch, heads, S, Ev, dtype=dtype, device='mps')

        t = benchmark.Timer(
            stmt="torch.nn.functional.scaled_dot_product_attention(q, k, v)",
            globals={"torch": torch, "q": q, "k": k, "v": v},
            num_threads=torch.get_num_threads(),
        )

        for _ in range(2):
            result_metal = t.timeit(num_iters).median

        q, k, v = (x.requires_grad_() for x in [q, k, v])

        t = benchmark.Timer(
            stmt="torch.nn.functional.scaled_dot_product_attention(q, k, v)",
            globals={"torch": torch, "q": q, "k": k, "v": v},
            num_threads=torch.get_num_threads(),
        )

        for _ in range(2):
            result_baseline = t.timeit(num_iters).median

        speedup = result_baseline/ result_metal

        print(f'{dtype}, {batch}, {heads}, {E}, {Ev}, {L}, {S}, {result_baseline:.2e}, {result_metal:.2e}, {speedup:.2f}')

run_benchmark("mps")

```

</details>

Results for float inputs when run on an Apple M4 are below. "math" refers to the implementation that just calls the higher level `aten` ops, which is currently run if the inputs require grad.

batch | heads | E | Ev | L | S | math time, s | MPSGraph time, s | Metal time, s | speedup, metal vs math | speedup, metal vs MPSGraph
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 8 | 32 | 32 | 128 | 128 | 1.11E-04 | 5.06E-05 | 4.38E-05 | 2.53 | 1.16
4 | 12 | 32 | 32 | 256 | 256 | 1.38E-03 | 1.28E-03 | 9.10E-04 | 1.52 | 1.41
8 | 16 | 32 | 32 | 512 | 512 | 1.45E-02 | 1.32E-02 | 1.02E-02 | 1.42 | 1.29
16 | 16 | 32 | 32 | 1024 | 1024 | 1.13E-01 | 1.03E-01 | 8.08E-02 | 1.40 | 1.27
1 | 8 | 64 | 64 | 128 | 128 | 1.13E-04 | 5.39E-05 | 6.65E-05 | 1.70 | 0.81
4 | 12 | 64 | 64 | 256 | 256 | 1.54E-03 | 1.36E-03 | 1.40E-03 | 1.10 | 0.97
8 | 16 | 64 | 64 | 512 | 512 | 1.54E-02 | 1.37E-02 | 1.51E-02 | 1.02 | 0.91
16 | 16 | 64 | 64 | 1024 | 1024 | 1.17E-01 | 1.07E-01 | 1.25E-01 | 0.94 | 0.86
1 | 8 | 128 | 128 | 128 | 128 | 1.14E-04 | 6.56E-05 | 1.19E-04 | 0.96 | 0.55
4 | 12 | 128 | 128 | 256 | 256 | 1.87E-03 | 1.56E-03 | 2.42E-03 | 0.77 | 0.64
8 | 16 | 128 | 128 | 512 | 512 | 1.78E-02 | 1.55E-02 | 2.56E-02 | 0.70 | 0.61
16 | 16 | 128 | 128 | 1024 | 1024 | 1.34E-01 | 1.22E-01 | 2.29E-01 | 0.59 | 0.53
8 | 8 | 64 | 64 | 1024 | 1024 | 2.95E-02 | 2.69E-02 | 3.34E-02 | 0.88 | 0.81
8 | 8 | 64 | 64 | 1024 | 2048 | 5.84E-02 | 5.38E-02 | 7.40E-02 | 0.79 | 0.73
8 | 8 | 64 | 64 | 1024 | 4096 | 1.22E-01 | 1.13E-01 | 1.61E-01 | 0.76 | 0.70
8 | 8 | 64 | 64 | 1024 | 8192 | 2.64E-01 | 2.45E-01 | 3.41E-01 | 0.77 | 0.72
8 | 8 | 64 | 64 | 2048 | 1024 | 5.93E-02 | 5.36E-02 | 6.59E-02 | 0.90 | 0.81
8 | 8 | 64 | 64 | 4096 | 1024 | 1.16E-01 | 1.23E-01 | 1.32E-01 | 0.88 | 0.93
8 | 8 | 64 | 64 | 8192 | 1024 | 2.31E-01 | 2.11E-01 | 2.64E-01 | 0.88 | 0.80
8 | 8 | 64 | 128 | 1024 | 1024 | 3.13E-02 | 2.87E-02 | 4.72E-02 | 0.66 | 0.61
8 | 8 | 64 | 256 | 1024 | 1024 | 3.67E-02 | 3.38E-02 | 7.51E-02 | 0.49 | 0.45
8 | 8 | 64 | 512 | 1024 | 1024 | 4.63E-02 | 4.38E-02 | 1.32E-01 | 0.35 | 0.33
8 | 8 | 128 | 64 | 1024 | 1024 | 3.97E-02 | 2.88E-02 | 4.62E-02 | 0.86 | 0.62
8 | 8 | 256 | 64 | 1024 | 1024 | 3.83E-02 | 3.38E-02 | 7.52E-02 | 0.51 | 0.45
8 | 8 | 512 | 64 | 1024 | 1024 | 5.15E-02 | 4.43E-02 | 1.28E-01 | 0.40 | 0.35







