### PR TITLE
Validate pivot range in linalg.ldl_solve CPU kernel

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -948,6 +948,16 @@ void ldl_solve_kernel(
     const Tensor& result,
     bool upper,
     bool hermitian) {
+  // Lapack SYTRS writes into unrelated memory if |IPIV(k)| is outside [1, N]
+  // (negative values encode 2x2 block pivots), so sanity-check user-provided
+  // pivots before dispatch on CPU.
+  TORCH_CHECK(pivots.abs().ge(1).all().item<bool>(),
+              "Pivots given to ldl_solve must all satisfy |pivot| >= 1. "
+              "Did you properly pass the result of ldl_factor?");
+  TORCH_CHECK(pivots.abs().le(LD.size(-2)).all().item<bool>(),
+              "Pivots given to ldl_solve must all satisfy |pivot| <= LD.size(-2). "
+              "Did you properly pass the result of ldl_factor?");
+
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
       LD.scalar_type(), "ldl_solve_kernel_cpu", [&] {
         apply_ldl_solve<scalar_t>(LD, pivots, result, upper, hermitian);

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -10222,6 +10222,44 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         for shape, batch, nrhs, hermitian in itertools.product(shapes, batches, nrhss, hermitians):
             run_test(shape, batch, nrhs, hermitian)
 
+    @onlyCPU
+    @skipCPUIfNoLapack
+    @dtypes(*floating_and_complex_types())
+    def test_ldl_solve_cpu_errors(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/163450:
+        # malformed pivots used to be passed straight to Lapack SYTRS which
+        # would write past the end of the matrix and corrupt the heap; they
+        # should now surface as a clean RuntimeError.
+        from torch.testing._internal.common_utils import random_hermitian_pd_matrix
+
+        hermitian = dtype.is_complex
+        n = 5
+        A = random_hermitian_pd_matrix(n, dtype=dtype, device=device)
+        B = make_tensor((n, 1), dtype=dtype, device=device)
+        LD, pivots, _ = torch.linalg.ldl_factor_ex(A, hermitian=hermitian)
+
+        # Sanity: the factorization output round-trips.
+        torch.linalg.ldl_solve(LD, pivots, B, hermitian=hermitian)
+
+        # Lapack uses 1-based pivot indices, so zero is invalid.
+        bad = pivots.clone()
+        bad[0] = 0
+        with self.assertRaisesRegex(RuntimeError, r"\|pivot\| >= 1"):
+            torch.linalg.ldl_solve(LD, bad, B, hermitian=hermitian)
+
+        # Out-of-range positive pivot.
+        bad = pivots.clone()
+        bad[0] = n + 1
+        with self.assertRaisesRegex(RuntimeError, r"\|pivot\| <= LD\.size\(-2\)"):
+            torch.linalg.ldl_solve(LD, bad, B, hermitian=hermitian)
+
+        # Negative pivots encode 2x2 block pivots and are legal, but |pivot|
+        # must still be <= N.
+        bad = pivots.clone()
+        bad[0] = -(n + 1)
+        with self.assertRaisesRegex(RuntimeError, r"\|pivot\| <= LD\.size\(-2\)"):
+            torch.linalg.ldl_solve(LD, bad, B, hermitian=hermitian)
+
     @onlyCUDA
     @skipCUDAIfNoMagma
     @setLinalgBackendsToDefaultFinally


### PR DESCRIPTION
## Summary

`torch.linalg.ldl_solve` forwards user-provided pivots straight to Lapack
SYTRS, which writes into unrelated memory when `|IPIV(k)|` falls outside
`[1, N]`. The out-of-bounds writes corrupt the heap, so the crash manifests
much later during tensor teardown as a malformed-free abort (the reproducer
from #163450 shows `malloc(): unsorted double linked list corrupted`).

The CPU kernel for `linalg.lu_solve` already guards against the same class
of bug; this PR ports that sanity check to `ldl_solve_kernel`. Negative
pivots are accepted since they legally encode 2x2 block pivots, but
`|pivot|` must still satisfy `1 <= |pivot| <= N`.

Fixes #163450.

## Test plan

- [x] Added `test_ldl_solve_cpu_errors` covering zero pivots and out-of-range positive/negative pivots across floating and complex dtypes. The new check catches the repro from #163450 (pivots `[2, 3, 5, 7, 11]` on a 5x5 matrix) before reaching SYTRS.