### PR TITLE
[hammer] Make HSTU manual recompute policies compatible with PT2 compile

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7011,6 +7011,55 @@ def forward(self, primals_1, tangents_1):
         finally:
             handle.destroy()
 
+    def test_force_save_multi_output_must_save_ops(self):
+        """Test that tuple-returning MUST_SAVE ops save tensor getitem leaves."""
+        from torch._functorch.partitioners import (
+            CheckpointPolicy,
+            force_save_multi_output_must_save_ops,
+        )
+
+        def fn(x):
+            var, mean = torch.var_mean(x, dim=0)
+            return var.sum() + mean.sum()
+
+        gm = make_fx(fn)(torch.randn(4, 4))
+
+        multi_output_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function"
+            and n.target == torch.ops.aten.var_mean.correction
+        ]
+        self.assertEqual(
+            len(multi_output_nodes),
+            1,
+            f"expected one var_mean node, got {len(multi_output_nodes)}",
+        )
+        multi_output_node = multi_output_nodes[0]
+        multi_output_node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+
+        getitem_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function"
+            and n.target == operator.getitem
+            and n.args[0] == multi_output_node
+        ]
+        self.assertEqual(len(getitem_nodes), 2, "expected two tensor getitem leaves")
+
+        force_save_multi_output_must_save_ops(gm)
+
+        must_save_count = sum(
+            1
+            for node in getitem_nodes
+            if node.meta.get("recompute") == CheckpointPolicy.MUST_SAVE
+        )
+        self.assertEqual(
+            must_save_count,
+            len(getitem_nodes),
+            f"all {len(getitem_nodes)} getitem leaves should be MUST_SAVE, got {must_save_count}",
+        )
+
     def test_static_input_indices_with_effect_tokens(self):
         """Test that static_input_indices are correctly offset when effect tokens are prepended."""
         from torch._functorch._aot_autograd.descriptors import PlainAOTInput

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1298,6 +1298,7 @@ def default_partition(
         force_save_collectives(joint_module)
 
     force_save_effectful_ops(joint_module)
+    force_save_multi_output_must_save_ops(joint_module)
     force_save_bw_mutation_src(joint_module)
 
     if static_lifetime_input_indices is None:
@@ -1959,20 +1960,13 @@ def force_save_effectful_ops(joint_module: fx.GraphModule) -> None:
     saved, the with_effects op doesn't need to be recomputed in backward.
     """
 
-    def mark_getitem_outputs(node: fx.Node) -> None:
-        for user in node.users:
-            if user.target is operator.getitem:
-                mark_getitem_outputs(user)
-                if not isinstance(user.meta.get("val"), (tuple, list)):
-                    user.meta["recompute"] = CheckpointPolicy.MUST_SAVE
-
     for node in joint_module.graph.nodes:
         if (
             is_with_effects(node)
             and not must_recompute(node)
             and not _has_tag_is_backward(node)
         ):
-            mark_getitem_outputs(node)
+            _mark_getitem_leaf_outputs_must_save(node)
 
 
 def force_save_bw_mutation_src(joint_module: fx.GraphModule) -> None:
@@ -1996,6 +1990,59 @@ def force_save_bw_mutation_src(joint_module: fx.GraphModule) -> None:
             # We do not want to iterate through all the joint graph,
             # so break at the first non-output, non-copy_ node.
             break
+
+
+def _is_multi_output_node(node: fx.Node) -> bool:
+    """Whether `node` is a tuple-/list-returning op whose users are all `getitem`.
+
+    A `MUST_SAVE` annotation on such a parent must be honored at the tensor-leaf
+    level instead, because `default_partition`'s saved-values loop (see the
+    ``if is_multi_output(node): continue`` skip earlier in this file) cannot
+    save tuple-typed values directly. The tensor leaves extracted via `getitem`
+    remain available for the cut and are routed via
+    ``force_save_multi_output_must_save_ops``.
+    """
+    return len(node.users) > 0 and all(
+        user.target == operator.getitem for user in node.users
+    )
+
+
+def _mark_getitem_leaf_outputs_must_save(node: fx.Node) -> None:
+    """Recursively mark the tensor-leaf getitem children of `node` as MUST_SAVE.
+
+    Used by both `force_save_effectful_ops` (for with_effects parents) and
+    `force_save_multi_output_must_save_ops` (for any tuple-/list-returning
+    op that selective-checkpoint policy tagged MUST_SAVE).
+    """
+    for user in node.users:
+        if user.target is operator.getitem:
+            _mark_getitem_leaf_outputs_must_save(user)
+            if not isinstance(user.meta.get("val"), (tuple, list)):
+                user.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+
+
+def force_save_multi_output_must_save_ops(joint_module: fx.GraphModule) -> None:
+    """
+    If a selective-checkpoint policy marks a tuple-/list-returning op as
+    MUST_SAVE, we cannot save the parent value directly because
+    `default_partition`'s saved-values loop (see the
+    ``if is_multi_output(node): continue`` skip earlier in this file) cannot
+    save tuple-typed values directly. Propagate MUST_SAVE to the tensor leaves
+    extracted via getitem so the partitioner can honor the policy without
+    re-running the parent op in backward.
+    """
+    for node in joint_module.graph.nodes:
+        if (
+            node.meta.get("recompute", None) == CheckpointPolicy.MUST_SAVE
+            and _is_multi_output_node(node)
+            and not _has_tag_is_backward(node)
+        ):
+            log.debug(
+                "force_save_multi_output_must_save_ops: propagating MUST_SAVE "
+                "from %s to its getitem leaves",
+                node.name,
+            )
+            _mark_getitem_leaf_outputs_must_save(node)
 
 
 def is_getitem_of_multi_output(node: fx.Node) -> bool:
@@ -2161,10 +2208,19 @@ def solve_min_cut(
         """Returns reason string if node should be banned from recomputation, None otherwise."""
         if node.op != "call_function":
             return None
+        # MUST_SAVE must be honored BEFORE the generic getitem fast-path so
+        # that user-saved getitem leaves of tuple-returning ops are also
+        # banned from recomputation. Skip multi-output (tuple-returning)
+        # parents — `default_partition`'s saved-values loop (the
+        # ``if is_multi_output(node): continue`` skip earlier in this file)
+        # cannot save tuple-typed values directly; their tensor leaves are
+        # routed via `force_save_multi_output_must_save_ops` instead.
+        if node.meta.get(
+            "recompute", None
+        ) == CheckpointPolicy.MUST_SAVE and not _is_multi_output_node(node):
+            return "marked MUST_SAVE"
         if node.target is operator.getitem:
             return None
-        if node.meta.get("recompute", None) == CheckpointPolicy.MUST_SAVE:
-            return "marked MUST_SAVE"
         if config.recompute_views and op_types.is_view(node):
             return None
         if node.target in [aten.lift_fresh_copy.default, aten.lift_fresh.default]:
@@ -3732,6 +3788,7 @@ def min_cut_rematerialization_partition(
         force_save_collectives(joint_module)
 
     force_save_effectful_ops(joint_module)
+    force_save_multi_output_must_save_ops(joint_module)
     force_save_bw_mutation_src(joint_module)
 
     if static_lifetime_input_indices is None:


### PR DESCRIPTION
Summary:
OSS Pull Request: https://github.com/meta-recsys/generative-recommenders/pull/503

HSTU uses custom Triton kernels with manual activation checkpointing flags (recompute_uvqk_in_backward, recompute_normed_x_in_backward, recompute_y_in_backward). Under torch.compile, PT2's auto AC conflicts with these manual policies — it inserts redundant forward kernel calls instead of using the fused backward recompute paths, causing duplicate computation and wasted memory.

This diff adds Selective Activation Checkpointing (SAC) support so we can manually specify per-kernel AC policies that torch.compile respects.

**What changed (high level):**
- `D99269706` is a PT2/manual-recompute compatibility fix for HSTU: when `activation_checkpointing=False`, `torch.compile` should preserve the existing manual recompute policy instead of introducing duplicate forward-kernel replays.
- Design considerations: no new public `selective_ac_policy`, no changes to the module-level `_activation_checkpointing=True` path, and no production `model_config.py` rollout in this diff.
- The autograd-Function-level control plane keeps the existing recompute booleans: `activation_recompute_y`, `activation_recompute_uvqk`, and `activation_recompute_normed_x`. These continue to govern what the custom HSTU backward kernels save vs. recompute (unchanged from before this diff).
- The compile-only SAC policy_fn (in `_make_hstu_manual_checkpoint_contexts`, see `fused_hstu.py:147` docstring) is intentionally asymmetric vs. the three booleans:
  - All heavy HSTU forward kernels (layer-norm / addmm / attention variants) are always MUST_SAVE in the SAC policy. This prevents `torch.utils.checkpoint` from replaying them on top of work the custom backward already owns. The `recompute_normed_x` and `recompute_y` flags do NOT need to be inspected by the policy_fn because the tensors they govern stay inside the custom Function HOP boundary; PT2 cannot reach in to disturb them.
  - `activation_recompute_uvqk` IS inspected by the policy_fn, because the projection chain (`addmm → split_with_sizes → views → permute → apply_rope`) ESCAPES the Preproc Function HOP — the q/k/v views become inputs to the Attn Function. When the boolean is True, the policy_fn marks that chain MUST_RECOMPUTE so PT2 honors the manual contract instead of saving the q/k/v views and erasing the backward addmm replay.
- A small generic enhancement to the partitioner (`force_save_multi_output_must_save_ops`) propagates `MUST_SAVE` from tuple-/list-returning op parents down to the tensor-leaf getitem children. This is HSTU-agnostic — any caller using SAC + tuple-returning ops benefits. The partitioner code contains zero HSTU references; the only HSTU-specific code lives in `fbcode/hammer/v2/modules/fused_hstu.py`.
- Validation includes RL benchmark matrix: baseline compile OFF/ON plus all 8 SAC flag combinations compile OFF/ON, with trace, kernel-count, throughput, and memory artifacts.

**Code-level changes (where):**
- [fused_hstu.py](/data/users/mengdih/fbsource/fbcode/hammer/v2/modules/fused_hstu.py): adds the SAC `context_fn` factory `_make_hstu_manual_checkpoint_contexts` (with the `_policy_fn` defining MUST_SAVE / MUST_RECOMPUTE substring sets) and a compile-only branch that wraps `_forward_impl` with `torch.utils.checkpoint(..., use_reentrant=False, context_fn=...)`. Leaves the `_activation_checkpointing and self._is_train` branch and the eager `else` branch unchanged.
- [partitioners.py](/data/users/mengdih/fbsource/fbcode/caffe2/torch/_functorch/partitioners.py): adds a generic `force_save_multi_output_must_save_ops` helper that propagates SAC `MUST_SAVE` annotations from tuple-returning op parents to tensor-leaf getitem children; this lets the partitioner honor the policy without re-running the parent op in backward.
- [partitioners.py](/data/users/mengdih/fbsource/xplat/caffe2/torch/_functorch/partitioners.py): mirror of the same partitioner enhancement for xplat parity.
- [fused_hstu_test.py](/data/users/mengdih/fbsource/fbcode/hammer/v2/modules/tests/fused_hstu_test.py): adds/updates focused compile-parity coverage for manual recompute settings.
- [fused_hstu_utils.py](/data/users/mengdih/fbsource/fbcode/hammer/v2/modules/tests/fused_hstu_utils.py): threads the existing recompute flags through the unit-test harness.
- [rllayer_benchmark.py](/data/users/mengdih/fbsource/fbcode/minimal_viable_ai/models/ig_ranking/lsr/nano_rl/benchmarks/rllayer_benchmark.py): exposes `torch.compile` on/off and the three recompute booleans so the full 18-config matrix can be run and traced.
- A handful of `generative_recommenders/...` and `hammer/v2/ops/triton/...` autograd Functions add a single `_saved = ctx.saved_tensors` unpack for `use_reentrant=False` SAC compatibility.

**Behavioral impact:**
- Runtime behavior changes only when a caller installs the HSTU PT2/manual-recompute pass under `torch.compile`; current task notes explicitly treat this diff as validation/library scope, not production rollout scope.
- For same-flag eager/compile pairs, the expected runtime behavior is identical HSTU forward-kernel counts; compile should add `CompiledFxGraph` wrappers, not extra HSTU forward replays.
- `recompute_normed_x` controls `_weighted_layer_norm_fwd` count; `recompute_uvqk` controls `_addmm_fwd`; `recompute_y` stays fused into backward and should not increase visible top-level `_ln_mul_dropout_fwd` count.
- `_ragged_hstu_attn_fwd` stays flat in the observed 3-flag matrix; this diff does not add a fourth independent attention-recompute flag.
- The module-level `_activation_checkpointing=True` path remains unchanged.

**Performance / resource impact (expected):**
- Primary expected impact is correctness of compile behavior, not a new throughput optimization: compile should preserve the chosen manual recompute contract without duplicate kernels.
- Local task artifacts show no duplicate HSTU forward kernels in same-flag eager/compile pairs across the full 18-config matrix.
- On the small benchmark shape, compiled rows are faster than eager rows by 8-22% in iter/s (e.g., `sac_010` improves from 6.27 → 7.12 iter/s).
- Local memory data does not show a meaningful compiled-memory win on this microbenchmark. Memory-savings claims remain a follow-up validation item for a larger-scale or MAST-style run.

**Risk assessment:**
- `Low/Medium`: partitioner behavior could affect unrelated graphs. Mitigation: the new `force_save_multi_output_must_save_ops` is a generic enhancement (HSTU-agnostic); it only fires when a node is BOTH `MUST_SAVE`-tagged AND multi-output. Non-SAC users see zero behavior change.
- `Medium`: local memory numbers can be overinterpreted as product evidence. Mitigation: task notes explicitly scope the local packet to trace parity and smoke performance, not production memory proof.
- `Low/Medium`: some local compiled RL benchmark runs can fail in the async compile-worker with `ModuleNotFoundError: triton.language.extra.tlx`. Mitigation: classified as Inductor/Triton environment mismatch, not an HSTU logic regression; focused unit tests still pass.

**Compatibility / migration notes:**
- No new public config/API was added; existing recompute booleans remain the only policy surface.
- No ABI/schema/storage migration is involved.
- No production rollout wiring is included in this diff; benchmark/test harnesses are the current callers.
- `baseline_*` rows are retained for reviewer readability, but the task notes state they are mechanically identical to `sac_111_*` because the benchmark defaults all three recompute booleans to `True`.

**Observability:**
- Reviewer-facing traces are stored at `manifold://gpu_traces/tree/hpc/mengdih/sac_validation_0417_v2/` with PerfDoctor URLs under `https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/hpc/mengdih/sac_validation_0417_v2/<label>.json&bucket=gpu_traces`.
- Machine-extracted result summaries live under `~/tasks/T262413313/profiling/04212026_V3.4_verify/summary.json`.
- Focused unit-test evidence is recorded in `~/tasks/T262413313/plan/04212026_cc.md`.
- No new product metrics or alerts are introduced by the diff itself.

**Rollback plan:**
- The safest functional rollback is to not install the HSTU PT2/manual-recompute pass and/or run without `torch.compile`; eager/manual behavior is the preexisting baseline.
- If the diff itself must be reverted, revert the touched files only.
- Roll back if any same-flag eager/compile pair shows extra HSTU forward kernels, if compile-parity unit tests fail, or if future larger-scale validation shows a real memory/perf regression attributable to this logic.

Test Plan:
1. Focused unit tests on the exact reviewed commit `f711a0f88266f2e6791a311648c65dc10a3cf60a`:
   - `buck2 test --test-executor-stdout=- --test-executor-stderr=- fbcode//hammer/v2/modules/tests:fused_hstu_test -- -r test_manual_recompute_compile_parity`
     - PASS, testrun `1125900404103903`
   - `buck2 test --test-executor-stdout=- --test-executor-stderr=- fbcode//hammer/v2/modules/tests:fused_hstu_test -- -r test_stu_pt2_compatibility`
     - PASS, testrun `3659175058733932`

2. Exact-commit RL trace parity on `f711a0f88266`:
   - 6-anchor packet: `/home/mengdih/tasks/T262413313/profiling/04212026_f711a0f88266_redteam_trace/summary.json`
   - remaining 5 mixed pairs: `/home/mengdih/tasks/T262413313/profiling/04212026_f711a0f88266_rest_pairs_trace/summary.json`
   - explicit `sac_010` pair: `/home/mengdih/tasks/T262413313/profiling/04212026_f711a0f88266_010_trace/summary.json`
   - all 9 same-flag eager/compile pairs matched exactly on the 4 critical HSTU kernels:
     - `weighted_layer_norm_fwd`
     - `addmm_fwd`
     - `ragged_hstu_attn_fwd`
     - `ln_mul_dropout_fwd`
   - observed exact-commit counts by flag tuple `<y><uvqk><normed_x>`:
     - `000`: `80 / 40 / 20 / 20`
     - `001`: `100 / 40 / 20 / 20`
     - `010`: `80 / 80 / 20 / 20`
     - `011`: `100 / 80 / 20 / 20`
     - `100`: `80 / 40 / 20 / 20`
     - `101`: `100 / 40 / 20 / 20`
     - `110`: `80 / 80 / 20 / 20`
     - `111`: `100 / 80 / 20 / 20`
   - `CompiledFxGraph=160` appears only on compile traces (vs `=20` on the V3.3 packet for the same flag set, before the V3.4 substring fix). Diagnostic logs show every V3.4+ compile run hits Dynamo's `recompile_limit (8)` once, with the resume frame at `fused_hstu.py:808` recompiling on `___check_obj_id(manual_context_fn.args[0], …)` — the per-forward `functools.partial` has fresh identity each call, so the cap saturates and that frame falls back to eager. The HSTU kernel-count parity contract is preserved (custom backward + SAC together produce the correct counts), but the resume frame's compile coverage is partial. Filed as follow-up: cache `manual_context_fn` at module init so its identity is stable; the V3.6 `cache_hash` attribute helps `torch.utils.checkpoint`'s SAC re-entry cache but does not suppress Dynamo's identity guard.

3. Larger-shape reviewer-facing RL benchmark matrix:
   - packet: `/home/mengdih/tasks/T262413313/profiling/04212026_V3.4_verify/summary.json`
   - covers baseline compile OFF/ON plus all 8 SAC combinations compile OFF/ON (18 rows total)
   - same-flag eager/compile kernel counts match across the matrix
   - throughput is generally higher in compile rows for same-flag pairs on this local packet
   - memory observations are mixed by shape/allocator behavior, so this local packet is used as correctness/smoke evidence only and does not claim a production memory win

4. Representative uploaded traces:
   - `baseline_compile`: `https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/hpc/new/models/feed/benchmark/libkineto_activities_2016411_2456c0b9c862416cb981f97f3e3f012f.json.gz&bucket=gpu_traces`
   - `sac_010_compile`: `https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/hpc/new/models/feed/benchmark/libkineto_activities_1840265_94a8b0dc899c43debb3231928187fd65.json.gz&bucket=gpu_traces`
   - `sac_111_compile`: `https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/hpc/new/models/feed/benchmark/libkineto_activities_3381727_ef43231f59d04e80adc028590b037517.json.gz&bucket=gpu_traces`

5. Additional red-team checks:
   - Hammer-only rollback of the generic tuple-output partitioner hunk reproduced the Inductor tuple-output assertion immediately, so the generic `partitioners.py` leaf-propagation fix is load-bearing for this design.
   - Draft refresh performed with `jf submit --draft` only; no publish action was taken.

Differential Revision: D99269706


