### PR TITLE
[TEST][FP8] Fix test_scaled_mm_vs_emulated_row_wise float32 tolerance using scaled inputs

### DIFF
--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -1340,7 +1340,10 @@ class TestFP8Matmul(TestCase):
             if base_dtype in {torch.bfloat16, torch.float16}:
                 atol, rtol = 7e-2, 7e-2
             else:
-                atol, rtol = 2e-3, 2e-3
+                # cuBLAS row-wise FP8 accumulates raw FP8 products before applying
+                # scales (vs. emulated which dequantizes per-element first), causing
+                # rounding differences that grow with K. 3e-2 is sufficient for K=512.
+                atol, rtol = 3e-2, 3e-2
 
             self.assertEqual(out_scaled_mm, out_emulated, atol=atol, rtol=rtol)
 

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -48,6 +48,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     MI350_ARCH,
     parametrize,
+    random_matrix_with_scaled_reduction_dim,
     run_tests,
     runOnRocmArch,
     skipIfRocm,
@@ -1309,8 +1310,8 @@ class TestFP8Matmul(TestCase):
         input_dtype = e4m3_type
         output_dtype = base_dtype
 
-        x = torch.randn(M, K, device=device, dtype=base_dtype)
-        y = torch.randn(N, K, device=device, dtype=base_dtype).t()
+        x = random_matrix_with_scaled_reduction_dim(M, K, dtype=base_dtype, device=device, reduction_dim=-1)
+        y = random_matrix_with_scaled_reduction_dim(N, K, dtype=base_dtype, device=device, reduction_dim=-1).t()
         bias = None
         if base_dtype in {torch.bfloat16, torch.float16}:
             bias = torch.randn((N,), device=device, dtype=base_dtype)
@@ -1340,10 +1341,7 @@ class TestFP8Matmul(TestCase):
             if base_dtype in {torch.bfloat16, torch.float16}:
                 atol, rtol = 7e-2, 7e-2
             else:
-                # cuBLAS row-wise FP8 accumulates raw FP8 products before applying
-                # scales (vs. emulated which dequantizes per-element first), causing
-                # rounding differences that grow with K. 3e-2 is sufficient for K=512.
-                atol, rtol = 3e-2, 3e-2
+                atol, rtol = 2e-3, 2e-3
 
             self.assertEqual(out_scaled_mm, out_emulated, atol=atol, rtol=rtol)
 


### PR DESCRIPTION
Use random_matrix_with_scaled_reduction_dim to generate test inputs scaled by 1/sqrt(K), which reduces output magnitudes proportionally so that the absolute differences between cuBLAS and the emulated reference stay within the original atol=2e-3 tolerance without needing to loosen it.                                                                                           
       
This is to fix [Limited CI on H100 / linux-jammy-cuda13.0-py3.10-gcc11-sm90 / test (smoke, 1, 1, linux.aws.h100)](https://hud.pytorch.org/pr/pytorch/pytorch/180052#71563064771) ([gh](https://github.com/pytorch/pytorch/actions/runs/24485687515/job/71563064771))
test/test_scaled_matmul_cuda.py::TestFP8MatmulCUDA::test_scaled_mm_vs_emulated_row_wise_float32_shapes0_cuda 

in https://github.com/pytorch/pytorch/pull/180052

cc @eqy @nWEIdia @ptrblck 