### PR TITLE
[dynamo] Update invoke_subgraph test for tainted proxy error message

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1514,12 +1514,11 @@ class GraphModule(torch.nn.Module):
 
         x = torch.randn(8, requires_grad=False)
         opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
-        # TODO When a filtered aliased intermediate is captured by side effects,
-        # it will fail later with "does not belong to this Graph" error
-        # because the proxy from the inner graph is used in the outer graph.
+        # When a filtered aliased intermediate is captured by side effects,
+        # the tainted proxy raises a clear error telling the user to clone.
         with self.assertRaisesRegex(
             torch._dynamo.exc.InternalTorchDynamoError,
-            "does not belong to this Graph",
+            "aliases an input or output.*clone",
         ):
             opt_fn(x)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181045
* #180939
* #180929

The test_side_effect_with_aliased_intermediate test expected the old
"does not belong to this Graph" lint error, but now gets the clearer
tainted proxy error from the aliased intermediates fix.

Authored with Claude.