### PR TITLE
Use std::move and c10::irange in Inductor 

### DIFF
--- a/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_holder.cpp
@@ -396,8 +396,8 @@ void AOTIPythonKernelHolder::init_aoti_kernel_cache() {
       } else {
         // Tensor
         auto metadata = item_metadata.cast<py::dict>();
-        auto tensor_metadata = build_tensor_metadata(metadata);
-        parameter_metadata_list.emplace_back(tensor_metadata, arg_idx);
+        parameter_metadata_list.emplace_back(
+            build_tensor_metadata(metadata), arg_idx);
       }
     }
 

--- a/torch/csrc/inductor/aoti_eager/kernel_meta_info.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_meta_info.cpp
@@ -128,19 +128,21 @@ std::ostream& operator<<(
 ParameterMetadata::ParameterMetadata(
     TensorMetadata tensor_metadata,
     uint64_t input_order)
-    : tag_(TENSOR), value_(tensor_metadata), order_(input_order) {}
+    : tag_(TENSOR),
+      value_(std::move(tensor_metadata)),
+      order_(input_order) {}
 
 ParameterMetadata::ParameterMetadata(
     const at::Tensor& tensor,
     uint64_t input_order)
-    : tag_(TENSOR), order_(input_order) {
-  value_ = TensorMetadata(tensor);
-}
+    : tag_(TENSOR), value_(TensorMetadata(tensor)), order_(input_order) {}
 
 ParameterMetadata::ParameterMetadata(
-    const std::vector<TensorMetadata>& tensor_metadata_list,
+    std::vector<TensorMetadata> tensor_metadata_list,
     uint64_t input_order)
-    : tag_(TENSOR_LIST), value_(tensor_metadata_list), order_(input_order) {}
+    : tag_(TENSOR_LIST),
+      value_(std::move(tensor_metadata_list)),
+      order_(input_order) {}
 
 ParameterMetadata::ParameterMetadata(
     const std::vector<at::Tensor>& tensor_list,
@@ -160,9 +162,9 @@ ParameterMetadata::ParameterMetadata(
     : tag_(SCALAR), value_(scalar), order_(input_order) {}
 
 ParameterMetadata::ParameterMetadata(
-    const std::string& str,
+    std::string str,
     uint64_t input_order)
-    : tag_(STRING), value_(str), order_(input_order) {}
+    : tag_(STRING), value_(std::move(str)), order_(input_order) {}
 
 ParameterMetadata::ParameterMetadata(
     const c10::Device& device,

--- a/torch/csrc/inductor/aoti_eager/kernel_meta_info.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_meta_info.cpp
@@ -1,4 +1,5 @@
 #if !defined(C10_MOBILE) && !defined(ANDROID)
+#include <c10/util/irange.h>
 #include <torch/csrc/inductor/aoti_eager/kernel_meta_info.h>
 #include <iostream>
 #include <utility>
@@ -128,9 +129,7 @@ std::ostream& operator<<(
 ParameterMetadata::ParameterMetadata(
     TensorMetadata tensor_metadata,
     uint64_t input_order)
-    : tag_(TENSOR),
-      value_(std::move(tensor_metadata)),
-      order_(input_order) {}
+    : tag_(TENSOR), value_(std::move(tensor_metadata)), order_(input_order) {}
 
 ParameterMetadata::ParameterMetadata(
     const at::Tensor& tensor,
@@ -161,9 +160,7 @@ ParameterMetadata::ParameterMetadata(
     uint64_t input_order)
     : tag_(SCALAR), value_(scalar), order_(input_order) {}
 
-ParameterMetadata::ParameterMetadata(
-    std::string str,
-    uint64_t input_order)
+ParameterMetadata::ParameterMetadata(std::string str, uint64_t input_order)
     : tag_(STRING), value_(std::move(str)), order_(input_order) {}
 
 ParameterMetadata::ParameterMetadata(
@@ -239,7 +236,7 @@ bool ParameterMetadata::dynamic_check(const ParameterMetadata& other) const {
       if (self_list.size() != other_list.size()) {
         return false;
       }
-      for (size_t i = 0; i < self_list.size(); ++i) {
+      for (const auto i : c10::irange(self_list.size())) {
         if (!self_list[i].dynamic_check(other_list[i])) {
           return false;
         }

--- a/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
+++ b/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
@@ -128,10 +128,10 @@ struct ParameterMetadata {
       const std::vector<at::Tensor>& tensor_list,
       uint64_t input_order);
   ParameterMetadata(
-      const std::vector<TensorMetadata>& tensor_metadata_list,
+      std::vector<TensorMetadata> tensor_metadata_list,
       uint64_t input_order);
   ParameterMetadata(const c10::Scalar& scalar, uint64_t input_order);
-  ParameterMetadata(const std::string& string_value, uint64_t input_order);
+  ParameterMetadata(std::string string_value, uint64_t input_order);
   ParameterMetadata(const c10::Device& device, uint64_t input_order);
 
   bool operator==(const ParameterMetadata& other) const;

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -314,7 +314,7 @@ void OSSProxyExecutor::prefill_stack_with_static_arguments(
               index,
               DynamicArgType::ListOptionalTensorType,
               serialized_arg_val.size(),
-              list_item_types);
+              std::move(list_item_types));
         } else if (serialized_arg_type == "as_tensors") {
           dynamic_args.emplace_back(
               index, DynamicArgType::ListTensorType, serialized_arg_val.size());

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -7,6 +7,7 @@
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/inductor/aoti_runtime/utils.h>
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <torch/csrc/inductor/aoti_torch/mkldnn_tensor.h>
@@ -253,7 +254,7 @@ AOTITorchError aoti_torch_strlist_to_ivalue(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::string> vec;
     vec.reserve(len);
-    for (int64_t i = 0; i < len; i++) {
+    for (const auto i : c10::irange(len)) {
       vec.emplace_back(val[i]);
     }
     c10::IValue* t = new c10::IValue(std::move(vec));

--- a/torch/csrc/inductor/aoti_torch/shim_common.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_common.cpp
@@ -1125,7 +1125,7 @@ AOTITorchError aoti_record_function_start(
     }
 
     std::vector<c10::IValue> recordInputs(n_inputs);
-    for (size_t i = 0; i < n_inputs; i++) {
+    for (const auto i : c10::irange(n_inputs)) {
       recordInputs[i] = *reinterpret_cast<c10::IValue*>(inputs[i]);
     }
 
@@ -1192,7 +1192,7 @@ AOTITorchError aoti_torch_index_put_out(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<at::Tensor>> indices_;
     indices_.reserve(num_indices);
-    for (size_t i = 0; i < num_indices; i++) {
+    for (const auto i : c10::irange(num_indices)) {
       indices_.emplace_back(
           pointer_to_optional(tensor_handle_to_tensor_pointer(indices[i])));
     }

--- a/torch/csrc/inductor/aoti_torch/shim_cpu.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_cpu.cpp
@@ -41,7 +41,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> unary_scalars_list;
     unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
+    for (const auto i : c10::irange(unary_scalars_len_)) {
       unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
     }
     auto tmp_result = at::native::mkldnn_convolution_pointwise_binary(
@@ -84,7 +84,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise_binary_(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> unary_scalars_list;
     unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
+    for (const auto i : c10::irange(unary_scalars_len_)) {
       unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
     }
     auto tmp_result = at::native::mkldnn_convolution_pointwise_binary_(
@@ -124,7 +124,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_pointwise(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(scalars_len_);
-    for (int64_t i = 0; i < scalars_len_; i++) {
+    for (const auto i : c10::irange(scalars_len_)) {
       scalars_list.emplace_back(pointer_to_optional(scalars[i]));
     }
     auto tmp_result = at::native::mkldnn_convolution_pointwise(
@@ -163,7 +163,7 @@ AOTITorchError aoti_torch_cpu_mkldnn__convolution_transpose_pointwise(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(scalars_len_);
-    for (int64_t i = 0; i < scalars_len_; i++) {
+    for (const auto i : c10::irange(scalars_len_)) {
       scalars_list.emplace_back(pointer_to_optional(scalars[i]));
     }
     auto tmp_result = at::native::mkldnn_convolution_transpose_pointwise(
@@ -241,7 +241,7 @@ AOTITorchError aoti_torch_cpu__linear_pointwise(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(scalars_len_);
-    for (int64_t i = 0; i < scalars_len_; i++) {
+    for (const auto i : c10::irange(scalars_len_)) {
       scalars_list.emplace_back(pointer_to_optional(scalars[i]));
     }
     auto tmp_result = at::native::mkldnn_linear_pointwise(
@@ -292,7 +292,7 @@ AOTITorchError aoti_torch_cpu__qlinear_pointwise_tensor(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(post_op_args_len_);
-    for (int64_t i = 0; i < post_op_args_len_; i++) {
+    for (const auto i : c10::irange(post_op_args_len_)) {
       scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
     }
 
@@ -338,7 +338,7 @@ AOTITorchError aoti_torch_cpu__qlinear_pointwise_binary_tensor(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(unary_post_op_args_len_);
-    for (int64_t i = 0; i < unary_post_op_args_len_; i++) {
+    for (const auto i : c10::irange(unary_post_op_args_len_)) {
       scalars_list.emplace_back(pointer_to_optional(unary_post_op_args[i]));
     }
 
@@ -391,7 +391,7 @@ AOTITorchError aoti_torch_cpu__qconv_pointwise_tensor(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(post_op_args_len_);
-    for (int64_t i = 0; i < post_op_args_len_; i++) {
+    for (const auto i : c10::irange(post_op_args_len_)) {
       scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
     }
 
@@ -455,7 +455,7 @@ AOTITorchError aoti_torch_cpu__qconv2d_pointwise_binary_tensor(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> unary_scalars_list;
     unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
+    for (const auto i : c10::irange(unary_scalars_len_)) {
       unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
     }
 

--- a/torch/csrc/inductor/aoti_torch/shim_xpu.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_xpu.cpp
@@ -105,7 +105,7 @@ AOTITorchError aoti_torch_xpu_mkldnn__convolution_pointwise_binary(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> unary_scalars_list;
     unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
+    for (const auto i : c10::irange(unary_scalars_len_)) {
       unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
     }
     auto tmp_result = at::native::xpu::convolution_pointwise_binary(
@@ -148,7 +148,7 @@ AOTITorchError aoti_torch_xpu_mkldnn__convolution_pointwise_binary_(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> unary_scalars_list;
     unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
+    for (const auto i : c10::irange(unary_scalars_len_)) {
       unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
     }
     auto tmp_result = at::native::xpu::convolution_pointwise_binary_(
@@ -188,7 +188,7 @@ AOTITorchError aoti_torch_xpu_mkldnn__convolution_pointwise(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(scalars_len_);
-    for (int64_t i = 0; i < scalars_len_; i++) {
+    for (const auto i : c10::irange(scalars_len_)) {
       scalars_list.emplace_back(pointer_to_optional(scalars[i]));
     }
     auto tmp_result = at::native::xpu::convolution_pointwise(
@@ -225,7 +225,7 @@ AOTITorchError aoti_torch_xpu__qlinear_pointwise_tensor(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(post_op_args_len_);
-    for (int64_t i = 0; i < post_op_args_len_; i++) {
+    for (const auto i : c10::irange(post_op_args_len_)) {
       scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
     }
 
@@ -272,7 +272,7 @@ AOTITorchError aoti_torch_xpu__qlinear_pointwise_binary_tensor(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(unary_post_op_args_len_);
-    for (int64_t i = 0; i < unary_post_op_args_len_; i++) {
+    for (const auto i : c10::irange(unary_post_op_args_len_)) {
       scalars_list.emplace_back(pointer_to_optional(unary_post_op_args[i]));
     }
 
@@ -326,7 +326,7 @@ AOTITorchError aoti_torch_xpu__qconv_pointwise_tensor(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> scalars_list;
     scalars_list.reserve(post_op_args_len_);
-    for (int64_t i = 0; i < post_op_args_len_; i++) {
+    for (const auto i : c10::irange(post_op_args_len_)) {
       scalars_list.emplace_back(pointer_to_optional(post_op_args[i]));
     }
 
@@ -390,7 +390,7 @@ AOTITorchError aoti_torch_xpu__qconv2d_pointwise_binary_tensor(
   AOTI_TORCH_CONVERT_EXCEPTION_TO_ERROR_CODE({
     c10::List<std::optional<c10::Scalar>> unary_scalars_list;
     unary_scalars_list.reserve(unary_scalars_len_);
-    for (int64_t i = 0; i < unary_scalars_len_; i++) {
+    for (const auto i : c10::irange(unary_scalars_len_)) {
       unary_scalars_list.emplace_back(pointer_to_optional(unary_scalars[i]));
     }
 

--- a/torch/csrc/inductor/aoti_torch/utils.h
+++ b/torch/csrc/inductor/aoti_torch/utils.h
@@ -8,6 +8,7 @@
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Logging.h>
 #include <c10/util/OptionalArrayRef.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <optional>
 
@@ -162,7 +163,7 @@ inline std::vector<T> pointer_to_list(U* ptr, int64_t len) {
   // site
   std::vector<T> result;
   result.reserve(len);
-  for (int64_t i = 0; i < len; i++) {
+  for (const auto i : c10::irange(len)) {
     result.emplace_back(T(ptr[i]));
   }
   return result;
@@ -175,7 +176,7 @@ inline std::vector<T> pointer_to_list(U** ptr, int64_t len) {
   // site
   std::vector<T> result;
   result.reserve(len);
-  for (int64_t i = 0; i < len; i++) {
+  for (const auto i : c10::irange(len)) {
     result.emplace_back(pointer_to_optional(ptr[i]));
   }
   return result;
@@ -187,7 +188,7 @@ inline std::vector<at::Tensor> pointer_to_list(
     int64_t len) {
   std::vector<at::Tensor> result;
   result.reserve(len);
-  for (int64_t i = 0; i < len; i++) {
+  for (const auto i : c10::irange(len)) {
     result.emplace_back(*tensor_handle_to_tensor_pointer(ptr[i]));
   }
   return result;
@@ -199,7 +200,7 @@ inline std::vector<std::optional<at::Tensor>> pointer_to_list(
     int64_t len) {
   std::vector<std::optional<at::Tensor>> result;
   result.reserve(len);
-  for (int64_t i = 0; i < len; i++) {
+  for (const auto i : c10::irange(len)) {
     result.emplace_back(pointer_to_optional<at::Tensor>(ptr[i]));
   }
   return result;
@@ -226,7 +227,7 @@ template <typename T>
 static c10::List<T> convert_to_c10_List(const T* scalars, const int64_t len) {
   c10::List<T> scalars_list;
   scalars_list.reserve(len);
-  for (int64_t i = 0; i < len; i++) {
+  for (const auto i : c10::irange(len)) {
     scalars_list.emplace_back(scalars[i]);
   }
   return scalars_list;


### PR DESCRIPTION
This PR uses more std::move and c10::irange in inductor code.