### PR TITLE
[PP] Support extra loss_fn kwargs in pipeline schedules

### DIFF
--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -284,9 +284,9 @@ class _PipelineSchedule(ABC):
         self._internal_losses: list[torch.Tensor] = []
         logger.info("Using %s", self.__class__.__name__)
 
-    def _maybe_compute_loss(self, stage, output, target_mbs, mb_index):
+    def _maybe_compute_loss(self, stage, output, target_mbs, mb_index, loss_kwargs=None):
         if stage.is_last and self._loss_fn is not None:
-            loss = self._compute_loss(output, target_mbs[mb_index])  # type: ignore[index]
+            loss = self._compute_loss(output, target_mbs[mb_index], loss_kwargs)  # type: ignore[index]
             self._internal_losses.append(loss)
 
     def _maybe_get_loss(self, stage, mb_index):
@@ -390,6 +390,7 @@ class _PipelineSchedule(ABC):
         target: Any,
         fwd_initialized: bool,
         bwd_initialized: bool,
+        loss_kwargs: dict[str, Any] | None = None,
     ) -> tuple[bool, bool]:
         """Common stage initialization shared by Single and Multi schedules.
 
@@ -444,6 +445,7 @@ class _PipelineSchedule(ABC):
                         loss_fn=self._loss_fn,
                         target=target,
                         received_grad_meta=prev_stage_grad_meta,
+                        loss_kwargs=loss_kwargs,
                     )
                 bwd_initialized = True
 
@@ -461,6 +463,7 @@ class _PipelineSchedule(ABC):
         target_mbs: list | None = None,
         losses: list | None = None,
         return_outputs: bool = True,
+        loss_kwargs: dict[str, Any] | None = None,
     ):
         """
         Run one iteration of the pipeline schedule with list of microbatches.
@@ -470,6 +473,7 @@ class _PipelineSchedule(ABC):
         Args:
             microbatches: list of microbatch args.
             return_outputs: whether to return the outputs from the last stage.
+            loss_kwargs: extra keyword arguments forwarded to the loss function.
         """
         raise NotImplementedError
 
@@ -480,6 +484,7 @@ class _PipelineSchedule(ABC):
         target=None,
         losses: list | None = None,
         return_outputs=True,
+        loss_kwargs: dict[str, Any] | None = None,
         **kwargs,
     ):
         """
@@ -492,6 +497,7 @@ class _PipelineSchedule(ABC):
         target: target for the loss function.
         losses: a list to store the losses for each microbatch.
         return_outputs: whether to return the outputs from the last stage.
+        loss_kwargs: extra keyword arguments forwarded to the loss function.
         """
         raise NotImplementedError
 
@@ -553,8 +559,8 @@ class _PipelineSchedule(ABC):
 
         return arg_mbs, kwarg_mbs
 
-    def _compute_loss(self, output, target):
-        return self._loss_fn(output, target)  # type: ignore[misc]
+    def _compute_loss(self, output, target, loss_kwargs=None):
+        return self._loss_fn(output, target, **(loss_kwargs or {}))  # type: ignore[misc]
 
     def _split_inputs(
         self,
@@ -693,7 +699,7 @@ class PipelineScheduleSingle(_PipelineSchedule):
             self._get_pipeline_order()
         )
 
-    def _initialize_stage(self, args, kwargs, target=None):
+    def _initialize_stage(self, args, kwargs, target=None, loss_kwargs=None):
         (
             self._stage_forward_initialized,
             self._stage_backward_initialized,
@@ -704,6 +710,7 @@ class PipelineScheduleSingle(_PipelineSchedule):
             target,
             self._stage_forward_initialized,
             self._stage_backward_initialized,
+            loss_kwargs=loss_kwargs,
         )
 
     def step(
@@ -712,6 +719,7 @@ class PipelineScheduleSingle(_PipelineSchedule):
         target=None,
         losses: list | None = None,
         return_outputs: bool = True,
+        loss_kwargs: dict[str, Any] | None = None,
         **kwargs,
     ):
         """
@@ -724,6 +732,8 @@ class PipelineScheduleSingle(_PipelineSchedule):
         target: target for the loss function.
         losses: a list to store the losses for each microbatch.
         return_outputs: whether to return the outputs from the last stage.
+        loss_kwargs: extra keyword arguments forwarded to the loss function
+            (e.g. ``global_valid_tokens`` for chunked cross-entropy loss).
         """
         if self._has_backward and not torch.is_grad_enabled():
             raise RuntimeError(
@@ -749,7 +759,8 @@ class PipelineScheduleSingle(_PipelineSchedule):
 
         # Run microbatches
         self._step_microbatches(
-            args_split, kwargs_split, targets_split, losses, return_outputs
+            args_split, kwargs_split, targets_split, losses, return_outputs,
+            loss_kwargs=loss_kwargs,
         )
 
         # Return merged results per original format
@@ -842,6 +853,7 @@ class ScheduleGPipe(PipelineScheduleSingle):
         target_mbs: list | None = None,
         losses: list | None = None,
         return_outputs: bool = True,
+        loss_kwargs: dict[str, Any] | None = None,
     ):
         """
         Run one iteration of the pipeline schedule with list of microbatches.
@@ -853,7 +865,7 @@ class ScheduleGPipe(PipelineScheduleSingle):
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
         maybe_first_target = target_mbs[0] if target_mbs is not None else None
-        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], maybe_first_target)
+        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs)
 
         # Delay send waits
         fwd_sends_to_wait: list[list[dist.Work]] = []
@@ -876,7 +888,7 @@ class ScheduleGPipe(PipelineScheduleSingle):
 
             logger.debug("[%s] Forwarded microbatch %s", self._stage.stage_index, i)
 
-            self._maybe_compute_loss(self._stage, output, target_mbs, i)
+            self._maybe_compute_loss(self._stage, output, target_mbs, i, loss_kwargs)
 
         # Wait for all forward sends to finish
         # This should not have performance impact because by the time the first
@@ -987,6 +999,7 @@ or equal to the number of stages ({self._num_stages})."
         target_mbs: list | None = None,
         losses: list | None = None,
         return_outputs: bool = True,
+        loss_kwargs: dict[str, Any] | None = None,
     ):
         """
         Run one iteration of the pipeline schedule with list of microbatches.
@@ -995,10 +1008,11 @@ or equal to the number of stages ({self._num_stages})."
         Args:
             microbatches: list of microbatch args.
             return_outputs: whether to return the outputs from the last stage.
+            loss_kwargs: extra keyword arguments forwarded to the loss function.
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
         maybe_first_target = target_mbs[0] if target_mbs is not None else None
-        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], maybe_first_target)
+        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs)
 
         # Last stage has 1 warmup, second-to-last 2 warmups, ...
         # first stage `num_stages` warmups
@@ -1042,7 +1056,7 @@ or equal to the number of stages ({self._num_stages})."
             #   The last forward send is left for fuse with first 1B in 1B1F below
 
             # Compute loss
-            self._maybe_compute_loss(self._stage, output, target_mbs, fwd_mb_index)
+            self._maybe_compute_loss(self._stage, output, target_mbs, fwd_mb_index, loss_kwargs)
             fwd_mb_index += 1
 
         # Now we should have send ops left over, to be fused with first 1B of 1B1F phase below.
@@ -1086,7 +1100,7 @@ or equal to the number of stages ({self._num_stages})."
             )  # type: ignore[index]
 
             # Compute loss
-            self._maybe_compute_loss(self._stage, output, target_mbs, fwd_mb_index)
+            self._maybe_compute_loss(self._stage, output, target_mbs, fwd_mb_index, loss_kwargs)
 
             # Get the fwd send ops, but don't fire, leave it for the next iter (wrap-around)
             fwd_sends = self._stage.get_fwd_send_ops(fwd_mb_index)
@@ -1665,7 +1679,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
                 "Simply stop passing it, and everything should still work fine."
             )
 
-    def _initialize_stages(self, args: tuple[Any, ...], kwargs, target=None):
+    def _initialize_stages(self, args: tuple[Any, ...], kwargs, target=None, loss_kwargs=None):
         (
             self._stages_forward_initialized,
             self._stages_backward_initialized,
@@ -1676,6 +1690,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
             target,
             self._stages_forward_initialized,
             self._stages_backward_initialized,
+            loss_kwargs=loss_kwargs,
         )
 
     def _validate_and_set_stage_mapping(
@@ -1723,6 +1738,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
         target=None,
         losses: list | None = None,
         return_outputs: bool = True,
+        loss_kwargs: dict[str, Any] | None = None,
         **kwargs,
     ):
         """
@@ -1735,6 +1751,8 @@ class PipelineScheduleMulti(_PipelineSchedule):
         target: target for the loss function.
         losses: a list to store the losses for each microbatch.
         return_outputs: whether to return the outputs from the last stage.
+        loss_kwargs: extra keyword arguments forwarded to the loss function
+            (e.g. ``global_valid_tokens`` for chunked cross-entropy loss).
         """
         if (
             self._has_backward
@@ -1766,7 +1784,8 @@ class PipelineScheduleMulti(_PipelineSchedule):
 
         # Run microbatches
         self._step_microbatches(
-            args_split, kwargs_split, targets_split, losses, return_outputs
+            args_split, kwargs_split, targets_split, losses, return_outputs,
+            loss_kwargs=loss_kwargs,
         )
 
         # Return merged results per original format
@@ -1783,6 +1802,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
         target_mbs: list | None = None,
         losses: list | None = None,
         return_outputs: bool = True,
+        loss_kwargs: dict[str, Any] | None = None,
     ):
         """
         Operate on the microbatches for looped schedules (multiple stages on each rank).
@@ -1792,7 +1812,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
         maybe_first_target = target_mbs[0] if target_mbs is not None else None
-        self._initialize_stages(arg_mbs[0], kwarg_mbs[0], maybe_first_target)
+        self._initialize_stages(arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs)
 
         # Based on the plan in Step 1 created in __init__:
         # 2. Perform communication based on the pipeline_order
@@ -1832,7 +1852,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
                             kwarg_mbs[mb_index],
                             save_forward_output=return_outputs,
                         )
-                        self._maybe_compute_loss(stage, output, target_mbs, mb_index)
+                        self._maybe_compute_loss(stage, output, target_mbs, mb_index, loss_kwargs)
                         ops.extend(stage.get_fwd_send_ops(mb_index))
                     elif computation_type == _ComputationType.FULL_BACKWARD:
                         # perform backward computation
@@ -2169,6 +2189,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
         target_mbs: list | None = None,
         losses: list | None = None,
         return_outputs: bool = True,
+        loss_kwargs: dict[str, Any] | None = None,
     ):
         """
         Operate on the microbatches for looped schedules (multiple stages on each rank).
@@ -2178,7 +2199,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
         maybe_first_target = target_mbs[0] if target_mbs is not None else None
-        self._initialize_stages(arg_mbs[0], kwarg_mbs[0], maybe_first_target)
+        self._initialize_stages(arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs)
 
         # Based on the plan in Step 1 created in __init__:
         # 2. Perform communication based on the pipeline_order
@@ -2288,7 +2309,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                     kwarg_mbs[mb_index],  # type: ignore[index]
                     save_forward_output=return_outputs,
                 )
-                self._maybe_compute_loss(stage, output, target_mbs, mb_index)
+                self._maybe_compute_loss(stage, output, target_mbs, mb_index, loss_kwargs)
 
                 # SEND/RECV op are avoided for special case with 2 adjacent stages on same rank
                 # see [Note: V-schedule special case]

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -1693,7 +1693,9 @@ class PipelineScheduleMulti(_PipelineSchedule):
                 "Simply stop passing it, and everything should still work fine."
             )
 
-    def _initialize_stages(self, args: tuple[Any, ...], kwargs, target=None, loss_kwargs=None):
+    def _initialize_stages(
+        self, args: tuple[Any, ...], kwargs, target=None, loss_kwargs=None
+    ):
         (
             self._stages_forward_initialized,
             self._stages_backward_initialized,

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -284,7 +284,9 @@ class _PipelineSchedule(ABC):
         self._internal_losses: list[torch.Tensor] = []
         logger.info("Using %s", self.__class__.__name__)
 
-    def _maybe_compute_loss(self, stage, output, target_mbs, mb_index, loss_kwargs=None):
+    def _maybe_compute_loss(
+        self, stage, output, target_mbs, mb_index, loss_kwargs=None
+    ):
         if stage.is_last and self._loss_fn is not None:
             loss = self._compute_loss(output, target_mbs[mb_index], loss_kwargs)  # type: ignore[index]
             self._internal_losses.append(loss)
@@ -732,8 +734,7 @@ class PipelineScheduleSingle(_PipelineSchedule):
         target: target for the loss function.
         losses: a list to store the losses for each microbatch.
         return_outputs: whether to return the outputs from the last stage.
-        loss_kwargs: extra keyword arguments forwarded to the loss function
-            (e.g. ``global_valid_tokens`` for chunked cross-entropy loss).
+        loss_kwargs: extra keyword arguments forwarded to the loss function.
         """
         if self._has_backward and not torch.is_grad_enabled():
             raise RuntimeError(
@@ -759,7 +760,11 @@ class PipelineScheduleSingle(_PipelineSchedule):
 
         # Run microbatches
         self._step_microbatches(
-            args_split, kwargs_split, targets_split, losses, return_outputs,
+            args_split,
+            kwargs_split,
+            targets_split,
+            losses,
+            return_outputs,
             loss_kwargs=loss_kwargs,
         )
 
@@ -801,6 +806,7 @@ class _ScheduleForwardOnly(PipelineScheduleSingle):
         target_mbs: list | None = None,
         losses: list | None = None,
         return_outputs: bool = True,
+        loss_kwargs: dict[str, Any] | None = None,
     ):
         """
         Run one iteration of the pipeline schedule
@@ -865,7 +871,9 @@ class ScheduleGPipe(PipelineScheduleSingle):
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
         maybe_first_target = target_mbs[0] if target_mbs is not None else None
-        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs)
+        self._initialize_stage(
+            arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs
+        )
 
         # Delay send waits
         fwd_sends_to_wait: list[list[dist.Work]] = []
@@ -1012,7 +1020,9 @@ or equal to the number of stages ({self._num_stages})."
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
         maybe_first_target = target_mbs[0] if target_mbs is not None else None
-        self._initialize_stage(arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs)
+        self._initialize_stage(
+            arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs
+        )
 
         # Last stage has 1 warmup, second-to-last 2 warmups, ...
         # first stage `num_stages` warmups
@@ -1056,7 +1066,9 @@ or equal to the number of stages ({self._num_stages})."
             #   The last forward send is left for fuse with first 1B in 1B1F below
 
             # Compute loss
-            self._maybe_compute_loss(self._stage, output, target_mbs, fwd_mb_index, loss_kwargs)
+            self._maybe_compute_loss(
+                self._stage, output, target_mbs, fwd_mb_index, loss_kwargs
+            )
             fwd_mb_index += 1
 
         # Now we should have send ops left over, to be fused with first 1B of 1B1F phase below.
@@ -1100,7 +1112,9 @@ or equal to the number of stages ({self._num_stages})."
             )  # type: ignore[index]
 
             # Compute loss
-            self._maybe_compute_loss(self._stage, output, target_mbs, fwd_mb_index, loss_kwargs)
+            self._maybe_compute_loss(
+                self._stage, output, target_mbs, fwd_mb_index, loss_kwargs
+            )
 
             # Get the fwd send ops, but don't fire, leave it for the next iter (wrap-around)
             fwd_sends = self._stage.get_fwd_send_ops(fwd_mb_index)
@@ -1751,8 +1765,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
         target: target for the loss function.
         losses: a list to store the losses for each microbatch.
         return_outputs: whether to return the outputs from the last stage.
-        loss_kwargs: extra keyword arguments forwarded to the loss function
-            (e.g. ``global_valid_tokens`` for chunked cross-entropy loss).
+        loss_kwargs: extra keyword arguments forwarded to the loss function.
         """
         if (
             self._has_backward
@@ -1784,7 +1797,11 @@ class PipelineScheduleMulti(_PipelineSchedule):
 
         # Run microbatches
         self._step_microbatches(
-            args_split, kwargs_split, targets_split, losses, return_outputs,
+            args_split,
+            kwargs_split,
+            targets_split,
+            losses,
+            return_outputs,
             loss_kwargs=loss_kwargs,
         )
 
@@ -1812,7 +1829,9 @@ class PipelineScheduleMulti(_PipelineSchedule):
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
         maybe_first_target = target_mbs[0] if target_mbs is not None else None
-        self._initialize_stages(arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs)
+        self._initialize_stages(
+            arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs
+        )
 
         # Based on the plan in Step 1 created in __init__:
         # 2. Perform communication based on the pipeline_order
@@ -1852,7 +1871,9 @@ class PipelineScheduleMulti(_PipelineSchedule):
                             kwarg_mbs[mb_index],
                             save_forward_output=return_outputs,
                         )
-                        self._maybe_compute_loss(stage, output, target_mbs, mb_index, loss_kwargs)
+                        self._maybe_compute_loss(
+                            stage, output, target_mbs, mb_index, loss_kwargs
+                        )
                         ops.extend(stage.get_fwd_send_ops(mb_index))
                     elif computation_type == _ComputationType.FULL_BACKWARD:
                         # perform backward computation
@@ -2199,7 +2220,9 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
         """
         arg_mbs, kwarg_mbs = self._check_inputs(arg_mbs, kwarg_mbs, target_mbs, losses)
         maybe_first_target = target_mbs[0] if target_mbs is not None else None
-        self._initialize_stages(arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs)
+        self._initialize_stages(
+            arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs
+        )
 
         # Based on the plan in Step 1 created in __init__:
         # 2. Perform communication based on the pipeline_order
@@ -2309,7 +2332,9 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                     kwarg_mbs[mb_index],  # type: ignore[index]
                     save_forward_output=return_outputs,
                 )
-                self._maybe_compute_loss(stage, output, target_mbs, mb_index, loss_kwargs)
+                self._maybe_compute_loss(
+                    stage, output, target_mbs, mb_index, loss_kwargs
+                )
 
                 # SEND/RECV op are avoided for special case with 2 adjacent stages on same rank
                 # see [Note: V-schedule special case]

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -1920,6 +1920,7 @@ class PipelineStage(_PipelineStageBase):
         loss_fn: Callable[..., torch.Tensor] | None = None,
         target: torch.Tensor | None = None,
         received_grad_meta: _StageBackwardMeta | None = None,
+        loss_kwargs: dict[str, Any] | None = None,
     ) -> _StageBackwardMeta | None:
         """Run backward metadata inference (Stage N → 0).
 
@@ -1928,6 +1929,8 @@ class PipelineStage(_PipelineStageBase):
             target: Target tensor (required for the last stage).
             received_grad_meta: Grad metadata from next same-rank stage
                 (V-schedule only).
+            loss_kwargs: Extra keyword arguments forwarded to the loss
+                function (e.g. ``global_valid_tokens``).
 
         Returns:
             ``_StageBackwardMeta`` for the previous stage, or ``None`` if sent via P2P.
@@ -1954,6 +1957,7 @@ class PipelineStage(_PipelineStageBase):
             loss = loss_fn(
                 fwd_outputs[0] if len(fwd_outputs) == 1 else fwd_outputs,
                 inference_target,
+                **(loss_kwargs or {}),
             )
             self._stage_meta.output_grads = None
             all_input_grads = self._compute_input_grads(
@@ -2062,6 +2066,7 @@ class PipelineStage(_PipelineStageBase):
         loss_fn: Callable[..., torch.Tensor] | None = None,
         target: torch.Tensor | None = None,
         received_grad_meta: "_StageBackwardMeta | None" = None,
+        loss_kwargs: dict[str, Any] | None = None,
     ) -> "_StageBackwardMeta | None":
         """Run backward metadata inference and prepare backward infrastructure.
 
@@ -2076,6 +2081,7 @@ class PipelineStage(_PipelineStageBase):
                 loss_fn=loss_fn,
                 target=target,
                 received_grad_meta=received_grad_meta,
+                loss_kwargs=loss_kwargs,
             )
             # Validate dynamically inferred metadata against user-provided metadata
             self._validate_inferred_metadata()

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -315,6 +315,7 @@ class _PipelineStageBase(ABC):
         loss_fn: Callable[..., torch.Tensor] | None = None,
         target: torch.Tensor | None = None,
         received_grad_meta: _StageBackwardMeta | None = None,
+        loss_kwargs: dict[str, Any] | None = None,
     ) -> _StageBackwardMeta | None:
         raise NotImplementedError
 
@@ -1273,6 +1274,7 @@ class _PipelineStage(_PipelineStageBase):
         loss_fn: Callable[..., torch.Tensor] | None = None,
         target: torch.Tensor | None = None,
         received_grad_meta: _StageBackwardMeta | None = None,
+        loss_kwargs: dict[str, Any] | None = None,
     ) -> _StageBackwardMeta | None:
         """
         Prepare backward infrastructure for traced pipeline.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181057

Add a `loss_kwargs` parameter threaded through `step()` →
`_step_microbatches()` → `_maybe_compute_loss()` → `_compute_loss()`
and through `_initialize_stage()` → `_initialize_pp_stages()` →
`_prepare_backward_infra()` → `_backward_metadata_inference()`.

This enables loss functions that require additional arguments beyond
`(output, target)`, such as chunked cross-entropy loss which needs
`global_valid_tokens` for proper scaling:

    schedule.step(..., loss_kwargs={"global_valid_tokens": tokens})

The kwargs are passed as a parameter rather than stored on the schedule
object, since they vary across steps and should not persist as state.

Without this, `_backward_metadata_inference` and `_compute_loss` call
`loss_fn(output, target)` with only 2 args, causing a TypeError when
the loss function requires additional keyword arguments.