### PR TITLE
[FSDP2] Migrate AllGatherState and ReduceScatterState to StreamHandoff

### DIFF
--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import Any, cast, Literal, NamedTuple, TYPE_CHECKING
+from typing import Any, cast, Literal, TYPE_CHECKING
 
 import torch
 import torch.distributed as dist
@@ -98,10 +98,10 @@ class FSDPCommContext:
         # in the typical intra-node sharding / inter-node replication case
         self.all_reduce_stream = self.device_handle.Stream()
         # All-gather/reduce-scatter states keep references to collective
-        # tensors produced in one stream and used in another and accompanying
-        # CUDA events for synchronization
-        self.all_gather_state: AllGatherState | None = None
-        self.reduce_scatter_states: list[ReduceScatterState] = []
+        # tensors produced in one stream and used in another; see
+        # StreamHandoff for the (tensor, event, release_stream) invariants.
+        self.all_gather_state: StreamHandoff | None = None
+        self.reduce_scatter_states: list[StreamHandoff] = []
         # Keeps the HSDP all-reduce buffer alive until the next layer's
         # backward can free it on the all-reduce stream. Required because:
         # (1) a post-reduce dtype cast orphans the pre-cast buffer (param
@@ -145,14 +145,6 @@ class FSDPCommContext:
 
 
 # See [Note: Overlapping all-gather copy-in and all-gather]
-class AllGatherState(NamedTuple):
-    all_gather_result: AllGatherResult
-    event: torch.Event | None  # all-gather copy-out
-
-
-class ReduceScatterState(NamedTuple):
-    reduce_scatter_input: torch.Tensor
-    event: torch.Event | None  # reduce-scatter event
 
 
 class FSDPParamGroup:
@@ -414,9 +406,13 @@ class FSDPParamGroup:
             return  # no preceding unshard
         async_op = self._all_gather_result.all_gather_work is not None
         if self._training_state == TrainingState.FORWARD:  # implicit prefetch
-            if prev_all_gather_state := self.comm_ctx.all_gather_state:
-                self._wait_all_gather_streams_on_event(prev_all_gather_state.event)
-                self.comm_ctx.all_gather_state = None  # free the all-gather result
+            if prev := self.comm_ctx.all_gather_state:
+                # Both AG streams need to wait before reclaim. release()
+                # handles all_gather_stream (the release_stream) and the
+                # drop; wait() adds copy-in as the other consumer.
+                prev.wait(self.comm_ctx.all_gather_copy_in_stream)
+                prev.release()
+                self.comm_ctx.all_gather_state = None
         if isinstance(self.mesh_info, FSDPMeshInfo):
             world_size = self._all_gather_process_group.size()
         else:
@@ -467,9 +463,14 @@ class FSDPParamGroup:
             and world_size > 1
         ):
             # Defer free to allow for overlap of this copy-out with next
-            # all-gather collective
-            self.comm_ctx.all_gather_state = AllGatherState(
-                self._all_gather_result, all_gather_copy_out_event
+            # all-gather collective. Keep only the output buffer alive
+            # via StreamHandoff; Result metadata (dtypes, split_sizes) is
+            # no longer needed after copy-out and can go out of scope.
+            self.comm_ctx.all_gather_state = StreamHandoff(
+                tensor=self._all_gather_result.all_gather_output,
+                ready_event=all_gather_copy_out_event,
+                release_stream=self.comm_ctx.all_gather_stream,
+                device_handle=self.device_handle,
             )
         else:
             self._wait_all_gather_streams_on_event(all_gather_copy_out_event)
@@ -579,8 +580,7 @@ class FSDPParamGroup:
         ):
             with record_function(f"FSDP::post_backward_rs_wait ({self._module_fqn})"):
                 for rs_state in self.comm_ctx.reduce_scatter_states:
-                    if rs_state.event is not None:
-                        self.device_handle.current_stream().wait_event(rs_state.event)
+                    rs_state.release()
                 self.comm_ctx.reduce_scatter_states.clear()
         if len(fsdp_params_with_grad) == 0:
             return
@@ -647,8 +647,16 @@ class FSDPParamGroup:
             )
             if prev_all_reduce_state is not None:
                 prev_all_reduce_state.release()
+            # RS input is allocated on the default stream and read on the
+            # RS stream; release on default so the free routes to the pool
+            # the next `reduce_scatter_comm.allocate` draws from.
             self.comm_ctx.reduce_scatter_states.append(
-                ReduceScatterState(reduce_scatter_input, reduce_scatter_event)
+                StreamHandoff(
+                    tensor=reduce_scatter_input,
+                    ready_event=reduce_scatter_event,
+                    release_stream=self.device_handle.current_stream(),
+                    device_handle=self.device_handle,
+                )
             )
             if all_reduce_input is not None:
                 # Keep the AR buffer alive so the next layer can free it on

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -314,13 +314,11 @@ class FSDPState(_State):
         self._training_state = TrainingState.IDLE
         if self._state_ctx.iter_forward_root is self:
             if all_gather_state := self._comm_ctx.all_gather_state:
-                # Free the last all-gather result if needed; refer to
+                # Free the last all-gather result; refer to
                 # [Note: Overlapping all-gather copy-in and all-gather]
-                self._comm_ctx.all_gather_copy_in_stream.wait_event(
-                    all_gather_state.event
-                )
-                self._comm_ctx.all_gather_stream.wait_event(all_gather_state.event)
-                self._comm_ctx.all_gather_state = None  # free the all-gather result
+                all_gather_state.wait(self._comm_ctx.all_gather_copy_in_stream)
+                all_gather_state.release()
+                self._comm_ctx.all_gather_state = None
             self._state_ctx.iter_forward_root = None
         if self._mp_policy.output_dtype is not None:
             with torch.profiler.record_function("FSDP::cast_forward_outputs"):
@@ -367,8 +365,7 @@ class FSDPState(_State):
                 # Catch the last module's RS states that no subsequent
                 # module's group N-1 wait will clear.
                 for rs_state in self._comm_ctx.reduce_scatter_states:
-                    if rs_state.event is not None:
-                        self._device_handle.current_stream().wait_event(rs_state.event)
+                    rs_state.release()
                 self._comm_ctx.reduce_scatter_states.clear()
             self._state_ctx.post_backward_final_callback_queued = False
 

--- a/torch/distributed/fsdp/_fully_shard/_stream_utils.py
+++ b/torch/distributed/fsdp/_fully_shard/_stream_utils.py
@@ -127,6 +127,20 @@ class StreamHandoff:
     def released(self) -> bool:
         return self._released
 
+    def wait(self, stream: torch.Stream) -> None:
+        """Make ``stream`` wait on ``ready_event``.
+
+        Use for multi-consumer cases where more than one stream reads the
+        tensor before release. Callers should invoke :meth:`wait` once per
+        extra consumer stream, then call :meth:`release` to drop the ref
+        (``release`` also waits on ``release_stream`` internally).
+
+        No-op if ``ready_event`` is ``None`` or the handoff is released.
+        """
+        if self._released or self._event is None:
+            return
+        stream.wait_event(self._event)
+
     def release(self) -> None:
         """Drop the tensor ref, routing the free to ``release_stream``'s pool.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181059
* #181047
* #179443

Second PR in the StreamHandoff series. With AR migrated in the prior
commit, this migrates the remaining two cross-stream keep-alive types:

- `AllGatherState` (comm_ctx.all_gather_state) — the AG output buffer
  held across the copy-out/next-AG overlap window. Added a `wait(stream)`
  method to StreamHandoff so the two-AG-stream drain
  (`_wait_all_gather_streams_on_event`) collapses to
  `h.wait(copy_in_stream); h.release()` — the release stream is the
  AG stream, the extra waiter is the copy-in stream. Stash keeps only
  the output buffer alive; the Result metadata (dtypes, split_sizes)
  is no longer needed after copy-out.

- `ReduceScatterState[]` (comm_ctx.reduce_scatter_states) —
  `list[ReduceScatterState]` becomes `list[StreamHandoff]`. Both drain
  sites (last-group-in-module wait at `post_backward`, end-of-backward
  wait at `_root_post_backward_final_callback`) replace the inline
  `wait_event + clear` loop with `h.release() + list.clear()`.

Both NamedTuples (`AllGatherState`, `ReduceScatterState`) are deleted.
`FSDPCommContext` now has three uniformly-typed cross-layer fields:

    all_gather_state:       StreamHandoff | None
    reduce_scatter_states:  list[StreamHandoff]
    all_reduce_state:       StreamHandoff | None

`_wait_all_gather_streams_on_event` is kept for the two event-only use
sites (`_reshard_after_forward_event`, the fallback `all_gather_copy_out_event`
drain when not stashing) — those don't have a tensor keep-alive so they
don't fit StreamHandoff. They're 2-liners; not worth a new primitive.

Verification:

- StreamHandoff unit tests: 10/10 pass.
- 1D parity: test_train_parity_single_group_shard_dim0 + multi_group
  pass.
- HSDP parity: test_train_parity_hsdp passes.
- Mixed precision: test_reduce_dtype + test_grad_acc_with_reduce_dtype
  pass.
- Overlap: test_fully_shard_post_optim_event_overlap passes.
- Lint clean.

Net LOC in FSDP2: small increase overall because StreamHandoff kwargs
stash is longer than NamedTuple positional stash. The real win is
uniformity — all three cross-layer fields share a type, readers learn
one API, and the "stream context is load-bearing" comment has one home.

Authored with Claude Code.