### PR TITLE
[fft] Validate _fft_c2r last_dim_size to fix heap-buffer overflow

### DIFF
--- a/aten/src/ATen/native/SpectralOpsUtils.h
+++ b/aten/src/ATen/native/SpectralOpsUtils.h
@@ -50,6 +50,24 @@ inline int64_t infer_ft_real_to_complex_onesided_size(int64_t real_size) {
   return (real_size / 2) + 1;
 }
 
+// Validates inputs of the low-level _fft_c2r operator. A `last_dim_size`
+// inconsistent with the input's last transformed dimension can otherwise
+// overflow, assert, or abort inside the FFT backend. The input dimension must
+// be the canonical onesided size (last_dim_size / 2 + 1) or the full size
+// (last_dim_size); a larger input is rejected since only pocketfft, not
+// MKL/cuFFT/MPS, would handle it.
+inline void check_fft_c2r_input(int64_t last_dim_size,
+                                int64_t input_last_dim_size) {
+  TORCH_CHECK(last_dim_size >= 1,
+              "Invalid number of data points (", last_dim_size, ") specified");
+  const int64_t onesided = infer_ft_real_to_complex_onesided_size(last_dim_size);
+  TORCH_CHECK(input_last_dim_size == onesided ||
+              input_last_dim_size == last_dim_size,
+              "Expected size of last transformed dimension of input to be ",
+              onesided, " (= last_dim_size / 2 + 1) or ", last_dim_size,
+              " (= last_dim_size), but got ", input_last_dim_size);
+}
+
 inline int64_t infer_ft_complex_to_real_onesided_size(int64_t complex_size,
                                                       int64_t expected_size=-1) {
   int64_t base = (complex_size - 1) * 2;

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -404,6 +404,8 @@ Tensor& _fft_r2c_cufft_out(const Tensor& self, IntArrayRef dim,
 // n-dimensional complex to real IFFT
 Tensor _fft_c2r_cufft(const Tensor& self, IntArrayRef dim, int64_t normalization, int64_t lastdim) {
   TORCH_CHECK(self.is_complex());
+  TORCH_CHECK(!dim.empty(), "_fft_c2r: dim must not be empty");
+  check_fft_c2r_input(lastdim, self.size(dim.back()));
   auto in_sizes = self.sizes();
   DimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = lastdim;

--- a/aten/src/ATen/native/cuda/SpectralOps.cpp
+++ b/aten/src/ATen/native/cuda/SpectralOps.cpp
@@ -492,6 +492,8 @@ Tensor& _fft_r2c_cufft_out(const Tensor& self, IntArrayRef dim,
 // n-dimensional complex to real IFFT
 Tensor _fft_c2r_cufft(const Tensor& self, IntArrayRef dim, int64_t normalization, int64_t lastdim) {
   TORCH_CHECK(self.is_complex());
+  TORCH_CHECK(!dim.empty(), "_fft_c2r: dim must not be empty");
+  check_fft_c2r_input(lastdim, self.size(dim.back()));
   auto in_sizes = self.sizes();
   DimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = lastdim;

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -255,6 +255,8 @@ T compute_fct(const Tensor& t, IntArrayRef dim, int64_t normalization) {
 } // anonymous namespace
 
 Tensor _fft_c2r_mkl(const Tensor& self, IntArrayRef dim, int64_t normalization, int64_t last_dim_size) {
+  TORCH_CHECK(!dim.empty(), "_fft_c2r: dim must not be empty");
+  check_fft_c2r_input(last_dim_size, self.size(dim.back()));
   auto in_sizes = self.sizes();
   DimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = last_dim_size;
@@ -525,6 +527,8 @@ static DimVector _sort_dims(const Tensor& self, IntArrayRef dim, bool exclude_la
 // n-dimensional complex to real IFFT
 Tensor _fft_c2r_mkl(const Tensor& self, IntArrayRef dim, int64_t normalization, int64_t last_dim_size) {
   TORCH_CHECK(self.is_complex(), "Only supports complex dtypes, but found: ", self.scalar_type());
+  TORCH_CHECK(!dim.empty(), "_fft_c2r: dim must not be empty");
+  check_fft_c2r_input(last_dim_size, self.size(dim.back()));
   // NOTE: Multi-dimensional C2R transforms don't agree with numpy in cases
   // where the input isn't strictly Hermitian-symmetric. Instead, we use a
   // multi-dim C2C transform followed by a 1D C2R transform.

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -255,6 +255,8 @@ T compute_fct(const Tensor& t, IntArrayRef dim, int64_t normalization) {
 } // anonymous namespace
 
 Tensor _fft_c2r_mkl(const Tensor& self, IntArrayRef dim, int64_t normalization, int64_t last_dim_size) {
+  TORCH_CHECK(!dim.empty(), "_fft_c2r: dim must not be empty");
+  check_fft_c2r_input(last_dim_size, self.size(dim.back()));
   auto in_sizes = self.sizes();
   DimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = last_dim_size;
@@ -534,6 +536,8 @@ static DimVector _sort_dims(const Tensor& self, IntArrayRef dim, bool exclude_la
 // n-dimensional complex to real IFFT
 Tensor _fft_c2r_mkl(const Tensor& self, IntArrayRef dim, int64_t normalization, int64_t last_dim_size) {
   TORCH_CHECK(self.is_complex(), "Only supports complex dtypes, but found: ", self.scalar_type());
+  TORCH_CHECK(!dim.empty(), "_fft_c2r: dim must not be empty");
+  check_fft_c2r_input(last_dim_size, self.size(dim.back()));
   // NOTE: Multi-dimensional C2R transforms don't agree with numpy in cases
   // where the input isn't strictly Hermitian-symmetric. Instead, we use a
   // multi-dim C2C transform followed by a 1D C2R transform.

--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -183,6 +183,8 @@ Tensor& _fft_c2r_mps_out(const Tensor& self,
   TORCH_CHECK(self.is_complex(), "Input must be complex");
   TORCH_CHECK(out.scalar_type() == c10::toRealValueType(self.scalar_type()), "Unexpected output type");
   TORCH_CHECK(out.device() == self.device(), "Expected out tensor on ", self.device(), " but got ", out.device());
+  TORCH_CHECK(!dim.empty(), "_fft_c2r: dim must not be empty");
+  check_fft_c2r_input(last_dim_size, self.size(dim.back()));
   const auto in_sizes = self.sym_sizes();
   SymDimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = last_dim_size;

--- a/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
+++ b/aten/src/ATen/native/mps/operations/FastFourierTransform.mm
@@ -178,6 +178,8 @@ Tensor& _fft_c2r_mps_out(const Tensor& self,
                          Tensor& out) {
   TORCH_CHECK(self.is_complex(), "Input must be complex");
   TORCH_CHECK(out.scalar_type() == c10::toRealValueType(self.scalar_type()), "Unexpected output type");
+  TORCH_CHECK(!dim.empty(), "_fft_c2r: dim must not be empty");
+  check_fft_c2r_input(last_dim_size, self.size(dim.back()));
   const auto in_sizes = self.sym_sizes();
   SymDimVector out_sizes(in_sizes.begin(), in_sizes.end());
   out_sizes[dim.back()] = last_dim_size;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3026,6 +3026,20 @@ class TestMPS(TestCaseMPS):
         # Expecting the inverted to yield the original signal
         self.assertEqual(ifft_result, signal)
 
+    def test_fft_c2r_invalid_last_dim_size(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/141448:
+        # an inconsistent last_dim_size used to abort MPSGraph uncatchably.
+        device = torch.device("mps")
+        t = torch.zeros(6, 3, dtype=torch.cfloat, device=device)
+        with self.assertRaisesRegex(RuntimeError, "Expected size of last transformed dimension"):
+            torch._fft_c2r(t, [0], 0, 4)
+        with self.assertRaisesRegex(RuntimeError, "Invalid number of data points"):
+            torch._fft_c2r(t, [0], 0, 0)
+        # onesided and full-size inputs are accepted
+        for k in (3, 4):
+            x = torch.zeros(k, 3, dtype=torch.cfloat, device=device)
+            self.assertEqual(torch._fft_c2r(x, [0], 0, 4).shape, torch.Size([4, 3]))
+
     def test_fftfreq(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/135223
         freq_cpu = torch.fft.fftfreq(10**4, device='cpu')

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2590,6 +2590,20 @@ class TestMPS(TestCaseMPS):
         # Expecting the inverted to yield the original signal
         self.assertEqual(ifft_result, signal)
 
+    def test_fft_c2r_invalid_last_dim_size(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/141448:
+        # an inconsistent last_dim_size used to abort MPSGraph uncatchably.
+        device = torch.device("mps")
+        t = torch.zeros(6, 3, dtype=torch.cfloat, device=device)
+        with self.assertRaisesRegex(RuntimeError, "Expected size of last transformed dimension"):
+            torch._fft_c2r(t, [0], 0, 4)
+        with self.assertRaisesRegex(RuntimeError, "Invalid number of data points"):
+            torch._fft_c2r(t, [0], 0, 0)
+        # onesided and full-size inputs are accepted
+        for k in (3, 4):
+            x = torch.zeros(k, 3, dtype=torch.cfloat, device=device)
+            self.assertEqual(torch._fft_c2r(x, [0], 0, 4).shape, torch.Size([4, 3]))
+
     def test_fftfreq(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/135223
         freq_cpu = torch.fft.fftfreq(10**4, device='cpu')

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -253,6 +253,49 @@ class TestFFT(TestCase):
             with self.assertRaisesRegex(RuntimeError, match):
                 f(t)
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/141448:
+    # _fft_c2r used to crash (heap-buffer overflow on pocketfft, an internal
+    # assert on MKL/cuFFT, or an uncatchable abort on MPS) when last_dim_size
+    # was inconsistent with the input's last transformed dimension.
+    @skipCPUIfNoFFT
+    @onlyNativeDeviceTypes
+    def test_fft_c2r_invalid_last_dim_size(self, device):
+        t = torch.full((3, 1, 3, 1), 0.372049, dtype=torch.cfloat, device=device)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"Expected size of last transformed dimension of input to be"):
+            torch._fft_c2r(t, [2], 2, 536870912)
+
+        with self.assertRaisesRegex(
+                RuntimeError, r"Invalid number of data points"):
+            torch._fft_c2r(t, [2], 2, 0)
+
+        with self.assertRaisesRegex(RuntimeError, r"dim must not be empty"):
+            torch._fft_c2r(t, [], 2, 4)
+
+        # Intermediate band (last_dim_size/2+1 < in_size < last_dim_size) is
+        # rejected.
+        t2 = torch.zeros(5, 1, dtype=torch.cfloat, device=device)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"Expected size of last transformed dimension of input to be"):
+            torch._fft_c2r(t2, [0], 0, 6)
+
+        # in_size > last_dim_size is rejected: pocketfft would read only the
+        # onesided prefix, but MKL/cuFFT assert and MPS aborts.
+        t3 = torch.zeros(6, 3, dtype=torch.cfloat, device=device)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"Expected size of last transformed dimension of input to be"):
+            torch._fft_c2r(t3, [0], 0, 4)
+
+        # Onesided (in_size == last_dim_size/2+1) and full (in_size ==
+        # last_dim_size) inputs are both accepted.
+        t4 = torch.zeros(3, 3, dtype=torch.cfloat, device=device)
+        self.assertEqual(torch._fft_c2r(t4, [0], 0, 4).shape, torch.Size([4, 3]))
+        t5 = torch.zeros(4, 3, dtype=torch.cfloat, device=device)
+        self.assertEqual(torch._fft_c2r(t5, [0], 0, 4).shape, torch.Size([4, 3]))
+
     @onlyNativeDeviceTypes
     def test_fft_invalid_dtypes(self, device):
         t = torch.randn(64, device=device, dtype=torch.complex128)

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -252,6 +252,49 @@ class TestFFT(TestCase):
             with self.assertRaisesRegex(RuntimeError, match):
                 f(t)
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/141448:
+    # _fft_c2r used to crash (heap-buffer overflow on pocketfft, an internal
+    # assert on MKL/cuFFT, or an uncatchable abort on MPS) when last_dim_size
+    # was inconsistent with the input's last transformed dimension.
+    @skipCPUIfNoFFT
+    @onlyNativeDeviceTypes
+    def test_fft_c2r_invalid_last_dim_size(self, device):
+        t = torch.full((3, 1, 3, 1), 0.372049, dtype=torch.cfloat, device=device)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"Expected size of last transformed dimension of input to be"):
+            torch._fft_c2r(t, [2], 2, 536870912)
+
+        with self.assertRaisesRegex(
+                RuntimeError, r"Invalid number of data points"):
+            torch._fft_c2r(t, [2], 2, 0)
+
+        with self.assertRaisesRegex(RuntimeError, r"dim must not be empty"):
+            torch._fft_c2r(t, [], 2, 4)
+
+        # Intermediate band (last_dim_size/2+1 < in_size < last_dim_size) is
+        # rejected.
+        t2 = torch.zeros(5, 1, dtype=torch.cfloat, device=device)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"Expected size of last transformed dimension of input to be"):
+            torch._fft_c2r(t2, [0], 0, 6)
+
+        # in_size > last_dim_size is rejected: pocketfft would read only the
+        # onesided prefix, but MKL/cuFFT assert and MPS aborts.
+        t3 = torch.zeros(6, 3, dtype=torch.cfloat, device=device)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r"Expected size of last transformed dimension of input to be"):
+            torch._fft_c2r(t3, [0], 0, 4)
+
+        # Onesided (in_size == last_dim_size/2+1) and full (in_size ==
+        # last_dim_size) inputs are both accepted.
+        t4 = torch.zeros(3, 3, dtype=torch.cfloat, device=device)
+        self.assertEqual(torch._fft_c2r(t4, [0], 0, 4).shape, torch.Size([4, 3]))
+        t5 = torch.zeros(4, 3, dtype=torch.cfloat, device=device)
+        self.assertEqual(torch._fft_c2r(t5, [0], 0, 4).shape, torch.Size([4, 3]))
+
     @onlyNativeDeviceTypes
     def test_fft_invalid_dtypes(self, device):
         t = torch.randn(64, device=device, dtype=torch.complex128)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -674,6 +674,23 @@ def meta_philox_uniform_(self, key, low=0.0, high=1.0):
 def meta_fft_c2r(self: Tensor, dim: list[int], normalization: int, lastdim: int):
     # _fft_c2r_mkl
     torch._check(self.dtype.is_complex)
+    # Mirror check_fft_c2r_input (SpectralOpsUtils.h) so export/compile reject
+    # an inconsistent last_dim_size at trace time, matching eager.
+    from torch.fx.experimental.symbolic_shapes import sym_or
+
+    torch._check(len(dim) > 0, lambda: "_fft_c2r: dim must not be empty")
+    torch._check(
+        lastdim >= 1,
+        lambda: f"Invalid number of data points ({lastdim}) specified",
+    )
+    onesided = lastdim // 2 + 1
+    in_size = self.size(dim[-1])
+    torch._check(
+        sym_or(in_size == onesided, in_size == lastdim),
+        lambda: f"Expected size of last transformed dimension of input to be "
+        f"{onesided} (= last_dim_size / 2 + 1) or {lastdim} (= last_dim_size), "
+        f"but got {in_size}",
+    )
 
     if device_hint(self) == "cuda":
         out_sizes = list(self.size())

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -623,6 +623,23 @@ def meta_philox_uniform_(self, key, low=0.0, high=1.0):
 def meta_fft_c2r(self: Tensor, dim: list[int], normalization: int, lastdim: int):
     # _fft_c2r_mkl
     torch._check(self.dtype.is_complex)
+    # Mirror check_fft_c2r_input (SpectralOpsUtils.h) so export/compile reject
+    # an inconsistent last_dim_size at trace time, matching eager.
+    from torch.fx.experimental.symbolic_shapes import sym_or
+
+    torch._check(len(dim) > 0, lambda: "_fft_c2r: dim must not be empty")
+    torch._check(
+        lastdim >= 1,
+        lambda: f"Invalid number of data points ({lastdim}) specified",
+    )
+    onesided = lastdim // 2 + 1
+    in_size = self.size(dim[-1])
+    torch._check(
+        sym_or(in_size == onesided, in_size == lastdim),
+        lambda: f"Expected size of last transformed dimension of input to be "
+        f"{onesided} (= last_dim_size / 2 + 1) or {lastdim} (= last_dim_size), "
+        f"but got {in_size}",
+    )
 
     if device_hint(self) == "cuda":
         out_sizes = list(self.size())


### PR DESCRIPTION
Fixes #141448.

Reland of c4948c56c41b, reverted in f11ab645017f because Executorch's `OpFftC2rOutTest::AllDtypesSupported` calls `_fft_c2r` with a full-size complex input, which the first version rejected. This version accepts that shape; see Fix.

## Root cause

The low-level `_fft_c2r` operator did not validate that `last_dim_size` is consistent with the input's last transformed dimension. Calling it directly with mismatched arguments (for example input `(3, 1, 3, 1)` and `last_dim_size=536870912`) caused a heap-buffer overflow inside pocketfft on CPU, an `INTERNAL_ASSERT` inside the MKL/cuFFT `_exec_fft` plan, or an uncatchable MPSGraph abort.

## Fix

Adds a `check_fft_c2r_input` helper in `SpectralOpsUtils.h`, called from all four C2R backends (pocketfft, MKL, cuFFT, MPS), plus a `!dim.empty()` guard so an empty `dim` argument does not crash on `dim.back()`. The input's last transformed dimension must equal either the canonical onesided size (`last_dim_size / 2 + 1`) or the full size (`last_dim_size`).

The accepted set is deliberately `{onesided, full}` rather than the broader `>= last_dim_size` used by the earlier reland attempt. Only pocketfft tolerates a larger input, because it reads just the onesided prefix. MKL and cuFFT set `signal_size = max(in, out)` and then write `in` reals into an output sized for `last_dim_size`, which overflows the heap for `in` in `{2n-2, 2n-1}` and asserts for other oversized inputs; MPS derives its output extent from the input and aborts. Restricting to the full-size case keeps the Executorch test working while giving a uniform clean error on every backend for genuinely inconsistent shapes.

The same validation is mirrored in `meta_fft_c2r`, so export, torch.compile, and fake tensors reject an inconsistent `last_dim_size` at trace time instead of only in eager.

## Verification

`test_fft_c2r_invalid_last_dim_size` (device-generic) covers the original repro, `last_dim_size=0`, empty `dim`, the intermediate band, `in > last` (now rejected), and both accepted shapes. An MPS copy lives in `test_mps.py` because the generic FFT suite does not run on MPS.

```
python test/test_spectral_ops.py -k test_fft_c2r_invalid_last_dim_size
python test/test_mps.py -k test_fft_c2r_invalid_last_dim_size
```

Both pass locally on CPU and MPS. irfft/irfft2/irfftn/hfft/istft round-trips on CPU and MPS irfft are unaffected, and the meta check was verified under `FakeTensorMode`. CUDA relies on CI.
