### PR TITLE
Validate grad_output shape in multi_margin_loss_backward

### DIFF
--- a/aten/src/ATen/native/LossMulti.h
+++ b/aten/src/ATen/native/LossMulti.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <ATen/core/Reduction.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
@@ -66,6 +67,30 @@ namespace at::native {
           "inconsistent weight size, expected ", dim, " but got ",
           weight->sizes());
     }
+}
+
+inline void multi_margin_loss_backward_grad_output_shape_check(
+    const Tensor& grad_output,
+    const Tensor& target,
+    int64_t nframe,
+    int64_t reduction) {
+  if (reduction != at::Reduction::None) {
+    return;
+  }
+  // The backward kernels index grad_output per sample, so it must match
+  // the forward output shape: [nframe] for a 1-D target, [] for a 0-D one.
+  if (target.dim() > 0) {
+    TORCH_CHECK(
+        grad_output.dim() == 1 && grad_output.size(0) == nframe,
+        "multi_margin_loss_backward: expected grad_output to have shape [",
+        nframe, "] when reduction='none', but got ", grad_output.sizes());
+  } else {
+    TORCH_CHECK(
+        grad_output.dim() == 0,
+        "multi_margin_loss_backward: expected grad_output to be a 0-D scalar "
+        "when reduction='none' with a 0-D target, but got ",
+        grad_output.sizes());
+  }
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/LossMultiMargin.cpp
+++ b/aten/src/ATen/native/LossMultiMargin.cpp
@@ -221,6 +221,8 @@ void multi_margin_loss_backward_out_cpu_template(
   TORCH_CHECK(p == 1 || p == 2, "only p == 1 and p == 2 supported");
 
   multi_margin_loss_shape_check(nframe, dim, ndims, input, target, weight);
+  multi_margin_loss_backward_grad_output_shape_check(
+      grad_output, target, nframe, reduction);
   grad_input.resize_as_(input);
   TORCH_CHECK(grad_input.is_contiguous(), "grad_input must be contiguous");
 

--- a/aten/src/ATen/native/cuda/MultiMarginLoss.cu
+++ b/aten/src/ATen/native/cuda/MultiMarginLoss.cu
@@ -272,6 +272,8 @@ Tensor& multi_margin_loss_cuda_backward_out(
               "multi_margin_loss_backward: Invalid p, expected 1 or 2 but got ", p);
 
   multi_margin_loss_shape_check(nframe, dim, ndims, input_, target_, weights_);
+  multi_margin_loss_backward_grad_output_shape_check(
+      grad_output_, target_, nframe, reduction);
   resize_output(grad_input_, input_.sizes());
 
   if (input_.numel() == 0) {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9938,6 +9938,40 @@ class TestNNDeviceType(NNTestCase):
                 y = torch.ones(10, 0, device=device).type(torch.long)
                 mod(x, y)
 
+    @expectedFailureMPS  # Unimplemented margin_loss
+    @onlyNativeDeviceTypes
+    def test_MultiMarginLoss_backward_invalid_grad_output(self, device):
+        # https://github.com/pytorch/pytorch/issues/146790
+        # With reduction='none' the kernel indexes grad_output per sample;
+        # a mismatched grad_output previously read past the end on both CPU
+        # and CUDA (including the 0-D target path).
+        dtype = torch.float
+
+        # 1-D input (nframe=1), 1-D target: expects grad_output of shape [1].
+        input_1d = torch.tensor([64.0], device=device, dtype=dtype)
+        target_1d = torch.tensor([0], device=device)
+        empty_grad = torch.empty(0, device=device, dtype=dtype)
+        with self.assertRaisesRegex(RuntimeError, 'grad_output'):
+            torch.ops.aten.multi_margin_loss_backward(
+                empty_grad, input_1d, target_1d, 2, 1.0, None, 0)
+
+        # 2-D input (nframe=3): expects grad_output of shape [3].
+        input_2d = torch.randn(3, 5, device=device, dtype=dtype)
+        target_2d = torch.zeros(3, dtype=torch.long, device=device)
+        wrong_grad = torch.randn(2, device=device, dtype=dtype)
+        with self.assertRaisesRegex(RuntimeError, 'grad_output'):
+            torch.ops.aten.multi_margin_loss_backward(
+                wrong_grad, input_2d, target_2d, 2, 1.0, None, 0)
+
+        # 0-D target (nframe=1): expects a 0-D scalar grad_output.
+        # Previously bypassed on CUDA, still segfaulting on the original bug.
+        input_scalar = torch.tensor([64.0], device=device, dtype=dtype)
+        target_scalar = torch.tensor(0, device=device)
+        empty_grad_scalar = torch.empty(0, device=device, dtype=dtype)
+        with self.assertRaisesRegex(RuntimeError, 'grad_output'):
+            torch.ops.aten.multi_margin_loss_backward(
+                empty_grad_scalar, input_scalar, target_scalar, 2, 1.0, None, 0)
+
     @onlyCUDA
     @dtypes(torch.float, torch.double)
     def test_MarginLoss_race(self, device, dtype):


### PR DESCRIPTION
Fixes #146790.

## Summary

`torch.ops.aten.multi_margin_loss_backward` segfaults when `reduction='none'` and `grad_output` doesn't have shape `[nframe]`. Both CPU and CUDA backward kernels index `grad_output` per sample without validating its shape, so an empty or undersized tensor reads past storage.

Mirrors the `check_dim_size(grad_output, 1, 0, nframe)` that `multilabel_margin_loss_backward_cpu_kernel` already does in the same spot. CUDA gets the same check host-side before the kernel launch (its backward also indexes `grad_output[k]` in the per-sample branch).

## Test plan

`test_MultiMarginLoss_backward_invalid_grad_output` covers the 1-D repro from the issue and a 2-D size-mismatch case, device-generic.
