### PR TITLE
Validate stride/padding/kernel_size length in slow_conv3d

### DIFF
--- a/aten/src/ATen/native/ConvolutionMM3d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM3d.cpp
@@ -587,6 +587,21 @@ Tensor& slow_conv3d_forward_out_cpu(const Tensor& self,
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
 
+  TORCH_CHECK(
+      kernel_size.size() == 3,
+      "It is expected kernel_size equals to 3, but got size ",
+      kernel_size.size());
+
+  TORCH_CHECK(
+      padding.size() == 3,
+      "It is expected padding equals to 3, but got size ",
+      padding.size());
+
+  TORCH_CHECK(
+      stride.size() == 3,
+      "It is expected stride equals to 3, but got size ",
+      stride.size());
+
   const int64_t kernel_depth = kernel_size[0];
   const int64_t kernel_height = kernel_size[1];
   const int64_t kernel_width = kernel_size[2];
@@ -722,6 +737,21 @@ static std::tuple<Tensor&, Tensor&, Tensor&> slow_conv3d_backward_out_cpu(const 
     Tensor& grad_input,
     Tensor& grad_weight,
     Tensor& grad_bias) {
+  TORCH_CHECK(
+      kernel_size.size() == 3,
+      "It is expected kernel_size equals to 3, but got size ",
+      kernel_size.size());
+
+  TORCH_CHECK(
+      padding.size() == 3,
+      "It is expected padding equals to 3, but got size ",
+      padding.size());
+
+  TORCH_CHECK(
+      stride.size() == 3,
+      "It is expected stride equals to 3, but got size ",
+      stride.size());
+
   // TODO: hacky way of determine the group size
   int64_t groups = self.size(1) / weight.size(1);
   if (grad_input.defined()) {

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9176,6 +9176,26 @@ class TestNNDeviceType(NNTestCase):
             torch._C._nn.thnn_conv2d(torch.rand([1, 1, 1, 1]), kernel_size=[1, 1], padding=[], stride=[1, 1],
                                      weight=torch.rand([1, 1]))
 
+    @onlyCPU
+    @dtypes(torch.float)
+    def test_slow_conv3d_empty_stride(self, device, dtype):
+        # https://github.com/pytorch/pytorch/issues/121095
+        inp = torch.rand([9], device=device, dtype=dtype)
+        weight = torch.rand([4], device=device, dtype=dtype)
+        bias = torch.rand([1, 1], device=device, dtype=dtype)
+        with self.assertRaisesRegex(RuntimeError, "It is expected stride equals to 3"):
+            torch._C._nn.slow_conv3d(
+                inp, weight=weight, bias=bias,
+                kernel_size=[1, 1, 1], padding=[1, 1, 1], stride=[])
+        with self.assertRaisesRegex(RuntimeError, "It is expected kernel_size equals to 3"):
+            torch._C._nn.slow_conv3d(
+                inp, weight=weight, bias=bias,
+                kernel_size=[1], padding=[1, 1, 1], stride=[1, 1, 1])
+        with self.assertRaisesRegex(RuntimeError, "It is expected padding equals to 3"):
+            torch._C._nn.slow_conv3d(
+                inp, weight=weight, bias=bias,
+                kernel_size=[1, 1, 1], padding=[1], stride=[1, 1, 1])
+
     def test_InstanceNorm1d_general(self, device):
         b = random.randint(3, 5)
         c = random.randint(3, 5)


### PR DESCRIPTION
Fixes #121095.

`torch._C._nn.slow_conv3d` SIGSEGVs when `kernel_size`, `padding`, or `stride` is shorter than 3. `slow_conv3d_forward_out_cpu` indexes each at `[0..2]` before any validation, so a short `IntArrayRef` reads past its storage. `slow_conv3d_shape_check` then runs on the extracted garbage ints, so in non-crashing runs the bug surfaces instead as a misleading `"stride should be greater than zero"` error.

Add `TORCH_CHECK(... .size() == 3, ...)` for each at the entry of `slow_conv3d_forward_out_cpu` and `slow_conv3d_backward_out_cpu`, matching `NaiveConvolutionTranspose3d.cpp`.

Test in `TestNNDeviceType.test_slow_conv3d_empty_stride` covers the short-length case for each argument.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01