### PR TITLE
address DDE in copy_to

### DIFF
--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -9,10 +9,10 @@
 
 #include <ATen/Tensor.h>
 #include <ATen/core/DimVector.h>
+#include <c10/core/SymBool.h>
 #include <c10/util/Exception.h>
 #include <c10/util/MaybeOwned.h>
 #include <c10/util/irange.h>
-#include <c10/core/SymBool.h>
 
 #include <functional>
 #include <tuple>

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -12,6 +12,7 @@
 #include <c10/util/Exception.h>
 #include <c10/util/MaybeOwned.h>
 #include <c10/util/irange.h>
+#include <c10/core/SymBool.h>
 
 #include <functional>
 #include <tuple>
@@ -99,7 +100,18 @@ inline void check_defined(
 inline c10::MaybeOwned<Tensor> expand_inplace(
     const Tensor& tensor,
     const Tensor& to_expand) {
-  if (tensor.sym_sizes().equals(to_expand.sym_sizes())) {
+  auto t_sizes = tensor.sym_sizes();
+  auto e_sizes = to_expand.sym_sizes();
+  bool same = t_sizes.size() == e_sizes.size();
+  if (same) {
+    for (size_t i = 0; i < t_sizes.size(); ++i) {
+      if (!TORCH_GUARD_OR_FALSE(sym_eq(t_sizes[i], e_sizes[i]))) {
+        same = false;
+        break;
+      }
+    }
+  }
+  if (same) {
     return c10::MaybeOwned<Tensor>::borrowed(to_expand);
   }
   return c10::MaybeOwned<Tensor>::owned(

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -417,7 +417,21 @@ inline SymIntArrayRef slicePrefix1sSize(const SymIntArrayRef& sizes) {
 }
 
 inline void copy_to(const Tensor& dst, const Tensor& src) {
-  if (dst.sym_sizes().equals(src.sym_sizes())) {
+  // Use TORCH_GUARD_OR_FALSE with sym_eq to avoid data-dependent-expression
+  // errors with unbacked symbolic sizes.  When we can't prove equality,
+  // we fall through to the broadcast/expand path.
+  auto dst_sizes = dst.sym_sizes();
+  auto src_sizes = src.sym_sizes();
+  bool same_sizes = dst_sizes.size() == src_sizes.size();
+  if (same_sizes) {
+    for (size_t i = 0; i < dst_sizes.size(); ++i) {
+      if (!TORCH_GUARD_OR_FALSE(sym_eq(dst_sizes[i], src_sizes[i]))) {
+        same_sizes = false;
+        break;
+      }
+    }
+  }
+  if (same_sizes) {
     // A shortcut to avoid generating hard-coded constant sizes during tracing.
     // This is not a perfect solution: when src & dst have different shapes,
     // constants will still appear. Users can workaround that case by

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -5562,6 +5562,56 @@ class TestMaybeFastEvalComparison(TestCase):
         result = shape_env._maybe_fast_eval_comparison(expr)
         self.assertIsNone(result)
 
+    @torch._dynamo.config.patch(capture_scalar_outputs=True)
+    def test_unbacked_slice_assignment_same_bounds(self):
+        # Repro from sequential_experts_gemm (MoE pattern in HuggingFace Aria).
+        # output[start:end] = out should not fail with a data-dependent guard
+        # because `out` was produced from token_states[start:end], so both
+        # slices share the same (start, end) and thus the same size.
+        def sequential_experts_gemm(token_states, expert_weights, tokens_per_expert):
+            num_tokens = token_states.shape[0]
+            out_features = expert_weights.shape[-1]
+            output = torch.zeros(
+                num_tokens,
+                out_features,
+                dtype=token_states.dtype,
+                device=token_states.device,
+            )
+
+            cumsum_num_tokens = torch.cumsum(tokens_per_expert, dim=0)
+            zero_tensor = torch.zeros(
+                1, dtype=torch.long, device=cumsum_num_tokens.device
+            )
+            cumsum_num_tokens = torch.cat((zero_tensor, cumsum_num_tokens))
+
+            for expert_num in range(expert_weights.shape[0]):
+                start = cumsum_num_tokens[expert_num]
+                end = cumsum_num_tokens[expert_num + 1]
+                tokens = token_states[start:end]
+                out = torch.matmul(tokens, expert_weights[expert_num])
+                output[start:end] = out
+            return output
+
+        num_tokens = 10
+        in_features = 16
+        out_features = 32
+        num_experts = 3
+
+        token_states = torch.randn(num_tokens, in_features)
+        expert_weights = torch.randn(num_experts, in_features, out_features)
+        tokens_per_expert = torch.tensor([3, 2, 5])
+
+        eager_result = sequential_experts_gemm(
+            token_states, expert_weights, tokens_per_expert
+        )
+
+        compiled_fn = torch.compile(
+            sequential_experts_gemm, fullgraph=True, backend="eager"
+        )
+        compiled_result = compiled_fn(token_states, expert_weights, tokens_per_expert)
+
+        self.assertEqual(eager_result, compiled_result)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181065

Avoid data-dependent expression error in copy_to and expand_inplace for unbacked symbolic sizes.
skip optimizations paths, the general path handle copy to find, because for unbacked we assumes a==b.


