### PR TITLE
[inductor][cpu] Enable Triton kernels in AOTI C++ wrapper on CPU (#181068)

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2079,6 +2079,45 @@ class CudaKernelParamCache:
         return cls.cache.keys()
 
 
+@clear_on_fresh_cache
+class CpuTritonKernelCache:
+    """AOTI counterpart of CudaKernelParamCache for CPU Triton kernels."""
+
+    cache: dict[str, dict[str, Any]] = {}
+    cache_clear = staticmethod(cache.clear)
+
+    @classmethod
+    def set(
+        cls,
+        key: str,
+        kernel_bytes: bytes,
+        launcher_bytes: bytes,
+        kernel_symbol: str,
+        signature: dict[str, Any],
+    ) -> None:
+        out_dir = split_aot_inductor_output_path(config.aot_inductor.output_path)[0]
+        _, kernel_so_path = write(
+            kernel_bytes, "so", hash_type="code", specified_dir=out_dir
+        )
+        _, launcher_so_path = write(
+            launcher_bytes, "so", hash_type="code", specified_dir=out_dir
+        )
+        cls.cache[key] = {
+            "kernel_so_path": kernel_so_path,
+            "launcher_so_path": launcher_so_path,
+            "kernel_symbol": kernel_symbol,
+            "signature": signature,
+        }
+
+    @classmethod
+    def get(cls, key: str) -> dict[str, Any] | None:
+        return cls.cache.get(key, None)
+
+    @classmethod
+    def get_keys(cls) -> KeysView[str]:
+        return cls.cache.keys()
+
+
 class AotCodeCompiler:
     """
     Compile AOT Inductor generated code.

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import ctypes
+import dataclasses
 import functools
 import math
 import os
@@ -16,6 +17,7 @@ import torch
 import torch._higher_order_ops.torchbind
 import torch._inductor.async_compile
 import torch._ops
+from torch import dtype as torch_dtype
 from torch._inductor.runtime.runtime_utils import dynamo_timed
 from torch.fx.experimental.symbolic_shapes import ConvertIntKey, DivideByKey, SymTypes
 from torch.utils._ordered_set import OrderedSet
@@ -53,6 +55,197 @@ class HasWriteLine(Protocol):
     def writeline(self, line: LineContext | DeferredLineBase | str) -> None: ...
 
 
+@dataclasses.dataclass
+class DeferredCpuTritonCallWrapper:
+    """CPU counterpart of DeferredTritonCallWrapper in cpp_wrapper_gpu.py.
+
+    Deferred so wrapper emission can read `CpuTritonKernelCache` entries
+    after the autotune block has populated them.
+
+    NOTE: CPU doesn't actively use autotuning, but we mirror
+    the GPU flow for symmetry.
+    """
+
+    wrapper_name: str
+    kernel_name: str
+    arg_types: list[Any]
+    triton_meta: dict[str, Any] | None = None
+    inductor_meta: dict[str, Any] | None = None
+
+    def _get_cpp_param_type(self, name: str, arg_type: Any) -> str:
+        if isinstance(arg_type, torch_dtype):
+            return f"const {name}_type_& {name}"
+        elif issubclass(arg_type, (SymbolicCallArg, sympy.Expr, int)):
+            return f"int64_t {name}"
+        elif arg_type is float:
+            return f"float {name}"
+        elif arg_type is bool:
+            return f"bool {name}"
+        else:
+            raise ValueError(
+                f"Unexpected arg type {arg_type} for CPU triton wrapper arg '{name}'"
+            )
+
+    def _resolve_arg_names(
+        self,
+    ) -> tuple[list[str], list[str], list[str]]:
+        """Return (wrapper_arg_names, kernel_arg_names, grid_arg_names).
+
+        Wrapper args exclude *declared* constexpr (the call site doesn't pass
+        them); kernel args additionally exclude *value-specialized* constexpr
+        (baked into the binary). Grid args are appended for `run_from_nativert`.
+        """
+        from torch._inductor.codecache import CpuTritonKernelCache
+
+        info = CpuTritonKernelCache.get(self.kernel_name)
+        assert info is not None, (
+            f"CpuTritonKernelCache not populated for {self.kernel_name}"
+        )
+        signature = info["signature"]
+        declared_constexpr_names = OrderedSet(
+            (self.inductor_meta or {}).get("declared_constexpr_names", [])
+        )
+        wrapper_arg_names = [
+            name for name in signature if name not in declared_constexpr_names
+        ]
+        kernel_arg_names = [name for name, ty in signature.items() if ty != "constexpr"]
+        grid_arg_names = list((self.inductor_meta or {}).get("extra_launcher_args", []))
+        return wrapper_arg_names + grid_arg_names, kernel_arg_names, grid_arg_names
+
+    def _write_wrapper_signature(
+        self,
+        prefix: IndentedBuffer,
+        wrapper_arg_names: list[str],
+    ) -> None:
+        # `cubin_dir_` name reused from GPU so the same AOTI runtime member feeds both.
+        assert len(wrapper_arg_names) == len(self.arg_types), (
+            wrapper_arg_names,
+            self.arg_types,
+        )
+        template_types = [
+            f"typename {name}_type_"
+            for name, arg_type in zip(wrapper_arg_names, self.arg_types)
+            if isinstance(arg_type, torch_dtype)
+        ]
+        if V.graph.aot_mode:
+            template_types.append("typename kernels_type_")
+        if template_types:
+            prefix.writeline(f"template <{', '.join(template_types)}>")
+
+        param_lines = [
+            self._get_cpp_param_type(name, arg_type)
+            for name, arg_type in zip(wrapper_arg_names, self.arg_types)
+        ]
+        if V.graph.aot_mode:
+            param_lines.append("kernels_type_& kernels_")
+        param_lines.append(
+            "const std::optional<std::string>& cubin_dir_ = std::nullopt"
+        )
+
+        prefix.writeline(f"static __attribute__((noinline)) void {self.wrapper_name}(")
+        with prefix.indent():
+            for i, param in enumerate(param_lines):
+                comma = "," if i < len(param_lines) - 1 else ""
+                prefix.writeline(f"{param}{comma}")
+        prefix.writeline("){")
+
+    def _generate_load_kernel(
+        self,
+        prefix: IndentedBuffer,
+        kernel_so: str,
+        launcher_so: str,
+        kernel_symbol: str,
+    ) -> None:
+        # `std::call_once` keeps init thread-safe under concurrent first calls.
+        kernel_member = f"kernels_.{self.kernel_name}_kernel_fn"
+        launcher_member = f"kernels_.{self.kernel_name}_launcher_fn"
+        prefix.splice(
+            f"""
+            using namespace torch::aot_inductor;
+            static std::once_flag {self.kernel_name}_init_flag;
+            std::call_once({self.kernel_name}_init_flag, [&]() {{
+                {kernel_member} = loadCpuTritonKernel(
+                    "{kernel_so}", "{kernel_symbol}", cubin_dir_);
+                {launcher_member} = loadCpuTritonLauncher(
+                    "{launcher_so}", cubin_dir_);
+            }});
+            """
+        )
+
+    def _generate_launch(
+        self,
+        prefix: IndentedBuffer,
+        kernel_arg_names: list[str],
+        grid_arg_names: list[str],
+        signature: dict[str, Any],
+    ) -> None:
+        # The launcher uses literal `args[i]` indices over the *original*
+        # signature, so constexpr slots must be padded (nullptr) to keep
+        # non-constexpr args at the expected positions.
+        kernel_member = f"kernels_.{self.kernel_name}_kernel_fn"
+        launcher_member = f"kernels_.{self.kernel_name}_launcher_fn"
+
+        args_array_entries: list[str] = []
+        for name, ty in signature.items():
+            if ty == "constexpr":
+                args_array_entries.append("nullptr")
+            elif isinstance(ty, str) and ty.startswith("*"):
+                args_array_entries.append(f"{name}.data_ptr()")
+            else:
+                args_array_entries.append(f"&{name}")
+        args_arr_str = ", ".join(args_array_entries)
+
+        # Grid args are int64_t in the wrapper but the launcher ABI is uint32_t.
+        grid_x = grid_arg_names[0] if len(grid_arg_names) > 0 else "1"
+        grid_y = grid_arg_names[1] if len(grid_arg_names) > 1 else "1"
+        grid_z = grid_arg_names[2] if len(grid_arg_names) > 2 else "1"
+
+        # TODO: thread `num_cpu_threads` from inductor_meta (autotune support).
+        prefix.splice(
+            f"""
+            void* args_arr[] = {{ {args_arr_str} }};
+            {launcher_member}(
+                static_cast<uint32_t>({grid_x}),
+                static_cast<uint32_t>({grid_y}),
+                static_cast<uint32_t>({grid_z}),
+                /*num_cpu_threads=*/1,
+                args_arr,
+                {kernel_member});
+            """
+        )
+
+    def generate(self, wrapper: CppWrapperCpu) -> None:
+        from torch._inductor.codecache import CpuTritonKernelCache
+
+        info = CpuTritonKernelCache.get(self.kernel_name)
+        if info is None:
+            raise RuntimeError(
+                f"CpuTritonKernelCache not populated for '{self.kernel_name}': "
+                "the autotune block did not save this kernel. Check that "
+                "config.triton.autotune_at_compile_time is True and the Triton "
+                "CPU backend emits a launcher .so exporting `run_from_nativert`."
+            )
+
+        signature = info["signature"]
+        wrapper_arg_names, kernel_arg_names, grid_arg_names = self._resolve_arg_names()
+
+        prefix = wrapper.prefix
+        self._write_wrapper_signature(prefix, wrapper_arg_names)
+        with prefix.indent():
+            self._generate_load_kernel(
+                prefix,
+                info["kernel_so_path"],
+                info["launcher_so_path"],
+                info["kernel_symbol"],
+            )
+            self._generate_launch(prefix, kernel_arg_names, grid_arg_names, signature)
+        prefix.writeline("}")
+
+        # Register .so artifacts so the AOTI packager picks them up.
+        V.graph.wrapper_code.additional_files.append(info["kernel_so_path"])
+        V.graph.wrapper_code.additional_files.append(info["launcher_so_path"])
+
+
 class CppWrapperCpu(PythonWrapperCodegen):
     """
     Generates cpp wrapper for running on CPU and calls cpp kernels
@@ -83,6 +276,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
         self.declared_int_array_vars: OrderedSet[str] = OrderedSet()
         self.tmp_tensor_id = count()  # for tmp tensor local variable declarations
         self.arg_var_id = count()
+        # Defined kernels drive member declarations; called kernels drive
+        # `call_<k>` emission. A kernel may be defined without being called.
+        self._cpu_triton_kernel_names: OrderedSet[str] = OrderedSet()
+        self._cpu_triton_call_wrappers: dict[str, DeferredCpuTritonCallWrapper] = {}
         self.used_cached_devices: OrderedSet[str] = OrderedSet()
         self.used_cached_dtypes: OrderedSet[str] = OrderedSet()
         self.used_cached_layouts: OrderedSet[str] = OrderedSet()
@@ -162,6 +359,50 @@ class CppWrapperCpu(PythonWrapperCodegen):
             f"call_args: {call_args}\n"
             f"arg_types: {arg_types}"
         )
+
+        # CPU Triton kernel: run the autotune block (populates
+        # `CpuTritonKernelCache`) and emit `call_<k>(...)`; the body is
+        # defined later by `DeferredCpuTritonCallWrapper` in `finalize_prefix`.
+        if triton and kernel_name in self._cpu_triton_kernel_names:
+            if (
+                config.triton.autotune_at_compile_time
+                and kernel_name not in self.kernel_autotune_names
+            ):
+                PythonWrapperCodegen._generate_kernel_call_helper(
+                    self,
+                    kernel_name,
+                    call_args,
+                    device=device,
+                    triton=triton,
+                    arg_types=arg_types,
+                    raw_keys=raw_keys,
+                    raw_args=raw_args,
+                    triton_meta=triton_meta,
+                    inductor_meta=inductor_meta,
+                    original_fxnode_name=original_fxnode_name,
+                )
+
+            wrapper_name = f"call_{kernel_name}"
+            if wrapper_name not in self._cpu_triton_call_wrappers:
+                self._cpu_triton_call_wrappers[wrapper_name] = (
+                    DeferredCpuTritonCallWrapper(
+                        wrapper_name=wrapper_name,
+                        kernel_name=kernel_name,
+                        arg_types=list(arg_types),
+                        triton_meta=triton_meta,
+                        inductor_meta=inductor_meta,
+                    )
+                )
+
+            stringified_args = [
+                self._stringify_cpu_triton_call_arg(a) for a in call_args
+            ]
+            if V.graph.aot_mode:
+                stringified_args.append("kernels")
+                stringified_args.append("this->cubin_dir_")
+            self.writeline(self.wrap_kernel_call(wrapper_name, stringified_args))
+            return
+
         new_args = []
         for idx, arg in enumerate(call_args):
             if isinstance(arg_types[idx], str) and "*" in arg_types[idx]:
@@ -719,11 +960,22 @@ class CppWrapperCpu(PythonWrapperCodegen):
             declare_kernel.update(
                 V.graph.const_module.wrapper_code.src_to_kernel.values()
             )
+        # CPU Triton kernels need a (kernel_fn, launcher_fn) pair, declared
+        # separately below; skip them in the default single-`void*` loop.
+        cpu_triton_names = self._cpu_triton_kernel_names
         for kernel in sorted(declare_kernel):
+            if kernel in cpu_triton_names:
+                continue
             self.prefix.writeline(
                 maybe_hipify_code_wrapper(
                     f"    {self.device_codegen.cpp_kernel_type()} {kernel}{{nullptr}};"
                 )
+            )
+        for kernel in sorted(cpu_triton_names):
+            self.prefix.writeline(f"    void* {kernel}_kernel_fn{{nullptr}};")
+            self.prefix.writeline(
+                f"    torch::aot_inductor::CpuTritonLauncherFn "
+                f"{kernel}_launcher_fn{{nullptr}};"
             )
         for name, kernel in self.initialized_kernels.items():
             assert hasattr(kernel, "get_signature"), (
@@ -1065,8 +1317,43 @@ class CppWrapperCpu(PythonWrapperCodegen):
         for memory_format in self.used_cached_memory_formats:
             cache_decls.writeline(f"CACHE_TORCH_MEMORY_FORMAT({memory_format});")
 
+        # Includes are needed whenever a kernel was *defined* (the model
+        # kernels class references `CpuTritonLauncherFn`); `call_<k>` bodies
+        # only for kernels that were actually *called*.
+        if self._cpu_triton_kernel_names:
+            self._write_cpu_triton_runtime_includes(self.prefix)
+        if self._cpu_triton_call_wrappers:
+            for wrapper in self._cpu_triton_call_wrappers.values():
+                self.prefix.writeline("\n")
+                wrapper.generate(self)
+
         self.prefix.splice(aot_mode_decls)
         self.prefix.splice(prior)
+
+    @staticmethod
+    def _write_cpu_triton_runtime_includes(prefix: IndentedBuffer) -> None:
+        """One-time includes/guards needed by emitted CPU Triton wrappers."""
+        prefix.writeline("// CPU AOTI Triton kernel wrappers")
+        prefix.writeline("#ifdef _WIN32")
+        prefix.writeline(
+            '#error "CPU AOTI Triton kernels are not supported on Windows"'
+        )
+        prefix.writeline("#endif")
+        prefix.writeline("#include <mutex>")
+        prefix.writeline(
+            "#include <torch/csrc/inductor/aoti_runtime/cpu_triton_runtime_wrappers.h>"
+        )
+
+    @staticmethod
+    def _stringify_cpu_triton_call_arg(arg: Any) -> str:
+        """Render a Triton kernel call argument as a C++ expression."""
+        if isinstance(arg, str):
+            return arg
+        if isinstance(arg, bool):
+            return "true" if arg else "false"
+        if isinstance(arg, (int, float, SymbolicCallArg)):
+            return str(arg)
+        return cexpr(V.graph.sizevars.simplify(arg))
 
     def _define_kernel_helper(
         self,
@@ -1076,6 +1363,16 @@ class CppWrapperCpu(PythonWrapperCodegen):
         gpu: bool = False,
         cpp_definition: str | None = None,
     ):
+        # Misnomer: `gpu` actually means "is this a Triton kernel?"
+        if gpu:
+            # Register as a CPU Triton kernel and let the autotune block
+            # compile it; the C++ wrapper is emitted later in finalize_prefix.
+            self._cpu_triton_kernel_names.add(kernel_name)
+            if config.triton.autotune_at_compile_time:
+                PythonWrapperCodegen._define_kernel_helper(
+                    self, kernel_name, kernel_body, metadata, gpu, cpp_definition
+                )
+            return
         if cpp_definition is not None:
             self.header.splice(cpp_definition)
             self.kernel_declarations.splice(f"\n{kernel_body}\n")

--- a/torch/_inductor/codegen/cpu_device_op_overrides.py
+++ b/torch/_inductor/codegen/cpu_device_op_overrides.py
@@ -24,7 +24,7 @@ class CpuDeviceOpOverrides(DeviceOpOverrides):
         return "pass"
 
     def device_guard(self, device_idx: int) -> str:
-        return "pass"
+        return "torch._ops.contextlib.nullcontext()"
 
 
 register_device_op_overrides("cpu", CpuDeviceOpOverrides())

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -379,6 +379,7 @@ class CachingAutotuner(KernelInterface):
         self.heuristic_type = heuristic_type
         self.custom_kernel = custom_kernel
         self.cuda_kernel_saved = False
+        self.cpu_kernel_saved = False
         self.autotune_cache_info = autotune_cache_info
         if log.isEnabledFor(logging.DEBUG):
             log.debug(
@@ -1575,6 +1576,43 @@ class CachingAutotuner(KernelInterface):
         CudaKernelParamCache.set(key, params, binary, bin_type, asm, asm_type)
         self.cuda_kernel_saved = True
 
+    def save_cpu_kernel(self, launcher):
+        """AOTI counterpart of save_gpu_kernel for CPU Triton kernels.
+
+        Captures the kernel and launcher `.so` files into
+        `CpuTritonKernelCache` for `CppWrapperCpu` to dlopen at runtime.
+        Triton CPU backend needs to emit `run_from_nativert`.
+        """
+        from torch._inductor.codecache import CpuTritonKernelCache
+
+        key = self.inductor_meta.get("kernel_name")
+        assert key is not None, "kernel_name can not be None"
+
+        compiled = launcher.bin
+        kernel_bytes = compiled.asm.get("so")
+        launcher_bytes = compiled.asm.get("launcher.so")
+        if kernel_bytes is None or launcher_bytes is None:
+            raise RuntimeError(
+                f"CPU AOTI requires a Triton CPU backend that emits a launcher "
+                f"`.so` exporting `run_from_nativert`; kernel '{key}' has "
+                f"compiled.asm keys {list(compiled.asm.keys())}."
+            )
+        kernel_symbol = (
+            compiled.metadata.name
+            if hasattr(compiled.metadata, "name")
+            else compiled.metadata["name"]
+        )
+        signature = compiled.src.signature
+
+        CpuTritonKernelCache.set(
+            key,
+            kernel_bytes=kernel_bytes,
+            launcher_bytes=launcher_bytes,
+            kernel_symbol=kernel_symbol,
+            signature=signature,
+        )
+        self.cpu_kernel_saved = True
+
     def coordinate_descent_tuning(self, launcher, *args, **kwargs):
         """
         Coordinate descent tuning can be run with or without max-autotune.
@@ -1839,7 +1877,11 @@ class CachingAutotuner(KernelInterface):
         # autotuning entirely, this is the only call site that records the winner.
         TritonBundler.put_winner(launcher.cache_hash)
         if launcher.store_cubin and (not benchmark_run or not self.cuda_kernel_saved):
-            self.save_gpu_kernel(stream, launcher)
+            if self.device_props.type == "cpu":
+                if not self.cpu_kernel_saved:
+                    self.save_cpu_kernel(launcher)
+            else:
+                self.save_gpu_kernel(stream, launcher)
 
         try:
             self._pre_launch(launcher, *args, stream=stream, **kwargs)
@@ -2621,7 +2663,10 @@ class DebugAutotuner(CachingAutotuner):
             (launcher,) = self.launchers
 
             if launcher.store_cubin:
-                self.save_gpu_kernel(stream, launcher)
+                if self.device_props.type == "cpu":
+                    self.save_cpu_kernel(launcher)
+                else:
+                    self.save_gpu_kernel(stream, launcher)
 
             if self.cached is None:
                 ms = self.bench(launcher, *args, with_profiler=self.with_profiler)

--- a/torch/csrc/inductor/aoti_runtime/cpu_triton_runtime_wrappers.h
+++ b/torch/csrc/inductor/aoti_runtime/cpu_triton_runtime_wrappers.h
@@ -1,0 +1,91 @@
+// CPU AOTI Triton runtime helpers. CPU counterpart of the GPU AOTI Triton path
+// (cf. `sycl_runtime_wrappers.h`, `static_launcher/cuda.cpp`): the generated
+// wrapper dlopens the per-kernel `.so` and a launcher `.so` exporting
+// `run_from_nativert`, then invokes the kernel through the launcher.
+//
+// Note: only Triton CPU builds that emit a NativeRT-compatible launcher are
+// supported. OSS triton-cpu does not yet, and `loadCpuTritonLauncher` aborts
+// at model load time -- expected and intentional.
+
+#pragma once
+
+#ifdef _WIN32
+#error "CPU AOTI Triton runtime helpers are not supported on Windows"
+#endif
+
+#include <c10/util/Exception.h>
+#include <dlfcn.h>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace torch::aot_inductor {
+
+// Launcher ABI: (gridX, gridY, gridZ, num_cpu_threads, void** args, kernel_fn).
+using CpuTritonLauncherFn =
+    void (*)(uint32_t, uint32_t, uint32_t, int, void**, void*);
+
+// Resolve `filePath` to an actual `.so` location: `soDir` override (GPU's
+// `binDir` / `cubin_dir_` analog), else the absolute path, else the basename
+// next to the AOTI .so via `dladdr`.
+[[maybe_unused]] static std::string _resolve_cpu_triton_so_path(
+    std::string filePath,
+    const std::optional<std::string>& soDir) {
+  if (soDir) {
+    std::filesystem::path p1{*soDir};
+    std::filesystem::path p2{filePath};
+    return (p1 / p2.filename()).string();
+  }
+  std::error_code ec;
+  if (std::filesystem::exists(filePath, ec)) {
+    return filePath;
+  }
+  Dl_info info{};
+  if (dladdr(reinterpret_cast<void*>(&_resolve_cpu_triton_so_path), &info) &&
+      info.dli_fname != nullptr) {
+    std::filesystem::path basename = std::filesystem::path(filePath).filename();
+    std::filesystem::path candidate =
+        std::filesystem::path(info.dli_fname).parent_path() / basename;
+    if (std::filesystem::exists(candidate, ec)) {
+      return candidate.string();
+    }
+  }
+  return filePath;
+}
+
+// Load a kernel symbol from `filePath`. The handle is intentionally leaked --
+// the AOTI process keeps the .so loaded for its lifetime, mirroring how cubin
+// modules are leaked on the GPU side.
+[[maybe_unused]] static void* loadCpuTritonKernel(
+    std::string filePath,
+    const std::string& funcName,
+    const std::optional<std::string>& soDir = std::nullopt) {
+  filePath = _resolve_cpu_triton_so_path(std::move(filePath), soDir);
+  void* handle = dlopen(filePath.c_str(), RTLD_NOW | RTLD_LOCAL);
+  TORCH_CHECK(handle, "dlopen ", filePath, ": ", dlerror());
+  void* fn = dlsym(handle, funcName.c_str());
+  TORCH_CHECK(fn, "dlsym ", funcName, " from ", filePath, ": ", dlerror());
+  return fn;
+}
+
+// Load the launcher's `run_from_nativert` entry point. Same handle-leak policy
+// as `loadCpuTritonKernel`. Aborts loudly if the symbol is missing.
+[[maybe_unused]] static CpuTritonLauncherFn loadCpuTritonLauncher(
+    std::string filePath,
+    const std::optional<std::string>& soDir = std::nullopt) {
+  filePath = _resolve_cpu_triton_so_path(std::move(filePath), soDir);
+  void* handle = dlopen(filePath.c_str(), RTLD_NOW | RTLD_LOCAL);
+  TORCH_CHECK(handle, "dlopen ", filePath, ": ", dlerror());
+  void* fn = dlsym(handle, "run_from_nativert");
+  TORCH_CHECK(
+      fn,
+      "Triton CPU launcher .so does not export 'run_from_nativert' (",
+      filePath,
+      "): ",
+      dlerror(),
+      ". The CPU AOTI Triton path requires a Triton CPU build that emits a "
+      "NativeRT-compatible launcher.");
+  return reinterpret_cast<CpuTritonLauncherFn>(fn);
+}
+
+} // namespace torch::aot_inductor


### PR DESCRIPTION
Summary:

**TL;DR:** This diff supports Triton CPU kernels AOTI's CPU C++ wrapper.
This change adds the missing CPU codegen path, structurally mirroring the GPU
AOTI Triton path.
---
**The problem**
- `clang` rejects the wrapper with `unknown type name 'async_compile'` (paste P2044772009).
- Blocks AOTI on CPU for any model that uses Triton kernels.

**Key objectives**
- **Make AOTI work on CPU when Triton is involved.** `test_triton_with_aoti_executor_cpu`, previously `unittest.expectedFailure`, now passes.
- **Mirror the GPU AOTI Triton path one-for-one.** Same shapes, same names, same flow. Only the loading mechanism differs: dlopen + `run_from_nativert` instead of `cuModuleLoad` + `cuLaunchKernel`. Anyone who has read the GPU codegen should read the CPU codegen at a glance.
- **Avoid divergent designs.** The runtime layer (Dylan's `CpuTritonKernelManager` in NativeRT, D80828148) is already symmetric across CPU/CUDA/MTIA via `TritonKernelManager`; the codegen layer should be too, so improvements to one side keep flowing naturally to the other.
- **Fail loudly when the runtime is incompatible.** Some Triton CPU builds (notably OSS triton-cpu) do not emit a launcher exporting `run_from_nativert`. In that case we abort at AOTI compile time with a clear error citing the missing symbol. No silent breakage.

**Symmetric pieces (CPU mirrors GPU one-for-one)**
- `CpuTritonKernelCache` ↔ `CudaKernelParamCache`
- `save_cpu_kernel` ↔ `save_gpu_kernel`
- `DeferredCpuTritonCallWrapper` ↔ `DeferredTritonCallWrapper`
- `cpu_triton_runtime_wrappers.h::loadCpuTritonKernel/Launcher` ↔ `sycl_runtime_wrappers.h::loadKernel`
- Same `call_<kernel>(...)` wrapper name; same `kernels_.<kernel>_*` member layout on `AOTInductorModelKernels`; same `cubin_dir_` override.

**Out of scope (deferred, not blockers)**
- Autotune support — CPU Triton doesn't currently use multi-config autotuning; the deferred-wrapper structure mirrors GPU so it can plug in later without churn.
- Windows — guarded with `#error`.
- The Triton CPU launcher symbol — depends on the runtime Triton CPU build. Aborts cleanly if absent.
- The OSS-shipped tests in `caffe2/test/inductor/test_aot_inductor.py` already skip CPU+Triton; we do not change them. The new positive test lives in `fbcode/sigmoid/inference/test/test_passes.py`, which is internal-only and so does not run in OSS CI.

Test Plan:
`test_triton_with_aoti_executor_cpu` was previously marked `unittest.expectedFailure`; now passes. CUDA counterpart still passes (no regression).

```
buck test fbcode//mode/opt -c remoteexecution.local=enabled fbcode//sigmoid/inference/test:test_passes -m ovr_config//triton:experimental -- -r test_triton_with_aoti_executor
```

Result: `Pass 2. Fail 0`. Test session: https://www.internalfb.com/intern/testinfra/testrun/24488322989801695.

Baseline (before this change) failed with the canonical clang error from paste P2044772009: `error: unknown type name 'async_compile'`.

---

Reviewed By: shawnxu26

Differential Revision: D101914212




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo