### PR TITLE
[FSDP2] Collapse keep-alive stash/drain boilerplate behind PipelinedBuffer

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_memory.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_memory.py
@@ -421,9 +421,9 @@ class TestFullyShardHSDPMemory(FSDPTest):
         #   - 1x unsharded bf16 block params (prefetched all-gather for the
         #     next block's backward compute)
         #   - 2x fp32 reduce-scatter input (current block + previous block
-        #     still held in reduce_scatter_states)
+        #     still held in comm_ctx.reduce_scatter_buffer)
         #   - 2x fp32 all-reduce output (current block + previous block's
-        #     orphaned buffer held by comm_ctx.all_reduce_state).
+        #     orphaned buffer held by comm_ctx.all_reduce_buffer).
         #     THIS is the term the fix bounds at 2; the bug made it O(n_layers).
         per_layer_fp32_mb = block_numel * 4 / dp_shard_size / 1e6
         expected_peak_mb = (

--- a/test/distributed/_composable/fsdp/test_fully_shard_stream_utils.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_stream_utils.py
@@ -3,7 +3,10 @@
 import unittest
 
 import torch
-from torch.distributed.fsdp._fully_shard._stream_utils import StreamHandoff
+from torch.distributed.fsdp._fully_shard._stream_utils import (
+    PipelinedBuffer,
+    StreamHandoff,
+)
 from torch.testing._internal.common_utils import run_tests, TEST_CUDA, TestCase
 
 
@@ -160,6 +163,114 @@ class TestStreamHandoff(TestCase):
         # (We don't assert the block is actually reused — allocator
         # decisions are internal — only that no UAF occurred above.)
         del t1, t2
+
+
+@unittest.skipUnless(TEST_CUDA, "PipelinedBuffer tests require CUDA")
+class TestPipelinedBuffer(TestCase):
+    def _make_handoff(self, *, release_stream=None):
+        producer = torch.cuda.Stream()
+        if release_stream is None:
+            release_stream = torch.cuda.Stream()
+        with torch.cuda.stream(producer):
+            t = torch.zeros(16, device="cuda")
+            event = producer.record_event()
+        return StreamHandoff(
+            tensor=t,
+            ready_event=event,
+            release_stream=release_stream,
+        )
+
+    def test_empty_buffer(self):
+        buf = PipelinedBuffer()
+        self.assertEqual(len(buf), 0)
+        self.assertFalse(buf)
+        # pop_event on empty returns None without raising.
+        self.assertIsNone(buf.pop_event())
+        # flush on empty is a no-op.
+        buf.flush()
+
+    def test_push_and_len(self):
+        buf = PipelinedBuffer()
+        buf.push(self._make_handoff())
+        self.assertEqual(len(buf), 1)
+        self.assertTrue(buf)
+        buf.push(self._make_handoff())
+        self.assertEqual(len(buf), 2)
+
+    def test_pop_event_returns_event_and_releases(self):
+        buf = PipelinedBuffer()
+        h = self._make_handoff()
+        expected_event = h.event
+        self.assertIsNotNone(expected_event)
+        buf.push(h)
+        event = buf.pop_event()
+        self.assertIs(event, expected_event)
+        # Entry is released and removed from the buffer.
+        self.assertTrue(h.released)
+        self.assertEqual(len(buf), 0)
+
+    def test_pop_event_raises_when_multiple(self):
+        buf = PipelinedBuffer()
+        buf.push(self._make_handoff())
+        buf.push(self._make_handoff())
+        with self.assertRaises(RuntimeError):
+            buf.pop_event()
+        # Buffer is untouched on error.
+        self.assertEqual(len(buf), 2)
+
+    def test_flush_releases_all(self):
+        buf = PipelinedBuffer()
+        handoffs = [self._make_handoff() for _ in range(3)]
+        for h in handoffs:
+            buf.push(h)
+        buf.flush()
+        for h in handoffs:
+            self.assertTrue(h.released)
+        self.assertEqual(len(buf), 0)
+        # Idempotent: flushing again on empty is fine.
+        buf.flush()
+
+    def test_flush_with_extra_waiters(self):
+        """flush(stream) calls handoff.wait(stream) for each entry so that
+        the extra stream is ordered after the entry's event, in addition to
+        release_stream being ordered via release()."""
+        release = torch.cuda.Stream()
+        extra = torch.cuda.Stream()
+        buf = PipelinedBuffer()
+        buf.push(self._make_handoff(release_stream=release))
+        buf.push(self._make_handoff(release_stream=release))
+        buf.flush(extra)
+        # Functional smoke: subsequent work on `extra` must not hang and
+        # must see a consistent ordering.
+        with torch.cuda.stream(extra):
+            probe = torch.zeros(1, device="cuda")
+        torch.cuda.synchronize()
+        self.assertEqual(probe.item(), 0.0)
+
+    def test_single_slot_pipeline_cycle(self):
+        """Simulate AR's per-layer cycle: pop_event + push, repeated. Verifies
+        each iteration sees the prior iteration's event and releases it."""
+        release = torch.cuda.Stream()
+        buf = PipelinedBuffer()
+        prior_events = []
+        for _ in range(3):
+            prior_event = buf.pop_event()
+            prior_events.append(prior_event)
+            buf.push(self._make_handoff(release_stream=release))
+        # First iteration has no predecessor.
+        self.assertIsNone(prior_events[0])
+        # Subsequent iterations see their predecessor's event.
+        self.assertIsNotNone(prior_events[1])
+        self.assertIsNotNone(prior_events[2])
+        # End-of-pipeline drain.
+        buf.flush()
+        self.assertEqual(len(buf), 0)
+
+    def test_repr_shows_count(self):
+        buf = PipelinedBuffer()
+        self.assertIn("entries=0", repr(buf))
+        buf.push(self._make_handoff())
+        self.assertIn("entries=1", repr(buf))
 
 
 if __name__ == "__main__":

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -43,7 +43,7 @@ from ._fsdp_common import (
     TrainingState,
 )
 from ._fsdp_param import alloc_storage, FSDPParam, ParamModuleInfo, ShardedState
-from ._stream_utils import StreamHandoff
+from ._stream_utils import PipelinedBuffer, StreamHandoff
 
 
 if TYPE_CHECKING:
@@ -70,9 +70,11 @@ reference to avoid holding onto memory after forward.
 class FSDPCommContext:
     """Communication state shared across FSDP states/parameter groups.
 
-    Cross-layer fields (all_gather_state, reduce_scatter_states,
-    all_reduce_state) assume backward passes sharing the context
-    run serially, not concurrently.
+    Cross-layer buffers (all_gather_buffer, reduce_scatter_buffer,
+    all_reduce_buffer) assume backward passes sharing the context run
+    serially, not concurrently. See :class:`PipelinedBuffer` for the
+    push/pop/flush idioms; see :class:`StreamHandoff` for the underlying
+    per-entry invariants.
     """
 
     def lazy_init(self, device: torch.device):
@@ -97,21 +99,14 @@ class FSDPCommContext:
         # since collectives use different network resources and can overlap
         # in the typical intra-node sharding / inter-node replication case
         self.all_reduce_stream = self.device_handle.Stream()
-        # All-gather/reduce-scatter states keep references to collective
-        # tensors produced in one stream and used in another; see
-        # StreamHandoff for the (tensor, event, release_stream) invariants.
-        self.all_gather_state: StreamHandoff | None = None
-        self.reduce_scatter_states: list[StreamHandoff] = []
-        # Keeps the HSDP all-reduce buffer alive until the next layer's
-        # backward can free it on the all-reduce stream. Required because:
-        # (1) a post-reduce dtype cast orphans the pre-cast buffer (param
-        # grads reference the cast result); (2) in the accumulate path,
-        # param grads reference a *previous* reduce_output, not the current
-        # one. Storing on comm_ctx (vs per-group) limits liveness to one
-        # buffer at a time, avoiding O(n_layers) accumulation in case (1).
-        # See StreamHandoff for the tensor+event+release_stream invariants
-        # that make "drop the ref" safe across streams.
-        self.all_reduce_state: StreamHandoff | None = None
+        # Cross-layer keep-alive buffers. Each holds zero or more
+        # StreamHandoffs bridging a producer->consumer stream boundary; the
+        # backward finalize callback / forward root flush drains the last
+        # layer's entries. All three use the same PipelinedBuffer idiom;
+        # see the class docstring for semantics.
+        self.all_gather_buffer: PipelinedBuffer = PipelinedBuffer()
+        self.reduce_scatter_buffer: PipelinedBuffer = PipelinedBuffer()
+        self.all_reduce_buffer: PipelinedBuffer = PipelinedBuffer()
         # Post-forward order for explicit backward prefetching
         self.post_forward_order: list[FSDPParamGroup] = []  # will cause ref cycles
 
@@ -128,20 +123,15 @@ class FSDPCommContext:
         return current_stream, current_stream
 
     def flush_all_reduce_state(self):
-        """Drain the last layer's state at end of backward. Safe because
-        autograd serializes finalize callbacks; first group drains, rest no-op.
+        """Drain the last layer's AR buffer at end of backward.
+
+        Safe to call from every group: autograd serializes finalize callbacks
+        so the first drains and the rest are no-ops. ``current_stream()`` is
+        passed as an extra waiter so subsequent default-stream allocations
+        are ordered after the AR buffer's event - ``release()`` on its own
+        only orders the AR stream.
         """
-        if self.all_reduce_state is None:
-            return
-        # Make default stream wait on AR completion before subsequent
-        # default-stream allocations can reuse memory that aliases
-        # the AR buffer. StreamHandoff.release() only waits on its own
-        # release_stream (the AR stream); the default-stream ordering
-        # here is an additional barrier this call site owns.
-        if self.all_reduce_state.event is not None:
-            self.device_handle.current_stream().wait_event(self.all_reduce_state.event)
-        self.all_reduce_state.release()
-        self.all_reduce_state = None
+        self.all_reduce_buffer.flush(self.device_handle.current_stream())
 
 
 # See [Note: Overlapping all-gather copy-in and all-gather]
@@ -406,13 +396,11 @@ class FSDPParamGroup:
             return  # no preceding unshard
         async_op = self._all_gather_result.all_gather_work is not None
         if self._training_state == TrainingState.FORWARD:  # implicit prefetch
-            if prev := self.comm_ctx.all_gather_state:
-                # Both AG streams need to wait before reclaim. release()
-                # handles all_gather_stream (the release_stream) and the
-                # drop; wait() adds copy-in as the other consumer.
-                prev.wait(self.comm_ctx.all_gather_copy_in_stream)
-                prev.release()
-                self.comm_ctx.all_gather_state = None
+            # Both AG streams need to wait before reclaim. release_stream is
+            # the AG stream; the copy-in stream is passed as an extra waiter.
+            self.comm_ctx.all_gather_buffer.flush(
+                self.comm_ctx.all_gather_copy_in_stream
+            )
         if isinstance(self.mesh_info, FSDPMeshInfo):
             world_size = self._all_gather_process_group.size()
         else:
@@ -466,16 +454,18 @@ class FSDPParamGroup:
             # all-gather collective. Keep only the output buffer alive
             # via StreamHandoff; Result metadata (dtypes, split_sizes) is
             # no longer needed after copy-out and can go out of scope.
-            self.comm_ctx.all_gather_state = StreamHandoff(
-                tensor=self._all_gather_result.all_gather_output,
-                ready_event=all_gather_copy_out_event,
-                release_stream=self.comm_ctx.all_gather_stream,
-                device_handle=self.device_handle,
+            self.comm_ctx.all_gather_buffer.push(
+                StreamHandoff(
+                    tensor=self._all_gather_result.all_gather_output,
+                    ready_event=all_gather_copy_out_event,
+                    release_stream=self.comm_ctx.all_gather_stream,
+                    device_handle=self.device_handle,
+                )
             )
         else:
             self._wait_all_gather_streams_on_event(all_gather_copy_out_event)
 
-        self._all_gather_result = None  # free unless saved in `all_gather_state`
+        self._all_gather_result = None  # free unless saved in `all_gather_buffer`
 
     def _wait_all_gather_streams_on_event(self, event: torch.Event | None):
         # Calling `unshard` before lazy init means streams are not initialized
@@ -572,16 +562,14 @@ class FSDPParamGroup:
                     fsdp_param.unsharded_param.grad = None
             if self.reshard_after_backward:
                 self.reshard()
-        # Wait on prior module's RS states (assumes backward fires groups
+        # Wait on prior module's RS buffer (assumes backward fires groups
         # N-1 first; if not, overlap degrades but correctness is preserved).
         if (
             self._param_group_index == self._num_param_groups - 1
-            and self.comm_ctx.reduce_scatter_states
+            and self.comm_ctx.reduce_scatter_buffer
         ):
             with record_function(f"FSDP::post_backward_rs_wait ({self._module_fqn})"):
-                for rs_state in self.comm_ctx.reduce_scatter_states:
-                    rs_state.release()
-                self.comm_ctx.reduce_scatter_states.clear()
+                self.comm_ctx.reduce_scatter_buffer.flush()
         if len(fsdp_params_with_grad) == 0:
             return
         with record_function(self._with_fqn("FSDP::post_backward_reduce")):
@@ -603,13 +591,10 @@ class FSDPParamGroup:
                 all_reduce_stream = self.comm_ctx.all_reduce_stream
 
             self._wait_for_post_backward()
-            # Drain predecessor's keep-alive so its reduce_output block can
-            # go to the all-reduce-stream free pool once we drop the ref.
-            prev_all_reduce_state = self.comm_ctx.all_reduce_state
-            self.comm_ctx.all_reduce_state = None
-            prev_all_reduce_event = (
-                prev_all_reduce_state.event if prev_all_reduce_state else None
-            )
+            # Drain predecessor's AR keep-alive: pop_event releases the prior
+            # handoff (its block routes to all_reduce_stream's free pool) and
+            # returns the event for foreach_reduce's ordering wait.
+            prev_all_reduce_event = self.comm_ctx.all_reduce_buffer.pop_event()
             (
                 reduce_scatter_input,
                 reduce_scatter_event,
@@ -645,12 +630,10 @@ class FSDPParamGroup:
                 self._label_suffix,
                 prev_all_reduce_event,
             )
-            if prev_all_reduce_state is not None:
-                prev_all_reduce_state.release()
             # RS input is allocated on the default stream and read on the
             # RS stream; release on default so the free routes to the pool
             # the next `reduce_scatter_comm.allocate` draws from.
-            self.comm_ctx.reduce_scatter_states.append(
+            self.comm_ctx.reduce_scatter_buffer.push(
                 StreamHandoff(
                     tensor=reduce_scatter_input,
                     ready_event=reduce_scatter_event,
@@ -671,11 +654,13 @@ class FSDPParamGroup:
                         raise AssertionError(
                             "Expected all_reduce_event to be set for non-CPU device"
                         )
-                self.comm_ctx.all_reduce_state = StreamHandoff(
-                    tensor=all_reduce_input,
-                    ready_event=all_reduce_event,
-                    release_stream=all_reduce_stream,
-                    device_handle=self.device_handle,
+                self.comm_ctx.all_reduce_buffer.push(
+                    StreamHandoff(
+                        tensor=all_reduce_input,
+                        ready_event=all_reduce_event,
+                        release_stream=all_reduce_stream,
+                        device_handle=self.device_handle,
+                    )
                 )
 
     def finalize_backward(self):

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -313,12 +313,11 @@ class FSDPState(_State):
         output = self._register_pre_backward_hook(output)
         self._training_state = TrainingState.IDLE
         if self._state_ctx.iter_forward_root is self:
-            if all_gather_state := self._comm_ctx.all_gather_state:
-                # Free the last all-gather result; refer to
-                # [Note: Overlapping all-gather copy-in and all-gather]
-                all_gather_state.wait(self._comm_ctx.all_gather_copy_in_stream)
-                all_gather_state.release()
-                self._comm_ctx.all_gather_state = None
+            # Free the last all-gather result; refer to
+            # [Note: Overlapping all-gather copy-in and all-gather]
+            self._comm_ctx.all_gather_buffer.flush(
+                self._comm_ctx.all_gather_copy_in_stream
+            )
             self._state_ctx.iter_forward_root = None
         if self._mp_policy.output_dtype is not None:
             with torch.profiler.record_function("FSDP::cast_forward_outputs"):
@@ -362,11 +361,9 @@ class FSDPState(_State):
                     state._finalize_backward()
             if self._state_ctx.is_last_backward:
                 self._comm_ctx.post_forward_order.clear()
-                # Catch the last module's RS states that no subsequent
+                # Catch the last module's RS entries that no subsequent
                 # module's group N-1 wait will clear.
-                for rs_state in self._comm_ctx.reduce_scatter_states:
-                    rs_state.release()
-                self._comm_ctx.reduce_scatter_states.clear()
+                self._comm_ctx.reduce_scatter_buffer.flush()
             self._state_ctx.post_backward_final_callback_queued = False
 
     def _finalize_backward(self) -> None:

--- a/torch/distributed/fsdp/_fully_shard/_stream_utils.py
+++ b/torch/distributed/fsdp/_fully_shard/_stream_utils.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
 
-__all__ = ["StreamHandoff"]
+__all__ = ["PipelinedBuffer", "StreamHandoff"]
 
 
 class StreamHandoff:
@@ -58,22 +58,17 @@ class StreamHandoff:
             used to open the stream context at release time. If ``None``,
             inferred from ``tensor.device.type``.
 
-    Example - AR keep-alive in FSDP2 HSDP backward::
+    Example - AR keep-alive in FSDP2 HSDP backward, via
+    :class:`PipelinedBuffer`::
 
-        # At the end of foreach_reduce, wrap the AR buffer so the next
-        # layer's post_backward can drop it on the AR stream:
-        handoff = StreamHandoff(
-            tensor=all_reduce_input,
-            ready_event=all_reduce_event,
-            release_stream=all_reduce_stream,
-        )
-        comm_ctx.all_reduce_state = handoff
-        ...
-        # Next layer, at top of post_backward:
-        prev = comm_ctx.all_reduce_state
-        comm_ctx.all_reduce_state = None
-        if prev is not None:
-            prev.release()  # AR.wait_event(evt); with stream(AR): tensor = None
+        # Layer N+1, top of post_backward: pop prior, use event for ordering.
+        prev_event = comm_ctx.all_reduce_buffer.pop_event()
+        (..., new_input, new_event, ...) = foreach_reduce(..., prev_event)
+        # Layer N, end of post_backward: stash new handoff.
+        if new_input is not None:
+            comm_ctx.all_reduce_buffer.push(
+                StreamHandoff(new_input, new_event, all_reduce_stream)
+            )
     """
 
     __slots__ = (
@@ -184,3 +179,96 @@ class StreamHandoff:
             f" dtype={self._tensor.dtype}"
             f" release_stream={self._release_stream}>"
         )
+
+
+class PipelinedBuffer:
+    """Sequence of :class:`StreamHandoff` with drain-all and single-slot-pop idioms.
+
+    FSDP2's cross-layer keep-alive buffers come in two shapes:
+
+    - **Single-slot pipeline** (AR, AG): layer N stashes one handoff on the
+      context; layer N+1 needs the prior event for causal ordering and then
+      releases the prior. Exactly one entry at a time.
+    - **Multi-slot queue** (RS): per-group handoffs accumulate across HSDP
+      groups and drain together at the next layer / end-of-backward.
+
+    ``PipelinedBuffer`` serves both. Callers pick between :meth:`pop_event`
+    (single-slot idiom: returns the sole entry's event, releases it) and
+    :meth:`flush` (multi-slot idiom: drain everything, with optional extra
+    consumer-stream waits).
+
+    :meth:`flush` accepts additional ``extra_waiters`` streams; each entry
+    calls ``handoff.wait(stream)`` on them before ``release()``. This covers
+    two cases today:
+
+    - AG prefetch drain: both AG streams (copy-in and AG) need the wait;
+      ``release_stream`` is the AG stream, so the copy-in stream is an
+      extra waiter.
+    - End-of-backward AR flush: the default stream must be ordered after
+      the AR event so that subsequent default-stream allocations don't
+      alias the AR buffer's storage.
+
+    Example (single-slot, AR)::
+
+        buf = comm_ctx.all_reduce_buffer
+        prev_event = buf.pop_event()           # releases prior; may be None
+        (..., new_input, new_event, ...) = foreach_reduce(..., prev_event)
+        if new_input is not None:
+            buf.push(StreamHandoff(new_input, new_event, all_reduce_stream))
+
+    Example (multi-slot, RS)::
+
+        buf = comm_ctx.reduce_scatter_buffer
+        if last_group_condition:
+            buf.flush()  # drain accumulated entries
+        buf.push(StreamHandoff(rs_input, rs_event, default_stream))
+    """
+
+    __slots__ = ("_items",)
+
+    def __init__(self) -> None:
+        self._items: list[StreamHandoff] = []
+
+    def push(self, handoff: StreamHandoff) -> None:
+        """Append ``handoff`` to the buffer."""
+        self._items.append(handoff)
+
+    def pop_event(self) -> torch.Event | None:
+        """Pop the sole entry; release it; return its event.
+
+        Returns ``None`` if the buffer is empty. Raises ``RuntimeError`` if
+        the buffer holds more than one entry - that would indicate a misuse
+        of the single-slot pipeline idiom.
+        """
+        if not self._items:
+            return None
+        if len(self._items) > 1:
+            raise RuntimeError(
+                f"pop_event() requires at most one entry; have {len(self._items)}"
+            )
+        handoff = self._items.pop()
+        event = handoff.event
+        handoff.release()
+        return event
+
+    def flush(self, *extra_waiters: torch.Stream) -> None:
+        """Release every entry. Idempotent.
+
+        For each entry, ``extra_waiters`` are made to wait on the entry's
+        event before the entry's ``release()`` runs (which itself waits
+        from ``release_stream``). No-op on an empty buffer.
+        """
+        for handoff in self._items:
+            for stream in extra_waiters:
+                handoff.wait(stream)
+            handoff.release()
+        self._items.clear()
+
+    def __bool__(self) -> bool:
+        return bool(self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __repr__(self) -> str:
+        return f"<PipelinedBuffer entries={len(self._items)}>"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181072
* #181047
* #179443

Follow-up to #181047 (StreamHandoff). That PR unified the *types* of FSDP2's
three cross-layer keep-alive buffers but left the control flow untouched:
every stash site still did `prev = ctx.X; ctx.X = None; prev.release()` by
hand, and every drain site still iterated + cleared + waited explicitly.

This PR introduces `PipelinedBuffer` in `_stream_utils.py` - a tiny container
around `list[StreamHandoff]` with two idioms:

- `pop_event()` - single-slot pipeline (AR, AG). Pops the sole entry,
  releases it, returns its event for the caller's causal-ordering wait.
  Raises if >1 entries (catches misuse).
- `flush(*extra_waiters)` - drain-all (RS, plus end-of-iteration flushes
  for AR and AG). Idempotent. `extra_waiters` are streams beyond
  `release_stream` that need a `wait_event` barrier; today this is the
  copy-in stream on the AG drain and the default stream on the AR flush.

`FSDPCommContext`'s three cross-layer fields migrate from typed optionals
and a list to uniform `PipelinedBuffer`:

    all_gather_buffer:     PipelinedBuffer
    reduce_scatter_buffer: PipelinedBuffer
    all_reduce_buffer:     PipelinedBuffer

The call-site shrink is real this time. Per-file net change:

    _fsdp_param_group.py:  +50 / -65  (net -15)
    _fsdp_state.py:        +7  / -10  (net -3)
    _stream_utils.py:      +104 / -16 (new class + docstring)

Specifically:

- `flush_all_reduce_state`: 9 lines -> 1 line. The "default stream ordering
  is an additional barrier this call site owns" comment that PR #181047
  flagged as unclear now lives in `PipelinedBuffer.flush`'s docstring,
  and the `current_stream()` is passed as an `extra_waiters` arg.
- AG prefetch drain (`wait_for_unshard`): 5 lines -> 3.
- AG final drain (`_post_forward`): 5 lines -> 3.
- RS drain (`post_backward`, `_root_post_backward_final_callback`): 3 lines
  -> 1 at each site.
- AR pop+push cycle (`post_backward`): 4 lines of `prev = ...; = None;
  prev_event = ...; prev.release()` -> 1 line `pop_event()`.

No behavioral change. The order of operations inside each site is identical
to HEAD: `release()` still does `wait_event` then `del` under
`stream(release_stream)`, same as before; the extra-waiter barrier at AR
flush is unchanged; and `pop_event()` performs `release()` before
`foreach_reduce`, which remains correct because subsequent AR work on
`all_reduce_stream` is naturally FIFO-ordered after the release's wait.

Verification:

- `test_fully_shard_stream_utils.py` extended with 8 `PipelinedBuffer`
  tests (empty-buffer, push, pop_event success/empty/multi-entry-raises,
  flush idempotency, flush with extra_waiters, single-slot cycle, repr).
  18/18 pass.
- HSDP parity: `test_train_parity_hsdp` pass.
- 1D parity: `test_train_parity_single_group_shard_dim0`,
  `test_train_parity_multi_group` pass.
- Mixed precision: `test_reduce_dtype`, `test_grad_acc_with_reduce_dtype`
  pass (the bf16/fp32-reduce config motivating #179443).
- HSDP memory regression: `test_hsdp_mixed_precision_no_buffer_accumulation`
  pass (the #179128 O(n_layers) accumulation guard).
- Overlap: `test_fully_shard_post_optim_event_overlap` pass.
- Lint clean.

Follow-ups (not in this PR):

- Event-only cross-stream sites (`_reshard_after_forward_event`,
  `all_gather_copy_out_event` fallback) still use
  `_wait_all_gather_streams_on_event`. These don't carry a tensor, so
  `StreamHandoff` isn't the right abstraction; a tensor-less variant
  (or keeping the helper) is out of scope here.
- `foreach_reduce` still takes `prev_all_reduce_event` explicitly.
  Moving the buffer through `foreach_reduce` could hide that last bit of
  plumbing but widens blast radius - left for a separate PR.

Authored with Claude Code.