### PR TITLE
Validate norm_type in lp_pool1d/2d/3d

### DIFF
--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -501,6 +501,13 @@ class TestPoolingNN(NNTestCase):
                 input, (1, 1, 1), (1, 1, 1), (0, 0, 0), (-3, 1, 1)
             )
 
+    @parametrize_test("dim", [1, 2, 3])
+    def test_lp_pool_rejects_zero_norm_type(self, dim):
+        fn = getattr(F, f"lp_pool{dim}d")
+        x = torch.randn(*([1, 3] + [8] * dim))
+        with self.assertRaisesRegex(ValueError, "norm_type"):
+            fn(x, norm_type=0, kernel_size=2)
+
 
 class TestPoolingNNDeviceType(NNTestCase):
     @expectedFailureMPS  # No double, float shape prop does not work

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1095,6 +1095,7 @@ def lp_pool3d(
 
     See :class:`~torch.nn.LPPool3d` for details.
     """
+    # isinstance guard skips this on fx.Proxy so test_fx.py PROXY_ITERATED still surfaces.
     if isinstance(norm_type, (int, float)) and norm_type == 0:
         raise ValueError("norm_type must not be 0")
     if has_torch_function_unary(input):
@@ -1138,6 +1139,7 @@ def lp_pool2d(
 
     See :class:`~torch.nn.LPPool2d` for details.
     """
+    # isinstance guard skips this on fx.Proxy so test_fx.py PROXY_ITERATED still surfaces.
     if isinstance(norm_type, (int, float)) and norm_type == 0:
         raise ValueError("norm_type must not be 0")
     if has_torch_function_unary(input):
@@ -1178,6 +1180,7 @@ def lp_pool1d(
 
     See :class:`~torch.nn.LPPool1d` for details.
     """
+    # isinstance guard skips this on fx.Proxy so test_fx.py PROXY_ITERATED still surfaces.
     if isinstance(norm_type, (int, float)) and norm_type == 0:
         raise ValueError("norm_type must not be 0")
     if has_torch_function_unary(input):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1095,6 +1095,8 @@ def lp_pool3d(
 
     See :class:`~torch.nn.LPPool3d` for details.
     """
+    if isinstance(norm_type, (int, float)) and norm_type == 0:
+        raise ValueError("norm_type must not be 0")
     if has_torch_function_unary(input):
         return handle_torch_function(
             lp_pool3d,
@@ -1136,6 +1138,8 @@ def lp_pool2d(
 
     See :class:`~torch.nn.LPPool2d` for details.
     """
+    if isinstance(norm_type, (int, float)) and norm_type == 0:
+        raise ValueError("norm_type must not be 0")
     if has_torch_function_unary(input):
         return handle_torch_function(
             lp_pool2d,
@@ -1174,6 +1178,8 @@ def lp_pool1d(
 
     See :class:`~torch.nn.LPPool1d` for details.
     """
+    if isinstance(norm_type, (int, float)) and norm_type == 0:
+        raise ValueError("norm_type must not be 0")
     if has_torch_function_unary(input):
         return handle_torch_function(
             lp_pool1d,


### PR DESCRIPTION
Fixes #134841.

## Summary

`F.lp_pool1d/2d/3d` compute `(avg_pool(x**p))**(1/p)`; with `norm_type=0` the `1/p` divides by zero and the result is NaN/Inf instead of a useful error. The `nn.LPPool*` modules forward to these and inherit the bug.

Raises `ValueError` at the top of each functional when `norm_type == 0`. Check is guarded by `isinstance(norm_type, (int, float))` so FX `symbolic_trace` (which passes `Proxy` for every arg) skips it and still hits the existing `Proxy object cannot be iterated` trace error that `test_nn_functional_lp_pool2d`/`3d` expect.

Picks up #143310 (stale) and works around the FX-tracing regression that blocked it.

## Test plan

`TestPoolingNN.test_lp_pool_rejects_zero_norm_type` parametrized over `dim ∈ {1, 2, 3}`.
