### PR TITLE
[sdpa] Fix export error with unbacked symbolic ints in attn_mask shape check

### DIFF
--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -278,22 +278,34 @@ inline bool check_attn_mask_shape(sdp_params const& params, bool debug) {
   auto qSize = params.query.sym_size(2);
   auto kvSize = params.key.sym_size(2);
   auto num_head = params.query.sym_size(1);
-  if (attn_mask.value().sym_size(-2) != qSize && attn_mask.value().sym_size(-2) != 1) {
+
+  // Use maybe_as_int() for comparisons to avoid guarding
+  // on unbacked symbolic ints (e.g. data-dependent dims during torch.export).
+  auto mask_seq = attn_mask.value().sym_size(-2);
+  if (mask_seq != qSize &&
+      mask_seq.maybe_as_int() != std::make_optional<int64_t>(1)) {
     return false;
   }
-  if (attn_mask.value().sym_size(-1) != kvSize && attn_mask.value().sym_size(-1) != 1) {
+  auto mask_kv = attn_mask.value().sym_size(-1);
+  if (mask_kv != kvSize &&
+      mask_kv.maybe_as_int() != std::make_optional<int64_t>(1)) {
     return false;
   }
   if (attn_mask.value().dim() == 2) {
     return true;
   } else if (attn_mask.value().dim() == 4) {
-    if ((attn_mask.value().sym_size(0) == 1 || attn_mask.value().sym_size(0) == batchSize)
-        && (attn_mask.value().sym_size(1) == 1 || attn_mask.value().sym_size(1) == num_head)) {
+    auto mask_b = attn_mask.value().sym_size(0);
+    auto mask_h = attn_mask.value().sym_size(1);
+    if ((mask_b == batchSize ||
+         mask_b.maybe_as_int() == std::make_optional<int64_t>(1)) &&
+        (mask_h == num_head ||
+         mask_h.maybe_as_int() == std::make_optional<int64_t>(1))) {
       return true;
     }
   }
   if (debug) {
-    TORCH_WARN("Please use the following attn mask shapes: ",
+    TORCH_WARN(
+        "Please use the following attn mask shapes: ",
         "2d - ({Q_seq_len, 1}  x {KV_seq_len, 1}); ",
         "4d - ({Batch, 1} x {Num_heads, 1} x {Q_seq_len, 1}  x {KV_seq_len, 1})");
   }

--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -279,16 +279,25 @@ inline bool check_attn_mask_shape(sdp_params const& params, bool debug) {
   auto kvSize = params.key.sym_size(2);
   auto num_head = params.query.sym_size(1);
 
-  // Use maybe_as_int() for comparisons to avoid guarding
-  // on unbacked symbolic ints (e.g. data-dependent dims during torch.export).
-  auto mask_seq = attn_mask.value().sym_size(-2);
-  if (mask_seq != qSize &&
-      mask_seq.maybe_as_int() != std::make_optional<int64_t>(1)) {
+  // Helper to check if a mask dim is compatible with a target dim.
+  // Compatible means: symbolically equal, or the mask dim is concretely 1
+  // (broadcast). Returns false (conservatively reject) when neither can be
+  // determined without guarding on unbacked symbolic ints.
+  auto dim_compatible = [](const c10::SymInt& mask_dim,
+                           const c10::SymInt& target_dim) -> bool {
+    if (TORCH_STATICALLY_KNOWN_TRUE(mask_dim == target_dim)) {
+      return true;
+    }
+    auto mask_int = mask_dim.maybe_as_int();
+    return mask_int.has_value() && *mask_int == 1;
+  };
+
+  auto mask_qsize = attn_mask.value().sym_size(-2);
+  if (!dim_compatible(mask_qsize, qSize)) {
     return false;
   }
-  auto mask_kv = attn_mask.value().sym_size(-1);
-  if (mask_kv != kvSize &&
-      mask_kv.maybe_as_int() != std::make_optional<int64_t>(1)) {
+  auto mask_kvsize = attn_mask.value().sym_size(-1);
+  if (!dim_compatible(mask_kvsize, kvSize)) {
     return false;
   }
   if (attn_mask.value().dim() == 2) {
@@ -296,10 +305,8 @@ inline bool check_attn_mask_shape(sdp_params const& params, bool debug) {
   } else if (attn_mask.value().dim() == 4) {
     auto mask_b = attn_mask.value().sym_size(0);
     auto mask_h = attn_mask.value().sym_size(1);
-    if ((mask_b == batchSize ||
-         mask_b.maybe_as_int() == std::make_optional<int64_t>(1)) &&
-        (mask_h == num_head ||
-         mask_h.maybe_as_int() == std::make_optional<int64_t>(1))) {
+    if (dim_compatible(mask_b, batchSize) &&
+        dim_compatible(mask_h, num_head)) {
       return true;
     }
   }

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2246,8 +2246,8 @@ class TestSDPA(NNTestCase):
 
             def forward(self, x):
                 keep = x.sum(dim=(-1, -2, -3)) != 0 # x: [B, 3, 12, 12]
-                x = x[keep] # [u0, 3, 12, 12].
-                flat = x.flatten(1) # [u0, 432]
+                x = x[keep]  # [u0, 3, 12, 12].
+                flat = x.flatten(1)  # [u0, 432]
                 q = self.proj_q(flat).view(-1, 1, self.num_heads, self.head_dim).transpose(1, 2)
                 k = self.proj_k(flat).view(-1, 1, self.num_heads, self.head_dim).transpose(1, 2)
                 v = self.proj_v(flat).view(-1, 1, self.num_heads, self.head_dim).transpose(1, 2)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2230,6 +2230,40 @@ class TestSDPA(NNTestCase):
             expected_shape[-1] = v_shape[-1]
             self.assertEqual(actual.shape, torch.Size(expected_shape))
 
+    def test_sdpa_export_unbacked_attn_mask(self, device):
+        """SDPA backend selection should not crash on unbacked symbolic mask shapes."""
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.num_heads = 4
+                self.head_dim = 8
+                self.hidden_size = self.num_heads * self.head_dim
+                # 3 * 12 * 12 = 432
+                self.proj_q = nn.Linear(432, self.hidden_size)
+                self.proj_k = nn.Linear(432, self.hidden_size)
+                self.proj_v = nn.Linear(432, self.hidden_size)
+
+            def forward(self, x):
+                keep = x.sum(dim=(-1, -2, -3)) != 0 # x: [B, 3, 12, 12]
+                x = x[keep] # [u0, 3, 12, 12].
+                flat = x.flatten(1) # [u0, 432]
+                q = self.proj_q(flat).view(-1, 1, self.num_heads, self.head_dim).transpose(1, 2)
+                k = self.proj_k(flat).view(-1, 1, self.num_heads, self.head_dim).transpose(1, 2)
+                v = self.proj_v(flat).view(-1, 1, self.num_heads, self.head_dim).transpose(1, 2)
+                attn_mask = torch.ones(
+                    (x.shape[0], 1, 1, 1), dtype=torch.bool, device=x.device
+                )
+                return F.scaled_dot_product_attention(
+                    q, k, v, attn_mask=attn_mask, dropout_p=0.0, is_causal=False
+                )
+
+        model = Model().eval().to(device)
+        x = torch.randn(4, 3, 12, 12, device=device)
+        x[0].zero_()
+
+        # Should not crash during export with unbacked symbolic mask batch dim
+        torch.export.export(model, args=(x,))
 
 class TestSDPACpuOnly(NNTestCase):
     """ Used to test CPU only functionality of scaled_dot_product_attention """

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2245,7 +2245,7 @@ class TestSDPA(NNTestCase):
                 self.proj_v = nn.Linear(432, self.hidden_size)
 
             def forward(self, x):
-                keep = x.sum(dim=(-1, -2, -3)) != 0 # x: [B, 3, 12, 12]
+                keep = x.sum(dim=(-1, -2, -3)) != 0  # x: [B, 3, 12, 12]
                 x = x[keep]  # [u0, 3, 12, 12].
                 flat = x.flatten(1)  # [u0, 432]
                 q = self.proj_q(flat).view(-1, 1, self.num_heads, self.head_dim).transpose(1, 2)


### PR DESCRIPTION
torch.export.export() fails with GuardOnDataDependentSymNode when tracing F.scaled_dot_product_attention on XPU with a 4D attention mask whose batch dimension is an unbacked symbolic integer (e.g., from data-dependent filtering).

Both CPU/XPU has this issue. see https://github.com/intel/torch-xpu-ops/issues/3418

# Rootcause
In check_attn_mask_shape (aten/src/ATen/native/transformers/sdp_utils_cpp.h), the mask shape validation compares symbolic dimensions against literal 1 using sym_size(0) == 1. During torch.export, if the batch dimension is an unbacked symbolic int u0 (produced by data-dependent operations like boolean indexing), this comparison triggers guard_bool on Eq(u0, 1), which is not allowed for data-dependent symbols.

# Fix
Replace direct sym_size() == 1 / sym_size() != 1 comparisons with
```
auto dim_compatible = [](const c10::SymInt& mask_dim,
                           const c10::SymInt& target_dim) -> bool {
    if (TORCH_STATICALLY_KNOWN_TRUE(mask_dim == target_dim)) {
      return true;
    }
    auto mask_int = mask_dim.maybe_as_int();
    return mask_int.has_value() && *mask_int == 1;
  };
```