### PR TITLE
[Inductor] Add config.batch_invariant in setup_batch_invariant ci perf

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -4197,6 +4197,7 @@ def setup_batch_invariant(args):
     if not torch.cuda.is_available():
         return
     setup_determinism(args)
+    inductor_config.batch_invariant = True
     inductor_config.triton.cudagraphs = False
     torch.backends.cuda.preferred_blas_library("cublaslt")
     torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = (False, False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181089
* __->__ #181088

Wires the `inductor_config.batch_invariant` flag into the dynamo benchmark harness so `--batch-invariant` runs actually turn it on.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @mlazos