### PR TITLE
[xpu] Relax tolerance for nondeterministic histogram op in TestCompositeCompliance.test_operator test

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20803,6 +20803,12 @@ op_db: list[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit'),
                # Not Implemented on XLA.
                DecorateInfo(unittest.skip("Skipped!"), 'TestOpInfo', device_type='xla'),
+           ),
+           decorators=(
+               DecorateInfo(
+                   toleranceOverride({torch.float32: tol(atol=5e-5, rtol=5e-6)}),
+                   'TestCompositeCompliance', 'test_operator', device_type="xpu",
+               ),
            )),
     OpInfo('histogramdd',
            dtypes=floating_types(),


### PR DESCRIPTION
Fix for: https://github.com/intel/torch-xpu-ops/issues/2751

## Summary
This PR adds an XPU-specific tolerance override for `histogram` in `torch/testing/_internal/common_methods_invocations.py` to stabilize:
`op_ut,third_party.torch-xpu-ops.test.xpu.test_ops_xpu.TestCompositeComplianceXPU,test_operator_histogram_xpu_float32`

## Detailed Description
Weighted `torch.histogram` on XPU can show small run-to-run `float32` differences because the XPU kernel accumulates results with `atomicAdd`. The XPU histogram path is also already explicitly marked as nondeterministic in the backend.

`TestCompositeCompliance.test_operator` executes the op multiple times and compares outputs, so these tiny numeric differences occasionally surface as flaky CI failures even though there is no functional correctness issue.

This change adds a narrow tolerance override for that specific XPU composite compliance case.
