### PR TITLE
[OpenReg]  Add Minimal torch.compile Backend to Validate PrivateUse1 Integration

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
@@ -1,0 +1,207 @@
+# Owner(s): ["module: PrivateUse1"]
+
+import torch
+import torch._dynamo
+from torch._dynamo.testing import CompileCounterWithBackend
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestBackendRegistration(TestCase):
+    def test_backend_in_list(self):
+        from torch._dynamo.backends.registry import list_backends
+
+        backends = list_backends(exclude_tags=())
+        self.assertIn("openreg", backends)
+
+
+class TestGraphCapture(TestCase):
+    def test_simple_compile(self):
+        @torch.compile(backend="openreg")
+        def fn(x):
+            return x + 1
+
+        x = torch.randn(4, device="openreg")
+        result = fn(x)
+        self.assertEqual(result, x + 1)
+
+    def test_compile_fullgraph_multiple_ops(self):
+        @torch.compile(backend="openreg", fullgraph=True)
+        def fn(x):
+            y = x + 1
+            z = y * 2
+            return torch.relu(z)
+
+        x = torch.randn(4, device="openreg")
+        result = fn(x)
+        self.assertEqual(result, torch.relu((x + 1) * 2))
+
+
+class TestFakeTensor(TestCase):
+    def test_device_metadata(self):
+        captured_gm = None
+
+        def capture_backend(gm, example_inputs):
+            nonlocal captured_gm
+            captured_gm = gm
+            return gm.forward
+
+        @torch.compile(backend=capture_backend)
+        def fn(x):
+            return x + 1
+
+        x = torch.randn(4, device="openreg")
+        fn(x)
+
+        self.assertIsNotNone(captured_gm)
+        for node in captured_gm.graph.nodes:
+            if node.op == "placeholder" and "val" in node.meta:
+                fake = node.meta["val"]
+                if isinstance(fake, torch.Tensor):
+                    self.assertEqual(fake.device.type, "openreg")
+
+    def test_fake_tensor_mode(self):
+        with torch._subclasses.fake_tensor.FakeTensorMode():
+            x = torch.empty(3, 3, device="openreg")
+            self.assertEqual(x.device.type, "openreg")
+            y = x + 1
+            self.assertEqual(y.device.type, "openreg")
+
+
+class TestGuards(TestCase):
+    def test_backend_recompilation(self):
+        counter = CompileCounterWithBackend("openreg")
+
+        @torch.compile(backend=counter)
+        def fn(x):
+            return x + 1
+
+        x = torch.randn(4, device="openreg")
+        fn(x)
+        self.assertEqual(counter.frame_count, 1)
+
+        fn(x)
+        self.assertEqual(counter.frame_count, 1)
+
+    def test_recompilation_on_shape_change(self):
+        counter = CompileCounterWithBackend("openreg")
+
+        @torch.compile(backend=counter)
+        def fn(x):
+            return x + 1
+
+        x1 = torch.randn(4, device="openreg")
+        fn(x1)
+        self.assertEqual(counter.frame_count, 1)
+
+        x2 = torch.randn(8, device="openreg")
+        fn(x2)
+        self.assertEqual(counter.frame_count, 2)
+
+
+class TestExecution(TestCase):
+    def test_autograd(self):
+
+        @torch.compile(backend="openreg")
+        def fn(x):
+            return (x * 2).sum()
+
+        x = torch.randn(4, device="openreg", requires_grad=True)
+        loss = fn(x)
+        loss.backward()
+
+        self.assertIsNotNone(x.grad)
+        self.assertEqual(x.grad, torch.full_like(x, 2.0))
+
+    def test_nn_module(self):
+
+        class SimpleModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        m = SimpleModule().to("openreg")
+        compiled_m = torch.compile(m, backend="openreg")
+
+        x = torch.randn(2, 4, device="openreg")
+        result = compiled_m(x)
+        self.assertEqual(result.device.type, "openreg")
+        self.assertEqual(result.shape, torch.Size([2, 4]))
+
+        eager_result = m(x)
+        self.assertEqual(result, eager_result)
+
+
+class TestDynamicShapes(TestCase):
+    def test_dynamic_shapes(self):
+
+        @torch.compile(backend="openreg", dynamic=True)
+        def fn(x):
+            return x + 1
+
+        x4 = torch.randn(4, device="openreg")
+        x8 = torch.randn(8, device="openreg")
+
+        self.assertEqual(fn(x4), x4 + 1)
+        self.assertEqual(fn(x8), x8 + 1)
+
+
+class TestGraphBreaks(TestCase):
+    def test_device_transfer_traces_fully(self):
+        @torch.compile(backend="openreg", fullgraph=True)
+        def fn(x):
+            y = x + 1
+            z = y.cpu()
+            return z * 2
+        x = torch.randn(4, device="openreg")
+        result = fn(x)
+        expected = (x + 1).cpu() * 2
+        self.assertEqual(result, expected)
+        self.assertEqual(result.device.type, "cpu")
+
+    def test_graph_break_resilience(self):
+        counter = CompileCounterWithBackend("openreg")
+        @torch.compile(backend=counter)
+        def fn(x):
+            y = x + 1
+            torch._dynamo.graph_break()
+            return y * 2
+        x = torch.randn(4, device="openreg")
+        result = fn(x)
+        self.assertEqual(result, (x + 1) * 2)
+        self.assertGreater(counter.frame_count, 1)
+
+
+class TestAutocast(TestCase):
+    def test_compile_with_autocast(self):
+
+        @torch.compile(backend="openreg")
+        def fn(x, y):
+            with torch.autocast(device_type="openreg", dtype=torch.float16):
+                return torch.mm(x, y)
+
+        x = torch.randn(2, 3, device="openreg")
+        y = torch.randn(3, 3, device="openreg")
+        result = fn(x, y)
+        self.assertEqual(result.dtype, torch.float16)
+
+
+class TestDefaultDevice(TestCase):
+    def test_compile_with_default_device(self):
+        self.addCleanup(lambda: torch.set_default_device(None))
+        torch.set_default_device("openreg")
+
+        @torch.compile(backend="openreg")
+        def fn(x):
+            y = torch.empty(4)
+            return x + y
+
+        x = torch.randn(4, device="openreg")
+        result = fn(x)
+        self.assertEqual(result.device.type, "openreg")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
@@ -100,7 +100,6 @@ class TestGuards(TestCase):
 
 class TestExecution(TestCase):
     def test_autograd(self):
-
         @torch.compile(backend="openreg")
         def fn(x):
             return (x * 2).sum()
@@ -113,7 +112,6 @@ class TestExecution(TestCase):
         self.assertEqual(x.grad, torch.full_like(x, 2.0))
 
     def test_nn_module(self):
-
         class SimpleModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -136,7 +134,6 @@ class TestExecution(TestCase):
 
 class TestDynamicShapes(TestCase):
     def test_dynamic_shapes(self):
-
         @torch.compile(backend="openreg", dynamic=True)
         def fn(x):
             return x + 1
@@ -155,6 +152,7 @@ class TestGraphBreaks(TestCase):
             y = x + 1
             z = y.cpu()
             return z * 2
+
         x = torch.randn(4, device="openreg")
         result = fn(x)
         expected = (x + 1).cpu() * 2
@@ -163,11 +161,13 @@ class TestGraphBreaks(TestCase):
 
     def test_graph_break_resilience(self):
         counter = CompileCounterWithBackend("openreg")
+
         @torch.compile(backend=counter)
         def fn(x):
             y = x + 1
             torch._dynamo.graph_break()
             return y * 2
+
         x = torch.randn(4, device="openreg")
         result = fn(x)
         self.assertEqual(result, (x + 1) * 2)
@@ -176,7 +176,6 @@ class TestGraphBreaks(TestCase):
 
 class TestAutocast(TestCase):
     def test_compile_with_autocast(self):
-
         @torch.compile(backend="openreg")
         def fn(x, y):
             with torch.autocast(device_type="openreg", dtype=torch.float16):

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/__init__.py
@@ -10,6 +10,7 @@ if sys.platform == "win32":
     del _load_dll_libraries
 
 import torch_openreg._C  # type: ignore[misc]
+import torch_openreg.compiler
 import torch_openreg.openreg
 
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/compiler.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/compiler.py
@@ -1,0 +1,29 @@
+import logging
+
+import torch
+from torch._dynamo.backends.registry import register_backend
+
+log = logging.getLogger(__name__)
+
+
+def openreg(gm, example_inputs):
+    gm.graph.lint()
+
+    for node in gm.graph.nodes:
+        if node.op == "placeholder" and "val" in node.meta:
+            fake = node.meta["val"]
+            if isinstance(fake, torch.Tensor):
+                assert fake.device.type in ("openreg", "cpu"), (
+                    f"Unexpected device {fake.device} in openreg backend"
+                )
+
+    gm.graph.eliminate_dead_code()
+    gm.recompile()
+
+    code = gm.graph.python_code("self")
+    log.debug("Compiled graph source:\n%s", code.src)
+
+    return gm.forward
+
+
+register_backend(compiler_fn=openreg, name="openreg")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/compiler.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/compiler.py
@@ -3,6 +3,7 @@ import logging
 import torch
 from torch._dynamo.backends.registry import register_backend
 
+
 log = logging.getLogger(__name__)
 
 
@@ -13,7 +14,7 @@ def openreg(gm, example_inputs):
         if node.op == "placeholder" and "val" in node.meta:
             fake = node.meta["val"]
             if isinstance(fake, torch.Tensor):
-                assert fake.device.type in ("openreg", "cpu"), (
+                assert fake.device.type in ("openreg", "cpu"), (  # noqa: S101
                     f"Unexpected device {fake.device} in openreg backend"
                 )
 


### PR DESCRIPTION
### Description:

Adds a minimal torch.compile backend to OpenReg that validates the PyTorch-side integration contract for PrivateUse1 devices.

The backend is a passthrough,  it receives the FX graph from Dynamo, performs lightweight validation using stable FX APIs (Graph.lint, eliminate_dead_code, recompile, python_code), checks FakeTensor device metadata on placeholder nodes, and returns gm.forward for eager execution through the existing CPU fallback. No lowering or device-specific compilation is performed.

### Changes:

torch_openreg/compiler.py: backend implementation, registered via register_backend
torch_openreg/__init__.py: import compiler module to trigger registration on package import
tests/test_compile.py: Tests covering registration, graph capture, FakeTensor device propagation, guard caching, recompilation, autograd, nn.Module, dynamic shapes, graph breaks, autocast, and default device interaction

Fixes: #181093 