### PR TITLE
Validate integral/bool dtype argument in nanmean

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1490,6 +1490,10 @@ Tensor& nanmean_out(
       self.is_floating_point() || self.is_complex(),
       "nanmean(): expected input to have floating point or complex dtype but got ",
       self.scalar_type());
+  TORCH_CHECK(
+      !opt_dtype.has_value() ||
+          !at::isIntegralType(*opt_dtype, /*includeBool=*/true),
+      "nanmean(): integral types and 'Bool' are not supported for the `dtype` argument, even for empty tensors.");
   const auto factor = at::native::isnan(self).logical_not_().sum(dim, keepdim);
   at::nansum_out(result, self, dim, keepdim, opt_dtype).div_(factor);
   return result;
@@ -1504,6 +1508,10 @@ Tensor nanmean(
       self.is_floating_point() || self.is_complex(),
       "nanmean(): expected input to have floating point or complex dtype but got ",
       self.scalar_type());
+  TORCH_CHECK(
+      !opt_dtype.has_value() ||
+          !at::isIntegralType(*opt_dtype, /*includeBool=*/true),
+      "nanmean(): integral types and 'Bool' are not supported for the `dtype` argument, even for empty tensors.");
   const auto factor =
       at::native::isnan(self.detach()).logical_not_().sum(dim, keepdim);
   return at::nansum(self, dim, keepdim, opt_dtype).div(factor);

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2357,6 +2357,27 @@ class TestReductions(TestCase):
             ):
                 torch.nanmean(t)
 
+    @onlyCPU
+    @dtypes(*integral_types_and(torch.bool))
+    def test_nanmean_integral_dtype_arg(self, device, dtype):
+        # A float input with an integral ``dtype`` argument must error out
+        # regardless of whether the input is empty. Previously the empty path
+        # silently returned tensor(nan); see #131043.
+        shapes = [(), (0,), (3,), (2, 0, 3)]
+        for shape in shapes:
+            t = make_tensor(shape, dtype=torch.float32, device=device)
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"nanmean\(\): integral types and 'Bool' are not supported for the `dtype` argument"
+            ):
+                torch.nanmean(t, dtype=dtype)
+            out = torch.empty((), dtype=dtype, device=device)
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"nanmean\(\): integral types and 'Bool' are not supported for the `dtype` argument"
+            ):
+                torch.nanmean(t, dtype=dtype, out=out)
+
     @skipIfMPS
     @precisionOverride({torch.float16: 1e-2, torch.bfloat16: 1e-2})
     @dtypes(*set(all_types_and(torch.half, torch.bfloat16)) - {torch.uint8})


### PR DESCRIPTION
## Summary
Fixes #131043. `nanmean` already rejects integral/bool `self` tensors (including empty ones), but it silently accepted integral/bool `dtype=` arguments when `self` was empty, returning `tensor(nan)` instead of erroring like the non-empty path.

## Repro
```python
>>> import torch
>>> torch.nanmean(torch.tensor([0., 1., 2.]), dtype=torch.int64)
RuntimeError: "nansum_cpu" not implemented for 'Long'
>>> torch.nanmean(torch.tensor([]), dtype=torch.int64)
tensor(nan)   # silently succeeds before this patch
```

## Fix
Add a `TORCH_CHECK` on `opt_dtype` in both `nanmean` and `nanmean_out` so an integral/bool `dtype` argument is rejected up front, regardless of input shape. The error mirrors the existing wording for integral `self` tensors.

## Test plan
- [x] New `test_nanmean_integral_dtype_arg` parametrized over all integral dtypes + bool, exercising empty and non-empty shapes and the `out=` variant
- [x] Existing `test_nanmean_integral_types` still passes
- [x] All 127 `nanmean`-tagged tests in `test/test_reductions.py` pass
- [x] `spin quicklint`: no lint issues

cc @malfet