### PR TITLE
inductor/flex_attention: fix fake block-mask generator for autotuner

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -6057,6 +6057,46 @@ class GraphModule(torch.nn.Module):
             "get_stride_and_maybe_freeze_layout should be called with FlexibleLayout nodes",
         )
 
+    @supported_platform
+    @skip_on_cpu
+    def test_fake_block_mask_generator_partial_full(self, device):
+        from unittest.mock import MagicMock, patch
+
+        from torch._inductor.kernel.flex.common import create_num_blocks_fake_generator
+
+        def causal(b, h, q, kv):
+            return q >= kv
+
+        bm = create_block_mask(causal, 1, 1, 512, 512, device=device)
+        max_blocks = bm.kv_indices.shape[-1]
+
+        mock_x = MagicMock()
+        mock_x.get_size.return_value = [1, 1, bm.kv_num_blocks.shape[-1]]
+        mock_x.get_dtype.return_value = torch.int32
+        mock_x.get_device.return_value = torch.device(device)
+
+        with patch("torch._inductor.kernel.flex.common.V") as mock_V:
+            mock_V.graph.sizevars.optimization_hint.side_effect = lambda x: int(x)
+            mock_V.graph.sizevars.optimization_hints.side_effect = lambda xs: [
+                int(x) for x in xs
+            ]
+            partial_val = (
+                create_num_blocks_fake_generator(bm.kv_indices, is_partial=True)(mock_x)
+                .max()
+                .item()
+            )
+            full_val = (
+                create_num_blocks_fake_generator(bm.full_kv_indices, is_partial=False)(
+                    mock_x
+                )
+                .max()
+                .item()
+            )
+
+        self.assertEqual(partial_val + full_val, max_blocks)
+        self.assertLessEqual(partial_val, 1)
+        self.assertGreaterEqual(full_val, 0)
+
 
 class TestBlockMask(InductorTestCase):
     def setUp(self):

--- a/torch/_inductor/kernel/flex/common.py
+++ b/torch/_inductor/kernel/flex/common.py
@@ -335,16 +335,24 @@ def create_num_blocks_fake_generator(sparse_indices, is_partial=None):
     that we are computing 0 blocks for each row, which would provide bogus
     autotuning results.
 
-    In this case, we choose to use min(16, max_block) blocks, because I
-    (Horace) think it'll probably result in pretty representative performance.
-    If it's too short then prefetching won't help. If it's too long then
-    autotuning will take longer for no good reason.
+    is_partial controls the estimate:
+    - is_partial=True  (partial/boundary blocks): uses min(1, max_blocks).
+      For typical causal masks each Q-row has exactly 1 boundary block.
+      Some masks (e.g. sliding-window + causal) may have 2, but 1 is a
+      reasonable approximation that avoids inflating autotuner cost.
+    - is_partial=False (full/interior blocks): uses max(0, max_blocks - 1),
+      complementary to the partial estimate so partial + full = total.
+    - is_partial=None  (default): uses max_blocks unchanged (legacy behavior).
     """
 
     def create_num_blocks_fake(x) -> torch.Tensor:
         num_blocks_for_autotuning = V.graph.sizevars.optimization_hint(
             sparse_indices.shape[-1]
         )
+        # Use 1 as a conservative estimate for partial (boundary) blocks.
+        # For typical causal masks, each Q-row has exactly 1 boundary block.
+        # Some masks (e.g. sliding-window + causal) may have 2, but 1 is a
+        # reasonable approximation that avoids over-inflating autotuner cost.
         if is_partial is True:
             num_blocks_for_autotuning = min(1, num_blocks_for_autotuning)
         elif is_partial is False:

--- a/torch/_inductor/kernel/flex/common.py
+++ b/torch/_inductor/kernel/flex/common.py
@@ -326,7 +326,7 @@ def create_indices_fake(x) -> torch.Tensor:
     return indices
 
 
-def create_num_blocks_fake_generator(sparse_indices):
+def create_num_blocks_fake_generator(sparse_indices, is_partial=None):
     """Create a fake num_blocks that is used for autotuning.
 
     The idea here is that we need to create a real tensor with real data
@@ -345,6 +345,10 @@ def create_num_blocks_fake_generator(sparse_indices):
         num_blocks_for_autotuning = V.graph.sizevars.optimization_hint(
             sparse_indices.shape[-1]
         )
+        if is_partial is True:
+            num_blocks_for_autotuning = min(1, num_blocks_for_autotuning)
+        elif is_partial is False:
+            num_blocks_for_autotuning = max(0, num_blocks_for_autotuning - 1)
         size = V.graph.sizevars.optimization_hints(x.get_size())
         return torch.full(
             size,

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -491,9 +491,9 @@ def flex_attention(
         + list(mask_mod_other_buffers)
     )
     input_gen_fns = {
-        5: create_num_blocks_fake_generator(kv_indices),
+        5: create_num_blocks_fake_generator(kv_indices, is_partial=True),
         6: create_indices_fake,
-        7: create_num_blocks_fake_generator(full_kv_indices),
+        7: create_num_blocks_fake_generator(full_kv_indices, is_partial=False),
         8: create_indices_fake,
     }
 
@@ -1026,13 +1026,21 @@ def flex_attention_backward(*args, **kwargs):
         + joint_outputs.mutated_grads
     )
     input_gen_fns = {
-        8: create_num_blocks_fake_generator(kv_indices),  # kv_num_blocks
+        8: create_num_blocks_fake_generator(
+            kv_indices, is_partial=True
+        ),  # kv_num_blocks
         9: create_indices_fake,
-        10: create_num_blocks_fake_generator(q_indices),  # q_num_blocks
+        10: create_num_blocks_fake_generator(
+            q_indices, is_partial=True
+        ),  # q_num_blocks
         11: create_indices_fake,
-        12: create_num_blocks_fake_generator(full_kv_indices),  # full_kv_num_blocks
+        12: create_num_blocks_fake_generator(
+            full_kv_indices, is_partial=False
+        ),  # full_kv_num_blocks
         13: create_indices_fake,
-        14: create_num_blocks_fake_generator(full_q_indices),  # full_q_num_blocks
+        14: create_num_blocks_fake_generator(
+            full_q_indices, is_partial=False
+        ),  # full_q_num_blocks
         15: create_indices_fake,
     }
 

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -408,9 +408,9 @@ def create_flex_decoding_kernel(*args, **kwargs):
     )
 
     input_gen_fns = {
-        5: create_num_blocks_fake_generator(kv_indices),
+        5: create_num_blocks_fake_generator(kv_indices, is_partial=True),
         6: create_indices_fake,
-        7: create_num_blocks_fake_generator(full_kv_indices),
+        7: create_num_blocks_fake_generator(full_kv_indices, is_partial=False),
         8: create_indices_fake,
     }
 

--- a/torch/_inductor/kernel/flex/flex_flash_attention.py
+++ b/torch/_inductor/kernel/flex/flex_flash_attention.py
@@ -443,8 +443,6 @@ def create_flex_flash_attention_kernel(
     if not choices:
         raise RuntimeError(f"CuteDSL template failed: {error}")
 
-    if not choices:
-        raise RuntimeError(f"CuteDSL template failed: {error}")
     input_gen_fns: dict[int, Callable] | None = None
     if has_full_blocks:
         input_gen_fns = {

--- a/torch/_inductor/kernel/flex/flex_flash_attention.py
+++ b/torch/_inductor/kernel/flex/flex_flash_attention.py
@@ -443,12 +443,14 @@ def create_flex_flash_attention_kernel(
     if not choices:
         raise RuntimeError(f"CuteDSL template failed: {error}")
 
+    if not choices:
+        raise RuntimeError(f"CuteDSL template failed: {error}")
     input_gen_fns: dict[int, Callable] | None = None
     if has_full_blocks:
         input_gen_fns = {
-            4: create_num_blocks_fake_generator(kv_indices),
+            4: create_num_blocks_fake_generator(kv_indices, is_partial=True),
             5: create_indices_fake,
-            6: create_num_blocks_fake_generator(full_kv_indices),
+            6: create_num_blocks_fake_generator(full_kv_indices, is_partial=False),
             7: create_indices_fake,
         }
 
@@ -671,9 +673,9 @@ def create_flex_flash_attention_backward_kernel(
     input_gen_fns: dict[int, Callable] | None = None
     if has_block_mask:
         input_gen_fns = {
-            8: create_num_blocks_fake_generator(q_indices),
+            8: create_num_blocks_fake_generator(q_indices, is_partial=True),
             9: create_indices_fake,
-            10: create_num_blocks_fake_generator(full_q_indices),
+            10: create_num_blocks_fake_generator(full_q_indices, is_partial=False),
             11: create_indices_fake,
         }
 


### PR DESCRIPTION
Fixes #180651

## Summary

When the Inductor autotuner benchmarks flex attention configs, it needs fake input tensors to drive the kernels. One of those inputs is the block-mask, which tells the kernel how many KV blocks each Q-row needs to process.

The block-mask splits KV blocks into two disjoint sets per Q-row:
- **Partial (boundary) blocks** : straddle the mask edge, need expensive `mask_mod` evaluation
- **Full (interior) blocks** : entirely inside the mask, skip `mask_mod`

The invariant is: `partial + full = total_blocks_to_process`

**The bug:** `create_num_blocks_fake_generator` was shared for both, filling both with `max_blocks`. For a typical causal mask with Q=512, KV=1664, BLOCK_SIZE=128, the real counts look like `partial=[1,1,1,1]`, `full=[9,10,11,12]`, but the fake generator was producing `partial=13, full=13, total=26` (double counted).

This caused two problems:
1. ~2× inflation of total work per Q-row
2. ~13× inflation of `mask_mod` evaluations

Since `mask_mod` cost scales as `SPARSE_KV_BLOCK_SIZE // BLOCK_N` per block, the inflation hit different `BLOCK_N` configs unevenly, distorting the autotuner's ranking and potentially causing it to select a slower config.

## Fix

Add an `is_partial` parameter to `create_num_blocks_fake_generator`:
- `is_partial=True` -> `min(1, max_blocks)` : realistic boundary block count for typical masks
- `is_partial=False` -> `max(0, max_blocks - 1)` : complementary interior count
- `is_partial=None` (default) — preserves original behavior for backward compatibility

Applied to all 8 call sites across forward and backward passes in `flex_attention.py`, `flex_decoding.py`, and `flex_flash_attention.py`.

Let me know if this looks good or if any changes are needed!

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo