### PR TITLE
Fix torch.compile crash with inference_mode and view ops in forward (#180823)

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8334,6 +8334,17 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         compiled = torch.compile(m, backend="aot_eager", fullgraph=True)
         self.assertEqual(compiled(x), m(x))
 
+    def test_inference_mode_wrapping_compile_with_view(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x.view(2, 20, 8, 64).transpose(1, 2)
+
+        m = M().eval()
+        x = torch.randn(2, 20, 512)
+        compiled = torch.compile(m, backend="aot_eager", fullgraph=True)
+        with torch.inference_mode():
+            self.assertEqual(compiled(x), m(x))
+
     def test_if_cond_nn_mod1(self):
         class MockModule(torch.nn.Module):
             def __init__(self, output_relu=True):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8317,6 +8317,23 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
             res = opt_fn(x)
             self.assertEqual(ref, res)
 
+    def test_inference_mode_inside_forward_with_view(self):
+        # Regression test: inference_mode() inside a compiled forward with
+        # view ops used to fail because C++ functionalization cannot handle
+        # inference tensors (no version counter), and graph inputs created
+        # outside inference_mode had their storage missing from
+        # _storage_to_base.
+        class M(torch.nn.Module):
+            def forward(self, x):
+                k = x.view(2, 20, 8, 64).transpose(1, 2)
+                with torch.inference_mode():
+                    return k.transpose(-2, -1)
+
+        m = M().eval()
+        x = torch.randn(2, 20, 512)
+        compiled = torch.compile(m, backend="inductor", fullgraph=True)
+        self.assertEqual(compiled(x), m(x))
+
     def test_if_cond_nn_mod1(self):
         class MockModule(torch.nn.Module):
             def __init__(self, output_relu=True):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -8331,7 +8331,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
 
         m = M().eval()
         x = torch.randn(2, 20, 512)
-        compiled = torch.compile(m, backend="inductor", fullgraph=True)
+        compiled = torch.compile(m, backend="aot_eager", fullgraph=True)
         self.assertEqual(compiled(x), m(x))
 
     def test_if_cond_nn_mod1(self):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -4248,6 +4248,16 @@ def forward(self, tangents_1):
             out_test = aot_mod(inp)
         self.assertEqual(out_ref, out_test)
 
+    def test_inference_mode_inside_forward_with_view(self):
+        def f(x):
+            y = x.view(4, 4)
+            with torch.inference_mode():
+                return y.transpose(0, 1)
+
+        inp = torch.randn(16)
+        compiled_f = aot_function(f, nop)
+        self.assertEqual(compiled_f(inp), f(inp))
+
     def test_default_partitioner_saves_symints_not_tensors_for_bw(self):
         """
         In this test, the important thing is that primals_1 is **only** needed in the backward

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1466,11 +1466,9 @@ class GraphModule(torch.nn.Module):
         x = torch.randn(8, requires_grad=False)
         y = torch.randn(8, requires_grad=False)
 
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "Inplace update to inference tensor outside InferenceMode is not allowed",
-        ):
-            opt_fn(x, y)
+        expected = fn(x.clone(), y)
+        result = opt_fn(x.clone(), y)
+        self.assertEqual(expected, result)
 
     def test_simple_module(self):
         mod = torch.nn.Linear(8, 8)

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -467,6 +467,7 @@ class FunctionalTensorMode(TorchDispatchMode):
 
         if _get_prev_mode() is None:
             self.enter_stack.append(True)
+            self._inference_mode_on_entry = torch.is_inference_mode_enabled()
             return super().__enter__()
         else:
             self.enter_stack.append(False)
@@ -496,15 +497,14 @@ class FunctionalTensorMode(TorchDispatchMode):
             return NotImplemented
 
         # C++ functionalization cannot operate on inference tensors because
-        # they lack a version counter.  Temporarily exit inference mode for
-        # the whole dispatch so that tensors created by decomposition and by
-        # the C++ Functionalize kernel are normal tensors.  This is safe
-        # because functionalization only runs during compilation, where
-        # inference_mode semantics (version-counter elision, inference-tensor
-        # tagging) are not needed — the real inference_mode is applied at
-        # runtime by the graph nodes emitted by Dynamo.
+        # they lack a version counter.  When inference_mode() is used inside
+        # the user's forward (entered via _enter_inference_mode nodes in the
+        # graph), we must temporarily exit it so tensors created during
+        # functionalization are normal tensors.  However, if inference mode
+        # was already active when FunctionalTensorMode was entered (i.e. the
+        # caller wrapped compilation in inference_mode), we must NOT exit it
         _inference_mode_ctx = None
-        if torch.is_inference_mode_enabled():
+        if torch.is_inference_mode_enabled() and not self._inference_mode_on_entry:
             _inference_mode_ctx = torch.autograd.grad_mode._enter_inference_mode(False)
         try:
             return self._torch_dispatch_impl(func, types, args, kwargs)

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -505,9 +505,7 @@ class FunctionalTensorMode(TorchDispatchMode):
         # runtime by the graph nodes emitted by Dynamo.
         _inference_mode_ctx = None
         if torch.is_inference_mode_enabled():
-            _inference_mode_ctx = torch.autograd.grad_mode._enter_inference_mode(
-                False
-            )
+            _inference_mode_ctx = torch.autograd.grad_mode._enter_inference_mode(False)
         try:
             return self._torch_dispatch_impl(func, types, args, kwargs)
         finally:
@@ -521,7 +519,6 @@ class FunctionalTensorMode(TorchDispatchMode):
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> Any:
-
         if (
             func not in FunctionalTensor.metadata_fns
             and self._can_decompose(func, args, kwargs)

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -467,7 +467,6 @@ class FunctionalTensorMode(TorchDispatchMode):
 
         if _get_prev_mode() is None:
             self.enter_stack.append(True)
-            self._inference_mode_on_entry = torch.is_inference_mode_enabled()
             return super().__enter__()
         else:
             self.enter_stack.append(False)
@@ -497,20 +496,16 @@ class FunctionalTensorMode(TorchDispatchMode):
             return NotImplemented
 
         # C++ functionalization cannot operate on inference tensors because
-        # they lack a version counter.  When inference_mode() is used inside
-        # the user's forward (entered via _enter_inference_mode nodes in the
-        # graph), we must temporarily exit it so tensors created during
-        # functionalization are normal tensors.  However, if inference mode
-        # was already active when FunctionalTensorMode was entered (i.e. the
-        # caller wrapped compilation in inference_mode), we must NOT exit it
-        _inference_mode_ctx = None
-        if torch.is_inference_mode_enabled() and not self._inference_mode_on_entry:
-            _inference_mode_ctx = torch.autograd.grad_mode._enter_inference_mode(False)
-        try:
-            return self._torch_dispatch_impl(func, types, args, kwargs)
-        finally:
-            if _inference_mode_ctx is not None:
-                torch.autograd.grad_mode._exit_inference_mode(_inference_mode_ctx)
+        # they lack a version counter.  Temporarily exit inference mode so
+        # tensors created during functionalization are normal tensors.  Since
+        # c10::InferenceMode(false) also sets grad_mode=true as a side effect,
+        # pair it with no_grad() to keep grad off -- this ensures output
+        # requires_grad stays False and AOT Autograd's inference-only graph
+        # decision is not disturbed.
+        if torch.is_inference_mode_enabled():
+            with torch.inference_mode(False), torch.no_grad():
+                return self._torch_dispatch_impl(func, types, args, kwargs)
+        return self._torch_dispatch_impl(func, types, args, kwargs)
 
     def _torch_dispatch_impl(
         self,

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -495,6 +495,33 @@ class FunctionalTensorMode(TorchDispatchMode):
         if _has_unrecognized_tensor_types(types):
             return NotImplemented
 
+        # C++ functionalization cannot operate on inference tensors because
+        # they lack a version counter.  Temporarily exit inference mode for
+        # the whole dispatch so that tensors created by decomposition and by
+        # the C++ Functionalize kernel are normal tensors.  This is safe
+        # because functionalization only runs during compilation, where
+        # inference_mode semantics (version-counter elision, inference-tensor
+        # tagging) are not needed — the real inference_mode is applied at
+        # runtime by the graph nodes emitted by Dynamo.
+        _inference_mode_ctx = None
+        if torch.is_inference_mode_enabled():
+            _inference_mode_ctx = torch.autograd.grad_mode._enter_inference_mode(
+                False
+            )
+        try:
+            return self._torch_dispatch_impl(func, types, args, kwargs)
+        finally:
+            if _inference_mode_ctx is not None:
+                torch.autograd.grad_mode._exit_inference_mode(_inference_mode_ctx)
+
+    def _torch_dispatch_impl(
+        self,
+        func: OpOverload,
+        types: Sequence[type],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+
         if (
             func not in FunctionalTensor.metadata_fns
             and self._can_decompose(func, args, kwargs)


### PR DESCRIPTION
Fixes #180823

### Root Cause
torch.compile with inference_mode() and view ops crashes during the AOT Autograd functionalization phase. When AOT Autograd replays the FX graph for functionalization, _enter_inference_mode nodes actually execute, causing tensors created during functionalization to be inference tensors. C++ functionalization needs set_version_counter to link views with their base, but inference tensors lack a version counter — this fails with Cannot set version_counter for inference tensor.

Dynamo already handles this at the tracing phase (maybe_disable_inference_mode in convert_frame.py), but this protection did not extend to the AOT Autograd functionalization phase.

### Fix
Temporarily exit inference mode in `FunctionalTensorMode.__torch_dispatch__`. Since c10::InferenceMode(false) also turns grad back on as a side effect (c10/core/InferenceMode.h:59), pair it with no_grad() to keep output requires_grad unchanged — mirroring the pattern in torch._dynamo.utils.maybe_disable_inference_mode. Runtime behavior is unaffected since _enter_inference_mode nodes still execute normally in the compiled graph.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98