### PR TITLE
tools/stats: add script to generate test-times.json from local JUnit XML reports

### DIFF
--- a/tools/stats/generate_test_times_from_reports.py
+++ b/tools/stats/generate_test_times_from_reports.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Generate test-times.json and test-class-times.json from local JUnit XML reports.
+
+For use by external CI pipelines (e.g. RISC-V) that cannot reach PyTorch's
+internal S3/ClickHouse infrastructure.  Output schema is identical to
+import_test_stats.get_test_times() / get_test_class_times() so no consumer
+changes are required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import DefaultDict
+from collections import defaultdict
+
+
+# ---------------------------------------------------------------------------
+# Core aggregation
+# ---------------------------------------------------------------------------
+
+
+def _parse_xml(report: Path) -> tuple[dict[str, float], dict[str, float]]:
+    """Parse a single JUnit XML report.
+
+    Returns
+    -------
+    module_times : dict[str, float]
+        Total elapsed seconds keyed by *invoking module* name.  The invoking
+        module is the directory that contains the XML file, matching the
+        convention used by upload_test_stats.py (``report.parent.name``).
+    class_times : dict[str, float]
+        Total elapsed seconds keyed by ``"<classname>::<invoking_module>"``.
+        Entries with a missing or empty classname are skipped.
+    """
+    invoking_module = report.parent.name
+    module_total: float = 0.0
+    class_totals: DefaultDict[str, float] = defaultdict(float)
+
+    try:
+        tree = ET.parse(report)  # noqa: S314 – local files only, no network input
+    except ET.ParseError:
+        # Malformed XML is silently skipped; a warning is printed so the
+        # operator is aware but the rest of the run is unaffected.
+        print(f"WARNING: skipping malformed XML: {report}", file=sys.stderr)
+        return {}, {}
+
+    for testcase in tree.iter("testcase"):
+        raw_time = testcase.get("time", "")
+        try:
+            elapsed = float(raw_time)
+        except ValueError:
+            # Missing or non-numeric time attribute – skip this testcase.
+            continue
+
+        module_total += elapsed
+
+        classname = testcase.get("classname", "").strip()
+        if classname:
+            class_totals[f"{classname}::{invoking_module}"] += elapsed
+
+    module_times = {invoking_module: module_total} if module_total > 0 else {}
+    return module_times, dict(class_totals)
+
+
+def collect_times(
+    reports_dir: Path,
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Walk *reports_dir* recursively and aggregate all JUnit XML files.
+
+    Returns
+    -------
+    module_times, class_times
+        Aggregated dictionaries as described in ``_parse_xml``.
+    """
+    all_module_times: DefaultDict[str, float] = defaultdict(float)
+    all_class_times: DefaultDict[str, float] = defaultdict(float)
+
+    xml_files = list(reports_dir.rglob("*.xml"))
+    if not xml_files:
+        print(
+            f"WARNING: no XML reports found under {reports_dir}",
+            file=sys.stderr,
+        )
+
+    for xml_file in xml_files:
+        mod_times, cls_times = _parse_xml(xml_file)
+        for module, t in mod_times.items():
+            all_module_times[module] += t
+        for cls, t in cls_times.items():
+            all_class_times[cls] += t
+
+    return dict(all_module_times), dict(all_class_times)
+
+
+# ---------------------------------------------------------------------------
+# JSON construction
+# ---------------------------------------------------------------------------
+
+
+def _build_payload(
+    times: dict[str, float],
+    job_name: str,
+    test_config: str,
+) -> dict[str, dict[str, dict[str, float]]]:
+    """Wrap *times* in the three-level lookup structure expected by run_test.py.
+
+    The three keys correspond to the fallback hierarchy:
+        [job_name][test_config]   – exact match
+        ["default"][test_config]  – any job, specific config
+        ["default"]["default"]    – ultimate fallback
+    """
+    inner = {test_config: times, "default": times}
+    return {
+        job_name: inner,
+        "default": inner,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build test-times.json / test-class-times.json from local JUnit XML "
+            "reports for use by run_test.py shard balancing on external CI."
+        ),
+    )
+    parser.add_argument(
+        "--reports-dir",
+        required=True,
+        type=Path,
+        metavar="DIR",
+        help="Root directory that contains JUnit XML reports (searched recursively).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        metavar="DIR",
+        help=(
+            "Directory where test-times.json and test-class-times.json are written. "
+            "Created if it does not exist."
+        ),
+    )
+    parser.add_argument(
+        "--job-name",
+        required=True,
+        metavar="NAME",
+        help=(
+            'Top-level key in the output JSON, e.g. "riscv64-linux-py3.12 / test". '
+            "Use the same value that the CI job would report."
+        ),
+    )
+    parser.add_argument(
+        "--test-config",
+        default="default",
+        metavar="CONFIG",
+        help=(
+            'Second-level key in the output JSON, e.g. "default" or "slow". '
+            "Matches the TEST_CONFIG environment variable used by run_test.py."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    reports_dir: Path = args.reports_dir
+    output_dir: Path = args.output_dir
+
+    if not reports_dir.is_dir():
+        print(f"ERROR: reports-dir does not exist: {reports_dir}", file=sys.stderr)
+        return 1
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Scanning XML reports under: {reports_dir}")
+    module_times, class_times = collect_times(reports_dir)
+    print(
+        f"Aggregated {len(module_times)} module(s) "
+        f"and {len(class_times)} class(es) from XML reports."
+    )
+
+    test_times_path = output_dir / "test-times.json"
+    class_times_path = output_dir / "test-class-times.json"
+
+    test_times_payload = _build_payload(module_times, args.job_name, args.test_config)
+    class_times_payload = _build_payload(class_times, args.job_name, args.test_config)
+
+    test_times_path.write_text(json.dumps(test_times_payload, indent=2), encoding="utf-8")
+    class_times_path.write_text(json.dumps(class_times_payload, indent=2), encoding="utf-8")
+
+    print(f"Wrote: {test_times_path}")
+    print(f"Wrote: {class_times_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/stats/generate_test_times_from_reports.py
+++ b/tools/stats/generate_test_times_from_reports.py
@@ -14,7 +14,6 @@ import json
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import DefaultDict
 from collections import defaultdict
 
 
@@ -38,10 +37,10 @@ def _parse_xml(report: Path) -> tuple[dict[str, float], dict[str, float]]:
     """
     invoking_module = report.parent.name
     module_total: float = 0.0
-    class_totals: DefaultDict[str, float] = defaultdict(float)
+    class_totals: defaultdict[str, float] = defaultdict(float)
 
     try:
-        tree = ET.parse(report)  # noqa: S314 – local files only, no network input
+        tree = ET.parse(report)
     except ET.ParseError:
         # Malformed XML is silently skipped; a warning is printed so the
         # operator is aware but the rest of the run is unaffected.
@@ -76,8 +75,8 @@ def collect_times(
     module_times, class_times
         Aggregated dictionaries as described in ``_parse_xml``.
     """
-    all_module_times: DefaultDict[str, float] = defaultdict(float)
-    all_class_times: DefaultDict[str, float] = defaultdict(float)
+    all_module_times: defaultdict[str, float] = defaultdict(float)
+    all_class_times: defaultdict[str, float] = defaultdict(float)
 
     xml_files = list(reports_dir.rglob("*.xml"))
     if not xml_files:
@@ -195,8 +194,12 @@ def main(argv: list[str] | None = None) -> int:
     test_times_payload = _build_payload(module_times, args.job_name, args.test_config)
     class_times_payload = _build_payload(class_times, args.job_name, args.test_config)
 
-    test_times_path.write_text(json.dumps(test_times_payload, indent=2), encoding="utf-8")
-    class_times_path.write_text(json.dumps(class_times_payload, indent=2), encoding="utf-8")
+    test_times_path.write_text(
+        json.dumps(test_times_payload, indent=2), encoding="utf-8"
+    )
+    class_times_path.write_text(
+        json.dumps(class_times_payload, indent=2), encoding="utf-8"
+    )
 
     print(f"Wrote: {test_times_path}")
     print(f"Wrote: {class_times_path}")

--- a/tools/stats/generate_test_times_from_reports.py
+++ b/tools/stats/generate_test_times_from_reports.py
@@ -13,8 +13,8 @@ import argparse
 import json
 import sys
 import xml.etree.ElementTree as ET
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 
 
 # ---------------------------------------------------------------------------

--- a/tools/test/test_generate_test_times_from_reports.py
+++ b/tools/test/test_generate_test_times_from_reports.py
@@ -1,0 +1,341 @@
+"""Tests for tools/stats/generate_test_times_from_reports.py.
+
+Run with:
+    pytest tools/test/test_generate_test_times_from_reports.py -v
+
+All tests are stdlib + pytest only; torch is not required.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from tools.stats.generate_test_times_from_reports import (
+    _build_payload,
+    collect_times,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_xml(path: Path, content: str) -> None:
+    """Write *content* to *path*, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _parse_xml / collect_times
+# ---------------------------------------------------------------------------
+
+
+class TestCollectTimes(unittest.TestCase):
+    """Tests for XML scanning and time aggregation."""
+
+    def test_basic_single_module(self) -> None:
+        """A single XML file with two testcases produces correct module total."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_xml(
+                root / "test_foo" / "TEST-test_foo.xml",
+                """\
+                <?xml version="1.0" ?>
+                <testsuite>
+                  <testcase classname="TestFoo" name="test_a" time="1.5"/>
+                  <testcase classname="TestFoo" name="test_b" time="0.5"/>
+                </testsuite>
+                """,
+            )
+            mod_times, cls_times = collect_times(root)
+
+        self.assertAlmostEqual(mod_times["test_foo"], 2.0)
+        self.assertAlmostEqual(cls_times["TestFoo::test_foo"], 2.0)
+
+    def test_multiple_modules_are_aggregated_independently(self) -> None:
+        """Two modules in different subdirectories accumulate separately."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_xml(
+                root / "test_alpha" / "TEST-test_alpha.xml",
+                """\
+                <?xml version="1.0" ?>
+                <testsuite>
+                  <testcase classname="Alpha" name="test_1" time="3.0"/>
+                </testsuite>
+                """,
+            )
+            _write_xml(
+                root / "test_beta" / "TEST-test_beta.xml",
+                """\
+                <?xml version="1.0" ?>
+                <testsuite>
+                  <testcase classname="Beta" name="test_1" time="7.0"/>
+                </testsuite>
+                """,
+            )
+            mod_times, _ = collect_times(root)
+
+        self.assertAlmostEqual(mod_times["test_alpha"], 3.0)
+        self.assertAlmostEqual(mod_times["test_beta"], 7.0)
+        self.assertEqual(len(mod_times), 2)
+
+    def test_multiple_xml_files_in_same_module_directory_are_summed(self) -> None:
+        """Multiple XML files under one directory are summed into one module entry."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for i, t in enumerate([1.0, 2.0, 3.0]):
+                _write_xml(
+                    root / "test_multi" / f"TEST-shard{i}.xml",
+                    f"""\
+                    <?xml version="1.0" ?>
+                    <testsuite>
+                      <testcase classname="Multi" name="test_{i}" time="{t}"/>
+                    </testsuite>
+                    """,
+                )
+            mod_times, _ = collect_times(root)
+
+        self.assertAlmostEqual(mod_times["test_multi"], 6.0)
+
+    def test_nested_subdirectory_structure(self) -> None:
+        """XML files in a deeply nested path use the immediate parent as the module name."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_xml(
+                root / "a" / "b" / "test_deep" / "TEST-test_deep.xml",
+                """\
+                <?xml version="1.0" ?>
+                <testsuite>
+                  <testcase classname="Deep" name="test_x" time="4.2"/>
+                </testsuite>
+                """,
+            )
+            mod_times, _ = collect_times(root)
+
+        # The invoking module is always report.parent.name, i.e. the immediate parent dir.
+        self.assertIn("test_deep", mod_times)
+        self.assertAlmostEqual(mod_times["test_deep"], 4.2)
+
+    def test_testcase_missing_time_attribute_is_skipped(self) -> None:
+        """A testcase with no 'time' attribute does not raise and contributes 0."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_xml(
+                root / "test_notimes" / "TEST.xml",
+                """\
+                <?xml version="1.0" ?>
+                <testsuite>
+                  <testcase classname="NoTime" name="test_a"/>
+                  <testcase classname="NoTime" name="test_b" time="2.0"/>
+                </testsuite>
+                """,
+            )
+            mod_times, cls_times = collect_times(root)
+
+        self.assertAlmostEqual(mod_times["test_notimes"], 2.0)
+        self.assertAlmostEqual(cls_times["NoTime::test_notimes"], 2.0)
+
+    def test_testcase_with_non_numeric_time_is_skipped(self) -> None:
+        """A time attribute that cannot be parsed as float is silently ignored."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_xml(
+                root / "test_badtime" / "TEST.xml",
+                """\
+                <?xml version="1.0" ?>
+                <testsuite>
+                  <testcase classname="C" name="test_a" time="N/A"/>
+                  <testcase classname="C" name="test_b" time="1.0"/>
+                </testsuite>
+                """,
+            )
+            mod_times, _ = collect_times(root)
+
+        self.assertAlmostEqual(mod_times["test_badtime"], 1.0)
+
+    def test_malformed_xml_is_skipped_gracefully(self) -> None:
+        """A corrupt XML file prints a warning and does not abort the entire run."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bad = root / "test_corrupt" / "bad.xml"
+            bad.parent.mkdir(parents=True)
+            bad.write_text("<<<not xml>>>", encoding="utf-8")
+
+            good = root / "test_good" / "good.xml"
+            _write_xml(
+                good,
+                """\
+                <?xml version="1.0" ?>
+                <testsuite>
+                  <testcase classname="Good" name="test_ok" time="1.0"/>
+                </testsuite>
+                """,
+            )
+            mod_times, _ = collect_times(root)
+
+        # The corrupt file contributes nothing; the good file is processed normally.
+        self.assertNotIn("test_corrupt", mod_times)
+        self.assertIn("test_good", mod_times)
+
+    def test_empty_reports_directory_returns_empty_dicts(self) -> None:
+        """An empty reports directory produces empty dicts without raising."""
+        with TemporaryDirectory() as tmp:
+            mod_times, cls_times = collect_times(Path(tmp))
+
+        self.assertEqual(mod_times, {})
+        self.assertEqual(cls_times, {})
+
+    def test_testcase_without_classname_is_excluded_from_class_times(self) -> None:
+        """Testcases with an empty or absent classname do not appear in class_times."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_xml(
+                root / "test_noclassname" / "TEST.xml",
+                """\
+                <?xml version="1.0" ?>
+                <testsuite>
+                  <testcase name="test_a" time="5.0"/>
+                  <testcase classname="" name="test_b" time="3.0"/>
+                </testsuite>
+                """,
+            )
+            mod_times, cls_times = collect_times(root)
+
+        # Module total includes all timed cases.
+        self.assertAlmostEqual(mod_times["test_noclassname"], 8.0)
+        # No class entry because classname was absent / empty.
+        self.assertEqual(cls_times, {})
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _build_payload
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPayload(unittest.TestCase):
+    """Tests for the three-level JSON payload construction."""
+
+    def setUp(self) -> None:
+        self.times = {"test_foo": 1.5, "test_bar": 2.5}
+        self.job_name = "riscv64-linux / test"
+        self.config = "default"
+
+    def test_exact_job_and_config_key_is_present(self) -> None:
+        payload = _build_payload(self.times, self.job_name, self.config)
+        self.assertIn(self.job_name, payload)
+        self.assertIn(self.config, payload[self.job_name])
+        self.assertEqual(payload[self.job_name][self.config], self.times)
+
+    def test_default_job_fallback_is_present(self) -> None:
+        payload = _build_payload(self.times, self.job_name, self.config)
+        self.assertIn("default", payload)
+        self.assertIn(self.config, payload["default"])
+
+    def test_default_default_fallback_is_present(self) -> None:
+        payload = _build_payload(self.times, self.job_name, self.config)
+        self.assertIn("default", payload["default"])
+        self.assertEqual(payload["default"]["default"], self.times)
+
+    def test_non_default_config_name(self) -> None:
+        """A non-'default' config name is stored under both the job and 'default'."""
+        payload = _build_payload(self.times, self.job_name, "slow")
+        self.assertIn("slow", payload[self.job_name])
+        self.assertIn("slow", payload["default"])
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: main() end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestMainEndToEnd(unittest.TestCase):
+    """End-to-end tests that exercise the CLI entry point."""
+
+    def _run(self, reports_dir: Path, output_dir: Path, **kwargs: str) -> int:
+        argv = [
+            "--reports-dir", str(reports_dir),
+            "--output-dir", str(output_dir),
+            "--job-name", kwargs.get("job_name", "test-job"),
+            "--test-config", kwargs.get("test_config", "default"),
+        ]
+        return main(argv)
+
+    def test_output_files_are_created(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            reports = root / "reports"
+            output = root / "output"
+            _write_xml(
+                reports / "test_bar" / "TEST.xml",
+                """\
+                <?xml version="1.0" ?>
+                <testsuite>
+                  <testcase classname="Bar" name="test_1" time="2.0"/>
+                </testsuite>
+                """,
+            )
+            rc = self._run(reports, output)
+            self.assertEqual(rc, 0)
+            self.assertTrue((output / "test-times.json").exists())
+            self.assertTrue((output / "test-class-times.json").exists())
+
+    def test_output_json_structure_and_values(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            reports = root / "reports"
+            output = root / "output"
+            _write_xml(
+                reports / "test_baz" / "TEST.xml",
+                """\
+                <?xml version="1.0" ?>
+                <testsuite>
+                  <testcase classname="Baz" name="test_x" time="3.0"/>
+                  <testcase classname="Baz" name="test_y" time="1.0"/>
+                </testsuite>
+                """,
+            )
+            self._run(reports, output, job_name="my-job", test_config="slow")
+
+            with open(output / "test-times.json") as f:
+                times = json.load(f)
+            with open(output / "test-class-times.json") as f:
+                class_times = json.load(f)
+
+        # Module times
+        self.assertAlmostEqual(times["my-job"]["slow"]["test_baz"], 4.0)
+        self.assertAlmostEqual(times["default"]["default"]["test_baz"], 4.0)
+
+        # Class times
+        self.assertAlmostEqual(
+            class_times["my-job"]["slow"]["Baz::test_baz"], 4.0
+        )
+
+    def test_nonexistent_reports_dir_returns_nonzero(self) -> None:
+        with TemporaryDirectory() as tmp:
+            output = Path(tmp) / "output"
+            rc = main([
+                "--reports-dir", "/this/does/not/exist",
+                "--output-dir", str(output),
+                "--job-name", "x",
+            ])
+        self.assertNotEqual(rc, 0)
+
+    def test_output_dir_is_created_if_missing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            reports = root / "reports"
+            reports.mkdir()
+            output = root / "deeply" / "nested" / "output"
+            self._run(reports, output)
+            self.assertTrue(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test/test_generate_test_times_from_reports.py
+++ b/tools/test/test_generate_test_times_from_reports.py
@@ -25,6 +25,7 @@ from tools.stats.generate_test_times_from_reports import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _write_xml(path: Path, content: str) -> None:
     """Write *content* to *path*, creating parent directories as needed."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -260,10 +261,14 @@ class TestMainEndToEnd(unittest.TestCase):
 
     def _run(self, reports_dir: Path, output_dir: Path, **kwargs: str) -> int:
         argv = [
-            "--reports-dir", str(reports_dir),
-            "--output-dir", str(output_dir),
-            "--job-name", kwargs.get("job_name", "test-job"),
-            "--test-config", kwargs.get("test_config", "default"),
+            "--reports-dir",
+            str(reports_dir),
+            "--output-dir",
+            str(output_dir),
+            "--job-name",
+            kwargs.get("job_name", "test-job"),
+            "--test-config",
+            kwargs.get("test_config", "default"),
         ]
         return main(argv)
 
@@ -313,18 +318,21 @@ class TestMainEndToEnd(unittest.TestCase):
         self.assertAlmostEqual(times["default"]["default"]["test_baz"], 4.0)
 
         # Class times
-        self.assertAlmostEqual(
-            class_times["my-job"]["slow"]["Baz::test_baz"], 4.0
-        )
+        self.assertAlmostEqual(class_times["my-job"]["slow"]["Baz::test_baz"], 4.0)
 
     def test_nonexistent_reports_dir_returns_nonzero(self) -> None:
         with TemporaryDirectory() as tmp:
             output = Path(tmp) / "output"
-            rc = main([
-                "--reports-dir", "/this/does/not/exist",
-                "--output-dir", str(output),
-                "--job-name", "x",
-            ])
+            rc = main(
+                [
+                    "--reports-dir",
+                    "/this/does/not/exist",
+                    "--output-dir",
+                    str(output),
+                    "--job-name",
+                    "x",
+                ]
+            )
         self.assertNotEqual(rc, 0)
 
     def test_output_dir_is_created_if_missing(self) -> None:


### PR DESCRIPTION
## Summary

External architecture CI pipelines cannot reach PyTorch's internal ClickHouse/S3 infrastructure to pull the test timing data that `run_test.py` uses for time-based sharding. Without it, the sharding falls back to round-robin, producing unbalanced shards and inflated wall time.

This PR adds `tools/stats/generate_test_times_from_reports.py`, a stdlib-only script that builds `test-times.json` and `test-class-times.json` from the JUnit XML files that a standard `run_test.py` invocation already produces under `test/test-reports/`. The output format is identical to what `load_test_times_from_file()` expects, so no changes to the consumer side are needed.

## How it works

- Recursively walks `test/test-reports/**/*.xml`
- Aggregates `<testcase time="...">` durations per invoking module (using `report.parent.name`, consistent with `upload_test_stats.py`)
- Writes both file-level and class-level timing JSON into `.additional_ci_files/`
- Populates all three lookup paths that `run_test.py` falls back through (`[job_name][config]`, `["default"][config]`, `["default"]["default"]`), so the file works regardless of which CI env vars are set

Typical usage after a test run:

\`\`\`bash
python tools/stats/generate_test_times_from_reports.py \
    --reports-dir test/test-reports \
    --output-dir .additional_ci_files \
    --job-name "riscv64-linux-py3.12 / test" \
    --test-config default
\`\`\`

## Changes

- `tools/stats/generate_test_times_from_reports.py` — new script
- `tools/test/test_generate_test_times_from_reports.py` — 17 unit tests, stdlib+pytest, no torch required

## Test plan

\`\`\`
pytest tools/test/test_generate_test_times_from_reports.py -v
# All 17 passed
\`\`\`

Tests cover: basic aggregation, multiple modules, empty dir, malformed XML (graceful skip), missing \`time\` attribute, nested subdirectory edge case, CLI exit codes, and full end-to-end JSON structure validation.

Related to #180975 (Phase 1.3: "Generate and maintain `test_times.json` for RISC-V CI sharding" — accepted RISC-V enablement tracking issue). Prior context: RFC #171659, #141550.

cc @mruberry @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
