### PR TITLE
[inductor][rocm] Add multi-warp alt configs for INNER persistent reduction on HIP

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4100,6 +4100,32 @@ def _persistent_reduction_configs(
                         reduction_hint=reduction_hint,
                     )
                 ]
+                if torch.version.hip:
+                    # Alternative with multi-warp reduction so the autotuner
+                    # can pick between num_warps=1 (no shared memory) and a
+                    # multi-warp variant (uses shared-memory reduction).
+                    configs.append(
+                        triton_config_reduction(
+                            size_hints,
+                            x_block,
+                            rnumel,
+                            register_intensive=True,
+                            num_warps=2,
+                            min_num_warps=1,
+                            reduction_hint=reduction_hint,
+                        )
+                    )
+                    configs.append(
+                        triton_config_reduction(
+                            size_hints,
+                            x_block,
+                            rnumel,
+                            register_intensive=True,
+                            num_warps=4,
+                            min_num_warps=1,
+                            reduction_hint=reduction_hint,
+                        )
+                    )
 
         elif reduction_hint == ReductionHint.OUTER:
             configs = configs[-1:]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

For INNER persistent reductions with rnumel <= 1024 and xnumel >= 1024, inductor
currently generates a single config with num_warps=1 (suppressing shared-memory
reduction on CUDA). On HIP, this leaves no room for the autotuner to explore
whether a multi-warp variant with shared-memory reduction is faster.

Add two additional configs with num_warps=2 and num_warps=4 on HIP so the
autotuner can choose among them. On a HuggingFace inference benchmark this
yields ~+0.5% geomean speedup with a ~+1% increase in compile time. Individual
wins include ElectraForCausalLM (+9%), DebertaV2ForMaskedLM (+8%),
BertForMaskedLM (+4%), RobertaForCausalLM (+3%).

Authored with Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben