### PR TITLE
[ROCm][CI] Update ROCm build-environment for operator_microbenchmark.yml

### DIFF
--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -105,7 +105,7 @@ jobs:
     name: opmicrobenchmark-build-rocm
     uses: ./.github/workflows/_linux-build.yml
     with:
-      build-environment: linux-jammy-rocm-py3_10
+      build-environment: linux-jammy-rocm-py3.10-mi355
       docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3-benchmarks
       test-matrix: |
         { include: [


### PR DESCRIPTION
To consolidate all build_environment values that correspond to a particular gfx arch, since we already updated the build_environment for trunk.yml, which uses the same MI355 runners.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang