### PR TITLE
Remove static initializers from lexer.cpp (#181118)

### DIFF
--- a/torch/csrc/jit/frontend/lexer.cpp
+++ b/torch/csrc/jit/frontend/lexer.cpp
@@ -6,56 +6,85 @@
 
 namespace torch::jit {
 
-static const std::unordered_map<int, int> binary_prec = {
-    {TK_IF, 1},
-    {TK_FOR, 1},
-    {TK_AND, 2},
-    {TK_OR, 2},
-    // reserve a level for unary not
-    {TK_IN, 4},
-    {TK_NOTIN, 4},
-    {'<', 4},
-    {'>', 4},
-    {TK_IS, 4},
-    {TK_ISNOT, 4},
-    {TK_EQ, 4},
-    {TK_LE, 4},
-    {TK_GE, 4},
-    {TK_NE, 4},
-    {'|', 5},
-    {'^', 6},
-    {'&', 7},
-    {TK_LSHIFT, 8},
-    {TK_RSHIFT, 8},
-    {'+', 9},
-    {'-', 9},
-    {'*', 10},
-    {'/', 10},
-    {TK_FLOOR_DIV, 10},
-    {'%', 10},
-    {'@', 10},
-    {TK_POW, 11},
-};
+namespace {
 
-static const std::unordered_map<int, int> unary_prec = {
-    {TK_NOT, 3},
-    {'~', 3},
-    {'-', 10},
-    {'*', 10},
-};
+constexpr int getBinaryPrec(int kind) {
+  switch (kind) {
+    case TK_IF:
+    case TK_FOR:
+      return 1;
+    case TK_AND:
+    case TK_OR:
+      return 2;
+    // reserve a level for unary not
+    case TK_IN:
+    case TK_NOTIN:
+    case '<':
+    case '>':
+    case TK_IS:
+    case TK_ISNOT:
+    case TK_EQ:
+    case TK_LE:
+    case TK_GE:
+    case TK_NE:
+      return 4;
+    case '|':
+      return 5;
+    case '^':
+      return 6;
+    case '&':
+      return 7;
+    case TK_LSHIFT:
+    case TK_RSHIFT:
+      return 8;
+    case '+':
+    case '-':
+      return 9;
+    case '*':
+    case '/':
+    case TK_FLOOR_DIV:
+    case '%':
+    case '@':
+      return 10;
+    case TK_POW:
+      return 11;
+    default:
+      return -1;
+  }
+}
+
+constexpr int getUnaryPrec(int kind) {
+  switch (kind) {
+    case TK_NOT:
+    case '~':
+      return 3;
+    case '-':
+    case '*':
+      return 10;
+    default:
+      return -1;
+  }
+}
+
+} // namespace
 
 bool SharedParserData::isUnary(int kind, int* prec) {
-  auto it = unary_prec.find(kind);
-  if (it != unary_prec.end()) {
-    *prec = it->second;
+  int p = getUnaryPrec(kind);
+  if (p >= 0) {
+    if (prec) {
+      *prec = p;
+    }
     return true;
   }
   return false;
 }
+
 bool SharedParserData::isBinary(int kind, int* prec) {
-  auto it = binary_prec.find(kind);
-  if (it != binary_prec.end()) {
-    *prec = it->second;
+  int p = getBinaryPrec(kind);
+  if (p >= 0) {
+    if (prec) {
+      *prec = p;
+    }
     return true;
   }
   return false;
@@ -69,7 +98,7 @@ C10_EXPORT int stringToKind(const std::string& str) {
       ret_str_to_kind[std::string(1, *tok)] = static_cast<unsigned char>(*tok);
     }
 #define DEFINE_CASE(tok, _, str) \
-  if (std::string(str) != "")    \
+  if (!std::string(str).empty()) \
     ret_str_to_kind[str] = tok;
     TC_FORALL_TOKEN_KINDS(DEFINE_CASE)
 #undef DEFINE_CASE
@@ -83,8 +112,9 @@ C10_EXPORT int stringToKind(const std::string& str) {
 }
 
 C10_EXPORT std::string kindToString(int kind) {
-  if (kind < 256)
+  if (kind < 256) {
     return std::string(1, static_cast<char>(kind));
+  }
   switch (kind) {
 #define DEFINE_CASE(tok, str, _) \
   case tok:                      \


### PR DESCRIPTION
Summary:

Remove static initializers from lexer.cpp to improve dyld load time.

The `_GLOBAL__sub_I_lexer.cpp` static initializer was consuming ~1.5% (1M out of 68.21M invocations) of dyld initialization time due to the construction of two `std::unordered_map<int, int>` static variables (`binary_prec` and `unary_prec`).

Replace static unordered_maps with constexpr switch-case lookup functions:
- `getBinaryPrec()` - returns precedence for binary operators
- `getUnaryPrec()` - returns precedence for unary operators

This eliminates the hash table allocations at static initialization time while maintaining the same O(1) lookup performance (switch-case on int is typically optimized to a jump table by the compiler).

Test Plan: Build verification - no functional changes to precedence lookup logic.

Differential Revision: D101361532


