### PR TITLE
[Inductor] Properly record aliased inputs in output code benchmark_compiled_module (#181119)

### DIFF
--- a/test/inductor/test_triton_wrapper.py
+++ b/test/inductor/test_triton_wrapper.py
@@ -2,6 +2,7 @@
 
 import inspect
 import os
+import re
 import subprocess
 import sys
 
@@ -13,6 +14,10 @@ from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 
 class TestTritonWrapper(TestCase):
+    def setUp(self):
+        super().setUp()
+        PyCodeCache.cache_clear()
+
     def get_compiled_module(self):
         compiled_module = None
         for v in PyCodeCache.modules:
@@ -89,6 +94,43 @@ class TestTritonWrapper(TestCase):
             env={**os.environ, "PYTHONPATH": augmented_pp},
         ).decode()
         self.assertTrue(len(bench_out) > 0)
+
+    def test_get_args_preserves_aliased_inputs(self):
+        @torch.compile
+        def f(x, y, empty_bool, empty_long):
+            return x + y, empty_bool.logical_not(), empty_long + 1
+
+        base = torch.arange(64, device=GPU_TYPE, dtype=torch.long)
+        x = torch.as_strided(base, (3, 4), (4, 1), 2)
+        y = torch.as_strided(base, (3, 4), (4, 1), 10)
+        empty_bool = torch.empty((0, 3), device=GPU_TYPE, dtype=torch.bool)
+        empty_long = torch.empty((0, 2), device=GPU_TYPE, dtype=torch.long)
+        f(x, y, empty_bool, empty_long)
+
+        compiled_module = self.get_compiled_module()
+        get_args_src = inspect.getsource(compiled_module.get_args)
+        shared_storage_names = re.findall(
+            r"(_shared_storage_\d+) = rand_strided\(",
+            get_args_src,
+        )
+        self.assertEqual(len(shared_storage_names), 1, get_args_src)
+
+        shared_storage = shared_storage_names[0]
+        aliased_view_lines = re.findall(
+            rf"^\s+\w+ = torch\.as_strided\({shared_storage}, .*$",
+            get_args_src,
+            re.MULTILINE,
+        )
+        self.assertEqual(len(aliased_view_lines), 2, get_args_src)
+
+        args = compiled_module.get_args()
+        recreated_x, recreated_y, _, _ = args
+
+        self.assertEqual(
+            recreated_x.untyped_storage().data_ptr(),
+            recreated_y.untyped_storage().data_ptr(),
+        )
+        self.assertEqual(len(args), 4)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -38,6 +38,7 @@ from torch.fx.experimental.symbolic_shapes import (
     SymTypes,
 )
 from torch.fx.node import _get_qualified_name
+from torch.multiprocessing.reductions import StorageWeakRef
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.singleton_int import SingletonInt
 from torch.utils._sympy.symbol import symbol_is_type, SymT
@@ -97,6 +98,15 @@ ReuseKey = tuple[torch.device, torch.dtype, str, bool, int]
 CommBufferReuseKey = tuple[torch.device, torch.dtype, str, "ir.CommBufferType", str]
 BufferLike = ir.Buffer | WorkspaceArg
 FxConversionFunc = Callable[["WrapperLine"], None]
+
+
+@dataclasses.dataclass
+class BenchmarkStorageGroup:
+    buffer_name: str
+    nbytes: int
+    device: Any
+    dtype: Any
+    inputs: dict[str, tuple[list[int], list[int]]]
 
 
 def buffer_reuse_key(node: BufferLike) -> ReuseKey:
@@ -2536,6 +2546,32 @@ class PythonWrapperCodegen(CodeGen):
                     f'raise TypeError("Failed to pickle opaque type {type(value)} for variable {name}: {str(e)}")'
                 )
 
+        # Preserve shared non-empty input storages so benchmark code does not
+        # explode large aliased views into separate allocations.
+        storage_groups: dict[StorageWeakRef, BenchmarkStorageGroup] = {}
+        aliased_input_specs: dict[str, tuple[str, Any, Any]] = {}
+        example_inputs = V.graph.example_inputs
+
+        if example_inputs is not None:
+            for name, ex in zip(V.graph.graph_inputs.keys(), example_inputs):
+                if not isinstance(ex, torch.Tensor):
+                    continue
+                storage = ex.untyped_storage()
+                nbytes = storage.nbytes()
+                storage_key = StorageWeakRef(storage)
+                group = storage_groups.get(storage_key)
+                if group is None:
+                    group = BenchmarkStorageGroup(
+                        buffer_name=f"_shared_storage_{len(storage_groups)}",
+                        nbytes=nbytes,
+                        device=ex.device,
+                        dtype=ex.dtype,
+                        inputs={},
+                    )
+                    storage_groups[storage_key] = group
+
+                group.inputs[name] = (list(ex.shape), list(ex.stride()))
+
         # Generate get_args() to create input tensors separately from benchmarking
         output.writelines(["", "", "def get_args():"])
         with output.indent():
@@ -2561,6 +2597,17 @@ class PythonWrapperCodegen(CodeGen):
                     # these 'global var_name' lines
                     output.writeline(f"global {name}")
                     add_torchbind_input(name, torchbind_obj)
+
+            # Generate shared storage buffers for aliased inputs
+            for group in storage_groups.values():
+                if len(group.inputs) < 2:
+                    continue
+                numel = group.nbytes // torch._utils._element_size(group.dtype)
+                output.writeline(
+                    f"{group.buffer_name} = rand_strided(({numel},), (1,), device='{group.device}', dtype={group.dtype})"
+                )
+                for name, (shape, stride) in group.inputs.items():
+                    aliased_input_specs[name] = (group.buffer_name, shape, stride)
 
             for name, value in V.graph.graph_inputs.items():
                 if isinstance(value, sympy.Symbol) and isinstance(
@@ -2592,6 +2639,13 @@ class PythonWrapperCodegen(CodeGen):
                     )
                 elif isinstance(value, ir.OpaqueObjectState):
                     output.writeline(f"{name} = None")
+                elif name in aliased_input_specs:
+                    buf_name, shape, stride = aliased_input_specs[name]
+                    output.writeline(
+                        f"{name} = torch.as_strided({buf_name}, "
+                        f"{self.codegen_python_shape_tuple(shape)}, "
+                        f"{self.codegen_python_shape_tuple(stride)})"
+                    )
                 else:
                     shape = V.graph.sizevars.optimization_hints(
                         value.get_size(), fallback=42


### PR DESCRIPTION
Summary:


Previously for aliased inputs, the resulting benchmark_compiled_module for the output_code did not properly allocate views for each of the aliased input, instead adding rand_strided for each one. This will OOM certain repros. This fix ensures that aliased inputs share the same common storage buffer

Test Plan: test_get_args_preserves_aliased_inputs

Reviewed By: njriasan

Differential Revision: D101886759




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos