### PR TITLE
Rename tensorlist autograd metadata

### DIFF
--- a/torch/_library/autograd.py
+++ b/torch/_library/autograd.py
@@ -127,7 +127,7 @@ def supports_tensorlist(cls: Any) -> Any:
     orig_apply = cls.apply
 
     @dataclass
-    class Metadata:
+    class TensorListMetadata:
         input_spec: _pytree.TreeSpec
         output_spec: _pytree.TreeSpec | None = None
         result_is_tuple: bool | None = None
@@ -135,7 +135,7 @@ def supports_tensorlist(cls: Any) -> Any:
     def new_forward(ctx, *args):
         metadata = args[-1]
         args = args[:-1]
-        if not isinstance(metadata, Metadata):
+        if not isinstance(metadata, TensorListMetadata):
             raise NotImplementedError(
                 "NYI: calling supports_tensorlist autograd.Function.forward directly. "
                 "You should probably be calling .apply instead. "
@@ -203,7 +203,7 @@ def supports_tensorlist(cls: Any) -> Any:
 
     def new_apply(*args):
         flat_args, input_spec = _pytree.tree_flatten(args, is_leaf=not_list_of_tensor)
-        metadata = Metadata(input_spec)
+        metadata = TensorListMetadata(input_spec)
         result = orig_apply(*flat_args, metadata)  # type: ignore[misc]
         if metadata.output_spec is None:
             raise AssertionError("metadata.output_spec must not be None")


### PR DESCRIPTION
## Summary
- Rename the `supports_tensorlist()` wrapper metadata dataclass to `TensorListMetadata`.
- Update the local type check and construction sites to use the clearer name.

## Root cause problem
`torch/_library/autograd.py` defines two nested dataclasses named `Metadata`: one in `make_autograd_impl()` for dispatch/autograd invocation state and one in `supports_tensorlist()` for pytree flattening state. The duplicate local names make the file harder to read and review.

## Proposed fix
Rename the `supports_tensorlist()` dataclass to `TensorListMetadata`, matching its specific role while preserving the original generated autograd metadata name.

## Why this is the right long term fix
The tensor-list wrapper metadata is distinct from dispatch metadata and is only used inside `supports_tensorlist()`. Giving it a specific name documents the ownership boundary without changing behavior or exposing a new public API.

Drafted via Codex, published after manual review by @bobrenjc93