### PR TITLE
Consolidate Python library global state

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -116,6 +116,43 @@ class CustomOpTestCaseBase(TestCase):
         return torch._custom_op.impl.get_op(qualname)
 
 
+class TestLibraryGlobalState(TestCase):
+    def test_global_state_aliases(self):
+        import torch._custom_op.impl as legacy_custom_op
+        import torch._library.custom_ops as custom_ops_impl
+        import torch._library.fake_class_registry as fake_class_registry
+        import torch._library.fake_impl as fake_impl
+        import torch._library.opaque_object as opaque_object
+        import torch._library.simple_registry as simple_registry
+        import torch._library.triton as triton
+        from torch._library.global_state import library_state
+
+        self.assertIs(torch.library._impls, library_state.impls)
+        self.assertIs(torch.library._defs, library_state.defs)
+        self.assertIs(torch.library._keep_alive, library_state.keep_alive)
+        self.assertIs(simple_registry.singleton, library_state.simple_registry)
+        self.assertIs(custom_ops_impl.OPDEFS, library_state.custom_opdefs)
+        self.assertIs(custom_ops_impl.OPDEF_TO_LIB, library_state.custom_opdef_to_lib)
+        self.assertIs(
+            legacy_custom_op.global_registry, library_state.legacy_custom_op_registry
+        )
+        self.assertIs(
+            fake_class_registry.global_fake_class_registry,
+            library_state.fake_class_registry,
+        )
+        self.assertIs(triton.triton_ops_to_kernels, library_state.triton_ops_to_kernels)
+        self.assertIs(opaque_object._OPAQUE_TYPES, library_state.opaque_types)
+        self.assertIs(
+            opaque_object._OPAQUE_TYPES_BY_NAME, library_state.opaque_types_by_name
+        )
+
+        prev_ctx_getter = library_state.global_ctx_getter
+        with fake_impl.set_ctx_getter(lambda: "ctx"):
+            self.assertEqual(fake_impl.global_ctx_getter(), "ctx")
+            self.assertEqual(library_state.global_ctx_getter(), "ctx")
+        self.assertIs(library_state.global_ctx_getter, prev_ctx_getter)
+
+
 @requires_compile
 class TestCustomOpTesting(CustomOpTestCaseBase):
     @parametrize("check_gradients", (False, "auto"))

--- a/torch/_custom_op/impl.py
+++ b/torch/_custom_op/impl.py
@@ -11,6 +11,7 @@ import torch
 import torch._C as _C
 import torch._library.infer_schema
 import torch.library as library
+from torch._library.global_state import library_state
 from torch._library.infer_schema import infer_schema
 from torch.library import get_ctx
 from torchgen.model import (
@@ -123,7 +124,7 @@ def custom_op(qualname: str, manual_schema: str | None = None) -> typing.Callabl
 # An example usage is FakeTensor: FakeTensor checks if a specific operator
 # has an implementation registered via the CustomOp API.
 # Indexed by qualname (e.g. aten::foo)
-global_registry: dict[str, "CustomOp"] = {}
+global_registry: dict[str, "CustomOp"] = library_state.legacy_custom_op_registry
 
 
 class CustomOp:

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -15,6 +15,7 @@ from torch.utils._exposed_in import exposed_in
 
 from . import autograd, utils
 from .effects import EffectType
+from .global_state import library_state
 
 
 device_types_t = str | Sequence[str] | None
@@ -958,8 +959,8 @@ def increment_version(val: Any) -> None:
 # decorator.
 
 
-OPDEF_TO_LIB: dict[str, "torch.library.Library"] = {}
-OPDEFS: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
+OPDEF_TO_LIB: dict[str, "torch.library.Library"] = library_state.custom_opdef_to_lib
+OPDEFS: weakref.WeakValueDictionary = library_state.custom_opdefs
 
 
 def get_library_allowing_overwrite(

--- a/torch/_library/fake_class_registry.py
+++ b/torch/_library/fake_class_registry.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Protocol
 
 import torch
+from torch._library.global_state import library_state
 from torch._library.utils import parse_namespace
 from torch.utils._python_dispatch import _disable_current_modes
 
@@ -199,7 +200,9 @@ class FakeClassRegistry:
             )
 
 
-global_fake_class_registry = FakeClassRegistry()
+global_fake_class_registry: FakeClassRegistry = (
+    library_state.get_or_create_fake_class_registry(FakeClassRegistry)
+)
 
 
 # TODO: add this check at compile time for __obj_flatten__.

--- a/torch/_library/fake_impl.py
+++ b/torch/_library/fake_impl.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from typing_extensions import deprecated
 
 import torch
+from torch._library.global_state import library_state
 from torch._library.utils import Kernel, RegistrationHandle
 
 
@@ -117,18 +118,21 @@ def get_none():
     return None
 
 
-global_ctx_getter: Callable = get_none
+library_state.global_ctx_getter = get_none
+
+
+def global_ctx_getter():
+    return library_state.global_ctx_getter()
 
 
 @contextlib.contextmanager
 def set_ctx_getter(ctx_getter):
-    global global_ctx_getter
-    prev = global_ctx_getter
+    prev = library_state.global_ctx_getter
     try:
-        global_ctx_getter = ctx_getter
+        library_state.global_ctx_getter = ctx_getter
         yield
     finally:
-        global_ctx_getter = prev
+        library_state.global_ctx_getter = prev
 
 
 class FakeImplCtx:

--- a/torch/_library/fake_impl.py
+++ b/torch/_library/fake_impl.py
@@ -114,13 +114,6 @@ def construct_meta_kernel(qualname: str, fake_impl_holder: FakeImplHolder) -> Ca
     return meta_kernel
 
 
-def get_none():
-    return None
-
-
-library_state.global_ctx_getter = get_none
-
-
 def global_ctx_getter():
     return library_state.global_ctx_getter()
 

--- a/torch/_library/global_state.py
+++ b/torch/_library/global_state.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
+from weakref import WeakKeyDictionary, WeakValueDictionary
+
+
+def _default_ctx_getter() -> None:
+    return None
+
+
+_T = TypeVar("_T")
+
+
+class LibraryGlobalState:
+    """
+    Central storage for Python-side torch.library registries.
+
+    These containers are intentionally still re-exported from their historical
+    modules for compatibility. New shared registry state should live here so
+    lifecycle and cleanup behavior is easier to audit.
+    """
+
+    def __init__(self) -> None:
+        self.impls: set[str] = set()
+        self.defs: set[str] = set()
+        self.keep_alive: list[Any] = []
+
+        self.simple_registry: Any | None = None
+        self.global_ctx_getter: Callable[[], Any] = _default_ctx_getter
+
+        self.custom_opdefs: WeakValueDictionary[str, Any] = WeakValueDictionary()
+        self.custom_opdef_to_lib: dict[str, Any] = {}
+        self.legacy_custom_op_registry: dict[str, Any] = {}
+
+        self.fake_class_registry: Any | None = None
+        self.triton_ops_to_kernels: dict[str, list[object]] = {}
+
+        self.opaque_types: WeakKeyDictionary[Any, Any] = WeakKeyDictionary()
+        self.opaque_types_by_name: dict[str, Any] = {}
+
+    def get_or_create_simple_registry(self, factory: type[_T]) -> _T:
+        if self.simple_registry is None:
+            self.simple_registry = factory()
+        return cast(_T, self.simple_registry)
+
+    def get_or_create_fake_class_registry(self, factory: type[_T]) -> _T:
+        if self.fake_class_registry is None:
+            self.fake_class_registry = factory()
+        return cast(_T, self.fake_class_registry)
+
+
+library_state = LibraryGlobalState()
+
+
+__all__ = ["LibraryGlobalState", "library_state"]

--- a/torch/_library/global_state.py
+++ b/torch/_library/global_state.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, TypeVar, cast
+from typing import Any, cast, TYPE_CHECKING, TypeVar
 from weakref import WeakKeyDictionary, WeakValueDictionary
 
 
-def _default_ctx_getter() -> None:
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _get_none() -> None:
     return None
 
 
@@ -22,12 +25,15 @@ class LibraryGlobalState:
     """
 
     def __init__(self) -> None:
+        # Keep this module dependency-free: most concrete registry value types
+        # are defined in modules that import global_state, so annotations here
+        # intentionally use Any to avoid circular imports.
         self.impls: set[str] = set()
         self.defs: set[str] = set()
         self.keep_alive: list[Any] = []
 
         self.simple_registry: Any | None = None
-        self.global_ctx_getter: Callable[[], Any] = _default_ctx_getter
+        self.global_ctx_getter: Callable[[], Any] = _get_none
 
         self.custom_opdefs: WeakValueDictionary[str, Any] = WeakValueDictionary()
         self.custom_opdef_to_lib: dict[str, Any] = {}
@@ -40,11 +46,15 @@ class LibraryGlobalState:
         self.opaque_types_by_name: dict[str, Any] = {}
 
     def get_or_create_simple_registry(self, factory: type[_T]) -> _T:
+        # These registries are lazy because their concrete classes live in
+        # modules that import global_state.
         if self.simple_registry is None:
             self.simple_registry = factory()
         return cast(_T, self.simple_registry)
 
     def get_or_create_fake_class_registry(self, factory: type[_T]) -> _T:
+        # These registries are lazy because their concrete classes live in
+        # modules that import global_state.
         if self.fake_class_registry is None:
             self.fake_class_registry = factory()
         return cast(_T, self.fake_class_registry)

--- a/torch/_library/opaque_object.py
+++ b/torch/_library/opaque_object.py
@@ -39,11 +39,12 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Literal, NewType, TYPE_CHECKING, TypeAlias
+from typing import Any, Literal, NewType, TYPE_CHECKING, TypeAlias, cast
 from typing_extensions import TypeIs
 from weakref import WeakKeyDictionary
 
 import torch
+from torch._library.global_state import library_state
 from torch._opaque_base import OpaqueBase, OpaqueBaseMeta
 
 
@@ -109,9 +110,13 @@ class _OpaqueTypeInfo:
 
 
 # Mapping of type -> (string name, reference/value type)
-_OPAQUE_TYPES: WeakKeyDictionary[Any, _OpaqueTypeInfo] = WeakKeyDictionary()
+_OPAQUE_TYPES: WeakKeyDictionary[Any, _OpaqueTypeInfo] = cast(
+    WeakKeyDictionary[Any, _OpaqueTypeInfo], library_state.opaque_types
+)
 # Mapping of class_name -> (type, reference/value type)
-_OPAQUE_TYPES_BY_NAME: dict[str, _OpaqueTypeInfo] = {}
+_OPAQUE_TYPES_BY_NAME: dict[str, _OpaqueTypeInfo] = cast(
+    dict[str, _OpaqueTypeInfo], library_state.opaque_types_by_name
+)
 
 
 def _resolve_opaque_type_info(cls: Any) -> _OpaqueTypeInfo | None:

--- a/torch/_library/opaque_object.py
+++ b/torch/_library/opaque_object.py
@@ -39,7 +39,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Literal, NewType, TYPE_CHECKING, TypeAlias, cast
+from typing import Any, cast, Literal, NewType, TYPE_CHECKING, TypeAlias
 from typing_extensions import TypeIs
 from weakref import WeakKeyDictionary
 

--- a/torch/_library/simple_registry.py
+++ b/torch/_library/simple_registry.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from .effects import EffectHolder
 from .fake_impl import FakeImplHolder
+from .global_state import library_state
 from .utils import RegistrationHandle
 
 
@@ -35,7 +36,9 @@ class SimpleLibraryRegistry:
         return res
 
 
-singleton: SimpleLibraryRegistry = SimpleLibraryRegistry()
+singleton: SimpleLibraryRegistry = library_state.get_or_create_simple_registry(
+    SimpleLibraryRegistry
+)
 
 
 class SimpleOperatorEntry:

--- a/torch/_library/triton.py
+++ b/torch/_library/triton.py
@@ -9,12 +9,13 @@ from typing import Any
 from torch.utils._exposed_in import exposed_in
 
 from .custom_ops import custom_op, CustomOpDef
+from .global_state import library_state
 from .infer_schema import infer_schema
 
 
 logger = logging.getLogger(__name__)
 
-triton_ops_to_kernels: dict[str, list[object]] = {}
+triton_ops_to_kernels: dict[str, list[object]] = library_state.triton_ops_to_kernels
 
 
 def get_triton_kernels_for_op(name: str) -> list[object]:

--- a/torch/library.py
+++ b/torch/library.py
@@ -20,6 +20,7 @@ from torch._library.custom_ops import (
     device_types_t,
 )
 from torch._library.effects import EffectType
+from torch._library.global_state import library_state
 from torch._library.infer_schema import infer_schema
 from torch._library.triton import triton_op, wrap_triton
 from torch._ops import OpOverload
@@ -51,8 +52,8 @@ _P = ParamSpec("_P")
 # The keys in the set are of the form `namespace + "/" + op_name + "/" + dispatch_key`.
 # This set is maintained to ensure that two libraries don't try to override the exact same functionality to avoid
 # libraries calling into kernels not intended to be called.
-_impls: set[str] = set()
-_defs: set[str] = set()
+_impls: set[str] = library_state.impls
+_defs: set[str] = library_state.defs
 
 # prim is reserved by TorchScript interpreter
 _reserved_namespaces = ["prim"]
@@ -576,7 +577,7 @@ def _scoped_library(*args, **kwargs):
         lib._destroy()
 
 
-_keep_alive: list[Library] = []
+_keep_alive: list[Library] = library_state.keep_alive
 
 
 NAMELESS_SCHEMA = re.compile(r"\(.*\) -> .*")

--- a/torch/library.py
+++ b/torch/library.py
@@ -519,6 +519,8 @@ class Library:
         for handle in self._registration_handles:
             handle.destroy()
         self._registration_handles.clear()
+        # Mutate the shared impl registry in-place so its global_state alias
+        # stays synchronized.
         global _impls
         _impls -= self._op_impls
         for name in self._op_defs:
@@ -559,6 +561,8 @@ def _del_library(
         ) in schema_to_signature_cache:
             del schema_to_signature_cache[(name, overload_name)]
 
+    # Mutate the captured shared registries in-place so their global_state aliases
+    # stay synchronized.
     captured_impls -= op_impls
     captured_defs -= op_defs
     for handle in registration_handles:


### PR DESCRIPTION
Summary:
- Add `torch._library.global_state` as the canonical storage for Python-side torch/library registries.
- Re-export the existing historical module-level names as aliases/accessors into that centralized state to preserve compatibility.
- Add a focused regression test that checks the aliases for `torch.library`, custom op, fake class, triton, opaque object, simple registry, and fake ctx state.

Validation:
- `python3 -m py_compile torch/_library/global_state.py torch/library.py torch/_library/simple_registry.py torch/_library/fake_impl.py torch/_library/custom_ops.py torch/_library/fake_class_registry.py torch/_library/triton.py torch/_library/opaque_object.py torch/_custom_op/impl.py test/test_custom_ops.py`
- `git diff --check`
- Source-level AST check confirming the listed globals are backed by `library_state`

Build/test limitations in this container:
- `python3 test/test_custom_ops.py TestLibraryGlobalState -v` fails before repo code runs because NumPy is not installed.
- `python3 setup.py develop` fails before building because `setuptools.command.bdist_wheel` is not installed.
- Importing local `torch` also fails in this unbuilt checkout because required Python deps such as `typing_extensions` and the local `torch._C` extension are unavailable.

Drafted via Codex, published after manual review by @bobrenjc93