### PR TITLE
Codegen custom op autograd forward

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2640,6 +2640,235 @@ class TestCustomOpAPI(TestCase):
         self.assertEqual(called, 1)
         self.assertEqual(y, x + 2.0)
 
+    def test_codegen_forward_no_setup_context(self):
+        @torch.library.custom_op("_torch_testing::mul", mutates_args=())
+        def mul(x: Tensor, y: Tensor) -> Tensor:
+            return x * y
+
+        def backward(ctx, grad):
+            x, y = ctx.saved_tensors
+            return grad * y, grad * x
+
+        def setup_context(ctx, inputs, output):
+            x, y = inputs
+            ctx.save_for_backward(x, y)
+
+        mul.register_autograd(backward, setup_context=setup_context)
+
+        x = torch.randn(3, requires_grad=True)
+        y = torch.randn(3, requires_grad=True)
+        out = mul(x, y)
+        self.assertEqual(out, x * y)
+        out.sum().backward()
+        self.assertEqual(x.grad, y)
+        self.assertEqual(y.grad, x)
+
+    def test_codegen_forward_no_setup_context_no_grad(self):
+        @torch.library.custom_op("_torch_testing::mul2", mutates_args=())
+        def mul2(x: Tensor, y: Tensor) -> Tensor:
+            return x * y
+
+        setup_called = 0
+
+        def backward(ctx, grad):
+            return grad, grad
+
+        def setup_context(ctx, inputs, output):
+            nonlocal setup_called
+            setup_called += 1
+
+        mul2.register_autograd(backward, setup_context=setup_context)
+
+        x = torch.randn(3, requires_grad=True)
+        y = torch.randn(3, requires_grad=True)
+        with torch.no_grad():
+            out = mul2(x, y)
+        self.assertEqual(out, x * y)
+        self.assertEqual(setup_called, 0)
+
+        out = mul2(x, y)
+        self.assertEqual(setup_called, 1)
+
+    def test_codegen_forward_without_setup_context_registered(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            lib.define("noctx(Tensor x) -> Tensor")
+
+            def impl(x):
+                return x * 2
+
+            lib.impl("noctx", impl, "CPU")
+
+            def backward(ctx, grad):
+                return grad * 2
+
+            torch.library.register_autograd("_torch_testing::noctx", backward, lib=lib)
+
+            x = torch.randn(3, requires_grad=True)
+            out = torch.ops._torch_testing.noctx(x)
+            self.assertEqual(out, x * 2)
+            out.sum().backward()
+            self.assertEqual(x.grad, torch.full((3,), 2.0))
+
+    def test_codegen_forward_kwarg_only(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            lib.define("kwop(Tensor x, *, float scale, float bias) -> Tensor")
+
+            def impl(x, *, scale, bias):
+                return x * scale + bias
+
+            lib.impl("kwop", impl, "CPU")
+
+            setup_kw = {}
+
+            def setup_context(ctx, inputs, keyword_only_inputs, output):
+                setup_kw.update(keyword_only_inputs)
+                ctx.scale = keyword_only_inputs["scale"]
+
+            def backward(ctx, grad):
+                return grad * ctx.scale
+
+            torch.library.register_autograd(
+                "_torch_testing::kwop", backward, setup_context=setup_context, lib=lib
+            )
+
+            x = torch.randn(3, requires_grad=True)
+            out = torch.ops._torch_testing.kwop(x, scale=2.5, bias=1.0)
+            self.assertEqual(out, x * 2.5 + 1.0)
+            out.sum().backward()
+            self.assertEqual(x.grad, torch.full((3,), 2.5))
+            self.assertEqual(setup_kw, {"scale": 2.5, "bias": 1.0})
+
+    def test_codegen_forward_kwarg_only_no_grad(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            lib.define("kwop2(Tensor x, *, float scale) -> Tensor")
+
+            def impl(x, *, scale):
+                return x * scale
+
+            lib.impl("kwop2", impl, "CPU")
+
+            setup_called = 0
+
+            def setup_context(ctx, inputs, keyword_only_inputs, output):
+                nonlocal setup_called
+                setup_called += 1
+
+            def backward(ctx, grad):
+                return grad
+
+            torch.library.register_autograd(
+                "_torch_testing::kwop2",
+                backward,
+                setup_context=setup_context,
+                lib=lib,
+            )
+
+            x = torch.randn(3, requires_grad=True)
+            with torch.no_grad():
+                out = torch.ops._torch_testing.kwop2(x, scale=3.0)
+            self.assertEqual(out, x * 3.0)
+            self.assertEqual(setup_called, 0)
+
+            out = torch.ops._torch_testing.kwop2(x, scale=3.0)
+            self.assertEqual(setup_called, 1)
+
+    def test_codegen_forward_default_args_filled(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            lib.define("defop(Tensor x, int a = 10, *, int b = 20) -> Tensor")
+
+            def impl(x, a=10, *, b=20):
+                return x * a * b
+
+            lib.impl("defop", impl, "CPU")
+
+            received_inputs = []
+            received_kw = []
+
+            def setup_context(ctx, inputs, keyword_only_inputs, output):
+                received_inputs.append(inputs)
+                received_kw.append(keyword_only_inputs)
+                ctx.c = inputs[1] * keyword_only_inputs["b"]
+
+            def backward(ctx, grad):
+                return grad * ctx.c
+
+            torch.library.register_autograd(
+                "_torch_testing::defop",
+                backward,
+                setup_context=setup_context,
+                lib=lib,
+            )
+
+            x = torch.randn(3, requires_grad=True)
+            out = torch.ops._torch_testing.defop(x, b=20)
+            self.assertEqual(out, x * 10 * 20)
+            self.assertEqual(len(received_inputs), 1)
+            self.assertEqual(received_inputs[0][1], 10)
+            self.assertEqual(received_kw[0], {"b": 20})
+            out.sum().backward()
+            self.assertEqual(x.grad, torch.full((3,), 200.0))
+
+    def test_codegen_forward_multi_output(self):
+        @torch.library.custom_op("_torch_testing::split_op", mutates_args=())
+        def split_op(x: Tensor) -> tuple[Tensor, Tensor]:
+            return x * 2, x * 3
+
+        def setup_context(ctx, inputs, output):
+            ctx.save_for_backward(inputs[0])
+
+        def backward(ctx, grad0, grad1):
+            (x,) = ctx.saved_tensors
+            return grad0 * 2 + grad1 * 3
+
+        split_op.register_autograd(backward, setup_context=setup_context)
+
+        x = torch.randn(4, requires_grad=True)
+        a, b = split_op(x)
+        self.assertEqual(a, x * 2)
+        self.assertEqual(b, x * 3)
+        (a.sum() + b.sum()).backward()
+        self.assertEqual(x.grad, torch.full((4,), 5.0))
+
+    def test_codegen_forward_preserves_requires_grad_false(self):
+        @torch.library.custom_op("_torch_testing::addone", mutates_args=())
+        def addone(x: Tensor) -> Tensor:
+            return x + 1
+
+        setup_called = 0
+
+        def setup_context(ctx, inputs, output):
+            nonlocal setup_called
+            setup_called += 1
+
+        def backward(ctx, grad):
+            raise AssertionError("should not be reached")
+
+        addone.register_autograd(backward, setup_context=setup_context)
+
+        x = torch.randn(3, requires_grad=False)
+        y = addone(x)
+        self.assertEqual(y, x + 1)
+        self.assertEqual(setup_called, 0)
+
+    def test_codegen_forward_second_order_grad(self):
+        @torch.library.custom_op("_torch_testing::square", mutates_args=())
+        def square(x: Tensor) -> Tensor:
+            return x * x
+
+        def setup_context(ctx, inputs, output):
+            ctx.save_for_backward(inputs[0])
+
+        def backward(ctx, grad):
+            (x,) = ctx.saved_tensors
+            return grad * 2 * x
+
+        square.register_autograd(backward, setup_context=setup_context)
+
+        x = torch.randn(3, requires_grad=True)
+        y = square(x)
+        (grad_x,) = torch.autograd.grad(y.sum(), x, create_graph=True)
+        self.assertEqual(grad_x, 2 * x)
+
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_manual_schema(self):
         @torch.library.custom_op(

--- a/torch/_library/autograd.py
+++ b/torch/_library/autograd.py
@@ -21,6 +21,71 @@ class Info:
     _setup_context_fn: Callable | None
 
 
+def _codegen_autograd_forward(
+    op: _ops.OpOverload,
+    info: InfoProtocol,
+    has_kwarg_only_args: bool,
+) -> tuple[Callable, Callable]:
+    code_globals: dict[str, object] = {
+        "_AutoDispatchBelowAutograd_": _C._AutoDispatchBelowAutograd,
+        "_after_autograd_keyset_": _C._after_autograd_keyset,
+        "_op_": op,
+    }
+
+    lines: list[str] = []
+
+    lines.append("def forward_no_grad(*args):")
+    lines.append("    metadata = args[-1]")
+    lines.append("    args = args[:-1]")
+    lines.append("    with _AutoDispatchBelowAutograd_():")
+    lines.append("        keyset = metadata.keyset")
+    lines.append("        kwargs = metadata.keyword_only_args")
+    lines.append(
+        "        return _op_.redispatch(keyset & _after_autograd_keyset_, *args, **kwargs)"
+    )
+
+    lines.append("")
+    lines.append("def forward(ctx, *args):")
+    lines.append("    metadata = args[-1]")
+    lines.append("    args = args[:-1]")
+    lines.append("    with _AutoDispatchBelowAutograd_():")
+    lines.append("        keyset = metadata.keyset")
+    lines.append("        kwargs = metadata.keyword_only_args")
+
+    if info._setup_context_fn:
+        code_globals["_fill_defaults_"] = utils.fill_defaults
+        code_globals["_schema_"] = op._schema
+        code_globals["_setup_context_fn_"] = info._setup_context_fn
+        lines.append(
+            "        result = _op_.redispatch(keyset & _after_autograd_keyset_, *args, **kwargs)"
+        )
+        # The dispatcher strips args equal to their default values for
+        # serialization forward/backward compatibility. We fill them back
+        # so setup_context sees all declared args — adding a new default
+        # arg requires the user to update setup_context anyway.
+        lines.append("        args, kwargs = _fill_defaults_(_schema_, args, kwargs)")
+        if has_kwarg_only_args:
+            lines.append(
+                "        _setup_context_fn_(ctx=ctx, inputs=args, keyword_only_inputs=kwargs, output=result)"
+            )
+        else:
+            lines.append(
+                "        _setup_context_fn_(ctx=ctx, inputs=args, output=result)"
+            )
+        lines.append("        return result")
+    else:
+        lines.append(
+            "        return _op_.redispatch(keyset & _after_autograd_keyset_, *args, **kwargs)"
+        )
+
+    source = "\n".join(lines)
+    code = compile(source, f"<custom_op_autograd_{op._namespace}_{op._opname}>", "exec")
+    local_dict: dict[str, object] = {}
+    exec(code, code_globals, local_dict)
+
+    return local_dict["forward_no_grad"], local_dict["forward"]  # type: ignore[return-value]
+
+
 def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
     name: str = f"GeneratedBackwardFor_{op._namespace}_{op._opname}_{op._overloadname}"
 
@@ -31,44 +96,7 @@ def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
         keyset: _C.DispatchKeySet
         keyword_only_args: dict[str, Any]
 
-    def forward_no_grad(*args):
-        metadata = args[-1]
-        args = args[:-1]
-
-        with _C._AutoDispatchBelowAutograd():
-            keyset = metadata.keyset
-            kwargs = metadata.keyword_only_args
-            result = op.redispatch(keyset & _C._after_autograd_keyset, *args, **kwargs)
-            return result
-
-    def forward(ctx, *args):
-        metadata = args[-1]
-        args = args[:-1]
-
-        with _C._AutoDispatchBelowAutograd():
-            keyset = metadata.keyset
-            kwargs = metadata.keyword_only_args
-            result = op.redispatch(keyset & _C._after_autograd_keyset, *args, **kwargs)
-            if info._setup_context_fn:
-                # The Dispatcher will remove args that are equal to their default
-                # values from (args, kwargs). We're going to add it back so that
-                # the user can access them.
-                #
-                # This is OK to do: The Dispatcher removed the args for serialization
-                # FC/BC reasons (that is, a graph will not store args that are equal
-                # to their default values), but that doesn't matter here. If the user
-                # adds a new default arg, then they must update
-                # their setup_context (along with the rest of their operator
-                # registrations)
-                args, kwargs = utils.fill_defaults(op._schema, args, kwargs)
-
-                if has_kwarg_only_args:
-                    info._setup_context_fn(
-                        ctx=ctx, inputs=args, keyword_only_inputs=kwargs, output=result
-                    )
-                else:
-                    info._setup_context_fn(ctx=ctx, inputs=args, output=result)
-            return result
+    forward_no_grad, forward = _codegen_autograd_forward(op, info, has_kwarg_only_args)
 
     def backward(ctx, *grads):
         if info._backward_fn:

--- a/torch/_library/autograd.py
+++ b/torch/_library/autograd.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+import torch._logging
 from torch import _C, _ops, autograd, Tensor
 from torch.utils import _pytree
 
@@ -79,6 +80,16 @@ def _codegen_autograd_forward(
         )
 
     source = "\n".join(lines)
+
+    torch._logging.trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": "custom_op_autograd_forward",
+            "encoding": "string",
+        },
+        payload_fn=lambda: source,
+    )
+
     code = compile(source, f"<custom_op_autograd_{op._namespace}_{op._opname}>", "exec")
     local_dict: dict[str, object] = {}
     exec(code, code_globals, local_dict)


### PR DESCRIPTION
Summary:
- Replace the interpreted `forward`/`forward_no_grad` closures in custom op autograd registration with codegen'd versions.
- At registration time, `_codegen_autograd_forward` generates straight-line Python source that bakes in whether `setup_context` exists and whether the op has kwarg-only args, then compiles and execs it.
- This eliminates runtime branching in the forward path, following the same codegen pattern used in AOT Autograd (see `_codegen_compiled_forward` in `runtime_wrappers.py`).

Drafted via Codex, published after manual review by @bobrenjc93