### PR TITLE
Merge custom op autocast cast helper

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -3559,6 +3559,31 @@ with warnings.catch_warnings(record=True) as w:
                 self.assertEqual(y.dtype, torch.float16)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    def test_library_register_autocast_dict_input(self):
+        with torch.library._scoped_library("_torch_testing", "FRAGMENT") as lib:
+            lib.define("autocast_dict(Tensor trigger, Dict(str, Tensor) x) -> Tensor")
+
+            def autocast_dict(trigger, x):
+                self.assertEqual(trigger.dtype, torch.bfloat16)
+                self.assertEqual(x["first"].dtype, torch.bfloat16)
+                self.assertEqual(x["second"].dtype, torch.bfloat16)
+                return trigger + x["first"]
+
+            lib.impl("autocast_dict", autocast_dict, "CPU")
+            torch.library.register_autocast(
+                "_torch_testing::autocast_dict", "cpu", torch.bfloat16, lib=lib
+            )
+
+            x = {
+                "first": torch.randn(3, dtype=torch.float32),
+                "second": torch.randn(3, dtype=torch.float32),
+            }
+            trigger = torch.randn(3, dtype=torch.float32)
+            with torch.autocast("cpu", dtype=torch.bfloat16):
+                y = torch.ops._torch_testing.autocast_dict(trigger, x)
+            self.assertEqual(y.dtype, torch.bfloat16)
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     @unittest.skipIf(not TEST_CUDA, "requires CUDA")
     def test_library_register_autocast_multiple_times(self):
         for device in ["cuda", "cpu"]:

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-import collections
 import inspect
 import logging
 import warnings
@@ -10,6 +9,7 @@ from typing import Any, overload, Union
 
 import torch
 from torch import _C, _ops, Tensor
+from torch.amp.autocast_mode import _cast
 from torch.types import _dtype
 from torch.utils._exposed_in import exposed_in
 
@@ -902,28 +902,6 @@ class CustomOpDef:
             self._lib.impl(self._name, kernel, "AutocastCPU", with_keyset=True)
 
         return kernel
-
-
-# TODO: Merge this function with torch.amp.autocast_mode._cast, and refactor it
-# into a utility function once custom ops support arbitrary input types.
-def _cast(value, device_type: str, dtype: _dtype):
-    if isinstance(value, torch.Tensor):
-        is_eligible = (
-            value.is_floating_point()
-            and value.device.type == device_type
-            and (value.dtype is not torch.float64)
-        )
-        return value.to(dtype) if is_eligible else value
-    elif isinstance(value, (str, bytes)):
-        return value
-    elif isinstance(value, collections.abc.Iterable):
-        iterable = (_cast(v, device_type, dtype) for v in value)
-        if isinstance(value, (list, tuple)):
-            return type(value)(iterable)
-        else:
-            return iterable
-    else:
-        return value
 
 
 def increment_version(val: Any) -> None:


### PR DESCRIPTION
Summary:
- Root cause: torch._library.custom_ops kept a duplicate _cast helper that did not handle mappings like torch.amp.autocast_mode._cast. For low-level custom ops with Dict inputs, autocast converted the mapping argument into a generator before redispatching.
- Proposed fix: import and reuse torch.amp.autocast_mode._cast from custom_ops, removing the duplicated implementation and its TODO.
- Long term fix: keeping a single autocast input-casting implementation ensures custom ops and AMP stay behaviorally aligned as supported container types evolve.

Tests:
- New regression test fails against the unmodified 2.13.0.dev20260422+cpu nightly wheel with Dict[str, Tensor] vs generator, then passes with this change applied in a temporary CPU-wheel venv.
- python3 -m py_compile torch/_library/custom_ops.py test/test_custom_ops.py
- python -m usort check torch/_library/custom_ops.py test/test_custom_ops.py
- python -m ruff format --check torch/_library/custom_ops.py test/test_custom_ops.py
- python -m pytest -q test/test_custom_ops.py -k test_library_register_autocast_dict_input (via temporary CPU-wheel venv)
- python -m pytest -q test/test_custom_ops.py -k library_register_autocast (via temporary CPU-wheel venv; 1 passed, 5 skipped)

Drafted via Codex, published after manual review by @bobrenjc93