### PR TITLE
[test] Fix duplicated-word typos in test comments and docstrings

### DIFF
--- a/test/distributed/tensor/test_strategy_validation.py
+++ b/test/distributed/tensor/test_strategy_validation.py
@@ -428,7 +428,7 @@ class TestValidateCombination(TestCase):
                 "P(max),R->P(max)",
                 "P(min),R->P(min)",
                 # NOTE: these two rules are NOT valid in general for torch.add since it accepts alpha=a, which if negative
-                # flips the the partial output from max to min or vice versa.
+                # flips the partial output from max to min or vice versa.
                 # However, this test is simpler than the end to end validator and ignores alpha, and the rules have to
                 # be listed as valid since without alpha they DO produce correct results and the test asserts any rule
                 # NOT listed here produces incorrect results.

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -250,7 +250,7 @@ def is_core_aten_op(schema) -> bool:
         #
         # If the core ATen op has been removed, we cannot be sure whether it
         # was previously a core ATen op or not via checking tags this way.
-        # Conservatively assume that you are ARE a core ATen op in this case.
+        # Conservatively assume that you ARE a core ATen op in this case.
         # This means that deleting a core ATen op will still be caught.
         # But if you're deleting an operator that is not a core ATen op
         # and add it to the allow_list, you would need to additionally specify

--- a/test/inductor/test_custom_op_autotune.py
+++ b/test/inductor/test_custom_op_autotune.py
@@ -260,7 +260,7 @@ class TestCustomOpAutoTune(TestCase):
         return a, b, bias
 
     def test_decompose_k_custom_op_autotune_dynamic_config_for_input_shape(self):
-        """Test decompose_k autotuning with with epilogue fusion(matmul+bias+relu+scale) and
+        """Test decompose_k autotuning with epilogue fusion(matmul+bias+relu+scale) and
         dynamic config generation based on matmul input shapes.
 
         Validates that the custom op encapsulates the entire fused operation (matmul + bias

--- a/test/inductor/test_torchinductor_strided_blocks.py
+++ b/test/inductor/test_torchinductor_strided_blocks.py
@@ -1371,7 +1371,7 @@ class CommonTemplate:
     #   dim_mod4_: 32, dim_mod3_: 2, stride_mod3_: 4, dim_mod2_: 1/16,
     #   dim_mod1_: 4, stride_mod1_: 1, stride_mod4_: 0, stride_mod2_: 0, stride_mod0_: 0
     # }
-    # This is now fixed by ensuring that that wild symbols only match integers
+    # This is now fixed by ensuring that wild symbols only match integers
     def test_ensure_integral_dims_and_strides(self):
         def model(data, *args):
             return torch.nn.functional.unfold(data, *args)

--- a/test/quantization/fx/test_model_report_fx.py
+++ b/test/quantization/fx/test_model_report_fx.py
@@ -1150,7 +1150,7 @@ class TestFxModelReportClass(QuantizationTestCase):
         """
         Tests for generation of qconfigs by ModelReport API
         - Tests that qconfigmapping is generated
-        - Tests that mappings include information for for relevant modules
+        - Tests that mappings include information for relevant modules
         """
         with override_quantized_engine('fbgemm'):
             # set the backend for this test
@@ -1209,7 +1209,7 @@ class TestFxModelReportClass(QuantizationTestCase):
         """
         Tests for generation of qconfigs by ModelReport API
         - Tests that equalization config generated when input-weight equalization detector used
-        - Tests that mappings include information for for relevant modules
+        - Tests that mappings include information for relevant modules
         """
         with override_quantized_engine('fbgemm'):
             # set the backend for this test

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2189,7 +2189,7 @@ torch.cuda.synchronize()
                     # thread 1 calls cublasSetStream()
                     # thread 0 launches its raw gemm, which it thinks is in
                     #          its own stream, but is actually in thread 1's stream.
-                    # thread 0 enqueues its div_, which IS is its own stream,
+                    # thread 0 enqueues its div_, which IS in its own stream,
                     #          but actually now races with its gemm.
                     results[t] = torch.mm(results[t], weight)
                     results[t].div_(float(size))
@@ -2245,7 +2245,7 @@ torch.cuda.synchronize()
                         # thread 1 calls setCuDNNStreamToCurrent()
                         # thread 0 launches its raw convolution, which it thinks is in
                         #          its own stream, but is actually in thread 1's stream.
-                        # thread 0 enqueues its div_, which IS is its own stream,
+                        # thread 0 enqueues its div_, which IS in its own stream,
                         #          but now races with its convolution.
                         results[t] = torch.nn.functional.conv2d(
                             results[t], weight, padding=0
@@ -2305,7 +2305,7 @@ torch.cuda.synchronize()
                     # thread 1 calls cublasSetStream()
                     # thread 0 launches its raw gemm, which it thinks is in
                     #          its own stream, but is actually in thread 1's stream.
-                    # thread 0 enqueues its div_, which IS is its own stream,
+                    # thread 0 enqueues its div_, which IS in its own stream,
                     #          but actually now races with its gemm.
                     results[t] = weight.mm(results[t])
                     results[t].div_(float(size))

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -4354,7 +4354,7 @@ def forward(self, arg0_1: "i64[2][1]cpu", arg1_1: "Sym(u2)", arg2_1: "Sym(u3)", 
         cnt = CompileCounterWithBackend("inductor")
 
         # This view (u2, u3) -> (u0, u1) can't happen in general unless we know that input is contiguous or we have
-        # hints to to compute strides.
+        # hints to compute strides.
         def func(x, y):
             u0, u1 = y.tolist()
             result2 = x.view(u0, u1) * 10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181132

Authored with Claude (Typo Terminator).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo