### PR TITLE
[Inductor][NFC] Refactor fusion legality checks for `UserDefinedTritonKernel`

### DIFF
--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1181,7 +1181,7 @@ class TritonStores:
 @functools.cache
 def identify_triton_stores(source_code: str) -> TritonStores:
     """
-    Parse Python source code of triton kernel and find all tl.store calls.
+    Parse Python source code of the Triton kernel and find all tl.store calls.
     Returns a TritonStores object containing information about pointer, value, and mask.
 
     tl.store signature: store(pointer, value, mask=None, boundary_check=(), ...)

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -906,7 +906,7 @@ def get_tma_stores(
 @dataclasses.dataclass
 class TensorAccesses:
     read_writes: "ReadWrites"
-    can_fuse_epilogue: bool
+    only_tt_stores: bool
 
 
 @MemoizeWithCycleCheck
@@ -928,7 +928,7 @@ def analyze_kernel_access(
 
     Returns ReadWrites with StarDep objects for each accessed tensor.
     """
-    from torch._inductor.dependencies import Dep, ReadWrites, StarDep
+    from torch._inductor.dependencies import Dep, ReadWrites, UserTritonDep
 
     # Name of mutation op to mutated parameter indices
     # List from Triton Github include/triton/Dialect/Triton/IR/TritonOps.td
@@ -949,6 +949,7 @@ def analyze_kernel_access(
     }
     UNKNOWN_OPS = {"tt.elementwise_inline_asm"}
 
+    only_tt_stores = True
     write_stack: list[Param | Intermediate] = []
     read_stack: list[Param | Intermediate] = []
 
@@ -1009,9 +1010,12 @@ def analyze_kernel_access(
                         write_stack.append(arg)
                     if name in read_set:
                         read_stack.append(arg)
-            else:
-                write_stack.extend(op.args[idx] for idx in WRITE_OPS.get(op.name, []))
-                read_stack.extend(op.args[idx] for idx in READ_OPS.get(op.name, []))
+            elif op.name in WRITE_OPS:
+                if op.name != "tt.store":
+                    only_tt_stores = False
+                write_stack.extend(op.args[idx] for idx in WRITE_OPS[op.name])
+            elif op.name in READ_OPS:
+                read_stack.extend(op.args[idx] for idx in READ_OPS[op.name])
 
     # For these ops, only the first argument (base pointer) refers to actual
     # memory. The remaining arguments are shape/stride/offset metadata and
@@ -1057,10 +1061,12 @@ def analyze_kernel_access(
     read_count = _find_arg_access_count(read_stack, skip_loads=False)
 
     writes: OrderedSet[Dep] = OrderedSet(
-        StarDep(tensor_names[i]) for i in sorted(write_count.keys())
+        UserTritonDep(tensor_names[i], access_count=write_count[i])
+        for i in sorted(write_count.keys())
     )
     reads: OrderedSet[Dep] = OrderedSet(
-        StarDep(tensor_names[i]) for i in sorted(read_count.keys())
+        UserTritonDep(tensor_names[i], access_count=read_count[i])
+        for i in sorted(read_count.keys())
     )
 
     read_writes = ReadWrites(
@@ -1069,26 +1075,7 @@ def analyze_kernel_access(
         index_exprs=OrderedSet(),
     )
 
-    def _decide_can_fuse_epilogue():
-        # only do epilogue fusion if the kernel has a single output tensor
-        if len(write_count) != 1:
-            return False
-
-        written_arg_index = next(iter(write_count))
-        # only do epilogue fusion if the written tensor is written exactly once
-        if write_count[written_arg_index] != 1:
-            return False
-
-        written_arg_name = next(iter(writes)).name
-        #  cannot fuse if the kernel also reads from the output buffer
-        if any(read_dep.name == written_arg_name for read_dep in reads):
-            return False
-
-        return True
-
-    can_fuse_epilogue = _decide_can_fuse_epilogue()
-
-    return TensorAccesses(read_writes=read_writes, can_fuse_epilogue=can_fuse_epilogue)
+    return TensorAccesses(read_writes=read_writes, only_tt_stores=only_tt_stores)
 
 
 def identify_accessed_tensors(
@@ -1103,7 +1090,7 @@ def identify_accessed_tensors(
     3) Analyzes the graph to detect which input tensors are read and/or written
     """
 
-    from torch._inductor.dependencies import Dep, ReadWrites, StarDep
+    from torch._inductor.dependencies import Dep, ReadWrites, UserTritonDep
     from torch._inductor.ir import TensorBox
 
     ttir_module = None
@@ -1167,7 +1154,7 @@ def identify_accessed_tensors(
             for key, value in kwargs.items()
             if isinstance(value, (Tensor, TensorBox))
         ]
-        all_deps = OrderedSet(StarDep(name) for name in all_tensor_names)
+        all_deps = OrderedSet(UserTritonDep(name) for name in all_tensor_names)
         all_deps = typing.cast(OrderedSet[Dep], all_deps)
         return TensorAccesses(
             ReadWrites(
@@ -1175,7 +1162,7 @@ def identify_accessed_tensors(
                 writes=all_deps,
                 index_exprs=OrderedSet(),
             ),
-            can_fuse_epilogue=False,
+            only_tt_stores=False,  # Conservative false
         )
 
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1,4 +1,3 @@
-import ast
 import collections
 import copy
 import dataclasses
@@ -1164,69 +1163,6 @@ def identify_accessed_tensors(
             ),
             only_tt_stores=False,  # Conservative false
         )
-
-
-@dataclasses.dataclass
-class TritonStore:
-    store_node: ast.Call
-    store_pointer_node: ast.Expr
-    store_value_node: ast.Expr
-
-
-@dataclasses.dataclass
-class TritonStores:
-    stores: list[TritonStore]
-
-
-@functools.cache
-def identify_triton_stores(source_code: str) -> TritonStores:
-    """
-    Parse Python source code of the Triton kernel and find all tl.store calls.
-    Returns a TritonStores object containing information about pointer, value, and mask.
-
-    tl.store signature: store(pointer, value, mask=None, boundary_check=(), ...)
-    """
-    return identify_triton_stores_from_ast(ast.parse(source_code))
-
-
-def identify_triton_stores_from_ast(tree: ast.Module) -> TritonStores:
-    stores = []
-
-    def _extract_arg(node, arg_name, positional_index):
-        """
-        Extract an argument from a Call node, checking both positional and keyword args.
-        Returns the AST node for the argument, or None if not found.
-        """
-        # Check positional args first
-        if len(node.args) > positional_index:
-            return node.args[positional_index]
-
-        # Check keyword args
-        for keyword in node.keywords:
-            if keyword.arg == arg_name:
-                return keyword.value
-
-        return None
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call):
-            # Check if this is a tl.store call
-            if (
-                isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "tl"
-                and node.func.attr == "store"
-            ):
-                # Extract required arguments
-                pointer_node = _extract_arg(node, "pointer", 0)
-                value_node = _extract_arg(node, "value", 1)
-
-                if pointer_node is None or value_node is None:
-                    continue
-
-                stores.append(TritonStore(node, pointer_node, value_node))
-
-    return TritonStores(stores=stores)
 
 
 ###############################################################################

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1985,6 +1985,12 @@ class SIMDScheduling(BaseScheduling):
         ):
             return scheduler.ForeachKernelSchedulerNode.can_fuse(node1, node2)
 
+        if isinstance(node1, scheduler.ExternKernelSchedulerNode) and isinstance(
+            node1.node, ir.UserDefinedTritonKernel
+        ):
+            # Fusion legality for UserDefinedTritonKernel is validated upstream.
+            return True
+
         _, (numel1, rnumel1) = node1.group
         _, (numel2, rnumel2) = node2.group
         why = WhyNoFuse(node1, node2)

--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -1985,12 +1985,6 @@ class SIMDScheduling(BaseScheduling):
         ):
             return scheduler.ForeachKernelSchedulerNode.can_fuse(node1, node2)
 
-        if isinstance(node1, scheduler.ExternKernelSchedulerNode) and isinstance(
-            node1.node, ir.UserDefinedTritonKernel
-        ):
-            # Fusion legality for UserDefinedTritonKernel is validated upstream.
-            return True
-
         _, (numel1, rnumel1) = node1.group
         _, (numel2, rnumel2) = node2.group
         why = WhyNoFuse(node1, node2)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6773,6 +6773,69 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             code.writeline(f"{entry.mask_name()} = {entry.name} < {x}numel")
 
 
+@dataclasses.dataclass
+class TritonStore:
+    store_node: ast.Call
+    store_pointer_node: ast.Expr
+    store_value_node: ast.Expr
+
+
+@dataclasses.dataclass
+class TritonStores:
+    stores: list[TritonStore]
+
+
+@functools.cache
+def identify_triton_stores(source_code: str) -> TritonStores:
+    """
+    Parse Python source code of the Triton kernel and find all tl.store calls.
+    Returns a TritonStores object containing information about pointer, value, and mask.
+
+    tl.store signature: store(pointer, value, mask=None, boundary_check=(), ...)
+    """
+    return identify_triton_stores_from_ast(ast.parse(source_code))
+
+
+def identify_triton_stores_from_ast(tree: ast.Module) -> TritonStores:
+    stores = []
+
+    def _extract_arg(node, arg_name, positional_index):
+        """
+        Extract an argument from a Call node, checking both positional and keyword args.
+        Returns the AST node for the argument, or None if not found.
+        """
+        # Check positional args first
+        if len(node.args) > positional_index:
+            return node.args[positional_index]
+
+        # Check keyword args
+        for keyword in node.keywords:
+            if keyword.arg == arg_name:
+                return keyword.value
+
+        return None
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            # Check if this is a tl.store call
+            if (
+                isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "tl"
+                and node.func.attr == "store"
+            ):
+                # Extract required arguments
+                pointer_node = _extract_arg(node, "pointer", 0)
+                value_node = _extract_arg(node, "value", 1)
+
+                if pointer_node is None or value_node is None:
+                    continue
+
+                stores.append(TritonStore(node, pointer_node, value_node))
+
+    return TritonStores(stores=stores)
+
+
 class FusedUserTritonKernel(TritonKernel):
     """
     When fusing a user-defined triton kernel with epilogues, we use this class
@@ -6788,10 +6851,6 @@ class FusedUserTritonKernel(TritonKernel):
         features: SIMDKernelFeatures,
         scheduler_node: FusedUserTritonSchedulerNode,
     ) -> None:
-        from torch._higher_order_ops.triton_kernel_wrap import (
-            identify_triton_stores_from_ast,
-        )
-
         super().__init__(
             tiling,
             features=features,
@@ -6850,8 +6909,6 @@ class FusedUserTritonKernel(TritonKernel):
 
     # returns a str which is the src code of a modified version of the user kernel that includes the epilogues
     def codegen(self) -> str:
-        from torch._higher_order_ops.triton_kernel_wrap import identify_triton_stores
-
         with self:
             index_vars = self.split_and_set_ranges(
                 self.scheduler_node.fused_epilogue.get_ranges()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import ast
 import collections
 import contextlib
-import copy
 import dataclasses
 import functools
 import itertools
@@ -6776,7 +6775,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
 class FusedUserDefinedTritonKernel(TritonKernel):
     """
-    When fusing a user-defined triton kernel with epilogues, we use this class to generate the modified triton kernel source
+    When fusing a user-defined triton kernel with epilogues, we use this class
+    to generate the modified triton kernel source.
+
+    For now, we assume a single mutated buffer, enforced by fusion legality checks
+    in the scheduler.
     """
 
     def __init__(
@@ -6785,6 +6788,10 @@ class FusedUserDefinedTritonKernel(TritonKernel):
         features: SIMDKernelFeatures,
         scheduler_node: FusedExternTritonKernelSchedulerNode,
     ) -> None:
+        from torch._higher_order_ops.triton_kernel_wrap import (
+            identify_triton_stores_from_ast,
+        )
+
         super().__init__(
             tiling,
             features=features,
@@ -6799,17 +6806,15 @@ class FusedUserDefinedTritonKernel(TritonKernel):
             self.scheduler_node.kernel_node.node, ir.UserDefinedTritonKernel
         )
         self.ir_node: ir.UserDefinedTritonKernel = self.scheduler_node.kernel_node.node
-        assert self.ir_node.can_fuse_epilogue()
 
-        # must be true because `self.ir_node.can_fuse_epilogue()`
-        assert len(self.ir_node.kernel_stores.stores) == 1
+        self.kernel_ast = ast.parse(self.ir_node.kernel_src)
+        self.kernel_stores = identify_triton_stores_from_ast(self.kernel_ast)
+        assert len(self.kernel_stores.stores) == 1
         self.original_stored_expr = ast.unparse(
-            self.ir_node.kernel_stores.stores[0].store_value_node
-        )
-        self.original_stored_expr = self.original_stored_expr.replace("\n", "")
+            self.kernel_stores.stores[0].store_value_node
+        ).replace("\n", "")
 
     def load(self, name: str, index: sympy.Expr) -> TritonCSEVariable:
-        # must be true because `self.ir_node.can_fuse_epilogue()`
         assert len(self.ir_node.mutable_args) == 1
         if name == self.ir_node.mutable_args[0].get_name():
             # when the fused epilogue nodes tries to load the mutated buffer
@@ -6851,17 +6856,6 @@ class FusedUserDefinedTritonKernel(TritonKernel):
             )
             self.scheduler_node.fused_epilogue.codegen(index_vars)
 
-        # Generate a new AST where the store value expr is replaced with the new value
-        new_ast = copy.deepcopy(self.ir_node.kernel_ast)
-        from torch._higher_order_ops.triton_kernel_wrap import (
-            identify_triton_stores,
-            identify_triton_stores_from_ast,
-        )
-
-        # avoid redundant cache entry of new_ast
-        kernel_stores = identify_triton_stores_from_ast(new_ast)
-        assert len(kernel_stores.stores) == 1
-
         new_store_value_node = ast.Name(self.new_store_cse_var.name)
 
         def _replace_arg(
@@ -6879,21 +6873,20 @@ class FusedUserDefinedTritonKernel(TritonKernel):
                     keyword.value = new_arg
 
         _replace_arg(
-            kernel_stores.stores[0].store_node, "value", 1, new_store_value_node
+            self.kernel_stores.stores[0].store_node, "value", 1, new_store_value_node
         )
 
-        src_with_store_replaced = ast.unparse(new_ast)
+        src_with_store_replaced = ast.unparse(self.kernel_ast)
 
         # then, we need to inject the additional `load` and `compute` lines generated when we `codegen` the epilogue nodes
 
         src_lines = src_with_store_replaced.splitlines()
 
         # identify the store again, because the previous parse-modify-unparse could've change its location
-        kernel_stores = identify_triton_stores(src_with_store_replaced)
         # python ast lineno is 1-indexed
-        store_line_index = kernel_stores.stores[0].store_node.lineno - 1
+        store_line_index = self.kernel_stores.stores[0].store_node.lineno - 1
 
-        indentations = " " * kernel_stores.stores[0].store_node.col_offset
+        indentations = " " * self.kernel_stores.stores[0].store_node.col_offset
 
         load_lines = [indentations + l for l in self.loads.get_lines_ref()]
         compute_lines = [indentations + l for l in self.compute.get_lines_ref()]

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6774,19 +6774,19 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
 
 @dataclasses.dataclass
-class TritonStore:
+class UserTritonStore:
     store_node: ast.Call
     store_pointer_node: ast.Expr
     store_value_node: ast.Expr
 
 
 @dataclasses.dataclass
-class TritonStores:
-    stores: list[TritonStore]
+class UserTritonStores:
+    stores: list[UserTritonStore]
 
 
 @functools.cache
-def identify_triton_stores(source_code: str) -> TritonStores:
+def identify_triton_stores(source_code: str) -> UserTritonStores:
     """
     Parse Python source code of the Triton kernel and find all tl.store calls.
     Returns a TritonStores object containing information about pointer, value, and mask.
@@ -6796,7 +6796,7 @@ def identify_triton_stores(source_code: str) -> TritonStores:
     return identify_triton_stores_from_ast(ast.parse(source_code))
 
 
-def identify_triton_stores_from_ast(tree: ast.Module) -> TritonStores:
+def identify_triton_stores_from_ast(tree: ast.Module) -> UserTritonStores:
     stores = []
 
     def _extract_arg(node, arg_name, positional_index):
@@ -6831,9 +6831,9 @@ def identify_triton_stores_from_ast(tree: ast.Module) -> TritonStores:
                 if pointer_node is None or value_node is None:
                     continue
 
-                stores.append(TritonStore(node, pointer_node, value_node))
+                stores.append(UserTritonStore(node, pointer_node, value_node))
 
-    return TritonStores(stores=stores)
+    return UserTritonStores(stores=stores)
 
 
 class FusedUserTritonKernel(TritonKernel):
@@ -6899,8 +6899,8 @@ class FusedUserTritonKernel(TritonKernel):
     def store(
         self, name: str, index: sympy.Expr, value: CSEVariable, mode: StoreMode = None
     ) -> None:
-        assert isinstance(self.scheduler_node.fused_epilogue.node, ir.ComputedBuffer)
-        if name == self.scheduler_node.fused_epilogue.node.get_name():
+        assert isinstance(self.scheduler_node.epilogue.node, ir.ComputedBuffer)
+        if name == self.scheduler_node.epilogue.node.get_name():
             # when the fused epilogue nodes tries to store to its destination buffer
             # we remember this expr and then later replace it into the `tl.store` call of the original kernel
             self.new_store_cse_var = value
@@ -6911,9 +6911,9 @@ class FusedUserTritonKernel(TritonKernel):
     def codegen(self) -> str:
         with self:
             index_vars = self.split_and_set_ranges(
-                self.scheduler_node.fused_epilogue.get_ranges()
+                self.scheduler_node.epilogue.get_ranges()
             )
-            self.scheduler_node.fused_epilogue.codegen(index_vars)
+            self.scheduler_node.epilogue.codegen(index_vars)
 
         new_store_value_node = ast.Name(self.new_store_cse_var.name)
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -60,8 +60,8 @@ from ..runtime.hints import (
 from ..runtime.runtime_utils import get_max_y_grid, next_power_of_2
 from ..scheduler import (
     BaseSchedulerNode,
-    FusedExternTritonKernelSchedulerNode,
     FusedSchedulerNode,
+    FusedUserTritonSchedulerNode,
     Scheduler,
     SchedulerNode,
 )
@@ -6786,7 +6786,7 @@ class FusedUserDefinedTritonKernel(TritonKernel):
         self,
         tiling: dict[str, sympy.Expr],
         features: SIMDKernelFeatures,
-        scheduler_node: FusedExternTritonKernelSchedulerNode,
+        scheduler_node: FusedUserTritonSchedulerNode,
     ) -> None:
         from torch._higher_order_ops.triton_kernel_wrap import (
             identify_triton_stores_from_ast,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6773,7 +6773,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             code.writeline(f"{entry.mask_name()} = {entry.name} < {x}numel")
 
 
-class FusedUserDefinedTritonKernel(TritonKernel):
+class FusedUserTritonKernel(TritonKernel):
     """
     When fusing a user-defined triton kernel with epilogues, we use this class
     to generate the modified triton kernel source.

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6850,6 +6850,8 @@ class FusedUserDefinedTritonKernel(TritonKernel):
 
     # returns a str which is the src code of a modified version of the user kernel that includes the epilogues
     def codegen(self) -> str:
+        from torch._higher_order_ops.triton_kernel_wrap import identify_triton_stores
+
         with self:
             index_vars = self.split_and_set_ranges(
                 self.scheduler_node.fused_epilogue.get_ranges()
@@ -6881,10 +6883,11 @@ class FusedUserDefinedTritonKernel(TritonKernel):
         # then, we need to inject the additional `load` and `compute` lines generated when we `codegen` the epilogue nodes
 
         src_lines = src_with_store_replaced.splitlines()
+        kernel_stores = identify_triton_stores(src_with_store_replaced)
 
         # identify the store again, because the previous parse-modify-unparse could've change its location
         # python ast lineno is 1-indexed
-        store_line_index = self.kernel_stores.stores[0].store_node.lineno - 1
+        store_line_index = kernel_stores.stores[0].store_node.lineno - 1
 
         indentations = " " * self.kernel_stores.stores[0].store_node.col_offset
 

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -368,6 +368,26 @@ class StarDep(Dep):
         return False
 
 
+@dataclasses.dataclass(frozen=True)
+class UserTritonDep(StarDep):
+    # pyrefly: ignore [bad-override]
+    access_count: int = 1
+
+    # depends on the entire buffer
+    @property
+    # pyrefly: ignore [bad-override]
+    def index(self) -> sympy.Expr:
+        raise NotImplementedError("UserTritonDep does not have an index")
+
+    def get_numel(self) -> sympy.Expr:
+        return V.graph.get_numel(self.name)  # type: ignore[return-value]
+
+    def rename(self, renames: dict[str, str]) -> "UserTritonDep":
+        if self.name in renames:
+            return UserTritonDep(renames[self.name], self.mode, self.access_count)
+        return self
+
+
 # Used for tracking mutation ordering
 # if A reads a buffer and B mutates it
 # B must be ordered after A

--- a/torch/_inductor/dependencies.py
+++ b/torch/_inductor/dependencies.py
@@ -371,7 +371,7 @@ class StarDep(Dep):
 @dataclasses.dataclass(frozen=True)
 class UserTritonDep(StarDep):
     # pyrefly: ignore [bad-override]
-    access_count: int = 1
+    access_count: int = 0
 
     # depends on the entire buffer
     @property

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7983,12 +7983,7 @@ class UserDefinedTritonKernel(ExternKernel):
         if not config.epilogue_fusion_user_defined_triton_kernel:
             return super().get_read_writes()
 
-        # Maps format kernel arg names to inductor buffer names.
-        formal_to_inductor = {
-            formal_arg_dep.name: self.kernel_args[formal_arg_dep.name].get_name()
-            for formal_arg_dep in self.formal_accesses.read_writes.reads_and_writes()
-        }
-
+        # Map formal kernel arg names to inductor buffer names.
         write_renames = {
             dep.name: mut_output.get_name()
             for dep, mut_output in zip(
@@ -8001,18 +7996,13 @@ class UserDefinedTritonKernel(ExternKernel):
             )
         }
 
-        tracked = OrderedSet(
-            [dep.name for dep in self.formal_accesses.read_writes.reads_and_writes()]
-        )
+        # All tensor args need to be included in reads, to avoid false dead-node-elimination
+        # see: https://github.com/pytorch/pytorch/issues/181864
         reads = OrderedSet(
-            dep.rename(formal_to_inductor)
-            for dep in self.formal_accesses.read_writes.reads_and_writes()
-            if dep.name in formal_to_inductor
+            dependencies.UserTritonDep(arg.get_name())
+            for arg in self.kernel_args.values()
+            if isinstance(arg, TensorBox)
         )
-        # Tensor args not accessed in the kernel body still need to be in reads.
-        for name, arg in self.kernel_args.items():
-            if name not in tracked and isinstance(arg, TensorBox):
-                reads.add(dependencies.UserTritonDep(arg.get_name()))
 
         return dependencies.ReadWrites(
             reads=reads,

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7775,62 +7775,6 @@ class UserDefinedTritonKernel(ExternKernel):
 
         return kernel, configs, restore_value_args, reset_to_zero_args
 
-    def can_fuse_epilogue(self) -> bool:
-        """
-        For kernels like
-
-        @triton.jit
-        def add_kernel(in_ptr0, in_ptr1, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
-            pid = tl.program_id(0)
-            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-            mask = offs < n_elements
-            x = tl.load(in_ptr0 + offs, mask=mask)
-            y = tl.load(in_ptr1 + offs, mask=mask)
-            tl.store(out_ptr + offs, x + y, mask=mask)
-
-        @torch.compile
-        def fn(a, b):
-            out = torch.empty_like(a)
-            grid = (triton.cdiv(a.numel(), 1024),)
-            add_kernel[grid](a, b, out, a.numel(), BLOCK_SIZE=1024)
-            return out.relu()
-
-        We can potentially fuse the relu epilogue into the add_kernel.
-        We do this by pruning the `out` tensor allocation and directly writing the relu-output.
-        """
-
-        if not config.epilogue_fusion_user_defined_triton_kernel:
-            return False
-
-        if not self.arg_accesses.can_fuse_epilogue:
-            return False
-
-        # We achieve fusion by parsing the original src into a python AST,
-        # then identify the expr containing the original value written via tl.store().
-        # We generate an expr for the value after the epilogue and replace that into the tl.store.
-        # So far we only support the simple case where there is a single tl.store in the kernel.
-        if len(self.kernel_stores.stores) != 1:
-            return False
-
-        # Only fuse if the mutated arg is originally an "empty" tensor.
-        # This is because we don't know exactly which element of that tensor is being written to.
-        # If the kernel only writes to a subset of the tensor, then we only apply the epilogue to that subset.
-        # In these edge cases, our fusion is only correct if the original tensor is empty,
-        # where the semantics is that content values are UB, and we can rely on the fact that `epilogue(UB) == UB`.
-        assert len(self.mutable_args) == 1
-        if not isinstance(self.mutable_args[0], TensorBox):
-            return False
-        if not isinstance(self.mutable_args[0].data, StorageBox):
-            return False
-        if not isinstance(self.mutable_args[0].data.data, ComputedBuffer):
-            return False
-        if not isinstance(self.mutable_args[0].data.data.data, Pointwise):
-            return False
-        if not all(r == 0 for r in self.mutable_args[0].data.data.data.ranges):
-            return False
-
-        return True
-
     @override
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         return self._codegen(wrapper, epilogue_fusion=None)
@@ -8004,19 +7948,12 @@ class UserDefinedTritonKernel(ExternKernel):
             arg for arg in kernel.arg_names if arg in kernel_args
         ]
 
-        from torch._higher_order_ops.triton_kernel_wrap import (
-            identify_accessed_tensors,
-            identify_triton_stores,
-        )
+        from torch._higher_order_ops.triton_kernel_wrap import identify_accessed_tensors
 
         autotuned_kwargs = configs[0].kwargs if len(configs) > 0 else {}
 
-        import ast
-
         # pyrefly: ignore [missing-attribute]
         self.kernel_src = kernel.src
-        self.kernel_ast = ast.parse(self.kernel_src)
-        self.kernel_stores = identify_triton_stores(self.kernel_src)
         self.kernel_args = kernel_args
         # names in `arg_accesses.read_writes` are names of formal arguments in the kernel's prototype
         self.arg_accesses = identify_accessed_tensors(

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6121,6 +6121,7 @@ def is_node_sequence(
 @ir_dataclass(frozen=False)
 class InputsKernel(OperationBuffer):
     inputs: Sequence[IRNode | Sequence[IRNode]]
+    _DepType = dependencies.StarDep
 
     def input_name(self, i: int) -> str:
         input = self.inputs[i]
@@ -6129,18 +6130,17 @@ class InputsKernel(OperationBuffer):
 
     def get_read_writes(self) -> dependencies.ReadWrites:
         reads = OrderedSet[dependencies.Dep]()
-        StarDep = dependencies.StarDep
         for input in self.inputs:
             if isinstance(input, Sequence):
-                reads.update(StarDep(x.get_name()) for x in input)
+                reads.update(self._DepType(x.get_name()) for x in input)
             elif isinstance(input, ShapeAsConstantBuffer):
                 # Skip creating dependency for symbolics as they're visible globally
                 continue
             else:
-                reads.add(StarDep(input.get_name()))
+                reads.add(self._DepType(input.get_name()))
 
         writes = OrderedSet[dependencies.Dep](
-            StarDep(buf.get_name()) for buf in self.get_outputs()
+            self._DepType(buf.get_name()) for buf in self.get_outputs()
         )
 
         return dependencies.ReadWrites(
@@ -7742,6 +7742,8 @@ class UserDefinedTritonKernel(ExternKernel):
     """
     A user-defined triton kernel (e.g. via @triton.jit).
     """
+
+    _DepType = dependencies.UserTritonDep
 
     def get_kernel_and_metadata(self) -> tuple[Kernel, Any, list[str], list[str]]:
         from triton.runtime.autotuner import Autotuner

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7824,8 +7824,8 @@ class UserDefinedTritonKernel(ExternKernel):
         }
 
         if epilogue_fusion:
-            assert len(self.arg_accesses.read_writes.writes) == 1
-            mutable_arg_name = next(iter(self.arg_accesses.read_writes.writes)).name
+            assert len(self.formal_accesses.read_writes.writes) == 1
+            mutable_arg_name = next(iter(self.formal_accesses.read_writes.writes)).name
             assert mutable_arg_name in named_args
             epilogue_computed_buffer, _ = epilogue_fusion
             named_args[mutable_arg_name] = epilogue_computed_buffer
@@ -7955,8 +7955,8 @@ class UserDefinedTritonKernel(ExternKernel):
         # pyrefly: ignore [missing-attribute]
         self.kernel_src = kernel.src
         self.kernel_args = kernel_args
-        # names in `arg_accesses.read_writes` are names of formal arguments in the kernel's prototype
-        self.arg_accesses = identify_accessed_tensors(
+        # names in `formal_accesses.read_writes` are names of formal arguments in the kernel's prototype
+        self.formal_accesses = identify_accessed_tensors(
             kernel,
             {**kernel_args, **autotuned_kwargs},
             tma_descriptor_metadata,
@@ -7966,7 +7966,7 @@ class UserDefinedTritonKernel(ExternKernel):
         # includes scalars, so writes may reference non-tensor args like SymInts.
         self.mutable_args = [
             kernel_args[key.name]
-            for key in self.arg_accesses.read_writes.writes
+            for key in self.formal_accesses.read_writes.writes
             if isinstance(kernel_args.get(key.name), TensorBox)
         ]
 
@@ -7978,43 +7978,51 @@ class UserDefinedTritonKernel(ExternKernel):
 
     @override
     def get_read_writes(self) -> dependencies.ReadWrites:
-        # Limit the new `get_read_writes` to `epilogue_fusion_user_defined_triton_kernel`
-        # to avoid potential regression to existing models.
+        # Limit override to `epilogue_fusion_user_defined_triton_kernel` to
+        # avoid potential regression to existing models.
         if not config.epilogue_fusion_user_defined_triton_kernel:
             return super().get_read_writes()
 
-        # Maps kernel arg names to inductor-generated arg names.
-        # We keep to scheduler formality and include writes as reads.
-        read_renames = {
+        # Maps format kernel arg names to inductor buffer names.
+        formal_to_inductor = {
             formal_arg_dep.name: self.kernel_args[formal_arg_dep.name].get_name()
-            for formal_arg_dep in self.arg_accesses.read_writes.reads
+            for formal_arg_dep in self.formal_accesses.read_writes.reads_and_writes()
         }
 
-        formal_arg_writes = list(self.arg_accesses.read_writes.writes)
         write_renames = {
-            formal_arg_dep.name: mut_output.get_name()
-            for formal_arg_dep, mut_output in zip(
-                formal_arg_writes, self.mutation_outputs
+            dep.name: mut_output.get_name()
+            for dep, mut_output in zip(
+                (
+                    d
+                    for d in self.formal_accesses.read_writes.writes
+                    if isinstance(self.kernel_args.get(d.name), TensorBox)
+                ),
+                self.mutation_outputs,
             )
         }
 
-        read_writes = dependencies.ReadWrites(
-            reads=OrderedSet(
-                [
-                    dep.rename(read_renames)
-                    for dep in self.arg_accesses.read_writes.reads
-                ]
-            ),
+        tracked = OrderedSet([
+            dep.name for dep in self.formal_accesses.read_writes.reads_and_writes()
+        ])
+        reads = OrderedSet(
+            dep.rename(formal_to_inductor)
+            for dep in self.formal_accesses.read_writes.reads_and_writes()
+            if dep.name in formal_to_inductor
+        )
+        # Tensor args not accessed in the kernel body still need to be in reads.
+        for name, arg in self.kernel_args.items():
+            if name not in tracked and isinstance(arg, TensorBox):
+                reads.add(dependencies.UserTritonDep(arg.get_name()))
+
+        return dependencies.ReadWrites(
+            reads=reads,
             writes=OrderedSet(
-                [
-                    dep.rename(write_renames)
-                    for dep in self.arg_accesses.read_writes.writes
-                ]
+                dep.rename(write_renames)
+                for dep in self.formal_accesses.read_writes.writes
+                if dep.name in write_renames
             ),
             index_exprs=OrderedSet(),
         )
-        return read_writes
-
 
     def get_outputs(self) -> list[Buffer]:
         return list(self.mutation_outputs)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -8001,9 +8001,9 @@ class UserDefinedTritonKernel(ExternKernel):
             )
         }
 
-        tracked = OrderedSet([
-            dep.name for dep in self.formal_accesses.read_writes.reads_and_writes()
-        ])
+        tracked = OrderedSet(
+            [dep.name for dep in self.formal_accesses.read_writes.reads_and_writes()]
+        )
         reads = OrderedSet(
             dep.rename(formal_to_inductor)
             for dep in self.formal_accesses.read_writes.reads_and_writes()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6121,7 +6121,6 @@ def is_node_sequence(
 @ir_dataclass(frozen=False)
 class InputsKernel(OperationBuffer):
     inputs: Sequence[IRNode | Sequence[IRNode]]
-    _DepType = dependencies.StarDep
 
     def input_name(self, i: int) -> str:
         input = self.inputs[i]
@@ -6130,17 +6129,18 @@ class InputsKernel(OperationBuffer):
 
     def get_read_writes(self) -> dependencies.ReadWrites:
         reads = OrderedSet[dependencies.Dep]()
+        StarDep = dependencies.StarDep
         for input in self.inputs:
             if isinstance(input, Sequence):
-                reads.update(self._DepType(x.get_name()) for x in input)
+                reads.update(StarDep(x.get_name()) for x in input)
             elif isinstance(input, ShapeAsConstantBuffer):
                 # Skip creating dependency for symbolics as they're visible globally
                 continue
             else:
-                reads.add(self._DepType(input.get_name()))
+                reads.add(StarDep(input.get_name()))
 
         writes = OrderedSet[dependencies.Dep](
-            self._DepType(buf.get_name()) for buf in self.get_outputs()
+            StarDep(buf.get_name()) for buf in self.get_outputs()
         )
 
         return dependencies.ReadWrites(
@@ -7743,8 +7743,6 @@ class UserDefinedTritonKernel(ExternKernel):
     A user-defined triton kernel (e.g. via @triton.jit).
     """
 
-    _DepType = dependencies.UserTritonDep
-
     def get_kernel_and_metadata(self) -> tuple[Kernel, Any, list[str], list[str]]:
         from triton.runtime.autotuner import Autotuner
 
@@ -7977,6 +7975,46 @@ class UserDefinedTritonKernel(ExternKernel):
             for buf in self.mutable_args
         ]
         V.graph.register_operation(self)
+
+    @override
+    def get_read_writes(self) -> dependencies.ReadWrites:
+        # Limit the new `get_read_writes` to `epilogue_fusion_user_defined_triton_kernel`
+        # to avoid potential regression to existing models.
+        if not config.epilogue_fusion_user_defined_triton_kernel:
+            return super().get_read_writes()
+
+        # Maps kernel arg names to inductor-generated arg names.
+        # We keep to scheduler formality and include writes as reads.
+        read_renames = {
+            formal_arg_dep.name: self.kernel_args[formal_arg_dep.name].get_name()
+            for formal_arg_dep in self.arg_accesses.read_writes.reads
+        }
+
+        formal_arg_writes = list(self.arg_accesses.read_writes.writes)
+        write_renames = {
+            formal_arg_dep.name: mut_output.get_name()
+            for formal_arg_dep, mut_output in zip(
+                formal_arg_writes, self.mutation_outputs
+            )
+        }
+
+        read_writes = dependencies.ReadWrites(
+            reads=OrderedSet(
+                [
+                    dep.rename(read_renames)
+                    for dep in self.arg_accesses.read_writes.reads
+                ]
+            ),
+            writes=OrderedSet(
+                [
+                    dep.rename(write_renames)
+                    for dep in self.arg_accesses.read_writes.writes
+                ]
+            ),
+            index_exprs=OrderedSet(),
+        )
+        return read_writes
+
 
     def get_outputs(self) -> list[Buffer]:
         return list(self.mutation_outputs)

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3122,6 +3122,10 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
                 )
                 return False
 
+        if self.node.mutable_args[0].layout != node2.node.layout:
+            why("user's Triton kernel and epilogue have different buffer layouts")
+            return False
+
         def _is_other_node_that_references_mutation_buffer(
             other_node: BaseSchedulerNode,
         ):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3022,6 +3022,12 @@ class FusedNestedReductions(FusedSchedulerNode):
 class UserTritonSchedulerNode(ExternKernelSchedulerNode):
     def __init__(self, scheduler: Scheduler, node: ir.UserDefinedTritonKernel) -> None:
         super().__init__(scheduler, node)
+        assert isinstance(self.node, ir.UserDefinedTritonKernel)
+
+        self.only_tt_stores = self.node.formal_accesses.only_tt_stores
+        self.formal_reads = self.node.formal_accesses.read_writes.reads
+        self.formal_writes = self.node.formal_accesses.read_writes.writes
+
         # TODO(JJVRAW)
         numel = math.prod(node.mutable_args[0].shape)
         rnumel = 1
@@ -7272,17 +7278,16 @@ class Scheduler:
             return False
 
         if isinstance(node1, UserTritonSchedulerNode):
-            if not node1.node.arg_accesses.only_tt_stores:
-                why("node1's triton kernel has non-store writes")
+            if not node1.only_tt_stores:
+                why("user Triton fusion only supports `tl.store`")
                 return False
 
-            write_deps = list(node1.node.arg_accesses.read_writes.writes)
-            if len(write_deps) != 1 or len(node1.node.mutable_args) != 1:
-                why("node1's triton kernel has multiple outputs")
+            if len(node1.node.mutable_args) != 1 or len(node1.formal_writes) != 1:
+                why("node1's triton kernel has multiple stores")
                 return False
 
-            assert isinstance(write_deps[0], UserTritonDep)
-            if write_deps[0].access_count != 1:
+            formal_writes = list(node1.formal_writes)
+            if formal_writes[0].access_count != 1:
                 why("node1's triton kernel writes to output more than once")
                 return False
 
@@ -7308,10 +7313,8 @@ class Scheduler:
                 why("node1's triton kernel output is not an empty tensor")
                 return False
 
-            if any(
-                dep.name == write_deps[0].name
-                for dep in node1.node.arg_accesses.read_writes.reads
-            ):
+            formal_arg_name = formal_writes[0].name
+            if any(dep.name == formal_arg_name for dep in node1.formal_reads):
                 why("node1's triton kernel reads from its output buffer")
                 return False
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3161,7 +3161,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         assert isinstance(self.fused_epilogue.node, ir.ComputedBuffer)
         from torch._inductor.codegen.simd import SIMDScheduling
         from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
-        from torch._inductor.codegen.triton import FusedUserDefinedTritonKernel
+        from torch._inductor.codegen.triton import FusedUserTritonKernel
 
         ir_node = self.kernel_node.node
         numel = math.prod(ir_node.mutable_args[0].shape)
@@ -3170,7 +3170,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
         kernel_features = SIMDKernelFeatures([self.fused_epilogue], numel)
 
-        fused_user_kernel = FusedUserDefinedTritonKernel(tiling, kernel_features, self)
+        fused_user_kernel = FusedUserTritonKernel(tiling, kernel_features, self)
         new_kernel_src = fused_user_kernel.codegen()
 
         return self.kernel_node.node.codegen_with_epilogue_fusion(

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3020,6 +3020,13 @@ class FusedNestedReductions(FusedSchedulerNode):
 
 
 class UserTritonSchedulerNode(ExternKernelSchedulerNode):
+    """
+    A scheduler node for user-defined Triton kernels.
+    """
+
+    # pyrefly: ignore [bad-override]
+    node: ir.UserDefinedTritonKernel
+
     def __init__(self, scheduler: Scheduler, node: ir.UserDefinedTritonKernel) -> None:
         super().__init__(scheduler, node)
         assert isinstance(self.node, ir.UserDefinedTritonKernel)
@@ -3035,6 +3042,13 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         self.group = (device, (numel, rnumel))
 
     def can_fuse_with(self, node2: BaseSchedulerNode) -> bool:
+        """
+        Allow unary a unary pointwise epilogue pointwise to be fused into this kernel.
+
+        Fusion of user-defined kernels is initially gated on `config.epilogue_fusion_user_defined_triton_kernel`
+        (see `Scheduler.unfusable_nodes`).
+        """
+
         why = WhyNoFuse(self, node2)
         if not self.only_tt_stores:
             why("user Triton fusion only supports `tl.store`")
@@ -3044,8 +3058,9 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             why("user's Triton kernel has multiple stores")
             return False
 
-        formal_writes = list(self.formal_writes)
-        if formal_writes[0].access_count != 1:
+        formal_write = next(iter(self.formal_writes))
+        assert isinstance(formal_write, dependencies.UserTritonDep)
+        if formal_write.access_count != 1:
             why("user's Triton kernel writes to output more than once")
             return False
 
@@ -3071,7 +3086,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             why("user's Triton kernel output is not an empty tensor")
             return False
 
-        formal_arg_name = formal_writes[0].name
+        formal_arg_name = formal_write.name
         if any(dep.name == formal_arg_name for dep in self.formal_reads):
             why("user's Triton kernel reads from its output buffer")
             return False
@@ -3126,6 +3141,8 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
 
 
 class FusedUserTritonSchedulerNode(FusedSchedulerNode):
+    kernel_node: UserTritonSchedulerNode
+
     def __init__(
         self,
         scheduler: Scheduler,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -33,7 +33,7 @@ from typing_extensions import ParamSpec
 
 from torch.utils._ordered_set import OrderedSet
 
-from .ir import ComputedBuffer, Pointwise
+from .ir import ComputedBuffer
 
 
 if TYPE_CHECKING:
@@ -2140,13 +2140,6 @@ class ExternKernelSchedulerNode(BaseSchedulerNode):
         assert self.node is not None
         return hasattr(self.node, "has_side_effects") and self.node.has_side_effects()
 
-    def get_ranges(self) -> Sequence[Sequence[sympy.Expr]]:
-        if not isinstance(self.node, ir.UserDefinedTritonKernel):
-            return ([], [])
-        assert len(self.node.mutable_args) == 1
-        numel = math.prod(self.node.mutable_args[0].shape)
-        return ([numel], [])
-
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         assert isinstance(self.node, ir.ExternKernel)
         return self.node.codegen(wrapper)
@@ -3090,9 +3083,6 @@ class FusedExternTritonKernelSchedulerNode(FusedSchedulerNode):
 
     def is_extern(self) -> bool:
         return True
-
-    def get_ranges(self) -> Sequence[Sequence[sympy.Expr]]:
-        return self.kernel_node.get_ranges()
 
 
 class ForeachKernelSchedulerNode(FusedSchedulerNode):
@@ -7286,16 +7276,12 @@ class Scheduler:
                 why("node1 is extern but not a triton kernel")
                 return False
 
-            if not config.epilogue_fusion_user_defined_triton_kernel:
-                why("epilogue fusion for user defined triton kernel is disabled")
-                return False
-
             if not node1.node.arg_accesses.only_tt_stores:
                 why("node1's triton kernel has non-store writes")
                 return False
 
             write_deps = list(node1.node.arg_accesses.read_writes.writes)
-            if len(write_deps) != 1:
+            if len(write_deps) != 1 or len(node1.node.mutable_args) != 1:
                 why("node1's triton kernel has multiple outputs")
                 return False
 
@@ -7317,8 +7303,6 @@ class Scheduler:
                     return False
                 if not isinstance(arg.data.data, ir.ComputedBuffer):
                     return False
-                if not isinstance(arg.data.data.data, ir.Pointwise):
-                    return False
                 if not all(r == 0 for r in arg.data.data.data.ranges):
                     return False
                 return True
@@ -7338,10 +7322,10 @@ class Scheduler:
             if not isinstance(node2, SchedulerNode):
                 why("node1 is extern but node2 is not SchedulerNode")
                 return False
-            if not isinstance(node2.node, ComputedBuffer):
-                why("node1 is extern but node2.node is not SchedulerNode")
-                return False
-            if not isinstance(node2.node.data, Pointwise):
+
+            if not isinstance(node2.node, ComputedBuffer) or not isinstance(
+                node2.node.data, ir.Pointwise
+            ):
                 why("node1 is extern but node2.node.data is not Pointwise")
                 return False
 
@@ -7350,7 +7334,7 @@ class Scheduler:
             # The epilogue can only read from the output buffer.
             # Any other tensor/s would require additional load expressions.
             if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
-                why("epilogue reads from buffers other than the mutated output")
+                why("node2 reads from buffers other than the mutated output")
                 return False
 
             # the epilogue depends on expressions which may not available in the user triton kernel
@@ -7359,11 +7343,8 @@ class Scheduler:
             for symbol in node2_inner_fn_free_symbols:
                 usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
                 if any(usage != "load" for usage in usages):
+                    why("node2 requires expressions not available in node1")
                     return False
-
-            if node1.node.mutable_args[0].layout != node2.node.layout:
-                why("node1 and node2 uses different buf layouts")
-                return False
 
             def _is_other_node_that_references_mutation_buffer(
                 other_node: BaseSchedulerNode,

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2123,13 +2123,6 @@ class ExternKernelSchedulerNode(BaseSchedulerNode):
         self._init_from_node(node)
         self.set_read_writes(node.get_read_writes())
 
-        if isinstance(node, ir.UserDefinedTritonKernel):
-            numel = math.prod(node.mutable_args[0].shape)
-            rnumel = 1
-            device = node.get_device_or_error()
-            # pyrefly: ignore [bad-assignment]
-            self.group = (device, (numel, rnumel))
-
     def debug_str_extra(self) -> str:
         return f"{self.get_name()}.node.kernel = {getattr(self.node, 'python_kernel_name', None)}"
 
@@ -3026,14 +3019,24 @@ class FusedNestedReductions(FusedSchedulerNode):
         return FusedNestedReductions(self.node1, new_node2)
 
 
-class FusedExternTritonKernelSchedulerNode(FusedSchedulerNode):
+class UserTritonSchedulerNode(ExternKernelSchedulerNode):
+    def __init__(self, scheduler: Scheduler, node: ir.UserDefinedTritonKernel) -> None:
+        super().__init__(scheduler, node)
+        # TODO(JJVRAW)
+        numel = math.prod(node.mutable_args[0].shape)
+        rnumel = 1
+        device = node.get_device_or_error()
+        # pyrefly: ignore [bad-assignment]
+        self.group = (device, (numel, rnumel))
+
+
+class FusedUserTritonSchedulerNode(FusedSchedulerNode):
     def __init__(
         self,
         scheduler: Scheduler,
-        kernel_node: ExternKernelSchedulerNode,
+        kernel_node: UserTritonSchedulerNode,
         fused_epilogue: SchedulerNode,
     ) -> None:
-        assert isinstance(kernel_node.node, ir.UserDefinedTritonKernel)
         snodes = typing.cast(list[BaseSchedulerNode], [kernel_node, fused_epilogue])
         super().__init__(scheduler, snodes)
         self.kernel_node = kernel_node
@@ -3044,10 +3047,9 @@ class FusedExternTritonKernelSchedulerNode(FusedSchedulerNode):
     @classmethod
     def epilogue_fuse(
         cls,
-        node1: ExternKernelSchedulerNode,
+        node1: UserTritonSchedulerNode,
         node2: SchedulerNode,
     ) -> FusedSchedulerNode:
-        assert isinstance(node1.node, ir.UserDefinedTritonKernel)
         scheduler = node1.scheduler
 
         assert len(node1.node.mutation_outputs) == 1
@@ -3062,7 +3064,6 @@ class FusedExternTritonKernelSchedulerNode(FusedSchedulerNode):
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         assert isinstance(self.fused_epilogue.node, ir.ComputedBuffer)
-        assert isinstance(self.kernel_node.node, ir.UserDefinedTritonKernel)
         numel = math.prod(self.kernel_node.node.mutable_args[0].shape)
         from torch._inductor.codegen.simd import SIMDScheduling
 
@@ -4072,10 +4073,7 @@ class Scheduler:
         if config._post_fusion_custom_pass is not None:
             self.nodes = config._post_fusion_custom_pass(self.nodes)
 
-        if any(
-            isinstance(node, FusedExternTritonKernelSchedulerNode)
-            for node in self.nodes
-        ):
+        if any(isinstance(node, FusedUserTritonSchedulerNode) for node in self.nodes):
             # if a user triton kernel has been epilogue-fused,
             # there is likely an opportunity to prune an NopKernel
             # (which is originally used to generate the buffer which the triton kernel writes to)
@@ -4316,6 +4314,8 @@ class Scheduler:
             return NopKernelSchedulerNode(self, node)
         elif isinstance(node, (ir.ComputedBuffer, ir.TemplateBuffer)):
             return SchedulerNode(self, node)
+        elif isinstance(node, ir.UserDefinedTritonKernel):
+            return UserTritonSchedulerNode(self, node)
         elif isinstance(node, ir.ExternKernel):
             return ExternKernelSchedulerNode(self, node)
         else:
@@ -6947,9 +6947,9 @@ class Scheduler:
             return not node.is_template() and not is_output_of_multi_outputs_template(
                 node.node
             )
+        if isinstance(node, UserTritonSchedulerNode):
+            return not config.epilogue_fusion_user_defined_triton_kernel
         if isinstance(node, ExternKernelSchedulerNode):
-            if isinstance(node.node, ir.UserDefinedTritonKernel):
-                return not config.epilogue_fusion_user_defined_triton_kernel
             return not node.is_template() and not is_output_of_multi_outputs_template(
                 node.node
             )
@@ -7271,11 +7271,7 @@ class Scheduler:
             why("node1 is nop")
             return False
 
-        if isinstance(node1, ExternKernelSchedulerNode):
-            if not isinstance(node1.node, ir.UserDefinedTritonKernel):
-                why("node1 is extern but not a triton kernel")
-                return False
-
+        if isinstance(node1, UserTritonSchedulerNode):
             if not node1.node.arg_accesses.only_tt_stores:
                 why("node1's triton kernel has non-store writes")
                 return False
@@ -8005,14 +8001,14 @@ class Scheduler:
             score = MixOrderReduction.get_fusion_score(node1, node2)
             return _construct_return_value(score, 0, True)
 
-        # For UserDefinedTritonKernel, the write deps are UserTritonDep that won't
+        # For UserTritonSchedulerNode, the write deps are UserTritonDep that won't
         # match the epilogue's MemoryDep via set intersection.  For templates,
         # view/reshape between the template output and epilogue can produce
         # different index expressions that don't match via set intersection.
         # Fall back to name-based matching so that the fusion score reflects
         # the actual shared buffers.
         if (
-            isinstance(node1.node, ir.UserDefinedTritonKernel)
+            isinstance(node1, UserTritonSchedulerNode)
             or node1.is_template()
             or node2.is_template()
         ):
@@ -8332,7 +8328,7 @@ class Scheduler:
     ) -> None:
         assert isinstance(
             scheduler_node,
-            (ExternKernelSchedulerNode, FusedExternTritonKernelSchedulerNode),
+            (ExternKernelSchedulerNode, FusedUserTritonSchedulerNode),
         )
         # 'decide_inplace_update' stores the inplace update decisions in
         # the current kernel from where 'allocate' retrieve those decisions.
@@ -9658,11 +9654,10 @@ class BaseScheduling:  # noqa: docstring_linter
             return node1.fuse_with(node2)
         elif isinstance(node1, FusedMixOrderReductions):
             return node1.fuse_with(node2)
-        elif isinstance(node1, ExternKernelSchedulerNode) and isinstance(
+        elif isinstance(node1, UserTritonSchedulerNode) and isinstance(
             node2, SchedulerNode
         ):
-            assert isinstance(node1.node, ir.UserDefinedTritonKernel)
-            return FusedExternTritonKernelSchedulerNode.epilogue_fuse(node1, node2)
+            return FusedUserTritonSchedulerNode.epilogue_fuse(node1, node2)
         else:
             return FusedSchedulerNode.fuse(node1, node2)
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3139,6 +3139,7 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
             _is_other_node_that_references_mutation_buffer(node)
             for node in self.scheduler.nodes
         ):
+            why("epilogue has other references")
             return False
 
         return self.scheduler.can_fuse_vertical(self, node2)
@@ -3151,14 +3152,14 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         self,
         scheduler: Scheduler,
         kernel_node: UserTritonSchedulerNode,
-        fused_epilogue: SchedulerNode,
+        epilogue: SchedulerNode,
     ) -> None:
-        snodes = typing.cast(list[BaseSchedulerNode], [kernel_node, fused_epilogue])
+        snodes = typing.cast(list[BaseSchedulerNode], [kernel_node, epilogue])
         super().__init__(scheduler, snodes)
         self.kernel_node = kernel_node
-        self.fused_epilogue = fused_epilogue
+        self.epilogue = epilogue
         self.min_order = self.kernel_node.min_order
-        self.outputs = fused_epilogue.outputs
+        self.outputs = epilogue.outputs
 
     @classmethod
     def epilogue_fuse(
@@ -3179,7 +3180,7 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
         return cls(scheduler, node1, node2)
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
-        assert isinstance(self.fused_epilogue.node, ir.ComputedBuffer)
+        assert isinstance(self.epilogue.node, ir.ComputedBuffer)
         from torch._inductor.codegen.simd import SIMDScheduling
         from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
         from torch._inductor.codegen.triton import FusedUserTritonKernel
@@ -3189,13 +3190,13 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
 
         # Epilogue fusion is gated on pointwise operations, thus 1D tiling, with no reduction.
         tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
-        kernel_features = SIMDKernelFeatures([self.fused_epilogue], numel)
+        kernel_features = SIMDKernelFeatures([self.epilogue], numel)
 
         fused_user_kernel = FusedUserTritonKernel(tiling, kernel_features, self)
         new_kernel_src = fused_user_kernel.codegen()
 
         return self.kernel_node.node.codegen_with_epilogue_fusion(
-            wrapper, (self.fused_epilogue.node, new_kernel_src)
+            wrapper, (self.epilogue.node, new_kernel_src)
         )
 
     def is_extern(self) -> bool:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3028,12 +3028,101 @@ class UserTritonSchedulerNode(ExternKernelSchedulerNode):
         self.formal_reads = self.node.formal_accesses.read_writes.reads
         self.formal_writes = self.node.formal_accesses.read_writes.writes
 
-        # TODO(JJVRAW)
         numel = math.prod(node.mutable_args[0].shape)
         rnumel = 1
         device = node.get_device_or_error()
         # pyrefly: ignore [bad-assignment]
         self.group = (device, (numel, rnumel))
+
+    def can_fuse_with(self, node2: BaseSchedulerNode) -> bool:
+        why = WhyNoFuse(self, node2)
+        if not self.only_tt_stores:
+            why("user Triton fusion only supports `tl.store`")
+            return False
+
+        if len(self.node.mutable_args) != 1 or len(self.formal_writes) != 1:
+            why("user's Triton kernel has multiple stores")
+            return False
+
+        formal_writes = list(self.formal_writes)
+        if formal_writes[0].access_count != 1:
+            why("user's Triton kernel writes to output more than once")
+            return False
+
+        # Only fuse if the mutated arg is originally an "empty" tensor.
+        # This is because we don't know exactly which element of that tensor is being written to.
+        # If the kernel only writes to a subset of the tensor, then we only apply the epilogue to
+        # that subset. In these edge cases, our fusion is only correct if the original tensor is empty,
+        # where the semantics is that content values are UB, and we can rely on the fact that
+        # `epilogue(UB) == UB`.
+        def _is_empty_tensor(arg) -> bool:
+            if not isinstance(arg, ir.TensorBox):
+                return False
+            if not isinstance(arg.data, ir.StorageBox):
+                return False
+            if not isinstance(arg.data.data, ir.ComputedBuffer):
+                return False
+            if not all(r == 0 for r in arg.data.data.data.ranges):
+                return False
+            return True
+
+        mutable_arg = self.node.mutable_args[0]
+        if not _is_empty_tensor(mutable_arg):
+            why("user's Triton kernel output is not an empty tensor")
+            return False
+
+        formal_arg_name = formal_writes[0].name
+        if any(dep.name == formal_arg_name for dep in self.formal_reads):
+            why("user's Triton kernel reads from its output buffer")
+            return False
+
+        if not isinstance(node2, SchedulerNode):
+            why("epilogue of user's Triton kernel is not a SchedulerNode")
+            return False
+
+        if not isinstance(node2.node, ComputedBuffer) or not isinstance(
+            node2.node.data, ir.Pointwise
+        ):
+            why("epilogue of user's Triton kernel is not Pointwise")
+            return False
+
+        written_buffer_name = self.node.mutation_outputs[0].name
+
+        # The epilogue can only read from the output buffer.
+        # Any other tensor/s would require additional load expressions.
+        if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
+            why(
+                "epilogue of user's Triton kernel reads from buffers other than the mutated output"
+            )
+            return False
+
+        # the epilogue depends on expressions which may not available in the user's Triton kernel
+        # (e.g. indexing exprs used not in a load)
+        node2_inner_fn_free_symbols = node2.node.data.inner_fn_free_symbols()
+        for symbol in node2_inner_fn_free_symbols:
+            usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
+            if any(usage != "load" for usage in usages):
+                why(
+                    "epilogue requires expressions not available in user's Triton kernel"
+                )
+                return False
+
+        def _is_other_node_that_references_mutation_buffer(
+            other_node: BaseSchedulerNode,
+        ):
+            return (
+                (other_node is not self)
+                and (other_node is not node2)
+                and written_buffer_name in other_node.used_buffer_names()
+            )
+
+        if any(
+            _is_other_node_that_references_mutation_buffer(node)
+            for node in self.scheduler.nodes
+        ):
+            return False
+
+        return self.scheduler.can_fuse_vertical(self, node2)
 
 
 class FusedUserTritonSchedulerNode(FusedSchedulerNode):
@@ -3076,6 +3165,8 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
 
         ir_node = self.kernel_node.node
         numel = math.prod(ir_node.mutable_args[0].shape)
+
+        # Epilogue fusion is gated on pointwise operations, thus 1D tiling, with no reduction.
         tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
         kernel_features = SIMDKernelFeatures([self.fused_epilogue], numel)
 
@@ -4078,7 +4169,7 @@ class Scheduler:
             self.nodes = config._post_fusion_custom_pass(self.nodes)
 
         if any(isinstance(node, FusedUserTritonSchedulerNode) for node in self.nodes):
-            # if a user triton kernel has been epilogue-fused,
+            # if a user's Triton kernel has been epilogue-fused,
             # there is likely an opportunity to prune an NopKernel
             # (which is originally used to generate the buffer which the triton kernel writes to)
             self.dead_node_elimination()
@@ -7276,87 +7367,7 @@ class Scheduler:
             return False
 
         if isinstance(node1, UserTritonSchedulerNode):
-            if not node1.only_tt_stores:
-                why("user Triton fusion only supports `tl.store`")
-                return False
-
-            if len(node1.node.mutable_args) != 1 or len(node1.formal_writes) != 1:
-                why("node1's triton kernel has multiple stores")
-                return False
-
-            formal_writes = list(node1.formal_writes)
-            if formal_writes[0].access_count != 1:
-                why("node1's triton kernel writes to output more than once")
-                return False
-
-            # Only fuse if the mutated arg is originally an "empty" tensor.
-            # This is because we don't know exactly which element of that tensor is being written to.
-            # If the kernel only writes to a subset of the tensor, then we only apply the epilogue to
-            # that subset. In these edge cases, our fusion is only correct if the original tensor is empty,
-            # where the semantics is that content values are UB, and we can rely on the fact that
-            # `epilogue(UB) == UB`.
-            def _is_empty_tensor(arg) -> bool:
-                if not isinstance(arg, ir.TensorBox):
-                    return False
-                if not isinstance(arg.data, ir.StorageBox):
-                    return False
-                if not isinstance(arg.data.data, ir.ComputedBuffer):
-                    return False
-                if not all(r == 0 for r in arg.data.data.data.ranges):
-                    return False
-                return True
-
-            mutable_arg = node1.node.mutable_args[0]
-            if not _is_empty_tensor(mutable_arg):
-                why("node1's triton kernel output is not an empty tensor")
-                return False
-
-            formal_arg_name = formal_writes[0].name
-            if any(dep.name == formal_arg_name for dep in node1.formal_reads):
-                why("node1's triton kernel reads from its output buffer")
-                return False
-
-            if not isinstance(node2, SchedulerNode):
-                why("node1 is extern but node2 is not SchedulerNode")
-                return False
-
-            if not isinstance(node2.node, ComputedBuffer) or not isinstance(
-                node2.node.data, ir.Pointwise
-            ):
-                why("node1 is extern but node2.node.data is not Pointwise")
-                return False
-
-            written_buffer_name = node1.node.mutation_outputs[0].name
-
-            # The epilogue can only read from the output buffer.
-            # Any other tensor/s would require additional load expressions.
-            if any(dep.name != written_buffer_name for dep in node2.read_writes.reads):
-                why("node2 reads from buffers other than the mutated output")
-                return False
-
-            # the epilogue depends on expressions which may not available in the user triton kernel
-            # (e.g. indexing exprs used not in a load)
-            node2_inner_fn_free_symbols = node2.node.data.inner_fn_free_symbols()
-            for symbol in node2_inner_fn_free_symbols:
-                usages = node2.node.data.collect_inner_fn_symbol_usage(symbol)
-                if any(usage != "load" for usage in usages):
-                    why("node2 requires expressions not available in node1")
-                    return False
-
-            def _is_other_node_that_references_mutation_buffer(
-                other_node: BaseSchedulerNode,
-            ):
-                return (
-                    (other_node is not node1)
-                    and (other_node is not node2)
-                    and written_buffer_name in other_node.used_buffer_names()
-                )
-
-            if any(
-                _is_other_node_that_references_mutation_buffer(node)
-                for node in self.nodes
-            ):
-                return False
+            return node1.can_fuse_with(node2)
 
         if (
             isinstance(node2, (ExternKernelSchedulerNode, NopKernelSchedulerNode))

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -68,7 +68,7 @@ from .comm_analysis import (
     estimate_nccl_collective_runtime,
     estimate_nccl_collective_runtime_nccl_estimator,
 )
-from .dependencies import Dep, MemoryDep, StarDep, WeakDep
+from .dependencies import Dep, MemoryDep, StarDep, UserTritonDep, WeakDep
 from .exc import GPUTooOldForTriton, TritonMissing
 from .fx_utils import count_flops_fx
 from .ir import (
@@ -2123,7 +2123,7 @@ class ExternKernelSchedulerNode(BaseSchedulerNode):
         self._init_from_node(node)
         self.set_read_writes(node.get_read_writes())
 
-        if isinstance(node, ir.UserDefinedTritonKernel) and node.can_fuse_epilogue():
+        if isinstance(node, ir.UserDefinedTritonKernel):
             numel = math.prod(node.mutable_args[0].shape)
             rnumel = 1
             device = node.get_device_or_error()
@@ -2141,13 +2141,11 @@ class ExternKernelSchedulerNode(BaseSchedulerNode):
         return hasattr(self.node, "has_side_effects") and self.node.has_side_effects()
 
     def get_ranges(self) -> Sequence[Sequence[sympy.Expr]]:
-        if (
-            isinstance(self.node, ir.UserDefinedTritonKernel)
-            and self.node.can_fuse_epilogue()
-        ):
-            numel = math.prod(self.node.mutable_args[0].shape)
-            return ([numel], [])
-        return ([], [])
+        if not isinstance(self.node, ir.UserDefinedTritonKernel):
+            return ([], [])
+        assert len(self.node.mutable_args) == 1
+        numel = math.prod(self.node.mutable_args[0].shape)
+        return ([numel], [])
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         assert isinstance(self.node, ir.ExternKernel)
@@ -3072,7 +3070,6 @@ class FusedExternTritonKernelSchedulerNode(FusedSchedulerNode):
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         assert isinstance(self.fused_epilogue.node, ir.ComputedBuffer)
         assert isinstance(self.kernel_node.node, ir.UserDefinedTritonKernel)
-        assert self.kernel_node.node.can_fuse_epilogue()
         numel = math.prod(self.kernel_node.node.mutable_args[0].shape)
         from torch._inductor.codegen.simd import SIMDScheduling
 
@@ -6962,7 +6959,7 @@ class Scheduler:
             )
         if isinstance(node, ExternKernelSchedulerNode):
             if isinstance(node.node, ir.UserDefinedTritonKernel):
-                return not node.node.can_fuse_epilogue()
+                return not config.epilogue_fusion_user_defined_triton_kernel
             return not node.is_template() and not is_output_of_multi_outputs_template(
                 node.node
             )
@@ -7289,8 +7286,53 @@ class Scheduler:
                 why("node1 is extern but not a triton kernel")
                 return False
 
-            if not node1.node.can_fuse_epilogue():
-                why("node1's triton kernel doesn't support epilogue fusion")
+            if not config.epilogue_fusion_user_defined_triton_kernel:
+                why("epilogue fusion for user defined triton kernel is disabled")
+                return False
+
+            if not node1.node.arg_accesses.only_tt_stores:
+                why("node1's triton kernel has non-store writes")
+                return False
+
+            write_deps = list(node1.node.arg_accesses.read_writes.writes)
+            if len(write_deps) != 1:
+                why("node1's triton kernel has multiple outputs")
+                return False
+
+            assert isinstance(write_deps[0], UserTritonDep)
+            if write_deps[0].access_count != 1:
+                why("node1's triton kernel writes to output more than once")
+                return False
+
+            # Only fuse if the mutated arg is originally an "empty" tensor.
+            # This is because we don't know exactly which element of that tensor is being written to.
+            # If the kernel only writes to a subset of the tensor, then we only apply the epilogue to
+            # that subset. In these edge cases, our fusion is only correct if the original tensor is empty,
+            # where the semantics is that content values are UB, and we can rely on the fact that
+            # `epilogue(UB) == UB`.
+            def _is_empty_tensor(arg) -> bool:
+                if not isinstance(arg, ir.TensorBox):
+                    return False
+                if not isinstance(arg.data, ir.StorageBox):
+                    return False
+                if not isinstance(arg.data.data, ir.ComputedBuffer):
+                    return False
+                if not isinstance(arg.data.data.data, ir.Pointwise):
+                    return False
+                if not all(r == 0 for r in arg.data.data.data.ranges):
+                    return False
+                return True
+
+            mutable_arg = node1.node.mutable_args[0]
+            if not _is_empty_tensor(mutable_arg):
+                why("node1's triton kernel output is not an empty tensor")
+                return False
+
+            if any(
+                dep.name == write_deps[0].name
+                for dep in node1.node.arg_accesses.read_writes.reads
+            ):
+                why("node1's triton kernel reads from its output buffer")
                 return False
 
             if not isinstance(node2, SchedulerNode):
@@ -7303,7 +7345,6 @@ class Scheduler:
                 why("node1 is extern but node2.node.data is not Pointwise")
                 return False
 
-            assert len(node1.node.mutation_outputs) == 1
             written_buffer_name = node1.node.mutation_outputs[0].name
 
             # The epilogue can only read from the output buffer.
@@ -7320,8 +7361,6 @@ class Scheduler:
                 if any(usage != "load" for usage in usages):
                     return False
 
-            # should be true now because we checked `can_fuse_epilogue`
-            assert len(node1.node.mutable_args) == 1
             if node1.node.mutable_args[0].layout != node2.node.layout:
                 why("node1 and node2 uses different buf layouts")
                 return False
@@ -7574,10 +7613,10 @@ class Scheduler:
                         ),
                     ):
                         remaining.remove(rd)  # noqa: B909
-                    elif isinstance(cd, StarDep) and (
-                        self.fusable_stardep_write_and_read_on_empty_tensor(
-                            rd, cd, node1.node
-                        )
+                    elif isinstance(
+                        cd, UserTritonDep
+                    ) and self.fusable_usertriton_write_and_read_on_empty_tensor(
+                        rd, cd
                     ):
                         remaining.remove(rd)  # noqa: B909
 
@@ -7831,21 +7870,15 @@ class Scheduler:
         write_index = sympy_subs(write.index, dict(zip(write.var_names, write_vars)))
         return sizevars.statically_known_equals(read_index, write_index)
 
-    # on tensors that are "empty" (i.e. with undefined values),
-    # we relax the conditions for fusion and additionally allow matching a writing StarDep with any read dep.
-    # This makes use of the fact that `f(UB) = UB`.
-    def fusable_stardep_write_and_read_on_empty_tensor(
-        self, read: Dep, write: StarDep, writing_node: ir.Operation | None
+    # On tensors that are "empty" (i.e. with undefined values),
+    # we relax the conditions for fusion and additionally allow matching a writing
+    # UserTritonDep with any read dep. This makes use of the fact that `f(UB) = UB`.
+    def fusable_usertriton_write_and_read_on_empty_tensor(
+        self, read: Dep, write: UserTritonDep
     ) -> bool:
-        if not isinstance(writing_node, ir.UserDefinedTritonKernel):
-            return False
-        if not writing_node.can_fuse_epilogue():
-            return False
         read_name = self.mutation_renames.get(read.name, read.name)
         write_name = self.mutation_renames.get(write.name, write.name)
-        if isinstance(write, StarDep) and read_name == write_name:
-            return True
-        return False
+        return read_name == write_name
 
     @staticmethod
     def deps_match_normalized(dep1: Dep, dep2: Dep) -> bool:
@@ -7991,17 +8024,14 @@ class Scheduler:
             score = MixOrderReduction.get_fusion_score(node1, node2)
             return _construct_return_value(score, 0, True)
 
-        # For UserDefinedTritonKernel, the write deps are StarDep that won't
+        # For UserDefinedTritonKernel, the write deps are UserTritonDep that won't
         # match the epilogue's MemoryDep via set intersection.  For templates,
         # view/reshape between the template output and epilogue can produce
         # different index expressions that don't match via set intersection.
         # Fall back to name-based matching so that the fusion score reflects
         # the actual shared buffers.
         if (
-            (
-                isinstance(node1.node, ir.UserDefinedTritonKernel)
-                and node1.node.can_fuse_epilogue()
-            )
+            isinstance(node1.node, ir.UserDefinedTritonKernel)
             or node1.is_template()
             or node2.is_template()
         ):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -3070,16 +3070,14 @@ class FusedUserTritonSchedulerNode(FusedSchedulerNode):
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
         assert isinstance(self.fused_epilogue.node, ir.ComputedBuffer)
-        numel = math.prod(self.kernel_node.node.mutable_args[0].shape)
         from torch._inductor.codegen.simd import SIMDScheduling
-
-        tiling, _ = SIMDScheduling.get_tiling_and_scores([self.fused_epilogue], numel)
-
         from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
-
-        kernel_features = SIMDKernelFeatures([self.fused_epilogue], numel)
-
         from torch._inductor.codegen.triton import FusedUserDefinedTritonKernel
+
+        ir_node = self.kernel_node.node
+        numel = math.prod(ir_node.mutable_args[0].shape)
+        tiling = SIMDScheduling.create_tiling([numel], [sympy.S.One])
+        kernel_features = SIMDKernelFeatures([self.fused_epilogue], numel)
 
         fused_user_kernel = FusedUserDefinedTritonKernel(tiling, kernel_features, self)
         new_kernel_src = fused_user_kernel.codegen()


### PR DESCRIPTION
Clean up user-triton related usage in scheduler, and separate concerns regarding epilogue fusion legality. 

#### Consolidate fusion legality logic
- Remove `UserDefinedTritonKernel.can_fuse_epilogue`:
    - `ir.UserDefinedTritonKernel` initialisation is no longer responsible for flagging fusion legality.
    - In turn, this also removes redundant `can_fuse_epilogue` calls throughout the scheduler. 
- Add  `UserDefinedSchedulerNode` to scheduler
    - Avoids polluting `ExternSchedulerNode` and matches `FusedUserTritonSchedulerNode` pattern.
    - All fusion-related logic moved to `UserTritonSchedulerNode.can_fuse_with(self, node2)`.
    - No longer passing through `SIMD.can_fuse` as well.
      
#### Refactor fusion legality logic
- Replace `StarDep` with new dep type: `UserTritonDep`, for user Triton kernels.
    - `UserTritonDep` carries `access_count` attr, representing how many times a buffer is read/stored to. This allows us to postpone the _"single `tl.store` constraint"_ to the scheduler, rather than having the eagerly-computed `_decide_can_fuse_epilogue` logic in `analyze_kernel_access`.
  - Replace `TensorAccesses.can_fuse_epilogue` with `TensorAccesses.only_tt_stores`
    - A kernel-level flag of whether all writes are all `tt.store` (no atomic writes or descriptors).
  - Rely on AST construction and traversal **only** during code-generation / kernel source manipulation.
    - It follows that we now use TTIR traversal for buffer tracking and AST for kernel manipulation.
    - Moved `identify_triton_stores_from_ast` to `triton.py`, where its only callsite lives.

#### Other nits
- Rename `node.arg_accesses` to `node.formal_accesses` to indicate the difference in the two sets of dependencies.
- Rename classes for consistency...
  - `FusedExternTritonKernelSchedulerNode` to `FusedTritonSchedulerNode`
  - `FusedUserDefinedTritonKernel` to `FusedUserTritonKernel`





cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo