### PR TITLE
[autograd] Convert shared_ptr<Node> to intrusive_ptr<Node>

### DIFF
--- a/aten/src/ATen/core/Tensor.cpp
+++ b/aten/src/ATen/core/Tensor.cpp
@@ -158,7 +158,7 @@ const std::string& TensorBase::name() const {
   return impl::GetVariableHooks()->name(*this);
 }
 
-const std::shared_ptr<torch::autograd::Node>& TensorBase::grad_fn() const {
+const c10::intrusive_ptr<torch::autograd::Node>& TensorBase::grad_fn() const {
   return impl::GetVariableHooks()->grad_fn(*this);
 }
 

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -860,7 +860,7 @@ class TORCH_API TensorBase {
   /// Gets the up-to-date grad_fn. If the shared data or base was modified, we
   /// re-create the grad_fn to express the up-to-date view relationship between
   /// this and the base Variable.
-  const std::shared_ptr<torch::autograd::Node>& grad_fn() const;
+  const c10::intrusive_ptr<torch::autograd::Node>& grad_fn() const;
 
   // Hooks
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aten/src/ATen/core/VariableHooksInterface.h
+++ b/aten/src/ATen/core/VariableHooksInterface.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/Tensor.h>
 #include <c10/macros/Export.h>
+#include <c10/util/intrusive_ptr.h>
 
 // A little explanation about why this file exists at all.  We have
 // a few methods on Tensor class which require access to reified access to
@@ -41,7 +42,7 @@ struct TORCH_API VariableHooksInterface {
   virtual ~VariableHooksInterface() = default;
   virtual TensorBase tensor_data(const TensorBase&) const = 0;
   virtual TensorBase variable_data(const TensorBase&) const = 0;
-  virtual const std::shared_ptr<torch::autograd::Node>& grad_fn(
+  virtual const c10::intrusive_ptr<torch::autograd::Node>& grad_fn(
       const TensorBase&) const = 0;
   virtual unsigned _register_hook(
       const TensorBase&,

--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -16,7 +16,7 @@ using namespace torch::test;
 #define ASSERT_VARIABLE_EQ(a, b) ASSERT_TRUE(torch::allclose((a), (b)))
 #define EXPECT_VARIABLE_EQ(a, b) EXPECT_TRUE(torch::allclose((a), (b)))
 
-std::string graph_desc(std::shared_ptr<Node> node) {
+std::string graph_desc(c10::intrusive_ptr<Node> node) {
   if (!node) {
     return "None";
   }

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -661,7 +661,7 @@ def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str
             uses_cpp_saved_variable_cls = True
             saved_variables.append(f"SavedVariable {name}_;")
             release_variables.append(f"{name}_.reset_data();")
-            ptr = "shared_from_this()" if is_output else ""
+            ptr = "getptr()" if is_output else ""
             unpack.append(f"auto {name} = {name}_.unpack({ptr});")
             getter_definitions.append(
                 GETTER_DEFINITION_SAVEDVAR.substitute(
@@ -703,7 +703,7 @@ def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str
             # Because the SavedVariable owns a tensor and a grad_fn, removing the SavedVariable makes them go away as well.
             release_variables.append(f"{name}_.clear();")
             release_variables.append(f"{name}_released_ = true;")
-            ptr = "shared_from_this()" if is_output else "nullptr"
+            ptr = "getptr()" if is_output else "nullptr"
             unpack.append(f"auto {name} = unpack_list({name}_, {ptr});")
             asserts.append(f"TORCH_CHECK(!{name}_released_, ERR_BACKWARD_TWICE);")
             getter_definitions.append(

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -597,13 +597,13 @@ DONT_ENFORCE_STORAGE_IMPL_USE_COUNT = {
 
 DECLARE_GRAD_FN = CodeTemplate(
     """\
-std::shared_ptr<${op}> grad_fn;
+c10::intrusive_ptr<${op}> grad_fn;
 """
 )
 
 DECLARE_VECTOR_OF_GRAD_FN = CodeTemplate(
     """\
-std::vector<std::shared_ptr<${op}>> grad_fns;
+std::vector<c10::intrusive_ptr<${op}>> grad_fns;
 """
 )
 
@@ -632,7 +632,7 @@ if (compute_requires_grad( ${args_to_check} )) {
 
 ASSIGN_GRAD_FN = CodeTemplate(
     """\
-grad_fn = std::shared_ptr<${op}>(new ${op}(${op_ctor}), deleteNode);
+grad_fn = c10::make_intrusive<${op}>(${op_ctor});
 grad_fn->set_next_edges(collect_next_edges( ${args_with_derivatives} ));
 """
 )
@@ -644,11 +644,11 @@ ASSIGN_VECTOR_OF_GRAD_FN = CodeTemplate(
 for (const auto& i : c10::irange( ${irange} )) {
   const auto ith_requires_grad = compute_requires_grad(${args_with_derivatives});
   check_inplace(self[i], ith_requires_grad);
-  grad_fns.push_back([&]() -> std::shared_ptr<${op}> {
+  grad_fns.push_back([&]() -> c10::intrusive_ptr<${op}> {
       if (!ith_requires_grad) {
           return nullptr;
       } else {
-          auto grad_fn = std::shared_ptr<${op}>(new ${op}(${op_ctor}), deleteNode);
+          auto grad_fn = c10::make_intrusive<${op}>(${op_ctor});
           grad_fn->set_next_edges(collect_next_edges( ${args_with_derivatives} ));
           return grad_fn;
       }

--- a/tools/autograd/templates/Functions.h
+++ b/tools/autograd/templates/Functions.h
@@ -25,7 +25,7 @@ using at::ScalarType;
 using std::optional;
 using c10::fmap;
 
-inline std::vector<Tensor> unpack_list(at::ArrayRef<SavedVariable> xs, std::shared_ptr<Node> saved_for = nullptr) {
+inline std::vector<Tensor> unpack_list(at::ArrayRef<SavedVariable> xs, c10::intrusive_ptr<Node> saved_for = nullptr) {
   // NB: we must explicitly do the conversion in the lambda, otherwise template
   // deduction will give a Tensor of Variable which is not convertible
   return fmap(xs, [&saved_for](const SavedVariable& x) {
@@ -34,7 +34,7 @@ inline std::vector<Tensor> unpack_list(at::ArrayRef<SavedVariable> xs, std::shar
   });
 }
 
-inline c10::List<std::optional<Tensor>> unpack_opt_list(at::ArrayRef<SavedVariable> xs, std::shared_ptr<Node> saved_for = nullptr) {
+inline c10::List<std::optional<Tensor>> unpack_opt_list(at::ArrayRef<SavedVariable> xs, c10::intrusive_ptr<Node> saved_for = nullptr) {
   torch::List<std::optional<Tensor>> result;
   result.reserve(xs.size());
   for (const SavedVariable& v : xs) {

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1634,7 +1634,7 @@ static PyObject* THPModule_willEngineExecuteNode(
       exec_info,
       "_get_should_execute_nodes should only be called during the backward pass");
   torch::autograd::Node* node = nullptr;
-  std::shared_ptr<torch::autograd::Node> node_sp;
+  c10::intrusive_ptr<torch::autograd::Node> node_sp;
   if (isTHPFunction) {
     node_sp = (reinterpret_cast<THPFunction*>(arg))->cdata.lock();
     node = node_sp.get();

--- a/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
+++ b/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
@@ -107,7 +107,7 @@ void replicate_grad_edges(
     const std::vector<std::shared_ptr<ModuleType>>& replicas,
     const std::vector<Device>& devices) {
   for (auto& parameter : module->named_parameters(/*recurse=*/false)) {
-    auto grad_fn = std::make_shared<ReduceAdd>((*parameter).device());
+    auto grad_fn = c10::make_intrusive<ReduceAdd>((*parameter).device());
     grad_fn->set_next_edges(autograd::collect_next_edges(*parameter));
 
     for (const auto i : c10::irange(devices.size())) {
@@ -117,7 +117,7 @@ void replicate_grad_edges(
 
   for (auto& buffer : module->named_buffers(/*recurse=*/false)) {
     if (buffer.value().requires_grad()) {
-      auto grad_fn = std::make_shared<ReduceAdd>((*buffer).device());
+      auto grad_fn = c10::make_intrusive<ReduceAdd>((*buffer).device());
       grad_fn->set_next_edges(autograd::collect_next_edges(*buffer));
 
       for (const auto i : c10::irange(devices.size())) {

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -7238,7 +7238,7 @@ std::tuple<Tensor, Tensor> scatter_reduce_backward(
     // GradMode::is_enabled() - adding the autograd Node is a no-op if autograd
     // is disabled; this also avoids having the item() call in the usual case.
     if (GradMode::is_enabled() && (src_num_zeros > 1).any().item<bool>()) {
-      auto node = std::make_shared<DelayedError>(
+      auto node = c10::make_intrusive<DelayedError>(
           "scatter_reduce(): Double backward is unsupported for src when >1 zeros in src are scattered to the same position in self",
           /* num inputs */ 1);
       auto result = node->apply({std::move(grad_src1)});
@@ -7335,7 +7335,7 @@ std::tuple<Tensor, Tensor> index_reduce_backward(
     // GradMode::is_enabled() - adding the autograd Node is a no-op if autograd
     // is disabled this also avoids having the item() call in the usual case
     if (GradMode::is_enabled() && (src_num_zeros > 1).any().item<bool>()) {
-      auto node = std::make_shared<DelayedError>(
+      auto node = c10::make_intrusive<DelayedError>(
           "index_reduce(): Double backward is unsupported for source when >1 zeros in source are scattered to the same position in self",
           /* num inputs */ 1);
       auto result = node->apply({std::move(grad_src1)});

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -122,9 +122,9 @@ namespace {
 // Taken from codegened version
 Tensor _fw_primal(c10::DispatchKeySet ks, const Tensor& self, int64_t level) {
   auto& self_ = unpack(self, "self", 0);
-  std::shared_ptr<Identity> grad_fn;
+  c10::intrusive_ptr<Identity> grad_fn;
   if (compute_requires_grad(self)) {
-    grad_fn = std::make_shared<Identity>();
+    grad_fn = c10::make_intrusive<Identity>();
     grad_fn->set_next_edges(collect_next_edges(self));
   }
 
@@ -166,9 +166,9 @@ Tensor _make_dual(
       " is not supported.");
   auto& primal_ = unpack(primal, "primal", 0);
   auto& tangent_ = unpack(tangent, "tangent", 0);
-  std::shared_ptr<ViewBackward0> grad_fn;
+  c10::intrusive_ptr<ViewBackward0> grad_fn;
   if (compute_requires_grad(primal_)) {
-    grad_fn = std::make_shared<ViewBackward0>();
+    grad_fn = c10::make_intrusive<ViewBackward0>();
     grad_fn->self_sym_sizes = primal_.sym_sizes().vec();
     grad_fn->set_next_edges(collect_next_edges(primal_));
   }
@@ -198,12 +198,12 @@ Tensor& copy_(
   // it automatically
   auto& self_ = unpack(self, "self", 0);
   auto& src_ = unpack(src, "src", 1);
-  std::shared_ptr<CopyBackwards> grad_fn;
+  c10::intrusive_ptr<CopyBackwards> grad_fn;
   auto requires_grad = compute_requires_grad(self, src);
   requires_grad &= isDifferentiableType(self.scalar_type());
   check_inplace(self, requires_grad);
   if (requires_grad) {
-    grad_fn = std::make_shared<CopyBackwards>();
+    grad_fn = c10::make_intrusive<CopyBackwards>();
     grad_fn->set_next_edges(collect_next_edges(self, src));
     grad_fn->src_options = src.options();
   }

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -133,7 +133,9 @@ inline void throw_error_for_complex_autograd(
 
 // TODO: Blegh, bare references
 
-inline void rebase_history(const Variable& var, std::shared_ptr<Node> grad_fn) {
+inline void rebase_history(
+    const Variable& var,
+    c10::intrusive_ptr<Node> grad_fn) {
   if (grad_fn && var.defined()) {
     grad_fn->add_input_metadata(var);
     impl::rebase_history(var, {std::move(grad_fn), 0});
@@ -142,7 +144,7 @@ inline void rebase_history(const Variable& var, std::shared_ptr<Node> grad_fn) {
 
 inline void rebase_history(
     const std::vector<Variable>& vars,
-    const std::shared_ptr<Node>& grad_fn) {
+    const c10::intrusive_ptr<Node>& grad_fn) {
   if (grad_fn) {
     for (auto& var : vars) {
       if (var.defined()) {

--- a/torch/csrc/autograd/anomaly_mode.cpp
+++ b/torch/csrc/autograd/anomaly_mode.cpp
@@ -70,7 +70,8 @@ void AnomalyMetadata::print_stack(const std::string& current_node_name) {
   }
 }
 
-void AnomalyMetadata::assign_parent(const std::shared_ptr<Node>& parent_node) {
+void AnomalyMetadata::assign_parent(
+    const c10::intrusive_ptr<Node>& parent_node) {
   parent_ = parent_node;
 }
 

--- a/torch/csrc/autograd/anomaly_mode.h
+++ b/torch/csrc/autograd/anomaly_mode.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <c10/util/intrusive_ptr.h>
 #include <torch/csrc/Export.h>
-#include <memory>
 #include <string>
 
 namespace torch::autograd {
@@ -61,11 +61,11 @@ struct TORCH_API AnomalyMetadata {
   virtual ~AnomalyMetadata();
   virtual void store_stack();
   virtual void print_stack(const std::string& current_node_name);
-  virtual void assign_parent(const std::shared_ptr<Node>& parent_node);
+  virtual void assign_parent(const c10::intrusive_ptr<Node>& parent_node);
 
  private:
   std::string traceback_;
-  std::shared_ptr<Node> parent_;
+  c10::intrusive_ptr<Node> parent_;
 };
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/autograd.cpp
+++ b/torch/csrc/autograd/autograd.cpp
@@ -130,7 +130,7 @@ static variable_list run_backward(
           " of the input tensors does not require grad");
       if (!grad_fn) {
         // See NOTE [ Autograd Unreachable Input ] for details
-        output_edges.emplace_back(std::make_shared<Identity>(), 0);
+        output_edges.emplace_back(c10::make_intrusive<Identity>(), 0);
       } else {
         output_edges.emplace_back(grad_fn, output_nr);
       }

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -142,7 +142,7 @@ static void basicAutogradNotImplementedFallbackImpl(
   // by putting it after the requires_grad checks.
   any_input_requires_grad = any_input_requires_grad && GradMode::is_enabled();
 
-  std::shared_ptr<WarnNotImplemented> grad_fn;
+  c10::intrusive_ptr<WarnNotImplemented> grad_fn;
   if (any_input_requires_grad) {
     // NB: It is standard to collect edges from all tensors
     // (see generated/VariableTypeEverything.cpp for examples)
@@ -154,9 +154,8 @@ static void basicAutogradNotImplementedFallbackImpl(
         stack,
         stack_start,
         num_arguments);
-    grad_fn = std::shared_ptr<WarnNotImplemented>(
-        new WarnNotImplemented(op_name, all_tensors_on_stack.size()),
-        deleteNode);
+    grad_fn = c10::make_intrusive<WarnNotImplemented>(
+        op_name, all_tensors_on_stack.size());
     grad_fn->set_next_edges(collect_next_edges(all_tensors_on_stack));
   }
 
@@ -340,10 +339,9 @@ static void autogradNotImplementedFallbackImpl(
       stack_start,
       num_arguments);
 
-  std::shared_ptr<NotImplemented> grad_fn;
+  c10::intrusive_ptr<NotImplemented> grad_fn;
   if (any_requires_grad) {
-    grad_fn = std::shared_ptr<NotImplemented>(
-        new NotImplemented(op_name), deleteNode);
+    grad_fn = c10::make_intrusive<NotImplemented>(op_name);
     grad_fn->set_next_edges(
         collect_next_edges(tensors_requiring_grad_on_stack));
   }

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -259,7 +259,7 @@ static optional_variable_list _process_backward_mode_ad(
     const std::unordered_set<at::TensorImpl*>& non_differentiable,
     const std::unordered_set<at::TensorImpl*>& dirty_inputs,
     const at::ArrayRef<std::optional<Variable>> raw_outputs,
-    const std::shared_ptr<Node>& cdata,
+    const c10::intrusive_ptr<Node>& cdata,
     const std::unordered_set<at::TensorImpl*>& to_save_if_setup_context,
     const _view_as_self_fn_t& view_as_self_fn,
     bool pure_view) {
@@ -447,7 +447,7 @@ optional_variable_list _wrap_outputs(
     const std::unordered_set<at::TensorImpl*>& non_differentiable,
     const std::unordered_set<at::TensorImpl*>& dirty_inputs,
     const at::ArrayRef<std::optional<Variable>> raw_outputs,
-    const std::shared_ptr<Node>& cdata,
+    const c10::intrusive_ptr<Node>& cdata,
     const _jvp_fn_t& jvp_user_function,
     const std::unordered_set<at::TensorImpl*>& to_save_if_setup_context,
     const _view_as_self_fn_t& view_as_self_fn,

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -21,7 +21,7 @@ TORCH_API std::vector<std::optional<Variable>> _wrap_outputs(
     const std::unordered_set<at::TensorImpl*>& non_differentiable,
     const std::unordered_set<at::TensorImpl*>& dirty_inputs,
     const at::ArrayRef<std::optional<Variable>> raw_outputs,
-    const std::shared_ptr<Node>& cdata,
+    const c10::intrusive_ptr<Node>& cdata,
     const _jvp_fn_t& jvp_user_function,
     const std::unordered_set<at::TensorImpl*>& to_save_if_setup_context,
     const _view_as_self_fn_t& view_as_self_fn,
@@ -169,7 +169,7 @@ struct TORCH_API AutogradContext {
   // The CppNode in the autograd graph that owns this AutogradContext. We need a
   // weak_ptr to avoid a refcycle. Since grad_fn_ owns this AutogradContext, it
   // will always be alive when we want to use it.
-  std::weak_ptr<Node> grad_fn_;
+  c10::weak_intrusive_ptr<Node> grad_fn_{c10::intrusive_ptr<Node>()};
   bool has_freed_buffers_{false};
 
   // Compiled autograd overrides saved_variables() and needs_input_grad().
@@ -284,7 +284,7 @@ struct CppNode : public Node {
 
   void release_variables() override;
 
-  void set_ctx_grad_fn(const std::shared_ptr<Node>& node);
+  void set_ctx_grad_fn(const c10::intrusive_ptr<Node>& node);
   void save_variables_to_ctx();
 
   void compiled_args(CompiledNodeArgs& args) const override {
@@ -475,7 +475,7 @@ auto Function<T>::apply(Args&&... args)
     functorch_tls->checkSupportsCppAutogradFunction();
   }
 
-  std::shared_ptr<CppNode<T>> node(new CppNode<T>(), deleteNode);
+  auto node = c10::make_intrusive<CppNode<T>>();
   variable_list input_vars;
 
   const size_t num_inputs = sizeof...(Args);
@@ -573,7 +573,7 @@ void CppNode<T>::save_variables_to_ctx() {
 }
 
 template <class T>
-void CppNode<T>::set_ctx_grad_fn(const std::shared_ptr<Node>& node) {
+void CppNode<T>::set_ctx_grad_fn(const c10::intrusive_ptr<Node>& node) {
   ctx_.grad_fn_ = node;
 }
 

--- a/torch/csrc/autograd/edge.h
+++ b/torch/csrc/autograd/edge.h
@@ -2,9 +2,9 @@
 
 #include <cstdint>
 #include <functional>
-#include <memory>
 
 #include <c10/util/hash.h>
+#include <c10/util/intrusive_ptr.h>
 
 namespace torch::autograd {
 
@@ -14,7 +14,7 @@ struct Node;
 struct Edge {
   Edge() noexcept : function(nullptr), input_nr(0) {}
 
-  Edge(std::shared_ptr<Node> function_, uint32_t input_nr_) noexcept
+  Edge(c10::intrusive_ptr<Node> function_, uint32_t input_nr_) noexcept
       : function(std::move(function_)), input_nr(input_nr_) {}
 
   /// Convenience method to test if an edge is valid.
@@ -32,7 +32,7 @@ struct Edge {
   }
 
   /// The function this `Edge` points to.
-  std::shared_ptr<Node> function;
+  c10::intrusive_ptr<Node> function;
 
   /// The identifier of a particular input to the function.
   uint32_t input_nr;

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -645,7 +645,7 @@ void Engine::reentrant_thread_init() {
 
 void Engine::thread_on_exception(
     const std::shared_ptr<GraphTask>& graph_task,
-    const std::shared_ptr<Node>& fn,
+    const c10::intrusive_ptr<Node>& fn,
     std::exception& e) {
   graph_task->set_exception(std::current_exception(), fn);
 }
@@ -780,7 +780,8 @@ void GraphTask::exec_post_processing() {
   }
 }
 
-void GraphTask::set_exception_without_signal(const std::shared_ptr<Node>& fn) {
+void GraphTask::set_exception_without_signal(
+    const c10::intrusive_ptr<Node>& fn) {
   if (!has_error_.exchange(true)) {
     if (AnomalyMode::is_enabled() && fn) {
       fn->metadata()->print_stack(fn->name());
@@ -790,7 +791,7 @@ void GraphTask::set_exception_without_signal(const std::shared_ptr<Node>& fn) {
 
 void GraphTask::set_exception(
     std::exception_ptr eptr,
-    const std::shared_ptr<Node>& fn) {
+    const c10::intrusive_ptr<Node>& fn) {
   set_exception_without_signal(fn);
   if (!future_completed_.exchange(true)) {
     future_result_->setError(std::move(eptr));
@@ -1336,9 +1337,12 @@ auto Engine::execute(
 
   // If we receive a single root, skip creating extra root node
   bool skip_dummy_node = root_edges.size() == 1 && compiled_autograd == nullptr;
-  auto graph_root = skip_dummy_node
-      ? root_edges.at(0).function
-      : std::make_shared<GraphRoot>(root_edges, inputs);
+  c10::intrusive_ptr<Node> graph_root;
+  if (skip_dummy_node) {
+    graph_root = root_edges.at(0).function;
+  } else {
+    graph_root = c10::make_intrusive<GraphRoot>(root_edges, inputs);
+  }
 
   auto min_topo_nr = compute_min_topological_nr(outputs);
   // Now compute the dependencies for all executable functions
@@ -1406,7 +1410,7 @@ void Engine::initialize_device_threads_pool() {
 
 c10::intrusive_ptr<at::ivalue::Future> Engine::execute_with_graph_task(
     const std::shared_ptr<GraphTask>& graph_task,
-    std::shared_ptr<Node> graph_root,
+    c10::intrusive_ptr<Node> graph_root,
     InputBuffer&& input_buffer) {
   initialize_device_threads_pool();
   // Lock mutex for GraphTask.

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -50,7 +50,7 @@ TORCH_API std::vector<std::optional<InputMetadata>> collect_input_metadata(
 
 struct NodeTask {
   std::weak_ptr<GraphTask> base_;
-  std::shared_ptr<Node> fn_;
+  c10::intrusive_ptr<Node> fn_;
   // This buffer serves as an implicit "addition" node for all of the
   // gradients flowing here.  Once all the dependencies are finished, we
   // use the contents of this buffer to run the function.
@@ -63,7 +63,7 @@ struct NodeTask {
 
   NodeTask(
       std::weak_ptr<GraphTask> base,
-      std::shared_ptr<Node> fn,
+      c10::intrusive_ptr<Node> fn,
       InputBuffer inputs,
       bool isShutdownTask = false)
       : base_(std::move(base)),
@@ -137,7 +137,7 @@ struct TORCH_API Engine {
   // can have python symbols, so we add a layer of indirection
   // see [Note: Compiled Autograd]
   typedef variable_list (*compiled_autograd_fn)(
-      const std::shared_ptr<Node>& graph_root,
+      const c10::intrusive_ptr<Node>& graph_root,
       const GraphTask& graph_task,
       bool accumulate_grad,
       const edge_list& outputs);
@@ -164,7 +164,7 @@ struct TORCH_API Engine {
   // machinery and shouldn't be exposed to users in anyway.
   virtual c10::intrusive_ptr<at::ivalue::Future> execute_with_graph_task(
       const std::shared_ptr<GraphTask>& graph_task,
-      std::shared_ptr<Node> graph_root,
+      c10::intrusive_ptr<Node> graph_root,
       InputBuffer&& input_buffer);
 
   virtual std::unique_ptr<AnomalyMetadata> make_anomaly_metadata() {
@@ -186,7 +186,7 @@ struct TORCH_API Engine {
   void initialize_device_threads_pool();
   virtual void thread_on_exception(
       const std::shared_ptr<GraphTask>& graph_task,
-      const std::shared_ptr<Node>& fn,
+      const c10::intrusive_ptr<Node>& fn,
       std::exception& e);
 
   void queue_callback(std::function<void()> callback);

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -6,7 +6,6 @@
 
 #include <ATen/ATen.h>
 
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -22,10 +21,10 @@ namespace torch::autograd {
 // The current evaluating node. This is useful to assign the current node as a
 // parent of new nodes created during the evaluation of this node in anomaly
 // mode.
-C10_DEFINE_TLS_static(std::shared_ptr<Node>, tls_current_evaluating_node);
+C10_DEFINE_TLS_static(c10::intrusive_ptr<Node>, tls_current_evaluating_node);
 #define current_evaluating_node (tls_current_evaluating_node.get())
 
-NodeGuard::NodeGuard(std::shared_ptr<Node> node)
+NodeGuard::NodeGuard(c10::intrusive_ptr<Node> node)
     : last_evaluating_node_(std::move(current_evaluating_node)) {
   current_evaluating_node = std::move(node);
 }
@@ -34,7 +33,7 @@ NodeGuard::~NodeGuard() {
   current_evaluating_node = std::move(last_evaluating_node_);
 }
 
-std::shared_ptr<Node> get_current_node() {
+c10::intrusive_ptr<Node> get_current_node() {
   return current_evaluating_node;
 }
 
@@ -91,9 +90,12 @@ AnomalyMetadata* Node::metadata() noexcept {
   return anomaly_metadata_.get();
 }
 
+// Iteratively release child nodes to prevent stack overflow on deletion
+// of deep computation graphs. See
+// https://github.com/pytorch/pytorch/issues/5534
 static void gatherFunctions(
     Node* func,
-    std::vector<std::shared_ptr<Node>>& stack) {
+    std::vector<c10::intrusive_ptr<Node>>& stack) {
   func->release_variables();
 
   for (auto& edge : func->next_edges()) {
@@ -105,42 +107,27 @@ static void gatherFunctions(
   }
 }
 
-/*
- * Fix for #5534: prevent stack overflow on deletion of deep computation graph
- *
- * Sometimes one can end up with a very big computation graph of Nodes
- * and Edges. Each std::shared_ptr<Node> contains a list of Edge, and
- * each Edge contains a std::shared_ptr<Node>. Deleting a
- * std::shared_ptr<Node> can trigger the recursive deletion of other
- * std::shared_ptr<Node>'s: this can stack overflow if the graph
- * is deep enough. Here is an example of such a graph:
- *
- * shared_ptr<Node> -> Edge -> shared_ptr<Node> -> Edge -> ... ->
- * shared_ptr<Node>
- *
- * The solution here is to detect when we are decrementing away the last
- * reference to a Node, and when doing so to buffer up the Node's
- * that will be recursively decremented.  We can then decrement (and free)
- * the original Node without causing a recursive cascade, before
- * draining the buffer applying the same behavior.  This is, in effect,
- * converting recursion to a loop, using a heap buffer in place of the
- * recursive call stack.
- */
-void deleteNode(Node* function) {
-  // To avoid stack overflow on large computational graphs,
-  // we need to track reference decrementing and freeing
-  // on the heap.
-  function->release_variables();
-  std::vector<std::shared_ptr<Node>> stack;
-  gatherFunctions(function, stack);
-  delete function;
-
+static void releaseGraphIteratively(Node* node) {
+  std::vector<c10::intrusive_ptr<Node>> stack;
+  gatherFunctions(node, stack);
   while (!stack.empty()) {
     auto func = std::move(stack.back());
     stack.pop_back();
     gatherFunctions(func.get(), stack);
-    // Reference count is decremented on the loop backedge.
   }
+}
+
+void Node::release_resources() {
+  releaseGraphIteratively(this);
+  pre_hooks_.clear();
+  post_hooks_.clear();
+  tensor_pre_hooks_.clear();
+  retains_grad_hooks_.clear();
+  anomaly_metadata_.reset();
+}
+
+Node::~Node() {
+  releaseGraphIteratively(this);
 }
 
 at::Tensor TypeAndSize::zeros() {

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -6,6 +6,8 @@
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/utils/variadic.h>
 
+#include <c10/util/intrusive_ptr.h>
+
 namespace torch::autograd {
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -50,7 +52,7 @@ struct MakeNextFunctionList : IterArgs<MakeNextFunctionList> {
 /// `set_gradient_edge` directly.
 inline void create_gradient_edge(
     Variable& variable,
-    std::shared_ptr<Node> function) {
+    c10::intrusive_ptr<Node> function) {
   // Copy before move.
   const auto input_nr = function->add_input_metadata(variable);
   impl::set_gradient_edge(variable, {std::move(function), input_nr});

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -61,7 +61,7 @@ variable_list AccumulateGrad_apply_functional_no_hooks_ivalue(
   // Functional Tensors insert an Error node to assert that backward is never
   // called
   if (variable.grad_fn() &&
-      std::dynamic_pointer_cast<Error>(variable.grad_fn()) == nullptr) {
+      dynamic_cast<Error*>(variable.grad_fn().get()) == nullptr) {
     throw std::logic_error(
         "leaf variable has been moved into the graph interior");
   }

--- a/torch/csrc/autograd/functions/accumulate_grad.h
+++ b/torch/csrc/autograd/functions/accumulate_grad.h
@@ -42,6 +42,11 @@ struct TORCH_API AccumulateGrad : public Node {
 
   variable_list apply(variable_list&& grads) override;
 
+  void release_resources() override {
+    variable.reset();
+    Node::release_resources();
+  }
+
   std::vector<std::unique_ptr<FunctionPreHook>>& tensor_pre_hooks() noexcept
       override {
     // NB: Since the AccumulateGrad Node is only a weak ref from the Tensor,

--- a/torch/csrc/autograd/functions/basic_ops.cpp
+++ b/torch/csrc/autograd/functions/basic_ops.cpp
@@ -39,7 +39,7 @@ auto DelayedError::apply(variable_list&& inputs) -> variable_list {
     outputs.emplace_back(var.defined() ? var.tensor_data() : at::Tensor());
   }
   return wrap_outputs(inputs, std::move(outputs), [&](edge_list&& next_edges) {
-    return std::make_shared<Error>(msg, std::move(next_edges));
+    return c10::make_intrusive<Error>(msg, std::move(next_edges));
   });
 }
 
@@ -51,7 +51,7 @@ auto UndefinedGrad::apply(variable_list&& inputs) -> variable_list {
         var.defined() ? var.clone().tensor_data() : at::Tensor());
   }
   return wrap_outputs(inputs, std::move(outputs), [&](edge_list&& next_edges) {
-    return std::make_shared<UndefinedGradBackward>(std::move(next_edges));
+    return c10::make_intrusive<UndefinedGradBackward>(std::move(next_edges));
   });
 }
 

--- a/torch/csrc/autograd/functions/comm.cpp
+++ b/torch/csrc/autograd/functions/comm.cpp
@@ -31,10 +31,10 @@ variable_list Scatter::apply(variable_list&& inputs) {
   AT_ASSERT(inputs.size() == 1);
   auto& input = inputs.front();
 
-  std::shared_ptr<Node> grad_fn;
+  c10::intrusive_ptr<Node> grad_fn;
   if (compute_requires_grad(input)) {
-    grad_fn =
-        std::make_shared<Gather>(/*destination_device=*/input.device(), dim_);
+    grad_fn = c10::make_intrusive<Gather>(
+        /*destination_device=*/input.device(), dim_);
     grad_fn->set_next_edges(collect_next_edges(input));
   }
 
@@ -88,7 +88,7 @@ variable_list Gather::apply(variable_list&& inputs) {
         "and return a vector.");
   }
 
-  std::shared_ptr<Node> grad_fn;
+  c10::intrusive_ptr<Node> grad_fn;
   // compute this before moving variables from `inputs`
   if (compute_requires_grad(inputs)) {
     std::vector<at::Device> source_devices;
@@ -99,7 +99,7 @@ variable_list Gather::apply(variable_list&& inputs) {
       source_devices.push_back(input.device());
       input_sizes.push_back(input.size(dim_));
     }
-    grad_fn = std::make_shared<Scatter>(
+    grad_fn = c10::make_intrusive<Scatter>(
         std::move(source_devices),
         std::move(input_sizes),
         dim_,

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -108,7 +108,7 @@ CopySlices::CopySlices(
     const Variable& base_var,
     at::TensorGeometry view_,
     std::unique_ptr<ViewFunc> view_fn_,
-    std::shared_ptr<Node> fn_)
+    c10::intrusive_ptr<Node> fn_)
     : base(base_var),
       view(std::move(view_)),
       view_fn(std::move(view_fn_)),

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -160,7 +160,7 @@ struct TORCH_API CopySlices : public Node {
       const Variable& base_var,
       at::TensorGeometry view_,
       std::unique_ptr<ViewFunc> view_fn_,
-      std::shared_ptr<Node> fn_);
+      c10::intrusive_ptr<Node> fn_);
 
   // common code between apply/apply_with_saved
   template <typename T>
@@ -179,7 +179,7 @@ struct TORCH_API CopySlices : public Node {
   // See Note [View + Inplace update for base tensor] for details.
   at::TensorGeometry view;
   std::unique_ptr<ViewFunc> view_fn;
-  std::shared_ptr<Node> fn;
+  c10::intrusive_ptr<Node> fn;
 };
 
 } // namespace torch::autograd

--- a/torch/csrc/autograd/functions/utils.h
+++ b/torch/csrc/autograd/functions/utils.h
@@ -15,7 +15,8 @@
 
 namespace torch::autograd {
 
-using function_constructor = std::function<std::shared_ptr<Node>(edge_list&&)>;
+using function_constructor =
+    std::function<c10::intrusive_ptr<Node>(edge_list&&)>;
 
 /**
  * Wraps the tensor outputs in variables and creates the grad_fn and sets the
@@ -65,7 +66,7 @@ inline bool compute_requires_grad(Args&&... args) {
 
 inline void set_history(
     const at::Tensor& variable,
-    const std::shared_ptr<Node>& grad_fn) {
+    const c10::intrusive_ptr<Node>& grad_fn) {
   TORCH_CHECK(grad_fn != nullptr);
   if (variable.defined()) {
     // If the codegen triggers this, you most likely want to add your newly
@@ -84,7 +85,7 @@ inline void set_history(
 
 inline void set_history(
     const std::vector<Variable>& variables,
-    const std::shared_ptr<Node>& grad_fn) {
+    const c10::intrusive_ptr<Node>& grad_fn) {
   for (auto& variable : variables) {
     set_history(variable, grad_fn);
   }

--- a/torch/csrc/autograd/graph_task.h
+++ b/torch/csrc/autograd/graph_task.h
@@ -158,13 +158,15 @@ struct GraphTask : std::enable_shared_from_this<GraphTask> {
 
   // Set an appropriate exception on this graph_task which was encountered while
   // running the provided function.
-  void set_exception(std::exception_ptr eptr, const std::shared_ptr<Node>& fn);
+  void set_exception(
+      std::exception_ptr eptr,
+      const c10::intrusive_ptr<Node>& fn);
 
   // Set an appropriate exception on this graph_task which was encountered while
   // running the provided function. But doesn't signal completion on
   // 'future_result_' right away. The user needs to explicitly mark
   // 'future_result_' completed with an appropriate exception.
-  void set_exception_without_signal(const std::shared_ptr<Node>& fn);
+  void set_exception_without_signal(const c10::intrusive_ptr<Node>& fn);
 
   // Whether or not to stop execution for this GraphTask when an error is
   // encountered. When set to true, this would cause Engine::execute() to throw

--- a/torch/csrc/autograd/node.h
+++ b/torch/csrc/autograd/node.h
@@ -11,6 +11,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/record_function.h>
 #include <c10/util/Exception.h>
+#include <c10/util/intrusive_ptr.h>
 #include <c10/util/irange.h>
 
 #include <algorithm>
@@ -42,23 +43,20 @@ using torch::dynamo::autograd::CompiledNodeArgs;
 using torch::dynamo::autograd::PackedArgs;
 using torch::dynamo::autograd::SwapSavedVariables;
 
-// Custom deleter to prevent stack overflows.
-TORCH_API void deleteNode(Node* function);
-
 // Guard that sets and restores the evaluating node
 class NodeGuard {
  public:
-  explicit NodeGuard(std::shared_ptr<Node> node);
+  explicit NodeGuard(c10::intrusive_ptr<Node> node);
   ~NodeGuard();
 
  private:
-  std::shared_ptr<Node> last_evaluating_node_;
+  c10::intrusive_ptr<Node> last_evaluating_node_;
 };
 
 // Return the Node currently being evaluated (if any)
 // This is only set during the backward pass while a Node is being
 // executed.
-TORCH_API std::shared_ptr<Node> get_current_node();
+TORCH_API c10::intrusive_ptr<Node> get_current_node();
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //                               Node
@@ -110,7 +108,7 @@ TORCH_API std::shared_ptr<Node> get_current_node();
 // See NOTE [ Sequence Number] for more details on the usages of sequence
 // number.
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-struct TORCH_API Node : std::enable_shared_from_this<Node> {
+struct TORCH_API Node : c10::intrusive_ptr_target {
  public:
   /// Construct a new `Node` with the given `next_edges`
   explicit Node(uint64_t sequence_nr, edge_list&& next_edges = edge_list())
@@ -144,10 +142,11 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
   Node(Node&& other) = delete;
   Node& operator=(const Node& other) = delete;
   Node& operator=(Node&& other) = delete;
-  virtual ~Node() = default;
+  ~Node() override;
+  void release_resources() override;
 
-  std::shared_ptr<Node> getptr() {
-    return shared_from_this();
+  c10::intrusive_ptr<Node> getptr() {
+    return c10::intrusive_ptr<Node>::unsafe_reclaim_from_nonowning(this);
   }
   /// Evaluates the function on the given inputs and returns the result of the
   /// function call.

--- a/torch/csrc/autograd/python_anomaly_mode.cpp
+++ b/torch/csrc/autograd/python_anomaly_mode.cpp
@@ -74,7 +74,7 @@ void PyAnomalyMetadata::print_stack(const std::string& current_node_name) {
 }
 
 void PyAnomalyMetadata::assign_parent(
-    const std::shared_ptr<Node>& parent_node) {
+    const c10::intrusive_ptr<Node>& parent_node) {
   // assign the python object of parent_node in metadata["parent_"]
   // if parent_node is nullptr, then do nothing (it can mean that "parent_" key
   // is not in metadata)

--- a/torch/csrc/autograd/python_anomaly_mode.h
+++ b/torch/csrc/autograd/python_anomaly_mode.h
@@ -26,7 +26,7 @@ struct PyAnomalyMetadata : public AnomalyMetadata {
   }
   void store_stack() override;
   void print_stack(const std::string& current_node_name) override;
-  void assign_parent(const std::shared_ptr<Node>& parent_node) override;
+  void assign_parent(const c10::intrusive_ptr<Node>& parent_node) override;
 
   PyObject* dict() {
     return dict_;

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -124,7 +124,7 @@ int THPCppFunction_clear(PyObject* self) {
 void THPCppFunction_dealloc(PyObject* self) {
   PyObject_GC_UnTrack(self);
   THPCppFunction_clear(self);
-  ((THPCppFunction*)self)->cdata.~shared_ptr();
+  ((THPCppFunction*)self)->cdata.~intrusive_ptr();
   Py_TYPE(self)->tp_free(self);
 }
 
@@ -282,7 +282,7 @@ static PyTypeObject* get_default_type() {
   return &(default_type.type);
 }
 
-PyObject* functionToPyObject(const std::shared_ptr<Node>& cdata) {
+PyObject* functionToPyObject(const c10::intrusive_ptr<Node>& cdata) {
   if (!cdata) {
     Py_RETURN_NONE;
   }
@@ -309,7 +309,7 @@ PyObject* functionToPyObject(const std::shared_ptr<Node>& cdata) {
     if (!obj)
       return nullptr;
     THPCppFunction* f = (THPCppFunction*)obj.get();
-    new (&f->cdata) std::shared_ptr<Node>(cdata);
+    new (&f->cdata) c10::intrusive_ptr<Node>(cdata);
 
     // No INCREF here as we only have a weak reference
     cdata->set_pyobj(obj.release());

--- a/torch/csrc/autograd/python_cpp_function.h
+++ b/torch/csrc/autograd/python_cpp_function.h
@@ -13,7 +13,7 @@ namespace torch::autograd {
 
 struct THPCppFunction {
   PyObject_HEAD
-  std::shared_ptr<Node> cdata;
+  c10::intrusive_ptr<Node> cdata;
 };
 
 template <typename Ctor>
@@ -26,7 +26,8 @@ TORCH_PYTHON_API PyObject* CppFunction_pynew(
     return nullptr;
   THPCppFunction* f = (THPCppFunction*)obj.get();
   HANDLE_TH_ERRORS
-  new (&f->cdata) std::shared_ptr<Node>(Ctor()(args));
+  new (&f->cdata) c10::intrusive_ptr<Node>(
+      c10::intrusive_ptr<Node>::unsafe_steal_from_new(Ctor()(args)));
   END_HANDLE_TH_ERRORS
   if (!f->cdata) {
     return nullptr;
@@ -124,7 +125,7 @@ TORCH_PYTHON_API void registerCppFunction(
     const std::type_info& type,
     PyTypeObject* pytype);
 TORCH_PYTHON_API PyObject* functionToPyObject(
-    const std::shared_ptr<Node>& cdata);
+    const c10::intrusive_ptr<Node>& cdata);
 
 TORCH_PYTHON_API bool THPCppFunction_Check(PyObject* obj);
 

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -91,7 +91,7 @@ void PythonEngine::thread_init(
 
 void PythonEngine::thread_on_exception(
     const std::shared_ptr<GraphTask>& graph_task,
-    const std::shared_ptr<Node>& fn,
+    const c10::intrusive_ptr<Node>& fn,
     std::exception& e) {
   // See Note [ Persisting PyErr state across autograd engine threads ]
   auto python_err = dynamic_cast<python_error*>(&e);
@@ -134,7 +134,7 @@ variable_list PythonEngine::execute(
 
 c10::intrusive_ptr<at::ivalue::Future> PythonEngine::execute_with_graph_task(
     const std::shared_ptr<GraphTask>& graph_task,
-    std::shared_ptr<Node> graph_root,
+    c10::intrusive_ptr<Node> graph_root,
     InputBuffer&& input_buffer) {
   try {
     return Engine::execute_with_graph_task(
@@ -153,7 +153,7 @@ c10::intrusive_ptr<at::ivalue::Future> PythonEngine::execute_with_graph_task(
 static Edge parseGradientEdge(PyObject* obj, int64_t index) {
   PyObject* grad_fn = PyTuple_GetItem(obj, 0);
   auto output_nr = THPUtils_unpackLong(PyTuple_GetItem(obj, 1));
-  std::shared_ptr<torch::autograd::Node> grad_fn_sp;
+  c10::intrusive_ptr<torch::autograd::Node> grad_fn_sp;
   if (THPFunction_Check(grad_fn)) {
     grad_fn_sp = ((THPFunction*)grad_fn)->cdata.lock();
   } else if (THPCppFunction_Check(grad_fn)) {
@@ -340,7 +340,7 @@ static PyObject* THPEngine_run_backward(
           // so nodes in the graph (e.g., mul when an operand is scalar) that
           // have edges pointing to nullptr don't get erroneously assigned
           // `needed = True` in exec_info.
-          output_edges.emplace_back(std::make_shared<Identity>(), 0);
+          output_edges.emplace_back(c10::make_intrusive<Identity>(), 0);
         } else {
           output_edges.emplace_back(grad_fn, output_nr);
         }

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -18,7 +18,7 @@ struct PythonEngine : public Engine {
       bool should_increment) override;
   void thread_on_exception(
       const std::shared_ptr<GraphTask>& graph_task,
-      const std::shared_ptr<Node>& fn,
+      const c10::intrusive_ptr<Node>& fn,
       std::exception& e) override;
   variable_list execute(
       const edge_list& roots,
@@ -30,7 +30,7 @@ struct PythonEngine : public Engine {
 
   c10::intrusive_ptr<at::ivalue::Future> execute_with_graph_task(
       const std::shared_ptr<GraphTask>& graph_task,
-      std::shared_ptr<Node> graph_root,
+      c10::intrusive_ptr<Node> graph_root,
       InputBuffer&& input_buffer) override;
 
   std::unique_ptr<AnomalyMetadata> make_anomaly_metadata() override;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -63,7 +63,7 @@ PyObject* THPGradientEdgeClass = nullptr;
 namespace {
 
 inline void check_legacy_fn_attr_access(
-    const std::shared_ptr<torch::autograd::Node>& cdata,
+    const c10::intrusive_ptr<torch::autograd::Node>& cdata,
     const char* attr) {
   TORCH_CHECK(
       cdata,
@@ -353,6 +353,20 @@ auto PyNode::release_variables() -> void {
   }
 }
 
+void PyNode::release_resources() {
+  // NB: Node::release_resources calls into release_variables(), which
+  // accesses the Python object so it must be called first.
+  Node::release_resources();
+
+  // Release the Python object so that it can be freed when the C++ Node
+  // outlives all strong references (weak_intrusive_ptr may keep the
+  // allocation alive, but shouldn't prevent the PyObject from being freed).
+  if (Py_IsInitialized()) {
+    pybind11::gil_scoped_acquire gil;
+    Py_CLEAR(obj);
+  }
+}
+
 auto PyNode::name() const -> std::string {
   pybind11::gil_scoped_acquire gil;
   auto f = (THPFunction*)obj;
@@ -583,7 +597,7 @@ static void THPFunction_dealloc(THPFunction* self) {
 
   PyObject_GC_UnTrack(self);
   THPFunction_clear(self);
-  self->cdata.~weak_ptr<PyNode>();
+  self->cdata.~weak_intrusive_ptr();
   self->output_info.~vector();
   self->input_info.~vector();
   self->saved_variables.~vector();
@@ -602,7 +616,8 @@ static PyObject* THPFunction_new(
   // most fields
   THPFunction* self = (THPFunction*)obj;
   // Setup the PyNode later; we can't keep it live here
-  new (&self->cdata) std::weak_ptr<PyNode>();
+  new (&self->cdata)
+      c10::weak_intrusive_ptr<PyNode>(c10::intrusive_ptr<PyNode>());
   new (&self->output_info) std::vector<VariableInfo>();
   new (&self->input_info) std::vector<VariableInfo>();
   new (&self->saved_variables) std::vector<SavedVariable>();
@@ -669,7 +684,7 @@ static std::unordered_set<at::TensorImpl*> _parse_non_differentiable(
 // do in this case.  After this method is run, t2var is extended with
 // mappings for output tensors as well.
 static void _wrap_outputs(
-    const std::shared_ptr<PyNode>& cdata,
+    const c10::intrusive_ptr<PyNode>& cdata,
     THPFunction* self,
     const variable_list& input_vars,
     PyObject* raw_output,
@@ -884,7 +899,7 @@ static void _get_tensors_to_save(
 // Save any variables that requested by to_save
 static void _save_variables(
     const std::vector<std::optional<at::Tensor>>& tensors_to_save,
-    const std::shared_ptr<PyNode>& cdata_ptr,
+    const c10::intrusive_ptr<PyNode>& cdata_ptr,
     THPFunction* self,
     PyObject* outputs,
     int64_t num_outputs) {
@@ -1173,7 +1188,7 @@ void _trace_post_record(
 
 PyObject* process_outputs(
     PyObject* op_obj,
-    const std::shared_ptr<PyNode>& cdata,
+    const c10::intrusive_ptr<PyNode>& cdata,
     THPFunction* grad_fn,
     const UnpackedInput& unpacked,
     PyObject* inputs,
@@ -1406,8 +1421,7 @@ PyObject* THPFunction_apply(PyObject* cls, PyObject* inputs) {
     return nullptr;
   THPFunction* ctx = (THPFunction*)ctx_obj.get();
 
-  auto cdata =
-      std::shared_ptr<PyNode>(new PyNode(std::move(ctx_obj)), deleteNode);
+  auto cdata = c10::make_intrusive<PyNode>(std::move(ctx_obj));
   ctx->cdata = cdata;
 
   // Record input nodes if tracing

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -41,6 +41,7 @@ struct PyNode : public Node {
       const SwapSavedVariables& saved);
 
   void release_variables() override;
+  void release_resources() override;
   std::string name() const override;
   bool is_traceable() override;
 
@@ -60,9 +61,9 @@ struct PyNode : public Node {
     // out GIL!  When I forgot to do this by hand
     // TestAutograd.test_inplace_view_python called me out about it.
     // If python is already dead, leak the wrapped python objects
-    if (Py_IsInitialized()) {
+    if (obj && Py_IsInitialized()) {
       pybind11::gil_scoped_acquire gil;
-      Py_DECREF(obj);
+      Py_CLEAR(obj);
     }
   }
 };
@@ -154,7 +155,8 @@ struct THPFunction {
   // for it.  We can't enforce this directly in the constructor of
   // THPFunction though, because there's no way to keep it live long enough
   // to save an owning reference to PyNode into the grad_fn of a Variable.
-  std::weak_ptr<torch::autograd::PyNode> cdata;
+  c10::weak_intrusive_ptr<torch::autograd::PyNode> cdata{
+      c10::intrusive_ptr<torch::autograd::PyNode>()};
 };
 
 bool THPFunction_initModule(PyObject* module);

--- a/torch/csrc/autograd/python_torch_functions_manual.cpp
+++ b/torch/csrc/autograd/python_torch_functions_manual.cpp
@@ -797,10 +797,8 @@ void initTorchFunctions(PyObject* module) {
         if (inner_autograd_meta) {
           dst_.set_requires_grad(src_.requires_grad());
           if (dst_.requires_grad()) {
-            auto new_grad_fn = std::shared_ptr<torch::autograd::Error>(
-                new torch::autograd::Error(
-                    "Cannot backprop through mirrored meta, file a bug in PyTorch"),
-                torch::autograd::deleteNode);
+            auto new_grad_fn = c10::make_intrusive<torch::autograd::Error>(
+                "Cannot backprop through mirrored meta, file a bug in PyTorch");
             torch::autograd::set_history(dst_, new_grad_fn);
           }
         }

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -127,7 +127,7 @@ SavedVariable::SavedVariable(
           is_output,
           is_inplace_on_view) {}
 
-Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
+Variable SavedVariable::unpack(c10::intrusive_ptr<Node> saved_for) const {
   if (was_default_constructed_) {
     return Variable();
   }
@@ -139,7 +139,7 @@ Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
   // We want grad_fn here to provide the most helpful debug message to the user
   // if versions don't match
 
-  std::shared_ptr<Node> grad_fn;
+  c10::intrusive_ptr<Node> grad_fn;
   if (is_inplace_on_view_) {
     grad_fn = weak_grad_fn_.lock();
   } else if (!hooks_) {
@@ -225,7 +225,8 @@ Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
     var = make_variable(data, requires_grad_);
   }
 
-  impl::set_grad_accumulator(var, grad_accumulator_);
+  impl::set_grad_accumulator(
+      var, c10::weak_intrusive_ptr<Node>(grad_accumulator_));
   impl::set_version_counter(var, impl::version_counter(data));
 
   // NB: var here is never a view so there is no need to make anything special

--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -3,6 +3,7 @@
 #include <c10/core/SafePyObject.h>
 #include <torch/csrc/Export.h>
 #include <torch/csrc/autograd/forward_grad.h>
+#include <torch/csrc/autograd/node.h>
 #include <torch/csrc/autograd/saved_variable_hooks.h>
 
 #include <ATen/core/Tensor.h>
@@ -13,7 +14,6 @@
 namespace torch::autograd {
 
 using Variable = at::Tensor;
-struct Node;
 
 TORCH_API extern const char* ERR_BACKWARD_TWICE;
 
@@ -44,7 +44,7 @@ class TORCH_API SavedVariable {
   /// Reconstructs the saved variable. Pass `saved_for` as the gradient
   /// function if constructing the `SavedVariable` with it would have caused a
   /// circular reference.
-  Variable unpack(std::shared_ptr<Node> saved_for = nullptr) const;
+  Variable unpack(c10::intrusive_ptr<Node> saved_for = nullptr) const;
 
   void register_hooks(std::unique_ptr<SavedVariableHooks>&& hooks);
 
@@ -105,7 +105,7 @@ class TORCH_API SavedVariable {
   // is_inplace_on_view = true.
   // In that case, the grad_fn passed in to the unpack function at unwrapping
   // time is unused.
-  std::weak_ptr<Node> weak_grad_fn_;
+  c10::weak_intrusive_ptr<Node> weak_grad_fn_{c10::intrusive_ptr<Node>()};
 
   uint32_t saved_version_ = 0;
   uint32_t output_nr_ = 0;
@@ -123,12 +123,12 @@ class TORCH_API SavedVariable {
   // Fields grad_fn_, grad_accumulator_, and requires_grad_ are only used if
   // hooks are defined. They are set before pack_hook is called and used after
   // unpack_hook is called.
-  std::shared_ptr<Node> grad_fn_;
+  c10::intrusive_ptr<Node> grad_fn_;
   // For the usual case where leaf tensors are the input, we expect its
   // grad_acc to be kept alive by the graph. The reason SavedVariable holds
   // a owning reference is to support the case where a custom autograd Function
   // saves an intermediate.
-  std::shared_ptr<Node> grad_accumulator_;
+  c10::intrusive_ptr<Node> grad_accumulator_;
   bool requires_grad_ = false;
 
   void save_metadata(const Variable& data);

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -179,8 +179,8 @@ AutogradMeta* materialize_autograd_meta(const at::TensorBase& self) {
 
 static void update_tensor_hooks_on_new_gradfn(
     const at::TensorBase& self,
-    const std::shared_ptr<torch::autograd::Node>& old_fn,
-    const std::shared_ptr<torch::autograd::Node>& new_fn) {
+    const c10::intrusive_ptr<torch::autograd::Node>& old_fn,
+    const c10::intrusive_ptr<torch::autograd::Node>& new_fn) {
   // This function is called whenever the grad_fn of the tensor is
   // changed. We assume here that new_fn does not yet have hooks of
   // its own.
@@ -228,7 +228,7 @@ void rebase_history(const Variable& self, Edge gradient_edge) {
         "Functions which modify views in-place must return a single Variable");
     const auto& view_info = diff_view_meta->get_backward_view();
     diff_view_meta->output_nr_ = gradient_edge.input_nr;
-    auto copy_slices = std::make_shared<CopySlices>(
+    auto copy_slices = c10::make_intrusive<CopySlices>(
         view_info.base_,
         at::TensorGeometry(self),
         view_info.has_view_fn() ? view_info.view_fn().clone_and_set() : nullptr,
@@ -268,12 +268,12 @@ void create_cpp_hook(const at::TensorBase& self, bool is_retains_grad_hook) {
 
 void set_grad_accumulator(
     const Variable& self,
-    std::weak_ptr<Node> grad_accumulator) {
+    c10::weak_intrusive_ptr<Node> grad_accumulator) {
   materialize_autograd_meta(self)->grad_accumulator_ =
       std::move(grad_accumulator);
 }
 
-std::shared_ptr<Node> try_get_grad_accumulator(const at::TensorBase& self) {
+c10::intrusive_ptr<Node> try_get_grad_accumulator(const at::TensorBase& self) {
   if (get_autograd_meta(self)) {
     return get_autograd_meta(self)->grad_accumulator_.lock();
   } else {
@@ -281,11 +281,11 @@ std::shared_ptr<Node> try_get_grad_accumulator(const at::TensorBase& self) {
   }
 }
 
-std::shared_ptr<Node> try_get_grad_accumulator(const Variable& self) {
+c10::intrusive_ptr<Node> try_get_grad_accumulator(const Variable& self) {
   return try_get_grad_accumulator(get_tensor_base(self));
 }
 
-std::shared_ptr<Node> grad_accumulator(const Variable& self) {
+c10::intrusive_ptr<Node> grad_accumulator(const Variable& self) {
   auto autograd_meta = get_autograd_meta(self);
   if (!autograd_meta) {
     return nullptr;
@@ -307,9 +307,9 @@ std::shared_ptr<Node> grad_accumulator(const Variable& self) {
   c10::raw::intrusive_ptr::incref(self.unsafeGetTensorImpl());
   auto intrusive_from_this =
       c10::intrusive_ptr<at::TensorImpl>::reclaim(self.unsafeGetTensorImpl());
-  result = std::make_shared<AccumulateGrad>(
+  result = c10::make_intrusive<AccumulateGrad>(
       Variable(std::move(intrusive_from_this)));
-  autograd_meta->grad_accumulator_ = result;
+  autograd_meta->grad_accumulator_ = c10::weak_intrusive_ptr<Node>(result);
   return result;
 }
 
@@ -645,10 +645,10 @@ const std::string& VariableHooks::name(const at::TensorBase& self) const {
 }
 
 namespace {
-std::shared_ptr<torch::autograd::Node> singleton_shared_ptr;
+c10::intrusive_ptr<torch::autograd::Node> singleton_intrusive_ptr;
 }
 
-const std::shared_ptr<torch::autograd::Node>& VariableHooks::grad_fn(
+const c10::intrusive_ptr<torch::autograd::Node>& VariableHooks::grad_fn(
     const at::TensorBase& self) const {
   auto diff_view_meta = torch::autograd::impl::get_view_autograd_meta(self);
   if (diff_view_meta && diff_view_meta->has_bw_view()) {
@@ -703,8 +703,8 @@ const std::shared_ptr<torch::autograd::Node>& VariableHooks::grad_fn(
         }
         diff_view_meta->grad_fn_ = diff_view.grad_fn();
       } else {
-        auto fn =
-            std::make_shared<torch::autograd::generated::AsStridedBackward0>();
+        auto fn = c10::make_intrusive<
+            torch::autograd::generated::AsStridedBackward0>();
         fn->self_geometry = at::TensorGeometry(view_info.base_);
         fn->size = self.sym_sizes().vec();
         fn->stride = self.sym_strides().vec();
@@ -731,7 +731,7 @@ const std::shared_ptr<torch::autograd::Node>& VariableHooks::grad_fn(
   if (torch::autograd::impl::get_autograd_meta(self)) {
     return torch::autograd::impl::get_autograd_meta(self)->grad_fn_;
   } else {
-    return singleton_shared_ptr;
+    return singleton_intrusive_ptr;
   }
 }
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -7,6 +7,7 @@
 #include <torch/csrc/autograd/edge.h>
 #include <torch/csrc/autograd/forward_grad.h>
 #include <torch/csrc/autograd/function_hook.h>
+#include <torch/csrc/autograd/node.h>
 
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/core/Tensor.h>
@@ -48,8 +49,6 @@ namespace torch::autograd {
 inline bool isDifferentiableType(at::ScalarType t) {
   return isFloatingType(t) || isComplexType(t);
 }
-
-struct Node;
 
 ///~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ///                                Variable
@@ -124,19 +123,19 @@ TORCH_API AutogradMeta* materialize_autograd_meta(
 /// leaf variables. Interior variables should call `set_gradient_edge()`.
 TORCH_API void set_grad_accumulator(
     const Variable& /*self*/,
-    std::weak_ptr<Node> grad_accumulator);
+    c10::weak_intrusive_ptr<Node> grad_accumulator);
 
 /// Attempts to get a pointer to the gradient accumulator of the `Variable`,
 /// if it still exists. If the gradient accumulator function has been
 /// destroyed, returns a `nullptr`.
-TORCH_API std::shared_ptr<Node> try_get_grad_accumulator(
+TORCH_API c10::intrusive_ptr<Node> try_get_grad_accumulator(
     const Variable& /*self*/);
-TORCH_API std::shared_ptr<Node> try_get_grad_accumulator(
+TORCH_API c10::intrusive_ptr<Node> try_get_grad_accumulator(
     const at::TensorBase& /*self*/);
 
 /// Gets the gradient accumulator of the `Variable` if it has one, or else
 /// create one on the fly and return it.
-TORCH_API std::shared_ptr<Node> grad_accumulator(const Variable& /*self*/);
+TORCH_API c10::intrusive_ptr<Node> grad_accumulator(const Variable& /*self*/);
 
 /// Returns the "canonical" gradient edge of this `Variable`, i.e. either the
 /// gradient function if this is an interior `Variable`, or the gradient
@@ -228,8 +227,8 @@ struct TORCH_API AutogradMeta : public c10::AutogradMetaInterface {
   std::string name_;
 
   Variable grad_;
-  std::shared_ptr<Node> grad_fn_;
-  std::weak_ptr<Node> grad_accumulator_;
+  c10::intrusive_ptr<Node> grad_fn_;
+  c10::weak_intrusive_ptr<Node> grad_accumulator_;
 
   // This field is used to store all the forward AD gradients
   // associated with this AutogradMeta (and the Tensor it corresponds to)
@@ -333,7 +332,7 @@ struct TORCH_API AutogradMeta : public c10::AutogradMetaInterface {
       bool requires_grad = false,
       Edge gradient_edge = Edge())
       : grad_fn_(std::move(gradient_edge.function)),
-
+        grad_accumulator_(c10::intrusive_ptr<Node>()),
         output_nr_(gradient_edge.input_nr) {
     // set_requires_grad also checks error conditions.
     if (requires_grad) {
@@ -961,7 +960,7 @@ struct VariableHooks final : at::impl::VariableHooksInterface {
       const at::TensorBase& /*self*/ /*unused*/) const override;
   at::TensorBase variable_data(
       const at::TensorBase& /*self*/ /*unused*/) const override;
-  const std::shared_ptr<torch::autograd::Node>& grad_fn(
+  const c10::intrusive_ptr<torch::autograd::Node>& grad_fn(
       const at::TensorBase& /*self*/ /*unused*/) const override;
   unsigned _register_hook(
       const at::TensorBase& /*self*/ /*unused*/,

--- a/torch/csrc/distributed/autograd/context/context.cpp
+++ b/torch/csrc/distributed/autograd/context/context.cpp
@@ -29,7 +29,7 @@ void DistAutogradContext::addKnownWorkerId(const rpc::worker_id_t workerId) {
 }
 
 void DistAutogradContext::addSendFunction(
-    const std::shared_ptr<SendRpcBackward>& func,
+    const c10::intrusive_ptr<SendRpcBackward>& func,
     int64_t autograd_message_id) {
   TORCH_INTERNAL_ASSERT(func != nullptr);
 
@@ -41,7 +41,7 @@ void DistAutogradContext::addSendFunction(
 }
 
 void DistAutogradContext::addRecvFunction(
-    std::shared_ptr<RecvRpcBackward>& func,
+    c10::intrusive_ptr<RecvRpcBackward>& func,
     int64_t autograd_message_id) {
   TORCH_INTERNAL_ASSERT(func != nullptr);
 
@@ -52,13 +52,13 @@ void DistAutogradContext::addRecvFunction(
   recvAutogradFunctions_.emplace(autograd_message_id, func);
 }
 
-std::unordered_map<int64_t, std::shared_ptr<SendRpcBackward>>
+std::unordered_map<int64_t, c10::intrusive_ptr<SendRpcBackward>>
 DistAutogradContext::sendFunctions() const {
   std::lock_guard<std::mutex> guard(lock_);
   return sendAutogradFunctions_;
 }
 
-std::unordered_map<int64_t, std::shared_ptr<RecvRpcBackward>>
+std::unordered_map<int64_t, c10::intrusive_ptr<RecvRpcBackward>>
 DistAutogradContext::recvFunctions() const {
   std::lock_guard<std::mutex> guard(lock_);
   return recvAutogradFunctions_;
@@ -218,7 +218,7 @@ c10::intrusive_ptr<c10::ivalue::Future> DistAutogradContext::
   return state->future;
 }
 
-std::shared_ptr<SendRpcBackward> DistAutogradContext::retrieveSendFunction(
+c10::intrusive_ptr<SendRpcBackward> DistAutogradContext::retrieveSendFunction(
     int64_t autograd_message_id) {
   std::lock_guard<std::mutex> guard(lock_);
   auto it = sendAutogradFunctions_.find(autograd_message_id);

--- a/torch/csrc/distributed/autograd/context/context.h
+++ b/torch/csrc/distributed/autograd/context/context.h
@@ -28,26 +28,26 @@ class TORCH_API DistAutogradContext {
   // Records a 'send' autograd function for this context with the provided
   // message id.
   void addSendFunction(
-      const std::shared_ptr<SendRpcBackward>& func,
+      const c10::intrusive_ptr<SendRpcBackward>& func,
       int64_t autograd_message_id);
 
   // Records a 'recv' autograd function for this context with the provided
   // message id.
   void addRecvFunction(
-      std::shared_ptr<RecvRpcBackward>& func,
+      c10::intrusive_ptr<RecvRpcBackward>& func,
       int64_t autograd_message_id);
 
   // Given an autograd_message_id, retrieve the appropriate send function.
-  std::shared_ptr<SendRpcBackward> retrieveSendFunction(
+  c10::intrusive_ptr<SendRpcBackward> retrieveSendFunction(
       int64_t autograd_message_id);
 
   // Return all send functions for this context.
-  std::unordered_map<int64_t, std::shared_ptr<SendRpcBackward>> sendFunctions()
-      const;
+  std::unordered_map<int64_t, c10::intrusive_ptr<SendRpcBackward>>
+  sendFunctions() const;
 
   // Return all recv functions for this context.
-  std::unordered_map<int64_t, std::shared_ptr<RecvRpcBackward>> recvFunctions()
-      const;
+  std::unordered_map<int64_t, c10::intrusive_ptr<RecvRpcBackward>>
+  recvFunctions() const;
 
   // Adds a future message recording an outstanding RPC.
   void addOutstandingRpc(const c10::intrusive_ptr<rpc::JitFuture>& jitFuture);
@@ -122,11 +122,11 @@ class TORCH_API DistAutogradContext {
   std::unordered_set<rpc::worker_id_t> knownWorkerIds_;
 
   // Map from autograd_message_id to appropriate 'send' autograd function.
-  std::unordered_map<int64_t, std::shared_ptr<SendRpcBackward>>
+  std::unordered_map<int64_t, c10::intrusive_ptr<SendRpcBackward>>
       sendAutogradFunctions_;
 
   // Map from autograd_message_id to appropriate 'recv' autograd function.
-  std::unordered_map<int64_t, std::shared_ptr<RecvRpcBackward>>
+  std::unordered_map<int64_t, c10::intrusive_ptr<RecvRpcBackward>>
       recvAutogradFunctions_;
 
   // Gradients accumulated in this context so far. The key is the variable on

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -36,7 +36,7 @@ class DistAccumulateGradCaptureHook
     : public GraphTask::ExecInfo::Capture::GradCaptureHook {
  public:
   DistAccumulateGradCaptureHook(
-      std::shared_ptr<AccumulateGrad> accumulateGrad,
+      c10::intrusive_ptr<AccumulateGrad> accumulateGrad,
       ContextPtr autogradContext)
       : accumulateGrad_(std::move(accumulateGrad)),
         autogradContext_(std::move(autogradContext)) {}
@@ -69,7 +69,7 @@ class DistAccumulateGradCaptureHook
   }
 
  private:
-  std::shared_ptr<AccumulateGrad> accumulateGrad_;
+  c10::intrusive_ptr<AccumulateGrad> accumulateGrad_;
   ContextPtr autogradContext_;
 };
 
@@ -183,7 +183,7 @@ void DistEngine::computeDependencies(
     const ContextPtr& autogradContext,
     const edge_list& rootEdges,
     const variable_list& grads,
-    const std::shared_ptr<Node>& graphRoot,
+    const c10::intrusive_ptr<Node>& graphRoot,
     edge_list& outputEdges,
     bool retainGraph) {
   TORCH_INTERNAL_ASSERT(graphRoot, "graphRoot is null!");
@@ -324,8 +324,8 @@ void DistEngine::computeDependencies(
           // support. See NOTE [Deprecated capture hooks] for more context.
           capture.DO_NOT_USE_DEPRECATED_register_capture_hook(
               std::make_unique<DistAccumulateGradCaptureHook>(
-                  std::dynamic_pointer_cast<AccumulateGrad>(
-                      accumulateGradFn->shared_from_this()),
+                  c10::static_intrusive_pointer_cast<AccumulateGrad>(
+                      accumulateGradFn->getptr()),
                   autogradContext));
         }
       }
@@ -405,7 +405,7 @@ void DistEngine::execute_graph_task_until_ready_queue_empty(
 c10::intrusive_ptr<c10::ivalue::Future> DistEngine::
     runEngineAndAccumulateGradients(
         const ContextPtr& autogradContext,
-        const std::shared_ptr<Node>& graphRoot,
+        const c10::intrusive_ptr<Node>& graphRoot,
         const edge_list& outputEdges,
         bool incrementOutstandingTasks) {
   // Cleanup previous state for outstanding RPCs. Outstanding RPCs could be
@@ -458,7 +458,7 @@ c10::intrusive_ptr<c10::ivalue::Future> DistEngine::
 
 c10::intrusive_ptr<c10::ivalue::Future> DistEngine::executeSendFunctionAsync(
     const ContextPtr& autogradContext,
-    const std::shared_ptr<SendRpcBackward>& sendFunction,
+    const c10::intrusive_ptr<SendRpcBackward>& sendFunction,
     bool retainGraph) {
   // Typically the local autograd engine ensures stream synchronizations between
   // nodes in the graph. However, for distributed autograd the sendFunction
@@ -483,7 +483,8 @@ c10::intrusive_ptr<c10::ivalue::Future> DistEngine::executeSendFunctionAsync(
       initializedContextIds_.end()) {
     edge_list outputEdges;
     // Pass in a dummy graphRoot since all send functions are the roots.
-    auto dummyRoot = std::make_shared<GraphRoot>(edge_list(), variable_list());
+    auto dummyRoot =
+        c10::make_intrusive<GraphRoot>(edge_list(), variable_list());
     computeDependencies(
         autogradContext, {}, {}, dummyRoot, outputEdges, retainGraph);
 
@@ -574,8 +575,8 @@ void DistEngine::execute(
   variable_list grads;
   validateRootsAndRetrieveEdges(roots, rootEdges, grads);
 
-  std::shared_ptr<Node> graphRoot =
-      std::make_shared<GraphRoot>(rootEdges, grads);
+  c10::intrusive_ptr<Node> graphRoot =
+      c10::make_intrusive<GraphRoot>(rootEdges, grads);
   edge_list outputEdges;
   // Compute dependencies locally, starting from all roots and all 'send'
   // functions.

--- a/torch/csrc/distributed/autograd/engine/dist_engine.h
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.h
@@ -44,7 +44,7 @@ class TORCH_API DistEngine {
   // The gradients are accumulated in the provided autograd context.
   c10::intrusive_ptr<c10::ivalue::Future> executeSendFunctionAsync(
       const ContextPtr& autogradContext,
-      const std::shared_ptr<SendRpcBackward>& sendFunction,
+      const c10::intrusive_ptr<SendRpcBackward>& sendFunction,
       bool retainGraph);
 
   // Number of backward passes currently running for the Distributed Engine.
@@ -82,7 +82,7 @@ class TORCH_API DistEngine {
       const ContextPtr& context,
       const torch::autograd::edge_list& rootEdges,
       const torch::autograd::variable_list& grads,
-      const std::shared_ptr<torch::autograd::Node>& graphRoot,
+      const c10::intrusive_ptr<torch::autograd::Node>& graphRoot,
       torch::autograd::edge_list& outputEdges,
       bool retainGraph);
 
@@ -125,7 +125,7 @@ class TORCH_API DistEngine {
   // context.
   c10::intrusive_ptr<c10::ivalue::Future> runEngineAndAccumulateGradients(
       const ContextPtr& autogradContext,
-      const std::shared_ptr<torch::autograd::Node>& graphRoot,
+      const c10::intrusive_ptr<torch::autograd::Node>& graphRoot,
       const torch::autograd::edge_list& outputEdges,
       bool incrementOutStandingTasks = true);
 

--- a/torch/csrc/distributed/autograd/utils.cpp
+++ b/torch/csrc/distributed/autograd/utils.cpp
@@ -30,7 +30,7 @@ void addSendRpcBackward(
       [](const torch::Tensor& t) { return t.requires_grad(); });
 
   // Attach the appropriate autograd edges.
-  auto grad_fn = std::make_shared<SendRpcBackward>();
+  auto grad_fn = c10::make_intrusive<SendRpcBackward>();
   grad_fn->set_next_edges(
       torch::autograd::collect_next_edges(tensors_with_grad));
 
@@ -55,7 +55,7 @@ ContextPtr addRecvRpcBackward(
 
   if (!tensors.empty() && torch::autograd::compute_requires_grad(tensors)) {
     // Attach the tensors as inputs to the autograd function.
-    auto grad_fn = std::make_shared<RecvRpcBackward>(
+    auto grad_fn = c10::make_intrusive<RecvRpcBackward>(
         autogradMetadata, autogradContext, fromWorkerId, deviceMap);
     for (auto& tensor : tensors) {
       if (tensor.requires_grad()) {

--- a/torch/csrc/distributed/c10d/reducer.hpp
+++ b/torch/csrc/distributed/c10d/reducer.hpp
@@ -216,11 +216,11 @@ class TORCH_API Reducer {
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::vector<bool> expect_sparse_gradients_;
 
-  std::vector<std::shared_ptr<torch::autograd::Node>>
+  std::vector<c10::intrusive_ptr<torch::autograd::Node>>
       grad_accumulators_; // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::unordered_map<torch::autograd::Node*, size_t> gradAccToVariableMap_;
-  std::vector<std::pair<uintptr_t, std::shared_ptr<torch::autograd::Node>>>
+  std::vector<std::pair<uintptr_t, c10::intrusive_ptr<torch::autograd::Node>>>
       hooks_; // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
 
   // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)

--- a/torch/csrc/distributed/rpc/request_callback_no_python.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.cpp
@@ -367,7 +367,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
       autogradMetadata.autogradContextId);
 
   // Lookup the appropriate 'send' function to enqueue.
-  std::shared_ptr<SendRpcBackward> sendFunction =
+  c10::intrusive_ptr<SendRpcBackward> sendFunction =
       autogradContext->retrieveSendFunction(autogradMetadata.autogradMessageId);
 
   // Attach the gradients to the send function.

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -155,7 +155,7 @@ struct CacheKey {
 };
 
 struct NodeCall {
-  NodeCall(uint32_t id_, std::shared_ptr<Node> node_)
+  NodeCall(uint32_t id_, c10::intrusive_ptr<Node> node_)
       : id(id_), node(std::move(node_)) {}
 
   void mark_output(int input_nr, int output_idx) {
@@ -163,7 +163,7 @@ struct NodeCall {
   }
 
   uint32_t id;
-  std::shared_ptr<Node> node;
+  c10::intrusive_ptr<Node> node;
   std::vector<std::pair<int, int>> tensor_pre_hooks;
   std::vector<std::pair<int, int>> cpp_tensor_pre_hooks;
   std::vector<int> pre_hooks;
@@ -174,7 +174,7 @@ struct NodeCall {
 };
 
 struct NodeCalls : public std::unordered_map<Node*, NodeCall> {
-  NodeCall& lookup(const std::shared_ptr<Node>& function) {
+  NodeCall& lookup(const c10::intrusive_ptr<Node>& function) {
     auto it = find(function.get());
     if (it == end()) {
       it = emplace(function.get(), NodeCall(_next_id++, function)).first;
@@ -254,7 +254,9 @@ struct TensorArgs {
     return lookup(tensor, true);
   }
 
-  TensorArg& add(const SavedVariable& sv, const std::shared_ptr<Node>& node) {
+  TensorArg& add(
+      const SavedVariable& sv,
+      const c10::intrusive_ptr<Node>& node) {
     // no unpack hooks in this codepath
     at::Tensor tensor = sv.unpack(node);
     TensorArg& arg = add(tensor);
@@ -552,7 +554,7 @@ class CompiledNodeArgs {
   void collect(const caffe2::TypeMeta& t) {
     specialize_on_bytes(t.id());
   }
-  void collect(const std::shared_ptr<Node>& t) {
+  void collect(const c10::intrusive_ptr<Node>& t) {
     // Note: this is only capturing the ID of the node not everything
     // contained inside it.  This is used for tracking connections between
     // nodes and the actual details of the node itself must be handled by

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -886,7 +886,7 @@ static SizeInput::DynType get_default_dyn_type() {
 
 // Only call this function while holding GIL
 static CacheNode* _compiled_autograd_impl(
-    const std::shared_ptr<Node>& graph_root,
+    const c10::intrusive_ptr<Node>& graph_root,
     const GraphTask& graph_task,
     bool accumulate_grad,
     const edge_list& output_edges,
@@ -900,7 +900,7 @@ static CacheNode* _compiled_autograd_impl(
   std::unordered_map<Node*, int> visited_dependencies;
   visited_dependencies.reserve(dependencies.size());
 
-  std::vector<std::shared_ptr<Node>> worklist{graph_root};
+  std::vector<c10::intrusive_ptr<Node>> worklist{graph_root};
   AutogradCompilerCall compiler_call(get_default_dyn_type());
 
   for (const auto i : c10::irange(output_edges.size())) {
@@ -919,7 +919,7 @@ static CacheNode* _compiled_autograd_impl(
   std::optional<VerboseLogger> vlogger = VerboseLogger::maybe_create();
   std::optional<std::string> compile_reason;
   while (!worklist.empty()) {
-    std::shared_ptr<Node> fn = std::move(worklist.back());
+    c10::intrusive_ptr<Node> fn = std::move(worklist.back());
     worklist.pop_back();
     NodeCall& call = compiler_call.node_calls.lookup(fn);
     ordered_calls.emplace_back(&call);
@@ -1000,7 +1000,7 @@ static CacheNode* _compiled_autograd_impl(
       THPObjectPtr set_node_origin(
           PyObject_GetAttrString(py_compiler.get(), "set_node_origin"));
       PyObject* pyobj = Py_None;
-      if (auto pynode = std::dynamic_pointer_cast<PyNode>(call.node)) {
+      if (auto pynode = dynamic_cast<PyNode*>(call.node.get())) {
         pyobj = pynode->obj;
       }
       check(PyObject_CallFunction(
@@ -1198,7 +1198,7 @@ struct LockGuardWithErrorLogs {
 };
 
 static variable_list compiled_autograd(
-    const std::shared_ptr<Node>& graph_root,
+    const c10::intrusive_ptr<Node>& graph_root,
     const GraphTask& graph_task,
     bool accumulate_grad,
     const edge_list& output_edges) {

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -149,7 +149,7 @@ struct CaptureList {
     return capture_types_.size();
   }
 
-  void unpack(Stack& stack, const std::shared_ptr<autograd::Node>& saved_for) {
+  void unpack(Stack& stack, const c10::intrusive_ptr<autograd::Node>& saved_for) {
     auto var_capture_it = var_captures_.begin();
     auto ivalue_capture_it = ivalue_captures_.begin();
     auto size_it = sizes_.begin();
@@ -261,7 +261,7 @@ struct DifferentiableGraphBackward : public autograd::Node {
     stack.reserve(captures_.size() + inputs.size());
 
     input_instructions_.unpack(std::move(inputs), stack);
-    captures_.unpack(stack, shared_from_this());
+    captures_.unpack(stack, getptr());
     GRAPH_DEBUG("Running DifferentiableGraphBackward for ", &executor);
     executor.run(stack);
     unpackReturnTuple(stack);
@@ -348,7 +348,7 @@ struct DifferentiableGraphBackward : public autograd::Node {
     // generally a hard error in autograd.
     if (at::isFloatingType(output.scalar_type()) ||
         at::isComplexType(output.scalar_type())) {
-      autograd::create_gradient_edge(output, shared_from_this());
+      autograd::create_gradient_edge(output, getptr());
       output.set_requires_grad(true);
     } else {
       add_input_metadata(autograd::Node::undefined_input{});
@@ -422,7 +422,7 @@ struct DifferentiableGraphOp {
 
   // XXX: keep in mind that stack can be larger than the inputs we need!
   void operator()(Stack& stack) const {
-    auto grad_fn = std::make_shared<DifferentiableGraphBackward>(
+    auto grad_fn = c10::make_intrusive<DifferentiableGraphBackward>(
         grad_executor,
         grad.df_input_vjps.size(),
         grad.df_input_captured_inputs.size() +


### PR DESCRIPTION
Replace std::shared_ptr<Node> with c10::intrusive_ptr<Node> throughout the autograd system. Node now inherits from c10::intrusive_ptr_target instead of std::enable_shared_from_this<Node>.

**BC Breaking**:

This changes the signature of `Tensor::grad_fn`.  Accesses to `Tensor.grad_fn()` should change from `std::shared_ptr<Node>` to `c10::intrusive_ptr<Node>`. Similarly, construction of a C++ autograd function should change from:

```c++
std::shared_ptr<CustomCppNode> node(new CustomCppNode(), torch::autograd::deleteNode);
```

to

```c++
auto node = c10::make_intrusive<CustomCppNode>();
```

Authored with Claude.

cc @ezyang @gchanan @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @xmfan @aditvenk