### PR TITLE
Skip test_conv_error when TORCH_SHOW_CPP_STACKTRACES=1

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -103,11 +103,11 @@ import torch.nn.functional as F
 # Testing utils
 from torch.testing._internal import jit_utils
 from torch.testing._internal.common_jit import check_against_reference
-from torch.testing._internal.common_utils import run_tests, IS_ARM64, IS_WINDOWS, \
+from torch.testing._internal.common_utils import run_tests, IS_WINDOWS, \
     GRAPH_EXECUTOR, suppress_warnings, IS_SANDCASTLE, ProfilingMode, \
     TestCase, freeze_rng_state, slowTest, TemporaryFileName, \
     enable_profiling_mode_for_profiling_tests, TEST_MKL, set_default_dtype, num_profiled_runs, \
-    skipIfCrossRef, skipIfTorchDynamo, xfailIf
+    skipIfCrossRef, skipIfTorchDynamo
 from torch.testing._internal.jit_utils import JitTestCase, enable_cpu_fuser, disable_autodiff_subgraph_inlining, \
     _trace, do_input_map, get_execution_plan, make_global, \
     execWrapper, _inline_everything, _tmp_donotuse_dont_inline_everything, \
@@ -15796,8 +15796,11 @@ dedent """
         y = torch.randn(3, 6)
         self.checkScript(split_two, [(x + y)])
 
-    @xfailIf(IS_ARM64)
-    # see https://github.com/pytorch/pytorch/issues/177255
+    @unittest.skipIf(
+        os.environ.get("TORCH_SHOW_CPP_STACKTRACES") == "1",
+        "C++ stack traces are expected in the error message when "
+        "TORCH_SHOW_CPP_STACKTRACES=1, so the 'frame' assertion doesn't apply.",
+    )
     def test_conv_error(self):
         @torch.jit.script
         def fn(x, y):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181142

The test asserts the word "frame" does not appear in the RuntimeError
message from a failed scripted conv2d call, guarding against the C++
backtrace leaking into the user-visible error. But when
TORCH_SHOW_CPP_STACKTRACES=1, the JIT interpreter's handleError
intentionally appends e.what() (including the backtrace) to the message,
so the assertion is expected to fail in that mode.

test/run_test.py flips TORCH_SHOW_CPP_STACKTRACES=1 on retry, which
turned any unrelated flakiness into a spurious "frame" failure and was
being masked by @xfailIf(IS_ARM64). That xfail was XPASS'ing on m8g
runners (where the test doesn't flake), breaking the aarch64 job.
Replace it with an env-based skip and drop the now-unused IS_ARM64
import. Fixes #177255.

Authored with Claude.