### PR TITLE
test: fix only 0-dimensional arrays can be converted to Python scalars

### DIFF
--- a/torch/testing/_internal/hypothesis_utils.py
+++ b/torch/testing/_internal/hypothesis_utils.py
@@ -242,7 +242,7 @@ def per_channel_tensor(draw, shapes=None, elements=None, qparams=None):
     if enforced_zp is not None:
         zp = enforced_zp
     # Permute to model quantization along an axis
-    axis = int(np.random.randint(0, X.ndim, 1))
+    axis = int(np.random.randint(0, X.ndim))
     permute_axes = np.arange(X.ndim)
     permute_axes[0] = axis
     permute_axes[axis] = 0


### PR DESCRIPTION
I got the following error when running `TestFakeQuantize.test_fq_module_per_channel`:
```
File "/third_party/py/torch/testing/_internal/hypothesis_utils.py", line 245, in per_channel_tensor
    axis = int(np.random.randint(0, X.ndim, 1))
TypeError: only 0-dimensional arrays can be converted to Python scalars
```
The issue was caused by calling `int()` on a 1D NumPy array with a single element, which is returned by `np.random.randint(low, high, 1)`. In recent versions of NumPy, this conversion is restricted or fails if the array is not 0-dimensional.