### PR TITLE
Back out #180958 and #180679

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -722,7 +722,7 @@ at::QEngine Context::qEngine() const {
     qengine = at::kONEDNN;
 #endif
 
-#if defined(USE_FBGEMM) && (defined(__x86_64__) || defined(_M_X64))
+#ifdef USE_FBGEMM
     if (fbgemm::fbgemmSupportedCPU()) {
       /* X86 is enabled if and only if fbgemm is available.
        * It combines goodness of fbgemm and onednn by dispatching.
@@ -761,7 +761,7 @@ const std::vector<at::QEngine>& Context::supportedQEngines() {
     engines.push_back(at::kONEDNN);
 #endif
 
-#if defined(USE_FBGEMM) && (defined(__x86_64__) || defined(_M_X64))
+#ifdef USE_FBGEMM
     if (fbgemm::fbgemmSupportedCPU()) {
       engines.push_back(at::kX86);
       // The X86 qengine is available if and only if FBGEMM is available

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -2339,10 +2339,6 @@ TEST(StaticRuntime, QuantizedLinear) {
 }
 
 TEST(StaticRuntime, QuantizedLinearDynamicFp16) {
-#if defined(__aarch64__) || defined(_M_ARM64)
-  // See https://github.com/pytorch/pytorch/issues/178522.
-  GTEST_SKIP() << "Skipping QuantizedLinearDynamicFp16 on AArch64.";
-#endif
   const std::string quantized_linear_dynamic_fp16_script = R"IR(
     graph(%input: Tensor, %weights: Tensor):
         %bias: None = prim::Constant()
@@ -2364,10 +2360,6 @@ TEST(StaticRuntime, QuantizedLinearDynamicFp16) {
 }
 
 TEST(StaticRuntime, QuantizedLinearReluDynamicFp16) {
-#if defined(__aarch64__) || defined(_M_ARM64)
-  // See https://github.com/pytorch/pytorch/issues/178522.
-  GTEST_SKIP() << "Skipping QuantizedLinearReluDynamicFp16 on AArch64.";
-#endif
   const std::string quantized_linear_relu_dynamic_fp16_script = R"IR(
     graph(%input: Tensor, %weights: Tensor):
         %bias: None = prim::Constant()

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -8363,21 +8363,6 @@ class TestQuantizedConv(TestCase):
         torch.manual_seed(0)  # For reproducibility in 3D conv tests
         self._test_qconv_fp8_helper(3, pointwise_post_op)
 
-    @unittest.skipIf(
-        torch.backends.quantized.engine == "none",
-        "No default quantized engine available",
-    )
-    def test_qconv1d_default_engine(self):
-        # Regression test for https://github.com/pytorch/pytorch/issues/177254
-        # On aarch64, fbgemmSupportedCPU() incorrectly returned True, causing
-        # the default quantized engine to be X86 which crashed in FBGEMM with
-        # "RuntimeError: unknown architecure".  # codespell:ignore architecure
-        qconv1d = torch.ao.nn.quantized.Conv1d(4, 8, 3)
-        x = torch.quantize_per_tensor(
-            torch.randn(1, 4, 16), scale=1.0, zero_point=0, dtype=torch.quint8
-        )
-        qconv1d(x)
-
 
 
 class TestPadding(TestCase):


### PR DESCRIPTION
Summary:
Back out "Fix fbgemm check from #180679 (#180958)"
Back out "Fix quantized engine registration on aarch64 (#180679)"

The fix only fixed one of two problems.

Original Phabricator Diff: D101503357,D101937712

Test Plan: Let CI run

Differential Revision: D102036687
