### PR TITLE
[Inductor] Allow max_autotune_gemm on Jetson Orin AGX

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1711,7 +1711,11 @@ def is_big_gpu(index_or_device: int | torch.device = 0) -> bool:
             return False
         return True
 
-    min_sms = 16 if device.type == "xpu" else 68  # 3080
+    min_sms = (
+        16
+        if device.type == "xpu" or "orin" in torch.cuda.get_device_name(device).lower()
+        else 68
+    )  # 3080 / Jetson Orin AGX
     avail_sms = prop.multi_processor_count
     if avail_sms < min_sms:
         log.warning(


### PR DESCRIPTION
Summary:
The is_big_gpu() check in _inductor/utils.py gates max_autotune_gemm
on a minimum SM count. Master uses 16 if device.type == "xpu" else 68,
which excludes any Nvidia Jetson Orin (16 SMs for the 64GB variant we are actively testing).

This unblocks CUDA AOTInductor export of the Gemma3n audio + text
decoder on Jetson Orin AGX devices.

Test Plan: CI, export for Jetson Orin w/ CUDA AOTInductor now works

Differential Revision: D101883537




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo