### PR TITLE
[export] Adds additional filtering for constants 

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -15332,6 +15332,39 @@ def forward(self, x, y):
             FooModel(), (Foo(torch.ones(4, 4), torch.ones(4, 4)),), strict=False
         )
 
+    def test_custom_pytree_run_decompositions(self):
+        class MyContainer:
+            def __init__(self, t1, t2):
+                self.t1 = t1
+                self.t2 = t2
+
+        torch.utils._pytree.register_pytree_node(
+            MyContainer,
+            lambda mc: ([mc.t1, mc.t2], None),
+            lambda vals, _: MyContainer(vals[0], vals[1]),
+            flatten_with_keys_fn=lambda mc: (
+                [
+                    (torch.utils._pytree.MappingKey("t1"), mc.t1),
+                    (torch.utils._pytree.MappingKey("t2"), mc.t2),
+                ],
+                None,
+            ),
+            serialized_type_name=f"{MyContainer.__module__}.{MyContainer.__qualname__}",
+        )
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, mc):
+                return self.linear(mc.t1) + self.linear(mc.t2) + torch.tensor(1.0)
+
+        m = M()
+        mc = MyContainer(torch.randn(4, 4), torch.randn(4, 4))
+        ep = torch.export.export(m, (mc,), strict=False)
+        ep.run_decompositions()
+
     def test_allow_explicit_guards_as_runtime_asserts(self):
         # check that explicit guards are treated as runtime assertions
         class Foo(torch.nn.Module):

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -886,6 +886,16 @@ def _get_updated_module_call_graph(
         **graph_signature.inputs_to_parameters,
         **graph_signature.inputs_to_buffers,
     }
+    old_graph_non_user_inputs = {
+        **old_graph_params_buffers,
+        **old_graph_signature.inputs_to_lifted_tensor_constants,
+        **old_graph_signature.inputs_to_lifted_custom_objs,
+    }
+    new_graph_non_user_inputs = {
+        **new_graph_params_buffers,
+        **graph_signature.inputs_to_lifted_tensor_constants,
+        **graph_signature.inputs_to_lifted_custom_objs,
+    }
 
     # use node-level provenance metadata to create a map
     # from old node names to new node names
@@ -897,7 +907,7 @@ def _get_updated_module_call_graph(
     ]
     old_user_input_names = list(
         filter(
-            lambda x: x not in old_graph_params_buffers
+            lambda x: x not in old_graph_non_user_inputs
             and x not in old_graph_signature.input_tokens,
             old_user_input_names,
         )
@@ -915,7 +925,7 @@ def _get_updated_module_call_graph(
         # must preserve the old name.
         elif node.op == "placeholder":
             if not (
-                node.target in new_graph_params_buffers
+                node.target in new_graph_non_user_inputs
                 or node.target in graph_signature.input_tokens
             ):
                 if node.target in new_user_input_names:


### PR DESCRIPTION
Fixes #179555

`_get_updated_module_call_graph` only excluded parameters, buffers, and tokens when identifying user-input placeholders. Lifted tensor constants and custom objects were incorrectly counted as user inputs. When decomposition introduced new constants (via `lift_constants_pass`), the new graph had more "user input" placeholders than the old graph, causing an `IndexError`.

Extend the filtering to also exclude `inputs_to_lifted_tensor_constants` and `inputs_to_lifted_custom_objs` on both old and new graph sides.