### PR TITLE
[CUDA][TEST][DLPack] Fix "device agnostic" DLPack test

### DIFF
--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -374,7 +374,7 @@ class TestTorchDlPack(TestCase):
         with self.assertRaisesRegex(
             BufferError, r"Can't export tensors on a different CUDA device"
         ):
-            with torch.device(dev1):
+            with torch.accelerator.device_index(torch.device(dev1).index):
                 x.__dlpack__()
 
     # TODO: add interchange tests once NumPy 1.22 (dlpack support) is required


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/173760 changed the context manager to be hopefully device agnostic but `torch.device` doesn't seem to actually change the current device... 

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @mruberry @gujinghui @EikanWang @fengyuan14 @guangyey