### PR TITLE
[distributed] Make torchmux transparent: remap cuda:{rank} and backend="nccl"

### DIFF
--- a/simple_tp_transformer.py
+++ b/simple_tp_transformer.py
@@ -1,0 +1,147 @@
+"""
+Minimal tensor-parallel transformer with one all-gather and one reduce-scatter.
+
+    torchrun --nproc_per_node=2 simple_tp_transformer.py
+    python -m torch.distributed.torchmux --nproc 2 simple_tp_transformer.py
+
+Architecture: embedding -> transformer block (attention + TP FFN) -> RMS norm -> linear
+The FFN uses column-parallel w1 / row-parallel w2 with sequence parallelism,
+giving exactly one all-gather (before w1) and one reduce-scatter (after w2).
+"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.distributed as dist
+
+
+def rms_norm(x, weight, eps=1e-6):
+    return weight * x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+
+
+def all_gather_seq(x, group):
+    gathered = [torch.empty_like(x) for _ in range(dist.get_world_size(group))]
+    dist.all_gather(gathered, x, group=group)
+    return torch.cat(gathered, dim=1)
+
+
+def reduce_scatter_seq(x, group):
+    chunks = list(x.chunk(dist.get_world_size(group), dim=1))
+    output = torch.empty_like(chunks[0])
+    dist.reduce_scatter(output, chunks, op=dist.ReduceOp.SUM, group=group)
+    return output
+
+
+class SimpleTPTransformer(nn.Module):
+    def __init__(self, vocab_size, d_model, n_heads, d_ff, rank, world_size, group):
+        super().__init__()
+        self.rank = rank
+        self.world_size = world_size
+        self.group = group
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.tok_emb = nn.Embedding(vocab_size, d_model)
+
+        self.wq = nn.Linear(d_model, d_model, bias=False)
+        self.wk = nn.Linear(d_model, d_model, bias=False)
+        self.wv = nn.Linear(d_model, d_model, bias=False)
+        self.wo = nn.Linear(d_model, d_model, bias=False)
+
+        self.attn_norm_w = nn.Parameter(torch.ones(d_model))
+        self.ffn_norm_w = nn.Parameter(torch.ones(d_model))
+        self.final_norm_w = nn.Parameter(torch.ones(d_model))
+
+        assert d_ff % world_size == 0
+        local_d_ff = d_ff // world_size
+        self.w1 = nn.Linear(d_model, local_d_ff, bias=False)
+        self.w2 = nn.Linear(local_d_ff, d_model, bias=False)
+
+        self.out_proj = nn.Linear(d_model, vocab_size, bias=False)
+
+    def _attention(self, x):
+        B, S, _ = x.shape
+        q = self.wq(x).view(B, S, self.n_heads, self.head_dim).transpose(1, 2)
+        k = self.wk(x).view(B, S, self.n_heads, self.head_dim).transpose(1, 2)
+        v = self.wv(x).view(B, S, self.n_heads, self.head_dim).transpose(1, 2)
+        scores = (q @ k.transpose(-2, -1)) * (self.head_dim ** -0.5)
+        mask = torch.triu(torch.ones(S, S, device=x.device, dtype=torch.bool), diagonal=1)
+        scores.masked_fill_(mask, float("-inf"))
+        out = (scores.softmax(dim=-1) @ v).transpose(1, 2).contiguous().view(B, S, -1)
+        return self.wo(out)
+
+    def forward(self, tokens):
+        x = self.tok_emb(tokens)
+
+        # Attention block (replicated across ranks)
+        x = x + self._attention(rms_norm(x, self.attn_norm_w))
+
+        # Transition to sequence parallelism: each rank takes its chunk
+        x_local = x.chunk(self.world_size, dim=1)[self.rank].contiguous()
+
+        # FFN with tensor parallelism + sequence parallelism
+        normed_local = rms_norm(x_local, self.ffn_norm_w)
+
+        # All-gather: [B, S/W, D] -> [B, S, D]
+        normed_full = all_gather_seq(normed_local, self.group)
+
+        # Column-parallel w1 (each rank has d_ff/W output columns)
+        h = F.silu(self.w1(normed_full))
+
+        # Row-parallel w2 (each rank produces partial sum over full D)
+        h = self.w2(h)
+
+        # Reduce-scatter: sum partials across ranks + scatter along seq dim
+        # [B, S, D] -> [B, S/W, D]
+        h_local = reduce_scatter_seq(h, self.group)
+
+        x_local = x_local + h_local
+
+        # Final RMS norm + output projection on local chunk
+        logits = self.out_proj(rms_norm(x_local, self.final_norm_w))
+        return logits
+
+
+def main():
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    torch.use_deterministic_algorithms(True)
+    torch.backends.cudnn.deterministic = True
+
+    vocab_size = 256
+    d_model = 64
+    n_heads = 4
+    d_ff = 128
+    batch_size = 2
+    seq_len = 16
+    lr = 1e-3
+
+    torch.manual_seed(42)
+    model = SimpleTPTransformer(
+        vocab_size, d_model, n_heads, d_ff, rank, world_size, dist.group.WORLD
+    ).to(device)
+
+    torch.manual_seed(0)
+    tokens = torch.randint(0, vocab_size, (batch_size, seq_len), device=device)
+
+    for i in range(5):
+        logits = model(tokens)
+        loss = logits.sum()
+        loss.backward()
+        print(f"[Rank {rank}] iter {i}: loss = {loss.item():.6f}")
+
+        with torch.no_grad():
+            for p in model.parameters():
+                if p.grad is not None:
+                    p -= lr * p.grad
+                    p.grad.zero_()
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/torch/distributed/torchmux.py
+++ b/torch/distributed/torchmux.py
@@ -21,7 +21,8 @@ cooperative scheduling means:
   - The global RNG is never corrupted by thread interleaving
   - Collective numerics are bitwise identical to real NCCL + torchrun
 
-Requires scripts to use LOCAL_RANK (not RANK) for device selection.
+Scripts can use device=f"cuda:{rank}" and backend="nccl" — torchmux
+remaps all CUDA device indices to 0 and redirects any backend to vnccl.
 """
 
 import argparse
@@ -38,6 +39,30 @@ import torch.distributed as dist
 _tls = threading.local()
 
 _exec_lock = threading.Lock()
+
+# ---- torch.device remapping ----
+# Replace torch.device so that cuda:N → cuda:0 when torchmux is active.
+# Uses a metaclass so isinstance(x, torch.device) still works.
+
+_OrigDevice = torch.device
+
+
+class _DeviceMeta(type):
+    def __instancecheck__(cls, instance):
+        return isinstance(instance, _OrigDevice)
+
+    def __subclasscheck__(cls, subclass):
+        if subclass is _OrigDevice:
+            return True
+        return type.__subclasscheck__(cls, subclass)
+
+
+class _MuxDevice(metaclass=_DeviceMeta):
+    def __new__(cls, *args, **kwargs):
+        d = _OrigDevice(*args, **kwargs)
+        if d.type == "cuda" and d.index is not None and d.index > 0:
+            return _OrigDevice("cuda", 0)
+        return d
 
 
 class _ThreadLocalEnv:
@@ -211,6 +236,7 @@ def main():
     dist.init_process_group = _patched_init_pg
     dist.destroy_process_group = _patched_destroy_pg
     torch.cuda.set_device = lambda *a, **kw: _orig_cuda_set_device(0)
+    torch.device = _MuxDevice
     os.environ = _ThreadLocalEnv(os.environ)
 
     for name in _COLLECTIVES:
@@ -241,6 +267,7 @@ def main():
     dist.init_process_group = _orig_init_pg
     dist.destroy_process_group = _orig_destroy_pg
     torch.cuda.set_device = _orig_cuda_set_device
+    torch.device = _OrigDevice
     torch._C._distributed_c10d._set_thread_isolation_mode(False)
 
     failed = False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181185
* #181184
* #181194
* #181183

Scripts that use device=f"cuda:{rank}" and backend="nccl" now work with
torchmux without any modifications. Two changes:

1. Remap torch.device so cuda:N → cuda:0. This is done by replacing
   torch.device with a wrapper class that clamps CUDA device indices
   to 0. A metaclass preserves isinstance(x, torch.device) checks.
   When torchmux exits, torch.device is restored to the original.

2. The init_process_group patch (from the previous commit) already
   ignores the user's backend= argument and uses vnccl.

Also removes CUDA graphs from simple_tp_transformer.py since they are
incompatible with thread-based collective resolution (CUDA graph
capture records GPU kernel launches, but vnccl collectives are
Python-level thread barriers). The script now works identically with
both torchrun and torchmux:

    torchrun --nproc_per_node=2 simple_tp_transformer.py
    python -m torch.distributed.torchmux --nproc 2 simple_tp_transformer.py

Both produce bitwise identical losses across all iterations.

Authored with Claude.