### PR TITLE
Have trace_structured bypass global logging.disable()

### DIFF
--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,6 +1,13 @@
 # Owner(s): ["module: unknown"]
 
+import glob
+import logging
+import os
+import tempfile
+
 import torch
+import torch._logging._internal as log_internal
+from torch._logging._internal import _init_logs, trace_log, trace_structured
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -18,6 +25,47 @@ class LoggingTest(TestCase):
             f"from ctypes import CDLL; CDLL('{torch._C.__file__}')"
         )
         self.assertNotRegex(s, "PYTORCH_API_USAGE")
+
+    def test_trace_structured_with_logging_disable(self):
+        """trace_structured should work even when logging.disable(DEBUG) is active."""
+        old_disable = logging.root.manager.disable
+        old_env = os.environ.get("TORCH_TRACE")
+        old_handler = log_internal.LOG_TRACE_HANDLER
+        try:
+            logging.disable(logging.DEBUG)
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                os.environ["TORCH_TRACE"] = tmpdir
+                log_internal.LOG_TRACE_HANDLER = None
+                _init_logs()
+
+                self.assertTrue(trace_log.handlers)
+                self.assertTrue(trace_log.isEnabledFor(logging.DEBUG))
+
+                trace_structured(
+                    "test_event",
+                    metadata_fn=lambda: {"key": "value"},
+                    expect_trace_id=False,
+                    record_logging_overhead=False,
+                )
+
+                log_files = glob.glob(os.path.join(tmpdir, "*.log"))
+                self.assertTrue(log_files, "Expected a trace log file to be created")
+                with open(log_files[0]) as f:
+                    content = f.read()
+                self.assertIn("test_event", content)
+
+                # Close the handler before the TemporaryDirectory is cleaned up,
+                # otherwise Windows fails with a PermissionError on the open file.
+                log_internal.LOG_TRACE_HANDLER.close()
+        finally:
+            logging.disable(old_disable)
+            if old_env is None:
+                os.environ.pop("TORCH_TRACE", None)
+            else:
+                os.environ["TORCH_TRACE"] = old_env
+            log_internal.LOG_TRACE_HANDLER = old_handler
+            _init_logs()
 
 
 if __name__ == "__main__":

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -1181,6 +1181,10 @@ def _init_logs(log_file_name=None) -> None:
     # are any handlers before deciding to actually call logging on this.  Do
     # not manually call
     trace_log.setLevel(logging.DEBUG)
+    # Override isEnabledFor so that logging.disable() cannot suppress trace
+    # events.  When TORCH_TRACE is set we always want output regardless of
+    # the global disable threshold.
+    trace_log.isEnabledFor = lambda level: level >= trace_log.level
     trace_log_handler = _track_handler(LOG_TRACE_HANDLER)
     trace_log_handler.setFormatter(TorchLogsFormatter(trace=True))
     trace_log.addHandler(trace_log_handler)


### PR DESCRIPTION
logging.disable() can suppress all DEBUG-level calls globally, which silently drops trace_structured() events even when TORCH_TRACE is set. but we always want to have the trace_structured logs when TORCH_TRACE is set, so we override `isEnabledFor` on `trace_log` during init so it only checks the logger's own level, ignoring the global disable threshold. 