### PR TITLE
[BE] Use [[maybe_unused]] instead of (void)what in ReadAdapter overrides

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni_common.h
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_common.h
@@ -80,8 +80,11 @@ class MemoryReadAdapter final : public caffe2::serialize::ReadAdapterInterface {
     return size_;
   }
 
-  size_t read(uint64_t pos, void* buf, size_t n, const char* what = "")
-      const override {
+  size_t read(
+      uint64_t pos,
+      void* buf,
+      size_t n,
+      [[maybe_unused]] const char* what = "") const override {
     memcpy(buf, (int8_t*)(data_) + pos, n);
     return n;
   }

--- a/caffe2/serialize/in_memory_adapter.h
+++ b/caffe2/serialize/in_memory_adapter.h
@@ -14,9 +14,11 @@ class MemoryReadAdapter final : public caffe2::serialize::ReadAdapterInterface {
     return size_;
   }
 
-  size_t read(uint64_t pos, void* buf, size_t n, const char* what = "")
-      const override {
-    (void)what;
+  size_t read(
+      uint64_t pos,
+      void* buf,
+      size_t n,
+      [[maybe_unused]] const char* what = "") const override {
     memcpy(buf, (int8_t*)(data_) + pos, n);
     return n;
   }

--- a/torch/csrc/api/src/serialize/input-archive.cpp
+++ b/torch/csrc/api/src/serialize/input-archive.cpp
@@ -113,9 +113,11 @@ void InputArchive::load_from(
     size_t size() const override {
       return size_;
     }
-    size_t read(uint64_t pos, void* buf, size_t n, const char* what = "")
-        const override {
-      (void)what;
+    size_t read(
+        uint64_t pos,
+        void* buf,
+        size_t n,
+        [[maybe_unused]] const char* what = "") const override {
       if (pos >= size_) {
         return 0;
       }

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -909,9 +909,8 @@ DetachedBuffer::UniqueDetachedBuffer save_jit_module_to_bytes(
 void save_jit_module_to_write_func(
     const Module& module,
     const ExtraFilesMap& extra_files,
-    bool save_mobile_debug_info,
+    [[maybe_unused]] bool save_mobile_debug_info,
     const std::function<size_t(const void*, size_t)>& writer_func) {
-  (void)save_mobile_debug_info;
   auto buffer = save_jit_module_to_bytes(module, extra_files);
   writer_func(buffer->data(), buffer->size());
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #181193
* __->__ #181192

PyTorch is C++17 project; the attribute form is the idiomatic way to suppress unused-parameter warnings

Authored with Claude.