### PR TITLE
Fix OOB read in MemoryReadAdapter::read

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni_common.h
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_common.h
@@ -85,6 +85,15 @@ class MemoryReadAdapter final : public caffe2::serialize::ReadAdapterInterface {
       void* buf,
       size_t n,
       [[maybe_unused]] const char* what = "") const override {
+    // Clamp pos/n against size_ to prevent OOB reads from crafted zip
+    // metadata. Mirrors FileAdapter::read (file_adapter.cc).
+    if (C10_UNLIKELY(pos >= static_cast<uint64_t>(size_))) {
+      return 0;
+    }
+    const uint64_t remaining = static_cast<uint64_t>(size_) - pos;
+    if (C10_UNLIKELY(n > remaining)) {
+      n = static_cast<size_t>(remaining);
+    }
     memcpy(buf, (int8_t*)(data_) + pos, n);
     return n;
   }

--- a/caffe2/serialize/in_memory_adapter.h
+++ b/caffe2/serialize/in_memory_adapter.h
@@ -19,6 +19,15 @@ class MemoryReadAdapter final : public caffe2::serialize::ReadAdapterInterface {
       void* buf,
       size_t n,
       [[maybe_unused]] const char* what = "") const override {
+    // Clamp pos/n against size_ to prevent OOB reads from crafted zip
+    // metadata. Mirrors FileAdapter::read (file_adapter.cc).
+    if (C10_UNLIKELY(pos >= static_cast<uint64_t>(size_))) {
+      return 0;
+    }
+    const uint64_t remaining = static_cast<uint64_t>(size_) - pos;
+    if (C10_UNLIKELY(n > remaining)) {
+      n = static_cast<size_t>(remaining);
+    }
     memcpy(buf, (int8_t*)(data_) + pos, n);
     return n;
   }

--- a/caffe2/serialize/inline_container_test.cc
+++ b/caffe2/serialize/inline_container_test.cc
@@ -8,6 +8,7 @@
 #include <c10/util/Logging.h>
 #include "c10/core/CPUAllocator.h"
 #include "c10/util/irange.h"
+#include "caffe2/serialize/in_memory_adapter.h"
 #include "caffe2/serialize/inline_container.h"
 
 namespace caffe2 {
@@ -688,6 +689,34 @@ TEST_P(ChunkRecordIteratorTest, ChunkRead) {
   ASSERT_EQ(totalReadSize, tensorDataSizeInBytes);
   // clean up
   remove(fileName);
+}
+
+TEST(MemoryReadAdapterTest, ClampsReadsToBufferSize) {
+  constexpr size_t kBufSize = 64;
+  std::vector<uint8_t> buf(kBufSize, 0xAA);
+  MemoryReadAdapter adapter(buf.data(), static_cast<off_t>(kBufSize));
+  ASSERT_EQ(adapter.size(), kBufSize);
+
+  std::array<uint8_t, 32> out{};
+
+  // pos straddles end: read starts at 48, only 16 bytes available.
+  out.fill(0);
+  EXPECT_EQ(adapter.read(48, out.data(), out.size()), 16u);
+  for (size_t i = 0; i < 16; ++i) {
+    EXPECT_EQ(out[i], 0xAA);
+  }
+
+  // pos at end: zero bytes available.
+  out.fill(0);
+  EXPECT_EQ(adapter.read(kBufSize, out.data(), out.size()), 0u);
+
+  // pos past end: still zero; no OOB memcpy.
+  out.fill(0);
+  EXPECT_EQ(adapter.read(kBufSize + 1024, out.data(), out.size()), 0u);
+
+  // In-bounds read returns full count.
+  out.fill(0);
+  EXPECT_EQ(adapter.read(0, out.data(), out.size()), out.size());
 }
 
 } // namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #181310
* __->__ #181193

`MemoryReadAdapter::read()` memcpy'd `n` bytes at `data_ + pos` with no bounds check and always returned `n`, so miniz/PyTorchStreamReader could be driven past the end of the backing buffer by crafted zip-archive metadata (e.g. a CDH with comp_size = 0xFFFFFFFF, or a local-header filename_len/extra_len pushing the record offset past size_). The unconditional return defeated miniz's short-read detection, so the over-read silently flowed into tensor storage.

Clamp `pos` and `n` against size_, matching the contract already implemented in FileAdapter::read. Fixed duplicate `MemoryReadAdapter` in the Android JNI shim the same way.
Add regression test.

Fixes T259151654

Authored with Claude.