### PR TITLE
Mock benchmarking during testing to prevent flaky prolog decision

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -4605,7 +4605,21 @@ class TestPrologueFusion(TestCase):
         c = torch.rand([M, K], dtype=torch.bfloat16, device=GPU_TYPE)
         d = torch.rand([K, N], dtype=torch.bfloat16, device=GPU_TYPE)
 
-        _, code = run_and_get_code(torch.compile(foo), a, b, c, d)
+        # Mock benchmarks to return deterministic results so fusion decisions
+        # don't depend on noisy GPU microbenchmarks.
+        with (
+            mock.patch.object(
+                Scheduler,
+                "benchmark_fused_nodes",
+                return_value=(1.0, ""),
+            ),
+            mock.patch.object(
+                Scheduler,
+                "benchmark_codegened_module",
+                return_value=(0.5, ""),
+            ),
+        ):
+            _, code = run_and_get_code(torch.compile(foo), a, b, c, d)
         FileCheck().check("tem_fused__to_copy_add_mm_mul").check(
             "to_copy_add_div_mm_mul_relu_sub_tanh_1"
         ).run(code[0])


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/180413

Basically we were using noisy gpu benchmarking which sometimes wouldn't fuse the prolog

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181195



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo