### PR TITLE
[do-not-review] enable inductor subproc logging for debugging

### DIFF
--- a/pool_demo.py
+++ b/pool_demo.py
@@ -1,0 +1,19 @@
+import torch
+from torch._inductor import config
+print("compile_threads:", config.compile_threads)
+
+
+@torch.compile(mode="max-autotune-no-cudagraphs")
+def f(x, y):
+    # Mix of pointwise, reductions, matmul — each becomes a distinct kernel
+    a = (x * y + x.sin()).relu()
+    b = a.softmax(-1)
+    c = b @ y
+    d = c.mean(-1, keepdim=True)
+    e = (d - c).pow(2).sum()
+    return e + a.sum() + b.sum() + c.sum()
+
+
+x = torch.randn(256, 256, device="cuda")
+y = torch.randn(256, 256, device="cuda")
+f(x, y)  # triggers compile

--- a/torch/_inductor/compile_worker/subproc_pool.py
+++ b/torch/_inductor/compile_worker/subproc_pool.py
@@ -450,6 +450,11 @@ class SubprocMain:
 
     @staticmethod
     def do_job(pickler: SubprocPickler, data: bytes) -> bytes:
+        import time
+
+        pid = os.getpid()
+        t0 = time.perf_counter()
+        print(f"[worker {pid}] job start t={t0:.3f}", flush=True)
         # do the pickle/unpickle in the sub-subproc
         job = typing.cast(Callable[[], object], pickler.loads(data))
 
@@ -457,6 +462,10 @@ class SubprocMain:
             result = job()
         except Exception:
             result = _SubprocExceptionInfo(traceback.format_exc())
+        print(
+            f"[worker {pid}] job end dt={time.perf_counter() - t0:.3f}s",
+            flush=True,
+        )
         return pickler.dumps(result)
 
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1080,7 +1080,7 @@ small_memory_access_threshold: int = 16777216
 worker_suppress_logging: bool = Config(
     justknob="pytorch/compiler:worker_suppress_logging",
     env_name_force="TORCHINDUCTOR_WORKER_SUPPRESS_LOGGING",
-    default=True,
+    default=False,
 )
 
 # Log per-operation runtime estimates for TLParse analysis.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

```
> python agent_space/pool_demo.py
compile_threads: 32
/home/xmfan/core/a/pytorch/torch/_inductor/compile_fx.py:320: UserWarning: TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. Consider setting `torch.set_float32_matmul_precision('high')` for better performance.
  warnings.warn(
[worker 616871] job start t=1295964.453
[worker 616871] job end dt=0.000s
ERROR:torch._inductor.select_algorithm:Exception No valid triton configs. OutOfMemoryError: out of resource: triton_mm Required: 262144 Hardware limit:232448 Reducing block sizes or `num_stages` may help. for benchmark choice TritonTemplateCaller(/tmp/torchinductor_xmfan/re/credqsjtg7csossycvs7vsitwrk2v4fpk6qjczxtgbyfytwt42o5.py, ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=5, num_warps=8)
Traceback (most recent call last):
  File "/home/xmfan/core/miniconda3/envs/a/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xmfan/core/a/pytorch/torch/_inductor/select_algorithm.py", line 4397, in precompile_with_captured_stdout
    choice.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/select_algorithm.py", line 3153, in precompile
    self.bmreq.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/autotune_process.py", line 728, in precompile
    kernel.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/runtime/triton_heuristics.py", line 515, in precompile
    self._make_launchers()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/runtime/triton_heuristics.py", line 681, in _make_launchers
    raise RuntimeError(f"No valid triton configs. {type(exc).__name__}: {exc}")
RuntimeError: No valid triton configs. OutOfMemoryError: out of resource: triton_mm Required: 262144 Hardware limit:232448 Reducing block sizes or `num_stages` may help.
ERROR:torch._inductor.select_algorithm:Exception No valid triton configs. OutOfMemoryError: out of resource: triton_mm Required: 262144 Hardware limit:232448 Reducing block sizes or `num_stages` may help. for benchmark choice TritonTemplateCaller(/tmp/torchinductor_xmfan/re/creiryxe4yh2l7wjdti3wmijsjss6wwg7vimzo6wr77pl6rsou7i.py, ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=64, BLOCK_N=64, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=5, num_warps=4)
Traceback (most recent call last):
  File "/home/xmfan/core/miniconda3/envs/a/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xmfan/core/a/pytorch/torch/_inductor/select_algorithm.py", line 4397, in precompile_with_captured_stdout
    choice.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/select_algorithm.py", line 3153, in precompile
    self.bmreq.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/autotune_process.py", line 728, in precompile
    kernel.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/runtime/triton_heuristics.py", line 515, in precompile
    self._make_launchers()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/runtime/triton_heuristics.py", line 681, in _make_launchers
    raise RuntimeError(f"No valid triton configs. {type(exc).__name__}: {exc}")
RuntimeError: No valid triton configs. OutOfMemoryError: out of resource: triton_mm Required: 262144 Hardware limit:232448 Reducing block sizes or `num_stages` may help.
ERROR:torch._inductor.select_algorithm:Exception No valid triton configs. OutOfMemoryError: out of resource: triton_mm Required: 393216 Hardware limit:232448 Reducing block sizes or `num_stages` may help. for benchmark choice TritonTemplateCaller(/tmp/torchinductor_xmfan/pj/cpjypek7y3o6qtqvx52zratiho2lkl7vkywed3jxkdd3hxcygh5j.py, ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=128, BLOCK_N=128, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=4, num_warps=8)
Traceback (most recent call last):
  File "/home/xmfan/core/miniconda3/envs/a/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xmfan/core/a/pytorch/torch/_inductor/select_algorithm.py", line 4397, in precompile_with_captured_stdout
    choice.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/select_algorithm.py", line 3153, in precompile
    self.bmreq.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/autotune_process.py", line 728, in precompile
    kernel.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/runtime/triton_heuristics.py", line 515, in precompile
    self._make_launchers()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/runtime/triton_heuristics.py", line 681, in _make_launchers
    raise RuntimeError(f"No valid triton configs. {type(exc).__name__}: {exc}")
RuntimeError: No valid triton configs. OutOfMemoryError: out of resource: triton_mm Required: 393216 Hardware limit:232448 Reducing block sizes or `num_stages` may help.
ERROR:torch._inductor.select_algorithm:Exception No valid triton configs. OutOfMemoryError: out of resource: triton_mm Required: 294912 Hardware limit:232448 Reducing block sizes or `num_stages` may help. for benchmark choice TritonTemplateCaller(/tmp/torchinductor_xmfan/2q/c2q5vcxzc54csmibb5bmhmxvlpejmwrj4tbv4dc6hwtbdyod4a3d.py, ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=4, num_warps=4)
Traceback (most recent call last):
  File "/home/xmfan/core/miniconda3/envs/a/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/xmfan/core/a/pytorch/torch/_inductor/select_algorithm.py", line 4397, in precompile_with_captured_stdout
    choice.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/select_algorithm.py", line 3153, in precompile
    self.bmreq.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/autotune_process.py", line 728, in precompile
    kernel.precompile()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/runtime/triton_heuristics.py", line 515, in precompile
    self._make_launchers()
  File "/home/xmfan/core/a/pytorch/torch/_inductor/runtime/triton_heuristics.py", line 681, in _make_launchers
    raise RuntimeError(f"No valid triton configs. {type(exc).__name__}: {exc}")
RuntimeError: No valid triton configs. OutOfMemoryError: out of resource: triton_mm Required: 294912 Hardware limit:232448 Reducing block sizes or `num_stages` may help.
/home/xmfan/core/a/pytorch/torch/_inductor/select_algorithm.py:4630: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  current_out_size = out_base.storage().size()
Autotune Choices Stats:
{"num_choices": 17, "num_triton_choices": 16, "best_kernel": "triton_mm_1", "best_kernel_desc": "ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=32, BLOCK_N=32, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=2, num_warps=4", "best_time": 0.009344000369310379, "best_triton_pos": 0}
AUTOTUNE mm(256x256, 256x256)
strides: [256, 1], [256, 1]
dtypes: torch.float32, torch.float32
  triton_mm_1 0.0093 ms 100.0% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=32, BLOCK_N=32, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=2, num_warps=4
  triton_mm_2 0.0111 ms 84.4% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=32, BLOCK_N=64, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=5, num_warps=8
  triton_mm_3 0.0114 ms 82.0% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=64, BLOCK_N=32, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=5, num_warps=8
  triton_mm_4 0.0126 ms 74.3% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=128, BLOCK_M=64, BLOCK_N=32, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=5, num_warps=4
  mm 0.0134 ms 69.5% 
  triton_mm_7 0.0142 ms 65.9% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=64, BLOCK_N=64, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=3, num_warps=8
  triton_mm_0 0.0173 ms 53.9% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=16, BLOCK_M=32, BLOCK_N=32, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=1, num_warps=2
  triton_mm_6 0.0176 ms 53.0% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=64, BLOCK_N=64, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=2, num_warps=4
  triton_mm_14 0.0192 ms 48.6% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=64, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=4, num_warps=8
  triton_mm_10 0.0196 ms 47.6% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=64, BLOCK_N=128, EVEN_K=True, GROUP_M=8, OUT_DTYPE='tl.float32', USE_FAST_ACCUM=False, num_stages=4, num_warps=8
SingleProcess AUTOTUNE benchmarking takes 0.6256 seconds and 4.2649 seconds precompiling for 17 choices
[worker 616872] job start t=1295967.504
[worker 616876] job start t=1295967.524
[worker 616878] job start t=1295967.532
[worker 616877] job start t=1295967.536
[worker 616875] job start t=1295967.551
[worker 616873] job start t=1295967.556
[worker 616874] job start t=1295967.567
[worker 616879] job start t=1295967.578
[worker 616873] job end dt=0.102s
[worker 616874] job end dt=0.110s
[worker 616875] job end dt=0.205s
[worker 616878] job end dt=0.348s
[worker 616877] job end dt=0.471s
[worker 616879] job end dt=0.465s
[worker 616876] job end dt=0.598s
[worker 616872] job end dt=0.966s
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo