### PR TITLE
[aot_autograd] Keep needs_autograd=True when graph contains autograd.grad

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -4460,5 +4460,41 @@ class TestInvokeSubgraphTrainStepCapture(TestCase):
         self.assertFalse(aux.requires_grad)
 
 
+    @torch._dynamo.config.patch(trace_autograd_ops=True)
+    def test_needs_autograd_with_autograd_grad_in_graph(self):
+        """When the graph contains torch.autograd.grad (from
+        trace_autograd_ops rewriting .backward()), AOT autograd must keep
+        needs_autograd=True even when output_and_mutation_safe is True.
+        Otherwise the inference path disables autograd at runtime, causing
+        HOPs like flex_attention to fall through to the dense CEA fallback.
+        """
+
+        @nested_compile_region()
+        def nested_fn(x):
+            return x.sin()
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4, bias=False)
+                self.head = torch.nn.Linear(4, 1, bias=False)
+
+            def forward(self, x):
+                y = self.linear(x)
+                z = nested_fn(y)
+                z_det = z.detach().requires_grad_()
+                loss = self.head(z_det).sum()
+                loss.backward()
+                z.backward(z_det.grad)
+                return loss.detach()
+
+        model = Model()
+        x = torch.randn(4, 4)
+        compiled = torch.compile(model, backend="aot_eager", fullgraph=True)
+        loss = compiled(x)
+        # Should succeed without "backward through graph second time" or OOM
+        self.assertIsNotNone(loss)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -1230,6 +1230,24 @@ def aot_module_simplified(
                 shape_env,
             )
             aot_state.fw_metadata.act_input_indices = act_input_indices
+
+            # If the graph contains torch.autograd.grad (e.g. train step
+            # capture with trace_autograd_ops=True), keep needs_autograd=True
+            # even when output_and_mutation_safe downgraded it to False.
+            # The graph still needs autograd at runtime for:
+            # 1. torch.autograd.grad inside the graph to function
+            # 2. HOPs like flex_attention to dispatch through the autograd
+            #    key to efficient kernels (CEA fallback causes OOM)
+            # The joint tracing will produce an empty backward since no
+            # outputs require grad.
+            if not aot_state.needs_autograd and isinstance(mod, torch.fx.GraphModule):
+                if any(
+                    n.target is torch.autograd.grad
+                    for n in mod.graph.nodes
+                    if n.op == "call_function"
+                ):
+                    aot_state.needs_autograd = True
+
             aot_graph_capture = aot_stage1_graph_capture(aot_state, functional_call)
             compiled_fn, _ = aot_stage2_compile(
                 aot_state,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181210
* __->__ #181209
* #181208

When the Dynamo graph contains `torch.autograd.grad` (from train step capture with trace_autograd_ops=True) and `need_autograd` becomes False. 

With needs_autograd=False, the inference runtime wrapper (runtime_wrappers.py:534) calls `torch._C._set_grad_enabled(False)`.  This causes `maybe_run_autograd` (_ops.py:330) to dispatch HOPs through ` _AutoDispatchBelowAutograd`, so invoke_subgraph and flex_attention skip the autograd key and fall through to the dense CEA fallback, causing OOM.

Fix: detect torch.autograd.grad in the graph and keep needs_autograd=True. The joint tracing produces an empty backward since no outputs require grad, but autograd stays active at runtime.

Authored with Claude.