### PR TITLE
Make DebugInfoKind extensible

### DIFF
--- a/c10/test/util/ThreadLocalDebugInfo_test.cpp
+++ b/c10/test/util/ThreadLocalDebugInfo_test.cpp
@@ -99,5 +99,5 @@ TEST(DebugInfoKind, CanBePutInSet) {
   EXPECT_TRUE(kinds.contains(DebugInfoKind::PROFILER_STATE));
 }
 
-}  // namespace
-}  // namespace c10
+} // namespace
+} // namespace c10

--- a/c10/test/util/ThreadLocalDebugInfo_test.cpp
+++ b/c10/test/util/ThreadLocalDebugInfo_test.cpp
@@ -82,6 +82,14 @@ TEST(DebugInfoKind, CtorThrowsOnNull) {
   EXPECT_THROW(const DebugInfoKind kKind2(kNullKindStr), c10::Error);
 }
 
+TEST(DebugInfoKind, DifferentPointersWithSameStringAreDifferentKinds) {
+  static constexpr std::string_view kKindStr1 = "CustomKind";
+  static constexpr std::string_view kKindStr2 = "CustomKind";
+  const DebugInfoKind kKind1(&kKindStr1);
+  const DebugInfoKind kKind2(&kKindStr2);
+  EXPECT_NE(kKind1, kKind2);
+}
+
 TEST(DebugInfoKind, CanBePutInSet) {
   std::set<DebugInfoKind> kinds;
   kinds.insert(DebugInfoKind::PRODUCER_INFO);

--- a/c10/test/util/ThreadLocalDebugInfo_test.cpp
+++ b/c10/test/util/ThreadLocalDebugInfo_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <set>
 #include <string_view>
 
 namespace c10 {
@@ -73,6 +74,21 @@ TEST(ThreadLocalDebugInfo, PeekThrowsOnMismatch) {
   EXPECT_THROW(ThreadLocalDebugInfo::_peek(kKind2), c10::Error);
 
   ThreadLocalDebugInfo::_pop(kKind1);
+}
+
+TEST(DebugInfoKind, CtorThrowsOnNull) {
+  EXPECT_THROW({ const DebugInfoKind kKind1(nullptr); }, c10::Error);
+  const std::string_view* const kNullKindStr = nullptr;
+  EXPECT_THROW(const DebugInfoKind kKind2(kNullKindStr), c10::Error);
+}
+
+TEST(DebugInfoKind, CanBePutInSet) {
+  std::set<DebugInfoKind> kinds;
+  kinds.insert(DebugInfoKind::PRODUCER_INFO);
+  kinds.insert(DebugInfoKind::PROFILER_STATE);
+  EXPECT_EQ(kinds.size(), 2);
+  EXPECT_TRUE(kinds.contains(DebugInfoKind::PRODUCER_INFO));
+  EXPECT_TRUE(kinds.contains(DebugInfoKind::PROFILER_STATE));
 }
 
 }  // namespace

--- a/c10/test/util/ThreadLocalDebugInfo_test.cpp
+++ b/c10/test/util/ThreadLocalDebugInfo_test.cpp
@@ -1,0 +1,79 @@
+#include <c10/util/Exception.h>
+#include <c10/util/ThreadLocalDebugInfo.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string_view>
+
+namespace c10 {
+namespace {
+
+struct MyDebugInfo : public DebugInfoBase {
+  explicit MyDebugInfo(int v) : value(v) {}
+  int value;
+};
+
+TEST(ThreadLocalDebugInfo, GetCustomKind) {
+  static constexpr std::string_view kKindStr = "CustomKind_Push";
+  const DebugInfoKind kKind(&kKindStr);
+
+  auto info = std::make_shared<MyDebugInfo>(42);
+  ThreadLocalDebugInfo::_push(kKind, info);
+
+  EXPECT_EQ(ThreadLocalDebugInfo::get(kKind), info.get());
+
+  ThreadLocalDebugInfo::_pop(kKind);
+}
+
+TEST(ThreadLocalDebugInfo, PeekCustomKind) {
+  static constexpr std::string_view kKindStr = "CustomKind_Peek";
+  const DebugInfoKind kKind(&kKindStr);
+
+  auto info = std::make_shared<MyDebugInfo>(42);
+  ThreadLocalDebugInfo::_push(kKind, info);
+
+  EXPECT_EQ(ThreadLocalDebugInfo::_peek(kKind), info);
+
+  ThreadLocalDebugInfo::_pop(kKind);
+}
+
+TEST(ThreadLocalDebugInfo, PopCustomKind) {
+  static constexpr std::string_view kKindStr = "CustomKind_Pop";
+  const DebugInfoKind kKind(&kKindStr);
+
+  auto info = std::make_shared<MyDebugInfo>(42);
+  ThreadLocalDebugInfo::_push(kKind, info);
+
+  EXPECT_EQ(ThreadLocalDebugInfo::_pop(kKind), info);
+}
+
+TEST(ThreadLocalDebugInfo, PopThrowsOnMismatch) {
+  static constexpr std::string_view kKindStr1 = "CustomKind_PopMismatch1";
+  const DebugInfoKind kKind1(&kKindStr1);
+  static constexpr std::string_view kKindStr2 = "CustomKind_PopMismatch2";
+  const DebugInfoKind kKind2(&kKindStr2);
+
+  auto info = std::make_shared<MyDebugInfo>(42);
+  ThreadLocalDebugInfo::_push(kKind1, info);
+
+  EXPECT_THROW(ThreadLocalDebugInfo::_pop(kKind2), c10::Error);
+
+  ThreadLocalDebugInfo::_pop(kKind1);
+}
+
+TEST(ThreadLocalDebugInfo, PeekThrowsOnMismatch) {
+  static constexpr std::string_view kKindStr1 = "CustomKind_PeekMismatch1";
+  const DebugInfoKind kKind1(&kKindStr1);
+  static constexpr std::string_view kKindStr2 = "CustomKind_PeekMismatch2";
+  const DebugInfoKind kKind2(&kKindStr2);
+
+  auto info = std::make_shared<MyDebugInfo>(42);
+  ThreadLocalDebugInfo::_push(kKind1, info);
+
+  EXPECT_THROW(ThreadLocalDebugInfo::_peek(kKind2), c10::Error);
+
+  ThreadLocalDebugInfo::_pop(kKind1);
+}
+
+}  // namespace
+}  // namespace c10

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -1,10 +1,38 @@
 #include <c10/util/Exception.h>
+#include <c10/util/Logging.h>
 #include <c10/util/ThreadLocal.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
 
+#include <ostream>
+#include <string_view>
 #include <utility>
 
 namespace c10 {
+
+constexpr std::string_view kProducerInfoName = "PRODUCER_INFO";
+constexpr std::string_view kMobileRuntimeInfoName = "MOBILE_RUNTIME_INFO";
+constexpr std::string_view kProfilerStateName = "PROFILER_STATE";
+constexpr std::string_view kInferenceContextName = "INFERENCE_CONTEXT";
+constexpr std::string_view kParamCommsInfoName = "PARAM_COMMS_INFO";
+constexpr std::string_view kTestInfoName = "TEST_INFO";
+constexpr std::string_view kTestInfo2Name = "TEST_INFO_2";
+
+const DebugInfoKind DebugInfoKind::PRODUCER_INFO(&kProducerInfoName);
+const DebugInfoKind DebugInfoKind::MOBILE_RUNTIME_INFO(&kMobileRuntimeInfoName);
+const DebugInfoKind DebugInfoKind::PROFILER_STATE(&kProfilerStateName);
+const DebugInfoKind DebugInfoKind::INFERENCE_CONTEXT(&kInferenceContextName);
+const DebugInfoKind DebugInfoKind::PARAM_COMMS_INFO(&kParamCommsInfoName);
+const DebugInfoKind DebugInfoKind::TEST_INFO(&kTestInfoName);
+const DebugInfoKind DebugInfoKind::TEST_INFO_2(&kTestInfo2Name);
+
+DebugInfoKind::DebugInfoKind(DebugInfoKind::value_type value) : value_(value) {
+  CHECK(value_ != nullptr)  // Crash OK as this indicates a bug in C++ code.
+      << "DebugInfoKind must be initialized with a non-null pointer.";
+}
+
+std::ostream& operator<<(std::ostream& os, const DebugInfoKind& kind) {
+  return os << (kind.value_ == nullptr ? "<uninitialized>" : *kind.value_);
+}
 
 C10_DEFINE_TLS_static(std::shared_ptr<ThreadLocalDebugInfo>, tls_debug_info);
 #define debug_info (tls_debug_info.get())
@@ -45,10 +73,8 @@ void ThreadLocalDebugInfo::_push(
 
 /* static */
 std::shared_ptr<DebugInfoBase> ThreadLocalDebugInfo::_pop(DebugInfoKind kind) {
-  TORCH_CHECK(
-      debug_info && debug_info->kind_ == kind,
-      "Expected debug info of type ",
-      (size_t)kind);
+  TORCH_CHECK(debug_info && debug_info->kind_ == kind,
+              "Expected debug info of type ", kind);
   auto res = debug_info;
   debug_info = debug_info->parent_info_;
   return res->info_;
@@ -56,10 +82,8 @@ std::shared_ptr<DebugInfoBase> ThreadLocalDebugInfo::_pop(DebugInfoKind kind) {
 
 /* static */
 std::shared_ptr<DebugInfoBase> ThreadLocalDebugInfo::_peek(DebugInfoKind kind) {
-  TORCH_CHECK(
-      debug_info && debug_info->kind_ == kind,
-      "Expected debug info of type ",
-      (size_t)kind);
+  TORCH_CHECK(debug_info && debug_info->kind_ == kind,
+              "Expected debug info of type ", kind);
   return debug_info->info_;
 }
 

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -51,8 +51,10 @@ void ThreadLocalDebugInfo::_push(
 
 /* static */
 std::shared_ptr<DebugInfoBase> ThreadLocalDebugInfo::_pop(DebugInfoKind kind) {
-  TORCH_CHECK(debug_info && debug_info->kind_ == kind,
-              "Expected debug info of type ", kind);
+  TORCH_CHECK(
+      debug_info && debug_info->kind_ == kind,
+      "Expected debug info of type ",
+      kind);
   auto res = debug_info;
   debug_info = debug_info->parent_info_;
   return res->info_;
@@ -60,8 +62,10 @@ std::shared_ptr<DebugInfoBase> ThreadLocalDebugInfo::_pop(DebugInfoKind kind) {
 
 /* static */
 std::shared_ptr<DebugInfoBase> ThreadLocalDebugInfo::_peek(DebugInfoKind kind) {
-  TORCH_CHECK(debug_info && debug_info->kind_ == kind,
-              "Expected debug info of type ", kind);
+  TORCH_CHECK(
+      debug_info && debug_info->kind_ == kind,
+      "Expected debug info of type ",
+      kind);
   return debug_info->info_;
 }
 
@@ -94,4 +98,4 @@ DebugInfoGuard::DebugInfoGuard(std::shared_ptr<ThreadLocalDebugInfo> info) {
   active_ = true;
 }
 
-}  // namespace c10
+} // namespace c10

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -12,6 +12,27 @@ std::ostream& operator<<(std::ostream& os, const DebugInfoKind& kind) {
   return os << (kind.value_ == nullptr ? "<uninitialized>" : *kind.value_);
 }
 
+// Names for predefined DebugInfoKinds.
+constexpr std::string_view kProducerInfoName = "PRODUCER_INFO";
+constexpr std::string_view kMobileRuntimeInfoName = "MOBILE_RUNTIME_INFO";
+constexpr std::string_view kProfilerStateName = "PROFILER_STATE";
+constexpr std::string_view kInferenceContextName = "INFERENCE_CONTEXT";
+constexpr std::string_view kParamCommsInfoName = "PARAM_COMMS_INFO";
+constexpr std::string_view kTestInfoName = "TEST_INFO";
+constexpr std::string_view kTestInfo2Name = "TEST_INFO_2";
+
+C10_API const DebugInfoKind DebugInfoKind::PRODUCER_INFO(&kProducerInfoName);
+C10_API const DebugInfoKind DebugInfoKind::MOBILE_RUNTIME_INFO(
+    &kMobileRuntimeInfoName);
+C10_API const DebugInfoKind DebugInfoKind::PROFILER_STATE(
+    &kProfilerStateName);
+C10_API const DebugInfoKind DebugInfoKind::INFERENCE_CONTEXT(
+    &kInferenceContextName);
+C10_API const DebugInfoKind DebugInfoKind::PARAM_COMMS_INFO(
+    &kParamCommsInfoName);
+C10_API const DebugInfoKind DebugInfoKind::TEST_INFO(&kTestInfoName);
+C10_API const DebugInfoKind DebugInfoKind::TEST_INFO_2(&kTestInfo2Name);
+
 C10_DEFINE_TLS_static(std::shared_ptr<ThreadLocalDebugInfo>, tls_debug_info);
 #define debug_info (tls_debug_info.get())
 

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -22,14 +22,13 @@ constexpr std::string_view kTestInfoName = "TEST_INFO";
 constexpr std::string_view kTestInfo2Name = "TEST_INFO_2";
 
 C10_API const DebugInfoKind DebugInfoKind::PRODUCER_INFO(&kProducerInfoName);
-C10_API const DebugInfoKind DebugInfoKind::MOBILE_RUNTIME_INFO(
-    &kMobileRuntimeInfoName);
-C10_API const DebugInfoKind DebugInfoKind::PROFILER_STATE(
-    &kProfilerStateName);
-C10_API const DebugInfoKind DebugInfoKind::INFERENCE_CONTEXT(
-    &kInferenceContextName);
-C10_API const DebugInfoKind DebugInfoKind::PARAM_COMMS_INFO(
-    &kParamCommsInfoName);
+C10_API const DebugInfoKind
+    DebugInfoKind::MOBILE_RUNTIME_INFO(&kMobileRuntimeInfoName);
+C10_API const DebugInfoKind DebugInfoKind::PROFILER_STATE(&kProfilerStateName);
+C10_API const DebugInfoKind
+    DebugInfoKind::INFERENCE_CONTEXT(&kInferenceContextName);
+C10_API const DebugInfoKind
+    DebugInfoKind::PARAM_COMMS_INFO(&kParamCommsInfoName);
 C10_API const DebugInfoKind DebugInfoKind::TEST_INFO(&kTestInfoName);
 C10_API const DebugInfoKind DebugInfoKind::TEST_INFO_2(&kTestInfo2Name);
 

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -1,5 +1,4 @@
 #include <c10/util/Exception.h>
-#include <c10/util/Logging.h>
 #include <c10/util/ThreadLocal.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
 

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -9,27 +9,6 @@
 
 namespace c10 {
 
-constexpr std::string_view kProducerInfoName = "PRODUCER_INFO";
-constexpr std::string_view kMobileRuntimeInfoName = "MOBILE_RUNTIME_INFO";
-constexpr std::string_view kProfilerStateName = "PROFILER_STATE";
-constexpr std::string_view kInferenceContextName = "INFERENCE_CONTEXT";
-constexpr std::string_view kParamCommsInfoName = "PARAM_COMMS_INFO";
-constexpr std::string_view kTestInfoName = "TEST_INFO";
-constexpr std::string_view kTestInfo2Name = "TEST_INFO_2";
-
-const DebugInfoKind DebugInfoKind::PRODUCER_INFO(&kProducerInfoName);
-const DebugInfoKind DebugInfoKind::MOBILE_RUNTIME_INFO(&kMobileRuntimeInfoName);
-const DebugInfoKind DebugInfoKind::PROFILER_STATE(&kProfilerStateName);
-const DebugInfoKind DebugInfoKind::INFERENCE_CONTEXT(&kInferenceContextName);
-const DebugInfoKind DebugInfoKind::PARAM_COMMS_INFO(&kParamCommsInfoName);
-const DebugInfoKind DebugInfoKind::TEST_INFO(&kTestInfoName);
-const DebugInfoKind DebugInfoKind::TEST_INFO_2(&kTestInfo2Name);
-
-DebugInfoKind::DebugInfoKind(DebugInfoKind::value_type value) : value_(value) {
-  CHECK(value_ != nullptr)  // Crash OK as this indicates a bug in C++ code.
-      << "DebugInfoKind must be initialized with a non-null pointer.";
-}
-
 std::ostream& operator<<(std::ostream& os, const DebugInfoKind& kind) {
   return os << (kind.value_ == nullptr ? "<uninitialized>" : *kind.value_);
 }
@@ -116,4 +95,4 @@ DebugInfoGuard::DebugInfoGuard(std::shared_ptr<ThreadLocalDebugInfo> info) {
   active_ = true;
 }
 
-} // namespace c10
+}  // namespace c10

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -18,7 +18,7 @@ namespace c10 {
 // Example:
 //
 //   inline constexpr std::string_view kMyCustomInfoName = "MY_CUSTOM_INFO";
-//   inline constexpr DebugInfoKind kMyCustomInfo(&kMyCustomInfoName);
+//   inline const DebugInfoKind kMyCustomInfo(&kMyCustomInfoName);
 //   ...
 //   ThreadLocalDebugInfo::_push(kMyCustomInfo, my_custom_info_shared_ptr);
 //   ...
@@ -54,17 +54,13 @@ class DebugInfoKind {
   }
 
   // Predefined DebugInfoKinds for common use cases.
-  // C++ doesn't allow declaring constexpr variables of an incomplete type,
-  // so these are declared as const. However, they are defined as constexpr
-  // outside the class, where the DebugInfoKind type is fully defined. We
-  // do this to ensure these are available at static initialization time.
-  static const DebugInfoKind PRODUCER_INFO;
-  static const DebugInfoKind MOBILE_RUNTIME_INFO;
-  static const DebugInfoKind PROFILER_STATE;
-  static const DebugInfoKind INFERENCE_CONTEXT; // for inference usage
-  static const DebugInfoKind PARAM_COMMS_INFO;
-  static const DebugInfoKind TEST_INFO; // used only in tests
-  static const DebugInfoKind TEST_INFO_2; // used only in tests
+  static C10_API const DebugInfoKind PRODUCER_INFO;
+  static C10_API const DebugInfoKind MOBILE_RUNTIME_INFO;
+  static C10_API const DebugInfoKind PROFILER_STATE;
+  static C10_API const DebugInfoKind INFERENCE_CONTEXT; // for inference usage
+  static C10_API const DebugInfoKind PARAM_COMMS_INFO;
+  static C10_API const DebugInfoKind TEST_INFO; // used only in tests
+  static C10_API const DebugInfoKind TEST_INFO_2; // used only in tests
 
   // Comparison operators. These allow putting DebugInfoKind in containers like
   // std::set and std::map.
@@ -92,33 +88,8 @@ class DebugInfoKind {
         false, "DebugInfoKind must be initialized with a non-null pointer.");
   }
 
-  // Names for predefined DebugInfoKinds.
-  inline static constexpr std::string_view kProducerInfoName = "PRODUCER_INFO";
-  inline static constexpr std::string_view kMobileRuntimeInfoName =
-      "MOBILE_RUNTIME_INFO";
-  inline static constexpr std::string_view kProfilerStateName =
-      "PROFILER_STATE";
-  inline static constexpr std::string_view kInferenceContextName =
-      "INFERENCE_CONTEXT";
-  inline static constexpr std::string_view kParamCommsInfoName =
-      "PARAM_COMMS_INFO";
-  inline static constexpr std::string_view kTestInfoName = "TEST_INFO";
-  inline static constexpr std::string_view kTestInfo2Name = "TEST_INFO_2";
-
   value_type value_ = nullptr;
 };
-
-inline constexpr DebugInfoKind DebugInfoKind::PRODUCER_INFO(&kProducerInfoName);
-inline constexpr DebugInfoKind DebugInfoKind::MOBILE_RUNTIME_INFO(
-    &kMobileRuntimeInfoName);
-inline constexpr DebugInfoKind DebugInfoKind::PROFILER_STATE(
-    &kProfilerStateName);
-inline constexpr DebugInfoKind DebugInfoKind::INFERENCE_CONTEXT(
-    &kInferenceContextName);
-inline constexpr DebugInfoKind DebugInfoKind::PARAM_COMMS_INFO(
-    &kParamCommsInfoName);
-inline constexpr DebugInfoKind DebugInfoKind::TEST_INFO(&kTestInfoName);
-inline constexpr DebugInfoKind DebugInfoKind::TEST_INFO_2(&kTestInfo2Name);
 
 class C10_API DebugInfoBase {
  public:

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -2,20 +2,55 @@
 
 #include <c10/macros/Export.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <ostream>
+#include <string_view>
 
 namespace c10 {
 
-enum class C10_API_ENUM DebugInfoKind : uint8_t {
-  PRODUCER_INFO = 0,
-  MOBILE_RUNTIME_INFO,
-  PROFILER_STATE,
-  INFERENCE_CONTEXT, // for inference usage
-  PARAM_COMMS_INFO,
+// Identifies a slot in ThreadLocalDebugInfo for storing a specific type
+// of python-thread-local state.
+//
+// This class is trivial to copy and move, and is cheap to construct and
+// destroy. It mimics the behavior of an enum class for backward compatibility
+// with existing uses.
+class C10_API DebugInfoKind {
+ private:
+  // Must be a non-null pointer to a string literal with static storage
+  // duration. The pointer address is used as the identifier for the slot.
+  // The string itself is only used for debugging purposes and should be
+  // descriptive of the slot's purpose and ideally (but not required) be unique.
+  using value_type = const std::string_view*;  // Must be non-null.
 
-  TEST_INFO, // used only in tests
-  TEST_INFO_2, // used only in tests
+ public:
+  // Creates an uninitialized DebugInfoKind.
+  DebugInfoKind() = default;
+
+  // Creates a DebugInfoKind with the given identity.
+  explicit DebugInfoKind(value_type value);
+
+  // Predefined DebugInfoKinds for common use cases.
+  static const DebugInfoKind PRODUCER_INFO;
+  static const DebugInfoKind MOBILE_RUNTIME_INFO;
+  static const DebugInfoKind PROFILER_STATE;
+  static const DebugInfoKind INFERENCE_CONTEXT;  // for inference usage
+  static const DebugInfoKind PARAM_COMMS_INFO;
+  static const DebugInfoKind TEST_INFO;    // used only in tests
+  static const DebugInfoKind TEST_INFO_2;  // used only in tests
+
+  constexpr bool operator==(const DebugInfoKind& other) const {
+    return value_ == other.value_;
+  }
+  constexpr bool operator!=(const DebugInfoKind& other) const {
+    return value_ != other.value_;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const DebugInfoKind& kind);
+
+ private:
+  value_type value_ = nullptr;
 };
 
 class C10_API DebugInfoBase {

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -10,24 +10,37 @@
 namespace c10 {
 
 // Identifies a slot in ThreadLocalDebugInfo for storing a specific type
-// of python-thread-local state.
+// of thread-local state.
 //
 // This class is trivial to copy and move, and is cheap to construct and
-// destroy. It mimics the behavior of an enum class for backward compatibility
-// with existing uses.
+// destroy.
+//
+// Example:
+//
+//   inline constexpr std::string_view kMyCustomInfoName = "MY_CUSTOM_INFO";
+//   inline constexpr DebugInfoKind kMyCustomInfo(&kMyCustomInfoName);
+//   ...
+//   ThreadLocalDebugInfo::_push(kMyCustomInfo, my_custom_info_shared_ptr);
+//   ...
+//   const DebugInfoBase* info = ThreadLocalDebugInfo::get(kMyCustomInfo);
+//   ...
+//   ThreadLocalDebugInfo::_pop(kMyCustomInfo);
 class C10_API DebugInfoKind {
  private:
-  // Must be a non-null pointer to a string literal with static storage
-  // duration. The pointer address is used as the identifier for the slot.
-  // The string itself is only used for debugging purposes and should be
-  // descriptive of the slot's purpose and ideally (but not required) be unique.
+  // Must be a non-null pointer to a string_view literal with static storage
+  // duration.
   using value_type = const std::string_view*;
 
  public:
   // Creates an uninitialized DebugInfoKind.
   constexpr DebugInfoKind() = default;
 
-  // Creates a DebugInfoKind with the given identity, which must not be null.
+  // Creates a DebugInfoKind with the given identity, which must be a non-null
+  // pointer to a string_view literal with static storage duration. The pointer
+  // address (not the string itself) is used as the identifier for the slot. The
+  // string itself is only used for debugging purposes and should be descriptive
+  // of the slot's purpose and ideally (but not required) be unique.
+  //
   // If called with a null value in a constexpr context, will trigger a compile
   // time error. If called with a null value in a non-constexpr context, will
   // trigger a runtime exception.
@@ -44,7 +57,7 @@ class C10_API DebugInfoKind {
   // C++ doesn't allow declaring constexpr variables of an incomplete type,
   // so these are declared as const. However, they are defined as constexpr
   // outside the class, where the DebugInfoKind type is fully defined. We
-  // do this for backward compatibility.
+  // do this to ensure these are available at static initialization time.
   static const DebugInfoKind PRODUCER_INFO;
   static const DebugInfoKind MOBILE_RUNTIME_INFO;
   static const DebugInfoKind PROFILER_STATE;

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <c10/macros/Export.h>
+#include <c10/util/Exception.h>
 
-#include <cstddef>
-#include <cstdint>
+#include <iosfwd>
 #include <memory>
-#include <ostream>
 #include <string_view>
 
 namespace c10 {
@@ -22,16 +21,30 @@ class C10_API DebugInfoKind {
   // duration. The pointer address is used as the identifier for the slot.
   // The string itself is only used for debugging purposes and should be
   // descriptive of the slot's purpose and ideally (but not required) be unique.
-  using value_type = const std::string_view*;  // Must be non-null.
+  using value_type = const std::string_view*;
 
  public:
   // Creates an uninitialized DebugInfoKind.
-  DebugInfoKind() = default;
+  constexpr DebugInfoKind() = default;
 
-  // Creates a DebugInfoKind with the given identity.
-  explicit DebugInfoKind(value_type value);
+  // Creates a DebugInfoKind with the given identity, which must not be null.
+  // If called with a null value in a constexpr context, will trigger a compile
+  // time error. If called with a null value in a non-constexpr context, will
+  // trigger a runtime exception.
+  explicit constexpr DebugInfoKind(value_type value) : value_(value) {
+    if (value == nullptr) {
+      // Since this function is not constexpr, it will trigger a compile-time
+      // error if the DebugInfoKind() ctor is called in a constexpr context
+      // with a null value.
+      DebugInfoKind_ctor_parameter_must_not_be_null();
+    }
+  }
 
   // Predefined DebugInfoKinds for common use cases.
+  // C++ doesn't allow declaring constexpr variables of an incomplete type,
+  // so these are declared as const. However, they are defined as constexpr
+  // outside the class, where the DebugInfoKind type is fully defined. We
+  // do this for backward compatibility.
   static const DebugInfoKind PRODUCER_INFO;
   static const DebugInfoKind MOBILE_RUNTIME_INFO;
   static const DebugInfoKind PROFILER_STATE;
@@ -40,18 +53,57 @@ class C10_API DebugInfoKind {
   static const DebugInfoKind TEST_INFO;    // used only in tests
   static const DebugInfoKind TEST_INFO_2;  // used only in tests
 
-  constexpr bool operator==(const DebugInfoKind& other) const {
+  // Comparison operators. These allow putting DebugInfoKind in containers like
+  // std::set and std::map.
+  constexpr bool operator==(const DebugInfoKind other) const {
     return value_ == other.value_;
   }
-  constexpr bool operator!=(const DebugInfoKind& other) const {
+  constexpr bool operator!=(const DebugInfoKind other) const {
     return value_ != other.value_;
+  }
+  constexpr bool operator<(const DebugInfoKind other) const {
+    return value_ < other.value_;
   }
 
   friend std::ostream& operator<<(std::ostream& os, const DebugInfoKind& kind);
 
  private:
+  // Doesn't compile in a constexpr context; throws in a non-constexpr context.
+  // The function name is intentionally verbose to make the compiler error
+  // more readable.
+  [[noreturn]] static inline void
+  DebugInfoKind_ctor_parameter_must_not_be_null() {
+    TORCH_INTERNAL_ASSERT(
+        false, "DebugInfoKind must be initialized with a non-null pointer.");
+  }
+
+  // Names for predefined DebugInfoKinds.
+  inline static constexpr std::string_view kProducerInfoName = "PRODUCER_INFO";
+  inline static constexpr std::string_view kMobileRuntimeInfoName =
+      "MOBILE_RUNTIME_INFO";
+  inline static constexpr std::string_view kProfilerStateName =
+      "PROFILER_STATE";
+  inline static constexpr std::string_view kInferenceContextName =
+      "INFERENCE_CONTEXT";
+  inline static constexpr std::string_view kParamCommsInfoName =
+      "PARAM_COMMS_INFO";
+  inline static constexpr std::string_view kTestInfoName = "TEST_INFO";
+  inline static constexpr std::string_view kTestInfo2Name = "TEST_INFO_2";
+
   value_type value_ = nullptr;
 };
+
+inline constexpr DebugInfoKind DebugInfoKind::PRODUCER_INFO(&kProducerInfoName);
+inline constexpr DebugInfoKind DebugInfoKind::MOBILE_RUNTIME_INFO(
+    &kMobileRuntimeInfoName);
+inline constexpr DebugInfoKind DebugInfoKind::PROFILER_STATE(
+    &kProfilerStateName);
+inline constexpr DebugInfoKind DebugInfoKind::INFERENCE_CONTEXT(
+    &kInferenceContextName);
+inline constexpr DebugInfoKind DebugInfoKind::PARAM_COMMS_INFO(
+    &kParamCommsInfoName);
+inline constexpr DebugInfoKind DebugInfoKind::TEST_INFO(&kTestInfoName);
+inline constexpr DebugInfoKind DebugInfoKind::TEST_INFO_2(&kTestInfo2Name);
 
 class C10_API DebugInfoBase {
  public:
@@ -117,4 +169,4 @@ class C10_API DebugInfoGuard {
   std::shared_ptr<ThreadLocalDebugInfo> prev_info_ = nullptr;
 };
 
-} // namespace c10
+}  // namespace c10

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -61,10 +61,10 @@ class C10_API DebugInfoKind {
   static const DebugInfoKind PRODUCER_INFO;
   static const DebugInfoKind MOBILE_RUNTIME_INFO;
   static const DebugInfoKind PROFILER_STATE;
-  static const DebugInfoKind INFERENCE_CONTEXT;  // for inference usage
+  static const DebugInfoKind INFERENCE_CONTEXT; // for inference usage
   static const DebugInfoKind PARAM_COMMS_INFO;
-  static const DebugInfoKind TEST_INFO;    // used only in tests
-  static const DebugInfoKind TEST_INFO_2;  // used only in tests
+  static const DebugInfoKind TEST_INFO; // used only in tests
+  static const DebugInfoKind TEST_INFO_2; // used only in tests
 
   // Comparison operators. These allow putting DebugInfoKind in containers like
   // std::set and std::map.
@@ -78,7 +78,8 @@ class C10_API DebugInfoKind {
     return value_ < other.value_;
   }
 
-  friend std::ostream& operator<<(std::ostream& os, const DebugInfoKind& kind);
+  C10_API friend std::ostream& operator<<(std::ostream& os,
+                                          const DebugInfoKind& kind);
 
  private:
   // Doesn't compile in a constexpr context; throws in a non-constexpr context.
@@ -182,4 +183,4 @@ class C10_API DebugInfoGuard {
   std::shared_ptr<ThreadLocalDebugInfo> prev_info_ = nullptr;
 };
 
-}  // namespace c10
+} // namespace c10

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -25,7 +25,7 @@ namespace c10 {
 //   const DebugInfoBase* info = ThreadLocalDebugInfo::get(kMyCustomInfo);
 //   ...
 //   ThreadLocalDebugInfo::_pop(kMyCustomInfo);
-class C10_API DebugInfoKind {
+class DebugInfoKind {
  private:
   // Must be a non-null pointer to a string_view literal with static storage
   // duration.

--- a/c10/util/ThreadLocalDebugInfo.h
+++ b/c10/util/ThreadLocalDebugInfo.h
@@ -78,8 +78,9 @@ class C10_API DebugInfoKind {
     return value_ < other.value_;
   }
 
-  C10_API friend std::ostream& operator<<(std::ostream& os,
-                                          const DebugInfoKind& kind);
+  C10_API friend std::ostream& operator<<(
+      std::ostream& os,
+      const DebugInfoKind& kind);
 
  private:
   // Doesn't compile in a constexpr context; throws in a non-constexpr context.


### PR DESCRIPTION
This PR fixes https://github.com/pytorch/pytorch/issues/56027.

It changes the `DebugInfoKind` type from an `uint8_t`-based `enum class` to a thin wrapper of a pointer, where the pointer address is used to identify the kind. This allows defining new kinds freely.

To maintain backward compatibility with existing code, we add methods and member variables to this class to mimic the old `enum class` interface.