### PR TITLE
[DeviceMesh] Enforce 2-level Layouts

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -11,7 +11,7 @@ import torch.distributed._functional_collectives as funcol
 from torch._C._distributed_c10d import Backend as C10dBackend
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.distributed import config as dist_config
-from torch.distributed._mesh_layout import _MeshLayout as _Layout
+from torch.distributed._mesh_layout import _FlatLayout, _MeshLayout
 from torch.distributed.device_mesh import _mesh_resources, DeviceMesh, init_device_mesh
 from torch.distributed.distributed_c10d import (
     _get_default_group,
@@ -958,9 +958,11 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         flatten_mesh_layout = root_mesh._flatten_mapping["dp_cp"]._layout
         self.assertEqual(flatten_mesh_layout, flattened_dp_cp_mesh._layout)
         self.assertEqual(
-            flattened_dp_cp_mesh._layout.global_ranks(8),
+            flattened_dp_cp_mesh._layout.collapse().global_ranks(8),
             [[0, 2, 4, 6], [1, 3, 5, 7]],
         )
+        # This should not raise as they are well separated
+        mesh_3d["dp_cp", "tp"]
 
         ref_pg_count = _world.group_count
         # Calling flatten again should not create a new pg.
@@ -978,13 +980,13 @@ class TestDeviceMeshGetItem(DTensorTestBase):
         flatten_mesh_root_layout = root_mesh._flatten_mapping["dp_tp"]._layout
         self.assertEqual(flatten_mesh_root_layout, flattened_dp_tp_mesh._layout)
         self.assertEqual(
-            flattened_dp_tp_mesh._layout.global_ranks(8),
+            flattened_dp_tp_mesh._layout.collapse().global_ranks(8),
             [[0, 1, 4, 5], [2, 3, 6, 7]],
         )
         with self.assertRaisesRegex(
-            NotImplementedError,
-            "Currently, this only allows slicing out a contiguous flattened dim",
+            KeyError, "Mesh dim indices should be in ascending order"
         ):
+            # dp_tp is partly "above" and partly "below" cp
             mesh_3d["dp_tp", "cp"]
 
         # Test flatten with a flattened mesh_dim_name
@@ -1624,24 +1626,54 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
 class CuTeLayoutTest(TestCase):
     def test_coalesce(self):
         # ((3,2),(2,1)) -> (6,1)
-        l = _Layout((3, 2), (2, 1))
-        l = l.coalesce()
+        l = _FlatLayout((3, 2), (2, 1))
         self.assertEqual(list(l.sizes_and_strides), [(6, 1)])
 
         # ((2,12),(3,4),(4,1)) -> (24,1)
-        l = _Layout((2, 3, 4), (12, 4, 1))
-        l = l.coalesce()
+        l = _FlatLayout((2, 3, 4), (12, 4, 1))
         self.assertEqual(list(l.sizes_and_strides), [(24, 1)])
 
     def test_coalesce_non_coalescible(self):
         # ((3,4),(2,1)) stays as-is (4 ≠ 2*1)
-        l = _Layout((3, 2), (4, 1))
-        l = l.coalesce()
+        l = _FlatLayout((3, 2), (4, 1))
         self.assertEqual(list(l.sizes_and_strides), [(3, 4), (2, 1)])
+
+    def test_coalesce_singleton_dims(self):
+        # Dimensions with size=1 are removed, even if it's all of them
+        l = _FlatLayout((1, 3, 1, 5, 1), (0, 10, 17, 2, 1))
+        self.assertEqual(list(l.sizes_and_strides), [(15, 2)])
+
+        l = _FlatLayout((1, 1, 1), (1, 42, 0))
+        self.assertEqual(list(l.sizes_and_strides), [])
+
+    def test_flatten(self):
+        l = _FlatLayout(((7, (5, 3)), 2), ((900, (36, 4)), 1))
+        self.assertEqual(list(l.sizes_and_strides), [(7, 900), (5, 36), (3, 4), (2, 1)])
+
+        l = _FlatLayout(((7, (5, 3)), 2), ((30, (6, 2)), 1))
+        self.assertEqual(list(l.sizes_and_strides), [(7 * 5 * 3 * 2, 1)])
+
+    def test_optional_strides(self):
+        l = _FlatLayout((7, 5, 3, 2))
+        # Strides default to suffix_product, which means they're coalescible
+        self.assertEqual(list(l.sizes_and_strides), [(7 * 5 * 3 * 2, 1)])
+
+    def test_mismatch_sizes_strides(self):
+        with self.assertRaisesRegex(ValueError, "sizes .* and strides .* don't match"):
+            _FlatLayout(42, (1,))
+
+        with self.assertRaisesRegex(ValueError, "sizes .* and strides .* don't match"):
+            _FlatLayout((3, 2), 1)
+
+        with self.assertRaisesRegex(ValueError, "sizes .* and strides .* don't match"):
+            _FlatLayout((5, 3, 2), (2, 1))
+
+        with self.assertRaisesRegex(ValueError, "sizes .* and strides .* don't match"):
+            _FlatLayout((5, (3, 2)), ((5, 3), 2))
 
     def test_complement_n_group_layout(self):
         # complement((4,2), 8) = (2,1); together form (8,1)
-        pg_layout = _Layout(
+        pg_layout = _FlatLayout(
             (4,),
             (2,),
         )
@@ -1687,7 +1719,7 @@ class CuTeLayoutTest(TestCase):
         )
 
         # Complement ((2,4), (2,1)) under world_size=16 → complement ((2,8), (2,2))
-        pg_layout = _Layout((2, 2), (4, 1))
+        pg_layout = _FlatLayout((2, 2), (4, 1))
         self.assertEqual(
             pg_layout.all_ranks_from_zero(),
             [0, 1, 4, 5],
@@ -1709,7 +1741,7 @@ class CuTeLayoutTest(TestCase):
         )
 
         # Test layout_to_global_ranks and layout_to_all_ranks_from_zero
-        pg_layout = _Layout((2, 2), (4, 2))
+        pg_layout = _FlatLayout((2, 2), (4, 2))
         self.assertEqual(
             pg_layout.all_ranks_from_zero(),
             [0, 2, 4, 6],
@@ -1727,7 +1759,7 @@ class CuTeLayoutTest(TestCase):
         self.assertEqual(list(outer.sizes_and_strides), [(2, 8), (2, 1)])
         # Test when stride is not monotonically decreasing, the complement layout
         # is same as the one sorted its stride.
-        pg_layout_r = _Layout((2, 2), (2, 4))
+        pg_layout_r = _FlatLayout((2, 2), (2, 4))
         outer = pg_layout_r.complement(world_size=16)
         self.assertEqual(list(outer.sizes_and_strides), [(2, 8), (2, 1)])
         self.assertEqual(
@@ -1741,7 +1773,7 @@ class CuTeLayoutTest(TestCase):
         )
 
         # Test just all_ranks_from_zero and global_ranks.
-        pg_layout = _Layout((4,), (2,))
+        pg_layout = _FlatLayout((4,), (2,))
         self.assertEqual(
             pg_layout.all_ranks_from_zero(),
             [0, 2, 4, 6],
@@ -1758,9 +1790,9 @@ class CuTeLayoutTest(TestCase):
 
     def test_composition(self):
         # self = ((4,2), (2,1)), l = (2,1)  → self o l = (2,1)
-        orig_l = _Layout((4, 2), (2, 1))
-        right_l = _Layout((2,), (1,))
-        composed_layout = orig_l.composition(right_l)
+        orig_l = _FlatLayout((4, 2), (2, 1))
+        right_l = _MeshLayout.from_sizes_strides((2,), (1,))
+        (composed_layout,) = orig_l.composition(right_l)
         self.assertEqual(list(composed_layout.sizes_and_strides), [(2, 1)])
         self.assertEqual(
             composed_layout.global_ranks(8),
@@ -1773,9 +1805,9 @@ class CuTeLayoutTest(TestCase):
         )
 
         # self = (4,2), l = (2,1)  → self o l = (2,2)
-        orig_l = _Layout((4,), (2,))
-        right_l = _Layout((2,), (1,))
-        composed_layout = orig_l.composition(right_l)
+        orig_l = _FlatLayout((4,), (2,))
+        right_l = _MeshLayout.from_sizes_strides((2,), (1,))
+        (composed_layout,) = orig_l.composition(right_l)
         self.assertEqual(list(composed_layout.sizes_and_strides), [(2, 2)])
         self.assertEqual(
             composed_layout.global_ranks(8),
@@ -1789,9 +1821,10 @@ class CuTeLayoutTest(TestCase):
 
         # self = (4,2), l = ((2,2), (2,1))  → self o l = ((2,4), (2,2))
         # This is to mimic the un-flatten from a 2D mesh to a 1D mesh.
-        right_l = _Layout((2, 2), (2, 1))
+        right_l = _MeshLayout.from_sizes_strides((2, 2), (2, 1))
         composed_layout = orig_l.composition(right_l)
-        self.assertEqual(list(composed_layout.sizes_and_strides), [(2, 4), (2, 2)])
+        self.assertEqual(list(composed_layout[0].sizes_and_strides), [(2, 4)])
+        self.assertEqual(list(composed_layout[1].sizes_and_strides), [(2, 2)])
         self.assertEqual(
             composed_layout[0].global_ranks(8),
             [
@@ -1812,91 +1845,91 @@ class CuTeLayoutTest(TestCase):
         )
 
         # Error case.
-        orig_l = _Layout((4, 2), (4, 1))
+        orig_l = _FlatLayout((4, 2), (4, 1))
         with self.assertRaises(
             AssertionError,
         ):
-            right_l = _Layout((2,), (3,))
+            right_l = _MeshLayout.from_sizes_strides((2,), (3,))
             orig_l.composition(right_l)
 
     def test_check_non_overlap(self):
         """Test the check_non_overlap method for various layout configurations."""
         # Test 1: Valid layout - no overlap
         # sizes=(2,3), strides=(6,1) - stride 6 > span 3, so no overlap
-        layout1 = _Layout((2, 3), (6, 1))
+        layout1 = _FlatLayout((2, 3), (6, 1))
         self.assertTrue(layout1.check_non_overlap())
 
         # Test 2: Invalid layout - overlap due to stride < previous span
         # sizes=(2,3), strides=(2,1) - stride 2 < span 3, causes overlap
-        layout2 = _Layout((2, 3), (2, 1))
+        layout2 = _FlatLayout((2, 3), (2, 1))
         self.assertFalse(layout2.check_non_overlap())
 
         # Test 3: Invalid layout - duplicate strides
         # sizes=(2,3), strides=(1,1) - same stride, causes overlap
-        layout3 = _Layout((2, 3), (1, 1))
+        layout3 = _FlatLayout((2, 3), (1, 1))
         self.assertFalse(layout3.check_non_overlap())
 
         # Test 4: Valid layout - single dimension
-        layout4 = _Layout((4,), (1,))
+        layout4 = _FlatLayout((4,), (1,))
         self.assertTrue(layout4.check_non_overlap())
 
         # Test 5: Valid layout - exact boundary case
         # sizes=(2,3), strides=(3,1) - stride 3 == span 3, valid
-        layout5 = _Layout((2, 3), (3, 1))
+        layout5 = _FlatLayout((2, 3), (3, 1))
         self.assertTrue(layout5.check_non_overlap())
 
         # Test 6: Valid layout - multi-dimensional with proper spacing
-        layout6 = _Layout((2, 2, 2), (8, 4, 1))
+        layout6 = _FlatLayout((2, 2, 2), (8, 4, 1))
         self.assertTrue(layout6.check_non_overlap())
 
         # Test 7: Valid layout - stride not ordered
-        layout7 = _Layout((2, 2, 2), (4, 1, 2))
+        layout7 = _FlatLayout((2, 2, 2), (4, 1, 2))
         self.assertTrue(layout7.check_non_overlap())
 
         # Test 8: Valid layout - Interleaved but no overlap
-        layout8 = _Layout((3, 2), (2, 3))
+        layout8 = _FlatLayout((3, 2), (2, 3))
         self.assertTrue(layout8.check_non_overlap())
 
     def test_remap_to_tensor(self):
         """Test the remap_to_tensor method for various scenarios."""
         # Test 1: Consecutive ranks, full world - should return logical groups directly
         original_mesh = torch.tensor([0, 1, 2, 3], dtype=torch.int)
-        layout1 = _Layout((2, 2), (2, 1))  # row-major 2x2
+        layout1 = _MeshLayout.from_sizes_strides((2, 2), (2, 1))  # row-major 2x2
         result1 = layout1.remap_to_tensor(original_mesh)
         expected1 = torch.tensor([[[0, 1], [2, 3]]], dtype=torch.int)
         self.assertEqual(result1, expected1)
 
         # Test 2: Non-consecutive ranks - should map to actual ranks
         original_mesh = torch.tensor([10, 20, 30, 40], dtype=torch.int)
-        layout2 = _Layout((2, 2), (2, 1))
+        layout2 = _MeshLayout.from_sizes_strides((2, 2), (2, 1))
         result2 = layout2.remap_to_tensor(original_mesh)
         expected2 = torch.tensor([[[10, 20], [30, 40]]], dtype=torch.int)
         self.assertEqual(result2, expected2)
 
         # Test 4: 1D layout with consecutive ranks
         original_mesh = torch.tensor([0, 1, 2, 3], dtype=torch.int)
-        layout4 = _Layout((4,), (1,))
+        layout4 = _MeshLayout.from_sizes_strides((4,), (1,))
         result4 = layout4.remap_to_tensor(original_mesh)
         expected4 = torch.tensor([[0, 1, 2, 3]], dtype=torch.int)
         self.assertEqual(result4, expected4)
 
         # Test 5: Complex strided layout with non-consecutive ranks
         original_mesh = torch.tensor([5, 10, 15, 20], dtype=torch.int)
-        layout5 = _Layout((2, 2), (2, 1))
+        layout5 = _MeshLayout.from_sizes_strides((2, 2), (2, 1))
         result5 = layout5.remap_to_tensor(original_mesh)
         expected5 = torch.tensor([[[5, 10], [15, 20]]], dtype=torch.int)
         self.assertEqual(result5, expected5)
 
         # Test 6: Tensor Cute representation of a 2D mesh
         original_mesh = torch.tensor([0, 2, 1, 3], dtype=torch.int)
-        layout6 = _Layout((2, 2), (1, 2))  # column-major style
+        layout6 = _MeshLayout.from_sizes_strides((2, 2), (1, 2))  # column-major style
         result6 = layout6.remap_to_tensor(original_mesh)
         expected6 = torch.tensor([[[0, 1], [2, 3]]], dtype=torch.int)
         self.assertEqual(result6, expected6)
 
         # Test 7: Layout with different stride pattern
         original_mesh = torch.tensor([0, 2, 1, 4], dtype=torch.int)
-        layout7 = _Layout((2, 2), (1, 2))  # column-major style
+        layout7 = _MeshLayout.from_sizes_strides((2, 2), (1, 2))  # column-major style
         result7 = layout7.remap_to_tensor(original_mesh)
         expected7 = torch.tensor([[[0, 1], [2, 4]]], dtype=torch.int)
         self.assertEqual(result7, expected7)

--- a/torch/distributed/_local_tensor/_c10d.py
+++ b/torch/distributed/_local_tensor/_c10d.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 import torch
 from torch._C import ScriptObject
 from torch._C._distributed_c10d import FakeWork, PythonCallbackWork
-from torch.distributed._mesh_layout import _MeshLayout
+from torch.distributed._mesh_layout import _FlatLayout
 from torch.distributed.distributed_c10d import (
     _check_op,
     _get_default_group,
@@ -94,7 +94,7 @@ def _prepare_collective_groups(
     ranks = [r - offset for r in ranks]
 
     shape, strides = _indices_to_layout(ranks)
-    layout = _MeshLayout(shape, strides)
+    layout = _FlatLayout(shape, strides)
 
     global_pg = _get_default_group()
     group_offsets = layout.complement(global_pg.size()).all_ranks_from_zero()

--- a/torch/distributed/_mesh_layout.py
+++ b/torch/distributed/_mesh_layout.py
@@ -3,9 +3,10 @@ Definition of CuTe inspired Layouts for DeviceMesh internal bookkeeping and func
 """
 
 import math
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from itertools import product
+from typing import NoReturn, overload
 
 import torch
 from torch.distributed._pycute import (
@@ -18,13 +19,17 @@ from torch.distributed._pycute import (
     is_int,
     is_tuple,
     Layout,
+    make_layout,
     match_structure,
+    suffix_product,
 )
 
 
-@dataclass(frozen=True, init=True)
-class _MeshLayout(Layout):
+@dataclass(frozen=True)
+class _FlatLayout:
     """
+    A canonical CuTe layout for a single dimension of a DeviceMesh
+
     Utility class for representing an integer layout by borrowing ideas from CuTe Layout Algebra.
     See https://docs.nvidia.com/cutlass/media/docs/cpp/cute/02_layout_algebra.html for more details.
 
@@ -37,82 +42,62 @@ class _MeshLayout(Layout):
     Note this is a CuTe-inspired layout, because CuTe uses co-lexicographic way in linearization while PyTorch
     is using lexicographic. So even though the CuTe documentation can still be referenced, the implementation will be
     different from that of PyCute's.
+
+    This layout is _not_ itself subdivided into multiple dimensions. It might
+    internally sometimes use multidimensional tuple to represent "irregular"
+    layouts (e.g., flattening non-adjacent dims), but this should be considered
+    an opaque implementation detail.
+
+    This class guarantees that all equivalent layouts are encoded as the same
+    normalized representation, and thus compare equal. This is achieved by
+    flattening and coalescing compatible adjacent dimensions (which includes
+    removing all dimensions of size 1).
+
     """
 
-    # pyrefly: ignore [bad-override]
-    shape: IntTuple
-    # pyrefly: ignore [bad-override]
-    stride: IntTuple
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
 
-    def __post_init__(self) -> None:
-        if not is_tuple(self.shape) and not is_int(self.shape):
-            raise TypeError(f"shape must be a tuple or int, got {type(self.shape)}")
-        if not is_tuple(self.stride) and not is_int(self.stride):
-            raise TypeError(f"stride must be a tuple or int, got {type(self.stride)}")
-        if not match_structure(self.shape, self.stride):
-            raise ValueError(
-                f"sizes {self.shape} and strides {self.stride} don't match"
-            )
+    def __init__(self, shape: IntTuple, stride: IntTuple | None = None) -> None:
+        if not is_tuple(shape) and not is_int(shape):
+            raise TypeError(f"shape must be a tuple or int, got {type(shape)}")
+        stride = stride if stride is not None else suffix_product(shape)
+        if not is_tuple(stride) and not is_int(stride):
+            raise TypeError(f"stride must be a tuple or int, got {type(stride)}")
+        if not match_structure(shape, stride):
+            raise ValueError(f"sizes {shape} and strides {stride} don't match")
 
-    @property
-    def sizes(self) -> IntTuple:
-        return self.shape
+        coalesced_layout = coalesce(Layout(shape, stride))
+        flat_shape = flatten(coalesced_layout.shape)
+        flat_stride = flatten(coalesced_layout.stride)
 
-    @property
-    def strides(self) -> IntTuple:
-        return self.stride
+        # pycute will preserve a size=1 dim if it's the only remaining dim, but
+        # we prefer to stick to the Tensor convention and make it 0-dimensional
+        if flat_shape == (1,) and flat_stride == (0,):
+            flat_shape = ()
+            flat_stride = ()
 
-    @property
-    def sizes_and_strides(self) -> Iterator[tuple[int, int]]:
-        return zip(flatten(self.shape), flatten(self.stride))
+        # Set attributes using object.__setattr__ since frozen=True
+        object.__setattr__(self, "shape", flat_shape)
+        object.__setattr__(self, "stride", flat_stride)
 
-    @property
-    def top_level_sizes(self) -> tuple[int, ...]:
-        return tuple(self[i].numel() for i in range(len(self)))
+    def __len__(self) -> NoReturn:
+        raise RuntimeError(
+            "You should never need to know the length of the internal representation of a FlatLayout"
+        )
+
+    def __getitem__(self, i: int) -> NoReturn:
+        raise RuntimeError(
+            "You should never need to index into the internal representation of a FlatLayout"
+        )
+
+    def to_pycute(self) -> Layout:
+        if not self.shape:
+            return Layout(1, 0)
+        return Layout(self.shape, self.stride)
 
     def numel(self) -> int:
-        return math.prod(flatten(self.shape))
-
-    # # operator []    (get-i like tuples)
-    def __getitem__(self, i: int) -> "_MeshLayout":
-        if i < -len(self) or i >= len(self):
-            raise IndexError(
-                f"Dim {i} is out of range for layout with {len(self)} dimensions. "
-                f"Expected dim to be in range [{-len(self)}, {len(self) - 1}]."
-            )
-        layout = super().__getitem__(i)
-        return _MeshLayout(layout.shape, layout.stride)
-
-    def nest(self) -> "_MeshLayout":
-        return _MeshLayout((self.shape,), (self.stride,))
-
-    def coalesce(self) -> "_MeshLayout":
-        """
-        A layout is represented by (sizes):(strides), e.g. (3,2):(4,2).
-        Two consecutive dimensions can be "merged" into one if their
-        strides are contiguous/multiplicative (i.e., the inner stride * inner size
-        equals the next stride), we perform this kind of merge inside coalesce.
-
-        Example 1 (simple): (3,2):(2,1)
-        - inner dimension: has stride=1, size=2
-        - outer dimension: stride = inner_stride * inner_size = 2
-        → coalesced = (6:1)    # acts like a flat 1D array of length 6
-
-        Example 2 (non-coalescible): (3,2):(4,1)
-        - inner dimension: stride=1, size=2 → 2*1 = 2
-        - outer dimension: stride=4, mismatch (≠ 2)
-        → cannot merge; result stays (3,2):(4,1)
-        """
-        layout = coalesce(self)
-        # The original PuCute coalesce() will use stride=0 for size=1 for all dimension.
-        # We don't want to do that in device mesh, we will reset them to be 1 to be same as PyTorch.
-        if is_int(layout.stride) and layout.stride == 0:
-            return _MeshLayout(layout.shape, 1)
-        elif is_tuple(layout.stride) and any(s == 0 for s in layout.stride):
-            non_zero_strides = tuple(s if s != 0 else 1 for s in layout.stride)
-            return _MeshLayout(layout.shape, non_zero_strides)
-        else:
-            return _MeshLayout(layout.shape, layout.stride)
+        return math.prod(self.shape)
 
     def composition(self, layout: "_MeshLayout") -> "_MeshLayout":
         """
@@ -137,10 +122,14 @@ class _MeshLayout(Layout):
         Returns:
           Layout being composed.
         """
-        result = composition(self, layout)
-        return _MeshLayout(result.shape, result.stride)
+        result = composition(self.to_pycute(), layout.to_pycute())
+        result_axes = [
+            _FlatLayout(shape, stride)
+            for shape, stride in zip(as_tuple(result.shape), as_tuple(result.stride))
+        ]
+        return _MeshLayout(result_axes)
 
-    def complement(self, world_size: int) -> "_MeshLayout":
+    def complement(self, world_size: int) -> "_FlatLayout":
         """
         Compute the "complement layout" relative to a given world_size.
         A complement layout fills in the "missing" factor so that: self repeat a layout of complement(self, world_size)
@@ -162,15 +151,8 @@ class _MeshLayout(Layout):
 
         For a visualized explanation, see https://x.com/ezyang/status/1962364978393981433/
         """
-        layout = complement(self, world_size)
-        return _MeshLayout(layout.shape, layout.stride)
-
-    def splice(self, start: int, end: int, layout: "_MeshLayout") -> "_MeshLayout":
-        sizes = list(as_tuple(self.sizes))
-        strides = list(as_tuple(self.strides))
-        sizes[start:end] = list(as_tuple(layout.sizes))
-        strides[start:end] = list(as_tuple(layout.strides))
-        return _MeshLayout(tuple(sizes), tuple(strides))
+        result = complement(self.to_pycute(), world_size)
+        return _FlatLayout(result.shape, result.stride)
 
     def all_ranks_from_zero(self) -> list[int]:
         """
@@ -207,8 +189,8 @@ class _MeshLayout(Layout):
         result = [0, 2, 4, 1, 3, 5]
         """
         return [
-            sum(c * s for c, s in zip(coord, flatten(self.strides)))
-            for coord in product(*(range(s) for s in flatten(self.sizes)))
+            sum(c * s for c, s in zip(coord, self.stride))
+            for coord in product(*(range(s) for s in self.shape))
         ]
 
     def global_ranks(self, world_size: int) -> list[list[int]]:
@@ -238,6 +220,9 @@ class _MeshLayout(Layout):
             [offset + rank for rank in self.all_ranks_from_zero()]
             for offset in self.complement(world_size).all_ranks_from_zero()
         ]
+
+    def check_sorted(self) -> bool:
+        return tuple(sorted(self.stride, reverse=True)) == self.stride
 
     def check_non_overlap(self) -> bool:
         """
@@ -270,6 +255,98 @@ class _MeshLayout(Layout):
         """
         ranks = self.all_ranks_from_zero()
         return len(ranks) == len(set(ranks))
+
+    @property
+    def sizes_and_strides(self) -> Iterator[tuple[int, int]]:
+        """Iterate over (size, stride) pairs for each dimension."""
+        return zip(self.shape, self.stride)
+
+
+@dataclass(frozen=True)
+class _MeshLayout(Sequence[_FlatLayout]):
+    """
+    A multi-dimensional structure consisting of a series of dimension-less layouts
+
+    This class represents the layout of a full DeviceMesh, where the overall
+    top-level ndim and "logical" shape are well defined, but each individual
+    mesh axis is squashed and normalized into a canonical _FlatLayout.
+
+    It only contains methods that need to make use of this multi-dimensional
+    structure (i.e., which access the ndim or the top-level sizes). Everything
+    else should go on _FlatLayout and accessed by first calling .collapse().
+
+    """
+
+    axes: tuple[_FlatLayout, ...]
+
+    def __init__(self, axes: Sequence[_FlatLayout]) -> None:
+        object.__setattr__(self, "axes", tuple(axes))
+
+    @classmethod
+    def from_sizes_strides(
+        cls, sizes: tuple[int, ...], strides: tuple[int, ...] | None = None
+    ) -> "_MeshLayout":
+        if strides is None:
+            strides = flatten(suffix_product(sizes))
+        if len(sizes) != len(strides):
+            raise ValueError(
+                f"sizes and strides must have the same length, got {len(sizes)} and {len(strides)}"
+            )
+        axes = tuple(_FlatLayout((s,), (d,)) for s, d in zip(sizes, strides))
+        return cls(axes)
+
+    def __len__(self) -> int:
+        return len(self.axes)
+
+    @overload
+    def __getitem__(self, i: int) -> _FlatLayout: ...
+
+    @overload
+    def __getitem__(self, i: slice) -> "_MeshLayout": ...
+
+    def __getitem__(self, i: int | slice) -> "_FlatLayout | _MeshLayout":
+        if isinstance(i, slice):
+            return _MeshLayout(self.axes[i])
+        return self.axes[i]
+
+    def __iter__(self) -> Iterator[_FlatLayout]:
+        return iter(self.axes)
+
+    def to_pycute(self) -> Layout:
+        if len(self.axes) == 0:
+            return Layout(1, 0)
+        return make_layout(*(axis.to_pycute() for axis in self.axes))
+
+    @property
+    def top_level_sizes(self) -> tuple[int, ...]:
+        return tuple(axis.numel() for axis in self.axes)
+
+    def numel(self) -> int:
+        return math.prod(self.top_level_sizes)
+
+    def cosize(self) -> int:
+        return self.to_pycute().cosize()
+
+    def collapse(self) -> _FlatLayout:
+        """
+        Merge all axes into a single _FlatLayout.
+
+        This is used to "forget" the multi-dimensional structure of this object
+        and recover a "flat" (and coalesced) representation.
+        """
+        shapes = tuple(axis.shape for axis in self.axes)
+        strides = tuple(axis.stride for axis in self.axes)
+        return _FlatLayout(shapes, strides)
+
+    def splice(self, start: int, end: int, layout: "_MeshLayout") -> "_MeshLayout":
+        """
+        Replace (out-of-place) the start:end slice with the given list of layouts
+
+        Returns the concatenation of self[:start] + layout + self[end:].
+        """
+        new_axes = list(self.axes)
+        new_axes[start:end] = list(layout.axes)
+        return _MeshLayout(new_axes)
 
     def remap_to_tensor(self, rank_map: torch.Tensor) -> torch.Tensor:
         """
@@ -312,9 +389,10 @@ class _MeshLayout(Layout):
         if rank_map.numel() < self.cosize():
             raise AssertionError
 
-        complement_layout = self.complement(rank_map.numel())
+        self_layout = self.collapse()
+        complement_layout = self_layout.complement(rank_map.numel())
 
         return rank_map.as_strided(
-            flatten(complement_layout.sizes) + flatten(self.sizes),
-            flatten(complement_layout.strides) + flatten(self.strides),
+            complement_layout.shape + self_layout.shape,
+            complement_layout.stride + self_layout.stride,
         ).reshape(-1, *self.top_level_sizes)

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -11,8 +11,7 @@ from typing import Any, TYPE_CHECKING
 import torch
 from torch._opaque_base import OpaqueBase
 from torch.distributed import is_available
-from torch.distributed._mesh_layout import _MeshLayout
-from torch.distributed._pycute import IntTuple, is_int, suffix_product
+from torch.distributed._mesh_layout import _FlatLayout, _MeshLayout
 from torch.types import IntLikeType
 from torch.utils._typing_utils import not_none
 
@@ -71,7 +70,7 @@ else:
             )
 
     BackendConfig = tuple[str | None, C10dBackend.Options | None]
-    torch.serialization.add_safe_globals([_MeshLayout])
+    torch.serialization.add_safe_globals([_FlatLayout, _MeshLayout])
 
     def _get_pg_from_name(mesh: "DeviceMesh", name: str) -> ProcessGroup:
         """
@@ -239,7 +238,9 @@ else:
                     if isinstance(mesh, torch.Tensor)
                     else torch.tensor(mesh, device="cpu", dtype=torch.int)
                 )
-                _layout = _MeshLayout(mesh_tensor.size(), mesh_tensor.stride())
+                _layout = _MeshLayout.from_sizes_strides(
+                    tuple(mesh_tensor.size()), tuple(mesh_tensor.stride())
+                )
                 _rank_map = mesh_tensor.flatten()
             else:
                 if _layout is None or _rank_map is None:
@@ -247,7 +248,7 @@ else:
                         "The mesh argument is required except for PRIVATE USAGE ONLY!"
                     )
 
-            if not _layout.check_non_overlap():
+            if not _layout.collapse().check_non_overlap():
                 raise AssertionError(
                     "Please use a non-overlapping layout when creating a DeviceMesh."
                 )
@@ -278,9 +279,11 @@ else:
             self._layout = (
                 _layout
                 if _layout
-                else _MeshLayout(self.mesh.size(), self.mesh.stride())
+                else _MeshLayout.from_sizes_strides(
+                    tuple(self.mesh.size()), tuple(self.mesh.stride())
+                )
             )
-            if not self._layout.check_non_overlap():
+            if not self._layout.collapse().check_non_overlap():
                 raise AssertionError(
                     "Please use a non-overlapping layout when creating a DeviceMesh."
                 )
@@ -494,13 +497,13 @@ else:
 
         @staticmethod
         def _init_one_process_group(
-            sub_layout: _MeshLayout,
+            sub_layout: _FlatLayout,
             rank_map: torch.Tensor,
             dim_name: str,
             backend_override: BackendConfig,
         ) -> GroupName | None:
             # Generate a 2D global mesh tensor for the current dim for PG creation.
-            pg_ranks_by_dim = sub_layout.nest().remap_to_tensor(rank_map)
+            pg_ranks_by_dim = _MeshLayout([sub_layout]).remap_to_tensor(rank_map)
             backend, pg_options = backend_override
             # We need to explicitly pass in timeout when specified in option, otherwise
             # the default timeout will be used to override the timeout set in option.
@@ -642,7 +645,13 @@ else:
                 if self._mesh_dim_names
                 else f"{self._layout.top_level_sizes}"
             )
-            device_mesh_repr = f"DeviceMesh({device_mesh_repr}, '{self.device_type}', stride={self._layout.strides}"
+            stride = tuple(
+                axis.stride[0] if len(axis.stride) == 1 else axis.stride
+                for axis in self._layout
+            )
+            device_mesh_repr = (
+                f"DeviceMesh({device_mesh_repr}, '{self.device_type}', stride={stride}"
+            )
             # We only print the mesh tensor if the debug mode is turned on.
             if os.environ.get("TORCH_DISTRIBUTED_DEBUG", "") == "DETAIL":
                 device_mesh_repr += f", Mesh: {self.mesh.tolist()}"
@@ -884,9 +893,7 @@ else:
                     f"Please specify another valid mesh_dim_name.",
                 )
 
-            flattened_mesh_layout = self._layout.coalesce()
-            if len(flattened_mesh_layout) > 1:
-                flattened_mesh_layout = flattened_mesh_layout.nest()
+            flattened_mesh_layout = _MeshLayout([self._layout.collapse()])
 
             # Check if the flatten mesh has been created before.
             if mesh_dim_name in root_mesh._flatten_mapping:
@@ -952,9 +959,9 @@ else:
 
             # The slice mesh_dim_names should consist either the current device_mesh's mesh_dim_names
             # or its flattened mesh's mesh_dim_names if it's root_mesh.
-            flatten_name_to_root_layout = (
+            flatten_name_to_root_layout: dict[str, _FlatLayout] = (
                 {
-                    key: mesh._layout
+                    key: mesh._layout[0]  # Extract the single axis from flattened mesh
                     for key, mesh in self._get_root_mesh()._flatten_mapping.items()
                 }
                 if slice_from_root
@@ -974,7 +981,7 @@ else:
                     f"Valid mesh_dim_names are {valid_mesh_dim_names}."
                 )
 
-            layout_sliced = []
+            layout_sliced: list[_FlatLayout] = []
             for name in mesh_dim_names:
                 if name in not_none(self._mesh_dim_names):
                     layout_sliced.append(
@@ -987,43 +994,29 @@ else:
                         stacklevel=2,
                     )
                     layout_sliced.append(flatten_name_to_root_layout[name])
-
-            sliced_sizes = tuple(l.sizes for l in layout_sliced)
-            sliced_strides = tuple(l.strides for l in layout_sliced)
+            result_layout = _MeshLayout(layout_sliced)
 
             # The check below is from DeviceMesh's implementation before adopting CuTe layout for internal
             # bookkeeping and it can be removed but we need to define what is the expected behavior.
             # TODO: Remove the below check and define the expected behavior.
             # Validate the order of the slice mesh dim indices.
             # This needs to be in ascending order.
-            pre_stride = -1
-            for stride in reversed(sliced_strides):
-                # Note that with CuTe layout, we can support slicing flattened non-contiguous mesh dims with no problem.
-                # But we don't see a use case for now so we don't want to support it.
-                if not is_int(stride):
-                    raise NotImplementedError(
-                        "Currently, this only allows slicing out a contiguous flattened dim."
-                    )
-                # Note that with CuTe layout, we can support slicing non-ascending order dims with no problem.
-                # But we don't see a use case for now so we don't want to support it.
-                if stride < pre_stride:
-                    raise KeyError(
-                        f"Invalid mesh_dim_names {mesh_dim_names} specified. "
-                        "Mesh dim indices should be in ascending order."
-                    )
-                pre_stride = stride
+            if not result_layout.collapse().check_sorted():
+                raise KeyError(
+                    f"Invalid mesh_dim_names {mesh_dim_names} specified. "
+                    "Mesh dim indices should be in ascending order."
+                )
 
             # When users sliced dim_names outside from current mesh, we will check whether
             # there is layout overlap.
             # TODO: Eventually we will just directly throw error here because
             # we will deprecate the slicing of flattened dim_name from root mesh.
-            layout_sliced = _MeshLayout(sliced_sizes, sliced_strides)
-            if not layout_sliced.check_non_overlap():
+            if not result_layout.collapse().check_non_overlap():
                 raise RuntimeError(
                     f"Slicing overlapping dim_names {mesh_dim_names} is not allowed."
                 )
 
-            return layout_sliced
+            return result_layout
 
         # TODO: to make this use case by other components public API in the future.
         def _get_all_submeshes(self, mesh_dim_name: str) -> list["DeviceMesh"]:
@@ -1032,7 +1025,7 @@ else:
             """
             mesh_dim = self._get_mesh_dim_by_name(mesh_dim_name)
             layout = self._layout[mesh_dim]
-            pg_ranks_by_dim = layout.remap_to_tensor(self._rank_map)
+            pg_ranks_by_dim = _MeshLayout([layout]).remap_to_tensor(self._rank_map)
             cur_rank = self.get_rank()
             res_submeshes = []
             for mesh_1d in pg_ranks_by_dim:
@@ -1320,7 +1313,7 @@ else:
                 tuple[str | None, C10dBackend.Options | None], ...
             ] = ((None, None),),
         ) -> "DeviceMesh":
-            inner_layout = _MeshLayout(tuple(mesh_sizes), suffix_product(mesh_sizes))
+            inner_layout = _MeshLayout.from_sizes_strides(tuple(mesh_sizes))
 
             if inner_layout.numel() != self._layout[dim].numel():
                 raise ValueError(
@@ -1431,14 +1424,11 @@ else:
         @staticmethod
         def _concatenate(device_mesh_list: list["DeviceMesh"]) -> "DeviceMesh":
             concat_dim_names: list[str] = []
-            concat_sizes: list[IntTuple] = []
-            concat_strides: list[IntTuple] = []
+            concat_axes: list[_FlatLayout] = []
             concat_dim_group_name: list[GroupName] = []
             flatten_rank_map = device_mesh_list[0]._flatten_rank_map
             for dm in device_mesh_list:
-                for i in range(len(dm._layout)):
-                    concat_sizes.append(dm._layout[i].sizes)
-                    concat_strides.append(dm._layout[i].strides)
+                concat_axes.extend(dm._layout)
                 concat_dim_names.extend(not_none(dm.mesh_dim_names))
                 concat_dim_group_name.extend(not_none(dm._dim_group_names))
                 # Concatenate device mesh having different root mesh tensors are meaningless
@@ -1447,8 +1437,8 @@ else:
                     raise RuntimeError(
                         "Cannot concatenate DeviceMeshes derived from different device meshs"
                     )
-            concat_mesh_layout = _MeshLayout(tuple(concat_sizes), tuple(concat_strides))
-            if not concat_mesh_layout.check_non_overlap():
+            concat_mesh_layout = _MeshLayout(concat_axes)
+            if not concat_mesh_layout.collapse().check_non_overlap():
                 raise RuntimeError(
                     f"Cannot concatenate overlapping meshes: {device_mesh_list}"
                 )
@@ -1580,7 +1570,7 @@ else:
                 "If you maintained a 'torch.device' object, it's recommended to pass in 'device.type'.",
             )
 
-        layout = _MeshLayout(tuple(mesh_shape), suffix_product(tuple(mesh_shape)))
+        layout = _MeshLayout.from_sizes_strides(tuple(mesh_shape))
         # Always initialize the (identity) rank map on CPU, regardless of what the
         # external device type has been set to be (e.g. meta)
         with torch.device("cpu"):

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -15,6 +15,7 @@ import torch
 import torch.distributed._functional_collectives as funcol
 import torch.distributed.tensor._api as dtensor
 from torch.distributed._functional_collectives import _are_we_tracing
+from torch.distributed._mesh_layout import _MeshLayout
 from torch.distributed.tensor._collective_utils import one_step_redistribute_cost
 from torch.distributed.tensor._dtensor_spec import (
     _StridedShardNotDecodableError,
@@ -275,9 +276,7 @@ def _get_flattened_mesh_by_layout_impl(
     # Compute expected layout WITHOUT creating a submesh (avoids tracing issues)
     # _get_slice_mesh_layout does pure layout math, no tensor operations
     sliced_layout = mesh._get_slice_mesh_layout(dim_names)
-    expected_layout = sliced_layout.coalesce()
-    if len(expected_layout) > 1:
-        expected_layout = expected_layout.nest()
+    expected_layout = _MeshLayout([sliced_layout.collapse()])
 
     # Search existing flattened meshes by comparing layouts
     for flattened_mesh in root_mesh._flatten_mapping.values():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181223

Using a fully-general recursive unbounded IntTuple to represent Layouts has demonstrated to be prone to pitfalls in the past (e.g., ambiguity between ints and singleton tuples, breakeges in code that wasn't expecting the nested tuples that occur when flattening non-contiguous dims, ...).

In practice, though, we don't need all this generality:
- We need one first topmost level in order to clearly separate the logical dimensions of the DeviceMesh
- And within each such dimension we actually want to renounce any structure and use the most flattened/coalesced/compact representation possible (because, in fact, we want to recover a "canonical" representation for each dimension).

In order to reduce ambiguity and complexity, we can also choose to disallow plain ints.

Given all this, we realize it would be much safer/easier/better to represent our layouts as `tuple[tuple[int, ...], ...]`, i.e., a structure which is always 2-level deep.

This PR does precisely this, but for better usability it encapsulates this structure into some helper classes:
- `_FlatLayout` is used to encode `tuple[int, ...]`, with its constructor taking care of flattening and coalescing, and methods that mimic most standard pycute functions but which preserve the flat invariant
- `_ListOfFlatLayouts` corresponds to `tuple[_FlatLayout, ...]`, i.e., `tuple[tuple[int, ...], ...]`, and contains the methods that rely on or manipulate multiple well-separated dimensions.

Differential Revision: [D102003592](https://our.internmc.facebook.com/intern/diff/D102003592/)