### PR TITLE
[c10] Fix reduced-precision rsqrt double promotion

### DIFF
--- a/c10/util/BFloat16-math.h
+++ b/c10/util/BFloat16-math.h
@@ -181,7 +181,7 @@ template <
     typename T,
     typename std::enable_if_t<c10::is_reduced_floating_point_v<T>, int> = 0>
 inline T rsqrt(T a) {
-  return 1.0 / std::sqrt(float(a));
+  return 1.0f / std::sqrt(float(a));
 }
 template <
     typename T,


### PR DESCRIPTION
Keep the reduced-precision rsqrt helper in float precision by using `1.0f` instead of `1.0`. This avoids an unnecessary promotion to double in the `c10::Half`/`c10::BFloat16` overload and prevents `-Wdouble-promotion` warnings on toolchains that treat them as errors.