### PR TITLE
[inductor/test_max_autotune] Skip TMA tests and use Blackwell-specific classes in pruning

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -774,12 +774,18 @@ class TestMaxAutotune(TestCase):
 
         torch._dynamo.maybe_mark_dynamic(a, 0)
 
+        choice_name_regex = (
+            "blackwell_ws_persistent_device_tma"
+            if has_datacenter_blackwell_tma_device()
+            else "mm_persistent_tma"
+        )
+
         with config.patch(
             {
                 "max_autotune": True,
                 "triton.enable_persistent_tma_matmul": "1",
                 "triton.native_matmul": False,
-                "test_configs.autotune_choice_name_regex": "mm_persistent_tma",
+                "test_configs.autotune_choice_name_regex": choice_name_regex,
             }
         ):
             c_actual = torch.compile(mm)(a, b)
@@ -1008,12 +1014,18 @@ class TestMaxAutotune(TestCase):
 
         torch._dynamo.maybe_mark_dynamic(a, 0)
 
+        choice_name_regex = (
+            "blackwell_ws_persistent_device_tma"
+            if has_datacenter_blackwell_tma_device()
+            else "mm_persistent_tma"
+        )
+
         with config.patch(
             {
                 "max_autotune": True,
                 "triton.enable_persistent_tma_matmul": "1",
                 "triton.native_matmul": False,
-                "test_configs.autotune_choice_name_regex": "mm_persistent_tma",
+                "test_configs.autotune_choice_name_regex": choice_name_regex,
             }
         ):
             c_actual = torch.compile(addmm)(x, a, b)

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -56,8 +56,11 @@ from torch._inductor.select_algorithm import (
 )
 from torch._inductor.template_heuristics.registry import override_template_heuristics
 from torch._inductor.template_heuristics.triton import (
+    BlackwellGPUGemmConfig,
     CUDAAddmmPersistentTMATemplateConfigHeuristic,
     CUDAAddMMTemplateConfigHeuristic,
+    CUDABlackwellAddmmPersistentTMATemplateConfigHeuristic,
+    CUDABlackwellPersistentTMATemplateConfigHeuristic,
     CUDAMMTemplateConfigHeuristic,
     CUDAPersistentTMATemplateConfigHeuristic,
     GemmConfig,
@@ -3288,17 +3291,34 @@ class TestTemplateConfigPruning(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         # Initialize heuristics once for all tests
-        cls.addmm_tma_heuristic = CUDAAddmmPersistentTMATemplateConfigHeuristic()
         cls.addmm_heuristic = CUDAAddMMTemplateConfigHeuristic()
-        cls.mm_tma_heuristic = CUDAPersistentTMATemplateConfigHeuristic()
         cls.mm_heuristic = CUDAMMTemplateConfigHeuristic()
+
+        tma_addmm_heuristic_cls = CUDAAddmmPersistentTMATemplateConfigHeuristic
+        tma_mm_heuristic_cls = CUDAPersistentTMATemplateConfigHeuristic
+        if has_datacenter_blackwell_tma_device():
+            tma_addmm_heuristic_cls = (
+                CUDABlackwellAddmmPersistentTMATemplateConfigHeuristic
+            )
+            tma_mm_heuristic_cls = CUDABlackwellPersistentTMATemplateConfigHeuristic
+        cls.addmm_tma_heuristic = tma_addmm_heuristic_cls()
+        cls.mm_tma_heuristic = tma_mm_heuristic_cls()
 
         block_sizes = [64, 128, 256]
         num_stages = [4, 5]
         from itertools import product
 
+        gemm_config_cls = GemmConfig
+        gemm_config_kwargs = {}
+        if has_datacenter_blackwell_tma_device():
+            gemm_config_cls = BlackwellGPUGemmConfig
+            gemm_config_kwargs = {
+                "epilogue_subtile": 2,
+                "warp_specialize": True,
+                "flatten": True,
+            }
         cls.gemm_configs = [
-            GemmConfig(BLOCK_M, BLOCK_N, BLOCK_K, stage, 8)
+            gemm_config_cls(BLOCK_M, BLOCK_N, BLOCK_K, stage, 8, **gemm_config_kwargs)
             for BLOCK_M, BLOCK_N, BLOCK_K, stage in product(
                 block_sizes, block_sizes, block_sizes, num_stages
             )

--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -218,6 +218,10 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
+    @unittest.skipIf(
+        has_datacenter_blackwell_tma_device(),
+        "Hopper-style mm_persistent_tma template is shadowed by the Blackwell warp-specialized TMA template on data-center Blackwell. Covered by test_max_autotune_blackwell.py",
+    )
     @skipIfXpu(msg="XPU TMA requires contiguous last dimension")
     @parametrize("a_transposed", (False, True))
     @parametrize("b_transposed", (False, True))
@@ -616,6 +620,10 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
+    @unittest.skipIf(
+        has_datacenter_blackwell_tma_device(),
+        "Hopper-style mm_persistent_tma template is shadowed by the Blackwell warp-specialized TMA template on data-center Blackwell.",
+    )
     @skipIfXpu(msg="XPU TMA requires contiguous last dimension")
     @parametrize("a_transposed", (False, True))
     @parametrize("b_transposed", (False, True))
@@ -779,6 +787,10 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
     )
+    @unittest.skipIf(
+        has_datacenter_blackwell_tma_device(),
+        "Hopper-style mm_persistent_tma template is shadowed by the Blackwell warp-specialized TMA template on data-center Blackwell.",
+    )
     def test_persistent_tma_epilogue_fusion_store_cache(self):
         # Regression test: when epilogue fusion runs with TMA store, the
         # store_cache must be updated so that a subsequent epilogue load from
@@ -857,6 +869,10 @@ class TestMaxAutotune(TestCase):
 
     @unittest.skipIf(
         not has_triton_tma_device(), "Need device-side TMA support in Triton"
+    )
+    @unittest.skipIf(
+        has_datacenter_blackwell_tma_device(),
+        "Hopper-style mm_persistent_tma template is shadowed by the Blackwell warp-specialized TMA template on data-center Blackwell; covered by test_max_autotune_blackwell.py",
     )
     @skipIfXpu(msg="XPU TMA requires contiguous last dimension")
     @parametrize("a_transposed", (False, True))
@@ -3172,6 +3188,10 @@ class TestMaxAutotune(TestCase):
     @unittest.skipIf(TEST_WITH_ROCM, "Test requires CUDA")
     @unittest.skipIf(
         not SM90OrLater, "Requires SM90+ (H100/B200) for sufficient GPU memory"
+    )
+    @unittest.skipIf(
+        has_datacenter_blackwell_tma_device(),
+        "Hopper-style mm_persistent_tma template is shadowed by the Blackwell warp-specialized TMA template on data-center Blackwell.",
     )
     @largeTensorTest("10 GB", device=GPU_TYPE)
     def test_max_autotune_mm_persistent_tma_large_input_tensor_int64_indexing(self):


### PR DESCRIPTION
This pull request updates the `test_max_autotune.py` test suite to properly handle and skip tests that are not applicable to data-center Blackwell GPUs, where the Blackwell warp-specialized TMA template supersedes the Hopper-style template. It also updates test configuration logic and template heuristics to use Blackwell-specific implementations when running on such hardware.

Test skipping and configuration updates for Blackwell GPUs:

* Added `@unittest.skipIf` decorators to multiple tests to skip cases where the Hopper-style `mm_persistent_tma` template is shadowed by the Blackwell warp-specialized TMA template on data-center Blackwell GPUs. This prevents running irrelevant tests and avoids duplicate coverage, which is handled in a separate test file. [[1]](diffhunk://#diff-ee670915dba4dc797dbf884564b9170b16fbc81ba52153bf32e18d5675721eabR224-R227) [[2]](diffhunk://#diff-ee670915dba4dc797dbf884564b9170b16fbc81ba52153bf32e18d5675721eabR626-R629) [[3]](diffhunk://#diff-ee670915dba4dc797dbf884564b9170b16fbc81ba52153bf32e18d5675721eabR799-R802) [[4]](diffhunk://#diff-ee670915dba4dc797dbf884564b9170b16fbc81ba52153bf32e18d5675721eabR882-R885) [[5]](diffhunk://#diff-ee670915dba4dc797dbf884564b9170b16fbc81ba52153bf32e18d5675721eabR3207-R3210)
* Updated test configuration logic to dynamically set `test_configs.autotune_choice_name_regex` to either `"mm_persistent_tma"` or `"blackwell_ws_persistent_device_tma"` depending on the detected hardware, ensuring tests select the correct autotune template. [[1]](diffhunk://#diff-ee670915dba4dc797dbf884564b9170b16fbc81ba52153bf32e18d5675721eabR777-R788) [[2]](diffhunk://#diff-ee670915dba4dc797dbf884564b9170b16fbc81ba52153bf32e18d5675721eabR1017-R1028)

Heuristic and config class selection:

* Modified the test class setup to instantiate Blackwell-specific heuristic and config classes (`CUDABlackwellAddmmPersistentTMATemplateConfigHeuristic`, `CUDABlackwellPersistentTMATemplateConfigHeuristic`, and `BlackwellGPUGemmConfig`) when running on data-center Blackwell, with appropriate configuration parameters. [[1]](diffhunk://#diff-ee670915dba4dc797dbf884564b9170b16fbc81ba52153bf32e18d5675721eabL3271-R3333) [[2]](diffhunk://#diff-ee670915dba4dc797dbf884564b9170b16fbc81ba52153bf32e18d5675721eabR59-R63)

These changes ensure the test suite accurately reflects the supported templates and autotuning logic on different GPU architectures, preventing false failures and improving test relevance.

Used Opus 4.7

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo