### PR TITLE
[test-fix] cudnn does not support batch_size > 65536, do not route into cudnn backend those batches

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -496,10 +496,21 @@ bool check_cudnn_dropout(sdp_params const& params, bool debug) {
 }
 
 bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
+  const auto b = params.query.sym_size(0);
   const auto s_q = params.query.sym_size(2);
   const auto s_k = params.key.sym_size(2);
   const auto d_qk = params.query.sym_size(3);
   const auto d_v = params.value.sym_size(3);
+  // cuDNN uses 16-bit indexing for batch dimension internally
+  constexpr int64_t max_cudnn_batch_size = 65535;
+  if (b > max_cudnn_batch_size) {
+    if (debug) {
+      TORCH_WARN(
+          "cuDNN SDPA does not support batch size greater than ",
+          max_cudnn_batch_size);
+    }
+    return false;
+  }
   long cudnn_version = at::detail::getCUDAHooks().versionRuntimeCuDNN();
   if (cudnn_version < 8903) {
     if (debug) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181235

Addresses disabled test https://github.com/pytorch/pytorch/issues/181085

  cuDNN's SDPA implementation fails silently when batch size >= 65536 (2^16), returning a non-good status from mha_graph.execute(). This causes a RuntimeError at execution time rather than gracefully falling back to another backend.

  The boundary is exact: batch=65535 passes, batch=65536 fails, consistent with an internal 16-bit batch dimension limit in cuDNN. Verified on H100 with cuDNN 9.2.0. The mem_efficient_attention and math backends both handle this batch size correctly.

  This PR adds a batch size check to check_cudnn_tensor_shapes() so that the backend selector skips cuDNN when batch > 65535 and falls back to a working backend automatically.

  Fixes https://github.com/pytorch/pytorch/issues/181085

  Test Plan:

  import torch
  import torch.nn as nn

  device = "cuda"
  eager = nn.MultiheadAttention(embed_dim=8, num_heads=1, batch_first=True, device=device, dtype=torch.float16)
  q = torch.rand(2**16, 1, 8, device=device, dtype=torch.float16)
  kv = torch.rand(2**16, 2, 8, device=device, dtype=torch.float16)
  mask = torch.randint(0, 2, (2**16, 2), device=device, dtype=torch.bool)

  # Before fix: RuntimeError from mha_graph.execute()
  # After fix: falls back to mem_efficient_attention, runs successfully
  out = eager(query=q, key=kv, value=kv, key_padding_mask=mask, attn_mask=None, need_weights=False)[0]
  out.sum().backward()
  print("PASSED")

  Also verified that smaller batch sizes (1024, 32768, 65535) still work and are unaffected.

  This PR was authored with Claude.
