### PR TITLE
Add XPU storage sharing via DMA-BUF IPC

### DIFF
--- a/c10/xpu/CMakeLists.txt
+++ b/c10/xpu/CMakeLists.txt
@@ -41,6 +41,7 @@ if(NOT BUILD_LIBTORCHLESS)
 
   # ---[ Dependency of c10_xpu
   target_link_libraries(c10_xpu PUBLIC c10 torch::xpurt)
+  target_link_libraries(c10_xpu PRIVATE ze_loader)
   target_include_directories(
       c10_xpu PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -4,10 +4,11 @@
 
 #include <ATen/DeviceGuard.h>
 
-#include <dlfcn.h>
 #include <level_zero/ze_api.h>
 #include <sycl/ext/oneapi/backend/level_zero.hpp>
+#if defined(__linux__)
 #include <unistd.h>
+#endif
 #include <algorithm>
 #include <array>
 #include <cstdlib>
@@ -30,45 +31,34 @@ constexpr size_t kDeviceAlignment = 512;
 
 namespace {
 struct ZeIpcApi {
-  using GetAllocPropertiesFn = ze_result_t (*)(
-      ze_context_handle_t,
-      const void*,
-      ze_memory_allocation_properties_t*,
-      ze_device_handle_t*);
-  using AllocDeviceFn = ze_result_t (*)(
-      ze_context_handle_t,
-      const ze_device_mem_alloc_desc_t*,
-      size_t,
-      size_t,
-      ze_device_handle_t,
-      void**);
-  using FreeDeviceFn = ze_result_t (*)(ze_context_handle_t, void*);
+  ze_result_t get_alloc_properties(
+      ze_context_handle_t context,
+      const void* ptr,
+      ze_memory_allocation_properties_t* props,
+      ze_device_handle_t* device) {
+    return zeMemGetAllocProperties(context, ptr, props, device);
+  }
 
-  GetAllocPropertiesFn get_alloc_properties{nullptr};
-  AllocDeviceFn alloc_device{nullptr};
-  FreeDeviceFn free_device{nullptr};
-  void* lib_handle{nullptr};
-  std::once_flag init_once;
+  ze_result_t alloc_device(
+      ze_context_handle_t context,
+      const ze_device_mem_alloc_desc_t* alloc_desc,
+      size_t size,
+      size_t alignment,
+      ze_device_handle_t device,
+      void** ptr) {
+    return zeMemAllocDevice(context, alloc_desc, size, alignment, device, ptr);
+  }
 
-  template <typename FnPtr>
-  void resolve(FnPtr& fn, const char* name) {
-    fn = reinterpret_cast<FnPtr>(dlsym(RTLD_DEFAULT, name));
-    if (!fn && lib_handle) {
-      fn = reinterpret_cast<FnPtr>(dlsym(lib_handle, name));
-    }
+  ze_result_t free_device(ze_context_handle_t context, void* ptr) {
+    return zeMemFree(context, ptr);
   }
 
   bool dma_buf_available() {
-    std::call_once(init_once, [this]() {
-      lib_handle = dlopen("libze_loader.so.1", RTLD_LAZY | RTLD_LOCAL);
-      if (!lib_handle) {
-        lib_handle = dlopen("libze_loader.so", RTLD_LAZY | RTLD_LOCAL);
-      }
-      resolve(get_alloc_properties, "zeMemGetAllocProperties");
-      resolve(alloc_device, "zeMemAllocDevice");
-      resolve(free_device, "zeMemFree");
-    });
-    return get_alloc_properties && alloc_device && free_device;
+#if defined(__linux__)
+    return true;
+#else
+    return false;
+#endif
   }
 };
 
@@ -473,31 +463,31 @@ void allocPrimitive(void** ptr, size_t size, AllocParams& p) {
   if (p.pool->owner_PrivatePool && p.pool->owner_PrivatePool->allocator()) {
     *ptr = p.pool->owner_PrivatePool->allocator()->raw_alloc(size);
   } else {
+#if defined(__linux__)
     auto& ze_ipc_api = get_ze_ipc_api();
-    if (ze_ipc_api.dma_buf_available()) {
-      auto ze_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
-          xpu::get_device_context());
-      auto ze_device = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
-          xpu::get_raw_device(p.device()));
+    auto ze_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+        xpu::get_device_context());
+    auto ze_device = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+        xpu::get_raw_device(p.device()));
 
-      ze_external_memory_export_desc_t export_desc = {};
-      export_desc.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_DESC;
-      export_desc.pNext = nullptr;
-      export_desc.flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF;
+    ze_external_memory_export_desc_t export_desc = {};
+    export_desc.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_DESC;
+    export_desc.pNext = nullptr;
+    export_desc.flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF;
 
-      ze_device_mem_alloc_desc_t alloc_desc = {};
-      alloc_desc.stype = ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC;
-      alloc_desc.pNext = &export_desc;
-      alloc_desc.flags = 0;
-      alloc_desc.ordinal = 0;
+    ze_device_mem_alloc_desc_t alloc_desc = {};
+    alloc_desc.stype = ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC;
+    alloc_desc.pNext = &export_desc;
+    alloc_desc.flags = 0;
+    alloc_desc.ordinal = 0;
 
-      const auto alloc_result = ze_ipc_api.alloc_device(
-          ze_context, &alloc_desc, size, kDeviceAlignment, ze_device, ptr);
-      if (alloc_result == ZE_RESULT_SUCCESS) {
-        p.dma_buf_used = true;
-        return;
-      }
+    const auto alloc_result = ze_ipc_api.alloc_device(
+        ze_context, &alloc_desc, size, kDeviceAlignment, ze_device, ptr);
+    if (alloc_result == ZE_RESULT_SUCCESS) {
+      p.dma_buf_used = true;
+      return;
     }
+#endif
 
     *ptr = sycl::aligned_alloc_device(
         kDeviceAlignment,
@@ -511,8 +501,9 @@ void deletePrimitive(void* ptr, BlockPool* pool, bool dma_buf_allocated) {
   if (pool->owner_PrivatePool && pool->owner_PrivatePool->allocator()) {
     pool->owner_PrivatePool->allocator()->raw_delete(ptr);
   } else {
+#if defined(__linux__)
     auto& ze_ipc_api = get_ze_ipc_api();
-    if (dma_buf_allocated && ze_ipc_api.free_device) {
+    if (dma_buf_allocated) {
       auto ze_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
           xpu::get_device_context());
       const auto free_result = ze_ipc_api.free_device(ze_context, ptr);
@@ -520,6 +511,9 @@ void deletePrimitive(void* ptr, BlockPool* pool, bool dma_buf_allocated) {
         return;
       }
     }
+#else
+    (void)dma_buf_allocated;
+#endif
 
     sycl::free(ptr, xpu::get_device_context());
   }
@@ -1883,6 +1877,11 @@ class NativeCachingAllocator : public XPUAllocator {
   struct MemHandleCacheEntry {
     MemHandleCacheEntry(c10::DeviceIndex device, const std::string& handle)
         : device_(device), initialized_(false), fd_(-1), alloc_size_(0) {
+#if !defined(__linux__)
+      (void)device;
+      (void)handle;
+      TORCH_CHECK(false, "XPU IPC storage sharing is only supported on Linux");
+#else
       auto& ze_ipc_api = get_ze_ipc_api();
 
       if (handle.rfind("dmabuf:", 0) == 0) {
@@ -1901,16 +1900,17 @@ class NativeCachingAllocator : public XPUAllocator {
             "unsupported XPU IPC handle format; expected dmabuf:<fd>:<alloc_size>");
       }
 
-      TORCH_CHECK(
-          ze_ipc_api.dma_buf_available(),
-          "Level Zero DMA-BUF IPC APIs are unavailable");
+      (void)ze_ipc_api;
+#endif
     }
 
     ~MemHandleCacheEntry() {
+#if defined(__linux__)
       if (fd_ >= 0) {
         ::close(static_cast<int>(fd_));
         fd_ = -1;
       }
+#endif
     }
 
     void init() {
@@ -1918,6 +1918,9 @@ class NativeCachingAllocator : public XPUAllocator {
         return;
       }
 
+#if !defined(__linux__)
+      TORCH_CHECK(false, "XPU IPC storage sharing is only supported on Linux");
+#else
       // Child processes must initialize XPU state.
       at::DeviceGuard guard(at::Device(at::kXPU, device_));
       c10::xpu::device_count_ensure_non_zero();
@@ -1957,6 +1960,7 @@ class NativeCachingAllocator : public XPUAllocator {
           "zeMemAllocDevice (DMA-BUF import) failed with code ",
           static_cast<int>(alloc_result));
       initialized_ = true;
+#endif
     }
 
     void clear() {
@@ -1964,11 +1968,8 @@ class NativeCachingAllocator : public XPUAllocator {
         return;
       }
 
+#if defined(__linux__)
       auto& ze_ipc_api = get_ze_ipc_api();
-      if (!ze_ipc_api.dma_buf_available()) {
-        return;
-      }
-
       const auto free_result =
           ze_ipc_api.free_device(ze_context_, xpu_ipc_ptr_);
       if (free_result != ZE_RESULT_SUCCESS) {
@@ -1976,6 +1977,7 @@ class NativeCachingAllocator : public XPUAllocator {
             "zeMemFree (DMA-BUF import) failed with code ",
             static_cast<int>(free_result));
       }
+#endif
       xpu_ipc_ptr_ = nullptr;
     }
 
@@ -2131,6 +2133,10 @@ class NativeCachingAllocator : public XPUAllocator {
   }
 
   ShareableHandle shareIpcHandle(void* ptr) override {
+#if !defined(__linux__)
+    (void)ptr;
+    TORCH_CHECK(false, "XPU IPC storage sharing is only supported on Linux");
+#else
     Block* block = get_allocated_block(ptr);
     TORCH_CHECK(block, "invalid device pointer for XPU IPC: ", ptr);
     TORCH_CHECK(
@@ -2158,9 +2164,7 @@ class NativeCachingAllocator : public XPUAllocator {
     auto ze_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
         xpu::get_device_context());
     auto& ze_ipc_api = get_ze_ipc_api();
-    TORCH_CHECK(
-        ze_ipc_api.dma_buf_available(),
-        "Level Zero DMA-BUF IPC APIs are unavailable");
+    (void)ze_ipc_api;
 
     ze_external_memory_export_fd_t export_fd = {};
     export_fd.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_FD;
@@ -2189,11 +2193,17 @@ class NativeCachingAllocator : public XPUAllocator {
         static_cast<int64_t>(export_fd.fd),
         true,
         static_cast<int64_t>(allocation_size_bytes)};
+#endif
   }
 
   std::shared_ptr<void> getIpcDevPtr(
       const std::string& handle,
       c10::DeviceIndex device) override {
+#if !defined(__linux__)
+    (void)handle;
+    (void)device;
+    TORCH_CHECK(false, "XPU IPC storage sharing is only supported on Linux");
+#else
     std::lock_guard<std::mutex> lock(ipc_mutex_);
     auto iter = ipcMemHandle_to_devptr.find(handle);
     if (iter != ipcMemHandle_to_devptr.end()) {
@@ -2228,6 +2238,7 @@ class NativeCachingAllocator : public XPUAllocator {
         });
     inserted_entry.wp_ = sp;
     return sp;
+#endif
   }
 
   void copy_data(void* dest, const void* src, std::size_t count) const final {

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -2,9 +2,21 @@
 #include <c10/util/irange.h>
 #include <c10/xpu/XPUCachingAllocator.h>
 
+#include <ATen/DeviceGuard.h>
+
+#include <algorithm>
+#include <array>
 #include <deque>
+#include <cstring>
+#include <cstdlib>
+#include <dlfcn.h>
+#include <level_zero/ze_api.h>
 #include <mutex>
+#include <sstream>
 #include <set>
+#include <sycl/ext/oneapi/backend/level_zero.hpp>
+#include <thread>
+#include <unistd.h>
 #include <vector>
 
 namespace c10::xpu::XPUCachingAllocator {
@@ -16,6 +28,65 @@ using namespace c10::CachingDeviceAllocator;
 constexpr size_t kDeviceAlignment = 512;
 
 namespace {
+struct ZeIpcApi {
+  using GetIpcHandleFn = ze_result_t (*)(
+      ze_context_handle_t,
+      const void*,
+      ze_ipc_mem_handle_t*);
+  using OpenIpcHandleFn = ze_result_t (*)(
+      ze_context_handle_t,
+      ze_device_handle_t,
+      ze_ipc_mem_handle_t,
+      ze_ipc_memory_flags_t,
+      void**);
+  using CloseIpcHandleFn = ze_result_t (*)(ze_context_handle_t, void*);
+
+  GetIpcHandleFn get_ipc_handle{nullptr};
+  OpenIpcHandleFn open_ipc_handle{nullptr};
+  CloseIpcHandleFn close_ipc_handle{nullptr};
+  void* lib_handle{nullptr};
+
+  bool available() {
+    if (get_ipc_handle && open_ipc_handle && close_ipc_handle) {
+      return true;
+    }
+
+    get_ipc_handle = reinterpret_cast<GetIpcHandleFn>(
+        dlsym(RTLD_DEFAULT, "zeMemGetIpcHandle"));
+    open_ipc_handle = reinterpret_cast<OpenIpcHandleFn>(
+        dlsym(RTLD_DEFAULT, "zeMemOpenIpcHandle"));
+    close_ipc_handle = reinterpret_cast<CloseIpcHandleFn>(
+        dlsym(RTLD_DEFAULT, "zeMemCloseIpcHandle"));
+
+    if (get_ipc_handle && open_ipc_handle && close_ipc_handle) {
+      return true;
+    }
+
+    if (!lib_handle) {
+      lib_handle = dlopen("libze_loader.so.1", RTLD_LAZY | RTLD_LOCAL);
+      if (!lib_handle) {
+        lib_handle = dlopen("libze_loader.so", RTLD_LAZY | RTLD_LOCAL);
+      }
+    }
+    if (!lib_handle) {
+      return false;
+    }
+
+    get_ipc_handle = reinterpret_cast<GetIpcHandleFn>(
+        dlsym(lib_handle, "zeMemGetIpcHandle"));
+    open_ipc_handle = reinterpret_cast<OpenIpcHandleFn>(
+        dlsym(lib_handle, "zeMemOpenIpcHandle"));
+    close_ipc_handle = reinterpret_cast<CloseIpcHandleFn>(
+        dlsym(lib_handle, "zeMemCloseIpcHandle"));
+    return get_ipc_handle && open_ipc_handle && close_ipc_handle;
+  }
+};
+
+ZeIpcApi& get_ze_ipc_api() {
+  static ZeIpcApi api;
+  return api;
+}
+
 using stream_set = ska::flat_hash_set<xpu::XPUStream>;
 
 struct Block;
@@ -1778,7 +1849,65 @@ static void local_raw_delete(void* ptr);
 class NativeCachingAllocator : public XPUAllocator {
  private:
   alignas(hardware_destructive_interference_size) std::mutex mutex;
+  std::mutex IpcMutex;
   ska::flat_hash_map<void*, Block*> allocated_blocks;
+  struct MemHandleCacheEntry {
+    MemHandleCacheEntry(c10::DeviceIndex device, const std::string& handle)
+        : device_(device) {
+      auto& ze_ipc_api = get_ze_ipc_api();
+      TORCH_CHECK(
+          handle.size() >= sizeof(ze_ipc_mem_handle_t),
+          "invalid XPU IPC handle size");
+
+      std::memcpy(&ipc_handle_, handle.data(), sizeof(ipc_handle_));
+
+      TORCH_CHECK(
+          ze_ipc_api.available(), "Level Zero IPC APIs are not available");
+
+      at::DeviceGuard guard(at::Device(at::kXPU, device_));
+      ze_context_ = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+          xpu::get_device_context());
+      auto ze_device = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+          xpu::get_raw_device(device_));
+
+      const auto result = ze_ipc_api.open_ipc_handle(
+          ze_context_, ze_device, ipc_handle_, static_cast<ze_ipc_memory_flags_t>(0), &xpu_ipc_ptr_);
+      TORCH_CHECK(
+          result == ZE_RESULT_SUCCESS,
+          "zeMemOpenIpcHandle failed with code ",
+          static_cast<int>(result));
+    }
+
+    void clear() {
+      if (xpu_ipc_ptr_ == nullptr) {
+        return;
+      }
+
+      auto& ze_ipc_api = get_ze_ipc_api();
+      if (!ze_ipc_api.available()) {
+        return;
+      }
+
+      auto close_result = ze_ipc_api.close_ipc_handle(ze_context_, xpu_ipc_ptr_);
+      if (close_result != ZE_RESULT_SUCCESS) {
+        TORCH_WARN(
+            "zeMemCloseIpcHandle failed with code ",
+            static_cast<int>(close_result));
+      }
+      xpu_ipc_ptr_ = nullptr;
+    }
+
+    void* ptr() const {
+      return xpu_ipc_ptr_;
+    }
+
+    c10::DeviceIndex device_;
+    ze_context_handle_t ze_context_{nullptr};
+    ze_ipc_mem_handle_t ipc_handle_{};
+    void* xpu_ipc_ptr_{nullptr};
+    std::weak_ptr<void> wp_;
+  };
+  ska::flat_hash_map<std::string, MemHandleCacheEntry> ipcMemHandle_to_devptr;
   c10::ApproximateClockToUnixTimeConverter clock_converter;
 
   void add_allocated_block(Block* block) {
@@ -1914,6 +2043,74 @@ class NativeCachingAllocator : public XPUAllocator {
 
   void raw_delete(void* ptr) override {
     this->free(ptr);
+  }
+
+  ShareableHandle shareIpcHandle(void* ptr) override {
+    Block* block = get_allocated_block(ptr);
+    TORCH_CHECK(block, "invalid device pointer for XPU IPC: ", ptr);
+    TORCH_CHECK(
+        !block->expandable_segment,
+        "XPU IPC is not supported for expandable segments");
+
+    Block* base_block = block;
+    while (base_block->prev != nullptr) {
+      base_block = base_block->prev;
+    }
+
+    const auto storage_offset_bytes =
+        static_cast<ptrdiff_t>(reinterpret_cast<char*>(block->ptr) -
+                               reinterpret_cast<char*>(base_block->ptr));
+
+    auto ze_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+        xpu::get_device_context());
+    auto& ze_ipc_api = get_ze_ipc_api();
+    TORCH_CHECK(
+        ze_ipc_api.available(), "Level Zero IPC APIs are not available");
+    ze_ipc_mem_handle_t ipc_handle = {};
+    auto result = ze_ipc_api.get_ipc_handle(
+        ze_context, base_block->ptr, &ipc_handle);
+    TORCH_CHECK(
+        result == ZE_RESULT_SUCCESS,
+        "zeMemGetIpcHandle failed with code ",
+        static_cast<int>(result));
+
+    return {
+        std::string(
+            reinterpret_cast<const char*>(&ipc_handle), sizeof(ipc_handle)),
+        storage_offset_bytes};
+  }
+
+  std::shared_ptr<void> getIpcDevPtr(
+      std::string handle,
+      c10::DeviceIndex device) override {
+    std::lock_guard<std::mutex> lock(IpcMutex);
+
+    auto iter = ipcMemHandle_to_devptr.find(handle);
+    if (iter != ipcMemHandle_to_devptr.end()) {
+      auto devptr = iter->second.wp_.lock();
+      TORCH_INTERNAL_ASSERT(devptr, "entry in cache has missing shared_ptr");
+      return devptr;
+    }
+
+    auto inserted = ipcMemHandle_to_devptr.insert(
+        iter, {handle, MemHandleCacheEntry(device, handle)});
+    auto shared_handle = inserted->first;
+    auto sp = std::shared_ptr<void>(
+        inserted->second.ptr(), [shared_handle, this](void* p) {
+          (void)p;
+          std::unique_lock<std::mutex> deleter_lock(IpcMutex);
+
+          auto it = ipcMemHandle_to_devptr.find(shared_handle);
+          TORCH_INTERNAL_ASSERT(it != ipcMemHandle_to_devptr.end());
+          auto entry = std::move(it->second);
+          ipcMemHandle_to_devptr.erase(it);
+
+          deleter_lock.unlock();
+
+          entry.clear();
+        });
+    inserted->second.wp_ = sp;
+    return sp;
   }
 
   void copy_data(void* dest, const void* src, std::size_t count) const final {

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <deque>
+#include <limits>
 #include <mutex>
 #include <set>
 #include <sstream>
@@ -1905,6 +1906,13 @@ class NativeCachingAllocator : public XPUAllocator {
           "Level Zero DMA-BUF IPC APIs are unavailable");
     }
 
+    ~MemHandleCacheEntry() {
+      if (fd_ >= 0) {
+        ::close(static_cast<int>(fd_));
+        fd_ = -1;
+      }
+    }
+
     void init() {
       if (initialized_) {
         return;
@@ -2138,6 +2146,15 @@ class NativeCachingAllocator : public XPUAllocator {
         reinterpret_cast<char*>(block->ptr) -
         reinterpret_cast<char*>(base_block->ptr));
 
+    size_t allocation_size_bytes = 0;
+    for (Block* cursor = base_block; cursor != nullptr; cursor = cursor->next) {
+      TORCH_CHECK(
+          allocation_size_bytes <=
+              std::numeric_limits<size_t>::max() - cursor->size,
+          "XPU IPC allocation size overflow");
+      allocation_size_bytes += cursor->size;
+    }
+
     auto ze_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
         xpu::get_device_context());
     auto& ze_ipc_api = get_ze_ipc_api();
@@ -2171,7 +2188,7 @@ class NativeCachingAllocator : public XPUAllocator {
         true,
         static_cast<int64_t>(export_fd.fd),
         true,
-        static_cast<int64_t>(base_block->size)};
+        static_cast<int64_t>(allocation_size_bytes)};
   }
 
   std::shared_ptr<void> getIpcDevPtr(

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -57,18 +57,16 @@ struct ZeIpcApi {
     }
   }
 
-  void init() {
-    lib_handle = dlopen("libze_loader.so.1", RTLD_LAZY | RTLD_LOCAL);
-    if (!lib_handle) {
-      lib_handle = dlopen("libze_loader.so", RTLD_LAZY | RTLD_LOCAL);
-    }
-    resolve(get_alloc_properties, "zeMemGetAllocProperties");
-    resolve(alloc_device, "zeMemAllocDevice");
-    resolve(free_device, "zeMemFree");
-  }
-
   bool dma_buf_available() {
-    std::call_once(init_once, [this]() { init(); });
+    std::call_once(init_once, [this]() {
+      lib_handle = dlopen("libze_loader.so.1", RTLD_LAZY | RTLD_LOCAL);
+      if (!lib_handle) {
+        lib_handle = dlopen("libze_loader.so", RTLD_LAZY | RTLD_LOCAL);
+      }
+      resolve(get_alloc_properties, "zeMemGetAllocProperties");
+      resolve(alloc_device, "zeMemAllocDevice");
+      resolve(free_device, "zeMemFree");
+    });
     return get_alloc_properties && alloc_device && free_device;
   }
 };
@@ -2124,6 +2122,8 @@ class NativeCachingAllocator : public XPUAllocator {
   }
 
   ShareableHandle shareIpcHandle(void* ptr) override {
+    std::lock_guard<std::mutex> ipc_lock(IpcMutex);
+
     Block* block = get_allocated_block(ptr);
     TORCH_CHECK(block, "invalid device pointer for XPU IPC: ", ptr);
     TORCH_CHECK(
@@ -2178,31 +2178,19 @@ class NativeCachingAllocator : public XPUAllocator {
   std::shared_ptr<void> getIpcDevPtr(
       std::string handle,
       c10::DeviceIndex device) override {
-    // Fast path: check if already in cache
-    {
-      std::lock_guard<std::mutex> lock(IpcMutex);
-      auto iter = ipcMemHandle_to_devptr.find(handle);
-      if (iter != ipcMemHandle_to_devptr.end()) {
-        auto devptr = iter->second.wp_.lock();
-        TORCH_INTERNAL_ASSERT(devptr, "entry in cache has missing shared_ptr");
-        return devptr;
-      }
-    }
-
-    MemHandleCacheEntry entry(device, handle);
-    entry.init();
-
-    // Slow path: insert into cache
     std::lock_guard<std::mutex> lock(IpcMutex);
     auto iter = ipcMemHandle_to_devptr.find(handle);
     if (iter != ipcMemHandle_to_devptr.end()) {
       auto devptr = iter->second.wp_.lock();
       TORCH_INTERNAL_ASSERT(devptr, "entry in cache has missing shared_ptr");
-      entry.clear();
       return devptr;
     }
 
+    MemHandleCacheEntry entry(device, handle);
+    entry.init();
+
     auto inserted = ipcMemHandle_to_devptr.emplace(handle, std::move(entry));
+    TORCH_INTERNAL_ASSERT(inserted.second);
     auto& inserted_entry = inserted.first->second;
     auto shared_handle = inserted.first->first;
 

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -113,6 +113,7 @@ struct Block {
   void* ptr{nullptr}; // memory address
   bool allocated{false}; // in-use flag
   bool mapped{true}; // True if this Block is backed by physical pages
+  bool dma_buf_allocated{false}; // True if allocated with DMA-BUF export flag
   Block* prev{nullptr}; // prev block if split from a larger allocation
   Block* next{nullptr}; // next block if split from a larger allocation
   int event_count{0}; // number of outstanding XPU events
@@ -417,6 +418,7 @@ struct AllocParams {
   BlockPool* pool;
   size_t alloc_size;
   Block* block{nullptr};
+  bool dma_buf_used{false};
   StatTypes stat_types = {};
 };
 
@@ -491,6 +493,7 @@ void allocPrimitive(void** ptr, size_t size, AllocParams& p) {
       const auto alloc_result = ze_ipc_api.alloc_device(
           ze_context, &alloc_desc, size, kDeviceAlignment, ze_device, ptr);
       if (alloc_result == ZE_RESULT_SUCCESS) {
+        p.dma_buf_used = true;
         return;
       }
     }
@@ -503,24 +506,17 @@ void allocPrimitive(void** ptr, size_t size, AllocParams& p) {
   }
 }
 
-void deletePrimitive(void* ptr, BlockPool* pool) {
+void deletePrimitive(void* ptr, BlockPool* pool, bool dma_buf_allocated) {
   if (pool->owner_PrivatePool && pool->owner_PrivatePool->allocator()) {
     pool->owner_PrivatePool->allocator()->raw_delete(ptr);
   } else {
     auto& ze_ipc_api = get_ze_ipc_api();
-    if (ze_ipc_api.free_device && ze_ipc_api.get_alloc_properties) {
+    if (dma_buf_allocated && ze_ipc_api.free_device) {
       auto ze_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
           xpu::get_device_context());
-      ze_memory_allocation_properties_t alloc_props = {};
-      alloc_props.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
-      alloc_props.pNext = nullptr;
-      const auto props_result = ze_ipc_api.get_alloc_properties(
-          ze_context, ptr, &alloc_props, nullptr);
-      if (props_result == ZE_RESULT_SUCCESS) {
-        const auto free_result = ze_ipc_api.free_device(ze_context, ptr);
-        if (free_result == ZE_RESULT_SUCCESS) {
-          return;
-        }
+      const auto free_result = ze_ipc_api.free_device(ze_context, ptr);
+      if (free_result == ZE_RESULT_SUCCESS) {
+        return;
       }
     }
 
@@ -1029,6 +1025,7 @@ class DeviceCachingAllocator {
       p.pool->owner_PrivatePool->allocation_count++;
     }
     p.block = new Block(p.device(), p.queue(), size, p.pool, ptr);
+    p.block->dma_buf_allocated = p.dma_buf_used;
     for_each_selected_stat_type(p.stat_types, [&](size_t stat_type) {
       stats.segment[stat_type].increase(1);
       stats.reserved_bytes[stat_type].increase(size);
@@ -1113,7 +1110,7 @@ class DeviceCachingAllocator {
         context ? context : block->context_when_segment_allocated);
 
     auto* pool = block->pool;
-    deletePrimitive(block->ptr, pool);
+    deletePrimitive(block->ptr, pool, block->dma_buf_allocated);
 
     if (pool->owner_PrivatePool) {
       TORCH_INTERNAL_ASSERT(pool->owner_PrivatePool->allocation_count > 0);
@@ -1880,7 +1877,7 @@ static void local_raw_delete(void* ptr);
 class NativeCachingAllocator : public XPUAllocator {
  private:
   alignas(hardware_destructive_interference_size) std::mutex mutex;
-  std::mutex IpcMutex;
+  std::mutex ipc_mutex_;
   ska::flat_hash_map<void*, Block*> allocated_blocks;
   struct MemHandleCacheEntry {
     MemHandleCacheEntry(c10::DeviceIndex device, const std::string& handle)
@@ -1943,6 +1940,10 @@ class NativeCachingAllocator : public XPUAllocator {
           kDeviceAlignment,
           ze_device,
           &xpu_ipc_ptr_);
+      if (fd_ >= 0) {
+        ::close(static_cast<int>(fd_));
+        fd_ = -1;
+      }
       TORCH_CHECK(
           alloc_result == ZE_RESULT_SUCCESS,
           "zeMemAllocDevice (DMA-BUF import) failed with code ",
@@ -2122,8 +2123,6 @@ class NativeCachingAllocator : public XPUAllocator {
   }
 
   ShareableHandle shareIpcHandle(void* ptr) override {
-    std::lock_guard<std::mutex> ipc_lock(IpcMutex);
-
     Block* block = get_allocated_block(ptr);
     TORCH_CHECK(block, "invalid device pointer for XPU IPC: ", ptr);
     TORCH_CHECK(
@@ -2176,14 +2175,16 @@ class NativeCachingAllocator : public XPUAllocator {
   }
 
   std::shared_ptr<void> getIpcDevPtr(
-      std::string handle,
+      const std::string& handle,
       c10::DeviceIndex device) override {
-    std::lock_guard<std::mutex> lock(IpcMutex);
+    std::lock_guard<std::mutex> lock(ipc_mutex_);
     auto iter = ipcMemHandle_to_devptr.find(handle);
     if (iter != ipcMemHandle_to_devptr.end()) {
       auto devptr = iter->second.wp_.lock();
-      TORCH_INTERNAL_ASSERT(devptr, "entry in cache has missing shared_ptr");
-      return devptr;
+      if (devptr) {
+        return devptr;
+      }
+      ipcMemHandle_to_devptr.erase(iter);
     }
 
     MemHandleCacheEntry entry(device, handle);
@@ -2197,7 +2198,7 @@ class NativeCachingAllocator : public XPUAllocator {
     auto sp = std::shared_ptr<void>(
         inserted_entry.ptr(), [shared_handle, this](void* p) {
           (void)p;
-          std::unique_lock<std::mutex> deleter_lock(IpcMutex);
+          std::unique_lock<std::mutex> deleter_lock(ipc_mutex_);
 
           auto it = ipcMemHandle_to_devptr.find(shared_handle);
           TORCH_INTERNAL_ASSERT(it != ipcMemHandle_to_devptr.end());

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -45,12 +45,9 @@ struct ZeIpcApi {
   OpenIpcHandleFn open_ipc_handle{nullptr};
   CloseIpcHandleFn close_ipc_handle{nullptr};
   void* lib_handle{nullptr};
+  std::once_flag init_once;
 
-  bool available() {
-    if (get_ipc_handle && open_ipc_handle && close_ipc_handle) {
-      return true;
-    }
-
+  void init() {
     get_ipc_handle = reinterpret_cast<GetIpcHandleFn>(
         dlsym(RTLD_DEFAULT, "zeMemGetIpcHandle"));
     open_ipc_handle = reinterpret_cast<OpenIpcHandleFn>(
@@ -59,17 +56,15 @@ struct ZeIpcApi {
         dlsym(RTLD_DEFAULT, "zeMemCloseIpcHandle"));
 
     if (get_ipc_handle && open_ipc_handle && close_ipc_handle) {
-      return true;
+      return;
     }
 
+    lib_handle = dlopen("libze_loader.so.1", RTLD_LAZY | RTLD_LOCAL);
     if (!lib_handle) {
-      lib_handle = dlopen("libze_loader.so.1", RTLD_LAZY | RTLD_LOCAL);
-      if (!lib_handle) {
-        lib_handle = dlopen("libze_loader.so", RTLD_LAZY | RTLD_LOCAL);
-      }
+      lib_handle = dlopen("libze_loader.so", RTLD_LAZY | RTLD_LOCAL);
     }
     if (!lib_handle) {
-      return false;
+      return;
     }
 
     get_ipc_handle = reinterpret_cast<GetIpcHandleFn>(
@@ -78,6 +73,12 @@ struct ZeIpcApi {
         dlsym(lib_handle, "zeMemOpenIpcHandle"));
     close_ipc_handle = reinterpret_cast<CloseIpcHandleFn>(
         dlsym(lib_handle, "zeMemCloseIpcHandle"));
+  }
+
+  bool available() {
+    std::call_once(init_once, [this]() {
+      init();
+    });
     return get_ipc_handle && open_ipc_handle && close_ipc_handle;
   }
 };

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -1915,7 +1915,7 @@ class NativeCachingAllocator : public XPUAllocator {
         return;
       }
 
-      // Child processes created via spawn/forkserver must initialize XPU state.
+      // Child processes must initialize XPU state.
       at::DeviceGuard guard(at::Device(at::kXPU, device_));
       c10::xpu::device_count_ensure_non_zero();
 
@@ -2189,49 +2189,39 @@ class NativeCachingAllocator : public XPUAllocator {
       }
     }
 
-    // Create and initialize entry without holding lock
     MemHandleCacheEntry entry(device, handle);
     entry.init();
-    std::shared_ptr<void> raced_devptr;
 
     // Slow path: insert into cache
-    {
-      std::lock_guard<std::mutex> lock(IpcMutex);
-
-      // Check again in case another thread inserted while we were initializing
-      auto iter = ipcMemHandle_to_devptr.find(handle);
-      if (iter != ipcMemHandle_to_devptr.end()) {
-        raced_devptr = iter->second.wp_.lock();
-        TORCH_INTERNAL_ASSERT(
-            raced_devptr, "entry in cache has missing shared_ptr");
-      } else {
-        // Insert the already-initialized entry
-        auto inserted =
-            ipcMemHandle_to_devptr.emplace(handle, std::move(entry));
-        auto& inserted_entry = inserted.first->second;
-        auto shared_handle = inserted.first->first;
-
-        auto sp = std::shared_ptr<void>(
-            inserted_entry.ptr(), [shared_handle, this](void* p) {
-              (void)p;
-              std::unique_lock<std::mutex> deleter_lock(IpcMutex);
-
-              auto it = ipcMemHandle_to_devptr.find(shared_handle);
-              TORCH_INTERNAL_ASSERT(it != ipcMemHandle_to_devptr.end());
-              auto entry = std::move(it->second);
-              ipcMemHandle_to_devptr.erase(it);
-
-              deleter_lock.unlock();
-
-              entry.clear();
-            });
-        inserted_entry.wp_ = sp;
-        return sp;
-      }
+    std::lock_guard<std::mutex> lock(IpcMutex);
+    auto iter = ipcMemHandle_to_devptr.find(handle);
+    if (iter != ipcMemHandle_to_devptr.end()) {
+      auto devptr = iter->second.wp_.lock();
+      TORCH_INTERNAL_ASSERT(devptr, "entry in cache has missing shared_ptr");
+      entry.clear();
+      return devptr;
     }
 
-    entry.clear();
-    return raced_devptr;
+    auto inserted = ipcMemHandle_to_devptr.emplace(handle, std::move(entry));
+    auto& inserted_entry = inserted.first->second;
+    auto shared_handle = inserted.first->first;
+
+    auto sp = std::shared_ptr<void>(
+        inserted_entry.ptr(), [shared_handle, this](void* p) {
+          (void)p;
+          std::unique_lock<std::mutex> deleter_lock(IpcMutex);
+
+          auto it = ipcMemHandle_to_devptr.find(shared_handle);
+          TORCH_INTERNAL_ASSERT(it != ipcMemHandle_to_devptr.end());
+          auto entry = std::move(it->second);
+          ipcMemHandle_to_devptr.erase(it);
+
+          deleter_lock.unlock();
+
+          entry.clear();
+        });
+    inserted_entry.wp_ = sp;
+    return sp;
   }
 
   void copy_data(void* dest, const void* src, std::size_t count) const final {

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -1886,11 +1886,7 @@ class NativeCachingAllocator : public XPUAllocator {
   ska::flat_hash_map<void*, Block*> allocated_blocks;
   struct MemHandleCacheEntry {
     MemHandleCacheEntry(c10::DeviceIndex device, const std::string& handle)
-        : device_(device),
-          initialized_(false),
-          from_dma_buf_(false),
-          fd_(-1),
-          alloc_size_(0) {
+        : device_(device), initialized_(false), fd_(-1), alloc_size_(0) {
       auto& ze_ipc_api = get_ze_ipc_api();
 
       if (handle.rfind("dmabuf:", 0) == 0) {
@@ -1898,7 +1894,6 @@ class NativeCachingAllocator : public XPUAllocator {
         TORCH_CHECK(
             fd_end != std::string::npos,
             "invalid dmabuf handle format for XPU IPC");
-        from_dma_buf_ = true;
         fd_ = std::stoll(handle.substr(7, fd_end - 7));
         alloc_size_ =
             static_cast<size_t>(std::stoull(handle.substr(fd_end + 1)));
@@ -1915,18 +1910,14 @@ class NativeCachingAllocator : public XPUAllocator {
           "Level Zero DMA-BUF IPC APIs are unavailable");
     }
 
-    // Initialize the IPC handle (called outside the cache lock)
     void init() {
       if (initialized_) {
         return;
       }
 
-      // Ensure device pool is properly initialized in this process
-      // This is critical for multiprocessing scenarios (spawn/forkserver)
-      // where child processes need to perform device initialization again.
+      // Child processes created via spawn/forkserver must initialize XPU state.
       at::DeviceGuard guard(at::Device(at::kXPU, device_));
-      c10::xpu::device_count_ensure_non_zero(); // Ensure device pool is
-                                                // initialized
+      c10::xpu::device_count_ensure_non_zero();
 
       ze_context_ = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
           xpu::get_device_context());
@@ -1935,34 +1926,30 @@ class NativeCachingAllocator : public XPUAllocator {
 
       auto& ze_ipc_api = get_ze_ipc_api();
 
-      if (from_dma_buf_) {
-        ze_external_memory_import_fd_t import_desc = {};
-        import_desc.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMPORT_FD;
-        import_desc.pNext = nullptr;
-        import_desc.flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF;
-        import_desc.fd = static_cast<int>(fd_);
+      ze_external_memory_import_fd_t import_desc = {};
+      import_desc.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMPORT_FD;
+      import_desc.pNext = nullptr;
+      import_desc.flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF;
+      import_desc.fd = static_cast<int>(fd_);
 
-        ze_device_mem_alloc_desc_t alloc_desc = {};
-        alloc_desc.stype = ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC;
-        alloc_desc.pNext = &import_desc;
-        alloc_desc.flags = 0;
-        alloc_desc.ordinal = 0;
+      ze_device_mem_alloc_desc_t alloc_desc = {};
+      alloc_desc.stype = ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC;
+      alloc_desc.pNext = &import_desc;
+      alloc_desc.flags = 0;
+      alloc_desc.ordinal = 0;
 
-        const auto alloc_result = ze_ipc_api.alloc_device(
-            ze_context_,
-            &alloc_desc,
-            alloc_size_,
-            kDeviceAlignment,
-            ze_device,
-            &xpu_ipc_ptr_);
-        TORCH_CHECK(
-            alloc_result == ZE_RESULT_SUCCESS,
-            "zeMemAllocDevice (DMA-BUF import) failed with code ",
-            static_cast<int>(alloc_result));
-        initialized_ = true;
-        return;
-      }
-      TORCH_CHECK(false, "unexpected non-DMA-BUF XPU IPC path");
+      const auto alloc_result = ze_ipc_api.alloc_device(
+          ze_context_,
+          &alloc_desc,
+          alloc_size_,
+          kDeviceAlignment,
+          ze_device,
+          &xpu_ipc_ptr_);
+      TORCH_CHECK(
+          alloc_result == ZE_RESULT_SUCCESS,
+          "zeMemAllocDevice (DMA-BUF import) failed with code ",
+          static_cast<int>(alloc_result));
+      initialized_ = true;
     }
 
     void clear() {
@@ -1975,19 +1962,14 @@ class NativeCachingAllocator : public XPUAllocator {
         return;
       }
 
-      if (from_dma_buf_) {
-        const auto free_result =
-            ze_ipc_api.free_device(ze_context_, xpu_ipc_ptr_);
-        if (free_result != ZE_RESULT_SUCCESS) {
-          TORCH_WARN(
-              "zeMemFree (DMA-BUF import) failed with code ",
-              static_cast<int>(free_result));
-        }
-        xpu_ipc_ptr_ = nullptr;
-        return;
+      const auto free_result =
+          ze_ipc_api.free_device(ze_context_, xpu_ipc_ptr_);
+      if (free_result != ZE_RESULT_SUCCESS) {
+        TORCH_WARN(
+            "zeMemFree (DMA-BUF import) failed with code ",
+            static_cast<int>(free_result));
       }
-
-      TORCH_CHECK(false, "unexpected non-DMA-BUF XPU IPC clear path");
+      xpu_ipc_ptr_ = nullptr;
     }
 
     void* ptr() const {
@@ -2000,7 +1982,6 @@ class NativeCachingAllocator : public XPUAllocator {
     void* xpu_ipc_ptr_{nullptr};
     std::weak_ptr<void> wp_;
     bool initialized_;
-    bool from_dma_buf_;
     int64_t fd_;
     size_t alloc_size_;
   };
@@ -2186,11 +2167,8 @@ class NativeCachingAllocator : public XPUAllocator {
         "zeMemGetAllocProperties did not provide a valid DMA-BUF fd for XPU IPC");
 
     return {
-        std::string(),
         storage_offset_bytes,
-        true,
         static_cast<int64_t>(export_fd.fd),
-        true,
         static_cast<int64_t>(base_block->size)};
   }
 
@@ -2220,6 +2198,9 @@ class NativeCachingAllocator : public XPUAllocator {
     if (iter != ipcMemHandle_to_devptr.end()) {
       auto devptr = iter->second.wp_.lock();
       TORCH_INTERNAL_ASSERT(devptr, "entry in cache has missing shared_ptr");
+      // Our entry lost the race; release its device allocation before
+      // discarding.
+      entry.clear();
       return devptr;
     }
 

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -2167,8 +2167,11 @@ class NativeCachingAllocator : public XPUAllocator {
         "zeMemGetAllocProperties did not provide a valid DMA-BUF fd for XPU IPC");
 
     return {
+        std::string(),
         storage_offset_bytes,
+        true,
         static_cast<int64_t>(export_fd.fd),
+        true,
         static_cast<int64_t>(base_block->size)};
   }
 
@@ -2189,42 +2192,46 @@ class NativeCachingAllocator : public XPUAllocator {
     // Create and initialize entry without holding lock
     MemHandleCacheEntry entry(device, handle);
     entry.init();
+    std::shared_ptr<void> raced_devptr;
 
     // Slow path: insert into cache
-    std::lock_guard<std::mutex> lock(IpcMutex);
+    {
+      std::lock_guard<std::mutex> lock(IpcMutex);
 
-    // Check again in case another thread inserted while we were initializing
-    auto iter = ipcMemHandle_to_devptr.find(handle);
-    if (iter != ipcMemHandle_to_devptr.end()) {
-      auto devptr = iter->second.wp_.lock();
-      TORCH_INTERNAL_ASSERT(devptr, "entry in cache has missing shared_ptr");
-      // Our entry lost the race; release its device allocation before
-      // discarding.
-      entry.clear();
-      return devptr;
+      // Check again in case another thread inserted while we were initializing
+      auto iter = ipcMemHandle_to_devptr.find(handle);
+      if (iter != ipcMemHandle_to_devptr.end()) {
+        raced_devptr = iter->second.wp_.lock();
+        TORCH_INTERNAL_ASSERT(
+            raced_devptr, "entry in cache has missing shared_ptr");
+      } else {
+        // Insert the already-initialized entry
+        auto inserted =
+            ipcMemHandle_to_devptr.emplace(handle, std::move(entry));
+        auto& inserted_entry = inserted.first->second;
+        auto shared_handle = inserted.first->first;
+
+        auto sp = std::shared_ptr<void>(
+            inserted_entry.ptr(), [shared_handle, this](void* p) {
+              (void)p;
+              std::unique_lock<std::mutex> deleter_lock(IpcMutex);
+
+              auto it = ipcMemHandle_to_devptr.find(shared_handle);
+              TORCH_INTERNAL_ASSERT(it != ipcMemHandle_to_devptr.end());
+              auto entry = std::move(it->second);
+              ipcMemHandle_to_devptr.erase(it);
+
+              deleter_lock.unlock();
+
+              entry.clear();
+            });
+        inserted_entry.wp_ = sp;
+        return sp;
+      }
     }
 
-    // Insert the already-initialized entry
-    auto inserted = ipcMemHandle_to_devptr.emplace(handle, std::move(entry));
-    auto& inserted_entry = inserted.first->second;
-    auto shared_handle = inserted.first->first;
-
-    auto sp = std::shared_ptr<void>(
-        inserted_entry.ptr(), [shared_handle, this](void* p) {
-          (void)p;
-          std::unique_lock<std::mutex> deleter_lock(IpcMutex);
-
-          auto it = ipcMemHandle_to_devptr.find(shared_handle);
-          TORCH_INTERNAL_ASSERT(it != ipcMemHandle_to_devptr.end());
-          auto entry = std::move(it->second);
-          ipcMemHandle_to_devptr.erase(it);
-
-          deleter_lock.unlock();
-
-          entry.clear();
-        });
-    inserted_entry.wp_ = sp;
-    return sp;
+    entry.clear();
+    return raced_devptr;
   }
 
   void copy_data(void* dest, const void* src, std::size_t count) const final {

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -29,57 +29,54 @@ constexpr size_t kDeviceAlignment = 512;
 
 namespace {
 struct ZeIpcApi {
-  using GetIpcHandleFn = ze_result_t (*)(
-      ze_context_handle_t,
-      const void*,
-      ze_ipc_mem_handle_t*);
-  using OpenIpcHandleFn = ze_result_t (*)(
-      ze_context_handle_t,
-      ze_device_handle_t,
-      ze_ipc_mem_handle_t,
-      ze_ipc_memory_flags_t,
-      void**);
+  using GetIpcHandleFn = ze_result_t (*)(ze_context_handle_t, const void*, ze_ipc_mem_handle_t*);
+  using GetFdFromIpcHandleExpFn = ze_result_t (*)(ze_context_handle_t, ze_ipc_mem_handle_t, uint64_t*);
+  using OpenIpcHandleFn = ze_result_t (*)(ze_context_handle_t, ze_device_handle_t, ze_ipc_mem_handle_t, ze_ipc_memory_flags_t, void**);
   using CloseIpcHandleFn = ze_result_t (*)(ze_context_handle_t, void*);
+  using GetAllocPropertiesFn = ze_result_t (*)(ze_context_handle_t, const void*, ze_memory_allocation_properties_t*, ze_device_handle_t*);
+  using AllocDeviceFn = ze_result_t (*)(ze_context_handle_t, const ze_device_mem_alloc_desc_t*, size_t, size_t, ze_device_handle_t, void**);
+  using FreeDeviceFn = ze_result_t (*)(ze_context_handle_t, void*);
 
   GetIpcHandleFn get_ipc_handle{nullptr};
+  GetFdFromIpcHandleExpFn get_fd_from_ipc_handle_exp{nullptr};
   OpenIpcHandleFn open_ipc_handle{nullptr};
   CloseIpcHandleFn close_ipc_handle{nullptr};
+  GetAllocPropertiesFn get_alloc_properties{nullptr};
+  AllocDeviceFn alloc_device{nullptr};
+  FreeDeviceFn free_device{nullptr};
   void* lib_handle{nullptr};
   std::once_flag init_once;
 
-  void init() {
-    get_ipc_handle = reinterpret_cast<GetIpcHandleFn>(
-        dlsym(RTLD_DEFAULT, "zeMemGetIpcHandle"));
-    open_ipc_handle = reinterpret_cast<OpenIpcHandleFn>(
-        dlsym(RTLD_DEFAULT, "zeMemOpenIpcHandle"));
-    close_ipc_handle = reinterpret_cast<CloseIpcHandleFn>(
-        dlsym(RTLD_DEFAULT, "zeMemCloseIpcHandle"));
-
-    if (get_ipc_handle && open_ipc_handle && close_ipc_handle) {
-      return;
+  template <typename FnPtr>
+  void resolve(FnPtr& fn, const char* name) {
+    fn = reinterpret_cast<FnPtr>(dlsym(RTLD_DEFAULT, name));
+    if (!fn && lib_handle) {
+      fn = reinterpret_cast<FnPtr>(dlsym(lib_handle, name));
     }
+  }
 
+  void init() {
     lib_handle = dlopen("libze_loader.so.1", RTLD_LAZY | RTLD_LOCAL);
     if (!lib_handle) {
       lib_handle = dlopen("libze_loader.so", RTLD_LAZY | RTLD_LOCAL);
     }
-    if (!lib_handle) {
-      return;
-    }
-
-    get_ipc_handle = reinterpret_cast<GetIpcHandleFn>(
-        dlsym(lib_handle, "zeMemGetIpcHandle"));
-    open_ipc_handle = reinterpret_cast<OpenIpcHandleFn>(
-        dlsym(lib_handle, "zeMemOpenIpcHandle"));
-    close_ipc_handle = reinterpret_cast<CloseIpcHandleFn>(
-        dlsym(lib_handle, "zeMemCloseIpcHandle"));
+    resolve(get_ipc_handle, "zeMemGetIpcHandle");
+    resolve(get_fd_from_ipc_handle_exp, "zeMemGetFileDescriptorFromIpcHandleExp");
+    resolve(open_ipc_handle, "zeMemOpenIpcHandle");
+    resolve(close_ipc_handle, "zeMemCloseIpcHandle");
+    resolve(get_alloc_properties, "zeMemGetAllocProperties");
+    resolve(alloc_device, "zeMemAllocDevice");
+    resolve(free_device, "zeMemFree");
   }
 
   bool available() {
-    std::call_once(init_once, [this]() {
-      init();
-    });
+    std::call_once(init_once, [this]() { init(); });
     return get_ipc_handle && open_ipc_handle && close_ipc_handle;
+  }
+
+  bool dma_buf_available() {
+    std::call_once(init_once, [this]() { init(); });
+    return get_alloc_properties && alloc_device && free_device;
   }
 };
 
@@ -482,6 +479,36 @@ void allocPrimitive(void** ptr, size_t size, AllocParams& p) {
   if (p.pool->owner_PrivatePool && p.pool->owner_PrivatePool->allocator()) {
     *ptr = p.pool->owner_PrivatePool->allocator()->raw_alloc(size);
   } else {
+    auto& ze_ipc_api = get_ze_ipc_api();
+    if (ze_ipc_api.dma_buf_available()) {
+      auto ze_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+          xpu::get_device_context());
+      auto ze_device = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+          xpu::get_raw_device(p.device()));
+
+      ze_external_memory_export_desc_t export_desc = {};
+      export_desc.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_DESC;
+      export_desc.pNext = nullptr;
+      export_desc.flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF;
+
+      ze_device_mem_alloc_desc_t alloc_desc = {};
+      alloc_desc.stype = ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC;
+      alloc_desc.pNext = &export_desc;
+      alloc_desc.flags = 0;
+      alloc_desc.ordinal = 0;
+
+      const auto alloc_result = ze_ipc_api.alloc_device(
+          ze_context,
+          &alloc_desc,
+          size,
+          kDeviceAlignment,
+          ze_device,
+          ptr);
+      if (alloc_result == ZE_RESULT_SUCCESS) {
+        return;
+      }
+    }
+
     *ptr = sycl::aligned_alloc_device(
         kDeviceAlignment,
         size,
@@ -494,6 +521,23 @@ void deletePrimitive(void* ptr, BlockPool* pool) {
   if (pool->owner_PrivatePool && pool->owner_PrivatePool->allocator()) {
     pool->owner_PrivatePool->allocator()->raw_delete(ptr);
   } else {
+    auto& ze_ipc_api = get_ze_ipc_api();
+    if (ze_ipc_api.free_device && ze_ipc_api.get_alloc_properties) {
+      auto ze_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
+          xpu::get_device_context());
+      ze_memory_allocation_properties_t alloc_props = {};
+      alloc_props.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
+      alloc_props.pNext = nullptr;
+      const auto props_result = ze_ipc_api.get_alloc_properties(
+          ze_context, ptr, &alloc_props, nullptr);
+      if (props_result == ZE_RESULT_SUCCESS) {
+        const auto free_result = ze_ipc_api.free_device(ze_context, ptr);
+        if (free_result == ZE_RESULT_SUCCESS) {
+          return;
+        }
+      }
+    }
+
     sycl::free(ptr, xpu::get_device_context());
   }
 }
@@ -1854,29 +1898,113 @@ class NativeCachingAllocator : public XPUAllocator {
   ska::flat_hash_map<void*, Block*> allocated_blocks;
   struct MemHandleCacheEntry {
     MemHandleCacheEntry(c10::DeviceIndex device, const std::string& handle)
-        : device_(device) {
+        : device_(
+              device),
+          initialized_(false),
+          from_fd_(false),
+          from_dma_buf_(false),
+          fd_(-1),
+          alloc_size_(0) {
       auto& ze_ipc_api = get_ze_ipc_api();
-      TORCH_CHECK(
-          handle.size() >= sizeof(ze_ipc_mem_handle_t),
-          "invalid XPU IPC handle size");
 
-      std::memcpy(&ipc_handle_, handle.data(), sizeof(ipc_handle_));
+      if (handle.rfind("dmabuf:", 0) == 0) {
+        const auto fd_end = handle.find(':', 7);
+        TORCH_CHECK(
+            fd_end != std::string::npos,
+            "invalid dmabuf handle format for XPU IPC");
+        from_dma_buf_ = true;
+        fd_ = std::stoll(handle.substr(7, fd_end - 7));
+        alloc_size_ = static_cast<size_t>(
+            std::stoull(handle.substr(fd_end + 1)));
+        TORCH_CHECK(
+            alloc_size_ > 0,
+            "invalid dmabuf allocation size for XPU IPC");
+      } else if (handle.rfind("fd:", 0) == 0) {
+        from_fd_ = true;
+        fd_ = std::stoll(handle.substr(3));
+      } else {
+        TORCH_CHECK(
+            handle.size() >= sizeof(ze_ipc_mem_handle_t),
+            "invalid XPU IPC handle size");
+        std::memcpy(&ipc_handle_, handle.data(), sizeof(ipc_handle_));
+      }
 
       TORCH_CHECK(
           ze_ipc_api.available(), "Level Zero IPC APIs are not available");
+    }
 
+    // Initialize the IPC handle (called outside the cache lock)
+    void init() {
+      if (initialized_) {
+        return;
+      }
+
+      // Ensure device pool is properly initialized in this process
+      // This is critical for multiprocessing scenarios (spawn/forkserver)
+      // where child processes need to perform device initialization again.
       at::DeviceGuard guard(at::Device(at::kXPU, device_));
+      c10::xpu::device_count_ensure_non_zero();  // Ensure device pool is initialized
+      
       ze_context_ = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
           xpu::get_device_context());
       auto ze_device = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
           xpu::get_raw_device(device_));
 
+      auto& ze_ipc_api = get_ze_ipc_api();
+
+      if (from_dma_buf_) {
+        TORCH_CHECK(
+            ze_ipc_api.dma_buf_available(),
+            "Level Zero DMA-BUF IPC APIs are unavailable");
+
+        ze_external_memory_import_fd_t import_desc = {};
+        import_desc.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMPORT_FD;
+        import_desc.pNext = nullptr;
+        import_desc.flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF;
+        import_desc.fd = static_cast<int>(fd_);
+
+        ze_device_mem_alloc_desc_t alloc_desc = {};
+        alloc_desc.stype = ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC;
+        alloc_desc.pNext = &import_desc;
+        alloc_desc.flags = 0;
+        alloc_desc.ordinal = 0;
+
+        const auto alloc_result = ze_ipc_api.alloc_device(
+            ze_context_,
+            &alloc_desc,
+            alloc_size_,
+            kDeviceAlignment,
+            ze_device,
+            &xpu_ipc_ptr_);
+        TORCH_CHECK(
+            alloc_result == ZE_RESULT_SUCCESS,
+            "zeMemAllocDevice (DMA-BUF import) failed with code ",
+            static_cast<int>(alloc_result));
+        initialized_ = true;
+        return;
+      }
+
+      if (from_fd_) {
+        TORCH_CHECK(
+            false,
+            "legacy fd-based XPU IPC handle is unsupported; expected dmabuf or raw IPC handle");
+      }
+
       const auto result = ze_ipc_api.open_ipc_handle(
-          ze_context_, ze_device, ipc_handle_, ZE_IPC_MEMORY_FLAG_BIAS_CACHED, &xpu_ipc_ptr_);
-      TORCH_CHECK(
-          result == ZE_RESULT_SUCCESS,
-          "zeMemOpenIpcHandle failed with code ",
-          static_cast<int>(result));
+          ze_context_, ze_device, ipc_handle_, static_cast<ze_ipc_memory_flags_t>(0), &xpu_ipc_ptr_);
+      
+      if (result != ZE_RESULT_SUCCESS) {
+        TORCH_WARN(
+            "zeMemOpenIpcHandle failed with code 0x",
+            std::hex, static_cast<uint32_t>(result), std::dec,
+            " on device ", device_);
+        TORCH_CHECK(
+            false,
+            "zeMemOpenIpcHandle failed with code ",
+            static_cast<int>(result));
+      }
+
+      initialized_ = true;
     }
 
     void clear() {
@@ -1886,6 +2014,17 @@ class NativeCachingAllocator : public XPUAllocator {
 
       auto& ze_ipc_api = get_ze_ipc_api();
       if (!ze_ipc_api.available()) {
+        return;
+      }
+
+      if (from_dma_buf_) {
+        const auto free_result = ze_ipc_api.free_device(ze_context_, xpu_ipc_ptr_);
+        if (free_result != ZE_RESULT_SUCCESS) {
+          TORCH_WARN(
+              "zeMemFree (DMA-BUF import) failed with code ",
+              static_cast<int>(free_result));
+        }
+        xpu_ipc_ptr_ = nullptr;
         return;
       }
 
@@ -1899,6 +2038,7 @@ class NativeCachingAllocator : public XPUAllocator {
     }
 
     void* ptr() const {
+      TORCH_CHECK(initialized_, "MemHandleCacheEntry not initialized");
       return xpu_ipc_ptr_;
     }
 
@@ -1907,6 +2047,11 @@ class NativeCachingAllocator : public XPUAllocator {
     ze_ipc_mem_handle_t ipc_handle_{};
     void* xpu_ipc_ptr_{nullptr};
     std::weak_ptr<void> wp_;
+    bool initialized_;
+    bool from_fd_;
+    bool from_dma_buf_;
+    int64_t fd_;
+    size_t alloc_size_;
   };
   ska::flat_hash_map<std::string, MemHandleCacheEntry> ipcMemHandle_to_devptr;
   c10::ApproximateClockToUnixTimeConverter clock_converter;
@@ -2067,6 +2212,31 @@ class NativeCachingAllocator : public XPUAllocator {
     auto& ze_ipc_api = get_ze_ipc_api();
     TORCH_CHECK(
         ze_ipc_api.available(), "Level Zero IPC APIs are not available");
+
+    if (ze_ipc_api.get_alloc_properties) {
+      ze_external_memory_export_fd_t export_fd = {};
+      export_fd.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_FD;
+      export_fd.pNext = nullptr;
+      export_fd.flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF;
+      export_fd.fd = -1;
+
+      ze_memory_allocation_properties_t alloc_props = {};
+      alloc_props.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
+      alloc_props.pNext = &export_fd;
+
+      const auto alloc_props_result = ze_ipc_api.get_alloc_properties(
+        ze_context, base_block->ptr, &alloc_props, nullptr);
+      if (alloc_props_result == ZE_RESULT_SUCCESS && export_fd.fd >= 0) {
+      return {
+        std::string(),
+        storage_offset_bytes,
+        true,
+        static_cast<int64_t>(export_fd.fd),
+        true,
+        static_cast<int64_t>(base_block->size)};
+      }
+    }
+
     ze_ipc_mem_handle_t ipc_handle = {};
     auto result = ze_ipc_api.get_ipc_handle(
         ze_context, base_block->ptr, &ipc_handle);
@@ -2078,14 +2248,35 @@ class NativeCachingAllocator : public XPUAllocator {
     return {
         std::string(
             reinterpret_cast<const char*>(&ipc_handle), sizeof(ipc_handle)),
-        storage_offset_bytes};
+      storage_offset_bytes,
+      false,
+      -1,
+      false,
+      -1};
   }
 
   std::shared_ptr<void> getIpcDevPtr(
       std::string handle,
       c10::DeviceIndex device) override {
-    std::lock_guard<std::mutex> lock(IpcMutex);
+    // Fast path: check if already in cache
+    {
+      std::lock_guard<std::mutex> lock(IpcMutex);
+      auto iter = ipcMemHandle_to_devptr.find(handle);
+      if (iter != ipcMemHandle_to_devptr.end()) {
+        auto devptr = iter->second.wp_.lock();
+        TORCH_INTERNAL_ASSERT(devptr, "entry in cache has missing shared_ptr");
+        return devptr;
+      }
+    }
 
+    // Create and initialize entry without holding lock
+    MemHandleCacheEntry entry(device, handle);
+    entry.init();
+
+    // Slow path: insert into cache
+    std::lock_guard<std::mutex> lock(IpcMutex);
+    
+    // Check again in case another thread inserted while we were initializing
     auto iter = ipcMemHandle_to_devptr.find(handle);
     if (iter != ipcMemHandle_to_devptr.end()) {
       auto devptr = iter->second.wp_.lock();
@@ -2093,11 +2284,13 @@ class NativeCachingAllocator : public XPUAllocator {
       return devptr;
     }
 
-    auto inserted = ipcMemHandle_to_devptr.insert(
-        iter, {handle, MemHandleCacheEntry(device, handle)});
-    auto shared_handle = inserted->first;
+    // Insert the already-initialized entry
+    auto inserted = ipcMemHandle_to_devptr.emplace(handle, std::move(entry));
+    auto& inserted_entry = inserted.first->second;
+    auto shared_handle = inserted.first->first;
+
     auto sp = std::shared_ptr<void>(
-        inserted->second.ptr(), [shared_handle, this](void* p) {
+        inserted_entry.ptr(), [shared_handle, this](void* p) {
           (void)p;
           std::unique_lock<std::mutex> deleter_lock(IpcMutex);
 
@@ -2110,7 +2303,7 @@ class NativeCachingAllocator : public XPUAllocator {
 
           entry.clear();
         });
-    inserted->second.wp_ = sp;
+    inserted_entry.wp_ = sp;
     return sp;
   }
 

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -1872,7 +1872,7 @@ class NativeCachingAllocator : public XPUAllocator {
           xpu::get_raw_device(device_));
 
       const auto result = ze_ipc_api.open_ipc_handle(
-          ze_context_, ze_device, ipc_handle_, static_cast<ze_ipc_memory_flags_t>(0), &xpu_ipc_ptr_);
+          ze_context_, ze_device, ipc_handle_, ZE_IPC_MEMORY_FLAG_BIAS_CACHED, &xpu_ipc_ptr_);
       TORCH_CHECK(
           result == ZE_RESULT_SUCCESS,
           "zeMemOpenIpcHandle failed with code ",

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -4,19 +4,19 @@
 
 #include <ATen/DeviceGuard.h>
 
-#include <algorithm>
-#include <array>
-#include <deque>
-#include <cstring>
-#include <cstdlib>
 #include <dlfcn.h>
 #include <level_zero/ze_api.h>
-#include <mutex>
-#include <sstream>
-#include <set>
 #include <sycl/ext/oneapi/backend/level_zero.hpp>
-#include <thread>
 #include <unistd.h>
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <thread>
 #include <vector>
 
 namespace c10::xpu::XPUCachingAllocator {
@@ -29,18 +29,20 @@ constexpr size_t kDeviceAlignment = 512;
 
 namespace {
 struct ZeIpcApi {
-  using GetIpcHandleFn = ze_result_t (*)(ze_context_handle_t, const void*, ze_ipc_mem_handle_t*);
-  using GetFdFromIpcHandleExpFn = ze_result_t (*)(ze_context_handle_t, ze_ipc_mem_handle_t, uint64_t*);
-  using OpenIpcHandleFn = ze_result_t (*)(ze_context_handle_t, ze_device_handle_t, ze_ipc_mem_handle_t, ze_ipc_memory_flags_t, void**);
-  using CloseIpcHandleFn = ze_result_t (*)(ze_context_handle_t, void*);
-  using GetAllocPropertiesFn = ze_result_t (*)(ze_context_handle_t, const void*, ze_memory_allocation_properties_t*, ze_device_handle_t*);
-  using AllocDeviceFn = ze_result_t (*)(ze_context_handle_t, const ze_device_mem_alloc_desc_t*, size_t, size_t, ze_device_handle_t, void**);
+  using GetAllocPropertiesFn = ze_result_t (*)(
+      ze_context_handle_t,
+      const void*,
+      ze_memory_allocation_properties_t*,
+      ze_device_handle_t*);
+  using AllocDeviceFn = ze_result_t (*)(
+      ze_context_handle_t,
+      const ze_device_mem_alloc_desc_t*,
+      size_t,
+      size_t,
+      ze_device_handle_t,
+      void**);
   using FreeDeviceFn = ze_result_t (*)(ze_context_handle_t, void*);
 
-  GetIpcHandleFn get_ipc_handle{nullptr};
-  GetFdFromIpcHandleExpFn get_fd_from_ipc_handle_exp{nullptr};
-  OpenIpcHandleFn open_ipc_handle{nullptr};
-  CloseIpcHandleFn close_ipc_handle{nullptr};
   GetAllocPropertiesFn get_alloc_properties{nullptr};
   AllocDeviceFn alloc_device{nullptr};
   FreeDeviceFn free_device{nullptr};
@@ -60,18 +62,9 @@ struct ZeIpcApi {
     if (!lib_handle) {
       lib_handle = dlopen("libze_loader.so", RTLD_LAZY | RTLD_LOCAL);
     }
-    resolve(get_ipc_handle, "zeMemGetIpcHandle");
-    resolve(get_fd_from_ipc_handle_exp, "zeMemGetFileDescriptorFromIpcHandleExp");
-    resolve(open_ipc_handle, "zeMemOpenIpcHandle");
-    resolve(close_ipc_handle, "zeMemCloseIpcHandle");
     resolve(get_alloc_properties, "zeMemGetAllocProperties");
     resolve(alloc_device, "zeMemAllocDevice");
     resolve(free_device, "zeMemFree");
-  }
-
-  bool available() {
-    std::call_once(init_once, [this]() { init(); });
-    return get_ipc_handle && open_ipc_handle && close_ipc_handle;
   }
 
   bool dma_buf_available() {
@@ -498,12 +491,7 @@ void allocPrimitive(void** ptr, size_t size, AllocParams& p) {
       alloc_desc.ordinal = 0;
 
       const auto alloc_result = ze_ipc_api.alloc_device(
-          ze_context,
-          &alloc_desc,
-          size,
-          kDeviceAlignment,
-          ze_device,
-          ptr);
+          ze_context, &alloc_desc, size, kDeviceAlignment, ze_device, ptr);
       if (alloc_result == ZE_RESULT_SUCCESS) {
         return;
       }
@@ -1898,10 +1886,8 @@ class NativeCachingAllocator : public XPUAllocator {
   ska::flat_hash_map<void*, Block*> allocated_blocks;
   struct MemHandleCacheEntry {
     MemHandleCacheEntry(c10::DeviceIndex device, const std::string& handle)
-        : device_(
-              device),
+        : device_(device),
           initialized_(false),
-          from_fd_(false),
           from_dma_buf_(false),
           fd_(-1),
           alloc_size_(0) {
@@ -1914,23 +1900,19 @@ class NativeCachingAllocator : public XPUAllocator {
             "invalid dmabuf handle format for XPU IPC");
         from_dma_buf_ = true;
         fd_ = std::stoll(handle.substr(7, fd_end - 7));
-        alloc_size_ = static_cast<size_t>(
-            std::stoull(handle.substr(fd_end + 1)));
+        alloc_size_ =
+            static_cast<size_t>(std::stoull(handle.substr(fd_end + 1)));
         TORCH_CHECK(
-            alloc_size_ > 0,
-            "invalid dmabuf allocation size for XPU IPC");
-      } else if (handle.rfind("fd:", 0) == 0) {
-        from_fd_ = true;
-        fd_ = std::stoll(handle.substr(3));
+            alloc_size_ > 0, "invalid dmabuf allocation size for XPU IPC");
       } else {
         TORCH_CHECK(
-            handle.size() >= sizeof(ze_ipc_mem_handle_t),
-            "invalid XPU IPC handle size");
-        std::memcpy(&ipc_handle_, handle.data(), sizeof(ipc_handle_));
+            false,
+            "unsupported XPU IPC handle format; expected dmabuf:<fd>:<alloc_size>");
       }
 
       TORCH_CHECK(
-          ze_ipc_api.available(), "Level Zero IPC APIs are not available");
+          ze_ipc_api.dma_buf_available(),
+          "Level Zero DMA-BUF IPC APIs are unavailable");
     }
 
     // Initialize the IPC handle (called outside the cache lock)
@@ -1943,8 +1925,9 @@ class NativeCachingAllocator : public XPUAllocator {
       // This is critical for multiprocessing scenarios (spawn/forkserver)
       // where child processes need to perform device initialization again.
       at::DeviceGuard guard(at::Device(at::kXPU, device_));
-      c10::xpu::device_count_ensure_non_zero();  // Ensure device pool is initialized
-      
+      c10::xpu::device_count_ensure_non_zero(); // Ensure device pool is
+                                                // initialized
+
       ze_context_ = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
           xpu::get_device_context());
       auto ze_device = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
@@ -1953,10 +1936,6 @@ class NativeCachingAllocator : public XPUAllocator {
       auto& ze_ipc_api = get_ze_ipc_api();
 
       if (from_dma_buf_) {
-        TORCH_CHECK(
-            ze_ipc_api.dma_buf_available(),
-            "Level Zero DMA-BUF IPC APIs are unavailable");
-
         ze_external_memory_import_fd_t import_desc = {};
         import_desc.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMPORT_FD;
         import_desc.pNext = nullptr;
@@ -1983,28 +1962,7 @@ class NativeCachingAllocator : public XPUAllocator {
         initialized_ = true;
         return;
       }
-
-      if (from_fd_) {
-        TORCH_CHECK(
-            false,
-            "legacy fd-based XPU IPC handle is unsupported; expected dmabuf or raw IPC handle");
-      }
-
-      const auto result = ze_ipc_api.open_ipc_handle(
-          ze_context_, ze_device, ipc_handle_, static_cast<ze_ipc_memory_flags_t>(0), &xpu_ipc_ptr_);
-      
-      if (result != ZE_RESULT_SUCCESS) {
-        TORCH_WARN(
-            "zeMemOpenIpcHandle failed with code 0x",
-            std::hex, static_cast<uint32_t>(result), std::dec,
-            " on device ", device_);
-        TORCH_CHECK(
-            false,
-            "zeMemOpenIpcHandle failed with code ",
-            static_cast<int>(result));
-      }
-
-      initialized_ = true;
+      TORCH_CHECK(false, "unexpected non-DMA-BUF XPU IPC path");
     }
 
     void clear() {
@@ -2013,12 +1971,13 @@ class NativeCachingAllocator : public XPUAllocator {
       }
 
       auto& ze_ipc_api = get_ze_ipc_api();
-      if (!ze_ipc_api.available()) {
+      if (!ze_ipc_api.dma_buf_available()) {
         return;
       }
 
       if (from_dma_buf_) {
-        const auto free_result = ze_ipc_api.free_device(ze_context_, xpu_ipc_ptr_);
+        const auto free_result =
+            ze_ipc_api.free_device(ze_context_, xpu_ipc_ptr_);
         if (free_result != ZE_RESULT_SUCCESS) {
           TORCH_WARN(
               "zeMemFree (DMA-BUF import) failed with code ",
@@ -2028,13 +1987,7 @@ class NativeCachingAllocator : public XPUAllocator {
         return;
       }
 
-      auto close_result = ze_ipc_api.close_ipc_handle(ze_context_, xpu_ipc_ptr_);
-      if (close_result != ZE_RESULT_SUCCESS) {
-        TORCH_WARN(
-            "zeMemCloseIpcHandle failed with code ",
-            static_cast<int>(close_result));
-      }
-      xpu_ipc_ptr_ = nullptr;
+      TORCH_CHECK(false, "unexpected non-DMA-BUF XPU IPC clear path");
     }
 
     void* ptr() const {
@@ -2044,11 +1997,9 @@ class NativeCachingAllocator : public XPUAllocator {
 
     c10::DeviceIndex device_;
     ze_context_handle_t ze_context_{nullptr};
-    ze_ipc_mem_handle_t ipc_handle_{};
     void* xpu_ipc_ptr_{nullptr};
     std::weak_ptr<void> wp_;
     bool initialized_;
-    bool from_fd_;
     bool from_dma_buf_;
     int64_t fd_;
     size_t alloc_size_;
@@ -2203,56 +2154,44 @@ class NativeCachingAllocator : public XPUAllocator {
       base_block = base_block->prev;
     }
 
-    const auto storage_offset_bytes =
-        static_cast<ptrdiff_t>(reinterpret_cast<char*>(block->ptr) -
-                               reinterpret_cast<char*>(base_block->ptr));
+    const auto storage_offset_bytes = static_cast<ptrdiff_t>(
+        reinterpret_cast<char*>(block->ptr) -
+        reinterpret_cast<char*>(base_block->ptr));
 
     auto ze_context = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(
         xpu::get_device_context());
     auto& ze_ipc_api = get_ze_ipc_api();
     TORCH_CHECK(
-        ze_ipc_api.available(), "Level Zero IPC APIs are not available");
+        ze_ipc_api.dma_buf_available(),
+        "Level Zero DMA-BUF IPC APIs are unavailable");
 
-    if (ze_ipc_api.get_alloc_properties) {
-      ze_external_memory_export_fd_t export_fd = {};
-      export_fd.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_FD;
-      export_fd.pNext = nullptr;
-      export_fd.flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF;
-      export_fd.fd = -1;
+    ze_external_memory_export_fd_t export_fd = {};
+    export_fd.stype = ZE_STRUCTURE_TYPE_EXTERNAL_MEMORY_EXPORT_FD;
+    export_fd.pNext = nullptr;
+    export_fd.flags = ZE_EXTERNAL_MEMORY_TYPE_FLAG_DMA_BUF;
+    export_fd.fd = -1;
 
-      ze_memory_allocation_properties_t alloc_props = {};
-      alloc_props.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
-      alloc_props.pNext = &export_fd;
+    ze_memory_allocation_properties_t alloc_props = {};
+    alloc_props.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
+    alloc_props.pNext = &export_fd;
 
-      const auto alloc_props_result = ze_ipc_api.get_alloc_properties(
+    const auto alloc_props_result = ze_ipc_api.get_alloc_properties(
         ze_context, base_block->ptr, &alloc_props, nullptr);
-      if (alloc_props_result == ZE_RESULT_SUCCESS && export_fd.fd >= 0) {
-      return {
+    TORCH_CHECK(
+        alloc_props_result == ZE_RESULT_SUCCESS,
+        "zeMemGetAllocProperties (DMA-BUF export) failed with code ",
+        static_cast<int>(alloc_props_result));
+    TORCH_CHECK(
+        export_fd.fd >= 0,
+        "zeMemGetAllocProperties did not provide a valid DMA-BUF fd for XPU IPC");
+
+    return {
         std::string(),
         storage_offset_bytes,
         true,
         static_cast<int64_t>(export_fd.fd),
         true,
         static_cast<int64_t>(base_block->size)};
-      }
-    }
-
-    ze_ipc_mem_handle_t ipc_handle = {};
-    auto result = ze_ipc_api.get_ipc_handle(
-        ze_context, base_block->ptr, &ipc_handle);
-    TORCH_CHECK(
-        result == ZE_RESULT_SUCCESS,
-        "zeMemGetIpcHandle failed with code ",
-        static_cast<int>(result));
-
-    return {
-        std::string(
-            reinterpret_cast<const char*>(&ipc_handle), sizeof(ipc_handle)),
-      storage_offset_bytes,
-      false,
-      -1,
-      false,
-      -1};
   }
 
   std::shared_ptr<void> getIpcDevPtr(
@@ -2275,7 +2214,7 @@ class NativeCachingAllocator : public XPUAllocator {
 
     // Slow path: insert into cache
     std::lock_guard<std::mutex> lock(IpcMutex);
-    
+
     // Check again in case another thread inserted while we were initializing
     auto iter = ipcMemHandle_to_devptr.find(handle);
     if (iter != ipcMemHandle_to_devptr.end()) {

--- a/c10/xpu/XPUCachingAllocator.h
+++ b/c10/xpu/XPUCachingAllocator.h
@@ -25,7 +25,7 @@ class XPUAllocator : public DeviceAllocator {
   virtual void raw_delete(void* ptr) = 0;
   virtual ShareableHandle shareIpcHandle(void* ptr) = 0;
   virtual std::shared_ptr<void> getIpcDevPtr(
-      std::string handle,
+      const std::string& handle,
       c10::DeviceIndex device) = 0;
 };
 
@@ -84,9 +84,9 @@ inline ShareableHandle shareIpcHandle(void* ptr) {
 }
 
 inline std::shared_ptr<void> getIpcDevPtr(
-    std::string handle,
+    const std::string& handle,
     c10::DeviceIndex device) {
-  return get()->getIpcDevPtr(std::move(handle), device);
+  return get()->getIpcDevPtr(handle, device);
 }
 
 C10_XPU_API void enablePeerAccess(

--- a/c10/xpu/XPUCachingAllocator.h
+++ b/c10/xpu/XPUCachingAllocator.h
@@ -4,13 +4,25 @@
 #include <c10/core/CachingDeviceAllocator.h>
 #include <c10/xpu/XPUStream.h>
 
+#include <memory>
+#include <string>
+
 namespace c10::xpu::XPUCachingAllocator {
+
+struct ShareableHandle {
+  std::string handle;
+  ptrdiff_t offset;
+};
 
 class XPUAllocator : public DeviceAllocator {
  public:
   virtual void init(c10::DeviceIndex device_count) = 0;
   virtual void* raw_alloc(size_t size) = 0;
   virtual void raw_delete(void* ptr) = 0;
+  virtual ShareableHandle shareIpcHandle(void* ptr) = 0;
+  virtual std::shared_ptr<void> getIpcDevPtr(
+      std::string handle,
+      c10::DeviceIndex device) = 0;
 };
 
 C10_XPU_API extern std::atomic<XPUAllocator*> allocator;
@@ -61,6 +73,16 @@ inline void raw_delete(void* ptr) {
 
 inline void recordStream(const DataPtr& dataPtr, XPUStream stream) {
   get()->recordStream(dataPtr, stream);
+}
+
+inline ShareableHandle shareIpcHandle(void* ptr) {
+  return get()->shareIpcHandle(ptr);
+}
+
+inline std::shared_ptr<void> getIpcDevPtr(
+    std::string handle,
+    c10::DeviceIndex device) {
+  return get()->getIpcDevPtr(std::move(handle), device);
 }
 
 C10_XPU_API void enablePeerAccess(

--- a/c10/xpu/XPUCachingAllocator.h
+++ b/c10/xpu/XPUCachingAllocator.h
@@ -12,6 +12,10 @@ namespace c10::xpu::XPUCachingAllocator {
 struct ShareableHandle {
   std::string handle;
   ptrdiff_t offset;
+  bool is_fd{false};
+  int64_t fd{-1};
+  bool is_dma_buf{false};
+  int64_t alloc_size{-1};
 };
 
 class XPUAllocator : public DeviceAllocator {

--- a/c10/xpu/XPUCachingAllocator.h
+++ b/c10/xpu/XPUCachingAllocator.h
@@ -10,8 +10,11 @@
 namespace c10::xpu::XPUCachingAllocator {
 
 struct ShareableHandle {
+  std::string handle;
   ptrdiff_t offset;
+  bool is_fd{false};
   int64_t fd{-1};
+  bool is_dma_buf{false};
   int64_t alloc_size{-1};
 };
 

--- a/c10/xpu/XPUCachingAllocator.h
+++ b/c10/xpu/XPUCachingAllocator.h
@@ -10,11 +10,8 @@
 namespace c10::xpu::XPUCachingAllocator {
 
 struct ShareableHandle {
-  std::string handle;
   ptrdiff_t offset;
-  bool is_fd{false};
   int64_t fd{-1};
-  bool is_dma_buf{false};
   int64_t alloc_size{-1};
 };
 

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -451,7 +451,7 @@ static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
     return nullptr;
   }
 
-  size_t storage_size = THPUtils_unpackUInt64(_size_bytes) / sizeof(uint8_t);
+  size_t storage_size = THPUtils_unpackUInt64(_size_bytes);
   ptrdiff_t storage_offset_bytes =
       static_cast<ptrdiff_t>(THPUtils_unpackLong(_offset_bytes));
 
@@ -675,8 +675,6 @@ static PyObject* THPStorage_newSharedXpu(PyObject* _unused, PyObject* args) {
       std::move(data_ptr),
       /*allocator=*/nullptr,
       /*resizable=*/false);
-
-  base->set_resizable(false);
   return THPStorage_NewWithStorage(THPStorageClass, std::move(base));
 #else
   TORCH_CHECK(false, "XPU is not available");

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -26,6 +26,10 @@
 #include <cuda_runtime.h>
 #endif
 
+#ifdef USE_XPU
+#include <c10/xpu/XPUCachingAllocator.h>
+#endif
+
 #include <ATen/MapAllocator.h>
 #include <ATen/StorageUtils.h>
 #include <torch/csrc/utils/python_numbers.h>
@@ -560,6 +564,115 @@ static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* THPStorage_shareXpu(PyObject* self, PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  THPStorage_assertNotNull(self);
+#ifdef USE_XPU
+  const auto& storage = THPStorage_Unpack(self);
+  TORCH_CHECK(storage.device_type() == at::kXPU, "_share_xpu_: only available on XPU");
+  at::DeviceGuard device_guard(storage.device());
+
+  THPObjectPtr tuple(PyTuple_New(4));
+  THPObjectPtr device(THPUtils_packInt32(storage.device().index()));
+  THPObjectPtr _handle(Py_None);
+  Py_INCREF(Py_None);
+  THPObjectPtr size_bytes(THPUtils_packUInt64(storage.nbytes()));
+  THPObjectPtr _offset_bytes(THPUtils_packInt32(0));
+
+  if (storage.data()) {
+    auto shandle =
+        c10::xpu::XPUCachingAllocator::shareIpcHandle(storage.mutable_data());
+
+    _handle = PyBytes_FromStringAndSize(
+        shandle.handle.data(),
+        static_cast<Py_ssize_t>(shandle.handle.size()));
+    _offset_bytes = PyLong_FromSsize_t(
+        static_cast<Py_ssize_t>(shandle.offset));
+  }
+
+  if (!tuple || !device || !_handle || !size_bytes || !_offset_bytes) {
+    return nullptr;
+  }
+  PyTuple_SET_ITEM(tuple.get(), 0, device.release());
+  PyTuple_SET_ITEM(tuple.get(), 1, _handle.release());
+  PyTuple_SET_ITEM(tuple.get(), 2, size_bytes.release());
+  PyTuple_SET_ITEM(tuple.get(), 3, _offset_bytes.release());
+  return tuple.release();
+#else
+  TORCH_CHECK(false, "XPU is not available");
+#endif
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* THPStorage_newSharedXpu(PyObject* _unused, PyObject* args) {
+  HANDLE_TH_ERRORS
+#ifdef USE_XPU
+  TORCH_CHECK(PyTuple_GET_SIZE(args) == 4, "tuple of 4 items expected");
+  PyObject* _device = PyTuple_GET_ITEM(args, 0);
+  PyObject* _handle = PyTuple_GET_ITEM(args, 1);
+  PyObject* _size_bytes = PyTuple_GET_ITEM(args, 2);
+  PyObject* _offset_bytes = PyTuple_GET_ITEM(args, 3);
+  if (!(THPUtils_checkLong(_device) && THPUtils_checkLong(_size_bytes) &&
+        PyBytes_Check(_handle) && THPUtils_checkLong(_offset_bytes))) {
+    THPUtils_invalidArguments(
+        args,
+        nullptr,
+        "_new_shared in XPU mode",
+        1,
+        "(int device, bytes handle, int storage_size_bytes, int storage_offset_bytes)");
+    return nullptr;
+  }
+
+  size_t storage_size = THPUtils_unpackUInt64(_size_bytes) / sizeof(uint8_t);
+  ptrdiff_t storage_offset_bytes =
+      static_cast<ptrdiff_t>(THPUtils_unpackLong(_offset_bytes));
+  const auto device = c10::checked_convert<c10::DeviceIndex>(
+      THPUtils_unpackLong(_device), "c10::DeviceIndex");
+  at::DeviceGuard device_guard(at::Device(at::kXPU, device));
+
+  char* handle_ptr = nullptr;
+  Py_ssize_t handle_size = 0;
+  if (PyBytes_AsStringAndSize(_handle, &handle_ptr, &handle_size) == -1) {
+    return nullptr;
+  }
+  std::string handle(handle_ptr, static_cast<size_t>(handle_size));
+
+  std::shared_ptr<void> base_ptr =
+      c10::xpu::XPUCachingAllocator::getIpcDevPtr(std::move(handle), device);
+  void* dev_ptr = static_cast<char*>(base_ptr.get()) + storage_offset_bytes;
+
+  struct XpuIpcDeleterContext {
+    std::shared_ptr<void> base_ptr;
+  };
+
+  auto ctx = std::make_unique<XpuIpcDeleterContext>();
+  ctx->base_ptr = std::move(base_ptr);
+
+  c10::DataPtr data_ptr(
+      dev_ptr,
+      ctx.release(),
+      +[](void* ctx_) {
+        std::unique_ptr<XpuIpcDeleterContext> ctx(
+            static_cast<XpuIpcDeleterContext*>(ctx_));
+        ctx->base_ptr.reset();
+      },
+      at::Device(at::DeviceType::XPU, device));
+
+  auto base = c10::make_intrusive<at::StorageImpl>(
+      c10::StorageImpl::use_byte_size_t(),
+      storage_size,
+      std::move(data_ptr),
+      /*allocator=*/nullptr,
+      /*resizable=*/false);
+
+  base->set_resizable(false);
+  return THPStorage_NewWithStorage(THPStorageClass, std::move(base));
+#else
+  TORCH_CHECK(false, "XPU is not available");
+#endif
+  END_HANDLE_TH_ERRORS
+}
+
 // Returns an object that holds a "weak" pointer to the c10::StorageImpl.  This
 // pointer keeps the c10::StorageImpl struct live, but does not retain the data
 // pointer.
@@ -647,6 +760,11 @@ static PyMethodDef THPStorage_sharingMethods[] = {
     {"_share_cuda_", THPStorage_shareCuda, METH_NOARGS, nullptr},
     {"_new_shared_cuda",
      THPStorage_newSharedCuda,
+     METH_VARARGS | METH_STATIC,
+     nullptr},
+    {"_share_xpu_", THPStorage_shareXpu, METH_NOARGS, nullptr},
+    {"_new_shared_xpu",
+     THPStorage_newSharedXpu,
      METH_VARARGS | METH_STATIC,
      nullptr},
     {"_release_ipc_counter_cuda",

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -645,6 +645,22 @@ static PyObject* THPStorage_newSharedXpu(PyObject* _unused, PyObject* args) {
 
   const auto fd = THPUtils_unpackLong(PyTuple_GET_ITEM(_handle, 0));
   const auto alloc_size = THPUtils_unpackLong(PyTuple_GET_ITEM(_handle, 1));
+  TORCH_CHECK(fd >= 0, "invalid DMA-BUF fd for XPU IPC");
+  TORCH_CHECK(alloc_size > 0, "invalid DMA-BUF allocation size for XPU IPC");
+  TORCH_CHECK(
+      storage_offset_bytes >= 0, "invalid negative storage offset for XPU IPC");
+  const auto alloc_size_u64 = static_cast<uint64_t>(alloc_size);
+  const auto storage_offset_u64 = static_cast<uint64_t>(storage_offset_bytes);
+  const auto storage_size_u64 = static_cast<uint64_t>(storage_size);
+  TORCH_CHECK(
+      storage_offset_u64 <= alloc_size_u64,
+      "XPU IPC storage offset exceeds allocation size");
+  TORCH_CHECK(
+      storage_size_u64 <= alloc_size_u64,
+      "XPU IPC storage size exceeds allocation size");
+  TORCH_CHECK(
+      storage_offset_u64 <= alloc_size_u64 - storage_size_u64,
+      "XPU IPC storage range exceeds allocation size");
   std::string handle = std::string("dmabuf:") + std::to_string(fd) + ":" +
       std::to_string(alloc_size);
 

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -576,7 +576,6 @@ static PyObject* THPStorage_shareXpu(PyObject* self, PyObject* noargs) {
   THPObjectPtr tuple(PyTuple_New(4));
   THPObjectPtr device(THPUtils_packInt32(storage.device().index()));
   THPObjectPtr _handle(Py_None);
-  Py_INCREF(Py_None);
   THPObjectPtr size_bytes(THPUtils_packUInt64(storage.nbytes()));
   THPObjectPtr _offset_bytes(THPUtils_packInt32(0));
 

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -583,9 +583,25 @@ static PyObject* THPStorage_shareXpu(PyObject* self, PyObject* noargs) {
     auto shandle =
         c10::xpu::XPUCachingAllocator::shareIpcHandle(storage.mutable_data());
 
-    _handle = PyBytes_FromStringAndSize(
-        shandle.handle.data(),
-        static_cast<Py_ssize_t>(shandle.handle.size()));
+    if (shandle.is_fd) {
+      if (shandle.is_dma_buf) {
+        THPObjectPtr handle_tuple(PyTuple_New(2));
+        THPObjectPtr _fd(PyLong_FromLongLong(shandle.fd));
+        THPObjectPtr _alloc_size(PyLong_FromLongLong(shandle.alloc_size));
+        if (!handle_tuple || !_fd || !_alloc_size) {
+          return nullptr;
+        }
+        PyTuple_SET_ITEM(handle_tuple.get(), 0, _fd.release());
+        PyTuple_SET_ITEM(handle_tuple.get(), 1, _alloc_size.release());
+        _handle = handle_tuple.release();
+      } else {
+        _handle = PyLong_FromLongLong(shandle.fd);
+      }
+    } else {
+      _handle = PyBytes_FromStringAndSize(
+          shandle.handle.data(),
+          static_cast<Py_ssize_t>(shandle.handle.size()));
+    }
     _offset_bytes = PyLong_FromSsize_t(
         static_cast<Py_ssize_t>(shandle.offset));
   }
@@ -612,14 +628,21 @@ static PyObject* THPStorage_newSharedXpu(PyObject* _unused, PyObject* args) {
   PyObject* _handle = PyTuple_GET_ITEM(args, 1);
   PyObject* _size_bytes = PyTuple_GET_ITEM(args, 2);
   PyObject* _offset_bytes = PyTuple_GET_ITEM(args, 3);
-  if (!(THPUtils_checkLong(_device) && THPUtils_checkLong(_size_bytes) &&
-        PyBytes_Check(_handle) && THPUtils_checkLong(_offset_bytes))) {
+    const bool is_dma_buf_tuple =
+      PyTuple_Check(_handle) && PyTuple_GET_SIZE(_handle) == 2 &&
+      THPUtils_checkLong(PyTuple_GET_ITEM(_handle, 0)) &&
+      THPUtils_checkLong(PyTuple_GET_ITEM(_handle, 1));
+
+    if (!(THPUtils_checkLong(_device) && THPUtils_checkLong(_size_bytes) &&
+      (PyBytes_Check(_handle) || THPUtils_checkLong(_handle) ||
+       is_dma_buf_tuple) &&
+      THPUtils_checkLong(_offset_bytes))) {
     THPUtils_invalidArguments(
         args,
         nullptr,
         "_new_shared in XPU mode",
         1,
-        "(int device, bytes handle, int storage_size_bytes, int storage_offset_bytes)");
+      "(int device, bytes|int|(int,int) handle, int storage_size_bytes, int storage_offset_bytes)");
     return nullptr;
   }
 
@@ -630,12 +653,23 @@ static PyObject* THPStorage_newSharedXpu(PyObject* _unused, PyObject* args) {
       THPUtils_unpackLong(_device), "c10::DeviceIndex");
   at::DeviceGuard device_guard(at::Device(at::kXPU, device));
 
-  char* handle_ptr = nullptr;
-  Py_ssize_t handle_size = 0;
-  if (PyBytes_AsStringAndSize(_handle, &handle_ptr, &handle_size) == -1) {
-    return nullptr;
+  std::string handle;
+  if (is_dma_buf_tuple) {
+    const auto fd = THPUtils_unpackLong(PyTuple_GET_ITEM(_handle, 0));
+    const auto alloc_size = THPUtils_unpackLong(PyTuple_GET_ITEM(_handle, 1));
+    handle = std::string("dmabuf:") + std::to_string(fd) + ":" +
+        std::to_string(alloc_size);
+  } else if (THPUtils_checkLong(_handle)) {
+    const auto fd = THPUtils_unpackLong(_handle);
+    handle = std::string("fd:") + std::to_string(fd);
+  } else {
+    char* handle_ptr = nullptr;
+    Py_ssize_t handle_size = 0;
+    if (PyBytes_AsStringAndSize(_handle, &handle_ptr, &handle_size) == -1) {
+      return nullptr;
+    }
+    handle = std::string(handle_ptr, static_cast<size_t>(handle_size));
   }
-  std::string handle(handle_ptr, static_cast<size_t>(handle_size));
 
   std::shared_ptr<void> base_ptr =
       c10::xpu::XPUCachingAllocator::getIpcDevPtr(std::move(handle), device);

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -569,7 +569,8 @@ static PyObject* THPStorage_shareXpu(PyObject* self, PyObject* noargs) {
   THPStorage_assertNotNull(self);
 #ifdef USE_XPU
   const auto& storage = THPStorage_Unpack(self);
-  TORCH_CHECK(storage.device_type() == at::kXPU, "_share_xpu_: only available on XPU");
+  TORCH_CHECK(
+      storage.device_type() == at::kXPU, "_share_xpu_: only available on XPU");
   at::DeviceGuard device_guard(storage.device());
 
   THPObjectPtr tuple(PyTuple_New(4));
@@ -583,27 +584,19 @@ static PyObject* THPStorage_shareXpu(PyObject* self, PyObject* noargs) {
     auto shandle =
         c10::xpu::XPUCachingAllocator::shareIpcHandle(storage.mutable_data());
 
-    if (shandle.is_fd) {
-      if (shandle.is_dma_buf) {
-        THPObjectPtr handle_tuple(PyTuple_New(2));
-        THPObjectPtr _fd(PyLong_FromLongLong(shandle.fd));
-        THPObjectPtr _alloc_size(PyLong_FromLongLong(shandle.alloc_size));
-        if (!handle_tuple || !_fd || !_alloc_size) {
-          return nullptr;
-        }
-        PyTuple_SET_ITEM(handle_tuple.get(), 0, _fd.release());
-        PyTuple_SET_ITEM(handle_tuple.get(), 1, _alloc_size.release());
-        _handle = handle_tuple.release();
-      } else {
-        _handle = PyLong_FromLongLong(shandle.fd);
-      }
-    } else {
-      _handle = PyBytes_FromStringAndSize(
-          shandle.handle.data(),
-          static_cast<Py_ssize_t>(shandle.handle.size()));
+    TORCH_CHECK(
+        shandle.is_fd && shandle.is_dma_buf,
+        "XPU IPC requires DMA-BUF handle export");
+    THPObjectPtr handle_tuple(PyTuple_New(2));
+    THPObjectPtr _fd(PyLong_FromLongLong(shandle.fd));
+    THPObjectPtr _alloc_size(PyLong_FromLongLong(shandle.alloc_size));
+    if (!handle_tuple || !_fd || !_alloc_size) {
+      return nullptr;
     }
-    _offset_bytes = PyLong_FromSsize_t(
-        static_cast<Py_ssize_t>(shandle.offset));
+    PyTuple_SET_ITEM(handle_tuple.get(), 0, _fd.release());
+    PyTuple_SET_ITEM(handle_tuple.get(), 1, _alloc_size.release());
+    _handle = handle_tuple.release();
+    _offset_bytes = PyLong_FromSsize_t(static_cast<Py_ssize_t>(shandle.offset));
   }
 
   if (!tuple || !device || !_handle || !size_bytes || !_offset_bytes) {
@@ -628,21 +621,19 @@ static PyObject* THPStorage_newSharedXpu(PyObject* _unused, PyObject* args) {
   PyObject* _handle = PyTuple_GET_ITEM(args, 1);
   PyObject* _size_bytes = PyTuple_GET_ITEM(args, 2);
   PyObject* _offset_bytes = PyTuple_GET_ITEM(args, 3);
-    const bool is_dma_buf_tuple =
-      PyTuple_Check(_handle) && PyTuple_GET_SIZE(_handle) == 2 &&
+  const bool is_dma_buf_tuple = PyTuple_Check(_handle) &&
+      PyTuple_GET_SIZE(_handle) == 2 &&
       THPUtils_checkLong(PyTuple_GET_ITEM(_handle, 0)) &&
       THPUtils_checkLong(PyTuple_GET_ITEM(_handle, 1));
 
-    if (!(THPUtils_checkLong(_device) && THPUtils_checkLong(_size_bytes) &&
-      (PyBytes_Check(_handle) || THPUtils_checkLong(_handle) ||
-       is_dma_buf_tuple) &&
-      THPUtils_checkLong(_offset_bytes))) {
+  if (!(THPUtils_checkLong(_device) && THPUtils_checkLong(_size_bytes) &&
+        is_dma_buf_tuple && THPUtils_checkLong(_offset_bytes))) {
     THPUtils_invalidArguments(
         args,
         nullptr,
         "_new_shared in XPU mode",
         1,
-      "(int device, bytes|int|(int,int) handle, int storage_size_bytes, int storage_offset_bytes)");
+        "(int device, (int,int) handle, int storage_size_bytes, int storage_offset_bytes)");
     return nullptr;
   }
 
@@ -653,23 +644,10 @@ static PyObject* THPStorage_newSharedXpu(PyObject* _unused, PyObject* args) {
       THPUtils_unpackLong(_device), "c10::DeviceIndex");
   at::DeviceGuard device_guard(at::Device(at::kXPU, device));
 
-  std::string handle;
-  if (is_dma_buf_tuple) {
-    const auto fd = THPUtils_unpackLong(PyTuple_GET_ITEM(_handle, 0));
-    const auto alloc_size = THPUtils_unpackLong(PyTuple_GET_ITEM(_handle, 1));
-    handle = std::string("dmabuf:") + std::to_string(fd) + ":" +
-        std::to_string(alloc_size);
-  } else if (THPUtils_checkLong(_handle)) {
-    const auto fd = THPUtils_unpackLong(_handle);
-    handle = std::string("fd:") + std::to_string(fd);
-  } else {
-    char* handle_ptr = nullptr;
-    Py_ssize_t handle_size = 0;
-    if (PyBytes_AsStringAndSize(_handle, &handle_ptr, &handle_size) == -1) {
-      return nullptr;
-    }
-    handle = std::string(handle_ptr, static_cast<size_t>(handle_size));
-  }
+  const auto fd = THPUtils_unpackLong(PyTuple_GET_ITEM(_handle, 0));
+  const auto alloc_size = THPUtils_unpackLong(PyTuple_GET_ITEM(_handle, 1));
+  std::string handle = std::string("dmabuf:") + std::to_string(fd) + ":" +
+      std::to_string(alloc_size);
 
   std::shared_ptr<void> base_ptr =
       c10::xpu::XPUCachingAllocator::getIpcDevPtr(std::move(handle), device);

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -584,9 +584,6 @@ static PyObject* THPStorage_shareXpu(PyObject* self, PyObject* noargs) {
     auto shandle =
         c10::xpu::XPUCachingAllocator::shareIpcHandle(storage.mutable_data());
 
-    TORCH_CHECK(
-        shandle.is_fd && shandle.is_dma_buf,
-        "XPU IPC requires DMA-BUF handle export");
     THPObjectPtr handle_tuple(PyTuple_New(2));
     THPObjectPtr _fd(PyLong_FromLongLong(shandle.fd));
     THPObjectPtr _alloc_size(PyLong_FromLongLong(shandle.alloc_size));

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -584,6 +584,9 @@ static PyObject* THPStorage_shareXpu(PyObject* self, PyObject* noargs) {
     auto shandle =
         c10::xpu::XPUCachingAllocator::shareIpcHandle(storage.mutable_data());
 
+    TORCH_CHECK(
+        shandle.is_fd && shandle.is_dma_buf,
+        "XPU IPC requires DMA-BUF handle export");
     THPObjectPtr handle_tuple(PyTuple_New(2));
     THPObjectPtr _fd(PyLong_FromLongLong(shandle.fd));
     THPObjectPtr _alloc_size(PyLong_FromLongLong(shandle.alloc_size));

--- a/torch/csrc/xpu/XPUPluggableAllocator.cpp
+++ b/torch/csrc/xpu/XPUPluggableAllocator.cpp
@@ -53,6 +53,23 @@ void XPUPluggableAllocator::raw_delete(void* ptr) {
   free_fn_(ptr, size, device_idx, queue);
 }
 
+c10::xpu::XPUCachingAllocator::ShareableHandle
+XPUPluggableAllocator::shareIpcHandle(void* ptr) {
+  TORCH_CHECK(
+      false,
+      "XPUPluggableAllocator does not yet support shareIpcHandle. "
+      "If you need it, please file an issue describing your use case.");
+}
+
+std::shared_ptr<void> XPUPluggableAllocator::getIpcDevPtr(
+    std::string handle,
+    c10::DeviceIndex device) {
+  TORCH_CHECK(
+      false,
+      "XPUPluggableAllocator does not yet support getIpcDevPtr. "
+      "If you need it, please file an issue describing your use case.");
+}
+
 void XPUPluggableAllocator::init(c10::DeviceIndex device_count) {
   if (init_fn_) {
     init_fn_(device_count);

--- a/torch/csrc/xpu/XPUPluggableAllocator.cpp
+++ b/torch/csrc/xpu/XPUPluggableAllocator.cpp
@@ -62,8 +62,10 @@ c10::xpu::XPUCachingAllocator::ShareableHandle XPUPluggableAllocator::
 }
 
 std::shared_ptr<void> XPUPluggableAllocator::getIpcDevPtr(
-    std::string handle,
+    const std::string& handle,
     c10::DeviceIndex device) {
+  (void)handle;
+  (void)device;
   TORCH_CHECK(
       false,
       "XPUPluggableAllocator does not yet support getIpcDevPtr. "

--- a/torch/csrc/xpu/XPUPluggableAllocator.cpp
+++ b/torch/csrc/xpu/XPUPluggableAllocator.cpp
@@ -53,8 +53,8 @@ void XPUPluggableAllocator::raw_delete(void* ptr) {
   free_fn_(ptr, size, device_idx, queue);
 }
 
-c10::xpu::XPUCachingAllocator::ShareableHandle
-XPUPluggableAllocator::shareIpcHandle(void* ptr) {
+c10::xpu::XPUCachingAllocator::ShareableHandle XPUPluggableAllocator::
+    shareIpcHandle(void* ptr) {
   TORCH_CHECK(
       false,
       "XPUPluggableAllocator does not yet support shareIpcHandle. "

--- a/torch/csrc/xpu/XPUPluggableAllocator.h
+++ b/torch/csrc/xpu/XPUPluggableAllocator.h
@@ -35,6 +35,11 @@ struct TORCH_PYTHON_API XPUPluggableAllocator
 
   void* raw_alloc(size_t nbytes) override;
   void raw_delete(void* ptr) override;
+    c10::xpu::XPUCachingAllocator::ShareableHandle shareIpcHandle(
+      void* ptr) override;
+    std::shared_ptr<void> getIpcDevPtr(
+      std::string handle,
+      c10::DeviceIndex device) override;
   void init(c10::DeviceIndex device_count) override;
   bool initialized() override;
   void copy_data(void* dest, const void* src, std::size_t count) const final;

--- a/torch/csrc/xpu/XPUPluggableAllocator.h
+++ b/torch/csrc/xpu/XPUPluggableAllocator.h
@@ -38,7 +38,7 @@ struct TORCH_PYTHON_API XPUPluggableAllocator
   c10::xpu::XPUCachingAllocator::ShareableHandle shareIpcHandle(
       void* ptr) override;
   std::shared_ptr<void> getIpcDevPtr(
-      std::string handle,
+      const std::string& handle,
       c10::DeviceIndex device) override;
   void init(c10::DeviceIndex device_count) override;
   bool initialized() override;

--- a/torch/csrc/xpu/XPUPluggableAllocator.h
+++ b/torch/csrc/xpu/XPUPluggableAllocator.h
@@ -35,9 +35,9 @@ struct TORCH_PYTHON_API XPUPluggableAllocator
 
   void* raw_alloc(size_t nbytes) override;
   void raw_delete(void* ptr) override;
-    c10::xpu::XPUCachingAllocator::ShareableHandle shareIpcHandle(
+  c10::xpu::XPUCachingAllocator::ShareableHandle shareIpcHandle(
       void* ptr) override;
-    std::shared_ptr<void> getIpcDevPtr(
+  std::shared_ptr<void> getIpcDevPtr(
       std::string handle,
       c10::DeviceIndex device) override;
   void init(c10::DeviceIndex device_count) override;

--- a/torch/multiprocessing/__init__.py
+++ b/torch/multiprocessing/__init__.py
@@ -20,10 +20,15 @@ import sys
 
 import torch
 
-from .reductions import init_reductions
+from .reductions import init_reductions, xpu_ipc_lock
 
 
-__all__ = ["set_sharing_strategy", "get_sharing_strategy", "get_all_sharing_strategies"]
+__all__ = [
+    "set_sharing_strategy",
+    "get_sharing_strategy",
+    "get_all_sharing_strategies",
+    "xpu_ipc_lock",
+]
 
 
 from multiprocessing import *  # noqa: F403

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -14,7 +14,7 @@ try:
     # from being inherited in a forked child process. The reduce_storage method
     # requires this module indirectly through DupFd(). The built-in mp.Queue
     # class pickles arguments in a background thread which may overlap with the
-    # forking process.
+    # fork.
     import multiprocessing.resource_sharer
 except ImportError:
     pass
@@ -690,17 +690,9 @@ def reduce_typed_storage_child(storage):
 def reduce_storage(storage):
     from . import get_sharing_strategy
 
-    privateuse1_backend_name = torch._C._get_privateuse1_backend_name()
-    privateuse1_like_device_types = {privateuse1_backend_name, "xpu"}
-
     if storage.is_cuda:
         raise RuntimeError(
             "Cannot pickle CUDA storage; try pickling a CUDA tensor instead"
-        )
-    elif storage.device.type in privateuse1_like_device_types:
-        raise RuntimeError(
-            f"Cannot pickle {storage.device.type.upper()} storage; "
-            f"try pickling a {storage.device.type.upper()} tensor instead"
         )
     elif storage.device.type == "meta":
         raise RuntimeError(

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -14,7 +14,7 @@ try:
     # from being inherited in a forked child process. The reduce_storage method
     # requires this module indirectly through DupFd(). The built-in mp.Queue
     # class pickles arguments in a background thread which may overlap with the
-    # fork.
+    # forking process.
     import multiprocessing.resource_sharer
 except ImportError:
     pass
@@ -234,11 +234,15 @@ def rebuild_xpu_tensor(
 ):
     if isinstance(storage_handle, tuple):
         storage_handle_list = list(storage_handle)
-        if storage_handle_list and hasattr(storage_handle_list[0], "detach"):
-            storage_handle_list[0] = storage_handle_list[0].detach()
+        if storage_handle_list:
+            detach = getattr(storage_handle_list[0], "detach", None)
+            if callable(detach):
+                storage_handle_list[0] = detach()
         storage_handle = tuple(storage_handle_list)
-    elif hasattr(storage_handle, "detach"):
-        storage_handle = storage_handle.detach()
+    else:
+        detach = getattr(storage_handle, "detach", None)
+        if callable(detach):
+            storage_handle = detach()
 
     if storage_handle is None or storage_size_bytes == 0:
         storage = storage_cls(0, dtype=dtype, device=storage_device, _internal=True)
@@ -453,22 +457,19 @@ def reduce_tensor(tensor):
             storage_offset_bytes,
         ) = storage._share_xpu_()
         tensor_offset = tensor.storage_offset()
-        cache_handle = handle
 
         if (
             isinstance(handle, tuple)
             and len(handle) == 2
             and isinstance(handle[0], int)
         ):
-            fd = os.dup(handle[0])
+            orig_fd = handle[0]
+            fd = os.dup(orig_fd)
             handle = (multiprocessing.reduction.DupFd(fd), handle[1])
         elif handle is not None:
             raise RuntimeError(
                 f"Unsupported XPU IPC handle type: {type(handle)!r}. Expected DMA-BUF tuple."
             )
-
-        if cache_handle is not None:
-            shared_cache[(cache_handle, storage_offset_bytes)] = StorageWeakRef(storage)
         return (
             rebuild_xpu_tensor,
             (

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -2,6 +2,7 @@
 import multiprocessing
 import os
 import threading
+import io
 from multiprocessing import reduction
 from multiprocessing.util import register_after_fork
 
@@ -219,6 +220,71 @@ def rebuild_cuda_tensor(
     return t
 
 
+def rebuild_xpu_tensor(
+    tensor_cls,
+    tensor_size,
+    tensor_stride,
+    tensor_offset,
+    storage_cls,
+    dtype,
+    storage_device,
+    storage_handle,
+    storage_size_bytes,
+    storage_offset_bytes,
+    requires_grad,
+):
+    if storage_handle is None or storage_size_bytes == 0:
+        storage = storage_cls(0, dtype=dtype, device=storage_device, _internal=True)
+    else:
+        cache_key = (storage_handle, storage_offset_bytes)
+        storage = storage_from_cache(storage_cls, cache_key)
+        if storage is None:
+            torch.xpu._lazy_init()
+            storage = storage_cls._new_shared_xpu(
+                storage_device,
+                storage_handle,
+                storage_size_bytes,
+                storage_offset_bytes,
+            )
+            shared_cache[cache_key] = StorageWeakRef(storage)
+
+    _storage = (
+        storage
+        if isinstance(storage, torch.UntypedStorage)
+        else storage._untyped_storage
+    )
+
+    t = torch._utils._rebuild_tensor(
+        torch.storage.TypedStorage(wrap_storage=_storage, dtype=dtype, _internal=True),
+        tensor_offset,
+        tensor_size,
+        tensor_stride,
+    )
+
+    if tensor_cls == torch.nn.parameter.Parameter:
+        t = torch.nn.parameter.Parameter(t, requires_grad=requires_grad)
+    else:
+        t.requires_grad = requires_grad
+
+    return t
+
+
+def rebuild_xpu_tensor_from_cpu(
+    tensor_cls,
+    cpu_tensor_bytes,
+    xpu_device,
+    requires_grad,
+):
+    cpu_buffer = io.BytesIO(cpu_tensor_bytes)
+    cpu_tensor = torch.load(cpu_buffer, map_location="cpu")
+    t = cpu_tensor.to(device=xpu_device)
+    if tensor_cls == torch.nn.parameter.Parameter:
+        t = torch.nn.parameter.Parameter(t, requires_grad=requires_grad)
+    else:
+        t.requires_grad = requires_grad
+    return t
+
+
 def reduce_tensor(tensor):
     if tensor.requires_grad and not tensor.is_leaf:
         raise RuntimeError(
@@ -385,6 +451,46 @@ def reduce_tensor(tensor):
                 tensor.storage_offset(),
                 tensor.dtype,
                 tensor.untyped_storage().size(),
+                tensor.requires_grad,
+            ),
+        )
+    elif storage._untyped_storage.device.type == "xpu":
+        if os.environ.get("TORCH_XPU_ENABLE_IPC", "0") != "1":
+            cpu_tensor = tensor.detach().to(device="cpu")
+            cpu_buffer = io.BytesIO()
+            torch.save(cpu_tensor, cpu_buffer)
+            return (
+                rebuild_xpu_tensor_from_cpu,
+                (
+                    type(tensor),
+                    cpu_buffer.getvalue(),
+                    tensor.device,
+                    tensor.requires_grad,
+                ),
+            )
+
+        (
+            device,
+            handle,
+            storage_size_bytes,
+            storage_offset_bytes,
+        ) = storage._share_xpu_()
+        tensor_offset = tensor.storage_offset()
+        if handle is not None:
+            shared_cache[(handle, storage_offset_bytes)] = StorageWeakRef(storage)
+        return (
+            rebuild_xpu_tensor,
+            (
+                type(tensor),
+                tensor.size(),
+                tensor.stride(),
+                tensor_offset,
+                type(storage),
+                tensor.dtype,
+                device,
+                handle,
+                storage_size_bytes,
+                storage_offset_bytes,
                 tensor.requires_grad,
             ),
         )
@@ -592,9 +698,17 @@ def reduce_typed_storage_child(storage):
 def reduce_storage(storage):
     from . import get_sharing_strategy
 
+    privateuse1_backend_name = torch._C._get_privateuse1_backend_name()
+    privateuse1_like_device_types = {privateuse1_backend_name, "xpu"}
+
     if storage.is_cuda:
         raise RuntimeError(
             "Cannot pickle CUDA storage; try pickling a CUDA tensor instead"
+        )
+    elif storage.device.type in privateuse1_like_device_types:
+        raise RuntimeError(
+            f"Cannot pickle {storage.device.type.upper()} storage; "
+            f"try pickling a {storage.device.type.upper()} tensor instead"
         )
     elif storage.device.type == "meta":
         raise RuntimeError(

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -3,6 +3,7 @@ import multiprocessing
 import os
 import threading
 import io
+import warnings
 from multiprocessing import reduction
 from multiprocessing.util import register_after_fork
 
@@ -96,6 +97,36 @@ class SharedCache(dict):
 
 # mapping from handles to StorageWeakRef objects
 shared_cache = SharedCache()
+
+_XPU_IPC_FALLBACK_WARNING_SHOWN = False
+
+
+def _reduce_xpu_tensor_via_cpu(tensor):
+    cpu_tensor = tensor.detach().to(device="cpu")
+    cpu_buffer = io.BytesIO()
+    torch.save(cpu_tensor, cpu_buffer)
+    return (
+        rebuild_xpu_tensor_from_cpu,
+        (
+            type(tensor),
+            cpu_buffer.getvalue(),
+            tensor.device,
+            tensor.requires_grad,
+        ),
+    )
+
+
+def _warn_xpu_ipc_fallback(error: Exception) -> None:
+    global _XPU_IPC_FALLBACK_WARNING_SHOWN
+    if _XPU_IPC_FALLBACK_WARNING_SHOWN:
+        return
+    _XPU_IPC_FALLBACK_WARNING_SHOWN = True
+    warnings.warn(
+        "XPU IPC sharing failed; falling back to CPU serialization for multiprocessing tensor transfer. "
+        f"Original error: {error!r}",
+        RuntimeWarning,
+        stacklevel=3,
+    )
 
 
 def rebuild_event(device, handle):
@@ -233,6 +264,14 @@ def rebuild_xpu_tensor(
     storage_offset_bytes,
     requires_grad,
 ):
+    if isinstance(storage_handle, tuple):
+        storage_handle_list = list(storage_handle)
+        if storage_handle_list and hasattr(storage_handle_list[0], "detach"):
+            storage_handle_list[0] = storage_handle_list[0].detach()
+        storage_handle = tuple(storage_handle_list)
+    elif hasattr(storage_handle, "detach"):
+        storage_handle = storage_handle.detach()
+
     if storage_handle is None or storage_size_bytes == 0:
         storage = storage_cls(0, dtype=dtype, device=storage_device, _internal=True)
     else:
@@ -455,45 +494,44 @@ def reduce_tensor(tensor):
             ),
         )
     elif storage._untyped_storage.device.type == "xpu":
-        if os.environ.get("TORCH_XPU_ENABLE_IPC", "0") != "1":
-            cpu_tensor = tensor.detach().to(device="cpu")
-            cpu_buffer = io.BytesIO()
-            torch.save(cpu_tensor, cpu_buffer)
-            return (
-                rebuild_xpu_tensor_from_cpu,
-                (
-                    type(tensor),
-                    cpu_buffer.getvalue(),
-                    tensor.device,
-                    tensor.requires_grad,
-                ),
-            )
-
-        (
-            device,
-            handle,
-            storage_size_bytes,
-            storage_offset_bytes,
-        ) = storage._share_xpu_()
-        tensor_offset = tensor.storage_offset()
-        if handle is not None:
-            shared_cache[(handle, storage_offset_bytes)] = StorageWeakRef(storage)
-        return (
-            rebuild_xpu_tensor,
+        try:
             (
-                type(tensor),
-                tensor.size(),
-                tensor.stride(),
-                tensor_offset,
-                type(storage),
-                tensor.dtype,
                 device,
                 handle,
                 storage_size_bytes,
                 storage_offset_bytes,
-                tensor.requires_grad,
-            ),
-        )
+            ) = storage._share_xpu_()
+            tensor_offset = tensor.storage_offset()
+            cache_handle = handle
+
+            if isinstance(handle, tuple) and len(handle) == 2 and isinstance(handle[0], int):
+                fd = os.dup(handle[0])
+                handle = (multiprocessing.reduction.DupFd(fd), handle[1])
+            elif isinstance(handle, int):
+                fd = os.dup(handle)
+                handle = multiprocessing.reduction.DupFd(fd)
+
+            if cache_handle is not None:
+                shared_cache[(cache_handle, storage_offset_bytes)] = StorageWeakRef(storage)
+            return (
+                rebuild_xpu_tensor,
+                (
+                    type(tensor),
+                    tensor.size(),
+                    tensor.stride(),
+                    tensor_offset,
+                    type(storage),
+                    tensor.dtype,
+                    device,
+                    handle,
+                    storage_size_bytes,
+                    storage_offset_bytes,
+                    tensor.requires_grad,
+                ),
+            )
+        except Exception as error:
+            _warn_xpu_ipc_fallback(error)
+            return _reduce_xpu_tensor_via_cpu(tensor)
 
     # _backward_hooks purposely omitted here, see Note [Don't serialize hooks]
     metadata = (

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -2,8 +2,6 @@
 import multiprocessing
 import os
 import threading
-import io
-import warnings
 from multiprocessing import reduction
 from multiprocessing.util import register_after_fork
 
@@ -97,36 +95,6 @@ class SharedCache(dict):
 
 # mapping from handles to StorageWeakRef objects
 shared_cache = SharedCache()
-
-_XPU_IPC_FALLBACK_WARNING_SHOWN = False
-
-
-def _reduce_xpu_tensor_via_cpu(tensor):
-    cpu_tensor = tensor.detach().to(device="cpu")
-    cpu_buffer = io.BytesIO()
-    torch.save(cpu_tensor, cpu_buffer)
-    return (
-        rebuild_xpu_tensor_from_cpu,
-        (
-            type(tensor),
-            cpu_buffer.getvalue(),
-            tensor.device,
-            tensor.requires_grad,
-        ),
-    )
-
-
-def _warn_xpu_ipc_fallback(error: Exception) -> None:
-    global _XPU_IPC_FALLBACK_WARNING_SHOWN
-    if _XPU_IPC_FALLBACK_WARNING_SHOWN:
-        return
-    _XPU_IPC_FALLBACK_WARNING_SHOWN = True
-    warnings.warn(
-        "XPU IPC sharing failed; falling back to CPU serialization for multiprocessing tensor transfer. "
-        f"Original error: {error!r}",
-        RuntimeWarning,
-        stacklevel=3,
-    )
 
 
 def rebuild_event(device, handle):
@@ -308,22 +276,6 @@ def rebuild_xpu_tensor(
     return t
 
 
-def rebuild_xpu_tensor_from_cpu(
-    tensor_cls,
-    cpu_tensor_bytes,
-    xpu_device,
-    requires_grad,
-):
-    cpu_buffer = io.BytesIO(cpu_tensor_bytes)
-    cpu_tensor = torch.load(cpu_buffer, map_location="cpu")
-    t = cpu_tensor.to(device=xpu_device)
-    if tensor_cls == torch.nn.parameter.Parameter:
-        t = torch.nn.parameter.Parameter(t, requires_grad=requires_grad)
-    else:
-        t.requires_grad = requires_grad
-    return t
-
-
 def reduce_tensor(tensor):
     if tensor.requires_grad and not tensor.is_leaf:
         raise RuntimeError(
@@ -494,44 +446,45 @@ def reduce_tensor(tensor):
             ),
         )
     elif storage._untyped_storage.device.type == "xpu":
-        try:
+        (
+            device,
+            handle,
+            storage_size_bytes,
+            storage_offset_bytes,
+        ) = storage._share_xpu_()
+        tensor_offset = tensor.storage_offset()
+        cache_handle = handle
+
+        if (
+            isinstance(handle, tuple)
+            and len(handle) == 2
+            and isinstance(handle[0], int)
+        ):
+            fd = os.dup(handle[0])
+            handle = (multiprocessing.reduction.DupFd(fd), handle[1])
+        elif handle is not None:
+            raise RuntimeError(
+                f"Unsupported XPU IPC handle type: {type(handle)!r}. Expected DMA-BUF tuple."
+            )
+
+        if cache_handle is not None:
+            shared_cache[(cache_handle, storage_offset_bytes)] = StorageWeakRef(storage)
+        return (
+            rebuild_xpu_tensor,
             (
+                type(tensor),
+                tensor.size(),
+                tensor.stride(),
+                tensor_offset,
+                type(storage),
+                tensor.dtype,
                 device,
                 handle,
                 storage_size_bytes,
                 storage_offset_bytes,
-            ) = storage._share_xpu_()
-            tensor_offset = tensor.storage_offset()
-            cache_handle = handle
-
-            if isinstance(handle, tuple) and len(handle) == 2 and isinstance(handle[0], int):
-                fd = os.dup(handle[0])
-                handle = (multiprocessing.reduction.DupFd(fd), handle[1])
-            elif isinstance(handle, int):
-                fd = os.dup(handle)
-                handle = multiprocessing.reduction.DupFd(fd)
-
-            if cache_handle is not None:
-                shared_cache[(cache_handle, storage_offset_bytes)] = StorageWeakRef(storage)
-            return (
-                rebuild_xpu_tensor,
-                (
-                    type(tensor),
-                    tensor.size(),
-                    tensor.stride(),
-                    tensor_offset,
-                    type(storage),
-                    tensor.dtype,
-                    device,
-                    handle,
-                    storage_size_bytes,
-                    storage_offset_bytes,
-                    tensor.requires_grad,
-                ),
-            )
-        except Exception as error:
-            _warn_xpu_ipc_fallback(error)
-            return _reduce_xpu_tensor_via_cpu(tensor)
+                tensor.requires_grad,
+            ),
+        )
 
     # _backward_hooks purposely omitted here, see Note [Don't serialize hooks]
     metadata = (

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -1,9 +1,16 @@
 # mypy: allow-untyped-defs
+import contextlib
 import multiprocessing
 import os
 import threading
 from multiprocessing import reduction
 from multiprocessing.util import register_after_fork
+
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 
 import torch
 from torch._namedtensor_internals import check_serializing_named_tensor
@@ -95,6 +102,121 @@ class SharedCache(dict):
 
 # mapping from handles to StorageWeakRef objects
 shared_cache = SharedCache()
+
+
+def _xpu_storage_cdata(storage) -> int:
+    untyped_storage = (
+        storage
+        if isinstance(storage, torch.UntypedStorage)
+        else storage._untyped_storage
+    )
+    return int(untyped_storage._cdata)
+
+
+def _create_xpu_ipc_lock_fd() -> int:
+    if hasattr(os, "memfd_create"):
+        fd = os.memfd_create("torch_xpu_ipc_lock", os.MFD_CLOEXEC)
+    else:
+        import tempfile
+
+        tmp = tempfile.NamedTemporaryFile(prefix="torch_xpu_ipc_lock_", delete=False)
+        try:
+            fd = os.open(tmp.name, os.O_RDWR)
+        finally:
+            tmp.close()
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+    os.ftruncate(fd, 1)
+    return fd
+
+
+class XpuIpcLockRegistry:
+    def __init__(self) -> None:
+        self._after_fork()
+        register_after_fork(self, XpuIpcLockRegistry._after_fork)
+
+    def _after_fork(self) -> None:
+        self._entries = {}
+        self._lock = threading.Lock()
+
+    def _prune_dead_locked(self) -> None:
+        for cdata, (lock_fd, storage_ref) in list(self._entries.items()):
+            if storage_ref.expired():
+                del self._entries[cdata]
+                os.close(lock_fd)
+
+    def _make_entry(self, storage, lock_fd: int) -> "tuple[int, StorageWeakRef]":
+        untyped_storage = (
+            storage
+            if isinstance(storage, torch.UntypedStorage)
+            else storage._untyped_storage
+        )
+        return (lock_fd, StorageWeakRef(untyped_storage))
+
+    def register_fd(self, storage, lock_fd) -> None:
+        if lock_fd is None:
+            return
+        cdata = _xpu_storage_cdata(storage)
+        fd_to_close = None
+        with self._lock:
+            self._prune_dead_locked()
+            existing = self._entries.get(cdata)
+            if existing is None:
+                self._entries[cdata] = self._make_entry(storage, lock_fd)
+                return
+            existing_fd, _ = existing
+            if existing_fd != lock_fd:
+                fd_to_close = lock_fd
+        if fd_to_close is not None:
+            os.close(fd_to_close)
+
+    def get_or_create_fd(self, storage) -> int:
+        cdata = _xpu_storage_cdata(storage)
+        with self._lock:
+            self._prune_dead_locked()
+            entry = self._entries.get(cdata)
+            if entry is None:
+                lock_fd = _create_xpu_ipc_lock_fd()
+                self._entries[cdata] = self._make_entry(storage, lock_fd)
+                return lock_fd
+            lock_fd, _ = entry
+            return lock_fd
+
+
+_xpu_ipc_lock_registry = XpuIpcLockRegistry()
+
+
+@contextlib.contextmanager
+def xpu_ipc_lock(tensor: torch.Tensor):
+    if tensor.device.type != "xpu":
+        yield
+        return
+
+    if fcntl is None:
+        raise RuntimeError("xpu_ipc_lock is only supported on platforms with fcntl")
+
+    untyped_storage = tensor.untyped_storage()
+    lock_fd = _xpu_ipc_lock_registry.get_or_create_fd(untyped_storage)
+    fcntl.lockf(lock_fd, fcntl.LOCK_EX)
+    try:
+        yield
+    finally:
+        fcntl.lockf(lock_fd, fcntl.LOCK_UN)
+
+
+def _detach_dupfd(handle: object) -> object:
+    detach = getattr(handle, "detach", None)
+    if callable(detach):
+        return detach()
+    return handle
+
+
+def _detach_lock_fd(lock_fd_handle: object) -> "int | None":
+    if lock_fd_handle is None:
+        return None
+    return int(_detach_dupfd(lock_fd_handle))
 
 
 def rebuild_event(device, handle):
@@ -231,18 +353,15 @@ def rebuild_xpu_tensor(
     storage_size_bytes,
     storage_offset_bytes,
     requires_grad,
+    lock_fd_handle,
 ):
     if isinstance(storage_handle, tuple):
-        storage_handle_list = list(storage_handle)
-        if storage_handle_list:
-            detach = getattr(storage_handle_list[0], "detach", None)
-            if callable(detach):
-                storage_handle_list[0] = detach()
-        storage_handle = tuple(storage_handle_list)
+        storage_handle = tuple(
+            _detach_dupfd(elem) if i == 0 else elem
+            for i, elem in enumerate(storage_handle)
+        )
     else:
-        detach = getattr(storage_handle, "detach", None)
-        if callable(detach):
-            storage_handle = detach()
+        storage_handle = _detach_dupfd(storage_handle)
 
     if storage_handle is None or storage_size_bytes == 0:
         storage = storage_cls(0, dtype=dtype, device=storage_device, _internal=True)
@@ -257,6 +376,7 @@ def rebuild_xpu_tensor(
                 storage_size_bytes,
                 storage_offset_bytes,
             )
+            torch.xpu.synchronize(storage_device)
             shared_cache[cache_key] = StorageWeakRef(storage)
 
     _storage = (
@@ -264,6 +384,8 @@ def rebuild_xpu_tensor(
         if isinstance(storage, torch.UntypedStorage)
         else storage._untyped_storage
     )
+    lock_fd = _detach_lock_fd(lock_fd_handle)
+    _xpu_ipc_lock_registry.register_fd(_storage, lock_fd)
 
     t = torch._utils._rebuild_tensor(
         torch.storage.TypedStorage(wrap_storage=_storage, dtype=dtype, _internal=True),
@@ -450,6 +572,9 @@ def reduce_tensor(tensor):
             ),
         )
     elif storage._untyped_storage.device.type == "xpu":
+        # Unlike CUDA, the sender does not populate shared_cache here. DMA-BUF
+        # handles are imported fresh on the receiver side, which caches via
+        # rebuild_xpu_tensor.
         (
             device,
             handle,
@@ -457,6 +582,8 @@ def reduce_tensor(tensor):
             storage_offset_bytes,
         ) = storage._share_xpu_()
         tensor_offset = tensor.storage_offset()
+        lock_fd = _xpu_ipc_lock_registry.get_or_create_fd(storage._untyped_storage)
+        lock_fd_handle = multiprocessing.reduction.DupFd(os.dup(lock_fd))
 
         if (
             isinstance(handle, tuple)
@@ -484,6 +611,7 @@ def reduce_tensor(tensor):
                 storage_size_bytes,
                 storage_offset_bytes,
                 tensor.requires_grad,
+                lock_fd_handle,
             ),
         )
 

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -185,11 +185,18 @@ class _StorageBase:
     def _share_cuda_(self, *args, **kwargs):
         raise NotImplementedError
 
+    def _share_xpu_(self, *args, **kwargs):
+        raise NotImplementedError
+
     def is_shared(self) -> _bool:
         raise NotImplementedError
 
     @classmethod
     def _new_shared_cuda(cls, *args, **kwargs) -> Self:
+        raise NotImplementedError
+
+    @classmethod
+    def _new_shared_xpu(cls, *args, **kwargs) -> Self:
         raise NotImplementedError
 
     def _shared_incref(self, *args, **kwargs):
@@ -1451,6 +1458,9 @@ class TypedStorage:
     def _share_cuda_(self, *args, **kwargs):
         return self._untyped_storage._share_cuda_(*args, **kwargs)
 
+    def _share_xpu_(self, *args, **kwargs):
+        return self._untyped_storage._share_xpu_(*args, **kwargs)
+
     def is_shared(self):
         _warn_typed_storage_removal()
         return self._is_shared()
@@ -1462,6 +1472,10 @@ class TypedStorage:
     @classmethod
     def _new_shared_cuda(cls, *args, **kwargs):
         return torch.UntypedStorage._new_shared_cuda(*args, **kwargs)
+
+    @classmethod
+    def _new_shared_xpu(cls, *args, **kwargs):
+        return torch.UntypedStorage._new_shared_xpu(*args, **kwargs)
 
     def _share_filename_cpu_(self, *args, **kwargs):
         (


### PR DESCRIPTION
Fixes: 
https://github.com/intel/torch-xpu-ops/issues/3000

This PR adds XPU storage sharing support for multiprocessing by exporting and importing XPU allocations through DMA-BUF-backed IPC handles.

The change adds the XPU allocator and storage-sharing plumbing needed to serialize a shareable XPU handle in one process and reopen the same device allocation in another process. It also updates the XPU tensor reduction path to use this handle flow consistently.

DMA-BUF support was required because the existing CPU shared-memory path does not apply to XPU device memory, and a raw CPU fallback would not preserve true device-backed sharing. To support inter-process sharing of real XPU allocations, we need an OS-visible handle that can be exported from Level Zero memory and imported back in another process. DMA-BUF provides that mechanism and fits the intended zero-copy IPC model for XPU memory.



The diagram shows the end-to-end flow of sharing an XPU tensor between two processes via a DMA-BUF:
```
┌──────────────────────────── Producer Process ──────────────────────────────┐
│  Tensor(XPU)                                                               │
│      │                                                                     │
│      ├─[Export]──> (device, (fd, alloc_size), storage_size, offset)        │
│      │             artifact: payload for serialization                     │
│      └─[Pack]────> dup(fd_orig) + wrap in transport handle (DupFd)         │
└───────────────────────┬────────────────────────────────────────────────────┘
                        │  fd ownership temporarily held by multiprocessing
                        ▼
┌──────────────────────────── Python MP Runtime ──────────────────────────────┐
│  queue / pickle + fd transfer                                                │
│  - keeps fd alive until child process starts                                 │
│  - passes: fd_transfer + alloc_size + storage metadata                       │
└───────────────────────┬─────────────────────────────────────────────────────┘
                        │
                        ▼
┌──────────────────────────── Consumer Process ───────────────────────────────┐
│  [Unpack] payload                                                            │
│      │                                                                       │
│      ├─[Import]──> XPU runtime import from fd_transfer + alloc_size         │
│      │             artifact: local dev ptr / storage base                    │
│      │             (+ cache: handle → dev ptr for reuse)                     │
│      ├─[Rebuild]   tensor view (offset / stride / shape)                     │
│      └─[Close]     fd after successful import                                │
└──────────────────────────────────────────────────────────────────────────────┘
```