### PR TITLE
[functorch] Skip flaky test_retain_grad_inside_transform under dynamo

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -3696,6 +3696,7 @@ class TestComposability(TestCase):
         with self.assertRaisesRegex(RuntimeError, "Tensor.requires_grad_()"):
             grad(grad(f))(x)
 
+    @skipIfTorchDynamo("test for eager functorch, flaky under dynamo")
     def test_retain_grad_inside_transform(self, device):
         def f(x):
             y = x.sin()


### PR DESCRIPTION
This test validates that `retain_grad()` raises `RuntimeError` inside functorch transforms (`grad`). It is an eager-mode functorch check and is orthogonal to dynamo compilation.

  Under the dynamo CI platform (`PYTORCH_TEST_WITH_DYNAMO=1`), the test method is wrapped with `torch._dynamo.optimize`, which traces the test body. Dynamo encounters `retain_grad()` during tracing, triggers a graph break (`unimplemented`), and falls back to eager execution where the C++ check properly raises the expected error. However, CI reports this
  as flaky (6 failures / 3 successes over 6 hours).

  Skip the test under dynamo since it tests eager functorch behavior, not dynamo compatibility. The eager-mode test continues to run and validate the behavior.

  Fixes #181013