### PR TITLE
[functorch] Skip flaky test_can_use_grad_when_key_is_excluded under dynamo

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -3888,6 +3888,7 @@ class TestComposability(TestCase):
             local_exclude_set = torch._C._dispatch_tls_local_exclude_set()
             self.assertTrue(local_exclude_set.has(DispatchKey.FuncTorchBatched))
 
+    @skipIfTorchDynamo("test for eager functorch, flaky under dynamo")
     def test_can_use_grad_when_key_is_excluded(self, device):
         def f(x):
             return x.sin()


### PR DESCRIPTION
This test validates that `grad()` works correctly when the Autograd dispatch key is excluded via `_ExcludeDispatchKeyGuard`. It is an eager-mode functorch check and is orthogonal to dynamo compilation.

  Under the dynamo CI platform (`PYTORCH_TEST_WITH_DYNAMO=1`), the test method is wrapped with `torch._dynamo.optimize`, which adds compilation overhead around low-level dispatch key manipulation. CI reports this as flaky (6 failures / 6 successes over 6 hours).

  Skip the test under dynamo since it tests eager functorch behavior, not dynamo compatibility. The eager-mode test continues to run and validate the behavior.

  Fixes https://github.com/pytorch/pytorch/issues/181155