### PR TITLE
trymerge: allowlist facebook-github-tools for skip_internal_checks

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -665,7 +665,10 @@ def can_skip_internal_checks(pr: GitHubPR, comment_id: int | None = None) -> boo
     comment = pr.get_comment_by_id(comment_id)
     if comment.editor_login is not None:
         return False
-    return comment.author_login == "facebook-github-bot"
+    if comment.author_login == "facebook-github-bot":
+        return True
+    # facebook-github-tools is a GitHub App; identify by its app URL.
+    return comment.author_url == "https://github.com/apps/facebook-github-tools"
 
 
 def _revlist_to_prs(


### PR DESCRIPTION
## Summary

`trymerge.py` aborts merges from `facebook-github-tools[bot]` when `has_internal_changes()` returns True, because `can_skip_internal_checks()` only recognizes the legacy `facebook-github-bot` user. This PR also allows `facebook-github-tools` to skip that guard (matched by app URL, the same pattern `validate_revert` uses at line 2041).

## Why most codev diffs land fine but some don't

`has_internal_changes()` (`.github/scripts/trymerge.py:1162`) is defined as:

```python
def has_internal_changes(self) -> bool:
    checkrun_name = INTERNAL_CHANGES_CHECKRUN_NAME  # "Meta Internal-Only Changes Check"
    if self.get_diff_revision() is None:
        return False
    checks = self.get_checkrun_conclusions()
    if checks is None or checkrun_name not in checks:
        return False
    return checks[checkrun_name].status != "SUCCESS"
```

So the guard only trips when the `Meta Internal-Only Changes Check` is in a non-success state.

In the **common codev flow** — Phab diff exported to a GitHub PR, diff lands internally, sync brings the PR up to date — `Meta Internal-Only Changes Check` concludes **SUCCESS** with title *"This Pull Request and its Phabricator Diff are identical"*. `has_internal_changes()` returns False and the guard is a no-op, so `facebook-github-tools[bot]`'s `@pytorchbot merge -i` lands without needing the skip. Example: [#181067](https://github.com/pytorch/pytorch/pull/181067).

In **edge cases** the check lands in `failure`. That's what's happening on [#179151](https://github.com/pytorch/pytorch/pull/179151) right now — the check fails with *"Reopening Pull Requests when an internal Diff was linked before landing (co-development) is not supported. Please create a new Pull Request."* `has_internal_changes()` returns True, and `facebook-github-tools[bot]` can't skip, so the bot has been stuck in a retry loop since ~12:27 UTC today. Historically a human unblocked this by stripping the `Differential Revision:` line to force `has_internal_changes()` to return False at the first `if` (e.g. [#177673](https://github.com/pytorch/pytorch/pull/177673)).

This PR closes that tail: when `Meta Internal-Only Changes Check` is non-success but the diff has already landed internally, the bot can proceed on its own.