### PR TITLE
[Bugfix] Fix triton crash in mixed device case for bmm

### DIFF
--- a/test/test_bmm_outer_product.py
+++ b/test/test_bmm_outer_product.py
@@ -80,6 +80,18 @@ class TestBmmOuterProduct(TestCase):
         self.assertEqual(a.grad.shape, a.shape)
         self.assertEqual(b.grad.shape, b.shape)
 
+    def test_cpu_outer_product_fallback(self):
+        a = torch.randn(4, 8, 1)
+        b = torch.randn(4, 1, 16)
+        self.assertTrue(a.device.type == "cpu")
+        self.assertEqual(torch.bmm(a, b), a @ b)
+
+    def test_mixed_device_outer_product_fallback(self):
+        a = torch.randn(4, 8, 1)
+        b = torch.randn(4, 1, 16, device=GPU_TYPE)
+        with self.assertRaises(RuntimeError):
+            torch.bmm(a, b)
+
 
 class TestOuterProductDetection(TestCase):
     def test_is_outer_product(self):

--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -35,7 +35,13 @@ def _bmm_outer_product_impl(
 ) -> torch.Tensor:
     a_is_cow = torch._C._is_cow_tensor(a)  # pyrefly: ignore[missing-attribute]
     b_is_cow = torch._C._is_cow_tensor(b)  # pyrefly: ignore[missing-attribute]
-    if _has_triton() and _is_outer_product(a, b) and not (a_is_cow or b_is_cow):
+    if (
+        _has_triton()
+        and a.is_cuda
+        and b.is_cuda
+        and _is_outer_product(a, b)
+        and not (a_is_cow or b_is_cow)
+    ):
         from .triton_kernels import bmm_outer_product
 
         return bmm_outer_product(a, b)


### PR DESCRIPTION
## Summary

Partial fix of https://github.com/pytorch/pytorch/issues/180909
   
PyTorch's bmm_outer_product Triton kernel override crashes with ValueError: Pointer argument cannot be accessed from Triton (cpu tensor?) when a non-CUDA tensor reaches the CUDA dispatch key handler. This happens in practice when transformers models have non-persistent CPU buffers (e.g. inv_freq in rotary embeddings) that get matmul'd with GPU tensors — the @ operator dispatches through the CUDA key, but the Triton kernel can't access the CPU pointer.                                                                                         

bmm_outer_product_impl guards on shape, Triton availability, and CoW status, but never checks that both inputs are actually on CUDA before dispatching to the Triton kernel. The fallback path (fallback_kernel.call_boxed) already exists and would handle this correctly (Runtime Error with descriptive failure), but the missing device guard means it's never reached so we add guards to check this

## Tests
  - test_mixed_device_outer_product_fallback: CPU + CUDA outer-product inputs now raise a clean RuntimeError (device mismatch) instead of a Triton pointer crash.
  - test_cpu_outer_product_fallback: Pure-CPU outer-product bmm produces correct results via the fallback path.                                                                          
