### PR TITLE
[torch] Fix duplicated-word typos in comments and docstrings

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -1394,7 +1394,7 @@ class FakeTensorMode(TorchDispatchMode):
 
         # [in_kernel_invocation]
         # when FakeTensor is invoked in user code, .device should return
-        # the fake_device of the tensor so that code such as as `if x.is_cuda`
+        # the fake_device of the tensor so that code such as `if x.is_cuda`
         # or torch.zeros([10, 10], device=x.device) continues to execute as if
         # the FakeTensor were real. However, within kernel execution, we return
         # the `Meta` device because all computation within the kernels should

--- a/torch/ao/quantization/fx/_model_report/detector.py
+++ b/torch/ao/quantization/fx/_model_report/detector.py
@@ -712,7 +712,7 @@ class DynamicStaticDetector(DetectorBase):
             model (GraphModule): The prepared and calibrated GraphModule with inserted ModelReportObservers
 
         Returns a tuple with two elements:
-            String report of of whether dynamic or static quantization is recommended for certain modules
+            String report of whether dynamic or static quantization is recommended for certain modules
             Dictionary mapping modules with ModelReportObservers around them to:
                 whether dynamic quantization is recommended
                 their S metric of input to module
@@ -1252,7 +1252,7 @@ class InputWeightEqualizationDetector(DetectorBase):
             model (GraphModule): The prepared and calibrated GraphModule with inserted ModelReportObservers
 
         Returns a tuple with two elements:
-            String report of of whether input weight equalization is recommended for certain modules
+            String report of whether input weight equalization is recommended for certain modules
             Dictionary mapping modules of interest to:
                 whether input weight equalization is recommended
                 their s_c metric compared to the threshold
@@ -1652,7 +1652,7 @@ class OutlierDetector(DetectorBase):
             model (GraphModule): The prepared and calibrated GraphModule with inserted ModelReportObservers
 
         Returns a tuple with two elements:
-            String report of of whether there are outliers in the activations around certain modules
+            String report of whether there are outliers in the activations around certain modules
             Dictionary mapping modules of interest to:
                 whether there were outliers found in activation before
                 the number of batches used for each channel

--- a/torch/distributed/_mesh_layout.py
+++ b/torch/distributed/_mesh_layout.py
@@ -111,7 +111,7 @@ class _FlatLayout:
         - The composition only generates indices that the left layout could originally produce,
           but the right layout determines which indices to be picked.
         - The stride of the composition layout will not be smaller than the stride of the right layout,
-          because when picking the indices the composition will at least follow the the right layout's stride
+          because when picking the indices the composition will at least follow the right layout's stride
           to move forward.
 
         Example:

--- a/torch/distributed/_tools/mem_tracker.py
+++ b/torch/distributed/_tools/mem_tracker.py
@@ -794,7 +794,7 @@ class MemTracker(TorchDispatchMode):
         This method should be called before the ``MemTracker`` is used. Any tensors that are not module parameters, buffers,
         gradients activations, or optimizer states will be categorized as ``Other``. If you want them categorized with a
         custom name, please file a GitHub issue. Any tensors created outside the MemTracker and not supplied to this
-        method will not be be tracked by ``MemTracker``.
+        method will not be tracked by ``MemTracker``.
 
         Args:
             *external (Union[nn.Module, optim.Optimizer, torch.Tensor]): The external modules, optimizers, and

--- a/torch/distributed/_tools/sac_estimator.py
+++ b/torch/distributed/_tools/sac_estimator.py
@@ -582,7 +582,7 @@ class SACEstimator(TorchDispatchMode):
         # recomputation time to total runtime incurred.
         delta = 1e-2
         tradeoff_curve = OrderedDict()
-        # 4. Initialize the trade-off curve with the stats of of already chosen recomputed_ops
+        # 4. Initialize the trade-off curve with the stats of already chosen recomputed_ops
         tradeoff_curve[(discarded_mem / sac_memory) + delta] = (
             recomp_runtime / sac_runtime
         )

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -1547,7 +1547,7 @@ def _allgather_orig_param_states(
     # flat_param (also sharded).
     # Then we perform an allgather_into_tensor to get the full flat_param state.
     # The full flat_param state is the result of concatenation of multiple states
-    # the order of of flat_param._fqns.
+    # the order of flat_param._fqns.
     # The final step is to split the flat_param state into original param states
     # and return the result.
     flat_param = fsdp_param_info.handle.flat_param

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -7862,7 +7862,7 @@ class ShapeEnv:
         fallback_value: bool | None = None,
     ) -> sympy.Basic:
         """
-        Given a a SymNode, evaluates sym_node.expr, adding guards if necessary.
+        Given a SymNode, evaluates sym_node.expr, adding guards if necessary.
         """
 
         self._expr_sym_node_id = id(sym_node)

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -299,7 +299,7 @@ def _lazy_init() -> None:
     if is_initialized() or hasattr(_tls, "is_initializing"):
         return
     with _initialization_lock:
-        # This test was was protected via GIL. Double-check whether XPU has
+        # This test was protected via GIL. Double-check whether XPU has
         # already been initialized.
         if is_initialized():
             return


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181260

Fix 10 instances of duplicated words (e.g., "of of" → "of", "the the" → "the",
"was was" → "was") across 8 files in the torch/ directory. Only comments,
docstrings, and string literals were changed — no code changes.

Authored with Claude.