### PR TITLE
[DCP] Forward FSDP process group to optimizer state-dict APIs

### DIFF
--- a/test/distributed/checkpoint/test_fsdp_optim_state.py
+++ b/test/distributed/checkpoint/test_fsdp_optim_state.py
@@ -6,6 +6,7 @@ import torch.distributed.checkpoint as dcp
 import torch.nn as nn
 from torch.distributed._shard.sharded_tensor.api import ShardedTensor
 from torch.distributed.checkpoint.optimizer import load_sharded_optimizer_state_dict
+from torch.distributed.checkpoint.state_dict import get_state_dict, set_state_dict
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
@@ -53,6 +54,57 @@ class FsdpOptimStateCheckpoint(DTensorTestBase):
     def backend(self):
         curr_backend = dist.get_default_backend_for_device(self.device_type)
         return f"cpu:gloo,{self.device_type}:{curr_backend}"
+
+    @skip_if_lt_x_gpu(2)
+    @with_comms
+    def test_get_set_state_dict_forwards_fsdp_process_group(self):
+        custom_pg = dist.new_group(ranks=list(range(self.world_size)))
+
+        model = self._create_model()
+        model = FSDP(model, process_group=custom_pg)
+        optim = torch.optim.Adam(model.parameters(), lr=0.1)
+
+        model(model.get_input()).sum().backward()
+        optim.step()
+        optim.zero_grad(set_to_none=True)
+
+        seen = {}
+        orig_save = FSDP.optim_state_dict
+        orig_load = FSDP.optim_state_dict_to_load
+
+        def wrapped_save(*args, **kwargs):
+            seen["save_group"] = kwargs.get("group")
+            return orig_save(*args, **kwargs)
+
+        def wrapped_load(*args, **kwargs):
+            seen["load_group"] = kwargs.get("group")
+            return orig_load(*args, **kwargs)
+
+        FSDP.optim_state_dict = staticmethod(wrapped_save)
+        FSDP.optim_state_dict_to_load = staticmethod(wrapped_load)
+
+        try:
+            model_state_dict, optim_state_dict = get_state_dict(model, optim)
+
+            model_2 = self._create_model()
+            model_2 = FSDP(model_2, process_group=custom_pg)
+            optim_2 = torch.optim.Adam(model_2.parameters(), lr=0.1)
+
+            set_state_dict(
+                model_2,
+                optim_2,
+                model_state_dict=model_state_dict,
+                optim_state_dict=optim_state_dict,
+            )
+
+            self.assertIn("save_group", seen)
+            self.assertIn("load_group", seen)
+            self.assertIs(seen["save_group"], custom_pg)
+            self.assertIs(seen["load_group"], custom_pg)
+        finally:
+            FSDP.optim_state_dict = staticmethod(orig_save)
+            FSDP.optim_state_dict_to_load = staticmethod(orig_load)
+            dist.destroy_process_group(custom_pg)
 
     @skip_if_lt_x_gpu(2)
     @with_comms

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -37,6 +37,9 @@ from torch.distributed.fsdp._common_utils import (
     _get_module_fsdp_state_if_fully_sharded_module,
     FSDP_WRAPPED_MODULE,
 )
+from torch.distributed.fsdp._init_utils import (
+    HYBRID_SHARDING_STRATEGIES
+)
 from torch.distributed.tensor import DTensor
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -456,12 +459,16 @@ def _get_fsdp_process_group(
     model: nn.Module, info: _StateDictInfo
 ) -> dist.ProcessGroup | None:
     if isinstance(model, FSDP):
-        process_group = model.process_group
+        fsdp_module = model
     elif info.fsdp_modules:
-        process_group = cast(FSDP, info.fsdp_modules[0]).process_group
+        fsdp_module = cast(FSDP, info.fsdp_modules[0])
     else:
         return None
 
+    if fsdp_module.sharding_strategy in HYBRID_SHARDING_STRATEGIES:
+        return None
+
+    process_group = fsdp_module.process_group
     if isinstance(process_group, tuple):
         return None
     return process_group

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -37,9 +37,7 @@ from torch.distributed.fsdp._common_utils import (
     _get_module_fsdp_state_if_fully_sharded_module,
     FSDP_WRAPPED_MODULE,
 )
-from torch.distributed.fsdp._init_utils import (
-    HYBRID_SHARDING_STRATEGIES
-)
+from torch.distributed.fsdp._init_utils import HYBRID_SHARDING_STRATEGIES
 from torch.distributed.tensor import DTensor
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.nn.parallel import DistributedDataParallel as DDP

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -452,6 +452,21 @@ def _state_dict_fn(obj: nn.Module | torch.optim.Optimizer, api: str) -> Callable
     return call
 
 
+def _get_fsdp_process_group(
+    model: nn.Module, info: _StateDictInfo
+) -> dist.ProcessGroup | None:
+    if isinstance(model, FSDP):
+        process_group = model.process_group
+    elif info.fsdp_modules:
+        process_group = cast(FSDP, info.fsdp_modules[0]).process_group
+    else:
+        return None
+
+    if isinstance(process_group, tuple):
+        return process_group[0]
+    return process_group
+
+
 def _maybe_full_or_cpu_state_dict(
     state_dict: dict[str, Any], info: _StateDictInfo
 ) -> dict[str, Any]:
@@ -897,7 +912,12 @@ def _get_optim_state_dict(
         osd = _state_dict_fn(optim, "state_dict")()
         if info.fsdp_modules:
             with info.fsdp_context():
-                osd = FSDP.optim_state_dict(model, optim, osd)
+                osd = FSDP.optim_state_dict(
+                    model,
+                    optim,
+                    osd,
+                    group=_get_fsdp_process_group(model, info),
+                )
 
             # We need to specially handle FlatParameter FSDP as
             # FlatParameter FSDP converts the FQNs.
@@ -1107,7 +1127,10 @@ def _load_optim_state_dict(
 
             with info.fsdp_context():
                 optim_state_dict = FSDP.optim_state_dict_to_load(
-                    model, optim, optim_state_dict
+                    model,
+                    optim,
+                    optim_state_dict,
+                    group=_get_fsdp_process_group(model, info),
                 )
         elif info.full_state_dict:
             info.full_state_dict = False

--- a/torch/distributed/checkpoint/state_dict.py
+++ b/torch/distributed/checkpoint/state_dict.py
@@ -463,7 +463,7 @@ def _get_fsdp_process_group(
         return None
 
     if isinstance(process_group, tuple):
-        return process_group[0]
+        return None
     return process_group
 
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in `torch.distributed.checkpoint.state_dict` where
`FSDP.optim_state_dict` and `FSDP.optim_state_dict_to_load` are called
without forwarding the FSDP process group.

For FSDP models initialized with a non-default process group, this can
cause optimizer state-dict save/load to use the wrong group.

## Changes

- add a small helper to retrieve the FSDP process group from the wrapped model
- forward that group into `FSDP.optim_state_dict`
- forward that group into `FSDP.optim_state_dict_to_load`
- add a regression test covering `get_state_dict` / `set_state_dict` with a custom FSDP process group

## Note on tuple process groups

In the tuple process-group case, this PR currently forwards `process_group[0]`.
The target FSDP optimizer state-dict APIs take a single `group` argument, so
this keeps the fix local and preserves the existing call structure. I’m happy
to adjust this if a different group is preferred for tuple-based configurations.

## Test Plan

- added a regression test covering `get_state_dict` / `set_state_dict`
  with a custom FSDP process group

Fixes #180449