### PR TITLE
Show node.meta["custom"]["stream"] in Graph.__str__

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1373,6 +1373,30 @@ class TestFX(JitTestCase):
                 f"Expected 2 occurrences of '_torch__ops_aten_aten_relu_', got {count}"
             )
 
+    def test_print_graph_stream_annotation(self):
+        op = torch.ops.aten.relu.default
+
+        graph = torch.fx.Graph()
+        x = graph.create_node("placeholder", "x")
+        with_stream = graph.create_node("call_function", op, (x,))
+        with_stream.meta["custom"] = {"stream": 2}
+        without_stream = graph.create_node("call_function", op, (with_stream,))
+        graph.output(without_stream)
+        graph.lint()
+
+        text = str(graph)
+        with_stream_line = next(
+            line for line in text.splitlines() if f"%{with_stream.name} " in line
+        )
+        without_stream_line = next(
+            line for line in text.splitlines() if f"%{without_stream.name} " in line
+        )
+        self.assertTrue(
+            with_stream_line.rstrip().endswith(", stream=2)"),
+            with_stream_line,
+        )
+        self.assertNotIn("stream=", without_stream_line)
+
     def test_print_readable_no_trailing_whitespace_with_inner_graph(self):
         # When a GraphModule has a child GraphModule (e.g., from invoke_subgraph),
         # print_readable() should not produce lines with trailing whitespace.

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1391,11 +1391,13 @@ class TestFX(JitTestCase):
         without_stream_line = next(
             line for line in text.splitlines() if f"%{without_stream.name} " in line
         )
+        # Graph.__str__ mirrors GraphModule.print_readable: node.meta["custom"]
+        # is rendered as a trailing "# Annotation: {...}" comment.
         self.assertTrue(
-            with_stream_line.rstrip().endswith(", stream=2)"),
+            with_stream_line.rstrip().endswith("# Annotation: {'stream': 2}"),
             with_stream_line,
         )
-        self.assertNotIn("stream=", without_stream_line)
+        self.assertNotIn("Annotation", without_stream_line)
 
     def test_print_readable_no_trailing_whitespace_with_inner_graph(self):
         # When a GraphModule has a child GraphModule (e.g., from invoke_subgraph),

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -683,10 +683,15 @@ class Node(_NodeBase):
                 type_annotation = (
                     f"{_type_repr(self.type)} " if self.type is not None else ""
                 )
+            stream_annotation = ""
+            custom = self.meta.get("custom")
+            if isinstance(custom, dict) and "stream" in custom:
+                stream_annotation = f", stream={custom['stream']}"
             return (
                 f"%{self.name} : {type_annotation}[num_users={len(self.users)}] = "
                 f"{self.op}[target={self._pretty_print_target(self.target)}]("
-                f"args = {_format_arg(self.args)}, kwargs = {_format_arg(self.kwargs)})"
+                f"args = {_format_arg(self.args)}, kwargs = {_format_arg(self.kwargs)}"
+                f"{stream_annotation})"
             )
 
     @compatibility(is_backward_compatible=True)

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -683,15 +683,26 @@ class Node(_NodeBase):
                 type_annotation = (
                     f"{_type_repr(self.type)} " if self.type is not None else ""
                 )
-            stream_annotation = ""
+            # Surface node.meta["custom"] annotations (e.g. the assigned stream)
+            # the same way GraphModule.print_readable does -- see the
+            # "Annotation: {...}" rendering in torch/fx/graph.py -- so that
+            # print(gm.graph) and print_readable() show the same information,
+            # with long values truncated identically.
+            annotation_str = ""
             custom = self.meta.get("custom")
-            if isinstance(custom, dict) and "stream" in custom:
-                stream_annotation = f", stream={custom['stream']}"
+            if isinstance(custom, dict) and custom:
+                annotation_trunc = {}
+                for key, value in custom.items():
+                    value_str = str(value)
+                    annotation_trunc[key] = (
+                        value_str[:40] + "..." if len(value_str) > 40 else value
+                    )
+                annotation_str = f"  # Annotation: {annotation_trunc}"
             return (
                 f"%{self.name} : {type_annotation}[num_users={len(self.users)}] = "
                 f"{self.op}[target={self._pretty_print_target(self.target)}]("
-                f"args = {_format_arg(self.args)}, kwargs = {_format_arg(self.kwargs)}"
-                f"{stream_annotation})"
+                f"args = {_format_arg(self.args)}, kwargs = {_format_arg(self.kwargs)})"
+                f"{annotation_str}"
             )
 
     @compatibility(is_backward_compatible=True)


### PR DESCRIPTION
print(gm.graph) does not currently surface stream annotations -- that information lives in node.meta["custom"]["stream"] and is only visible via gm.print_readable(), which emits it as a separate `# Annotation: {'stream': N}` comment line.

Extend Node.format_node (which `Graph.__str__` delegates to) so that call_* nodes with a custom stream metadata. This mimics the `print_readable` format.

Authored with Claude.