### PR TITLE
[PT2] Fix predispatch function serialization in torch.export save/load (#181263)

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -814,8 +814,6 @@ class TestExport(TestCase):
                 self.assertTrue("custom" in node.meta)
                 self.assertTrue(node.meta["custom"] != {})
 
-    @testing.expectedFailureSerDer  # can't serialize functorch ops
-    @testing.expectedFailureSerDerNonStrict  # can't serialize functorch ops
     def test_vmap_to_assert(self):
         class VmapToAssert(torch.nn.Module):
             def forward(self, x, y):
@@ -3747,8 +3745,6 @@ graph():
         res = ep.module()(ref_x)
         self.assertEqual(res, ref_out)
 
-    @testing.expectedFailureSerDer  # can't serialize functorch ops
-    @testing.expectedFailureSerDerNonStrict  # can't serialize functorch ops
     @testing.expectedFailureCppRuntime
     def test_vmap(self):
         class Vmap(torch.nn.Module):

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -2541,5 +2541,95 @@ def forward(self, x):
         self.assertEqual(shape_env.var_to_range[s0.node.expr].lower, 0)
 
 
+@unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")
+class TestPredispatchSerialization(TestCase):
+    def test_predispatch_jvp_serialize_roundtrip(self):
+        """Test that JVP predispatch wrapper functions survive serialization round-trip."""
+        from torch._functorch.predispatch import (
+            _jvp_decrement_nesting,
+            _jvp_increment_nesting,
+        )
+
+        class JVP(torch.nn.Module):
+            def foo(self, x, r, t) -> torch.Tensor:
+                return x - 0.1 * r + 0.1 * t
+
+            def forward(self, x, y, r, t, z, o) -> tuple[torch.Tensor, torch.Tensor]:
+                return torch.func.jvp(
+                    self.foo,
+                    (x, r, t),
+                    (y, z, o),
+                )
+
+        inp = (
+            torch.rand(2, 4),
+            torch.rand(2, 4),
+            torch.rand(2, 1),
+            torch.rand(2, 1),
+            torch.zeros(2, 1),
+            torch.ones(2, 1),
+        )
+
+        ep = export(JVP(), inp, strict=False)
+
+        graph_str = str(ep.graph)
+        self.assertIn("_jvp_increment_nesting", graph_str)
+        self.assertIn("_jvp_decrement_nesting", graph_str)
+
+        buffer = io.BytesIO()
+        torch.export.save(ep, buffer)
+        buffer.seek(0)
+        loaded_ep = torch.export.load(buffer)
+
+        loaded_graph_str = str(loaded_ep.graph)
+        self.assertIn("_jvp_increment_nesting", loaded_graph_str)
+        self.assertIn("_jvp_decrement_nesting", loaded_graph_str)
+
+        # Verify the deserialized targets are the actual functions
+        for node in loaded_ep.graph.nodes:
+            if node.op == "call_function":
+                if "increment" in node.name:
+                    self.assertIs(node.target, _jvp_increment_nesting)
+                elif "decrement" in node.name:
+                    self.assertIs(node.target, _jvp_decrement_nesting)
+
+        exp_out = ep.module()(*inp)
+        actual_out = loaded_ep.module()(*inp)
+        self.assertTrue(torch.allclose(exp_out[0], actual_out[0]))
+        self.assertTrue(torch.allclose(exp_out[1], actual_out[1]))
+
+    def test_predispatch_vmap_serialize_roundtrip(self):
+        """Test that vmap predispatch wrapper functions survive serialization round-trip."""
+        from torch.export._trace import _export
+
+        class Vmap(torch.nn.Module):
+            def forward(self, x, y):
+                f = lambda x, y: (x * y + 1).sum(dim=0)  # noqa: E731
+                return torch.vmap(f)(x, y).sum(dim=0)
+
+        inp = (torch.tensor([1.0, 2.0, 3.0]), torch.tensor([0.1, 0.2, 0.3]))
+
+        ep = _export(Vmap(), inp, pre_dispatch=True)
+
+        # Verify predispatch vmap nodes are in the graph
+        graph_str = str(ep.graph)
+        self.assertIn("_vmap_increment_nesting", graph_str)
+        self.assertIn("_vmap_decrement_nesting", graph_str)
+
+        buffer = io.BytesIO()
+        torch.export.save(ep, buffer)
+        buffer.seek(0)
+        loaded_ep = torch.export.load(buffer)
+
+        # Verify predispatch nodes survive round-trip
+        loaded_graph_str = str(loaded_ep.graph)
+        self.assertIn("_vmap_increment_nesting", loaded_graph_str)
+        self.assertIn("_vmap_decrement_nesting", loaded_graph_str)
+
+        exp_out = ep.module()(*inp)
+        actual_out = loaded_ep.module()(*inp)
+        self.assertTrue(torch.allclose(exp_out, actual_out))
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1021,6 +1021,16 @@ class GraphModuleSerializer(metaclass=Final):
                 outputs=self.serialize_outputs(node),
                 metadata=self.serialize_metadata(node),
             )
+        elif callable(node.target):
+            # Handle predispatch wrapper functions (vmap, JVP, etc.) that appear
+            # as plain Python function call_function nodes in pre_dispatch graphs.
+            ex_node = Node(
+                name=node.name,
+                target=self.serialize_operator(node.target),
+                inputs=self.serialize_hoo_inputs(node.args, node.kwargs),
+                outputs=self.serialize_hoo_outputs(node),
+                metadata=self.serialize_metadata(node),
+            )
         else:
             raise SerializeError(f"Serializing {node.target} is not supported")
 
@@ -1963,7 +1973,7 @@ class GraphModuleSerializer(metaclass=Final):
                 # When the return type is annotated as Tensor type, the op can also return an
                 # undefined Tensor which will be implicitly converted to None in Python.
                 output_arguments.append(Argument.create(as_none=True))
-            elif isinstance(meta, FakeTensor):
+            elif isinstance(meta, torch.Tensor):
                 if not isinstance(
                     return_schema.real_type, (torch.OptionalType, torch.TensorType)
                 ):
@@ -2696,6 +2706,14 @@ class GraphModuleDeserializer(metaclass=Final):
                 )
 
             args, kwargs = self.deserialize_inputs(target, serialized_node)
+            fx_node = self.graph.create_node(
+                "call_function", target, args, kwargs, name
+            )
+            self.deserialize_outputs(serialized_node, fx_node)
+        elif callable(target):
+            # Handle predispatch wrapper functions (vmap, JVP, etc.)
+            args, kwargs = self.deserialize_hoo_inputs(serialized_node.inputs)
+            name = serialized_node.name if serialized_node.name else None
             fx_node = self.graph.create_node(
                 "call_function", target, args, kwargs, name
             )


### PR DESCRIPTION
Summary:

Fix serialization of predispatch wrapper functions (JVP, vmap) that appear as
`call_function` nodes with plain Python callable targets in pre_dispatch export
graphs.

Two bugs fixed:
1. **Callable target not serialized**: `handle_call_function` only handled
   `OpOverload` and `HigherOrderOperator` targets. Predispatch wrapper functions
   like `_jvp_increment_nesting` are plain callables that fell through to
   `ValueError`. Added `elif callable(node.target)` branch using
   `serialize_hoo_inputs`/`serialize_hoo_outputs`.
2. **_unpack_dual output type too strict**: `serialize_outputs` checked
   `isinstance(meta, FakeTensor)` for multi-return ops, but `_unpack_dual`
   (from JVP decomposition) has `torch.Tensor` in `node.meta["val"]`.
   Changed to `isinstance(meta, torch.Tensor)` since FakeTensor is a subclass.

Key insight: `torch.export.export()` always passes `pre_dispatch=True`
internally, so predispatch wrapper nodes appear in ALL export graphs. Models
using `torch.func.jvp` (e.g., MeanFlowLoss with `use_jvp_func=True`) produce
these nodes.

Test Plan:
- Added `TestPredispatchSerialization` with JVP and vmap round-trip tests
- `buck run fbcode//caffe2/test:test_serialize -- -k TestPredispatchSerialization`
- IR dry run WF 1065020129: 4/4 GPU children COMPLETED (no serialization errors)

Differential Revision: D100484916


