### PR TITLE
Fix duplicate word typos across the codebase

### DIFF
--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -334,7 +334,7 @@ qconfig.
     * This qconfig uses signed activations and weights. Weights have added
     restrictions such as zero point is forced to be 0, making the weights
     symmetric, hence the name. And the 8-bit quantized values are
-    restricting to to [-127, +127], excluding -128.
+    restricting to [-127, +127], excluding -128.
 
     * xnnpack has a requantization scale value restriction, 0x1p-32 <=
     requantization_scale < 256.0 where, `requantization_scale = (input_scale

--- a/torch/csrc/autograd/node.h
+++ b/torch/csrc/autograd/node.h
@@ -341,7 +341,7 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
   ///    be executed in the backward pass. One caveat is that we prioritize
   ///    AccumulateGrad nodes by explicitly setting its sequence_nr to be
   ///    UINT64_MAX.
-  /// 2) The sequence number of this `Node` is paired with with thread_id it was
+  /// 2) The sequence number of this `Node` is paired with thread_id it was
   /// created in
   ///    as a unique identifier by the profiler to annotate recorded events.
   ///    The purpose of this is to help users (and possibly programs)

--- a/torch/csrc/distributed/c10d/socket.cpp
+++ b/torch/csrc/distributed/c10d/socket.cpp
@@ -191,7 +191,7 @@ class SocketImpl {
 };
 
 std::string formatSockAddr(const struct ::sockaddr* addr, socklen_t len) {
-  // It can be be very slow to repeatedly hit DNS resolution failure, but its
+  // It can be very slow to repeatedly hit DNS resolution failure, but its
   // very helpful to have DNS names in logs by default. So we try to use DNS but
   // if we hit a transient failure we just disable it for the remainder of the
   // job, logging IP addresses instead. See

--- a/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/intra_node_comm.hpp
@@ -26,7 +26,7 @@ enum class AllReduceAlgo : uint8_t {
   TWO_SHOT = 2,
 };
 
-// NOTE: this class will be be removed soon in favor of SymmetricMemory
+// NOTE: this class will be removed soon in favor of SymmetricMemory
 class TORCH_API IntraNodeComm : public c10::intrusive_ptr_target {
  public:
   IntraNodeComm(

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -127,7 +127,7 @@ std::shared_ptr<SugaredValue> PythonValue::call(
   MatchedSchema matched_schema =
       matchSchema(schema, loc, *m.graph(), argsWithSelf, kwargs);
 
-  // If if a function is marked as dropped,
+  // If a function is marked as dropped,
   // we throw an exception if it is invoked.
   if (py::cast<bool>(py::module::import("torch._jit_internal")
                          .attr("should_drop")(self))) {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1276,7 +1276,7 @@ Tensor TensorExprKernel::convertSymbolicOutputToCorrectStrides(
   // `val` we want here is equal to the indices for the output
   // tensor that would have given the same position as the output
   // The position is equal to the sum of stride[i] * index[i],
-  // and we can can calculate the equivalent indices in the
+  // and we can calculate the equivalent indices in the
   // output tensor strides by iteratively computing the index of
   // the biggest stride:
   // absolute = ...

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -118,7 +118,7 @@ class PythonKernelHolder : public c10::OperatorKernel {
     const auto& schema = op.schema();
     const auto num_arguments = schema.arguments().size();
 
-    // Otherwise, find a PyInterpreter on a Tensor IF if has Python key (which
+    // Otherwise, find a PyInterpreter on a Tensor if it has Python key (which
     // means it's a nontrivial tensor subclass)
     for (const auto& ivalue : torch::jit::last(*stack, num_arguments)) {
       if (ivalue.isTensor()) {

--- a/torch/jit/_shape_functions.py
+++ b/torch/jit/_shape_functions.py
@@ -1330,7 +1330,7 @@ def cross_entropy_loss(
 Currently deferring the enabling of this, as part of the propoasal to suspend
 adding ops.
 There are currently cases in the test case where this is being called
-in the SSA opinfo tests with with unexpected values (eg list of two ints, see the first
+in the SSA opinfo tests with unexpected values (eg list of two ints, see the first
 opinfo test). The behavior of index is significantly dependent on the inputs.
 
 This could be an error with how we are matching up shape functions, or that this


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181268

Remove accidental repeated words ("to to", "be be", "with with", "can can",
"If if") in comments, docstrings, and string literals across multiple files
in torch core, JIT, distributed, autograd, and quantization.

Authored with Claude (typo_terminator2).

cc @EikanWang @jgong5