### PR TITLE
[BE] Drop unused CUDA 12.8 and ROCm 7.0 Docker image builds

### DIFF
--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: linux.9xlarge.ephemeral
     strategy:
       matrix:
-        tag: ["cuda12.6", "cuda12.8", "cuda13.0", "cuda13.2", "rocm7.0", "rocm7.1", "rocm7.2", "cpu"]
+        tag: ["cuda12.6", "cuda13.0", "cuda13.2", "rocm7.1", "rocm7.2", "cpu"]
     steps:
       - name: Build docker image
         uses: pytorch/pytorch/.github/actions/binary-docker-build@main

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -48,13 +48,10 @@ jobs:
         include: [
           { name: "manylinux2_28-builder",          tag: "cuda13.2",          runner: "linux.9xlarge.ephemeral" },
           { name: "manylinux2_28-builder",          tag: "cuda13.0",          runner: "linux.9xlarge.ephemeral" },
-          { name: "manylinux2_28-builder",          tag: "cuda12.8",          runner: "linux.9xlarge.ephemeral" },
           { name: "manylinux2_28-builder",          tag: "cuda12.6",          runner: "linux.9xlarge.ephemeral" },
           { name: "manylinuxaarch64-builder",       tag: "cuda13.2",          runner: "linux.arm64.m7g.4xlarge.ephemeral" },
           { name: "manylinuxaarch64-builder",       tag: "cuda13.0",          runner: "linux.arm64.m7g.4xlarge.ephemeral" },
-          { name: "manylinuxaarch64-builder",       tag: "cuda12.8",          runner: "linux.arm64.m7g.4xlarge.ephemeral" },
           { name: "manylinuxaarch64-builder",       tag: "cuda12.6",          runner: "linux.arm64.m7g.4xlarge.ephemeral" },
-          { name: "manylinux2_28-builder",          tag: "rocm7.0",           runner: "linux.9xlarge.ephemeral" },
           { name: "manylinux2_28-builder",          tag: "rocm7.1",           runner: "linux.9xlarge.ephemeral" },
           { name: "manylinux2_28-builder",          tag: "rocm7.2",           runner: "linux.9xlarge.ephemeral" },
           { name: "manylinux2_28-builder",          tag: "cpu",               runner: "linux.9xlarge.ephemeral" },


### PR DESCRIPTION
 ## Summary                                                         

  - Remove cuda12.8 rows (x86_64 + aarch64) and the rocm7.0 row from                                 
  .github/workflows/build-manywheel-images.yml.
  - Drop cuda12.8 and rocm7.0 from the tag matrix in .github/workflows/build-almalinux-images.yml.   
                                                                                                     
  Neither tag is referenced by any downstream consumer — generate_binary_build_matrix.py pins        
  CUDA_ARCHES = ["12.6", "13.0", "13.2"] and ROCM_ARCHES = ["7.1", "7.2"], so these image builds were
   producing tags that no binary/manywheel/test job pulls. Removing them cuts wasted Docker build    
  cost with no behavior change.                                   

 ## Test plan

  - build-manywheel-images workflow builds only tags that appear in MANYWHEEL_CONTAINER_IMAGES /     
  CUDA_ARCHES / ROCM_ARCHES.
  - build-almalinux-images workflow matrix matches the active CUDA/ROCm sets.                        
  - Verify no workflow in .github/workflows/ still references :cuda12.8 or :rocm7.0 after the change.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang