### PR TITLE
[ROCm] fix issue #168635; remove dead quantization code from test_mkldnn_pattern_matcher.py

### DIFF
--- a/test/inductor/test_mkldnn_pattern_matcher.py
+++ b/test/inductor/test_mkldnn_pattern_matcher.py
@@ -151,13 +151,8 @@ class TestPatternMatcherBase(TestCase):
         atol=1e-5,
         rtol=1.3e-6,
         check_autocast=torch.float32,
-        check_quantization=False,
-        is_qat=False,
         dtype=None,
-        is_dynamic=False,
-        quantizer=None,
         compile_options={},  # noqa: B006
-        quantization_with_autocast=False,
     ):
         if not hasattr(self, "device"):
             has_xpu = any(
@@ -189,34 +184,17 @@ class TestPatternMatcherBase(TestCase):
                     f"Expected check_autocast to be torch.float32, got {check_autocast}"
                 )
             maybe_autocast = contextlib.nullcontext()
-        if check_quantization:
-            raise NotImplementedError("not supported, please migrate to torchao")
-            """
-            if quantization_with_autocast:
-                with maybe_autocast:
-                    convert_model = _generate_qdq_quantized_model(
-                        mod, inputs, is_qat, is_dynamic, quantizer
-                    )
-            else:
-                convert_model = _generate_qdq_quantized_model(
-                    mod, inputs, is_qat, is_dynamic, quantizer
+        with torch.no_grad(), maybe_autocast:
+            clone_inputs = self._clone_inputs(inputs)
+            expected = mod(*inputs)
+            actual = torch.compile(mod, **compile_options)(*clone_inputs)
+            if self.precision != 0:
+                torch.testing.assert_close(
+                    actual, expected, atol=self.precision, rtol=self.precision
                 )
-            with torch.no_grad(), maybe_autocast:
-                _ = torch.compile(convert_model)(*inputs)
-                matcher_check_fn()
-            """
-        else:
-            with torch.no_grad(), maybe_autocast:
-                clone_inputs = self._clone_inputs(inputs)
-                expected = mod(*inputs)
-                actual = torch.compile(mod, **compile_options)(*clone_inputs)
-                if self.precision != 0:
-                    torch.testing.assert_close(
-                        actual, expected, atol=self.precision, rtol=self.precision
-                    )
-                else:
-                    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
-                matcher_check_fn()
+            else:
+                torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+            matcher_check_fn()
 
     def _test_code_common(
         self,
@@ -226,18 +204,11 @@ class TestPatternMatcherBase(TestCase):
         exclude_ops,
         atol=1e-5,
         rtol=1.3e-6,
-        check_quantization=False,
         check_dynamic=None,
         num_include_ops=None,
-        quantizer=None,
     ):
         with torch.no_grad():
             clone_inputs = self._clone_inputs(inputs)
-            if check_quantization:
-                raise NotImplementedError("not supported, please migrate to torchao")
-                """
-                mod = _generate_qdq_quantized_model(mod, inputs, quantizer=quantizer)
-                """
             expected = mod(*inputs)
             actual, (source_code,) = run_and_get_code(
                 torch.compile(mod, fullgraph=True, dynamic=check_dynamic),
@@ -266,9 +237,7 @@ class TestPatternMatcherBase(TestCase):
                 self.assertNotIn(op, source_code)
             if check_dynamic is not None:
                 _check_has_dynamic_shape(self, source_code)
-            if not check_quantization:
-                # Skip due to reduce range setting for Quantization on preCI system.
-                torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+            torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
 
 
 class TestPatternMatcherGeneric(TestPatternMatcherBase):
@@ -750,13 +719,14 @@ class TestPatternMatcherGeneric(TestPatternMatcherBase):
                 mod,
                 (x, w, s),
                 matcher_check_fn,
-                check_quantization=False,
                 atol=0.001,
                 rtol=0.07,
             )
 
 
 class TestPatternMatcher(TestPatternMatcherBase):
+    # Note: tests containing the pattern *qconv2d* were removed in PR #169151 (PT2E migration to torchao).
+    # See issue #168635 and its sub-issues.
     @reduced_f32_on_and_off()
     def test_linear_unary(self, device="cpu"):
         self.device = device


### PR DESCRIPTION
FIXES #168635
FIXES #168636
FIXES #168637
FIXES #168638
FIXES #168639
FIXES #168640
FIXES #168641
FIXES #168642
FIXES #168643

### Investigation summary (April, 2026)
All 8 sub-issues in https://github.com/pytorch/pytorch/issues/168635 have a similarly problem. The tests are invalid and does not exist anymore in `test/inductor/test_mkldnn_pattern_matcher.py`. See https://github.com/pytorch/pytorch/issues/168636 ticket body for extra debugging information. 

### Command to reproduce
From PyTorch repo's root,

```
$ cd test
$ python -m pytest inductor/test_mkldnn_pattern_matcher.py -k "qconv2d" --collect-only -q 2>&1
```
The above command returns nothing, indicating the test is not statically defined or dynamically generated in this file.

Further,
`$ git log --all --oneline -20 -- test/inductor/test_mkldnn_pattern_matcher.py` 
AND
`$ git show 0e38e0291cc -- test/inductor/test_mkldnn_pattern_matcher.py | grep -E 'def test_q(conv2d|at_qconv2d)'`
Indicates that *qconv2d tests were removed in commit https://github.com/pytorch/pytorch/commit/0e38e0291ccb84d0ff0314846014f65c7080e1de or PR https://github.com/pytorch/pytorch/pull/169151 — "Delete pt2e flow from pytorch/pytorch since it's migrated to torchao").

As a result of this migration, there is left behind dead code in _test_common and _test_code_common:
- `check_quantization` parameter (always False, raises `NotImplementedError` if True)
- `is_qat`, `is_dynamic`, `quantizer`, `quantization_with_autocast` parameters (unused)
- Commented-out code blocks behind `NotImplementedError` guards

### Recommendation
1. Close the bug ticket as it is no longer relevant here, the tests have been moved from `test_mkldnn_pattern_matcher.py` to torchao as of Dec, 2025. 
2. Further remove the dead quantization code that is now not reachable as a result of the aforementioned migration.

### Regression testing
Running the full suite of tests using the command `$ pytest test/inductor/test_mkldnn_pattern_matcher.py -v` before and after my changes show the same result, e.g., out of the 36 tests in total, the same 26 pass and the same 10 fails. 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben