### PR TITLE
Use TORCH_CHECK instead of AT_ASSERT for single input/output node helpers

### DIFF
--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -492,19 +492,43 @@ struct TORCH_API Node {
   // lots of things like chunk have a single input or single output, so we have
   // a helper to make accessing it easier
   Value* input() {
-    AT_ASSERT(inputs_.size() == 1);
+    TORCH_CHECK(
+      inputs_.size() == 1,
+      "Tried to access a single input on node '",
+      kind().toDisplayString(),
+      "' which has ",
+      inputs_.size(),
+      " outputs. You may consider using node.inputs() instead.");
     return inputs_.at(0);
   }
   Value* output() {
-    AT_ASSERT(outputs_.size() == 1);
+    TORCH_CHECK(
+      outputs_.size() == 1,
+      "Tried to access a single output on node '",
+      kind().toDisplayString(),
+      "' which has ",
+      outputs_.size(),
+      " outputs. You may consider using node.outputs() instead.");
     return outputs_.at(0);
   }
   const Value* output() const {
-    AT_ASSERT(outputs_.size() == 1);
+    TORCH_CHECK(
+      outputs_.size() == 1,
+      "Tried to access a single output on node '",
+      kind().toDisplayString(),
+      "' which has ",
+      outputs_.size(),
+      " outputs. You may consider using node.outputs() instead.");
     return outputs_.at(0);
   }
   const Value* input() const {
-    AT_ASSERT(inputs_.size() == 1);
+    TORCH_CHECK(
+      inputs_.size() == 1,
+      "Tried to access a single input on node '",
+      kind().toDisplayString(),
+      "' which has ",
+      inputs_.size(),
+      " outputs. You may consider using node.inputs() instead.");
     return inputs_.at(0);
   }
   // Access a particular input.  This is a checked index.

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -493,42 +493,42 @@ struct TORCH_API Node {
   // a helper to make accessing it easier
   Value* input() {
     TORCH_CHECK(
-      inputs_.size() == 1,
-      "Tried to access a single input on node '",
-      kind().toDisplayString(),
-      "' which has ",
-      inputs_.size(),
-      " outputs. You may consider using node.inputs() instead.");
+        inputs_.size() == 1,
+        "Tried to access a single input on node '",
+        kind().toDisplayString(),
+        "' which has ",
+        inputs_.size(),
+        " outputs. You may consider using node.inputs() instead.");
     return inputs_.at(0);
   }
   Value* output() {
     TORCH_CHECK(
-      outputs_.size() == 1,
-      "Tried to access a single output on node '",
-      kind().toDisplayString(),
-      "' which has ",
-      outputs_.size(),
-      " outputs. You may consider using node.outputs() instead.");
+        outputs_.size() == 1,
+        "Tried to access a single output on node '",
+        kind().toDisplayString(),
+        "' which has ",
+        outputs_.size(),
+        " outputs. You may consider using node.outputs() instead.");
     return outputs_.at(0);
   }
   const Value* output() const {
     TORCH_CHECK(
-      outputs_.size() == 1,
-      "Tried to access a single output on node '",
-      kind().toDisplayString(),
-      "' which has ",
-      outputs_.size(),
-      " outputs. You may consider using node.outputs() instead.");
+        outputs_.size() == 1,
+        "Tried to access a single output on node '",
+        kind().toDisplayString(),
+        "' which has ",
+        outputs_.size(),
+        " outputs. You may consider using node.outputs() instead.");
     return outputs_.at(0);
   }
   const Value* input() const {
     TORCH_CHECK(
-      inputs_.size() == 1,
-      "Tried to access a single input on node '",
-      kind().toDisplayString(),
-      "' which has ",
-      inputs_.size(),
-      " outputs. You may consider using node.inputs() instead.");
+        inputs_.size() == 1,
+        "Tried to access a single input on node '",
+        kind().toDisplayString(),
+        "' which has ",
+        inputs_.size(),
+        " outputs. You may consider using node.inputs() instead.");
     return inputs_.at(0);
   }
   // Access a particular input.  This is a checked index.


### PR DESCRIPTION
Fixes:
- #67893 

## Issue description

Calling `node.output()` on a JIT graph node with more than one output (e.g. `aten::adaptive_max_pool2d`, which returns `(values, indices)`) causes `INTERNAL ASSERT FAILED`:

```
RuntimeError: outputs_.size() == 1 INTERNAL ASSERT FAILED at
    "torch/csrc/jit/ir/ir.h":447
```

## Root cause

`Node::output()` in `ir.h` uses `AT_ASSERT` to guard against multi-output nodes:
```cpp
Value* output() {
  AT_ASSERT(outputs_.size() == 1);  // triggers internal error
  return outputs_.at(0);
}
```

`AT_ASSERT` is for internal invariants conditions that must never be false. 
But a caller invoking `output()` on a multi-output node is a user error, not a broken internal invariant. 
The correct macro for user-facing preconditions is `TORCH_CHECK`.

See #20287 for more details.