### PR TITLE
Fix duplicate word typos across the codebase

### DIFF
--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -4220,7 +4220,7 @@
     {
       "Gb_type": "torch.associative_scan: mismatched input/output tree structure",
       "Context": "xs: {xs_treespec.as_python_constant()}, output: {_combine_treespec.as_python_constant()}",
-      "Explanation": "The tree structure of the xs and the outs of the combine_fn are are expected to be identical, but got xs: {xs_treespec.as_python_constant()} vs output: {_combine_treespec.as_python_constant()}.",
+      "Explanation": "The tree structure of the xs and the outs of the combine_fn are expected to be identical, but got xs: {xs_treespec.as_python_constant()} vs output: {_combine_treespec.as_python_constant()}.",
       "Hints": [
         "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
       ]

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2751,7 +2751,7 @@ class AssociativeScanHigherOrderVariable(TorchHigherOrderOperatorVariable):
             unimplemented(
                 gb_type="torch.associative_scan: mismatched input/output tree structure",
                 context=f"xs: {xs_treespec.as_python_constant()}, output: {_combine_treespec.as_python_constant()}",
-                explanation="The tree structure of the xs and the outs of the combine_fn are are expected to be identical, but got "
+                explanation="The tree structure of the xs and the outs of the combine_fn are expected to be identical, but got "
                 f"xs: {xs_treespec.as_python_constant()} vs output: {_combine_treespec.as_python_constant()}.",
                 hints=[
                     *graph_break_hints.USER_ERROR,

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -1913,7 +1913,7 @@ def _categorize_saved_tensors_for_backward(
 # We can do this by manually detach'ing y before sending it through the `CompiledFunction`.
 #
 # Note that this solution is not bulletproof.
-# It's possible to construct a case where eager may or may not have have tried to autograd through y,
+# It's possible to construct a case where eager may or may not have tried to autograd through y,
 # depending on the actual grad_outputs that were passed in during the backward.
 # There is no easy fix for this: the simplest fix would be to run with `retain_graph=True`,
 # allowing autograd to reuse the graph.

--- a/torch/_inductor/codegen/cpp_template_kernel.py
+++ b/torch/_inductor/codegen/cpp_template_kernel.py
@@ -384,7 +384,7 @@ class CppTemplateKernel(CppKernel):
         1. `src` and `dst` buffer could be the same buffer in which case we are doing in-place compute
            and stores. In case `epilogue_nodes` are not provided, we do nothing.
         2. The `epilogue_nodes`, if exist, have computations on `src` before storing to `dst` but since
-           they come form the original Inductor IR, they might need to be adjusted before working with
+           they come from the original Inductor IR, they might need to be adjusted before working with
            `src` and `dst` as outlined below:
            a) `src` or `dst` buffer could be a sub-slice of the ranges the `epilogue_nodes`work on.
               In this case, the `offsets` could be provided to adjust the indices passed to

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -111,7 +111,7 @@ class TORCH_API LoopNest {
   // Sanitize variables and buffer names.
   // The pass assigns predefined names for loop index variables
   // (i,j,k,l,m,n,o,p,i1,j1,k1,...) and ensures these names are not conflicting
-  // anywhere. It also removes duplicates from other Buf nad Var names as well
+  // anywhere. It also removes duplicates from other Buf and Var names as well
   // as replaces illegal characters in them with underscores.
   //
   // Note: since it's currently technically possible to use the same variable

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5719,7 +5719,7 @@ def _new_group_with_tag(
     _check_valid_timeout(timeout)
 
     if use_local_synchronization:
-        # MPI backend doesn't have have a way for us to perform a partial sync
+        # MPI backend doesn't have a way for us to perform a partial sync
         if backend == Backend.MPI:
             raise ValueError(
                 "MPI backend doesn't support use_local_synchronization=True"

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -921,7 +921,7 @@ Computes a compact representation of the LDL factorization of a Hermitian or sym
 When :attr:`A` is complex valued it can be Hermitian (:attr:`hermitian`\ `= True`)
 or symmetric (:attr:`hermitian`\ `= False`).
 
-The factorization is of the form the form :math:`A = L D L^T`.
+The factorization is of the form :math:`A = L D L^T`.
 If :attr:`hermitian` is `True` then transpose operation is the conjugate transpose.
 
 :math:`L` (or :math:`U`) and :math:`D` are stored in compact form in ``LD``.

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1711,7 +1711,7 @@ def _enforce_mem_layouts(
         return tensor.stride()[-2] == 1
 
     # These memory layout constraint are only for FP8 GEMMs on NVIDIA GPU architectures >= SM89 and < SM100.
-    # This is because GPU arch < SM89 does not not support FP8 GEMMs, and
+    # This is because GPU arch < SM89 does not support FP8 GEMMs, and
     # SM100 has support for TN, NT, TT, NN layouts for FP8 GEMMs
     # (i.e., left and right operands can be in row or column major layouts)
     # so this check is only needed for older architectures.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181284

Remove repeated words ("are are", "have have", "does not not", "the form
the form", "come form", "nad") in comments, docstrings, and error
messages across torch/_dynamo, torch/_functorch, torch/_inductor,
torch/csrc/jit, torch/distributed, torch/linalg, and torch/nn.

Authored with Claude (typo_terminator2).

cc @EikanWang @jgong5 @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98