### PR TITLE
[TEST][ARM] Remove Pointer Authentication Code from address, fall back to `dladdr_lookup` where possible

### DIFF
--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -353,7 +353,7 @@ struct Symbolizer {
     }
     auto maybe_library = libraryFor(addr);
     if (!maybe_library) {
-      frame_map_[addr] = Frame{"??", "<unwind unsupported>", 0};
+      frame_map_[addr] = Frame{dladdr_lookup(addr), "??", 0};
       return;
     }
     has_pending_results_ = true;
@@ -572,12 +572,23 @@ static bool get_stack_bounds(uintptr_t& lo, uintptr_t& hi) {
   return true;
 }
 
+// Strip PAC (Pointer Authentication Code) signature bits from an address.
+// Uses raw instruction encoding because the build may target armv8-a which
+// lacks assembler support for XPACI, even though the instruction is a NOP
+// on hardware without PAC.
+static inline uintptr_t strip_pac(uintptr_t addr) {
+  // XPACI X16 = 0xDAC143F0
+  register uintptr_t x __asm__("x16") = addr;
+  __asm__ volatile(".inst 0xDAC143F0" : "+r"(x));
+  return x;
+}
+
 extern "C" C10_USED void unwind_c(
     std::vector<void*>* result,
     uintptr_t fp,
     uintptr_t lr) {
   // NOLINTNEXTLINE(performance-no-int-to-ptr)
-  result->push_back((void*)lr);
+  result->push_back((void*)strip_pac(lr));
 
   uintptr_t stack_lo = 0, stack_hi = 0;
   if (!get_stack_bounds(stack_lo, stack_hi)) {
@@ -597,7 +608,7 @@ extern "C" C10_USED void unwind_c(
       break;
     }
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    result->push_back((void*)saved_lr);
+    result->push_back((void*)strip_pac(saved_lr));
     uintptr_t next_fp;
     std::memcpy(&next_fp, reinterpret_cast<const void*>(fp), sizeof(next_fp));
     if (next_fp <= fp) {

--- a/torch/csrc/profiler/unwind/unwind_fb.cpp
+++ b/torch/csrc/profiler/unwind/unwind_fb.cpp
@@ -1,8 +1,10 @@
 #if defined(__linux__) && (defined(__x86_64__) || defined(__aarch64__)) && \
     defined(FBCODE_CAFFE2)
 
+#include <dlfcn.h>
 #include <c10/util/flat_hash_map.h>
 #include <llvm/DebugInfo/Symbolize/Symbolize.h>
+#include <torch/csrc/profiler/unwind/sections.h>
 #include <torch/csrc/profiler/unwind/unwind.h>
 
 namespace torch::unwind {
@@ -17,7 +19,7 @@ std::vector<Frame> symbolize(const std::vector<void*>& frames, Mode mode) {
   results.reserve(frames.size());
   for (auto addr : frames) {
     if (!frame_map_.count(addr)) {
-      auto frame = Frame{"??", "<unwind unsupported>", 0};
+      auto frame = Frame{"??", "??", 0};
       auto maybe_library = libraryFor(addr);
       if (maybe_library) {
         auto libaddress = maybe_library->second - 1;
@@ -28,6 +30,12 @@ std::vector<Frame> symbolize(const std::vector<void*>& frames, Mode mode) {
           frame.filename = r->FileName;
           frame.funcname = r->FunctionName;
           frame.lineno = r->Line;
+        }
+      }
+      if (frame.funcname == "??") {
+        Dl_info dlinfo;
+        if (dladdr(addr, &dlinfo) && dlinfo.dli_sname) {
+          frame.funcname = demangle(dlinfo.dli_sname);
         }
       }
       frame_map_[addr] = std::move(frame);

--- a/torch/csrc/profiler/unwind/unwind_fb.cpp
+++ b/torch/csrc/profiler/unwind/unwind_fb.cpp
@@ -1,8 +1,8 @@
 #if defined(__linux__) && (defined(__x86_64__) || defined(__aarch64__)) && \
     defined(FBCODE_CAFFE2)
 
-#include <dlfcn.h>
 #include <c10/util/flat_hash_map.h>
+#include <dlfcn.h>
 #include <llvm/DebugInfo/Symbolize/Symbolize.h>
 #include <torch/csrc/profiler/unwind/sections.h>
 #include <torch/csrc/profiler/unwind/unwind.h>


### PR DESCRIPTION
authored with claude

Mainly to fix failures on ARM64 systems where we were not getting stack traces e.g., `python test/test_cuda.py TestCudaAllocator.test_cpp_memory_snapshot_pickle`

cc @mruberry @snadampal @milpuz01 @aditew01 @nikhil-arm @fadara01 @robert-hardwick @nWEIdia