### PR TITLE
[ROCm] Bump ROCm CI images to 7.2.3

### DIFF
--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -166,7 +166,7 @@ EOF
 
     # we want the patch version of 7.2 instead
     if [[ $(ver $ROCM_VERSION) -eq $(ver 7.2) ]]; then
-        ROCM_VERSION="${ROCM_VERSION}.1"
+        ROCM_VERSION="${ROCM_VERSION}.2"
     fi
 
     # Default url values

--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -166,7 +166,7 @@ EOF
 
     # we want the patch version of 7.2 instead
     if [[ $(ver $ROCM_VERSION) -eq $(ver 7.2) ]]; then
-        ROCM_VERSION="${ROCM_VERSION}.2"
+        ROCM_VERSION="${ROCM_VERSION}.3"
     fi
 
     # Default url values


### PR DESCRIPTION
Update CI ROCm install path from 7.2.1 to 7.2.3.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang