### PR TITLE
[inductor] Bound AsyncCompile._wait_futures with compile_worker_wait_timeout

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -74,10 +74,15 @@ NUM_TEST_SHARDS="${NUM_TEST_SHARDS:=1}"
 # enable debug asserts in serialization
 export TORCH_SERIALIZATION_DEBUG=1
 
-# Bound Inductor compile-worker futures so a stuck Triton compile fails fast
-# with a clear RuntimeError naming the kernel, instead of blocking until the
-# outer test timeout kills the shard and loses all context.
-export TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT=300
+# Bound Inductor compile-worker futures on ROCm so a stuck Triton compile
+# fails fast with a clear RuntimeError naming the kernel, instead of blocking
+# until the outer test timeout kills the shard and loses all context. Scoped
+# to ROCm because the known-bad cases (sort-with-index on gfx90a/gfx942) have
+# only been observed there; leaving CPU/CUDA jobs unbounded avoids regressing
+# any legitimately long compile on those backends.
+if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+    export TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT=300
+fi
 
 export VALGRIND=ON
 # export TORCH_INDUCTOR_INSTALL_GXX=ON

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -74,6 +74,11 @@ NUM_TEST_SHARDS="${NUM_TEST_SHARDS:=1}"
 # enable debug asserts in serialization
 export TORCH_SERIALIZATION_DEBUG=1
 
+# Bound Inductor compile-worker futures so a stuck Triton compile fails fast
+# with a clear RuntimeError naming the kernel, instead of blocking until the
+# outer test timeout kills the shard and loses all context.
+export TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT=300
+
 export VALGRIND=ON
 # export TORCH_INDUCTOR_INSTALL_GXX=ON
 if [[ "$BUILD_ENVIRONMENT" == *clang9* || "$BUILD_ENVIRONMENT" == *xpu* ]]; then

--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -153,6 +153,34 @@ def triton_fused_fake_name(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.cons
         self.assertEqual(args[1].num_warps, autotune_config.num_warps)
         self.assertEqual(args[1].num_stages, autotune_config.num_stages)
 
+    def test_wait_futures_timeout(self):
+        """A compile future that doesn't finish within
+        compile_worker_wait_timeout causes _wait_futures to raise
+        RuntimeError naming the kernel.
+        """
+        import threading
+        from concurrent.futures import ThreadPoolExecutor
+
+        # Use an Event so the worker thread exits promptly once the assertion
+        # passes. A plain time.sleep here would keep the interpreter alive
+        # until it completes.
+        release = threading.Event()
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
+            hanging_future = pool.submit(release.wait)
+            scope = {"kernel_that_hangs": hanging_future}
+            with config.patch(compile_worker_wait_timeout=1):
+                async_compile = AsyncCompile()
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    r"compile-worker future for 'kernel_that_hangs' did not "
+                    r"complete within",
+                ):
+                    async_compile._wait_futures(scope)
+        finally:
+            release.set()
+            pool.shutdown(wait=True)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -729,6 +729,8 @@ class AsyncCompile:
         _compile_end()
 
     def _wait_futures(self, scope: dict[str, Any]) -> None:
+        from concurrent.futures import TimeoutError as _FutTimeoutError
+
         kernels = {
             key: value
             for key, value in scope.items()
@@ -740,9 +742,33 @@ class AsyncCompile:
             disable=config.disable_progress,
             delay=0,
         )
+        wait_timeout = config.compile_worker_wait_timeout
         for key, result in kernels.items():
             if config.verbose_progress and not isinstance(pbar, _Faketqdm):
                 pbar.set_postfix_str(key)
+            # Bound cross-process futures with compile_worker_wait_timeout so
+            # a stuck worker doesn't block the parent indefinitely.
+            # Synchronous CodeCacheFuture subclasses without a .future
+            # attribute don't need bounding.
+            underlying: Future | None = None
+            if isinstance(result, Future):
+                underlying = result
+            else:
+                underlying = getattr(result, "future", None)
+                if not isinstance(underlying, Future):
+                    underlying = None
+            if underlying is not None and wait_timeout > 0:
+                try:
+                    underlying.result(timeout=wait_timeout)
+                except _FutTimeoutError as e:
+                    raise RuntimeError(
+                        f"Inductor compile-worker future for {key!r} did not "
+                        f"complete within {wait_timeout}s. Override with "
+                        "TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT=<seconds>."
+                    ) from e
+                except BrokenProcessPool:
+                    # Fall through to the outer handler for a consistent message.
+                    pass
             try:
                 kernel = result.result()
                 scope[key] = kernel

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -729,8 +729,6 @@ class AsyncCompile:
         _compile_end()
 
     def _wait_futures(self, scope: dict[str, Any]) -> None:
-        from concurrent.futures import TimeoutError as _FutTimeoutError
-
         kernels = {
             key: value
             for key, value in scope.items()
@@ -742,36 +740,22 @@ class AsyncCompile:
             disable=config.disable_progress,
             delay=0,
         )
-        wait_timeout = config.compile_worker_wait_timeout
+        # compile_worker_wait_timeout=0 (default) means "wait forever"; map
+        # it to None so both Future.result() and CodeCacheFuture.result()
+        # receive the same "no timeout" sentinel.
+        wait_timeout = config.compile_worker_wait_timeout or None
         for key, result in kernels.items():
             if config.verbose_progress and not isinstance(pbar, _Faketqdm):
                 pbar.set_postfix_str(key)
-            # Bound cross-process futures with compile_worker_wait_timeout so
-            # a stuck worker doesn't block the parent indefinitely.
-            # Synchronous CodeCacheFuture subclasses without a .future
-            # attribute don't need bounding.
-            underlying: Future | None = None
-            if isinstance(result, Future):
-                underlying = result
-            else:
-                underlying = getattr(result, "future", None)
-                if not isinstance(underlying, Future):
-                    underlying = None
-            if underlying is not None and wait_timeout > 0:
-                try:
-                    underlying.result(timeout=wait_timeout)
-                except _FutTimeoutError as e:
-                    raise RuntimeError(
-                        f"Inductor compile-worker future for {key!r} did not "
-                        f"complete within {wait_timeout}s. Override with "
-                        "TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT=<seconds>."
-                    ) from e
-                except BrokenProcessPool:
-                    # Fall through to the outer handler for a consistent message.
-                    pass
             try:
-                kernel = result.result()
+                kernel = result.result(timeout=wait_timeout)
                 scope[key] = kernel
+            except TimeoutError as e:
+                raise RuntimeError(
+                    f"Inductor compile-worker future for {key!r} did not "
+                    f"complete within {wait_timeout}s. Override with "
+                    "TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT=<seconds>."
+                ) from e
             except BrokenProcessPool as e:
                 raise RuntimeError(
                     "A compilation subprocess exited unexpectedly. This "

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -9,7 +9,11 @@ import multiprocessing
 import os
 import re
 import sys
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import (
+    Future,
+    ThreadPoolExecutor,
+    TimeoutError as FuturesTimeoutError,
+)
 from concurrent.futures.process import BrokenProcessPool
 from functools import partial
 from time import time, time_ns
@@ -750,7 +754,10 @@ class AsyncCompile:
             try:
                 kernel = result.result(timeout=wait_timeout)
                 scope[key] = kernel
-            except TimeoutError as e:
+            except FuturesTimeoutError as e:
+                # concurrent.futures.TimeoutError became an alias of the
+                # builtin TimeoutError in Python 3.11; on 3.10 it is a
+                # distinct class, so catch it explicitly.
                 raise RuntimeError(
                     f"Inductor compile-worker future for {key!r} did not "
                     f"complete within {wait_timeout}s. Override with "

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -4633,7 +4633,7 @@ class ROCmCodeCache:
 
 
 class CodeCacheFuture:
-    def result(self) -> Callable[..., Any]:
+    def result(self, timeout: float | None = None) -> Callable[..., Any]:
         raise NotImplementedError
 
 
@@ -4644,7 +4644,13 @@ class LambdaFuture(CodeCacheFuture):
         self.result_fn = result_fn
         self.future = future
 
-    def result(self) -> Callable[..., Any]:
+    def result(self, timeout: float | None = None) -> Callable[..., Any]:
+        if timeout is not None and self.future is not None:
+            # Wait on the underlying cross-process future with the caller's
+            # timeout; raises concurrent.futures.TimeoutError if it does not
+            # resolve in time. result_fn will then consume the completed
+            # future without blocking further.
+            self.future.result(timeout=timeout)
         return self.result_fn()
 
 
@@ -4662,7 +4668,10 @@ class StaticAutotunerFuture(CodeCacheFuture):
         # since it can be very large.
         self.reload_kernel_from_src: Callable[[], Any] | None = None
 
-    def result(self) -> CachingAutotuner:
+    def result(self, timeout: float | None = None) -> CachingAutotuner:
+        # timeout is accepted for interface parity with other CodeCacheFuture
+        # subclasses; this work is synchronous in-process and has no pending
+        # future to wait on.
         assert self.reload_kernel_from_src is not None
         with dynamo_timed("StaticAutotunerFuture.warm_precompile"):
             self.static_autotuner.recheck_autotune_cache(

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1501,6 +1501,15 @@ autotune_lookup_table: dict[str, dict[str, Any]] = {}
 
 file_lock_timeout: int = int(os.environ.get("TORCHINDUCTOR_FILE_LOCK_TIMEOUT", "600"))
 
+# Per-future timeout (seconds) for AsyncCompile._wait_futures. If a compile
+# worker does not finish within this time, raise a RuntimeError naming the
+# kernel instead of blocking the parent until the outer CI timeout fires.
+# Slowest legitimate single-test compile observed is ~130s, so 300s leaves
+# ~2.3x margin.
+compile_worker_wait_timeout: int = int(
+    os.environ.get("TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT", "300")
+)
+
 enable_autograd_for_aot: bool = False
 
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1501,13 +1501,14 @@ autotune_lookup_table: dict[str, dict[str, Any]] = {}
 
 file_lock_timeout: int = int(os.environ.get("TORCHINDUCTOR_FILE_LOCK_TIMEOUT", "600"))
 
-# Per-future timeout (seconds) for AsyncCompile._wait_futures. If a compile
-# worker does not finish within this time, raise a RuntimeError naming the
-# kernel instead of blocking the parent until the outer CI timeout fires.
-# Slowest legitimate single-test compile observed is ~130s, so 300s leaves
-# ~2.3x margin.
+# Per-future timeout (seconds) for AsyncCompile._wait_futures. 0 (the
+# default) means no timeout; a positive value raises a RuntimeError naming
+# the kernel when a compile worker does not finish in time. CI sets this
+# via TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT (300s) so a stuck compile
+# doesn't burn the whole shard budget, while non-CI users with legitimately
+# long compiles are not affected.
 compile_worker_wait_timeout: int = int(
-    os.environ.get("TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT", "300")
+    os.environ.get("TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT", "0")
 )
 
 enable_autograd_for_aot: bool = False


### PR DESCRIPTION
Inductor currently calls future.result() on compile-worker futures with no timeout. When a worker's Triton compile stalls, the test subprocess waits until the outer CI 30-min limit fires and gets SIGKILL'd — no signal about which kernel was stuck.

Concrete motivating case: test_sort_dynamic_shape_with_check_cuda hits a super-linear register-allocator complexity pathology in Triton's compile backend on one specific autotune config of a fused sort-with-index kernel. On MI300 the compile completes in 420s; on MI200 it completes in 865s. Either way the shard's 30-min CI budget is consumed by that one compile and the rest of the shard is lost.

With this bound, the test shard continues past the stuck kernel with a RuntimeError naming it, which is immediately actionable:

    RuntimeError: Inductor compile-worker future for 'triton_per_fused_sort_0'
    did not complete within 300s. Override with
    TORCHINDUCTOR_COMPILE_WORKER_WAIT_TIMEOUT=<seconds>.

Default 300s is chosen from empirical CI data: the slowest legitimate single test observed end-to-end is ~130s, so 300s gives ~2.3x margin. Env override is available if future workloads legitimately exceed this.

CodeCacheFuture subclasses without an underlying concurrent.futures.Future attribute are synchronous and complete on .result(); the bound only wraps real cross-process futures.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos