### PR TITLE
[aten] Fix CPU and MPS logit for eps > 0.5

### DIFF
--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -168,7 +168,12 @@ static void logit_kernel(TensorIteratorBase& iter, const Scalar& eps_scalar) {
                     : std::log(x / (scalar_t(1) - x));
               },
               [kOneVec, lo_vec, hi_vec](Vectorized<scalar_t> x_vec) {
-                x_vec = vec::clamp(x_vec, lo_vec, hi_vec);
+                // Apply lo last so it wins when eps > 1 - eps, matching
+                // the scalar `x < lo ? lo : (x > hi ? hi : x)` priority.
+                x_vec = Vectorized<scalar_t>::blendv(
+                    Vectorized<scalar_t>::blendv(x_vec, hi_vec, x_vec > hi_vec),
+                    lo_vec,
+                    x_vec < lo_vec);
                 return (x_vec / (kOneVec - x_vec)).log();
               });
         }

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -224,10 +224,22 @@ static void logit_mps_impl(const Tensor& self, std::optional<double> eps, Tensor
     if (eps.has_value()) {
       MPSGraphTensor* lowTensor = [mpsGraph constantWithScalar:eps.value() shape:@[ @1 ] dataType:inputTensor.dataType];
       MPSGraphTensor* highTensor = [mpsGraph subtractionWithPrimaryTensor:oneTensor secondaryTensor:lowTensor name:nil];
-      logitInputTensor = [mpsGraph clampWithTensor:inputTensor
-                                    minValueTensor:lowTensor
-                                    maxValueTensor:highTensor
-                                              name:nil];
+      // Apply lo last so it wins when eps > 1 - eps, matching the
+      // scalar `x < lo ? lo : (x > hi ? hi : x)` priority.
+      MPSGraphTensor* inputGreaterThanHighTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
+                                                                          secondaryTensor:highTensor
+                                                                                     name:nil];
+      MPSGraphTensor* clampedHighTensor = [mpsGraph selectWithPredicateTensor:inputGreaterThanHighTensor
+                                                          truePredicateTensor:highTensor
+                                                         falsePredicateTensor:inputTensor
+                                                                         name:nil];
+      MPSGraphTensor* inputLessThanLowTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
+                                                                   secondaryTensor:lowTensor
+                                                                              name:nil];
+      logitInputTensor = [mpsGraph selectWithPredicateTensor:inputLessThanLowTensor
+                                         truePredicateTensor:lowTensor
+                                        falsePredicateTensor:clampedHighTensor
+                                                        name:nil];
     } else {
       logitInputTensor = inputTensor;
     }

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -43,6 +43,7 @@ from torch.testing._internal.common_utils import (
     gradcheck,
     is_iterable_of_tensors,
     numpy_to_torch_dtype_dict,
+    parametrize,
     run_tests,
     skipIfNoSciPy,
     slowTest,
@@ -1937,6 +1938,35 @@ class TestUnaryUfuncs(TestCase):
         y = x.to(torch.float8_e5m2)
         ref = x.cpu().float().to(torch.float8_e5m2)
         self.assertEqual(y.cpu().view(torch.uint8), ref.view(torch.uint8))
+
+    # Regression for https://github.com/pytorch/pytorch/issues/177839:
+    # when eps > 0.5 the scalar kernel clamps via `x < eps ? eps : ...` (so
+    # the lower bound wins over the upper bound when eps > 1 - eps), and the
+    # vectorized kernel must match.
+    @onlyCPU
+    @dtypes(torch.float32, torch.float64, torch.float16, torch.bfloat16)
+    @parametrize("eps", [0.49, 0.51, 0.6, 0.9])
+    @parametrize("shape", [(2, 16), (4, 32), (8, 64)])
+    def test_logit_vectorized_matches_scalar(self, device, dtype, eps, shape):
+        torch.manual_seed(0)
+        # Slice from a wider tensor so the result is non-contiguous and
+        # bypasses the contiguous MKL fast-path — ensures the vectorized
+        # kernel we patched is actually exercised on MKL-enabled builds.
+        rows, cols = shape
+        t = torch.rand((rows, cols + 2), dtype=dtype, device=device) * 2 - 0.5
+        x = t[:, :cols]
+        self.assertFalse(x.is_contiguous())
+        got = torch.special.logit(x, eps=eps)
+        # Reference: apply the scalar kernel elementwise against a single-
+        # lane tensor of the same dtype. cpu_kernel_vec falls back to its
+        # scalar lambda for lengths below `Vectorized::size()`, so this
+        # always hits the scalar path and gives a bit-exact ground truth.
+        ref = torch.empty_like(x)
+        x_flat = x.reshape(-1)
+        ref_flat = ref.reshape(-1)
+        for i in range(x_flat.numel()):
+            ref_flat[i] = torch.special.logit(x_flat[i : i + 1], eps=eps)
+        self.assertEqual(got, ref)
 
 
 instantiate_device_type_tests(TestUnaryUfuncs, globals())

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7129,6 +7129,8 @@ def sample_inputs_logit(op_info, device, dtype, requires_grad, **kwargs):
     yield SampleInput(make_arg((S, S, S)), 0.2)
     yield SampleInput(make_arg(()))
     yield SampleInput(make_arg(()), 0.2)
+    # eps > 0.5 exercises the branch where lo > hi; see issue #177839.
+    yield SampleInput(make_arg((S, S, S)), 0.6)
 
 def sample_inputs_isin(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)


### PR DESCRIPTION
## Issue

Fixes #177839.

## Summary

For `eps > 0.5` the clamp bounds invert (`lo = eps > hi = 1 - eps`). The scalar and CUDA kernels resolve this as `x < lo ? lo : (x > hi ? hi : x)`, so `lo` wins. Two paths disagreed and produced a sign-flipped result:

- CPU vectorized: `vec::clamp` = `min(hi, max(lo, x))`, so `hi` won.
- MPS `logit`: `clampWithTensor`, also `min(max(x, lo), hi)`, so `hi` won.

Both now apply `lo` last (nested `blendv` on CPU, nested `select` on MPS), matching scalar and CUDA. CUDA already conformed, so all three backends agree. `eps > 0.5` is mathematically ill-defined; the goal is cross-backend consistency.

## Tests

Added `test_logit_vectorized_matches_scalar` (eps `{0.49, 0.51, 0.6, 0.9}` x 4 dtypes, bit-exact vs the scalar kernel) and an `eps=0.6` `sample_inputs_logit` sample so `test_ops.py` and the MPS consistency tests cover `eps > 0.5`. Verified on Apple Silicon: `test_mps.py -k logit`, `test_ops.py -k logit`, and `test_unary_ufuncs.py -k logit` pass, including the previously failing `test_output_grad_match_logit_mps_float32`.

## BC-breaking?

No.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @laithsakka @williamwen42
