### PR TITLE
[CI] Mark functorch_dp_cifar10 as fail_accuracy in dynamic_inductor_torchbench_inference

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_inference.csv
@@ -114,7 +114,7 @@ fastNLP_Bert,pass,4
 
 
 
-functorch_dp_cifar10,pass,0
+functorch_dp_cifar10,fail_accuracy,0
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181299

Batch norm accuracy regression under dynamic shapes only (not static).
Flipping the expected state to unblock periodic inductor CI while the
underlying fix is tracked in #180740.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98