### PR TITLE
Add an all partial var to create_block_mask

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1604,8 +1604,10 @@ class TestFlexAttention(InductorTestCase):
             enable_gqa=True,
             kernel_options={"BACKEND": "TRITON"},
         )
-        self.assertEqual(
-            out_partial[:, :, :shared_prefix], out_full[:, :, :shared_prefix]
+        self.assertTrue(
+            torch.equal(
+                out_partial[:, :, :shared_prefix], out_full[:, :, :shared_prefix]
+            )
         )
 
     @supported_platform

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -1531,6 +1531,84 @@ class TestFlexAttention(InductorTestCase):
         )
 
     @supported_platform
+    @skip_on_cpu
+    def test_kv_order_invariance_padded_causal(self, device):
+        if device == "cuda" and not PLATFORM_SUPPORTS_BF16:
+            self.skipTest("bf16 is required for this regression test")
+
+        batch_size = 1
+        q_heads = 16
+        kv_heads = 4
+        seq_len = 256
+        head_dim = 128
+        shared_prefix = 201
+        dtype = torch.bfloat16
+
+        def make_block_mask(real_q_len: int, separate_full_blocks: bool):
+            def padded_causal_mask(b, h, q, kv):
+                return (q < real_q_len) & (q >= kv)
+
+            return create_block_mask(
+                padded_causal_mask,
+                B=batch_size,
+                H=1,
+                Q_LEN=seq_len,
+                KV_LEN=seq_len,
+                device=device,
+                separate_full_blocks=separate_full_blocks,
+            )
+
+        q = torch.randn(
+            batch_size, q_heads, seq_len, head_dim, device=device, dtype=dtype
+        )
+        k = torch.randn(
+            batch_size, kv_heads, seq_len, head_dim, device=device, dtype=dtype
+        )
+        v = torch.randn(
+            batch_size, kv_heads, seq_len, head_dim, device=device, dtype=dtype
+        )
+
+        compiled_attention = torch.compile(
+            flex_attention,
+            fullgraph=True,
+        )
+        default_partial_block_mask = make_block_mask(shared_prefix, True)
+        default_full_block_mask = make_block_mask(seq_len, True)
+        self.assertEqual(default_partial_block_mask.kv_indices[0, 0, 1, :2], [0, 1])
+        self.assertEqual(default_partial_block_mask.full_kv_num_blocks[0, 0, 1], 0)
+        self.assertEqual(default_full_block_mask.kv_indices[0, 0, 1, :1], [1])
+        self.assertEqual(default_full_block_mask.full_kv_indices[0, 0, 1, :1], [0])
+
+        partial_block_mask = make_block_mask(shared_prefix, False)
+        full_block_mask = make_block_mask(seq_len, False)
+        self.assertEqual(partial_block_mask.kv_indices[0, 0, 1, :2], [0, 1])
+        self.assertIsNone(partial_block_mask.full_kv_num_blocks)
+        self.assertEqual(full_block_mask.kv_indices[0, 0, 1, :2], [0, 1])
+        self.assertIsNone(full_block_mask.full_kv_num_blocks)
+
+        out_partial = compiled_attention(
+            q,
+            k,
+            v,
+            score_mod=_identity,
+            block_mask=partial_block_mask,
+            enable_gqa=True,
+            kernel_options={"BACKEND": "TRITON"},
+        )
+        out_full = compiled_attention(
+            q,
+            k,
+            v,
+            score_mod=_identity,
+            block_mask=full_block_mask,
+            enable_gqa=True,
+            kernel_options={"BACKEND": "TRITON"},
+        )
+        self.assertEqual(
+            out_partial[:, :, :shared_prefix], out_full[:, :, :shared_prefix]
+        )
+
+    @supported_platform
     @dtypes(*device_configs["cpu"].dtypes_fast)
     @dtypesIfCUDA(*device_configs["cuda"].dtypes_fast)
     @dtypesIfXPU(*device_configs["xpu"].dtypes_fast)

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -1486,6 +1486,7 @@ def create_block_mask(
     device: DeviceLikeType | None = None,
     BLOCK_SIZE: int | tuple[int, int] = _DEFAULT_SPARSE_BLOCK_SIZE,
     _compile=False,
+    separate_full_blocks: bool = True,
 ) -> BlockMask:
     r"""This function creates a block mask tuple from a mask_mod function.
 
@@ -1501,6 +1502,10 @@ def create_block_mask(
         KV_LEN (int): Sequence length of key/value.
         device (str): Device to run the mask creation on.
         BLOCK_SIZE (int or tuple[int, int]): Block size for the block mask. If a single int is provided it is used for both query and key/value.
+        separate_full_blocks (bool): If True, fully unmasked blocks are stored
+            separately so kernels can skip mask_mod on those blocks. If False,
+            all non-empty blocks are stored as partial blocks and mask_mod is
+            applied to every block.
 
     Returns:
         BlockMask:  A BlockMask object that contains the block mask information.
@@ -1542,7 +1547,15 @@ def create_block_mask(
             stacklevel=2,
         )
         return torch.compile(create_block_mask)(
-            mask_mod, B, H, Q_LEN, KV_LEN, device, BLOCK_SIZE
+            mask_mod,
+            B,
+            H,
+            Q_LEN,
+            KV_LEN,
+            device,
+            BLOCK_SIZE,
+            False,
+            separate_full_blocks,
         )
 
     mask_tensor = create_mask(mask_mod, B, H, Q_LEN, KV_LEN, device)
@@ -1550,7 +1563,7 @@ def create_block_mask(
         mask_tensor,
         Q_BLOCK_SIZE=Q_BLOCK_SIZE,
         KV_BLOCK_SIZE=KV_BLOCK_SIZE,
-        separate_full_blocks=True,
+        separate_full_blocks=separate_full_blocks,
     )
     block_mask = _create_sparse_block_from_block_mask(
         (partial_block_mask, full_block_mask),


### PR DESCRIPTION
## Human Note
For batch invariance we need to ensure that we iterate blocks in the same order.  You can see in the worklog if we add more bm metadata we can do this more cleverly with ad have near zero overhad. We can also do more clever double pointer sorted walk, but alas the numbers are the numbers and KISS wins again

## Agent Report
# Report

## Current patch

The current solution is the lower-risk/user-controlled path for flex attention KV-order invariance:

- `torch/nn/attention/flex_attention.py`
  - Added `separate_full_blocks: bool = True` to `create_block_mask`.
  - Default behavior remains unchanged: fully unmasked blocks are separated into `full_kv_*` so kernels can keep the full-block fast path.
  - When `separate_full_blocks=False`, all non-empty blocks stay in `kv_indices` in KV-ascending order and `full_kv_*` is `None`, so flex attention applies `mask_mod` to every block and avoids full/partial classification changing the processing order.
- `test/inductor/test_flex_attention.py`
  - Added a CUDA bf16 padded-causal regression test matching the original partial/full flip scenario.
  - The test checks that the default separated mask produces the problematic schedules, then verifies that `separate_full_blocks=False` produces identical ordered partial lists and bit-exact outputs over the shared real prefix.
  - The final output comparison now uses `torch.equal(...)`, not `self.assertEqual`, so the regression enforces exact tensor equality instead of dtype-dependent tolerances.

## PR comments fetched

Fetched comments for PR `pytorch/pytorch#181303` with `gh pr view --comments`, `gh pr view --json comments,reviews`, and `gh api repos/pytorch/pytorch/pulls/181303/comments --paginate`.

Artifacts:

- `pr_comments_raw.json`: `gh pr view` JSON output.
- `pr_review_comments.json`: inline review comments API output.
- `pr_comments.md`: human-readable extracted comments/reviews.

Actionable comment found:

- `chatgpt-codex-connector[bot]` on `test/inductor/test_flex_attention.py` requested exact semantics for the shared-prefix assertion because `self.assertEqual` on bf16 tensors is tolerance-based.

Other PR status/comments:

- `liangel-02` approved the PR.
- Dr. CI says the PR is mergeable; the two listed failures are categorized as unrelated/flaky or broken trunk.
- The label bot requested a `release notes:` or `topic: not user facing` label.

## Review

Earlier read-only Pi review over the working-tree diff reported:

```text
No findings.
```

No review-driven code tweaks were needed from that review. The GitHub inline review comment above was addressed by switching the assertion to `torch.equal`.

## Validation

Targeted regression after switching to `torch.equal`:

```bash
~/.ptq_workspace/jobs/20260423-pytorch-adhoc-af67e0/.venv/bin/python -m pytest \
  test/inductor/test_flex_attention.py::TestFlexAttentionCUDA::test_kv_order_invariance_padded_causal_cuda -q
```

Result:

```text
1 passed in 14.86s
```

Because this test now asserts `torch.equal(out_partial[:, :, :shared_prefix], out_full[:, :, :shared_prefix])`, the passing result verifies bitwise identity for the shared real prefix.

## Lint

I reran `spin fixlint` from `~/.ptq_workspace/jobs/20260423-pytorch-adhoc-af67e0/pytorch` after the `torch.equal` tweak.

Outcome:

- The final lint command failed in the existing environment-level clang-tidy path because `~/.ptq_workspace/jobs/20260423-pytorch-adhoc-af67e0/pytorch/build` does not exist in this worktree.
- The subsequent non-clang lint subset reported `ok No lint issues.`

## Performance context

The previous kernel-level ordered-merge prototypes were reverted because they caused unacceptable long-causal regressions. The current patch keeps the default fast path unchanged and makes deterministic ordering opt-in by constructing the `BlockMask` with `separate_full_blocks=False`.

Current benchmark takeaway from the local sweep: the opt-in all-partial path is generally much better than in-kernel merge, with overhead around 4-21% on larger causal/sliding cases and sometimes neutral/faster on small padded cases. Users only pay that cost when they choose deterministic full/partial flip invariance.


<details>
<summary>Agent Worklog</summary>

## Run 1

> **User:** ---
project: pytorch
topic: flex_attention batch-invariance (full/partial kv block ordering)
date: 2026-04-23
machine: gpu-dev-5db60d35
repo: /home/dev/meta/pytorch
status: proposed
---

# flex_attention: make KV-block processing order deterministic wrt full/partial classification

## Problem

`flex_attention` is not batch-invariant when the `full` / `partial` classification
of a KV block flips due to masked-out query rows (e.g. tail padding beyond the
real sequence length). Outputs at real query positions differ by ~2e-3 in bf16
even though the Q, K, V, and effective mask at those positions are identical.

### Root cause — two-pass kernel

`torch/_inductor/kernel/flex/templates/flex_attention.py.jinja` (lines ~139–190)
processes KV blocks in two sequential passes:

```
# pass 1 — partial (mask_mod applied)
for i in KV_IDX[:P]:        forward_inner(..., IS_FULL_BLOCKS=False)
# pass 2 — full    (mask_mod skipped)
if HAS_FULL_BLOCKS:
    for i in FULL_KV_IDX[:F]: forward_inner(..., IS_FULL_BLOCKS=True)
```

Within each pass, blocks are in KV-ascending order. Across passes, **all
partials run before all fulls**, regardless of their KV indices.

### Root cause — classification

`torch/nn/attention/flex_attention.py::_convert_mask_to_block_mask`
(`separate_full_blocks=True`, line ~1346) classifies a block as `full` only
if every (q, kv) pair in the 128×128 tile returns True. Padded Q rows are
all-False, so they downgrade otherwise-full blocks to partial. The same
block's *processing position* therefore depends on the padding, which
changes the online-softmax accumulation order.

### Evidence

Repro: `~/meta/my_scripts/flex/diff.py`

```
Setup A (real=201): Qb1 partials=[0,1] full=[]      → order 0→1
Setup B (real=256): Qb1 partials=[1]   full=[0]     → order 1→0
pos 200 (real in both): max_diff = 1.953e-03
```

Verified with `/tmp/verify_fix2.py`: merging `full_kv_*` into `kv_*` sorted
ascending makes both setups bit-exact (`max_diff=0.0`) on real rows.

## Why fix in the kernel (not via block-mask workaround)

Benchmark of the "merge all → partial" workaround
(`/tmp/bench_merge.py`, `transformer_nuggets.benchmark_cuda_function_in_microseconds`):

```
shape             full%    base       merged     Δ
repro 256 r=256   33%      12.7 us    12.7 us    -0.2%
repro 256 r=201    0%      14.2 us    12.6 us   -11.9%
causal 1 k        78%      33.1 us    48.2 us   +45.8%
causal 2 k        88%      95.0 us   146.6 us   +54.3%
causal 4 k        94%     257.1 us   427.6 us   +66.3%
causal 8 k        97%     815.3 us  1421.0 us   +74.3%
causal 16 k       98%    2857.7 us  5126.6 us   +79.4%
```

Disabling the full-block fast path is ~2× slower on realistic causal
shapes. The fix must keep `mask_mod` skippable per-block at runtime.

## Proposed fix — single-pass, KV-ascending order with per-block `is_full` flag

### Design

- `BlockMask` gains a unified `kv_indices` view containing `partial ∪ full`
  sorted by KV index, plus a parallel `is_full_flag: [B, H, Qb, Kmax]`
  byte tensor (1 = full, 0 = partial). The existing `full_kv_*` fields
  stay for BC.
- Kernel templates (`flex_attention.py.jinja`, `flex_decode.py.jinja`)
  replace the two sequential `forward_inner` calls with a single loop
  that loads the flag and predicates `mask_mod` per block.
- The flag is uniform across a Q tile, so the branch is warp-uniform
  (no divergence).

### Expected perf

- Full blocks: same work as today (mask_mod compiled in but not executed)
  + one `tl.load` + one uniform branch per block (~cycles).
- Partial blocks: identical to today.
- Target overhead: well under 1% on the causal-shape table above. If the
  prototype shows more than ~2% regression on `causal 16k`, reconsider.

## Implementation steps

- [ ] **Prototype in a branch** (`fix/flex-attn-kv-order-invariance`)
  - [ ] Inspect `_create_sparse_block_from_block_mask` and confirm how
        `kv_indices` and `full_kv_indices` are currently populated.
  - [ ] Add `is_full_kv_flag` tensor builder next to existing index tensors.
  - [ ] Thread the new tensor through `torch/_inductor/kernel/flex/flex_attention.py`
        (and `flex_decoding.py`) as an extra kernel arg guarded by
        `kernel_options["KV_ORDER_INVARIANT"]` (default: True).
  - [ ] Modify `flex_attention.py.jinja`: replace the two `forward_inner`
        calls with a single loop reading `is_full_ptr[start_n]` and
        branching around `mask_mod`. Preserve the existing
        `IS_FULL_BLOCKS=False` path exactly for backward-compat when the
        flag is not provided.
  - [ ] Mirror the change in `flex_decode.py.jinja`.
  - [ ] Keep `flex_flash_attention.py` (cutedsl) untouched in this PR,
        track in a follow-up.

- [ ] **BlockMask API**
  - [ ] Decide: populate the unified list always, or only when
        `kernel_options["KV_ORDER_INVARIANT"]` is set. Leaning toward
        always populate (cheap) and gate only kernel behavior.
  - [ ] `BlockMask.from_kv_blocks` can keep its signature; build the
        unified view lazily as a property.
  - [ ] Document the invariant in the `BlockMask` docstring:
        "When full/partial classification of a block changes due to
        mask_mod geometry, outputs remain bit-exact."

- [ ] **Code-surface compat**
  - [ ] Grep for external callers of `full_kv_num_blocks` / `full_kv_indices`
        (tests, `flex_cpu.py`, distributed `flex_attention_cp.py`,
        `test_flex_attention.py`) and leave them unchanged.
  - [ ] Ensure `BlockMask.__getitem__`, `.to`, `_adjust`, `as_tuple`,
        and serialization paths all handle the new tensor.

- [ ] **Perf validation**
  - [ ] Run `/tmp/bench_merge.py` variant that includes the new kernel
        (three bars: baseline-two-pass, new-single-pass, merged-workaround)
        across the same shape matrix.
  - [ ] Accept the change if `new` is within 2% of `baseline-two-pass`
        on every row. Reject and iterate otherwise.

## Tests

Put all new tests in `test/inductor/test_flex_attention.py`. Use
`instantiate_device_type_tests` so they also run on the CPU path where
meaningful.

- [ ] **test_kv_order_invariance_padded_causal** (the exact repro)
  - padded=256, head_dim=128, H=16, Hkv=4, bf16.
  - Run with real_seq_len ∈ {201, 256}.
  - Assert `torch.equal(out_a[:, :, :201], out_b[:, :, :201])` (bit-exact,
    not `assertEqual` with tolerance).

- [ ] **test_kv_order_invariance_across_classification_flips**
  - Build a synthetic mask_mod where a single parameter (`threshold`)
    controls whether one specific KV block is full or partial for a
    given Q block, without changing the mask value at any of the real
    query positions.
  - Sweep the parameter across the flip point. Assert outputs at the
    unchanged positions are bit-exact.

- [ ] **test_kv_order_invariance_multiple_q_blocks**
  - Larger shape (seq=1024, 8 Q blocks) with a mask whose padding knocks
    each Q block into a different full-count.
  - For every Q block, the output at real positions must be independent
    of the padding length.

- [ ] **test_no_regression_basic_causal**
  - Ordinary causal mask (no padding). Output must bit-exact match a
    golden run saved under `test/inductor/` (captured once on current
    main, before the patch lands) to guarantee we didn't shift numerics
    for the common case.

- [ ] **test_no_regression_document_mask**
  - Run `generate_doc_mask_mod` from `torch.nn.attention.flex_attention`
    on a representative shape. Compare against pre-patch golden.

- [ ] **test_backward_order_invariance**
  - Same setup as `test_kv_order_invariance_padded_causal` but check
    `torch.autograd.grad` w.r.t. q, k, v.
  - This may need the same fix in `flash_attention_backward.py.jinja`;
    if so, expand the implementation scope before landing.

- [ ] **test_block_mask_unified_view**
  - Build a BlockMask with separate_full_blocks=True.
  - Assert the new unified view is sorted, matches
    `partial ∪ full`, and has the correct `is_full_flag`.

- [ ] **test_flex_decoding_order_invariance**
  - Same repro pattern but in decode mode
    (`kernel_options` without `FORCE_USE_FLEX_ATTENTION`, small Q).
  - Must also be bit-exact.

## Non-goals for this PR

- Fixing `flex_flash_attention` (CuTeDSL) path — track as follow-up;
  that path has its own ordering model.
- Changing backward determinism unrelated to the kv order (e.g. atomics
  in dq/dk/dv accumulation).
- Changing classification semantics (when a block is full vs partial);
  only the processing order is touched.

## Open questions

- Should `is_full_flag` be a `torch.bool` tensor or packed into an `int8`
  alongside the existing layout? Preference: plain `torch.bool` for
  clarity; perf impact is negligible compared to the matmul.
- Should we emit a warning (once) when users still pass a BlockMask built
  from an old serialized form without the unified view? Probably yes,
  logged through `torch._logging`.
- The in-kernel branch around `mask_mod` inlines that subgraph in both
  partial and full variants. Is the extra code size acceptable in the
  shared kernel? Verify by comparing compiled kernel bytes on a few
  shapes.

## Files to touch

- `torch/nn/attention/flex_attention.py`
  - `_convert_mask_to_block_mask`
  - `BlockMask.from_kv_blocks`, `__init__`, `__getitem__`, `_adjust`
  - Exported constructor helpers
- `torch/_inductor/kernel/flex/flex_attention.py`
  - `_flex_attention_hop_impl`, kernel arg list, `kernel_options` plumbing
- `torch/_inductor/kernel/flex/flex_decoding.py`
  - mirror changes
- `torch/_inductor/kernel/flex/templates/flex_attention.py.jinja`
  - merge passes, load `is_full` per block
- `torch/_inductor/kernel/flex/templates/flex_decode.py.jinja`
  - mirror changes
- `test/inductor/test_flex_attention.py`
  - new tests above

## Reference artifacts

- Minimal repro: `~/meta/my_scripts/flex/diff.py`
- Workaround verification: `/tmp/verify_fix2.py` (diff = 0 after merge)
- Workaround perf: `/tmp/bench_merge.py`



## Run 2

> **User:** are you still running? what happend?

### Status check

I checked the current job artifacts after the user's question. The PyTorch worktree is clean (`git status --short` returned no changes), and there is no `report.md` yet in the job directory.

At this point, this run has not applied the proposed flex-attention fix in this worktree. What exists so far is the carried-over investigation summary and plan from the previous run context; implementation work had not started here yet.



## Run 3

> **User:** yup lets start implementing based off of the plan

### Initial code survey
I inspected the current flex attention/block-mask code paths in the job worktree.
The existing implementation still uses separate partial/full KV lists in BlockMask and two-pass processing in both Triton templates.
I also confirmed the main touch points for threading a new unified KV-order view: torch/nn/attention/flex_attention.py, torch/_inductor/kernel/flex/flex_attention.py, torch/_inductor/kernel/flex/flex_decoding.py, and the flex_attention/flex_decode Jinja templates.
### Added BlockMask ordered KV view
I updated torch/nn/attention/flex_attention.py to derive and store a merged KV-ascending view plus a per-entry full/partial flag.
The new tensors are threaded through BlockMask construction, serialization, repr, pytree flattening, and device moves while preserving the existing partial/full tensors for backward compatibility.
### Forward kernel plumbing switched to ordered KV inputs
I rewired the Triton forward and decode lowerings/templates to consume the merged KV-ordered tensors plus a per-block full flag.
A quick CPU-side Python sanity check confirmed BlockMask now exposes a 16-element tuple with ordered_kv_* tensors and that causal masks produce the expected mix of ordered full/partial flags.
### Targeted validation
I added a new BlockMask ordered-view unit test plus a padded-causal invariance regression test, then ran targeted pytest coverage.
Current targeted results: ordered_kv_view passes, the new padded-causal CUDA regression passes, and an existing decode-focused backend test also passes with the ordered-KV decode path.
### Lint attempt
I ran `spin fixlint` from the PyTorch worktree as required.
The run hit an environment-level clang-tidy failure because `/home/dev/.ptq_workspace/jobs/20260423-pytorch-adhoc-af67e0/pytorch/build` does not exist in this worktree, but it still applied Python lint fixes to touched files before failing.


## Run 4

> **User:** Did you also use the transfromernuggets bnechmarsk to ensure that what perf impact there was before and after?

### Perf benchmark check
I checked the job Python for `transformer_nuggets` first. In this environment `importlib.util.find_spec("transformer_nuggets")` returned `None`, so the exact transformer-nuggets helper is not available in the job venv.

To still answer the perf question with data, I added a local benchmark harness at `bench_flex_perf.py` in the job directory and ran a before/after timing sweep with CUDA events. I benchmarked the patched tree, stashed the repo changes, benchmarked `HEAD`, and then restored the stash.

Artifacts written:
- `perf_before.json`
- `perf_after.json`
- `perf_before_repeat.json`
- `perf_after_repeat.json`

### Perf findings
The patch does not show a meaningful change on the small repro or decode case, but it does show a large regression on long causal forward shapes.

Key results:
- `padded_causal_256_real201`: 0.05115 ms → 0.05134 ms (~+0.4%)
- `decode_q1_kv4096`: 0.06192 ms → 0.06256 ms (~+1.0%)
- `causal_1024`: noisy across runs; repeat measured 0.05358 ms → 0.05342 ms (effectively flat)
- `causal_4096`: 0.25626 ms → 0.48341 ms on the first sweep, and 0.25626 ms → 0.48264 ms on repeat (~+88%)

Conclusion for this question: I had not previously run a before/after perf sweep of the actual patch with transformer-nuggets. I checked now with an equivalent local timing harness, and the current implementation has a serious `causal_4096` forward regression that needs follow-up before calling perf acceptable.



## Run 5

> **User:** can you look at the changes the original we were going off of was `/home/dev/meta/my_scripts/flex/diff.py`; wanted invariance to partial/full by changing order; seeing a big regression. Later: update worklog with all variants tried, current perf numbers, and how current solution works.

### Original repro and root cause rechecked

Re-ran the original repro from `/home/dev/meta/my_scripts/flex/diff.py`. The bug is the same full/partial classification order issue:

- `real_seq_len=201`: Q block 1 has `partial=[0, 1]`, `full=[]`, so processing order is `[0, 1]`.
- `real_seq_len=256`: Q block 1 has `partial=[1]`, `full=[0]`, so old/default two-pass order is `[1, 0]`.
- Query position 200 attends to the same values in both cases, but online-softmax accumulation order differs.

### Things tried

1. **Ordered BlockMask metadata prototype**
   - Added generated `ordered_kv_num_blocks`, `ordered_kv_indices`, and `ordered_kv_is_full` tensors to `BlockMask`.
   - Threaded those tensors through HOP/lowering/templates.
   - Made forward process one KV-ascending list and skip `mask_mod` when the per-block flag says full.
   - Correct on the repro.
   - First performance problem was caused by evaluating `mask_mod` unconditionally and doing `IS_FULL_BLOCKS | mask_mod_output`; restoring a dynamic `if not IS_FULL_BLOCKS:` fixed the worst regression.
   - Still added too much metadata/API surface and was not the preferred direction.

2. **In-kernel sorted merge prototype**
   - Removed need for ordered metadata by merging existing sorted `kv_indices` and `full_kv_indices` inside the Triton forward kernel.
   - Correct for arbitrary interleavings including sliding-window patterns like `partial=[1, 3]`, `full=[2]`.
   - Forward-only naive merge perf was much slower than default and all-partial:

   ```text
   causal 1k     40.4 us
   causal 2k    118.8 us
   causal 4k    336.2 us
   causal 8k   1091.9 us
   causal 16k  3875.8 us
   ```

   - Tried cached-head and literal full/partial branch variants; both were slower.
   - Tried a shared range-capable merge for decode; it was slower still.
   - Conclusion: functionally nice, but merge overhead dominates.

3. **Kernel-option gated in-kernel merge**
   - Added a temporary `ORDERED_KV_BLOCKS` constexpr option so the default path stayed original two-pass and ordered path enabled in-kernel merge.
   - Correct, but the perf table showed this was not competitive with all-partial.
   - Reverted the kernel/template changes.

4. **All-partial construction**
   - Key realization: no kernel/template change is needed. If the `BlockMask` is constructed with no full-block separation, then all non-empty blocks are placed in `kv_indices` in KV-ascending order and `full_kv_*` is `None`.
   - Exposed existing lower-level behavior via a new user-facing `create_block_mask(..., separate_full_blocks=False)` argument.
   - Current patch only touches:
     - `torch/nn/attention/flex_attention.py`
     - `test/inductor/test_flex_attention.py`
   - Kernel fast/default behavior remains unchanged when `separate_full_blocks=True` (default).

### Current solution mechanics

Use:

```python
block_mask = create_block_mask(
    mask_mod,
    B=1,
    H=None,
    Q_LEN=padded,
    KV_LEN=padded,
    BLOCK_SIZE=BLOCK_SIZE,
    device=device,
    separate_full_blocks=False,
)
```

This means:

```text
separate_full_blocks=True  (default): full blocks stored in full_kv_indices; kernel may process partials then fulls.
separate_full_blocks=False: all non-empty blocks stored in kv_indices; full_kv_indices/full_kv_num_blocks are None; kernel applies mask_mod to every block.
```

For the original repro:

```text
Default separated schedules:
  real=201: partial=[0, 1], full=[]
  real=256: partial=[1],    full=[0]

All-partial schedules:
  real=201: partial=[0, 1], full=None
  real=256: partial=[0, 1], full=None
```

So both runs process KV blocks in the same order and become bit-exact for real rows.

### Validation

Targeted test:

```bash
pytest test/inductor/test_flex_attention.py::TestFlexAttentionCUDA::test_kv_order_invariance_padded_causal_cuda -q
```

Result:

```text
1 passed
```

Direct repro script written and run:

```text
agent_space/flex_diff_separate_full_blocks_false.py
```

Result:

```text
separate_full_blocks=False
real=201 partial=[0, 1], full=None
real=256 partial=[0, 1], full=None
pos= 64 diff=0.000e+00 match=True
pos=127 diff=0.000e+00 match=True
pos=128 diff=0.000e+00 match=True
pos=150 diff=0.000e+00 match=True
pos=200 diff=0.000e+00 match=True
```

### Current perf numbers

Benchmark script:

```text
agent_space/flex_ordered_kv_sweep.py
agent_space/run_flex_ordered_kv_sweep.sh
```

The sweep now compares default `separate_full_blocks=True` against all-partial `separate_full_blocks=False`. Latest numbers provided by the user:

| case | partial | full | full % | default us | all-partial us | all-partial Δus | all-partial Δ% |
|---|---:|---:|---:|---:|---:|---:|---:|
| padded256_real256 | 2 | 1 | 33.3 | 12.7 | 12.6 | -0.1 | -0.6 |
| padded256_real201 | 3 | 0 | 0.0 | 14.3 | 12.5 | -1.8 | -12.4 |
| causal_1024 | 8 | 28 | 77.8 | 25.8 | 27.8 | +2.0 | +7.6 |
| causal_2048 | 16 | 120 | 88.2 | 73.4 | 80.7 | +7.3 | +9.9 |
| causal_4096 | 32 | 496 | 93.9 | 245.1 | 229.5 | -15.6 | -6.4 |
| causal_8192 | 64 | 2016 | 96.9 | 632.9 | 749.5 | +116.6 | +18.4 |
| causal_16384 | 128 | 8128 | 98.4 | 2216.1 | 2677.6 | +461.5 | +20.8 |
| sliding_2048_w512 | 28 | 42 | 60.0 | 39.3 | 41.1 | +1.8 | +4.6 |
| sliding_2048_w1024 | 24 | 84 | 77.8 | 58.3 | 64.1 | +5.8 | +10.0 |
| sliding_4096_w512 | 60 | 90 | 60.0 | 75.8 | 79.2 | +3.3 | +4.4 |
| sliding_4096_w1024 | 56 | 196 | 77.8 | 102.7 | 115.4 | +12.8 | +12.4 |

Takeaway: all-partial construction is much better than in-kernel sorted merge for these masks. Overhead is generally ~4-21% in the larger causal/sliding cases and sometimes faster/no-cost for small padded cases.

### Profiler trace

Generated a Chrome/PyTorch profiler trace comparing default vs all-partial:

```text
agent_space/traces/flex_causal_4096_default_vs_all_partial.json
```

Trace ranges:

```text
default_separate_full_blocks_iter_0/1/2
all_partial_no_full_blocks_iter_0/1/2
```

Generator script:

```text
agent_space/profile_flex_all_partial.py
```

### Notes / caveats

- This is now a userland/block-mask construction option, not a kernel option.
- Default `create_block_mask` behavior remains unchanged (`separate_full_blocks=True`).
- Users who want stable bitwise behavior across full/partial classification flips should construct their mask with `separate_full_blocks=False`.
- This intentionally gives up the full-block fast path for that BlockMask: `mask_mod` runs on every non-empty block.
- The earlier very large all-partial slowdown numbers came from the older post-hoc merge benchmark path and/or different measurements. The current preferred measurement is direct construction with `separate_full_blocks=False` via `agent_space/flex_ordered_kv_sweep.py`.
- The pasted `SyntaxError: invalid syntax` was not reproduced during the final validation; the current test and sweep commands run successfully.


## Run 5

> **User:** run the review command and make an tweaks if needed also run spin fixlint


### Review command

I saved the current working-tree diff to `review_input.diff` and ran a read-only Pi review over it with no tools/session writes.
The review output was `No findings.`, so I did not make any code tweaks from review feedback.

### Lint and targeted validation

I ran `spin fixlint` from the PyTorch worktree. It applied formatting to the Python test, then failed in the existing environment-level clang-tidy path because `pytorch/build` is absent; the non-clang linters reported no issues.
I reran the targeted CUDA regression with the job Python after fixlint formatting: `1 passed in 14.67s`.

### Artifacts updated

I rewrote `report.md` to reflect the current opt-in `separate_full_blocks=False` solution, review result, lint result, and targeted validation.
I generated `fix.diff` from the current PyTorch working-tree diff after running `spin fixlint`.


## Run 6

> **User:** can you fetch teh ocmments and I guess change to torch.equal and verify they are bitwise identical


### PR comments fetched

Fetched PR #181303 comments with `gh pr view --comments`, `gh pr view --json comments,reviews`, and the review-comment API endpoint.
The actionable review comment is from `chatgpt-codex-connector[bot]` on `test/inductor/test_flex_attention.py`: the padded-causal invariance regression used `self.assertEqual` on bf16 tensors, which is tolerance-based, so it should use exact semantics such as `torch.equal`.
Dr. CI says the PR is mergeable with unrelated/flaky failures, and `liangel-02` approved the PR.

### Exact equality test tweak

Changed the new padded-causal invariance assertion from `self.assertEqual(out_partial_slice, out_full_slice)` to `self.assertTrue(torch.equal(out_partial_slice, out_full_slice))` so the regression now enforces bitwise identity over the shared real prefix.

### Bitwise validation

Ran the targeted CUDA regression after switching to `torch.equal`:
`~/.ptq_workspace/jobs/20260423-pytorch-adhoc-af67e0/.venv/bin/python -m pytest test/inductor/test_flex_attention.py::TestFlexAttentionCUDA::test_kv_order_invariance_padded_causal_cuda -q`.
Result: `1 passed in 14.86s`, so the test now verifies bitwise equality for the shared prefix.

### Lint

Ran `spin fixlint` from the PyTorch worktree after the `torch.equal` tweak.
It again failed only in the existing environment-level clang-tidy path because `pytorch/build` is missing; the later non-clang lint subset reported `ok No lint issues.`

### Artifacts updated

Wrote fetched PR/comment details to `pr_comments_raw.json`, `pr_review_comments.json`, and `pr_comments.md`.
Updated `report.md` with the actionable GitHub comment, the `torch.equal` change, the bitwise validation result, and the lint result.
Regenerated `fix.diff` from the current PyTorch working-tree diff.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo