### PR TITLE
Set device in forward input tests

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -116,6 +116,7 @@ class TestFullyShardForwardInputs(FSDPTestMultiThread):
 
     def test_root_move_forward_input_to_device(self):
         device = torch.device(device_type.type, 0)
+        getattr(torch, str(device_type), None).set_device(device)
 
         class ParamlessModule(nn.Module):
             def forward(self, x: torch.Tensor, ys: tuple[torch.Tensor, ...]):

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -116,7 +116,7 @@ class TestFullyShardForwardInputs(FSDPTestMultiThread):
 
     def test_root_move_forward_input_to_device(self):
         device = torch.device(device_type.type, 0)
-        getattr(torch, str(device_type), None).set_device(device)
+        torch.accelerator.set_device_index(device)
 
         class ParamlessModule(nn.Module):
             def forward(self, x: torch.Tensor, ys: tuple[torch.Tensor, ...]):

--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -116,7 +116,8 @@ class TestFullyShardForwardInputs(FSDPTestMultiThread):
 
     def test_root_move_forward_input_to_device(self):
         device = torch.device(device_type.type, 0)
-        torch.accelerator.set_device_index(device)
+        if device.type != "cpu":
+            torch.accelerator.set_device_index(device)
 
         class ParamlessModule(nn.Module):
             def forward(self, x: torch.Tensor, ys: tuple[torch.Tensor, ...]):

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -72,7 +72,7 @@ class TestReplicateForwardInputs(FSDPTestMultiThread):
     @skip_if_lt_x_gpu(1)
     def test_root_move_forward_input_to_device(self):
         device = torch.device(device_type.type, 0)
-        getattr(torch, str(device_type), None).set_device(device)
+        torch.accelerator.set_device_index(device)
 
         class ParamlessModule(nn.Module):
             def forward(self, x: torch.Tensor, ys: tuple[torch.Tensor, ...]):

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -72,7 +72,8 @@ class TestReplicateForwardInputs(FSDPTestMultiThread):
     @skip_if_lt_x_gpu(1)
     def test_root_move_forward_input_to_device(self):
         device = torch.device(device_type.type, 0)
-        torch.accelerator.set_device_index(device)
+        if device.type != "cpu":
+            torch.accelerator.set_device_index(device)
 
         class ParamlessModule(nn.Module):
             def forward(self, x: torch.Tensor, ys: tuple[torch.Tensor, ...]):

--- a/test/distributed/_composable/test_replicate_training.py
+++ b/test/distributed/_composable/test_replicate_training.py
@@ -72,6 +72,7 @@ class TestReplicateForwardInputs(FSDPTestMultiThread):
     @skip_if_lt_x_gpu(1)
     def test_root_move_forward_input_to_device(self):
         device = torch.device(device_type.type, 0)
+        getattr(torch, str(device_type), None).set_device(device)
 
         class ParamlessModule(nn.Module):
             def forward(self, x: torch.Tensor, ys: tuple[torch.Tensor, ...]):


### PR DESCRIPTION
The change sets device explicitly to avoid initializing DeviceMesh based on default behavior. Currently, since device type like XPU is not initialized for the current thread, DeviceMesh is initialized based on rank and the tests could have different expected behaviors, causing issue https://github.com/intel/torch-xpu-ops/issues/3139.