### PR TITLE
[CPU] Fix std_mean/var_mean all-reduce ~4x slower than std + mean (#122191)

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1822,7 +1822,7 @@ TORCH_IMPL_FUNC(argmin_out)
   argmax_argmin_impl(self, dim, keepdim, result, argmin_stub);
 }
 
-static double std_var_all_cpu(const Tensor& self, double correction, bool take_sqrt) {
+static std::tuple<double, double> std_var_all_cpu(const Tensor& self, double correction, bool take_sqrt) {
   const auto dtype = self.scalar_type();
   TORCH_CHECK(dtype == kDouble || dtype == kFloat,
               "std_var_all: Unsupported dtype ", dtype);
@@ -1867,9 +1867,9 @@ static double std_var_all_cpu(const Tensor& self, double correction, bool take_s
   if (dtype == kFloat) {
     // Convert to infinity if out of range for a float.
     // Doing it now prevents checked_convert failing later
-    return static_cast<float>(result);
+    return {static_cast<float>(mean), static_cast<float>(result)};
   }
-  return result;
+  return {mean, result};
 }
 
 namespace {
@@ -1946,7 +1946,7 @@ static Tensor& std_var_out(
     // ATen,
     //   so all-reduce has a custom implementation.
     //   See https://github.com/pytorch/pytorch/pull/43858.
-    result.fill_(std_var_all_cpu(self, correction, take_sqrt));
+    result.fill_(std::get<1>(std_var_all_cpu(self, correction, take_sqrt)));
   } else {
     std_var_stub(iter.device_type(), iter, correction, take_sqrt);
   }
@@ -2019,6 +2019,15 @@ static std::tuple<Tensor&, Tensor&> std_var_mean_out(
     // Trivial reduction
     result1.fill_(std::numeric_limits<double>::quiet_NaN());
     result2.fill_(std::numeric_limits<double>::quiet_NaN());
+  } else if (
+      result1.numel() == 1 && iter.device_type() == kCPU &&
+      iter.common_dtype() != kBFloat16 && iter.common_dtype() != kHalf) {
+    // Mirror the CPU all-reduce fast path used by std / var alone (see
+    // std_var_out above); std_var_stub is scalar Welford and is a few times
+    // slower than the parallel two-pass path here.
+    auto [mean, res] = std_var_all_cpu(self, correction, take_sqrt);
+    result1.fill_(res);
+    result2.fill_(mean);
   } else {
     std_var_stub(iter.device_type(), iter, correction, take_sqrt);
   }

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -3054,6 +3054,36 @@ class TestReductions(TestCase):
             self.assertEqual(var1, var2)
             self.assertEqual(mean1, mean2)
 
+    @onlyCPU
+    @dtypes(torch.float32, torch.float64)
+    def test_std_var_mean_all_reduce_cpu_fast_path(self, device, dtype):
+        # Regression guard for the CPU all-reduce fast path in
+        # std_var_mean_out added for issue #122191. On fp32/fp64 CPU,
+        # std_mean / var_mean over all dims take the same parallel two-pass
+        # route as std / var alone instead of scalar Welford; verify the
+        # outputs stay consistent with separate calls and within fp32
+        # precision of an fp64 ground truth.
+        torch.manual_seed(0)
+        # Non-trivial mean and stddev; |value| ~ 10 stays well inside fp32.
+        x = make_tensor(
+            (4096,), dtype=dtype, device=device, low=-3.0, high=3.0) + 10.0
+        ref_mean = x.double().mean().item()
+        # cascade_sum(fp32) accumulates error O(log(N) * eps * |value|);
+        # N=4096, |value|=10 => ~1.4e-5.
+        mean_atol = 5e-5 if dtype is torch.float32 else 1e-12
+        for correction in (None, 0, 1):
+            for keepdim in (False, True):
+                kwargs = dict(correction=correction, keepdim=keepdim)
+                got_std, got_smean = torch.std_mean(x, **kwargs)
+                got_var, got_vmean = torch.var_mean(x, **kwargs)
+                # the fast path must agree with separate std / var / mean
+                # calls, which also route through std_var_all_cpu + cascade_sum.
+                self.assertEqual(got_std, torch.std(x, **kwargs))
+                self.assertEqual(got_var, torch.var(x, **kwargs))
+                self.assertEqual(got_smean, got_vmean)
+                self.assertEqual(
+                    got_smean.item(), ref_mean, atol=mean_atol, rtol=0)
+
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
     @skipIfMPS
     def test_warn_invalid_degrees_of_freedom(self, device, dtype):


### PR DESCRIPTION
Fixes #122191.

## Summary

```python
torch.set_num_threads(1); x = torch.rand(128, 128, 128)
torch.std_mean(x)              # ~7 ms on M5
torch.std(x); torch.mean(x)    # ~1.8 ms combined
```

`std_var_out` has a CPU all-reduce fast path (added in #43858) that routes fp32/fp64 to a parallel two-pass `(x - mean)^2` in `std_var_all_cpu`. `std_var_mean_out` doesn't, and always dispatches to `std_var_stub` (scalar Welford, no vectorization).

`std_var_all_cpu` already computes the mean internally and throws it away. Returning it and adding the same fast-path branch to `std_var_mean_out` lifts the speedup. Welford stays for per-dim, complex, bf16/fp16, CUDA, and empty reductions. Diff is +13/-4 in `ReduceOps.cpp`.

Note: after this, `std_mean` fp32 all-reduce uses fp32 `cascade_sum` for the mean (as `std` already did) instead of Welford's double accumulator. For pathological `|mean| >> stddev` inputs Welford was marginally more precise; aligning `std_mean` with `std`/`var` is the intended trade-off. Promoting `self.mean()` to double inside `std_var_all_cpu` is a clean follow-up.

## Test plan

Existing `test_std_mean_*` / `test_var_mean_correction` already cross-check fused vs separate. Added `test_std_var_mean_all_reduce_cpu_fast_path` to guard the new branch against an fp64 ground truth.

Apple M5, matched source builds:

| shape | dtype | threads | before | after | speedup |
|---|---|---|---:|---:|---:|
| 1024×1024 | fp32 | 1 | 3372 µs | 842 µs | 4.00× |
| 128×128×128 | fp32 | 1 | 6764 µs | 1685 µs | 4.01× |
| 64×512×512 | fp32 | 1 | 54096 µs | 13759 µs | 3.93× |
| 64×512×512 | fp64 | 1 | 53867 µs | 14625 µs | 3.68× |
| 128×128×128 | fp32 | 10 | 6892 µs | 1727 µs | 3.99× |

Same speedup for `var_mean`. Per-dim, bf16/fp16, and the standalone std/var/mean: within jitter.
