### PR TITLE
[BE] Use sparse checkout for binary upload job

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -17,6 +17,18 @@ inputs:
   checkout-mode:
     description: 'Mode of checkout; one of "normal", "blobless", "treeless".'
     default: "normal"
+  sparse-checkout:
+    description: >
+      Newline-separated list of patterns to sparse-checkout. When set, only the
+      matching paths are materialized in the working tree. Ignored if the
+      partial-clone filter (from checkout-mode) is also honored by the underlying
+      action; passed through to actions/checkout's sparse-checkout input.
+    required: false
+    default: ""
+  sparse-checkout-cone-mode:
+    description: Whether to use cone-mode when doing a sparse checkout.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -65,6 +77,8 @@ runs:
         show-progress: false
         filter: ${{ env.filter }}
         submodules-filter: ${{ env.filter }}
+        sparse-checkout: ${{ inputs.sparse-checkout }}
+        sparse-checkout-cone-mode: ${{ inputs.sparse-checkout-cone-mode }}
 
     - name: Clean submodules post checkout
       id: clean-submodules
@@ -113,3 +127,5 @@ runs:
         show-progress: false
         filter: ${{ env.filter }}
         submodules-filter: ${{ env.filter }}
+        sparse-checkout: ${{ inputs.sparse-checkout }}
+        sparse-checkout-cone-mode: ${{ inputs.sparse-checkout-cone-mode }}

--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -94,6 +94,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
         with:
           no-sudo: true
+          submodules: "false"
+          fetch-depth: "1"
+          sparse-checkout: |
+            .ci/pytorch/binary_upload.sh
 
       - name: Configure AWS credentials(PyTorch account) for nightly
         if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/nightly' }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #181312
* #181317

The binary upload job only executes `.ci/pytorch/binary_upload.sh`, yet it was doing a full recursive checkout with all submodules, which took around 4 minutes. (see https://github.com/pytorch/pytorch/actions/runs/24824391922/job/72664393143 for example)

With this change, time it takes to "Checkout PyTorch" for the upload job is reduced to 1 sec (see https://github.com/pytorch/pytorch/actions/runs/24867696190/job/72811943869?pr=181312) 



Authored with Claude.