### PR TITLE
[BE] Add sparse-checkout input to checkout-pytorch action

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -17,6 +17,18 @@ inputs:
   checkout-mode:
     description: 'Mode of checkout; one of "normal", "blobless", "treeless".'
     default: "normal"
+  sparse-checkout:
+    description: >
+      Newline-separated list of patterns to sparse-checkout. When set, only the
+      matching paths are materialized in the working tree. Ignored if the
+      partial-clone filter (from checkout-mode) is also honored by the underlying
+      action; passed through to actions/checkout's sparse-checkout input.
+    required: false
+    default: ""
+  sparse-checkout-cone-mode:
+    description: Whether to use cone-mode when doing a sparse checkout.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -65,6 +77,8 @@ runs:
         show-progress: false
         filter: ${{ env.filter }}
         submodules-filter: ${{ env.filter }}
+        sparse-checkout: ${{ inputs.sparse-checkout }}
+        sparse-checkout-cone-mode: ${{ inputs.sparse-checkout-cone-mode }}
 
     - name: Clean submodules post checkout
       id: clean-submodules
@@ -113,3 +127,5 @@ runs:
         show-progress: false
         filter: ${{ env.filter }}
         submodules-filter: ${{ env.filter }}
+        sparse-checkout: ${{ inputs.sparse-checkout }}
+        sparse-checkout-cone-mode: ${{ inputs.sparse-checkout-cone-mode }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #181312
* __->__ #181317

Plumb `sparse-checkout` / `sparse-checkout-cone-mode` inputs through to both the primary and retry calls of pytorch/test-infra's checkout action. This lets lightweight jobs (upload, runner-determinator, etc.) materialize only the files they need instead of doing a full recursive checkout.

Authored with Claude.