### PR TITLE
Improve overlap error for in-place view updates

### DIFF
--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -96,7 +96,9 @@ void assert_no_partial_overlap(TensorImpl* a, TensorImpl* b) {
   TORCH_CHECK(get_overlap_status(a, b) != MemOverlapStatus::Partial,
     "unsupported operation: some elements of the input tensor and "
     "the written-to tensor refer to a single memory location. "
-    "Please clone() the tensor before performing the operation.");
+    "Please clone() the tensor before performing the operation. "
+    "If the tensors are overlapping views of the same base tensor, "
+    "clone() the input tensor before writing through the view.");
 }
 
 void assert_no_overlap(const TensorBase& a, const TensorBase& b) {
@@ -108,7 +110,9 @@ void assert_no_overlap(TensorImpl* a, TensorImpl* b) {
   TORCH_CHECK(lap != MemOverlapStatus::Partial && lap != MemOverlapStatus::Full,
     "unsupported operation: some elements of the input tensor and "
     "the written-to tensor refer to a single memory location. "
-    "Please clone() the tensor before performing the operation.");
+    "Please clone() the tensor before performing the operation. "
+    "If the tensors are overlapping views of the same base tensor, "
+    "clone() the input tensor before writing through the view.");
 }
 
 }

--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -96,9 +96,7 @@ void assert_no_partial_overlap(TensorImpl* a, TensorImpl* b) {
   TORCH_CHECK(get_overlap_status(a, b) != MemOverlapStatus::Partial,
     "unsupported operation: some elements of the input tensor and "
     "the written-to tensor refer to a single memory location. "
-    "Please clone() the tensor before performing the operation. "
-    "If the tensors are overlapping views of the same base tensor, "
-    "clone() the input tensor before writing through the view.");
+    "Please clone() one of the tensors before performing the operation.");
 }
 
 void assert_no_overlap(const TensorBase& a, const TensorBase& b) {
@@ -110,9 +108,7 @@ void assert_no_overlap(TensorImpl* a, TensorImpl* b) {
   TORCH_CHECK(lap != MemOverlapStatus::Partial && lap != MemOverlapStatus::Full,
     "unsupported operation: some elements of the input tensor and "
     "the written-to tensor refer to a single memory location. "
-    "Please clone() the tensor before performing the operation. "
-    "If the tensors are overlapping views of the same base tensor, "
-    "clone() the input tensor before writing through the view.");
+    "Please clone() one of the tensors before performing the operation.");
 }
 
 }

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1240,6 +1240,11 @@ class TestBinaryUfuncs(TestCase):
         t %= 1
         self.assertEqual(expected, t.data_ptr())
 
+    def test_inplace_binary_op_overlapping_views_error_message(self, device):
+        base = torch.ones((4, 4), dtype=torch.bool, device=device)
+        with self.assertRaisesRegex(RuntimeError, "overlapping views"):
+            base[:, 1:].bitwise_or_(base[:, :-1])
+
     def check_internal_mem_overlap(
         self, inplace_op, num_inputs, dtype, device, expected_failure=False
     ):

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1242,7 +1242,7 @@ class TestBinaryUfuncs(TestCase):
 
     def test_inplace_binary_op_overlapping_views_error_message(self, device):
         base = torch.ones((4, 4), dtype=torch.bool, device=device)
-        with self.assertRaisesRegex(RuntimeError, "overlapping views"):
+        with self.assertRaisesRegex(RuntimeError, r"clone\(\) one of the tensors"):
             base[:, 1:].bitwise_or_(base[:, :-1])
 
     def check_internal_mem_overlap(


### PR DESCRIPTION
## Summary

This PR improves the error message for partial memory overlap in in-place / `out=` tensor operations.

I ran into this with an overlapping-view pattern like:

```python
base[:, 1:].bitwise_or_(base[:, :-1])
```

PyTorch is correct to reject this, since the write view and input view partially overlap and the result would be order-dependent. The current error says to clone the tensor, which can be ambiguous when two tensors alias the same storage.

This updates the shared overlap diagnostic to make the remediation clearer:
```
Please clone() one of the tensors before performing the operation.
```

It also adds a regression test covering the overlapping-slice in-place binary op case.

## Test Plan
```bash
python3 -m py_compile test/test_binary_ufuncs.py
```
I did not run the compiled C++ test locally because this checkout does not have a freshly built PyTorch extension for the MemoryOverlap.cpp error-message change.