### PR TITLE
[Profiler] Add a skip_build_tree metadata field to Kineto events to m…

### DIFF
--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -1036,6 +1036,14 @@ class TransferEvents {
     return activity->getMetadataValue("hidden") == "1";
   }
 
+  bool skipBuildTree(const itrace_t* activity) const {
+    TORCH_INTERNAL_ASSERT(activity != nullptr);
+    // Kineto uses "skip_build_tree" metadata to mark events that should not be
+    // processed in build_tree. For example, some custom events intended only
+    // for marking/annotation purposes are excluded from the call tree.
+    return activity->getMetadataValue("skip_build_tree") == "1";
+  }
+
   std::shared_ptr<Result> resultFromActivity(const itrace_t* activity) {
     TORCH_INTERNAL_ASSERT(activity != nullptr);
 
@@ -1057,6 +1065,7 @@ class TransferEvents {
              /*type=*/static_cast<uint32_t>(activity->flowType()),
              /*start=*/activity->flowStart()}});
     event->hidden_ = isHiddenEvent(activity);
+    event->finished_ = skipBuildTree(activity);
     // NB: It's tempting to set `event->kineto_activity_`; however we can only
     // guarantee that the events we passed to Kineto are of type
     // `GenericTraceActivity`. Others may derive from ITraceActivity and thus


### PR DESCRIPTION
In my custom kineto backend, some events are added only for state annotation within a time range and should not appear in the call tree. Including them in build_tree may lead to incorrect parent–child relationships, so we add a `skip_build_tree` field to skip them during build_tree.