### PR TITLE
[TEST]Remove ProfilerActivity.CUDA from 2 test methods that profile CPU only Python function calls

### DIFF
--- a/test/profiler/test_python_tracer.py
+++ b/test/profiler/test_python_tracer.py
@@ -27,9 +27,7 @@ class TestPythonTracer(TestCase):
 
         names = ["Alice", "Bob"]
 
-        with profile(
-            activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], with_stack=True
-        ) as prof:
+        with profile(activities=[ProfilerActivity.CPU], with_stack=True) as prof:
             sorted(names, key=get_key)
 
         with TemporaryFileName(mode="w+") as fname:
@@ -53,9 +51,7 @@ class TestPythonTracer(TestCase):
         vi = sys.version_info
         from sys import monitoring
 
-        with profile(
-            activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], with_stack=True
-        ):
+        with profile(activities=[ProfilerActivity.CPU], with_stack=True):
             name = monitoring.get_tool(2)
             if vi.micro < 5:
                 self.assertEqual(name, "PyTorch Profiler")


### PR DESCRIPTION
Refactor test/profiler/test_python_tracer.py to be properly CPU-only by removing incorrect ProfilerActivity.CUDA from tests that profile Python function execution without any device operations.

Changes in test/profiler/test_python_tracer.py:

Remove ProfilerActivity.CUDA from 2 test methods that only profile CPU-side Python function calls:
test_method_with_c_function (line 31): Changed activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA] to activities=[ProfilerActivity.CPU]
test_monitoring_callback (line 57): Changed activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA] to activities=[ProfilerActivity.CPU]

Rationale: These tests profile Python function tracing and monitoring callbacks without creating device tensors or performing GPU operations. Including ProfilerActivity.CUDA was incorrect and inconsistent with
test_unexpected_c_return_events which already uses CPU-only profiling.

  **Test Plan:**
Verified tests pass with TEST_CONFIG=cpu:
test_method_with_c_function: ok
test_monitoring_callback: ok

Verified tests pass with TEST_CONFIG=cuda:
test_method_with_c_function: ok
test_monitoring_callback: ok

@albanD @fffrog @mansiag05 