### PR TITLE
[xpu][fix] Guard CUDA-only calls in _run_test_captured_scalar_grad for XPU

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2134,9 +2134,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         gc.collect()
         if torch.cuda.is_available():
             torch._C._cuda_clearCublasWorkspaces()
-            torch.cuda.empty_cache()
-        elif torch.xpu.is_available():
-            torch.xpu.empty_cache()
+        torch.accelerator.empty_cache()
 
     @supported_platform
     @dtypes(*device_configs["cpu"].dtypes_fast)

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2127,9 +2127,7 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         gc.collect()
         if torch.cuda.is_available():
             torch._C._cuda_clearCublasWorkspaces()
-            torch.cuda.empty_cache()
-        elif torch.xpu.is_available():
-            torch.xpu.empty_cache()
+        torch.accelerator.empty_cache()
         torch._dynamo.reset()
         gc.collect()
         if torch.cuda.is_available():

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2125,12 +2125,18 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         run()
         torch._dynamo.reset()
         gc.collect()
-        torch._C._cuda_clearCublasWorkspaces()
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch._C._cuda_clearCublasWorkspaces()
+            torch.cuda.empty_cache()
+        elif torch.xpu.is_available():
+            torch.xpu.empty_cache()
         torch._dynamo.reset()
         gc.collect()
-        torch._C._cuda_clearCublasWorkspaces()
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch._C._cuda_clearCublasWorkspaces()
+            torch.cuda.empty_cache()
+        elif torch.xpu.is_available():
+            torch.xpu.empty_cache()
 
     @supported_platform
     @dtypes(*device_configs["cpu"].dtypes_fast)


### PR DESCRIPTION
Fixes #181335
This PR wrap CUDA specific call with `if torch.cuda.is_available():`

Authored with @claude .
Co-Authored-By: Claude Sonnet 4.6 [noreply@anthropic.com](mailto:noreply@anthropic.com)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @gujinghui @fengyuan14 @guangyey