### PR TITLE
Clean up CMake related to XPU

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -525,7 +525,6 @@ if(USE_XPU)
   list(APPEND ATen_XPU_SRCS ${native_transformers_xpu_cpp})
   list(APPEND ATen_XPU_DEPENDENCY_LIBS xpu_mkldnn)
 
-  list(APPEND ATen_XPU_DEPENDENCY_LIBS ${OCL_LIBRARY})
   list(APPEND ATen_XPU_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/native/mkldnn/xpu)
   list(APPEND ATen_XPU_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/native/mkldnn/xpu/detail)
   list(APPEND ATen_XPU_INCLUDE ${XPU_MKLDNN_INCLUDE})

--- a/cmake/Modules/FindSYCLToolkit.cmake
+++ b/cmake/Modules/FindSYCLToolkit.cmake
@@ -94,38 +94,15 @@ find_file(
   NO_DEFAULT_PATH
   )
 
-# Define the old version of SYCL toolkit that is compatible with the current version of PyTorch.
-set(PYTORCH_2_5_SYCL_TOOLKIT_VERSION 20249999)
-
-# By default, we use libsycl.so on Linux and sycl.lib on Windows as the SYCL library name.
-if (SYCL_COMPILER_VERSION VERSION_LESS_EQUAL PYTORCH_2_5_SYCL_TOOLKIT_VERSION)
-  # Don't use if(WIN32) here since this requires cmake>=3.25 and file is installed
-  # and used by other projects.
-  # See: https://cmake.org/cmake/help/v3.25/variable/LINUX.html
-  if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    # On Windows, the SYCL library is named sycl7.lib until PYTORCH_2_5_SYCL_TOOLKIT_VERSION.
-    # sycl.lib is supported in the later version.
-    set(sycl_lib_suffix "7")
-  endif()
-endif()
-
 # Find SYCL library fullname.
 find_library(
   SYCL_LIBRARY
-  NAMES "sycl${sycl_lib_suffix}"
+  NAMES "sycl"
   HINTS ${SYCL_LIBRARY_DIR}
   NO_DEFAULT_PATH
 )
 
-# Find OpenCL library fullname, which is a dependency of oneDNN.
-find_library(
-  OCL_LIBRARY
-  NAMES OpenCL
-  HINTS ${SYCL_LIBRARY_DIR}
-  NO_DEFAULT_PATH
-)
-
-if((NOT SYCL_LIBRARY) OR (NOT OCL_LIBRARY))
+if(NOT SYCL_LIBRARY)
   set(SYCL_FOUND False)
   set(SYCL_REASON_FAILURE "SYCL library is incomplete!!")
   set(SYCL_NOT_FOUND_MESSAGE "${SYCL_REASON_FAILURE}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181355
# Motivation
1. oneDNN said until 3.11, oneDNN will not depend on OpenCL in build time, so we removed its dependency
2. Remove the support for the obsolete compiler 2024.*
