### PR TITLE
[dynamo] Add polyfill for operator.indexOf

### DIFF
--- a/test/dynamo/test_decorators.py
+++ b/test/dynamo/test_decorators.py
@@ -1145,10 +1145,8 @@ class DecoratorTests(PytreeRegisteringTestCase):
     def test_substitute_in_graph(self):
         counters.clear()
 
-        # NB: Choose another C function for test when we support operator.indexOf
-        #     out of the box
         cnts = torch._dynamo.testing.CompileCounter()
-        fn = operator.indexOf
+        fn = operator.delitem
         opt_fn = torch.compile(fn, backend=cnts)
         out = fn([1, 2, 3, 4, 5], 3)
         opt_out = opt_fn([1, 2, 3, 4, 5], 3)
@@ -1161,22 +1159,16 @@ class DecoratorTests(PytreeRegisteringTestCase):
 
         with self.assertRaisesRegex(TypeError, "Signature mismatch"):
 
-            @torch._dynamo.substitute_in_graph(operator.indexOf)
+            @torch._dynamo.substitute_in_graph(operator.delitem)
             def _(sequence, x):
-                for i, item in enumerate(sequence):
-                    if item is x or item == x:
-                        return i
-                raise ValueError("sequence.index(x): x not in sequence")
+                raise NotImplementedError
 
-        @torch._dynamo.substitute_in_graph(operator.indexOf)
+        @torch._dynamo.substitute_in_graph(operator.delitem)
         def polyfill(a, b):
-            for i, item in enumerate(a):
-                if item is b or item == b:
-                    return i
-            raise ValueError("sequence.index(x): x not in sequence")
+            del a[b]
 
         cnts = torch._dynamo.testing.CompileCounter()
-        fn = operator.indexOf
+        fn = operator.delitem
         opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
         out = fn([1, 2, 3, 4, 5], 3)
         opt_out = opt_fn([1, 2, 3, 4, 5], 3)

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -3718,6 +3718,18 @@ class GraphModule(torch.nn.Module):
         opt_fn = torch.compile(fn, fullgraph=True)
         self.assertEqual(opt_fn([1, 2, 3], [4, 5, 6]), [1, 2, 3, 4, 5, 6])
 
+    def test_operator_indexOf(self):
+        for seq_type in (list, tuple):
+            with self.subTest(seq_type=seq_type):
+
+                def fn(a, b):
+                    return operator.indexOf(a, b)
+
+                opt_fn = torch.compile(fn, fullgraph=True)
+                a = seq_type([4, 3, 2, 1])
+                self.assertEqual(opt_fn(a, 3), 1)
+                self.assertEqual(opt_fn(a, 4), 0)
+
     def test_attrgetter(self):
         for attrs in (
             ("shape",),

--- a/torch/_dynamo/polyfills/operator.py
+++ b/torch/_dynamo/polyfills/operator.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 # Most unary and binary operators are handled by BuiltinVariable (e.g., `pos`, `add`)
-__all__ = ["attrgetter", "concat", "countOf", "iconcat", "itemgetter", "methodcaller"]
+__all__ = ["attrgetter", "concat", "countOf", "iconcat", "indexOf", "itemgetter", "methodcaller"]
 
 
 _T = TypeVar("_T")
@@ -86,6 +86,15 @@ def countOf(a: Iterable[_T], b: _T, /) -> int:
 def iconcat(a: Sequence[_T], b: Sequence[_T2], /) -> Sequence[_T | _T2]:
     a += b  # type: ignore[operator]
     return a  # type: ignore[return-value]
+
+
+# Reference: https://docs.python.org/3/library/operator.html#operator.indexOf
+@substitute_in_graph(operator.indexOf, can_constant_fold_through=True)  # type: ignore[arg-type,misc]
+def indexOf(a: Iterable[_T], b: _T, /) -> int:
+    for i, item in enumerate(a):
+        if item is b or item == b:
+            return i
+    raise ValueError("sequence.index(x): x not in sequence")
 
 
 @overload

--- a/torch/_dynamo/polyfills/operator.py
+++ b/torch/_dynamo/polyfills/operator.py
@@ -16,7 +16,15 @@ if TYPE_CHECKING:
 
 
 # Most unary and binary operators are handled by BuiltinVariable (e.g., `pos`, `add`)
-__all__ = ["attrgetter", "concat", "countOf", "iconcat", "indexOf", "itemgetter", "methodcaller"]
+__all__ = [
+    "attrgetter",
+    "concat",
+    "countOf",
+    "iconcat",
+    "indexOf",
+    "itemgetter",
+    "methodcaller",
+]
 
 
 _T = TypeVar("_T")


### PR DESCRIPTION
`operator.indexOf` currently causes a graph break in Dynamo because it is a C builtin with no traceable Python implementation:

Failed to trace builtin operator indexOf with argument types ['list', 'int']

This PR adds a `substitute_in_graph` polyfill following the same pattern used for `operator.countOf`, `operator.concat`, `operator.attrgetter`, `operator.itemgetter`, and `operator.methodcaller`.

- `operator.indexOf(a, b)` — returns the index of the first occurrence of `b` in sequence `a`, marked `can_constant_fold_through=True`

Tests added alongside the existing `test_operator_concat` / `test_operator_iconcat` tests in `test/dynamo/test_functions.py`.

Fixes part of #116396

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98