### PR TITLE
[pytorch] enable frame pointers in aoti_inductor wrappers.so by default

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2060,7 +2060,7 @@ class aot_inductor:
 
     # Enable frame pointers for profiling tools (e.g. strobelight)
     enable_frame_pointer = (
-        os.environ.get("AOT_INDUCTOR_ENABLE_FRAME_POINTER", "0") == "1"
+        os.environ.get("AOT_INDUCTOR_ENABLE_FRAME_POINTER", "1") == "1"
     )
 
     # Annotate generated main wrapper function, i.e. AOTInductorModel::run_impl,


### PR DESCRIPTION
Summary:
Enable `config.aot_inductor.enable_frame_pointer` by default so that `-fno-omit-frame-pointer` is always passed when building AOTInductor shared libraries. This allows profiling tools like Strobelight to produce accurate stack traces through AOTInductor-compiled code without requiring users to set an env var.

Can be disabled via `AOT_INDUCTOR_ENABLE_FRAME_POINTER=0` if needed.

SlimDSNN benchmark results (1M iterations each, `fbcode//mode/opt`, `slimdsnn_dso_benchmark`):

| Run | No FP (latency us) | No FP (QPS) | With FP (latency us) | With FP (QPS) |
|-----|---------------------|-------------|----------------------|---------------|
| 1   | 0.373               | 2,678,610   | 0.354                | 2,826,751     |
| 2   | 0.349               | 2,864,148   | 0.375                | 2,670,063     |
| 3   | 0.356               | 2,809,218   | 0.362                | 2,762,446     |
| 4   | 0.350               | 2,861,116   | 0.353                | 2,832,388     |
| 5   | 0.348               | 2,876,630   | 0.356                | 2,805,820     |
| Avg | 0.355               | 2,817,944   | 0.360                | 2,779,494     |

Average overhead: ~1.4%, well within noise — individual runs show the frame-pointer version both faster and slower than baseline. Correctness unaffected (scores match exactly: 0.01308460).

Test Plan:
```
buck build fbcode//mode/opt fbcode//accelerators/workloads/models/slimdsnn:slimdsnn_dso_benchmark
buck run fbcode//mode/opt fbcode//accelerators/workloads/models/slimdsnn:slimdsnn -- aot --batch-size 1 --output /tmp/slimdsnn_no_fp.so --skip-bench True
AOT_INDUCTOR_ENABLE_FRAME_POINTER=1 buck run fbcode//mode/opt fbcode//accelerators/workloads/models/slimdsnn:slimdsnn -- aot --batch-size 1 --output /tmp/slimdsnn_with_fp.so --skip-bench True
buck run fbcode//mode/opt fbcode//accelerators/workloads/models/slimdsnn:slimdsnn_dso_benchmark -- --dso /tmp/slimdsnn_no_fp.so --iterations 1000000
buck run fbcode//mode/opt fbcode//accelerators/workloads/models/slimdsnn:slimdsnn_dso_benchmark -- --dso /tmp/slimdsnn_with_fp.so --iterations 1000000
```

Differential Revision: D102311464




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo