### PR TITLE
S390x: fixes for docker image build

### DIFF
--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -37,6 +37,7 @@ RUN yum install -y \
   gcc-toolset-${DEVTOOLSET_VERSION}-gcc \
   gcc-toolset-${DEVTOOLSET_VERSION}-gcc-c++ \
   gcc-toolset-${DEVTOOLSET_VERSION}-binutils \
+  gcc-toolset-${DEVTOOLSET_VERSION}-binutils-gold \
   gcc-toolset-${DEVTOOLSET_VERSION}-gcc-gfortran \
   cmake \
   rust \

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -104,18 +104,6 @@ RUN pip-3.12 install typing_extensions
 ENTRYPOINT []
 CMD ["/bin/bash"]
 
-# install test dependencies:
-# - grpcio requires system openssl, bundled crypto fails to build
-RUN dnf install -y \
-  hdf5-devel \
-  python3-h5py \
-  git
-
-RUN env GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True pip3 install grpcio
-
-# cmake-3.28.0 from pip for onnxruntime
-RUN python3 -mpip install cmake==3.28.0
-
 ADD ./common/patch_libstdc.sh patch_libstdc.sh
 RUN bash ./patch_libstdc.sh && rm patch_libstdc.sh
 

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -99,8 +99,6 @@ COPY --from=patchelf           /usr/local/bin/patchelf               /usr/local/
 RUN alternatives --set python /usr/bin/python3.12
 RUN alternatives --set python3 /usr/bin/python3.12
 
-RUN pip-3.12 install typing_extensions
-
 ENTRYPOINT []
 CMD ["/bin/bash"]
 

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -13,7 +13,6 @@ ARG DEVTOOLSET_VERSION=14
 RUN yum -y install epel-release
 RUN yum -y update
 RUN yum install -y \
-  sudo \
   autoconf \
   automake \
   bison \

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -84,15 +84,19 @@ RUN cp $(which patchelf) /patchelf
 FROM patchelf as python
 # build python
 COPY manywheel/s390_scripts /build_scripts
+
+# python 3.9 is no longer used and fails when running get-pip.py script, and 3.11.0 needs to be updated on s390x
+ENV CPYTHON_VERSIONS="3.10.1 3.11.14 3.12.0 3.13.0 3.13.0t 3.14.0 3.14.0t"
+
 ADD ./common/install_cpython.sh /build_scripts/install_cpython.sh
 ENV SSL_CERT_FILE=
 RUN bash build_scripts/build.sh && rm -r build_scripts
 
 FROM base as final
-COPY --from=python             /opt/python                           /opt/python
-COPY --from=python             /opt/_internal                        /opt/_internal
-COPY --from=python             /opt/python/cp39-cp39/bin/auditwheel  /usr/local/bin/auditwheel
-COPY --from=patchelf           /usr/local/bin/patchelf               /usr/local/bin/patchelf
+COPY --from=python             /opt/python                             /opt/python
+COPY --from=python             /opt/_internal                          /opt/_internal
+COPY --from=python             /opt/python/cp312-cp312/bin/auditwheel  /usr/local/bin/auditwheel
+COPY --from=patchelf           /usr/local/bin/patchelf                 /usr/local/bin/patchelf
 
 RUN alternatives --set python /usr/bin/python3.12
 RUN alternatives --set python3 /usr/bin/python3.12

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -48,7 +48,6 @@ RUN yum install -y \
   python3.12-test \
   python3.12-setuptools \
   python3.12-pip \
-  python3-virtualenv \
   python3.12-pyyaml \
   python3.12-numpy \
   python3.12-wheel \

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -119,27 +119,5 @@ RUN python3 -mpip install cmake==3.28.0
 ADD ./common/patch_libstdc.sh patch_libstdc.sh
 RUN bash ./patch_libstdc.sh && rm patch_libstdc.sh
 
-# build onnxruntime 1.21.0 from sources.
-# it is not possible to build it from sources using pip,
-# so just build it from upstream repository.
-# h5py is dependency of onnxruntime_training.
-# h5py==3.11.0 builds with hdf5-devel 1.10.5 from repository.
-# h5py 3.11.0 doesn't build with numpy >= 2.3.0.
-# install newest flatbuffers version first:
-# for some reason old version is getting pulled in otherwise.
-# packaging package is required for onnxruntime wheel build.
-RUN pip3 install flatbuffers && \
-  pip3 install cython 'pkgconfig>=1.5.5' 'setuptools>=77' 'numpy<2.3.0' && \
-  pip3 install --no-build-isolation h5py==3.11.0 && \
-  pip3 install packaging && \
-  git clone https://github.com/microsoft/onnxruntime && \
-  cd onnxruntime && git checkout v1.21.0 && \
-  git submodule update --init --recursive && \
-  wget https://github.com/microsoft/onnxruntime/commit/f57db79743c4d1a3553aa05cf95bcd10966030e6.patch && \
-  patch -p1 < f57db79743c4d1a3553aa05cf95bcd10966030e6.patch && \
-  ./build.sh --config Release --parallel 0 --enable_pybind \
-  --build_wheel --enable_training --enable_training_apis \
-  --enable_training_ops --skip_tests --allow_running_as_root \
-  --compile_no_warning_as_error && \
-  pip3 install ./build/Linux/Release/dist/onnxruntime_training-*.whl && \
-  cd .. && /bin/rm -rf ./onnxruntime
+COPY manywheel/s390_scripts/dependencies_s390x.sh dependencies_s390x.sh
+RUN bash ./dependencies_s390x.sh && rm dependencies_s390x.sh

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -99,11 +99,11 @@ COPY --from=patchelf           /usr/local/bin/patchelf               /usr/local/
 RUN alternatives --set python /usr/bin/python3.12
 RUN alternatives --set python3 /usr/bin/python3.12
 
-ENTRYPOINT []
-CMD ["/bin/bash"]
-
 ADD ./common/patch_libstdc.sh patch_libstdc.sh
 RUN bash ./patch_libstdc.sh && rm patch_libstdc.sh
 
 COPY manywheel/s390_scripts/dependencies_s390x.sh dependencies_s390x.sh
 RUN bash ./dependencies_s390x.sh && rm dependencies_s390x.sh
+
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/.ci/docker/manywheel/Dockerfile_s390x
+++ b/.ci/docker/manywheel/Dockerfile_s390x
@@ -86,7 +86,7 @@ FROM patchelf as python
 COPY manywheel/s390_scripts /build_scripts
 
 # python 3.9 is no longer used and fails when running get-pip.py script, and 3.11.0 needs to be updated on s390x
-ENV CPYTHON_VERSIONS="3.10.1 3.11.14 3.12.0 3.13.0 3.13.0t 3.14.0 3.14.0t"
+ENV CPYTHON_VERSIONS="3.10.1 3.11.14 3.12.0 3.13.0 3.14.0 3.14.0t 3.15.0 3.15.0t"
 
 ADD ./common/install_cpython.sh /build_scripts/install_cpython.sh
 ENV SSL_CERT_FILE=

--- a/.ci/docker/manywheel/s390_scripts/build.sh
+++ b/.ci/docker/manywheel/s390_scripts/build.sh
@@ -43,14 +43,14 @@ autoconf --version
 build_openssl $OPENSSL_ROOT $OPENSSL_HASH
 /build_scripts/install_cpython.sh
 
-PY39_BIN=/opt/python/cp39-cp39/bin
+PY312_BIN=/opt/python/cp312-cp312/bin
 
 # Our openssl doesn't know how to find the system CA trust store
 #   (https://github.com/pypa/manylinux/issues/53)
 # And it's not clear how up-to-date that is anyway
 # So let's just use the same one pip and everyone uses
-$PY39_BIN/pip install certifi
-ln -s $($PY39_BIN/python -c 'import certifi; print(certifi.where())') \
+$PY312_BIN/pip install certifi
+ln -s $($PY312_BIN/python -c 'import certifi; print(certifi.where())') \
       /opt/_internal/certs.pem
 # If you modify this line you also have to modify the versions in the
 # Dockerfiles:
@@ -71,8 +71,8 @@ tar -xzf patchelf-0.10.tar.gz
 rm -rf patchelf-0.10.tar.gz patchelf-0.10
 
 # Install latest pypi release of auditwheel
-$PY39_BIN/pip install auditwheel
-ln -s $PY39_BIN/auditwheel /usr/local/bin/auditwheel
+$PY312_BIN/pip install auditwheel
+ln -s $PY312_BIN/auditwheel /usr/local/bin/auditwheel
 
 # Clean up development headers and other unnecessary stuff for
 # final image

--- a/.ci/docker/manywheel/s390_scripts/build_utils.sh
+++ b/.ci/docker/manywheel/s390_scripts/build_utils.sh
@@ -2,7 +2,7 @@
 # Helper utilities for build
 # Script used only in CD pipeline
 
-OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source/old/1.1.1/  # @lint-ignore
+OPENSSL_DOWNLOAD_URL=https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1l/  # @lint-ignore
 CURL_DOWNLOAD_URL=https://curl.se/download
 
 AUTOCONF_DOWNLOAD_URL=https://ftp.gnu.org/gnu/autoconf

--- a/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
+++ b/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Helper dependencies build script for s390x
+# Script used only in CD pipeline
+
+# Stop at any error, show all commands
+set -ex
+
+# Function to retry functions that sometimes timeout or have flaky failures
+retry () {
+    $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
+}
+
+
+# build onnxruntime 1.21.0 from sources.
+# it is not possible to build it from sources using pip,
+# so just build it from upstream repository.
+# h5py is dependency of onnxruntime_training.
+# h5py==3.11.0 builds with hdf5-devel 1.10.5 from repository.
+# h5py 3.11.0 doesn't build with numpy >= 2.3.0.
+# install newest flatbuffers version first:
+# for some reason old version is getting pulled in otherwise.
+# packaging package is required for onnxruntime wheel build.
+retry pip3 install flatbuffers
+retry pip3 install cython 'pkgconfig>=1.5.5' 'setuptools>=77' 'numpy<2.3.0'
+retry pip3 install --no-build-isolation h5py==3.11.0
+retry pip3 install packaging
+retry git clone https://github.com/microsoft/onnxruntime
+
+cd onnxruntime
+git checkout v1.21.0
+retry git submodule update --init --recursive
+retry wget https://github.com/microsoft/onnxruntime/commit/f57db79743c4d1a3553aa05cf95bcd10966030e6.patch
+patch -p1 < f57db79743c4d1a3553aa05cf95bcd10966030e6.patch
+retry ./build.sh --config Release --parallel 0 --enable_pybind \
+  --build_wheel --enable_training --enable_training_apis \
+  --enable_training_ops --skip_tests --allow_running_as_root \
+  --compile_no_warning_as_error
+
+pip3 install ./build/Linux/Release/dist/onnxruntime_training-*.whl
+cd ..
+/bin/rm -rf ./onnxruntime

--- a/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
+++ b/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
@@ -10,6 +10,16 @@ retry () {
     $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
 }
 
+# protobuf with fix from https://github.com/protocolbuffers/protobuf/pull/25363
+retry wget https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz
+tar xzvf protobuf-6.33.5.tar.gz
+cd protobuf-6.33.5
+retry wget https://github.com/protocolbuffers/protobuf/pull/25363.patch
+patch -p1 < 25363.patch
+python3 setup.py bdist_wheel
+pip3 install dist/protobuf-*.whl
+cd ..
+/bin/rm -rf ./protobuf-6.33.5 ./protobuf-6.33.5.tar.gz
 
 # build onnxruntime 1.21.0 from sources.
 # it is not possible to build it from sources using pip,

--- a/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
+++ b/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
@@ -10,6 +10,7 @@ retry () {
     $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
 }
 
+retry pip-3.12 install typing_extensions
 
 # install test dependencies:
 # - grpcio requires system openssl, bundled crypto fails to build

--- a/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
+++ b/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
@@ -10,6 +10,7 @@ retry () {
     $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
 }
 
+retry pip-3.12 install virtualenv
 retry pip-3.12 install typing_extensions
 
 # install test dependencies:

--- a/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
+++ b/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
@@ -20,8 +20,8 @@ retry dnf install -y \
 
 retry env GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True pip3 install grpcio
 
-# cmake-3.28.0 from pip for onnxruntime
-retry python3 -mpip install cmake==3.28.0
+# cmake-3.28.4 from pip for onnxruntime
+retry python3 -mpip install cmake==3.28.4
 
 # protobuf with fix from https://github.com/protocolbuffers/protobuf/pull/25363
 retry wget https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz

--- a/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
+++ b/.ci/docker/manywheel/s390_scripts/dependencies_s390x.sh
@@ -10,6 +10,19 @@ retry () {
     $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
 }
 
+
+# install test dependencies:
+# - grpcio requires system openssl, bundled crypto fails to build
+retry dnf install -y \
+  hdf5-devel \
+  python3-h5py \
+  git
+
+retry env GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True pip3 install grpcio
+
+# cmake-3.28.0 from pip for onnxruntime
+retry python3 -mpip install cmake==3.28.0
+
 # protobuf with fix from https://github.com/protocolbuffers/protobuf/pull/25363
 retry wget https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz
 tar xzvf protobuf-6.33.5.tar.gz

--- a/.github/workflows/build-manywheel-images-s390x.yml
+++ b/.github/workflows/build-manywheel-images-s390x.yml
@@ -2,11 +2,18 @@ name: Build manywheel docker images for s390x
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/build-manywheel-images-s390x.yml
+      - .ci/docker/manywheel/Dockerfile_s390x
+      - .ci/docker/manywheel/s390_scripts/**
   push:
     tags:
       - ciflow/s390/*
     paths:
       - .github/workflows/build-manywheel-images-s390x.yml
+      - .ci/docker/manywheel/Dockerfile_s390x
+      - .ci/docker/manywheel/s390_scripts/**
 
 
 env:

--- a/.github/workflows/build-manywheel-images-s390x.yml
+++ b/.github/workflows/build-manywheel-images-s390x.yml
@@ -3,11 +3,18 @@ name: Build manywheel docker images for s390x
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/build-manywheel-images-s390x.yml
+      - .ci/docker/manywheel/Dockerfile_s390x
+      - .ci/docker/manywheel/s390_scripts/**
   push:
     tags:
       - ciflow/s390/*
     paths:
       - .github/workflows/build-manywheel-images-s390x.yml
+      - .ci/docker/manywheel/Dockerfile_s390x
+      - .ci/docker/manywheel/s390_scripts/**
 
 
 env:


### PR DESCRIPTION
Update OpenSSL old downloads location.

Install gcc-toolset-14-binutils-gold: it fixes linking issue on s390x when building nightly wheels.
Add retries when building additional dependencies for s390x image, and move building those dependencies into a separate script file.
Install fixed protobuf.
Update cmake to version 3.28.4 since version 3.28.0 is no longer available on pypi.

Update file triggers for s390x docker image build test.