### PR TITLE
[inductor] Realize conv bias input before freezing layout

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -197,6 +197,18 @@ class CPUReproTests(TestCase):
             self.assertTrue(conv_seen)
 
     @patch("torch.cuda.is_available", lambda: False)
+    def test_conv_bias_flattened_view(self):
+        def fn(x):
+            bias = x.to(torch.bool).float().flatten()
+            return F.conv2d(x, x, bias, stride=1, padding=0)
+
+        x = torch.ones(1, 1, 1, 1)
+        expected = fn(x)
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True)
+
+        self.assertEqual(compiled(x), expected)
+
+    @patch("torch.cuda.is_available", lambda: False)
     def test_conv2d_bn_mixed_dtype(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -597,6 +597,7 @@ def convolution(
         ordered_kwargs_for_cpp_kernel.insert(0, "bias")
     else:
         bias = ir.ExternKernel.realize_input(bias)  # type: ignore[assignment]
+        assert bias is not None
         args = [x, weight, bias]
         bias.freeze_layout()
         V.graph.sizevars.guard_int_seq(bias.get_size())

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -596,8 +596,8 @@ def convolution(
         kwargs["bias"] = None  # type: ignore[typeddict-unknown-key]
         ordered_kwargs_for_cpp_kernel.insert(0, "bias")
     else:
+        bias = ir.ExternKernel.realize_input(bias)  # type: ignore[assignment]
         args = [x, weight, bias]
-        bias.realize()
         bias.freeze_layout()
         V.graph.sizevars.guard_int_seq(bias.get_size())
 


### PR DESCRIPTION
## Summary
- realize convolution bias inputs through `ExternKernel.realize_input()` before freezing layout in the inductor conv lowering path
- add a regression test covering a `flatten()`-produced bias view passed into `F.conv2d` under `torch.compile`

## Repro
```python
import torch
import torch.nn.functional as F

def fn(x):
    bias = x.to(torch.bool).float().flatten()
    return F.conv2d(x, x, bias, stride=1, padding=0)

x = torch.ones(1, 1, 1, 1)
torch.compile(fn, backend="inductor", fullgraph=True)(x)
```

## Validation
- `OMP_PREFIX=/opt/homebrew/opt/libomp uv run --no-sync python3 -m pytest test/inductor/test_cpu_repro.py -k conv_bias_flattened_view -q`

Closes #181351


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo