### PR TITLE
Fix shared-weight gradient double-counting in zero-bubble pipeline schedules

### DIFF
--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -265,6 +265,43 @@ class StageBackwardTests(TestCase):
             ref_p = ref_mod.get_parameter(name)
             torch.testing.assert_close(p.grad, ref_p.grad)
 
+    def test_stage_backward_weight_shared_weights(self, device):
+        class SharedWeightModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+
+            def forward(self, x):
+                x = torch.matmul(x, self.w)
+                x = torch.relu(x)
+                return torch.matmul(x, self.w)
+
+        mod = SharedWeightModule().to(device)
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+
+        ref_mod = copy.deepcopy(mod)
+        ref_x = x.detach().clone().requires_grad_(True)
+
+        out = mod(x)
+        loss = out.sum()
+
+        dinputs, param_groups = stage_backward_input(
+            stage_outputs_or_loss=[loss],
+            output_grads=None,
+            input_values=[x],
+            weights=mod.parameters(),
+        )
+        stage_backward_weight(mod.parameters(), param_groups)
+
+        ref_out = ref_mod(ref_x)
+        ref_loss = ref_out.sum()
+        ref_loss.backward()
+
+        torch.testing.assert_close(dinputs[0], ref_x.grad)
+        for name, p in mod.named_parameters():
+            ref_p = ref_mod.get_parameter(name)
+            torch.testing.assert_close(p.grad, ref_p.grad)
+
 
 devices = ["cpu", "cuda", "hpu", "xpu"]
 instantiate_device_type_tests(

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -286,7 +286,9 @@ def stage_backward_weight(
         handles = []
         if len(param_group["intermediates"]) > 1:
             for grads_tuple, intermediate in zip(
-                param_group["grads"], param_group["intermediates"]
+                param_group["grads"],
+                param_group["intermediates"],
+                strict=True,
             ):
                 handles.append(
                     intermediate.register_prehook(

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -281,6 +281,19 @@ def stage_backward_weight(
                     # pyrefly: ignore [bad-argument-type]
                     valid_grad_outputs.append(grad)
 
+        # prevent shared weights from double counting when
+        # intermediates are ancestor-descendant
+        handles = []
+        if len(param_group["intermediates"]) > 1:
+            for grads_tuple, intermediate in zip(
+                param_group["grads"], param_group["intermediates"]
+            ):
+                handles.append(
+                    intermediate.register_prehook(
+                        lambda grad_outputs, sg=grads_tuple: sg
+                    )
+                )
+
         # Break a reference cycle caused inside stage_backward_input->get_hook->hook
         # The summarized cycle is:
         # `hook` -> cell -> param_group -> intermediates -> `hook`
@@ -307,6 +320,9 @@ def stage_backward_weight(
                     weight.grad = dw
                 else:
                     weight.grad += dw
+
+        for handle in handles:
+            handle.remove()
     # return grads in the original order weights were provided in
     return tuple(weight_grads)
 

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -206,55 +206,60 @@ def stage_backward_input(
     )
 
     handles = []
-    for param_group in param_groups:
-        for i, intermediate in enumerate(param_group["intermediates"]):
+    try:
+        for param_group in param_groups:
+            intermediates = list(param_group["intermediates"])
+            param_group["intermediates"] = intermediates
+            for i, intermediate in enumerate(intermediates):
 
-            def get_hook(param_group, i):
-                def hook(grad_inputs):
-                    if param_group.get("grads", None) is None:
-                        param_group["grads"] = [None] * len(
-                            param_group["intermediates"]
-                        )
-                    param_group["grads"][i] = grad_inputs
+                def get_hook(param_group, i):
+                    def hook(grad_inputs):
+                        if param_group.get("grads", None) is None:
+                            param_group["grads"] = [None] * len(
+                                param_group["intermediates"]
+                            )
+                        param_group["grads"][i] = grad_inputs
 
-                return hook
+                    return hook
 
-            # These are always "split" nodes that we need to recompute, so
-            # save their inputs.
-            handle = intermediate.register_prehook(get_hook(param_group, i))
-            handles.append(handle)
+                handle = intermediate.register_prehook(get_hook(param_group, i))
+                handles.append(handle)
 
-    if output_grads is None:
-        # In case this is the loss and there are no output_grads, then we just use 1s
-        output_grads = [
-            torch.ones_like(stage_output) for stage_output in stage_outputs_or_loss
-        ]
+        if output_grads is None:
+            output_grads = [
+                torch.ones_like(stage_output) for stage_output in stage_outputs_or_loss
+            ]
 
-    dinputs = _autograd_grad_for_inputs(
-        stage_outputs_or_loss,
-        input_values,
-        output_grads,
-        retain_graph=True,
-    )
+        dinputs = _autograd_grad_for_inputs(
+            stage_outputs_or_loss,
+            input_values,
+            output_grads,
+            retain_graph=True,
+        )
 
-    # Accumulate into .grad
-    for inp, dinput in zip(input_values, dinputs):
-        if isinstance(inp, torch.Tensor) and dinput is not None:
-            if inp.grad is None:
-                inp.grad = dinput
-            else:
-                inp.grad += dinput
+        for inp, dinput in zip(input_values, dinputs):
+            if isinstance(inp, torch.Tensor) and dinput is not None:
+                if inp.grad is None:
+                    inp.grad = dinput
+                else:
+                    inp.grad += dinput
 
-    # stage_outputs_or_loss are not used in backwards after this point, so we can safely remove it from the autograd graph
-    # this allows autograd to clear up the graph dedicated for this tensor and free up significant memory
-    for t in stage_outputs_or_loss:
-        t.detach_()
+        # drop output side graph state we no longer need
+        for t in stage_outputs_or_loss:
+            t.detach_()
 
-    # hooks are no longer necessary, clean up for consistency
-    for handle in handles:
-        handle.remove()
-
-    return dinputs, param_groups
+        return dinputs, param_groups
+    except Exception as e:
+        exc_msg = f"""
+        Failed to run stage backward input:
+        Stage output: {map_debug_info(stage_outputs_or_loss)}
+        Output gradient: {map_debug_info(output_grads)}
+        Input: {map_debug_info(input_values)}
+        """
+        raise RuntimeError(exc_msg) from e
+    finally:
+        for handle in handles:
+            handle.remove()
 
 
 def stage_backward_weight(
@@ -281,51 +286,44 @@ def stage_backward_weight(
                     # pyrefly: ignore [bad-argument-type]
                     valid_grad_outputs.append(grad)
 
-        # prevent shared weights from double counting when
-        # intermediates are ancestor-descendant
+        # clamp saved grads to avoid double counting through descendant intermediates.
         handles = []
-        if len(param_group["intermediates"]) > 1:
-            for grads_tuple, intermediate in zip(
-                param_group["grads"],
-                param_group["intermediates"],
-                strict=True,
-            ):
-                handles.append(
-                    intermediate.register_prehook(
-                        lambda grad_outputs, sg=grads_tuple: sg
+        try:
+            if len(param_group["intermediates"]) > 1:
+                for grads_tuple, intermediate in zip(
+                    param_group["grads"],
+                    param_group["intermediates"],
+                    strict=True,
+                ):
+                    handles.append(
+                        intermediate.register_prehook(
+                            lambda grad_outputs, sg=grads_tuple: sg
+                        )
                     )
+
+            # break the hook -> param_group -> intermediates cycle
+            del param_group["intermediates"]
+
+            if valid_edges:
+                weights_edges = tuple(GradientEdge(w, 0) for w in param_group["params"])
+                dweights = torch.autograd.grad(
+                    valid_edges,
+                    weights_edges,
+                    grad_outputs=valid_grad_outputs,
+                    retain_graph=retain_graph,
                 )
 
-        # Break a reference cycle caused inside stage_backward_input->get_hook->hook
-        # The summarized cycle is:
-        # `hook` -> cell -> param_group -> intermediates -> `hook`
-        # because we install the hook function onto each of the intermediate autograd nodes.
-        # We need to keep intermediates alive up until backward_weight, but we can free it now.
-        del param_group["intermediates"]
+                del param_group["grads"]
 
-        if valid_edges:  # Only call autograd.grad if we have valid gradients
-            # [NEW!] Able to pass a GradientEdge to autograd.grad as output
-            weights_edges = tuple(GradientEdge(w, 0) for w in param_group["params"])
-            dweights = torch.autograd.grad(
-                valid_edges,
-                weights_edges,
-                grad_outputs=valid_grad_outputs,
-                retain_graph=retain_graph,
-            )
-
-            # release grad memory early after use
-            del param_group["grads"]
-
-            for grad_acc, dw in zip(param_group["params"], dweights):
-                weight, index = grad_acc_to_weight[grad_acc]
-                if weight.grad is None:
-                    weight.grad = dw
-                else:
-                    weight.grad += dw
-
-        for handle in handles:
-            handle.remove()
-    # return grads in the original order weights were provided in
+                for grad_acc, dw in zip(param_group["params"], dweights):
+                    weight, index = grad_acc_to_weight[grad_acc]
+                    if weight.grad is None:
+                        weight.grad = dw
+                    else:
+                        weight.grad += dw
+        finally:
+            for handle in handles:
+                handle.remove()
     return tuple(weight_grads)
 
 


### PR DESCRIPTION
Fixes #180952 

`torch.distributed.pipelining` scheduler `ScheduleInterleavedZeroBubble` split backward into separate input and weight phases via `stage_backward_input`  and `stage_backward_weight`. When stage's module has shared weights the double count happens.

Registered prehooks when param group has multiple intermediates during the weight phase that replace incoming gradients with the values saved during the input phase, preventing the double counting.