### PR TITLE
[jit] Fix LiteInterpreter test data file resolution for installed binaries

### DIFF
--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -159,6 +159,8 @@ if(INSTALL_TEST)
   set_target_properties(test_jit PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${_rpath_portable_origin}/../lib")
   install(TARGETS test_jit DESTINATION bin)
   install(FILES ${JIT_TEST_ROOT}/test_interpreter_async.pt DESTINATION bin)
+  install(FILES ${JIT_TEST_ROOT}/script_module_v4.ptl DESTINATION bin)
+  install(DIRECTORY ${JIT_TEST_ROOT}/upgrader_models DESTINATION bin)
   # Install PDB files for MSVC builds
   if(MSVC AND BUILD_SHARED_LIBS)
     install(FILES $<TARGET_PDB_FILE:test_jit> DESTINATION bin OPTIONAL)

--- a/test/cpp/jit/test_flatbuffer.cpp
+++ b/test/cpp/jit/test_flatbuffer.cpp
@@ -28,6 +28,8 @@
 #include <torch/csrc/jit/serialization/import_export_functions.h>
 #include <unordered_set>
 
+#include <filesystem>
+
 #if defined(FB_XPLAT_BUILD) || defined(FBCODE_CAFFE2)
 #include <torch/csrc/jit/serialization/mobile_bytecode_generated_fbsource.h> // NOLINT
 namespace flatbuffers = flatbuffers_fbsource;
@@ -38,6 +40,18 @@ namespace flatbuffers = flatbuffers_fbsource;
 // Tests go in torch::jit
 namespace torch {
 namespace jit {
+
+static std::string resolveTestDataFile(
+    const char* sourceFile,
+    const char* relative) {
+  std::string srcDir(sourceFile);
+  srcDir = srcDir.substr(0, srcDir.find_last_of("/\\") + 1);
+  auto candidate = srcDir + relative;
+  if (std::filesystem::exists(candidate))
+    return candidate;
+  auto exeDir = std::filesystem::read_symlink("/proc/self/exe").parent_path();
+  return (exeDir / relative).string();
+}
 
 namespace {
 mobile::Module parse_mobile_module(
@@ -1409,9 +1423,8 @@ TEST(TestSourceFlatbuffer,
 #if !defined FB_XPLAT_BUILD
 // The following test run in fbcode only
 TEST(FlatbufferUpgraderTest, DivTensorV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append("upgrader_models/test_versioned_div_tensor_v2.ptl.ff");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_tensor_v2.ptl.ff");
   /*
   (('__torch__.MyModule.forward',
     (('instructions',
@@ -1456,10 +1469,8 @@ TEST(FlatbufferUpgraderTest, DivTensorV2) {
 }
 
 TEST(FlatbufferUpgraderTest, DivTensorOutV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
-      "upgrader_models/test_versioned_div_tensor_out_v2.ptl.ff");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_tensor_out_v2.ptl.ff");
   /*
   (('__torch__.MyModule.forward',
     (('instructions',
@@ -1498,10 +1509,8 @@ TEST(FlatbufferUpgraderTest, DivTensorOutV2) {
 }
 
 TEST(FlatbufferUpgraderTest, DivTensorInplaceV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
-      "upgrader_models/test_versioned_div_tensor_inplace_v2.ptl.ff");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_tensor_inplace_v2.ptl.ff");
   /*
   (('__torch__.MyModule.forward',
     (('instructions',
@@ -1537,10 +1546,8 @@ TEST(FlatbufferUpgraderTest, DivTensorInplaceV2) {
 }
 
 TEST(FlatbufferUpgraderTest, DivScalarFloatV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
-      "upgrader_models/test_versioned_div_scalar_float_v2.ptl.ff");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_scalar_float_v2.ptl.ff");
   /*
   (('__torch__.MyModuleFloat.forward',
     (('instructions',
@@ -1577,9 +1584,8 @@ TEST(FlatbufferUpgraderTest, DivScalarFloatV2) {
 }
 
 TEST(FlatbufferUpgraderTest, DivScalarReciprocalFloatV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
+  auto test_model_file = resolveTestDataFile(
+      __FILE__,
       "upgrader_models/test_versioned_div_scalar_reciprocal_float_v2.ptl.ff");
   /*
   (('__torch__.MyModuleFloat.forward',
@@ -1616,9 +1622,8 @@ TEST(FlatbufferUpgraderTest, DivScalarReciprocalFloatV2) {
 }
 
 TEST(FlatbufferUpgraderTest, DivScalarReciprocalIntV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
+  auto test_model_file = resolveTestDataFile(
+      __FILE__,
       "upgrader_models/test_versioned_div_scalar_reciprocal_int_v2.ptl.ff");
   /*
   (('__torch__.MyModuleInt.forward',
@@ -1656,10 +1661,8 @@ TEST(FlatbufferUpgraderTest, DivScalarReciprocalIntV2) {
 }
 
 TEST(FlatbufferUpgraderTest, DivScalarScalarV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
-      "upgrader_models/test_versioned_div_scalar_scalar_v2.ptl.ff");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_scalar_scalar_v2.ptl.ff");
   /*
   (('__torch__.MyModule.forward',
     (('instructions',
@@ -1710,10 +1713,8 @@ TEST(FlatbufferUpgraderTest, DivScalarScalarV2) {
 }
 
 TEST(FlatbufferUpgraderTest, DivScalarIntV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
-      "upgrader_models/test_versioned_div_scalar_int_v2.ptl.ff");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_scalar_int_v2.ptl.ff");
   /*
   (('__torch__.MyModuleInt.forward',
     (('instructions',
@@ -1749,9 +1750,8 @@ TEST(FlatbufferUpgraderTest, DivScalarIntV2) {
 }
 
 TEST(FlatbufferUpgraderTest, DivScalarInplaceFloatV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
+  auto test_model_file = resolveTestDataFile(
+      __FILE__,
       "upgrader_models/test_versioned_div_scalar_inplace_float_v2.ptl.ff");
   /*
   (('__torch__.MyModuleFloat.forward',
@@ -1789,9 +1789,8 @@ TEST(FlatbufferUpgraderTest, DivScalarInplaceFloatV2) {
 }
 
 TEST(FlatbufferUpgraderTest, DivScalarInplaceIntV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
+  auto test_model_file = resolveTestDataFile(
+      __FILE__,
       "upgrader_models/test_versioned_div_scalar_inplace_int_v2.ptl.ff");
   /*
   (('__torch__.MyModuleInt.forward',

--- a/test/cpp/jit/test_flatbuffer.cpp
+++ b/test/cpp/jit/test_flatbuffer.cpp
@@ -28,8 +28,6 @@
 #include <torch/csrc/jit/serialization/import_export_functions.h>
 #include <unordered_set>
 
-#include <filesystem>
-
 #if defined(FB_XPLAT_BUILD) || defined(FBCODE_CAFFE2)
 #include <torch/csrc/jit/serialization/mobile_bytecode_generated_fbsource.h> // NOLINT
 namespace flatbuffers = flatbuffers_fbsource;
@@ -40,18 +38,6 @@ namespace flatbuffers = flatbuffers_fbsource;
 // Tests go in torch::jit
 namespace torch {
 namespace jit {
-
-static std::string resolveTestDataFile(
-    const char* sourceFile,
-    const char* relative) {
-  std::string srcDir(sourceFile);
-  srcDir = srcDir.substr(0, srcDir.find_last_of("/\\") + 1);
-  auto candidate = srcDir + relative;
-  if (std::filesystem::exists(candidate))
-    return candidate;
-  auto exeDir = std::filesystem::read_symlink("/proc/self/exe").parent_path();
-  return (exeDir / relative).string();
-}
 
 namespace {
 mobile::Module parse_mobile_module(

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -23,9 +23,26 @@
 #include <torch/csrc/jit/serialization/import_export_functions.h>
 #include <unordered_set>
 
+#include <filesystem>
+
 // Tests go in torch::jit
 namespace torch {
 namespace jit {
+
+// Resolve a test data file path relative to this source file's directory.
+// Falls back to the executable's directory when the source tree is absent
+// (e.g. when running from an installed wheel in CI).
+static std::string resolveTestDataFile(
+    const char* sourceFile,
+    const char* relative) {
+  std::string srcDir(sourceFile);
+  srcDir = srcDir.substr(0, srcDir.find_last_of("/\\") + 1);
+  auto candidate = srcDir + relative;
+  if (std::filesystem::exists(candidate))
+    return candidate;
+  auto exeDir = std::filesystem::read_symlink("/proc/self/exe").parent_path();
+  return (exeDir / relative).string();
+}
 
 TEST(LiteInterpreterTest, UpsampleNearest2d) {
   Module m("m");
@@ -541,10 +558,8 @@ TEST(LiteInterpreterTest, GetRuntimeOperatorsVersion) {
  * build/run does).
  */
 TEST(LiteInterpreterTest, GetByteCodeVersion) {
-  std::string filePath(__FILE__);
   auto test_model_file_v4 =
-      filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file_v4.append("script_module_v4.ptl");
+      resolveTestDataFile(__FILE__, "script_module_v4.ptl");
 
   auto version_v4 = _get_model_bytecode_version(test_model_file_v4);
   AT_ASSERT(version_v4 == 4);
@@ -1670,9 +1685,8 @@ TEST(LiteInterpreterTest, OperatorTest2) { // NOLINT (use =delete in gtest)
 #if !defined FB_XPLAT_BUILD
 // The following test run in fbcode only
 TEST(LiteInterpreterUpgraderTest, DivTensorV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append("upgrader_models/test_versioned_div_tensor_v2.ptl");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_tensor_v2.ptl");
   /*
   (('__torch__.MyModule.forward',
     (('instructions',
@@ -1717,10 +1731,8 @@ TEST(LiteInterpreterUpgraderTest, DivTensorV2) {
 }
 
 TEST(LiteInterpreterUpgraderTest, DivTensorOutV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
-      "upgrader_models/test_versioned_div_tensor_out_v2.ptl");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_tensor_out_v2.ptl");
   /*
   (('__torch__.MyModule.forward',
     (('instructions',
@@ -1759,10 +1771,8 @@ TEST(LiteInterpreterUpgraderTest, DivTensorOutV2) {
 }
 
 TEST(LiteInterpreterUpgraderTest, DivTensorInplaceV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
-      "upgrader_models/test_versioned_div_tensor_inplace_v2.ptl");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_tensor_inplace_v2.ptl");
   /*
   (('__torch__.MyModule.forward',
     (('instructions',
@@ -1798,10 +1808,8 @@ TEST(LiteInterpreterUpgraderTest, DivTensorInplaceV2) {
 }
 
 TEST(LiteInterpreterUpgraderTest, DivScalarFloatV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
-      "upgrader_models/test_versioned_div_scalar_float_v2.ptl");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_scalar_float_v2.ptl");
   /*
   (('__torch__.MyModuleFloat.forward',
     (('instructions',
@@ -1838,9 +1846,8 @@ TEST(LiteInterpreterUpgraderTest, DivScalarFloatV2) {
 }
 
 TEST(LiteInterpreterUpgraderTest, DivScalarReciprocalFloatV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
+  auto test_model_file = resolveTestDataFile(
+      __FILE__,
       "upgrader_models/test_versioned_div_scalar_reciprocal_float_v2.ptl");
   /*
   (('__torch__.MyModuleFloat.forward',
@@ -1879,9 +1886,8 @@ TEST(LiteInterpreterUpgraderTest, DivScalarReciprocalFloatV2) {
 }
 
 TEST(LiteInterpreterUpgraderTest, DivScalarReciprocalIntV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
+  auto test_model_file = resolveTestDataFile(
+      __FILE__,
       "upgrader_models/test_versioned_div_scalar_reciprocal_int_v2.ptl");
   /*
   (('__torch__.MyModuleInt.forward',
@@ -1919,10 +1925,8 @@ TEST(LiteInterpreterUpgraderTest, DivScalarReciprocalIntV2) {
 }
 
 TEST(LiteInterpreterUpgraderTest, DivScalarScalarV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
-      "upgrader_models/test_versioned_div_scalar_scalar_v2.ptl");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_scalar_scalar_v2.ptl");
   /*
   (('__torch__.MyModule.forward',
     (('instructions',
@@ -1973,10 +1977,8 @@ TEST(LiteInterpreterUpgraderTest, DivScalarScalarV2) {
 }
 
 TEST(LiteInterpreterUpgraderTest, DivScalarIntV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
-      "upgrader_models/test_versioned_div_scalar_int_v2.ptl");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_scalar_int_v2.ptl");
   /*
   (('__torch__.MyModuleInt.forward',
     (('instructions',
@@ -2012,9 +2014,8 @@ TEST(LiteInterpreterUpgraderTest, DivScalarIntV2) {
 }
 
 TEST(LiteInterpreterUpgraderTest, DivScalarInplaceFloatV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
+  auto test_model_file = resolveTestDataFile(
+      __FILE__,
       "upgrader_models/test_versioned_div_scalar_inplace_float_v2.ptl");
   /*
   (('__torch__.MyModuleFloat.forward',
@@ -2052,10 +2053,8 @@ TEST(LiteInterpreterUpgraderTest, DivScalarInplaceFloatV2) {
 }
 
 TEST(LiteInterpreterUpgraderTest, DivScalarInplaceIntV2) {
-  std::string filePath(__FILE__);
-  auto test_model_file = filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file.append(
-      "upgrader_models/test_versioned_div_scalar_inplace_int_v2.ptl");
+  auto test_model_file = resolveTestDataFile(
+      __FILE__, "upgrader_models/test_versioned_div_scalar_inplace_int_v2.ptl");
   /*
   (('__torch__.MyModuleInt.forward',
     (('instructions',

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -23,26 +23,9 @@
 #include <torch/csrc/jit/serialization/import_export_functions.h>
 #include <unordered_set>
 
-#include <filesystem>
-
 // Tests go in torch::jit
 namespace torch {
 namespace jit {
-
-// Resolve a test data file path relative to this source file's directory.
-// Falls back to the executable's directory when the source tree is absent
-// (e.g. when running from an installed wheel in CI).
-static std::string resolveTestDataFile(
-    const char* sourceFile,
-    const char* relative) {
-  std::string srcDir(sourceFile);
-  srcDir = srcDir.substr(0, srcDir.find_last_of("/\\") + 1);
-  auto candidate = srcDir + relative;
-  if (std::filesystem::exists(candidate))
-    return candidate;
-  auto exeDir = std::filesystem::read_symlink("/proc/self/exe").parent_path();
-  return (exeDir / relative).string();
-}
 
 TEST(LiteInterpreterTest, UpsampleNearest2d) {
   Module m("m");

--- a/test/cpp/jit/test_lite_interpreter_direct.cpp
+++ b/test/cpp/jit/test_lite_interpreter_direct.cpp
@@ -23,9 +23,23 @@
 
 #include <unordered_set>
 
+#include <filesystem>
+
 // Tests go in torch::jit
 namespace torch {
 namespace jit {
+
+static std::string resolveTestDataFile(
+    const char* sourceFile,
+    const char* relative) {
+  std::string srcDir(sourceFile);
+  srcDir = srcDir.substr(0, srcDir.find_last_of("/\\") + 1);
+  auto candidate = srcDir + relative;
+  if (std::filesystem::exists(candidate))
+    return candidate;
+  auto exeDir = std::filesystem::read_symlink("/proc/self/exe").parent_path();
+  return (exeDir / relative).string();
+}
 
 TEST(LiteInterpreterDirectTest, UpsampleNearest2d) {
   Module m("m");
@@ -410,10 +424,8 @@ TEST(LiteInterpreterDirectTest, GetRuntimeOperatorsVersion) {
  * build/run does).
  */
 TEST(LiteInterpreterDirectTest, GetByteCodeVersion) {
-  std::string filePath(__FILE__);
   auto test_model_file_v4 =
-      filePath.substr(0, filePath.find_last_of("/\\") + 1);
-  test_model_file_v4.append("script_module_v4.ptl");
+      resolveTestDataFile(__FILE__, "script_module_v4.ptl");
 
   auto version_v4 = _get_model_bytecode_version(test_model_file_v4);
   AT_ASSERT(version_v4 == 4);

--- a/test/cpp/jit/test_lite_interpreter_direct.cpp
+++ b/test/cpp/jit/test_lite_interpreter_direct.cpp
@@ -23,23 +23,9 @@
 
 #include <unordered_set>
 
-#include <filesystem>
-
 // Tests go in torch::jit
 namespace torch {
 namespace jit {
-
-static std::string resolveTestDataFile(
-    const char* sourceFile,
-    const char* relative) {
-  std::string srcDir(sourceFile);
-  srcDir = srcDir.substr(0, srcDir.find_last_of("/\\") + 1);
-  auto candidate = srcDir + relative;
-  if (std::filesystem::exists(candidate))
-    return candidate;
-  auto exeDir = std::filesystem::read_symlink("/proc/self/exe").parent_path();
-  return (exeDir / relative).string();
-}
 
 TEST(LiteInterpreterDirectTest, UpsampleNearest2d) {
   Module m("m");

--- a/test/cpp/jit/test_utils.h
+++ b/test/cpp/jit/test_utils.h
@@ -5,6 +5,23 @@
 #include <torch/csrc/jit/runtime/interpreter.h>
 #include <torch/csrc/jit/testing/file_check.h>
 
+#include <filesystem>
+
+// Resolve a test data file path relative to a source file's directory.
+// Falls back to the executable's directory when the source tree is absent
+// (e.g. when running from an installed wheel in CI).
+static inline std::string resolveTestDataFile(
+    const char* sourceFile,
+    const char* relative) {
+  std::string srcDir(sourceFile);
+  srcDir = srcDir.substr(0, srcDir.find_last_of("/\\") + 1);
+  auto candidate = srcDir + relative;
+  if (std::filesystem::exists(candidate))
+    return candidate;
+  auto exeDir = std::filesystem::read_symlink("/proc/self/exe").parent_path();
+  return (exeDir / relative).string();
+}
+
 namespace {
 static inline void trim(std::string& s) {
   s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181372

Tests like LiteInterpreterUpgraderTest.DivTensorV2 and
LiteInterpreterTest.GetByteCodeVersion use __FILE__ to locate .ptl
model files relative to the source tree. When test_jit runs from an
installed location (site-packages/torch/bin/), the source tree path
may not exist, causing "No such file or directory" failures on CI
runners where the source checkout is absent at test time.

Add resolveTestDataFile() helper (matching the existing pattern in
test_graph_executor.cpp) that tries __FILE__-relative first, then
falls back to the executable's directory. Also install the
upgrader_models/ directory and script_module_v4.ptl alongside the
test binary so the fallback path finds them.

Authored with Claude.