### PR TITLE
[spmd_check] Fix spmd check for non-hashable ops

### DIFF
--- a/torch/_inductor/fx_passes/spmd_check.py
+++ b/torch/_inductor/fx_passes/spmd_check.py
@@ -105,8 +105,6 @@ def spmd_check(gm: torch.fx.GraphModule) -> bool:
         return True
 
     structure_hash = _compute_hash(gm)
-    if structure_hash is None:
-        return True
 
     from torch._subclasses.fake_tensor import unset_fake_temporarily
     from torch.distributed.distributed_c10d import _get_default_group
@@ -115,9 +113,15 @@ def spmd_check(gm: torch.fx.GraphModule) -> bool:
     world_size = dist.get_world_size()
     rank = dist.get_rank()
 
+    # All ranks must participate in all_gather even if hash is None,
+    # to avoid collective desync when only some ranks get None.
     with unset_fake_temporarily():
-        all_hashes: list[int] = [0] * world_size
+        all_hashes: list[int | None] = [None] * world_size
         dist.all_gather_object(all_hashes, structure_hash, pg)
+
+    # If any rank couldn't compute a hash, skip the check
+    if any(h is None for h in all_hashes):
+        return True
 
     if all(h == all_hashes[0] for h in all_hashes):
         return True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181373

  Summary:
  - Fix TypeError: object of type 'int' has no len() crash in _build_mismatch_report caused by collective desync
  - When _compute_hash() returns None (graph contains unpicklable objects like mkldnn tensors), the old code returned early on that rank, skipping all subsequent all_gather_object calls. Other ranks that got a valid hash proceeded with their
  collectives, causing a mismatch — the fingerprint gather received data from a different collective, putting an int into all_fingerprints
  - Fix: all ranks now participate in the hash all_gather_object regardless of whether their hash is None. After gathering, if any rank's hash is None, all ranks skip the check together, keeping collectives synchronized

  Test plan:
  - Verified the fix addresses the reported crash in spmd_check during production workloads
  - Existing test test_spmd_verify_crashes_on_mismatch in test/distributed/test_aten_comm_compute_reordering.py continues to pass

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo