### PR TITLE
Run test/custom_operator/** in CI

### DIFF
--- a/test/custom_operator/test_infer_schema_annotation.py
+++ b/test/custom_operator/test_infer_schema_annotation.py
@@ -6,7 +6,7 @@ import unittest
 
 import torch
 from torch import Tensor, types
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
 
 
 if typing.TYPE_CHECKING:
@@ -16,6 +16,7 @@ if typing.TYPE_CHECKING:
 mutates_args = {}
 
 
+@skipIfTorchDynamo("custom operator tests not applicable to dynamo")
 class TestInferSchemaWithAnnotation(TestCase):
     def test_tensor(self):
         def foo_op(x: torch.Tensor) -> torch.Tensor:

--- a/test/custom_operator/test_infer_schema_annotation.py
+++ b/test/custom_operator/test_infer_schema_annotation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import typing
+import unittest
 
 import torch
 from torch import Tensor, types
@@ -116,6 +117,7 @@ class TestInferSchemaWithAnnotation(TestCase):
         result = torch.library.infer_schema(foo_op_7, mutates_args=mutates_args)
         self.assertEqual(result, "(Scalar x) -> Scalar")
 
+    @unittest.expectedFailure
     def test_no_library_prefix(self):
         def foo_op(x: Tensor) -> Tensor:
             return x.clone()

--- a/test/custom_operator/test_out_variant.py
+++ b/test/custom_operator/test_out_variant.py
@@ -8,6 +8,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    skipIfTorchDynamo,
     TestCase,
 )
 
@@ -49,6 +50,7 @@ _test_lib.impl(
 )
 
 
+@skipIfTorchDynamo("custom operator tests not applicable to dynamo")
 class TestOutVariant(TestCase):
     def setUp(self):
         self.lib = torch.library.Library("_TestOutVariant", "FRAGMENT")  # noqa: TOR901

--- a/tools/testing/discover_tests.py
+++ b/tools/testing/discover_tests.py
@@ -74,7 +74,6 @@ TESTS = discover_tests(
     blocklisted_patterns=[
         "ao",
         "custom_backend",
-        "custom_operator",
         "fx",  # executed by test_fx.py
         "jit",  # executed by test_jit.py
         "mobile",
@@ -85,6 +84,7 @@ TESTS = discover_tests(
         "cpp_extensions/open_registration_extension/torch_openreg/tests",  # executed by test_openreg.py
     ],
     blocklisted_tests=[
+        "custom_operator/test_custom_ops",
         "test_bundled_images",
         "test_cpp_extensions_aot",
         "test_determination",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181100
* #181099
* #180987
* __->__ #181380

My guess is they were blocklisted because
test/custom_operator/test_custom_ops.py requires some special setup. This
PR removes everything except that file from the blocklist.

Test Plan:
- check the test is run in CI