### PR TITLE
[dynamo] Refactor small updates to cleanup set migration. Note on migrating internal re…

### DIFF
--- a/torch/_dynamo/variables/sets.py
+++ b/torch/_dynamo/variables/sets.py
@@ -77,6 +77,8 @@ class SetVariable(VariableTracker):
                 # VariableTracker - realize to install guards, then wrap
                 # pyrefly: ignore [bad-argument-type]
                 hashable_items.append(HashableTracker(item.realize()))
+        # Internal representation as dict allows for simple integration with
+        # OrderedSet, notably polyfills. Using set moves complexity to OrderedSet
         self.items = dict.fromkeys(hashable_items, SetVariable._default_value())
         self.should_reconstruct_all = (
             not is_from_local_source(self.source) if self.source else True
@@ -123,14 +125,7 @@ class SetVariable(VariableTracker):
         if not is_hashable(vt):
             return False
         key = HashableTracker(vt)
-        return key in self.items and not isinstance(
-            self.items[key], variables.DeletedVariable
-        )
-
-    def len(self) -> int:
-        return sum(
-            not isinstance(x, variables.DeletedVariable) for x in self.items.values()
-        )
+        return key in self.items
 
     def has_new_items(self) -> bool:
         return self.should_reconstruct_all or any(


### PR DESCRIPTION
Clean up unnecessary code from set migration. Since the values of set are always None, there isn't a need to check whether they are DeletedVariable.

Left a comment on challenge for migrating from internally represented as dict to set.
Since OrderedSet is used to reduced recompilations, afaik it can't be removed. Migrating to an internal set representation means OrderedSet can't use the polyfill ops so those have to be manually implemented for OrderedSet.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98