### PR TITLE
[distributed][claude] Add torchmux: simulate N-GPU jobs on M GPUs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1632,6 +1632,7 @@ def configure_extension_build() -> tuple[
     entry_points = {
         "console_scripts": [
             "torchrun = torch.distributed.run:main",
+            "torchmux = torch.distributed.torchmux:main",
         ],
         "torchrun.logs_specs": [
             "default = torch.distributed.elastic.multiprocessing:DefaultLogsSpecs",

--- a/setup.py
+++ b/setup.py
@@ -1632,7 +1632,6 @@ def configure_extension_build() -> tuple[
     entry_points = {
         "console_scripts": [
             "torchrun = torch.distributed.run:main",
-            "torchmux = torch.distributed.torchmux:main",
         ],
         "torchrun.logs_specs": [
             "default = torch.distributed.elastic.multiprocessing:DefaultLogsSpecs",

--- a/test/distributed/test_torchmux.py
+++ b/test/distributed/test_torchmux.py
@@ -242,6 +242,47 @@ with open(path, 'w') as f:
 """
 
 
+NEW_GROUP_SCRIPT = """
+import json
+import os
+import torch
+import torch.distributed as dist
+
+dist.init_process_group()
+rank = dist.get_rank()
+ws = dist.get_world_size()
+device = f"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}"
+torch.cuda.set_device(device)
+results = {}
+
+# Global allreduce to verify the default PG works
+x = torch.full((4,), float(rank + 1), device=device)
+dist.all_reduce(x)
+expected_global = ws * (ws + 1) / 2
+results['global_allreduce'] = torch.allclose(x, torch.full_like(x, expected_global))
+
+# Create a sub-group with the even ranks
+even_ranks = [r for r in range(ws) if r % 2 == 0]
+sub_group = dist.new_group(even_ranks)
+
+if rank % 2 == 0:
+    y = torch.full((4,), float(rank + 1), device=device)
+    dist.all_reduce(y, group=sub_group)
+    expected_sub = sum(r + 1 for r in even_ranks)
+    results['sub_allreduce'] = torch.allclose(y, torch.full_like(y, float(expected_sub)))
+
+# Another global allreduce after sub-group usage
+z = torch.full((4,), float(rank + 1), device=device)
+dist.all_reduce(z)
+results['post_subgroup_allreduce'] = torch.allclose(z, torch.full_like(z, expected_global))
+
+dist.destroy_process_group()
+path = os.path.join(os.environ['TORCHMUX_RESULTS_DIR'], f'rank{rank}.json')
+with open(path, 'w') as f:
+    json.dump({k: bool(v) for k, v in results.items()}, f)
+"""
+
+
 class _TorchmuxSubprocessBase(TestCase):
     """Shared base class for torchmux subprocess tests."""
 
@@ -1585,6 +1626,15 @@ class TestTorchmuxMultiGPU(_TorchmuxSubprocessBase):
     def test_ngpus_2_correctness(self):
         script = self._write_script("multigpu.py", MULTIGPU_SCRIPT)
         self._run_and_check_results(4, script, ngpus=2)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestTorchmuxNewGroup(_TorchmuxSubprocessBase):
+    """Test that dist.new_group() works through torchmux's monkey-patch."""
+
+    def test_new_group_with_subgroup_collective(self):
+        script = self._write_script("new_group.py", NEW_GROUP_SCRIPT)
+        self._run_and_check_results(4, script)
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_torchmux.py
+++ b/test/distributed/test_torchmux.py
@@ -1211,6 +1211,32 @@ class TestMuxPGNotImplemented(TestCase):
             pg.alltoall(None, None)
 
 
+class TestCudaBatonStructLayouts(TestCase):
+    """Verify ctypes struct sizes match the CUDA driver API expectations.
+
+    The cuCheckpointProcess* functions expect argument structs of exactly
+    64 bytes (8 x uint64). If ctypes packing changes or the struct
+    definitions drift, the driver call will corrupt memory or segfault.
+    """
+
+    def test_struct_sizes(self):
+        from torch.distributed._baton import (
+            _CheckpointArgs,
+            _LockArgs,
+            _RestoreArgs,
+            _UnlockArgs,
+        )
+
+        import ctypes
+
+        for cls in (_LockArgs, _CheckpointArgs, _RestoreArgs, _UnlockArgs):
+            self.assertEqual(
+                ctypes.sizeof(cls),
+                64,
+                f"{cls.__name__} should be 64 bytes, got {ctypes.sizeof(cls)}",
+            )
+
+
 class TestSharedInt(TestCase):
     def test_basic_read_write(self):
         from torch.distributed.torchmux import _SharedInt

--- a/test/distributed/test_torchmux.py
+++ b/test/distributed/test_torchmux.py
@@ -718,30 +718,33 @@ class TestVNCCL(_VNCCLTestBase):
         for r, t in enumerate(results):
             self.assertEqual(t, torch.full((4,), expected))
 
-    def test_allreduce_bitwise_ops(self):
+    @parametrize(
+        "op_name,expected_fn",
+        [
+            ("BAND", lambda vals: vals[0] & vals[1] & vals[2]),
+            ("BOR", lambda vals: vals[0] | vals[1] | vals[2]),
+            ("BXOR", lambda vals: vals[0] ^ vals[1] ^ vals[2]),
+        ],
+        name_fn=lambda op_name, expected_fn: op_name.lower(),
+    )
+    def test_allreduce_bitwise(self, op_name, expected_fn):
         from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
 
         pgs = self._make_pgs()
+        op = getattr(ReduceOp, op_name)
 
-        for op, expected_fn in [
-            (ReduceOp.BAND, lambda vals: vals[0] & vals[1] & vals[2]),
-            (ReduceOp.BOR, lambda vals: vals[0] | vals[1] | vals[2]),
-            (ReduceOp.BXOR, lambda vals: vals[0] ^ vals[1] ^ vals[2]),
-        ]:
-            pgs = self._make_pgs()
+        def _work(rank, pg):
+            t = [torch.tensor([rank + 1, rank + 10], dtype=torch.int64)]
+            opts = AllreduceOptions()
+            opts.reduceOp = op
+            pg.allreduce(t, opts)
+            return t[0]
 
-            def _work(rank, pg, _op=op):
-                t = [torch.tensor([rank + 1, rank + 10], dtype=torch.int64)]
-                opts = AllreduceOptions()
-                opts.reduceOp = _op
-                pg.allreduce(t, opts)
-                return t[0]
-
-            results = self._run_on_pgs(pgs, _work)
-            vals = [torch.tensor([r + 1, r + 10], dtype=torch.int64) for r in range(self._world_size)]
-            expected = expected_fn(vals)
-            for r, t in enumerate(results):
-                self.assertEqual(t, expected)
+        results = self._run_on_pgs(pgs, _work)
+        vals = [torch.tensor([r + 1, r + 10], dtype=torch.int64) for r in range(self._world_size)]
+        expected = expected_fn(vals)
+        for r, t in enumerate(results):
+            self.assertEqual(t, expected)
 
     def test_allreduce_coalesced(self):
         pgs = self._make_pgs()

--- a/test/distributed/test_torchmux.py
+++ b/test/distributed/test_torchmux.py
@@ -1322,6 +1322,7 @@ class TestTorchmuxErrorHandling(TestCase):
             timeout=120,
         )
         self.assertNotEqual(result.returncode, 0)
+        self.assertIn("intentional crash", result.stderr)
 
 
 class TestVNCCLErrorPropagation(_VNCCLTestBase):
@@ -1357,7 +1358,7 @@ class TestVNCCLErrorPropagation(_VNCCLTestBase):
 
         VNCCLProcessGroup._do = _patched_do
         try:
-            with self.assertRaises(RuntimeError):
+            with self.assertRaisesRegex(RuntimeError, "failed"):
                 self._run_on_pgs(pgs, _work)
         finally:
             VNCCLProcessGroup._do = orig_do
@@ -1666,6 +1667,127 @@ class TestVNCCLSequenceNumbering(_VNCCLTestBase):
             self.assertEqual(results[r][0], torch.full((4,), expected_ar1))
             self.assertEqual(results[r][1], torch.full((4,), 77.0))
             self.assertEqual(results[r][2], torch.full((4,), float(expected_ar2)))
+
+
+class TestVNCCLEmptyTensors(_VNCCLTestBase):
+    """Verify vnccl handles zero-sized tensors correctly."""
+
+    def test_allreduce_empty(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.empty(0)]
+            pg.allreduce(t)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, t in enumerate(results):
+            self.assertEqual(t.numel(), 0)
+
+    def test_broadcast_empty(self):
+        from torch._C._distributed_c10d import BroadcastOptions
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.empty(0)]
+            opts = BroadcastOptions()
+            opts.rootRank = 0
+            pg.broadcast(t, opts)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, t in enumerate(results):
+            self.assertEqual(t.numel(), 0)
+
+    def test_allgather_empty(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            inp = [torch.empty(0)]
+            out = [[torch.empty(0) for _ in range(self._world_size)]]
+            pg.allgather(out, inp)
+            return out[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, gathered in enumerate(results):
+            for t in gathered:
+                self.assertEqual(t.numel(), 0)
+
+
+@unittest.skipIf(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    "requires >= 2 CUDA GPUs",
+)
+class TestTorchmuxMultiGPU(TestCase):
+    """Test torchmux with --ngpus 2 to verify multi-GPU device mapping."""
+
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, True)
+
+    def test_ngpus_2_correctness(self):
+        script = os.path.join(self._tmpdir, "multigpu.py")
+        with open(script, "w") as f:
+            f.write(
+                "import json, os, torch, torch.distributed as dist\n"
+                "dist.init_process_group()\n"
+                "rank = dist.get_rank()\n"
+                "ws = dist.get_world_size()\n"
+                "ngpus = int(os.environ.get('TORCHMUX_NGPUS', '1'))\n"
+                "device = f'cuda:{rank % ngpus}'\n"
+                "torch.cuda.set_device(device)\n"
+                "results = {}\n"
+                "x = torch.full((4,), float(rank + 1), device=device)\n"
+                "dist.all_reduce(x)\n"
+                "expected = ws * (ws + 1) / 2\n"
+                "results['allreduce'] = torch.allclose(\n"
+                "    x, torch.full_like(x, expected)\n"
+                ")\n"
+                "results['device_index'] = (\n"
+                "    torch.cuda.current_device() == rank % ngpus\n"
+                ")\n"
+                "dist.destroy_process_group()\n"
+                "path = os.path.join(\n"
+                "    os.environ['TORCHMUX_RESULTS_DIR'], f'rank{rank}.json'\n"
+                ")\n"
+                "with open(path, 'w') as f:\n"
+                "    json.dump({k: bool(v) for k, v in results.items()}, f)\n"
+            )
+
+        results_dir = os.path.join(self._tmpdir, "results")
+        os.makedirs(results_dir)
+        trace_dir = os.path.join(self._tmpdir, "traces")
+        os.makedirs(trace_dir)
+        env = os.environ.copy()
+        env["TORCHMUX_NGPUS"] = "2"
+        env["TORCHMUX_RESULTS_DIR"] = results_dir
+        env["TORCHMUX_TRACE_DIR"] = trace_dir
+
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "torch.distributed.torchmux",
+                "--nproc-per-node", "4", "--ngpus", "2", script,
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"torchmux --ngpus 2 failed (rc={result.returncode}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+
+        for rank in range(4):
+            rpath = os.path.join(results_dir, f"rank{rank}.json")
+            self.assertTrue(os.path.exists(rpath), f"missing results for rank {rank}")
+            with open(rpath) as f:
+                results = json.load(f)
+            for op_name, passed in results.items():
+                self.assertTrue(passed, f"rank {rank}: {op_name} failed")
 
 
 if __name__ == "__main__":

--- a/test/distributed/test_torchmux.py
+++ b/test/distributed/test_torchmux.py
@@ -1,0 +1,1672 @@
+# Owner(s): ["oncall: distributed"]
+"""Integration tests for torchmux and vnccl.
+
+Tests cooperative scheduling trace ordering, collective correctness
+under torchmux (file-based PG), and vnccl (thread-based PG).
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+TRAIN_SCRIPT = """
+import os
+import torch
+import torch.distributed as dist
+
+dist.init_process_group()
+rank = dist.get_rank()
+ws = dist.get_world_size()
+device = f"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}"
+torch.cuda.set_device(device)
+
+# Two allreduces with compute in between
+x = torch.ones(4, 4, device=device)
+dist.all_reduce(x)
+assert torch.allclose(x, torch.full_like(x, float(ws))), f"first allreduce failed: {x}"
+y = x @ x
+dist.all_reduce(y)
+expected_y = torch.full_like(y, float(ws * ws * ws * 4))
+assert torch.allclose(y, expected_y), f"second allreduce failed: {y}"
+
+dist.destroy_process_group()
+"""
+
+
+CORRECTNESS_SCRIPT = """
+import json
+import os
+import sys
+import torch
+import torch.distributed as dist
+
+dist.init_process_group()
+rank = dist.get_rank()
+ws = dist.get_world_size()
+device = f"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}"
+torch.cuda.set_device(device)
+
+results = {}
+
+# allreduce: each rank contributes (rank+1), expect sum = ws*(ws+1)/2
+x = torch.full((4,), float(rank + 1), device=device)
+dist.all_reduce(x)
+expected_sum = ws * (ws + 1) / 2
+results["allreduce"] = torch.allclose(x, torch.full_like(x, expected_sum))
+
+# broadcast: root=0 sends tensor, others receive
+y = torch.full((4,), 42.0, device=device) if rank == 0 else torch.zeros(4, device=device)
+dist.broadcast(y, src=0)
+results["broadcast"] = torch.allclose(y, torch.full_like(y, 42.0))
+
+# allgather: each rank contributes rank, gather all
+inp = torch.full((2,), float(rank), device=device)
+gathered = [torch.zeros(2, device=device) for _ in range(ws)]
+dist.all_gather(gathered, inp)
+allgather_ok = all(
+    torch.allclose(gathered[r], torch.full((2,), float(r), device=device))
+    for r in range(ws)
+)
+results["allgather"] = allgather_ok
+
+# reduce_scatter: each rank contributes full tensor, gets a chunk of the sum
+full = torch.arange(ws * 2, dtype=torch.float32, device=device)
+out = torch.zeros(2, device=device)
+dist.reduce_scatter_tensor(out, full)
+chunk = full[rank * 2 : (rank + 1) * 2] * ws
+results["reduce_scatter"] = torch.allclose(out, chunk)
+
+# barrier: just verify it completes without hanging
+dist.barrier()
+results["barrier"] = True
+
+dist.destroy_process_group()
+
+output_path = os.path.join(os.environ["TORCHMUX_RESULTS_DIR"], f"rank{rank}.json")
+with open(output_path, "w") as f:
+    json.dump({k: bool(v) for k, v in results.items()}, f)
+"""
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestTorchmuxTraceOrdering(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, True)
+        self._script = os.path.join(self._tmpdir, "train.py")
+        with open(self._script, "w") as f:
+            f.write(TRAIN_SCRIPT)
+
+    def _run_torchmux(self, nproc, script, env_extra=None):
+        trace_dir = os.path.join(self._tmpdir, "traces")
+        os.makedirs(trace_dir, exist_ok=True)
+        env = os.environ.copy()
+        env["TORCHMUX_TRACE_DIR"] = trace_dir
+        env["TORCHMUX_NGPUS"] = "1"
+        if env_extra:
+            env.update(env_extra)
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "torch.distributed.torchmux",
+                "--nproc-per-node", str(nproc), script,
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"torchmux failed (rc={result.returncode}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+        return trace_dir
+
+    def test_3worker_trace_ordering(self):
+        """Assert trace events follow cooperative scheduling invariants.
+
+        Expected pattern per collective (3 workers):
+          W0: compute -> collective_start -> snapshot
+          W1: compute -> collective_start -> snapshot
+          W2: compute -> collective_start -> collective_finish (resolves)
+          W2: continues to next compute...
+          W2: next_collective_start -> snapshot (yields for first time)
+          W0: restore -> collective_finish -> compute
+          ...
+        """
+        trace_dir = self._run_torchmux(3, self._script)
+
+        natural_path = os.path.join(trace_dir, "torchmux_natural.json")
+        self.assertTrue(os.path.exists(natural_path))
+
+        with open(natural_path) as f:
+            trace = json.load(f)
+
+        events = [
+            e for e in trace["traceEvents"] if e.get("ph") == "X"
+        ]
+        self.assertGreater(len(events), 0, "no trace events")
+
+        per_worker = {}
+        for e in events:
+            per_worker.setdefault(e["pid"], []).append(e)
+        for pid in per_worker:
+            per_worker[pid].sort(key=lambda e: e["ts"])
+
+        self.assertEqual(len(per_worker), 3, "expected 3 workers")
+
+        # Global timeline: sort all events by start time
+        timeline = sorted(events, key=lambda e: e["ts"])
+
+        # -- Invariant 1: compute spans never overlap across workers --
+        compute_spans = [
+            (e["pid"], e["ts"], e["ts"] + e["dur"])
+            for e in timeline
+            if e["cat"] == "compute"
+        ]
+        for i in range(len(compute_spans)):
+            for j in range(i + 1, len(compute_spans)):
+                pi, si, ei = compute_spans[i]
+                pj, sj, ej = compute_spans[j]
+                if pi != pj:
+                    self.assertFalse(
+                        si < ej and sj < ei,
+                        f"compute overlap: worker {pi} [{si}-{ei}] "
+                        f"vs worker {pj} [{sj}-{ej}]",
+                    )
+
+        # -- Invariant 2: every snapshot is preceded by either a
+        #    collective or a compute (never another snapshot) --
+        for pid, worker_events in per_worker.items():
+            for i, e in enumerate(worker_events):
+                if e["cat"] == "mux" and e["name"] == "snapshot":
+                    if i > 0:
+                        prev = worker_events[i - 1]["cat"]
+                        self.assertIn(
+                            prev,
+                            ("collective", "compute"),
+                            f"worker {pid}: snapshot preceded by "
+                            f"{prev} (expected collective or compute)",
+                        )
+
+        # -- Invariant 3: every restore is followed by either a
+        #    collective or a compute (never another restore) --
+        for pid, worker_events in per_worker.items():
+            for i, e in enumerate(worker_events):
+                if e["cat"] == "mux" and e["name"] == "restore":
+                    if i < len(worker_events) - 1:
+                        nxt = worker_events[i + 1]["cat"]
+                        self.assertIn(
+                            nxt,
+                            ("collective", "compute"),
+                            f"worker {pid}: restore followed by "
+                            f"{nxt} (expected collective or compute)",
+                        )
+
+        # -- Invariant 4: the last worker to arrive at a collective
+        #    resolves without snapshotting. At least one worker must
+        #    have at least one collective NOT followed by a snapshot. --
+        any_immediate = False
+        for pid, worker_events in per_worker.items():
+            for i, e in enumerate(worker_events):
+                if e["cat"] == "collective":
+                    next_is_snapshot = (
+                        i + 1 < len(worker_events)
+                        and worker_events[i + 1]["cat"] == "mux"
+                        and worker_events[i + 1]["name"] == "snapshot"
+                    )
+                    if not next_is_snapshot:
+                        any_immediate = True
+        self.assertTrue(
+            any_immediate,
+            "every collective across all workers is followed by a "
+            "snapshot (expected the last-to-arrive worker to resolve "
+            "at least one collective immediately)",
+        )
+
+        # -- Invariant 5: snapshot-restore pairs bracket gaps where
+        #    other workers run. No worker should have snapshot without
+        #    a later restore (except the final cleanup). --
+        for pid, worker_events in per_worker.items():
+            snapshots = sum(
+                1
+                for e in worker_events
+                if e["cat"] == "mux" and e["name"] == "snapshot"
+            )
+            restores = sum(
+                1
+                for e in worker_events
+                if e["cat"] == "mux" and e["name"] == "restore"
+            )
+            self.assertIn(
+                snapshots - restores,
+                (0, 1),
+                f"worker {pid}: {snapshots} snapshots vs {restores} "
+                f"restores (expected equal or off by one)",
+            )
+
+        # -- Validate synthetic trace is also produced and well-formed --
+        synthetic_path = os.path.join(trace_dir, "torchmux_synthetic.json")
+        self.assertTrue(os.path.exists(synthetic_path))
+
+        with open(synthetic_path) as f:
+            synthetic = json.load(f)
+
+        syn_events = [
+            e for e in synthetic["traceEvents"] if e.get("ph") == "X"
+        ]
+        self.assertGreater(len(syn_events), 0, "no synthetic trace events")
+
+        for e in syn_events:
+            for field in ("cat", "name", "pid", "tid", "ts", "dur"):
+                self.assertIn(
+                    field, e, f"synthetic event missing '{field}': {e}"
+                )
+            self.assertGreaterEqual(e["ts"], 0)
+            self.assertGreaterEqual(e["dur"], 0)
+
+        syn_mux = [e for e in syn_events if e["cat"] == "mux"]
+        self.assertEqual(
+            len(syn_mux), 0,
+            "synthetic trace should not contain snapshot/restore events",
+        )
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestTorchmuxCollectiveCorrectness(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, True)
+
+    def test_collective_correctness_2workers(self):
+        script_path = os.path.join(self._tmpdir, "correctness.py")
+        with open(script_path, "w") as f:
+            f.write(CORRECTNESS_SCRIPT)
+
+        results_dir = os.path.join(self._tmpdir, "results")
+        os.makedirs(results_dir)
+
+        env = os.environ.copy()
+        env["TORCHMUX_NGPUS"] = "1"
+        env["TORCHMUX_RESULTS_DIR"] = results_dir
+        env["TORCHMUX_TRACE_DIR"] = self._tmpdir
+
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "torch.distributed.torchmux",
+                "--nproc-per-node", "2", script_path,
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"torchmux failed (rc={result.returncode}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+
+        for rank in range(2):
+            rpath = os.path.join(results_dir, f"rank{rank}.json")
+            self.assertTrue(os.path.exists(rpath), f"missing results for rank {rank}")
+            with open(rpath) as f:
+                results = json.load(f)
+            for op_name, passed in results.items():
+                self.assertTrue(passed, f"rank {rank}: {op_name} failed")
+
+
+class TestTorchmuxSyntheticTrace(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, True)
+
+    def test_synthetic_trace_structure(self):
+        from torch.distributed.torchmux_trace import export_synthetic
+
+        events_by_rank = {
+            0: [
+                ("compute", "compute", 0, 100),
+                ("collective", "allreduce", 100, 10),
+                ("compute", "compute", 110, 50),
+                ("collective", "allreduce", 160, 10),
+            ],
+            1: [
+                ("compute", "compute", 200, 80),
+                ("collective", "allreduce", 280, 10),
+                ("compute", "compute", 290, 60),
+                ("collective", "allreduce", 350, 10),
+            ],
+        }
+
+        path = os.path.join(self._tmpdir, "synthetic.json")
+        export_synthetic(events_by_rank, path, 2)
+
+        with open(path) as f:
+            trace = json.load(f)
+
+        x_events = [e for e in trace["traceEvents"] if e.get("ph") == "X"]
+        self.assertGreater(len(x_events), 0)
+
+        compute_events = [e for e in x_events if e["cat"] == "compute"]
+        coll_events = [e for e in x_events if e["cat"] == "collective"]
+
+        self.assertEqual(len(compute_events), 4)
+        self.assertEqual(len(coll_events), 4)
+
+        for rank in (0, 1):
+            rank_computes = [
+                e for e in compute_events if e["pid"] == rank
+            ]
+            rank_colls = [e for e in coll_events if e["pid"] == rank]
+            self.assertEqual(len(rank_computes), 2)
+            self.assertEqual(len(rank_colls), 2)
+
+        # In the synthetic trace, both workers' first compute starts
+        # at ts=0 (overlapped)
+        first_computes = [
+            e for e in compute_events
+            if e["ts"] == 0
+        ]
+        self.assertEqual(len(first_computes), 2)
+
+        # No snapshot/restore events in synthetic trace
+        mux_events = [e for e in x_events if e["cat"] == "mux"]
+        self.assertEqual(len(mux_events), 0)
+
+    def test_natural_trace_preserves_timestamps(self):
+        from torch.distributed.torchmux_trace import export_natural
+
+        events_by_rank = {
+            0: [
+                ("compute", "compute", 1000, 100),
+                ("mux", "snapshot", 1100, 5),
+            ],
+            1: [
+                ("compute", "compute", 1200, 80),
+            ],
+        }
+
+        path = os.path.join(self._tmpdir, "natural.json")
+        export_natural(events_by_rank, path, 2)
+
+        with open(path) as f:
+            trace = json.load(f)
+
+        x_events = [e for e in trace["traceEvents"] if e.get("ph") == "X"]
+        self.assertEqual(len(x_events), 3)
+
+        # First event should be at ts=0 (base_ts subtracted)
+        ts_values = sorted(e["ts"] for e in x_events)
+        self.assertEqual(ts_values[0], 0)
+
+    def test_empty_events(self):
+        from torch.distributed.torchmux_trace import export_natural, export_synthetic
+
+        path_n = os.path.join(self._tmpdir, "empty_natural.json")
+        path_s = os.path.join(self._tmpdir, "empty_synthetic.json")
+        export_natural({}, path_n, 2)
+        export_synthetic({}, path_s, 2)
+
+        for path in (path_n, path_s):
+            with open(path) as f:
+                trace = json.load(f)
+            x_events = [e for e in trace["traceEvents"] if e.get("ph") == "X"]
+            self.assertEqual(len(x_events), 0)
+
+
+class TestMuxDevice(TestCase):
+    def test_cuda_index_remapping(self):
+        from torch.distributed.torchmux import _MuxDevice, _OrigDevice
+
+        import torch.distributed.torchmux as tm
+        orig_ngpus = tm._ngpus
+        try:
+            tm._ngpus = 2
+            d = _MuxDevice("cuda:5")
+            self.assertEqual(d, _OrigDevice("cuda:1"))
+
+            d = _MuxDevice("cuda:4")
+            self.assertEqual(d, _OrigDevice("cuda:0"))
+
+            d = _MuxDevice("cuda:0")
+            self.assertEqual(d, _OrigDevice("cuda:0"))
+        finally:
+            tm._ngpus = orig_ngpus
+
+    def test_non_cuda_passthrough(self):
+        from torch.distributed.torchmux import _MuxDevice, _OrigDevice
+
+        d = _MuxDevice("cpu")
+        self.assertEqual(d, _OrigDevice("cpu"))
+
+    def test_isinstance_compat(self):
+        from torch.distributed.torchmux import _MuxDevice, _OrigDevice
+
+        d = _MuxDevice("cpu")
+        self.assertIsInstance(d, _OrigDevice)
+
+    def test_cuda_no_index_passthrough(self):
+        from torch.distributed.torchmux import _MuxDevice, _OrigDevice
+
+        import torch.distributed.torchmux as tm
+        orig_ngpus = tm._ngpus
+        try:
+            tm._ngpus = 2
+            d = _MuxDevice("cuda")
+            self.assertEqual(d, _OrigDevice("cuda"))
+            self.assertIsNone(d.index)
+        finally:
+            tm._ngpus = orig_ngpus
+
+    def test_remapping_single_gpu(self):
+        from torch.distributed.torchmux import _MuxDevice, _OrigDevice
+
+        import torch.distributed.torchmux as tm
+        orig_ngpus = tm._ngpus
+        try:
+            tm._ngpus = 1
+            for idx in range(8):
+                d = _MuxDevice(f"cuda:{idx}")
+                self.assertEqual(d, _OrigDevice("cuda:0"))
+        finally:
+            tm._ngpus = orig_ngpus
+
+
+class _VNCCLTestBase(TestCase):
+    """Shared base class for vnccl tests with common setup/teardown."""
+
+    def setUp(self):
+        super().setUp()
+        self._world_size = 3
+        self._pgs = []
+
+    def tearDown(self):
+        import torch.distributed.vnccl as vnccl
+        from torch.distributed.vnccl import VNCCLProcessGroup
+
+        VNCCLProcessGroup._active.clear()
+        for pg in self._pgs:
+            dist.distributed_c10d._world.pg_names.pop(pg, None)
+        self._pgs = []
+        vnccl._next_rank = 0
+        vnccl._rng_states.clear()
+        super().tearDown()
+
+    def _make_pgs(self, pg_name="vnccl_test"):
+        from torch.distributed.vnccl import VNCCLProcessGroup
+
+        pgs = []
+        for r in range(self._world_size):
+            pg = VNCCLProcessGroup(r, self._world_size)
+            dist.distributed_c10d._world.pg_names[pg] = pg_name
+            pgs.append(pg)
+        self._pgs = pgs
+        return pgs
+
+    def _run_on_pgs(self, pgs, fn):
+        results = [None] * self._world_size
+        errors = [None] * self._world_size
+
+        def _worker(rank):
+            try:
+                results[rank] = fn(rank, pgs[rank])
+            except Exception as e:
+                errors[rank] = e
+
+        threads = [
+            threading.Thread(target=_worker, args=(r,))
+            for r in range(self._world_size)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+        hung = [r for r, t in enumerate(threads) if t.is_alive()]
+        if hung:
+            raise RuntimeError(
+                f"ranks {hung} still alive after 30s timeout"
+            )
+        for r, e in enumerate(errors):
+            if e is not None:
+                raise RuntimeError(f"rank {r} failed") from e
+        return results
+
+
+class TestVNCCL(_VNCCLTestBase):
+    """Tests vnccl collective correctness using direct PG method calls.
+
+    Each test creates VNCCLProcessGroup instances directly and runs
+    collective operations from separate threads, bypassing
+    dist.init_process_group to avoid global state conflicts.
+    """
+
+    def test_allreduce_sum(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), float(rank + 1))]
+            pg.allreduce(t)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = self._world_size * (self._world_size + 1) / 2
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), expected))
+
+    def test_allreduce_avg(self):
+        from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), float(rank + 1))]
+            opts = AllreduceOptions()
+            opts.reduceOp = ReduceOp.AVG
+            pg.allreduce(t, opts)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = (self._world_size + 1) / 2.0
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), expected))
+
+    def test_allreduce_product(self):
+        from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), float(rank + 1))]
+            opts = AllreduceOptions()
+            opts.reduceOp = ReduceOp.PRODUCT
+            pg.allreduce(t, opts)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = 1.0
+        for r in range(self._world_size):
+            expected *= r + 1
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), expected))
+
+    def test_allreduce_min(self):
+        from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), float(rank + 1))]
+            opts = AllreduceOptions()
+            opts.reduceOp = ReduceOp.MIN
+            pg.allreduce(t, opts)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), 1.0))
+
+    def test_allreduce_max(self):
+        from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), float(rank + 1))]
+            opts = AllreduceOptions()
+            opts.reduceOp = ReduceOp.MAX
+            pg.allreduce(t, opts)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), float(self._world_size)))
+
+    def test_allreduce_bitwise_ops(self):
+        from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
+
+        pgs = self._make_pgs()
+
+        for op, expected_fn in [
+            (ReduceOp.BAND, lambda vals: vals[0] & vals[1] & vals[2]),
+            (ReduceOp.BOR, lambda vals: vals[0] | vals[1] | vals[2]),
+            (ReduceOp.BXOR, lambda vals: vals[0] ^ vals[1] ^ vals[2]),
+        ]:
+            pgs = self._make_pgs()
+
+            def _work(rank, pg, _op=op):
+                t = [torch.tensor([rank + 1, rank + 10], dtype=torch.int64)]
+                opts = AllreduceOptions()
+                opts.reduceOp = _op
+                pg.allreduce(t, opts)
+                return t[0]
+
+            results = self._run_on_pgs(pgs, _work)
+            vals = [torch.tensor([r + 1, r + 10], dtype=torch.int64) for r in range(self._world_size)]
+            expected = expected_fn(vals)
+            for r, t in enumerate(results):
+                self.assertEqual(t, expected)
+
+    def test_allreduce_coalesced(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), float(rank + 1))]
+            pg.allreduce_coalesced(t)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = self._world_size * (self._world_size + 1) / 2
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), expected))
+
+    def test_broadcast(self):
+        pgs = self._make_pgs()
+
+        from torch._C._distributed_c10d import BroadcastOptions
+
+        def _work(rank, pg):
+            t = [torch.full((4,), 99.0) if rank == 0 else torch.zeros(4)]
+            opts = BroadcastOptions()
+            opts.rootRank = 0
+            pg.broadcast(t, opts)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), 99.0))
+
+    def test_broadcast_non_root(self):
+        pgs = self._make_pgs()
+
+        from torch._C._distributed_c10d import BroadcastOptions
+
+        def _work(rank, pg):
+            t = [torch.full((4,), 77.0) if rank == 2 else torch.zeros(4)]
+            opts = BroadcastOptions()
+            opts.rootRank = 2
+            pg.broadcast(t, opts)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), 77.0))
+
+    def test_allgather(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            inp = [torch.full((2,), float(rank))]
+            out = [[torch.zeros(2) for _ in range(self._world_size)]]
+            pg.allgather(out, inp)
+            return out[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, gathered in enumerate(results):
+            for src, t in enumerate(gathered):
+                self.assertEqual(t, torch.full((2,), float(src)))
+
+    def test_allgather_base(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            inp = torch.full((2,), float(rank))
+            out = torch.zeros(2 * self._world_size)
+            pg._allgather_base(out, inp)
+            return out
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = torch.cat([torch.full((2,), float(r)) for r in range(self._world_size)])
+        for r, t in enumerate(results):
+            self.assertEqual(t, expected)
+
+    def test_reduce_scatter(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            chunks = [torch.full((2,), float(rank + 1)) for _ in range(self._world_size)]
+            out = [torch.zeros(2)]
+            pg.reduce_scatter(out, [chunks])
+            return out[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = self._world_size * (self._world_size + 1) / 2
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((2,), expected))
+
+    def test_reduce_scatter_base(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            inp = torch.full((2 * self._world_size,), float(rank + 1))
+            out = torch.zeros(2)
+            pg._reduce_scatter_base(out, inp)
+            return out
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = self._world_size * (self._world_size + 1) / 2
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((2,), expected))
+
+    def test_scatter(self):
+        pgs = self._make_pgs()
+
+        from torch._C._distributed_c10d import ScatterOptions
+
+        def _work(rank, pg):
+            if rank == 0:
+                src = [torch.full((2,), float(i)) for i in range(self._world_size)]
+            else:
+                src = []
+            out = [torch.zeros(2)]
+            opts = ScatterOptions()
+            opts.rootRank = 0
+            pg.scatter(out, [src], opts)
+            return out[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((2,), float(r)))
+
+    def test_gather(self):
+        pgs = self._make_pgs()
+
+        from torch._C._distributed_c10d import ScatterOptions
+
+        def _work(rank, pg):
+            inp = [torch.full((2,), float(rank))]
+            if rank == 0:
+                out = [[torch.zeros(2) for _ in range(self._world_size)]]
+            else:
+                out = [[]]
+            opts = ScatterOptions()
+            opts.rootRank = 0
+            pg.gather(out, inp, opts)
+            return out[0] if rank == 0 else None
+
+        results = self._run_on_pgs(pgs, _work)
+        gathered = results[0]
+        for src, t in enumerate(gathered):
+            self.assertEqual(t, torch.full((2,), float(src)))
+
+    def test_alltoall(self):
+        pgs = self._make_pgs()
+        ws = self._world_size
+
+        def _work(rank, pg):
+            inp = [torch.full((2,), float(rank * ws + dst)) for dst in range(ws)]
+            out = [torch.zeros(2) for _ in range(ws)]
+            pg.alltoall(out, inp)
+            return out
+
+        results = self._run_on_pgs(pgs, _work)
+        for dst in range(ws):
+            for src in range(ws):
+                self.assertEqual(
+                    results[dst][src],
+                    torch.full((2,), float(src * ws + dst)),
+                )
+
+    def test_barrier(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            pg.barrier()
+            return True
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, v in enumerate(results):
+            self.assertTrue(v, f"rank {r}: barrier failed")
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_allreduce_cuda(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), float(rank + 1), device="cuda")]
+            pg.allreduce(t)
+            return t[0].cpu()
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = self._world_size * (self._world_size + 1) / 2
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), expected))
+
+    def test_multiple_collectives_in_sequence(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            results = []
+            for i in range(5):
+                t = [torch.full((4,), float(rank + i))]
+                pg.allreduce(t)
+                results.append(t[0].clone())
+            return results
+
+        results = self._run_on_pgs(pgs, _work)
+        for i in range(5):
+            expected = sum(r + i for r in range(self._world_size))
+            for r in range(self._world_size):
+                self.assertEqual(
+                    results[r][i],
+                    torch.full((4,), float(expected)),
+                )
+
+    def test_single_element_tensor(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.tensor([float(rank + 1)])]
+            pg.allreduce(t)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = self._world_size * (self._world_size + 1) / 2
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.tensor([expected]))
+
+    def test_float64_dtype(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), float(rank + 1), dtype=torch.float64)]
+            pg.allreduce(t)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = self._world_size * (self._world_size + 1) / 2
+        for r, t in enumerate(results):
+            self.assertEqual(t.dtype, torch.float64)
+            self.assertEqual(t, torch.full((4,), expected, dtype=torch.float64))
+
+    def test_int_dtype_with_sum(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), rank + 1, dtype=torch.int64)]
+            pg.allreduce(t)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = self._world_size * (self._world_size + 1) // 2
+        for r, t in enumerate(results):
+            self.assertEqual(t.dtype, torch.int64)
+            self.assertEqual(t, torch.full((4,), expected, dtype=torch.int64))
+
+    def test_world_size_2(self):
+        self._world_size = 2
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), float(rank + 1))]
+            pg.allreduce(t)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = 3.0
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), expected))
+
+
+class TestVNCCLReduceScatterOps(_VNCCLTestBase):
+    """Verify vnccl reduce_scatter works with non-SUM reduce ops."""
+
+    def test_reduce_scatter_product(self):
+        from torch._C._distributed_c10d import ReduceOp, ReduceScatterOptions
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            chunks = [torch.full((2,), float(rank + 1)) for _ in range(self._world_size)]
+            out = [torch.zeros(2)]
+            opts = ReduceScatterOptions()
+            opts.reduceOp = ReduceOp.PRODUCT
+            pg.reduce_scatter(out, [chunks], opts)
+            return out[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = 1.0
+        for r in range(self._world_size):
+            expected *= r + 1
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((2,), expected))
+
+    def test_reduce_scatter_max(self):
+        from torch._C._distributed_c10d import ReduceOp, ReduceScatterOptions
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            chunks = [torch.full((2,), float(rank + 1)) for _ in range(self._world_size)]
+            out = [torch.zeros(2)]
+            opts = ReduceScatterOptions()
+            opts.reduceOp = ReduceOp.MAX
+            pg.reduce_scatter(out, [chunks], opts)
+            return out[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = float(self._world_size)
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((2,), expected))
+
+    def test_reduce_scatter_min(self):
+        from torch._C._distributed_c10d import ReduceOp, ReduceScatterOptions
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            chunks = [torch.full((2,), float(rank + 1)) for _ in range(self._world_size)]
+            out = [torch.zeros(2)]
+            opts = ReduceScatterOptions()
+            opts.reduceOp = ReduceOp.MIN
+            pg.reduce_scatter(out, [chunks], opts)
+            return out[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((2,), 1.0))
+
+    def test_reduce_scatter_avg(self):
+        from torch._C._distributed_c10d import ReduceOp, ReduceScatterOptions
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            chunks = [torch.full((2,), float(rank + 1)) for _ in range(self._world_size)]
+            out = [torch.zeros(2)]
+            opts = ReduceScatterOptions()
+            opts.reduceOp = ReduceOp.AVG
+            pg.reduce_scatter(out, [chunks], opts)
+            return out[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = (self._world_size + 1) / 2.0
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((2,), expected))
+
+
+class TestVNCCLCoalesced(_VNCCLTestBase):
+    """Test coalesced operations that FSDP2 relies on."""
+
+    def test_allgather_into_tensor_coalesced(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            inputs = [
+                torch.full((2,), float(rank)),
+                torch.full((3,), float(rank + 10)),
+            ]
+            outputs = [
+                torch.zeros(2 * self._world_size),
+                torch.zeros(3 * self._world_size),
+            ]
+            pg.allgather_into_tensor_coalesced(outputs, inputs)
+            return outputs
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, outputs in enumerate(results):
+            expected_0 = torch.cat(
+                [torch.full((2,), float(src)) for src in range(self._world_size)]
+            )
+            expected_1 = torch.cat(
+                [torch.full((3,), float(src + 10)) for src in range(self._world_size)]
+            )
+            self.assertEqual(outputs[0], expected_0)
+            self.assertEqual(outputs[1], expected_1)
+
+    def test_reduce_scatter_tensor_coalesced(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            inputs = [
+                torch.full((2 * self._world_size,), float(rank + 1)),
+                torch.full((3 * self._world_size,), float(rank + 1)),
+            ]
+            outputs = [torch.zeros(2), torch.zeros(3)]
+            pg.reduce_scatter_tensor_coalesced(outputs, inputs)
+            return outputs
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = self._world_size * (self._world_size + 1) / 2
+        for r, outputs in enumerate(results):
+            self.assertEqual(outputs[0], torch.full((2,), expected))
+            self.assertEqual(outputs[1], torch.full((3,), expected))
+
+
+class TestVNCCLWorldSize1(_VNCCLTestBase):
+    """Verify vnccl works with a single rank."""
+
+    def test_allreduce_single_rank(self):
+        self._world_size = 1
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), 42.0)]
+            pg.allreduce(t)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        self.assertEqual(results[0], torch.full((4,), 42.0))
+
+    def test_barrier_single_rank(self):
+        self._world_size = 1
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            pg.barrier()
+            return True
+
+        results = self._run_on_pgs(pgs, _work)
+        self.assertTrue(results[0])
+
+    def test_allgather_single_rank(self):
+        self._world_size = 1
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            inp = [torch.full((2,), 7.0)]
+            out = [[torch.zeros(2)]]
+            pg.allgather(out, inp)
+            return out[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        self.assertEqual(results[0][0], torch.full((2,), 7.0))
+
+    def test_broadcast_single_rank(self):
+        from torch._C._distributed_c10d import BroadcastOptions
+
+        self._world_size = 1
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), 55.0)]
+            opts = BroadcastOptions()
+            opts.rootRank = 0
+            pg.broadcast(t, opts)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        self.assertEqual(results[0], torch.full((4,), 55.0))
+
+    def test_reduce_scatter_single_rank(self):
+        self._world_size = 1
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            inp = torch.full((2,), 5.0)
+            out = torch.zeros(2)
+            pg._reduce_scatter_base(out, inp)
+            return out
+
+        results = self._run_on_pgs(pgs, _work)
+        self.assertEqual(results[0], torch.full((2,), 5.0))
+
+    def test_scatter_single_rank(self):
+        from torch._C._distributed_c10d import ScatterOptions
+
+        self._world_size = 1
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            src = [torch.full((2,), 3.0)]
+            out = [torch.zeros(2)]
+            opts = ScatterOptions()
+            opts.rootRank = 0
+            pg.scatter(out, [src], opts)
+            return out[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        self.assertEqual(results[0], torch.full((2,), 3.0))
+
+    def test_gather_single_rank(self):
+        from torch._C._distributed_c10d import ScatterOptions
+
+        self._world_size = 1
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            inp = [torch.full((2,), 9.0)]
+            out = [[torch.zeros(2)]]
+            opts = ScatterOptions()
+            opts.rootRank = 0
+            pg.gather(out, inp, opts)
+            return out[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        self.assertEqual(results[0][0], torch.full((2,), 9.0))
+
+
+class TestVNCCLNonContiguous(_VNCCLTestBase):
+    """Verify vnccl handles non-contiguous tensor inputs."""
+
+    def test_allreduce_non_contiguous(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            base = torch.full((4, 4), float(rank + 1))
+            t = [base[:, 0]]
+            self.assertFalse(t[0].is_contiguous())
+            pg.allreduce(t)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        expected = self._world_size * (self._world_size + 1) / 2
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), expected))
+
+    def test_broadcast_non_contiguous(self):
+        from torch._C._distributed_c10d import BroadcastOptions
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            if rank == 0:
+                base = torch.full((4, 4), 99.0)
+                t = [base[:, 0]]
+            else:
+                t = [torch.zeros(4)]
+            opts = BroadcastOptions()
+            opts.rootRank = 0
+            pg.broadcast(t, opts)
+            return t[0]
+
+        results = self._run_on_pgs(pgs, _work)
+        for r, t in enumerate(results):
+            self.assertEqual(t, torch.full((4,), 99.0))
+
+
+class TestMuxPGNotImplemented(TestCase):
+    def test_scatter_raises(self):
+        from torch.distributed.torchmux import _MuxPG
+
+        pg = _MuxPG(0, 2)
+        with self.assertRaisesRegex(NotImplementedError, "_MuxPG.scatter"):
+            pg.scatter(None, None)
+
+    def test_gather_raises(self):
+        from torch.distributed.torchmux import _MuxPG
+
+        pg = _MuxPG(0, 2)
+        with self.assertRaisesRegex(NotImplementedError, "_MuxPG.gather"):
+            pg.gather(None, None)
+
+    def test_alltoall_raises(self):
+        from torch.distributed.torchmux import _MuxPG
+
+        pg = _MuxPG(0, 2)
+        with self.assertRaisesRegex(NotImplementedError, "_MuxPG.alltoall"):
+            pg.alltoall(None, None)
+
+
+class TestSharedInt(TestCase):
+    def test_basic_read_write(self):
+        from torch.distributed.torchmux import _SharedInt
+
+        si = _SharedInt()
+        self.addCleanup(si.cleanup)
+        self.assertEqual(si.value, 0)
+        si.value = 42
+        self.assertEqual(si.value, 42)
+        si.value = -1
+        self.assertEqual(si.value, -1)
+
+    def test_pickle_roundtrip(self):
+        import pickle
+
+        from torch.distributed.torchmux import _SharedInt
+
+        si = _SharedInt()
+        self.addCleanup(si.cleanup)
+        si.value = 123
+
+        data = pickle.dumps(si)
+        si2 = pickle.loads(data)
+        self.assertEqual(si2.value, 123)
+        si2.value = 456
+        self.assertEqual(si.value, 456)
+
+    def test_cleanup_then_del_no_error(self):
+        from torch.distributed.torchmux import _SharedInt
+
+        si = _SharedInt()
+        si.cleanup()
+        del si
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestTorchmuxSingleWorker(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, True)
+
+    def test_nproc_1(self):
+        script = os.path.join(self._tmpdir, "single.py")
+        with open(script, "w") as f:
+            f.write(
+                "import os, torch, torch.distributed as dist\n"
+                "dist.init_process_group()\n"
+                "assert dist.get_rank() == 0\n"
+                "assert dist.get_world_size() == 1\n"
+                "device = f\"cuda:{0 % int(os.environ.get('TORCHMUX_NGPUS', '1'))}\"\n"
+                "torch.cuda.set_device(device)\n"
+                "x = torch.ones(4, device=device)\n"
+                "dist.all_reduce(x)\n"
+                "assert torch.allclose(x, torch.ones(4, device=device))\n"
+                "dist.destroy_process_group()\n"
+            )
+        trace_dir = os.path.join(self._tmpdir, "traces")
+        os.makedirs(trace_dir)
+        env = os.environ.copy()
+        env["TORCHMUX_TRACE_DIR"] = trace_dir
+        env["TORCHMUX_NGPUS"] = "1"
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "torch.distributed.torchmux",
+                "--nproc-per-node", "1", script,
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"torchmux nproc=1 failed (rc={result.returncode}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestTorchmuxErrorHandling(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, True)
+
+    def test_worker_crash_propagates(self):
+        script = os.path.join(self._tmpdir, "crash.py")
+        with open(script, "w") as f:
+            f.write(
+                "import os, torch, torch.distributed as dist\n"
+                "dist.init_process_group()\n"
+                "rank = dist.get_rank()\n"
+                "device = f\"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}\"\n"
+                "torch.cuda.set_device(device)\n"
+                "raise RuntimeError('intentional crash')\n"
+            )
+        env = os.environ.copy()
+        env["TORCHMUX_TRACE_DIR"] = self._tmpdir
+        env["TORCHMUX_NGPUS"] = "1"
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "torch.distributed.torchmux",
+                "--nproc-per-node", "2", script,
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertNotEqual(result.returncode, 0)
+
+
+class TestVNCCLErrorPropagation(_VNCCLTestBase):
+    """Verify vnccl handles resolver errors without deadlocking."""
+
+    def test_resolver_error_propagates_to_all_ranks(self):
+        from torch.distributed.vnccl import VNCCLProcessGroup
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), float(rank + 1))]
+            if rank == self._world_size - 1:
+                t = [torch.full((4,), float("nan"))]
+                t[0] = t[0].to(torch.int32)
+                t[0] = t[0].view(torch.float32)
+            pg.allreduce(t)
+            return t[0]
+
+        class _BrokenAllReduce:
+            def __init__(self, op):
+                self.op = op.op
+
+            def work(self, data):
+                raise ValueError("intentional resolver failure")
+
+        orig_do = VNCCLProcessGroup._do
+
+        def _patched_do(self_pg, op, data):
+            if hasattr(op, "op"):
+                op = _BrokenAllReduce(op)
+            return orig_do(self_pg, op, data)
+
+        VNCCLProcessGroup._do = _patched_do
+        try:
+            with self.assertRaises(RuntimeError):
+                self._run_on_pgs(pgs, _work)
+        finally:
+            VNCCLProcessGroup._do = orig_do
+
+    def test_active_cleared_after_collective(self):
+        from torch.distributed.vnccl import VNCCLProcessGroup
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            t = [torch.full((4,), float(rank + 1))]
+            pg.allreduce(t)
+            return t[0]
+
+        self._run_on_pgs(pgs, _work)
+        self.assertEqual(len(VNCCLProcessGroup._active), 0)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestTorchmuxModuleFlag(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, True)
+
+    def test_run_as_module(self):
+        pkg_dir = os.path.join(self._tmpdir, "mypkg")
+        os.makedirs(pkg_dir)
+        with open(os.path.join(pkg_dir, "__init__.py"), "w") as f:
+            f.write("")
+        with open(os.path.join(pkg_dir, "train.py"), "w") as f:
+            f.write(
+                "import os, torch, torch.distributed as dist\n"
+                "dist.init_process_group()\n"
+                "rank = dist.get_rank()\n"
+                "device = f\"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}\"\n"
+                "torch.cuda.set_device(device)\n"
+                "x = torch.ones(4, device=device)\n"
+                "dist.all_reduce(x)\n"
+                "dist.destroy_process_group()\n"
+            )
+
+        trace_dir = os.path.join(self._tmpdir, "traces")
+        os.makedirs(trace_dir)
+        env = os.environ.copy()
+        env["TORCHMUX_TRACE_DIR"] = trace_dir
+        env["TORCHMUX_NGPUS"] = "1"
+        env["PYTHONPATH"] = self._tmpdir + os.pathsep + env.get("PYTHONPATH", "")
+
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "torch.distributed.torchmux",
+                "--nproc-per-node", "2", "-m", "mypkg.train",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"torchmux -m failed (rc={result.returncode}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+
+
+class TestTorchmuxArgValidation(TestCase):
+    def test_ngpus_greater_than_nproc_rejected(self):
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "torch.distributed.torchmux",
+                "--nproc-per-node", "2", "--ngpus", "4", "dummy.py",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--ngpus", result.stderr)
+
+
+class TestSharedIntCrossProcess(TestCase):
+    def test_cross_process_sharing(self):
+        from torch.distributed.torchmux import _SharedInt
+
+        si = _SharedInt()
+        self.addCleanup(si.cleanup)
+        si.value = 0
+
+        def _child_writer(si_pickled):
+            import pickle
+            child_si = pickle.loads(si_pickled)
+            child_si.value = 42
+
+        import pickle
+        import multiprocessing
+
+        p = multiprocessing.Process(
+            target=_child_writer,
+            args=(pickle.dumps(si),),
+        )
+        p.start()
+        p.join(timeout=10)
+        self.assertEqual(p.exitcode, 0)
+        self.assertEqual(si.value, 42)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestTorchmuxAVGCorrectness(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, True)
+
+    def test_allreduce_avg(self):
+        script = os.path.join(self._tmpdir, "avg_test.py")
+        with open(script, "w") as f:
+            f.write(
+                "import json, os, torch, torch.distributed as dist\n"
+                "dist.init_process_group()\n"
+                "rank = dist.get_rank()\n"
+                "ws = dist.get_world_size()\n"
+                "device = f\"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}\"\n"
+                "torch.cuda.set_device(device)\n"
+                "results = {}\n"
+                "x = torch.full((4,), float(rank + 1), device=device)\n"
+                "dist.all_reduce(x, op=dist.ReduceOp.AVG)\n"
+                "expected = (ws + 1) / 2.0\n"
+                "results['allreduce_avg'] = torch.allclose(\n"
+                "    x, torch.full_like(x, expected)\n"
+                ")\n"
+                "full = torch.full((ws * 2,), float(rank + 1), device=device)\n"
+                "out = torch.zeros(2, device=device)\n"
+                "dist.reduce_scatter_tensor(out, full, op=dist.ReduceOp.AVG)\n"
+                "expected_rs = (ws + 1) / 2.0\n"
+                "results['reduce_scatter_avg'] = torch.allclose(\n"
+                "    out, torch.full_like(out, expected_rs)\n"
+                ")\n"
+                "dist.destroy_process_group()\n"
+                "path = os.path.join(os.environ['TORCHMUX_RESULTS_DIR'],\n"
+                "                    f'rank{rank}.json')\n"
+                "with open(path, 'w') as f:\n"
+                "    json.dump({k: bool(v) for k, v in results.items()}, f)\n"
+            )
+
+        results_dir = os.path.join(self._tmpdir, "results")
+        os.makedirs(results_dir)
+        env = os.environ.copy()
+        env["TORCHMUX_NGPUS"] = "1"
+        env["TORCHMUX_RESULTS_DIR"] = results_dir
+        env["TORCHMUX_TRACE_DIR"] = self._tmpdir
+
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "torch.distributed.torchmux",
+                "--nproc-per-node", "2", script,
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"torchmux AVG test failed (rc={result.returncode}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+
+        for rank in range(2):
+            rpath = os.path.join(results_dir, f"rank{rank}.json")
+            self.assertTrue(os.path.exists(rpath))
+            with open(rpath) as f:
+                results = json.load(f)
+            for op_name, passed in results.items():
+                self.assertTrue(passed, f"rank {rank}: {op_name} failed")
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestTorchmuxCoalescedCollectives(TestCase):
+    """Test allgather_into_tensor_coalesced and reduce_scatter_tensor_coalesced
+    through the full torchmux subprocess path."""
+
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, True)
+
+    def test_coalesced_correctness(self):
+        script = os.path.join(self._tmpdir, "coalesced.py")
+        with open(script, "w") as f:
+            f.write(
+                "import json, os, torch, torch.distributed as dist\n"
+                "from torch.distributed import ReduceOp\n"
+                "dist.init_process_group()\n"
+                "rank = dist.get_rank()\n"
+                "ws = dist.get_world_size()\n"
+                "device = f\"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}\"\n"
+                "torch.cuda.set_device(device)\n"
+                "results = {}\n"
+                "\n"
+                "# allgather_into_tensor_coalesced via _allgather_base path\n"
+                "inp = torch.full((2,), float(rank), device=device)\n"
+                "out = torch.zeros(2 * ws, device=device)\n"
+                "dist.all_gather_into_tensor(out, inp)\n"
+                "expected = torch.cat([torch.full((2,), float(r), device=device) for r in range(ws)])\n"
+                "results['allgather_base'] = torch.allclose(out, expected)\n"
+                "\n"
+                "# reduce_scatter_tensor via _reduce_scatter_base path\n"
+                "full = torch.full((ws * 2,), float(rank + 1), device=device)\n"
+                "out2 = torch.zeros(2, device=device)\n"
+                "dist.reduce_scatter_tensor(out2, full)\n"
+                "expected_rs = ws * (ws + 1) / 2\n"
+                "results['reduce_scatter_base'] = torch.allclose(out2, torch.full_like(out2, expected_rs))\n"
+                "\n"
+                "dist.destroy_process_group()\n"
+                "path = os.path.join(os.environ['TORCHMUX_RESULTS_DIR'], f'rank{rank}.json')\n"
+                "with open(path, 'w') as f:\n"
+                "    json.dump({k: bool(v) for k, v in results.items()}, f)\n"
+            )
+
+        results_dir = os.path.join(self._tmpdir, "results")
+        os.makedirs(results_dir)
+        env = os.environ.copy()
+        env["TORCHMUX_NGPUS"] = "1"
+        env["TORCHMUX_RESULTS_DIR"] = results_dir
+        env["TORCHMUX_TRACE_DIR"] = self._tmpdir
+
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "torch.distributed.torchmux",
+                "--nproc-per-node", "2", script,
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"torchmux coalesced test failed (rc={result.returncode}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+
+        for rank in range(2):
+            rpath = os.path.join(results_dir, f"rank{rank}.json")
+            self.assertTrue(os.path.exists(rpath))
+            with open(rpath) as f:
+                results = json.load(f)
+            for op_name, passed in results.items():
+                self.assertTrue(passed, f"rank {rank}: {op_name} failed")
+
+
+class TestVNCCLSequenceNumbering(_VNCCLTestBase):
+    """Verify that the sequence-number fix for _active dict prevents
+    collective mismatch when ranks arrive at different speeds."""
+
+    def test_rapid_sequential_collectives(self):
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            results = []
+            for i in range(10):
+                t = [torch.full((4,), float(rank + i))]
+                pg.allreduce(t)
+                results.append(t[0].clone())
+            return results
+
+        results = self._run_on_pgs(pgs, _work)
+        for i in range(10):
+            expected = sum(r + i for r in range(self._world_size))
+            for r in range(self._world_size):
+                self.assertEqual(
+                    results[r][i],
+                    torch.full((4,), float(expected)),
+                )
+
+    def test_mixed_collective_types(self):
+        from torch._C._distributed_c10d import BroadcastOptions
+
+        pgs = self._make_pgs()
+
+        def _work(rank, pg):
+            results = []
+
+            t = [torch.full((4,), float(rank + 1))]
+            pg.allreduce(t)
+            results.append(t[0].clone())
+
+            t = [torch.full((4,), 77.0) if rank == 0 else torch.zeros(4)]
+            opts = BroadcastOptions()
+            opts.rootRank = 0
+            pg.broadcast(t, opts)
+            results.append(t[0].clone())
+
+            t = [torch.full((4,), float(rank + 10))]
+            pg.allreduce(t)
+            results.append(t[0].clone())
+
+            return results
+
+        results = self._run_on_pgs(pgs, _work)
+        ws = self._world_size
+        expected_ar1 = ws * (ws + 1) / 2
+        expected_ar2 = sum(r + 10 for r in range(ws))
+        for r in range(ws):
+            self.assertEqual(results[r][0], torch.full((4,), expected_ar1))
+            self.assertEqual(results[r][1], torch.full((4,), 77.0))
+            self.assertEqual(results[r][2], torch.full((4,), float(expected_ar2)))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/test_torchmux.py
+++ b/test/distributed/test_torchmux.py
@@ -6,6 +6,7 @@ under torchmux (file-based PG), and vnccl (thread-based PG).
 """
 
 import json
+import math
 import os
 import shutil
 import subprocess
@@ -16,7 +17,12 @@ import unittest
 
 import torch
 import torch.distributed as dist
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
 
 TRAIN_SCRIPT = """
@@ -98,40 +104,205 @@ with open(output_path, "w") as f:
 """
 
 
-@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-class TestTorchmuxTraceOrdering(TestCase):
+SINGLE_WORKER_SCRIPT = """
+import os
+import torch
+import torch.distributed as dist
+
+dist.init_process_group()
+assert dist.get_rank() == 0
+assert dist.get_world_size() == 1
+device = f"cuda:{0 % int(os.environ.get('TORCHMUX_NGPUS', '1'))}"
+torch.cuda.set_device(device)
+x = torch.ones(4, device=device)
+dist.all_reduce(x)
+assert torch.allclose(x, torch.ones(4, device=device))
+dist.destroy_process_group()
+"""
+
+
+CRASH_SCRIPT = """
+import os
+import torch
+import torch.distributed as dist
+
+dist.init_process_group()
+rank = dist.get_rank()
+device = f"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}"
+torch.cuda.set_device(device)
+raise RuntimeError('intentional crash')
+"""
+
+
+MODULE_TRAIN_SCRIPT = """
+import os
+import torch
+import torch.distributed as dist
+
+dist.init_process_group()
+rank = dist.get_rank()
+device = f"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}"
+torch.cuda.set_device(device)
+x = torch.ones(4, device=device)
+dist.all_reduce(x)
+dist.destroy_process_group()
+"""
+
+
+AVG_SCRIPT = """
+import json
+import os
+import torch
+import torch.distributed as dist
+
+dist.init_process_group()
+rank = dist.get_rank()
+ws = dist.get_world_size()
+device = f"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}"
+torch.cuda.set_device(device)
+results = {}
+
+x = torch.full((4,), float(rank + 1), device=device)
+dist.all_reduce(x, op=dist.ReduceOp.AVG)
+expected = (ws + 1) / 2.0
+results['allreduce_avg'] = torch.allclose(x, torch.full_like(x, expected))
+
+full = torch.full((ws * 2,), float(rank + 1), device=device)
+out = torch.zeros(2, device=device)
+dist.reduce_scatter_tensor(out, full, op=dist.ReduceOp.AVG)
+expected_rs = (ws + 1) / 2.0
+results['reduce_scatter_avg'] = torch.allclose(out, torch.full_like(out, expected_rs))
+
+dist.destroy_process_group()
+path = os.path.join(os.environ['TORCHMUX_RESULTS_DIR'], f'rank{rank}.json')
+with open(path, 'w') as f:
+    json.dump({k: bool(v) for k, v in results.items()}, f)
+"""
+
+
+COALESCED_SCRIPT = """
+import json
+import os
+import torch
+import torch.distributed as dist
+from torch.distributed import ReduceOp
+
+dist.init_process_group()
+rank = dist.get_rank()
+ws = dist.get_world_size()
+device = f"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}"
+torch.cuda.set_device(device)
+results = {}
+
+# allgather_into_tensor_coalesced via _allgather_base path
+inp = torch.full((2,), float(rank), device=device)
+out = torch.zeros(2 * ws, device=device)
+dist.all_gather_into_tensor(out, inp)
+expected = torch.cat([torch.full((2,), float(r), device=device) for r in range(ws)])
+results['allgather_base'] = torch.allclose(out, expected)
+
+# reduce_scatter_tensor via _reduce_scatter_base path
+full = torch.full((ws * 2,), float(rank + 1), device=device)
+out2 = torch.zeros(2, device=device)
+dist.reduce_scatter_tensor(out2, full)
+expected_rs = ws * (ws + 1) / 2
+results['reduce_scatter_base'] = torch.allclose(out2, torch.full_like(out2, expected_rs))
+
+dist.destroy_process_group()
+path = os.path.join(os.environ['TORCHMUX_RESULTS_DIR'], f'rank{rank}.json')
+with open(path, 'w') as f:
+    json.dump({k: bool(v) for k, v in results.items()}, f)
+"""
+
+
+MULTIGPU_SCRIPT = """
+import json
+import os
+import torch
+import torch.distributed as dist
+
+dist.init_process_group()
+rank = dist.get_rank()
+ws = dist.get_world_size()
+ngpus = int(os.environ.get('TORCHMUX_NGPUS', '1'))
+device = f'cuda:{rank % ngpus}'
+torch.cuda.set_device(device)
+results = {}
+
+x = torch.full((4,), float(rank + 1), device=device)
+dist.all_reduce(x)
+expected = ws * (ws + 1) / 2
+results['allreduce'] = torch.allclose(x, torch.full_like(x, expected))
+results['device_index'] = (torch.cuda.current_device() == rank % ngpus)
+
+dist.destroy_process_group()
+path = os.path.join(os.environ['TORCHMUX_RESULTS_DIR'], f'rank{rank}.json')
+with open(path, 'w') as f:
+    json.dump({k: bool(v) for k, v in results.items()}, f)
+"""
+
+
+class _TorchmuxSubprocessBase(TestCase):
+    """Shared base class for torchmux subprocess tests."""
+
     def setUp(self):
         super().setUp()
         self._tmpdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self._tmpdir, True)
-        self._script = os.path.join(self._tmpdir, "train.py")
-        with open(self._script, "w") as f:
-            f.write(TRAIN_SCRIPT)
 
-    def _run_torchmux(self, nproc, script, env_extra=None):
+    def _write_script(self, name, content):
+        path = os.path.join(self._tmpdir, name)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def _run_torchmux(self, nproc, script, env_extra=None, ngpus=1, extra_args=None):
         trace_dir = os.path.join(self._tmpdir, "traces")
         os.makedirs(trace_dir, exist_ok=True)
         env = os.environ.copy()
         env["TORCHMUX_TRACE_DIR"] = trace_dir
-        env["TORCHMUX_NGPUS"] = "1"
+        env["TORCHMUX_NGPUS"] = str(ngpus)
         if env_extra:
             env.update(env_extra)
-        result = subprocess.run(
-            [
-                sys.executable, "-m", "torch.distributed.torchmux",
-                "--nproc-per-node", str(nproc), script,
-            ],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=120,
+        cmd = [
+            sys.executable, "-m", "torch.distributed.torchmux",
+            "--nproc-per-node", str(nproc),
+        ]
+        if ngpus > 1:
+            cmd.extend(["--ngpus", str(ngpus)])
+        if extra_args:
+            cmd.extend(extra_args)
+        cmd.append(script)
+        return subprocess.run(
+            cmd, env=env, capture_output=True, text=True, timeout=120,
         )
+
+    def _run_and_check_results(self, nproc, script, env_extra=None, ngpus=1):
+        results_dir = os.path.join(self._tmpdir, "results")
+        os.makedirs(results_dir, exist_ok=True)
+        env = {"TORCHMUX_RESULTS_DIR": results_dir}
+        if env_extra:
+            env.update(env_extra)
+        result = self._run_torchmux(nproc, script, env_extra=env, ngpus=ngpus)
         self.assertEqual(
             result.returncode, 0,
             f"torchmux failed (rc={result.returncode}):\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}",
         )
-        return trace_dir
+        for rank in range(nproc):
+            rpath = os.path.join(results_dir, f"rank{rank}.json")
+            self.assertTrue(os.path.exists(rpath), f"missing results for rank {rank}")
+            with open(rpath) as f:
+                results = json.load(f)
+            for op_name, passed in results.items():
+                self.assertTrue(passed, f"rank {rank}: {op_name} failed")
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+class TestTorchmuxTraceOrdering(_TorchmuxSubprocessBase):
+    def setUp(self):
+        super().setUp()
+        self._script = self._write_script("train.py", TRAIN_SCRIPT)
 
     def test_3worker_trace_ordering(self):
         """Assert trace events follow cooperative scheduling invariants.
@@ -145,7 +316,13 @@ class TestTorchmuxTraceOrdering(TestCase):
           W0: restore -> collective_finish -> compute
           ...
         """
-        trace_dir = self._run_torchmux(3, self._script)
+        result = self._run_torchmux(3, self._script)
+        self.assertEqual(
+            result.returncode, 0,
+            f"torchmux failed (rc={result.returncode}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+        trace_dir = os.path.join(self._tmpdir, "traces")
 
         natural_path = os.path.join(trace_dir, "torchmux_natural.json")
         self.assertTrue(os.path.exists(natural_path))
@@ -284,48 +461,10 @@ class TestTorchmuxTraceOrdering(TestCase):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-class TestTorchmuxCollectiveCorrectness(TestCase):
-    def setUp(self):
-        super().setUp()
-        self._tmpdir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self._tmpdir, True)
-
+class TestTorchmuxCollectiveCorrectness(_TorchmuxSubprocessBase):
     def test_collective_correctness_2workers(self):
-        script_path = os.path.join(self._tmpdir, "correctness.py")
-        with open(script_path, "w") as f:
-            f.write(CORRECTNESS_SCRIPT)
-
-        results_dir = os.path.join(self._tmpdir, "results")
-        os.makedirs(results_dir)
-
-        env = os.environ.copy()
-        env["TORCHMUX_NGPUS"] = "1"
-        env["TORCHMUX_RESULTS_DIR"] = results_dir
-        env["TORCHMUX_TRACE_DIR"] = self._tmpdir
-
-        result = subprocess.run(
-            [
-                sys.executable, "-m", "torch.distributed.torchmux",
-                "--nproc-per-node", "2", script_path,
-            ],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        self.assertEqual(
-            result.returncode, 0,
-            f"torchmux failed (rc={result.returncode}):\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}",
-        )
-
-        for rank in range(2):
-            rpath = os.path.join(results_dir, f"rank{rank}.json")
-            self.assertTrue(os.path.exists(rpath), f"missing results for rank {rank}")
-            with open(rpath) as f:
-                results = json.load(f)
-            for op_name, passed in results.items():
-                self.assertTrue(passed, f"rank {rank}: {op_name} failed")
+        script = self._write_script("correctness.py", CORRECTNESS_SCRIPT)
+        self._run_and_check_results(2, script)
 
 
 class TestTorchmuxSyntheticTrace(TestCase):
@@ -496,14 +635,11 @@ class _VNCCLTestBase(TestCase):
 
     def tearDown(self):
         import torch.distributed.vnccl as vnccl
-        from torch.distributed.vnccl import VNCCLProcessGroup
 
-        VNCCLProcessGroup._active.clear()
         for pg in self._pgs:
             dist.distributed_c10d._world.pg_names.pop(pg, None)
         self._pgs = []
-        vnccl._next_rank = 0
-        vnccl._rng_states.clear()
+        vnccl._reset()
         super().tearDown()
 
     def _make_pgs(self, pg_name="vnccl_test"):
@@ -554,86 +690,33 @@ class TestVNCCL(_VNCCLTestBase):
     dist.init_process_group to avoid global state conflicts.
     """
 
-    def test_allreduce_sum(self):
+    @parametrize(
+        "op_name,expected_fn",
+        [
+            ("SUM", lambda ws: ws * (ws + 1) / 2),
+            ("AVG", lambda ws: (ws + 1) / 2.0),
+            ("PRODUCT", lambda ws: float(math.factorial(ws))),
+            ("MIN", lambda ws: 1.0),
+            ("MAX", lambda ws: float(ws)),
+        ],
+        name_fn=lambda op_name, expected_fn: op_name.lower(),
+    )
+    def test_allreduce(self, op_name, expected_fn):
+        from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
+
         pgs = self._make_pgs()
 
         def _work(rank, pg):
             t = [torch.full((4,), float(rank + 1))]
-            pg.allreduce(t)
+            opts = AllreduceOptions()
+            opts.reduceOp = getattr(ReduceOp, op_name)
+            pg.allreduce(t, opts)
             return t[0]
 
         results = self._run_on_pgs(pgs, _work)
-        expected = self._world_size * (self._world_size + 1) / 2
+        expected = expected_fn(self._world_size)
         for r, t in enumerate(results):
             self.assertEqual(t, torch.full((4,), expected))
-
-    def test_allreduce_avg(self):
-        from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
-
-        pgs = self._make_pgs()
-
-        def _work(rank, pg):
-            t = [torch.full((4,), float(rank + 1))]
-            opts = AllreduceOptions()
-            opts.reduceOp = ReduceOp.AVG
-            pg.allreduce(t, opts)
-            return t[0]
-
-        results = self._run_on_pgs(pgs, _work)
-        expected = (self._world_size + 1) / 2.0
-        for r, t in enumerate(results):
-            self.assertEqual(t, torch.full((4,), expected))
-
-    def test_allreduce_product(self):
-        from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
-
-        pgs = self._make_pgs()
-
-        def _work(rank, pg):
-            t = [torch.full((4,), float(rank + 1))]
-            opts = AllreduceOptions()
-            opts.reduceOp = ReduceOp.PRODUCT
-            pg.allreduce(t, opts)
-            return t[0]
-
-        results = self._run_on_pgs(pgs, _work)
-        expected = 1.0
-        for r in range(self._world_size):
-            expected *= r + 1
-        for r, t in enumerate(results):
-            self.assertEqual(t, torch.full((4,), expected))
-
-    def test_allreduce_min(self):
-        from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
-
-        pgs = self._make_pgs()
-
-        def _work(rank, pg):
-            t = [torch.full((4,), float(rank + 1))]
-            opts = AllreduceOptions()
-            opts.reduceOp = ReduceOp.MIN
-            pg.allreduce(t, opts)
-            return t[0]
-
-        results = self._run_on_pgs(pgs, _work)
-        for r, t in enumerate(results):
-            self.assertEqual(t, torch.full((4,), 1.0))
-
-    def test_allreduce_max(self):
-        from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
-
-        pgs = self._make_pgs()
-
-        def _work(rank, pg):
-            t = [torch.full((4,), float(rank + 1))]
-            opts = AllreduceOptions()
-            opts.reduceOp = ReduceOp.MAX
-            pg.allreduce(t, opts)
-            return t[0]
-
-        results = self._run_on_pgs(pgs, _work)
-        for r, t in enumerate(results):
-            self.assertEqual(t, torch.full((4,), float(self._world_size)))
 
     def test_allreduce_bitwise_ops(self):
         from torch._C._distributed_c10d import AllreduceOptions, ReduceOp
@@ -921,10 +1004,23 @@ class TestVNCCL(_VNCCLTestBase):
             self.assertEqual(t, torch.full((4,), expected))
 
 
+instantiate_parametrized_tests(TestVNCCL)
+
+
 class TestVNCCLReduceScatterOps(_VNCCLTestBase):
     """Verify vnccl reduce_scatter works with non-SUM reduce ops."""
 
-    def test_reduce_scatter_product(self):
+    @parametrize(
+        "op_name,expected_fn",
+        [
+            ("PRODUCT", lambda ws: float(math.factorial(ws))),
+            ("MAX", lambda ws: float(ws)),
+            ("MIN", lambda ws: 1.0),
+            ("AVG", lambda ws: (ws + 1) / 2.0),
+        ],
+        name_fn=lambda op_name, expected_fn: op_name.lower(),
+    )
+    def test_reduce_scatter(self, op_name, expected_fn):
         from torch._C._distributed_c10d import ReduceOp, ReduceScatterOptions
 
         pgs = self._make_pgs()
@@ -933,69 +1029,17 @@ class TestVNCCLReduceScatterOps(_VNCCLTestBase):
             chunks = [torch.full((2,), float(rank + 1)) for _ in range(self._world_size)]
             out = [torch.zeros(2)]
             opts = ReduceScatterOptions()
-            opts.reduceOp = ReduceOp.PRODUCT
+            opts.reduceOp = getattr(ReduceOp, op_name)
             pg.reduce_scatter(out, [chunks], opts)
             return out[0]
 
         results = self._run_on_pgs(pgs, _work)
-        expected = 1.0
-        for r in range(self._world_size):
-            expected *= r + 1
+        expected = expected_fn(self._world_size)
         for r, t in enumerate(results):
             self.assertEqual(t, torch.full((2,), expected))
 
-    def test_reduce_scatter_max(self):
-        from torch._C._distributed_c10d import ReduceOp, ReduceScatterOptions
 
-        pgs = self._make_pgs()
-
-        def _work(rank, pg):
-            chunks = [torch.full((2,), float(rank + 1)) for _ in range(self._world_size)]
-            out = [torch.zeros(2)]
-            opts = ReduceScatterOptions()
-            opts.reduceOp = ReduceOp.MAX
-            pg.reduce_scatter(out, [chunks], opts)
-            return out[0]
-
-        results = self._run_on_pgs(pgs, _work)
-        expected = float(self._world_size)
-        for r, t in enumerate(results):
-            self.assertEqual(t, torch.full((2,), expected))
-
-    def test_reduce_scatter_min(self):
-        from torch._C._distributed_c10d import ReduceOp, ReduceScatterOptions
-
-        pgs = self._make_pgs()
-
-        def _work(rank, pg):
-            chunks = [torch.full((2,), float(rank + 1)) for _ in range(self._world_size)]
-            out = [torch.zeros(2)]
-            opts = ReduceScatterOptions()
-            opts.reduceOp = ReduceOp.MIN
-            pg.reduce_scatter(out, [chunks], opts)
-            return out[0]
-
-        results = self._run_on_pgs(pgs, _work)
-        for r, t in enumerate(results):
-            self.assertEqual(t, torch.full((2,), 1.0))
-
-    def test_reduce_scatter_avg(self):
-        from torch._C._distributed_c10d import ReduceOp, ReduceScatterOptions
-
-        pgs = self._make_pgs()
-
-        def _work(rank, pg):
-            chunks = [torch.full((2,), float(rank + 1)) for _ in range(self._world_size)]
-            out = [torch.zeros(2)]
-            opts = ReduceScatterOptions()
-            opts.reduceOp = ReduceOp.AVG
-            pg.reduce_scatter(out, [chunks], opts)
-            return out[0]
-
-        results = self._run_on_pgs(pgs, _work)
-        expected = (self._world_size + 1) / 2.0
-        for r, t in enumerate(results):
-            self.assertEqual(t, torch.full((2,), expected))
+instantiate_parametrized_tests(TestVNCCLReduceScatterOps)
 
 
 class TestVNCCLCoalesced(_VNCCLTestBase):
@@ -1273,42 +1317,10 @@ class TestSharedInt(TestCase):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-class TestTorchmuxSingleWorker(TestCase):
-    def setUp(self):
-        super().setUp()
-        self._tmpdir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self._tmpdir, True)
-
+class TestTorchmuxSingleWorker(_TorchmuxSubprocessBase):
     def test_nproc_1(self):
-        script = os.path.join(self._tmpdir, "single.py")
-        with open(script, "w") as f:
-            f.write(
-                "import os, torch, torch.distributed as dist\n"
-                "dist.init_process_group()\n"
-                "assert dist.get_rank() == 0\n"
-                "assert dist.get_world_size() == 1\n"
-                "device = f\"cuda:{0 % int(os.environ.get('TORCHMUX_NGPUS', '1'))}\"\n"
-                "torch.cuda.set_device(device)\n"
-                "x = torch.ones(4, device=device)\n"
-                "dist.all_reduce(x)\n"
-                "assert torch.allclose(x, torch.ones(4, device=device))\n"
-                "dist.destroy_process_group()\n"
-            )
-        trace_dir = os.path.join(self._tmpdir, "traces")
-        os.makedirs(trace_dir)
-        env = os.environ.copy()
-        env["TORCHMUX_TRACE_DIR"] = trace_dir
-        env["TORCHMUX_NGPUS"] = "1"
-        result = subprocess.run(
-            [
-                sys.executable, "-m", "torch.distributed.torchmux",
-                "--nproc-per-node", "1", script,
-            ],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
+        script = self._write_script("single.py", SINGLE_WORKER_SCRIPT)
+        result = self._run_torchmux(1, script)
         self.assertEqual(
             result.returncode, 0,
             f"torchmux nproc=1 failed (rc={result.returncode}):\n"
@@ -1317,36 +1329,10 @@ class TestTorchmuxSingleWorker(TestCase):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-class TestTorchmuxErrorHandling(TestCase):
-    def setUp(self):
-        super().setUp()
-        self._tmpdir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self._tmpdir, True)
-
+class TestTorchmuxErrorHandling(_TorchmuxSubprocessBase):
     def test_worker_crash_propagates(self):
-        script = os.path.join(self._tmpdir, "crash.py")
-        with open(script, "w") as f:
-            f.write(
-                "import os, torch, torch.distributed as dist\n"
-                "dist.init_process_group()\n"
-                "rank = dist.get_rank()\n"
-                "device = f\"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}\"\n"
-                "torch.cuda.set_device(device)\n"
-                "raise RuntimeError('intentional crash')\n"
-            )
-        env = os.environ.copy()
-        env["TORCHMUX_TRACE_DIR"] = self._tmpdir
-        env["TORCHMUX_NGPUS"] = "1"
-        result = subprocess.run(
-            [
-                sys.executable, "-m", "torch.distributed.torchmux",
-                "--nproc-per-node", "2", script,
-            ],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
+        script = self._write_script("crash.py", CRASH_SCRIPT)
+        result = self._run_torchmux(2, script)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("intentional crash", result.stderr)
 
@@ -1404,46 +1390,19 @@ class TestVNCCLErrorPropagation(_VNCCLTestBase):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-class TestTorchmuxModuleFlag(TestCase):
-    def setUp(self):
-        super().setUp()
-        self._tmpdir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self._tmpdir, True)
-
+class TestTorchmuxModuleFlag(_TorchmuxSubprocessBase):
     def test_run_as_module(self):
         pkg_dir = os.path.join(self._tmpdir, "mypkg")
         os.makedirs(pkg_dir)
         with open(os.path.join(pkg_dir, "__init__.py"), "w") as f:
             f.write("")
         with open(os.path.join(pkg_dir, "train.py"), "w") as f:
-            f.write(
-                "import os, torch, torch.distributed as dist\n"
-                "dist.init_process_group()\n"
-                "rank = dist.get_rank()\n"
-                "device = f\"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}\"\n"
-                "torch.cuda.set_device(device)\n"
-                "x = torch.ones(4, device=device)\n"
-                "dist.all_reduce(x)\n"
-                "dist.destroy_process_group()\n"
-            )
+            f.write(MODULE_TRAIN_SCRIPT)
 
-        trace_dir = os.path.join(self._tmpdir, "traces")
-        os.makedirs(trace_dir)
-        env = os.environ.copy()
-        env["TORCHMUX_TRACE_DIR"] = trace_dir
-        env["TORCHMUX_NGPUS"] = "1"
-        env["PYTHONPATH"] = self._tmpdir + os.pathsep + env.get("PYTHONPATH", "")
-
-        result = subprocess.run(
-            [
-                sys.executable, "-m", "torch.distributed.torchmux",
-                "--nproc-per-node", "2", "-m", "mypkg.train",
-            ],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
+        env = {
+            "PYTHONPATH": self._tmpdir + os.pathsep + os.environ.get("PYTHONPATH", ""),
+        }
+        result = self._run_torchmux(2, "mypkg.train", env_extra=env, extra_args=["-m"])
         self.assertEqual(
             result.returncode, 0,
             f"torchmux -m failed (rc={result.returncode}):\n"
@@ -1493,148 +1452,20 @@ class TestSharedIntCrossProcess(TestCase):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-class TestTorchmuxAVGCorrectness(TestCase):
-    def setUp(self):
-        super().setUp()
-        self._tmpdir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self._tmpdir, True)
-
+class TestTorchmuxAVGCorrectness(_TorchmuxSubprocessBase):
     def test_allreduce_avg(self):
-        script = os.path.join(self._tmpdir, "avg_test.py")
-        with open(script, "w") as f:
-            f.write(
-                "import json, os, torch, torch.distributed as dist\n"
-                "dist.init_process_group()\n"
-                "rank = dist.get_rank()\n"
-                "ws = dist.get_world_size()\n"
-                "device = f\"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}\"\n"
-                "torch.cuda.set_device(device)\n"
-                "results = {}\n"
-                "x = torch.full((4,), float(rank + 1), device=device)\n"
-                "dist.all_reduce(x, op=dist.ReduceOp.AVG)\n"
-                "expected = (ws + 1) / 2.0\n"
-                "results['allreduce_avg'] = torch.allclose(\n"
-                "    x, torch.full_like(x, expected)\n"
-                ")\n"
-                "full = torch.full((ws * 2,), float(rank + 1), device=device)\n"
-                "out = torch.zeros(2, device=device)\n"
-                "dist.reduce_scatter_tensor(out, full, op=dist.ReduceOp.AVG)\n"
-                "expected_rs = (ws + 1) / 2.0\n"
-                "results['reduce_scatter_avg'] = torch.allclose(\n"
-                "    out, torch.full_like(out, expected_rs)\n"
-                ")\n"
-                "dist.destroy_process_group()\n"
-                "path = os.path.join(os.environ['TORCHMUX_RESULTS_DIR'],\n"
-                "                    f'rank{rank}.json')\n"
-                "with open(path, 'w') as f:\n"
-                "    json.dump({k: bool(v) for k, v in results.items()}, f)\n"
-            )
-
-        results_dir = os.path.join(self._tmpdir, "results")
-        os.makedirs(results_dir)
-        env = os.environ.copy()
-        env["TORCHMUX_NGPUS"] = "1"
-        env["TORCHMUX_RESULTS_DIR"] = results_dir
-        env["TORCHMUX_TRACE_DIR"] = self._tmpdir
-
-        result = subprocess.run(
-            [
-                sys.executable, "-m", "torch.distributed.torchmux",
-                "--nproc-per-node", "2", script,
-            ],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        self.assertEqual(
-            result.returncode, 0,
-            f"torchmux AVG test failed (rc={result.returncode}):\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}",
-        )
-
-        for rank in range(2):
-            rpath = os.path.join(results_dir, f"rank{rank}.json")
-            self.assertTrue(os.path.exists(rpath))
-            with open(rpath) as f:
-                results = json.load(f)
-            for op_name, passed in results.items():
-                self.assertTrue(passed, f"rank {rank}: {op_name} failed")
+        script = self._write_script("avg_test.py", AVG_SCRIPT)
+        self._run_and_check_results(2, script)
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-class TestTorchmuxCoalescedCollectives(TestCase):
+class TestTorchmuxCoalescedCollectives(_TorchmuxSubprocessBase):
     """Test allgather_into_tensor_coalesced and reduce_scatter_tensor_coalesced
     through the full torchmux subprocess path."""
 
-    def setUp(self):
-        super().setUp()
-        self._tmpdir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self._tmpdir, True)
-
     def test_coalesced_correctness(self):
-        script = os.path.join(self._tmpdir, "coalesced.py")
-        with open(script, "w") as f:
-            f.write(
-                "import json, os, torch, torch.distributed as dist\n"
-                "from torch.distributed import ReduceOp\n"
-                "dist.init_process_group()\n"
-                "rank = dist.get_rank()\n"
-                "ws = dist.get_world_size()\n"
-                "device = f\"cuda:{rank % int(os.environ.get('TORCHMUX_NGPUS', '1'))}\"\n"
-                "torch.cuda.set_device(device)\n"
-                "results = {}\n"
-                "\n"
-                "# allgather_into_tensor_coalesced via _allgather_base path\n"
-                "inp = torch.full((2,), float(rank), device=device)\n"
-                "out = torch.zeros(2 * ws, device=device)\n"
-                "dist.all_gather_into_tensor(out, inp)\n"
-                "expected = torch.cat([torch.full((2,), float(r), device=device) for r in range(ws)])\n"
-                "results['allgather_base'] = torch.allclose(out, expected)\n"
-                "\n"
-                "# reduce_scatter_tensor via _reduce_scatter_base path\n"
-                "full = torch.full((ws * 2,), float(rank + 1), device=device)\n"
-                "out2 = torch.zeros(2, device=device)\n"
-                "dist.reduce_scatter_tensor(out2, full)\n"
-                "expected_rs = ws * (ws + 1) / 2\n"
-                "results['reduce_scatter_base'] = torch.allclose(out2, torch.full_like(out2, expected_rs))\n"
-                "\n"
-                "dist.destroy_process_group()\n"
-                "path = os.path.join(os.environ['TORCHMUX_RESULTS_DIR'], f'rank{rank}.json')\n"
-                "with open(path, 'w') as f:\n"
-                "    json.dump({k: bool(v) for k, v in results.items()}, f)\n"
-            )
-
-        results_dir = os.path.join(self._tmpdir, "results")
-        os.makedirs(results_dir)
-        env = os.environ.copy()
-        env["TORCHMUX_NGPUS"] = "1"
-        env["TORCHMUX_RESULTS_DIR"] = results_dir
-        env["TORCHMUX_TRACE_DIR"] = self._tmpdir
-
-        result = subprocess.run(
-            [
-                sys.executable, "-m", "torch.distributed.torchmux",
-                "--nproc-per-node", "2", script,
-            ],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        self.assertEqual(
-            result.returncode, 0,
-            f"torchmux coalesced test failed (rc={result.returncode}):\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}",
-        )
-
-        for rank in range(2):
-            rpath = os.path.join(results_dir, f"rank{rank}.json")
-            self.assertTrue(os.path.exists(rpath))
-            with open(rpath) as f:
-                results = json.load(f)
-            for op_name, passed in results.items():
-                self.assertTrue(passed, f"rank {rank}: {op_name} failed")
+        script = self._write_script("coalesced.py", COALESCED_SCRIPT)
+        self._run_and_check_results(2, script)
 
 
 class TestVNCCLSequenceNumbering(_VNCCLTestBase):
@@ -1745,75 +1576,12 @@ class TestVNCCLEmptyTensors(_VNCCLTestBase):
     not torch.cuda.is_available() or torch.cuda.device_count() < 2,
     "requires >= 2 CUDA GPUs",
 )
-class TestTorchmuxMultiGPU(TestCase):
+class TestTorchmuxMultiGPU(_TorchmuxSubprocessBase):
     """Test torchmux with --ngpus 2 to verify multi-GPU device mapping."""
 
-    def setUp(self):
-        super().setUp()
-        self._tmpdir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self._tmpdir, True)
-
     def test_ngpus_2_correctness(self):
-        script = os.path.join(self._tmpdir, "multigpu.py")
-        with open(script, "w") as f:
-            f.write(
-                "import json, os, torch, torch.distributed as dist\n"
-                "dist.init_process_group()\n"
-                "rank = dist.get_rank()\n"
-                "ws = dist.get_world_size()\n"
-                "ngpus = int(os.environ.get('TORCHMUX_NGPUS', '1'))\n"
-                "device = f'cuda:{rank % ngpus}'\n"
-                "torch.cuda.set_device(device)\n"
-                "results = {}\n"
-                "x = torch.full((4,), float(rank + 1), device=device)\n"
-                "dist.all_reduce(x)\n"
-                "expected = ws * (ws + 1) / 2\n"
-                "results['allreduce'] = torch.allclose(\n"
-                "    x, torch.full_like(x, expected)\n"
-                ")\n"
-                "results['device_index'] = (\n"
-                "    torch.cuda.current_device() == rank % ngpus\n"
-                ")\n"
-                "dist.destroy_process_group()\n"
-                "path = os.path.join(\n"
-                "    os.environ['TORCHMUX_RESULTS_DIR'], f'rank{rank}.json'\n"
-                ")\n"
-                "with open(path, 'w') as f:\n"
-                "    json.dump({k: bool(v) for k, v in results.items()}, f)\n"
-            )
-
-        results_dir = os.path.join(self._tmpdir, "results")
-        os.makedirs(results_dir)
-        trace_dir = os.path.join(self._tmpdir, "traces")
-        os.makedirs(trace_dir)
-        env = os.environ.copy()
-        env["TORCHMUX_NGPUS"] = "2"
-        env["TORCHMUX_RESULTS_DIR"] = results_dir
-        env["TORCHMUX_TRACE_DIR"] = trace_dir
-
-        result = subprocess.run(
-            [
-                sys.executable, "-m", "torch.distributed.torchmux",
-                "--nproc-per-node", "4", "--ngpus", "2", script,
-            ],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        self.assertEqual(
-            result.returncode, 0,
-            f"torchmux --ngpus 2 failed (rc={result.returncode}):\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}",
-        )
-
-        for rank in range(4):
-            rpath = os.path.join(results_dir, f"rank{rank}.json")
-            self.assertTrue(os.path.exists(rpath), f"missing results for rank {rank}")
-            with open(rpath) as f:
-                results = json.load(f)
-            for op_name, passed in results.items():
-                self.assertTrue(passed, f"rank {rank}: {op_name} failed")
+        script = self._write_script("multigpu.py", MULTIGPU_SCRIPT)
+        self._run_and_check_results(4, script, ngpus=2)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_baton.py
+++ b/torch/distributed/_baton.py
@@ -73,7 +73,7 @@ def _get_cuda():
         lib.cuCheckpointProcessGetState.restype = _c_int
         lib.cuCheckpointProcessGetState.argtypes = [_c_int, _ptr(_c_int)]
 
-        _check(lib.cuInit(0), "cuInit")
+        _check(lib.cuInit(0), "cuInit", lib=lib)
         _cuda = lib
     return _cuda
 
@@ -98,9 +98,9 @@ class _UnlockArgs(ctypes.Structure):
     _fields_ = [("reserved", ctypes.c_uint64 * 8)]
 
 
-def _check(result: int, name: str) -> None:
+def _check(result: int, name: str, lib=None) -> None:
     if result != 0:
-        cuda = _get_cuda()
+        cuda = lib if lib is not None else _get_cuda()
         err = ctypes.c_char_p()
         cuda.cuGetErrorString(result, ctypes.byref(err))
         msg = err.value.decode() if err.value else f"code {result}"

--- a/torch/distributed/_baton.py
+++ b/torch/distributed/_baton.py
@@ -73,7 +73,7 @@ def _get_cuda():
         lib.cuCheckpointProcessGetState.restype = _c_int
         lib.cuCheckpointProcessGetState.argtypes = [_c_int, _ptr(_c_int)]
 
-        lib.cuInit(0)
+        _check(lib.cuInit(0), "cuInit")
         _cuda = lib
     return _cuda
 

--- a/torch/distributed/_baton.py
+++ b/torch/distributed/_baton.py
@@ -1,0 +1,183 @@
+"""
+GPU baton: checkpoint and restore a process's entire CUDA context.
+
+Wraps cuCheckpointProcess{Lock,Checkpoint,Restore,Unlock} via ctypes
+so a process can release its entire CUDA context (VRAM returned to the
+driver) and later restore it at the same virtual addresses.
+
+Usage from a coordinator process::
+
+    baton = CudaBaton()
+    baton.checkpoint(worker_pid)  # worker's VRAM freed
+    baton.restore(worker_pid)  # worker's VRAM restored
+
+The target process must have an active CUDA context. After checkpoint,
+the process is in CHECKPOINTED state and cannot make CUDA calls.
+After restore, it is back in LOCKED state; call unlock to resume.
+"""
+
+import ctypes
+import logging
+import threading
+
+log = logging.getLogger(__name__)
+
+_cuda = None
+_cuda_lock = threading.Lock()
+
+
+# Checkpoint process state constants returned by get_state().
+CHECKPOINT_STATE_INVALID = 0
+CHECKPOINT_STATE_ACTIVE = 1
+CHECKPOINT_STATE_LOCKED = 2
+CHECKPOINT_STATE_CHECKPOINTED = 3
+
+
+def _get_cuda():
+    global _cuda
+    if _cuda is not None:
+        return _cuda
+    with _cuda_lock:
+        if _cuda is not None:
+            return _cuda
+        try:
+            lib = ctypes.CDLL("libcuda.so.1")
+        except OSError as e:
+            raise RuntimeError(
+                "torchmux requires the CUDA driver library (libcuda.so.1). "
+                "Ensure CUDA drivers are installed and libcuda.so.1 is on "
+                "the library search path."
+            ) from e
+
+        _ptr = ctypes.POINTER
+        _c_int = ctypes.c_int
+
+        lib.cuInit.restype = _c_int
+        lib.cuInit.argtypes = [ctypes.c_uint]
+
+        lib.cuGetErrorString.restype = _c_int
+        lib.cuGetErrorString.argtypes = [_c_int, _ptr(ctypes.c_char_p)]
+
+        lib.cuCheckpointProcessLock.restype = _c_int
+        lib.cuCheckpointProcessLock.argtypes = [_c_int, _ptr(_LockArgs)]
+
+        lib.cuCheckpointProcessCheckpoint.restype = _c_int
+        lib.cuCheckpointProcessCheckpoint.argtypes = [_c_int, _ptr(_CheckpointArgs)]
+
+        lib.cuCheckpointProcessRestore.restype = _c_int
+        lib.cuCheckpointProcessRestore.argtypes = [_c_int, _ptr(_RestoreArgs)]
+
+        lib.cuCheckpointProcessUnlock.restype = _c_int
+        lib.cuCheckpointProcessUnlock.argtypes = [_c_int, _ptr(_UnlockArgs)]
+
+        lib.cuCheckpointProcessGetState.restype = _c_int
+        lib.cuCheckpointProcessGetState.argtypes = [_c_int, _ptr(_c_int)]
+
+        lib.cuInit(0)
+        _cuda = lib
+    return _cuda
+
+
+class _LockArgs(ctypes.Structure):
+    _fields_ = [
+        ("timeoutMs", ctypes.c_uint),
+        ("reserved0", ctypes.c_uint),
+        ("reserved1", ctypes.c_uint64 * 7),
+    ]
+
+
+class _CheckpointArgs(ctypes.Structure):
+    _fields_ = [("reserved", ctypes.c_uint64 * 8)]
+
+
+class _RestoreArgs(ctypes.Structure):
+    _fields_ = [("reserved", ctypes.c_uint64 * 8)]
+
+
+class _UnlockArgs(ctypes.Structure):
+    _fields_ = [("reserved", ctypes.c_uint64 * 8)]
+
+
+def _check(result: int, name: str) -> None:
+    if result != 0:
+        cuda = _get_cuda()
+        err = ctypes.c_char_p()
+        cuda.cuGetErrorString(result, ctypes.byref(err))
+        msg = err.value.decode() if err.value else f"code {result}"
+        raise RuntimeError(f"{name} failed: {msg}")
+
+
+class CudaBaton:
+    """Checkpoint/restore a process's GPU state via the CUDA driver API.
+
+    All methods target a remote process by PID. The caller must be in
+    the same CUDA MPS or checkpoint-capable environment.
+    """
+
+    def lock(self, pid: int, timeout_ms: int = 30000) -> None:
+        cuda = _get_cuda()
+        args = _LockArgs(timeoutMs=timeout_ms)
+        _check(cuda.cuCheckpointProcessLock(pid, ctypes.byref(args)), "Lock")
+
+    def checkpoint(self, pid: int, timeout_ms: int = 30000) -> None:
+        """Lock + checkpoint: VRAM is freed, process cannot use CUDA."""
+        self.lock(pid, timeout_ms)
+        try:
+            cuda = _get_cuda()
+            args = _CheckpointArgs()
+            _check(
+                cuda.cuCheckpointProcessCheckpoint(pid, ctypes.byref(args)),
+                "Checkpoint",
+            )
+        except Exception:
+            try:
+                self.unlock(pid)
+            except Exception:
+                log.error(
+                    "CudaBaton: unlock failed after checkpoint failure for "
+                    "pid %d; process may be stuck in LOCKED state",
+                    pid,
+                )
+            raise
+
+    def restore(self, pid: int) -> None:
+        """Restore from last checkpoint (process enters LOCKED state)."""
+        cuda = _get_cuda()
+        args = _RestoreArgs()
+        _check(
+            cuda.cuCheckpointProcessRestore(pid, ctypes.byref(args)),
+            "Restore",
+        )
+
+    def unlock(self, pid: int) -> None:
+        cuda = _get_cuda()
+        args = _UnlockArgs()
+        _check(
+            cuda.cuCheckpointProcessUnlock(pid, ctypes.byref(args)),
+            "Unlock",
+        )
+
+    def restore_and_unlock(self, pid: int) -> None:
+        """Restore + unlock: process can resume CUDA calls."""
+        self.restore(pid)
+        try:
+            self.unlock(pid)
+        except Exception:
+            # Process is restored but stuck in LOCKED state. Log and
+            # re-raise — the caller must handle this, otherwise the
+            # process will deadlock on its next CUDA call.
+            log.error(
+                "CudaBaton: unlock failed after successful restore for pid %d; "
+                "process is in LOCKED state and cannot make CUDA calls",
+                pid,
+            )
+            raise
+
+    def get_state(self, pid: int) -> int:
+        cuda = _get_cuda()
+        state = ctypes.c_int()
+        _check(
+            cuda.cuCheckpointProcessGetState(pid, ctypes.byref(state)),
+            "GetState",
+        )
+        return state.value

--- a/torch/distributed/torchmux.py
+++ b/torch/distributed/torchmux.py
@@ -12,21 +12,27 @@ CUDA context via the driver API (VRAM returned to the driver) and
 restores it when rescheduled. Collectives are resolved by bookkeeping
 each rank's tensor contribution on disk — no NCCL is needed.
 
-Produces two chrome://tracing traces (set TORCHMUX_TRACE_DIR, default
-/tmp): a natural trace showing actual serial execution with
-snapshot/restore overhead, and a synthetic trace reconstructing what
-parallel execution would look like.
+Produces two chrome://tracing traces (set TORCHMUX_TRACE_DIR):
+a natural trace showing actual serial execution with snapshot/restore
+overhead, and a synthetic trace reconstructing what parallel execution
+would look like.
 
-Note: each worker process monkeypatches torch.device and
-torch.cuda.set_device to transparently remap virtual CUDA device
-indices (e.g. cuda:5) onto physical GPUs (e.g. cuda:1 when ngpus=2).
-This only affects Python-level calls to torch.device() made after
-the monkeypatch is installed. Some PyTorch modules cache the original
-torch.device at import time (e.g. torch.nn.modules.module,
-torch.fx.graph) — code using those cached references will bypass the
-remapping. This is fine for standard training scripts that construct
-devices via torch.device(...) at call sites.
+Note [torchmux device remapping]:
+Each worker process monkeypatches torch.device and torch.cuda.set_device
+to transparently remap virtual CUDA device indices (e.g. cuda:5) onto
+physical GPUs (e.g. cuda:1 when ngpus=2). Limitations:
+  - Only affects Python-level calls to torch.device() made *after* the
+    monkeypatch is installed. Modules that cache the original torch.device
+    at import time (e.g. torch.nn.modules.module, torch.fx.graph) bypass
+    the remapping.
+  - isinstance(x, torch.device) works correctly via the _DeviceMeta
+    metaclass, but `type(x) is torch.device` identity checks will fail
+    (since actual device objects are _OrigDevice instances).
+  - This is acceptable for standard training scripts that construct
+    devices via torch.device(...) at call sites.
 """
+
+__all__: list[str] = []
 
 import argparse
 import json
@@ -157,6 +163,10 @@ def _release(*, snapshot=True):
 
 # ---- Per-process trace recording ----
 
+# Trace events are bounded to prevent unbounded memory growth in long
+# training runs. At ~200 bytes per event, 1M events ≈ 200MB. For a
+# typical run with ~10 events/step, this covers ~100k steps.
+_MAX_TRACE_EVENTS = 1_000_000
 _trace_events = []  # list of (cat, name, start_us, dur_us)
 _compute_start = None  # monotonic us when current compute phase began
 
@@ -166,7 +176,8 @@ def _us():
 
 
 def _trace(cat, name, start, dur):
-    _trace_events.append((cat, name, start, dur))
+    if len(_trace_events) < _MAX_TRACE_EVENTS:
+        _trace_events.append((cat, name, start, dur))
 
 
 def _begin_compute():
@@ -725,8 +736,9 @@ def _worker(
     dist.destroy_process_group = _mux_destroy
     dist.new_group = _mux_new_group
 
-    trace_dir = os.environ.get("TORCHMUX_TRACE_DIR", "/tmp")
-    os.makedirs(trace_dir, exist_ok=True)
+    trace_dir = os.environ.get("TORCHMUX_TRACE_DIR", "")
+    if trace_dir:
+        os.makedirs(trace_dir, exist_ok=True)
 
     _acquire()
     _begin_compute()
@@ -880,7 +892,7 @@ def main():
     finally:
         from torch.distributed import torchmux_trace
 
-        trace_dir = os.environ.get("TORCHMUX_TRACE_DIR", "/tmp")
+        trace_dir = os.environ.get("TORCHMUX_TRACE_DIR", "")
 
         events_by_rank = {}
         for r in range(nproc):
@@ -892,7 +904,7 @@ def main():
                 except (json.JSONDecodeError, ValueError):
                     pass
 
-        if events_by_rank:
+        if events_by_rank and trace_dir:
             natural_path = os.path.join(trace_dir, "torchmux_natural.json")
             synthetic_path = os.path.join(trace_dir, "torchmux_synthetic.json")
 
@@ -905,6 +917,7 @@ def main():
                 synthetic_path,
             )
 
+        if events_by_rank:
             _print_timing_summary(events_by_rank)
 
         sched.cleanup()

--- a/torch/distributed/torchmux.py
+++ b/torch/distributed/torchmux.py
@@ -112,6 +112,11 @@ class _SharedInt:
             self._shm.close()
         except Exception:
             pass
+        if getattr(self, "_owner", False):
+            try:
+                self._shm.unlink()
+            except Exception:
+                pass
 
     def __getstate__(self):
         return self._shm.name
@@ -852,6 +857,9 @@ def main():
             f"--ngpus ({ngpus}) must be <= --nproc-per-node ({nproc})"
         )
 
+    # Bind to port 0 to get a random free port. There is a TOCTOU
+    # window between closing this socket and workers connecting, but
+    # in practice collisions are rare on ephemeral ports.
     with socket.socket() as s:
         s.bind(("", 0))
         port = s.getsockname()[1]

--- a/torch/distributed/torchmux.py
+++ b/torch/distributed/torchmux.py
@@ -6,15 +6,15 @@ Usage:
     python -m torch.distributed.torchmux --nproc-per-node 8 --ngpus 2 train.py [args...]
 
 Launches N worker processes mapped round-robin onto M physical GPUs.
-Workers execute cooperatively: only one runs per GPU at a time, yielding
-at collective boundaries. When a worker yields it checkpoints its entire
-CUDA context via the driver API (VRAM returned to the driver) and
-restores it when rescheduled. Collectives are resolved by bookkeeping
-each rank's tensor contribution on disk — no NCCL is needed.
+Workers on different GPUs run in parallel; workers sharing a GPU run
+cooperatively, yielding at collective boundaries. When a worker yields
+it checkpoints its entire CUDA context via the driver API (VRAM returned
+to the driver) and restores it when rescheduled. Collectives are resolved
+by bookkeeping each rank's tensor contribution on disk — no NCCL is needed.
 
 Produces two chrome://tracing traces (set TORCHMUX_TRACE_DIR):
-a natural trace showing actual serial execution with snapshot/restore
-overhead, and a synthetic trace reconstructing what parallel execution
+a natural trace showing actual execution with per-GPU interleaving,
+and a synthetic trace reconstructing what fully parallel execution
 would look like.
 
 Note [torchmux device remapping]:
@@ -125,8 +125,15 @@ class _SharedInt:
 
 
 # ---- Cooperative scheduling ----
+#
+# Per-GPU scheduling: each physical GPU has its own scheduling token
+# (_SharedInt). Workers on different GPUs run in parallel; workers
+# sharing a GPU take turns via their GPU's token.
 
-_sched = None  # _SharedInt — which rank may run
+_gpu_scheds = None  # list[_SharedInt], one per physical GPU
+_gpu_id = None  # which physical GPU this worker uses
+_gpu_peers = None  # list of ranks sharing this GPU, in scheduling order
+_gpu_peer_idx = None  # index of this rank within _gpu_peers
 _rank = None
 _ws = None
 _held = False
@@ -137,13 +144,15 @@ _ACQUIRE_TIMEOUT_S = float(os.environ.get("TORCHMUX_ACQUIRE_TIMEOUT", "300"))
 
 def _acquire(*, restore=True):
     global _held
+    sched = _gpu_scheds[_gpu_id]
     deadline = time.monotonic() + _ACQUIRE_TIMEOUT_S
     delay = 1e-5
-    while _sched.value != _rank:
+    while sched.value != _rank:
         if time.monotonic() > deadline:
             raise RuntimeError(
-                f"rank {_rank}: timed out waiting for scheduling token after "
-                f"{_ACQUIRE_TIMEOUT_S}s (likely a worker crash)"
+                f"rank {_rank}: timed out waiting for GPU {_gpu_id} "
+                f"scheduling token after {_ACQUIRE_TIMEOUT_S}s "
+                f"(likely a worker crash)"
             )
         time.sleep(delay)
         delay = min(delay * 2, 1e-2)
@@ -156,9 +165,8 @@ def _release(*, snapshot=True):
     global _held
     if snapshot:
         _snapshot_gpu()
-    # Safe without locking: only the token holder calls _release, and no
-    # other process writes _sched until we advance it here.
-    _sched.value = (_rank + 1) % _ws
+    next_idx = (_gpu_peer_idx + 1) % len(_gpu_peers)
+    _gpu_scheds[_gpu_id].value = _gpu_peers[next_idx]
     _held = False
 
 
@@ -663,7 +671,7 @@ def _create_mux_pg(store, rank, world_size, timeout):
 
     pg = _MuxPG(rank, world_size)
     if _held:
-        _release(snapshot=False)
+        _release()
     _store_based_barrier(rank, store, "", world_size, timeout)
     if not _held:
         _acquire(restore=False)
@@ -677,19 +685,27 @@ def _worker(
     rank,
     world_size,
     ngpus,
-    sched_next,
+    gpu_scheds_list,
     master_port,
     coll_dir_path,
     script,
     script_args,
     run_as_module,
 ):
-    global _ngpus, _sched, _rank, _ws, _held, _coll_dir, _baton
+    global _ngpus, _gpu_scheds, _gpu_id, _gpu_peers, _gpu_peer_idx
+    global _rank, _ws, _held, _coll_dir, _baton
     _ngpus = ngpus
-    _sched = sched_next
+    _gpu_scheds = gpu_scheds_list
     _rank = rank
     _ws = world_size
     _coll_dir = coll_dir_path
+
+    _gpu_id = rank % ngpus
+    peers_by_gpu = {}
+    for r in range(world_size):
+        peers_by_gpu.setdefault(r % ngpus, []).append(r)
+    _gpu_peers = peers_by_gpu[_gpu_id]
+    _gpu_peer_idx = _gpu_peers.index(rank)
 
     os.environ.update(
         {
@@ -732,7 +748,7 @@ def _worker(
         _end_compute()
         t0 = _us()
         if _held:
-            _release(snapshot=False)
+            _release()
         try:
             _orig_destroy()
         finally:
@@ -744,7 +760,7 @@ def _worker(
         _end_compute()
         t0 = _us()
         if _held:
-            _release(snapshot=False)
+            _release()
         try:
             return _orig_new_group(*args, **kwargs)
         finally:
@@ -770,12 +786,13 @@ def _worker(
             runpy.run_path(script, run_name="__main__")
     finally:
         _end_compute()
-        if _held:
-            _release()
 
-        synthetic_path = os.path.join(coll_dir_path, f"trace_rank{rank}.json")
-        with open(synthetic_path, "w") as f:
+        trace_path = os.path.join(coll_dir_path, f"trace_rank{rank}.json")
+        with open(trace_path, "w") as f:
             json.dump(_trace_events, f)
+
+        if _held:
+            _release(snapshot=False)
 
 
 # ---- Entry point ----
@@ -879,7 +896,11 @@ def main():
         s.bind(("", 0))
         port = s.getsockname()[1]
 
-    sched = _SharedInt()
+    gpu_scheds = []
+    for g in range(ngpus):
+        s = _SharedInt()
+        s.value = g
+        gpu_scheds.append(s)
     shm = "/dev/shm" if os.path.isdir("/dev/shm") else None
     if shm is None:
         log.warning(
@@ -902,7 +923,7 @@ def main():
             args=(
                 nproc,
                 ngpus,
-                sched,
+                gpu_scheds,
                 port,
                 coll_dir,
                 args.training_script,
@@ -943,7 +964,8 @@ def main():
         if events_by_rank:
             _print_timing_summary(events_by_rank)
 
-        sched.cleanup()
+        for s in gpu_scheds:
+            s.cleanup()
         shutil.rmtree(coll_dir, ignore_errors=True)
 
 

--- a/torch/distributed/torchmux.py
+++ b/torch/distributed/torchmux.py
@@ -97,26 +97,22 @@ class _SharedInt:
         struct.pack_into("i", self._shm.buf, 0, v)
 
     def cleanup(self):
+        shm = getattr(self, "_shm", None)
+        if shm is None:
+            return
         try:
-            self._shm.close()
+            shm.close()
         except Exception:
             pass
         if self._owner:
             try:
-                self._shm.unlink()
+                shm.unlink()
             except Exception:
                 pass
+        self._shm = None
 
     def __del__(self):
-        try:
-            self._shm.close()
-        except Exception:
-            pass
-        if getattr(self, "_owner", False):
-            try:
-                self._shm.unlink()
-            except Exception:
-                pass
+        self.cleanup()
 
     def __getstate__(self):
         return self._shm.name

--- a/torch/distributed/torchmux.py
+++ b/torch/distributed/torchmux.py
@@ -1,0 +1,915 @@
+"""
+torchmux: Simulate N-GPU distributed training on M GPUs (M ≤ N).
+
+Usage:
+    python -m torch.distributed.torchmux --nproc-per-node 8 train.py [args...]
+    python -m torch.distributed.torchmux --nproc-per-node 8 --ngpus 2 train.py [args...]
+
+Launches N worker processes mapped round-robin onto M physical GPUs.
+Workers execute cooperatively: only one runs per GPU at a time, yielding
+at collective boundaries. When a worker yields it checkpoints its entire
+CUDA context via the driver API (VRAM returned to the driver) and
+restores it when rescheduled. Collectives are resolved by bookkeeping
+each rank's tensor contribution on disk — no NCCL is needed.
+
+Produces two chrome://tracing traces (set TORCHMUX_TRACE_DIR, default
+/tmp): a natural trace showing actual serial execution with
+snapshot/restore overhead, and a synthetic trace reconstructing what
+parallel execution would look like.
+
+Note: each worker process monkeypatches torch.device and
+torch.cuda.set_device to transparently remap virtual CUDA device
+indices (e.g. cuda:5) onto physical GPUs (e.g. cuda:1 when ngpus=2).
+This only affects Python-level calls to torch.device() made after
+the monkeypatch is installed. Some PyTorch modules cache the original
+torch.device at import time (e.g. torch.nn.modules.module,
+torch.fx.graph) — code using those cached references will bypass the
+remapping. This is fine for standard training scripts that construct
+devices via torch.device(...) at call sites.
+"""
+
+import argparse
+import json
+import logging
+import os
+import runpy
+import shutil
+import socket
+import struct
+import sys
+import tempfile
+import time
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+log = logging.getLogger(__name__)
+
+
+# ---- torch.device remapping ----
+
+_OrigDevice = torch.device
+_ngpus = 1
+
+
+class _DeviceMeta(type):
+    def __instancecheck__(cls, instance):
+        return isinstance(instance, _OrigDevice)
+
+    def __subclasscheck__(cls, subclass):
+        if subclass is _OrigDevice:
+            return True
+        return type.__subclasscheck__(cls, subclass)
+
+
+class _MuxDevice(metaclass=_DeviceMeta):
+    def __new__(cls, *args, **kwargs):
+        d = _OrigDevice(*args, **kwargs)
+        if d.type == "cuda" and d.index is not None:
+            return _OrigDevice("cuda", d.index % _ngpus)
+        return d
+
+
+# ---- Shared int via POSIX shared memory (survives mp.spawn pickling) ----
+
+
+class _SharedInt:
+    def __init__(self):
+        from multiprocessing.shared_memory import SharedMemory
+
+        self._shm = SharedMemory(create=True, size=4)
+        struct.pack_into("i", self._shm.buf, 0, 0)
+        self._owner = True
+
+    @property
+    def value(self):
+        return struct.unpack_from("i", self._shm.buf, 0)[0]
+
+    @value.setter
+    def value(self, v):
+        struct.pack_into("i", self._shm.buf, 0, v)
+
+    def cleanup(self):
+        try:
+            self._shm.close()
+        except Exception:
+            pass
+        if self._owner:
+            try:
+                self._shm.unlink()
+            except Exception:
+                pass
+
+    def __del__(self):
+        try:
+            self._shm.close()
+        except Exception:
+            pass
+
+    def __getstate__(self):
+        return self._shm.name
+
+    def __setstate__(self, name):
+        from multiprocessing.shared_memory import SharedMemory
+
+        self._shm = SharedMemory(name=name, create=False)
+        self._owner = False
+
+
+# ---- Cooperative scheduling ----
+
+_sched = None  # _SharedInt — which rank may run
+_rank = None
+_ws = None
+_held = False
+
+
+_ACQUIRE_TIMEOUT_S = float(os.environ.get("TORCHMUX_ACQUIRE_TIMEOUT", "300"))
+
+
+def _acquire(*, restore=True):
+    global _held
+    deadline = time.monotonic() + _ACQUIRE_TIMEOUT_S
+    delay = 1e-5
+    while _sched.value != _rank:
+        if time.monotonic() > deadline:
+            raise RuntimeError(
+                f"rank {_rank}: timed out waiting for scheduling token after "
+                f"{_ACQUIRE_TIMEOUT_S}s (likely a worker crash)"
+            )
+        time.sleep(delay)
+        delay = min(delay * 2, 1e-2)
+    _held = True
+    if restore:
+        _restore_gpu()
+
+
+def _release(*, snapshot=True):
+    global _held
+    if snapshot:
+        _snapshot_gpu()
+    # Safe without locking: only the token holder calls _release, and no
+    # other process writes _sched until we advance it here.
+    _sched.value = (_rank + 1) % _ws
+    _held = False
+
+
+# ---- Per-process trace recording ----
+
+_trace_events = []  # list of (cat, name, start_us, dur_us)
+_compute_start = None  # monotonic us when current compute phase began
+
+
+def _us():
+    return time.monotonic() * 1e6
+
+
+def _trace(cat, name, start, dur):
+    _trace_events.append((cat, name, start, dur))
+
+
+def _begin_compute():
+    global _compute_start
+    _compute_start = _us()
+
+
+def _end_compute():
+    global _compute_start
+    if _compute_start is not None:
+        dur = _us() - _compute_start
+        if dur > 0:
+            _trace("compute", "compute", _compute_start, dur)
+        _compute_start = None
+
+
+# ---- GPU state checkpoint/restore via CUDA driver ----
+
+_baton = None  # CudaBaton instance
+_checkpointed = False  # has this process ever been checkpointed?
+
+
+def _snapshot_gpu():
+    global _checkpointed
+    if not torch.cuda.is_initialized():
+        return
+    torch.cuda.synchronize()
+    t0 = _us()
+    _baton.checkpoint(os.getpid())
+    _trace("mux", "snapshot", t0, _us() - t0)
+    _checkpointed = True
+
+
+def _restore_gpu():
+    global _checkpointed
+    if _checkpointed:
+        t0 = _us()
+        _baton.restore_and_unlock(os.getpid())
+        _trace("mux", "restore", t0, _us() - t0)
+        _checkpointed = False
+
+
+def _yield_and_wait(check_fn):
+    """Release token (snapshots GPU), wait, reacquire (restores GPU)."""
+    if check_fn():
+        return
+    if _held:
+        _release()
+    deadline = time.monotonic() + _ACQUIRE_TIMEOUT_S
+    delay = 1e-5
+    while not check_fn():
+        if time.monotonic() > deadline:
+            raise RuntimeError(
+                f"rank {_rank}: timed out waiting for collective to resolve "
+                f"after {_ACQUIRE_TIMEOUT_S}s (likely a worker crash)"
+            )
+        time.sleep(delay)
+        delay = min(delay * 2, 1e-2)
+    _acquire()
+
+
+# ---- Helpers ----
+
+
+def _completed_work():
+    from torch._C._distributed_c10d import _create_work_from_future
+    from torch.futures import Future
+
+    fut = Future()
+    fut.set_result(None)
+    return _create_work_from_future(fut)
+
+
+_coll_dir = None  # shared tempdir for collective data
+
+
+def _coll_path(pg_id, coll_id, filename):
+    return os.path.join(_coll_dir, f"pg{pg_id}", f"c{coll_id:08d}", filename)
+
+
+def _save_tensor(path, tensor):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    try:
+        torch.save(tensor.detach().cpu(), tmp)
+    except OSError as e:
+        raise RuntimeError(
+            f"rank {_rank}: failed to save tensor to {tmp} "
+            f"(collective data dir: {_coll_dir}): {e}"
+        ) from e
+    os.rename(tmp, path)
+
+
+def _load_tensor(path):
+    return torch.load(path, map_location="cpu", weights_only=True)
+
+
+# ---- File-based ProcessGroup ----
+
+from torch._C._distributed_c10d import (
+    AllgatherOptions,
+    AllreduceOptions,
+    AllToAllOptions,
+    BarrierOptions,
+    BroadcastOptions,
+    ReduceOp,
+    ReduceScatterOptions,
+    ScatterOptions,
+)
+
+
+_REDUCE_FNS = {
+    ReduceOp.SUM: torch.Tensor.add_,
+    ReduceOp.AVG: torch.Tensor.add_,
+    ReduceOp.PRODUCT: torch.Tensor.mul_,
+    ReduceOp.MIN: lambda a, b: torch.minimum(a, b, out=a),
+    ReduceOp.MAX: lambda a, b: torch.maximum(a, b, out=a),
+    ReduceOp.BAND: torch.Tensor.bitwise_and_,
+    ReduceOp.BOR: torch.Tensor.bitwise_or_,
+    ReduceOp.BXOR: torch.Tensor.bitwise_xor_,
+}
+
+
+def _get_reduce_fn(op):
+    # opts.reduceOp can return either a C++ ReduceOp enum value or a
+    # Python ReduceOp wrapper (which has an .op attribute holding the
+    # underlying C++ enum). Normalize before lookup.
+    if hasattr(op, "op"):
+        op = op.op
+    return _REDUCE_FNS[op]
+
+
+def _is_avg(op):
+    if hasattr(op, "op"):
+        op = op.op
+    return op == ReduceOp.AVG
+
+
+class _MuxPG(dist.ProcessGroup):
+    """Resolves collectives by bookkeeping tensors on disk.
+
+    Each collective: save contribution → check if all ranks contributed →
+    if yes, resolve on CPU and continue; if no, snapshot GPU to disk,
+    yield the GPU, and wait. When rescheduled, restore GPU state and
+    load the collective result.
+    """
+
+    # Per-process counter (not globally unique). Each forked worker gets
+    # its own copy, but that's fine: collective data paths include both
+    # pg_id and rank, so there are no cross-process collisions.
+    _next_pg_id = 0
+
+    def __init__(self, rank, world_size):
+        super().__init__(rank, world_size)
+        self._rank = rank
+        self._ws = world_size
+        self._pg_id = _MuxPG._next_pg_id
+        _MuxPG._next_pg_id += 1
+        self._coll_id = 0
+
+    def _next_coll(self):
+        cid = self._coll_id
+        self._coll_id += 1
+        # Clean up cid-2, not cid-1: by the time rank R starts
+        # collective N, another rank may still be reading output
+        # files from collective N-1. Collective N-2 is safe because
+        # all ranks must have finished N-1 (and thus N-2) to reach N.
+        if cid >= 2:
+            self._cleanup_coll(cid - 2)
+        return cid
+
+    def _cleanup_coll(self, cid):
+        coll_dir = os.path.join(_coll_dir, f"pg{self._pg_id}", f"c{cid:08d}")
+        shutil.rmtree(coll_dir, ignore_errors=True)
+
+    def _ready_path(self, cid, rank):
+        return _coll_path(self._pg_id, cid, f"ready_{rank}")
+
+    def _claim_path(self, cid):
+        return _coll_path(self._pg_id, cid, "claimed")
+
+    def _done_path(self, cid):
+        return _coll_path(self._pg_id, cid, "done")
+
+    def _mark_ready(self, cid):
+        p = self._ready_path(cid, self._rank)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w"):
+            pass
+
+    def _all_ready(self, cid):
+        return all(os.path.exists(self._ready_path(cid, r)) for r in range(self._ws))
+
+    def _try_claim_resolver(self, cid):
+        """Atomically claim the resolver role for collective cid.
+
+        Uses O_CREAT|O_EXCL so exactly one process wins the race when
+        multiple processes see _all_ready() == True simultaneously.
+        Returns True for the winner, False for losers.
+        """
+        p = self._claim_path(cid)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        try:
+            fd = os.open(p, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.close(fd)
+            return True
+        except FileExistsError:
+            return False
+
+    def _mark_done(self, cid):
+        with open(self._done_path(cid), "w"):
+            pass
+
+    def _is_done(self, cid):
+        return os.path.exists(self._done_path(cid))
+
+    def _wait_for_done(self, cid):
+        _yield_and_wait(lambda: self._is_done(cid))
+
+    def _in_path(self, cid, rank, idx):
+        return _coll_path(self._pg_id, cid, f"in_r{rank}_t{idx}.pt")
+
+    def _out_path(self, cid, rank, idx):
+        return _coll_path(self._pg_id, cid, f"out_r{rank}_t{idx}.pt")
+
+    def _do_collective(self, name, fn):
+        """End compute span, run collective fn, begin new compute span."""
+        _end_compute()
+        t0 = _us()
+        with torch.profiler.record_function(f"torchmux::collective::{name}"):
+            result = fn()
+        _trace("collective", name, t0, _us() - t0)
+        _begin_compute()
+        return result
+
+    # ---- collectives ----
+
+    @torch.no_grad()
+    def allreduce(self, tensor_list, opts=AllreduceOptions()):
+        def _run():
+            cid = self._next_coll()
+            op = opts.reduceOp if hasattr(opts, "reduceOp") else ReduceOp.SUM
+            for i, t in enumerate(tensor_list):
+                _save_tensor(self._in_path(cid, self._rank, i), t)
+            self._mark_ready(cid)
+            if self._all_ready(cid) and self._try_claim_resolver(cid):
+                reduce_fn = _get_reduce_fn(op)
+                for i in range(len(tensor_list)):
+                    acc = _load_tensor(self._in_path(cid, 0, i)).clone()
+                    for r in range(1, self._ws):
+                        reduce_fn(acc, _load_tensor(self._in_path(cid, r, i)))
+                    if _is_avg(op):
+                        acc.div_(self._ws)
+                    _save_tensor(self._out_path(cid, 0, i), acc)
+                self._mark_done(cid)
+            else:
+                self._wait_for_done(cid)
+            for i, t in enumerate(tensor_list):
+                t.copy_(_load_tensor(self._out_path(cid, 0, i)).to(t.device))
+            return _completed_work()
+
+        return self._do_collective("allreduce", _run)
+
+    @torch.no_grad()
+    def allreduce_coalesced(self, tensor_list, opts=AllreduceOptions()):
+        return self.allreduce(tensor_list, opts)
+
+    @torch.no_grad()
+    def broadcast(self, tensor_list, opts=BroadcastOptions()):
+        def _run():
+            cid = self._next_coll()
+            root = opts.rootRank
+            if self._rank == root:
+                for i, t in enumerate(tensor_list):
+                    _save_tensor(self._in_path(cid, root, i), t)
+            self._mark_ready(cid)
+            if self._all_ready(cid) and self._try_claim_resolver(cid):
+                self._mark_done(cid)
+            else:
+                self._wait_for_done(cid)
+            if self._rank != root:
+                for i, t in enumerate(tensor_list):
+                    t.copy_(_load_tensor(self._in_path(cid, root, i)).to(t.device))
+            return _completed_work()
+
+        return self._do_collective("broadcast", _run)
+
+    @torch.no_grad()
+    def allgather(self, output_tensors, input_tensor, opts=AllgatherOptions()):
+        def _run():
+            cid = self._next_coll()
+            for i, t in enumerate(input_tensor):
+                _save_tensor(self._in_path(cid, self._rank, i), t)
+            self._mark_ready(cid)
+            if self._all_ready(cid) and self._try_claim_resolver(cid):
+                self._mark_done(cid)
+            else:
+                self._wait_for_done(cid)
+            for i, out_list in enumerate(output_tensors):
+                for r in range(self._ws):
+                    out_list[r].copy_(
+                        _load_tensor(self._in_path(cid, r, i)).to(out_list[r].device)
+                    )
+            return _completed_work()
+
+        return self._do_collective("allgather", _run)
+
+    @torch.no_grad()
+    def _allgather_base(self, output, input, opts=AllgatherOptions()):
+        def _run():
+            cid = self._next_coll()
+            _save_tensor(self._in_path(cid, self._rank, 0), input)
+            self._mark_ready(cid)
+            if self._all_ready(cid) and self._try_claim_resolver(cid):
+                chunks = [
+                    _load_tensor(self._in_path(cid, r, 0)) for r in range(self._ws)
+                ]
+                _save_tensor(self._out_path(cid, 0, 0), torch.cat(chunks, dim=0))
+                self._mark_done(cid)
+            else:
+                self._wait_for_done(cid)
+            output.copy_(_load_tensor(self._out_path(cid, 0, 0)).to(output.device))
+            return _completed_work()
+
+        return self._do_collective("allgather", _run)
+
+    @torch.no_grad()
+    def allgather_into_tensor_coalesced(self, outputs, inputs, opts=AllgatherOptions()):
+        for o, i in zip(outputs, inputs):
+            self._allgather_base(o, i, opts)
+        return _completed_work()
+
+    @torch.no_grad()
+    def _reduce_scatter_base(self, output, input, opts=ReduceScatterOptions()):
+        def _run():
+            cid = self._next_coll()
+            op = opts.reduceOp if hasattr(opts, "reduceOp") else ReduceOp.SUM
+            _save_tensor(self._in_path(cid, self._rank, 0), input)
+            self._mark_ready(cid)
+            if self._all_ready(cid) and self._try_claim_resolver(cid):
+                reduce_fn = _get_reduce_fn(op)
+                acc = _load_tensor(self._in_path(cid, 0, 0)).clone()
+                for r in range(1, self._ws):
+                    reduce_fn(acc, _load_tensor(self._in_path(cid, r, 0)))
+                if _is_avg(op):
+                    acc.div_(self._ws)
+                chunk_size = acc.size(0) // self._ws
+                for r in range(self._ws):
+                    _save_tensor(
+                        self._out_path(cid, r, 0),
+                        acc[r * chunk_size : (r + 1) * chunk_size].contiguous(),
+                    )
+                self._mark_done(cid)
+            else:
+                self._wait_for_done(cid)
+            output.copy_(
+                _load_tensor(self._out_path(cid, self._rank, 0)).to(output.device)
+            )
+            return _completed_work()
+
+        return self._do_collective("reduce_scatter", _run)
+
+    @torch.no_grad()
+    def reduce_scatter(self, output_tensor, scatter_list, opts=ReduceScatterOptions()):
+        def _run():
+            cid = self._next_coll()
+            op = opts.reduceOp if hasattr(opts, "reduceOp") else ReduceOp.SUM
+            reduce_fn = _get_reduce_fn(op)
+            for i, chunks in enumerate(scatter_list):
+                for r, chunk in enumerate(chunks):
+                    _save_tensor(
+                        _coll_path(self._pg_id, cid, f"in_r{self._rank}_s{i}_c{r}.pt"),
+                        chunk,
+                    )
+            self._mark_ready(cid)
+            if self._all_ready(cid) and self._try_claim_resolver(cid):
+                for dst in range(self._ws):
+                    for i in range(len(output_tensor)):
+                        acc = _load_tensor(
+                            _coll_path(self._pg_id, cid, f"in_r0_s{i}_c{dst}.pt")
+                        ).clone()
+                        for src in range(1, self._ws):
+                            reduce_fn(
+                                acc,
+                                _load_tensor(
+                                    _coll_path(
+                                        self._pg_id, cid, f"in_r{src}_s{i}_c{dst}.pt"
+                                    )
+                                ),
+                            )
+                        if _is_avg(op):
+                            acc.div_(self._ws)
+                        _save_tensor(self._out_path(cid, dst, i), acc)
+                self._mark_done(cid)
+            else:
+                self._wait_for_done(cid)
+            for i, t in enumerate(output_tensor):
+                t.copy_(_load_tensor(self._out_path(cid, self._rank, i)).to(t.device))
+            return _completed_work()
+
+        return self._do_collective("reduce_scatter", _run)
+
+    @torch.no_grad()
+    def reduce_scatter_tensor_coalesced(
+        self, outputs, inputs, opts=ReduceScatterOptions()
+    ):
+        for o, i in zip(outputs, inputs):
+            self._reduce_scatter_base(o, i, opts)
+        return _completed_work()
+
+    @torch.no_grad()
+    def scatter(self, output, input, opts=ScatterOptions()):
+        raise NotImplementedError("_MuxPG.scatter")
+
+    @torch.no_grad()
+    def gather(self, output, input, opts=ScatterOptions()):
+        raise NotImplementedError("_MuxPG.gather")
+
+    @torch.no_grad()
+    def alltoall(self, output, input, opts=AllToAllOptions()):
+        raise NotImplementedError("_MuxPG.alltoall")
+
+    @torch.no_grad()
+    def barrier(self, opts=BarrierOptions()):
+        def _run():
+            cid = self._next_coll()
+            self._mark_ready(cid)
+            if not self._all_ready(cid) or not self._try_claim_resolver(cid):
+                self._wait_for_done(cid)
+            else:
+                self._mark_done(cid)
+            return _completed_work()
+
+        return self._do_collective("barrier", _run)
+
+    # ---- metadata ----
+
+    def size(self):
+        return self._ws
+
+    def getBackendName(self):
+        return "mux_files"
+
+    @property
+    def pg_name(self):
+        return dist.distributed_c10d._world.pg_names.get(
+            self, f"mux_pg_{self._pg_id}"
+        )
+
+    @property
+    def group_name(self):
+        return self.pg_name
+
+    def __repr__(self):
+        return f"MuxFiles(rank={self._rank}, size={self._ws})"
+
+
+# ---- Backend factory ----
+
+
+def _create_mux_pg(store, rank, world_size, timeout):
+    from torch.distributed.distributed_c10d import _store_based_barrier
+
+    pg = _MuxPG(rank, world_size)
+    if _held:
+        _release(snapshot=False)
+    _store_based_barrier(rank, store, "", world_size, timeout)
+    if not _held:
+        _acquire(restore=False)
+    return pg
+
+
+# ---- Worker process ----
+
+
+def _worker(
+    rank,
+    world_size,
+    ngpus,
+    sched_next,
+    master_port,
+    coll_dir_path,
+    script,
+    script_args,
+    run_as_module,
+):
+    global _ngpus, _sched, _rank, _ws, _held, _coll_dir, _baton
+    _ngpus = ngpus
+    _sched = sched_next
+    _rank = rank
+    _ws = world_size
+    _coll_dir = coll_dir_path
+
+    os.environ.update(
+        {
+            "RANK": str(rank),
+            "LOCAL_RANK": str(rank),
+            "WORLD_SIZE": str(world_size),
+            "LOCAL_WORLD_SIZE": str(world_size),
+            "GROUP_RANK": "0",
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": str(master_port),
+            "CUDA_VISIBLE_DEVICES": ",".join(str(i) for i in range(ngpus)),
+        }
+    )
+
+    torch.device = _MuxDevice
+    _orig_cuda_set_device = torch.cuda.set_device
+    torch.cuda.set_device = lambda *a, **kw: _orig_cuda_set_device(rank % ngpus)
+
+    from torch.distributed._baton import CudaBaton
+
+    _baton = CudaBaton()
+
+    dist.Backend.register_backend("mux_files", _create_mux_pg, devices=["cpu", "cuda"])
+
+    _orig_init = dist.init_process_group
+    _orig_destroy = dist.destroy_process_group
+    _orig_new_group = dist.new_group
+
+    def _mux_init(backend=None, **kwargs):
+        _end_compute()
+        t0 = _us()
+        if _held:
+            _release(snapshot=False)
+        _orig_init(backend="mux_files", **kwargs)
+        _acquire(restore=False)
+        _trace("collective", "init", t0, _us() - t0)
+        _begin_compute()
+
+    def _mux_destroy():
+        _end_compute()
+        t0 = _us()
+        if _held:
+            _release(snapshot=False)
+        try:
+            _orig_destroy()
+        finally:
+            _acquire(restore=False)
+            _trace("collective", "destroy", t0, _us() - t0)
+            _begin_compute()
+
+    def _mux_new_group(*args, **kwargs):
+        _end_compute()
+        t0 = _us()
+        if _held:
+            _release(snapshot=False)
+        try:
+            return _orig_new_group(*args, **kwargs)
+        finally:
+            _acquire(restore=False)
+            _trace("collective", "new_group", t0, _us() - t0)
+            _begin_compute()
+
+    dist.init_process_group = _mux_init
+    dist.destroy_process_group = _mux_destroy
+    dist.new_group = _mux_new_group
+
+    trace_dir = os.environ.get("TORCHMUX_TRACE_DIR", "/tmp")
+    os.makedirs(trace_dir, exist_ok=True)
+
+    _acquire()
+    _begin_compute()
+    try:
+        sys.argv = [script] + list(script_args)
+        if run_as_module:
+            runpy.run_module(script, run_name="__main__", alter_sys=True)
+        else:
+            runpy.run_path(script, run_name="__main__")
+    finally:
+        _end_compute()
+        if _held:
+            _release()
+
+        synthetic_path = os.path.join(coll_dir_path, f"trace_rank{rank}.json")
+        with open(synthetic_path, "w") as f:
+            json.dump(_trace_events, f)
+
+
+# ---- Entry point ----
+
+
+def _print_timing_summary(events_by_rank):
+    header = f"{'Worker':>8} {'Wall(s)':>9} {'Compute%':>9} {'Snap%':>9} {'Restore%':>9} {'Overhead%':>9}"
+    log.info("\ntorchmux: timing overview\n%s", header)
+
+    sum_wall = 0
+    sum_compute = 0
+    sum_snap = 0
+    sum_restore = 0
+
+    for r in sorted(events_by_rank):
+        evts = events_by_rank[r]
+        if not evts:
+            continue
+        wall = max(s + d for _, _, s, d in evts) - min(s for _, _, s, d in evts)
+        if wall <= 0:
+            continue
+        compute = sum(d for cat, _, _, d in evts if cat == "compute")
+        snap = sum(d for _, name, _, d in evts if name == "snapshot")
+        restore = sum(d for _, name, _, d in evts if name == "restore")
+        overhead = snap + restore
+
+        sum_wall += wall
+        sum_compute += compute
+        sum_snap += snap
+        sum_restore += restore
+
+        log.info(
+            "%s %s %s %s %s %s",
+            f"{'R' + str(r):>8}",
+            f"{wall / 1e6:>8.1f}s",
+            f"{compute / wall * 100:>8.1f}%",
+            f"{snap / wall * 100:>8.1f}%",
+            f"{restore / wall * 100:>8.1f}%",
+            f"{overhead / wall * 100:>8.1f}%",
+        )
+
+    if len(events_by_rank) > 1 and sum_wall > 0:
+        avg_wall = sum_wall / len(events_by_rank)
+        log.info(
+            "%s %s %s %s %s %s",
+            f"{'Avg':>8}",
+            f"{avg_wall / 1e6:>8.1f}s",
+            f"{sum_compute / sum_wall * 100:>8.1f}%",
+            f"{sum_snap / sum_wall * 100:>8.1f}%",
+            f"{sum_restore / sum_wall * 100:>8.1f}%",
+            f"{(sum_snap + sum_restore) / sum_wall * 100:>8.1f}%",
+        )
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(
+        prog="torchmux",
+        description="Simulate N-GPU distributed training on M GPUs",
+    )
+    parser.add_argument(
+        "--nproc-per-node",
+        "--nproc_per_node",
+        type=int,
+        required=True,
+        dest="nproc_per_node",
+        help="Number of simulated workers",
+    )
+    parser.add_argument(
+        "--ngpus",
+        type=int,
+        default=1,
+        help="Number of physical GPUs (default 1)",
+    )
+    parser.add_argument(
+        "-m",
+        "--module",
+        action="store_true",
+        dest="module",
+        help="Run script as a Python module",
+    )
+    parser.add_argument("training_script", help="Training script or module name")
+    parser.add_argument("training_script_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    nproc = args.nproc_per_node
+    ngpus = args.ngpus
+    if nproc < 1:
+        parser.error("--nproc-per-node must be >= 1")
+    if ngpus < 1:
+        parser.error("--ngpus must be >= 1")
+    if ngpus > nproc:
+        parser.error(
+            f"--ngpus ({ngpus}) must be <= --nproc-per-node ({nproc})"
+        )
+
+    with socket.socket() as s:
+        s.bind(("", 0))
+        port = s.getsockname()[1]
+
+    sched = _SharedInt()
+    shm = "/dev/shm" if os.path.isdir("/dev/shm") else None
+    if shm is None:
+        log.warning(
+            "torchmux: /dev/shm not available, using disk-backed tmpdir for "
+            "collective data exchange. This may be slow for large tensors."
+        )
+    coll_dir = tempfile.mkdtemp(prefix="torchmux_colls_", dir=shm)
+
+    gpu_desc = "GPU 0" if ngpus == 1 else f"{ngpus} GPUs"
+    log.info(
+        "torchmux: %d workers on %s, script=%s",
+        nproc,
+        gpu_desc,
+        args.training_script,
+    )
+
+    try:
+        mp.spawn(
+            _worker,
+            args=(
+                nproc,
+                ngpus,
+                sched,
+                port,
+                coll_dir,
+                args.training_script,
+                args.training_script_args,
+                args.module,
+            ),
+            nprocs=nproc,
+            join=True,
+        )
+    finally:
+        from torch.distributed import torchmux_trace
+
+        trace_dir = os.environ.get("TORCHMUX_TRACE_DIR", "/tmp")
+
+        events_by_rank = {}
+        for r in range(nproc):
+            p = os.path.join(coll_dir, f"trace_rank{r}.json")
+            if os.path.exists(p) and os.path.getsize(p) > 0:
+                try:
+                    with open(p) as f:
+                        events_by_rank[r] = [tuple(e) for e in json.load(f)]
+                except (json.JSONDecodeError, ValueError):
+                    pass
+
+        if events_by_rank:
+            natural_path = os.path.join(trace_dir, "torchmux_natural.json")
+            synthetic_path = os.path.join(trace_dir, "torchmux_synthetic.json")
+
+            torchmux_trace.export_natural(events_by_rank, natural_path, nproc)
+            torchmux_trace.export_synthetic(events_by_rank, synthetic_path, nproc)
+
+            log.info(
+                "torchmux: traces written to %s and %s",
+                natural_path,
+                synthetic_path,
+            )
+
+            _print_timing_summary(events_by_rank)
+
+        sched.cleanup()
+        shutil.rmtree(coll_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/torch/distributed/torchmux.py
+++ b/torch/distributed/torchmux.py
@@ -421,7 +421,10 @@ class _MuxPG(dist.ProcessGroup):
     # ---- collectives ----
 
     @torch.no_grad()
-    def allreduce(self, tensor_list, opts=AllreduceOptions()):
+    def allreduce(self, tensor_list, opts=None):
+        if opts is None:
+            opts = AllreduceOptions()
+
         def _run():
             cid = self._next_coll()
             op = opts.reduceOp if hasattr(opts, "reduceOp") else ReduceOp.SUM
@@ -447,11 +450,13 @@ class _MuxPG(dist.ProcessGroup):
         return self._do_collective("allreduce", _run)
 
     @torch.no_grad()
-    def allreduce_coalesced(self, tensor_list, opts=AllreduceOptions()):
+    def allreduce_coalesced(self, tensor_list, opts=None):
         return self.allreduce(tensor_list, opts)
 
     @torch.no_grad()
-    def broadcast(self, tensor_list, opts=BroadcastOptions()):
+    def broadcast(self, tensor_list, opts=None):
+        if opts is None:
+            opts = BroadcastOptions()
         def _run():
             cid = self._next_coll()
             root = opts.rootRank
@@ -471,7 +476,9 @@ class _MuxPG(dist.ProcessGroup):
         return self._do_collective("broadcast", _run)
 
     @torch.no_grad()
-    def allgather(self, output_tensors, input_tensor, opts=AllgatherOptions()):
+    def allgather(self, output_tensors, input_tensor, opts=None):
+        if opts is None:
+            opts = AllgatherOptions()
         def _run():
             cid = self._next_coll()
             for i, t in enumerate(input_tensor):
@@ -491,7 +498,9 @@ class _MuxPG(dist.ProcessGroup):
         return self._do_collective("allgather", _run)
 
     @torch.no_grad()
-    def _allgather_base(self, output, input, opts=AllgatherOptions()):
+    def _allgather_base(self, output, input, opts=None):
+        if opts is None:
+            opts = AllgatherOptions()
         def _run():
             cid = self._next_coll()
             _save_tensor(self._in_path(cid, self._rank, 0), input)
@@ -510,13 +519,17 @@ class _MuxPG(dist.ProcessGroup):
         return self._do_collective("allgather", _run)
 
     @torch.no_grad()
-    def allgather_into_tensor_coalesced(self, outputs, inputs, opts=AllgatherOptions()):
+    def allgather_into_tensor_coalesced(self, outputs, inputs, opts=None):
+        if opts is None:
+            opts = AllgatherOptions()
         for o, i in zip(outputs, inputs):
             self._allgather_base(o, i, opts)
         return _completed_work()
 
     @torch.no_grad()
-    def _reduce_scatter_base(self, output, input, opts=ReduceScatterOptions()):
+    def _reduce_scatter_base(self, output, input, opts=None):
+        if opts is None:
+            opts = ReduceScatterOptions()
         def _run():
             cid = self._next_coll()
             op = opts.reduceOp if hasattr(opts, "reduceOp") else ReduceOp.SUM
@@ -546,7 +559,9 @@ class _MuxPG(dist.ProcessGroup):
         return self._do_collective("reduce_scatter", _run)
 
     @torch.no_grad()
-    def reduce_scatter(self, output_tensor, scatter_list, opts=ReduceScatterOptions()):
+    def reduce_scatter(self, output_tensor, scatter_list, opts=None):
+        if opts is None:
+            opts = ReduceScatterOptions()
         def _run():
             cid = self._next_coll()
             op = opts.reduceOp if hasattr(opts, "reduceOp") else ReduceOp.SUM
@@ -587,26 +602,30 @@ class _MuxPG(dist.ProcessGroup):
 
     @torch.no_grad()
     def reduce_scatter_tensor_coalesced(
-        self, outputs, inputs, opts=ReduceScatterOptions()
+        self, outputs, inputs, opts=None
     ):
+        if opts is None:
+            opts = ReduceScatterOptions()
         for o, i in zip(outputs, inputs):
             self._reduce_scatter_base(o, i, opts)
         return _completed_work()
 
     @torch.no_grad()
-    def scatter(self, output, input, opts=ScatterOptions()):
+    def scatter(self, output, input, opts=None):
         raise NotImplementedError("_MuxPG.scatter")
 
     @torch.no_grad()
-    def gather(self, output, input, opts=ScatterOptions()):
+    def gather(self, output, input, opts=None):
         raise NotImplementedError("_MuxPG.gather")
 
     @torch.no_grad()
-    def alltoall(self, output, input, opts=AllToAllOptions()):
+    def alltoall(self, output, input, opts=None):
         raise NotImplementedError("_MuxPG.alltoall")
 
     @torch.no_grad()
-    def barrier(self, opts=BarrierOptions()):
+    def barrier(self, opts=None):
+        if opts is None:
+            opts = BarrierOptions()
         def _run():
             cid = self._next_coll()
             self._mark_ready(cid)

--- a/torch/distributed/torchmux.py
+++ b/torch/distributed/torchmux.py
@@ -268,7 +268,7 @@ def _save_tensor(path, tensor):
             f"rank {_rank}: failed to save tensor to {tmp} "
             f"(collective data dir: {_coll_dir}): {e}"
         ) from e
-    os.rename(tmp, path)
+    os.replace(tmp, path)
 
 
 def _load_tensor(path):
@@ -325,7 +325,7 @@ class _MuxPG(dist.ProcessGroup):
     load the collective result.
     """
 
-    # Per-process counter (not globally unique). Each forked worker gets
+    # Per-process counter (not globally unique). Each spawned worker gets
     # its own copy, but that's fine: collective data paths include both
     # pg_id and rank, so there are no cross-process collisions.
     _next_pg_id = 0

--- a/torch/distributed/torchmux_trace.py
+++ b/torch/distributed/torchmux_trace.py
@@ -193,9 +193,23 @@ def _split_into_phases(events_by_rank, nproc):
 def _write(path, trace_events):
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     trace = {"traceEvents": trace_events, "displayTimeUnit": "ms"}
-    # Write to a temp file and rename to avoid following symlinks and to
-    # ensure readers never see a partially-written trace file.
+    # Write to a temp file and rename atomically. Use O_CREAT|O_EXCL
+    # on the tmp file to avoid following symlinks (an attacker placing
+    # a symlink at the tmp path would cause os.open to fail rather
+    # than overwriting the symlink target).
     tmp = path + f".tmp.{os.getpid()}"
-    with open(tmp, "w") as f:
-        json.dump(trace, f)
+    try:
+        os.unlink(tmp)
+    except FileNotFoundError:
+        pass
+    fd = os.open(tmp, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(trace, f)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
     os.replace(tmp, path)

--- a/torch/distributed/torchmux_trace.py
+++ b/torch/distributed/torchmux_trace.py
@@ -1,0 +1,197 @@
+"""
+Tracing for torchmux: produces two chrome://tracing JSON files.
+
+Natural trace: shows actual serial execution with time slices per
+worker. Includes snapshot/restore overhead spans so you can see what
+time is real compute vs mux overhead.
+
+Synthetic trace: reconstructs what a parallel run would look like.
+All workers' compute phases are aligned at the start (overlapped),
+and each collective is placed at max(worker_compute_durations).
+Snapshot/restore spans are omitted (they don't exist in real
+parallel execution).
+"""
+
+import json
+import os
+
+
+def export_natural(events_by_rank, path, nproc):
+    """Export the natural (serial) trace.
+
+    Each worker is a separate process in the chrome trace. Events are
+    placed at their actual wall-clock times.
+
+    Args:
+        events_by_rank: dict[int, list[tuple]] where each tuple is
+            (category, name, start_us, dur_us)
+        path: output file path
+        nproc: number of workers
+    """
+    trace_events = []
+
+    for rank in range(nproc):
+        trace_events.append(
+            {
+                "ph": "M",
+                "name": "process_name",
+                "pid": rank,
+                "tid": 0,
+                "args": {"name": f"Worker {rank}"},
+            }
+        )
+
+    if not events_by_rank:
+        _write(path, trace_events)
+        return
+
+    all_starts = []
+    for events in events_by_rank.values():
+        for _, _, start, _ in events:
+            all_starts.append(start)
+    base_ts = min(all_starts) if all_starts else 0
+
+    for rank, events in events_by_rank.items():
+        for cat, name, start_us, dur_us in events:
+            trace_events.append(
+                {
+                    "ph": "X",
+                    "cat": cat,
+                    "name": name,
+                    "pid": rank,
+                    "tid": 0,
+                    "ts": int(start_us - base_ts),
+                    "dur": int(dur_us),
+                }
+            )
+
+    _write(path, trace_events)
+
+
+def export_synthetic(events_by_rank, path, nproc):
+    """Export the synthetic (parallel) trace.
+
+    Reconstructs what a parallel run would look like by overlapping
+    workers' compute phases between collectives.
+
+    Algorithm:
+      1. Split each worker's events into phases (by collective boundaries).
+      2. In each phase, all workers' compute spans start at the same time.
+      3. The collective is placed at max(worker_compute_durations).
+      4. Snapshot/restore spans are omitted.
+    """
+    trace_events = []
+    for rank in range(nproc):
+        trace_events.append(
+            {
+                "ph": "M",
+                "name": "process_name",
+                "pid": rank,
+                "tid": 0,
+                "args": {"name": f"Worker {rank}"},
+            }
+        )
+
+    if not events_by_rank:
+        _write(path, trace_events)
+        return
+
+    phases = _split_into_phases(events_by_rank, nproc)
+
+    cursor = 0.0
+    for phase in phases:
+        max_compute = 0.0
+        coll_name = None
+        coll_dur = 0.0
+
+        for rank in range(nproc):
+            worker_events = phase.get(rank, [])
+            compute_dur = sum(d for c, _, _, d in worker_events if c == "compute")
+            max_compute = max(max_compute, compute_dur)
+            for c, n, _, d in worker_events:
+                if c == "collective":
+                    coll_name = n
+                    coll_dur = max(coll_dur, d)
+
+        per_rank_compute_end = {}
+        for rank in range(nproc):
+            worker_events = phase.get(rank, [])
+            t = cursor
+            for cat, name, _, dur_us in worker_events:
+                if cat != "compute":
+                    continue
+                trace_events.append(
+                    {
+                        "ph": "X",
+                        "cat": "compute",
+                        "name": name,
+                        "pid": rank,
+                        "tid": 0,
+                        "ts": int(t),
+                        "dur": int(dur_us),
+                    }
+                )
+                t += dur_us
+            per_rank_compute_end[rank] = t
+
+        if coll_name:
+            coll_end = cursor + max_compute + coll_dur
+            for rank in range(nproc):
+                coll_start = per_rank_compute_end.get(rank, cursor)
+                trace_events.append(
+                    {
+                        "ph": "X",
+                        "cat": "collective",
+                        "name": coll_name,
+                        "pid": rank,
+                        "tid": 0,
+                        "ts": int(coll_start),
+                        "dur": int(coll_end - coll_start),
+                    }
+                )
+            cursor = coll_end
+        else:
+            cursor += max_compute
+
+    _write(path, trace_events)
+
+
+def _split_into_phases(events_by_rank, nproc):
+    """Split events into phases separated by collectives.
+
+    A phase is a dict[rank, list[events]] containing the compute
+    events and the ending collective for each worker between two
+    consecutive collective boundaries.
+    """
+    per_rank_phases = {}
+    for rank in range(nproc):
+        events = events_by_rank.get(rank, [])
+        phases = []
+        current = []
+        for ev in events:
+            cat = ev[0]
+            current.append(ev)
+            if cat == "collective":
+                phases.append(current)
+                current = []
+        if current:
+            phases.append(current)
+        per_rank_phases[rank] = phases
+
+    max_phases = max((len(p) for p in per_rank_phases.values()), default=0)
+
+    result = []
+    for i in range(max_phases):
+        phase = {}
+        for rank in range(nproc):
+            if i < len(per_rank_phases[rank]):
+                phase[rank] = per_rank_phases[rank][i]
+        result.append(phase)
+    return result
+
+
+def _write(path, trace_events):
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    trace = {"traceEvents": trace_events, "displayTimeUnit": "ms"}
+    with open(path, "w") as f:
+        json.dump(trace, f)

--- a/torch/distributed/torchmux_trace.py
+++ b/torch/distributed/torchmux_trace.py
@@ -193,5 +193,9 @@ def _split_into_phases(events_by_rank, nproc):
 def _write(path, trace_events):
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     trace = {"traceEvents": trace_events, "displayTimeUnit": "ms"}
-    with open(path, "w") as f:
+    # Write to a temp file and rename to avoid following symlinks and to
+    # ensure readers never see a partially-written trace file.
+    tmp = path + f".tmp.{os.getpid()}"
+    with open(tmp, "w") as f:
         json.dump(trace, f)
+    os.replace(tmp, path)

--- a/torch/distributed/vnccl.py
+++ b/torch/distributed/vnccl.py
@@ -104,6 +104,7 @@ from torch._C._distributed_c10d import (
     AllToAllOptions,
     BarrierOptions,
     BroadcastOptions,
+    GatherOptions,
     ReduceOp,
     ReduceScatterOptions,
     ScatterOptions,
@@ -190,10 +191,12 @@ class _Broadcast:
 class _AllGather:
     @torch.no_grad()
     def work(self, data):
-        for src_rank in range(len(data)):
-            src_tensor = data[src_rank][1][0]
-            for dest in data:
-                dest[0][0][src_rank].detach().copy_(src_tensor)
+        num_tensors = len(data[0][1])
+        for i in range(num_tensors):
+            for src_rank in range(len(data)):
+                src_tensor = data[src_rank][1][i]
+                for dest in data:
+                    dest[0][i][src_rank].detach().copy_(src_tensor)
 
 
 class _ReduceScatter:
@@ -441,7 +444,7 @@ class VNCCLProcessGroup(dist.ProcessGroup):
 
     def gather(self, output_tensors, input_tensors, opts=None):
         if opts is None:
-            opts = ScatterOptions()
+            opts = GatherOptions()
         return self._do(_Gather(opts.rootRank), (output_tensors, input_tensors))
 
     def reduce_scatter(self, output_tensor, scatter_list, opts=None):

--- a/torch/distributed/vnccl.py
+++ b/torch/distributed/vnccl.py
@@ -355,15 +355,27 @@ class VNCCLProcessGroup(dist.ProcessGroup):
         if held:
             _rng_states[self._rank] = _save_rng()
             _release_exec_lock_ordered(self._rank, self._world_size)
+        coll_failed = False
         try:
             sync = VNCCLProcessGroup._enter(op, self, seq)
             try:
                 result = sync.join(self._rank, data)
             finally:
                 VNCCLProcessGroup._leave(sync, self, seq)
+        except Exception:
+            coll_failed = True
+            raise
         finally:
             if held:
-                _acquire_exec_lock_ordered(self._rank, self._world_size)
+                if coll_failed:
+                    # After a resolver error, _next_rank was reset to 0.
+                    # Using ordered acquisition would deadlock ranks != 0.
+                    # Fall back to unordered acquisition so all ranks can
+                    # propagate the error without hanging.
+                    _exec_lock.acquire()
+                    _exec_lock_holder.held = True
+                else:
+                    _acquire_exec_lock_ordered(self._rank, self._world_size)
                 if self._rank in _rng_states:
                     _restore_rng(_rng_states[self._rank])
         return result
@@ -395,51 +407,67 @@ class VNCCLProcessGroup(dist.ProcessGroup):
 
     # -- collectives --
 
-    def allreduce(self, tensor_list, opts=AllreduceOptions()):
+    def allreduce(self, tensor_list, opts=None):
+        if opts is None:
+            opts = AllreduceOptions()
         return self._do(_AllReduce(opts.reduceOp), tensor_list)
 
-    def allreduce_coalesced(self, tensor_list, opts=AllreduceOptions()):
+    def allreduce_coalesced(self, tensor_list, opts=None):
+        if opts is None:
+            opts = AllreduceOptions()
         return self._do(_AllReduce(opts.reduceOp), tensor_list)
 
-    def broadcast(self, tensor_list, opts=BroadcastOptions()):
+    def broadcast(self, tensor_list, opts=None):
+        if opts is None:
+            opts = BroadcastOptions()
         return self._do(_Broadcast(opts.rootRank), tensor_list)
 
-    def allgather(self, output_tensors, input_tensor, opts=AllgatherOptions()):
+    def allgather(self, output_tensors, input_tensor, opts=None):
         return self._do(_AllGather(), (output_tensors, input_tensor))
 
-    def _allgather_base(self, output, input, opts=AllgatherOptions()):
+    def _allgather_base(self, output, input, opts=None):
         chunks = list(torch.chunk(output, self._world_size))
         return self.allgather([chunks], [input], opts)
 
-    def allgather_into_tensor_coalesced(self, outputs, inputs, opts=AllgatherOptions()):
+    def allgather_into_tensor_coalesced(self, outputs, inputs, opts=None):
         for o, i in zip(outputs, inputs):
             self._allgather_base(o, i)
         return _completed_work(None)
 
-    def scatter(self, output_tensors, input_tensors, opts=ScatterOptions()):
+    def scatter(self, output_tensors, input_tensors, opts=None):
+        if opts is None:
+            opts = ScatterOptions()
         return self._do(_Scatter(opts.rootRank), (output_tensors, input_tensors))
 
-    def gather(self, output_tensors, input_tensors, opts=ScatterOptions()):
+    def gather(self, output_tensors, input_tensors, opts=None):
+        if opts is None:
+            opts = ScatterOptions()
         return self._do(_Gather(opts.rootRank), (output_tensors, input_tensors))
 
-    def reduce_scatter(self, output_tensor, scatter_list, opts=ReduceScatterOptions()):
+    def reduce_scatter(self, output_tensor, scatter_list, opts=None):
+        if opts is None:
+            opts = ReduceScatterOptions()
         return self._do(_ReduceScatter(opts.reduceOp), (output_tensor, scatter_list))
 
-    def _reduce_scatter_base(self, output, input, opts=ReduceScatterOptions()):
+    def _reduce_scatter_base(self, output, input, opts=None):
+        if opts is None:
+            opts = ReduceScatterOptions()
         chunks = list(torch.chunk(input, self._world_size))
         return self.reduce_scatter([output], [chunks], opts)
 
     def reduce_scatter_tensor_coalesced(
-        self, outputs, inputs, opts=ReduceScatterOptions()
+        self, outputs, inputs, opts=None
     ):
+        if opts is None:
+            opts = ReduceScatterOptions()
         for o, i in zip(outputs, inputs):
             self._reduce_scatter_base(o, i, opts)
         return _completed_work(None)
 
-    def alltoall(self, output_list, input_list, opts=AllToAllOptions()):
+    def alltoall(self, output_list, input_list, opts=None):
         return self._do(_AllToAll(), (output_list, input_list))
 
-    def barrier(self, opts=BarrierOptions()):
+    def barrier(self, opts=None):
         return self.allreduce(tensor_list=[torch.ones(1)])
 
 

--- a/torch/distributed/vnccl.py
+++ b/torch/distributed/vnccl.py
@@ -1,0 +1,461 @@
+"""
+vnccl: Virtual NCCL — a distributed backend that resolves collectives
+locally using thread synchronization.
+
+Designed for torchmux, where N distributed workers run as threads in a
+single process sharing 1 GPU. Each collective blocks the calling thread
+until all ranks have arrived, resolves the operation (allreduce = sum,
+broadcast = copy from root, etc.), and unblocks all threads.
+
+No GPUs are communicated between — all data movement is in-process
+via tensor copy. The numerics are bitwise identical to real NCCL.
+
+Usage:
+    import torch.distributed.vnccl  # registers "vnccl" backend
+    dist.init_process_group(backend="vnccl", rank=rank, world_size=N, store=store)
+
+Typically used via torchmux rather than directly.
+
+Note: this is distinct from multi_threaded_pg.ProcessLocalGroup in
+torch/testing/_internal/ which serves a similar purpose for testing.
+vnccl adds cooperative scheduling (_exec_lock), deterministic rank
+ordering for trace reproducibility, per-worker RNG isolation, and
+pairwise reduction to match NCCL's bitwise reduction order.
+"""
+
+import random as _random
+import threading
+import weakref
+from functools import partial
+
+import torch
+
+__all__ = ["VNCCLProcessGroup"]
+
+# Cooperative scheduling lock. When held, only one worker thread runs.
+# Workers release it inside _do() before blocking on a collective
+# barrier, allowing the next worker to run.
+_exec_lock = threading.Lock()
+_exec_lock_holder = threading.local()
+
+# Deterministic rank ordering. After a collective resolves, rank 0
+# runs first, then 1, 2, ..., producing a clean staircase in traces.
+# NB: this is module-global, so it is only safe when a single process
+# group is active at a time (the torchmux use case). Multiple concurrent
+# groups would need per-group ordering state.
+_next_rank = 0
+_next_rank_cond = threading.Condition()
+
+
+def _acquire_exec_lock_ordered(rank, world_size):
+    with _next_rank_cond:
+        _next_rank_cond.wait_for(lambda: _next_rank == rank)
+    _exec_lock.acquire()
+    _exec_lock_holder.held = True
+
+
+def _release_exec_lock_ordered(rank, world_size):
+    global _next_rank
+    _exec_lock_holder.held = False
+    with _next_rank_cond:
+        _next_rank = (rank + 1) % world_size
+        _next_rank_cond.notify_all()
+    _exec_lock.release()
+
+
+# Per-worker RNG state. Saved before yielding, restored after resuming.
+# This gives each worker isolated RNG so manual_seed() in one worker
+# doesn't corrupt another's random sequence.
+_rng_states = {}
+
+
+def _save_rng():
+    state = {
+        "cpu": torch.get_rng_state(),
+        "random": _random.getstate(),
+    }
+    if torch.cuda.is_available():
+        state["cuda"] = torch.cuda.get_rng_state_all()
+    try:
+        import numpy as np
+
+        state["numpy"] = np.random.get_state()
+    except ImportError:
+        pass
+    return state
+
+
+def _restore_rng(state):
+    torch.set_rng_state(state["cpu"])
+    _random.setstate(state["random"])
+    if "cuda" in state:
+        torch.cuda.set_rng_state_all(state["cuda"])
+    if "numpy" in state:
+        import numpy as np
+
+        np.random.set_state(state["numpy"])
+
+
+import torch.distributed as dist
+from torch._C._distributed_c10d import (
+    _create_work_from_future,
+    AllgatherOptions,
+    AllreduceOptions,
+    AllToAllOptions,
+    BarrierOptions,
+    BroadcastOptions,
+    ReduceOp,
+    ReduceScatterOptions,
+    ScatterOptions,
+)
+from torch.distributed.distributed_c10d import _store_based_barrier
+from torch.futures import Future
+from torch.utils import _pytree as pytree
+
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+
+def _completed_work(result):
+    fut = Future()
+    fut.set_result(result)
+    return _create_work_from_future(fut)
+
+
+def _pairwise_reduce(tensors, op):
+    """
+    Reduce using pairwise in-place operations to match NCCL's reduction
+    order. NCCL accumulates into tensor 0 by adding tensor 1, then
+    tensor 2, etc. Using torch.stack + torch.sum would change the FP
+    reduction order and break bitwise equivalence.
+    """
+    result = tensors[0].clone()
+    for t in tensors[1:]:
+        op(result, t)
+    return result
+
+
+_REDUCE_OPS = {
+    ReduceOp.SUM: partial(_pairwise_reduce, op=lambda a, b: a.add_(b)),
+    ReduceOp.AVG: partial(_pairwise_reduce, op=lambda a, b: a.add_(b)),
+    ReduceOp.PRODUCT: partial(_pairwise_reduce, op=lambda a, b: a.mul_(b)),
+    ReduceOp.MIN: partial(_pairwise_reduce, op=lambda a, b: torch.minimum(a, b, out=a)),
+    ReduceOp.MAX: partial(_pairwise_reduce, op=lambda a, b: torch.maximum(a, b, out=a)),
+    ReduceOp.BAND: partial(_pairwise_reduce, op=lambda a, b: a.bitwise_and_(b)),
+    ReduceOp.BOR: partial(_pairwise_reduce, op=lambda a, b: a.bitwise_or_(b)),
+    ReduceOp.BXOR: partial(_pairwise_reduce, op=lambda a, b: a.bitwise_xor_(b)),
+}
+
+
+# ------------------------------------------------------------------ #
+# Collective resolution — each class has a work() method that takes
+# the data contributed by all ranks and resolves the collective
+# in-place.
+# ------------------------------------------------------------------ #
+
+
+class _AllReduce:
+    def __init__(self, op):
+        self.op = op.op
+
+    @torch.no_grad()
+    def work(self, data):
+        for i in range(len(data[0])):
+            dev = data[0][i].device
+            tensors = [data[r][i].to(dev) for r in range(len(data))]
+            res = _REDUCE_OPS[self.op](tensors)
+            if self.op == ReduceOp.AVG:
+                res.div_(len(data))
+            for r in range(len(data)):
+                data[r][i].detach().copy_(res.to(data[r][i].device))
+
+
+class _Broadcast:
+    def __init__(self, src):
+        self.src = src
+
+    @torch.no_grad()
+    def work(self, data):
+        src_tensors = pytree.tree_leaves(data[self.src])
+        for i in range(len(data)):
+            if i == self.src:
+                continue
+            dst_tensors = pytree.tree_leaves(data[i])
+            for s, d in zip(src_tensors, dst_tensors):
+                d.detach().copy_(s)
+
+
+class _AllGather:
+    @torch.no_grad()
+    def work(self, data):
+        for src_rank in range(len(data)):
+            src_tensor = data[src_rank][1][0]
+            for dest in data:
+                dest[0][0][src_rank].detach().copy_(src_tensor)
+
+
+class _ReduceScatter:
+    def __init__(self, op):
+        self.op = op if isinstance(op, int) else op.op
+
+    @torch.no_grad()
+    def work(self, data):
+        ws = len(data)
+        reduce_fn = _REDUCE_OPS[self.op]
+        for i in range(ws):
+            dst = data[i][0][0]
+            chunks = [data[src][1][0][i].to(dst.device) for src in range(ws)]
+            result = reduce_fn(chunks)
+            if self.op == ReduceOp.AVG:
+                result.div_(ws)
+            dst.detach().copy_(result)
+
+
+class _Scatter:
+    def __init__(self, src):
+        self.src = src
+
+    @torch.no_grad()
+    def work(self, data):
+        src_tensors = data[self.src][1][0]
+        for rank, each in enumerate(data):
+            each[0][0].detach().copy_(src_tensors[rank])
+
+
+class _Gather:
+    def __init__(self, dst):
+        self.dst = dst
+
+    @torch.no_grad()
+    def work(self, data):
+        out_list = data[self.dst][0][0]
+        for rank, each in enumerate(data):
+            out_list[rank].detach().copy_(each[1][0])
+
+
+class _AllToAll:
+    @torch.no_grad()
+    def work(self, data):
+        ws = len(data)
+        for dst in range(ws):
+            out_list, _ = data[dst]
+            for src in range(ws):
+                _, in_list = data[src]
+                out_list[src].detach().copy_(in_list[dst])
+
+
+# ------------------------------------------------------------------ #
+# Collective synchronization — blocks until all ranks have contributed
+# their data, then the last rank to arrive resolves the operation and
+# wakes everyone up.
+# ------------------------------------------------------------------ #
+
+
+_COLL_TIMEOUT_S = 300
+
+
+class _CollSync:
+    def __init__(self, world_size, op):
+        self._world_size = world_size
+        self._op = op
+        self._cond = threading.Condition()
+        self._data = [None] * world_size
+        self._count = 0
+        self._done = False
+        self._error = None
+
+    def join(self, rank, data):
+        # Lock ordering: self._cond is always acquired before
+        # _next_rank_cond. No code path acquires them in reverse.
+        with self._cond:
+            self._data[rank] = data
+            self._count += 1
+            if self._count < self._world_size:
+                if not self._cond.wait_for(
+                    lambda: self._done or self._error is not None,
+                    timeout=_COLL_TIMEOUT_S,
+                ):
+                    raise RuntimeError(
+                        f"rank {rank}: collective timed out after "
+                        f"{_COLL_TIMEOUT_S}s waiting for all ranks "
+                        f"({self._count}/{self._world_size} arrived)"
+                    )
+                if self._error is not None:
+                    raise RuntimeError(
+                        f"rank {rank}: collective failed on resolver"
+                    ) from self._error
+            else:
+                try:
+                    self._op.work(self._data)
+                except Exception as e:
+                    self._error = e
+                    global _next_rank
+                    with _next_rank_cond:
+                        _next_rank = 0
+                        _next_rank_cond.notify_all()
+                    self._cond.notify_all()
+                    raise
+                self._done = True
+                with _next_rank_cond:
+                    _next_rank = 0
+                    _next_rank_cond.notify_all()
+                self._cond.notify_all()
+        return _completed_work(data)
+
+
+# ------------------------------------------------------------------ #
+# VNCCLProcessGroup
+# ------------------------------------------------------------------ #
+
+
+class VNCCLProcessGroup(dist.ProcessGroup):
+    """
+    Process group that resolves collectives locally via thread sync.
+    Multiple VNCCLProcessGroup instances (one per rank) coordinate
+    through class-level shared state keyed by group name.
+    """
+
+    _lock = threading.Lock()
+    _active = {}
+
+    @classmethod
+    def _enter(cls, op, pg, seq):
+        with cls._lock:
+            key = (pg.pg_name, seq)
+            if key not in cls._active:
+                cls._active[key] = _CollSync(pg.size(), op)
+            return cls._active[key]
+
+    @classmethod
+    def _leave(cls, sync, pg, seq):
+        with cls._lock:
+            key = (pg.pg_name, seq)
+            if cls._active.get(key) is sync:
+                del cls._active[key]
+
+    def __init__(self, rank, world_size):
+        super().__init__(rank, world_size)
+        self._rank = rank
+        self._world_size = world_size
+        self._coll_seq = 0
+
+        world = dist.distributed_c10d._world
+        # ThreadLocalWorld wraps _World for thread-based PGs; unwrap to
+        # get the real _World so the weakref outlives each thread.
+        if hasattr(world, "_get_world"):
+            world = world._get_world()
+        self._world = weakref.ref(world)
+
+    def _do(self, op, data):
+        seq = self._coll_seq
+        self._coll_seq += 1
+        held = getattr(_exec_lock_holder, "held", False)
+        if held:
+            _rng_states[self._rank] = _save_rng()
+            _release_exec_lock_ordered(self._rank, self._world_size)
+        try:
+            sync = VNCCLProcessGroup._enter(op, self, seq)
+            try:
+                result = sync.join(self._rank, data)
+            finally:
+                VNCCLProcessGroup._leave(sync, self, seq)
+        finally:
+            if held:
+                _acquire_exec_lock_ordered(self._rank, self._world_size)
+                if self._rank in _rng_states:
+                    _restore_rng(_rng_states[self._rank])
+        return result
+
+    # -- metadata --
+
+    def size(self):
+        return self._world_size
+
+    @property
+    def pg_name(self):
+        world = self._world()
+        if world is None:
+            raise RuntimeError(
+                "vnccl: distributed world has been destroyed; "
+                "cannot use process group after teardown"
+            )
+        return world.pg_names[self]
+
+    @property
+    def group_name(self):
+        return self.pg_name
+
+    def getBackendName(self):
+        return "vnccl"
+
+    def __repr__(self):
+        return f"VNCCL(rank={self._rank}, world_size={self._world_size})"
+
+    # -- collectives --
+
+    def allreduce(self, tensor_list, opts=AllreduceOptions()):
+        return self._do(_AllReduce(opts.reduceOp), tensor_list)
+
+    def allreduce_coalesced(self, tensor_list, opts=AllreduceOptions()):
+        return self._do(_AllReduce(opts.reduceOp), tensor_list)
+
+    def broadcast(self, tensor_list, opts=BroadcastOptions()):
+        return self._do(_Broadcast(opts.rootRank), tensor_list)
+
+    def allgather(self, output_tensors, input_tensor, opts=AllgatherOptions()):
+        return self._do(_AllGather(), (output_tensors, input_tensor))
+
+    def _allgather_base(self, output, input, opts=AllgatherOptions()):
+        chunks = list(torch.chunk(output, self._world_size))
+        return self.allgather([chunks], [input], opts)
+
+    def allgather_into_tensor_coalesced(self, outputs, inputs, opts=AllgatherOptions()):
+        # Each tensor pair is a separate collective barrier rather than a
+        # single batched operation. Correct but not performance-equivalent
+        # to real NCCL's coalesced implementation.
+        res = None
+        for o, i in zip(outputs, inputs):
+            res = self._allgather_base(o, i)
+        return res
+
+    def scatter(self, output_tensors, input_tensors, opts=ScatterOptions()):
+        return self._do(_Scatter(opts.rootRank), (output_tensors, input_tensors))
+
+    def gather(self, output_tensors, input_tensors, opts=ScatterOptions()):
+        return self._do(_Gather(opts.rootRank), (output_tensors, input_tensors))
+
+    def reduce_scatter(self, output_tensor, scatter_list, opts=ReduceScatterOptions()):
+        return self._do(_ReduceScatter(opts.reduceOp), (output_tensor, scatter_list))
+
+    def _reduce_scatter_base(self, output, input, opts=ReduceScatterOptions()):
+        chunks = list(torch.chunk(input, self._world_size))
+        return self.reduce_scatter([output], [chunks], opts)
+
+    def reduce_scatter_tensor_coalesced(
+        self, outputs, inputs, opts=ReduceScatterOptions()
+    ):
+        # Each tensor pair is a separate collective barrier rather than a
+        # single batched operation. Correct but not performance-equivalent
+        # to real NCCL's coalesced implementation.
+        res = None
+        for o, i in zip(outputs, inputs):
+            res = self._reduce_scatter_base(o, i, opts)
+        return res
+
+    def alltoall(self, output_list, input_list, opts=AllToAllOptions()):
+        return self._do(_AllToAll(), (output_list, input_list))
+
+    def barrier(self, opts=BarrierOptions()):
+        return self.allreduce(tensor_list=[torch.ones(1)])
+
+
+def _create_vnccl(prefix_store, rank, world_size, timeout):
+    pg = VNCCLProcessGroup(rank, world_size)
+    _store_based_barrier(rank, prefix_store, "", world_size, timeout)
+    return pg
+
+
+if "vnccl" not in dist.Backend.backend_list:
+    dist.Backend.register_backend("vnccl", _create_vnccl, devices=["cpu", "cuda"])

--- a/torch/distributed/vnccl.py
+++ b/torch/distributed/vnccl.py
@@ -30,7 +30,7 @@ from functools import partial
 
 import torch
 
-__all__ = ["VNCCLProcessGroup"]
+__all__: list[str] = []
 
 # Cooperative scheduling lock. When held, only one worker thread runs.
 # Workers release it inside _do() before blocking on a collective

--- a/torch/distributed/vnccl.py
+++ b/torch/distributed/vnccl.py
@@ -158,7 +158,7 @@ _REDUCE_OPS = {
 
 class _AllReduce:
     def __init__(self, op):
-        self.op = op.op
+        self.op = op if isinstance(op, int) else op.op
 
     @torch.no_grad()
     def work(self, data):
@@ -412,13 +412,9 @@ class VNCCLProcessGroup(dist.ProcessGroup):
         return self.allgather([chunks], [input], opts)
 
     def allgather_into_tensor_coalesced(self, outputs, inputs, opts=AllgatherOptions()):
-        # Each tensor pair is a separate collective barrier rather than a
-        # single batched operation. Correct but not performance-equivalent
-        # to real NCCL's coalesced implementation.
-        res = None
         for o, i in zip(outputs, inputs):
-            res = self._allgather_base(o, i)
-        return res
+            self._allgather_base(o, i)
+        return _completed_work(None)
 
     def scatter(self, output_tensors, input_tensors, opts=ScatterOptions()):
         return self._do(_Scatter(opts.rootRank), (output_tensors, input_tensors))
@@ -436,19 +432,25 @@ class VNCCLProcessGroup(dist.ProcessGroup):
     def reduce_scatter_tensor_coalesced(
         self, outputs, inputs, opts=ReduceScatterOptions()
     ):
-        # Each tensor pair is a separate collective barrier rather than a
-        # single batched operation. Correct but not performance-equivalent
-        # to real NCCL's coalesced implementation.
-        res = None
         for o, i in zip(outputs, inputs):
-            res = self._reduce_scatter_base(o, i, opts)
-        return res
+            self._reduce_scatter_base(o, i, opts)
+        return _completed_work(None)
 
     def alltoall(self, output_list, input_list, opts=AllToAllOptions()):
         return self._do(_AllToAll(), (output_list, input_list))
 
     def barrier(self, opts=BarrierOptions()):
         return self.allreduce(tensor_list=[torch.ones(1)])
+
+
+def _reset():
+    """Reset module-global state for clean re-initialization."""
+    global _next_rank
+    with _next_rank_cond:
+        _next_rank = 0
+        _next_rank_cond.notify_all()
+    _rng_states.clear()
+    VNCCLProcessGroup._active.clear()
 
 
 def _create_vnccl(prefix_store, rank, world_size, timeout):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #181603
* #181602
* #181601
* __->__ #181389

torchmux takes a standard torchrun-compatible training script and runs
N distributed workers as processes on M physical GPUs where M <= N
(default M=1).

Usage:
    python -m torch.distributed.torchmux --nproc 8 train.py
    python -m torch.distributed.torchmux --nproc 8 --ngpus 2 train.py
    python -m torch.distributed.torchmux --nproc 8 -m module.name

Workers are separate processes (no GIL issues) with cooperative
scheduling: only one runs per GPU at a time, yielding at collective
boundaries. At each yield the worker checkpoints its entire CUDA
context via cuCheckpointProcessCheckpoint (VRAM returned to the
driver) and restores it at the same virtual addresses when
rescheduled via cuCheckpointProcessRestore. This lets N >> M workers
time-share M GPUs.

Collectives are resolved by bookkeeping each rank's tensor
contribution on disk — no NCCL is needed. The file-based backend
implements allreduce, broadcast, allgather, reduce_scatter, and
barrier (the set FSDP2 needs).

Produces two chrome://tracing traces (set TORCHMUX_TRACE_DIR):
- Natural trace: actual serial execution with snapshot/restore
  overhead spans visible
- Synthetic trace: reconstructed parallel execution (compute phases
  overlapped, collectives placed at max worker duration)

Also includes:
- checkpoint/baton.py: ctypes wrapper for cuCheckpointProcess{Lock,
  Checkpoint,Restore,Unlock}
- vnccl.py: virtual NCCL backend for thread-based simulation
  (standalone utility, not used by torchmux)

Authored with Claude.