### PR TITLE
[AC] Add example_inputs param to remat pass and mark recomputed nodes as backward

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -2635,10 +2635,10 @@ def forward(self, arg0_1):
     expand = torch.ops.aten.expand.default(ones_like, [4, 4]);  ones_like = None
     sigmoid_recomputed = torch.ops.aten.sigmoid.default(arg0_1);  arg0_1 = None
     detach_3_recomputed = torch.ops.aten.detach.default(sigmoid_recomputed);  sigmoid_recomputed = None
-    detach_5 = torch.ops.aten.detach.default(detach_3_recomputed);  detach_3_recomputed = None
-    sigmoid_backward = torch.ops.aten.sigmoid_backward.default(expand, detach_5);  expand = detach_5 = None
-    detach_6 = torch.ops.aten.detach.default(sigmoid_backward);  sigmoid_backward = None
-    return (detach_6,)""",
+    detach_4 = torch.ops.aten.detach.default(detach_3_recomputed);  detach_3_recomputed = None
+    sigmoid_backward = torch.ops.aten.sigmoid_backward.default(expand, detach_4);  expand = detach_4 = None
+    detach_5 = torch.ops.aten.detach.default(sigmoid_backward);  sigmoid_backward = None
+    return (detach_5,)""",
         )
 
     def test_joint_graph_passes_permute_optimization(self):
@@ -2683,10 +2683,10 @@ def forward(self, arg0_1):
     expand = torch.ops.aten.expand.default(ones_like, [4, 4]);  ones_like = None
     sigmoid_recomputed = torch.ops.aten.sigmoid.default(arg0_1);  arg0_1 = None
     detach_3_recomputed = torch.ops.aten.detach.default(sigmoid_recomputed);  sigmoid_recomputed = None
-    detach_5 = torch.ops.aten.detach.default(detach_3_recomputed);  detach_3_recomputed = None
-    sigmoid_backward = torch.ops.aten.sigmoid_backward.default(expand, detach_5);  expand = detach_5 = None
-    detach_6 = torch.ops.aten.detach.default(sigmoid_backward);  sigmoid_backward = None
-    return (detach_6,)""",
+    detach_4 = torch.ops.aten.detach.default(detach_3_recomputed);  detach_3_recomputed = None
+    sigmoid_backward = torch.ops.aten.sigmoid_backward.default(expand, detach_4);  expand = detach_4 = None
+    detach_5 = torch.ops.aten.detach.default(sigmoid_backward);  sigmoid_backward = None
+    return (detach_5,)""",
         )
 
     @torch._dynamo.config.patch(skip_fwd_side_effects_in_bwd_under_checkpoint=True)
@@ -2912,6 +2912,29 @@ def forward(self, arg0_1, arg1_1, arg2_1):
             "require recomputation",
         ):
             self._compile_and_capture(TwoBackwards(), True, (x,))
+
+    def test_recomputed_nodes_have_autograd_backward_meta(self):
+        x = torch.randn(4, 4, requires_grad=True)
+
+        def simple_fwd_bwd(x):
+            z = torch.utils.checkpoint.checkpoint(
+                lambda a: torch.sigmoid(torch.matmul(a, a)),
+                x,
+                use_reentrant=False,
+            )
+            loss = z.sum()
+            dx = _grad(loss, (x,))
+            return dx[0].detach()
+
+        _, gm = self._compile_and_capture(simple_fwd_bwd, True, (x,))
+
+        recomputed = [n for n in gm.graph.nodes if "_recomputed" in n.name]
+        self.assertTrue(len(recomputed) > 0, "Expected recomputed nodes")
+        for node in recomputed:
+            self.assertTrue(
+                node.meta.get("autograd_backward", False),
+                f"Recomputed node {node.name} should have autograd_backward=True",
+            )
 
 
 devices = ["cuda", "hpu"]

--- a/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
+++ b/torch/_functorch/_activation_checkpointing/remat_using_tags_for_fwd_loss_bwd_graph_pass.py
@@ -1,8 +1,6 @@
 """AC rematerialize pass: Duplicates recompute nodes for backward, then DCE removes unused forward versions."""
 
-import itertools
 import logging
-from typing import Any, overload
 
 import torch
 import torch.fx as fx
@@ -88,7 +86,9 @@ def _collect_backward_regions(
     return regions
 
 
-def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModule:
+def remat_using_tags_for_fwd_loss_bwd_graph(
+    gm: fx.GraphModule, example_inputs: tuple | None = None
+) -> fx.GraphModule:
     """
     Duplicate recompute nodes for backward use. DCE removes unused forward versions.
 
@@ -145,25 +145,12 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
 
     bwd_start, bwd_end = remat_regions[0]
 
-    order = {node: idx for idx, node in enumerate(gm.graph.nodes)}
-    new_graph = fx.Graph()
-    env: dict[fx.Node, fx.Node] = {}
+    nodes_list = list(gm.graph.nodes)
+    order = {node: idx for idx, node in enumerate(nodes_list)}
     recomputed_nodes: dict[fx.Node, fx.Node] = {}
 
-    # Insert forward nodes
-    for node in itertools.islice(gm.graph.nodes, 0, bwd_start):
-        env[node] = new_graph.node_copy(node, lambda x: env[x])
-
-    @overload
-    def remat_input(x: fx.Node) -> fx.Node: ...
-    @overload
-    def remat_input(x: Any) -> Any: ...
-
-    def remat_input(x: object) -> object:
-        # fx.Node can have args that are primitive types (e.g. int, float, bool)
-        if not isinstance(x, fx.Node):
-            return x
-        return recomputed_nodes.get(x, env[x])
+    def remat_input(x: fx.Node) -> fx.Node:
+        return recomputed_nodes.get(x, x)
 
     def gather_recompute_deps(node: fx.Node) -> set[fx.Node]:
         deps: set[fx.Node] = set()
@@ -181,14 +168,9 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
             _gather(inp)
         return deps
 
-    # Insert backward nodes
-    for node in itertools.islice(gm.graph.nodes, bwd_start, bwd_end):
-        # Gather all deps that need to be recomputed for this node
+    for node in nodes_list[bwd_start:bwd_end]:
         deps = gather_recompute_deps(node)
 
-        # Insert deps in forward order (guaranteed disjoint from already-inserted)
-        # This is not as inefficient as it looks, because we only add fresh dependencies
-        # when they are not yet processed as recomputed nodes.
         new_deps = sorted(deps, key=lambda n: order[n])
         if new_deps:
             log.debug(
@@ -197,24 +179,23 @@ def remat_using_tags_for_fwd_loss_bwd_graph(gm: fx.GraphModule) -> fx.GraphModul
                 ", ".join(dep.name for dep in new_deps),
             )
         for dep in new_deps:
-            dup = new_graph.node_copy(dep, remat_input)
-            dup.name = dep.name + "_recomputed"
-            recomputed_nodes[dep] = dup
+            with gm.graph.inserting_before(node):
+                dup = gm.graph.node_copy(dep, remat_input)
+                dup.name = dep.name + "_recomputed"
+                dup.meta["autograd_backward"] = True
+                recomputed_nodes[dep] = dup
 
-        env[node] = new_graph.node_copy(node, remat_input)
-
-    for node in itertools.islice(gm.graph.nodes, bwd_end, None):
-        env[node] = new_graph.node_copy(node, lambda x: env[x])
-
-    new_gm = torch.fx.GraphModule(gm, new_graph)
+        for inp in list(node.all_input_nodes):
+            if inp in recomputed_nodes:
+                node.replace_input_with(inp, recomputed_nodes[inp])
 
     # DCE with custom is_impure_node (like default_partition)
     # Treats certain collectives as pure while delegating to default impurity logic
-    new_gm.graph.eliminate_dead_code(is_impure_node=is_impure_node_for_dce)
+    gm.graph.eliminate_dead_code(is_impure_node=is_impure_node_for_dce)
 
     # raise_getitems pass for better memory (like default_partition)
-    new_gm = raise_getitems(new_gm)
+    gm = raise_getitems(gm)
 
-    new_gm.recompile()
+    gm.recompile()
 
-    return new_gm
+    return gm

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -261,7 +261,9 @@ def aot_stage1_graph_capture(
                     remat_using_tags_for_fwd_loss_bwd_graph,
                 )
 
-                graph = remat_using_tags_for_fwd_loss_bwd_graph(graph)
+                graph = remat_using_tags_for_fwd_loss_bwd_graph(
+                    graph, updated_flat_args
+                )
 
     if config.selective_decompose:
         from torch.fx.experimental.proxy_tensor import selective_decompose


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181392

Add an `example_inputs` parameter to `remat_using_tags_for_fwd_loss_bwd_graph`
for consistency with other partitioner APIs, set `autograd_backward=True`
on recomputed nodes so downstream passes can identify them as belonging to the
backward region, and rewrite the pass to modify the graph in-place instead of
recreating it (avoids global node renaming).

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98