### PR TITLE
Docs: recommend stable ABI umbrella headers instead of *_struct.h

### DIFF
--- a/docs/cpp/source/api/stable/index.md
+++ b/docs/cpp/source/api/stable/index.md
@@ -51,8 +51,8 @@ For more information on the stable ABI, see the
 
 - `torch/csrc/stable/library.h` - Stable library registration
 - `torch/csrc/stable/ops.h` - Stable operator definitions
-- `torch/csrc/stable/tensor_struct.h` - Stable tensor structures
-- `torch/csrc/stable/device_struct.h` - Stable device structures
+- `torch/csrc/stable/tensor.h` - Stable tensor structures
+- `torch/csrc/stable/device.h` - Stable device structures
 - `torch/csrc/stable/accelerator.h` - Accelerator support
 - `torch/csrc/stable/macros.h` - Stable API macros
 

--- a/docs/source/notes/libtorch_stable_abi.md
+++ b/docs/source/notes/libtorch_stable_abi.md
@@ -25,7 +25,8 @@ discussed below.
 It consists of
 
 - torch/csrc/stable/library.h: Provides a stable version of TORCH_LIBRARY and similar macros.
-- torch/csrc/stable/tensor_struct.h: Provides torch::stable::Tensor, a stable version of at::Tensor.
+- torch/csrc/stable/tensor.h: Provides torch::stable::Tensor, a stable version of at::Tensor.
+- torch/csrc/stable/device.h: Provides torch::stable::Device, a stable version of c10::Device.
 - torch/csrc/stable/ops.h: Provides a stable interface for calling ATen ops from `native_functions.yaml`.
 - torch/csrc/stable/accelerator.h: Provides a stable interface for device-generic objects and APIs
 (e.g. `getCurrentStream`, `DeviceGuard`).
@@ -103,7 +104,7 @@ TORCH_LIBRARY_IMPL(myops, CompositeExplicitAutograd, m) {
 // (1) Don't include <torch/torch.h> <ATen/ATen.h>
 //     only include APIs from torch/csrc/stable, torch/headeronly and C-shims
 #include <torch/csrc/stable/library.h>
-#include <torch/csrc/stable/tensor_struct.h>
+#include <torch/csrc/stable/tensor.h>
 #include <torch/csrc/stable/ops.h>
 #include <torch/headeronly/core/ScalarType.h>
 #include <torch/headeronly/macros/Macros.h>


### PR DESCRIPTION
Fixes #180492.

The stable ABI docs pointed users at `torch/csrc/stable/tensor_struct.h` and `device_struct.h`, which only contain forward declarations for constructors that are defined `inline` in the matching `*_inl.h` files. Following the docs led to a linker error such as:

```
undefined reference to `torch::stable::Device::Device(std::string const&)'
```

Update the docs to point at the umbrella headers `tensor.h` and `device.h`, which include both the struct and the inl headers and match what `test/cpp_extensions` already uses. Also add an entry for `device.h` in the header list in `libtorch_stable_abi.md`, which was previously missing.

## Test plan

Pure docs change; relying on the docs-preview build in CI to confirm rendering.