### PR TITLE
[ONNX] Do not rename passthrough values in call_function lowering

### DIFF
--- a/test/onnx/exporter/test_small_models_e2e.py
+++ b/test/onnx/exporter/test_small_models_e2e.py
@@ -461,6 +461,30 @@ class DynamoExporterTest(common_utils.TestCase, _WithExport):
                 args=(torch.rand((4, 3), dtype=torch.float32), torch.randn(4, 3)),
             )
 
+    def test_export_exported_program_with_buffer_inplace_copy(self):
+        # https://github.com/pytorch/pytorch/issues/178868
+        # aten.copy lowers via CastLike, which returns its input unchanged when
+        # src and self share a dtype. Previously the lowering handler then
+        # renamed the passthrough value, destroying the buffer placeholder's
+        # name and producing "Key 'b_prompt_feat' does not match the name of
+        # the value 'copy'" at initializer registration time.
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.register_buffer("prompt_feat", torch.zeros(1, 4, 8))
+                self.linear = torch.nn.Linear(8, 8)
+
+            def forward(self, x):
+                out = torch.zeros(1, 4, 8)
+                out[:, :, :] = self.prompt_feat.to(x.device)
+                return self.linear(out + x)
+
+        x = torch.randn(1, 4, 8)
+        exported_program = torch.export.export(Model().eval(), (x,))
+        onnx_program = self.export(exported_program, (x,))
+        # capture_strategy is None when exporting an ExportedProgram directly.
+        onnx_testing.assert_onnx_program(onnx_program, strategy=None)
+
     def test_export_with_non_arg_name_with_container_type(self):
         class Model(torch.nn.Module):
             def forward(self, a, b):

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -635,17 +635,20 @@ def _handle_call_function_node_with_lowering(
         _set_shape_types(outputs, node.meta["val"], complex_to_float=True)
         node_name_to_values[node.name] = outputs
         for i, output in enumerate(outputs):
-            output.name = f"{node.name}__{i}"
-            # Set the name of the producing node using the value name for correspondence
+            # Skip renaming values that were passed through rather than produced
+            # by this node's translation (e.g. aten.copy lowers to CastLike which
+            # returns its input when src and self share a dtype). Overwriting the
+            # name of an input/initializer breaks later initializer registration.
             producer = output.producer()
             if producer is not None:
+                output.name = f"{node.name}__{i}"
                 producer.name = f"node_{output.name}"
     else:
         _set_shape_type(outputs, node.meta["val"], complex_to_float=True)
         node_name_to_values[node.name] = outputs
-        outputs.name = node.name
         producer = outputs.producer()
         if producer is not None:
+            outputs.name = node.name
             producer.name = f"node_{outputs.name}"
 
     for ir_node in onnx_nodes:


### PR DESCRIPTION
Fixes #178868.

## Problem

`_handle_call_function_node_with_lowering` unconditionally renamed the value returned by the lowered ONNX function to the FX node name. This breaks when the ONNX function returns one of its inputs unchanged. The in-tree reproducer:

```python
class Model(nn.Module):
    def __init__(self):
        super().__init__()
        self.register_buffer("prompt_feat", torch.zeros(1, 4, 8))
        self.linear = nn.Linear(8, 8)
    def forward(self, x):
        out = torch.zeros(1, 4, 8)
        out[:, :, :] = self.prompt_feat.to(x.device)
        return self.linear(out + x)

ep = torch.export.export(Model().eval(), (torch.randn(1, 4, 8),))
torch.onnx.export(ep, args=(torch.randn(1, 4, 8),), f="test.onnx")
# ValueError: Key 'b_prompt_feat' does not match the name of the value 'copy'.
```

`aten.copy.default` is translated via `op.CastLike(src, self)`, which returns `src` unchanged when `src` and `self` share a dtype (no new ONNX node). The handler then did `outputs.name = node.name`, overwriting the buffer placeholder's name `b_prompt_feat` with `copy`. When initializer registration later looked up `b_prompt_feat`, the name no longer matched and it raised.

## Fix

Only rename a value (and its producing node) when the value was produced by a node in this translation, i.e. when `producer() is not None`. Values without a producer are graph inputs / initializers / passthroughs whose names must be preserved. The same guard is applied to the multi-output path for symmetry.

`node_name_to_values[node.name] = outputs` stays unconditional, so downstream FX nodes still resolve the passthrough correctly.

## Test plan

Added `test_export_exported_program_with_buffer_inplace_copy` in `test/onnx/exporter/test_small_models_e2e.py`, which exports the issue's exact repro as an `ExportedProgram` and verifies numerics against the eager module via `assert_onnx_program`. Rely on CI to run it.