### PR TITLE
[ROCm] Mark log1p eager-equivalence opinfo xfail

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -446,6 +446,7 @@ ROCM_EAGER_EQUIV_XFAILS = {
         "log_softmax": {fp32},
     },
     "inductor_default": {
+        "log1p": {fp32},
         "sigmoid": {fp32},
         "nn.functional.gelu": {fp32},
         "nn.functional.layer_norm": {fp32},


### PR DESCRIPTION
## Summary
- mark the ROCm `log1p` eager-equivalence opinfo case as an expected failure for `inductor_default`
- align the ROCm eager-equivalence xfail table with the existing skipped test entry for #180043

Fixes #180043

## Test Plan
- `py -3 -m py_compile test/inductor/test_torchinductor_opinfo_properties.py`


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben