### PR TITLE
[ROCm] Mark log1p determinism opinfo xfail

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -463,7 +463,11 @@ ROCM_EAGER_EQUIV_XFAILS = {
     },
 }
 
-ROCM_DETERMINISM_XFAILS = {}
+ROCM_DETERMINISM_XFAILS = {
+    "inductor_default": {
+        "log1p": {fp32},
+    },
+}
 
 ROCM_BATCH_INVARIANCE_XFAILS = {
     "aot_eager_decomp_partition": {


### PR DESCRIPTION
## Summary
- mark the ROCm `log1p` determinism opinfo case as an expected failure for `inductor_default`
- align the ROCm determinism xfail table with the existing skipped test entry for #180040

Fixes #180040

## Test Plan
- `py -3 -m py_compile test/inductor/test_torchinductor_opinfo_properties.py`


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben