### PR TITLE
[ROCm] Mark rsqrt unary numerical bf16 opinfo xfail

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -488,6 +488,7 @@ ROCM_UNARY_NUMERICAL_XFAILS = {
         "tanh": {fp32},
     },
     "inductor_numerics": {
+        "rsqrt": {bf16},
         "sigmoid": {fp32},
     },
 }


### PR DESCRIPTION
## Summary
- mark the ROCm `rsqrt` unary numerical opinfo case as an expected failure for `inductor_numerics` bfloat16
- align the ROCm unary numerical xfail table with the existing skipped test entry for #180071

Fixes #180071

## Test Plan
- `py -3 -m py_compile test/inductor/test_torchinductor_opinfo_properties.py`


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben