### PR TITLE
[ROCm] Mark tanh eager-equivalence opinfo xfail

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -447,6 +447,7 @@ ROCM_EAGER_EQUIV_XFAILS = {
     },
     "inductor_default": {
         "sigmoid": {fp32},
+        "tanh": {fp32},
         "nn.functional.gelu": {fp32},
         "nn.functional.layer_norm": {fp32},
         "nn.functional.silu": {fp16, fp32},


### PR DESCRIPTION
## Summary
- mark the ROCm `tanh` eager-equivalence opinfo case as an expected failure for `inductor_default` float32
- align the ROCm eager-equivalence xfail table with the existing skipped test entry for #180057

Fixes #180057

## Test Plan
- `py -3 -m py_compile test/inductor/test_torchinductor_opinfo_properties.py`


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben