### PR TITLE
[ROCm] Mark cos unary numerical opinfo xfail

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -480,6 +480,7 @@ ROCM_BATCH_INVARIANCE_XFAILS = {
 
 ROCM_UNARY_NUMERICAL_XFAILS = {
     "inductor_default": {
+        "cos": {fp32},
         "log1p": {fp32},
         "rsqrt": {bf16, fp32},
         "sigmoid": {fp32},


### PR DESCRIPTION
## Summary
- mark the ROCm `cos` unary numerical opinfo case as an expected failure for `inductor_default` float32
- align the ROCm unary numerical xfail table with the existing skipped test entry for #180058

Fixes #180058

## Test Plan
- `py -3 -m py_compile test/inductor/test_torchinductor_opinfo_properties.py`


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben