### PR TITLE
Temporarily disable XPU workflow on pull

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -509,7 +509,7 @@ jobs:
   # ╠══════════════════════════════════════════════════════════════════════╣
 
   linux-jammy-xpu-n-py3_10-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-xpu-n-py3.10 ') }}
+    if: false  # DISABLED: XPU job disabled on pull
     name: linux-jammy-xpu-n-py3.10
     uses: ./.github/workflows/_linux-build.yml
     needs:


### PR DESCRIPTION
Needed to land my tags PR https://github.com/pytorch/pytorch/pull/180190 which failed XPU build again due to a land race with Richard's PR https://github.com/pytorch/pytorch/pull/180851 adding a new tag.

cc @EikanWang @chuanqi129 Sorry for the churn! I'm trying to unblock this as soon as I can!

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181408

