### PR TITLE
[MPS] Fix BatchNorm2d backward for channels_last inputs

### DIFF
--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -873,8 +873,18 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
       newCachedGraph->gradBiasTensor_ = gradBiasTensor;
     });
 
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input, input_shape);
-    auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_out, input_shape_readonly);
+    // For channels_last, pass the raw NHWC buffer directly (matching the forward
+    // path): the default gather path either rejects the NHWC strides via .view()
+    // on macOS >= 15 or silently copies into NCHW layout while the graph expects
+    // NHWC on macOS < 15. contiguous(memory_format) handles non-packed views
+    // from autograd.
+    const bool is_channels_last = (memory_format == MemoryFormat::ChannelsLast);
+    const auto& input_cl = input.contiguous(memory_format);
+    const auto& grad_out_cl = grad_out.contiguous(memory_format);
+
+    auto inputPlaceholder = Placeholder(
+        cachedGraph->inputTensor_, input_cl, input_shape, !is_channels_last, MPSDataTypeInvalid, !is_channels_last);
+    auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_out_cl, input_shape_readonly);
     auto weightPlaceholder = Placeholder();
     if (has_weight)
       weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_opt.value(), new_mean_shape);
@@ -893,7 +903,12 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
 
     auto gradInputPlaceholder = Placeholder();
     if (grad_input_mask[0])
-      gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input, input_shape);
+      gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_,
+                                         grad_input,
+                                         input_shape,
+                                         !is_channels_last,
+                                         MPSDataTypeInvalid,
+                                         !is_channels_last);
     auto gradWeightPlaceholder = Placeholder();
     if (grad_input_mask[1])
       gradWeightPlaceholder = Placeholder(cachedGraph->gradWeightTensor_, grad_weight);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2059,6 +2059,48 @@ class TestMPS(TestCaseMPS):
         y_mps.sum().backward()
         self.assertIsNotNone(x.grad)
 
+    def test_batch_norm_backward_channels_last(self):
+        # Regression for https://github.com/pytorch/pytorch/issues/175189.
+        # Forward was correct on channels_last inputs, but backward either
+        # raised RuntimeError about view incompatibility (macOS 15+) or silently
+        # produced weight gradients off by roughly seven orders of magnitude
+        # (macOS 14), because the backward did not pass the raw NHWC buffer the
+        # way the forward does.
+        def helper(shape, dtype, affine, training):
+            torch.manual_seed(42)
+            N, C, H, W = shape
+            bn_cpu = nn.BatchNorm2d(C, affine=affine).train(training)
+            # Match dtype between the MPS module and input to sidestep the
+            # unrelated mixed-dtype eval-mode broadcast issue in MPSGraph
+            # normalization (fp16 input vs fp32 running stats). Default init
+            # (weight=1, bias=0) is exact in every dtype so no cast-loss here.
+            bn_mps = nn.BatchNorm2d(C, affine=affine).to(device="mps", dtype=dtype).train(training)
+
+            base = torch.randn(N, C, H, W)
+            x_cpu = base.clone().to(memory_format=torch.channels_last).requires_grad_(True)
+            x_mps = (base.to(device="mps", dtype=dtype).clone()
+                     .to(memory_format=torch.channels_last).requires_grad_(True))
+
+            bn_cpu(x_cpu).sum().backward()
+            bn_mps(x_mps).sum().backward()
+
+            atol, rtol = (1e-5, 1e-5) if dtype == torch.float32 else (5e-2, 5e-2)
+            self.assertEqual(x_cpu.grad, x_mps.grad.cpu(), atol=atol, rtol=rtol, exact_dtype=False)
+            if affine:
+                self.assertEqual(
+                    bn_cpu.weight.grad, bn_mps.weight.grad.cpu(), atol=atol, rtol=rtol, exact_dtype=False)
+                self.assertEqual(
+                    bn_cpu.bias.grad, bn_mps.bias.grad.cpu(), atol=atol, rtol=rtol, exact_dtype=False)
+
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            for affine in [True, False]:
+                for training in [True, False]:
+                    helper((4, 3, 8, 8), dtype, affine, training)
+        # single-channel edge case
+        helper((2, 1, 5, 5), torch.float32, affine=True, training=True)
+        # batch-size-1 eval (N=1 training would reduce over zero variance)
+        helper((1, 4, 6, 6), torch.float32, affine=True, training=False)
+
     def test_layer_norm_backward(self):
         inputs = torch.rand(4, 4, device="mps", requires_grad=True)
         x = torch.nn.LayerNorm(4).to("mps")

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -4070,8 +4070,6 @@ module_db: list[ModuleInfo] = [
                module_inputs_func=module_inputs_torch_nn_BatchNorm2d,
                module_error_inputs_func=module_error_inputs_torch_nn_BatchNorm1d_2d_3d,
                skips=(
-                   # See https://github.com/pytorch/pytorch/issues/134580
-                   DecorateInfo(expectedFailureMPS, 'TestModule', 'test_memory_format', active_if=operator.itemgetter('training')),
                    # tracking here rather than in the list in test_aotdispatch.py as eval mode passes
                    # RuntimeError: tried to get Double out of SymInt
                    DecorateInfo(


### PR DESCRIPTION
Fixes #175189.

## Summary

The forward path in `batch_norm_mps` already uses `gatherTensorData=false, useMPSStridedAPI=false` for `inputPlaceholder` when the input is channels_last (`Normalization.mm:346-347`). The backward path didn't, so for CL inputs it either crashed (macOS 26, on the strided `.view([N,H,W,C])` in `OperationUtils.mm:549`) or silently corrupted `inputTensor` and every grad derived from it (macOS 14, gather copies NCHW-contiguous bytes but labels them NHWC). Bias grad survives because `gradOutputPlaceholder` uses the NCHW shape and the default gather happens to match.

Fix mirrors the pool2d fix in #175320: `.contiguous(memory_format)` and pass `!is_channels_last` to both flags for `inputPlaceholder` and `gradInputPlaceholder`. `gradOutputPlaceholder` keeps defaults.

The xfail on `test_memory_format` for BatchNorm2d (referencing the closed #134580) was unblocked by this and is removed in the same commit.

## Test plan

New `test_batch_norm_backward_channels_last` covers fp32/fp16/bf16 × affine × training plus single-channel and batch=1 eval. Red without the fix, green with it.

CPU vs MPS max-abs-diff after the fix on macOS 26 CL: input.grad 8.9e-8, weight.grad 6.2e-6, bias.grad 0 (NCHW reference: 1.3e-8 / 1.6e-6 / 0). Pre-fix the issue's CL run produced weight.grad 12.81 vs CPU 1.4e-7 (~7 orders off), or a hard RuntimeError on macOS 26.

A 20-step Conv+BN+ReLU SGD loop converges identically across layouts (loss 26058 → 26.58 either way), versus diverging to ~1e13 by step 7 pre-fix.
