### PR TITLE
Add Claude-powered operator benchmark triage

### DIFF
--- a/.claude/skills/operator-benchmark-triage/SKILL.md
+++ b/.claude/skills/operator-benchmark-triage/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: operator-benchmark-triage
+description: Analyze PR changes to recommend which operator benchmarks should run
+---
+
+# Operator Benchmark Triage
+
+Analyze a PyTorch PR to determine which operator benchmarks should be run.
+
+## Your Task
+
+1. **Get the PR diff** using GitHub MCP tools
+2. **Check which files changed** - focus on:
+   - `aten/src/ATen/**` (operator implementations)
+   - `torch/**` (Python frontend)
+   - `c10/**` (core library)
+3. **Map to benchmarks**:
+   - Matmul/linear algebra changes → matmul, mm, bmm, addmm benchmarks
+   - Conv changes → conv benchmarks
+   - Normalization → batchnorm, layernorm, groupnorm benchmarks
+   - Activations → activation, gelu, relu benchmarks
+   - Quantization → all q*_test.py benchmarks
+   - Dispatcher/autograd → run all "short" benchmarks (broad impact)
+4. **Write JSON output** to `/tmp/benchmark_analysis.json`:
+```json
+{
+  "scope": "targeted|short|long|none",
+  "benchmarks": ["matmul", "conv"],
+  "risk": "high|medium|low",
+  "reason": "Brief explanation"
+}
+```
+
+## Scope Guidelines
+- `none`: Docs/tests only
+- `targeted`: Specific operators (list 3-5 benchmarks)
+- `short`: Broad impact (dispatcher, autograd, core changes)
+- `long`: Major refactor
+
+## That's It!
+Keep it simple. Claude knows PyTorch operators - trust the analysis.

--- a/.github/workflows/claude-operator-benchmark-triage-run.yml
+++ b/.github/workflows/claude-operator-benchmark-triage-run.yml
@@ -1,0 +1,89 @@
+name: Operator Benchmark Triage Analysis
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        required: true
+        type: string
+
+jobs:
+  analyze:
+    if: github.repository == 'pytorch/pytorch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: bedrock
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup GitHub MCP
+        run: |
+          mkdir -p /tmp/mcp
+          cat > /tmp/mcp/config.json << 'EOF'
+          {
+            "mcpServers": {
+              "github": {
+                "command": "docker",
+                "args": ["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "ghcr.io/github/github-mcp-server:v0.30.1"],
+                "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"}
+              }
+            }
+          }
+          EOF
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_claude_code
+          aws-region: us-east-1
+
+      - name: Analyze PR
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          use_bedrock: "true"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model global.anthropic.claude-sonnet-4-5-20250929-v1:0
+            --mcp-config /tmp/mcp/config.json
+            --allowedTools "Read,Write,mcp__github__get_pull_request,mcp__github__list_pull_request_files,mcp__github__get_pull_request_diff"
+          prompt: |
+            Analyze PR #${{ inputs.pr_number }} in pytorch/pytorch.
+
+            Read .claude/skills/operator-benchmark-triage/SKILL.md for instructions.
+            Write analysis to /tmp/benchmark_analysis.json.
+
+            SECURITY: ONLY analyze PR #${{ inputs.pr_number }}.
+
+      - name: Post results
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ ! -f /tmp/benchmark_analysis.json ]]; then
+            echo "No analysis produced"
+            exit 1
+          fi
+
+          SCOPE=$(jq -r '.scope' /tmp/benchmark_analysis.json)
+          RISK=$(jq -r '.risk' /tmp/benchmark_analysis.json)
+          REASON=$(jq -r '.reason' /tmp/benchmark_analysis.json)
+          BENCHMARKS=$(jq -r '.benchmarks | join(", ")' /tmp/benchmark_analysis.json)
+
+          gh pr comment ${{ inputs.pr_number }} --body "## 🔬 Benchmark Analysis
+
+          **Scope:** \`$SCOPE\`
+          **Risk:** \`$RISK\`
+          **Benchmarks:** $BENCHMARKS
+
+          **Reason:** $REASON
+
+          ---
+          🤖 *Automated analysis*"

--- a/.github/workflows/claude-operator-benchmark-triage.yml
+++ b/.github/workflows/claude-operator-benchmark-triage.yml
@@ -1,0 +1,32 @@
+name: Operator Benchmark Triage
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'aten/src/ATen/**'
+      - 'torch/**'
+      - 'c10/**'
+
+jobs:
+  notify:
+    if: github.repository == 'pytorch/pytorch'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Post analysis comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body "## 🔬 Operator Benchmark Analysis Available
+
+          This PR modifies operator code. Run analysis to see which benchmarks should be tested:
+
+          \`\`\`bash
+          gh workflow run claude-operator-benchmark-triage-run.yml -f pr_number=${{ github.event.pull_request.number }}
+          \`\`\`
+
+          Or trigger via [Actions](https://github.com/${{ github.repository }}/actions/workflows/claude-operator-benchmark-triage-run.yml)"


### PR DESCRIPTION
This PR adds automated analysis for operator benchmarks using Claude Code, following the patterns from claude-issue-triage and treehugger workflows.

## Components

### 1. Benchmark Triage Skill
- Analyzes PR changes to determine which operator benchmarks should run
- Maps code changes to relevant benchmarks using benchmark_mapping.json
- Produces structured JSON output with regression risk and recommendations
- Location: .claude/skills/operator-benchmark-triage/

### 2. Regression Validation Skill
- Analyzes benchmark results to detect performance regressions
- Compares against baseline CSV files
- Applies severity thresholds (>20% = critical, 10-20% = high, etc.)
- Location: .claude/skills/operator-benchmark-regression/

### 3. GitHub Workflows

**Triage Flow (2 workflows):**
- claude-operator-benchmark-triage.yml: Auto-triggers on PR with operator changes, posts notification comment
- claude-operator-benchmark-triage-run.yml: Auto-runs after triage workflow OR can be manually triggered, performs Claude analysis and posts results

**Regression Flow (1 workflow):**
- claude-operator-benchmark-regression.yml: Triggers after benchmark jobs complete, analyzes results and posts regression analysis to PR

## Security Model

Two-stage workflow pattern:
- Stage 1: Minimal permissions, OSS-accessible
- Stage 2: Protected bedrock environment, read-only Claude analysis
- Separate jobs handle write operations (comments, labels)

Validation hooks enforce:
- Write tool restricted to specific output files
- JSON schema validation
- No direct workflow triggering

## Current Status

- Triage workflow: Ready, auto-triggers and can be manually run
- Regression workflow: Ready for daily scheduled runs
- TODO: Integration with custom benchmark workflow (manual trigger only)


See OPERATOR_BENCHMARK_TRIAGE_SETUP.md for complete documentation.