### PR TITLE
[ROCm] Fix AutoHeuristic test device capability assertion

### DIFF
--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import torch
 import torch._inductor.config as inductor_config
-from torch._dynamo.device_interface import get_interface_for_device
 from torch._inductor.autoheuristic.autoheuristic import AutoHeuristic, LocalFeedback
 from torch._inductor.autoheuristic.autoheuristic_utils import AHContext
 from torch._inductor.runtime.runtime_utils import cache_dir
@@ -107,16 +106,14 @@ class AutoHeuristicTest(TestCase):
         self.assertEqual(num_lines, 5)
 
         shared_memory = get_gpu_shared_memory()
-        compute_cap = get_interface_for_device(GPU_TYPE).get_compute_capability()
-        # Convert single int compute capability (e.g., 90) to tuple (e.g., (9, 0))
-        fst, snd = compute_cap // 10, compute_cap % 10
+        device_capa = list(torch.cuda.get_device_capability())
 
         with open(path) as file:
             lines = file.readlines()
             self.assertTrue('"numerical_features": ["fa"]' in lines[0])
             self.assertTrue('"categorical_features": []' in lines[0])
             self.assertTrue(f'"shared_memory": {shared_memory}' in lines[0])
-            self.assertTrue(f'"device_capa": [{fst}, {snd}]' in lines[0])
+            self.assertTrue(f'"device_capa": {device_capa}' in lines[0])
             self.assertTrue('"name": "test"' in lines[0])
             self.assertEqual("fa,choice,feedback", lines[1].rstrip())
             self.assertEqual("5,a,1", lines[2].rstrip())


### PR DESCRIPTION
Fixes #180475

## Summary
- use `torch.cuda.get_device_capability()` in the AutoHeuristic test assertion
- match the metadata format that `AutoHeuristic` actually serializes
- avoid the ROCm-specific mismatch where the device interface helper may return an architecture string instead of an integer-like compute capability

## Test Plan
- `py -3 -m py_compile test/inductor/test_autoheuristic.py`
- not run: ROCm test suite locally (no ROCm-enabled PyTorch test environment on this machine)


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben