### PR TITLE
[ROCm] Mark log1p determinism opinfo xfail

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -463,7 +463,11 @@ ROCM_EAGER_EQUIV_XFAILS = {
     },
 }
 
-ROCM_DETERMINISM_XFAILS = {}
+ROCM_DETERMINISM_XFAILS = {
+    "inductor_default": {
+        "log1p": {fp32},
+    },
+}
 
 ROCM_BATCH_INVARIANCE_XFAILS = {
     "aot_eager_decomp_partition": {


### PR DESCRIPTION
Fixes #180040

## Summary
- mark the ROCm `log1p` determinism opinfo case as an expected failure for `inductor_numerics`
- align the ROCm xfail table with the existing skipped test entry for #180040

## Test Plan
- `py -3 -m py_compile test/inductor/test_torchinductor_opinfo_properties.py`
- not run: ROCm test suite locally (no ROCm-enabled PyTorch test environment on this machine)
