### PR TITLE
[ROCm] Mark log1p unary numerical fp16 opinfo xfail

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -480,7 +480,7 @@ ROCM_BATCH_INVARIANCE_XFAILS = {
 
 ROCM_UNARY_NUMERICAL_XFAILS = {
     "inductor_default": {
-        "log1p": {fp32},
+        "log1p": {fp16, fp32},
         "rsqrt": {bf16, fp32},
         "sigmoid": {fp32},
         "sin": {fp32},


### PR DESCRIPTION
Fixes #180419

## Summary
- mark the ROCm `log1p` unary numerical float16 opinfo case as an expected failure for `inductor_numerics`
- align the ROCm xfail table with the existing skipped test entry for #180419

## Test Plan
- `py -3 -m py_compile test/inductor/test_torchinductor_opinfo_properties.py`
- not run: ROCm test suite locally (no ROCm-enabled PyTorch test environment on this machine)
