### PR TITLE
[ROCm] Mark rsqrt unary numerical bf16 opinfo xfail

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -488,6 +488,7 @@ ROCM_UNARY_NUMERICAL_XFAILS = {
         "tanh": {fp32},
     },
     "inductor_numerics": {
+        "rsqrt": {bf16},
         "sigmoid": {fp32},
     },
 }


### PR DESCRIPTION
Fixes #180071

## Summary
- mark the ROCm `rsqrt` unary numerical bfloat16 opinfo case as an expected failure for `inductor_numerics`
- align the ROCm xfail table with the existing skipped test entry for #180071

## Test Plan
- `py -3 -m py_compile test/inductor/test_torchinductor_opinfo_properties.py`
- not run: ROCm test suite locally (no ROCm-enabled PyTorch test environment on this machine)
