### PR TITLE
[ROCm] Mark tanh eager-equivalence opinfo xfail

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -447,6 +447,7 @@ ROCM_EAGER_EQUIV_XFAILS = {
     },
     "inductor_default": {
         "sigmoid": {fp32},
+        "tanh": {fp32},
         "nn.functional.gelu": {fp32},
         "nn.functional.layer_norm": {fp32},
         "nn.functional.silu": {fp16, fp32},


### PR DESCRIPTION
Fixes #180057

## Summary
- mark the ROCm `tanh` eager-equivalence float32 opinfo case as an expected failure for `inductor_eager`
- align the ROCm xfail table with the existing skipped test entry for #180057

## Test Plan
- `py -3 -m py_compile test/inductor/test_torchinductor_opinfo_properties.py`
- not run: ROCm test suite locally (no ROCm-enabled PyTorch test environment on this machine)
