### PR TITLE
[ROCm] Mark exp unary numerical opinfo xfail

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -480,6 +480,7 @@ ROCM_BATCH_INVARIANCE_XFAILS = {
 
 ROCM_UNARY_NUMERICAL_XFAILS = {
     "inductor_default": {
+        "exp": {fp32},
         "log1p": {fp32},
         "rsqrt": {bf16, fp32},
         "sigmoid": {fp32},


### PR DESCRIPTION
Fixes #180061

## Summary
- mark the ROCm `exp` unary numerical float32 opinfo case as an expected failure for `inductor_numerics`
- align the ROCm xfail table with the existing skipped test entry for #180061

## Test Plan
- `py -3 -m py_compile test/inductor/test_torchinductor_opinfo_properties.py`
- not run: ROCm test suite locally (no ROCm-enabled PyTorch test environment on this machine)
