### PR TITLE
[ROCm] Mark rsqrt eager-equivalence opinfo xfail

### DIFF
--- a/test/inductor/test_torchinductor_opinfo_properties.py
+++ b/test/inductor/test_torchinductor_opinfo_properties.py
@@ -446,6 +446,7 @@ ROCM_EAGER_EQUIV_XFAILS = {
         "log_softmax": {fp32},
     },
     "inductor_default": {
+        "rsqrt": {fp32},
         "sigmoid": {fp32},
         "nn.functional.gelu": {fp32},
         "nn.functional.layer_norm": {fp32},


### PR DESCRIPTION
Fixes #180055

## Summary
- mark the ROCm `rsqrt` eager-equivalence float32 opinfo case as an expected failure for `inductor_eager`
- align the ROCm xfail table with the existing skipped test entry for #180055

## Test Plan
- `py -3 -m py_compile test/inductor/test_torchinductor_opinfo_properties.py`
- not run: ROCm test suite locally (no ROCm-enabled PyTorch test environment on this machine)
