### PR TITLE
Allow more time and bigger runner for docs workflow

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -92,9 +92,9 @@ jobs:
             # Let's try to figure out how this can be improved
             timeout-minutes: 360
           - docs_type: python
-            runner: ${{ inputs.runner_prefix }}linux.c7i.2xlarge
+            runner: ${{ inputs.runner_prefix }}linux.c7i.8xlarge
             # It takes less than 30m to finish python docs unless there are issues
-            timeout-minutes: 45
+            timeout-minutes: 120
     # Set a fixed name for this job instead of using the current matrix-generated name, i.e. build-docs (cpp, linux.12xlarge, 180)
     # The current name requires updating the database last docs push query from test-infra every time the matrix is updated
     name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}


### PR DESCRIPTION
1. Use ``c7i.8xlarge`` runner
2. Use 2hrs max time

Mitigate docs workflow failure since April 9