### PR TITLE
[BE][Docs] Error out rather than hang if workflow is missing credentials

### DIFF
--- a/.ci/pytorch/python_doc_push_script.sh
+++ b/.ci/pytorch/python_doc_push_script.sh
@@ -155,6 +155,8 @@ git commit -m "Generate Python docs from pytorch/pytorch@${GITHUB_SHA}" || true
 git status
 
 if [[ "${WITH_PUSH:-}" == true ]]; then
+  # Error out if credentials to push are missing
+  export GIT_TERMINAL_PROMPT=0
   # push to a temp branch first to trigger CLA check and satisfy branch protections
   git push -u origin HEAD:pytorchbot/temp-branch-py -f
   git push -u origin HEAD^:pytorchbot/base -f


### PR DESCRIPTION
Before
```
jenkins@6cd2d53a3758:~/workspace/pytorch_docs$ git push -u origin HEAD:pytorchbot/temp-branch-py -f
Username for 'https://github.com': ^C
```
After
```
jenkins@6cd2d53a3758:~/workspace/pytorch_docs$ GIT_TERMINAL_PROMPT=0 git push -u origin HEAD:pytorchbot/temp-branch-py -f
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```