### PR TITLE
Change default of torchgen headeronly-install-dir to depend on install-dir

### DIFF
--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2786,8 +2786,10 @@ def main() -> None:
     parser.add_argument(
         "--headeronly-install-dir",
         "--headeronly_install_dir",
-        help="output directory for header-only generated files (e.g. enum_tag.h)",
-        default="build/torch/headeronly/core",
+        help="output directory for header-only generated files (e.g. enum_tag.h). "
+        "Defaults to `<install-dir>/core` when --install-dir is set, otherwise "
+        "`build/torch/headeronly/core`.",
+        default=None,
     )
     parser.add_argument(
         "--rocm",
@@ -2986,7 +2988,12 @@ def main() -> None:
     aoti_install_dir = f"{options.aoti_install_dir}"
     Path(aoti_install_dir).mkdir(parents=True, exist_ok=True)
 
-    headeronly_install_dir = f"{options.headeronly_install_dir}"
+    if options.headeronly_install_dir is not None:
+        headeronly_install_dir = options.headeronly_install_dir
+    elif options.install_dir is not None:
+        headeronly_install_dir = f"{options.install_dir}/core"
+    else:
+        headeronly_install_dir = "build/torch/headeronly/core"
     Path(headeronly_install_dir).mkdir(parents=True, exist_ok=True)
 
     core_fm = make_file_manager(options=options, install_dir=core_install_dir)


### PR DESCRIPTION
This is a "forward fix" of https://github.com/pytorch/pytorch/pull/181161 and will need to be cherrypicked to make sure xpu builds still work. To describe the issue:
- torch-xpu-ops has its own version of tags.yaml
- the natural default of headeronly-install-dir had the XPU build overriding the enum_tags.h, and since their tag.yaml weren't the same as ours, we get build issues
- I tried fixing this before by just aligning the torch-xpu-ops version of tags.yaml but we're still adding more tags so that problem will come back
- I finally decided the fix is just to make the the default doesn't have the install locations colliding even if it makes the default for torchgen a tad more complicated.

Test plan:
make sure the XPU build on the PR stacked on top of this one passes.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181437
* __->__ #181434

