### PR TITLE
Codegen AOTSyntheticBaseWrapper post_compile

### DIFF
--- a/test/functorch/test_codegen_synthetic_base.py
+++ b/test/functorch/test_codegen_synthetic_base.py
@@ -1,0 +1,202 @@
+# Owner(s): ["module: functorch"]
+
+"""
+Tests for codegen'ing the AOTSyntheticBaseWrapper in aot_autograd.
+
+The codegen'd synthetic base wrapper bakes the metadata mutation indices
+and output slice as compile-time constants, eliminating the data-driven
+loop that applies as_strided_ to metadata-mutated aliased inputs.
+
+Tests verify that a "synthetic_base_wrapper" artifact is emitted via
+trace_structured.
+"""
+
+import logging
+from contextlib import contextmanager
+
+import torch
+import torch._dynamo
+from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+
+
+trace_log = logging.getLogger("torch.__trace")
+
+
+class TestCodegenSyntheticBase(TestCase):
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+
+    @contextmanager
+    def _capture_codegen_source(self, artifact_name):
+        captured: list[str] = []
+
+        class _ArtifactHandler(logging.Handler):
+            def emit(self, record):
+                metadata = getattr(record, "metadata", {})
+                if (
+                    "artifact" in metadata
+                    and metadata["artifact"].get("name") == artifact_name
+                ):
+                    payload = getattr(record, "payload", None)
+                    if payload is not None:
+                        captured.append(payload)
+
+        handler = _ArtifactHandler()
+        handler.setLevel(logging.DEBUG)
+        old_level = trace_log.level
+        trace_log.setLevel(logging.DEBUG)
+        trace_log.addHandler(handler)
+        try:
+            yield captured
+        finally:
+            trace_log.removeHandler(handler)
+            trace_log.setLevel(old_level)
+
+    def test_no_aliased_inputs_no_codegen(self):
+        """
+        When inputs don't alias each other, no synthetic bases are
+        needed and no codegen artifact is emitted.
+        """
+        with self._capture_codegen_source("synthetic_base_wrapper") as captured:
+
+            @torch.compile(backend="aot_eager")
+            def f(x, y):
+                return x + y
+
+            f(torch.randn(4), torch.randn(4))
+
+        self.assertEqual(
+            len(captured),
+            0,
+            "No codegen should be emitted when inputs don't alias",
+        )
+
+    def test_aliased_inputs_with_mutation(self):
+        """
+        Two aliased inputs where one is mutated. Should emit a
+        synthetic_base_wrapper codegen artifact.
+        """
+        with self._capture_codegen_source("synthetic_base_wrapper") as captured:
+
+            @torch.compile(backend="aot_eager")
+            def f(a, b):
+                a.mul_(2)
+                return a + b
+
+            x = torch.randn(4)
+            out = f(x.view(-1), x.view(-1))
+
+        self.assertEqual(len(captured), 1)
+
+    def test_aliased_mutation_correctness(self):
+        """
+        Verify that aliased mutation produces correct results through
+        the codegen'd wrapper.
+        """
+
+        @torch.compile(backend="aot_eager")
+        def f(a, b):
+            a.mul_(2)
+            return a + b
+
+        x = torch.randn(4)
+        x_ref = x.clone()
+        a = x.view(-1)
+        b = x.view(-1)
+        out = f(a, b)
+
+        self.assertEqual(a, x_ref * 2)
+        self.assertEqual(b, x_ref * 2)
+        self.assertEqual(out, x_ref * 4)
+
+    @skipIfTorchDynamo("dynamo handles metadata mutations in-graph")
+    def test_metadata_mutation_on_aliased_input(self):
+        """
+        Metadata mutation (transpose) on an aliased input. Uses
+        aot_function directly since dynamo handles metadata mutations
+        in-graph.
+        """
+        from functorch.compile import nop
+        from torch._functorch.aot_autograd import aot_function
+
+        with self._capture_codegen_source("synthetic_base_wrapper") as captured:
+
+            def f(a, b):
+                a.mul_(2)
+                b.transpose_(1, 0)
+                return a + 1
+
+            x = torch.randn(2, 2)
+            a = x.view(2, 2)
+            b = x.view(2, 2)
+            compiled_f = aot_function(f, nop)
+            out = compiled_f(a, b)
+
+        self.assertEqual(len(captured), 1)
+        source = captured[0]
+        self.assertIn("as_strided_", source)
+
+    def test_non_aliased_inputs_passthrough(self):
+        """
+        Non-aliased inputs should pass through the synthetic base
+        wrapper without modification.
+        """
+
+        @torch.compile(backend="aot_eager")
+        def f(x, a, b):
+            a.mul_(2)
+            return x + a + b
+
+        x = torch.randn(4)
+        base = torch.randn(4)
+        base_ref = base.clone()
+        a = base.view(-1)
+        b = base.view(-1)
+        x_ref = x.clone()
+        out = f(x, a, b)
+
+        self.assertEqual(a, base_ref * 2)
+        self.assertEqual(out, x_ref + base_ref * 2 + base_ref * 2)
+
+    def test_codegen_source_structure(self):
+        """
+        Verify the codegen'd source has the expected structure.
+        """
+        with self._capture_codegen_source("synthetic_base_wrapper") as captured:
+
+            @torch.compile(backend="aot_eager")
+            def f(a, b):
+                a.add_(1)
+                return a + b
+
+            x = torch.randn(4)
+            f(x.view(-1), x.view(-1))
+
+        self.assertEqual(len(captured), 1)
+        source = captured[0]
+        self.assertIn("def _synthetic_base_wrapper", source)
+        self.assertIn("_merge_view_inputs_", source)
+        self.assertIn("_compiled_fn_", source)
+        self.assertIn("args.clear()", source)
+
+    def test_training_path_aliased_mutation(self):
+        """
+        Training path with aliased inputs and mutation. Verify backward
+        correctness through the synthetic base wrapper.
+        """
+
+        @torch.compile(backend="aot_eager")
+        def f(a, b):
+            a.mul_(2)
+            return (a + b).sum()
+
+        x = torch.randn(4, requires_grad=True)
+        a = x.clone()
+        b = a.view(-1)
+        out = f(a, b)
+        out.backward()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -1894,45 +1894,71 @@ class AOTSyntheticBaseWrapper(CompilerWrapper):
             return compiled_fn
 
         is_inference = not self.trace_joint
+        aliased_arg_idx_with_metadata_mutations = (
+            self.aliased_arg_idx_with_metadata_mutations
+        )
+        num_aliased = len(aliased_arg_idx_with_metadata_mutations)
+
+        from .subclass_codegen import _compile_and_exec_source
+
+        lines = [
+            "def _synthetic_base_wrapper("
+            "_compiled_fn_, _merge_view_inputs_, _aot_config_, "
+            "_old_input_info_, args):"
+        ]
+        lines.append(
+            "    args_with_synthetic_bases, _, synthetic_base_info = "
+            "_merge_view_inputs_("
+            "_aot_config_, args, None, _old_input_info_, "
+            f"is_inference={is_inference!r})"
+        )
+        lines.append("    if synthetic_base_info is None:")
+        lines.append(
+            '        raise AssertionError("synthetic_base_info must not be None")'
+        )
+
+        if num_aliased > 0:
+            idx_str = ", ".join(
+                f"args[{i}]" for i in aliased_arg_idx_with_metadata_mutations
+            )
+            lines.append(f"    aliased_args = [{idx_str}]")
+
+        lines.append("    args.clear()")
+        lines.append("    outs = _compiled_fn_(args_with_synthetic_bases)")
+
+        if num_aliased > 0:
+            lines.append(f"    mutated_inps = outs[-{num_aliased}:]")
+            lines.append(f"    user_outs = outs[:-{num_aliased}]")
+            for i in range(num_aliased):
+                lines.append(
+                    f"    aliased_args[{i}].as_strided_("
+                    f"mutated_inps[{i}].size(), "
+                    f"mutated_inps[{i}].stride(), "
+                    f"mutated_inps[{i}].storage_offset())"
+                )
+            lines.append("    return user_outs")
+        else:
+            lines.append("    return outs")
+
+        source = "\n".join(lines)
+        _codegen_fn = _compile_and_exec_source(
+            source,
+            {},
+            "_synthetic_base_wrapper",
+            "synthetic_base_wrapper",
+        )
+        _inner_compiled_fn = compiled_fn
+        _old_input_info = self.old_input_info
 
         @wraps(compiled_fn)
         def wrapped_compiled_fn(args: list[Any]) -> Any:
-            # TODO: this sure seems expensive to run at runtime (which
-            # post_compile seems to imply it does?!)
-            args_with_synthetic_bases, _, synthetic_base_info = merge_view_inputs(
-                aot_config, args, None, self.old_input_info, is_inference=is_inference
+            return _codegen_fn(
+                _inner_compiled_fn,
+                merge_view_inputs,
+                aot_config,
+                _old_input_info,
+                args,
             )
-            if synthetic_base_info is None:
-                raise AssertionError("synthetic_base_info must not be None")
-            aliased_args_w_metadata_mutations = [
-                args[i] for i in self.aliased_arg_idx_with_metadata_mutations
-            ]
-            num_aliased_args_with_metadata_mutations = len(
-                aliased_args_w_metadata_mutations
-            )
-            args.clear()
-            outs = compiled_fn(args_with_synthetic_bases)
-            if num_aliased_args_with_metadata_mutations > 0:
-                # This code does not handle **all** input metadata mutations.
-                # Instead, it only handles metadata mutations on inputs that were converted into synthetic bases
-                # (which only happens if at least one aliased input experienced a data mutation).
-                # e.g:
-                # def f(a, b):
-                #     a.mul_(2)
-                #     b.t_(1, 0)
-                # f(x.view(2, 2), x.view(2, 2))
-                mutated_metadata_inps = outs[-num_aliased_args_with_metadata_mutations:]
-                user_outs = outs[:-num_aliased_args_with_metadata_mutations]
-                for inp, mutated_inp in zip(
-                    aliased_args_w_metadata_mutations, mutated_metadata_inps
-                ):
-                    inp.as_strided_(
-                        mutated_inp.size(),
-                        mutated_inp.stride(),
-                        mutated_inp.storage_offset(),
-                    )
-                return user_outs
-            return outs
 
         return wrapped_compiled_fn
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181438
* __->__ #181436
* #181271
* #181250
* #181120

Replace AOTSyntheticBaseWrapper.post_compile closure with a codegen'd
function that bakes the metadata mutation indices and output slice as
compile-time constants. The data-driven loop that applies as_strided_ to
metadata-mutated aliased inputs becomes straight-line code with baked
indices and constant slice offsets.

Generated code for 2 aliased inputs with metadata mutations:

    def _synthetic_base_wrapper(
        _compiled_fn_, _merge_view_inputs_, _aot_config_,
        _old_input_info_, args):
        args_with_synthetic_bases, _, synthetic_base_info = (
            _merge_view_inputs_(...))
        if synthetic_base_info is None:
            raise AssertionError(...)
        aliased_args = [args[0], args[1]]
        args.clear()
        outs = _compiled_fn_(args_with_synthetic_bases)
        mutated_inps = outs[-2:]
        user_outs = outs[:-2]
        aliased_args[0].as_strided_(...)
        aliased_args[1].as_strided_(...)
        return user_outs

AOTSyntheticBaseWrapper post_compile step in isolation (us/call):

| Case | Before (closure) | After (codegen) | Speedup |
|---|---|---|---|
| 0 aliased, 5 args | 0.39 us | 0.29 us | 1.3x |
| 1 aliased, 5 args | 0.64 us | 0.42 us | 1.5x |
| 2 aliased, 5 args | 0.67 us | 0.44 us | 1.5x |
| 3 aliased, 10 args | 0.73 us | 0.46 us | 1.6x |