### PR TITLE
Codegen process_runtime_tangent in backward prologue

### DIFF
--- a/test/functorch/test_codegen_process_tangent.py
+++ b/test/functorch/test_codegen_process_tangent.py
@@ -1,0 +1,206 @@
+# Owner(s): ["module: functorch"]
+
+"""
+Tests for codegen'ing the process_runtime_tangent in aot_autograd.
+
+The codegen'd tangent processing replaces the per-tangent
+process_runtime_tangent loop with straight-line code that inlines
+the memory format coercion for each tangent with baked-in format
+metadata. For PlainTensorMeta tangents (the common case), this
+eliminates multiple isinstance checks and function calls per tangent.
+
+Tests verify that a "process_tangents" artifact is emitted via
+trace_structured.
+"""
+
+import logging
+from contextlib import contextmanager
+
+import torch
+import torch._dynamo
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+trace_log = logging.getLogger("torch.__trace")
+
+
+class TestCodegenProcessTangent(TestCase):
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+
+    @contextmanager
+    def _capture_codegen_source(self, artifact_name):
+        captured: list[str] = []
+
+        class _ArtifactHandler(logging.Handler):
+            def emit(self, record):
+                metadata = getattr(record, "metadata", {})
+                if (
+                    "artifact" in metadata
+                    and metadata["artifact"].get("name") == artifact_name
+                ):
+                    payload = getattr(record, "payload", None)
+                    if payload is not None:
+                        captured.append(payload)
+
+        handler = _ArtifactHandler()
+        handler.setLevel(logging.DEBUG)
+        old_level = trace_log.level
+        trace_log.setLevel(logging.DEBUG)
+        trace_log.addHandler(handler)
+        try:
+            yield captured
+        finally:
+            trace_log.removeHandler(handler)
+            trace_log.setLevel(old_level)
+
+    def test_codegen_emitted_for_training(self):
+        """
+        Training path should emit a process_tangents codegen artifact.
+        """
+        with self._capture_codegen_source("process_tangents") as captured:
+
+            @torch.compile(backend="aot_eager")
+            def f(x):
+                return x * 2
+
+            x = torch.randn(4, requires_grad=True)
+            out = f(x)
+            out.sum().backward()
+
+        self.assertEqual(len(captured), 1)
+        source = captured[0]
+        self.assertIn("def _process_tangents", source)
+        self.assertIn("_coerce_", source)
+
+    def test_no_codegen_for_inference(self):
+        """
+        Inference path should not emit a process_tangents artifact.
+        """
+        with self._capture_codegen_source("process_tangents") as captured:
+
+            @torch.compile(backend="aot_eager")
+            def f(x):
+                return x * 2
+
+            f(torch.randn(4))
+
+        self.assertEqual(
+            len(captured),
+            0,
+            "No codegen should be emitted for inference",
+        )
+
+    def test_backward_correctness_single_input(self):
+        """
+        Verify backward correctness through the codegen'd tangent
+        processing with a single input.
+        """
+
+        @torch.compile(backend="aot_eager")
+        def f(x):
+            return x * 3 + 1
+
+        x = torch.randn(4, requires_grad=True)
+        out = f(x)
+        out.sum().backward()
+
+        self.assertEqual(x.grad, torch.full((4,), 3.0))
+
+    def test_backward_correctness_multiple_inputs(self):
+        """
+        Verify backward correctness with multiple inputs. Each tangent
+        gets its own inline coercion in the codegen.
+        """
+
+        @torch.compile(backend="aot_eager")
+        def f(x, y):
+            return x * y + x
+
+        x = torch.randn(4, requires_grad=True)
+        y = torch.randn(4, requires_grad=True)
+        out = f(x, y)
+        out.sum().backward()
+
+        self.assertEqual(x.grad, y + 1)
+        self.assertEqual(y.grad, x)
+
+    def test_backward_correctness_multiple_outputs(self):
+        """
+        Multiple outputs produce multiple tangents. The codegen should
+        handle all of them.
+        """
+
+        @torch.compile(backend="aot_eager")
+        def f(x):
+            return x * 2, x * 3
+
+        x = torch.randn(4, requires_grad=True)
+        out1, out2 = f(x)
+        (out1.sum() + out2.sum()).backward()
+
+        self.assertEqual(x.grad, torch.full((4,), 5.0))
+
+    def test_per_tangent_format_baked(self):
+        """
+        Each tangent should have its memory format baked into the
+        codegen as a separate constant.
+        """
+        with self._capture_codegen_source("process_tangents") as captured:
+
+            @torch.compile(backend="aot_eager")
+            def f(x, y):
+                return x + y, x * y
+
+            x = torch.randn(3, requires_grad=True)
+            y = torch.randn(3, requires_grad=True)
+            o1, o2 = f(x, y)
+            (o1.sum() + o2.sum()).backward()
+
+        self.assertEqual(len(captured), 1)
+        source = captured[0]
+        self.assertIn("_fmt_0", source)
+
+    def test_backward_with_non_differentiable_output(self):
+        """
+        When some outputs don't require grad, there should be fewer
+        tangents. Codegen should handle this correctly.
+        """
+
+        @torch.compile(backend="aot_eager")
+        def f(x, y):
+            return x * 2, y.detach()
+
+        x = torch.randn(4, requires_grad=True)
+        y = torch.randn(4, requires_grad=True)
+        out1, out2 = f(x, y)
+
+        self.assertTrue(out1.requires_grad)
+        self.assertFalse(out2.requires_grad)
+
+        out1.sum().backward()
+        self.assertEqual(x.grad, torch.full((4,), 2.0))
+
+    def test_codegen_source_structure(self):
+        """
+        Verify the structure of the generated source code.
+        """
+        with self._capture_codegen_source("process_tangents") as captured:
+
+            @torch.compile(backend="aot_eager")
+            def f(x):
+                return x + 1
+
+            x = torch.randn(4, requires_grad=True)
+            f(x).sum().backward()
+
+        self.assertEqual(len(captured), 1)
+        source = captured[0]
+        self.assertIn("all_args[:start]", source)
+        self.assertIn("all_args[end:]", source)
+        self.assertIn("isinstance", source)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/functorch/test_codegen_synthetic_base.py
+++ b/test/functorch/test_codegen_synthetic_base.py
@@ -85,7 +85,7 @@ class TestCodegenSyntheticBase(TestCase):
                 return a + b
 
             x = torch.randn(4)
-            out = f(x.view(-1), x.view(-1))
+            f(x.view(-1), x.view(-1))
 
         self.assertEqual(len(captured), 1)
 
@@ -131,7 +131,7 @@ class TestCodegenSyntheticBase(TestCase):
             a = x.view(2, 2)
             b = x.view(2, 2)
             compiled_f = aot_function(f, nop)
-            out = compiled_f(a, b)
+            compiled_f(a, b)
 
         self.assertEqual(len(captured), 1)
         source = captured[0]

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2319,6 +2319,7 @@ def _backward_prologue_functional(
     maybe_subclass_metadata: SubclassMeta | None,
     flat_args: Sequence[Any],
     codegen_unwrap_fn: Callable[..., Any] | None = None,
+    codegen_process_tangent_fn: Callable[..., Any] | None = None,
 ) -> list[Any]:
     # Calling convention: we expect a grad_out passed to the backward:
     # - for every output of the fw that does *not* alias an input or graph intermediate
@@ -2515,25 +2516,34 @@ def _backward_prologue_functional(
             + unwrap(all_args[tangents_end_idx:])
         )
     else:
-        stack_traces = metadata.tangent_source_stack_traces or ()
-
-        all_args = [
-            (
-                AOTDispatchAutograd.process_runtime_tangent(
-                    t,
-                    metadata.subclass_tangent_meta[i - tangents_start_idx],
-                    tangent_idx=i - tangents_start_idx,
-                    tangent_desc=metadata.traced_tangents_descs[i - tangents_start_idx],
-                    compile_id_str=metadata.compile_id_str,
-                    tangent_stack_trace=(
-                        stack_traces[i - tangents_start_idx] if stack_traces else None
-                    ),
-                )[0]
-                if (tangents_start_idx <= i < tangents_end_idx)
-                else t
+        if codegen_process_tangent_fn is not None:
+            all_args = codegen_process_tangent_fn(
+                all_args, tangents_start_idx, tangents_end_idx
             )
-            for i, t in enumerate(all_args)
-        ]
+        else:
+            stack_traces = metadata.tangent_source_stack_traces or ()
+
+            all_args = [
+                (
+                    AOTDispatchAutograd.process_runtime_tangent(
+                        t,
+                        metadata.subclass_tangent_meta[i - tangents_start_idx],
+                        tangent_idx=i - tangents_start_idx,
+                        tangent_desc=metadata.traced_tangents_descs[
+                            i - tangents_start_idx
+                        ],
+                        compile_id_str=metadata.compile_id_str,
+                        tangent_stack_trace=(
+                            stack_traces[i - tangents_start_idx]
+                            if stack_traces
+                            else None
+                        ),
+                    )[0]
+                    if (tangents_start_idx <= i < tangents_end_idx)
+                    else t
+                )
+                for i, t in enumerate(all_args)
+            ]
 
     # Backward with forward inputs mutations is not supported in double backward.
     if (
@@ -3150,12 +3160,54 @@ class _AOTDispatchAutogradFunctionFactory:
 
         _codegen_bw_unwrap_fn = None
         _codegen_bw_wrap_fn = None
+        _codegen_process_tangent_fn = None
         if maybe_subclass_meta is not None:
             from .subclass_codegen import codegen_backward_subclass_fns
 
             _codegen_bw_unwrap_fn, _codegen_bw_wrap_fn = codegen_backward_subclass_fns(
                 grad_input_metas=maybe_subclass_meta.grad_input_metas,
             )
+
+        # Codegen tangent processing: for the non-subclass case, generate
+        # straight-line per-tangent coercion with baked-in memory formats.
+        if maybe_subclass_meta is None and fw_metadata.subclass_tangent_meta:
+            from .subclass_codegen import _compile_and_exec_source
+
+            tangent_metas = fw_metadata.subclass_tangent_meta
+            all_plain = all(isinstance(m, PlainTensorMeta) for m in tangent_metas)
+            if all_plain:
+                pt_lines = ["def _process_tangents(_coerce_, all_args, start, end):"]
+                pt_globals: dict[str, object] = {
+                    "torch": torch,
+                }
+                pt_lines.append("    result = list(all_args[:start])")
+                for i, meta in enumerate(tangent_metas):
+                    fmt_name = f"_fmt_{i}"
+                    pt_globals[fmt_name] = meta.memory_format
+                    pt_lines.append(f"    _t{i} = all_args[start + {i}]")
+                    pt_lines.append(
+                        f"    if isinstance(_t{i}, torch.Tensor): "
+                        f"_t{i} = _coerce_(_t{i}, {fmt_name})"
+                    )
+                    pt_lines.append(f"    result.append(_t{i})")
+                pt_lines.append("    result.extend(all_args[end:])")
+                pt_lines.append("    return result")
+                pt_source = "\n".join(pt_lines)
+
+                _codegen_pt_fn = _compile_and_exec_source(
+                    pt_source,
+                    pt_globals,
+                    "_process_tangents",
+                    "process_tangents",
+                )
+                _coerce_fn = coerce_to_expected_memory_format
+
+                def _codegen_process_tangent_fn(
+                    all_args: list[Any],
+                    start: int,
+                    end: int,
+                ) -> list[Any]:
+                    return _codegen_pt_fn(_coerce_fn, all_args, start, end)  # type: ignore[return-value]
 
         # Codegen for CompiledFunction.forward: emit straight-line TensorAlias
         # wrapping, _unsafe_view, and non-differentiable output collection with
@@ -3269,6 +3321,7 @@ class _AOTDispatchAutogradFunctionFactory:
             _lazy_backward_info = lazy_backward_info
             _bw_epilogue_wrap_fn = _codegen_bw_wrap_fn
             _bw_prologue_unwrap_fn = _codegen_bw_unwrap_fn
+            _bw_process_tangent_fn = _codegen_process_tangent_fn
             boxed_grads_call = True
 
             @staticmethod
@@ -3334,6 +3387,7 @@ class _AOTDispatchAutogradFunctionFactory:
                     CompiledFunction.maybe_subclass_metadata,
                     grad_args,
                     codegen_unwrap_fn=CompiledFunction._bw_prologue_unwrap_fn,
+                    codegen_process_tangent_fn=CompiledFunction._bw_process_tangent_fn,
                 )
                 rng_state.add_backward_args(ctx, all_args)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181438
* #181436
* #181271
* #181250
* #181120

Replace the per-tangent process_runtime_tangent loop in
_backward_prologue_functional with a codegen'd function that inlines
memory format coercion for each tangent with baked-in format metadata.

For PlainTensorMeta tangents (the common non-subclass case), the
generated function eliminates multiple isinstance checks, function
calls, and the itertools.chain.from_iterable overhead per tangent.
SubclassCreationMeta tangents fall back to the generic function.

Generated code for 1 tangent:

    def _process_tangents(_coerce_, all_args, start, end):
        result = list(all_args[:start])
        _t0 = all_args[start + 0]
        if isinstance(_t0, torch.Tensor): _t0 = _coerce_(_t0, _fmt_0)
        result.append(_t0)
        result.extend(all_args[end:])
        return result

process_runtime_tangent step in isolation (us/call):

| Case | Before (loop) | After (codegen) | Speedup |
|---|---|---|---|
| 1 tangent, 5 total args | 0.58 us | 0.32 us | 1.9x |
| 3 tangents, 7 total args | 1.04 us | 0.53 us | 2.0x |
| 5 tangents, 10 total args | 1.47 us | 0.75 us | 2.0x |
| 10 tangents, 15 total args | 2.49 us | 1.31 us | 1.9x |