### PR TITLE
Fix typos across torch codebase

### DIFF
--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -168,7 +168,7 @@ class CoordescTuner:
     def get_neighbour_values(self, name, orig_val, radius=None, include_self=False):
         """
         Get neighbour values in 'radius' steps. The original value is not
-        returned as it's own neighbour.
+        returned as its own neighbour.
         """
         if radius is None:
             radius = 1

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -560,7 +560,7 @@ def _check_reduction_value(reduction: str):
         raise ValueError(f"{reduction} is not a valid value for reduction")
 
 
-# This helper function maps depreciated arguments, "size_average" and "reduce"
+# This helper function maps deprecated arguments, "size_average" and "reduce"
 # to their corresponding "reduction" string argument
 def _get_string_reduction_arg(*, size_average: bool | None, reduce: bool | None) -> str:
     if size_average is None:

--- a/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
+++ b/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
@@ -593,7 +593,7 @@ class ModelReportVisualizer:
             ...     feature_filter="per_channel_min", module_fqn_filter="block1"
             ... )
             >>> # outputs line plot of per_channel_min information for all
-            >>> # modules in block1 of model each channel gets it's own line,
+            >>> # modules in block1 of model each channel gets its own line,
             >>> # and it's plotted across the in-order modules on the x-axis
         """
         # checks if we have matplotlib and let's user know to install it if don't

--- a/torch/csrc/api/include/torch/nn/pimpl.h
+++ b/torch/csrc/api/include/torch/nn/pimpl.h
@@ -34,7 +34,7 @@ class ModuleHolder : torch::detail::ModuleHolderIndicator {
  public:
   using ContainedType = Contained;
 
-  /// Default constructs the contained module if if has a default constructor,
+  /// Default constructs the contained module if it has a default constructor,
   /// else produces a static error.
   ///
   /// NOTE: This uses the behavior of template

--- a/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
+++ b/torch/csrc/distributed/c10d/TCPStoreLibUvBackend.cpp
@@ -385,7 +385,7 @@ class UvTcpServer : public UvTcpSocket {
 
   static void missingOnConnect(int status) {
     C10D_THROW_ERROR(
-        DistStoreError, "Socket accepted byt onConnect callback missing");
+        DistStoreError, "Socket accepted but onConnect callback missing");
   }
 
   static void on_new_connection(uv_stream_t* server, int status) {

--- a/torch/distributed/_pycute/layout.py
+++ b/torch/distributed/_pycute/layout.py
@@ -139,7 +139,7 @@ LayoutProfile: TypeAlias = tuple[object, ...] | Layout | None
 LayoutInput: TypeAlias = Layout | IntTuple | tuple[object, ...] | None
 
 
-# Make Layout from a list of layouts (each layout it's own mode in the result)
+# Make Layout from a list of layouts (each layout its own mode in the result)
 def make_layout(*layouts: Layout | tuple[Layout, ...]) -> Layout:
     if len(layouts) == 1 and not is_layout(layouts[0]):
         layouts = layouts[0]

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -221,7 +221,7 @@ class TracerBase:
             check_for_mutable_operation(target_fn, args, kwargs)
 
         node = self.graph.create_node(kind, target, args, kwargs, name, type_expr)
-        # TODO node_name_to_scope will be depreciated in favor of
+        # TODO node_name_to_scope will be deprecated in favor of
         # node.meta['nn_module_stack']
         self.node_name_to_scope[node.name] = (
             self.scope.module_path,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181439

Fix common typos in comments, docstrings, and error messages:
- "it's" → "its" for possessive form (coordinate_descent_tuner.py,
  model_report_visualizer.py, layout.py)
- "depreciated" → "deprecated" (nn/functional/__init__.py, proxy.py)
- "if if" → "if it" (pimpl.h)
- "byt" → "but" (TCPStoreLibUvBackend.cpp)

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo