### PR TITLE
[MPS] Migrate gelu and gelu_backward to metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -256,14 +256,6 @@ REGISTER_UNARY_OP(gelu_tanh, float, float);
 REGISTER_UNARY_OP(gelu_tanh, half, half);
 REGISTER_UNARY_OP(gelu_tanh, bfloat, bfloat);
 
-REGISTER_UNARY_VEC4_OP(gelu, float, float);
-REGISTER_UNARY_VEC4_OP(gelu, half, half);
-REGISTER_UNARY_VEC4_OP(gelu, bfloat, bfloat);
-
-REGISTER_UNARY_VEC4_OP(gelu_tanh, float, float);
-REGISTER_UNARY_VEC4_OP(gelu_tanh, half, half);
-REGISTER_UNARY_VEC4_OP(gelu_tanh, bfloat, bfloat);
-
 struct gelu_backward_functor {
   template <typename T>
   inline T operator()(const T grad, const T self) {

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -232,7 +232,8 @@ struct gelu_functor {
   template <typename T>
   inline T operator()(const T x) {
     const float xf = float(x);
-    return static_cast<T>(0.5f * xf * (1.0f + ::c10::metal::erf(xf * M_SQRT1_2_F)));
+    return static_cast<T>(
+        0.5f * xf * (1.0f + ::c10::metal::erf(xf * M_SQRT1_2_F)));
   }
 };
 

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -227,3 +227,73 @@ struct silu_backward_functor {
 REGISTER_BINARY_OP(silu_backward, float, float);
 REGISTER_BINARY_OP(silu_backward, half, half);
 REGISTER_BINARY_OP(silu_backward, bfloat, bfloat);
+
+struct gelu_functor {
+  template <typename T>
+  inline T operator()(const T x) {
+    const float xf = float(x);
+    return static_cast<T>(0.5f * xf * (1.0f + ::c10::metal::erf(xf * M_SQRT1_2_F)));
+  }
+};
+
+struct gelu_tanh_functor {
+  template <typename T>
+  inline T operator()(const T x) {
+    const float xf = float(x);
+    constexpr float kBeta = M_SQRT2_F * M_2_SQRTPI_F * 0.5f;
+    constexpr float kKappa = 0.044715f;
+    const float inner = kBeta * (xf + kKappa * xf * xf * xf);
+    return static_cast<T>(0.5f * xf * (1.0f + ::metal::tanh(inner)));
+  }
+};
+
+REGISTER_UNARY_OP(gelu, float, float);
+REGISTER_UNARY_OP(gelu, half, half);
+REGISTER_UNARY_OP(gelu, bfloat, bfloat);
+
+REGISTER_UNARY_OP(gelu_tanh, float, float);
+REGISTER_UNARY_OP(gelu_tanh, half, half);
+REGISTER_UNARY_OP(gelu_tanh, bfloat, bfloat);
+
+REGISTER_UNARY_VEC4_OP(gelu, float, float);
+REGISTER_UNARY_VEC4_OP(gelu, half, half);
+REGISTER_UNARY_VEC4_OP(gelu, bfloat, bfloat);
+
+REGISTER_UNARY_VEC4_OP(gelu_tanh, float, float);
+REGISTER_UNARY_VEC4_OP(gelu_tanh, half, half);
+REGISTER_UNARY_VEC4_OP(gelu_tanh, bfloat, bfloat);
+
+struct gelu_backward_functor {
+  template <typename T>
+  inline T operator()(const T grad, const T self) {
+    const float xf = float(self);
+    constexpr float kPdfCoeff = M_2_SQRTPI_F * M_SQRT1_2_F * 0.5f;
+    const float cdf = 0.5f * (1.0f + ::c10::metal::erf(xf * M_SQRT1_2_F));
+    const float pdf = kPdfCoeff * ::metal::exp(-0.5f * xf * xf);
+    return static_cast<T>(float(grad) * (cdf + xf * pdf));
+  }
+};
+
+struct gelu_tanh_backward_functor {
+  template <typename T>
+  inline T operator()(const T grad, const T self) {
+    const float xf = float(self);
+    constexpr float kBeta = M_SQRT2_F * M_2_SQRTPI_F * 0.5f;
+    constexpr float kKappa = 0.044715f;
+    const float x_sq = xf * xf;
+    const float inner = kBeta * (xf + kKappa * xf * x_sq);
+    const float th = ::metal::tanh(inner);
+    const float dth = 1.0f - th * th;
+    const float dinner = kBeta * (1.0f + 3.0f * kKappa * x_sq);
+    const float dgelu = 0.5f * (1.0f + th) + 0.5f * xf * dth * dinner;
+    return static_cast<T>(float(grad) * dgelu);
+  }
+};
+
+REGISTER_BINARY_OP(gelu_backward, float, float);
+REGISTER_BINARY_OP(gelu_backward, half, half);
+REGISTER_BINARY_OP(gelu_backward, bfloat, bfloat);
+
+REGISTER_BINARY_OP(gelu_tanh_backward, float, float);
+REGISTER_BINARY_OP(gelu_tanh_backward, half, half);
+REGISTER_BINARY_OP(gelu_tanh_backward, bfloat, bfloat);

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -230,7 +230,7 @@ REGISTER_BINARY_OP(silu_backward, bfloat, bfloat);
 
 template <typename T>
 static inline float gelu_dispatch_tanh(float x) {
-  if constexpr (::metal::is_same_v<T, float>) {
+  if IF_CONSTEXPR (::metal::is_same_v<T, float>) {
     return ::metal::tanh(x);
   } else {
     return ::metal::fast::tanh(x);

--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -228,6 +228,15 @@ REGISTER_BINARY_OP(silu_backward, float, float);
 REGISTER_BINARY_OP(silu_backward, half, half);
 REGISTER_BINARY_OP(silu_backward, bfloat, bfloat);
 
+template <typename T>
+static inline float gelu_dispatch_tanh(float x) {
+  if constexpr (::metal::is_same_v<T, float>) {
+    return ::metal::tanh(x);
+  } else {
+    return ::metal::fast::tanh(x);
+  }
+}
+
 struct gelu_functor {
   template <typename T>
   inline T operator()(const T x) {
@@ -244,7 +253,7 @@ struct gelu_tanh_functor {
     constexpr float kBeta = M_SQRT2_F * M_2_SQRTPI_F * 0.5f;
     constexpr float kKappa = 0.044715f;
     const float inner = kBeta * (xf + kKappa * xf * xf * xf);
-    return static_cast<T>(0.5f * xf * (1.0f + ::metal::tanh(inner)));
+    return static_cast<T>(0.5f * xf * (1.0f + gelu_dispatch_tanh<T>(inner)));
   }
 };
 
@@ -275,7 +284,7 @@ struct gelu_tanh_backward_functor {
     constexpr float kKappa = 0.044715f;
     const float x_sq = xf * xf;
     const float inner = kBeta * (xf + kKappa * xf * x_sq);
-    const float th = ::metal::tanh(inner);
+    const float th = gelu_dispatch_tanh<T>(inner);
     const float dth = 1.0f - th * th;
     const float dinner = kBeta * (1.0f + 3.0f * kKappa * x_sq);
     const float dgelu = 0.5f * (1.0f + th) + 0.5f * xf * dth * dinner;

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -1,6 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/Activation.h>
+#include <ATen/native/Gelu.h>
 #include <ATen/native/mps/OperationUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -436,191 +437,13 @@ TORCH_IMPL_FUNC(threshold_backward_out_mps)
   }
 }
 
-static MPSGraphTensor* normcdf(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
-  // (1.0f + erf(x*SQRT1_2)) * 0.5f;
-  auto dataType = [inputTensor dataType];
-  const float SQRT1_2 = 0.707106781186547524400844362104849039f;
-  MPSGraphTensor* sqrt1_2 = [mpsGraph constantWithScalar:SQRT1_2 shape:@[ @1 ] dataType:dataType];
-  MPSGraphTensor* onef = [mpsGraph constantWithScalar:1.0f shape:@[ @1 ] dataType:dataType];
-  MPSGraphTensor* halff = [mpsGraph constantWithScalar:0.5f shape:@[ @1 ] dataType:dataType];
-
-  MPSGraphTensor* erfTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor secondaryTensor:sqrt1_2 name:nil];
-  erfTensor = [mpsGraph erfWithTensor:erfTensor name:nil];
-  erfTensor = [mpsGraph additionWithPrimaryTensor:erfTensor secondaryTensor:onef name:nil];
-  erfTensor = [mpsGraph multiplicationWithPrimaryTensor:erfTensor secondaryTensor:halff name:nil];
-
-  return erfTensor;
-}
-
-static MPSGraphTensor* tanh(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
-  // 0.5 * x * (1 + text{Tanh}(sqrt(2 / pi) * (x + 0.044715 * x^3)))
-  auto dataType = [inputTensor dataType];
-  constexpr float kBeta = M_SQRT2 * M_2_SQRTPI * 0.5;
-  constexpr float kKappa = 0.044715f;
-  MPSGraphTensor* betaf = [mpsGraph constantWithScalar:kBeta shape:@[ @1 ] dataType:dataType];
-  MPSGraphTensor* kappaf = [mpsGraph constantWithScalar:kKappa shape:@[ @1 ] dataType:dataType];
-  MPSGraphTensor* onef = [mpsGraph constantWithScalar:1.0f shape:@[ @1 ] dataType:dataType];
-  MPSGraphTensor* halff = [mpsGraph constantWithScalar:0.5f shape:@[ @1 ] dataType:dataType];
-  MPSGraphTensor* erfTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                        secondaryTensor:inputTensor
-                                                                   name:nil];
-  erfTensor = [mpsGraph multiplicationWithPrimaryTensor:erfTensor secondaryTensor:inputTensor name:nil];
-  erfTensor = [mpsGraph multiplicationWithPrimaryTensor:erfTensor secondaryTensor:kappaf name:nil];
-  erfTensor = [mpsGraph additionWithPrimaryTensor:erfTensor secondaryTensor:inputTensor name:nil];
-  erfTensor = [mpsGraph multiplicationWithPrimaryTensor:erfTensor secondaryTensor:betaf name:nil];
-  erfTensor = [mpsGraph tanhWithTensor:erfTensor name:nil];
-  erfTensor = [mpsGraph additionWithPrimaryTensor:erfTensor secondaryTensor:onef name:nil];
-  erfTensor = [mpsGraph multiplicationWithPrimaryTensor:erfTensor secondaryTensor:halff name:nil];
-
-  return erfTensor;
-}
-
 TORCH_IMPL_FUNC(gelu_out_mps)(const Tensor& self, std::string_view approximate, const Tensor& output) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryCachedGraph;
-  TORCH_CHECK(output.is_mps());
-  TORCH_CHECK(c10::isFloatingType(self.scalar_type()), "GELU is only implemented for floating types");
-
-  // Empty output
-  if (output.numel() == 0)
-    return;
-
-  auto approximate_type = get_gelutype_enum(approximate);
-  MPSStream* stream = getCurrentMPSStream();
-
-  bool executeGatherOp = needsGather(output);
-  Tensor output_;
-  if (executeGatherOp) {
-    output_ = at::empty_like(output, MemoryFormat::Contiguous);
-  }
-
-  @autoreleasepool {
-    const auto key = "gelu_out_mps" + getTensorsStringKey({self}) + ":" + gelutype_to_string(approximate_type);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), getMPSShape(self));
-
-      MPSGraphTensor* outputTensor = nil;
-      if (approximate_type == GeluType::Tanh) {
-        outputTensor = tanh(mpsGraph, inputTensor);
-      } else {
-        outputTensor = normcdf(mpsGraph, inputTensor);
-      }
-      outputTensor = [mpsGraph multiplicationWithPrimaryTensor:outputTensor secondaryTensor:inputTensor name:nil];
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder =
-        Placeholder(cachedGraph->outputTensor_, executeGatherOp ? output_ : output, nil, false);
-
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-
-  if (executeGatherOp) {
-    output.copy_(output_);
-  }
+  GeluKernel(kMPS, *this, get_gelutype_enum(approximate));
 }
 
 TORCH_IMPL_FUNC(gelu_backward_out_mps)
 (const Tensor& grad, const Tensor& self, std::string_view approximate, const Tensor& grad_input) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryGradCachedGraph;
-
-  // Empty output
-  if (self.numel() == 0) {
-    return;
-  }
-
-  bool executeGatherOp = needsGather(grad_input);
-  Tensor grad_input_;
-  if (executeGatherOp) {
-    grad_input_ = at::empty_like(grad_input, MemoryFormat::Contiguous);
-  }
-
-  auto approximate_type = get_gelutype_enum(approximate);
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    const auto key =
-        "gelu_backward_out_mps" + getTensorsStringKey({self, grad}) + ":" + gelutype_to_string(approximate_type);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      auto dataType = getMPSDataType(self);
-
-      MPSGraphTensor* gradTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad), getMPSShape(grad));
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, dataType, getMPSShape(self));
-      MPSGraphTensor* outputTensor = nil;
-      if (approximate_type == GeluType::Tanh) {
-        constexpr float kBeta = M_SQRT2 * M_2_SQRTPI * (0.5f);
-        constexpr float kKappa = 0.044715f;
-        MPSGraphTensor* betaf = [mpsGraph constantWithScalar:kBeta shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* kappaf = [mpsGraph constantWithScalar:kKappa shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* halff = [mpsGraph constantWithScalar:0.5f shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* onef = [mpsGraph constantWithScalar:1.0f shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* threef = [mpsGraph constantWithScalar:3.0f shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* x_sq = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                         secondaryTensor:inputTensor
-                                                                    name:nil];
-        MPSGraphTensor* x_cube = [mpsGraph multiplicationWithPrimaryTensor:x_sq secondaryTensor:inputTensor name:nil];
-        MPSGraphTensor* inner = [mpsGraph multiplicationWithPrimaryTensor:kappaf secondaryTensor:x_cube name:nil];
-        inner = [mpsGraph additionWithPrimaryTensor:inner secondaryTensor:inputTensor name:nil];
-        inner = [mpsGraph multiplicationWithPrimaryTensor:betaf secondaryTensor:inner name:nil];
-        MPSGraphTensor* tanhInner = [mpsGraph tanhWithTensor:inner name:nil];
-        MPSGraphTensor* left = [mpsGraph multiplicationWithPrimaryTensor:halff secondaryTensor:inputTensor name:nil];
-        MPSGraphTensor* right = [mpsGraph additionWithPrimaryTensor:onef secondaryTensor:tanhInner name:nil];
-        MPSGraphTensor* left_derivative = [mpsGraph multiplicationWithPrimaryTensor:halff
-                                                                    secondaryTensor:right
-                                                                               name:nil];
-        MPSGraphTensor* tanh_derivative = [mpsGraph multiplicationWithPrimaryTensor:tanhInner
-                                                                    secondaryTensor:tanhInner
-                                                                               name:nil];
-        tanh_derivative = [mpsGraph subtractionWithPrimaryTensor:onef secondaryTensor:tanh_derivative name:nil];
-        MPSGraphTensor* inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:threef
-                                                                     secondaryTensor:kappaf
-                                                                                name:nil];
-        inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:inner_derivative secondaryTensor:x_sq name:nil];
-        inner_derivative = [mpsGraph additionWithPrimaryTensor:inner_derivative secondaryTensor:onef name:nil];
-        inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:betaf secondaryTensor:inner_derivative name:nil];
-        MPSGraphTensor* right_derivative = [mpsGraph multiplicationWithPrimaryTensor:left
-                                                                     secondaryTensor:tanh_derivative
-                                                                                name:nil];
-        right_derivative = [mpsGraph multiplicationWithPrimaryTensor:right_derivative
-                                                     secondaryTensor:inner_derivative
-                                                                name:nil];
-        outputTensor = [mpsGraph additionWithPrimaryTensor:left_derivative secondaryTensor:right_derivative name:nil];
-        outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor secondaryTensor:outputTensor name:nil];
-      } else {
-        constexpr float kBeta = M_2_SQRTPI * M_SQRT1_2 * (0.5);
-        MPSGraphTensor* halff = [mpsGraph constantWithScalar:-0.5f shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* betaf = [mpsGraph constantWithScalar:kBeta shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* cdf = normcdf(mpsGraph, inputTensor);
-        MPSGraphTensor* pdfMul = [mpsGraph squareWithTensor:inputTensor name:nil];
-        pdfMul = [mpsGraph multiplicationWithPrimaryTensor:pdfMul secondaryTensor:halff name:nil];
-        pdfMul = [mpsGraph exponentWithTensor:pdfMul name:nil];
-        MPSGraphTensor* pdf = [mpsGraph multiplicationWithPrimaryTensor:pdfMul secondaryTensor:betaf name:nil];
-        pdf = [mpsGraph multiplicationWithPrimaryTensor:inputTensor secondaryTensor:pdf name:nil];
-        pdf = [mpsGraph additionWithPrimaryTensor:pdf secondaryTensor:cdf name:nil];
-        outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor secondaryTensor:pdf name:nil];
-      }
-
-      newCachedGraph->gradOutputTensor_ = gradTensor;
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->gradInputTensor_ = outputTensor;
-    });
-
-    Placeholder gradPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad);
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder =
-        Placeholder(cachedGraph->gradInputTensor_, executeGatherOp ? grad_input_ : grad_input);
-
-    auto feeds = dictionaryFromPlaceholders(gradPlaceholder, selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-
-  if (executeGatherOp) {
-    grad_input.copy_(grad_input_);
-  }
+  GeluBackwardKernel(kMPS, *this, get_gelutype_enum(approximate));
 }
 
 TORCH_IMPL_FUNC(glu_out_mps)(const Tensor& self, const int64_t dim, const Tensor& output) {

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -16,6 +16,7 @@
 #include <ATen/ops/sigmoid.h>
 #include <ATen/ops/sigmoid_native.h>
 #endif
+#include <ATen/native/Gelu.h>
 #include <ATen/native/mps/kernels/Activation.h>
 #include <fmt/format.h>
 
@@ -130,6 +131,16 @@ static void leaky_relu_backward_kernel(TensorIteratorBase& iter, const Scalar& n
   lib.exec_binary_kernel(iter, "leaky_relu_backward", negative_slope);
 }
 
+static void gelu_kernel(TensorIteratorBase& iter, GeluType approximate) {
+  const char* name = (approximate == GeluType::Tanh) ? "gelu_tanh" : "gelu";
+  lib.exec_unary_kernel(iter, name, /*alpha=*/std::nullopt, /*scalar_arg_type=*/std::nullopt, /*supports_vec4=*/true);
+}
+
+static void gelu_backward_kernel(TensorIteratorBase& iter, GeluType approximate) {
+  const char* name = (approximate == GeluType::Tanh) ? "gelu_tanh_backward" : "gelu_backward";
+  lib.exec_binary_kernel(iter, name);
+}
+
 REGISTER_DISPATCH(hardshrink_stub, hardshrink_kernel);
 REGISTER_DISPATCH(softshrink_stub, softshrink_kernel);
 REGISTER_DISPATCH(shrink_backward_stub, shrink_backward_kernel);
@@ -143,5 +154,7 @@ REGISTER_DISPATCH(leaky_relu_stub, leaky_relu_kernel);
 REGISTER_DISPATCH(leaky_relu_backward_stub, leaky_relu_backward_kernel);
 REGISTER_DISPATCH(silu_stub, silu_kernel);
 REGISTER_DISPATCH(silu_backward_stub, silu_backward_kernel);
+REGISTER_DISPATCH(GeluKernel, gelu_kernel);
+REGISTER_DISPATCH(GeluBackwardKernel, gelu_backward_kernel);
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -133,7 +133,7 @@ static void leaky_relu_backward_kernel(TensorIteratorBase& iter, const Scalar& n
 
 static void gelu_kernel(TensorIteratorBase& iter, GeluType approximate) {
   const char* name = (approximate == GeluType::Tanh) ? "gelu_tanh" : "gelu";
-  lib.exec_unary_kernel(iter, name, /*alpha=*/std::nullopt, /*scalar_arg_type=*/std::nullopt, /*supports_vec4=*/true);
+  lib.exec_unary_kernel(iter, name);
 }
 
 static void gelu_backward_kernel(TensorIteratorBase& iter, GeluType approximate) {


### PR DESCRIPTION
Partially answers the concerns in issue #181213 migrating the gelu and gelu_backward including the tanh approximation to metal kernels. Below will be some implementation considerations as well as benchmarking for the implementation.

For bf16/fp16 registrations for gelu_tanh use metal::fast::tanh as an experimental sweep concluded that numerically the discrepancy between the fast and precise modes used will be confined to reasonably low absolute errors. Note the intermediate computations are still done in fp32 but tanh uses a faster approximation. Attaching the summary plots for both dtypes in backward and forward configurations displaying both the absolute error and the corresponding discrepancy in ULPs for the storage dtype is scanned between [-10.0, 10.0]. The region where the function approaches zero displays the largest discrepancy in ULPs due to the values being clustered more tightly together near zero especially for fp16. However the absolute error between the modes in that region stays around 10^-5 so the overall effect from the approximation seems well behaved by the experiment.

<img width="1454" height="1394" alt="gelu_tanh_fast_accuracy" src="https://github.com/user-attachments/assets/f5f7959c-f13c-46a7-bbef-2f14345e2ac6" />

<img width="1454" height="1394" alt="gelu_tanh_backwards_fast_accuracy" src="https://github.com/user-attachments/assets/be0fc354-24ab-4a9c-837c-2ff332d077d2" />

### Benchmarks

The fresh benchmarks on a M5 Max. Extended the shapes with a couple of example shapes from realistic workloads to get a more comprehensive view. The benchmarking script below and a graph summarizing the delta after measured both with the per-op sync as well as the tight encode loop with a single sync (per-batch in the script). As was discussed below in the thread this affects the performance of MPSGraph as commitAndContinue gives it some freedom to optimize how the computations are dispatched.

```
import argparse
import statistics
import time
import torch
import torch.nn.functional as F

DTYPE_TAG = {torch.float32: "f32", torch.float16: "f16", torch.bfloat16: "bf16"}

BERT_SHAPES = [
    (1, 128, 4096),
    (1, 1024, 4096),
    (1, 4096, 4096),
    (4, 128, 4096),
    (4, 1024, 4096),
    (16, 128, 4096),
    (1, 8192, 8192),
    (4, 8192, 8192),
]

LLM_SHAPES = [
    (1, 2048, 11008),
    (1, 4096, 11008),
    (4, 2048, 13824),
]

MODES = ("none", "tanh")

parser = argparse.ArgumentParser()
parser.add_argument("--sync", choices=("per-iter", "per-batch"), default="per-iter")
parser.add_argument("--warmup", type=int, default=20)
parser.add_argument("--iters", type=int, default=300)
parser.add_argument("--samples", type=int, default=10)
args = parser.parse_args()


if args.sync == "per-iter":
    def time_op(fn):
        torch.mps.synchronize()
        t0 = time.perf_counter()
        for _ in range(args.iters):
            fn()
            torch.mps.synchronize()
        return (time.perf_counter() - t0) / args.iters * 1e6
else:
    def time_op(fn):
        torch.mps.synchronize()
        t0 = time.perf_counter()
        for _ in range(args.iters):
            fn()
        torch.mps.synchronize()
        return (time.perf_counter() - t0) / args.iters * 1e6


cases = []
for s in BERT_SHAPES:
    for mode in MODES:
        cases.append((s, torch.float32, mode))
for s in LLM_SHAPES:
    for dtype in (torch.float16, torch.bfloat16, torch.float32):
        for mode in MODES:
            cases.append((s, dtype, mode))


ops = []
for shape, dtype, mode in cases:
    x = torch.randn(*shape, device="mps", dtype=dtype)
    fwd = lambda x=x, m=mode: F.gelu(x, approximate=m)
    xg = torch.randn(*shape, device="mps", dtype=dtype, requires_grad=True)
    g = torch.ones_like(xg)

    def bwd(xg=xg, g=g, m=mode):
        xg.grad = None
        F.gelu(xg, approximate=m).backward(g)

    tag = f"{mode[0]}_{DTYPE_TAG[dtype]}"
    ops.append((shape, tag, fwd, bwd))

for _, _, fwd, bwd in ops:
    for _ in range(args.warmup):
        fwd()
    for _ in range(args.warmup):
        bwd()

fwd_samples = {(s, t): [] for s, t, _, _ in ops}
bwd_samples = {(s, t): [] for s, t, _, _ in ops}
for _ in range(args.samples):
    for s, t, fwd, bwd in ops:
        fwd_samples[(s, t)].append(time_op(fwd))
        bwd_samples[(s, t)].append(time_op(bwd))

print(f"{'shape':<22} {'tag':<8} {'fwd_us':>10} {'fwd_sd':>8} {'bwd_us':>10} {'bwd_sd':>8}",
      flush=True)
for shape, dtype, mode in cases:
    tag = f"{mode[0]}_{DTYPE_TAG[dtype]}"
    f = fwd_samples[(shape, tag)]
    b = bwd_samples[(shape, tag)]
    print(f"{str(shape):<22} {tag:<8} "
          f"{statistics.mean(f):>10.1f} {statistics.stdev(f):>8.1f} "
          f"{statistics.mean(b):>10.1f} {statistics.stdev(b):>8.1f}",
          flush=True)
```

<img width="2700" height="1755" alt="gelu_perf_bars_sync_nosync" src="https://github.com/user-attachments/assets/d80cbf33-c0ff-4386-a0ec-66e482bce4f1" />

To summarize the results the metal op implementation seems good enough here after the recent changes added for the vectorized versions being registered for both forward and backward calls. As discussed below the commitAndContinue mechanism makes comparing the methods a bit difficult due to metal kernels and MPSGraph handling it differently. So the "true performance" depends a bit on the context the op is used and is likely going to be somewhere between the two sets of measurements (synced vs. no sync) presented here. But overall the benefit seems to be towards the metal kernel with maybe the backward pass no sync measurements being more on the fence. However especially smaller shapes the metal kernel shows benefits. Also for the LLM inspired shapes there seems to a trend towards the metal kernel being slightly but consistently better than the pre-existing implementation.
