### PR TITLE
[nativert] Allow caching weights across different executions of the same model (#181453)

### DIFF
--- a/torch/nativert/executor/Weights.cpp
+++ b/torch/nativert/executor/Weights.cpp
@@ -58,10 +58,12 @@ Weights::Weights(
     std::function<bool(const std::string&)> skipDtypeCheck,
     std::shared_ptr<std::unordered_map<
         std::string,
-        std::shared_ptr<torch::nativert::TensorMeta>>> maybeNewWeightsMeta)
+        std::shared_ptr<torch::nativert::TensorMeta>>> maybeNewWeightsMeta,
+    const std::unordered_map<std::string, at::Tensor>* cachedWeights)
     : graph_(graph),
       weightsMeta_(graph->weightsMeta()),
       version_(globalVersion_++),
+      hasCachedWeights_(cachedWeights != nullptr),
       skipSizeCheck_(std::move(skipSizeCheck)),
       skipDtypeCheck_(std::move(skipDtypeCheck)) {
   auto loadAndInsert = [&](const std::string& tensorName,
@@ -73,6 +75,15 @@ Weights::Weights(
                                std::string,
                                std::shared_ptr<torch::nativert::TensorMeta>>>
                                maybeNewWeightsMeta) {
+    if (cachedWeights) {
+      auto cacheIt = cachedWeights->find(tensorName);
+      if (cacheIt != cachedWeights->end()) {
+        VLOG(1) << "Using cached weight for: " << tensorName;
+        allValues_[tensorName] = cacheIt->second;
+        return;
+      }
+    }
+
     auto pathIt = tensorPaths.find(tensorName);
     TORCH_CHECK(
         pathIt != tensorPaths.end(),

--- a/torch/nativert/executor/Weights.h
+++ b/torch/nativert/executor/Weights.h
@@ -49,6 +49,8 @@ class Weights {
       std::shared_ptr<std::unordered_map<
           std::string,
           std::shared_ptr<torch::nativert::TensorMeta>>> maybeNewWeightsMeta =
+          nullptr,
+      const std::unordered_map<std::string, at::Tensor>* cachedWeights =
           nullptr);
 
   at::Tensor at(const std::string& name) const;
@@ -107,6 +109,10 @@ class Weights {
     constFoldedValues_.insert_or_assign(n, std::move(iv));
   }
 
+  bool hasCachedWeights() const {
+    return hasCachedWeights_;
+  }
+
   std::string toString() const;
 
   WeightVersion version() const {
@@ -140,6 +146,8 @@ class Weights {
 
   // every instance of Weight has a unique version number
   static WeightVersion globalVersion_;
+
+  bool hasCachedWeights_ = false;
 
   std::function<bool(const std::string&)> skipSizeCheck_;
   std::function<bool(const std::string&)> skipDtypeCheck_;


### PR DESCRIPTION
Summary:

Add an optional `cachedWeights` parameter to the nativert `Weights` constructor. When provided, the constructor checks the cache before loading each tensor from the model archive. If the tensor is found in the cache, it is used directly (zero-copy, no disk I/O). If not found, the existing disk-loading path runs as before.

This enables callers to pre-populate weights (e.g., from a previous model load or a shared memory region) and reuse them across multiple instantiations of the same model, avoiding redundant deserialization and device transfers.

All existing call sites are unchanged — the new parameter defaults to nullptr, preserving the current behavior.

Test Plan: buck build fbcode//caffe2/torch/nativert/executor:Weights

Differential Revision: D102396243


