### PR TITLE
Add checkout-mode input to setup-linux action

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: Submodule checkout mode passed to checkout-pytorch (default "recursive", use "false" for test jobs).
     required: false
     default: 'recursive'
+  checkout-mode:
+    description: Checkout mode passed to checkout-pytorch (one of "normal", "blobless", "treeless").
+    required: false
+    default: 'treeless'
   github-token:
     description: GITHUB_TOKEN, needed to retrieve the workflow job id.
     required: false
@@ -69,7 +73,7 @@ runs:
       uses: pytorch/pytorch/.github/actions/checkout-pytorch@main
       with:
         no-sudo: true
-        checkout-mode: treeless
+        checkout-mode: ${{ inputs.checkout-mode }}
         submodules: ${{ inputs.submodules }}
 
     - name: Parse ref


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #181457
* #181456
* #181459
* __->__ #181455

Make the partial-clone filter passed to checkout-pytorch configurable
instead of hardcoding `treeless`. Default stays at `treeless` so all
existing callers (lint, build, test) keep their cheap clone; jobs that
need a full clone (e.g. docs, which walks per-file git history) can
opt in by passing `checkout-mode: normal`.

Authored with Claude.