### PR TITLE
Use full clone for docs build to fix nightly hang

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -92,9 +92,9 @@ jobs:
             # Let's try to figure out how this can be improved
             timeout-minutes: 360
           - docs_type: python
-            runner: ${{ inputs.runner_prefix }}linux.12xlarge
+            runner: ${{ inputs.runner_prefix }}linux.c7i.2xlarge
             # It takes less than 30m to finish python docs unless there are issues
-            timeout-minutes: 120
+            timeout-minutes: 45
     # Set a fixed name for this job instead of using the current matrix-generated name, i.e. build-docs (cpp, linux.12xlarge, 180)
     # The current name requires updating the database last docs push query from test-infra every time the matrix is updated
     name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}
@@ -111,6 +111,11 @@ jobs:
 
       - name: Setup Linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main
+        with:
+          # Docs build runs `git log --follow` per page for "Created/Updated"
+          # dates; a treeless clone triggers lazy fetches and makes the build
+          # hang. Use a full checkout for this job.
+          checkout-mode: normal
 
       - name: Login to ECR
         uses: ./.github/actions/ecr-login
@@ -297,6 +302,8 @@ jobs:
           compiler: ${{ inputs.compiler }}
           cuda-version: ${{ inputs.cuda-version }}
           submodules: false
+          # See comment in the EC2 build-docs job above.
+          checkout-mode: normal
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -93,8 +93,7 @@ jobs:
             timeout-minutes: 360
           - docs_type: python
             runner: ${{ inputs.runner_prefix }}linux.c7i.2xlarge
-            # It takes less than 30m to finish python docs unless there are issues
-            timeout-minutes: 45
+            timeout-minutes: 60
     # Set a fixed name for this job instead of using the current matrix-generated name, i.e. build-docs (cpp, linux.12xlarge, 180)
     # The current name requires updating the database last docs push query from test-infra every time the matrix is updated
     name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}
@@ -290,7 +289,7 @@ jobs:
             timeout-minutes: 360
           - docs_type: python
             runner: ${{ inputs.runner_prefix }}l-x86iavx512-16-128
-            timeout-minutes: 45
+            timeout-minutes: 60
     name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}
     steps:
       - name: Setup Linux

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -156,7 +156,8 @@ html_theme_options = {
         },
     ],
     "show_version_warning_banner": True,
-    "llm_disabled": "true",
+    "llm_disabled": os.environ.get("CI") and os.environ.get("WITH_PUSH") != "true",
+    "llm_generate_full": "false",
     "icon_links": [
         {
             "name": "X",
@@ -2595,10 +2596,10 @@ def _skip_git_dates_on_ci(app):
     The pytorch theme runs 2 git subprocess calls per page to display
     "Created/Updated" dates. On CI preview builds this is wasteful (dates
     aren't needed) and problematic (treeless clones make git log slow).
-    Release builds previously kept date lookups, but on CI's treeless clones
-    the git log calls are too slow (~5600 subprocess calls for ~2800 pages).
+    Release builds (WITH_PUSH=true) keep the original behavior so dates
+    appear in published docs.
     """
-    if not os.environ.get("CI"):
+    if not os.environ.get("CI") or os.environ.get("WITH_PUSH") == "true":
         return
 
     try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181456
* #181459

The docs build calls `git log --follow` per page (via the theme's Created/Updated date footer). On a treeless clone (--filter=tree:0, the setup-linux default) those calls trigger lazy blob/tree fetches from origin over HTTPS, taking tens of seconds per file and hanging the nightly docs-push job for ~45 min.
The pull/trunk path was unaffected only because it ran on the OSDC/ARC container path with `WITH_PUSH=false`, which tripped the existing CI carve-out and skipped the git-log calls entirely.

Switching the docs job to a normal (non-partial) checkout makes `git log --follow` purely local, so we can keep the `WITH_PUSH=true` behavior that publishes Created/Updated dates and revert the two bandaid commits that bumped the runner size and timeout to mask the hang (7e6f239, 8dabde).

### Verification

Hangin in treeless mode:

```
time git log --follow --format='%ad' --date='format:%b %d, %Y' -- /var/lib/jenkins/workspace/docs/source/accelerator.md
Apr 13, 2026
Apr 12, 2026
Apr 10, 2026
Mar 25, 2026
Mar 23, 2026
Mar 20, 2026
Mar 19, 2026
Mar 13, 2026
Nov 13, 2025
Nov 12, 2025
Nov 07, 2025
```

Working fine in normal full checkout:

```
time git log --follow --format='%ad' --date='format:%b %d, %Y' -- /tmp/pytorch/docs/source/accelerator.md
Apr 13, 2026
Apr 12, 2026
Apr 10, 2026
Mar 25, 2026
Mar 23, 2026
Mar 20, 2026
Mar 19, 2026
Mar 13, 2026
Nov 13, 2025
Nov 12, 2025
Nov 07, 2025
Aug 08, 2025
Aug 07, 2025
Aug 06, 2025
Jul 22, 2025
Jul 11, 2025
Jun 25, 2025
Jun 23, 2025
Jun 12, 2025
Apr 25, 2025
Dec 12, 2024
Dec 11, 2024
Dec 11, 2024
Oct 27, 2024

real	0m1.928s
user	0m1.699s
sys	0m0.230s
```

### Testing

https://github.com/pytorch/pytorch/actions/runs/24916325902/job/72969042645 builds the doc fine, it failed because there is no clean way to push `git push -u origin HEAD:pytorchbot/temp-branch-py -f` from PR, only when the change is landed can that be done, not because of timing out


Authored with Claude.