### PR TITLE
[DO NOT MERGE] Use local setup-linux action for docs EC2 job

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -110,7 +110,7 @@ jobs:
               cd docs && make html && make coverage
 
       - name: Setup Linux
-        uses: pytorch/pytorch/.github/actions/setup-linux@main
+        uses: ./.github/actions/setup-linux
         with:
           # Docs build runs `git log --follow` per page for "Created/Updated"
           # dates; a treeless clone triggers lazy fetches and makes the build


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181457
* #181456
* #181459
* #181455

Temporarily point the EC2 build-docs job at ./.github/actions/setup-linux
so the new `checkout-mode` input can be exercised from this branch
without waiting for it to land on main. Drop this commit before merging.

Authored with Claude.