### PR TITLE
[Inductor] Call latest c_shim version for versioned fallback ops

### DIFF
--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6357,9 +6357,7 @@ class ExternKernel(InputsKernel):
                 # already-compiled artifacts.
                 from torchgen.aoti.fallback_ops import inductor_fallback_ops
 
-                version_info = inductor_fallback_ops.get(
-                    f"aten.{kernel.__name__}", {}
-                )
+                version_info = inductor_fallback_ops.get(f"aten.{kernel.__name__}", {})
                 latest_version = max(
                     (int(v[1:]) for v in version_info if v.startswith("v")),
                     default=1,

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6351,6 +6351,21 @@ class ExternKernel(InputsKernel):
                     if kernel._overloadname == "default"
                     else kernel.__name__.replace(".", "_")
                 )
+                # If the op has a versioned c_shim entry, call the latest _v{N}
+                # variant so new AOTI artifacts match the current op schema. The
+                # unversioned shim is retained solely for BC with existing
+                # already-compiled artifacts.
+                from torchgen.aoti.fallback_ops import inductor_fallback_ops
+
+                version_info = inductor_fallback_ops.get(
+                    f"aten.{kernel.__name__}", {}
+                )
+                latest_version = max(
+                    (int(v[1:]) for v in version_info if v.startswith("v")),
+                    default=1,
+                )
+                if latest_version > 1:
+                    opname = f"{opname}_v{latest_version}"
                 self.cpp_kernel_name = f"at::_ops::{opname}::call"
             else:
                 self.cpp_kernel_name = kernel._schema.name


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #181448
* __->__ #181458
* #181383

When an aten fallback op has a versioned c_shim entry in
torchgen/aoti/fallback_ops.py (e.g. {"v2": [...]}), the cpp wrapper
was still emitting the unversioned shim name with the current-schema
args. The unversioned shim keeps the pre-v2 signature for backward
compatibility with already-compiled artifacts, so new AOTI compilations
failed to link when the op had been extended with new args.

ExternKernel.set_cpp_kernel_name now looks up inductor_fallback_ops and
appends _v{N} (max N) to the opname for new compilations. The
unversioned shim is retained solely for BC with existing artifacts.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo