### PR TITLE
Revert "Change runner to linux.12xlarge for nightly doc push (#181256)"

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -92,9 +92,9 @@ jobs:
             # Let's try to figure out how this can be improved
             timeout-minutes: 360
           - docs_type: python
-            runner: ${{ inputs.runner_prefix }}linux.12xlarge
+            runner: ${{ inputs.runner_prefix }}linux.c7i.2xlarge
             # It takes less than 30m to finish python docs unless there are issues
-            timeout-minutes: 120
+            timeout-minutes: 45
     # Set a fixed name for this job instead of using the current matrix-generated name, i.e. build-docs (cpp, linux.12xlarge, 180)
     # The current name requires updating the database last docs push query from test-infra every time the matrix is updated
     name: build-docs-${{ matrix.docs_type }}-${{ inputs.push }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -156,7 +156,8 @@ html_theme_options = {
         },
     ],
     "show_version_warning_banner": True,
-    "llm_disabled": "true",
+    "llm_disabled": os.environ.get("CI") and os.environ.get("WITH_PUSH") != "true",
+    "llm_generate_full": "false",
     "icon_links": [
         {
             "name": "X",
@@ -2595,10 +2596,10 @@ def _skip_git_dates_on_ci(app):
     The pytorch theme runs 2 git subprocess calls per page to display
     "Created/Updated" dates. On CI preview builds this is wasteful (dates
     aren't needed) and problematic (treeless clones make git log slow).
-    Release builds previously kept date lookups, but on CI's treeless clones
-    the git log calls are too slow (~5600 subprocess calls for ~2800 pages).
+    Release builds (WITH_PUSH=true) keep the original behavior so dates
+    appear in published docs.
     """
-    if not os.environ.get("CI"):
+    if not os.environ.get("CI") or os.environ.get("WITH_PUSH") == "true":
         return
 
     try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #181456
* __->__ #181459

and "Allow more time and bigger runner for docs workflow (#181427)"

These two commits bumped the docs runner size and timeout to mask the
nightly hang on a treeless clone. With the docs job switched to a full
checkout in a follow-up commit, the hang root cause goes away and the
runner/timeout bandaids are no longer needed.

Reverting these is a prerequisite for restoring the WITH_PUSH=true
carve-out in conf.py so published docs keep their Created/Updated date
footer.

Reverts:
  7e6f239a8cb Change runner to linux.12xlarge for nightly doc push (#181256)
  8dabde398906 Allow more time and bigger runner for docs workflow (#181427)

Authored with Claude.