### PR TITLE
[Inductor] Skip max_persistent_rblock for combo per_subkernel_blocks

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1262,6 +1262,7 @@ class ComboKernelPDLTests(TestCase):
         self.assertEqual(out_eager, out_compiled)
 
 
+@instantiate_parametrized_tests
 class ComboKernelTestsMaxAutotune(TestCase):
     def setUp(self):
         super().setUp()
@@ -1483,7 +1484,15 @@ class ComboKernelTestsMaxAutotune(TestCase):
         self.assertEqual([[0], [1]], [g["member_indices"] for g in groups])
 
     @requires_gpu_and_triton
-    def test_combo_per_subkernel_blocks_skips_max_persistent_rblock(self):
+    @parametrize("per_subkernel", [True, False])
+    def test_combo_max_persistent_rblock_gated_on_per_subkernel(self, per_subkernel):
+        """The combo-only HIP filter (XBLOCK * max_persistent_rblock <= 4096)
+        from PR #175671 guards a shared-XBLOCK blowup that only exists in
+        the legacy combo path. Under per_subkernel_blocks=True each sub has
+        its own XBLOCK_n so the filter must be skipped (key absent). Under
+        per_subkernel_blocks=False the combo-max value must be set as before.
+        """
+
         def fn(a, b):
             return a.sum(-1), b.sum(-1)
 
@@ -1491,11 +1500,17 @@ class ComboKernelTestsMaxAutotune(TestCase):
             torch.rand(32, 256, device=GPU_TYPE),
             torch.rand(32, 1024, device=GPU_TYPE),
         ]
-        out_eager = fn(*inps)
-        out_compiled, code = run_and_get_code(torch.compile(fn), *inps)
+        with torch._inductor.config.patch(
+            {"combo_kernel_per_subkernel_blocks": per_subkernel}
+        ):
+            out_eager = fn(*inps)
+            out_compiled, code = run_and_get_code(torch.compile(fn), *inps)
         self.assertEqual(out_eager, out_compiled)
         joined = " ".join(code)
-        self.assertNotIn("'max_persistent_rblock'", joined)
+        if per_subkernel:
+            self.assertNotIn("'max_persistent_rblock'", joined)
+        else:
+            self.assertIn("'max_persistent_rblock': 1024", joined)
 
     @requires_gpu_and_triton
     def test_combo_kernel_coordesc_tunes_largest_subkernel_first(self):

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1483,6 +1483,21 @@ class ComboKernelTestsMaxAutotune(TestCase):
         self.assertEqual([[0], [1]], [g["member_indices"] for g in groups])
 
     @requires_gpu_and_triton
+    def test_combo_per_subkernel_blocks_skips_max_persistent_rblock(self):
+        def fn(a, b):
+            return a.sum(-1), b.sum(-1)
+
+        inps = [
+            torch.rand(32, 256, device=GPU_TYPE),
+            torch.rand(32, 1024, device=GPU_TYPE),
+        ]
+        out_eager = fn(*inps)
+        out_compiled, code = run_and_get_code(torch.compile(fn), *inps)
+        self.assertEqual(out_eager, out_compiled)
+        joined = " ".join(code)
+        self.assertNotIn("'max_persistent_rblock'", joined)
+
+    @requires_gpu_and_triton
     def test_combo_kernel_coordesc_tunes_largest_subkernel_first(self):
         def fn(a, b, c):
             return (

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -747,14 +747,15 @@ class ComboKernel(Kernel):
         # The max_persistent_rblock mirrors how R0_BLOCK is computed in
         # codegen_static_numels_sub_kernel() for persistent reductions.
         max_persistent_rblock = 0
-        for sub in self.sub_kernels:
-            if sub.persistent_reduction:
-                for tree in sub.range_trees:
-                    if tree.is_reduction:
-                        simplified_numel = V.graph.sizevars.simplify(tree.numel)
-                        if isinstance(simplified_numel, (Integer, int)):
-                            val = next_power_of_2(int(simplified_numel))
-                            max_persistent_rblock = max(max_persistent_rblock, val)
+        if not config.combo_kernel_per_subkernel_blocks:
+            for sub in self.sub_kernels:
+                if sub.persistent_reduction:
+                    for tree in sub.range_trees:
+                        if tree.is_reduction:
+                            simplified_numel = V.graph.sizevars.simplify(tree.numel)
+                            if isinstance(simplified_numel, (Integer, int)):
+                                val = next_power_of_2(int(simplified_numel))
+                                max_persistent_rblock = max(max_persistent_rblock, val)
 
         inductor_meta = {
             "grid_type": dispatch.grid_expr.__name__,

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -748,14 +748,18 @@ class ComboKernel(Kernel):
         # codegen_static_numels_sub_kernel() for persistent reductions.
         max_persistent_rblock = 0
         if not config.combo_kernel_per_subkernel_blocks:
-            for sub in self.sub_kernels:
-                if sub.persistent_reduction:
-                    for tree in sub.range_trees:
-                        if tree.is_reduction:
-                            simplified_numel = V.graph.sizevars.simplify(tree.numel)
-                            if isinstance(simplified_numel, (Integer, int)):
-                                val = next_power_of_2(int(simplified_numel))
-                                max_persistent_rblock = max(max_persistent_rblock, val)
+            max_persistent_rblock = max(
+                (
+                    next_power_of_2(int(simplified))
+                    for sub in self.sub_kernels
+                    if sub.persistent_reduction
+                    for tree in sub.range_trees
+                    if tree.is_reduction
+                    for simplified in [V.graph.sizevars.simplify(tree.numel)]
+                    if isinstance(simplified, (Integer, int))
+                ),
+                default=0,
+            )
 
         inductor_meta = {
             "grid_type": dispatch.grid_expr.__name__,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181460

This PR enables combo kernels under `combo_kernel_per_subkernel_blocks=True` to skip the `max_persistent_rblock` cap that was added by #175671 for the shared-XBLOCK combo path. Each sub-kernel has its own `XBLOCK_n` in per_subkernel mode, so the cross-sub blowup mode the filter was guarding against cannot occur - and applying the combo-max value over-filtered configs that compile fine for the smaller-rnumel sub-kernels (e.g. `XBLOCK=8`/`64` with `num_warps=1`). 


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos