### PR TITLE
Add type annotations to torch/_linalg_utils.py

### DIFF
--- a/torch/_linalg_utils.py
+++ b/torch/_linalg_utils.py
@@ -1,12 +1,14 @@
-# mypy: allow-untyped-defs
 """Various linear algebra utility methods for internal use."""
 
 import torch
 from torch import Tensor
 
 
-def is_sparse(A):
-    """Check if tensor A is a sparse COO tensor. All other sparse storage formats (CSR, CSC, etc...) will return False."""
+def is_sparse(A: Tensor) -> bool:
+    """Check if tensor A is a sparse COO tensor.
+
+    All other sparse storage formats (CSR, CSC, etc...) will return False.
+    """
     if isinstance(A, torch.Tensor):
         return A.layout == torch.sparse_coo
 
@@ -16,7 +18,7 @@ def is_sparse(A):
     raise TypeError(error_str)
 
 
-def get_floating_dtype(A):
+def get_floating_dtype(A: Tensor) -> torch.dtype:
     """Return the floating point dtype of tensor A.
 
     Integer types map to float32.
@@ -45,12 +47,12 @@ def bform(X: Tensor, A: Tensor | None, Y: Tensor) -> Tensor:
     return matmul(X.mT, matmul(A, Y))
 
 
-def qform(A: Tensor | None, S: Tensor):
+def qform(A: Tensor | None, S: Tensor) -> Tensor:
     """Return quadratic form :math:`S^T A S`."""
     return bform(S, A, S)
 
 
-def basis(A):
+def basis(A: Tensor) -> Tensor:
     """Return orthogonal basis of A columns."""
     return torch.linalg.qr(A).Q
 


### PR DESCRIPTION
Annotates `is_sparse`, `get_floating_dtype`, `basis`, and `qform` with parameter and return types, and removes the `# mypy: allow-untyped-defs` suppressor now that the file is fully typed. Also wraps an overlong one-line docstring in `is_sparse` to comply with B950.
