### PR TITLE
[MPS] Workaround  MetalPerformancePrimitives bug for F.linear on M5+

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -7,12 +7,17 @@
 #include <ATen/ops/linear_backward_native.h>
 #include <ATen/ops/linear_native.h>
 
+// MTLGPUFamilyApple10 is only defined in the macOS 26+ SDK.
+#if !defined(__MAC_26_0)
+static constexpr auto MTLGPUFamilyApple10 = static_cast<MTLGPUFamily>(1010);
+#endif
+
 namespace at::native {
 
 using namespace mps;
 
 // MPSNDArrayMatrixMultiplication and MPSGraph matrixMultiplication produce
-// non-deterministic results for >2D fp16/bf16 inputs on Apple M5+ (Apple10 // GPU family).
+// non-deterministic results for >2D fp16/bf16 inputs on Apple M5+ (Apple10 GPU family).
 // Flatten to 2D to work around the issue (See https://github.com/pytorch/pytorch/issues/180776 )
 static bool needs_nd_workaround(const Tensor& input) {
   static const bool is_m5_or_newer = [MPSDevice::getInstance()->device() supportsFamily:MTLGPUFamilyApple10];

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -11,33 +11,40 @@ namespace at::native {
 
 using namespace mps;
 
+// MPSNDArrayMatrixMultiplication and MPSGraph matrixMultiplication produce
+// non-deterministic results for >2D fp16/bf16 inputs on Apple M5+ (Apple10 // GPU family).
+// Flatten to 2D to work around the issue (See https://github.com/pytorch/pytorch/issues/180776 )
+static bool needs_nd_workaround(const Tensor& input) {
+  static const bool is_m5_or_newer = [MPSDevice::getInstance()->device() supportsFamily:MTLGPUFamilyApple10];
+  return input.dim() > 2 && is_m5_or_newer && (input.scalar_type() == kHalf || input.scalar_type() == kBFloat16);
+}
+
 static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const Tensor& bias, Tensor& output) {
   bool is_bias_defined = bias.defined();
 
-  MPSStream* mpsStream = getCurrentMPSStream();
-  id<MTLDevice> device = MPSDevice::getInstance()->device();
+  auto mpsStream = getCurrentMPSStream();
+  auto device = MPSDevice::getInstance()->device();
 
   const std::string key = "mps_linear" + getTensorsStringKey({input, weight, bias}, true, true);
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       mpsStream->endKernelCoalescing();
 
-      id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
-      id<MTLCommandBuffer> commandBuffer = mpsStream->commandBuffer();
+      auto computeEncoder = mpsStream->commandEncoder();
+      auto commandBuffer = mpsStream->commandBuffer();
 
-      MPSDataType mpsDataType = getMPSDataType(weight.scalar_type());
+      const auto mpsDataType = getMPSDataType(weight.scalar_type());
 
       auto inputNDArray = getMPSNDArray(input, input.sizes(), input.strides());
       auto outNDArray = getMPSNDArray(output, output.sizes(), output.strides());
 
-      id<MTLBuffer> weightBuf = getMTLBufferStorage(weight);
-      MPSNDArrayDescriptor* weightDesc = [MPSNDArrayDescriptor descriptorWithDataType:mpsDataType
-                                                                                shape:getMPSShape(weight.sizes())];
+      auto weightBuf = getMTLBufferStorage(weight);
+      auto weightDesc = [MPSNDArrayDescriptor descriptorWithDataType:mpsDataType shape:getMPSShape(weight.sizes())];
       weightDesc.preferPackedRows = YES;
       [weightDesc transposeDimension:0 withDimension:1];
-      MPSNDArray* weightNDArray = [[[MPSNDArray alloc] initWithBuffer:weightBuf
-                                                               offset:weight.storage_offset() * weight.element_size()
-                                                           descriptor:weightDesc] autorelease];
+      auto weightNDArray = [[[MPSNDArray alloc] initWithBuffer:weightBuf
+                                                        offset:weight.storage_offset() * weight.element_size()
+                                                    descriptor:weightDesc] autorelease];
 
       if (is_bias_defined) {
         auto biasNDArray = getMPSNDArray(bias, bias.sizes(), bias.strides());
@@ -113,12 +120,19 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
     return output;
   }
 
-  // No-graph execution causes nonsense if these are non-contiguous.
-  const bool is_contiguous = input.is_contiguous() && weight.is_contiguous() && bias.is_contiguous();
   const bool is_complex = input.is_complex() || weight.is_complex() || (is_bias_defined && bias.is_complex());
 
+  // No-graph execution causes nonsense if these are non-contiguous.
+  const bool is_contiguous = input.is_contiguous() && weight.is_contiguous() && bias.is_contiguous();
+
   if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) && is_contiguous && !is_complex) {
-    _mps_linear_nograph(input, weight, bias, output);
+    if (needs_nd_workaround(input) && (!is_bias_defined || bias.dim() <= 1)) {
+      auto input2d = input.flatten(0, -2);
+      auto output2d = output.flatten(0, -2);
+      _mps_linear_nograph(input2d, weight, bias, output2d);
+    } else {
+      _mps_linear_nograph(input, weight, bias, output);
+    }
     // Squeeze last dim of 1D linear
     return weight_arg.dim() != 1 ? output : output.squeeze(-1);
   }
@@ -147,6 +161,10 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
         // workaround to improve the performance with 3D+ inputs
         doReshape =
             input_size.size() > 2 && input_size[0] > 1 && input_size[1] >= 1 && input_size[1] <= 32 && bias.dim() <= 1;
+      }
+      // Non-deterministic results for >2D fp16/bf16 on Apple10+
+      if (!doReshape) {
+        doReshape = needs_nd_workaround(input);
       }
       auto inputFlattened = doReshape ? [mpsGraph flatten2DTensor:inputTensor axis:-1 name:nil] : inputTensor;
       auto outputTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:inputFlattened

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1530,6 +1530,25 @@ class TestMPS(TestCaseMPS):
 
         self.assertEqual(out_cpu, out_mps)
 
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    @parametrize("shape", [(2, 13, 1024), (6, 6, 634), (1, 3, 28, 315),
+                           (1, 12, 4, 512), (1, 1, 5, 6, 1024)])
+    @parametrize("transposed_weight", [False, True])
+    def test_linear_nd_determinism(self, dtype, shape, transposed_weight):
+        # Regression test for https://github.com/pytorch/pytorch/issues/180776
+        # F.linear on MPS with >2D fp16/bf16 inputs and no bias produced
+        # different results across consecutive calls.
+        # transposed_weight=True forces the MPSGraph path (non-contiguous weight).
+        h = shape[-1]
+        x = torch.randn(shape, dtype=dtype, device="mps")
+        if transposed_weight:
+            w = torch.randn(h, h, dtype=dtype, device="mps").t()
+        else:
+            w = torch.randn(h, h, dtype=dtype, device="mps")
+        first = F.linear(x, w).clone()
+        second = F.linear(x, w).clone()
+        self.assertEqual(first, second, atol=0, rtol=0)
+
     def test_uniform(self):
         low = torch.zeros(5, 5, requires_grad=True)
         high = (torch.ones(5, 5) * 3).requires_grad_()


### PR DESCRIPTION
`MPSNDArrayMatrixMultiplication` and `MPSGraph matrixMultiplication:` produce non-deterministic results for >2D fp16/bf16 inputs on Apple10 GPUs (M5).

Work around this in `F.linear` by flattening the input to 2D before the matmul on affected hardware/dtype combinations, on both the nograph and MPSGraph code paths.

At some point attempted to fix this by migrating Linear to MPP on MacOS-26, which works great on M5, but performance is 2X lower than MPS on M4

Fixes https://github.com/pytorch/pytorch/issues/180776

🤖 Generated with [Claude Code](https://claude.com/claude-code)