### PR TITLE
[ROCm] Remove ROCm-specific skip for test_python_ref, add OpInfo-level skips for ihfftn/ihfft2 float16

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -70,7 +70,6 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     skipIfTorchInductor,
     suppress_warnings,
-    TEST_WITH_ROCM,
     TEST_WITH_TORCHDYNAMO,
     TEST_WITH_TORCHINDUCTOR,
     TestCase,
@@ -737,12 +736,6 @@ class TestCommon(TestCase):
         # In this test, primTorch refs call into the refs namespace
         # For example, a ref with torch.foo in it will calls refs.foo instead
         # Direct calls to refs and prims are not affected
-        if (
-            TEST_WITH_ROCM
-            and (op.name == "_refs.fft.ihfftn" or op.name == "_refs.fft.ihfft2")
-            and dtype == torch.float16
-        ):
-            self.skipTest("Skipped on ROCm")
         self._ref_test_helper(lambda: TorchRefsMode(strict=True), device, dtype, op)
 
     # Tests that experimental Python References perform the same computation

--- a/torch/testing/_internal/opinfo/definitions/fft.py
+++ b/torch/testing/_internal/opinfo/definitions/fft.py
@@ -824,6 +824,16 @@ python_ref_db: list[OpInfo] = [
                 dtypes=(torch.float16,),
                 device_type="cuda",
             ),
+            # AssertionError: Reference result was farther (0.10395266714717796) from the precise
+            # computation than the torch result was (0.10251794906889385)
+            # See https://github.com/pytorch/pytorch/pull/170856 for more details.
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestCommon",
+                "test_python_ref",
+                dtypes=(torch.float16,),
+                device_type="cuda",
+            ),
             # AssertionError: Reference result was farther (0.0953431016138116) from the precise
             # computation than the torch result was (0.09305490684430734)
             DecorateInfo(
@@ -916,6 +926,16 @@ python_ref_db: list[OpInfo] = [
                 unittest.skip("Skipped!"),
                 "TestCommon",
                 "test_python_ref_executor",
+                device_type="cuda",
+            ),
+            # AssertionError: Reference result was farther (0.10395266714717796) from the precise
+            # computation than the torch result was (0.10251794906889385)
+            # See https://github.com/pytorch/pytorch/pull/170856 for more details.
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestCommon",
+                "test_python_ref",
+                dtypes=(torch.float16,),
                 device_type="cuda",
             ),
         ],


### PR DESCRIPTION
FIXES #168813
FIXES #168814

### Investigation summary

### Relevant test snippet
```
722-    # Tests that experimental Python References perform the same computation
723-    # as the operators they reference, when operator calls in the torch
724-    # namespace are remapped to the refs namespace (torch.foo becomes refs.foo).
725-    @skipXPU
726-    @onlyNativeDeviceTypesAnd(["hpu"])
727-    @ops(python_ref_db)
728-    @skipIfTorchInductor("Takes too long for inductor")
729:    def test_python_ref(self, device, dtype, op):
730-        # In this test, primTorch refs call into the refs namespace
731-        # For example, a ref with torch.foo in it will calls refs.foo instead
732-        # Direct calls to refs and prims are not affected
733-        if (
734-            TEST_WITH_ROCM
735-            and (op.name == "_refs.fft.ihfftn" or op.name == "_refs.fft.ihfft2")
736-            and dtype == torch.float16
737-        ):
738-            self.skipTest("Skipped on ROCm")
739-        self._ref_test_helper(lambda: TorchRefsMode(strict=True), device, dtype, op)
```

### Command to reproduce
`$ PYTORCH_TEST_WITH_ROCM=1 python -m pytest pytorch/test/test_ops.py -k "test_python_ref and ihfftn" -v --no-header`

**Output WITH skipTest("Skipped on ROCm") in test/test_ops.py**:
`pytorch/test/test_ops.py::TestCommonCUDA::test_python_ref__refs_fft_ihfftn_cuda_float16 SKIPPED [0.0672s] (Skipped on ROCm)`

**Output WITHOUT skipTest("Skipped on ROCm") in test/test_ops.py**:
`FAILED [1.4508s] pytorch/test/test_ops.py::TestCommonCUDA::test_python_ref__refs_fft_ihfftn_cuda_float16 - Exception: tensor(False, device='cuda:0') is not true : Reference result was farther (0.10395266714717796) from the precise computation than the torch result was (0.10251794906889385)!`

### Diagnosis

Similar rationale as in PR https://github.com/pytorch/pytorch/pull/170856. The test fails on both NVIDIA CUDA and ROCm GPUs because the Python reference implementation uses a different normalization code path than the native torch operator.

	• Native torch (aten): fft_r2c(+norm) → conj → fft_c2c(+norm) — normalization is applied at each FFT step
	• Python reference (_refs): fft_r2c(no norm) → conj → fft_c2c(no norm) → fused norm — normalization factors are fused and applied once at the end via _apply_norm

The issue is the skip in `test_python_ref()` in `test/test_ops.py` for `_refs.fft.ihfftn` and `_refs.fft.ihfft2` with `float16` was ROCm-specific (see above code snippet), but the underlying failure is not only a ROCm issue.

### Solution

Remove the ROCm-specific skip for `test_python_ref` with `_refs.fft.ihfftn` and `_refs.fft.ihfft2` at `float16` dtype, and replace it with OpInfo-level skips that apply to all CUDA devices.

**Output AFTER my changes**:
`pytorch/test/test_ops.py::TestCommonCUDA::test_python_ref__refs_fft_ihfftn_cuda_float16 SKIPPED [0.0002s] (Skipped!)`

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang