### PR TITLE
Fix typos in comments: missing spaces between words

### DIFF
--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -505,7 +505,7 @@ class GuardManagerWrapper:
                 )
                 and config.assume_dunder_attributes_remain_unchanged
             ):
-                # Assumption: callers will not reassignthe attributes
+                # Assumption: callers will not reassign the attributes
                 #   func.__code__, func.__closure__, func.__defaults__, or func.__kwdefaults__.
                 # Mutating the objects those attributes point to is fine;
                 # rebinding the attribute itself is not.

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -674,7 +674,7 @@ from a multi-output view call"
                 )
             ) or (
                 # 2. If the output_type is alias_of_input, and no in-place view
-                #    operationthe was run on the input (base tensor).
+                #    operation was run on the input (base tensor).
                 #
                 # In this case, we need to check for metadata mutation because
                 # the runtime explicitly reconstructs the inputs, before actually


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181472

Fix two typos in comments where a space was missing between words:
"reassignthe" → "reassign the" and "operationthe" → "operation".

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98