### PR TITLE
[MPS] Clear MPSGraphCache in torch.mps.empty_cache()

### DIFF
--- a/aten/src/ATen/mps/MPSHooks.mm
+++ b/aten/src/ATen/mps/MPSHooks.mm
@@ -6,6 +6,7 @@
 #include <ATen/mps/MPSHooks.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/mps/MPSStream.h>
+#include <ATen/native/mps/OperationUtils.h>
 #include <c10/util/Logging.h>
 
 namespace at::mps {
@@ -90,6 +91,7 @@ void* MPSHooks::getDispatchQueue() const {
 
 void MPSHooks::emptyCache() const {
   at::mps::getIMPSAllocator()->emptyCache();
+  at::native::mps::MPSGraphCache::getInstance()->clear();
 }
 
 size_t MPSHooks::getCurrentAllocatedMemory() const {

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -389,6 +389,15 @@ struct MPSGraphCache {
     return static_cast<T*>(LookUp(key));
   }
 
+  void clear() {
+    dispatch_sync(serialQueue_, ^() {
+      for (const auto& i : cache_) {
+        delete i.second.cachedGraph_;
+      }
+      cache_.clear();
+    });
+  }
+
  private:
   MPSGraphCache() {
     serialQueue_ = dispatch_queue_create("cache queue", DISPATCH_QUEUE_SERIAL);


### PR DESCRIPTION
## Summary

`MPSGraphCache` is an unbounded singleton cache storing compiled `MPSGraph` objects keyed by tensor shape/dtype/operation signatures. For workloads with variable tensor shapes (e.g. GNN training with variable-size graphs, NLP with variable-length sequences, or any dynamic-shape workload), every unique shape produces a cache entry that may never be reused, causing Metal driver memory to grow without bound.

`torch.mps.empty_cache()` only cleared the MPS allocator pool, leaving the graph cache untouched — users had no way to reclaim the leaked memory short of killing the process.

**This change:**
1. Adds a `clear()` method to `MPSGraphCache` that safely deletes all cached graphs under the serial queue lock
2. Wires `MPSHooks::emptyCache()` to call `MPSGraphCache::clear()` alongside the existing allocator clear

Fixes #181213, #132596
Related: #164299, #152550

## Test plan

Tested on Apple M4 Max (macOS 15) with a variable-shape GNN training workload (batch_size=32, 315 batches/epoch where each batch has a unique graph topology).

| Stage | MPS driver memory |
|---|---|
| Before training | 9 MB |
| After 1 epoch (315 unique shapes) | 13,692 MB |
| After `torch.mps.empty_cache()` | **52 MB** |
| After epoch 2 | 14,730 MB |
| After 2nd `empty_cache()` | **52 MB** |

Memory measured via `torch.mps.driver_allocated_memory()`. The allocator-tracked memory (`current_allocated_memory()`) remained ~10 MB throughout — confirming the leak is in the graph cache, not the tensor allocator.

**Before this fix:** MPS driver memory grew ~14 GB/epoch with no reclaim path.
**After this fix:** `torch.mps.empty_cache()` drops driver memory from ~14 GB to 52 MB.

cc @malfet @kulinseth