### PR TITLE
[Test] Device-agnostic APIs and test fixes in test_repros.py (1/4)

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -105,11 +105,9 @@ if HAS_MSGSPEC:
     import msgspec
 
 
-HAS_OMEGACONG = importlib.util.find_spec("omegaconf")
-if HAS_OMEGACONG:
+HAS_OMEGACONF = importlib.util.find_spec("omegaconf")
+if HAS_OMEGACONF:
     from omegaconf import OmegaConf
-
-HAS_CUDA = torch.cuda.is_available()
 
 
 def exists(val):
@@ -978,7 +976,7 @@ class IncByTwo:
 
 
 class LRUCacheWarningTests(LoggingTestCase):
-    @requires_cuda
+    @unittest.skipUnless(torch.accelerator.is_available(), "requires accelerator")
     @make_logging_test(dynamo=logging.DEBUG)
     def test_lru_cache_warning_issued_during_tracing(self, records):
         prev_default = torch._C._get_default_device()
@@ -990,7 +988,7 @@ class LRUCacheWarningTests(LoggingTestCase):
                 torch.set_default_device(prev_default)
 
         self.addCleanup(_restore_default_device)
-        torch.set_default_device("cuda")
+        torch.set_default_device(torch.accelerator.current_accelerator().type)
 
         @torch.compile(backend="eager")
         def f(x):
@@ -6630,7 +6628,7 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
         opt_fn = torch.compile(fn, backend="eager")
         self.assertEqual(fn(x), opt_fn(x))
 
-    @unittest.skipIf(not HAS_OMEGACONG, "missing omegaconf package")
+    @unittest.skipIf(not HAS_OMEGACONF, "missing omegaconf package")
     def test_omegaconf_dictconfig(self):
         def fn(cfg, x):
             a = cfg["foo"].a * x
@@ -6650,7 +6648,7 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
         self.assertEqual(fn(config, x), opt_fn(config, x))
         self.assertEqual(cloned_config.baz, 4)
 
-    @unittest.skipIf(not HAS_OMEGACONG, "missing omegaconf package")
+    @unittest.skipIf(not HAS_OMEGACONF, "missing omegaconf package")
     def test_omegaconf_listconfig_contains(self):
         def fn(cfg, x):
             if 1 in cfg:
@@ -7173,18 +7171,27 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
 
         # Generate input once to ensure consistency across runs
         torch.manual_seed(54321)
-        torch.cuda.manual_seed_all(54321)
+        if torch.accelerator.is_available():
+            torch.get_device_module(
+                torch.accelerator.current_accelerator().type
+            ).manual_seed_all(54321)
         image_latent = torch.randn((2, 12, 16, 32, 32))
 
         torch.manual_seed(54321)
-        torch.cuda.manual_seed_all(54321)
+        if torch.accelerator.is_available():
+            torch.get_device_module(
+                torch.accelerator.current_accelerator().type
+            ).manual_seed_all(54321)
         expected = f(image_latent).sum()
 
         # https://github.com/pytorch/pytorch/issues/147171
         with torch._inductor.config.patch(fallback_random=True):
             for backend in ["eager", "aot_eager"]:
                 torch.manual_seed(54321)
-                torch.cuda.manual_seed_all(54321)
+                if torch.accelerator.is_available():
+                    torch.get_device_module(
+                        torch.accelerator.current_accelerator().type
+                    ).manual_seed_all(54321)
                 actual = torch.compile(backend=backend, fullgraph=True)(f)(
                     image_latent
                 ).sum()


### PR DESCRIPTION
## Summary
This PR makes test/dynamo/test_repros.py device-agnostic to support out-of-tree accelerator backends.

**Device-agnostic changes:**
- Replace `@requires_cuda` with `@unittest.skipUnless(torch.accelerator.is_available())` in `LRUCacheWarningTests`
- Replace `torch.set_default_device("cuda")` with `torch.set_default_device(torch.accelerator.current_accelerator().type)`
- Replace `torch.cuda.manual_seed_all()` with `torch.get_device_module(...).manual_seed_all()` in `test_dont_dce_rand`
**Cleanup:**
- Fix `HAS_OMEGACONG` typo → `HAS_OMEGACONF` (definition + 2 skip decorator references)
- Remove unused `HAS_CUDA = torch.cuda.is_available()` variable
## Split plan
Refactoring of `test/dynamo/test_repros.py` has been split into smaller, focused PRs to make review simpler:
- **PR 1 (this PR)** - Device-agnostic APIs + typo fix + dead code removal (Independent)
- **PR 2 (#180368)** - Replace CUDA APIs in ReproTestsDevice (Independent)
- **PR 3 (#181497)** - Move accelerator tests between classes (Depends on #180368)
- **PR 4 (#181498)** - Create ReproTestsAllDevices class (Depends on #181497)
## Test plan
- `TEST_CONFIG=cuda python test/run_test.py -i dynamo/test_repros` passes
- CPU tests pass

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @fffrog @albanD @mansiag05 @Lucaskabela @guilhermeleobas 