### PR TITLE
[dynamo] Fix scalar symbolic bit shift handling

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -526,6 +526,26 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         sample_input = torch.tensor([4, 4, 16, 32], dtype=torch.uint8)
         opt_fn(sample_input)
 
+    def test_lshift_scalar_dynamic(self):
+        def shift_left(x: int) -> int:
+            return 1 << x
+
+        opt_fn = torch.compile(
+            shift_left, fullgraph=True, dynamic=True, backend="eager"
+        )
+        self.assertEqual(opt_fn(1), 2)
+        self.assertEqual(opt_fn(5), 32)
+
+    def test_rshift_scalar_dynamic(self):
+        def shift_right(x: int) -> int:
+            return 64 >> x
+
+        opt_fn = torch.compile(
+            shift_right, fullgraph=True, dynamic=True, backend="eager"
+        )
+        self.assertEqual(opt_fn(2), 16)
+        self.assertEqual(opt_fn(4), 4)
+
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_symfloat_to_tensor(self):
         def f1(v):

--- a/test/test_sympy_utils.py
+++ b/test/test_sympy_utils.py
@@ -25,7 +25,9 @@ from torch.utils._sympy.functions import (
     Identity,
     Max as TorchSymMax,
     Min as TorchSymMin,
+    LShift,
     OpaqueUnaryFn_cos,
+    RShift,
     BitwiseFn_bitwise_and,
     simple_floordiv_gcd,
 )
@@ -983,6 +985,15 @@ class TestSympySolve(TestCase):
 
 
 class TestSympyFunctions(TestCase):
+    def test_shift_edges(self):
+        x = sympy.Symbol("x", integer=True)
+        self.assertEqual(LShift(x, 0), x)
+        self.assertEqual(RShift(x, 0), x)
+        with self.assertRaisesRegex(ValueError, "negative shift count"):
+            LShift(x, -1)
+        with self.assertRaisesRegex(ValueError, "negative shift count"):
+            RShift(x, -1)
+
     def test_pickle(self):
         x = OpaqueUnaryFn_cos(sympy.Symbol("a"))
         r = pickle.loads(pickle.dumps(x))

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -615,10 +615,7 @@ class LShift(sympy.Function):
 
     @classmethod
     def eval(cls, base, shift):
-        if shift.is_number:
-            if shift < 0:
-                raise ValueError("negative shift count")
-        elif shift.is_nonnegative is False:
+        if shift.is_negative:
             raise ValueError("negative shift count")
         return base * PowByNatural(sympy.Integer(2), shift)
 
@@ -628,10 +625,7 @@ class RShift(sympy.Function):
 
     @classmethod
     def eval(cls, base, shift):
-        if shift.is_number:
-            if shift < 0:
-                raise ValueError("negative shift count")
-        elif shift.is_nonnegative is False:
+        if shift.is_negative:
             raise ValueError("negative shift count")
         return FloorDiv(base, PowByNatural(sympy.Integer(2), shift))
 

--- a/torch/utils/_sympy/functions.py
+++ b/torch/utils/_sympy/functions.py
@@ -615,9 +615,12 @@ class LShift(sympy.Function):
 
     @classmethod
     def eval(cls, base, shift):
-        if shift < 0:
+        if shift.is_number:
+            if shift < 0:
+                raise ValueError("negative shift count")
+        elif shift.is_nonnegative is False:
             raise ValueError("negative shift count")
-        return base * 2**shift
+        return base * PowByNatural(sympy.Integer(2), shift)
 
 
 class RShift(sympy.Function):
@@ -625,9 +628,12 @@ class RShift(sympy.Function):
 
     @classmethod
     def eval(cls, base, shift):
-        if shift < 0:
+        if shift.is_number:
+            if shift < 0:
+                raise ValueError("negative shift count")
+        elif shift.is_nonnegative is False:
             raise ValueError("negative shift count")
-        return FloorDiv(base, 2**shift)
+        return FloorDiv(base, PowByNatural(sympy.Integer(2), shift))
 
 
 class MinMaxBase(Expr, LatticeOp):  # type: ignore[misc]


### PR DESCRIPTION
Fixes #119152.

## Summary

Dynamo could fail when tracing scalar `<<` or `>>` with `dynamic=True` because `LShift` and `RShift` compared symbolic shift counts directly against zero. For unknown symbolic counts, that can force a SymPy relational into a Python truth value.

This PR updates `LShift` and `RShift` to reject only shift counts that SymPy can prove are negative. Symbolic shift counts with unknown sign are preserved instead of failing during tracing. It also uses `PowByNatural` for the shift multiplier/divisor so symbolic bit shifts encode Python's non-negative integer shift-count semantics.

Also includes regression tests for scalar shifts with `dynamic=True`.

CC: @ezyang 

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @mlazos