### PR TITLE
[decomp] Fix torch.split decomposition for empty dim with nonzero split_size

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -607,6 +607,16 @@ class FakeTensorTest(TestCase):
         out_eager = fn(torch.empty((0,)))
         self.checkMetaProps(out_fake, out_eager)
 
+    def test_split_empty_dim(self):
+        def fn(x):
+            return torch.split(x, 2)[0]
+
+        with FakeTensorMode(), enable_python_dispatcher():
+            out_fake = fn(torch.empty((0,)))
+
+        out_eager = fn(torch.empty((0,)))
+        self.checkMetaProps(out_fake, out_eager)
+
     def test_as_strided_negative_stride_error(self):
         error = (
             r"as_strided: Negative strides are not supported at the "

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1449,9 +1449,7 @@ def split(self: Tensor, split_size: int, dim: int = 0) -> tuple[Tensor, ...]:
     if dim_size == 0:
         return (self.detach(),)
     if split_size == 0:
-        raise AssertionError(
-            f"split_size is 0 but dim_size is {dim_size}, expected 0"
-        )
+        raise AssertionError(f"split_size is 0 but dim_size is {dim_size}, expected 0")
     chunks = (dim_size + split_size - 1) // split_size
 
     # Avoid importing sympy at a module level

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1446,12 +1446,12 @@ def unsafe_split_with_sizes(
 def split(self: Tensor, split_size: int, dim: int = 0) -> tuple[Tensor, ...]:
     input_sizes = self.shape
     dim_size = input_sizes[dim]
-    if split_size == 0:
-        if dim_size != 0:
-            raise AssertionError(
-                f"split_size is 0 but dim_size is {dim_size}, expected 0"
-            )
+    if dim_size == 0:
         return (self.detach(),)
+    if split_size == 0:
+        raise AssertionError(
+            f"split_size is 0 but dim_size is {dim_size}, expected 0"
+        )
     chunks = (dim_size + split_size - 1) // split_size
 
     # Avoid importing sympy at a module level


### PR DESCRIPTION
## Summary

`torch.split` raises `IndexError` in `FakeTensorMode` when `dim_size == 0` and `split_size > 0`.

**Root cause:** In `torch/_decomp/decompositions.py`, when `dim_size == 0` and `split_size > 0`, `chunks = 0`, producing an empty `split_sizes` list. The subsequent `split_sizes[-1] = ...` then raises `IndexError: list assignment index out of range`.

**Fix:** Return early when `dim_size == 0`, consistent with the behavior of the real tensor path.

Fixes #181462

## Test plan

- Added `test_split_empty_dim` to `test/test_fake_tensor.py`
- Ran `test/test_fake_tensor.py`: 229 passed, 0 failed
- Ran `test/test_decomp.py -k split`: 181 passed, 0 failed