### PR TITLE
SymmetricMemory `get` API.

### DIFF
--- a/docs/source/symmetric_memory.md
+++ b/docs/source/symmetric_memory.md
@@ -93,6 +93,25 @@ pointer (if supported), and signal pads.
 The `empty` and `rendezvous` functions must be called in the same order on all
 ranks in the group.
 
+## One-sided get
+
+Symmetric memory also exposes a small one-sided `get` API for copying data from
+a peer's symmetric allocation into a local tensor:
+
+```python
+src = symm_mem.empty(1024, device=device)
+hdl = symm_mem.rendezvous(src, group)
+
+dst = torch.empty_like(src)
+symm_mem.get(dst, src, group, peer=1)
+```
+
+`src` identifies the symmetric allocation to read from on the peer rank.
+`dst` may be a regular CUDA tensor or another symmetric tensor. Both tensors
+must be contiguous, have the same dtype, be on the same device, and contain the
+same number of elements. The copy is issued on the current CUDA stream and
+returns `dst`.
+
 Then, collectives can be called on these tensors. For example, to perform a
 one-shot all-reduce:
 
@@ -390,6 +409,10 @@ inter-node communication are not affected.
 
 ```{eval-rst}
 .. autofunction:: rendezvous
+```
+
+```{eval-rst}
+.. autofunction:: get
 ```
 
 ```{eval-rst}

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -433,6 +433,30 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version((2, 28), "NCCL Symmetric Memory device API support from nccl 2.28")
+    @skip_if_lt_x_gpu(2)
+    def test_get(self):
+        symm_mem.set_backend("NCCL")
+        torch.cuda.set_device(self.rank)
+        c10d.all_reduce(torch.ones(1, device=self.device))
+        group = c10d.group.WORLD
+
+        dtype = torch.float
+        numel = 1024
+        src = symm_mem.empty(numel, dtype=dtype, device=self.device).fill_(self.rank)
+        dst = torch.empty_like(src)
+        symm_mem.rendezvous(src, group=group)
+        c10d.barrier()
+
+        if self.rank == 0:
+            ret = symm_mem.get(dst, src, group, peer=1)
+            self.assertIs(ret, dst)
+            torch.testing.assert_close(dst, torch.ones_like(dst))
+
+        c10d.barrier()
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
+    @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @requires_nccl_version(
         (2, 29, 7), "nccl_reduce_scatter_offset requires nccl 2.29.7"
     )

--- a/test/distributed/test_nvshmem.py
+++ b/test/distributed/test_nvshmem.py
@@ -290,6 +290,24 @@ class NVSHMEMSymmetricMemoryTest(MultiProcContinuousTest):
             # TODO: remove after we have wait_signal
             dist.barrier()
 
+    def test_get(self) -> None:
+        self._init_device()
+        group = dist.group.WORLD
+
+        dtype = torch.float
+        numel = 1024
+        src = symm_mem.empty(numel, dtype=dtype, device=self.device).fill_(self.rank)
+        dst = torch.empty_like(src)
+        symm_mem.rendezvous(src, group=group)
+        dist.barrier()
+
+        if self.rank == 0:
+            ret = symm_mem.get(dst, src, group, peer=1)
+            self.assertIs(ret, dst)
+            torch.testing.assert_close(dst, torch.ones_like(dst))
+
+        dist.barrier()
+
 
 @instantiate_parametrized_tests
 @requires_nvshmem()

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -367,6 +367,28 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
+    def test_get(self) -> None:
+        self._init_process()
+        group = dist.group.WORLD
+
+        dtype = torch.float
+        numel = 1024
+        src = symm_mem.empty(numel, dtype=dtype, device=self.device).fill_(self.rank)
+        dst = torch.empty_like(src)
+        symm_mem.rendezvous(src, group=group)
+        dist.barrier()
+
+        if self.rank == 0:
+            ret = symm_mem.get(dst, src, group, peer=1)
+            self.assertIs(ret, dst)
+            torch.testing.assert_close(dst, torch.ones_like(dst))
+
+        dist.barrier()
+
+    @skipIf(
+        not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
+    )
+    @skip_if_lt_x_gpu(2)
     def test_dispatcher_torchbind_symmetric_memory(self) -> None:
         self._init_process()
         group_name = dist.group.WORLD.group_name

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -551,12 +551,16 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
   m.def("nvshmem_put(Tensor(a!) tensor, int peer) -> ()");
   m.def("nvshmem_get(Tensor(a!) tensor, int peer) -> ()");
   m.def(
+      "nvshmem_get_out(Tensor(a!) dst, Tensor src, int peer, str group_name) -> Tensor(a!)");
+  m.def(
       "nvshmem_broadcast(Tensor(a!) input, int root, str group_name) -> Tensor(a!)");
   m.def("nvshmem_wait_for_signal(Tensor sigpad, int signal, int peer) -> ()");
   m.def(
       "nvshmem_put_with_signal(Tensor(a) tensor, Tensor(a) sigpad, int signal, int peer) -> ()");
   m.def("nccl_put(Tensor(a!) tensor, int peer) -> ()");
   m.def("nccl_get(Tensor(a!) tensor, int peer) -> ()");
+  m.def(
+      "nccl_get_out(Tensor(a!) dst, Tensor src, int peer, str group_name) -> Tensor(a!)");
   m.def("nccl_wait_for_signal(Tensor sigpad, int signal) -> ()");
   m.def("nccl_put_with_signal(Tensor(a) tensor, int signal, int peer) -> ()");
   m.def(

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_extension.cu
@@ -285,6 +285,55 @@ void nccl_get(at::Tensor& tensor, const int64_t peer) {
 #endif
 }
 
+at::Tensor& nccl_get_out(
+    at::Tensor& dst,
+    const at::Tensor& src,
+    int64_t peer,
+    const std::string& group_name) {
+#ifdef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+  TORCH_CHECK(dst.is_cuda() && src.is_cuda(), "symm_mem.get: expected CUDA tensors");
+  TORCH_CHECK(
+      dst.device() == src.device(),
+      "symm_mem.get: dst and src must be on the same device");
+  TORCH_CHECK(
+      dst.scalar_type() == src.scalar_type(),
+      "symm_mem.get: dst and src must have the same dtype");
+  TORCH_CHECK(
+      dst.numel() == src.numel(),
+      "symm_mem.get: dst and src must have the same number of elements");
+  TORCH_CHECK(
+      dst.is_contiguous() && src.is_contiguous(),
+      "symm_mem.get: dst and src must be contiguous");
+
+  auto symm_mem = c10d::symmetric_memory::rendezvous(src, group_name);
+  TORCH_CHECK(peer >= 0 && peer < symm_mem->get_world_size(), "symm_mem.get: invalid peer");
+  auto nbytes = dst.numel() * dst.element_size();
+  if (nbytes == 0) {
+    return dst;
+  }
+
+  c10::cuda::CUDAGuard guard(dst.device());
+  int threads = THREADS_PER_BLOCK;
+  int blocks = (nbytes + threads - 1) / threads;
+  size_t src_byte_offset =
+      symm_mem->get_offset() + src.storage_offset() * src.element_size();
+
+  lsa_get_kernel<<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+      symm_mem->get_buffer_ptrs_dev(),
+      peer,
+      src_byte_offset,
+      dst.mutable_data_ptr(),
+      nbytes);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return dst;
+#else
+  TORCH_CHECK(
+      false,
+      "NCCL symmetric memory get is not supported. Requires NCCL >= 2.28.0");
+  return dst;
+#endif
+}
+
 bool is_nccl_symmem_available() {
 #ifdef NCCL_HAS_SYMMEM_SUPPORT
     return true;
@@ -401,6 +450,7 @@ void nccl_wait_signal_boxed(
 TORCH_LIBRARY_IMPL(symm_mem, CUDA, m) {
   m.impl("nccl_put", c10d::nccl_extension::nccl_put);
   m.impl("nccl_get", c10d::nccl_extension::nccl_get);
+  m.impl("nccl_get_out", c10d::nccl_extension::nccl_get_out);
   // APIs that accept a signal pad from user
   // TODO: rename with more descriptive name
   m.impl("nccl_wait_for_signal", c10d::nccl_extension::nccl_wait_for_signal);

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_extension.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_extension.hpp
@@ -11,6 +11,12 @@ TORCH_API void nccl_put(at::Tensor& tensor, const int64_t peer);
 
 TORCH_API void nccl_get(at::Tensor& tensor, const int64_t peer);
 
+TORCH_API at::Tensor& nccl_get_out(
+    at::Tensor& dst,
+    const at::Tensor& src,
+    int64_t peer,
+    const std::string& group_name);
+
 TORCH_API void nccl_wait_for_signal(at::Tensor& sigpad, int64_t signal);
 
 TORCH_API void nccl_put_with_signal(

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.cu
@@ -147,6 +147,40 @@ void nvshmem_get(at::Tensor& tensor, const int64_t peer) {
   nvshmemx_getmem_on_stream(tensor.mutable_data_ptr(), buffer_ptr, buffer_size, peer, stream);
 }
 
+at::Tensor& nvshmem_get_out(
+    at::Tensor& dst,
+    const at::Tensor& src,
+    int64_t peer,
+    const std::string& group_name) {
+  TORCH_CHECK(dst.is_cuda() && src.is_cuda(), "symm_mem.get: expected CUDA tensors");
+  TORCH_CHECK(
+      dst.device() == src.device(),
+      "symm_mem.get: dst and src must be on the same device");
+  TORCH_CHECK(
+      dst.scalar_type() == src.scalar_type(),
+      "symm_mem.get: dst and src must have the same dtype");
+  TORCH_CHECK(
+      dst.numel() == src.numel(),
+      "symm_mem.get: dst and src must have the same number of elements");
+  TORCH_CHECK(
+      dst.is_contiguous() && src.is_contiguous(),
+      "symm_mem.get: dst and src must be contiguous");
+
+  auto hdl = c10d::symmetric_memory::rendezvous(src, group_name);
+  TORCH_CHECK(peer >= 0 && peer < hdl->get_world_size(), "symm_mem.get: invalid peer");
+  auto global_peer = hdl->get_rank_to_global_rank().at(peer);
+  auto nbytes = dst.numel() * dst.element_size();
+  if (nbytes == 0) {
+    return dst;
+  }
+
+  c10::cuda::CUDAGuard guard(dst.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
+  nvshmemx_getmem_on_stream(
+      dst.mutable_data_ptr(), src.const_data_ptr(), nbytes, global_peer, stream);
+  return dst;
+}
+
 at::Tensor nvshmem_all_to_all(
     at::Tensor& input,
     at::Tensor& out,
@@ -1063,6 +1097,7 @@ TORCH_LIBRARY_IMPL(symm_mem, CUDA, m) {
   m.impl("nvshmem_broadcast", c10d::nvshmem_extension::nvshmem_broadcast);
   m.impl("nvshmem_put", c10d::nvshmem_extension::nvshmem_put);
   m.impl("nvshmem_get", c10d::nvshmem_extension::nvshmem_get);
+  m.impl("nvshmem_get_out", c10d::nvshmem_extension::nvshmem_get_out);
   m.impl("nvshmem_wait_for_signal", c10d::nvshmem_extension::nvshmem_wait_for_signal);
   m.impl("nvshmem_put_with_signal", c10d::nvshmem_extension::nvshmem_put_with_signal);
   m.impl("nvshmem_all_to_all", c10d::nvshmem_extension::nvshmem_all_to_all);

--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_extension.hpp
@@ -25,6 +25,12 @@ TORCH_API void nvshmem_put(at::Tensor& tensor, const int64_t peer);
 
 TORCH_API void nvshmem_get(at::Tensor& tensor, const int64_t peer);
 
+TORCH_API at::Tensor& nvshmem_get_out(
+    at::Tensor& dst,
+    const at::Tensor& src,
+    int64_t peer,
+    const std::string& group_name);
+
 at::Tensor nvshmem_broadcast(
     at::Tensor& input,
     const int64_t root,

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1976,6 +1976,16 @@ def empty(  # type: ignore[misc]
         return _SymmetricMemory.empty_strided_p2p(size, stride, dtype, device)
 
 
+def _resolve_group_name(group: c10d.GroupName | ProcessGroup) -> c10d.GroupName:
+    from torch._C._distributed_c10d import ProcessGroup
+
+    if isinstance(group, str):
+        return c10d.GroupName(group)
+    if isinstance(group, ProcessGroup):
+        return group.group_name
+    raise TypeError(f"unsupported group type: {type(group)}")
+
+
 def rendezvous(
     tensor: torch.Tensor, group: c10d.GroupName | ProcessGroup
 ) -> _SymmetricMemory:
@@ -1992,15 +2002,7 @@ def rendezvous(
         group (Union[str, :class:`torch.distributed.ProcessGroup`]): The group identifying the
             participating processes. This can be either a group name or a process group object.
     """
-    from torch._C._distributed_c10d import ProcessGroup
-
-    if isinstance(group, str):
-        group_name = c10d.GroupName(group)
-    elif isinstance(group, ProcessGroup):
-        group_name = group.group_name
-    else:
-        raise TypeError(f"rendezvous: unsupported group type: {type(group)}")
-
+    group_name = _resolve_group_name(group)
     return _SymmetricMemory.rendezvous(tensor, group_name)
 
 
@@ -2154,6 +2156,62 @@ def get_mem_pool(device: _device) -> torch.cuda.MemPool:
 
 
 # One-sided communication APIs.
+def get(
+    dst: torch.Tensor,
+    src: torch.Tensor,
+    group: c10d.GroupName | ProcessGroup,
+    peer: int,
+) -> torch.Tensor:
+    r"""
+    get(dst, src, group, peer) -> Tensor
+
+    Copy ``src`` from ``peer`` into local ``dst`` using one-sided symmetric
+    memory access.
+
+    ``src`` must be a contiguous tensor allocated with
+    :func:`torch.distributed._symmetric_memory.empty` and rendezvoused with
+    ``group``. ``dst`` can be a regular CUDA tensor or a symmetric-memory
+    tensor. The tensors must be contiguous, have the same dtype, be on the same
+    device, and contain the same number of elements. The copy is issued on the
+    current CUDA stream and the returned tensor is ``dst``.
+
+    Args:
+        dst (Tensor): local destination tensor.
+        src (Tensor): local symmetric-memory tensor whose peer allocation is
+            the remote source.
+        group (Union[str, ProcessGroup]): process group identifying peers.
+        peer (int): rank in ``group`` to copy from.
+    """
+    if dst.device != src.device:
+        raise ValueError("get: dst and src must be on the same device")
+    if dst.dtype != src.dtype:
+        raise ValueError("get: dst and src must have the same dtype")
+    if dst.numel() != src.numel():
+        raise ValueError("get: dst and src must have the same number of elements")
+    if not dst.is_contiguous() or not src.is_contiguous():
+        raise ValueError("get: dst and src must be contiguous")
+
+    group_name = _resolve_group_name(group)
+    backend = get_backend(src.device)
+    if backend == "NVSHMEM":
+        return torch.ops.symm_mem.nvshmem_get_out(dst, src, peer, group_name)
+    if backend == "NCCL":
+        return torch.ops.symm_mem.nccl_get_out(dst, src, peer, group_name)
+    if backend == "CUDA":
+        hdl = rendezvous(src, group_name)
+        if hdl is None:
+            raise RuntimeError("get: src must be allocated from symmetric memory")
+        if peer < 0 or peer >= hdl.world_size:
+            raise ValueError("get: invalid peer")
+        if hdl.offset % src.element_size() != 0:
+            raise RuntimeError("get: source storage offset is not element-aligned")
+        storage_offset = hdl.offset // src.element_size() + src.storage_offset()
+        remote_src = hdl.get_buffer(peer, src.size(), src.dtype, storage_offset)
+        dst.copy_(remote_src)
+        return dst
+    raise ValueError(f"get: unsupported backend: {backend}")
+
+
 def put_signal(src: torch.Tensor, hdl: _SymmetricMemory, peer: int) -> None:
     r"""
     put_signal(src, hdl, peer) -> None
@@ -2295,6 +2353,7 @@ __all__ = [
     "is_nvshmem_available",
     "set_backend",
     "get_backend",
+    "get",
     "set_signal_pad_size",
     "get_signal_pad_size",
     "get_mem_pool",


### PR DESCRIPTION
Add a simple one-sided `get` API to SymmetricMemory.