### PR TITLE
docs: add DataLoader performance guidance for in-memory datasets

### DIFF
--- a/docs/source/data.md
+++ b/docs/source/data.md
@@ -339,34 +339,42 @@ decision guide before tuning it.
 
 **Use `num_workers=0` (default) when:**
 
-- Your dataset is already in CPU memory as a `torch.Tensor` or `numpy` array.
-  Worker IPC overhead exceeds any parallelism benefit when data is in RAM.
+- Your `__getitem__` does minimal work per sample — for example, returning a
+  row from a pre-loaded `torch.Tensor` or `numpy` array with no preprocessing.
+  Worker IPC overhead can exceed any parallelism benefit when `__getitem__` is
+  cheap.
 - You are debugging: single-process mode gives cleaner error traces.
 
 **Use `num_workers > 0` when:**
 
-- Each {meth}`__getitem__` call reads from disk, network, or a database.
-  Multiple workers overlap I/O with GPU computation, hiding per-sample latency.
-- CPU-heavy transforms (image decoding, augmentation) can run in parallel.
+- `__getitem__` does significant work per sample — such as image decoding,
+  random augmentation, or feature extraction. Workers run these operations in
+  parallel, overlapping CPU preprocessing with GPU computation and keeping the
+  GPU fed.
 
-For in-memory tensors, DataLoader calls `__getitem__` once per sample index
-and then runs `collate_fn` to assemble the batch — even with `num_workers=0`.
-Direct slicing bypasses both:
-
-```python
-# Faster for in-memory data
-for i in range(0, len(X), batch_size):
-    batch = X[i : i + batch_size].to(device)
-
-# Slower — per-sample __getitem__ + collation overhead applies
-for batch in DataLoader(X, batch_size=batch_size):
-    batch = batch.to(device)
-```
-
-The gap widens on fast GPUs (including Apple MPS) because the GPU finishes
-each batch before DataLoader finishes preparing the next one. See
+For plain `torch.Tensor` or `numpy` datasets with no per-sample preprocessing,
+direct slicing (`X[i : i + batch_size].to(device)`) bypasses DataLoader
+overhead entirely and is typically 3-10x faster — see
 [GitHub issue #154318](https://github.com/pytorch/pytorch/issues/154318)
-for benchmarks across tensor, numpy, CSV, HDF5, and image-like datasets.
+for benchmarks across tensor, numpy, CSV, and image-like datasets.
+
+**Finding the right num_workers value**
+
+When workers help, there is no single correct value — it depends on your
+specific hardware and pipeline. The right approach is to benchmark:
+
+- Start with `num_workers=0` as your baseline
+- Increase by one step at a time: try 1, 2, 4, 8
+- Measure training throughput (samples per second) at each value
+- Stop increasing when throughput stops improving — adding more workers beyond
+  this point wastes memory without speeding things up
+
+Two resources are consumed as you increase `num_workers`:
+
+- **CPU time**: Workers run `__getitem__` in parallel. Throughput improves
+  until your CPU cores are fully utilized.
+- **CPU memory**: Each worker holds its own prefetched data. If RAM is
+  limited, keep `num_workers` low to avoid out-of-memory errors.
 
 :::{note}
 {attr}`pin_memory=True` only benefits discrete GPU setups (NVIDIA, AMD) where

--- a/docs/source/data.md
+++ b/docs/source/data.md
@@ -331,6 +331,49 @@ using {ref}`automatic memory pinning <memory-pinning>` (i.e., setting
 GPUs.
 :::
 
+(choosing-num-workers)=
+### Choosing the right num_workers
+
+Increasing {attr}`num_workers` does not always improve performance. Use this
+decision guide before tuning it.
+
+**Use `num_workers=0` (default) when:**
+
+- Your dataset is already in CPU memory as a `torch.Tensor` or `numpy` array.
+  Worker IPC overhead exceeds any parallelism benefit when data is in RAM.
+- You are debugging: single-process mode gives cleaner error traces.
+
+**Use `num_workers > 0` when:**
+
+- Each {meth}`__getitem__` call reads from disk, network, or a database.
+  Multiple workers overlap I/O with GPU computation, hiding per-sample latency.
+- CPU-heavy transforms (image decoding, augmentation) can run in parallel.
+
+For in-memory tensors, DataLoader calls `__getitem__` once per sample index
+and then runs `collate_fn` to assemble the batch — even with `num_workers=0`.
+Direct slicing bypasses both:
+
+```python
+# Faster for in-memory data
+for i in range(0, len(X), batch_size):
+    batch = X[i : i + batch_size].to(device)
+
+# Slower — per-sample __getitem__ + collation overhead applies
+for batch in DataLoader(X, batch_size=batch_size):
+    batch = batch.to(device)
+```
+
+The gap widens on fast GPUs (including Apple MPS) because the GPU finishes
+each batch before DataLoader finishes preparing the next one. See
+[GitHub issue #154318](https://github.com/pytorch/pytorch/issues/154318)
+for benchmarks across tensor, numpy, CSV, HDF5, and image-like datasets.
+
+:::{note}
+{attr}`pin_memory=True` only benefits discrete GPU setups (NVIDIA, AMD) where
+tensors travel from CPU RAM to GPU DRAM across the PCIe bus. It is silently
+ignored on MPS (Apple Silicon unified memory) and CPU-only machines.
+:::
+
 (platform-specific-behaviors)=
 #### Platform-specific behaviors
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -164,7 +164,12 @@ class DataLoader(Generic[_T_co]):
             and :attr:`drop_last`.
         num_workers (int, optional): how many subprocesses to use for data
             loading. ``0`` means that the data will be loaded in the main process.
-            (default: ``0``)
+            (default: ``0``). For datasets already in CPU memory (e.g.,
+            ``torch.Tensor``, ``numpy`` arrays), increasing ``num_workers``
+            typically *hurts* performance due to inter-process communication and
+            memory-copying costs. Use multiple workers only when ``__getitem__``
+            performs real I/O (disk reads, network requests, etc.). See the
+            ``Performance Tips`` section below.
         collate_fn (Callable, optional): merges a list of samples to form a
             mini-batch of Tensor(s).  Used when using batched loading from a
             map-style dataset.
@@ -231,6 +236,50 @@ class DataLoader(Generic[_T_co]):
 
     .. warning:: Setting `in_order` to `False` can harm reproducibility and may lead to a skewed data
                  distribution being fed to the trainer in cases with imbalanced data.
+
+    .. rubric:: Performance Tips
+
+    **Use** ``num_workers=0`` **(the default) when:**
+
+    - The dataset is already in CPU memory as a ``torch.Tensor`` or ``numpy``
+      array. Worker processes add IPC overhead that exceeds any parallelism
+      benefit when data is already in RAM.
+    - Debugging: single-process mode gives cleaner tracebacks.
+
+    **Use** ``num_workers > 0`` **when:**
+
+    - Each ``__getitem__`` call does real disk or network I/O (reading image
+      files, HDF5 rows, database queries). Workers overlap I/O with GPU
+      computation, hiding latency.
+    - CPU-heavy transforms (decoding, augmentation) can run in parallel.
+
+    **For in-memory tensors, direct slicing is much faster than DataLoader:**
+
+    .. code-block:: python
+
+        # Recommended for in-memory data (3-100x faster depending on hardware)
+        for i in range(0, len(X), batch_size):
+            batch = X[i : i + batch_size].to(device)
+            model(batch)
+
+        # DataLoader adds per-sample __getitem__ + collation overhead
+        # even at num_workers=0
+        for batch in DataLoader(X, batch_size=batch_size):
+            model(batch.to(device))
+
+    The performance gap grows on fast GPUs: the GPU finishes each batch before
+    DataLoader has collated the next one, leaving the GPU idle. See
+    `GitHub issue #154318 <https://github.com/pytorch/pytorch/issues/154318>`_
+    for detailed benchmarks across tensor, numpy, CSV, HDF5, and image datasets.
+
+    **pin_memory=True** only benefits discrete GPU setups (NVIDIA, AMD) where
+    data travels across the PCIe bus. It is silently ignored on MPS (Apple
+    Silicon unified memory) and CPU-only machines.
+
+    **Higher num_workers can hurt for in-memory data.** ``numpy`` arrays are
+    fully copied per worker (total RAM: ``num_workers × dataset size``).
+    ``torch.Tensor`` uses shared memory, but IPC overhead still applies.
+    Always benchmark before increasing ``num_workers``.
     """
 
     dataset: Dataset[_T_co]


### PR DESCRIPTION
## Summary

Adds a "Performance Tips" section to the `DataLoader` docstring and a
new "Choosing the right num_workers" subsection to `docs/source/data.md`,
explaining when `num_workers > 0` helps vs hurts performance.

Fixes the documentation gap identified in #154318, where users
experience 3–124× slowdowns using DataLoader with in-memory tensor
datasets because no guidance exists in the docs to warn them.

## Motivation

DataLoader with `num_workers > 0` is significantly **slower** than
direct tensor slicing for in-memory datasets:

| Data Source | DataLoader overhead |
|---|---|
| `torch.Tensor` (in-memory) | 3–124× slower (hardware dependent) |
| `numpy` array (in-memory) | 4–8× slower (full copy per worker) |
| CSV (row-by-row) | 18–29× slower |
| Image files (disk I/O) | Can be faster — workers genuinely help |

The gap is largest on fast GPUs because the GPU finishes each batch
before DataLoader finishes preparing the next one, leaving the GPU idle.
This is a pure documentation fix — no behavior change.

## Changes

**`torch/utils/data/dataloader.py`**
- Added `Performance Tips` rubric to the `DataLoader` class docstring
  explaining when to use `num_workers=0` vs `num_workers > 0`
- Added performance note directly to the `num_workers` parameter
  docstring warning that higher values hurt in-memory dataset performance
- Added code example showing direct slicing vs DataLoader with timing context
- Clarified that `pin_memory=True` is silently ignored on MPS (Apple
  Silicon) and CPU-only machines
- Noted that `numpy` arrays are fully copied per worker
  (`num_workers × dataset size` total RAM)

**`docs/source/data.md`**
- Added `Choosing the right num_workers` subsection with anchor
  `(choosing-num-workers)=` for cross-referencing
- Added decision guide: use `num_workers=0` for in-memory data,
  `num_workers > 0` for disk/network I/O
- Explained that `collate_fn` overhead applies even at `num_workers=0`,
  making direct slicing faster for tensor datasets
- Added note block clarifying `pin_memory=True` behavior across
  CUDA, MPS, and CPU backends

## Testing

No code behavior changes. Documentation rendering verified locally.

Benchmarks across tensor, numpy, CSV, and image-like datasets on
Apple MPS are posted in the linked issue:
[#154318 (comment)](https://github.com/pytorch/pytorch/issues/154318#issuecomment-4320859900)
