### PR TITLE
[MPS] Flatten matrices for _mps_linear_nograph

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -14,6 +14,13 @@ using namespace mps;
 static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const Tensor& bias, Tensor& output) {
   bool is_bias_defined = bias.defined();
 
+  // MPSNDArrayMatrixMultiplication produces non-deterministic results on M5 for >2D
+  // fp16/bf16 inputs. Flatten to 2D for the matmul, then reshape the output.
+  // See https://github.com/pytorch/pytorch/issues/180776.
+  bool needFlatten = input.dim() > 2 && (!is_bias_defined || bias.dim() <= 1);
+  auto input2d = needFlatten ? input.flatten(0, -2) : input;
+  auto output2d = needFlatten ? output.flatten(0, -2) : output;
+
   MPSStream* mpsStream = getCurrentMPSStream();
   id<MTLDevice> device = MPSDevice::getInstance()->device();
 
@@ -27,8 +34,8 @@ static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const
 
       MPSDataType mpsDataType = getMPSDataType(weight.scalar_type());
 
-      auto inputNDArray = getMPSNDArray(input, input.sizes(), input.strides());
-      auto outNDArray = getMPSNDArray(output, output.sizes(), output.strides());
+      auto inputNDArray = getMPSNDArray(input2d, input2d.sizes(), input2d.strides());
+      auto outNDArray = getMPSNDArray(output2d, output2d.sizes(), output2d.strides());
 
       id<MTLBuffer> weightBuf = getMTLBufferStorage(weight);
       MPSNDArrayDescriptor* weightDesc = [MPSNDArrayDescriptor descriptorWithDataType:mpsDataType
@@ -141,13 +148,11 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
                                                               dimension:-1
                                                           withDimension:-2
                                                                    name:nil];
-      // matrixMultiplicationWithPrimary crashes for 5D tensors, see https://github.com/pytorch/pytorch/issues/114942
-      bool doReshape = input.dim() > 4;
-      if (!doReshape && is_bias_defined) {
-        // workaround to improve the performance with 3D+ inputs
-        doReshape =
-            input_size.size() > 2 && input_size[0] > 1 && input_size[1] >= 1 && input_size[1] <= 32 && bias.dim() <= 1;
-      }
+      // matrixMultiplicationWithPrimary crashes for 5D tensors (see #114942)
+      // and produces non-deterministic results for >2D fp16/bf16 inputs
+      // (see #180776). Flatten to 2D unless bias has >1 dims (which would
+      // change broadcast semantics).
+      bool doReshape = input.dim() > 2 && (!is_bias_defined || bias.dim() <= 1);
       auto inputFlattened = doReshape ? [mpsGraph flatten2DTensor:inputTensor axis:-1 name:nil] : inputTensor;
       auto outputTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:inputFlattened
                                                           secondaryTensor:weightTransposeTensor

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1530,6 +1530,25 @@ class TestMPS(TestCaseMPS):
 
         self.assertEqual(out_cpu, out_mps)
 
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    @parametrize("shape", [(2, 13, 1024), (6, 6, 634), (1, 3, 28, 315),
+                           (1, 12, 4, 512), (1, 1, 5, 6, 1024)])
+    @parametrize("transposed_weight", [False, True])
+    def test_linear_nd_determinism(self, dtype, shape, transposed_weight):
+        # Regression test for https://github.com/pytorch/pytorch/issues/180776
+        # F.linear on MPS with >2D fp16/bf16 inputs and no bias produced
+        # different results across consecutive calls.
+        # transposed_weight=True forces the MPSGraph path (non-contiguous weight).
+        h = shape[-1]
+        x = torch.randn(shape, dtype=dtype, device="mps")
+        if transposed_weight:
+            w = torch.randn(h, h, dtype=dtype, device="mps").t()
+        else:
+            w = torch.randn(h, h, dtype=dtype, device="mps")
+        first = F.linear(x, w).clone()
+        second = F.linear(x, w).clone()
+        self.assertEqual(first, second, atol=0, rtol=0)
+
     def test_uniform(self):
         low = torch.zeros(5, 5, requires_grad=True)
         high = (torch.ones(5, 5) * 3).requires_grad_()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181504

Otherwise, MPS fails non-deterministically on M5 running MacOS-26.4

Fixes https://github.com/pytorch/pytorch/issues/180776