### PR TITLE
mergebot: identify failing PR in ghstack merge rule errors

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -35,6 +35,7 @@ from trymerge import (
     main as trymerge_main,
     MandatoryChecksMissingError,
     MergeRule,
+    MergeRuleFailedError,
     PostCommentError,
     RE_GHSTACK_DESC,
     read_merge_rules,
@@ -1113,6 +1114,70 @@ class TestGitHubPRGhstackDependencies(TestCase):
             "Approved by: \n"
             "ghstack dependencies: #106032, #106033, #106034\n"
         )
+
+    @mock.patch.object(GitHubPR, "is_closed", return_value=False)
+    @mock.patch("trymerge.find_matching_merge_rule")
+    @mock.patch("trymerge.GitRepo")
+    @mock.patch("trymerge.get_ghstack_prs")
+    def test_merge_ghstack_into_wraps_parent_rule_error(
+        self,
+        mock_get_ghstack_prs: mock.MagicMock,
+        mock_repo: mock.MagicMock,
+        mock_find_matching_merge_rule: mock.MagicMock,
+        _mock_is_closed: mock.MagicMock,
+        *args: Any,
+    ) -> None:
+        """
+        When a stacked dependency PR fails the merge-rule check, the error
+        raised by merge_ghstack_into should identify the failing PR number
+        and preserve the original exception subclass.
+        """
+        parent_pr = GitHubPR("pytorch", "pytorch", 106034)
+        top_pr = GitHubPR("pytorch", "pytorch", 106068)
+
+        mock_get_ghstack_prs.return_value = [
+            (parent_pr, "rev_parent"),
+            (top_pr, "rev_top"),
+        ]
+
+        inner_msg = "Approvers from one of the following sets are needed"
+        mock_find_matching_merge_rule.side_effect = MergeRuleFailedError(inner_msg)
+
+        with self.assertRaises(MergeRuleFailedError) as cm:
+            top_pr.merge_ghstack_into(mock_repo, True)
+
+        self.assertIn("#106034", str(cm.exception))
+        self.assertIn(inner_msg, str(cm.exception))
+        self.assertNotIsInstance(cm.exception, MandatoryChecksMissingError)
+
+    @mock.patch.object(GitHubPR, "is_closed", return_value=False)
+    @mock.patch("trymerge.find_matching_merge_rule")
+    @mock.patch("trymerge.GitRepo")
+    @mock.patch("trymerge.get_ghstack_prs")
+    def test_merge_ghstack_into_preserves_mandatory_checks_subclass(
+        self,
+        mock_get_ghstack_prs: mock.MagicMock,
+        mock_repo: mock.MagicMock,
+        mock_find_matching_merge_rule: mock.MagicMock,
+        _mock_is_closed: mock.MagicMock,
+        *args: Any,
+    ) -> None:
+        """The wrapping must preserve MandatoryChecksMissingError so callers
+        that catch it specifically (e.g. for retry behavior) keep working."""
+        parent_pr = GitHubPR("pytorch", "pytorch", 106034)
+        top_pr = GitHubPR("pytorch", "pytorch", 106068)
+        mock_get_ghstack_prs.return_value = [
+            (parent_pr, "rev_parent"),
+            (top_pr, "rev_top"),
+        ]
+        mock_find_matching_merge_rule.side_effect = MandatoryChecksMissingError(
+            "1 mandatory check(s) failed"
+        )
+
+        with self.assertRaises(MandatoryChecksMissingError) as cm:
+            top_pr.merge_ghstack_into(mock_repo, True)
+
+        self.assertIn("#106034", str(cm.exception))
 
 
 @mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1199,13 +1199,18 @@ class GitHubPR:
                 filter_ghstack=True, ghstack_deps=pr_dependencies
             )
             if pr.pr_num != self.pr_num and not skip_all_rule_checks:
-                # Raises exception if matching rule is not found
-                find_matching_merge_rule(
-                    pr,
-                    repo,
-                    skip_mandatory_checks=skip_mandatory_checks,
-                    skip_internal_checks=can_skip_internal_checks(self, comment_id),
-                )
+                try:
+                    find_matching_merge_rule(
+                        pr,
+                        repo,
+                        skip_mandatory_checks=skip_mandatory_checks,
+                        skip_internal_checks=can_skip_internal_checks(self, comment_id),
+                    )
+                except MergeRuleFailedError as ex:
+                    raise type(ex)(
+                        f"Merge rule check failed for stacked PR #{pr.pr_num}:\n\n{ex}",
+                        ex.rule,
+                    ) from ex
             repo.cherry_pick(rev)
             repo.amend_commit_message(commit_msg)
             pr_dependencies.append(pr)


### PR DESCRIPTION
## Summary

When a ghstack PR fails to merge because a parent PR in the stack lacks required approvals (or required checks), the error surfaced by `merge_ghstack_into` gives no hint about which PR in the stack is the problem. The user sees something like:

> Approvers from one of the following sets are needed:
> - superuser (pytorch/metamates)
> - Core Reviewers (...)
> - Core Maintainers (...)

…posted on the top PR — even though it's actually a parent that needs the approval.

This just hit #181437: the top PR only changes `.github/workflows/pull.yml` (covered by the OSS CI rule, fully approved), but the parent #181434 only changes `torchgen/gen.py`, which has no specific merge rule and falls through to the catch-all `*` rules requiring Core Reviewers / Core Maintainers / superuser. None of the parent's reviewers were in those sets, but the merge bot only ever named the top PR.

## Change

Wrap the per-PR `find_matching_merge_rule` call inside `merge_ghstack_into` to re-raise with the failing PR number prefixed, preserving the original exception subclass (so callers that distinguish `MandatoryChecksMissingError` from `MergeRuleFailedError` keep working — that distinction drives retry behavior at trymerge.py:2391/2444).

After this PR, the same failure surfaces as:

> Merge rule check failed for stacked PR #181434:
>
> Approvers from one of the following sets are needed: …

## Test plan

- [x] Added `test_merge_ghstack_into_wraps_parent_rule_error` — verifies the failing parent's PR number appears in the message and the exception is `MergeRuleFailedError` but **not** the `MandatoryChecksMissingError` subclass.
- [x] Added `test_merge_ghstack_into_preserves_mandatory_checks_subclass` — verifies a `MandatoryChecksMissingError` from a parent stays a `MandatoryChecksMissingError` so retry behavior keeps working.
- [x] `pytest .github/scripts/test_trymerge.py::TestGitHubPRGhstackDependencies` — 4 passed, 1 skipped (pre-existing).

Authored with Claude.