### PR TITLE
fix: #181231 support list unpacking syntax in TorchScript assignments

### DIFF
--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -707,7 +707,12 @@ class StmtBuilder(Builder):
     @staticmethod
     def build_Assign(ctx, stmt):
         rhs = build_expr(ctx, stmt.value)
-        lhs = [build_expr(ctx, x) for x in stmt.targets]
+        new_targets = []
+        for x in stmt.targets:
+            if isinstance(x, ast.List):
+                x = ast.Tuple(elts=x.elts, ctx=x.ctx)
+            new_targets.append(x)
+        lhs = [build_expr(ctx, x) for x in new_targets]
         return Assign(lhs, rhs)
 
     @staticmethod


### PR DESCRIPTION
## **Description**

TorchScript is rejecting a valid Python syntax. As mentioned in the bug, both functions should be exactly equivalent. C++ backend is rejecting the ListLiteral on the left-hand side of an assignment. But since this a Python sequence unpack, this needs to be corrected. For that we just need to normalize any ast.List target to ast.Tuple.




## **Root Cause**

`build_Assign` passes targets directly to `build_expr` is rejecting the ListLiteral on the left-hand side of an assignment.

Code changed from :

```
@staticmethod
def build_Assign(ctx, stmt):
    rhs = build_expr(ctx, stmt.value)
    lhs = [build_expr(ctx, x) for x in stmt.targets]
    return Assign(lhs, rhs)
```

To this :

```
    @staticmethod
    def build_Assign(ctx, stmt):
        rhs = build_expr(ctx, stmt.value)
        new_targets = []
        for x in stmt.targets:
            if isinstance(x, ast.List):
                x = ast.Tuple(elts=x.elts, ctx=x.ctx)
            new_targets.append(x)
        lhs = [build_expr(ctx, x) for x in new_targets]
        return Assign(lhs, rhs)
```