### PR TITLE
[Test] Make test_execution_trace.py device-agnostic for out-of-tree accelerator backends

### DIFF
--- a/test/profiler/test_execution_trace.py
+++ b/test/profiler/test_execution_trace.py
@@ -35,7 +35,6 @@ from torch.testing._internal.common_utils import (
     skipIfHpu,
     skipIfTorchDynamo,
     TemporaryFileName,
-    TEST_HPU,
     TEST_XPU,
     TestCase,
 )
@@ -145,11 +144,7 @@ class TestExecutionTrace(TestCase):
             nonlocal trace_called_num
             trace_called_num += 1
 
-        use_device = (
-            torch.profiler.ProfilerActivity.CUDA
-            or torch.profiler.ProfilerActivity.XPU in supported_activities()
-            or torch.profiler.ProfilerActivity.HPU in supported_activities()
-        )
+        use_device = device != "cpu"
         # Create a temp file to save execution trace and kineto data.
 
         with (
@@ -237,11 +232,7 @@ class TestExecutionTrace(TestCase):
             nonlocal trace_called_num
             trace_called_num += 1
 
-        use_device = (
-            torch.profiler.ProfilerActivity.CUDA
-            or torch.profiler.ProfilerActivity.XPU in supported_activities()
-            or torch.profiler.ProfilerActivity.HPU in supported_activities()
-        )
+        use_device = device != "cpu"
         # Create a temp file to save kineto data.
 
         with (
@@ -315,11 +306,7 @@ class TestExecutionTrace(TestCase):
         )
 
     def test_execution_trace_alone(self, device):
-        use_device = (
-            torch.profiler.ProfilerActivity.CUDA
-            or torch.profiler.ProfilerActivity.HPU in supported_activities()
-            or torch.profiler.ProfilerActivity.XPU in supported_activities()
-        )
+        use_device = device != "cpu"
         # Create a temp file to save execution trace data.
         # Use a gzip file to test compression codepath
         with tempfile.NamedTemporaryFile("w", suffix=".et.json.gz", delete=False) as fp:
@@ -376,11 +363,7 @@ class TestExecutionTrace(TestCase):
         },
     )
     def test_execution_trace_env_disabled(self, device):
-        use_device = (
-            torch.profiler.ProfilerActivity.CUDA
-            or torch.profiler.ProfilerActivity.HPU in supported_activities()
-            or torch.profiler.ProfilerActivity.XPU in supported_activities()
-        )
+        use_device = device != "cpu"
 
         with profile(
             activities=torch.profiler.supported_activities(),
@@ -635,11 +618,7 @@ class TestExecutionTrace(TestCase):
                 os.remove(file_path)
 
     def test_execution_trace_start_stop(self, device):
-        use_device = (
-            torch.profiler.ProfilerActivity.CUDA
-            or torch.profiler.ProfilerActivity.XPU in supported_activities()
-            or torch.profiler.ProfilerActivity.HPU in supported_activities()
-        )
+        use_device = device != "cpu"
         # Create a temp file to save execution trace data.
         with tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False) as fp:
             filename = fp.name
@@ -683,11 +662,7 @@ class TestExecutionTrace(TestCase):
             )
 
     def test_execution_trace_repeat_in_loop(self, device):
-        use_device = (
-            torch.profiler.ProfilerActivity.CUDA
-            or torch.profiler.ProfilerActivity.XPU in supported_activities()
-            or torch.profiler.ProfilerActivity.HPU in supported_activities()
-        )
+        use_device = device != "cpu"
         iter_list = {3, 4, 6, 8}
         expected_loop_events = len(iter_list)
         output_files = []
@@ -771,16 +746,13 @@ class TestExecutionTrace(TestCase):
         if not found_cos:
             raise AssertionError("Expected to find cos node")
 
-    @unittest.skipIf(
-        not TEST_CUDA,
-        "need CUDA device availability to run",
-    )
+    @skipCPUIf(True, "accelerator required for integral tensor range profiling")
     @patch.dict(
         os.environ, {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_RANGE": "1"}
     )
-    def test_execution_trace_record_integral_tensor_range(self):
-        t1 = torch.tensor([[1, 2], [3, 4]]).cuda()
-        t2 = torch.tensor([[0, 0], [1, 0]]).cuda()
+    def test_execution_trace_record_integral_tensor_range(self, device):
+        t1 = torch.tensor([[1, 2], [3, 4]], device=device)
+        t2 = torch.tensor([[0, 0], [1, 0]], device=device)
         with (
             tempfile.NamedTemporaryFile("w+t", suffix=".et.json", delete=False) as fp,
             profile(
@@ -812,23 +784,20 @@ class TestExecutionTrace(TestCase):
                                 '{"0":[1,4],"1":[0,1]}'
                             )
 
-    @unittest.skipIf(
-        not TEST_CUDA,
-        "need CUDA device availability to run",
-    )
+    @skipCPUIf(True, "accelerator required for integral tensor data profiling")
     @patch.dict(
         os.environ,
         {"ENABLE_PYTORCH_EXECUTION_TRACE_SAVE_INTEGRAL_TENSOR_DATA": "aten::gather"},
     )
-    def test_execution_trace_record_integral_tensor_data(self):
+    def test_execution_trace_record_integral_tensor_data(self, device):
         with tempfile.TemporaryDirectory() as temp_dir:
             fp_name = os.path.join(temp_dir, "test.et.json")
             et = ExecutionTraceObserver()
             et.register_callback(fp_name)
             et.set_extra_resource_collection(True)
 
-            t1 = torch.tensor([[1, 2], [3, 4]]).cuda()
-            t2 = torch.tensor([[0, 0], [1, 0]]).cuda()
+            t1 = torch.tensor([[1, 2], [3, 4]], device=device)
+            t2 = torch.tensor([[0, 0], [1, 0]], device=device)
             with profile(
                 activities=supported_activities(),
                 schedule=torch.profiler.schedule(
@@ -854,14 +823,7 @@ class TestExecutionTrace(TestCase):
                 raise AssertionError("Expected t2 contents to match [0, 0, 1, 0]")
 
 
-devices = ["cpu", "cuda"]
-if TEST_XPU:
-    devices.append("xpu")
-if TEST_HPU:
-    devices.append("hpu")
-instantiate_device_type_tests(
-    TestExecutionTrace, globals(), allow_xpu="xpu" in devices, only_for=devices
-)
+instantiate_device_type_tests(TestExecutionTrace, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
**Summary**

This patch makes the profiler execution trace tests fully device-agnostic, enabling out-of-tree accelerator backends to run them.

**Changes**

- Bug fix (6 locations): Fixed use_device operator precedence bug where ProfilerActivity.CUDA or ... always evaluated to truthy (since ProfilerActivity.CUDA is a non-zero enum). Replaced with device != "cpu" which correctly uses the parameterized device from instantiate_device_type_tests.
- Device-agnostic conversion (2 tests): Converted test_execution_trace_record_integral_tensor_range and test_execution_trace_record_integral_tensor_data from CUDA-hardcoded to device-agnostic:
    - Added device parameter to method signatures
    - Replaced .cuda() with device=device
    - Replaced @unittest.skipIf(not TEST_CUDA, ...) with @skipCPUIf(True, ...)
   - Removed only_for restriction: Simplified instantiate_device_type_tests call by removing the hardcoded devices = ["cpu",        "cuda", ...] list and only_for=devices, allowing all registered device types to run these tests.

- Import cleanup: Removed unused TEST_HPU import.

**Test results** 

Before: 21 passed, 5 skipped. After: 19 passed, 7 skipped. 

The 2 new CPU skips are expected - the integral tensor tests now correctly skip on CPU (previously ran with .cuda() even in the CPU test suite)