### PR TITLE
[CD] Remove cu132->cu130 wheel install fallback in Dockerfile 

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -133,7 +133,7 @@ jobs:
             } >> "${GITHUB_ENV}"
           fi
       - name: Setup nightly specific variables
-        if: ${{ github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/ciflow/nightly/') }}
+        if: ${{ github.event_name == 'pull_request' || github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/ciflow/nightly/') }}
         run: |
           {
             echo "DOCKER_IMAGE=pytorch-nightly";

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,9 @@ ARG INSTALL_CHANNEL=whl/nightly
 # Automatically set by buildx
 ARG TARGETPLATFORM
 
-RUN WHEEL_CUDA_PATH="${CUDA_PATH#.}"; \
-    case ${TARGETPLATFORM} in \
+RUN case ${TARGETPLATFORM} in \
          "linux/arm64")  pip3 install --extra-index-url https://download.pytorch.org/whl/cpu/ torch torchvision torchaudio ;; \
-         *)              pip3 install --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${WHEEL_CUDA_PATH}/ torch torchvision torchaudio ;; \
+         *)              pip3 install --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${CUDA_PATH}/ torch torchvision torchaudio ;; \
     esac
 RUN pip3 install torchelastic
 RUN IS_CUDA=$(python3 -c 'import torch ; print(torch.cuda._is_compiled())'); \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,7 @@ ARG INSTALL_CHANNEL=whl/nightly
 # Automatically set by buildx
 ARG TARGETPLATFORM
 
-# INSTALL_CHANNEL whl - release, whl/nightly - nightly, whl/test - test channels
-# TODO: revert cu132->cu130 fallback once cu132 wheels are published
 RUN WHEEL_CUDA_PATH="${CUDA_PATH#.}"; \
-    if [ "${WHEEL_CUDA_PATH}" = "cu132" ]; then WHEEL_CUDA_PATH=cu130; fi; \
     case ${TARGETPLATFORM} in \
          "linux/arm64")  pip3 install --extra-index-url https://download.pytorch.org/whl/cpu/ torch torchvision torchaudio ;; \
          *)              pip3 install --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${WHEEL_CUDA_PATH}/ torch torchvision torchaudio ;; \


### PR DESCRIPTION
  ## Summary    

  Removes the hardcoded cu132 → cu130 wheel-install fallback in Dockerfile. The fallback was added in
   #177316 as a temporary workaround when CUDA 13.2 nightlies weren't yet published; cu132 wheels
  have been on download.pytorch.org/whl/nightly/cu132/ since 2026-04-20, so the override is now stale
   and actively wrong.                                            

  With the override in place, the cuda13.2-cudnn9-{runtime,devel} images installed +cu130 wheels,    
  causing the docker-release validation smoke test to fail:
                                                                                                     
  RuntimeError: Wrong CUDA version. Loaded: 13.0 Expected: 13.2   
  (from smoke_test.py smoke_test_cuda — torch.version.cuda != gpu_arch_ver)                          
                                                                                                     
  Failing run: https://github.com/pytorch/pytorch/actions/runs/24879565337 (jobs validate /          
  cuda13.2-cudnn9-runtime and validate / cuda13.2-cudnn9-devel).                                     
                                                                  
  ## Test plan                                                                                          
                                                                  
  - Build Official Docker Images workflow runs green on nightly, including validate /                
  cuda13.2-cudnn9-runtime and validate / cuda13.2-cudnn9-devel.   
  - In the built cuda13.2-cudnn9-runtime image, python -c 'import torch; print(torch.version.cuda)'  
  reports 13.2.  