### PR TITLE
Fix heap-buffer-overflow in torch.linalg.eig on subnormal real inputs

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -167,6 +167,22 @@ static void linalg_eig_make_complex_eigenvectors_cpu_impl(const Tensor& result, 
           res[j * n + i] = c10::complex<scalar_t>(vecs[j * n + i], 0);
         }
       } else {
+        // LAPACK's GEEV contract: a complex eigenvalue at index j is the
+        // first of a conjugate pair and uses VR column j+1 as the imaginary
+        // part. A complex eigenvalue at j == n-1 would require the
+        // non-existent column n and is a structural inconsistency in
+        // LAPACK's output (observed on subnormal inputs with some netlib
+        // builds; pytorch/pytorch#162358). Refuse rather than read past
+        // the end of VR.
+        TORCH_CHECK(
+            j + 1 < n,
+            "torch.linalg.eig: LAPACK returned a complex eigenvalue at index ",
+            j, " (the final index of an n=", n, " problem) with no partner ",
+            "column in the packed real-eigenvector output. This indicates the ",
+            "underlying LAPACK produced an inconsistent classification of ",
+            "eigenvalues for this input, typically due to subnormal or ",
+            "otherwise ill-conditioned values. Consider using a ",
+            "higher-precision dtype or perturbing the input.");
         for (auto i = decltype(n){0}; i < n; i++) {
           res[j * n + i] = c10::complex<scalar_t>(vecs[j * n + i],  vecs[(j+1) * n + i]);      // v(j)   = VR(:,j) + i*VR(:,j+1)
           res[(j+1) * n + i] = c10::complex<scalar_t>(vecs[j * n + i], -vecs[(j+1) * n + i]);  // v(j+1) = VR(:,j) - i*VR(:,j+1)

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebraEig.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebraEig.cu
@@ -44,10 +44,32 @@ __global__ void linalg_eig_make_complex_eigenvectors_kernel(
         batch_vectors[col * n + row],
         scalar_t(0));
   } else if (eigenvalue.imag() > scalar_t(0)) {
+    // Complex eigenvalue with positive imag must be the first of a conjugate
+    // pair, so a partner column col+1 must exist. A positive-imag eigenvalue
+    // at col == n-1 is a structural inconsistency in the LAPACK/MAGMA output
+    // (see pytorch/pytorch#162358). Refuse rather than reading past the end
+    // of the vectors buffer.
+    CUDA_KERNEL_ASSERT_PRINTF(
+        col + 1 < n,
+        "torch.linalg.eig: complex eigenvalue with positive imag reported at "
+        "the trailing column (col=%lld, n=%lld) with no partner column in the "
+        "packed real-eigenvector output. Input is likely subnormal or "
+        "ill-conditioned; try a higher-precision dtype or perturb the input.\n",
+        static_cast<long long>(col), static_cast<long long>(n));
     batch_result[col * n + row] = c10::complex<scalar_t>(
         batch_vectors[col * n + row],
         batch_vectors[(col + 1) * n + row]);
   } else {
+    // eigenvalue.imag() < 0: second of a conjugate pair, so a preceding
+    // column col-1 must exist. imag < 0 at col == 0 is the leading-boundary
+    // analogue of the same structural inconsistency.
+    CUDA_KERNEL_ASSERT_PRINTF(
+        col > 0,
+        "torch.linalg.eig: complex eigenvalue with negative imag reported at "
+        "the leading column (col=0, n=%lld) with no partner column in the "
+        "packed real-eigenvector output. Input is likely subnormal or "
+        "ill-conditioned; try a higher-precision dtype or perturb the input.\n",
+        static_cast<long long>(n));
     batch_result[col * n + row] = c10::complex<scalar_t>(
         batch_vectors[(col - 1) * n + row],
         -batch_vectors[col * n + row]);

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -22,6 +22,7 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/index_kernel_utils_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ivalue_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/lazy_tensor_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/linalg_eig_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/math_kernel_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/memory_format_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/memory_overlapping_test.cpp

--- a/aten/src/ATen/test/linalg_eig_test.cpp
+++ b/aten/src/ATen/test/linalg_eig_test.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <ATen/native/BatchLinearAlgebra.h>
+#include <c10/util/complex.h>
+
+using namespace at;
+
+// Regression test for pytorch/pytorch#162358. The CPU unpacker used to trust
+// LAPACK's classification of eigenvalues and read the "partner" column of the
+// packed real-eigenvector output. If LAPACK reported a complex eigenvalue at
+// the trailing index (j == n-1), the partner column j+1 == n is outside the
+// n-column buffer, causing a heap-buffer-overflow. The fix replaces the silent
+// OOB read with a TORCH_CHECK. This test constructs the exact structurally
+// inconsistent input directly, bypassing LAPACK, so it exercises the fixed
+// branch deterministically on every CI configuration regardless of BLAS
+// backend.
+TEST(LinalgEigTest, TrailingComplexEigenvalueRaises) {
+  const int64_t n = 2;
+
+  auto values = at::zeros({n}, at::kComplexDouble);
+  values[0] = c10::complex<double>(1.0, 0.0);
+  // Trailing index carries a nonzero imag with no partner column in VR.
+  values[1] = c10::complex<double>(2.0, 0.5);
+
+  auto vectors = at::eye(n, at::kDouble);
+  auto result = at::empty({n, n}, at::kComplexDouble);
+
+  EXPECT_THROW(
+      at::native::linalg_eig_make_complex_eigenvectors(result, values, vectors),
+      c10::Error);
+}
+
+// Well-formed input still works: real eigenvalues, matching real vectors.
+TEST(LinalgEigTest, RealEigenvaluesUnpackCorrectly) {
+  const int64_t n = 2;
+
+  auto values = at::zeros({n}, at::kComplexDouble);
+  values[0] = c10::complex<double>(1.0, 0.0);
+  values[1] = c10::complex<double>(2.0, 0.0);
+
+  auto vectors = at::eye(n, at::kDouble);
+  auto result = at::empty({n, n}, at::kComplexDouble);
+
+  at::native::linalg_eig_make_complex_eigenvectors(result, values, vectors);
+
+  auto expected = at::eye(n, at::kComplexDouble);
+  ASSERT_TRUE(result.equal(expected));
+}

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2513,6 +2513,41 @@ class TestLinalg(TestCase):
         not TEST_WITH_ROCM and _get_torch_cuda_version() < (12, 8) and not torch.cuda.has_magma,
         "torch.linalg.eig requires MAGMA for CUDA versions < 12.8",
     )
+    @dtypes(torch.float64)
+    def test_eig_subnormal_input_no_overflow(self, device, dtype):
+        # Regression smoke test for pytorch/pytorch#162358: subnormal inputs
+        # could trigger a heap-buffer-overflow in
+        # linalg_eig_make_complex_eigenvectors when LAPACK's eigenvalue array
+        # reported a complex eigenvalue at the trailing index with no partner
+        # column in the packed real-eigenvector layout.
+        #
+        # Whether the code path is exercised depends on the linked LAPACK: MKL
+        # (PyTorch CI) raises "algorithm failed to converge" before the
+        # unpacker; Apple Accelerate classifies the trailing pair as a valid
+        # conjugate pair; only netlib on the OP's environment reaches the
+        # buggy branch. The deterministic regression test lives in
+        # aten/src/ATen/test/linalg_eig_test.cpp; this test just ensures no
+        # OOB/segfault regression on any backend by accepting either success
+        # or a clean RuntimeError.
+        v = 9.01285756841503997614390621177016e-188
+        a = torch.full((9, 9), v, dtype=dtype, device=device)
+        a[0, 0] = 6.92733286357142009759300753973877e-310
+        a[0, 1] = 4.87107170610649251002689828257271e-310
+        a[0, 2] = 9.01272004312255329946307405656429e-188
+        a[8, 7] = 3.09700932956638653566522653421558e-312
+        a[8, 8] = -1.09006211749085692498734985786208e-277
+
+        try:
+            L, V = torch.linalg.eig(a)
+        except RuntimeError:
+            return
+        self.assertEqual(a.to(L.dtype) @ V, V @ torch.diag(L), atol=1e-6, rtol=1e-6)
+
+    @skipCPUIfNoLapack
+    @skipCUDAIf(
+        not TEST_WITH_ROCM and _get_torch_cuda_version() < (12, 8) and not torch.cuda.has_magma,
+        "torch.linalg.eig requires MAGMA for CUDA versions < 12.8",
+    )
     # NumPy computes only in float64 and complex128 precisions
     # for float32 or complex64 results might be very different from float64 or complex128
     @dtypes(torch.float64, torch.complex128)


### PR DESCRIPTION
## Summary

Fixes pytorch/pytorch#162358, a heap-buffer-overflow in
`torch.linalg.eig` on some subnormal real inputs.

## Root cause

LAPACK's GEEV documents that a complex eigenvalue at index `j` is the
first of a conjugate pair and uses VR column `j+1` as the imaginary
part. On certain subnormal inputs (observed with conda-forge netlib
LAPACK, see #162358) GEEV violates that contract by classifying the
trailing eigenvalue (`j == n-1`) as complex while VR still has only
`n` columns. The unpacker in
`linalg_eig_make_complex_eigenvectors_cpu_impl` trusted the
classification and read `VR[(n)*n + i]`, walking past the end of the
`n*n` VR buffer. The CUDA kernel had the analogous bug at both the
trailing (`col == n-1`, `imag > 0`) and leading (`col == 0`,
`imag < 0`) boundaries since its per-thread dispatch reads based on
`sign(imag(λ[col]))`.

## Fix

Defensive programming: detect the structural inconsistency and refuse
to proceed rather than reading OOB or guessing an interpretation. The
CPU path raises a clean `TORCH_CHECK` with a message that names the
problem and suggests a higher-precision dtype or perturbing the input.
The CUDA kernel uses `CUDA_KERNEL_ASSERT_PRINTF` at both boundaries
(`TORCH_CHECK` can't cross the `__global__` boundary).

An earlier version of this PR silently recovered by treating the lone
trailing entry as a real eigenvector; per reviewer feedback that is
"guessing outside the LAPACK spec" rather than defensive programming,
so this revision replaces it with a hard error.

## Test plan

- New C++ gtest `aten/src/ATen/test/linalg_eig_test.cpp` with two
  cases:
  - `TrailingComplexEigenvalueRaises`: constructs a
    structurally-inconsistent input (complex eigenvalue at
    `j == n-1`, `n`-column VR) and calls
    `at::native::linalg_eig_make_complex_eigenvectors` directly.
    Deterministically exercises the fixed branch on every CI
    configuration regardless of BLAS backend.
  - `RealEigenvaluesUnpackCorrectly`: sanity-check on well-formed
    input.
- Python regression test `test_eig_subnormal_input_no_overflow` in
  `test/test_linalg.py`: uses the OP's exact matrix; intentionally
  permissive (accepts either a successful decomposition or a clean
  `RuntimeError`) since no CI config deterministically triggers the
  branch through `linalg.eig`:
  - MKL raises "algorithm failed to converge" before the unpacker
    runs;
  - Apple Accelerate classifies the trailing pair as a valid
    conjugate pair and bypasses the branch;
  - only netlib on the OP's environment reaches the buggy branch.
  The C++ gtest above is the load-bearing regression test.

- [ ] `python test/test_linalg.py -v -k test_eig_subnormal_input_no_overflow`
- [ ] C++ gtest built and run as part of ATen test suite

Authored with Claude.