### PR TITLE
[Inductor] enable MSVC precompiled headers for cpp-wrapper

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -11,7 +11,6 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_utils import (
     IS_MACOS,
-    IS_WINDOWS,
     slowTest,
     TEST_MKL,
     TEST_WITH_ROCM,

--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -257,7 +257,7 @@ if RUN_CPU:
                 func,
                 "",
                 test_cpu_repro.CPUReproTests(),
-                condition=torch.backends.mkldnn.is_available() and not IS_WINDOWS,
+                condition=torch.backends.mkldnn.is_available(),
             )
             for func in dir(test_cpu_repro.CPUReproTests())
             if func.startswith("test_lstm_packed_change_input_sizes")
@@ -271,7 +271,6 @@ if RUN_CPU:
         BaseTest("test_multihead_attention", "cpu", test_cpu_repro.CPUReproTests()),
         BaseTest(
             "test_multi_threading",
-            condition=not IS_WINDOWS,
             # Two threads compile, so we expect the output code to be printed twice.
             code_string_count={"py::gil_scoped_release_simple release;": 2},
         ),

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2853,10 +2853,11 @@ end
                         min_optimize=not config.aot_inductor.package_cpp_only,
                         **compile_command,
                     )
-                    wrapper_build_options.precompiled_header_include = header_file
-                    wrapper_build_options.precompiled_header_object = (
-                        f"{wrapper_build_options.precompiled_header}.obj"
-                    )
+                    if _IS_WINDOWS:
+                        wrapper_build_options.precompiled_header_include = header_file
+                        wrapper_build_options.precompiled_header_object = (
+                            f"{wrapper_build_options.precompiled_header}.obj"
+                        )
                     if cpp_prefix := _get_cpp_prefix_header(device_type):
                         kernel_build_options.precompiled_header = _precompile_header(
                             cpp_prefix,
@@ -2864,10 +2865,11 @@ end
                             min_optimize=not config.aot_inductor.package_cpp_only,
                             **compile_command,
                         )
-                        kernel_build_options.precompiled_header_include = cpp_prefix
-                        kernel_build_options.precompiled_header_object = (
-                            f"{kernel_build_options.precompiled_header}.obj"
-                        )
+                        if _IS_WINDOWS:
+                            kernel_build_options.precompiled_header_include = cpp_prefix
+                            kernel_build_options.precompiled_header_object = (
+                                f"{kernel_build_options.precompiled_header}.obj"
+                            )
 
             wrapper_builder = CppBuilder(
                 name=str(wrapper_path_operator.stem),
@@ -3414,7 +3416,8 @@ def _precompile_header(
         preprocessor_hash = _get_file_checksum(preprocessor.get_target_file_path())
 
     header_build_option = CppTorchDeviceOptions(**compile_command, precompiling=True)
-    header_build_option.precompiled_header_include = header
+    if _IS_WINDOWS:
+        header_build_option.precompiled_header_include = header
     header_hash, header_full_path = write(
         content=f"#include <{header}>\n",
         extension="h",
@@ -3430,9 +3433,10 @@ def _precompile_header(
         sources=header_full_path,
         BuildOption=header_build_option,
     )
-    header_build_option.precompiled_header_object = (
-        cpp_builder.get_precompiled_header_object_file_path()
-    )
+    if _IS_WINDOWS:
+        header_build_option.precompiled_header_object = (
+            cpp_builder.get_precompiled_header_object_file_path()
+        )
     # _worker_compile_cpp will automatically ignore any compilation whose result already
     # exists, so this is always safe.
     os.makedirs(_HEADER_LOCK_DIR, exist_ok=True)
@@ -3619,10 +3623,11 @@ class CppCodeCache:
                         min_optimize=min_optimize,
                         **main_compile_command,
                     )
-                    main_build_option.precompiled_header_include = header
-                    main_build_option.precompiled_header_object = (
-                        f"{main_build_option.precompiled_header}.obj"
-                    )
+                    if _IS_WINDOWS:
+                        main_build_option.precompiled_header_include = header
+                        main_build_option.precompiled_header_object = (
+                            f"{main_build_option.precompiled_header}.obj"
+                        )
 
                 # Currently, the optimized_code field is only used for cpp kernel code,
                 # so go ahead and precompile the relevant header here.  Revisit this
@@ -3634,10 +3639,11 @@ class CppCodeCache:
                         optimized_cmd_line,
                         **optimized_compile_command,
                     )
-                    optimized_build_option.precompiled_header_include = header
-                    optimized_build_option.precompiled_header_object = (
-                        f"{optimized_build_option.precompiled_header}.obj"
-                    )
+                    if _IS_WINDOWS:
+                        optimized_build_option.precompiled_header_include = header
+                        optimized_build_option.precompiled_header_object = (
+                            f"{optimized_build_option.precompiled_header}.obj"
+                        )
 
             main_name, output_dir = get_name_and_dir_from_output_file_path(main_path)
             main_builder = CppBuilder(

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2859,17 +2859,24 @@ end
                             f"{wrapper_build_options.precompiled_header}.obj"
                         )
                     if cpp_prefix := _get_cpp_prefix_header(device_type):
-                        kernel_build_options.precompiled_header = _precompile_header(
-                            cpp_prefix,
-                            cpp_command,
-                            min_optimize=not config.aot_inductor.package_cpp_only,
-                            **compile_command,
-                        )
                         if _IS_WINDOWS:
+                            kernel_build_options.precompiled_header = _precompile_header(
+                                cpp_prefix,
+                                cpp_command,
+                                min_optimize=not config.aot_inductor.package_cpp_only,
+                                **compile_command,
+                            )
                             kernel_build_options.precompiled_header_include = cpp_prefix
                             kernel_build_options.precompiled_header_object = (
                                 f"{kernel_build_options.precompiled_header}.obj"
                             )
+                        else:
+                            kernel_build_options.precompiled_header = _precompile_header(
+                                cpp_prefix,
+                                cpp_command,
+                                **compile_command,
+                            )
+
 
             wrapper_builder = CppBuilder(
                 name=str(wrapper_path_operator.stem),

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2871,12 +2871,13 @@ end
                                 f"{kernel_build_options.precompiled_header}.obj"
                             )
                         else:
-                            kernel_build_options.precompiled_header = _precompile_header(
-                                cpp_prefix,
-                                cpp_command,
-                                **compile_command,
+                            kernel_build_options.precompiled_header = (
+                                _precompile_header(
+                                    cpp_prefix,
+                                    cpp_command,
+                                    **compile_command,
+                                )
                             )
-
 
             wrapper_builder = CppBuilder(
                 name=str(wrapper_path_operator.stem),

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -2842,7 +2842,7 @@ end
             )
 
             # potentially, precompile the AOT header for this device
-            if config.aot_inductor.precompile_headers and not _IS_WINDOWS:
+            if config.aot_inductor.precompile_headers:
                 with dynamo_timed("aoti_precompile_header", log_pt2_compile_event=True):
                     header_file = _get_cpp_wrapper_header(
                         device_type, aot_mode=graph.aot_mode
@@ -2853,11 +2853,20 @@ end
                         min_optimize=not config.aot_inductor.package_cpp_only,
                         **compile_command,
                     )
+                    wrapper_build_options.precompiled_header_include = header_file
+                    wrapper_build_options.precompiled_header_object = (
+                        f"{wrapper_build_options.precompiled_header}.obj"
+                    )
                     if cpp_prefix := _get_cpp_prefix_header(device_type):
                         kernel_build_options.precompiled_header = _precompile_header(
                             cpp_prefix,
                             cpp_command,
+                            min_optimize=not config.aot_inductor.package_cpp_only,
                             **compile_command,
+                        )
+                        kernel_build_options.precompiled_header_include = cpp_prefix
+                        kernel_build_options.precompiled_header_object = (
+                            f"{kernel_build_options.precompiled_header}.obj"
                         )
 
             wrapper_builder = CppBuilder(
@@ -3145,7 +3154,24 @@ end
                     ],
                 )
 
-            obj_srcs = [wrapper_o, kernel_o, consts_o, *gpu_kernels_o, *cubins_o]
+            pch_obj_srcs: list[str] = []
+            if _IS_WINDOWS:
+                pch_obj_srcs = [
+                    obj
+                    for obj in (
+                        wrapper_build_options.precompiled_header_object,
+                        kernel_build_options.precompiled_header_object,
+                    )
+                    if obj is not None
+                ]
+            obj_srcs = [
+                wrapper_o,
+                kernel_o,
+                consts_o,
+                *gpu_kernels_o,
+                *cubins_o,
+                *pch_obj_srcs,
+            ]
             so_builder = CppBuilder(
                 name=output_name,
                 sources=obj_srcs,
@@ -3361,10 +3387,6 @@ def _precompile_header(
     hashable_cmd_line: str,
     **compile_command: Any,
 ) -> str:
-    assert not _IS_WINDOWS, (
-        "CppBuilder does not currently support precompiling on Windows!"
-    )
-
     # Get the preprocessed output from the header file to be precompiled.  This allows
     # us to properly invalidate the file cache when any header dependency changes.  This
     # is thread-safe, as each thread will get its own temporary directory.
@@ -3382,17 +3404,17 @@ def _precompile_header(
         preprocessor.build()
 
         def _get_file_checksum(filename: str) -> str:
-            """Reading the whole preprocessed header in for hashing is very expensive,
-            but calling a fast hashing utility in a subprocess is cheap."""
-            # If Windows support needs to be added here, use certutil -hashfile.
-            cmd_output = subprocess.run(
-                ("openssl", "sha512", filename), capture_output=True, text=True
-            )
-            return cmd_output.stdout.split()[-1]
+            """Compute a stable hash of the preprocessed header output."""
+            hasher = hashlib.sha512()
+            with open(filename, "rb") as f:
+                while chunk := f.read(1024 * 1024):
+                    hasher.update(chunk)
+            return hasher.hexdigest()
 
         preprocessor_hash = _get_file_checksum(preprocessor.get_target_file_path())
 
     header_build_option = CppTorchDeviceOptions(**compile_command, precompiling=True)
+    header_build_option.precompiled_header_include = header
     header_hash, header_full_path = write(
         content=f"#include <{header}>\n",
         extension="h",
@@ -3407,6 +3429,9 @@ def _precompile_header(
         name=header_full_path,
         sources=header_full_path,
         BuildOption=header_build_option,
+    )
+    header_build_option.precompiled_header_object = (
+        cpp_builder.get_precompiled_header_object_file_path()
     )
     # _worker_compile_cpp will automatically ignore any compilation whose result already
     # exists, so this is always safe.
@@ -3586,13 +3611,17 @@ class CppCodeCache:
             lib = None
 
             # if requested, pre-compile any headers
-            if config.cpp_cache_precompile_headers and not _IS_WINDOWS:
+            if config.cpp_cache_precompile_headers:
                 if header := cls._get_uncompiled_header(device_type):
                     main_build_option.precompiled_header = _precompile_header(
                         header,
                         main_cmd_line,
                         min_optimize=min_optimize,
                         **main_compile_command,
+                    )
+                    main_build_option.precompiled_header_include = header
+                    main_build_option.precompiled_header_object = (
+                        f"{main_build_option.precompiled_header}.obj"
                     )
 
                 # Currently, the optimized_code field is only used for cpp kernel code,
@@ -3604,6 +3633,10 @@ class CppCodeCache:
                         header,
                         optimized_cmd_line,
                         **optimized_compile_command,
+                    )
+                    optimized_build_option.precompiled_header_include = header
+                    optimized_build_option.precompiled_header_object = (
+                        f"{optimized_build_option.precompiled_header}.obj"
                     )
 
             main_name, output_dir = get_name_and_dir_from_output_file_path(main_path)
@@ -3630,6 +3663,18 @@ class CppCodeCache:
                     sources=[
                         main_builder.get_target_file_path(),
                         optimized_builder.get_target_file_path(),
+                        *(
+                            [main_build_option.precompiled_header_object]
+                            if _IS_WINDOWS
+                            and main_build_option.precompiled_header_object
+                            else []
+                        ),
+                        *(
+                            [optimized_build_option.precompiled_header_object]
+                            if _IS_WINDOWS
+                            and optimized_build_option.precompiled_header_object
+                            else []
+                        ),
                     ],
                     # pyrefly: ignore [bad-argument-type]
                     BuildOption=CppTorchDeviceOptions(**shared_compile_command),

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -2341,7 +2341,7 @@ class CppBuilder:
                 relative_pch_obj = (
                     os.path.basename(pch_obj) if self._use_relative_path else pch_obj
                 )
-                    self._cflags_args += f'/Fo"{relative_pch_obj}" '  # codespell:ignore /Fo
+                self._cflags_args += f'/Fo"{relative_pch_obj}" '  # codespell:ignore /Fo
                 self._precompiled_header_object_file = normalize_path_separator(pch_obj)
             else:
                 self._sources_args = f"-x c++-header {sources[0]}"

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -2341,7 +2341,7 @@ class CppBuilder:
                 relative_pch_obj = (
                     os.path.basename(pch_obj) if self._use_relative_path else pch_obj
                 )
-                self._cflags_args += f'/Fo"{relative_pch_obj}" '
+                    self._cflags_args += f'/Fo"{relative_pch_obj}" '  # codespell:ignore /Fo
                 self._precompiled_header_object_file = normalize_path_separator(pch_obj)
             else:
                 self._sources_args = f"-x c++-header {sources[0]}"

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -757,6 +757,11 @@ class BuildOptionsBase:
         # Optionally, the path to a precompiled header which should be included on the
         # build command line.
         self.precompiled_header: str | None = None
+        # Header identity for MSVC /Yc and /Yu matching.
+        self.precompiled_header_include: str | None = None
+        # For MSVC, the precompiled header creation step also emits a companion object
+        # file which may need to be linked into the final binary.
+        self.precompiled_header_object: str | None = None
 
         self._aot_mode: bool = aot_mode
         self._use_relative_path: bool = use_relative_path
@@ -2243,7 +2248,7 @@ class CppBuilder:
     @staticmethod
     def __get_preprocessor_output_flags() -> tuple[str, str]:
         extension = ".i"
-        output_flags = "/EP /P" if _IS_WINDOWS else "-E -P -o"
+        output_flags = "/EP /P /Fi" if _IS_WINDOWS else "-E -P -o"
         return extension, output_flags
 
     def __init__(
@@ -2266,6 +2271,7 @@ class CppBuilder:
         self._orig_source_paths = []
         self._output_dir = ""
         self._target_file = ""
+        self._precompiled_header_object_file: str | None = None
 
         self._use_relative_path: bool = False
         self._aot_mode: bool = False
@@ -2292,13 +2298,6 @@ class CppBuilder:
             self._compile_only or self._precompiling or self._preprocessing
         )
 
-        # MSVC produces two files when precompiling: the actual .pch file, as well as an
-        # object file which must be linked into the final library.  This class assumes
-        # only one output file of note, so for now we'll error out here.
-        assert not _IS_WINDOWS or not self._precompiling, (
-            "Cannot currently precompile headers on Windows!"
-        )
-
         if self._compile_only:
             file_ext, output_flags = self.__get_object_flags()
         elif self._precompiling:
@@ -2315,11 +2314,7 @@ class CppBuilder:
             else self._target_file
         )
         if _IS_WINDOWS:
-            if self._preprocessing:
-                # The target file name is automatically determined by MSVC.
-                self._output = output_flags
-            else:
-                self._output = f"{output_flags}{relative_target_file}"
+            self._output = f"{output_flags}{relative_target_file}"
         else:
             self._output = f"{output_flags} {relative_target_file}"
 
@@ -2335,15 +2330,33 @@ class CppBuilder:
 
         if self._precompiling:
             assert len(sources) == 1
-            # See above; we can currently assume this is not on MSVC.
-            self._sources_args = f"-x c++-header {sources[0]}"
-            if self._use_relative_path and _is_clang(BuildOption.get_compiler()):
-                # Store PCH paths relative to -isysroot so the .pch can
-                # be used from a different build directory.  The matching
-                # -isysroot is injected by build_fbcode_re().
-                self._cflags_args += " -relocatable-pch -Xclang -fno-pch-timestamp "
+            if _IS_WINDOWS:
+                # For MSVC, force C++ mode and request both the .pch and companion .obj
+                # artifacts from this precompile step.
+                self._sources_args = sources[0]
+                self._cflags_args += "/c /TP "
+                pch_include = BuildOption.precompiled_header_include or sources[0]
+                self._cflags_args += f'/Yc"{normalize_path_separator(pch_include)}" '
+                pch_obj = os.path.join(self._output_dir, f"{self._name}.obj")
+                relative_pch_obj = (
+                    os.path.basename(pch_obj) if self._use_relative_path else pch_obj
+                )
+                self._cflags_args += f'/Fo"{relative_pch_obj}" '
+                self._precompiled_header_object_file = normalize_path_separator(pch_obj)
+            else:
+                self._sources_args = f"-x c++-header {sources[0]}"
+                if self._use_relative_path and _is_clang(BuildOption.get_compiler()):
+                    # Store PCH paths relative to -isysroot so the .pch can
+                    # be used from a different build directory.  The matching
+                    # -isysroot is injected by build_fbcode_re().
+                    self._cflags_args += " -relocatable-pch -Xclang -fno-pch-timestamp "
         else:
             self._sources_args = " ".join(sources)
+
+        if self._preprocessing and _IS_WINDOWS:
+            # The preprocessing path feeds a temporary header-like source into cl,
+            # so force C++ parsing mode for STL includes.
+            self._cflags_args += "/TP "
 
         for cflag in BuildOption.get_cflags():
             if _IS_WINDOWS:
@@ -2359,10 +2372,19 @@ class CppBuilder:
 
         if precompiled_header := BuildOption.precompiled_header:
             if _IS_WINDOWS:
-                log.warning(
-                    "Precompiled header support for MSVC is currently unavailable; ignoring %s",
-                    precompiled_header,
+                pch_path = normalize_path_separator(f"{precompiled_header}.pch")
+                pch_include = normalize_path_separator(
+                    BuildOption.precompiled_header_include or precompiled_header
                 )
+                self._cflags_args += f'/Yu"{pch_include}" '
+                self._cflags_args += f'/FI"{pch_include}" '
+                self._cflags_args += f'/Fp"{pch_path}" '
+
+                # If this compile call also links, provide the companion .obj emitted
+                # during precompilation as a linker input.
+                pch_obj = BuildOption.precompiled_header_object
+                if self._do_link and pch_obj:
+                    self._sources_args += f" {normalize_path_separator(pch_obj)}"
             else:
                 self._include_dirs_args = f"-include {precompiled_header} "
                 if self._use_relative_path and _is_clang(BuildOption.get_compiler()):
@@ -2448,6 +2470,11 @@ class CppBuilder:
 
     def get_target_file_path(self) -> str:
         return normalize_path_separator(self._target_file)
+
+    def get_precompiled_header_object_file_path(self) -> str | None:
+        if self._precompiled_header_object_file is None:
+            return None
+        return normalize_path_separator(self._precompiled_header_object_file)
 
     def build_fbcode_re(
         self,


### PR DESCRIPTION
This PR fixes Windows-specific failures in Inductor cpp-wrapper builds and adds end-to-end MSVC precompiled header support in the C++ compile path.

## What changed
- Fixed CPU cpp-wrapper header emission so required device declarations are still included when graph device types are empty.
- Enabled Windows PCH flow in the builder/codecache pipeline.
- Added MSVC PCH create/use wiring using Yc, Yu, FI, Fp flags and companion object handling for link steps.
- Enabled preprocessing output handling on Windows with explicit output flags and C++ mode where needed.
- Removed the Windows PCH hard-block and propagated PCH metadata through JIT and AOT compile paths.
- Replaced external openssl hashing for preprocessed headers with in-process hashlib sha512.
- Updated existing Windows-gated cpp-wrapper tests that are now valid with this support:
  - enabled test_multi_threading cpp-wrapper variant on Windows
  - enabled test_lstm_packed_change_input_sizes variants on Windows
- Adjusted one cpp-wrapper pattern check to accept Windows/Linux integer literal formatting differences.

## Validation
Targeted tests were run with TORCHINDUCTOR_CPP_WRAPPER=1 && TORCHINDUCTOR_CPP_CACHE_PRECOMPILE_HEADERS=1 on windows and passed:
- test_cpu_repro.py -k test_meta_device
- test_torchinductor.py -k test_linspace3_cpu
- test_torchinductor.py -k test_max_unpool_empty_output_cpu

## Impact
- Windows: fixes correctness issues and enables PCH support in cpp-wrapper compile paths.
- Linux/macOS: no intended functional change to compile/link semantics; checksum implementation now uses internal Python hashing instead of an openssl subprocess.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos