### PR TITLE
dataloader: add performance warning for in-memory datasets with num_workers>0

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -3058,6 +3058,42 @@ except RuntimeError as e:
         ):
             dataloader = DataLoader(self.dataset, batch_size=2, num_workers=1000)
 
+    def test_perf_warning_tensor(self):
+        with self.assertWarnsRegex(
+            UserWarning,
+            r"in-memory dataset \(Tensor\)",
+        ):
+            DataLoader(torch.randn(10, 2), batch_size=2, num_workers=1)
+
+    def test_perf_warning_tensor_dataset(self):
+        with self.assertWarnsRegex(
+            UserWarning,
+            r"in-memory dataset \(TensorDataset\)",
+        ):
+            DataLoader(self.dataset, batch_size=2, num_workers=1)
+
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_perf_warning_numpy(self):
+        import numpy as np
+
+        with self.assertWarnsRegex(
+            UserWarning,
+            r"in-memory dataset \(ndarray\)",
+        ):
+            DataLoader(np.arange(10), batch_size=2, num_workers=1)
+
+    def test_no_perf_warning_num_workers_zero(self):
+        self.assertNotWarn(
+            lambda: DataLoader(torch.randn(10, 2), batch_size=2, num_workers=0),
+            "Should not warn for in-memory dataset when num_workers=0",
+        )
+
+    def test_no_perf_warning_custom_dataset(self):
+        self.assertNotWarn(
+            lambda: DataLoader(CountingDataset(10), batch_size=2, num_workers=1),
+            "Should not warn for a custom Dataset subclass with num_workers=1",
+        )
+
 
 class TestDataLoaderDeviceType(TestCase):
     @parametrize(

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -32,7 +32,7 @@ from torch.utils.data.datapipes.datapipe import (
     IterDataPipe,
     MapDataPipe,
 )
-from torch.utils.data.dataset import Dataset, IterableDataset
+from torch.utils.data.dataset import Dataset, IterableDataset, TensorDataset
 from torch.utils.data.sampler import (
     BatchSampler,
     RandomSampler,
@@ -420,6 +420,32 @@ class DataLoader(Generic[_T_co]):
         )
 
         self._iterator = None
+
+        # Performance warning for in-memory datasets with num_workers > 0
+        if self.num_workers > 0:
+            _is_in_memory = isinstance(self.dataset, (torch.Tensor, TensorDataset))
+            if not _is_in_memory:
+                try:
+                    import numpy as np
+                    _is_in_memory = isinstance(self.dataset, np.ndarray)
+                except ImportError:
+                    pass
+            if _is_in_memory:
+                warnings.warn(
+                    f"DataLoader received an in-memory dataset "
+                    f"({type(self.dataset).__name__}) with "
+                    f"num_workers={self.num_workers}. For in-memory "
+                    f"datasets, worker processes add IPC and collation "
+                    f"overhead that typically makes DataLoader 3-10x "
+                    f"slower than direct indexing. Consider using "
+                    f"num_workers=0, or for torch.Tensor datasets use "
+                    f"a manual loop: "
+                    f"`for i in range(0, len(X), batch_size): "
+                    f"model(X[i:i+batch_size].to(device))`. "
+                    f"See https://github.com/pytorch/pytorch/issues/154318",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
         self.check_worker_number_rationality()
 


### PR DESCRIPTION
## Summary
Adds a `UserWarning` when `DataLoader` is constructed with an 
in-memory dataset (`torch.Tensor`, `TensorDataset`, `numpy.ndarray`) 
and `num_workers > 0`, since this combination is consistently slower 
than direct indexing due to IPC and collation overhead.

## Motivation
As documented in #154318, DataLoader with `num_workers > 0` is 
3–10x slower than direct tensor slicing for in-memory datasets 
on CPU, and up to 124x slower on fast GPUs. Users have no 
indication this is happening — this warning closes that gap.

## Changes
- `torch/utils/data/dataloader.py`: adds `UserWarning` in 
  `__init__` when in-memory dataset + `num_workers > 0`
- `test/test_dataloader.py`: adds 5 tests covering warning 
  trigger and non-trigger conditions

## Related
- #154318