### PR TITLE
sdp: warn when enable_gqa=True silently falls back to MATH

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -988,6 +988,32 @@ SDPBackend select_sdp_backend(sdp_params const& kernel_params) {
         break;
       case SDPBackend::math:
         if (ctx.userEnabledMathSDP()) {
+          // Diagnose the GQA fast-path footgun: if the user opted into GQA
+          // (enable_gqa=true) and at least one fused backend was eligible
+          // (i.e. not explicitly disabled), but landed here on MATH despite
+          // mismatched q/kv head counts, then every fused kernel rejected
+          // their config. The most common cause is fp32 inputs: FLASH
+          // requires fp16/bf16, while mem_efficient and cuDNN do not accept
+          // mismatched q/kv head counts. The MATH backend is correct but
+          // unfused, often 2x+ slower than pre-expanding K/V and using a
+          // fused kernel. Today this fallback is silent — see
+          // https://github.com/pytorch/pytorch/issues/154363.
+          if (kernel_params.enable_gqa &&
+              kernel_params.query.sym_size(-3) != kernel_params.key.sym_size(-3) &&
+              (ctx.userEnabledFlashSDP() ||
+               ctx.userEnabledMemEfficientSDP() ||
+               ctx.userEnabledCuDNNSDP())) {
+            TORCH_WARN_ONCE(
+                "scaled_dot_product_attention(enable_gqa=True) dispatched to "
+                "the MATH backend: no fused kernel accepted the GQA "
+                "configuration. The MATH backend is unfused and often "
+                "significantly slower than the fused path. Common cause: "
+                "fp32 inputs (FLASH requires fp16/bf16; mem_efficient and "
+                "cuDNN do not support GQA broadcast). To get the fused path: "
+                "cast Q/K/V to bf16/fp16, or pre-expand K/V via "
+                "repeat_interleave and pass enable_gqa=False. "
+                "(This warning is shown once.)");
+          }
           return SDPBackend::math;
         }
         break;

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1743,6 +1743,27 @@ class TestSDPAFailureModes(NNTestCase):
                                                    is_causal=False, enable_gqa=True)
 
     @onlyCUDA
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FUSED_ATTENTION,
+                     "Test requires that at least one fused backend exists to fall back from.")
+    def test_enable_gqa_silent_math_fallback_warns(self, device):
+        # When enable_gqa=True but no fused kernel accepts the config (e.g. fp32
+        # inputs: FLASH requires fp16/bf16 and mem_efficient/cuDNN do not support
+        # GQA broadcast), the dispatcher falls back to the MATH backend. MATH is
+        # correct but unfused and often 2x+ slower. This used to be silent. We
+        # now emit a one-time UserWarning. See pytorch/pytorch#154363.
+        # Note: TORCH_WARN_ONCE deduplicates per call site within a process, so
+        # this test relies on running before any other test that hits the same
+        # warning site.
+        rand_query = torch.rand(2, 8, 64, 16, device=device, dtype=torch.float32)
+        rand_key = torch.rand(2, 4, 64, 16, device=device, dtype=torch.float32)
+        rand_value = torch.rand(2, 4, 64, 16, device=device, dtype=torch.float32)
+        with self.assertWarnsRegex(UserWarning, "dispatched to the MATH backend"):
+            F.scaled_dot_product_attention(
+                rand_query, rand_key, rand_value,
+                dropout_p=0.0, is_causal=False, enable_gqa=True,
+            )
+
+    @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Does not flash_attention fused scaled dot product attention")
     @parametrize("kernel", PLATFORM_SPECIFIC_SDPA)
     def test_invalid_fused_inputs_head_dim(self, device, kernel: SDPBackend):


### PR DESCRIPTION
## Motivation

Closes part of #154363.

When a user passes `enable_gqa=True` to `F.scaled_dot_product_attention` but no fused backend supports their configuration, the dispatcher silently falls back to the **MATH** backend. MATH is correct but unfused and often 2x+ slower than pre-expanding K/V with `repeat_interleave` and using a fused kernel — so users hit a hidden performance regression with no diagnostic.

The most common trigger is **fp32 inputs**:
- FLASH requires fp16/bf16 (rejects fp32).
- `mem_efficient` and cuDNN do not support GQA broadcast (per docs and per `check_grouped_query_attention<requires_same_num_heads=true>`).
- → MATH is the only viable backend, and is selected silently.

Real-world data point — a production ViT (Meta's Sapiens2, GQA factor=2 in the middle blocks): swapping `repeat_interleave + sdpa` for `sdpa(enable_gqa=True)` on a 1B model attention call (B=4, seq=3081, 24 q-heads, 12 kv-heads, dim=64):

| dtype | path | latency |
|---|---|---|
| bf16 | `enable_gqa=True` | **0.32 ms** (FLASH path, faster) |
| fp32 | `repeat_interleave + sdpa` | 7.5 ms (mem_efficient, fast) |
| fp32 | `enable_gqa=True` | **23.1 ms** (MATH, ~3x slower) |

Today, the third row is silent. After this PR, the user gets a one-time `UserWarning` pointing to the two practical workarounds (cast to bf16/fp16, or pre-expand K/V with `enable_gqa=False`).

## What this PR does

In `select_sdp_backend` (`aten/src/ATen/native/transformers/cuda/sdp_utils.cpp`), when about to return `SDPBackend::math`, emit a `TORCH_WARN_ONCE` if all of:

1. `enable_gqa=true` (user explicitly opted into GQA),
2. `q.size(-3) != k.size(-3)` (real GQA, not just the flag with matched heads),
3. at least one fused backend is eligible in the global context (i.e. the user did not force MATH-only via `sdpa_kernel(SDPBackend.MATH)`).

When all three hold, the dispatch to MATH is necessarily a fallback caused by every fused backend rejecting the GQA config — exactly the footgun documented in #154363.

## What this PR does NOT do

This is purely a diagnostic-warning patch. It does not:
- Change which backend is selected.
- Add GQA broadcast support to `mem_efficient` or cuDNN (the underlying capability gap).
- Re-route `enable_gqa=True` in fp32 to a different code path.

Those are larger kernel-side changes; the maintainer comment on #154363 indicated they would accept a PR adding GQA support to `mem_efficient` for the MQA case, but that is out of scope here.

## Test

Adds `test_enable_gqa_silent_math_fallback_warns` in `test/test_transformers.py`. It constructs an fp32 GQA call with `q_heads=8, kv_heads=4` on CUDA and asserts that `assertWarnsRegex(UserWarning, "dispatched to the MATH backend")` fires.

I confirmed the **pre-patch** behavior with the installed `torch==2.11.0+cu128`: the same call emits zero warnings, runs to completion on MATH (output shape and dtype as expected). After this patch, the warning fires.

## Caveat — local validation

I have **not** done a full PyTorch build locally to run the test against the patched binary; CI is the source of truth here. I'd appreciate a build-and-test from a maintainer. The patch is small, the change is contained to `select_sdp_backend`'s MATH return path, and the test mirrors the existing `test_invalid_sdpa_kernel_grouped_query_attention_cuda` style.

One known concern: `TORCH_WARN_ONCE` deduplicates per call site within a process, so a test that runs after another test that already triggered the same warning site will see no warning. The test note documents this; happy to switch to a fresh-subprocess test or to `TORCH_WARN` (per-call) if reviewers prefer.

## Linked

- Issue: #154363 (`scaled_dot_product_attention` broadcasting (GQA) is a memory footgun)
- Concrete adopter affected: facebookresearch/sapiens2#3 (had to add a dtype-guard workaround for exactly this regression)
