### PR TITLE
[caffe2] Fix HIP build: cccl_counting_iterator needs explicit type

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -304,7 +304,7 @@ Tensor embedding_backward_cuda_kernel(
   int64_t *num_of_segments_ptr = num_of_segments_tensor.mutable_data_ptr<int64_t>();
   AT_DISPATCH_INDEX_TYPES(orig_indices.scalar_type(), "embedding_backward_cuda_kernel", [&] () {
     cuda::cub::unique_by_key(
-      sorted_indices.const_data_ptr<index_t>(), cccl_counting_iterator{0},
+      sorted_indices.const_data_ptr<index_t>(), cccl_counting_iterator<int>{0},
       segment_offsets.mutable_data_ptr<index_t>(),
       num_of_segments_ptr, sorted_indices.numel());
   });


### PR DESCRIPTION
Summary:
The fbpkg build for rccl-tests is broke on trunk:

```
    [2026-04-26T14:30:50.594-07:00] Stderr:
    buck-out/v2/art/fbcode/caffe2/__fb_aten_hipify_gen_eqsb_ATen/native/hip/EmbeddingBackwardKernel.hip__/3c9526a4a98b3c9a/out/ATen/native/hip/EmbeddingBackwardKernel.hip:309:49: error: alias template 'cccl_counting_iterator' requires template arguments; argument deduction only allowed for class templates
      309 |       sorted_indices.const_data_ptr<index_t>(), cccl_counting_iterator{0},
          |                                                 ^
    buck-out/v2/art/fbcode/caffe2/__ATen-hip-headers__/60046fc56b742cb4/buck-headers/ATen/hip/cub.cuh:105:1: note: template is declared here
      105 | using cccl_counting_iterator = ::thrust::counting_iterator<T>;
          | ^
    buck-out/v2/art/fbcode/caffe2/__fb_aten_hipify_gen_eqsb_ATen/native/hip/EmbeddingBackwardKernel.hip__/3c9526a4a98b3c9a/out/ATen/native/hip/EmbeddingBackwardKernel.hip:309:49: error: alias template 'cccl_counting_iterator' requires template arguments; argument deduction only allowed for class templates
      309 |       sorted_indices.const_data_ptr<index_t>(), cccl_counting_iterator{0},
          |                                                 ^
    buck-out/v2/art/fbcode/caffe2/__ATen-hip-headers__/60046fc56b742cb4/buck-headers/ATen/hip/cub.cuh:105:1: note: template is declared here
      105 | using cccl_counting_iterator = ::thrust::counting_iterator<T>;
          | ^
    2 errors generated when compiling for gfx942.
```

Appears to be introduced by: D102465810

This diff adds the template parameter to fix the issue.

Test Plan:
Show the fbpkg builds pass after fix:

ROCm 6.2: hpc_comms.rccl-tests.mast_launcher.develop:1f4482943296e9e10fa9d321baa8ac86
ROCm 6.4: pending
ROCm 7.0: pending

Differential Revision: D102536624


