### PR TITLE
[dynamo] Skip wrap_inline for exec'd Python functions

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -15785,6 +15785,21 @@ def forward(self, L_x_ : torch.Tensor):
         self.assertEqual(fn_compile_and_search(t), torch.tensor(15))
         self.assertEqual(fn_escape(t), torch.tensor(11))
 
+    @torch._dynamo.config.patch(recompile_limit=2)
+    def test_compile_exec_function_no_cache_thrash(self):
+        # Issue #124269: functions created via exec have no source
+        # file, but should not be wrapped in external_utils.wrap_inline.
+        # Otherwise every exec'd function compiles through wrap_inline's
+        # shared `inner` code object, exhausting its recompile cache
+        # after a few unique functions (and raising under fullgraph=True).
+        code = "def op(x):\n    return torch.mean(x)"
+        x = torch.zeros(3)
+        for _ in range(5):  # > recompile_limit
+            scope: dict = {"torch": torch}
+            exec(code, scope)
+            compiled = torch.compile(scope["op"], fullgraph=True)
+            self.assertEqual(compiled(x), torch.tensor(0.0))
+
 
 class MiscTestsPyTree(torch._inductor.test_case.TestCase):
     @parametrize_pytree_module

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -15787,11 +15787,8 @@ def forward(self, L_x_ : torch.Tensor):
 
     @torch._dynamo.config.patch(recompile_limit=2)
     def test_compile_exec_function_no_cache_thrash(self):
-        # Issue #124269: functions created via exec have no source
-        # file, but should not be wrapped in external_utils.wrap_inline.
-        # Otherwise every exec'd function compiles through wrap_inline's
-        # shared `inner` code object, exhausting its recompile cache
-        # after a few unique functions (and raising under fullgraph=True).
+        # Issue #124269: exec'd functions must not go through wrap_inline,
+        # else they share one `inner` code object and hit recompile_limit.
         code = "def op(x):\n    return torch.mean(x)"
         x = torch.zeros(3)
         for _ in range(5):  # > recompile_limit

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1001,7 +1001,14 @@ class _TorchDynamoContext:
             fn = external_utils.wrap_inline(fn)
         elif config.wrap_top_frame or (
             (
-                filename is None
+                # filename is None covers C-level callables (builtins, slot
+                # wrappers, methods of C objects) that Dynamo cannot trace
+                # without an extra Python frame. Python functions defined via
+                # exec/eval also report no source file, but they have a real
+                # code object Dynamo can trace; wrapping them collapses every
+                # such function onto wrap_inline's shared `inner` code object
+                # and hits the recompile limit (#124269).
+                (filename is None and not inspect.isfunction(fn))
                 or trace_rules.check(fn)
                 or top_level_in_graph
                 or has_polyfill

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1001,13 +1001,9 @@ class _TorchDynamoContext:
             fn = external_utils.wrap_inline(fn)
         elif config.wrap_top_frame or (
             (
-                # filename is None covers C-level callables (builtins, slot
-                # wrappers, methods of C objects) that Dynamo cannot trace
-                # without an extra Python frame. Python functions defined via
-                # exec/eval also report no source file, but they have a real
-                # code object Dynamo can trace; wrapping them collapses every
-                # such function onto wrap_inline's shared `inner` code object
-                # and hits the recompile limit (#124269).
+                # exec/eval'd Python functions also report no source file
+                # but can be traced directly; wrapping collapses them onto
+                # wrap_inline's shared `inner` code (#124269).
                 (filename is None and not inspect.isfunction(fn))
                 or trace_rules.check(fn)
                 or top_level_in_graph


### PR DESCRIPTION
## Summary

`OptimizedModule.__call__` wraps the target callable in `external_utils.wrap_inline` whenever `inspect.getsourcefile(fn)` returns `None`. The intent (per the inline comment) is to interpose a Python frame around C-level callables (builtins, slot wrappers, methods of C objects) that Dynamo cannot otherwise trace.

Python functions created via `exec` / `eval` also report no source file. Wrapping those in `wrap_inline` is harmful: every such function ends up running through the same `inner` code object inside `wrap_inline`, with the original function captured as a closure cell. After `recompile_limit` (default 8) distinct exec'd functions have been compiled, the cache for that single `inner` code object fills up and Dynamo emits the recompilation warning. Under `fullgraph=True` this becomes a hard `FailOnRecompileLimitHit`.

## Fix

Narrow the `filename is None` clause to also require that `fn` is not a `types.FunctionType` (`inspect.isfunction`):

```python
(filename is None and not inspect.isfunction(fn))
or trace_rules.check(fn)
or top_level_in_graph
or has_polyfill
```

- C-level callables (builtins, `types.BuiltinFunctionType`, `types.MethodWrapperType`, etc.) still match the first clause; `inspect.isfunction` returns `False` for those.
- Python functions defined via `exec` / `eval` no longer match. They are `types.FunctionType` and have their own code object Dynamo can trace directly.
- Functions covered by `trace_rules.check`, `top_level_in_graph`, or `has_polyfill` remain wrapped via the other clauses, unchanged.

This is a more principled version of the approach in the prior attempt #124720 (which keyed on `co_filename == "<string>"`). Typing the callable instead of pattern-matching the filename string is not sensitive to whatever filename `compile()` happened to use.

Fixes #124269.

## Test plan

A new regression test is included in this commit: `MiscTests.test_compile_exec_function_no_cache_thrash` in `test/dynamo/test_misc.py`. It runs the issue's repro pattern under `recompile_limit=2`:

```python
code = "def op(x):\n    return torch.mean(x)"
x = torch.zeros(3)
for _ in range(5):
    scope = {"torch": torch}
    exec(code, scope)
    compiled = torch.compile(scope["op"], fullgraph=True)
    self.assertEqual(compiled(x), torch.tensor(0.0))
```

Without this fix, the third iteration raises `FailOnRecompileLimitHit` because `wrap_inline.inner`'s shared cache is full. With the fix, each exec'd function has its own code object and the cache never thrashes, so all five iterations pass. Wait admin approval to run CI.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @mlazos @Lucaskabela