### PR TITLE
[DTensor] Fix OpSpec.mesh crash when specs contain None entries

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -1094,6 +1094,74 @@ class TestOpSchemaMetaProperties(TestCase):
         self.assertNotIn(1, shard_dims, "Should not shard on padded dim")
 
 
+class TestOpSpecMesh(TestCase):
+    """Tests for OpSpec.mesh property handling of None specs."""
+
+    def setUp(self):
+        super().setUp()
+        store = FakeStore()
+        torch.distributed.init_process_group(
+            backend="fake", rank=0, world_size=4, store=store
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        torch.distributed.destroy_process_group()
+
+    def _make_spec(self, placements):
+        mesh = DeviceMesh("cpu", torch.arange(4))
+        tm = TensorMeta(
+            shape=torch.Size([8, 16]),
+            stride=(16, 1),
+            dtype=torch.float32,
+        )
+        return DTensorSpec(mesh, placements, tm)
+
+    def test_mesh_from_single_output_spec(self):
+        spec = self._make_spec((Replicate(),))
+        op_spec = OpSpec(output_specs=spec, input_specs=(spec,))
+        self.assertEqual(op_spec.mesh.shape, (4,))
+
+    def test_mesh_from_tuple_output_specs(self):
+        spec = self._make_spec((Shard(0),))
+        op_spec = OpSpec(output_specs=(spec, spec), input_specs=(spec,))
+        self.assertEqual(op_spec.mesh.shape, (4,))
+
+    def test_mesh_from_tuple_output_specs_with_leading_none(self):
+        """When the first output spec is None, mesh should come from the
+        next non-None entry."""
+        spec = self._make_spec((Replicate(),))
+        op_spec = OpSpec(output_specs=(None, spec), input_specs=(spec,))
+        self.assertEqual(op_spec.mesh.shape, (4,))
+
+    def test_mesh_from_input_specs_when_output_is_none(self):
+        """When output_specs is None, mesh should come from input_specs."""
+        spec = self._make_spec((Shard(0),))
+        op_spec = OpSpec(output_specs=None, input_specs=(spec,))
+        self.assertEqual(op_spec.mesh.shape, (4,))
+
+    def test_mesh_from_input_specs_with_leading_none(self):
+        """When output_specs is None and input_specs has leading None entries,
+        mesh should come from the first non-None input spec."""
+        spec = self._make_spec((Replicate(),))
+        op_spec = OpSpec(output_specs=None, input_specs=(None, spec))
+        self.assertEqual(op_spec.mesh.shape, (4,))
+
+    def test_mesh_from_input_specs_when_tuple_output_all_none(self):
+        """When output_specs is a tuple of all None, mesh should fall through
+        to input_specs — same behavior as output_specs=None."""
+        spec = self._make_spec((Shard(0),))
+        op_spec = OpSpec(output_specs=(None, None), input_specs=(spec,))
+        self.assertEqual(op_spec.mesh.shape, (4,))
+
+    def test_mesh_raises_when_all_specs_none(self):
+        """When both output_specs and all input_specs are None, mesh should
+        raise AssertionError."""
+        op_spec = OpSpec(output_specs=None, input_specs=(None, None))
+        with self.assertRaisesRegex(AssertionError, "Cannot determine mesh"):
+            _ = op_spec.mesh
+
+
 class TestExpandToFullMeshOpStrategy(TestCase):
     """Tests for expand_to_full_mesh_op_strategy function.
 

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -160,21 +160,22 @@ class OpSpec:
         if isinstance(self.output_specs, DTensorSpec):
             return self.output_specs.mesh
         elif isinstance(self.output_specs, tuple):
-            out_spec = self.output_specs[0]
-            if not isinstance(out_spec, DTensorSpec):
-                raise AssertionError
-            return out_spec.mesh
-        elif self.output_specs is None:
-            # For no-output ops, get mesh from input_specs
-            if self.input_specs is None or len(self.input_specs) <= 0:
-                raise AssertionError(
-                    "Cannot determine mesh: output_specs is None and input_specs is empty"
-                )
-            return self.input_specs[0].mesh
-        else:
+            for out_spec in self.output_specs:
+                if isinstance(out_spec, DTensorSpec):
+                    return out_spec.mesh
+            # all entries are None — fall through to input_specs
+        elif self.output_specs is not None:
             raise ValueError(
-                f"function output_spec expects a single DTensorSpec or a tuple of DTensorSpec but got: {self.output_specs}"
+                f"output_specs expects DTensorSpec, tuple of DTensorSpec, or None but got: {self.output_specs}"
             )
+        # output_specs is None or tuple-of-all-None — try input_specs
+        if self.input_specs is not None:
+            for spec in self.input_specs:
+                if spec is not None:
+                    return spec.mesh
+        raise AssertionError(
+            "Cannot determine mesh: no non-None DTensorSpec in output_specs or input_specs"
+        )
 
     def input_spec(self, index: int = 0) -> DTensorSpec:
         if self.input_specs is None:


### PR DESCRIPTION
OpSpec.mesh assumed output_specs[0] and input_specs[0] were always DTensorSpec. This crashes when they are None, which is valid per the OpSpec docstring for non-tensor args/outputs.

Fix the mesh property to skip None entries when searching for a DTensorSpec in both output_specs tuples and input_specs. When output_specs is None, fall through to input_specs. When output_specs is a tuple with all-None entries, raise a clear AssertionError.

See meta-pytorch/autoparallel#436 for the downstream impact.

<!-- ps-id: 318973bc-04a6-42f1-9e58-0a38b5aa14fd -->