### PR TITLE
Migrate smoke test on B200 to OSDC

### DIFF
--- a/.github/workflows/test-b200.yml
+++ b/.github/workflows/test-b200.yml
@@ -48,6 +48,7 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+      check_experiments: arc,lf
 
   linux-jammy-cuda13_0-py3_10-gcc11-sm100-build:
     name: linux-jammy-cuda13.0-py3.10-gcc11-sm100
@@ -64,6 +65,10 @@ jobs:
           { config: "smoke_b200", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
         ]}
       # config: "smoke_b200" maps to test_python_smoke_b200() in .ci/pytorch/test.sh
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   linux-jammy-cuda13_0-py3_10-gcc11-sm100-test:
@@ -71,9 +76,13 @@ jobs:
     uses: ./.github/workflows/_linux-test.yml
     needs:
       - linux-jammy-cuda13_0-py3_10-gcc11-sm100-build
+      - get-label-type
     with:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm100-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm100-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm100-build.outputs.test-matrix }}
-      aws-role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit


### PR DESCRIPTION
Add OSDC plumbing to the B200 smoke-tests workflow by passing use-arc plus python-version, compiler, and cuda-version through to both build and test reusable workflows. Drive both runner_prefix and use-arc off the runner-determinator outputs so OSDC can be dialed up gradually via labels (similar to pull/trunk), rather than opting in 100% like operator_microbenchmark.

@nWEIdia The smoke test on B200 is relatively quick, taking around 45 minutes, so I want to use it to test the single B200 we have on EKS.  Wdyt?

Authored with Claude.