### PR TITLE
Skip standard logging methods by default in dynamo tracing

### DIFF
--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -75,6 +75,20 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
         else:
             self.assertEqual(len(counters["graph_break"]), 0)
 
+    def test_logger_with_tensor_arg_graph_breaks(self):
+        counters.clear()
+
+        def f(x):
+            x = x + x
+            logger.info("tensor: %s", x)
+            x = x * x
+            return x
+
+        x = torch.randn(3, 3)
+        opt_f = torch.compile(backend="eager")(f)
+        opt_f(x)
+        self.assertGreater(len(counters["graph_break"]), 0)
+
     def test_ignore_arbitrary_function_noop(self):
         counters.clear()
         calls = []

--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -38,19 +38,23 @@ def f_isEnabledFor(x):
 @instantiate_parametrized_tests
 class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
     @parametrize(
-        "ignore_method, fn, should_ignore_logger",
+        "ignore_method, fn, expect_moo, expect_graph_break",
         [
-            (None, f_info, False),
-            (logger_test.info, f_info, False),
-            (None, f_isEnabledFor, False),
-            (logger_test.isEnabledFor, f_isEnabledFor, False),
-            (logger.info, f_info, True),
-            (logging.Logger.info, f_info, True),
-            (logger.isEnabledFor, f_isEnabledFor, True),
-            (logging.Logger.isEnabledFor, f_isEnabledFor, True),
+            # logger.info("moo") with constant args is auto-skipped
+            (None, f_info, False, False),
+            (logger_test.info, f_info, False, False),
+            # isEnabledFor still graph breaks, but info("moo") in the
+            # continuation is auto-skipped
+            (None, f_isEnabledFor, False, True),
+            (logger_test.isEnabledFor, f_isEnabledFor, False, True),
+            # Explicit ignore via config
+            (logger.info, f_info, False, False),
+            (logging.Logger.info, f_info, False, False),
+            (logger.isEnabledFor, f_isEnabledFor, False, False),
+            (logging.Logger.isEnabledFor, f_isEnabledFor, False, False),
         ],
     )
-    def test_ignore_logger(self, ignore_method, fn, should_ignore_logger):
+    def test_ignore_logger(self, ignore_method, fn, expect_moo, expect_graph_break):
         counters.clear()
         x = torch.randn(3, 3)
         orig_out = fn(x)
@@ -62,12 +66,14 @@ class IgnoreLogsTests(torch._dynamo.test_case.TestCase):
                 printed_output = [entry.split(":", 2)[2] for entry in captured.output]
 
         self.assertTrue(same(orig_out, opt_out))
-        if should_ignore_logger:
-            self.assertNotIn("moo", printed_output)
-            self.assertEqual(len(counters["graph_break"]), 0)
-        else:
+        if expect_moo:
             self.assertIn("moo", printed_output)
+        else:
+            self.assertNotIn("moo", printed_output)
+        if expect_graph_break:
             self.assertGreater(len(counters["graph_break"]), 0)
+        else:
+            self.assertEqual(len(counters["graph_break"]), 0)
 
     def test_ignore_arbitrary_function_noop(self):
         counters.clear()

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -2095,6 +2095,24 @@ class LoggingLoggerVariable(VariableTracker):
     def get_real_python_backed_value(self) -> logging.Logger:
         return self.value
 
+    # Safe to skip when args are all constants: these methods only emit
+    # log output and never affect program state. We graph break if any
+    # arg is a tensor or symbolic value to avoid silently dropping them.
+    SAFE_LOGGER_METHODS = frozenset(
+        {
+            "debug",
+            "info",
+            "warning",
+            "warn",
+            "error",
+            "critical",
+            "fatal",
+            "log",
+            "exception",
+            "warning_once",
+        }
+    )
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -2103,17 +2121,23 @@ class LoggingLoggerVariable(VariableTracker):
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
         if tx.export:
-            # For export cases, we can just make logging functions no-ops.
             return variables.ConstantVariable.create(None)
 
         method = getattr(self.value, name, None)
         function = getattr(method, "__func__", None)
 
-        # Unified ignore set
         ignore_set = torch._dynamo.config.ignore_logging_functions
 
         if method in ignore_set or function in ignore_set:
             return variables.ConstantVariable.create(None)
+
+        if name in self.SAFE_LOGGER_METHODS:
+            has_graph_arg = any(
+                a.is_tensor() or a.is_symnode_like()
+                for a in itertools.chain(args, kwargs.values())
+            )
+            if not has_graph_arg:
+                return variables.ConstantVariable.create(None)
 
         unimplemented(
             gb_type="logging.Logger method not supported for non-export cases",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181552
* __->__ #181551

I know this is a little bit of a controversial change, but I feel its safe enough and practical to not graph break on these. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98