### PR TITLE
[Test] Add registry APIs for test configuration

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -90,15 +90,13 @@ op_combined_unsupported = _make_dummy_op("op_combined_unsupported")
 
 
 @contextmanager
-def _temp_attrs(obj, **attrs):
-    backup = {k: getattr(obj, k) for k in attrs}
-    for k, v in attrs.items():
-        setattr(obj, k, v)
+def _temp_test_configs(obj, **configs):
+    backup = {k: getattr(obj, k, None) for k in configs}
+    obj.register_test_configs(**configs)
     try:
         yield
     finally:
-        for k, v in backup.items():
-            setattr(obj, k, v)
+        obj.register_test_configs(**backup)
 
 
 class TestDeviceTypeOpenReg(TestCase):
@@ -152,18 +150,15 @@ class TestDeviceTypeOpenReg(TestCase):
 
 
 # Modify PrivateUse1TestBase which is automatically included for OpenReg
-PrivateUse1TestBase.register_op_overrides(
-    {
-        "op_skip": [DecorateInfo(unittest.skip("skip op_skip"))],
-        "op_skip_f32": [
-            DecorateInfo(unittest.skip("skip op_skip"), dtypes=(torch.float32,))
-        ],
-        "op_xfail": [DecorateInfo(unittest.expectedFailure)],
-        # This overrides the 1e-5 precision already declared on op_precision's OpInfo.
-        "op_precision": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
-    }
-)
-
+PrivateUse1TestBase.op_overrides = {
+    "op_skip": [DecorateInfo(unittest.skip("skip op_skip"))],
+    "op_skip_f32": [
+        DecorateInfo(unittest.skip("skip op_skip"), dtypes=(torch.float32,))
+    ],
+    "op_xfail": [DecorateInfo(unittest.expectedFailure)],
+    # This overrides the 1e-5 precision already declared on op_precision's OpInfo.
+    "op_precision": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
+}
 
 class TestSkippedSpecificTestCases(TestCase):
     executed_count = 0
@@ -194,12 +189,10 @@ class TestSkippedWholeTestClass(TestCase):
 
 
 # PrivateUse1 can skip individual methods or an entire instantiated class.
-PrivateUse1TestBase.register_test_exclusions(
-    {
-        "TestSkippedSpecificTestCases": ["test_skipped"],
-        "TestSkippedWholeTestClass": "*",
-    }
-)
+PrivateUse1TestBase.test_exclusions = {
+    "TestSkippedSpecificTestCases": ["test_skipped"],
+    "TestSkippedWholeTestClass": "*",
+}
 
 
 class TestSupportedOpsWithOverrides(TestCase):
@@ -240,7 +233,7 @@ instantiate_device_type_tests(
 )
 instantiate_device_type_tests(TestSkippedWholeTestClass, globals(), only_for="openreg")
 
-with _temp_attrs(
+with _temp_test_configs(
     PrivateUse1TestBase,
     op_overrides={
         "op_combined_skip": [DecorateInfo(unittest.skip("skip via op_overrides"))]

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -152,15 +152,17 @@ class TestDeviceTypeOpenReg(TestCase):
 
 
 # Modify PrivateUse1TestBase which is automatically included for OpenReg
-PrivateUse1TestBase.op_overrides = {
-    "op_skip": [DecorateInfo(unittest.skip("skip op_skip"))],
-    "op_skip_f32": [
-        DecorateInfo(unittest.skip("skip op_skip"), dtypes=(torch.float32,))
-    ],
-    "op_xfail": [DecorateInfo(unittest.expectedFailure)],
-    # This overrides the 1e-5 precision already declared on op_precision's OpInfo.
-    "op_precision": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
-}
+PrivateUse1TestBase.register_op_overrides(
+    {
+        "op_skip": [DecorateInfo(unittest.skip("skip op_skip"))],
+        "op_skip_f32": [
+            DecorateInfo(unittest.skip("skip op_skip"), dtypes=(torch.float32,))
+        ],
+        "op_xfail": [DecorateInfo(unittest.expectedFailure)],
+        # This overrides the 1e-5 precision already declared on op_precision's OpInfo.
+        "op_precision": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
+    }
+)
 
 
 class TestSkippedSpecificTestCases(TestCase):
@@ -192,10 +194,12 @@ class TestSkippedWholeTestClass(TestCase):
 
 
 # PrivateUse1 can skip individual methods or an entire instantiated class.
-PrivateUse1TestBase.test_exclusions = {
-    "TestSkippedSpecificTestCases": ["test_skipped"],
-    "TestSkippedWholeTestClass": "*",
-}
+PrivateUse1TestBase.register_test_exclusions(
+    {
+        "TestSkippedSpecificTestCases": ["test_skipped"],
+        "TestSkippedWholeTestClass": "*",
+    }
+)
 
 
 class TestSupportedOpsWithOverrides(TestCase):

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -160,6 +160,7 @@ PrivateUse1TestBase.op_overrides = {
     "op_precision": [DecorateInfo(precisionOverride({torch.float32: 1e-2}))],
 }
 
+
 class TestSkippedSpecificTestCases(TestCase):
     executed_count = 0
 

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -92,11 +92,11 @@ op_combined_unsupported = _make_dummy_op("op_combined_unsupported")
 @contextmanager
 def _temp_test_configs(obj, **configs):
     backup = {k: getattr(obj, k, None) for k in configs}
-    obj.register_test_configs(**configs)
+    obj.set_test_configs(**configs)
     try:
         yield
     finally:
-        obj.register_test_configs(**backup)
+        obj.set_test_configs(**backup)
 
 
 class TestDeviceTypeOpenReg(TestCase):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -495,9 +495,9 @@ class DeviceTypeTestBase(TestCase):
         """
         Sets or resets the test configuration fields.
 
-        WARNING: This method is designed to perform a FULL replacement of the 
-        current configuration. Calling this method without any arguments will 
-        act as a "reset", clearing all stored configurations back to their 
+        WARNING: This method is designed to perform a FULL replacement of the
+        current configuration. Calling this method without any arguments will
+        act as a "reset", clearing all stored configurations back to their
         default `None` state.
         """
         cls.op_overrides = op_overrides

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -484,6 +484,35 @@ class DeviceTypeTestBase(TestCase):
             self.precision = self._get_precision_override(test, dtype)
             self.precision, self.rel_tol = self._get_tolerance_override(test, dtype)
 
+    @classmethod
+    def register_op_overrides(cls, op_overrides, overwrite=False):
+        if cls.op_overrides is None or overwrite:
+            cls.op_overrides = {}
+
+        for op_name, decorators in op_overrides.items():
+            cls.op_overrides.setdefault(op_name, [])
+            cls.op_overrides[op_name].extend(decorators)
+
+    @classmethod
+    def register_test_exclusions(cls, test_exclusions, overwrite=False):
+        if (
+            not hasattr(cls, "test_exclusions")
+            or cls.test_exclusions is None
+            or overwrite
+        ):
+            cls.test_exclusions = {}
+        for test_class, tests in test_exclusions.items():
+            if test_class not in cls.test_exclusions:
+                cls.test_exclusions[test_class] = tests
+            elif cls.test_exclusions[test_class] == "*":
+                continue
+            elif tests == "*":
+                cls.test_exclusions[test_class] = "*"
+            else:
+                cls.test_exclusions[test_class] = list(
+                    set(cls.test_exclusions[test_class]) | set(tests)
+                )
+
     # Creates device-specific tests.
     @classmethod
     def instantiate_test(cls, name, test, *, generic_cls=None):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -356,7 +356,7 @@ class DeviceTypeTestBase(TestCase):
     #       "TestClassA": ["test_a", "test_b"],   # Selective: Skips specific
     #       "TestClassB": "*",                    # Global: Skips the entire class
     #   }
-    test_exclusions: ClassVar[dict[str, Collection[str]]]
+    test_exclusions: ClassVar[dict[str, Collection[str]] | None] = None
 
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -485,16 +485,19 @@ class DeviceTypeTestBase(TestCase):
             self.precision, self.rel_tol = self._get_tolerance_override(test, dtype)
 
     @classmethod
-    def register_test_configs(cls, **kwargs):
+    def set_test_configs(cls, **kwargs):
         allowed = {
             "op_overrides",
             "op_allowlist",
             "test_exclusions",
         }
 
-        for key in allowed:
-            if key in kwargs:
-                setattr(cls, key, kwargs[key])
+        invalid_keys = set(kwargs) - allowed
+        if invalid_keys:
+            raise ValueError(f"Unsupported test configs: {invalid_keys}")
+
+        for key, value in kwargs.items():
+            setattr(cls, key, value)
 
     # Creates device-specific tests.
     @classmethod

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -493,10 +493,12 @@ class DeviceTypeTestBase(TestCase):
         test_exclusions=None,
     ):
         """
-        Sets the test configuration fields (op_overrides, op_allowlist, test_exclusions).
+        Sets or resets the test configuration fields.
 
-        This API replaces the full configuration in one call. Unspecified arguments
-        default to None, and all values overwrite any previously stored configuration.
+        WARNING: This method is designed to perform a FULL replacement of the 
+        current configuration. Calling this method without any arguments will 
+        act as a "reset", clearing all stored configurations back to their 
+        default `None` state.
         """
         cls.op_overrides = op_overrides
         cls.op_allowlist = op_allowlist

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -485,19 +485,22 @@ class DeviceTypeTestBase(TestCase):
             self.precision, self.rel_tol = self._get_tolerance_override(test, dtype)
 
     @classmethod
-    def set_test_configs(cls, **kwargs):
-        allowed = {
-            "op_overrides",
-            "op_allowlist",
-            "test_exclusions",
-        }
+    def set_test_configs(
+        cls,
+        *,
+        op_overrides=None,
+        op_allowlist=None,
+        test_exclusions=None,
+    ):
+        """
+        Sets the test configuration fields (op_overrides, op_allowlist, test_exclusions).
 
-        invalid_keys = set(kwargs) - allowed
-        if invalid_keys:
-            raise ValueError(f"Unsupported test configs: {invalid_keys}")
-
-        for key, value in kwargs.items():
-            setattr(cls, key, value)
+        This API replaces the full configuration in one call. Unspecified arguments
+        default to None, and all values overwrite any previously stored configuration.
+        """
+        cls.op_overrides = op_overrides
+        cls.op_allowlist = op_allowlist
+        cls.test_exclusions = test_exclusions
 
     # Creates device-specific tests.
     @classmethod

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -485,33 +485,16 @@ class DeviceTypeTestBase(TestCase):
             self.precision, self.rel_tol = self._get_tolerance_override(test, dtype)
 
     @classmethod
-    def register_op_overrides(cls, op_overrides, overwrite=False):
-        if cls.op_overrides is None or overwrite:
-            cls.op_overrides = {}
+    def register_test_configs(cls, **kwargs):
+        allowed = {
+            "op_overrides",
+            "op_allowlist",
+            "test_exclusions",
+        }
 
-        for op_name, decorators in op_overrides.items():
-            cls.op_overrides.setdefault(op_name, [])
-            cls.op_overrides[op_name].extend(decorators)
-
-    @classmethod
-    def register_test_exclusions(cls, test_exclusions, overwrite=False):
-        if (
-            not hasattr(cls, "test_exclusions")
-            or cls.test_exclusions is None
-            or overwrite
-        ):
-            cls.test_exclusions = {}
-        for test_class, tests in test_exclusions.items():
-            if test_class not in cls.test_exclusions:
-                cls.test_exclusions[test_class] = tests
-            elif cls.test_exclusions[test_class] == "*":
-                continue
-            elif tests == "*":
-                cls.test_exclusions[test_class] = "*"
-            else:
-                cls.test_exclusions[test_class] = list(
-                    set(cls.test_exclusions[test_class]) | set(tests)
-                )
+        for key in allowed:
+            if key in kwargs:
+                setattr(cls, key, kwargs[key])
 
     # Creates device-specific tests.
     @classmethod


### PR DESCRIPTION
Fixes #181348

## Summary

This PR adds APIs to allow vendors to register `op_overrides`, `op_allowlist` and `test_exclusions`  
for subclasses of DeviceTypeTestBase (e.g. PrivateUse1TestBase).