### PR TITLE
Reject aliased Q and R in linalg.qr `out=` argument

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2,6 +2,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/core/grad_mode.h>
 #include <ATen/Dispatch.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorMeta.h>
 #include <ATen/TensorOperators.h>
@@ -2448,6 +2449,11 @@ TORCH_IMPL_FUNC(linalg_qr_out)(const Tensor& A,
                                std::string_view mode,
                                const Tensor & Q,
                                const Tensor & R) {
+  // Aliased Q and R produce silent wrong results: the GEQRF stage writes the
+  // packed factorization into the shared storage, then `R.triu_()` zeros the
+  // lower triangle that ORGQR needs to reconstruct Q. See #180377.
+  at::assert_no_overlap(Q, R);
+
   auto m = A.size(-2);
   auto n = A.size(-1);
   auto k = std::min(m, n);

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4419,6 +4419,12 @@ class TestLinalg(TestCase):
         t2 = torch.randn((5, 7), device=device, dtype=dtype)
         with self.assertRaisesRegex(RuntimeError, "qr received unrecognized mode 'hello'"):
             torch.linalg.qr(t2, mode='hello')
+        # https://github.com/pytorch/pytorch/issues/180377: aliasing Q and R
+        # in `out=` silently produced wrong results when A was square.
+        t3 = torch.randn(3, 3, device=device, dtype=dtype)
+        B = torch.empty_like(t3)
+        with self.assertRaisesRegex(RuntimeError, 'single memory location'):
+            torch.linalg.qr(t3, out=(B, B))
 
     def _check_einsum(self, *args, np_args=None):
         if np_args is None:


### PR DESCRIPTION
## Problem

`torch.linalg.qr(A, out=(B, B))` silently returns wrong results when `A` is square. The out-tensor aliasing is not validated anywhere, and the in-place GEQRF + `R.triu_()` path zeros the Householder reflectors that the subsequent ORGQR needs to reconstruct Q. The function returns without error and `B` ends up holding an arbitrary matrix — neither Q nor R.

```python
import torch
X = torch.randn(2, 2)
B = torch.zeros_like(X)
torch.linalg.qr(X, out=(B, B))   # no error; B is now garbage
```

The non-square case already errors via shape mismatch, so the gap is square-input only.

## Fix

Reuse the existing `at::assert_no_overlap(Q, R)` helper at the top of `TORCH_IMPL_FUNC(linalg_qr_out)`. Same helper `kthvalue`, `cross`, `sort`, etc. already use for output-aliasing bugs in this class, so the user-facing error stays consistent across the codebase:

> RuntimeError: unsupported operation: some elements of the input tensor and the written-to tensor refer to a single memory location. Please clone() the tensor before performing the operation.

The check applies uniformly to all modes — for `mode='r'` where Q is a placeholder, the user can `clone()` if they truly want the same object for both outputs.

## Test

Added a case to `test_qr_error_cases` (`test/test_linalg.py`) that asserts the error fires for `out=(B, B)` on a square input. Runs on both CPU (LAPACK) and CUDA (cuSOLVER) via the existing decorators.

Fixes #180377