### PR TITLE
Clamp count in Vectorized16 partial loadu/store paths for gcc-14

### DIFF
--- a/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_bfloat16.h
@@ -100,7 +100,7 @@ class Vectorized<BFloat16> {
     std::memcpy(
         reinterpret_cast<bfloat16_t*>(ptr),
         reinterpret_cast<const bfloat16_t*>(tmp),
-        count * sizeof(bfloat16_t));
+        std::min<int64_t>(count, size()) * sizeof(bfloat16_t));
   }
   const BFloat16& operator[](int idx) const = delete;
   BFloat16& operator[](int idx) = delete;

--- a/aten/src/ATen/cpu/vec/sve/vec_qint.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_qint.h
@@ -92,7 +92,10 @@ struct VectorizedQuantizedConverter {
   }
 
   void store(void* ptr, int count = size()) const {
-    memcpy(ptr, vals.data(), std::min<int64_t>(count, size()) * sizeof(value_type));
+    memcpy(
+        ptr,
+        vals.data(),
+        std::min<int64_t>(count, size()) * sizeof(value_type));
   }
 
   float_vec_return_type dequantize(

--- a/aten/src/ATen/cpu/vec/sve/vec_qint.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_qint.h
@@ -92,7 +92,7 @@ struct VectorizedQuantizedConverter {
   }
 
   void store(void* ptr, int count = size()) const {
-    memcpy(ptr, vals.data(), count * sizeof(value_type));
+    memcpy(ptr, vals.data(), std::min<int64_t>(count, size()) * sizeof(value_type));
   }
 
   float_vec_return_type dequantize(
@@ -186,7 +186,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return loadu(tmp_values);
   }
 #else
@@ -349,7 +349,7 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return loadu(tmp_values);
   }
 
@@ -492,7 +492,7 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return loadu(tmp_values);
   }
 #else

--- a/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
@@ -320,7 +320,10 @@ class Vectorized<c10::BFloat16> : public Vectorized16<
     } else {
       at_bfloat16_t tmp_values[size()];
       at_vst1q_bf16(reinterpret_cast<at_bfloat16_t*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(at_bfloat16_t));
+      std::memcpy(
+          ptr,
+          tmp_values,
+          std::min<int64_t>(count, size()) * sizeof(at_bfloat16_t));
     }
   }
   Vectorized<c10::BFloat16> isnan() const {

--- a/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_bfloat16_neon.h
@@ -310,7 +310,7 @@ class Vectorized<c10::BFloat16> : public Vectorized16<
     std::memcpy(
         tmp_values,
         reinterpret_cast<const at_bfloat16_t*>(ptr),
-        count * sizeof(at_bfloat16_t));
+        std::min<int64_t>(count, size()) * sizeof(at_bfloat16_t));
     return at_vld1q_bf16(reinterpret_cast<const at_bfloat16_t*>(tmp_values));
   }
   void store(void* ptr, int64_t count = size()) const {
@@ -320,7 +320,7 @@ class Vectorized<c10::BFloat16> : public Vectorized16<
     } else {
       at_bfloat16_t tmp_values[size()];
       at_vst1q_bf16(reinterpret_cast<at_bfloat16_t*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(at_bfloat16_t));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(at_bfloat16_t));
     }
   }
   Vectorized<c10::BFloat16> isnan() const {

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -179,7 +179,7 @@ class Vectorized<float> {
       std::memcpy(
           tmp_values,
           reinterpret_cast<const float*>(ptr),
-          count * sizeof(float));
+          std::min<int64_t>(count, size()) * sizeof(float));
       return vld1q_f32(reinterpret_cast<const float*>(tmp_values));
     }
   }
@@ -189,7 +189,7 @@ class Vectorized<float> {
     } else {
       float tmp_values[size()];
       vst1q_f32(reinterpret_cast<float*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(float));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(float));
     }
   }
   // Very slow implementation of indexing.

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -189,7 +189,8 @@ class Vectorized<float> {
     } else {
       float tmp_values[size()];
       vst1q_f32(reinterpret_cast<float*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(float));
+      std::memcpy(
+          ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(float));
     }
   }
   // Very slow implementation of indexing.

--- a/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
@@ -206,7 +206,7 @@ class Vectorized<c10::Half> : public Vectorized16<
     std::memcpy(
         tmp_values,
         reinterpret_cast<const float16_t*>(ptr),
-        count * sizeof(float16_t));
+        std::min<int64_t>(count, size()) * sizeof(float16_t));
     return vld1q_f16(reinterpret_cast<const float16_t*>(tmp_values));
   }
   void store(void* ptr, int64_t count = size()) const {
@@ -216,7 +216,7 @@ class Vectorized<c10::Half> : public Vectorized16<
     } else {
       float16_t tmp_values[size()];
       vst1q_f16(reinterpret_cast<float16_t*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(float16_t));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(float16_t));
     }
   }
   int zero_mask() const {

--- a/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_half_neon.h
@@ -216,7 +216,10 @@ class Vectorized<c10::Half> : public Vectorized16<
     } else {
       float16_t tmp_values[size()];
       vst1q_f16(reinterpret_cast<float16_t*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(float16_t));
+      std::memcpy(
+          ptr,
+          tmp_values,
+          std::min<int64_t>(count, size()) * sizeof(float16_t));
     }
   }
   int zero_mask() const {

--- a/aten/src/ATen/cpu/vec/vec128/vec128_int_aarch64.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_int_aarch64.h
@@ -386,7 +386,7 @@ Vectorized<int8_t> Vectorized<int8_t>::blend(
       std::memcpy(                                                            \
           tmp_values,                                                         \
           reinterpret_cast<const int##bit##_t*>(ptr),                         \
-          std::min<int64_t>(count, size()) * sizeof(int##bit##_t));                                      \
+          std::min<int64_t>(count, size()) * sizeof(int##bit##_t));           \
       return vld1q_s##bit(reinterpret_cast<const int##bit##_t*>(tmp_values)); \
     }                                                                         \
   }                                                                           \
@@ -397,7 +397,10 @@ Vectorized<int8_t> Vectorized<int8_t>::blend(
     } else {                                                                  \
       int##bit##_t tmp_values[size()];                                        \
       vst1q_s##bit(reinterpret_cast<int##bit##_t*>(tmp_values), values);      \
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int##bit##_t));             \
+      std::memcpy(                                                            \
+          ptr,                                                                \
+          tmp_values,                                                         \
+          std::min<int64_t>(count, size()) * sizeof(int##bit##_t));           \
     }                                                                         \
   }
 

--- a/aten/src/ATen/cpu/vec/vec128/vec128_int_aarch64.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_int_aarch64.h
@@ -386,7 +386,7 @@ Vectorized<int8_t> Vectorized<int8_t>::blend(
       std::memcpy(                                                            \
           tmp_values,                                                         \
           reinterpret_cast<const int##bit##_t*>(ptr),                         \
-          count * sizeof(int##bit##_t));                                      \
+          std::min<int64_t>(count, size()) * sizeof(int##bit##_t));                                      \
       return vld1q_s##bit(reinterpret_cast<const int##bit##_t*>(tmp_values)); \
     }                                                                         \
   }                                                                           \
@@ -397,7 +397,7 @@ Vectorized<int8_t> Vectorized<int8_t>::blend(
     } else {                                                                  \
       int##bit##_t tmp_values[size()];                                        \
       vst1q_s##bit(reinterpret_cast<int##bit##_t*>(tmp_values), values);      \
-      std::memcpy(ptr, tmp_values, count * sizeof(int##bit##_t));             \
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int##bit##_t));             \
     }                                                                         \
   }
 

--- a/aten/src/ATen/cpu/vec/vec128/vec128_uint_aarch64.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_uint_aarch64.h
@@ -262,7 +262,7 @@ Vectorized<uint8_t> Vectorized<uint8_t>::blend(
       std::memcpy(                                                             \
           tmp_values,                                                          \
           reinterpret_cast<const uint##bit##_t*>(ptr),                         \
-          std::min<int64_t>(count, size()) * sizeof(uint##bit##_t));                                      \
+          std::min<int64_t>(count, size()) * sizeof(uint##bit##_t));           \
       return vld1q_u##bit(reinterpret_cast<const uint##bit##_t*>(tmp_values)); \
     }                                                                          \
   }                                                                            \
@@ -273,7 +273,10 @@ Vectorized<uint8_t> Vectorized<uint8_t>::blend(
     } else {                                                                   \
       uint##bit##_t tmp_values[size()];                                        \
       vst1q_u##bit(reinterpret_cast<uint##bit##_t*>(tmp_values), values);      \
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(uint##bit##_t));             \
+      std::memcpy(                                                             \
+          ptr,                                                                 \
+          tmp_values,                                                          \
+          std::min<int64_t>(count, size()) * sizeof(uint##bit##_t));           \
     }                                                                          \
   }
 

--- a/aten/src/ATen/cpu/vec/vec128/vec128_uint_aarch64.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_uint_aarch64.h
@@ -262,7 +262,7 @@ Vectorized<uint8_t> Vectorized<uint8_t>::blend(
       std::memcpy(                                                             \
           tmp_values,                                                          \
           reinterpret_cast<const uint##bit##_t*>(ptr),                         \
-          count * sizeof(uint##bit##_t));                                      \
+          std::min<int64_t>(count, size()) * sizeof(uint##bit##_t));                                      \
       return vld1q_u##bit(reinterpret_cast<const uint##bit##_t*>(tmp_values)); \
     }                                                                          \
   }                                                                            \
@@ -273,7 +273,7 @@ Vectorized<uint8_t> Vectorized<uint8_t>::blend(
     } else {                                                                   \
       uint##bit##_t tmp_values[size()];                                        \
       vst1q_u##bit(reinterpret_cast<uint##bit##_t*>(tmp_values), values);      \
-      std::memcpy(ptr, tmp_values, count * sizeof(uint##bit##_t));             \
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(uint##bit##_t));             \
     }                                                                          \
   }
 

--- a/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
@@ -251,14 +251,19 @@ class Vectorized16 {
     if (count == size())
       return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
 
+    // The contract is 0 <= count <= size(), but the parameter type allows
+    // values that would overflow the fixed-size buffer below; clamp
+    // explicitly so the memcpy bound is provable to gcc-14 (#159962) and
+    // out-of-contract callers stay safe.
+    const int n = std::clamp(static_cast<int>(count), 0, size());
     __at_align__ int16_t tmp_values[size()];
 #ifndef __msvc_cl__
 #pragma unroll
 #endif
-    for (const auto i : c10::irange(count, size())) {
+    for (const auto i : c10::irange(n, size())) {
       tmp_values[i] = 0;
     }
-    std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
+    std::memcpy(tmp_values, ptr, n * sizeof(int16_t));
     return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(tmp_values));
   }
   void store(void* ptr, int count = size()) const {
@@ -267,7 +272,9 @@ class Vectorized16 {
     } else if (count > 0) {
       __at_align__ int16_t tmp_values[size()];
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(int16_t));
+      // Clamp for the same reason as loadu above.
+      const int n = std::min(count, size());
+      std::memcpy(ptr, tmp_values, n * sizeof(int16_t));
     }
   }
   template <int64_t mask>

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -110,7 +110,7 @@ class Vectorized<c10::complex<double>> {
     std::memcpy(
         tmp_values,
         reinterpret_cast<const double*>(ptr),
-        count * sizeof(c10::complex<double>));
+        std::min<int64_t>(count, size()) * sizeof(c10::complex<double>));
     return _mm256_load_pd(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -119,7 +119,7 @@ class Vectorized<c10::complex<double>> {
     } else if (count > 0) {
       double tmp_values[2 * size()];
       _mm256_storeu_pd(reinterpret_cast<double*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(c10::complex<double>));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(c10::complex<double>));
     }
   }
   const c10::complex<double>& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -119,7 +119,10 @@ class Vectorized<c10::complex<double>> {
     } else if (count > 0) {
       double tmp_values[2 * size()];
       _mm256_storeu_pd(reinterpret_cast<double*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(c10::complex<double>));
+      std::memcpy(
+          ptr,
+          tmp_values,
+          std::min<int64_t>(count, size()) * sizeof(c10::complex<double>));
     }
   }
   const c10::complex<double>& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -175,7 +175,7 @@ class Vectorized<c10::complex<float>> {
     std::memcpy(
         tmp_values,
         reinterpret_cast<const float*>(ptr),
-        count * sizeof(c10::complex<float>));
+        std::min<int64_t>(count, size()) * sizeof(c10::complex<float>));
     return _mm256_load_ps(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -184,7 +184,7 @@ class Vectorized<c10::complex<float>> {
     } else if (count > 0) {
       float tmp_values[2 * size()];
       _mm256_storeu_ps(reinterpret_cast<float*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(c10::complex<float>));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(c10::complex<float>));
     }
   }
   const c10::complex<float>& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -184,7 +184,10 @@ class Vectorized<c10::complex<float>> {
     } else if (count > 0) {
       float tmp_values[2 * size()];
       _mm256_storeu_ps(reinterpret_cast<float*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(c10::complex<float>));
+      std::memcpy(
+          ptr,
+          tmp_values,
+          std::min<int64_t>(count, size()) * sizeof(c10::complex<float>));
     }
   }
   const c10::complex<float>& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_double.h
@@ -103,7 +103,8 @@ class Vectorized<double> {
     } else if (count > 0) {
       double tmp_values[size()];
       _mm256_storeu_pd(reinterpret_cast<double*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(double));
+      std::memcpy(
+          ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(double));
     }
   }
   const double& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_double.h
@@ -94,7 +94,7 @@ class Vectorized<double> {
     std::memcpy(
         tmp_values,
         reinterpret_cast<const double*>(ptr),
-        count * sizeof(double));
+        std::min<int64_t>(count, size()) * sizeof(double));
     return _mm256_load_pd(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -103,7 +103,7 @@ class Vectorized<double> {
     } else if (count > 0) {
       double tmp_values[size()];
       _mm256_storeu_pd(reinterpret_cast<double*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(double));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(double));
     }
   }
   const double& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -123,7 +123,9 @@ class Vectorized<float> {
       tmp_values[i] = 0.0;
     }
     std::memcpy(
-        tmp_values, reinterpret_cast<const float*>(ptr), std::min<int64_t>(count, size()) * sizeof(float));
+        tmp_values,
+        reinterpret_cast<const float*>(ptr),
+        std::min<int64_t>(count, size()) * sizeof(float));
     return _mm256_loadu_ps(tmp_values);
   }
   void store(void* ptr, int64_t count = size()) const {
@@ -132,7 +134,8 @@ class Vectorized<float> {
     } else if (count > 0) {
       float tmp_values[size()];
       _mm256_storeu_ps(reinterpret_cast<float*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(float));
+      std::memcpy(
+          ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(float));
     }
   }
   const float& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -123,7 +123,7 @@ class Vectorized<float> {
       tmp_values[i] = 0.0;
     }
     std::memcpy(
-        tmp_values, reinterpret_cast<const float*>(ptr), count * sizeof(float));
+        tmp_values, reinterpret_cast<const float*>(ptr), std::min<int64_t>(count, size()) * sizeof(float));
     return _mm256_loadu_ps(tmp_values);
   }
   void store(void* ptr, int64_t count = size()) const {
@@ -132,7 +132,7 @@ class Vectorized<float> {
     } else if (count > 0) {
       float tmp_values[size()];
       _mm256_storeu_ps(reinterpret_cast<float*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(float));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(float));
     }
   }
   const float& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_int.h
@@ -121,7 +121,8 @@ class Vectorized<int64_t> : public Vectorizedi {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
-    std::memcpy(tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int64_t));
+    std::memcpy(
+        tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int64_t));
     return loadu(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -132,7 +133,8 @@ class Vectorized<int64_t> : public Vectorizedi {
     } else if (count > 0) {
       __at_align__ int64_t tmp_values[size()];
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int64_t));
+      std::memcpy(
+          ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int64_t));
     }
   }
   const int64_t& operator[](int idx) const = delete;
@@ -271,7 +273,8 @@ class Vectorized<int32_t> : public Vectorizedi {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
-    std::memcpy(tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int32_t));
+    std::memcpy(
+        tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int32_t));
     return loadu(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -282,7 +285,8 @@ class Vectorized<int32_t> : public Vectorizedi {
     } else if (count > 0) {
       __at_align__ int32_t tmp_values[size()];
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int32_t));
+      std::memcpy(
+          ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int32_t));
     }
   }
   const int32_t& operator[](int idx) const = delete;
@@ -571,7 +575,8 @@ class Vectorized<int16_t> : public Vectorizedi {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
-    std::memcpy(tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int16_t));
+    std::memcpy(
+        tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int16_t));
     return loadu(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -582,7 +587,8 @@ class Vectorized<int16_t> : public Vectorizedi {
     } else if (count > 0) {
       __at_align__ int16_t tmp_values[size()];
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int16_t));
+      std::memcpy(
+          ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int16_t));
     }
   }
   const int16_t& operator[](int idx) const = delete;
@@ -935,7 +941,8 @@ class Vectorized8 : public Vectorizedi {
       } else {
         __at_align__ T tmp_values[size()];
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
-        std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(T));
+        std::memcpy(
+            ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(T));
       }
     }
   }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_int.h
@@ -121,7 +121,7 @@ class Vectorized<int64_t> : public Vectorizedi {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
-    std::memcpy(tmp_values, ptr, count * sizeof(int64_t));
+    std::memcpy(tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int64_t));
     return loadu(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -132,7 +132,7 @@ class Vectorized<int64_t> : public Vectorizedi {
     } else if (count > 0) {
       __at_align__ int64_t tmp_values[size()];
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(int64_t));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int64_t));
     }
   }
   const int64_t& operator[](int idx) const = delete;
@@ -271,7 +271,7 @@ class Vectorized<int32_t> : public Vectorizedi {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
-    std::memcpy(tmp_values, ptr, count * sizeof(int32_t));
+    std::memcpy(tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int32_t));
     return loadu(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -282,7 +282,7 @@ class Vectorized<int32_t> : public Vectorizedi {
     } else if (count > 0) {
       __at_align__ int32_t tmp_values[size()];
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(int32_t));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int32_t));
     }
   }
   const int32_t& operator[](int idx) const = delete;
@@ -571,7 +571,7 @@ class Vectorized<int16_t> : public Vectorizedi {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
-    std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
+    std::memcpy(tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(int16_t));
     return loadu(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -582,7 +582,7 @@ class Vectorized<int16_t> : public Vectorizedi {
     } else if (count > 0) {
       __at_align__ int16_t tmp_values[size()];
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(int16_t));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(int16_t));
     }
   }
   const int16_t& operator[](int idx) const = delete;
@@ -919,7 +919,7 @@ class Vectorized8 : public Vectorizedi {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
-    std::memcpy(tmp_values, ptr, count * sizeof(T));
+    std::memcpy(tmp_values, ptr, std::min<int64_t>(count, size()) * sizeof(T));
     return loadu(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -935,7 +935,7 @@ class Vectorized8 : public Vectorizedi {
       } else {
         __at_align__ T tmp_values[size()];
         _mm256_storeu_si256(reinterpret_cast<__m256i*>(tmp_values), values);
-        std::memcpy(ptr, tmp_values, count * sizeof(T));
+        std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(T));
       }
     }
   }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -373,7 +373,7 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
 
   void store(void* ptr, int count = size()) const {
     if (count != size()) {
-      memcpy(ptr, &vals, count * sizeof(value_type));
+      memcpy(ptr, &vals, std::min<int64_t>(count, size()) * sizeof(value_type));
     } else {
       _mm256_storeu_si256((__m256i*)ptr, vals);
     }
@@ -395,7 +395,7 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return _mm256_loadu_si256((const __m256i*)tmp_values);
   }
 
@@ -589,7 +589,7 @@ struct Vectorized<c10::qint8> : public Vectorizedqi {
 
   void store(void* ptr, int count = size()) const {
     if (count != size()) {
-      memcpy(ptr, &vals, count * sizeof(value_type));
+      memcpy(ptr, &vals, std::min<int64_t>(count, size()) * sizeof(value_type));
     } else {
       _mm256_storeu_si256((__m256i*)ptr, vals);
     }
@@ -611,7 +611,7 @@ struct Vectorized<c10::qint8> : public Vectorizedqi {
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return _mm256_loadu_si256((const __m256i*)tmp_values);
   }
 
@@ -800,7 +800,7 @@ struct Vectorized<c10::quint8> : public Vectorizedqi {
 
   void store(void* ptr, int count = size()) const {
     if (count != size()) {
-      memcpy(ptr, &vals, count * sizeof(value_type));
+      memcpy(ptr, &vals, std::min<int64_t>(count, size()) * sizeof(value_type));
     } else {
       _mm256_storeu_si256((__m256i*)ptr, vals);
     }
@@ -822,7 +822,7 @@ struct Vectorized<c10::quint8> : public Vectorizedqi {
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return _mm256_loadu_si256((const __m256i*)tmp_values);
   }
 
@@ -1007,7 +1007,7 @@ struct VectorizedQuantizedConverter {
   }
 
   void store(void* ptr, int count = size()) const {
-    memcpy(ptr, vals.data(), count * sizeof(value_type));
+    memcpy(ptr, vals.data(), std::min<int64_t>(count, size()) * sizeof(value_type));
   }
 
   float_vec_return_type dequantize(
@@ -1063,7 +1063,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return Vectorized<c10::qint32>(tmp_values);
   }
 
@@ -1198,7 +1198,7 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return Vectorized<c10::qint8>(tmp_values);
   }
 
@@ -1322,7 +1322,7 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return Vectorized<c10::quint8>(tmp_values);
   }
 

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -1007,7 +1007,10 @@ struct VectorizedQuantizedConverter {
   }
 
   void store(void* ptr, int count = size()) const {
-    memcpy(ptr, vals.data(), std::min<int64_t>(count, size()) * sizeof(value_type));
+    memcpy(
+        ptr,
+        vals.data(),
+        std::min<int64_t>(count, size()) * sizeof(value_type));
   }
 
   float_vec_return_type dequantize(

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
@@ -180,7 +180,7 @@ class Vectorized<c10::complex<double>> {
     std::memcpy(
         tmp_values,
         reinterpret_cast<const double*>(ptr),
-        count * sizeof(c10::complex<double>));
+        std::min<int64_t>(count, size()) * sizeof(c10::complex<double>));
     return _mm512_load_pd(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -189,7 +189,7 @@ class Vectorized<c10::complex<double>> {
     } else if (count > 0) {
       double tmp_values[2 * size()];
       _mm512_storeu_pd(reinterpret_cast<double*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(c10::complex<double>));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(c10::complex<double>));
     }
   }
   const c10::complex<double>& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
@@ -189,7 +189,10 @@ class Vectorized<c10::complex<double>> {
     } else if (count > 0) {
       double tmp_values[2 * size()];
       _mm512_storeu_pd(reinterpret_cast<double*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(c10::complex<double>));
+      std::memcpy(
+          ptr,
+          tmp_values,
+          std::min<int64_t>(count, size()) * sizeof(c10::complex<double>));
     }
   }
   const c10::complex<double>& operator[](int idx) const = delete;

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
@@ -688,7 +688,10 @@ class Vectorized<c10::complex<float>> {
     } else if (count > 0) {
       float tmp_values[2 * size()];
       _mm512_storeu_ps(reinterpret_cast<float*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(c10::complex<float>));
+      std::memcpy(
+          ptr,
+          tmp_values,
+          std::min<int64_t>(count, size()) * sizeof(c10::complex<float>));
     }
   }
   // AVX512 doesn't have horizontal add & horizontal sub instructions.

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
@@ -679,7 +679,7 @@ class Vectorized<c10::complex<float>> {
     std::memcpy(
         tmp_values,
         reinterpret_cast<const float*>(ptr),
-        count * sizeof(c10::complex<float>));
+        std::min<int64_t>(count, size()) * sizeof(c10::complex<float>));
     return _mm512_load_ps(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -688,7 +688,7 @@ class Vectorized<c10::complex<float>> {
     } else if (count > 0) {
       float tmp_values[2 * size()];
       _mm512_storeu_ps(reinterpret_cast<float*>(tmp_values), values);
-      std::memcpy(ptr, tmp_values, count * sizeof(c10::complex<float>));
+      std::memcpy(ptr, tmp_values, std::min<int64_t>(count, size()) * sizeof(c10::complex<float>));
     }
   }
   // AVX512 doesn't have horizontal add & horizontal sub instructions.

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -1090,7 +1090,10 @@ struct VectorizedQuantizedConverter {
   }
 
   void store(void* ptr, int count = size()) const {
-    memcpy(ptr, vals.data(), std::min<int64_t>(count, size()) * sizeof(value_type));
+    memcpy(
+        ptr,
+        vals.data(),
+        std::min<int64_t>(count, size()) * sizeof(value_type));
   }
 
   float_vec_return_type dequantize(

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -400,7 +400,7 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
 
   void store(void* ptr, int count = size()) const {
     if (count != size()) {
-      memcpy(ptr, &vals, count * sizeof(value_type));
+      memcpy(ptr, &vals, std::min<int64_t>(count, size()) * sizeof(value_type));
     } else {
       _mm512_storeu_si512((__m512i*)ptr, vals);
     }
@@ -422,7 +422,7 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return loadu(tmp_values);
   }
 
@@ -624,7 +624,7 @@ struct Vectorized<c10::qint8> : public Vectorizedqi {
 
   void store(void* ptr, int count = size()) const {
     if (count != size()) {
-      memcpy(ptr, &vals, count * sizeof(value_type));
+      memcpy(ptr, &vals, std::min<int64_t>(count, size()) * sizeof(value_type));
     } else {
       _mm512_storeu_si512((__m512i*)ptr, vals);
     }
@@ -646,7 +646,7 @@ struct Vectorized<c10::qint8> : public Vectorizedqi {
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return loadu(tmp_values);
   }
 
@@ -859,7 +859,7 @@ struct Vectorized<c10::quint8> : public Vectorizedqi {
 
   void store(void* ptr, int count = size()) const {
     if (count != size()) {
-      memcpy(ptr, &vals, count * sizeof(value_type));
+      memcpy(ptr, &vals, std::min<int64_t>(count, size()) * sizeof(value_type));
     } else {
       _mm512_storeu_si512((__m512i*)ptr, vals);
     }
@@ -881,7 +881,7 @@ struct Vectorized<c10::quint8> : public Vectorizedqi {
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return loadu(tmp_values);
   }
 
@@ -1090,7 +1090,7 @@ struct VectorizedQuantizedConverter {
   }
 
   void store(void* ptr, int count = size()) const {
-    memcpy(ptr, vals.data(), count * sizeof(value_type));
+    memcpy(ptr, vals.data(), std::min<int64_t>(count, size()) * sizeof(value_type));
   }
 
   float_vec_return_type dequantize(
@@ -1180,7 +1180,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return loadu(tmp_values);
   }
 
@@ -1332,7 +1332,7 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return loadu(tmp_values);
   }
 
@@ -1473,7 +1473,7 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
     std::memcpy(
         tmp_values,
         reinterpret_cast<const value_type*>(ptr),
-        count * sizeof(value_type));
+        std::min<int64_t>(count, size()) * sizeof(value_type));
     return loadu(tmp_values);
   }
 

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -282,7 +282,7 @@ struct Vectorized {
   }
   static Vectorized<T> loadu(const void* ptr, int64_t count) {
     Vectorized vector;
-    std::memcpy(vector.values, ptr, count * sizeof(T));
+    std::memcpy(vector.values, ptr, std::min<int64_t>(count, size()) * sizeof(T));
     return vector;
   }
   static Vectorized<T> loadu_one_fourth(const void* ptr) {
@@ -293,7 +293,7 @@ struct Vectorized {
   }
 
   void store(void* ptr, int count = size()) const {
-    std::memcpy(ptr, values, count * sizeof(T));
+    std::memcpy(ptr, values, std::min<int64_t>(count, size()) * sizeof(T));
   }
   int zero_mask() const {
     // returns an integer mask where all zero elements are translated to 1-bit

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -282,7 +282,8 @@ struct Vectorized {
   }
   static Vectorized<T> loadu(const void* ptr, int64_t count) {
     Vectorized vector;
-    std::memcpy(vector.values, ptr, std::min<int64_t>(count, size()) * sizeof(T));
+    std::memcpy(
+        vector.values, ptr, std::min<int64_t>(count, size()) * sizeof(T));
     return vector;
   }
   static Vectorized<T> loadu_one_fourth(const void* ptr) {


### PR DESCRIPTION
## Problem

Building PyTorch from source with gcc-14 (CentOS Stream 10, Fedora 41+, etc.) fails when compiling `vec_test_all_types`:

```
aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h:261:16: error: 'void* memcpy(void*, const void*, size_t)' forming offset [32, 33] is out of the bounds [0, 32] of object 'tmp_values' with type 'int16_t [16]' [-Werror=array-bounds=]
  261 |     std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
```

`Vectorized16::loadu` and `Vectorized16::store` take a `count` parameter typed `int16_t` / `int`, then `memcpy` `count * sizeof(int16_t)` bytes into a 16-element stack buffer. The contract is `0 <= count <= size()` (== 16), but neither type bounds it, so gcc-14 reasonably refuses to prove the memcpy is in-range.

## Fix

Clamp `count` before the memcpy:
- `loadu` (signed `int16_t`, can be negative): `std::clamp(static_cast<int>(count), 0, size())`
- `store` (already guarded by `count > 0`): `std::min(count, size())`

This mirrors what `vec_n.h::loadu` already does at the wrapper layer (`std::min(count, Vectorized<T>::size())` before recursing) and gives gcc-14 a provable bound. Behavior is unchanged for in-contract callers; out-of-contract callers now truncate rather than corrupt the stack frame.

Fixes #159962


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01