### PR TITLE
[ci-fix] fix DivTensor2 jit failures: Include bin/ subdirectories in wheel package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1645,6 +1645,7 @@ def main() -> None:
     torch_package_data = [
         "py.typed",
         "bin/*",
+        "bin/**/*",
         "test/*",
         "*.pyi",
         "**/*.pyi",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181562

The CMake install rules from #181372 correctly install
upgrader_models/ and script_module_v4.ptl into torch/bin/, but
setup.py's package_data glob "bin/*" only matches flat files, not
subdirectories. Add "bin/**/*" to include all files under bin/
(such as bin/upgrader_models/*.ptl) in the wheel.

Without this, LiteInterpreterUpgraderTest.DivTensorV2 fails in CI
because the .ptl files are missing from the installed wheel even
though they were installed by CMake.

Authored with Claude.