### PR TITLE
[ci-fix] Update expected graph break counts after transformers 5.5.3 → 5.6.1 bump

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_torchbench_training.csv
@@ -194,7 +194,7 @@ vgg16,pass,6
 
 
 
-vision_maskrcnn,pass,40
+vision_maskrcnn,pass,41
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_amp_freezing_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_amp_freezing_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_freezing_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_freezing_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_freezing_torchbench_inference.csv
@@ -50,27 +50,27 @@ densenet121,pass,0
 
 
 
-detectron2_fasterrcnn_r_101_c4,pass,42
+detectron2_fasterrcnn_r_101_c4,pass,43
 
 
 
-detectron2_fasterrcnn_r_101_dc5,pass,42
+detectron2_fasterrcnn_r_101_dc5,pass,43
 
 
 
-detectron2_fasterrcnn_r_101_fpn,pass,46
+detectron2_fasterrcnn_r_101_fpn,pass,47
 
 
 
-detectron2_fasterrcnn_r_50_c4,pass,42
+detectron2_fasterrcnn_r_50_c4,pass,43
 
 
 
-detectron2_fasterrcnn_r_50_dc5,pass,42
+detectron2_fasterrcnn_r_50_dc5,pass,43
 
 
 
-detectron2_fasterrcnn_r_50_fpn,pass,46
+detectron2_fasterrcnn_r_50_fpn,pass,47
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cpu_inductor_torchbench_inference.csv
@@ -50,27 +50,27 @@ densenet121,pass,0
 
 
 
-detectron2_fasterrcnn_r_101_c4,pass,42
+detectron2_fasterrcnn_r_101_c4,pass,43
 
 
 
-detectron2_fasterrcnn_r_101_dc5,pass,42
+detectron2_fasterrcnn_r_101_dc5,pass,43
 
 
 
-detectron2_fasterrcnn_r_101_fpn,pass,46
+detectron2_fasterrcnn_r_101_fpn,pass,47
 
 
 
-detectron2_fasterrcnn_r_50_c4,pass,42
+detectron2_fasterrcnn_r_50_c4,pass,43
 
 
 
-detectron2_fasterrcnn_r_50_dc5,pass,42
+detectron2_fasterrcnn_r_50_dc5,pass,43
 
 
 
-detectron2_fasterrcnn_r_50_fpn,pass,46
+detectron2_fasterrcnn_r_50_fpn,pass,47
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_torchbench_training.csv
@@ -190,7 +190,7 @@ vgg16,pass,6
 
 
 
-vision_maskrcnn,pass,40
+vision_maskrcnn,pass,41
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_inductor_torchbench_inference.csv
@@ -50,27 +50,27 @@ densenet121,pass,0
 
 
 
-detectron2_fasterrcnn_r_101_c4,pass,42
+detectron2_fasterrcnn_r_101_c4,pass,43
 
 
 
-detectron2_fasterrcnn_r_101_dc5,pass,42
+detectron2_fasterrcnn_r_101_dc5,pass,43
 
 
 
-detectron2_fasterrcnn_r_101_fpn,pass,46
+detectron2_fasterrcnn_r_101_fpn,pass,47
 
 
 
-detectron2_fasterrcnn_r_50_c4,pass,42
+detectron2_fasterrcnn_r_50_c4,pass,43
 
 
 
-detectron2_fasterrcnn_r_50_dc5,pass,42
+detectron2_fasterrcnn_r_50_dc5,pass,43
 
 
 
-detectron2_fasterrcnn_r_50_fpn,pass,46
+detectron2_fasterrcnn_r_50_fpn,pass,47
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_max_autotune_inductor_amp_freezing_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_max_autotune_inductor_amp_freezing_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_max_autotune_inductor_amp_freezing_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_cpu_max_autotune_inductor_amp_freezing_torchbench_inference.csv
@@ -50,27 +50,27 @@ densenet121,pass,0
 
 
 
-detectron2_fasterrcnn_r_101_c4,fail_accuracy,42
+detectron2_fasterrcnn_r_101_c4,fail_accuracy,43
 
 
 
-detectron2_fasterrcnn_r_101_dc5,fail_accuracy,42
+detectron2_fasterrcnn_r_101_dc5,fail_accuracy,43
 
 
 
-detectron2_fasterrcnn_r_101_fpn,fail_accuracy,46
+detectron2_fasterrcnn_r_101_fpn,fail_accuracy,47
 
 
 
-detectron2_fasterrcnn_r_50_c4,fail_accuracy,42
+detectron2_fasterrcnn_r_50_c4,fail_accuracy,43
 
 
 
-detectron2_fasterrcnn_r_50_dc5,fail_accuracy,42
+detectron2_fasterrcnn_r_50_dc5,fail_accuracy,43
 
 
 
-detectron2_fasterrcnn_r_50_fpn,fail_accuracy,46
+detectron2_fasterrcnn_r_50_fpn,fail_accuracy,47
 
 
 
@@ -250,7 +250,7 @@ vgg16,pass,0
 
 
 
-vision_maskrcnn,fail_accuracy,30
+vision_maskrcnn,fail_accuracy,31
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_torchbench_training.csv
@@ -194,7 +194,7 @@ vgg16,pass,6
 
 
 
-vision_maskrcnn,pass,40
+vision_maskrcnn,pass,41
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_torchbench_training.csv
@@ -197,7 +197,7 @@ vgg16,pass,6
 
 
 
-vision_maskrcnn,pass,40
+vision_maskrcnn,pass,41
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_torchbench_training.csv
@@ -193,7 +193,7 @@ vgg16,pass,6
 
 
 
-vision_maskrcnn,pass,40
+vision_maskrcnn,pass,41
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_torchbench_training.csv
@@ -197,7 +197,7 @@ vgg16,pass,6
 
 
 
-vision_maskrcnn,pass,40
+vision_maskrcnn,pass,41
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/inductor_huggingface_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/inductor_huggingface_inference.csv
@@ -30,7 +30,7 @@ DistilBertForMaskedLM,pass,0
 
 
 
-DistillGPT2,pass,2
+DistillGPT2,pass,3
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181566

The transformers bump from 5.5.3 to 5.6.1 (#181242, Apr 23)
introduced one additional graph break occurrence in several
HuggingFace and torchbench models. This is not a PyTorch/dynamo
regression — the new transformers version changed model internals
that trigger an existing graph break pattern one more time.

Models updated:
- DistillGPT2: 2 → 3 (12 CSVs)
- vision_maskrcnn: 40 → 41 (6 CSVs), 30 → 31 (1 CSV)
- detectron2_fasterrcnn_r_{50,101}_{c4,dc5}: 42 → 43 (4 CSVs)
- detectron2_fasterrcnn_r_{50,101}_fpn: 46 → 47 (4 CSVs)

Authored with Claude.