### PR TITLE
Fix batched LU factorization grain_size heuristic for large matrices (#181570)

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -1017,7 +1017,13 @@ void apply_lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& in
   // https://github.com/pytorch/pytorch/pull/93037#discussion_r1090112948
   int64_t chunk_size_per_thread = static_cast<int64_t>(
       std::min(1.0, 3200.0 / (matrix_rank * matrix_rank * matrix_rank)));
-  int64_t grain_size = chunk_size_per_thread * at::get_num_threads();
+  // When chunk_size_per_thread is 0 (large matrices), we must serialize to
+  // avoid concurrent LAPACK calls that trigger MKL thread-safety issues
+  // (e.g., DLASWP "Parameter 6 incorrect" errors). grain_size=0 would mean
+  // "always parallelize", so we use batch_size to force single-threaded.
+  int64_t grain_size = chunk_size_per_thread > 0
+      ? chunk_size_per_thread * at::get_num_threads()
+      : batch_size;
   at::parallel_for(0, batch_size, grain_size, loop);
 #endif
 }

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -1024,7 +1024,13 @@ void apply_lu_factor(const Tensor& input, const Tensor& pivots, const Tensor& in
   // https://github.com/pytorch/pytorch/pull/93037#discussion_r1090112948
   int64_t chunk_size_per_thread = static_cast<int64_t>(
       std::min(1.0, 3200.0 / (matrix_rank * matrix_rank * matrix_rank)));
-  int64_t grain_size = chunk_size_per_thread * at::get_num_threads();
+  // When chunk_size_per_thread is 0 (large matrices), we must serialize to
+  // avoid concurrent LAPACK calls that trigger MKL thread-safety issues
+  // (e.g., DLASWP "Parameter 6 incorrect" errors). grain_size=0 would mean
+  // "always parallelize", so we use batch_size to force single-threaded.
+  int64_t grain_size = chunk_size_per_thread > 0
+      ? chunk_size_per_thread * at::get_num_threads()
+      : batch_size;
   at::parallel_for(0, batch_size, grain_size, loop);
 #endif
 }

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -11455,6 +11455,36 @@ class TestLinalgCudaOnly(TestCase):
             self.assertEqual(ck_out, cpu_out)
 
 
+    @onlyCPU
+    @skipCPUIfNoLapack
+    @dtypes(torch.float64)
+    def test_inverse_batched_multithread(self, device, dtype):
+        # Regression test: batched linalg.inv with large matrices and multiple
+        # threads used to trigger MKL DLASWP thread-safety errors because
+        # apply_lu_factor's grain_size heuristic produced grain_size=0 for
+        # large matrices, which at::parallel_for interprets as "always
+        # parallelize" instead of the intended "serialize".
+        num_threads = torch.get_num_threads()
+        try:
+            torch.set_num_threads(4)
+            n = 256
+            batch = 8
+            A = torch.randn(batch, n, n, dtype=dtype, device=device)
+            # Make matrices well-conditioned by adding n*I
+            A = A + n * torch.eye(n, dtype=dtype, device=device)
+            A_inv = torch.linalg.inv(A)
+            identity = torch.eye(n, dtype=dtype, device=device)
+            residual = A @ A_inv - identity.expand_as(A)
+            self.assertEqual(
+                residual,
+                torch.zeros_like(residual),
+                atol=1e-5,
+                rtol=1e-5,
+            )
+        finally:
+            torch.set_num_threads(num_threads)
+
+
 instantiate_device_type_tests(TestLinalg, globals())
 instantiate_device_type_tests(TestLinalgCudaOnly, globals(), only_for=("cuda"))
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -10589,6 +10589,35 @@ class TestLinalgCudaOnly(TestCase):
             self.assertEqual(ck_out, cpu_out)
 
 
+    @onlyCPU
+    @skipCPUIfNoLapack
+    @dtypes(torch.float64)
+    def test_inverse_batched_multithread(self, device, dtype):
+        # Regression test: batched linalg.inv with large matrices and multiple
+        # threads used to trigger MKL DLASWP thread-safety errors because
+        # apply_lu_factor's grain_size heuristic produced grain_size=0 for
+        # large matrices, which at::parallel_for interprets as "always
+        # parallelize" instead of the intended "serialize".
+        num_threads = torch.get_num_threads()
+        try:
+            torch.set_num_threads(4)
+            n = 256
+            batch = 8
+            A = torch.randn(batch, n, n, dtype=dtype, device=device)
+            # Make matrices well-conditioned by adding n*I
+            A = A + n * torch.eye(n, dtype=dtype, device=device)
+            A_inv = torch.linalg.inv(A)
+            identity = torch.eye(n, dtype=dtype, device=device)
+            residual = A @ A_inv - identity.expand_as(A)
+            self.assertEqual(
+                residual,
+                torch.zeros_like(residual),
+                atol=1e-5,
+                rtol=1e-5,
+            )
+        finally:
+            torch.set_num_threads(num_threads)
+
 instantiate_device_type_tests(TestLinalg, globals())
 instantiate_device_type_tests(TestLinalgCudaOnly, globals(), only_for=("cuda"))
 


### PR DESCRIPTION
Summary:

The parallelization heuristic in `apply_lu_factor` computes `chunk_size_per_thread` as `min(1.0, 3200 / rank^3)` and then `grain_size = chunk_size_per_thread * num_threads`. For large matrices (rank > ~14), this truncates to `chunk_size_per_thread = 0`, producing `grain_size = 0`. However, `at::parallel_for` interprets `grain_size=0` as "always parallelize" (since `numiter > 0` is trivially true), which is the opposite of the intended behavior.

This causes multiple threads to call `dgetrf_` concurrently, triggering MKL thread-safety issues in `DLASWP` (row pivot swap). The symptom is `Intel oneMKL ERROR: Parameter 6 was incorrect on entry to DLASWP` errors and incorrect numerical results when using `torch.linalg.inv` on batched large matrices with `num_threads > 1`.

The fix: when `chunk_size_per_thread` truncates to 0, set `grain_size = batch_size` so the entire batch runs on a single thread, which was the original intent of the heuristic for large matrices.

Test Plan:
Added `test_inverse_batched_multithread` which runs batched `linalg.inv` on 256x256 matrices with 4 threads. Before this fix, this would produce MKL errors and incorrect results. After the fix, the residual `||A @ A_inv - I||` is within tolerance.

buck2 test //caffe2/test:linalg -- -r test_inverse_batched_multithread

Differential Revision: D102573456


