### PR TITLE
[inductor] Enable CUTLASS GEMM templates under JIT cpp_wrapper

### DIFF
--- a/test/inductor/test_cutlass_backend.py
+++ b/test/inductor/test_cutlass_backend.py
@@ -574,6 +574,45 @@ class TestCutlassBackend(TestCase):
 
             torch.testing.assert_close(actual, expected)
 
+    @unittest.skipIf(torch.version.hip is not None, "ROCm not supported")
+    @skipCUDAIf(not SM90OrLater, "need sm_90")
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    @mock.patch.dict(os.environ, {"PATH": _get_path_without_sccache()})
+    def test_max_autotune_cutlass_backend_cpp_wrapper(
+        self,
+        dtype: torch.dtype,
+    ):
+        """
+        Verify that CUTLASS GEMM templates work under JIT cpp_wrapper mode
+        """
+        M, N, K = 128, 128, 16
+
+        class MyModel(torch.nn.Module):
+            def forward(self, a, b):
+                return a @ b
+
+        model = MyModel().to(GPU_TYPE)
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        b = torch.randn(K, N, device=GPU_TYPE, dtype=dtype)
+        expected = model(a, b)
+
+        with config.patch(
+            {
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "CUTLASS",
+                "cutlass.cutlass_max_profiling_configs": 2,
+                "cpp_wrapper": True,
+            }
+        ):
+            from torch._inductor.utils import run_and_get_code
+
+            compiled = torch.compile(model, fullgraph=True)
+            actual, codes = run_and_get_code(compiled, a, b)
+            torch.testing.assert_close(actual, expected)
+            # JIT path must call the bare extern "C" symbol, not via the
+            # AOT-only `kernels.` member.
+            FileCheck().check("cutlass_").check_not("kernels.cutlass_").run(codes[0])
+
     @skipXPUIf(True, "XPU SYCL-TLA has not supported fp8 yet")
     @skipCUDAIf(not SM90OrLater, "need sm_90")
     @parametrize("dynamic", (False, True))

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -694,9 +694,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
     def codegen_additional_funcs(self):
         pass
 
-    def codegen_model_kernels(self):
-        self.prefix.writeline("namespace {")
-
+    def codegen_initialized_kernel_decls(self):
         # Tell compiler we need to link with the non-mangled symbols
         for kernel in self.initialized_kernels.values():
             assert hasattr(kernel, "get_signature"), (
@@ -705,6 +703,9 @@ class CppWrapperCpu(PythonWrapperCodegen):
             signature = kernel.get_signature()
             self.prefix.writeline(f'extern "C" {signature};')
 
+    def codegen_model_kernels(self):
+        self.prefix.writeline("namespace {")
+        self.codegen_initialized_kernel_decls()
         self.prefix.writeline(
             "class AOTInductorModelKernels : public AOTInductorModelKernelsBase {"
         )
@@ -1054,6 +1055,10 @@ class CppWrapperCpu(PythonWrapperCodegen):
             self.codegen_const_run_driver()
             aot_mode_decls.writeline("} // namespace torch::aot_inductor")
             aot_mode_decls.writeline("using namespace torch::aot_inductor;")
+        elif not V.graph.is_const_graph and self.initialized_kernels:
+            # JIT cpp_wrapper: emit extern "C" decls for kernels we link
+            # against (e.g. CUTLASS .so passed via extra_flags).
+            self.codegen_initialized_kernel_decls()
 
         self.prefix = cache_decls = IndentedBuffer()
         for dtype in self.used_cached_dtypes:
@@ -1196,6 +1201,14 @@ class CppWrapperCpu(PythonWrapperCodegen):
             result.splice('"""\n)')
 
         kernel_code = "kernel_src" if config.cpp_wrapper_build_separate else "None"
+        # Link any precompiled CUTLASS .so kernels into the wrapper, with
+        # rpath entries so the dynamic linker can find them at module load.
+        extra_flags: list[str] = list(self.cutlass_kernel_libs)
+        rpath_dirs = list(
+            dict.fromkeys(os.path.dirname(p) for p in self.cutlass_kernel_libs)
+        )
+        extra_flags.extend(f"-Wl,-rpath,{d}" for d in rpath_dirs)
+        extra_flags_repr = repr(tuple(extra_flags))
         # Cpp entry function for JIT with cpp wrapper
         result.splice(
             f"""
@@ -1205,6 +1218,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 device_type="{self.device}",
                 num_outputs={len(V.graph.graph_outputs)},
                 kernel_code={kernel_code},
+                extra_flags={extra_flags_repr},
             )
             """
         )

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1293,7 +1293,11 @@ static struct TritonKernelCompileInit {{
                 # pyrefly: ignore [bad-argument-type]
                 casted.append(f"({arg_type}){cexpr(new_arg)}")
             call_args_str = ", ".join(casted)
-            self.writeline(f"kernels.{kernel_name}({call_args_str}, {stream});")
+            # AOT: dispatch through AOTInductorModelKernels member.
+            # JIT: call the extern "C" symbol directly (resolved at link time
+            # via extra_flags pointing at the compiled .so).
+            kernel_prefix = "kernels." if V.graph.aot_mode else ""
+            self.writeline(f"{kernel_prefix}{kernel_name}({call_args_str}, {stream});")
 
     def prepare_triton_wrapper_args(
         self, call_args: list[Any], arg_types: list[Any]

--- a/torch/_inductor/codegen/cutlass/scheduling.py
+++ b/torch/_inductor/codegen/cutlass/scheduling.py
@@ -121,6 +121,17 @@ class CUTLASSScheduling(BaseScheduling):
             wrapper.define_kernel(
                 kernel_name, compile_wrapper.getvalue(), metadata_comment
             )
+
+            # For JIT cpp_wrapper, the kernel call site emits a bare
+            # `extern "C"` symbol reference; capture the .so path so the
+            # wrapper compile links against it via extra_flags.
+            if V.graph.cpp_wrapper and not V.graph.aot_mode:
+                from ...codecache import CUDACodeCache
+
+                _, input_path = CUDACodeCache.write(src_code, "so")
+                so_path = input_path[: -len(CUDACodeCache._SOURCE_CODE_SUFFIX)] + "so"
+                if so_path not in wrapper.cutlass_kernel_libs:
+                    wrapper.cutlass_kernel_libs.append(so_path)
         return kernel_name
 
     def codegen_template(

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1326,6 +1326,10 @@ class PythonWrapperCodegen(CodeGen):
         # Additional files that are dependent to the wrapper (ex. cubin files)
         self.additional_files = []
 
+        # Compiled CUTLASS .so paths to link into the JIT cpp_wrapper.
+        # Populated by CUTLASSScheduling.define_kernel when not aot_mode.
+        self.cutlass_kernel_libs: list[str] = []
+
     @staticmethod
     def create(
         is_subgraph: bool,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -23,7 +23,6 @@ import tempfile
 import textwrap
 import time
 import unittest
-import warnings
 from collections.abc import (
     Callable,
     Collection,
@@ -2175,21 +2174,6 @@ def use_blackwell_cutedsl_grouped_mm(
 
 def use_cutlass_template(layout: Layout, m: int, n: int, k: int) -> bool:
     from .virtualized import V
-
-    # TODO: Enable CUTLASS in non-AOT cpp_wrapper mode. The CUTLASS
-    # codegen (CUDATemplateKernel.call_kernel) already has cpp_wrapper-aware
-    # arg handling, but the other half is missing: the non-triton branch of
-    # CppWrapperGpu._generate_kernel_call_helper unconditionally emits
-    # `kernels.<name>(...)`, and that AOTInductorModelKernels struct only
-    # exists in AOT mode. Fixing this requires adding dlopen/dlsym loading
-    # for the compiled CUTLASS .so, similar to how the triton branch uses
-    # static CUfunction + loadKernel for non-AOT mode.
-    if V.graph.cpp_wrapper and not V.graph.aot_mode:
-        warnings.warn(
-            "CUTLASS backend is not supported with non-AOT cpp_wrapper mode. "
-            "Skipping CUTLASS backend.",
-        )
-        return False
 
     gemm_size = V.graph.sizevars.optimization_hint(m * n * k, fallback=-1)
     if gemm_size <= 0 or gemm_size < config.cutlass.cutlass_backend_min_gemm_size:


### PR DESCRIPTION
Summary:
`use_cutlass_template` previously bailed when `cpp_wrapper=True` and not in AOT mode. This change makes the JIT path call the bare `extern "C"` symbol and links the precompiled CUTLASS `.so` into the wrapper at compile time via the existing `extra_flags` plumbing (same mechanism `HalideCodeCache` uses for its standalone runtime). `-Wl,-rpath` entries are added so the dynamic linker finds the `.so` at module load.

Authored with Claude.

Differential Revision: D102608430




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo