### PR TITLE
[Inductor][CPU] Fix explicit lowp-fp casts being silently eliminated in fused kernels

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5955,7 +5955,7 @@ class CPUReproTests(TestCase):
             check_metrics_vec_kernel_count(1)
             _, code = run_and_get_cpp_code(torch.compile(fn), x)
             FileCheck().check_count(
-                "tmp1 + tmp2",
+                "tmp1 + tmp4",
                 2,
                 exactly=True,
             ).run(code)

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -711,38 +711,7 @@ class CppOverrides(OpOverrides):
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("to_dtype", (x, dtype), {"src_dtype": src_dtype})
         if dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            """
-            https://github.com/pytorch/pytorch/issues/115260
-            For FusedSchedulerNode[node1, node2], the node2 loads what node1 stores and the buffer is
-            in low-precision floating point data type. When the output of node1 also serves as the output of the
-            kernel, the result of nodes would be different from the case when output of node1 is not the output
-            of the kernel (where we don't need to insert `to_dtype` for legalization). To address the problem, on
-            storing the lowp node1 output, we also add the inverse dtype conversion to high precision data type
-            to the cse cache.
-
-            Example (pseudo code):
-                node1_output = ...
-                node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
-                store(buf, node1_output_lowp)
-                node2_input_lowp = load(buf)
-                node2_input = to_dtype(node2_input_lowp, dtype=torch.float)
-
-            Without cse cache trick:
-                node1_output = ...
-                node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
-                store(buf, node1_output_lowp)
-                node2_input_lowp = node_output_lowp # hit store cache
-                node2_input = to_dtype(node2_input_lowp, dtype=torch.float)
-
-            With cse cache trick:
-                node1_output = ...
-                node1_output_lowp = to_dtype(node1_output, dtype=torch.bfloat16)
-                # also add `to_dtype(node1_input_lowp, dtype=torch.float)` -> `node1_output` to cse cache
-                store(buf, node1_output_lowp)
-                node2_input_lowp = node_output_lowp # hit store cache
-                node2_input = node1_output # hit cse cache
-            """
-            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
+            csevar.lowp_fp_from = x
         return csevar
 
     @staticmethod
@@ -755,7 +724,7 @@ class CppOverrides(OpOverrides):
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("round_to_int", (x, dtype), {"src_dtype": src_dtype})
         if dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
+            csevar.lowp_fp_from = x
         return csevar
 
     @staticmethod
@@ -1731,7 +1700,7 @@ class CppVecOverrides(CppOverrides):
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("to_dtype", (x, dtype), {"src_dtype": src_dtype})
         if dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
+            csevar.lowp_fp_from = x
         return csevar
 
     @staticmethod
@@ -1747,7 +1716,7 @@ class CppVecOverrides(CppOverrides):
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("round_to_int", (x, dtype), {"src_dtype": src_dtype})
         if dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
-            V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
+            csevar.lowp_fp_from = x
         return csevar
 
     @staticmethod
@@ -2229,6 +2198,7 @@ class CppKernel(Kernel):
 
     def store(self, name, index, value, mode=None):
         assert "buf" in name
+        self.cache_lowp_fp_on_store(value)
         var = self.args.output(name)
         index = self.rename_indexing(index)
         if mode is None:
@@ -2687,6 +2657,16 @@ class CppKernel(Kernel):
         expr = self.get_to_dtype_expr(src, dst_dtype, src_dtype)
         self.cse.put(expr, dst)
 
+    def cache_lowp_fp_on_store(self, value):
+        if (
+            isinstance(value, CppCSEVariable)
+            and value.lowp_fp_from is not None
+            and value.dtype in DTYPE_LOWP_FP
+        ):
+            self.cache_dtype_convert(
+                value.lowp_fp_from, torch.float, value, value.dtype
+            )
+
     def codegen_conditions(
         self,
         code: BracesBuffer,
@@ -3049,6 +3029,7 @@ class CppVecKernel(CppKernel):
     def store(self, name, index, value, mode=None):
         assert "buf" in name
         assert isinstance(value, CppCSEVariable), value
+        self.cache_lowp_fp_on_store(value)
         if not value.is_vec:
             # this happens when we store a scalar into a vectorized buffer like "fill"
             value = self.broadcast(value)
@@ -3794,6 +3775,7 @@ class CppTile2DKernel(CppVecKernel):
     def store(self, name, index, value, mode=None):
         assert "buf" in name
         assert isinstance(value, CppCSEVariable), value
+        self.cache_lowp_fp_on_store(value)
         if not value.is_vec:
             # this happens when we store a scalar into a vectorized buffer like "fill"
             value = self.broadcast(value)

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -153,6 +153,7 @@ class CppCSEVariable(CSEVariable):
         super().__init__(name, bounds, dtype, shape=shape)
         self.is_vec = False
         self.dependent_itervars = OrderedSet[sympy.Symbol]()
+        self.lowp_fp_from: CppCSEVariable | None = None
 
     def __repr__(self) -> str:
         return (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #181585
* __->__ #181583

The CPU C++ codegen eagerly cached the reverse dtype conversion in
`to_dtype`: when converting fp32 to bf16/fp16, it pre-populated the CSE
cache so that any subsequent bf16→fp32 conversion resolved back to the
original fp32 variable. This treated fp32→bf16→fp32 as lossless, which
silently eliminated user-specified precision boundaries like
`(x @ w).to(torch.bfloat16) + b` — producing 99%+ mismatched elements
vs eager.

The cache was introduced for #115260 to avoid spurious precision loss in
FusedSchedulerNode when a lowp-fp value is stored and then CSE-loaded
within the same kernel. That use case is legitimate — the fix preserves
it by deferring the cache population from `to_dtype` to `store`:

- `CppCSEVariable.lowp_fp_from` tracks the fp32 source variable when
  converting to lowp-fp.
- `cache_lowp_fp_on_store` populates the reverse-conversion CSE cache
  only when the lowp-fp value is actually stored to a buffer.

This correctly distinguishes store-format conversions (cache beneficial)
from user precision boundaries (cache harmful, no store involved).

Note: the same symptom (explicit bf16 cast eliminated) also reproduces
on CUDA/Triton through a different mechanism (`upcast_compute_type`
converting bf16→fp32 in `to_dtype`). That is a separate fix.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo