### PR TITLE
[Inductor] Preserve explicit lowp-fp casts in convert_element_type lowering

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -945,8 +945,8 @@ def _convert_element_type(x: TensorBox, dtype: torch.dtype):
     src_dtype = x.get_dtype()
     low_pr_fp = (torch.bfloat16, torch.float16)
     use_compute_types = not (
-        config.emulate_precision_casts
-        and (src_dtype in low_pr_fp or dtype in low_pr_fp)
+        dtype in low_pr_fp
+        or (config.emulate_precision_casts and src_dtype in low_pr_fp)
     )
     return to_dtype(x, dtype, copy=True, use_compute_types=use_compute_types)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

When lowering `prims.convert_element_type` to a lowp-fp target dtype
(bf16/fp16), always pass `use_compute_types=False` so the actual
narrowing conversion is emitted. Previously this was gated on
`config.emulate_precision_casts` (default False), causing the Triton
codegen to upcast bf16 back to fp32 via `triton_compute_type` — turning
the user's explicit `.to(torch.bfloat16)` into a no-op.

With `use_compute_types=False`, the existing `to_dtype` infrastructure
emits the round-trip: convert to lowp-fp (truncation), then upcast back
to compute type for fused consumers. This matches eager semantics.

The `emulate_precision_casts` config continues to control widening casts
(lowp-fp → fp32), which is its original purpose for emulating
intermediate precision truncation between fused lowp-fp operators.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo