### PR TITLE
Extract linux ROCm and XPU binary tests into reusable workflows

### DIFF
--- a/.github/workflows/_binary-test-rocm-linux.yml
+++ b/.github/workflows/_binary-test-rocm-linux.yml
@@ -1,0 +1,120 @@
+name: linux-binary-test-rocm
+
+on:
+  workflow_call:
+    inputs:
+      build_name:
+        required: true
+        type: string
+        description: The build's name (matches the downloaded artifact name)
+      PYTORCH_ROOT:
+        required: true
+        type: string
+        description: Root directory for the pytorch/pytorch repository
+      PACKAGE_TYPE:
+        required: true
+        type: string
+        description: Package type
+      DESIRED_CUDA:
+        required: true
+        type: string
+        description: Desired CUDA / ROCm identifier (e.g. rocm7.1)
+      GPU_ARCH_VERSION:
+        required: true
+        type: string
+        description: ROCm version (e.g. 7.1)
+      GPU_ARCH_TYPE:
+        required: true
+        type: string
+        description: GPU arch type (always "rocm" here)
+      DOCKER_IMAGE:
+        required: true
+        type: string
+        description: Base docker image name
+      DOCKER_IMAGE_TAG_PREFIX:
+        required: true
+        type: string
+        description: Docker image tag prefix (e.g. rocm7.1)
+      DESIRED_PYTHON:
+        required: false
+        type: string
+        description: Desired python version
+      runs_on:
+        required: false
+        type: string
+        default: linux.rocm.gpu.gfx942.1
+        description: ROCm runner label
+      timeout-minutes:
+        required: false
+        type: number
+        default: 240
+
+permissions:
+  id-token: write
+
+jobs:
+  test:
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      PYTORCH_ROOT: ${{ inputs.PYTORCH_ROOT }}
+      PACKAGE_TYPE: ${{ inputs.PACKAGE_TYPE }}
+      # TODO: This is a legacy variable that we eventually want to get rid of in
+      #       favor of GPU_ARCH_VERSION
+      DESIRED_CUDA: ${{ inputs.DESIRED_CUDA }}
+      GPU_ARCH_VERSION: ${{ inputs.GPU_ARCH_VERSION }}
+      GPU_ARCH_TYPE: ${{ inputs.GPU_ARCH_TYPE }}
+      SKIP_ALL_TESTS: 1
+      DOCKER_IMAGE: ${{ inputs.DOCKER_IMAGE }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
+      DESIRED_PYTHON: ${{ inputs.DESIRED_PYTHON }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout PyTorch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          submodules: recursive
+          show-progress: false
+      - name: Clean PyTorch checkout
+        run: |
+          # Remove any artifacts from the previous checkouts
+          git clean -fxd
+      - name: Setup ROCm
+        uses: ./.github/actions/setup-rocm
+      - uses: actions/download-artifact@v4.1.7
+        name: Download Build Artifacts
+        with:
+          name: ${{ inputs.build_name }}
+          path: "${{ runner.temp }}/artifacts/"
+      - name: ROCm set GPU_FLAG
+        run: |
+          echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon" >> "${GITHUB_ENV}"
+      - name: configure aws credentials
+        id: aws_creds
+        if: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/') }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
+          aws-region: us-east-1
+          role-duration-seconds: 18000
+      - name: Calculate docker image
+        id: calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        with:
+          docker-registry: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/') && '308535385114.dkr.ecr.us-east-1.amazonaws.com' || 'docker.io' }}
+          docker-image-name: ${{ inputs.DOCKER_IMAGE }}
+          custom-tag-prefix: ${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
+          docker-build-dir: .ci/docker
+      - name: Pull Docker image
+        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        with:
+          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
+      - name: Test Pytorch binary
+        uses: ./.github/actions/test-pytorch-binary
+        env:
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
+      - name: Teardown ROCm
+        uses: ./.github/actions/teardown-rocm

--- a/.github/workflows/_binary-test-xpu-linux.yml
+++ b/.github/workflows/_binary-test-xpu-linux.yml
@@ -1,0 +1,106 @@
+name: linux-binary-test-xpu
+
+on:
+  workflow_call:
+    inputs:
+      build_name:
+        required: true
+        type: string
+        description: The build's name (matches the downloaded artifact name)
+      PYTORCH_ROOT:
+        required: true
+        type: string
+        description: Root directory for the pytorch/pytorch repository
+      PACKAGE_TYPE:
+        required: true
+        type: string
+        description: Package type
+      DESIRED_CUDA:
+        required: true
+        type: string
+        description: Desired CUDA / XPU identifier (always "xpu" here)
+      GPU_ARCH_TYPE:
+        required: true
+        type: string
+        description: GPU arch type (always "xpu" here)
+      DOCKER_IMAGE:
+        required: true
+        type: string
+        description: Base docker image name
+      DOCKER_IMAGE_TAG_PREFIX:
+        required: true
+        type: string
+        description: Docker image tag prefix (e.g. xpu)
+      DESIRED_PYTHON:
+        required: false
+        type: string
+        description: Desired python version
+      runs_on:
+        required: false
+        type: string
+        default: linux.idc.xpu
+        description: XPU runner label
+      timeout-minutes:
+        required: false
+        type: number
+        default: 240
+
+permissions:
+  id-token: write
+
+jobs:
+  test:
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      PYTORCH_ROOT: ${{ inputs.PYTORCH_ROOT }}
+      PACKAGE_TYPE: ${{ inputs.PACKAGE_TYPE }}
+      # TODO: This is a legacy variable that we eventually want to get rid of in
+      #       favor of GPU_ARCH_VERSION
+      DESIRED_CUDA: ${{ inputs.DESIRED_CUDA }}
+      GPU_ARCH_TYPE: ${{ inputs.GPU_ARCH_TYPE }}
+      SKIP_ALL_TESTS: 1
+      DOCKER_IMAGE: ${{ inputs.DOCKER_IMAGE }}
+      DOCKER_IMAGE_TAG_PREFIX: ${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
+      DESIRED_PYTHON: ${{ inputs.DESIRED_PYTHON }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout PyTorch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          submodules: recursive
+          show-progress: false
+      - name: Clean PyTorch checkout
+        run: |
+          # Remove any artifacts from the previous checkouts
+          git clean -fxd
+      - name: Setup XPU
+        uses: ./.github/actions/setup-xpu
+      - name: Login to ECR
+        uses: ./.github/actions/ecr-login
+      - uses: actions/download-artifact@v4.1.7
+        name: Download Build Artifacts
+        with:
+          name: ${{ inputs.build_name }}
+          path: "${{ runner.temp }}/artifacts/"
+      - name: Calculate docker image
+        id: calculate-docker-image
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        with:
+          docker-registry: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/') && '308535385114.dkr.ecr.us-east-1.amazonaws.com' || 'docker.io' }}
+          docker-image-name: ${{ inputs.DOCKER_IMAGE }}
+          custom-tag-prefix: ${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
+          docker-build-dir: .ci/docker
+      - name: Pull Docker image
+        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
+        with:
+          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
+      - name: Test Pytorch binary
+        uses: ./.github/actions/test-pytorch-binary
+        env:
+          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
+      - name: Teardown XPU
+        uses: ./.github/actions/teardown-xpu

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -128,145 +128,48 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  # ROCm test: inline steps with setup-rocm / teardown-rocm; cannot use
-  # the standard reusable workflow because it needs GPU_FLAG and custom
-  # docker registry login.
+  # ROCm test: delegates to _binary-test-rocm-linux.yml (setup-rocm +
+  # GPU_FLAG + ECR docker pull + teardown-rocm).
   test-rocm:
     name: ${{ matrix.config.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' && needs.generate-matrix.outputs.test-rocm-configs != '[]' }}
     needs: [generate-matrix, build]
-    runs-on: linux.rocm.gpu.gfx942.1
-    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:
         config: ${{ fromJSON(needs.generate-matrix.outputs.test-rocm-configs) }}
-    env:
+    uses: ./.github/workflows/_binary-test-rocm-linux.yml
+    with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
-      # TODO: This is a legacy variable that we eventually want to get rid of in
-      #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: ${{ matrix.config.desired_cuda }}
       GPU_ARCH_VERSION: ${{ matrix.config.gpu_arch_version }}
       GPU_ARCH_TYPE: ${{ matrix.config.gpu_arch_type }}
-      SKIP_ALL_TESTS: 1
       DOCKER_IMAGE: ${{ matrix.config.container_image }}
       DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.config.container_image_tag_prefix }}
       DESIRED_PYTHON: ${{ matrix.config.python_version }}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Checkout PyTorch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          submodules: recursive
-          show-progress: false
-      - name: Clean PyTorch checkout
-        run: |
-          # Remove any artifacts from the previous checkouts
-          git clean -fxd
-      - name: Setup ROCm
-        uses: ./.github/actions/setup-rocm
-      - uses: actions/download-artifact@v4.1.7
-        name: Download Build Artifacts
-        with:
-          name: ${{ matrix.config.build_name }}
-          path: "${{ runner.temp }}/artifacts/"
-      - name: ROCm set GPU_FLAG
-        run: |
-          echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd --device=/dev/dri --group-add video --group-add daemon" >> "${GITHUB_ENV}"
-      - name: configure aws credentials
-        id: aws_creds
-        if: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/') }}
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
-        with:
-          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_s3_and_ecr_read_only
-          aws-region: us-east-1
-          role-duration-seconds: 18000
-      - name: Calculate docker image
-        id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
-        with:
-          docker-registry: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/') && '308535385114.dkr.ecr.us-east-1.amazonaws.com' || 'docker.io' }}
-          docker-image-name: ${{ matrix.config.container_image }}
-          custom-tag-prefix: ${{ matrix.config.container_image_tag_prefix }}
-          docker-build-dir: .ci/docker
-      - name: Pull Docker image
-        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
-        with:
-          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
-      - name: Test Pytorch binary
-        uses: ./.github/actions/test-pytorch-binary
-        env:
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
-      - name: Teardown ROCm
-        uses: ./.github/actions/teardown-rocm
+      build_name: ${{ matrix.config.build_name }}
 
-  # XPU test: inline steps with setup-xpu / teardown-xpu.
+  # XPU test: delegates to _binary-test-xpu-linux.yml (setup-xpu + ECR
+  # docker pull + teardown-xpu).
   test-xpu:
     name: ${{ matrix.config.build_name }}-test
     if: ${{ github.repository_owner == 'pytorch' && needs.generate-matrix.outputs.test-xpu-configs != '[]' }}
     needs: [generate-matrix, build]
-    runs-on: linux.idc.xpu
-    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:
         config: ${{ fromJSON(needs.generate-matrix.outputs.test-xpu-configs) }}
-    env:
+    uses: ./.github/workflows/_binary-test-xpu-linux.yml
+    with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
-      # TODO: This is a legacy variable that we eventually want to get rid of in
-      #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: ${{ matrix.config.desired_cuda }}
       GPU_ARCH_TYPE: ${{ matrix.config.gpu_arch_type }}
-      SKIP_ALL_TESTS: 1
       DOCKER_IMAGE: ${{ matrix.config.container_image }}
       DOCKER_IMAGE_TAG_PREFIX: ${{ matrix.config.container_image_tag_prefix }}
       DESIRED_PYTHON: ${{ matrix.config.python_version }}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Checkout PyTorch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          submodules: recursive
-          show-progress: false
-      - name: Clean PyTorch checkout
-        run: |
-          # Remove any artifacts from the previous checkouts
-          git clean -fxd
-      - name: Setup XPU
-        uses: pytorch/pytorch/.github/actions/setup-xpu@main
-      - name: Login to ECR
-        uses: pytorch/pytorch/.github/actions/ecr-login@main
-      - uses: actions/download-artifact@v4.1.7
-        name: Download Build Artifacts
-        with:
-          name: ${{ matrix.config.build_name }}
-          path: "${{ runner.temp }}/artifacts/"
-      - name: Calculate docker image
-        id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
-        with:
-          docker-registry: ${{ startsWith(github.event.ref, 'refs/tags/ciflow/') && '308535385114.dkr.ecr.us-east-1.amazonaws.com' || 'docker.io' }}
-          docker-image-name: ${{ matrix.config.container_image }}
-          custom-tag-prefix: ${{ matrix.config.container_image_tag_prefix }}
-          docker-build-dir: .ci/docker
-      - name: Pull Docker image
-        uses: pytorch/test-infra/.github/actions/pull-docker-image@main
-        with:
-          docker-image: ${{ steps.calculate-docker-image.outputs.docker-image }}
-      - name: Test Pytorch binary
-        uses: ./.github/actions/test-pytorch-binary
-        env:
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
-      - name: Teardown XPU
-        uses: ./.github/actions/teardown-xpu
+      build_name: ${{ matrix.config.build_name }}
 
   # Upload depends on whichever test job covers this config. We list all
   # three test jobs in `needs` and rely on the matrix cell that doesn't


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181599
* #181597
* #181596
* #181595
* #181594
* #181593
* #181592
* #181591
* #181590
* #181589
* __->__ #181588
* #181587
* #181586

Mirror the CPU/CUDA pattern (which uses _binary-test-linux.yml) by
pulling the inline ROCm and XPU test steps out of
generated-linux-binary-manywheel-nightly.yml into two new reusable
workflows:

  - .github/workflows/_binary-test-rocm-linux.yml
      setup-rocm, GPU_FLAG, ECR docker pull, test-pytorch-binary,
      teardown-rocm.

  - .github/workflows/_binary-test-xpu-linux.yml
      setup-xpu, ecr-login, ECR docker pull, test-pytorch-binary,
      teardown-xpu.

generated-linux-binary-manywheel-nightly.yml is now 209 lines; the
test-rocm / test-xpu matrix jobs just `uses:` the new reusable
workflows with matrix-driven inputs, matching how test (CPU/CUDA)
calls _binary-test-linux.yml.

Authored with Claude.