### PR TITLE
Grant id-token + contents: read to matrix-driven binary workflows

### DIFF
--- a/.github/workflows/linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/linux-binary-manywheel-nightly.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 env:
   # Needed for conda builds

--- a/.github/workflows/windows-arm64-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/windows-arm64-binary-libtorch-debug-nightly.yml
@@ -11,6 +11,10 @@ on:
       - 'ciflow/binaries_libtorch/*'
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/windows-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/windows-arm64-binary-wheel-nightly.yml
@@ -12,6 +12,10 @@ on:
       - 'ciflow/binaries_wheel/*'
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/windows-binary-libtorch-debug-nightly.yml
@@ -11,6 +11,10 @@ on:
       - 'ciflow/binaries_libtorch/*'
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/windows-binary-wheel-nightly.yml
+++ b/.github/workflows/windows-binary-wheel-nightly.yml
@@ -19,6 +19,10 @@ on:
       - 'ciflow/binaries_wheel/*'
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   # Needed for conda builds
   ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181599
* #181597
* #181596
* #181595
* #181594
* #181593
* __->__ #181592
* #181591
* #181590
* #181589
* #181588
* #181587
* #181586

Reusable binary-{build,test}-{linux,windows}[-arm64].yml workflows run
their inner jobs with:
    permissions:
      id-token: write
      contents: read

When a caller sets `permissions:` explicitly, all unspecified
permissions default to `none`. For reusable workflows, the nested
job's permission set must be a subset of the caller's, so:

- linux-binary-manywheel (only declared `id-token: write`) was
  rejecting the ROCm/XPU reusables' `contents: read`.
- Windows workflows didn't declare workflow-level permissions at all,
  so the reusables' `id-token: write` exceeded the default.

Fix: declare both `id-token: write` and `contents: read` at the
workflow level on every caller that invokes these reusables.

Authored with Claude.