### PR TITLE
Pass dummy DESIRED_PYTHON for windows x86 libtorch-debug

### DIFF
--- a/.github/workflows/windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/windows-binary-libtorch-debug-nightly.yml
@@ -72,6 +72,8 @@ jobs:
       GPU_ARCH_TYPE: ${{ matrix.config.gpu_arch_type }}
       LIBTORCH_CONFIG: ${{ matrix.config.libtorch_config }}
       LIBTORCH_VARIANT: ${{ matrix.config.libtorch_variant }}
+      # Dummy value so the batch scripts install pip correctly for libtorch builds.
+      DESIRED_PYTHON: "3.10"
       runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
       runs_on: windows.12xlarge
       build_name: ${{ matrix.config.build_name }}
@@ -94,6 +96,7 @@ jobs:
       GPU_ARCH_TYPE: ${{ matrix.config.gpu_arch_type }}
       LIBTORCH_CONFIG: ${{ matrix.config.libtorch_config }}
       LIBTORCH_VARIANT: ${{ matrix.config.libtorch_variant }}
+      DESIRED_PYTHON: "3.10"
       runner_prefix: ${{ needs.get-label-type.outputs.label-type }}
       runs_on: ${{ matrix.config.gpu_arch_type == 'cuda' && 'windows.g4dn.xlarge' || 'windows.4xlarge' }}
       build_name: ${{ matrix.config.build_name }}
@@ -119,6 +122,7 @@ jobs:
       GPU_ARCH_TYPE: ${{ matrix.config.gpu_arch_type }}
       LIBTORCH_CONFIG: ${{ matrix.config.libtorch_config }}
       LIBTORCH_VARIANT: ${{ matrix.config.libtorch_variant }}
+      DESIRED_PYTHON: "3.10"
       build_name: ${{ matrix.config.build_name }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181599
* #181597
* #181596
* #181595
* #181594
* __->__ #181593
* #181592
* #181591
* #181590
* #181589
* #181588
* #181587
* #181586

.ci/pytorch/binary_populate_env.sh + binary_windows_build.sh rely on
DESIRED_PYTHON being set so the batch scripts can extract the right
Python tarball into .ci/pytorch/windows/Python/. Without it the build
fails with `'"python"' is not recognized as an internal or external
command` and the subsequent upload errors with "No files were found".

The windows-arm64 libtorch-debug workflow already passes
DESIRED_PYTHON: "3.10" as a dummy; mirror that in the x86 workflow.

Authored with Claude.