### PR TITLE
Fix windows-arm64 bootstrap_python in reusable workflows

### DIFF
--- a/.github/workflows/_binary-build-windows-arm64.yml
+++ b/.github/workflows/_binary-build-windows-arm64.yml
@@ -58,6 +58,14 @@ jobs:
       LIBTORCH_CONFIG: ${{ inputs.LIBTORCH_CONFIG }}
       LIBTORCH_VARIANT: ${{ inputs.LIBTORCH_VARIANT }}
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: ${{ inputs.PYTORCH_EXTRA_INSTALL_REQUIREMENTS }}
+      # arm64-specific paths consumed by bootstrap_*.bat. These were set at
+      # workflow-level env: in the legacy (non-reusable) workflow; a reusable
+      # workflow doesn't inherit caller env, so redeclare them here.
+      DOWNLOADS_DIR: c:\temp\downloads
+      DEPENDENCIES_DIR: c:\temp\dependencies
+      ENABLE_APL: 1
+      ENABLE_OPENBLAS: 0
+      MSVC_VERSION: 14.42
     steps:
       - name: Populate binary env
         shell: cmd

--- a/.github/workflows/_binary-test-windows-arm64.yml
+++ b/.github/workflows/_binary-test-windows-arm64.yml
@@ -54,6 +54,14 @@ jobs:
       DESIRED_PYTHON: ${{ inputs.DESIRED_PYTHON }}
       LIBTORCH_CONFIG: ${{ inputs.LIBTORCH_CONFIG }}
       LIBTORCH_VARIANT: ${{ inputs.LIBTORCH_VARIANT }}
+      # arm64-specific paths consumed by bootstrap_*.bat. These were set at
+      # workflow-level env: in the legacy (non-reusable) workflow; a reusable
+      # workflow doesn't inherit caller env, so redeclare them here.
+      DOWNLOADS_DIR: c:\temp\downloads
+      DEPENDENCIES_DIR: c:\temp\dependencies
+      ENABLE_APL: 1
+      ENABLE_OPENBLAS: 0
+      MSVC_VERSION: 14.42
     steps:
       - name: Populate binary env
         shell: cmd

--- a/.github/workflows/windows-arm64-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/windows-arm64-binary-libtorch-debug-nightly.yml
@@ -78,7 +78,9 @@ jobs:
       LIBTORCH_CONFIG: ${{ matrix.config.libtorch_config }}
       LIBTORCH_VARIANT: ${{ matrix.config.libtorch_variant }}
       # Dummy value so our batch scripts install pip correctly for libtorch builds.
-      DESIRED_PYTHON: "3.10"
+      # Dummy value so bootstrap_python.bat installs a python for pip
+      # (arm64 has no 3.10 installer — use 3.12, the bootstrap default).
+      DESIRED_PYTHON: "3.12"
       build_name: ${{ matrix.config.build_name }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +100,9 @@ jobs:
       GPU_ARCH_TYPE: ${{ matrix.config.gpu_arch_type }}
       LIBTORCH_CONFIG: ${{ matrix.config.libtorch_config }}
       LIBTORCH_VARIANT: ${{ matrix.config.libtorch_variant }}
-      DESIRED_PYTHON: "3.10"
+      # Dummy value so bootstrap_python.bat installs a python for pip
+      # (arm64 has no 3.10 installer — use 3.12, the bootstrap default).
+      DESIRED_PYTHON: "3.12"
       build_name: ${{ matrix.config.build_name }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181599
* #181597
* #181596
* #181595
* __->__ #181594
* #181593
* #181592
* #181591
* #181590
* #181589
* #181588
* #181587
* #181586

Two problems with windows-arm64 binary builds after the reusable-
workflow split:

1. bootstrap_python.bat / bootstrap_apl.bat / bootstrap_sccache.bat
   read DOWNLOADS_DIR, DEPENDENCIES_DIR, ENABLE_APL, ENABLE_OPENBLAS,
   MSVC_VERSION. The legacy workflow set those at the workflow-level
   env: block, but reusable workflows don't inherit caller env. The
   batch scripts saw empty strings and errored out with "The syntax
   of the command is incorrect." from `if not exist "" mkdir `. Cmd
   then fell through the `if/else if` ladder, landed in the else
   branch, tried to install 3.12 into an empty TargetDir, and died
   with MSI exit code 1603.
   Redeclare the env vars inside _binary-build-windows-arm64.yml and
   _binary-test-windows-arm64.yml so the reusable job sees them.

2. windows-arm64-binary-libtorch-debug-nightly.yml was passing
   DESIRED_PYTHON: "3.10" as a dummy (copy-pasted from the x86
   convention). arm64 bootstrap_python.bat only ships 3.11/3.12/3.13
   installers, so 3.10 falls through to the default. Switched the
   dummy to "3.12" to match the bootstrap default explicitly.

Authored with Claude.