### PR TITLE
Propagate caller env into ROCm/XPU reusable test workflows

### DIFF
--- a/.github/workflows/_binary-test-rocm-linux.yml
+++ b/.github/workflows/_binary-test-rocm-linux.yml
@@ -68,6 +68,16 @@ jobs:
       DOCKER_IMAGE: ${{ inputs.DOCKER_IMAGE }}
       DOCKER_IMAGE_TAG_PREFIX: ${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
       DESIRED_PYTHON: ${{ inputs.DESIRED_PYTHON }}
+      # The following were set at the caller workflow's top-level env: in the
+      # legacy (non-reusable) flow. A reusable workflow doesn't inherit caller
+      # env, so redeclare the ones the docker/test scripts read.
+      ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
+      AWS_DEFAULT_REGION: us-east-1
+      BINARY_ENV_FILE: /tmp/env
+      BUILD_ENVIRONMENT: linux-binary-manywheel
+      PYTORCH_FINAL_PACKAGE_DIR: /artifacts
+      SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/_binary-test-xpu-linux.yml
+++ b/.github/workflows/_binary-test-xpu-linux.yml
@@ -63,6 +63,16 @@ jobs:
       DOCKER_IMAGE: ${{ inputs.DOCKER_IMAGE }}
       DOCKER_IMAGE_TAG_PREFIX: ${{ inputs.DOCKER_IMAGE_TAG_PREFIX }}
       DESIRED_PYTHON: ${{ inputs.DESIRED_PYTHON }}
+      # The following were set at the caller workflow's top-level env: in the
+      # legacy (non-reusable) flow. A reusable workflow doesn't inherit caller
+      # env, so redeclare the ones the docker/test scripts read.
+      ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
+      AWS_DEFAULT_REGION: us-east-1
+      BINARY_ENV_FILE: /tmp/env
+      BUILD_ENVIRONMENT: linux-binary-manywheel
+      PYTORCH_FINAL_PACKAGE_DIR: /artifacts
+      SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181599
* #181597
* #181596
* __->__ #181595
* #181594
* #181593
* #181592
* #181591
* #181590
* #181589
* #181588
* #181587
* #181586

ROCm and XPU test jobs both invoke ./.github/actions/test-pytorch-binary,
which calls `docker exec ... bash -c 'source $BINARY_ENV_FILE && bash
/run.sh'`. In the legacy (non-reusable) workflow, BINARY_ENV_FILE,
PYTORCH_FINAL_PACKAGE_DIR, ALPINE_IMAGE, AWS_DEFAULT_REGION, and the
PR_NUMBER/SHA1 helpers all came from the caller workflow's top-level
env: block.

A reusable workflow doesn't inherit caller env, so the var was empty
and the docker exec collapsed to `source  && bash /run.sh` which fails
with `bash: line 0: source: filename argument required`.

Redeclare those env vars inside _binary-test-rocm-linux.yml and
_binary-test-xpu-linux.yml at the test job's env: level.

Authored with Claude.