### PR TITLE
Set OS=windows-arm64 in arm64 reusable workflows

### DIFF
--- a/.github/workflows/_binary-build-windows-arm64.yml
+++ b/.github/workflows/_binary-build-windows-arm64.yml
@@ -58,9 +58,12 @@ jobs:
       LIBTORCH_CONFIG: ${{ inputs.LIBTORCH_CONFIG }}
       LIBTORCH_VARIANT: ${{ inputs.LIBTORCH_VARIANT }}
       PYTORCH_EXTRA_INSTALL_REQUIREMENTS: ${{ inputs.PYTORCH_EXTRA_INSTALL_REQUIREMENTS }}
-      # arm64-specific paths consumed by bootstrap_*.bat. These were set at
-      # workflow-level env: in the legacy (non-reusable) workflow; a reusable
-      # workflow doesn't inherit caller env, so redeclare them here.
+      # arm64-specific paths consumed by bootstrap_*.bat and the
+      # `if [[ "$OS" == "windows-arm64" ]]` branch in
+      # .ci/pytorch/binary_windows_build.sh. These were set at workflow-level
+      # env: in the legacy (non-reusable) workflow; a reusable workflow
+      # doesn't inherit caller env, so redeclare them here.
+      OS: windows-arm64
       DOWNLOADS_DIR: c:\temp\downloads
       DEPENDENCIES_DIR: c:\temp\dependencies
       ENABLE_APL: 1

--- a/.github/workflows/_binary-test-windows-arm64.yml
+++ b/.github/workflows/_binary-test-windows-arm64.yml
@@ -54,9 +54,12 @@ jobs:
       DESIRED_PYTHON: ${{ inputs.DESIRED_PYTHON }}
       LIBTORCH_CONFIG: ${{ inputs.LIBTORCH_CONFIG }}
       LIBTORCH_VARIANT: ${{ inputs.LIBTORCH_VARIANT }}
-      # arm64-specific paths consumed by bootstrap_*.bat. These were set at
-      # workflow-level env: in the legacy (non-reusable) workflow; a reusable
-      # workflow doesn't inherit caller env, so redeclare them here.
+      # arm64-specific paths consumed by bootstrap_*.bat and the
+      # `if [[ "$OS" == "windows-arm64" ]]` branch in
+      # .ci/pytorch/binary_windows_build.sh. These were set at workflow-level
+      # env: in the legacy (non-reusable) workflow; a reusable workflow
+      # doesn't inherit caller env, so redeclare them here.
+      OS: windows-arm64
       DOWNLOADS_DIR: c:\temp\downloads
       DEPENDENCIES_DIR: c:\temp\dependencies
       ENABLE_APL: 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181599
* __->__ #181597
* #181596
* #181595
* #181594
* #181593
* #181592
* #181591
* #181590
* #181589
* #181588
* #181587
* #181586

binary_windows_build.sh branches on `if [[ "$OS" == "windows-arm64" ]]`
to choose between ./windows/arm64/build_pytorch.bat and the x86 path
(./windows/internal/build_wheels.bat -> setup_build.bat). In the legacy
non-reusable workflow OS came from the caller workflow's top-level
env: block; reusable workflows don't inherit caller env, so $OS was
empty and binary_windows_build.sh fell into the x86 branch on arm64
runners, dying on:

  tar: ...\.ci\pytorch\windows\Python: Cannot open: No such file or directory

Add OS: windows-arm64 to _binary-build-windows-arm64.yml and
_binary-test-windows-arm64.yml so the script routes to the arm64
build_pytorch.bat / build_libtorch.bat scripts.

Authored with Claude.