### PR TITLE
Fix link to C++ torch stable docs

### DIFF
--- a/docs/source/notes/libtorch_stable_abi.md
+++ b/docs/source/notes/libtorch_stable_abi.md
@@ -32,7 +32,7 @@ It consists of
 
 We are continuing to improve coverage in our `torch/csrc/stable` APIs. Please file an issue if you'd like to see support for particular APIs in your custom extension.
 
-For complete API documentation of the stable operators, see the [Torch Stable API cpp documentation](https://docs.pytorch.org/cppdocs/stable.html). <!-- @lint-ignore: URL won't exist till stable.rst cpp docs are published in 2.10 -->
+For complete API documentation of the stable operators, see the [Torch Stable API cpp documentation](https://docs.pytorch.org/cppdocs/api/stable/index.html).
 
 ### Stable C headers
 


### PR DESCRIPTION
The link didn't work! now it does

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181604

