### PR TITLE
Empty cache in test_set_per_process_memory_fraction

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -520,6 +520,7 @@ print(t.is_pinned())
         IS_JETSON, "oom reporting has issues on jetson igx due to partial nvml support"
     )
     def test_set_per_process_memory_fraction(self):
+        torch.cuda.empty_cache()
         orig = torch.cuda.get_per_process_memory_fraction(0)
         torch.cuda.reset_peak_memory_stats(0)
         try:


### PR DESCRIPTION
This test needs to be more robust because a previous test's behaviour can impact this test's behaviour.

A specific case where we ran into this situation is on gfx1101, where the test fails with

```
test/test_cuda.py::TestCuda::test_set_per_process_memory_fraction FAILED
[0.1163s]

Traceback (most recent call last):
  File "/var/lib/jenkins/pytorch/test/test_cuda.py", line 471, in test_set_per_process_memory_fraction
    tmp_tensor = torch.empty(application, dtype=torch.int8, device="cuda")
RuntimeError: Trying to create tensor with negative dimension -5681285432: [-5681285432]
```

This error is coming from an integer overflow when another unit test,
test/test_cuda.py::TestCuda::test_randint_generation_for_large_numel
creates a tensor with a huge numel, which overflows into a higher
torch.cuda.max_memory_reserved() when you call
test/test_cuda.py::TestCuda::test_set_per_process_memory_fraction
afterward. To avoid this we introduced torch.cuda.empty_cache() to clean up CUDA states.

cc @rraminen 