### PR TITLE
[ROCm] CI: skip operator matmul microbenchmark

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2091,6 +2091,9 @@ test_operator_microbenchmark() {
 
   # NOTE: When adding a new test here, please update README: ../../benchmarks/operator_benchmark/README.md
   for OP_BENCHMARK_TESTS in matmul mm addmm bmm conv optimizer activation norm scaled_mm scaled_grouped_mm; do
+    if [[ "${BUILD_ENVIRONMENT}" == *rocm* && "${OP_BENCHMARK_TESTS}" == "matmul" ]]; then
+      continue
+    fi
     $TASKSET python -m pt.${OP_BENCHMARK_TESTS}_test --tag-filter long \
       --output-json-for-dashboard "${TEST_REPORTS_DIR}/operator_microbenchmark_${OP_BENCHMARK_TESTS}_compile.json" \
       --benchmark-name "PyTorch operator microbenchmark" --use-compile


### PR DESCRIPTION
Skip `pt.matmul_test` in `test_operator_microbenchmark()` when `BUILD_ENVIRONMENT` matches `ROCm`, so `CUDA`/`CPU` coverage is unchanged. This temporary fix avoids `ROCm` CI failures (e.g. segfaults) while keeping the rest of the microbenchmark suite.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang