### PR TITLE
[Inductor] Mock n_regs/n_spills to deflake epilogue fusion static analysis test

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -5088,6 +5088,8 @@ class TestEpilogueFusionStaticAnalysis(TestCase):
                 aten_time=aten_time,
                 triton_time=triton_time,
                 epilogue_runtime=epilogue_runtime,
+                mock_fused_n_regs=32,
+                mock_n_spills=0,
             ):
                 compiled_fn = torch.compile(fn)
                 _, code = run_and_get_code(compiled_fn, x, w, bias, scale)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181616

`test_template_epilogue_fusion_extra_reads_fuse_epilogue_False_use_async_compile_False`
was flaky because the static-analysis fusion path in `_fuse_epilogue` reads
`n_regs` and `n_spills` from the real Triton-compiled launcher
(`scheduler.py:4655-4659`). Triton's register allocation can vary across
runs, flipping the fusion decision and breaking the test's `FileCheck`
assertion on the generated kernel name.

`TestEpilogueFusionStaticAnalysis` sets `benchmark_epilogue_fusion=False`
in `setUpClass`, which routes around `benchmark_fused_nodes` and
`benchmark_codegened_module` entirely, so mocking those (the approach
#181195 took for `TestPrologueFusion`) is a no-op here. Instead, pass
`mock_fused_n_regs=32` and `mock_n_spills=0` to the existing
`get_common_patches` helper, which patches `CachingAutotuner.precompile`
to override the launcher's register/spill counts deterministically.

Fixes https://github.com/pytorch/pytorch/issues/179693

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo