### PR TITLE
Fixes NCCLComm::abort() to use correct deregister API for window-registered handles

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -379,14 +379,27 @@ void NCCLComm::abort(std::optional<std::string> commFailureReason) {
 #ifdef NCCL_HAS_COMM_REGISTER
   // Deregister all registered segments before aborting.
   for (auto& it : registeredSegmentHandles_) {
-    void* handle = it.second;
-    C10D_NCCL_CHECK(
-        ::ncclCommDeregister(ncclComm_, handle),
-        c10::str(
-            "Failed to deregister segment handle ",
-            handle,
-            " on ncclComm_ ",
-            ncclComm_));
+    void* handle = it.second.first;
+    bool is_window = it.second.second;
+    if (is_window) {
+#ifdef NCCL_HAS_COMM_WINDOW_REGISTER
+      C10D_NCCL_CHECK(
+          ::ncclCommWindowDeregister(ncclComm_, (ncclWindow_t)handle),
+          c10::str(
+              "Failed to window deregister segment handle ",
+              handle,
+              " on ncclComm_ ",
+              ncclComm_));
+#endif
+    } else {
+      C10D_NCCL_CHECK(
+          ::ncclCommDeregister(ncclComm_, handle),
+          c10::str(
+              "Failed to deregister segment handle ",
+              handle,
+              " on ncclComm_ ",
+              ncclComm_));
+    }
   }
   registeredSegmentHandles_.clear();
 #endif
@@ -531,7 +544,7 @@ ncclResult_t NCCLComm::registerSegment(
           " on ncclComm_ ",
           comm));
 #endif
-  registeredSegmentHandles_[ptr] = handle;
+  registeredSegmentHandles_[ptr] = {handle, window};
   return ncclSuccess;
 #else
   return ncclInvalidUsage;
@@ -548,7 +561,7 @@ ncclResult_t NCCLComm::deregisterSegment(void* ptr, bool window /*false*/) {
       " is not registered on ncclComm_ ",
       ncclComm_);
 
-  void* handle = registeredSegmentHandles_[ptr];
+  void* handle = registeredSegmentHandles_[ptr].first;
   // Use getNcclComm to make sure comm is ready before calling nccl APIs
   auto comm = getNcclComm();
 #ifdef NCCL_HAS_COMM_WINDOW_REGISTER

--- a/torch/csrc/distributed/c10d/NCCLUtils.hpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.hpp
@@ -409,8 +409,9 @@ class NCCLComm {
   // Device index for which the NCCL comm is created
   at::DeviceIndex deviceIndex_{-1};
 #ifdef NCCL_HAS_COMM_REGISTER
-  // Stores handlers for tensors registered by NCCL
-  std::unordered_map<void*, void*> registeredSegmentHandles_;
+  // Stores handlers for tensors registered by NCCL.
+  // Maps ptr -> (handle, is_window_registered).
+  std::unordered_map<void*, std::pair<void*, bool>> registeredSegmentHandles_;
 #endif // NCCL_HAS_COMM_REGISTER
 
  private:


### PR DESCRIPTION
`NCCLComm::abort()` unconditionally called `ncclCommDeregister()` on all entries in `registeredSegmentHandles_`. However, handles registered via `ncclCommWindowRegister()` (symmetric registration) require `ncclCommWindowDeregister()` instead. Using the wrong API causes NCCL to fail with "Deregister: Could not find handle" followed by a SIGABRT crash during ProcessGroupNCCL destruction.

The fix tracks whether each handle was window-registered by changing `registeredSegmentHandles_` from `map<void*, void*>` to `map<void*, pair<void*, bool>>`, and dispatches to the correct deregister call in `abort()`, matching the existing logic in `deregisterSegment()`.

Fixes: https://github.com/pytorch/pytorch/issues/181610

Assistant used: Claude Opus 4.7 (1M)