### PR TITLE
fix fix_test_divisible_by_16_covers_numel_args

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,0 @@
-repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.9
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.9
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -27,7 +27,6 @@ from typing_extensions import ParamSpec
 from unittest.mock import patch
 
 import numpy as np
-from torch.testing._internal.common_cuda import SM100OrLater
 import torch
 import torch._dynamo.config as dynamo_config
 import torch._inductor.aoti_eager
@@ -74,6 +73,7 @@ from torch.testing._internal.common_cuda import (
     IS_SM90,
     PLATFORM_SUPPORTS_FLASH_ATTENTION,
     PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+    SM100OrLater,
     SM80OrLater,
     SM90OrLater,
     TEST_CUDNN,
@@ -16675,13 +16675,11 @@ if RUN_GPU:
                     # one kernel, with extra workspace/semaphore args
                     0: (0, 1, 2, 3, 5),
                 }
-            elif(
-                SM100OrLater
-            ):
+            elif SM100OrLater:
                 self.assertEqual(len(kernels), 1)
                 expected_divisible = {
-                     0: (0, 1, 3),
-                 }
+                    0: (0, 1, 3),
+                }
             else:
                 self.assertEqual(len(kernels), 2)
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -27,7 +27,7 @@ from typing_extensions import ParamSpec
 from unittest.mock import patch
 
 import numpy as np
-
+from torch.testing._internal.common_cuda import SM100OrLater
 import torch
 import torch._dynamo.config as dynamo_config
 import torch._inductor.aoti_eager
@@ -16675,6 +16675,13 @@ if RUN_GPU:
                     # one kernel, with extra workspace/semaphore args
                     0: (0, 1, 2, 3, 5),
                 }
+            elif(
+                SM100OrLater
+            ):
+                self.assertEqual(len(kernels), 1)
+                expected_divisible = {
+                     0: (0, 1, 3),
+                 }
             else:
                 self.assertEqual(len(kernels), 2)
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -27,6 +27,7 @@ from typing_extensions import ParamSpec
 from unittest.mock import patch
 
 import numpy as np
+
 import torch
 import torch._dynamo.config as dynamo_config
 import torch._inductor.aoti_eager


### PR DESCRIPTION
Fix CI detected err in https://github.com/pytorch/pytorch/actions/runs/24899130435/job/72915802248?pr=181270

Similar to https://github.com/pytorch/pytorch/issues/181174, number of kernels is changed from 2 to 1 due to revise of reduction split threshold on sm100+ gpus.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo