### PR TITLE
[Docs - PT2] Fix stale Triton URLs and archived torchdynamo links

### DIFF
--- a/docs/source/user_guide/torch_compiler/torch.compiler.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler.md
@@ -74,7 +74,7 @@ Some of the most commonly used backends include:
    * - ``torch.compile(m, backend="inductor")``
      - Uses the TorchInductor backend. `Read more <https://dev-discuss.pytorch.org/t/torchinductor-a-pytorch-native-compiler-with-define-by-run-ir-and-symbolic-shapes/747>`__
    * - ``torch.compile(m, backend="cudagraphs")``
-     - CUDA graphs with AOT Autograd. `Read more <https://github.com/pytorch/torchdynamo/pull/757>`__
+     - CUDA graphs with AOT Autograd. `Read more <https://pytorch.org/docs/stable/torch.compiler_cudagraph_trees.html>`__
    * - ``torch.compile(m, backend="ipex")``
      - Uses IPEX on CPU. `Read more <https://github.com/intel/intel-extension-for-pytorch>`__
 ```

--- a/docs/source/user_guide/torch_compiler/torch.compiler_dynamo_overview.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_dynamo_overview.md
@@ -27,9 +27,9 @@ and without it:
 
 `TorchInductor` is one of the backends
 supported by [Dynamo Graph](https://pytorch.org/docs/stable/fx.html)
-into [Triton](https://github.com/openai/triton) for GPUs or
+into [Triton](https://github.com/triton-lang/triton) for GPUs or
 [C++/OpenMP](https://www.openmp.org/) for CPUs. We have a
-[training performance dashboard](https://github.com/pytorch/torchdynamo/issues/681#issuecomment-1233828468)
+[training performance dashboard](https://hud.pytorch.org/benchmark/compilers)
 that provides performance comparison for different training backends. You can read
 more in the [TorchInductor post on PyTorch
 dev-discuss](https://dev-discuss.pytorch.org/t/torchinductor-a-pytorch-native-compiler-with-define-by-run-ir-and-symbolic-shapes/747).
@@ -50,19 +50,18 @@ demonstrate how Dynamo works under the hood.
 
 Dynamo operates just-in-time and specializes graphs based on
 dynamic properties. Below is a basic example of how to use Dynamo.
-One can decorate a function or a method using `torchdynamo.optimize` to enable
+One can decorate a function or a method using `torch.compile` to enable
 Dynamo optimization:
 
 ```python
 from typing import List
 import torch
-from torch import _dynamo as torchdynamo
 def my_compiler(gm: torch.fx.GraphModule, example_inputs: List[torch.Tensor]):
     print("my_compiler() called with FX graph:")
     gm.graph.print_tabular()
     return gm.forward  # return a python callable
 
-@torchdynamo.optimize(my_compiler)
+@torch.compile(backend=my_compiler)
 def toy_example(a, b):
     x = a / (torch.abs(a) + 1)
     if b.sum() < 0:

--- a/docs/source/user_guide/torch_compiler/torch.compiler_fake_tensor.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_fake_tensor.md
@@ -139,7 +139,7 @@ Because fake tensors are used in situations that are very sensitive to the exact
 
 You would think fake tensors are fast because they don't do any tensor compute. But at small tensor sizes we are actually entirely overhead bound, and, well, fake tensor is in Python, and we often do a LOT of work to do a single tensor operation (because they are implemented as decompositions). So fake tensors are actually pretty slow in practice, especially when symbolic shapes are involved. There are two important fastpaths we currently have in fake tensor that make a big difference in practice:
 
-- Pointwise ops don't go through PrimTorch decomps, instead we've hand-coded their propagation rule.
+- Pointwise ops don't go through decompositions, instead we've hand-coded their propagation rule.
 - If possible, we should.
 
 ## Fake tensor of fake tensor?

--- a/docs/source/user_guide/torch_compiler/torch.compiler_get_started.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_get_started.md
@@ -46,7 +46,7 @@ CUDA graphs help eliminate the overhead from launching individual
 kernels from a Python program which is especially relevant for newer GPUs.
 
 TorchDynamo supports many different backends, but TorchInductor specifically works
-by generating [Triton](https://github.com/openai/triton) kernels. Let's save
+by generating [Triton](https://github.com/triton-lang/triton) kernels. Let's save
 our example above into a file called `example.py`. We can inspect the code
 generated Triton kernels by running `TORCH_COMPILE_DEBUG=1 python example.py`.
 As the script executes, you should see `DEBUG` messages printed to the
@@ -80,7 +80,7 @@ because the `cos` and `sin` operations occur within a single Triton kernel
 and the temporary variables are held in registers with very fast access.
 
 Read more on Triton's performance
-[here](https://openai.com/blog/triton/). Because the code is written
+[here](https://triton-lang.org/). Because the code is written
 in Python, it's fairly easy to understand even if you have not written all that
 many CUDA kernels.
 


### PR DESCRIPTION
## Summary

Fixes stale links and one deprecated code example in `docs/source/user_guide/torch_compiler/`:

- **Triton URL updates** (3 files): `github.com/openai/triton` -> `github.com/triton-lang/triton`; `openai.com/blog/triton/` -> `triton-lang.org`. Triton moved out of the OpenAI org.
- **Archived torchdynamo repo links** (2 files): `pytorch/torchdynamo` (archived) -> current `pytorch/pytorch` URLs.
- **Deprecated API example** (dynamo_overview.md): `@torchdynamo.optimize(my_compiler)` -> `@torch.compile(backend=my_compiler)` (public API form).
- **Terminology** (fake_tensor.md): "PrimTorch decomps" -> "decompositions".

## Test plan

- [ ] Sphinx CI build passes
- [ ] Spot-check that each new URL resolves to the intended target

cc @svekars @sekyondaMeta @AlannaBurke @williamwen42
