### PR TITLE
Make ConfigModule hash digest per-thread via ContextVar

### DIFF
--- a/test/test_utils_config_module.py
+++ b/test/test_utils_config_module.py
@@ -27,7 +27,7 @@ class TestConfigModule(TestCase):
         for k in config._config:
             config._config[k].user_override.set(_UNSET_SENTINEL)
             config._config[k].hide = False
-        config._hash_digest = None
+        config._hash_cache_var.set(None)
         config._get_dict_dirty_keys_var.set(None)
         config._get_dict_cache_var.set(None)
         # Reset deprecation warning flags
@@ -287,8 +287,8 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
                 hash_value,
             )
 
-        config._hash_digest = "fake"
-        self.assertEqual(config.get_hash(), "fake")
+        config._hash_cache_var.set(b"fake")
+        self.assertEqual(config.get_hash(), b"fake")
 
         config.e_bool = False
         self.assertNotEqual(
@@ -765,6 +765,78 @@ torch.testing._internal.fake_config_module3.e_func = _warnings.warn""",
             revert()
         d3 = config._get_dict(readonly_values=True)
         self.assertEqual(d3["e_int"], 1)
+
+    def test_get_hash_per_thread_isolation(self):
+        """Each thread should compute its own hash based on its own config values."""
+        import threading
+
+        base_hash = config.get_hash()
+
+        thread_hash = [None]
+        error = [None]
+
+        def thread_fn():
+            try:
+                config.e_int = 999
+                thread_hash[0] = config.get_hash()
+            except Exception as e:
+                error[0] = e
+
+        t = threading.Thread(target=thread_fn)
+        t.start()
+        t.join()
+        if error[0] is not None:
+            raise error[0]
+
+        # The main thread's hash should be unchanged (e_int still at default)
+        self.assertEqual(config.get_hash(), base_hash)
+        # The child thread should have gotten a different hash
+        self.assertNotEqual(thread_hash[0], base_hash)
+
+    def test_hash_dirty_on_setattr(self):
+        """Direct config assignment should mark the hash dirty."""
+        config.get_hash()
+        self.assertFalse(config._hash_dirty_var.get())
+        config.e_int = 42
+        self.assertTrue(config._hash_dirty_var.get())
+
+    def test_hash_dirty_on_delattr(self):
+        """Deleting a config key should mark the hash dirty."""
+        config.get_hash()
+        self.assertFalse(config._hash_dirty_var.get())
+        del config.e_int
+        self.assertTrue(config._hash_dirty_var.get())
+
+    def test_hash_dirty_on_patch(self):
+        """Entering and exiting a patch should mark the hash dirty."""
+        config.get_hash()
+        self.assertFalse(config._hash_dirty_var.get())
+        with config.patch(e_int=42):
+            self.assertTrue(config._hash_dirty_var.get())
+            config.get_hash()
+            self.assertFalse(config._hash_dirty_var.get())
+        # Exiting the patch restores old values via __setattr__, which marks dirty
+        self.assertTrue(config._hash_dirty_var.get())
+
+    def test_hash_dirty_on_closure_patcher(self):
+        """_make_closure_patcher should mark the hash dirty on apply and revert."""
+        config.get_hash()
+        self.assertFalse(config._hash_dirty_var.get())
+        change_fn = config._make_closure_patcher(e_int=42)
+        revert = change_fn()
+        self.assertTrue(config._hash_dirty_var.get())
+        config.get_hash()
+        self.assertFalse(config._hash_dirty_var.get())
+        revert()
+        self.assertTrue(config._hash_dirty_var.get())
+
+    def test_hash_dirty_on_load_config(self):
+        """Loading a saved config should mark the hash dirty."""
+        saved = config.save_config()
+        config.get_hash()
+        self.assertFalse(config._hash_dirty_var.get())
+        config.load_config(saved)
+        self.assertTrue(config._hash_dirty_var.get())
 
 
 if __name__ == "__main__":

--- a/torch/utils/_config_module.py
+++ b/torch/utils/_config_module.py
@@ -179,8 +179,8 @@ def install_config_module(module: ModuleType) -> None:
     class ConfigModuleInstance(ConfigModule):
         # __annotations__ is written to by Sphinx autodoc
         _bypass_keys = {
-            "_is_dirty",
-            "_hash_digest",
+            "_hash_dirty_var",
+            "_hash_cache_var",
             "_get_dict_dirty_keys_var",
             "_get_dict_cache_var",
             "__annotations__",
@@ -248,8 +248,10 @@ def install_config_module(module: ModuleType) -> None:
     module._config = config  # type: ignore[attr-defined]
     module._compile_ignored_keys = compile_ignored_keys  # type: ignore[attr-defined]
     module.__class__ = ConfigModuleInstance
-    module._is_dirty = True  # type: ignore[attr-defined]
-    module._hash_digest = None  # type: ignore[attr-defined]
+    module._hash_dirty_var = ContextVar(f"{module.__name__}._hash_dirty", default=True)  # type: ignore[attr-defined]  # pyrefly: ignore[missing-attribute]
+    module._hash_cache_var = ContextVar(  # pyrefly: ignore[missing-attribute]
+        f"{module.__name__}._hash_cache", default=None
+    )  # type: ignore[attr-defined]
     module._get_dict_dirty_keys_var = ContextVar(  # pyrefly: ignore[missing-attribute]
         f"{module.__name__}._get_dict_dirty_keys", default=None
     )  # type: ignore[attr-defined]
@@ -387,8 +389,8 @@ class ConfigModule(ModuleType):
     _config: dict[str, _ConfigEntry]
     _bypass_keys: set[str]
     _compile_ignored_keys: set[str]
-    _is_dirty: bool
-    _hash_digest: bytes | None
+    _hash_dirty_var: ContextVar[bool]
+    _hash_cache_var: ContextVar[bytes | None]
     # Per-thread cache state, backed by ContextVar so each thread/context gets
     # its own dirty set and cache (config values are per-thread via ContextVar).
     # None means fully dirty (initial state or >_GET_DICT_DIRTY_KEYS_CAP keys
@@ -427,7 +429,7 @@ class ConfigModule(ModuleType):
                 self._set_alias_val(config, value)
             else:
                 config.user_override.set(value)
-                self._is_dirty = True
+                self._hash_dirty_var.set(True)
                 self._mark_get_dict_dirty(name)
                 config.hide = False
 
@@ -471,7 +473,7 @@ class ConfigModule(ModuleType):
             raise AttributeError(f"{self.__name__}.{name} does not exist") from e
 
     def __delattr__(self, name: str) -> None:
-        self._is_dirty = True
+        self._hash_dirty_var.set(True)
         self._mark_get_dict_dirty(name)
         # must support delete because unittest.mock.patch deletes
         # then recreate things
@@ -744,16 +746,23 @@ class ConfigModule(ModuleType):
 
     def get_hash(self) -> bytes:
         """Hashes the configs that are not compile_ignored"""
-        if self._is_dirty or self._hash_digest is None:
+        if self._hash_dirty_var.get() or self._hash_cache_var.get() is None:
             dict_to_hash = self._get_dict(
                 ignored_keys=list(self._compile_ignored_keys), readonly_values=True
             )
             string_to_hash = repr(sorted(dict_to_hash.items()))
-            self._hash_digest = hashlib.md5(
-                string_to_hash.encode("utf-8"), usedforsecurity=False
-            ).digest()
-            self._is_dirty = False
-        return self._hash_digest
+            self._hash_cache_var.set(
+                hashlib.md5(
+                    string_to_hash.encode("utf-8"), usedforsecurity=False
+                ).digest()
+            )
+            self._hash_dirty_var.set(False)
+        result = self._hash_cache_var.get()
+        if result is None:
+            raise AssertionError(
+                "_hash_cache_var should not be None after recomputation"
+            )
+        return result
 
     @deprecated(
         "`config.to_dict()` has been deprecated. It no longer changes the underlying config."
@@ -905,11 +914,13 @@ class ConfigModule(ModuleType):
             prior = {k: config[k].user_override.get() for k in changes}
             for k, v in changes.items():
                 config[k].user_override.set(v)
+                self._hash_dirty_var.set(True)
                 self._mark_get_dict_dirty(k)
 
             def revert() -> None:
                 for k, v in prior.items():
                     config[k].user_override.set(v)
+                    self._hash_dirty_var.set(True)
                     self._mark_get_dict_dirty(k)
 
             return revert


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181651
* #181159

_is_dirty and _hash_digest were plain instance attributes shared across
threads, but they guard a cache derived from per-thread config values
(user_override is a ContextVar). This meant one thread's get_hash()
could return a stale digest computed from another thread's config state.

Fix by converting both to ContextVar-backed attributes (_hash_dirty_var
and _hash_cache_var), matching the existing pattern used for _get_dict
cache state. Also mark dirty in _make_closure_patcher (both apply and
revert) so the hash is correctly invalidated for the fast-path config
patching code.

Authored with Claude.