### PR TITLE
Fix "the a" → correct article in comments and docstrings

### DIFF
--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -297,7 +297,7 @@ def init_cellvars(
 ) -> None:
     """
     Update `result` to add mapping from local name to new cells created
-    directly by `code`, or update SideEffects in `parent` if the a local cell is
+    directly by `code`, or update SideEffects in `parent` if a local cell is
     already in `result` (cell argument).
     """
     side_effects = parent.output.side_effects

--- a/torch/_inductor/virtualized.py
+++ b/torch/_inductor/virtualized.py
@@ -102,7 +102,7 @@ class NullHandler:
 
 
 # If a virtualized value is set to _PoisonedVirtual then any attempt to get the
-# value will result an an exception being raised. This is useful if we want to
+# value will result in an exception being raised. This is useful if we want to
 # trap uninitialized reads of virtualized globals - for example when compiling
 # in a subprocess we don't want the child reading globals that weren't copied
 # from the parent.

--- a/torch/csrc/api/include/torch/nn/modules/container/parameterlist.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/parameterlist.h
@@ -45,21 +45,21 @@ class ParameterListImpl : public Cloneable<ParameterListImpl> {
     stream << ')';
   }
 
-  /// push the a given parameter at the end of the list
+  /// push a given parameter at the end of the list
   void append(torch::Tensor&& param) {
     bool requires_grad = param.requires_grad();
     register_parameter(
         std::to_string(parameters_.size()), std::move(param), requires_grad);
   }
 
-  /// push the a given parameter at the end of the list
+  /// push a given parameter at the end of the list
   void append(const torch::Tensor& param) {
     bool requires_grad = param.requires_grad();
     register_parameter(
         std::to_string(parameters_.size()), param, requires_grad);
   }
 
-  /// push the a given parameter at the end of the list
+  /// push a given parameter at the end of the list
   /// And the key of the pair will be discarded, only the value
   /// will be added into the `ParameterList`
   void append(const OrderedDict<std::string, torch::Tensor>::Item& pair) {

--- a/torch/csrc/api/include/torch/nn/options/transformercoder.h
+++ b/torch/csrc/api/include/torch/nn/options/transformercoder.h
@@ -50,7 +50,7 @@ struct TORCH_API TransformerEncoderOptions {
 /// transformer_decoder(options);
 /// ```
 struct TORCH_API TransformerDecoderOptions {
-  // This constructor will keep the a ref of passed in decoder_layer,
+  // This constructor will keep a ref of passed in decoder_layer,
   // so it keeps all the data in decoder_layer.
   TransformerDecoderOptions(
       TransformerDecoderLayer decoder_layer,

--- a/torch/csrc/distributed/c10d/cuda/StreamBlock.hpp
+++ b/torch/csrc/distributed/c10d/cuda/StreamBlock.hpp
@@ -15,7 +15,7 @@ enum StreamBlockStatus : int32_t {
 };
 
 /*
-StreamBlock implements a baton that will block a the active CUDA stream
+StreamBlock implements a baton that will block the active CUDA stream
 until aborted by the main process.
 */
 class TORCH_API StreamBlock {

--- a/torch/csrc/jit/passes/loop_unrolling.cpp
+++ b/torch/csrc/jit/passes/loop_unrolling.cpp
@@ -91,7 +91,7 @@ void inlineBody(Node* loop) {
 }
 
 // inserts a copy of body, passing inputs to the inputs of the block
-// it returns the a list of the Values for the output of the block
+// it returns a list of the Values for the output of the block
 std::vector<Value*> insertBlockCopy(
     Graph& graph,
     Block* body,

--- a/torch/csrc/stable/c/shim.h
+++ b/torch/csrc/stable/c/shim.h
@@ -159,7 +159,7 @@ torch_set_requires_grad(AtenTensorHandle tensor, bool requires_grad);
  */
 #if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_11_0
 
-// Shims for the a few dtypes not already in
+// Shims for a few dtypes not already in
 // torch/csrc/inductor/aoti_torch/c/shim.h
 AOTI_TORCH_EXPORT int32_t torch_dtype_float8_e8m0fnu();
 AOTI_TORCH_EXPORT int32_t torch_dtype_float4_e2m1fn_x2();

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -242,7 +242,7 @@ class JitTestCase(JitCommonTestCase):
                 else:
                     return
 
-            # import the model again (from a the copy we made of the original)
+            # import the model again (from the copy we made of the original)
             buffer2 = io.BytesIO(buffer_copy)
             imported = torch.jit.load(buffer2)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181656

Remove spurious duplicate article "the a" across multiple files in
torch, replacing with the grammatically correct form ("a", "the", or
"the copy" as appropriate). These are comment/docstring-only changes
with no functional impact.

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98