### PR TITLE
[Dynamo] Support @nonstrict_trace on autograd.Function

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -2588,6 +2588,134 @@ class AutogradFunctionFunctorchTests(torch._dynamo.test_case.TestCase):
         result = torch.func.grad(loss_fn)(x)
         self.assertEqual(result, torch.tensor([2.0, 2.0]))
 
+    def test_nonstrict_trace_autograd_function(self):
+        """@nonstrict_trace on autograd.Function fixes backward metadata mismatch.
+
+        Without the decorator, Dynamo traces backward assuming the gradient has
+        the same strides as the forward output (contiguous). At runtime the
+        gradient is non-contiguous, so the wrong branch is baked in.
+
+        With @nonstrict_trace, the autograd.Function is opaque to Dynamo and
+        AOTAutograd traces backward with correct metadata. Also tests
+        save_for_backward and inductor backend.
+        """
+
+        @torch._dynamo.nonstrict_trace
+        class StrideBranchFunc(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.save_for_backward(x)
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                (x,) = ctx.saved_tensors
+                if grad_output.is_contiguous():
+                    return grad_output * x
+                else:
+                    return grad_output.contiguous() * x * 0.5
+
+        def fn(x):
+            y = StrideBranchFunc.apply(x)
+            return y.t().sum()
+
+        for backend in ["aot_eager", "inductor"]:
+            torch._dynamo.reset()
+            x_ref = torch.randn(4, 4, requires_grad=True)
+            x_test = x_ref.clone().detach().requires_grad_(True)
+
+            fn(x_ref).backward()
+            torch.compile(fn, backend=backend)(x_test).backward()
+
+            self.assertEqual(x_ref.grad, x_test.grad)
+
+    def test_nonstrict_trace_autograd_function_dataclass_input(self):
+        """@nonstrict_trace supports pytree-registered dataclass inputs."""
+        from torch.utils._pytree import register_dataclass
+
+        @dataclass
+        class ScaleConfig:
+            scale: float
+            offset: float
+
+        register_dataclass(ScaleConfig)
+
+        @torch._dynamo.nonstrict_trace
+        class ConfiguredFunc(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, config):
+                ctx.save_for_backward(x)
+                ctx.scale = config.scale
+                return x * config.scale + config.offset
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                (x,) = ctx.saved_tensors
+                return grad_output * ctx.scale, None
+
+        config = ScaleConfig(scale=2.0, offset=1.0)
+
+        def fn(x, config):
+            return ConfiguredFunc.apply(x, config).sum()
+
+        x_ref = torch.randn(4, 4, requires_grad=True)
+        x_test = x_ref.clone().detach().requires_grad_(True)
+
+        fn(x_ref, config).backward()
+        torch.compile(fn, backend="aot_eager")(x_test, config).backward()
+
+        self.assertEqual(x_ref.grad, x_test.grad)
+
+    def test_nonstrict_trace_autograd_function_selective(self):
+        """Only the decorated autograd.Function uses nonstrict; others use
+        default Dynamo tracing."""
+
+        @torch._dynamo.nonstrict_trace
+        class NonstrictFunc(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x.clone()
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                if grad_output.is_contiguous():
+                    return grad_output
+                else:
+                    return grad_output.contiguous() * 0.5
+
+        class DefaultFunc(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x * 3.0
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return grad_output * 3.0
+
+        # NonstrictFunc with transpose to trigger non-contiguous grad
+        def fn_nonstrict(x):
+            y = NonstrictFunc.apply(x)
+            return y.t().sum()
+
+        x_ref = torch.randn(4, 4, requires_grad=True)
+        x_test = x_ref.clone().detach().requires_grad_(True)
+        fn_nonstrict(x_ref).backward()
+        torch.compile(fn_nonstrict, backend="aot_eager")(x_test).backward()
+        self.assertEqual(x_ref.grad, x_test.grad)
+
+        # DefaultFunc still uses default Dynamo tracing
+        def fn_default(x):
+            y = DefaultFunc.apply(x)
+            return y.t().sum()
+
+        x3 = torch.randn(4, 4, requires_grad=True)
+        x4 = x3.clone().detach().requires_grad_(True)
+        fn_default(x3).backward()
+        torch._dynamo.reset()
+        torch.compile(fn_default, backend="aot_eager")(x4).backward()
+        # DefaultFunc.backward has no branching, so both paths agree
+        self.assertEqual(x3.grad, x4.grad)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -231,6 +231,8 @@ def nonstrict_trace(traceable_fn: Callable[_P, _R]) -> Callable[_P, _R]:
     - User-defined classes as inputs (must be registered with pytree)
     - ``nn.Module`` as input arguments (parameters and buffers are tracked for autograd)
     - Global/captured tensors treated as constants (assumed not updated during execution)
+    - ``torch.autograd.Function`` subclasses: Dynamo will not trace into forward/backward,
+      letting aot_autograd handle them natively with correct gradient metadata.
 
     Note:
         - With ``backend="eager"``, the original Python function runs directly.
@@ -282,7 +284,36 @@ def nonstrict_trace(traceable_fn: Callable[_P, _R]) -> Callable[_P, _R]:
         >>> out = opt_model(torch.randn(10, 10))
         >>> out.sum().backward()  # Gradients flow through traced_forward
 
+    Example with autograd.Function::
+
+        >>> @torch._dynamo.nonstrict_trace
+        ... class MyFunc(torch.autograd.Function):
+        ...     @staticmethod
+        ...     def forward(ctx, x):
+        ...         ctx.save_for_backward(x)
+        ...         return x.clone()
+        ...
+        ...     @staticmethod
+        ...     def backward(ctx, grad_output):
+        ...         (x,) = ctx.saved_tensors
+        ...         if grad_output.is_contiguous():
+        ...             return grad_output
+        ...         else:
+        ...             return grad_output.contiguous() * 0.5
+
     """
+    if isinstance(traceable_fn, type) and issubclass(
+        traceable_fn, torch.autograd.Function
+    ):
+        fn_id = id(traceable_fn)
+        trace_rules._nonstrict_trace_callable_ids.add(fn_id)
+
+        def deregister() -> None:
+            trace_rules._nonstrict_trace_callable_ids.remove(fn_id)
+
+        weakref.finalize(traceable_fn, deregister)
+        return traceable_fn  # type: ignore[return-value]
+
     assert callable(traceable_fn), "nonstrict_trace expects a callable"
 
     _check_mutually_exclusive_decorators(traceable_fn, "nonstrict_trace")

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -875,6 +875,17 @@ class AutogradFunctionVariable(VariableTracker):
         VariableTracker.visit(visit, (args, kwargs))
 
         if requires_grad and torch.is_grad_enabled():
+            if trace_rules.is_nonstrict_trace_callable(self.fn_cls):
+                from .torch import AllowInGraphKind, TorchInGraphFunctionVariable
+
+                trampoline_autograd_apply = produce_trampoline_autograd_apply(
+                    self.fn_cls
+                )
+                return TorchInGraphFunctionVariable(
+                    trampoline_autograd_apply,
+                    kind=AllowInGraphKind.NONSTRICT_TRACE,
+                ).call_function(tx, args, kwargs)
+
             source = self.source
 
             from torch._functorch.autograd_function import (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181660
* #181339
* #181210
* #181208

Dynamo traces autograd.Function backward with FakeTensors whose metadata
matches the forward output. If the runtime gradient has different metadata
(e.g., non-contiguous strides from upstream ops), data-dependent branches
in backward are traced incorrectly, causing silent wrong results.

This extends @nonstrict_trace to accept autograd.Function subclasses. When
decorated, the autograd.Function is opaque to Dynamo — it emits a
flat_apply HOP and lets AOTAutograd handle forward/backward tracing
natively with correct gradient metadata. This also inherits nonstrict_trace
support for pytree-registered inputs (dataclasses, etc.) and nn.Module
parameters.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98