### PR TITLE
ci: add torchcomms to distributed CI

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -286,6 +286,10 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* ]]; then
     install_torchao
   fi
 
+  if [[ "${BUILD_ADDITIONAL_PACKAGES:-}" == *torchcomms* ]]; then
+    install_torchcomms
+  fi
+
   if [[ "$BUILD_ENVIRONMENT" == *xpu* ]]; then
     echo "Checking that xpu is compiled"
     pushd dist/

--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -295,6 +295,20 @@ function install_torchao() {
   pip_build_and_install "git+https://github.com/pytorch/ao.git@${commit}" dist/ao
 }
 
+function install_torchcomms() {
+  local commit
+  commit=$(get_pinned_commit torchcomms)
+  export USE_GLOO=1
+  export USE_NCCLX=0
+  export USE_TRANSPORT=0
+  if [[ "${BUILD_ENVIRONMENT}" == *cuda* ]]; then
+    export USE_NCCL=1
+  else
+    export USE_NCCL=0
+  fi
+  pip_build_and_install "git+https://github.com/meta-pytorch/torchcomms.git@${commit}" dist/torchcomms
+}
+
 function install_flash_attn_cute() {
   echo "Installing FlashAttention 4 from PyPI..."
   pip_install flash-attn-4==4.0.0b5

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2188,6 +2188,7 @@ elif [[ "${BUILD_ENVIRONMENT}" == *libtorch* ]]; then
   # TODO: run some C++ tests
   echo "no-op at the moment"
 elif [[ "$TEST_CONFIG" == distributed ]]; then
+  install_torchcomms
   test_distributed
   # Only run RPC C++ tests on the first shard
   if [[ "${SHARD_NUMBER}" == 1 ]]; then
@@ -2211,6 +2212,7 @@ elif [[ "${TEST_CONFIG}" == *operator_microbenchmark* ]]; then
 elif [[ "${TEST_CONFIG}" == *attention_microbenchmark* ]]; then
   test_attention_microbenchmark
 elif [[ "${TEST_CONFIG}" == *inductor_distributed* ]]; then
+  install_torchcomms
   setup_torch_trace
   test_inductor_distributed
   collect_tlparse_output
@@ -2345,6 +2347,7 @@ elif [[ "${TEST_CONFIG}" == smoke_xpu ]]; then
 elif [[ "${TEST_CONFIG}" == dtensor ]]; then
   test_dtensor
 elif [[ "${TEST_CONFIG}" == h100_distributed ]]; then
+  install_torchcomms
   test_h100_distributed
 elif [[ "${TEST_CONFIG}" == "h100-symm-mem" ]]; then
   test_h100_symm_mem

--- a/.github/ci_commit_pins/torchcomms.txt
+++ b/.github/ci_commit_pins/torchcomms.txt
@@ -1,0 +1,1 @@
+567c9737f1fbc81ba3fd52b891b5d99bbfafa5ec

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,6 +99,10 @@ jobs:
             repo-owner: pytorch
             branch: main
             pin-folder: .github/ci_commit_pins
+          - repo-name: torchcomms
+            repo-owner: meta-pytorch
+            branch: main
+            pin-folder: .github/ci_commit_pins
     # Allow this to be triggered on either a schedule or on workflow_dispatch to allow for easier testing
     if: github.repository_owner == 'pytorch' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     steps:


### PR DESCRIPTION
This adds torchcomms to the PyTorch Distributed CI.

This is intended as a less invasive alternative to #181046.

Test plan:

CI + double check that ncclx is not being built