### PR TITLE
Fix UBSan in weight_norm CPU kernel for empty input (#181510)

### DIFF
--- a/aten/src/ATen/native/cpu/WeightNormKernel.cpp
+++ b/aten/src/ATen/native/cpu/WeightNormKernel.cpp
@@ -10,6 +10,8 @@
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/irange.h>
 
+#include <algorithm>
+
 namespace at::native {
 
 namespace {
@@ -407,6 +409,22 @@ void weight_norm_kernel(
     int64_t dim) {
   TORCH_INTERNAL_ASSERT(dim == 0 || dim == v.dim() - 1,
       "fused kernels can only be applied for first or last dim");
+  // #181510: with an empty input (e.g. nn.Linear(0, 1).weight has shape (1, 0)),
+  // the inner kernels dispatch v_data + i*N pointers (which can be null for
+  // a zero-numel tensor) into the vectorized loadu paths and trigger UBSan
+  // null-pointer-passed-to-non-null. The L2 norm of an empty vector is
+  // sqrt(0) = 0, so fill `norm` accordingly and skip the kernel when there is
+  // nothing to reduce.
+  if (v.numel() == 0) {
+    if (norm.numel() > 0) {
+      AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::BFloat16, ScalarType::Half, v.scalar_type(),
+          "weight_norm_kernel_empty", [&]() {
+        using accscalar_t = at::opmath_type<scalar_t>;
+        std::fill_n(norm.data_ptr<accscalar_t>(), norm.numel(), accscalar_t(0));
+      });
+    }
+    return;
+  }
   AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::BFloat16, ScalarType::Half, v.scalar_type(),
       "weight_norm_kernel", [&]() {
     using accscalar_t = at::opmath_type<scalar_t>;
@@ -432,6 +450,20 @@ void weight_norm_backward_kernel(
     int64_t dim) {
   TORCH_INTERNAL_ASSERT(dim == 0 || dim == saved_v.dim() - 1,
       "fused kernels can only be applied for first or last dim");
+  // #181510 (companion to the forward fix): the backward kernels have the
+  // same vectorized-loadu pattern over `v_data + i*N` and would trigger the
+  // same UBSan diagnostic if a backward pass ever runs with empty saved_v.
+  // grad_v is empty (numel matches saved_v); grad_g has no signal, so fill
+  // it with zeros.
+  if (saved_v.numel() == 0) {
+    if (grad_g.numel() > 0) {
+      AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::BFloat16, ScalarType::Half, saved_v.scalar_type(),
+          "weight_norm_backward_kernel_empty", [&]() {
+        std::fill_n(grad_g.data_ptr<scalar_t>(), grad_g.numel(), scalar_t(0));
+      });
+    }
+    return;
+  }
   AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::BFloat16, ScalarType::Half, saved_v.scalar_type(),
       "weight_norm_backward_kernel", [&]() {
     using accscalar_t = at::opmath_type<scalar_t>;

--- a/aten/src/ATen/native/cpu/WeightNormKernel.cpp
+++ b/aten/src/ATen/native/cpu/WeightNormKernel.cpp
@@ -10,8 +10,6 @@
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/irange.h>
 
-#include <algorithm>
-
 namespace at::native {
 
 namespace {
@@ -409,20 +407,8 @@ void weight_norm_kernel(
     int64_t dim) {
   TORCH_INTERNAL_ASSERT(dim == 0 || dim == v.dim() - 1,
       "fused kernels can only be applied for first or last dim");
-  // #181510: with an empty input (e.g. nn.Linear(0, 1).weight has shape (1, 0)),
-  // the inner kernels dispatch v_data + i*N pointers (which can be null for
-  // a zero-numel tensor) into the vectorized loadu paths and trigger UBSan
-  // null-pointer-passed-to-non-null. The L2 norm of an empty vector is
-  // sqrt(0) = 0, so fill `norm` accordingly and skip the kernel when there is
-  // nothing to reduce.
   if (v.numel() == 0) {
-    if (norm.numel() > 0) {
-      AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::BFloat16, ScalarType::Half, v.scalar_type(),
-          "weight_norm_kernel_empty", [&]() {
-        using accscalar_t = at::opmath_type<scalar_t>;
-        std::fill_n(norm.data_ptr<accscalar_t>(), norm.numel(), accscalar_t(0));
-      });
-    }
+    norm.fill_(0);
     return;
   }
   AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::BFloat16, ScalarType::Half, v.scalar_type(),
@@ -450,18 +436,8 @@ void weight_norm_backward_kernel(
     int64_t dim) {
   TORCH_INTERNAL_ASSERT(dim == 0 || dim == saved_v.dim() - 1,
       "fused kernels can only be applied for first or last dim");
-  // #181510 (companion to the forward fix): the backward kernels have the
-  // same vectorized-loadu pattern over `v_data + i*N` and would trigger the
-  // same UBSan diagnostic if a backward pass ever runs with empty saved_v.
-  // grad_v is empty (numel matches saved_v); grad_g has no signal, so fill
-  // it with zeros.
   if (saved_v.numel() == 0) {
-    if (grad_g.numel() > 0) {
-      AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::BFloat16, ScalarType::Half, saved_v.scalar_type(),
-          "weight_norm_backward_kernel_empty", [&]() {
-        std::fill_n(grad_g.data_ptr<scalar_t>(), grad_g.numel(), scalar_t(0));
-      });
-    }
+    grad_g.fill_(0);
     return;
   }
   AT_DISPATCH_FLOATING_TYPES_AND2(ScalarType::BFloat16, ScalarType::Half, saved_v.scalar_type(),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1885,6 +1885,19 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         m = nn.Linear(4, 5, dtype=torch.float16)
         m = torch.nn.utils.weight_norm(m)
 
+    def test_weight_norm_empty_input(self):
+        # Regression test for #181510. weight_norm on a Linear layer with a
+        # zero-sized in_features dim used to dispatch a nullptr/zero-length
+        # pointer into the vectorized loadu helpers and trip UBSan
+        # (null-pointer-passed-to-non-null) under an ASAN/UBSAN build. The
+        # fused CPU kernel now treats an empty `v` as "norm of empty = 0" and
+        # skips the reduction.
+        for dtype in [torch.float, torch.bfloat16, torch.float16]:
+            m = torch.nn.utils.weight_norm(nn.Linear(0, 1).to(dtype=dtype))
+            x = torch.empty((1, 0), dtype=dtype)
+            out = m(x)
+            self.assertEqual(out.shape, torch.Size([1, 1]))
+
     def test_parameterlistdict_setting_attributes(self):
         with warnings.catch_warnings(record=True) as w:
             mod = nn.ParameterList(map(nn.Parameter, [torch.rand(2), torch.rand(2)]))


### PR DESCRIPTION
Fixes #181510.

## What

`torch.nn.utils.weight_norm` applied to `nn.Linear(0, 1)` and run on an empty input tripped UBSan in an ASAN/UBSAN build:

```
aten/src/ATen/cpu/vec/vec256/vec256_float.h:124:16:
runtime error: null pointer passed as argument 2,
which is declared to never be null
```

Stack trace bottoms out in `Vectorized<float>::loadu(void const*, long)` called from `map_reduce_all` inside `weight_norm_first_dim_kernel`. The kernel does `vec::map_reduce_all(..., v_data + i*N, N)` with `N == 0`; an empty `v` surfaces a zero-numel `data_ptr()` (which can be `nullptr`), and the vectorized load path declares its buffer argument as nonnull.

## Fix

Per @albanD's response on the issue, this is the minimum fix — early-exit when there is no work. The L2 norm of an empty vector is `sqrt(0) = 0`, `w` / `grad_v` are zero-numel, and `grad_g` has no signal. Fill `norm` / `grad_g` with zeros at the dispatch wrapper and return before entering the inner kernels, so the vectorized `loadu` calls never see a nullptr.

The fix lives in `weight_norm_kernel` and `weight_norm_backward_kernel` so it covers both `dim == 0` (`first_dim`) and `dim == v.dim() - 1` (`last_dim`) paths in one place; the inner kernels stay unchanged.

## Test

`test/test_nn.py::TestNN::test_weight_norm_empty_input` exercises the original repro from #181510 across `float`, `bfloat16`, `float16`. Pre-fix this returned `null pointer passed as argument 2` under UBSan; with the fix it produces the same `(1, 1)` output the plain `nn.Linear(0, 1)` control case already returned.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki