### PR TITLE
[inductor] Add SDK lib fallback for cpp-wrapper linking in fbcode

### DIFF
--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1891,6 +1891,20 @@ def _transform_cuda_paths(lpaths: list[str]) -> None:
             if stub_dir.exists():
                 lpaths.append(str(stub_dir))
 
+    # Internal path needs special care, using the SDK lib path directly.
+    if config.is_fbcode():
+        stub_dir = Path(build_paths.sdk_lib) / "stubs"
+        if stub_dir.is_dir() and str(stub_dir) not in lpaths:
+            lpaths.append(str(stub_dir))
+
+
+def _transform_rocm_paths(lpaths: list[str]) -> None:
+    # Internal path needs special care, using the SDK lib path directly.
+    if config.is_fbcode():
+        sdk_lib = build_paths.sdk_lib
+        if os.path.isdir(sdk_lib) and sdk_lib not in lpaths:
+            lpaths.append(sdk_lib)
+
 
 def get_cpp_torch_device_options(
     device_type: str,
@@ -1939,6 +1953,7 @@ def get_cpp_torch_device_options(
             else:
                 libraries += ["torch_hip"]
             definitions.append(" __HIP_PLATFORM_AMD__")
+            _transform_rocm_paths(libraries_dirs)
         else:
             if config.is_fbcode() or not link_libtorch:
                 libraries += ["cuda"]


### PR DESCRIPTION
Summary:
torch.compile cpp-wrapper mode fails to link `-lcuda` on MAST. Fix by falling back to `build_paths.sdk_lib` when no stubs dir was resolved. Added a symmetric `_transform_rocm_paths` helper and wired it into the HIP branch.

Authored with Claude.

Differential Revision: D102265326




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo