### PR TITLE
Bump pytest to 9.0.3 without breaking the host Python 3.9 install

### DIFF
--- a/.ci/lumen_cli/pyproject.toml
+++ b/.ci/lumen_cli/pyproject.toml
@@ -5,7 +5,7 @@ dependencies = [
     "pyyaml==6.0.2",
     "GitPython==3.1.47",
     "docker==7.1.0",
-    "pytest==7.3.2",
+    "pytest==9.0.3",
     "uv==0.11.6"
 ]
 

--- a/.ci/lumen_cli/pyproject.toml
+++ b/.ci/lumen_cli/pyproject.toml
@@ -5,9 +5,11 @@ dependencies = [
     "pyyaml==6.0.2",
     "GitPython==3.1.47",
     "docker==7.1.0",
-    "pytest==9.0.3",
     "uv==0.11.6"
 ]
+
+[project.optional-dependencies]
+test = ["pytest==9.0.3"]
 
 [tool.setuptools]
 packages = ["cli"]

--- a/.github/actions/build-external-packages/action.yml
+++ b/.github/actions/build-external-packages/action.yml
@@ -44,14 +44,6 @@ outputs:
 runs:
   using: composite
   steps:
-    # The host runner's system Python is 3.9, which can't install modern
-    # tooling like pytest>=9. Pin a supported version for the lumen_cli
-    # install below.
-    - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-      with:
-        python-version: '3.12'
-
     - name: Build external packages in sequence
       id: build-external
       env:

--- a/.github/actions/build-external-packages/action.yml
+++ b/.github/actions/build-external-packages/action.yml
@@ -44,6 +44,14 @@ outputs:
 runs:
   using: composite
   steps:
+    # The host runner's system Python is 3.9, which can't install modern
+    # tooling like pytest>=9. Pin a supported version for the lumen_cli
+    # install below.
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: '3.12'
+
     - name: Build external packages in sequence
       id: build-external
       env:

--- a/.github/workflows/tools-unit-tests.yml
+++ b/.github/workflows/tools-unit-tests.yml
@@ -41,7 +41,7 @@ jobs:
           set -ex
           python3 -m venv /tmp/venv
           source /tmp/venv/bin/activate
-          pip install -e .ci/lumen_cli/
+          pip install -e '.ci/lumen_cli/[test]'
           pytest -v -s .ci/lumen_cli/tests/*
 
   lumen-cli-compatible-python39:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #181668

The previous pytest 9.0.3 bump (#180394) was reverted because the `build-external-packages` composite action installs `lumen_cli` on a self-hosted EC2 runner whose system Python is 3.9, and pytest 9 dropped 3.9 support so no wheel was available. The first attempt at this PR added `actions/setup-python` to fetch 3.12, but that fails on the AL2 self-hosted runner — `actions/python-versions` doesn't ship a prebuilt for that OS, so setup-python errors with "version '3.12' with architecture 'x64' was not found for this operating system."

`pytest` is not actually a runtime dependency of `lumen_cli` — there is no `import pytest` anywhere under `cli/`; the only references build shell command strings (`pytest -v -s …`) that get exec'd inside the vLLM Docker container, where vLLM's own deps provide pytest. The only real consumers are `lumen_cli`'s own unit tests under `tools-unit-tests.yml`, which run on `ubuntu-latest` where pytest 9 installs cleanly.

Move `pytest==9.0.3` into a `[project.optional-dependencies] test` extra and update the unit-test workflow to install with `[test]`. The host install (`pip install -e .ci/lumen_cli`) keeps working on Python 3.9, no setup-python step needed.

Authored with Claude.