### PR TITLE
Fix duplicated article "the the" typos in comments

### DIFF
--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -383,7 +383,7 @@ class _AutotuneCacheBundlerImpl:
         if not inductor_meta.get("autotune_local_cache", True):
             return False
 
-        # Check if the we're enabled via config
+        # Check if we're enabled via config
         if (
             bundled_autotune_remote_cache := inductor_meta.get(
                 "bundled_autotune_remote_cache"

--- a/torch/csrc/jit/passes/batch_mm.cpp
+++ b/torch/csrc/jit/passes/batch_mm.cpp
@@ -65,7 +65,7 @@ c10::AliasAnalysisKind aliasAnalysisIsSpecialCase() {
 
 // Note [Overlapping trees]
 // Additionally it wouldn't be too hard to add support for partially overlapping
-// trees. Right now the it's forbidden in the algorithm (only a single tree will
+// trees. Right now it's forbidden in the algorithm (only a single tree will
 // be allowed), so theoretically we might miss some optimization options,
 // especially that the rejected tree could be much larger. I didn't implement
 // that because it's not necessary for the simple RNN cases I saw, so I decided

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -51,7 +51,7 @@ logger.setLevel(logging.INFO)
 logger.addHandler(_log_handler)
 
 
-# Retryable failure exception means the we were too late to make
+# Retryable failure exception means we were too late to make
 # a desired state transition (e.g. because of a race condition),
 # and should now restart from the beginning.
 # A small delay is recommended to avoid spamming Etcd.

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -900,8 +900,8 @@ def distribute_tensor(
     assert_no_mixed_partial_types(placements)
     if isinstance(tensor, DTensor):
         # if the tensor is already a DTensor, we need to check:
-        # 1. if the we can further shard this DTensor if the two device mesh belong to
-        #   the same parenet mesh and further sharding is possible.
+        # 1. if we can further shard this DTensor if the two device mesh belong to
+        #   the same parent mesh and further sharding is possible.
         # 2. check if device mesh and placements are the same
         if tensor.device_mesh != device_mesh:
             raise ValueError(

--- a/torch/fx/passes/reinplace.py
+++ b/torch/fx/passes/reinplace.py
@@ -289,7 +289,7 @@ def _get_view_inverse_node_usages(
                 continue
             self_alias_base = self_alias.meta["view_of"]
             try:
-                # The we're trying to reuse the args from the view_scatter call inside of the corresponding
+                # We're trying to reuse the args from the view_scatter call inside of the corresponding
                 # view op, which might throw. This just indicates that view_scatter op isn't a valid inverse
                 # of the current alias we're looking at.
                 view_replay_metadata = original_view(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181672

Remove spurious duplicate "the" occurrences in comments and docstrings
across several files. These were all instances of "the the" or "the we"
where the extra article slipped in.

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo