### PR TITLE
Fix partitioner crash when register_hook inside checkpoint mutates a buffer

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7706,6 +7706,37 @@ def forward(self, primals_1, tangents_1):
         )
 
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    def test_register_hook_in_checkpoint_with_mutation(self):
+        stats_buffer = torch.zeros(10, device="cuda")
+
+        def log_stats(x):
+            stats_buffer[0] = x.abs().mean()
+
+        def checkpointed_fn(x, w):
+            out = x @ w
+            log_stats(out)
+            out.register_hook(lambda grad: log_stats(grad) or grad)
+            return out
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = torch.nn.Parameter(torch.randn(64, 64, device="cuda"))
+
+            def forward(self, x):
+                return torch.utils.checkpoint.checkpoint(
+                    checkpointed_fn, x, self.w, use_reentrant=False
+                )
+
+        m = MyModule()
+        x = torch.randn(2, 64, device="cuda", requires_grad=True)
+        opt_m = torch.compile(m, backend="aot_eager", fullgraph=True)
+        out = opt_m(x)
+        out.sum().backward()
+        self.assertEqual(out.shape, torch.Size([2, 64]))
+
+
 class TestAOTDispatch(AOTTestCase):
     # Tests to add cases for (non-exhaustive list, mostly for my notes):
     # - subclass / mode introduced in the middle of the compiled fn

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -233,6 +233,21 @@ def _get_ho_op_original_input(getitem_node: fx.Node) -> fx.Node | None:
     return None
 
 
+_FUNCTIONAL_SCATTER_OP_NAMES = frozenset(
+    {
+        "select_scatter",
+        "slice_scatter",
+        "scatter",
+        "scatter_add",
+        "scatter_reduce",
+        "as_strided_scatter",
+        "diagonal_scatter",
+        "masked_scatter",
+        "index_put",
+    }
+)
+
+
 def _is_copy_node_bw_only(node: fx.Node) -> fx.Node | None:
     """Check if node is a view/reshape of a higher-order op output that aliases an input.
 
@@ -363,6 +378,22 @@ def _extract_graph_with_inputs_outputs(
                 if (
                     x.target is torch.ops.aten.copy_.default
                     and _must_be_in_backward(x)
+                    and len(x.args) >= 1
+                    and isinstance(x.args[0], fx.Node)
+                    and x.args[0] in env
+                    and not isinstance(env[x.args[0]], InvalidNodeBase)
+                ):
+                    replacement = env[x.args[0]]
+                # For functional scatter ops (select_scatter, slice_scatter,
+                # etc.) where the base tensor is valid but the update value
+                # depends on backward, use the base tensor. This happens when
+                # a tensor hook registered inside checkpoint mutates an input
+                # in both forward and backward.
+                if (
+                    replacement is None
+                    and isinstance(x.target, torch._ops.OpOverload)
+                    and x.target.name().split("::")[1].split(".")[0]
+                    in _FUNCTIONAL_SCATTER_OP_NAMES
                     and len(x.args) >= 1
                     and isinstance(x.args[0], fx.Node)
                     and x.args[0] in env


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181760
* __->__ #181674
* #181552

When a tensor hook registered via `register_hook` inside
`torch.utils.checkpoint` mutates a global buffer, the joint graph chains
forward and backward mutations (e.g. `select_scatter` → `select_scatter_1`).
The backward mutation node is listed as a forward output but depends on
tangents, causing `_extract_graph_with_inputs_outputs` to raise
"Node was invalid, but is output".

Handle this by recognizing functional scatter ops (`select_scatter`,
`slice_scatter`, etc.) whose base tensor (first arg) is valid in the
forward graph, and using that base tensor as the forward output.

Authored with Claude.