### PR TITLE
Fix register_hook inside checkpoint crashing in subgraph tracing

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7737,6 +7737,55 @@ def forward(self, primals_1, tangents_1):
         self.assertEqual(out.shape, torch.Size([2, 64]))
 
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    def test_register_hook_in_checkpoint_inside_autograd_function(self):
+        stats_buffer = torch.zeros(10, device="cuda")
+
+        def log_stats(x):
+            stats_buffer[0] = x.abs().mean()
+
+        def finalize_fn(og, output):
+            log_stats(output)
+            output.register_hook(lambda grad: log_stats(grad) or grad)
+            return torch.sigmoid(og) * output
+
+        class RecomputeGate(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, o_proj_output, gate_output, og, pre_gate_output):
+                ctx.save_for_backward(og, pre_gate_output)
+                return o_proj_output.clone()
+
+            @staticmethod
+            def backward(ctx, grad):
+                og, pre_gate_output = ctx.saved_tensors
+                with torch.no_grad():
+                    torch.utils.checkpoint.checkpoint(
+                        finalize_fn, og, pre_gate_output, use_reentrant=False
+                    )
+                return grad, None, None, None
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(64, 64, device="cuda")
+
+            def forward(self, x):
+                x = self.linear(x)
+                og = x.clone()
+                gate_output = torch.utils.checkpoint.checkpoint(
+                    finalize_fn, og, x, use_reentrant=False
+                )
+                o_proj_output = x @ self.linear.weight.t()
+                return RecomputeGate.apply(o_proj_output, gate_output, og, x)
+
+        m = MyModule()
+        x = torch.randn(2, 64, device="cuda")
+        opt_m = torch.compile(m, backend="aot_eager")
+        out = opt_m(x)
+        out.sum().backward()
+        self.assertEqual(out.shape, torch.Size([2, 64]))
+
+
 class TestAOTDispatch(AOTTestCase):
     # Tests to add cases for (non-exhaustive list, mostly for my notes):
     # - subclass / mode introduced in the middle of the compiled fn

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1921,8 +1921,21 @@ class TensorVariable(VariableTracker):
             #     a = glb_list[0] * 3
             #     b = glb_dict['tensor'] + 1
             #     return (a + b).sum()
-            # Get the original tensor's node and save its current users
-            tensor_node = self.as_proxy().node
+            # Get the original tensor's node and save its current users.
+            # When inside a subgraph (e.g., checkpoint), the tensor's proxy
+            # may be in a parent graph. Find the corresponding lifted
+            # placeholder in the current subgraph so that node reordering
+            # and user replacement operate within the same graph.
+            tensor_proxy = self.as_proxy()
+            current_tracer = tx.output.current_tracer
+            in_subgraph = tensor_proxy.node.graph is not current_tracer.graph
+            if in_subgraph:
+                inner_proxy = current_tracer.maybe_lift_tracked_freevar_to_input(
+                    tensor_proxy
+                )
+                tensor_node = inner_proxy.node
+            else:
+                tensor_node = tensor_proxy.node
 
             users_to_replace = list(tensor_node.users.keys())
 
@@ -1964,9 +1977,16 @@ class TensorVariable(VariableTracker):
             for user in users_to_replace:
                 user.replace_input_with(tensor_node, tensor_prime_node)
 
-            # Update tensor to point to the tensor_prime
             assert isinstance(result, TensorVariable)
-            self.proxy = result.as_proxy()
+            if in_subgraph:
+                # Inside a subgraph, don't update self.proxy — that would
+                # leave a stale subgraph proxy after the subgraph exits.
+                # Instead, update the tracer's lifted_freevars mapping so
+                # future references to this tensor within the subgraph
+                # resolve to the hooked version.
+                current_tracer.lifted_freevars[tensor_proxy] = result.as_proxy()
+            else:
+                self.proxy = result.as_proxy()
             # TensorVariable doesn't actually store the grad_fn
             # so this is fine.
             self.synchronize_attributes(tx)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181675
* #181674
* #181552

When `register_hook` is called inside a checkpoint (or checkpoint nested
inside an autograd.Function), the `_ApplyBackwardHook` node reordering
fails with "Attempting to move a Node into a different Graph" because the
tensor's proxy node lives in a parent graph while the HOP call is in the
current subgraph.

Two fixes:
1. When the tensor's proxy is in a parent graph, find the corresponding
   lifted freevar placeholder in the current subgraph and use that for
   node reordering and user replacement.
2. When inside a subgraph, update the tracer's `lifted_freevars` mapping
   instead of `self.proxy` to avoid leaving a stale subgraph proxy that
   corrupts subsequent root-level tracing.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98