### PR TITLE
Fix UBSan null-pointer UB in vec256 partial-load Vec::loadu (#181510)

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
@@ -258,7 +258,9 @@ class Vectorized16 {
     for (const auto i : c10::irange(count, size())) {
       tmp_values[i] = 0;
     }
-    std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
+    if (count > 0) {
+      std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
+    }
     return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(tmp_values));
   }
   void store(void* ptr, int count = size()) const {

--- a/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_16bit_float.h
@@ -258,7 +258,7 @@ class Vectorized16 {
     for (const auto i : c10::irange(count, size())) {
       tmp_values[i] = 0;
     }
-    if (count > 0) {
+    if (count > 0 && count < size()) {
       std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
     }
     return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(tmp_values));

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -107,10 +107,12 @@ class Vectorized<c10::complex<double>> {
     for (const auto i : c10::irange(2 * size())) {
       tmp_values[i] = 0.0;
     }
-    std::memcpy(
-        tmp_values,
-        reinterpret_cast<const double*>(ptr),
-        count * sizeof(c10::complex<double>));
+    if (count > 0) {
+      std::memcpy(
+          tmp_values,
+          reinterpret_cast<const double*>(ptr),
+          count * sizeof(c10::complex<double>));
+    }
     return _mm256_load_pd(tmp_values);
   }
   void store(void* ptr, int count = size()) const {

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -172,10 +172,12 @@ class Vectorized<c10::complex<float>> {
     for (const auto i : c10::irange(2 * size())) {
       tmp_values[i] = 0.0;
     }
-    std::memcpy(
-        tmp_values,
-        reinterpret_cast<const float*>(ptr),
-        count * sizeof(c10::complex<float>));
+    if (count > 0) {
+      std::memcpy(
+          tmp_values,
+          reinterpret_cast<const float*>(ptr),
+          count * sizeof(c10::complex<float>));
+    }
     return _mm256_load_ps(tmp_values);
   }
   void store(void* ptr, int count = size()) const {

--- a/aten/src/ATen/cpu/vec/vec256/vec256_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_double.h
@@ -91,10 +91,12 @@ class Vectorized<double> {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0.0;
     }
-    std::memcpy(
-        tmp_values,
-        reinterpret_cast<const double*>(ptr),
-        count * sizeof(double));
+    if (count > 0) {
+      std::memcpy(
+          tmp_values,
+          reinterpret_cast<const double*>(ptr),
+          count * sizeof(double));
+    }
     return _mm256_load_pd(tmp_values);
   }
   void store(void* ptr, int count = size()) const {

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -124,7 +124,9 @@ class Vectorized<float> {
     }
     if (count > 0) {
       std::memcpy(
-          tmp_values, reinterpret_cast<const float*>(ptr), count * sizeof(float));
+          tmp_values,
+          reinterpret_cast<const float*>(ptr),
+          count * sizeof(float));
     }
     return _mm256_loadu_ps(tmp_values);
   }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float.h
@@ -122,8 +122,10 @@ class Vectorized<float> {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 0.0;
     }
-    std::memcpy(
-        tmp_values, reinterpret_cast<const float*>(ptr), count * sizeof(float));
+    if (count > 0) {
+      std::memcpy(
+          tmp_values, reinterpret_cast<const float*>(ptr), count * sizeof(float));
+    }
     return _mm256_loadu_ps(tmp_values);
   }
   void store(void* ptr, int64_t count = size()) const {

--- a/aten/src/ATen/cpu/vec/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_int.h
@@ -121,7 +121,9 @@ class Vectorized<int64_t> : public Vectorizedi {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
-    std::memcpy(tmp_values, ptr, count * sizeof(int64_t));
+    if (count > 0) {
+      std::memcpy(tmp_values, ptr, count * sizeof(int64_t));
+    }
     return loadu(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -271,7 +273,9 @@ class Vectorized<int32_t> : public Vectorizedi {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
-    std::memcpy(tmp_values, ptr, count * sizeof(int32_t));
+    if (count > 0) {
+      std::memcpy(tmp_values, ptr, count * sizeof(int32_t));
+    }
     return loadu(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -571,7 +575,9 @@ class Vectorized<int16_t> : public Vectorizedi {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
-    std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
+    if (count > 0) {
+      std::memcpy(tmp_values, ptr, count * sizeof(int16_t));
+    }
     return loadu(tmp_values);
   }
   void store(void* ptr, int count = size()) const {
@@ -919,7 +925,9 @@ class Vectorized8 : public Vectorizedi {
     for (const auto i : c10::irange(size())) {
       tmp_values[i] = 1;
     }
-    std::memcpy(tmp_values, ptr, count * sizeof(T));
+    if (count > 0) {
+      std::memcpy(tmp_values, ptr, count * sizeof(T));
+    }
     return loadu(tmp_values);
   }
   void store(void* ptr, int count = size()) const {

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -5,6 +5,8 @@ namespace {
     template <typename T>
     class Memory : public ::testing::Test {};
     template <typename T>
+    class MemoryAllPatched : public ::testing::Test {};
+    template <typename T>
     class Arithmetic : public ::testing::Test {};
     template <typename T>
     class Comparison : public ::testing::Test {};
@@ -91,7 +93,15 @@ namespace {
     using FloatIntTestedTypes = ::testing::Types<vfloat, vdouble, vcomplex, vcomplexDbl, vlong, vint, vshort>;
     using ComplexTypes = ::testing::Types<vcomplex, vcomplexDbl>;
     using ReducedFloatTestedTypes = ::testing::Types<vBFloat16, vHalf>;
+    // Types that exercise the Vectorized<T>::loadu(ptr, count) overloads
+    // patched for #181510. Excludes vqint8/vquint8/vqint because those
+    // route through vec256_qint.h, which has its own loadu overloads not
+    // touched by this PR.
+    using LoaduPatchedTypes = ::testing::Types<
+        vfloat, vdouble, vcomplex, vcomplexDbl,
+        vBFloat16, vHalf, vlong, vint, vshort>;
     TYPED_TEST_SUITE(Memory, ALLTestedTypes);
+    TYPED_TEST_SUITE(MemoryAllPatched, LoaduPatchedTypes);
     TYPED_TEST_SUITE(Arithmetic, FloatIntTestedTypes);
     TYPED_TEST_SUITE(Comparison, RealFloatIntReducedFloatTestedTypes);
     TYPED_TEST_SUITE(Bitwise, FloatIntTestedTypes);
@@ -178,6 +188,18 @@ namespace {
             // clear storage
             std::memset(storage, 0, sizeof storage);
         }
+    }
+    TYPED_TEST(MemoryAllPatched, LoaduPartialNullPointer) {
+        // Regression test for #181510: loadu(nullptr, 0) tripped UBSan
+        // (memcpy nonnull) before the partial-load branch was guarded.
+        using vec = TypeParam;
+        constexpr size_t b_size = vec::size() * sizeof(ValueType<TypeParam>);
+        CACHE_ALIGN unsigned char storage[b_size];
+        CACHE_ALIGN unsigned char zero_storage[b_size];
+        std::memset(storage, 0xff, b_size);
+        std::memset(zero_storage, 0x00, b_size);
+        vec::loadu(nullptr, 0).store(storage);
+        ASSERT_EQ(std::memcmp(storage, zero_storage, b_size), 0);
     }
     TYPED_TEST(SignManipulation, Absolute) {
         using vec = TypeParam;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1885,6 +1885,34 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         m = nn.Linear(4, 5, dtype=torch.float16)
         m = torch.nn.utils.weight_norm(m)
 
+    def test_loadu_partial_null_pointer_zero_numel(self):
+        # Regression test for #181510 covering all 9 vec256 Vectorized<T>::loadu
+        # overloads our fix touches. Each dtype corresponds to one specialization
+        # that used to trip UBSan via memcpy(nullptr, 0) in its partial-load branch
+        # when handed a zero-numel tensor's data_ptr().
+        #
+        # Float family uses the exact #181510 repro path (weight_norm).
+        # Complex and int dtypes use sum(), which also goes through CPU vec
+        # reductions; if a kernel takes an early-exit fast path for zero-numel
+        # inputs the test still passes (no crash), which is the regression
+        # boundary we care about.
+
+        # vec256_float.h, vec256_double.h, vec256_16bit_float.h (BFloat16, Half)
+        for dtype in [torch.float32, torch.float64, torch.bfloat16, torch.float16]:
+            m = torch.nn.utils.weight_norm(nn.Linear(0, 1).to(dtype=dtype))
+            x = torch.empty((1, 0), dtype=dtype)
+            self.assertEqual(m(x).shape, torch.Size([1, 1]))
+
+        # vec256_complex_float.h, vec256_complex_double.h
+        for dtype in [torch.complex64, torch.complex128]:
+            x = torch.empty((0,), dtype=dtype)
+            self.assertEqual(x.sum().item(), 0)
+
+        # vec256_int.h: Vectorized<int64_t>, <int32_t>, <int16_t>, Vectorized8<T>
+        for dtype in [torch.int64, torch.int32, torch.int16, torch.int8, torch.uint8]:
+            x = torch.empty((0,), dtype=dtype)
+            self.assertEqual(x.sum().item(), 0)
+
     def test_parameterlistdict_setting_attributes(self):
         with warnings.catch_warnings(record=True) as w:
             mod = nn.ParameterList(map(nn.Parameter, [torch.rand(2), torch.rand(2)]))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1913,6 +1913,24 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             x = torch.empty((0,), dtype=dtype)
             self.assertEqual(x.sum().item(), 0)
 
+    def test_loadu_partial_null_pointer_backward(self):
+        # Backward-path regression test. The forward-only test above covers
+        # weight_norm / sum; these backward kernels also reach
+        # vec::loadu(nullptr, 0) through map2_reduce_all / map3_reduce_all
+        # when an inner dimension is 0 and the outer dimension is > 0.
+
+        # layer_norm backward: M=2, N=0 dispatches into
+        # LayerNormBackwardKernelImpl with size=N=0 and nullptr data.
+        x = torch.randn(2, 0, requires_grad=True)
+        F.layer_norm(x, [0]).sum().backward()
+        self.assertEqual(x.grad.shape, x.shape)
+
+        # group_norm backward: N*C=4, HxW=0 dispatches parallel_for(0, 4)
+        # with size=0 and nullptr inner data.
+        x = torch.randn(1, 4, 0, requires_grad=True)
+        F.group_norm(x, 4).sum().backward()
+        self.assertEqual(x.grad.shape, x.shape)
+
     def test_parameterlistdict_setting_attributes(self):
         with warnings.catch_warnings(record=True) as w:
             mod = nn.ParameterList(map(nn.Parameter, [torch.rand(2), torch.rand(2)]))


### PR DESCRIPTION
## What

`Vectorized<T>::loadu(ptr, count)` in the vec256 specializations calls `std::memcpy(tmp_values, ptr, count * sizeof(T))` unconditionally in its partial-load branch. When `ptr == nullptr` and `count == 0` (which happens when a zero-numel tensor's `data_ptr()` is passed in), this is UB:

```
aten/src/ATen/cpu/vec/vec256/vec256_float.h:125:21: runtime error:
null pointer passed as argument 2, which is declared to never be null
```

The repro from #181510:

```python
m = torch.nn.utils.weight_norm(torch.nn.Linear(0, 1))
m(torch.empty((1, 0), dtype=torch.float32))
```

walks this chain:

```
weight_norm_first_dim_kernel  (v_data=nullptr, N=0)
  -> vec::map_reduce_all       (size < Vec::size() branch in
                                 functional_base.h:250-251)
  -> Vectorized<float>::loadu(nullptr, 0)
  -> memcpy(tmp_values, nullptr, 0)   // UB
```

## Fix

Guard the `memcpy` with `if (count > 0)`:

```diff
-    std::memcpy(
-        tmp_values, reinterpret_cast<const float*>(ptr), count * sizeof(float));
+    if (count > 0) {
+      std::memcpy(
+          tmp_values, reinterpret_cast<const float*>(ptr), count * sizeof(float));
+    }
```

`tmp_values` is already zero-initialized by the loop above (intentional, not `={0}`, see #32502 for why). When `count == 0` there are no source bytes to copy, and the function returns the same all-zero vector the partial-load branch was already producing on every successful call. No behavior change for valid inputs.

The same guard goes on all 9 `loadu(ptr, count)` overloads in `aten/src/ATen/cpu/vec/vec256/`:

| File | Class | Guard |
|------|-------|-------|
| `vec256_float.h` | `Vectorized<float>` | `if (count > 0)` |
| `vec256_double.h` | `Vectorized<double>` | `if (count > 0)` |
| `vec256_16bit_float.h` | `Vectorized16<T>` (BFloat16, Half) | `if (count > 0 && count < size())` |
| `vec256_complex_float.h` | `Vectorized<c10::complex<float>>` | `if (count > 0)` |
| `vec256_complex_double.h` | `Vectorized<c10::complex<double>>` | `if (count > 0)` |
| `vec256_int.h` | `Vectorized<int64_t>` | `if (count > 0)` |
| `vec256_int.h` | `Vectorized<int32_t>` | `if (count > 0)` |
| `vec256_int.h` | `Vectorized<int16_t>` | `if (count > 0)` |
| `vec256_int.h` | `Vectorized8<T>` | `if (count > 0)` |

The `vec256_16bit_float.h` overload uses the stricter `count > 0 && count < size()` guard to satisfy gcc's `-Werror=array-bounds` analyzer. `count` is declared `int16_t` there, and gcc proved that with only the `count > 0` guard, an out-of-contract caller passing `count > size()` (e.g. `count == 17` with `size() == 16`) could form a 33-byte memcpy into the 32-byte `tmp_values` buffer. Adding `count < size()` lets the analyzer prove the memcpy stays within bounds. For in-contract callers (`count` in `[0, size()]`) the behavior is unchanged: `count == size()` short-circuits in the early-return above; `count` in `[0, size())` enters the partial-load branch and now harmlessly skips the memcpy when 0 (returning the zero-initialized `tmp_values`); `count > size()` is the previously-unsafe case where we now skip the memcpy instead of buffer-overflowing.

The vec512 paths use masked-load intrinsics (`_mm512_maskz_loadu_*`) and don't have this pattern.

## Relationship to #181665

#181665 already proposes a fix at the kernel level: early-exit in `weight_norm_kernel` and `weight_norm_backward_kernel` when `v.numel() == 0`, with `norm` / `grad_g` filled with zeros via `std::fill_n`. Its description calls this "the minimum fix" per @albanD's response on the issue. This PR is not a critique of that approach, just an alternative at a different layer.

Two reasons I picked the SIMD primitive layer:

1. `vec::map_reduce_all` has more than one production caller. A `git grep map_reduce_all aten/` finds two CPU kernels using it: `WeightNormKernel.cpp:32` (the one in #181510) and `LogSoftmaxKernelImpl.h:63`. Both pass `data + i * size` as the pointer; both would hit the same `loadu(nullptr, 0)` UB if that size is 0 and the underlying tensor's `data_ptr()` is null. The kernel-level fix covers `WeightNorm`. Patching `loadu` covers both, and any future caller that goes through the same `size < Vec::size()` branch.
2. `loadu` has no semantic decision to make, only a `memcpy` precondition to honor. Guarding `map_reduce_all` itself wouldn't work because `ReduceOp` is generic and has no universal identity; a forced zero-size return would silently wrong-answer non-additive reductions like max/min/product. The `count == 0` case in `loadu` is unambiguous: load zero elements, and the function already zero-initializes its return buffer.

The two fixes aren't mutually exclusive. #181665 documents the empty-tensor semantic for `weight_norm`; this PR removes the underlying UB at the primitive. Up to maintainers which (or both) to land.

## Tests

Two tests added in separate commits:

1. **C++** in `aten/src/ATen/test/vec_test_all_types.cpp` (`MemoryAllPatched.LoaduPartialNullPointer`). Calls `vec::loadu(nullptr, 0)` directly and asserts the returned vector is all zero. Runs across a custom `LoaduPatchedTypes` list (`vfloat, vdouble, vcomplex, vcomplexDbl, vBFloat16, vHalf, vlong, vint, vshort`) covering 8 of the 9 patched specializations. Plain int8/uint8 (`Vectorized8<T>` in `vec256_int.h`) doesn't have a typed-test alias in `vec_test_all_types.h`; the Python test below covers those via `sum()` over zero-numel int8/uint8 tensors. The `vqint8/vquint8/vqint` types are intentionally excluded — they route through `vec256_qint.h`, which has its own loadu overloads not touched by this PR.
2. **Python** in `test/test_nn.py` (`test_loadu_partial_null_pointer_zero_numel`). Mirrors #181665's `test_weight_norm_empty_input` style. Float family uses the original `weight_norm(nn.Linear(0, 1))` repro; complex and int dtypes use `sum()` on a zero-numel tensor.

Both tests are UBSan-only: `memcpy(_, nullptr, 0)` is UB by the standard but produces no observable runtime behavior on glibc, so a regression is only caught under a UBSan-instrumented build.

## Reproduction

UBSan harness (`-fsanitize=undefined -fno-sanitize-recover=all`) calling `Vectorized<T>::loadu(nullptr, 0)` directly across all 11 dtypes / 9 specializations:

| dtype | Specialization | Pre-patch UBSan | Post-patch |
|-------|----------------|-----------------|------------|
| `float` | `Vectorized<float>` | `vec256_float.h:125:21` | OK, all-zero vector |
| `double` | `Vectorized<double>` | `vec256_double.h:94:9` | OK, all-zero vector |
| `bfloat16` | `Vectorized16<BFloat16>` | `vec256_16bit_float.h:261:29` | OK, all-zero vector |
| `float16` | `Vectorized16<Half>` | `vec256_16bit_float.h:261:29` | OK, all-zero vector |
| `complex64` | `Vectorized<c10::complex<float>>` | `vec256_complex_float.h:175:9` | OK, all-zero vector |
| `complex128` | `Vectorized<c10::complex<double>>` | `vec256_complex_double.h:110:9` | OK, all-zero vector |
| `int64` | `Vectorized<int64_t>` | `vec256_int.h:120:29` | OK, all-zero vector |
| `int32` | `Vectorized<int32_t>` | `vec256_int.h:270:29` | OK, all-zero vector |
| `int16` | `Vectorized<int16_t>` | `vec256_int.h:570:29` | OK, all-zero vector |
| `int8` | `Vectorized8<int8_t>` | `vec256_int.h:918:29` | OK, all-zero vector |
| `uint8` | `Vectorized8<uint8_t>` | `vec256_int.h:918:29` | OK, all-zero vector |

Additional check on the post-patch float harness:
- `valgrind --tool=memcheck`: `ERROR SUMMARY: 0 errors from 0 contexts`, `All heap blocks were freed -- no leaks are possible`.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01