### PR TITLE
[fix] dynamo: handle _tuplegetter at UserDefinedTupleVariable base

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -3600,6 +3600,25 @@ class UserDefinedTupleVariable(UserDefinedObjectVariable):
         assert self._base_vt is not None
         return self._base_vt.items  # type: ignore[return-value]
 
+    def resolve_data_descriptor(
+        self,
+        tx: "InstructionTranslator",
+        name: str,
+        type_attr: object,
+        source: Source | None,
+    ) -> VariableTracker:
+        if isinstance(type_attr, _collections._tuplegetter):
+            # namedtuple fields are _tuplegetter descriptors implemented in C.
+            # Emulate _tuplegetter.__get__ via tracked tuple items because
+            # self.value may be a freshly-created empty tuple from
+            # SideEffects.get_example_value (tuple.__new__(cls) with no args)
+            # or otherwise underpopulated. Subclasses (NamedTupleVariable,
+            # StructSequenceVariable) may further override for their specific
+            # descriptor types.
+            _, (idx, _) = type_attr.__reduce__()
+            return self.items[idx]
+        return super().resolve_data_descriptor(tx, name, type_attr, source)
+
     def call_method(
         self,
         tx: "InstructionTranslator",


### PR DESCRIPTION
Summary:
## Issue
PR #179381 split `NamedTupleVariable` into a base `UserDefinedTupleVariable` plus `NamedTupleVariable/StructSequenceVariable` subclasses, and moved `_tuplegetter` field-access handling out of the base into `NamedTupleVariable` only. Tuple subclasses that fail `is_namedtuple_cls()` (e.g. `typing.NamedTuple` with mixin/Generic bases) get wrapped as base `UserDefinedTupleVariable`; field access then falls through to  `UserDefinedObjectVariable.resolve_data_descriptor` which calls `type(self.value).__getattribute__(self.value, name)` on the empty placeholder tuple created by `SideEffects.get_example_value` via `tuple.__new__(user_cls)`. `_tuplegetter.__get__` on an empty tuple raises `IndexError`, which during Python's exception cascade leads to `FakeTensor.data_ptr()` being invoked by Triton's binder during torch.export non-strict tracing of Hammer's `triton_concat_2D_jagged_jagged` wrapper, surfacing as the `LoweringStageException 'Cannot access data pointer of Tensor'` and breaking AOTI lowering for IGR LSR model.

## Fix
Move the `_tuplegetter` handling up into `UserDefinedTupleVariable.resolve_data_descriptor` so any tuple subclass tracked at the base level returns the tracked `self.items[idx]` instead of crashing.

Test Plan: buck test mode/dev-nosan -c fbcode.use_link_groups=True -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=a100,h100 fbcode//minimal_viable_ai/models/ig_ranking/lsr/mb8_infra_test/gpu_tests:publish_e2e_test_h100 -- Mb8InfraTestH100LoweringE2eTest --print-passing-details

Differential Revision: D102713195




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98