### PR TITLE
[ROCm] Relax foreach custom error assertion

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -544,7 +544,8 @@ class TestForeach(TestCase):
                     ):
                         ref(ref_inputs, **kwargs)
                 else:
-                    self.assertEqual(re.escape(str(e)), re.escape(custom_values_err))
+                    self.assertRegex(str(e), re.escape(custom_values_err))
+
             else:
                 expected = ref(ref_inputs, **kwargs)
                 self.assertEqual(expected, actual)


### PR DESCRIPTION
Update the `custom_values_err` check in `TestForeach._pointwise_test` to look for the expected error text within the full `RuntimeError` string instead of requiring an exact match. This fixes failures where the expected foreach argument-validation error is raised, but `str(e)` also includes C++ traceback context, as seen in:

[https://ossci-raw-job-status.s3.amazonaws.com/log/73162269351](https://ossci-raw-job-status.s3.amazonaws.com/log/73162269351)

>2026-04-27T12:20:14.9756916Z 
>AssertionError: String comparison failed: 'Expe[83 chars]ad\\.\\\nException\\ raised\\ from\\ convert_t[16730 chars]\\\n' != 'Expe[83 chars]ad\\.'

The test should verify the stable user-facing error text, not fail because extra diagnostic context was appended.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang