### PR TITLE
[Inductor][Triton] Codegen TMA load within fused pointwise epilogues

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2278,7 +2278,7 @@ class TestMaxAutotune(TestCase):
         # Make sure all args of generate_and_load_args are passed to make_key_args (Except generate_with_caching)
         # update this function each time new arg added to generate_and_load and make sure arg is added to make_key
         self.assertEqual(generate_and_load_args - 1, make_key_args)
-        self.assertEqual(generate_and_load_args, 20)
+        self.assertEqual(generate_and_load_args, 21)
 
     @fresh_cache()
     @config.patch(
@@ -2367,7 +2367,7 @@ class TestMaxAutotune(TestCase):
                         'num_stages':1,'num_warps':2,'prefix_args':0,'suffix_args':0,'call_sizes':[10,30],
                         'layout':"[[10,30],[30,1],torch.float32,device(type='cuda',index=0),0]",
                         'num_consumer_groups':0,'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
-                        'transpose_discontiguous_tensor_descriptors_override':None,
+                        'tma_load_for_template_epilogue':False,'transpose_discontiguous_tensor_descriptors_override':None,
                         'kwargs':{'EVEN_K':False,'USE_FAST_ACCUM':False,'ACC_TYPE':'tl.float32',
                         'BLOCK_M':16,'BLOCK_N':32,'BLOCK_K':16,'GROUP_M':8,'ALLOW_TF32':True},
                         'hint_override':None,'triton_meta':None}"""
@@ -2409,7 +2409,7 @@ class TestMaxAutotune(TestCase):
                     'num_stages':1,'num_warps':2,'prefix_args':0,'suffix_args':0,'call_sizes':[s77,s94],
                     'layout':"[[s77,s94],[s94,1],torch.float32,device(type='cuda',index=0),0]",'num_consumer_groups':0,
                     'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
-                    'transpose_discontiguous_tensor_descriptors_override':None,
+                    'tma_load_for_template_epilogue':False,'transpose_discontiguous_tensor_descriptors_override':None,
                     'kwargs':{'EVEN_K':False,'USE_FAST_ACCUM':False,'ACC_TYPE':'tl.float32','BLOCK_M':16,'BLOCK_N':32,
                     'BLOCK_K':16,'GROUP_M':8,'ALLOW_TF32':True},'hint_override':None,'triton_meta':None}"""
                 expected = expected.replace("cuda", GPU_TYPE)

--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -456,6 +456,190 @@ class TestBlackwellTMAStoreFusion(TestCase):
 
 
 @instantiate_parametrized_tests
+class TestBlackwellTMALoadFusion(TestCase):
+    """Tests for TMA load with fused pointwise epilogues on Blackwell."""
+
+    @staticmethod
+    def _make_tma_load_test_config(epilogue_subtile: int) -> BlackwellGPUGemmConfig:
+        return BlackwellGPUGemmConfig(
+            128,
+            128,
+            64,
+            3,
+            4,
+            epilogue_subtile=epilogue_subtile,
+            warp_specialize=False,
+            flatten=False,
+        )
+
+    @unittest.skipIf(
+        not has_datacenter_blackwell_tma_device(),
+        "Need Blackwell with device-side TMA support in Triton",
+    )
+    @parametrize("shape", ((512, 256, 256), (4096, 256, 256)))
+    @parametrize("epilogue_subtile", (1, 2))
+    def test_blackwell_mm_sigmoid_epilogue_tma_load(
+        self,
+        shape: tuple[int, int, int],
+        epilogue_subtile: int,
+    ):
+        """Verify fused mm + sigmoid epilogue with TMA load (1 epilogue load)."""
+
+        def fn(x, W):
+            mm = torch.mm(x, W.T)
+            return x * (2.0 * torch.sigmoid(mm))
+
+        M, N, K = shape
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=GPU_TYPE)
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=GPU_TYPE)
+
+        test_config = self._make_tma_load_test_config(epilogue_subtile=epilogue_subtile)
+        from torch._inductor.template_heuristics.registry import get_template_heuristic
+
+        _cache_keys = [
+            ("triton::blackwell_ws_persistent_device_tma", "cuda", "mm"),
+            ("triton::blackwell_ws_persistent_device_tma", "cuda", "addmm"),
+        ]
+        orig_configs_by_key = {}
+        for key in _cache_keys:
+            h = get_template_heuristic(*key)
+            orig_configs_by_key[key] = h.mm_configs
+            h.mm_configs = [test_config]
+        try:
+            with config.patch(
+                {
+                    "max_autotune": True,
+                    "triton.enable_persistent_tma_matmul": True,
+                    "triton.enable_tma_load_for_template_epilogue": True,
+                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                }
+            ):
+                actual, code = run_and_get_code(torch.compile(fn), x, W)
+                expected = fn(x, W)
+        finally:
+            for key, orig in orig_configs_by_key.items():
+                if key in _HEURISTIC_CACHE:
+                    _HEURISTIC_CACHE[key].mm_configs = orig
+
+        torch.testing.assert_close(actual, expected, atol=1e-1, rtol=1e-1)
+
+        FileCheck().check("triton_tem_fused_mm").check("tma_descriptor").check(
+            ".load(["
+        ).run(code[0])
+
+    @unittest.skipIf(
+        not has_datacenter_blackwell_tma_device(),
+        "Need Blackwell with device-side TMA support in Triton",
+    )
+    @parametrize("shape", ((512, 256, 256), (4096, 256, 256)))
+    @parametrize("epilogue_subtile", (1, 2))
+    def test_blackwell_mm_scale_bias_epilogue_tma_load(
+        self,
+        shape: tuple[int, int, int],
+        epilogue_subtile: int,
+    ):
+        """Verify fused mm * scale + bias epilogue with TMA load (2 epilogue loads)."""
+
+        def fn(x, W, scale, bias):
+            return torch.mm(x, W.T) * scale + bias
+
+        M, N, K = shape
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=GPU_TYPE)
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=GPU_TYPE)
+        scale = torch.randn(M, N, dtype=torch.bfloat16, device=GPU_TYPE)
+        bias = torch.randn(M, N, dtype=torch.bfloat16, device=GPU_TYPE)
+
+        test_config = self._make_tma_load_test_config(epilogue_subtile=epilogue_subtile)
+        from torch._inductor.template_heuristics.registry import get_template_heuristic
+
+        _cache_keys = [
+            ("triton::blackwell_ws_persistent_device_tma", "cuda", "mm"),
+            ("triton::blackwell_ws_persistent_device_tma", "cuda", "addmm"),
+        ]
+        orig_configs_by_key = {}
+        for key in _cache_keys:
+            h = get_template_heuristic(*key)
+            orig_configs_by_key[key] = h.mm_configs
+            h.mm_configs = [test_config]
+        try:
+            with config.patch(
+                {
+                    "max_autotune": True,
+                    "triton.enable_persistent_tma_matmul": True,
+                    "triton.enable_tma_load_for_template_epilogue": True,
+                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                }
+            ):
+                actual, code = run_and_get_code(torch.compile(fn), x, W, scale, bias)
+                expected = fn(x, W, scale, bias)
+        finally:
+            for key, orig in orig_configs_by_key.items():
+                if key in _HEURISTIC_CACHE:
+                    _HEURISTIC_CACHE[key].mm_configs = orig
+
+        torch.testing.assert_close(actual, expected, atol=1e-1, rtol=1e-1)
+
+        FileCheck().check("triton_tem_fused").check("tma_descriptor").check(
+            ".load(["
+        ).run(code[0])
+
+    @unittest.skipIf(
+        not has_datacenter_blackwell_tma_device(),
+        "Need Blackwell with device-side TMA support in Triton",
+    )
+    @parametrize("shape", ((512, 256, 256), (4096, 256, 256)))
+    @parametrize("epilogue_subtile", (1, 2))
+    def test_blackwell_addmm_1d_bias_epilogue_tma_load(
+        self,
+        shape: tuple[int, int, int],
+        epilogue_subtile: int,
+    ):
+        """Verify fused addmm with 1D bias epilogue with TMA load."""
+
+        def fn(bias, x, W):
+            return torch.addmm(bias, x, W.T)
+
+        M, N, K = shape
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=GPU_TYPE)
+        W = torch.randn(N, K, dtype=torch.bfloat16, device=GPU_TYPE)
+        bias = torch.randn(N, dtype=torch.bfloat16, device=GPU_TYPE)
+
+        test_config = self._make_tma_load_test_config(epilogue_subtile=epilogue_subtile)
+        from torch._inductor.template_heuristics.registry import get_template_heuristic
+
+        _cache_keys = [
+            ("triton::blackwell_ws_persistent_device_tma", "cuda", "mm"),
+            ("triton::blackwell_ws_persistent_device_tma", "cuda", "addmm"),
+        ]
+        orig_configs_by_key = {}
+        for key in _cache_keys:
+            h = get_template_heuristic(*key)
+            orig_configs_by_key[key] = h.mm_configs
+            h.mm_configs = [test_config]
+        try:
+            with config.patch(
+                {
+                    "max_autotune": True,
+                    "triton.enable_persistent_tma_matmul": True,
+                    "triton.enable_tma_load_for_template_epilogue": True,
+                    "test_configs.autotune_choice_name_regex": "blackwell_ws_persistent_device_tma",
+                }
+            ):
+                actual, code = run_and_get_code(torch.compile(fn), bias, x, W)
+                expected = fn(bias, x, W)
+        finally:
+            for key, orig in orig_configs_by_key.items():
+                if key in _HEURISTIC_CACHE:
+                    _HEURISTIC_CACHE[key].mm_configs = orig
+
+        torch.testing.assert_close(actual, expected, atol=1e-1, rtol=1e-1)
+
+        FileCheck().check("triton_tem_fused").check("tma_descriptor").check(
+            ".load(["
+        ).run(code[0])
+
+
+@instantiate_parametrized_tests
 class TestBlackwellExhaustiveConfigs(TestCase):
     """Tests for exhaustive config generation for Blackwell templates."""
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -3818,7 +3818,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 self,
                 dtype,
                 for_store=False,
-                force=False,
+                force=getattr(self, "tma_load_for_template_epilogue", False),
             ),
         )
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2030,6 +2030,10 @@ class triton:
     # Should TMA store be enable from templates. TODO: Remove once we
     # can autotune over the result.
     enable_template_tma_store = os.environ.get("ENABLE_TEMPLATE_TMA_STORE", "0") == "1"
+    # Controls TMA load enablement in template epilogues
+    enable_tma_load_for_template_epilogue = (
+        os.environ.get("ENABLE_TMA_LOAD_FOR_TEMPLATE_EPILOGUE", "0") == "1"
+    )
     # Skip L1 cache for buffers that are used only once.  Disabled by default
     skip_l1_cache = os.environ.get("TORCHINDUCTOR_SKIP_L1", "0") == "1"
 

--- a/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_blackwell_ws_persistent_device_tma_mm.py.jinja
@@ -29,7 +29,6 @@
         strides=[stride_bk, 1] if B_ROW_MAJOR else [stride_bn, 1],
         block_shape=[BLOCK_K, BLOCK_N] if B_ROW_MAJOR else [BLOCK_N, BLOCK_K],
     )
-
     # tile_id_c is used in the epilogue to break the dependency between
     # the prologue and the epilogue
     tile_id_c = start_pid - NUM_SMS

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -502,6 +502,7 @@ class TritonTemplateKernel(TritonKernel):
         num_buffers_warp_spec=0,
         use_jit=False,
         tma_store=False,
+        tma_load_for_template_epilogue=False,
         transpose_discontiguous_tensor_descriptors_override=None,
         prefix_args=0,
         suffix_args=0,
@@ -514,12 +515,13 @@ class TritonTemplateKernel(TritonKernel):
         always_freeze_layout: bool = False,
         index_dtype_override: str | None = None,
     ) -> None:
+        tma_2d = tma_store or tma_load_for_template_epilogue
         if tma_store:
             pass
         numel = sympy_product(output_node.get_size())
-        if tma_store:
+        if tma_2d:
             assert len(output_node.get_size()) == 2, (
-                "TMA store only supported for 2D with templates"
+                "TMA load/store only supported for 2D with templates"
             )
             tiling = {
                 "x": output_node.get_size()[0],
@@ -536,7 +538,7 @@ class TritonTemplateKernel(TritonKernel):
             features=SIMDKernelFeatures([], numel),
             hint_override=hint_override,
         )
-        if tma_store:
+        if tma_2d:
             # By default `construct_range_trees` will return the range_trees in the order
             # ["z", "y", "x", "r0_", "r1_"] (see simd.py:all_prefixes)
             # and this order defines what the kernel block shape will be. So if the template
@@ -566,6 +568,7 @@ class TritonTemplateKernel(TritonKernel):
         self.kernel_name = kernel_name
         self.use_jit = use_jit
         self.tma_store = tma_store
+        self.tma_load_for_template_epilogue = tma_load_for_template_epilogue
         self.transpose_discontiguous_tensor_descriptors_override = (
             transpose_discontiguous_tensor_descriptors_override
         )
@@ -1398,7 +1401,7 @@ class TritonTemplateKernel(TritonKernel):
                 assert not mask, "Mask is not supported with blocking indexing"
                 intermediate_lines: list[str] = []
                 epilogue_index_symbols: list[sympy.Symbol] = []
-                if self.tma_store:
+                if self.tma_store or self.tma_load_for_template_epilogue:
                     val_shape_copy = list(val_shape)
                     for i, range_tree in enumerate(self.range_trees[:-1]):
                         name = range_tree.name
@@ -1474,7 +1477,7 @@ class TritonTemplateKernel(TritonKernel):
                     self.template_mask = final_mask_var
                 index_symbols = epilogue_index_symbols
                 contiguous_index = sympy_dot(output_layout.stride, index_symbols)
-                if not self.tma_store:
+                if not (self.tma_store or self.tma_load_for_template_epilogue):
                     # Convert to just use xindex.
                     contiguous_index = self.rename_indexing(contiguous_index)
                     intermediate_lines.append(f"xindex = {texpr(contiguous_index)}")
@@ -2399,6 +2402,7 @@ class GeneratedCodeCache:
         epilogue_fn: Callable[..., Any] | None,
         epilogue_fn_hash: str | None,
         tma_store: bool,
+        tma_load_for_template_epilogue: bool,
         transpose_discontiguous_tensor_descriptors_override: bool | None,
         subgraphs: list[ir.Buffer] | None,  # has to be none to cache
         workspace_arg: WorkspaceArg | None,  # has to be none to cache
@@ -2458,6 +2462,7 @@ class GeneratedCodeCache:
                 "num_buffers_warp_spec": num_buffers_warp_spec,
                 "epilogue_fn_hash": epilogue_fn_hash,
                 "tma_store": tma_store,
+                "tma_load_for_template_epilogue": tma_load_for_template_epilogue,
                 "transpose_discontiguous_tensor_descriptors_override": transpose_discontiguous_tensor_descriptors_override,
                 "kwargs": kwargs,
                 "hint_override": hint_override,
@@ -2580,6 +2585,7 @@ class TritonTemplate(KernelTemplate):
         generate_with_caching,
         hint_override: int | None = None,
         tma_store: bool = False,
+        tma_load_for_template_epilogue: bool = False,
         transpose_discontiguous_tensor_descriptors_override: bool | None = None,
         triton_meta: dict[str, Any] | None = None,
     ) -> GenerateAndLoadResult | None:
@@ -2601,6 +2607,7 @@ class TritonTemplate(KernelTemplate):
                 epilogue_fn,
                 epilogue_fn_hash,
                 tma_store,
+                tma_load_for_template_epilogue,
                 transpose_discontiguous_tensor_descriptors_override,
                 subgraphs,
                 workspace_arg,
@@ -2666,6 +2673,7 @@ class TritonTemplate(KernelTemplate):
                 use_jit=False,
                 hint_override=hint_override,
                 tma_store=tma_store,
+                tma_load_for_template_epilogue=tma_load_for_template_epilogue,
                 transpose_discontiguous_tensor_descriptors_override=transpose_discontiguous_tensor_descriptors_override,
                 triton_meta=triton_meta,
                 **kernel_options,
@@ -2788,6 +2796,7 @@ class TritonTemplate(KernelTemplate):
         generate_with_caching=False,
         hint_override: int | None = None,
         tma_store: bool = False,
+        tma_load_for_template_epilogue: bool = False,
         transpose_discontiguous_tensor_descriptors_override: bool | None = None,
         triton_meta: dict[str, Any] | None = None,
         **kwargs,
@@ -2836,6 +2845,7 @@ class TritonTemplate(KernelTemplate):
             generate_with_caching and self._cache_codegen_enabled_for_template,
             hint_override=hint_override,
             tma_store=tma_store,
+            tma_load_for_template_epilogue=tma_load_for_template_epilogue,
             transpose_discontiguous_tensor_descriptors_override=transpose_discontiguous_tensor_descriptors_override,
             triton_meta=triton_meta,
         )
@@ -2913,6 +2923,7 @@ class TritonTemplate(KernelTemplate):
                 use_jit=False,
                 hint_override=hint_override,
                 tma_store=tma_store,
+                tma_load_for_template_epilogue=tma_load_for_template_epilogue,
                 transpose_discontiguous_tensor_descriptors_override=transpose_discontiguous_tensor_descriptors_override,
                 triton_meta=triton_meta,
                 **options,

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2237,6 +2237,7 @@ class TMATemplateConfigMixin(TMAWorkspaceMixin, MMTemplateConfigMixin):
             "TMA_SIZE": TMA_DESCRIPTOR_SIZE,
             "TMA_EXPERIMENTAL_API": not has_triton_stable_tma_api(),
             "tma_store": config.triton.enable_template_tma_store,
+            "tma_load_for_template_epilogue": config.triton.enable_tma_load_for_template_epilogue,
             "transpose_discontiguous_tensor_descriptors_override": True,
         }
 


### PR DESCRIPTION
Enable TMA descriptor load support within fused pointwise epilogues for Inductor-generated Triton kernels. When `ENABLE_TEMPLATE_TMA_LOAD=1`, input loads from within kernel epilogues use `tma_descriptor.load()` instead of pointer-based `tl.load()`.

e.g. for
```
def fn(x, W, scale, bias):
    mm = torch.mm(x, W.T)
    return mm * scale + bias
```
Inductor generates the following epilogue (full output code here: [P2292447201](https://www.internalfb.com/phabricator/paste/view/P2292447201)):
```
...
for i in tl.static_range(EPILOGUE_SUBTILE):
            subtile = subtiles[i]
            offs_cn_i = offs_cn + i * (BLOCK_N // EPILOGUE_SUBTILE)
            xoffset = offs_cm
            xindex = (xoffset + tl.arange(0, XBLOCK))[:, None]
            xmask = xindex < 4096
            yoffset = offs_cn_i
            yindex = (yoffset + tl.arange(0, YBLOCK))[None, :, ]
            ymask = yindex < 256
            tmp0 = tma_descriptor0.load([xoffset, yoffset]).to(tl.float32)
            tmp2 = tma_descriptor1.load([xoffset, yoffset]).to(tl.float32)
            tmp1 = subtile * tmp0
            tmp3 = tmp1 + tmp2
            tl.store(out_ptr1 + (yindex + 256*xindex), tmp3, ymask)
...
```

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @mcarilli @ptrblck @leslie-fang-intel @EikanWang @voznesenskym @penguinwu @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @xmfan @aditvenk