### PR TITLE
[Test][PrivateUse1] Register `op_allowlist` for OOT backends to reuse PyTorch test suites

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -2,6 +2,7 @@
 
 import unittest
 from collections import defaultdict
+from contextlib import contextmanager
 
 import torch
 from torch.testing._internal.common_device_type import (
@@ -81,6 +82,23 @@ op_precision = _make_dummy_op(
     "op_precision",
     decorators=[DecorateInfo(precisionOverride({torch.float32: 1e-5}))],
 )
+
+# Dummy ops for testing combined op_allowlist + op_overrides
+op_combined_supported = _make_dummy_op("op_combined_supported")
+op_combined_skip = _make_dummy_op("op_combined_skip")
+op_combined_unsupported = _make_dummy_op("op_combined_unsupported")
+
+
+@contextmanager
+def _temp_attrs(obj, **attrs):
+    backup = {k: getattr(obj, k) for k in attrs}
+    for k, v in attrs.items():
+        setattr(obj, k, v)
+    try:
+        yield
+    finally:
+        for k, v in backup.items():
+            setattr(obj, k, v)
 
 
 class TestDeviceTypeOpenReg(TestCase):
@@ -179,6 +197,36 @@ PrivateUse1TestBase.test_exclusions = {
     "TestSkippedWholeTestClass": "*",
 }
 
+
+class TestSupportedOpsWithOverrides(TestCase):
+    """Verify that op_allowlist filtering works together with op_overrides.
+
+    op_allowlist filters which ops generate variants.
+    op_overrides adds decorators to those ops that pass the filter.
+    """
+
+    _executed_combined: dict = defaultdict(int)
+
+    @classmethod
+    def tearDownClass(cls):
+        # op_combined_supported should run (it's in op_allowlist, no skip decorator)
+        if cls._executed_combined["op_combined_supported"] == 0:
+            raise AssertionError("op_combined_supported should have run")
+        # op_combined_skip should NOT run (in op_allowlist but has skip decorator)
+        if cls._executed_combined["op_combined_skip"] != 0:
+            raise AssertionError("op_combined_skip should be skipped by op_overrides")
+        # op_combined_unsupported should NOT run (not in op_allowlist)
+        if cls._executed_combined["op_combined_unsupported"] != 0:
+            raise AssertionError(
+                "op_combined_unsupported should not run (not in op_allowlist)"
+            )
+        super().tearDownClass()
+
+    @ops([op_combined_supported, op_combined_skip, op_combined_unsupported])
+    def test_combined_filter(self, device, dtype, op):
+        type(self)._executed_combined[op.name] += 1
+
+
 instantiate_device_type_tests(TestDeviceTypeOpenReg, globals(), only_for=("openreg",))
 instantiate_device_type_tests(
     TestBypassDeviceRestrictions, globals(), only_for="openreg"
@@ -187,6 +235,17 @@ instantiate_device_type_tests(
     TestSkippedSpecificTestCases, globals(), only_for="openreg"
 )
 instantiate_device_type_tests(TestSkippedWholeTestClass, globals(), only_for="openreg")
+
+with _temp_attrs(
+    PrivateUse1TestBase,
+    op_overrides={
+        "op_combined_skip": [DecorateInfo(unittest.skip("skip via op_overrides"))]
+    },
+    op_allowlist=("op_combined_supported", "op_combined_skip"),
+):
+    instantiate_device_type_tests(
+        TestSupportedOpsWithOverrides, globals(), only_for=("openreg",)
+    )
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -337,6 +337,13 @@ class DeviceTypeTestBase(TestCase):
     # in the future.
     op_overrides = None  # type: Optional[dict[str, list[DecorateInfo]]]
 
+    # An optional mechanism to limit which ops generate test variants.
+    # When set, only ops whose full_name is in this collection will generate tests.
+    # This is useful for less mature backends that only implement a few operators.
+    # Keys are OpInfo.full_name (e.g. "add", "mul", "linalg.norm").
+    # If None (default), all ops in the @ops decorator's op_list generate variants.
+    op_allowlist = None  # type: Optional[Collection[str]]
+
     # An optional skip mechanism built upon instantiate_device_type_tests(),
     # designed to facilitate skipping either an entire class or specific test cases
     # within a class.
@@ -405,6 +412,23 @@ class DeviceTypeTestBase(TestCase):
         if test_exclusions is not None and test_class_name in test_exclusions:
             return test_exclusions[test_class_name]
         return []
+
+    @classmethod
+    def _apply_op_allowlist(cls, ops):
+        """Filters ops.op_list to only include ops declared in op_allowlist.
+
+        If op_allowlist is None (default), no filtering is applied.
+        If op_allowlist is set, only ops whose full_name is in the collection
+        will generate test variants.
+
+        Args:
+            ops: The ops decorator instance whose op_list will be filtered.
+        """
+        if cls.op_allowlist is None:
+            return
+
+        supported_set = set(cls.op_allowlist)
+        ops.op_list = [op for op in ops.op_list if op.full_name in supported_set]
 
     @classmethod
     def _init_and_get_primary_device(cls):
@@ -1151,6 +1175,9 @@ class ops(_TestParametrizer):
                 "instantiate_parametrized_tests()"
             )
 
+        # Order matters: op_allowlist filters first, then op_overrides adds decorators
+        # This ensures op_overrides only applies to ops that passed the op_allowlist filter
+        device_cls._apply_op_allowlist(self)
         device_cls._apply_op_overrides(self)
         op = check_exhausted_iterator = object()
         for op in self.op_list:


### PR DESCRIPTION
Fixes #178516 

## Summary
1. Add `op_allowlist` whitelist for OOT backends reusing PyTorch test suites.
2. Add unit tests in OpenReg.

cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD