### PR TITLE
[dynamo] Add monomorphic inline frame cache

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -199,7 +199,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(cnt.frame_count, 1)
         self.assertEqual(cnt.op_count, 8)
-        self.assertEqual(run_count, 1)
+        self.assertEqual(run_count, ifdynstaticdefault(1, 3))
 
     def test_monomorphic_inline_frame_cache_fresh_tensor_result(self):
         def leaf(x):
@@ -572,6 +572,16 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         self.assertFalse(
             _inline_frame_cache_node_is_replayable(
                 graph.call_method("__ixor__", (x, 1), {})
+            )
+        )
+        self.assertFalse(
+            _inline_frame_cache_node_is_replayable(
+                graph.call_method("__setitem__", (x, 0, 1), {})
+            )
+        )
+        self.assertFalse(
+            _inline_frame_cache_node_is_replayable(
+                graph.call_method("__delattr__", (x, "attr"), {})
             )
         )
 
@@ -3631,6 +3641,8 @@ class GraphModule(torch.nn.Module):
 
         eager_result = fn(udf_mul, udf_mul, x)
         self.assertEqual(eager_result, dynamo_result)
+        # Static shapes replay the second partial call, shifting print_readable's
+        # stack-context separator. Dynamic shapes bypass this cache path.
         if torch._dynamo.config.assume_static_by_default:
             self.assertExpectedInline(
                 normalize_gm(backend.graphs[0].print_readable(print_output=False)),
@@ -3655,8 +3667,8 @@ class GraphModule(torch.nn.Module):
         l_lambda0_keywords_y_ = L_lambda0_keywords_y_
 
         mul: "f32[s9, s9]" = l_lambda0_keywords_y_ * l_lambda0_keywords_y_
-
         mul_1: "f32[s9, s9]" = l_lambda0_keywords_y_ * l_lambda0_keywords_y_;  l_lambda0_keywords_y_ = None
+
         mul_2: "f32[s9, s9]" = torch.mul(mul, mul_1);  mul = mul_1 = None
         return (mul_2,)
 """,

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -398,6 +398,40 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         self.assertTrue(same(opt_fn(x, y), fn(x, y)))
 
+    def test_monomorphic_inline_frame_cache_skips_nested_tracer(self):
+        from functorch.experimental import control_flow
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(y):
+            return y + 1
+
+        def true_fn(y):
+            return y.sin()
+
+        def false_fn(y):
+            return leaf(y) + leaf(y)
+
+        def fn(x, y):
+            return control_flow.cond(x.sum() > 0, true_fn, false_fn, [y])
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.ones(3, 2, 4, requires_grad=True)
+        y = torch.ones(4, requires_grad=True)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x, y), fn(x, y)))
+
+        self.assertEqual(run_count, 4)
+
     def test_monomorphic_inline_frame_cache_skips_polymorphic_calls(self):
         from torch._dynamo.symbolic_convert import InliningInstructionTranslator
 
@@ -618,6 +652,62 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             self.assertTrue(same(opt_fn(x), fn(x)))
 
         self.assertEqual(run_count, 3)
+
+    def test_monomorphic_inline_frame_cache_skips_node_dedup_tracking(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            return x + 1
+
+        def fn(x):
+            return leaf(x) + leaf(x) + leaf(x)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with (
+            torch._dynamo.config.patch("track_nodes_for_deduplication", True),
+            patch.object(InliningInstructionTranslator, "run", counted_run),
+        ):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 3)
+
+    def test_monomorphic_inline_frame_cache_skips_inconsistent_side_effects(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            torch.compiler.is_dynamo_compiling()
+            return x + 1
+
+        def fn(x):
+            return leaf(x) + leaf(x)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 2)
 
     def test_monomorphic_inline_frame_cache_skips_tensor_hooks(self):
         from torch._dynamo.symbolic_convert import InliningInstructionTranslator

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -218,6 +218,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(opt_fn(x), fn(x)))
 
     def test_monomorphic_inline_frame_cache_replays_tuple_with_placeholder(self):
+        from torch._dynamo.output_graph import SubgraphTracer
         from torch._dynamo.symbolic_convert import InliningInstructionTranslator
         from torch._dynamo.variables import TensorVariable, TupleVariable
 
@@ -230,7 +231,9 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             return a + b + c + d
 
         original_remap = InliningInstructionTranslator._remap_inline_frame_cache_result
+        original_record_proxyable_vt = SubgraphTracer.record_proxyable_vt
         placeholder_reuses = 0
+        placeholder_proxyable_records = 0
         tuple_remaps = 0
 
         def checked_remap(tx, result, node_remap):
@@ -246,19 +249,34 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
                         placeholder_reuses += 1
             return remapped
 
+        def checked_record_proxyable_vt(tracer, vt):
+            nonlocal placeholder_proxyable_records
+            node = getattr(getattr(vt, "proxy", None), "node", None)
+            if getattr(node, "op", None) == "placeholder":
+                placeholder_proxyable_records += 1
+            return original_record_proxyable_vt(tracer, vt)
+
         cnt = torch._dynamo.testing.CompileCounter()
         x = torch.randn(4)
 
-        with patch.object(
-            InliningInstructionTranslator,
-            "_remap_inline_frame_cache_result",
-            checked_remap,
+        with (
+            patch.object(
+                SubgraphTracer,
+                "record_proxyable_vt",
+                checked_record_proxyable_vt,
+            ),
+            patch.object(
+                InliningInstructionTranslator,
+                "_remap_inline_frame_cache_result",
+                checked_remap,
+            ),
         ):
             opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
             self.assertTrue(same(opt_fn(x), fn(x)))
 
         self.assertEqual(tuple_remaps, ifdynstaticdefault(1, 0))
         self.assertEqual(placeholder_reuses, 0)
+        self.assertEqual(placeholder_proxyable_records, 0)
         self.assertEqual(cnt.frame_count, 1)
         self.assertEqual(cnt.op_count, 5)
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -369,6 +369,51 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(run_count, 2)
 
+    def test_monomorphic_inline_frame_cache_skips_dynamic_shapes(self):
+        from torch._dynamo import symbolic_convert
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            return torch.sin(x) + x
+
+        def fn(x):
+            return leaf(x) + leaf(x)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4, 3)
+        global_check_count = 0
+        original_global_value_is_supported = (
+            symbolic_convert._inline_frame_cache_global_value_is_supported
+        )
+
+        def counted_global_value_is_supported(value):
+            nonlocal global_check_count
+            if value is torch:
+                global_check_count += 1
+            return original_global_value_is_supported(value)
+
+        with (
+            patch.object(InliningInstructionTranslator, "run", counted_run),
+            patch.object(
+                symbolic_convert,
+                "_inline_frame_cache_global_value_is_supported",
+                counted_global_value_is_supported,
+            ),
+        ):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True, dynamic=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 2)
+        self.assertEqual(global_check_count, 2)
+
     def test_monomorphic_inline_frame_cache_skips_global_tensor(self):
         from torch._dynamo.symbolic_convert import InliningInstructionTranslator
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -194,6 +194,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             self.assertTrue(same(opt_fn(x), fn(x)))
 
         self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 8)
         self.assertEqual(run_count, 1)
 
     def test_monomorphic_inline_frame_cache_fresh_tensor_result(self):
@@ -210,6 +211,147 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
 
         self.assertTrue(same(opt_fn(x), fn(x)))
+
+    def test_monomorphic_inline_frame_cache_skips_polymorphic_calls(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            return x + 1
+
+        def fn(x):
+            return leaf(x) + leaf(x + 1)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 2)
+
+    def test_monomorphic_inline_frame_cache_skips_graph_dedup(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            return x + 1
+
+        def fn(x):
+            return leaf(x) + leaf(x) + leaf(x)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with (
+            torch._dynamo.config.patch("use_graph_deduplication", True),
+            patch.object(InliningInstructionTranslator, "run", counted_run),
+        ):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 3)
+
+    def test_monomorphic_inline_frame_cache_skips_tensor_hooks(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def hook(grad):
+            return grad
+
+        def leaf(x):
+            x.register_hook(hook)
+            return x + 1
+
+        def fn(x):
+            return leaf(x) + leaf(x)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4, requires_grad=True)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 2)
+
+    def test_monomorphic_inline_frame_cache_skips_mutable_ops(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            return x.add_(1)
+
+        def fn(x):
+            y = x.clone()
+            return leaf(y) + leaf(y)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 2)
+
+    def test_monomorphic_inline_frame_cache_skips_non_leaf(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def inner(x):
+            return torch.sin(x)
+
+        def leaf(x):
+            return inner(x) + 1
+
+        def fn(x):
+            return leaf(x) + leaf(x)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 2)
 
     def test_lru_cache_warning_issued_during_tracing(self):
         import warnings

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -216,6 +216,51 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         self.assertTrue(same(opt_fn(x), fn(x)))
 
+    def test_monomorphic_inline_frame_cache_replays_tuple_with_placeholder(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+        from torch._dynamo.variables import TensorVariable, TupleVariable
+
+        def leaf(x):
+            return x, torch.sin(x)
+
+        def fn(x):
+            a, b = leaf(x)
+            c, d = leaf(x)
+            return a + b + c + d
+
+        original_remap = InliningInstructionTranslator._remap_inline_frame_cache_result
+        placeholder_reuses = 0
+        tuple_remaps = 0
+
+        def checked_remap(tx, result, node_remap):
+            nonlocal placeholder_reuses, tuple_remaps
+            unwrapped = result.unwrap()
+            remapped = original_remap(tx, result, node_remap)
+            if tx.f_code is leaf.__code__:
+                if isinstance(unwrapped, TupleVariable):
+                    tuple_remaps += 1
+                if isinstance(unwrapped, TensorVariable):
+                    node = unwrapped.proxy.node
+                    if node_remap.get(node) is node and remapped is unwrapped:
+                        placeholder_reuses += 1
+            return remapped
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        x = torch.randn(4)
+
+        with patch.object(
+            InliningInstructionTranslator,
+            "_remap_inline_frame_cache_result",
+            checked_remap,
+        ):
+            opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(tuple_remaps, ifdynstaticdefault(1, 0))
+        self.assertEqual(placeholder_reuses, 0)
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 5)
+
     def test_monomorphic_inline_frame_cache_skips_mutated_arg_version(self):
         from torch._dynamo.symbolic_convert import InliningInstructionTranslator
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -152,6 +152,9 @@ def inline_script_if_tracing_fn_with_default_args(x, y, c=1.2):
     return torch.cos(x * y) + c
 
 
+_inline_frame_cache_global_tensor = torch.ones(4)
+
+
 class FunctionTests(torch._dynamo.test_case.TestCase):
     @make_test
     def test_inline_jit_annotations(x):
@@ -220,6 +223,59 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         def fn(x):
             return leaf(x) + leaf(x + 1)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 2)
+
+    def test_monomorphic_inline_frame_cache_skips_different_shapes(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            return torch.sin(x).sum()
+
+        def fn(x, y):
+            return leaf(x) + leaf(y)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+        y = torch.randn(8)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x, y), fn(x, y)))
+
+        self.assertEqual(run_count, 2)
+
+    def test_monomorphic_inline_frame_cache_skips_global_tensor(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            return x + _inline_frame_cache_global_tensor
+
+        def fn(x):
+            return leaf(x) + leaf(x)
 
         run_count = 0
         original_run = InliningInstructionTranslator.run
@@ -3389,8 +3445,8 @@ class GraphModule(torch.nn.Module):
         l_lambda0_keywords_y_ = L_lambda0_keywords_y_
 
         mul: "f32[2, 2]" = l_lambda0_keywords_y_ * l_lambda0_keywords_y_
-        mul_1: "f32[2, 2]" = l_lambda0_keywords_y_ * l_lambda0_keywords_y_;  l_lambda0_keywords_y_ = None
 
+        mul_1: "f32[2, 2]" = l_lambda0_keywords_y_ * l_lambda0_keywords_y_;  l_lambda0_keywords_y_ = None
         mul_2: "f32[2, 2]" = torch.mul(mul, mul_1);  mul = mul_1 = None
         return (mul_2,)
 """,
@@ -3404,8 +3460,8 @@ class GraphModule(torch.nn.Module):
         l_lambda0_keywords_y_ = L_lambda0_keywords_y_
 
         mul: "f32[s9, s9]" = l_lambda0_keywords_y_ * l_lambda0_keywords_y_
-        mul_1: "f32[s9, s9]" = l_lambda0_keywords_y_ * l_lambda0_keywords_y_;  l_lambda0_keywords_y_ = None
 
+        mul_1: "f32[s9, s9]" = l_lambda0_keywords_y_ * l_lambda0_keywords_y_;  l_lambda0_keywords_y_ = None
         mul_2: "f32[s9, s9]" = torch.mul(mul, mul_1);  mul = mul_1 = None
         return (mul_2,)
 """,

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -216,6 +216,61 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         self.assertTrue(same(opt_fn(x), fn(x)))
 
+    def test_monomorphic_inline_frame_cache_skips_mutated_arg_version(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            return x + 1
+
+        def fn(x):
+            a = leaf(x)
+            x.add_(1)
+            b = leaf(x)
+            return a + b
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x.clone()), fn(x.clone())))
+
+        self.assertEqual(run_count, 2)
+
+    def test_monomorphic_inline_frame_cache_skips_constant_only_leaf(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf():
+            return 1
+
+        def fn(x):
+            return x + leaf() + leaf()
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 2)
+
     def test_monomorphic_inline_frame_cache_replays_hop_operand(self):
         from functorch.experimental import control_flow
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -153,6 +153,7 @@ def inline_script_if_tracing_fn_with_default_args(x, y, c=1.2):
 
 
 _inline_frame_cache_global_tensor = torch.ones(4)
+_inline_frame_cache_global_store = None
 
 
 class FunctionTests(torch._dynamo.test_case.TestCase):
@@ -214,6 +215,27 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
 
         self.assertTrue(same(opt_fn(x), fn(x)))
+
+    def test_monomorphic_inline_frame_cache_replays_hop_operand(self):
+        from functorch.experimental import control_flow
+
+        def true_fn(y):
+            return y.sin()
+
+        def false_fn(y):
+            def leaf(z):
+                return z + 1
+
+            return leaf(y) + leaf(y)
+
+        def fn(x, y):
+            return control_flow.cond(x.shape[0] > 4, true_fn, false_fn, [y])
+
+        x = torch.ones(3, 2, 4, requires_grad=True)
+        y = torch.ones(4, requires_grad=True)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+
+        self.assertTrue(same(opt_fn(x, y), fn(x, y)))
 
     def test_monomorphic_inline_frame_cache_skips_polymorphic_calls(self):
         from torch._dynamo.symbolic_convert import InliningInstructionTranslator
@@ -286,6 +308,36 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
                 run_count += 1
             return original_run(tx)
 
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 2)
+
+    def test_monomorphic_inline_frame_cache_skips_store_global(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            global _inline_frame_cache_global_store
+            _inline_frame_cache_global_store = x
+            return x + 1
+
+        def fn(x):
+            return leaf(x) + leaf(x)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        global _inline_frame_cache_global_store
+        _inline_frame_cache_global_store = None
         x = torch.randn(4)
 
         with patch.object(InliningInstructionTranslator, "run", counted_run):

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -271,6 +271,30 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(run_count, 2)
 
+    def test_monomorphic_inline_frame_cache_skips_tensorless_leaf(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf():
+            return torch.ones(4)
+
+        def fn():
+            return leaf() + leaf()
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(), fn()))
+
+        self.assertEqual(run_count, 2)
+
     def test_monomorphic_inline_frame_cache_replays_hop_operand(self):
         from functorch.experimental import control_flow
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -153,6 +153,7 @@ def inline_script_if_tracing_fn_with_default_args(x, y, c=1.2):
 
 
 _inline_frame_cache_global_tensor = torch.ones(4)
+_inline_frame_cache_global_offset = 0
 _inline_frame_cache_global_store = None
 
 
@@ -510,6 +511,44 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         def counted_run(tx):
             nonlocal run_count
             if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 2)
+
+    def test_monomorphic_inline_frame_cache_skips_different_f_globals(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf_template(x):
+            return x + _inline_frame_cache_global_offset
+
+        common_globals = {"__builtins__": globals()["__builtins__"]}
+        leaf_one = types.FunctionType(
+            leaf_template.__code__,
+            {**common_globals, "_inline_frame_cache_global_offset": 1},
+            "leaf",
+        )
+        leaf_two = types.FunctionType(
+            leaf_template.__code__,
+            {**common_globals, "_inline_frame_cache_global_offset": 2},
+            "leaf",
+        )
+
+        def fn(x):
+            return leaf_one(x) + leaf_two(x)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf_template.__code__:
                 run_count += 1
             return original_run(tx)
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -433,6 +433,32 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(run_count, 2)
 
+    def test_monomorphic_inline_frame_cache_skips_generator(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            yield x + 1
+
+        def fn(x):
+            return next(leaf(x)) + next(leaf(x))
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 2)
+
     def test_monomorphic_inline_frame_cache_late_enabled_start_node(self):
         from torch._dynamo import symbolic_convert
 
@@ -622,6 +648,37 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(run_count, 2)
         self.assertEqual(global_check_count, 2)
 
+    def test_monomorphic_inline_frame_cache_analyzes_globals_once(self):
+        from torch._dynamo import symbolic_convert
+
+        def leaf(x):
+            return torch.sin(x) + 1
+
+        def fn(x):
+            return leaf(x) + leaf(x) + leaf(x)
+
+        analyze_count = 0
+        original_analyze_globals = (
+            symbolic_convert._inline_frame_cache_analyze_global_instructions
+        )
+
+        def counted_analyze_globals(instructions):
+            nonlocal analyze_count
+            analyze_count += 1
+            return original_analyze_globals(instructions)
+
+        x = torch.randn(4)
+
+        with patch.object(
+            symbolic_convert,
+            "_inline_frame_cache_analyze_global_instructions",
+            counted_analyze_globals,
+        ):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(analyze_count, 1)
+
     def test_monomorphic_inline_frame_cache_skips_global_tensor(self):
         from torch._dynamo.symbolic_convert import InliningInstructionTranslator
 
@@ -738,6 +795,35 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         with (
             torch._dynamo.config.patch("use_graph_deduplication", True),
+            patch.object(InliningInstructionTranslator, "run", counted_run),
+        ):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(run_count, 3)
+
+    def test_monomorphic_inline_frame_cache_skips_when_disabled(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            return x + 1
+
+        def fn(x):
+            return leaf(x) + leaf(x) + leaf(x)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        x = torch.randn(4)
+
+        with (
+            torch._dynamo.config.patch("enable_inline_frame_cache", False),
             patch.object(InliningInstructionTranslator, "run", counted_run),
         ):
             opt_fn = torch.compile(fn, backend="eager", fullgraph=True)

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -168,6 +168,49 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     def test_inline_lru_cache_fn_with_default_args(a, b):
         return inline_lru_cache_fn_with_default_args(a, 2, b)
 
+    def test_monomorphic_inline_frame_cache_replays_leaf(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            return torch.sin(x) + 1
+
+        def fn(x):
+            return leaf(x) + leaf(x) + leaf(x)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(run_count, 1)
+
+    def test_monomorphic_inline_frame_cache_fresh_tensor_result(self):
+        def leaf(x):
+            return x + 1
+
+        def fn(x):
+            a = leaf(x)
+            b = leaf(x)
+            a.add_(2)
+            return b
+
+        x = torch.randn(4)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+
+        self.assertTrue(same(opt_fn(x), fn(x)))
+
     def test_lru_cache_warning_issued_during_tracing(self):
         import warnings
         from functools import lru_cache

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -295,6 +295,42 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(run_count, 2)
 
+    def test_monomorphic_inline_frame_cache_late_enabled_start_node(self):
+        from torch._dynamo import symbolic_convert
+
+        def leaf(x):
+            return torch.sin(x) + 1
+
+        def fn(x):
+            y = torch.cos(x)
+            return y + leaf(x) + leaf(x)
+
+        original_locals_have_tensor = (
+            symbolic_convert._inline_frame_cache_locals_have_tensor
+        )
+        force_disabled_once = True
+
+        def locals_have_tensor_after_init(symbolic_locals):
+            nonlocal force_disabled_once
+            if force_disabled_once:
+                force_disabled_once = False
+                return False
+            return original_locals_have_tensor(symbolic_locals)
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        x = torch.randn(4)
+
+        with patch.object(
+            symbolic_convert,
+            "_inline_frame_cache_locals_have_tensor",
+            locals_have_tensor_after_init,
+        ):
+            opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 7)
+
     def test_monomorphic_inline_frame_cache_replays_hop_operand(self):
         from functorch.experimental import control_flow
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -262,6 +262,36 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnt.frame_count, 1)
         self.assertEqual(cnt.op_count, 5)
 
+    def test_monomorphic_inline_frame_cache_replays_tuple_local(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(pair):
+            return pair[0] + pair[1]
+
+        def fn(x):
+            pair = (x, x)
+            return leaf(pair) + leaf(pair)
+
+        run_count = 0
+        original_run = InliningInstructionTranslator.run
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        x = torch.randn(4)
+
+        with patch.object(InliningInstructionTranslator, "run", counted_run):
+            opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 3)
+        self.assertEqual(run_count, ifdynstaticdefault(1, 2))
+
     def test_monomorphic_inline_frame_cache_skips_mutated_arg_version(self):
         from torch._dynamo.symbolic_convert import InliningInstructionTranslator
 
@@ -315,6 +345,50 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
             self.assertTrue(same(opt_fn(x), fn(x)))
 
+        self.assertEqual(run_count, 2)
+
+    def test_monomorphic_inline_frame_cache_skips_unrealized_lazy_local(self):
+        from torch._dynamo import symbolic_convert
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+        from torch._dynamo.variables.lazy import LazyVariableTracker
+
+        def leaf(x, unused):
+            return x + 1
+
+        def fn(x, unused):
+            return leaf(x, unused) + leaf(x, unused)
+
+        run_count = 0
+        unrealized_lazy_key_attempts = 0
+        original_run = InliningInstructionTranslator.run
+        original_value_key = symbolic_convert._make_inline_frame_cache_value_key
+
+        def counted_run(tx):
+            nonlocal run_count
+            if tx.f_code is leaf.__code__:
+                run_count += 1
+            return original_run(tx)
+
+        def counted_value_key(value):
+            nonlocal unrealized_lazy_key_attempts
+            if isinstance(value, LazyVariableTracker) and not value.is_realized():
+                unrealized_lazy_key_attempts += 1
+            return original_value_key(value)
+
+        x = torch.randn(4)
+
+        with (
+            patch.object(InliningInstructionTranslator, "run", counted_run),
+            patch.object(
+                symbolic_convert,
+                "_make_inline_frame_cache_value_key",
+                counted_value_key,
+            ),
+        ):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertTrue(same(opt_fn(x, 1), fn(x, 1)))
+
+        self.assertGreaterEqual(unrealized_lazy_key_attempts, 1)
         self.assertEqual(run_count, 2)
 
     def test_monomorphic_inline_frame_cache_skips_tensorless_leaf(self):

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -511,6 +511,25 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(run_count, 2)
 
+    def test_monomorphic_inline_frame_cache_rejects_inplace_dunders(self):
+        from torch._dynamo.symbolic_convert import (
+            _inline_frame_cache_node_is_replayable,
+        )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+
+        self.assertFalse(
+            _inline_frame_cache_node_is_replayable(
+                graph.call_method("__iadd__", (x, 1), {})
+            )
+        )
+        self.assertFalse(
+            _inline_frame_cache_node_is_replayable(
+                graph.call_method("__ixor__", (x, 1), {})
+            )
+        )
+
     def test_monomorphic_inline_frame_cache_skips_non_leaf(self):
         from torch._dynamo.symbolic_convert import InliningInstructionTranslator
 

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -585,6 +585,40 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             )
         )
 
+    def test_monomorphic_inline_frame_cache_rolls_back_failed_result_remap(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def leaf(x):
+            return torch.sin(x) + 1
+
+        def fn(x):
+            return leaf(x) + leaf(x)
+
+        original_remap = InliningInstructionTranslator._remap_inline_frame_cache_result
+        failed_remaps = 0
+
+        def fail_first_replay_remap(tx, result, node_remap):
+            nonlocal failed_remaps
+            if tx.f_code is leaf.__code__ and failed_remaps == 0:
+                failed_remaps += 1
+                return None
+            return original_remap(tx, result, node_remap)
+
+        cnt = torch._dynamo.testing.CompileCounter()
+        x = torch.randn(4)
+
+        with patch.object(
+            InliningInstructionTranslator,
+            "_remap_inline_frame_cache_result",
+            fail_first_replay_remap,
+        ):
+            opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+            self.assertTrue(same(opt_fn(x), fn(x)))
+
+        self.assertEqual(failed_remaps, ifdynstaticdefault(1, 0))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(cnt.op_count, 5)
+
     def test_monomorphic_inline_frame_cache_skips_non_leaf(self):
         from torch._dynamo.symbolic_convert import InliningInstructionTranslator
 

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -594,6 +594,11 @@ enable_cpp_framelocals_guard_eval = True
 # regions with a call to invoke_subgraph
 use_graph_deduplication = False
 
+# Whether to replay repeated monomorphic leaf inline frames from a per-trace
+# cache. This is intentionally independent from graph deduplication so the
+# optimization has a narrow kill switch.
+enable_inline_frame_cache = True
+
 # Whether to track nodes for deduplication (testing only)
 # This flag is ignored if use_graph_deduplication is True
 track_nodes_for_deduplication = False

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5293,6 +5293,11 @@ def profile_inline_call(
 
 
 _INLINE_FRAME_CACHE_UNSUPPORTED = object()
+_INLINE_FRAME_CACHE_FRESH_META_KEYS = {
+    "nn_module_stack",
+    "source_fn_stack",
+    "stack_trace",
+}
 
 
 def _make_inline_frame_cache_key(
@@ -5416,8 +5421,7 @@ def _clone_inline_frame_cache_example_value(value: Any, tx: Any) -> Any:
         return cloned
     if isinstance(value, dict):
         cloned = {
-            k: _clone_inline_frame_cache_example_value(v, tx)
-            for k, v in value.items()
+            k: _clone_inline_frame_cache_example_value(v, tx) for k, v in value.items()
         }
         if any(v is _INLINE_FRAME_CACHE_UNSUPPORTED for v in cloned.values()):
             return _INLINE_FRAME_CACHE_UNSUPPORTED
@@ -5431,9 +5435,7 @@ def _inline_frame_cache_example_value_is_supported(value: Any, tx: Any) -> bool:
     if is_fake(value):
         return _inline_frame_cache_fake_is_supported(value, tx)
     if isinstance(value, (tuple, list)):
-        return all(
-            _inline_frame_cache_example_value_is_supported(v, tx) for v in value
-        )
+        return all(_inline_frame_cache_example_value_is_supported(v, tx) for v in value)
     if isinstance(value, dict):
         return all(
             _inline_frame_cache_example_value_is_supported(v, tx)
@@ -5445,20 +5447,24 @@ def _inline_frame_cache_example_value_is_supported(value: Any, tx: Any) -> bool:
 def _clone_inline_frame_cache_node_meta(
     node: torch.fx.Node, tx: Any
 ) -> dict[str, Any] | None:
-    meta = copy.copy(node.meta)
-    if "example_value" in meta:
-        example_value = _clone_inline_frame_cache_example_value(
-            meta["example_value"], tx
-        )
-        if example_value is _INLINE_FRAME_CACHE_UNSUPPORTED:
+    meta = {}
+    for key, value in node.meta.items():
+        if key in _INLINE_FRAME_CACHE_FRESH_META_KEYS:
+            continue
+        if key == "example_value":
+            example_value = _clone_inline_frame_cache_example_value(value, tx)
+            if example_value is _INLINE_FRAME_CACHE_UNSUPPORTED:
+                return None
+            meta[key] = example_value
+            continue
+        try:
+            meta[key] = copy.deepcopy(value)
+        except Exception:
             return None
-        meta["example_value"] = example_value
     return meta
 
 
-def _inline_frame_cache_node_meta_is_supported(
-    node: torch.fx.Node, tx: Any
-) -> bool:
+def _inline_frame_cache_node_meta_is_supported(node: torch.fx.Node, tx: Any) -> bool:
     if "example_value" not in node.meta:
         return True
     return _inline_frame_cache_example_value_is_supported(
@@ -5476,8 +5482,7 @@ def _inline_frame_cache_result_is_supported(
         )
     if isinstance(result, TensorVariable):
         return (
-            result.proxy.node in cached_nodes
-            or result.proxy.node.op == "placeholder"
+            result.proxy.node in cached_nodes or result.proxy.node.op == "placeholder"
         )
     if isinstance(result, TupleVariable):
         return all(
@@ -5494,14 +5499,17 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
     # pyrefly: ignore [bad-override]
     parent: InstructionTranslatorBase
 
+    def _inline_frame_cache_is_enabled(self) -> bool:
+        return not (
+            is_generator(self.f_code)
+            or self.parent.strict_checks_fn
+            or config.use_graph_deduplication
+            or config.track_nodes_for_deduplication
+            or self.output.current_tracer.parent is not None
+        )
+
     def _maybe_replay_inline_frame_cache(self) -> VariableTracker | None:
-        if is_generator(self.f_code):
-            return None
-        if self.parent.strict_checks_fn:
-            return None
-        if config.use_graph_deduplication or config.track_nodes_for_deduplication:
-            return None
-        if self.output.current_tracer.parent is not None:
+        if not self._inline_frame_cache_is_enabled():
             return None
 
         tracing_ctx = self.output.tracing_context
@@ -5538,7 +5546,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             if node.op == "placeholder":
                 continue
 
-            def remap_arg(arg: torch.fx.Node) -> torch.fx.Proxy:
+            def remap_arg(arg: torch.fx.Node) -> torch.fx.node.Argument:
                 return tracer.proxy(node_remap.get(arg, arg))
 
             args = torch.fx.node.map_arg(node.args, remap_arg)
@@ -5551,7 +5559,11 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 name=node.name,
                 type_expr=node.type,
             )
-            proxy.node.meta = cloned_meta[node]
+            meta = cloned_meta[node]
+            replay_meta = {**meta, **proxy.node.meta}
+            if "example_value" in meta:
+                replay_meta["example_value"] = meta["example_value"]
+            proxy.node.meta = replay_meta
             if "example_value" in proxy.node.meta:
                 tracer.track_produced_symints(proxy.node.meta["example_value"], proxy)
             node_remap[node] = proxy.node
@@ -5617,17 +5629,22 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 and side_effects.is_modified(variable)
             ):
                 return True
+        if (
+            len(side_effects.save_for_backward)
+            != self._inline_frame_cache_save_for_backward_count
+        ):
+            return True
+        if (
+            frozenset(side_effects.tensor_hooks.keys())
+            != self._inline_frame_cache_tensor_hook_ids
+        ):
+            return True
         return False
 
     def _maybe_store_inline_frame_cache(self, result: VariableTracker) -> None:
-        if is_generator(self.f_code):
+        if not self._inline_frame_cache_is_enabled():
             return
-        if self.parent.strict_checks_fn:
-            return
-        if config.use_graph_deduplication or config.track_nodes_for_deduplication:
-            return
-        if self.output.current_tracer.parent is not None:
-            return
+        start_nodes = self._inline_frame_cache_start_nodes
         if self.output.should_exit:
             return
         if not self.has_no_inlined_calls:
@@ -5644,14 +5661,13 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         new_nodes = [
             node
             for node in self.output.current_tracer.graph.nodes
-            if node not in self._inline_frame_cache_start_nodes
+            if node not in start_nodes
         ]
         cached_nodes = set(new_nodes)
         if not all(_inline_frame_cache_node_is_replayable(node) for node in new_nodes):
             return
         if not all(
-            _inline_frame_cache_node_meta_is_supported(node, self)
-            for node in new_nodes
+            _inline_frame_cache_node_meta_is_supported(node, self) for node in new_nodes
         ):
             return
         if not _inline_frame_cache_result_is_supported(result, cached_nodes):
@@ -6033,22 +6049,42 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             indexof=indexof,
         )
         self.funcvar = funcvar
-        self._inline_frame_cache_start_nodes = frozenset(
-            parent.output.current_tracer.graph.nodes
-        )
-        side_effects = self.output.side_effects
-        self._inline_frame_cache_tracked_side_effect_ids = frozenset(
-            side_effects.id_to_variable.keys()
-        )
-        self._inline_frame_cache_modified_side_effect_ids = frozenset(
-            item_id
-            for item_id, variable in side_effects.id_to_variable.items()
-            if side_effects.is_modified(variable)
-        )
-        self._inline_frame_cache_had_existing_dict_mutation = (
-            side_effects.has_existing_dict_mutation()
-        )
         self.parent = parent
+        side_effects = self.output.side_effects
+        if self._inline_frame_cache_is_enabled():
+            self._inline_frame_cache_start_nodes = frozenset(
+                parent.output.current_tracer.graph.nodes
+            )
+            self._inline_frame_cache_tracked_side_effect_ids = frozenset(
+                side_effects.id_to_variable.keys()
+            )
+            self._inline_frame_cache_modified_side_effect_ids = frozenset(
+                item_id
+                for item_id, variable in side_effects.id_to_variable.items()
+                if side_effects.is_modified(variable)
+            )
+            self._inline_frame_cache_had_existing_dict_mutation = (
+                side_effects.has_existing_dict_mutation()
+            )
+            self._inline_frame_cache_save_for_backward_count = len(
+                side_effects.save_for_backward
+            )
+            self._inline_frame_cache_tensor_hook_ids = frozenset(
+                side_effects.tensor_hooks.keys()
+            )
+        else:
+            self._inline_frame_cache_start_nodes = frozenset()
+            self._inline_frame_cache_tracked_side_effect_ids = frozenset()
+            self._inline_frame_cache_modified_side_effect_ids = frozenset()
+            self._inline_frame_cache_had_existing_dict_mutation = (
+                side_effects.has_existing_dict_mutation()
+            )
+            self._inline_frame_cache_save_for_backward_count = len(
+                side_effects.save_for_backward
+            )
+            self._inline_frame_cache_tensor_hook_ids = frozenset(
+                side_effects.tensor_hooks.keys()
+            )
         self.num_calls = parent.num_calls
         self.symbolic_result = None
         self.nn_module_stack = parent.nn_module_stack.copy()

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5503,6 +5503,8 @@ def _clone_inline_frame_cache_fake(value: Any, tx: Any) -> Any:
     if not _inline_frame_cache_fake_is_supported(value, tx):
         return _INLINE_FRAME_CACHE_UNSUPPORTED
     try:
+        # FakeTensor example metadata is structural here; replay clones do not
+        # preserve real autograd history.
         with tx.fake_mode:
             return torch.empty_strided(
                 tuple(value.size()),
@@ -5601,6 +5603,49 @@ def _inline_frame_cache_result_is_supported(
             for item in result.items
         )
     return isinstance(result, ConstantVariable)
+
+
+def _clone_inline_frame_cache_result_template(
+    result: VariableTracker,
+) -> VariableTracker | None:
+    result = result.unwrap()
+    if isinstance(result, LazyVariableTracker):
+        if not result.is_realized():
+            return None
+        return _clone_inline_frame_cache_result_template(result.unwrap())
+    if isinstance(result, TensorVariable):
+        return result.clone(mutation_type=None)
+    if isinstance(result, TupleVariable):
+        items = [
+            _clone_inline_frame_cache_result_template(item) for item in result.items
+        ]
+        if any(item is None for item in items):
+            return None
+        return result.clone(
+            items=cast(list[VariableTracker], items),
+            mutation_type=None,
+        )
+    if isinstance(result, ConstantVariable):
+        return result.clone()
+    return None
+
+
+def _inline_frame_cache_graph_nodes_after(
+    graph: torch.fx.Graph, start_node: torch.fx.Node | None
+) -> list[torch.fx.Node] | None:
+    if start_node is None:
+        return list(graph.nodes)
+    if start_node.graph is not graph or getattr(start_node, "_erased", False):
+        return None
+
+    new_nodes: list[torch.fx.Node] = []
+    node = start_node.next
+    for _ in range(len(graph.nodes)):
+        if node.op == "root":
+            return new_nodes
+        new_nodes.append(node)
+        node = node.next
+    return None
 
 
 class InliningInstructionTranslator(InstructionTranslatorBase):
@@ -5815,14 +5860,10 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             return
 
         start_node = self._inline_frame_cache_start_node
-        new_nodes: list[torch.fx.Node] = []
-        found_start_node = start_node is None
-        for node in self.output.current_tracer.graph.nodes:
-            if found_start_node:
-                new_nodes.append(node)
-            elif node is start_node:
-                found_start_node = True
-        if not found_start_node:
+        new_nodes = _inline_frame_cache_graph_nodes_after(
+            self.output.current_tracer.graph, start_node
+        )
+        if new_nodes is None:
             return
         if not new_nodes:
             return
@@ -5836,6 +5877,10 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         if not _inline_frame_cache_result_is_supported(result, cached_nodes):
             return
 
+        cached_result = _clone_inline_frame_cache_result_template(result)
+        if cached_result is None:
+            return
+
         cache_entry = self.output.tracing_context.inlined_code_cache.get(self.f_code)
         if cache_entry is None:
             return
@@ -5844,7 +5889,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         cache_entry.inline_frame_cache = InlinedFrameCache(
             key=key,
             nodes=new_nodes,
-            result=result,
+            result=cached_result,
             f_globals_id=id(self.f_globals),
         )
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5696,8 +5696,12 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         if isinstance(result, TensorVariable):
             node = result.proxy.node
             new_node = node_remap.get(node)
-            if new_node is None or new_node is node:
-                return result
+            if new_node is None:
+                return None
+            if new_node is node:
+                remapped = result.clone(mutation_type=None)
+                self.output.current_tracer.record_proxyable_vt(remapped)
+                return remapped
             proxy = self.output.current_tracer.proxy(new_node)
             remapped = result.clone(proxy=proxy, mutation_type=None)
             self.output.side_effects._track_obj(

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5395,6 +5395,8 @@ def _make_inline_frame_cache_value_key(value: VariableTracker) -> Any | None:
         # such as operator.is_.
         return ("constant", type(constant), constant, id(constant))
 
+    # Unsupported symbolic locals conservatively skip cache use. Additional
+    # container/object keys can be added here if they become worthwhile.
     return None
 
 
@@ -5711,7 +5713,6 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 return None
             if new_node is node:
                 remapped = result.clone(mutation_type=None)
-                self.output.current_tracer.record_proxyable_vt(remapped)
                 return remapped
             proxy = self.output.current_tracer.proxy(new_node)
             remapped = result.clone(proxy=proxy, mutation_type=None)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5398,11 +5398,11 @@ def _inline_frame_cache_node_is_replayable(node: torch.fx.Node) -> bool:
         return True
     if node.op == "call_method":
         target = node.target
-        return not (
-            isinstance(target, str)
-            and target.endswith("_")
-            and not target.startswith("__")
-        )
+        if not isinstance(target, str):
+            return True
+        if target.startswith("__i") and target.endswith("__"):
+            return False
+        return not (target.endswith("_") and not target.startswith("__"))
     if node.op != "call_function":
         return False
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -52,8 +52,9 @@ import torch
 import torch._logging
 from torch._dynamo.dynamo_profiler import DynamoProfilerState, FunctionTraceTiming
 from torch._dynamo.exc import ObservedException, TensorifyScalarRestartAnalysis
-from torch._guards import InlinedCodeCache, tracing, TracingContext
+from torch._guards import InlinedCodeCache, InlinedFrameCache, tracing, TracingContext
 from torch._logging.structured import dump_file
+from torch._subclasses.fake_tensor import FakeTensor, is_fake
 from torch.fx.experimental.symbolic_shapes import guard_bool
 from torch.utils._functools import cache_method
 
@@ -141,7 +142,13 @@ from .utils import (
     LazyString,
     proxy_args_kwargs,
 )
-from .variables.base import SourceLocation, typestr, ValueMutationNew, VariableTracker
+from .variables.base import (
+    AttributeMutationNew,
+    SourceLocation,
+    typestr,
+    ValueMutationNew,
+    VariableTracker,
+)
 from .variables.builder import FrameStateSizeEntry, VariableBuilder, wrap_fx_proxy
 from .variables.builtin import BuiltinVariable, DictBuiltinVariable
 from .variables.constant import ConstantVariable
@@ -5285,12 +5292,379 @@ def profile_inline_call(
             output.profiler_state.add_child_time(cumtime_ns)
 
 
+_INLINE_FRAME_CACHE_UNSUPPORTED = object()
+
+
+def _make_inline_frame_cache_key(
+    symbolic_locals: dict[str, VariableTracker],
+) -> tuple[Any, ...] | None:
+    key = []
+    for name in sorted(symbolic_locals):
+        value_key = _make_inline_frame_cache_value_key(symbolic_locals[name])
+        if value_key is None:
+            return None
+        key.append((name, value_key))
+    return tuple(key)
+
+
+def _make_inline_frame_cache_value_key(value: VariableTracker) -> Any | None:
+    value = value.unwrap()
+    if isinstance(value, LazyVariableTracker):
+        if not value.is_realized():
+            return None
+        value = value.unwrap()
+
+    if isinstance(value, TensorVariable):
+        node = value.proxy.node
+        example_value = node.meta.get("example_value")
+        version = getattr(example_value, "_version", None)
+        return ("tensor", id(value), id(node), version)
+
+    if isinstance(value, TupleVariable):
+        items = []
+        for item in value.items:
+            item_key = _make_inline_frame_cache_value_key(item)
+            if item_key is None:
+                return None
+            items.append(item_key)
+        return ("tuple", tuple(items))
+
+    if isinstance(value, ConstantVariable):
+        try:
+            constant = value.as_python_constant()
+            hash(constant)
+        except Exception:
+            return None
+        return ("constant", type(constant), constant)
+
+    return None
+
+
+def _inline_frame_cache_node_is_replayable(node: torch.fx.Node) -> bool:
+    if node.op in ("placeholder", "get_attr"):
+        return True
+    if node.op == "call_method":
+        target = node.target
+        return not (
+            isinstance(target, str)
+            and target.endswith("_")
+            and not target.startswith("__")
+        )
+    if node.op != "call_function":
+        return False
+
+    schema = getattr(node.target, "_schema", None)
+    if schema is not None and getattr(schema, "is_mutable", False):
+        return False
+    return node.target not in (
+        operator.delitem,
+        operator.setitem,
+        setattr,
+        delattr,
+    )
+
+
+def _inline_frame_cache_fake_is_supported(value: Any, tx: Any) -> bool:
+    return (
+        type(value) is FakeTensor
+        and tx.fake_mode is not None
+        and value.fake_mode is tx.fake_mode
+        and value.layout is torch.strided
+        and not value.is_sparse
+        and not value.is_nested
+        and not value.is_quantized
+        and not value.is_conj()
+        and not value.is_neg()
+        and value.storage_offset() == 0
+        and getattr(value, "_base", None) is None
+        and value.constant is None
+        and value.real_tensor is None
+        and value.pytype in (None, torch.Tensor)
+    )
+
+
+def _clone_inline_frame_cache_fake(value: Any, tx: Any) -> Any:
+    if not _inline_frame_cache_fake_is_supported(value, tx):
+        return _INLINE_FRAME_CACHE_UNSUPPORTED
+    try:
+        with tx.fake_mode:
+            return torch.empty_strided(
+                tuple(value.size()),
+                tuple(value.stride()),
+                dtype=value.dtype,
+                device=value.fake_device,
+                requires_grad=value.requires_grad,
+            )
+    except Exception:
+        return _INLINE_FRAME_CACHE_UNSUPPORTED
+
+
+def _clone_inline_frame_cache_example_value(value: Any, tx: Any) -> Any:
+    if is_fake(value):
+        return _clone_inline_frame_cache_fake(value, tx)
+    if isinstance(value, tuple):
+        cloned = [_clone_inline_frame_cache_example_value(v, tx) for v in value]
+        if any(v is _INLINE_FRAME_CACHE_UNSUPPORTED for v in cloned):
+            return _INLINE_FRAME_CACHE_UNSUPPORTED
+        if hasattr(value, "_fields"):
+            return type(value)(*cloned)
+        return tuple(cloned)
+    if isinstance(value, list):
+        cloned = [_clone_inline_frame_cache_example_value(v, tx) for v in value]
+        if any(v is _INLINE_FRAME_CACHE_UNSUPPORTED for v in cloned):
+            return _INLINE_FRAME_CACHE_UNSUPPORTED
+        return cloned
+    if isinstance(value, dict):
+        cloned = {
+            k: _clone_inline_frame_cache_example_value(v, tx)
+            for k, v in value.items()
+        }
+        if any(v is _INLINE_FRAME_CACHE_UNSUPPORTED for v in cloned.values()):
+            return _INLINE_FRAME_CACHE_UNSUPPORTED
+        return cloned
+    if isinstance(value, torch.Tensor):
+        return _INLINE_FRAME_CACHE_UNSUPPORTED
+    return value
+
+
+def _inline_frame_cache_example_value_is_supported(value: Any, tx: Any) -> bool:
+    if is_fake(value):
+        return _inline_frame_cache_fake_is_supported(value, tx)
+    if isinstance(value, (tuple, list)):
+        return all(
+            _inline_frame_cache_example_value_is_supported(v, tx) for v in value
+        )
+    if isinstance(value, dict):
+        return all(
+            _inline_frame_cache_example_value_is_supported(v, tx)
+            for v in value.values()
+        )
+    return not isinstance(value, torch.Tensor)
+
+
+def _clone_inline_frame_cache_node_meta(
+    node: torch.fx.Node, tx: Any
+) -> dict[str, Any] | None:
+    meta = copy.copy(node.meta)
+    if "example_value" in meta:
+        example_value = _clone_inline_frame_cache_example_value(
+            meta["example_value"], tx
+        )
+        if example_value is _INLINE_FRAME_CACHE_UNSUPPORTED:
+            return None
+        meta["example_value"] = example_value
+    return meta
+
+
+def _inline_frame_cache_node_meta_is_supported(
+    node: torch.fx.Node, tx: Any
+) -> bool:
+    if "example_value" not in node.meta:
+        return True
+    return _inline_frame_cache_example_value_is_supported(
+        node.meta["example_value"], tx
+    )
+
+
+def _inline_frame_cache_result_is_supported(
+    result: VariableTracker, cached_nodes: set[torch.fx.Node]
+) -> bool:
+    result = result.unwrap()
+    if isinstance(result, LazyVariableTracker):
+        return result.is_realized() and _inline_frame_cache_result_is_supported(
+            result.unwrap(), cached_nodes
+        )
+    if isinstance(result, TensorVariable):
+        return (
+            result.proxy.node in cached_nodes
+            or result.proxy.node.op == "placeholder"
+        )
+    if isinstance(result, TupleVariable):
+        return all(
+            _inline_frame_cache_result_is_supported(item, cached_nodes)
+            for item in result.items
+        )
+    return isinstance(result, ConstantVariable)
+
+
 class InliningInstructionTranslator(InstructionTranslatorBase):
     """Trace and inline a called method"""
 
     symbolic_result: VariableTracker | None
     # pyrefly: ignore [bad-override]
     parent: InstructionTranslatorBase
+
+    def _maybe_replay_inline_frame_cache(self) -> VariableTracker | None:
+        if is_generator(self.f_code):
+            return None
+        if self.parent.strict_checks_fn:
+            return None
+        if config.use_graph_deduplication or config.track_nodes_for_deduplication:
+            return None
+        if self.output.current_tracer.parent is not None:
+            return None
+
+        tracing_ctx = self.output.tracing_context
+        cache_entry = tracing_ctx.inlined_code_cache.get(self.f_code)
+        cached = cache_entry.inline_frame_cache if cache_entry is not None else None
+        if cached is None:
+            return None
+
+        key = _make_inline_frame_cache_key(self.symbolic_locals)
+        if key != cached.key:
+            return None
+
+        return self._replay_inline_frame_cache(cached)
+
+    def _replay_inline_frame_cache(
+        self, cached: InlinedFrameCache
+    ) -> VariableTracker | None:
+        tracer = self.output.current_tracer
+        node_remap: dict[torch.fx.Node, torch.fx.Node] = {}
+        cloned_meta: dict[torch.fx.Node, dict[str, Any]] = {}
+
+        for node in cached.nodes:
+            if node.op == "placeholder":
+                node_remap[node] = node
+                continue
+            if not _inline_frame_cache_node_is_replayable(node):
+                return None
+            meta = _clone_inline_frame_cache_node_meta(node, self)
+            if meta is None:
+                return None
+            cloned_meta[node] = meta
+
+        for node in cached.nodes:
+            if node.op == "placeholder":
+                continue
+
+            def remap_arg(arg: torch.fx.Node) -> torch.fx.Proxy:
+                return tracer.proxy(node_remap.get(arg, arg))
+
+            args = torch.fx.node.map_arg(node.args, remap_arg)
+            kwargs = torch.fx.node.map_arg(node.kwargs, remap_arg)
+            proxy = tracer.create_proxy(
+                node.op,
+                node.target,
+                args,
+                dict(kwargs),
+                name=node.name,
+                type_expr=node.type,
+            )
+            proxy.node.meta = cloned_meta[node]
+            if "example_value" in proxy.node.meta:
+                tracer.track_produced_symints(proxy.node.meta["example_value"], proxy)
+            node_remap[node] = proxy.node
+
+        return self._remap_inline_frame_cache_result(cached.result, node_remap)
+
+    def _remap_inline_frame_cache_result(
+        self,
+        result: VariableTracker,
+        node_remap: dict[torch.fx.Node, torch.fx.Node],
+    ) -> VariableTracker | None:
+        result = result.unwrap()
+        if isinstance(result, LazyVariableTracker):
+            if not result.is_realized():
+                return None
+            return self._remap_inline_frame_cache_result(result.unwrap(), node_remap)
+
+        if isinstance(result, TensorVariable):
+            node = result.proxy.node
+            new_node = node_remap.get(node)
+            if new_node is None or new_node is node:
+                return result
+            proxy = self.output.current_tracer.proxy(new_node)
+            remapped = result.clone(proxy=proxy, mutation_type=None)
+            self.output.side_effects._track_obj(
+                proxy, remapped, mutation_type_cls=AttributeMutationNew
+            )
+            self.output.current_tracer.record_proxyable_vt(remapped)
+            return remapped
+
+        if isinstance(result, TupleVariable):
+            items = [
+                self._remap_inline_frame_cache_result(item, node_remap)
+                for item in result.items
+            ]
+            if any(item is None for item in items):
+                return None
+            return result.clone(items=cast(list[VariableTracker], items))
+
+        if isinstance(result, ConstantVariable):
+            return result
+
+        return None
+
+    def _inline_frame_cache_has_new_existing_mutation(self) -> bool:
+        side_effects = self.output.side_effects
+        if (
+            side_effects.has_existing_dict_mutation()
+            and not self._inline_frame_cache_had_existing_dict_mutation
+        ):
+            return True
+
+        for item_id, variable in side_effects.id_to_variable.items():
+            mutation_type = variable.mutation_type
+            if item_id not in self._inline_frame_cache_tracked_side_effect_ids:
+                if not isinstance(
+                    mutation_type, (AttributeMutationNew, ValueMutationNew)
+                ) and side_effects.is_modified(variable):
+                    return True
+                continue
+            if (
+                item_id not in self._inline_frame_cache_modified_side_effect_ids
+                and side_effects.is_modified(variable)
+            ):
+                return True
+        return False
+
+    def _maybe_store_inline_frame_cache(self, result: VariableTracker) -> None:
+        if is_generator(self.f_code):
+            return
+        if self.parent.strict_checks_fn:
+            return
+        if config.use_graph_deduplication or config.track_nodes_for_deduplication:
+            return
+        if self.output.current_tracer.parent is not None:
+            return
+        if self.output.should_exit:
+            return
+        if not self.has_no_inlined_calls:
+            return
+        if self.inconsistent_side_effects:
+            return
+        if self._inline_frame_cache_has_new_existing_mutation():
+            return
+
+        key = _make_inline_frame_cache_key(self.symbolic_locals)
+        if key is None:
+            return
+
+        new_nodes = [
+            node
+            for node in self.output.current_tracer.graph.nodes
+            if node not in self._inline_frame_cache_start_nodes
+        ]
+        cached_nodes = set(new_nodes)
+        if not all(_inline_frame_cache_node_is_replayable(node) for node in new_nodes):
+            return
+        if not all(
+            _inline_frame_cache_node_meta_is_supported(node, self)
+            for node in new_nodes
+        ):
+            return
+        if not _inline_frame_cache_result_is_supported(result, cached_nodes):
+            return
+
+        cache_entry = self.output.tracing_context.inlined_code_cache.get(self.f_code)
+        if cache_entry is None:
+            return
+        cache_entry.inline_frame_cache = InlinedFrameCache(
+            key=key,
+            nodes=new_nodes,
+            result=result,
+        )
 
     @classmethod
     def inline_call(
@@ -5517,8 +5891,16 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
     def inline_call_(self) -> VariableTracker:
         parent = self.parent
         parent.has_no_inlined_calls = False
-        parent.is_child_tracer_active = True
         code = self.f_code
+
+        cached_result = self._maybe_replay_inline_frame_cache()
+        if cached_result is not None:
+            parent.error_on_graph_break = self.error_on_graph_break
+            log.debug("DONE INLINING %s (inline frame cache hit)", code)
+            self.output.tracing_context.traced_code.append(code)
+            return cached_result
+
+        parent.is_child_tracer_active = True
 
         strict_ctx: Any = contextlib.nullcontext()
         if parent.strict_checks_fn:
@@ -5579,17 +5961,20 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                     args = [self.symbolic_result]
                 exc.raise_observed_exception(StopIteration, self, args=args)
             else:
-                return self.symbolic_result
+                result = self.symbolic_result
         else:
             if is_generator(code):
                 assert isinstance(self, InliningGeneratorInstructionTranslator)
                 assert self.symbolic_result.is_constant_none()
-                return ListIteratorVariable(
+                result = ListIteratorVariable(
                     self.generated_items,
                     mutation_type=ValueMutationNew(),
                 )
             else:
-                return self.symbolic_result
+                result = self.symbolic_result
+
+        self._maybe_store_inline_frame_cache(result)
+        return result
 
     def __init__(
         self,
@@ -5648,6 +6033,21 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             indexof=indexof,
         )
         self.funcvar = funcvar
+        self._inline_frame_cache_start_nodes = frozenset(
+            parent.output.current_tracer.graph.nodes
+        )
+        side_effects = self.output.side_effects
+        self._inline_frame_cache_tracked_side_effect_ids = frozenset(
+            side_effects.id_to_variable.keys()
+        )
+        self._inline_frame_cache_modified_side_effect_ids = frozenset(
+            item_id
+            for item_id, variable in side_effects.id_to_variable.items()
+            if side_effects.is_modified(variable)
+        )
+        self._inline_frame_cache_had_existing_dict_mutation = (
+            side_effects.has_existing_dict_mutation()
+        )
         self.parent = parent
         self.num_calls = parent.num_calls
         self.symbolic_result = None

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5371,6 +5371,28 @@ def _make_inline_frame_cache_value_key(value: VariableTracker) -> Any | None:
     return None
 
 
+def _inline_frame_cache_value_has_tensor(value: VariableTracker) -> bool:
+    value = value.unwrap()
+    if isinstance(value, LazyVariableTracker):
+        return value.is_realized() and _inline_frame_cache_value_has_tensor(
+            value.unwrap()
+        )
+    if isinstance(value, TensorVariable):
+        return True
+    if isinstance(value, TupleVariable):
+        return any(_inline_frame_cache_value_has_tensor(item) for item in value.items)
+    return False
+
+
+def _inline_frame_cache_locals_have_tensor(
+    symbolic_locals: dict[str, VariableTracker],
+) -> bool:
+    return any(
+        _inline_frame_cache_value_has_tensor(value)
+        for value in symbolic_locals.values()
+    )
+
+
 def _inline_frame_cache_node_is_replayable(node: torch.fx.Node) -> bool:
     if node.op in ("placeholder", "get_attr"):
         return True
@@ -5539,6 +5561,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             or config.use_graph_deduplication
             or config.track_nodes_for_deduplication
             or self.output.current_tracer.parent is not None
+            or not _inline_frame_cache_locals_have_tensor(self.symbolic_locals)
         )
 
     def _inline_frame_cache_globals_are_supported(self) -> bool:
@@ -5592,12 +5615,12 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 return None
             cloned_meta[node] = meta
 
+        def remap_arg(arg: torch.fx.Node) -> Any:
+            return tracer.proxy(node_remap.get(arg, arg))
+
         for node in cached.nodes:
             if node.op == "placeholder":
                 continue
-
-            def remap_arg(arg: torch.fx.Node) -> Any:
-                return tracer.proxy(node_remap.get(arg, arg))
 
             args = torch.fx.node.map_arg(node.args, remap_arg)
             kwargs = torch.fx.node.map_arg(node.kwargs, remap_arg)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5297,6 +5297,9 @@ def profile_inline_call(
 
 
 _INLINE_FRAME_CACHE_UNSUPPORTED = object()
+# These are fresh context keys we can skip deepcopying from cached nodes. Replay
+# still preserves every key populated by create_proxy via the fresh-meta merge;
+# this set is an optimization, not an exhaustive safety allowlist.
 _INLINE_FRAME_CACHE_FRESH_META_KEYS = {
     "creation_timestamp",
     "nn_module_stack",
@@ -5413,7 +5416,8 @@ def _make_inline_frame_cache_value_key(value: VariableTracker) -> Any | None:
         except Exception:
             return None
         # Keep object identity in the key for identity-sensitive leaf frames
-        # such as operator.is_.
+        # such as operator.is_. This intentionally trades hit rate for
+        # correctness; equal values from different allocations trace normally.
         return ("constant", type(constant), constant, id(constant))
 
     # Unsupported symbolic locals conservatively skip cache use. Additional
@@ -5461,6 +5465,10 @@ def _inline_frame_cache_node_is_replayable(node: torch.fx.Node) -> bool:
     if node.op != "call_function":
         return False
 
+    # Dynamo FX call_function targets are expected to be ATen/operator-style
+    # pure functions. Mutable ATen ops are rejected through _schema, and Python
+    # mutation builtins are denied explicitly. Existing-object mutations that do
+    # not appear in FX are also rejected by the side-effect snapshots on store.
     schema = getattr(node.target, "_schema", None)
     if schema is not None and getattr(schema, "is_mutable", False):
         return False

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5334,6 +5334,17 @@ def _inline_frame_cache_store_attr_mutation_keys(
 def _inline_frame_cache_analyze_globals(
     instructions: list[Instruction], f_globals: dict[str, Any]
 ) -> tuple[bool, frozenset[str]]:
+    globals_safe, loaded_global_names = _inline_frame_cache_analyze_global_instructions(
+        instructions
+    )
+    if not globals_safe:
+        return False, frozenset()
+    return _inline_frame_cache_analyze_global_values(loaded_global_names, f_globals)
+
+
+def _inline_frame_cache_analyze_global_instructions(
+    instructions: list[Instruction],
+) -> tuple[bool, frozenset[str]]:
     loaded_global_names: set[str] = set()
     for inst in instructions:
         if inst.opname in ("STORE_GLOBAL", "DELETE_GLOBAL"):
@@ -5341,12 +5352,22 @@ def _inline_frame_cache_analyze_globals(
         if inst.opname != "LOAD_GLOBAL":
             continue
         name = inst.argval
-        if not isinstance(name, str) or name not in f_globals:
+        if isinstance(name, str):
+            loaded_global_names.add(name)
+    return True, frozenset(loaded_global_names)
+
+
+def _inline_frame_cache_analyze_global_values(
+    loaded_global_names: frozenset[str], f_globals: dict[str, Any]
+) -> tuple[bool, frozenset[str]]:
+    supported_loaded_global_names: set[str] = set()
+    for name in loaded_global_names:
+        if name not in f_globals:
             continue
         if not _inline_frame_cache_global_value_is_supported(f_globals[name]):
             return False, frozenset()
-        loaded_global_names.add(name)
-    return True, frozenset(loaded_global_names)
+        supported_loaded_global_names.add(name)
+    return True, frozenset(supported_loaded_global_names)
 
 
 def _make_inline_frame_cache_key(
@@ -5600,7 +5621,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
 
     def _inline_frame_cache_can_be_enabled(self) -> bool:
         return not (
-            is_generator(self.f_code)
+            not config.enable_inline_frame_cache
+            or is_generator(self.f_code)
             or self.parent.strict_checks_fn
             or config.use_graph_deduplication
             or config.track_nodes_for_deduplication
@@ -6171,11 +6193,12 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             indexof = get_indexof(instructions)
             code_options = {k: getattr(code, k) for k in get_code_keys()}
             if tracing_ctx:
-                tracing_ctx.inlined_code_cache[code] = InlinedCodeCache(
+                cached = InlinedCodeCache(
                     instructions=instructions,
                     indexof=indexof,
                     code_options=code_options,
                 )
+                tracing_ctx.inlined_code_cache[code] = cached
 
         super().__init__(
             output=parent.output,
@@ -6202,10 +6225,30 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         side_effects = self.output.side_effects
         inline_frame_cache_can_be_enabled = self._inline_frame_cache_can_be_enabled()
         if inline_frame_cache_can_be_enabled:
-            (
-                self._inline_frame_cache_static_globals_supported,
-                self._inline_frame_cache_loaded_global_names,
-            ) = _inline_frame_cache_analyze_globals(self.instructions, self.f_globals)
+            if cached is not None:
+                if cached.inline_frame_cache_global_instruction_analysis is None:
+                    cached.inline_frame_cache_global_instruction_analysis = (
+                        _inline_frame_cache_analyze_global_instructions(
+                            self.instructions
+                        )
+                    )
+                (
+                    self._inline_frame_cache_static_globals_supported,
+                    self._inline_frame_cache_loaded_global_names,
+                ) = _inline_frame_cache_analyze_global_values(
+                    cached.inline_frame_cache_global_instruction_analysis[1],
+                    self.f_globals,
+                )
+                self._inline_frame_cache_static_globals_supported &= (
+                    cached.inline_frame_cache_global_instruction_analysis[0]
+                )
+            else:
+                (
+                    self._inline_frame_cache_static_globals_supported,
+                    self._inline_frame_cache_loaded_global_names,
+                ) = _inline_frame_cache_analyze_globals(
+                    self.instructions, self.f_globals
+                )
         else:
             self._inline_frame_cache_static_globals_supported = False
             self._inline_frame_cache_loaded_global_names = frozenset()

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5624,6 +5624,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         tracer = self.output.current_tracer
         node_remap: dict[torch.fx.Node, torch.fx.Node] = {}
         cloned_meta: dict[torch.fx.Node, dict[str, Any]] = {}
+        replayed_nodes: list[torch.fx.Node] = []
 
         for node in cached.nodes:
             if node.op == "placeholder":
@@ -5661,8 +5662,16 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             if "example_value" in proxy.node.meta:
                 tracer.track_produced_symints(proxy.node.meta["example_value"], proxy)
             node_remap[node] = proxy.node
+            replayed_nodes.append(proxy.node)
 
-        return self._remap_inline_frame_cache_result(cached.result, node_remap)
+        remapped_result = self._remap_inline_frame_cache_result(
+            cached.result, node_remap
+        )
+        if remapped_result is None:
+            for node in reversed(replayed_nodes):
+                tracer.graph.erase_node(node)
+            return None
+        return remapped_result
 
     def _remap_inline_frame_cache_result(
         self,

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5422,7 +5422,12 @@ def _inline_frame_cache_node_is_replayable(node: torch.fx.Node) -> bool:
         target = node.target
         if not isinstance(target, str):
             return True
-        if target.startswith("__i") and target.endswith("__"):
+        if target in (
+            "__setitem__",
+            "__delitem__",
+            "__setattr__",
+            "__delattr__",
+        ) or (target.startswith("__i") and target.endswith("__")):
             return False
         return not (target.endswith("_") and not target.startswith("__"))
     if node.op != "call_function":
@@ -6013,6 +6018,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
 
         cached_result = self._maybe_replay_inline_frame_cache()
         if cached_result is not None:
+            # No child tracer runs on a cache hit, so graph-break gating does not
+            # need the normal is_child_tracer_active toggle here.
             parent.error_on_graph_break = self.error_on_graph_break
             if self.f_globals is parent.f_globals:
                 parent.symbolic_globals.update(self.symbolic_globals)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -55,7 +55,7 @@ from torch._dynamo.exc import ObservedException, TensorifyScalarRestartAnalysis
 from torch._guards import InlinedCodeCache, InlinedFrameCache, tracing, TracingContext
 from torch._logging.structured import dump_file
 from torch._subclasses.fake_tensor import FakeTensor, is_fake
-from torch.fx.experimental.symbolic_shapes import guard_bool
+from torch.fx.experimental.symbolic_shapes import guard_bool, statically_known_true
 from torch.utils._functools import cache_method
 
 from . import (
@@ -5298,6 +5298,32 @@ _INLINE_FRAME_CACHE_FRESH_META_KEYS = {
     "source_fn_stack",
     "stack_trace",
 }
+_INLINE_FRAME_CACHE_GLOBAL_SAFE_TYPES = (
+    types.ModuleType,
+    types.FunctionType,
+    types.BuiltinFunctionType,
+    type,
+)
+
+
+def _inline_frame_cache_global_value_is_supported(value: Any) -> bool:
+    if ConstantVariable.is_base_literal(value) or isinstance(value, torch.Size):
+        return True
+    if isinstance(value, tuple):
+        return all(_inline_frame_cache_global_value_is_supported(v) for v in value)
+    if isinstance(value, frozenset):
+        return all(_inline_frame_cache_global_value_is_supported(v) for v in value)
+    return isinstance(value, _INLINE_FRAME_CACHE_GLOBAL_SAFE_TYPES)
+
+
+def _inline_frame_cache_store_attr_mutation_keys(
+    side_effects: Any,
+) -> frozenset[tuple[int, str, int]]:
+    return frozenset(
+        (id(item), name, id(value))
+        for item, mutations in side_effects.store_attr_mutations.items()
+        for name, value in mutations.items()
+    )
 
 
 def _make_inline_frame_cache_key(
@@ -5323,7 +5349,7 @@ def _make_inline_frame_cache_value_key(value: VariableTracker) -> Any | None:
         node = value.proxy.node
         example_value = node.meta.get("example_value")
         version = getattr(example_value, "_version", None)
-        return ("tensor", id(value), id(node), version)
+        return ("tensor", id(node), version)
 
     if isinstance(value, TupleVariable):
         items = []
@@ -5340,7 +5366,7 @@ def _make_inline_frame_cache_value_key(value: VariableTracker) -> Any | None:
             hash(constant)
         except Exception:
             return None
-        return ("constant", type(constant), constant)
+        return ("constant", type(constant), constant, id(constant))
 
     return None
 
@@ -5370,18 +5396,25 @@ def _inline_frame_cache_node_is_replayable(node: torch.fx.Node) -> bool:
 
 
 def _inline_frame_cache_fake_is_supported(value: Any, tx: Any) -> bool:
+    if type(value) is not FakeTensor:
+        return False
+    if tx.fake_mode is None or value.fake_mode is not tx.fake_mode:
+        return False
+    try:
+        if (
+            value.layout is not torch.strided
+            or value.is_sparse
+            or value.is_nested
+            or value.is_quantized
+            or value.is_conj()
+            or value.is_neg()
+            or not statically_known_true(value.storage_offset() == 0)
+        ):
+            return False
+    except Exception:
+        return False
     return (
-        type(value) is FakeTensor
-        and tx.fake_mode is not None
-        and value.fake_mode is tx.fake_mode
-        and value.layout is torch.strided
-        and not value.is_sparse
-        and not value.is_nested
-        and not value.is_quantized
-        and not value.is_conj()
-        and not value.is_neg()
-        and value.storage_offset() == 0
-        and getattr(value, "_base", None) is None
+        getattr(value, "_base", None) is None
         and value.constant is None
         and value.real_tensor is None
         and value.pytype in (None, torch.Tensor)
@@ -5508,8 +5541,25 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             or self.output.current_tracer.parent is not None
         )
 
+    def _inline_frame_cache_globals_are_supported(self) -> bool:
+        for inst in self.instructions:
+            if inst.opname != "LOAD_GLOBAL":
+                continue
+            name = inst.argval
+            if not isinstance(name, str) or name not in self.f_globals:
+                continue
+            if name in self.symbolic_globals:
+                return False
+            if not _inline_frame_cache_global_value_is_supported(
+                self.f_globals[name]
+            ):
+                return False
+        return True
+
     def _maybe_replay_inline_frame_cache(self) -> VariableTracker | None:
         if not self._inline_frame_cache_is_enabled():
+            return None
+        if not self._inline_frame_cache_globals_are_supported():
             return None
 
         tracing_ctx = self.output.tracing_context
@@ -5547,7 +5597,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 continue
 
             def remap_arg(arg: torch.fx.Node) -> torch.fx.node.Argument:
-                return tracer.proxy(node_remap.get(arg, arg))
+                return node_remap.get(arg, arg)
 
             args = torch.fx.node.map_arg(node.args, remap_arg)
             kwargs = torch.fx.node.map_arg(node.kwargs, remap_arg)
@@ -5639,12 +5689,16 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             != self._inline_frame_cache_tensor_hook_ids
         ):
             return True
+        if (
+            _inline_frame_cache_store_attr_mutation_keys(side_effects)
+            != self._inline_frame_cache_store_attr_mutation_keys
+        ):
+            return True
         return False
 
     def _maybe_store_inline_frame_cache(self, result: VariableTracker) -> None:
         if not self._inline_frame_cache_is_enabled():
             return
-        start_nodes = self._inline_frame_cache_start_nodes
         if self.output.should_exit:
             return
         if not self.has_no_inlined_calls:
@@ -5653,16 +5707,23 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             return
         if self._inline_frame_cache_has_new_existing_mutation():
             return
+        if not self._inline_frame_cache_globals_are_supported():
+            return
 
         key = _make_inline_frame_cache_key(self.symbolic_locals)
         if key is None:
             return
 
-        new_nodes = [
-            node
-            for node in self.output.current_tracer.graph.nodes
-            if node not in start_nodes
-        ]
+        start_node = self._inline_frame_cache_start_node
+        new_nodes: list[torch.fx.Node] = []
+        found_start_node = start_node is None
+        for node in self.output.current_tracer.graph.nodes:
+            if found_start_node:
+                new_nodes.append(node)
+            elif node is start_node:
+                found_start_node = True
+        if not found_start_node:
+            return
         cached_nodes = set(new_nodes)
         if not all(_inline_frame_cache_node_is_replayable(node) for node in new_nodes):
             return
@@ -6052,8 +6113,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         self.parent = parent
         side_effects = self.output.side_effects
         if self._inline_frame_cache_is_enabled():
-            self._inline_frame_cache_start_nodes = frozenset(
-                parent.output.current_tracer.graph.nodes
+            self._inline_frame_cache_start_node = next(
+                reversed(parent.output.current_tracer.graph.nodes), None
             )
             self._inline_frame_cache_tracked_side_effect_ids = frozenset(
                 side_effects.id_to_variable.keys()
@@ -6072,8 +6133,11 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             self._inline_frame_cache_tensor_hook_ids = frozenset(
                 side_effects.tensor_hooks.keys()
             )
+            self._inline_frame_cache_store_attr_mutation_keys = (
+                _inline_frame_cache_store_attr_mutation_keys(side_effects)
+            )
         else:
-            self._inline_frame_cache_start_nodes = frozenset()
+            self._inline_frame_cache_start_node = None
             self._inline_frame_cache_tracked_side_effect_ids = frozenset()
             self._inline_frame_cache_modified_side_effect_ids = frozenset()
             self._inline_frame_cache_had_existing_dict_mutation = (
@@ -6084,6 +6148,9 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             )
             self._inline_frame_cache_tensor_hook_ids = frozenset(
                 side_effects.tensor_hooks.keys()
+            )
+            self._inline_frame_cache_store_attr_mutation_keys = (
+                _inline_frame_cache_store_attr_mutation_keys(side_effects)
             )
         self.num_calls = parent.num_calls
         self.symbolic_result = None

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5543,6 +5543,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
 
     def _inline_frame_cache_globals_are_supported(self) -> bool:
         for inst in self.instructions:
+            if inst.opname in ("STORE_GLOBAL", "DELETE_GLOBAL"):
+                return False
             if inst.opname != "LOAD_GLOBAL":
                 continue
             name = inst.argval
@@ -5550,9 +5552,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 continue
             if name in self.symbolic_globals:
                 return False
-            if not _inline_frame_cache_global_value_is_supported(
-                self.f_globals[name]
-            ):
+            if not _inline_frame_cache_global_value_is_supported(self.f_globals[name]):
                 return False
         return True
 
@@ -5596,8 +5596,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             if node.op == "placeholder":
                 continue
 
-            def remap_arg(arg: torch.fx.Node) -> torch.fx.node.Argument:
-                return node_remap.get(arg, arg)
+            def remap_arg(arg: torch.fx.Node) -> Any:
+                return tracer.proxy(node_remap.get(arg, arg))
 
             args = torch.fx.node.map_arg(node.args, remap_arg)
             kwargs = torch.fx.node.map_arg(node.kwargs, remap_arg)
@@ -5973,6 +5973,9 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         cached_result = self._maybe_replay_inline_frame_cache()
         if cached_result is not None:
             parent.error_on_graph_break = self.error_on_graph_break
+            if self.f_globals is parent.f_globals:
+                parent.symbolic_globals.update(self.symbolic_globals)
+            parent.inconsistent_side_effects |= self.inconsistent_side_effects
             log.debug("DONE INLINING %s (inline frame cache hit)", code)
             self.output.tracing_context.traced_code.append(code)
             return cached_result
@@ -6140,18 +6143,10 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             self._inline_frame_cache_start_node = None
             self._inline_frame_cache_tracked_side_effect_ids = frozenset()
             self._inline_frame_cache_modified_side_effect_ids = frozenset()
-            self._inline_frame_cache_had_existing_dict_mutation = (
-                side_effects.has_existing_dict_mutation()
-            )
-            self._inline_frame_cache_save_for_backward_count = len(
-                side_effects.save_for_backward
-            )
-            self._inline_frame_cache_tensor_hook_ids = frozenset(
-                side_effects.tensor_hooks.keys()
-            )
-            self._inline_frame_cache_store_attr_mutation_keys = (
-                _inline_frame_cache_store_attr_mutation_keys(side_effects)
-            )
+            self._inline_frame_cache_had_existing_dict_mutation = False
+            self._inline_frame_cache_save_for_backward_count = 0
+            self._inline_frame_cache_tensor_hook_ids = frozenset()
+            self._inline_frame_cache_store_attr_mutation_keys = frozenset()
         self.num_calls = parent.num_calls
         self.symbolic_result = None
         self.nn_module_stack = parent.nn_module_stack.copy()

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5370,6 +5370,8 @@ def _make_inline_frame_cache_value_key(value: VariableTracker) -> Any | None:
     if isinstance(value, TensorVariable):
         node = value.proxy.node
         example_value = node.meta.get("example_value")
+        # In-place updates can keep the same FX node while bumping the fake
+        # tensor version, so keep both in the monomorphic key.
         version = getattr(example_value, "_version", None)
         return ("tensor", id(node), version)
 
@@ -6194,7 +6196,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         self.funcvar = funcvar
         self.parent = parent
         side_effects = self.output.side_effects
-        if self._inline_frame_cache_can_be_enabled():
+        inline_frame_cache_can_be_enabled = self._inline_frame_cache_can_be_enabled()
+        if inline_frame_cache_can_be_enabled:
             (
                 self._inline_frame_cache_static_globals_supported,
                 self._inline_frame_cache_loaded_global_names,
@@ -6207,7 +6210,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         self._inline_frame_cache_start_node = next(
             reversed(parent.output.current_tracer.graph.nodes), None
         )
-        if self._inline_frame_cache_is_enabled():
+        if inline_frame_cache_can_be_enabled:
             self._inline_frame_cache_tracked_side_effect_ids = frozenset(
                 side_effects.id_to_variable.keys()
             )
@@ -6229,9 +6232,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 _inline_frame_cache_store_attr_mutation_keys(side_effects)
             )
         else:
-            # These conservative defaults still matter if lazy locals make this frame
-            # eligible by the store path; they prevent silently ignoring pre-existing
-            # side effects captured before eligibility became knowable.
+            # Frames that fail the static precheck return before reading these fields.
             self._inline_frame_cache_tracked_side_effect_ids = frozenset()
             self._inline_frame_cache_modified_side_effect_ids = frozenset()
             self._inline_frame_cache_had_existing_dict_mutation = False

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5654,7 +5654,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             return result.clone(items=cast(list[VariableTracker], items))
 
         if isinstance(result, ConstantVariable):
-            return result
+            return result.clone()
 
         return None
 
@@ -5723,6 +5723,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             elif node is start_node:
                 found_start_node = True
         if not found_start_node:
+            return
+        if not new_nodes:
             return
         cached_nodes = set(new_nodes)
         if not all(_inline_frame_cache_node_is_replayable(node) for node in new_nodes):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5298,6 +5298,7 @@ def profile_inline_call(
 
 _INLINE_FRAME_CACHE_UNSUPPORTED = object()
 _INLINE_FRAME_CACHE_FRESH_META_KEYS = {
+    "creation_timestamp",
     "nn_module_stack",
     "source_fn_stack",
     "stack_trace",
@@ -5390,6 +5391,8 @@ def _make_inline_frame_cache_value_key(value: VariableTracker) -> Any | None:
             hash(constant)
         except Exception:
             return None
+        # Keep object identity in the key for identity-sensitive leaf frames
+        # such as operator.is_.
         return ("constant", type(constant), constant, id(constant))
 
     return None

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5581,6 +5581,15 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
     symbolic_result: VariableTracker | None
     # pyrefly: ignore [bad-override]
     parent: InstructionTranslatorBase
+    _inline_frame_cache_static_globals_supported: bool
+    _inline_frame_cache_loaded_global_names: frozenset[str]
+    _inline_frame_cache_start_node: torch.fx.Node | None
+    _inline_frame_cache_tracked_side_effect_ids: frozenset[int]
+    _inline_frame_cache_modified_side_effect_ids: frozenset[int]
+    _inline_frame_cache_had_existing_dict_mutation: bool
+    _inline_frame_cache_save_for_backward_count: int
+    _inline_frame_cache_tensor_hook_ids: frozenset[int]
+    _inline_frame_cache_store_attr_mutation_keys: frozenset[tuple[int, str, int]]
 
     def _inline_frame_cache_is_enabled(self) -> bool:
         return not (
@@ -6176,10 +6185,11 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             self._inline_frame_cache_static_globals_supported,
             self._inline_frame_cache_loaded_global_names,
         ) = _inline_frame_cache_analyze_globals(self.instructions, self.f_globals)
+        # Locals may be lazy at construction and realized before the store path.
+        self._inline_frame_cache_start_node = next(
+            reversed(parent.output.current_tracer.graph.nodes), None
+        )
         if self._inline_frame_cache_is_enabled():
-            self._inline_frame_cache_start_node = next(
-                reversed(parent.output.current_tracer.graph.nodes), None
-            )
             self._inline_frame_cache_tracked_side_effect_ids = frozenset(
                 side_effects.id_to_variable.keys()
             )
@@ -6201,8 +6211,6 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 _inline_frame_cache_store_attr_mutation_keys(side_effects)
             )
         else:
-            # Locals may be lazy at construction and realized before the store path.
-            self._inline_frame_cache_start_node = None
             self._inline_frame_cache_tracked_side_effect_ids = frozenset()
             self._inline_frame_cache_modified_side_effect_ids = frozenset()
             self._inline_frame_cache_had_existing_dict_mutation = False

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5620,6 +5620,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         cached = cache_entry.inline_frame_cache if cache_entry is not None else None
         if cached is None:
             return None
+        if cached.f_globals_id != id(self.f_globals):
+            return None
 
         key = _make_inline_frame_cache_key(self.symbolic_locals)
         if key != cached.key:
@@ -5809,6 +5811,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             key=key,
             nodes=new_nodes,
             result=result,
+            f_globals_id=id(self.f_globals),
         )
 
     @classmethod

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -55,7 +55,11 @@ from torch._dynamo.exc import ObservedException, TensorifyScalarRestartAnalysis
 from torch._guards import InlinedCodeCache, InlinedFrameCache, tracing, TracingContext
 from torch._logging.structured import dump_file
 from torch._subclasses.fake_tensor import FakeTensor, is_fake
-from torch.fx.experimental.symbolic_shapes import guard_bool, statically_known_true
+from torch.fx.experimental.symbolic_shapes import (
+    guard_bool,
+    has_free_symbols,
+    statically_known_true,
+)
 from torch.utils._functools import cache_method
 
 from . import (
@@ -5326,6 +5330,24 @@ def _inline_frame_cache_store_attr_mutation_keys(
     )
 
 
+def _inline_frame_cache_analyze_globals(
+    instructions: list[Instruction], f_globals: dict[str, Any]
+) -> tuple[bool, frozenset[str]]:
+    loaded_global_names: set[str] = set()
+    for inst in instructions:
+        if inst.opname in ("STORE_GLOBAL", "DELETE_GLOBAL"):
+            return False, frozenset()
+        if inst.opname != "LOAD_GLOBAL":
+            continue
+        name = inst.argval
+        if not isinstance(name, str) or name not in f_globals:
+            continue
+        if not _inline_frame_cache_global_value_is_supported(f_globals[name]):
+            return False, frozenset()
+        loaded_global_names.add(name)
+    return True, frozenset(loaded_global_names)
+
+
 def _make_inline_frame_cache_key(
     symbolic_locals: dict[str, VariableTracker],
 ) -> tuple[Any, ...] | None:
@@ -5430,6 +5452,7 @@ def _inline_frame_cache_fake_is_supported(value: Any, tx: Any) -> bool:
             or value.is_quantized
             or value.is_conj()
             or value.is_neg()
+            or has_free_symbols((value.size(), value.stride()))
             or not statically_known_true(value.storage_offset() == 0)
         ):
             return False
@@ -5565,19 +5588,12 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         )
 
     def _inline_frame_cache_globals_are_supported(self) -> bool:
-        for inst in self.instructions:
-            if inst.opname in ("STORE_GLOBAL", "DELETE_GLOBAL"):
-                return False
-            if inst.opname != "LOAD_GLOBAL":
-                continue
-            name = inst.argval
-            if not isinstance(name, str) or name not in self.f_globals:
-                continue
-            if name in self.symbolic_globals:
-                return False
-            if not _inline_frame_cache_global_value_is_supported(self.f_globals[name]):
-                return False
-        return True
+        return (
+            self._inline_frame_cache_static_globals_supported
+            and self._inline_frame_cache_loaded_global_names.isdisjoint(
+                self.symbolic_globals
+            )
+        )
 
     def _maybe_replay_inline_frame_cache(self) -> VariableTracker | None:
         if not self._inline_frame_cache_is_enabled():
@@ -6140,6 +6156,10 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         self.funcvar = funcvar
         self.parent = parent
         side_effects = self.output.side_effects
+        (
+            self._inline_frame_cache_static_globals_supported,
+            self._inline_frame_cache_loaded_global_names,
+        ) = _inline_frame_cache_analyze_globals(self.instructions, self.f_globals)
         if self._inline_frame_cache_is_enabled():
             self._inline_frame_cache_start_node = next(
                 reversed(parent.output.current_tracer.graph.nodes), None
@@ -6165,6 +6185,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 _inline_frame_cache_store_attr_mutation_keys(side_effects)
             )
         else:
+            # Locals may be lazy at construction and realized before the store path.
             self._inline_frame_cache_start_node = None
             self._inline_frame_cache_tracked_side_effect_ids = frozenset()
             self._inline_frame_cache_modified_side_effect_ids = frozenset()

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5591,14 +5591,18 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
     _inline_frame_cache_tensor_hook_ids: frozenset[int]
     _inline_frame_cache_store_attr_mutation_keys: frozenset[tuple[int, str, int]]
 
-    def _inline_frame_cache_is_enabled(self) -> bool:
+    def _inline_frame_cache_can_be_enabled(self) -> bool:
         return not (
             is_generator(self.f_code)
             or self.parent.strict_checks_fn
             or config.use_graph_deduplication
             or config.track_nodes_for_deduplication
             or self.output.current_tracer.parent is not None
-            or not _inline_frame_cache_locals_have_tensor(self.symbolic_locals)
+        )
+
+    def _inline_frame_cache_is_enabled(self) -> bool:
+        return self._inline_frame_cache_can_be_enabled() and (
+            _inline_frame_cache_locals_have_tensor(self.symbolic_locals)
         )
 
     def _inline_frame_cache_globals_are_supported(self) -> bool:
@@ -5807,6 +5811,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         cache_entry = self.output.tracing_context.inlined_code_cache.get(self.f_code)
         if cache_entry is None:
             return
+        # RestartAnalysis retries use a fresh TracingContext and InlinedCodeCache, so
+        # entries stored here cannot leak from an abandoned trace attempt.
         cache_entry.inline_frame_cache = InlinedFrameCache(
             key=key,
             nodes=new_nodes,
@@ -6188,11 +6194,16 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         self.funcvar = funcvar
         self.parent = parent
         side_effects = self.output.side_effects
-        (
-            self._inline_frame_cache_static_globals_supported,
-            self._inline_frame_cache_loaded_global_names,
-        ) = _inline_frame_cache_analyze_globals(self.instructions, self.f_globals)
-        # Locals may be lazy at construction and realized before the store path.
+        if self._inline_frame_cache_can_be_enabled():
+            (
+                self._inline_frame_cache_static_globals_supported,
+                self._inline_frame_cache_loaded_global_names,
+            ) = _inline_frame_cache_analyze_globals(self.instructions, self.f_globals)
+        else:
+            self._inline_frame_cache_static_globals_supported = False
+            self._inline_frame_cache_loaded_global_names = frozenset()
+        # Locals may be lazy at construction and realized before the store path, so
+        # capture the graph position even while the cache is temporarily disabled.
         self._inline_frame_cache_start_node = next(
             reversed(parent.output.current_tracer.graph.nodes), None
         )
@@ -6218,6 +6229,9 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 _inline_frame_cache_store_attr_mutation_keys(side_effects)
             )
         else:
+            # These conservative defaults still matter if lazy locals make this frame
+            # eligible by the store path; they prevent silently ignoring pre-existing
+            # side effects captured before eligibility became knowable.
             self._inline_frame_cache_tracked_side_effect_ids = frozenset()
             self._inline_frame_cache_modified_side_effect_ids = frozenset()
             self._inline_frame_cache_had_existing_dict_mutation = False

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1054,6 +1054,9 @@ class InlinedCodeCache:
     instructions: list[Any]
     indexof: dict[Any, int]
     code_options: dict[str, Any]
+    inline_frame_cache_global_instruction_analysis: (
+        tuple[bool, frozenset[str]] | None
+    ) = None
     inline_frame_cache: InlinedFrameCache | None = None
 
 

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1038,12 +1038,22 @@ class CompileContext:
 
 
 @dataclass
+class InlinedFrameCache:
+    """Monomorphic cache entry for a successfully traced inline frame."""
+
+    key: Any
+    nodes: list[Any]
+    result: Any
+
+
+@dataclass
 class InlinedCodeCache:
     """Cache for code-object-derived data used during inlining."""
 
     instructions: list[Any]
     indexof: dict[Any, int]
     code_options: dict[str, Any]
+    inline_frame_cache: InlinedFrameCache | None = None
 
 
 class TracingContext:

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1044,6 +1044,7 @@ class InlinedFrameCache:
     key: Any
     nodes: list[Any]
     result: Any
+    f_globals_id: int
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Extend the existing inlined-code cache with one monomorphic inline-frame specialization per inlined code object.
- Replay cached leaf inline frames by cloning their FX nodes and fresh fake tensor metadata when locals match the cached specialization.
- Keep caching conservative: skip generators, nested subgraph tracers, strict checks, graph dedup tracking, nested inline frames, mutable FX nodes, existing side-effect mutations, mutable globals, and constant-only leaf frames with no FX nodes to replay.
- Clone replayed tensor and constant VariableTracker results so cached entries are not returned directly.
- Add Dynamo coverage that counts actual leaf inline bytecode runs, checks replayed tensor results remain fresh, and verifies cache bypasses for unsafe specialization changes.

## Root cause problem
`InliningInstructionTranslator` currently reuses only code-object-derived data (`instructions`, `indexof`, and `code_options`). Repeated calls to the same leaf helper still rebuild and run an inline bytecode frame every time, which repeatedly pays `inline_call_`, `wrap_fx_proxy`, and `get_fake_value` costs even for monomorphic repeated calls.

## Proposed fix
Cache a successfully traced leaf inline frame on the existing `InlinedCodeCache` entry. On a later call with the same local VariableTracker specialization, replay the cached FX nodes into the current graph and remap the cached result to those fresh nodes instead of rerunning the inline bytecode. The cache is skipped for frames that do not create FX nodes, mutate existing side-effect state, read mutable globals, or otherwise produce unsupported replay metadata/results.

## Why this is the right long term fix
This keeps the optimization local to Dynamo’s inline-frame machinery and extends the existing per-code cache instead of adding a separate cache path. The replay path is intentionally conservative and only caches cases whose graph fragment can be cloned without existing side effects or mutable operations, which gives the hot monomorphic leaf-helper case a reusable fast path while preserving the normal tracer for anything more complex.

## Validation
- `USE_NIGHTLY=2.13.0.dev20260428+cpu python setup.py develop` in Python 3.10 and Python 3.13 CPU virtualenvs.
- `python -m pytest test/dynamo/test_functions.py -k monomorphic_inline_frame_cache -q` passed: 13 passed.
- The two newest tests fail when their corresponding cache protections are temporarily removed.
- `PYTHONPATH=/tmp/cpython-3.13.13/Lib python -m pytest test/dynamo/cpython/3_13/test_exceptions.py -k test_unicode_error_str_does_not_crash -q` passed: 1 passed, 101 deselected, 2100 subtests passed.
- `python3 -m py_compile torch/_guards.py torch/_dynamo/symbolic_convert.py test/dynamo/test_functions.py`
- `git diff --check`
- `lintrunner --take PYFMT,FLAKE8,RUFF torch/_dynamo/symbolic_convert.py test/dynamo/test_functions.py`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98

Drafted via Codex, published after manual review by @bobrenjc93