### PR TITLE
[dynamo] Make invoke_subgraph reuse cache persistent

### DIFF
--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -986,6 +986,49 @@ class outer_fn(torch.nn.Module):
 """,
         )
 
+    def test_nested_compile_region_cache_persists_across_traces(self):
+        torch._dynamo.reset()
+
+        from torch._dynamo.testing import CompileCounter
+        from torch._dynamo.variables.invoke_subgraph import (
+            InvokeSubgraphHigherOrderVariable,
+        )
+
+        @torch.compiler.nested_compile_region
+        def helper(x):
+            return x.sin() * 2
+
+        def outer1(x, y):
+            return helper(x) + helper(y)
+
+        def outer2(x, y):
+            return helper(x) + helper(y)
+
+        x = torch.randn(3, 3)
+        y = torch.randn(3, 3)
+        cnt = CompileCounter()
+        trace_count = 0
+        original = InvokeSubgraphHigherOrderVariable.create_wrapped_node
+
+        def counted_create_wrapped_node(self, *args, **kwargs):
+            nonlocal trace_count
+            trace_count += 1
+            return original(self, *args, **kwargs)
+
+        with patch.object(
+            InvokeSubgraphHigherOrderVariable,
+            "create_wrapped_node",
+            counted_create_wrapped_node,
+        ):
+            actual1 = torch.compile(outer1, backend=cnt, fullgraph=True)(x, y)
+            self.assertEqual(trace_count, 1)
+            actual2 = torch.compile(outer2, backend=cnt, fullgraph=True)(x, y)
+
+        expected = x.sin() * 2 + y.sin() * 2
+        self.assertEqual(actual1, expected)
+        self.assertEqual(actual2, expected)
+        self.assertEqual(trace_count, 1)
+
     @torch._functorch.config.patch(guess_tangent_strides_as_outputs=True)
     @torch._dynamo.config.patch(force_compile_during_fx_trace=True)
     def test_invoke_subgraph_seq_nr(self):

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -987,8 +987,6 @@ class outer_fn(torch.nn.Module):
         )
 
     def test_nested_compile_region_cache_persists_across_traces(self):
-        torch._dynamo.reset()
-
         from torch._dynamo.testing import CompileCounter
         from torch._dynamo.variables.invoke_subgraph import (
             InvokeSubgraphHigherOrderVariable,
@@ -1023,11 +1021,14 @@ class outer_fn(torch.nn.Module):
             actual1 = torch.compile(outer1, backend=cnt, fullgraph=True)(x, y)
             self.assertEqual(trace_count, 1)
             actual2 = torch.compile(outer2, backend=cnt, fullgraph=True)(x, y)
+            torch._dynamo.reset()
+            actual3 = torch.compile(outer2, backend=cnt, fullgraph=True)(x, y)
 
         expected = x.sin() * 2 + y.sin() * 2
         self.assertEqual(actual1, expected)
         self.assertEqual(actual2, expected)
-        self.assertEqual(trace_count, 1)
+        self.assertEqual(actual3, expected)
+        self.assertEqual(trace_count, 2)
 
     @torch._functorch.config.patch(guess_tangent_strides_as_outputs=True)
     @torch._dynamo.config.patch(force_compile_during_fx_trace=True)

--- a/test/dynamo/test_modes.py
+++ b/test/dynamo/test_modes.py
@@ -1021,6 +1021,7 @@ class outer_fn(torch.nn.Module):
             actual1 = torch.compile(outer1, backend=cnt, fullgraph=True)(x, y)
             self.assertEqual(trace_count, 1)
             actual2 = torch.compile(outer2, backend=cnt, fullgraph=True)(x, y)
+            self.assertEqual(trace_count, 1)
             torch._dynamo.reset()
             actual3 = torch.compile(outer2, backend=cnt, fullgraph=True)(x, y)
 

--- a/torch/_dynamo/__init__.py
+++ b/torch/_dynamo/__init__.py
@@ -203,6 +203,9 @@ def reset_code_caches() -> None:
             if code:
                 reset_code(code)
         code_context.clear()
+        from torch._guards import reset_invoke_subgraph_reuse_cache
+
+        reset_invoke_subgraph_reuse_cache()
 
 
 def get_recursion_limit() -> int:

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -1047,6 +1047,10 @@ def stamp_out_subgraph(
         # In the original trace the cached module may already be installed;
         # in a later trace we register it under the cached name when possible
         # so proxy-dispatch tracing can reuse its identifier-based cache.
+        # The GraphModule object is intentionally shared across traces rather
+        # than deep-copied. Registration stores the object by reference; later
+        # __name__ writes are only lookup bookkeeping for the active OutputGraph
+        # after a module has been registered.
         if remapped_name is not None:
             body_name = remapped_name
         elif tx.output.nn_modules.get(body_name) is cached.body_gmod:

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -4,7 +4,6 @@ supporting helpers for subgraph reuse (auto-cache) in Dynamo's invoke_subgraph
 higher-order operator.
 """
 
-import copy
 import enum
 import logging
 import traceback
@@ -343,6 +342,17 @@ class LiftedBoundSymbol:
 LiftedArgOrigin = (
     LiftedUserArg | LiftedCapturedSource | LiftedSyntheticObject | LiftedBoundSymbol
 )
+
+
+def graph_has_free_unbacked_symbols(gm: torch.fx.GraphModule) -> bool:
+    from torch.fx.experimental.symbolic_shapes import has_free_unbacked_symbols
+
+    for node in gm.graph.nodes:
+        for key in ("example_value", "val", "unbacked_bindings"):
+            value = node.meta.get(key)
+            if value is not None and has_free_unbacked_symbols(value):
+                return True
+    return False
 
 
 def get_fn_code(fn_var: Any) -> types.CodeType | None:
@@ -764,7 +774,7 @@ def has_reuse_entries(
     if not isinstance(invoke_subgraph_cache, InvokeSubgraphCache):
         return False
     fn_code = get_fn_code(fn_var)
-    return fn_code is not None and fn_code in invoke_subgraph_cache.subgraph_reuse_cache
+    return fn_code is not None and invoke_subgraph_cache.has_reuse_entries(fn_code)
 
 
 def find_reuse_match(
@@ -876,6 +886,7 @@ def save_reuse_entry(
         # rewrite captured variable sources for the current invocation.
         arg_sources=fingerprint.arg_sources,
         num_user_outputs=num_user_outputs,
+        has_free_unbacked_symbols=graph_has_free_unbacked_symbols(body_gmod),
     )
     if condition is not None:
         invoke_subgraph_cache.add_reuse_entry(
@@ -1033,14 +1044,24 @@ def stamp_out_subgraph(
         remapped_name = invoke_subgraph_cache.installed_reuse_subgraphs.get(
             cached.reuse_id
         )
+        # In the original trace the cached module may already be installed;
+        # in a later trace we register it under the cached name when possible
+        # so proxy-dispatch tracing can reuse its identifier-based cache.
         if remapped_name is not None:
             body_name = remapped_name
         elif tx.output.nn_modules.get(body_name) is cached.body_gmod:
             invoke_subgraph_cache.installed_reuse_subgraphs[cached.reuse_id] = body_name
+        elif body_name not in tx.output.nn_modules:
+            cached.body_gmod.__name__ = body_name  # type: ignore[assignment]
+            cached.body_gmod.torchdynamo_force_dynamic = False  # type: ignore[assignment]
+            tx.output.register_attr_or_module(cached.body_gmod, body_name, source=None)
+            for name, mod in tx.output.nn_modules.items():
+                if mod is cached.body_gmod:
+                    body_name = name
+                    break
+            invoke_subgraph_cache.installed_reuse_subgraphs[cached.reuse_id] = body_name
         else:
-            body_name = tx.output.install_subgraph(
-                cached.body_name, copy.deepcopy(cached.body_gmod)
-            )
+            body_name = tx.output.install_subgraph(cached.body_name, cached.body_gmod)
             invoke_subgraph_cache.installed_reuse_subgraphs[cached.reuse_id] = body_name
 
     body_node = make_attr(tx, body_name)

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -289,6 +289,20 @@ def get_flat_proxies(fingerprint: InputFingerprint) -> list[Proxy]:
     return flat_proxies
 
 
+def build_input_aliases(fingerprint: InputFingerprint) -> list[int | None]:
+    """Record tensor/symnode aliasing by flattened input position."""
+    node_to_first_idx: dict[torch.fx.Node, int] = {}
+    aliases: list[int | None] = []
+    for idx, (tag, vt) in enumerate(fingerprint.flat_vts):
+        if tag in (InputTag.TENSOR, InputTag.SYMNODE):
+            node = vt.as_proxy().node
+            first_idx = node_to_first_idx.setdefault(node, idx)
+            aliases.append(first_idx)
+        else:
+            aliases.append(None)
+    return aliases
+
+
 @dataclass
 class LiftedUserArg:
     """Lifted arg that came from a user argument (intermediate activation or explicit input)."""
@@ -496,10 +510,14 @@ def build_reuse_condition(
     for source in all_sources:
         all_relevant_guards.update(tx.output.guards.get_guards_for_source(source))
 
+    explicit_arg_sources = {s for s in fingerprint.arg_sources if s is not None}
     guard_tuples: list[tuple[Source, GuardCheckSpec, object, Guard]] = []
     for guard in all_relevant_guards:
         source = guard.originating_source
         type_str = guard.create_fn_name()
+        if type_str == "TENSOR_MATCH" and source in explicit_arg_sources:
+            continue
+
         handler = GUARD_VALUE_DISPATCH.get(type_str)
 
         if handler is SKIP_GUARD:
@@ -532,6 +550,7 @@ def build_reuse_condition(
         input_checks=input_checks,
         guards=guard_tuples,
         treespec=fingerprint.treespec,
+        input_aliases=build_input_aliases(fingerprint),
         traced_sources=traced_sources,
     )
 
@@ -584,6 +603,11 @@ def is_reusable(
             len(condition.input_checks),
             len(fingerprint.flat_vts),
         )
+        return False
+
+    input_aliases = build_input_aliases(fingerprint)
+    if condition.input_aliases is not None and input_aliases != condition.input_aliases:
+        hc_log.debug("subgraph_reuse: reuse failed -- input aliasing mismatch")
         return False
 
     for i, ((cached_tag, cached_val), (cur_tag, cur_vt)) in enumerate(
@@ -915,9 +939,9 @@ def stamp_out_subgraph(
     source replacement before we can look up or create the corresponding
     graph placeholders.
     """
-    from torch._guards import InvokeSubgraphCache
     from torch._dynamo.variables.builder import VariableBuilder
     from torch._dynamo.variables.higher_order_ops import add_call_function, make_attr
+    from torch._guards import InvokeSubgraphCache
 
     flat_proxies = get_flat_proxies(fingerprint)
     new_arg_sources = fingerprint.arg_sources
@@ -997,17 +1021,18 @@ def stamp_out_subgraph(
         torch._higher_order_ops.invoke_subgraph
     )
     if isinstance(invoke_subgraph_cache, InvokeSubgraphCache):
-        entry_id = id(cached)
-        remapped_name = invoke_subgraph_cache.installed_reuse_subgraphs.get(entry_id)
+        remapped_name = invoke_subgraph_cache.installed_reuse_subgraphs.get(
+            cached.reuse_id
+        )
         if remapped_name is not None:
             body_name = remapped_name
         elif tx.output.nn_modules.get(body_name) is cached.body_gmod:
-            invoke_subgraph_cache.installed_reuse_subgraphs[entry_id] = body_name
+            invoke_subgraph_cache.installed_reuse_subgraphs[cached.reuse_id] = body_name
         else:
             body_name = tx.output.install_subgraph(
                 cached.body_name, copy.deepcopy(cached.body_gmod)
             )
-            invoke_subgraph_cache.installed_reuse_subgraphs[entry_id] = body_name
+            invoke_subgraph_cache.installed_reuse_subgraphs[cached.reuse_id] = body_name
 
     body_node = make_attr(tx, body_name)
     p_args = (body_node, body_name, *new_lifted_args)

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -4,6 +4,7 @@ supporting helpers for subgraph reuse (auto-cache) in Dynamo's invoke_subgraph
 higher-order operator.
 """
 
+import copy
 import enum
 import logging
 import traceback
@@ -19,6 +20,7 @@ from torch._dynamo.guards import (
     extract_tensor_metadata,
     GUARD_VALUE_DISPATCH,
     GuardCheckSpec,
+    install_guard,
     SKIP_GUARD,
     UnsupportedGuardCheckSpec,
 )
@@ -654,11 +656,6 @@ def is_reusable(
     if has_mutated_vars(tx, remapped):
         return False
 
-    # If no sources changed, all guards were already checked during the
-    # original trace and will trivially pass again.
-    if not source_replacement:
-        return True
-
     # Shared resolution context so source.get_value memoizes intermediate
     # results (e.g. common base sources) across all guards in this check.
     resolve_globals: dict[str, Any] = {
@@ -667,13 +664,10 @@ def is_reusable(
     }
     resolve_locals: dict[str, Any] = {}
     resolve_cache: dict[Source, Any] = {}
+    guards_to_install: list[Guard] = []
 
     for source, handler, expected, guard in condition.guards:
         new_source = source.clone(replacement_fn)
-        # Source unchanged after replacement — guard already passed during
-        # the original trace, skip re-evaluation.
-        if new_source == source:
-            continue
 
         try:
             value = new_source.get_value(resolve_globals, resolve_locals, resolve_cache)
@@ -712,6 +706,14 @@ def is_reusable(
                 else "<no stack>",
             )
             return False
+
+        new_guard = new_source.make_guard(guard.create_fn)
+        new_guard.stack = guard.stack
+        new_guard.user_stack = guard.user_stack
+        guards_to_install.append(new_guard)
+
+    if guards_to_install:
+        install_guard(*guards_to_install)
 
     return True
 
@@ -913,6 +915,7 @@ def stamp_out_subgraph(
     source replacement before we can look up or create the corresponding
     graph placeholders.
     """
+    from torch._guards import InvokeSubgraphCache
     from torch._dynamo.variables.builder import VariableBuilder
     from torch._dynamo.variables.higher_order_ops import add_call_function, make_attr
 
@@ -989,8 +992,25 @@ def stamp_out_subgraph(
         )
 
     # Install the invoke_subgraph call
-    body_node = make_attr(tx, cached.body_name)
-    p_args = (body_node, cached.body_name, *new_lifted_args)
+    body_name = cached.body_name
+    invoke_subgraph_cache = tx.output.tracing_context.hop_dispatch_set_cache.get_cache(
+        torch._higher_order_ops.invoke_subgraph
+    )
+    if isinstance(invoke_subgraph_cache, InvokeSubgraphCache):
+        entry_id = id(cached)
+        remapped_name = invoke_subgraph_cache.installed_reuse_subgraphs.get(entry_id)
+        if remapped_name is not None:
+            body_name = remapped_name
+        elif tx.output.nn_modules.get(body_name) is cached.body_gmod:
+            invoke_subgraph_cache.installed_reuse_subgraphs[entry_id] = body_name
+        else:
+            body_name = tx.output.install_subgraph(
+                cached.body_name, copy.deepcopy(cached.body_gmod)
+            )
+            invoke_subgraph_cache.installed_reuse_subgraphs[entry_id] = body_name
+
+    body_node = make_attr(tx, body_name)
+    p_args = (body_node, body_name, *new_lifted_args)
     flat_variable = add_call_function(
         tx,
         torch._higher_order_ops.invoke_subgraph,

--- a/torch/_dynamo/variables/invoke_subgraph.py
+++ b/torch/_dynamo/variables/invoke_subgraph.py
@@ -692,6 +692,7 @@ def is_reusable(
 
     for source, handler, expected, guard in condition.guards:
         new_source = source.clone(replacement_fn)
+        guard_type = guard.create_fn_name()
 
         try:
             value = new_source.get_value(resolve_globals, resolve_locals, resolve_cache)
@@ -702,7 +703,7 @@ def is_reusable(
                 "  guard source: %s\n"
                 "  guard source name: %s\n"
                 "  user stack:\n%s",
-                guard.create_fn_name(),
+                guard_type,
                 new_source,
                 new_source.name,
                 "".join(guard.user_stack.format())
@@ -720,7 +721,7 @@ def is_reusable(
                 "  expected: %s\n"
                 "  got: %s\n"
                 "  user stack:\n%s",
-                guard.create_fn_name(),
+                guard_type,
                 new_source,
                 new_source.name,
                 expected,
@@ -730,6 +731,14 @@ def is_reusable(
                 else "<no stack>",
             )
             return False
+
+        # TENSOR_MATCH guards are validated above but not replayed here:
+        # explicit tensor inputs are covered by input_checks/input_aliases, and
+        # captured tensor sources are rewrapped by stamp_out_subgraph's
+        # VariableBuilder, which installs the current trace's tensor guard.
+        # Replaying the cached guard as well can duplicate no-alias sources.
+        if guard_type == "TENSOR_MATCH":
+            continue
 
         new_guard = new_source.make_guard(guard.create_fn)
         new_guard.stack = guard.stack

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -4,6 +4,7 @@ import contextlib
 import dataclasses
 import enum
 import functools
+import itertools
 import logging
 import re
 import threading
@@ -28,6 +29,13 @@ from torch.utils.weak import WeakTensorKeyDictionary
 log = logging.getLogger(__name__)
 
 
+_invoke_subgraph_reuse_entry_counter = itertools.count()
+
+
+def _next_invoke_subgraph_reuse_entry_id() -> int:
+    return next(_invoke_subgraph_reuse_entry_counter)
+
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterator
     from types import CodeType
@@ -37,6 +45,7 @@ if TYPE_CHECKING:
     from torch._dynamo.backends.distributed import DDPOptimizerContext
     from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.guards import GuardCheckSpec
+    from torch._dynamo.utils import ExactWeakKeyDictionary
     from torch._functorch._aot_autograd.schemas import ViewAndMutationMeta
     from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
     from torch._subclasses.fake_tensor import FakeTensorMode
@@ -798,6 +807,11 @@ class InvokeSubgraphReuseEntry:
     # The graph may have additional outputs from side-effect intermediates;
     # stamp_out_subgraph uses this to return only the user-visible slice.
     num_user_outputs: int = 0
+    # Stable identity for per-trace remapping of a persistent cache entry.
+    # Avoids using id(entry), whose value can be reused after object deletion.
+    reuse_id: int = dataclasses.field(
+        default_factory=_next_invoke_subgraph_reuse_entry_id
+    )
 
 
 @dataclass
@@ -821,6 +835,11 @@ class InvokeSubgraphReuseCondition:
     # On cache hit, we verify the new call has the same treespec.
     treespec: pytree.TreeSpec | None = None
 
+    # Per flattened input VT: first flattened index with the same proxy node, or
+    # None for non-proxy inputs. This preserves tensor/symnode aliasing
+    # contracts without replaying TENSOR_MATCH guards for explicit inputs.
+    input_aliases: list[int | None] | None = None
+
     # All sources accessed via VariableBuilder during the subgraph trace.
     # On cache hit, we check if any modified VT's source is a base of one
     # of these to detect mutations on captured variables.
@@ -828,15 +847,43 @@ class InvokeSubgraphReuseCondition:
 
 
 class InvokeSubgraphCache(HopSubgraphCache):
-    _persistent_subgraph_reuse_cache: weakref.WeakKeyDictionary[
-        Any,
-        list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]],
-    ] = weakref.WeakKeyDictionary()
-    _persistent_subgraph_reuse_key_cache: weakref.WeakKeyDictionary[
-        Any, dict[int, InvokeSubgraphReuseEntry]
-    ] = weakref.WeakKeyDictionary()
+    _persistent_subgraph_reuse_cache: Any = None
+    _persistent_subgraph_reuse_key_cache: Any = None
+
+    @staticmethod
+    def _new_code_cache() -> Any:
+        from torch._dynamo.utils import ExactWeakKeyDictionary
+
+        return ExactWeakKeyDictionary()
+
+    @classmethod
+    def _ensure_reuse_caches(cls) -> None:
+        if cls._persistent_subgraph_reuse_cache is None:
+            cls._persistent_subgraph_reuse_cache = cls._new_code_cache()
+        if cls._persistent_subgraph_reuse_key_cache is None:
+            cls._persistent_subgraph_reuse_key_cache = cls._new_code_cache()
+
+    _persistent_subgraph_reuse_cache: Any
+    _persistent_subgraph_reuse_key_cache: Any
+    # Runtime type:
+    # ExactWeakKeyDictionary[
+    #     CodeType,
+    #     list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]],
+    # ]
+    # ExactWeakKeyDictionary[
+    #     CodeType, dict[int, InvokeSubgraphReuseEntry]
+    # ]
+    if TYPE_CHECKING:
+        _persistent_subgraph_reuse_cache: ExactWeakKeyDictionary[
+            CodeType,
+            list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]],
+        ]
+        _persistent_subgraph_reuse_key_cache: ExactWeakKeyDictionary[
+            CodeType, dict[int, InvokeSubgraphReuseEntry]
+        ]
 
     def __init__(self) -> None:
+        self._ensure_reuse_caches()
         self.autograd_cache: dict[str, Callable] = {}
         self.proxy_dispatch_cache: dict[str, Callable] = {}
         self.dynamo_installed_submodules: dict[CodeType, list[str]] = defaultdict(list)
@@ -858,6 +905,7 @@ class InvokeSubgraphCache(HopSubgraphCache):
 
     @classmethod
     def reset_reuse_cache(cls) -> None:
+        cls._ensure_reuse_caches()
         cls._persistent_subgraph_reuse_cache.clear()
         cls._persistent_subgraph_reuse_key_cache.clear()
 

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -828,6 +828,14 @@ class InvokeSubgraphReuseCondition:
 
 
 class InvokeSubgraphCache(HopSubgraphCache):
+    _persistent_subgraph_reuse_cache: weakref.WeakKeyDictionary[
+        Any,
+        list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]],
+    ] = weakref.WeakKeyDictionary()
+    _persistent_subgraph_reuse_key_cache: weakref.WeakKeyDictionary[
+        Any, dict[int, InvokeSubgraphReuseEntry]
+    ] = weakref.WeakKeyDictionary()
+
     def __init__(self) -> None:
         self.autograd_cache: dict[str, Callable] = {}
         self.proxy_dispatch_cache: dict[str, Callable] = {}
@@ -838,17 +846,20 @@ class InvokeSubgraphCache(HopSubgraphCache):
         self.effects_cache: dict[
             str, set
         ] = {}  # Maps identifier -> set of effect types
-        # fn.__code__ → list of (condition, cache_entry) pairs. Walked linearly
-        # on lookup; first matching condition wins.
-        self.subgraph_reuse_cache: dict[
-            CodeType,
-            list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]],
-        ] = defaultdict(list)
-        # fn_code → {hash_key → cache_entry}. Used by user-provided
-        # reuse_hash_fn for O(1) subgraph reuse lookup.
-        self.subgraph_reuse_key_cache: dict[
-            CodeType, dict[int, InvokeSubgraphReuseEntry]
-        ] = defaultdict(dict)
+        # Process-persistent fn.__code__ → list of (condition, cache_entry)
+        # pairs. Walked linearly on lookup; first matching condition wins.
+        self.subgraph_reuse_cache = self._persistent_subgraph_reuse_cache
+        # Process-persistent fn_code → {hash_key → cache_entry}. Used by
+        # user-provided reuse_hash_fn for O(1) subgraph reuse lookup.
+        self.subgraph_reuse_key_cache = self._persistent_subgraph_reuse_key_cache
+        # Per tracing context remap from persistent cache entries to the subgraph
+        # name installed in the current OutputGraph.
+        self.installed_reuse_subgraphs: dict[int, str] = {}
+
+    @classmethod
+    def reset_reuse_cache(cls) -> None:
+        cls._persistent_subgraph_reuse_cache.clear()
+        cls._persistent_subgraph_reuse_key_cache.clear()
 
     def add_dynamo_installed_submodule(
         self, fn_code: CodeType, identifier: str
@@ -912,7 +923,10 @@ class InvokeSubgraphCache(HopSubgraphCache):
         entry: InvokeSubgraphReuseEntry,
         max_reuse_entries: int = 8,
     ) -> None:
-        entries = self.subgraph_reuse_cache[fn_code]
+        entries = self.subgraph_reuse_cache.get(fn_code)
+        if entries is None:
+            entries = []
+            self.subgraph_reuse_cache[fn_code] = entries
         if len(entries) >= max_reuse_entries:
             raise RuntimeError(
                 f"invoke_subgraph: exceeded maximum reuse entries "
@@ -954,7 +968,10 @@ class InvokeSubgraphCache(HopSubgraphCache):
         entry: InvokeSubgraphReuseEntry,
         max_reuse_entries: int = 8,
     ) -> None:
-        key_cache = self.subgraph_reuse_key_cache[fn_code]
+        key_cache = self.subgraph_reuse_key_cache.get(fn_code)
+        if key_cache is None:
+            key_cache = {}
+            self.subgraph_reuse_key_cache[fn_code] = key_cache
         if len(key_cache) >= max_reuse_entries and hash_key not in key_cache:
             raise RuntimeError(
                 f"invoke_subgraph: exceeded maximum reuse entries "
@@ -963,6 +980,10 @@ class InvokeSubgraphCache(HopSubgraphCache):
                 f"nested_compile_region()."
             )
         key_cache[hash_key] = entry
+
+
+def reset_invoke_subgraph_reuse_cache() -> None:
+    InvokeSubgraphCache.reset_reuse_cache()
 
 
 class HopDispatchSetCache:

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
     from torch._dynamo.backends.distributed import DDPOptimizerContext
     from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.guards import GuardCheckSpec
-    from torch._dynamo.utils import ExactWeakKeyDictionary
     from torch._functorch._aot_autograd.schemas import ViewAndMutationMeta
     from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
     from torch._subclasses.fake_tensor import FakeTensorMode
@@ -847,6 +846,14 @@ class InvokeSubgraphReuseCondition:
 
 
 class InvokeSubgraphCache(HopSubgraphCache):
+    # Runtime types:
+    # ExactWeakKeyDictionary[
+    #     CodeType,
+    #     list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]],
+    # ]
+    # ExactWeakKeyDictionary[
+    #     CodeType, dict[int, InvokeSubgraphReuseEntry]
+    # ]
     _persistent_subgraph_reuse_cache: Any = None
     _persistent_subgraph_reuse_key_cache: Any = None
 
@@ -862,25 +869,6 @@ class InvokeSubgraphCache(HopSubgraphCache):
             cls._persistent_subgraph_reuse_cache = cls._new_code_cache()
         if cls._persistent_subgraph_reuse_key_cache is None:
             cls._persistent_subgraph_reuse_key_cache = cls._new_code_cache()
-
-    _persistent_subgraph_reuse_cache: Any
-    _persistent_subgraph_reuse_key_cache: Any
-    # Runtime type:
-    # ExactWeakKeyDictionary[
-    #     CodeType,
-    #     list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]],
-    # ]
-    # ExactWeakKeyDictionary[
-    #     CodeType, dict[int, InvokeSubgraphReuseEntry]
-    # ]
-    if TYPE_CHECKING:
-        _persistent_subgraph_reuse_cache: ExactWeakKeyDictionary[
-            CodeType,
-            list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]],
-        ]
-        _persistent_subgraph_reuse_key_cache: ExactWeakKeyDictionary[
-            CodeType, dict[int, InvokeSubgraphReuseEntry]
-        ]
 
     def __init__(self) -> None:
         self._ensure_reuse_caches()

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -811,6 +811,10 @@ class InvokeSubgraphReuseEntry:
     reuse_id: int = dataclasses.field(
         default_factory=_next_invoke_subgraph_reuse_entry_id
     )
+    # GraphModules carrying unbacked symbols in FX metadata are tied to the
+    # ShapeEnv that created those symbols, so they cannot be reused across
+    # tracing contexts without retracing.
+    has_free_unbacked_symbols: bool = False
 
 
 @dataclass
@@ -881,6 +885,15 @@ class InvokeSubgraphCache(HopSubgraphCache):
         self.effects_cache: dict[
             str, set
         ] = {}  # Maps identifier -> set of effect types
+        # ShapeEnv-scoped entries, such as graphs with unbacked symbols, stay
+        # local to the tracing context. Process-persistent entries live below.
+        self.local_subgraph_reuse_cache: dict[
+            CodeType,
+            list[tuple[InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry]],
+        ] = defaultdict(list)
+        self.local_subgraph_reuse_key_cache: dict[
+            CodeType, dict[int, InvokeSubgraphReuseEntry]
+        ] = defaultdict(dict)
         # Process-persistent fn.__code__ → list of (condition, cache_entry)
         # pairs. Walked linearly on lookup; first matching condition wins.
         self.subgraph_reuse_cache = self._persistent_subgraph_reuse_cache
@@ -959,10 +972,15 @@ class InvokeSubgraphCache(HopSubgraphCache):
         entry: InvokeSubgraphReuseEntry,
         max_reuse_entries: int = 8,
     ) -> None:
-        entries = self.subgraph_reuse_cache.get(fn_code)
+        cache = (
+            self.local_subgraph_reuse_cache
+            if entry.has_free_unbacked_symbols
+            else self.subgraph_reuse_cache
+        )
+        entries = cache.get(fn_code)
         if entries is None:
             entries = []
-            self.subgraph_reuse_cache[fn_code] = entries
+            cache[fn_code] = entries
         if len(entries) >= max_reuse_entries:
             raise RuntimeError(
                 f"invoke_subgraph: exceeded maximum reuse entries "
@@ -983,18 +1001,22 @@ class InvokeSubgraphCache(HopSubgraphCache):
             [InvokeSubgraphReuseCondition, InvokeSubgraphReuseEntry], bool
         ],
     ) -> InvokeSubgraphReuseEntry | None:
-        entries = self.subgraph_reuse_cache.get(fn_code, [])
-        for i, (condition, entry) in enumerate(entries):
-            if evaluator(condition, entry):
-                # MRU: move the hit entry to the front for faster future lookups
-                if i > 0:
-                    entries.insert(0, entries.pop(i))
-                return entry
+        for cache in (self.local_subgraph_reuse_cache, self.subgraph_reuse_cache):
+            entries = cache.get(fn_code, [])
+            for i, (condition, entry) in enumerate(entries):
+                if evaluator(condition, entry):
+                    # MRU: move the hit entry to the front for faster future lookups
+                    if i > 0:
+                        entries.insert(0, entries.pop(i))
+                    return entry
         return None
 
     def find_reuse_entry_by_key(
         self, fn_code: CodeType, hash_key: int
     ) -> InvokeSubgraphReuseEntry | None:
+        local_entry = self.local_subgraph_reuse_key_cache.get(fn_code, {}).get(hash_key)
+        if local_entry is not None:
+            return local_entry
         return self.subgraph_reuse_key_cache.get(fn_code, {}).get(hash_key)
 
     def add_reuse_entry_by_key(
@@ -1004,10 +1026,15 @@ class InvokeSubgraphCache(HopSubgraphCache):
         entry: InvokeSubgraphReuseEntry,
         max_reuse_entries: int = 8,
     ) -> None:
-        key_cache = self.subgraph_reuse_key_cache.get(fn_code)
+        cache = (
+            self.local_subgraph_reuse_key_cache
+            if entry.has_free_unbacked_symbols
+            else self.subgraph_reuse_key_cache
+        )
+        key_cache = cache.get(fn_code)
         if key_cache is None:
             key_cache = {}
-            self.subgraph_reuse_key_cache[fn_code] = key_cache
+            cache[fn_code] = key_cache
         if len(key_cache) >= max_reuse_entries and hash_key not in key_cache:
             raise RuntimeError(
                 f"invoke_subgraph: exceeded maximum reuse entries "
@@ -1016,6 +1043,12 @@ class InvokeSubgraphCache(HopSubgraphCache):
                 f"nested_compile_region()."
             )
         key_cache[hash_key] = entry
+
+    def has_reuse_entries(self, fn_code: CodeType) -> bool:
+        return bool(
+            self.local_subgraph_reuse_cache.get(fn_code)
+            or self.subgraph_reuse_cache.get(fn_code)
+        )
 
 
 def reset_invoke_subgraph_reuse_cache() -> None:


### PR DESCRIPTION
Summary:
- Make the invoke_subgraph reuse cache process-persistent instead of scoped to one TracingContext.
- Store persistent CodeType caches in ExactWeakKeyDictionary so structurally equal code objects do not alias.
- Re-check cached guards on reuse, but do not replay TENSOR_MATCH guards; explicit tensor inputs are covered by input metadata/alias checks, and captured tensors are guarded when stamp_out_subgraph rewraps them for the active trace.
- Keep ShapeEnv-scoped entries with free unbacked symbols local to the tracing context, while safe entries remain process-persistent.
- Preserve cached subgraph names when stamping into a fresh trace so proxy-dispatch export caching deduplicates repeated subgraphs.
- Use a stable reuse entry id when remapping cached subgraphs into each active OutputGraph.
- Add a Dynamo test that verifies reuse across independent outer traces and that torch._dynamo.reset() clears the persistent reuse cache.

Root cause problem:
Dynamo already records an abstract invoke_subgraph trace with input fingerprints, source-remapped guards, and lifted placeholder mappings, but the storage lived on each TracingContext. Once a trace ended, the summary was unavailable to later traces, so helper-heavy code paid the tracing cost again.

Making that cache persistent exposed correctness details: CodeType keys need identity-based weak lookup, replayed tensor guards can duplicate same-frame no-alias guard inputs, explicit input tensor aliasing needs to be validated as part of the input fingerprint, and FX GraphModules carrying unbacked-symbol metadata are tied to the ShapeEnv that created those symbols. Export also keys proxy-dispatch subgraph reuse by identifier, so cross-trace stamp-out must keep the cached identifier when it can.

Proposed fix:
Move safe invoke_subgraph reuse entries to an ExactWeakKeyDictionary-backed process cache keyed by function code, keep ShapeEnv-scoped unbacked-symbol entries in per-TracingContext local caches, and make cache hits validate cached guard metadata before stamping the subgraph into the active OutputGraph. Cache entries now carry a stable reuse id and a free-unbacked-symbol marker, reuse conditions store the flattened explicit input alias signature, and cache hits skip TENSOR_MATCH guard replay after validation so the active trace installs exactly one tensor guard for each explicit or captured tensor source.

Why this is the right long term fix:
The existing invoke_subgraph summary format is already the Dynamo representation that knows how to parameterize sources, validate guards, and stamp out placeholders. Persisting only ShapeEnv-independent entries keeps the cache at the abstract-trace layer without leaking ShapeEnv-local FX metadata across traces, while identity-keyed code caches, explicit alias signatures, and single-owner tensor guard installation preserve the same correctness boundaries Dynamo relies on elsewhere. reset_code_caches still gives users and tests a clean process state.

Testing:
- Built a binary-backed CPU editable install with `USE_NIGHTLY=2.13.0.dev20260428+cpu python -m pip install --no-build-isolation -v -e .`
- Per test-validation workflow, temporarily reverted the earlier implementation patch and verified the new regression test fails without the fix with: AssertionError: Guard failed on the same frame it was created ... Duplicate tensors found: ["y", "y"]
- `PYTHONPATH=$PWD:$PWD/test python test/higher_order_ops/test_invoke_subgraph.py -v` (125 tests, 7 skipped)
- `PYTHONPATH=$PWD:$PWD/test python test/higher_order_ops/test_invoke_subgraph.py TestInvokeSubgraphExportNonstrict.test_multiple_module TestInvokeSubgraphExportNonstrict.test_pending_unbacked TestInvokeSubgraphExportStrict.test_pending_unbacked -v`
- `PYTHONPATH=$PWD:$PWD/test python test/higher_order_ops/test_invoke_subgraph.py TestInvokeSubgraphCompile.test_buffer_mutation_works_under_no_grad -v`
- `PYTHONPATH=$PWD:$PWD/test python test/dynamo/test_modes.py InvokeSubgraphBackendTests.test_nested_compile_region_cache_persists_across_traces -v`
- `PYTHONPATH=$PWD python -m py_compile torch/_guards.py torch/_dynamo/variables/invoke_subgraph.py`
- `git diff --check`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98

Drafted via Codex, published after manual review by @bobrenjc93
