### PR TITLE
Add Dynamo tensor SSA fast path

### DIFF
--- a/test/dynamo/test_tensor_ssa.py
+++ b/test/dynamo/test_tensor_ssa.py
@@ -150,7 +150,6 @@ class TensorSSATests(torch._dynamo.test_case.TestCase):
 
     def test_fastpath_preserves_shape_dependency_current_node(self):
         from functorch.experimental.control_flow import cond
-        from torch.fx.experimental.proxy_tensor import make_fx
 
         a = torch.ones(2, 3)
         b = torch.ones(2, 3) + 1
@@ -164,18 +163,70 @@ class TensorSSATests(torch._dynamo.test_case.TestCase):
         def fn(x):
             return cond(x.shape[0] == 4, true_fn, false_fn, [x])
 
-        gm = make_fx(fn, tracing_mode="symbolic", _allow_non_fake_inputs=True)(
-            torch.randn(2, 3)
+        backend = EagerAndRecordGraphs()
+        opt_fn = torch.compile(fn, backend=backend, fullgraph=True, dynamic=True)
+        x = torch.randn(2, 3)
+
+        with self.collect_fastpath_hits() as hits:
+            self.assertEqual(opt_fn(x), fn(x))
+
+        self.assertEqual(hits, [("stack", operator.add), ("stack", operator.add)])
+        self.assertEqual(len(backend.graphs), 1)
+        graph_code = backend.graphs[0].code
+
+        self.assertIn("torch.ops.higher_order.cond", graph_code)
+        self.assertRegex(graph_code, r"eq = s\d+ == 4")
+        self.assertRegex(
+            graph_code,
+            r"torch\.ops\.higher_order\.cond"
+            r"\(eq, cond_true_0, cond_false_0, \(l_x_, s\d+, s\d+,",
         )
 
-        self.assertIn(
-            "sym_size_int_1 = torch.ops.aten.sym_size.int(x_1, 1)",
-            gm.code,
-        )
-        self.assertIn(
-            "(x_1, _tensor_constant0, sym_size_int_1, sym_size_int, _tensor_constant1)",
-            gm.code,
-        )
+    def test_unsupported_fastpath_fake_value_removes_speculative_node(self):
+        from torch._dynamo.exc import Unsupported
+        from torch._dynamo.output_graph import OutputGraph
+
+        def fn(x):
+            y = x.relu()
+            z = y + 1
+            return z.cos()
+
+        orig_compute_fake_value = tensor_ssa._compute_fake_value
+        orig_remove_node = OutputGraph.remove_node
+        removed_targets = []
+        raised = False
+
+        def fail_add_once(tx, node, op, args, kwargs):
+            nonlocal raised
+            if (
+                not raised
+                and node.op == "call_function"
+                and node.target is operator.add
+            ):
+                raised = True
+                raise Unsupported("forced tensor SSA graph break")
+            return orig_compute_fake_value(tx, node, op, args, kwargs)
+
+        def record_remove_node(output_graph, node):
+            removed_targets.append(node.target)
+            return orig_remove_node(output_graph, node)
+
+        backend = EagerAndRecordGraphs()
+        opt_fn = torch.compile(fn, backend=backend)
+        x = torch.randn(4)
+
+        with (
+            mock.patch.object(
+                tensor_ssa,
+                "_compute_fake_value",
+                side_effect=fail_add_once,
+            ),
+            mock.patch.object(OutputGraph, "remove_node", record_remove_node),
+        ):
+            self.assertEqual(opt_fn(x), fn(x))
+
+        self.assertTrue(raised)
+        self.assertIn(operator.add, removed_targets)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_tensor_ssa.py
+++ b/test/dynamo/test_tensor_ssa.py
@@ -1,15 +1,49 @@
 # Owner(s): ["module: dynamo"]
 
+import contextlib
 import operator
 from unittest import mock
 
 import torch
 import torch._dynamo.test_case
+from torch._dynamo import tensor_ssa
 from torch._dynamo.testing import EagerAndRecordGraphs
 
 
 class TensorSSATests(torch._dynamo.test_case.TestCase):
-    def test_straight_line_tensor_ops_skip_generic_fake_value(self):
+    @contextlib.contextmanager
+    def collect_fastpath_hits(self):
+        hits = []
+        orig_stack_op = tensor_ssa.maybe_fastpath_tensor_stack_op
+        orig_method = tensor_ssa.maybe_fastpath_tensor_method
+
+        def stack_op_wrapper(tx, fn, args):
+            result = orig_stack_op(tx, fn, args)
+            if result is not None:
+                hits.append(("stack", fn))
+            return result
+
+        def method_wrapper(tx, tensor, name, args, kwargs):
+            result = orig_method(tx, tensor, name, args, kwargs)
+            if result is not None:
+                hits.append(("method", name))
+            return result
+
+        with (
+            mock.patch.object(
+                tensor_ssa,
+                "maybe_fastpath_tensor_stack_op",
+                side_effect=stack_op_wrapper,
+            ),
+            mock.patch.object(
+                tensor_ssa,
+                "maybe_fastpath_tensor_method",
+                side_effect=method_wrapper,
+            ),
+        ):
+            yield hits
+
+    def test_straight_line_tensor_ops_use_fastpath(self):
         def fn(a, b):
             result = a.clone()
             result = result + b
@@ -22,11 +56,19 @@ class TensorSSATests(torch._dynamo.test_case.TestCase):
         a = torch.ones(10)
         b = torch.randn(10)
 
-        with mock.patch(
-            "torch._dynamo.variables.builder.get_fake_value",
-            side_effect=AssertionError("generic fake-value path used"),
-        ):
+        with self.collect_fastpath_hits() as hits:
             self.assertEqual(opt_fn(a, b), fn(a, b))
+
+        self.assertEqual(
+            hits,
+            [
+                ("method", "clone"),
+                ("stack", operator.add),
+                ("stack", operator.mul),
+                ("stack", operator.add),
+                ("method", "sin"),
+            ],
+        )
 
         targets = [
             node.target
@@ -35,6 +77,104 @@ class TensorSSATests(torch._dynamo.test_case.TestCase):
         ]
         self.assertEqual(
             targets, ["clone", operator.add, operator.mul, operator.add, "sin"]
+        )
+
+    def test_config_flag_disables_fastpath(self):
+        def fn(a, b):
+            return (a + b).sin()
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        a = torch.randn(4)
+        b = torch.randn(4)
+
+        with (
+            torch._dynamo.config.patch(enable_tensor_ssa_fastpath=False),
+            self.collect_fastpath_hits() as hits,
+        ):
+            self.assertEqual(opt_fn(a, b), fn(a, b))
+
+        self.assertEqual(hits, [])
+
+    def test_tensor_subclass_torch_function_falls_back(self):
+        class TestSubclass(torch.Tensor):
+            @classmethod
+            def __torch_function__(cls, func, types, args=(), kwargs=None):
+                return super().__torch_function__(func, types, args, kwargs or {})
+
+        def fn(x):
+            return x + 1
+
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        x = torch.randn(4).as_subclass(TestSubclass)
+
+        with self.collect_fastpath_hits() as hits:
+            self.assertEqual(opt_fn(x), fn(x))
+
+        self.assertEqual(hits, [])
+
+    def test_sparse_tensor_falls_back(self):
+        def fn(x):
+            return x + x
+
+        opt_fn = torch.compile(fn, backend="eager")
+        indices = torch.tensor([[0, 1, 1], [2, 0, 2]])
+        values = torch.tensor([3.0, 4.0, 5.0])
+        x = torch.sparse_coo_tensor(indices, values, (2, 3))
+
+        with self.collect_fastpath_hits() as hits:
+            self.assertEqual(opt_fn(x).to_dense(), fn(x).to_dense())
+
+        self.assertEqual(hits, [])
+
+    def test_symnode_constant_matmul_and_unary_fastpath(self):
+        def fn(a, b):
+            return -(a @ b + a.shape[0] + 2)
+
+        backend = EagerAndRecordGraphs()
+        opt_fn = torch.compile(fn, backend=backend, fullgraph=True, dynamic=True)
+        a = torch.randn(3, 4)
+        b = torch.randn(4, 5)
+
+        with self.collect_fastpath_hits() as hits:
+            self.assertEqual(opt_fn(a, b), fn(a, b))
+
+        self.assertEqual(
+            hits,
+            [
+                ("stack", operator.matmul),
+                ("stack", operator.add),
+                ("stack", operator.add),
+                ("stack", operator.neg),
+            ],
+        )
+
+    def test_fastpath_preserves_shape_dependency_current_node(self):
+        from functorch.experimental.control_flow import cond
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        a = torch.ones(2, 3)
+        b = torch.ones(2, 3) + 1
+
+        def true_fn(x):
+            return x + a
+
+        def false_fn(x):
+            return x + b
+
+        def fn(x):
+            return cond(x.shape[0] == 4, true_fn, false_fn, [x])
+
+        gm = make_fx(fn, tracing_mode="symbolic", _allow_non_fake_inputs=True)(
+            torch.randn(2, 3)
+        )
+
+        self.assertIn(
+            "sym_size_int_1 = torch.ops.aten.sym_size.int(x_1, 1)",
+            gm.code,
+        )
+        self.assertIn(
+            "(x_1, _tensor_constant0, sym_size_int_1, sym_size_int, _tensor_constant1)",
+            gm.code,
         )
 
 

--- a/test/dynamo/test_tensor_ssa.py
+++ b/test/dynamo/test_tensor_ssa.py
@@ -1,0 +1,44 @@
+# Owner(s): ["module: dynamo"]
+
+import operator
+from unittest import mock
+
+import torch
+import torch._dynamo.test_case
+from torch._dynamo.testing import EagerAndRecordGraphs
+
+
+class TensorSSATests(torch._dynamo.test_case.TestCase):
+    def test_straight_line_tensor_ops_skip_generic_fake_value(self):
+        def fn(a, b):
+            result = a.clone()
+            result = result + b
+            result = result + 8 * b
+            result = result.sin()
+            return result
+
+        backend = EagerAndRecordGraphs()
+        opt_fn = torch.compile(fn, backend=backend, fullgraph=True)
+        a = torch.ones(10)
+        b = torch.randn(10)
+
+        with mock.patch(
+            "torch._dynamo.variables.builder.get_fake_value",
+            side_effect=AssertionError("generic fake-value path used"),
+        ):
+            self.assertEqual(opt_fn(a, b), fn(a, b))
+
+        targets = [
+            node.target
+            for node in backend.graphs[0].graph.nodes
+            if node.op in ("call_function", "call_method")
+        ]
+        self.assertEqual(
+            targets, ["clone", operator.add, operator.mul, operator.add, "sin"]
+        )
+
+
+if __name__ == "__main__":
+    from torch._dynamo.test_case import run_tests
+
+    run_tests()

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -884,6 +884,10 @@ wrap_top_frame = False
 # and AOTAutograd runtime wrapper.
 record_runtime_overhead = True
 
+# Route simple, side-effect-free tensor bytecode through a direct FX/fake-value
+# path instead of the generic VariableTracker operator dispatch.
+enable_tensor_ssa_fastpath = True
+
 # Flag to enable the use of torch.compile().aot_compile() API. Should be always True.
 enable_aot_compile = True
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -482,7 +482,13 @@ def stack_op(fn: Callable[..., object]) -> Callable[..., Any]:
 
     @functools.wraps(fn)
     def impl(self: InstructionTranslator, inst: Instruction) -> None:
-        self.push(fn_var.call_function(self, self.popn(nargs), {}))
+        args = self.popn(nargs)
+        from .tensor_ssa import maybe_fastpath_tensor_stack_op
+
+        result = maybe_fastpath_tensor_stack_op(self, fn, args)
+        if result is None:
+            result = fn_var.call_function(self, args, {})
+        self.push(result)
 
     return impl
 

--- a/torch/_dynamo/tensor_ssa.py
+++ b/torch/_dynamo/tensor_ssa.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import operator
+import time
 from collections.abc import Callable, Sequence  # noqa: TC003
 from typing import Any, NamedTuple, TYPE_CHECKING
 
@@ -66,8 +67,8 @@ _TENSOR_METHODS: set[str] = {
 
 
 class NormalizedArgs(NamedTuple):
-    proxy_args: list[Any]
-    proxy_kwargs: dict[str, Any]
+    vt_args: list[Any]
+    vt_kwargs: dict[str, Any]
     fake_args: list[Any]
     fake_kwargs: dict[str, Any]
     has_tensor_arg: bool
@@ -166,13 +167,14 @@ def _compute_fake_value(
     args: Sequence[Any],
     kwargs: dict[str, Any],
 ) -> Any:
+    _t0 = time.time_ns()
     fake_mode = tx.fake_mode
-    if fake_mode is None:
-        return None
-
-    from .exc import Unsupported
-
     try:
+        if fake_mode is None:
+            return None
+
+        from .exc import Unsupported
+
         with (
             _disable_saved_tensors_hooks_during_tracing(),
             set_current_node(node),
@@ -184,6 +186,41 @@ def _compute_fake_value(
         raise
     except (RuntimeError, TypeError):
         return None
+    finally:
+        tx.output.bytecode_tracing_timings.get_fake_value_ns += time.time_ns() - _t0
+
+
+def _collect_mutation_inputs(
+    tx: InstructionTranslator,
+    node: torch.fx.Node,
+) -> tuple[list[Any], dict[int, int]] | None:
+    if not (config.use_graph_deduplication or config.track_nodes_for_deduplication):
+        return None
+
+    from .graph_utils import _get_flat_args
+    from .utils import get_fake_values_from_nodes, is_fake
+
+    flat_args_kwargs = get_fake_values_from_nodes(tx, _get_flat_args(node, {}), False)
+    id_to_initial_version = {
+        id(arg): arg._version for arg in flat_args_kwargs if is_fake(arg)
+    }
+    return flat_args_kwargs, id_to_initial_version
+
+
+def _track_node_mutations(
+    tx: InstructionTranslator,
+    node: torch.fx.Node,
+    mutation_inputs: tuple[list[Any], dict[int, int]] | None,
+) -> None:
+    if mutation_inputs is None:
+        return
+
+    flat_args_kwargs, id_to_initial_version = mutation_inputs
+    tx.output.region_tracker.track_node_mutations(
+        node,
+        flat_args_kwargs,
+        id_to_initial_version,
+    )
 
 
 def _can_use_fastpath(
@@ -217,14 +254,21 @@ def maybe_fastpath_tensor_stack_op(
     proxy = tx.output.create_proxy(
         "call_function",
         fn,
-        *proxy_args_kwargs(normalized.proxy_args, normalized.proxy_kwargs),
+        *proxy_args_kwargs(normalized.vt_args, normalized.vt_kwargs),
     )
-    example_value = _compute_fake_value(
-        tx, proxy.node, fn, normalized.fake_args, normalized.fake_kwargs
-    )
+    try:
+        mutation_inputs = _collect_mutation_inputs(tx, proxy.node)
+        example_value = _compute_fake_value(
+            tx, proxy.node, fn, normalized.fake_args, normalized.fake_kwargs
+        )
+    except Exception:
+        tx.output.remove_node(proxy.node)
+        raise
     if not isinstance(example_value, torch.Tensor):
         tx.output.remove_node(proxy.node)
         return None
+
+    _track_node_mutations(tx, proxy.node, mutation_inputs)
 
     from .variables.builder import wrap_fx_proxy
 
@@ -255,21 +299,28 @@ def maybe_fastpath_tensor_method(
     proxy = tx.output.create_proxy(
         "call_method",
         name,
-        *proxy_args_kwargs(normalized.proxy_args, normalized.proxy_kwargs),
+        *proxy_args_kwargs(normalized.vt_args, normalized.vt_kwargs),
     )
     fake_self, *fake_method_args = normalized.fake_args
-    example_value = _compute_fake_value(
-        tx,
-        proxy.node,
-        lambda *method_args, **method_kwargs: getattr(fake_self, name)(
-            *method_args, **method_kwargs
-        ),
-        fake_method_args,
-        normalized.fake_kwargs,
-    )
+    try:
+        mutation_inputs = _collect_mutation_inputs(tx, proxy.node)
+        example_value = _compute_fake_value(
+            tx,
+            proxy.node,
+            lambda *method_args, **method_kwargs: getattr(fake_self, name)(
+                *method_args, **method_kwargs
+            ),
+            fake_method_args,
+            normalized.fake_kwargs,
+        )
+    except Exception:
+        tx.output.remove_node(proxy.node)
+        raise
     if not isinstance(example_value, torch.Tensor):
         tx.output.remove_node(proxy.node)
         return None
+
+    _track_node_mutations(tx, proxy.node, mutation_inputs)
 
     from .variables.builder import wrap_fx_proxy
 

--- a/torch/_dynamo/tensor_ssa.py
+++ b/torch/_dynamo/tensor_ssa.py
@@ -12,6 +12,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 from . import config
 from .utils import (
     _disable_saved_tensors_hooks_during_tracing,
+    ensure_graph_fake,
     proxy_args_kwargs,
     set_current_node,
     wrap_fake_exception,
@@ -167,13 +168,13 @@ def _compute_fake_value(
     args: Sequence[Any],
     kwargs: dict[str, Any],
 ) -> Any:
+    from .exc import Unsupported
+
     _t0 = time.time_ns()
     fake_mode = tx.fake_mode
     try:
         if fake_mode is None:
             return None
-
-        from .exc import Unsupported
 
         with (
             _disable_saved_tensors_hooks_during_tracing(),
@@ -261,6 +262,8 @@ def maybe_fastpath_tensor_stack_op(
         example_value = _compute_fake_value(
             tx, proxy.node, fn, normalized.fake_args, normalized.fake_kwargs
         )
+        if isinstance(example_value, torch.Tensor):
+            example_value = ensure_graph_fake(example_value, tx)
     except Exception:
         tx.output.remove_node(proxy.node)
         raise
@@ -313,6 +316,8 @@ def maybe_fastpath_tensor_method(
             fake_method_args,
             normalized.fake_kwargs,
         )
+        if isinstance(example_value, torch.Tensor):
+            example_value = ensure_graph_fake(example_value, tx)
     except Exception:
         tx.output.remove_node(proxy.node)
         raise

--- a/torch/_dynamo/tensor_ssa.py
+++ b/torch/_dynamo/tensor_ssa.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import operator
+from collections.abc import Callable, Sequence  # noqa: TC003
+from typing import Any
+
+import torch
+from torch._dispatch.python import enable_python_dispatcher
+from torch._subclasses.fake_tensor import FakeTensor
+
+from . import config
+from .utils import (
+    _disable_saved_tensors_hooks_during_tracing,
+    proxy_args_kwargs,
+    wrap_fake_exception,
+)
+
+
+_BINARY_TENSOR_FNS: set[Callable[..., object]] = {
+    operator.add,
+    operator.sub,
+    operator.mul,
+    operator.truediv,
+    operator.floordiv,
+    operator.mod,
+    operator.pow,
+    operator.matmul,
+}
+
+_UNARY_TENSOR_FNS: set[Callable[..., object]] = {
+    operator.neg,
+    operator.pos,
+}
+
+_TENSOR_METHODS: set[str] = {
+    "abs",
+    "acos",
+    "asin",
+    "atan",
+    "ceil",
+    "clone",
+    "cos",
+    "cosh",
+    "erf",
+    "exp",
+    "expm1",
+    "floor",
+    "log",
+    "log1p",
+    "neg",
+    "reciprocal",
+    "relu",
+    "round",
+    "sigmoid",
+    "sin",
+    "sinh",
+    "sqrt",
+    "tan",
+    "tanh",
+    "trunc",
+}
+
+
+def _realize_lazy_tensor(value: Any) -> Any:
+    from .variables.lazy import LazyVariableTracker
+
+    if not isinstance(value, LazyVariableTracker):
+        return value
+    if value.is_realized():
+        return value.realize()
+
+    try:
+        value_type = value.peek_type()
+    except Exception:
+        return value
+
+    if isinstance(value_type, type) and issubclass(value_type, torch.Tensor):
+        return value.realize()
+    return value
+
+
+def _normalize_arg(tx: Any, value: Any) -> tuple[Any, Any, bool] | None:
+    from .variables.constant import ConstantVariable
+    from .variables.tensor import SymNodeVariable, TensorVariable
+
+    value = _realize_lazy_tensor(value)
+    if type(value) is TensorVariable and value.class_type is torch.Tensor:
+        example_value = value.as_proxy().node.meta.get("example_value")
+        if (
+            isinstance(example_value, FakeTensor)
+            and example_value.fake_mode is tx.fake_mode
+            and not example_value.is_sparse
+            and not example_value.is_nested
+        ):
+            return value, example_value, True
+        return None
+
+    if isinstance(value, ConstantVariable):
+        constant = value.as_python_constant()
+        if constant is None or type(constant) in (bool, int, float):
+            return value, constant, False
+        return None
+
+    if isinstance(value, SymNodeVariable):
+        return value, value.sym_num, False
+
+    return None
+
+
+def _normalize_args(
+    tx: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+) -> tuple[list[Any], dict[str, Any], list[Any], dict[str, Any], bool] | None:
+    normalized_args = []
+    fake_args = []
+    has_tensor_arg = False
+
+    for arg in args:
+        normalized = _normalize_arg(tx, arg)
+        if normalized is None:
+            return None
+        proxy_arg, fake_arg, is_tensor_arg = normalized
+        normalized_args.append(proxy_arg)
+        fake_args.append(fake_arg)
+        has_tensor_arg = has_tensor_arg or is_tensor_arg
+
+    normalized_kwargs = {}
+    fake_kwargs = {}
+    for key, value in kwargs.items():
+        normalized = _normalize_arg(tx, value)
+        if normalized is None:
+            return None
+        proxy_arg, fake_arg, is_tensor_arg = normalized
+        normalized_kwargs[key] = proxy_arg
+        fake_kwargs[key] = fake_arg
+        has_tensor_arg = has_tensor_arg or is_tensor_arg
+
+    return normalized_args, normalized_kwargs, fake_args, fake_kwargs, has_tensor_arg
+
+
+def _compute_fake_value(tx: Any, fn: Callable[..., Any], args: Any, kwargs: Any) -> Any:
+    fake_mode = tx.fake_mode
+    if fake_mode is None:
+        return None
+
+    try:
+        with (
+            _disable_saved_tensors_hooks_during_tracing(),
+            fake_mode,
+            enable_python_dispatcher(),
+        ):
+            return wrap_fake_exception(lambda: fn(*args, **kwargs))
+    except Exception:
+        return None
+
+
+def _can_use_fastpath(tx: Any, args: Sequence[Any], kwargs: dict[str, Any]) -> bool:
+    if not config.enable_tensor_ssa_fastpath:
+        return False
+
+    from .variables.torch_function import can_dispatch_torch_function
+
+    return not can_dispatch_torch_function(tx, args, kwargs)
+
+
+def maybe_fastpath_tensor_stack_op(
+    tx: Any,
+    fn: Callable[..., object],
+    args: Sequence[Any],
+) -> Any | None:
+    if fn not in _BINARY_TENSOR_FNS and fn not in _UNARY_TENSOR_FNS:
+        return None
+    if not _can_use_fastpath(tx, args, {}):
+        return None
+
+    normalized = _normalize_args(tx, args, {})
+    if normalized is None:
+        return None
+
+    proxy_args, proxy_kwargs, fake_args, fake_kwargs, has_tensor_arg = normalized
+    if not has_tensor_arg:
+        return None
+
+    example_value = _compute_fake_value(tx, fn, fake_args, fake_kwargs)
+    if not isinstance(example_value, torch.Tensor):
+        return None
+
+    from .variables.builder import wrap_fx_proxy_with_precomputed_value
+
+    proxy = tx.output.create_proxy(
+        "call_function",
+        fn,
+        *proxy_args_kwargs(proxy_args, proxy_kwargs),
+    )
+    return wrap_fx_proxy_with_precomputed_value(tx, proxy, example_value)
+
+
+def maybe_fastpath_tensor_method(
+    tx: Any,
+    tensor: Any,
+    name: str,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+) -> Any | None:
+    if name not in _TENSOR_METHODS:
+        return None
+
+    all_args = [tensor, *args]
+    if not _can_use_fastpath(tx, all_args, kwargs):
+        return None
+
+    normalized = _normalize_args(tx, all_args, kwargs)
+    if normalized is None:
+        return None
+
+    proxy_args, proxy_kwargs, fake_args, fake_kwargs, has_tensor_arg = normalized
+    if not has_tensor_arg:
+        return None
+
+    fake_self, *fake_method_args = fake_args
+    example_value = _compute_fake_value(
+        tx,
+        lambda *method_args, **method_kwargs: getattr(fake_self, name)(
+            *method_args, **method_kwargs
+        ),
+        fake_method_args,
+        fake_kwargs,
+    )
+    if not isinstance(example_value, torch.Tensor):
+        return None
+
+    from .variables.builder import wrap_fx_proxy_with_precomputed_value
+
+    proxy = tx.output.create_proxy(
+        "call_method",
+        name,
+        *proxy_args_kwargs(proxy_args, proxy_kwargs),
+    )
+    return wrap_fx_proxy_with_precomputed_value(tx, proxy, example_value)

--- a/torch/_dynamo/tensor_ssa.py
+++ b/torch/_dynamo/tensor_ssa.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import operator
 from collections.abc import Callable, Sequence  # noqa: TC003
-from typing import Any
+from typing import Any, NamedTuple, TYPE_CHECKING
 
 import torch
 from torch._dispatch.python import enable_python_dispatcher
@@ -12,9 +12,13 @@ from . import config
 from .utils import (
     _disable_saved_tensors_hooks_during_tracing,
     proxy_args_kwargs,
+    set_current_node,
     wrap_fake_exception,
 )
 
+
+if TYPE_CHECKING:
+    from .symbolic_convert import InstructionTranslator
 
 _BINARY_TENSOR_FNS: set[Callable[..., object]] = {
     operator.add,
@@ -61,6 +65,14 @@ _TENSOR_METHODS: set[str] = {
 }
 
 
+class NormalizedArgs(NamedTuple):
+    proxy_args: list[Any]
+    proxy_kwargs: dict[str, Any]
+    fake_args: list[Any]
+    fake_kwargs: dict[str, Any]
+    has_tensor_arg: bool
+
+
 def _realize_lazy_tensor(value: Any) -> Any:
     from .variables.lazy import LazyVariableTracker
 
@@ -79,7 +91,9 @@ def _realize_lazy_tensor(value: Any) -> Any:
     return value
 
 
-def _normalize_arg(tx: Any, value: Any) -> tuple[Any, Any, bool] | None:
+def _normalize_arg(
+    tx: InstructionTranslator, value: Any
+) -> tuple[Any, Any, bool] | None:
     from .variables.constant import ConstantVariable
     from .variables.tensor import SymNodeVariable, TensorVariable
 
@@ -108,10 +122,10 @@ def _normalize_arg(tx: Any, value: Any) -> tuple[Any, Any, bool] | None:
 
 
 def _normalize_args(
-    tx: Any,
+    tx: InstructionTranslator,
     args: Sequence[Any],
     kwargs: dict[str, Any],
-) -> tuple[list[Any], dict[str, Any], list[Any], dict[str, Any], bool] | None:
+) -> NormalizedArgs | None:
     normalized_args = []
     fake_args = []
     has_tensor_arg = False
@@ -136,26 +150,45 @@ def _normalize_args(
         fake_kwargs[key] = fake_arg
         has_tensor_arg = has_tensor_arg or is_tensor_arg
 
-    return normalized_args, normalized_kwargs, fake_args, fake_kwargs, has_tensor_arg
+    return NormalizedArgs(
+        normalized_args,
+        normalized_kwargs,
+        fake_args,
+        fake_kwargs,
+        has_tensor_arg,
+    )
 
 
-def _compute_fake_value(tx: Any, fn: Callable[..., Any], args: Any, kwargs: Any) -> Any:
+def _compute_fake_value(
+    tx: InstructionTranslator,
+    node: torch.fx.Node,
+    fn: Callable[..., Any],
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+) -> Any:
     fake_mode = tx.fake_mode
     if fake_mode is None:
         return None
 
+    from .exc import Unsupported
+
     try:
         with (
             _disable_saved_tensors_hooks_during_tracing(),
+            set_current_node(node),
             fake_mode,
             enable_python_dispatcher(),
         ):
             return wrap_fake_exception(lambda: fn(*args, **kwargs))
-    except Exception:
+    except Unsupported:
+        raise
+    except (RuntimeError, TypeError):
         return None
 
 
-def _can_use_fastpath(tx: Any, args: Sequence[Any], kwargs: dict[str, Any]) -> bool:
+def _can_use_fastpath(
+    tx: InstructionTranslator, args: Sequence[Any], kwargs: dict[str, Any]
+) -> bool:
     if not config.enable_tensor_ssa_fastpath:
         return False
 
@@ -165,7 +198,7 @@ def _can_use_fastpath(tx: Any, args: Sequence[Any], kwargs: dict[str, Any]) -> b
 
 
 def maybe_fastpath_tensor_stack_op(
-    tx: Any,
+    tx: InstructionTranslator,
     fn: Callable[..., object],
     args: Sequence[Any],
 ) -> Any | None:
@@ -178,26 +211,28 @@ def maybe_fastpath_tensor_stack_op(
     if normalized is None:
         return None
 
-    proxy_args, proxy_kwargs, fake_args, fake_kwargs, has_tensor_arg = normalized
-    if not has_tensor_arg:
+    if not normalized.has_tensor_arg:
         return None
-
-    example_value = _compute_fake_value(tx, fn, fake_args, fake_kwargs)
-    if not isinstance(example_value, torch.Tensor):
-        return None
-
-    from .variables.builder import wrap_fx_proxy_with_precomputed_value
 
     proxy = tx.output.create_proxy(
         "call_function",
         fn,
-        *proxy_args_kwargs(proxy_args, proxy_kwargs),
+        *proxy_args_kwargs(normalized.proxy_args, normalized.proxy_kwargs),
     )
-    return wrap_fx_proxy_with_precomputed_value(tx, proxy, example_value)
+    example_value = _compute_fake_value(
+        tx, proxy.node, fn, normalized.fake_args, normalized.fake_kwargs
+    )
+    if not isinstance(example_value, torch.Tensor):
+        tx.output.remove_node(proxy.node)
+        return None
+
+    from .variables.builder import wrap_fx_proxy
+
+    return wrap_fx_proxy(tx, proxy, precomputed_example_value=example_value)
 
 
 def maybe_fastpath_tensor_method(
-    tx: Any,
+    tx: InstructionTranslator,
     tensor: Any,
     name: str,
     args: Sequence[Any],
@@ -214,27 +249,28 @@ def maybe_fastpath_tensor_method(
     if normalized is None:
         return None
 
-    proxy_args, proxy_kwargs, fake_args, fake_kwargs, has_tensor_arg = normalized
-    if not has_tensor_arg:
+    if not normalized.has_tensor_arg:
         return None
-
-    fake_self, *fake_method_args = fake_args
-    example_value = _compute_fake_value(
-        tx,
-        lambda *method_args, **method_kwargs: getattr(fake_self, name)(
-            *method_args, **method_kwargs
-        ),
-        fake_method_args,
-        fake_kwargs,
-    )
-    if not isinstance(example_value, torch.Tensor):
-        return None
-
-    from .variables.builder import wrap_fx_proxy_with_precomputed_value
 
     proxy = tx.output.create_proxy(
         "call_method",
         name,
-        *proxy_args_kwargs(proxy_args, proxy_kwargs),
+        *proxy_args_kwargs(normalized.proxy_args, normalized.proxy_kwargs),
     )
-    return wrap_fx_proxy_with_precomputed_value(tx, proxy, example_value)
+    fake_self, *fake_method_args = normalized.fake_args
+    example_value = _compute_fake_value(
+        tx,
+        proxy.node,
+        lambda *method_args, **method_kwargs: getattr(fake_self, name)(
+            *method_args, **method_kwargs
+        ),
+        fake_method_args,
+        normalized.fake_kwargs,
+    )
+    if not isinstance(example_value, torch.Tensor):
+        tx.output.remove_node(proxy.node)
+        return None
+
+    from .variables.builder import wrap_fx_proxy
+
+    return wrap_fx_proxy(tx, proxy, precomputed_example_value=example_value)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -3219,6 +3219,36 @@ def wrap_fx_proxy_cls(
     return out
 
 
+def wrap_fx_proxy_with_precomputed_value(
+    tx: "InstructionTranslatorBase",
+    proxy: Any,
+    example_value: Any,
+    target_cls: type[VTTypeAlias] = TensorVariable,
+    subclass_type: type | None = None,
+    **options: Any,
+) -> VariableTracker:
+    out = handle_traced_output(
+        example_value,
+        tx,
+        proxy,
+        options,
+        subclass_type,
+        target_cls,
+    )
+    if (
+        isinstance(
+            out,
+            (
+                torch._dynamo.variables.TensorVariable,
+                torch._dynamo.variables.SymNodeVariable,
+            ),
+        )
+        and proxy.node.op != "placeholder"
+    ):
+        tx.output.current_tracer.record_proxyable_vt(out)
+    return out
+
+
 # This is 1 above (wrapping a preexisting tensor)
 def _wrap_fx_preexisting_tensor(
     target_cls: type[VTTypeAlias],

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -335,6 +335,7 @@ from typing import TypeVar
 # creation so that we don't type erase
 VTTypeAlias = TypeVar("VTTypeAlias")
 T = TypeVar("T")
+_NO_PRECOMPUTED_VALUE = object()
 
 DimList = list
 
@@ -3103,6 +3104,7 @@ def wrap_fx_proxy(
     proxy: Any,
     example_value: Any | None = None,
     subclass_type: type | None = None,
+    precomputed_example_value: Any = _NO_PRECOMPUTED_VALUE,
     **options: Any,
 ) -> VariableTracker:
     kwargs = {
@@ -3110,6 +3112,7 @@ def wrap_fx_proxy(
         "proxy": proxy,
         "example_value": example_value,
         "subclass_type": subclass_type,
+        "precomputed_example_value": precomputed_example_value,
         **options,
     }
     if subclass_type is None:
@@ -3186,9 +3189,22 @@ def wrap_fx_proxy_cls(
     proxy: Any,
     example_value: Any | None = None,
     subclass_type: type | None = None,
+    precomputed_example_value: Any = _NO_PRECOMPUTED_VALUE,
     **options: Any,
 ) -> VTTypeAlias:
-    if example_value is None:
+    if precomputed_example_value is not _NO_PRECOMPUTED_VALUE:
+        # This is the traced-op case where the caller already ran fake
+        # propagation. Keep the post-processing shared with wrap_fx_proxy_cls.
+        # pyrefly: ignore[bad-assignment]
+        out: VTTypeAlias = handle_traced_output(
+            precomputed_example_value,
+            tx,
+            proxy,
+            options,
+            subclass_type,
+            target_cls,
+        )
+    elif example_value is None:
         out: VTTypeAlias = _wrap_fx_proxy(
             target_cls, tx, proxy, example_value, subclass_type, **options
         )
@@ -3205,36 +3221,6 @@ def wrap_fx_proxy_cls(
             example_value, tx, proxy, options, subclass_type, target_cls
         )
 
-    if (
-        isinstance(
-            out,
-            (
-                torch._dynamo.variables.TensorVariable,
-                torch._dynamo.variables.SymNodeVariable,
-            ),
-        )
-        and proxy.node.op != "placeholder"
-    ):
-        tx.output.current_tracer.record_proxyable_vt(out)
-    return out
-
-
-def wrap_fx_proxy_with_precomputed_value(
-    tx: "InstructionTranslatorBase",
-    proxy: Any,
-    example_value: Any,
-    target_cls: type[VTTypeAlias] = TensorVariable,
-    subclass_type: type | None = None,
-    **options: Any,
-) -> VariableTracker:
-    out = handle_traced_output(
-        example_value,
-        tx,
-        proxy,
-        options,
-        subclass_type,
-        target_cls,
-    )
     if (
         isinstance(
             out,

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -912,6 +912,12 @@ class TensorVariable(VariableTracker):
                 ],
             )
 
+        from ..tensor_ssa import maybe_fastpath_tensor_method
+
+        fastpath_result = maybe_fastpath_tensor_method(tx, self, name, args, kwargs)
+        if fastpath_result is not None:
+            return fastpath_result
+
         try:
             handler_method = getattr(self, f"method_{name}")
         except AttributeError:


### PR DESCRIPTION
## Summary
Add a conservative straight-line tensor SSA fast path for side-effect-free tensor bytecode in Dynamo. The fast path handles exact base `TensorVariable` operands plus scalar constants for common binary/unary ops and selected pure tensor methods such as `clone()` and `sin()`.

## Root cause problem
Common straight-line tensor expressions currently route through generic `VariableTracker` operator dispatch and then through `wrap_fx_proxy -> get_fake_value -> run_node` for each op. In add-loop style traces, that repeatedly pays the full generic wrapping and fake-value node replay cost even when the bytecode is a simple pure tensor op.

The follow-up CI failure was caused by the fast path computing fake values before there was an FX current node. ShapeEnv could not attribute symbolic shape work to the tensor op node, so higher-order-op closure lifting dropped symbolic shape dependencies and changed expected `cond` graphs.

## Proposed fix
Intercept eligible tensor stack ops in `stack_op` and eligible tensor methods in `TensorVariable.call_method`, compute the fake result directly from operand example values, create the FX proxy, and wrap it with precomputed metadata. The helper is guarded by `torch._dynamo.config.enable_tensor_ssa_fastpath` and falls back to the existing path for subclasses, sparse/nested tensors, unsupported args, `__torch_function__`, mutation, and non-tensor outputs.

The follow-up fix creates the FX proxy before fake propagation, runs the fake computation under `set_current_node(proxy.node)`, preserves graph-break `Unsupported` exceptions, and routes precomputed fake values through `wrap_fx_proxy_cls` instead of a duplicate wrapper helper.

## Why this is the right long term fix
This establishes a small SSA-style tracing boundary for straight-line tensor bytecode while preserving the existing `VariableTracker` machinery as the correctness fallback. Keeping the eligibility checks narrow makes the fast path safe to expand incrementally to more pure tensor ops without changing behavior for complex Python, subclasses, side effects, or graph-break cases.

The current-node fix keeps the fast path aligned with `get_fake_value -> run_node` semantics for ShapeEnv dependency tracking, which is the durable behavior higher-order ops and symbolic shape validation already rely on.

## Tests
- `python3 -m py_compile torch/_dynamo/tensor_ssa.py torch/_dynamo/variables/builder.py test/dynamo/test_tensor_ssa.py`
- `lintrunner --take RUFF,PYFMT,FLAKE8 torch/_dynamo/config.py torch/_dynamo/symbolic_convert.py torch/_dynamo/tensor_ssa.py torch/_dynamo/variables/builder.py torch/_dynamo/variables/tensor.py test/dynamo/test_tensor_ssa.py`
- `uv run --script tools/linter/adapters/pyrefly_linter.py --config=pyrefly.toml` and checked that the prior PR-caused `tensor_ssa.py` / `builder.py` pyrefly errors are gone
- CPU nightly overlay with `torch-2.13.0.dev20260427+cpu`
- `/tmp/pytorch-ssa-venv/bin/python /tmp/repos/pytorch/pytorch/test/dynamo/test_tensor_ssa.py`
- `/tmp/pytorch-ssa-venv/bin/python /tmp/repos/pytorch/pytorch/test/functorch/test_control_flow.py TestControlFlow.test_cond_autograd_pytree_not_all_inputs_used`
- `PYTORCH_TEST_WITH_DYNAMO=1 /tmp/pytorch-ssa-venv/bin/python /tmp/repos/pytorch/pytorch/test/functorch/test_control_flow.py TestControlFlowTraced.test_cond_with_tensor_closure_graph_module`
- Verified `TensorSSATests.test_fastpath_preserves_shape_dependency_current_node` fails against the previous PR implementation because `sym_size_int_1` is missing from the lifted `cond` graph.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98

Drafted via Codex, published after manual review by @bobrenjc93
