### PR TITLE
Add Dynamo inline trace cache

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -11,6 +11,7 @@ import math
 import operator
 import random
 import sys
+import traceback
 import types
 import typing
 import unittest
@@ -337,6 +338,28 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(counters["inline_trace_cache"]["stored"], 0)
         self.assertEqual(counters["inline_trace_cache"]["hit"], 0)
 
+    def test_inline_trace_cache_rejects_setitem_mutation(self):
+        def block(x):
+            x[0] = 1.0
+            return x.sum()
+
+        def fn(x):
+            x = x.clone()
+            out = x.sum() * 0.0
+            for _ in range(2):
+                out = out + block(x)
+            return out
+
+        counters.clear()
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+
+        x = torch.randn(3, 4)
+        self.assertTrue(same(opt_fn(x), fn(x)))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(counters["inline_trace_cache"]["stored"], 0)
+        self.assertEqual(counters["inline_trace_cache"]["hit"], 0)
+
     def test_inline_trace_cache_clones_tuple_return(self):
         def block(x):
             return torch.sin(x), torch.cos(x)
@@ -368,15 +391,28 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         side_effects = SideEffects(output_graph)
         side_effects.save_for_backward.append(("ctx", []))
         side_effects.tensor_hooks[0] = ("tensor", "hook", "handle", "name")
+        mutation_key = object()
+        side_effects.mutation_user_stacks[mutation_key] = [traceback.extract_stack()]
 
         cloned = side_effects.clone()
 
         self.assertIsNot(cloned.save_for_backward, side_effects.save_for_backward)
         self.assertIsNot(cloned.tensor_hooks, side_effects.tensor_hooks)
+        self.assertIsNot(
+            cloned.mutation_user_stacks[mutation_key],
+            side_effects.mutation_user_stacks[mutation_key],
+        )
         side_effects.save_for_backward.append(("ctx2", []))
         side_effects.tensor_hooks[1] = ("tensor2", "hook2", "handle2", "name2")
+        side_effects.mutation_user_stacks[mutation_key].append(
+            traceback.extract_stack()
+        )
         self.assertNotEqual(cloned.save_for_backward, side_effects.save_for_backward)
         self.assertNotEqual(cloned.tensor_hooks, side_effects.tensor_hooks)
+        self.assertNotEqual(
+            cloned.mutation_user_stacks[mutation_key],
+            side_effects.mutation_user_stacks[mutation_key],
+        )
 
     def test_lru_cache_warning_issued_during_tracing(self):
         import warnings

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -168,6 +168,25 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     def test_inline_lru_cache_fn_with_default_args(a, b):
         return inline_lru_cache_fn_with_default_args(a, 2, b)
 
+    def test_inline_trace_cache_reuses_same_shape_function(self):
+        def block(x):
+            return torch.cos(torch.sin(x + 1.0)) * 2.0
+
+        def fn(x):
+            for _ in range(4):
+                x = block(x)
+            return x
+
+        counters.clear()
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+
+        x = torch.randn(3, 4)
+        self.assertTrue(same(opt_fn(x), fn(x)))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(counters["inline_trace_cache"]["stored"], 1)
+        self.assertEqual(counters["inline_trace_cache"]["hit"], 3)
+
     def test_lru_cache_warning_issued_during_tracing(self):
         import warnings
         from functools import lru_cache

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -173,6 +173,7 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             return torch.cos(torch.sin(x + 1.0)) * 2.0
 
         def fn(x):
+            x = x + 0.0
             for _ in range(4):
                 x = block(x)
             return x
@@ -192,6 +193,8 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
             return torch.cos(torch.sin(x + 1.0)) * 2.0
 
         def fn(x, y):
+            x = x.as_strided(x.shape, x.stride())
+            y = y.as_strided(y.shape, y.stride())
             return block(x) + block(y)
 
         counters.clear()
@@ -205,6 +208,71 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(opt_fn(x, y), fn(x, y)))
         self.assertEqual(cnt.frame_count, 1)
         self.assertEqual(counters["inline_trace_cache"]["stored"], 2)
+        self.assertEqual(counters["inline_trace_cache"]["hit"], 0)
+
+    def test_inline_trace_cache_keys_on_callsite(self):
+        def block(x):
+            return torch.cos(torch.sin(x + 1.0)) * 2.0
+
+        def fn(x):
+            x = x + 0.0
+            y = block(x)
+            z = block(x)
+            return y + z
+
+        counters.clear()
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+
+        x = torch.randn(2, 3)
+        self.assertTrue(same(opt_fn(x), fn(x)))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(counters["inline_trace_cache"]["stored"], 2)
+        self.assertEqual(counters["inline_trace_cache"]["hit"], 0)
+
+    def test_inline_trace_cache_rejects_tensor_subclasses(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+        from torch._dynamo.variables.torch_function import TensorWithTFOverrideVariable
+
+        class TensorProxy(torch.Tensor):
+            @classmethod
+            def __torch_function__(cls, func, types, args=(), kwargs=None):
+                return super().__torch_function__(func, types, args, kwargs)
+
+        def block(x):
+            return torch.cos(torch.sin(x + 1.0)) * 2.0
+
+        def fn(x):
+            x = x + 0.0
+            for _ in range(2):
+                x = block(x)
+            return x
+
+        counters.clear()
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+        original = InliningInstructionTranslator.inline_trace_cache_info.__func__
+        accepted_subclass_input = False
+
+        def wrapped_inline_trace_cache_info(cls, parent, func, args, kwargs):
+            nonlocal accepted_subclass_input
+            result = original(cls, parent, func, args, kwargs)
+            if result is not None and any(
+                type(arg) is TensorWithTFOverrideVariable for arg in args
+            ):
+                accepted_subclass_input = True
+            return result
+
+        x = torch.randn(2, 3).as_subclass(TensorProxy)
+        with patch.object(
+            InliningInstructionTranslator,
+            "inline_trace_cache_info",
+            classmethod(wrapped_inline_trace_cache_info),
+        ):
+            self.assertTrue(same(opt_fn(x), fn(x)))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertFalse(accepted_subclass_input)
+        self.assertEqual(counters["inline_trace_cache"]["stored"], 0)
         self.assertEqual(counters["inline_trace_cache"]["hit"], 0)
 
     def test_inline_trace_cache_rejects_constant_inputs(self):

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -296,6 +296,88 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(counters["inline_trace_cache"]["stored"], 0)
         self.assertEqual(counters["inline_trace_cache"]["hit"], 0)
 
+    @torch._dynamo.config.patch(inline_trace_cache=False)
+    def test_inline_trace_cache_disabled(self):
+        def block(x):
+            return torch.cos(torch.sin(x + 1.0)) * 2.0
+
+        def fn(x):
+            x = x + 0.0
+            for _ in range(4):
+                x = block(x)
+            return x
+
+        counters.clear()
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+
+        x = torch.randn(3, 4)
+        self.assertTrue(same(opt_fn(x), fn(x)))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(counters["inline_trace_cache"]["stored"], 0)
+        self.assertEqual(counters["inline_trace_cache"]["hit"], 0)
+
+    def test_inline_trace_cache_rejects_inplace_mutation(self):
+        def block(x):
+            return x.add_(1.0)
+
+        def fn(x):
+            x = x.clone()
+            for _ in range(2):
+                x = block(x)
+            return x
+
+        counters.clear()
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+
+        x = torch.randn(3, 4)
+        self.assertTrue(same(opt_fn(x), fn(x)))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(counters["inline_trace_cache"]["stored"], 0)
+        self.assertEqual(counters["inline_trace_cache"]["hit"], 0)
+
+    def test_inline_trace_cache_clones_tuple_return(self):
+        def block(x):
+            return torch.sin(x), torch.cos(x)
+
+        def fn(x):
+            x = x + 0.0
+            for _ in range(3):
+                y, z = block(x)
+                x = y + z
+            return x
+
+        counters.clear()
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+
+        x = torch.randn(3, 4)
+        self.assertTrue(same(opt_fn(x), fn(x)))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(counters["inline_trace_cache"]["stored"], 1)
+        self.assertEqual(counters["inline_trace_cache"]["hit"], 2)
+
+    def test_side_effects_clone_copies_inline_cache_snapshot_fields(self):
+        from torch._dynamo.side_effects import SideEffects
+
+        class OutputGraph:
+            pass
+
+        output_graph = OutputGraph()
+        side_effects = SideEffects(output_graph)
+        side_effects.save_for_backward.append(("ctx", []))
+        side_effects.tensor_hooks[0] = ("tensor", "hook", "handle", "name")
+
+        cloned = side_effects.clone()
+
+        self.assertIsNot(cloned.save_for_backward, side_effects.save_for_backward)
+        self.assertIsNot(cloned.tensor_hooks, side_effects.tensor_hooks)
+        side_effects.save_for_backward.append(("ctx2", []))
+        side_effects.tensor_hooks[1] = ("tensor2", "hook2", "handle2", "name2")
+        self.assertNotEqual(cloned.save_for_backward, side_effects.save_for_backward)
+        self.assertNotEqual(cloned.tensor_hooks, side_effects.tensor_hooks)
+
     def test_lru_cache_warning_issued_during_tracing(self):
         import warnings
         from functools import lru_cache

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -187,6 +187,47 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(counters["inline_trace_cache"]["stored"], 1)
         self.assertEqual(counters["inline_trace_cache"]["hit"], 3)
 
+    def test_inline_trace_cache_keys_on_tensor_stride(self):
+        def block(x):
+            return torch.cos(torch.sin(x + 1.0)) * 2.0
+
+        def fn(x, y):
+            return block(x) + block(y)
+
+        counters.clear()
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+
+        x = torch.randn(2, 3)
+        y = torch.randn(3, 2).t()
+        self.assertEqual(x.shape, y.shape)
+        self.assertNotEqual(x.stride(), y.stride())
+        self.assertTrue(same(opt_fn(x, y), fn(x, y)))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(counters["inline_trace_cache"]["stored"], 2)
+        self.assertEqual(counters["inline_trace_cache"]["hit"], 0)
+
+    def test_inline_trace_cache_rejects_constant_inputs(self):
+        def same_object(a, b):
+            return a is b
+
+        def fn(x):
+            a = b = "xyzpdq"
+            c = a[:3] + b[3:]
+            return (
+                x + (1 if same_object(a, b) else 0) + (10 if same_object(a, c) else 0)
+            )
+
+        counters.clear()
+        cnt = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch.compile(fn, backend=cnt, fullgraph=True)
+
+        x = torch.randn(())
+        self.assertTrue(same(opt_fn(x), fn(x)))
+        self.assertEqual(cnt.frame_count, 1)
+        self.assertEqual(counters["inline_trace_cache"]["stored"], 0)
+        self.assertEqual(counters["inline_trace_cache"]["hit"], 0)
+
     def test_lru_cache_warning_issued_during_tracing(self):
         import warnings
         from functools import lru_cache

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -594,6 +594,10 @@ enable_cpp_framelocals_guard_eval = True
 # regions with a call to invoke_subgraph
 use_graph_deduplication = False
 
+# Reuse previously traced inline FX regions for calls with the same code object
+# and flattened tensor input metadata.
+inline_trace_cache = True
+
 # Whether to track nodes for deduplication (testing only)
 # This flag is ignored if use_graph_deduplication is True
 track_nodes_for_deduplication = False

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -294,7 +294,7 @@ class SideEffects:
         """Create a shallow copy"""
         ref = self.output_graph_weakref()
         assert ref is not None
-        return self.__class__(
+        clone = self.__class__(
             output_graph=ref,
             id_to_variable=dict(self.id_to_variable),
             store_attr_mutations={
@@ -305,6 +305,14 @@ class SideEffects:
             save_for_backward=self.save_for_backward,
             tensor_hooks=self.tensor_hooks,
         )
+        clone._has_existing_dict_mutation = self._has_existing_dict_mutation
+        clone.ca_final_callbacks_var = self.ca_final_callbacks_var
+        clone.ignore_mutation_on_these_variables = set(
+            self.ignore_mutation_on_these_variables
+        )
+        clone.mutated_sources = OrderedSet(self.mutated_sources)
+        clone.deferred_attr_mutations = dict(self.deferred_attr_mutations)
+        return clone
 
     def __contains__(self, item: Any) -> bool:
         return id(item) in self.id_to_variable

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -300,7 +300,9 @@ class SideEffects:
             store_attr_mutations={
                 k: dict(v) for k, v in self.store_attr_mutations.items()
             },
-            mutation_user_stacks=self.mutation_user_stacks,
+            mutation_user_stacks={
+                k: list(v) for k, v in self.mutation_user_stacks.items()
+            },
             keepalive=list(self.keepalive),
             save_for_backward=list(self.save_for_backward),
             tensor_hooks=dict(self.tensor_hooks),

--- a/torch/_dynamo/side_effects.py
+++ b/torch/_dynamo/side_effects.py
@@ -302,8 +302,8 @@ class SideEffects:
             },
             mutation_user_stacks=self.mutation_user_stacks,
             keepalive=list(self.keepalive),
-            save_for_backward=self.save_for_backward,
-            tensor_hooks=self.tensor_hooks,
+            save_for_backward=list(self.save_for_backward),
+            tensor_hooks=dict(self.tensor_hooks),
         )
         clone._has_existing_dict_mutation = self._has_existing_dict_mutation
         clone.ca_final_callbacks_var = self.ca_final_callbacks_var

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5291,9 +5291,17 @@ def profile_inline_call(
             output.profiler_state.add_child_time(cumtime_ns)
 
 
+ConstantCacheKey: TypeAlias = tuple[type, int, Any]
+InlineTraceCacheKey: TypeAlias = tuple[
+    types.CodeType,
+    tuple[tuple[Any, ...], ...],
+    tuple[tuple[str, ConstantCacheKey], ...],
+]
+
+
 @dataclasses.dataclass(frozen=True)
 class InlineTraceCacheInfo:
-    key: Any
+    key: InlineTraceCacheKey
     input_nodes: tuple[torch.fx.Node, ...]
     input_vts: tuple[VariableTracker, ...]
 
@@ -5360,21 +5368,31 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             return result
 
     @staticmethod
-    def _shape_key(shape: Any) -> tuple[Any, ...]:
-        def dim_key(dim: Any) -> Any:
-            if isinstance(dim, torch.SymInt):
-                return dim.node.expr
-            return dim
+    def _tensor_dim_key(dim: Any) -> Any:
+        if isinstance(dim, torch.SymInt):
+            return dim.node.expr
+        return dim
 
-        return tuple(dim_key(dim) for dim in shape)
+    @classmethod
+    def _tensor_dim_sequence_key(cls, shape: Any) -> tuple[Any, ...]:
+        return tuple(cls._tensor_dim_key(dim) for dim in shape)
 
     @staticmethod
-    def _hashable_value_key(value: Any) -> tuple[type, Any] | None:
+    def _hashable_value_key(value: Any) -> ConstantCacheKey | None:
         try:
             hash(value)
         except TypeError:
             return None
-        return (type(value), value)
+        return (type(value), id(value), value)
+
+    @staticmethod
+    @functools.cache
+    def _global_names_for_code(code: types.CodeType) -> tuple[str, ...]:
+        return tuple(
+            inst.argval
+            for inst in dis.get_instructions(code)
+            if inst.opname == "LOAD_GLOBAL" and isinstance(inst.argval, str)
+        )
 
     @classmethod
     def _tensor_input_key(cls, vt: TensorVariable) -> tuple[Any, ...] | None:
@@ -5384,32 +5402,27 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         example_value = proxy.node.meta.get("example_value")
         if not isinstance(example_value, torch.Tensor):
             return None
+        if example_value.layout is not torch.strided:
+            return None
+        if example_value.is_nested:
+            return None
         return (
             "tensor",
-            cls._shape_key(example_value.shape),
+            cls._tensor_dim_sequence_key(example_value.shape),
+            cls._tensor_dim_sequence_key(example_value.stride()),
+            cls._tensor_dim_key(example_value.storage_offset()),
             example_value.dtype,
             example_value.device,
             example_value.requires_grad,
         )
 
     @classmethod
-    def _constant_input_key(cls, vt: ConstantVariable) -> tuple[Any, ...] | None:
-        value_key = cls._hashable_value_key(vt.value)
-        if value_key is None:
-            return None
-        return ("constant", value_key)
-
-    @classmethod
     def _global_key(
         cls, parent: Any, func: BaseUserFunctionVariable, code: types.CodeType
-    ) -> tuple[tuple[str, tuple[type, Any]], ...] | None:
+    ) -> tuple[tuple[str, ConstantCacheKey], ...] | None:
         f_globals = func.get_globals()
-        global_keys: list[tuple[str, tuple[type, Any]]] = []
-        for inst in dis.get_instructions(code):
-            if inst.opname != "LOAD_GLOBAL" or not isinstance(inst.argval, str):
-                continue
-
-            name = inst.argval
+        global_keys: list[tuple[str, ConstantCacheKey]] = []
+        for name in cls._global_names_for_code(code):
             if name not in f_globals:
                 continue
 
@@ -5442,6 +5455,10 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             return None
         if not parent.output.is_root_tracer():
             return None
+        if torch._C._functorch.peek_interpreter_stack() is not None:
+            return None
+        if torch.autograd.forward_ad._current_level != -1:
+            return None
         if not isinstance(func, UserFunctionVariable) or func.has_self():
             return None
 
@@ -5458,23 +5475,19 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         ]
         flat_args.extend(("kwarg", name, kwargs[name]) for name in sorted(kwargs))
 
+        if not all(isinstance(vt, TensorVariable) for _, _, vt in flat_args):
+            return None
+
         for kind, name, vt in flat_args:
-            if isinstance(vt, TensorVariable):
-                tensor_key = cls._tensor_input_key(vt)
-                if tensor_key is None:
-                    return None
-                proxy = vt.as_proxy()
-                assert isinstance(proxy, torch.fx.Proxy)
-                input_nodes.append(proxy.node)
-                input_vts.append(vt)
-                key_parts.append((kind, name, tensor_key))
-            elif isinstance(vt, ConstantVariable):
-                constant_key = cls._constant_input_key(vt)
-                if constant_key is None:
-                    return None
-                key_parts.append((kind, name, constant_key))
-            else:
+            assert isinstance(vt, TensorVariable)
+            tensor_key = cls._tensor_input_key(vt)
+            if tensor_key is None:
                 return None
+            proxy = vt.as_proxy()
+            assert isinstance(proxy, torch.fx.Proxy)
+            input_nodes.append(proxy.node)
+            input_vts.append(vt)
+            key_parts.append((kind, name, tensor_key))
 
         global_key = cls._global_key(parent, func, code)
         if global_key is None:
@@ -5493,8 +5506,12 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
 
     @classmethod
     def _node_is_cacheable(cls, node: torch.fx.Node) -> bool:
+        # Keep the first implementation deliberately narrow: cloned inline
+        # regions are plain operator calls, not module calls or lifted attrs.
         if node.op not in {"call_function", "call_method"}:
             return False
+        # Static schemas catch normal mutable ops. The name fallback catches
+        # Python/custom operators that follow the conventional trailing "_".
         if cls._node_target_name(node).split(".", 1)[0].endswith("_"):
             return False
         schema = getattr(node.target, "_schema", None)
@@ -5545,8 +5562,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             or before.save_for_backward != after.save_for_backward
             or before.tensor_hooks != after.tensor_hooks
             or before.mutated_sources != after.mutated_sources
-            or before.has_existing_dict_mutation()
-            != after.has_existing_dict_mutation()
+            or before.has_existing_dict_mutation() != after.has_existing_dict_mutation()
         )
 
     @classmethod
@@ -5582,6 +5598,15 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         )
         counters["inline_trace_cache"]["stored"] += 1
 
+    @staticmethod
+    def _clone_node_meta(meta: dict[str, Any]) -> dict[str, Any]:
+        new_meta = copy.copy(meta)
+        for key in ("example_value", "val"):
+            value = new_meta.get(key)
+            if isinstance(value, torch.Tensor):
+                new_meta[key] = value.clone()
+        return new_meta
+
     @classmethod
     def _clone_cached_result(
         cls,
@@ -5600,6 +5625,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             proxy = torch.fx.Proxy(new_node, parent.output.current_tracer)
             cloned = result.clone(proxy=proxy, source=None)
             parent.output.current_tracer.record_proxyable_vt(cloned)
+            # _track_obj keeps the proxy alive, so the id-based side-effect
+            # table cannot observe a recycled id during this trace.
             parent.output.side_effects._track_obj(
                 proxy, cloned, mutation_type_cls=AttributeMutationNew
             )
@@ -5636,14 +5663,13 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 new_node = parent.output.graph.node_copy(node, lambda n: node_map[n])
             except KeyError:
                 return None
+            new_node.meta = cls._clone_node_meta(node.meta)
             parent.output.current_tracer._used_names.add(new_node.name)
             if config.use_graph_deduplication or config.track_nodes_for_deduplication:
                 parent.output.region_tracker.track_node(parent, new_node)
             node_map[node] = new_node
 
-        return cls._clone_cached_result(
-            parent, entry.result, node_map, input_vt_map
-        )
+        return cls._clone_cached_result(parent, entry.result, node_map, input_vt_map)
 
     @staticmethod
     def check_inlineable(

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5535,6 +5535,10 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         # regions are plain operator calls, not module calls or lifted attrs.
         if node.op not in {"call_function", "call_method"}:
             return False
+        # Tensor item assignment/deletion routes through Python operator targets
+        # that do not carry torch schemas or conventional mutable names.
+        if node.target in {operator.setitem, operator.delitem}:
+            return False
         # Static schemas catch normal mutable ops. The name fallback catches
         # Python/custom operators that follow the conventional trailing "_".
         if cls._node_target_name(node).split(".", 1)[0].endswith("_"):

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5625,6 +5625,9 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
 
     @staticmethod
     def _clone_node_meta(meta: dict[str, Any]) -> dict[str, Any]:
+        # The cache only stores narrow, pure call_function/call_method regions.
+        # Shallow-copy structural metadata and clone the tensor payloads known to
+        # be mutable downstream so the cached nodes are not corrupted by hits.
         new_meta = copy.copy(meta)
         for key in ("example_value", "val"):
             value = new_meta.get(key)

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -141,7 +141,13 @@ from .utils import (
     LazyString,
     proxy_args_kwargs,
 )
-from .variables.base import SourceLocation, typestr, ValueMutationNew, VariableTracker
+from .variables.base import (
+    AttributeMutationNew,
+    SourceLocation,
+    typestr,
+    ValueMutationNew,
+    VariableTracker,
+)
 from .variables.builder import FrameStateSizeEntry, VariableBuilder, wrap_fx_proxy
 from .variables.builtin import BuiltinVariable, DictBuiltinVariable
 from .variables.constant import ConstantVariable
@@ -5285,6 +5291,20 @@ def profile_inline_call(
             output.profiler_state.add_child_time(cumtime_ns)
 
 
+@dataclasses.dataclass(frozen=True)
+class InlineTraceCacheInfo:
+    key: Any
+    input_nodes: tuple[torch.fx.Node, ...]
+    input_vts: tuple[VariableTracker, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class InlineTraceCacheEntry:
+    input_nodes: tuple[torch.fx.Node, ...]
+    nodes: tuple[torch.fx.Node, ...]
+    result: VariableTracker
+
+
 class InliningInstructionTranslator(InstructionTranslatorBase):
     """Trace and inline a called method"""
 
@@ -5304,8 +5324,326 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         with profile_inline_call(
             parent.output, func.get_code(), lambda: parent.inline_depth + 1
         ):
+            cache_info = cls.inline_trace_cache_info(parent, func, args, kwargs)
+            if cache_info is not None:
+                cached = parent.output.tracing_context.inline_trace_cache.get(
+                    cache_info.key
+                )
+                if cached is not None:
+                    result = cls.try_clone_inline_trace_cache(
+                        parent, cached, cache_info
+                    )
+                    if result is not None:
+                        counters["inline_trace_cache"]["hit"] += 1
+                        parent.has_no_inlined_calls = False
+                        parent.output.tracing_context.traced_code.append(
+                            func.get_code()
+                        )
+                        return result
+
+            prior_nodes = (
+                set(parent.output.graph.nodes) if cache_info is not None else None
+            )
+            prior_side_effects = (
+                parent.output.side_effects.clone() if cache_info is not None else None
+            )
             tracer = cls.build_inline_tracer(parent, func, args, kwargs)
-            return tracer.inline_call_()
+            result = tracer.inline_call_()
+            if (
+                cache_info is not None
+                and prior_nodes is not None
+                and prior_side_effects is not None
+            ):
+                cls.maybe_save_inline_trace_cache(
+                    parent, cache_info, prior_nodes, prior_side_effects, result
+                )
+            return result
+
+    @staticmethod
+    def _shape_key(shape: Any) -> tuple[Any, ...]:
+        def dim_key(dim: Any) -> Any:
+            if isinstance(dim, torch.SymInt):
+                return dim.node.expr
+            return dim
+
+        return tuple(dim_key(dim) for dim in shape)
+
+    @staticmethod
+    def _hashable_value_key(value: Any) -> tuple[type, Any] | None:
+        try:
+            hash(value)
+        except TypeError:
+            return None
+        return (type(value), value)
+
+    @classmethod
+    def _tensor_input_key(cls, vt: TensorVariable) -> tuple[Any, ...] | None:
+        proxy = vt.as_proxy()
+        if not isinstance(proxy, torch.fx.Proxy):
+            return None
+        example_value = proxy.node.meta.get("example_value")
+        if not isinstance(example_value, torch.Tensor):
+            return None
+        return (
+            "tensor",
+            cls._shape_key(example_value.shape),
+            example_value.dtype,
+            example_value.device,
+            example_value.requires_grad,
+        )
+
+    @classmethod
+    def _constant_input_key(cls, vt: ConstantVariable) -> tuple[Any, ...] | None:
+        value_key = cls._hashable_value_key(vt.value)
+        if value_key is None:
+            return None
+        return ("constant", value_key)
+
+    @classmethod
+    def _global_key(
+        cls, parent: Any, func: BaseUserFunctionVariable, code: types.CodeType
+    ) -> tuple[tuple[str, tuple[type, Any]], ...] | None:
+        f_globals = func.get_globals()
+        global_keys: list[tuple[str, tuple[type, Any]]] = []
+        for inst in dis.get_instructions(code):
+            if inst.opname != "LOAD_GLOBAL" or not isinstance(inst.argval, str):
+                continue
+
+            name = inst.argval
+            if name not in f_globals:
+                continue
+
+            symbolic = parent.symbolic_globals.get(name)
+            if isinstance(symbolic, ConstantVariable):
+                value = symbolic.value
+            else:
+                value = f_globals[name]
+
+            value_key = cls._hashable_value_key(value)
+            if value_key is None:
+                return None
+            global_keys.append((name, value_key))
+
+        return tuple(global_keys)
+
+    @classmethod
+    def inline_trace_cache_info(
+        cls,
+        parent: Any,
+        func: BaseUserFunctionVariable,
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> InlineTraceCacheInfo | None:
+        if not config.inline_trace_cache:
+            return None
+        if config.dont_skip_tracing:
+            return None
+        if parent.strict_checks_fn:
+            return None
+        if not parent.output.is_root_tracer():
+            return None
+        if not isinstance(func, UserFunctionVariable) or func.has_self():
+            return None
+
+        code = func.get_code()
+        if is_generator(code) or code.co_freevars:
+            return None
+
+        key_parts: list[tuple[Any, ...]] = []
+        input_nodes: list[torch.fx.Node] = []
+        input_vts: list[VariableTracker] = []
+
+        flat_args: list[tuple[str, Any, VariableTracker]] = [
+            ("arg", i, arg) for i, arg in enumerate(args)
+        ]
+        flat_args.extend(("kwarg", name, kwargs[name]) for name in sorted(kwargs))
+
+        for kind, name, vt in flat_args:
+            if isinstance(vt, TensorVariable):
+                tensor_key = cls._tensor_input_key(vt)
+                if tensor_key is None:
+                    return None
+                proxy = vt.as_proxy()
+                assert isinstance(proxy, torch.fx.Proxy)
+                input_nodes.append(proxy.node)
+                input_vts.append(vt)
+                key_parts.append((kind, name, tensor_key))
+            elif isinstance(vt, ConstantVariable):
+                constant_key = cls._constant_input_key(vt)
+                if constant_key is None:
+                    return None
+                key_parts.append((kind, name, constant_key))
+            else:
+                return None
+
+        global_key = cls._global_key(parent, func, code)
+        if global_key is None:
+            return None
+
+        return InlineTraceCacheInfo(
+            key=(code, tuple(key_parts), global_key),
+            input_nodes=tuple(input_nodes),
+            input_vts=tuple(input_vts),
+        )
+
+    @staticmethod
+    def _node_target_name(node: torch.fx.Node) -> str:
+        target = node.target
+        return getattr(target, "__name__", str(target))
+
+    @classmethod
+    def _node_is_cacheable(cls, node: torch.fx.Node) -> bool:
+        if node.op not in {"call_function", "call_method"}:
+            return False
+        if cls._node_target_name(node).split(".", 1)[0].endswith("_"):
+            return False
+        schema = getattr(node.target, "_schema", None)
+        if schema is not None and getattr(schema, "is_mutable", False):
+            return False
+        return True
+
+    @classmethod
+    def _nodes_are_cacheable(
+        cls, nodes: Sequence[torch.fx.Node], input_nodes: Sequence[torch.fx.Node]
+    ) -> bool:
+        node_set = set(nodes)
+        input_node_set = set(input_nodes)
+
+        for node in nodes:
+            if not cls._node_is_cacheable(node):
+                return False
+
+            def check_arg(arg: Any) -> Any:
+                if isinstance(arg, torch.fx.Node) and (
+                    arg not in node_set and arg not in input_node_set
+                ):
+                    raise RuntimeError
+                return arg
+
+            try:
+                torch.fx.node.map_arg((node.args, node.kwargs), check_arg)
+            except RuntimeError:
+                return False
+
+        return True
+
+    @classmethod
+    def _result_is_cacheable(cls, result: VariableTracker) -> bool:
+        if isinstance(result, (TensorVariable, ConstantVariable)):
+            return True
+        if isinstance(result, TupleVariable):
+            return all(cls._result_is_cacheable(item) for item in result.items)
+        return False
+
+    @staticmethod
+    def _has_external_side_effects(
+        before: Any,
+        after: Any,
+    ) -> bool:
+        return (
+            before.store_attr_mutations != after.store_attr_mutations
+            or before.save_for_backward != after.save_for_backward
+            or before.tensor_hooks != after.tensor_hooks
+            or before.mutated_sources != after.mutated_sources
+            or before.has_existing_dict_mutation()
+            != after.has_existing_dict_mutation()
+        )
+
+    @classmethod
+    def maybe_save_inline_trace_cache(
+        cls,
+        parent: Any,
+        cache_info: InlineTraceCacheInfo,
+        prior_nodes: set[torch.fx.Node],
+        prior_side_effects: Any,
+        result: VariableTracker,
+    ) -> None:
+        if parent.output.should_exit:
+            return
+        if cls._has_external_side_effects(
+            prior_side_effects, parent.output.side_effects
+        ):
+            return
+        if not cls._result_is_cacheable(result):
+            return
+
+        new_nodes = tuple(
+            node for node in parent.output.graph.nodes if node not in prior_nodes
+        )
+        if not cls._nodes_are_cacheable(new_nodes, cache_info.input_nodes):
+            return
+
+        parent.output.tracing_context.inline_trace_cache[cache_info.key] = (
+            InlineTraceCacheEntry(
+                input_nodes=cache_info.input_nodes,
+                nodes=new_nodes,
+                result=result,
+            )
+        )
+        counters["inline_trace_cache"]["stored"] += 1
+
+    @classmethod
+    def _clone_cached_result(
+        cls,
+        parent: Any,
+        result: VariableTracker,
+        node_map: dict[torch.fx.Node, torch.fx.Node],
+        input_vt_map: dict[torch.fx.Node, VariableTracker],
+    ) -> VariableTracker | None:
+        if isinstance(result, TensorVariable):
+            old_node = result.as_proxy().node
+            if old_node in input_vt_map:
+                return input_vt_map[old_node]
+            new_node = node_map.get(old_node)
+            if new_node is None:
+                return None
+            proxy = torch.fx.Proxy(new_node, parent.output.current_tracer)
+            cloned = result.clone(proxy=proxy, source=None)
+            parent.output.current_tracer.record_proxyable_vt(cloned)
+            parent.output.side_effects._track_obj(
+                proxy, cloned, mutation_type_cls=AttributeMutationNew
+            )
+            return cloned
+
+        if isinstance(result, ConstantVariable):
+            return result
+
+        if isinstance(result, TupleVariable):
+            items = []
+            for item in result.items:
+                cloned_item = cls._clone_cached_result(
+                    parent, item, node_map, input_vt_map
+                )
+                if cloned_item is None:
+                    return None
+                items.append(cloned_item)
+            return result.clone(items=items, source=None)
+
+        return None
+
+    @classmethod
+    def try_clone_inline_trace_cache(
+        cls,
+        parent: Any,
+        entry: InlineTraceCacheEntry,
+        cache_info: InlineTraceCacheInfo,
+    ) -> VariableTracker | None:
+        node_map = dict(zip(entry.input_nodes, cache_info.input_nodes))
+        input_vt_map = dict(zip(entry.input_nodes, cache_info.input_vts))
+
+        for node in entry.nodes:
+            try:
+                new_node = parent.output.graph.node_copy(node, lambda n: node_map[n])
+            except KeyError:
+                return None
+            parent.output.current_tracer._used_names.add(new_node.name)
+            if config.use_graph_deduplication or config.track_nodes_for_deduplication:
+                parent.output.region_tracker.track_node(parent, new_node)
+            node_map[node] = new_node
+
+        return cls._clone_cached_result(
+            parent, entry.result, node_map, input_vt_map
+        )
 
     @staticmethod
     def check_inlineable(

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5292,8 +5292,12 @@ def profile_inline_call(
 
 
 ConstantCacheKey: TypeAlias = tuple[type, int, Any]
+InlineTraceCacheCallsiteKey: TypeAlias = tuple[
+    tuple[types.CodeType, int | None, int], ...
+]
 InlineTraceCacheKey: TypeAlias = tuple[
     types.CodeType,
+    InlineTraceCacheCallsiteKey,
     tuple[tuple[Any, ...], ...],
     tuple[tuple[str, ConstantCacheKey], ...],
 ]
@@ -5349,8 +5353,8 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                         )
                         return result
 
-            prior_nodes = (
-                set(parent.output.graph.nodes) if cache_info is not None else None
+            prior_node_count = (
+                len(parent.output.graph.nodes) if cache_info is not None else None
             )
             prior_side_effects = (
                 parent.output.side_effects.clone() if cache_info is not None else None
@@ -5359,11 +5363,11 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             result = tracer.inline_call_()
             if (
                 cache_info is not None
-                and prior_nodes is not None
+                and prior_node_count is not None
                 and prior_side_effects is not None
             ):
                 cls.maybe_save_inline_trace_cache(
-                    parent, cache_info, prior_nodes, prior_side_effects, result
+                    parent, cache_info, prior_node_count, prior_side_effects, result
                 )
             return result
 
@@ -5384,6 +5388,16 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         except TypeError:
             return None
         return (type(value), id(value), value)
+
+    @staticmethod
+    def _callsite_key(parent: Any) -> InlineTraceCacheCallsiteKey:
+        frames: list[tuple[types.CodeType, int | None, int]] = []
+        tx = parent
+        while tx is not None:
+            inst = getattr(tx, "current_instruction", None)
+            frames.append((tx.f_code, getattr(inst, "offset", None), tx.lineno))
+            tx = getattr(tx, "parent", None)
+        return tuple(reversed(frames))
 
     @staticmethod
     @functools.cache
@@ -5474,12 +5488,23 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             ("arg", i, arg) for i, arg in enumerate(args)
         ]
         flat_args.extend(("kwarg", name, kwargs[name]) for name in sorted(kwargs))
+        realized_flat_args: list[tuple[str, Any, VariableTracker]] = []
+        for kind, name, vt in flat_args:
+            if isinstance(vt, LazyVariableTracker):
+                # Cache probing must not realize lazy inputs: realization can
+                # install guards and source metadata at the callsite instead of
+                # the callee bytecode location.
+                if not vt.is_realized():
+                    return None
+                vt = vt.unwrap()
+            realized_flat_args.append((kind, name, vt))
+        flat_args = realized_flat_args
 
-        if not all(isinstance(vt, TensorVariable) for _, _, vt in flat_args):
+        if not all(type(vt) is TensorVariable for _, _, vt in flat_args):
             return None
 
         for kind, name, vt in flat_args:
-            assert isinstance(vt, TensorVariable)
+            assert type(vt) is TensorVariable
             tensor_key = cls._tensor_input_key(vt)
             if tensor_key is None:
                 return None
@@ -5494,7 +5519,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             return None
 
         return InlineTraceCacheInfo(
-            key=(code, tuple(key_parts), global_key),
+            key=(code, cls._callsite_key(parent), tuple(key_parts), global_key),
             input_nodes=tuple(input_nodes),
             input_vts=tuple(input_vts),
         )
@@ -5570,7 +5595,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         cls,
         parent: Any,
         cache_info: InlineTraceCacheInfo,
-        prior_nodes: set[torch.fx.Node],
+        prior_node_count: int,
         prior_side_effects: Any,
         result: VariableTracker,
     ) -> None:
@@ -5584,7 +5609,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             return
 
         new_nodes = tuple(
-            node for node in parent.output.graph.nodes if node not in prior_nodes
+            itertools.islice(parent.output.graph.nodes, prior_node_count, None)
         )
         if not cls._nodes_are_cacheable(new_nodes, cache_info.input_nodes):
             return

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -37,6 +37,10 @@ if TYPE_CHECKING:
     from torch._dynamo.backends.distributed import DDPOptimizerContext
     from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.guards import GuardCheckSpec
+    from torch._dynamo.symbolic_convert import (
+        InlineTraceCacheEntry,
+        InlineTraceCacheKey,
+    )
     from torch._functorch._aot_autograd.schemas import ViewAndMutationMeta
     from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
     from torch._subclasses.fake_tensor import FakeTensorMode
@@ -1075,8 +1079,11 @@ class TracingContext:
         # Combined cache for inlined code data (instructions, indexof, code_options)
         self.inlined_code_cache: dict[Any, InlinedCodeCache] = dict()
         # Cache of successfully traced inline FX regions, keyed by code object
-        # and flattened input metadata. Values are defined in symbolic_convert.py.
-        self.inline_trace_cache: dict[Any, Any] = dict()
+        # and flattened input metadata. Entries intentionally keep FX nodes alive
+        # for this TracingContext lifetime; clear() drops them between traces.
+        self.inline_trace_cache: dict[InlineTraceCacheKey, InlineTraceCacheEntry] = (
+            dict()
+        )
         self.fake_mode: FakeTensorMode | None = fake_mode
         self.frame_summary_stack: list[traceback.FrameSummary] = []
         # This is morally part of frame_summary_stack, but it is kept separate

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1074,6 +1074,9 @@ class TracingContext:
         self.previously_cleaned_instructions: dict[Any, Any] = dict()
         # Combined cache for inlined code data (instructions, indexof, code_options)
         self.inlined_code_cache: dict[Any, InlinedCodeCache] = dict()
+        # Cache of successfully traced inline FX regions, keyed by code object
+        # and flattened input metadata. Values are defined in symbolic_convert.py.
+        self.inline_trace_cache: dict[Any, Any] = dict()
         self.fake_mode: FakeTensorMode | None = fake_mode
         self.frame_summary_stack: list[traceback.FrameSummary] = []
         # This is morally part of frame_summary_stack, but it is kept separate
@@ -1127,6 +1130,7 @@ class TracingContext:
         self.previously_inlined_functions.clear()
         self.previously_cleaned_instructions.clear()
         self.inlined_code_cache.clear()
+        self.inline_trace_cache.clear()
 
     @staticmethod
     @contextmanager


### PR DESCRIPTION
## Summary
- add a conservative inline trace cache keyed by code object, inline callsite stack, flattened tensor input metadata, and global identities
- clone cached FX nodes on cache hits instead of re-running duplicate callee bytecode
- keep cache probing non-invasive for lazy inputs, reject tensor subclasses, and avoid cross-callsite reuse that would carry stale source metadata
- add coverage for same-callsite reuse, stride-sensitive misses, callsite-sensitive misses, tensor subclass rejection, and constant-input rejection

## Root cause problem
Repeated calls to the same side-effect-free user function with the same input tensor metadata always build a fresh `InliningInstructionTranslator` and replay the callee bytecode, even when a prior inline trace already emitted an equivalent FX region in the same Dynamo trace.

The initial cache implementation was still too broad in three places: probing unrealized lazy inputs could install guards/source metadata at the caller instead of the callee bytecode location, the key did not distinguish different inline callsites, and `TensorVariable` subclasses such as `TensorWithTFOverrideVariable` could pass the cache eligibility check.

## Proposed fix
Cache eligible inline FX regions in the current `TracingContext`. On a matching later call, remap the cached input FX nodes to the current call inputs, clone the cached FX nodes, and reconstruct the returned `VariableTracker` without stepping through the callee bytecode again.

The cache now only unwraps already-realized lazy inputs, requires exact `TensorVariable` inputs, includes the inline callsite stack in the key, and records new nodes from the prior graph length rather than building a full pre-inline node set.

## Why this is the right long term fix
Doing the reuse before tracing avoids paying bytecode interpretation cost for duplicate regions while preserving Dynamo's guard/source attribution behavior. Keeping the first implementation conservative is the right tradeoff: calls with lazy inputs, tensor subclasses, constants, side effects, mutation-like nodes, or different source callsites fall back to normal tracing instead of risking stale FX metadata or incorrect dispatch behavior.

## Testing
- `USE_NIGHTLY="2.13.0.dev20260427+cpu" python -m pip install --no-build-isolation -v -e .`
- New tests failed without the implementation change: `PYTHONPATH=$PWD .venv/bin/python test/dynamo/test_functions.py FunctionTests.test_inline_trace_cache_keys_on_callsite FunctionTests.test_inline_trace_cache_rejects_tensor_subclasses`
- `PYTHONPATH=$PWD .venv/bin/python test/dynamo/test_functions.py FunctionTests.test_inline_trace_cache_reuses_same_shape_function FunctionTests.test_inline_trace_cache_keys_on_tensor_stride FunctionTests.test_inline_trace_cache_keys_on_callsite FunctionTests.test_inline_trace_cache_rejects_tensor_subclasses FunctionTests.test_inline_trace_cache_rejects_constant_inputs`
- `PYTHONPATH=$PWD .venv/bin/python test/dynamo/test_logging.py LoggingTests.test_recompiles`
- `PYTHONPATH=$PWD .venv/bin/python test/dynamo/test_error_messages.py ErrorMessagesTest.test_variable_tracker_source_attribution`
- `PYTHONPATH=$PWD .venv/bin/python test/dynamo/test_fake_distributed.py TestFakeDistributed.test_all_to_all_single_autograd`
- `PATH=$PWD/.venv/bin:$PATH .venv/bin/lintrunner --skip PYREFLY torch/_dynamo/symbolic_convert.py test/dynamo/test_functions.py`
- `git diff --check`

Note: full `lintrunner` with PYREFLY was attempted, but local pyrefly reported broad pre-existing missing-attribute errors across unrelated `torch/*` and `test/*` files under the editable nightly setup, so I reran the touched-file lint suite with PYREFLY skipped.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98