### PR TITLE
Use modular compile regions for TransformerEncoder layers

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -2,6 +2,7 @@
 # flake8: noqa: E731
 
 import contextlib
+import copy
 import unittest
 import unittest.mock as mock
 
@@ -3277,6 +3278,41 @@ class TestInvokeSubgraphReuse(TestCase):
 
         self.assertEqual(ref, res)
         self.assertEqual(count(), 1)
+
+    def test_transformer_encoder_layers_auto_reuse_backward(self):
+        torch.manual_seed(0)
+        layer = torch.nn.TransformerEncoderLayer(
+            d_model=4,
+            nhead=2,
+            dim_feedforward=8,
+            dropout=0.0,
+            batch_first=True,
+        )
+        encoder = torch.nn.TransformerEncoder(layer, num_layers=3)
+        with torch.no_grad():
+            encoder.layers[1].linear1.weight.add_(0.25)
+            encoder.layers[2].linear2.bias.add_(0.5)
+
+        compiled_encoder = copy.deepcopy(encoder)
+        x = torch.randn(2, 3, 4, requires_grad=True)
+        x_clone = x.detach().clone().requires_grad_(True)
+
+        ref = encoder(x)
+        with self._count_speculate_calls() as count:
+            res = torch.compile(compiled_encoder, backend="aot_eager", fullgraph=True)(
+                x_clone
+            )
+
+        self.assertEqual(count(), 1)
+        ref.sum().backward()
+        res.sum().backward()
+
+        self.assertEqual(ref, res)
+        self.assertEqual(x.grad, x_clone.grad)
+        for ref_param, res_param in zip(
+            encoder.parameters(), compiled_encoder.parameters()
+        ):
+            self.assertEqual(ref_param.grad, res_param.grad)
 
     def test_subgraph_reuse_different_shapes(self):
         @nested_compile_region

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -3254,6 +3254,30 @@ class TestInvokeSubgraphReuse(TestCase):
 
         self.assertEqual(count(), 1)
 
+    def test_transformer_encoder_layers_auto_reuse(self):
+        torch.manual_seed(0)
+        layer = torch.nn.TransformerEncoderLayer(
+            d_model=4,
+            nhead=2,
+            dim_feedforward=8,
+            dropout=0.0,
+            batch_first=True,
+        )
+        encoder = torch.nn.TransformerEncoder(layer, num_layers=3)
+        encoder.eval()
+        with torch.no_grad():
+            encoder.layers[1].linear1.weight.add_(0.25)
+            encoder.layers[2].linear2.bias.add_(0.5)
+
+        x = torch.randn(2, 3, 4, requires_grad=True)
+        ref = encoder(x)
+
+        with self._count_speculate_calls() as count:
+            res = torch.compile(encoder, backend="aot_eager", fullgraph=True)(x)
+
+        self.assertEqual(ref, res)
+        self.assertEqual(count(), 1)
+
     def test_subgraph_reuse_different_shapes(self):
         @nested_compile_region
         def gn(x):

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -77,7 +77,11 @@ def _call_transformer_encoder_layer(
     is_causal: bool | None,
     src_key_padding_mask: Tensor | None,
 ) -> Tensor:
-    if torch.compiler.is_dynamo_compiling() and not torch.compiler.is_exporting():
+    if (
+        not torch.jit.is_scripting()
+        and torch.compiler.is_dynamo_compiling()
+        and not torch.compiler.is_exporting()
+    ):
         from torch._higher_order_ops.invoke_subgraph import invoke_subgraph_placeholder
 
         # Keep mod as an explicit argument so the reuse cache can remap
@@ -580,13 +584,21 @@ class TransformerEncoder(Module):
         is_causal = _detect_is_causal_mask(mask, is_causal, seq_len)
 
         for mod in self.layers:
-            output = _call_transformer_encoder_layer(
-                mod,
-                output,
-                mask,
-                is_causal,
-                src_key_padding_mask_for_layers,
-            )
+            if torch.jit.is_scripting():
+                output = mod(
+                    output,
+                    src_mask=mask,
+                    is_causal=is_causal,
+                    src_key_padding_mask=src_key_padding_mask_for_layers,
+                )
+            else:
+                output = _call_transformer_encoder_layer(
+                    mod,
+                    output,
+                    mask,
+                    is_causal,
+                    src_key_padding_mask_for_layers,
+                )
 
         if convert_to_nested:
             output = output.to_padded_tensor(0.0, src.size())

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -55,6 +55,51 @@ def _get_seq_len(src: Tensor, batch_first: bool) -> int | None:
             return src_size[seq_len_pos]
 
 
+def _transformer_encoder_layer_forward(
+    mod: Module,
+    src: Tensor,
+    src_mask: Tensor | None,
+    is_causal: bool | None,
+    src_key_padding_mask: Tensor | None,
+) -> Tensor:
+    return mod(
+        src,
+        src_mask=src_mask,
+        is_causal=is_causal,
+        src_key_padding_mask=src_key_padding_mask,
+    )
+
+
+def _call_transformer_encoder_layer(
+    mod: Module,
+    src: Tensor,
+    src_mask: Tensor | None,
+    is_causal: bool | None,
+    src_key_padding_mask: Tensor | None,
+) -> Tensor:
+    if torch.compiler.is_dynamo_compiling() and not torch.compiler.is_exporting():
+        from torch._higher_order_ops.invoke_subgraph import invoke_subgraph_placeholder
+
+        # Keep mod as an explicit argument so the reuse cache can remap
+        # captured parameter sources across self.layers[0], self.layers[1], ...
+        return invoke_subgraph_placeholder(
+            _transformer_encoder_layer_forward,
+            mod,
+            src,
+            src_mask,
+            is_causal,
+            src_key_padding_mask,
+        )
+
+    return _transformer_encoder_layer_forward(
+        mod,
+        src,
+        src_mask,
+        is_causal,
+        src_key_padding_mask,
+    )
+
+
 class Transformer(Module):
     r"""A basic transformer layer.
 
@@ -535,11 +580,12 @@ class TransformerEncoder(Module):
         is_causal = _detect_is_causal_mask(mask, is_causal, seq_len)
 
         for mod in self.layers:
-            output = mod(
+            output = _call_transformer_encoder_layer(
+                mod,
                 output,
-                src_mask=mask,
-                is_causal=is_causal,
-                src_key_padding_mask=src_key_padding_mask_for_layers,
+                mask,
+                is_causal,
+                src_key_padding_mask_for_layers,
             )
 
         if convert_to_nested:


### PR DESCRIPTION
## Summary
- Route `TransformerEncoder` layer calls through `invoke_subgraph` while Dynamo is compiling so repeated encoder layers are traced once and stamped out through the existing reuse cache.
- Keep eager and export behavior on the direct module-call path.
- Add a regression test covering parameter remapping across cloned encoder layers with distinct weights.

## Root cause problem
`TransformerEncoder.forward` directly called each cloned `TransformerEncoderLayer`, so Dynamo inlined every layer into the parent graph. The existing graph dedup pass can replace repeated regions after tracing, but it still pays the O(N * layer_size) tracing cost first.

## Proposed fix
During `torch.compile` tracing, call a small encoder-layer wrapper through `invoke_subgraph_placeholder`. The layer module is an explicit argument, allowing the invoke-subgraph reuse cache to remap captured parameter sources from `self.layers[0]` to later layers. Outside Dynamo compilation, and during export, the helper falls back to the original direct layer call.

## Why this is the right long term fix
This reuses the compiler-owned nested-region/invoke-subgraph abstraction instead of adding a Transformer-specific compiler path. It moves repeated-layer modularization before tracing cost is paid, while relying on existing guard and source-remapping checks for correctness when layers have distinct parameters.

## Tests
- `PYTHONPATH=$PWD:$PWD/test .venv/bin/python -m py_compile torch/nn/modules/transformer.py test/higher_order_ops/test_invoke_subgraph.py`
- `PYTHONPATH=$PWD:$PWD/test .venv/bin/python test/higher_order_ops/test_invoke_subgraph.py TestInvokeSubgraphReuse.test_transformer_encoder_layers_auto_reuse`
- `PYTHONPATH=$PWD:$PWD/test .venv/bin/python test/higher_order_ops/test_invoke_subgraph.py TestInvokeSubgraphReuse`
- Verified the new test fails without the `TransformerEncoder` implementation change: expected 1 speculate trace, got 0.

## Notes
- A broad `lintrunner` attempt was not actionable in this source-only/nightly-binary environment: it ran broad PyRefly checks outside the touched files and reported pre-existing generated-stub/module attribute errors.

Drafted via Codex, published after manual review by @bobrenjc93