### PR TITLE
Make Dynamo stream state lazy

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -2,6 +2,8 @@
 import re
 import unittest
 import weakref
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import patch
 
 import torch
@@ -59,6 +61,39 @@ class TestStreams(torch._dynamo.test_case.TestCase):
             self.assertEqual(opt_fn(torch.ones(1)), torch.ones(1) + 1)
 
         current_stream.assert_not_called()
+
+    def test_event_record_rescans_delayed_input_mutations(self):
+        from torch._dynamo.variables.streams import EventVariable, StreamVariable
+
+        class FakeOutput:
+            def __init__(self) -> None:
+                self.checked_input_mutation = False
+
+            def check_input_mutation_on_current_stream(self, tx) -> None:
+                self.checked_input_mutation = True
+
+            def check_event_record_after_input_mutation(self, stream_id) -> None:
+                if not self.checked_input_mutation:
+                    raise AssertionError(
+                        "input mutations were not checked before record"
+                    )
+
+            def create_proxy(self, *args, **kwargs):
+                return None
+
+        class FakeStream:
+            device = torch.device("cuda")
+
+        output = FakeOutput()
+        tx = SimpleNamespace(output=output)
+        stream = StreamVariable(
+            cast(Any, None), cast(torch.Stream, FakeStream()), user_object_index=1
+        )
+        event = EventVariable(
+            cast(Any, None), cast(torch.Event, object()), user_object_index=2
+        )
+
+        event.call_method(tx, "record", [stream], {})
 
     @requires_cuda
     def test_stream_enter_exit(self):

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -8,8 +8,9 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.graph_bytecode_inputs import (
+    FIRST_USER_OBJECT_INDEX,
     reset_user_object_tracking,
-    store_user_object_weakrefs,
+    store_user_object_weakrefs_by_index,
 )
 from torch._dynamo.testing import extract_graph, remove_trailing_space
 from torch.testing._internal.common_utils import requires_cuda
@@ -669,11 +670,13 @@ class <lambda>(torch.nn.Module):
         try:
             s0 = torch.Stream()
             s1 = torch.Stream()
-            store_user_object_weakrefs(s0, s1)
+            s0_index = FIRST_USER_OBJECT_INDEX
+            s1_index = FIRST_USER_OBJECT_INDEX + 1
+            store_user_object_weakrefs_by_index((s0_index, s1_index), s0, s1)
 
             sample_inputs = [
-                (0, 1),
-                (1, 0),
+                (s0_index, s1_index),
+                (s1_index, s0_index),
             ]
             for args in sample_inputs:
                 opcheck(fork_stream, args)
@@ -693,11 +696,17 @@ class <lambda>(torch.nn.Module):
             s1 = torch.Stream()
             e0 = torch.Event()
             e1 = torch.Event()
-            store_user_object_weakrefs(s0, s1, e0, e1)
+            s0_index = FIRST_USER_OBJECT_INDEX
+            s1_index = FIRST_USER_OBJECT_INDEX + 1
+            e0_index = FIRST_USER_OBJECT_INDEX + 2
+            e1_index = FIRST_USER_OBJECT_INDEX + 3
+            store_user_object_weakrefs_by_index(
+                (s0_index, s1_index, e0_index, e1_index), s0, s1, e0, e1
+            )
 
             sample_inputs = [
-                (2, 0),
-                (3, 1),
+                (e0_index, s0_index),
+                (e1_index, s1_index),
             ]
             for args in sample_inputs:
                 opcheck(wait_event, args)
@@ -715,11 +724,16 @@ class <lambda>(torch.nn.Module):
             s0 = torch.Stream()
             s1 = torch.Stream()
             s2 = torch.Stream()
-            store_user_object_weakrefs(s0, s1, s2)
+            s0_index = FIRST_USER_OBJECT_INDEX
+            s1_index = FIRST_USER_OBJECT_INDEX + 1
+            s2_index = FIRST_USER_OBJECT_INDEX + 2
+            store_user_object_weakrefs_by_index(
+                (s0_index, s1_index, s2_index), s0, s1, s2
+            )
 
             sample_inputs = [
-                (0, 1),
-                (2, 0),
+                (s0_index, s1_index),
+                (s2_index, s0_index),
             ]
             for args in sample_inputs:
                 opcheck(wait_stream, args)

--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -42,6 +42,23 @@ class TestStreams(torch._dynamo.test_case.TestCase):
         e = torch.Event()
         weakref.ref(e)
 
+    def test_stream_state_is_lazy_for_non_stream_graphs(self):
+        def fn(x):
+            return x + 1
+
+        with (
+            patch.object(torch.accelerator, "is_available", return_value=True),
+            patch.object(
+                torch.accelerator,
+                "current_stream",
+                side_effect=AssertionError("current_stream should be lazy"),
+            ) as current_stream,
+        ):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertEqual(opt_fn(torch.ones(1)), torch.ones(1) + 1)
+
+        current_stream.assert_not_called()
+
     @requires_cuda
     def test_stream_enter_exit(self):
         def fn(x, y, s1, s2):

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1083,7 +1083,7 @@ main()
 
             insts = list(dis.get_instructions(out_code))
             # Find the CALL that invokes the compiled graph function
-            # (not an earlier CALL from e.g. store_user_object_weakrefs).
+            # (not an earlier CALL from e.g. store_user_object_weakrefs_by_index).
             # The compiled fn is loaded via LOAD_GLOBAL __compiled_fn_*.
             load_graph_idx = next(
                 i
@@ -1168,7 +1168,7 @@ main()
 
                 insts = list(dis.get_instructions(out_code))
                 # Find the CALL that invokes the compiled graph function
-                # (not an earlier CALL from e.g. store_user_object_weakrefs).
+                # (not an earlier CALL from e.g. store_user_object_weakrefs_by_index).
                 load_graph_idx = next(
                     i
                     for i, inst in enumerate(insts)

--- a/torch/_dynamo/graph_bytecode_inputs.py
+++ b/torch/_dynamo/graph_bytecode_inputs.py
@@ -51,14 +51,6 @@ def get_external_object_by_index(index: int) -> Any:
     return index_to_external_object_weakref[index]()
 
 
-def store_user_object_weakrefs(*args: Any) -> None:
-    global index_to_external_object_weakref
-    index_to_external_object_weakref.clear()
-    index_to_external_object_weakref.update(
-        {i: weakref.ref(arg) for i, arg in enumerate(args)}
-    )
-
-
 def store_user_object_weakrefs_by_index(indices: tuple[int, ...], *args: Any) -> None:
     global index_to_external_object_weakref
     assert len(indices) == len(args)
@@ -76,15 +68,34 @@ def reset_user_object_tracking() -> None:
     next_user_object_index = FIRST_USER_OBJECT_INDEX
 
 
-def _store_user_object_weakref(index: int, value: Any) -> None:
+def _try_store_external_object_weakref(index: int, value: Any) -> TypeError | None:
     try:
         index_to_external_object_weakref[index] = weakref.ref(value)
+        return None
     except TypeError as e:
+        return e
+
+
+def _store_user_object_weakref(index: int, value: Any) -> None:
+    if e := _try_store_external_object_weakref(index, value):
         from .exc import unimplemented
 
         unimplemented(
             gb_type="Failed to make weakref to User Object",
             context=f"user_object: {value}",
+            explanation="Object does not allow us to make a weakref to it",
+            hints=[],
+            from_exc=e,
+        )
+
+
+def _store_graph_created_object_weakref(index: int, example_value: Any) -> None:
+    if e := _try_store_external_object_weakref(index, example_value):
+        from .exc import unimplemented
+
+        unimplemented(
+            gb_type="Failed to make weakref to graph-created external object",
+            context=f"user_object: {example_value}",
             explanation="Object does not allow us to make a weakref to it",
             hints=[],
             from_exc=e,
@@ -106,18 +117,7 @@ def register_graph_created_object(
     keep_alive.append(example_value)
     index = _next_user_object_index()
     index_to_bytecode_constructor[index] = lambda cg: construct_fn(index, cg)
-    try:
-        index_to_external_object_weakref[index] = weakref.ref(example_value)
-    except TypeError as e:
-        from .exc import unimplemented
-
-        unimplemented(
-            gb_type="Failed to make weakref to graph-created external object",
-            context=f"user_object: {example_value}",
-            explanation="Object does not allow us to make a weakref to it",
-            hints=[],
-            from_exc=e,
-        )
+    _store_graph_created_object_weakref(index, example_value)
     return index
 
 

--- a/torch/_dynamo/graph_bytecode_inputs.py
+++ b/torch/_dynamo/graph_bytecode_inputs.py
@@ -20,6 +20,12 @@ index_to_external_object_weakref: dict[int, weakref.ReferenceType[Any]] = {}
 
 keep_alive: list[Any] = []
 
+# Keep index 0 available for the ambient current stream so cudagraph wrappers
+# can replace it with the capture stream at runtime.
+CURRENT_STREAM_INDEX = 0
+FIRST_USER_OBJECT_INDEX = CURRENT_STREAM_INDEX + 1
+next_user_object_index = FIRST_USER_OBJECT_INDEX
+
 
 def has_user_objects() -> bool:
     return bool(index_to_bytecode_constructor)
@@ -28,12 +34,6 @@ def has_user_objects() -> bool:
 def stash_graph_created_object(obj: Any) -> Any:
     keep_alive.append(obj)
     return obj
-
-
-# Keep index 0 available for the ambient current stream so cudagraph wrappers
-# can replace it with the capture stream at runtime.
-CURRENT_STREAM_INDEX = 0
-FIRST_USER_OBJECT_INDEX = CURRENT_STREAM_INDEX + 1
 
 
 def set_external_object_by_index(index: int, value: Any) -> None:
@@ -69,19 +69,32 @@ def store_user_object_weakrefs_by_index(indices: tuple[int, ...], *args: Any) ->
 
 
 def reset_user_object_tracking() -> None:
+    global next_user_object_index
     index_to_bytecode_constructor.clear()
     index_to_external_object_weakref.clear()
     keep_alive.clear()
+    next_user_object_index = FIRST_USER_OBJECT_INDEX
 
 
-def _store_external_object_weakref(index: int, value: Any) -> None:
-    index_to_external_object_weakref[index] = weakref.ref(value)
+def _store_user_object_weakref(index: int, value: Any) -> None:
+    try:
+        index_to_external_object_weakref[index] = weakref.ref(value)
+    except TypeError as e:
+        from .exc import unimplemented
+
+        unimplemented(
+            gb_type="Failed to make weakref to User Object",
+            context=f"user_object: {value}",
+            explanation="Object does not allow us to make a weakref to it",
+            hints=[],
+            from_exc=e,
+        )
 
 
 def _next_user_object_index() -> int:
-    index = FIRST_USER_OBJECT_INDEX
-    while index in index_to_bytecode_constructor:
-        index += 1
+    global next_user_object_index
+    index = next_user_object_index
+    next_user_object_index += 1
     return index
 
 
@@ -94,7 +107,7 @@ def register_graph_created_object(
     index = _next_user_object_index()
     index_to_bytecode_constructor[index] = lambda cg: construct_fn(index, cg)
     try:
-        _store_external_object_weakref(index, example_value)
+        index_to_external_object_weakref[index] = weakref.ref(example_value)
     except TypeError as e:
         from .exc import unimplemented
 
@@ -113,18 +126,7 @@ def register_user_object(value: Any, source: Source) -> int:
     global index_to_bytecode_constructor
     index = _next_user_object_index()
     index_to_bytecode_constructor[index] = lambda cg: cg(source)
-    try:
-        _store_external_object_weakref(index, value)
-    except TypeError as e:
-        from .exc import unimplemented
-
-        unimplemented(
-            gb_type="Failed to make weakref to User Object",
-            context=f"user_object: {value}",
-            explanation="Object does not allow us to make a weakref to it",
-            hints=[],
-            from_exc=e,
-        )
+    _store_user_object_weakref(index, value)
     return index
 
 
@@ -134,18 +136,7 @@ def register_current_stream(value: Any, source: Source) -> int:
         f"Current stream index {CURRENT_STREAM_INDEX} is already registered"
     )
     index_to_bytecode_constructor[CURRENT_STREAM_INDEX] = lambda cg: cg(source)
-    try:
-        _store_external_object_weakref(CURRENT_STREAM_INDEX, value)
-    except TypeError as e:
-        from .exc import unimplemented
-
-        unimplemented(
-            gb_type="Failed to make weakref to User Object",
-            context=f"user_object: {value}",
-            explanation="Object does not allow us to make a weakref to it",
-            hints=[],
-            from_exc=e,
-        )
+    _store_user_object_weakref(CURRENT_STREAM_INDEX, value)
     return CURRENT_STREAM_INDEX
 
 

--- a/torch/_dynamo/graph_bytecode_inputs.py
+++ b/torch/_dynamo/graph_bytecode_inputs.py
@@ -30,7 +30,10 @@ def stash_graph_created_object(obj: Any) -> Any:
     return obj
 
 
+# Keep index 0 available for the ambient current stream so cudagraph wrappers
+# can replace it with the capture stream at runtime.
 CURRENT_STREAM_INDEX = 0
+FIRST_USER_OBJECT_INDEX = CURRENT_STREAM_INDEX + 1
 
 
 def set_external_object_by_index(index: int, value: Any) -> None:
@@ -56,10 +59,30 @@ def store_user_object_weakrefs(*args: Any) -> None:
     )
 
 
+def store_user_object_weakrefs_by_index(indices: tuple[int, ...], *args: Any) -> None:
+    global index_to_external_object_weakref
+    assert len(indices) == len(args)
+    index_to_external_object_weakref.clear()
+    index_to_external_object_weakref.update(
+        {i: weakref.ref(arg) for i, arg in zip(indices, args)}
+    )
+
+
 def reset_user_object_tracking() -> None:
     index_to_bytecode_constructor.clear()
     index_to_external_object_weakref.clear()
     keep_alive.clear()
+
+
+def _store_external_object_weakref(index: int, value: Any) -> None:
+    index_to_external_object_weakref[index] = weakref.ref(value)
+
+
+def _next_user_object_index() -> int:
+    index = FIRST_USER_OBJECT_INDEX
+    while index in index_to_bytecode_constructor:
+        index += 1
+    return index
 
 
 def register_graph_created_object(
@@ -68,10 +91,10 @@ def register_graph_created_object(
     global index_to_bytecode_constructor
     global keep_alive
     keep_alive.append(example_value)
-    index = len(index_to_bytecode_constructor)
+    index = _next_user_object_index()
     index_to_bytecode_constructor[index] = lambda cg: construct_fn(index, cg)
     try:
-        index_to_external_object_weakref[index] = weakref.ref(example_value)
+        _store_external_object_weakref(index, example_value)
     except TypeError as e:
         from .exc import unimplemented
 
@@ -88,10 +111,10 @@ def register_graph_created_object(
 # Register a user object to be used in the graph
 def register_user_object(value: Any, source: Source) -> int:
     global index_to_bytecode_constructor
-    index = len(index_to_bytecode_constructor)
+    index = _next_user_object_index()
     index_to_bytecode_constructor[index] = lambda cg: cg(source)
     try:
-        index_to_external_object_weakref[index] = weakref.ref(value)
+        _store_external_object_weakref(index, value)
     except TypeError as e:
         from .exc import unimplemented
 
@@ -103,6 +126,27 @@ def register_user_object(value: Any, source: Source) -> int:
             from_exc=e,
         )
     return index
+
+
+def register_current_stream(value: Any, source: Source) -> int:
+    global index_to_bytecode_constructor
+    assert CURRENT_STREAM_INDEX not in index_to_bytecode_constructor, (
+        f"Current stream index {CURRENT_STREAM_INDEX} is already registered"
+    )
+    index_to_bytecode_constructor[CURRENT_STREAM_INDEX] = lambda cg: cg(source)
+    try:
+        _store_external_object_weakref(CURRENT_STREAM_INDEX, value)
+    except TypeError as e:
+        from .exc import unimplemented
+
+        unimplemented(
+            gb_type="Failed to make weakref to User Object",
+            context=f"user_object: {value}",
+            explanation="Object does not allow us to make a weakref to it",
+            hints=[],
+            from_exc=e,
+        )
+    return CURRENT_STREAM_INDEX
 
 
 # Register a callback so invoke_leaf_function can retrieve nn.Module instances at runtime.

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2849,12 +2849,14 @@ class OutputGraph(OutputGraphCommon):
                 cg.add_push_null(
                     lambda: cg.load_import_from(
                         torch._dynamo.graph_bytecode_inputs.__name__,
-                        "store_user_object_weakrefs",
+                        "store_user_object_weakrefs_by_index",
                     )
                 )
 
                 tmp_vars = []
-                for constructor in index_to_bytecode_constructor.values():
+                user_object_indices = tuple(sorted(index_to_bytecode_constructor))
+                for index in user_object_indices:
+                    constructor = index_to_bytecode_constructor[index]
                     constructor(cg)
                     var_name = (
                         self.new_var()
@@ -2863,10 +2865,11 @@ class OutputGraph(OutputGraphCommon):
                     cg.store(var_name)
                     tmp_vars.append(var_name)
 
+                cg.append_output(cg.create_load_const(user_object_indices))
                 for var_name in tmp_vars:
                     cg.append_output(cg.create_load(var_name))
 
-                cg.call_function(len(index_to_bytecode_constructor), False)
+                cg.call_function(len(user_object_indices) + 1, False)
                 cg.pop_top()
 
             for idx, arg in enumerate(self.graphargs):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1201,7 +1201,7 @@ class VariableBuilder:
         elif isinstance(value, torch.Stream):
             self.install_guards(GuardBuilder.TYPE_MATCH)
             if isinstance(self.source, CurrentStreamSource):
-                # Reuse the index pre-allocated in SymbolicStreamState.__init__
+                # Reuse the index registered by SymbolicStreamState on demand.
                 index = CURRENT_STREAM_INDEX
             else:
                 index = register_user_object(value, self.source)

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -448,6 +448,7 @@ class StreamVariable(StreamContextVariable):
         elif name == "record_event":
             from .builder import wrap_fx_proxy
 
+            tx.output.check_input_mutation_on_current_stream(tx)
             tx.output.check_event_record_after_input_mutation(id(self.value))
             if args and isinstance(args[0], EventVariable):
                 event_var = args[0]
@@ -624,6 +625,7 @@ class EventVariable(VariableTracker):
             return ConstantVariable.create(None)
         elif name == "record":
             stream_arg, stream_index = EventVariable._get_stream_arg(tx, args, kwargs)
+            tx.output.check_input_mutation_on_current_stream(tx)
             tx.output.check_event_record_after_input_mutation(id(stream_arg.value))
             tx.output.create_proxy(
                 "call_function",

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -13,9 +13,8 @@ from ..exc import TYPE_CHECKING, unimplemented
 from ..graph_bytecode_inputs import (
     CURRENT_STREAM_INDEX,
     get_external_object_by_index,
+    register_current_stream,
     register_graph_created_object,
-    register_user_object,
-    reset_user_object_tracking,
 )
 from ..source import CurrentStreamSource
 from .base import VariableTracker
@@ -264,19 +263,21 @@ class SymbolicStreamState:
     """Track the currently entered stream if any"""
 
     def __init__(self) -> None:
-        from ..source import CurrentStreamSource
+        self.cur_stream_stack: collections.deque[StreamVariable] = collections.deque()
+        self.initialized = False
 
-        cur_stack: list[StreamVariable] = []
+    def _ensure_initialized(self) -> None:
+        if self.initialized:
+            return
+
+        self.initialized = True
         if torch.accelerator.is_available():
-            # Reset the registry so the current stream is guaranteed index 0.
-            reset_user_object_tracking()
             stream = torch.accelerator.current_stream()
             source = CurrentStreamSource(stream.device)
-            # Register the current stream so it gets index 0 (registry is
-            # fresh at tracing start).  The inductor wrapper updates this
-            # entry at runtime so cudagraph capture uses the capture stream
-            # instead of this stale trace-time stream.
-            index = register_user_object(stream, source)
+            # Register the current stream at index 0.  The inductor wrapper
+            # updates this entry at runtime so cudagraph capture uses the
+            # capture stream instead of this stale trace-time stream.
+            index = register_current_stream(stream, source)
             assert index == CURRENT_STREAM_INDEX, (
                 f"Current stream must be registered at index {CURRENT_STREAM_INDEX}, "
                 f"got {index}"
@@ -285,19 +286,17 @@ class SymbolicStreamState:
             # Set user_object_index as an instance attribute so accessing it
             # does NOT trigger LazyVariableTracker realization.
             stream_var.user_object_index = index  # type: ignore[union-attr]
-            cur_stack = [stream_var]  # type: ignore[list-item]
-
-        self.cur_stream_stack: collections.deque[StreamVariable] = collections.deque(
-            cur_stack
-        )
+            self.cur_stream_stack.append(stream_var)  # type: ignore[arg-type]
 
     def enter_stream(self, stream: "StreamVariable") -> None:
+        self._ensure_initialized()
         self.cur_stream_stack.append(stream)
 
     def exit_stream(self) -> None:
         self.cur_stream_stack.pop()
 
     def cur_stream(self, device: torch.device | None = None) -> "StreamVariable":
+        self._ensure_initialized()
         if device is not None:
             for stream in reversed(self.cur_stream_stack):
                 if stream.device == device:
@@ -310,6 +309,7 @@ class SymbolicStreamState:
 
     def cur_stream_id(self) -> int:
         """Get a Python object id for the current stream without realizing lazy variables."""
+        self._ensure_initialized()
         stream = self.cur_stream_stack[-1]
         if isinstance(stream, LazyVariableTracker) and not stream.is_realized():
             return id(stream.peek_value())

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -305,6 +305,8 @@ class SymbolicStreamState:
         return self.cur_stream_stack[-1]
 
     def in_stream_context(self) -> bool:
+        # Keep this lazy: pure Dynamo graphs that never touch streams should
+        # not initialize accelerator stream state just to answer this check.
         return len(self.cur_stream_stack) > 0
 
     def cur_stream_id(self) -> int:


### PR DESCRIPTION
Root cause problem:
Dynamo constructs SymbolicStreamState for every traced frame. Its constructor eagerly queried torch.accelerator.current_stream() whenever an accelerator was available, so pure Dynamo traces that never touched streams still paid the accelerator current-stream cost.

Proposed fix:
Initialize SymbolicStreamState with an empty stream stack and materialize the ambient current stream only when stream APIs ask for it. Keep external object index 0 reserved for the ambient stream by allocating ordinary user objects from index 1 and emitting explicit user-object indices in generated bytecode.

Why this is the right long term fix:
Stream handling remains available on first use and keeps the cudagraph current-stream replacement contract, but pure non-stream traces no longer initialize an optional accelerator subsystem. The explicit-index bytecode path also makes the current-stream slot independent from the order in which other user objects are registered.

Validation:
- python3 -m py_compile torch/_dynamo/graph_bytecode_inputs.py torch/_dynamo/output_graph.py torch/_dynamo/variables/streams.py torch/_dynamo/variables/builder.py test/dynamo/test_streams.py
- git diff --check
- lintrunner --take RUFF,GB_REGISTRY torch/_dynamo/graph_bytecode_inputs.py torch/_dynamo/variables/streams.py
- USE_NIGHTLY=2.13.0.dev20260427+cpu pip install --no-build-isolation -v -e /tmp/pytorch-build (temporary copy)
- python test/dynamo/test_streams.py TestStreams.test_stream_state_is_lazy_for_non_stream_graphs
- python test/dynamo/test_streams.py
- python test/dynamo/test_flat_apply.py

The new regression test was also run against the unmodified nightly CPU wheel and failed at SymbolicStreamState construction when current_stream was patched to raise.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98