### PR TITLE
Add Dynamo inline call summaries

### DIFF
--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -176,9 +176,16 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     def test_inline_lru_cache_fn_with_default_args(a, b):
         return inline_lru_cache_fn_with_default_args(a, 2, b)
 
+    def _skip_inline_summary_dynamic_shapes(self):
+        if not torch._dynamo.config.assume_static_by_default:
+            self.skipTest("inline summaries currently require static tensor metadata")
+
     @torch._dynamo.config.patch(inline_user_function_summaries=True)
     def test_repeated_inline_uses_hierarchical_summary(self):
         from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        self._skip_inline_summary_dynamic_shapes()
+        counters.clear()
 
         def fn(x):
             return inline_summary_outer(x) + inline_summary_outer(x + 2.0)
@@ -205,6 +212,105 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(counts["leaf"], 1)
         self.assertEqual(counts["outer"], 1)
+        self.assertGreaterEqual(counters["inline_call_summary"]["hit"], 2)
+        self.assertGreaterEqual(counters["inline_call_summary"]["store"], 2)
+
+    @torch._dynamo.config.patch(inline_user_function_summaries=False)
+    def test_inline_summary_config_disables_replay(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        counters.clear()
+
+        def fn(x):
+            return inline_summary_outer(x) + inline_summary_outer(x + 2.0)
+
+        counts = collections.Counter()
+        orig_build_inline_tracer = InliningInstructionTranslator.build_inline_tracer
+
+        def counted_build_inline_tracer(parent, func, args, kwargs):
+            code = func.get_code()
+            if code is inline_summary_leaf.__code__:
+                counts["leaf"] += 1
+            elif code is inline_summary_outer.__code__:
+                counts["outer"] += 1
+            return orig_build_inline_tracer(parent, func, args, kwargs)
+
+        x = torch.randn(4)
+        with patch.object(
+            InliningInstructionTranslator,
+            "build_inline_tracer",
+            side_effect=counted_build_inline_tracer,
+        ):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertEqual(opt_fn(x), fn(x))
+
+        self.assertEqual(counts["leaf"], 4)
+        self.assertEqual(counts["outer"], 2)
+        self.assertEqual(counters["inline_call_summary"]["hit"], 0)
+        self.assertEqual(counters["inline_call_summary"]["store"], 0)
+
+    @torch._dynamo.config.patch(inline_user_function_summaries=True)
+    def test_inline_summary_cache_misses_on_tensor_metadata(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        self._skip_inline_summary_dynamic_shapes()
+        counters.clear()
+
+        def fn(x, y):
+            return inline_summary_leaf(x) + inline_summary_leaf(y)
+
+        counts = collections.Counter()
+        orig_build_inline_tracer = InliningInstructionTranslator.build_inline_tracer
+
+        def counted_build_inline_tracer(parent, func, args, kwargs):
+            if func.get_code() is inline_summary_leaf.__code__:
+                counts["leaf"] += 1
+            return orig_build_inline_tracer(parent, func, args, kwargs)
+
+        x = torch.randn(4)
+        y = torch.randn(4, dtype=torch.float64)
+        with patch.object(
+            InliningInstructionTranslator,
+            "build_inline_tracer",
+            side_effect=counted_build_inline_tracer,
+        ):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertEqual(opt_fn(x, y), fn(x, y))
+
+        self.assertEqual(counts["leaf"], 2)
+        self.assertEqual(counters["inline_call_summary"]["miss"], 1)
+
+    @torch._dynamo.config.patch(inline_user_function_summaries=True)
+    def test_inline_summary_rejects_nested_function(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def with_nested_fn(x):
+            def inner(y):
+                return y + 1.0
+
+            return torch.sin(inner(x))
+
+        def fn(x):
+            return with_nested_fn(x) + with_nested_fn(x + 2.0)
+
+        counts = collections.Counter()
+        orig_build_inline_tracer = InliningInstructionTranslator.build_inline_tracer
+
+        def counted_build_inline_tracer(parent, func, args, kwargs):
+            if func.get_code() is with_nested_fn.__code__:
+                counts["nested"] += 1
+            return orig_build_inline_tracer(parent, func, args, kwargs)
+
+        x = torch.randn(4)
+        with patch.object(
+            InliningInstructionTranslator,
+            "build_inline_tracer",
+            side_effect=counted_build_inline_tracer,
+        ):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertEqual(opt_fn(x), fn(x))
+
+        self.assertEqual(counts["nested"], 2)
 
     def test_lru_cache_warning_issued_during_tracing(self):
         import warnings

--- a/test/dynamo/test_functions.py
+++ b/test/dynamo/test_functions.py
@@ -147,6 +147,14 @@ def inline_lru_cache_fn_with_default_args(x, y, _=None):
     return torch.sin(x * y)
 
 
+def inline_summary_leaf(x):
+    return torch.sin(x + 1.0)
+
+
+def inline_summary_outer(x):
+    return inline_summary_leaf(x) * inline_summary_leaf(x + 1.0)
+
+
 @torch.jit.script_if_tracing
 def inline_script_if_tracing_fn_with_default_args(x, y, c=1.2):
     return torch.cos(x * y) + c
@@ -167,6 +175,36 @@ class FunctionTests(torch._dynamo.test_case.TestCase):
     @make_test
     def test_inline_lru_cache_fn_with_default_args(a, b):
         return inline_lru_cache_fn_with_default_args(a, 2, b)
+
+    @torch._dynamo.config.patch(inline_user_function_summaries=True)
+    def test_repeated_inline_uses_hierarchical_summary(self):
+        from torch._dynamo.symbolic_convert import InliningInstructionTranslator
+
+        def fn(x):
+            return inline_summary_outer(x) + inline_summary_outer(x + 2.0)
+
+        counts = collections.Counter()
+        orig_build_inline_tracer = InliningInstructionTranslator.build_inline_tracer
+
+        def counted_build_inline_tracer(parent, func, args, kwargs):
+            code = func.get_code()
+            if code is inline_summary_leaf.__code__:
+                counts["leaf"] += 1
+            elif code is inline_summary_outer.__code__:
+                counts["outer"] += 1
+            return orig_build_inline_tracer(parent, func, args, kwargs)
+
+        x = torch.randn(4)
+        with patch.object(
+            InliningInstructionTranslator,
+            "build_inline_tracer",
+            side_effect=counted_build_inline_tracer,
+        ):
+            opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+            self.assertEqual(opt_fn(x), fn(x))
+
+        self.assertEqual(counts["leaf"], 1)
+        self.assertEqual(counts["outer"], 1)
 
     def test_lru_cache_warning_issued_during_tracing(self):
         import warnings

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -560,6 +560,10 @@ enable_trace_unittest = False
 # generators upon first execution. And if True, the generator will be accessed lazily
 enable_faithful_generator_behavior = True
 
+# Trace eligible pure user functions once, then replay a hierarchical FX summary
+# for repeated calls with matching formal tensor slots.
+inline_user_function_summaries = True
+
 # Inline inbuilt nn modules
 inline_inbuilt_nn_modules = Config(  # type: ignore[var-annotated]
     default=True,

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -141,7 +141,13 @@ from .utils import (
     LazyString,
     proxy_args_kwargs,
 )
-from .variables.base import SourceLocation, typestr, ValueMutationNew, VariableTracker
+from .variables.base import (
+    AttributeMutationNew,
+    SourceLocation,
+    typestr,
+    ValueMutationNew,
+    VariableTracker,
+)
 from .variables.builder import FrameStateSizeEntry, VariableBuilder, wrap_fx_proxy
 from .variables.builtin import BuiltinVariable, DictBuiltinVariable
 from .variables.constant import ConstantVariable
@@ -5285,6 +5291,364 @@ def profile_inline_call(
             output.profiler_state.add_child_time(cumtime_ns)
 
 
+@dataclasses.dataclass(frozen=True)
+class _InlineSummaryTensorSpec:
+    vt_type: type
+    dtype: torch.dtype
+    device: torch.device
+    layout: torch.layout
+    ndim: int
+    size: tuple[int, ...]
+    stride: tuple[int, ...]
+    requires_grad: bool
+    is_nested: bool
+    is_quantized: bool
+    is_sparse: bool
+    is_contiguous: Any
+    class_type: type
+    has_grad_fn: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class _InlineCallSummary:
+    code: types.CodeType
+    input_signature: tuple[Any, ...]
+    input_nodes: tuple[torch.fx.Node, ...]
+    captured_nodes: tuple[torch.fx.Node, ...]
+    nodes: tuple[torch.fx.Node, ...]
+    output: VariableTracker
+
+
+_INLINE_SUMMARY_SIDE_EFFECT_OPS = frozenset(
+    {
+        "DELETE_ATTR",
+        "DELETE_DEREF",
+        "DELETE_GLOBAL",
+        "DELETE_NAME",
+        "DELETE_SUBSCR",
+        "IMPORT_FROM",
+        "IMPORT_NAME",
+        "STORE_ATTR",
+        "STORE_DEREF",
+        "STORE_GLOBAL",
+        "STORE_NAME",
+        "STORE_SUBSCR",
+    }
+)
+
+
+_INLINE_SUMMARY_MUTATING_METHOD_NAMES = frozenset(
+    {
+        "__delitem__",
+        "__setitem__",
+        "add",
+        "append",
+        "clear",
+        "discard",
+        "extend",
+        "insert",
+        "pop",
+        "popitem",
+        "remove",
+        "setdefault",
+        "sort",
+        "update",
+    }
+)
+
+
+def _inline_summary_static_int_tuple(
+    values: collections.abc.Sequence[Any] | None,
+) -> tuple[int, ...] | None:
+    if values is None:
+        return None
+    if not all(type(value) is int for value in values):
+        return None
+    return tuple(values)
+
+
+def _inline_summary_tensor_spec(
+    value: TensorVariable,
+) -> _InlineSummaryTensorSpec | None:
+    if not value.valid_size():
+        return None
+    size = _inline_summary_static_int_tuple(value.size)
+    stride = _inline_summary_static_int_tuple(value.stride)
+    if size is None or stride is None:
+        return None
+    return _InlineSummaryTensorSpec(
+        vt_type=type(value),
+        dtype=value.dtype,
+        device=value.device,
+        layout=value.layout,
+        ndim=value.ndim,
+        size=size,
+        stride=stride,
+        requires_grad=value.requires_grad,
+        is_nested=value.is_nested,
+        is_quantized=value.is_quantized,
+        is_sparse=value.is_sparse,
+        is_contiguous=value.is_contiguous,
+        class_type=value.class_type,
+        has_grad_fn=value.has_grad_fn,
+    )
+
+
+def _inline_summary_unwrap(value: VariableTracker) -> VariableTracker | None:
+    if isinstance(value, LazyVariableTracker):
+        if not value.is_realized():
+            return None
+        value = value.unwrap()
+    return value
+
+
+def _inline_summary_value_spec(value: VariableTracker) -> Any | None:
+    value = _inline_summary_unwrap(value)
+    if value is None:
+        return None
+    if isinstance(value, TensorVariable):
+        tensor_spec = _inline_summary_tensor_spec(value)
+        if tensor_spec is None:
+            return None
+        return ("tensor", tensor_spec)
+    if isinstance(value, ConstantVariable):
+        constant = value.as_python_constant()
+        return ("constant", type(constant), constant)
+    if type(value) in (TupleVariable, ListVariable):
+        items = tuple(_inline_summary_value_spec(item) for item in value.items)
+        if any(item is None for item in items):
+            return None
+        return (value.python_type(), items)
+    return None
+
+
+def _inline_summary_call_signature(
+    symbolic_locals: dict[str, VariableTracker],
+) -> tuple[Any, ...] | None:
+    result: list[Any] = []
+    for name, value in symbolic_locals.items():
+        spec = _inline_summary_value_spec(value)
+        if spec is None:
+            return None
+        result.append((name, spec))
+    return tuple(result)
+
+
+def _inline_summary_collect_input_nodes(
+    value: VariableTracker,
+    graph: torch.fx.Graph,
+    result: list[torch.fx.Node],
+    seen: set[torch.fx.Node],
+) -> bool:
+    value = _inline_summary_unwrap(value)
+    if value is None:
+        return False
+    if isinstance(value, TensorVariable):
+        node = value.as_proxy().node
+        if node.graph is not graph:
+            return False
+        if node not in seen:
+            seen.add(node)
+            result.append(node)
+        return True
+    if isinstance(value, ConstantVariable):
+        return True
+    if type(value) in (TupleVariable, ListVariable):
+        return all(
+            _inline_summary_collect_input_nodes(item, graph, result, seen)
+            for item in value.items
+        )
+    return False
+
+
+def _inline_summary_input_nodes(
+    symbolic_locals: dict[str, VariableTracker],
+    graph: torch.fx.Graph,
+) -> tuple[torch.fx.Node, ...] | None:
+    result: list[torch.fx.Node] = []
+    seen: set[torch.fx.Node] = set()
+    for value in symbolic_locals.values():
+        if not _inline_summary_collect_input_nodes(value, graph, result, seen):
+            return None
+    return tuple(result)
+
+
+def _inline_summary_output_supported(
+    value: VariableTracker,
+    created_nodes: set[torch.fx.Node],
+) -> bool:
+    value = _inline_summary_unwrap(value)
+    if value is None:
+        return False
+    if isinstance(value, TensorVariable):
+        if _inline_summary_tensor_spec(value) is None:
+            return False
+        return value.as_proxy().node in created_nodes
+    if isinstance(value, ConstantVariable):
+        return True
+    if type(value) in (TupleVariable, ListVariable):
+        return all(
+            _inline_summary_output_supported(item, created_nodes)
+            for item in value.items
+        )
+    return False
+
+
+def _inline_summary_replay_output(
+    parent: InstructionTranslatorBase,
+    value: VariableTracker,
+    node_env: dict[torch.fx.Node, torch.fx.Node],
+) -> VariableTracker | None:
+    value = _inline_summary_unwrap(value)
+    if value is None:
+        return None
+    if isinstance(value, TensorVariable):
+        new_node = node_env.get(value.as_proxy().node)
+        if new_node is None:
+            return None
+        new_proxy = torch.fx.Proxy(new_node, parent.output.current_tracer)
+        result = value.clone(proxy=new_proxy, source=None, mutation_type=None)
+        parent.output.side_effects._track_obj(
+            new_proxy, result, mutation_type_cls=AttributeMutationNew
+        )
+        parent.output.current_tracer.record_proxyable_vt(result)
+        return result
+    if isinstance(value, ConstantVariable):
+        return ConstantVariable.create(value.as_python_constant())
+    if type(value) in (TupleVariable, ListVariable):
+        items = [
+            _inline_summary_replay_output(parent, item, node_env)
+            for item in value.items
+        ]
+        if any(item is None for item in items):
+            return None
+        return type(value)(
+            cast(list[VariableTracker], items),
+            mutation_type=ValueMutationNew() if value.mutation_type else None,
+            source=None,
+        )
+    return None
+
+
+def _inline_summary_is_replayable_node(node: torch.fx.Node) -> bool:
+    if node.op != "call_function":
+        return False
+    target = node.target
+    schema = getattr(target, "_schema", None)
+    is_mutable = getattr(schema, "is_mutable", False)
+    if callable(is_mutable):
+        is_mutable = is_mutable()
+    if is_mutable:
+        return False
+    target_name = getattr(target, "__name__", "")
+    if target_name.endswith("_") or "_." in str(target):
+        return False
+    return True
+
+
+def _inline_summary_captured_nodes(
+    graph: torch.fx.Graph,
+    input_nodes: tuple[torch.fx.Node, ...],
+    nodes: tuple[torch.fx.Node, ...],
+) -> tuple[torch.fx.Node, ...] | None:
+    input_node_set = set(input_nodes)
+    node_set = set(nodes)
+    captured: list[torch.fx.Node] = []
+    seen: set[torch.fx.Node] = set()
+    ok = True
+
+    def visit(node: torch.fx.Node) -> torch.fx.Node:
+        nonlocal ok
+        if node in input_node_set or node in node_set:
+            return node
+        if node.graph is not graph:
+            ok = False
+            return node
+        if node not in seen:
+            seen.add(node)
+            captured.append(node)
+        return node
+
+    for node in nodes:
+        torch.fx.node.map_arg(node.args, visit)
+        torch.fx.node.map_arg(node.kwargs, visit)
+        if not ok:
+            return None
+    return tuple(captured)
+
+
+def _inline_summary_function_key(
+    parent: InstructionTranslatorBase,
+    func: BaseUserFunctionVariable,
+) -> types.FunctionType | None:
+    if not config.inline_user_function_summaries:
+        return None
+    if config.dont_skip_tracing or parent.strict_checks_fn:
+        return None
+    if parent.output.current_tracer.parent is not None:
+        return None
+    if type(func) is not UserFunctionVariable:
+        return None
+    try:
+        fn = func.get_function()
+    except NotImplementedError:
+        return None
+    if type(fn) is not types.FunctionType:
+        return None
+    if fn.__defaults__ or fn.__kwdefaults__:
+        return None
+    code = fn.__code__
+    if is_generator(code) or code.co_freevars or code.co_cellvars:
+        return None
+    instructions = tuple(dis.get_instructions(code))
+    for inst in instructions:
+        if inst.opname in _INLINE_SUMMARY_SIDE_EFFECT_OPS:
+            return None
+        if (
+            inst.opname in ("LOAD_ATTR", "LOAD_METHOD")
+            and inst.argval in _INLINE_SUMMARY_MUTATING_METHOD_NAMES
+        ):
+            return None
+        if inst.opname == "LOAD_GLOBAL":
+            global_name = inst.argval
+            if not isinstance(global_name, str) or global_name not in fn.__globals__:
+                return None
+            global_value = fn.__globals__[global_name]
+            if global_value is torch or isinstance(global_value, types.FunctionType):
+                continue
+            if inspect.ismodule(global_value) and getattr(
+                global_value, "__name__", ""
+            ).startswith("torch"):
+                continue
+            return None
+    return fn
+
+
+def _inline_summary_side_effects_supported(
+    before: Any,
+    after: Any,
+    allowed_tensor_nodes: set[torch.fx.Node],
+) -> bool:
+    if before.store_attr_mutations != after.store_attr_mutations:
+        return False
+    if before.save_for_backward != after.save_for_backward:
+        return False
+    if before.tensor_hooks != after.tensor_hooks:
+        return False
+
+    before_ids = set(before.id_to_variable)
+    after_ids = set(after.id_to_variable)
+    if not before_ids <= after_ids:
+        return False
+    for item_id in after_ids - before_ids:
+        value = after.id_to_variable[item_id]
+        if not isinstance(value, TensorVariable):
+            continue
+        if value.as_proxy().node not in allowed_tensor_nodes:
+            return False
+    return True
+
+
 class InliningInstructionTranslator(InstructionTranslatorBase):
     """Trace and inline a called method"""
 
@@ -5304,8 +5668,175 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         with profile_inline_call(
             parent.output, func.get_code(), lambda: parent.inline_depth + 1
         ):
+            summary_result = cls.try_replay_inline_summary(parent, func, args, kwargs)
+            if summary_result is not None:
+                return summary_result
+
+            summary_key = _inline_summary_function_key(parent, func)
+            before_nodes = set(parent.output.graph.nodes) if summary_key else None
+            before_side_effects = (
+                parent.output.side_effects.clone() if summary_key else None
+            )
+            before_inconsistent_side_effects = parent.inconsistent_side_effects
             tracer = cls.build_inline_tracer(parent, func, args, kwargs)
-            return tracer.inline_call_()
+            result = tracer.inline_call_()
+            cls.maybe_record_inline_summary(
+                parent,
+                func,
+                summary_key,
+                tracer,
+                result,
+                before_nodes,
+                before_side_effects,
+                before_inconsistent_side_effects,
+            )
+            return result
+
+    @staticmethod
+    def replay_inline_summary_nodes(
+        parent: Any,
+        summary: _InlineCallSummary,
+        input_nodes: tuple[torch.fx.Node, ...],
+    ) -> dict[torch.fx.Node, torch.fx.Node]:
+        node_env = dict(zip(summary.input_nodes, input_nodes))
+        node_env.update(zip(summary.captured_nodes, summary.captured_nodes))
+
+        def load(node: torch.fx.Node) -> torch.fx.Node:
+            return node_env[node]
+
+        for node in summary.nodes:
+            new_args = torch.fx.node.map_arg(node.args, load)
+            new_kwargs = torch.fx.node.map_arg(node.kwargs, load)
+            new_node = parent.output.create_node(
+                node.op,
+                node.target,
+                new_args,
+                new_kwargs,
+                type_expr=node.type,
+            )
+            creation_timestamp = new_node.meta.get("creation_timestamp")
+            new_node.meta = copy.copy(node.meta)
+            if creation_timestamp is not None:
+                new_node.meta["creation_timestamp"] = creation_timestamp
+            node_env[node] = new_node
+        return node_env
+
+    @staticmethod
+    def try_replay_inline_summary(
+        parent: Any,
+        func: BaseUserFunctionVariable,
+        args: Sequence[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker | None:
+        summary_key = _inline_summary_function_key(parent, func)
+        if summary_key is None:
+            return None
+
+        tracing_ctx = parent.output.tracing_context
+        summaries = tracing_ctx.inlined_call_summary_cache.get(summary_key)
+        if not summaries:
+            return None
+
+        try:
+            sub_locals = func.bind_args(parent, args, kwargs)
+        except TypeError:
+            return None
+
+        signature = _inline_summary_call_signature(sub_locals)
+        input_nodes = _inline_summary_input_nodes(sub_locals, parent.output.graph)
+        if signature is None or input_nodes is None:
+            return None
+
+        for summary in summaries:
+            if summary.input_signature != signature:
+                continue
+
+            parent.has_no_inlined_calls = False
+            node_env = InliningInstructionTranslator.replay_inline_summary_nodes(
+                parent, summary, input_nodes
+            )
+            result = _inline_summary_replay_output(parent, summary.output, node_env)
+            assert result is not None
+            tracing_ctx.traced_code.append(summary.code)
+            counters["inline_call_summary"]["hit"] += 1
+            log.debug("REPLAYED INLINING SUMMARY %s", summary.code)
+            return result
+
+        counters["inline_call_summary"]["miss"] += 1
+        return None
+
+    @staticmethod
+    def maybe_record_inline_summary(
+        parent: Any,
+        func: BaseUserFunctionVariable,
+        summary_key: types.FunctionType | None,
+        tracer: InliningInstructionTranslator,
+        result: VariableTracker,
+        before_nodes: set[torch.fx.Node] | None,
+        before_side_effects: Any | None,
+        before_inconsistent_side_effects: bool,
+    ) -> None:
+        if summary_key is None or before_nodes is None:
+            return
+        if before_side_effects is None:
+            return
+        if parent.output.should_exit:
+            return
+        if parent.inconsistent_side_effects != before_inconsistent_side_effects:
+            return
+
+        signature = _inline_summary_call_signature(tracer.symbolic_locals)
+        if signature is None:
+            return
+        input_nodes = _inline_summary_input_nodes(
+            tracer.symbolic_locals, parent.output.graph
+        )
+        if input_nodes is None:
+            return
+
+        input_node_set = set(input_nodes)
+        nodes = tuple(
+            node
+            for node in parent.output.graph.nodes
+            if node not in before_nodes and node not in input_node_set
+        )
+        if not nodes or any(
+            not _inline_summary_is_replayable_node(node) for node in nodes
+        ):
+            return
+        created_nodes = set(nodes)
+        if not _inline_summary_side_effects_supported(
+            before_side_effects,
+            parent.output.side_effects,
+            created_nodes | input_node_set,
+        ):
+            return
+        if not _inline_summary_output_supported(result, created_nodes):
+            return
+        captured_nodes = _inline_summary_captured_nodes(
+            parent.output.graph, input_nodes, nodes
+        )
+        if captured_nodes is None:
+            return
+
+        summaries = parent.output.tracing_context.inlined_call_summary_cache.setdefault(
+            summary_key, []
+        )
+        if any(summary.input_signature == signature for summary in summaries):
+            return
+        if len(summaries) >= 8:
+            return
+        summaries.append(
+            _InlineCallSummary(
+                code=tracer.f_code,
+                input_signature=signature,
+                input_nodes=input_nodes,
+                captured_nodes=captured_nodes,
+                nodes=nodes,
+                output=result,
+            )
+        )
+        counters["inline_call_summary"]["store"] += 1
 
     @staticmethod
     def check_inlineable(

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -5319,6 +5319,16 @@ class _InlineCallSummary:
     output: VariableTracker
 
 
+@dataclasses.dataclass(frozen=True)
+class _InlineSummaryLookup:
+    key: types.FunctionType
+    input_signature: tuple[Any, ...]
+    input_nodes: tuple[torch.fx.Node, ...]
+
+
+_INLINE_SUMMARY_MAX_PER_FUNCTION = 8
+
+
 _INLINE_SUMMARY_SIDE_EFFECT_OPS = frozenset(
     {
         "DELETE_ATTR",
@@ -5328,6 +5338,7 @@ _INLINE_SUMMARY_SIDE_EFFECT_OPS = frozenset(
         "DELETE_SUBSCR",
         "IMPORT_FROM",
         "IMPORT_NAME",
+        "MAKE_FUNCTION",
         "STORE_ATTR",
         "STORE_DEREF",
         "STORE_GLOBAL",
@@ -5340,7 +5351,20 @@ _INLINE_SUMMARY_SIDE_EFFECT_OPS = frozenset(
 _INLINE_SUMMARY_MUTATING_METHOD_NAMES = frozenset(
     {
         "__delitem__",
+        "__iadd__",
+        "__iand__",
+        "__ifloordiv__",
+        "__ilshift__",
+        "__imatmul__",
+        "__imod__",
+        "__imul__",
+        "__ior__",
+        "__ipow__",
+        "__irshift__",
         "__setitem__",
+        "__isub__",
+        "__itruediv__",
+        "__ixor__",
         "add",
         "append",
         "clear",
@@ -5350,9 +5374,32 @@ _INLINE_SUMMARY_MUTATING_METHOD_NAMES = frozenset(
         "pop",
         "popitem",
         "remove",
+        "reverse",
         "setdefault",
         "sort",
         "update",
+    }
+)
+
+
+_INLINE_SUMMARY_ALLOWED_OPERATOR_TARGETS = frozenset(
+    {
+        operator.add,
+        operator.and_,
+        operator.floordiv,
+        operator.getitem,
+        operator.lshift,
+        operator.matmul,
+        operator.mod,
+        operator.mul,
+        operator.neg,
+        operator.or_,
+        operator.pos,
+        operator.pow,
+        operator.rshift,
+        operator.sub,
+        operator.truediv,
+        operator.xor,
     }
 )
 
@@ -5403,22 +5450,22 @@ def _inline_summary_unwrap(value: VariableTracker) -> VariableTracker | None:
 
 
 def _inline_summary_value_spec(value: VariableTracker) -> Any | None:
-    value = _inline_summary_unwrap(value)
-    if value is None:
+    unwrapped = _inline_summary_unwrap(value)
+    if unwrapped is None:
         return None
-    if isinstance(value, TensorVariable):
-        tensor_spec = _inline_summary_tensor_spec(value)
+    if isinstance(unwrapped, TensorVariable):
+        tensor_spec = _inline_summary_tensor_spec(unwrapped)
         if tensor_spec is None:
             return None
         return ("tensor", tensor_spec)
-    if isinstance(value, ConstantVariable):
-        constant = value.as_python_constant()
+    if isinstance(unwrapped, ConstantVariable):
+        constant = unwrapped.as_python_constant()
         return ("constant", type(constant), constant)
-    if type(value) in (TupleVariable, ListVariable):
-        items = tuple(_inline_summary_value_spec(item) for item in value.items)
+    if isinstance(unwrapped, (TupleVariable, ListVariable)):
+        items = tuple(_inline_summary_value_spec(item) for item in unwrapped.items)
         if any(item is None for item in items):
             return None
-        return (value.python_type(), items)
+        return (unwrapped.python_type(), items)
     return None
 
 
@@ -5440,23 +5487,23 @@ def _inline_summary_collect_input_nodes(
     result: list[torch.fx.Node],
     seen: set[torch.fx.Node],
 ) -> bool:
-    value = _inline_summary_unwrap(value)
-    if value is None:
+    unwrapped = _inline_summary_unwrap(value)
+    if unwrapped is None:
         return False
-    if isinstance(value, TensorVariable):
-        node = value.as_proxy().node
+    if isinstance(unwrapped, TensorVariable):
+        node = unwrapped.as_proxy().node
         if node.graph is not graph:
             return False
         if node not in seen:
             seen.add(node)
             result.append(node)
         return True
-    if isinstance(value, ConstantVariable):
+    if isinstance(unwrapped, ConstantVariable):
         return True
-    if type(value) in (TupleVariable, ListVariable):
+    if isinstance(unwrapped, (TupleVariable, ListVariable)):
         return all(
             _inline_summary_collect_input_nodes(item, graph, result, seen)
-            for item in value.items
+            for item in unwrapped.items
         )
     return False
 
@@ -5477,19 +5524,19 @@ def _inline_summary_output_supported(
     value: VariableTracker,
     created_nodes: set[torch.fx.Node],
 ) -> bool:
-    value = _inline_summary_unwrap(value)
-    if value is None:
+    unwrapped = _inline_summary_unwrap(value)
+    if unwrapped is None:
         return False
-    if isinstance(value, TensorVariable):
-        if _inline_summary_tensor_spec(value) is None:
+    if isinstance(unwrapped, TensorVariable):
+        if _inline_summary_tensor_spec(unwrapped) is None:
             return False
-        return value.as_proxy().node in created_nodes
-    if isinstance(value, ConstantVariable):
+        return unwrapped.as_proxy().node in created_nodes
+    if isinstance(unwrapped, ConstantVariable):
         return True
-    if type(value) in (TupleVariable, ListVariable):
+    if isinstance(unwrapped, (TupleVariable, ListVariable)):
         return all(
             _inline_summary_output_supported(item, created_nodes)
-            for item in value.items
+            for item in unwrapped.items
         )
     return False
 
@@ -5499,41 +5546,61 @@ def _inline_summary_replay_output(
     value: VariableTracker,
     node_env: dict[torch.fx.Node, torch.fx.Node],
 ) -> VariableTracker | None:
-    value = _inline_summary_unwrap(value)
-    if value is None:
+    unwrapped = _inline_summary_unwrap(value)
+    if unwrapped is None:
         return None
-    if isinstance(value, TensorVariable):
-        new_node = node_env.get(value.as_proxy().node)
+    if isinstance(unwrapped, TensorVariable):
+        new_node = node_env.get(unwrapped.as_proxy().node)
         if new_node is None:
             return None
         new_proxy = torch.fx.Proxy(new_node, parent.output.current_tracer)
-        result = value.clone(proxy=new_proxy, source=None, mutation_type=None)
+        result = unwrapped.clone(proxy=new_proxy, source=None, mutation_type=None)
         parent.output.side_effects._track_obj(
             new_proxy, result, mutation_type_cls=AttributeMutationNew
         )
         parent.output.current_tracer.record_proxyable_vt(result)
         return result
-    if isinstance(value, ConstantVariable):
-        return ConstantVariable.create(value.as_python_constant())
-    if type(value) in (TupleVariable, ListVariable):
+    if isinstance(unwrapped, ConstantVariable):
+        return ConstantVariable.create(unwrapped.as_python_constant())
+    if isinstance(unwrapped, (TupleVariable, ListVariable)):
         items = [
             _inline_summary_replay_output(parent, item, node_env)
-            for item in value.items
+            for item in unwrapped.items
         ]
         if any(item is None for item in items):
             return None
-        return type(value)(
-            cast(list[VariableTracker], items),
-            mutation_type=ValueMutationNew() if value.mutation_type else None,
+        replayed_items = cast(list[VariableTracker], items)
+        mutation_type = ValueMutationNew() if unwrapped.mutation_type else None
+        if isinstance(unwrapped, TupleVariable):
+            return TupleVariable(
+                replayed_items,
+                mutation_type=mutation_type,
+                source=None,
+            )
+        return ListVariable(
+            replayed_items,
+            mutation_type=mutation_type,
             source=None,
         )
     return None
+
+
+def _inline_summary_is_replayable_target(target: Any) -> bool:
+    if target in _INLINE_SUMMARY_ALLOWED_OPERATOR_TARGETS:
+        return True
+    schema = getattr(target, "_schema", None)
+    if schema is not None:
+        schema_name = getattr(schema, "name", "")
+        return isinstance(schema_name, str) and schema_name.startswith("aten::")
+    return getattr(target, "__module__", None) == "torch"
 
 
 def _inline_summary_is_replayable_node(node: torch.fx.Node) -> bool:
     if node.op != "call_function":
         return False
     target = node.target
+    if not _inline_summary_is_replayable_target(target):
+        return False
     schema = getattr(target, "_schema", None)
     is_mutable = getattr(schema, "is_mutable", False)
     if callable(is_mutable):
@@ -5544,6 +5611,16 @@ def _inline_summary_is_replayable_node(node: torch.fx.Node) -> bool:
     if target_name.endswith("_") or "_." in str(target):
         return False
     return True
+
+
+def _inline_summary_allowed_constant(value: Any) -> bool:
+    if isinstance(value, (int, float, str, bool, type(None))):
+        return True
+    if isinstance(value, tuple):
+        return all(_inline_summary_allowed_constant(item) for item in value)
+    if isinstance(value, frozenset):
+        return all(_inline_summary_allowed_constant(item) for item in value)
+    return False
 
 
 def _inline_summary_captured_nodes(
@@ -5585,6 +5662,8 @@ def _inline_summary_function_key(
         return None
     if config.dont_skip_tracing or parent.strict_checks_fn:
         return None
+    if torch._logging._internal.log_state.is_artifact_enabled("trace_call"):
+        return None
     if parent.output.current_tracer.parent is not None:
         return None
     if type(func) is not UserFunctionVariable:
@@ -5611,10 +5690,23 @@ def _inline_summary_function_key(
             return None
         if inst.opname == "LOAD_GLOBAL":
             global_name = inst.argval
-            if not isinstance(global_name, str) or global_name not in fn.__globals__:
+            if not isinstance(global_name, str):
                 return None
-            global_value = fn.__globals__[global_name]
+            if global_name in fn.__globals__:
+                global_value = fn.__globals__[global_name]
+            elif isinstance(fn.__builtins__, dict) and global_name in fn.__builtins__:
+                global_value = fn.__builtins__[global_name]
+            else:
+                global_value = getattr(fn.__builtins__, global_name, None)
+                if global_value is None:
+                    return None
             if global_value is torch or isinstance(global_value, types.FunctionType):
+                continue
+            if isinstance(global_value, types.BuiltinFunctionType):
+                continue
+            if isinstance(global_value, type) and global_value.__module__ == "builtins":
+                continue
+            if _inline_summary_allowed_constant(global_value):
                 continue
             if inspect.ismodule(global_value) and getattr(
                 global_value, "__name__", ""
@@ -5622,6 +5714,30 @@ def _inline_summary_function_key(
                 continue
             return None
     return fn
+
+
+def _inline_summary_lookup(
+    parent: InstructionTranslatorBase,
+    func: BaseUserFunctionVariable,
+    args: Sequence[VariableTracker],
+    kwargs: dict[str, VariableTracker],
+) -> _InlineSummaryLookup | None:
+    summary_key = _inline_summary_function_key(parent, func)
+    if summary_key is None:
+        return None
+    user_func = cast(UserFunctionVariable, func)
+    try:
+        sub_locals = user_func.bind_args(
+            cast(InstructionTranslator, parent), args, kwargs
+        )
+    except TypeError:
+        return None
+
+    signature = _inline_summary_call_signature(sub_locals)
+    input_nodes = _inline_summary_input_nodes(sub_locals, parent.output.graph)
+    if signature is None or input_nodes is None or not input_nodes:
+        return None
+    return _InlineSummaryLookup(summary_key, signature, input_nodes)
 
 
 def _inline_summary_side_effects_supported(
@@ -5659,7 +5775,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
     @classmethod
     def inline_call(
         cls,
-        parent: Any,
+        parent: InstructionTranslatorBase,
         func: BaseUserFunctionVariable,
         args: Sequence[VariableTracker],
         kwargs: dict[str, VariableTracker],
@@ -5668,14 +5784,19 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         with profile_inline_call(
             parent.output, func.get_code(), lambda: parent.inline_depth + 1
         ):
-            summary_result = cls.try_replay_inline_summary(parent, func, args, kwargs)
-            if summary_result is not None:
-                return summary_result
+            summary_lookup = _inline_summary_lookup(parent, func, args, kwargs)
+            if summary_lookup is not None:
+                summary_result = cls.try_replay_inline_summary(parent, summary_lookup)
+                if summary_result is not None:
+                    return summary_result
 
-            summary_key = _inline_summary_function_key(parent, func)
-            before_nodes = set(parent.output.graph.nodes) if summary_key else None
+            before_nodes = (
+                set(parent.output.graph.nodes) if summary_lookup is not None else None
+            )
             before_side_effects = (
-                parent.output.side_effects.clone() if summary_key else None
+                parent.output.side_effects.clone()
+                if summary_lookup is not None
+                else None
             )
             before_inconsistent_side_effects = parent.inconsistent_side_effects
             tracer = cls.build_inline_tracer(parent, func, args, kwargs)
@@ -5683,7 +5804,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
             cls.maybe_record_inline_summary(
                 parent,
                 func,
-                summary_key,
+                summary_lookup,
                 tracer,
                 result,
                 before_nodes,
@@ -5694,12 +5815,13 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
 
     @staticmethod
     def replay_inline_summary_nodes(
-        parent: Any,
+        parent: InstructionTranslatorBase,
         summary: _InlineCallSummary,
         input_nodes: tuple[torch.fx.Node, ...],
-    ) -> dict[torch.fx.Node, torch.fx.Node]:
+    ) -> tuple[dict[torch.fx.Node, torch.fx.Node], tuple[torch.fx.Node, ...]]:
         node_env = dict(zip(summary.input_nodes, input_nodes))
         node_env.update(zip(summary.captured_nodes, summary.captured_nodes))
+        created_nodes: list[torch.fx.Node] = []
 
         def load(node: torch.fx.Node) -> torch.fx.Node:
             return node_env[node]
@@ -5712,51 +5834,50 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
                 node.target,
                 new_args,
                 new_kwargs,
+                name=node.name,
                 type_expr=node.type,
             )
             creation_timestamp = new_node.meta.get("creation_timestamp")
             new_node.meta = copy.copy(node.meta)
+            if "nn_module_stack" in new_node.meta:
+                new_node.meta["nn_module_stack"] = copy.copy(
+                    new_node.meta["nn_module_stack"]
+                )
+            if "source_fn_stack" in new_node.meta:
+                new_node.meta["source_fn_stack"] = copy.copy(
+                    new_node.meta["source_fn_stack"]
+                )
             if creation_timestamp is not None:
                 new_node.meta["creation_timestamp"] = creation_timestamp
             node_env[node] = new_node
-        return node_env
+            created_nodes.append(new_node)
+        return node_env, tuple(created_nodes)
 
     @staticmethod
     def try_replay_inline_summary(
-        parent: Any,
-        func: BaseUserFunctionVariable,
-        args: Sequence[VariableTracker],
-        kwargs: dict[str, VariableTracker],
+        parent: InstructionTranslatorBase,
+        lookup: _InlineSummaryLookup,
     ) -> VariableTracker | None:
-        summary_key = _inline_summary_function_key(parent, func)
-        if summary_key is None:
-            return None
-
         tracing_ctx = parent.output.tracing_context
-        summaries = tracing_ctx.inlined_call_summary_cache.get(summary_key)
+        summaries = tracing_ctx.inlined_call_summary_cache.get(lookup.key)
         if not summaries:
             return None
 
-        try:
-            sub_locals = func.bind_args(parent, args, kwargs)
-        except TypeError:
-            return None
-
-        signature = _inline_summary_call_signature(sub_locals)
-        input_nodes = _inline_summary_input_nodes(sub_locals, parent.output.graph)
-        if signature is None or input_nodes is None:
-            return None
-
         for summary in summaries:
-            if summary.input_signature != signature:
+            if summary.input_signature != lookup.input_signature:
                 continue
 
             parent.has_no_inlined_calls = False
-            node_env = InliningInstructionTranslator.replay_inline_summary_nodes(
-                parent, summary, input_nodes
+            node_env, created_nodes = (
+                InliningInstructionTranslator.replay_inline_summary_nodes(
+                    parent, summary, lookup.input_nodes
+                )
             )
             result = _inline_summary_replay_output(parent, summary.output, node_env)
-            assert result is not None
+            if result is None:
+                for node in reversed(created_nodes):
+                    parent.output.remove_node(node)
+                return None
             tracing_ctx.traced_code.append(summary.code)
             counters["inline_call_summary"]["hit"] += 1
             log.debug("REPLAYED INLINING SUMMARY %s", summary.code)
@@ -5767,16 +5888,16 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
 
     @staticmethod
     def maybe_record_inline_summary(
-        parent: Any,
+        parent: InstructionTranslatorBase,
         func: BaseUserFunctionVariable,
-        summary_key: types.FunctionType | None,
+        lookup: _InlineSummaryLookup | None,
         tracer: InliningInstructionTranslator,
         result: VariableTracker,
         before_nodes: set[torch.fx.Node] | None,
         before_side_effects: Any | None,
         before_inconsistent_side_effects: bool,
     ) -> None:
-        if summary_key is None or before_nodes is None:
+        if lookup is None or before_nodes is None:
             return
         if before_side_effects is None:
             return
@@ -5785,16 +5906,7 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         if parent.inconsistent_side_effects != before_inconsistent_side_effects:
             return
 
-        signature = _inline_summary_call_signature(tracer.symbolic_locals)
-        if signature is None:
-            return
-        input_nodes = _inline_summary_input_nodes(
-            tracer.symbolic_locals, parent.output.graph
-        )
-        if input_nodes is None:
-            return
-
-        input_node_set = set(input_nodes)
+        input_node_set = set(lookup.input_nodes)
         nodes = tuple(
             node
             for node in parent.output.graph.nodes
@@ -5814,23 +5926,25 @@ class InliningInstructionTranslator(InstructionTranslatorBase):
         if not _inline_summary_output_supported(result, created_nodes):
             return
         captured_nodes = _inline_summary_captured_nodes(
-            parent.output.graph, input_nodes, nodes
+            parent.output.graph, lookup.input_nodes, nodes
         )
         if captured_nodes is None:
             return
 
         summaries = parent.output.tracing_context.inlined_call_summary_cache.setdefault(
-            summary_key, []
+            lookup.key, []
         )
-        if any(summary.input_signature == signature for summary in summaries):
+        if any(
+            summary.input_signature == lookup.input_signature for summary in summaries
+        ):
             return
-        if len(summaries) >= 8:
+        if len(summaries) >= _INLINE_SUMMARY_MAX_PER_FUNCTION:
             return
         summaries.append(
             _InlineCallSummary(
                 code=tracer.f_code,
-                input_signature=signature,
-                input_nodes=input_nodes,
+                input_signature=lookup.input_signature,
+                input_nodes=lookup.input_nodes,
                 captured_nodes=captured_nodes,
                 nodes=nodes,
                 output=result,

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -1074,6 +1074,8 @@ class TracingContext:
         self.previously_cleaned_instructions: dict[Any, Any] = dict()
         # Combined cache for inlined code data (instructions, indexof, code_options)
         self.inlined_code_cache: dict[Any, InlinedCodeCache] = dict()
+        # Per-trace summaries for replaying eligible repeated user-function inlines.
+        self.inlined_call_summary_cache: dict[Any, Any] = dict()
         self.fake_mode: FakeTensorMode | None = fake_mode
         self.frame_summary_stack: list[traceback.FrameSummary] = []
         # This is morally part of frame_summary_stack, but it is kept separate
@@ -1127,6 +1129,7 @@ class TracingContext:
         self.previously_inlined_functions.clear()
         self.previously_cleaned_instructions.clear()
         self.inlined_code_cache.clear()
+        self.inlined_call_summary_cache.clear()
 
     @staticmethod
     @contextmanager


### PR DESCRIPTION
Summary:
- add a per-trace Dynamo inline-call summary cache keyed by eligible pure Python function objects
- replay recorded FX node summaries through formal tensor slots before constructing a fresh inline tracer
- add a regression test showing repeated nested eager inlines build the leaf and outer inline tracers once

Root cause problem:
The eager inline path constructs a new `InliningInstructionTranslator` and executes the full child bytecode trace for every repeated user-function call. Workloads such as `basic_inline_eager` spend most of their time rebuilding and running those inline tracers even when the callee body, formal tensor metadata, and resulting FX fragment are identical within the same root trace.

Proposed fix:
This change records conservative hierarchical inline summaries in `TracingContext`. For eligible pure `UserFunctionVariable` calls, Dynamo stores the formal input signature, formal input FX nodes, captured external nodes, replayable FX nodes, and output variable structure after the first normal inline trace. Later calls with matching formal slots replay the summary nodes directly into the parent graph before `build_inline_tracer` is called. The recorder rejects defaults, closures, generators, mutating bytecode, unsupported globals, side-effect changes, mutable ops, non-static tensor metadata, and unsupported outputs.

Why this is the right long term fix:
Formal-slot summaries attack the repeated work at the correct level: Dynamo traces a function body once per compatible local shape/signature and then composes the resulting graph fragment hierarchically for repeated calls, including nested inlines. That avoids stacking more narrow caches around inline-tracer construction while keeping the replay path scoped to a single trace and guarded by conservative eligibility checks.

Testing:
- `git diff --check`
- `.venv/bin/python -m py_compile torch/_dynamo/symbolic_convert.py torch/_guards.py torch/_dynamo/config.py test/dynamo/test_functions.py`
- verified the new test fails without the implementation by reverting the code changes before committing
- `python /tmp/repos/pytorch/pytorch/test/dynamo/test_functions.py -k test_repeated_inline_uses_hierarchical_summary`
- `python /tmp/repos/pytorch/pytorch/test/dynamo/test_functions.py FunctionTests.test_inline_script_if_tracing_fn_with_default_args FunctionTests.test_inline_lru_cache_fn_with_default_args FunctionTests.test_repeated_inline_uses_hierarchical_summary`

Note: `lintrunner -a torch/_dynamo/symbolic_convert.py torch/_dynamo/config.py torch/_guards.py test/dynamo/test_functions.py` still fails in this sandbox because PyRefly scans the uninitialized/unbuilt checkout and reports missing `torch`/`torch._C` attributes across unrelated files.

Drafted via Codex, published after manual review by @bobrenjc93

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98