### PR TITLE
Skip duplicate AOTAutograd inference trace

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -464,6 +464,7 @@ class TestAOTAutograd(AOTTestCase):
             )
         return compiled_f
 
+    # Keep debug_assert from intentionally re-running metadata collection.
     @patch("torch._functorch.config.debug_assert", False)
     def test_inference_metadata_collection_reuses_graph_trace(self):
         calls = 0
@@ -478,6 +479,37 @@ class TestAOTAutograd(AOTTestCase):
 
         self.assertEqual(compiled_f(x), x.sin().cos())
         self.assertEqual(calls, 1)
+
+    # Keep debug_assert from intentionally re-running metadata collection.
+    @patch("torch._functorch.config.debug_assert", False)
+    def test_inference_metadata_collection_discards_alias_trace(self):
+        calls = 0
+        trace_and_metadata_calls = 0
+
+        def f(x):
+            nonlocal calls
+            calls += 1
+            return x.view_as(x)
+
+        import torch._functorch.aot_autograd as aot_autograd
+
+        orig = aot_autograd._create_graph_and_collect_metadata
+
+        def counted_create_graph_and_collect_metadata(*args, **kwargs):
+            nonlocal trace_and_metadata_calls
+            trace_and_metadata_calls += 1
+            return orig(*args, **kwargs)
+
+        with patch(
+            "torch._functorch.aot_autograd._create_graph_and_collect_metadata",
+            counted_create_graph_and_collect_metadata,
+        ):
+            compiled_f = aot_function(f, fw_compiler=nop)
+            x = torch.randn(4)
+
+            self.assertEqual(compiled_f(x), x)
+        self.assertEqual(trace_and_metadata_calls, 1)
+        self.assertEqual(calls, 2)
 
     # test_mutation will:
     # - Ensure that inputs are non-leaves, so our graphs can mutate them

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -464,6 +464,21 @@ class TestAOTAutograd(AOTTestCase):
             )
         return compiled_f
 
+    @patch("torch._functorch.config.debug_assert", False)
+    def test_inference_metadata_collection_reuses_graph_trace(self):
+        calls = 0
+
+        def f(x):
+            nonlocal calls
+            calls += 1
+            return x.sin().cos()
+
+        compiled_f = aot_function(f, fw_compiler=nop)
+        x = torch.randn(4)
+
+        self.assertEqual(compiled_f(x), x.sin().cos())
+        self.assertEqual(calls, 1)
+
     # test_mutation will:
     # - Ensure that inputs are non-leaves, so our graphs can mutate them
     # - try to mutate outputs of the graph (to ensure that autograd meta is set properly on outputs)

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -171,7 +171,14 @@ def run_functionalized_fw_and_collect_metadata(
     # Note: this is guaranteed to be set when running under dynamo
     static_input_indices: list[int] | None = None,
     pre_dispatch: bool = False,
-) -> Callable[..., ViewAndMutationMeta]:
+    _return_graph_outputs: bool = False,
+    _metadata_out: list[ViewAndMutationMeta] | None = None,
+) -> Callable[..., Any]:
+    if _return_graph_outputs and _metadata_out is None:
+        raise AssertionError(
+            "_metadata_out must be provided when _return_graph_outputs=True"
+        )
+
     memo: dict[Tensor, Tensor] = {}
 
     # TODO: see if we can rewrite this to be more accurate using
@@ -833,15 +840,20 @@ from a multi-output view call"
             for inp, info in zip(flat_f_args, input_info)
             if info.mutation_type == MutationType.MUTATED_OUT_GRAPH
         ]
-        # Build the full list of forward graph outputs so the subclass wrapping
-        # code knows exactly which graph outputs to wrap back into subclasses.
-        # Including intermediate_bases unconditionally is safe: they are only
-        # populated when outputs require grad (line ~539), so they are naturally
-        # empty during pure inference.  In the "downgrade from training to
-        # inference" path, num_intermediate_bases > 0 is already gated behind
-        # `assert not req_subclass_dispatch` (aot_autograd.py), so the subclass
-        # wrapping code that consumes subclass_fw_graph_out_meta never sees them.
+        f_mutated_inputs_descs = [
+            InputMutationAOTOutput(inp_desc)
+            for inp_desc, info in zip(flat_f_args_descs, input_info)
+            if info.mutation_type == MutationType.MUTATED_OUT_GRAPH
+        ]
+        # Match the compiled forward output convention so graph capture can
+        # reuse this execution when no wrappers need to change the calling
+        # convention.
         f_fw_graph_outs = [*f_mutated_inputs, *flat_f_outs, *intermediate_bases]
+        f_fw_graph_outs_descs = [
+            *f_mutated_inputs_descs,
+            *flat_f_outs_descs,
+            *intermediate_bases_descs,
+        ]
         fw_graph_outs = pytree.tree_map(from_fun, f_fw_graph_outs)
 
         grad_enabled_mutation = None
@@ -878,6 +890,11 @@ from a multi-output view call"
             static_input_indices=static_input_indices,
             tokens=mode._tokens,
         )
+        if _return_graph_outputs:
+            if _metadata_out is None:
+                raise AssertionError("_metadata_out must not be None")
+            _metadata_out.append(metadata)
+            return fw_graph_outs, f_fw_graph_outs_descs
         return metadata
 
     return inner

--- a/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
+++ b/torch/_functorch/_aot_autograd/collect_metadata_analysis.py
@@ -172,13 +172,7 @@ def run_functionalized_fw_and_collect_metadata(
     static_input_indices: list[int] | None = None,
     pre_dispatch: bool = False,
     _return_graph_outputs: bool = False,
-    _metadata_out: list[ViewAndMutationMeta] | None = None,
 ) -> Callable[..., Any]:
-    if _return_graph_outputs and _metadata_out is None:
-        raise AssertionError(
-            "_metadata_out must be provided when _return_graph_outputs=True"
-        )
-
     memo: dict[Tensor, Tensor] = {}
 
     # TODO: see if we can rewrite this to be more accurate using
@@ -194,7 +188,7 @@ def run_functionalized_fw_and_collect_metadata(
             return t
 
     @simple_wraps(f)
-    def inner(*flat_args: Any) -> ViewAndMutationMeta:
+    def inner(*flat_args: Any) -> Any:
         # This function is meant to be run with the forward, which expects a flat list of tensor/symint/other args.
         if not all(
             isinstance(a, tuple(KNOWN_TYPES)) or is_opaque_type(type(a))
@@ -891,10 +885,7 @@ from a multi-output view call"
             tokens=mode._tokens,
         )
         if _return_graph_outputs:
-            if _metadata_out is None:
-                raise AssertionError("_metadata_out must not be None")
-            _metadata_out.append(metadata)
-            return fw_graph_outs, f_fw_graph_outs_descs
+            return tuple(fw_graph_outs), tuple(f_fw_graph_outs_descs), metadata
         return metadata
 
     return inner

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -19,6 +19,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torchgen.utils import dataclass_repr
 
 from .. import config
+from .collect_metadata_analysis import run_functionalized_fw_and_collect_metadata
 from .descriptors import AOTInput, BackwardTokenAOTInput
 from .functional_utils import (
     assert_functional_graph,
@@ -32,7 +33,14 @@ from .graph_capture_wrappers import (
     fn_prepped_for_autograd,
     handle_effect_tokens_fn,
 )
-from .schemas import AOTConfig, FxValue, SubclassMeta, TraceFn, ViewAndMutationMeta
+from .schemas import (
+    AOTConfig,
+    FxValue,
+    OutputType,
+    SubclassMeta,
+    TraceFn,
+    ViewAndMutationMeta,
+)
 from .streams import (
     assign_backward_streams,
     assign_epilogue_copy_streams,
@@ -281,6 +289,104 @@ def _create_graph_and_save_traced_inputs(
     )
 
 
+def _can_reuse_precomputed_fw_graph(
+    fw_metadata: ViewAndMutationMeta,
+    *,
+    aot_config: AOTConfig,
+) -> bool:
+    if (
+        aot_config.disable_functionalization
+        or aot_config.is_export
+        or aot_config.pre_dispatch
+    ):
+        return False
+
+    return (
+        fw_metadata.num_mutated_inp_runtime_indices == 0
+        and fw_metadata.num_mutated_graph_handled_indices == 0
+        and fw_metadata.num_outputs_aliased == 0
+        and fw_metadata.num_unsafe_view_outputs == 0
+        and fw_metadata.num_intermediate_bases == 0
+        and len(fw_metadata.tokens) == 0
+        and fw_metadata.grad_enabled_mutation is None
+        and all(
+            info.output_type == OutputType.non_alias for info in fw_metadata.output_info
+        )
+    )
+
+
+def _create_graph_and_collect_metadata(
+    f: Callable[..., Any],
+    args: list[Any],
+    args_descs: list[AOTInput],
+    *,
+    aot_config: AOTConfig,
+) -> tuple[torch.fx.GraphModule, list[Any], list[AOTInput], ViewAndMutationMeta]:
+    if aot_config.disable_functionalization:
+        raise AssertionError("cannot collect functionalization metadata when disabled")
+
+    saved_flat_args = _detach_traced_inputs(args)
+    fw_metadata_cell: list[ViewAndMutationMeta] = []
+    metadata_fn = run_functionalized_fw_and_collect_metadata(
+        f,
+        flat_args_descs=args_descs,
+        static_input_indices=aot_config.static_input_indices,
+        keep_input_mutations=aot_config.keep_inference_input_mutations,
+        pre_dispatch=aot_config.pre_dispatch,
+        _return_graph_outputs=True,
+        _metadata_out=fw_metadata_cell,
+    )
+    out_descs = None
+
+    @simple_wraps(f)
+    def inner_f(*args: Any) -> Any:
+        nonlocal out_descs
+        if out_descs is not None:
+            raise AssertionError("out_descs must be None")
+        out, out_descs = call_and_expect_output_descs(metadata_fn, args)
+        return out
+
+    with enable_python_dispatcher():
+        fx_g = make_fx(
+            inner_f,
+            decomposition_table=aot_config.decompositions,
+            record_module_stack=True,
+            pre_dispatch=aot_config.pre_dispatch,
+            _disable_torch_fn_metadata_mode=aot_config._disable_torch_fn_metadata_mode,
+        )(*args)
+
+    if len(fw_metadata_cell) != 1:
+        raise AssertionError(
+            f"expected exactly one metadata result, got {len(fw_metadata_cell)}"
+        )
+    if out_descs is None:
+        raise AssertionError("out_descs must not be None")
+
+    flat_args_descs, _ = pytree.tree_flatten(args_descs)
+    flat_out_descs, _ = pytree.tree_flatten(out_descs)
+
+    i = 0
+    j = 0
+    for n in fx_g.graph.nodes:
+        if n.op == "placeholder":
+            if n.name.startswith("tangents_token"):
+                n.meta["desc"] = BackwardTokenAOTInput(j)
+                j += 1
+            else:
+                if i >= len(flat_args_descs):
+                    raise AssertionError(
+                        f"i={i} >= len(flat_args_descs)={len(flat_args_descs)}: "
+                        f"fn_wrappers={fn_wrappers(inner_f)}, "
+                        f"placeholders={[n for n in fx_g.graph.nodes if n.op == 'placeholder']}"
+                    )
+                n.meta["desc"] = flat_args_descs[i]
+                i += 1
+        elif n.op == "output":
+            n.meta["desc"] = flat_out_descs
+
+    return fx_g, saved_flat_args, args_descs, fw_metadata_cell[0]
+
+
 def aot_dispatch_base_graph(
     flat_fn: TraceFn,
     flat_args: list[FxValue],
@@ -288,6 +394,9 @@ def aot_dispatch_base_graph(
     aot_config: AOTConfig,
     *,
     fw_metadata: ViewAndMutationMeta,
+    precomputed_fw_module: torch.fx.GraphModule | None = None,
+    precomputed_flat_args: list[Any] | None = None,
+    precomputed_flat_args_descs: list[AOTInput] | None = None,
 ) -> tuple[torch.fx.GraphModule, list[FxValue], list[AOTInput], SubclassMeta | None]:
     # aot_dispatch_base requires functionalization, but doesn't need to handle as many cases as the autograd case.
     # The cases that aot_dispatch_base doesn't need to handle include:
@@ -302,76 +411,89 @@ def aot_dispatch_base_graph(
         fw_metadata,
         keep_data_input_mutations=aot_config.keep_inference_input_mutations,
     )
-    # TODO: replace with AOTDispatchSubclassWrapper once we refactor
-    # fn_input_mutations_to_outputs and create_functionalized_fn
-    # into CompilerWrappers.
-    tracing_state = _prepare_graph_capture_tracing(
-        fn_to_trace,
-        flat_args,
-        flat_args_descs,
-        flat_fn,
-        fw_metadata=fw_metadata,
-        aot_config=aot_config,
-        trace_joint=False,
-    )
-    fn_to_trace = tracing_state.fn_to_trace
-    updated_flat_args_subclasses_desugared = tracing_state.flat_args
-    updated_flat_args_subclasses_desugared_descs = tracing_state.flat_args_descs
-    maybe_subclass_meta = tracing_state.maybe_subclass_meta
+    if precomputed_fw_module is not None and _can_reuse_precomputed_fw_graph(
+        fw_metadata, aot_config=aot_config
+    ):
+        if precomputed_flat_args is None or precomputed_flat_args_descs is None:
+            raise AssertionError("precomputed graph inputs must be provided")
+        fw_module = precomputed_fw_module
+        saved_updated_flat_args_subclasses_desugared = precomputed_flat_args
+        saved_updated_flat_args_subclasses_desugared_descs = precomputed_flat_args_descs
+        maybe_subclass_meta = None
+    else:
+        # TODO: replace with AOTDispatchSubclassWrapper once we refactor
+        # fn_input_mutations_to_outputs and create_functionalized_fn
+        # into CompilerWrappers.
+        tracing_state = _prepare_graph_capture_tracing(
+            fn_to_trace,
+            flat_args,
+            flat_args_descs,
+            flat_fn,
+            fw_metadata=fw_metadata,
+            aot_config=aot_config,
+            trace_joint=False,
+        )
+        fn_to_trace = tracing_state.fn_to_trace
+        updated_flat_args_subclasses_desugared = tracing_state.flat_args
+        updated_flat_args_subclasses_desugared_descs = tracing_state.flat_args_descs
+        maybe_subclass_meta = tracing_state.maybe_subclass_meta
 
-    aot_graphs_log.debug(
-        "aot_config id: %s, fw_metadata=%s,subclass_metadata=%s",
-        aot_config.aot_id,
-        fw_metadata,
-        maybe_subclass_meta,
-    )
-
-    # We track buffer assignments when exporting in non-strict mode.
-    # (In contrast, strict mode errors on any attribute assignment.)
-    mod_when_exporting_non_strict = root_module_when_exporting_non_strict(flat_fn)
-    if aot_config.is_export and mod_when_exporting_non_strict is not None:
-        # For any buffer that is assigned, we want to associate it to the final proxy node
-        # that it is assigned to. This node can then be added as a buffer mutation output.
-        assigned_buffers: dict[str, str] = {}
-        hook = register_buffer_assignment_hook(
-            mod_when_exporting_non_strict, assigned_buffers
+        aot_graphs_log.debug(
+            "aot_config id: %s, fw_metadata=%s,subclass_metadata=%s",
+            aot_config.aot_id,
+            fw_metadata,
+            maybe_subclass_meta,
         )
 
-    (
-        fw_module,
-        saved_updated_flat_args_subclasses_desugared,
-    ) = _create_graph_and_save_traced_inputs(
-        fn_to_trace,
-        updated_flat_args_subclasses_desugared,
-        updated_flat_args_subclasses_desugared_descs,
-        aot_config=aot_config,
-    )
-    saved_updated_flat_args_subclasses_desugared_descs = (
-        updated_flat_args_subclasses_desugared_descs
-    )
+        # We track buffer assignments when exporting in non-strict mode.
+        # (In contrast, strict mode errors on any attribute assignment.)
+        mod_when_exporting_non_strict = root_module_when_exporting_non_strict(flat_fn)
+        if aot_config.is_export and mod_when_exporting_non_strict is not None:
+            # For any buffer that is assigned, we want to associate it to the final proxy node
+            # that it is assigned to. This node can then be added as a buffer mutation output.
+            assigned_buffers: dict[str, str] = {}
+            hook = register_buffer_assignment_hook(
+                mod_when_exporting_non_strict, assigned_buffers
+            )
 
-    if aot_config.is_export and mod_when_exporting_non_strict is not None:
-        # We update metadata to consider any assigned buffers as buffer mutations.
-        i = len(dict(mod_when_exporting_non_strict.named_parameters()))
-        for name, _ in mod_when_exporting_non_strict.named_buffers():
-            if name in assigned_buffers and not fw_metadata.input_info[i].mutates_data:  # type: ignore[possibly-undefined]
-                fw_metadata.input_info[i] = dataclasses.replace(
-                    fw_metadata.input_info[i], mutates_data=True
-                )
-                fw_metadata.num_mutated_inp_runtime_indices += 1
-            i += 1
+        (
+            fw_module,
+            saved_updated_flat_args_subclasses_desugared,
+        ) = _create_graph_and_save_traced_inputs(
+            fn_to_trace,
+            updated_flat_args_subclasses_desugared,
+            updated_flat_args_subclasses_desugared_descs,
+            aot_config=aot_config,
+        )
+        saved_updated_flat_args_subclasses_desugared_descs = (
+            updated_flat_args_subclasses_desugared_descs
+        )
 
-        # We add nodes corresponding to buffer assignments as output nodes in the graph.
-        add_nodes = []
-        output_node = list(fw_module.graph.nodes)[-1]
-        for name in assigned_buffers.values():  # type: ignore[possibly-undefined]
-            for node in fw_module.graph.nodes:
-                if node.name == name:
-                    add_nodes.append(node)
-                    node.users[output_node] = None
-        output_node.args = ((*add_nodes, *output_node.args[0]),)
+        if aot_config.is_export and mod_when_exporting_non_strict is not None:
+            # We update metadata to consider any assigned buffers as buffer mutations.
+            i = len(dict(mod_when_exporting_non_strict.named_parameters()))
+            for name, _ in mod_when_exporting_non_strict.named_buffers():
+                if (
+                    name in assigned_buffers
+                    and not fw_metadata.input_info[i].mutates_data
+                ):  # type: ignore[possibly-undefined]
+                    fw_metadata.input_info[i] = dataclasses.replace(
+                        fw_metadata.input_info[i], mutates_data=True
+                    )
+                    fw_metadata.num_mutated_inp_runtime_indices += 1
+                i += 1
 
-        hook.remove()  # type: ignore[possibly-undefined]
+            # We add nodes corresponding to buffer assignments as output nodes in the graph.
+            add_nodes = []
+            output_node = list(fw_module.graph.nodes)[-1]
+            for name in assigned_buffers.values():  # type: ignore[possibly-undefined]
+                for node in fw_module.graph.nodes:
+                    if node.name == name:
+                        add_nodes.append(node)
+                        node.users[output_node] = None
+            output_node.args = ((*add_nodes, *output_node.args[0]),)
+
+            hook.remove()  # type: ignore[possibly-undefined]
 
     # As long as we opted to remove input mutations, then
     # there should be *NO* mutating ops in the graph at this point.

--- a/torch/_functorch/_aot_autograd/graph_capture.py
+++ b/torch/_functorch/_aot_autograd/graph_capture.py
@@ -144,50 +144,45 @@ def _create_graph(
         )(*args)
 
         if args_descs is not None:
-            flat_args_descs, _ = pytree.tree_flatten(args_descs)
-            flat_out_descs, _ = pytree.tree_flatten(out_descs)
-
-            # Unfortunately, flat_args_descs is not guaranteed to match the
-            # number of actual arguments that show up on the FX graph.
-            # Specifically, allow_token_discovery=True means that we will
-            # silently add extra token arguments to the backwards graph.
-            #
-            # Although there are a few ways to detect what these tokens are,
-            # we are going to settle for something dodgy but simple to
-            # implement: match tangents_token placeholders specifically,
-            # as these are the only placeholders that are created by token
-            # discovery (NB: there is NO other code that treats this name
-            # as load bearing, so this is a bit naughty!)
-            #
-            # I originally wanted to detect tokens in exactly the same way
-            # that they are detected at normal runtime, but to be honest
-            # the normal runtime detection is pretty strange: it seems the
-            # backward tokens are not reliably at the end of the argument list
-            # but *precede* the RNG arguments (I don't understand why this is
-            # the case).  And in unlift_tokens, token arguments are detected
-            # by seeing if they feed into an effects call!  Dastardly.  Why
-            # didn't we just introduce a new type.
-
-            i = 0
-            j = 0
-            for n in fx_g.graph.nodes:
-                if n.op == "placeholder":
-                    if n.name.startswith("tangents_token"):
-                        n.meta["desc"] = BackwardTokenAOTInput(j)
-                        j += 1
-                    else:
-                        if i >= len(flat_args_descs):
-                            raise AssertionError(
-                                f"i={i} >= len(flat_args_descs)={len(flat_args_descs)}: "
-                                f"fn_wrappers={fn_wrappers(inner_f)}, "
-                                f"placeholders={[n for n in fx_g.graph.nodes if n.op == 'placeholder']}"
-                            )
-                        n.meta["desc"] = flat_args_descs[i]
-                        i += 1
-                elif n.op == "output":
-                    n.meta["desc"] = flat_out_descs
+            if out_descs is None:
+                raise AssertionError("out_descs must not be None")
+            _assign_graph_node_descs(fx_g, args_descs, out_descs, inner_f)
 
     return fx_g
+
+
+def _assign_graph_node_descs(
+    fx_g: torch.fx.GraphModule,
+    args_descs: Any,
+    out_descs: Any,
+    wrapped_fn: Callable[..., Any],
+) -> None:
+    flat_args_descs, _ = pytree.tree_flatten(args_descs)
+    flat_out_descs, _ = pytree.tree_flatten(out_descs)
+
+    # Unfortunately, flat_args_descs is not guaranteed to match the number of
+    # actual arguments that show up on the FX graph.  Specifically,
+    # allow_token_discovery=True can silently add extra token arguments to the
+    # backwards graph.  Match tangents_token placeholders specifically, as these
+    # are the only placeholders created by token discovery.
+    i = 0
+    j = 0
+    for n in fx_g.graph.nodes:
+        if n.op == "placeholder":
+            if n.name.startswith("tangents_token"):
+                n.meta["desc"] = BackwardTokenAOTInput(j)
+                j += 1
+            else:
+                if i >= len(flat_args_descs):
+                    raise AssertionError(
+                        f"i={i} >= len(flat_args_descs)={len(flat_args_descs)}: "
+                        f"fn_wrappers={fn_wrappers(wrapped_fn)}, "
+                        f"placeholders={[n for n in fx_g.graph.nodes if n.op == 'placeholder']}"
+                    )
+                n.meta["desc"] = flat_args_descs[i]
+                i += 1
+        elif n.op == "output":
+            n.meta["desc"] = flat_out_descs
 
 
 # TODO: Refactor the following code so detach() persists item_memo
@@ -301,6 +296,9 @@ def _can_reuse_precomputed_fw_graph(
     ):
         return False
 
+    # Metadata can reveal that the normal stage-1 wrappers need to alter the
+    # calling convention after the trace has already run.  In those cases,
+    # discard the precomputed graph and re-enter the existing capture path.
     return (
         fw_metadata.num_mutated_inp_runtime_indices == 0
         and fw_metadata.num_mutated_graph_handled_indices == 0
@@ -326,7 +324,6 @@ def _create_graph_and_collect_metadata(
         raise AssertionError("cannot collect functionalization metadata when disabled")
 
     saved_flat_args = _detach_traced_inputs(args)
-    fw_metadata_cell: list[ViewAndMutationMeta] = []
     metadata_fn = run_functionalized_fw_and_collect_metadata(
         f,
         flat_args_descs=args_descs,
@@ -334,16 +331,21 @@ def _create_graph_and_collect_metadata(
         keep_input_mutations=aot_config.keep_inference_input_mutations,
         pre_dispatch=aot_config.pre_dispatch,
         _return_graph_outputs=True,
-        _metadata_out=fw_metadata_cell,
     )
     out_descs = None
+    fw_metadata = None
 
     @simple_wraps(f)
     def inner_f(*args: Any) -> Any:
-        nonlocal out_descs
+        nonlocal out_descs, fw_metadata
         if out_descs is not None:
             raise AssertionError("out_descs must be None")
-        out, out_descs = call_and_expect_output_descs(metadata_fn, args)
+        result = metadata_fn(*args)
+        if not (isinstance(result, tuple) and len(result) == 3):
+            raise AssertionError(
+                f"expected tuple of length 3, got {type(result)} with value {result}"
+            )
+        out, out_descs, fw_metadata = result
         return out
 
     with enable_python_dispatcher():
@@ -355,36 +357,14 @@ def _create_graph_and_collect_metadata(
             _disable_torch_fn_metadata_mode=aot_config._disable_torch_fn_metadata_mode,
         )(*args)
 
-    if len(fw_metadata_cell) != 1:
-        raise AssertionError(
-            f"expected exactly one metadata result, got {len(fw_metadata_cell)}"
-        )
     if out_descs is None:
         raise AssertionError("out_descs must not be None")
+    if not isinstance(fw_metadata, ViewAndMutationMeta):
+        raise AssertionError(f"expected ViewAndMutationMeta, got {type(fw_metadata)}")
 
-    flat_args_descs, _ = pytree.tree_flatten(args_descs)
-    flat_out_descs, _ = pytree.tree_flatten(out_descs)
+    _assign_graph_node_descs(fx_g, args_descs, out_descs, inner_f)
 
-    i = 0
-    j = 0
-    for n in fx_g.graph.nodes:
-        if n.op == "placeholder":
-            if n.name.startswith("tangents_token"):
-                n.meta["desc"] = BackwardTokenAOTInput(j)
-                j += 1
-            else:
-                if i >= len(flat_args_descs):
-                    raise AssertionError(
-                        f"i={i} >= len(flat_args_descs)={len(flat_args_descs)}: "
-                        f"fn_wrappers={fn_wrappers(inner_f)}, "
-                        f"placeholders={[n for n in fx_g.graph.nodes if n.op == 'placeholder']}"
-                    )
-                n.meta["desc"] = flat_args_descs[i]
-                i += 1
-        elif n.op == "output":
-            n.meta["desc"] = flat_out_descs
-
-    return fx_g, saved_flat_args, args_descs, fw_metadata_cell[0]
+    return fx_g, saved_flat_args, args_descs, fw_metadata
 
 
 def aot_dispatch_base_graph(
@@ -448,10 +428,11 @@ def aot_dispatch_base_graph(
         # We track buffer assignments when exporting in non-strict mode.
         # (In contrast, strict mode errors on any attribute assignment.)
         mod_when_exporting_non_strict = root_module_when_exporting_non_strict(flat_fn)
+        assigned_buffers: dict[str, str] = {}
+        hook = None
         if aot_config.is_export and mod_when_exporting_non_strict is not None:
             # For any buffer that is assigned, we want to associate it to the final proxy node
             # that it is assigned to. This node can then be added as a buffer mutation output.
-            assigned_buffers: dict[str, str] = {}
             hook = register_buffer_assignment_hook(
                 mod_when_exporting_non_strict, assigned_buffers
             )
@@ -476,7 +457,7 @@ def aot_dispatch_base_graph(
                 if (
                     name in assigned_buffers
                     and not fw_metadata.input_info[i].mutates_data
-                ):  # type: ignore[possibly-undefined]
+                ):
                     fw_metadata.input_info[i] = dataclasses.replace(
                         fw_metadata.input_info[i], mutates_data=True
                     )
@@ -486,14 +467,16 @@ def aot_dispatch_base_graph(
             # We add nodes corresponding to buffer assignments as output nodes in the graph.
             add_nodes = []
             output_node = list(fw_module.graph.nodes)[-1]
-            for name in assigned_buffers.values():  # type: ignore[possibly-undefined]
+            for name in assigned_buffers.values():
                 for node in fw_module.graph.nodes:
                     if node.name == name:
                         add_nodes.append(node)
                         node.users[output_node] = None
             output_node.args = ((*add_nodes, *output_node.args[0]),)
 
-            hook.remove()  # type: ignore[possibly-undefined]
+            if hook is None:
+                raise AssertionError("buffer assignment hook must not be None")
+            hook.remove()
 
     # As long as we opted to remove input mutations, then
     # there should be *NO* mutating ops in the graph at this point.

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -255,6 +255,9 @@ def aot_stage1_graph_capture(
                     aot_state.flat_args_descs,
                     aot_config,
                     fw_metadata=aot_state.fw_metadata,
+                    precomputed_fw_module=aot_state.precomputed_fw_module,
+                    precomputed_flat_args=aot_state.precomputed_flat_args,
+                    precomputed_flat_args_descs=aot_state.precomputed_flat_args_descs,
                 )
             )
     if config.selective_decompose:

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -1212,6 +1212,14 @@ class AOTState:
     # original trace.
     fake_mode: FakeTensorMode
 
+    # For simple inference graphs, metadata collection can happen while tracing
+    # the forward graph.  These fields hold that trace so stage 1 can avoid
+    # running the same forward a second time when no wrappers need to change the
+    # calling convention.
+    precomputed_fw_module: torch.fx.GraphModule | None = None
+    precomputed_flat_args: list[Any] | None = None
+    precomputed_flat_args_descs: list[AOTInput] | None = None
+
 
 FxValue = Tensor | int | SymInt | BackwardState | OpaqueBase
 

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -476,11 +476,16 @@ def _can_collect_metadata_during_fw_graph_trace(
     aot_config: AOTConfig,
     needs_autograd: bool,
 ) -> bool:
+    # The combined metadata/trace path intentionally stays narrow: it is only
+    # profitable when stage 1 can reuse the traced graph.  Dynamic-shape traces
+    # have extra ShapeEnv/FakeTensor side effects during metadata analysis, so
+    # keep them on the existing two-step path for now.
     if (
         needs_autograd
         or aot_config.disable_functionalization
         or aot_config.is_export
         or aot_config.pre_dispatch
+        or aot_config.dynamic_shapes
         or config.functionalize_rng_ops
         or config.selective_decompose
         or torch._C._is_any_autocast_enabled()

--- a/torch/_functorch/aot_autograd.py
+++ b/torch/_functorch/aot_autograd.py
@@ -31,6 +31,7 @@ from torch._inductor.codecache import resolve_pre_grad_pass_timing
 from torch._subclasses import FakeTensor, FakeTensorMode
 from torch.export._tree_utils import reorder_kwargs
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 from . import config
 from ._aot_autograd import autograd_cache
@@ -68,6 +69,7 @@ from ._aot_autograd.functional_utils import (  # noqa: F401
     sync_functional_tensor,
     to_fun,
 )
+from ._aot_autograd.graph_capture import _create_graph_and_collect_metadata
 from ._aot_autograd.graph_capture_wrappers import (  # noqa: F401
     aot_dispatch_subclass,
     create_functional_call,
@@ -469,6 +471,34 @@ AOT_COUNTER = itertools.count()
 aot_autograd_decompositions: dict[OpOverload, Callable[..., Any]] = {}
 
 
+def _can_collect_metadata_during_fw_graph_trace(
+    fake_flat_args: FakifiedFlatArgs,
+    aot_config: AOTConfig,
+    needs_autograd: bool,
+) -> bool:
+    if (
+        needs_autograd
+        or aot_config.disable_functionalization
+        or aot_config.is_export
+        or aot_config.pre_dispatch
+        or config.functionalize_rng_ops
+        or config.selective_decompose
+        or torch._C._is_any_autocast_enabled()
+    ):
+        return False
+
+    seen_arg_ids: set[int] = set()
+    for arg in fake_flat_args:
+        if isinstance(arg, Tensor):
+            if is_traceable_wrapper_subclass(arg):
+                return False
+            arg_id = id(arg)
+            if arg_id in seen_arg_ids:
+                return False
+            seen_arg_ids.add(arg_id)
+    return True
+
+
 def create_aot_state(
     stack: contextlib.ExitStack,
     flat_fn: Callable[_P, _R],
@@ -558,6 +588,9 @@ def create_aot_state(
     needs_autograd = any(
         x.requires_grad for x in fake_flat_args if isinstance(x, Tensor)
     )
+    precomputed_fw_module = None
+    precomputed_flat_args = None
+    precomputed_flat_args_descs = None
 
     with enable_python_dispatcher():
         # Patch set_rng_state as set_rng_state with fake tensors is
@@ -579,17 +612,39 @@ def create_aot_state(
                 )
 
             with dynamo_timed_ctx, ctx:
-                fw_metadata = run_functionalized_fw_and_collect_metadata(
-                    flat_fn,
-                    flat_args_descs=flat_args_descs,
-                    static_input_indices=aot_config.static_input_indices,
-                    keep_input_mutations=aot_config.keep_inference_input_mutations,
-                    pre_dispatch=aot_config.pre_dispatch,
-                )(*_dup_fake_script_obj(fake_flat_args))
+                fake_flat_args_for_metadata = _dup_fake_script_obj(fake_flat_args)
+                if _can_collect_metadata_during_fw_graph_trace(
+                    fake_flat_args,
+                    aot_config,
+                    needs_autograd,
+                ):
+                    (
+                        precomputed_fw_module,
+                        precomputed_flat_args,
+                        precomputed_flat_args_descs,
+                        fw_metadata,
+                    ) = _create_graph_and_collect_metadata(
+                        flat_fn,
+                        fake_flat_args_for_metadata,
+                        flat_args_descs,
+                        aot_config=aot_config,
+                    )
+                else:
+                    fw_metadata = run_functionalized_fw_and_collect_metadata(
+                        flat_fn,
+                        flat_args_descs=flat_args_descs,
+                        static_input_indices=aot_config.static_input_indices,
+                        keep_input_mutations=aot_config.keep_inference_input_mutations,
+                        pre_dispatch=aot_config.pre_dispatch,
+                    )(*fake_flat_args_for_metadata)
 
             req_subclass_dispatch = requires_subclass_dispatch(
                 fake_flat_args, fw_metadata
             )
+            if req_subclass_dispatch:
+                precomputed_fw_module = None
+                precomputed_flat_args = None
+                precomputed_flat_args_descs = None
             CompileEventLogger.try_add_pt2_compile(
                 "backend_compile", requires_subclass_dispatch=req_subclass_dispatch
             )
@@ -692,6 +747,9 @@ or otherwise set torch._functorch.config.functionalize_rng_ops = False."""
         aot_config=aot_config,
         stack=stack,
         fake_mode=fake_mode,
+        precomputed_fw_module=precomputed_fw_module,
+        precomputed_flat_args=precomputed_flat_args,
+        precomputed_flat_args_descs=precomputed_flat_args_descs,
     )
 
 


### PR DESCRIPTION
Summary:
- Collect AOTAutograd inference metadata during the forward graph trace when the inputs and config are simple enough to preserve the base calling convention.
- Reuse the precomputed forward graph in stage 1 when metadata confirms there are no mutations, aliases, tokens, grad-mode mutations, or subclass wrapping requirements.
- Add a regression test that verifies simple inference AOTAutograd compilation only executes the user function once.

Root cause problem:
AOTAutograd currently runs simple inference functions once for metadata collection and again for make_fx forward graph capture. The first execution already has the information needed to build the forward graph for simple no-autograd cases, so the second execution is redundant.

Proposed fix:
Let metadata collection optionally return the forward graph outputs and descriptors while make_fx is tracing. Store that precomputed graph and its traced inputs on AOTState, then have the base graph-capture path reuse it only after metadata proves no wrapper or calling-convention adjustment is required. More complex cases keep the existing trace path.

Why this is the right long term fix:
The optimization is gated in two places: before tracing for known config/input cases that cannot safely use it, and after metadata collection for mutation, aliasing, token, grad-mode, and subclass cases. That keeps the fast path narrow and lets the existing, more general graph-capture machinery remain the source of truth for complex behavior.

Tests:
- Confirmed the new regression test fails without the implementation: `PYTHONPATH=. .venv/bin/python test/functorch/test_aotdispatch.py -k test_inference_metadata_collection_reuses_graph_trace` failed with calls == 2.
- `PYTHONPATH=. .venv/bin/python test/functorch/test_aotdispatch.py -k test_inference_metadata_collection_reuses_graph_trace`
- `PYTHONPATH=. .venv/bin/python test/functorch/test_aotdispatch.py TestAOTAutograd`
- `python3 -m py_compile torch/_functorch/aot_autograd.py torch/_functorch/_aot_autograd/collect_metadata_analysis.py torch/_functorch/_aot_autograd/graph_capture.py torch/_functorch/_aot_autograd/graph_compile.py torch/_functorch/_aot_autograd/schemas.py test/functorch/test_aotdispatch.py`
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" lintrunner --skip PYREFLY torch/_functorch/aot_autograd.py torch/_functorch/_aot_autograd/collect_metadata_analysis.py torch/_functorch/_aot_autograd/graph_capture.py torch/_functorch/_aot_autograd/graph_compile.py torch/_functorch/_aot_autograd/schemas.py test/functorch/test_aotdispatch.py`
- `PATH="$PWD/.venv/bin:$PATH" lintrunner --take PYFMT torch/_functorch/aot_autograd.py torch/_functorch/_aot_autograd/collect_metadata_analysis.py torch/_functorch/_aot_autograd/graph_capture.py torch/_functorch/_aot_autograd/graph_compile.py torch/_functorch/_aot_autograd/schemas.py test/functorch/test_aotdispatch.py`

Drafted via Codex, published after manual review by @bobrenjc93