### PR TITLE
Move intrusive_ptr's is_always_lock_free static_assert to .cpp

### DIFF
--- a/c10/util/intrusive_ptr.cpp
+++ b/c10/util/intrusive_ptr.cpp
@@ -1,1 +1,9 @@
 #include <c10/util/intrusive_ptr.h>
+
+// Checked here rather than in the header so device compilers (CUDA, HIP, and
+// other CUDA-like backends that may not define a recognizable device-pass
+// macro) parsing intrusive_ptr.h aren't forced to satisfy a host-only
+// invariant. combined_refcount_ is only ever touched from host code.
+// See https://github.com/pytorch/pytorch/pull/163394 and
+// https://github.com/pytorch/pytorch/issues/171775.
+static_assert(std::atomic<uint64_t>::is_always_lock_free);

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -188,7 +188,11 @@ class C10_API intrusive_ptr_target {
   mutable std::atomic<uint64_t> combined_refcount_;
   static_assert(sizeof(std::atomic<uint64_t>) == 8);
   static_assert(alignof(std::atomic<uint64_t>) == 8);
-  static_assert(std::atomic<uint64_t>::is_always_lock_free);
+  // is_always_lock_free check lives in intrusive_ptr.cpp so it's only
+  // evaluated by the host compiler. CUDA-like device compilers parsing this
+  // header may target hardware without 64-bit atomics; see
+  // https://github.com/pytorch/pytorch/issues/171775 (introduced by
+  // https://github.com/pytorch/pytorch/pull/163394).
 
   template <typename T, typename NullType>
   friend class intrusive_ptr;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #181719

The header is parsed by host *and* device compilers (nvcc, hip, and various CUDA-like privateuse1 backends). std::atomic<uint64_t>::is_always_lock_free reflects the target the compiler is currently generating code for, so a device pass targeting hardware without 64-bit atomics fails the assert even though combined_refcount_ is only ever touched from host code. A preprocessor guard would only protect device compilers we know to enumerate; moving the check to intrusive_ptr.cpp makes it host-only by construction and works for arbitrary unknown backends.

Fixes #171775.

Authored with Claude.