### PR TITLE
S390X: update binaries labels

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -250,8 +250,6 @@ S390X_BINARY_BUILD_WORKFLOWS = [
         ),
         ciflow_config=CIFlowConfig(
             labels={
-                LABEL_CIFLOW_BINARIES,
-                LABEL_CIFLOW_BINARIES_WHEEL,
                 LABEL_CIFLOW_S390,
             },
             isolated_workflow=True,

--- a/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-s390x-binary-manywheel-nightly.yml
@@ -14,8 +14,6 @@ on:
       # NOTE: Binary build pipelines should only get triggered on release candidate builds
       # Release candidate tags look like: v1.11.0-rc1
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-      - 'ciflow/binaries/*'
-      - 'ciflow/binaries_wheel/*'
       - 'ciflow/s390/*'
   workflow_dispatch:
 


### PR DESCRIPTION
There's currently a big volume of generated PRs that run binaries builds.

S390X CI doesn't have capacity to run too many builds at once in a timely manner.
Due to that, remove non-s390x labels from s390x-specific binaries builds.