### PR TITLE
[xpu][2/3]Implement scaled_mm_v1 for MXFP8/MXFP4/NVFP4 on XPU

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -474,8 +474,8 @@ Tensor& _scaled_mm_out_xpu(
 
   // TODO: Scale_result is not supported by now!!
   // API shapes match CUDA v1. oneDNN needs row-major contiguous.
-  // scale_a: [M, K//128] or [M//128, K//128] or [M, K//32]
-  // scale_b: [K//128, N] or [K//128, N//128] or [K//32, N]
+  // scale_a: [M, K//128] or [M//128, K//128] or [M, K//32] or [M, K//16]
+  // scale_b: [K//128, N] or [K//128, N//128] or [K//32, N] or [K//16, N]
   // Because the user might passed in the CUDA's stride (col-major because of
   // swizzling)
   // call a contiguous() to ensure row-major for oneDNN

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -120,6 +120,23 @@ bool is_blockwise_128x128_scaling(
       (scale.is_contiguous() || scale.t().is_contiguous()));
 }
 
+// 1x32 blocks for microscaled fp8 data and fp8_e8m0fnu scales
+bool is_blockwise_1x32_scaling(const at::Tensor& t, const at::Tensor& scale) {
+  bool is_fp8_path =
+      (isFloat8Type(t.scalar_type()) &&
+       scale.scalar_type() == at::kFloat8_e8m0fnu && scale.dim() == 2 &&
+       scale.size(0) == t.size(0) &&
+       scale.size(1) == ceil_div<int64_t>(t.size(1), 32) &&
+       (scale.is_contiguous() || scale.t().is_contiguous()));
+  bool is_packed_fp4_path =
+      (t.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2 &&
+       scale.scalar_type() == at::kFloat8_e8m0fnu && scale.dim() == 2 &&
+       scale.size(0) == t.size(0) &&
+       scale.size(1) == ceil_div<int64_t>(t.size(1) * 2, 32) &&
+       (scale.is_contiguous() || scale.t().is_contiguous()));
+  return (is_fp8_path || is_packed_fp4_path);
+}
+
 bool is_desired_scaling(
     const at::Tensor& t,
     const at::Tensor& scale,
@@ -133,6 +150,8 @@ bool is_desired_scaling(
       return is_blockwise_1x128_scaling(t, scale);
     case ScalingType::BlockWise128x128:
       return is_blockwise_128x128_scaling(t, scale);
+    case ScalingType::BlockWise1x32:
+      return is_blockwise_1x32_scaling(t, scale);
     default:
       return false;
   }
@@ -181,6 +200,24 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
       ceil_div<int64_t>(b.size(0), 128),
       ", ",
       ceil_div<int64_t>(b.size(1), 128),
+      ").\n"
+      "- For MXFP8 1x32 scaling, a and b should be float8, scales should be float8_e8m0fnu, scale_a should be (",
+      a.size(0),
+      ", ",
+      ceil_div<int64_t>(a.size(1), 32),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(b.size(0), 32),
+      ", ",
+      b.size(1),
+      ").\n"
+      "- For MXFP4 1x32 scaling, a and b should be float4_e2m1fn_x2, scales should be float8_e8m0fnu, scale_a should be (",
+      a.size(0),
+      ", ",
+      ceil_div<int64_t>(a.size(1) * 2, 32),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(b.size(0) * 2, 32),
+      ", ",
+      b.size(1),
       ").\n"
       "Got a.dtype()=",
       a.scalar_type(),
@@ -318,6 +355,8 @@ Tensor& _scaled_mm_out_xpu(
               ScalingType::BlockWise1x128, ScalingType::BlockWise128x128),
           std::make_pair(
               ScalingType::BlockWise1x128, ScalingType::BlockWise1x128),
+          std::make_pair(
+              ScalingType::BlockWise1x32, ScalingType::BlockWise1x32),
       },
       mat1,
       mat2,
@@ -353,12 +392,14 @@ Tensor& _scaled_mm_out_xpu(
       !out_dtype || *out_dtype == out.scalar_type(),
       "out_dtype must match output matrix type");
   TORCH_CHECK(
-      at::isFloat8Type(mat1.scalar_type()),
-      "Expected mat1 to be Float8 matrix got ",
+      at::isFloat8Type(mat1.scalar_type()) ||
+          mat1.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2,
+      "Expected mat1 to be Float8 or Float4_e2m1fn_x2 matrix got ",
       mat1.scalar_type());
   TORCH_CHECK(
-      at::isFloat8Type(mat2.scalar_type()),
-      "Expected mat2 to be Float8 matrix got ",
+      at::isFloat8Type(mat2.scalar_type()) ||
+          mat2.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2,
+      "Expected mat2 to be Float8 or Float4_e2m1fn_x2 matrix got ",
       mat2.scalar_type());
   // TODO: oneDNN Currently only supports e4m3 with group scales on BMG. Not
   // support 2D scales, only 1D. Needs to add more checks there.
@@ -408,21 +449,23 @@ Tensor& _scaled_mm_out_xpu(
 
   // TODO: Scale_result is not supported by now!!
   // API shapes match CUDA v1. oneDNN needs row-major contiguous.
-  // scale_a: [M, K//128] or [M//128, K//128]
-  // scale_b: [K//128, N] or [K//128, N//128]
+  // scale_a: [M, K//128] or [M//128, K//128] or [M, K//32]
+  // scale_b: [K//128, N] or [K//128, N//128] or [K//32, N]
   // Because the user might passed in the CUDA's stride (col-major because of
   // swizzling)
   // call a contiguous() to ensure row-major for oneDNN
   Tensor scale_a_internal = scale_a;
   Tensor scale_b_internal = scale_b;
   if (scaling_choice_a == ScalingType::BlockWise128x128 ||
-      scaling_choice_a == ScalingType::BlockWise1x128) {
+      scaling_choice_a == ScalingType::BlockWise1x128 ||
+      scaling_choice_a == ScalingType::BlockWise1x32) {
     scale_a_internal = scale_a.is_contiguous() ? scale_a : scale_a.contiguous();
   }
   if (scaling_choice_b == ScalingType::BlockWise1x128 ||
-      scaling_choice_b == ScalingType::BlockWise128x128) {
-    // CUDA v1 shapes [K//128, N] and [K//128, N//128] already match oneDNN's
-    // expected row-major layout. Just ensure contiguous.
+      scaling_choice_b == ScalingType::BlockWise128x128 ||
+      scaling_choice_b == ScalingType::BlockWise1x32) {
+    // CUDA v1 shapes [K//128, N], [K//128, N//128], or [K//32, N] already
+    // match oneDNN's expected row-major layout. Just ensure contiguous.
     scale_b_internal = scale_b.is_contiguous() ? scale_b : scale_b.contiguous();
   }
   return _scaled_gemm(

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -137,6 +137,18 @@ bool is_blockwise_1x32_scaling(const at::Tensor& t, const at::Tensor& scale) {
   return (is_fp8_path || is_packed_fp4_path);
 }
 
+// 1x16 blocks for packed nvfp4 data and float8_e4m3fn scales
+bool is_blockwise_1x16_scaling(const at::Tensor& t, const at::Tensor& scale) {
+  // Packed FP4 stores 2 elements per byte, so the logical column count is
+  // size(1) * 2.
+  return (
+      t.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2 &&
+      scale.scalar_type() == at::kFloat8_e4m3fn && scale.dim() == 2 &&
+      scale.size(0) == t.size(0) &&
+      scale.size(1) == ceil_div<int64_t>(t.size(1) * 2, 16) &&
+      (scale.is_contiguous() || scale.t().is_contiguous()));
+}
+
 bool is_desired_scaling(
     const at::Tensor& t,
     const at::Tensor& scale,
@@ -152,6 +164,8 @@ bool is_desired_scaling(
       return is_blockwise_128x128_scaling(t, scale);
     case ScalingType::BlockWise1x32:
       return is_blockwise_1x32_scaling(t, scale);
+    case ScalingType::BlockWise1x16:
+      return is_blockwise_1x16_scaling(t, scale);
     default:
       return false;
   }
@@ -216,6 +230,15 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
       ceil_div<int64_t>(a.size(1) * 2, 32),
       ") and scale_b should be (",
       ceil_div<int64_t>(b.size(0) * 2, 32),
+      ", ",
+      b.size(1),
+      ").\n"
+      "- For NVFP4 1x16 scaling, a and b should be float4_e2m1fn_x2, scales should be float8_e4m3fn, scale_a should be (",
+      a.size(0),
+      ", ",
+      ceil_div<int64_t>(a.size(1) * 2, 16),
+      ") and scale_b should be (",
+      ceil_div<int64_t>(b.size(0) * 2, 16),
       ", ",
       b.size(1),
       ").\n"
@@ -357,6 +380,8 @@ Tensor& _scaled_mm_out_xpu(
               ScalingType::BlockWise1x128, ScalingType::BlockWise1x128),
           std::make_pair(
               ScalingType::BlockWise1x32, ScalingType::BlockWise1x32),
+          std::make_pair(
+              ScalingType::BlockWise1x16, ScalingType::BlockWise1x16),
       },
       mat1,
       mat2,
@@ -458,14 +483,16 @@ Tensor& _scaled_mm_out_xpu(
   Tensor scale_b_internal = scale_b;
   if (scaling_choice_a == ScalingType::BlockWise128x128 ||
       scaling_choice_a == ScalingType::BlockWise1x128 ||
-      scaling_choice_a == ScalingType::BlockWise1x32) {
+      scaling_choice_a == ScalingType::BlockWise1x32 ||
+      scaling_choice_a == ScalingType::BlockWise1x16) {
     scale_a_internal = scale_a.is_contiguous() ? scale_a : scale_a.contiguous();
   }
   if (scaling_choice_b == ScalingType::BlockWise1x128 ||
       scaling_choice_b == ScalingType::BlockWise128x128 ||
-      scaling_choice_b == ScalingType::BlockWise1x32) {
-    // CUDA v1 shapes [K//128, N], [K//128, N//128], or [K//32, N] already
-    // match oneDNN's expected row-major layout. Just ensure contiguous.
+      scaling_choice_b == ScalingType::BlockWise1x32 ||
+      scaling_choice_b == ScalingType::BlockWise1x16) {
+    // CUDA v1 shapes [K//128, N], [K//128, N//128], [K//32, N], or [K//16, N]
+    // already match oneDNN's expected row-major layout. Just ensure contiguous.
     scale_b_internal = scale_b.is_contiguous() ? scale_b : scale_b.contiguous();
   }
   return _scaled_gemm(

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -92,61 +92,54 @@ bool is_rowwise_scaling(const at::Tensor& t, const at::Tensor& scale) {
       scale.is_contiguous());
 }
 
-// Scale shape checks for blockwise scaling.
-// For a matrix t [rows, cols]:
-//   BlockWise1x128:   scale has shape [rows, ceil_div(cols, 128)]
-//   BlockWise128x128: scale has shape [ceil_div(rows, 128), ceil_div(cols,
-//   128)]
-// These shapes match CUDA's convention.
+// Shared scale shape check for blockwise scaling.
+// For a matrix t [rows, cols], scale must have shape
+// [ceil_div(rows, block_rows), ceil_div(cols, block_cols)], where cols is the
+// logical column count: packed FP4 stores two elements per byte, so its
+// logical width is size(1) * 2.
 // XPU accepts both row-major (contiguous) and column-major strides,
 // since it internally calls .contiguous() for oneDNN. CUDA requires
 // specific strides for cuBLAS swizzling; XPU is more permissive but
 // still validates that strides form a valid contiguous layout.
-bool is_blockwise_1x128_scaling(const at::Tensor& t, const at::Tensor& scale) {
+bool is_blockwise_scaling(
+    const at::Tensor& t,
+    const at::Tensor& scale,
+    at::ScalarType scale_dtype,
+    int64_t block_rows,
+    int64_t block_cols) {
+  const int64_t cols = t.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2
+      ? t.size(1) * 2
+      : t.size(1);
   return (
-      at::isFloat8Type(t.scalar_type()) && scale.scalar_type() == at::kFloat &&
-      scale.dim() == 2 && scale.size(0) == t.size(0) &&
-      scale.size(1) == ceil_div<int64_t>(t.size(1), 128) &&
+      scale.scalar_type() == scale_dtype && scale.dim() == 2 &&
+      scale.size(0) == ceil_div<int64_t>(t.size(0), block_rows) &&
+      scale.size(1) == ceil_div<int64_t>(cols, block_cols) &&
       (scale.is_contiguous() || scale.t().is_contiguous()));
+}
+
+bool is_blockwise_1x128_scaling(const at::Tensor& t, const at::Tensor& scale) {
+  return at::isFloat8Type(t.scalar_type()) &&
+      is_blockwise_scaling(t, scale, at::kFloat, 1, 128);
 }
 
 bool is_blockwise_128x128_scaling(
     const at::Tensor& t,
     const at::Tensor& scale) {
-  return (
-      at::isFloat8Type(t.scalar_type()) && scale.scalar_type() == at::kFloat &&
-      scale.dim() == 2 && scale.size(0) == ceil_div<int64_t>(t.size(0), 128) &&
-      scale.size(1) == ceil_div<int64_t>(t.size(1), 128) &&
-      (scale.is_contiguous() || scale.t().is_contiguous()));
+  return at::isFloat8Type(t.scalar_type()) &&
+      is_blockwise_scaling(t, scale, at::kFloat, 128, 128);
 }
 
-// 1x32 blocks for microscaled fp8 data and fp8_e8m0fnu scales
+// 1x32 blocks for microscaled fp8 or packed fp4 data and fp8_e8m0fnu scales
 bool is_blockwise_1x32_scaling(const at::Tensor& t, const at::Tensor& scale) {
-  bool is_fp8_path =
-      (isFloat8Type(t.scalar_type()) &&
-       scale.scalar_type() == at::kFloat8_e8m0fnu && scale.dim() == 2 &&
-       scale.size(0) == t.size(0) &&
-       scale.size(1) == ceil_div<int64_t>(t.size(1), 32) &&
-       (scale.is_contiguous() || scale.t().is_contiguous()));
-  bool is_packed_fp4_path =
-      (t.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2 &&
-       scale.scalar_type() == at::kFloat8_e8m0fnu && scale.dim() == 2 &&
-       scale.size(0) == t.size(0) &&
-       scale.size(1) == ceil_div<int64_t>(t.size(1) * 2, 32) &&
-       (scale.is_contiguous() || scale.t().is_contiguous()));
-  return (is_fp8_path || is_packed_fp4_path);
+  return (at::isFloat8Type(t.scalar_type()) ||
+          t.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2) &&
+      is_blockwise_scaling(t, scale, at::kFloat8_e8m0fnu, 1, 32);
 }
 
 // 1x16 blocks for packed nvfp4 data and float8_e4m3fn scales
 bool is_blockwise_1x16_scaling(const at::Tensor& t, const at::Tensor& scale) {
-  // Packed FP4 stores 2 elements per byte, so the logical column count is
-  // size(1) * 2.
-  return (
-      t.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2 &&
-      scale.scalar_type() == at::kFloat8_e4m3fn && scale.dim() == 2 &&
-      scale.size(0) == t.size(0) &&
-      scale.size(1) == ceil_div<int64_t>(t.size(1) * 2, 16) &&
-      (scale.is_contiguous() || scale.t().is_contiguous()));
+  return t.scalar_type() == c10::ScalarType::Float4_e2m1fn_x2 &&
+      is_blockwise_scaling(t, scale, at::kFloat8_e4m3fn, 1, 16);
 }
 
 bool is_desired_scaling(

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1793,7 +1793,11 @@ class TestFP8Lowering(TestCase):
     @onlyCUDA
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, "Not supported on non B200")
     def test_mx_fp8_max_autotune(self, device):
-        M, K, N = 128, 32, 128
+        # K must match the operands, which are eye(M)/eye(N) (i.e. 128 wide);
+        # using a smaller K would size the MX 1x32 scales for fewer K-blocks
+        # than the data has (XPU rejects this; CUDA only masks it via the
+        # to_blocked() zero-padding below).
+        M, K, N = 128, 128, 128
         BLOCK_SIZE = 32
         dtype = torch.bfloat16
         A_ref = torch.eye(M, device=device, dtype=torch.bfloat16)
@@ -1806,8 +1810,11 @@ class TestFP8Lowering(TestCase):
         B_scale = torch.full(
             (N, ceil_div(K, BLOCK_SIZE)), 1.0, device=device, dtype=torch.float8_e8m0fnu
         )
-        A_scale = to_blocked(A_scale)
-        B_scale = to_blocked(B_scale)
+        if "cuda" in device:
+            A_scale = to_blocked(A_scale)
+            B_scale = to_blocked(B_scale)
+        elif "xpu" in device:
+            B_scale = B_scale.t()
 
         def linear(A, B, A_scale, B_scale):
             y = torch._scaled_mm(

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -1790,7 +1790,7 @@ class TestFP8Lowering(TestCase):
         # The swizzled path must use the ATen fallback, not a generated kernel
         FileCheck().check("_scaled_mm_v2").run(code)
 
-    @onlyCUDA
+    @onlyOn(["cuda", "xpu"])
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, "Not supported on non B200")
     def test_mx_fp8_max_autotune(self, device):
         # K must match the operands, which are eye(M)/eye(N) (i.e. 128 wide);


### PR DESCRIPTION
Add blockwise scaling support (1x32), (1x16) to the v1 _scaled_mm API for XPU, enabling MXFP8/MXFP4/NVFP4.

### PR Stack:
Since I don't have ghstack permission, I manually created the following stacked PRs for review. 

#181726 [xpu][1/3]Implement scaled_mm_v2 for MXFP8/MXFP4/NVFP4 on XPU
#181727 [xpu][2/3]Implement scaled_mm_v1 for MXFP8/MXFP4/NVFP4 on XPU
#187315 [xpu][3/3] inductor: route MX scaled_mm_v2 fallback through v2 aten kernel


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jerryzh168