### PR TITLE
Prevent DCE eliminate "triton_kernel_wrapper_mutation"

### DIFF
--- a/test/fx/test_dce_pass.py
+++ b/test/fx/test_dce_pass.py
@@ -356,6 +356,28 @@ class TestDCE(TestCase):
         self._run_dce_and_test(TestModule(), expect_dce_changes=False, custom=False)
         torch.distributed.destroy_process_group()
 
+    def test_keep_triton_kernel_wrapper_mutation(self):
+        """
+        Test that DCE doesn't remove triton_kernel_wrapper_mutation nodes.
+        """
+        from torch._higher_order_ops.triton_kernel_wrap import (
+            triton_kernel_wrapper_mutation,
+        )
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+        mutation_node = g.call_function(
+            triton_kernel_wrapper_mutation, args=(), kwargs={}
+        )
+        g.output(x)
+        gm = torch.fx.GraphModule({}, g)
+
+        self.assertTrue(mutation_node.is_impure())
+        changed = gm.graph.eliminate_dead_code()
+        self.assertFalse(changed)
+        call_fn_nodes = [n for n in gm.graph.nodes if n.op == "call_function"]
+        self.assertEqual(len(call_fn_nodes), 1)
+        self.assertIs(call_fn_nodes[0].target, triton_kernel_wrapper_mutation)
+
     @unittest.skipIf(IS_MACOS, "Not working on macos")
     def test_keep_collectives_no_overload(self):
         """

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1248,6 +1248,10 @@ def identify_triton_stores_from_ast(tree: ast.Module) -> TritonStores:
 
 # Used for wrapping a Triton Kernel
 class TritonKernelWrapperMutation(HigherOrderOperator):
+    
+    # Mark as impure so that calls to it will not be removed during DCE.
+    _is_impure = True
+
     def __init__(self) -> None:
         super().__init__("triton_kernel_wrapper_mutation", cacheable=True)
 

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1248,10 +1248,6 @@ def identify_triton_stores_from_ast(tree: ast.Module) -> TritonStores:
 
 # Used for wrapping a Triton Kernel
 class TritonKernelWrapperMutation(HigherOrderOperator):
-    
-    # Mark as impure so that calls to it will not be removed during DCE.
-    _is_impure = True
-
     def __init__(self) -> None:
         super().__init__("triton_kernel_wrapper_mutation", cacheable=True)
 
@@ -1275,6 +1271,9 @@ class TritonKernelWrapperMutation(HigherOrderOperator):
 
 triton_kernel_wrapper_mutation = TritonKernelWrapperMutation()
 
+# Register as side-effectful so DCE (eliminate_dead_code) does not remove calls to it.
+from torch.fx.node import _side_effectful_functions  # noqa: E402
+_side_effectful_functions.add(triton_kernel_wrapper_mutation)
 
 # Used for wrapping a Triton Kernel in a functional manner
 class TritonKernelWrapperFunctional(HigherOrderOperator):

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -776,6 +776,9 @@ class Node(_NodeBase):
 
         # For call_function, delegate to the unified has_side_effects function
         if self.op == "call_function":
+            if getattr(self.target, "_is_impure", False):
+                    return True
+
             from torch._library.utils import is_impure
 
             return is_impure(

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -776,7 +776,6 @@ class Node(_NodeBase):
 
         # For call_function, delegate to the unified has_side_effects function
         if self.op == "call_function":
-
             from torch._library.utils import is_impure
 
             return is_impure(

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -776,8 +776,6 @@ class Node(_NodeBase):
 
         # For call_function, delegate to the unified has_side_effects function
         if self.op == "call_function":
-            if getattr(self.target, "_is_impure", False):
-                    return True
 
             from torch._library.utils import is_impure
 


### PR DESCRIPTION
`triton_kernel_wrapper_mutation` has [num_users=0] (returns None) but mutates its input buffers in-place, so` Node.is_impure() `incorrectly returned False and DCE eliminated it, corrupting downstream consumers of the mutated buffers.

This pr add `TritonKernelWrapperMutation`  to `torch.fx.node._side_effectful_functions`.