### PR TITLE
[TEST] Refactor profiler test xpu profiler to be device_agnostic

### DIFF
--- a/test/profiler/test_kineto.py
+++ b/test/profiler/test_kineto.py
@@ -5,21 +5,30 @@ import sys
 from unittest.mock import patch
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    ALLOW_XPU_PROFILING_TEST,
+    DEVICE_LIST_SUPPORT_PROFILING_TEST,
+    run_tests,
+    TestCase,
+)
 
 
 class SimpleKinetoInitializationTest(TestCase):
     @patch.dict(os.environ, {"KINETO_USE_DAEMON": "1"})
-    def test_kineto_profiler_with_environment_variable(self):
+    def test_kineto_profiler_with_environment_variable(self, device):
         """
         This test checks whether kineto works with torch in daemon mode, please refer to issue #112389 and #131020.
         Besides that, this test will also check that kineto will not be initialized when user loads the shared library
         directly.
         """
-        script = """
+        device_type = device.split(":")[0]
+        script = f"""
 import torch
-if torch.cuda.is_available() > 0:
-    torch.cuda.init()
+if torch.{device_type}.is_available():
+    device_module = torch.{device_type}
+    if hasattr(device_module, 'init'):
+        device_module.init()
 """
         try:
             subprocess.check_output(
@@ -46,6 +55,13 @@ if torch.cuda.is_available() > 0:
             "kineto should not be initialized when the shared library is imported directly",
         )
 
+
+instantiate_device_type_tests(
+    SimpleKinetoInitializationTest,
+    globals(),
+    only_for=DEVICE_LIST_SUPPORT_PROFILING_TEST,
+    allow_xpu=ALLOW_XPU_PROFILING_TEST,
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/profiler/test_xpu_profiler.py
+++ b/test/profiler/test_xpu_profiler.py
@@ -4,24 +4,33 @@
 import json
 import os
 import tempfile
-import unittest
 from collections import defaultdict
 
 import torch
-from torch.profiler import DeviceType
-from torch.testing._internal.common_utils import run_tests, TEST_XPU, TestCase
+from torch.profiler import DeviceType, ProfilerActivity
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    ALLOW_XPU_PROFILING_TEST,
+    DEVICE_LIST_SUPPORT_PROFILING_TEST,
+    run_tests,
+    TestCase,
+)
 
 
 Verbose = False
 
 
-class XpuProfilerTest(TestCase):
-    @unittest.skipIf(not TEST_XPU, "test requires XPU")
-    def test_profiler(self):
-        t = torch.empty(1000, dtype=torch.int, device="xpu")
+class AcceleratorProfilerTest(TestCase):
+    def test_profiler(self, device):
+        device_type = device.split(":")[0]
+        t = torch.empty(1000, dtype=torch.int, device=device)
+
+        # Dynamically get the ProfilerActivity for this device
+        profiler_activity = getattr(ProfilerActivity, device_type.upper())
+
         with torch.profiler.profile(
             activities=[
-                torch.profiler.ProfilerActivity.XPU,
+                profiler_activity,
             ]
         ) as p:
             for _ in range(10):
@@ -32,13 +41,20 @@ class XpuProfilerTest(TestCase):
             events[event.device_type] += 1
 
         if Verbose:
-            print(f"{events = }")
+            print(f"{events=}")
 
-        self.assertEqual(len(events), 2)
-        self.assertTrue(DeviceType.CPU in events)
-        self.assertTrue(DeviceType.XPU in events)
+        # CPU profiling only shows CPU events, accelerators show CPU + device events
+        if device_type == "cpu":
+            self.assertEqual(len(events), 1)
+            self.assertTrue(DeviceType.CPU in events)
+        else:
+            self.assertEqual(len(events), 2)
+            self.assertTrue(DeviceType.CPU in events)
+            # Dynamically check for the correct device type
+            expected_device_type = getattr(DeviceType, device_type.upper())
+            self.assertTrue(expected_device_type in events)
 
-    def gen_and_check_json(self, p, json_file):
+    def gen_and_check_json(self, p, json_file, device_type):
         p.export_chrome_trace(json_file)
 
         with open(json_file) as f:
@@ -61,22 +77,31 @@ class XpuProfilerTest(TestCase):
                     count_cats[event["cat"]] += 1
 
             if Verbose:
-                print(f"{count_names = }")
-                print(f"{count_cats = }")
+                print(f"{count_names=}")
+                print(f"{count_cats=}")
 
-            self.assertTrue("xpu_runtime" in count_cats)
-            self.assertTrue("xpu_driver" in count_cats)
-            self.assertTrue("kernel" in count_cats)
+            # Check for device-specific categories (only for accelerators, not CPU)
+            if device_type != "cpu":
+                # Check that at least runtime category exists for accelerators
+                self.assertTrue(f"{device_type}_runtime" in count_cats)
+                # Kernel category is GPU-specific
+                self.assertTrue("kernel" in count_cats)
 
-    @unittest.skipIf(not TEST_XPU, "test requires XPU")
-    def test_profiler_xpu_driver(self):
-        a = torch.rand([100, 200]).to("xpu")
-        b = torch.rand([200, 300]).to("xpu")
+    def test_profiler_driver(self, device):
+        device_type = device.split(":")[0]
+        a = torch.rand([100, 200]).to(device)
+        b = torch.rand([200, 300]).to(device)
+
+        # Dynamically get the ProfilerActivity for this device
+        profiler_activity = getattr(ProfilerActivity, device_type.upper())
+
+        # Build activities list - avoid duplicating CPU
+        activities = [torch.profiler.ProfilerActivity.CPU]
+        if device_type != "cpu":
+            activities.append(profiler_activity)
+
         with torch.profiler.profile(
-            activities=[
-                torch.profiler.ProfilerActivity.CPU,
-                torch.profiler.ProfilerActivity.XPU,
-            ],
+            activities=activities,
         ) as p:
             r1 = torch.matmul(a, b)
             r2 = torch.add(r1, 1.0)
@@ -87,14 +112,21 @@ class XpuProfilerTest(TestCase):
         json_file = os.environ.get("JSON_FILE")
 
         if json_file:
-            self.gen_and_check_json(p, json_file)
+            self.gen_and_check_json(p, json_file, device_type)
         else:
             with tempfile.NamedTemporaryFile(mode="w+", delete=True) as tmp:
-                self.gen_and_check_json(p, tmp.name)
+                self.gen_and_check_json(p, tmp.name, device_type)
 
         if Verbose:
             print(p.key_averages().table())
 
+
+instantiate_device_type_tests(
+    AcceleratorProfilerTest,
+    globals(),
+    only_for=DEVICE_LIST_SUPPORT_PROFILING_TEST,
+    allow_xpu=ALLOW_XPU_PROFILING_TEST,
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
Refactor test/profiler/test_xpu_profiler.py to be device-agnostic by converting XPU-specific profiler tests to support all accelerators (CPU, CUDA, XPU) using the device-generic testing framework.

**1.Class and decorator changes (lines 18-24):**
  **Before**: `XpuProfilerTest` with `@unittest.skipIf(not TEST_XPU, "test requires XPU")`
  **After**: `AcceleratorProfilerTest` with `device` parameter using `instantiate_device_type_tests`
**2. Dynamic ProfilerActivity selection (lines 25-29):**
  **Before**: Hardcoded `ProfilerActivity.XPU`
  **After**: `getattr(ProfilerActivity, device_type.upper())` to dynamically select `ProfilerActivity.CPU/CUDA/XPU`
**3. Device-agnostic tensor creation (line 23):**
  **Before**: `device="xpu"`
  **After**: `device=device` parameter
**4. Conditional event checking (lines 46-54):**
  Handle CPU-only profiling (1 event type) vs accelerators (2 event types: CPU + device)
  Dynamically check for correct `DeviceType` based on device
**5. Conditional trace category validation (lines 83-88):**
  **Before**: Hardcoded checks for `xpu_runtime`, `xpu_driver`, `kernel`
  **After**: Dynamic checks for `{device_type}_runtime` and `kernel` (only for accelerators, not CPU)
**6. Fix ProfilerActivity duplication (lines 100-106):**
  Avoid adding `ProfilerActivity.CPU` twice when device is CPU
  Build activities list conditionally

Changes:
- Use `instantiate_device_type_tests` for standardized device-generic test instantiation
- Creates `AcceleratorProfilerTestCPU`, `AcceleratorProfilerTestCUDA`, `AcceleratorProfilerTestXPU` test variants
- Enables out-of-tree backends to run and skip tests via `DeviceTypeTestBase.skipped_testcases`
- Handles CPU vs accelerator differences in profiler event categories

Test Plan:
Verified all tests pass with `TEST_CONFIG=cpu python test/profiler/test_xpu_profiler.py -v: Ran 4 tests in 0.132s OK
Verified all tests pass with `TEST_CONFIG=cuda python test/profiler/test_xpu_profiler.py -v: Ran 4 tests in 0.127s OK