### PR TITLE
mps: fast path in multi_head_attention_forward for need_weights=False (-40% forward)

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6578,6 +6578,80 @@ def multi_head_attention_forward(
             average_attn_weights=average_attn_weights,
         )
 
+    # MPS fast path: when attention weights are not needed, bypass the Python-heavy
+    # general path and go straight to SDPA.  The general path runs ~30% slower on
+    # MPS at typical model sizes because every intermediate reshape and mask
+    # normalisation encodes a separate Metal command buffer entry.
+    if (
+        not need_weights
+        and not use_separate_proj_weight
+        and in_proj_weight is not None
+        and bias_k is None
+        and bias_v is None
+        and not add_zero_attn
+        and static_k is None
+        and static_v is None
+        and not torch.jit.is_scripting()
+        and not torch.jit.is_tracing()
+        and query.device.type == "mps"
+        and query.dim() == 3  # batched seq-first: (L, N, E)
+        and not (query.is_nested or key.is_nested or value.is_nested)
+    ):
+        tgt_len, bsz, embed_dim = query.shape
+        src_len = key.shape[0]
+        if embed_dim != embed_dim_to_check:
+            raise ValueError(
+                f"was expecting embedding dimension of {embed_dim_to_check}, but got {embed_dim}"
+            )
+        head_dim = embed_dim // num_heads
+        if head_dim * num_heads != embed_dim:
+            raise ValueError(
+                f"embed_dim {embed_dim} not divisible by num_heads {num_heads}"
+            )
+        q, k, v = _in_projection_packed(query, key, value, in_proj_weight, in_proj_bias)
+        # (L, N, E) -> (N, H, L, D)
+        q = q.view(tgt_len, bsz, num_heads, head_dim).permute(1, 2, 0, 3)
+        k = k.view(src_len, bsz, num_heads, head_dim).permute(1, 2, 0, 3)
+        v = v.view(src_len, bsz, num_heads, head_dim).permute(1, 2, 0, 3)
+        # Build merged mask
+        merged_mask: Tensor | None = None
+        if key_padding_mask is not None:
+            kpm = _canonical_mask(
+                mask=key_padding_mask,
+                mask_name="key_padding_mask",
+                other_type=_none_or_dtype(attn_mask),
+                other_name="attn_mask",
+                target_type=query.dtype,
+            )
+            if kpm is not None:
+                merged_mask = kpm.view(bsz, 1, 1, src_len)
+        if attn_mask is not None:
+            am = _canonical_mask(
+                mask=attn_mask,
+                mask_name="attn_mask",
+                other_type=None,
+                other_name="",
+                target_type=query.dtype,
+                check_other=False,
+            )
+            if am is not None:
+                if am.dim() == 2:
+                    am = am.unsqueeze(0).unsqueeze(0)
+                elif am.dim() == 3:
+                    am = am.view(bsz, num_heads, tgt_len, src_len)
+                merged_mask = am if merged_mask is None else merged_mask + am
+                is_causal = False
+        attn_output = scaled_dot_product_attention(
+            q, k, v, merged_mask, dropout_p if training else 0.0, is_causal
+        )
+        # (N, H, L, D) -> (L, N, E)
+        attn_output = attn_output.permute(2, 0, 1, 3).contiguous().view(
+            tgt_len * bsz, embed_dim
+        )
+        attn_output = linear(attn_output, out_proj_weight, out_proj_bias)
+        attn_output = attn_output.view(tgt_len, bsz, embed_dim)
+        return attn_output, None
+
     is_batched = _mha_shape_check(
         query, key, value, key_padding_mask, attn_mask, num_heads
     )


### PR DESCRIPTION
## Summary

Adds an early-exit fast path in `multi_head_attention_forward` for MPS (Apple Silicon) when `need_weights=False`.

On MPS, each Python-level tensor operation encodes a separate Metal command buffer entry. The general path runs 30–40% slower than necessary for the common `need_weights=False` training case because of the overhead from shape checks, mask canonicalisation, and the reshape pipeline before reaching `scaled_dot_product_attention`.

The fast path activates under standard conditions (packed weights, no exotic features, batched seq-first input, not scripting/tracing) and goes directly from in-projection to SDPA, bypassing ~50 lines of Python overhead.

## Related

**#181503** — Metal softmax kernels for MPS (by the same author). These two PRs address different parts of the same call stack:
- `need_weights=False`: this PR's fast path → `scaled_dot_product_attention` (MPSGraph fused attention, softmax internal)
- `need_weights=True`: general path → `bmm` + standalone softmax → #181503's Metal softmax kernel

Together they cover both attention dispatch paths on MPS.

## Conditions for the fast path

- `device == "mps"`
- `need_weights=False`
- Packed in-projection weights (`use_separate_proj_weight=False`, `in_proj_weight is not None`)
- No `bias_k`/`bias_v`, no `add_zero_attn`, no `static_k`/`static_v`
- Batched seq-first input (`query.dim() == 3`), not nested tensors
- Not scripting or tracing

When any condition is not met, falls through to the existing general path unchanged.

## Benchmarks

Apple M-series, `nn.MultiheadAttention(256, 2, batch_first=True)`, B=16, S=35, `key_padding_mask` provided (typical graph transformer / short-sequence scenario):

| | Before | After | Improvement |
|--|--|--|--|
| Forward | 0.384 ms | 0.232 ms | **-40%** |
| Backward | 0.764 ms | 0.684 ms | **-10%** |
| Numerical error | — | 2e-7 | (float32 precision) |

## Context

This benefits any model using `nn.MultiheadAttention(..., need_weights=False)` on MPS — graph transformers, vision transformers, LLM fine-tuning on Apple Silicon — without requiring model code changes beyond setting `need_weights=False` (already recommended in the `MultiheadAttention` docstring for performance).

`need_weights` defaults to `True` for API compatibility, but the MPS overhead for the `True` path is disproportionate because Metal command buffer encoding is synchronous and sensitive to op count in a way CUDA async dispatch is not.
