### PR TITLE
[CUDA][TEST] Skip undefined behavior in tests

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -30,6 +30,7 @@ from torch.testing._internal.common_device_type import (
     OpDTypes,
     ops,
     precisionOverride,
+    skipCUDAIfNotRocm,
     skipIf,
     skipMeta,
     skipXPU,
@@ -1099,6 +1100,9 @@ class TestBinaryUfuncsDevice(TestCase):
         else:
             info = torch.iinfo(dtype)
             low, high = info.min, info.max
+            if dtype.is_signed:
+                # Avoid source-level UB from signed overflow and signed min / -1.
+                low += 1
 
         a = make_tensor((100,), dtype=dtype, device=device, low=low, high=high)
         b = make_tensor((100,), dtype=dtype, device=device, low=low, high=high)
@@ -1233,6 +1237,9 @@ class TestBinaryUfuncsDevice(TestCase):
     def test_div_rounding_numpy(self, device, dtype):
         info = torch.finfo(dtype) if dtype.is_floating_point else torch.iinfo(dtype)
         low, high = info.min, info.max
+        if not dtype.is_floating_point and not dtype.is_complex and dtype.is_signed:
+            # Avoid source-level UB from signed min / -1 in truncating division.
+            low += 1
 
         # Compare division of random values against NumPy
         a = make_tensor((4096,), dtype=dtype, device=device, low=low, high=high)
@@ -2785,7 +2792,7 @@ class TestBinaryUfuncsDevice(TestCase):
     @dtypesIfXPU(*set(get_all_math_dtypes("xpu")) - {torch.complex64, torch.complex128})
     @dtypes(*set(get_all_math_dtypes("cpu")) - {torch.complex64, torch.complex128})
     def test_floor_divide_tensor(self, device, dtype):
-        x = torch.randn(10, device=device).mul(30).to(dtype)
+        x = make_tensor((10,), dtype=dtype, device=device, low=-90, high=90)
         y = torch.arange(1, 11, dtype=dtype, device=device)
 
         z = x // y
@@ -2800,7 +2807,7 @@ class TestBinaryUfuncsDevice(TestCase):
     @dtypesIfXPU(*set(get_all_math_dtypes("xpu")) - {torch.complex64, torch.complex128})
     @dtypes(*set(get_all_math_dtypes("cpu")) - {torch.complex64, torch.complex128})
     def test_floor_divide_scalar(self, device, dtype):
-        x = torch.randn(100, device=device).mul(10).to(dtype)
+        x = make_tensor((100,), dtype=dtype, device=device, low=-30, high=30)
 
         z = x // 3
         z_alt = torch.tensor(
@@ -2821,6 +2828,7 @@ class TestBinaryUfuncsDevice(TestCase):
             self.assertTrue(torch.all(fn(x, zero).isnan()))
 
     @onlyNativeDeviceTypes  # Check Issue https://github.com/pytorch/pytorch/issues/48130
+    @skipCUDAIfNotRocm  # NVIDIA CUDA reaches source-level UB for these inputs.
     @dtypes(*integral_types())
     @dtypesIfXPU(*set(integral_types()) - {torch.int64})
     def test_fmod_remainder_by_zero_integral(self, device, dtype):
@@ -2837,10 +2845,8 @@ class TestBinaryUfuncsDevice(TestCase):
                 # ROCm behavior: x % 0 is a no-op; x is returned
                 self.assertEqual(fn(x, zero), x)
             else:
-                # CUDA behavior: Different value for different dtype
-                # Due to it's an undefined behavior, CUDA returns a pattern of all 1s
-                # for integral dividend (other than int64) divided by zero. For int64,
-                # CUDA returns all 1s for negative dividend, half 1s for positive dividend.
+                # Other accelerator backends may return backend-specific bit
+                # patterns for integral remainder by zero.
                 # uint8: 0xff -> 255
                 # int32: 0xffffffff -> -1
                 if dtype == torch.int64:
@@ -2851,6 +2857,7 @@ class TestBinaryUfuncsDevice(TestCase):
                     self.assertTrue(torch.all(fn(x, zero) == value))
 
     @onlyNativeDeviceTypes
+    @skipCUDAIfNotRocm  # NVIDIA CUDA reaches source-level UB for these inputs.
     @dtypes(*integral_types())
     def test_fmod_remainder_overflow(self, device, dtype):
         fn_list = (torch.fmod, torch.remainder)

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -169,15 +169,13 @@ class TestScatterGather(TestCase):
             src = make_tensor(tuple(src_size), device=device, dtype=dtype)
 
         base = make_tensor((m, n, o), device=device, dtype=dtype)
-        if reduction is not None:
-            if fn is torch.Tensor.scatter_reduce_:
-                actual = fn(base.clone(), dim, idx, src, reduce=reduction, include_self=include_self)
-            else:
-                actual = fn(base.clone(), dim, idx, src, reduce=reduction)
-        else:
-            actual = fn(base.clone(), dim, idx, src)
+        # for signed integers, avoid undefined behavior in expected output
+        use_int64_expected = (
+            dtype in (torch.int8, torch.int16, torch.int32)
+            and reduction in {"add", "sum", "multiply", "prod", "mean"}
+        )
+        expected = base.to(torch.int64, copy=True) if use_int64_expected else base.clone()
 
-        expected = base.clone()
         counts = torch.zeros(base.shape, dtype=torch.long, device=device) + include_self
         for i in range(idx_size[0]):
             for j in range(idx_size[1]):
@@ -191,6 +189,8 @@ class TestScatterGather(TestCase):
                         # or 'scatter_reduce_', the former two might have a reduction argument
                         # while the latter two always do
                         value = src if is_scalar else src[i, j, k]
+                        if use_int64_expected:
+                            value = int(value) if is_scalar else value.to(torch.int64)
 
                         if ((not include_self) and counts[tuple(ii)] == 0):
                             expected[tuple(ii)] = value
@@ -210,12 +210,40 @@ class TestScatterGather(TestCase):
 
                         counts[tuple(ii)] += 1
 
+        if use_int64_expected:
+            iinfo = torch.iinfo(dtype)
+            expected_out_of_range = torch.any(
+                (expected < iinfo.min) | (expected > iinfo.max)
+            )
+            if bool(expected_out_of_range.item()):
+                min_observed = expected.min().item()
+                max_observed = expected.max().item()
+                self.skipTest(
+                    f"Skipping {fn.__name__} reference case with {dtype=} and "
+                    f"{reduction=} because it would overflow {dtype}: observed "
+                    f"expected range [{min_observed}, {max_observed}], allowed "
+                    f"[{iinfo.min}, {iinfo.max}]"
+                )
+            else:
+                # note: this cast is not UB because we checked above
+                expected = expected.to(dtype)
+
         if (reduction == "mean"):
             counts.masked_fill_(counts == 0, 1)
             if (dtype.is_floating_point or dtype.is_complex):
                 expected /= counts
             else:
                 expected.div_(counts, rounding_mode="floor")
+
+        # note: only call `fn` once we know expected values in `base`
+        # are safe from signed overflow (UB). Otherwise, test is skipped above
+        if reduction is not None:
+            if fn is torch.Tensor.scatter_reduce_:
+                actual = fn(base.clone(), dim, idx, src, reduce=reduction, include_self=include_self)
+            else:
+                actual = fn(base.clone(), dim, idx, src, reduce=reduction)
+        else:
+            actual = fn(base.clone(), dim, idx, src)
 
         if dtype == torch.float16 or dtype == torch.bfloat16:
             # Some CUDA kernels (e.g. indexing_backward_kernel_stride_1) that are called during

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3867,7 +3867,9 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(dst, dst2, atol=0, rtol=0)
 
         # test non-contiguous case
-        dst = ((torch.randn(num_dest, num_dest, num_dest) * 10).to(dtype)).permute((2, 0, 1))
+        dst = make_tensor(
+            (num_dest, num_dest, num_dest), dtype=dtype, device=device, low=-30, high=30
+        ).permute((2, 0, 1))
         dst2 = dst.contiguous()
         if dtype.is_complex:
             mask = dst.abs() > 0


### PR DESCRIPTION
Skip cases of potential undefined behavior in CUDA unit tests: CUDA C++ does not provide any kind of guarantees for undefined behavior, as the name implies.
Specifically, division or remainder by 0 on integral types is undefined and can give *any* output: it is not testable. Any combination of CUDA version, compute capability, etc. may change results and in case predictable behavior did happen on some combinations in the past, this was pure coincidence.

The PR attempts to fix a few other edge cases where potential overflow can happen, usually for small signed integral types such as `torch.int8`.

@eqy @ptrblck @msaroufim please add more relevant reviewers

Also CC @zou3519 / @ejguan as you seemed to have looked at the fmod/remainder cases a long time ago already (https://github.com/pytorch/pytorch/pull/47323/changes#r534261905) and I might be missing some obvious reason for why we should attempt to test these.