### PR TITLE
fix(numpy): add context/return_scalar params to Tensor.__array_wrap__

### DIFF
--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -705,7 +705,6 @@ class TestNumPyInterop(TestCase):
         y = opt_f(x)
         self.assertEqual(y, f(x))
 
-
     @onlyCPU
     def test_array_wrap_numpy2_no_deprecation_warning(self, device):
         # gh-180657: NumPy 2 added context/return_scalar params to __array_wrap__.

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -706,6 +706,19 @@ class TestNumPyInterop(TestCase):
         self.assertEqual(y, f(x))
 
 
+    @onlyCPU
+    def test_array_wrap_numpy2_no_deprecation_warning(self, device):
+        # gh-180657: NumPy 2 added context/return_scalar params to __array_wrap__.
+        # Verify that calling np.delete (which triggers __array_wrap__) does not
+        # raise a DeprecationWarning.
+        import warnings
+
+        x = torch.arange(10)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            np.delete(x, 0)
+
+
 instantiate_device_type_tests(TestNumPyInterop, globals())
 
 if __name__ == "__main__":

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1256,7 +1256,7 @@ class Tensor(torch._C.TensorBase):
 
     # Wrap Numpy array again in a suitable tensor when done, to support e.g.
     # `numpy.sin(tensor) -> tensor` or `numpy.greater(tensor, 0) -> ByteTensor`
-    def __array_wrap__(self, array):
+    def __array_wrap__(self, array, context=None, return_scalar=None):
         if has_torch_function_unary(self):
             return handle_torch_function(
                 Tensor.__array_wrap__, (self,), self, array=array

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1337,7 +1337,7 @@ def get_testing_overrides() -> dict[Callable, Callable]:
         Tensor.__mod__: lambda self, other: -1,
         Tensor.__rmod__: lambda self, other: -1,
         Tensor.__imod__: lambda self, other: -1,
-        Tensor.__array_wrap__: lambda self, array: -1,
+        Tensor.__array_wrap__: lambda self, array, context=None, return_scalar=None: -1,
         Tensor.__getitem__: lambda self, idx: -1,
         Tensor.__deepcopy__: lambda self, memo: -1,
         Tensor.__int__: lambda self: -1,


### PR DESCRIPTION
Fixes #180657

NumPy 2 extended the `__array_wrap__` protocol with two new keyword arguments (`context` and `return_scalar`) and emits a `DeprecationWarning` when the old two-argument form is called. This surfaces as a warning (or error with `warnings.filterwarnings("error")`) in common operations such as `np.delete(tensor, ...)`.

**Fix:** Accept the two new parameters and ignore them. PyTorch has no scalars, and the `context` info is not needed downstream.

Changes:
- `torch/_tensor.py`: `def __array_wrap__(self, array)` → `def __array_wrap__(self, array, context=None, return_scalar=None)`
- `torch/overrides.py`: update the testing-override lambda to match the new signature
- `test/test_numpy_interop.py`: regression test — verifies `np.delete(tensor, ...)` does not raise `DeprecationWarning`

**Testing:** The new test (`test_array_wrap_numpy2_no_deprecation_warning`) runs on CPU and calls `np.delete` with `warnings.simplefilter("error", DeprecationWarning)` so any future regression would be caught immediately.