### PR TITLE
Add riseproject-dev/pytorch as L1 cross repo CI relay

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -37,3 +37,4 @@
 
 L1:
   - Ascend/pytorch
+  - riseproject-dev/pytorch


### PR DESCRIPTION
In the context of adding testing on CI for the RISC-V platform, RISE [1] is working with the PyTorch community to provide necessary resources (machines, engineering) to enable that platform. Following engagement with the Multi-Cloud WG and Accelerator Integration WG, and following [2], this commits adds riseproject-dev/pytorch [3] as a downstream to trigger CI runs on at L1 level. The CI runs on native hardware provided by the RISE RISC-V Runners Github app [4] and currently runs on Scaleway EM-RV1 [5] machines.

[1] https://riseproject.dev/
[2] https://github.com/pytorch/pytorch/blob/main/docs/source/accelerator/ci.md
[3] https://github.com/riseproject-dev/pytorch
[4] https://github.com/apps/rise-risc-v-runners
[5] https://labs.scaleway.com/en/em-rv1/