### PR TITLE
[Native DSL] Add internal custom op tracking

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -2226,6 +2226,50 @@ Dynamic shape operator
         lib.impl(op_name, foo_impl2, "CPU", allow_override=True)
         self.assertEqual(op(torch.ones(3)), torch.ones(6))
 
+    def test_internal_impl(self):
+        from torch.library import _impls
+
+        lib = self.lib()
+        op_name = f"{self.test_ns}::foo"
+        torch.library.define(op_name, "(Tensor x) -> Tensor", lib=lib)
+        op = self.ns().foo.default
+
+        key = f"{self.test_ns}/foo/CPU"
+
+        def foo_internal(x):
+            return x * 1
+
+        def foo_external(x):
+            return torch.cat([x, x])
+
+        # internal_impl=True must not record the kernel in _impls, so
+        # out-of-tree authors don't collide with in-tree torch._native kernels.
+        lib.impl("foo", foo_internal, "CPU", internal_impl=True)
+        self.assertNotIn(key, _impls)
+        self.assertNotIn(key, lib._op_impls)
+        self.assertEqual(op(torch.ones(3)), torch.ones(3))
+
+        # Because the internal registration was not tracked, a subsequent
+        # out-of-tree registration for the same (ns, op, dispatch key) must
+        # succeed without requiring allow_override=True.
+        lib.impl("foo", foo_external, "CPU")
+        self.assertIn(key, _impls)
+        self.assertEqual(op(torch.ones(3)), torch.ones(6))
+
+        # An internal registration on top of an existing external registration
+        # must also be allowed and must leave the external tracking entry intact.
+        def foo_internal2(x):
+            return x * 3
+
+        lib.impl("foo", foo_internal2, "CPU", internal_impl=True)
+        self.assertIn(key, _impls)
+        self.assertEqual(op(torch.ones(3)), torch.ones(3) * 3)
+
+        # A second external registration should still be rejected, since the
+        # external registration remains tracked regardless of later internal ones.
+        with self.assertRaisesRegex(RuntimeError, "already a kernel registered"):
+            lib.impl("foo", foo_external, "CPU")
+
     def test_override_fake(self):
         lib = self.lib()
         op_name = f"{self.test_ns}::foo"

--- a/torch/_native/registry.py
+++ b/torch/_native/registry.py
@@ -239,6 +239,7 @@ def _register_node_impl(
         dispatch_key,
         with_keyset=not node.unconditional_override,
         allow_override=True,
+        internal_impl=True,
     )
 
 

--- a/torch/library.py
+++ b/torch/library.py
@@ -423,7 +423,14 @@ class Library:
         self._op_impls.add(key)
 
     def impl(
-        self, op_name, fn, dispatch_key="", *, with_keyset=False, allow_override=False
+        self,
+        op_name,
+        fn,
+        dispatch_key="",
+        *,
+        with_keyset=False,
+        allow_override=False,
+        internal_impl=False,
     ):
         r"""Registers the function implementation for an operator defined in the library.
 
@@ -440,6 +447,13 @@ class Library:
                          default off, and will error you're trying to register a
                          kernel to a dispatch key with a kernel already
                          registered.
+            internal_impl: Flag marking this registration as an in-tree
+                         (``torch._native``) kernel. Internal kernels are not
+                         tracked in the global ``_impls`` set, so they do not
+                         collide with out-of-tree registrations for the same
+                         (namespace, op, dispatch key), and out-of-tree kernels
+                         are free to register on top of them without
+                         ``allow_override=True``.
 
         Example::
             >>> # xdoctest: +SKIP("Requires Python <= 3.11")
@@ -469,7 +483,7 @@ class Library:
             )
 
         key = self.ns + "/" + name.split("::")[-1] + "/" + dispatch_key
-        if (not allow_override) and key in _impls:
+        if (not allow_override) and (not internal_impl) and key in _impls:
             # TODO: in future, add more info about where the existing function is registered (this info is
             # today already returned by the C++ warning when impl is called but we error out before that)
             raise RuntimeError(
@@ -507,8 +521,9 @@ class Library:
             with_keyset,
         )
 
-        _impls.add(key)
-        self._op_impls.add(key)
+        if not internal_impl:
+            _impls.add(key)
+            self._op_impls.add(key)
 
     def fallback(self, fn, dispatch_key="", *, with_keyset=False):
         r"""Registers the function implementation as the fallback for the given key.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181740

Summary:

Add a notion of an "internal" op implemented using `Library.impl`
to distinguish between in-tree `torch._native` ops and true external,
out-of-tree ops.

This is to prevent hard-failures when a user registers
without `allow_overrides=True`, when they expect there to be
no existing overrides (but there now are due to the
`torch._native` effort)

Adds a new test in `test_custom_ops.py` to verify this behavior.

Should be a more permanent fix/WAR for https://github.com/pytorch/pytorch/issues/181122

Test Plan:

```
pytest -sv test/python_native
pytest -sv test/test_python_dispatch.py
pytest -sv test/test_custom_ops.py
```

Signed-off-by: Simon Layton <simonlayton@meta.com>