### PR TITLE
Remove skipXPU from test_binary_ufuncs

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -33,7 +33,6 @@ from torch.testing._internal.common_device_type import (
     skipCUDAIfNotRocm,
     skipIf,
     skipMeta,
-    skipXPU,
 )
 from torch.testing._internal.common_dtype import (
     all_types,
@@ -3027,7 +3026,6 @@ class TestBinaryUfuncsDevice(TestCase):
 
     @dtypesIfCPU(torch.bfloat16, torch.half, torch.float32, torch.float64)
     @dtypes(torch.float32, torch.float64)
-    @skipXPU
     def test_hypot(self, device, dtype):
         inputs = [
             (
@@ -3560,7 +3558,6 @@ class TestBinaryUfuncsDevice(TestCase):
             raise AssertionError("m is intentionally a scalar")
         self.assertEqual(torch.pow(2, m), 2**m)
 
-    @skipXPU
     def test_ldexp(self, device):
         # random values
         mantissas = torch.randn(64, device=device)


### PR DESCRIPTION
This PR is to enable `test_hypot` and `test_ldexp` on XPU devices. Fixed by:

- https://github.com/intel/torch-xpu-ops/pull/2962
- https://github.com/intel/torch-xpu-ops/pull/3248.