### PR TITLE
[Inductor] Make sure AutoHeuristic init doesn't crash in non-cuda environments

### DIFF
--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -209,6 +209,32 @@ class AutoHeuristicTest(TestCase):
         # because AutoHeuristics makes the decision without benchmarking
         self.assertEqual(counters["inductor"]["pad_mm_bench"], 0)
 
+    @inductor_config.patch(deterministic=True)
+    @inductor_config.patch("autoheuristic_use.pad_mm", None)
+    def test_use_autoheuristic_pad_mm_enabled_in_deterministic_mode(self):
+        """pad_mm defaults to None; with deterministic=True, use_autoheuristic should return True."""
+        self.assertTrue(inductor_config.use_autoheuristic("pad_mm"))
+
+    def test_autoheuristic_init_no_cuda(self):
+        """AutoHeuristic.__init__ must not crash when CUDA is unavailable."""
+
+        def fallback():
+            return "fallback"
+
+        context = AHContext()
+        context.add_feature("x", 1)
+
+        with (
+            patch("torch.cuda.is_available", return_value=False),
+            patch(
+                "torch._inductor.autoheuristic.autoheuristic.get_gpu_shared_memory",
+                return_value=0,
+            ),
+        ):
+            ah = AutoHeuristic(fallback, ["a", "b"], None, context, "test_no_cuda")
+
+        self.assertEqual(ah.metadata.device_capa, (0, 0))
+
 
 if __name__ == "__main__":
     if HAS_GPU:

--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -215,25 +215,22 @@ class AutoHeuristicTest(TestCase):
         """pad_mm defaults to None; with deterministic=True, use_autoheuristic should return True."""
         self.assertTrue(inductor_config.use_autoheuristic("pad_mm"))
 
-    def test_autoheuristic_init_no_cuda(self):
-        """AutoHeuristic.__init__ must not crash when CUDA is unavailable."""
+    def test_autoheuristic_init_device_capa(self):
+        """AutoHeuristic.__init__ must not crash regardless of CUDA availability."""
 
         def fallback():
             return "fallback"
 
         context = AHContext()
         context.add_feature("x", 1)
+        ah = AutoHeuristic(fallback, ["a", "b"], None, context, "test_device_capa")
 
-        with (
-            patch("torch.cuda.is_available", return_value=False),
-            patch(
-                "torch._inductor.autoheuristic.autoheuristic.get_gpu_shared_memory",
-                return_value=0,
-            ),
-        ):
-            ah = AutoHeuristic(fallback, ["a", "b"], None, context, "test_no_cuda")
-
-        self.assertEqual(ah.metadata.device_capa, (0, 0))
+        if torch.cuda.is_available():
+            self.assertEqual(
+                ah.metadata.device_capa, torch.cuda.get_device_capability()
+            )
+        else:
+            self.assertEqual(ah.metadata.device_capa, (0, 0))
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -210,9 +210,9 @@ class AutoHeuristicTest(TestCase):
         self.assertEqual(counters["inductor"]["pad_mm_bench"], 0)
 
     @inductor_config.patch(deterministic=True)
-    @inductor_config.patch("autoheuristic_use.pad_mm", None)
     def test_use_autoheuristic_pad_mm_enabled_in_deterministic_mode(self):
-        """pad_mm defaults to None; with deterministic=True, use_autoheuristic should return True."""
+        inductor_config.autoheuristic_use.pad_mm = None
+        """pad_mm set to None; with deterministic=True, use_autoheuristic should return True."""
         self.assertTrue(inductor_config.use_autoheuristic("pad_mm"))
 
     def test_autoheuristic_init_device_capa(self):

--- a/torch/_inductor/autoheuristic/autoheuristic.py
+++ b/torch/_inductor/autoheuristic/autoheuristic.py
@@ -85,7 +85,7 @@ class AutoHeuristic:
         self.augment_context = augment_context
         self.metadata = AHMetadata(
             get_gpu_shared_memory(),
-            torch.cuda.get_device_capability(),
+            torch.cuda.get_device_capability() if torch.cuda.is_available() else (0, 0),
             self.choices,
             self.name,
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181745


This PR is for fixing, https://github.com/intel/torch-xpu-ops/issues/3455, see the issue for a detailed breakdown of the problem.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo