### PR TITLE
[torchfuzz] Device plugin architecture: extract CUDA-specific code behind a plugin boundary (#181746)

### DIFF
--- a/tools/experimental/torchfuzz/README.md
+++ b/tools/experimental/torchfuzz/README.md
@@ -94,6 +94,9 @@ python fuzzer.py --seed 42 --template dtensor
 
 # Unbacked template: data-dependent operations (nonzero, unique, etc.)
 python fuzzer.py --seed 42 --template unbacked
+
+# Use a third-party device plugin (see "Device Plugins" below)
+TORCHFUZZ_DEVICE_MODULE=torchfuzz_xpu python fuzzer.py --seed 42 --template default
 ```
 
 ### Debug Mode
@@ -110,7 +113,7 @@ python fuzzer.py --seed 42 --log-level DEBUG --max-depth 5
 |--------|-------------|---------|
 | `--seed INT` | Random seed for reproducible tests | `--seed 42` |
 | `--max-depth INT` | Maximum operation graph depth (1-20) | `--max-depth 5` |
-| `--template NAME` | Template to use (default, dtensor, unbacked) | `--template unbacked` |
+| `--template NAME` | Template name from the active device plugin (use `--help` to see available choices for the active plugin) | `--template unbacked` |
 | `--log-level LEVEL` | Logging verbosity (DEBUG, INFO, WARNING, ERROR) | `--log-level DEBUG` |
 
 ### Multi-Process Fuzzing
@@ -154,11 +157,12 @@ Notes:
 | `fuzzer.py` | Main CLI orchestrator, coordinates fuzzing workflow |
 | `tensor_fuzzer.py` | Generates random tensor/scalar specifications |
 | `ops_fuzzer.py` | Builds operation graphs via recursive decomposition |
-| `codegen.py` | Converts operation graphs to executable Python code |
+| `codegen.py` | Code-generation core, plugin registry, and `FuzzTemplate` / `DeviceInfo` base classes |
+| `cuda/` | Reference device plugin (CUDA). Provides `FuzzTemplate` subclasses, `Check` subclasses, and runtime device hooks via the plugin protocol exposed by `codegen.py` |
 | `runner.py` | Executes generated programs and reports results |
 | `multi_process_fuzzer.py` | Parallel fuzzing across multiple processes |
 | `visualize_graph.py` | Creates visual diagrams of operation graphs |
-| `checks.py` | Defines validation strategies (eager vs compiled) |
+| `checks.py` | `Check` ABC; concrete checks live in device plugins |
 | `operators/` | Modular operator implementations |
 
 ### Operator System
@@ -209,9 +213,79 @@ class Operator(ABC):
 - `arg` - Function arguments
 - `constant` - Constant scalar values
 
+## Device Plugins
+
+TorchFuzz separates device-agnostic code-generation infrastructure from device-specific behaviour using a small plugin protocol. The default plugin is `torchfuzz.cuda`, which is loaded automatically when `TORCHFUZZ_DEVICE_MODULE` is unset; pointing `TORCHFUZZ_DEVICE_MODULE` at any importable module that implements the protocol switches the fuzzer to that device without modifying core source.
+
+### Selecting a plugin
+
+```bash
+TORCHFUZZ_DEVICE_MODULE=torchfuzz_xpu python fuzzer.py --seed 42 --template default
+```
+
+The value of `TORCHFUZZ_DEVICE_MODULE` is fed straight into `importlib.import_module(...)`.
+
+### Plugin contract
+
+A plugin module must define two module-level functions:
+
+```python
+from torchfuzz.codegen import DeviceInfo, FuzzTemplate
+
+def register_codegen() -> dict[str, type[FuzzTemplate]]:
+    """Map template short-name (used by --template) to FuzzTemplate subclass."""
+
+def get_device_info() -> DeviceInfo:
+    """Return device metadata used by the core."""
+```
+
+Where `DeviceInfo` is a dataclass declared in `torchfuzz.codegen`:
+
+```python
+@dataclass
+class DeviceInfo:
+    device_name: str                                                   # e.g. "cuda", "xpu", "mtia"
+    select_runtime_env: Callable[[dict[str, str]], dict[str, str]] | None = None
+```
+
+* `device_name` is emitted into tensor descriptor comments (`device=<name>`).
+* `select_runtime_env(env)` is called by `runner.py` to mutate the subprocess environment when launching generated programs (e.g. CUDA picks a random visible device and narrows `CUDA_VISIBLE_DEVICES` to it). Returning `None` here means "run with the unmodified environment".
+
+### Worked example skeleton
+
+```python
+# torchfuzz_xpu/__init__.py
+from torchfuzz.codegen import DeviceInfo, FuzzTemplate
+
+class MyDefaultTemplate(FuzzTemplate):
+    def imports_codegen(self): return ["import torch"]
+    def flags_codegen(self):   return ["torch.set_default_device('xpu')"]
+    # ... override args_codegen / codegen_constant / etc. as needed
+
+def register_codegen() -> dict[str, type[FuzzTemplate]]:
+    return {"default": MyDefaultTemplate}
+
+def get_device_info() -> DeviceInfo:
+    return DeviceInfo(device_name="xpu", select_runtime_env=None)
+```
+
+For a fully worked example, including how `FuzzTemplate` hook overrides interact with `convert_graph_to_python_code`, see `torchfuzz/cuda/_codegen.py` and the documentation comments at the top of `torchfuzz/cuda/__init__.py`.
+
+### Where each kind of customization belongs
+
+| Customization | Where to put it |
+|---|---|
+| New templates | Plugin's `_codegen.py` + register in `register_codegen` |
+| New checks | Plugin's `_checks.py` (no separate registration; templates own their checks) |
+| Per-device runtime behaviour | `DeviceInfo.select_runtime_env` |
+| Per-device emitted device string in tensor descriptors | `DeviceInfo.device_name` |
+| Per-template behaviour previously expressed via `if template == "…":` checks | `FuzzTemplate` hook overrides (`treat_constant_as_global`, `wrap_body`, `return_codegen`, `args_codegen`, `codegen_constant`) |
+
+The CUDA plugin at `torchfuzz/cuda/` is the canonical reference; consult its module docstring for the full hook table and the rationale behind each override.
+
 ## Templates
 
-Templates define specialized fuzzing strategies with custom operator sets, checks, and argument generation.
+The templates below are provided by the default CUDA plugin (`torchfuzz/cuda`).
 
 ### Default Template
 
@@ -222,6 +296,8 @@ Templates define specialized fuzzing strategies with custom operator sets, check
 **Check**: Compares eager vs compiled outputs with numerical tolerance (5% relative + 1.0 absolute difference)
 
 **Use Case**: General PyTorch compilation testing
+
+**Implemented in**: `torchfuzz/cuda/_codegen.py`
 
 ```bash
 python fuzzer.py --seed 42 --template default
@@ -242,8 +318,31 @@ python fuzzer.py --seed 42 --template default
 
 **Use Case**: Testing torch.compile with distributed tensors
 
+**Implemented in**: `torchfuzz/cuda/_codegen.py`
+
 ```bash
 python fuzzer.py --seed 42 --template dtensor
+```
+
+### DTensor Placements Template
+
+**Focus**: DTensor with randomized placement strategies
+
+**Operators**: Same as DTensor
+
+**Check**: Validates compilation correctness
+
+**Special Features**:
+- Randomizes placements across `Replicate`, `Shard(d)`, and `Partial`
+- Lifts constants out of the traced function via `treat_constant_as_global`
+- Materializes args and constants with `dist_tensor.{ones,randn,full}`
+
+**Use Case**: Stress-testing DTensor sharding propagation
+
+**Implemented in**: `torchfuzz/cuda/_codegen.py`
+
+```bash
+python fuzzer.py --seed 42 --template dtensor_placements
 ```
 
 ### Unbacked Template
@@ -261,8 +360,31 @@ python fuzzer.py --seed 42 --template dtensor
 
 **Use Case**: Testing dynamic shape handling and unbacked SymInt scenarios
 
+**Implemented in**: `torchfuzz/cuda/_codegen.py`
+
 ```bash
 python fuzzer.py --seed 42 --template unbacked
+```
+
+### Streams Template
+
+**Focus**: CUDA stream parallelism / wait-stream / event-based sync
+
+**Operators**: Same set as Default
+
+**Check**: Eager vs compiled including a backward pass
+
+**Special Features**:
+- Wraps non-leaf operations in 2-3 random `torch.cuda.Stream()` contexts via the `wrap_body` hook
+- Inserts cross-stream synchronization (`wait_stream` or `Event` record + `wait_event`)
+- Sets `requires_grad_(True)` on float args to exercise backward through stream-wrapped ops
+
+**Use Case**: Exercising Inductor's stream handling
+
+**Implemented in**: `torchfuzz/cuda/_codegen.py`
+
+```bash
+python fuzzer.py --seed 42 --template streams
 ```
 
 ## Multi-Process Fuzzing
@@ -324,7 +446,7 @@ Ignored failures are tracked separately and don't count as failures in the summa
 
 ## Custom Checks
 
-Checks define how generated programs are validated. Create custom checks by subclassing `Check`:
+Checks define how generated programs are validated. The `Check` ABC lives in core (`torchfuzz/checks.py`); concrete checks live in device plugins. Define your check inside your device plugin (`my_plugin/_checks.py`) and import it from your `FuzzTemplate.__init__`. Checks are not separately registered — templates own their checks.
 
 ```python
 from torchfuzz.checks import Check
@@ -342,9 +464,15 @@ class MyCustomCheck(Check):
 
 ### Built-in Checks
 
+These live in `torchfuzz/cuda/_checks.py` and are used by the CUDA plugin's templates.
+
 #### EagerVsFullGraphDynamicCompileCheck
 
 Validates that eager and compiled execution both succeed (no output comparison).
+
+#### EagerVsFullGraphDynamicCompileWithBackwardCheck
+
+Validates that eager and compiled execution both succeed and that a backward pass runs cleanly through both.
 
 #### EagerVsFullGraphDynamicCompileWithNumericsCheck
 
@@ -380,6 +508,18 @@ print(f"Root node: {operation_graph.root_node_id}")
 print(f"Topological order: {operation_graph.get_topological_order()}")
 print(f"Leaf nodes: {operation_graph.get_leaf_nodes()}")
 ```
+
+### Plugin Lifecycle
+
+```python
+from torchfuzz.codegen import initialize_codegen, get_template_names, make_template
+
+initialize_codegen()                   # picks up TORCHFUZZ_DEVICE_MODULE or defaults to torchfuzz.cuda
+print(get_template_names())            # e.g. ['default', 'dtensor', ...]
+tpl = make_template("default")
+```
+
+Callers using `fuzz_and_execute` / `convert_graph_to_python_code` do not need to call `initialize_codegen` themselves — the core does it lazily.
 
 ## Adding New Operations
 
@@ -436,9 +576,10 @@ class OperatorRegistry:
 
 ### Step 3: Add to Template (Optional)
 
-If you want the operator in specific templates, add its torch_op_name to the template's `supported_ops` list in `codegen.py`:
+If you want the operator in specific templates of the CUDA plugin, edit `torchfuzz/cuda/_codegen.py` and add `torch.my_op` to the relevant template's `supported_ops` list. For a non-CUDA plugin, edit the equivalent file in that plugin.
 
 ```python
+# torchfuzz/cuda/_codegen.py
 class DefaultFuzzTemplate(FuzzTemplate):
     def __init__(self):
         super().__init__(
@@ -446,7 +587,7 @@ class DefaultFuzzTemplate(FuzzTemplate):
                 # ... existing ops ...
                 "torch.my_op",
             ],
-            check=EagerVsFullGraphDynamicCompileWithNumericsCheck(),
+            check=EagerVsFullGraphDynamicCompileCheck(),
         )
 ```
 

--- a/tools/experimental/torchfuzz/__init__.py
+++ b/tools/experimental/torchfuzz/__init__.py
@@ -1,19 +1,33 @@
 """Torchfuzz package for generating and testing random PyTorch operations."""
 
 # Make key classes available at package level
+from .codegen import (
+    DeviceInfo,
+    FuzzTemplate,
+    get_device_info,
+    get_template_names,
+    initialize_codegen,
+    make_template,
+)
 from .operators import get_operator, list_operators, register_operator
 from .ops_fuzzer import fuzz_operation_graph, fuzz_spec, OperationGraph
 from .tensor_fuzzer import ScalarSpec, Spec, TensorSpec
 
 
 __all__ = [
-    "TensorSpec",
+    "DeviceInfo",
+    "FuzzTemplate",
+    "OperationGraph",
     "ScalarSpec",
     "Spec",
-    "OperationGraph",
+    "TensorSpec",
     "fuzz_operation_graph",
     "fuzz_spec",
+    "get_device_info",
     "get_operator",
-    "register_operator",
+    "get_template_names",
+    "initialize_codegen",
     "list_operators",
+    "make_template",
+    "register_operator",
 ]

--- a/tools/experimental/torchfuzz/checks.py
+++ b/tools/experimental/torchfuzz/checks.py
@@ -1,4 +1,8 @@
-"""Check abstractions for different execution modes and validations."""
+"""Check abstractions for different execution modes and validations.
+
+Concrete :class:`Check` subclasses are owned by device plugins (see
+``torchfuzz/cuda/_checks.py`` for the CUDA reference implementation).
+"""
 
 from abc import ABC, abstractmethod
 
@@ -9,61 +13,3 @@ class Check(ABC):
     @abstractmethod
     def codegen(self, args_tuple: str) -> list[str]:
         """Generate code lines for this check."""
-
-
-class EagerVsFullGraphDynamicCompileCheck(Check):
-    """Standard check that runs eager then fullgraph+dynamic compilation."""
-
-    def codegen(self, args_tuple: str) -> list[str]:
-        return [
-            f"args = {args_tuple}",
-            "result_original = fuzzed_program(*args)",
-            "print('✅ eager success')",
-            "compiled_program = torch.compile(fuzzed_program, fullgraph=True, dynamic=True)",
-            "result_compiled = compiled_program(*args)",
-            "print('✅ compile success')",
-        ]
-
-
-class EagerVsFullGraphDynamicCompileWithBackwardCheck(Check):
-    """Check that runs eager then fullgraph+dynamic compilation with backward pass."""
-
-    def codegen(self, args_tuple: str) -> list[str]:
-        return [
-            f"args = {args_tuple}",
-            "result_original = fuzzed_program(*args)",
-            "result_original.sum().backward()",
-            "print('✅ eager + backward success')",
-            "compiled_program = torch.compile(fuzzed_program, fullgraph=True, dynamic=True)",
-            "result_compiled = compiled_program(*args)",
-            "result_compiled.sum().backward()",
-            "print('✅ compile + backward success')",
-        ]
-
-
-class EagerVsFullGraphDynamicCompileWithNumericsCheck(Check):
-    """Check that runs eager and compiled, compares forward numerics."""
-
-    def codegen(self, args_tuple: str) -> list[str]:
-        return [
-            f"args = {args_tuple}",
-            "out_eager = fuzzed_program(*args)",
-            "out_eager.sum().backward()",
-            "print('Eager Success! ✅')",
-            "compiled_program = torch.compile(fuzzed_program, fullgraph=True, dynamic=True)",
-            "out_compiled = compiled_program(*args)",
-            "out_compiled.sum().backward()",
-            "print('Compile Success! ✅')",
-            "out_eager_sum = out_eager.sum()",
-            "out_compiled_sum = out_compiled.sum()",
-            "diff = (out_eager_sum - out_compiled_sum).abs().item()",
-            "rel_diff = diff / (out_eager_sum.abs().item() + 1e-12) * 100",
-            "print(f'Relative diff (sum): {rel_diff:.6f}%')",
-            "if rel_diff > 5 and diff > 1:",
-            "    print(f'❌ Forward output sums differ significantly (relative and absolute)!')",
-            "    print('out_eager_sum:', out_eager_sum.item())",
-            "    print('out_compiled_sum:', out_compiled_sum.item())",
-            "    print('Absolute diff:', diff)",
-            "    print('Relative diff (%):', rel_diff)",
-            "    import sys; sys.exit(1)",
-        ]

--- a/tools/experimental/torchfuzz/codegen.py
+++ b/tools/experimental/torchfuzz/codegen.py
@@ -1,6 +1,10 @@
 # mypy: ignore-errors
+import hashlib
+import importlib
 import os
 import random
+from collections.abc import Callable
+from dataclasses import dataclass
 
 import torch
 
@@ -8,6 +12,37 @@ from torchfuzz.operators import get_operator
 from torchfuzz.ops_fuzzer import OperationGraph
 from torchfuzz.tensor_descriptor import format_tensor_descriptor
 from torchfuzz.tensor_fuzzer import ScalarSpec, Spec, TensorSpec
+
+
+_DEFAULT_DEVICE_MODULE = "torchfuzz.cuda"
+
+
+@dataclass
+class DeviceInfo:
+    """Per-device metadata returned by a torchfuzz device plugin.
+
+    Attributes:
+        device_name: Short device name (e.g. "cuda", "xpu", "mtia").  Used by
+            ``tensor_descriptor`` to label the device in emitted comments.
+        select_runtime_env: Optional callback that customizes the subprocess
+            environment passed to ``runner.py``.  Signature::
+
+                def select_runtime_env(
+                    env: dict[str, str],
+                    *,
+                    exclude_primary_device: bool = False,
+                ) -> dict[str, str]: ...
+
+            *env* is the current environment (``PYTHONPATH`` is already set by
+            the runner).  When *exclude_primary_device* is ``True`` the plugin
+            should avoid selecting device 0 (or the equivalent primary device)
+            to prevent contention with the orchestrating process.  Return a
+            (new) ``env`` dict; when the callback is ``None`` the runner uses
+            the environment as-is.
+    """
+
+    device_name: str
+    select_runtime_env: Callable[..., dict[str, str]] | None = None
 
 
 class FuzzTemplate:
@@ -54,15 +89,11 @@ class FuzzTemplate:
         Returns:
             Spec: Either a TensorSpec or ScalarSpec according to template's distribution
         """
-        import random
-
-        from torchfuzz.tensor_fuzzer import fuzz_torch_tensor_type
-
         # Get template's distribution configuration
         distribution = self.spec_distribution()
 
-        # Get random dtype based on template
-        dtype = fuzz_torch_tensor_type("default")
+        # Get random dtype based on this template's supported dtypes
+        dtype = random.choice(self.supported_dtypes())
 
         # Validate distribution configuration
         allow_tensors = distribution.get("allow_tensors", True)
@@ -104,8 +135,70 @@ class FuzzTemplate:
 
         return ScalarSpec(dtype=dtype)
 
-    def args_codegen(self, arg_operations):
-        """Generate argument creation code for default template."""
+    def imports_codegen(self):
+        """Return import lines emitted at the top of the generated file."""
+        return []
+
+    def flags_codegen(self):
+        """Return flag/setup lines emitted at the top of the generated file."""
+        return []
+
+    def epilogue_codegen(self):
+        """Return lines emitted at the very end of the generated file."""
+        return []
+
+    def treat_constant_as_global(self) -> bool:
+        """Whether ``constant`` ops should be lifted to function arguments.
+
+        When True, ``constant`` ops are appended to ``constant_operations`` and
+        passed into ``args_codegen``; the function signature receives them as
+        explicit parameters.  Templates that materialize constants outside the
+        traced function (e.g. DTensor placements with random sharding) should
+        return True.  Default is False.
+        """
+        return False
+
+    def wrap_body(
+        self, generated_code_lines: list[str], graph: OperationGraph
+    ) -> list[str]:
+        """Optionally rewrite the per-node body lines.
+
+        Default is a passthrough.  Used by ``StreamFuzzTemplate`` to partition
+        operations across CUDA streams.
+        """
+        return generated_code_lines
+
+    def return_codegen(self, final_var_name: str) -> list[str]:
+        """Return the lines that emit the ``return`` statement.
+
+        Default uses ``.real`` to drop imaginary parts of complex outputs.
+        """
+        return [
+            "    # Ensure gradient computation by multiplying with sentinel and taking real part",
+            f"    result = {final_var_name} * sentinel",
+            "    if result.is_complex():",
+            "        result = result.real",
+            "    return result",
+            "",
+        ]
+
+    def codegen_constant(self, output_name: str, tensor_creation_expr: str) -> str:
+        """Wrap a tensor-creation expression for use as a ``constant`` op.
+
+        Default just assigns the expression to ``output_name``.  Templates that
+        need to wrap constants (e.g. DTensor's ``DTensor.from_local``) should
+        override this hook.
+        """
+        return f"{output_name} = {tensor_creation_expr}"
+
+    def args_codegen(self, arg_operations, constant_operations=None):
+        """Generate argument creation code for default template.
+
+        ``constant_operations`` is only consulted by templates that opt in via
+        :meth:`treat_constant_as_global`.  The base implementation ignores it.
+        """
+        del constant_operations  # unused in the base implementation
+
         code_lines = []
 
         # Add sentinel tensor that ensures gradient computation
@@ -194,609 +287,55 @@ class FuzzTemplate:
         return code_lines
 
 
-class DefaultFuzzTemplate(FuzzTemplate):
-    def __init__(self):
-        from torchfuzz.checks import EagerVsFullGraphDynamicCompileCheck
-
-        super().__init__(
-            supported_ops=[
-                # Basic arithmetic operations
-                "torch.add",
-                "torch.sub",
-                "torch.mul",
-                "torch.div",
-                "torch.clamp",
-                "torch.cumsum",
-                # Tensor shape operations
-                "torch.Tensor.view",
-                "torch.reshape",
-                "torch.flatten",
-                "torch.squeeze",
-                "torch.unsqueeze",
-                "torch.split",
-                "torch.chunk",
-                "torch.expand",
-                "torch.cat",
-                "torch.stack",
-                # Indexing operations
-                "torch.gather",
-                "torch.index_select",
-                "torch.argsort",
-                # Matrix operations
-                "torch.mm",
-                "torch.addmm",
-                "torch.bmm",
-                "torch.matmul",
-                # Neural network operations
-                "torch.nn.functional.embedding",
-                "torch.nn.functional.linear",
-                "torch.nn.functional.scaled_dot_product_attention",
-                "torch.nn.functional.multi_head_attention_forward",
-                # Activation functions
-                "torch.nn.functional.relu",
-                "torch.nn.functional.leaky_relu",
-                "torch.nn.functional.elu",
-                "torch.nn.functional.gelu",
-                "torch.nn.functional.silu",
-                "torch.sigmoid",
-                "torch.tanh",
-                "torch.nn.functional.softmax",
-                # Normalization layers
-                "torch.nn.functional.layer_norm",
-                "torch.nn.functional.rms_norm",
-                "torch.nn.functional.batch_norm",
-                "torch.nn.functional.group_norm",
-                # Regularization
-                "torch.nn.functional.dropout",
-            ],
-            check=EagerVsFullGraphDynamicCompileCheck(),
-        )
-
-    def spec_distribution(self):
-        """Default template: tensor-only (no scalars)."""
-        return {
-            "tensor_prob": 1.0,
-            "scalar_prob": 0.0,
-            "allow_tensors": True,
-            "allow_scalars": False,
-        }
-
-    def imports_codegen(self):
-        return [
-            "import torch",
-        ]
-
-    def flags_codegen(self):
-        return [
-            "torch.set_default_device('cuda')",
-            "torch._dynamo.config.capture_scalar_outputs = True",
-        ]
-
-    def epilogue_codegen(self):
-        return []
+# ---------------------------------------------------------------------------
+# Plugin registry
+# ---------------------------------------------------------------------------
 
 
-class DTensorFuzzTemplate(FuzzTemplate):
-    def __init__(self):
-        from torchfuzz.checks import EagerVsFullGraphDynamicCompileCheck
-
-        super().__init__(
-            supported_ops=[
-                "torch.add",
-                "torch.sub",
-                "torch.mul",
-                "torch.div",
-                "torch.mm",
-                "torch.addmm",
-                "torch.bmm",
-                "torch.matmul",
-            ],
-            check=EagerVsFullGraphDynamicCompileCheck(),
-        )
-
-    def supported_dtypes(self):
-        """Return list of DTensor-compatible dtypes (no complex types)."""
-        return [
-            torch.float32,
-            torch.float64,
-            torch.float16,
-            torch.bfloat16,
-            torch.int8,
-            torch.int16,
-            torch.int32,
-            torch.int64,
-            torch.bool,
-        ]
-
-    def spec_distribution(self):
-        """DTensor template: tensor-only (no scalars)."""
-        return {
-            "tensor_prob": 1.0,
-            "scalar_prob": 0.0,
-            "allow_tensors": True,
-            "allow_scalars": False,
-        }
-
-    def imports_codegen(self):
-        return [
-            "import torch",
-            "from torch.distributed.tensor.placement_types import Replicate, Shard",
-            "from torch.testing._internal.distributed.fake_pg import FakeStore",
-            "from torch.distributed.tensor import DTensor",
-        ]
-
-    def flags_codegen(self):
-        return [
-            "torch._dynamo.config.capture_scalar_outputs = True",
-            "torch._dynamo.config.capture_dynamic_output_shape_ops = True",
-            "torch._inductor.config.emulate_precision_casts = True",
-        ]
-
-    def args_codegen(self, arg_operations):
-        """Generate DTensor argument creation code with proper mesh setup."""
-        code_lines = []
-
-        # Add DTensor setup code first
-        code_lines.extend(
-            [
-                "world_size = 1024",
-                "fake_store = FakeStore()",
-                "torch.distributed.init_process_group(",
-                '    "fake", store=fake_store, rank=0, world_size=world_size',
-                ")",
-                "",
-                "mesh = torch.distributed.device_mesh.init_device_mesh(",
-                '    "cuda",',
-                "    (2, 8),",
-                "    mesh_dim_names=(",
-                '        "dim1", "dim2",',
-                "    ),",
-                ")",
-                "",
-                "placements = (Replicate(), Replicate())",
-                "",
-                "# Sentinel tensor to ensure gradient computation",
-                "sentinel_local = torch.tensor(1.0, device='cuda', requires_grad=True)",
-                "sentinel = DTensor.from_local(sentinel_local, mesh, placements)",
-                "",
-            ]
-        )
-
-        if arg_operations:
-            for i, (node_id, spec) in enumerate(arg_operations):
-                arg_name = f"arg_{i}"
-
-                if isinstance(spec, ScalarSpec):
-                    # For scalars in DTensor, create a 0-dim tensor
-                    dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")
-                    code_lines.extend(
-                        [
-                            f"{arg_name}_local = torch.randn((), dtype={dtype_str}, device='cuda', requires_grad=True)",
-                            f"{arg_name} = DTensor.from_local({arg_name}_local, mesh, placements)",
-                        ]
-                    )
-
-                elif isinstance(spec, TensorSpec):
-                    size_str = str(spec.size)
-                    dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")
-
-                    # Handle different dtypes appropriately for DTensor
-                    if spec.dtype in [
-                        torch.int32,
-                        torch.int64,
-                        torch.int8,
-                        torch.int16,
-                    ]:
-                        # Integer dtypes: use randint and no requires_grad
-                        code_lines.extend(
-                            [
-                                f"{arg_name}_local = torch.randint(1, 10, {size_str}, dtype={dtype_str}, device='cuda')",
-                                f"{arg_name} = DTensor.from_local({arg_name}_local, mesh, placements)",
-                            ]
-                        )
-                    elif spec.dtype == torch.bool:
-                        # Boolean dtype: use randint and cast to bool
-                        code_lines.extend(
-                            [
-                                f"{arg_name}_local = torch.randint(0, 2, {size_str}, device='cuda').bool()",
-                                f"{arg_name} = DTensor.from_local({arg_name}_local, mesh, placements)",
-                            ]
-                        )
-                    else:
-                        # Float dtypes: use randn and requires_grad
-                        code_lines.extend(
-                            [
-                                f"{arg_name}_local = torch.randn({size_str}, dtype={dtype_str}, device='cuda', requires_grad=True)",
-                                f"{arg_name} = DTensor.from_local({arg_name}_local, mesh, placements)",
-                            ]
-                        )
-
-        return code_lines
-
-    def epilogue_codegen(self):
-        return ["torch.distributed.destroy_process_group()"]
+_TEMPLATE_REGISTRY: dict[str, type[FuzzTemplate]] | None = None
+_DEVICE_INFO: DeviceInfo | None = None
 
 
-class UnbackedFuzzTemplate(FuzzTemplate):
-    def __init__(self):
-        from torchfuzz.checks import EagerVsFullGraphDynamicCompileCheck
+def initialize_codegen() -> None:
+    """Load the device plugin module and populate the template registry.
 
-        super().__init__(
-            supported_ops=[
-                "torch.ops.aten.item",
-                "torch.ops.aten.nonzero",
-                "torch.ops.aten.masked_select",
-                "torch.ops.aten.unique",
-                # Basic arithmetic operations
-                "torch.add",
-                "torch.sub",
-                "torch.mul",
-                "torch.div",
-                # Tensor shape operations
-                "torch.Tensor.view",
-                "torch.reshape",
-                "torch.flatten",
-                "torch.squeeze",
-                "torch.unsqueeze",
-                # Matrix operations
-                "torch.mm",
-                "torch.addmm",
-                "torch.bmm",
-                "torch.matmul",
-                # Neural network operations
-                "torch.nn.functional.embedding",
-                "torch.nn.functional.linear",
-                # Activation functions
-                "torch.nn.functional.relu",
-                "torch.nn.functional.leaky_relu",
-                "torch.nn.functional.elu",
-                "torch.nn.functional.gelu",
-                "torch.nn.functional.silu",
-                "torch.sigmoid",
-                "torch.tanh",
-                "torch.nn.functional.softmax",
-                # Normalization layers
-                "torch.nn.functional.layer_norm",
-                "torch.nn.functional.rms_norm",
-                "torch.nn.functional.batch_norm",
-                "torch.nn.functional.group_norm",
-                # Regularization
-                "torch.nn.functional.dropout",
-            ],
-            check=EagerVsFullGraphDynamicCompileCheck(),
-        )
+    Idempotent.  Called explicitly from ``fuzzer.py`` and lazily from
+    :func:`make_template` / :func:`get_template_names` / :func:`get_device_info`
+    so that library callers do not have to remember to invoke it themselves.
 
-    def supported_dtypes(self):
-        """Return list of dtypes good for data-dependent operations."""
-        # Focus on dtypes that work well with data-dependent ops and arithmetic
-        # Exclude bool since arithmetic operations don't work with boolean tensors
-        return [
-            torch.float32,
-            torch.float64,
-            torch.int32,
-            torch.int64,
-        ]
-
-    def spec_distribution(self):
-        """Unbacked template: 50% tensors, 50% scalars."""
-        return {
-            "tensor_prob": 0.5,
-            "scalar_prob": 0.5,
-            "allow_tensors": True,
-            "allow_scalars": True,
-        }
-
-    def imports_codegen(self):
-        return [
-            "import torch",
-        ]
-
-    def flags_codegen(self):
-        return [
-            "torch.set_default_device('cuda')",
-            "torch._dynamo.config.capture_scalar_outputs = True",
-            "torch._dynamo.config.capture_dynamic_output_shape_ops = True",
-        ]
-
-    def epilogue_codegen(self):
-        return []
-
-
-class StreamFuzzTemplate(DefaultFuzzTemplate):
-    """Template that wraps operations in random CUDA stream contexts.
-
-    Reuses the same operator set as DefaultFuzzTemplate but partitions non-leaf
-    operations across 2-3 CUDA streams, inserting proper wait_stream
-    synchronization between dependent operations on different streams.
+    The plugin module name comes from the ``TORCHFUZZ_DEVICE_MODULE`` environment
+    variable; if unset, the default ``torchfuzz.cuda`` plugin is loaded.
     """
-
-    def __init__(self):
-        super().__init__()
-        from torchfuzz.checks import EagerVsFullGraphDynamicCompileWithBackwardCheck
-
-        self.check = EagerVsFullGraphDynamicCompileWithBackwardCheck()
-
-    def imports_codegen(self):
-        return [
-            "import torch",
-        ]
-
-    def flags_codegen(self):
-        return [
-            "torch.set_default_device('cuda')",
-            "torch._dynamo.config.capture_scalar_outputs = True",
-        ]
-
-    def args_codegen(self, arg_operations):
-        """Generate args with requires_grad=True on float tensors.
-
-        This ensures the backward pass traces through stream-wrapped operations,
-        exercising Inductor's stream handling in the backward graph.
-        """
-        code_lines = super().args_codegen(arg_operations)
-        if arg_operations:
-            for i, (node_id, spec) in enumerate(arg_operations):
-                if isinstance(spec, TensorSpec) and spec.dtype in [
-                    torch.float32,
-                    torch.float64,
-                    torch.float16,
-                    torch.bfloat16,
-                ]:
-                    code_lines.append(f"arg_{i} = arg_{i}.requires_grad_(True)")
-        return code_lines
-
-    @staticmethod
-    def wrap_body_with_streams(
-        generated_code_lines: list[str],
-        graph: OperationGraph,
-    ) -> list[str]:
-        """Wrap generated function body lines with CUDA stream contexts.
-
-        Assigns each non-leaf operation to one of 2-3 random streams, wraps each
-        in ``with torch.cuda.stream(sN):``, and inserts ``wait_stream`` calls
-        between dependent operations on different streams.
-        """
-        topo_order = graph.get_topological_order()
-
-        # Identify leaf vs non-leaf node ids
-        leaf_ids = set()
-        non_leaf_ids = []
-        for nid in topo_order:
-            node = graph.nodes[nid]
-            if (
-                node.op_name == "arg"
-                or node.op_name.startswith("arg_")
-                or node.op_name == "constant"
-            ):
-                leaf_ids.add(nid)
-            else:
-                non_leaf_ids.append(nid)
-
-        if not non_leaf_ids:
-            return generated_code_lines
-
-        num_streams = random.randint(2, 3)
-        stream_names = [f"s{i + 1}" for i in range(num_streams)]
-
-        # Decide sync strategy: wait_stream or event-based (record + wait_event)
-        use_events = random.choice([True, False])
-        event_counter = 0
-
-        # Assign each non-leaf node to a random stream
-        node_stream: dict[str, str] = {}
-        for nid in non_leaf_ids:
-            node_stream[nid] = random.choice(stream_names)
-
-        # Build a mapping from node_id -> the original code lines for that node.
-        # Each node produces lines prefixed with "    " (4-space indent for the
-        # function body).  We identify nodes by their ``var_{node_id} =`` pattern.
-        node_lines: dict[str, list[str]] = {}
-        current_node: str | None = None
-        current_buf: list[str] = []
-
-        for line in generated_code_lines:
-            stripped = line.strip()
-            # Detect lines like "var_node_3 = ..." or "var_node_3, _ = ..."
-            matched_node = None
-            for nid in topo_order:
-                if stripped.startswith((f"var_{nid} =", f"var_{nid},")):
-                    matched_node = nid
-                    break
-
-            if matched_node is not None:
-                # Flush previous node buffer
-                if current_node is not None:
-                    node_lines[current_node] = current_buf
-                current_node = matched_node
-                current_buf = [line]
-            else:
-                current_buf.append(line)
-
-        # Flush last node
-        if current_node is not None:
-            node_lines[current_node] = current_buf
-
-        # Rebuild the body with stream contexts and synchronization
-        new_lines: list[str] = []
-
-        # Stream variable declarations at the top of the function body
-        for sname in stream_names:
-            new_lines.append(f"    {sname} = torch.cuda.Stream()")
-
-        for nid in topo_order:
-            lines_for_node = node_lines.get(nid, [])
-            if nid in leaf_ids:
-                # Leaf nodes (args) stay on the default stream
-                new_lines.extend(lines_for_node)
-                continue
-
-            stream = node_stream[nid]
-            node = graph.nodes[nid]
-
-            # Insert synchronization for cross-stream dependencies
-            waited: set[str] = set()
-            for dep_id in node.input_nodes:
-                if dep_id in node_stream and node_stream[dep_id] != stream:
-                    dep_stream = node_stream[dep_id]
-                    if dep_stream not in waited:
-                        if use_events:
-                            ename = f"e{event_counter}"
-                            event_counter += 1
-                            new_lines.append(f"    {ename} = torch.cuda.Event()")
-                            new_lines.append(f"    {ename}.record({dep_stream})")
-                            new_lines.append(f"    {stream}.wait_event({ename})")
-                        else:
-                            new_lines.append(f"    {stream}.wait_stream({dep_stream})")
-                        waited.add(dep_stream)
-
-            # Wrap the operation in a stream context
-            new_lines.append(f"    with torch.cuda.stream({stream}):")
-            for code_line in lines_for_node:
-                # Each line already has 4-space indent; add 4 more for the with block
-                new_lines.append("    " + code_line)
-
-        # Synchronize all streams before the return statement
-        if use_events:
-            for sname in stream_names:
-                ename = f"e{event_counter}"
-                event_counter += 1
-                new_lines.append(f"    {ename} = torch.cuda.Event()")
-                new_lines.append(f"    {ename}.record({sname})")
-                new_lines.append(f"    torch.cuda.current_stream().wait_event({ename})")
-        else:
-            for sname in stream_names:
-                new_lines.append(
-                    f"    torch.cuda.current_stream().wait_stream({sname})"
-                )
-
-        return new_lines
+    global _TEMPLATE_REGISTRY, _DEVICE_INFO
+    if _TEMPLATE_REGISTRY is not None:
+        return
+    module_name = os.environ.get("TORCHFUZZ_DEVICE_MODULE", _DEFAULT_DEVICE_MODULE)
+    plugin = importlib.import_module(module_name)
+    _TEMPLATE_REGISTRY = plugin.register_codegen()
+    _DEVICE_INFO = plugin.get_device_info()
 
 
-class DTensorFuzzPlacementsTemplate(DTensorFuzzTemplate):
-    """DTensor template with randomized placements (Replicate, Shard, Partial).
+def get_template_names() -> list[str]:
+    """Return the list of template names registered by the active plugin."""
+    initialize_codegen()
+    return list(_TEMPLATE_REGISTRY.keys())
 
-    Extends DTensorFuzzTemplate to randomize placement strategies instead of
-    using fixed (Replicate(), Replicate()) for all tensors.
-    """
 
-    def fuzz_spec_custom(self):
-        """Generate tensor specs with minimum 1 dimension for proper DTensor sharding."""
-        import random
-
-        from torchfuzz.tensor_fuzzer import fuzz_valid_stride
-
-        # Get random dtype
-        dtype = random.choice(self.supported_dtypes())
-
-        # Generate tensor size with minimum 1 dimension (avoid 0-dim scalars)
-        # Prefer 2D-3D tensors for interesting sharding patterns
-        ndim = random.choices([1, 2, 3, 4], weights=[0.1, 0.5, 0.3, 0.1])[0]
-        size = tuple(random.randint(2, 32) for _ in range(ndim))
-        stride = fuzz_valid_stride(size)
-
-        from torchfuzz.tensor_fuzzer import TensorSpec
-
-        return TensorSpec(size=size, stride=stride, dtype=dtype)
-
-    def imports_codegen(self):
-        """Add Partial to imports."""
-        base_imports = super().imports_codegen()
-        # Update the placement imports to include Partial
-        for i, imp in enumerate(base_imports):
-            if "placement_types import" in imp:
-                base_imports[i] = (
-                    "from torch.distributed.tensor.placement_types import Replicate, Shard, Partial"
-                )
-                break
-        base_imports.append("import torch.distributed.tensor as dist_tensor")
-        return base_imports
-
-    def _generate_random_placement(self, tensor_size):
-        """Generate random placement tuple (Replicate, Shard, or Partial)."""
-        import random
-
-        placements = []
-        for _ in range(2):  # 2D mesh
-            placement_type = random.randint(0, 2)
-            if placement_type == 0:
-                placements.append("Replicate()")
-            elif placement_type == 1 and len(tensor_size) > 0:
-                shard_dim = random.randint(0, len(tensor_size) - 1)
-                placements.append(f"Shard({shard_dim})")
-            else:
-                placements.append("Partial()" if placement_type == 2 else "Replicate()")
-        return f"({', '.join(placements)})"
-
-    def args_codegen(self, arg_operations, constant_operations=None):
-        """Generate args with randomized placements using dist_tensor API."""
-
-        code_lines = []
-
-        # DTensor setup (same as parent)
-        code_lines.extend(
-            [
-                "world_size = 1024",
-                "fake_store = FakeStore()",
-                "torch.distributed.init_process_group(",
-                '    "fake", store=fake_store, rank=0, world_size=world_size',
-                ")",
-                "",
-                "mesh = torch.distributed.device_mesh.init_device_mesh(",
-                '    "cuda", (2, 8), mesh_dim_names=("dim1", "dim2")',
-                ")",
-                "",
-            ]
+def make_template(name: str) -> FuzzTemplate:
+    """Instantiate the FuzzTemplate registered under ``name``."""
+    initialize_codegen()
+    if name not in _TEMPLATE_REGISTRY:
+        raise KeyError(
+            f"Unknown template '{name}'; available templates: "
+            f"{sorted(_TEMPLATE_REGISTRY.keys())}"
         )
+    return _TEMPLATE_REGISTRY[name]()
 
-        # Sentinel with random placement
-        sentinel_placements = self._generate_random_placement((1,))
-        code_lines.extend(
-            [
-                f"sentinel = dist_tensor.ones((1,), device_mesh=mesh, placements={sentinel_placements}, dtype=torch.float32, requires_grad=True)",
-                "",
-            ]
-        )
 
-        # Args with random placements using dist_tensor API
-        if arg_operations:
-            for i, (node_id, spec) in enumerate(arg_operations):
-                if isinstance(spec, TensorSpec):
-                    size_str = str(spec.size)
-                    dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")
-                    placements = self._generate_random_placement(spec.size)
-
-                    if spec.dtype in [
-                        torch.int32,
-                        torch.int64,
-                        torch.int8,
-                        torch.int16,
-                    ]:
-                        code_lines.append(
-                            f"arg_{i} = dist_tensor.ones({size_str}, device_mesh=mesh, placements={placements}, dtype={dtype_str}) * 5"
-                        )
-                    elif spec.dtype == torch.bool:
-                        code_lines.append(
-                            f"arg_{i} = dist_tensor.ones({size_str}, device_mesh=mesh, placements={placements}, dtype=torch.int8).bool()"
-                        )
-                    else:
-                        code_lines.append(
-                            f"arg_{i} = dist_tensor.randn({size_str}, device_mesh=mesh, placements={placements}, dtype={dtype_str}, requires_grad=True)"
-                        )
-
-        # Constants (if any) - use same dist_tensor approach
-        if constant_operations:
-            for node_id, var_name, spec in constant_operations:
-                if isinstance(spec, TensorSpec):
-                    size_str = str(spec.size)
-                    dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")
-                    placements = self._generate_random_placement(spec.size)
-                    # Use dist_tensor.full with a simple fill value
-                    code_lines.append(
-                        f"{var_name} = dist_tensor.full({size_str}, 1.0, device_mesh=mesh, placements={placements}, dtype={dtype_str})"
-                    )
-
-        code_lines.append("")
-        return code_lines
+def get_device_info() -> DeviceInfo:
+    """Return the active plugin's :class:`DeviceInfo`."""
+    initialize_codegen()
+    return _DEVICE_INFO
 
 
 def convert_graph_to_python_code(
@@ -820,22 +359,11 @@ def convert_graph_to_python_code(
         String containing the complete Python code that executes the operations
     """
 
-    # Instantiate template
-    if template == "dtensor":
-        fuzz_template = DTensorFuzzTemplate()
-    elif template == "dtensor_placements":
-        fuzz_template = DTensorFuzzPlacementsTemplate()
-    elif template == "unbacked":
-        fuzz_template = UnbackedFuzzTemplate()
-    elif template == "streams":
-        fuzz_template = StreamFuzzTemplate()
-    else:
-        fuzz_template = DefaultFuzzTemplate()
+    # Instantiate template via the device plugin registry.
+    fuzz_template = make_template(template)
 
     # Set seed for reproducible code generation
     if seed is not None:
-        import random
-
         random.seed(seed + 1000)  # Offset to avoid conflicts with graph generation
         torch.manual_seed(seed + 1000)
 
@@ -845,6 +373,8 @@ def convert_graph_to_python_code(
     # Get topological order - this ensures dependencies are processed before dependents
     topo_order = operation_graph.get_topological_order()
 
+    constant_as_global = fuzz_template.treat_constant_as_global()
+
     # Track generated variables, arg operations, and constant operations
     generated_code_lines = []
     node_variables: dict[str, tuple[str, Spec]] = {}  # Maps node_id to (var_name, spec)
@@ -853,7 +383,7 @@ def convert_graph_to_python_code(
     ] = []  # List of (node_id, spec) for arg operations
     constant_operations: list[
         tuple[str, str, Spec]
-    ] = []  # List of (node_id, var_name, spec) for constant operations (DTensor templates only)
+    ] = []  # List of (node_id, var_name, spec) for templates that lift constants out
 
     # Process nodes in topological order
     for node_id in topo_order:
@@ -884,8 +414,8 @@ def convert_graph_to_python_code(
             # Add tensor descriptor comment for arg operations too
             descriptor_comment = f"# {format_tensor_descriptor(output_spec)}"
             operation_lines = [f"{output_var_name} = {arg_name} " + descriptor_comment]
-        elif op_name == "constant" and template == "dtensor_placements":
-            # For DTensor placements template, track constants to create them outside the function
+        elif op_name == "constant" and constant_as_global:
+            # Track constants to create them outside the function
             constant_operations.append((node_id, output_var_name, output_spec))
             descriptor_comment = f"# {format_tensor_descriptor(output_spec)}"
             operation_lines = [
@@ -903,11 +433,10 @@ def convert_graph_to_python_code(
         # Track this node's variable
         node_variables[node_id] = (output_var_name, output_spec)
 
-    # Wrap body with stream contexts if using the streams template
-    if template == "streams":
-        generated_code_lines = StreamFuzzTemplate.wrap_body_with_streams(
-            generated_code_lines, operation_graph
-        )
+    # Optional template-driven body rewrite (e.g. CUDA stream wrapping).
+    generated_code_lines = fuzz_template.wrap_body(
+        generated_code_lines, operation_graph
+    )
 
     # The final result comes from the root node
     root_node_id = operation_graph.root_node_id
@@ -920,7 +449,7 @@ def convert_graph_to_python_code(
     param_names = []
     if arg_operations:
         param_names.extend([f"arg_{i}" for i in range(len(arg_operations))])
-    if template == "dtensor_placements" and constant_operations:
+    if constant_as_global and constant_operations:
         param_names.extend([var_name for _, var_name, _ in constant_operations])
     param_names.append("sentinel")
 
@@ -946,47 +475,19 @@ def convert_graph_to_python_code(
     # Add the generated operation code
     code_lines.extend(generated_code_lines)
 
-    # Add return statement with sentinel multiplication to ensure gradient computation
-    # Handle complex tensors appropriately based on template
-    if template in ["dtensor", "dtensor_placements"]:
-        # For DTensor, avoid .real operation which doesn't work with sharding
-        # Instead use abs() for complex tensors to get a real result
-        code_lines.extend(
-            [
-                "    # Ensure gradient computation by multiplying with sentinel",
-                f"    result = {final_var_name} * sentinel",
-                "    if result.is_complex():",
-                "        result = result.abs()  # Use abs() instead of .real for DTensor compatibility",
-                "    return result",
-                "",
-            ]
-        )
-    else:
-        code_lines.extend(
-            [
-                "    # Ensure gradient computation by multiplying with sentinel and taking real part",
-                f"    result = {final_var_name} * sentinel",
-                "    if result.is_complex():",
-                "        result = result.real",
-                "    return result",
-                "",
-            ]
-        )
+    # Add return statement (template-controlled to handle complex tensors etc.)
+    code_lines.extend(fuzz_template.return_codegen(final_var_name))
 
-    # Generate argument creation code using template
-    if template == "dtensor_placements" and hasattr(fuzz_template, "args_codegen"):
-        # For dtensor_placements, pass constants to args_codegen which handles both
-        arg_code_lines = fuzz_template.args_codegen(arg_operations, constant_operations)
-        code_lines.extend(arg_code_lines)
-    else:
-        arg_code_lines = fuzz_template.args_codegen(arg_operations)
-        code_lines.extend(arg_code_lines)
+    # Generate argument creation code using template (always pass constant_operations;
+    # templates that don't opt in via treat_constant_as_global ignore the second arg).
+    arg_code_lines = fuzz_template.args_codegen(arg_operations, constant_operations)
+    code_lines.extend(arg_code_lines)
 
     # Generate the final execution with both normal and compiled versions
     param_values = []
     if arg_operations:
         param_values.extend([f"arg_{i}" for i in range(len(arg_operations))])
-    if template == "dtensor_placements" and constant_operations:
+    if constant_as_global and constant_operations:
         param_values.extend([var_name for _, var_name, _ in constant_operations])
     param_values.append("sentinel")
 
@@ -1058,8 +559,6 @@ def create_program_file(python_code: str) -> str:
     Returns:
         Path to the created temporary file
     """
-    import hashlib
-
     # Generate a deterministic filename based on code content hash
     code_hash = hashlib.md5(python_code.encode()).hexdigest()[:8]  # noqa: S324
     tmp_dir = "/tmp/torchfuzz"

--- a/tools/experimental/torchfuzz/cuda/__init__.py
+++ b/tools/experimental/torchfuzz/cuda/__init__.py
@@ -1,0 +1,157 @@
+"""CUDA device plugin for torchfuzz.
+
+This is the reference device plugin loaded by ``torchfuzz.codegen`` when
+``TORCHFUZZ_DEVICE_MODULE`` is unset (its default value is ``"torchfuzz.cuda"``).
+
+Plugin contract
+---------------
+
+A device plugin is any importable Python module that exposes the following
+two module-level functions::
+
+    def register_codegen() -> dict[str, type[FuzzTemplate]]: ...
+    def get_device_info() -> DeviceInfo: ...
+
+where ``FuzzTemplate`` and ``DeviceInfo`` are imported from
+``torchfuzz.codegen``.
+
+* ``register_codegen()`` returns a mapping from template short-name (used by
+  ``--template`` on the CLI) to the :class:`FuzzTemplate` subclass that
+  implements that template.
+* ``get_device_info()`` returns a :class:`DeviceInfo` instance carrying the
+  device name (emitted into tensor descriptors) and an optional
+  ``select_runtime_env(env)`` callback that mutates the subprocess environment
+  ``runner.py`` uses when launching generated programs.
+
+FuzzTemplate hooks
+------------------
+
+The core ``convert_graph_to_python_code`` is device-agnostic.  Plugins
+customize emitted code by overriding the following hooks on
+:class:`FuzzTemplate`:
+
+================================  ========================================  ==================================================
+Hook                              Default behaviour                         Where it is invoked
+================================  ========================================  ==================================================
+``imports_codegen``               ``[]``                                    Top of generated file
+``flags_codegen``                 ``[]``                                    Top of generated file (after imports)
+``args_codegen``                  Sentinel + per-arg ``torch.as_strided``   After the ``def fuzzed_program(...):`` body
+``codegen_constant``              ``f"{output_name} = {expr}"``             ``operators/constant.py`` (TensorSpec branch)
+``treat_constant_as_global``      ``False``                                 Decides if ``constant`` ops become function args
+``return_codegen``                Multiplies by sentinel; ``.real`` for     Body's last lines (return statement)
+                                  complex
+``wrap_body``                     Returns lines unchanged                   After per-node code is emitted
+``epilogue_codegen``              ``[]``                                    End of generated file
+================================  ========================================  ==================================================
+
+Per-template overrides for the CUDA plugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* :class:`DefaultFuzzTemplate` - emits ``torch.set_default_device('cuda')``
+  in ``flags_codegen``; otherwise inherits all base hooks.
+* :class:`UnbackedFuzzTemplate` - same as default plus the
+  ``capture_dynamic_output_shape_ops`` flag; tensor/scalar mix is 50/50.
+* :class:`StreamFuzzTemplate` - overrides ``args_codegen`` to add
+  ``requires_grad_(True)`` to float args, and overrides ``wrap_body`` to
+  partition non-leaf operations across 2-3 ``torch.cuda.Stream()`` contexts
+  with proper ``wait_stream`` / event-based synchronization.
+* :class:`DTensorFuzzTemplate` - overrides ``imports_codegen`` /
+  ``flags_codegen`` for distributed setup, ``args_codegen`` to wrap each arg
+  via ``DTensor.from_local`` on a fake-PG 2D mesh, ``return_codegen`` to use
+  ``.abs()`` (instead of ``.real``) for complex tensors,
+  ``epilogue_codegen`` to destroy the process group, and
+  ``codegen_constant`` to wrap constants via ``DTensor.from_local`` on cuda.
+* :class:`DTensorFuzzPlacementsTemplate` - extends DTensor with randomized
+  placements (Replicate/Shard/Partial); overrides ``treat_constant_as_global``
+  to ``True`` so constants are materialized in ``args_codegen`` (via
+  ``dist_tensor.full``), and ``codegen_constant`` becomes a comment marker.
+
+Concrete implementations live in :mod:`torchfuzz.cuda._codegen`.
+
+Runtime environment hook
+------------------------
+
+``select_runtime_env(env, *, exclude_primary_device=False)`` (registered as
+``DeviceInfo.select_runtime_env``) is called by ``runner.py`` to customize the
+environment used when launching the generated program in a subprocess.
+``PYTHONPATH`` is already set by the runner before the hook is called; plugins
+should not set it.  The CUDA implementation (:func:`_select_cuda_device`) picks
+a random device from ``CUDA_VISIBLE_DEVICES`` (or ``torch.cuda.device_count()``
+if unset) and narrows ``CUDA_VISIBLE_DEVICES`` to that single device.  When
+*exclude_primary_device* is ``True`` and more than one GPU is available, GPU 0
+is excluded to avoid contention with the orchestrating process.  Other plugins
+should follow the same pattern (return a *new* dict, do not mutate the caller's
+environment in place).
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+
+from torchfuzz.codegen import DeviceInfo, FuzzTemplate
+from torchfuzz.cuda._codegen import (
+    DefaultFuzzTemplate,
+    DTensorFuzzPlacementsTemplate,
+    DTensorFuzzTemplate,
+    StreamFuzzTemplate,
+    UnbackedFuzzTemplate,
+)
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def register_codegen() -> dict[str, type[FuzzTemplate]]:
+    """Return the CUDA plugin's template registry."""
+    return {
+        "default": DefaultFuzzTemplate,
+        "dtensor": DTensorFuzzTemplate,
+        "dtensor_placements": DTensorFuzzPlacementsTemplate,
+        "unbacked": UnbackedFuzzTemplate,
+        "streams": StreamFuzzTemplate,
+    }
+
+
+def _select_cuda_device(
+    env: dict[str, str],
+    *,
+    exclude_primary_device: bool = False,
+) -> dict[str, str]:
+    """Pick a random CUDA device and narrow CUDA_VISIBLE_DEVICES to it.
+
+    Returns a new env mapping (does not mutate ``env``).
+
+    When *exclude_primary_device* is ``True`` and more than one GPU is
+    available, GPU 0 is excluded from the candidate pool to avoid contention
+    with the orchestrating process.
+    """
+    new_env = dict(env)
+    cuda_visible_devices = new_env.get("CUDA_VISIBLE_DEVICES")
+    if cuda_visible_devices:
+        devices = [d.strip() for d in cuda_visible_devices.split(",") if d.strip()]
+    else:
+        # Default to all GPUs if not set
+        try:
+            import torch
+
+            num_gpus = torch.cuda.device_count()
+            device_range = (
+                range(1, num_gpus)
+                if exclude_primary_device and num_gpus > 1
+                else range(num_gpus)
+            )
+            devices = [str(i) for i in device_range]
+        except ImportError:
+            devices = []
+
+    if devices:
+        selected_device = random.choice(devices)
+        new_env["CUDA_VISIBLE_DEVICES"] = selected_device
+        logger.info("Selected CUDA_VISIBLE_DEVICES=%s", selected_device)
+    return new_env
+
+
+def get_device_info() -> DeviceInfo:
+    """Return the CUDA plugin's device metadata."""
+    return DeviceInfo(device_name="cuda", select_runtime_env=_select_cuda_device)

--- a/tools/experimental/torchfuzz/cuda/_checks.py
+++ b/tools/experimental/torchfuzz/cuda/_checks.py
@@ -1,0 +1,61 @@
+"""Concrete Check subclasses provided by the CUDA device plugin."""
+
+from torchfuzz.checks import Check
+
+
+class EagerVsFullGraphDynamicCompileCheck(Check):
+    """Standard check that runs eager then fullgraph+dynamic compilation."""
+
+    def codegen(self, args_tuple: str) -> list[str]:
+        return [
+            f"args = {args_tuple}",
+            "result_original = fuzzed_program(*args)",
+            "print('✅ eager success')",
+            "compiled_program = torch.compile(fuzzed_program, fullgraph=True, dynamic=True)",
+            "result_compiled = compiled_program(*args)",
+            "print('✅ compile success')",
+        ]
+
+
+class EagerVsFullGraphDynamicCompileWithBackwardCheck(Check):
+    """Check that runs eager then fullgraph+dynamic compilation with backward pass."""
+
+    def codegen(self, args_tuple: str) -> list[str]:
+        return [
+            f"args = {args_tuple}",
+            "result_original = fuzzed_program(*args)",
+            "result_original.sum().backward()",
+            "print('✅ eager + backward success')",
+            "compiled_program = torch.compile(fuzzed_program, fullgraph=True, dynamic=True)",
+            "result_compiled = compiled_program(*args)",
+            "result_compiled.sum().backward()",
+            "print('✅ compile + backward success')",
+        ]
+
+
+class EagerVsFullGraphDynamicCompileWithNumericsCheck(Check):
+    """Check that runs eager and compiled, compares forward numerics."""
+
+    def codegen(self, args_tuple: str) -> list[str]:
+        return [
+            f"args = {args_tuple}",
+            "out_eager = fuzzed_program(*args)",
+            "out_eager.sum().backward()",
+            "print('Eager Success! ✅')",
+            "compiled_program = torch.compile(fuzzed_program, fullgraph=True, dynamic=True)",
+            "out_compiled = compiled_program(*args)",
+            "out_compiled.sum().backward()",
+            "print('Compile Success! ✅')",
+            "out_eager_sum = out_eager.sum()",
+            "out_compiled_sum = out_compiled.sum()",
+            "diff = (out_eager_sum - out_compiled_sum).abs().item()",
+            "rel_diff = diff / (out_eager_sum.abs().item() + 1e-12) * 100",
+            "print(f'Relative diff (sum): {rel_diff:.6f}%')",
+            "if rel_diff > 5 and diff > 1:",
+            "    print(f'❌ Forward output sums differ significantly (relative and absolute)!')",
+            "    print('out_eager_sum:', out_eager_sum.item())",
+            "    print('out_compiled_sum:', out_compiled_sum.item())",
+            "    print('Absolute diff:', diff)",
+            "    print('Relative diff (%):', rel_diff)",
+            "    import sys; sys.exit(1)",
+        ]

--- a/tools/experimental/torchfuzz/cuda/_codegen.py
+++ b/tools/experimental/torchfuzz/cuda/_codegen.py
@@ -1,0 +1,650 @@
+# mypy: ignore-errors
+"""FuzzTemplate subclasses provided by the CUDA device plugin.
+
+These templates are returned by ``torchfuzz.cuda.register_codegen()`` and
+override the device-agnostic hooks defined on
+:class:`torchfuzz.codegen.FuzzTemplate` (``treat_constant_as_global``,
+``wrap_body``, ``return_codegen``, ``args_codegen``, ``codegen_constant``)
+to inject CUDA-specific behaviour into the code that
+``convert_graph_to_python_code`` emits.
+"""
+
+import random
+
+import torch
+
+from torchfuzz.codegen import FuzzTemplate
+from torchfuzz.ops_fuzzer import OperationGraph
+from torchfuzz.tensor_fuzzer import ScalarSpec, TensorSpec
+
+
+class DefaultFuzzTemplate(FuzzTemplate):
+    def __init__(self):
+        from torchfuzz.cuda._checks import EagerVsFullGraphDynamicCompileCheck
+
+        super().__init__(
+            supported_ops=[
+                # Basic arithmetic operations
+                "torch.add",
+                "torch.sub",
+                "torch.mul",
+                "torch.div",
+                "torch.clamp",
+                "torch.cumsum",
+                # Tensor shape operations
+                "torch.Tensor.view",
+                "torch.reshape",
+                "torch.flatten",
+                "torch.squeeze",
+                "torch.unsqueeze",
+                "torch.split",
+                "torch.chunk",
+                "torch.expand",
+                "torch.cat",
+                "torch.stack",
+                # Indexing operations
+                "torch.gather",
+                "torch.index_select",
+                "torch.argsort",
+                # Matrix operations
+                "torch.mm",
+                "torch.addmm",
+                "torch.bmm",
+                "torch.matmul",
+                # Neural network operations
+                "torch.nn.functional.embedding",
+                "torch.nn.functional.linear",
+                "torch.nn.functional.scaled_dot_product_attention",
+                "torch.nn.functional.multi_head_attention_forward",
+                # Activation functions
+                "torch.nn.functional.relu",
+                "torch.nn.functional.leaky_relu",
+                "torch.nn.functional.elu",
+                "torch.nn.functional.gelu",
+                "torch.nn.functional.silu",
+                "torch.sigmoid",
+                "torch.tanh",
+                "torch.nn.functional.softmax",
+                # Normalization layers
+                "torch.nn.functional.layer_norm",
+                "torch.nn.functional.rms_norm",
+                "torch.nn.functional.batch_norm",
+                "torch.nn.functional.group_norm",
+                # Regularization
+                "torch.nn.functional.dropout",
+            ],
+            check=EagerVsFullGraphDynamicCompileCheck(),
+        )
+
+    def spec_distribution(self):
+        """Default template: tensor-only (no scalars)."""
+        return {
+            "tensor_prob": 1.0,
+            "scalar_prob": 0.0,
+            "allow_tensors": True,
+            "allow_scalars": False,
+        }
+
+    def imports_codegen(self):
+        return [
+            "import torch",
+        ]
+
+    def flags_codegen(self):
+        return [
+            "torch.set_default_device('cuda')",
+            "torch._dynamo.config.capture_scalar_outputs = True",
+        ]
+
+    def epilogue_codegen(self):
+        return []
+
+
+class DTensorFuzzTemplate(FuzzTemplate):
+    def __init__(self):
+        from torchfuzz.cuda._checks import EagerVsFullGraphDynamicCompileCheck
+
+        super().__init__(
+            supported_ops=[
+                "torch.add",
+                "torch.sub",
+                "torch.mul",
+                "torch.div",
+                "torch.mm",
+                "torch.addmm",
+                "torch.bmm",
+                "torch.matmul",
+            ],
+            check=EagerVsFullGraphDynamicCompileCheck(),
+        )
+
+    def supported_dtypes(self):
+        """Return list of DTensor-compatible dtypes (no complex types)."""
+        return [
+            torch.float32,
+            torch.float64,
+            torch.float16,
+            torch.bfloat16,
+            torch.int8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+            torch.bool,
+        ]
+
+    def spec_distribution(self):
+        """DTensor template: tensor-only (no scalars)."""
+        return {
+            "tensor_prob": 1.0,
+            "scalar_prob": 0.0,
+            "allow_tensors": True,
+            "allow_scalars": False,
+        }
+
+    def imports_codegen(self):
+        return [
+            "import torch",
+            "from torch.distributed.tensor.placement_types import Replicate, Shard",
+            "from torch.testing._internal.distributed.fake_pg import FakeStore",
+            "from torch.distributed.tensor import DTensor",
+        ]
+
+    def flags_codegen(self):
+        return [
+            "torch._dynamo.config.capture_scalar_outputs = True",
+            "torch._dynamo.config.capture_dynamic_output_shape_ops = True",
+            "torch._inductor.config.emulate_precision_casts = True",
+        ]
+
+    def args_codegen(self, arg_operations, constant_operations=None):
+        """Generate DTensor argument creation code with proper mesh setup."""
+        code_lines = []
+
+        # Add DTensor setup code first
+        code_lines.extend(
+            [
+                "world_size = 1024",
+                "fake_store = FakeStore()",
+                "torch.distributed.init_process_group(",
+                '    "fake", store=fake_store, rank=0, world_size=world_size',
+                ")",
+                "",
+                "mesh = torch.distributed.device_mesh.init_device_mesh(",
+                '    "cuda",',
+                "    (2, 8),",
+                "    mesh_dim_names=(",
+                '        "dim1", "dim2",',
+                "    ),",
+                ")",
+                "",
+                "placements = (Replicate(), Replicate())",
+                "",
+                "# Sentinel tensor to ensure gradient computation",
+                "sentinel_local = torch.tensor(1.0, device='cuda', requires_grad=True)",
+                "sentinel = DTensor.from_local(sentinel_local, mesh, placements)",
+                "",
+            ]
+        )
+
+        if arg_operations:
+            for i, (node_id, spec) in enumerate(arg_operations):
+                arg_name = f"arg_{i}"
+
+                if isinstance(spec, ScalarSpec):
+                    # For scalars in DTensor, create a 0-dim tensor
+                    dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")
+                    code_lines.extend(
+                        [
+                            f"{arg_name}_local = torch.randn((), dtype={dtype_str}, device='cuda', requires_grad=True)",
+                            f"{arg_name} = DTensor.from_local({arg_name}_local, mesh, placements)",
+                        ]
+                    )
+
+                elif isinstance(spec, TensorSpec):
+                    size_str = str(spec.size)
+                    dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")
+
+                    # Handle different dtypes appropriately for DTensor
+                    if spec.dtype in [
+                        torch.int32,
+                        torch.int64,
+                        torch.int8,
+                        torch.int16,
+                    ]:
+                        # Integer dtypes: use randint and no requires_grad
+                        code_lines.extend(
+                            [
+                                f"{arg_name}_local = torch.randint(1, 10, {size_str}, dtype={dtype_str}, device='cuda')",
+                                f"{arg_name} = DTensor.from_local({arg_name}_local, mesh, placements)",
+                            ]
+                        )
+                    elif spec.dtype == torch.bool:
+                        # Boolean dtype: use randint and cast to bool
+                        code_lines.extend(
+                            [
+                                f"{arg_name}_local = torch.randint(0, 2, {size_str}, device='cuda').bool()",
+                                f"{arg_name} = DTensor.from_local({arg_name}_local, mesh, placements)",
+                            ]
+                        )
+                    else:
+                        # Float dtypes: use randn and requires_grad
+                        code_lines.extend(
+                            [
+                                f"{arg_name}_local = torch.randn({size_str}, dtype={dtype_str}, device='cuda', requires_grad=True)",
+                                f"{arg_name} = DTensor.from_local({arg_name}_local, mesh, placements)",
+                            ]
+                        )
+
+        return code_lines
+
+    def epilogue_codegen(self):
+        return ["torch.distributed.destroy_process_group()"]
+
+    def return_codegen(self, final_var_name: str) -> list[str]:
+        """DTensor return: avoid .real (incompatible with sharding); use .abs() for complex."""
+        return [
+            "    # Ensure gradient computation by multiplying with sentinel",
+            f"    result = {final_var_name} * sentinel",
+            "    if result.is_complex():",
+            "        result = result.abs()  # Use abs() instead of .real for DTensor compatibility",
+            "    return result",
+            "",
+        ]
+
+    def codegen_constant(self, output_name: str, tensor_creation_expr: str) -> str:
+        """DTensor constants live on cuda and are wrapped via DTensor.from_local."""
+        return (
+            f"{output_name}_local = {tensor_creation_expr}.to('cuda')\n"
+            f"{output_name} = DTensor.from_local({output_name}_local, mesh, placements)"
+        )
+
+
+class UnbackedFuzzTemplate(FuzzTemplate):
+    def __init__(self):
+        from torchfuzz.cuda._checks import EagerVsFullGraphDynamicCompileCheck
+
+        super().__init__(
+            supported_ops=[
+                "torch.ops.aten.item",
+                "torch.ops.aten.nonzero",
+                "torch.ops.aten.masked_select",
+                "torch.ops.aten.unique",
+                # Basic arithmetic operations
+                "torch.add",
+                "torch.sub",
+                "torch.mul",
+                "torch.div",
+                # Tensor shape operations
+                "torch.Tensor.view",
+                "torch.reshape",
+                "torch.flatten",
+                "torch.squeeze",
+                "torch.unsqueeze",
+                # Matrix operations
+                "torch.mm",
+                "torch.addmm",
+                "torch.bmm",
+                "torch.matmul",
+                # Neural network operations
+                "torch.nn.functional.embedding",
+                "torch.nn.functional.linear",
+                # Activation functions
+                "torch.nn.functional.relu",
+                "torch.nn.functional.leaky_relu",
+                "torch.nn.functional.elu",
+                "torch.nn.functional.gelu",
+                "torch.nn.functional.silu",
+                "torch.sigmoid",
+                "torch.tanh",
+                "torch.nn.functional.softmax",
+                # Normalization layers
+                "torch.nn.functional.layer_norm",
+                "torch.nn.functional.rms_norm",
+                "torch.nn.functional.batch_norm",
+                "torch.nn.functional.group_norm",
+                # Regularization
+                "torch.nn.functional.dropout",
+            ],
+            check=EagerVsFullGraphDynamicCompileCheck(),
+        )
+
+    def supported_dtypes(self):
+        """Return list of dtypes good for data-dependent operations."""
+        # Focus on dtypes that work well with data-dependent ops and arithmetic
+        # Exclude bool since arithmetic operations don't work with boolean tensors
+        return [
+            torch.float32,
+            torch.float64,
+            torch.int32,
+            torch.int64,
+        ]
+
+    def spec_distribution(self):
+        """Unbacked template: 50% tensors, 50% scalars."""
+        return {
+            "tensor_prob": 0.5,
+            "scalar_prob": 0.5,
+            "allow_tensors": True,
+            "allow_scalars": True,
+        }
+
+    def imports_codegen(self):
+        return [
+            "import torch",
+        ]
+
+    def flags_codegen(self):
+        return [
+            "torch.set_default_device('cuda')",
+            "torch._dynamo.config.capture_scalar_outputs = True",
+            "torch._dynamo.config.capture_dynamic_output_shape_ops = True",
+        ]
+
+    def epilogue_codegen(self):
+        return []
+
+
+class StreamFuzzTemplate(DefaultFuzzTemplate):
+    """Template that wraps operations in random CUDA stream contexts.
+
+    Reuses the same operator set as DefaultFuzzTemplate but partitions non-leaf
+    operations across 2-3 CUDA streams, inserting proper wait_stream
+    synchronization between dependent operations on different streams.
+    """
+
+    def __init__(self):
+        super().__init__()
+        from torchfuzz.cuda._checks import (
+            EagerVsFullGraphDynamicCompileWithBackwardCheck,
+        )
+
+        self.check = EagerVsFullGraphDynamicCompileWithBackwardCheck()
+
+    def imports_codegen(self):
+        return [
+            "import torch",
+        ]
+
+    def flags_codegen(self):
+        return [
+            "torch.set_default_device('cuda')",
+            "torch._dynamo.config.capture_scalar_outputs = True",
+        ]
+
+    def args_codegen(self, arg_operations, constant_operations=None):
+        """Generate args with requires_grad=True on float tensors.
+
+        This ensures the backward pass traces through stream-wrapped operations,
+        exercising Inductor's stream handling in the backward graph.
+        """
+        code_lines = super().args_codegen(arg_operations, constant_operations)
+        if arg_operations:
+            for i, (node_id, spec) in enumerate(arg_operations):
+                if isinstance(spec, TensorSpec) and spec.dtype in [
+                    torch.float32,
+                    torch.float64,
+                    torch.float16,
+                    torch.bfloat16,
+                ]:
+                    code_lines.append(f"arg_{i} = arg_{i}.requires_grad_(True)")
+        return code_lines
+
+    def wrap_body(
+        self, generated_code_lines: list[str], graph: OperationGraph
+    ) -> list[str]:
+        return self.wrap_body_with_streams(generated_code_lines, graph)
+
+    @staticmethod
+    def wrap_body_with_streams(
+        generated_code_lines: list[str],
+        graph: OperationGraph,
+    ) -> list[str]:
+        """Wrap generated function body lines with CUDA stream contexts.
+
+        Assigns each non-leaf operation to one of 2-3 random streams, wraps each
+        in ``with torch.cuda.stream(sN):``, and inserts ``wait_stream`` calls
+        between dependent operations on different streams.
+        """
+        topo_order = graph.get_topological_order()
+
+        # Identify leaf vs non-leaf node ids
+        leaf_ids = set()
+        non_leaf_ids = []
+        for nid in topo_order:
+            node = graph.nodes[nid]
+            if (
+                node.op_name == "arg"
+                or node.op_name.startswith("arg_")
+                or node.op_name == "constant"
+            ):
+                leaf_ids.add(nid)
+            else:
+                non_leaf_ids.append(nid)
+
+        if not non_leaf_ids:
+            return generated_code_lines
+
+        num_streams = random.randint(2, 3)
+        stream_names = [f"s{i + 1}" for i in range(num_streams)]
+
+        # Decide sync strategy: wait_stream or event-based (record + wait_event)
+        use_events = random.choice([True, False])
+        event_counter = 0
+
+        # Assign each non-leaf node to a random stream
+        node_stream: dict[str, str] = {}
+        for nid in non_leaf_ids:
+            node_stream[nid] = random.choice(stream_names)
+
+        # Build a mapping from node_id -> the original code lines for that node.
+        # Each node produces lines prefixed with "    " (4-space indent for the
+        # function body).  We identify nodes by their ``var_{node_id} =`` pattern.
+        node_lines: dict[str, list[str]] = {}
+        current_node: str | None = None
+        current_buf: list[str] = []
+
+        for line in generated_code_lines:
+            stripped = line.strip()
+            # Detect lines like "var_node_3 = ..." or "var_node_3, _ = ..."
+            matched_node = None
+            for nid in topo_order:
+                if stripped.startswith((f"var_{nid} =", f"var_{nid},")):
+                    matched_node = nid
+                    break
+
+            if matched_node is not None:
+                # Flush previous node buffer
+                if current_node is not None:
+                    node_lines[current_node] = current_buf
+                current_node = matched_node
+                current_buf = [line]
+            else:
+                current_buf.append(line)
+
+        # Flush last node
+        if current_node is not None:
+            node_lines[current_node] = current_buf
+
+        # Rebuild the body with stream contexts and synchronization
+        new_lines: list[str] = []
+
+        # Stream variable declarations at the top of the function body
+        for sname in stream_names:
+            new_lines.append(f"    {sname} = torch.cuda.Stream()")
+
+        for nid in topo_order:
+            lines_for_node = node_lines.get(nid, [])
+            if nid in leaf_ids:
+                # Leaf nodes (args) stay on the default stream
+                new_lines.extend(lines_for_node)
+                continue
+
+            stream = node_stream[nid]
+            node = graph.nodes[nid]
+
+            # Insert synchronization for cross-stream dependencies
+            waited: set[str] = set()
+            for dep_id in node.input_nodes:
+                if dep_id in node_stream and node_stream[dep_id] != stream:
+                    dep_stream = node_stream[dep_id]
+                    if dep_stream not in waited:
+                        if use_events:
+                            ename = f"e{event_counter}"
+                            event_counter += 1
+                            new_lines.append(f"    {ename} = torch.cuda.Event()")
+                            new_lines.append(f"    {ename}.record({dep_stream})")
+                            new_lines.append(f"    {stream}.wait_event({ename})")
+                        else:
+                            new_lines.append(f"    {stream}.wait_stream({dep_stream})")
+                        waited.add(dep_stream)
+
+            # Wrap the operation in a stream context
+            new_lines.append(f"    with torch.cuda.stream({stream}):")
+            for code_line in lines_for_node:
+                # Each line already has 4-space indent; add 4 more for the with block
+                new_lines.append("    " + code_line)
+
+        # Synchronize all streams before the return statement
+        if use_events:
+            for sname in stream_names:
+                ename = f"e{event_counter}"
+                event_counter += 1
+                new_lines.append(f"    {ename} = torch.cuda.Event()")
+                new_lines.append(f"    {ename}.record({sname})")
+                new_lines.append(f"    torch.cuda.current_stream().wait_event({ename})")
+        else:
+            for sname in stream_names:
+                new_lines.append(
+                    f"    torch.cuda.current_stream().wait_stream({sname})"
+                )
+
+        return new_lines
+
+
+class DTensorFuzzPlacementsTemplate(DTensorFuzzTemplate):
+    """DTensor template with randomized placements (Replicate, Shard, Partial).
+
+    Extends DTensorFuzzTemplate to randomize placement strategies instead of
+    using fixed (Replicate(), Replicate()) for all tensors.
+    """
+
+    def fuzz_spec_custom(self):
+        """Generate tensor specs with minimum 1 dimension for proper DTensor sharding."""
+        from torchfuzz.tensor_fuzzer import fuzz_valid_stride
+
+        # Get random dtype
+        dtype = random.choice(self.supported_dtypes())
+
+        # Generate tensor size with minimum 1 dimension (avoid 0-dim scalars)
+        # Prefer 2D-3D tensors for interesting sharding patterns
+        ndim = random.choices([1, 2, 3, 4], weights=[0.1, 0.5, 0.3, 0.1])[0]
+        size = tuple(random.randint(2, 32) for _ in range(ndim))
+        stride = fuzz_valid_stride(size)
+
+        return TensorSpec(size=size, stride=stride, dtype=dtype)
+
+    def imports_codegen(self):
+        """Add Partial to imports."""
+        base_imports = super().imports_codegen()
+        # Update the placement imports to include Partial
+        for i, imp in enumerate(base_imports):
+            if "placement_types import" in imp:
+                base_imports[i] = (
+                    "from torch.distributed.tensor.placement_types import Replicate, Shard, Partial"
+                )
+                break
+        base_imports.append("import torch.distributed.tensor as dist_tensor")
+        return base_imports
+
+    def treat_constant_as_global(self) -> bool:
+        """Constants are created outside the function and passed in as args."""
+        return True
+
+    def codegen_constant(self, output_name: str, tensor_creation_expr: str) -> str:
+        """Constants are materialized in args_codegen for this template."""
+        return f"# {output_name} is created globally"
+
+    def _generate_random_placement(self, tensor_size):
+        """Generate random placement tuple (Replicate, Shard, or Partial)."""
+        placements = []
+        for _ in range(2):  # 2D mesh
+            placement_type = random.randint(0, 2)
+            if placement_type == 0:
+                placements.append("Replicate()")
+            elif placement_type == 1 and len(tensor_size) > 0:
+                shard_dim = random.randint(0, len(tensor_size) - 1)
+                placements.append(f"Shard({shard_dim})")
+            else:
+                placements.append("Partial()" if placement_type == 2 else "Replicate()")
+        return f"({', '.join(placements)})"
+
+    def args_codegen(self, arg_operations, constant_operations=None):
+        """Generate args with randomized placements using dist_tensor API."""
+
+        code_lines = []
+
+        # DTensor setup (same as parent)
+        code_lines.extend(
+            [
+                "world_size = 1024",
+                "fake_store = FakeStore()",
+                "torch.distributed.init_process_group(",
+                '    "fake", store=fake_store, rank=0, world_size=world_size',
+                ")",
+                "",
+                "mesh = torch.distributed.device_mesh.init_device_mesh(",
+                '    "cuda", (2, 8), mesh_dim_names=("dim1", "dim2")',
+                ")",
+                "",
+            ]
+        )
+
+        # Sentinel with random placement
+        sentinel_placements = self._generate_random_placement((1,))
+        code_lines.extend(
+            [
+                f"sentinel = dist_tensor.ones((1,), device_mesh=mesh, placements={sentinel_placements}, dtype=torch.float32, requires_grad=True)",
+                "",
+            ]
+        )
+
+        # Args with random placements using dist_tensor API
+        if arg_operations:
+            for i, (node_id, spec) in enumerate(arg_operations):
+                if isinstance(spec, TensorSpec):
+                    size_str = str(spec.size)
+                    dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")
+                    placements = self._generate_random_placement(spec.size)
+
+                    if spec.dtype in [
+                        torch.int32,
+                        torch.int64,
+                        torch.int8,
+                        torch.int16,
+                    ]:
+                        code_lines.append(
+                            f"arg_{i} = dist_tensor.ones({size_str}, device_mesh=mesh, placements={placements}, dtype={dtype_str}) * 5"
+                        )
+                    elif spec.dtype == torch.bool:
+                        code_lines.append(
+                            f"arg_{i} = dist_tensor.ones({size_str}, device_mesh=mesh, placements={placements}, dtype=torch.int8).bool()"
+                        )
+                    else:
+                        code_lines.append(
+                            f"arg_{i} = dist_tensor.randn({size_str}, device_mesh=mesh, placements={placements}, dtype={dtype_str}, requires_grad=True)"
+                        )
+
+        # Constants (if any) - use same dist_tensor approach
+        if constant_operations:
+            for node_id, var_name, spec in constant_operations:
+                if isinstance(spec, TensorSpec):
+                    size_str = str(spec.size)
+                    dtype_str = f"torch.{spec.dtype}".replace("torch.torch.", "torch.")
+                    placements = self._generate_random_placement(spec.size)
+                    # Use dist_tensor.full with a simple fill value
+                    code_lines.append(
+                        f"{var_name} = dist_tensor.full({size_str}, 1.0, device_mesh=mesh, placements={placements}, dtype={dtype_str})"
+                    )
+
+        code_lines.append("")
+        return code_lines

--- a/tools/experimental/torchfuzz/fuzzer.py
+++ b/tools/experimental/torchfuzz/fuzzer.py
@@ -13,7 +13,12 @@ if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
 import torch
-from torchfuzz.codegen import convert_graph_to_python_code, create_program_file
+from torchfuzz.codegen import (
+    convert_graph_to_python_code,
+    create_program_file,
+    get_template_names,
+    initialize_codegen,
+)
 from torchfuzz.ops_fuzzer import fuzz_operation_graph, fuzz_spec
 from torchfuzz.runner import ProgramRunner
 from torchfuzz.visualize_graph import visualize_operation_graph
@@ -236,8 +241,14 @@ def fuzz_and_execute(
         sys.exit(1)
 
 
-if __name__ == "__main__":
+def main():
     import argparse
+
+    # Initialize the device plugin once up front so argparse choices reflect the
+    # active plugin's templates.
+    initialize_codegen()
+    template_names = get_template_names()
+    default_template = "default" if "default" in template_names else template_names[0]
 
     try:
         from multi_process_fuzzer import run_multi_process_fuzzer, run_until_failure
@@ -262,9 +273,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--template",
-        choices=["default", "dtensor", "dtensor_placements", "unbacked", "streams"],
-        default="default",
-        help="Template to use for code generation (default: default)",
+        choices=template_names,
+        default=default_template,
+        help=(
+            "Template to use for code generation "
+            f"(default: {default_template}; from active TORCHFUZZ_DEVICE_MODULE plugin)"
+        ),
     )
     parser.add_argument(
         "--supported-ops",
@@ -320,7 +334,6 @@ if __name__ == "__main__":
     logging.basicConfig(
         level=getattr(logging, args.log_level), format="%(levelname)s: %(message)s"
     )
-    logger = logging.getLogger(__name__)
 
     # Determine execution mode
     if args.seed is not None or args.single:
@@ -412,3 +425,7 @@ if __name__ == "__main__":
             "  python fuzzer.py --start 0 --count 1000       # Run multi-process fuzzing"
         )
         print("  python fuzzer.py --start 100 --count 50 -p 8  # Use 8 processes")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/experimental/torchfuzz/operators/constant.py
+++ b/tools/experimental/torchfuzz/operators/constant.py
@@ -15,15 +15,24 @@ class ConstantOperator(Operator):
 
     def __init__(self):
         super().__init__("constant")
-        self.template = "default"  # Track template for DTensor compatibility
+        # Active FuzzTemplate instance (set via set_template) used to delegate
+        # device-specific tensor wrapping in codegen.  None until set_template
+        # is called.
+        self.template = None
 
     @property
     def torch_op_name(self) -> str | None:
         """Constant is not a torch operation, it generates constant values."""
         return None
 
-    def set_template(self, template: str):
-        """Set the template for context-aware code generation."""
+    def set_template(self, template):
+        """Set the active :class:`FuzzTemplate` instance for codegen.
+
+        ``ops_fuzzer._get_template_filtered_operators`` calls this with the
+        instance that ``convert_graph_to_python_code`` will subsequently use,
+        so the operator's ``codegen`` can defer device-specific wrapping
+        (``DTensor.from_local`` etc.) to ``template.codegen_constant``.
+        """
         self.template = template
 
     def can_produce(self, output_spec: Spec) -> bool:
@@ -115,19 +124,11 @@ class ConstantOperator(Operator):
                     f"torch.full({size_str}, {fill_value}, dtype={dtype_str})"
                 )
 
-            # For DTensor templates, constants are created outside the function
-            if self.template in ["dtensor", "dtensor_placements"]:
-                # For dtensor_placements, constants are handled in args_codegen
-                # For dtensor, use the global placements variable
-                if self.template == "dtensor_placements":
-                    return f"# {output_name} is created globally"
-                else:
-                    return (
-                        f"{output_name}_local = {tensor_creation}.to('cuda')\n"
-                        f"{output_name} = DTensor.from_local({output_name}_local, mesh, placements)"
-                    )
-            else:
-                return f"{output_name} = {tensor_creation}"
+            # Delegate device-specific wrapping (cuda placement, DTensor, etc.) to the
+            # active template; falls back to a plain assignment when no template is set.
+            if self.template is not None:
+                return self.template.codegen_constant(output_name, tensor_creation)
+            return f"{output_name} = {tensor_creation}"
 
         else:
             return f"# Unknown output spec type for constant: {type(output_spec)}"

--- a/tools/experimental/torchfuzz/ops_fuzzer.py
+++ b/tools/experimental/torchfuzz/ops_fuzzer.py
@@ -38,27 +38,9 @@ def _get_template_filtered_operators(
     registry. Otherwise, the template's supported_ops are used. If neither are
     specified, all operators are returned.
     """
-    # Instantiate template
-    if template == "dtensor":
-        from torchfuzz.codegen import DTensorFuzzTemplate
+    from torchfuzz.codegen import make_template
 
-        fuzz_template = DTensorFuzzTemplate()
-    elif template == "dtensor_placements":
-        from torchfuzz.codegen import DTensorFuzzPlacementsTemplate
-
-        fuzz_template = DTensorFuzzPlacementsTemplate()
-    elif template == "unbacked":
-        from torchfuzz.codegen import UnbackedFuzzTemplate
-
-        fuzz_template = UnbackedFuzzTemplate()
-    elif template == "streams":
-        from torchfuzz.codegen import StreamFuzzTemplate
-
-        fuzz_template = StreamFuzzTemplate()
-    else:
-        from torchfuzz.codegen import DefaultFuzzTemplate
-
-        fuzz_template = DefaultFuzzTemplate()
+    fuzz_template = make_template(template)
 
     all_operators = _get_cached_operators()
 
@@ -67,6 +49,9 @@ def _get_template_filtered_operators(
 
     # If no supported_ops specified, return all operators
     if not allowed_ops:
+        for operator in all_operators.values():
+            if hasattr(operator, "set_template"):
+                operator.set_template(fuzz_template)  # type: ignore[attr-defined]
         return all_operators
 
     # Filter operators based on allowed_ops
@@ -79,7 +64,7 @@ def _get_template_filtered_operators(
         if torch_op is None:
             # Set template on operators that support it
             if hasattr(operator, "set_template"):
-                operator.set_template(template)  # type: ignore[attr-defined]
+                operator.set_template(fuzz_template)  # type: ignore[attr-defined]
             filtered_ops[op_name] = operator
             continue
 
@@ -99,7 +84,7 @@ def _get_template_filtered_operators(
         if should_include:
             # Set template on operators that support it
             if hasattr(operator, "set_template"):
-                operator.set_template(template)  # type: ignore[attr-defined]
+                operator.set_template(fuzz_template)  # type: ignore[attr-defined]
             filtered_ops[op_name] = operator
 
     return filtered_ops
@@ -243,27 +228,9 @@ def fuzz_spec(template: str = "default") -> Spec:
     """
     # Try to use template's custom distribution if available
     try:
-        # Instantiate template
-        if template == "dtensor":
-            from torchfuzz.codegen import DTensorFuzzTemplate
+        from torchfuzz.codegen import make_template
 
-            fuzz_template = DTensorFuzzTemplate()
-        elif template == "dtensor_placements":
-            from torchfuzz.codegen import DTensorFuzzPlacementsTemplate
-
-            fuzz_template = DTensorFuzzPlacementsTemplate()
-        elif template == "unbacked":
-            from torchfuzz.codegen import UnbackedFuzzTemplate
-
-            fuzz_template = UnbackedFuzzTemplate()
-        elif template == "streams":
-            from torchfuzz.codegen import StreamFuzzTemplate
-
-            fuzz_template = StreamFuzzTemplate()
-        else:
-            from torchfuzz.codegen import DefaultFuzzTemplate
-
-            fuzz_template = DefaultFuzzTemplate()
+        fuzz_template = make_template(template)
 
         # Use template's custom spec generation
         return fuzz_template.fuzz_spec_custom()

--- a/tools/experimental/torchfuzz/runner.py
+++ b/tools/experimental/torchfuzz/runner.py
@@ -4,9 +4,21 @@ This module handles running and testing generated PyTorch programs.
 """
 
 import os
-import random
 import subprocess
 import sys
+
+
+def _build_subprocess_env(*, exclude_primary_device: bool = False) -> dict[str, str]:
+    """Build the subprocess environment, applying the active plugin's hook (if any)."""
+    from torchfuzz.codegen import get_device_info
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
+
+    select_runtime_env = get_device_info().select_runtime_env
+    if select_runtime_env is not None:
+        env = select_runtime_env(env, exclude_primary_device=exclude_primary_device)
+    return env
 
 
 class ProgramRunner:
@@ -28,25 +40,7 @@ class ProgramRunner:
         abs_path = os.path.abspath(program_path)
         print(f"Running: {abs_path}")
 
-        # Select a random CUDA device if available
-        cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
-        if cuda_visible_devices:
-            devices = [d.strip() for d in cuda_visible_devices.split(",") if d.strip()]
-        else:
-            # Default to all GPUs if not set
-            try:
-                import torch
-
-                num_gpus = torch.cuda.device_count()
-                devices = [str(i) for i in range(num_gpus)]
-            except ImportError:
-                devices = []
-        env = os.environ.copy()
-        env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
-        if devices:
-            selected_device = random.choice(devices)
-            env["CUDA_VISIBLE_DEVICES"] = selected_device
-            print(f"Selected CUDA_VISIBLE_DEVICES={selected_device}")
+        env = _build_subprocess_env(exclude_primary_device=True)
 
         try:
             result = subprocess.run(
@@ -72,60 +66,3 @@ class ProgramRunner:
             print("======================")
             print(f"Program exited with code: {e.returncode}")
             sys.exit(1)
-
-    def run_and_validate(self, program_path):
-        """
-        Run a program and return detailed results for validation.
-
-        Args:
-            program_path: Path to the Python program to run
-
-        Returns:
-            dict: Dictionary with 'success', 'stdout', 'stderr', 'returncode'
-        """
-        abs_path = os.path.abspath(program_path)
-
-        # Select a random CUDA device if available
-        cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
-        if cuda_visible_devices:
-            devices = [d.strip() for d in cuda_visible_devices.split(",") if d.strip()]
-        else:
-            try:
-                import torch
-
-                num_gpus = torch.cuda.device_count()
-                if num_gpus > 1:
-                    devices = [str(i) for i in range(1, num_gpus)]
-                else:
-                    devices = [str(i) for i in range(num_gpus)]
-            except ImportError:
-                devices = []
-        env = os.environ.copy()
-        env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
-        if devices:
-            selected_device = random.choice(devices)
-            env["CUDA_VISIBLE_DEVICES"] = selected_device
-            print(f"Selected CUDA_VISIBLE_DEVICES={selected_device}")
-
-        try:
-            result = subprocess.run(
-                [sys.executable, abs_path],
-                capture_output=True,
-                text=True,
-                check=True,
-                env=env,
-            )
-            return {
-                "success": True,
-                "stdout": result.stdout,
-                "stderr": result.stderr,
-                "returncode": result.returncode,
-            }
-
-        except subprocess.CalledProcessError as e:
-            return {
-                "success": False,
-                "stdout": e.stdout,
-                "stderr": e.stderr,
-                "returncode": e.returncode,
-            }

--- a/tools/experimental/torchfuzz/tensor_descriptor.py
+++ b/tools/experimental/torchfuzz/tensor_descriptor.py
@@ -19,11 +19,14 @@ def format_tensor_descriptor(spec: Spec) -> str:
         dtype_str = str(spec.dtype).replace("torch.", "")
         return f"dtype={dtype_str}"
     elif isinstance(spec, TensorSpec):
-        # For tensors, show size, stride, dtype, and device (assuming cuda for now)
+        # For tensors, show size, stride, dtype, and device (queried from active plugin).
+        # Imported lazily to avoid an import cycle with codegen.py.
+        from torchfuzz.codegen import get_device_info
+
         size_str = str(tuple(spec.size))
         stride_str = str(tuple(spec.stride))
         dtype_str = str(spec.dtype).replace("torch.", "")
-        device_str = "cuda"  # Most fuzzing is done on GPU
+        device_str = get_device_info().device_name
 
         return f"size={size_str}, stride={stride_str}, dtype={dtype_str}, device={device_str}"
     else:

--- a/tools/experimental/torchfuzz/tensor_fuzzer.py
+++ b/tools/experimental/torchfuzz/tensor_fuzzer.py
@@ -43,31 +43,10 @@ def fuzz_torch_tensor_type(template: str = "default") -> torch.dtype:
     Returns:
         torch.dtype: A randomly selected PyTorch tensor data type based on template constraints
     """
+    # Import here to avoid circular imports
+    from torchfuzz.codegen import make_template
 
-    # Get template-specific dtypes
-    if template == "dtensor":
-        # Import here to avoid circular imports
-        from torchfuzz.codegen import DTensorFuzzTemplate
-
-        fuzz_template = DTensorFuzzTemplate()
-        tensor_dtypes = fuzz_template.supported_dtypes()
-    elif template == "dtensor_placements":
-        # Import here to avoid circular imports
-        from torchfuzz.codegen import DTensorFuzzPlacementsTemplate
-
-        fuzz_template = DTensorFuzzPlacementsTemplate()
-        tensor_dtypes = fuzz_template.supported_dtypes()
-    elif template == "unbacked":
-        # Import here to avoid circular imports
-        from torchfuzz.codegen import UnbackedFuzzTemplate
-
-        fuzz_template = UnbackedFuzzTemplate()
-        tensor_dtypes = fuzz_template.supported_dtypes()
-    else:
-        from torchfuzz.codegen import DefaultFuzzTemplate
-
-        fuzz_template = DefaultFuzzTemplate()
-        tensor_dtypes = fuzz_template.supported_dtypes()
+    tensor_dtypes = make_template(template).supported_dtypes()
 
     # Randomly select and return a data type
     return random.choice(tensor_dtypes)

--- a/tools/experimental/torchfuzz/test_streams_template.py
+++ b/tools/experimental/torchfuzz/test_streams_template.py
@@ -14,7 +14,7 @@ if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
 import torch
-from torchfuzz.codegen import convert_graph_to_python_code, StreamFuzzTemplate
+from torchfuzz.codegen import convert_graph_to_python_code, make_template
 from torchfuzz.ops_fuzzer import fuzz_operation_graph, fuzz_spec
 
 
@@ -29,15 +29,17 @@ class TestStreamsFuzzTemplate(unittest.TestCase):
         return convert_graph_to_python_code(graph, seed=seed, template="streams")
 
     def test_template_inherits_default_ops(self):
-        template = StreamFuzzTemplate()
+        template = make_template("streams")
         self.assertGreater(len(template.supported_ops), 0)
         self.assertIn("torch.add", template.supported_ops)
         self.assertIn("torch.matmul", template.supported_ops)
 
     def test_template_uses_backward_check(self):
-        from torchfuzz.checks import EagerVsFullGraphDynamicCompileWithBackwardCheck
+        from torchfuzz.cuda._checks import (
+            EagerVsFullGraphDynamicCompileWithBackwardCheck,
+        )
 
-        template = StreamFuzzTemplate()
+        template = make_template("streams")
         self.assertIsInstance(
             template.check, EagerVsFullGraphDynamicCompileWithBackwardCheck
         )


### PR DESCRIPTION
Summary:

torchfuzz today hardcodes CUDA throughout its codebase: templates emit
`torch.set_default_device("cuda")`, the runner enumerates GPUs via
`torch.cuda.device_count()`, tensor descriptors hardcode `device=cuda`,
and the constant operator branches on template-name strings to wrap
tensors with `DTensor.from_local(..., device="cuda")`. Template dispatch
is duplicated as an if/elif/else chain in four call sites, and template
names are repeated in argparse choices.

This diff introduces a device plugin architecture that moves all
CUDA-specific behaviour into a new `torchfuzz/cuda/` package while
keeping the core fuzzer device-agnostic. The mechanism:

1. **Plugin protocol** — A device plugin is any importable Python module
   that exposes `register_codegen() -> dict[str, type[FuzzTemplate]]`
   and `get_device_info() -> DeviceInfo`. The core loads the plugin via
   `importlib.import_module(os.environ.get("TORCHFUZZ_DEVICE_MODULE",
   "torchfuzz.cuda"))`.

2. **Plugin registry** — `codegen.py` gains `initialize_codegen()`,
   `get_template_names()`, `make_template(name)`, and
   `get_device_info()`. All four former dispatch chains now go through
   `make_template()`. Registration is lazy (inside
   `initialize_codegen()`, never at import time) per fbsource lazy-
   import guidelines.

3. **FuzzTemplate hooks** — Template-name string checks
   (`if template == "dtensor_placements":` etc.) are replaced by
   overridable methods on FuzzTemplate:
   - `treat_constant_as_global()` — lifts constants to function args
   - `wrap_body(lines, graph)` — CUDA stream wrapping
   - `return_codegen(final_var_name)` — DTensor .abs() vs .real
   - `codegen_constant(output_name, expr)` — DTensor.from_local wrapping
   - `args_codegen(arg_ops, constant_ops)` — accepts constants for
     templates that opt in

4. **CUDA plugin** (`torchfuzz/cuda/`) — Contains the 5 FuzzTemplate
   subclasses (moved from codegen.py), the 3 Check subclasses (moved
   from checks.py), and the `_select_cuda_device` runtime-env hook
   (extracted from runner.py). The plugin `__init__.py` carries the
   authoritative hook-table documentation for plugin authors.

5. **Peripheral modules updated**:
   - `runner.py` — delegates env setup to `DeviceInfo.select_runtime_env`
   - `tensor_descriptor.py` — uses `get_device_info().device_name`
   - `operators/constant.py` — `set_template()` accepts a FuzzTemplate
     instance; delegates wrapping to `template.codegen_constant()`
   - `fuzzer.py` — calls `initialize_codegen()` once; argparse choices
     come from `get_template_names()`
   - `checks.py` — only the Check ABC remains
   - `__init__.py` — exports the plugin API surface

6. **README** — adds a "Device Plugins" section with the contract, a
   worked XPU skeleton example, and the customization-location table.
   Templates/Checks sections reframed as plugin-owned. Missing
   DTensor Placements and Streams template docs added.

7. **Bug fix** — `FuzzTemplate.fuzz_spec_custom()` previously called
   `fuzz_torch_tensor_type("default")` regardless of the actual
   template, ignoring the template's own `supported_dtypes()`.
   Now uses `random.choice(self.supported_dtypes())`.

After this change:
- The core torchfuzz package contains no "cuda" literals (outside the
  default plugin module name and documentation).
- No template-name string dispatch chains remain in core code.
- New device support (MTIA, XPU, ...) is added by writing a sibling
  plugin package and setting TORCHFUZZ_DEVICE_MODULE.

Test Plan:
- `arc lint -a` clean on all modified/new files
- `buck2 build fbcode//caffe2/tools/experimental/torchfuzz:torchfuzz` succeeds
- `buck2 run ... -- --help` lists the same 5 template choices from the plugin
- Smoke runs for all 5 templates (default, dtensor, dtensor_placements,
  unbacked, streams) generate correct device-specific code verified by
  inspecting the emitted Python programs
- Grep audits confirm zero `template == "..."` checks outside README,
  zero direct template class instantiations outside cuda/, and no stray
  cuda literals in core modules
- Ran a simple `-seed 1` run successfully on an A100 host.
- Ran an e2e fuzz with the mtia plugin implemented in D102795789

Reviewed By: bobrenjc93

Differential Revision: D102795790


