### PR TITLE
Fix the torchcomms backed device mesh tests

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -73,6 +73,11 @@ def _with_torchcomm_env(func):
         os.environ["TORCHCOMM_RANK"] = str(self.rank)
         os.environ["TORCHCOMM_SIZE"] = str(self.world_size)
         os.environ["TORCHCOMM_STORE_PATH"] = self.file_name
+        # torchcomms' StoreManager unconditionally requires MASTER_ADDR /
+        # MASTER_PORT (TORCHCOMM_STORE_PATH no longer suffices after the
+        # StoreManager refactor in torchcomms #971).
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "25901"
         try:
             return func(self, *args, **kwargs)
         finally:
@@ -1520,11 +1525,11 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
     @unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
     @dist_config.patch(use_torchcomms=True)
     @_with_torchcomm_env
-    @with_comms(backend="cpu:gloo,cuda:ncclx")
+    @with_comms(backend="cpu:gloo,cuda:nccl")
     def test_pg_api_w_torchcomms(self) -> None:
         ranks = list(range(self.world_size))
         pg = new_group(
-            backend="cpu:gloo,cuda:ncclx",
+            backend="cpu:gloo,cuda:nccl",
             ranks=ranks,
             group_desc="new_pg",
         )
@@ -1543,14 +1548,42 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
         )
         self.assertEqual(gpu_tensor, expected_gpu_tensor)
 
+        # No-op split should preserve both backends and produce identical
+        # results to the parent.
+        split_group_no_op = dist.split_group(pg, [ranks])
+        cpu_tensor = torch.ones(3, 3)
+        dist.all_reduce(cpu_tensor, group=split_group_no_op)
+        self.assertEqual(cpu_tensor, expected_cpu_tensor)
+        gpu_tensor = torch.ones(3, 3, device=self.device_type)
+        dist.all_reduce(gpu_tensor, group=split_group_no_op)
+        self.assertEqual(gpu_tensor, expected_gpu_tensor)
+
+        # Real split with multiple sub-groups; each sub-group must keep both
+        # cpu:gloo and cuda:nccl backends and dispatch to the right one based
+        # on tensor device.
+        pg_ranks_by_dim = torch.arange(self.world_size).view(2, 4)
+        split_pg = dist.split_group(pg, pg_ranks_by_dim.tolist())
+        expected_split_size = self.world_size // 2
+
+        cpu_tensor = torch.ones(3, 3)
+        dist.all_reduce(cpu_tensor, group=split_pg)
+        self.assertEqual(cpu_tensor, torch.ones(3, 3) * expected_split_size)
+
+        gpu_tensor = torch.ones(3, 3, device=self.device_type)
+        dist.all_reduce(gpu_tensor, group=split_pg)
+        self.assertEqual(
+            gpu_tensor,
+            torch.ones(3, 3, device=self.device_type) * expected_split_size,
+        )
+
     @unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
     @dist_config.patch(use_torchcomms=True)
     @_with_torchcomm_env
-    @with_comms(backend="cuda:ncclx")
-    def test_pg_api_w_torchcomms_ncclx(self) -> None:
+    @with_comms(backend="nccl")
+    def test_pg_api_w_torchcomms_nccl(self) -> None:
         ranks = list(range(self.world_size))
         pg = new_group(
-            backend="cuda:ncclx",
+            backend="nccl",
             ranks=ranks,
             group_desc="new_pg",
         )
@@ -1595,7 +1628,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
     @unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
     @dist_config.patch(use_torchcomms=True)
     @_with_torchcomm_env
-    @with_comms(backend="cpu:gloo,cuda:ncclx")
+    @with_comms(backend="cpu:gloo,cuda:nccl")
     def test_device_mesh_w_torchcomms(self) -> None:
         mesh_shape = (2, 2, self.world_size // 4)
         mesh_3d = init_device_mesh(

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2067,8 +2067,17 @@ def _new_process_group_helper(
                 backend_str,
             )
             # TODO: figure out pg option conversion for torchComms.
+            # `persistent_store=true` tells torchcomms to reuse the c10d-side
+            # `backend_prefix_store` directly instead of constructing its own
+            # TCPStore via StoreManager (which would otherwise require an
+            # explicit MASTER_ADDR/MASTER_PORT and conflict with the c10d
+            # rendezvous store on rapid re-binds).
             comm = new_comm(
-                backend_str, torch_device, name=group_name, store=backend_prefix_store
+                backend_str,
+                torch_device,
+                name=group_name,
+                store=backend_prefix_store,
+                hints={"persistent_store": "true"},
             )
             buffer_size = os.environ.get(
                 "TORCH_FR_BUFFER_SIZE",


### PR DESCRIPTION
Fixes the torchcomms-enabled tests in test_device_mesh.py and adds a multi-backend split coverage case.

After the torchcomms StoreManager refactor https://github.com/meta-pytorch/torchcomms/pull/971,  `TORCHCOMM_STORE_PATH` is no longer honored 


This PR:

1. Sets `MASTER_ADDR` and `MASTER_PORT` to use TCP store instead
2. Passes hints={"persistent_store": "true"} to use persistent store
3. Extends test_pg_api_w_torchcomms (hybrid `cpu:gloo,cuda:ncclx` parent) to also cover dist.split_group:
  - No-op split (all ranks) — verifies both cpu and gpu allreduce on the child match the parent.
  - 2x4 split — verifies each sub-group retains both backends and dispatches correctly per tensor device.

Test plan

```
pytest -vvs test/distributed/test_device_mesh.py -k torchcomms
```

Getting ready for torchcomms cobuild with pytorch 