### PR TITLE
 [Inductor][Triton] Enable decompose_k and use Triton for inner BMM on HIP (#181748) (#181748)

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1777,9 +1777,15 @@ class TestMaxAutotune(TestCase):
                     "decompose_k"
                 ).run(code[0])
             else:
-                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                    "triton_.*_fused_.*.run"
-                ).check("decompose_k").run(code[0])
+                fc = FileCheck()
+                # On ROCm the inner bmm in decompose_k uses a Triton
+                # template instead of the ATen extern kernel, and the
+                # fused kernel naming differs.
+                if not torch.version.hip:
+                    fc = fc.check("extern_kernels.bmm_dtype").check_regex(
+                        "triton_.*_fused_.*.run"
+                    )
+                fc.check("decompose_k").run(code[0])
                 check_divisors(code)
                 torch.testing.assert_close(out, a @ b, atol=atol, rtol=rtol)
 
@@ -1791,9 +1797,12 @@ class TestMaxAutotune(TestCase):
                     "decompose_k"
                 ).run(code[0])
             else:
-                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                    "triton_.*_fused_.*.run"
-                ).check("decompose_k").run(code[0])
+                fc = FileCheck()
+                if not torch.version.hip:
+                    fc = fc.check("extern_kernels.bmm_dtype").check_regex(
+                        "triton_.*_fused_.*.run"
+                    )
+                fc.check("decompose_k").run(code[0])
                 check_divisors(code)
                 torch.testing.assert_close(
                     compiled_func(a, b), (a @ b).relu(), atol=atol, rtol=rtol
@@ -1811,9 +1820,12 @@ class TestMaxAutotune(TestCase):
                     "decompose_k"
                 ).run(code[0])
             else:
-                FileCheck().check("extern_kernels.bmm_dtype").check_regex(
-                    "triton_.*_fused_.*_0.run"
-                ).check("decompose_k").run(code[0])
+                fc = FileCheck()
+                if not torch.version.hip:
+                    fc = fc.check("extern_kernels.bmm_dtype").check_regex(
+                        "triton_.*_fused_.*_0.run"
+                    )
+                fc.check("decompose_k").run(code[0])
                 check_divisors(code)
                 torch.testing.assert_close(
                     compiled_func(a, b),
@@ -1827,6 +1839,57 @@ class TestMaxAutotune(TestCase):
             )
             torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = (
                 bf16_red_setting
+            )
+
+    @unittest.skipIf(
+        config.cpp_wrapper, "decompose_k not supported for cpp_wrapper yet"
+    )
+    @unittest.skipIf(
+        config.triton.native_matmul,
+        "ignore decompose_k when native matmul codegen",
+    )
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    @parametrize("sizes", ((32, 32, 32768), (64, 128, 200000)))
+    @config.patch(
+        max_autotune=True,
+        max_autotune_gemm_backends="TRITON",
+        comprehensive_padding=False,
+        shape_padding=False,
+    )
+    def test_max_autotune_decompose_k_addmm(self, sizes, dtype):
+        with config.patch(_DECOMPOSE_K_PATCH_ROCM):
+            M, N, K = sizes
+
+            atol = 1e-2
+            rtol = 1e-2
+            a, b = self._make_matrices(
+                M,
+                K,
+                N,
+                dtype=dtype,
+                device=GPU_TYPE,
+                requires_grad=False,
+            )
+            bias = torch.randn(N, dtype=dtype, device=GPU_TYPE)
+
+            compiled_func = torch.compile(lambda a, b, bias: torch.addmm(bias, a, b))
+            out, code = run_and_get_code(compiled_func, a, b, bias)
+            FileCheck().check("decompose_k").run(code[0])
+            torch.testing.assert_close(
+                out, torch.addmm(bias, a, b), atol=atol, rtol=rtol
+            )
+
+            # Test with non-unit alpha/beta
+            compiled_func = torch.compile(
+                lambda a, b, bias: torch.addmm(bias, a, b, alpha=0.5, beta=2.0)
+            )
+            out, code = run_and_get_code(compiled_func, a, b, bias)
+            FileCheck().check("decompose_k").run(code[0])
+            torch.testing.assert_close(
+                out,
+                torch.addmm(bias, a, b, alpha=0.5, beta=2.0),
+                atol=atol,
+                rtol=rtol,
             )
 
     @unittest.skipIf(

--- a/test/inductor/test_subgraph_choice.py
+++ b/test/inductor/test_subgraph_choice.py
@@ -56,11 +56,7 @@ class TestSubgraphChoice(TestCase):
 
             kPartitions = 256
 
-            decompose_k_subgraph_template = (
-                torch._inductor.kernel.mm.DecomposeKSugraphTemplate()
-            )
-
-            decompose_k_subgraph_template.maybe_append_choice(
+            torch._inductor.kernel.mm.decompose_k_subgraph_template.maybe_append_choice(
                 choices,
                 k_split=kPartitions,
                 input_nodes=(mat1, mat2),
@@ -125,11 +121,7 @@ class TestSubgraphChoice(TestCase):
 
             kPartitions = 2
 
-            decompose_k_subgraph_template = (
-                torch._inductor.kernel.mm.DecomposeKSugraphTemplate()
-            )
-
-            decompose_k_subgraph_template.maybe_append_choice(
+            torch._inductor.kernel.mm.decompose_k_subgraph_template.maybe_append_choice(
                 choices,
                 k_split=kPartitions,
                 input_nodes=(mat1, mat2),

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -204,11 +204,14 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
 
         with V.set_graph_handler(bm_graph_lowering):
             # Apply config_patches during benchmarking (e.g., coordinate_descent_tuning)
-            # Also disable max_autotune to avoid nested autotuning
+            # Also disable max_autotune to avoid nested autotuning.
+            # On AMD/HIP only use Triton
+            # On NVIDIA, hard coded to ATen always
             benchmark_config: dict[str, Any] = {
                 "max_autotune": False,
-                "max_autotune_gemm": False,
-                "max_autotune_gemm_backends": "ATEN",
+                "max_autotune_gemm": bool(torch.version.hip),
+                "max_autotune_gemm_backends": "TRITON" if torch.version.hip else "ATEN",
+                **({"triton.num_decompose_k_splits": 0} if torch.version.hip else {}),
                 "benchmark_fusion": False,
                 "pipeline_max_autotune_gemm": False,
                 **self.config_patches,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2066,17 +2066,14 @@ class triton:
     disallow_failing_autotune_kernels_TESTING_ONLY = False
 
     # specify number of splits to autotune on for decompose_k. 0 disables decompose_k
-    # Disabled on ROCm by default pending performance validation.
     num_decompose_k_splits = int(
-        os.environ.get(
-            "TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "0" if torch.version.hip else "10"
-        )
+        os.environ.get("TORCHINDUCTOR_NUM_DECOMPOSE_K_SPLITS", "10")
     )
 
     # specify minimum ratio of K to M AND N in order to autotune on decompose_k. 0 enables
     # it as an autotuning choice for all matmuls
     decompose_k_threshold = int(
-        os.environ.get("TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD", "32")
+        os.environ.get("TORCHINDUCTOR_DECOMPOSE_K_THRESHOLD", "20")
     )
 
     # Programmatic Dependent Launch improves launch latency on Nvidia Hopper+ devices

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7712,11 +7712,16 @@ class SubgraphBuffer(ExternKernel):
         import torch._inductor.config as inductor_config
 
         with V.set_graph_handler(self.subgraph):
-            # Base config: don't autotune Triton, but allow other optimizations
+            # Base config: don't autotune Triton, but allow other optimizations.
+            # On AMD/HIP, use Triton for the inner BMM as it outperforms
+            # cuBLAS-equivalent (rocBLAS) for the batched shapes produced by
+            # decompose_k. On NVIDIA, ATen (cuBLAS) is used instead.
+            # num_decompose_k_splits=0 prevents recursive decompose_k.
             base_patches = {
                 "max_autotune": False,
-                "max_autotune_gemm": False,
-                "max_autotune_gemm_backends": "ATEN",
+                "max_autotune_gemm": bool(torch.version.hip),
+                "max_autotune_gemm_backends": "TRITON" if torch.version.hip else "ATEN",
+                **({"triton.num_decompose_k_splits": 0} if torch.version.hip else {}),
             }
             # Merge with user config_patches (e.g., coordinate_descent_tuning)
             merged_patches: dict[str, Any] = {**base_patches, **(config_patches or {})}

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -207,7 +207,8 @@ def check_supported_striding(mat_a, mat_b) -> None:
 aten_bias_addmm = ExternKernelChoice(bias_addmm, None)
 
 
-def decomposeK(a, b, k_splits):
+def _decomposeK_core(a, b, k_splits):
+    """Shared core: reshape, batched matmul, sum-reduce over the split dimension."""
     m = a.shape[0]
     n = b.shape[1]
     k = a.shape[1]
@@ -217,33 +218,43 @@ def decomposeK(a, b, k_splits):
     a_reshaped = torch.permute(a.reshape(m, B, k_parts), (1, 0, 2))
     b_reshaped = b.reshape(B, k_parts, n)
     result = torch.bmm(a_reshaped, b_reshaped, out_dtype=torch.float32)
-    reduced_buf = torch.sum(result, 0)
-    return reduced_buf.to(a.dtype)
+    return torch.sum(result, 0)
 
 
-class DecomposeKSugraphTemplate(SubgraphTemplate):
-    def __init__(self):
-        super().__init__(
-            name="decompose_k",
-        )
+def decomposeK(a, b, k_splits):
+    return _decomposeK_core(a, b, k_splits).to(a.dtype)
+
+
+def decomposeK_addmm(bias, a, b, k_splits, alpha=1, beta=1):
+    reduced_buf = _decomposeK_core(a, b, k_splits)
+    out = reduced_buf * alpha + bias.float() * beta
+    return out.to(a.dtype)
+
+
+class DecomposeKSubgraphTemplate(SubgraphTemplate):
+    def __init__(self, name: str, op_name: str, fn: Any):
+        self.op_name = op_name
+        self.fn = fn
+        super().__init__(name=name)
 
     def generate(  # type: ignore[override]
         self,
         input_nodes: list[Buffer],
         layout: Layout,
         k_split: int,
+        **kwargs: Any,
     ) -> SubgraphChoiceCaller:
         from torch._dispatch.python import enable_python_dispatcher
 
         from ..decomposition import select_decomp_table
 
-        name = f"decompose_k_mm_{k_split}_split"
+        name = f"decompose_k_{self.op_name}_{k_split}_split"
         description = f"{k_split=}"
 
         with enable_python_dispatcher():
             decompositions = select_decomp_table()
             fn = make_fx(
-                functools.partial(decomposeK, k_splits=k_split),
+                functools.partial(self.fn, k_splits=k_split, **kwargs),
                 decompositions,
             )
 
@@ -256,7 +267,12 @@ class DecomposeKSugraphTemplate(SubgraphTemplate):
             )
 
 
-decompose_k_subgraph_template = DecomposeKSugraphTemplate()
+decompose_k_subgraph_template = DecomposeKSubgraphTemplate(
+    "decompose_k", "mm", decomposeK
+)
+decompose_k_addmm_subgraph_template = DecomposeKSubgraphTemplate(
+    "decompose_k_addmm", "addmm", decomposeK_addmm
+)
 
 
 class ContiguousTemplate(SubgraphTemplate):

--- a/torch/_inductor/template_heuristics/decompose_k.py
+++ b/torch/_inductor/template_heuristics/decompose_k.py
@@ -5,7 +5,10 @@ from typing import Any, TYPE_CHECKING
 import sympy
 
 from ..ir import get_free_symbols
-from ..kernel.mm import decompose_k_subgraph_template
+from ..kernel.mm import (
+    decompose_k_addmm_subgraph_template,
+    decompose_k_subgraph_template,
+)
 from ..kernel_inputs import KernelInputs, MMKernelInputs
 from ..utils import get_k_splits
 from ..virtualized import V
@@ -19,6 +22,9 @@ if TYPE_CHECKING:
 
 
 @register_template_heuristic(decompose_k_subgraph_template.uid, None, op_name="mm")
+@register_template_heuristic(
+    decompose_k_addmm_subgraph_template.uid, None, op_name="addmm"
+)
 class EmptyDecomposeKConfigHeuristics(TemplateConfigHeuristics):
     """empty heuristics to skip decompose k on anything not cuda"""
 
@@ -35,23 +41,21 @@ class EmptyDecomposeKConfigHeuristics(TemplateConfigHeuristics):
     "cuda",
     op_name="mm",
 )
-# TODO(coconutruben): enable decompose k on other devices (xpu, cpu, mps, mtia)
-# by either adding specific register_template_heuristic tags, or setting the
-# device to None (enabled on all devices)
+@register_template_heuristic(
+    decompose_k_addmm_subgraph_template.uid,
+    "cuda",
+    op_name="addmm",
+)
 class DecomposeKConfigHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
     def _get_template_configs_impl(
         self,
         kernel_inputs: KernelInputs,
         op_name: str,
     ) -> Generator[dict[str, Any], None, None]:
-        """
-        Get all the valid k_splits for the given m, n, k.
-        """
         assert isinstance(kernel_inputs, MMKernelInputs), (
             f"{self.__class__.__name__} requires MMKernelInputs"
         )
 
-        # Check for unbacked symbols - if found, yield nothing
         unbacked_symbols = any(
             len(get_free_symbols(itr, unbacked_only=True)) > 0
             for itr in (
@@ -70,3 +74,15 @@ class DecomposeKConfigHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
             ):
                 continue
             yield {"k_split": k_split}
+
+    def get_extra_kwargs(
+        self,
+        kernel_inputs: KernelInputs,
+        op_name: str,
+    ) -> dict[str, Any]:
+        if op_name == "addmm":
+            return {
+                "alpha": kernel_inputs.get_scalar("alpha"),
+                "beta": kernel_inputs.get_scalar("beta"),
+            }
+        return {}


### PR DESCRIPTION
Summary:
Enable `decompose_k` on AMD/ROCm by removing the conditional that disabled it (previously defaulted `num_decompose_k_splits` to 0 on HIP). Both NVIDIA and AMD now default to 10 splits.

On HIP, the inner BMM produced by `decompose_k` is routed through a Triton template (`max_autotune_gemm_backends="TRITON"`) since it outperforms the rocBLAS equivalent for the batched shapes generated by the split. On NVIDIA, ATen/cuBLAS remains the backend. A guard (`num_decompose_k_splits=0`) is also applied on HIP to prevent recursive decompose_k.

Add `decompose_k_addmm` support so the bias addition from addmm is fused into the decompose_k subgraph. The new `decomposeK_addmm` function traces bmm + sum + alpha*result + beta*bias through `make_fx`, allowing inductor's fusion passes to collapse the sum, scaling, and bias add into a single kernel. A corresponding `DecomposeKSubgraphTemplate` and heuristic wire this into `tuned_addmm` as an autotuning choice.

Some benchmarking analysis on MI350 shows:
~1.0x 1024x20480x1024 (K/N=20)
K/N threshold ~20, decompose_k_addmm consistently delivers ~1.27-1.4x speedups for tested sizes
1.38x speedup over Aten for 1024x6144x41312 (K/N = 23)
1.3x speedup over Aten for 1024x184320x6144 (K/N=30)
1.27x for K/N=40


Test Plan: TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 buck test fbcode//mode/opt-amd-gpu fbcode//caffe2/test/inductor:max_autotune_amd -- test_max_autotune_decompose_k_addmm --print-passing-details

Reviewed By: PaulZhang12

Differential Revision: D98028065

Pulled By: CRobeck




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo