### PR TITLE
[Xcode 26.4 SDK] Fix -Wnullable-to-nonnull-conversion

### DIFF
--- a/aten/src/ATen/native/metal/MetalContext.mm
+++ b/aten/src/ATen/native/metal/MetalContext.mm
@@ -13,6 +13,14 @@
 #import <Foundation/NSProcessInfo.h>
 #endif
 
+namespace {
+const char *nonnullUTF8(NSString *s) {
+    const char *utf8 = s.UTF8String;
+    NSCAssert(utf8, @"UTF8String returned nil");
+    return utf8;
+}
+} // namespace
+
 using namespace at::native::metal;
 @implementation MetalContext {
   std::mutex _pipelineCacheMutex;
@@ -64,8 +72,8 @@ C10_CLANG_DIAGNOSTIC_POP()
 #endif
   NSError* error = [self _compileProgram];
   if (error) {
-    std::string compilationError = error.localizedDescription.UTF8String;
-    std::string deviceInfo = self.description.UTF8String;
+    std::string compilationError = nonnullUTF8(error.localizedDescription);
+    std::string deviceInfo = nonnullUTF8(self.description);
     TORCH_CHECK(false, compilationError + "\n" + deviceInfo);
   }
   return _device && _library && _commandQueue;
@@ -82,7 +90,7 @@ C10_CLANG_DIAGNOSTIC_POP()
   TORCH_CHECK(func, "Failed to load the Metal Shader function: ", kernel);
   NSError* errors = nil;
   state = [_device newComputePipelineStateWithFunction:func error:&errors];
-  TORCH_CHECK(state, errors.localizedDescription.UTF8String);
+  TORCH_CHECK(state, nonnullUTF8(errors.localizedDescription));
   _pipelineCache[kernel] = state;
   return state;
 }
@@ -93,7 +101,7 @@ C10_CLANG_DIAGNOSTIC_POP()
   TORCH_CHECK(_library, "Failed to load Metal shaders");
   std::string kernelStr = kernel;
   for (NSUInteger i = 0; i < constants.count; ++i) {
-    kernelStr += "_" + std::string([constants[i] stringValue].UTF8String);
+    kernelStr += "_" + std::string(nonnullUTF8([constants[i] stringValue]));
   }
   std::lock_guard<std::mutex> g(_pipelineCacheMutex);
   id<MTLComputePipelineState> state = _pipelineCache[kernelStr];
@@ -129,9 +137,9 @@ C10_CLANG_DIAGNOSTIC_POP()
   id<MTLFunction> func = [_library newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()] ?: @""
                                         constantValues:constantValues
                                                  error:&errors];
-  TORCH_CHECK(func, errors.localizedDescription.UTF8String);
+  TORCH_CHECK(func, nonnullUTF8(errors.localizedDescription));
   state = [_device newComputePipelineStateWithFunction:func error:&errors];
-  TORCH_CHECK(state, errors.localizedDescription.UTF8String);
+  TORCH_CHECK(state, nonnullUTF8(errors.localizedDescription));
   _pipelineCache[kernelStr] = state;
   return state;
 }
@@ -167,7 +175,5 @@ C10_CLANG_DIAGNOSTIC_POP()
   });
   return compilationError;
 }
-
-
 
 @end

--- a/aten/src/ATen/native/metal/MetalDevice.h
+++ b/aten/src/ATen/native/metal/MetalDevice.h
@@ -15,7 +15,10 @@ struct MetalDeviceInfo {
 static inline MetalDeviceInfo createDeviceInfo(id<MTLDevice> device) {
   MetalDeviceInfo device_info;
   if (device.name != nil) {
-    device_info.name = device.name.UTF8String;
+    const char* utf8_name = device.name.UTF8String;
+    if (utf8_name != nullptr) {
+      device_info.name = utf8_name;
+    }
   }
   if (@available(macOS 11.0, iOS 14.0, *)) {
     device_info.languageVersion = MTLLanguageVersion2_3;


### PR DESCRIPTION
Summary: Xcode 26.4 SDK libc++ headers include some new nullability annotations, so new compiler diagnostics are created when a std::string is initialized from a pointer that might be null. A very common case is -[NSString UTF8String] which in rare occassions might return a null pointer. Since the code seems to have been working fine until now, null pointers might not be a problem, so the changes below should not not change functionality at all.

Test Plan: tested on top of the stack

Reviewed By: mattjgalloway

Differential Revision: D102622399


