### PR TITLE
[Bugfix][Caching] Fix Caching error by avoiding failure for triton kernels in pickling error (#181463)

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3557,6 +3557,74 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         ):
             AOTAutogradCache._pickle_entry(entry, remote=False)
 
+    @requires_cuda_and_triton
+    def test_prepare_for_pickle_clears_benchmark_failure_reasons(self):
+        """prepare_for_pickle clears benchmark_failure_reasons which can hold
+        exec'd launcher keys that aren't picklable.
+        """
+        from torch._inductor.runtime.hints import (
+            AttrsDescriptorWrapper,
+            DeviceProperties,
+            HeuristicType,
+        )
+        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+        from torch._inductor.utils import triton_version_uses_attrs_dict
+
+        meta = {
+            "signature": {
+                "in_ptr0": "*fp32",
+                "out_ptr0": "*fp32",
+                "xnumel": "i32",
+            },
+            "device": DeviceProperties.create(torch.device(GPU_TYPE)),
+            "configs": [AttrsDescriptorWrapper(divisible_by_16=(0, 1), equal_to_1=())],
+            "constants": {},
+        }
+        if triton_version_uses_attrs_dict():
+            meta["signature"]["XBLOCK"] = "constexpr"
+
+        @triton.jit
+        def _add_kernel(in_ptr0, out_ptr0, xnumel, XBLOCK: tl.constexpr):
+            pid = tl.program_id(0)
+            offsets = pid * XBLOCK + tl.arange(0, XBLOCK)
+            mask = offsets < xnumel
+            x = tl.load(in_ptr0 + offsets, mask=mask)
+            tl.store(out_ptr0 + offsets, x + 1.0, mask=mask)
+
+        autotuner = CachingAutotuner(
+            fn=_add_kernel,
+            triton_meta=meta,
+            configs=[triton.Config({"XBLOCK": 128})],
+            save_cache_hook=False,
+            mutated_arg_names=[],
+            optimize_mem=True,
+            heuristic_type=HeuristicType.POINTWISE,
+            inductor_meta={"grid_type": "Grid1D"},
+        )
+
+        xnumel = 256
+        inp = torch.randn(xnumel, device=GPU_TYPE)
+        out = torch.empty_like(inp)
+        autotuner.run(inp, out, xnumel, stream=torch.cuda.current_stream().cuda_stream)
+        self.assertEqual(out, inp + 1.0)
+
+        # Inject a launcher key into benchmark_failure_reasons — this is how
+        # the leak happens in production (launcher used as dict key).
+        self.assertTrue(len(autotuner.launchers) > 0)
+        launcher_fn = autotuner.launchers[0]
+        autotuner.benchmark_failure_reasons[launcher_fn] = "test"
+
+        # The autotuner is unpicklable: __getstate__ asserts launchers are
+        # empty, and benchmark_failure_reasons holds an exec'd launcher key.
+        with self.assertRaises((pickle.PicklingError, AttributeError, AssertionError)):
+            pickle.dumps(autotuner)
+
+        # prepare_for_pickle clears benchmark_failure_reasons (and other
+        # unpicklable fields), making pickle succeed.
+        autotuner.prepare_for_pickle()
+        self.assertEqual(autotuner.benchmark_failure_reasons, {})
+        pickle.dumps(autotuner)
+
     def test_nested_tensor_subclass_cache_key(self):
         ctx = multiprocessing.get_context("spawn")
         results = []

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -681,7 +681,7 @@ class CachingAutotuner(KernelInterface):
             raise RuntimeError(f"No valid triton configs. {type(exc).__name__}: {exc}")
         self.launchers = launchers
 
-    def prepare_for_pickle(self) -> tuple[Any, Any, Any, Any, Any, Any]:
+    def prepare_for_pickle(self) -> tuple[Any, ...]:
         """Drop stuff from triton.JITFunction that does not pickle.
         This must be called after precompile so that these things are no longer needed.
         Returns a tuple of old values
@@ -693,18 +693,18 @@ class CachingAutotuner(KernelInterface):
             self.fn.repr,
             self.launchers,
             getattr(self.fn, "_hash_lock", None),
+            self.benchmark_failure_reasons,
         )
         self.fn.fn = None
         self.fn.__globals__ = None
         self.fn.used_global_vals = None
         self.fn.repr = _ConstRepr(self.fn.repr(self.fn))
         self.launchers = []
+        self.benchmark_failure_reasons = {}
         self.fn._hash_lock = None
         return old_values
 
-    def restore_after_unpickle(
-        self, old_values: tuple[Any, Any, Any, Any, Any, Any] | None
-    ) -> None:
+    def restore_after_unpickle(self, old_values: tuple[Any, ...] | None) -> None:
         if old_values:
             (
                 self.fn.fn,
@@ -713,6 +713,7 @@ class CachingAutotuner(KernelInterface):
                 self.fn.repr,
                 self.launchers,
                 self.fn._hash_lock,
+                self.benchmark_failure_reasons,
             ) = old_values
         else:
             # even if we don't need/have specific values, we do need the


### PR DESCRIPTION
Cherrypick of https://github.com/pytorch/pytorch/pull/181463


Fixes https://github.com/pytorch/pytorch/issues/180911

  - AOTAutogradCache.save(): Catch pickle.PicklingError from triton kernel and treat it as a bypass (warn + continue) instead of a fatal error. The cache is an optimization — failing to save shouldn't kill compilation.

```bash
pytest test/dynamo/test_aot_autograd_cache.py -xvs -k test_save_bypasses_triton_launcher_pickle_error && pytest test/dynamo/test_aot_autograd_cache.py -xvs -k test_triton_launcher_pickle_bypass_e2e
```

```bash
with-proxy pytest tests/compile/fullgraph/test_full_graph.py::test_custom_compile_config[compilation_config8-meta-llama/Llama-3.2-1B-Instruct-model_kwargs8]
```
and
```
vllm bench startup --model meta-llama/Llama-4-Scout-17B-16E-Instruct --compilation-config '{"compile_mm_encoder": true}' --tensor-parallel-size 8 --num-iters-cold 3 --num-iters-warm 3
```

*Pytorch*
```
3 passed
```

*vLLM*
Now doesn't crash; the startup command puts out warning like:
```
(Worker_TP5 pid=2922090) [rank5]:W0424 16:12:11.480000 2922090 /home/lucaskabela/pytorch/torch/_functorch/_aot_autograd/autograd_cache.py:1240] AOTAutograd cache unable to serialize compiled graph: Can't pickle <function launcher at 0x7f1c60cb2440>: attribute lookup launcher on __main__ failed
(Worker_TP1 pid=2922069) [rank1]:W0424 16:12:11.497000 2922069 /home/lucaskabela/pytorch/torch/_functorch/_aot_autograd/autograd_cache.py:1240] AOTAutograd cache unable to serialize compiled graph: Can't pickle <function launcher at 0x7f74dd23ef80>: attribute lookup launcher on __main__ failed
```

Pull Request resolved: https://github.com/pytorch/pytorch/pull/181463
Approved by: https://github.com/atalman

(cherry picked from commit fcea8749c22fd79d47529c8bb37348c86f93aa61)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98