### PR TITLE
[Inductor] Guard same_meta against non-Tensor meta values (#181752)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -7352,6 +7352,26 @@ class CommonTemplate:
 
         self.common(fn, (torch.randn(2, 4),))
 
+    def test_same_meta_non_tensor(self):
+        from torch._inductor.fx_passes.post_grad import same_meta
+
+        g = torch.fx.Graph()
+        n1 = g.create_node("placeholder", "x")
+        n2 = g.create_node("placeholder", "y")
+
+        n1.meta["val"] = torch.SymInt(42)
+        n2.meta["val"] = torch.SymInt(42)
+        self.assertFalse(same_meta(n1, n2))
+
+        n1.meta["val"] = None
+        n2.meta["val"] = torch.randn(4)
+        self.assertFalse(same_meta(n1, n2))
+
+        t = torch.randn(4)
+        n1.meta["val"] = t
+        n2.meta["val"] = t
+        self.assertTrue(same_meta(n1, n2))
+
     def test_remove_noop_slice(self):
         def f(x):
             x = x + 1

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1040,6 +1040,8 @@ def same_meta(node1: torch.fx.Node, node2: torch.fx.Node):
     return (
         val1 is not None
         and val2 is not None
+        and isinstance(val1, torch.Tensor)
+        and isinstance(val2, torch.Tensor)
         and statically_known_true(sym_eq(val1.size(), val2.size()))
         and val1.layout == val2.layout
         and val1.dtype == val2.dtype


### PR DESCRIPTION
Summary:

`same_meta` in `remove_noop_ops` unconditionally calls `.size()` on
`node.meta["val"]`, but scalar placeholder nodes (from auto dynamic shapes)
have `SymInt` or `SymFloat` values that lack `.size()`. This causes:
  `AttributeError: 'SymInt' object has no attribute 'size'`

Add `isinstance(val, torch.Tensor)` guards before accessing tensor-specific
attributes.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: mtia_sw_inductor

Test Plan:
`buck2 test fbcode//caffe2/test/inductor:test_inductor -- -r test_same_meta_non_tensor`

Result: Pass 1. Fail 0.
Test session: https://www.internalfb.com/intern/testinfra/testrun/28147497688470311

Verifies:
- `same_meta` returns False for SymInt meta values (no AttributeError)
- `same_meta` returns False when one value is None
- `same_meta` returns True for matching tensors (existing behavior preserved)

Reviewed By: sidt-meta

Differential Revision: D102820186




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo