### PR TITLE
[dynamo][guards] Fix use-after-free in recursive dict-tag tensor metadata recording

### DIFF
--- a/test/dynamo/test_guard_manager.py
+++ b/test/dynamo/test_guard_manager.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 import abc
 import functools
+import gc
 import inspect
 import weakref
 
@@ -10,6 +11,7 @@ import torch._dynamo.test_case
 from torch._C._dynamo import guards
 from torch._dynamo.convert_frame import GlobalStateGuard
 from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+from torch._dynamo.testing import CompileCounter
 from torch.testing._internal.common_utils import set_default_dtype
 
 
@@ -1356,6 +1358,37 @@ class TagSafetyChecks(RecursiveDictTagTests):
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         with install_guard_manager_testing_hook(hook):
             opt_fn(torch.randn(4, 4))
+
+    def test_recorded_tensor_freed_gracefully(self):
+        """Tensors recorded by the dict-tag fast path must not be prevented
+        from being garbage-collected.  When they *are* collected, the guard
+        should fall back to the slow path (return False) instead of crashing."""
+
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        mod = Mod()
+        weight_ref = weakref.ref(mod.linear.weight)
+        mod_ref = weakref.ref(mod)
+
+        cnt = CompileCounter()
+        opt_fn = torch.compile(mod, backend=cnt)
+        x = torch.randn(4, 4)
+        opt_fn(x)
+        self.assertEqual(cnt.frame_count, 1)
+
+        # The guard system must not prevent the module from being freed.
+        del mod, opt_fn, x
+        gc.collect()
+        self.assertIsNone(mod_ref(), "Module was kept alive by the guard system")
+        self.assertIsNone(
+            weight_ref(), "Weight tensor was kept alive by the guard system"
+        )
 
 
 class RecursiveDictGuardTests(RecursiveDictTagTests):

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -2833,7 +2833,7 @@ inline TensorCheck make_tensor_check(
 }
 
 struct RecordedTensorMetadata {
-  PyObject* tensor_ptr;
+  PyObject* tensor_wr; // weak reference to the tensor (owned)
   TensorCheck check;
 };
 
@@ -3102,13 +3102,25 @@ class GuardManager {
 
   void stash_tensor_pointers(
       PyObject* value,
-      std::vector<PyObject*> tensor_pointers) {
-    _tensor_pointers[value] = tensor_pointers;
+      std::vector<PyObject*>&& tensor_pointers) {
+    auto it = _tensor_pointers.find(value);
+    if (it != _tensor_pointers.end()) {
+      for (auto* old_wr : it->second) {
+        Py_DECREF(old_wr);
+      }
+    }
+    _tensor_pointers[value] = std::move(tensor_pointers);
   }
 
   void stash_tensor_metadata(
       PyObject* value,
       std::vector<RecordedTensorMetadata>&& tensor_metadata) {
+    auto it = _tensor_metadata_pointers.find(value);
+    if (it != _tensor_metadata_pointers.end()) {
+      for (auto& old_entry : it->second) {
+        Py_DECREF(old_entry.tensor_wr);
+      }
+    }
     _tensor_metadata_pointers[value] = std::move(tensor_metadata);
   }
 
@@ -3122,6 +3134,20 @@ class GuardManager {
   void disable_recursive_dict_tag_optimization(DictToGuardManagersMap& map) {
     unwatch_all_saved_dict_pointers(map);
     _disable_dict_tag_matching = true;
+    if (!Py_IsFinalizing()) {
+      for (auto& [key, vec] : _tensor_pointers) {
+        for (auto* wr : vec) {
+          Py_DECREF(wr);
+        }
+      }
+      for (auto& [key, vec] : _tensor_metadata_pointers) {
+        for (auto& entry : vec) {
+          Py_DECREF(entry.tensor_wr);
+        }
+      }
+    }
+    _tensor_pointers.clear();
+    _tensor_metadata_pointers.clear();
   }
 
  public:
@@ -3251,10 +3277,15 @@ class GuardManager {
       return true;
     }
     for (auto& recorded_tensor : it->second) {
-      if (!THPVariable_Check(recorded_tensor.tensor_ptr) ||
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+      PyObject* tensor_obj = PyWeakref_GET_OBJECT(recorded_tensor.tensor_wr);
+      if (tensor_obj == Py_None) {
+        // Tensor was collected; metadata cannot be verified.
+        return false;
+      }
+      if (!THPVariable_Check(tensor_obj) ||
           !recorded_tensor.check.check(
-              get_local_state(_root),
-              THPVariable_Unpack(recorded_tensor.tensor_ptr))) {
+              get_local_state(_root), THPVariable_Unpack(tensor_obj))) {
         return false;
       }
     }
@@ -3264,8 +3295,13 @@ class GuardManager {
   bool check_no_tensor_aliasing_guards_fast(PyObject* value) {
     std::shared_ptr<RelationalGuard> no_tensor_aliasing_guard =
         get_no_tensor_aliasing_guard(_root);
-    for (auto* tensor_pointer : _tensor_pointers[value]) {
-      if (!no_tensor_aliasing_guard->check_nopybind(tensor_pointer)) {
+    for (auto* wr : _tensor_pointers[value]) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+      PyObject* tensor_obj = PyWeakref_GET_OBJECT(wr);
+      if (tensor_obj == Py_None) {
+        return false;
+      }
+      if (!no_tensor_aliasing_guard->check_nopybind(tensor_obj)) {
         return false;
       }
     }
@@ -4033,7 +4069,13 @@ class RootGuardManager : public GuardManager {
     _is_recording_dict_pointers = false;
     _current_tag_safe_root = nullptr;
     _recorded_dict_pointers.clear();
+    for (auto* wr : _recorded_tensor_pointers) {
+      Py_DECREF(wr);
+    }
     _recorded_tensor_pointers.clear();
+    for (auto& entry : _recorded_tensor_metadata) {
+      Py_DECREF(entry.tensor_wr);
+    }
     _recorded_tensor_metadata.clear();
   }
 
@@ -4043,7 +4085,7 @@ class RootGuardManager : public GuardManager {
       _current_tag_safe_root->stash_dict_pointers(
           value, _recorded_dict_pointers);
       _current_tag_safe_root->stash_tensor_pointers(
-          value, _recorded_tensor_pointers);
+          value, std::move(_recorded_tensor_pointers));
       _current_tag_safe_root->stash_tensor_metadata(
           value, std::move(_recorded_tensor_metadata));
     }
@@ -4060,12 +4102,22 @@ class RootGuardManager : public GuardManager {
   }
 
   void record_tensor_pointer(PyObject* tensor_pointer) {
-    _recorded_tensor_pointers.push_back(tensor_pointer);
+    PyObject* wr = PyWeakref_NewRef(tensor_pointer, nullptr);
+    if (!wr) {
+      PyErr_Clear();
+      return;
+    }
+    _recorded_tensor_pointers.push_back(wr);
   }
 
   void record_tensor_metadata(PyObject* tensor_pointer) {
+    PyObject* wr = PyWeakref_NewRef(tensor_pointer, nullptr);
+    if (!wr) {
+      PyErr_Clear();
+      return;
+    }
     _recorded_tensor_metadata.push_back(RecordedTensorMetadata{
-        tensor_pointer,
+        wr,
         make_tensor_check(_local_state, THPVariable_Unpack(tensor_pointer)),
     });
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181753

## Motivation

The dict-tag fast path in the guard system stores raw `PyObject*` pointers
to tensors in `_tensor_pointers` and `_tensor_metadata_pointers`.  When a
tensor is freed and its memory reused by another object,
`check_tensor_metadata_fast` dereferences the dangling pointer, causing a
segfault. This was observed in the speech_transformer benchmark on XPU
(intel/torch-xpu-ops#3434) but not xpu specific.

## Solution

Replace raw `PyObject*` with `PyWeakref_NewRef` weak references. When a
tensor is garbage-collected, `PyWeakref_GET_OBJECT` returns `Py_None`
instead of a dangling pointer, so the fast path safely returns `false` and
falls back to the slow path. This avoids the crash without preventing
tensors from being freed (unlike a Py_INCREF approach that would break
test_release_module_memory).

Key changes:
- `record_tensor_pointer`/`record_tensor_metadata`: create weakrefs
- `check_tensor_metadata_fast`/`check_no_tensor_aliasing_guards_fast`:
  resolve weakrefs, bail to slow path if dead
- `stash_*`/`disable_*`/`reset_*`: properly Py_DECREF owned weakrefs

## Test plan

- test_release_module_memory: PASS
- test_release_module_memory_dynamic_shapes: PASS
- test_guard_manager (77 tests): PASS
- speech_transformer on XPU: PASS (1.46x, no segfault, 10/10 iters)

Co-authored-by: Claude (Anthropic AI)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98