### PR TITLE
[Docs] Replace outdated flake8 and git-pre-commit references with lintrunner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1209,15 +1209,10 @@ Note: There's a [compilation issue](https://github.com/uxlfoundation/oneDNN/issu
 
 PyTorch uses [lintrunner](https://github.com/pytorch/pytorch/wiki/lintrunner)
 for linting, which runs clang-tidy and other checks. You can lint your changes
-locally with:
+locally with `spin`:
 
 ```bash
-make lint
-```
-
-or use `spin` for finer control:
-
-```bash
+spin lint        # run default lint on all files
 spin quicklint   # lint files changed in the latest commit and working directory
 spin quickfix    # auto-fix lint issues on changed files
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1207,26 +1207,24 @@ Note: There's a [compilation issue](https://github.com/uxlfoundation/oneDNN/issu
 
 ## Pre-commit tidy/linting hook
 
-We use clang-tidy to perform additional
-formatting and semantic checking of code. We provide a pre-commit git hook for
-performing these checks, before a commit is created:
+PyTorch uses [lintrunner](https://github.com/pytorch/pytorch/wiki/lintrunner)
+for linting, which runs clang-tidy and other checks. You can lint your changes
+locally with:
 
-  ```bash
-  ln -s ../../tools/git-pre-commit .git/hooks/pre-commit
-  ```
+```bash
+make lint
+```
 
-If you have already committed files and
-CI reports `flake8` errors, you can run the check locally in your PR branch with:
+or use `spin` for finer control:
 
-  ```bash
-  flake8 $(git diff --name-only $(git merge-base --fork-point main))
-  ```
+```bash
+spin quicklint   # lint files changed in the latest commit and working directory
+spin quickfix    # auto-fix lint issues on changed files
+```
 
-You'll need to install an appropriately configured flake8; see
-[Lint as you type](https://github.com/pytorch/pytorch/wiki/Lint-as-you-type)
-for documentation on how to do this.
+Learn more about the linter on the [lintrunner wiki page](https://github.com/pytorch/pytorch/wiki/lintrunner).
 
-Fix the code so that no errors are reported when you re-run the above check again,
+Fix the code so that no errors are reported when you re-run the lint check again,
 and then commit the fix.
 
 ## Building PyTorch with ASAN

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1209,12 +1209,12 @@ Note: There's a [compilation issue](https://github.com/uxlfoundation/oneDNN/issu
 
 PyTorch uses [lintrunner](https://github.com/pytorch/pytorch/wiki/lintrunner)
 for linting, which runs clang-tidy and other checks. You can lint your changes
-locally with `spin`:
+locally:
 
 ```bash
-spin lint        # run default lint on all files
-spin quicklint   # lint files changed in the latest commit and working directory
-spin quickfix    # auto-fix lint issues on changed files
+lintrunner -a                # auto-fix lint issues on changed files
+lintrunner -m origin/main    # lint files changed vs main
+lintrunner --all-files       # run lint on all files
 ```
 
 Learn more about the linter on the [lintrunner wiki page](https://github.com/pytorch/pytorch/wiki/lintrunner).


### PR DESCRIPTION
Fixes #164478

The "Pre-commit tidy/linting hook" section in `CONTRIBUTING.md` referenced two items that no longer exist in the repository:
- `tools/git-pre-commit` (removed in #76984)
- `flake8` / `flake8-requirements.txt` (replaced by lintrunner in #121657)

This PR updates the section to point to the current linting workflow using `spin` commands (`spin lint`, `spin quicklint`, `spin quickfix`) and the [lintrunner wiki page](https://github.com/pytorch/pytorch/wiki/lintrunner).

cc @ZainRizvi