### PR TITLE
[Do Not Commit] Add minimal CI workflow to repro #181683

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2211,9 +2211,16 @@ elif [[ "${TEST_CONFIG}" == *operator_microbenchmark* ]]; then
 elif [[ "${TEST_CONFIG}" == *attention_microbenchmark* ]]; then
   test_attention_microbenchmark
 elif [[ "${TEST_CONFIG}" == *repro_181683* ]]; then
+  # Pre-seed the disabled-tests cache as empty so test_vmap_grad_sum_cpu
+  # (disabled via #181683) actually runs. fetch_and_cache reuses any existing
+  # file < 3h old, so the download is skipped and our empty dict wins.
+  mkdir -p test
+  echo '{}' > test/.pytorch-disabled-tests.json
   for i in 1 2 3 4 5; do
     echo "=== repro-181683 attempt ${i}/5 ==="
     NUM_TEST_SHARDS=3 test_dynamo_wrapped_shard 3 || true
+    # Re-write in case anything modified it.
+    echo '{}' > test/.pytorch-disabled-tests.json
   done
 elif [[ "${TEST_CONFIG}" == *inductor_distributed* ]]; then
   setup_torch_trace

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2210,6 +2210,11 @@ elif [[ "${TEST_CONFIG}" == *operator_microbenchmark* ]]; then
   test_operator_microbenchmark
 elif [[ "${TEST_CONFIG}" == *attention_microbenchmark* ]]; then
   test_attention_microbenchmark
+elif [[ "${TEST_CONFIG}" == *repro_181683* ]]; then
+  for i in 1 2 3 4 5; do
+    echo "=== repro-181683 attempt ${i}/5 ==="
+    NUM_TEST_SHARDS=3 test_dynamo_wrapped_shard 3 || true
+  done
 elif [[ "${TEST_CONFIG}" == *inductor_distributed* ]]; then
   setup_torch_trace
   test_inductor_distributed

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2211,16 +2211,15 @@ elif [[ "${TEST_CONFIG}" == *operator_microbenchmark* ]]; then
 elif [[ "${TEST_CONFIG}" == *attention_microbenchmark* ]]; then
   test_attention_microbenchmark
 elif [[ "${TEST_CONFIG}" == *repro_181683* ]]; then
-  # Pre-seed the disabled-tests cache as empty so test_vmap_grad_sum_cpu
-  # (disabled via #181683) actually runs. fetch_and_cache reuses any existing
-  # file < 3h old, so the download is skipped and our empty dict wins.
+  # Re-seed the disabled-tests cache as empty before each iteration so
+  # test_vmap_grad_sum_cpu (disabled via #181683) actually runs. fetch_and_cache
+  # reuses any existing file < 3h old, so freshly-seeded mtime keeps the
+  # download skipped and our empty dict wins.
   mkdir -p test
-  echo '{}' > test/.pytorch-disabled-tests.json
   for i in 1 2 3 4 5; do
     echo "=== repro-181683 attempt ${i}/5 ==="
-    NUM_TEST_SHARDS=3 test_dynamo_wrapped_shard 3 || true
-    # Re-write in case anything modified it.
     echo '{}' > test/.pytorch-disabled-tests.json
+    NUM_TEST_SHARDS=3 test_dynamo_wrapped_shard 3 || true
   done
 elif [[ "${TEST_CONFIG}" == *inductor_distributed* ]]; then
   setup_torch_trace

--- a/.github/workflows/lint-bc.yml
+++ b/.github/workflows/lint-bc.yml
@@ -2,12 +2,8 @@ name: BC Lint
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-    branches-ignore:
-      - nightly
+    paths:
+      - .github/workflows/lint-bc.yml
   push:
     tags:
       # TODO: Remove me later

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,8 @@ name: Lint
 
 on:
   pull_request:
-    branches-ignore:
-      - nightly
+    paths:
+      - .github/workflows/lint.yml
   push:
     branches:
       - main

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -2,8 +2,8 @@ name: pull
 
 on:
   pull_request:
-    branches-ignore:
-      - nightly
+    paths:
+      - .github/workflows/pull.yml
   push:
     branches:
       - main

--- a/.github/workflows/repro-181683.yml
+++ b/.github/workflows/repro-181683.yml
@@ -53,4 +53,5 @@ jobs:
       build-environment: ${{ needs.repro-build.outputs.build-environment }}
       docker-image: ${{ needs.repro-build.outputs.docker-image }}
       test-matrix: ${{ needs.repro-build.outputs.test-matrix }}
+      timeout-minutes: 360
     secrets: inherit

--- a/.github/workflows/repro-181683.yml
+++ b/.github/workflows/repro-181683.yml
@@ -1,0 +1,56 @@
+name: repro-181683
+
+on:
+  push:
+    branches:
+      - 'repro-181683*'
+  pull_request:
+    paths:
+      - .github/workflows/repro-181683.yml
+      - .ci/pytorch/test.sh
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  get-label-type:
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    if: github.repository_owner == 'pytorch'
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+      opt_out_experiments: lf
+
+  repro-build:
+    name: repro-build
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      build-environment: linux-jammy-py3.14-clang18
+      docker-image-name: ci-image:pytorch-linux-jammy-py3.14-clang18
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      test-matrix: |
+        { include: [
+          { config: "repro_181683", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+        ]}
+    secrets: inherit
+
+  repro-test:
+    name: repro-test
+    uses: ./.github/workflows/_linux-test.yml
+    needs: repro-build
+    with:
+      build-environment: ${{ needs.repro-build.outputs.build-environment }}
+      docker-image: ${{ needs.repro-build.outputs.docker-image }}
+      test-matrix: ${{ needs.repro-build.outputs.test-matrix }}
+    secrets: inherit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181757

Reproduces the flaky test_vmap_grad_sum_cpu failure on the same build
env (linux-jammy-py3.14-clang18 dynamo_wrapped shard 3) that the
original CI run used.

The test.sh branch loops the failing dynamo_wrapped shard 5x — the bug
only manifests when the full 373-test shard runs in one process; the
test passes deterministically in isolation.

Other workflows (pull.yml, lint.yml, lint-bc.yml) have their
pull_request: triggers narrowed to their own files so this PR doesn't
burn unrelated CI capacity. Not for merge.

Authored with Claude.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal