### PR TITLE
[CUDA Graph] Fix cuda_event_test missing CUDACachingAllocator::init after #176752

### DIFF
--- a/aten/src/ATen/test/cuda_event_test.cpp
+++ b/aten/src/ATen/test/cuda_event_test.cpp
@@ -3,6 +3,8 @@
 #include <ATen/cuda/CUDAEvent.h>
 #include <ATen/cuda/CUDAGraph.h>
 #include <ATen/cuda/Sleep.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAFunctions.h>
 
 TEST(CUDAEventTest, testCUDAExternalEvent) {
   if (!at::cuda::is_available()) {
@@ -33,4 +35,10 @@ TEST(CUDAEventTest, testCUDAExternalEvent) {
   graph.replay();
   at::cuda::device_synchronize();
   EXPECT_TRUE(start_event.elapsed_time(end_event) > 0);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  c10::cuda::CUDACachingAllocator::init(c10::cuda::device_count());
+  return RUN_ALL_TESTS();
 }

--- a/aten/tools/run_tests.sh
+++ b/aten/tools/run_tests.sh
@@ -51,6 +51,7 @@ run_if_exists cuda_complex_math_test
 run_if_exists cuda_cub_test
 run_if_exists cuda_atomic_ops_test
 run_if_exists cuda_allocator_test
+run_if_exists cuda_event_test
 
 if [ "$VALGRIND" == "ON" ]; then
   # NB: As these tests are invoked by valgrind, let's leave them for now as it's


### PR DESCRIPTION
`CUDAEventTest.testCUDAExternalEvent` started throwing `"Invalid device argument "` after #176752 (per-capture RNG state, 603e244): `CUDAGraph::capture_begin()` reaches `c10::cuda::CUDACachingAllocator::beginAllocateToPool(capture_dev_, ...)` → `assertValidDevice()` before anything has run `lazyInitDevice(kCUDA)`

Because the deleted `register_graph → at::empty({1}, kCUDA, kLong)` was the implicit init trigger this gtest binary depended on. 

Linux CI didn't catch it because `aten/tools/run_tests.sh` runs ATen C++ tests by hardcoded allowlist and `cuda_event_test` was added to `aten/src/ATen/test/CMakeLists.txt` in #167711 but never added to the runner, the binary has been built and silently not invoked. 

1. add a custom `main()` to `cuda_event_test.cpp` that calls `c10::cuda::CUDACachingAllocator::init(c10::cuda::device_count())` before `RUN_ALL_TESTS()`, matching the existing pattern in `cuda_cublas_handle_pool_test.cpp` / `cuda_reportMemoryUsage_test.cpp` / `cuda_allocatorTraceTracker_test.cpp` 
2. add `run_if_exists cuda_event_test` to `aten/tools/run_tests.sh` so Linux CI exercises this binary going forward. 

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng @nkhasbag-nv