### PR TITLE
add explicit template arguments in cccl_counting_iterator

### DIFF
--- a/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
+++ b/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu
@@ -304,7 +304,7 @@ Tensor embedding_backward_cuda_kernel(
   int64_t *num_of_segments_ptr = num_of_segments_tensor.mutable_data_ptr<int64_t>();
   AT_DISPATCH_INDEX_TYPES(orig_indices.scalar_type(), "embedding_backward_cuda_kernel", [&] () {
     cuda::cub::unique_by_key(
-      sorted_indices.const_data_ptr<index_t>(), cccl_counting_iterator{0},
+      sorted_indices.const_data_ptr<index_t>(), cccl_counting_iterator<index_t>{0},
       segment_offsets.mutable_data_ptr<index_t>(),
       num_of_segments_ptr, sorted_indices.numel());
   });


### PR DESCRIPTION
This change fixes a build error in `cccl_counting_iterator{0}` without explicit template arguments. When clang is configured  with `-Wctad-maybe-unsupported`, it treats class template argument deduction as an error.
```
third_party/py/torch/aten/src/ATen/native/cuda/EmbeddingBackwardKernel.cu:307:49: error: 'cccl_counting_iterator' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]
  307 |       sorted_indices.const_data_ptr<index_t>(), cccl_counting_iterator{0},
```