### PR TITLE
Raise clear error when register_hook inside checkpoint mutates a buffer

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7732,9 +7732,61 @@ def forward(self, primals_1, tangents_1):
         m = MyModule()
         x = torch.randn(2, 64, device="cuda", requires_grad=True)
         opt_m = torch.compile(m, backend="aot_eager", fullgraph=True)
-        out = opt_m(x)
-        out.sum().backward()
-        self.assertEqual(out.shape, torch.Size([2, 64]))
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "mutated in both the forward and backward",
+        ):
+            opt_m(x)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA is unavailable")
+    def test_register_hook_in_checkpoint_inside_autograd_function(self):
+        stats_buffer = torch.zeros(10, device="cuda")
+
+        def log_stats(x):
+            stats_buffer[0] = x.abs().mean()
+
+        def finalize_fn(og, output):
+            log_stats(output)
+            output.register_hook(lambda grad: log_stats(grad) or grad)
+            return torch.sigmoid(og) * output
+
+        class RecomputeGate(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, o_proj_output, gate_output, og, pre_gate_output):
+                ctx.save_for_backward(og, pre_gate_output)
+                return o_proj_output.clone()
+
+            @staticmethod
+            def backward(ctx, grad):
+                og, pre_gate_output = ctx.saved_tensors
+                with torch.no_grad():
+                    torch.utils.checkpoint.checkpoint(
+                        finalize_fn, og, pre_gate_output, use_reentrant=False
+                    )
+                return grad, None, None, None
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(64, 64, device="cuda")
+
+            def forward(self, x):
+                x = self.linear(x)
+                og = x.clone()
+                gate_output = torch.utils.checkpoint.checkpoint(
+                    finalize_fn, og, x, use_reentrant=False
+                )
+                o_proj_output = x @ self.linear.weight.t()
+                return RecomputeGate.apply(o_proj_output, gate_output, og, x)
+
+        m = MyModule()
+        x = torch.randn(2, 64, device="cuda")
+        opt_m = torch.compile(m, backend="aot_eager")
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "mutated in both the forward and backward",
+        ):
+            opt_m(x)
 
 
 class TestAOTDispatch(AOTTestCase):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -1921,8 +1921,21 @@ class TensorVariable(VariableTracker):
             #     a = glb_list[0] * 3
             #     b = glb_dict['tensor'] + 1
             #     return (a + b).sum()
-            # Get the original tensor's node and save its current users
-            tensor_node = self.as_proxy().node
+            # Get the original tensor's node and save its current users.
+            # When inside a subgraph (e.g., checkpoint), the tensor's proxy
+            # may be in a parent graph. Find the corresponding lifted
+            # placeholder in the current subgraph so that node reordering
+            # and user replacement operate within the same graph.
+            tensor_proxy = self.as_proxy()
+            current_tracer = tx.output.current_tracer
+            in_subgraph = tensor_proxy.node.graph is not current_tracer.graph
+            if in_subgraph:
+                inner_proxy = current_tracer.maybe_lift_tracked_freevar_to_input(
+                    tensor_proxy
+                )
+                tensor_node = inner_proxy.node
+            else:
+                tensor_node = tensor_proxy.node
 
             users_to_replace = list(tensor_node.users.keys())
 
@@ -1964,9 +1977,16 @@ class TensorVariable(VariableTracker):
             for user in users_to_replace:
                 user.replace_input_with(tensor_node, tensor_prime_node)
 
-            # Update tensor to point to the tensor_prime
             assert isinstance(result, TensorVariable)
-            self.proxy = result.as_proxy()
+            if in_subgraph:
+                # Inside a subgraph, don't update self.proxy — that would
+                # leave a stale subgraph proxy after the subgraph exits.
+                # Instead, update the tracer's lifted_freevars mapping so
+                # future references to this tensor within the subgraph
+                # resolve to the hooked version.
+                current_tracer.lifted_freevars[tensor_proxy] = result.as_proxy()
+            else:
+                self.proxy = result.as_proxy()
             # TensorVariable doesn't actually store the grad_fn
             # so this is fine.
             self.synchronize_attributes(tx)

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -233,20 +233,6 @@ def _get_ho_op_original_input(getitem_node: fx.Node) -> fx.Node | None:
     return None
 
 
-_FUNCTIONAL_SCATTER_OP_NAMES = frozenset(
-    {
-        "select_scatter",
-        "slice_scatter",
-        "scatter",
-        "scatter_add",
-        "scatter_reduce",
-        "as_strided_scatter",
-        "diagonal_scatter",
-        "masked_scatter",
-        "index_put",
-    }
-)
-
 
 def _is_copy_node_bw_only(node: fx.Node) -> fx.Node | None:
     """Check if node is a view/reshape of a higher-order op output that aliases an input.
@@ -384,22 +370,6 @@ def _extract_graph_with_inputs_outputs(
                     and not isinstance(env[x.args[0]], InvalidNodeBase)
                 ):
                     replacement = env[x.args[0]]
-                # For functional scatter ops (select_scatter, slice_scatter,
-                # etc.) where the base tensor is valid but the update value
-                # depends on backward, use the base tensor. This happens when
-                # a tensor hook registered inside checkpoint mutates an input
-                # in both forward and backward.
-                if (
-                    replacement is None
-                    and isinstance(x.target, torch._ops.OpOverload)
-                    and x.target.name().split("::")[1].split(".")[0]
-                    in _FUNCTIONAL_SCATTER_OP_NAMES
-                    and len(x.args) >= 1
-                    and isinstance(x.args[0], fx.Node)
-                    and x.args[0] in env
-                    and not isinstance(env[x.args[0]], InvalidNodeBase)
-                ):
-                    replacement = env[x.args[0]]
                 # For view/reshape outputs that trace back to a getitem of a
                 # higher-order op that mutates an input, find that input.
                 # This handles custom_function_view outputs from triton kernels.
@@ -408,6 +378,26 @@ def _extract_graph_with_inputs_outputs(
                 if replacement is not None:
                     output_values.append(replacement)
                     continue
+                # Check if this is a functional scatter op whose base
+                # tensor (first arg) is valid — this pattern occurs when
+                # a buffer is mutated in both forward and backward (e.g.
+                # via register_hook) inside activation checkpointing.
+                if (
+                    isinstance(x.target, torch._ops.OpOverload)
+                    and len(x.args) >= 1
+                    and isinstance(x.args[0], fx.Node)
+                    and x.args[0] in env
+                    and not isinstance(env[x.args[0]], InvalidNodeBase)
+                ):
+                    raise RuntimeError(
+                        f"Node {x} depends on backward but is a forward "
+                        f"output. This can happen when a global buffer is "
+                        f"mutated in both the forward and backward (e.g. "
+                        f"via register_hook) inside activation "
+                        f"checkpointing. Move the buffer mutation outside "
+                        f"of checkpoint, or avoid mutating the same buffer "
+                        f"in both forward and backward."
+                    )
                 raise AssertionError(f"Node {x} was invalid, but is output")
             output_values.append(env[x])
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181760
* #181674
* #181552

When a tensor hook registered via `register_hook` inside
`torch.utils.checkpoint` mutates a global buffer in both forward and
backward, the joint graph chains the mutations (e.g. `select_scatter` →
`select_scatter_1`). The backward mutation node depends on tangents but
appears as a forward output, which the partitioner cannot handle.

Rather than silently dropping the backward mutation, raise a clear
RuntimeError explaining the issue and suggesting workarounds: move the
buffer mutation outside of checkpoint, or avoid mutating the same buffer
in both forward and backward.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98