### PR TITLE
[CODEOWNERS] Narrow jeffdaily's /.ci/docker/ ownership to ROCm files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -72,11 +72,11 @@ nn/qat/ @jerryzh168
 /.ci  @pytorch/pytorch-dev-infra
 
 # Docker
-/.ci/docker/ubuntu-rocm/                              @jeffdaily
-/.ci/docker/common/install_roc*.sh                    @jeffdaily
-/.ci/docker/common/install_miopen.sh                  @jeffdaily
-/.ci/docker/common/install_amdsmi.sh                  @jeffdaily
-/.ci/docker/ci_commit_pins/rocm-*.txt                 @jeffdaily
+/.ci/docker/ubuntu-rocm/ @jeffdaily
+/.ci/docker/common/install_roc*.sh @jeffdaily
+/.ci/docker/common/install_miopen.sh @jeffdaily
+/.ci/docker/common/install_amdsmi.sh @jeffdaily
+/.ci/docker/ci_commit_pins/rocm-*.txt @jeffdaily
 /.ci/docker/ci_commit_pins/triton.txt @desertfire @Chillee @eellison @shunting314 @bertmaher @jeffdaily @jataylo @jithunnair-amd @pruthvistony
 /.ci/docker/ci_commit_pins/triton-xpu.txt @EikanWang @gujinghui
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -72,22 +72,11 @@ nn/qat/ @jerryzh168
 /.ci  @pytorch/pytorch-dev-infra
 
 # Docker
-# ROCm-specific docker plumbing, plus shared multi-flavor build entry
-# points that produce ROCm images. Other CPU/CUDA/XPU-only files under
-# /.ci/docker/ fall through to the /.ci catch-all above.
 /.ci/docker/ubuntu-rocm/                              @jeffdaily
-/.ci/docker/common/install_rocm.sh                    @jeffdaily
-/.ci/docker/common/install_rocm_drm.sh                @jeffdaily
-/.ci/docker/common/install_rocm_magma.sh              @jeffdaily
+/.ci/docker/common/install_roc*.sh                    @jeffdaily
 /.ci/docker/common/install_miopen.sh                  @jeffdaily
-/.ci/docker/common/install_rocSHMEM.sh                @jeffdaily
 /.ci/docker/common/install_amdsmi.sh                  @jeffdaily
-/.ci/docker/ci_commit_pins/rocm-composable-kernel.txt @jeffdaily
-/.ci/docker/build.sh                                  @jeffdaily
-/.ci/docker/manywheel/build.sh                        @jeffdaily
-/.ci/docker/manywheel/Dockerfile_2_28                 @jeffdaily
-/.ci/docker/almalinux/Dockerfile                      @jeffdaily
-/.ci/docker/almalinux/build.sh                        @jeffdaily
+/.ci/docker/ci_commit_pins/rocm-*.txt                 @jeffdaily
 /.ci/docker/ci_commit_pins/triton.txt @desertfire @Chillee @eellison @shunting314 @bertmaher @jeffdaily @jataylo @jithunnair-amd @pruthvistony
 /.ci/docker/ci_commit_pins/triton-xpu.txt @EikanWang @gujinghui
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -72,7 +72,22 @@ nn/qat/ @jerryzh168
 /.ci  @pytorch/pytorch-dev-infra
 
 # Docker
-/.ci/docker/ @jeffdaily
+# ROCm-specific docker plumbing, plus shared multi-flavor build entry
+# points that produce ROCm images. Other CPU/CUDA/XPU-only files under
+# /.ci/docker/ fall through to the /.ci catch-all above.
+/.ci/docker/ubuntu-rocm/                              @jeffdaily
+/.ci/docker/common/install_rocm.sh                    @jeffdaily
+/.ci/docker/common/install_rocm_drm.sh                @jeffdaily
+/.ci/docker/common/install_rocm_magma.sh              @jeffdaily
+/.ci/docker/common/install_miopen.sh                  @jeffdaily
+/.ci/docker/common/install_rocSHMEM.sh                @jeffdaily
+/.ci/docker/common/install_amdsmi.sh                  @jeffdaily
+/.ci/docker/ci_commit_pins/rocm-composable-kernel.txt @jeffdaily
+/.ci/docker/build.sh                                  @jeffdaily
+/.ci/docker/manywheel/build.sh                        @jeffdaily
+/.ci/docker/manywheel/Dockerfile_2_28                 @jeffdaily
+/.ci/docker/almalinux/Dockerfile                      @jeffdaily
+/.ci/docker/almalinux/build.sh                        @jeffdaily
 /.ci/docker/ci_commit_pins/triton.txt @desertfire @Chillee @eellison @shunting314 @bertmaher @jeffdaily @jataylo @jithunnair-amd @pruthvistony
 /.ci/docker/ci_commit_pins/triton-xpu.txt @EikanWang @gujinghui
 


### PR DESCRIPTION
## Summary

The broad `/.ci/docker/ @jeffdaily` rule auto-pages me on every change under `.ci/docker/`, including non-ROCm dependency bumps (transformers, NCCL pip pins, pytest), aarch64-specific manywheel changes, and other generic CI/Docker tooling owned by `@pytorch/pytorch-dev-infra`.

This PR replaces it with explicit lines for the files that are ROCm-only or contain ROCm build paths.

Authored with assistance from Claude.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang