### PR TITLE
[Docs] Fix linalg.norm docstring: rename parameter `A` to `input`

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1353,7 +1353,7 @@ Examples::
 norm = _add_docstr(
     _linalg.linalg_norm,
     r"""
-linalg.norm(A, ord=None, dim=None, keepdim=False, *, out=None, dtype=None) -> Tensor
+linalg.norm(input, ord=None, dim=None, keepdim=False, *, out=None, dtype=None) -> Tensor
 
 Computes a vector or matrix norm.
 
@@ -1364,8 +1364,8 @@ Whether this function computes a vector or matrix norm is determined as follows:
 - If :attr:`dim` is an `int`, the vector norm will be computed.
 - If :attr:`dim` is a `2`-`tuple`, the matrix norm will be computed.
 - If :attr:`dim`\ `= None` and :attr:`ord`\ `= None`,
-  :attr:`A` will be flattened to 1D and the `2`-norm of the resulting vector will be computed.
-- If :attr:`dim`\ `= None` and :attr:`ord` `!= None`, :attr:`A` must be 1D or 2D.
+  :attr:`input` will be flattened to 1D and the `2`-norm of the resulting vector will be computed.
+- If :attr:`dim`\ `= None` and :attr:`ord` `!= None`, :attr:`input` must be 1D or 2D.
 
 :attr:`ord` defines the norm that is computed. The following norms are supported:
 
@@ -1394,12 +1394,12 @@ where `inf` refers to `float('inf')`, NumPy's `inf` object, or any equivalent ob
         :func:`torch.linalg.matrix_norm` computes a matrix norm.
 
         The above functions are often clearer and more flexible than using :func:`torch.linalg.norm`.
-        For example, `torch.linalg.norm(A, ord=1, dim=(0, 1))` always
-        computes a matrix norm, but with `torch.linalg.vector_norm(A, ord=1, dim=(0, 1))` it is possible
+        For example, `torch.linalg.norm(input, ord=1, dim=(0, 1))` always
+        computes a matrix norm, but with `torch.linalg.vector_norm(input, ord=1, dim=(0, 1))` it is possible
         to compute a vector norm over the two dimensions.
 
 Args:
-    A (Tensor): tensor of shape `(*, n)` or `(*, m, n)` where `*` is zero or more batch dimensions
+    input (Tensor): tensor of shape `(*, n)` or `(*, m, n)` where `*` is zero or more batch dimensions
     ord (int, float, inf, -inf, 'fro', 'nuc', optional): order of norm. Default: `None`
     dim (int, Tuple[int], optional): dimensions over which to compute
         the vector or matrix norm. See above for the behavior when :attr:`dim`\ `= None`.
@@ -1414,7 +1414,7 @@ Keyword args:
         will be :attr:`dtype`. Default: `None`
 
 Returns:
-    A real-valued tensor, even when :attr:`A` is complex.
+    A real-valued tensor, even when :attr:`input` is complex.
 
 Examples::
 


### PR DESCRIPTION
Fixes #136555

The docstring for `torch.linalg.norm` used `A` as the first parameter name, but the actual keyword argument accepted by the function is `input`:

```python
torch.linalg.norm(A=my_tensor)   # TypeError: missing required positional argument "input"
torch.linalg.norm(input=my_tensor)  # works
```

This updates the signature, Args section, and descriptive text in the docstring to use `input`, matching the actual API. Example code variable names are left unchanged.

cc @malfet @mruberry