### PR TITLE
[inductor][coordesc] extract get_all_tuning_directions enumeration helper (#181768)

### DIFF
--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -227,22 +227,17 @@ class CoordescTuner:
             return xblock <= split_size
         return True
 
-    def check_all_tuning_directions(
+    def get_all_tuning_directions(
         self,
         # pyrefly: ignore [missing-attribute]
-        func: Callable[["triton.Config"], float],
-        best_config,
-        best_timing,
-    ):
-        """
-        Check all directions. We only do this once the regular coordinate
-        descent tuning find no better choices any more.
-        We only have a few tunable fields, so this should be fine.
-        """
+        config: "triton.Config",
+    ) -> list["triton.Config"]:  # pyrefly: ignore [missing-attribute]
+        """Return the Cartesian product of neighbour values across every
+        tunable field, as a list of valid candidate configs."""
         candidate_values_list = []
         effective_fields = []
         for field in self.tunable_fields:
-            old_value = get_field(best_config, field)
+            old_value = get_field(config, field)
             if old_value is None:
                 continue
             radius = self.inductor_meta.get("coordinate_descent_search_radius", 1)
@@ -255,15 +250,30 @@ class CoordescTuner:
             candidate_values_list.append(candidate_values)
             effective_fields.append(field)
 
-        choices = itertools.product(*candidate_values_list)
-        improved = False
-        for choice in choices:
+        configs = []
+        for choice in itertools.product(*candidate_values_list):
             assert len(choice) == len(effective_fields)
-            candidate_config = copy.deepcopy(best_config)
+            candidate = copy.deepcopy(config)
             for new_val, field in zip(choice, effective_fields):
-                set_field(candidate_config, field, new_val)
-            if not self.is_valid_config(candidate_config):
-                continue
+                set_field(candidate, field, new_val)
+            if self.is_valid_config(candidate):
+                configs.append(candidate)
+        return configs
+
+    def check_all_tuning_directions(
+        self,
+        # pyrefly: ignore [missing-attribute]
+        func: Callable[["triton.Config"], float],
+        best_config,
+        best_timing,
+    ):
+        """
+        Check all directions. We only do this once the regular coordinate
+        descent tuning find no better choices any more.
+        We only have a few tunable fields, so this should be fine.
+        """
+        improved = False
+        for candidate_config in self.get_all_tuning_directions(best_config):
             cmp_res, candidate_timing = self.compare_config(
                 func, candidate_config, best_config, best_timing
             )


### PR DESCRIPTION
Summary:

TLDR; This is an NFC which refactors `CoordescTuner.check_all_tuning_directions` into two components: `check_all_tuning_directions` and `get_all_tuning_directions`; `get_all_tuning_directions` now contains the logic to produce configs in all directions, and `check_all_tuning_directions` autotunes across this set of configs. We are making this change so that `CachingAutotuner` plugins can decide the logic behind `get_all_tuning_directions` themselves, without having to recalculate the set of configs.

Pure refactor of `CoordescTuner.check_all_tuning_directions`. Hoists the Cartesian-product enumeration of valid neighbour-value combinations into a standalone `get_all_tuning_directions(config) -> list[Config]` helper that returns the candidate list without benchmarking. The original `check_all_tuning_directions` now iterates the helper's output and runs `compare_config` per candidate, exactly as before.

## Why this is non-functional (algorithmic identity)

The candidate set produced by the new `get_all_tuning_directions(best_config)` is bit-identical to the candidate set the original loop body iterated over. The reasoning hinges on three invariants of the original code, all preserved by the refactor:

1. The Cartesian-product cursor — `itertools.product(*candidate_values_list)` — is built from `candidate_values_list` and `effective_fields`, both computed ONCE before the loop from the initial `best_config`. Neither is rebuilt as `best_config` is updated.

2. Each `choice` overrides every field in `effective_fields` via `set_field(candidate_config, field, new_val)`. So the candidate's value for every effective field comes from `choice`, not from the deepcopy source.

3. Non-effective fields (those in `tunable_fields` but with `get_field(initial_best_config, field) is None`) cannot drift between iterations: `set_field` is only called for `effective_fields`, so a winning candidate cannot introduce a new kwarg key for a field that was None at start. The deepcopy source's non-effective fields therefore stay constant across the entire loop.

The original deepcopied a possibly-updated `best_config` per inner iteration; the refactor's `get_all_tuning_directions(initial_best_config)` deepcopies the initial `best_config` once per candidate. By (1)+(2)+(3), both paths produce candidates with identical effective-field values (from `choice`) and identical non-effective-field values (from the original `best_config`).

The new `check_all_tuning_directions` preserves the original's improvement-tracking semantics verbatim: `best_config` and `best_timing` are still updated when `compare_config` reports an improvement, and subsequent comparisons use the latest `best_config` as the baseline.

Test Plan:
```
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:coordinate_descent_tuner
```

Differential Revision: D102842186




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo