### PR TITLE
[inductor][coordesc] extract get_neighbour_configs per-axis enumeration helper (#181769)

### DIFF
--- a/test/inductor/test_coordinate_descent_tuner.py
+++ b/test/inductor/test_coordinate_descent_tuner.py
@@ -114,6 +114,25 @@ class TestCoordinateDescentTuner(TestCase):
         self.assertFalse(tuner.value_too_large("R0_BLOCK", max_block["R0_"]))
         self.assertTrue(tuner.value_too_large("R0_BLOCK", max_block["R0_"] * 2))
 
+    def test_combo_tunable_fields_flow_into_tunable_fields(self):
+        """``inductor_meta["combo_coordesc_field_order"]`` must be
+        prepended to ``tunable_fields`` so combo-kernel per-subkernel
+        block fields are visible from the moment the tuner is
+        constructed (not only after ``autotune`` is called)."""
+        tuner = CoordescTuner(
+            inductor_meta={
+                "combo_coordesc_field_order": [
+                    "XBLOCK_0",
+                    "YBLOCK_0",
+                    "XBLOCK_1",
+                ],
+            }
+        )
+        fields = tuner.tunable_fields
+        # Combo fields appear in order, ahead of the base fields.
+        self.assertEqual(fields[:3], ["XBLOCK_0", "YBLOCK_0", "XBLOCK_1"])
+        self.assertIn("XBLOCK", fields)
+
     def test_value_too_large_combo_field_limits(self):
         tuner = CoordescTuner(
             size_hints={"x": 2**20, "r0_": 2**20},
@@ -203,6 +222,15 @@ class TestCoordinateDescentTuner(TestCase):
                 "XBLOCK_2": 128,
                 "YBLOCK_2": 16,
             },
+        )
+
+        # End-to-end: a CoordescTuner constructed with the populated
+        # ``inductor_meta`` must surface the combo fields via
+        # ``tunable_fields`` in the same order, ahead of the base fields.
+        tuner = CoordescTuner(inductor_meta=inductor_meta)
+        self.assertEqual(
+            tuner.tunable_fields[: len(inductor_meta["combo_coordesc_field_order"])],
+            inductor_meta["combo_coordesc_field_order"],
         )
 
 

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -227,22 +227,17 @@ class CoordescTuner:
             return xblock <= split_size
         return True
 
-    def check_all_tuning_directions(
+    def get_all_tuning_directions(
         self,
         # pyrefly: ignore [missing-attribute]
-        func: Callable[["triton.Config"], float],
-        best_config,
-        best_timing,
-    ):
-        """
-        Check all directions. We only do this once the regular coordinate
-        descent tuning find no better choices any more.
-        We only have a few tunable fields, so this should be fine.
-        """
+        config: "triton.Config",
+    ) -> list["triton.Config"]:  # pyrefly: ignore [missing-attribute]
+        """Return the Cartesian product of neighbour values across every
+        tunable field, as a list of valid candidate configs."""
         candidate_values_list = []
         effective_fields = []
         for field in self.tunable_fields:
-            old_value = get_field(best_config, field)
+            old_value = get_field(config, field)
             if old_value is None:
                 continue
             radius = self.inductor_meta.get("coordinate_descent_search_radius", 1)
@@ -255,15 +250,30 @@ class CoordescTuner:
             candidate_values_list.append(candidate_values)
             effective_fields.append(field)
 
-        choices = itertools.product(*candidate_values_list)
-        improved = False
-        for choice in choices:
+        configs = []
+        for choice in itertools.product(*candidate_values_list):
             assert len(choice) == len(effective_fields)
-            candidate_config = copy.deepcopy(best_config)
+            candidate = copy.deepcopy(config)
             for new_val, field in zip(choice, effective_fields):
-                set_field(candidate_config, field, new_val)
-            if not self.is_valid_config(candidate_config):
-                continue
+                set_field(candidate, field, new_val)
+            if self.is_valid_config(candidate):
+                configs.append(candidate)
+        return configs
+
+    def check_all_tuning_directions(
+        self,
+        # pyrefly: ignore [missing-attribute]
+        func: Callable[["triton.Config"], float],
+        best_config,
+        best_timing,
+    ):
+        """
+        Check all directions. We only do this once the regular coordinate
+        descent tuning find no better choices any more.
+        We only have a few tunable fields, so this should be fine.
+        """
+        improved = False
+        for candidate_config in self.get_all_tuning_directions(best_config):
             cmp_res, candidate_timing = self.compare_config(
                 func, candidate_config, best_config, best_timing
             )

--- a/torch/_inductor/runtime/coordinate_descent_tuner.py
+++ b/torch/_inductor/runtime/coordinate_descent_tuner.py
@@ -75,7 +75,6 @@ class CoordescTuner:
         self.frozen_fields: OrderedSet[str] = (
             OrderedSet(frozen_fields) if frozen_fields is not None else OrderedSet()
         )
-        self._combo_tunable_fields: list[str] = []
 
     def get_config_max(self, prefix: str) -> int:
         max_block = TRITON_MAX_BLOCK[prefix.upper()]
@@ -107,8 +106,8 @@ class CoordescTuner:
         return timing
 
     @property
-    def tunable_fields(self):
-        out = [
+    def tunable_fields(self) -> list[str]:
+        out: list[str] = [
             "XBLOCK",
             "YBLOCK",
             "ZBLOCK",
@@ -137,7 +136,15 @@ class CoordescTuner:
             # control the stage of pipelining of tl.range.
             out.append("NUM_STAGES")
 
-        out = self._combo_tunable_fields + out
+        # Combo-kernel per-subkernel block fields (e.g. XBLOCK_0/1, YBLOCK_0/1)
+        # come from the worker-side metadata in ``inductor_meta``. Prepend
+        # them so coordesc iterates them alongside the base fields. Read
+        # live each call so any post-construction mutation of
+        # ``inductor_meta`` is observed.
+        combo_fields: list[str] = self.inductor_meta.get(
+            "combo_coordesc_field_order", []
+        )
+        out = combo_fields + out
         return [f for f in out if f not in self.frozen_fields]
 
     def value_too_large(self, name: str, val: int) -> bool:
@@ -310,6 +317,28 @@ class CoordescTuner:
             return True, candidate_timing
         return False, candidate_timing
 
+    def get_neighbour_configs(
+        self,
+        # pyrefly: ignore [missing-attribute]
+        config: "triton.Config",
+        field: str,
+    ) -> list["triton.Config"]:  # pyrefly: ignore [missing-attribute]
+        """Return every valid neighbour of ``config`` along ``field``
+        only — the per-axis counterpart of ``get_neighbour_values``.
+
+        Precondition: ``field`` must be present on ``config``. Callers
+        iterating ``tunable_fields`` against arbitrary configs must
+        filter empty fields up front; ``autotune`` does."""
+        cur_val = get_field(config, field)
+        assert cur_val is not None, f"field {field!r} not present on config"
+        neighbours = []
+        for next_val in self.get_neighbour_values(field, cur_val):
+            candidate = copy.deepcopy(config)
+            set_field(candidate, field, next_val)
+            if self.is_valid_config(candidate):
+                neighbours.append(candidate)
+        return neighbours
+
     def autotune(
         self,
         # pyrefly: ignore [missing-attribute]
@@ -335,32 +364,20 @@ class CoordescTuner:
         best_config = baseline_config
         best_timing = baseline_timing
 
-        self._combo_tunable_fields = self.inductor_meta.get(
-            "combo_coordesc_field_order", []
-        )
-
-        tunable_fields = self.tunable_fields
-
         while improved:
             improved = False
 
-            for name in tunable_fields:
-                cur_val = get_field(best_config, name)
-                # some kernel don't have R0_BLOCK/YBLOCK/ZBLOCK. So cur_val may be None
-                if cur_val is None:
+            # Gauss-Seidel: walk one field at a time, applying any
+            # improvement immediately so subsequent fields see the
+            # updated working point.
+            for field in self.tunable_fields:
+                # Some kernels don't have R0_BLOCK / YBLOCK / ZBLOCK,
+                # so the field may be absent from ``best_config``.
+                # Filter here so ``get_neighbour_configs`` can assume
+                # the field is present.
+                if get_field(best_config, field) is None:
                     continue
-
-                # It's possible that candidate_values is empty.
-                # E.g., if XBLOCK is 1 initially and size_hint for x is also 1.
-                # We would not try either larger or smaller XBLOCK in this case.
-                candidate_values = self.get_neighbour_values(name, cur_val)
-
-                for next_val in candidate_values:
-                    candidate_config = copy.deepcopy(best_config)
-                    set_field(candidate_config, name, next_val)
-
-                    if not self.is_valid_config(candidate_config):
-                        continue
+                for candidate_config in self.get_neighbour_configs(best_config, field):
                     cmp_res, candidate_timing = self.compare_config(
                         func, candidate_config, best_config, best_timing
                     )


### PR DESCRIPTION
Summary:

TLDR; NFC, with the same flavor/justification as D102842187.

Pure refactor of `CoordescTuner.autotune`'s per-axis exploration step.

## What changes

- New `get_neighbour_configs(config, field) -> list[Config]`: per-axis counterpart to `get_neighbour_values`. Yields valid `triton.Config` candidates with the single field swapped (validity-checked). Precondition: `field` must be present on `config` — caller filters.
- `combo_coordesc_field_order` ingestion is moved out of `autotune`'s lazy in-place mutation and into the `tunable_fields` property itself (read live from `inductor_meta` each access). The `_combo_tunable_fields` instance attribute is dropped.
- `autotune`'s inner loop is rewritten to drive Gauss-Seidel via `get_neighbour_configs` per axis, with the `get_field is None` filter retained at the call site so the helper has a single, simple precondition.

## Why this is non-functional (algorithmic identity)

The Gauss-Seidel trajectory of `autotune` — i.e., the sequence of `(best_config, candidate_config)` pairs handed to `compare_config`, and the resulting evolution of `best_config` / `best_timing` — is bit-identical between pre- and post-refactor for every existing call path. Reasoning by part:

**`tunable_fields` snapshot vs live read.** Pre-refactor, `autotune` snapshots `self.tunable_fields` once outside the `while improved` loop. Post-refactor, the outer loop iterates `self.tunable_fields` (the property, evaluated fresh each outer iteration). For the values driving the property — `self.inductor_meta`, `self.frozen_fields`, `self.is_mm`, `self.is_native_matmul`, `self.is_mix_order_reduction` — none are mutated by `autotune` or any callee on its hot path (`call_func`, `cache_benchmark_result`, `compare_config`, `get_neighbour_values`, `is_valid_config`, `check_all_tuning_directions`, `get_all_tuning_directions`, `get_neighbour_configs`, `value_too_large`, `value_too_small`, `get_field`, `set_field`). Only `self.cached_benchmark_results` is mutated, and it does not feed `tunable_fields`. Snapshot = live read.

**`_combo_tunable_fields` removal.** A repository-wide search confirms no other reader of `self._combo_tunable_fields`. The single producer was `autotune`'s lazy assignment, which is replaced by the live read in `tunable_fields`. Net behaviour: same field list, available immediately at construction time instead of after the first `autotune` call.

**Per-axis Gauss-Seidel candidate generation.** Pre-refactor, the inner per-axis loop did `candidate = deepcopy(best_config); set_field(candidate, name, next_val); is_valid_config check; compare`. Post-refactor, `get_neighbour_configs(best_config, field)` returns the same list — same deepcopy, same `set_field`, same `is_valid_config` filter, same iteration order over `get_neighbour_values(field, cur_val)`. The pre-refactor inner loop deepcopied the latest `best_config` per neighbour-value iteration; the refactor snapshots `best_config` once at function entry. Within a single per-axis iteration, the only field of `best_config` that can change is `field` itself (if a neighbour-value improvement promotes a candidate to best), and that field is overridden by the next `set_field(candidate, field, next_val)` regardless of the deepcopy source. Other tunable fields and non-tunable fields are unchanged within the per-axis loop. Same candidates, same order.

**Cross-axis Gauss-Seidel update.** The outer-axis loop in both versions reads `best_config` afresh at the top of each per-axis iteration (pre-refactor: `cur_val = get_field(best_config, name)`; post-refactor: `get_field(best_config, field)` filter + `get_neighbour_configs(best_config, field)`). So the per-axis exploration starts from the latest best — preserving the cross-axis Gauss-Seidel semantics where one axis's improvement shifts the working point for the next axis.

**`check_all_tuning_directions` post-loop block.** Verbatim — the if-not-improved-and-check-all-directions block, the `get_all_tuning_directions` call, the `improved` re-tracking, the logging, and the return tuple are all unchanged.

## Verified by

- Static analysis (formal mutation audit + per-iteration field equivalence proof above).
- Empirical side-by-side trajectory comparison across 5 scenarios (pointwise minimal, reduction with all-directions, mm with radius=2, combo `field_order`, multi-block radius=2) and 2 entry points (`autotune`, `check_all_tuning_directions`). All 30 pairwise trajectory comparisons (pre/post for both refactors and both entry points) match byte-for-byte: every `(best_kwargs, candidate_kwargs, candidate_timing)` tuple from `compare_config` matches in order, and every scenario's final winning config matches.

## One intentional, scoped behaviour change for external callers (no in-tree caller affected)

Pre-refactor, `tunable_fields` did not include combo fields until `autotune` had been called once (because `_combo_tunable_fields` was set inside `autotune`). External callers of `tunable_fields` / `get_all_tuning_directions` / `check_all_tuning_directions` that did not first call `autotune` would never see combo fields, even with `inductor_meta["combo_coordesc_field_order"]` populated.

Post-refactor, `tunable_fields` reads combo fields live from `inductor_meta`, so any caller sees the configured fields immediately. There is no in-tree caller that relied on the old behaviour (the only existing caller is `autotune` itself, which would always produce a populated list either way). This change is intentional — incremental autotune (downstream in this stack) drives `get_neighbour_configs` directly without going through `autotune`, and needs the combo fields to be visible.

Test Plan:
```
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:coordinate_descent_tuner
```

Differential Revision: D102842187




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo