### PR TITLE
fix(dynamo): Handle blocked tp slots like bool()

### DIFF
--- a/test/dynamo/test_iterators.py
+++ b/test/dynamo/test_iterators.py
@@ -1233,6 +1233,18 @@ class NoIterNoGetitem:
     pass
 
 
+class BlockedIter:
+    __iter__ = None
+
+
+class BlockedGetItem:
+    __getitem__ = None
+
+
+class BlockedLen:
+    __len__ = None
+
+
 class TestIterErrors(torch._dynamo.test_case.TestCase):
     """Test that iter() raises the correct exceptions"""
 
@@ -1319,6 +1331,21 @@ class TestIterErrors(torch._dynamo.test_case.TestCase):
         with self.assertRaises(RuntimeError):
             d["d"] = 4
             next(it)
+
+    @make_dynamo_test
+    def test_iter_blocked_slot_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            iter(BlockedIter())
+
+    @make_dynamo_test
+    def test_getitem_blocked_slot_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            BlockedGetItem()[0]
+
+    @make_dynamo_test
+    def test_len_blocked_slot_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            len(BlockedLen())
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_nb_bool.py
+++ b/test/dynamo/test_nb_bool.py
@@ -245,13 +245,20 @@ class NbBoolTests(TestCase):
         class NoBool:
             __bool__ = None
 
-        def fn(x, obj):
-            return x + 1 if bool(obj) else x - 1
+        obj = NoBool()
 
-        with self.assertRaisesRegex(TypeError, "'NoneType' object is not callable"):
-            bool(NoBool())
-        with self.assertRaisesRegex(TypeError, "'NoneType' object is not callable"):
-            torch.compile(fn, backend="eager")(torch.randn(4), NoBool())
+        def fn(x):
+            try:
+                return str(bool(obj))
+            except TypeError as e:
+                return str(e)
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
+        eager_result = fn(torch.tensor(0))
+        self.assertTrue(
+            "NoneType" in result or "cannot be interpreted as a boolean" in result
+        )
+        self.assertEqual(result, eager_result)
 
     # --- Metaclass with __bool__ (UserDefinedClassVariable path) ---
 

--- a/test/dynamo/test_nb_bool.py
+++ b/test/dynamo/test_nb_bool.py
@@ -239,6 +239,20 @@ class NbBoolTests(TestCase):
         ):
             fn(Baz())
 
+    # --- Blocked slot: __bool__ = None ---
+
+    def test_user_defined_bool_none_raises(self):
+        class NoBool:
+            __bool__ = None
+
+        def fn(x, obj):
+            return x + 1 if bool(obj) else x - 1
+
+        with self.assertRaisesRegex(TypeError, "'NoneType' object is not callable"):
+            bool(NoBool())
+        with self.assertRaisesRegex(TypeError, "'NoneType' object is not callable"):
+            torch.compile(fn, backend="eager")(torch.randn(4), NoBool())
+
     # --- Metaclass with __bool__ (UserDefinedClassVariable path) ---
 
     def test_metaclass_bool(self):

--- a/test/dynamo/test_nb_float.py
+++ b/test/dynamo/test_nb_float.py
@@ -301,6 +301,25 @@ class NbFloatTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(5))
         self.assertEqual(result, 5.0)
 
+    # --- Blocked slot: __float__ = None ---
+
+    def test_user_defined_float_none_raises(self):
+        class NoFloat:
+            __float__ = None
+
+        obj = NoFloat()
+
+        def fn(x):
+            try:
+                return float(obj)
+            except TypeError as e:
+                return str(e)
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
+        eager_result = fn(torch.tensor(0))
+        self.assertIn("NoneType", result)
+        self.assertEqual(result, eager_result)
+
     # --- SymNodeVariable ---
 
     @skipIfCrossRef

--- a/test/dynamo/test_nb_index.py
+++ b/test/dynamo/test_nb_index.py
@@ -321,6 +321,25 @@ class NbIndexTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
         self.assertEqual(result, "custom error")
 
+    # --- Blocked slot: __index__ = None ---
+
+    def test_user_defined_index_none_raises(self):
+        class NoIndex:
+            __index__ = None
+
+        obj = NoIndex()
+
+        def fn(x):
+            try:
+                return operator.index(obj)
+            except TypeError as e:
+                return str(e)
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
+        eager_result = fn(torch.tensor(0))
+        self.assertIn("NoneType", result)
+        self.assertEqual(result, eager_result)
+
     # --- Tensor __index__ ---
 
     def test_tensor_int_index(self):

--- a/test/dynamo/test_nb_int.py
+++ b/test/dynamo/test_nb_int.py
@@ -303,6 +303,25 @@ class NbIntTests(TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(5))
         self.assertEqual(result, 5)
 
+    # --- Blocked slot: __int__ = None ---
+
+    def test_user_defined_int_none_raises(self):
+        class NoInt:
+            __int__ = None
+
+        obj = NoInt()
+
+        def fn(x):
+            try:
+                return int(obj)
+            except TypeError as e:
+                return str(e)
+
+        result = torch.compile(fn, backend="eager", fullgraph=True)(torch.tensor(0))
+        eager_result = fn(torch.tensor(0))
+        self.assertIn("NoneType", result)
+        self.assertEqual(result, eager_result)
+
     # --- SymNodeVariable ---
 
     def test_symnode_int(self):

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1536,17 +1536,32 @@ class UserDefinedObjectVariable(UserDefinedVariable):
             return self.value
         return super().guard_as_python_constant()
 
+    def _lookup_slot_type_attr(
+        self,
+        tx: "InstructionTranslator",
+        name: str,
+        *,
+        none_error: str = "'NoneType' object is not callable",
+    ) -> tuple[object, Source | None]:
+        """Walk class MRO for *name*, raising TypeError when slot is blocked (= None)."""
+        type_attr = self.lookup_class_mro_attr(name)
+        if type_attr is None:
+            raise_type_error(tx, none_error)
+
+        source = None
+        if type_attr is not NO_SUCH_SUBOBJ and self.source:
+            source = self.get_source_by_walking_mro(tx, name)
+        return type_attr, source
+
     def bool_impl(
         self,
         tx: "InstructionTranslator",
     ) -> "VariableTracker | None":
         # Mirrors slot_nb_bool:
         # https://github.com/python/cpython/blob/c09ccd9c429/Objects/typeobject.c#L9408-L9458
-        type_attr = self.lookup_class_mro_attr("__bool__")
+        type_attr, _ = self._lookup_slot_type_attr(tx, "__bool__")
         if type_attr is NO_SUCH_SUBOBJ:
             return None
-        if type_attr is None:
-            raise_type_error(tx, "'NoneType' object is not callable")
 
         result = self.call_method(tx, "__bool__", [], {})
         if result.python_type() is not bool:
@@ -1561,11 +1576,9 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         tx: "InstructionTranslator",
     ) -> VariableTracker:
         # CPython: PyNumber_Index checks tp_as_number->nb_index.
-        # For user-defined types, __index__ in tp_dict means nb_index is set.
-        type_attr = inspect.getattr_static(type(self.value), "__index__", None)
-        if type_attr is None:
+        type_attr, source = self._lookup_slot_type_attr(tx, "__index__")
+        if type_attr is NO_SUCH_SUBOBJ:
             return super().nb_index_impl(tx)
-        source = self.source and self.get_source_by_walking_mro(tx, "__index__")
         method_var = self.resolve_type_attr(tx, "__index__", type_attr, source)
         result = method_var.call_function(tx, [], {})
         # CPython validates that __index__ returns an int.
@@ -1588,13 +1601,10 @@ class UserDefinedObjectVariable(UserDefinedVariable):
     ) -> VariableTracker:
         # CPython: slot_nb_int calls __int__(), PyNumber_Long validates the return type.
         # https://github.com/python/cpython/blob/v3.13.0/Objects/abstract.c#L1538-L1550
-        source = self.source and self.get_source_by_walking_mro(tx, "__int__")
-        method_var = self.resolve_type_attr(
-            tx,
-            "__int__",
-            inspect.getattr_static(type(self.value), "__int__"),
-            source,
-        )
+        type_attr, source = self._lookup_slot_type_attr(tx, "__int__")
+        if type_attr is NO_SUCH_SUBOBJ:
+            return super().nb_int_impl(tx)
+        method_var = self.resolve_type_attr(tx, "__int__", type_attr, source)
         result = method_var.call_function(tx, [], {})
         if not issubclass(result.python_type(), int):
             raise_observed_exception(
@@ -1612,13 +1622,10 @@ class UserDefinedObjectVariable(UserDefinedVariable):
     ) -> VariableTracker:
         # CPython: slot_nb_float calls __float__(), PyNumber_Float validates the return type.
         # https://github.com/python/cpython/blob/v3.13.0/Objects/abstract.c#L1647-L1658
-        source = self.source and self.get_source_by_walking_mro(tx, "__float__")
-        method_var = self.resolve_type_attr(
-            tx,
-            "__float__",
-            inspect.getattr_static(type(self.value), "__float__"),
-            source,
-        )
+        type_attr, source = self._lookup_slot_type_attr(tx, "__float__")
+        if type_attr is NO_SUCH_SUBOBJ:
+            return super().nb_float_impl(tx)
+        method_var = self.resolve_type_attr(tx, "__float__", type_attr, source)
         result = method_var.call_function(tx, [], {})
         if not issubclass(result.python_type(), float):
             raise_observed_exception(
@@ -1700,7 +1707,11 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         return super().tp_iternext_impl(tx)
 
     def tp_iter_impl(self, tx: "InstructionTranslator") -> VariableTracker:
-        method = self._maybe_get_baseclass_method("__iter__")
+        method, source_fn = self._lookup_slot_type_attr(
+            tx,
+            "__iter__",
+            none_error=f"'{self.python_type_name()}' object is not iterable",
+        )
         if (
             self._base_vt is not None
             and self._base_methods is not None
@@ -1730,7 +1741,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         key: VariableTracker,
     ) -> VariableTracker:
         # PyObject_GetItem: https://github.com/python/cpython/blob/62a6e898e01/Objects/abstract.c#L155-L206
-        method = self._maybe_get_baseclass_method("__getitem__")
+        method, source_fn = self._lookup_slot_type_attr(tx, "__getitem__")
         if (
             self._base_vt is not None
             and self._base_methods is not None
@@ -1738,9 +1749,6 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         ):
             return self._base_vt.mp_subscript_impl(tx, key)
         if isinstance(method, types.FunctionType):
-            source_fn = self.source and self.get_source_by_walking_mro(
-                tx, "__getitem__"
-            )
             return variables.UserMethodVariable(
                 method, self, source_fn=source_fn, source=self.source
             ).call_function(tx, [key], {})
@@ -1972,10 +1980,8 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         return super().call_method(tx, name, args, kwargs)
 
     def len_impl(self, tx: "InstructionTranslator") -> VariableTracker:
-        method = self._maybe_get_baseclass_method("__len__")
-        if method is not None:
-            type_attr = self.lookup_class_mro_attr("__len__")
-            source = self.source and self.get_source_by_walking_mro(tx, "__len__")
+        type_attr, source = self._lookup_slot_type_attr(tx, "__len__")
+        if type_attr is not NO_SUCH_SUBOBJ:
             method_var = self.resolve_type_attr(tx, "__len__", type_attr, source)
             if not isinstance(method_var, variables.GetAttrVariable):
                 return method_var.call_function(tx, [], {})
@@ -1997,7 +2003,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if (
             self._base_vt is not None
             and self._base_methods is not None
-            and self._maybe_get_baseclass_method("__len__") in self._base_methods
+            and self.lookup_class_mro_attr("__len__") in self._base_methods
         ):
             return self._base_vt.sq_length(tx)
         return self.len_impl(tx)
@@ -2006,7 +2012,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         if (
             self._base_vt is not None
             and self._base_methods is not None
-            and self._maybe_get_baseclass_method("__len__") in self._base_methods
+            and self.lookup_class_mro_attr("__len__") in self._base_methods
         ):
             return self._base_vt.mp_length(tx)
         return self.len_impl(tx)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1559,7 +1559,14 @@ class UserDefinedObjectVariable(UserDefinedVariable):
     ) -> "VariableTracker | None":
         # Mirrors slot_nb_bool:
         # https://github.com/python/cpython/blob/c09ccd9c429/Objects/typeobject.c#L9408-L9458
-        type_attr, _ = self._lookup_slot_type_attr(tx, "__bool__")
+        none_error = "'NoneType' object is not callable"
+        if sys.version_info >= (3, 14):
+            none_error = (
+                f"'{self.python_type_name()}' cannot be interpreted as a boolean"
+            )
+        type_attr, _ = self._lookup_slot_type_attr(
+            tx, "__bool__", none_error=none_error
+        )
         if type_attr is NO_SUCH_SUBOBJ:
             return None
 


### PR DESCRIPTION
This PR is a continuation of refactoring from https://github.com/pytorch/pytorch/pull/181104

This change makes Dynamo handle blocked special-method slots on user-defined objects the same way CPython does. It introduces a shared slot-lookup path in UserDefinedObjectVariable so that when methods like __bool__, __int__, __float__, __index__, __iter__, __getitem__, or __len__ are explicitly set to None, torch.compile raises the same TypeError behavior as eager Python instead of falling through to default behavior. The patch also adds regression tests covering these blocked-slot cases to keep Dynamo aligned with CPython semantics.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98