### PR TITLE
[Tests][CUDA][Inductor] Disable shape padding in `test_mm_concat`

### DIFF
--- a/test/inductor/test_inductor_freezing.py
+++ b/test/inductor/test_inductor_freezing.py
@@ -262,7 +262,9 @@ class OptimizeForInferenceTemplate(TestCase):
                 FileCheck().check_not("@triton.jit").run(code[0])
                 self.assertEqual(out_eager, out_compiled)
 
-    @torch._inductor.config.patch("cpp.enable_concat_linear", True)
+    @torch._inductor.config.patch(
+        {"cpp.enable_concat_linear": True, "shape_padding": False}
+    )
     def test_mm_concat(self):
         class MM(torch.nn.Module):
             def __init__(self) -> None:


### PR DESCRIPTION
The pad_mm optimization pass runs a GPU benchmarking step to determine whether to pad matrix dimensions or not. `test_mm_concat` uses small 10x10 matrices, and due to GPU timing noise this pass non-deterministically adds padding, which changes the graph and breaks the expected pattern matching. This PR just disables shape padding entirely since it is not relevant for this test.

Fixes #181770 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy 