### PR TITLE
[xplat] Fix clang-diagnostic-conditional-uninitialized errors (caffe2)

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -2860,7 +2860,7 @@ inline C10_HOST_DEVICE T chebyshev_polynomial_t_forward(T x, int64_t n) {
 
     T p = T(1.0);
     T q = x;
-    T r;
+    T r = x;
 
     for (int64_t k = 2; (k <= n) && !std::isnan(q); k++) {
         r = (x + x) * q - p;

--- a/aten/src/ATen/native/SegmentReduce.cpp
+++ b/aten/src/ATen/native/SegmentReduce.cpp
@@ -70,7 +70,7 @@ void _segment_reduce_lengths_cpu_kernel1(
             }
             for (const auto inner_idx : c10::irange(inner_offset)) {
               // ===== step1: initialize starting value
-              scalar_t initial_value;
+              scalar_t initial_value = 0;
               if (initial.has_value()) {
                 initial_value = initial.value().to<scalar_t>();
               } else if (reduction == ReductionType::MAX) {

--- a/aten/src/ATen/native/cpu/UpSampleKernelNEONAntialias.h
+++ b/aten/src/ATen/native/cpu/UpSampleKernelNEONAntialias.h
@@ -323,9 +323,9 @@ void upsample_neon_bilinear_bicubic_uint8(const at::Tensor& input_,
   auto need_horizontal = xout != xin;
   auto need_vertical = yout != yin;
 
-  int ksize_horiz, ksize_vert;
+  int ksize_horiz = 0, ksize_vert = 0;
   std::vector<at::Tensor> horiz_indices_weights, vert_indices_weights;
-  unsigned int horiz_weights_precision, vert_weights_precision;
+  unsigned int horiz_weights_precision = 0, vert_weights_precision = 0;
 
   if (need_horizontal) {
     int interp_dim = 3;


### PR DESCRIPTION
Summary: In preparation for promoting conditional-uninitialized to a compiler error at Meta, this diff stack is resolving cases of this compiler warning in Meta libraries.

Test Plan:
CI, existing unit tests.
Manually spot-checking to make sure we are avoiding antipatterns like setting a nonnull-annotated-variable to null

Differential Revision: D102849844




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01