### PR TITLE
Fix FakeProcessGroup allgather on tensors that require grad

### DIFF
--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -57,6 +57,18 @@ class TestFakePG(TestCase):
         for out_tensor in output_tensors:
             self.assertEqual(tuple(out_tensor.shape), (3, 3))
 
+    def test_allgather_into_tensor_requires_grad(self):
+        # Regression test: fake PG's _allgather_base uses chunk() which
+        # produces multi-output views. Writing into those views inplace when
+        # the input requires grad used to trip an autograd safety check.
+        dist.init_process_group(backend="fake", rank=0, world_size=4)
+        world_size = dist.get_world_size()
+
+        input_tensor = torch.randn(4, requires_grad=True)
+        output_tensor = torch.empty(4 * world_size)
+        dist.all_gather_into_tensor(output_tensor, input_tensor)
+        self.assertEqual(output_tensor.shape, (4 * world_size,))
+
     def test_reduce_scatter(self):
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=1, world_size=2, store=store)

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/core/LegacyTypeDispatch.h>
 #include <torch/csrc/distributed/c10d/Backend.hpp>
 #include <torch/csrc/utils.h>
 
@@ -107,6 +108,11 @@ class FakeProcessGroup : public Backend {
       at::Tensor& inputBuffer,
       const AllgatherOptions& /* opts */ = AllgatherOptions()) override {
     checkCollectiveError();
+    // Real collective backends (e.g. NCCL) write into the output from C++
+    // kernels that autograd never sees. We emulate that here: chunk() produces
+    // multi-output views, and without this guard autograd would reject the
+    // subsequent copy_() when the input requires grad.
+    at::AutoDispatchBelowAutograd guard;
     auto chunks = outputBuffer.chunk(size_);
     for (auto& tensor : chunks) {
       tensor.copy_(inputBuffer);
@@ -127,6 +133,8 @@ class FakeProcessGroup : public Backend {
       std::vector<at::Tensor>& inputs,
       const AllgatherOptions& /* opts */ = AllgatherOptions()) override {
     checkCollectiveError();
+    // See note in _allgather_base above.
+    at::AutoDispatchBelowAutograd guard;
     for (size_t i = 0; i < outputs.size(); ++i) {
       auto chunks = outputs[i].chunk(size_);
       for (auto& chunk : chunks) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181790

Fixes https://github.com/pytorch/pytorch/issues/181774

`FakeProcessGroup::_allgather_base` and
`allgather_into_tensor_coalesced` use `output.chunk()` to produce views
and then `copy_()` into them. When the input requires grad, autograd's
multi-output-view safety check rejects the inplace write and the
collective fails with "A view was created in no_grad mode and is being
modified inplace with grad mode enabled". Real backends (e.g. NCCL) do
not hit this because their C++ kernels are invisible to autograd.

Wrap the chunk+copy in `at::AutoDispatchBelowAutograd` to match the real
backends' behavior.

Authored with Claude.