### PR TITLE
Fix dynamic shape tile issue (#181793)

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -563,6 +563,48 @@ class LoopOrderingTest(TestCase):
             ms = do_bench(lambda: opt_f(x))
             print(f"{ms=:.3f}")
 
+    def test_factored_vs_expanded_pw_numel_in_fused_group(self):
+        """
+        Regression test for https://github.com/pytorch/pytorch/issues/181563
+
+        Conv2d(kernel=1, stride=4) decomposes its output spatial size as
+        ``1 + (T - 1)//4``, so when those ranges are multiplied together for
+        a node body via ``sympy_product`` the result stays factored
+        (``s*(a+1)*(b+1)``). The fused-group's ``pointwise_numel`` for the
+        same value goes through ``SizeVarAllocator.simplify`` which calls
+        ``sympy.expand`` and yields the expanded form
+        (``s + s*a + s*b + s*a*b``). Sympy's structural ``==`` says these are
+        not equal, so without the fix the early-return guard in
+        ``get_pw_red_splits`` is missed and we fall through to an assert
+        that can never hold for a non-reduction body in a group whose
+        ``red_numel > 1``.
+        """
+
+        class Mod(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj = nn.Conv2d(8, 8, kernel_size=1, stride=4, bias=False)
+
+            def forward(self, x):
+                a = self.proj(x)
+                # Outer-only pointwise sharing `a`'s sym shape; returning it
+                # forces materialization as its own SchedulerNode rather than
+                # being inlined into the softmax kernel.
+                bias = a[:, 0]
+                bias = bias * 2 + 1
+                a = a.permute(0, 2, 3, 1).contiguous()
+                a = a + bias.unsqueeze(-1)
+                b = a.softmax(dim=-1)  # red_numel = 8 in the fused group
+                return b, bias
+
+        mod = Mod().to(GPU_TYPE)
+        x = torch.randn(2, 8, 17, 19, device=GPU_TYPE)
+        torch._dynamo.mark_dynamic(x, 2)
+        torch._dynamo.mark_dynamic(x, 3)
+
+        with torch.no_grad():
+            self.do_acc_test(mod, x)
+
     @inductor_config.patch(
         {
             "max_autotune": True,

--- a/torch/_inductor/tiling_utils.py
+++ b/torch/_inductor/tiling_utils.py
@@ -261,7 +261,12 @@ def get_pw_red_splits(
     red_numel: sympy.Expr,
     none_if_not_divisible: bool = False,
 ) -> tuple[VarsAndRanges, VarsAndRanges] | None:
-    if n.is_reduction() or sympy_product(n._body.sizes[0]) == pointwise_numel:
+    # nb: use statically_known_equals here to mimic scheduler.
+    # TODO : store type of split/broadcast on fused node itself,
+    # instead of re-deriving it.
+    if n.is_reduction() or V.graph.sizevars.statically_known_equals(
+        sympy_product(n._body.sizes[0]), pointwise_numel
+    ):
         # pyrefly: ignore [bad-return]
         return (
             (n._body.iter_vars, n._body.sizes[0]),


### PR DESCRIPTION
Cherrypick of https://github.com/pytorch/pytorch/pull/181793

Fixes https://github.com/pytorch/pytorch/issues/181563

`get_pw_red_splits` was missing its early-return for non-reduction nodes whose body iter ranges multiplied out to a sympy expression structurally different from the fused group's `pointwise_numel` (e.g. `s*(a+1)*(b+1)` vs the `sympy.expand`'d form `s + s*a + s*b + s*a*b` produced by `SizeVarAllocator.simplify`). The fall-through then hit an assert that can't hold for a non-reduction body in a group with `red_numel > 1`. Switch the guard to `V.graph.sizevars.statically_known_equals` so factored-vs-expanded forms compare equal — the same check the scheduler uses for fusion compatibility.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/181793

(cherry picked from commit 5784dd3e60c06a9d659f160ba8e095c9e149ce8a)

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo