### PR TITLE
[AI Codemod][PerfAICT-StrConversion] perf: Avoid string construction (#181796)

### DIFF
--- a/aten/src/ATen/record_function.cpp
+++ b/aten/src/ATen/record_function.cpp
@@ -728,7 +728,7 @@ void RecordFunction::before(RecordFunction::FunctionDescriptor fn, int64_t seque
   std::visit([this](auto&& fn) {
     if constexpr (std::is_same_v<std::decay_t<decltype(fn)>, std::string_view>) {
       is_nccl_meta_ = (fn == kParamCommsCallName);
-      fn_ = std::string(fn);
+      fn_.emplace<std::string>(fn);
     } else {
       is_nccl_meta_ = (fn.get().name() == kParamCommsCallName);
       fn_ = fn;


### PR DESCRIPTION
Summary:

Optimized `fn_ = std::string(fn)` to `fn_.emplace<std::string>(fn)` on line 731 of `record_function.cpp`. This avoids creating a temporary `std::string` object and then move-assigning it into the `std::variant<std::string, schema_ref_t>` member `fn_`. Instead, `emplace` constructs the `std::string` directly in-place within the variant from the `std::string_view`, eliminating the temporary allocation and move operation.

Reviewed By: lexprfuncall

Differential Revision: D102281694


