### PR TITLE
[DTensor][BugFix] Fix DTensor + AC + compile crash: unbound inner symbol at root tracer  

### DIFF
--- a/test/distributed/tensor/test_dtensor_compile.py
+++ b/test/distributed/tensor/test_dtensor_compile.py
@@ -2927,5 +2927,75 @@ class TestDTensorCompileE2E(DTensorTestBase):
             )
 
 
+class TestDTensorACCompile(DTensorTestBase):
+    """Regression test for DTensor + AC + compile interaction.
+
+    When a DTensor with independent inner/outer symbolic shapes is lifted
+    as a freevar into a checkpoint HOP subgraph, ``_lift_basic_symbols``
+    recurses into the inner tensor with ``source=None`` and tries to lift
+    an unbound inner symbol to the root tracer, crashing with::
+
+        AssertionError: Source of '<sym>' is None when lifting it
+        to input of top-level.
+    """
+
+    @property
+    def world_size(self):
+        return 2
+
+    @with_comms
+    @skip_if_lt_x_gpu(2)
+    def test_tp_ac_compile_dtensor_inner_symbol(self):
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+
+        # Embedding produces a DTensor whose inner/outer sizes get
+        # independent symbols (outer = global seq_len, inner = local
+        # seq_len). This is the pattern from TP with variable-length seqs.
+        class EmbedBlock(nn.Module):
+            def __init__(self, vocab, dim, device):
+                super().__init__()
+                self.embed = nn.Embedding(vocab, dim, device=device)
+                self.block = MLPModule(device)
+
+            def forward(self, ids):
+                return self.block(self.embed(ids))
+
+        model = EmbedBlock(32, 10, self.device_type)
+
+        parallelize_module(
+            model,
+            mesh,
+            {
+                "embed": RowwiseParallel(
+                    output_layouts=Shard(1), use_local_output=False
+                ),
+                "block.net1": ColwiseParallel(
+                    input_layouts=Shard(1), use_local_output=False
+                ),
+                "block.net2": RowwiseParallel(use_local_output=False),
+            },
+        )
+        model.block = checkpoint_wrapper(
+            model.block,
+            checkpoint_impl=CheckpointImpl.NO_REENTRANT,
+            checkpoint_fn=checkpoint,
+            use_reentrant=False,
+        )
+        torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
+
+        model.block.compile(backend="aot_eager", fullgraph=True)
+
+        ids1 = torch.randint(0, 32, (4, 20), device=self.device_type)
+        out1 = model(ids1)
+        out1.sum().backward()
+        model.zero_grad()
+
+        # Different seq_len triggers dynamic-shape recompilation where
+        # the DTensor inner symbol gets lifted through the AC HOP.
+        ids2 = torch.randint(0, 32, (4, 25), device=self.device_type)
+        out2 = model(ids2)
+        out2.sum().backward()
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -4078,6 +4078,16 @@ class SubgraphTracer(fx.Tracer):
         if proxy.tracer != self.parent:
             self.parent.lift_tracked_freevar_to_input(proxy)
 
+        # Wrapper subclasses (e.g. DTensor) from dynamo-disabled regions may not
+        # have had track_produced_symints called, causing _lift_basic_symbols to
+        # hit "Source of 'sN' is None" when lifting inner tensor symbols.
+        if (
+            isinstance(example_value, torch.Tensor)
+            and is_traceable_wrapper_subclass(example_value)
+            and proxy.tracer is self.parent
+        ):
+            self.parent.track_produced_symints(example_value, proxy)
+
         example_value = proxy.node.meta["example_value"]
         type_expr = (
             type(example_value.real_obj)


### PR DESCRIPTION
Partial fix of https://github.com/pytorch/torchtitan/issues/3104

## Summary:

Fix DTensor + AC + compile crash: unbound inner symbol at root tracer                              

### Bug
When a DTensor with independent inner/outer symbolic shapes (e.g. from TP with Shard placements) is captured as a freevar into a checkpoint HOP subgraph, _lift_basic_symbols recurses into the inner _local_tensor with source=None and tries to lift the unbound symbol to the root tracer, crashing with:

> AssertionError: Source of 'sN' is None when lifting it to input of top-level

This happens during dynamic-shape recompilation (second forward+backward with different sequence   
lengths) when AC recompute re-traces the checkpointed region. The inner tensor's shape symbol was
never tracked at the parent graph because the DTensor was produced in a dynamo-disabled region     
(e.g. FSDP2 hooks), so track_produced_symints was never called for it.

### Fix
In SubgraphTracer.lift_tracked_freevar_to_input, after lifting a proxy to the parent, check if the example value is a traceable wrapper subclass (like DTensor). If so, call self.parent.track_produced_symints(example_value, proxy) to ensure the inner tensor's symbols are  registered at the parent level before _lift_basic_symbols tries to resolve them.

## Test
```bash  
python test/distributed/tensor/test_dtensor_compile.py -k test_tp_ac_compile_dtensor_inner_symbol  
```

The test (TestDTensorACCompile.test_tp_ac_compile_dtensor_inner_symbol) creates a TP-parallelized model with an embedding (producing DTensors with Shard(1) placements), wraps a block in AC (checkpoint_wrapper), compiles it with aot_eager, then runs two forward+backward passes with different sequence lengths to trigger dynamic-shape recompilation through the checkpoint HOP


Authored with Claude
cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98