### PR TITLE
[leaf_function] fix detach() to preserve grad_dtype

### DIFF
--- a/test/functorch/test_leaf_function.py
+++ b/test/functorch/test_leaf_function.py
@@ -2686,5 +2686,96 @@ class TestLeafFunctionRegisterHook(TestCase):
         self.assertEqual(hook_count[0], 1)
 
 
+@skipIfTorchDynamo("leaf_function tests manage their own compilation")
+class TestLeafFunctionGradDtype(TestCase):
+    def _make_pair(self, size, dtype, grad_dtype):
+        torch.manual_seed(42)
+        x_ref = torch.randn(size, dtype=dtype, requires_grad=True)
+        x_test = x_ref.detach().clone().requires_grad_(True)
+        if grad_dtype is not None:
+            x_ref.grad_dtype = grad_dtype
+            x_test.grad_dtype = grad_dtype
+        return x_ref, x_test
+
+    @staticmethod
+    def _precision_sensitive_fn(x, w):
+        return (x.float() * w.float()).sum() + (x.float() ** 3 / 7.0).sum()
+
+    def test_grad_bitwise_equal_with_grad_dtype(self):
+        @leaf_function
+        def fn(x, w):
+            return (self._precision_sensitive_fn(x, w),)
+
+        @fn.register_fake
+        def fn_fake(x, w):
+            return (torch.empty((), dtype=torch.float32, device=x.device),)
+
+        x_ref, x_test = self._make_pair(64, torch.bfloat16, torch.float32)
+        torch.manual_seed(7)
+        w = torch.randn(64, dtype=torch.bfloat16)
+
+        self._precision_sensitive_fn(x_ref, w).backward()
+        fn(x_test, w)[0].backward()
+
+        self.assertTrue(torch.equal(x_test.grad, x_ref.grad))
+
+    @parametrize(
+        "dtype,grad_dtype",
+        [
+            (torch.bfloat16, torch.float32),
+            (torch.float16, torch.float32),
+            (torch.float32, torch.bfloat16),
+            (torch.float32, torch.float16),
+        ],
+    )
+    def test_backward_engine_with_dtype_grad_dtype_mismatch(self, dtype, grad_dtype):
+        observed_inner = {}
+
+        @leaf_function
+        def fn(x, w):
+            observed_inner["dtype"] = x.dtype
+            observed_inner["grad_dtype"] = x.grad_dtype
+            return ((x.float() * w.float()).sum(),)
+
+        @fn.register_fake
+        def fn_fake(x, w):
+            return (torch.empty((), dtype=torch.float32, device=x.device),)
+
+        torch.manual_seed(0)
+        x = torch.randn(8, dtype=dtype, requires_grad=True)
+        x.grad_dtype = grad_dtype
+        w = torch.randn(8, dtype=dtype)
+        self.assertNotEqual(x.dtype, x.grad_dtype)
+
+        fn(x, w)[0].backward()
+
+        self.assertEqual(observed_inner["dtype"], dtype)
+        self.assertEqual(observed_inner["grad_dtype"], grad_dtype)
+        self.assertEqual(x.grad.dtype, grad_dtype)
+
+    def test_nonleaf_input_does_not_raise(self):
+        @leaf_function
+        def fn(x, b):
+            return (self._precision_sensitive_fn(x, b),)
+
+        @fn.register_fake
+        def fn_fake(x, b):
+            return (torch.empty((), dtype=torch.float32, device=x.device),)
+
+        x_ref, x_test = self._make_pair(64, torch.bfloat16, torch.float32)
+        torch.manual_seed(7)
+        b_leaf = torch.randn(64, dtype=torch.bfloat16)
+        b_ref = b_leaf * 2
+        b_test = b_leaf * 2
+
+        self._precision_sensitive_fn(x_ref, b_ref).backward()
+        fn(x_test, b_test)[0].backward()
+
+        self.assertTrue(torch.equal(x_test.grad, x_ref.grad))
+
+
+instantiate_parametrized_tests(TestLeafFunctionGradDtype)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_higher_order_ops/invoke_leaf_function.py
+++ b/torch/_higher_order_ops/invoke_leaf_function.py
@@ -896,6 +896,24 @@ def invoke_leaf_function_fake(
         return fake_fn_callable(*args, **kwargs)
 
 
+def _detach_with_grad_dtype(arg):
+    # Tensor.detach() resets grad_dtype to the tensor's own dtype, dropping
+    # any caller-set grad_dtype (e.g. param.grad_dtype = torch.float32 on a
+    # bf16 weight). Propagate it back so the inner autograd graph accumulates
+    # the kernel's gradient at the requested dtype. grad_dtype is only
+    # meaningful on leaf tensors.
+    if not isinstance(arg, torch.Tensor):
+        return arg
+    detached = arg.detach()
+    if (
+        arg is not detached
+        and arg.is_leaf
+        and arg.grad_dtype != detached.grad_dtype
+    ):
+        detached.grad_dtype = arg.grad_dtype
+    return detached
+
+
 @invoke_leaf_function.py_impl(DispatchKey.CompositeExplicitAutograd)
 def invoke_leaf_function_dense(
     real_fn_callable,
@@ -911,9 +929,7 @@ def invoke_leaf_function_dense(
         arg._version if isinstance(arg, torch.Tensor) else 0 for arg in flat_args
     ]
 
-    flat_args = tuple(
-        arg.detach() if isinstance(arg, torch.Tensor) else arg for arg in flat_args
-    )
+    flat_args = tuple(_detach_with_grad_dtype(arg) for arg in flat_args)
     requires_grad_indices_set = _parse_mutated_arg_indices(requires_grad_indices)
     flat_args = tuple(
         arg.requires_grad_(True) if idx in requires_grad_indices_set else arg

--- a/torch/_higher_order_ops/invoke_leaf_function.py
+++ b/torch/_higher_order_ops/invoke_leaf_function.py
@@ -905,11 +905,7 @@ def _detach_with_grad_dtype(arg):
     if not isinstance(arg, torch.Tensor):
         return arg
     detached = arg.detach()
-    if (
-        arg is not detached
-        and arg.is_leaf
-        and arg.grad_dtype != detached.grad_dtype
-    ):
+    if arg is not detached and arg.is_leaf and arg.grad_dtype != detached.grad_dtype:
         detached.grad_dtype = arg.grad_dtype
     return detached
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181798

Tensor.detach() creates a fresh leaf whose grad_dtype defaults back to
its own dtype, dropping any caller-set value (e.g. param.grad_dtype =
torch.float32 on a bf16 weight, the FSDP fp32-master pattern). When
invoke_leaf_function detaches inputs at the leaf boundary, the inner
autograd graph then casts the kernel's fp32 weight gradient down to bf16,
and the outer engine upcasts back to fp32 -- a lossy round-trip on the
weight grad that silently diverges from the un-wrapped reference.

Propagate grad_dtype across the detach boundary in invoke_leaf_function_dense
via a small _detach_with_grad_dtype helper, guarded with is_leaf since
grad_dtype is only meaningful on leaves.