### PR TITLE
[OSDC]Migrate slow.yml jobs to OSDC (ARC) via dial-up pattern

### DIFF
--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -43,6 +43,7 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+      check_experiments: arc,lf
 
   linux-jammy-cuda13_0-py3_10-gcc11-sm86-build:
     name: linux-jammy-cuda13.0-py3.10-gcc11-sm86
@@ -59,6 +60,10 @@ jobs:
           { config: "slow", shard: 2, num_shards: 3, runner: "linux.g5.4xlarge.nvidia.gpu" },
           { config: "slow", shard: 3, num_shards: 3, runner: "linux.g5.4xlarge.nvidia.gpu" },
         ]}
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   linux-jammy-cuda13_0-py3_10-gcc11-sm86-test:
@@ -67,10 +72,15 @@ jobs:
     needs:
       - linux-jammy-cuda13_0-py3_10-gcc11-sm86-build
       - target-determination
+      - get-label-type
     with:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11-sm86
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm86-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-sm86-build.outputs.test-matrix }}
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   linux-jammy-py3_10-clang18-build:
@@ -86,6 +96,9 @@ jobs:
           { config: "slow", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
           { config: "slow", shard: 2, num_shards: 2, runner: "linux.2xlarge" },
         ]}
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: clang18
     secrets: inherit
 
   linux-jammy-py3_10-clang18-test:
@@ -94,10 +107,14 @@ jobs:
     needs:
       - linux-jammy-py3_10-clang18-build
       - target-determination
+      - get-label-type
     with:
       build-environment: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix }}
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: clang18
     secrets: inherit
 
   linux-jammy-py3_10-clang18-asan-build:
@@ -116,6 +133,9 @@ jobs:
           { config: "slow", shard: 3, num_shards: 3, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
         ]}
       sync-tag: asan-build
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: clang18
     secrets: inherit
 
   linux-jammy-py3_10-clang18-asan-test:
@@ -124,9 +144,13 @@ jobs:
     needs:
       - linux-jammy-py3_10-clang18-asan-build
       - target-determination
+      - get-label-type
     with:
       build-environment: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-py3_10-clang18-asan-build.outputs.test-matrix }}
       sync-tag: asan-test
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: clang18
     secrets: inherit


### PR DESCRIPTION
Enable OSDC dial-up for all three slow.yml jobs by plumbing use-arc, python-version, compiler, and cuda-version inputs through the reusable _linux-build.yml / _linux-test.yml workflows.

Authored with Claude.