### PR TITLE
[invoke_subgraph] Pair fw and bw HOPs by per-call call_id in run_joint_graph_passes_on_hops

### DIFF
--- a/test/dynamo/test_graph_deduplication.py
+++ b/test/dynamo/test_graph_deduplication.py
@@ -119,10 +119,14 @@ class GraphModule(torch.nn.Module):
         sin: "f32[10, 20]" = torch.ops.aten.sin.default(primals_2)
 
         partitioned_fw_subgraph_0_0 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_5 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_0, 'partitioned_fw_subgraph_0_0', primals_1, sin);  partitioned_fw_subgraph_0_0 = sin = None
+
         getitem_1: "f32[]" = invoke_subgraph_5[0];  invoke_subgraph_5 = None
         partitioned_fw_subgraph_0_1 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_7 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_1, 'partitioned_fw_subgraph_0_0', primals_1, primals_2);  partitioned_fw_subgraph_0_1 = primals_1 = None
+
         getitem_2: "f32[]" = invoke_subgraph_7[0];  invoke_subgraph_7 = None
 
         mul: "f32[]" = torch.ops.aten.mul.Tensor(getitem_2, getitem_2)
@@ -209,13 +213,17 @@ class GraphModule(torch.nn.Module):
         add: "f32[10, 10]" = torch.ops.aten.add.Tensor(primals_1, 2);  primals_1 = None
 
         partitioned_fw_subgraph_0_0 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_4 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_0, 'partitioned_fw_subgraph_0_0', add);  partitioned_fw_subgraph_0_0 = add = None
+
         getitem: "f32[10, 10]" = invoke_subgraph_4[0];  invoke_subgraph_4 = None
 
         cos: "f32[10, 10]" = torch.ops.aten.cos.default(getitem)
 
         partitioned_fw_subgraph_0_1 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_6 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_1, 'partitioned_fw_subgraph_0_0', cos);  partitioned_fw_subgraph_0_1 = cos = None
+
         getitem_1: "f32[10, 10]" = invoke_subgraph_6[0];  invoke_subgraph_6 = None
 
         sin: "f32[10, 10]" = torch.ops.aten.sin.default(getitem_1)
@@ -346,25 +354,33 @@ class GraphModule(torch.nn.Module):
         sin: "f32[10, 20]" = torch.ops.aten.sin.default(primals_2)
 
         partitioned_fw_subgraph_0_0 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_9 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_0, 'partitioned_fw_subgraph_0_0', primals_1, primals_2);  partitioned_fw_subgraph_0_0 = None
+
         getitem: "f32[]" = invoke_subgraph_9[0];  invoke_subgraph_9 = None
 
         sin_1: "f32[]" = torch.ops.aten.sin.default(getitem)
 
         partitioned_fw_subgraph_0_1 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_11 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_1, 'partitioned_fw_subgraph_0_0', primals_1, sin);  partitioned_fw_subgraph_0_1 = None
+
         getitem_1: "f32[]" = invoke_subgraph_11[0];  invoke_subgraph_11 = None
 
         mul: "f32[]" = torch.ops.aten.mul.Tensor(sin_1, getitem_1);  sin_1 = None
 
         partitioned_fw_subgraph_0_2 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_13 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_2, 'partitioned_fw_subgraph_0_0', primals_1, primals_2);  partitioned_fw_subgraph_0_2 = None
+
         getitem_2: "f32[]" = invoke_subgraph_13[0];  invoke_subgraph_13 = None
         partitioned_fw_subgraph_1_0 = self.partitioned_fw_subgraph_1_0
+
         invoke_subgraph_15 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_1_0, 'partitioned_fw_subgraph_1_0', cos, sin);  partitioned_fw_subgraph_1_0 = cos = sin = None
         getitem_19: "f32[]" = invoke_subgraph_15[3]
         getitem_18: "f32[10, 20]" = invoke_subgraph_15[2]
         getitem_17: "f32[10, 10]" = invoke_subgraph_15[1]
+
         getitem_4: "f32[10, 10]" = invoke_subgraph_15[0];  invoke_subgraph_15 = None
 
         mul_1: "f32[10, 10]" = torch.ops.aten.mul.Tensor(mul, getitem_4);  mul = None

--- a/test/dynamo/test_graph_deduplication.py
+++ b/test/dynamo/test_graph_deduplication.py
@@ -430,7 +430,9 @@ class GraphModule(torch.nn.Module):
         sum_1: "f32[]" = torch.ops.aten.sum.default(add);  add = None
 
         partitioned_fw_subgraph_0_0 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_4 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_0, 'partitioned_fw_subgraph_0_0', primals_1, sum_1);  partitioned_fw_subgraph_0_0 = sum_1 = None
+
         getitem: "f32[]" = invoke_subgraph_4[0];  invoke_subgraph_4 = None
 
         add_1: "f32[]" = torch.ops.aten.add.Tensor(getitem, 2);  getitem = None
@@ -438,7 +440,9 @@ class GraphModule(torch.nn.Module):
         sum_2: "f32[]" = torch.ops.aten.sum.default(add_1);  add_1 = None
 
         partitioned_fw_subgraph_0_1 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_6 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_1, 'partitioned_fw_subgraph_0_0', primals_1, sum_2);  partitioned_fw_subgraph_0_1 = primals_1 = sum_2 = None
+
         getitem_1: "f32[]" = invoke_subgraph_6[0];  invoke_subgraph_6 = None
         return (getitem_1,)
 

--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -1307,6 +1307,196 @@ def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals
                 original_mincut_partitioner
             )
 
+    @parametrize("serialize", [False])
+    @torch._dynamo.config.patch("trace_autograd_ops", True)
+    def test_multi_invocation_chunked_loss_with_backward(self, serialize):
+        # Single nested_compile_region invoked many times in a for-loop, summed,
+        # then a single outer .backward(). Exercises pairing fw/bw HOPs by
+        # call_id when there are multiple fw calls per region.
+        nested_config = get_invoke_subgraph_compile_options()
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def chunk_loss(logits, targets):
+            return (logits - targets).pow(2).mean()
+
+        def fn(x, targets_chunks):
+            x_d = x.detach().requires_grad_()
+            total = sum(chunk_loss(x_d, t) for t in targets_chunks)
+            total.backward()
+            return total.detach(), x_d.grad.detach()
+
+        x = torch.randn(8, 4, requires_grad=True)
+        targets_chunks = [torch.randn(8, 4) for _ in range(4)]
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(
+                serialize=serialize, on_invoke_subgraph=True
+            ),
+            fullgraph=True,
+        )
+
+        ref_loss, ref_grad = fn(x.detach().clone(), targets_chunks)
+        out_loss, out_grad = opt_fn(x, targets_chunks)
+        self.assertEqual(out_loss, ref_loss)
+        self.assertEqual(out_grad, ref_grad)
+
+    @parametrize("serialize", [False])
+    @torch._dynamo.config.patch("trace_autograd_ops", True)
+    def test_two_regions_chunked_loss(self, serialize):
+        # Two nested_compile_regions composed in one fwd+bwd: `attn` called per
+        # layer, `chunk_loss` called per chunk. The fw and bw HOP counts per
+        # region differ, so positional zip-pairing fails; call_id pairing works.
+        nested_config = get_invoke_subgraph_compile_options()
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def attn(q, k):
+            return (q * k).sum(dim=-1, keepdim=True) + q
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def chunk_loss(logits, targets):
+            return (logits - targets).pow(2).mean()
+
+        def fn(x, y, targets_chunks):
+            for _ in range(3):
+                x = attn(x, y)
+            x_d = x.detach().requires_grad_()
+            total = sum(chunk_loss(x_d, t) for t in targets_chunks)
+            total.backward()
+            return total.detach(), x_d.grad.detach()
+
+        x = torch.randn(8, 4, requires_grad=True)
+        y = torch.randn(8, 4, requires_grad=True)
+        targets_chunks = [torch.randn(8, 4) for _ in range(4)]
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(
+                serialize=serialize, on_invoke_subgraph=True
+            ),
+            fullgraph=True,
+        )
+
+        ref_loss, ref_grad = fn(x.detach().clone(), y.detach().clone(), targets_chunks)
+        out_loss, out_grad = opt_fn(x, y, targets_chunks)
+        self.assertEqual(out_loss, ref_loss)
+        self.assertEqual(out_grad, ref_grad)
+
+    @parametrize("serialize", [False])
+    def test_one_fw_subgraph_multiple_bw_subgraphs(self, serialize):
+        # Same fw region called 5 times under dynamic batch dim. The tangents
+        # flowing into each call have different strides depending on their
+        # position in the fw graph, so AOTAutograd's lazy-bw cache produces
+        # multiple bw subgraphs for the same fw — bw HOPs end up with args[1]
+        # like `bw_subgraph_0_0`, `bw_subgraph_0_1`, etc., even though all fws
+        # share `fw_subgraph_0`. Each bw has its own joint partitioning, and
+        # call_id pairing routes each bw to the fw call with the matching
+        # primals — gradients must match eager.
+        @torch.compiler.nested_compile_region
+        def gn(x):
+            return torch.cos(x)
+
+        def fn(x):
+            a = gn(x)
+            a2 = gn(a)
+            b = torch.sin(a2)
+            c = gn(b)
+            c2 = gn(c)
+            return c.sum() + c2.sum() + gn(x).sum()
+
+        x = torch.randn(8, 16, requires_grad=True)
+        torch._dynamo.mark_dynamic(x, 0)
+        x_ref = x.detach().clone().requires_grad_(True)
+        torch._dynamo.mark_dynamic(x_ref, 0)
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(
+                serialize=serialize, on_invoke_subgraph=True
+            ),
+            fullgraph=True,
+        )
+
+        ref = fn(x_ref)
+        ref.backward()
+        out = opt_fn(x)
+        out.backward()
+
+        self.assertEqual(out, ref)
+        self.assertEqual(x.grad, x_ref.grad)
+
+    @parametrize("serialize", [False])
+    def test_nested_compile_region_basic_nesting(self, serialize):
+        # Outer nested_compile_region calls inner nested_compile_region once.
+        # `run_joint_graph_passes_on_hops` only sees the outer HOP at the joint
+        # graph level; inner is inside outer's subgraph and is handled by
+        # recursive regional inductor compilation, not by the joint partitioner.
+        # call_id pairing for the visible (outer) HOP must still hold.
+        @torch.compiler.nested_compile_region
+        def inner(x):
+            return x * 2
+
+        @torch.compiler.nested_compile_region
+        def outer(x):
+            return inner(x) + 1
+
+        def fn(x):
+            return outer(x).sum()
+
+        x = torch.randn(8, 4, requires_grad=True)
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(
+                serialize=serialize, on_invoke_subgraph=True
+            ),
+            fullgraph=True,
+        )
+
+        x_ref = x.detach().clone().requires_grad_()
+        ref = fn(x_ref)
+        ref.backward()
+        out = opt_fn(x)
+        out.backward()
+        self.assertEqual(out, ref)
+        self.assertEqual(x.grad, x_ref.grad)
+
+    @parametrize("serialize", [False])
+    @torch._dynamo.config.patch("trace_autograd_ops", True)
+    def test_nested_compile_region_multi_invocation(self, serialize):
+        # Outer is called multiple times in a Python for-loop; each outer call
+        # also invokes inner. Joint pass sees N outer fws and N outer bws (one
+        # per call); call_id pairs them correctly. Inner HOPs are nested inside
+        # each outer subgraph and not visible to the joint pass.
+        @torch.compiler.nested_compile_region
+        def inner(x, t):
+            return (x - t).pow(2)
+
+        @torch.compiler.nested_compile_region
+        def outer(x, t):
+            return inner(x, t).mean()
+
+        def fn(x, ts):
+            x_d = x.detach().requires_grad_()
+            total = sum(outer(x_d, t) for t in ts)
+            total.backward()
+            return total.detach(), x_d.grad.detach()
+
+        x = torch.randn(8, 4, requires_grad=True)
+        ts = [torch.randn(8, 4) for _ in range(3)]
+
+        opt_fn = torch.compile(
+            fn,
+            backend=aot_eager_regional_inductor(
+                serialize=serialize, on_invoke_subgraph=True
+            ),
+            fullgraph=True,
+        )
+
+        ref_loss, ref_grad = fn(x.detach().clone(), ts)
+        out_loss, out_grad = opt_fn(x, ts)
+        self.assertEqual(out_loss, ref_loss)
+        self.assertEqual(out_grad, ref_grad)
+
     def test_refcounts(self):
         """Tests that activations can be cleared before the end of graph"""
 

--- a/test/functorch/test_aot_joint_with_descriptors.py
+++ b/test/functorch/test_aot_joint_with_descriptors.py
@@ -1250,11 +1250,11 @@ class inner_f(torch.nn.Module):
             """\
 ('get_attr', 'repeated_subgraph0', {'mod_name': 'my_mod'})
 [('placeholder', 'arg0_1', {'mod_name': 'my_mod'}), ('call_function', 'sin', {'mod_name': 'bar'}), ('call_function', 'mul', {'mod_name': 'bar'}), ('output', 'output', {'mod_name': 'my_mod'})]
-('call_function', 'invoke_subgraph', {'mod_name': 'my_mod'})
+('call_function', 'invoke_subgraph', {'mod_name': 'my_mod', 'call_id': 1})
 ('call_function', 'getitem', {'mod_name': 'my_mod'})
 ('get_attr', 'repeated_subgraph1', {'mod_name': 'my_mod'})
 [('placeholder', 'arg0_1', {'mod_name': 'my_mod'}), ('placeholder', 'arg1_1', {'mod_name': 'my_mod'}), ('call_function', 'sin', {'mod_name': 'bar'}), ('call_function', 'mul', {'mod_name': 'bar'}), ('call_function', 'mul_1', {'mod_name': 'bar'}), ('call_function', 'cos', {'mod_name': 'bar'}), ('call_function', 'mul_2', {'mod_name': 'bar'}), ('output', 'output', {'mod_name': 'my_mod'})]
-('call_function', 'invoke_subgraph_1', {'mod_name': 'my_mod'})
+('call_function', 'invoke_subgraph_1', {'call_id': 1, 'mod_name': 'my_mod'})
 ('call_function', 'getitem_1', {'mod_name': 'my_mod'})""",
         )
 

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -1807,7 +1807,9 @@ class GraphModule(torch.nn.Module):
 class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f32[8, 8]"):
         partitioned_fw_subgraph_0_0 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_0, 'partitioned_fw_subgraph_0_0', primals_1);  partitioned_fw_subgraph_0_0 = primals_1 = None
+
         getitem: "f32[8, 8]" = invoke_subgraph_2[0]
         getitem_1: "f32[8, 8]" = invoke_subgraph_2[1];  invoke_subgraph_2 = None
 
@@ -1828,7 +1830,9 @@ class GraphModule(torch.nn.Module):
 class GraphModule(torch.nn.Module):
     def forward(self, tangents_1: "f32[8, 8]"):
         partitioned_bw_subgraph_0_0 = self.partitioned_bw_subgraph_0_0
+
         invoke_subgraph_3 = torch.ops.higher_order.invoke_subgraph(partitioned_bw_subgraph_0_0, 'partitioned_bw_subgraph_0_0', tangents_1, tangents_1);  partitioned_bw_subgraph_0_0 = tangents_1 = None
+
         getitem_2: "f32[8, 8]" = invoke_subgraph_3[0];  invoke_subgraph_3 = None
         return (getitem_2,)
 

--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -2000,10 +2000,12 @@ class GraphModule(torch.nn.Module):
 class GraphModule(torch.nn.Module):
     def forward(self, primals_1: "f32[8, 8]", primals_2: "f32[8, 8]"):
         partitioned_fw_subgraph_0_0 = self.partitioned_fw_subgraph_0_0
+
         invoke_subgraph_2 = torch.ops.higher_order.invoke_subgraph(partitioned_fw_subgraph_0_0, 'partitioned_fw_subgraph_0_0', primals_1, primals_2);  partitioned_fw_subgraph_0_0 = primals_1 = primals_2 = None
         getitem_6: "f32[8, 8]" = invoke_subgraph_2[3]
         getitem_5: "f32[8, 8]" = invoke_subgraph_2[2]
         getitem_4: "f32[8, 8]" = invoke_subgraph_2[1]
+
         getitem: "f32[8, 8]" = invoke_subgraph_2[0];  invoke_subgraph_2 = None
         sin: "f32[8, 8]" = torch.ops.aten.sin.default(getitem)
         cos: "f32[8, 8]" = torch.ops.aten.cos.default(getitem);  getitem = None
@@ -2028,7 +2030,9 @@ class GraphModule(torch.nn.Module):
     def forward(self, getitem_6: "f32[8, 8]", getitem_5: "f32[8, 8]", getitem_4: "f32[8, 8]", cos: "f32[8, 8]", tangents_1: "f32[8, 8]"):
         mul: "f32[8, 8]" = torch.ops.aten.mul.Tensor(tangents_1, cos);  tangents_1 = cos = None
         partitioned_bw_subgraph_0_0 = self.partitioned_bw_subgraph_0_0
+
         invoke_subgraph_3 = torch.ops.higher_order.invoke_subgraph(partitioned_bw_subgraph_0_0, 'partitioned_bw_subgraph_0_0', getitem_4, getitem_5, getitem_6, mul);  partitioned_bw_subgraph_0_0 = getitem_4 = getitem_5 = getitem_6 = mul = None
+
         getitem_1: "f32[8, 8]" = invoke_subgraph_3[0]
         getitem_2: "f32[8, 8]" = invoke_subgraph_3[1];  invoke_subgraph_3 = None
         return (getitem_1, getitem_2)

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -801,6 +801,13 @@ def run_joint_graph_passes_on_hops(
 
     NB: This pass works for invoke_subgraph today because we took extra care in
     the Autograd.Dispatch key of invoke_subgraph to vastly simplify Step 1.
+
+    NB: This pass only matches **top-level** invoke_subgraph HOP nodes in
+    `joint_gm`. It does not recurse into subgraph modules, so when one
+    `nested_compile_region` is invoked from inside another, the inner
+    invoke_subgraph HOPs live inside the outer's subgraph module and are not
+    paired here. Top-level HOPs are still paired correctly via `call_id`;
+    recursive partitioning of nested regions is left to downstream passes.
     """
     from torch._higher_order_ops import invoke_subgraph
 
@@ -841,17 +848,69 @@ def run_joint_graph_passes_on_hops(
     if not bw_hop_nodes:
         return joint_gm
 
-    if len(fw_hop_nodes) != len(bw_hop_nodes):
-        raise AssertionError(
-            f"expected len(fw_hop_nodes) == len(bw_hop_nodes), "
-            f"got {len(fw_hop_nodes)} != {len(bw_hop_nodes)}"
-        )
+    # The fw and bw HOP counts are not necessarily equal. A fw HOP can have no
+    # corresponding bw HOP when autograd never runs backward through that call
+    # — e.g. the user does `x_d = x.detach().requires_grad_()` between two
+    # regions, or some outputs are not used in the loss. Likewise, multiple fw
+    # calls in the same compile region can share a single bw if autograd dedups
+    # or DCEs intermediate bws.
+    #
+    # Pair fw and bw HOPs by `call_id` — a per-call counter stamped by
+    # InvokeSubgraphAutogradOp's fw/bw on each FX node. This is unambiguous
+    # regardless of how autograd dispatched the backward (single outer
+    # `.backward()`, per-iter `.backward()` in a loop, interleaved regions).
+    fws_by_call_id: dict[int, torch.fx.Node] = {}
+    for fw in fw_hop_nodes:
+        cid = fw.meta.get("custom", {}).get("call_id")
+        if cid is None:
+            continue
+        if cid in fws_by_call_id:
+            raise AssertionError(
+                f"duplicate call_id={cid} on fw HOPs "
+                f"{fws_by_call_id[cid].name!r} and {fw.name!r}"
+            )
+        fws_by_call_id[cid] = fw
 
-    # Create a bw to hop node mapping. This helps us in identifying the bw and
-    # fw subgraph pairs without relying on the identifier. This is important
-    # because we can have different subgraphs for bwd for same subgraph in the
-    # fwd because of differing strides in the backward.
-    bw_to_fw_hop_node = dict(zip(list(reversed(bw_hop_nodes)), fw_hop_nodes))
+    bw_to_fw_hop_node: dict[torch.fx.Node, torch.fx.Node] = {}
+    paired_fws: set[torch.fx.Node] = set()
+    for bw in bw_hop_nodes:
+        cid = bw.meta.get("custom", {}).get("call_id")
+        if cid is None:
+            raise AssertionError(
+                f"bw HOP {bw.args[1]!r} has no call_id in meta['custom']"
+            )
+        fw = fws_by_call_id.get(cid)
+        if fw is None:
+            raise AssertionError(
+                f"could not find matching fw HOP for bw {bw.args[1]!r} "
+                f"with call_id={cid} (fw call_ids: {sorted(fws_by_call_id)})"
+            )
+        bw_to_fw_hop_node[bw] = fw
+        paired_fws.add(fw)
+
+    # Extra fws share a compile region with a paired bw but have no bw of
+    # their own (autograd may dedup or DCE the bw). They still must be
+    # rewritten to call the new partitioned fw subgraph, otherwise the output
+    # signatures diverge from the rewritten paired fws. Key by the bw
+    # identifier so the key matches `new_hop_graphs`.
+    fw_args_to_bw_identifier: dict[str, str] = {}
+    for bw, fw in bw_to_fw_hop_node.items():
+        fw_arg = fw.args[1]
+        bw_arg = bw.args[1]
+        if not (isinstance(fw_arg, str) and isinstance(bw_arg, str)):
+            raise AssertionError(
+                f"expected fw/bw invoke_subgraph HOP args[1] to be str identifiers, "
+                f"got fw={type(fw_arg)}, bw={type(bw_arg)}"
+            )
+        fw_args_to_bw_identifier.setdefault(fw_arg, bw_arg.removeprefix("bw"))
+    extra_fws_by_id: dict[str, list[torch.fx.Node]] = defaultdict(list)
+    for fw in fw_hop_nodes:
+        if fw in paired_fws:
+            continue
+        bw_ident_key = fw_args_to_bw_identifier.get(fw.args[1])
+        if bw_ident_key is None:
+            continue
+        extra_fws_by_id[bw_ident_key].append(fw)
 
     for node in bw_hop_nodes:
         identifier = node.args[1].removeprefix("bw")
@@ -863,7 +922,19 @@ def run_joint_graph_passes_on_hops(
 
         # Collect some information from the forward hop graph
         fw_hop_node = bw_to_fw_hop_node[node]
-        fw_hop_gm = getattr(joint_gm, fw_hop_node.args[0].target)
+        fw_subgraph_attr = fw_hop_node.args[0]
+        if not isinstance(fw_subgraph_attr, torch.fx.Node):
+            raise AssertionError(
+                f"expected fw invoke_subgraph HOP args[0] to be torch.fx.Node, "
+                f"got {type(fw_subgraph_attr)}"
+            )
+        fw_subgraph_attr_target = fw_subgraph_attr.target
+        if not isinstance(fw_subgraph_attr_target, str):
+            raise AssertionError(
+                f"expected fw invoke_subgraph HOP args[0].target to be str, "
+                f"got {type(fw_subgraph_attr_target)}"
+            )
+        fw_hop_gm = getattr(joint_gm, fw_subgraph_attr_target)
         if not isinstance(fw_hop_gm, torch.fx.GraphModule):
             raise AssertionError(
                 f"expected fw_hop_gm to be GraphModule, got {type(fw_hop_gm)}"
@@ -1029,10 +1100,16 @@ def run_joint_graph_passes_on_hops(
         extra_fw_outputs = []
 
         # Insert the new_fw_hop_gm into the joint_gm
+        fw_subgraph_attr = fw_node.args[0]
+        if not isinstance(fw_subgraph_attr, torch.fx.Node):
+            raise AssertionError(
+                f"expected fw invoke_subgraph HOP args[0] to be torch.fx.Node, "
+                f"got {type(fw_subgraph_attr)}"
+            )
         with joint_gm.graph.inserting_after(fw_node):
             new_fw_mod_attr_name = add_new_hop_gm(new_fw_hop_gm, f"fw{identifier}")
             new_fw_mod_attr = joint_gm.graph.get_attr(new_fw_mod_attr_name)
-            new_fw_mod_attr.meta = copy.copy(fw_node.args[0].meta)
+            new_fw_mod_attr.meta = copy.copy(fw_subgraph_attr.meta)
 
         # new_hop_fw_gm output signature is (*fw_outs, *saved_tensors)
         with joint_gm.graph.inserting_after(new_fw_mod_attr):
@@ -1111,6 +1188,35 @@ def run_joint_graph_passes_on_hops(
 
         bw_node.replace_all_uses_with(new_bw_node)
         joint_gm.graph.erase_node(bw_node)
+
+    # Rewrite extra (unpaired) fws to call the new partitioned fw subgraph.
+    # Their additional saved-tensor outputs become dead and are pruned by
+    # eliminate_dead_code.
+    for identifier, extras in extra_fws_by_id.items():
+        if not new_hop_graphs[identifier].partitioning_done:
+            continue
+        new_fw_hop_gm = new_hop_graphs[identifier].new_fw_hop_gm
+        if new_fw_hop_gm is None:
+            continue
+        for fw_node in extras:
+            fw_subgraph_attr = fw_node.args[0]
+            if not isinstance(fw_subgraph_attr, torch.fx.Node):
+                raise AssertionError(
+                    f"expected fw invoke_subgraph HOP args[0] to be torch.fx.Node, "
+                    f"got {type(fw_subgraph_attr)}"
+                )
+            with joint_gm.graph.inserting_after(fw_node):
+                new_attr_name = add_new_hop_gm(new_fw_hop_gm, f"fw{identifier}")
+                new_attr = joint_gm.graph.get_attr(new_attr_name)
+                new_attr.meta = copy.copy(fw_subgraph_attr.meta)
+            with joint_gm.graph.inserting_after(new_attr):
+                new_fw_node = joint_gm.graph.call_function(
+                    the_function=invoke_subgraph,
+                    args=(new_attr, new_attr_name, *fw_node.args[2:]),
+                )
+                propagate_meta_info(new_fw_hop_gm, new_fw_node, fw_node)
+            fw_node.replace_all_uses_with(new_fw_node)
+            joint_gm.graph.erase_node(fw_node)
 
     joint_gm.graph.eliminate_dead_code()
     joint_gm.graph.lint()

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -624,7 +624,12 @@ def _copy_metadata_to_bw_nodes_in_subgraph(
             # TODO: better to change to a specific field of custom?
             custom = fwd_node.meta.get("custom")
             if custom is not None:
-                node.meta["custom"] = copy.deepcopy(custom)
+                # Merge rather than overwrite so bw-only keys survive
+                # fw keys win on conflict.
+                node.meta["custom"] = {
+                    **node.meta.get("custom", {}),
+                    **copy.deepcopy(custom),
+                }
 
 
 def copy_fwd_metadata_to_bw_nodes(fx_g: torch.fx.GraphModule) -> None:

--- a/torch/_higher_order_ops/invoke_subgraph.py
+++ b/torch/_higher_order_ops/invoke_subgraph.py
@@ -3,6 +3,7 @@
 import contextlib
 import copy
 import functools
+import threading
 from collections import defaultdict
 from collections.abc import Callable
 from contextlib import nullcontext
@@ -97,6 +98,34 @@ def _extract_nested_region_config(fn):
         ):
             return gm_to_compile.meta["nested_region_config"].decompositions
     return None
+
+
+# Per-call id used by downstream graph passes to pair fw and bw
+# invoke_subgraph HOP nodes (e.g. run_joint_graph_passes_on_hops). The
+# autograd Function pushes the id around its fw and bw dispatches; the
+# proxy-mode handler stamps it on the resulting FX nodes via
+# meta["custom"]["call_id"].
+_invoke_subgraph_call_state = threading.local()
+
+
+def _next_invoke_subgraph_call_id() -> int:
+    counter = getattr(_invoke_subgraph_call_state, "counter", 0)
+    _invoke_subgraph_call_state.counter = counter + 1
+    return counter
+
+
+def _current_invoke_subgraph_call_id() -> int | None:
+    return getattr(_invoke_subgraph_call_state, "current", None)
+
+
+@contextlib.contextmanager
+def _set_invoke_subgraph_call_id(call_id: int):
+    prev = getattr(_invoke_subgraph_call_state, "current", None)
+    _invoke_subgraph_call_state.current = call_id
+    try:
+        yield
+    finally:
+        _invoke_subgraph_call_state.current = prev
 
 
 class InvokeSubgraphHOP(HigherOrderOperator):
@@ -632,6 +661,7 @@ class InvokeSubgraphAutogradOp(torch.autograd.Function):
         ctx._subgraph = subgraph
         ctx._identifier = identifier
         ctx._output_metadata = output_metadata
+        ctx._call_id = _next_invoke_subgraph_call_id()
         # We snapshot the dispatch keys in forward for materializing the
         # the bw_graph in backward.
         ctx._fw_include_key_set = torch._C._dispatch_tls_local_include_set()
@@ -639,7 +669,10 @@ class InvokeSubgraphAutogradOp(torch.autograd.Function):
 
         save_values_for_backward(ctx, operands)
 
-        with torch._C._AutoDispatchBelowAutograd():
+        with (
+            torch._C._AutoDispatchBelowAutograd(),
+            _set_invoke_subgraph_call_id(ctx._call_id),
+        ):
             out = invoke_subgraph(
                 subgraph,
                 f"fw_{identifier}",
@@ -789,9 +822,10 @@ class InvokeSubgraphAutogradOp(torch.autograd.Function):
                 identifier, tangent_metadata, bw_graph
             )
 
-        grads = invoke_subgraph(
-            bw_graph, f"bw_{identifier}_{suffix}", *primals_and_tangents
-        )[: -output_metadata.num_fw_outs]
+        with _set_invoke_subgraph_call_id(ctx._call_id):
+            grads = invoke_subgraph(
+                bw_graph, f"bw_{identifier}_{suffix}", *primals_and_tangents
+            )[: -output_metadata.num_fw_outs]
         return None, None, None, *grads
 
 
@@ -1072,11 +1106,17 @@ def _(proxy_mode: ProxyTorchDispatchMode, subgraph, identifier, *operands):
         ):
             nested_config = gm.meta["nested_region_config"]
             break
-    if nested_config is not None:
+
+    call_id = _current_invoke_subgraph_call_id()
+
+    if nested_config is not None or call_id is not None:
         node = out_proxy.node
         if "custom" not in node.meta:
             node.meta["custom"] = {}
-        node.meta["custom"]["nested_region_config"] = nested_config
+        if nested_config is not None:
+            node.meta["custom"]["nested_region_config"] = nested_config
+        if call_id is not None:
+            node.meta["custom"]["call_id"] = call_id
 
     example_out = invoke_subgraph(graph, identifier, *operands)
     return track_tensor_tree(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #181958
* #181834
* #181809
* __->__ #181808


### Problem

`run_joint_graph_passes_on_hops` paired forward and backward `invoke_subgraph`
HOP nodes positionally:

```python
bw_to_fw_hop_node = dict(zip(reversed(bw_hop_nodes), fw_hop_nodes))
# ...
if len(fw_hop_nodes) != len(bw_hop_nodes):
    raise AssertionError(
        f"expected len(fw_hop_nodes) == len(bw_hop_nodes), "
        f"got {len(fw_hop_nodes)} != {len(bw_hop_nodes)}"
    )
```

This breaks for any model that uses **two** `nested_compile_region`s where one
of them is invoked many times in a Python `for` loop. A common shape:
`attn` called once per layer (`N` calls) plus `chunk_loss` called once per
loss-vocab chunk (`M` calls). When `M ≠ N`, autograd dispatch produces fw and
bw counts that don't match the strict `zip(reversed, ...)` expectation, and the
assertion fires (we observed `5 != 1`, `8 != 4`, `12 != 5`, etc.).

Even when the counts happen to match, the assumption that bws appear strictly
in reverse fw order is wrong when a region is called inside a per-iteration
`.backward()` loop — the bws there are **interleaved** with their fws (one bw
right after each fw), not all at the end of the joint graph.

### Why fw and bw HOP counts may not match

The strict `len(fw) == len(bw)` invariant the old code assumed is wrong even
in well-formed user programs. Concretely, a fw `invoke_subgraph` HOP can have
**no** corresponding bw HOP, and a single bw HOP can correspond to **many** fw
HOPs of the same region. The asymmetry comes from autograd's behavior, not
from anything the user is doing wrong:

1. **Detach severs the autograd graph.** If the user does
   `x_d = x.detach().requires_grad_()` between two regions, backward only
   flows through the second region — the first region's fws have no bw at all.
   Concrete shape from `test_two_regions_chunked_loss`:

   ```python
   for _ in range(3):
       x = attn(x, y)              # 3 fw attn HOPs, no bw
   x_d = x.detach().requires_grad_()
   total = sum(chunk_loss(x_d, t) for t in targets_chunks)  # 4 fw + 4 bw
   total.backward()
   ```

   Result: 7 fw HOPs, 4 bw HOPs.

2. **Outputs not used in the loss.** When some region outputs don't reach the
   loss tensor `.backward()` is called on, autograd never dispatches that
   region's backward. Its fws stand alone.

3. **Autograd dedup / DCE.** Multiple fw calls in the same compile region can
   end up sharing one bw if autograd dedups identical backward sub-tasks
   (we have observed `5 != 1`, `8 != 4`, `12 != 5` in production training
   workloads where a region was called many times per step).

The pairing pass therefore needs to handle three cases per fw HOP: paired
with a bw of its own (rewrite both), unpaired but in a region that has
*some* paired bw (rewrite the fw to match the new partitioned signature),
and unpaired with no paired bw in its region (leave as-is — there's no new
partitioned subgraph for it to call).

### Why the pairing has to be exact (and we have to add call_id)

Given how the rewrite is structured today, the bijection between paired fws
and bws cannot be arbitrary — each bw must be paired with the fw that came
from the *same* `InvokeSubgraphAutogradOp.apply` call. The rewrite (in
`run_joint_graph_passes_on_hops`) inserts the new partitioned fw using
`*fw_node.args[2:]` (the paired fw's primals) and feeds *those* saved tensors
into the new bw:

```python
new_fw_node = call_function(invoke_subgraph, (new_fw_mod, name, *fw_node.args[2:]))
saved_tensor_nodes = extra_fw_outputs[:new_num_saved_nodes]
tangents = bw_node.args[2 + num_primals :]
new_bw_node = call_function(invoke_subgraph,
                            (new_bw_mod, bw_name, *sym_nodes, *saved_tensor_nodes, *tangents))
```

Saved tensors are deterministic functions of the call's primals. After
partitioning the bw expects `(saved_tensors, tangents)` — primals are gone —
so the bw is fully determined by whichever fw fed its saved tensors. Mispair
`bw_i ← fw_j` and the resulting graph computes
`grads_i = bw_partition(saved_tensors_from_primals_j, tangents_i)`, which is
the wrong gradient (the call that produced `tangents_i` had primals `i`, not
`j`).

This was masked under the old positional `dict(zip(reversed(bw), fw))`
because for the common top-down shape `fw1, fw2, fw3, …, bw3, bw2, bw1`,
positional reversal happens to land on the correct bijection. For
interleaved or partially-detached graphs (per-iter `.backward()` in a loop,
two regions with different fw/bw counts) it picks the wrong pairing — silent
wrong-grad when counts happen to match, assertion failure when they don't.
`call_id` makes the correct bijection explicit at dispatch time so the
rewrite is correct under any dispatch order.

There is a possible refactor that would remove the bijection requirement
entirely: feed the *bw's own* primals (`bw_node.args[2:2+num_primals]`) into
the new fw call rather than the paired fw's. Then saved tensors are
self-contained per bw and any unique fw can be picked just for the purpose
of replacing its downstream uses. That is structurally cleaner but is out of
scope here.

### Fix

Stamp each `invoke_subgraph` HOP node with a per-call `call_id` and pair fw/bw
by that id. Each call to `InvokeSubgraphAutogradOp.apply` gets a fresh id, so
the pairing is unambiguous regardless of how the autograd backward is
dispatched (single outer `.backward()`, per-iter `.backward()` in a loop,
multi-region interleaving, etc.).

#### `torch/_higher_order_ops/invoke_subgraph.py`

- Added a thread-local counter (`_invoke_subgraph_call_state`,
  `_next_invoke_subgraph_call_id`, `_set_invoke_subgraph_call_id` context
  manager).
- `InvokeSubgraphAutogradOp.forward` increments the counter into
  `ctx._call_id` and pushes it via the context manager across the
  `invoke_subgraph(subgraph, "fw_…", …)` dispatch.
- `InvokeSubgraphAutogradOp.backward` pushes the same `ctx._call_id` across
  the bw dispatch.
- The proxy-mode handler reads `_current_invoke_subgraph_call_id()` and
  stamps `node.meta["custom"]["call_id"]` on the resulting fw / bw FX nodes.

#### `torch/_functorch/_aot_autograd/utils.py`

- `_copy_metadata_to_bw_nodes_in_subgraph` now **merges** fw `meta["custom"]`
  into bw `meta["custom"]` rather than overwriting. This preserves bw-only
  keys (specifically `call_id`) when the fw node picked for the seq_nr
  match is a `get_attr` for the subgraph module — that get_attr inherits
  some custom keys from the GraphModule but not the per-call ids set by the
  proxy tracer.

#### `torch/_functorch/_aot_autograd/graph_compile.py`

- `run_joint_graph_passes_on_hops` pairs fw and bw HOPs by
  `node.meta["custom"]["call_id"]`. The strict `len(fw) == len(bw)`
  assertion is gone. Unpaired fws that share a compile region with some
  paired bw (identified via the fw HOP's `args[1]`, which is `fw_<region>`)
  are still rewritten to call the new partitioned fw subgraph; their extra
  saved-tensor outputs become dead and `eliminate_dead_code` prunes them.
  Unpaired fws whose region has no paired bw at all are left untouched.
- Docstring updated with a note that this pass only matches **top-level**
  invoke_subgraph HOPs in `joint_gm`. When one `nested_compile_region` is
  invoked from inside another, the inner HOPs live inside the outer's
  subgraph module and are not paired here; recursive partitioning of nested
  regions is left to downstream passes.

### Tests

`test/dynamo/test_regional_inductor.py::RegionalInductorInvokeSubgraphTests`,
five new tests:

- `test_multi_invocation_chunked_loss_with_backward` — single region invoked
  many times in a `for` loop with sum-then-single-backward; checks forward
  output and input gradient match eager.
- `test_two_regions_chunked_loss` — two regions composed (3 attn + 4
  chunk_loss) in one fwd+bwd; checks forward output and input gradient match
  eager. **Fails on main** with
  `AssertionError: expected len(fw_hop_nodes) == len(bw_hop_nodes), got 7 != 4`;
  passes on this PR.
- `test_one_fw_subgraph_multiple_bw_subgraphs` — same fw region called 5
  times under a dynamic batch dim; tangent-stride differences cause the
  lazy-bw cache to produce **multiple** bw subgraphs (`bw_subgraph_0_0`,
  `bw_subgraph_0_1`, …) for one fw. Each bw gets its own joint
  partitioning; `call_id` routes each bw to the fw call with the matching
  primals. Asserts forward output and input gradient match eager.
- `test_nested_compile_region_basic_nesting` — outer region calls inner
  region once; verifies pairing works at the top level even when subgraphs
  contain other invoke_subgraph HOPs.
- `test_nested_compile_region_multi_invocation` — outer region called N
  times in a loop, each call also invokes inner. Joint pass sees N outer
  fws and N outer bws (paired by call_id); inner HOPs are nested inside
  each outer subgraph and not visible to the joint pass.

All tests in `test_regional_inductor.py` pass on this PR, including
existing coverage like `test_simple`, `test_repeated_blocks`,
`test_two_graphs`, and `test_invoke_subgraph_inner`.


tests that need to be updated:

```
  python test/higher_order_ops/test_invoke_subgraph.py TestInvokeSubgraphCompile.test_bwd_partitioning
  python test/dynamo/test_graph_deduplication.py GraphDededuplicationTests.test_dependent_subgraphs
  python test/functorch/test_aot_joint_with_descriptors.py TestAOTJointWithDescriptors.test_annotate_invoke_subgraph_simple
```

### Validation against a real workload

Combined with the companion rigi [PR](https://github.com/fairinternal/rigi/pull/356) (using `nested_compile_region` around a
chunked CE loss),  training compiles end-to-end and the
chunked-CE bw region is fully fused by Inductor.

| Variant                                    | Peak    | Median step |
|--------------------------------------------|---------|-------------|
| Un-lowered ATen baseline                   | ~17.0 G | 1330 ms     |
| autograd.Function chunked CE (no region)   | 14.35 G | 1610 ms     |
| **`nested_chunk_loss` region (this PR)**   | **13.7 G** | **1206 ms** |
| fg=False reference target                  | 12.5 G  |  1440 ms         |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98