### PR TITLE
Fix typos across torch codebase

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1494,7 +1494,7 @@ def use_deterministic_algorithms(
         will use some heuristics to pick the most promising configs rather
         than do autotuning.
       - Skip autotuning for reduction in coordinate descent tuning.
-      - Don't benchmarking for the computation/communication reordering pass
+      - Don't benchmark for the computation/communication reordering pass
       - Disable the feature that dynamically scale down RBLOCK triton config for higher
         occupancy.
 

--- a/torch/_inductor/fx_passes/auto_chunker/propagator.py
+++ b/torch/_inductor/fx_passes/auto_chunker/propagator.py
@@ -444,8 +444,8 @@ def propagate_general_copy_metadata(
             and first_meta.chunk_dim is not None
             and _chunk_broadcasted_tensor(first_meta.chunk_dim)
         ):
-            # We don't chunking a broadcasted tensor for now.
-            # Can add the rule if such a use case come up
+            # We don't chunk a broadcasted tensor for now.
+            # Can add the rule if such a use case comes up
             return PropagateStatus.FAIL
 
         changed = set_chunking_meta_if_none(

--- a/torch/csrc/jit/ir/ir_views.h
+++ b/torch/csrc/jit/ir/ir_views.h
@@ -143,7 +143,7 @@ struct LoopView {
  private:
   Node* node_;
 
-  // adjust index_ordering by adding indices 0 - thorough adjust, and
+  // adjust index_ordering by adding indices 0 - through adjust, and
   // incrementing all existing inputs by adjust
   static std::vector<size_t> adjustIndices(
       size_t adjust,

--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -406,7 +406,7 @@ class ShardedTensor(ShardedTensorBase):
             dst(int): The rank where full tensor is constructed.
                 Default: 0
             out (:class `torch.Tensor`, optional): The output full tensor.
-                Must to be provided ONLY on ``dst`` rank.
+                Must be provided ONLY on ``dst`` rank.
                 Default: ``None``
             enforce_dtype (bool): Deprecated, please use dtype instead.  Force the
                 gathered tensors to be the same type as input and output.

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_init.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_init.py
@@ -297,7 +297,7 @@ def _get_managed_modules(
 
     modules: list[nn.Module] = []
     root_modules_set = set(root_modules)
-    # Track visisted modules to avoid visiting shared modules multiple times
+    # Track visited modules to avoid visiting shared modules multiple times
     visited_modules: set[nn.Module] = set()
 
     def dfs(module: nn.Module) -> None:

--- a/torch/sparse/_semi_structured_conversions.py
+++ b/torch/sparse/_semi_structured_conversions.py
@@ -216,7 +216,7 @@ def sparse_semi_structured_to_dense_cutlass(sparse, meta_reordered):
     meta_nrows, meta_ncols = meta_reordered.shape
     if meta_nrows != m:
         raise RuntimeError(
-            f"Number of rows of meta matrix {meta_nrows} must be equal to number of columns of spase matrix {m}"
+            f"Number of rows of meta matrix {meta_nrows} must be equal to number of columns of sparse matrix {m}"
         )
     if meta_ncols * ksparse * quadbits_per_meta_elem != 2 * k:
         raise RuntimeError(

--- a/torch/utils/tensorboard/_utils.py
+++ b/torch/utils/tensorboard/_utils.py
@@ -104,7 +104,7 @@ def make_grid(I, ncols=8):
 
 def convert_to_HWC(tensor, input_format):  # tensor: numpy array
     if len(set(input_format)) != len(input_format):
-        raise AssertionError(f"You can not use the same dimension shordhand twice. \
+        raise AssertionError(f"You can not use the same dimension shorthand twice. \
             input_format: {input_format}")
     if len(tensor.shape) != len(input_format):
         raise AssertionError(f"size of input tensor and input format are different. \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181813

Correct various spelling mistakes in comments, docstrings, and error
messages: "benchmarking" → "benchmark", "chunking" → "chunk", "thorough"
→ "through", "Must to be" → "Must be", "visisted" → "visited", "spase"
→ "sparse", and "shordhand" → "shorthand".

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo