### PR TITLE
Make custom-test binaries' RUNPATH $ORIGIN-relative

### DIFF
--- a/test/custom_backend/CMakeLists.txt
+++ b/test/custom_backend/CMakeLists.txt
@@ -2,6 +2,11 @@
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(custom_backend)
 
+# CI reuses these build artifacts across runners that may have different
+# absolute workspace paths; emit $ORIGIN-relative RUNPATH so the binary finds
+# its sibling .so wherever the build tree is dropped.
+set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
+
 if(USE_ROCM)
 include(utils)
 include(LoadHIP)

--- a/test/custom_operator/CMakeLists.txt
+++ b/test/custom_operator/CMakeLists.txt
@@ -2,6 +2,11 @@
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(custom_ops)
 
+# CI reuses these build artifacts across runners that may have different
+# absolute workspace paths; emit $ORIGIN-relative RUNPATH so the binary finds
+# its sibling .so wherever the build tree is dropped.
+set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
+
 if(USE_ROCM)
 include(utils)
 include(LoadHIP)

--- a/test/jit_hooks/CMakeLists.txt
+++ b/test/jit_hooks/CMakeLists.txt
@@ -2,6 +2,11 @@
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(jit_hooks)
 
+# CI reuses these build artifacts across runners that may have different
+# absolute workspace paths; emit $ORIGIN-relative RUNPATH so the binary finds
+# its sibling .so wherever the build tree is dropped.
+set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
+
 if(USE_ROCM)
 include(utils)
 include(LoadHIP)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181814

`test/custom_{operator,backend}/` and `test/jit_hooks/` are standalone
CMake projects, so they don't pick up the $ORIGIN-style RPATH setup that
`cmake/Dependencies.cmake` configures for the main project. CMake's
default behavior bakes the absolute build directory into `DT_RUNPATH`,
which breaks once the artifact is moved.

This bites the artifact-reuse path in CI: `reuse-old-whl` downloads
`build/custom_test_artifacts/` from a prior main-branch run, and that
prior run may have been an OSDC build (workspace `/__w/pytorch/pytorch/`)
while the test runner is on EC2 (workspace `/var/lib/jenkins/workspace/`).
The embedded RUNPATH points at a path that doesn't exist on the test
runner, so `build/test_custom_ops` fails with `libcustom_ops.so: cannot
open shared object file` and the shell exits 127.

Setting `CMAKE_BUILD_RPATH_USE_ORIGIN` makes the linker emit
$ORIGIN-relative entries instead. Since `test.sh` always copies the
build tree so the binary and its sibling .so are co-located, $ORIGIN
resolves correctly regardless of where the artifact came from.

Authored with Claude.