### PR TITLE
Update arc.yaml runner mappings for 3 renamed GPU scale sets

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -58,15 +58,15 @@ runner_mapping:
 
   # ---- x86 GPU — T4 (g4dn family) ----
 
-  linux.g4dn.4xlarge.nvidia.gpu: l-x86iavx512-29-115-t4          # g4dn.4xlarge
+  linux.g4dn.4xlarge.nvidia.gpu: l-x86iavx512-29-114-t4          # g4dn.4xlarge
   linux.g4dn.12xlarge.nvidia.gpu: l-x86iavx512-45-172-t4-4       # g4dn.12xlarge
   linux.g4dn.metal.nvidia.gpu: l-bx86iavx512-94-344-t4-8         # g4dn.metal
 
   # ---- x86 GPU — A10G (g5 family) ----
 
   linux.g5.4xlarge.nvidia.gpu: l-x86aavx2-29-113-a10g            # g5.4xlarge
-  linux.g5.12xlarge.nvidia.gpu: l-x86aavx2-45-167-a10g-4         # g5.12xlarge
-  linux.g5.48xlarge.nvidia.gpu: l-x86aavx2-189-704-a10g-8        # g5.48xlarge
+  linux.g5.12xlarge.nvidia.gpu: l-x86aavx2-45-166-a10g-4         # g5.12xlarge
+  linux.g5.48xlarge.nvidia.gpu: l-x86aavx2-189-703-a10g-8        # g5.48xlarge
 
   # ---- x86 GPU — L4 (g6 family) ----
 


### PR DESCRIPTION
The OSDC scale sets for the g4dn.4xlarge, g5.12xlarge, and g5.48xlarge GPU runners are being renamed in pytorch/ci-infra to match their post-bump workflow memory after the runner sidecar was raised from 512Mi to 768Mi (which trimmed each fleet's job memory by 1Gi to keep the pair within node-allocatable):

- l-x86iavx512-29-115-t4    -> l-x86iavx512-29-114-t4
- l-x86aavx2-45-167-a10g-4  -> l-x86aavx2-45-166-a10g-4
- l-x86aavx2-189-704-a10g-8 -> l-x86aavx2-189-703-a10g-8

This file maps the legacy `linux.*` `runs-on` labels used in pytorch CI workflows to the OSDC scale-set names, so it must be updated in the same window that the ci-infra rename lands. Keeping the legacy keys (`linux.g4dn.4xlarge.nvidia.gpu`, `linux.g5.12xlarge.nvidia.gpu`, `linux.g5.48xlarge.nvidia.gpu`) unchanged so no workflow YAMLs need to move.

Paired PR (ci-infra): the rename commit on branch
`bump-runner-pod-memory-768mi`.

## Test plan
- [ ] Land the ci-infra PR first so both old and new scale sets are registered with ARC during deploy.
- [ ] Land this PR within the same hour to redirect pytorch CI jobs to the new scale-set names before the old scale sets are uninstalled.
- [ ] Verify GPU jobs targeting these three legacy labels start scheduling against the new scale sets in the pytorch CI HUD.