### PR TITLE
Docs: update torch.multinomial num_samples requirement note for bette…

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7835,7 +7835,7 @@ If not, they are drawn without replacement, which means that when a
 sample index is drawn for a row, it cannot be drawn again for that row.
 
 .. note::
-    When drawn without replacement, :attr:`num_samples` must be lower than
+    When drawn without replacement, :attr:`num_samples` must be less than or equal to the
     number of non-zero elements in :attr:`input` (or the min number of non-zero
     elements in each row of :attr:`input` if it is a matrix).
 


### PR DESCRIPTION
Fixed inconsistency in torch.multinomial. Previously the note said "lower than" but example allows "equal to" for num_samples without replacement. 


Evidence from Example:

>>> weights = torch.tensor([0, 10, 3, 0], dtype=torch.float)  # Contains exactly 2 non-zero elements
>>> torch.multinomial(weights, 2)  # Runs successfully, returns tensor([1, 2])
