### PR TITLE
Return LSE from flex flash in correct base

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -1,9 +1,10 @@
 # Owner(s): ["module: inductor"]
 
 import functools
+import math
 import unittest
 from collections.abc import Callable
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 
 import torch
@@ -80,6 +81,21 @@ def _distance_decay(score, _b, _h, q_idx, kv_idx):
     distance_sq = (q_idx - kv_idx) * (q_idx - kv_idx)
     decay = 1.0 / (1.0 + distance_sq * 0.0001)
     return score * decay
+
+
+def _fake_flex_attention_hop_units_by_backend(
+    query, key, value, _score_mod, _block_mask, scale, kernel_options
+):
+    scores = torch.matmul(query.float(), key.float().transpose(-2, -1)) * scale
+    out = torch.matmul(torch.softmax(scores, dim=-1).to(query.dtype), value)
+    if kernel_options["BACKEND"] == "FLASH":
+        return out, torch.logsumexp(scores, dim=-1), torch.max(scores, dim=-1).values
+    inv_ln2 = 1 / math.log(2.0)
+    return (
+        out,
+        torch.logsumexp(scores, dim=-1) * inv_ln2,
+        torch.max(scores, dim=-1).values * inv_ln2,
+    )
 
 
 def create_alibi_learned(num_heads=4, dtype=torch.float16):
@@ -1323,6 +1339,59 @@ class TestFlexFlash(InductorTestCase):
                 flash_vs_triton(q, k, v, block_mask=block_mask)
         else:
             flash_vs_triton(q, k, v, block_mask=block_mask)
+
+    @xfailIfSM120OrLater
+    @dtypes(torch.float16, torch.bfloat16)
+    @parametrize("deterministic", [False, True])
+    def test_flash_backend_return_lse_matches_triton_and_reference(
+        self, device, dtype, deterministic
+    ):
+        from torch.nn.attention import flex_attention as flex_attention_module
+
+        torch.manual_seed(0)
+        q, k, v = create_test_tensors(
+            batch_size=1,
+            num_heads=2,
+            seq_len=128,
+            dim=32,
+            dtype=dtype,
+            device=device,
+        )
+
+        flash_flex = torch.compile(
+            functools.partial(
+                flex_attention,
+                scale=1.0,
+                return_lse=True,
+                kernel_options={"BACKEND": "FLASH"},
+            )
+        )
+        triton_flex = torch.compile(
+            functools.partial(
+                flex_attention,
+                scale=1.0,
+                return_lse=True,
+                kernel_options={"BACKEND": "TRITON"},
+            )
+        )
+        context = DeterministicGuard(True) if deterministic else nullcontext()
+        ref_lse = torch.logsumexp(
+            torch.matmul(q.float(), k.float().transpose(-2, -1)), dim=-1
+        )
+
+        with (
+            unittest.mock.patch.object(
+                flex_attention_module,
+                "flex_attention_hop",
+                _fake_flex_attention_hop_units_by_backend,
+            ),
+            context,
+        ):
+            _, lse_flash = flash_flex(q, k, v)
+            _, lse_triton = triton_flex(q, k, v)
+
+        torch.testing.assert_close(lse_triton.float(), ref_lse, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(lse_flash.float(), ref_lse, atol=1e-5, rtol=1e-5)
 
     @xfailIfSM120OrLater
     @dtypes(torch.float16, torch.bfloat16)

--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -1,10 +1,9 @@
 # Owner(s): ["module: inductor"]
 
 import functools
-import math
 import unittest
 from collections.abc import Callable
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 import torch
@@ -81,21 +80,6 @@ def _distance_decay(score, _b, _h, q_idx, kv_idx):
     distance_sq = (q_idx - kv_idx) * (q_idx - kv_idx)
     decay = 1.0 / (1.0 + distance_sq * 0.0001)
     return score * decay
-
-
-def _fake_flex_attention_hop_units_by_backend(
-    query, key, value, _score_mod, _block_mask, scale, kernel_options
-):
-    scores = torch.matmul(query.float(), key.float().transpose(-2, -1)) * scale
-    out = torch.matmul(torch.softmax(scores, dim=-1).to(query.dtype), value)
-    if kernel_options["BACKEND"] == "FLASH":
-        return out, torch.logsumexp(scores, dim=-1), torch.max(scores, dim=-1).values
-    inv_ln2 = 1 / math.log(2.0)
-    return (
-        out,
-        torch.logsumexp(scores, dim=-1) * inv_ln2,
-        torch.max(scores, dim=-1).values * inv_ln2,
-    )
 
 
 def create_alibi_learned(num_heads=4, dtype=torch.float16):
@@ -1342,16 +1326,11 @@ class TestFlexFlash(InductorTestCase):
 
     @xfailIfSM120OrLater
     @dtypes(torch.float16, torch.bfloat16)
-    @parametrize("deterministic", [False, True])
-    def test_flash_backend_return_lse_matches_triton_and_reference(
-        self, device, dtype, deterministic
-    ):
-        from torch.nn.attention import flex_attention as flex_attention_module
-
+    def test_flash_backend_return_lse_matches_triton_and_reference(self, device, dtype):
         torch.manual_seed(0)
         q, k, v = create_test_tensors(
             batch_size=1,
-            num_heads=2,
+            num_heads=1,
             seq_len=128,
             dim=32,
             dtype=dtype,
@@ -1374,24 +1353,18 @@ class TestFlexFlash(InductorTestCase):
                 kernel_options={"BACKEND": "TRITON"},
             )
         )
-        context = DeterministicGuard(True) if deterministic else nullcontext()
+
+        _, lse_flash = flash_flex(q, k, v)
+        _, lse_triton = triton_flex(q, k, v)
         ref_lse = torch.logsumexp(
             torch.matmul(q.float(), k.float().transpose(-2, -1)), dim=-1
         )
 
-        with (
-            unittest.mock.patch.object(
-                flex_attention_module,
-                "flex_attention_hop",
-                _fake_flex_attention_hop_units_by_backend,
-            ),
-            context,
-        ):
-            _, lse_flash = flash_flex(q, k, v)
-            _, lse_triton = triton_flex(q, k, v)
-
-        torch.testing.assert_close(lse_triton.float(), ref_lse, atol=1e-5, rtol=1e-5)
-        torch.testing.assert_close(lse_flash.float(), ref_lse, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(lse_triton.float(), ref_lse, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(lse_flash.float(), ref_lse, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(
+            lse_flash.float(), lse_triton.float(), atol=1e-4, rtol=1e-4
+        )
 
     @xfailIfSM120OrLater
     @dtypes(torch.float16, torch.bfloat16)

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -2022,16 +2022,19 @@ def flex_attention(
         *,
         return_aux: AuxRequest | None,
         return_lse: bool,
+        stats_are_log2: bool,
     ):
         """Normalize stats and build return value (aux-aware, legacy-compatible)."""
         ln2 = math.log(2.0)
         return_lse = return_lse or return_aux is not None and return_aux.lse
         return_max = return_aux is not None and return_aux.max_scores
 
-        lse_scaled = lse * ln2 if (return_lse and lse.numel() > 0) else None
-        max_scaled = (
-            max_scores * ln2 if (return_max and max_scores.numel() > 0) else None
-        )
+        lse_scaled = lse if (return_lse and lse.numel() > 0) else None
+        max_scaled = max_scores if (return_max and max_scores.numel() > 0) else None
+
+        if stats_are_log2:
+            lse_scaled = lse_scaled * ln2 if lse_scaled is not None else None
+            max_scaled = max_scaled * ln2 if max_scaled is not None else None
 
         if return_aux is not None:
             return out, AuxOutput(
@@ -2060,7 +2063,12 @@ def flex_attention(
             kernel_options,  # type: ignore[union-attr]
         )
         return _finalize_outputs(
-            out, lse, max_scores, return_aux=return_aux, return_lse=return_lse
+            out,
+            lse,
+            max_scores,
+            return_aux=return_aux,
+            return_lse=return_lse,
+            stats_are_log2=kernel_options["BACKEND"] != "FLASH",
         )
 
     if not _FLEX_ATTENTION_DISABLE_COMPILE_DEBUG:
@@ -2101,5 +2109,11 @@ def flex_attention(
             kernel_options,
         )
     return _finalize_outputs(
-        out, lse, max_scores, return_aux=return_aux, return_lse=return_lse
+        out,
+        lse,
+        max_scores,
+        return_aux=return_aux,
+        return_lse=return_lse,
+        stats_are_log2=_FLEX_ATTENTION_DISABLE_COMPILE_DEBUG
+        or kernel_options["BACKEND"] != "FLASH",
     )


### PR DESCRIPTION
## Human Note
Straight forward fix for top level wrapper to return in expected base

Fixes: #181645


## Agent Report
# Report

## Summary of the issue
`flex_attention(..., kernel_options={"BACKEND": "FLASH"}, return_lse=True)` returned FLASH `lse` in the wrong units during `torch.compile`: FA4 already returned natural-log `lse`, but the public finalizer treated it like log2-space stats and multiplied by `ln(2)` again.

The clean ptq worktree for this run already contained the minimal product fix in `torch/nn/attention/flex_attention.py` (commit `d6b1b77a134`, `Return LSE from flex flash in correct base`). In this run I kept that source fix and replaced the old stubbed regression test with a real FLASH-backend test.

## Root cause analysis
The flex-attention finalizer converts backend statistics from log2 space back to natural-log space. That is correct for the TRITON path and the eager math fallback, but wrong for FA4/FLASH because FA4 already returns natural-log `lse`. Without a FLASH-specific unit check, compiled FLASH `lse` gets over-scaled by `ln(2)`.

## What the fix does
The product fix in `torch/nn/attention/flex_attention.py` makes finalization conditional on whether the backend stats are actually log2-based, so FLASH skips the extra `* ln(2)`.

In this run I updated `test/inductor/test_flex_flash.py` to:
- remove the fake `_fake_flex_attention_hop_units_by_backend` helper
- remove the `unittest.mock.patch`-based test path
- add a focused real-backend test that compiles `flex_attention` with `BACKEND="FLASH"` and `BACKEND="TRITON"`, `return_lse=True`, `scale=1.0`, and checks both against the natural-log reference

<details>
<summary>Repro Script</summary>

```python
import math
from functools import partial

import torch
from torch.nn.attention.flex_attention import flex_attention


def main() -> None:
    torch.manual_seed(0)
    N, D = 1024, 32
    q = torch.randn(1, 1, N, D, device="cuda", dtype=torch.float16)
    k = torch.randn(1, 1, N, D, device="cuda", dtype=torch.float16)
    v = torch.randn(1, 1, N, D, device="cuda", dtype=torch.float16)

    triton = torch.compile(partial(flex_attention, kernel_options={"BACKEND": "TRITON"}))
    flash = torch.compile(partial(flex_attention, kernel_options={"BACKEND": "FLASH"}))

    _, lse_t = triton(q, k, v, scale=1.0, return_lse=True)
    _, lse_f = flash(q, k, v, scale=1.0, return_lse=True)

    ref = torch.logsumexp(q.squeeze().float() @ k.squeeze().float().T, dim=-1)
    print((lse_t.squeeze().float() - ref).abs().max())
    print((lse_f.squeeze().float() - ref).abs().max())
    print((lse_f.squeeze().float() / math.log(2.0) - ref).abs().max())


if __name__ == "__main__":
    main()
```

Output on the fixed tree:

```text
tensor(7.6294e-06, device='cuda:0')
tensor(8.9645e-05, device='cuda:0')
tensor(12.8411, device='cuda:0')
```
</details>

## Test results
### Regression test before the fix
I temporarily reverted `torch/nn/attention/flex_attention.py` to the old unconditional `* ln(2)` behavior to validate the new real-backend test against the actual bug.

Command:
```text
cd /home/dev/.ptq_workspace/jobs/20260429-pytorch-181645/pytorch && /home/dev/.ptq_workspace/jobs/20260429-pytorch-181645/.venv/bin/python -m pytest test/inductor/test_flex_flash.py -k return_lse_matches_triton_and_reference -q
```

Result:
```text
FF
2 failed, 218 deselected in 14.75s
```

The failures showed FLASH `lse` off by about `7.99` for both `float16` and `bfloat16`.

The standalone repro also showed the bug after the temporary revert:
```text
tensor(7.6294e-06, device='cuda:0')
tensor(8.9009, device='cuda:0')
tensor(8.9645e-05, device='cuda:0')
```

### Regression test after restoring the fix
Command:
```text
cd /home/dev/.ptq_workspace/jobs/20260429-pytorch-181645/pytorch && /home/dev/.ptq_workspace/jobs/20260429-pytorch-181645/.venv/bin/python -m pytest test/inductor/test_flex_flash.py -k return_lse_matches_triton_and_reference -q
```

Result:
```text
..
2 passed, 218 deselected in 14.57s
```

The standalone repro also passed again with real FLASH, matching the natural-log reference closely.

### Lint
`spin fixlint` was run as requested, but it failed in the repo-wide `CLANGTIDY_EXECUTORCH_COMPATIBILITY` step because this checkout has no `pytorch/build` directory. No extra tracked file changes were left behind.


Fixes #181645


<details>
<summary>Repro Script</summary>

```python
import math
from functools import partial

import torch
from torch.nn.attention.flex_attention import flex_attention


def main() -> None:
    torch.manual_seed(0)
    N, D = 1024, 32
    q = torch.randn(1, 1, N, D, device="cuda", dtype=torch.float16)
    k = torch.randn(1, 1, N, D, device="cuda", dtype=torch.float16)
    v = torch.randn(1, 1, N, D, device="cuda", dtype=torch.float16)

    triton = torch.compile(partial(flex_attention, kernel_options={"BACKEND": "TRITON"}))
    flash = torch.compile(partial(flex_attention, kernel_options={"BACKEND": "FLASH"}))

    _, lse_t = triton(q, k, v, scale=1.0, return_lse=True)
    _, lse_f = flash(q, k, v, scale=1.0, return_lse=True)

    ref = torch.logsumexp(q.squeeze().float() @ k.squeeze().float().T, dim=-1)
    print((lse_t.squeeze().float() - ref).abs().max())
    print((lse_f.squeeze().float() - ref).abs().max())
    print((lse_f.squeeze().float() / math.log(2.0) - ref).abs().max())


if __name__ == "__main__":
    main()
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 1

> **User:** Investigate this issue in diagnosis-and-plan mode.

You may inspect code, compare versions, and create throwaway helpers inside the job directory, but you may not modify product source files or prepare a patch yet.

Use subagents early for parallel exploration. Prefer read-only subagents. Good subagent tasks include:
- finding related kernels or codepaths
- comparing behavior across versions or backends
- locating similar bugs or existing tests
- checking whether the first hypothesis actually matches the runtime evidence

Your goal:
- gather evidence
- produce a minimal repro or a clear non-repro conclusion
- rank the top root-cause hypotheses
- propose the smallest plausible fix plan
- identify unknowns and risks

Rules:
- do not generate a diff
- do not broaden scope mid-run
- do not treat mathematical plausibility or static inspection as sufficient proof
- if runtime evidence and code inspection disagree, trust runtime evidence and report the disagreement

Output:
- repro status
- strongest evidence
- ranked hypotheses with confidence
- likely files involved
- proposed fix plan
- open questions
- recommended next action for user approval

Stop after the plan and wait.

Investigate and reproduce the reported failure first. Prioritize extracting or creating a minimal repro, running it, and documenting exact repro steps and observed behavior before proposing any fix.

### Initial reconnaissance
- Confirmed there is no existing `repro.py` in the job directory, so I need to create one.
- Parallel code search found the key flex-attention paths: `torch/nn/attention/flex_attention.py`, `torch/_higher_order_ops/flex_attention.py`, `torch/_inductor/kernel/flex/templates/flash_attention.py.jinja`, and `torch/nn/attention/_fa4.py`.
- Static inspection already matches the issue narrative: top-level output finalization multiplies `lse`/`max_scores` by `ln(2)`, while the eager math path explicitly pre-divides by `ln(2)`.

### Native repro attempt
- Wrote `repro.py` from the issue description and ran it with the job venv Python.
- The run does not reach the correctness check on this machine because `flash_attn` is not installed; compilation fails with `BACKEND='FLASH' but flash attention cannot be used: CUTE flash attention library is not available`.
- Confirmed separately that `torch.cuda.is_available()` is `True` and the local PyTorch build is `2.13.0a0+git0dd0356`, CUDA `13.2`, so the blocker is specifically the missing FA4 Python package.

### Synthetic runtime probes
- Created a throwaway `flash_attn.cute` stub inside the job directory to unblock runtime inspection without changing product source.
- `repro_fake_flash.py` showed that `_fa4_run_forward(...)` passes through natural-log `lse` unchanged: the stub FA4 wrapper matched the reference exactly (`max diff 0.0`).
- `probe_ln2_mismatch.py` monkeypatched `flex_attention_hop` to return natural-log `lse`/`max_scores` during the compiled branch and confirmed the top-level finalization rescales them by `ln(2)`: `lse` max error was `7.99`, but `lse / ln(2)` matched within `1.9e-6`; `max_scores` showed the same pattern.
- Separately confirmed the real compiled TRITON backend still returns correct `lse` on this machine (`max diff 5.7e-6`), so the conversion convention expected by the finalizer is still valid for non-FA4 paths.



## Run 2

> **User:** I agree with the reproduction and the proposed solution. Implement and verify it.

Your job:
- write the smallest fix that explains the reproduced failure
- add or update a focused regression test
- demonstrate that the test would fail before the fix
- demonstrate that the same test passes with the fix
- keep scope tight to the approved diagnosis and plan

Rules:
- no speculative cleanup or unrelated refactors
- if the test does not fail before the fix, stop and report that the evidence is insufficient
- if the fix requires a broader change than planned, stop and ask before expanding scope
- prefer the narrowest test that captures the reported failure mode

Output:
- patch summary
- regression test added or updated
- evidence that it fails before the fix
- evidence that it passes after the fix
- any remaining risks or gaps

We verified issue #181645 with /home/dev/.venvs/dev: BACKEND=FLASH returns lse off by ln(2), while TRITON and deterministic TRITON return natural-log lse. Use the active dev env evidence: /home/dev/.ptq/results/20260429-pytorch-181645/flex_flash_lse_real.py. Figure out and apply the minimal correct fix in the ptq worktree only. Expected direction: the public flex_attention finalizer multiplies lse/max_scores by ln(2) for HOP/kernel outputs that are in log2 units, but the FLASH/FA4 path already returns natural-log lse, so avoid that multiplication only for BACKEND=FLASH (or equivalently normalize at the FLASH wrapper boundary if that is more correct after inspecting backward conventions). Add/adjust a targeted test in test/inductor/test_flex_flash.py proving FLASH return_lse matches TRITON/natural-log reference, including deterministic mode if feasible. Do not touch unrelated files. Validate with the repro and the targeted flex flash test using /home/dev/.venvs/dev/bin/python if the ptq venv lacks flash_attn.cute.

### Regression test before the fix
- Added a focused test in `pytorch/test/inductor/test_flex_flash.py` that monkeypatches `flex_attention_hop` to emulate the backend contract: TRITON returns log2-space stats and FLASH returns natural-log stats.
- The first attempt to run a real FLASH test in the ptq env hit a separate environment blocker (`ModuleNotFoundError: No module named 'cutlass'`), so I kept the test at the public `flex_attention` finalization layer.
- With the new test in place and no product fix yet, `pytest test/inductor/test_flex_flash.py -k return_lse_matches_triton_and_reference -q` failed in all 4 cases, with FLASH `lse` off by about `7.99` while the TRITON assertion passed.

### Finalizer fix
- Implemented the narrow fix in `pytorch/torch/nn/attention/flex_attention.py`.
- `_finalize_outputs(...)` now takes a `stats_are_log2` flag so only backends that actually return log2-space stats get multiplied by `ln(2)`.
- For compiled FLASH, the caller passes `stats_are_log2=False`; for other compiled backends it remains `True`; and the debug no-compile path keeps the old log2 behavior.

### Verification after the fix
- Re-ran `pytest test/inductor/test_flex_flash.py -k return_lse_matches_triton_and_reference -q` with the same setup.
- All 4 cases now pass, including deterministic mode for both `float16` and `bfloat16`.

### Lint attempt
- Ran `spin fixlint` as requested before generating the diff.
- The Python linters completed, but the run failed in the repo-wide `CLANGTIDY_EXECUTORCH_COMPATIBILITY` step because this checkout has no `pytorch/build` directory (`FileNotFoundError` while `clang-tidy` tried to chdir there). No extra tracked file changes were left behind.

### Artifacts
- Wrote `report.md` with the root cause, fix summary, repro script, and test results.
- Generated `fix.diff` from the ptq worktree.



## Run 3

> **User:** I agree with the reproduction and the proposed solution. Implement and verify it.

Your job:
- write the smallest fix that explains the reproduced failure
- add or update a focused regression test
- demonstrate that the test would fail before the fix
- demonstrate that the same test passes with the fix
- keep scope tight to the approved diagnosis and plan

Rules:
- no speculative cleanup or unrelated refactors
- if the test does not fail before the fix, stop and report that the evidence is insufficient
- if the fix requires a broader change than planned, stop and ask before expanding scope
- prefer the narrowest test that captures the reported failure mode

Output:
- patch summary
- regression test added or updated
- evidence that it fails before the fix
- evidence that it passes after the fix
- any remaining risks or gaps

Revise the prior fix/test. The product fix direction is still likely correct, but the regression test must not stub or monkeypatch flex_attention_hop and must not use a fake FLASH path. Remove the fake _fake_flex_attention_hop_units_by_backend test helper and any unittest.mock patching for this test. Instead install and use the real flash-attn-4 package in the ptq venv if needed. I checked the package command: flash-attn-4 (4.0.0b10)
Available versions: 4.0.0b10, 4.0.0b9, 4.0.0b8, 4.0.0b7, 4.0.0b5, 4.0.0b4, 4.0.0b3 shows latest beta is flash-attn-4==4.0.0b10 and pip says install pre-releases with ; use  (or pin  if needed). Then write a focused real-backend test in test/inductor/test_flex_flash.py that compiles flex_attention with BACKEND=FLASH and BACKEND=TRITON, return_lse=True, scale=1.0, and asserts FLASH lse matches the natural-log reference / TRITON. Do not include deterministic parametrization; just one normal test over existing dtypes is enough. Demonstrate it fails before the fix and passes after. Also rerun the standalone repro with real FLASH if possible. Keep only the minimal source fix and the real FLASH regression test; remove the stubbed test code/imports.



## Run 4

> **User:** I agree with the reproduction and the proposed solution. Implement and verify it.

Your job:
- write the smallest fix that explains the reproduced failure
- add or update a focused regression test
- demonstrate that the test would fail before the fix
- demonstrate that the same test passes with the fix
- keep scope tight to the approved diagnosis and plan

Rules:
- no speculative cleanup or unrelated refactors
- if the test does not fail before the fix, stop and report that the evidence is insufficient
- if the fix requires a broader change than planned, stop and ask before expanding scope
- prefer the narrowest test that captures the reported failure mode

Output:
- patch summary
- regression test added or updated
- evidence that it fails before the fix
- evidence that it passes after the fix
- any remaining risks or gaps

Revise the prior fix/test for issue #181645.

The product fix direction is still likely correct, but the regression test must use the real FLASH backend. Do not stub or monkeypatch flex_attention_hop. Do not use a fake FLASH path.

Required cleanup:
- Remove the fake _fake_flex_attention_hop_units_by_backend helper if present.
- Remove unittest.mock patching for this return_lse test if present.
- Remove the deterministic parametrization for this test. One normal test over the existing dtype parametrization is enough.
- Keep only the minimal source fix and a real FLASH regression test.

Package/install details checked from /home/dev/.venvs/dev:
- python -m pip index versions --pre flash-attn-4 reports latest beta: flash-attn-4==4.0.0b10
- install command for the ptq venv if needed: python -m pip install --pre flash-attn-4
- if pip resolution is flaky, pin: python -m pip install flash-attn-4==4.0.0b10

Write a focused real-backend test in test/inductor/test_flex_flash.py that:
- uses real flash_attn.cute / flash-attn-4, not stubs
- compiles flex_attention with kernel_options={"BACKEND": "FLASH"}, return_lse=True, scale=1.0
- compiles flex_attention with kernel_options={"BACKEND": "TRITON"}, return_lse=True, scale=1.0
- asserts FLASH lse matches the natural-log reference and/or TRITON lse
- does not test deterministic mode

Validation required:
- Demonstrate this real FLASH test fails before the fix.
- Demonstrate the same test passes after the fix.
- Rerun the standalone real FLASH repro if possible.

Important environment note:
- The ptq venv may lack flash_attn.cute/cutlass initially; install flash-attn-4 beta into that venv with the command above rather than falling back to a stub.
- /home/dev/.venvs/dev already has a working real FLASH setup and can run /home/dev/.ptq/results/20260429-pytorch-181645/flex_flash_lse_real.py, but the regression test itself should be real-backend and not mocked.

### Real-FLASH validation blocker
- Re-checked the mandated job interpreter from the pytorch worktree: `flash_attn`, `flash_attn.cute`, and `cutlass` are all missing in `~/.ptq_workspace/jobs/20260429-pytorch-181645/.venv`.
- The current `TestFlexFlash` class is guarded by `ensure_flash_available()`, so a real-backend regression test cannot run in this environment without installing those packages.
- The job rules also require using the job venv and explicitly forbid `pip install` / environment modification, so I could not satisfy the user's requested `flash-attn-4` installation step inside this run.

### Decision for this run
- I did not make new product-source edits, because I could not run the required real FLASH regression test or show before/after failure with the mandated environment.
- I updated the artifacts to record the blocker and regenerated `fix.diff` from the clean worktree so the outputs are not stale.



## Run 5

> **User:** I agree with the reproduction and the proposed solution. Implement and verify it.

Your job:
- write the smallest fix that explains the reproduced failure
- add or update a focused regression test
- demonstrate that the test would fail before the fix
- demonstrate that the same test passes with the fix
- keep scope tight to the approved diagnosis and plan

Rules:
- no speculative cleanup or unrelated refactors
- if the test does not fail before the fix, stop and report that the evidence is insufficient
- if the fix requires a broader change than planned, stop and ask before expanding scope
- prefer the narrowest test that captures the reported failure mode

Output:
- patch summary
- regression test added or updated
- evidence that it fails before the fix
- evidence that it passes after the fix
- any remaining risks or gaps

Continue issue #181645 from the clean ptq worktree.

I manually installed the real FLASH dependencies into the exact ptq venv you will use:
- removed the old job-local fake package directory: /home/dev/.ptq_workspace/jobs/20260429-pytorch-181645/flash_attn
- ran: /home/dev/.ptq_workspace/jobs/20260429-pytorch-181645/.venv/bin/python -m pip install --pre flash-attn-4
- installed flash-attn-4==4.0.0b10 plus nvidia-cutlass-dsl/cutlass deps
- verified from /home/dev/.ptq_workspace/jobs/20260429-pytorch-181645/pytorch:
  - flash_attn imports OK
  - flash_attn.cute imports from the ptq venv site-packages
  - cutlass imports from the ptq venv site-packages

Now implement the real-backend version only:
- Keep the minimal product fix for BACKEND="FLASH" lse units in torch/nn/attention/flex_attention.py.
- Add a focused regression test in test/inductor/test_flex_flash.py using the real FLASH backend, no stubs and no monkeypatching.
- Do not add _fake_flex_attention_hop_units_by_backend or unittest.mock patching.
- Do not include deterministic parametrization.
- The test should compile flex_attention with BACKEND="FLASH" and BACKEND="TRITON", return_lse=True, scale=1.0, and assert FLASH lse matches natural-log reference and/or TRITON lse.

Validation:
- Demonstrate the real FLASH test fails before the product fix.
- Demonstrate it passes after the product fix.
- Rerun a standalone real FLASH repro if possible.
- Generate report.md and fix.diff with the real-backend test, not the prior stubbed test.

### Real FLASH environment check
- Confirmed the job venv now imports `flash_attn.cute` and `cutlass` successfully, and `repro.py` runs against the real FLASH backend on CUDA.
- On the fixed tree, the standalone repro shows TRITON max error `7.6294e-06` and FLASH max error `8.9645e-05`; dividing FLASH by `ln(2)` is now wrong (`12.8411`), which is the expected post-fix behavior.

### Replaced stubbed regression test with real backend coverage
- Removed the fake `_fake_flex_attention_hop_units_by_backend` helper, `math`/`nullcontext` imports used only by the stub path, and the `unittest.mock.patch`-based test body.
- Updated `test_flash_backend_return_lse_matches_triton_and_reference` to compile real `flex_attention` calls with `kernel_options={"BACKEND": "FLASH"}` and `{"BACKEND": "TRITON"}`, `return_lse=True`, and `scale=1.0`, then compare both results to a natural-log reference.
- Kept the test focused: existing dtype parametrization only, no deterministic parametrization, no monkeypatching.

### Before-fix validation with the real test
- Temporarily reverted `torch/nn/attention/flex_attention.py` to the old unconditional `* ln(2)` finalization to validate the new real-backend test against the actual bug.
- `python -m pytest test/inductor/test_flex_flash.py -k return_lse_matches_triton_and_reference -q` failed for both `float16` and `bfloat16`, with FLASH `lse` off by about `7.99` while the TRITON path remained correct.
- The standalone real-FLASH repro also failed in the expected way: TRITON diff `7.6294e-06`, FLASH diff `8.9009`, and `FLASH/ln(2)` diff `8.9645e-05`.

### After-fix validation
- Restored the minimal FLASH-aware finalization logic in `torch/nn/attention/flex_attention.py`.
- Re-ran the same targeted pytest selection and it passed: `2 passed, 218 deselected`.
- Re-ran `repro.py`; FLASH again matched the natural-log reference closely (`8.9645e-05` max diff).

### Lint and artifacts
- Ran `spin fixlint` as requested. The lint run reached the same repo-wide `CLANGTIDY_EXECUTORCH_COMPATIBILITY` failure mode seen earlier because this checkout has no `pytorch/build` directory.
- Regenerated `report.md` with the real-backend validation details and regenerated `fix.diff` from the current pytorch worktree.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv