### PR TITLE
Fix XPU SDPA to accept broadcast attention masks

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Attention.cpp
@@ -51,6 +51,29 @@ bool check_no_grad(sdp::sdp_params const& params, bool debug) {
   return !any_inputs_require_grad || !gradmode_enabled;
 }
 
+// XPU-specific: accept stride(-1) == 0 for broadcast masks, since
+// undo_broadcast in the oneDNN path handles this correctly.
+// When the last dim is broadcast (stride 0), require stride(-2) == 1
+// to ensure the underlying data is still contiguous.
+bool check_last_dim_stride_xpu(sdp::sdp_params const& params, bool debug) {
+  bool qkv_ok = params.query.sym_stride(-1) == 1 &&
+      params.key.sym_stride(-1) == 1 &&
+      params.value.sym_stride(-1) == 1;
+  bool mask_ok = true;
+  if (params.attn_mask.has_value()) {
+    const auto& mask = *params.attn_mask;
+    auto last_stride = mask.sym_stride(-1);
+    mask_ok = last_stride == 1 ||
+        (last_stride == 0 && mask.dim() >= 2 && mask.sym_stride(-2) == 1);
+  }
+  if (!(qkv_ok && mask_ok) && debug) {
+    TORCH_WARN(
+        "XPU fused attention requires the last dimension stride to be 1, "
+        "or 0 (broadcast) with the second-to-last dimension stride equal to 1 for attention mask.");
+  }
+  return qkv_ok && mask_ok;
+}
+
 bool can_use_overrideable_attention(sdp::sdp_params const& params, bool debug) {
   constexpr auto supported_dtypes = c10::array_of<at::ScalarType>(
       at::kFloat, at::kBFloat16, at::kHalf); // double is not supported
@@ -64,7 +87,7 @@ bool can_use_overrideable_attention(sdp::sdp_params const& params, bool debug) {
       sdp::check_batch_size_and_num_heads_dense<true /*supports GQA*/>,
       sdp::check_attn_mask_shape,
       sdp::check_nonzero_sequence_lengths_dense,
-      sdp::check_last_dim_stride_equals_1_dense<false /*ignore_singleton_dim*/>,
+      check_last_dim_stride_xpu,
       check_head_dim_size_xpu,
       check_no_grad);
   for (auto& constraint : constraints) {
@@ -149,7 +172,7 @@ bool can_use_mem_efficient_attention(
     constexpr auto dense_constraints =
         c10::array_of<bool (*)(sdp::sdp_params const&, bool)>(
             sdp::check_nonzero_sequence_lengths_dense,
-            sdp::check_last_dim_stride_equals_1_dense<false>,
+            check_last_dim_stride_xpu,
             sdp::check_batch_size_and_num_heads_dense<false>);
     for (auto& constraint : dense_constraints) {
       if (!constraint(params, debug)) {


### PR DESCRIPTION
## Summary

Transformers 5.3.0 creates boolean attention masks via `expand()`, producing tensors with stride 0 on broadcast dimensions (e.g. shape `[8, 1, 512, 512]` with strides `(0, 512, 1, 0)`). The shared `check_last_dim_stride_equals_1_dense` constraint rejects `stride(-1) == 0`, causing SDPA to fall back to the math backend (BMM + softmax decomposition) instead of using the fused oneDNN kernel. This results in a significant performance regression for models like `hf_Roberta_base` on XPU.

## Fix

Add an XPU-specific stride check (`check_last_dim_stride_xpu`) that accepts `stride(-1) == 0` for the attention mask when `stride(-2) == 1`, ensuring the underlying data is still contiguous. This replaces the shared `check_last_dim_stride_equals_1_dense` in both `can_use_overrideable_attention` and `can_use_mem_efficient_attention` for XPU.

The existing `undo_broadcast` in `detail/Attention.cpp` already handles collapsing broadcast dims (stride 0) back to size 1 via `as_strided` + `unsqueeze` — no memory allocation or copy is needed.

## Root Cause

- **Transformers 4.55.2**: passes `attn_mask=None` to SDPA → C++ converts to `full(0.0)` with contiguous strides
- **Transformers 5.3.0**: creates a boolean mask via `expand()` → broadcast strides with `stride(-1) == 0`

The shared stride check does not distinguish between truly non-contiguous tensors and broadcast tensors. Rather than modifying the shared check (which would affect CUDA), this fix is scoped to XPU only, where the oneDNN path already handles broadcast tensors correctly.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @EikanWang

Co-authored-by: Claude <noreply@anthropic.com>