### PR TITLE
[invoke_subgraph] add joint graph passes to partitioner

### DIFF
--- a/test/dynamo/test_regional_inductor.py
+++ b/test/dynamo/test_regional_inductor.py
@@ -987,11 +987,7 @@ def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals
     flex_attention = torch.ops.higher_order.flex_attention(primals_0, primals_0, primals_0, sdpa_score0, (768, 768, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8, 128, 128, sdpa_mask0), 0.125, {'BACKEND': 'AUTO', 'PRESCALE_QK': False, 'ROWS_GUARANTEED_SAFE': False, 'BLOCKS_ARE_CONTIGUOUS': False, 'WRITE_DQ': True, 'OUTPUT_LOGSUMEXP': True, 'OUTPUT_MAX': False}, (), ());  sdpa_score0 = sdpa_mask0 = None
     getitem = flex_attention[0]
     getitem_1 = flex_attention[1];  flex_attention = None
-    alias = torch.ops.aten.alias.default(getitem)
-    alias_1 = torch.ops.aten.alias.default(getitem_1);  getitem_1 = None
-    alias_2 = torch.ops.aten.alias.default(alias);  alias = None
-    alias_3 = torch.ops.aten.alias.default(alias_1);  alias_1 = None
-    return (getitem, primals_0, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8, alias_2, alias_3)""",
+    return (getitem, primals_0, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8, getitem, getitem_1)""",
                 ignore_comments=True,
                 ignore_empty_lines=True,
             )
@@ -999,11 +995,11 @@ def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals
             self.assertExpectedInline(
                 captured_gms[1].code.strip(),
                 """\
-def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8, alias_2, alias_3, tangents_0):
+def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8, getitem, getitem_1, tangents_0):
     fw_graph0 = self.fw_graph0
     joint_graph0 = self.joint_graph0
     mask_graph0 = self.mask_graph0
-    flex_attention_backward = torch.ops.higher_order.flex_attention_backward(primals_0, primals_0, primals_0, alias_2, alias_3, tangents_0, None, fw_graph0, joint_graph0, (768, 768, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8, 128, 128, mask_graph0), 0.125, {'BACKEND': 'AUTO', 'PRESCALE_QK': False, 'ROWS_GUARANTEED_SAFE': False, 'BLOCKS_ARE_CONTIGUOUS': False, 'WRITE_DQ': True, 'OUTPUT_LOGSUMEXP': True, 'OUTPUT_MAX': False}, (), ());  primals_0 = alias_2 = alias_3 = tangents_0 = fw_graph0 = joint_graph0 = primals_1 = primals_2 = primals_3 = primals_4 = primals_5 = primals_6 = primals_7 = primals_8 = mask_graph0 = None
+    flex_attention_backward = torch.ops.higher_order.flex_attention_backward(primals_0, primals_0, primals_0, getitem, getitem_1, tangents_0, None, fw_graph0, joint_graph0, (768, 768, primals_1, primals_2, primals_3, primals_4, primals_5, primals_6, primals_7, primals_8, 128, 128, mask_graph0), 0.125, {'BACKEND': 'AUTO', 'PRESCALE_QK': False, 'ROWS_GUARANTEED_SAFE': False, 'BLOCKS_ARE_CONTIGUOUS': False, 'WRITE_DQ': True, 'OUTPUT_LOGSUMEXP': True, 'OUTPUT_MAX': False}, (), ());  primals_0 = getitem = getitem_1 = tangents_0 = fw_graph0 = joint_graph0 = primals_1 = primals_2 = primals_3 = primals_4 = primals_5 = primals_6 = primals_7 = primals_8 = mask_graph0 = None
     getitem_3 = flex_attention_backward[0]
     getitem_4 = flex_attention_backward[1]
     getitem_5 = flex_attention_backward[2];  flex_attention_backward = None
@@ -1607,6 +1603,97 @@ def forward(self, primals_0, primals_1, primals_2, primals_3, primals_4, primals
         self.assertEqual(out, ref)
         self.assertEqual(x.grad, x_ref.grad)
         self.assertEqual(w.grad, w_ref.grad)
+
+    @parametrize("serialize", [False])
+    def test_joint_graph_passes_run_on_hop_subgraph(self, serialize):
+        # Inductor's joint-graph passes (e.g. scatter_upon_const_tensor, which
+        # rewrites full+scatter into eq+where to avoid materializing a sparse
+        # buffer) must run on the HOP subgraph's joint graph, not just the
+        # outer one. nll_loss_backward decomposes to full+scatter; without the
+        # rewrite the bw subgraph keeps a (B, V) scatter destination buffer.
+        from torch._inductor.decomposition import select_decomp_table
+
+        nested_config = get_invoke_subgraph_compile_options(
+            decompositions=dict(select_decomp_table()),
+        )
+
+        @torch.compiler.nested_compile_region(options=nested_config)
+        def loss_region(logits_f32, targets):
+            return torch.nn.functional.cross_entropy(
+                logits_f32, targets, reduction="none"
+            )
+
+        def fn(logits, targets):
+            return loss_region(logits.to(torch.float32), targets).sum()
+
+        logits = torch.randn(8, 64, requires_grad=True)
+        targets = torch.randint(0, 64, (8,))
+
+        with _testing_capture_invoke_subgraph_inductor_compile_gms() as captured_gms:
+            opt_fn = torch.compile(
+                fn,
+                backend=aot_eager_regional_inductor(
+                    serialize=serialize, on_invoke_subgraph=True
+                ),
+                fullgraph=True,
+            )
+            opt_fn(logits, targets).backward()
+
+        # captured_gms[0] is the fw subgraph and captured_gms[1] is the bw
+        # subgraph. The bw should NOT contain aten.scatter — the joint pass
+        # rewrote full+scatter into eq+where.
+        self.assertExpectedInline(
+            captured_gms[0].code.strip(),
+            """\
+def forward(self, primals_0, primals_1):
+    amax = torch.ops.aten.amax.default(primals_0, [1], True)
+    sub = torch.ops.aten.sub.Tensor(primals_0, amax)
+    exp = torch.ops.aten.exp.default(sub)
+    sum_1 = torch.ops.aten.sum.dim_IntList(exp, [1], True);  exp = None
+    log = torch.ops.aten.log.default(sum_1);  sum_1 = None
+    sub_1 = torch.ops.aten.sub.Tensor(sub, log);  sub = None
+    ne = torch.ops.aten.ne.Scalar(primals_1, -100)
+    full_default = torch.ops.aten.full.default([], 0, dtype = torch.int64, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
+    where = torch.ops.aten.where.self(ne, primals_1, full_default);  full_default = None
+    unsqueeze = torch.ops.aten.unsqueeze.default(where, 1);  where = None
+    gather = torch.ops.aten.gather.default(sub_1, 1, unsqueeze);  sub_1 = unsqueeze = None
+    squeeze = torch.ops.aten.squeeze.dim(gather, 1);  gather = None
+    neg = torch.ops.aten.neg.default(squeeze);  squeeze = None
+    full_default_1 = torch.ops.aten.full.default([], 0.0, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
+    where_1 = torch.ops.aten.where.self(ne, neg, full_default_1);  ne = neg = full_default_1 = None
+    return (where_1, primals_0, primals_1, amax, log)""",
+            ignore_comments=True,
+            ignore_empty_lines=True,
+        )
+        self.assertExpectedInline(
+            captured_gms[1].code.strip(),
+            """\
+def forward(self, primals_0, primals_1, amax, log, tangents_0):
+    unsqueeze_2 = torch.ops.aten.unsqueeze.default(tangents_0, 1);  tangents_0 = None
+    full_default_1 = torch.ops.aten.full.default([], 0.0, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
+    unsqueeze_1 = torch.ops.aten.unsqueeze.default(primals_1, 1);  primals_1 = None
+    ne_2 = torch.ops.aten.ne.Scalar(unsqueeze_1, -100)
+    where_3 = torch.ops.aten.where.self(ne_2, unsqueeze_2, full_default_1);  unsqueeze_2 = full_default_1 = None
+    full_default = torch.ops.aten.full.default([], 0, dtype = torch.int64, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
+    where_2 = torch.ops.aten.where.self(ne_2, unsqueeze_1, full_default);  ne_2 = unsqueeze_1 = full_default = None
+    iota_default = torch.ops.prims.iota.default(64, start = 0, step = 1, dtype = torch.int64, device = device(type='cpu'), requires_grad = False)
+    view_default = torch.ops.aten.view.default(iota_default, [1, 64]);  iota_default = None
+    expand_default = torch.ops.aten.expand.default(where_2, [8, 64]);  where_2 = None
+    eq_tensor = torch.ops.aten.eq.Tensor(expand_default, view_default);  expand_default = view_default = None
+    scalar_tensor_default = torch.ops.aten.scalar_tensor.default(0, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'))
+    scalar_tensor_default_1 = torch.ops.aten.scalar_tensor.default(-1.0, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'))
+    where_self = torch.ops.aten.where.self(eq_tensor, scalar_tensor_default_1, scalar_tensor_default);  eq_tensor = scalar_tensor_default_1 = scalar_tensor_default = None
+    mul = torch.ops.aten.mul.Tensor(where_self, where_3);  where_self = where_3 = None
+    sub = torch.ops.aten.sub.Tensor(primals_0, amax);  primals_0 = amax = None
+    sub_1 = torch.ops.aten.sub.Tensor(sub, log);  sub = log = None
+    exp_1 = torch.ops.aten.exp.default(sub_1);  sub_1 = None
+    sum_2 = torch.ops.aten.sum.dim_IntList(mul, [1], True)
+    mul_1 = torch.ops.aten.mul.Tensor(exp_1, sum_2);  exp_1 = sum_2 = None
+    sub_2 = torch.ops.aten.sub.Tensor(mul, mul_1);  mul = mul_1 = None
+    return (sub_2, None)""",
+            ignore_comments=True,
+            ignore_empty_lines=True,
+        )
 
 
 @skipIfTorchDynamo("Not a suitable dynamo wrapped test")

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -10,6 +10,7 @@ An aot_dispatch_* function:
 
 import copy
 import dataclasses
+import functools
 import itertools
 import logging
 import operator
@@ -749,25 +750,38 @@ def _get_partition_fn(
         ].partitioner
         if hop_partition_fn is not None:
             if callable(hop_partition_fn):
-                return True, hop_partition_fn  # pyrefly: ignore[bad-return]
-            if not isinstance(hop_partition_fn, str):
+                raw_partitioner = hop_partition_fn
+            elif not isinstance(hop_partition_fn, str):
                 raise AssertionError(
                     f"expected hop_partition_fn to be str, got {type(hop_partition_fn)}"
                 )
-            match hop_partition_fn:
-                case "default_partition":
-                    return True, torch._functorch.partitioners.default_partition
-                case "min_cut_rematerialization_partition":
-                    return (
-                        True,
-                        torch._functorch.partitioners.min_cut_rematerialization_partition,
-                    )
-                case _:
-                    raise ValueError(
-                        f"Unknown HOP partitioner config: {hop_partition_fn}"
-                    )
+            else:
+                match hop_partition_fn:
+                    case "default_partition":
+                        raw_partitioner = (
+                            torch._functorch.partitioners.default_partition
+                        )
+                    case "min_cut_rematerialization_partition":
+                        raw_partitioner = torch._functorch.partitioners.min_cut_rematerialization_partition
+                    case _:
+                        raise ValueError(
+                            f"Unknown HOP partitioner config: {hop_partition_fn}"
+                        )
 
-    # Fall back to the parent partitioner from aot_config
+            # Route through Inductor's `partition_fn` so joint-graph passes
+            # (e.g. scatter_upon_const_tensor) run on the HOP subgraph before
+            # the user-selected raw partitioner.
+            from torch._inductor.compile_fx import (
+                partition_fn as _inductor_partition_fn,
+            )
+
+            return True, functools.partial(
+                _inductor_partition_fn, partitioner_fn_override=raw_partitioner
+            )
+
+    # Fall back to the parent partitioner from aot_config. When the outer
+    # compile is Inductor this is already `compile_fx.partition_fn` so
+    # joint-graph passes run there too.
     if aot_config.partition_fn is None:
         raise AssertionError("aot_config.partition_fn must not be None")
     return used_hop_custom_partition, aot_config.partition_fn
@@ -1221,6 +1235,20 @@ def run_joint_graph_passes_on_hops(
     joint_gm.graph.eliminate_dead_code()
     joint_gm.graph.lint()
     joint_gm.recompile()
+
+    trace_structured(
+        "artifact",
+        metadata_fn=lambda: {
+            "name": "gm_after_joint_graph_passes_on_hops",
+            "encoding": "string",
+        },
+        payload_fn=lambda: joint_gm.print_readable(
+            print_output=False,
+            include_stride=True,
+            include_device=True,
+            expanded_def=True,
+        ),
+    )
     return joint_gm
 
 

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -1235,20 +1235,6 @@ def run_joint_graph_passes_on_hops(
     joint_gm.graph.eliminate_dead_code()
     joint_gm.graph.lint()
     joint_gm.recompile()
-
-    trace_structured(
-        "artifact",
-        metadata_fn=lambda: {
-            "name": "gm_after_joint_graph_passes_on_hops",
-            "encoding": "string",
-        },
-        payload_fn=lambda: joint_gm.print_readable(
-            print_output=False,
-            include_stride=True,
-            include_device=True,
-            expanded_def=True,
-        ),
-    )
     return joint_gm
 
 

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2264,6 +2264,13 @@ def get_cuda_device_context(gm: torch.fx.GraphModule) -> AbstractContextManager[
 def partition_fn(
     gm: GraphModule,
     joint_inputs: Sequence[object],
+    *,
+    # When set, replaces the default partitioner (`config.custom_partitioner_fn`
+    # or `min_cut_rematerialization_partition`) while still running Inductor's
+    # joint-graph passes first. Used by `_get_partition_fn` so HOP subgraphs
+    # go through the same joint-pass + raw-partitioner pipeline as the outer
+    # Inductor compile.
+    partitioner_fn_override: Callable[..., Any] | None = None,
     **kwargs: object,
 ) -> tuple[GraphModule, GraphModule]:
     cuda_context = get_cuda_device_context(gm)
@@ -2281,6 +2288,14 @@ def partition_fn(
     static_lifetime_input_indices: list[int] | None = kwargs.pop(  # type: ignore[assignment]
         "static_lifetime_input_indices", None
     )
+
+    if partitioner_fn_override is not None:
+        return partitioner_fn_override(
+            gm,
+            joint_inputs,
+            static_lifetime_input_indices=static_lifetime_input_indices,
+            **kwargs,
+        )
 
     if config.custom_partitioner_fn is None:
         with dynamo_utils.dynamo_timed(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #181958
* __->__ #181834
* #181809
* #181808


### Problem

Inductor's joint-graph pattern matchers (`scatter_upon_const_tensor`, SDPA
fusions, dead-code-with-side-effects elimination, etc., all registered via
`register_graph_pattern` in `torch/_inductor/fx_passes/joint_graph.py`) **never
run on the HOP subgraph's joint graph** when the HOP carries a
`nested_region_config` (i.e., was created via
`torch.compiler.nested_compile_region(options=…)`).

Wiring problem:

- `compile_fx.partition_fn` (the wrapper installed as `aot_config.partition_fn`)
  calls `_recursive_joint_graph_passes(gm, skip_invoke_subgraph=True, …)`
  before partitioning. `skip_invoke_subgraph=True` bypasses HOP subgraphs on
  the assumption that they will be handled separately when the HOP is
  partitioned.
- `run_joint_graph_passes_on_hops` extracts the HOP joint subgraph and calls
  its partitioner via `_get_partition_fn`. For HOPs *without* a
  `nested_region_config`, this falls through to `aot_config.partition_fn` — the
  wrapper — and joint passes run.
- For HOPs *with* a `nested_region_config` (the user-options path),
  `_get_partition_fn` returns the **raw** `min_cut_rematerialization_partition`
  / `default_partition`. Joint passes never run.

Concrete consequence: `aten.nll_loss_backward` decomposes (in
`torch/_decomp/decompositions.py`) to

```python
grad_input = torch.zeros_like(self)
grad_input = torch.scatter(grad_input, channel_dim, safe_target, -1.0)
```

Inductor's `scatter_upon_const_tensor` joint pass would normally rewrite this
to an `eq + where` form that fuses into the next reduction kernel. With the
rewrite missing, the bw codegen for a chunked-CE region in our production
model allocates a 3.05 GiB f32 `(B*S, V)` buffer (the `full` destination of
the scatter) that lives until the fused bw reduction kernel reads it — pure
memory waste plus an extra kernel.

### Fix

Add a `partitioner_fn_override` keyword to `compile_fx.partition_fn` and route
HOP partitioners through it via `functools.partial`:

```python
# torch/_inductor/compile_fx.py
def partition_fn(
    gm: GraphModule,
    joint_inputs: Sequence[object],
    *,
    partitioner_fn_override: Callable[..., Any] | None = None,
    **kwargs: object,
) -> tuple[GraphModule, GraphModule]:
    ...
    gm = _recursive_joint_graph_passes(gm, skip_invoke_subgraph=True, ...)
    ...
    if partitioner_fn_override is not None:
        return partitioner_fn_override(gm, joint_inputs, ...)
    if config.custom_partitioner_fn is None:
        return min_cut_rematerialization_partition(gm, joint_inputs, ...)
    ...
```

```python
# torch/_functorch/_aot_autograd/graph_compile.py
def _get_partition_fn(fw_hop_node, aot_config):
    if (... has nested_region_config ...):
        if hop_partition_fn is not None:
            ...resolve callable / "default_partition" / "min_cut_rematerialization_partition" → raw_partitioner
            from torch._inductor.compile_fx import partition_fn as _inductor_partition_fn
            return True, functools.partial(
                _inductor_partition_fn, partitioner_fn_override=raw_partitioner
            )
    return False, aot_config.partition_fn
```

The HOP subgraph now goes through the same `joint_graph_passes` →
`raw_partitioner` pipeline as the outer Inductor compile. The default path
(no override) is unchanged.

### Tests

`test/dynamo/test_regional_inductor.py::RegionalInductorInvokeSubgraphTests::test_joint_graph_passes_run_on_hop_subgraph_serialize_False`
(new) — runs a `cross_entropy(reduction="none")` region, captures fw and bw
HOP subgraphs, asserts via `assertExpectedInline` that the bw uses the
rewritten `iota → expand → eq → where` chain (the
`scatter_upon_const_tensor` rewrite output) instead of `aten.full` +
`aten.scatter`. Fails on `main` with the buffered scatter pattern; passes
with the fix.

Existing snapshot tests updated to reflect the simplification:

- `test_regional_inductor.py::test_flex_attention` — the joint passes now
  eliminate four redundant `aten.alias` ops in the flex-attention HOP fw +
  bw graphs (alias-elimination was already a registered pattern; it just
  never ran on HOPs before).
- `test_graph_deduplication.py` and `test_invoke_subgraph.py` — minor
  inline-snapshot adjustments where additional rewrites now apply.

### Importance for the production model

Combined with PR 1, this lets a chunked-CE region's bw subgraph produce
end-to-end IR that's structurally close to the full-Inductor (no-region)
baseline: no `full+scatter` 3 GiB buffer, no redundant aliases. It's the
last large chunk of "Inductor optimization the regional path silently
forfeited" we identified from a memory-snapshot analysis.




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98