### PR TITLE
Add a100_default_flex_config entries for head_dim=192

### DIFF
--- a/test/inductor/test_template_heuristics_registry.py
+++ b/test/inductor/test_template_heuristics_registry.py
@@ -1,4 +1,5 @@
 # Owner(s): ["module: inductor"]
+import torch
 from torch._inductor.template_heuristics.base import TemplateConfigHeuristics
 from torch._inductor.template_heuristics.registry import (
     _TEMPLATE_HEURISTIC_REGISTRY,
@@ -6,7 +7,11 @@ from torch._inductor.template_heuristics.registry import (
     get_template_heuristic,
     register_template_heuristic,
 )
-from torch._inductor.template_heuristics.triton import BlackwellGPUGemmConfig
+from torch._inductor.template_heuristics.triton import (
+    BlackwellGPUGemmConfig,
+    CUDAConfigHeuristic,
+    FlexConfig,
+)
 from torch._inductor.test_case import run_tests, TestCase
 
 
@@ -208,6 +213,29 @@ class TestTemplateHeuristicsRegistry(TestCase):
         heuristic4 = get_template_heuristic("unknown_template", "cuda", "unknown_op")
         self.assertIsInstance(heuristic4, _NewlyRegisteredHeuristic)
         self.assertIs(heuristic3, heuristic4)  # Should be same cached instance
+
+
+class TestA100DefaultFlexConfig(TestCase):
+    def test_head_dim_192_entries(self):
+        """``(bf16, 192)`` and ``(fp16, 192)`` entries are required for
+        DeepSeek V3 MLA (qk_nope_head_dim=128 + qk_rope_head_dim=64 = 192,
+        v_head_dim=128) on every ``capability >= (8, 0)`` board.
+
+        Without these entries, dispatch falls through to
+        ``FlexConfig(64, 64, 3, 4)``, which exceeds the 99 KiB per-block
+        shared-memory opt-in budget on sm_8.6 / sm_8.9 (A10G, L40, A2)
+        and fails compilation with "No valid triton configs."
+
+        The pinned tile fits the sm_8.6 budget with margin and was the
+        empirical fastest among the candidates on A2, L40, and A100. If
+        you want to retune, please re-validate on a real sm_8.6 board
+        before changing this value (the formula-based SMEM estimate alone
+        is not a reliable proxy for what triton actually allocates).
+        """
+        expected = FlexConfig(128, 32, 2, 8)
+        h = CUDAConfigHeuristic()
+        self.assertEqual(h.a100_default_flex_config[(torch.bfloat16, 192)], expected)
+        self.assertEqual(h.a100_default_flex_config[(torch.float16, 192)], expected)
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -1298,9 +1298,11 @@ class CUDAConfigHeuristic(BaseConfigHeuristic):
             (torch.float32, 256): FlexConfig(64, 16, 3, 4),
             (torch.bfloat16, 64): FlexConfig(128, 64, 3, 4),
             (torch.bfloat16, 128): FlexConfig(128, 64, 3, 8),
+            (torch.bfloat16, 192): FlexConfig(128, 32, 2, 8),
             (torch.bfloat16, 256): FlexConfig(32, 64, 3, 4),
             (torch.float16, 64): FlexConfig(128, 64, 3, 4),
             (torch.float16, 128): FlexConfig(128, 64, 3, 8),
+            (torch.float16, 192): FlexConfig(128, 32, 2, 8),
             (torch.float16, 256): FlexConfig(32, 64, 3, 4),
         }
 


### PR DESCRIPTION
Fixes #180278.

Adds `(bf16, 192)` and `(fp16, 192)` entries to `a100_default_flex_config`, both `FlexConfig(128, 32, 2, 8)`. The same dict is consulted for every `capability >= (8, 0)` board (including A100, A30, A10G, A2, L40), so I cross-validated on A2 (sm_8.6), L40 (sm_8.9), and A100 (sm_8.0): the chosen tile is empirically fastest on each, and a ~3% improvement on A100 over the current fallthrough. Full numbers and methodology in https://github.com/pytorch/pytorch/issues/180278#issuecomment-4340480245.

## Test plan

New unit test in `test/inductor/test_template_heuristics_registry.py` pins both entries to the validated tile, so any future retune has to update the test alongside re-validating on a real sm_8.6 board.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos @Chillee @drisspg @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo