### PR TITLE
[Bugfix]: handle accelerator device_index in Dynamo

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -591,6 +591,31 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x)
         self.assertEqual(ref, res)
 
+    @unittest.skipIf(not torch.accelerator.is_available(), "requires accelerator")
+    def test_accelerator_device_index(self):
+        def fn_construct(x):
+            torch.accelerator.device_index(x.device.index)
+            return x + 1
+
+        def fn_with_ctx(x):
+            with torch.accelerator.device_index(x.device.index):
+                x = torch.sin(x + 1)
+            return x
+
+        def fn_with_none(x):
+            with torch.accelerator.device_index(None):
+                x = torch.cos(x + 1)
+            return x
+
+        device = torch.accelerator.current_accelerator()
+        x = torch.randn((2, 2), device=device)
+
+        for fn in (fn_construct, fn_with_ctx, fn_with_none):
+            ref = fn(x)
+            opt_fn = torch.compile(backend="eager", fullgraph=True)(fn)
+            res = opt_fn(x)
+            self.assertEqual(ref, res)
+
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
     def test_cuda__exchange_device_args(self):
         @torch.compile(backend="eager", fullgraph=True)

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -27,6 +27,7 @@ from .builtin import (
 )
 from .constant import ConstantVariable
 from .ctx_manager import (
+    AcceleratorDeviceIndexVariable,
     CatchWarningsCtxManagerVariable,
     ContextWrappingVariable,
     CUDADeviceVariable,

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -810,6 +810,70 @@ class CUDADeviceVariable(ContextWrappingVariable):
         return torch.cuda.device
 
 
+class AcceleratorDeviceIndexVariable(ContextWrappingVariable):
+    """represents torch.accelerator.device_index"""
+
+    @staticmethod
+    def create(
+        tx: "InstructionTranslator", device: Any, **kwargs: Any
+    ) -> "AcceleratorDeviceIndexVariable":
+        var = AcceleratorDeviceIndexVariable(
+            target_values=[device],
+            initial_values=None,
+            **kwargs,
+        )
+        return var
+
+    def __init__(
+        self,
+        target_values: Any,
+        initial_values: Any | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            target_values=target_values, initial_values=initial_values, **kwargs
+        )
+
+    def exit(
+        self, tx: "InstructionTranslator", *args: VariableTracker
+    ) -> VariableTracker:
+        self.cleanup_assert()
+        if self.target_values[0] is not None:
+            tx.output.create_node(
+                "call_function",
+                torch._C._accelerator_maybeExchangeDevice,
+                (self.proxy,),
+                {},
+            )
+        return variables.ConstantVariable.create(False)
+
+    def enter(self, tx: "InstructionTranslator") -> VariableTracker:
+        if self.target_values[0] is None:
+            self.set_cleanup_hook(tx, lambda: None)
+            return variables.ConstantVariable.create(None)
+
+        prev_idx = torch._C._accelerator_exchangeDevice(*self.target_values)
+        self.set_cleanup_hook(
+            tx, lambda: torch._C._accelerator_maybeExchangeDevice(prev_idx)
+        )
+        self.proxy = tx.output.create_node(
+            "call_function",
+            torch._C._accelerator_exchangeDevice,
+            (*self.target_values,),
+            {},
+        )
+        return variables.ConstantVariable.create(None)
+
+    def module_name(self) -> str:
+        return "torch.accelerator"
+
+    def fn_name(self) -> str:
+        return "device_index"
+
+    def python_type(self) -> type:
+        return torch.accelerator.device_index
+
+
 class TorchFunctionDisableVariable(ContextWrappingVariable):
     """represents whether torch function overrides are enabled or not"""
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -931,6 +931,19 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 raise_type_error(tx, "torch.cuda.device() requires a constant argument")
             return variables.CUDADeviceVariable.create(tx, args[0].as_python_constant())
         elif (
+            self.value is torch.accelerator.device_index
+            and not kwargs
+            and len(args) == 1
+        ):
+            if not args[0].is_python_constant():
+                raise_type_error(
+                    tx,
+                    "torch.accelerator.device_index() requires a constant argument",
+                )
+            return variables.AcceleratorDeviceIndexVariable.create(
+                tx, args[0].as_python_constant()
+            )
+        elif (
             issubclass(type(self.value), type)
             and hasattr(
                 self.value, "__enter__"


### PR DESCRIPTION
As titled, this PR fix: https://github.com/pytorch/pytorch/issues/181540

The root cause seems to be that Dynamo has special handling for `torch.cuda.device`, but not for `torch.accelerator.device_index`, so it tries to inline `device_index.__init__` and hits the skiplist error.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98