### PR TITLE
[Inductor] Make channels_last contiguous check from ConcatKernel support symbolic shapes (#181845)

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -1008,6 +1008,37 @@ class TestUnbackedSymints(InductorTestCase):
         result = compiled_fn(t)
         self.assertEqual(result, 8)
 
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
+    @inductor_config.patch(
+        {"max_complex_pointwise_cat_inputs": 1, "max_pointwise_cat_inputs": 1}
+    )
+    def test_cat_sympy_channels_last_contiguous(self, device):
+        """torch.cat with symbolic shapes in shapes / strides should not raise
+        GuardOnDataDependentSymNode when checking channels_last contiguity."""
+
+        def fn(x, y):
+            # nonzero produces an unbacked symint in dim 0
+            nz = torch.nonzero(x)  # (u0, 1)
+            u0 = nz.size(0)
+            # All inputs are unrealized Pointwise (new_zeros), so
+            # any_input_is_storage_and_layout is False, reaching the
+            # meta["val"] channels_last check. Lower both pointwise cat
+            # thresholds to force ConcatKernel path instead of pointwise_cat.
+            inputs = [
+                y.new_zeros(y.size(0), u0, y.size(2), y.size(3)),
+                y.new_zeros(y.size(0), u0 + 1, y.size(2), y.size(3)),
+            ]
+            return torch.cat(inputs, dim=1)
+
+        example_inputs = (
+            torch.tensor([1.0, 0.0, 1.0, 1.0], device=device),
+            torch.randn(2, 3, 4, 10, device=device),
+        )
+        actual = torch.compile(fn, fullgraph=True)(*example_inputs)
+        expected = fn(*example_inputs)
+        torch.testing.assert_close(actual, expected)
+
 
 instantiate_device_type_tests(TestUnbackedSymints, globals(), allow_xpu=True)
 

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -951,7 +951,14 @@ max_fusion_buffer_group_pairwise_attempts = 64
 # The check is disabled if set to None.
 max_fusion_unique_io_buffers: int | None = None
 
-# max number of inputs to generate cat as a pointwise op with masked loads
+# max number of inputs to always fuse cat as a pointwise op regardless of
+# per-input op complexity. Beyond this limit (up to max_pointwise_cat_inputs),
+# fusion is only applied when every input has a low op count.
+max_complex_pointwise_cat_inputs = 8
+
+# max number of inputs to generate cat as a pointwise op with masked loads.
+# Inputs beyond max_complex_pointwise_cat_inputs but within this limit are
+# only fused when every input has a simple computation (op count <= 2).
 max_pointwise_cat_inputs = 8
 
 # force concat to be generated as a pointwise op with masked loads

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6094,11 +6094,15 @@ class ConcatKernel(NopKernel):
                 # pyrefly: ignore [missing-attribute]
                 "val" in arg.meta
                 and (
-                    # pyrefly: ignore [missing-attribute]
-                    arg.meta["val"].is_contiguous(memory_format=torch.channels_last)
-                    # pyrefly: ignore [missing-attribute]
-                    or arg.meta["val"].is_contiguous(
-                        memory_format=torch.channels_last_3d
+                    is_contiguous_for_memory_format_or_false(
+                        # pyrefly: ignore [missing-attribute]
+                        arg.meta["val"],
+                        memory_format=torch.channels_last,
+                    )
+                    or is_contiguous_for_memory_format_or_false(
+                        # pyrefly: ignore [missing-attribute]
+                        arg.meta["val"],
+                        memory_format=torch.channels_last_3d,
                     )
                 )
                 for arg in fx_node_args

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2157,17 +2157,14 @@ def cat(inputs, dim=0):
 
         return count
 
-    # as of inputs increase, possibility for register spilling also increases
-    # past a certain threshold of inputs we only fuse if the input kernels
-    # are simple
-    # not sure if we want to expose to users via config since logic may change in future
-    MAX_COMPLEX_POINTWISE_CAT = 8
+    # as inputs increase, possibility for register spilling also increases.
+    # Past a certain threshold we only fuse if the input kernels are simple.
     MAX_SIMPLE_OP_COUNT = 2
 
     def additional_pointwise_ops(op: torch._ops.OpOverload):
         return op in (aten.cat.default, aten.constant_pad_nd.default)
 
-    if len(inputs) <= MAX_COMPLEX_POINTWISE_CAT or (
+    if len(inputs) <= config.max_complex_pointwise_cat_inputs or (
         (len(inputs) <= config.max_pointwise_cat_inputs)
         and all(op_count(t) <= MAX_SIMPLE_OP_COUNT for t in inputs)
     ):


### PR DESCRIPTION
Summary:

### Issue
Surfaced from an internal use case:

```
torch.ops.aten.cat.default([index_42, view_165], 1) -->
  index_42: "i64[s10, s44 + u15, s112, 10]" = torch.ops.aten.index.Tensor...
  view_165: "i64[s10, 1, s112, 10]" = torch.ops.aten.view.default...
```

will throw DDE inside ConcatKernel when checking if any of the inputs is channels_last continuous

```
Details: LoweringException: GuardOnDataDependentSymNode: Could not guard on data-dependent expression Eq(1, u15 + 1000) & Eq(10, 10*u15 + 10000) & Eq(70*Max(1, u15 + 1000), 70*u15 + 70000) (unhinted: Eq(1, s44 + u15) & (Eq(s112, 1) | Eq(10, 10*s44 + 10*u15)) & (Eq(s10, 1) | Eq(10*s112*Max(1, s44 + u15), s112*(10*s44 + 10*u15)))).  (Size-like symbols: none)

consider using data-dependent friendly APIs such as guard_or_false, guard_or_true and statically_known_true.
Caused by: (_inductor/ir.py:5668 in <genexpr>)
```

This could also be reproduced by the added unit test.

### Fix
Noticed that we have a util func `is_contiguous_for_memory_format_or_false` that's supposed to work with symbolic shapes, so make use of it to fix this issue.

Test Plan:
Unit test repro: https://www.internalfb.com/intern/testinfra/testrun/18295873503539612

- Unit tests passed
- Internal use case DDE resolved
- OSS CI

Reviewed By: lurunming, desertfire

Differential Revision: D102833257




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos