### PR TITLE
Enable FP32 emulation via BF16 in cuSOLVER

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
@@ -42,6 +42,18 @@ cusolverDnHandle_t getCurrentCUDASolverDnHandle() {
   auto handle = myPoolWindow->reserve(device);
   auto stream = c10::cuda::getCurrentCUDAStream();
   TORCH_CUSOLVER_CHECK(cusolverDnSetStream(handle, stream));
+
+  #if CUDA_VERSION >= 12900
+    cudaDeviceProp prop;
+    AT_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
+    // Emulation of FP32 via 9xBF16 is only available on CC 10 and 10.3
+    // See: https://docs.nvidia.com/cuda/cublas/#floating-point-emulation-support-overview
+    if (prop.major == 10 && (prop.minor == 0 || prop.minor == 3)) {
+      TORCH_CUSOLVER_CHECK(cusolverDnSetMathMode(handle, CUSOLVER_FP32_EMULATED_BF16X9_MATH));
+      TORCH_CUSOLVER_CHECK(cusolverDnSetEmulationStrategy(handle, CUDA_EMULATION_STRATEGY_PERFORMANT));
+    }
+  #endif
+
   return handle;
 }
 

--- a/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
@@ -43,7 +43,7 @@ cusolverDnHandle_t getCurrentCUDASolverDnHandle() {
   auto stream = c10::cuda::getCurrentCUDAStream();
   TORCH_CUSOLVER_CHECK(cusolverDnSetStream(handle, stream));
 
-  #if CUDA_VERSION >= 12900
+  #if CUDA_VERSION >= 12090
     cudaDeviceProp prop;
     AT_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
     // Emulation of FP32 via 9xBF16 is only available on CC 10 and 10.3


### PR DESCRIPTION
### Summary
Adds support for emulation of FP32 accuracy by emulating via 9 BF16 operations by selecting the corresponding cuSOLVER math mode for all cuSOLVER operations in linalg using the handle generated in `CusolverDnHandlePool.cpp` .

### Motivation

With Blackwell, Nvidia is moving the focus of their accelerators towards lower accuracy dtypes. BF16 performance is increasing drastically, resulting in a over 9x performance increase for BF16 vs FP32. Therefore the emulation is expected to outperform native FP32 for B200 and B300.

### Details

Implementation based on [https://docs.nvidia.com/cuda/cusolver/index.html#floating-point-emulation](https://docs.nvidia.com/cuda/cusolver/index.html#floating-point-emulation) and [https://docs.nvidia.com/cuda/cublas/#floating-point-emulation](https://docs.nvidia.com/cuda/cublas/#floating-point-emulation)

- Sets the cuSOLVER MathMode flag via `cusolverDnSetMathMode` to `CUSOLVER_FP32_EMULATED_BF16X9_MATH`
- Compile time guard to only compile for supported CUDA (>=12.9)
- Only enabled for CC 10.0 and 10.3 (supported architectures according to cuBLAS docs, no issues observed when enabling on CC12, but it is not officially supported)
- Sets the emulation strategy via `cusolverDnSetEmulationStrategy` to `CUDA_EMULATION_STRATEGY_PERFORMANT`

### Testing

Testing was performed on B200. For n<=4096 no meaningfull performance impact was observed. For larger n performance improves by over to 50% for some cuSOLVER ops. Other ops stayed within margin of error to native FP32 calculation. 
I tried to cover as broad a spectrum of matrix sizes and operations as possible and tested both for numerics as well as performance. Numerics was tested by calculating the residual of the mathematical identity underlying the operations. I chose this way instead of comparing to other dtypes/backends to avoid ordering issues. Additional testing with `test/test_linalg.py` was performed, showing no failures. Results from numerics and performance can be seen here:

<img width="2000" height="1200" alt="image" src="https://github.com/user-attachments/assets/4a8116b9-2ed3-4f27-9e92-756a20f96dc4" />


<img width="2000" height="1200" alt="image" src="https://github.com/user-attachments/assets/240854e7-16c3-499c-ab01-4d84084ebc5e" />


@lezcano as you suspected, the paths that seem to make use of emulation actually show an improvement in accuracy.

### Implementation

Right now this path is hardcoded to enable on B200 and B300. I am not sure this is the right way to go, as Nvidia specifies that the emulation does not obey IEEE FP32 specifications, although it seems to be advantageous in every observed aspect. It might make sense to implement an API similar to `torch.backends.cuda.matmul.fp32_precision`. Open to input on the way to go here.

cc @jianyuh @nikitaved @mruberry @walterddr @xwang233 @Lezcano @lezcano @IvanYashchuk @albanD 