### PR TITLE
[MPS] sdpa causal with attn mask proper error

### DIFF
--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -666,6 +666,9 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
   TORCH_CHECK_NOT_IMPLEMENTED(c10::isFloatingType(value_.scalar_type()),
                               "scaled_dot_product_attention for MPS does not support dtype ",
                               value_.scalar_type());
+  // match generic attention.cpp ref, combination is ill-defined
+  TORCH_CHECK(!(is_causal && attn_mask.has_value()),
+              "_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True");
   const auto any_nested = query.is_nested() || key_.is_nested() || value_.is_nested();
   const auto all_contiguous =
       query.is_contiguous_or_false() && key_.is_contiguous_or_false() && value_.is_contiguous_or_false();

--- a/aten/src/ATen/native/mps/operations/Attention.mm
+++ b/aten/src/ATen/native/mps/operations/Attention.mm
@@ -51,6 +51,9 @@ static std::tuple<Tensor, Tensor> sdpa_general_mps(const Tensor& query,
                                                    const Tensor& orig_query,
                                                    bool unsqueezed) {
   using namespace mps;
+  // MPSGraph fallback path doesn't combine causal + attn_mask correctly
+  TORCH_CHECK(!(is_causal && attn_mask.has_value()),
+              "_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True");
   struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* qTensor = nil;
@@ -666,9 +669,6 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_attention_math_mps(const Tensor& 
   TORCH_CHECK_NOT_IMPLEMENTED(c10::isFloatingType(value_.scalar_type()),
                               "scaled_dot_product_attention for MPS does not support dtype ",
                               value_.scalar_type());
-  // match generic attention.cpp ref, combination is ill-defined
-  TORCH_CHECK(!(is_causal && attn_mask.has_value()),
-              "_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True");
   const auto any_nested = query.is_nested() || key_.is_nested() || value_.is_nested();
   const auto all_contiguous =
       query.is_contiguous_or_false() && key_.is_contiguous_or_false() && value_.is_contiguous_or_false();

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10394,6 +10394,21 @@ class TestSDPA(TestCaseMPS):
         y_cpu = F.scaled_dot_product_attention(q_cpu, k_cpu, v_cpu)
         self._compare_tensors(y_mps.cpu(), y_cpu)
 
+    def test_sdpa_causal_with_attn_mask_raises(self):
+        # Passing both is_causal=True and an explicit attn_mask is ill-defined
+        # input and must raise rather than crash
+        torch.manual_seed(0)
+        q = torch.randn(1, 2, 4, 64, device="mps")
+        k = torch.randn(1, 2, 16, 64, device="mps")
+        v = torch.randn(1, 2, 16, 64, device="mps")
+        mask = torch.zeros(1, 2, 4, 16, dtype=torch.bool, device="mps")
+        with torch.nn.attention.sdpa_kernel([torch.nn.attention.SDPBackend.MATH]):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True",
+            ):
+                F.scaled_dot_product_attention(q, k, v, attn_mask=mask, is_causal=True)
+
     @unittest.skip("Full attention fast kernel not implemented yet")
     @parametrize("dtype", [torch.float16, torch.float32])
     @parametrize("layout", ["contiguous", "mT"])


### PR DESCRIPTION
sdpa causal with attn mask proper error. Without this it gives a bogus MPS Graph error:

Run this to get the below error:
```
import torch
import torch.nn.functional as F
q = torch.randn(1, 2, 4, 64, device="mps")
k = torch.randn(1, 2, 16, 64, device="mps")
v = torch.randn(1, 2, 16, 64, device="mps")
mask = torch.zeros(1, 2, 4, 16, dtype=torch.bool, device="mps")
F.scaled_dot_product_attention(q, k, v, attn_mask=mask, is_causal=True)
```

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[3]'
*** First throw call stack:
(
        0   CoreFoundation                      0x0000000183966bf0 __exceptionPreprocess + 176
        1   libobjc.A.dylib                     0x00000001833f291c objc_exception_throw + 88
        2   CoreFoundation                      0x0000000183884d40 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 764
        3   CoreFoundation                      0x0000000183884a18 +[NSDictionary dictionaryWithObjects:forKeys:count:] + 52
        4   libtorch_cpu.dylib                  0x000000011defb580 _ZN2at6native38_scaled_dot_product_attention_math_mpsERKNS_6TensorES3_S3_RKNSt3__18optionalIS1_EEdbS8_NS5_IdEEb + 4724
        5   libtorch_cpu.dylib                  0x000000011b2b460c _ZN3c104impl31make_boxed_from_unboxed_functorINS0_6detail24WrapFunctionIntoFunctor_INS_26CompileTimeFunctionPointerIFNSt3__15tupleIJN2at6TensorES8_EEERKS8_SB_SB_RKNS5_8optionalIS8_EEdbSF_NSC_IdEE     6   libtorch_cpu.dylib                  0x000000011d42d428 _ZN3c1011BoxedKernel19make_boxed_functionIXadL_ZN5torch8autogradL34autogradNotImplementedFallbackImplERKNS_14OperatorHandleENS_14DispatchKeySetEPNSt3__16vectorINS_6IValueENS8_9allocatorISA_EEEEEE        7   libtorch_cpu.dylib                  0x000000011a6beb8c _ZN3c104impl18BoxedKernelWrapperIFNSt3__15tupleIJN2at6TensorES5_EEERKS5_S8_S8_RKNS2_8optionalIS5_EEdbSC_NS9_IdEEbEvE4callERKNS_11BoxedKernelERKNS_14OperatorHandleENS_14DispatchKeySetES8_S8_S8_SC_        8   libtorch_cpu.dylib                  0x000000011a6be0d4 _ZN2at4_ops42_scaled_dot_product_attention_math_for_mps4callERKNS_6TensorES4_S4_RKNSt3__18optionalIS2_EEdbS9_NS6_IdEEb + 624
        9   libtorch_cpu.dylib                  0x0000000119ff44d4 _ZN2at6native28scaled_dot_product_attentionERKNS_6TensorES3_S3_RKNSt3__18optionalIS1_EEdbNS5_IdEEb + 3516
        10  libtorch_cpu.dylib                  0x000000011a544054 _ZN2at4_ops28scaled_dot_product_attention4callERKNS_6TensorES4_S4_RKNSt3__18optionalIS2_EEdbNS6_IdEEb + 408
        11  libtorch_python.dylib               0x0000000108c09344 _ZN5torch8autogradL40THPVariable_scaled_dot_product_attentionEP7_objectS2_S2_ + 944
        12  libpython3.14.dylib                 0x000000010201df78 cfunction_call + 72
        13  libpython3.14.dylib                 0x0000000101da20e4 PyObject_Vectorcall + 456
        14  libpython3.14.dylib                 0x0000000101eacabc _TAIL_CALL_CALL_KW.llvm.10127954890374434623 + 656
        15  libpython3.14.dylib                 0x0000000101e9dd00 _PyEval_Vector + 780
        16  libpython3.14.dylib                 0x0000000101ead88c PyEval_EvalCode + 160
        17  libpython3.14.dylib                 0x0000000101ebfa7c run_mod.llvm.9148091775861049191 + 292
        18  libpython3.14.dylib                 0x0000000101fed880 pyrun_file + 164
        19  libpython3.14.dylib                 0x0000000101dbc080 _PyRun_SimpleFileObject + 256
        20  libpython3.14.dylib                 0x0000000101dbbe24 _PyRun_AnyFileObject + 80
        21  libpython3.14.dylib                 0x0000000101dbbd18 pymain_run_file_obj + 164
        22  libpython3.14.dylib                 0x0000000101f8cce8 pymain_run_file + 72
        23  libpython3.14.dylib                 0x0000000101f892ac Py_RunMain + 1132
        24  libpython3.14.dylib                 0x0000000101f3a8f4 pymain_main + 464
        25  libpython3.14.dylib                 0x0000000101f3a718 Py_BytesMain + 36
        26  dyld                                0x000000018347fda4 start + 6992
)
libc++abi: terminating due to uncaught exception of type NSException
zsh: abort      python temp.py
```