### PR TITLE
[c10] Add InlineEventBase to unify event APIs in DeviceGuardImplInter…

### DIFF
--- a/c10/core/EventFlag.h
+++ b/c10/core/EventFlag.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace c10 {
+
+/**
+ * Note [Flags defining the behavior of events]
+ *
+ * PYTORCH_DEFAULT and BACKEND_DEFAULT are valid for all backends. The
+ * BACKEND_DEFAULT is what a particular backend would select if no
+ * flags were given. PYTORCH_DEFAULT is the PyTorch's framework default
+ * choice for events on that backend, which may not be the same.
+ *
+ * The mapping of PYTORCH_DEFAULT and BACKEND_DEFAULT is done by each
+ * backend implementation.
+ */
+enum class EventFlag {
+  // Disable timing
+  PYTORCH_DEFAULT,
+  // Enable timing
+  BACKEND_DEFAULT,
+  // FOR TESTING ONLY
+  INVALID
+};
+
+} // namespace c10

--- a/c10/core/impl/DeviceGuardImplInterface.h
+++ b/c10/core/impl/DeviceGuardImplInterface.h
@@ -3,7 +3,9 @@
 #include <c10/core/Device.h>
 #include <c10/core/DeviceCapability.h>
 #include <c10/core/DeviceType.h>
+#include <c10/core/EventFlag.h>
 #include <c10/core/Stream.h>
+#include <c10/core/impl/InlineEventBase.h>
 #include <c10/util/Exception.h>
 
 // Just for C10_ANONYMOUS_VARIABLE
@@ -17,26 +19,6 @@ namespace c10 {
 
 // Forward declaration
 class DataPtr;
-
-/**
- * Note [Flags defining the behavior of events]
- *
- * PYTORCH_DEFAULT and BACKEND_DEFAULT are valid for all backends. The
- * BACKEND_DEFAULT is what a particular backend would select if no
- * flags were given. PYTORCH_DEFAULT is the PyTorch's framework default
- * choice for events on that backend, which may not be the same.
- *
- * The mapping of PYTORCH_DEFAULT and BACKEND_DEFAULT is done by each
- * backend implementation.
- */
-enum class EventFlag {
-  // Disable timing
-  PYTORCH_DEFAULT,
-  // Enable timing
-  BACKEND_DEFAULT,
-  // FOR TESTING ONLY
-  INVALID
-};
 
 namespace impl {
 
@@ -269,6 +251,39 @@ struct C10_API DeviceGuardImplInterface {
       void* /*event2*/,
       const DeviceIndex /*device_index*/) const {
     TORCH_CHECK(false, "Backend doesn't support elapsedTime.");
+  }
+
+  // -- New event APIs taking InlineEventBase --
+  // Backends may override these directly. The default implementations
+  // delegate to the legacy void* overloads above for backwards
+  // compatibility with existing backends.
+
+  virtual void destroyEvent(InlineEventBase& event) const noexcept {
+    destroyEvent(event.event(), event.device_index());
+  }
+
+  virtual void record(InlineEventBase& event, const Stream& stream) const {
+    void* raw = event.event();
+    record(&raw, stream, event.device_index(), event.flag());
+    event.setEvent(raw);
+  }
+
+  virtual void block(const InlineEventBase& event, const Stream& stream) const {
+    block(event.event(), stream);
+  }
+
+  virtual bool queryEvent(const InlineEventBase& event) const {
+    return queryEvent(event.event());
+  }
+
+  virtual void synchronizeEvent(const InlineEventBase& event) const {
+    synchronizeEvent(event.event());
+  }
+
+  virtual double elapsedTime(
+      const InlineEventBase& event1,
+      const InlineEventBase& event2) const {
+    return elapsedTime(event1.event(), event2.event(), event1.device_index());
   }
 
   /**

--- a/c10/core/impl/FakeGuardImpl.h
+++ b/c10/core/impl/FakeGuardImpl.h
@@ -57,7 +57,7 @@ struct FakeGuardImpl final : public DeviceGuardImplInterface {
     return kFakeGuardImplMaxDevices;
   }
 
-  // Event-related functions
+  // Event-related functions (legacy void* API)
   void record(
       void** /*event*/,
       const Stream& /*stream*/,
@@ -69,6 +69,22 @@ struct FakeGuardImpl final : public DeviceGuardImplInterface {
   }
   void destroyEvent(void* /*event*/, const DeviceIndex /*device_index*/)
       const noexcept override {}
+
+  // Event-related functions (new InlineEventBase API)
+  void record(InlineEventBase& /*event*/, const Stream& /*stream*/)
+      const override {}
+  void block(const InlineEventBase& /*event*/, const Stream& /*stream*/)
+      const override {}
+  bool queryEvent(const InlineEventBase& /*event*/) const override {
+    return true;
+  }
+  void destroyEvent(InlineEventBase& /*event*/) const noexcept override {}
+  void synchronizeEvent(const InlineEventBase& /*event*/) const override {}
+  double elapsedTime(
+      const InlineEventBase& /*event1*/,
+      const InlineEventBase& /*event2*/) const override {
+    return 0.0;
+  }
 
   // Convenience methods for testing
   static DeviceIndex getDeviceIndex() {

--- a/c10/core/impl/InlineEvent.h
+++ b/c10/core/impl/InlineEvent.h
@@ -2,6 +2,7 @@
 
 #include <c10/core/DeviceType.h>
 #include <c10/core/Stream.h>
+#include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/core/impl/InlineEventBase.h>
 #include <c10/util/Exception.h>
 
@@ -42,7 +43,7 @@ struct InlineEvent final : public InlineEventBase {
 
   ~InlineEvent() noexcept {
     if (event())
-      backend_.destroyEvent(*this);
+      base().destroyEvent(*this);
   }
 
   bool was_marked_for_recording() const noexcept {
@@ -63,7 +64,7 @@ struct InlineEvent final : public InlineEventBase {
         DeviceTypeName(stream.device_type()),
         ".");
 
-    backend_.record(*this, stream);
+    base().record(*this, stream);
     was_marked_for_recording_ = true;
     setDeviceIndex(stream.device_index());
   }
@@ -80,13 +81,13 @@ struct InlineEvent final : public InlineEventBase {
         DeviceTypeName(stream.device_type()),
         ".");
 
-    backend_.block(*this, stream);
+    base().block(*this, stream);
   }
 
   bool query() const {
     if (!was_marked_for_recording_)
       return true;
-    return backend_.queryEvent(*this);
+    return base().queryEvent(*this);
   }
 
   void* eventId() const {
@@ -114,16 +115,23 @@ struct InlineEvent final : public InlineEventBase {
         (query() && other.query()) || device_type() == DeviceType::MPS,
         "Both events must be completed before calculating elapsed time.");
 
-    return backend_.elapsedTime(*this, other);
+    return base().elapsedTime(*this, other);
   }
 
   void synchronize() const {
     if (!was_marked_for_recording_)
       return;
-    backend_.synchronizeEvent(*this);
+    base().synchronizeEvent(*this);
   }
 
  private:
+  DeviceGuardImplInterface& base() {
+    return static_cast<DeviceGuardImplInterface&>(backend_);
+  }
+  const DeviceGuardImplInterface& base() const {
+    return static_cast<const DeviceGuardImplInterface&>(backend_);
+  }
+
   T backend_;
   bool was_marked_for_recording_ = false;
 };

--- a/c10/core/impl/InlineEvent.h
+++ b/c10/core/impl/InlineEvent.h
@@ -2,18 +2,18 @@
 
 #include <c10/core/DeviceType.h>
 #include <c10/core/Stream.h>
-#include <c10/core/impl/DeviceGuardImplInterface.h>
+#include <c10/core/impl/InlineEventBase.h>
 #include <c10/util/Exception.h>
 
 namespace c10::impl {
 
 template <typename T>
-struct InlineEvent final {
+struct InlineEvent final : public InlineEventBase {
   InlineEvent() = delete;
   InlineEvent(
       const DeviceType _device_type,
       const EventFlag _flag = EventFlag::PYTORCH_DEFAULT)
-      : backend_{_device_type}, device_type_{_device_type}, flag_{_flag} {}
+      : InlineEventBase(_device_type, _flag), backend_{_device_type} {}
 
   // Copy constructor and copy assignment operator (deleted)
   InlineEvent(const InlineEvent&) = delete;
@@ -21,13 +21,10 @@ struct InlineEvent final {
 
   // Move constructor and move assignment operator
   InlineEvent(InlineEvent&& other) noexcept
-      : event_(other.event_),
+      : InlineEventBase(std::move(other)),
         backend_(std::move(other.backend_)),
-        device_type_(other.device_type_),
-        device_index_(other.device_index_),
-        flag_(other.flag_),
         was_marked_for_recording_(other.was_marked_for_recording_) {
-    other.event_ = nullptr;
+    other.was_marked_for_recording_ = false;
   }
   InlineEvent& operator=(InlineEvent&& other) noexcept {
     swap(other);
@@ -35,28 +32,19 @@ struct InlineEvent final {
   }
 
   void swap(InlineEvent& other) noexcept {
-    std::swap(event_, other.event_);
-    std::swap(backend_, other.backend_);
-    std::swap(device_type_, other.device_type_);
-    std::swap(device_index_, other.device_index_);
-    std::swap(flag_, other.flag_);
-    std::swap(was_marked_for_recording_, other.was_marked_for_recording_);
+    using std::swap;
+    swap(
+        static_cast<InlineEventBase&>(*this),
+        static_cast<InlineEventBase&>(other));
+    swap(backend_, other.backend_);
+    swap(was_marked_for_recording_, other.was_marked_for_recording_);
   }
 
   ~InlineEvent() noexcept {
-    if (event_)
-      backend_.destroyEvent(event_, device_index_);
+    if (event())
+      backend_.destroyEvent(*this);
   }
 
-  DeviceType device_type() const noexcept {
-    return device_type_;
-  }
-  DeviceIndex device_index() const noexcept {
-    return device_index_;
-  }
-  EventFlag flag() const noexcept {
-    return flag_;
-  }
   bool was_marked_for_recording() const noexcept {
     return was_marked_for_recording_;
   }
@@ -68,16 +56,16 @@ struct InlineEvent final {
 
   void record(const Stream& stream) {
     TORCH_CHECK(
-        stream.device_type() == device_type_,
+        stream.device_type() == device_type(),
         "Event device type ",
-        DeviceTypeName(device_type_),
+        DeviceTypeName(device_type()),
         " does not match recording stream's device type ",
         DeviceTypeName(stream.device_type()),
         ".");
 
-    backend_.record(&event_, stream, device_index_, flag_);
+    backend_.record(*this, stream);
     was_marked_for_recording_ = true;
-    device_index_ = stream.device_index();
+    setDeviceIndex(stream.device_index());
   }
 
   void block(const Stream& stream) const {
@@ -85,37 +73,37 @@ struct InlineEvent final {
       return;
 
     TORCH_CHECK(
-        stream.device_type() == device_type_,
+        stream.device_type() == device_type(),
         "Event device type ",
-        DeviceTypeName(device_type_),
+        DeviceTypeName(device_type()),
         " does not match blocking stream's device type ",
         DeviceTypeName(stream.device_type()),
         ".");
 
-    backend_.block(event_, stream);
+    backend_.block(*this, stream);
   }
 
   bool query() const {
     if (!was_marked_for_recording_)
       return true;
-    return backend_.queryEvent(event_);
+    return backend_.queryEvent(*this);
   }
 
   void* eventId() const {
-    return event_;
+    return event();
   }
 
   double elapsedTime(const InlineEvent& other) const {
     TORCH_CHECK(
-        other.device_type() == device_type_,
+        other.device_type() == device_type(),
         "Event device type ",
-        DeviceTypeName(device_type_),
+        DeviceTypeName(device_type()),
         " does not match other's device type ",
         DeviceTypeName(other.device_type()),
         ".");
     TORCH_CHECK_VALUE(
-        (flag_ == EventFlag::BACKEND_DEFAULT) &&
-            (other.flag_ == EventFlag::BACKEND_DEFAULT),
+        (flag() == EventFlag::BACKEND_DEFAULT) &&
+            (other.flag() == EventFlag::BACKEND_DEFAULT),
         "Both events must be created with argument 'enable_timing=True'.");
     TORCH_CHECK_VALUE(
         was_marked_for_recording() && other.was_marked_for_recording(),
@@ -123,24 +111,20 @@ struct InlineEvent final {
     // elapsedTime in MPS can wait event to be completed if event is not ready,
     // which is a little different from CUDA
     TORCH_CHECK(
-        (query() && other.query()) || device_type_ == DeviceType::MPS,
+        (query() && other.query()) || device_type() == DeviceType::MPS,
         "Both events must be completed before calculating elapsed time.");
 
-    return backend_.elapsedTime(event_, other.event_, device_index_);
+    return backend_.elapsedTime(*this, other);
   }
 
   void synchronize() const {
     if (!was_marked_for_recording_)
       return;
-    backend_.synchronizeEvent(event_);
+    backend_.synchronizeEvent(*this);
   }
 
  private:
-  void* event_ = nullptr;
   T backend_;
-  DeviceType device_type_;
-  DeviceIndex device_index_ = -1;
-  EventFlag flag_ = EventFlag::PYTORCH_DEFAULT;
   bool was_marked_for_recording_ = false;
 };
 

--- a/c10/core/impl/InlineEventBase.h
+++ b/c10/core/impl/InlineEventBase.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <c10/core/DeviceType.h>
+#include <c10/core/EventFlag.h>
+
+namespace c10::impl {
+
+struct InlineEventBase {
+  InlineEventBase(const InlineEventBase&) = delete;
+  InlineEventBase& operator=(const InlineEventBase&) = delete;
+
+  DeviceType device_type() const noexcept {
+    return device_type_;
+  }
+  DeviceIndex device_index() const noexcept {
+    return device_index_;
+  }
+  EventFlag flag() const noexcept {
+    return flag_;
+  }
+  void* event() const noexcept {
+    return event_;
+  }
+  void setEvent(void* p) noexcept {
+    event_ = p;
+  }
+  void setDeviceIndex(const DeviceIndex i) noexcept {
+    device_index_ = i;
+  }
+
+ protected:
+  InlineEventBase(const DeviceType device_type, const EventFlag flag)
+      : device_type_{device_type}, flag_{flag} {}
+
+  InlineEventBase(InlineEventBase&& other) noexcept = default;
+  InlineEventBase& operator=(InlineEventBase&& other) noexcept = default;
+
+  friend void swap(InlineEventBase& a, InlineEventBase& b) noexcept {
+    using std::swap;
+    swap(a.event_, b.event_);
+    swap(a.device_type_, b.device_type_);
+    swap(a.device_index_, b.device_index_);
+    swap(a.flag_, b.flag_);
+  }
+
+ private:
+  void* event_ = nullptr;
+  DeviceType device_type_{};
+  DeviceIndex device_index_ = -1;
+  EventFlag flag_ = EventFlag::PYTORCH_DEFAULT;
+};
+
+} // namespace c10::impl

--- a/c10/core/impl/InlineEventBase.h
+++ b/c10/core/impl/InlineEventBase.h
@@ -32,7 +32,13 @@ struct InlineEventBase {
   InlineEventBase(const DeviceType device_type, const EventFlag flag)
       : device_type_{device_type}, flag_{flag} {}
 
-  InlineEventBase(InlineEventBase&& other) noexcept = default;
+  InlineEventBase(InlineEventBase&& other) noexcept
+      : event_(other.event_),
+        device_type_(other.device_type_),
+        device_index_(other.device_index_),
+        flag_(other.flag_) {
+    other.event_ = nullptr;
+  }
   InlineEventBase& operator=(InlineEventBase&& other) noexcept = default;
 
   friend void swap(InlineEventBase& a, InlineEventBase& b) noexcept {

--- a/c10/core/impl/VirtualGuardImpl.h
+++ b/c10/core/impl/VirtualGuardImpl.h
@@ -107,6 +107,29 @@ class VirtualGuardImpl final : public DeviceGuardImplInterface {
     impl_->synchronizeEvent(event);
   }
 
+  // New event functions taking InlineEventBase
+  void destroyEvent(InlineEventBase& event) const noexcept override {
+    impl_->destroyEvent(event);
+  }
+  void record(InlineEventBase& event, const Stream& stream) const override {
+    impl_->record(event, stream);
+  }
+  void block(const InlineEventBase& event, const Stream& stream)
+      const override {
+    impl_->block(event, stream);
+  }
+  bool queryEvent(const InlineEventBase& event) const override {
+    return impl_->queryEvent(event);
+  }
+  void synchronizeEvent(const InlineEventBase& event) const override {
+    impl_->synchronizeEvent(event);
+  }
+  double elapsedTime(
+      const InlineEventBase& event1,
+      const InlineEventBase& event2) const override {
+    return impl_->elapsedTime(event1, event2);
+  }
+
   void synchronizeDevice(const DeviceIndex device_index) const override {
     impl_->synchronizeDevice(device_index);
   }


### PR DESCRIPTION
…face

Event methods on DeviceGuardImplInterface have inconsistent signatures some take void* + DeviceIndex, others take just void*. This makes it impossible for backends to uniformly access event metadata like device type or flags without extra bookkeeping.

Adding InlineEventBase, a minimal non-templated base class that carries event state (void* handle, DeviceType, DeviceIndex, EventFlag). InlineEvent<T> now inherits from it. New virtual methods on DeviceGuardImplInterface take InlineEventBase& instead of void*, giving backends uniform access to event metadata.

The new methods have default implementations that delegate to the existing void* methods, so no in-tree or OOT backends need to change in this PR. Backends can migrate to the new signatures incrementally; once all backends have migrated, the legacy void* methods can be removed.

Fixes: #163836 