### PR TITLE
collect_env: add uv support

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -44,6 +44,7 @@ SystemEnv = namedtuple(
         "is_xpu_available",
         "pip_version",  # 'pip' or 'pip3'
         "pip_packages",
+        "uv_packages",
         "conda_packages",
         "hip_compiled_version",
         "hip_runtime_version",
@@ -654,6 +655,24 @@ def get_pip_packages(run_lambda, patterns=None):
     return pip_version, filtered_out
 
 
+def get_uv_packages(run_lambda, patterns=None):
+    """Return `uv pip list` output. Note: will also find conda-installed pytorch and numpy packages."""
+    if patterns is None:
+        patterns = PIP_PATTERNS + COMMON_PATTERNS + NVIDIA_PATTERNS + ONEAPI_PATTERNS
+
+    out = run_and_read_all(
+        run_lambda, ["uv", "pip", "list", "--format=freeze"]
+    )
+    if out is None:
+        return out
+
+    filtered_out = "\n".join(
+        line for line in out.splitlines() if any(name in line for name in patterns)
+    )
+
+    return filtered_out
+
+
 def get_cachingallocator_config() -> _Dict[str, str]:
     """Return the caching allocator configuration from environment variables.
     """
@@ -705,6 +724,7 @@ def get_env_info():
     """
     run_lambda = run
     pip_version, pip_list_output = get_pip_packages(run_lambda)
+    uv_list_output = get_uv_packages(run_lambda)
 
     if TORCH_AVAILABLE:
         version_str = torch.__version__
@@ -763,6 +783,7 @@ def get_env_info():
         miopen_runtime_version=miopen_runtime_version,
         pip_version=pip_version,
         pip_packages=pip_list_output,
+        uv_packages=uv_list_output,
         conda_packages=conda_packages,
         os=get_os(run_lambda),
         libc_version=get_libc_version(),
@@ -806,6 +827,7 @@ CPU:
 
 Versions of relevant libraries:
 {pip_packages}
+{uv_packages}
 {conda_packages}
 """.strip()
 
@@ -877,13 +899,18 @@ def pretty_str(envinfo):
 
     # If either of these are '', replace with 'No relevant packages'
     mutable_dict["pip_packages"] = replace_if_empty(mutable_dict["pip_packages"])
+    mutable_dict["uv_packages"] = replace_if_empty(mutable_dict["uv_packages"])
     mutable_dict["conda_packages"] = replace_if_empty(mutable_dict["conda_packages"])
 
-    # Tag conda and pip packages with a prefix
+    # Tag pip, uv, and conda packages with a prefix
     # If they were previously None, they'll show up as ie '[conda] Could not collect'
     if mutable_dict["pip_packages"]:
         mutable_dict["pip_packages"] = prepend(
             mutable_dict["pip_packages"], "[{}] ".format(envinfo.pip_version)
+        )
+    if mutable_dict["uv_packages"]:
+        mutable_dict["uv_packages"] = prepend(
+            mutable_dict["uv_packages"], "[uv] "
         )
     if mutable_dict["conda_packages"]:
         mutable_dict["conda_packages"] = prepend(

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -660,9 +660,13 @@ def get_uv_packages(run_lambda, patterns=None):
     if patterns is None:
         patterns = PIP_PATTERNS + COMMON_PATTERNS + NVIDIA_PATTERNS + ONEAPI_PATTERNS
 
-    out = run_and_read_all(
-        run_lambda, ["uv", "pip", "list", "--format=freeze"]
-    )
+    try:
+        out = run_and_read_all(
+            run_lambda, ["uv", "pip", "list", "--format=freeze"]
+        )
+    except FileNotFoundError:
+        out = None
+
     if out is None:
         return out
 


### PR DESCRIPTION
uv is becoming a very popular package manager, and may people are ditching pip and conda entirely. This PR adds support for uv-managed installations in the `collect_env.py` script.

### With uv

```console
> python3 torch/utils/collect_env.py
Collecting environment information...
PyTorch version: 2.11.0
Is debug build: False
CUDA used to build PyTorch: None
ROCM used to build PyTorch: N/A

OS: macOS 26.4.1 (arm64)
GCC version: Could not collect
Clang version: 18.1.8
CMake version: version 3.31.11
Libc version: N/A

Python version: 3.13.7 (main, Sep 18 2025, 22:52:34) [Clang 20.1.4 ] (64-bit runtime)
Python platform: macOS-26.4.1-arm64-arm-64bit-Mach-O
Is CUDA available: False
CUDA runtime version: No CUDA
CUDA_MODULE_LOADING set to: N/A
GPU models and configuration: No CUDA
Nvidia driver version: No CUDA
cuDNN version: No CUDA
Is XPU available: False
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: True
Caching allocator config: N/A

CPU:
Apple M2 Pro

Versions of relevant libraries:
[pip3] Could not collect
[uv] mypy==1.20.2
[uv] mypy-extensions==1.1.0
[uv] numpy==2.4.4
[uv] pytorch-lightning==2.6.1
[uv] segmentation-models-pytorch==0.5.0
[uv] torch==2.11.0
[uv] torchgeo==0.10.0.dev0
[uv] torchmetrics==1.9.0
[uv] torchvision==0.26.0
[conda] Could not collect
```
### Without uv
```console
> python3 torch/utils/collect_env.py
Collecting environment information...
PyTorch version: 2.11.0
Is debug build: False
CUDA used to build PyTorch: None
ROCM used to build PyTorch: N/A

OS: macOS 26.4.1 (arm64)
GCC version: Could not collect
Clang version: 21.0.0 (clang-2100.0.123.102)
CMake version: Could not collect
Libc version: N/A

Python version: 3.13.7 (main, Sep 18 2025, 22:52:34) [Clang 20.1.4 ] (64-bit runtime)
Python platform: macOS-26.4.1-arm64-arm-64bit-Mach-O
Is CUDA available: False
CUDA runtime version: No CUDA
CUDA_MODULE_LOADING set to: N/A
GPU models and configuration: No CUDA
Nvidia driver version: No CUDA
cuDNN version: No CUDA
Is XPU available: False
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: True
Caching allocator config: N/A

CPU:
Apple M2 Pro

Versions of relevant libraries:
[pip3] Could not collect
[uv] Could not collect
[conda] Could not collect
```
I just copied and pasted the `pip` section and replaced the logic with `uv pip`, but we could also use `python -m pip` or `uv pip` in the same `pip_packages` section. We could also use `uv tree` or another native API instead of `uv pip`.