### PR TITLE
[dynamo][guards] Disable recursive dict tag optimization

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -7271,6 +7271,7 @@ def forward(self, s77 : torch.SymInt, s27 : torch.SymInt, L_x_ : torch.Tensor):
         res = torch.compile(f, backend="aot_eager")()
         self.assertEqual(ref, res)
 
+    @torch._dynamo.config.patch("use_recursive_dict_tags_for_guards", True)
     def test_guard_tag_safe_tensor_metadata_segfault(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/180741
         # When a submodule becomes a tag-safe root, the recording pass stashes

--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -485,7 +485,7 @@ assume_dunder_attributes_remain_unchanged = True
 
 # Speedup guard execution of nested nn modules by recursively checking for dict
 # tags to avoid full guard execution.
-use_recursive_dict_tags_for_guards = True
+use_recursive_dict_tags_for_guards = False
 
 # Maximum number of objects for which we check dict pointers tags. This is
 # useful for regional compilation.


### PR DESCRIPTION
Recursive dict tag optimization reduces guard lantecy (if the model passes some conditions). However, this optimization is implemented in C++ and complicated, requiring careful handling of PyObject pointers. Recently, there have been 3 bugs - https://github.com/pytorch/pytorch/issues/180741, https://github.com/pytorch/pytorch/pull/178231 and https://fb.workplace.com/groups/1075192433118967/permalink/1939251640046371/, all of them resulting in segfaults.

So, this PR disables the optimization. We will cherry-pick this in 2.12.

Is the downside acceptable? Yes, there are a few reasons

1) The optimization is effective mostly for inference, and vLLM, the primary inference provider, skips all the guards. So, guards are not relevant for vLLM. 

2) For other inference usecases, the dict tag optimization is applied when the nn module does not have mutable attributes like list, sets as one of the attributes. Therefore, the optimization kicks in some small scenarios. 

3) Even for the cases where this optimization kicks in, the benefit can be dwarfed by the actual model exection time.

The optimization adds lot more complexity that can cause segfaults, with not a lot of benefits.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98