### PR TITLE
Preserve agent_space/ in setup.py clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 
 ## PyTorch
 
-agent_space/
 .dmypy.json
 .gradle
 .hypothesis
@@ -301,6 +300,9 @@ cmake-build-debug
 # BEGIN NOT-CLEAN-FILES (setup.py handles this marker. Do not change.)
 #
 # Below files are not deleted by "setup.py clean".
+
+# Scratch space for agent-authored throwaway files
+agent_space/
 
 # Downloaded bazel
 tools/bazel


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #181874

Move the `agent_space/` entry below the BEGIN NOT-CLEAN-FILES marker in
.gitignore so `python setup.py clean` does not wipe out the scratch
directory used for throwaway agent-authored files.

Authored with Claude.