### PR TITLE
[dtensor] Register sharding strategy for aten.detach_.default

### DIFF
--- a/test/distributed/tensor/test_tensor_ops.py
+++ b/test/distributed/tensor/test_tensor_ops.py
@@ -60,6 +60,18 @@ class DistTensorOpsTest(DTensorContinuousTestBase):
         detached_mat = mat.detach()
         self.assertFalse(detached_mat is mat)
 
+    def test_detach_inplace_inference_mode(self):
+        # Under inference_mode, autograd does not intercept detach_, so the
+        # call falls through to DTensor's dispatcher. Ensure aten.detach_ has a
+        # registered sharding strategy and propagates the input spec.
+        device_mesh = self.build_device_mesh()
+        for spec in ([Shard(0)], [Replicate()]):
+            mat = distribute_tensor(torch.randn(12, 8), device_mesh, spec)
+            with torch.inference_mode():
+                out = torch.ops.aten.detach_(mat)
+            self.assertTrue(out is mat)
+            self.assertEqual(out.placements, tuple(spec))
+
     def test_clone(self):
         device_mesh = self.build_device_mesh()
         specs = [[Replicate()], [Shard(0)]]

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -91,6 +91,7 @@ register_op_strategy(
         aten.clone.default,
         aten.contiguous.default,
         aten.detach.default,
+        aten.detach_.default,
         aten.alias.default,
         aten.fill_.Scalar,
         aten.view.dtype,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181876

Under inference_mode, autograd no longer intercepts detach_, so the call
falls through to DTensor's dispatcher and crashes with "Operator
aten.detach_.default does not have a sharding strategy registered."

Register aten.detach_.default alongside aten.detach.default with
propagate_single_input_strategy.

Authored-with: Claude <noreply@anthropic.com>