### PR TITLE
[lint] Register RAWTHROW linter and make unknown-linter check a hard error

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -528,17 +528,38 @@ include_patterns = [
     '**/*.h',
 ]
 exclude_patterns = [
-    # Vendored code (do not modify)
-    'c10/util/flat_hash_map.h',
-    'c10/util/order_preserving_flat_hash_map.h',
-    'aten/src/ATen/native/quantized/cpu/qnnpack/**',
-    'aten/src/ATen/native/transformers/cuda/mem_eff_attention/**',
-    # Standalone code that cannot depend on c10
-    'torch/csrc/inductor/aoti_runtime/**',
-    # Test files use EXPECT_THROW which is a gtest macro
-    'test/cpp/**/*.cpp',
-    # JIT frontend uses throw(ErrorReport(...)) pervasively
-    'torch/csrc/jit/frontend/schema_type_parser.cpp',
+    # Pre-existing violations; burn down over time.
+    'aten/src/**',
+    'c10/core/**',
+    'c10/cuda/**',
+    'c10/test/**',
+    'c10/util/**',
+    'c10/xpu/**',
+    'test/cpp/**',
+    'test/cpp_extensions/**',
+    'third_party/concurrentqueue/**',
+    'tools/autograd/**',
+    'torch/csrc/*.cpp',
+    'torch/csrc/*.h',
+    'torch/csrc/api/**',
+    'torch/csrc/autograd/**',
+    'torch/csrc/cuda/**',
+    'torch/csrc/distributed/**',
+    'torch/csrc/dynamo/**',
+    'torch/csrc/export/**',
+    'torch/csrc/fx/**',
+    'torch/csrc/inductor/**',
+    'torch/csrc/jit/**',
+    'torch/csrc/lazy/**',
+    'torch/csrc/multiprocessing/**',
+    'torch/csrc/profiler/**',
+    'torch/csrc/stable/**',
+    'torch/csrc/tensor/**',
+    'torch/csrc/utils/**',
+    'torch/csrc/xpu/**',
+    'torch/headeronly/**',
+    'torch/lib/**',
+    'torch/nativert/**',
 ]
 command = [
     'python3',

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -164,6 +164,7 @@ VERY_FAST_LINTERS = {
     "PYPROJECT",
     "RAWCUDA",
     "RAWCUDADEVICE",
+    "RAWTHROW",
     "ROOT_LOGGING",
     "TABS",
     "TESTOWNERS",
@@ -240,16 +241,14 @@ def _check_linters():
     unknown_linters = linters - ALL_LINTERS
     missing_linters = ALL_LINTERS - linters
     if unknown_linters:
-        click.secho(
+        raise click.ClickException(
             f"Unknown linters found; please add them to the correct category "
-            f"in .spin/cmds.py: {', '.join(unknown_linters)}",
-            fg="yellow",
+            f"in .spin/cmds.py: {', '.join(sorted(unknown_linters))}"
         )
     if missing_linters:
-        click.secho(
+        raise click.ClickException(
             f"Missing linters found; please update the corresponding category "
-            f"in .spin/cmds.py: {', '.join(missing_linters)}",
-            fg="yellow",
+            f"in .spin/cmds.py: {', '.join(sorted(missing_linters))}"
         )
     return unknown_linters, missing_linters
 


### PR DESCRIPTION
## Author Notes
Fixes the "spin lint" unknown lint to be a proper error. Otherwise, new lint will be silently not run in CI.
Emergency cleanup of rawthrow skip list. Will burn it down next.

## Agent Notes

The RAWTHROW linter was added to `.lintrunner.toml` but never registered in `.spin/cmds.py`, causing CI to fail with "Unknown linters found" while `spin lint` passed locally (because the check was only a warning).

Two fixes:
1. Register `RAWTHROW` in `VERY_FAST_LINTERS` and expand the exclude list with 31 directory-level glob patterns covering all 1433 pre-existing violations (334 files), so the linter is clean and new code outside those directories is enforced immediately.
2. Upgrade the unknown/missing linter validation in `_check_linters()` from a yellow warning to a hard error, so this class of issue is caught by `spin lint` locally going forward.

Authored with Claude.

## Test plan

- Verified `spin lint` passes locally
- Verified `uvx lintrunner --take RAWTHROW --all-files` produces zero violations
- Verified `spin lint` now hard-fails when a linter is missing from `.spin/cmds.py`