### PR TITLE
Add shim files to trigger STABLE_SHIM_USAGE lint to update shim_function_versions.txt

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1783,6 +1783,10 @@ command = [
 code = 'STABLE_SHIM_USAGE'
 include_patterns = [
     'torch/csrc/stable/**/*.h',
+    # We're including the shim file because this linter writes a shim_function_versions.txt that it reads
+    # in order to check usages of the shim. Even if the shim API is added but not used anywhere, we want to
+    # update that file.
+    'torch/csrc/inductor/aoti_torch/c/shim.h',
 ]
 command = [
     'python3',


### PR DESCRIPTION
You may be wondering (well i was wondering) "we have a STABLE_SHIM_VERSION lint! why don't we update the file there?"

It's because then we'd intro a dependency between two lints, which is bad. STABLE_SHIM_VERSION would then write a file that STABLE_SHIM_USAGE uses. lintrunner is great cuz all the lints are parallel! So while it could be a tad confusing, it's better to have the lints run in parallel and for STABLE_SHIM_USAGE to generate that file that it uses.

This change is needed because even if no top level C++ headers are using the shim, we should still update that file (shim_function_versions.txt). This would solve confusion like https://github.com/pytorch/pytorch/pull/179400#discussion_r3037013450

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181882

