### PR TITLE
[inductor][overlap] Register flex_attention in flop_registry for overlap scheduling

### DIFF
--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -1263,5 +1263,52 @@ class TestFlopCounter(TestCase):
         self.assertExpectedInline(str(fw_bw_flops), """146800640""")
 
 
+class TestFlexAttentionEstimation(TestCase):
+    def test_flex_attention_flop_registration(self):
+        """flex_attention HOPs are registered in flop_registry and recognized as compute nodes."""
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            estimate_roofline_runtime_ms,
+            is_compute_node,
+        )
+        from torch.utils.flop_counter import flop_registry
+
+        # Registered in flop_registry like sdpa
+        self.assertIn(torch.ops.higher_order.flex_attention, flop_registry)
+        self.assertIn(torch.ops.higher_order.flex_attention_backward, flop_registry)
+
+        # Build FX nodes: GQA with 16 query heads, 4 kv heads
+        q_shape = (2, 16, 1024, 64)
+        k_shape = (2, 4, 1024, 64)
+        v_shape = (2, 4, 1024, 64)
+
+        graph = torch.fx.Graph()
+        q = graph.placeholder("q")
+        k = graph.placeholder("k")
+        v = graph.placeholder("v")
+        q.meta["val"] = torch.randn(*q_shape, device="meta", dtype=torch.bfloat16)
+        k.meta["val"] = torch.randn(*k_shape, device="meta", dtype=torch.bfloat16)
+        v.meta["val"] = torch.randn(*v_shape, device="meta", dtype=torch.bfloat16)
+
+        fwd = graph.call_function(torch.ops.higher_order.flex_attention, args=(q, k, v))
+        fwd.meta["val"] = q.meta["val"]
+        mm = graph.call_function(torch.ops.aten.mm.default, args=(q, q))
+
+        # is_compute_node recognizes flex_attention alongside mm
+        self.assertTrue(is_compute_node(fwd))
+        self.assertTrue(is_compute_node(mm))
+        self.assertFalse(is_compute_node(q))
+
+        # Flops match sdpa_flop_count
+        fwd_flops = flop_registry[torch.ops.higher_order.flex_attention](
+            q.meta["val"], k.meta["val"], v.meta["val"], out_val=fwd.meta["val"]
+        )
+        expected_flops = sdpa_flop_count(q_shape, k_shape, v_shape)
+        self.assertEqual(fwd_flops, expected_flops)
+
+        # estimate_roofline_runtime_ms returns positive
+        est_ms = estimate_roofline_runtime_ms(fwd)
+        self.assertGreater(est_ms, 0.0)
+
+
 if __name__ == "__main__":
     run_tests()

--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -1266,17 +1266,14 @@ class TestFlopCounter(TestCase):
 class TestFlexAttentionEstimation(TestCase):
     def test_flex_attention_flop_registration(self):
         """flex_attention HOPs are registered in flop_registry and recognized as compute nodes."""
-        from torch._inductor.fx_passes.overlap_scheduling import (
-            estimate_roofline_runtime_ms,
-            is_compute_node,
-        )
+        from torch._inductor.fx_passes.overlap_scheduling import is_compute_node
         from torch.utils.flop_counter import flop_registry
 
         # Registered in flop_registry like sdpa
         self.assertIn(torch.ops.higher_order.flex_attention, flop_registry)
         self.assertIn(torch.ops.higher_order.flex_attention_backward, flop_registry)
 
-        # Build FX nodes: GQA with 16 query heads, 4 kv heads
+        # GQA: 16 query heads, 4 kv heads
         q_shape = (2, 16, 1024, 64)
         k_shape = (2, 4, 1024, 64)
         v_shape = (2, 4, 1024, 64)
@@ -1290,7 +1287,16 @@ class TestFlexAttentionEstimation(TestCase):
         v.meta["val"] = torch.randn(*v_shape, device="meta", dtype=torch.bfloat16)
 
         fwd = graph.call_function(torch.ops.higher_order.flex_attention, args=(q, k, v))
-        fwd.meta["val"] = q.meta["val"]
+        # Realistic output: (out_bf16, logsumexp_fp32, max_scores_fp32)
+        fwd.meta["val"] = (
+            torch.randn(*q_shape, device="meta", dtype=torch.bfloat16),
+            torch.randn(
+                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
+            ),
+            torch.randn(
+                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
+            ),
+        )
         mm = graph.call_function(torch.ops.aten.mm.default, args=(q, q))
 
         # is_compute_node recognizes flex_attention alongside mm
@@ -1305,7 +1311,36 @@ class TestFlexAttentionEstimation(TestCase):
         expected_flops = sdpa_flop_count(q_shape, k_shape, v_shape)
         self.assertEqual(fwd_flops, expected_flops)
 
-        # estimate_roofline_runtime_ms returns positive
+    @unittest.skipIf(not HAS_CUDA, "requires CUDA")
+    def test_flex_attention_roofline_estimate(self):
+        """estimate_roofline_runtime_ms works for flex_attention with mixed-dtype output."""
+        from torch._inductor.fx_passes.overlap_scheduling import (
+            estimate_roofline_runtime_ms,
+        )
+
+        q_shape = (2, 16, 1024, 64)
+        k_shape = (2, 4, 1024, 64)
+        v_shape = (2, 4, 1024, 64)
+
+        graph = torch.fx.Graph()
+        q = graph.placeholder("q")
+        k = graph.placeholder("k")
+        v = graph.placeholder("v")
+        q.meta["val"] = torch.randn(*q_shape, device="meta", dtype=torch.bfloat16)
+        k.meta["val"] = torch.randn(*k_shape, device="meta", dtype=torch.bfloat16)
+        v.meta["val"] = torch.randn(*v_shape, device="meta", dtype=torch.bfloat16)
+
+        fwd = graph.call_function(torch.ops.higher_order.flex_attention, args=(q, k, v))
+        fwd.meta["val"] = (
+            torch.randn(*q_shape, device="meta", dtype=torch.bfloat16),
+            torch.randn(
+                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
+            ),
+            torch.randn(
+                q_shape[0], q_shape[1], q_shape[2], device="meta", dtype=torch.float32
+            ),
+        )
+
         est_ms = estimate_roofline_runtime_ms(fwd)
         self.assertGreater(est_ms, 0.0)
 

--- a/torch/_inductor/fx_passes/node_runtime_estimation.py
+++ b/torch/_inductor/fx_passes/node_runtime_estimation.py
@@ -1,5 +1,5 @@
 """
-Collective runtime estimation using CUDA events and power-of-2 rounding.
+Node runtime estimation for overlap scheduling.
 """
 
 from __future__ import annotations

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -212,8 +212,18 @@ def estimate_roofline_runtime_ms(node: fx.Node) -> float:
     # Compute time (FLOPs-based, only if op is in flop_registry)
     compute_ns: float = 0.0
     flop_key = _get_flop_registry_key(node.target)
-    if flop_key is not None and len(out_dtypes) == 1:
-        compute_ns = get_compute_time(flop_key, args, kwargs, out, out_dtypes.copy())
+    if flop_key is not None and len(out_dtypes) >= 1:
+        # Use a single dtype for peak-flops lookup. For mixed-dtype outputs
+        # (e.g. flex_attention returns bf16 out + fp32 logsumexp), use the
+        # first output tensor's dtype as the compute dtype.
+        compute_dtypes = (
+            OrderedSet(out_dtypes)
+            if len(out_dtypes) == 1
+            else OrderedSet(
+                [next(t.dtype for t in flat_outs if isinstance(t, torch.Tensor))]
+            )
+        )
+        compute_ns = get_compute_time(flop_key, args, kwargs, out, compute_dtypes)
         if isinstance(compute_ns, (torch.SymInt, torch.SymFloat)):
             compute_ns = compute_ns.node.hint if compute_ns.node.has_hint() else 0.0
 

--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -161,15 +161,22 @@ def estimate_collective_time(
     )
 
 
+def _get_flop_registry_key(target: Any) -> Any | None:
+    """Return the flop_registry key for a node target, or None if not registered."""
+    key = getattr(target, "overloadpacket", None)
+    if key in torch.utils.flop_counter.flop_registry:
+        return key
+    if target in torch.utils.flop_counter.flop_registry:
+        return target
+    return None
+
+
 def is_compute_node(n: fx.Node) -> bool:
     """
     Should we consider this node computationally expensive ?
     Currently uses flop registration, but we could expand more generally.
     """
-    return (
-        getattr(n.target, "overloadpacket", None)
-        in torch.utils.flop_counter.flop_registry
-    )
+    return _get_flop_registry_key(n.target) is not None
 
 
 def estimate_roofline_runtime_ms(node: fx.Node) -> float:
@@ -182,7 +189,6 @@ def estimate_roofline_runtime_ms(node: fx.Node) -> float:
     from torch._inductor.fx_passes.fusion_regions import is_view_node
     from torch.utils._pytree import tree_flatten, tree_map
     from torch.utils._runtime_estimation import get_compute_time, get_transfer_time
-    from torch.utils.flop_counter import flop_registry
 
     if is_view_node(node):
         return 0.0
@@ -204,12 +210,10 @@ def estimate_roofline_runtime_ms(node: fx.Node) -> float:
     out_dtypes = OrderedSet([t.dtype for t in flat_outs if isinstance(t, torch.Tensor)])
 
     # Compute time (FLOPs-based, only if op is in flop_registry)
-    # May return SymFloat if shapes are symbolic (after flop division)
     compute_ns: float = 0.0
-    func_packet = getattr(node.target, "overloadpacket", None)
-    if func_packet in flop_registry and len(out_dtypes) == 1:
-        compute_ns = get_compute_time(func_packet, args, kwargs, out, out_dtypes.copy())
-        # Extract hint from symbolic value if needed
+    flop_key = _get_flop_registry_key(node.target)
+    if flop_key is not None and len(out_dtypes) == 1:
+        compute_ns = get_compute_time(flop_key, args, kwargs, out, out_dtypes.copy())
         if isinstance(compute_ns, (torch.SymInt, torch.SymFloat)):
             compute_ns = compute_ns.node.hint if compute_ns.node.has_hint() else 0.0
 
@@ -245,6 +249,12 @@ def benchmark_node_with_cache_key(
 ) -> tuple[float, str | None]:
     """Benchmark a compute node and return (runtime, cache_key)."""
     assert is_compute_node(n)
+
+    # HOPs can't be benchmarked standalone (args include subgraphs) — use analytical
+    from torch._ops import HigherOrderOperator
+
+    if isinstance(n.target, HigherOrderOperator):
+        return estimate_roofline_runtime_ms(n), None
 
     from torch._dynamo.testing import rand_strided
 

--- a/torch/utils/_runtime_estimation.py
+++ b/torch/utils/_runtime_estimation.py
@@ -74,6 +74,18 @@ _CREATE_OPS = OrderedSet(
 _IGNORE_OPS = _VIEW_OPS | _CREATE_OPS
 
 
+def flops_to_ns(flops: float | int, dtype: "torch.dtype") -> float:
+    """Convert a FLOPs count to estimated nanoseconds on the current GPU.
+
+    Uses 75% of theoretical peak and converts FLOPs to MACs (divide by 2).
+    """
+    peak_gpu_flops = get_device_tflops(dtype) * 1e15
+    if peak_gpu_flops == 0:
+        return 0.0
+    macs = flops / 2
+    return (macs / (0.75 * peak_gpu_flops)) * 1e9
+
+
 def get_compute_time(func_packet, args, kwargs, out, out_dtypes) -> float:  # type: ignore[no-untyped-def]
     """
     Estimates the compute time of an aten operator.
@@ -94,17 +106,9 @@ def get_compute_time(func_packet, args, kwargs, out, out_dtypes) -> float:  # ty
                 f"Only support single out dtype got {out_dtypes} for {func_packet}"
             )
         dtype = out_dtypes.pop()
-        # This actually gives peta-FLOPs/s hence multiply by 1e15 to get the FLOPs/s
-        peak_gpu_flops = get_device_tflops(dtype) * 1e15
-        # We can expect to achieve 75% of theoretical peak flops
-        factor = 0.75
-        peak_empirical_flops = factor * peak_gpu_flops
         flop_count_func = flop_registry[func_packet]
-        # We divide by a factor of 2 to get the MACs (multiply and accumulate)
-        flop_count = flop_count_func(*args, **kwargs, out_val=out) / 2
-        # We multiply by 1e9 to get the time in nano seconds
-        compute_time = (flop_count / peak_empirical_flops) * 1e9
-        return compute_time
+        flop_count = flop_count_func(*args, **kwargs, out_val=out)
+        return flops_to_ns(flop_count, dtype)
     return 0.0
 
 

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -627,8 +627,9 @@ def _register_flex_attention_flops() -> None:
     def flex_attention_backward_flop(
         query, key, value, out, logsumexp, grad_out, *args, out_val=None, **kwargs
     ) -> int:
+        grad_out_shape = grad_out.shape if grad_out is not None else out.shape
         return sdpa_backward_flop_count(
-            grad_out.shape, query.shape, key.shape, value.shape
+            grad_out_shape, query.shape, key.shape, value.shape
         )
 
 

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -53,10 +53,13 @@ def register_flop_formula(targets, get_raw=False) -> Callable[[Callable[_P, _T]]
             flop_formula = shape_wrapper(flop_formula)
 
         def register(target) -> None:
-            if not (isinstance(target, (torch._ops.OpOverloadPacket, _JITFunction))):
+            from torch._ops import HigherOrderOperator
+
+            if not (isinstance(target, (torch._ops.OpOverloadPacket, _JITFunction, HigherOrderOperator))):
                 raise ValueError(
                     f"register_flop_formula(targets): expected each target to be "
-                    f"OpOverloadPacket (i.e. torch.ops.mylib.foo), or JitFunction"
+                    f"OpOverloadPacket (i.e. torch.ops.mylib.foo), JitFunction, "
+                    f"or HigherOrderOperator"
                     f", got {target} which is of type {type(target)}")
             if target in flop_registry:
                 raise RuntimeError(f"duplicate registrations for {target}")
@@ -608,6 +611,27 @@ def _efficient_attention_backward_flop(
     )
 
 
+def _register_flex_attention_flops() -> None:
+    from torch._higher_order_ops.flex_attention import (
+        flex_attention,
+        flex_attention_backward,
+    )
+
+    @register_flop_formula(flex_attention, get_raw=True)
+    def flex_attention_forward_flop(
+        query, key, value, *args, out_val=None, **kwargs
+    ) -> int:
+        return sdpa_flop_count(query.shape, key.shape, value.shape)
+
+    @register_flop_formula(flex_attention_backward, get_raw=True)
+    def flex_attention_backward_flop(
+        query, key, value, out, logsumexp, grad_out, *args, out_val=None, **kwargs
+    ) -> int:
+        return sdpa_backward_flop_count(
+            grad_out.shape, query.shape, key.shape, value.shape
+        )
+
+
 def _varlen_attn_forward_flop(
     query,
     key,
@@ -710,6 +734,9 @@ flop_registry = {
     aten._flash_attention_backward: _flash_attention_backward_flop,
     aten._efficient_attention_backward: _efficient_attention_backward_flop,
 }
+
+_register_flex_attention_flops()
+
 
 def normalize_tuple(x):
     if not isinstance(x, tuple):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181883

flex_attention HOPs were invisible to the overlap scheduler because
they weren't in flop_registry. The scheduler treated them as
zero-cost, missing the most expensive op in transformer layers.

Register flex_attention forward/backward in flop_registry using
sdpa_flop_count/sdpa_backward_flop_count — same formulas as all
other sdpa variants. Extend register_flop_formula to accept
HigherOrderOperator targets. Extend is_compute_node and
estimate_roofline_runtime_ms to look up HOPs directly in
flop_registry when overloadpacket is absent. Guard
benchmark_node_with_cache_key to skip benchmarking for HOPs
(their args include subgraphs). Extract flops_to_ns from
get_compute_time so the roofline formula is shared.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo