### PR TITLE
[Dynamo] Replace manual `__bool__` / `__len__` call by `generic_bool`

### DIFF
--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -380,6 +380,12 @@
   "GB0035": [
     {
       "Gb_type": "Data-dependent branching with non-constant __bool__",
+      "Context": "value: {value}, result: {result}",
+      "Explanation": "Attempted to perform data-dependent branching on a user-defined object with non-constant truthiness.",
+      "Hints": []
+    },
+    {
+      "Gb_type": "Data-dependent branching with non-constant __bool__",
       "Context": "method: {x}, result: {result}",
       "Explanation": "Attempted to perform data-dependent branching on a user-defined object with a __bool__ method that did not return a constant.",
       "Hints": []

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -159,7 +159,6 @@ from .variables.functions import (
     NestedUserFunctionVariable,
     SkipFunctionVariable,
     UserFunctionVariable,
-    UserMethodVariable,
 )
 from .variables.iter import IteratorVariable, MAX_ITERATOR_LIMIT
 from .variables.lazy import LazyVariableTracker
@@ -180,6 +179,7 @@ from .variables.misc import (
     UnknownVariable,
 )
 from .variables.nn_module import NNModuleVariable, UnspecializedNNModuleVariable
+from .variables.object_protocol import generic_bool
 from .variables.sets import SetVariable
 from .variables.streams import SymbolicStreamState
 from .variables.tensor import supported_comparison_ops, SymNodeVariable, TensorVariable
@@ -897,54 +897,27 @@ def generic_jump(
                     self.push(value)
                 self.jump(inst)
         elif isinstance(value, UserDefinedObjectVariable):
-            try:
-                x = value.var_getattr(self, "__bool__")  # type: ignore[arg-type]
-            except exc.ObservedAttributeError:
-                exc.handle_observed_exception(self)
-                # if __bool__ is missing, trying __len__ to infer a truth value.
-                try:
-                    x = value.var_getattr(self, "__len__")  # type: ignore[arg-type]
-                except exc.ObservedAttributeError:
-                    exc.handle_observed_exception(self)
-                    x = None
-
-            # __bool__ or __len__ is function
-            if isinstance(x, (GetAttrVariable, UserMethodVariable)):
-                result = x.call_function(self, [], {})  # type: ignore[arg-type, assignment]
-                method_name = getattr(getattr(x, "fn", None), "__name__", None)
-                if result.is_python_constant():
-                    result_value = result.as_python_constant()
-                    if method_name == "__bool__" and not isinstance(result_value, bool):
-                        exc.raise_observed_exception(
-                            TypeError,
-                            self,
-                            args=[
-                                f"__bool__ should return bool, returned {type(result_value).__name__}"
-                            ],
-                        )
-                    if isinstance(result_value, (bool, int)) and truth_fn(result_value):
-                        if push:
-                            self.push(value)
-                        self.jump(inst)
-                elif isinstance(result, SymNodeVariable):
-                    if result.evaluate_expr():
-                        if push:
-                            self.push(value)
-                        self.jump(inst)
-                else:
-                    unimplemented(
-                        gb_type="Data-dependent branching with non-constant __bool__",
-                        context=f"method: {x}, result: {result}",
-                        explanation="Attempted to perform data-dependent branching on a user-defined "
-                        "object with a __bool__ method that did not return a constant.",
-                        hints=[],
-                    )
-            # __bool__ or __len__ is non-function or not existed in the user defined object
-            else:
-                if truth_fn(True):
+            result = generic_bool(self, value)  # type: ignore[arg-type]
+            if result.is_python_constant():
+                if truth_fn(result.as_python_constant()):
                     if push:
                         self.push(value)
                     self.jump(inst)
+            elif isinstance(result, SymNodeVariable):
+                if truth_fn(result.evaluate_expr()):
+                    if push:
+                        self.push(value)
+                    self.jump(inst)
+            elif self.should_compile_partial_graph():
+                jump_graph_break(self, inst, value)
+            else:
+                unimplemented(
+                    gb_type="Data-dependent branching with non-constant __bool__",
+                    context=f"value: {value}, result: {result}",
+                    explanation="Attempted to perform data-dependent branching on a user-defined "
+                    "object with non-constant truthiness.",
+                    hints=[],
+                )
         elif not value.is_tensor() and value.has_unpack_var_sequence(self):
             if truth_fn(len(value.unpack_var_sequence(self))):
                 if push:

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -908,8 +908,6 @@ def generic_jump(
                     if push:
                         self.push(value)
                     self.jump(inst)
-            elif self.should_compile_partial_graph():
-                jump_graph_break(self, inst, value)
             else:
                 unimplemented(
                     gb_type="Data-dependent branching with non-constant __bool__",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181884

Refactor the manual truthness call in symbolic_convert.py by generic_bool

Co-authored-by: Copilot <copilot@github.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98