### PR TITLE
[rfc] Canonicalize node names in FxGraphCachePickler for cache key stability

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -3058,6 +3058,222 @@ class TestFxGraphCacheHashing(TestCase):
                 temp.close()
                 os.unlink(temp.name)
 
+    def _make_graph_module(self, ops, rename_map=None):
+        """
+        Build a simple FX graph: placeholders x, y followed by a chain of
+        binary ops where each op takes the previous result and x as inputs.
+
+        ops: list of callables, e.g. [torch.add, torch.mul]
+        rename_map: optional dict mapping original auto-generated node names
+                    to new names, simulating different tracing contexts
+        """
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        y = graph.placeholder("y")
+        prev = y
+        for op in ops:
+            prev = graph.call_function(op, (prev, x))
+        graph.output(prev)
+        gm = torch.fx.GraphModule({}, graph)
+        if rename_map:
+            from copy import copy
+
+            old_used = copy(gm.graph._graph_namespace._used_names)
+            gm.graph._graph_namespace._used_names = set()
+            for node in gm.graph.nodes:
+                if node.name in rename_map:
+                    node._rename(rename_map[node.name])
+            gm.graph._graph_namespace._used_names = (
+                old_used | gm.graph._graph_namespace._used_names
+            )
+            gm.recompile()
+        return gm
+
+    def test_node_name_canonicalization_same_structure(self):
+        """
+        Two structurally identical graphs with different node names
+        should produce the same hash.
+        """
+        gm1 = self._make_graph_module([torch.add, torch.mul])
+        gm2 = self._make_graph_module(
+            [torch.add, torch.mul],
+            rename_map={"add": "add_42", "mul": "mul_42"},
+        )
+        gm3 = self._make_graph_module(
+            [torch.add, torch.mul],
+            rename_map={"add": "layer7_add", "mul": "layer7_mul"},
+        )
+
+        h1 = FxGraphCachePickler(gm1).get_hash(gm1)
+        h2 = FxGraphCachePickler(gm2).get_hash(gm2)
+        h3 = FxGraphCachePickler(gm3).get_hash(gm3)
+
+        self.assertEqual(h1, h2)
+        self.assertEqual(h1, h3)
+
+    def test_node_name_canonicalization_different_structure(self):
+        """
+        Structurally different graphs must still produce different hashes
+        even after canonicalization.
+        """
+        gm_add_mul = self._make_graph_module([torch.add, torch.mul])
+        gm_mul_add = self._make_graph_module([torch.mul, torch.add])
+        gm_add_only = self._make_graph_module([torch.add])
+
+        h1 = FxGraphCachePickler(gm_add_mul).get_hash(gm_add_mul)
+        h2 = FxGraphCachePickler(gm_mul_add).get_hash(gm_mul_add)
+        h3 = FxGraphCachePickler(gm_add_only).get_hash(gm_add_only)
+
+        self.assertNotEqual(h1, h2)
+        self.assertNotEqual(h1, h3)
+        self.assertNotEqual(h2, h3)
+
+    def test_node_name_canonicalization_restores_names(self):
+        """
+        After hashing, the original node names must be preserved on the
+        graph module.
+        """
+        gm = self._make_graph_module(
+            [torch.add, torch.mul, torch.sub],
+            rename_map={
+                "add": "custom_add",
+                "mul": "custom_mul",
+                "sub": "custom_sub",
+            },
+        )
+
+        original_names = [n.name for n in gm.graph.nodes]
+        FxGraphCachePickler(gm).get_hash(gm)
+        restored_names = [n.name for n in gm.graph.nodes]
+
+        self.assertEqual(original_names, restored_names)
+
+    def test_node_name_canonicalization_preserves_code(self):
+        """
+        After hashing, the generated code of the graph module must be
+        identical to what it was before (i.e. the recompile restores it).
+        """
+        gm = self._make_graph_module([torch.add, torch.mul])
+        original_code = gm._code
+        FxGraphCachePickler(gm).get_hash(gm)
+        self.assertEqual(original_code, gm._code)
+
+    def test_node_name_canonicalization_many_ops(self):
+        """
+        Canonicalization works for longer chains of operations with many
+        different op types.
+        """
+        ops = [torch.add, torch.mul, torch.sub, torch.add, torch.mul]
+        gm1 = self._make_graph_module(ops)
+        gm2 = self._make_graph_module(
+            ops,
+            rename_map={
+                "add": "block0_add",
+                "mul": "block0_mul",
+                "sub": "block0_sub",
+                "add_1": "block0_add_1",
+                "mul_1": "block0_mul_1",
+            },
+        )
+
+        h1 = FxGraphCachePickler(gm1).get_hash(gm1)
+        h2 = FxGraphCachePickler(gm2).get_hash(gm2)
+        self.assertEqual(h1, h2)
+
+    def test_node_name_canonicalization_transformer_layers(self):
+        """
+        Simulates the real-world scenario: identical transformer layer
+        graphs traced at different positions produce different node names
+        (add vs add_12) but should share the same cache entry.
+        """
+        ops = [torch.add, torch.mul, torch.add]
+
+        gms = []
+        for layer_idx in range(4):
+            rename = {}
+            for name in ["add", "mul", "add_1"]:
+                base, _, suffix = name.rpartition("_")
+                if base and suffix.isdigit():
+                    new_suffix = int(suffix) + layer_idx * 3
+                    rename[name] = f"{base}_{new_suffix}"
+                else:
+                    rename[name] = f"{name}_{layer_idx * 3}" if layer_idx else name
+            gms.append(self._make_graph_module(ops, rename_map=rename))
+
+        hashes = [FxGraphCachePickler(gm).get_hash(gm) for gm in gms]
+        for h in hashes[1:]:
+            self.assertEqual(hashes[0], h)
+
+    def test_node_name_canonicalization_with_getattr(self):
+        """
+        get_attr nodes should also be canonicalized.
+        """
+        graph1 = torch.fx.Graph()
+        x = graph1.placeholder("x")
+        weight = graph1.get_attr("weight")
+        result = graph1.call_function(torch.add, (x, weight))
+        graph1.output(result)
+
+        w = torch.randn(3)
+
+        gm1 = torch.fx.GraphModule({"weight": w}, graph1)
+
+        graph2 = torch.fx.Graph()
+        x2 = graph2.placeholder("x")
+        weight2 = graph2.get_attr("weight")
+        result2 = graph2.call_function(torch.add, (x2, weight2))
+        graph2.output(result2)
+        gm2 = torch.fx.GraphModule({"weight": w}, graph2)
+
+        from copy import copy
+
+        old_used = copy(gm2.graph._graph_namespace._used_names)
+        gm2.graph._graph_namespace._used_names = set()
+        for node in gm2.graph.nodes:
+            if node.op == "get_attr":
+                node._rename("weight_layer5")
+            elif node.op == "call_function":
+                node._rename("add_layer5")
+        gm2.graph._graph_namespace._used_names = (
+            old_used | gm2.graph._graph_namespace._used_names
+        )
+        gm2.recompile()
+
+        h1 = FxGraphCachePickler(gm1).get_hash(gm1)
+        h2 = FxGraphCachePickler(gm2).get_hash(gm2)
+        self.assertEqual(h1, h2)
+
+    def test_node_name_canonicalization_placeholders_not_renamed(self):
+        """
+        Placeholder names should NOT be canonicalized by the pickler
+        (they are handled separately by normalize_placeholder_names).
+        Changing a placeholder name should change the hash.
+        """
+        gm1 = self._make_graph_module([torch.add])
+        graph2 = torch.fx.Graph()
+        graph2.placeholder("a")
+        graph2.placeholder("b")
+        ab = graph2.call_function(torch.add, tuple(graph2.nodes)[:2])
+        graph2.output(ab)
+        gm2 = torch.fx.GraphModule({}, graph2)
+
+        h1 = FxGraphCachePickler(gm1).get_hash(gm1)
+        h2 = FxGraphCachePickler(gm2).get_hash(gm2)
+        self.assertNotEqual(h1, h2)
+
+    def test_node_name_canonicalization_idempotent(self):
+        """
+        Hashing the same graph module multiple times should always produce
+        the same result.
+        """
+        gm = self._make_graph_module(
+            [torch.add, torch.mul],
+            rename_map={"add": "custom_add", "mul": "custom_mul"},
+        )
+        hashes = [FxGraphCachePickler(gm).get_hash(gm) for _ in range(5)]
+        for h in hashes[1:]:
+            self.assertEqual(hashes[0], h)
+
 
 class TestCudaCompileCommand(TestCase):
     @requires_cuda_and_triton

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -516,6 +516,7 @@ class FxGraphCachePickler(pickle.Pickler):
         self._device_id_agnostic = device_id_agnostic
         super().__init__(self._stream)
 
+        self._has_user_defined_triton_kernels = has_user_defined_triton_kernels
         self.dispatch_table = copyreg.dispatch_table.copy()
         self.dispatch_table.update(
             {
@@ -529,11 +530,8 @@ class FxGraphCachePickler(pickle.Pickler):
                 FakeScriptObject: functools.partial(self._reduce_fake_script_object),
             }
         )
-        if has_user_defined_triton_kernels:
-            # Need to use runtime type as GraphModule generates a singleton in __new__ function
-            self.dispatch_table[gm.__class__] = functools.partial(
-                self._reduce_graph_module
-            )
+        # Need to use runtime type as GraphModule generates a singleton in __new__ function
+        self.dispatch_table[gm.__class__] = functools.partial(self._reduce_graph_module)
 
         # Run with pickler.fast so it doesn't intern strings, making the hash result more predictable
         # TODO: pickler.fast is technically deprecated. Will this work on new python versions?
@@ -610,19 +608,38 @@ class FxGraphCachePickler(pickle.Pickler):
         self, gm: torch.fx.GraphModule
     ) -> tuple[Any, tuple[dict[str, Any], str]]:
         """
-        Custom reducer for graph module to handle irrelevant data for user
-        defined triton kernels
-        Essentially what we are doing here is a huge hack where user defined
-        triton kernel contain a dynamo time side table and the arguments to the
-        call_function are indices into this side table. These arguments are not
-        for hashing purposes since we included the source code into the cache
-        key and the numbers are prone to give false negatives due to ordering.
+        Custom reducer for graph module that canonicalizes node names
+        so structurally identical graphs hash the same regardless of
+        the names assigned during tracing (e.g. add vs add_42). Also
+        strips user-defined triton kernel side-table indices which are
+        prone to false-negative cache misses.
         """
+        old_names: list[tuple[torch.fx.Node, str]] = []
+        old_used_names = copy(gm.graph._graph_namespace._used_names)
+        gm.graph._graph_namespace._used_names = set()
+
+        i = 0
+        for node in gm.graph.nodes:
+            if node.op not in ("placeholder", "output"):
+                old_names.append((node, node.name))
+                node._rename(f"n{i}")
+                i += 1
+
+        gm.recompile()
         fn, (data, imports) = gm.__reduce__()
         code = data["_code"]
-        code = re.sub(r"kernel_idx = \d+", "", code)
-        code = re.sub(r"constant_args_idx = \d+", "", code)
+
+        if self._has_user_defined_triton_kernels:
+            code = re.sub(r"kernel_idx = \d+", "", code)
+            code = re.sub(r"constant_args_idx = \d+", "", code)
         data["_code"] = code
+
+        gm.graph._graph_namespace._used_names = set()
+        for node, name in old_names:
+            node._rename(name)
+        gm.graph._graph_namespace._used_names = old_used_names
+        gm.recompile()
+
         return fn, (data, imports)
 
     def _reduce_fake_script_object(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181894

FX node names (e.g. `add`, `add_1`, `mul_3`) are auto-generated during
tracing and vary depending on trace order. When the same subgraph
structure appears at different positions in a model (e.g. repeated
transformer layers), each instance gets different node names even though
the graphs are structurally identical. Since the generated Python code
from `GraphModule.__reduce__` uses these names as variable names, they
flow directly into the SHA-256 cache key, causing cache misses between
structurally equivalent graphs.

This change teaches `FxGraphCachePickler._reduce_graph_module` to
temporarily rename all non-placeholder, non-output nodes to canonical
positional names (`n0`, `n1`, `n2`, ...) before generating the code
that gets hashed. The original names are restored immediately after,
so the graph module is unchanged after hashing. The reducer is now
always registered (previously it was only registered when user-defined
triton kernels were present).

This applies to both `FxGraphCache` (inductor level) and
`AOTAutogradCache` (since `AOTAutogradCachePickler` extends
`FxGraphCachePickler`), so all PT2 caches benefit from this
canonicalization.

Note: placeholder names are intentionally left untouched here since
they are already handled by `normalize_placeholder_names` in the
AOTAutograd cache path.

Authored with Claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo