### PR TITLE
bugfix: unwinder logic conflates load_bias and start addr

### DIFF
--- a/torch/csrc/profiler/unwind/unwind.cpp
+++ b/torch/csrc/profiler/unwind/unwind.cpp
@@ -45,6 +45,7 @@ Stats stats() {
 #include <algorithm>
 #include <climits>
 #include <cstring>
+#include <limits>
 #include <vector>
 
 #include <c10/util/irange.h>
@@ -90,15 +91,20 @@ struct LibraryInfo {
   LibraryInfo(
       std::string name,
       uint64_t load_bias,
+      uint64_t first_addr,
       uint64_t last_addr,
       void* eh_frame_hdr_ptr_)
       : name_(std::move(name)),
         load_bias_(load_bias),
+        first_addr_(first_addr),
         last_addr_(last_addr),
         eh_frame_hdr_(eh_frame_hdr_ptr_) {}
 
   uint64_t load_bias() const {
     return load_bias_;
+  }
+  uint64_t first_addr() const {
+    return first_addr_;
   }
   uint64_t last_addr() const {
     return last_addr_;
@@ -116,7 +122,8 @@ struct LibraryInfo {
 
  private:
   std::string name_;
-  uint64_t load_bias_; // addr >= load_bias_
+  uint64_t load_bias_;
+  uint64_t first_addr_; // addr >= first_addr_
   uint64_t last_addr_; // addr < last_addr_
   EHFrameHdr eh_frame_hdr_;
 };
@@ -161,25 +168,27 @@ struct UnwindCache {
            size_t size [[maybe_unused]],
            void* data) {
           auto self = (UnwindCache*)data;
+          uint64_t load_bias = info->dlpi_addr;
+          uint64_t first_addr = std::numeric_limits<uint64_t>::max();
           uint64_t last_addr = 0;
           auto segments = (Elf64_Phdr*)info->dlpi_phdr;
           for (auto i : c10::irange(info->dlpi_phnum)) {
             if (segments[i].p_type == PT_LOAD) {
-              auto begin = ((uint64_t)info->dlpi_addr + segments[i].p_vaddr);
-              auto end = (begin + segments[i].p_memsz);
+              auto begin = load_bias + segments[i].p_vaddr;
+              auto end = begin + segments[i].p_memsz;
+              first_addr = std::min(begin, first_addr);
               last_addr = std::max(end, last_addr);
-            }
-            if (segments[i].p_type == PT_GNU_EH_FRAME) {
+            } else if (segments[i].p_type == PT_GNU_EH_FRAME) {
               std::string library_name = info->dlpi_name;
               if (library_name.empty()) {
                 library_name = process_name();
               }
-              auto eh_frame_hdr =
-                  // NOLINTNEXTLINE(performance-no-int-to-ptr)
-                  (void*)(segments[i].p_vaddr + info->dlpi_addr);
+              // NOLINTNEXTLINE(performance-no-int-to-ptr)
+              auto eh_frame_hdr = (void*)(load_bias + segments[i].p_vaddr);
               self->all_libraries_.emplace_back(
                   std::move(library_name),
-                  info->dlpi_addr,
+                  load_bias,
+                  first_addr,
                   last_addr,
                   eh_frame_hdr);
               return 0;
@@ -193,7 +202,7 @@ struct UnwindCache {
         all_libraries_.begin(),
         all_libraries_.end(),
         [](const LibraryInfo& lhs, const LibraryInfo& rhs) {
-          return lhs.load_bias() < rhs.load_bias();
+          return lhs.first_addr() < rhs.first_addr();
         });
   }
   void checkRefresh(std::shared_lock<std::shared_timed_mutex>& rdlock) {
@@ -271,20 +280,20 @@ struct UnwindCache {
     uint64_t high = all_libraries_.size();
     while (low + 1 < high) {
       auto mid = (low + high) / 2;
-      if (addr < all_libraries_.at(mid).load_bias()) {
+      if (addr < all_libraries_.at(mid).first_addr()) {
         high = mid;
       } else {
         low = mid;
       }
     }
     LibraryInfo* r = &all_libraries_.at(low);
-    if (addr < r->load_bias() || addr >= r->last_addr()) {
+    if (addr < r->first_addr() || addr >= r->last_addr()) {
       return nullptr;
     }
     return r;
   }
 
-  // sorted by load_bias
+  // sorted by first_addr
   std::vector<LibraryInfo> all_libraries_;
   ska::flat_hash_map<uint64_t, Unwinder> ip_cache_;
 


### PR DESCRIPTION
The unwinder was using [load_bias, last_addr) as the
address range for libraries. This is only true when
p_vaddr is zero which is not always the case.

This commit removes that assumption by computing the
first address by combining load_bias and p_vaddr.

This failure was discovered in NVIDIA internal ARM CI
where the incorrect address range was messing up the
later binary search for addresses leading to missing
stack traces. This was caught by the following test:

```
______________ TestCudaAllocator.test_cpp_memory_snapshot_pickle _______________
Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3514, in wrapper
    method(*args, **kwargs)
  File "/opt/pytorch/pytorch/test/test_cuda.py", line 5382, in test_cpp_memory_snapshot_pickle
    self.assertTrue("::rand" in frame_text)
  File "/usr/lib/python3.12/unittest/case.py", line 727, in assertTrue
    raise self.failureException(msg)
AssertionError: False is not true
To execute this test, run the following from the base repo dir:
    python test/test_cuda.py TestCudaAllocator.test_cpp_memory_snapshot_pickle
```

Testing:
- Test passes in NVIDIA's internal build
- Test passes in NVIDIA's internal build with customizations disabled
- Test passes in the PyTorch CI