### PR TITLE
[Inductor] Skip illegal launch grid values as 'inf' during autotune (#181899)

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -306,6 +306,70 @@ class TestTritonHeuristics(TestCase):
             )
             self.assertEqual(len(configs), expected_count)
 
+    @skipIfRocm  # upstream Triton's HIP MLIR pipeline issue, see: https://github.com/pytorch/pytorch/pull/182254
+    def test_grid_overflow_skips_config(self):
+        """
+        When runtime xnumel produces a grid that exceeds CUDA maxGridSize,
+        the autotuner should skip that config instead of crashing with
+        OverflowError.
+        """
+
+        @triton.jit
+        def triton_(in_ptr0, out_ptr0, xnumel, n_elements, XBLOCK: tl.constexpr):
+            xoffset = tl.program_id(0).to(tl.int64) * XBLOCK
+            xindex = xoffset + tl.arange(0, XBLOCK)[:].to(tl.int64)
+            xmask = xindex < n_elements
+            tmp0 = tl.load(in_ptr0 + xindex, xmask)
+            tl.store(out_ptr0 + xindex, tmp0, xmask)
+
+        triton_meta = {
+            "signature": {
+                "in_ptr0": "*fp32",
+                "out_ptr0": "*fp32",
+                "xnumel": "i64",
+                "n_elements": "i64",
+            },
+            "device": DeviceProperties.create(torch.device(GPU_TYPE)),
+            "constants": {},
+            "configs": [AttrsDescriptorWrapper(divisible_by_16=(0, 1), equal_to_1=())],
+        }
+
+        configs = [
+            # XBLOCK=1: ceildiv(3*10^9, 1) > 2^31-1 -> grid overflow
+            triton_config({"x": 8192}, 1),
+            # XBLOCK=2048: ceildiv(3*10^9, 2048) < 2^31-1 -> valid
+            triton_config({"x": 8192}, 2048),
+        ]
+
+        inductor_meta = {"grid_type": "Grid1D"}
+
+        autotuner = CachingAutotuner(
+            fn=triton_,
+            triton_meta=triton_meta,
+            configs=configs,
+            save_cache_hook=False,
+            mutated_arg_names=[],
+            reset_to_zero_arg_names=[],
+            optimize_mem=True,
+            heuristic_type=HeuristicType.POINTWISE,
+            inductor_meta=inductor_meta,
+        )
+
+        # xnumel large enough that XBLOCK=1 overflows grid but XBLOCK=2048 does not
+        xnumel = 3_000_000_000
+        n_elements = 16
+        inp = torch.randn(n_elements, device=GPU_TYPE)
+        out = torch.empty(n_elements, device=GPU_TYPE)
+
+        # Should not crash -- autotuner skips the overflowing config
+        autotuner.run(inp, out, xnumel, n_elements, stream=0)
+
+        # The overflowing config should have been skipped, leaving one valid config
+        self.assertEqual(len(autotuner.launchers), 1)
+        self.assertEqual(autotuner.launchers[0].config.kwargs["XBLOCK"], 2048)
+        # Kernel should have copied inp to out for the in-bounds elements
+        self.assertEqual(out, inp)
+
 
 _PLUGIN_FACTORY_PATH = (
     "torch._inductor.runtime.triton_heuristics.get_caching_autotuner_plugins"

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -22,6 +22,7 @@ use_experimental_benchmarker = (
 
 
 MILLISECONDS_PER_SECOND = 1000
+INVALID_CONFIG_ERR_SUBSTR = "Invalid Configuration"
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -386,7 +387,7 @@ class TritonBenchmarker(Benchmarker):
             # ErrorInvalidConfiguration
             # Return inf to skip this config during autotuning
             error_str = str(e).lower()
-            if "invalid configuration" in error_str:
+            if INVALID_CONFIG_ERR_SUBSTR.lower() in error_str:
                 logger.warning(
                     "Skipping benchmark due to invalid configuration error: %s",
                     error_str,

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -10,6 +10,10 @@ import torch
 from torch.utils._triton import has_triton_package
 
 
+# Ideally we want to read this from some device config
+MAX_GRID_SIZE = (2147483647, 65535, 65535)
+
+
 # The following maximums only apply to runtime autotuning, when using FixedTritonConfig one may see larger values
 # NOTE: if these fail asserts submit a PR to increase them
 TRITON_MAX_BLOCK = {

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -39,13 +39,14 @@ from ..utils import (
 )
 from . import triton_helpers
 from .autotune_cache import AutotuneCache
-from .benchmarking import benchmarker
+from .benchmarking import benchmarker, INVALID_CONFIG_ERR_SUBSTR
 from .coordinate_descent_tuner import CoordescTuner
 from .hints import (
     _NUM_THREADS_PER_WARP,
     AutotuneHint,
     DeviceProperties,
     HeuristicType,
+    MAX_GRID_SIZE,
     ReductionHint,
     TileHint,
     TRITON_MAX_BLOCK,
@@ -107,6 +108,10 @@ class InductorConfig(Config):
 
 class NoTritonConfigsError(RuntimeError):
     pass
+
+
+class GridOverflowError(RuntimeError):
+    """Raised when a Triton grid dimension exceeds CUDA limits."""
 
 
 if TYPE_CHECKING:
@@ -2193,9 +2198,11 @@ class CompileResult(Generic[_T]):
             f"    grid_0 = {grid.x_grid}",
             f"    grid_1 = {grid.y_grid}",
             f"    grid_2 = {grid.z_grid}",
+            "    _check_grid_values(grid_0, grid_1, grid_2)",
             f"    runner({', '.join(runner_args)})",
         ]
         launcher_code = "\n".join(lines)
+        scope["_check_grid_values"] = _check_grid_values
         exec(launcher_code, scope)
         return scope["launcher"]
 
@@ -2972,9 +2979,21 @@ def _num_warps(num_warps, max_num_warps=8, min_num_warps=2, register_intensive=F
     return next_power_of_2(min(max(num_warps, min_num_warps), max_num_warps))
 
 
+def _check_grid_values(grid_0: int, grid_1: int, grid_2: int) -> None:
+    """Runtime check that grid dimensions don't exceed GPU limits."""
+    # These limits apply to both CUDA and ROCm/HIP
+    for i, (val, limit) in enumerate(zip((grid_0, grid_1, grid_2), MAX_GRID_SIZE)):
+        if val > limit:
+            raise GridOverflowError(
+                f"{INVALID_CONFIG_ERR_SUBSTR}: Grid dimension {i} = {val} exceeds maxGridSize limit {limit}. "
+                f"This can happen with dynamic shapes when runtime tensor sizes are "
+                f"much larger than compile-time size hints."
+            )
+
+
 def _check_max_grid_x(size_hints, x, num_warps):
     # Check if maxGridSize is exceeded - if so then must scale XBLOCK further
-    max_grid_x = 2147483647
+    max_grid_x = MAX_GRID_SIZE[0]
     max_block_x = TRITON_MAX_BLOCK["X"]
     warp_size = (
         64 if torch.version.hip else 32
@@ -3031,10 +3050,6 @@ def triton_config(
     min_elem_per_thread controls the minimum number of elements
     processed by each thread. It's always enforced.
     """
-    # Ideally we want to read this from some device config
-
-    maxGridSize = [2147483647, 65535, 65535]
-
     target = conditional_product(x, y, z)
     if conditional_product(*size_hints.values()) < target:
         target //= 8
@@ -3049,14 +3064,14 @@ def triton_config(
     # if we are below original block size, scale up where we can;
     # or if the calculated grid size is larger than the limit, we bump up the corresponding dimension
     while x < min(size_hints["x"], TRITON_MAX_BLOCK["X"]) and (
-        x * maxGridSize[0] < size_hints["x"] or conditional_product(x, y, z) < target
+        x * MAX_GRID_SIZE[0] < size_hints["x"] or conditional_product(x, y, z) < target
     ):
         x *= 2
     while (
         y
         and y < min(size_hints["y"], TRITON_MAX_BLOCK["Y"])
         and (
-            y * maxGridSize[1] < size_hints["y"]
+            y * MAX_GRID_SIZE[1] < size_hints["y"]
             or conditional_product(x, y, z) < target
         )
     ):
@@ -3065,7 +3080,7 @@ def triton_config(
         z
         and z < min(size_hints["z"], TRITON_MAX_BLOCK["Z"])
         and (
-            z * maxGridSize[2] < size_hints["z"]
+            z * MAX_GRID_SIZE[2] < size_hints["z"]
             or conditional_product(x, y, z) < target
         )
     ):


### PR DESCRIPTION
Summary:

### Issue
When generating auto-tuning configs, we do max grid size check only using size_hitns.

However, when running the auto-tuning code, we generate kernel inputs that could be much larger than size hints.

We need autotune code runtime guard against the max grid size over flow as well.

For the internal use case, we have the below kernel failing when XBLOCK=2 (xnume=7,516,192,768)

```
triton_heuristics.reduction(
    size_hints={'x': 8192, 'r0_': 128},
    reduction_hint=ReductionHint.DEFAULT,
    filename=__file__,
    triton_meta={...},
    inductor_meta={...}
)
triton.jit
def triton_red_fused_<failing_kernel_name>_123(
...

buf1036 = generate_example_value((64, 4096, 4096, 7), (117440512, 28672, 7, 1), 'cuda:0', torch.bool, 0, (64, 4096, 4096, 7))
with torch.cuda._DeviceGuard(0):
    triton_red_fused_<failing_kernel_name>_123.run(buf1034, buf1035, buf1036, 7, 4096, 4096, 7516192768, 100, stream=stream0)
```



### Fix
- generate a runtime check for grid sizes, throw customized error when overflowing
- relying on existing invalid config capture + skip logic to not crash the autotune process, hence lifting up the substr into `INVALID_CONFIG_ERR_SUBSTR` to make it more maintainable
- also centrialize the usage of max grid sizes into a common constant

Test Plan:
Failure repro: https://www.internalfb.com/intern/testinfra/testrun/25614222898236081

```
OverflowError: signed integer is greater than maximum
```

- passed new unit test
- internal use case resolved
- OSS CI

Reviewed By: lurunming

Differential Revision: D103032505




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo