### PR TITLE
[Inductor][NVGEMM] Link tracking issue in supplement configs comment

### DIFF
--- a/torch/_inductor/template_heuristics/nv_universal_gemm.py
+++ b/torch/_inductor/template_heuristics/nv_universal_gemm.py
@@ -175,6 +175,10 @@ class NVUniversalGemmHeuristics(GemmMaxAutotuneTemplateConfigHeuristics):
         result = [k for k, _ in selected]
 
         # Supplement with hand-picked configs in the space nvMatmulHeuristics doesn't currently explore.
+        # NOTE: once nvMatmulHeuristics' search space is extended to cover
+        # these tile/cluster shapes, this block (and the
+        # `nvgemm_supplement_configs` flag) can be removed.
+        # Tracking: https://github.com/pytorch/pytorch/issues/181908
         if config.nvgemm_supplement_configs:
             _SUPPLEMENT_CONFIGS: OrderedSet[ConfigKey] = OrderedSet(
                 [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181910
* #181909
* #181903
* #181902
* #181622
* #174893



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo