### PR TITLE
[Xcode 26.4 SDK] Fix -Wnullable-to-nonnull-conversion in MetalContext.mm and MetalDevice.h (PyTorch Metal)

### DIFF
--- a/aten/src/ATen/native/metal/MetalContext.mm
+++ b/aten/src/ATen/native/metal/MetalContext.mm
@@ -64,8 +64,8 @@ C10_CLANG_DIAGNOSTIC_POP()
 #endif
   NSError* error = [self _compileProgram];
   if (error) {
-    std::string compilationError = error.localizedDescription.UTF8String;
-    std::string deviceInfo = self.description.UTF8String;
+    std::string compilationError = error.localizedDescription.UTF8String ?: "<unknown error>";
+    std::string deviceInfo = self.description.UTF8String ?: "<unknown device>";
     TORCH_CHECK(false, compilationError + "\n" + deviceInfo);
   }
   return _device && _library && _commandQueue;
@@ -82,7 +82,7 @@ C10_CLANG_DIAGNOSTIC_POP()
   TORCH_CHECK(func, "Failed to load the Metal Shader function: ", kernel);
   NSError* errors = nil;
   state = [_device newComputePipelineStateWithFunction:func error:&errors];
-  TORCH_CHECK(state, errors.localizedDescription.UTF8String);
+  TORCH_CHECK(state, errors.localizedDescription.UTF8String ?: "<unknown error>");
   _pipelineCache[kernel] = state;
   return state;
 }
@@ -93,7 +93,9 @@ C10_CLANG_DIAGNOSTIC_POP()
   TORCH_CHECK(_library, "Failed to load Metal shaders");
   std::string kernelStr = kernel;
   for (NSUInteger i = 0; i < constants.count; ++i) {
-    kernelStr += "_" + std::string([constants[i] stringValue].UTF8String);
+    const char* constantStr = [constants[i] stringValue].UTF8String;
+    NSCAssert(constantStr, @"UTF8String returned nil for constant value");
+    kernelStr += "_" + std::string(constantStr);
   }
   std::lock_guard<std::mutex> g(_pipelineCacheMutex);
   id<MTLComputePipelineState> state = _pipelineCache[kernelStr];
@@ -129,9 +131,9 @@ C10_CLANG_DIAGNOSTIC_POP()
   id<MTLFunction> func = [_library newFunctionWithName:[NSString stringWithUTF8String:kernel.c_str()] ?: @""
                                         constantValues:constantValues
                                                  error:&errors];
-  TORCH_CHECK(func, errors.localizedDescription.UTF8String);
+  TORCH_CHECK(func, errors.localizedDescription.UTF8String ?: "<unknown error>");
   state = [_device newComputePipelineStateWithFunction:func error:&errors];
-  TORCH_CHECK(state, errors.localizedDescription.UTF8String);
+  TORCH_CHECK(state, errors.localizedDescription.UTF8String ?: "<unknown error>");
   _pipelineCache[kernelStr] = state;
   return state;
 }

--- a/aten/src/ATen/native/metal/MetalDevice.h
+++ b/aten/src/ATen/native/metal/MetalDevice.h
@@ -15,7 +15,10 @@ struct MetalDeviceInfo {
 static inline MetalDeviceInfo createDeviceInfo(id<MTLDevice> device) {
   MetalDeviceInfo device_info;
   if (device.name != nil) {
-    device_info.name = device.name.UTF8String;
+    const char* utf8_name = device.name.UTF8String;
+    if (utf8_name != nullptr) {
+      device_info.name = utf8_name;
+    }
   }
   if (@available(macOS 11.0, iOS 14.0, *)) {
     device_info.languageVersion = MTLLanguageVersion2_3;


### PR DESCRIPTION
Summary:
Xcode 26.4.1 SDK libc++ headers add nullability annotations on `std::string` ctors and `std::unordered_map::operator[]`, and `[NSString UTF8String]` is documented as `_Nullable`. This makes the previously silent conversion a hard error.

Fixes in `xplat/caffe2/aten/src/ATen/native/metal/`:

- `MetalDevice.h:18` (`createDeviceInfo`): capture `device.name.UTF8String` into a local `const char* utf8_name` and null-check before assigning to `device_info.name`. Skipping the assignment leaves `device_info.name` as the default-constructed empty string, matching prior behavior when `UTF8String` returned a valid empty buffer.
- `MetalContext.mm` — two patterns depending on the consequence of nil:
  - **Diagnostic sites** (lines 67-68, 85, 134, 136): `expr.UTF8String ?: "<unknown error>"` (and `"<unknown device>"` for `self.description`). These feed `TORCH_CHECK` failure messages — a readable placeholder is friendlier than an empty string that looks like a check with no message, and the program is already aborting at that point so the data has no downstream consumers.
  - **Cache key site** (line 96): inlined `NSCAssert` + null check, since silently coercing nil to empty here would risk **cache key collisions** in `_pipelineCache` — two distinct constants both producing nil would hash to the same `kernelStr` and resolve to the wrong `MTLComputePipelineState`. `NSCAssert` aborts in debug; in release `std::string(nullptr)` is still UB, matching prior behavior.

Test Plan: build

Differential Revision: D102979199


