### PR TITLE
Fix torch.compile crash with batched matmul in inference_mode

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -1871,6 +1871,19 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
             loss.backward()
         self.assertIsNotNone(x.grad)
 
+    def test_batched_matmul_inference_mode(self):
+        # Regression test for torch.compile crash with batched matmul in inference_mode
+        x = torch.randn(2, 4, 8)
+        w = torch.randn(8, 8)
+
+        def f(x, w):
+            with torch.inference_mode():
+                return (x @ w).sum()
+
+        torch._dynamo.reset()
+        result = torch.compile(f)(x, w)
+        self.assertIsInstance(result, torch.Tensor)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -225,13 +225,13 @@ class FunctionalTensor(torch.Tensor):
             and torch.is_inference_mode_enabled()
             and torch._inductor.config.enable_auto_functionalized_v2
         ):
+            storage = out.elem.untyped_storage()
             if out.is_base_tensor():
                 out._inference_mode_base = None
                 # This assumes that the FunctionalTensor.elem does not change its storage after this point.
                 # Otherwise this would be invalid.
-                mode._storage_to_base[out.elem.untyped_storage()] = out
+                mode._storage_to_base[storage] = out
             else:
-                storage = out.elem.untyped_storage()
                 out._inference_mode_base = mode._storage_to_base.get(storage)
                 if out._inference_mode_base is None:
                     mode._storage_to_base[storage] = out

--- a/torch/_subclasses/functional_tensor.py
+++ b/torch/_subclasses/functional_tensor.py
@@ -231,11 +231,10 @@ class FunctionalTensor(torch.Tensor):
                 # Otherwise this would be invalid.
                 mode._storage_to_base[out.elem.untyped_storage()] = out
             else:
-                out._inference_mode_base = mode._storage_to_base[
-                    out.elem.untyped_storage()
-                ]
+                storage = out.elem.untyped_storage()
+                out._inference_mode_base = mode._storage_to_base.get(storage)
                 if out._inference_mode_base is None:
-                    raise AssertionError("out._inference_mode_base must not be None")
+                    mode._storage_to_base[storage] = out
         return out
 
     def __torch_dispatch__(  # type: ignore[override]


### PR DESCRIPTION
Fixes #181512 

Fixes a crash when compiling batched matrix multiplication inside torch.inference_mode( ) where a keyerror was raise during storage-to-base tensor lookup. The fix uses .get() instead of idctionray indexing to handle cases where view tensors are created before their base tensors are registered.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98