### PR TITLE
Support returning None from torch.cond() true_fn and false_fn

### DIFF
--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -5670,6 +5670,70 @@ def forward(self, L_pred_ : torch.Tensor, L_x_ : torch.Tensor):
         not TEST_CUDA_GRAPH_CONDITIONAL_NODES,
         "CUDA 12.4 or greater is required for CUDA Graphs with conditional nodes",
     )
+    def test_cond_traced_no_outputs_cudagraphs(self):
+        state = torch.zeros(4, device="cuda")
+
+        def true_fn():
+            state.add_(1.0)
+
+        def false_fn():
+            state.add_(-1.0)
+
+        predicate = torch.tensor(True, device="cuda")
+
+        with torch.no_grad():
+            # Warmup runs both branches and then executes the cond, so
+            # state is incremented once (by the true branch).
+            with ControlFlowOpWarmupDispatchMode():
+                torch.cond(predicate, true_fn, false_fn, [])
+            torch.cuda.synchronize()
+            self.assertEqual(state, torch.ones(4, device="cuda"))
+
+            # Capture records the conditional node but does not execute
+            # GPU code, so state is unchanged.
+            g = torch.cuda.CUDAGraph()
+            with (
+                torch.cuda.graph(g),
+                CUDAGraphCaptureControlFlowOpDispatchMode(),
+            ):
+                torch.cond(predicate, true_fn, false_fn, [])
+            self.assertEqual(state, torch.ones(4, device="cuda"))
+
+            g.replay()
+            torch.cuda.synchronize()
+            # Replay with pred=True runs the true branch: state += 1.
+            self.assertEqual(state, 2 * torch.ones(4, device="cuda"))
+
+            predicate.fill_(False)
+            g.replay()
+            torch.cuda.synchronize()
+            # Replay with pred=False runs the false branch: state -= 1.
+            self.assertEqual(state, torch.ones(4, device="cuda"))
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH_CONDITIONAL_NODES,
+        "CUDA 12.4 or greater is required for CUDA Graphs with conditional nodes",
+    )
+    def test_cond_traced_unequal_constant_outputs_cudagraphs(self):
+        def true_fn():
+            return 1
+
+        def false_fn():
+            return 2
+
+        predicate = torch.tensor(True, device="cuda")
+        g = torch.cuda.CUDAGraph()
+        with self.assertRaisesRegex(
+            ValueError,
+            "returned constants of both branches must be equal",
+        ):
+            with torch.cuda.graph(g), CUDAGraphCaptureControlFlowOpDispatchMode():
+                torch.cond(predicate, true_fn, false_fn, [])
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH_CONDITIONAL_NODES,
+        "CUDA 12.4 or greater is required for CUDA Graphs with conditional nodes",
+    )
     def test_cond_traced_record_stream_reuse(self):
         torch.cuda.memory._set_allocator_settings(
             "graph_capture_record_stream_reuse:True"

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -7296,6 +7296,7 @@ def forward(self, arg0_1):
         res_compiled = torch.compile(f)(*example_inputs)
         self.assertEqual(res, res_compiled)
 
+    @skipIfTorchDynamo("don't test compile on compile")
     @skipIfCrossRef  # Arg order changes with crossref
     def test_cond_no_outputs_aot_autograd_graph(self):
         backend = AotEagerAndRecordGraphs()

--- a/test/functorch/test_control_flow.py
+++ b/test/functorch/test_control_flow.py
@@ -7296,6 +7296,47 @@ def forward(self, arg0_1):
         res_compiled = torch.compile(f)(*example_inputs)
         self.assertEqual(res, res_compiled)
 
+    @skipIfCrossRef  # Arg order changes with crossref
+    def test_cond_no_outputs_aot_autograd_graph(self):
+        backend = AotEagerAndRecordGraphs()
+
+        def f(pred, x):
+            def true_fn(x):
+                x.sin()
+
+            def false_fn(x):
+                x.cos()
+
+            torch.cond(pred, true_fn, false_fn, (x,))
+            return x + 1
+
+        x = torch.ones(3, 4)
+        compiled_f = torch.compile(f, backend=backend, fullgraph=True, dynamic=False)
+
+        self.assertEqual(compiled_f(torch.tensor(True), x), f(torch.tensor(True), x))
+        self.assertEqual(compiled_f(torch.tensor(False), x), f(torch.tensor(False), x))
+        self.assertEqual(len(backend.fw_graphs), 1)
+
+        self.assertExpectedInline(
+            normalize_gm(backend.fw_graphs[0].print_readable(print_output=False)),
+            """\
+class <lambda>(torch.nn.Module):
+    def forward(self, arg0_1: "b8[]", arg1_1: "f32[3, 4]"):
+        add: "f32[3, 4]" = torch.ops.aten.add.Tensor(arg1_1, 1);  arg1_1 = None
+        return (add,)
+
+    class true_graph_0(torch.nn.Module):
+        def forward(self, arg0_1: "f32[3, 4]"):
+            sin: "f32[3, 4]" = torch.ops.aten.sin.default(arg0_1);  arg0_1 = sin = None
+            return (None,)
+
+    class false_graph_0(torch.nn.Module):
+        def forward(self, arg0_1: "f32[3, 4]"):
+            cos: "f32[3, 4]" = torch.ops.aten.cos.default(arg0_1);  arg0_1 = cos = None
+            return (None,)
+""",
+        )
+
     @skipIfTorchDynamo("Skip because we're testing export")
     def test_cond_autograd_backward_inp_out_aliasing(self):
         from torch._dynamo.testing import AotEagerAndRecordGraphs

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -5154,6 +5154,14 @@
     {
       "Gb_type": "torch.cond: unsupported branch return type (constant non-int)",
       "Context": "str(ret_val)",
+      "Explanation": "Constants returned from branches must be ints or None.",
+      "Hints": [
+        "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "
+      ]
+    },
+    {
+      "Gb_type": "torch.cond: unsupported branch return type (constant non-int)",
+      "Context": "str(ret_val)",
       "Explanation": "Constants returned from branches must be ints.",
       "Hints": [
         "Your code may result in an error when running in eager. Please double check that your code doesn't contain a similar error when actually running eager/uncompiled. You can do this by removing the `torch.compile` call, or by using `torch.compiler.set_stance(\"force_eager\")`. "

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2515,12 +2515,12 @@ class CondHigherOrderVariable(TorchHigherOrderOperatorVariable):
                 )
             for ret in unpack_iterable(tx, ret_val):
                 if ret.is_python_constant() and not isinstance(
-                    ret.as_python_constant(), int
+                    ret.as_python_constant(), (int, type(None))
                 ):
                     unimplemented(
                         gb_type="torch.cond: unsupported branch return type (constant non-int)",
                         context=str(ret_val),
-                        explanation="Constants returned from branches must be ints.",
+                        explanation="Constants returned from branches must be ints or None.",
                         hints=[
                             *graph_break_hints.USER_ERROR,
                         ],

--- a/torch/_higher_order_ops/cudagraph_conditional_nodes.py
+++ b/torch/_higher_order_ops/cudagraph_conditional_nodes.py
@@ -126,5 +126,15 @@ def if_else_node(pred: torch.Tensor, true_fn, false_fn, operands):
                 for if_out, else_out in zip(
                     pytree.tree_iter(outs[0]), pytree.tree_iter(outs[1])
                 ):
+                    if (
+                        not (
+                            isinstance(if_out, torch.Tensor)
+                            and isinstance(else_out, torch.Tensor)
+                        )
+                        and if_out != else_out
+                    ):
+                        raise ValueError(
+                            f"For cudagraph captured torch.cond(), the returned constants of both branches must be equal. Got true_fn tried to return {if_out} and while false_fn tried to return {else_out}"
+                        )
                     if_out.copy_(else_out)
     return outs[0]

--- a/torch/_higher_order_ops/cudagraph_conditional_nodes.py
+++ b/torch/_higher_order_ops/cudagraph_conditional_nodes.py
@@ -126,15 +126,13 @@ def if_else_node(pred: torch.Tensor, true_fn, false_fn, operands):
                 for if_out, else_out in zip(
                     pytree.tree_iter(outs[0]), pytree.tree_iter(outs[1])
                 ):
-                    if (
-                        not (
-                            isinstance(if_out, torch.Tensor)
-                            and isinstance(else_out, torch.Tensor)
-                        )
-                        and if_out != else_out
+                    if isinstance(if_out, torch.Tensor) and isinstance(
+                        else_out, torch.Tensor
                     ):
+                        if_out.copy_(else_out)
+                    elif if_out != else_out:
                         raise ValueError(
                             f"For cudagraph captured torch.cond(), the returned constants of both branches must be equal. Got true_fn tried to return {if_out} and while false_fn tried to return {else_out}"
                         )
-                    if_out.copy_(else_out)
+                    # otherwise, if_out and else_out are the same, so we can return either. We arbitrarily choose the if_out one.
     return outs[0]


### PR DESCRIPTION
This allows us to run conditional code that only mutates inputs or captured variables, but does not return anything.

While making this change, I realized as well that it should be disallowed for true_fn and false_fn to return different non-tensor outputs in the same output slot when using torch.cond() during cuda graph capture. This is banned because a different non-tensor output could cause the cuda graph to be different depending upon which path was taken. I now raise an explicit error alerting the user. Previously, you would simply get a runtime crash if you tried to return a non-tensor output at all, even if it was the same for both true_fn and false_fn.

I use either claude-code or codex to help make these edits. Forgot which though.

Fixes #181891

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @ydwu4