### PR TITLE
Improve autograd.grad unused-input error message to report input index

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -13675,6 +13675,19 @@ class TestAutogradDeviceType(TestCase):
         with self.assertRaisesRegex(RuntimeError, msg):
             torch.autograd.grad(b, a)
 
+    def test_grad_unused_input_error_message(self, device):
+        for unused_idx in [0, 1]:
+            x = torch.randn(10, requires_grad=True, device=device)
+            y = torch.randn(10, requires_grad=True, device=device)
+            inputs = (x, y)
+
+            # If unused_idx is 0, use inputs[1]. If unused_idx is 1, use inputs[0].
+            out = inputs[1 - unused_idx].sum()
+
+            expected_msg = f"The differentiated Tensor at index {unused_idx} appears"
+            with self.assertRaisesRegex(RuntimeError, expected_msg):
+                torch.autograd.grad(out, inputs)
+
     def test_pow_real_negative_base_complex_exponent(self, device):
         # OpInfo doesn't naturally support input of mixed types, hence this test here.
         base = -torch.ones(2, device=device, dtype=torch.double)

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -371,8 +371,7 @@ static PyObject* THPEngine_run_backward(
     for (const auto i : c10::irange(num_inputs)) {
       TORCH_CHECK(
           allow_unreachable || outputs[i].defined(),
-          "One of the "
-          "differentiated Tensors appears to not have been used "
+          "The differentiated Tensor at index ", i, " appears to not have been used "
           "in the graph. Set allow_unused=True if this is the "
           "desired behavior.");
       PyTuple_SET_ITEM(py_outputs.get(), i, THPVariable_Wrap(outputs[i]));

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -371,7 +371,9 @@ static PyObject* THPEngine_run_backward(
     for (const auto i : c10::irange(num_inputs)) {
       TORCH_CHECK(
           allow_unreachable || outputs[i].defined(),
-          "The differentiated Tensor at index ", i, " appears to not have been used "
+          "The differentiated Tensor at index ",
+          i,
+          " appears to not have been used "
           "in the graph. Set allow_unused=True if this is the "
           "desired behavior.");
       PyTuple_SET_ITEM(py_outputs.get(), i, THPVariable_Wrap(outputs[i]));


### PR DESCRIPTION
**Related Issue**
Fixes #73697

**Summary**
This PR improves the error message raised by torch.autograd.grad when an input tensor is not part of the computation graph and allow_unused=False.

Previously, the error was:

`One of the differentiated Tensors appears to not have been used in the graph.`

For [users passing multiple inputs](https://discuss.pytorch.org/t/runtimeerror-one-of-the-differentiated-tensors-appears-to-not-have-been-used-in-the-graph-set-allow-unused-true-if-this-is-the-desired-behavior/43679), that message is hard to debug because it does not identify which input is unused. This change updates the error to report the index of the offending tensor in the inputs tuple, which matches the direction discussed on the issue.  

**Changes**
* Updated torch/csrc/autograd/python_engine.cpp to include the input index in the unused-input error path.
* Added test_grad_unused_input_error_message in test/test_autograd.py to verify the message for both index 0 and index 1 cases.

**Testing**
`python test/test_autograd.py TestAutogradDeviceTypeCPU.test_grad_unused_input_error_message_cpu`

Verified locally on Apple Silicon CPU.

**Notes**
* I also confirmed that unrelated local failures in test/test_autograd.py were present before this change.
* This PR keeps the scope narrow and only improves the autograd.grad(..., inputs=...) unused-input error message, rather than attempting to report Python variable names or module names.