### PR TITLE
[dynamic shape]Add auto naming for IntSpec No name

### DIFF
--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -97,6 +97,15 @@ class TestIntSpecConstruction(TestCase):
         s = IntSpec.static()
         self.assertEqual(s._type, IntSpecType.STATIC)
         self.assertIsNone(s._value)
+        # ``name=None`` auto-fills with a stable per-instance handle.
+        self.assertTrue(s._name.startswith("_intspec_static_"))
+
+    def test_anonymous_specs_have_distinct_names(self):
+        # Two anonymous specs of the same mode get different auto-names so
+        # they can be distinguished in error messages / logs.
+        a = IntSpec.static()
+        b = IntSpec.static()
+        self.assertNotEqual(a._name, b._name)
 
     def test_backed(self):
         s = IntSpec.backed("batch", min=1, max=64, guarding_hint=32)
@@ -180,8 +189,11 @@ class TestIntSpecConstruction(TestCase):
         )
 
     def test_repr(self):
-        # Anonymous, no fields set.
-        self.assertEqual(repr(IntSpec.static()), "IntSpec(type=STATIC)")
+        # Anonymous: name is auto-generated; check shape via prefix since
+        # the trailing id-hex is process-dependent.
+        anon = repr(IntSpec.static())
+        self.assertTrue(anon.startswith("IntSpec(name='_intspec_static_"))
+        self.assertIn("type=STATIC", anon)
         # Named + value.
         self.assertEqual(
             repr(IntSpec.static("x", value=10)),

--- a/torch/_dynamo/dynamic_spec.py
+++ b/torch/_dynamo/dynamic_spec.py
@@ -99,12 +99,7 @@ class IntSpec:
         if not isinstance(type, IntSpecType):
             raise TypeError(f"IntSpec type must be an IntSpecType, got {type!r}")
         self._type = type
-        # Auto-generate a name when the user doesn't supply one. Two
-        # otherwise-anonymous specs constructed at different points need
-        # to be distinguishable in error messages, structured logs, and
-        # ``ObjectSpec`` lookups. ``id(self)`` is process-stable for the
-        # spec's lifetime and unique per live instance — good enough for
-        # a debugging handle.
+        # Auto-generate a name when the user doesn't supply one.
         if name is None:
             name = f"_intspec_{type.value}_{id(self):x}"
         self._name = name

--- a/torch/_dynamo/dynamic_spec.py
+++ b/torch/_dynamo/dynamic_spec.py
@@ -99,6 +99,14 @@ class IntSpec:
         if not isinstance(type, IntSpecType):
             raise TypeError(f"IntSpec type must be an IntSpecType, got {type!r}")
         self._type = type
+        # Auto-generate a name when the user doesn't supply one. Two
+        # otherwise-anonymous specs constructed at different points need
+        # to be distinguishable in error messages, structured logs, and
+        # ``ObjectSpec`` lookups. ``id(self)`` is process-stable for the
+        # spec's lifetime and unique per live instance — good enough for
+        # a debugging handle.
+        if name is None:
+            name = f"_intspec_{type.value}_{id(self):x}"
         self._name = name
         self._min = min
         self._max = max


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #181922


## Summary

Reviewer-suggested follow-up to PR 1 (IntSpec) — when `IntSpec` is constructed without a `name`, auto-fill it with a stable per-instance handle so anonymous specs are distinguishable in error messages, logs, and `ObjectSpec`-keyed lookups.

```python
# Before this PR
spec = IntSpec.static()
spec._name  # None — indistinguishable from any other anonymous spec

# After
spec = IntSpec.static()
spec._name  # "_intspec_static_7f8a9b0c1d2e"  (process-stable, unique per live instance)
```

The format is `f"_intspec_{type.value}_{id(self):x}"` — type-prefixed (`static`/`backed`/`unbacked`) so the mode is obvious from the name, with the object's `id` in hex as the unique suffix.

User-supplied names are unchanged: `IntSpec.static("x")` still gets `_name = "x"`.

## Motivation

Two otherwise-identical `IntSpec` instances created at different points (e.g., `IntSpec.backed()` called twice in a sweep over tensor dims) need a way to be told apart. Without auto-naming:

- Error messages that include `repr(spec)` look identical for both: `IntSpec(type=BACKED)`.
- Structured logs can't disambiguate them.
- `ObjectSpec` / `dict` lookups keyed by name require the user to invent unique names.

`id(self)` is process-stable for the spec's lifetime and unique per live instance — good enough as a debugging handle. Not stable across processes (so don't serialize it as a cache key), but the `IntSpec` itself isn't directly part of any cache key — its values are.

## What changed

- `torch/_dynamo/dynamic_spec.py` — `IntSpec.__init__` adds the `if name is None: name = f"_intspec_{type.value}_{id(self):x}"` branch before storing `self._name`.

## Test plan — `python test/dynamo/test_dynamic_spec.py TestIntSpecConstruction`

- **`test_static_no_value`** — extended to assert `s._name.startswith("_intspec_static_")` after construction.
- **`test_anonymous_specs_have_distinct_names`** — new: two `IntSpec.static()` instances get different `_name` values.
- **`test_repr`** — anonymous case switched from exact-match (`"IntSpec(type=STATIC)"`) to prefix check (`startswith("IntSpec(name='_intspec_static_")`) plus `assertIn("type=STATIC")`, since the trailing id-hex varies per process.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98