### PR TITLE
[cherry-pick][dynamo][guards] Disable recursive dict tag optimization

### DIFF
--- a/torch/_dynamo/config.py
+++ b/torch/_dynamo/config.py
@@ -485,7 +485,7 @@ assume_dunder_attributes_remain_unchanged = True
 
 # Speedup guard execution of nested nn modules by recursively checking for dict
 # tags to avoid full guard execution.
-use_recursive_dict_tags_for_guards = True
+use_recursive_dict_tags_for_guards = False
 
 # Maximum number of objects for which we check dict pointers tags. This is
 # useful for regional compilation.


### PR DESCRIPTION
 Go to https://github.com/pytorch/pytorch/pull/181873 for the description.

Related to the 3 issues - #180741, #178231 and fb.workplace.com/groups/1075192433118967/permalink/1939251640046371


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98