### PR TITLE
Enable XPU for sparse_sampled_addmm

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7236,12 +7236,14 @@
   dispatch:
     SparseCsrCUDA: sparse_sampled_addmm_out_sparse_csr_cuda
     SparseCsrCPU: sparse_sampled_addmm_out_sparse_csr_cpu
+    SparseCsrXPU: sparse_sampled_addmm_out_sparse_csr_xpu
 
 - func: sparse_sampled_addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
   python_module: sparse
   dispatch:
     SparseCsrCUDA: sparse_sampled_addmm_sparse_csr_cuda
     SparseCsrCPU: sparse_sampled_addmm_sparse_csr_cpu
+    SparseCsrXPU: sparse_sampled_addmm_sparse_csr_xpu
 
 - func: _sparse_mm_reduce_impl(Tensor self, Tensor other, str reduce) -> (Tensor, Tensor)
   python_module: sparse

--- a/torch/sparse/_triton_ops.py
+++ b/torch/sparse/_triton_ops.py
@@ -31,7 +31,7 @@ def check_bsr_layout(f_name, t):
 
 def check_device(f_name, t, device):
     check(
-        t.device == device and t.device.type == "cuda",
+        t.device == device and t.device.type in ("cuda", "xpu"),
         f"{f_name}(): all inputs are expected to be on the same GPU device.",
     )
 


### PR DESCRIPTION
Wire SparseCsrXPU into sparse_sampled_addmm and sparse_sampled_addmm.out in native_functions.yaml so CSR sampled addmm can execute on XPU.

Fix for: [#3175](https://github.com/intel/torch-xpu-ops/issues/3175)
Requires [PR#3534](https://github.com/intel/torch-xpu-ops/pull/3534)