### PR TITLE
[DeviceMesh] Use hashed PG names for fake backend when torchcomms is enabled

### DIFF
--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -1622,6 +1622,36 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
         expected_tensor = torch.ones(3, 3) * 28
         self.assertEqual(tensor, expected_tensor)
 
+    @unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
+    @dist_config.patch(use_torchcomms=True)
+    @_with_torchcomm_env
+    @with_comms(backend="cpu:gloo,cuda:ncclx")
+    def test_fake_backend_pg_names_w_torchcomms(self) -> None:
+        """Fake-backend PG names must be hash-based when torchcomms is enabled.
+
+        When torchcomms is enabled, split_group produces hash-based PG names
+        for real backends. Fake-backend dimensions (from backend_override)
+        must also use hash-based names; sequential integer names are not
+        resolvable from compiled code via the C++ GroupRegistry.
+        """
+        world_mesh = init_device_mesh(
+            self.device_type, (self.world_size,), mesh_dim_names=("world",)
+        )
+        # One fake dim and one real dim, mimicking torchtitan's
+        # unflatten_mesh for disabled parallelism dimensions.
+        mesh = world_mesh._unflatten(
+            0,
+            (1, self.world_size),
+            ("fake_dim", "real_dim"),
+            backend_override={"fake_dim": "fake"},
+        )
+        fake_pg_name = mesh._dim_group_names[0]
+        self.assertFalse(
+            fake_pg_name.isdigit(),
+            f"Fake-backend PG name '{fake_pg_name}' is a sequential integer; "
+            f"expected a hash-based name for torchcomms compatibility.",
+        )
+
 
 class CuTeLayoutTest(TestCase):
     def test_coalesce(self):

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -576,6 +576,10 @@ else:
             # and append the `group_name` to the `dim_group_names` list when the current rank is in the subgroup.
             # Otherwise, we use `new_group` instead of `split_group` to create subgroups by looping over `pg_ranks_by_dim`
             # along with appending information to the `dim_group_names` list whenever necessary.
+            # When torchcomms is enabled with a fake backend (e.g. disabled mesh dimensions), use hashed PG names so they
+            # stay consistent with the hash-based names produced by split_group for real backends. Sequential integer names
+            # from new_group are not resolvable from compiled code when mixed with split_group hash names.
+            use_hashed = dist_config.use_torchcomms and backend == "fake"
             pg_name = None
             for dim_mesh in pg_ranks_by_dim:
                 subgroup_ranks = dim_mesh.tolist()

--- a/torch/distributed/device_mesh.py
+++ b/torch/distributed/device_mesh.py
@@ -589,6 +589,7 @@ else:
                     backend=backend,
                     pg_options=pg_options,
                     group_desc=group_desc,
+                    use_local_synchronization=use_hashed,
                 )
 
                 # only add to dim_groups if the current rank in the subgroup


### PR DESCRIPTION
 When torchcomms is enabled, split_group produces hash-based PG names for real backends, but _init_one_process_group falls back to new_group for backend="fake" dimensions (disabled parallelism dimensions), producing sequential integer names like '19'. These sequential names are not resolvable from the C++ GroupRegistry when referenced by compiled code, causing:                                                              
  RuntimeError: Could not resolve the process group registered under the name 19
                                                                                
This fix passes use_local_synchronization=True to new_group for fake-backend dimensions when torchcomms is enabled, so they use hash-based names consistent with split_group.                                                                                                            
                                                                                                                                                
Reported from torchtitan: https://github.com/pytorch/torchtitan/actions/runs/25083897445/job/73494994394


### Test plan                                                                                                                                     
                                                                     
  - New unit test: test_fake_backend_pg_names_w_torchcomms                                                                                      
  - torchtitan torchcomms_3d_dp+tp+pp+compile fails without this fix
  - torchtitan torchcomms_3d_dp+tp+pp+compile passes with this fix 