### PR TITLE
[inductor] Skip non-tensor IR nodes in _CollectiveKernel.create_inplace

### DIFF
--- a/test/distributed/tensor/test_compile_on_one_rank.py
+++ b/test/distributed/tensor/test_compile_on_one_rank.py
@@ -155,6 +155,21 @@ class TestCompileOnOneRank(DTensorTestBase):
 
     @with_comms
     @dist_config.patch(compile_on_one_rank=True)
+    def test_all_reduce_with_explicit_pg_input(self):
+        pg = dist.distributed_c10d._get_default_group()
+
+        def f(t, group):
+            t = t.clone()
+            dist.all_reduce(t, group=group)
+            return t + 1
+
+        x = torch.arange(4, dtype=torch.float32, device=self.device_type)
+        opt = torch.compile(f, backend="inductor", fullgraph=True)
+        out = opt(x, pg)
+        self.assertEqual(out, f(x, pg))
+
+    @with_comms
+    @dist_config.patch(compile_on_one_rank=True)
     def test_compiled_dtensor_rng_op_graph_consistency(self):
         """Compiled random ops on sharded DTensors should produce identical graphs."""
         mesh = self.build_device_mesh()

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -10429,6 +10429,9 @@ class NonTensorObj(IRNode):
     ) -> OrderedSet[sympy.Symbol]:
         return OrderedSet()
 
+    def realize(self) -> str | None:
+        return None
+
 
 @ir_dataclass
 class TorchBindObject(NonTensorObj):
@@ -10565,11 +10568,18 @@ class _CollectiveKernel(FallbackKernel):
                 unbacked_bindings,
             ) = cls.process_kernel(kernel, inputs, *args, **kwargs)
         assert not unbacked_bindings, f"{kernel} {unbacked_bindings}"
+        device = None
         for tensor_arg in tensor_args:
+            if isinstance(tensor_arg, NonTensorObj):
+                continue
             tensor_arg.realize()
             V.graph.mark_buffer_mutated(tensor_arg.get_name())
-
-        device = tensor_args[0].get_device()
+            if device is None:
+                device = tensor_arg.get_device()
+        assert device is not None, (
+            f"In-place collective {kernel} requires at least one tensor "
+            f"argument; got only non-tensor IR nodes."
+        )
         packed = cls(
             NoneLayout(device=device),
             kernel,


### PR DESCRIPTION
Fixes #181893

- Give `NonTensorObj` a no-op `realize()` returning None, matching `Buffer.realize()` and the `IRNode.realize()` docstring's note that most IRNodes can be no-ops.
- In `_CollectiveKernel.create_inplace`, skip `NonTensorObj` entries when realizing and marking buffers mutated, and pick the device from the first tensor arg (a PG isn't a buffer that can be mutated). `_CollectiveKernel.create_out_of_place` already had a similar guard filtering out `TorchBindObject`; this brings `create_inplace` in line.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo