### PR TITLE
Fix "fist" -> "first" typo in comments

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/nvshmem_team_manager.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nvshmem_team_manager.hpp
@@ -49,7 +49,7 @@ class TeamManager {
       const std::vector<int>& global_ranks) {
     auto [team_pool, pool_updated] =
         group_to_team_pool(group_name, global_ranks, 1);
-    // Return the fist available team
+    // Return the first available team
     return team_pool[0];
   }
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1311,11 +1311,11 @@ class BuildExtension(build_ext):
                     parts = flag.split("=", 1)
                     if len(parts) == 2:
                         flag_part, value_part = parts
-                        # replace fist instance of "CUDA" with "HIP" only in the flag and not flag value
+                        # replace first instance of "CUDA" with "HIP" only in the flag and not flag value
                         modified_flag_part = flag_part.replace("CUDA", "HIP", 1)
                         modified_flag = f"{modified_flag_part}={value_part}"
                     else:
-                        # replace fist instance of "CUDA" with "HIP" in flag
+                        # replace first instance of "CUDA" with "HIP" in flag
                         modified_flag = flag.replace("CUDA", "HIP", 1)
                     modified_flags.append(modified_flag)
                     logger.info('Modified flag: %s -> %s', flag, modified_flag)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181931

Fix a repeated typo in comments where "fist" was used instead of
"first" in the NVSHMEM team manager header and the cpp_extension
utility.

Authored with Claude (typo_terminator2).