### PR TITLE
Fix typo in constant_folding.py comment

### DIFF
--- a/torch/_export/passes/constant_folding.py
+++ b/torch/_export/passes/constant_folding.py
@@ -219,7 +219,7 @@ def constant_fold(
 
         erased_params = []
         # Get all attr users by looking up the graph instead from node.users, because in this case
-        # _tensor_constant0 and _tensor_constant0_1 are actually refereing to the same tensor.
+        # _tensor_constant0 and _tensor_constant0_1 are actually referring to the same tensor.
 
         #     opcode         name                 target            args                         kwargs
         # -------------  -------------------  ----------------  ---------------------------  --------


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181932

Fix "refereing" → "referring" in a comment explaining tensor constant
aliasing behavior.

Authored with Claude (typo_terminator2).