### PR TITLE
Fix typo in aot_autograd graph capture comment

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
+++ b/torch/_functorch/_aot_autograd/graph_capture_wrappers.py
@@ -742,7 +742,7 @@ def apply_in_graph_mutations(
     # There are 3 cases:
     # (1) We mutate inp *after* the set_() call. other is a graph intermediate.
     #     In this case, we're not really mutating the input storage of "inp";
-    #     we're mutating the storage of an intermdiate value (other),
+    #     we're mutating the storage of an intermediate value (other),
     #     and slamming that storage into the input tensor. So no data mutation is necessary.
     # (2) We mutate inp *after* the set_() call. other is a graph *input*.
     #     In this case, the data mutation will be properly handled in the runtime


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181933

Fix "intermdiate" → "intermediate" in a comment explaining storage
mutation handling for set_() calls.

Authored with Claude (typo_terminator2).