### PR TITLE
Fix duplicate-word typos and a misspelling in comments and docs

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2158,7 +2158,7 @@ def cat(inputs, dim=0):
         return count
 
     # as of inputs increase, possibility for register spilling also increases
-    # past a certain threshold of inputs we only fuse if the if the input kernels
+    # past a certain threshold of inputs we only fuse if the input kernels
     # are simple
     # not sure if we want to expose to users via config since logic may change in future
     MAX_COMPLEX_POINTWISE_CAT = 8

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -6944,7 +6944,7 @@ add_docstr_all(
 Returns a new tensor containing real values of the :attr:`self` tensor for a complex-valued input tensor.
 The returned tensor and :attr:`self` share the same underlying storage.
 
-Returns :attr:`self` if :attr:`self` is a real-valued tensor tensor.
+Returns :attr:`self` if :attr:`self` is a real-valued tensor.
 
 Example::
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -10579,7 +10579,7 @@ Keyword args:
         coalesced tensor.  If the :attr:`check_invariants` flag is
         False, no error will be raised if the prerequisites are not
         met and this will lead to silently incorrect results. To force
-        coalescion please use :meth:`coalesce` on the resulting
+        coalescing please use :meth:`coalesce` on the resulting
         Tensor.
         Default: None: except for trivial cases (e.g. nnz < 2) the
         resulting Tensor has is_coalesced set to ``False```.

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -80,7 +80,7 @@ c10::AliasAnalysisKind aliasAnalysisInternalSpecialCase() {
 
 // for debugging it is helpful to be able to force autodiff subgraphs
 // to be created, to check their correctness, even when the
-// size of the of the subgraph is too small to be profitable.
+// size of the subgraph is too small to be profitable.
 static thread_local bool autodiff_subgraph_inlining = true;
 void debugSetAutodiffSubgraphInlining(bool state) {
   autodiff_subgraph_inlining = state;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181934

Remove repeated words ("if the if the", "tensor tensor", "of the of the")
in comments and docstrings across inductor, JIT, and tensor documentation.
Also fix "coalescion" → "coalescing" in sparse tensor docs.

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo