### PR TITLE
[SymmMem] Add NCCL implementation of all_to_all_vdev

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -788,6 +788,7 @@ libtorch_cuda_distributed_extra_sources = [
     "torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu",
     "torch/csrc/distributed/c10d/symm_mem/nccl_extension.cu",
     "torch/csrc/distributed/c10d/symm_mem/ops/nccl_reduce_scatter_offset.cu",
+    "torch/csrc/distributed/c10d/symm_mem/ops/nccl_alltoall_vdev.cu",
     "torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp",
     "torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cu",
     "torch/csrc/distributed/c10d/symm_mem/cuda_mem_pool.cpp",

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -601,6 +601,7 @@ if(USE_CUDA)
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/nccl_extension.cu
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/ops/nccl_reduce_scatter_offset.cu
+        ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/ops/nccl_alltoall_vdev.cu
         ${TORCH_SRC_DIR}/csrc/distributed/c10d/symm_mem/cuda_mem_pool.cpp
         PROPERTIES COMPILE_FLAGS "-DPYTORCH_C10_DRIVER_API_SUPPORTED=1"
       )

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -581,6 +581,158 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
 
     @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version(
+        (2, 28), "nccl_all_to_all_vdev requires the NCCL device API (>=2.28)"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_all_to_all_vdev(self):
+        """all_to_all_vdev: device-side split sizes drive a one-sided pull
+        AllToAllV over NCCL symmetric memory. Mirrors the NVSHMEM test of the
+        same name in test/distributed/test_nvshmem.py."""
+        symm_mem.set_backend("NCCL")
+        torch.cuda.set_device(self.rank)
+        # Initialise the NCCL communicator before any rendezvous.
+        c10d.all_reduce(torch.ones(1, device=self.device))
+        group_name = c10d.group.WORLD.group_name
+
+        dtype = torch.float
+        # Random per-peer send count in [0, k). Different on every rank.
+        torch.manual_seed(42 + self.rank)
+        k = 10
+        inp_splits = torch.randint(k, (self.world_size,), device=self.device)
+        inp_numel = inp_splits.sum().item()
+
+        # Out-of-band exchange of split sizes (used to size out + as oracle).
+        out_splits = torch.zeros_like(inp_splits)
+        c10d.all_to_all_single(out_splits, inp_splits)
+        out_numel = out_splits.sum().item()
+
+        # Symmetric tensors must have the same shape on every rank, so size
+        # them by the worst case.
+        max_inp_numel = k * self.world_size
+        # Worst case: a single rank receives every other rank's data.
+        max_out_numel = max_inp_numel * self.world_size
+
+        inp = symm_mem.empty(max_inp_numel, dtype=dtype, device=self.device).copy_(
+            torch.randn(max_inp_numel, dtype=dtype, device=self.device)
+        )
+        out = symm_mem.empty(max_out_numel, dtype=dtype, device=self.device).fill_(-1)
+        in_splits = symm_mem.empty(
+            self.world_size, dtype=torch.int64, device=self.device
+        )
+        out_splits_offsets = symm_mem.empty(
+            (2, self.world_size), dtype=torch.int64, device=self.device
+        )
+        in_splits.copy_(inp_splits)
+
+        # Rendezvous everything before launching the kernel; needed because
+        # NCCLSymmetricMemory is lazily initialised on first rendezvous.
+        symm_mem.rendezvous(inp, group=group_name)
+        symm_mem.rendezvous(out, group=group_name)
+        symm_mem.rendezvous(in_splits, group=group_name)
+        symm_mem.rendezvous(out_splits_offsets, group=group_name)
+        c10d.barrier()
+
+        symm_mem.all_to_all_vdev(
+            inp, out, in_splits, out_splits_offsets, group_name
+        )
+
+        # in_splits must be unchanged.
+        torch.testing.assert_close(in_splits, inp_splits)
+
+        # Row 0 of out_splits_offsets is the output splits (= what every peer
+        # sent us), which the oracle all_to_all_single also computed.
+        torch.testing.assert_close(out_splits_offsets[0], out_splits)
+
+        # Row 1 is the per-peer write offset in `out` (exclusive scan of row 0).
+        out_offsets = torch.cumsum(out_splits, dim=0)  # inclusive
+        self.assertEqual(out_splits_offsets[1][0].item(), 0)
+        torch.testing.assert_close(out_splits_offsets[1][1:], out_offsets[:-1])
+
+        # Data oracle: classic NCCL all_to_all_single over the prefix of `inp`
+        # actually used.
+        expected = torch.empty(out_numel, dtype=dtype, device=self.device)
+        c10d.all_to_all_single(
+            expected, inp[:inp_numel], out_splits.tolist(), inp_splits.tolist()
+        )
+        torch.testing.assert_close(out[:out_numel], expected)
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
+    @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
+    @requires_nccl_version(
+        (2, 28), "nccl_all_to_all_vdev requires the NCCL device API (>=2.28)"
+    )
+    @skip_if_lt_x_gpu(2)
+    def test_all_to_all_vdev_with_zero_splits(self):
+        """Corner case: some peers receive 0 elements. Exercises the
+        `peer_split == 0` early-out in nccl_a2av_data_kernel and confirms that
+        a 0-byte chunk does not break the divisibility assertion."""
+        symm_mem.set_backend("NCCL")
+        torch.cuda.set_device(self.rank)
+        c10d.all_reduce(torch.ones(1, device=self.device))
+        group_name = c10d.group.WORLD.group_name
+
+        dtype = torch.float
+        # Rank r sends `r` elements to peer 0 and 0 to everyone else.
+        # So peer 0 receives `0+1+2+...+(W-1)`, every other peer receives 0.
+        inp_splits = torch.zeros(
+            self.world_size, dtype=torch.int64, device=self.device
+        )
+        inp_splits[0] = self.rank
+
+        out_splits = torch.zeros_like(inp_splits)
+        c10d.all_to_all_single(out_splits, inp_splits)
+        out_numel = out_splits.sum().item()
+        inp_numel = inp_splits.sum().item()
+
+        max_inp_numel = self.world_size  # rank ≤ W-1 ≤ W
+        max_out_numel = self.world_size * self.world_size
+
+        inp = symm_mem.empty(max_inp_numel, dtype=dtype, device=self.device).copy_(
+            torch.arange(max_inp_numel, dtype=dtype, device=self.device)
+            + 100 * self.rank
+        )
+        out = symm_mem.empty(max_out_numel, dtype=dtype, device=self.device).fill_(-1)
+        in_splits = symm_mem.empty(
+            self.world_size, dtype=torch.int64, device=self.device
+        )
+        out_splits_offsets = symm_mem.empty(
+            (2, self.world_size), dtype=torch.int64, device=self.device
+        )
+        in_splits.copy_(inp_splits)
+
+        symm_mem.rendezvous(inp, group=group_name)
+        symm_mem.rendezvous(out, group=group_name)
+        symm_mem.rendezvous(in_splits, group=group_name)
+        symm_mem.rendezvous(out_splits_offsets, group=group_name)
+        c10d.barrier()
+
+        symm_mem.all_to_all_vdev(
+            inp, out, in_splits, out_splits_offsets, group_name
+        )
+
+        torch.testing.assert_close(out_splits_offsets[0], out_splits)
+
+        # Build the same oracle via classic alltoall.
+        expected = torch.empty(out_numel, dtype=dtype, device=self.device)
+        c10d.all_to_all_single(
+            expected,
+            inp[:inp_numel],
+            out_splits.tolist(),
+            inp_splits.tolist(),
+        )
+        if out_numel > 0:
+            torch.testing.assert_close(out[:out_numel], expected)
+        # Ranks other than 0 receive nothing; their output prefix should be
+        # untouched (still -1).
+        if self.rank != 0:
+            self.assertEqual(out_numel, 0)
+            torch.testing.assert_close(
+                out[:1], torch.full((1,), -1.0, dtype=dtype, device=self.device)
+            )
+
+    @skip_but_pass_in_sandcastle_if(TEST_WITH_ROCM, "Skip NCCL tests for ROCm")
+    @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @requires_nccl_version((2, 29), "NCCL one-sided host API support from nccl 2.29")
     @skip_if_lt_x_gpu(2)
     def test_put_wait_signal(self):

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -633,9 +633,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         symm_mem.rendezvous(out_splits_offsets, group=group_name)
         c10d.barrier()
 
-        symm_mem.all_to_all_vdev(
-            inp, out, in_splits, out_splits_offsets, group_name
-        )
+        symm_mem.all_to_all_vdev(inp, out, in_splits, out_splits_offsets, group_name)
 
         # in_splits must be unchanged.
         torch.testing.assert_close(in_splits, inp_splits)
@@ -675,9 +673,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         dtype = torch.float
         # Rank r sends `r` elements to peer 0 and 0 to everyone else.
         # So peer 0 receives `0+1+2+...+(W-1)`, every other peer receives 0.
-        inp_splits = torch.zeros(
-            self.world_size, dtype=torch.int64, device=self.device
-        )
+        inp_splits = torch.zeros(self.world_size, dtype=torch.int64, device=self.device)
         inp_splits[0] = self.rank
 
         out_splits = torch.zeros_like(inp_splits)
@@ -707,9 +703,7 @@ class NCCLSymmetricMemoryTest(MultiProcContinuousTest):
         symm_mem.rendezvous(out_splits_offsets, group=group_name)
         c10d.barrier()
 
-        symm_mem.all_to_all_vdev(
-            inp, out, in_splits, out_splits_offsets, group_name
-        )
+        symm_mem.all_to_all_vdev(inp, out, in_splits, out_splits_offsets, group_name)
 
         torch.testing.assert_close(out_splits_offsets[0], out_splits)
 

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -422,6 +422,22 @@ c10::Device NCCLSymmetricMemory::get_device() {
   return c10::Device(c10::DeviceType::CUDA, device_idx_);
 }
 
+bool NCCLSymmetricMemory::world_within_direct_access() {
+#ifdef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+  if (static_cast<int>(pai_->buffers_.size()) != world_size_) {
+    return false;
+  }
+  for (void* p : pai_->buffers_) {
+    if (p == nullptr) {
+      return false;
+    }
+  }
+  return true;
+#else
+  return false;
+#endif
+}
+
 ncclWindow_t NCCLSymmetricMemory::get_window() {
   return pai_->buffer_win_;
 }

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp
@@ -43,6 +43,8 @@ class NCCLSymmetricMemory : public SymmetricMemory {
 
   c10::Device get_device() override;
 
+  bool world_within_direct_access() override;
+
   ncclWindow_t get_window();
 
   ncclWindow_t get_signal_pad_handle();

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -562,6 +562,8 @@ TORCH_LIBRARY_FRAGMENT(symm_mem, m) {
   m.def(
       "nccl_reduce_scatter_offset(Tensor input, Tensor(a!)[] out, str group_name, int dim, int[]? offsets=None, int[]? dst_ranks=None, str red_op='sum') -> ()");
   m.def(
+      "nccl_all_to_all_vdev(Tensor(a!) input, Tensor(b!) out, Tensor(c!) in_splits, Tensor(d!) out_splits_offsets, str group_name) -> ()");
+  m.def(
       "nvshmem_all_to_all(Tensor input, Tensor(a!) out, str group_name) -> Tensor(a!)");
   m.def(
       "all_to_all_vdev(Tensor input, Tensor(a!) out, Tensor in_splits, Tensor(a!) out_splits_offsets, str group_name) -> ()");

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_extension.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_extension.cu
@@ -409,6 +409,7 @@ TORCH_LIBRARY_IMPL(symm_mem, CUDA, m) {
   m.impl("nccl_put_signal",
       torch::CppFunction::makeFromBoxedFunction<&nccl_put_signal_boxed>());
   m.impl("nccl_reduce_scatter_offset", c10d::nccl_extension::nccl_reduce_scatter_offset);
+  m.impl("nccl_all_to_all_vdev", c10d::nccl_extension::nccl_all_to_all_vdev);
 }
 
 // Use CompositeExplicitAutograd as key since ops do not accept tensor as input

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_extension.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_extension.hpp
@@ -30,4 +30,15 @@ TORCH_API void nccl_reduce_scatter_offset(
     std::optional<at::IntArrayRef> offsets,
     std::optional<at::IntArrayRef> dst_ranks,
     const std::string& red_op);
+
+// AllToAllV with split sizes that live on device. Drop-in for the
+// NVSHMEM `all_to_all_vdev` -- see ops/nccl_alltoall_vdev.cu for the
+// kernel description and the user-visible contract on `out_splits_offsets`.
+// All four tensors must come from the NCCL symmetric memory backend.
+TORCH_API void nccl_all_to_all_vdev(
+    at::Tensor& input,
+    at::Tensor& out,
+    at::Tensor& in_splits,
+    at::Tensor& out_splits_offsets,
+    const std::string& group_name);
 } // namespace c10d::nccl_extension

--- a/torch/csrc/distributed/c10d/symm_mem/ops/nccl_alltoall_vdev.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/ops/nccl_alltoall_vdev.cu
@@ -1,0 +1,403 @@
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/Dispatch.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/cub.cuh>
+#include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/macros.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_extension.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp>
+
+// AllToAllV with split sizes that live on device (drop-in for the existing
+// nvshmem_extension.cu `all_to_all_vdev`). All four tensors must be allocated
+// from the NCCL symmetric memory backend (e.g. via empty_strided_p2p).
+//
+// API matches the NVSHMEM version verbatim:
+//   - `input`              : send buffer (contiguous along dim 0)
+//   - `out`                : recv buffer (contiguous along dim 0)
+//   - `in_splits`          : 1-D int64 tensor of size (npes,)
+//                            `in_splits[p]` = number of rows to send to peer p
+//   - `out_splits_offsets` : 2-D int64 tensor of shape (2, npes); on return
+//                            row 0 holds output splits, row 1 holds output
+//                            offsets (the position of each peer's chunk inside
+//                            `out`).  During execution row 1 transiently holds
+//                            *source* offsets (where to read from on the peer)
+//                            -- the kernel rewrites it to write offsets at the
+//                            end so the user observes the documented contract.
+//
+// Algorithm (mirrors the NVSHMEM implementation):
+//   Phase 1 (1 CTA, `nccl_a2av_exchange_kernel`):
+//     - Each rank computes the exclusive prefix sum of its own `in_splits` to
+//       get per-peer source offsets in its send buffer.
+//     - Each rank writes to peer p's `out_splits_offsets`:
+//         peer.out[      mype] = in_splits[p]                (output split)
+//         peer.out[npes+ mype] = source_offset_for(p)        (source offset)
+//       via one-sided LSA pointer writes (NVLink load/store).
+//     - LSA barrier so all peers' metadata is visible.
+//
+//   Phase 2 (N CTAs, `nccl_a2av_data_kernel`):
+//     - Each rank reads the now-populated `output_splits` and `source_offsets`,
+//       computes the exclusive prefix sum of `output_splits` to get write
+//       offsets in its own recv buffer.
+//     - CTAs are partitioned across peers; each block-cooperatively pulls a
+//       slice of `peer.input[source_offset .. source_offset + split)` into
+//       `out[write_offset .. write_offset + split)` using `ncclGetLsaPointer`
+//       (direct NVLink loads, no in-flight queue / quiet needed -- on
+//       completion of the kernel the loads have all retired locally).
+//     - CTA 0 overwrites row 1 of `out_splits_offsets` with write offsets so
+//       the user-visible contract (row 1 = output offsets) is honoured.
+//
+//   No exit barrier is added (matches NVSHMEM's behaviour); the user is
+//   responsible for synchronising before reusing send buffers, exactly as with
+//   the NVSHMEM path. The next collective's entry barrier (or a manual
+//   `barrier()` on the symm_mem handle) closes the read-after-write hazard
+//   between successive ops.
+
+namespace c10d::nccl_extension {
+
+using namespace c10d::symmetric_memory;
+
+#ifdef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+
+namespace {
+
+// THREADS_PER_BLOCK also caps the maximum world size we can serve -- one
+// thread per peer is used for the metadata exchange and prefix-sum stages.
+// For NVLink-domain symmetric memory (NVL8 / NVL72) this is plenty.
+constexpr int A2A_THREADS_PER_BLOCK = 128;
+constexpr int A2A_MAX_PEERS = A2A_THREADS_PER_BLOCK;
+// CTA caps for the data kernel; mirrors the NVSHMEM heuristic.
+constexpr int A2A_MAX_BLOCKS_INTRA = 64;
+constexpr int A2A_MAX_BLOCKS_INTER = 16;
+
+// Block-cooperative byte copy. Vectorises to 16-B loads when src/dst are both
+// 16-B aligned (always true for empty_strided_p2p allocations, but we still
+// fall back gracefully on the tail).
+__device__ __forceinline__ void block_copy_bytes(
+    char* __restrict__ dst,
+    const char* __restrict__ src,
+    size_t n_bytes) {
+  constexpr size_t kVec = 16;
+  size_t bulk = 0;
+  if ((reinterpret_cast<uintptr_t>(src) % kVec == 0) &&
+      (reinterpret_cast<uintptr_t>(dst) % kVec == 0)) {
+    bulk = (n_bytes / kVec) * kVec;
+    const int4* src4 = reinterpret_cast<const int4*>(src);
+    int4* dst4 = reinterpret_cast<int4*>(dst);
+    const size_t n_vec = bulk / kVec;
+    for (size_t i = threadIdx.x; i < n_vec; i += blockDim.x) {
+      dst4[i] = src4[i];
+    }
+  }
+  for (size_t i = bulk + threadIdx.x; i < n_bytes; i += blockDim.x) {
+    dst[i] = src[i];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: exchange output splits and source offsets.
+// Launched as a single CTA so we can use a CUB block-scan and a single LSA
+// barrier slot. All ranks launch one CTA so the per-CTA LSA barrier slot 0
+// pairs up cleanly across ranks.
+// ---------------------------------------------------------------------------
+__global__ void nccl_a2av_exchange_kernel(
+    ncclWindow_t in_splits_win,
+    size_t in_splits_off,
+    ncclWindow_t scratch_win,
+    size_t scratch_off,
+    ncclDevComm devcomm) {
+  using BlockScanT = at_cuda_detail::cub::
+      BlockScan<int64_t, A2A_THREADS_PER_BLOCK, at_cuda_detail::cub::BLOCK_SCAN_WARP_SCANS>;
+  __shared__ typename BlockScanT::TempStorage temp_storage;
+  __shared__ int64_t s_my_offsets[A2A_MAX_PEERS];
+
+  const ncclTeam lsa = ncclTeamLsa(devcomm);
+  const int mype = lsa.rank;
+  const int npes = lsa.nRanks;
+  const int tid = threadIdx.x;
+  CUDA_KERNEL_ASSERT(npes <= A2A_MAX_PEERS);
+
+  // Read MY input_splits[tid] from local window.
+  int64_t* in_splits = reinterpret_cast<int64_t*>(
+      ncclGetLocalPointer(in_splits_win, in_splits_off));
+  int64_t my_split = (tid < npes) ? in_splits[tid] : int64_t{0};
+
+  // Exclusive prefix sum -> per-peer source offset in MY send buffer.
+  int64_t my_src_off;
+  int64_t total;
+  BlockScanT(temp_storage).ExclusiveSum(my_split, my_src_off, total);
+  if (tid < npes) {
+    s_my_offsets[tid] = my_src_off;
+  }
+  __syncthreads();
+
+  // Each thread tid (tid < npes) writes 2 int64s into peer tid's scratchpad:
+  //   peer.scratch[mype]        = my in_splits[tid]      (peer's output split from me)
+  //   peer.scratch[npes + mype] = my src_off for peer    (peer's source offset on me)
+  if (tid < npes) {
+    int64_t* peer_scratch = reinterpret_cast<int64_t*>(
+        ncclGetLsaPointer(scratch_win, scratch_off, tid));
+    peer_scratch[mype] = my_split;
+    peer_scratch[npes + mype] = s_my_offsets[tid];
+  }
+
+  // Cross-rank fence: after this returns, all peers have completed their
+  // metadata writes into MY scratchpad and the writes are visible to me.
+  ncclCoopCta coop{};
+  ncclLsaBarrierSession<ncclCoopCta> bar{
+      coop,
+      devcomm,
+      ncclTeamLsa(devcomm),
+      devcomm.lsaBarrier,
+      /*index=*/0};
+  bar.sync(coop, cuda::memory_order_seq_cst);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: pull data from peers using one-sided NVLink loads.
+// Each peer is assigned `blocks_per_peer = max(gridDim.x / npes, 1)` CTAs;
+// CTAs are rotated by `mype` so different ranks hammer different peers first
+// (matches the NVSHMEM heuristic to spread NVLink load).
+// ---------------------------------------------------------------------------
+__global__ void nccl_a2av_data_kernel(
+    ncclWindow_t input_win,
+    size_t input_win_off,
+    void* output_ptr,
+    ncclWindow_t scratch_win,
+    size_t scratch_off,
+    size_t stride_bytes,
+    ncclDevComm devcomm) {
+  using BlockScanT = at_cuda_detail::cub::
+      BlockScan<int64_t, A2A_THREADS_PER_BLOCK, at_cuda_detail::cub::BLOCK_SCAN_WARP_SCANS>;
+  __shared__ typename BlockScanT::TempStorage temp_storage;
+  __shared__ int64_t s_write_offsets[A2A_MAX_PEERS];
+
+  const ncclTeam lsa = ncclTeamLsa(devcomm);
+  const int mype = lsa.rank;
+  const int npes = lsa.nRanks;
+  const int bid = blockIdx.x;
+  const int tid = threadIdx.x;
+  const int blocks_per_peer = max(gridDim.x / npes, 1);
+  CUDA_KERNEL_ASSERT(npes <= A2A_MAX_PEERS);
+
+  // Read the metadata that peers wrote in phase 1.
+  int64_t* scratch = reinterpret_cast<int64_t*>(
+      ncclGetLocalPointer(scratch_win, scratch_off));
+  int64_t* output_splits = scratch;
+  int64_t* source_offsets = scratch + npes;
+
+  // Exclusive prefix sum of output_splits -> per-peer write offsets in MY
+  // recv buffer.
+  int64_t my_split = (tid < npes) ? output_splits[tid] : int64_t{0};
+  int64_t my_write_off;
+  int64_t total;
+  BlockScanT(temp_storage).ExclusiveSum(my_split, my_write_off, total);
+  if (tid < npes) {
+    s_write_offsets[tid] = my_write_off;
+  }
+  __syncthreads();
+
+  // Walk peers in rotated order so different ranks start on different peers.
+  for (int i = bid / blocks_per_peer; i < npes;
+       i += gridDim.x / blocks_per_peer) {
+    const int peer = (mype + i) % npes;
+    const int64_t peer_split = output_splits[peer];
+    if (peer_split == 0) {
+      continue;
+    }
+    const size_t peer_bytes = static_cast<size_t>(peer_split) * stride_bytes;
+    const size_t block_bytes = peer_bytes / blocks_per_peer;
+    // We assume each peer's chunk divides evenly across its CTAs (matches
+    // NVSHMEM's allToAllV; the CTA budget is rounded up to a multiple of npes
+    // on the host side). If the peer's chunk is smaller than blocks_per_peer
+    // bytes, only block 0 will do useful work for that peer.
+    CUDA_KERNEL_ASSERT(block_bytes * blocks_per_peer == peer_bytes);
+    const size_t block_off = block_bytes * (bid % blocks_per_peer);
+    const size_t src_off_bytes =
+        static_cast<size_t>(source_offsets[peer]) * stride_bytes + block_off;
+    const size_t dst_off_bytes =
+        static_cast<size_t>(s_write_offsets[peer]) * stride_bytes + block_off;
+
+    char* peer_src = reinterpret_cast<char*>(ncclGetLsaPointer(
+        input_win, input_win_off + src_off_bytes, peer));
+    char* dst = reinterpret_cast<char*>(output_ptr) + dst_off_bytes;
+    block_copy_bytes(dst, peer_src, block_bytes);
+  }
+
+  // Honour the user-visible contract: row 1 of out_splits_offsets must be the
+  // *output* offsets (write offsets in `out`). It currently holds the source
+  // offsets we used internally; CTA 0 overwrites it once with the write
+  // offsets we just computed.
+  if (bid == 0 && tid < npes) {
+    source_offsets[tid] = s_write_offsets[tid];
+  }
+}
+
+// CTA budget for the data kernel. We pad up to a multiple of npes so each
+// peer has the same number of CTAs, then cap by an intra-/inter-node ceiling.
+int get_a2a_nblocks(size_t input_bytes, int npes, bool intra_node) {
+  // 16 B per thread, 8 unrolled iterations per CTA -- the same heuristic the
+  // NVSHMEM implementation uses for the inter-rank case.
+  constexpr size_t kChunk = 16ull * A2A_THREADS_PER_BLOCK * 8;
+  int n = static_cast<int>((input_bytes + kChunk - 1) / kChunk);
+  // Round up to a multiple of npes so each peer gets the same number of CTAs.
+  n = ((n + npes - 1) / npes) * npes;
+  if (n < npes) n = npes;
+  const int max_n = intra_node ? A2A_MAX_BLOCKS_INTRA : A2A_MAX_BLOCKS_INTER;
+  return std::min(n, max_n);
+}
+
+} // namespace
+
+// Host entry point. See file-level comment for semantics.
+void nccl_all_to_all_vdev(
+    at::Tensor& input,
+    at::Tensor& out,
+    at::Tensor& in_splits,
+    at::Tensor& out_splits_offsets,
+    const std::string& group_name) {
+  // Rendezvous all four tensors as symmetric memory. We require all four to
+  // be NCCL-symmetric; this matches the NVSHMEM contract (all participating
+  // tensors live on the symmetric heap).
+  auto in_hdl = c10d::symmetric_memory::rendezvous(input, group_name);
+  auto out_hdl = c10d::symmetric_memory::rendezvous(out, group_name);
+  auto in_splits_hdl =
+      c10d::symmetric_memory::rendezvous(in_splits, group_name);
+  auto scratch_hdl =
+      c10d::symmetric_memory::rendezvous(out_splits_offsets, group_name);
+
+  TORCH_CHECK(
+      in_hdl != nullptr && out_hdl != nullptr && in_splits_hdl != nullptr &&
+          scratch_hdl != nullptr,
+      "nccl_all_to_all_vdev: all of input / out / in_splits / out_splits_offsets "
+      "must be allocated via NCCL symmetric memory (use empty_strided_p2p with "
+      "the NCCL backend)");
+
+  auto* nccl_in = dynamic_cast<NCCLSymmetricMemory*>(in_hdl.get());
+  auto* nccl_in_splits = dynamic_cast<NCCLSymmetricMemory*>(in_splits_hdl.get());
+  auto* nccl_scratch = dynamic_cast<NCCLSymmetricMemory*>(scratch_hdl.get());
+  TORCH_CHECK(
+      nccl_in != nullptr && nccl_in_splits != nullptr &&
+          nccl_scratch != nullptr,
+      "nccl_all_to_all_vdev: requires the NCCL symmetric memory backend");
+
+  TORCH_CHECK(input.is_contiguous(), "nccl_all_to_all_vdev: input must be contiguous");
+  TORCH_CHECK(out.is_contiguous(), "nccl_all_to_all_vdev: out must be contiguous");
+  TORCH_CHECK(input.dim() >= 1, "nccl_all_to_all_vdev: input must be at least 1-D");
+  TORCH_CHECK(input.dtype() == out.dtype(),
+      "nccl_all_to_all_vdev: input and out must have the same dtype");
+  TORCH_CHECK(in_splits.scalar_type() == at::kLong,
+      "nccl_all_to_all_vdev: in_splits must be int64");
+  TORCH_CHECK(out_splits_offsets.scalar_type() == at::kLong,
+      "nccl_all_to_all_vdev: out_splits_offsets must be int64");
+  TORCH_CHECK(out_splits_offsets.dim() == 2 && out_splits_offsets.size(0) == 2,
+      "nccl_all_to_all_vdev: out_splits_offsets must have shape (2, npes), got ",
+      out_splits_offsets.sizes());
+  TORCH_CHECK(in_splits.is_contiguous() && out_splits_offsets.is_contiguous(),
+      "nccl_all_to_all_vdev: in_splits and out_splits_offsets must be contiguous");
+
+  c10::cuda::CUDAGuard guard(input.device());
+  auto stream = at::cuda::getCurrentCUDAStream(input.device().index());
+  auto device = input.device();
+
+  auto& manager = NCCLDevCommManager::get(device);
+  ncclComm_t comm = manager.get_comm(group_name);
+
+  // Cache a devcomm under our own key so we don't trample whatever
+  // reduce_scatter_offset (or any other op) has already created on this group.
+  static constexpr char const kDevcommKey[] = "nccl_all_to_all_vdev";
+  auto devcomm_opt = manager.get_devcomm(group_name, kDevcommKey);
+  if (!devcomm_opt) {
+    ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
+    // We only need a single LSA barrier slot: phase 1's single CTA enters
+    // and exits it before phase 2 starts (stream order on each rank, LSA
+    // sync across ranks). Phase 2 deliberately has no inter-rank barrier
+    // -- callers must synchronise before reusing the send buffer, exactly
+    // as with the NVSHMEM version.
+    reqs.lsaBarrierCount = 1;
+    ncclDevComm devcomm;
+    C10D_NCCL_CHECK(
+        ncclDevCommCreate(comm, &reqs, &devcomm),
+        "ncclDevCommCreate failed in nccl_all_to_all_vdev");
+    devcomm_opt = manager.register_devcomm(group_name, devcomm, kDevcommKey);
+  }
+  ncclDevComm& devcomm = devcomm_opt->get();
+
+  const int npes = devcomm.nRanks;
+  TORCH_CHECK(npes <= A2A_MAX_PEERS,
+      "nccl_all_to_all_vdev: world size ", npes,
+      " exceeds compile-time max ", A2A_MAX_PEERS,
+      " (= A2A_THREADS_PER_BLOCK)");
+  TORCH_CHECK(in_splits.numel() == npes,
+      "nccl_all_to_all_vdev: in_splits.numel() must equal world size, got ",
+      in_splits.numel(), " vs ", npes);
+  TORCH_CHECK(out_splits_offsets.size(1) == npes,
+      "nccl_all_to_all_vdev: out_splits_offsets.size(1) must equal world size, got ",
+      out_splits_offsets.size(1), " vs ", npes);
+
+  // Resolve the per-tensor (window, byte-offset) pairs. get_offset() is the
+  // tensor's allocation offset within the NCCL window; we add the tensor's
+  // own storage_offset so views work correctly.
+  ncclWindow_t in_win = nccl_in->get_window();
+  size_t in_off = nccl_in->get_offset() +
+      static_cast<size_t>(input.storage_offset()) * input.element_size();
+
+  ncclWindow_t in_splits_win = nccl_in_splits->get_window();
+  size_t in_splits_off = nccl_in_splits->get_offset() +
+      static_cast<size_t>(in_splits.storage_offset()) * in_splits.element_size();
+
+  ncclWindow_t scratch_win = nccl_scratch->get_window();
+  size_t scratch_off = nccl_scratch->get_offset() +
+      static_cast<size_t>(out_splits_offsets.storage_offset()) *
+          out_splits_offsets.element_size();
+
+  TORCH_CHECK(in_win != nullptr && in_splits_win != nullptr && scratch_win != nullptr,
+      "nccl_all_to_all_vdev: NCCL window is null");
+
+  // Bytes per row in the input tensor along dim 0; matches NVSHMEM's `stride`
+  // argument and is used to scale split counts (which are in row units, not
+  // bytes) into byte offsets.
+  const size_t stride_bytes =
+      static_cast<size_t>(input.stride(0)) * input.element_size();
+
+  // ---- Phase 1: metadata exchange (1 CTA) ----
+  nccl_a2av_exchange_kernel<<<1, A2A_THREADS_PER_BLOCK, 0, stream>>>(
+      in_splits_win, in_splits_off,
+      scratch_win, scratch_off,
+      devcomm);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // ---- Phase 2: data exchange (N CTAs) ----
+  // input.numel() * element_size is the size of MY send buffer; we choose the
+  // CTA budget from that (NVSHMEM does the same -- using the recv size would
+  // require the device-side metadata which isn't available host-side until
+  // after the alltoallv finishes).
+  const size_t input_bytes =
+      static_cast<size_t>(input.numel()) * input.element_size();
+  const bool intra_node = nccl_in->has_multicast_support();
+  const int num_blocks = get_a2a_nblocks(input_bytes, npes, intra_node);
+  nccl_a2av_data_kernel<<<num_blocks, A2A_THREADS_PER_BLOCK, 0, stream>>>(
+      in_win, in_off,
+      out.mutable_data_ptr(),
+      scratch_win, scratch_off,
+      stride_bytes,
+      devcomm);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+#else // !NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+
+void nccl_all_to_all_vdev(
+    at::Tensor& /*input*/,
+    at::Tensor& /*out*/,
+    at::Tensor& /*in_splits*/,
+    at::Tensor& /*out_splits_offsets*/,
+    const std::string& /*group_name*/) {
+  TORCH_CHECK(false,
+      "nccl_all_to_all_vdev requires NCCL >= 2.28 with symmetric memory device API support");
+}
+
+#endif // NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+
+} // namespace c10d::nccl_extension

--- a/torch/csrc/distributed/c10d/symm_mem/ops/nccl_alltoall_vdev.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/ops/nccl_alltoall_vdev.cu
@@ -282,6 +282,13 @@ void nccl_all_to_all_vdev(
           nccl_scratch != nullptr,
       "nccl_all_to_all_vdev: requires the NCCL symmetric memory backend");
 
+  // One-sided LSA loads require every peer in the NCCL team to be in the same
+  // direct-access (LSA) domain. Cross-node groups are not supported yet.
+  TORCH_CHECK(
+      in_hdl->world_within_direct_access(),
+      "nccl_all_to_all_vdev: requires intra-node direct peer access for all ranks "
+      "(LSA domain); cross-node execution is not supported yet");
+
   TORCH_CHECK(input.is_contiguous(), "nccl_all_to_all_vdev: input must be contiguous");
   TORCH_CHECK(out.is_contiguous(), "nccl_all_to_all_vdev: out must be contiguous");
   TORCH_CHECK(input.dim() >= 1, "nccl_all_to_all_vdev: input must be at least 1-D");
@@ -375,8 +382,8 @@ void nccl_all_to_all_vdev(
   // after the alltoallv finishes).
   const size_t input_bytes =
       static_cast<size_t>(input.numel()) * input.element_size();
-  const bool intra_node = nccl_in->has_multicast_support();
-  const int num_blocks = get_a2a_nblocks(input_bytes, npes, intra_node);
+  const int num_blocks =
+      get_a2a_nblocks(input_bytes, npes, /*intra_node=*/true);
   nccl_a2av_data_kernel<<<num_blocks, A2A_THREADS_PER_BLOCK, 0, stream>>>(
       in_win, in_off,
       out.mutable_data_ptr(),

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -2328,8 +2328,9 @@ def all_to_all_vdev(
         >>> # doctest: +SKIP
         >>> # MoE token shuffle: every rank decides per-peer how many tokens to send
         >>> max_in = group.size() * max_tokens_per_peer
+        >>> max_out = group.size() * max_tokens_per_peer  # upper bound on rows received
         >>> input  = symm_mem.empty(max_in, hidden, dtype=torch.bfloat16, device="cuda")
-        >>> out    = symm_mem.empty(max_in, hidden, dtype=torch.bfloat16, device="cuda")
+        >>> out    = symm_mem.empty(max_out, hidden, dtype=torch.bfloat16, device="cuda")
         >>> in_sp  = symm_mem.empty(group.size(), dtype=torch.int64, device="cuda")
         >>> out_sp = symm_mem.empty(2, group.size(), dtype=torch.int64, device="cuda")
         >>> for t in (input, out, in_sp, out_sp):

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -2272,6 +2272,88 @@ def reduce_scatter_offset(
         )
 
 
+def all_to_all_vdev(
+    input: torch.Tensor,
+    out: torch.Tensor,
+    in_splits: torch.Tensor,
+    out_splits_offsets: torch.Tensor,
+    group: str,
+) -> None:
+    r"""
+    all_to_all_vdev(input, out, in_splits, out_splits_offsets, group) -> None
+
+    Variable-length AllToAll where the per-peer split sizes live on device.
+    Functionally equivalent to :func:`torch.distributed.all_to_all_single` with
+    explicit ``input_split_sizes`` / ``output_split_sizes``, but the splits
+    never have to leave the device, which avoids the host/device sync that the
+    standard collective imposes when the splits are device tensors.
+
+    All four tensor arguments must be allocated via
+    :func:`torch.distributed._symmetric_memory.empty` and rendezvous'd on
+    ``group`` (i.e. they must be symmetric-memory tensors on the *same*
+    backend).
+
+    Args:
+        input (Tensor): Send buffer (contiguous).  Sized to fit
+            ``sum(in_splits)`` rows along dim 0.  All ranks must agree on the
+            tensor shape and dtype.
+        out (Tensor): Recv buffer (contiguous).  Must be large enough to hold
+            the rows pulled from every peer (i.e. the sum of the output splits
+            this rank receives).  Same dtype as ``input``.
+        in_splits (Tensor): 1-D ``int64`` tensor of length
+            ``group.size()``.  ``in_splits[p]`` = number of rows this rank
+            sends to peer ``p``.
+        out_splits_offsets (Tensor): 2-D ``int64`` tensor of shape
+            ``(2, group.size())``.  On return:
+
+            - ``out_splits_offsets[0, p]`` = number of rows received from peer ``p``.
+            - ``out_splits_offsets[1, p]`` = exclusive prefix-sum of row 0
+              (the position of peer ``p``'s chunk inside ``out``).
+
+            The contents on entry are ignored / used as scratch.
+        group (str): Name of the :class:`~torch.distributed.ProcessGroup` to
+            perform the operation on.
+
+    Backend dispatch:
+
+    - ``"NCCL"``    -> :func:`torch.ops.symm_mem.nccl_all_to_all_vdev`
+      (NCCL device-API based, requires NCCL >= 2.28).
+    - ``"NVSHMEM"`` -> :func:`torch.ops.symm_mem.all_to_all_vdev`
+      (NVSHMEM-based, requires PyTorch built with NVSHMEM support).
+
+    Other backends raise :class:`NotImplementedError`.
+
+    Example::
+
+        >>> # doctest: +SKIP
+        >>> # MoE token shuffle: every rank decides per-peer how many tokens to send
+        >>> max_in = group.size() * max_tokens_per_peer
+        >>> input  = symm_mem.empty(max_in, hidden, dtype=torch.bfloat16, device="cuda")
+        >>> out    = symm_mem.empty(max_in, hidden, dtype=torch.bfloat16, device="cuda")
+        >>> in_sp  = symm_mem.empty(group.size(), dtype=torch.int64, device="cuda")
+        >>> out_sp = symm_mem.empty(2, group.size(), dtype=torch.int64, device="cuda")
+        >>> for t in (input, out, in_sp, out_sp):
+        ...     symm_mem.rendezvous(t, group=group_name)
+        >>> # ... fill `input` and `in_sp` from your router on device ...
+        >>> symm_mem.all_to_all_vdev(input, out, in_sp, out_sp, group_name)
+        >>> # `out_sp[0]` = received splits, `out_sp[1]` = exclusive offsets in `out`
+    """
+    backend = get_backend(input.device)
+    match backend:
+        case "NCCL":
+            torch.ops.symm_mem.nccl_all_to_all_vdev(
+                input, out, in_splits, out_splits_offsets, group
+            )
+        case "NVSHMEM":
+            torch.ops.symm_mem.all_to_all_vdev(
+                input, out, in_splits, out_splits_offsets, group
+            )
+        case _:
+            raise NotImplementedError(
+                f"all_to_all_vdev: unsupported backend: {backend}"
+            )
+
+
 def is_symm_mem_tensor(tensor: torch.Tensor) -> bool:
     r"""
     is_symm_mem_tensor(tensor) -> bool
@@ -2299,4 +2381,5 @@ __all__ = [
     "get_signal_pad_size",
     "get_mem_pool",
     "reduce_scatter_offset",
+    "all_to_all_vdev",
 ]


### PR DESCRIPTION
Mirrors the existing NVSHMEM all_to_all_vdev (with on-device split sizes) on top of the NCCL symmetric memory backend, so applications already using NCCL symm memory can dispatch the same torch.ops.symm_mem.all_to_all_vdev schema without pulling in NVSHMEM.

Implementation pattern follows nccl_reduce_scatter_offset.cu:

1-CTA exchange kernel writes per-peer output_splits + source_offsets into peers' symmetric scratchpads via ncclGetLsaPointer, then ncclLsaBarrierSession::sync(seq_cst) for the cross-rank fence.
N-CTA data kernel computes write offsets via CUB BlockScan and block-cooperatively pulls each peer's slice from peer.input via one-sided NVLink loads; CTA 0 overwrites row 1 of out_splits_offsets with write offsets to honour the user-visible contract.
No exit barrier (matches NVSHMEM behaviour); the next op's entry barrier closes the read-after-write hazard.
Tests in test/distributed/test_nccl.py mirror the NVSHMEM test_all_to_all_vdev (random per-peer splits + dist.all_to_all_single oracle) and add a zero-splits corner case for the empty-peer fast path.

Note: header decl in nccl_extension.hpp and the
TORCH_LIBRARY_IMPL(symm_mem, CUDA, m) registration still need to be added in a follow-up so the schema dispatches to the new kernel.

Made-with: Cursor

