### PR TITLE
[dynamo] warn instead of error on fullgraph=True fallback to eager

### DIFF
--- a/test/dynamo/test_compile.py
+++ b/test/dynamo/test_compile.py
@@ -309,7 +309,7 @@ class PublicTorchCompilerTests(TestCase):
 
 
 class FullgraphTests(TestCase):
-    def test_fullgraph_errors_on_frame_skip_with_dispatch_mode(self):
+    def test_fullgraph_warns_on_frame_skip_with_dispatch_mode(self):
         from torch.utils._python_dispatch import TorchDispatchMode
 
         class SkipMode(TorchDispatchMode):
@@ -321,16 +321,16 @@ class FullgraphTests(TestCase):
 
         x = torch.randn(5)
         with SkipMode():
-            with self.assertRaisesRegex(RuntimeError, "found no compiled frames"):
+            with self.assertWarnsRegex(UserWarning, "found no compiled frames"):
                 torch.compile(fn, backend="eager", fullgraph=True)(x)
 
-    def test_fullgraph_errors_on_frame_skip_dynamo_disabled(self):
+    def test_fullgraph_warns_on_frame_skip_dynamo_disabled(self):
         def fn(x):
             return x + 1
 
         x = torch.randn(5)
         with torch._dynamo.config.patch(disable=True):
-            with self.assertRaisesRegex(RuntimeError, "found no compiled frames"):
+            with self.assertWarnsRegex(UserWarning, "found no compiled frames"):
                 torch.compile(fn, backend="eager", fullgraph=True)(x)
 
     def test_fullgraph_empty_graph_no_error(self):

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -412,7 +412,7 @@ graph():
         self.assertEqual(len(backend.graphs), 0)
 
         with YoloMode():
-            with self.assertRaisesRegex(RuntimeError, "found no compiled frames"):
+            with self.assertWarnsRegex(UserWarning, "found no compiled frames"):
                 torch.compile(torch.add, backend=backend, fullgraph=True)(x, x)
 
     def test_compile_non_infra_empty_with_disalloed_dispatch_mode(self):

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1066,10 +1066,11 @@ class _TorchDynamoContext:
                     if fullgraph_count_enabled and call_succeeded:
                         count = set_fullgraph_compiled_frame_count(-1)
                         if count == 0:
-                            raise RuntimeError(
+                            torch._dynamo.utils.warn_once(
                                 "torch.compile with fullgraph=True found no compiled frames. "
                                 "The frame was likely skipped (e.g., a non-infra torch dispatch "
-                                "mode was active, dynamo was disabled, or the frame was skipped."
+                                "mode was active, dynamo was disabled, or the frame was skipped. "
+                                "This may become an error in the future."
                             )
                     if prior_error_on_graph_break is not None:
                         _set_error_on_graph_break(prior_error_on_graph_break)


### PR DESCRIPTION
Original issue: https://github.com/pytorch/pytorch/issues/181817

We introduced a new behavior for fullgraph=True in https://github.com/pytorch/pytorch/pull/177809 where an error is thrown when no compiled code is run. However, an internal issue revealed that this new behavior is incompatible with the "eager_on_recompile" stance.

Our solution is that for 2.12, we will issue a warning instead of erroring out if no compiled code is ran under fullgraph=True. We will keep the erroring behavior on trunk as we seek to improve the behavior - i.e. steps 2 and 3 in the original issue.

Future plans: we will error on 2.13 after addressing the other points (2 and 3) in the issue.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @mlazos