### PR TITLE
Fix deadlock in AOTInductorModelContainer::run() during concurrent constant folding (#181941)

### DIFF
--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -1097,6 +1097,59 @@ void test_multi_cuda_streams(const std::string& device) {
   }
 }
 #endif // USE_CUDA
+
+void test_concurrent_run_with_const_fold(const std::string& device) {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  std::string suffix = device + "_use_runtime_constant_folding";
+  const auto& model_so_path =
+      data_loader.attr(("model_so_path_" + suffix).c_str()).toStringRef();
+  auto input_tensors =
+      data_loader.attr(("inputs_" + suffix).c_str()).toTensorList().vec();
+  const auto& ref_output_tensors =
+      data_loader.attr(("outputs_" + suffix).c_str()).toTensorList().vec();
+
+  // num_models=1 forces all threads to contend for the single model instance.
+  std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
+  if (device == "cuda") {
+    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+        model_so_path, /* num_models = */ 1);
+  } else {
+    FAIL() << "unsupported device: " << device;
+  }
+
+  constexpr int num_threads = 4;
+  constexpr int num_iters = 4;
+  std::atomic<int> ready{0};
+  std::atomic<bool> failed{false};
+
+  std::vector<std::thread> threads;
+  for (int t = 0; t < num_threads; t++) {
+    threads.emplace_back([&]() {
+      ready.fetch_add(1);
+      while (ready.load() < num_threads) {
+      }
+      for (int i = 0; i < num_iters; i++) {
+        auto outputs = runner->run(input_tensors);
+        if (!torch::allclose(ref_output_tensors[0], outputs[0])) {
+          failed.store(true);
+        }
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  ASSERT_FALSE(failed.load())
+      << "One or more threads produced incorrect output";
+}
 #endif // USE_CUDA || USE_ROCM
 } // namespace
 
@@ -1187,6 +1240,10 @@ TEST_F(AotInductorTest, MultiStreamTestCuda) {
 
 TEST_F(AotInductorTest, CudaAllocTestCuda) {
   test_cuda_alloc_test();
+}
+
+TEST_F(AotInductorTest, ConcurrentRunConstFoldCuda) {
+  test_concurrent_run_with_const_fold("cuda");
 }
 #endif
 

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -107,18 +107,19 @@ class AOTInductorModelContainer {
       DeviceStreamType stream,
       AOTIProxyExecutorHandle proxy_executor) {
     std::shared_lock model_lk(model_exec_mutex_);
-    auto* model = get_available_model();
 
     ConstantState& const_folded =
         use_secondary_ ? constant_folded_secondary_ : constant_folded_;
     if (const_folded == ConstantState::INITIALIZED) {
-      // At this point, constant is not ready yet. We need to call constant
-      // folding before we execute the model. We obtain a unique lock at this
-      // point to make sure constant is ready for all.
+      // Do NOT call get_available_model() before upgrading to exclusive lock.
+      // Holding a model across the upgrade causes a deadlock when another
+      // thread holds a shared lock and waits for the model.
       model_lk.unlock();
       std::unique_lock constants_folding_lk(model_exec_mutex_);
       // Double locking to make sure constant folding is only ran once.
       if (const_folded == ConstantState::INITIALIZED) {
+        auto* model = get_available_model();
+        // TODO: add try catch block to handle exception.
         auto folded_const_map = model->run_const_fold(
             stream, proxy_executor, /* initialization = */ true);
         update_constant_buffer(
@@ -126,6 +127,11 @@ class AOTInductorModelContainer {
             /* use_inactive = */ false,
             /* validate_full_update = */ false);
         const_folded = ConstantState::FOLDED;
+        {
+          std::lock_guard lk(models_mutex_);
+          pending_models_.push_back(model);
+        }
+        pending_models_available_.notify_one();
       }
       constants_folding_lk.unlock();
       model_lk.lock();
@@ -133,6 +139,8 @@ class AOTInductorModelContainer {
       throw std::runtime_error(
           "Unknown constant state: " + toStringConstantState(constant_folded_));
     }
+
+    auto* model = get_available_model();
 
     try {
       model->run(input_handles, output_handles, stream, proxy_executor);


### PR DESCRIPTION
Summary:

AOTInductorModelContainer::run() has a deadlock when multiple threads call it concurrently with num_models=1 and constant_folded_ == ConstantState::INITIALIZED (the first inference call with runtime constant folding enabled).

The root cause is a two-resource circular dependency during the shared-to-exclusive lock upgrade. The old code acquired a shared lock, took the only model from the pool, then released the shared lock and tried to acquire an exclusive lock for constant folding. A second thread that acquired a shared lock in the meantime and called get_available_model() would block waiting for the model, creating a circular wait: Thread A holds the model and waits for the exclusive lock (blocked by Thread B's shared lock), while Thread B holds a shared lock and waits for the model (held by Thread A).

The fix moves get_available_model() from before the constant folding check to after it. The model for folding is acquired inside the exclusive lock (where no other thread can hold a shared lock), and a separate model is acquired under the shared lock for inference.

Test Plan: Added ConcurrentRunConstFoldCuda C++ test in test/cpp/aoti_inference/test.cpp. The test creates a runner with num_models=1 using a model compiled with use_runtime_constant_folding=True, then spawns 4 C++ threads that synchronize via an atomic spin barrier and call run() simultaneously. A 60-second timeout on a condition variable detects deadlock. Without the fix, the threads hang indefinitely; with the fix, all threads complete and produce correct outputs matching the reference.

Reviewed By: desertfire

Differential Revision: D103044350


