### PR TITLE
[cuBLAS][cuBLASLt] Shared default workspace size across cuBLAS and Lt

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -228,9 +228,8 @@ size_t parseCUDABlasLtWorkspaceSize() {
   }
   size_t workspace_size = 76*1024; /* Use 76 MB for hipBLASLt */
 #else
-  /* use CUDABlas default workspace size if unified */
-  /* otherwise, use default size in KiB according to #73328 */
-  size_t workspace_size = unified_cublas_and_lt_workspaces() ? parseChosenWorkspaceSize() / 1024 : 1024;
+  // use CUBLAS_WORKSPACE_CONFIG / default if LT env var is not set
+  size_t workspace_size = parseChosenWorkspaceSize() / 1024;
 #endif
 
   if (val.has_value()) {


### PR DESCRIPTION
We've had persistent workspaces for a while now, so perhaps this helps with the peak memory allocation situation?

Also motivated by @nikitaved finding a significant source of Lt - nonLt divergence was differing workspaces sizes without unified workspaces e.g., in `FBCODE`

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @csarofeen