### PR TITLE
Add GPU stream synchronization after constant folding in AOTI (#181945)

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -572,6 +572,11 @@ class AOTInductorModelBase {
     run_finished_ = true;
 #endif // USE_CUDA
 
+    // Wait for the constant folding kernels to complete. The folded
+    // constants may be read by inference on a different stream after
+    // swap_constant_buffer(), which has no GPU synchronization.
+    wait_for_completion();
+
     return folded_constants;
   }
 


### PR DESCRIPTION
Summary:

run_const_fold() in AOTInductorModelBase enqueues GPU kernels on a stream and records a CUDA event, but did not wait for the kernels to complete before returning. When swap_constant_buffer() subsequently made the folded constants active, inference on a different stream could read partially-written folded constants. This caused rare numerical issues, particularly on AMD (ROCm) where HIP streams are truly independent (no implicit cross-stream synchronization like NVIDIA's default stream).

The fix adds wait_for_completion() at the end of run_const_fold() in model_base.h, which calls cudaEventSynchronize on the event recorded after the fold kernels. This ensures the folded constants are fully written before the function returns, making it safe for any subsequent swap and inference on any stream.

Test Plan: The stream sync fix cannot be reliably reproduced in a test — it requires GPU scheduling to interleave const fold kernels with inference kernels on different streams, which is non-deterministic and hardware-dependent. The fix is verifiable by inspection: without the sync, const fold kernels can still be executing when inference reads the results on a different stream after swap_constant_buffer(). The issue was observed as rare numerical mismatches on AMD MI300X.

Differential Revision: D103105501


