### PR TITLE
[ROCm] Bump CK submodule to include gfx1033 support

### DIFF
--- a/.ci/pytorch/build.sh
+++ b/.ci/pytorch/build.sh
@@ -13,6 +13,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/common-build.sh"
 if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
   # shellcheck source=./rocm_utils.sh
   source "$(dirname "${BASH_SOURCE[0]}")/rocm_utils.sh"
+  export PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH};gfx1033"
 fi
 
 echo "Python version:"


### PR DESCRIPTION
Bumping `third_party/composable_kernel` to [3fb26ec](https://github.com/ROCm/composable_kernel/tree/3fb26ec98c14adcc743e7c7d80958b3fc836fd64) to include gfx1033 support changes. 

Blocked by https://github.com/pytorch/pytorch/pull/178310

This intends to resolve the nightly TheRock CI failures seen here https://github.com/ROCm/TheRock/actions/runs/25095469497/job/73531116898.

Reference issue with more context: https://github.com/ROCm/TheRock/issues/4768

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang