### PR TITLE
[MPS] Enhance Col2Im tensor op to avoid .contiguous() call and make corresponding Metal kernel stride-aware 

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Col2Im.metal
+++ b/aten/src/ATen/native/mps/kernels/Col2Im.metal
@@ -14,6 +14,7 @@ kernel void col2im_kernel(
     constant uint2& dilation_hw [[buffer(8)]],
     constant uint2& col_hw [[buffer(9)]],
     constant uint& im_batch_stride [[buffer(10)]],
+    constant uint2& col_inner_strides [[buffer(11)]],
     uint3 gid [[thread_position_in_grid]]) {
   const uint output_height = im_hw.x;
   const uint output_width = im_hw.y;
@@ -50,6 +51,8 @@ kernel void col2im_kernel(
 
   float accumulator = 0.0;
   uint col_batch_offset = batch_idx * col_batch_stride;
+  uint col_channel_stride = col_inner_strides.x;
+  uint col_spatial_stride = col_inner_strides.y;
 
   for (uint h_col = h_col_start; h_col < h_col_end; h_col++) {
     for (uint w_col = w_col_start; w_col < w_col_end; w_col++) {
@@ -60,11 +63,10 @@ kernel void col2im_kernel(
         h_k /= dilation_h;
         w_k /= dilation_w;
         if (h_k < kernel_h && w_k < kernel_w) {
+          uint dim1_idx = c_im * kernel_h * kernel_w + h_k * kernel_w + w_k;
+          uint dim2_idx = h_col * width_col + w_col;
           uint col_index =
-              (((c_im * kernel_h + h_k) * kernel_w + w_k) * height_col +
-               h_col) *
-                  width_col +
-              w_col;
+              dim1_idx * col_channel_stride + dim2_idx * col_spatial_stride;
           accumulator +=
               static_cast<float>(data_col[col_batch_offset + col_index]);
         }
@@ -91,6 +93,7 @@ kernel void col2im_kernel(
       constant uint2& dilation_hw [[buffer(8)]],              \
       constant uint2& col_hw [[buffer(9)]],                   \
       constant uint& im_batch_stride [[buffer(10)]],          \
+      constant uint2& col_inner_strides [[buffer(11)]],       \
       uint3 gid [[thread_position_in_grid]]);
 
 INSTANTIATE_COL2IM(bool);

--- a/aten/src/ATen/native/mps/operations/Col2Im.mm
+++ b/aten/src/ATen/native/mps/operations/Col2Im.mm
@@ -37,7 +37,7 @@ static void col2im_out_mps_template(const Tensor& input,
   auto stride_height = stride[0];
   auto stride_width = stride[1];
 
-  Tensor col_tensor = input.contiguous();
+  Tensor col_tensor = input;
   bool batched_input = true;
   if (col_tensor.dim() == 2) {
     batched_input = false;
@@ -49,6 +49,8 @@ static void col2im_out_mps_template(const Tensor& input,
   TORCH_CHECK(n_input_plane % (kernel_height * kernel_width) == 0, "col2im_mps: invalid number of input channels");
   auto n_output_plane = n_input_plane / (kernel_height * kernel_width);
   auto input_batch_stride = col_tensor.stride(0);
+  auto input_channel_stride = col_tensor.stride(1);
+  auto input_spatial_stride = col_tensor.stride(2);
 
   output.resize_({batch_size, n_output_plane, output_height, output_width});
   auto output_batch_stride = output.stride(0);
@@ -86,7 +88,9 @@ static void col2im_out_mps_template(const Tensor& input,
           std::array<uint32_t, 2>{static_cast<uint32_t>(dilation_height),
                                   static_cast<uint32_t>(dilation_width)}, // dilation_hw
           std::array<uint32_t, 2>{static_cast<uint32_t>(height_col), static_cast<uint32_t>(width_col)}, // col_hw
-          output_batch_stride);
+          output_batch_stride,
+          std::array<uint32_t, 2>{static_cast<uint32_t>(input_channel_stride),
+                                  static_cast<uint32_t>(input_spatial_stride)}); // col_inner_strides
       [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadgroupSize];
     }
   });


### PR DESCRIPTION
Col2Im Tensor OP Enhancement 
  * Removing the `.contiguous()` call on `col_tensor` in `col2im_out_mps_template()` operation
  * Updating `col2im_kernel()` kernel to take in inner strides and manually calculate strided `col_index`

Benchmarked using following script
```python
import torch
import torch.nn.functional as F
import torch.utils.benchmark as benchmark

# col2im_out_mps_template() calls input.contiguous() before PR #181949.
# Transpose dims 1 and 2 to make the input non-contiguous and force the copy.
x = torch.randn(32, 16384, 27, device="mps").transpose(1, 2)
assert not x.is_contiguous()

m = benchmark.Timer(
    stmt="F.fold(x, output_size=(128, 128), kernel_size=3, padding=1, stride=1)",
    globals={"F": F, "x": x},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

print(f"col2im: mean={m.mean * 1e6:.2f} us  median={m.median * 1e6:.2f} us  iqr={m.iqr * 1e6:.2f} us")

```
On an M3 Macbook Pro with 48GB memory we observe a 3.1x speedup.

Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
802.07 | 258.65 | 3.1x

Issue #181946 