### PR TITLE
[MPS] Enhance HistogramKernel tensor op to avoid unnecessary .contiguous() call

### DIFF
--- a/aten/src/ATen/native/mps/operations/HistogramKernel.mm
+++ b/aten/src/ATen/native/mps/operations/HistogramKernel.mm
@@ -50,7 +50,6 @@ void histogramdd_kernel_impl(Tensor& hist_output,
   TORCH_INTERNAL_ASSERT(int64_t(bin_edges.size()) == D);
   for (const auto dim : c10::irange(D)) {
     bin_edges_numel += bin_edges[dim].numel();
-    TORCH_INTERNAL_ASSERT(bin_edges[dim].is_contiguous());
     TORCH_INTERNAL_ASSERT(hist_output.size(dim) + 1 == bin_edges[dim].numel());
   }
 
@@ -161,16 +160,11 @@ static void histogramdd_out_mps_template(const Tensor& self,
   const auto reshaped_weight =
       weight.has_value() ? std::optional<Tensor>(weight.value().reshape({M})) : std::optional<Tensor>();
 
-  std::vector<Tensor> bin_edges_contig(bin_edges.size());
-  for (const auto dim : c10::irange(bin_edges_contig.size())) {
-    bin_edges_contig[dim] = bin_edges[dim].contiguous();
-  }
-
   AT_DISPATCH_V2(self.scalar_type(),
                  "histogram_mps",
                  AT_WRAP([&]() {
                    mps::histogramdd_kernel_impl<scalar_t, bin_algorithm>(
-                       hist, bin_edges_contig, reshaped_input, reshaped_weight);
+                       hist, bin_edges, reshaped_input, reshaped_weight);
                  }),
                  AT_EXPAND(AT_ALL_TYPES),
                  kBFloat16,


### PR DESCRIPTION
### Summary:
  *  Removing the .contiguous() call for `bin_edges` and the `is_contiguous()` assertion in `histogramdd_out_mps_template()`
  * The tensor is never passed into kernel, it is only consumed on CPU through the `.item()` which already supports non-contiguous tensors. 

### Performance Analysis:
Benchmarked using following script:
```python
import torch
import torch.nn.functional as F
import torch.utils.benchmark as benchmark

bins_buf = torch.linspace(-4.0, 4.0, 514, device=self._device)
bins = bins_buf[::2]  # 257 edges → 256 bins, stride=2, non-contiguous
self.assertFalse(bins.is_contiguous())
x = torch.randn(1_000_000, device=self._device)

m = benchmark.Timer(
    stmt="torch.histogram(x, bins=bins)",
    globals={"torch": torch, "x": x, "bins": bins},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

m_c = benchmark.Timer(
    stmt="torch.histogram(x, bins=bins.contiguous())",
    globals={"torch": torch, "x": x, "bins": bins},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

print(f"non-contiguous: mean={m.mean * 1e6:.2f} us  median={m.median * 1e6:.2f} us  iqr={m.iqr * 1e6:.2f} us")
print(f"contiguous    : mean={m_c.mean * 1e6:.2f} us  median={m_c.median * 1e6:.2f} us  iqr={m_c.iqr * 1e6:.2f} us")

```

On an M3 Macbook Pro with 48GB memory we observe a 1.08x speedup on non-contiguous tensors:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
65242.76 | 60402.98 | 1.08x

And for contiguous tensors we do not observe any performance regression:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
57627.64 | 56,151.22 | 1.03x


### Correctness Analysis:
- Locally tested through an expanded version of the OpsInfo noncontig tests (PR [#183759](https://github.com/pytorch/pytorch/pull/183759)) that covers several more complicated cases of non-contiguity. 
- MPS Results show this modification introduces no regressions (existing bugs that were uncovered through the test expansion are excluded through XFail).


**Pytorch** | **Passed** | **Skipped** | **Deselected** | **XFailed**
------------ | ----------- | ------------ | --------------- | ------------
Baseline       | 16384 | 1074 | 53457 | 1052
Updated       | 16384 | 1074 | 53457 | 1052



Issue #181946 