### PR TITLE
 [PyTorch][operator benchmark] Enable XPU device support for operator benchmark tests

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -363,15 +363,7 @@ class BenchmarkRunner:
         ) and curr_test_total_time > self.args.min_time_per_test
 
     def _launch_forward(self, test_case, iters, print_per_iter):
-        """Use Python's timeit module to measure execution time (unit: second).
-
-        Treat cuda and xpu the same — both go through the
-        ``Timer.adaptive_autorange`` path, both sync their GPU inside
-        the stmt.  The cpu branch keeps the plain ``timeit.timeit``
-        path.  Return value is ``result.median * iters`` (matching
-        the original cuda logic), so ``_measure_metrics`` downstream
-        sees the same units for both GPU devices.
-        """
+        """Use Python's timeit module to measure execution time (unit: second)."""
         test_name = test_case.test_config.test_name
         gpu_sync = ("cuda" in test_name) or ("xpu" in test_name)
         func = test_case.run_forward

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -117,6 +117,12 @@ def _build_test(
                     keep_config = False
                     break
 
+            # same for 'xpu': skip configs that target XPU on machines without XPU support
+            if "xpu" in attr.values():
+                if not torch.xpu.is_available():
+                    keep_config = False
+                    break
+
             test_attrs.update(attr)
 
         if not keep_config:
@@ -386,16 +392,13 @@ class BenchmarkRunner:
                 functools.partial(func, iters, print_per_iter, gpu_sync), number=1
             )
             return forward_time
-        # Stable timing with Timer; stmt runs iters forwards + device sync.
-        # `cuda_sync` is still the parameter name on ``run_forward`` for
-        # backwards compat; semantically it means "sync the GPU".
         timer = Timer(
-            stmt="func(iters, print_per_iter, cuda_sync)",
+            stmt="func(iters, print_per_iter, gpu_sync)",
             globals={
                 "func": func,
                 "iters": iters,
                 "print_per_iter": print_per_iter,
-                "cuda_sync": gpu_sync,
+                "gpu_sync": gpu_sync,
             },
         )
         result = timer.adaptive_autorange(min_run_time=0.0001)

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -394,7 +394,7 @@ class BenchmarkRunner:
         and the execution time is reported
         """
         cuda_sync = "cuda" in test_case.test_config.test_name
-        test_case.run_forward(num_runs=1, print_per_iter=False, cuda_sync=cuda_sync)
+        test_case.run_forward(num_runs=1, print_per_iter=False, gpu_sync=cuda_sync)
         test_case._output_mean()
 
         timer = Timer(

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -393,17 +393,18 @@ class BenchmarkRunner:
         """This function runs forward path of an op to get an output. Then the backward path is executed
         and the execution time is reported
         """
-        cuda_sync = "cuda" in test_case.test_config.test_name
-        test_case.run_forward(num_runs=1, print_per_iter=False, gpu_sync=cuda_sync)
+        test_name = test_case.test_config.test_name
+        gpu_sync = ("cuda" in test_name) or ("xpu" in test_name)
+        test_case.run_forward(num_runs=1, print_per_iter=False, gpu_sync=gpu_sync)
         test_case._output_mean()
 
         timer = Timer(
-            stmt="test_case.run_backward(iters, print_per_iter, cuda_sync)",
+            stmt="test_case.run_backward(iters, print_per_iter, gpu_sync)",
             globals={
                 "test_case": test_case,
                 "iters": iters,
                 "print_per_iter": print_per_iter,
-                "cuda_sync": cuda_sync,
+                "gpu_sync": gpu_sync,
             },
         )
         result = timer.adaptive_autorange(min_run_time=0.0001)

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -357,27 +357,45 @@ class BenchmarkRunner:
         ) and curr_test_total_time > self.args.min_time_per_test
 
     def _launch_forward(self, test_case, iters, print_per_iter):
-        """Use Python's timeit module to measure execution time (unit: second)."""
-        cuda_sync = "cuda" in test_case.test_config.test_name
+        """Use Python's timeit module to measure execution time (unit: second).
+
+        The trigger flag was historically ``cuda_sync = "cuda" in test_name``
+        which meant xpu runs never actually synced the GPU inside the
+        stmt (they fell into the no-sync ``timeit.timeit`` path), so
+        the timer captured host-submit time only — xpu kernels were
+        still running when the timer stopped, artificially deflating
+        the reported wall.
+
+        Fix: treat cuda and xpu the same — both go through the
+        ``Timer.adaptive_autorange`` path, both sync their GPU inside
+        the stmt.  The cpu branch keeps the plain ``timeit.timeit``
+        path.  Return value is ``result.median * iters`` (matching
+        the original cuda logic), so ``_measure_metrics`` downstream
+        sees the same units for both GPU devices.
+        """
+        test_name = test_case.test_config.test_name
+        gpu_sync = ("cuda" in test_name) or ("xpu" in test_name)
         func = test_case.run_forward
         if self.use_jit:
             func = test_case.run_jit_forward
         if self.use_compile:
             func = test_case.run_compile_forward
 
-        if not cuda_sync:
+        if not gpu_sync:
             forward_time = timeit.timeit(
-                functools.partial(func, iters, print_per_iter, cuda_sync), number=1
+                functools.partial(func, iters, print_per_iter, gpu_sync), number=1
             )
             return forward_time
-        # Stable timing with Timer
+        # Stable timing with Timer; stmt runs iters forwards + device sync.
+        # `cuda_sync` is still the parameter name on ``run_forward`` for
+        # backwards compat; semantically it means "sync the GPU".
         timer = Timer(
             stmt="func(iters, print_per_iter, cuda_sync)",
             globals={
                 "func": func,
                 "iters": iters,
                 "print_per_iter": print_per_iter,
-                "cuda_sync": cuda_sync,
+                "cuda_sync": gpu_sync,
             },
         )
         result = timer.adaptive_autorange(min_run_time=0.0001)

--- a/benchmarks/operator_benchmark/benchmark_core.py
+++ b/benchmarks/operator_benchmark/benchmark_core.py
@@ -365,14 +365,7 @@ class BenchmarkRunner:
     def _launch_forward(self, test_case, iters, print_per_iter):
         """Use Python's timeit module to measure execution time (unit: second).
 
-        The trigger flag was historically ``cuda_sync = "cuda" in test_name``
-        which meant xpu runs never actually synced the GPU inside the
-        stmt (they fell into the no-sync ``timeit.timeit`` path), so
-        the timer captured host-submit time only — xpu kernels were
-        still running when the timer stopped, artificially deflating
-        the reported wall.
-
-        Fix: treat cuda and xpu the same — both go through the
+        Treat cuda and xpu the same — both go through the
         ``Timer.adaptive_autorange`` path, both sync their GPU inside
         the stmt.  The cpu branch keeps the plain ``timeit.timeit``
         path.  Return value is ``result.median * iters`` (matching

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -213,18 +213,18 @@ class PyTorchOperatorTestCase:
         )
         return compiled_forward_consume
 
-    def run_jit_forward(self, num_runs, print_per_iter=False, cuda_sync=False):
+    def run_jit_forward(self, num_runs, print_per_iter=False, gpu_sync=False):
         """Run the forward path of an op with JIT mode"""
         if self._jit_forward_graph is None:
             self._jit_forward_graph = self._generate_jit_forward_graph()
         self._jit_forward_graph(num_runs)
 
-    def run_compile_forward(self, num_runs, print_per_iter=False, cuda_sync=False):
+    def run_compile_forward(self, num_runs, print_per_iter=False, gpu_sync=False):
         """Run the forward path of an op with compile mode"""
         if self._compile_forward_graph is None:
             self._compile_forward_graph = self._generate_compile_forward_graph()
         self._compile_forward_graph(num_runs)
-        if cuda_sync:
+        if gpu_sync:
             # Despite the legacy parameter name, sync the device that
             # actually holds the inputs (cuda or xpu).  See the note
             # in benchmark_core._launch_forward.
@@ -246,20 +246,20 @@ class PyTorchOperatorTestCase:
                 )
             )
 
-    def run_forward(self, num_runs, print_per_iter, cuda_sync):
+    def run_forward(self, num_runs, print_per_iter, gpu_sync):
         """Run the forward path of an op with eager mode"""
         if print_per_iter:
             for _ in range(num_runs):
                 start_time = time.time()
                 self.output = self.op_bench.forward_impl_eager()
-                if cuda_sync:
+                if gpu_sync:
                     _sync_current_device(self.op_bench.inputs)
                 end_time = time.time()
                 self.time_series.append((end_time - start_time) * 1e3)
         else:
             for _ in range(num_runs):
                 self.output = self.op_bench.forward_impl_eager()
-            if cuda_sync:
+            if gpu_sync:
                 _sync_current_device(self.op_bench.inputs)
 
     def _output_mean(self):
@@ -272,12 +272,12 @@ class PyTorchOperatorTestCase:
         """
         self.mean = self.output.mean()
 
-    def run_backward(self, num_runs, print_per_iter=False, cuda_sync=False):
+    def run_backward(self, num_runs, print_per_iter=False, gpu_sync=False):
         """Run the backward path of an op in many iterations"""
         # TODO: can we use JIT here to reduce python overhead?
         for _ in range(num_runs):
             self.mean.backward(retain_graph=True)
-        if cuda_sync:
+        if gpu_sync:
             torch.cuda.synchronize()
 
 

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -20,6 +20,31 @@ microbenchmarks.
 """
 
 
+def _sync_current_device(inputs):
+    """Sync whichever GPU device the benchmark's inputs live on.
+
+    The benchmark harness historically only called
+    ``torch.cuda.synchronize()``, which meant xpu runs never actually
+    waited for the GPU before stopping the timer — the reported wall
+    captured host submit time only.  This helper picks the right sync
+    based on the device of one of the input tensors.
+    """
+    if isinstance(inputs, dict):
+        it = iter(inputs.values())
+    else:
+        it = iter(inputs or [])
+    for v in it:
+        if isinstance(v, torch.Tensor):
+            dev = v.device.type
+            if dev == "cuda":
+                torch.cuda.synchronize(torch.cuda.current_device())
+            elif dev == "xpu":
+                torch.xpu.synchronize(torch.xpu.current_device())
+            return
+    # no tensor inputs — nothing to sync
+    return
+
+
 class TorchBenchmarkBase(torch.nn.Module):
     """This is a base class used to create Pytorch operator benchmark.
     module_name is the name of the operator being benchmarked.
@@ -200,7 +225,10 @@ class PyTorchOperatorTestCase:
             self._compile_forward_graph = self._generate_compile_forward_graph()
         self._compile_forward_graph(num_runs)
         if cuda_sync:
-            torch.cuda.synchronize(torch.cuda.current_device())
+            # Despite the legacy parameter name, sync the device that
+            # actually holds the inputs (cuda or xpu).  See the note
+            # in benchmark_core._launch_forward.
+            _sync_current_device(self.op_bench.inputs)
 
     def _print_per_iter(self):
         # print last 50 values
@@ -225,14 +253,14 @@ class PyTorchOperatorTestCase:
                 start_time = time.time()
                 self.output = self.op_bench.forward_impl_eager()
                 if cuda_sync:
-                    torch.cuda.synchronize(torch.cuda.current_device())
+                    _sync_current_device(self.op_bench.inputs)
                 end_time = time.time()
                 self.time_series.append((end_time - start_time) * 1e3)
         else:
             for _ in range(num_runs):
                 self.output = self.op_bench.forward_impl_eager()
             if cuda_sync:
-                torch.cuda.synchronize(torch.cuda.current_device())
+                _sync_current_device(self.op_bench.inputs)
 
     def _output_mean(self):
         """TODO (mingzhe): it is not necessary to sum up everything by myself,

--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -20,31 +20,6 @@ microbenchmarks.
 """
 
 
-def _sync_current_device(inputs):
-    """Sync whichever GPU device the benchmark's inputs live on.
-
-    The benchmark harness historically only called
-    ``torch.cuda.synchronize()``, which meant xpu runs never actually
-    waited for the GPU before stopping the timer — the reported wall
-    captured host submit time only.  This helper picks the right sync
-    based on the device of one of the input tensors.
-    """
-    if isinstance(inputs, dict):
-        it = iter(inputs.values())
-    else:
-        it = iter(inputs or [])
-    for v in it:
-        if isinstance(v, torch.Tensor):
-            dev = v.device.type
-            if dev == "cuda":
-                torch.cuda.synchronize(torch.cuda.current_device())
-            elif dev == "xpu":
-                torch.xpu.synchronize(torch.xpu.current_device())
-            return
-    # no tensor inputs — nothing to sync
-    return
-
-
 class TorchBenchmarkBase(torch.nn.Module):
     """This is a base class used to create Pytorch operator benchmark.
     module_name is the name of the operator being benchmarked.
@@ -225,10 +200,7 @@ class PyTorchOperatorTestCase:
             self._compile_forward_graph = self._generate_compile_forward_graph()
         self._compile_forward_graph(num_runs)
         if gpu_sync:
-            # Despite the legacy parameter name, sync the device that
-            # actually holds the inputs (cuda or xpu).  See the note
-            # in benchmark_core._launch_forward.
-            _sync_current_device(self.op_bench.inputs)
+            torch.accelerator.synchronize()
 
     def _print_per_iter(self):
         # print last 50 values
@@ -253,14 +225,14 @@ class PyTorchOperatorTestCase:
                 start_time = time.time()
                 self.output = self.op_bench.forward_impl_eager()
                 if gpu_sync:
-                    _sync_current_device(self.op_bench.inputs)
+                    torch.accelerator.synchronize()
                 end_time = time.time()
                 self.time_series.append((end_time - start_time) * 1e3)
         else:
             for _ in range(num_runs):
                 self.output = self.op_bench.forward_impl_eager()
             if gpu_sync:
-                _sync_current_device(self.op_bench.inputs)
+                torch.accelerator.synchronize()
 
     def _output_mean(self):
         """TODO (mingzhe): it is not necessary to sum up everything by myself,
@@ -278,7 +250,7 @@ class PyTorchOperatorTestCase:
         for _ in range(num_runs):
             self.mean.backward(retain_graph=True)
         if gpu_sync:
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
 
 
 def create_pytorch_op_test_case(op_bench, test_config):

--- a/benchmarks/operator_benchmark/benchmark_utils.py
+++ b/benchmarks/operator_benchmark/benchmark_utils.py
@@ -14,7 +14,7 @@ This module contains utilities for writing microbenchmark tests.
 
 # Here are the reserved keywords in the benchmark suite
 _reserved_keywords = {"probs", "total_samples", "tags"}
-_supported_devices = {"cpu", "cuda", "mps"}
+_supported_devices = {"cpu", "cuda", "mps", "xpu"}
 
 
 def shape_to_string(shape):

--- a/benchmarks/operator_benchmark/pt/addmm_test.py
+++ b/benchmarks/operator_benchmark/pt/addmm_test.py
@@ -10,7 +10,7 @@ addmm_long_configs = op_bench.cross_product_configs(
     M=[256, 1024, 3000],
     N=[512, 4096],
     K=[512, 4096],
-    device=["cuda"],
+    device=["cuda", "xpu"],
     tags=["long"],
     dtype=[torch.float16, torch.bfloat16, torch.float32],
 )
@@ -24,7 +24,7 @@ addmm_short_configs = op_bench.config_list(
         [64, 64, 128],
     ],
     cross_product_configs={
-        "device": ["cpu", "cuda"],
+        "device": ["cpu", "cuda", "xpu"],
         "dtype": [torch.float],
     },
     tags=["short"],
@@ -132,7 +132,7 @@ addbmm_long_configs = op_bench.cross_product_configs(
     M=[256, 1024],
     N=[256, 1024],
     K=[64, 128],
-    device=["cuda"],
+    device=["cuda", "xpu"],
     dtype=[torch.float16, torch.bfloat16, torch.float32],
     tags=["long"],
 )
@@ -141,7 +141,7 @@ addbmm_short_configs = op_bench.cross_product_configs(
     M=[8, 128],
     N=[32, 64],
     K=[256, 512],
-    device=["cpu", "cuda"],
+    device=["cpu", "cuda", "xpu"],
     dtype=[torch.float16, torch.bfloat16, torch.float32],
     tags=["short"],
 )

--- a/benchmarks/operator_benchmark/pt/configs.py
+++ b/benchmarks/operator_benchmark/pt/configs.py
@@ -26,7 +26,7 @@ conv_1d_configs_short = op_bench.config_list(
         [256, 256, 3, 2, 4, 64],
     ],
     cross_product_configs={
-        "device": ["cpu", "cuda"],
+        "device": ["cpu", "cuda", "xpu"],
     },
     tags=["short"],
 )
@@ -38,7 +38,7 @@ conv_1d_configs_long = op_bench.cross_product_configs(
     stride=[1, 2],
     N=[8],
     L=[128],
-    device=["cpu", "cuda"],
+    device=["cpu", "cuda", "xpu"],
     tags=["long"],
 )
 
@@ -48,7 +48,7 @@ convtranspose_1d_configs_short = op_bench.config_list(
         [2016, 1026, 1024, 256, 1, 224],
     ],
     cross_product_configs={
-        "device": ["cpu", "cuda"],
+        "device": ["cpu", "cuda", "xpu"],
     },
     tags=["short"],
 )
@@ -70,7 +70,7 @@ conv_2d_configs_short = op_bench.config_list(
         [256, 256, 3, 1, 1, 16, 16, 1, 0],
     ],
     cross_product_configs={
-        "device": ["cpu", "cuda"],
+        "device": ["cpu", "cuda", "xpu"],
     },
     tags=["short"],
 )
@@ -85,7 +85,7 @@ conv_2d_configs_long = op_bench.cross_product_configs(
     W=[32],
     G=[1],
     pad=[0],
-    device=["cpu", "cuda"],
+    device=["cpu", "cuda", "xpu"],
     tags=["long"],
 )
 
@@ -105,7 +105,7 @@ conv_2d_pw_configs_short = op_bench.config_list(
         [256, 256, 1, 1, 16, 16, 1, 0],
     ],
     cross_product_configs={
-        "device": ["cpu", "cuda"],
+        "device": ["cpu", "cuda", "xpu"],
     },
     tags=["short"],
 )
@@ -119,7 +119,7 @@ conv_2d_pw_configs_long = op_bench.cross_product_configs(
     W=[32],
     G=[1],
     pad=[0],
-    device=["cpu", "cuda"],
+    device=["cpu", "cuda", "xpu"],
     tags=["long"],
 )
 
@@ -130,7 +130,7 @@ conv_3d_configs_short = op_bench.config_list(
         [64, 64, 3, 1, 8, 4, 16, 16],
     ],
     cross_product_configs={
-        "device": ["cpu", "cuda"],
+        "device": ["cpu", "cuda", "xpu"],
         "dtype": [torch.float32],
     },
     tags=["short"],
@@ -144,7 +144,7 @@ conv_3d_configs_long = op_bench.cross_product_configs(
     D=[128],
     H=[128],
     W=[128],
-    device=["cpu", "cuda"],
+    device=["cpu", "cuda", "xpu"],
     dtype=[torch.float32, torch.float16, torch.bfloat16],
     tags=["long"],
 )
@@ -157,7 +157,7 @@ linear_configs_short = op_bench.config_list(
         [16, 512, 256],
     ],
     cross_product_configs={
-        "device": ["cpu", "cuda"],
+        "device": ["cpu", "cuda", "xpu"],
     },
     tags=["short"],
 )

--- a/benchmarks/operator_benchmark/pt/matmul_test.py
+++ b/benchmarks/operator_benchmark/pt/matmul_test.py
@@ -13,7 +13,7 @@ mm_short_configs = op_bench.config_list(
         [128, 128, 128, True, False],
         [256, 256, 256, False, True],
     ],
-    cross_product_configs={"device": ["cpu", "cuda"]},
+    cross_product_configs={"device": ["cpu", "cuda", "xpu"]},
     tags=["short"],
 )
 
@@ -24,7 +24,7 @@ mm_long_configs = op_bench.cross_product_configs(
     K=[512, 4096],
     trans_a=[False, True],
     trans_b=[True, False],
-    device=["cuda"],
+    device=["cuda", "xpu"],
     dtype=[torch.float16, torch.bfloat16, torch.float32],
     tags=["long"],
 )


### PR DESCRIPTION
The patch will make the following operator benchmark work.  
```
cd benchmarks/operator_benchmark/pt_extension
python -m pip install . -v --no-build-isolation
cd ..
python -m pt.matmul_test --device xpu --warmup-iterations 10 --iterations 10 --output-csv results_matmul.csv
python -m pt.addmm_test --device xpu --warmup-iterations 10 --iterations 10 --output-csv results_addmm.csv
python -m pt.conv_test --device xpu --warmup-iterations 10 --iterations 10 --output-csv results_conv.csv
```

 Signed-off-by: Sun, Chenwei <chenwei.sun@intel.com>
