### PR TITLE
[AMD][PyTorch] Reland: Redirect index_add_ to scatter_add_ on HIP for large tensors (#181955)

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1533,6 +1533,27 @@ void index_reduce_func_cuda_impl(
 
 TORCH_IMPL_FUNC(index_add_cuda_out)
 (const Tensor& self, int64_t dim, const Tensor& index, const Tensor& source, const Scalar& alpha, const Tensor& result) {
+#if defined(__HIP_PLATFORM_AMD__)
+  // On AMD MI350X, scatter_add_ outperforms the indexFuncLargeIndex
+  // atomicAdd path across all measured source sizes (>=1.0x at 1K rising
+  // to ~2x for uniform / ~5x for Zipf-distributed indices). Always
+  // redirect for the matching shape; see bench_index_add_powerlaw.py.
+  // When deterministicAlgorithms() is enabled, fall through to
+  // index_add_cuda_impl so its index_put_ deterministic path is honored —
+  // scatter_add_ on HIP uses non-deterministic atomicAdd.
+  if (alpha.equal(1) && dim == 0 && self.dim() == 2 &&
+      !globalContext().deterministicAlgorithms()) {
+    // Mirror index_add_cuda_impl's structured-kernel pre-copy: for
+    // out-of-place / index_add(out=...) the result is uninitialized
+    // and must be seeded with self before accumulating.
+    if (!result.is_same(self)) {
+      result.copy_(self);
+    }
+    auto expanded_index = index.to(at::kLong).unsqueeze(1).expand_as(source);
+    result.scatter_add_(dim, expanded_index, source);
+    return;
+  }
+#endif
   index_add_cuda_impl(self, dim, index, source, alpha, result);
 }
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_device_type import (
     expectedFailureMPS,
     instantiate_device_type_tests,
     onlyCPU,
+    onlyCUDA,
     onlyNativeDeviceTypes,
     onlyOn,
     skipMPS,
@@ -2125,6 +2126,174 @@ class TestIndexing(TestCase):
             100,
             "3D vec4 sliceSize=128",
         )
+
+    @onlyCUDA
+    @dtypes(torch.float, torch.bfloat16, torch.half)
+    def test_index_add_correctness_2d_large(self, device, dtype):
+        # Correctness for the path used on HIP when index_add_ is redirected
+        # to scatter_add_ (alpha=1, dim=0, 2D). Uses duplicate indices
+        # (200K src into 1K dest) to stress-test atomic accumulation.
+        # On NVIDIA CUDA this exercises the original index_add_ kernel and
+        # is still useful coverage. Selection is verified separately by
+        # test_index_add_redirect_kernel_selection_hip.
+        num_dest, dim = 1000, 64
+        num_src = 200_000
+
+        idx = torch.randint(0, num_dest, (num_src,), device=device, dtype=torch.int64)
+        src = torch.randn(num_src, dim, dtype=dtype, device=device)
+        dst = torch.zeros(num_dest, dim, dtype=dtype, device=device)
+
+        # Reference on CPU in float32
+        dst_ref = torch.zeros(num_dest, dim, dtype=torch.float32)
+        dst_ref.index_add_(0, idx.cpu(), src.cpu().float())
+
+        dst.index_add_(0, idx, src)
+
+        # ~200 atomicAdds per row vs sequential CPU sum: bf16/fp16 accumulate
+        # rounding error up to several tenths in worst-case elements (use L2
+        # relative error to avoid outlier flakes); fp32 atomic-add ordering
+        # gives ~1e-4 max-abs deviation from a CPU sequential reference.
+        if dtype in (torch.bfloat16, torch.half):
+            err = (dst.cpu().float() - dst_ref).norm().item()
+            ref_norm = max(dst_ref.norm().item(), 1e-8)
+            self.assertLess(
+                err / ref_norm,
+                5e-2,
+                f"index_add_ {dtype} L2 rel err too high: {err / ref_norm}",
+            )
+        else:
+            self.assertEqual(
+                dst.cpu(),
+                dst_ref,
+                atol=1e-3,
+                rtol=1e-3,
+                msg=f"index_add_ correctness failed for {dtype}",
+            )
+
+    @onlyCUDA
+    @dtypes(torch.float, torch.bfloat16)
+    def test_index_add_correctness_2d_out_of_place(self, device, dtype):
+        # Regression test: torch.index_add (out-of-place) and
+        # torch.index_add(..., out=) hit the same TORCH_IMPL_FUNC as the
+        # in-place variant via structured_delegate. The HIP redirect must
+        # seed `result` with self before scattering, otherwise out-of-place
+        # accumulates into uninitialized memory.
+        num_dest, dim, num_src = 200, 32, 5000
+
+        idx = torch.randint(0, num_dest, (num_src,), device=device, dtype=torch.int64)
+        src = torch.randn(num_src, dim, dtype=dtype, device=device)
+        self_ = torch.randn(num_dest, dim, dtype=dtype, device=device)
+
+        # Reference: CPU fp32 in-place starting from self
+        ref = self_.cpu().float().clone()
+        ref.index_add_(0, idx.cpu(), src.cpu().float())
+
+        # Functional out-of-place: returns a fresh tensor.
+        out_func = torch.index_add(self_, 0, idx, src)
+        # Out-explicit: caller-provided destination tensor.
+        out_explicit = torch.empty_like(self_)
+        torch.index_add(self_, 0, idx, src, out=out_explicit)
+
+        if dtype == torch.bfloat16:
+            # ~25 atomicAdds per dest row on NVIDIA's index_add_ kernel
+            # produce per-element rounding too large for max-abs tolerance;
+            # use L2 relative error like test_index_add_correctness_2d_large.
+            ref_norm = max(ref.norm().item(), 1e-8)
+            err_func = (out_func.cpu().float() - ref).norm().item() / ref_norm
+            err_explicit = (out_explicit.cpu().float() - ref).norm().item() / ref_norm
+            self.assertLess(err_func, 5e-2, f"bf16 functional L2 rel err: {err_func}")
+            self.assertLess(err_explicit, 5e-2, f"bf16 out= L2 rel err: {err_explicit}")
+        else:
+            self.assertEqual(out_func.cpu().float(), ref, atol=1e-3, rtol=1e-3)
+            self.assertEqual(out_explicit.cpu().float(), ref, atol=1e-3, rtol=1e-3)
+        # self must be untouched by out-of-place form.
+        self.assertFalse(out_func.data_ptr() == self_.data_ptr())
+
+    @onlyCUDA
+    def test_index_add_correctness_2d_alpha(self, device):
+        # Correctness with alpha != 1, which bypasses the HIP redirect and
+        # always hits index_add_'s native alpha-scaling path on both HIP
+        # and CUDA.
+        num_dest, dim = 100, 32
+        num_src = 200_000
+        idx = torch.randint(0, num_dest, (num_src,), device=device, dtype=torch.int64)
+        src = torch.randn(num_src, dim, dtype=torch.float32, device=device)
+        dst = torch.zeros(num_dest, dim, dtype=torch.float32, device=device)
+
+        dst_ref = torch.zeros(num_dest, dim, dtype=torch.float32)
+        dst_ref.index_add_(0, idx.cpu(), src.cpu(), alpha=2.0)
+
+        dst.index_add_(0, idx, src, alpha=2.0)
+        # ~2000 atomic adds per dest row in fp32: ordering produces ~1e-4
+        # per-element deviation from a CPU sequential reference.
+        self.assertEqual(dst.cpu(), dst_ref, atol=1e-3, rtol=1e-3)
+
+    @onlyCUDA
+    def test_index_add_redirect_kernel_selection_hip(self, device):
+        # Verify the HIP-only redirect actually fires for matching cases
+        # and does NOT fire for any unmet condition. The redirect calls
+        # scatter_add_ from inside the index_add_ implementation, which
+        # surfaces in the profiler as an aten::scatter_add_ event nested
+        # under aten::index_add_. CUDA (NVIDIA) has no redirect.
+        if not torch.version.hip:
+            raise unittest.SkipTest("redirect is HIP-only")
+
+        n_dest, dim, n_src = 100, 32, 1024
+        idx = torch.randint(0, n_dest, (n_src,), device=device, dtype=torch.int64)
+
+        def saw_scatter_add(fn):
+            with torch.profiler.profile(
+                activities=[torch.profiler.ProfilerActivity.CPU]
+            ) as prof:
+                fn()
+                torch.cuda.synchronize()
+            return any(e.name == "aten::scatter_add_" for e in prof.events())
+
+        # 1. Conditions met (alpha=1, dim=0, 2D): redirect MUST fire.
+        dst = torch.zeros(n_dest, dim, dtype=torch.float32, device=device)
+        src = torch.randn(n_src, dim, dtype=torch.float32, device=device)
+        self.assertTrue(
+            saw_scatter_add(lambda: dst.index_add_(0, idx, src)),
+            "redirect should fire when alpha=1, dim=0, 2D",
+        )
+
+        # 2. alpha != 1 -> bypass.
+        self.assertFalse(
+            saw_scatter_add(lambda: dst.index_add_(0, idx, src, alpha=2.0)),
+            "alpha != 1 must bypass redirect",
+        )
+
+        # 3. dim != 0 -> bypass.
+        dst_t = torch.zeros(dim, n_dest, dtype=torch.float32, device=device)
+        src_t = torch.randn(dim, n_src, dtype=torch.float32, device=device)
+        self.assertFalse(
+            saw_scatter_add(lambda: dst_t.index_add_(1, idx, src_t)),
+            "dim != 0 must bypass redirect",
+        )
+
+        # 4. 1D tensor -> bypass (self.dim() != 2).
+        dst_1d = torch.zeros(n_dest, dtype=torch.float32, device=device)
+        src_1d = torch.randn(n_src, dtype=torch.float32, device=device)
+        self.assertFalse(
+            saw_scatter_add(lambda: dst_1d.index_add_(0, idx, src_1d)),
+            "1D tensor must bypass redirect",
+        )
+
+        # 5. 3D tensor -> bypass (self.dim() != 2).
+        dst_3d = torch.zeros(n_dest, dim, 4, dtype=torch.float32, device=device)
+        src_3d = torch.randn(n_src, dim, 4, dtype=torch.float32, device=device)
+        self.assertFalse(
+            saw_scatter_add(lambda: dst_3d.index_add_(0, idx, src_3d)),
+            "3D tensor must bypass redirect",
+        )
+
+        # 6. deterministicAlgorithms() enabled -> bypass; index_add_cuda_impl
+        # uses index_put_ for determinism, which scatter_add_ would break.
+        with DeterministicGuard(True):
+            self.assertFalse(
+                saw_scatter_add(lambda: dst.index_add_(0, idx, src)),
+                "deterministic mode must bypass redirect",
+            )
 
     @onlyNativeDeviceTypes
     @expectedFailureMPS  # See https://github.com/pytorch/pytorch/issues/161029


### PR DESCRIPTION
Summary:

Reland of D100635529 (https://github.com/pytorch/pytorch/pull/180430), which was reverted in D103039749 because the new bf16 path of `test_index_add_correctness_2d_out_of_place` failed on NVIDIA OSS CI. ngimel pointed out that with `num_dest=200, num_src=5000` (~25 atomic adds per destination row), the per-element rounding from NVIDIA's `index_add_` kernel exceeds the original `atol=5e-2` max-abs tolerance — exactly the rounding behavior expected for bf16 atomics under contention. Local repro on H100 confirmed the same failure (max abs diff ~0.39 vs 0.05 allowed) and showed that two more nearby tests (`test_index_add_correctness_2d_large` and `test_index_add_correctness_2d_alpha`) had similarly tight tolerances that fail on NVIDIA when the high-contention atomic-add ordering diverges from the CPU sequential reference.

All AMD-side changes from D100635529 are restored — the HIP-only `index_add_ → scatter_add_` redirect in `Indexing.cu` and the new `scripts/haoyuz/amd/index_add/` benchmark + standalone test. The only difference vs the reverted version is in the three new tests in `caffe2/test/test_indexing.py` that compare a high-contention GPU result against a CPU fp32 sequential reference. Per-element max-abs/rel tolerances are replaced with bounds that reflect the actual atomic-add accumulation noise: bf16/fp16 use L2 relative error with a 5e-2 ceiling (measured 0.017 worst-case), and fp32 uses atol=rtol=1e-3 (measured 1.3e-5 to 1.8e-4 worst-case). The HIP redirect itself is unchanged and the AMD MI350X performance numbers (4.8x speedup on Zipf alpha=1.5) still hold.

[PR #146264](https://github.com/pytorch/pytorch/pull/146264) has more details on `scatter_add` optimizations for AMD MI300 / MI350 GPUs.

Co-authored-by: Claude

Test Plan:
On NVIDIA H100 (devvm2464), all six new index_add CUDA tests pass, and the broader `TestIndexing` suite is clean:

```
PYTORCH_TEST_REMOTE_GPU=1 .../test_others_cuda.par -r 'index_add_correctness'
test_index_add_correctness_2d_alpha_cuda                       ... ok
test_index_add_correctness_2d_large_cuda_bfloat16              ... ok
test_index_add_correctness_2d_large_cuda_float16               ... ok
test_index_add_correctness_2d_large_cuda_float32               ... ok
test_index_add_correctness_2d_out_of_place_cuda_bfloat16       ... ok
test_index_add_correctness_2d_out_of_place_cuda_float32        ... ok
Ran 6 tests in 0.139s

PYTORCH_TEST_REMOTE_GPU=1 .../test_others_cuda.par -r 'TestIndexing'
Ran 176 tests in 8.290s
OK (skipped=1)
```

Confirmed the fix actually addresses the original failure: with the prior tolerances re-applied, `test_index_add_correctness_2d_out_of_place_cuda_bfloat16` reproduces the exact OSS CI failure on H100 (Mismatched elements: 54 / 6400, greatest absolute difference: 0.3878 vs 0.05 allowed).

The pre-existing AMD MI350X benchmarks and standalone tests from D100635529 are unchanged.

Reverted-by: D103039749

Reviewed By: echen4096

Differential Revision: D103100245


