### PR TITLE
[inductor][CI] Call gc.collect only for aten.mm.out

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -11813,10 +11813,10 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                         nonlocal test_self
                         nonlocal matmul_seen
 
-                        # by matmul, inputs should be deallocated
-                        # TODO: should not be necessary, ref-cycle ?
-                        gc.collect()
                         if func is aten.mm.out:
+                            # by matmul, inputs should be deallocated
+                            # TODO: should not be necessary, ref-cycle ?
+                            gc.collect()
                             matmul_seen = True
                             test_self.assertEqual(len(inps), 0)
                             test_self.assertIsNone(inp_refs[0]())


### PR DESCRIPTION
This PR moves `gc.collect()` from the unconditional dispatch path into the `if func is aten.mm.out:` branch, where the assertions about input deallocation actually run. The behavior at the assertion point is unchanged: a single `gc.collect()` still fires before `len(inps) == 0` / `inp_refs[i]() is None` are checked. The redundant collects on every unrelated dispatch — which were doing no useful work for the assertions — are removed.

## Why this is safe (vs. reintroducing #106299)

Issue [#106299](https://github.com/pytorch/pytorch/issues/106299) was fixed in e61558b5 by adding the per-dispatch `gc.collect()`. The author noted *"I suspect their was a refcycle introduced which is making it flakey"* — the cycle was suspected, not pinpointed.

I confirmed the cycle is still present on current main: with `gc` disabled and no explicit `gc.collect()`, the input weakrefs are not `None` at `mm.out` time. The cycle is rooted in Inductor's `GraphLowering` / FX `env`, which retains the input tensors as graph node values. So a cycle break is genuinely needed for the assertions to hold.

This PR keeps that cycle break. Both the original code and this PR run exactly one `gc.collect()` on entry to the `mm.out`
dispatch, before the assertions:

- **Before:** `gc.collect()` runs on every dispatch (including `mm.out`); assertions run inside the `mm.out` branch immediately after.
- **After:** `gc.collect()` runs inside the `mm.out` branch immediately before the assertions.

The only `gc.collect()` calls removed are the ones on dispatches *other* than `mm.out` — none of which are load-bearing for the assertion outcome, since the cycle (if formed by an intermediate dispatch) is still broken on entry to `mm.out` before the assertions check.

## Validation

On a gfx90a (MI250X) host, HEAD `8804b122355`, fresh cache:

| Setup | `test_list_clearing` | `test_graph_partition_refcount` |
|---|---|---|
| Before (CI samples) | 86–922s | 86–922s |
| After (this PR, full `DynamicShapesGPUTests` class run) | 5.5s | 5.5s |

Full-class run: **927 passed, 45 skipped, 1 xfailed, 0 failed in 33:24** — slowest test in the class is now
`test_batch_norm_2d_2` at 17.5s.

Stress test: **200 / 200 passed** (100 fresh-process invocations of each test, with cache cleaned between invocations) — zero
flakes against the assertion the original `gc.collect()` was guarding.

## Follow-ups (out of scope here)

- The underlying cycle in Inductor's `GraphLowering` / FX `env` retaining inputs is real. Fixing it at source would let both
`gc.collect()` calls be removed entirely. That's a bigger refactor and unrelated to this test fix.
- The `# TODO: should not be necessary, ref-cycle ?` comment is preserved (relocated) since the underlying cycle is still there.

Co-authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo