### PR TITLE
Fix typos in comments, docstrings, and documentation

### DIFF
--- a/torch/_inductor/analysis/README.md
+++ b/torch/_inductor/analysis/README.md
@@ -2,7 +2,7 @@
 Contains scripts for inductor performance analysis.
 
 ## Analysis
-This will analyze a chrome trace to create a table useful for performance work. We mainly care about . Currently, it will add the flops and the memory reads of a kernel via formula (it's not looking at program counters or anything.) These, combined with the kernel duration, can be use to calculate achieved flops, achieved memory bandwidth, and roofline calculations.
+This will analyze a chrome trace to create a table useful for performance work. We mainly care about . Currently, it will add the flops and the memory reads of a kernel via formula (it's not looking at program counters or anything.) These, combined with the kernel duration, can be used to calculate achieved flops, achieved memory bandwidth, and roofline calculations.
 
 ### Usage
 ```
@@ -28,7 +28,7 @@ python profile_analysis.py --diff <json_profile_1> <profile_name_1> <json_profil
  - `name_limit`: The maximum number of characters in the kernel name (they can be quite lengthy and hard to read).
 
 ## Augment
-This mode will add post-hoc analysis to a profile. Currently, it will add the flops and the memory reads of a kernel via formula (it's not looking at program counters or anything.) These, combined with the kernel duration, can be use to calculate achieved flops, achieved memory bandwidth, and roofline calculations.
+This mode will add post-hoc analysis to a profile. Currently, it will add the flops and the memory reads of a kernel via formula (it's not looking at program counters or anything.) These, combined with the kernel duration, can be used to calculate achieved flops, achieved memory bandwidth, and roofline calculations.
 
 ### Usage
 ```

--- a/torch/_inductor/fx_passes/quantization.py
+++ b/torch/_inductor/fx_passes/quantization.py
@@ -1212,7 +1212,7 @@ def _register_concat_linear_int8_woq_lowering(
         # Some other pass is making some changes that entails
         # adding a node before it's used, but it can only be found when
         # lint is run. stable_topological_sort() is being run before lint,
-        # so that error was not being being discovered.
+        # so that error was not being discovered.
         # We call stable_topological_sort here as a workaround.
         stable_topological_sort(match.graph)
         with match.graph.inserting_before(user_of_scaling_node):

--- a/torch/csrc/jit/frontend/parser.cpp
+++ b/torch/csrc/jit/frontend/parser.cpp
@@ -310,8 +310,8 @@ struct ParserImpl {
 
       if (kind == TK_FOR) {
         // TK_FOR targets should only parse exprs prec greater than 4, which
-        // only includes subset of Exprs that suppose to be on the LHS according
-        // to the python grammar
+        // only includes subset of Exprs that are supposed to be on the LHS
+        // according to the python grammar
         // https://docs.python.org/3/reference/grammar.html
         auto target = parseLHSExp();
         L.expect(TK_IN);

--- a/torch/csrc/jit/passes/integer_value_refinement.cpp
+++ b/torch/csrc/jit/passes/integer_value_refinement.cpp
@@ -60,7 +60,7 @@ struct IntegerValueRefiner {
     // same value, which opens up further optimization opportunities. The pass
     // will already handle if both outputs are refined to the same constant.
     // Here, we look for cases where one block output has been refined in the
-    // other block to be equal to the same constant value as the other other
+    // other block to be equal to the same constant value as the other
     // block output:
     //  graph(%y.1 : int):
     //   %one_constant : int = prim::Constant[value=1]()

--- a/torch/csrc/utils/schema_info.cpp
+++ b/torch/csrc/utils/schema_info.cpp
@@ -275,9 +275,9 @@ std::vector<c10::FunctionSchema> SchemaInfo::getNonDeterministicOps() {
 
 std::vector<SchemaSpecialCasePair> SchemaInfo::getTrainingOps() {
   // This is a list of pairs of ops to sets of strings
-  //  where the a boolean variable (either "training",
+  //  where a boolean variable (either "training",
   // "train" or "use_input_stats") affects the mutability
-  // of the unorderered set of strings.
+  // of the unordered set of strings.
   static const std::vector<std::pair<std::string, std::unordered_set<std::string>>> training_op_pairs =
       {{"aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
         {"running_mean", "running_var"}},

--- a/torch/distributed/_state_dict_utils.py
+++ b/torch/distributed/_state_dict_utils.py
@@ -494,7 +494,7 @@ def _check_state_dict_similarity(
     """
     Given two state_dicts, check if the structures are the same. And
     if a [key, tensor] pair exist in one state_dict there must be
-    the a corresponding pait, [key, other_tensor], in the other state_dict,
+    a corresponding pair, [key, other_tensor], in the other state_dict,
     where tensor and other_tensor have the same size and dtype.
 
     Return the check result.

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -763,7 +763,7 @@ def retrieve_result_from_completion_queue(
         if timeout is not None:
             elapsed = time.time() - start_time
             if elapsed > timeout:
-                return RuntimeError(f"Process timed out out after {elapsed}s")
+                return RuntimeError(f"Process timed out after {elapsed}s")
 
 
 # Most tests operate with this worldsize

--- a/torch/testing/_internal/common_pruning.py
+++ b/torch/testing/_internal/common_pruning.py
@@ -118,7 +118,7 @@ class LinearActivation(nn.Module):
 class LinearActivationFunctional(nn.Module):
     r"""Model with only Linear layers, some with bias, some in a Sequential and some following.
     Activation functions modules in between each Linear in the Sequential, and functional
-    activationals are called in between each outside layer.
+    activations are called in between each outside layer.
     Used to test pruned Linear(Bias)-Activation-Linear fusion."""
 
     def __init__(self) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181966

Correct duplicated words ("being being", "timed out out", "other other"),
fix grammatical errors ("can be use" → "can be used", "suppose to be" →
"are supposed to be"), and fix misspellings ("unorderered" → "unordered",
"pait" → "pair", "activationals" → "activations").

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo