### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_decode.py.jinja
@@ -119,7 +119,7 @@
 
     # Make sure each split is a multiple of BLOCK_N
     if HAS_FULL_BLOCKS:
-        # TODO do the a optimization as partial blocks once vllm is
+        # TODO do the optimization as partial blocks once vllm is
         # able to pass in full blocks:
         # https://github.com/vllm-project/vllm/blob/61249b177de1566027fc74e9b51b45a4c973eb47/vllm/v1/attention/backends/flex_attention.py#L615-L616
         TILE_KV_OG = tl.cdiv(KV_LEN, SPLIT_KV)
@@ -128,7 +128,7 @@
     TILE_KV = tl.cdiv(TILE_KV_OG, BLOCK_N) * BLOCK_N
     TILE_KV_MULTIPLE: tl.constexpr = (TILE_KV // BLOCK_N)
 
-    # Calculate KV blocks that belong this CTA.
+    # Calculate KV blocks that belong to this CTA.
     block_n_start = off_t * TILE_KV_MULTIPLE                        # n_offset inside sparse block
     block_n_end = block_n_start + TILE_KV_MULTIPLE                  # end BLOCK_N
 

--- a/torch/_python_dispatcher.py
+++ b/torch/_python_dispatcher.py
@@ -8,7 +8,7 @@ import torch._C as C
 PythonDispatcher class is a thin python-binding to C++ dispatcher and it
 is designed to show how dispatcher precompute works. In particular,
 it shows for a certain op `foo`, what the computed dispatch table looks
-like after user register their kernels to certains dispatch keys.
+like after user register their kernels to certain dispatch keys.
 
 In the real C++ dispatcher we support many dispatch keys for different
 functionalities. For simplicity PythonDispatcher only supports dispatch
@@ -46,7 +46,7 @@ Usage:
   # print(dispatcher.registrations())
   # print(dispatcher.rawRegistrations())
   # print(dispatcher.rawDispatchTable())
-PythonDispatcher calls C++ dispatcher under the hood for to precompute dispatch table.
+PythonDispatcher calls C++ dispatcher under the hood to precompute dispatch table.
 This file only provides the simplified API for developers, relevant test code is located in
 test/test_dispatch.py
 """

--- a/torch/fx/experimental/_config.py
+++ b/torch/fx/experimental/_config.py
@@ -30,7 +30,7 @@ translation_validation_no_bisect = (
     os.environ.get("TORCHDYNAMO_TRANSLATION_NO_BISECT", "0") == "1"
 )
 # Checks whether replaying ShapeEnv events on a freshly constructed one yields
-# the a ShapeEnv with the same state. This should be used only in testing.
+# a ShapeEnv with the same state. This should be used only in testing.
 check_shape_env_recorded_events = False
 
 # TODO: Perhaps consider allowing unions for the configs below (so you can hit

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -1139,7 +1139,7 @@ def arange_inference_rule(
     arange, counter = gen_tvar(counter)
     symbols[n] = arange
 
-    # either the a parameter is a number or it is Dyn
+    # either a parameter is a number or it is Dyn
     c1 = Disj(
         [
             BinConstraintD(end, Dyn, op_eq),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181967

Fix several minor typos across the codebase: remove spurious articles
("the a" → "a"), add missing prepositions ("belong this" → "belong to
this"), and correct pluralization ("certains" → "certain").

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo