### PR TITLE
Fix "tracable" typo to "traceable"

### DIFF
--- a/torch/_dynamo/tensor_version_op.py
+++ b/torch/_dynamo/tensor_version_op.py
@@ -31,7 +31,7 @@ _tensor_version = _make_prim(
     return_type=RETURN_TYPE.NEW,
     meta=torch.ops.aten._version.default,
     impl_aten=torch.ops.aten._version.default,
-    doc="Tracable unbacked SymInt version of torch.Tensor._version",
+    doc="Traceable unbacked SymInt version of torch.Tensor._version",
 )
 
 
@@ -51,7 +51,7 @@ _unsafe_set_version_counter = _make_prim(
     return_type=RETURN_TYPE.NEW,
     meta=lambda self, version: None,
     impl_aten=torch._C._autograd._unsafe_set_version_counter,
-    doc="Tracable+SymInt version of torch._C._autograd._unsafe_set_version_counter",
+    doc="Traceable+SymInt version of torch._C._autograd._unsafe_set_version_counter",
 )
 torch.fx.node.has_side_effect(_unsafe_set_version_counter)
 

--- a/torch/_export/db/examples/assume_constant_result.py
+++ b/torch/_export/db/examples/assume_constant_result.py
@@ -5,7 +5,7 @@ import torch._dynamo as torchdynamo
 
 class AssumeConstantResult(torch.nn.Module):
     """
-    Applying `assume_constant_result` decorator to burn make non-tracable code as constant.
+    Applying `assume_constant_result` decorator to burn make non-traceable code as constant.
     """
 
     @torchdynamo.assume_constant_result

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -44,7 +44,7 @@ at trace time.
 
 Notes:
   - We require hooks to not change shapes of tensors.
-  - We require non-hook autograd nodes to be tracable.
+  - We require non-hook autograd nodes to be traceable.
 */
 
 namespace torch::dynamo::autograd {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181968

The word "traceable" was consistently misspelled as "tracable" in
docstrings and comments related to dynamo tracing. Fix the typo in
tensor_version_op.py, assume_constant_result.py, and
python_compiled_autograd.cpp.

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @xmfan @aditvenk