### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -71,7 +71,7 @@ C10_DEFINE_bool(
 C10_DEFINE_int32(
     torch_jit_release_profiling_graph_delay_in_seconds,
     60,
-    "How long to wait before releasing the profiling graph after optimizaiton is done. Only used if torch_jit_release_profiling_graph_after_optimization is set to true.")
+    "How long to wait before releasing the profiling graph after optimization is done. Only used if torch_jit_release_profiling_graph_after_optimization is set to true.")
 
 constexpr size_t kDefaultNumProfiledRuns = 1;
 constexpr size_t kDefaultBailoutDepth = 20;

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -104,7 +104,7 @@ TORCH_API std::vector<Shape> compute_shape_arange_out(
 
   AT_DISPATCH_ALL_TYPES_AND(
       c10::kBFloat16, out.scalar_type(), "compute_shape_arange_out", [&]() {
-        // Note: acc_type further defines an accumulataion type depending on the
+        // Note: acc_type further defines an accumulation type depending on the
         // scalar_t and whether its on cuda vs cpu.
         using accscalar_t = at::acc_type<scalar_t, false>;
 

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -920,7 +920,7 @@ def _get_updated_module_call_graph(
         if history := node.meta.get("from_node", []):
             provenance[history[-1].name] = node.name
 
-        # For params and buffers, we might have applied parameterizaiton rule
+        # For params and buffers, we might have applied parameterization rule
         # so that the names might have changed. But for user inputs, we know we
         # must preserve the old name.
         elif node.op == "placeholder":

--- a/torch/fx/experimental/graph_gradual_typechecker.py
+++ b/torch/fx/experimental/graph_gradual_typechecker.py
@@ -807,7 +807,7 @@ def element_wise_eq(n: Node) -> list[Any]:
     Note that it takes two iterations for this result. One iteration to establish
     equality between certain dimensions of the operands (requiring the whole solver
     including unification) and another iteration to establish equality between the operands
-    and the resulting type, requiring another round of constraint generation and unificaiton.
+    and the resulting type, requiring another round of constraint generation and unification.
     """
     res: list[Any] = []
     if isinstance(n.args[0], Node) and isinstance(n.args[1], Node):

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -147,7 +147,7 @@ class PackageImporter(Importer):
 
         self._mangler = PackageMangler()
 
-        # used for reduce deserializaiton
+        # used for reduce deserialization
         self.storage_context: Any = None
         self.last_map_location = None
 
@@ -294,7 +294,7 @@ class PackageImporter(Importer):
 
         @contextmanager
         def set_deserialization_context():
-            # to let reduce_package access deserializaiton context
+            # to let reduce_package access deserialization context
             self.storage_context = storage_context
             self.last_map_location = map_location
             try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181970

Fix several instances of transposed letters in comments across the
codebase: "optimizaiton" → "optimization", "accumulataion" →
"accumulation", "parameterizaiton" → "parameterization",
"unificaiton" → "unification", and "deserializaiton" →
"deserialization".

Authored with Claude (typo_terminator2).