### PR TITLE
Fix typos in inductor and export comments

### DIFF
--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -1195,7 +1195,7 @@ class TritonTemplateKernel(TritonKernel):
                     V.kernel.cse.store_cache[name] = value
                     if name in V.kernel.prologue_fused_inputs:
                         # We load masked out values with 0, then apply a prologue.
-                        # The masked out values may not necessariliy be 0 any more
+                        # The masked out values may not necessarily be 0 any more
                         # so we need to reapply the mask.
                         value_dtype = value.dtype
                         value_str = str(value)

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -288,7 +288,7 @@ def _extract_fake_inputs(gm, args, kwargs):
         # fake (and symbolic) inputs. The way currently it's implemented
         # is by looking at the node.meta["val"] of the placeholder nodes.
         # This doesn't work when the graph is Dynamo flattened, because now
-        # plceholder nodes doesn't have the ordering like pytree inputs do.
+        # placeholder nodes doesn't have the ordering like pytree inputs do.
         # Instead, we need to look at how the inputs are shuffled, and map
         # the inputs to their actual fake inputs and symbolic inputs.
         # Since inputs can also contain symints, we cannot simply use the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181971

Fix "necessariliy" → "necessarily" in select_algorithm.py and
"plceholder" → "placeholder" in export/_trace.py.

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo