### PR TITLE
Fix typos in export wrapper docstring and transformer module comment

### DIFF
--- a/torch/_export/wrappers.py
+++ b/torch/_export/wrappers.py
@@ -195,7 +195,7 @@ def _is_init(fn):
 def mark_subclass_constructor_exportable_experimental(constructor_subclass):
     """
     Experimental decorator that makes subclass to be traceable in export
-    with pre-dispatch IR. To make your subclass traceble in export, you need to:
+    with pre-dispatch IR. To make your subclass traceable in export, you need to:
         1. Implement __init__ method for your subclass (Look at DTensor implementation)
         2. Decorate your __init__ method with _mark_constructor_exportable_experimental
         3. Put torch._dynamo_disable decorator to prevent dynamo from peeking into its' impl

--- a/torch/csrc/api/src/nn/modules/transformer.cpp
+++ b/torch/csrc/api/src/nn/modules/transformer.cpp
@@ -105,7 +105,7 @@ void TransformerDecoderLayerImpl::reset() {
           MultiheadAttentionOptions(options.d_model(), options.nhead())
               .dropout(options.dropout())));
 
-  // initialize multihed attention
+  // initialize multihead attention
   multihead_attn = this->register_module(
       "multihead_attn",
       MultiheadAttention(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181972

Correct "traceble" to "traceable" in the subclass constructor export
decorator docstring, and "multihed" to "multihead" in the C++ transformer
decoder layer initialization comment.

Authored with Claude (typo_terminator2).