### PR TITLE
Fix typo in tensor string formatting comment

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -291,7 +291,7 @@ def _vector_str(self, indent, summarize, formatter1, formatter2=None):
 
 # formatter2 is only used for printing complex tensors.
 # For complex tensors, formatter1 and formatter2 are the formatters for tensor.real
-# and tensor.imag respesectively
+# and tensor.imag respectively
 def _tensor_str_with_formatter(self, indent, summarize, formatter1, formatter2=None):
     dim = self.dim()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181973

Fix "respesectively" → "respectively" in a comment describing the
formatter used for complex tensor printing.

Authored with Claude (typo_terminator2).