### PR TITLE
Fix indefinite article typos ("a" -> "an") before vowel sounds

### DIFF
--- a/torch/csrc/autograd/saved_variable.h
+++ b/torch/csrc/autograd/saved_variable.h
@@ -126,7 +126,7 @@ class TORCH_API SavedVariable {
   std::shared_ptr<Node> grad_fn_;
   // For the usual case where leaf tensors are the input, we expect its
   // grad_acc to be kept alive by the graph. The reason SavedVariable holds
-  // a owning reference is to support the case where a custom autograd Function
+  // an owning reference is to support the case where a custom autograd Function
   // saves an intermediate.
   std::shared_ptr<Node> grad_accumulator_;
   bool requires_grad_ = false;

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -654,7 +654,7 @@ struct TORCH_API ViewInfo {
 /// Such views include:
 ///   1. Views created from .detach()
 ///   2. Views that are non-differentiable by its nature.
-///      E.g., `sparse_tensor.indices()` is a integral view on a (possibly)
+///      E.g., `sparse_tensor.indices()` is an integral view on a (possibly)
 ///      floating point tensor.
 ///      See top of `derivatives.yaml` on how to specify that outputs of a
 ///      function are non-differentiable.

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -56,7 +56,7 @@ static PyObject* THCPStream_pynew(
 
   if (stream_ptr) {
     TORCH_CHECK(
-        priority == 0, "Priority was explicitly set for a external stream")
+        priority == 0, "Priority was explicitly set for an external stream")
   }
   at::cuda::CUDAStream stream = (stream_id || device_index || device_type)
       ? at::cuda::CUDAStream::unpack3(

--- a/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
+++ b/torch/csrc/inductor/aoti_eager/kernel_meta_info.h
@@ -117,7 +117,7 @@ struct ParameterMetadata {
   ParameterMetadataValue value_;
   // The order of the parameter is used to distinguish the parameters with the
   // same tag. For example, an operation with two input tensors, the first
-  // tensor is a optional tensor and the second tensor is a tensor. The first
+  // tensor is an optional tensor and the second tensor is a tensor. The first
   // tensor will have the order 0 and the second tensor will have the order 1.
   uint64_t order_{};
 

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -129,7 +129,7 @@ def caching_allocator_alloc(size, device: "Device" = None, stream=None):
         raise TypeError(
             "Invalid type for stream argument, must be "
             "`torch.cuda.Stream` or `int` representing a pointer "
-            "to a existing stream"
+            "to an existing stream"
         )
     with torch.cuda.device(device):
         return torch._C._cuda_cudaCachingAllocator_raw_alloc(size, stream)

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -209,7 +209,7 @@ class UninitializedParameter(UninitializedTensorMixin, Parameter):
 
     Unlike a :class:`torch.nn.Parameter`, uninitialized parameters
     hold no data and attempting to access some properties, like their shape,
-    will throw a runtime error. The only operations that can be performed on a uninitialized
+    will throw a runtime error. The only operations that can be performed on an uninitialized
     parameter are changing its datatype, moving it to a different device and
     converting it to a regular :class:`torch.nn.Parameter`.
 
@@ -286,7 +286,7 @@ class UninitializedBuffer(UninitializedTensorMixin, torch.Tensor):
 
     Unlike a :class:`torch.Tensor`, uninitialized parameters
     hold no data and attempting to access some properties, like their shape,
-    will throw a runtime error. The only operations that can be performed on a uninitialized
+    will throw a runtime error. The only operations that can be performed on an uninitialized
     parameter are changing its datatype, moving it to a different device and
     converting it to a regular :class:`torch.Tensor`.
 

--- a/torch/onnx/_internal/exporter/_isolated.py
+++ b/torch/onnx/_internal/exporter/_isolated.py
@@ -23,7 +23,7 @@ _IS_WINDOWS = os.name == "nt"
 def _call_function_and_return_exception(
     func: Callable[[Unpack[_Ts]], _R], args: tuple[Unpack[_Ts]], kwargs: dict[str, Any]
 ) -> _R | Exception:
-    """Call function and return a exception if there is one."""
+    """Call function and return an exception if there is one."""
 
     try:
         return func(*args, **kwargs)

--- a/torch/optim/sparse_adam.py
+++ b/torch/optim/sparse_adam.py
@@ -157,7 +157,7 @@ SparseAdam.__doc__ = rf"""SparseAdam implements a masked version of the Adam alg
     It is important to not conflate a semantically sparse tensor (a tensor where many
     of its values are zeros) with a sparse layout tensor (a tensor where ``.is_sparse``
     returns ``True``). The SparseAdam approximation is intended for `semantically` sparse
-    tensors and the sparse layout is only a implementation detail. A clearer implementation
+    tensors and the sparse layout is only an implementation detail. A clearer implementation
     would be to use MaskedTensors, but those are experimental.
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181976

Several comments, docstrings, and error messages used "a" before words
starting with a vowel sound (e.g., "a owning", "a integral", "a
external", "a optional", "a existing", "a uninitialized", "a
exception", "a implementation"). Correct these to "an" for proper
grammar.

Authored with Claude (typo_terminator2).