### PR TITLE
Fix typos in comments and docstrings across torch

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -918,7 +918,7 @@ loop_reindexing_after_fusion: bool = (
 # so that the nodes can fuse. for more details: https://gist.github.com/eellison/6f9f4a7ec10a860150b15b719f9285a9
 loop_index_inversion_in_fusion: bool = True
 
-# If fusing two nodes only save less then score_fusion_memory_threshold memory,
+# If fusing two nodes only save less than score_fusion_memory_threshold memory,
 # we should not bother fusing the nodes.
 #
 # This is especially helpful to resolve https://github.com/pytorch/pytorch/issues/133242

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1357,8 +1357,8 @@ def perload_icx_libomp_win(cpp_compiler: str) -> None:
         return False
 
     """
-    Intel Compiler implemented more math libraries than clang, for performance proposal.
-    We need preload them like openmp library.
+    Intel Compiler implemented more math libraries than clang, for performance purposes.
+    We need to preload them like openmp library.
     """
     preload_list = [
         "libiomp5md.dll",  # openmp

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -980,8 +980,8 @@ class GraphLowering(torch.fx.Interpreter):
         1. the output of batch-norm should be channels last initially since its input is a conv's output.
            Forcing the batch-norm's output to be contiguous results in the first copy
         2. The second conv's input is initially contiguous. This layout is propagated from the batch-norm's output.
-           We need convert it to channels last layout which results in the second copy.
-        With rule 2, we makes sure all the tensors in the chain uses channels last layout. So both copies
+           We need to convert it to channels last layout which results in the second copy.
+        With rule 2, we make sure all the tensors in the chain use channels last layout. So both copies
         can be saved.
         """
         last_conv = None
@@ -1968,7 +1968,7 @@ class GraphLowering(torch.fx.Interpreter):
             # output different strides than eager
             # long term the solution is to make view() always succeed
             # with infallible strides.
-            # 2: as_strided ops, we need make sure its input has same size/stride with
+            # 2: as_strided ops, we need to make sure its input has same size/stride with
             # eager model to align with eager behavior.
             as_strided_ops = [
                 torch.ops.aten.as_strided.default,

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2814,7 +2814,7 @@ def get_benchmark_name() -> str | None:
     It works for torchbench.py/hugginface.py/timm_models.py. But for ad-hoc
     scripts, this function may return None.
 
-    There are 2 flavors of --only argument we need handle:
+    There are 2 flavors of --only argument we need to handle:
     1. --only model_name
     2. --only=model_name
     """

--- a/torch/_numpy/_util.py
+++ b/torch/_numpy/_util.py
@@ -1,6 +1,6 @@
 # mypy: ignore-errors
 
-"""Assorted utilities, which do not need anything other then torch and stdlib."""
+"""Assorted utilities, which do not need anything other than torch and stdlib."""
 
 import operator
 

--- a/torch/_sources.py
+++ b/torch/_sources.py
@@ -16,7 +16,7 @@ def get_source_lines_and_file(
     """
     Wrapper around inspect.getsourcelines and inspect.getsourcefile.
 
-    Returns: (sourcelines, file_lino, filename)
+    Returns: (sourcelines, file_lineno, filename)
     """
     filename = None  # in case getsourcefile throws
     try:

--- a/torch/csrc/jit/codegen/onednn/graph_helper.cpp
+++ b/torch/csrc/jit/codegen/onednn/graph_helper.cpp
@@ -241,7 +241,7 @@ Operator LlgaGraphHelper::createOperator(Node* node) {
             dnnl::graph::op::attr::rounding_type, std::string(rounding_type))
         .setAttr(dnnl::graph::op::attr::data_format, std::string("NCX"));
   } else if (nodeKind == Symbol::fromQualString("aten::avg_pool2d")) {
-    // TODO: do we need add checks for all Constants?
+    // TODO: do we need to add checks for all Constants?
     REQUIRE(node->namedInput("kernel_size")->node()->kind() == prim::Constant);
     auto rounding_type =
         toIValue(node->namedInput("ceil_mode"))->toBool() ? "ceil" : "floor";

--- a/torch/library.py
+++ b/torch/library.py
@@ -1140,7 +1140,7 @@ def register_fake(
                         and will error you're trying to register a fake impl to
                         an operator that already has a fake impl. This also only
                         applies if the custom operator was not created via
-                        torch.library.custom_op, as overriding and existing fake
+                        torch.library.custom_op, as overriding an existing fake
                         impl is already allowed.
 
     Examples:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181978

Fix a variety of small typos: "then" → "than", missing "to" before
verbs ("need handle" → "need to handle"), subject-verb agreement
("we makes sure" → "we make sure"), "proposal" → "purposes",
"lino" → "lineno", and "and existing" → "an existing". These are
scattered across inductor, JIT, numpy compat, and library modules.

Authored with Claude (typo_terminator2).

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo