### PR TITLE
Fix typos in comments and docstrings across distributed, decomp, and fx modules

### DIFF
--- a/torch/_decomp/decompositions_for_rng.py
+++ b/torch/_decomp/decompositions_for_rng.py
@@ -173,7 +173,7 @@ class PhiloxStateTracker:
         # concat the (seed, offset) to create a tensor for get_rng_state, and
         # then split it back to get (seed, offset) tuple in set_rng_state.
 
-        # TODO: Investigate if there is be a better way to wrap the tuple in a
+        # TODO: Investigate if there is a better way to wrap the tuple in a
         # false Tensor object, and then desugar it later on.
         return cls.running_state.get_state_as_tensor()
 

--- a/torch/csrc/distributed/rpc/profiler/server_process_global_profiler.h
+++ b/torch/csrc/distributed/rpc/profiler/server_process_global_profiler.h
@@ -34,7 +34,7 @@ class State {
   void pushResult(thread_event_lists result) {
     std::unique_lock<std::mutex> lock(resultsMutex_);
 
-    // NB: When a thread wants to push an entry into the this container,
+    // NB: When a thread wants to push an entry into this container,
     // main control logic might have exited the process-global profile range.
     results_.emplace_back(std::move(result));
   }

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -198,7 +198,7 @@ class TORCH_API RpcAgent {
   // before every RPC process exits.
   virtual void join(bool shutdown = false, float timeout = 0) = 0;
 
-  // Synchronize the this process with other ``RpcAgent`` processes. Block until
+  // Synchronize this process with other ``RpcAgent`` processes. Block until
   // all ``RpcAgent``s reach this method and send all pending messages.
   virtual void sync() = 0;
 

--- a/torch/distributed/_tools/runtime_estimator.py
+++ b/torch/distributed/_tools/runtime_estimator.py
@@ -361,7 +361,7 @@ class RuntimeEstimator(TorchDispatchMode):
         fake_mode = active_fake_mode()
         if not isinstance(fake_mode, FakeTensorMode):
             raise AssertionError(
-                "No FakeTensorMode found, designed to used under FakeTensorMode"
+                "No FakeTensorMode found, designed to be used under FakeTensorMode"
             )
         RuntimeEstimator.fake_mode = fake_mode
         self.total_runtime = 0.0

--- a/torch/distributed/fsdp/_unshard_param_utils.py
+++ b/torch/distributed/fsdp/_unshard_param_utils.py
@@ -37,7 +37,7 @@ def _writeback_to_local_shard(
     writeback_grad: bool,
 ):
     """
-    For the handle, writes back the this rank's shard of the unsharded
+    For the handle, writes back this rank's shard of the unsharded
     flattened parameter to the sharded flattened parameter. If
     ``writeback_grad=True``, then writes back to the sharded gradient as
     well.

--- a/torch/fx/passes/utils/matcher_utils.py
+++ b/torch/fx/passes/utils/matcher_utils.py
@@ -356,8 +356,8 @@ class SubgraphMatcher:
         in order for the match to be valid. This is implemented with backtracking. See `backtracking`
         for more details.
 
-        Notice: graph traversal must be done in the reverser order because a tensor can have multiple
-        consumers, but can only have a single producer. Only with reverser order, we can we jointly
+        Notice: graph traversal must be done in the reverse order because a tensor can have multiple
+        consumers, but can only have a single producer. Only with reverse order can we jointly
         traverse the pattern and target graph in a deterministic path.
 
         Warning: In theory, this backtracking algorithm have an **exponential** time complexity. However,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181979

Correct minor grammatical errors: "is be a" → "is a", "the this" → "this",
"designed to used" → "designed to be used", and "reverser order" → "reverse
order". These are comment/docstring-only changes with no behavioral impact.

Authored with Claude (typo_terminator2).