### PR TITLE
Fix typos in comments and error messages

### DIFF
--- a/torch/csrc/jit/mobile/function.cpp
+++ b/torch/csrc/jit/mobile/function.cpp
@@ -217,7 +217,7 @@ std::optional<std::function<void(Stack&)>> makeOperatorFunction(
             static_cast<size_t>(num_specified_args.value()) >= out_args.size(),
             "The number of output arguments is: ",
             out_args.size(),
-            ", which is more then the number of specified arguments: ",
+            ", which is more than the number of specified arguments: ",
             num_specified_args.value());
         size_t start_index = num_specified_args.value() - out_args.size();
         for (size_t i = start_index; i < (args.size() - out_args.size()); ++i) {

--- a/torch/csrc/jit/mobile/model_tracer/tracer.cpp
+++ b/torch/csrc/jit/mobile/model_tracer/tracer.cpp
@@ -157,7 +157,7 @@ int main(int argc, char* argv[]) {
         << c10::str(
                "Error traced_operators size: ",
                tracer_result.traced_operators.size(),
-               ". Expected the traced operator list to be bigger then the default size ",
+               ". Expected the traced operator list to be bigger than the default size ",
                torch::jit::mobile::always_included_traced_ops.size(),
                ". Please report a bug in PyTorch.")
         << '\n';

--- a/torch/csrc/lazy/core/helpers.cpp
+++ b/torch/csrc/lazy/core/helpers.cpp
@@ -82,7 +82,7 @@ std::vector<int64_t> GetPromotedShape(
     c10::ArrayRef<int64_t> shape1_dims,
     c10::ArrayRef<int64_t> shape2_dims) {
   std::vector<int64_t> dimensions;
-  // If the rank of a shape is bigger than then other, fill up the first
+  // If the rank of a shape is bigger than the other, fill up the first
   // dimensions with the ones of the bigger.
   // Example:
   //   shape1 = [9, 7, 6, 5, 2]

--- a/torch/csrc/utils/python_strings.h
+++ b/torch/csrc/utils/python_strings.h
@@ -91,7 +91,7 @@ inline void THPUtils_internStringInPlace(PyObject** obj) {
  * avoids lookups for None, tuple, and List objects,
  * and doesn't create a PyErr since this code ignores it.
  *
- * This can be much faster then PyObject_GetAttrString where
+ * This can be much faster than PyObject_GetAttrString where
  * exceptions are not used by caller.
  *
  * 'obj' is the object to search for attribute.

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1606,7 +1606,7 @@ class Graph:
     @compatibility(is_backward_compatible=True)
     def inserting_before(self, n: Node | None = None) -> _InsertPoint:
         """Set the point at which create_node and companion methods will insert into the graph.
-        When used within a 'with' statement, this will temporary set the insert point and
+        When used within a 'with' statement, this will temporarily set the insert point and
         then restore it when the with statement exits::
 
             with g.inserting_before(n):
@@ -1631,7 +1631,7 @@ class Graph:
     @compatibility(is_backward_compatible=True)
     def inserting_after(self, n: Node | None = None) -> _InsertPoint:
         """Set the point at which create_node and companion methods will insert into the graph.
-        When used within a 'with' statement, this will temporary set the insert point and
+        When used within a 'with' statement, this will temporarily set the insert point and
         then restore it when the with statement exits::
 
             with g.inserting_after(n):

--- a/torch/nativert/executor/memory/LayoutManager.cpp
+++ b/torch/nativert/executor/memory/LayoutManager.cpp
@@ -71,7 +71,7 @@ void LayoutManager::allocate_plan(const LayoutPlan& plan) {
     // will set the offset and size directly, as opposed to creating and
     // swapping it with a new one
     //
-    // apart from the first allocation when the storage still has the its
+    // apart from the first allocation when the storage still has its
     // allocator-created dataptr (https://fburl.com/code/u7dsspjm) whose
     // deleter is non-null (https://fburl.com/code/7hiwo5zo), this should
     // always be true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181982

Replace "then" with "than" in comparison contexts across several files,
fix "temporary" to "temporarily" as an adverb in torch/fx/graph.py, and
remove a spurious "the" in a comment in LayoutManager.cpp.

Authored with Claude (typo_terminator2).