### PR TITLE
Fix typos in sharded embedding op docstrings

### DIFF
--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py
@@ -61,7 +61,7 @@ def sharded_embedding(types, args, kwargs, pg):
        be re-normed so mask IDs whose embeddings are not stored in current
        rank will to an extra row will ensure max_norm still works as expected.
     3. If max_norm is specified, the extra row guarantees that the mask ID will
-       not affect the behavior of weigh re-norm.
+       not affect the behavior of weight re-norm.
 
     COLWISE SHARDING
     ================

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding_bag.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding_bag.py
@@ -60,11 +60,11 @@ def sharded_embedding_bag(types, args, kwargs, pg):
                [4, 0, 4, 4, 4, 4],
                [4, 4, 4, 4, 4, 1]])
     3. If ``max_norm`` is specified, the extra row guarantees that the mask ID will
-       not affect the behavior of weigh re-norm.
+       not affect the behavior of weight re-norm.
     4. The example above only happens in one rank and each rank does a very similar thing.
        For "Mean" mode we need to divide by either column size (2D) or the interval length
        defined by the offset (excluding the row specified in ``padding_idx``).
-       We also need to mask the unexisting row to neg Inf so that negative value does not
+       We also need to mask the nonexistent row to neg Inf so that negative value does not
        gets wiped out in the "Max" mode.
 
     COLWISE SHARDING


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181985

Correct "weigh re-norm" to "weight re-norm" in both embedding and
embedding_bag sharding spec ops, and fix "unexisting" to "nonexistent"
in the embedding_bag docstring.

Authored with Claude (typo_terminator2).