### PR TITLE
Fix possessive "its" and "other than" typos in comments and docstrings

### DIFF
--- a/torch/_numpy/_util.py
+++ b/torch/_numpy/_util.py
@@ -1,6 +1,6 @@
 # mypy: ignore-errors
 
-"""Assorted utilities, which do not need anything other then torch and stdlib."""
+"""Assorted utilities, which do not need anything other than torch and stdlib."""
 
 import operator
 

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -81,7 +81,7 @@ ViewInfo ViewInfo::chain(
   // [View + Inplace update on view tensor] for more details how we use this
   // function in backward.
   if (view_func) {
-    // both current_view and it's parent have a view_func
+    // both current_view and its parent have a view_func
     if (view_fn_) {
       view_func = std::make_unique<ChainedViewFunc>(
           view_fn_->clone_and_set(), std::move(view_func));
@@ -93,7 +93,7 @@ ViewInfo ViewInfo::chain(
         return prev_rev_fn(temp);
       };
     } else {
-      // current_view has a view_func and but it's parent doesn't have one
+      // current_view has a view_func but its parent doesn't have one
       if (base.unsafeGetTensorImpl()->support_as_strided()) {
         auto match_base_view_func = create_view_func_matching(base);
         view_func = std::make_unique<ChainedViewFunc>(
@@ -124,7 +124,7 @@ ViewInfo ViewInfo::chain(
       }
     }
   } else if (view_fn_) {
-    // if current_view doesn't have a view_func but it's parent has one
+    // if current_view doesn't have a view_func but its parent has one
     auto match_tensor_view_func = create_view_func_matching(tensor);
     view_func = std::make_unique<ChainedViewFunc>(
         view_fn_->clone_and_set(), std::move(match_tensor_view_func));

--- a/torch/csrc/distributed/c10d/PyProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/PyProcessGroup.hpp
@@ -55,7 +55,7 @@ class PyProcessGroup : public ProcessGroup {
     return cname::name(__VA_ARGS__);                                    \
   } while (false)
 
-  // This class is used to wrap a PyWork trampoline with it's corresponding
+  // This class is used to wrap a PyWork trampoline with its corresponding
   // Python object to prevent the Python object from being garbage collected.
   class PyWorkHolder : public Work {
    public:

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -963,7 +963,7 @@ void MemDependencyChecker::visit(const CondPtr& v) {
   mergeScope(trueScope, enclosingScope, false);
   mergeScope(falseScope, enclosingScope, false);
 
-  // Merge the enclosing scope into it's parent.
+  // Merge the enclosing scope into its parent.
   mergeScope(enclosingScope, enclosingScope->parent, false);
 
   currentScope_ = enclosingScope;

--- a/torch/csrc/jit/tensorexpr/registerizer.cpp
+++ b/torch/csrc/jit/tensorexpr/registerizer.cpp
@@ -517,7 +517,7 @@ void RegisterizerAnalysis::mergeHiddenScope(bool allowClosed) {
   }
 }
 
-// Merge currentScope_ into it's parent, and make parent the new currentScope_.
+// Merge currentScope_ into its parent, and make parent the new currentScope_.
 void RegisterizerAnalysis::mergeCurrentScopeIntoParent() {
   auto parent = currentScope_->parent();
 

--- a/torch/fft/__init__.py
+++ b/torch/fft/__init__.py
@@ -403,7 +403,7 @@ Example:
     tensor([ 6.+0.j, -2.+2.j, -2.+0.j, -2.-2.j])
 
     Notice that the symmetric element ``T[-1] == T[1].conj()`` is omitted.
-    At the Nyquist frequency ``T[-2] == T[2]`` is it's own symmetric pair,
+    At the Nyquist frequency ``T[-2] == T[2]`` is its own symmetric pair,
     and therefore must always be real-valued.
 """.format(**common_args),
 )

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset9.py
@@ -1473,7 +1473,7 @@ def _max_pool(name, tuple_fn, ndims, return_indices):
         # so the values in indices are in [0, N x C x D1 x ... x Dn).
         # To convert the indices to the same format used by Pytorch,
         # we first execute a maxpool with a kernel and stride of 1 on the same input.
-        # This will result in a tensor of indices in which each index will have it's own value.
+        # This will result in a tensor of indices in which each index will have its own value.
         # Using this tensor as a reference, we extract the first index of each axis and subtract
         # it from each index of this axis in the indices to convert.
         # This step will result in a tensor were each dimension has values of indices within

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -301,11 +301,11 @@ class SummaryWriter:
 
         Args:
             hparam_dict (dict): Each key-value pair in the dictionary is the
-              name of the hyper parameter and it's corresponding value.
+              name of the hyper parameter and its corresponding value.
               The type of the value can be one of `bool`, `string`, `float`,
               `int`, or `None`.
             metric_dict (dict): Each key-value pair in the dictionary is the
-              name of the metric and it's corresponding value. Note that the key used
+              name of the metric and its corresponding value. Note that the key used
               here should be unique in the tensorboard record. Otherwise the value
               you added by ``add_scalar`` will be displayed in hparam plugin. In most
               cases, this is unwanted.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181986

Replace "it's" with "its" where the possessive form is intended rather
than the contraction of "it is", and fix one instance of "other then"
that should be "other than". These appear in comments, docstrings, and
documentation strings across autograd, JIT, distributed, FFT, ONNX,
TensorBoard, and NumPy compatibility modules.

Authored with Claude (typo_terminator2).

cc @EikanWang @jgong5