### PR TITLE
Fix typos and grammar errors in comments and docstrings

### DIFF
--- a/torch/_dynamo/polyfills/__init__.py
+++ b/torch/_dynamo/polyfills/__init__.py
@@ -557,7 +557,7 @@ def predicate(obj: object) -> bool:
 
 def cmp_eq(a: object, b: object) -> bool:
     # Note that the commented `is` check should ideally be removed. This is a
-    # CPython optimization that skips the __eq__ checks it the obj id's are
+    # CPython optimization that skips the __eq__ checks if the obj id's are
     # same. But, these lines adds many `is` nodes in the Fx graph for
     # SymNodeVariable. For now, we can just skip this check. This is STILL
     # correct because one of the __eq__ checks will pass later, just could be

--- a/torch/_dynamo/repro/aoti.py
+++ b/torch/_dynamo/repro/aoti.py
@@ -356,7 +356,7 @@ def export_for_aoti_minifier(
 ) -> torch.nn.Module | None:
     # Some graphs cannot be used for AOTI/export (illegal graphs), these should be
     # considered as graphs that don't fail in the minifier, so the minifier keeps searching.
-    # In these case, we return None. Otherwise, we return the exported graph module.
+    # In these cases, we return None. Otherwise, we return the exported graph module.
     # This won't affect the minifier result because the minifier is only responsible for catching
     # errors in AOTI, not export.
     #

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -3475,8 +3475,8 @@ def same(
 
                 def get_multiplier() -> float:
                     # In some particular cases, we expect high difference in results.
-                    # At the moment one of this cases is inductor freezing bfloat16 convolution const folding.
-                    # In case of it the res_error is at least one order of magnitude higher.
+                    # At the moment one of these cases is inductor freezing bfloat16 convolution const folding.
+                    # In this case, the res_error is at least one order of magnitude higher.
                     if force_max_multiplier:
                         return 10.0
                     # In the case of using AMP (Automatic Mixed Precision), certain models have

--- a/torch/_export/verifier.py
+++ b/torch/_export/verifier.py
@@ -176,7 +176,7 @@ class Verifier(metaclass=_VerifierMeta):
         return (torch.fx.GraphModule, torch.utils._pytree.TreeSpec)
 
     def allowed_getattr_types_for_subgm(self) -> tuple[type[Any], ...]:
-        # subgm in HOP's argument could has have getattr(weight) nodes, thus stateful
+        # subgm in HOP's argument could have getattr(weight) nodes, thus stateful
         return (
             torch.fx.GraphModule,
             torch.nn.parameter.Parameter,

--- a/torch/_numpy/_dtypes.py
+++ b/torch/_numpy/_dtypes.py
@@ -382,7 +382,7 @@ def set_default_dtype(fp_dtype="numpy", int_dtype="numpy"):
 
     Notes
     ------------
-    This functions has a side effect: it sets the global state with the provided dtypes.
+    This function has a side effect: it sets the global state with the provided dtypes.
 
     The complex dtype has bit width of at least twice the width of the float
     dtype, i.e. it's complex128 for float64 and complex64 for float32.

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -1326,7 +1326,7 @@ def special_pattern_replacement(model: GraphModule):
         if is_call_function:
             # pass scale/zer_point arguments from quantize_per_tensor to the default node operator
             # insert an op after the zero_point node so that the scale/zero_point
-            # nodes are is available
+            # nodes are available
             qop = get_quantized_operator(ref_node.target)
             args = list(ref_node.args)
             kwargs = dict(ref_node.kwargs)

--- a/torch/csrc/utils/tensor_memoryformats.h
+++ b/torch/csrc/utils/tensor_memoryformats.h
@@ -8,7 +8,7 @@ namespace torch::utils {
 
 void initializeMemoryFormats();
 
-// This methods returns a borrowed reference!
+// This method returns a borrowed reference!
 TORCH_PYTHON_API PyObject* getTHPMemoryFormat(
     c10::MemoryFormat /*memory_format*/);
 

--- a/torch/nativert/graph/Serialization.cpp
+++ b/torch/nativert/graph/Serialization.cpp
@@ -87,8 +87,8 @@ Value* symbolicToValue(
           }
           case torch::_export::SymIntArgument::Tag::AS_INT: {
             // These are concrete int values in the SymIntList, e.g [s0, 8]
-            // We convert them into a constant Value in graph. These value
-            // doesn't have producer node
+            // We convert them into a constant Value in graph. These values
+            // don't have producer node
             int64_t value = listEl.get_as_int();
             TORCH_CHECK(
                 value >= std::numeric_limits<int>::min() &&


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181989

Correct minor typos across several files: wrong pronouns ("it" vs
"if"), subject-verb agreement ("functions" vs "function", "methods"
vs "method"), redundant words ("are is"), and plural consistency
("these cases", "these values").

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98