### PR TITLE
Fix typos in comments, docstrings, and error messages

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -1324,7 +1324,7 @@ class TestAutogradFunction(TestCase):
         def fn(x):
             return A.apply(x.clone())
 
-        err_msg = "A input that has been returned as-is"
+        err_msg = "An input that has been returned as-is"
 
         a = torch.tensor(2.0, device=device, requires_grad=inner_requires_grad)
         a_t = torch.tensor(2.0, device=device, requires_grad=inner_requires_grad)

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1054,7 +1054,7 @@ def _extract_fwd_bwd_modules(
         # wait_tensor is a bit special: if we have a "dead activation" that is not used in the bw,
         # but this dead activation is actually a collective,
         # then the collective will generally by followed by a wait_tensor() call.
-        # we need to peak one node further to see if this wait_tensor is dead as well.
+        # we need to peek one node further to see if this wait_tensor is dead as well.
         elif distributed_enabled and all(
             n.target is torch.ops._c10d_functional.wait_tensor.default
             and len(n.users) == 0

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -403,7 +403,7 @@ def set_logs(
             Whether to emit the TorchInductor output code on a per-graph basis. Default: ``False``
 
         kernel_code (:class:`bool`):
-            Whether to emit the TorchInductor output code on a per-kernel bases. Default: ``False``
+            Whether to emit the TorchInductor output code on a per-kernel basis. Default: ``False``
 
         schedule (:class:`bool`):
             Whether to emit the TorchInductor schedule. Default: ``False``
@@ -433,7 +433,7 @@ def set_logs(
             Whether to emit detailed Inductor compute/comm overlap decisions. Default: ``False``
 
         sym_node (:class:`bool`):
-            Whether to emit debug info for various SymNode opterations. Default: ``False``
+            Whether to emit debug info for various SymNode operations. Default: ``False``
 
         export (:class:`Optional[int]`):
             The log level for export. Default: ``logging.WARN``

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -154,7 +154,7 @@ static void _process_forward_mode_AD(
             "forward mode gradients as-is. If the forward is modifying an input inplace, then the jvp "
             "function must modify the gradient inplace and return it as-is.")
       } else {
-        // If that Tensor didn't had gradients already, set the newly returned
+        // If that Tensor didn't have gradients already, set the newly returned
         // one We could also use inputs[inp_idx] here as it is the same as out
         out._set_fw_grad(out_grad, level, /* is_inplace_op */ true);
       }
@@ -267,7 +267,7 @@ static optional_variable_list _process_backward_mode_ad(
 
 #ifndef STRIP_ERROR_MESSAGES
   const char* error_msg_input_returned_as_is =
-      "A input that has been returned as-is as output is being saved for backward. "
+      "An input that has been returned as-is as output is being saved for backward. "
       "This is not supported if you override setup_context. You should return and "
       "save a view of the input instead, e.g. with x.view_as(x) or setup ctx inside "
       "the forward function itself.";

--- a/torch/distributed/fsdp/_runtime_utils.py
+++ b/torch/distributed/fsdp/_runtime_utils.py
@@ -319,7 +319,7 @@ def _reshard(
     handle.reshard(free_unsharded_flat_param)
     if state.limit_all_gathers and free_unsharded_flat_param:
         if not torch.distributed._functional_collectives.is_torchdynamo_compiling():
-            # We don't run a even queue for freeing under torch compile atm
+            # We don't run an event queue for freeing under torch compile atm
             # But maybe we need to? TODO(voz): Look into this
             free_event = state._device_handle.Event()
             free_event.record()
@@ -1135,7 +1135,7 @@ def _catch_all_reshard(
     post-backward hook. This can happen when a module's output is used in the
     forward pass, meaning that its pre-backward hook runs (unsharding the
     parameter), but the post-backward hook does not run because the output was
-    not jused in the loss computation corresponding to this backward pass.
+    not used in the loss computation corresponding to this backward pass.
     """
     # Wrap with a try-except to provide a more informative traceback if an
     # error is raised

--- a/torch/profiler/_pattern_matcher.py
+++ b/torch/profiler/_pattern_matcher.py
@@ -365,7 +365,7 @@ class OptimizerSingleTensorPattern(Pattern):
     the kernels are relatively small.
 
     Pattern:
-    XXXXX: _single_tenser_<OPTIMIZER_NAME>
+    XXXXX: _single_tensor_<OPTIMIZER_NAME>
 
     Algorithm:
     String match

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -219,7 +219,7 @@ def _get_storage_alignment() -> int:
     Defaults to 64.
 
     Returns:
-        storage_alginment: int
+        storage_alignment: int
     """
     from torch.utils.serialization import config
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181990

Correct various spelling mistakes across multiple files: "peak" →
"peek", "bases" → "basis", "opterations" → "operations", "didn't had"
→ "didn't have", "A input" → "An input", "a even" → "an event",
"jused" → "used", "tenser" → "tensor", and "alginment" → "alignment".

Authored with Claude (typo_terminator2).