### PR TITLE
Fix typos in comments, docstrings, and documentation

### DIFF
--- a/torch/ao/pruning/_experimental/data_sparsifier/lightning/callbacks/README.md
+++ b/torch/ao/pruning/_experimental/data_sparsifier/lightning/callbacks/README.md
@@ -1,6 +1,6 @@
 # Lightning callbacks for data sparsifier and scheduler
 
-**These are callback scripts for lightning and does not introduce pytorch lightning dependency on PyTorch.**
+**These are callback scripts for lightning and do not introduce pytorch lightning dependency on PyTorch.**
 
 ## Introduction
 Callbacks for PytorchLightning that specifies on when and how to sparsify the data weights of the model.

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -222,7 +222,7 @@ static PySequenceMethods THPSize_as_sequence = {
 #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 14
 static Py_hash_t THPSize_hash(PyObject* self) {
   /*
-  Python 3.14 introduce a caching mechanism for tuple hashing which is stored
+  Python 3.14 introduced a caching mechanism for tuple hashing which is stored
   in the `ob_hash` field. The caching mechanism relies on a sentinel value (-1)
   to indicate the hash has not yet been computed.
   For some unknown reason, this field is initialized with 0 when Size is

--- a/torch/distributed/tensor/parallel/api.py
+++ b/torch/distributed/tensor/parallel/api.py
@@ -64,7 +64,7 @@ def parallelize_module(  # type: ignore[return]
 
     .. note:: For complex module architecture like Attention, MLP layers, we recommend composing
         different ParallelStyles together (i.e. ``ColwiseParallel`` and ``RowwiseParallel``) and pass
-        as a parallelize_plan, to achieves the desired sharding computation.
+        as a parallelize_plan, to achieve the desired sharding computation.
     """
     torch._C._log_api_usage_once("torch.distributed.tensor.parallel.parallelize_module")
 

--- a/torch/fx/passes/net_min_base.py
+++ b/torch/fx/passes/net_min_base.py
@@ -192,7 +192,7 @@ class _MinimizerBase:
     ) -> None:
         """
         Store the outputs of self.run_a() and self.run_b() into self.a_outputs and
-        self.b_outputs, so that we can use them when execute preceding nodes that
+        self.b_outputs, so that we can use them when executing preceding nodes that
         use those outputs as inputs.
 
         Args:

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -688,7 +688,7 @@ class PackageExporter:
                         memo_count += 1
                     elif opcode.name == "STACK_GLOBAL":
                         if module is None:
-                            # If not module was passed on in the entries preceding this one, continue.
+                            # If no module was passed on in the entries preceding this one, continue.
                             continue
                         if not isinstance(module, str):
                             raise AssertionError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #181991

Fix minor grammatical and spelling errors across several files:
subject-verb agreement ("does not" → "do not"), missing past tense
("introduce" → "introduced"), incorrect verb form ("achieves" →
"achieve", "execute" → "executing"), and a wrong word ("not" → "no").

Authored with Claude (typo_terminator2).