### PR TITLE
[CI] Fix expandable_segments allocator state leak in test_cuda.py

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -180,20 +180,6 @@ def get_wait_for_cpu_kernel():
     return _wait_for_cpu_kernel
 
 
-def _allocator_settings_for_restore():
-    # Build a settings string that pins the live allocator state, including the
-    # sticky knobs (expandable_segments, pinned_use_background_threads) that
-    # AcceleratorAllocatorConfig::parseArgs does not auto-reset between calls.
-    # Round-tripping _accelerator_getAllocatorSettings() alone is not enough
-    # when the saved string omits a sticky knob.
-    md = torch.cuda.memory._snapshot()["allocator_settings"]
-    last = torch._C._accelerator_getAllocatorSettings() or ""
-    if "expandable_segments" in last:
-        return last
-    es = "True" if md["expandable_segments"] else "False"
-    return f"expandable_segments:{es},{last}" if last else f"expandable_segments:{es}"
-
-
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCuda(TestCase):
@@ -5112,11 +5098,14 @@ class TestCudaAllocator(TestCase):
                 finally:
                     torch.cuda.memory._record_memory_history(None)
 
+    @unittest.skipIf(
+        not EXPANDABLE_SEGMENTS,
+        "requires expandable_segments mode (run via test_cuda_expandable_segments.py)",
+    )
     @serialTest()
     def test_max_split_expandable(self):
-        orig = torch.cuda.get_per_process_memory_fraction()
-        restore_alloc_settings = _allocator_settings_for_restore()
         try:
+            orig = torch.cuda.get_per_process_memory_fraction()
             torch.cuda.memory.empty_cache()
             mb = 1024 * 1024
             _, all_memory = torch.cuda.memory.mem_get_info()
@@ -5148,13 +5137,15 @@ class TestCudaAllocator(TestCase):
             alloc(120)
         finally:
             torch.cuda.memory.set_per_process_memory_fraction(orig)
-            torch._C._accelerator_setAllocatorSettings(restore_alloc_settings)
 
+    @unittest.skipIf(
+        not EXPANDABLE_SEGMENTS,
+        "requires expandable_segments mode (run via test_cuda_expandable_segments.py)",
+    )
     @serialTest()
     def test_garbage_collect_expandable(self):
-        orig = torch.cuda.get_per_process_memory_fraction(0)
-        restore_alloc_settings = _allocator_settings_for_restore()
         try:
+            orig = torch.cuda.get_per_process_memory_fraction(0)
             torch.cuda.memory.empty_cache()
             mb = 1024 * 1024
             _, all_memory = torch.cuda.memory.mem_get_info()
@@ -5182,7 +5173,6 @@ class TestCudaAllocator(TestCase):
             alloc(80)
         finally:
             torch.cuda.memory.set_per_process_memory_fraction(orig)
-            torch._C._accelerator_setAllocatorSettings(restore_alloc_settings)
 
     def test_allocator_settings(self):
         def power2_div(size, div_factor):
@@ -5859,15 +5849,6 @@ class TestBlockStateAbsorption(TestCase):
 
     def setUp(self):
         super().setUp()
-        # Pin allocator settings around this test class. Segment-count
-        # assertions in this suite depend on whether expandable_segments is
-        # active, and that knob is sticky in parseArgs — see issue #158764
-        # for the cross-test leak this guards against. Force the runtime to
-        # match self.expandable_segments so a leaked True from another test
-        # cannot make these assertions flaky.
-        self._restore_alloc_settings = _allocator_settings_for_restore()
-        es = "True" if self.expandable_segments else "False"
-        torch._C._accelerator_setAllocatorSettings(f"expandable_segments:{es}")
         self.segment_length = len(get_all_cudagraph_segments())
 
     def tearDown(self):
@@ -5876,7 +5857,6 @@ class TestBlockStateAbsorption(TestCase):
         torch.cuda.empty_cache()
 
         self.assertEqual(len(get_all_cudagraph_segments()), self.segment_length)
-        torch._C._accelerator_setAllocatorSettings(self._restore_alloc_settings)
 
         super().tearDown()
 
@@ -7307,6 +7287,10 @@ class TestMemPool(TestCase):
             "graph_capture_record_stream_reuse:False"
         )
 
+    @unittest.skipIf(
+        not EXPANDABLE_SEGMENTS,
+        "requires expandable_segments mode (run via test_cuda_expandable_segments.py)",
+    )
     # expandable_segments not supported (PYTORCH_C10_DRIVER_API_SUPPORTED not defined for windows builds)
     @unittest.skipIf(
         IS_WINDOWS and SM89OrLater,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5098,10 +5098,6 @@ class TestCudaAllocator(TestCase):
                 finally:
                     torch.cuda.memory._record_memory_history(None)
 
-    @unittest.skipIf(
-        not EXPANDABLE_SEGMENTS,
-        "requires expandable_segments mode (run via test_cuda_expandable_segments.py)",
-    )
     @serialTest()
     def test_max_split_expandable(self):
         try:
@@ -5137,11 +5133,12 @@ class TestCudaAllocator(TestCase):
             alloc(120)
         finally:
             torch.cuda.memory.set_per_process_memory_fraction(orig)
+            # Test toggles expandable_segments internally; restore the
+            # suite's baseline so subsequent tests see consistent state.
+            torch.cuda.memory._set_allocator_settings(
+                f"expandable_segments:{EXPANDABLE_SEGMENTS}"
+            )
 
-    @unittest.skipIf(
-        not EXPANDABLE_SEGMENTS,
-        "requires expandable_segments mode (run via test_cuda_expandable_segments.py)",
-    )
     @serialTest()
     def test_garbage_collect_expandable(self):
         try:
@@ -5173,6 +5170,11 @@ class TestCudaAllocator(TestCase):
             alloc(80)
         finally:
             torch.cuda.memory.set_per_process_memory_fraction(orig)
+            # Test toggles expandable_segments internally; restore the
+            # suite's baseline so subsequent tests see consistent state.
+            torch.cuda.memory._set_allocator_settings(
+                f"expandable_segments:{EXPANDABLE_SEGMENTS}"
+            )
 
     def test_allocator_settings(self):
         def power2_div(size, div_factor):
@@ -7300,7 +7302,6 @@ class TestMemPool(TestCase):
     @unittest.skipIf(IS_FBCODE or IS_SANDCASTLE, "Load_inline doesn't work in fbcode")
     def test_mempool_expandable(self):
         torch.cuda.empty_cache()
-        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
         allocator, _ = self.get_dummy_allocator(check_vars=False)
         pool = torch.cuda.MemPool(allocator.allocator())
 
@@ -7323,8 +7324,6 @@ class TestMemPool(TestCase):
         self.assertEqual(
             num_expandable_segments, 1, "Expected to have 1 expandable segment only"
         )
-
-        torch.cuda.memory._set_allocator_settings("expandable_segments:False")
 
     @serialTest()
     def test_mempool_ctx_multithread(self):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -180,6 +180,20 @@ def get_wait_for_cpu_kernel():
     return _wait_for_cpu_kernel
 
 
+def _allocator_settings_for_restore():
+    # Build a settings string that pins the live allocator state, including the
+    # sticky knobs (expandable_segments, pinned_use_background_threads) that
+    # AcceleratorAllocatorConfig::parseArgs does not auto-reset between calls.
+    # Round-tripping _accelerator_getAllocatorSettings() alone is not enough
+    # when the saved string omits a sticky knob.
+    md = torch.cuda.memory._snapshot()["allocator_settings"]
+    last = torch._C._accelerator_getAllocatorSettings() or ""
+    if "expandable_segments" in last:
+        return last
+    es = "True" if md["expandable_segments"] else "False"
+    return f"expandable_segments:{es},{last}" if last else f"expandable_segments:{es}"
+
+
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCuda(TestCase):
@@ -5100,8 +5114,9 @@ class TestCudaAllocator(TestCase):
 
     @serialTest()
     def test_max_split_expandable(self):
+        orig = torch.cuda.get_per_process_memory_fraction()
+        restore_alloc_settings = _allocator_settings_for_restore()
         try:
-            orig = torch.cuda.get_per_process_memory_fraction()
             torch.cuda.memory.empty_cache()
             mb = 1024 * 1024
             _, all_memory = torch.cuda.memory.mem_get_info()
@@ -5133,11 +5148,13 @@ class TestCudaAllocator(TestCase):
             alloc(120)
         finally:
             torch.cuda.memory.set_per_process_memory_fraction(orig)
+            torch._C._accelerator_setAllocatorSettings(restore_alloc_settings)
 
     @serialTest()
     def test_garbage_collect_expandable(self):
+        orig = torch.cuda.get_per_process_memory_fraction(0)
+        restore_alloc_settings = _allocator_settings_for_restore()
         try:
-            orig = torch.cuda.get_per_process_memory_fraction(0)
             torch.cuda.memory.empty_cache()
             mb = 1024 * 1024
             _, all_memory = torch.cuda.memory.mem_get_info()
@@ -5165,6 +5182,7 @@ class TestCudaAllocator(TestCase):
             alloc(80)
         finally:
             torch.cuda.memory.set_per_process_memory_fraction(orig)
+            torch._C._accelerator_setAllocatorSettings(restore_alloc_settings)
 
     def test_allocator_settings(self):
         def power2_div(size, div_factor):
@@ -5841,6 +5859,15 @@ class TestBlockStateAbsorption(TestCase):
 
     def setUp(self):
         super().setUp()
+        # Pin allocator settings around this test class. Segment-count
+        # assertions in this suite depend on whether expandable_segments is
+        # active, and that knob is sticky in parseArgs — see issue #158764
+        # for the cross-test leak this guards against. Force the runtime to
+        # match self.expandable_segments so a leaked True from another test
+        # cannot make these assertions flaky.
+        self._restore_alloc_settings = _allocator_settings_for_restore()
+        es = "True" if self.expandable_segments else "False"
+        torch._C._accelerator_setAllocatorSettings(f"expandable_segments:{es}")
         self.segment_length = len(get_all_cudagraph_segments())
 
     def tearDown(self):
@@ -5849,6 +5876,7 @@ class TestBlockStateAbsorption(TestCase):
         torch.cuda.empty_cache()
 
         self.assertEqual(len(get_all_cudagraph_segments()), self.segment_length)
+        torch._C._accelerator_setAllocatorSettings(self._restore_alloc_settings)
 
         super().tearDown()
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4589,6 +4589,14 @@ print(ret)
 @unittest.skipIf(not TEST_CUDA, "CUDA not available, skipping tests")
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestCudaAllocator(TestCase):
+    def tearDown(self):
+        super().tearDown()
+        # Regression check: no test in this class should leave the runtime
+        # expandable_segments knob mismatched against the suite's env-derived
+        # baseline. This is the only class that toggles it.
+        md = torch.cuda.memory._snapshot()["allocator_settings"]
+        self.assertEqual(md["expandable_segments"], EXPANDABLE_SEGMENTS)
+
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"
     )

--- a/test/test_cuda_expandable_segments.py
+++ b/test/test_cuda_expandable_segments.py
@@ -1,6 +1,16 @@
 # Owner(s): ["module: cuda"]
 # run time cuda tests, but with the allocator using expandable segments
 
+import os
+
+
+# Must precede the test_cuda import: EXPANDABLE_SEGMENTS in
+# torch.testing._internal.common_utils reads PYTORCH_CUDA_ALLOC_CONF once at
+# import time, and the C10 caching allocator picks up the same env var on
+# first use. Setting it here keeps the @skipIf(not EXPANDABLE_SEGMENTS, ...)
+# guards on expandable-only tests in test_cuda.py from skipping in this runner.
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 import pathlib
 import sys
 
@@ -8,6 +18,7 @@ from test_cuda import (  # noqa: F401
     TestBlockStateAbsorption,
     TestCuda,
     TestCudaAllocator,
+    TestMemPool,
 )
 
 import torch
@@ -27,9 +38,4 @@ sys.path.remove(str(REPO_ROOT))
 if __name__ == "__main__":
     if torch.cuda.is_available() and not IS_JETSON and not IS_WINDOWS:
         get_disabled_tests(".")
-
-        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
-        TestCuda.expandable_segments = lambda _: True
-        TestBlockStateAbsorption.expandable_segments = lambda _: True
-
         run_tests()

--- a/test/test_cuda_expandable_segments.py
+++ b/test/test_cuda_expandable_segments.py
@@ -6,9 +6,13 @@ import os
 
 # Must precede the test_cuda import: EXPANDABLE_SEGMENTS in
 # torch.testing._internal.common_utils reads PYTORCH_CUDA_ALLOC_CONF once at
-# import time, and the C10 caching allocator picks up the same env var on
-# first use. Setting it here keeps the @skipIf(not EXPANDABLE_SEGMENTS, ...)
-# guards on expandable-only tests in test_cuda.py from skipping in this runner.
+# import time. Setting it here lets the @skipIf(not EXPANDABLE_SEGMENTS, ...)
+# guards on expandable-only tests in test_cuda.py run in this runner. We
+# restore the prior env state below (after the import) so subprocesses
+# spawned by tests don't inherit expandable_segments:True, which would
+# conflict with backend:cudaMallocAsync and similar settings those
+# subprocesses set themselves.
+_PRIOR_ALLOC_CONF = os.environ.get("PYTORCH_CUDA_ALLOC_CONF")
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 import pathlib
@@ -26,6 +30,14 @@ from torch.testing._internal.common_cuda import IS_JETSON, IS_WINDOWS
 from torch.testing._internal.common_utils import run_tests
 
 
+# Restore prior env state. EXPANDABLE_SEGMENTS has already been resolved at
+# import time above; the runtime allocator is forced into expandable mode
+# via _set_allocator_settings in __main__ below.
+if _PRIOR_ALLOC_CONF is None:
+    os.environ.pop("PYTORCH_CUDA_ALLOC_CONF", None)
+else:
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = _PRIOR_ALLOC_CONF
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
@@ -38,4 +50,5 @@ sys.path.remove(str(REPO_ROOT))
 if __name__ == "__main__":
     if torch.cuda.is_available() and not IS_JETSON and not IS_WINDOWS:
         get_disabled_tests(".")
+        torch.cuda.memory._set_allocator_settings("expandable_segments:True")
         run_tests()


### PR DESCRIPTION
test_garbage_collect_expandable left expandable_segments:True in the runtime allocator config because parseArgs doesn't auto-reset that sticky knob. Later tests like test_allocate_in_thread_to_pool then saw a runtime/EXPANDABLE_SEGMENTS mismatch, making #158764 flaky.

The toggling tests now restore the suite's baseline (EXPANDABLE_SEGMENTS) in their finally; test_cuda_expandable_segments.py sets the env var before importing test_cuda; and TestCudaAllocator gets a tearDown that fails fast if any future test leaks the knob.

Fixes #158764
Fixes #180263

Authored with Claude.