### PR TITLE
[torch.package] Register package modules in sys.modules for Python 3.12 dataclass compat

### DIFF
--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -392,6 +392,12 @@ class PackageImporter(Importer):
                 f"module {module.__name__} already exists in _package_imported_modules"
             )
         _package_imported_modules[module.__name__] = module
+        # Also register in sys.modules under the mangled name so that
+        # stdlib code (e.g. dataclasses._is_type in Python 3.12+) that
+        # does sys.modules.get(cls.__module__) can find the module.
+        # The mangled name (e.g. "<torch_package_0>.foo.bar") is unique
+        # and won't collide with normal module names.
+        sys.modules[module.__name__] = module
 
         # preemptively install on the parent to prevent IMPORT_FROM from trying to
         # access sys.modules


### PR DESCRIPTION
Summary:
In Python 3.12, `dataclasses._is_type()` calls `sys.modules.get(cls.__module__).__dict__` to resolve `ClassVar`/`InitVar` annotations. When a `dataclass` is defined inside a torch.package, `cls.__module__` is set to a mangled name (e.g. `<torch_package_0>.foo.bar`). This mangled name is registered in the private `_package_imported_modules` registry but NOT in `sys.modules`, so the lookup returns `None` and accessing `.__dict__` raises `AttributeError: 'NoneType' object has no attribute '__dict__'`.

Fix: also register the module in `sys.modules` under its mangled name. The mangled name is guaranteed unique (asserted at line 390) and starts with `<torch_package_N>` so it cannot collide with normal module names. This is safe for package isolation — normal imports use non-mangled names.

This fixes the root cause of multiple test failures like `smallworld_dlrm_training_platform_backward_compat_offline_training_unittest_gpu` where model packages contain `dataclass` classes. Previously each affected module had to be individually added to the extern list (D92928989, D101269942, D103087071).

Test Plan: buck2 test fbcode//caffe2/torch/package/test:test_package

Differential Revision: D103148235


