### PR TITLE
Fix CuteDSL FlexAttention crash with shared captured buffers

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -1107,6 +1107,43 @@ class TestFlexFlash(InductorTestCase):
 
     @xfailIfSM120OrLater
     @dtypes(torch.float16, torch.bfloat16)
+    def test_flash_attention_shared_captured_buffers(self, device, dtype):
+        """Captured closure buffers shared with other graph ops must not be
+        freed before the FlexAttention kernel runs."""
+        B, H, Q_LEN, KV_LEN, D = 2, 4, 256, 512, 128
+
+        def model(q, k, v, rule_masks_per_query, prefix_mask, backend=None):
+            masks = rule_masks_per_query & prefix_mask.unsqueeze(0)
+
+            def mask_mod(b, h, q_idx, kv_idx):
+                return masks[q_idx, b, kv_idx]
+
+            block_mask = create_block_mask(
+                mask_mod, B=B, H=None, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device=device,
+            )
+            kernel_options = {"BACKEND": backend} if backend else {}
+            return flex_attention(
+                q, k, v,
+                block_mask=block_mask,
+                kernel_options=kernel_options,
+            )
+
+        q = torch.randn(B, H, Q_LEN, D, device=device, dtype=dtype)
+        k = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
+        v = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
+        rule_masks = torch.randint(0, 2, (Q_LEN, B, KV_LEN), dtype=torch.bool, device=device)
+        prefix = torch.randint(0, 2, (B, KV_LEN), dtype=torch.bool, device=device)
+
+        ref = model(q.float(), k.float(), v.float(), rule_masks, prefix)
+        torch._dynamo.reset()
+        triton_out = torch.compile(model, dynamic=False)(q, k, v, rule_masks, prefix, "TRITON")
+        torch._dynamo.reset()
+        flash_out = torch.compile(model, dynamic=False)(q, k, v, rule_masks, prefix, "FLASH")
+        torch.testing.assert_close(triton_out, ref.to(dtype), atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(flash_out, ref.to(dtype), atol=1e-2, rtol=1e-2)
+
+    @xfailIfSM120OrLater
+    @dtypes(torch.float16, torch.bfloat16)
     def test_flash_attention_kernel_called(self, device, dtype):
         q, k, v = create_test_tensors(dtype=dtype, device=device)
         compiled_fn = torch.compile(flex_attention)

--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -1119,11 +1119,18 @@ class TestFlexFlash(InductorTestCase):
                 return masks[q_idx, b, kv_idx]
 
             block_mask = create_block_mask(
-                mask_mod, B=B, H=None, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device=device,
+                mask_mod,
+                B=B,
+                H=None,
+                Q_LEN=Q_LEN,
+                KV_LEN=KV_LEN,
+                device=device,
             )
             kernel_options = {"BACKEND": backend} if backend else {}
             return flex_attention(
-                q, k, v,
+                q,
+                k,
+                v,
                 block_mask=block_mask,
                 kernel_options=kernel_options,
             )
@@ -1131,14 +1138,20 @@ class TestFlexFlash(InductorTestCase):
         q = torch.randn(B, H, Q_LEN, D, device=device, dtype=dtype)
         k = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
         v = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
-        rule_masks = torch.randint(0, 2, (Q_LEN, B, KV_LEN), dtype=torch.bool, device=device)
+        rule_masks = torch.randint(
+            0, 2, (Q_LEN, B, KV_LEN), dtype=torch.bool, device=device
+        )
         prefix = torch.randint(0, 2, (B, KV_LEN), dtype=torch.bool, device=device)
 
         ref = model(q.float(), k.float(), v.float(), rule_masks, prefix)
         torch._dynamo.reset()
-        triton_out = torch.compile(model, dynamic=False)(q, k, v, rule_masks, prefix, "TRITON")
+        triton_out = torch.compile(model, dynamic=False)(
+            q, k, v, rule_masks, prefix, "TRITON"
+        )
         torch._dynamo.reset()
-        flash_out = torch.compile(model, dynamic=False)(q, k, v, rule_masks, prefix, "FLASH")
+        flash_out = torch.compile(model, dynamic=False)(
+            q, k, v, rule_masks, prefix, "FLASH"
+        )
         torch.testing.assert_close(triton_out, ref.to(dtype), atol=1e-2, rtol=1e-2)
         torch.testing.assert_close(flash_out, ref.to(dtype), atol=1e-2, rtol=1e-2)
 

--- a/torch/_inductor/codegen/cutedsl/cutedsl_template.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_template.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from typing import Any
 from unittest.mock import patch
 
-from torch._inductor.utils import Placeholder
+from torch._inductor.utils import Placeholder, unique
 from torch._inductor.virtualized import V
 from torch._logging import getArtifactLogger
 
@@ -90,6 +90,21 @@ class CuteDSLTemplate(KernelTemplate):
             code = kernel.render(self.template, **kwargs)
 
             log.debug("Generated CuteDSL Code:\n%s", code)
+
+            # Append captured closure buffers discovered during rendering
+            input_call_args = tuple(kernel.args.input_buffers.keys())
+            expected_input_args = tuple(unique(x.get_name() for x in input_nodes))
+            assert input_call_args[: len(expected_input_args)] == expected_input_args, (
+                input_call_args,
+                expected_input_args,
+            )
+            if len(input_call_args) > len(expected_input_args):
+                kernel_input_nodes = tuple(
+                    V.graph.get_buffer(k) for k in input_call_args
+                )
+                input_nodes = list(input_nodes) + list(
+                    kernel_input_nodes[len(expected_input_args) :]
+                )
 
             bmreq = CuteDSLBenchmarkRequest(
                 kernel_name=kernel_name,

--- a/torch/_inductor/codegen/cutedsl/cutedsl_template.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_template.py
@@ -64,7 +64,7 @@ class CuteDSLTemplate(KernelTemplate):
             return NotImplementedError(f"CuteDSL template failed: {e}")
 
     def generate(self, **kwargs: Any) -> ChoiceCaller:
-        """Generate the CuteDSL kernel caller."""
+        """Generate the CuteDSL kernel caller for template autotuning."""
         input_nodes = kwargs.pop("input_nodes")
         layout = kwargs.pop("layout")
         mutated_inputs = kwargs.pop("mutated_inputs", None)

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -278,6 +278,10 @@ def flex_attention(
         num_score_mod_placeholders=len(placeholder_inps),
         backend=backend,
     ):
+        score_mod_other_buffers = maybe_realize(score_mod_other_buffers)
+        mask_mod_other_buffers = maybe_realize(mask_mod_other_buffers)
+        freeze_irnodes(score_mod_other_buffers)
+        freeze_irnodes(mask_mod_other_buffers)
         return create_flex_flash_attention_kernel(
             query,
             key,


### PR DESCRIPTION
When a closure captures a tensor that is also used by another operation in the same compiled graph, the CuteDSL (FLASH) backend crashes with either:

```
CuteDSL template failed: convert FlexibleLayout to FixedLayout first
```
or after getting past compilation:
```
UnboundLocalError: cannot access local variable 'buf0' where it is not associated with a value
```

The Triton backend handles the same model correctly.

Two fixes, both mirroring what the Triton path already does:

1. **`flex_attention.py`**: Call `maybe_realize`/`freeze_irnodes` on captured buffers before the CuteDSL early return.
2. **`cutedsl_template.py`**: Augment `input_nodes` with captured buffers discovered during rendering (via `kernel.args.input_buffers`), so the scheduler tracks them as read dependencies.

Added test which compares eager, Triton and CuteDSL. 

Fixes #181800

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo