### PR TITLE
[inductor] Use scaled persistent configs for Blackwell scaled-mm TMA heuristic

### DIFF
--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -7,6 +7,7 @@ from torch._inductor.template_heuristics.triton import (
     BlackwellGPUGemmConfig,
     CUDABlackwellAddmmPersistentTMATemplateConfigHeuristic,
     CUDABlackwellPersistentTMATemplateConfigHeuristic,
+    CUDAScaledBlackwellTMATemplateConfigHeuristic,
 )
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
@@ -371,6 +372,29 @@ class TestBlackwellExhaustiveConfigs(TestCase):
         self.assertEqual(num_stages_values, self.VALID_NUM_STAGES)
         self.assertEqual(num_warps_values, self.VALID_NUM_WARPS)
         self.assertEqual(epilogue_subtile_values, self.VALID_EPILOGUE_SUBTILE)
+
+    def test_scaled_blackwell_tma_uses_scaled_persistent_configs(self):
+        """Verify scaled Blackwell TMA heuristic uses blackwell_scaled_persistent_mm_configs."""
+        heuristic = CUDAScaledBlackwellTMATemplateConfigHeuristic()
+
+        for cfg in heuristic.mm_configs:
+            self.assertIsInstance(cfg, BlackwellGPUGemmConfig)
+
+        expected_configs = heuristic.blackwell_scaled_persistent_mm_configs
+        self.assertEqual(len(heuristic.mm_configs), len(expected_configs))
+        for actual, expected in zip(heuristic.mm_configs, expected_configs):
+            self.assertEqual(actual.block_m, expected.block_m)
+            self.assertEqual(actual.block_n, expected.block_n)
+            self.assertEqual(actual.block_k, expected.block_k)
+            self.assertEqual(actual.num_stages, expected.num_stages)
+            self.assertEqual(actual.num_warps, expected.num_warps)
+
+        addmm_configs = heuristic.blackwell_persistent_addmm_configs
+        self.assertGreater(
+            len(heuristic.mm_configs),
+            len(addmm_configs),
+            "Scaled TMA should use the larger scaled_persistent list, not the small addmm list",
+        )
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -617,7 +617,7 @@ class BaseConfigHeuristic(metaclass=BaseHeuristicSingleton):
             GemmConfig(64, 256, 128, 4, 4),
         ]
 
-        self.blackwell_scaled_persistent_mm_configs = [
+        self.blackwell_scaled_persistent_mm_configs: list[BaseConfig] = [
             BlackwellGPUGemmConfig(
                 block_m=c.block_m,
                 block_n=c.block_n,
@@ -2790,8 +2790,7 @@ class CUDAScaledBlackwellTMATemplateConfigHeuristic(
 
     def __init__(self) -> None:
         super().__init__()
-        # TODO: Tune scaled_persistent_mm_configs for Blackwell
-        self.mm_configs = self.blackwell_persistent_addmm_configs
+        self.mm_configs = self.blackwell_scaled_persistent_mm_configs
 
 
 @register_template_heuristic(


### PR DESCRIPTION
`CUDAScaledBlackwellTMATemplateConfigHeuristic` was using blackwell_persistent_addmm_configs (3 entries, all 256x128x64) as a placeholder. 
The TODO said "Tune scaled_persistent_mm_configs for Blackwell" but `blackwell_scaled_persistent_mm_configs` (13 entries with diverse block shapes) was already constructed and never wired up.

Switch `self.mm_configs` to use the existing
`blackwell_scaled_persistent_mm_configs` list. This gives the autotuner access to 13 diverse FP8-scaled configs instead of 3 identical-shape addmm configs that were never intended for the scaled-mm path.

Benchmark on GB200 (CUDA 13.2), per-tensor FP8 E4M3 scaled-mm, max-autotune, Blackwell TMA persistent kernel, `torch.utils.benchmark` (blocked_autorange, min_run_time=2s):

## Benchmark Results (GB200, CUDA 13.2)

Comparison of old 3-entry `blackwell_persistent_addmm_configs` (all 256x128x64)
vs new 13-entry `blackwell_scaled_persistent_mm_configs` on representative MoE
and LLM shapes. Per-tensor FP8 E4M3 scaled-mm, `max-autotune-no-cudagraphs`,
Blackwell TMA persistent kernel. Measured with `torch.utils.benchmark.Timer`
(`blocked_autorange`, `min_run_time=2s`).

| Shape (MxKxN) | Old (us) | New (us) | Delta |
|---|---:|---:|---:|
| 256x7168x2048 | 39.8 | 38.6 | -3.0% |
| 512x7168x2048 | 40.5 | 38.6 | -4.7% |
| 1024x7168x2048 | 40.8 | 38.3 | -6.1% |
| 2048x7168x2048 | 41.2 | 38.6 | -6.3% |
| 4096x7168x2048 | 90.6 | 56.4 | -37.7% |
| 256x2048x7168 | 38.5 | 38.9 | +1.0% |
| 512x2048x7168 | 37.9 | 38.8 | +2.4% |
| 1024x2048x7168 | 38.2 | 38.8 | +1.6% |
| 2048x2048x7168 | 39.0 | 38.3 | -1.8% |
| 4096x2048x7168 | 85.1 | 60.4 | -29.0% |
| 512x4096x14336 | 57.6 | 38.7 | -32.8% |
| 512x14336x4096 | 74.4 | 37.9 | -49.1% |
| 2048x4096x4096 | 47.6 | 38.8 | -18.5% |
| 4096x4096x4096 | 98.9 | 64.0 | -35.3% |

note: Small 1-2% regressions on Mx2048x7168 shapes where the old tiling happened to be reasonable.

Used Claude Opus 4.7

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos