### PR TITLE
[inductor][autotuning] add IncrementalAutotunePlugin (#182010)

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -1552,6 +1552,7 @@ exclusions = {
     "loop_tiling",
     "auto_chunker",
     "autotuning",
+    "incremental",
     "graph_region_expansion",
     "hierarchical_compile",
     "compute_dependencies",

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5583,6 +5583,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             "autotune_remote_cache": config.autotune_remote_cache,
             "force_disable_caches": config.force_disable_caches,
             "dynamic_scale_rblock": config.dynamic_scale_rblock,
+            "incremental_autotune": config.incremental_autotune,
             "max_autotune": config.max_autotune,
             "max_autotune_pointwise": config.max_autotune_pointwise,
             "min_split_scan_rblock": config.triton.min_split_scan_rblock,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -512,6 +512,14 @@ max_autotune_pointwise = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_POINTWISE") 
 # enable slow autotuning passes to select gemm algorithms
 max_autotune_gemm = os.environ.get("TORCHINDUCTOR_MAX_AUTOTUNE_GEMM") == "1"
 
+# When True, autotuning is spread across real kernel invocations instead of
+# blocking on the first call. Each run() call executes one config and records
+# timing via CUDA events, progressively eliminating underperforming configs.
+# An additional JK gate inside the plugin can still block the feature on True.
+incremental_autotune: bool | None = get_tristate_env(
+    "TORCHINDUCTOR_INCREMENTAL_AUTOTUNE", default=False
+)
+
 inductor_default_autotune_warmup = int(
     os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_WARMUP", 25)
 )

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -395,6 +395,13 @@ def get_caching_autotuner_plugins(
     imports kept inside the relevant branch.
     """
     plugins: list[CachingAutotunerPlugin] = []
+    if autotuner.inductor_meta.get("incremental_autotune", False):
+        try:
+            from .fb.incremental import IncrementalAutotunePlugin
+
+            plugins.append(IncrementalAutotunePlugin())
+        except ImportError:
+            pass
     return plugins
 
 

--- a/torch/_logging/_internal.py
+++ b/torch/_logging/_internal.py
@@ -257,6 +257,7 @@ def set_logs(
     cudagraph_static_inputs: bool = False,
     benchmarking: bool = False,
     autotuning: bool = False,
+    incremental: bool = False,
     graph_region_expansion: bool = False,
     inductor_metrics: bool = False,
     hierarchical_compile: bool = False,
@@ -457,6 +458,9 @@ def set_logs(
         autotuning (:class:`bool`):
             Autotuning choice logs, such as kernel source, perf, and tuning parameters. Default: ``False``
 
+        incremental (:class:`bool`):
+            Incremental autotuning logs. Default: ``False``
+
         graph_region_expansion (:class:`bool`):
             Whether to emit the detailed steps of the duplicate graph region tracker expansion algorithm. Default: ``False``
 
@@ -585,6 +589,7 @@ def set_logs(
         cudagraph_static_inputs=cudagraph_static_inputs,
         benchmarking=benchmarking,
         autotuning=autotuning,
+        incremental=incremental,
         graph_region_expansion=graph_region_expansion,
         inductor_metrics=inductor_metrics,
         hierarchical_compile=hierarchical_compile,

--- a/torch/_logging/_registrations.py
+++ b/torch/_logging/_registrations.py
@@ -241,6 +241,11 @@ register_artifact(
     off_by_default=True,
 )
 register_artifact(
+    "incremental",
+    "Incremental autotuning logs.",
+    off_by_default=True,
+)
+register_artifact(
     "node_runtime_estimation",
     "Node runtime estimation for compile-time optimization decisions.",
     off_by_default=True,


### PR DESCRIPTION
Summary:

TLDR; this version is incomplete and not yet fully optimized, and is landing only to serve specific, tested internal use cases. a distinct, new version will land separately in the coming weeks, not gated to fb-only, which will be complete feature-wise and fully optimized.

Adds incremental autotuning as a `CachingAutotunerPlugin` and lands the supporting state machine, daemon-resolved CUDA-event timing, dispatch-sampling, and cross-recompilation state-sharing pieces from the prior research stack — but rewired against the new plugin infrastructure so the integration points on `CachingAutotuner` itself are zero (the plugin owns all the new state, the autotuner just gets a `_plugins` entry from `get_caching_autotuner_plugins`).

The new module lives at `torch/_inductor/runtime/fb/incremental/` (separate from the upstream-friendly `runtime/` files):

- `_state.py` — `IncrementalAutotuneState`: round-robin dispatch, warmup → sampling queue transition, threshold-based progressive filtering, convergence detection (early when only the best survives, or when both queues drain).
- `_resolver.py` — global daemon thread that synchronizes CUDA events and writes timings back into states off the hot path.
- `_stats.py` — per-launcher timing stats (median over a sorted insertion list).
- `_utils.py` — JK gate + artifact logger.
- `config.py` — tunable thresholds and queue sizes.
- `_plugin.py` — `IncrementalAutotunePlugin(CachingAutotunerPlugin)`: `pre_autotune` hook initializes the state from `autotuner.launchers` (or joins/inherits one from the cross-recompilation registry, keyed by a content hash over normalized source + inductor/Triton metadata + configs); `pre_dispatch` routes calls through the state and finalizes when joined-shared states converge.

`get_caching_autotuner_plugins` registers the plugin gated on `inductor_meta["incremental_autotune"]`; `codegen/triton.py` threads `config.incremental_autotune` into `inductor_meta`. `config.py` exposes `incremental_autotune: bool | None` (env: `TORCHINDUCTOR_INCREMENTAL_AUTOTUNE`) and `incremental_autotune_exclude: list[HeuristicType]` (defaults exclude reduction kernels because varying RBLOCK / num_warps shifts numerics). `torch._logging` registers an `incremental` artifact for the new module's logger.

The plugin's `pre_autotune` collapses launchers to `[best]` and DEFERs when joining a converged shared state, so the standard fast-path takes over; for new and joined-in-progress states it returns the dispatch result directly. Once convergence finalizes (state's `on_convergence_fn`), `autotuner.launchers = [best]`, the plugin clears its state, and steady-state runs hit the autotuner's existing `_cached_launcher` fast path with no plugin overhead.

Test Plan:
```
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:test_incremental_autotune
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:triton_heuristics
```

Reviewed By: atalman

Differential Revision: D103165295




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98