### PR TITLE
Rename vec256_tests to vec_tests and fix executable search

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2020,16 +2020,16 @@ test_cpp_extensions() {
   assert_git_not_dirty
 }
 
-test_vec256() {
-  # This is to test vec256 instructions DEFAULT/AVX/AVX2 (platform dependent, some platforms might not support AVX/AVX2)
+test_vec() {
+  # This is to test vec instructions DEFAULT/AVX/AVX2 (platform dependent, some platforms might not support AVX/AVX2)
   if [[ "$BUILD_ENVIRONMENT" != *rocm* ]]; then
-    echo "Testing vec256 instructions"
-    mkdir -p test/test-reports/vec256
+    echo "Testing vec instructions"
+    mkdir -p test/test-reports/vec
     pushd build/bin
-    vec256_tests=$(find . -maxdepth 1 -executable -name 'vec256_test*')
-    for vec256_exec in $vec256_tests
+    vec_tests=$(find . -maxdepth 1 -executable -name 'vec_test*')
+    for vec_exec in $vec_tests
     do
-      $vec256_exec --gtest_output=xml:test/test-reports/vec256/"$vec256_exec".xml
+      $vec_exec --gtest_output=xml:test/test-reports/vec/"$vec_exec".xml
     done
     popd
     assert_git_not_dirty
@@ -2361,7 +2361,7 @@ else
   install_monkeytype
   test_python
   test_aten
-  test_vec256
+  test_vec
   test_libtorch
   test_aot_compilation
   test_custom_script_ops

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2313,6 +2313,7 @@ elif [[ "${SHARD_NUMBER}" == 1 && $NUM_TEST_SHARDS -gt 1 ]]; then
   install_torchvision
   test_python_shard 1
   test_aten
+  test_vec
   test_libtorch 1
   if [[ "${BUILD_ENVIRONMENT}" == *xpu* ]]; then
     test_xpu_bin


### PR DESCRIPTION
It looks like https://github.com/pytorch/pytorch/pull/58438 renamed vec265 to vec, which appears that it would cause `vec256_tests=$(find . -maxdepth 1 -executable -name 'vec256_test*')` to return empty in test.sh.

So it looks like we may not have been running any vectorized c++ tests in CI for around 5 years.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182013

@aditew01 @fadara01 @malfet @jgong5 
