### PR TITLE
[inductor] Conditionalize `dynamic_disable_pipelining` workaround on `is_fbcode`

### DIFF
--- a/test/inductor/test_max_autotune_blackwell.py
+++ b/test/inductor/test_max_autotune_blackwell.py
@@ -294,7 +294,7 @@ class TestMaxAutotuneBlackwell(TestCase):
                 #
                 # This only happens in fbcode https://www.internalfb.com/diff/D101855575.
                 # Can not repro it in OSS build.
-                "triton.dynamic_disable_pipelining": False,
+                "triton.dynamic_disable_pipelining": not config.is_fbcode(),
             }
         ):
             c_actual, code = run_and_get_code(


### PR DESCRIPTION
The Blackwell addmm TMA test previously set `dynamic_disable_pipelining=False` unconditionally to work around an fbcode-internal misaligned-access issue (D101855575) that was never reproducible in OSS builds.

Change to `not config.is_fbcode()` so that:
- fbcode builds keep the workaround (False)
- OSS builds use the default (True)

Validated on GB200 (4x NVIDIA GB200, Triton 3.7.0, CUDA 13.2):
- 106/106 Blackwell tests pass in OSS with the default setting

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo