### PR TITLE
[inductor][estimations] Tera = 1e12

### DIFF
--- a/torch/utils/_runtime_estimation.py
+++ b/torch/utils/_runtime_estimation.py
@@ -94,8 +94,7 @@ def get_compute_time(func_packet, args, kwargs, out, out_dtypes) -> float:  # ty
                 f"Only support single out dtype got {out_dtypes} for {func_packet}"
             )
         dtype = out_dtypes.pop()
-        # This actually gives peta-FLOPs/s hence multiply by 1e15 to get the FLOPs/s
-        peak_gpu_flops = get_device_tflops(dtype) * 1e15
+        peak_gpu_flops = get_device_tflops(dtype) * 1e12
         # We can expect to achieve 75% of theoretical peak flops
         factor = 0.75
         peak_empirical_flops = factor * peak_gpu_flops


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182017

`get_device_tflops()` returns TFLOPS (e.g. 1979 for H100 BF16), as
confirmed by `datasheet_tops()` which documents "theoretical TFLOPS".
To convert to FLOPS/s the multiplier must be 1e12 (tera = 10^12).

The code used 1e15 (peta), making the theoretical peak 1000x too high
and every compute-time estimate 1000x too small. The old comment
saying "peta-FLOPs/s" was documenting the bug, not the correct unit.

The scheduler (`scheduler.py`) already uses the correct `* 10**12`.

Authored with Claude.