### PR TITLE
[docs] Fix typo in data page

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -183,7 +183,7 @@ class DataLoader(Generic[_T_co]):
             input, after seeding and before data loading. (default: ``None``)
         multiprocessing_context (str or multiprocessing.context.BaseContext, optional): If
             ``None``, the default
-            `multiprocessing context <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_ # noqa: D401
+            `multiprocessing context <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_
             of your operating system will
             be used. (default: ``None``)
         generator (torch.Generator, optional): If not ``None``, this RNG will be used


### PR DESCRIPTION
**Description**:

Corrected a minor typo in the [[utils.data]](https://docs.pytorch.org/docs/2.11/data.html) docs (see multiprocessing_context) to improve readability.

No functional changes included.

