### PR TITLE
[MPS] Use MetalPerformancePrimitives for F.linear on macOS 26+

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Linear.metal
+++ b/aten/src/ATen/native/mps/kernels/Linear.metal
@@ -1,72 +1,110 @@
 // MPP (MetalPerformancePrimitives) matmul2d kernel for F.linear.
 // Computes C[M,N] = A[M,K] @ B[N,K]^T with optional fused bias.
-// Multiple tile-size variants are instantiated; the host selects the best one
-// based on input dimensions.
+// NEEDS_PADDING=false: M and N must be tile-aligned; emits no per-tile
+// bounds checks. NEEDS_PADDING=true: handles arbitrary M and N — interior
+// tiles still take the fast static-extent path, edge tiles fall through to
+// a dynamic-extent slice that lets matmul2d zero-extend OOB reads and clip
+// OOB writes. The host picks the variant based on whether M and N are
+// tile-aligned.
 // Requires Metal 4.0 (macOS 26+).
 #if __METAL_VERSION__ >= 400
 #include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
 using namespace metal;
 using namespace mpp::tensor_ops;
 
-template <typename T, bool HAS_BIAS, int TILE_M, int TILE_N>
+template <typename T, bool HAS_BIAS, bool NEEDS_PADDING, int TILE_M, int TILE_N>
 kernel void mpp_linear(
     device T* A [[buffer(0)]],
     device T* B [[buffer(1)]],
     device T* C [[buffer(2)]],
     device T* bias [[buffer(3)]],
-    constant uint3 &sizes [[buffer(4)]],
+    constant uint3& sizes [[buffer(4)]],
     uint2 tgid [[threadgroup_position_in_grid]],
-    uint tid [[thread_index_in_threadgroup]])
-{
-    const uint M = sizes.x;
-    const uint K = sizes.y;
-    const uint N = sizes.z;
+    uint tid [[thread_index_in_threadgroup]]) {
+  const uint M = sizes.x;
+  const uint K = sizes.y;
+  const uint N = sizes.z;
+  const uint m_off = tgid.y * TILE_M;
+  const uint n_off = tgid.x * TILE_N;
 
-    device T* A_tile = A + tgid.y * TILE_M * K;
-    device T* B_tile = B + tgid.x * TILE_N * K;
-    device T* C_tile = C + tgid.y * TILE_M * N + tgid.x * TILE_N;
+  // Convention: rank0 is the fast / contiguous dim (K for A and B, N for C),
+  // rank1 is the slow / outer dim. A is [M,K] row-major, B is [N,K] row-major;
+  // matmul2d transposes B at run time.
+  using ext2d = dextents<int32_t, 2>;
+  tensor<device T, ext2d, tensor_inline> mA_full(A, ext2d((int)K, (int)M));
+  tensor<device T, ext2d, tensor_inline> mB_full(B, ext2d((int)K, (int)N));
+  tensor<device T, ext2d, tensor_inline> mC_full(C, ext2d((int)N, (int)M));
 
-    using ext_a = extents<int32_t, dynamic_extent, TILE_M>;
-    using ext_b = extents<int32_t, dynamic_extent, TILE_N>;
-    using ext_c = extents<int32_t, TILE_N, TILE_M>;
+  constexpr auto desc = matmul2d_descriptor(
+      TILE_M, TILE_N, static_cast<int>(dynamic_extent), false, true);
+  matmul2d<desc, execution_simdgroups<4>> op;
 
-    tensor<device T, ext_a, tensor_inline> mA(A_tile, ext_a(K));
-    tensor<device T, ext_b, tensor_inline> mB(B_tile, ext_b(K));
-    tensor<device T, ext_c, tensor_inline> mC(
-        C_tile, ext_c(), array<int32_t, 2>{1, (int)N});
-
-    constexpr auto desc = matmul2d_descriptor(
-        TILE_M, TILE_N, static_cast<int>(dynamic_extent), false, true);
-    matmul2d<desc, execution_simdgroups<4>> op;
+  // Static-extent slice: matmul2d treats the tile as fully in-bounds, no
+  // checks. Plain slice: dynamic extents, matmul2d emits per-access bounds
+  // checks. When NEEDS_PADDING is false the condition folds to true at compile
+  // time.
+  if (!NEEDS_PADDING || (m_off + TILE_M <= M && n_off + TILE_N <= N)) {
+    auto mA = mA_full.template slice<dynamic_extent, TILE_M>(0, (int)m_off);
+    auto mB = mB_full.template slice<dynamic_extent, TILE_N>(0, (int)n_off);
+    auto mC = mC_full.template slice<TILE_N, TILE_M>((int)n_off, (int)m_off);
     op.run(mA, mB, mC);
+  } else {
+    auto mA = mA_full.slice(0, (int)m_off);
+    auto mB = mB_full.slice(0, (int)n_off);
+    auto mC = mC_full.slice((int)n_off, (int)m_off);
+    op.run(mA, mB, mC);
+  }
 
-    if (HAS_BIAS) {
-        constexpr uint TG_SIZE = 4 * 32;
-        device T* bias_tile = bias + tgid.x * TILE_N;
-        for (uint i = tid; i < TILE_M * TILE_N; i += TG_SIZE) {
-            uint m = i / TILE_N;
-            uint n = i % TILE_N;
-            C_tile[m * N + n] += bias_tile[n];
+  if (HAS_BIAS) {
+    constexpr uint TG_SIZE = 4 * 32;
+    device T* bias_tile = bias + n_off;
+    if (NEEDS_PADDING) {
+      const uint m_lim = M - m_off < (uint)TILE_M ? M - m_off : (uint)TILE_M;
+      const uint n_lim = N - n_off < (uint)TILE_N ? N - n_off : (uint)TILE_N;
+      for (uint i = tid; i < TILE_M * TILE_N; i += TG_SIZE) {
+        uint m = i / TILE_N;
+        uint n = i % TILE_N;
+        if (m < m_lim && n < n_lim) {
+          C[(m_off + m) * N + (n_off + n)] += bias_tile[n];
         }
+      }
+    } else {
+      device T* C_tile = C + m_off * N + n_off;
+      for (uint i = tid; i < TILE_M * TILE_N; i += TG_SIZE) {
+        uint m = i / TILE_N;
+        uint n = i % TILE_N;
+        C_tile[m * N + n] += bias_tile[n];
+      }
     }
+  }
 }
 
-#define INSTANTIATE_TILE(T, suffix, TM, TN)                                       \
-template [[host_name("mpp_linear_" #TM "x" #TN "_" #suffix)]]                    \
-kernel void mpp_linear<T, false, TM, TN>(device T*, device T*, device T*,        \
-    device T*, constant uint3&, uint2, uint);                                     \
-template [[host_name("mpp_linear_bias_" #TM "x" #TN "_" #suffix)]]               \
-kernel void mpp_linear<T, true, TM, TN>(device T*, device T*, device T*,         \
-    device T*, constant uint3&, uint2, uint);
+#define INSTANTIATE_VARIANT(T, suffix, TM, TN, name, HAS_BIAS, PAD)      \
+  template [[host_name("mpp_linear_" name "_" #TM "x" #TN "_" #suffix)]] \
+  kernel void mpp_linear<T, HAS_BIAS, PAD, TM, TN>(                      \
+      device T*,                                                         \
+      device T*,                                                         \
+      device T*,                                                         \
+      device T*,                                                         \
+      constant uint3&,                                                   \
+      uint2,                                                             \
+      uint);
 
-#define INSTANTIATE(T, suffix)     \
-INSTANTIATE_TILE(T, suffix, 32, 32)  \
-INSTANTIATE_TILE(T, suffix, 64, 64)  \
-INSTANTIATE_TILE(T, suffix, 128, 64)
+#define INSTANTIATE_TILE(T, suffix, TM, TN)                           \
+  INSTANTIATE_VARIANT(T, suffix, TM, TN, "aligned", false, false)     \
+  INSTANTIATE_VARIANT(T, suffix, TM, TN, "aligned_bias", true, false) \
+  INSTANTIATE_VARIANT(T, suffix, TM, TN, "dyn", false, true)          \
+  INSTANTIATE_VARIANT(T, suffix, TM, TN, "dyn_bias", true, true)
+
+#define INSTANTIATE(T, suffix)        \
+  INSTANTIATE_TILE(T, suffix, 32, 32) \
+  INSTANTIATE_TILE(T, suffix, 64, 64) \
+  INSTANTIATE_TILE(T, suffix, 128, 64)
 
 INSTANTIATE(float, float)
 INSTANTIATE(half, half)
 INSTANTIATE(bfloat, bfloat)
 #undef INSTANTIATE
 #undef INSTANTIATE_TILE
+#undef INSTANTIATE_VARIANT
 #endif // __METAL_VERSION__ >= 400

--- a/aten/src/ATen/native/mps/kernels/Linear.metal
+++ b/aten/src/ATen/native/mps/kernels/Linear.metal
@@ -1,0 +1,72 @@
+// MPP (MetalPerformancePrimitives) matmul2d kernel for F.linear.
+// Computes C[M,N] = A[M,K] @ B[N,K]^T with optional fused bias.
+// Multiple tile-size variants are instantiated; the host selects the best one
+// based on input dimensions.
+// Requires Metal 4.0 (macOS 26+).
+#if __METAL_VERSION__ >= 400
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+using namespace metal;
+using namespace mpp::tensor_ops;
+
+template <typename T, bool HAS_BIAS, int TILE_M, int TILE_N>
+kernel void mpp_linear(
+    device T* A [[buffer(0)]],
+    device T* B [[buffer(1)]],
+    device T* C [[buffer(2)]],
+    device T* bias [[buffer(3)]],
+    constant uint3 &sizes [[buffer(4)]],
+    uint2 tgid [[threadgroup_position_in_grid]],
+    uint tid [[thread_index_in_threadgroup]])
+{
+    const uint M = sizes.x;
+    const uint K = sizes.y;
+    const uint N = sizes.z;
+
+    device T* A_tile = A + tgid.y * TILE_M * K;
+    device T* B_tile = B + tgid.x * TILE_N * K;
+    device T* C_tile = C + tgid.y * TILE_M * N + tgid.x * TILE_N;
+
+    using ext_a = extents<int32_t, dynamic_extent, TILE_M>;
+    using ext_b = extents<int32_t, dynamic_extent, TILE_N>;
+    using ext_c = extents<int32_t, TILE_N, TILE_M>;
+
+    tensor<device T, ext_a, tensor_inline> mA(A_tile, ext_a(K));
+    tensor<device T, ext_b, tensor_inline> mB(B_tile, ext_b(K));
+    tensor<device T, ext_c, tensor_inline> mC(
+        C_tile, ext_c(), array<int32_t, 2>{1, (int)N});
+
+    constexpr auto desc = matmul2d_descriptor(
+        TILE_M, TILE_N, static_cast<int>(dynamic_extent), false, true);
+    matmul2d<desc, execution_simdgroups<4>> op;
+    op.run(mA, mB, mC);
+
+    if (HAS_BIAS) {
+        constexpr uint TG_SIZE = 4 * 32;
+        device T* bias_tile = bias + tgid.x * TILE_N;
+        for (uint i = tid; i < TILE_M * TILE_N; i += TG_SIZE) {
+            uint m = i / TILE_N;
+            uint n = i % TILE_N;
+            C_tile[m * N + n] += bias_tile[n];
+        }
+    }
+}
+
+#define INSTANTIATE_TILE(T, suffix, TM, TN)                                       \
+template [[host_name("mpp_linear_" #TM "x" #TN "_" #suffix)]]                    \
+kernel void mpp_linear<T, false, TM, TN>(device T*, device T*, device T*,        \
+    device T*, constant uint3&, uint2, uint);                                     \
+template [[host_name("mpp_linear_bias_" #TM "x" #TN "_" #suffix)]]               \
+kernel void mpp_linear<T, true, TM, TN>(device T*, device T*, device T*,         \
+    device T*, constant uint3&, uint2, uint);
+
+#define INSTANTIATE(T, suffix)     \
+INSTANTIATE_TILE(T, suffix, 32, 32)  \
+INSTANTIATE_TILE(T, suffix, 64, 64)  \
+INSTANTIATE_TILE(T, suffix, 128, 64)
+
+INSTANTIATE(float, float)
+INSTANTIATE(half, half)
+INSTANTIATE(bfloat, bfloat)
+#undef INSTANTIATE
+#undef INSTANTIATE_TILE
+#endif // __METAL_VERSION__ >= 400

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -7,21 +7,94 @@
 #include <ATen/ops/linear_backward_native.h>
 #include <ATen/ops/linear_native.h>
 
-// MTLGPUFamilyApple10 is only defined in the macOS 26+ SDK.
-#if !defined(__MAC_26_0)
-static constexpr auto MTLGPUFamilyApple10 = static_cast<MTLGPUFamily>(1010);
-#endif
-
 namespace at::native {
 
 using namespace mps;
 
-// MPSNDArrayMatrixMultiplication and MPSGraph matrixMultiplication produce
-// non-deterministic results for >2D fp16/bf16 inputs on Apple M5+ (Apple10 GPU family).
-// Flatten to 2D to work around the issue (See https://github.com/pytorch/pytorch/issues/180776 )
-static bool needs_nd_workaround(const Tensor& input) {
-  static const bool is_m5_or_newer = [MPSDevice::getInstance()->device() supportsFamily:MTLGPUFamilyApple10];
-  return input.dim() > 2 && is_m5_or_newer && (input.scalar_type() == kHalf || input.scalar_type() == kBFloat16);
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/Linear_metallib.h>
+#endif
+
+// Pad a 2D tensor along `dim` to a multiple of `align`, zero-filling.
+static Tensor pad_to_multiple(const Tensor& t, int64_t dim, int64_t align) {
+  int64_t size = t.size(dim);
+  int64_t padded = (size + align - 1) / align * align;
+  if (padded == size)
+    return t;
+  auto pad_sizes = t.sizes().vec();
+  pad_sizes[dim] = padded;
+  auto padded_t = at::zeros(pad_sizes, t.options());
+  padded_t.narrow(dim, 0, size).copy_(t);
+  return padded_t;
+}
+
+// Select tile sizes based on input dimensions.
+// Tuned on M5 Pro for fp16 across LLM and small shapes.
+static std::pair<int64_t, int64_t> select_tile_sizes(int64_t M, int64_t N) {
+  if (M >= 128 && N >= 64)
+    return {128, 64};
+  if (M >= 64 && N >= 64)
+    return {64, 64};
+  return {32, 32};
+}
+
+static void _mps_linear_mpp(const Tensor& input, const Tensor& weight, const Tensor& bias, Tensor& output) {
+  bool has_bias = bias.defined();
+
+  int64_t M = input.size(0);
+  int64_t K = input.size(1);
+  int64_t N = weight.size(0);
+
+  auto tile_sizes = select_tile_sizes(M, N);
+  int64_t TILE_M = tile_sizes.first;
+  int64_t TILE_N = tile_sizes.second;
+
+  // MPP matmul2d requires M and N to be multiples of tile sizes.
+  auto input_padded = pad_to_multiple(input, 0, TILE_M);
+  auto weight_padded = pad_to_multiple(weight, 0, TILE_N);
+  int64_t M_padded = input_padded.size(0);
+  int64_t N_padded = weight_padded.size(0);
+
+  auto bias_padded = has_bias ? pad_to_multiple(bias.contiguous(), 0, TILE_N) : bias;
+
+  bool needs_slice = (M_padded != M || N_padded != N);
+  auto output_buf = needs_slice ? at::empty({M_padded, N_padded}, output.options()) : output;
+
+  auto dtype_str = scalarToMetalTypeString(input);
+  auto tile_str = std::to_string(TILE_M) + "x" + std::to_string(TILE_N);
+  auto func_name = (has_bias ? "mpp_linear_bias_" : "mpp_linear_") + tile_str + "_" + dtype_str;
+  auto stream = getCurrentMPSStream();
+  auto pso = lib.getPipelineStateForFunc(func_name);
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      stream->endKernelCoalescing();
+      auto computeEncoder = stream->commandEncoder();
+      [computeEncoder setComputePipelineState:pso];
+
+      std::array<uint32_t, 3> sizes = {
+          static_cast<uint32_t>(M_padded), static_cast<uint32_t>(K), static_cast<uint32_t>(N_padded)};
+      if (has_bias) {
+        mtl_setArgs(computeEncoder, input_padded, weight_padded, output_buf, bias_padded, sizes);
+      } else {
+        mtl_setArgs(computeEncoder, input_padded, weight_padded, output_buf, output_buf, sizes);
+      }
+
+      NSUInteger simd_w = [pso threadExecutionWidth];
+      NSUInteger threads_per_tg = simd_w * 4;
+      uint32_t num_tg_x = static_cast<uint32_t>(N_padded / TILE_N);
+      uint32_t num_tg_y = static_cast<uint32_t>(M_padded / TILE_M);
+
+      [computeEncoder dispatchThreadgroups:MTLSizeMake(num_tg_x, num_tg_y, 1)
+                     threadsPerThreadgroup:MTLSizeMake(threads_per_tg, 1, 1)];
+    }
+  });
+
+  if (needs_slice) {
+    output.copy_(output_buf.narrow(0, 0, M).narrow(1, 0, N));
+  }
 }
 
 static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const Tensor& bias, Tensor& output) {
@@ -126,6 +199,22 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
   }
 
   const bool is_complex = input.is_complex() || weight.is_complex() || (is_bias_defined && bias.is_complex());
+
+  // MPP path: use MetalPerformancePrimitives matmul2d on macOS 26+.
+  // Handles arbitrary strides by contiguifying and flattening to 2D.
+  // Bias is fused into the kernel when it's 1D (the common case).
+  if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_26_0_PLUS) && !is_complex) {
+    auto input_c = input.contiguous();
+    auto input2d = input_c.dim() == 1 ? input_c.unsqueeze(0) : input_c.dim() > 2 ? input_c.flatten(0, -2) : input_c;
+    auto weight2d = weight.contiguous();
+    auto output2d = output.dim() == 1 ? output.unsqueeze(0) : output.dim() > 2 ? output.flatten(0, -2) : output;
+    bool fuse_bias = is_bias_defined && bias.dim() == 1;
+    _mps_linear_mpp(input2d, weight2d, fuse_bias ? bias : Tensor(), output2d);
+    if (is_bias_defined && !fuse_bias) {
+      output.add_(bias);
+    }
+    return weight_arg.dim() != 1 ? output : output.squeeze(-1);
+  }
 
   // No-graph execution causes nonsense if these are non-contiguous.
   const bool is_contiguous = input.is_contiguous() && weight.is_contiguous() && bias.is_contiguous();

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -220,13 +220,7 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
   const bool is_contiguous = input.is_contiguous() && weight.is_contiguous() && bias.is_contiguous();
 
   if (is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS) && is_contiguous && !is_complex) {
-    if (needs_nd_workaround(input) && (!is_bias_defined || bias.dim() <= 1)) {
-      auto input2d = input.flatten(0, -2);
-      auto output2d = output.flatten(0, -2);
-      _mps_linear_nograph(input2d, weight, bias, output2d);
-    } else {
-      _mps_linear_nograph(input, weight, bias, output);
-    }
+    _mps_linear_nograph(input, weight, bias, output);
     // Squeeze last dim of 1D linear
     return weight_arg.dim() != 1 ? output : output.squeeze(-1);
   }
@@ -255,10 +249,6 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
         // workaround to improve the performance with 3D+ inputs
         doReshape =
             input_size.size() > 2 && input_size[0] > 1 && input_size[1] >= 1 && input_size[1] <= 32 && bias.dim() <= 1;
-      }
-      // Non-deterministic results for >2D fp16/bf16 on Apple10+
-      if (!doReshape) {
-        doReshape = needs_nd_workaround(input);
       }
       auto inputFlattened = doReshape ? [mpsGraph flatten2DTensor:inputTensor axis:-1 name:nil] : inputTensor;
       auto outputTensor = [mpsGraph matrixMultiplicationWithPrimaryTensor:inputFlattened

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -17,19 +17,6 @@ static auto& lib = MetalShaderLibrary::getBundledLibrary();
 #include <ATen/native/mps/Linear_metallib.h>
 #endif
 
-// Pad a 2D tensor along `dim` to a multiple of `align`, zero-filling.
-static Tensor pad_to_multiple(const Tensor& t, int64_t dim, int64_t align) {
-  int64_t size = t.size(dim);
-  int64_t padded = (size + align - 1) / align * align;
-  if (padded == size)
-    return t;
-  auto pad_sizes = t.sizes().vec();
-  pad_sizes[dim] = padded;
-  auto padded_t = at::zeros(pad_sizes, t.options());
-  padded_t.narrow(dim, 0, size).copy_(t);
-  return padded_t;
-}
-
 // Select tile sizes based on input dimensions.
 // Tuned on M5 Pro for fp16 across LLM and small shapes.
 static std::pair<int64_t, int64_t> select_tile_sizes(int64_t M, int64_t N) {
@@ -51,20 +38,15 @@ static void _mps_linear_mpp(const Tensor& input, const Tensor& weight, const Ten
   int64_t TILE_M = tile_sizes.first;
   int64_t TILE_N = tile_sizes.second;
 
-  // MPP matmul2d requires M and N to be multiples of tile sizes.
-  auto input_padded = pad_to_multiple(input, 0, TILE_M);
-  auto weight_padded = pad_to_multiple(weight, 0, TILE_N);
-  int64_t M_padded = input_padded.size(0);
-  int64_t N_padded = weight_padded.size(0);
-
-  auto bias_padded = has_bias ? pad_to_multiple(bias.contiguous(), 0, TILE_N) : bias;
-
-  bool needs_slice = (M_padded != M || N_padded != N);
-  auto output_buf = needs_slice ? at::empty({M_padded, N_padded}, output.options()) : output;
+  // When M and N are already tile-aligned the aligned kernel runs without
+  // any per-tile bounds checks. Otherwise the dyn kernel handles edge tiles
+  // via dynamic-extent slices, so we never need to allocate padded buffers.
+  bool aligned = (M % TILE_M == 0) && (N % TILE_N == 0);
+  const char* variant = aligned ? "aligned" : "dyn";
 
   auto dtype_str = scalarToMetalTypeString(input);
   auto tile_str = std::to_string(TILE_M) + "x" + std::to_string(TILE_N);
-  auto func_name = (has_bias ? "mpp_linear_bias_" : "mpp_linear_") + tile_str + "_" + dtype_str;
+  auto func_name = std::string("mpp_linear_") + variant + (has_bias ? "_bias_" : "_") + tile_str + "_" + dtype_str;
   auto stream = getCurrentMPSStream();
   auto pso = lib.getPipelineStateForFunc(func_name);
 
@@ -74,27 +56,22 @@ static void _mps_linear_mpp(const Tensor& input, const Tensor& weight, const Ten
       auto computeEncoder = stream->commandEncoder();
       [computeEncoder setComputePipelineState:pso];
 
-      std::array<uint32_t, 3> sizes = {
-          static_cast<uint32_t>(M_padded), static_cast<uint32_t>(K), static_cast<uint32_t>(N_padded)};
+      std::array<uint32_t, 3> sizes = {static_cast<uint32_t>(M), static_cast<uint32_t>(K), static_cast<uint32_t>(N)};
       if (has_bias) {
-        mtl_setArgs(computeEncoder, input_padded, weight_padded, output_buf, bias_padded, sizes);
+        mtl_setArgs(computeEncoder, input, weight, output, bias, sizes);
       } else {
-        mtl_setArgs(computeEncoder, input_padded, weight_padded, output_buf, output_buf, sizes);
+        mtl_setArgs(computeEncoder, input, weight, output, output, sizes);
       }
 
       NSUInteger simd_w = [pso threadExecutionWidth];
       NSUInteger threads_per_tg = simd_w * 4;
-      uint32_t num_tg_x = static_cast<uint32_t>(N_padded / TILE_N);
-      uint32_t num_tg_y = static_cast<uint32_t>(M_padded / TILE_M);
+      uint32_t num_tg_x = static_cast<uint32_t>((N + TILE_N - 1) / TILE_N);
+      uint32_t num_tg_y = static_cast<uint32_t>((M + TILE_M - 1) / TILE_M);
 
       [computeEncoder dispatchThreadgroups:MTLSizeMake(num_tg_x, num_tg_y, 1)
                      threadsPerThreadgroup:MTLSizeMake(threads_per_tg, 1, 1)];
     }
   });
-
-  if (needs_slice) {
-    output.copy_(output_buf.narrow(0, 0, M).narrow(1, 0, N));
-  }
 }
 
 static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const Tensor& bias, Tensor& output) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #182038
* __->__ #182025

MPSNDArrayMatrixMultiplication and MPSGraph matrixMultiplication produce non-deterministic results for >2D fp16/bf16 inputs on M5 (macOS 26).
Replace them with a custom MPP matmul2d kernel on macOS 26+ that handles arbitrary strides (via contiguify+flatten), non-aligned sizes (via padding), and fuses 1D bias addition. Older macOS versions fall back to the existing nograph/MPSGraph paths unchanged.

Authored with Claude.