### PR TITLE
Skip Dynamo graph break for scalar-only bin_ops when tensorify is enabled (#182026)

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -16686,6 +16686,37 @@ class DynamoOpPromotionTests(torch._dynamo.test_case.TestCase):
         self.assertTrue(224 <= h <= 256)
         self.assertTrue(224 <= w <= 256)
 
+    def test_tensorify_scalar_only_bin_ops(self):
+        """When tensorify is enabled, torch bin_ops on scalar-only args should
+        not graph-break. The scalars are lifted as 0-dim tensor placeholders by
+        Dynamo; the tensorify pass converts them back to tensor ops."""
+        for op, expected in [
+            (torch.add, lambda a, b: a + b),
+            (torch.sub, lambda a, b: a - b),
+            (torch.mul, lambda a, b: a * b),
+            (torch.div, lambda a, b: a / b),
+        ]:
+            with self.subTest(op=op.__name__):
+
+                def fn(a, b):
+                    return op(a, b)
+
+                compiled = torch.compile(
+                    fn, backend="eager", dynamic=True, fullgraph=True
+                )
+                result = compiled(3.5, 2.0)
+                self.assertEqual(result, expected(3.5, 2.0))
+
+    def test_tensorify_scalar_only_bin_ops_int(self):
+        """Same as above but with integer scalar args."""
+
+        def fn(a, b):
+            return torch.add(a, b)
+
+        compiled = torch.compile(fn, backend="eager", dynamic=True, fullgraph=True)
+        result = compiled(5, 3)
+        self.assertEqual(result, 8)
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -67,7 +67,7 @@ test_failures = {
     "test_max_min_bool_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     # calling div on only symint args
     "test_AllenaiLongformerBase_repro_dynamic_shapes": TestFailure(
-        ("cpu", "cuda", "xpu", "mps")
+        ("cpu", "cuda", "xpu")
     ),
     "test_argmax_argmin_with_duplicates_dynamic_shapes": TestFailure(("mps",)),
     "test_batch_norm_2d_2_dynamic_shapes": TestFailure(("mps",)),

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -30,6 +30,7 @@ import functools
 import inspect
 import logging
 import math
+import os
 import re
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import nullcontext
@@ -243,6 +244,16 @@ def tracing_state_functions() -> dict[Callable[[], Any], bool | None]:
 
 
 bin_ops = dict.fromkeys(["add", "sub", "mul", "div", "sqrt"])
+
+
+@functools.cache
+def _is_tensorify_enabled() -> bool:
+    from torch._utils_internal import justknobs_check
+
+    if (env := os.getenv("TENSORIFY_PYTHON_SCALARS")) is not None:
+        return env not in ("0", "FALSE")
+    return justknobs_check("pytorch/compiler:tensorify_python_scalars")
+
 
 dispatch_key_set_functions = {
     torch._C._dispatch_keys,
@@ -2940,6 +2951,7 @@ class TorchInGraphFunctionVariable(BaseTorchVariable):
             and self.value.__name__ in bin_ops
             and any_symints_or_symfloats
             and all_ints_or_floats
+            and not _is_tensorify_enabled()
         ):
             msg = f"""\
 Calling {str(self.value)} on only torch.SymInt arguments is not yet supported.


### PR DESCRIPTION
Summary:

When `tensorify_python_scalars` is enabled and `dynamic=True`, Dynamo lifts Python float/int arguments as 0-dim tensor placeholders followed by `.item()` calls, producing SymFloat/SymInt values. The tensorify pass (in AOTAutograd) then converts scalar ops back to tensor ops.

However, `torch.add/sub/mul/div` on all-scalar args hit a graph break in TorchInGraphFunctionVariable ("Attempted to call torch in-graph function on only torch.SymInt arguments") that was added before the tensorify infrastructure existed. This prevents the graph from reaching AOTAutograd, so tensorify never runs.

Fix: check `_is_tensorify_enabled()` to skip the graph break when tensorify can handle the scalar-to-tensor conversion downstream. This allows scalar-only binary ops to be compiled rather than graph-broken.

The `_is_tensorify_enabled()` helper is moved to `torch/_dynamo/utils.py` so it is shared between the Dynamo tracing check (in `variables/torch.py`) and the tensorify FX pass itself (`torch/fx/passes/_tensorify_python_scalars.py`), eliminating the previous duplication.

A comment at the Dynamo call site documents that this is an intentional abstraction violation: Dynamo peeks at a downstream pass's config to decide whether to graph-break, because when tensorify is enabled these scalar-only ops will be handled later in the pipeline.

Changed files:
- `torch/_dynamo/utils.py`: Add shared `_is_tensorify_enabled()` (cached env var + JustKnobs check)
- `torch/_dynamo/variables/torch.py`: Import `_is_tensorify_enabled` from utils, add abstraction-violation comment, gate graph break on tensorify being disabled
- `torch/fx/passes/_tensorify_python_scalars.py`: Replace inline knob logic with import of shared `_is_tensorify_enabled()`
- `test/dynamo/test_misc.py`: Add `test_tensorify_scalar_only_bin_ops` and `test_tensorify_scalar_only_bin_ops_int` verifying scalar-only binary ops compile without graph break when tensorify is enabled

Test Plan:
## Unit Tests

Added two tests in `test_misc.py` (`DynamoOpPromotionTests`):
- `test_tensorify_scalar_only_bin_ops`: Verifies `torch.add/sub/mul/div(float, float)` with `dynamic=True` compiles without graph break when tensorify is enabled
- `test_tensorify_scalar_only_bin_ops_int`: Verifies `torch.add(int, int)` with `dynamic=True` compiles without graph break when tensorify is enabled

Differential Revision: D103055794




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98