### PR TITLE
Add a utility method for interrupting long running subprocess during run_test.py

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1053,6 +1053,12 @@ def parse_cmd_line_args():
 
     set_rng_seed()
 
+def _get_int_signal() -> signal.Signals:
+    """Get the interruption signal. SIGINT for unix, SIGTERM for windows."""
+    if IS_WINDOWS:
+        return signal.SIGTERM  # type: ignore[attr-defined]
+    else:
+        return signal.SIGINT
 
 def wait_for_process(p, timeout=None):
     try:
@@ -1067,8 +1073,11 @@ def wait_for_process(p, timeout=None):
             p.kill()
             raise
     except subprocess.TimeoutExpired:
-        # send SIGINT to give pytest a chance to make xml
-        p.send_signal(signal.SIGINT)
+        # Send the interrupt signal returned by `_get_int_signal()` to give
+        # pytest a chance to write XML: SIGINT on Unix-like platforms, but
+        # SIGTERM on Windows, where the Unix-style SIGINT handling is not used
+        # in the same way for subprocess interruption.
+        p.send_signal(_get_int_signal())
         exit_status = None
         try:
             exit_status = p.wait(timeout=5)


### PR DESCRIPTION
The Problem

When attempting to interrupt a long-running subprocess, the code was explicitly sending signal.SIGINT. On Windows, the subprocess.send_signal() method does not support SIGINT properly, causing it to throw a ValueError: Unsupported signal: 2.

While this doesn't necessarily crash the parent runner, it prevents the intended signal from ever reaching the subprocess and litters the logs with avoidable error stack traces.
The Solution

Introduced _get_int_signal() to provide the correct, platform-specific interruption signal:

    Windows: Returns signal.SIGTERM. In Python on Windows, send_signal(signal.SIGTERM) is the standard way to trigger a clean termination via TerminateProcess.

    Unix/Linux: Continues to return signal.SIGINT to allow for graceful handling and cleanup.

Impact

    Clean Exits: Subprocesses are now signaled correctly according to the host OS.

    Log Hygiene: Eliminates the noisy ValueError stack traces previously triggered during the shutdown sequence.

    Reliability: Ensures that the TimeoutExpired or cleanup blocks in our test logic can proceed as intended.