### PR TITLE
Add no-tree-loop-optimize pragma for apply_grad_input on GCC/AArch64

### DIFF
--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -488,6 +488,11 @@ void inline apply_grad_input(scalar_in* buffer_ptr, scalar_out* gin, int64_t siz
   return;
 }
 
+// Avoid GCC AArch64 tree-vectorization issues when adding float buffers to BFloat16/Half gradients.
+#if defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__)
+#pragma GCC push_options
+#pragma GCC optimize("no-tree-vectorize")
+#endif
 template <typename scalar_in, typename scalar_out,
           typename std::enable_if_t<is_reduced_floating_point_v<scalar_out> && std::is_same_v<scalar_in, float>, int> = 0>
 void inline apply_grad_input(scalar_in* buffer_ptr, scalar_out* gin, int64_t size) {
@@ -508,5 +513,8 @@ void inline apply_grad_input(scalar_in* buffer_ptr, scalar_out* gin, int64_t siz
     buffer_ptr[d] = 0;
   }
 }
+#if defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__)
+#pragma GCC pop_options
+#endif
 
 } // namespace at::native

--- a/aten/src/ATen/native/UpSample.h
+++ b/aten/src/ATen/native/UpSample.h
@@ -488,8 +488,8 @@ void inline apply_grad_input(scalar_in* buffer_ptr, scalar_out* gin, int64_t siz
   return;
 }
 
-// Avoid GCC AArch64 tree-vectorization issues when adding float buffers to BFloat16/Half gradients.
-#if defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__)
+// Avoid GCC < 14 AArch64 tree-vectorization issues when adding float buffers to BFloat16/Half gradients.
+#if defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__) && (__GNUC__ < 14)
 #pragma GCC push_options
 #pragma GCC optimize("no-tree-vectorize")
 #endif
@@ -513,7 +513,7 @@ void inline apply_grad_input(scalar_in* buffer_ptr, scalar_out* gin, int64_t siz
     buffer_ptr[d] = 0;
   }
 }
-#if defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__)
+#if defined(__GNUC__) && !defined(__clang__) && defined(__aarch64__) && (__GNUC__ < 14)
 #pragma GCC pop_options
 #endif
 

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -3199,7 +3199,6 @@ class TestConvolutionNNDeviceType(NNTestCase):
             gradgradcheck(convolution, inputs, nondet_tol=gradcheck_nondet_tol)
         )
 
-    @xfailIf(IS_LINUX and IS_ARM64)
     # see https://github.com/pytorch/pytorch/issues/177245
     @onlyCPU
     def test_conv_contiguous_for_oneDNN(self):
@@ -3225,9 +3224,11 @@ class TestConvolutionNNDeviceType(NNTestCase):
                 # Disable MKLDNN explicitly
                 with torch.backends.mkldnn.flags(enabled=False):
                     y_ = conv(x2)
-                    self.assertEqual(y, y_)
+                    if IS_LINUX and IS_ARM64 and dtype is torch.half:
+                        self.assertEqual(y, y_, rtol=1e-3, atol=3e-3)
+                    else:
+                        self.assertEqual(y, y_)
 
-    @xfailIf(IS_LINUX and IS_ARM64)
     # see https://github.com/pytorch/pytorch/issues/177245
     @onlyCPU
     def test_conv_ic1_channels_last_for_oneDNN(self):
@@ -3243,7 +3244,10 @@ class TestConvolutionNNDeviceType(NNTestCase):
                 # Disable MKLDNN explicitly
                 with torch.backends.mkldnn.flags(enabled=False):
                     y_ = conv(x)
-                    self.assertEqual(y, y_)
+                    if IS_LINUX and IS_ARM64 and dtype is torch.half:
+                        self.assertEqual(y, y_, rtol=1e-3, atol=3e-3)
+                    else:
+                        self.assertEqual(y, y_)
 
     @dtypes(torch.float, torch.cfloat)
     def test_conv_empty_channel(self, device, dtype):

--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -3199,6 +3199,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
             gradgradcheck(convolution, inputs, nondet_tol=gradcheck_nondet_tol)
         )
 
+    @xfailIf(IS_LINUX and IS_ARM64)
     # see https://github.com/pytorch/pytorch/issues/177245
     @onlyCPU
     def test_conv_contiguous_for_oneDNN(self):
@@ -3224,11 +3225,9 @@ class TestConvolutionNNDeviceType(NNTestCase):
                 # Disable MKLDNN explicitly
                 with torch.backends.mkldnn.flags(enabled=False):
                     y_ = conv(x2)
-                    if IS_LINUX and IS_ARM64 and dtype is torch.half:
-                        self.assertEqual(y, y_, rtol=1e-3, atol=3e-3)
-                    else:
-                        self.assertEqual(y, y_)
+                    self.assertEqual(y, y_)
 
+    @xfailIf(IS_LINUX and IS_ARM64)
     # see https://github.com/pytorch/pytorch/issues/177245
     @onlyCPU
     def test_conv_ic1_channels_last_for_oneDNN(self):
@@ -3244,10 +3243,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
                 # Disable MKLDNN explicitly
                 with torch.backends.mkldnn.flags(enabled=False):
                     y_ = conv(x)
-                    if IS_LINUX and IS_ARM64 and dtype is torch.half:
-                        self.assertEqual(y, y_, rtol=1e-3, atol=3e-3)
-                    else:
-                        self.assertEqual(y, y_)
+                    self.assertEqual(y, y_)
 
     @dtypes(torch.float, torch.cfloat)
     def test_conv_empty_channel(self, device, dtype):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -37,7 +37,7 @@ from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, r
     skipIfNoLapack, skipIfRocm, MI300_ARCH, skipIfRocmArch, \
     TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, \
     download_file, get_function_arglist, load_tests, skipIfMPS, \
-    IS_PPC, IS_ARM64, IS_MACOS, IS_WINDOWS, IS_CPU_CAPABILITY_SVE256, IS_CPU_EXT_SVE_SUPPORTED, xfailIf, \
+    IS_PPC, IS_ARM64, IS_MACOS, IS_WINDOWS, IS_CPU_EXT_SVE_SUPPORTED, xfailIf, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
     skipIfTorchDynamo, gcIfJetson, set_default_dtype
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6865,8 +6865,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         expected_out_t = torch.tensor([[[[2.5]]]])
         self.assertEqual(expected_out_t, out_t)
 
-    @xfailIf(IS_ARM64 and IS_CPU_EXT_SVE_SUPPORTED and not IS_CPU_CAPABILITY_SVE256)
-    # see https://github.com/pytorch/pytorch/issues/177250
     def test_upsampling_bfloat16(self, dtype=torch.bfloat16):
         def helper(size, scale_factor, mode, device, memory_format=torch.contiguous_format):
             input = torch.randn(size, device=device, dtype=dtype).to(memory_format=memory_format).detach().requires_grad_(True)


### PR DESCRIPTION
### Summary

  Fixes an AArch64 GCC optimization issue in CPU upsample backward for reduced-precision gradients.

  The reduced-precision `apply_grad_input` path accumulates a temporary float buffer into BFloat16/Half gradients. On AArch64 GCC builds, tree vectorization of this function can produce incorrect results or illegal instructions. This change disables GCC tree vectorization only around that overload, while preserving the explicit PyTorch Vectorized<> implementation inside the function.

The ARM64 xfail for TestNN.test_upsampling_bfloat16 is removed because the test now passes with this guard.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182034

Fixes #177250