### PR TITLE
Fix XPU module share memory using CPU shared-fd path

### DIFF
--- a/torch/storage.py
+++ b/torch/storage.py
@@ -392,7 +392,11 @@ class _StorageBase:
         """See :meth:`torch.UntypedStorage.share_memory_`"""
         from torch.multiprocessing import get_sharing_strategy
 
-        if self.device.type in ["cuda", torch._C._get_privateuse1_backend_name()]:
+        if self.device.type in [
+            "cuda",
+            "xpu",
+            torch._C._get_privateuse1_backend_name(),
+        ]:
             pass  # CUDA or PrivateUse1 doesn't use POSIX shared memory
         elif get_sharing_strategy() == "file_system":
             self._share_filename_cpu_()
@@ -406,7 +410,12 @@ class _StorageBase:
         from torch.multiprocessing import get_sharing_strategy
 
         device = torch.device(device)
-        if device.type in ["cuda", torch._C._get_privateuse1_backend_name(), "hpu"]:
+        if device.type in [
+            "cuda",
+            "xpu",
+            torch._C._get_privateuse1_backend_name(),
+            "hpu",
+        ]:
             return cls(size, device=device)
         elif get_sharing_strategy() == "file_system":
             return cls._new_using_filename_cpu(size)

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -395,9 +395,10 @@ class _StorageBase:
         if self.device.type in [
             "cuda",
             "xpu",
+            "hpu",
             torch._C._get_privateuse1_backend_name(),
         ]:
-            pass  # CUDA or PrivateUse1 doesn't use POSIX shared memory
+            pass  # CUDA/XPU/HPU/PrivateUse1 doesn't use POSIX shared memory
         elif get_sharing_strategy() == "file_system":
             self._share_filename_cpu_()
         else:


### PR DESCRIPTION
Fixes: 
https://github.com/intel/torch-xpu-ops/issues/2513

Add xpu to non-CPU shared-memory handling in storage.
Verify with test_module_share_memory_xpu