### PR TITLE
Download magma & sccache install scripts over https instead of aws s3

### DIFF
--- a/.ci/pytorch/win-test-helpers/installation-helpers/install_magma.bat
+++ b/.ci/pytorch/win-test-helpers/installation-helpers/install_magma.bat
@@ -23,11 +23,7 @@ if "%CUDA_SUFFIX%" == "" (
 )
 
 if "%REBUILD%"=="" (
-  if "%BUILD_ENVIRONMENT%"=="" (
-    curl --retry 3 --retry-all-errors -k https://s3.amazonaws.com/ossci-windows/magma_2.5.4_%CUDA_SUFFIX%_%BUILD_TYPE%.7z --output %TMP_DIR_WIN%\magma_2.5.4_%CUDA_SUFFIX%_%BUILD_TYPE%.7z & REM @lint-ignore
-  ) else (
-    aws s3 cp s3://ossci-windows/magma_2.5.4_%CUDA_SUFFIX%_%BUILD_TYPE%.7z %TMP_DIR_WIN%\magma_2.5.4_%CUDA_SUFFIX%_%BUILD_TYPE%.7z --quiet
-  )
+  curl --retry 3 --retry-all-errors -k https://s3.amazonaws.com/ossci-windows/magma_2.5.4_%CUDA_SUFFIX%_%BUILD_TYPE%.7z --output %TMP_DIR_WIN%\magma_2.5.4_%CUDA_SUFFIX%_%BUILD_TYPE%.7z & REM @lint-ignore
   if errorlevel 1 exit /b
   if not errorlevel 0 exit /b
   7z x -aoa %TMP_DIR_WIN%\magma_2.5.4_%CUDA_SUFFIX%_%BUILD_TYPE%.7z -o%TMP_DIR_WIN%\magma

--- a/.ci/pytorch/win-test-helpers/installation-helpers/install_sccache.bat
+++ b/.ci/pytorch/win-test-helpers/installation-helpers/install_sccache.bat
@@ -5,9 +5,5 @@ if "%REBUILD%"=="" (
     taskkill /im sccache.exe /f /t || ver > nul
     del %TMP_DIR_WIN%\bin\sccache.exe || ver > nul
   )
-  if "%BUILD_ENVIRONMENT%"=="" (
-    curl --retry 3 --retry-all-errors -k https://s3.amazonaws.com/ossci-windows/sccache-v0.7.4.exe --output %TMP_DIR_WIN%\bin\sccache.exe
-  ) else (
-    aws s3 cp s3://ossci-windows/sccache-v0.7.4.exe %TMP_DIR_WIN%\bin\sccache.exe
-  )
+  curl --retry 3 --retry-all-errors -k https://s3.amazonaws.com/ossci-windows/sccache-v0.7.4.exe --output %TMP_DIR_WIN%\bin\sccache.exe
 )


### PR DESCRIPTION
Removed the conditional logic that switched between curl and aws s3 cp based on the %BUILD_ENVIRONMENT% variable. The script now uses the standard curl approach exclusively to fetch the binary from S3.
