### PR TITLE
Remove OUT_DTYPE from Triton BMM template (#182041)

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -2402,7 +2402,7 @@ class TestMaxAutotune(TestCase):
                         'num_consumer_groups':0,'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
                         'transpose_discontiguous_tensor_descriptors_override':None,
                         'kwargs':{'EVEN_K':False,'USE_FAST_ACCUM':False,'ACC_TYPE':'tl.float32',
-                        'OUT_DTYPE':'tl.float32','BLOCK_M':16,'BLOCK_N':32,'BLOCK_K':16,'GROUP_M':8,'ALLOW_TF32':True},
+                        'BLOCK_M':16,'BLOCK_N':32,'BLOCK_K':16,'GROUP_M':8,'ALLOW_TF32':True},
                         'hint_override':None,'triton_meta':None}"""
 
                 expected = expected.replace("cuda", GPU_TYPE)
@@ -2443,7 +2443,7 @@ class TestMaxAutotune(TestCase):
                     'layout':"[[s77,s94],[s94,1],torch.float32,device(type='cuda',index=0),0]",'num_consumer_groups':0,
                     'num_buffers_warp_spec':0,'epilogue_fn_hash':'identity','tma_store':False,
                     'transpose_discontiguous_tensor_descriptors_override':None,
-                    'kwargs':{'EVEN_K':False,'USE_FAST_ACCUM':False,'ACC_TYPE':'tl.float32','OUT_DTYPE':'tl.float32','BLOCK_M':16,'BLOCK_N':32,
+                    'kwargs':{'EVEN_K':False,'USE_FAST_ACCUM':False,'ACC_TYPE':'tl.float32','BLOCK_M':16,'BLOCK_N':32,
                     'BLOCK_K':16,'GROUP_M':8,'ALLOW_TF32':True},'hint_override':None,'triton_meta':None}"""
                 expected = expected.replace("cuda", GPU_TYPE)
                 self.assertExpectedInline(

--- a/torch/_inductor/kernel/templates/triton_bmm.py.jinja
+++ b/torch/_inductor/kernel/templates/triton_bmm.py.jinja
@@ -67,7 +67,5 @@
     idx_n = rn[None, :]
     mask = (idx_m < M) & (idx_n < N) & (idx_q < BATCH)
 
-    # cast accumulator to output dtype
-    acc = acc.to(OUT_DTYPE)
     # inductor generates a suffix
     {{store_output(("idx_q", "idx_m", "idx_n"), "acc", "mask", val_shape=("BLOCK_M", "BLOCK_N"))}}

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -2102,7 +2102,6 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
             EVEN_K=even_k_symbolic,
             USE_FAST_ACCUM=False,  # Option for _scaled_mm
             ACC_TYPE=self._get_acc_type(out_dtype),
-            OUT_DTYPE=self._get_out_dtype(out_dtype),
             num_stages=triton_config.num_stages,
             num_warps=triton_config.num_warps,
             **triton_config.kwargs,
@@ -2127,10 +2126,6 @@ class MMTemplateConfigMixin(GemmMaxAutotuneTemplateConfigHeuristics):
         """
         if dtype in (torch.float16, torch.bfloat16):
             return "tl.float32"
-        return self._dtype_to_triton(dtype)
-
-    def _get_out_dtype(self, dtype: torch.dtype) -> str:
-        """Get output dtype as a triton type string."""
         return self._dtype_to_triton(dtype)
 
 
@@ -2357,7 +2352,6 @@ class BaseScaledMMConfigMixin(MMTemplateConfigMixin):
             nodes,
             mat1_idx=kernel_inputs._mat1_idx,
             mat2_idx=kernel_inputs._mat2_idx,
-            out_dtype=kernel_inputs._out_dtype,
         )
 
     def _get_template_configs_impl(


### PR DESCRIPTION
Summary:

The OUT_DTYPE cast in the Triton BMM template is unnecessary — the inductor-generated suffix already handles output dtype conversion. This removes the `acc = acc.to(OUT_DTYPE)` line from the Jinja template, the `_get_out_dtype` helper method, the `OUT_DTYPE` kwarg from template configuration, the `out_dtype` parameter from a call site, and updates test expectations accordingly.

Test Plan: Existing inductor tests (test_max_autotune)

Reviewed By: PaulZhang12

Differential Revision: D103216241




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos