### PR TITLE
[Dynamo] test case and runner consistency

### DIFF
--- a/test/dynamo/test_activation_offloading.py
+++ b/test/dynamo/test_activation_offloading.py
@@ -14,9 +14,10 @@ from functorch.compile import (
     min_cut_rematerialization_partition,
 )
 from torch._dynamo.graph_bytecode_inputs import reset_user_object_tracking
+from torch._dynamo.test_case import run_tests, TestCase
 from torch._inductor.utils import run_fw_bw_and_get_code
 from torch.testing import FileCheck
-from torch.testing._internal.common_utils import run_tests, serialTest, TestCase
+from torch.testing._internal.common_utils import serialTest
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
 

--- a/test/dynamo/test_cudagraphs_expandable_segments.py
+++ b/test/dynamo/test_cudagraphs_expandable_segments.py
@@ -6,8 +6,8 @@ import pathlib
 import sys
 
 import torch
-from torch.testing._internal.common_cuda import IS_JETSON, IS_WINDOWS
 from torch._dynamo.test_case import run_tests
+from torch.testing._internal.common_cuda import IS_JETSON, IS_WINDOWS
 
 
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/test/dynamo/test_cudagraphs_expandable_segments.py
+++ b/test/dynamo/test_cudagraphs_expandable_segments.py
@@ -7,7 +7,7 @@ import sys
 
 import torch
 from torch.testing._internal.common_cuda import IS_JETSON, IS_WINDOWS
-from torch.testing._internal.common_utils import run_tests
+from torch._dynamo.test_case import run_tests
 
 
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -8,7 +8,7 @@ import torch._dynamo.testing
 import torch.fx.experimental._config as _fx_experimental_config
 from torch._dynamo.decorators import mark_static, mark_unbacked, maybe_mark_dynamic
 from torch._dynamo.dynamic_spec import IntSpec, IntSpecType, TensorSpec
-from torch._dynamo.test_case import TestCase
+from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import EagerAndRecordGraphs
 from torch.fx.experimental.symbolic_shapes import (
     free_unbacked_symbols,
@@ -17,8 +17,6 @@ from torch.fx.experimental.symbolic_shapes import (
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
-    run_tests,
-    skipIfTorchDynamo,
 )
 
 
@@ -488,7 +486,6 @@ class TestTensorSpecConstruction(TestCase):
         self.assertIsNotNone(ts[3])
 
 
-@skipIfTorchDynamo()
 class TestTensorSpecCompile(TestCase):
     """TensorSpec + compile integration via the test-local
     `_compile_with_dynamic_shapes` helper. Same scaffolding path as
@@ -563,7 +560,6 @@ class TestTensorSpecCompile(TestCase):
         self.assertEqual(len(backend.graphs), 2)
 
 
-@skipIfTorchDynamo()
 class TestIntSpecCompile(TestCase):
     """Covers IntSpec + torch.compile integration using the local
     `_compile_with_dynamic_shapes` helper.

--- a/test/dynamo/test_guard_exclusion.py
+++ b/test/dynamo/test_guard_exclusion.py
@@ -2,7 +2,7 @@
 import torch
 import torch._dynamo
 import torch._dynamo.testing
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch._dynamo.test_case import run_tests, TestCase
 
 
 class GraphTracker:
@@ -31,7 +31,6 @@ class GraphTracker:
         self.call_log.clear()
 
 
-@skipIfTorchDynamo("uses custom backend incompatible with PYTORCH_TEST_WITH_DYNAMO")
 @torch._dynamo.config.patch(automatic_dynamic_exclusion_guard=True)
 class TestGuardExclusion(TestCase):
     def setUp(self):

--- a/test/dynamo/test_model_output.py
+++ b/test/dynamo/test_model_output.py
@@ -6,8 +6,8 @@ import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch._dynamo.testing import same
+from torch._dynamo.test_case import TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import TestCase
 
 
 try:
@@ -30,7 +30,7 @@ def maybe_skip(fn):
     return fn
 
 
-class TestHFPretrained(torch._dynamo.test_case.TestCase):
+class TestHFPretrained(TestCase):
     @maybe_skip
     def test_pretrained(self):
         def fn(a, tmp):
@@ -63,7 +63,7 @@ class TestHFPretrained(torch._dynamo.test_case.TestCase):
         self.assertTrue(same(ref, res))
 
 
-class TestModelOutput(torch._dynamo.test_case.TestCase):
+class TestModelOutput(TestCase):
     @maybe_skip
     def test_mo_create(self):
         def fn(a, b):

--- a/test/dynamo/test_model_output.py
+++ b/test/dynamo/test_model_output.py
@@ -3,10 +3,9 @@ import dataclasses
 import unittest.mock
 
 import torch
-import torch._dynamo.test_case
 import torch._dynamo.testing
+from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import same
-from torch._dynamo.test_case import TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
 
@@ -362,6 +361,4 @@ class TestModelOutputBert(TestCase):
 instantiate_device_type_tests(TestModelOutputBert, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
-    from torch._dynamo.test_case import run_tests
-
     run_tests()

--- a/test/dynamo/test_nb_bool.py
+++ b/test/dynamo/test_nb_bool.py
@@ -13,7 +13,8 @@ class _Color(enum.Enum):
 
 
 import torch.nn
-from torch.testing._internal.common_utils import make_dynamo_test, run_tests, TestCase
+from torch._dynamo.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import make_dynamo_test
 
 
 class NbBoolTests(TestCase):

--- a/test/dynamo/test_nb_float.py
+++ b/test/dynamo/test_nb_float.py
@@ -2,13 +2,8 @@
 """Tests for nb_float_impl: unified __float__ / float() protocol in Dynamo."""
 
 import torch
-import torch._dynamo.testing
-from torch.testing._internal.common_utils import (
-    make_dynamo_test,
-    run_tests,
-    skipIfCrossRef,
-    TestCase,
-)
+from torch._dynamo.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import make_dynamo_test, skipIfCrossRef
 
 
 class NbFloatTests(TestCase):

--- a/test/dynamo/test_nb_index.py
+++ b/test/dynamo/test_nb_index.py
@@ -4,8 +4,8 @@
 import operator
 
 import torch
-import torch._dynamo.testing
-from torch.testing._internal.common_utils import make_dynamo_test, run_tests, TestCase
+from torch._dynamo.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import make_dynamo_test
 
 
 class NbIndexTests(TestCase):

--- a/test/dynamo/test_nb_int.py
+++ b/test/dynamo/test_nb_int.py
@@ -2,8 +2,8 @@
 """Tests for nb_int_impl: unified __int__ / int() protocol in Dynamo."""
 
 import torch
-import torch._dynamo.testing
-from torch.testing._internal.common_utils import make_dynamo_test, run_tests, TestCase
+from torch._dynamo.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import make_dynamo_test
 
 
 class NbIntTests(TestCase):

--- a/test/dynamo/test_polyfills.py
+++ b/test/dynamo/test_polyfills.py
@@ -1,12 +1,12 @@
 # Owner(s): ["module: dynamo"]
 
 import torch
-import torch._dynamo.test_case
+from torch._dynamo.test_case import run_tests, TestCase
 import torch._dynamo.testing
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo
+from torch.testing._internal.common_utils import skipIfTorchDynamo
 
 
-class TestGroupTensorsByDeviceAndDtype(torch._dynamo.test_case.TestCase):
+class TestGroupTensorsByDeviceAndDtype(TestCase):
     """Tests for the group_tensors_by_device_and_dtype polyfill."""
 
     def test_polyfill_matches_cpp_single_list(self):
@@ -185,7 +185,6 @@ class TestGroupTensorsByDeviceAndDtype(torch._dynamo.test_case.TestCase):
         self.assertTrue(torch.equal(f64_lists[0][1], t_f64_1))
         self.assertEqual(f64_indices, [1, 3])
 
-    @skipIfTorchDynamo("test uses CompileCounter which doesn't work under dynamo")
     def test_group_tensors_traceable_with_compile(self):
         """Test that torch._C._group_tensors_by_device_and_dtype is traceable with torch.compile.
 

--- a/test/dynamo/test_polyfills.py
+++ b/test/dynamo/test_polyfills.py
@@ -1,9 +1,8 @@
 # Owner(s): ["module: dynamo"]
 
 import torch
-from torch._dynamo.test_case import run_tests, TestCase
 import torch._dynamo.testing
-from torch.testing._internal.common_utils import skipIfTorchDynamo
+from torch._dynamo.test_case import run_tests, TestCase
 
 
 class TestGroupTensorsByDeviceAndDtype(TestCase):

--- a/test/dynamo/test_tp_slots.py
+++ b/test/dynamo/test_tp_slots.py
@@ -19,7 +19,7 @@ from torch._C._dynamo import (
     PySequenceSlots,
     PyTypeSlots,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch._dynamo.test_case import run_tests, TestCase
 
 
 class TestTypeSlots(TestCase):


### PR DESCRIPTION
### The Problem:
Noted several tp_slot dynamo test cases were importing `TestCase` and `run_tests` from `torch.testing._internal.common_utils` instead of `torch._dynamo.test_case`
Some additional tests became apparent as well within the dynamo folder which were explicitly calling `@skipIfTorchDynamo()`, `dynamo.reset`, etc instead of relying on dynamo's `TestCase` to handle these.

Additionally, the tests updates don't require testing both with and without `PYTORCH_TEST_WITH_DYNAMO` as they're directly testing dynamo functionality the second test with `PYTORCH_TEST_WITH_DYNAMO=1` is excessive.

### The Fix:
Updates tests under the test/dynamo folder to import both `TestCase` and `run_tests` from `torch._dynamo.test_case` which has specific handling to skip `PYTORCH_TEST_WITH_DYNAMO=1` and perform dynamo resets for a fresh compile.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98