### PR TITLE
[AOTInductor] Preserve CUDA error messages across C ABI boundary (#182045)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -5003,6 +5003,26 @@ class AOTInductorTestsTemplate:
         result2 = aoti_module(sample)
         self.assertTrue(torch.allclose(result2, sample * 2))
 
+    @unittest.skipIf(IS_FBCODE, "Not yet runnable in fbcode")
+    @patch.dict(os.environ, {"AOTI_RUNTIME_CHECK_INPUTS": "1"})
+    def test_runtime_check_error_message_preserved(self):
+        # Exception thrown from CONVERT_EXCEPTION_TO_ERROR_CODE at the outer
+        # AOTI C ABI boundary (i.e. not from an aoti_torch_* shim) must reach
+        # Python via AOTInductorGetLastError, not be flattened to the generic
+        # "run_func_(...) API call failed" message.
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        m = M()
+        good = torch.randn(4, dtype=torch.float32, device=self.device)
+        bad_dtype = good.to(torch.float16)
+        so_path = AOTIRunnerUtil.compile(m, (good,))
+        aoti_module = torch._inductor.aoti_load_package(so_path)
+        aoti_module(good)
+        with self.assertRaisesRegex(RuntimeError, "unmatched dtype"):
+            aoti_module(bad_dtype)
+
     def test_fqn(self):
         class NestedChild(torch.nn.Module):
             def __init__(self) -> None:
@@ -5333,7 +5353,7 @@ class AOTInductorTestsTemplate:
 
             self.assertTrue(same(optimized(*example_inputs), m(*example_inputs)))
 
-            with self.assertRaisesRegex(Exception, "run_func_(.*) API call failed "):
+            with self.assertRaisesRegex(Exception, "Expected .* but received"):
                 optimized(torch.randn(100), torch.tensor(2))
 
     @patch.dict(os.environ, {"TORCHINDUCTOR_SCALAR_ASSERTS_FULL": "1"})
@@ -5360,7 +5380,7 @@ class AOTInductorTestsTemplate:
         )
         optimized = torch._inductor.aoti_load_package(package_path)
         self.assertEqual(model(*input1), optimized(*input1))
-        with self.assertRaisesRegex(Exception, "run_func_(.*) API call failed "):
+        with self.assertRaisesRegex(Exception, "Expected .* but received"):
             optimized(*input2)
 
     @skipIfWindows(msg="TODO: (xuhancn) confirm, Crash: access violation")

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -4,15 +4,26 @@
 #include <torch/csrc/inductor/aoti_runtime/model_container.h>
 
 #include <iostream>
+#include <string>
 #include <vector>
+
+// Stores the last error message from a failed AOTI runtime call so that
+// callers on the other side of the C ABI boundary can retrieve it via
+// AOTInductorGetLastError(). Without this, exception messages (e.g.
+// "CUDA error: an illegal memory access was encountered") are lost when
+// CONVERT_EXCEPTION_TO_ERROR_CODE catches them and returns an error code.
+static thread_local std::string g_aoti_last_error;
 
 #define CONVERT_EXCEPTION_TO_ERROR_CODE(...)      \
   try {                                           \
+    g_aoti_last_error.clear();                    \
     __VA_ARGS__                                   \
   } catch (const std::exception& e) {             \
+    g_aoti_last_error = e.what();                 \
     std::cerr << "Error: " << e.what() << '\n';   \
     return AOTI_RUNTIME_FAILURE;                  \
   } catch (...) {                                 \
+    g_aoti_last_error = "Unknown exception";      \
     std::cerr << "Unknown exception occurred.\n"; \
     return AOTI_RUNTIME_FAILURE;                  \
   }                                               \
@@ -522,5 +533,11 @@ AOTIRuntimeError AOTInductorModelUpdateConstantsFromBlob(
       {container->update_constants_from_blob(weight_blob_ptr); })
     }
 
+
+AOTIRuntimeError AOTInductorGetLastError(
+    const char** error_msg) {
+  *error_msg = g_aoti_last_error.c_str();
+  return AOTI_RUNTIME_SUCCESS;
+}
 
 } // extern "C"

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -109,6 +109,7 @@ consider rebuild your model with the latest AOTInductor.");
   TRY_LOAD_SYMBOL(
       update_constants_from_blob_func_,
       "AOTInductorModelUpdateConstantsFromBlob")
+  TRY_LOAD_SYMBOL(get_last_error_func_, "AOTInductorGetLastError")
 #undef TRY_LOAD_SYMBOL
 
   // Hack to find the json file name from the model so file
@@ -164,6 +165,13 @@ std::vector<at::Tensor> AOTIModelContainerRunner::run_impl(
     const char* err = torch::aot_inductor::get_last_error();
     if (err) {
       throw std::runtime_error(err);
+    }
+    if (get_last_error_func_) {
+      const char* aoti_err = nullptr;
+      if (get_last_error_func_(&aoti_err) == AOTI_RUNTIME_SUCCESS && aoti_err &&
+          aoti_err[0]) {
+        throw std::runtime_error(aoti_err);
+      }
     }
     torch::headeronly::detail::throw_exception(
         "run_func_(...)", __FILE__, __LINE__);

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -119,6 +119,7 @@ class TORCH_API AOTIModelContainerRunner {
       get_constants_blob_size_func_{nullptr};
   decltype(&AOTInductorModelUpdateConstantsFromBlob)
       update_constants_from_blob_func_{nullptr};
+  decltype(&AOTInductorGetLastError) get_last_error_func_{nullptr};
 
   AOTInductorModelContainerHandle container_handle_ = nullptr;
 

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -329,6 +329,11 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
     const char** in_spec,
     const char** out_spec);
 
+// Retrieves the error message from the last failed AOTI runtime call on the
+// current thread. The returned pointer is valid until the next AOTI runtime
+// call on the same thread. Returns an empty string if the last call succeeded.
+AOTI_API AOTIRuntimeError AOTInductorGetLastError(const char** error_msg);
+
 // ---------------------------------------------------------------------------
 // C-ABI-safe variant of AOTInductorModelRunMinimalArrayrefInterface.
 //


### PR DESCRIPTION
Summary:

When a CUDA error (e.g. illegal memory access) occurs inside an
AOTInductor-compiled model, the exception is caught by
CONVERT_EXCEPTION_TO_ERROR_CODE at the C ABI boundary and converted to
an error code. The original exception message is printed to stderr but
discarded. The caller (AOTInductorModelImpl) then throws a new exception
with only the input spec, losing the "CUDA error" text entirely.

This causes the sigrid predictor's sticky GPU error detection
(checkStickyGPUError) to fail — it searches for "CUDA error" in the
exception message but never finds it. The predictor stays alive as a
zombie, accepting and failing requests indefinitely instead of crashing
cleanly.

Fix: Store the exception message in a thread-local string inside the
.wrapper.so and expose it via a new AOTInductorGetLastError() C API.
The Sigmoid runtime retrieves it and includes the original error in the
rethrown exception.

Test Plan:
Manual repro: send a request that triggers cudaErrorIllegalAddress,
verify the predictor now self-terminates via checkStickyGPUError within
the 2-minute upload timeout.

buck2 run fbcode//ip_runtime/scripts/iprcli:iprcli_click.real --       load model --model-id 2137644003 --use-defaults    --additional-gflags="--smc_tiername=feed.sigrid.predictor_${USER}-test --enable_thrift_warmup=false --disable_incontainer_warmup=true --enable_generic_request_batching=false"

 ipr replay bad-requests --sql=$'SELECT time, error_message, request_manifold_path, tw_task_handle FROM sigrid_predictor_bad_requests WHERE 1776114985 <= time AND time <= 1776201384 AND ( (request_manifold_path) IN ( \'manifold://inference_request_dump/tree/bad_request_logger/2137644003_797_tsp_atn_14_140628253995008_1776131944044520740_dumped_requests.recordio\' ) ) LIMIT 100;

Reviewed By: desertfire, huydhn






cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo