### PR TITLE
[CI] Add @unittest.skipUnless(nvcc_exist()) for UT's in test/inductor/test_cudacodecache.py

### DIFF
--- a/test/inductor/test_cudacodecache.py
+++ b/test/inductor/test_cudacodecache.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 
 import ctypes
+import unittest
 
 import torch
 from torch._inductor.async_compile import AsyncCompile
@@ -38,6 +39,7 @@ int saxpy(int n, float a, float *x, float *y) {
 
 class TestCUDACodeCache(InductorTestCase):
     @requires_cuda_and_triton
+    @unittest.skipUnless(nvcc_exist(), "requires nvcc")
     def test_cuda_load(self):
         with fresh_cache():
             # Test both .o and .so compilation.
@@ -66,6 +68,7 @@ class TestCUDACodeCache(InductorTestCase):
             torch.testing.assert_close(y, expected_y)
 
     @requires_cuda_and_triton
+    @unittest.skipUnless(nvcc_exist(), "requires nvcc")
     def test_compilation_error(self):
         with fresh_cache():
             error_source_code = _SOURCE_CODE.replace("saxpy_device", "saxpy_wrong", 1)
@@ -73,6 +76,7 @@ class TestCUDACodeCache(InductorTestCase):
                 CUDACodeCache.compile(error_source_code, "o")
 
     @requires_cuda_and_triton
+    @unittest.skipUnless(nvcc_exist(), "requires nvcc")
     def test_async_compile(self):
         with fresh_cache():
             async_compile = AsyncCompile()

--- a/test/inductor/test_cudacodecache.py
+++ b/test/inductor/test_cudacodecache.py
@@ -36,10 +36,9 @@ int saxpy(int n, float a, float *x, float *y) {
 }
 """
 
-
+@unittest.skipUnless(nvcc_exist(), "requires nvcc")
 class TestCUDACodeCache(InductorTestCase):
     @requires_cuda_and_triton
-    @unittest.skipUnless(nvcc_exist(), "requires nvcc")
     def test_cuda_load(self):
         with fresh_cache():
             # Test both .o and .so compilation.
@@ -68,7 +67,6 @@ class TestCUDACodeCache(InductorTestCase):
             torch.testing.assert_close(y, expected_y)
 
     @requires_cuda_and_triton
-    @unittest.skipUnless(nvcc_exist(), "requires nvcc")
     def test_compilation_error(self):
         with fresh_cache():
             error_source_code = _SOURCE_CODE.replace("saxpy_device", "saxpy_wrong", 1)
@@ -76,7 +74,6 @@ class TestCUDACodeCache(InductorTestCase):
                 CUDACodeCache.compile(error_source_code, "o")
 
     @requires_cuda_and_triton
-    @unittest.skipUnless(nvcc_exist(), "requires nvcc")
     def test_async_compile(self):
         with fresh_cache():
             async_compile = AsyncCompile()
@@ -100,5 +97,4 @@ class TestCUDACodeCache(InductorTestCase):
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if nvcc_exist():
-        run_tests("cuda")
+    run_tests("cuda")

--- a/test/inductor/test_cudacodecache.py
+++ b/test/inductor/test_cudacodecache.py
@@ -36,6 +36,7 @@ int saxpy(int n, float a, float *x, float *y) {
 }
 """
 
+
 @unittest.skipUnless(nvcc_exist(), "requires nvcc")
 class TestCUDACodeCache(InductorTestCase):
     @requires_cuda_and_triton


### PR DESCRIPTION
This PR intends to skip unit tests in test/inductor/test_cudacodecache.py when using pytest and nvcc_exist() is False.
The existing guard in main checks for nvcc_exist() before invoking run_tests():
```python
if __name__ == "__main__":
    from torch._inductor.test_case import run_tests

    if nvcc_exist():
        run_tests("cuda")
```
Changes
- import unittest added (was not previously imported)
- @unittest.skipUnless(nvcc_exist(), "requires nvcc") added above TestCUDACodeCache class

Results when nvcc_exist() is False using pytest

Before applying patch:
3 failed

After applying patch:
3 skipped

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo