### PR TITLE
[MPS] Fix typo `MPSGaph` should be `MPSGraph`

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -398,7 +398,7 @@ static MPSNDArray* permuteNDArray(MPSNDArray* inArray, const std::vector<int64_t
 static void check_mps_shape(MPSShape* shape) {
   for (NSNumber* elem in shape) {
     const auto val = [elem longValue];
-    TORCH_CHECK(val <= std::numeric_limits<int32_t>::max(), "MPSGaph does not support tensor dims larger than INT_MAX");
+    TORCH_CHECK(val <= std::numeric_limits<int32_t>::max(), "MPSGraph does not support tensor dims larger than INT_MAX");
   }
 }
 
@@ -559,7 +559,7 @@ Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor,
 
     auto storage_numel = src.storage().nbytes() / src.element_size() - src.storage_offset();
     TORCH_CHECK(storage_numel <= std::numeric_limits<int32_t>::max(),
-                "MPSGaph does not support tensor dims larger than INT_MAX");
+                "MPSGraph does not support tensor dims larger than INT_MAX");
     MPSNDArrayDescriptor* srcTensorDesc = [MPSNDArrayDescriptor descriptorWithDataType:dataType
                                                                                  shape:@[ @(storage_numel) ]];
     srcTensorDesc.preferPackedRows = YES;

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -398,7 +398,8 @@ static MPSNDArray* permuteNDArray(MPSNDArray* inArray, const std::vector<int64_t
 static void check_mps_shape(MPSShape* shape) {
   for (NSNumber* elem in shape) {
     const auto val = [elem longValue];
-    TORCH_CHECK(val <= std::numeric_limits<int32_t>::max(), "MPSGraph does not support tensor dims larger than INT_MAX");
+    TORCH_CHECK(val <= std::numeric_limits<int32_t>::max(),
+                "MPSGraph does not support tensor dims larger than INT_MAX");
   }
 }
 


### PR DESCRIPTION
Typo `MPSGaph` should be `MPSGraph`:
* https://github.com/pytorch/pytorch/blob/da0df3472f8964c96db7bb6dccceb5e3cc09236d/aten/src/ATen/native/mps/OperationUtils.mm#L401
* https://github.com/pytorch/pytorch/blob/da0df3472f8964c96db7bb6dccceb5e3cc09236d/aten/src/ATen/native/mps/OperationUtils.mm#L562