### PR TITLE
[docs] Link CUDA stream semantics from Tensor.to/copy_ non_blocking docstrings

### DIFF
--- a/docs/source/notes/cuda.md
+++ b/docs/source/notes/cuda.md
@@ -345,6 +345,8 @@ As an exception, several functions such as {meth}`~torch.Tensor.to` and
 which lets the caller bypass synchronization when it is unnecessary.
 Another exception is CUDA streams, explained below.
 
+(cuda-stream-semantics)=
+
 ### CUDA streams
 
 A [CUDA stream](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#streams) is a linear sequence of execution that belongs to a specific

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -1160,6 +1160,13 @@ Args:
     non_blocking (bool, optional): if ``True`` and this copy is between CPU and GPU,
         the copy may occur asynchronously with respect to the host. For other
         cases, this argument has no effect. Default: ``False``
+
+.. note::
+
+    When :attr:`non_blocking` is ``True`` and the copy is issued on a
+    non-default CUDA stream, the caller is responsible for proper
+    cross-stream synchronization. See :ref:`cuda-stream-semantics` for
+    the required pattern.
 """,
 )
 
@@ -5174,6 +5181,13 @@ Here are the ways to call ``to``:
     `tutorial on good usage of non_blocking and pin_memory <https://pytorch.org/tutorials/intermediate/pinmem_nonblock.html>`__.
     When :attr:`copy` is set, a new Tensor is created even when the Tensor
     already matches the desired conversion.
+
+.. note::
+
+    When :attr:`non_blocking` is ``True`` and the conversion is issued on
+    a non-default CUDA stream, the caller is responsible for proper
+    cross-stream synchronization. See :ref:`cuda-stream-semantics` for
+    the required pattern.
 
 Example::
 


### PR DESCRIPTION
## Summary

Adds a `.. note::` admonition to the `Tensor.to(non_blocking=True)` and `Tensor.copy_(non_blocking=True)` docstrings cross-referencing the existing CUDA streams note (`docs/source/notes/cuda.rst`), plus a `.. _cuda-stream-semantics:` label so the cross-reference resolves.

This is a pure docs-visibility tweak; no runtime behavior change.

## Motivation

Users hitting cross-stream synchronization hazards with `non_blocking=True` on a non-default CUDA stream rarely find the streams note on their own — `Tensor.to` and `Tensor.copy_` docstrings don't mention the synchronization responsibility, and that's where users look first. The note intentionally defers all synchronization detail (`wait_stream`, `record_stream`, source storage liveness) to the streams note itself to avoid content duplication.

## Context

Suggested by @jeffdaily in ROCm/pytorch#3194 during the triage of a cross-stream race that turned out to be a contract issue (not a runtime bug) — the streams note already documents the required synchronization, but it isn't discoverable from the per-method docstrings.

## Files touched

- `docs/source/notes/cuda.rst` — add `.. _cuda-stream-semantics:` label (2 lines)
- `torch/_tensor_docs.py` — add `.. note::` to `Tensor.to` and `Tensor.copy_` docstrings (7 lines each)

Total diff: +16 / -0.
