### PR TITLE
[MPS] Fix uint32 offset overflow in scatter/gather kernels for strided views crossing 2^32 elements

### DIFF
--- a/aten/src/ATen/mps/IndexKernels.h
+++ b/aten/src/ATen/mps/IndexKernels.h
@@ -11,11 +11,12 @@ template<>
  return {2};
 }}
 
+template <typename OffsetT>
 kernel void scatter_kernel_n(uint linear_index          [[thread_position_in_grid]],
                              constant void * src_       [[buffer(0)]],
                              device void * dst_         [[buffer(1)]],
                              constant uint32_t * size   [[buffer(2)]],
-                             constant ulong * stride    [[buffer(3)]],
+                             constant OffsetT * stride  [[buffer(3)]],
                             constant uint32_t & numel   [[buffer(4)]],
                             constant int32_t & ndim     [[buffer(5)]]) {{
     if (linear_index >= numel) return;
@@ -23,7 +24,7 @@ kernel void scatter_kernel_n(uint linear_index          [[thread_position_in_gri
     constant {0} * src = (constant {0} *)src_;
     device {1} * dst = (device {1} *)dst_;
 
-    ulong dst_offs = 0;
+    OffsetT dst_offs = 0;
     auto dst_idx = linear_index;
     for(int dim = ndim - 1; dim >= 0; --dim) {{
       dst_offs += stride[dim] * (dst_idx % size[dim]);
@@ -33,11 +34,32 @@ kernel void scatter_kernel_n(uint linear_index          [[thread_position_in_gri
     dst[dst_offs] = cast<{1}>(src[linear_index]);
 }}
 
+template [[host_name("scatter_kernel_n_u32")]]
+kernel void scatter_kernel_n<uint>(
+    uint linear_index          [[thread_position_in_grid]],
+    constant void * src_       [[buffer(0)]],
+    device void * dst_         [[buffer(1)]],
+    constant uint32_t * size   [[buffer(2)]],
+    constant uint * stride     [[buffer(3)]],
+    constant uint32_t & numel  [[buffer(4)]],
+    constant int32_t & ndim    [[buffer(5)]]);
+
+template [[host_name("scatter_kernel_n_u64")]]
+kernel void scatter_kernel_n<ulong>(
+    uint linear_index          [[thread_position_in_grid]],
+    constant void * src_       [[buffer(0)]],
+    device void * dst_         [[buffer(1)]],
+    constant uint32_t * size   [[buffer(2)]],
+    constant ulong * stride    [[buffer(3)]],
+    constant uint32_t & numel  [[buffer(4)]],
+    constant int32_t & ndim    [[buffer(5)]]);
+
+template <typename PackedT, typename VecT>
 kernel void scatter_kernel_4(uint linear_index              [[thread_position_in_grid]],
                              constant void * src_           [[buffer(0)]],
                              device void * dst_             [[buffer(1)]],
                              constant packed_uint4 & size   [[buffer(2)]],
-                             constant packed_ulong4 & stride [[buffer(3)]],
+                             constant PackedT & stride      [[buffer(3)]],
                              constant uint32_t & numel      [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -50,15 +72,34 @@ kernel void scatter_kernel_4(uint linear_index              [[thread_position_in
     local_index.z = linear_index / size[3] % size[2];
     local_index.w = linear_index % size[3];
 
-    const packed_ulong4 strided_index = ulong4(local_index) * stride;
+    const PackedT strided_index = VecT(local_index) * stride;
     dst[strided_index.x + strided_index.y + strided_index.z + strided_index.w] = cast<{1}>(src[linear_index]);
 }}
 
+template [[host_name("scatter_kernel_4_u32")]]
+kernel void scatter_kernel_4<packed_uint4, uint4>(
+    uint linear_index              [[thread_position_in_grid]],
+    constant void * src_           [[buffer(0)]],
+    device void * dst_             [[buffer(1)]],
+    constant packed_uint4 & size   [[buffer(2)]],
+    constant packed_uint4 & stride [[buffer(3)]],
+    constant uint32_t & numel      [[buffer(4)]]);
+
+template [[host_name("scatter_kernel_4_u64")]]
+kernel void scatter_kernel_4<packed_ulong4, ulong4>(
+    uint linear_index               [[thread_position_in_grid]],
+    constant void * src_            [[buffer(0)]],
+    device void * dst_              [[buffer(1)]],
+    constant packed_uint4 & size    [[buffer(2)]],
+    constant packed_ulong4 & stride [[buffer(3)]],
+    constant uint32_t & numel       [[buffer(4)]]);
+
+template <typename PackedT, typename VecT>
 kernel void scatter_kernel_3(uint linear_index              [[thread_position_in_grid]],
                              constant void * src_           [[buffer(0)]],
                              device void * dst_             [[buffer(1)]],
                              constant packed_uint3 & size   [[buffer(2)]],
-                             constant packed_ulong3 & stride [[buffer(3)]],
+                             constant PackedT & stride      [[buffer(3)]],
                              constant uint32_t & numel      [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -70,15 +111,34 @@ kernel void scatter_kernel_3(uint linear_index              [[thread_position_in
     local_index.y = linear_index / size[2] % size[1];
     local_index.z = linear_index % size[2];
 
-    const packed_ulong3 strided_index = ulong3(local_index) * stride;
+    const PackedT strided_index = VecT(local_index) * stride;
     dst[strided_index.x + strided_index.y + strided_index.z] = cast<{1}>(src[linear_index]);
 }}
 
+template [[host_name("scatter_kernel_3_u32")]]
+kernel void scatter_kernel_3<packed_uint3, uint3>(
+    uint linear_index              [[thread_position_in_grid]],
+    constant void * src_           [[buffer(0)]],
+    device void * dst_             [[buffer(1)]],
+    constant packed_uint3 & size   [[buffer(2)]],
+    constant packed_uint3 & stride [[buffer(3)]],
+    constant uint32_t & numel      [[buffer(4)]]);
+
+template [[host_name("scatter_kernel_3_u64")]]
+kernel void scatter_kernel_3<packed_ulong3, ulong3>(
+    uint linear_index               [[thread_position_in_grid]],
+    constant void * src_            [[buffer(0)]],
+    device void * dst_              [[buffer(1)]],
+    constant packed_uint3 & size    [[buffer(2)]],
+    constant packed_ulong3 & stride [[buffer(3)]],
+    constant uint32_t & numel       [[buffer(4)]]);
+
+template <typename PackedT, typename VecT>
 kernel void scatter_kernel_2(uint linear_index              [[thread_position_in_grid]],
                              constant void * src_           [[buffer(0)]],
                              device void * dst_             [[buffer(1)]],
                              constant packed_uint2 & size   [[buffer(2)]],
-                             constant packed_ulong2 & stride [[buffer(3)]],
+                             constant PackedT & stride      [[buffer(3)]],
                              constant uint32_t & numel      [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -89,15 +149,34 @@ kernel void scatter_kernel_2(uint linear_index              [[thread_position_in
     local_index.x = linear_index / size[1] % size[0];
     local_index.y = linear_index % size[1];
 
-    const packed_ulong2 strided_index = ulong2(local_index) * stride;
+    const PackedT strided_index = VecT(local_index) * stride;
     dst[strided_index.x + strided_index.y] = cast<{1}>(src[linear_index]);
 }}
 
+template [[host_name("scatter_kernel_2_u32")]]
+kernel void scatter_kernel_2<packed_uint2, uint2>(
+    uint linear_index              [[thread_position_in_grid]],
+    constant void * src_           [[buffer(0)]],
+    device void * dst_             [[buffer(1)]],
+    constant packed_uint2 & size   [[buffer(2)]],
+    constant packed_uint2 & stride [[buffer(3)]],
+    constant uint32_t & numel      [[buffer(4)]]);
+
+template [[host_name("scatter_kernel_2_u64")]]
+kernel void scatter_kernel_2<packed_ulong2, ulong2>(
+    uint linear_index               [[thread_position_in_grid]],
+    constant void * src_            [[buffer(0)]],
+    device void * dst_              [[buffer(1)]],
+    constant packed_uint2 & size    [[buffer(2)]],
+    constant packed_ulong2 & stride [[buffer(3)]],
+    constant uint32_t & numel       [[buffer(4)]]);
+
+template <typename OffsetT>
 kernel void scatter_kernel_1(uint linear_index              [[thread_position_in_grid]],
                              constant void * src_           [[buffer(0)]],
                              device void * dst_             [[buffer(1)]],
                              constant int & size            [[buffer(2)]],
-                             constant ulong & stride        [[buffer(3)]],
+                             constant OffsetT & stride      [[buffer(3)]],
                              constant uint32_t & numel      [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -105,9 +184,27 @@ kernel void scatter_kernel_1(uint linear_index              [[thread_position_in
     device {1} * dst = (device {1} *)dst_;
 
     const uint local_index = linear_index % size;
-    const ulong strided_index = local_index * stride;
+    const OffsetT strided_index = local_index * stride;
     dst[strided_index] = cast<{1}>(src[linear_index]);
 }}
+
+template [[host_name("scatter_kernel_1_u32")]]
+kernel void scatter_kernel_1<uint>(
+    uint linear_index              [[thread_position_in_grid]],
+    constant void * src_           [[buffer(0)]],
+    device void * dst_             [[buffer(1)]],
+    constant int & size            [[buffer(2)]],
+    constant uint & stride         [[buffer(3)]],
+    constant uint32_t & numel      [[buffer(4)]]);
+
+template [[host_name("scatter_kernel_1_u64")]]
+kernel void scatter_kernel_1<ulong>(
+    uint linear_index              [[thread_position_in_grid]],
+    constant void * src_           [[buffer(0)]],
+    device void * dst_             [[buffer(1)]],
+    constant int & size            [[buffer(2)]],
+    constant ulong & stride        [[buffer(3)]],
+    constant uint32_t & numel      [[buffer(4)]]);
 )METAL_SCATTER";
 
 static const char* GATHER_OPS_TEMPLATE = R"METAL_GATHER(
@@ -119,11 +216,12 @@ template<>
  return {2};
 }}
 
+template <typename OffsetT>
 kernel void gather_kernel_n(uint linear_index           [[thread_position_in_grid]],
                             constant void * src_        [[buffer(0)]],
                             device void * dst_          [[buffer(1)]],
                             constant uint32_t * size    [[buffer(2)]],
-                            constant ulong * stride     [[buffer(3)]],
+                            constant OffsetT * stride   [[buffer(3)]],
                             constant uint32_t & numel   [[buffer(4)]],
                             constant int32_t & ndim     [[buffer(5)]]) {{
     if (linear_index >= numel) return;
@@ -131,7 +229,7 @@ kernel void gather_kernel_n(uint linear_index           [[thread_position_in_gri
     constant {0} * src = (constant {0} *)src_;
     device {1} * dst = (device {1} *)dst_;
 
-    ulong src_offs = 0;
+    OffsetT src_offs = 0;
     auto src_idx = linear_index;
     for(int dim = ndim - 1; dim >= 0; --dim) {{
       src_offs += stride[dim] * (src_idx % size[dim]);
@@ -141,11 +239,32 @@ kernel void gather_kernel_n(uint linear_index           [[thread_position_in_gri
     dst[linear_index] = cast<{1}>(src[src_offs]);
 }}
 
+template [[host_name("gather_kernel_n_u32")]]
+kernel void gather_kernel_n<uint>(
+    uint linear_index           [[thread_position_in_grid]],
+    constant void * src_        [[buffer(0)]],
+    device void * dst_          [[buffer(1)]],
+    constant uint32_t * size    [[buffer(2)]],
+    constant uint * stride      [[buffer(3)]],
+    constant uint32_t & numel   [[buffer(4)]],
+    constant int32_t & ndim     [[buffer(5)]]);
+
+template [[host_name("gather_kernel_n_u64")]]
+kernel void gather_kernel_n<ulong>(
+    uint linear_index           [[thread_position_in_grid]],
+    constant void * src_        [[buffer(0)]],
+    device void * dst_          [[buffer(1)]],
+    constant uint32_t * size    [[buffer(2)]],
+    constant ulong * stride     [[buffer(3)]],
+    constant uint32_t & numel   [[buffer(4)]],
+    constant int32_t & ndim     [[buffer(5)]]);
+
+template <typename PackedT, typename VecT>
 kernel void gather_kernel_4(uint linear_index               [[thread_position_in_grid]],
                             constant void * src_            [[buffer(0)]],
                             device void * dst_              [[buffer(1)]],
                             constant packed_uint4 & size    [[buffer(2)]],
-                            constant packed_ulong4 & stride [[buffer(3)]],
+                            constant PackedT & stride       [[buffer(3)]],
                             constant uint32_t & numel       [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -158,15 +277,34 @@ kernel void gather_kernel_4(uint linear_index               [[thread_position_in
     local_index.z = linear_index / size[3] % size[2];
     local_index.w = linear_index % size[3];
 
-    const packed_ulong4 strided_index = ulong4(local_index) * stride;
+    const PackedT strided_index = VecT(local_index) * stride;
     dst[linear_index] = cast<{1}>(src[strided_index.x + strided_index.y + strided_index.z + strided_index.w]);
 }}
 
+template [[host_name("gather_kernel_4_u32")]]
+kernel void gather_kernel_4<packed_uint4, uint4>(
+    uint linear_index              [[thread_position_in_grid]],
+    constant void * src_           [[buffer(0)]],
+    device void * dst_             [[buffer(1)]],
+    constant packed_uint4 & size   [[buffer(2)]],
+    constant packed_uint4 & stride [[buffer(3)]],
+    constant uint32_t & numel      [[buffer(4)]]);
+
+template [[host_name("gather_kernel_4_u64")]]
+kernel void gather_kernel_4<packed_ulong4, ulong4>(
+    uint linear_index               [[thread_position_in_grid]],
+    constant void * src_            [[buffer(0)]],
+    device void * dst_              [[buffer(1)]],
+    constant packed_uint4 & size    [[buffer(2)]],
+    constant packed_ulong4 & stride [[buffer(3)]],
+    constant uint32_t & numel       [[buffer(4)]]);
+
+template <typename PackedT, typename VecT>
 kernel void gather_kernel_3(uint linear_index               [[thread_position_in_grid]],
                             constant void * src_            [[buffer(0)]],
                             device void * dst_              [[buffer(1)]],
                             constant packed_uint3 & size    [[buffer(2)]],
-                            constant packed_ulong3 & stride [[buffer(3)]],
+                            constant PackedT & stride       [[buffer(3)]],
                             constant uint32_t & numel       [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -178,15 +316,34 @@ kernel void gather_kernel_3(uint linear_index               [[thread_position_in
     local_index.y = linear_index / size[2] % size[1];
     local_index.z = linear_index % size[2];
 
-    const packed_ulong3 strided_index = ulong3(local_index) * stride;
+    const PackedT strided_index = VecT(local_index) * stride;
     dst[linear_index] = cast<{1}>(src[strided_index.x + strided_index.y + strided_index.z]);
 }}
 
+template [[host_name("gather_kernel_3_u32")]]
+kernel void gather_kernel_3<packed_uint3, uint3>(
+    uint linear_index              [[thread_position_in_grid]],
+    constant void * src_           [[buffer(0)]],
+    device void * dst_             [[buffer(1)]],
+    constant packed_uint3 & size   [[buffer(2)]],
+    constant packed_uint3 & stride [[buffer(3)]],
+    constant uint32_t & numel      [[buffer(4)]]);
+
+template [[host_name("gather_kernel_3_u64")]]
+kernel void gather_kernel_3<packed_ulong3, ulong3>(
+    uint linear_index               [[thread_position_in_grid]],
+    constant void * src_            [[buffer(0)]],
+    device void * dst_              [[buffer(1)]],
+    constant packed_uint3 & size    [[buffer(2)]],
+    constant packed_ulong3 & stride [[buffer(3)]],
+    constant uint32_t & numel       [[buffer(4)]]);
+
+template <typename PackedT, typename VecT>
 kernel void gather_kernel_2(uint linear_index               [[thread_position_in_grid]],
                             constant void * src_            [[buffer(0)]],
                             device void * dst_              [[buffer(1)]],
                             constant packed_uint2 & size    [[buffer(2)]],
-                            constant packed_ulong2 & stride [[buffer(3)]],
+                            constant PackedT & stride       [[buffer(3)]],
                             constant uint32_t & numel       [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -197,15 +354,34 @@ kernel void gather_kernel_2(uint linear_index               [[thread_position_in
     local_index.x = linear_index / size[1] % size[0];
     local_index.y = linear_index % size[1];
 
-    const packed_ulong2 strided_index = ulong2(local_index) * stride;
+    const PackedT strided_index = VecT(local_index) * stride;
     dst[linear_index] = cast<{1}>(src[strided_index.x + strided_index.y]);
 }}
 
+template [[host_name("gather_kernel_2_u32")]]
+kernel void gather_kernel_2<packed_uint2, uint2>(
+    uint linear_index              [[thread_position_in_grid]],
+    constant void * src_           [[buffer(0)]],
+    device void * dst_             [[buffer(1)]],
+    constant packed_uint2 & size   [[buffer(2)]],
+    constant packed_uint2 & stride [[buffer(3)]],
+    constant uint32_t & numel      [[buffer(4)]]);
+
+template [[host_name("gather_kernel_2_u64")]]
+kernel void gather_kernel_2<packed_ulong2, ulong2>(
+    uint linear_index               [[thread_position_in_grid]],
+    constant void * src_            [[buffer(0)]],
+    device void * dst_              [[buffer(1)]],
+    constant packed_uint2 & size    [[buffer(2)]],
+    constant packed_ulong2 & stride [[buffer(3)]],
+    constant uint32_t & numel       [[buffer(4)]]);
+
+template <typename OffsetT>
 kernel void gather_kernel_1(uint linear_index               [[thread_position_in_grid]],
                             constant void * src_            [[buffer(0)]],
                             device void * dst_              [[buffer(1)]],
                             constant int & size             [[buffer(2)]],
-                            constant ulong & stride         [[buffer(3)]],
+                            constant OffsetT & stride       [[buffer(3)]],
                             constant uint32_t & numel       [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -213,8 +389,26 @@ kernel void gather_kernel_1(uint linear_index               [[thread_position_in
     device {1} * dst = (device {1} *)dst_;
 
     const uint local_index = linear_index % size;
-    const ulong strided_index = local_index * stride;
+    const OffsetT strided_index = local_index * stride;
     dst[linear_index] = cast<{1}>(src[strided_index]);
 }}
+
+template [[host_name("gather_kernel_1_u32")]]
+kernel void gather_kernel_1<uint>(
+    uint linear_index              [[thread_position_in_grid]],
+    constant void * src_           [[buffer(0)]],
+    device void * dst_             [[buffer(1)]],
+    constant int & size            [[buffer(2)]],
+    constant uint & stride         [[buffer(3)]],
+    constant uint32_t & numel      [[buffer(4)]]);
+
+template [[host_name("gather_kernel_1_u64")]]
+kernel void gather_kernel_1<ulong>(
+    uint linear_index              [[thread_position_in_grid]],
+    constant void * src_           [[buffer(0)]],
+    device void * dst_             [[buffer(1)]],
+    constant int & size            [[buffer(2)]],
+    constant ulong & stride        [[buffer(3)]],
+    constant uint32_t & numel      [[buffer(4)]]);
 )METAL_GATHER";
 } // namespace at::mps

--- a/aten/src/ATen/mps/IndexKernels.h
+++ b/aten/src/ATen/mps/IndexKernels.h
@@ -15,7 +15,7 @@ kernel void scatter_kernel_n(uint linear_index          [[thread_position_in_gri
                              constant void * src_       [[buffer(0)]],
                              device void * dst_         [[buffer(1)]],
                              constant uint32_t * size   [[buffer(2)]],
-                             constant uint32_t * stride [[buffer(3)]],
+                             constant ulong * stride    [[buffer(3)]],
                             constant uint32_t & numel   [[buffer(4)]],
                             constant int32_t & ndim     [[buffer(5)]]) {{
     if (linear_index >= numel) return;
@@ -23,7 +23,7 @@ kernel void scatter_kernel_n(uint linear_index          [[thread_position_in_gri
     constant {0} * src = (constant {0} *)src_;
     device {1} * dst = (device {1} *)dst_;
 
-    uint64_t dst_offs = 0;
+    ulong dst_offs = 0;
     auto dst_idx = linear_index;
     for(int dim = ndim - 1; dim >= 0; --dim) {{
       dst_offs += stride[dim] * (dst_idx % size[dim]);
@@ -37,7 +37,7 @@ kernel void scatter_kernel_4(uint linear_index              [[thread_position_in
                              constant void * src_           [[buffer(0)]],
                              device void * dst_             [[buffer(1)]],
                              constant packed_uint4 & size   [[buffer(2)]],
-                             constant packed_uint4 & stride [[buffer(3)]],
+                             constant packed_ulong4 & stride [[buffer(3)]],
                              constant uint32_t & numel      [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -50,7 +50,7 @@ kernel void scatter_kernel_4(uint linear_index              [[thread_position_in
     local_index.z = linear_index / size[3] % size[2];
     local_index.w = linear_index % size[3];
 
-    const packed_uint4 strided_index = local_index * stride;
+    const packed_ulong4 strided_index = ulong4(local_index) * stride;
     dst[strided_index.x + strided_index.y + strided_index.z + strided_index.w] = cast<{1}>(src[linear_index]);
 }}
 
@@ -58,7 +58,7 @@ kernel void scatter_kernel_3(uint linear_index              [[thread_position_in
                              constant void * src_           [[buffer(0)]],
                              device void * dst_             [[buffer(1)]],
                              constant packed_uint3 & size   [[buffer(2)]],
-                             constant packed_uint3 & stride [[buffer(3)]],
+                             constant packed_ulong3 & stride [[buffer(3)]],
                              constant uint32_t & numel      [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -70,7 +70,7 @@ kernel void scatter_kernel_3(uint linear_index              [[thread_position_in
     local_index.y = linear_index / size[2] % size[1];
     local_index.z = linear_index % size[2];
 
-    const packed_uint3 strided_index = local_index * stride;
+    const packed_ulong3 strided_index = ulong3(local_index) * stride;
     dst[strided_index.x + strided_index.y + strided_index.z] = cast<{1}>(src[linear_index]);
 }}
 
@@ -78,7 +78,7 @@ kernel void scatter_kernel_2(uint linear_index              [[thread_position_in
                              constant void * src_           [[buffer(0)]],
                              device void * dst_             [[buffer(1)]],
                              constant packed_uint2 & size   [[buffer(2)]],
-                             constant packed_uint2 & stride [[buffer(3)]],
+                             constant packed_ulong2 & stride [[buffer(3)]],
                              constant uint32_t & numel      [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -89,7 +89,7 @@ kernel void scatter_kernel_2(uint linear_index              [[thread_position_in
     local_index.x = linear_index / size[1] % size[0];
     local_index.y = linear_index % size[1];
 
-    const packed_uint2 strided_index = local_index * stride;
+    const packed_ulong2 strided_index = ulong2(local_index) * stride;
     dst[strided_index.x + strided_index.y] = cast<{1}>(src[linear_index]);
 }}
 
@@ -97,15 +97,15 @@ kernel void scatter_kernel_1(uint linear_index              [[thread_position_in
                              constant void * src_           [[buffer(0)]],
                              device void * dst_             [[buffer(1)]],
                              constant int & size            [[buffer(2)]],
-                             constant int & stride          [[buffer(3)]],
+                             constant ulong & stride        [[buffer(3)]],
                              constant uint32_t & numel      [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
     constant {0} * src = (constant {0} *)src_;
     device {1} * dst = (device {1} *)dst_;
 
-    const int local_index = linear_index % size;
-    const int strided_index = local_index * stride;
+    const uint local_index = linear_index % size;
+    const ulong strided_index = local_index * stride;
     dst[strided_index] = cast<{1}>(src[linear_index]);
 }}
 )METAL_SCATTER";
@@ -123,7 +123,7 @@ kernel void gather_kernel_n(uint linear_index           [[thread_position_in_gri
                             constant void * src_        [[buffer(0)]],
                             device void * dst_          [[buffer(1)]],
                             constant uint32_t * size    [[buffer(2)]],
-                            constant uint32_t * stride  [[buffer(3)]],
+                            constant ulong * stride     [[buffer(3)]],
                             constant uint32_t & numel   [[buffer(4)]],
                             constant int32_t & ndim     [[buffer(5)]]) {{
     if (linear_index >= numel) return;
@@ -131,7 +131,7 @@ kernel void gather_kernel_n(uint linear_index           [[thread_position_in_gri
     constant {0} * src = (constant {0} *)src_;
     device {1} * dst = (device {1} *)dst_;
 
-    uint64_t src_offs = 0;
+    ulong src_offs = 0;
     auto src_idx = linear_index;
     for(int dim = ndim - 1; dim >= 0; --dim) {{
       src_offs += stride[dim] * (src_idx % size[dim]);
@@ -145,7 +145,7 @@ kernel void gather_kernel_4(uint linear_index               [[thread_position_in
                             constant void * src_            [[buffer(0)]],
                             device void * dst_              [[buffer(1)]],
                             constant packed_uint4 & size    [[buffer(2)]],
-                            constant packed_uint4 & stride  [[buffer(3)]],
+                            constant packed_ulong4 & stride [[buffer(3)]],
                             constant uint32_t & numel       [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -158,7 +158,7 @@ kernel void gather_kernel_4(uint linear_index               [[thread_position_in
     local_index.z = linear_index / size[3] % size[2];
     local_index.w = linear_index % size[3];
 
-    const packed_uint4 strided_index = local_index * stride;
+    const packed_ulong4 strided_index = ulong4(local_index) * stride;
     dst[linear_index] = cast<{1}>(src[strided_index.x + strided_index.y + strided_index.z + strided_index.w]);
 }}
 
@@ -166,7 +166,7 @@ kernel void gather_kernel_3(uint linear_index               [[thread_position_in
                             constant void * src_            [[buffer(0)]],
                             device void * dst_              [[buffer(1)]],
                             constant packed_uint3 & size    [[buffer(2)]],
-                            constant packed_uint3 & stride  [[buffer(3)]],
+                            constant packed_ulong3 & stride [[buffer(3)]],
                             constant uint32_t & numel       [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -178,7 +178,7 @@ kernel void gather_kernel_3(uint linear_index               [[thread_position_in
     local_index.y = linear_index / size[2] % size[1];
     local_index.z = linear_index % size[2];
 
-    const packed_uint3 strided_index = local_index * stride;
+    const packed_ulong3 strided_index = ulong3(local_index) * stride;
     dst[linear_index] = cast<{1}>(src[strided_index.x + strided_index.y + strided_index.z]);
 }}
 
@@ -186,7 +186,7 @@ kernel void gather_kernel_2(uint linear_index               [[thread_position_in
                             constant void * src_            [[buffer(0)]],
                             device void * dst_              [[buffer(1)]],
                             constant packed_uint2 & size    [[buffer(2)]],
-                            constant packed_uint2 & stride  [[buffer(3)]],
+                            constant packed_ulong2 & stride [[buffer(3)]],
                             constant uint32_t & numel       [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
@@ -197,7 +197,7 @@ kernel void gather_kernel_2(uint linear_index               [[thread_position_in
     local_index.x = linear_index / size[1] % size[0];
     local_index.y = linear_index % size[1];
 
-    const packed_uint2 strided_index = local_index * stride;
+    const packed_ulong2 strided_index = ulong2(local_index) * stride;
     dst[linear_index] = cast<{1}>(src[strided_index.x + strided_index.y]);
 }}
 
@@ -205,15 +205,15 @@ kernel void gather_kernel_1(uint linear_index               [[thread_position_in
                             constant void * src_            [[buffer(0)]],
                             device void * dst_              [[buffer(1)]],
                             constant int & size             [[buffer(2)]],
-                            constant int & stride           [[buffer(3)]],
+                            constant ulong & stride         [[buffer(3)]],
                             constant uint32_t & numel       [[buffer(4)]]) {{
     if (linear_index >= numel) return;
 
     constant {0} * src = (constant {0} *)src_;
     device {1} * dst = (device {1} *)dst_;
 
-    const int local_index = linear_index % size;
-    const int strided_index = local_index * stride;
+    const uint local_index = linear_index % size;
+    const ulong strided_index = local_index * stride;
     dst[linear_index] = cast<{1}>(src[strided_index]);
 }}
 )METAL_GATHER";

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -75,8 +75,7 @@ static id<MTLComputePipelineState> getPipelineState(const std::string& kernel,
                                                     bool needsScatter,
                                                     bool needsConj) {
   auto cvtFunc = genScatterGatherCvtFunc(dtypeSrc, dtypeDst, needsConj);
-  return (needsScatter ? scatterLib : gatherLib)
-      .getPipelineStateForFunc(kernel, {dtypeSrc, dtypeDst, cvtFunc});
+  return (needsScatter ? scatterLib : gatherLib).getPipelineStateForFunc(kernel, {dtypeSrc, dtypeDst, cvtFunc});
 }
 
 static bool viewNeeds64BitOffsets(const at::Tensor& view) {
@@ -120,12 +119,11 @@ Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst) {
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
     std::string functionName = getGatherScatterFunctionName(output.scalar_type(), output.dim(), /*needsScatter=*/false);
-    id<MTLComputePipelineState> gatherPSO =
-        getPipelineState(functionName + (needs64Bit ? "_u64" : "_u32"),
-                         scalarToMetalTypeString(src),
-                         scalarToMetalTypeString(output),
-                         /*needsScatter=*/false,
-                         src.is_conj() != dst.is_conj());
+    id<MTLComputePipelineState> gatherPSO = getPipelineState(functionName + (needs64Bit ? "_u64" : "_u32"),
+                                                             scalarToMetalTypeString(src),
+                                                             scalarToMetalTypeString(output),
+                                                             /*needsScatter=*/false,
+                                                             src.is_conj() != dst.is_conj());
 
     // this function call is a no-op if MPS Profiler is not enabled
     getMPSProfiler().beginProfileKernel(gatherPSO, functionName, {src, output});
@@ -174,12 +172,11 @@ Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output) {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
       std::string functionName =
           getGatherScatterFunctionName(output.scalar_type(), output.dim(), /*needsScatter=*/true);
-      id<MTLComputePipelineState> scatterPSO =
-          getPipelineState(functionName + (needs64Bit ? "_u64" : "_u32"),
-                           scalarToMetalTypeString(src),
-                           scalarToMetalTypeString(output),
-                           /*needsScatter=*/true,
-                           src.is_conj() != output.is_conj());
+      id<MTLComputePipelineState> scatterPSO = getPipelineState(functionName + (needs64Bit ? "_u64" : "_u32"),
+                                                                scalarToMetalTypeString(src),
+                                                                scalarToMetalTypeString(output),
+                                                                /*needsScatter=*/true,
+                                                                src.is_conj() != output.is_conj());
 
       getMPSProfiler().beginProfileKernel(scatterPSO, functionName, {src, output});
 
@@ -194,9 +191,7 @@ Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output) {
       }
 
       [computeEncoder setComputePipelineState:scatterPSO];
-      auto encode = [&](auto strides) {
-        mtl_setArgs(computeEncoder, src, output, output_sizes, strides, numThreads);
-      };
+      auto encode = [&](auto strides) { mtl_setArgs(computeEncoder, src, output, output_sizes, strides, numThreads); };
       if (needs64Bit) {
         encode(makeStridesBuffer<uint64_t>(output));
       } else {

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -106,14 +106,14 @@ Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst) {
 
     uint32_t kernel_size = src.sizes().size();
     std::vector<uint32_t> src_sizes(kernel_size == 0 ? 1 : kernel_size);
-    std::vector<uint32_t> src_strides(kernel_size == 0 ? 1 : kernel_size);
+    std::vector<uint64_t> src_strides(kernel_size == 0 ? 1 : kernel_size);
 
     if (kernel_size == 0) {
       src_sizes[0] = src_strides[0] = 1;
     } else {
       for (const auto i : c10::irange(kernel_size)) {
         src_sizes[i] = (uint32_t)(src.sizes()[i]);
-        src_strides[i] = (uint32_t)(src.strides()[i]);
+        src_strides[i] = (uint64_t)(src.strides()[i]);
       }
     }
 
@@ -152,14 +152,14 @@ Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output) {
 
       uint32_t kernel_size = output.sizes().size();
       std::vector<uint32_t> output_sizes(kernel_size == 0 ? 1 : kernel_size);
-      std::vector<uint32_t> output_strides(kernel_size == 0 ? 1 : kernel_size);
+      std::vector<uint64_t> output_strides(kernel_size == 0 ? 1 : kernel_size);
 
       if (kernel_size == 0) {
         output_sizes[0] = output_strides[0] = 1;
       } else {
         for (const auto i : c10::irange(kernel_size)) {
           output_sizes[i] = (uint32_t)(output.sizes()[i]);
-          output_strides[i] = (uint32_t)(output.strides()[i]);
+          output_strides[i] = (uint64_t)(output.strides()[i]);
         }
       }
 

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -35,7 +35,6 @@ namespace at::native::mps {
 //   - Benchmark on whether or not this is really the case
 //   - Instantiate specialized tensors from template
 //   - Have proper error checking for 64-bit tensors
-//   - Add flavors for 64-bit tensors
 //   - Merged both scatter and gather templates together, as they more or less alike
 
 static std::string getGatherScatterFunctionName(ScalarType scalarType, int64_t dim, bool needsScatter) {
@@ -76,7 +75,32 @@ static id<MTLComputePipelineState> getPipelineState(const std::string& kernel,
                                                     bool needsScatter,
                                                     bool needsConj) {
   auto cvtFunc = genScatterGatherCvtFunc(dtypeSrc, dtypeDst, needsConj);
-  return (needsScatter ? scatterLib : gatherLib).getPipelineStateForFunc(kernel, {dtypeSrc, dtypeDst, cvtFunc});
+  return (needsScatter ? scatterLib : gatherLib)
+      .getPipelineStateForFunc(kernel, {dtypeSrc, dtypeDst, cvtFunc});
+}
+
+static bool viewNeeds64BitOffsets(const at::Tensor& view) {
+  int64_t max_offset = 0;
+  for (const auto i : c10::irange(view.dim())) {
+    if (view.size(i) > 0) {
+      max_offset += (view.size(i) - 1) * view.stride(i);
+    }
+  }
+  return max_offset >= (int64_t(1) << 32);
+}
+
+template <typename OffsetT>
+static std::vector<OffsetT> makeStridesBuffer(const at::Tensor& view) {
+  uint32_t kernel_size = view.sizes().size();
+  std::vector<OffsetT> strides(kernel_size == 0 ? 1 : kernel_size);
+  if (kernel_size == 0) {
+    strides[0] = 1;
+  } else {
+    for (const auto i : c10::irange(kernel_size)) {
+      strides[i] = static_cast<OffsetT>(view.strides()[i]);
+    }
+  }
+  return strides;
 }
 
 Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst) {
@@ -90,35 +114,41 @@ Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst) {
   }
 
   uint32_t numThreads = output.numel();
+  const bool needs64Bit = viewNeeds64BitOffsets(src);
 
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
     std::string functionName = getGatherScatterFunctionName(output.scalar_type(), output.dim(), /*needsScatter=*/false);
-    id<MTLComputePipelineState> gatherPSO = getPipelineState(functionName,
-                                                             scalarToMetalTypeString(src),
-                                                             scalarToMetalTypeString(output),
-                                                             /*needsScatter=*/false,
-                                                             src.is_conj() != dst.is_conj());
+    id<MTLComputePipelineState> gatherPSO =
+        getPipelineState(functionName + (needs64Bit ? "_u64" : "_u32"),
+                         scalarToMetalTypeString(src),
+                         scalarToMetalTypeString(output),
+                         /*needsScatter=*/false,
+                         src.is_conj() != dst.is_conj());
 
     // this function call is a no-op if MPS Profiler is not enabled
     getMPSProfiler().beginProfileKernel(gatherPSO, functionName, {src, output});
 
     uint32_t kernel_size = src.sizes().size();
     std::vector<uint32_t> src_sizes(kernel_size == 0 ? 1 : kernel_size);
-    std::vector<uint64_t> src_strides(kernel_size == 0 ? 1 : kernel_size);
-
     if (kernel_size == 0) {
-      src_sizes[0] = src_strides[0] = 1;
+      src_sizes[0] = 1;
     } else {
       for (const auto i : c10::irange(kernel_size)) {
         src_sizes[i] = (uint32_t)(src.sizes()[i]);
-        src_strides[i] = (uint64_t)(src.strides()[i]);
       }
     }
 
     [computeEncoder setComputePipelineState:gatherPSO];
-    mtl_setArgs(computeEncoder, src, dst.has_storage() ? dst : output, src_sizes, src_strides, numThreads);
+    auto encode = [&](auto strides) {
+      mtl_setArgs(computeEncoder, src, dst.has_storage() ? dst : output, src_sizes, strides, numThreads);
+    };
+    if (needs64Bit) {
+      encode(makeStridesBuffer<uint64_t>(src));
+    } else {
+      encode(makeStridesBuffer<uint32_t>(src));
+    }
     if (src.dim() > 4) {
       mtl_setBytes<int32_t>(computeEncoder, src.dim(), 5);
     }
@@ -136,35 +166,42 @@ Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output) {
   }
 
   uint32_t numThreads = src.numel();
+  const bool needs64Bit = viewNeeds64BitOffsets(output);
+
   MPSStream* mpsStream = getCurrentMPSStream();
   dispatch_sync_with_rethrow(mpsStream->queue(), ^() {
     @autoreleasepool {
       id<MTLComputeCommandEncoder> computeEncoder = mpsStream->commandEncoder();
       std::string functionName =
           getGatherScatterFunctionName(output.scalar_type(), output.dim(), /*needsScatter=*/true);
-      id<MTLComputePipelineState> scatterPSO = getPipelineState(functionName,
-                                                                scalarToMetalTypeString(src),
-                                                                scalarToMetalTypeString(output),
-                                                                /*needsScatter=*/true,
-                                                                src.is_conj() != output.is_conj());
+      id<MTLComputePipelineState> scatterPSO =
+          getPipelineState(functionName + (needs64Bit ? "_u64" : "_u32"),
+                           scalarToMetalTypeString(src),
+                           scalarToMetalTypeString(output),
+                           /*needsScatter=*/true,
+                           src.is_conj() != output.is_conj());
 
       getMPSProfiler().beginProfileKernel(scatterPSO, functionName, {src, output});
 
       uint32_t kernel_size = output.sizes().size();
       std::vector<uint32_t> output_sizes(kernel_size == 0 ? 1 : kernel_size);
-      std::vector<uint64_t> output_strides(kernel_size == 0 ? 1 : kernel_size);
-
       if (kernel_size == 0) {
-        output_sizes[0] = output_strides[0] = 1;
+        output_sizes[0] = 1;
       } else {
         for (const auto i : c10::irange(kernel_size)) {
           output_sizes[i] = (uint32_t)(output.sizes()[i]);
-          output_strides[i] = (uint64_t)(output.strides()[i]);
         }
       }
 
       [computeEncoder setComputePipelineState:scatterPSO];
-      mtl_setArgs(computeEncoder, src, output, output_sizes, output_strides, numThreads);
+      auto encode = [&](auto strides) {
+        mtl_setArgs(computeEncoder, src, output, output_sizes, strides, numThreads);
+      };
+      if (needs64Bit) {
+        encode(makeStridesBuffer<uint64_t>(output));
+      } else {
+        encode(makeStridesBuffer<uint32_t>(output));
+      }
       if (output.dim() > 4) {
         mtl_setBytes<int32_t>(computeEncoder, output.dim(), 5);
       }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3969,6 +3969,44 @@ class TestMPS(TestCaseMPS):
             ),
         )
 
+    # Regression test for uint32 element-offset wrap in MPS scatter/gather kernels
+    # (aten/src/ATen/mps/IndexKernels.h): a strided view whose storage-relative
+    # element offset crossed 2^32 routed writes/reads to (offset mod 2^32).
+    # uint8 chosen for memory economy; the bug is in element-offset arithmetic
+    # and is dtype-independent. Minimum 5-D shape that crosses 2^32 elements:
+    # max view offset is 8 * 2^29 + 1 * 2^28 = 2^32 + 2^28.
+    _OVERFLOW_SHAPE = (9, 1, 2, 1, 1 << 28)  # uint8, 4.5 GiB
+
+    def test_copy_strided_scatter_offset_overflow_n(self):
+        shape = self._OVERFLOW_SHAPE
+        required_memory = 1.05 * 2 * math.prod(shape)
+        self._skip_if_exceeds_total_memory(required_memory)
+
+        x_cpu = torch.zeros(shape, dtype=torch.uint8)
+        x_mps = x_cpu.to('mps')
+
+        # 18 distinct markers, one per (dim-0, dim-2) position.
+        update = torch.arange(1, 19, dtype=torch.uint8).view(shape[0], 1, shape[2], 1, 1)
+
+        x_cpu[:, :, :, :, 0:1] = update
+        x_mps[:, :, :, :, 0:1] = update.to('mps')  # aten::slice + aten::copy_ -> scatter_kernel_n
+
+        self.assertEqual(x_mps.cpu(), x_cpu)
+
+    def test_copy_strided_gather_offset_overflow_n(self):
+        shape = self._OVERFLOW_SHAPE
+        required_memory = 1.05 * 2 * math.prod(shape)
+        self._skip_if_exceeds_total_memory(required_memory)
+
+        x_cpu = torch.zeros(shape, dtype=torch.uint8)
+        markers = torch.arange(1, 19, dtype=torch.uint8).view(shape[0], 1, shape[2], 1, 1)
+        x_cpu[:, :, :, :, 0:1] = markers
+        x_mps = x_cpu.to('mps')
+
+        gathered_mps = x_mps[:, :, :, :, 0:1].contiguous().cpu()
+        gathered_cpu = x_cpu[:, :, :, :, 0:1].contiguous()
+        self.assertEqual(gathered_mps, gathered_cpu)
+
     # See https://github.com/pytorch/pytorch/issues/152701
     def test_jacfwd_cat(self):
         def fn(x, y):


### PR DESCRIPTION
Fixes issue: #182052

Addresses the wrapping around in scatter/gather kernels when relative linear offset in storage greater than 2^32. In `aten/src/ATen/mps/IndexKernels.h` scatter and gather variants use uint32 stride arithmetic, so stride[d] * idx[d] truncates to 32 bits before summing to the accumulator. CPU works correctly. 

Adds regression tests against the issue. Note that the tests require a relatively hefty amount of memory due to the error only reproducing at the stride values crossing the uint32 boundary. Especially if the second test fails (like the current nightly) since the assert framework computes the statistics to report. Let me know if we should work around this somehow to avoid issues with the CI, but the current CPU vs. MPS formulation of the test seemed to be the cleanest way to demonstrate the issue here.