### PR TITLE
[Inductor] Fix flaky test_allow_reuse_disable_if_exceed_peak by checking reuse marker

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15784,12 +15784,8 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
     @staticmethod
     def _is_triggering_buffer_reuse(fn, *inputs):
         with config.patch(allow_buffer_reuse=True):
-            _, (code_allowed,) = run_and_get_code(fn, *inputs)
-        with config.patch(allow_buffer_reuse=False):
-            _, (code_disallowed,) = run_and_get_code(fn, *inputs)
-        code_allowed = re.sub(r"AOT ID: .*", "AOT ID: ['test']", code_allowed)
-        code_disallowed = re.sub(r"AOT ID: .*", "AOT ID: ['test']", code_disallowed)
-        return code_allowed != code_disallowed
+            _, (code,) = run_and_get_code(fn, *inputs)
+        return "# reuse" in code
 
     # If matmul is implemented by triton there is more reuse
     @config.patch(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15784,8 +15784,17 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
     @staticmethod
     def _is_triggering_buffer_reuse(fn, *inputs):
         with config.patch(allow_buffer_reuse=True):
-            _, (code,) = run_and_get_code(fn, *inputs)
-        return "# reuse" in code
+            _, (code_allowed,) = run_and_get_code(fn, *inputs)
+        with config.patch(allow_buffer_reuse=False):
+            _, (code_disallowed,) = run_and_get_code(fn, *inputs)
+        # Compare only the reuse-decision lines so that unrelated codegen
+        # non-determinism (AOT IDs, autotune outcomes, kernel ordering) does
+        # not cause spurious diffs.
+        reuse_lines_allowed = [l for l in code_allowed.splitlines() if "# reuse" in l]
+        reuse_lines_disallowed = [
+            l for l in code_disallowed.splitlines() if "# reuse" in l
+        ]
+        return reuse_lines_allowed != reuse_lines_disallowed
 
     # If matmul is implemented by triton there is more reuse
     @config.patch(

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -15783,18 +15783,16 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
     @staticmethod
     def _is_triggering_buffer_reuse(fn, *inputs):
+        marker = re.compile(r"(?:#|//) reuse\b")
+
+        def reuse_count(code: str) -> int:
+            return sum(1 for line in code.splitlines() if marker.search(line))
+
         with config.patch(allow_buffer_reuse=True):
             _, (code_allowed,) = run_and_get_code(fn, *inputs)
         with config.patch(allow_buffer_reuse=False):
             _, (code_disallowed,) = run_and_get_code(fn, *inputs)
-        # Compare only the reuse-decision lines so that unrelated codegen
-        # non-determinism (AOT IDs, autotune outcomes, kernel ordering) does
-        # not cause spurious diffs.
-        reuse_lines_allowed = [l for l in code_allowed.splitlines() if "# reuse" in l]
-        reuse_lines_disallowed = [
-            l for l in code_disallowed.splitlines() if "# reuse" in l
-        ]
-        return reuse_lines_allowed != reuse_lines_disallowed
+        return reuse_count(code_allowed) != reuse_count(code_disallowed)
 
     # If matmul is implemented by triton there is more reuse
     @config.patch(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182055


The `_is_triggering_buffer_reuse` helper was comparing full generated code strings from two independent compilations (allow_buffer_reuse=True vs False). Any non-determinism between compilations (autotuning, global counters surviving dynamo.reset()) could cause spurious diffs unrelated to buffer reuse, making
the test flaky.

Extract only the `# reuse` lines from each compilation before comparing. This preserves the semantics while ignoring the non-deterministic surrounding codegen.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo