### PR TITLE
Fix the split_group API to align with torchcomms

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -1886,6 +1886,37 @@ class PythonProcessGroupExtensionTest(MultiProcessTestCase):
                 with self.assertRaises(ValueError):
                     dist.BackendConfig(config_str)
 
+    def test_parse_backend_string(self):
+        from torch.distributed.distributed_c10d import _parse_backend_string
+
+        # Simple form maps to device(s) where the backend is the registered default.
+        self.assertEqual(_parse_backend_string("nccl"), {"cuda": "nccl"})
+        self.assertEqual(_parse_backend_string("NCCL"), {"cuda": "nccl"})
+        # gloo is the default for both cpu and mps in default_device_backend_map.
+        self.assertEqual(_parse_backend_string("gloo"), {"cpu": "gloo", "mps": "gloo"})
+
+        # Merged form returns exactly what was named, no synthesized defaults.
+        self.assertEqual(
+            _parse_backend_string("cpu:gloo,cuda:nccl"),
+            {"cpu": "gloo", "cuda": "nccl"},
+        )
+        self.assertEqual(
+            _parse_backend_string("CPU:GLOO , CUDA:NCCL"),
+            {"cpu": "gloo", "cuda": "nccl"},
+        )
+        # Unknown device types in merged form are accepted (no validation here).
+        self.assertEqual(_parse_backend_string("xpu:nccl"), {"xpu": "nccl"})
+
+        # Errors.
+        with self.assertRaisesRegex(ValueError, "Unknown backend"):
+            _parse_backend_string("definitely_not_a_backend")
+        with self.assertRaisesRegex(ValueError, "Invalid device:backend pairing"):
+            _parse_backend_string("cpu:gloo:extra")
+        with self.assertRaisesRegex(ValueError, "Invalid device:backend pairing"):
+            _parse_backend_string("cpu:gloo,bare")
+        with self.assertRaisesRegex(ValueError, "Duplicate device type"):
+            _parse_backend_string("cpu:gloo,cpu:dummy")
+
     def test_init_process_group_with_multiple_backends(self):
         dist.Backend.register_backend(
             "dummy", PythonProcessGroupExtensionTest.create_dummy

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -1204,6 +1204,76 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
 
     @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_comm_split_group_backend_filter(self):
+        # Hybrid parent (cpu:gloo + cuda:nccl); request only cuda:nccl in the
+        # child via the new `backend` arg. The child should only have the cuda
+        # backend, and the gloo backend should not be split.
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        c10d.init_process_group(
+            "cpu:gloo,cuda:nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+            pg_options=self.opts(),
+            device_id=device,
+        )
+        pg = c10d.distributed_c10d._get_default_group()
+        cuda_backend = pg._get_backend(torch.device("cuda"))
+
+        subg_ranks = [0, 1]
+        ng = c10d.split_group(pg, [subg_ranks], backend="cuda:nccl")
+        if self.rank in subg_ranks:
+            self.assertIsNotNone(ng)
+            ng_cuda = ng._get_backend(torch.device("cuda"))
+            self.assertEqual(cuda_backend.options._timeout, ng_cuda.options._timeout)
+            # cpu backend should not be present in the child.
+            with self.assertRaises(Exception):
+                ng._get_backend(torch.device("cpu"))
+            self.assertEqual(
+                c10d.distributed_c10d._world.pg_backend_config[ng], "cuda:nccl"
+            )
+
+            cuda_tensor = torch.full((1,), self.rank).cuda(device)
+            dist.broadcast(cuda_tensor, dist.get_global_rank(ng, 0), group=ng)
+            self.assertEqual(cuda_tensor, torch.full((1,), 0))
+
+        # cuda comm split happened on this rank.
+        self.assertEqual(cuda_backend.comm_split_count(), 1)
+
+        dist.destroy_process_group()
+
+    @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
+    def test_comm_split_group_backend_validation(self):
+        store = c10d.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        c10d.init_process_group(
+            "cpu:gloo,cuda:nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+            pg_options=self.opts(),
+            device_id=device,
+        )
+        pg = c10d.distributed_c10d._get_default_group()
+
+        # Backend name mismatch (parent has cuda:nccl, request cuda:gloo).
+        with self.assertRaisesRegex(ValueError, "Backend mismatch"):
+            c10d.split_group(pg, [[0, 1]], backend="cuda:gloo")
+
+        # Device type not present in parent.
+        with self.assertRaisesRegex(ValueError, "is not present in the parent"):
+            c10d.split_group(pg, [[0, 1]], backend="xpu:nccl")
+
+        # Filtering out the parent's default backend (cuda) must raise from C++.
+        with self.assertRaises(RuntimeError):
+            c10d.split_group(pg, [[0, 1]], backend="cpu:gloo")
+
+        dist.destroy_process_group()
+
+    @requires_nccl_version((2, 18), "Need NCCL 2.18+ for ncclCommSplit")
+    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     def test_non_blocking_init(self):
         # Test creating a pg using nonblocking mode but not eagerly
         os.environ["TORCH_NCCL_USE_COMM_NONBLOCKING"] = "1"

--- a/test/distributed/test_device_mesh.py
+++ b/test/distributed/test_device_mesh.py
@@ -1628,6 +1628,40 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
     @unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
     @dist_config.patch(use_torchcomms=True)
     @_with_torchcomm_env
+    @with_comms(eager_init=True, backend="cpu:gloo,cuda:nccl")
+    def test_split_group_backend_filter_w_torchcomms(self) -> None:
+        # Hybrid parent (cpu:gloo + cuda:nccl); request only cuda:nccl in the
+        # child via the `backend` arg. eager_init=True binds device_id=cuda so
+        # nccl is the parent's default backend, satisfying the C++ check that
+        # the filter must include the default backend's device.
+        ranks = list(range(self.world_size))
+        pg = dist.distributed_c10d._get_default_group()
+
+        pg_ranks_by_dim = torch.arange(self.world_size).view(2, 4)
+        ng = dist.split_group(pg, pg_ranks_by_dim.tolist(), backend="cuda:nccl")
+        self.assertIsNotNone(ng)
+        self.assertEqual(
+            dist.distributed_c10d._world.pg_backend_config[ng], "cuda:nccl"
+        )
+        gpu_tensor = torch.ones(3, 3, device=self.device_type)
+        dist.all_reduce(gpu_tensor, group=ng)
+        expected_split_size = self.world_size // 2
+        self.assertEqual(
+            gpu_tensor,
+            torch.ones(3, 3, device=self.device_type) * expected_split_size,
+        )
+
+        # Backend name mismatch (parent has cuda:nccl, request cuda:gloo).
+        with self.assertRaisesRegex(ValueError, "Backend mismatch"):
+            dist.split_group(pg, [ranks], backend="cuda:gloo")
+
+        # Device type not present in parent.
+        with self.assertRaisesRegex(ValueError, "is not present in the parent"):
+            dist.split_group(pg, [ranks], backend="xpu:nccl")
+
+    @unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
+    @dist_config.patch(use_torchcomms=True)
+    @_with_torchcomm_env
     @with_comms(backend="cpu:gloo,cuda:nccl")
     def test_device_mesh_w_torchcomms(self) -> None:
         mesh_shape = (2, 2, self.world_size // 4)
@@ -1658,7 +1692,7 @@ class DeviceMeshCollectiveTest(DTensorTestBase):
     @unittest.skipIf(not _TORCHCOMM_AVAILABLE, "TorchComms is not installed")
     @dist_config.patch(use_torchcomms=True)
     @_with_torchcomm_env
-    @with_comms(backend="cpu:gloo,cuda:ncclx")
+    @with_comms(backend="cpu:gloo,cuda:nccl")
     def test_fake_backend_pg_names_w_torchcomms(self) -> None:
         """Fake-backend PG names must be hash-based when torchcomms is enabled.
 

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -382,6 +382,7 @@ class ProcessGroup:
         opts: Backend.Options | None = None,
         group_name: GroupName | None = None,
         group_desc: str | None = None,
+        device_types: list[torch.device] | None = None,
     ) -> ProcessGroup | None: ...
     def merge_remote_group(
         self,

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -158,7 +158,8 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
     const std::optional<std::chrono::milliseconds>& timeout,
     const std::optional<c10::intrusive_ptr<Backend::Options>>& opts,
     const std::optional<std::string>& name,
-    const std::optional<std::string>& desc) {
+    const std::optional<std::string>& desc,
+    const std::optional<std::vector<c10::Device>>& devices) {
   TORCH_CHECK(
       !ranks.empty(),
       "Split ranks cannot be empty. Please provide a non-empty list of ranks to split the group.");
@@ -169,6 +170,26 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
   TORCH_CHECK(
       ranks_set.size() == ranks.size(),
       "Split ranks should not have duplicates. Please provide a list of unique ranks to split the group.");
+  std::set<c10::DeviceType> deviceTypeFilter;
+  for (const auto& d : devices.value_or(std::vector<c10::Device>{})) {
+    deviceTypeFilter.insert(d.type());
+  }
+  if (!deviceTypeFilter.empty()) {
+    for (const auto& deviceType : deviceTypeFilter) {
+      TORCH_CHECK(
+          deviceTypeToBackendType_.count(deviceType) != 0,
+          "Requested device type for splitGroup is not present in the parent process group: ",
+          deviceType);
+    }
+    auto defaultBackendIt = std::find_if(
+        deviceTypeToBackendType_.begin(),
+        deviceTypeToBackendType_.end(),
+        [&](const auto& p) { return p.second == backendType_; });
+    TORCH_CHECK(
+        defaultBackendIt != deviceTypeToBackendType_.end() &&
+            deviceTypeFilter.count(defaultBackendIt->first) != 0,
+        "splitGroup deviceTypes filter must include the parent process group's default backend device type.");
+  }
   std::vector<int> sorted_ranks = ranks;
   std::sort(sorted_ranks.begin(), sorted_ranks.end());
   c10::intrusive_ptr<ProcessGroup> newGroup;
@@ -184,6 +205,10 @@ c10::intrusive_ptr<ProcessGroup> ProcessGroup::splitGroup(
   for (const auto& pair : deviceTypeToBackendType_) {
     c10::DeviceType deviceType = pair.first;
     BackendType backendType = pair.second;
+
+    if (!deviceTypeFilter.empty() && deviceTypeFilter.count(deviceType) == 0) {
+      continue;
+    }
 
     auto parentBackend = getBackend(deviceType);
     auto backendOpts =

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -984,7 +984,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
       const std::optional<std::chrono::milliseconds>& timeout,
       const std::optional<c10::intrusive_ptr<Backend::Options>>& opts,
       const std::optional<std::string>& name,
-      const std::optional<std::string>& groupDesc);
+      const std::optional<std::string>& groupDesc,
+      const std::optional<std::vector<c10::Device>>& devices = std::nullopt);
 
   // This creates a new subgroup using the specified ranks.
   // The current rank must be included in the list of new_ranks.

--- a/torch/csrc/distributed/c10d/PyProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/PyProcessGroup.hpp
@@ -156,7 +156,8 @@ class PyProcessGroup : public ProcessGroup {
       const std::optional<std::chrono::milliseconds>& timeout,
       const std::optional<c10::intrusive_ptr<Backend::Options>>& opts,
       const std::optional<std::string>& group_name,
-      const std::optional<std::string>& group_desc) override {
+      const std::optional<std::string>& group_desc,
+      const std::optional<std::vector<c10::Device>>& devices) override {
     PYBIND11_OVERRIDE(
         c10::intrusive_ptr<ProcessGroup>, /* Return type */
         ProcessGroup, /* Parent class */
@@ -165,7 +166,8 @@ class PyProcessGroup : public ProcessGroup {
         timeout,
         opts,
         group_name,
-        group_desc);
+        group_desc,
+        devices);
   }
 
   c10::intrusive_ptr<ProcessGroup> mergeRemoteGroup(

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -2191,6 +2191,7 @@ communication mechanism.
               py::arg("opts") = std::nullopt,
               py::arg("group_name") = std::nullopt,
               py::arg("group_desc") = std::nullopt,
+              py::arg("device_types") = std::nullopt,
               py::call_guard<py::gil_scoped_release>())
            .def(
               "merge_remote_group",

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -489,6 +489,48 @@ class BackendConfig:
         return self.device_backend_map
 
 
+def _parse_backend_string(backend: str) -> dict[str, str]:
+    """Parse a backend string into a ``{device_type: backend_name}`` dict.
+
+    Accepts either the merged form (``"cpu:gloo,cuda:nccl"``) or a simple
+    backend name (``"nccl"``). For the simple form, the backend is mapped to
+    every device for which it is registered as the default in
+    ``Backend.default_device_backend_map``.
+
+    Unlike :class:`BackendConfig`, this does not synthesize defaults for
+    unspecified devices — callers get back exactly what was named.
+    """
+    backend = backend.lower()
+    if ":" in backend:
+        device_backends: dict[str, str] = {}
+        for part in backend.split(","):
+            pieces = part.split(":")
+            if len(pieces) != 2:
+                raise ValueError(
+                    f"Invalid device:backend pairing '{part}' in '{backend}'. "
+                    "Expected format: '<device_type1>:<backend1>,<device_type2>:<backend2>...'"
+                )
+            device, be = pieces[0].strip(), pieces[1].strip()
+            if device in device_backends:
+                raise ValueError(
+                    f"Duplicate device type '{device}' in backend string '{backend}'"
+                )
+            device_backends[device] = be
+        return device_backends
+
+    device_types = [
+        device
+        for device, be in Backend.default_device_backend_map.items()
+        if be == backend
+    ]
+    if not device_types:
+        raise ValueError(
+            f"Unknown backend '{backend}'. Specify a 'device:backend' string "
+            f"or use one of: {sorted(Backend.default_device_backend_map.values())}"
+        )
+    return dict.fromkeys(device_types, backend)
+
+
 class _reduce_op:
     r"""
     Deprecated enum-like class.
@@ -2089,7 +2131,14 @@ def _new_process_group_helper(
             _world.comms.append(comm)
             group_name = GroupName(group_name)
             backend_class = _BackendWrapper(comm)
-            backend_type = ProcessGroup.BackendType.CUSTOM
+            # Use the underlying backend's BackendType so distinct torchcomms
+            # backends (e.g. gloo vs nccl in a "cpu:gloo,cuda:nccl" PG) don't
+            # collide in ProcessGroup::setBackend's backendTypeToBackend_ map
+            # — that collision silently aliases the second device to the first
+            # backend and trips the bound_device_id consistency check.
+            backend_type = Backend.backend_type_map.get(
+                backend_str, ProcessGroup.BackendType.CUSTOM
+            )
         elif backend_str == Backend.MPI:
             if not is_mpi_available():
                 raise RuntimeError(
@@ -5414,6 +5463,7 @@ def split_group(
     timeout: timedelta | None = None,
     pg_options: Any | None = None,
     group_desc: str | None = None,
+    backend: str | Backend | None = None,
 ) -> ProcessGroup | None:
     """
     Create a new process group split from the given parent process group.
@@ -5439,6 +5489,15 @@ def split_group(
             the construction of specific process groups. i.e.``is_high_priority_stream``
             can be specified so that process group can pick up high priority cuda streams.
         group_desc (str, optional): a string to describe the process group.
+        backend (str or Backend, optional): selects a subset of the parent process
+            group's per-device backends to retain in the child group. The string
+            follows the same format as ``init_process_group`` (e.g. ``"nccl"`` or
+            ``"cpu:gloo,cuda:nccl"``). Each device type in the requested backend
+            must be present in the parent group, and the backend name for that
+            device type must exactly match the parent's. The child's default
+            backend's device type must be in the requested set. If ``None``
+            (default), the child inherits the full backend configuration of the
+            parent.
 
     Returns:
         ProcessGroup if the current rank is within one split/subgroup given by split_ranks,
@@ -5501,8 +5560,35 @@ def split_group(
 
     parent_backend_str, _ = _world.pg_map[parent_pg]
     # same type of backend as the parent process group
-    backend = Backend(parent_backend_str)
-    backend_config = BackendConfig(backend)
+    pg_backend = Backend(parent_backend_str)
+    backend_config = BackendConfig(pg_backend)
+
+    # `backend` (extension API) lets the caller select a subset of the parent
+    # group's per-device backends to retain in the child group. The C++ split
+    # loop honors this filter so unwanted backends are never split.
+    device_types_filter: list[torch.device] | None = None
+    if backend is not None:
+        parent_device_backends = _parse_backend_string(parent_backend_str)
+        requested_device_backends = _parse_backend_string(str(backend))
+        for device_type, requested_be in requested_device_backends.items():
+            if device_type not in parent_device_backends:
+                raise ValueError(
+                    f"Requested backend for device '{device_type}' is not "
+                    f"present in the parent process group (parent backends: "
+                    f"{parent_device_backends})"
+                )
+            parent_be = parent_device_backends[device_type]
+            if parent_be != requested_be:
+                raise ValueError(
+                    f"Backend mismatch for device '{device_type}': parent has "
+                    f"'{parent_be}', requested '{requested_be}'. Backend names "
+                    f"must match exactly when filtering split_group backends."
+                )
+        device_types_filter = [
+            torch.device(device_type) for device_type in requested_device_backends
+        ]
+        pg_backend = Backend(str(backend))
+        backend_config = BackendConfig(pg_backend)
 
     # TODO: figure out pg option for torchComms
     if pg_options is None and not _use_torchcomms_enabled():
@@ -5514,7 +5600,7 @@ def split_group(
     # this timeout defaulting/validation is used for all the new_groups/new_subgroups variants,
     # which may just pass their timeout value (or None)
     if timeout is None:
-        timeout = _get_default_timeout(backend)
+        timeout = _get_default_timeout(pg_backend)
     _check_valid_timeout(timeout)
 
     # find my group of ranks and my group local rank in split_ranks
@@ -5547,6 +5633,7 @@ def split_group(
         opts=pg_options,
         group_name=group_name,
         group_desc=group_desc,
+        device_types=device_types_filter,
     )
     if split_pg is None:
         return None
@@ -5571,7 +5658,7 @@ def split_group(
         )
 
     # update global state
-    _world.pg_map[split_pg] = (backend, split_pg.get_group_store())
+    _world.pg_map[split_pg] = (pg_backend, split_pg.get_group_store())
     _world.pg_names[split_pg] = group_name
     _register_process_group(group_name, split_pg)
     _world.pg_backend_config[split_pg] = str(backend_config)


### PR DESCRIPTION
When using multi-backend process groups (e.g., `init_process_group(backend="cpu:gloo,cuda:nccl")`), calling `split_group` unconditionally splits **every** backend registered in the parent group. This causes three concrete problems:
1. **Backend options mismatch.** `split_group` passes a single options object (typically `ProcessGroupNCCL::Options`) to every backend's `split()`. When Gloo receives NCCL options, it can't dynamic-cast them to `ProcessGroupGloo::Options`, triggering a fallback path with a warning. At scale this is noisy and error-prone.
2. **Unnecessary collective overhead.** Splitting the Gloo backend requires a full-mesh rendezvous through the store -- even when the caller only needs the NCCL communicator. This has overhead.
3. **Inconsistency with `new_group`.** The fallback path in `DeviceMesh` uses `new_group`, which only creates groups for the relevant backend. But `split_group` splits all backends, meaning the two paths produce structurally different process groups - a source of subtle bugs when code assumes a consistent PG shape.

When calling `split_group` - we want to filter to the specific backends instead of splitting all. This change allows us to do that and also align the behavior torchcomms that will be a default backend in future.