### PR TITLE
[CUDA] Early-exit in `release_cached_blocks` if `captures_underway` isn't empty

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -3711,9 +3711,11 @@ class DeviceCachingAllocator {
   }
 
   /**
-   * If mempool_id is {0,0} (the default pool) and there are no
-   * currently capturing memory pools, free the default pool's blocks
-   * and also free the blocks of the freeable private pools.
+   * If any allocations are being diverted to a specific pool, avoid
+   * synchronizing and freeing blocks until the diversion ends.
+   *
+   * If mempool_id is {0,0} (the default pool), free the default pool's
+   * blocks and also free the blocks of the freeable private pools.
    *
    * If mempool_id corresponds to a private pool that is freeable,
    * call synchronize_and_free_events() on that private pool. Free the
@@ -3722,8 +3724,11 @@ class DeviceCachingAllocator {
   bool release_cached_blocks(
       const std::shared_ptr<GatheredContext>& context,
       MempoolId_t mempool_id) {
-    if (mempool_id.first == 0 && mempool_id.second == 0 &&
-        captures_underway.empty()) {
+    if (C10_UNLIKELY(!captures_underway.empty())) {
+      return false;
+    }
+
+    if (mempool_id.first == 0 && mempool_id.second == 0) {
       // If there is no active mempool, we work on releasing *all* blocks.
 
       // First ensure that all blocks that can't currently be allocated due to

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6873,6 +6873,22 @@ class TestMemPool(TestCase):
             s = p.snapshot()
             self.assertEqual(len(s), 1, "Expected to have a single segment")
 
+    def test_mempool_delete_while_other_pool_active(self):
+        torch.cuda.empty_cache()
+        pool_to_delete = torch.cuda.MemPool()
+        with torch.cuda.use_mem_pool(pool_to_delete):
+            x = torch.empty(4, device="cuda")
+        del x
+
+        active_pool = torch.cuda.MemPool()
+        with torch.cuda.use_mem_pool(active_pool):
+            del pool_to_delete
+            gc.collect()
+            y = torch.empty(4, device="cuda")
+
+        del y, active_pool
+        torch.cuda.empty_cache()
+
     @serialTest()
     def test_nested_mempool(self):
         torch.cuda.empty_cache()


### PR DESCRIPTION
defers calling `synchronize_and_free_events` so that we don't call `synchronize_and_free_events` on non-default mempool, otherwise `synchronize_and_free_events` immediately asserts that it's `false` after

authored with codex



cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng