### PR TITLE
Update pytest_pycollect_makemodule signature

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -233,7 +233,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_pycollect_makemodule(module_path, path, parent) -> Module:
+def pytest_pycollect_makemodule(module_path, parent) -> Module:
     if parent.config.getoption("--use-main-module"):
         mod = Module.from_parent(parent, path=module_path)
         mod._getobj = MethodType(lambda x: sys.modules["__main__"], mod)


### PR DESCRIPTION
This has been deprecated for quite some time, and is removed in pytest-9, so it blocks dependabot [updates](https://github.com/pytorch/pytorch/pull/180271), see https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path