### PR TITLE
[CI] Update lumen_cli torch nightly index from cu129 to cu130

### DIFF
--- a/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
+++ b/.ci/lumen_cli/cli/lib/core/torchtitan/torchtitan_test.py
@@ -28,7 +28,7 @@ class TorchtitanTestRunner(BaseRunner):
                 "torchao",
                 "torchcomms",
                 "--index-url",
-                "https://download.pytorch.org/whl/nightly/cu129",
+                "https://download.pytorch.org/whl/nightly/cu130",
             ],
         )
         with working_directory(self.work_directory):

--- a/.ci/lumen_cli/cli/lib/core/vllm/vllm_test.py
+++ b/.ci/lumen_cli/cli/lib/core/vllm/vllm_test.py
@@ -175,7 +175,7 @@ class VllmTestRunner(BaseRunner):
             "-o test/cuda.txt "
             "--index-strategy unsafe-best-match "
             "--constraint snapshot_constraint.txt "
-            "--torch-backend cu129"
+            "--torch-backend cu130"
         )
         pip_install_packages(requirements="test/cuda.txt", prefer_uv=True)
         logger.info("Done. installed requirements for test dependencies")


### PR DESCRIPTION
Align the torchtitan and vLLM lumen_cli test runners with the cu130/cu132 nightly channels PyTorch publishes today. cu129 is no longer produced, so the nightly install in these runners would end up having issues soon.

Authored with Claude.