### PR TITLE
Make custom op aliasing check warn (not error) in CI

### DIFF
--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -93,10 +93,9 @@ autograd_cache_normalize_inputs = not is_fbcode()
 #   - When False: Emits UserWarning on aliasing violations.
 #
 # Deprecated: Custom ops returning aliased outputs is deprecated and will
-# become an error in PyTorch 2.12. Currently error_on_custom_op_aliasing
-# is True only in CI.
+# become an error in a future version of PyTorch.
 check_custom_op_aliasing = True
-error_on_custom_op_aliasing = bool(os.getenv("CI"))
+error_on_custom_op_aliasing = False
 
 
 def remote_autograd_cache_default() -> bool | None:


### PR DESCRIPTION
Set error_on_custom_op_aliasing to False unconditionally so CI runs and local runs produce the same UserWarning instead of CI hard-erroring. Previously, error_on_custom_op_aliasing=bool(os.getenv("CI")) caused the check to raise RuntimeError under CI=1 while only warning elsewhere, which surfaced surprising failures (e.g. vllm::sparse_attn_indexer in DeepSeek-V3.2 hitting a hard error in GitHub Actions but warning in user-land). Fixes #182006.

This probably will have a conflict with @zou3519 https://github.com/pytorch/pytorch/pull/182063, so I can rebase and land this after

Authored with Claude.