### PR TITLE
Add strict_autotune_cache flag to catch autotune cache misses on cache replay

### DIFF
--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -370,6 +370,11 @@ _test_disable_functionalization = True
 # Used for tests
 strict_autograd_cache = False
 
+# When True, error if the autograd cache (AOTAutograd or FxGraph) hits
+# but the runtime autotune cache misses. This catches the failure mode
+# where we replay cached compiled code but have to re-autotune kernels.
+strict_autotune_cache = False
+
 # Note [Recomputing collectives in the partitioner]
 # The purpose of this config is as follows:
 # - We have many passes in the compiler (min-cut partitioning, DCE, etc)

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1618,7 +1618,10 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
                         CompileEventLogger.increment_toplevel, "num_triton_bundles"
                     )
 
+        from .runtime.triton_heuristics import _is_cache_hit_post_compile
+
         try:
+            _is_cache_hit_post_compile.value = True
             artifact_path = graph.after_deserialization(constants)
 
             from .graph import GraphLowering
@@ -1631,6 +1634,8 @@ class FxGraphCache(GuardedCache[CompiledFxGraph]):
             # Not expected, but in case the PyCodeCache entry is removed from
             # underneath us, treat it as a cache miss and recompile.
             return None, cache_info
+        finally:
+            _is_cache_hit_post_compile.value = False
 
         inductor_meta = autotune_cache.inductor_meta_from_config()
         code = graph.source_code

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -125,6 +125,29 @@ _T = TypeVar("_T", bound=_KernelType)
 
 log = logging.getLogger(__name__)
 
+_is_cache_hit_post_compile = threading.local()
+
+
+def _in_cache_hit_post_compile() -> bool:
+    return getattr(_is_cache_hit_post_compile, "value", False)
+
+
+def _raise_if_strict_autotune_cache(filename: str | None) -> None:
+    if not _in_cache_hit_post_compile():
+        return
+    import torch._functorch.config as functorch_config
+
+    if functorch_config.strict_autotune_cache:
+        raise RuntimeError(
+            f"Autotune cache miss for kernel {filename} during "
+            f"cache hit post-compile. This means we hit the "
+            f"AOTAutograd/FxGraph cache but missed the autotune "
+            f"cache, which will cause expensive re-autotuning. "
+            f"Set torch._functorch.config.strict_autotune_cache = "
+            f"False to disable this check."
+        )
+
+
 triton_name_sub = re.compile(r"^def [^(]+\(")
 
 
@@ -301,6 +324,7 @@ def check_autotune_cache(
             else:
                 autotune_cache_info["autotune_cache_state"] = "miss"
                 autotune_cache_info["num_configs"] = len(configs)
+                _raise_if_strict_autotune_cache(filename)
                 if inductor_meta.get("coordinate_descent_tuning"):
                     autotune_cache_info["coordesc_tuning"] = True
                     if len(configs) == 1:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182070
* #181529

There is a failure mode where we cache hit on AOTAutogradCache (or
FxGraphCache) but then cache miss on the runtime autotune cache. This
means we successfully loaded the compiled graph from cache — avoiding
recompilation — but still have to benchmark all Triton kernel configs at
runtime, which is expensive and defeats part of the purpose of caching.

This can happen when the local autotune cache directory was cleared
between runs (different machine, CI, etc.) while the AOTAutograd cache
is still intact.

Fix: add a `strict_autotune_cache` config flag (off by default) that
causes a hard RuntimeError when this happens. The mechanism is a
thread-local flag set during FxGraphCache.cache_hit_post_compile —
specifically around the after_deserialization call that loads the
compiled Python module and triggers all cached_autotune() calls. When
check_autotune_cache() detects a miss while this flag is set and strict
mode is enabled, it raises immediately with a diagnostic message
identifying the kernel.

The flag lives in torch._functorch.config alongside the existing
strict_autograd_cache flag. Enable with:

    torch._functorch.config.strict_autotune_cache = True