### PR TITLE
[Docs] Fix Tensor.expand docstring: rename parameter `*sizes` to `*size`

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -6301,7 +6301,7 @@ Args:
 add_docstr_all(
     "expand",
     r"""
-expand(*sizes) -> Tensor
+expand(*size) -> Tensor
 
 Returns a new view of the :attr:`self` tensor with singleton dimensions expanded
 to a larger size.
@@ -6320,7 +6320,7 @@ of size 1 can be expanded to an arbitrary value without allocating new
 memory.
 
 Args:
-    *sizes (torch.Size or int...): the desired expanded size
+    *size (torch.Size or int...): the desired expanded size
 
 .. warning::
 


### PR DESCRIPTION
Fixes #130960

The docstring for `Tensor.expand` used `*sizes` as the parameter name in both the signature and Args section, but the actual keyword argument defined in `native_functions.yaml` is `size`:

```python
x.expand(sizes=(4, 3))  # TypeError: missing required positional argument "size"
x.expand(size=(4, 3))   # works
```

This renames `*sizes` to `*size` in the docstring to match the actual API.

cc @malfet