### PR TITLE
[Docs] Use standard RL notation for score function in distributions docs

### DIFF
--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -31,11 +31,11 @@ parameters, we only need :meth:`~torch.distributions.Distribution.sample` and
 
 .. math::
 
-    \Delta\theta  = \alpha r \frac{\partial\log p(a|\pi^\theta(s))}{\partial\theta}
+    \Delta\theta  = \alpha r \nabla_\theta \log \pi_\theta(a \mid s)
 
 where :math:`\theta` are the parameters, :math:`\alpha` is the learning rate,
-:math:`r` is the reward and :math:`p(a|\pi^\theta(s))` is the probability of
-taking action :math:`a` in state :math:`s` given policy :math:`\pi^\theta`.
+:math:`r` is the reward and :math:`\pi_\theta(a \mid s)` is the probability of
+taking action :math:`a` in state :math:`s` given policy :math:`\pi_\theta`.
 
 In practice we would sample an action from the output of a network, apply this
 action in an environment, and then use ``log_prob`` to construct an equivalent


### PR DESCRIPTION
Fixes #148253

The REINFORCE score function formula in `torch.distributions` used non-standard notation. This updates it to conventional RL notation:

- Use gradient operator `nabla_theta` instead of partial derivative `d/d_theta`, since `theta` is a parameter vector
- Use `pi_theta(a | s)` instead of `p(a | pi^theta(s))` for the policy, which is the standard convention in RL literature (Sutton & Barto, etc.)

cc @jbschlosser @fritzo