### PR TITLE
[Fix] Add overflow and validation checks for pixel_shuffle in decomposition and meta

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4658,6 +4658,39 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         test_pixel_shuffle_unshuffle_4D()
         test_pixel_shuffle_unshuffle_5D()
 
+    def test_pixel_shuffle_decomp_validation(self):
+        from torch._refs.nn.functional import pixel_shuffle as pixel_shuffle_decomp
+
+        x = torch.randn(1, 4, 2, 2)
+        with self.assertRaisesRegex(RuntimeError, "positive upscale_factor"):
+            pixel_shuffle_decomp(x, 0)
+        with self.assertRaisesRegex(RuntimeError, "positive upscale_factor"):
+            pixel_shuffle_decomp(x, -2)
+
+        with self.assertRaisesRegex(RuntimeError, "too large"):
+            pixel_shuffle_decomp(x, 545460846592)
+
+        x_bad_channels = torch.randn(1, 5, 2, 2)
+        with self.assertRaisesRegex(RuntimeError, "divisible by"):
+            pixel_shuffle_decomp(x_bad_channels, 2)
+
+        x_2d = torch.randn(4, 4)
+        with self.assertRaisesRegex(RuntimeError, "at least 3 dimensions"):
+            pixel_shuffle_decomp(x_2d, 2)
+
+    def test_pixel_shuffle_meta_validation(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            x = torch.randn(1, 4, 2, 2)
+            with self.assertRaisesRegex(RuntimeError, "positive upscale_factor"):
+                torch.ops.aten.pixel_shuffle(x, 0)
+            with self.assertRaisesRegex(RuntimeError, "too large"):
+                torch.ops.aten.pixel_shuffle(x, 545460846592)
+            x_bad = torch.randn(1, 5, 2, 2)
+            with self.assertRaisesRegex(RuntimeError, "divisible by"):
+                torch.ops.aten.pixel_shuffle(x_bad, 2)
+
     @set_default_dtype(torch.double)
     def test_pixel_shuffle_nhwc_cpu(self):
         input = torch.randn(3, 18, 4, 4, device='cpu')

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7910,9 +7910,14 @@ def meta_pixel_shuffle(self, upscale_factor):
         f"upscale_factor^2 overflows int64",
     )
     torch._check(
-        len(self.shape) > 2 and self.shape[-3] % upscale_factor_squared == 0,
+        len(self.shape) > 2,
+        lambda: f"pixel_shuffle expects input to have at least 3 dimensions, "
+        f"but got input with {len(self.shape)} dimension(s)",
+    )
+    torch._check(
+        self.shape[-3] % upscale_factor_squared == 0,
         lambda: f"pixel_shuffle expects input channel to be divisible by "
-        f"upscale_factor^2, but got input shape {self.shape} and "
+        f"upscale_factor^2, but got input.size(-3)={self.shape[-3]} and "
         f"upscale_factor={upscale_factor}",
     )
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7899,12 +7899,22 @@ def linear_backward(input_, grad_output_, weight_, output_mask):
 
 @register_meta(aten.pixel_shuffle.default)
 def meta_pixel_shuffle(self, upscale_factor):
-    if not (
-        len(self.shape) > 2 and self.shape[-3] % (upscale_factor * upscale_factor) == 0
-    ):
-        raise AssertionError(
-            f"Invalid input shape for pixel_shuffle: {self.shape} with upscale_factor = {upscale_factor}"
-        )
+    torch._check(
+        upscale_factor > 0,
+        lambda: f"pixel_shuffle expects a positive upscale_factor, but got upscale_factor={upscale_factor}",
+    )
+    upscale_factor_squared = upscale_factor * upscale_factor
+    torch._check(
+        upscale_factor_squared <= torch.iinfo(torch.int64).max,
+        lambda: f"pixel_shuffle: upscale_factor ({upscale_factor}) is too large, "
+        f"upscale_factor^2 overflows int64",
+    )
+    torch._check(
+        len(self.shape) > 2 and self.shape[-3] % upscale_factor_squared == 0,
+        lambda: f"pixel_shuffle expects input channel to be divisible by "
+        f"upscale_factor^2, but got input shape {self.shape} and "
+        f"upscale_factor={upscale_factor}",
+    )
 
     def is_channels_last(ten):
         return torch._prims_common.suggest_memory_format(ten) == torch.channels_last
@@ -7920,7 +7930,7 @@ def meta_pixel_shuffle(self, upscale_factor):
         elif self.is_contiguous(memory_format=torch.preserve_format):
             return torch.preserve_format
 
-    C = self.shape[-3] // (upscale_factor * upscale_factor)
+    C = self.shape[-3] // upscale_factor_squared
     Hr = self.shape[-2] * upscale_factor
     Wr = self.shape[-1] * upscale_factor
     out_shape = (*self.shape[:-3], C, Hr, Wr)

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -1237,8 +1237,24 @@ def pixel_shuffle(self: Tensor, upscale_factor: int):
         self.dim() >= 3,
         lambda: f"pixel_shuffle expects input to have at least 3 dimensions, but got input with {self.dim} dimension(s)",
     )
+    torch._check(
+        upscale_factor > 0,
+        lambda: f"pixel_shuffle expects a positive upscale_factor, but got upscale_factor={upscale_factor}",
+    )
+    upscale_factor_squared = upscale_factor * upscale_factor
+    torch._check(
+        upscale_factor_squared <= torch.iinfo(torch.int64).max,
+        lambda: f"pixel_shuffle: upscale_factor ({upscale_factor}) is too large, "
+        f"upscale_factor^2 overflows int64",
+    )
+    torch._check(
+        self.shape[-3] % upscale_factor_squared == 0,
+        lambda: f"pixel_shuffle expects input channel to be divisible by "
+        f"upscale_factor^2, but got input.size(-3)={self.shape[-3]} and "
+        f"upscale_factor={upscale_factor}",
+    )
     batch = self.shape[:-3]
-    C_out = self.shape[-3] // upscale_factor**2
+    C_out = self.shape[-3] // upscale_factor_squared
     HW_out = (self.shape[-2] * upscale_factor, self.shape[-1] * upscale_factor)
     n = len(batch)
     B_dims = range(n)


### PR DESCRIPTION
Fixes #171838

The eager C++ crash (SIGFPE) from an extremely large `upscale_factor` was fixed in #163154. However, the `torch.compile` path (Python decomposition in `_refs` and the meta registration) still lacked validation, which could cause incorrect shapes or crashes during compilation.

This adds three checks to both `_refs/nn/functional/pixel_shuffle` and `meta_pixel_shuffle`:
- `upscale_factor > 0`
- `upscale_factor^2 <= torch.iinfo(torch.int64).max` (overflow guard, using `torch.iinfo` per review feedback on #171855)
- `input.shape[-3] % upscale_factor^2 == 0` (channel divisibility)

Also replaces the bare `AssertionError` in the meta function with `torch._check` for consistency with the rest of the codebase.

cc @malfet