### PR TITLE
[inductor] Release GPU memory between combo kernel benchmark iterations

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6948,6 +6948,8 @@ class TritonScheduling(SIMDScheduling):
             total_ms += ms
             total_clone_ms += ms_clone
             file_list.append(mod.__file__)
+            del args, call, wrapped_jit_function
+            torch.accelerator.empty_cache()
         V.graph.removed_buffers = removed_buffers_orig
         V.graph.inplaced_to_remove = inplaced_to_remove_orig
         return total_ms, total_clone_ms, file_list


### PR DESCRIPTION
Summary:
During AOTI lowering with combo_kernels=True and max_autotune=True, the
benchmark_combo_kernel() function benchmarks multiple combo kernel groups
sequentially. Each iteration allocates benchmark tensors via rand_strided()
with potentially inflated strides (from ReinterpretView buffers in the
inductor IR). These tensors are freed by Python's refcounting when
reassigned, but PyTorch's CUDACachingAllocator holds the freed blocks
in its free list without returning them to the GPU driver.

Over many iterations, the cached blocks accumulate, causing GPU memory
to grow from ~28 GiB to ~187 GiB on MI300X (192 GiB HBM), eventually
OOMing when trying to allocate the next benchmark tensor.

This fix adds del + torch.cuda.empty_cache() after each benchmark
iteration to flush the caching allocator's free list back to the driver,
preventing memory accumulation across iterations.

Confirmed fix: 2/2 truly cold cache lowering runs succeeded with this
fix on MI300X with combo_kernels=True, vs 6/6 OOM without it.

GPU memory profile evidence: P2295513688
Runbook: https://docs.google.com/document/d/1ECcXlpUeCn5ib24RWIgoDARBsarUKU0K5HF8vjcyMWI/edit

Test Plan:
- Lowered model 1071085802 with max_autotune=True, combo_kernels=True on MI300X devserver with truly cold cache (rm -rf /var/tmp/torchinductor_lruishen/): SUCCESS (run 28)
- Repeated with fresh cold cache: SUCCESS (run 29)
- Without this fix, same config OOMs consistently at 187.46 GiB (runs 17b, 18, 21, 22, 23, 26)

Reviewed By: kqfu

Differential Revision: D103152384




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo