### PR TITLE
Upgrade numba to 0.64.0

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -118,7 +118,7 @@ ninja==1.11.1.4
 #test that import: run_test.py, test_cpp_extensions_aot.py,test_determination.py
 
 numba==0.57.1 ; python_version == "3.10" and platform_machine != "s390x"
-numba==0.60.0 ; python_version == "3.12" and platform_machine != "s390x"
+numba==0.64.0 ; python_version == "3.12" and platform_machine != "s390x"
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.55.2, 0.60.0
 #test that import: test_numba_integration.py


### PR DESCRIPTION
Windows tests need numba 0.64.0
Upgrade package for both Windows and Linux as suggested by @malfet : 
https://github.com/pytorch/pytorch/pull/176678#discussion_r3164615993
