### PR TITLE
[CUDA] Zero `total_weight` before accumulating in `nll_loss2d`

### DIFF
--- a/aten/src/ATen/native/cuda/NLLLoss2d.cu
+++ b/aten/src/ATen/native/cuda/NLLLoss2d.cu
@@ -253,6 +253,8 @@ void nll_loss2d_forward_out_cuda_template(
   total_weight.resize_({});
 
   if (reduction == at::Reduction::None) {
+    total_weight.zero_();
+
     int64_t batch_size = input.size(0);
     int64_t H = input.size(2);
     int64_t W = input.size(3);


### PR DESCRIPTION
For failing tests such as `python test/test_decomp.py -k test_comprehensive_nn_functional_nll_loss_cuda` as it appears were were previously accumulating into uninitialized buffers

authored with codex

CC @nWEIdia 

cc @ptrblck @msaroufim @jerryzh168 @tinglvv @nWEIdia