### PR TITLE
[Inductor] Serialize CompiledFxGraph._original_gm via GraphPickler

### DIFF
--- a/test/inductor/test_compiled_fx_graph_serialization.py
+++ b/test/inductor/test_compiled_fx_graph_serialization.py
@@ -15,14 +15,12 @@ GraphPickler (which serializes the graph structure directly without
 retracing), and post_compile deserializes it back on load.
 """
 
-import unittest
-
 import torch
 from torch._inductor.output_code import CompiledFxGraph
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 
-class TestCompiledFxGraphSerialization(unittest.TestCase):
+class TestCompiledFxGraphSerialization(TestCase):
     def _make_gm(self):
         gm = torch.fx.GraphModule(torch.nn.Module(), torch.fx.Graph())
         gm.graph.placeholder("x")

--- a/test/inductor/test_compiled_fx_graph_serialization.py
+++ b/test/inductor/test_compiled_fx_graph_serialization.py
@@ -1,0 +1,115 @@
+# Owner(s): ["module: inductor"]
+
+"""Tests that CompiledFxGraph serializes _original_gm via GraphPickler.
+
+_original_gm is a deepcopy of the pre-compiled FX graph, stored when
+wrap_inductor_compiled_regions is enabled. It is used for FakeTensor
+shape inference (inductor_compiled_code_fake). Regular pickle cannot
+serialize GraphModules containing higher-order ops with lifted buffers
+(e.g. flex_attention with BlockMask mask_mod_other_buffers), because
+deserialization retraces via KeepModules().trace() which calls
+validate_subgraph_args_types on Proxy-typed arguments.
+
+prepare_for_serialization converts _original_gm to bytes via
+GraphPickler (which serializes the graph structure directly without
+retracing), and post_compile deserializes it back on load.
+"""
+
+import unittest
+
+import torch
+from torch._inductor.output_code import CompiledFxGraph
+from torch.testing._internal.common_utils import run_tests
+
+
+class TestCompiledFxGraphSerialization(unittest.TestCase):
+    def _make_gm(self):
+        gm = torch.fx.GraphModule(torch.nn.Module(), torch.fx.Graph())
+        gm.graph.placeholder("x")
+        gm.graph.output(next(iter(gm.graph.nodes)))
+        gm.recompile()
+        return gm
+
+    def _make_cfg(self, gm=None):
+        cfg = CompiledFxGraph.__new__(CompiledFxGraph)
+        cfg._original_gm = gm
+        cfg._serialized_original_gm = None
+        cfg.current_callable = None
+        cfg.recursively_apply_fns = None
+        cfg.compiled_fn_runner = None
+        return cfg
+
+    def test_prepare_serializes_original_gm_via_graph_pickler(self):
+        """prepare_for_serialization converts _original_gm to GraphPickler bytes."""
+        cfg = self._make_cfg(self._make_gm())
+
+        self.assertIsNotNone(cfg._original_gm)
+        self.assertIsNone(cfg._serialized_original_gm)
+
+        cfg.prepare_for_serialization()
+
+        self.assertIsNone(cfg._original_gm)
+        self.assertIsNotNone(cfg._serialized_original_gm)
+        self.assertIsInstance(cfg._serialized_original_gm, bytes)
+
+    def test_prepare_with_none_original_gm(self):
+        """prepare_for_serialization is a no-op when _original_gm is None."""
+        cfg = self._make_cfg(None)
+        cfg.prepare_for_serialization()
+
+        self.assertIsNone(cfg._original_gm)
+        self.assertIsNone(cfg._serialized_original_gm)
+
+    def test_prepare_with_hop_containing_lifted_buffers(self):
+        """GraphModule with flex_attention HOP + lifted buffers serializes cleanly.
+
+        This is the exact pattern that crashes with regular pickle:
+        flex_attention with non-empty mask_mod_other_buffers. GraphPickler
+        handles it without retracing.
+        """
+        score_mod = torch.fx.GraphModule(torch.nn.Module(), torch.fx.Graph())
+        for name in ["score", "b", "h", "m", "n"]:
+            score_mod.graph.placeholder(name)
+        score_mod.graph.output(next(iter(score_mod.graph.nodes)))
+        score_mod.recompile()
+
+        gm = torch.fx.GraphModule(torch.nn.Module(), torch.fx.Graph())
+        gm.score_mod_0 = score_mod
+
+        g = gm.graph
+        q = g.placeholder("q")
+        k = g.placeholder("k")
+        v = g.placeholder("v")
+        mask_buf = g.placeholder("mask_buf")
+        score_attr = g.get_attr("score_mod_0")
+
+        block_mask = (
+            128,
+            128,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            128,
+            128,
+        )
+        g.call_function(
+            torch.ops.higher_order.flex_attention,
+            args=(q, k, v, score_attr, block_mask, 0.125, {}, (), (mask_buf,)),
+        )
+        g.output(next(n for n in g.nodes if n.op == "call_function"))
+        gm.recompile()
+
+        cfg = self._make_cfg(gm)
+        cfg.prepare_for_serialization()
+
+        self.assertIsNone(cfg._original_gm)
+        self.assertIsNotNone(cfg._serialized_original_gm)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -26,7 +26,7 @@ import dataclasses
 import logging
 import os
 from functools import partial
-from typing import Any, TYPE_CHECKING, TypeAlias
+from typing import Any, cast, TYPE_CHECKING, TypeAlias
 
 import torch
 from torch._dynamo.utils import counters, get_runtime_metrics_context
@@ -832,30 +832,31 @@ class CompiledFxGraph(OutputCode):
             self.mutated_input_idxs,
         )
 
+        if self._original_gm is None and self._serialized_original_gm is not None:
+            from torch._subclasses import FakeTensorMode
+            from torch.fx._graph_pickler import GraphPickler
+            from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+            fake_mode = FakeTensorMode(
+                allow_non_fake_inputs=True,
+                shape_env=ShapeEnv(),
+            )
+            self._original_gm = cast(
+                torch.fx.GraphModule,
+                GraphPickler.loads(self._serialized_original_gm, fake_mode),
+            )
+            self._serialized_original_gm = None
+
         # Apply inductor_compiled_code HOP wrapper if configured
         # This is done in post_compile to ensure it works with cached artifacts
         if self._wrap_compiled_regions and self.current_callable is not None:
             from torch._higher_order_ops.wrap import InductorCompiledCallable
 
-            original_gm = self._original_gm
-            if original_gm is None and self._serialized_original_gm is not None:
-                from torch._subclasses import FakeTensorMode
-                from torch.fx._graph_pickler import GraphPickler
-                from torch.fx.experimental.symbolic_shapes import ShapeEnv
-
-                fake_mode = FakeTensorMode(
-                    allow_non_fake_inputs=True,
-                    shape_env=ShapeEnv(),
-                )
-                original_gm = GraphPickler.loads(
-                    self._serialized_original_gm, fake_mode
-                )
-
             original_callable = self.current_callable
 
             inductor_callable = InductorCompiledCallable(
                 original_callable,
-                original_gm,
+                self._original_gm,
                 compile_region_name=self.compile_region_name,
             )
 
@@ -884,9 +885,11 @@ class CompiledFxGraph(OutputCode):
         self.recursively_apply_fns = None
         self.compiled_fn_runner = None
         if self._original_gm is not None:
-            from torch.fx._graph_pickler import GraphPickler
+            from torch.fx._graph_pickler import GraphPickler, Options
 
-            self._serialized_original_gm = GraphPickler.dumps(self._original_gm)
+            self._serialized_original_gm = GraphPickler.dumps(
+                self._original_gm, Options(ops_filter=None)
+            )
             self._original_gm = None
         # Note: _serialized_fx_graph is already in serializable form (SerializedGraphModule)
         # so it doesn't need to be cleared

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -510,6 +510,7 @@ class CompiledFxGraph(OutputCode):
     # Running this graph under FakeTensorMode re-derives output shapes
     # (including aliasing) from the input shapes.
     _original_gm: torch.fx.GraphModule | None = None
+    _serialized_original_gm: bytes | None = None
 
     def __init__(
         self,
@@ -836,11 +837,25 @@ class CompiledFxGraph(OutputCode):
         if self._wrap_compiled_regions and self.current_callable is not None:
             from torch._higher_order_ops.wrap import InductorCompiledCallable
 
+            original_gm = self._original_gm
+            if original_gm is None and self._serialized_original_gm is not None:
+                from torch._subclasses import FakeTensorMode
+                from torch.fx._graph_pickler import GraphPickler
+                from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+                fake_mode = FakeTensorMode(
+                    allow_non_fake_inputs=True,
+                    shape_env=ShapeEnv(),
+                )
+                original_gm = GraphPickler.loads(
+                    self._serialized_original_gm, fake_mode
+                )
+
             original_callable = self.current_callable
 
             inductor_callable = InductorCompiledCallable(
                 original_callable,
-                self._original_gm,
+                original_gm,
                 compile_region_name=self.compile_region_name,
             )
 
@@ -868,7 +883,11 @@ class CompiledFxGraph(OutputCode):
         self.current_callable = None
         self.recursively_apply_fns = None
         self.compiled_fn_runner = None
-        # Note: _original_gm is already picklable (metadata stripped at creation)
+        if self._original_gm is not None:
+            from torch.fx._graph_pickler import GraphPickler
+
+            self._serialized_original_gm = GraphPickler.dumps(self._original_gm)
+            self._original_gm = None
         # Note: _serialized_fx_graph is already in serializable form (SerializedGraphModule)
         # so it doesn't need to be cleared
 

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -841,10 +841,12 @@ class CompiledFxGraph(OutputCode):
                 allow_non_fake_inputs=True,
                 shape_env=ShapeEnv(),
             )
-            self._original_gm = cast(
+            original_gm = cast(
                 torch.fx.GraphModule,
                 GraphPickler.loads(self._serialized_original_gm, fake_mode),
             )
+            original_gm.recompile()
+            self._original_gm = original_gm
             self._serialized_original_gm = None
 
         # Apply inductor_compiled_code HOP wrapper if configured


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182088

CompiledFxGraph stores _original_gm (a deepcopy of the pre-compiled FX
graph) when wrap_inductor_compiled_regions is enabled (PR #175794). This
is used by inductor_compiled_code_fake for FakeTensor shape inference.

Previously, _original_gm was serialized via regular pickle as part of
the AOTAutograd cache and AOTCompiledArtifact. Regular pickle uses
GraphModule.__reduce__ → reduce_graph_module → KeepModules().trace(),
which retraces the forward code. When the graph contains higher-order
ops with lifted buffers (e.g. flex_attention with non-empty
mask_mod_other_buffers from a causal BlockMask), this retrace crashes:
validate_subgraph_args_types rejects the Proxy-typed buffer arguments.

GraphPickler avoids this by serializing the graph structure directly
(nodes, edges, metadata) without retracing. It was already used for
the outer graph in torchtitan's precompile path, but the inner
AOTCompiledArtifact used regular pickle for its embedded GraphModules.

The fix: in prepare_for_serialization(), convert _original_gm to
GraphPickler bytes (_serialized_original_gm). In post_compile(),
deserialize back via GraphPickler.loads() under a fresh FakeTensorMode.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo