### PR TITLE
Allow torch.meshgrid() with empty input to return empty tuple

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1383,9 +1383,8 @@ class TestTensorCreation(TestCase):
         self.assertEqual(int(y), 3)
 
     def test_meshgrid_empty(self):
-        with self.assertRaisesRegex(RuntimeError,
-                                    'expects a non-empty TensorList'):
-            torch.meshgrid()
+        self.assertEqual(torch.meshgrid(), ())
+        self.assertEqual(torch.meshgrid([]), ())
 
     def test_meshgrid_unsupported_indexing(self):
         with self.assertRaisesRegex(RuntimeError,

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5638,7 +5638,8 @@ def meshgrid(
         lambda: "meshgrid expects its inputs to be tensors",
     )
 
-    torch._check(len(tensors) > 0, lambda: "meshgrid expects a non-empty TensorList")
+    if len(tensors) == 0:
+        return []
 
     for i in range(len(tensors) - 1):
         torch._check(

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -493,9 +493,13 @@ else:
 def _meshgrid(*tensors, indexing: str | None):
     if has_torch_function(tensors):
         return handle_torch_function(meshgrid, tensors, *tensors, indexing=indexing)
+
     if len(tensors) == 1 and isinstance(tensors[0], (list, tuple)):
         # the old interface of passing the operands as one list argument
         tensors = tensors[0]  # type: ignore[assignment]
+
+    if len(tensors) == 0:
+        return ()
 
     # Continue allowing call of old method that takes no indexing
     # kwarg for forward compatibility reasons.


### PR DESCRIPTION
torch.meshgrid() with no arguments previously raised a RuntimeError. This is inconsistent with NumPy behavior and the Array API Standard, which both specify that empty input should return an empty sequence.

**Changes:**
- `torch/functional.py`: add early return `()` in `_meshgrid()` after old-interface unwrapping
- `torch/_refs/__init__.py`: same guard for the FakeTensor path
- `test/test_tensor_creation_ops.py`: update `test_meshgrid_empty` to assert the new behavior

**Before:**
torch.meshgrid()   # RuntimeError
**After:**
torch.meshgrid()   # ()

Fixes #181576