### PR TITLE
Revert "[FSDP2] add fqn to communication ops"

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -2496,7 +2496,6 @@ class TestFullyShardShareCommContext(FSDPTest):
             all_gather_stream: torch.Stream,
             device: torch.device,
             all_gather_comm: AllGather,
-            module_fqn: str | None = None,
         ):
             nonlocal all_gather_streams
             all_gather_streams.add(all_gather_stream)
@@ -2508,7 +2507,6 @@ class TestFullyShardShareCommContext(FSDPTest):
                 all_gather_stream,
                 device,
                 all_gather_comm,
-                module_fqn,
             )
 
         orig_foreach_reduce = foreach_reduce
@@ -2530,7 +2528,6 @@ class TestFullyShardShareCommContext(FSDPTest):
             partial_reduce_output: torch.Tensor | None,  # only used for HSDP
             all_reduce_hook: Callable[[torch.Tensor], None] | None,
             force_sum_reduction_for_comms: bool = False,
-            module_fqn: str | None = None,
         ):
             nonlocal reduce_scatter_streams
             reduce_scatter_streams.add(reduce_scatter_stream)
@@ -2550,7 +2547,6 @@ class TestFullyShardShareCommContext(FSDPTest):
                 partial_reduce_output,
                 all_reduce_hook,
                 force_sum_reduction_for_comms,
-                module_fqn,
             )
 
         with (

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -20,12 +20,6 @@ from ._fsdp_common import (
 from ._fsdp_param import FSDPParam, ShardedState
 
 
-def _label_with_suffix(label: str, suffix: str) -> str:
-    if suffix:
-        return f"{label} {suffix}"
-    return label
-
-
 class AllGatherResult(NamedTuple):
     all_gather_output: torch.Tensor
     all_gather_event: torch.Event | None
@@ -336,49 +330,43 @@ def foreach_all_gather(
     all_gather_stream: torch.Stream,
     device: torch.device,
     all_gather_comm: AllGather,
-    label_suffix: str = "",
 ) -> AllGatherResult | None:
     world_size, rank = group.size(), group.rank()
     device_handle = _get_device_handle(device.type)
-
     with device_handle.stream(all_gather_copy_in_stream):
-        with torch.profiler.record_function(
-            _label_with_suffix("FSDP::all_gather_copy_in", label_suffix)
-        ):
-            param_all_gather_inputs = _get_param_all_gather_inputs(fsdp_params)
-            (
-                param_all_gather_input_dtypes,
-                param_all_gather_input_numels,
-                dtype,
-            ) = _get_all_gather_input_metadatas(param_all_gather_inputs)
-            if dtype == torch.uint8:
-                all_gather_inputs = [
-                    t.view(torch.uint8) for ts in param_all_gather_inputs for t in ts
-                ]
-            else:
-                all_gather_inputs = [*chain.from_iterable(param_all_gather_inputs)]
-            inp_split_sizes = [t.numel() for t in all_gather_inputs]
-            all_gather_input_numel = sum(inp_split_sizes)
-            all_gather_output = all_gather_comm.allocate(
-                (all_gather_input_numel * world_size,), dtype=dtype, device=device
-            )
-            all_gather_input, all_gather_output = torch.ops.fsdp.all_gather_copy_in(
-                all_gather_inputs,
-                all_gather_output,
-                inp_split_sizes,
-                all_gather_input_numel,
-                rank,
-            )
-            del param_all_gather_inputs
+        param_all_gather_inputs = _get_param_all_gather_inputs(fsdp_params)
+        (
+            param_all_gather_input_dtypes,
+            param_all_gather_input_numels,
+            dtype,
+        ) = _get_all_gather_input_metadatas(param_all_gather_inputs)
+        if dtype == torch.uint8:
+            all_gather_inputs = [
+                t.view(torch.uint8) for ts in param_all_gather_inputs for t in ts
+            ]
+        else:
+            all_gather_inputs = [*chain.from_iterable(param_all_gather_inputs)]
+        inp_split_sizes = [t.numel() for t in all_gather_inputs]
+        all_gather_input_numel = sum(inp_split_sizes)
+        all_gather_output = all_gather_comm.allocate(
+            (all_gather_input_numel * world_size,), dtype=dtype, device=device
+        )
+        all_gather_input, all_gather_output = torch.ops.fsdp.all_gather_copy_in(
+            all_gather_inputs,
+            all_gather_output,
+            inp_split_sizes,
+            all_gather_input_numel,
+            rank,
+        )
+        del param_all_gather_inputs
     all_gather_stream.wait_stream(all_gather_copy_in_stream)
     with device_handle.stream(all_gather_stream):
-        with dist.record_comm(_label_with_suffix("FSDP::all_gather", label_suffix)):
-            all_gather_work = all_gather_comm(
-                output_tensor=all_gather_output,
-                input_tensor=all_gather_input,
-                group=group,
-                async_op=async_op,
-            )
+        all_gather_work = all_gather_comm(
+            output_tensor=all_gather_output,
+            input_tensor=all_gather_input,
+            group=group,
+            async_op=async_op,
+        )
         all_gather_event = all_gather_stream.record_event()
         return AllGatherResult(
             all_gather_output,
@@ -547,7 +535,6 @@ def foreach_reduce(
     partial_reduce_output: torch.Tensor | None,  # only used for HSDP
     all_reduce_hook: Callable[[torch.Tensor], None] | None,
     force_sum_reduction_for_comms: bool = False,
-    label_suffix: str = "",
 ) -> tuple[
     torch.Tensor,
     torch.Event,
@@ -628,15 +615,12 @@ def foreach_reduce(
         )
         _div_if_needed(reduce_scatter_input, predivide_factor)
         if world_size > 1:
-            with dist.record_comm(
-                _label_with_suffix("FSDP::reduce_scatter", label_suffix)
-            ):
-                reduce_scatter_comm(
-                    output_tensor=reduce_output,
-                    input_tensor=reduce_scatter_input,
-                    group=reduce_scatter_group,
-                    op=reduce_scatter_op,
-                )
+            reduce_scatter_comm(
+                output_tensor=reduce_output,
+                input_tensor=reduce_scatter_input,
+                group=reduce_scatter_group,
+                op=reduce_scatter_op,
+            )
         else:
             # For single GPU, just copy the input to output (no actual reduce-scatter needed), and
             # account for a possible gradient_divide_factor.
@@ -669,14 +653,11 @@ def foreach_reduce(
             else:
                 all_reduce_stream.wait_stream(current_stream)
             with device_handle.stream(all_reduce_stream):
-                with dist.record_comm(
-                    _label_with_suffix("FSDP::all_reduce", label_suffix)
-                ):
-                    dist.all_reduce(
-                        reduce_output,
-                        group=all_reduce_group,
-                        op=all_reduce_op,
-                    )
+                dist.all_reduce(
+                    reduce_output,
+                    group=all_reduce_group,
+                    op=all_reduce_op,
+                )
                 # Keep refs to the reduce-dtype AR buffer + completion
                 # event so FSDPParamGroup._all_reduce_state can hold them
                 # across layers. This keeps the buffer off the caching

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -389,7 +389,6 @@ class FSDPParamGroup:
                 *self.comm_ctx.get_all_gather_streams(async_op, self._training_state),
                 self.device,
                 self._all_gather_comm,
-                self._label_suffix,
             )
 
     def wait_for_unshard(self):
@@ -677,7 +676,6 @@ class FSDPParamGroup:
                 self._partial_reduce_output,
                 self._all_reduce_hook,
                 self.force_sum_reduction_for_comms,
-                self._label_suffix,
             )
             self.comm_ctx.reduce_scatter_states.append(
                 ReduceScatterState(reduce_scatter_input, reduce_scatter_event)
@@ -936,17 +934,11 @@ class FSDPParamGroup:
             )
         return self.mesh_info.replicate_process_group
 
-    @property
-    def _label_suffix(self) -> str:
-        suffix = f"({self._module_fqn})" if self._module_fqn else ""
-        if self._num_param_groups > 1 and isinstance(self.mesh_info, FSDPMeshInfo):
-            suffix = f"{suffix} [pg={self.mesh_info.shard_mesh_size}]".lstrip()
-        return suffix
-
     def _with_fqn(self, label: str) -> str:
-        suffix = self._label_suffix
-        if suffix:
-            return f"{label} {suffix}"
+        if self._module_fqn:
+            label = f"{label} ({self._module_fqn})"
+        if self._num_param_groups > 1 and isinstance(self.mesh_info, FSDPMeshInfo):
+            label = f"{label} [pg={self.mesh_info.shard_mesh_size}]"
         return label
 
     def __repr__(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182100

Reverts #173838. It messed up async_op=True profiler traces

This removes the FSDP2 communication-op FQN annotations added via
`dist.record_comm()` and stops threading the collective label suffix through
the foreach collective helpers. I

The revert preserves later HSDP all-reduce buffer lifetime handling from
  #180900.