### PR TITLE
[nativert] Fix NativeRT Triton HOP argument packing (#182101)

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -732,18 +732,31 @@ def forward(self, x):
             self.assertIsNotNone(triton_node)
 
             args = []
+            arg_names = []
             kwargs = {}
 
             for arg in triton_node.inputs:
                 if arg.kind == ArgumentKind.POSITIONAL:
                     args.append(arg.arg)
+                    arg_names.append(arg.name)
                 elif arg.kind == ArgumentKind.KEYWORD:
                     kwargs[arg.name] = arg.arg
 
             self.assertEqual(len(args), 6)
-            # Always: name, grid, output_indices and num_warps are
+            # Positional args carry kernel parameter names
+            expected_param_names = [
+                "in_ptr0",
+                "in_ptr1",
+                "out_ptr",
+                "n_elements",
+                "fval",
+                "ival",
+            ]
+            self.assertEqual(arg_names, expected_param_names)
+            # Always: name, grid, output_indices, num_warps,
+            # kernel_param_names, kernel_param_types
             # Triton version dependent: num_cpu_threads, shared_memory_bytes
-            self.assertTrue(len(kwargs) >= 4)
+            self.assertTrue(len(kwargs) >= 6)
 
             for i in range(3):
                 self.assertIsNotNone(args[i].as_tensor)
@@ -764,6 +777,16 @@ def forward(self, x):
                 self.assertEqual(kwargs["num_cpu_threads"].as_int, 0)
             if "shared_memory_bytes" in kwargs:
                 self.assertEqual(kwargs["shared_memory_bytes"].as_int, 0)
+
+            self.assertIn("kernel_param_names", kwargs)
+            self.assertEqual(
+                kwargs["kernel_param_names"].as_strings, expected_param_names
+            )
+            self.assertIn("kernel_param_types", kwargs)
+            self.assertEqual(
+                len(kwargs["kernel_param_types"].as_strings),
+                len(expected_param_names),
+            )
 
             self.assertEqual(len(triton_node.outputs), 1)
             self.assertIsNotNone(triton_node.outputs[0].as_tensors)

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -895,7 +895,7 @@ class GraphModuleSerializer(metaclass=Final):
 
                 constexpr_keys = {p.name for p in kernel.params if p.is_constexpr}
                 found_constexpr = False
-                args_new = ()
+                inputs_new = []
                 i = 0
 
                 if not isinstance(node.kwargs["kwargs"], dict):
@@ -917,7 +917,13 @@ class GraphModuleSerializer(metaclass=Final):
 
                     if k in output_keys:
                         output_indices.append(i)
-                    args_new += (v,)  # type: ignore[assignment]
+                    inputs_new.append(
+                        NamedArgument(
+                            name=k,
+                            arg=self.serialize_input(v),
+                            kind=ArgumentKind.POSITIONAL,
+                        )
+                    )
                     i += 1
 
                 if not isinstance(node.kwargs["grid"], list):
@@ -982,7 +988,15 @@ class GraphModuleSerializer(metaclass=Final):
                 ex_node = Node(
                     name=node.name,
                     target=self.serialize_operator(node.target),
-                    inputs=self.serialize_hoo_inputs(args_new, kwargs_new),
+                    inputs=inputs_new
+                    + [
+                        NamedArgument(
+                            name=name,
+                            arg=self.serialize_input(a),
+                            kind=ArgumentKind.KEYWORD,
+                        )
+                        for name, a in kwargs_new.items()
+                    ],
                     outputs=self.serialize_hoo_outputs(node),
                     metadata=self.serialize_metadata(node),
                     is_hop_single_tensor_return=_is_hop_single_tensor_return(node),
@@ -3059,10 +3073,10 @@ class GraphModuleDeserializer(metaclass=Final):
         args = []
         kwargs = {}
         for input_ in inputs:
-            if input_.name != "":
-                kwargs[input_.name] = self.deserialize_input(input_.arg)
-            else:
+            if input_.kind == ArgumentKind.POSITIONAL or input_.name == "":
                 args.append(self.deserialize_input(input_.arg))
+            else:
+                kwargs[input_.name] = self.deserialize_input(input_.arg)
         return (tuple(args), kwargs)
 
     def deserialize_input(self, inp: Argument) -> Any:

--- a/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/CudaTritonKernelManager.cpp
@@ -62,6 +62,12 @@ class CudaKernelInputs final : public KernelInputs {
     arg_idx_++;
   }
 
+  void add_scalar_arg(const c10::IValue& value, std::string_view param_type)
+      override {
+    TORCH_CHECK(arg_idx_ < num_args_, "Too many args");
+    inputs_[arg_idx_++] = store_scalar_arg(value, param_type);
+  }
+
  private:
   std::vector<void*> arg_ptrs_;
   CUdeviceptr global_scratch_;

--- a/torch/nativert/executor/triton/TritonKernelManager.cpp
+++ b/torch/nativert/executor/triton/TritonKernelManager.cpp
@@ -2,7 +2,94 @@
 
 #include <c10/util/Exception.h>
 
+#include <limits>
+
 namespace torch::nativert {
+namespace {
+
+bool contains(std::string_view value, std::string_view needle) {
+  return value.find(needle) != std::string_view::npos;
+}
+
+bool isPointerParam(std::string_view param_type) {
+  return contains(param_type, "*") || contains(param_type, "pointer");
+}
+
+bool isBoolParam(std::string_view param_type) {
+  return param_type == "i1" || contains(param_type, "bool");
+}
+
+bool isInt32Param(std::string_view param_type) {
+  return param_type == "i32" || param_type == "u32" ||
+      contains(param_type, "int32") || contains(param_type, "uint32");
+}
+
+bool isFloat64Param(std::string_view param_type) {
+  return param_type == "fp64" || param_type == "f64" ||
+      contains(param_type, "float64") || contains(param_type, "double");
+}
+
+} // namespace
+
+void* KernelInputs::store_scalar_arg(
+    const c10::IValue& value,
+    std::string_view param_type) {
+  TORCH_CHECK(
+      !isPointerParam(param_type),
+      "Expected Tensor for Triton pointer parameter type ",
+      param_type,
+      " but got ",
+      value.tagKind());
+
+  if (value.isBool()) {
+    const bool scalar = value.toBool();
+    if (isInt32Param(param_type)) {
+      scalar_values_.emplace_back(static_cast<int32_t>(scalar));
+      return &std::get<int32_t>(scalar_values_.back());
+    }
+    scalar_values_.emplace_back(scalar);
+    return &std::get<bool>(scalar_values_.back());
+  }
+
+  if (value.isInt()) {
+    const auto scalar = value.toInt();
+    if (isBoolParam(param_type)) {
+      TORCH_CHECK(
+          scalar == 0 || scalar == 1,
+          "Cannot pass integer value ",
+          scalar,
+          " as Triton bool parameter");
+      scalar_values_.emplace_back(static_cast<bool>(scalar));
+      return &std::get<bool>(scalar_values_.back());
+    }
+    if (isInt32Param(param_type)) {
+      TORCH_CHECK(
+          scalar >= std::numeric_limits<int32_t>::min() &&
+              scalar <= std::numeric_limits<int32_t>::max(),
+          "Triton i32 parameter value out of range: ",
+          scalar);
+      scalar_values_.emplace_back(static_cast<int32_t>(scalar));
+      return &std::get<int32_t>(scalar_values_.back());
+    }
+    scalar_values_.emplace_back(static_cast<int64_t>(scalar));
+    return &std::get<int64_t>(scalar_values_.back());
+  }
+
+  if (value.isDouble()) {
+    const auto scalar = value.toDouble();
+    if (isFloat64Param(param_type)) {
+      scalar_values_.emplace_back(static_cast<double>(scalar));
+      return &std::get<double>(scalar_values_.back());
+    }
+    scalar_values_.emplace_back(static_cast<float>(scalar));
+    return &std::get<float>(scalar_values_.back());
+  }
+
+  TORCH_CHECK(
+      false,
+      "Unsupported Triton scalar parameter IValue kind: ",
+      value.tagKind());
+}
 
 void LaunchParams::parseCommonAttributes(const Node* node) {
   for (const auto& attr : node->attributes()) {

--- a/torch/nativert/executor/triton/TritonKernelManager.h
+++ b/torch/nativert/executor/triton/TritonKernelManager.h
@@ -1,12 +1,15 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
 #include <ATen/core/TensorBody.h>
+#include <ATen/core/ivalue.h>
 #include <c10/core/DeviceType.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Registry.h>
@@ -91,7 +94,9 @@ class KernelInputs {
   KernelInputs(size_t num_args, size_t num_attrs)
       : num_args_(num_args),
         inputs_(num_args + num_attrs),
-        num_attrs_(num_attrs) {}
+        num_attrs_(num_attrs) {
+    scalar_values_.reserve(num_args + num_attrs);
+  }
   virtual ~KernelInputs() = default;
 
   virtual void add_arg(void* arg) {
@@ -106,6 +111,12 @@ class KernelInputs {
     add_arg(tensor.data_ptr());
   }
 
+  virtual void add_scalar_arg(
+      const c10::IValue& value,
+      std::string_view param_type) {
+    add_arg(store_scalar_arg(value, param_type));
+  }
+
   virtual void add_attribute(void* attr) {
     TORCH_CHECK(attr_idx_ < num_attrs_, "Too many attributes");
     inputs_[num_args_ + attr_idx_++] = attr;
@@ -116,11 +127,16 @@ class KernelInputs {
   }
 
  protected:
+  void* store_scalar_arg(const c10::IValue& value, std::string_view param_type);
+
   size_t num_args_;
   size_t arg_idx_ = 0;
   std::vector<void*> inputs_;
 
  private:
+  using ScalarValue = std::variant<bool, int32_t, int64_t, float, double>;
+
+  std::vector<ScalarValue> scalar_values_;
   size_t num_attrs_;
   size_t attr_idx_ = 0;
 };

--- a/torch/nativert/kernels/TritonKernel.cpp
+++ b/torch/nativert/kernels/TritonKernel.cpp
@@ -2,6 +2,10 @@
 
 #include <c10/util/Exception.h>
 
+#include <algorithm>
+#include <limits>
+#include <optional>
+
 #include <torch/nativert/executor/DelegateExecutor.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -10,6 +14,127 @@
 #endif
 
 namespace torch::nativert {
+namespace {
+
+int checkedGridDim(const c10::IValue& value, size_t idx) {
+  TORCH_CHECK(
+      value.isInt(),
+      "Expected integer Triton grid dimension at index ",
+      idx,
+      " but got ",
+      value.tagKind());
+  const auto dim = value.toInt();
+  TORCH_CHECK(
+      dim >= std::numeric_limits<int>::min() &&
+          dim <= std::numeric_limits<int>::max(),
+      "Triton grid dimension at index ",
+      idx,
+      " is out of range: ",
+      dim);
+  return static_cast<int>(dim);
+}
+
+GridDims gridDimsFromIValue(const c10::IValue& value) {
+  TORCH_CHECK(
+      value.isList(),
+      "Expected Triton grid input to be List[int] but got ",
+      value.tagKind());
+
+  const auto list = value.toListRef();
+  TORCH_CHECK(
+      list.size() == 3,
+      "Expected Triton grid input to have 3 dimensions but got ",
+      list.size());
+
+  GridDims grid_dims;
+  size_t idx = 0;
+  for (const auto& elem : list) {
+    const auto dim = checkedGridDim(elem, idx);
+    if (idx == 0) {
+      grid_dims.x = dim;
+    } else if (idx == 1) {
+      grid_dims.y = dim;
+    } else {
+      grid_dims.z = dim;
+    }
+    ++idx;
+  }
+  return grid_dims;
+}
+
+bool isLaunchMetadataInput(std::string_view name) {
+  return name == "grid";
+}
+
+bool isKernelParamName(const KernelInputParams& params, std::string_view name) {
+  return std::find(
+             params.kernel_param_names.begin(),
+             params.kernel_param_names.end(),
+             name) != params.kernel_param_names.end();
+}
+
+std::optional<size_t> findInputIndex(
+    const std::vector<NamedArgument>& inputs,
+    std::string_view name) {
+  for (const auto i : c10::irange(inputs.size())) {
+    if (inputs[i].name == name) {
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+
+const Attribute* findAttribute(const Node* node, std::string_view name) {
+  for (const auto& attr : node->attributes()) {
+    if (attr.name == name) {
+      return &attr;
+    }
+  }
+  return nullptr;
+}
+
+void addKernelArg(
+    KernelInputs& inputs,
+    const c10::IValue& value,
+    std::string_view param_name,
+    std::string_view param_type,
+    size_t source_idx) {
+  if (value.isTensor()) {
+    inputs.add_tensor_arg(value.toTensor());
+  } else if (value.isInt() || value.isDouble() || value.isBool()) {
+    inputs.add_scalar_arg(value, param_type);
+  } else if (value.isNone()) {
+    inputs.add_arg(nullptr);
+  } else if (value.isList()) {
+    TORCH_CHECK(
+        false,
+        "Unsupported Triton kernel input at index ",
+        source_idx,
+        " (",
+        param_name,
+        ": ",
+        param_type,
+        "): ",
+        value.tagKind(),
+        "(size=",
+        value.toListRef().size(),
+        ")");
+  } else {
+    TORCH_CHECK(
+        false,
+        "Unsupported Triton kernel input at index ",
+        source_idx,
+        " (",
+        param_name,
+        ": ",
+        param_type,
+        ")",
+        ": ",
+        value.tagKind());
+  }
+}
+
+} // namespace
 
 // in this case, we want to use the symbol from torch_cpu.dll
 #ifndef NATIVERT_MSVC_TEST
@@ -118,31 +243,176 @@ TritonKernel::TritonKernel(
   TORCH_CHECK(
       loader_ != nullptr,
       "couldn't find triton kernel loader -- are you trying to run gpu kernels on a cpu build?");
-
-  // Create target-specific launch parameters
-  launch_params_ = loader_->createLaunchParams(node_);
 }
 
 TritonKernel::~TritonKernel() = default;
 
 void TritonKernel::computeInternal(ExecutionFrame& executionFrame) const {
-  const auto num_inputs = node_->inputs().size();
+  const auto& node_inputs = node_->inputs();
   const auto num_attrs = attr_ptrs_.size();
 
   auto* loader = const_cast<TritonKernelManager*>(loader_.get());
 
-  auto inputs =
-      loader->create_inputs(num_inputs, num_attrs, kernel_input_params_);
+  auto launch_params = loader->createLaunchParams(node_);
 
-  for (const auto i : c10::irange(num_inputs)) {
-    inputs->add_tensor_arg(input(i, executionFrame).toTensor());
+  const auto param_type = [this](size_t i) -> std::string_view {
+    return i < kernel_input_params_.kernel_param_types.size()
+        ? std::string_view(kernel_input_params_.kernel_param_types[i])
+        : std::string_view();
+  };
+  const auto param_name = [this](size_t i) -> std::string_view {
+    return i < kernel_input_params_.kernel_param_names.size()
+        ? std::string_view(kernel_input_params_.kernel_param_names[i])
+        : std::string_view();
+  };
+
+  const bool use_named_kernel_arg_packing =
+      !kernel_input_params_.kernel_param_names.empty() &&
+      std::any_of(
+          node_inputs.begin(), node_inputs.end(), [this](const auto& input) {
+            return !input.name.empty() &&
+                isKernelParamName(kernel_input_params_, input.name);
+          });
+
+  if (use_named_kernel_arg_packing) {
+    const auto num_kernel_args = kernel_input_params_.kernel_param_names.size();
+    auto inputs =
+        loader->create_inputs(num_kernel_args, 0, kernel_input_params_);
+    std::vector<std::optional<size_t>> kernel_arg_input_indices(
+        num_kernel_args);
+
+    for (const auto i : c10::irange(node_inputs.size())) {
+      const auto input_name = std::string_view(node_inputs[i].name);
+      if (isLaunchMetadataInput(input_name)) {
+        launch_params->grid_dims = gridDimsFromIValue(input(i, executionFrame));
+      } else {
+        TORCH_CHECK(
+            isKernelParamName(kernel_input_params_, input_name),
+            "Unsupported symbolic Triton launch input '",
+            input_name,
+            "' at index ",
+            i,
+            ": ",
+            input(i, executionFrame).tagKind());
+      }
+    }
+
+    for (const auto kernel_arg_idx : c10::irange(num_kernel_args)) {
+      const auto name = param_name(kernel_arg_idx);
+      if (const auto input_idx = findInputIndex(node_inputs, name)) {
+        addKernelArg(
+            *inputs,
+            input(*input_idx, executionFrame),
+            name,
+            param_type(kernel_arg_idx),
+            *input_idx);
+        kernel_arg_input_indices[kernel_arg_idx] = *input_idx;
+      } else if (const auto* attr = findAttribute(node_, name)) {
+        addKernelArg(
+            *inputs,
+            constantToIValue(attr->value),
+            name,
+            param_type(kernel_arg_idx),
+            kernel_arg_idx);
+      } else {
+        TORCH_CHECK(
+            false,
+            "Missing serialized Triton kernel parameter '",
+            name,
+            "' at index ",
+            kernel_arg_idx);
+      }
+    }
+
+    loader->launch(*launch_params, inputs->as_void());
+
+    const auto outputTensor = [&](int64_t output_idx) -> at::Tensor {
+      TORCH_CHECK(
+          output_idx >= 0 && static_cast<size_t>(output_idx) < num_kernel_args,
+          "Triton output index out of range: ",
+          output_idx);
+      const auto output_pos = static_cast<size_t>(output_idx);
+      const auto input_idx = kernel_arg_input_indices[output_pos];
+      TORCH_CHECK(
+          input_idx.has_value(),
+          "Triton output parameter '",
+          param_name(output_pos),
+          "' is not a runtime tensor input");
+      return input(*input_idx, executionFrame).toTensor();
+    };
+
+    auto& out = output(0, executionFrame);
+    if (out.isNone()) {
+      auto list = c10::List<at::Tensor>();
+      for (const auto& i : output_indices_) {
+        list.emplace_back(outputTensor(i));
+      }
+      out = c10::IValue(std::move(list));
+      return;
+    }
+
+    auto out_t = out.toTensorList();
+    for (const auto i : c10::irange(output_indices_.size())) {
+      out_t[i] = outputTensor(output_indices_[i]);
+    }
+    return;
+  }
+
+  size_t num_runtime_kernel_args = 0;
+  for (const auto& node_input : node_inputs) {
+    if (node_input.name.empty()) {
+      ++num_runtime_kernel_args;
+    }
+  }
+
+  if (!kernel_input_params_.kernel_param_names.empty()) {
+    TORCH_CHECK(
+        num_runtime_kernel_args + num_attrs ==
+            kernel_input_params_.kernel_param_names.size(),
+        "Triton kernel parameter count mismatch: got ",
+        num_runtime_kernel_args,
+        " runtime args and ",
+        num_attrs,
+        " constant attrs, but kernel metadata has ",
+        kernel_input_params_.kernel_param_names.size(),
+        " parameters");
+  }
+
+  auto inputs = loader->create_inputs(
+      num_runtime_kernel_args, num_attrs, kernel_input_params_);
+
+  size_t kernel_arg_idx = 0;
+  for (const auto i : c10::irange(node_inputs.size())) {
+    const auto input_name = std::string_view(node_inputs[i].name);
+    const auto& value = input(i, executionFrame);
+    if (isLaunchMetadataInput(input_name)) {
+      launch_params->grid_dims = gridDimsFromIValue(value);
+      continue;
+    }
+
+    TORCH_CHECK(
+        input_name.empty(),
+        "Unsupported symbolic Triton launch input '",
+        input_name,
+        "' at index ",
+        i,
+        ": ",
+        value.tagKind());
+
+    addKernelArg(
+        *inputs,
+        value,
+        param_name(kernel_arg_idx),
+        param_type(kernel_arg_idx),
+        i);
+    ++kernel_arg_idx;
   }
 
   for (const auto i : c10::irange(num_attrs)) {
     inputs->add_attribute(attr_ptrs_[i]);
   }
 
-  loader->launch(*launch_params_, inputs->as_void());
+  loader->launch(*launch_params, inputs->as_void());
 
   auto& out = output(0, executionFrame);
   if (out.isNone()) {

--- a/torch/nativert/kernels/TritonKernel.h
+++ b/torch/nativert/kernels/TritonKernel.h
@@ -27,7 +27,6 @@ class TritonKernel : public OpKernel {
   // Storage for float attributes that were serialized as doubles
   std::vector<float> float_attrs_;
   std::vector<int64_t> output_indices_;
-  std::unique_ptr<LaunchParams> launch_params_;
   KernelInputParams kernel_input_params_;
 };
 


### PR DESCRIPTION
Summary:
Minjang: The initial Sigmoid Interpreter had a limitation on the triton (CPU) argument packing. It needed some strict ordering and type restrictions. This diff finally tries to address this limitation.

---


NativeRT needed to preserve and consume Triton HOP kernel argument metadata instead of assuming graph input order is identical to the compiled kernel ABI.


Minimal shape of the failing Triton HOP pattern:
```python
triton.jit
def add_kernel(x, n_elements, y, out, BLOCK_SIZE: tl.constexpr):
    offs = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
    mask = offs < n_elements
    tl.store(out + offs, tl.load(x + offs, mask=mask) + tl.load(y + offs, mask=mask), mask=mask)

n_elements = out.numel()
grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
wrap_triton(add_kernel)[grid](x, n_elements, y, out, BLOCK_SIZE=16)
```

Without this fix, both `test_triton_hop_cpu_dynamic_scalar_arg` and `test_triton_hop_cuda_dynamic_scalar_arg` fail in NativeRT with:
- `RuntimeError: Expected Tensor but got Int` from `TritonKernel::computeInternal`, or
- `Unsupported Triton kernel input at index 14 (N: i32): GenericList(size=3)` when launch grid metadata was packed as an ABI input.

This diff supports more robust arguments handling:
- Kernels with mixed tensor inputs, dynamic scalar arguments, and dynamic launch metadata could fail in NativeRT because runtime graph input order is not the Triton compiled kernel ABI.
- Export serialization now keeps Triton kernel parameter names on positional runtime arguments while preserving Python roundtrip behavior during deserialization.
- NativeRT now packs Triton ABI arguments by `kernel_param_names`, resolves named parameters from runtime inputs or node attributes, excludes launch metadata from the ABI, and builds launch params per call.
- Triton kernel managers now store scalar arguments with type-aware casting from compiled Triton parameter types, and the change is mirrored in both fbcode and xplat NativeRT/serde copies.
- Added Sigmoid regression coverage for the tensor/int/tensor/tensor Triton HOP argument ordering with dynamic grid sizing on both CPU and CUDA.

Reviewed By: shawnxu26

Differential Revision: D103357030


