### PR TITLE
[buck][apple] Replace is_production_build/is_profile_build with build_mode_select in caffe2 buckbuild (#182103)

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -11,7 +11,7 @@ load("//tools/build_defs:fbsource_utils.bzl", "is_arvr_mode")
 load("//tools/build_defs:glob_defs.bzl", "subdir_glob")
 load("//tools/build_defs:platform_defs.bzl", "IOS", "MACOSX")
 load("//tools/build_defs:type_defs.bzl", "is_list", "is_string")
-load("//tools/build_defs/apple:build_mode_defs.bzl", is_production_build_ios = "is_production_build", is_profile_build_ios = "is_profile_build")
+load("//tools/build_defs/apple:build_mode_defs.bzl", "build_mode_select")
 load(
     ":build_variables.bzl",
     "aten_cpu_source_list",
@@ -71,13 +71,17 @@ def read_bool(section, field, default, required = True):
         fail("`{}:{}`: no value set".format(section, field))
 
 def _select_if_build_mode_dev(dev_value, default = []):
-    if is_production_build_ios() or is_profile_build_ios():
-        return default
-
-    return select({
+    dev_select = select({
         "DEFAULT": default,
         "ovr_config//build_mode:optimization[dev]": dev_value,
     })
+    return build_mode_select(
+        local = dev_select,
+        development = dev_select,
+        production = default,
+        profile = default,
+        release = dev_select,
+    )
 
 
 def _get_enable_lightweight_dispatch():
@@ -98,14 +102,17 @@ def strip_error_messages_select(value, default = []):
     strip_error = read_bool("pt", "strip_error_messages", default = None, required = False)
 
     if strip_error == None:
-
-        if is_production_build_ios() or is_profile_build_ios():
-            return value
-
-        return select({
+        opt_select = select({
             "DEFAULT": default,
             "ovr_config//build_mode:optimization[opt]": value,
         })
+        return build_mode_select(
+            local = opt_select,
+            development = opt_select,
+            production = value,
+            profile = value,
+            release = opt_select,
+        )
 
     if strip_error:
         return value


### PR DESCRIPTION
Summary:

Replace the load-time `is_production_build_ios()` and `is_profile_build_ios()` boolean checks with `build_mode_select()` in two functions:

- `_select_if_build_mode_dev()`: Previously short-circuited to `default` for production/profile builds. Now uses `build_mode_select` to return `default` for production/profile and a nested `select()` on the optimization constraint for local/development/release.

- `strip_error_messages_select()`: Previously short-circuited to `value` (strip) for production/profile builds. Now uses `build_mode_select` to return `value` for production/profile and a nested `select()` on the optimization constraint for local/development/release.

Both changes move from load-time evaluation to build-time `select()` resolution.

Test Plan: CI, issues would surface as parse time TD errors

Reviewed By: rmaz

Differential Revision: D103302074


