### PR TITLE
[dynamo] Add pytest 9 RaisesExc/RaisesGroup to is_forbidden_context_manager

### DIFF
--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -135,11 +135,27 @@ def is_standard_delattr(val: object) -> bool:
 def is_forbidden_context_manager(ctx: object) -> bool:
     f_ctxs: list[Any] = []
 
+    # pytest >= 8.4 moved RaisesContext into _pytest.raises and renamed it to RaisesExc,
+    # also adding RaisesGroup for ExceptionGroup matching. Keep both old and new names
+    # in independent try blocks so that one missing symbol doesn't drop the others.
+    try:
+        from _pytest.raises import RaisesExc, RaisesGroup  # type: ignore[attr-defined]
+
+        f_ctxs.append(RaisesExc)
+        f_ctxs.append(RaisesGroup)
+    except ImportError:
+        pass
+
     try:
         from _pytest.python_api import RaisesContext  # type: ignore[attr-defined]
-        from _pytest.recwarn import WarningsChecker  # type: ignore[attr-defined]
 
         f_ctxs.append(RaisesContext)
+    except ImportError:
+        pass
+
+    try:
+        from _pytest.recwarn import WarningsChecker  # type: ignore[attr-defined]
+
         f_ctxs.append(WarningsChecker)
     except ImportError:
         pass


### PR DESCRIPTION
pytest 8.4 moved `_pytest.python_api.RaisesContext` to `_pytest.raises.RaisesExc` and added `RaisesGroup`. The denylist's single try-block silently dropped both `RaisesContext` and `WarningsChecker` the moment one import failed, so after the pytest 7.3.2 -> 9.0.3 bump (#180271) Dynamo started inline-tracing `with pytest.raises(...):` blocks. That made the whole class of torch_np dynamo_wrapped tests fail: any fake-tensor `RuntimeError` inside the asserted-on numpy call escaped as `TorchRuntimeError`, bypassing the context manager's `__exit__`.

Add the new pytest 9 names to the denylist, split the imports so a missing symbol no longer hides the others, and document why this denylist is load-bearing.

### Public docs reference

The new classes were introduced in pytest 8.4.0 and are documented:

- [pytest changelog, 8.4.0 (2025-06-02), #11538](https://docs.pytest.org/en/stable/changelog.html): _"Added `pytest.RaisesGroup` as an equivalent to `pytest.raises()` for expecting `ExceptionGroup`. Also adds `pytest.RaisesExc` which is now the logic behind `pytest.raises()` and used as parameter to `pytest.RaisesGroup`."_
- [API reference: `pytest.RaisesExc`](https://docs.pytest.org/en/stable/reference/reference.html#pytest.RaisesExc) — _"Added in version 8.4. This is the class constructed when calling `pytest.raises()`."_
- [API reference: `pytest.RaisesGroup`](https://docs.pytest.org/en/stable/reference/reference.html#pytest.RaisesGroup) — _"Added in version 8.4. Contextmanager for checking for an expected `ExceptionGroup`."_

`RaisesContext` was a private internal class (`_pytest.python_api.RaisesContext`) and is not mentioned in the public changelog — pytest 8.4 just relocated/renamed the implementation to `_pytest.raises.RaisesExc` as part of the same redesign that exposed public `pytest.RaisesExc` / `pytest.RaisesGroup`. That's why the breakage was silent: PyTorch was reaching into the private `_pytest.*` namespace, where there's no deprecation path.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98