### PR TITLE
[MPS] Replace MPSGraph LayerNorm backward with native Metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LayerNorm.metal
+++ b/aten/src/ATen/native/mps/kernels/LayerNorm.metal
@@ -1,5 +1,5 @@
 #include <c10/metal/common.h>
-#include <metal_simdgroup>
+#include <c10/metal/reduction_utils.h>
 #include <metal_stdlib>
 using namespace metal;
 using c10::metal::simdgroup_size;
@@ -18,11 +18,10 @@ kernel void layer_norm_single_row(
     device T* bias [[buffer(9)]],
     uint tg_id [[threadgroup_position_in_grid]],
     uint tid [[thread_position_in_threadgroup]],
-    uint simd_lane_id [[thread_index_in_simdgroup]],
-    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+    uint tptg [[threads_per_threadgroup]]) {
   constexpr int N_READS = 4;
 
-  // each threadgroup handles one full “row” of length axis_size
+  // each threadgroup handles one full "row" of length axis_size
   uint row_offset = tg_id * axis_size;
   device T* x = input + row_offset + tid * N_READS;
   device T* out = output + row_offset + tid * N_READS;
@@ -52,44 +51,16 @@ kernel void layer_norm_single_row(
     }
   }
 
-  // threadgroup‐wide reduction
-  threadgroup float local_sums[simdgroup_size];
-  threadgroup float local_sums_sq[simdgroup_size];
-  threadgroup float tg_mean[1];
-  threadgroup float tg_inv_std[1];
-
-  if (simdgroup_id == 0) {
-    local_sums[simd_lane_id] = 0.0f;
-    local_sums_sq[simd_lane_id] = 0.0f;
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  // each simdgroup writes its partial
-  float group_partial_sum = simd_sum(partial_sum);
-  float group_partial_sum_sq = simd_sum(partial_sum_sq);
-  if (simd_lane_id == 0) {
-    local_sums[simdgroup_id] = group_partial_sum;
-    local_sums_sq[simdgroup_id] = group_partial_sum_sq;
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  // warp 0 reduces those 32 values
-  if (simdgroup_id == 0) {
-    float sum = simd_sum(local_sums[simd_lane_id]);
-    float sum_sq = simd_sum(local_sums_sq[simd_lane_id]);
-    if (simd_lane_id == 0) {
-      float mean = sum / float(axis_size);
-      float var = sum_sq / float(axis_size) - mean * mean;
-      var = var < 1e-6 ? 0.0f : var; // for rsqrt precision
-      float inv_std = metal::precise::rsqrt(var + epsilon);
-      tg_mean[0] = mean;
-      tg_inv_std[0] = inv_std;
-    }
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  float mean = tg_mean[0];
-  float inv_std = tg_inv_std[0];
+  // threadgroup-wide reduction
+  threadgroup float shared_sum[simdgroup_size];
+  threadgroup float shared_sum_sq[simdgroup_size];
+  float sum = c10::metal::threadgroup_sum(shared_sum, partial_sum, tid, tptg);
+  float sum_sq =
+      c10::metal::threadgroup_sum(shared_sum_sq, partial_sum_sq, tid, tptg);
+  float mean = sum / float(axis_size);
+  float var = sum_sq / float(axis_size) - mean * mean;
+  var = var < 1e-6 ? 0.0f : var;
+  float inv_std = metal::precise::rsqrt(var + epsilon);
 
   // normalize and optional scale & shift
   if (base_lane + N_READS <= axis_size) {
@@ -120,7 +91,7 @@ kernel void layer_norm_single_row(
     }
   }
 
-  if (tid == 0 && simd_lane_id == 0) {
+  if (tid == 0) {
     meanOut[tg_id] = static_cast<T>(mean);
     rstdTensor[tg_id] = static_cast<T>(inv_std);
   }
@@ -140,9 +111,7 @@ kernel void layer_norm_looped(
     device T* bias [[buffer(9)]],
     uint tg_id [[threadgroup_position_in_grid]],
     uint tid [[thread_position_in_threadgroup]],
-    uint lsize [[threads_per_threadgroup]],
-    uint simd_lane_id [[thread_index_in_simdgroup]],
-    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+    uint lsize [[threads_per_threadgroup]]) {
   constexpr int N_READS = 4;
 
   uint row_offset = tg_id * axis_size;
@@ -175,42 +144,16 @@ kernel void layer_norm_looped(
     }
   }
 
-  partial_sum = simd_sum(partial_sum);
-  partial_sum_sq = simd_sum(partial_sum_sq);
-
-  threadgroup float local_sums[simdgroup_size];
-  threadgroup float local_sums_sq[simdgroup_size];
-  threadgroup float tg_mean[1];
-  threadgroup float tg_inv_std[1];
-
-  if (simd_lane_id == 0) {
-    local_sums[simdgroup_id] = 0.0f;
-    local_sums_sq[simdgroup_id] = 0.0f;
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  if (simd_lane_id == 0) {
-    local_sums[simdgroup_id] = partial_sum;
-    local_sums_sq[simdgroup_id] = partial_sum_sq;
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  if (simdgroup_id == 0) {
-    float s = simd_sum(local_sums[simd_lane_id]);
-    float ss = simd_sum(local_sums_sq[simd_lane_id]);
-    if (simd_lane_id == 0) {
-      float mean = s / float(axis_size);
-      float var = ss / float(axis_size) - mean * mean;
-      var = var < 1e-6 ? 0.0f : var; // for rsqrt precision
-      float inv_std = metal::precise::rsqrt(var + epsilon);
-      tg_mean[0] = mean;
-      tg_inv_std[0] = inv_std;
-    }
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-
-  float mean = tg_mean[0];
-  float inv_std = tg_inv_std[0];
+  // threadgroup-wide reduction
+  threadgroup float shared_sum[simdgroup_size];
+  threadgroup float shared_sum_sq[simdgroup_size];
+  float sum = c10::metal::threadgroup_sum(shared_sum, partial_sum, tid, lsize);
+  float sum_sq =
+      c10::metal::threadgroup_sum(shared_sum_sq, partial_sum_sq, tid, lsize);
+  float mean = sum / float(axis_size);
+  float var = sum_sq / float(axis_size) - mean * mean;
+  var = var < 1e-6 ? 0.0f : var;
+  float inv_std = metal::precise::rsqrt(var + epsilon);
 
   // write back normalized + scale/shift if needed
   for (uint r = 0; r < axis_size; r += lsize * N_READS) {
@@ -242,7 +185,7 @@ kernel void layer_norm_looped(
     }
   }
 
-  if (tid == 0 && simd_lane_id == 0) {
+  if (tid == 0) {
     meanOut[tg_id] = T(mean);
     rstdTensor[tg_id] = T(inv_std);
   }
@@ -263,8 +206,7 @@ kernel void layer_norm_looped(
       device DTYPE* bias [[buffer(9)]],                                   \
       uint tg_id [[threadgroup_position_in_grid]],                        \
       uint tid [[thread_position_in_threadgroup]],                        \
-      uint simd_lane_id [[thread_index_in_simdgroup]],                    \
-      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+      uint tptg [[threads_per_threadgroup]]);
 
 #define instantiate_layer_norm_looped(DTYPE)                          \
   template [[host_name("layer_norm_looped_" #DTYPE)]] [[kernel]] void \
@@ -281,9 +223,7 @@ kernel void layer_norm_looped(
       device DTYPE* bias [[buffer(9)]],                               \
       uint tg_id [[threadgroup_position_in_grid]],                    \
       uint tid [[thread_position_in_threadgroup]],                    \
-      uint lsize [[threads_per_threadgroup]],                         \
-      uint simd_lane_id [[thread_index_in_simdgroup]],                \
-      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+      uint lsize [[threads_per_threadgroup]]);
 
 #define instantiate_layer_norm(DTYPE) \
   instantiate_layer_norm_single_row(DTYPE) instantiate_layer_norm_looped(DTYPE)
@@ -291,3 +231,408 @@ kernel void layer_norm_looped(
 instantiate_layer_norm(float);
 instantiate_layer_norm(half);
 instantiate_layer_norm(bfloat);
+// =============================================================
+//  Backward: grad_input (dx)
+//  Template parameter HAS_WEIGHT eliminates the runtime branch
+//  and the use_weight buffer binding.
+//  Two passes:
+//    1. reduce sb = sum_j(gamma_j*dy_j) and ss = sum_j(gamma_j*dy_j*xhat_j)
+//    2. dx_i = (rstd/N) * (N*gamma_i*dy_i - sb - xhat_i*ss)
+//  In the fast path (base + N_READS <= N) xi, dyi, wi are cached in
+//  registers to avoid a second round-trip to global memory.
+// =============================================================
+template <typename T, bool HAS_WEIGHT>
+kernel void layer_norm_bwd_dx_single_row(
+    device const T* dy [[buffer(0)]],
+    device const T* x [[buffer(1)]],
+    device const T* mean [[buffer(2)]],
+    device const T* rstd [[buffer(3)]],
+    device const T* weight [[buffer(4)]],
+    device T* dx [[buffer(5)]],
+    constant uint& N [[buffer(6)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]]) {
+  constexpr int N_READS = 4;
+
+  uint row_off = tg_id * N;
+  float mu = float(mean[tg_id]);
+  float rs = float(rstd[tg_id]);
+
+  float sb = 0.0f, ss = 0.0f;
+  uint base = tid * N_READS;
+  float dyi_r[N_READS], xi_r[N_READS], wi_r[N_READS];
+
+  if (base + N_READS <= N) {
+    for (int i = 0; i < N_READS; i++) {
+      uint idx = base + i;
+      dyi_r[i] = float(dy[row_off + idx]);
+      xi_r[i] = float(x[row_off + idx]);
+      wi_r[i] = HAS_WEIGHT ? float(weight[idx]) : 1.0f;
+      float xh = (xi_r[i] - mu) * rs;
+      float wdy = wi_r[i] * dyi_r[i];
+      sb += wdy;
+      ss += wdy * xh;
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      uint idx = base + i;
+      if (idx < N) {
+        dyi_r[i] = float(dy[row_off + idx]);
+        xi_r[i] = float(x[row_off + idx]);
+        wi_r[i] = HAS_WEIGHT ? float(weight[idx]) : 1.0f;
+        float xh = (xi_r[i] - mu) * rs;
+        float wdy = wi_r[i] * dyi_r[i];
+        sb += wdy;
+        ss += wdy * xh;
+      } else {
+        dyi_r[i] = xi_r[i] = wi_r[i] = 0.0f;
+      }
+    }
+  }
+
+  threadgroup float shared_sb[simdgroup_size];
+  threadgroup float shared_ss[simdgroup_size];
+  sb = c10::metal::threadgroup_sum(shared_sb, sb, tid, tptg);
+  ss = c10::metal::threadgroup_sum(shared_ss, ss, tid, tptg);
+
+  float c = rs / float(N);
+  float fN = float(N);
+  if (base + N_READS <= N) {
+    for (int i = 0; i < N_READS; i++) {
+      uint idx = base + i;
+      float xh = (xi_r[i] - mu) * rs;
+      dx[row_off + idx] = T(c * (fN * wi_r[i] * dyi_r[i] - sb - xh * ss));
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      uint idx = base + i;
+      if (idx < N) {
+        float xh = (xi_r[i] - mu) * rs;
+        dx[row_off + idx] = T(c * (fN * wi_r[i] * dyi_r[i] - sb - xh * ss));
+      }
+    }
+  }
+}
+
+template <typename T, bool HAS_WEIGHT>
+kernel void layer_norm_bwd_dx_looped(
+    device const T* dy [[buffer(0)]],
+    device const T* x [[buffer(1)]],
+    device const T* mean [[buffer(2)]],
+    device const T* rstd [[buffer(3)]],
+    device const T* weight [[buffer(4)]],
+    device T* dx [[buffer(5)]],
+    constant uint& N [[buffer(6)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  constexpr int N_READS = 4;
+  constexpr int MAX_CACHED = 8;
+
+  uint row_off = tg_id * N;
+  float mu = float(mean[tg_id]);
+  float rs = float(rstd[tg_id]);
+
+  // Compute elements this thread will process
+  uint elems_per_thread =
+      ((N + lsize * N_READS - 1) / (lsize * N_READS)) * N_READS;
+  bool use_cache = (elems_per_thread <= MAX_CACHED);
+
+  float cached_wdy[MAX_CACHED];
+  float cached_xhat[MAX_CACHED];
+
+  float sb = 0.0f, ss = 0.0f;
+  uint ci = 0;
+  for (uint r = 0; r < N; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= N) {
+      for (int i = 0; i < N_READS; i++) {
+        uint idx = base + i;
+        float dyi = float(dy[row_off + idx]);
+        float xi = float(x[row_off + idx]);
+        float wi = HAS_WEIGHT ? float(weight[idx]) : 1.0f;
+        float xh = (xi - mu) * rs;
+        float wdy = wi * dyi;
+        if (use_cache) {
+          cached_wdy[ci] = wdy;
+          cached_xhat[ci] = xh;
+          ci++;
+        }
+        sb += wdy;
+        ss += wdy * xh;
+      }
+    } else {
+      for (int i = 0; i < N_READS; i++) {
+        uint idx = base + i;
+        if (idx < N) {
+          float dyi = float(dy[row_off + idx]);
+          float xi = float(x[row_off + idx]);
+          float wi = HAS_WEIGHT ? float(weight[idx]) : 1.0f;
+          float xh = (xi - mu) * rs;
+          float wdy = wi * dyi;
+          if (use_cache) {
+            cached_wdy[ci] = wdy;
+            cached_xhat[ci] = xh;
+            ci++;
+          }
+          sb += wdy;
+          ss += wdy * xh;
+        }
+      }
+    }
+  }
+  uint total_cached = ci;
+
+  threadgroup float shared_sb[simdgroup_size];
+  threadgroup float shared_ss[simdgroup_size];
+  sb = c10::metal::threadgroup_sum(shared_sb, sb, tid, lsize);
+  ss = c10::metal::threadgroup_sum(shared_ss, ss, tid, lsize);
+
+  // Pass 2: compute dx
+  float c = rs / float(N);
+  float fN = float(N);
+  if (use_cache) {
+    // Fast path: read from cached wdy/xhat (no global re-read)
+    ci = 0;
+    for (uint r = 0; r < N; r += lsize * N_READS) {
+      uint base = r + tid * N_READS;
+      if (base + N_READS <= N) {
+        for (int i = 0; i < N_READS; i++) {
+          dx[row_off + base + i] =
+              T(c * (fN * cached_wdy[ci] - sb - cached_xhat[ci] * ss));
+          ci++;
+        }
+      } else {
+        for (int i = 0; i < N_READS; i++) {
+          if (base + i < N) {
+            dx[row_off + base + i] =
+                T(c * (fN * cached_wdy[ci] - sb - cached_xhat[ci] * ss));
+            ci++;
+          }
+        }
+      }
+    }
+  } else {
+    // Fallback for very large N: re-read from global memory
+    for (uint r = 0; r < N; r += lsize * N_READS) {
+      uint base = r + tid * N_READS;
+      if (base + N_READS <= N) {
+        for (int i = 0; i < N_READS; i++) {
+          uint idx = base + i;
+          float dyi = float(dy[row_off + idx]);
+          float xi = float(x[row_off + idx]);
+          float wi = HAS_WEIGHT ? float(weight[idx]) : 1.0f;
+          float xh = (xi - mu) * rs;
+          dx[row_off + idx] = T(c * (fN * wi * dyi - sb - xh * ss));
+        }
+      } else {
+        for (int i = 0; i < N_READS; i++) {
+          uint idx = base + i;
+          if (idx < N) {
+            float dyi = float(dy[row_off + idx]);
+            float xi = float(x[row_off + idx]);
+            float wi = HAS_WEIGHT ? float(weight[idx]) : 1.0f;
+            float xh = (xi - mu) * rs;
+            dx[row_off + idx] = T(c * (fN * wi * dyi - sb - xh * ss));
+          }
+        }
+      }
+    }
+  }
+}
+
+#define instantiate_layer_norm_bwd_dx_single_row(DTYPE, HW, SFXW) \
+  template [[host_name("layer_norm_bwd_dx_single_row_" #DTYPE     \
+                       "_" #SFXW)]] [[kernel]] void               \
+  layer_norm_bwd_dx_single_row<DTYPE, HW>(                        \
+      device const DTYPE* dy [[buffer(0)]],                       \
+      device const DTYPE* x [[buffer(1)]],                        \
+      device const DTYPE* mean [[buffer(2)]],                     \
+      device const DTYPE* rstd [[buffer(3)]],                     \
+      device const DTYPE* weight [[buffer(4)]],                   \
+      device DTYPE* dx [[buffer(5)]],                             \
+      constant uint& N [[buffer(6)]],                             \
+      uint tg_id [[threadgroup_position_in_grid]],                \
+      uint tid [[thread_position_in_threadgroup]],                \
+      uint tptg [[threads_per_threadgroup]]);
+
+#define instantiate_layer_norm_bwd_dx_looped(DTYPE, HW, SFXW) \
+  template [[host_name("layer_norm_bwd_dx_looped_" #DTYPE     \
+                       "_" #SFXW)]] [[kernel]] void           \
+  layer_norm_bwd_dx_looped<DTYPE, HW>(                        \
+      device const DTYPE* dy [[buffer(0)]],                   \
+      device const DTYPE* x [[buffer(1)]],                    \
+      device const DTYPE* mean [[buffer(2)]],                 \
+      device const DTYPE* rstd [[buffer(3)]],                 \
+      device const DTYPE* weight [[buffer(4)]],               \
+      device DTYPE* dx [[buffer(5)]],                         \
+      constant uint& N [[buffer(6)]],                         \
+      uint tg_id [[threadgroup_position_in_grid]],            \
+      uint tid [[thread_position_in_threadgroup]],            \
+      uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_layer_norm_bwd(DTYPE)                        \
+  instantiate_layer_norm_bwd_dx_single_row(DTYPE, true, w)       \
+      instantiate_layer_norm_bwd_dx_single_row(DTYPE, false, nw) \
+          instantiate_layer_norm_bwd_dx_looped(DTYPE, true, w)   \
+              instantiate_layer_norm_bwd_dx_looped(DTYPE, false, nw)
+
+instantiate_layer_norm_bwd(float);
+instantiate_layer_norm_bwd(half);
+instantiate_layer_norm_bwd(bfloat);
+
+// =============================================================
+//  M=1 specialization: dgamma[j] = dy[j] * xhat[j], dbeta[j] = dy[j]
+//  No reduction needed — one row, one element per column.
+// =============================================================
+template <typename T>
+kernel void layer_norm_bwd_dw_db_m1(
+    device const T* dy [[buffer(0)]],
+    device const T* x [[buffer(1)]],
+    device const T* mean [[buffer(2)]],
+    device const T* rstd [[buffer(3)]],
+    device T* dgamma [[buffer(4)]],
+    device T* dbeta [[buffer(5)]],
+    constant uint& N [[buffer(6)]],
+    uint gid [[thread_position_in_grid]]) {
+  if (gid >= N)
+    return;
+  float mu = float(mean[0]);
+  float rs = float(rstd[0]);
+  float dyi = float(dy[gid]);
+  float xi = float(x[gid]);
+  float xh = (xi - mu) * rs;
+  dgamma[gid] = T(dyi * xh);
+  dbeta[gid] = T(dyi);
+}
+
+#define instantiate_layer_norm_bwd_dw_db_m1(DTYPE)                          \
+  template [[host_name("layer_norm_bwd_dw_db_m1_" #DTYPE)]] [[kernel]] void \
+  layer_norm_bwd_dw_db_m1<DTYPE>(                                           \
+      device const DTYPE* dy [[buffer(0)]],                                 \
+      device const DTYPE* x [[buffer(1)]],                                  \
+      device const DTYPE* mean [[buffer(2)]],                               \
+      device const DTYPE* rstd [[buffer(3)]],                               \
+      device DTYPE* dgamma [[buffer(4)]],                                   \
+      device DTYPE* dbeta [[buffer(5)]],                                    \
+      constant uint& N [[buffer(6)]],                                       \
+      uint gid [[thread_position_in_grid]]);
+
+instantiate_layer_norm_bwd_dw_db_m1(float);
+instantiate_layer_norm_bwd_dw_db_m1(half);
+instantiate_layer_norm_bwd_dw_db_m1(bfloat);
+
+// =============================================================
+//  Tiled dw_db: two-phase column reduction
+//  Phase 1 (layer_norm_bwd_dw_db_tiled): each threadgroup handles
+//    a TILE_M × TILE_N block. Threads cooperatively reduce TILE_M
+//    rows for TILE_N columns, writing partial sums to a temp buffer
+//    of shape [num_row_blocks, N].
+//  Phase 2 (layer_norm_bwd_dw_db_reduce): each thread sums one
+//    column across num_row_blocks partials.
+// =============================================================
+
+constant constexpr uint TILE_M = 64;
+constant constexpr uint TILE_N = 32;
+
+template <typename T>
+kernel void layer_norm_bwd_dw_db_tiled(
+    device const T* dy [[buffer(0)]],
+    device const T* x [[buffer(1)]],
+    device const T* mean [[buffer(2)]],
+    device const T* rstd [[buffer(3)]],
+    device float* partial_dgam [[buffer(4)]],
+    device float* partial_dbet [[buffer(5)]],
+    constant uint& N [[buffer(6)]],
+    constant uint& M [[buffer(7)]],
+    uint2 tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint2 tg_dim [[threadgroups_per_grid]]) {
+  // tg_id.x = row-block index, tg_id.y = col-block index
+  uint row_base = tg_id.x * TILE_M;
+  uint col_base = tg_id.y * TILE_N;
+  uint num_row_blocks = tg_dim.x;
+
+  // Thread layout: TILE_N threads (one per column in the tile)
+  uint col_local = tid; // 0..TILE_N-1
+  uint col = col_base + col_local;
+
+  if (col >= N)
+    return;
+
+  float dgam = 0.0f;
+  float dbet = 0.0f;
+
+  // Each thread iterates over TILE_M rows (or fewer at the boundary)
+  uint row_end = min(row_base + TILE_M, M);
+  for (uint m = row_base; m < row_end; m++) {
+    float mu = float(mean[m]);
+    float rs = float(rstd[m]);
+    float dyi = float(dy[m * N + col]);
+    float xi = float(x[m * N + col]);
+    float xh = (xi - mu) * rs;
+    dgam += dyi * xh;
+    dbet += dyi;
+  }
+
+  // Write partial to temp buffer: [row_block, col]
+  uint partial_idx = tg_id.x * N + col;
+  partial_dgam[partial_idx] = dgam;
+  partial_dbet[partial_idx] = dbet;
+}
+
+template <typename T>
+kernel void layer_norm_bwd_dw_db_reduce(
+    device const float* partial_dgam [[buffer(0)]],
+    device const float* partial_dbet [[buffer(1)]],
+    device T* dgamma [[buffer(2)]],
+    device T* dbeta [[buffer(3)]],
+    constant uint& N [[buffer(4)]],
+    constant uint& num_row_blocks [[buffer(5)]],
+    uint gid [[thread_position_in_grid]]) {
+  if (gid >= N)
+    return;
+  float dgam = 0.0f;
+  float dbet = 0.0f;
+  for (uint rb = 0; rb < num_row_blocks; rb++) {
+    dgam += partial_dgam[rb * N + gid];
+    dbet += partial_dbet[rb * N + gid];
+  }
+  dgamma[gid] = T(dgam);
+  dbeta[gid] = T(dbet);
+}
+
+#define instantiate_layer_norm_bwd_dw_db_tiled(DTYPE)                          \
+  template [[host_name("layer_norm_bwd_dw_db_tiled_" #DTYPE)]] [[kernel]] void \
+  layer_norm_bwd_dw_db_tiled<DTYPE>(                                           \
+      device const DTYPE* dy [[buffer(0)]],                                    \
+      device const DTYPE* x [[buffer(1)]],                                     \
+      device const DTYPE* mean [[buffer(2)]],                                  \
+      device const DTYPE* rstd [[buffer(3)]],                                  \
+      device float* partial_dgam [[buffer(4)]],                                \
+      device float* partial_dbet [[buffer(5)]],                                \
+      constant uint& N [[buffer(6)]],                                          \
+      constant uint& M [[buffer(7)]],                                          \
+      uint2 tg_id [[threadgroup_position_in_grid]],                            \
+      uint tid [[thread_index_in_threadgroup]],                                \
+      uint2 tg_dim [[threadgroups_per_grid]]);
+
+#define instantiate_layer_norm_bwd_dw_db_reduce(DTYPE)                     \
+  template                                                                 \
+      [[host_name("layer_norm_bwd_dw_db_reduce_" #DTYPE)]] [[kernel]] void \
+      layer_norm_bwd_dw_db_reduce<DTYPE>(                                  \
+          device const float* partial_dgam [[buffer(0)]],                  \
+          device const float* partial_dbet [[buffer(1)]],                  \
+          device DTYPE* dgamma [[buffer(2)]],                              \
+          device DTYPE* dbeta [[buffer(3)]],                               \
+          constant uint& N [[buffer(4)]],                                  \
+          constant uint& num_row_blocks [[buffer(5)]],                     \
+          uint gid [[thread_position_in_grid]]);
+
+instantiate_layer_norm_bwd_dw_db_tiled(float);
+instantiate_layer_norm_bwd_dw_db_tiled(half);
+instantiate_layer_norm_bwd_dw_db_tiled(bfloat);
+instantiate_layer_norm_bwd_dw_db_reduce(float);
+instantiate_layer_norm_bwd_dw_db_reduce(half);
+instantiate_layer_norm_bwd_dw_db_reduce(bfloat);

--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -972,7 +972,7 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_mps(const Tensor& input,
   @autoreleasepool {
     dispatch_sync_with_rethrow(stream->queue(), ^() {
       // which kernel variant to use based on the normalized axis N size
-      const int N_READS = 4;
+      constexpr int N_READS = 4;
       auto metalType = mps::scalarToMetalTypeString(input);
       id<MTLComputePipelineState> layerNormKernel = nil;
       if (axis_size <= 1024 * N_READS) {
@@ -1071,244 +1071,104 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_mps(const Tensor& grad_ou
   }
   if (M > 0) {
     using namespace at::native::mps;
-
-    // Derive from MPSCachedGraph
-    struct CachedGraph : public MPSCachedGraph {
-      CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-      MPSGraphTensor* gradOutputTensor_ = nil;
-      MPSGraphTensor* inputTensor_ = nil;
-      MPSGraphTensor* weightTensor_ = nil;
-      MPSGraphTensor* meanTensor_ = nil;
-      MPSGraphTensor* rstdTensor_ = nil;
-      MPSGraphTensor* gradInputTensor_ = nil;
-      MPSGraphTensor* gradWeightTensor_ = nil;
-      MPSGraphTensor* gradBiasTensor_ = nil;
-    };
-
-    auto stream = at::mps::getCurrentMPSStream();
-
+    constexpr int N_READS = 4;
+    // Kernels index rows as 32-bit tg_id * N; reject extents whose offsets
+    // would wrap (silently wrong gradients past 2^32 elements). Each extent is
+    // also bounded to int32 so the signed host-side casts and the kernels'
+    // uint tail arithmetic (base + N_READS, N + lsize * N_READS) cannot wrap.
+    constexpr int64_t kMaxI32 = std::numeric_limits<int32_t>::max();
+    TORCH_CHECK(M <= kMaxI32 && N <= kMaxI32 && M * N <= static_cast<int64_t>(UINT32_MAX),
+                "MPS layer_norm_backward does not support inputs with more than 2^32 elements");
+    const int iN = static_cast<int>(N);
+    const int iM = static_cast<int>(M);
     const bool has_weight = (weight_opt.has_value() && weight_opt->defined());
 
-    if (X->numel() == 0) {
+    // N == 0 (or nothing requested): all outputs are empty or zero-length,
+    // nothing to encode. Mirrors the pre-Metal graph implementation's guard.
+    if (X->numel() == 0 || (grad_input.numel() == 0 && !grad_input_mask[1] && !grad_input_mask[2])) {
       return std::make_tuple(grad_input, grad_weight, grad_bias);
     }
 
-    // const auto memory_format = input.suggest_memory_format();
+    // Flatten mean/rstd from stat_shape [...outer, 1,..1] to [M]
+    auto mean_flat = mean.contiguous().view({iM});
+    auto rstd_flat = rstd.contiguous().view({iM});
+
+    const auto metalType = mps::scalarToMetalTypeString(*X);
+    MPSStream* stream = getCurrentMPSStream();
+
+    // All temp/output buffers must be allocated BEFORE entering the stream
+    // queue: the allocator's failure fallback dispatch_syncs the same serial
+    // queue to release cached buffers, which deadlocks if we already hold it.
+    Tensor dw_buf, db_buf, partial_dgam, partial_dbet;
+    uint num_row_blocks = 0;
+    constexpr uint TILE_M = 64;
+    constexpr uint TILE_N = 32;
+    if (grad_input_mask[1] || grad_input_mask[2]) {
+      dw_buf = grad_input_mask[1] ? grad_weight : at::empty({(int64_t)N}, X->options().device(kMPS));
+      db_buf = grad_input_mask[2] ? grad_bias : at::empty({(int64_t)N}, X->options().device(kMPS));
+      if (iM != 1) {
+        num_row_blocks = (iM + TILE_M - 1) / TILE_M;
+        partial_dgam = at::empty({(int64_t)(num_row_blocks * iN)}, X->options().dtype(at::kFloat).device(kMPS));
+        partial_dbet = at::empty({(int64_t)(num_row_blocks * iN)}, X->options().dtype(at::kFloat).device(kMPS));
+      }
+    }
 
     @autoreleasepool {
-      MPSShape* input_shape = mps::getMPSShape(*X);
-      MPSShape* gamma_shape = mps::getMPSShape(normalized_shape);
+      dispatch_sync_with_rethrow(stream->queue(), ^() {
+        id<MTLComputeCommandEncoder> computeEncoder = stream->commandEncoder();
 
-      auto num_normalized_dims = [gamma_shape count];
-      auto num_channel_dims = [input_shape count] - num_normalized_dims;
-
-      NSMutableArray<NSNumber*>* gamma_axes = [NSMutableArray<NSNumber*> arrayWithCapacity:num_channel_dims];
-
-      for (const auto i : c10::irange(num_channel_dims))
-        gamma_axes[i] = [NSNumber numberWithInt:static_cast<int>(i)];
-
-      // Axes along which to reduce to get "batch norm" gradient
-      // This will be applied on shape [1, M, -1]
-      NSMutableArray<NSNumber*>* bn_axes = [NSMutableArray<NSNumber*> arrayWithCapacity:num_normalized_dims];
-      for (const auto i : c10::irange(num_normalized_dims))
-        bn_axes[i] = [NSNumber numberWithInt:static_cast<int>(1 + 1 + i)];
-
-      // Shape of input to do "batch norm" backward
-      // This is [1, M, -1]
-      NSMutableArray<NSNumber*>* bn_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:(num_normalized_dims + 2)];
-      bn_shape[0] = [NSNumber numberWithInt:1];
-      bn_shape[1] = [NSNumber numberWithInt:M];
-      for (const auto i : c10::irange(num_normalized_dims))
-        bn_shape[i + 2] = input_shape[i + num_channel_dims];
-
-      // Shape of mean to do "batch norm" backward
-      // This is [1, M, [1,1,1..1]]
-      NSMutableArray<NSNumber*>* bn_mean_shape =
-          [NSMutableArray<NSNumber*> arrayWithCapacity:(num_normalized_dims + 2)];
-      bn_mean_shape[0] = [NSNumber numberWithInt:1];
-      bn_mean_shape[1] = [NSNumber numberWithInt:M];
-      for (const auto i : c10::irange(num_normalized_dims))
-        bn_mean_shape[i + 2] = [NSNumber numberWithInt:1];
-
-      // Shape of gamma to multiply with "batch norm" backward
-      // This is [1, 1, -1]
-      NSMutableArray<NSNumber*>* bn_gamma_shape =
-          [NSMutableArray<NSNumber*> arrayWithCapacity:(num_normalized_dims + 2)];
-      bn_gamma_shape[0] = [NSNumber numberWithInt:1];
-      bn_gamma_shape[1] = [NSNumber numberWithInt:1];
-      for (const auto i : c10::irange(num_normalized_dims))
-        bn_gamma_shape[i + 2] = input_shape[i + num_channel_dims];
-
-      std::string key = fmt::format("layer_norm_backward_mps:{}:{}:{}:{}:{}",
-                                    has_weight,
-                                    getArrayRefString(normalized_shape),
-                                    getArrayRefString((*X).sizes()),
-                                    c10::Join(",", grad_input_mask),
-                                    getMPSTypeString(*X));
-      auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-        MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, *X);
-        MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, *dOut);
-        MPSGraphTensor* weightTensor = nil;
-        if (has_weight)
-          weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, *gamma);
-
-        // Mean and inv std tensors to be saved and returned
-        MPSGraphTensor* meanTensor = mpsGraphRankedPlaceHolder(mpsGraph, mean);
-        MPSGraphTensor* rstdTensor = mpsGraphRankedPlaceHolder(mpsGraph, rstd);
-
-        MPSGraphTensor* gradInputTensor = nil;
-        MPSGraphTensor* gradWeightTensor = nil;
-        MPSGraphTensor* gradBiasTensor = nil;
-
-        if (grad_input_mask[1]) {
-          MPSGraphTensor* xMinusMean = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                              secondaryTensor:meanTensor
-                                                                         name:nil];
-          MPSGraphTensor* bnForwardTensor = [mpsGraph multiplicationWithPrimaryTensor:xMinusMean
-                                                                      secondaryTensor:rstdTensor
-                                                                                 name:nil];
-          MPSGraphTensor* gradBnMulTensor = [mpsGraph multiplicationWithPrimaryTensor:bnForwardTensor
-                                                                      secondaryTensor:gradOutputTensor
-                                                                                 name:nil];
-          gradWeightTensor = [mpsGraph reductionSumWithTensor:gradBnMulTensor axes:gamma_axes name:nil];
-        }
-        if (grad_input_mask[2]) {
-          gradBiasTensor = [mpsGraph reductionSumWithTensor:gradOutputTensor axes:gamma_axes name:nil];
-        }
-        if (grad_input_mask[0]) {
-          // Reshape input to [1, M, -1]
-          // Reshape mean and rstd to [1, M, -1]
-          // Reshape gamma to [1, 1, -1] (-1 has N dims)
-
-          MPSGraphTensor* bnInputTensor = [mpsGraph reshapeTensor:inputTensor withShape:bn_shape name:nil];
-          MPSGraphTensor* bnGradOutputTensor = [mpsGraph reshapeTensor:gradOutputTensor withShape:bn_shape name:nil];
-          // Do this at the end
-          if (has_weight) {
-            MPSGraphTensor* bnGammaTensor = [mpsGraph reshapeTensor:weightTensor withShape:bn_gamma_shape name:nil];
-            bnGradOutputTensor = [mpsGraph multiplicationWithPrimaryTensor:bnGradOutputTensor
-                                                           secondaryTensor:bnGammaTensor
-                                                                      name:nil];
+        // --- dx kernel ---
+        if (grad_input_mask[0] && grad_input.numel() > 0) {
+          id<MTLComputePipelineState> dxKernel;
+          std::string wsfx = has_weight ? "_w" : "_nw";
+          if (iN <= 1024 * N_READS) {
+            dxKernel = mps::lib.getPipelineStateForFunc("layer_norm_bwd_dx_single_row_" + metalType + wsfx);
+          } else {
+            dxKernel = mps::lib.getPipelineStateForFunc("layer_norm_bwd_dx_looped_" + metalType + wsfx);
           }
-          MPSGraphTensor* bnMeanTensor = [mpsGraph reshapeTensor:meanTensor withShape:bn_mean_shape name:nil];
-          MPSGraphTensor* bnRstdTensor = [mpsGraph reshapeTensor:rstdTensor withShape:bn_mean_shape name:nil];
-
-          MPSGraphTensor* mulTensor = [mpsGraph constantWithScalar:N shape:@[ @1 ] dataType:MPSDataTypeInt32];
-
-          MPSGraphTensor* numberToReduceTensor = mulTensor;
-
-          MPSGraphTensor* cast2Tensor = [mpsGraph castTensor:numberToReduceTensor
-                                                      toType:bnInputTensor.dataType
-                                                        name:@"cast2Tensor"];
-
-          MPSGraphTensor* sizeReciprocalTensor = [mpsGraph reciprocalWithTensor:cast2Tensor name:nil];
-
-          // TODO: Reduce redundant computation
-          MPSGraphTensor* xMinusMean = [mpsGraph subtractionWithPrimaryTensor:bnInputTensor
-                                                              secondaryTensor:bnMeanTensor
-                                                                         name:nil];
-
-          MPSGraphTensor* normalizedTensor = [mpsGraph multiplicationWithPrimaryTensor:xMinusMean
-                                                                       secondaryTensor:bnRstdTensor
-                                                                                  name:nil];
-
-          MPSGraphTensor* bnGradMulTensor = [mpsGraph multiplicationWithPrimaryTensor:bnGradOutputTensor
-                                                                      secondaryTensor:normalizedTensor
-                                                                                 name:nil];
-
-          MPSGraphTensor* gammaGradient = [mpsGraph reductionSumWithTensor:bnGradMulTensor axes:bn_axes name:nil];
-
-          MPSGraphTensor* betaGradient = [mpsGraph reductionSumWithTensor:bnGradOutputTensor axes:bn_axes name:nil];
-
-          MPSGraphTensor* gradient1 = [mpsGraph multiplicationWithPrimaryTensor:bnGradOutputTensor
-                                                                secondaryTensor:bnRstdTensor
-                                                                           name:nil];
-
-          MPSGraphTensor* gradient2_1 = [mpsGraph multiplicationWithPrimaryTensor:sizeReciprocalTensor
-                                                                  secondaryTensor:xMinusMean
-                                                                             name:nil];
-
-          // reverseVariance is square of rstd
-          MPSGraphTensor* reverseVariance = [mpsGraph squareWithTensor:bnRstdTensor name:nil];
-          MPSGraphTensor* gradient2_2 = [mpsGraph multiplicationWithPrimaryTensor:gammaGradient
-                                                                  secondaryTensor:reverseVariance
-                                                                             name:nil];
-
-          MPSGraphTensor* gradient2 = [mpsGraph multiplicationWithPrimaryTensor:gradient2_1
-                                                                secondaryTensor:gradient2_2
-                                                                           name:nil];
-
-          MPSGraphTensor* gradient3_1 = [mpsGraph multiplicationWithPrimaryTensor:sizeReciprocalTensor
-                                                                  secondaryTensor:betaGradient
-                                                                             name:nil];
-
-          MPSGraphTensor* gradient3 = [mpsGraph multiplicationWithPrimaryTensor:gradient3_1
-                                                                secondaryTensor:bnRstdTensor
-                                                                           name:nil];
-
-          MPSGraphTensor* gradient4 = [mpsGraph subtractionWithPrimaryTensor:gradient1
-                                                             secondaryTensor:gradient2
-                                                                        name:nil];
-
-          MPSGraphTensor* gradient = [mpsGraph subtractionWithPrimaryTensor:gradient4
-                                                            secondaryTensor:gradient3
-                                                                       name:nil];
-
-          gradInputTensor = [mpsGraph reshapeTensor:gradient withShape:input_shape name:nil];
+          [computeEncoder setComputePipelineState:dxKernel];
+          mps::mtl_setArgs(computeEncoder, *dOut, *X, mean_flat, rstd_flat);
+          if (has_weight) {
+            mps::mtl_setArgs<4>(computeEncoder, *gamma);
+          }
+          mps::mtl_setArgs<5>(computeEncoder, grad_input, (uint)iN);
+          MTLSize numThreadsDx = MTLSizeMake(std::min((iN + N_READS - 1) / N_READS, 1024), 1, 1);
+          MTLSize numGroupsDx = MTLSizeMake(iM, 1, 1);
+          [computeEncoder dispatchThreadgroups:numGroupsDx threadsPerThreadgroup:numThreadsDx];
         }
 
-        if (grad_input_mask[1]) {
-          gradWeightTensor = [mpsGraph reshapeTensor:gradWeightTensor withShape:gamma_shape name:nil];
-        }
-        if (grad_input_mask[2]) {
-          gradBiasTensor = [mpsGraph reshapeTensor:gradBiasTensor withShape:gamma_shape name:nil];
-        }
+        // --- dgamma / dbeta kernel ---
+        if (grad_input_mask[1] || grad_input_mask[2]) {
+          if (iM == 1) {
+            id<MTLComputePipelineState> dwdbKernel =
+                mps::lib.getPipelineStateForFunc("layer_norm_bwd_dw_db_m1_" + metalType);
+            [computeEncoder setComputePipelineState:dwdbKernel];
+            mps::mtl_setArgs(computeEncoder, *dOut, *X, mean_flat, rstd_flat, dw_buf, db_buf, (uint)iN);
+            mps::mtl_dispatch1DJob(computeEncoder, dwdbKernel, iN);
+          } else {
+            // Tiled two-phase dw_db: cache-friendly for all M>1 shapes
+            uint num_col_blocks = (iN + TILE_N - 1) / TILE_N;
 
-        newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-        newCachedGraph->inputTensor_ = inputTensor;
-        newCachedGraph->weightTensor_ = weightTensor;
-        newCachedGraph->meanTensor_ = meanTensor;
-        newCachedGraph->rstdTensor_ = rstdTensor;
-        newCachedGraph->gradInputTensor_ = gradInputTensor;
-        newCachedGraph->gradWeightTensor_ = gradWeightTensor;
-        newCachedGraph->gradBiasTensor_ = gradBiasTensor;
+            // Phase 1: partial reduction per tile → temp buffer [num_row_blocks, N]
+            id<MTLComputePipelineState> tiledKernel =
+                mps::lib.getPipelineStateForFunc("layer_norm_bwd_dw_db_tiled_" + metalType);
+            [computeEncoder setComputePipelineState:tiledKernel];
+            mps::mtl_setArgs(
+                computeEncoder, *dOut, *X, mean_flat, rstd_flat, partial_dgam, partial_dbet, (uint)iN, (uint)iM);
+            MTLSize tiledGroups = MTLSizeMake(num_row_blocks, num_col_blocks, 1);
+            MTLSize tiledThreads = MTLSizeMake(TILE_N, 1, 1);
+            [computeEncoder dispatchThreadgroups:tiledGroups threadsPerThreadgroup:tiledThreads];
+
+            // Phase 2: reduce partials across row blocks → final dgamma, dbeta
+            id<MTLComputePipelineState> reduceKernel =
+                mps::lib.getPipelineStateForFunc("layer_norm_bwd_dw_db_reduce_" + metalType);
+            [computeEncoder setComputePipelineState:reduceKernel];
+            mps::mtl_setArgs(
+                computeEncoder, partial_dgam, partial_dbet, dw_buf, db_buf, (uint)iN, (uint)num_row_blocks);
+            mps::mtl_dispatch1DJob(computeEncoder, reduceKernel, iN);
+          }
+        }
       });
-
-      auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, *X);
-      auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, *dOut);
-      auto weightPlaceholder = Placeholder();
-      if (has_weight)
-        weightPlaceholder = Placeholder(cachedGraph->weightTensor_, *gamma);
-      auto saveMeanPlaceholder = Placeholder(cachedGraph->meanTensor_, mean);
-      auto saveVarPlaceholder = Placeholder(cachedGraph->rstdTensor_, rstd);
-
-      auto gradInputPlaceholder = Placeholder();
-      if (grad_input_mask[0])
-        gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
-      auto gradWeightPlaceholder = Placeholder();
-      if (grad_input_mask[1])
-        gradWeightPlaceholder = Placeholder(cachedGraph->gradWeightTensor_, grad_weight);
-      auto gradBiasPlaceholder = Placeholder();
-      ;
-      if (grad_input_mask[2])
-        gradBiasPlaceholder = Placeholder(cachedGraph->gradBiasTensor_, grad_bias);
-
-      NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];
-      feeds[inputPlaceholder.getMPSGraphTensor()] = inputPlaceholder.getMPSGraphTensorData();
-      feeds[gradOutputPlaceholder.getMPSGraphTensor()] = gradOutputPlaceholder.getMPSGraphTensorData();
-      if (has_weight)
-        feeds[weightPlaceholder.getMPSGraphTensor()] = weightPlaceholder.getMPSGraphTensorData();
-      feeds[saveMeanPlaceholder.getMPSGraphTensor()] = saveMeanPlaceholder.getMPSGraphTensorData();
-      feeds[saveVarPlaceholder.getMPSGraphTensor()] = saveVarPlaceholder.getMPSGraphTensorData();
-
-      NSMutableDictionary* results = [[NSMutableDictionary new] autorelease];
-      if (grad_input_mask[0])
-        results[gradInputPlaceholder.getMPSGraphTensor()] = gradInputPlaceholder.getMPSGraphTensorData();
-      if (grad_input_mask[1])
-        results[gradWeightPlaceholder.getMPSGraphTensor()] = gradWeightPlaceholder.getMPSGraphTensorData();
-      if (grad_input_mask[2])
-        results[gradBiasPlaceholder.getMPSGraphTensor()] = gradBiasPlaceholder.getMPSGraphTensorData();
-
-      runMPSGraph(stream, cachedGraph->graph(), feeds, results);
     }
   }
   return std::make_tuple(std::move(grad_input), std::move(grad_weight), std::move(grad_bias));

--- a/benchmarks/bench_mps_layer_norm.py
+++ b/benchmarks/bench_mps_layer_norm.py
@@ -1,0 +1,68 @@
+"""Benchmark Metal vs MPSGraph LayerNorm backward on Apple Silicon.
+
+Usage:
+    python benchmarks/bench_mps_layer_norm.py
+
+Measures torch.nn.functional.layer_norm forward+backward using
+torch.utils.benchmark.Timer.blocked_autorange (median reported).
+
+Device: mps (Apple Silicon). Run with PYTHONPATH pointing to a Metal-enabled
+PyTorch build for the 'metal' numbers; run with stock nightly for 'mpsgraph'.
+"""
+
+import argparse
+
+import torch
+from torch.utils.benchmark import Timer
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--label", default="run", help="Label for this run")
+parser.add_argument(
+    "--dtype", default="float32", choices=["float32", "float16", "bfloat16"]
+)
+args = parser.parse_args()
+
+dtype = getattr(torch, args.dtype)
+device = "mps"
+
+configs = [
+    # (M, N, description)
+    (1, 64, "(1,1,64)    batch-1 small"),
+    (1, 256, "(1,1,256)   batch-1 mid"),
+    (1, 1024, "(1,1,1024)  batch-1 large"),
+    (1, 4096, "(1,1,4096)  batch-1 xlarge"),
+    (512, 64, "(512,1,64)  BERT-like small-N"),
+    (512, 256, "(512,1,256) BERT-like"),
+    (512, 768, "(512,1,768) BERT hidden"),
+    (512, 1024, "(512,1,1024)"),
+    (512, 4096, "(512,1,4096)"),
+    (4096, 256, "(4096,1,256) large-M"),
+]
+
+print(
+    f"label={args.label}  dtype={args.dtype}  device={device}  torch={torch.__version__}"
+)
+print("Methodology: torch.utils.benchmark.Timer.blocked_autorange (median)")
+print()
+print(f"{'Config':<32} {'fwd+bwd (ms)':>14}")
+print("-" * 48)
+
+for M, N, label in configs:
+    setup = f"""
+import torch
+x = torch.randn({M}, {N}, device='{device}', dtype=torch.{args.dtype}, requires_grad=True)
+w = torch.randn({N}, device='{device}', dtype=torch.{args.dtype}, requires_grad=True)
+b = torch.randn({N}, device='{device}', dtype=torch.{args.dtype}, requires_grad=True)
+dy = torch.randn({M}, {N}, device='{device}', dtype=torch.{args.dtype})
+"""
+    stmt = f"""
+xc = x.detach().requires_grad_(True)
+wc = w.detach().requires_grad_(True)
+bc = b.detach().requires_grad_(True)
+y = torch.nn.functional.layer_norm(xc, [{N}], wc, bc)
+y.backward(dy)
+torch.mps.synchronize()
+"""
+    t = Timer(stmt=stmt, setup=setup).blocked_autorange(min_run_time=1.0)
+    print(f"{label:<32} {t.median * 1e3:>14.3f}")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2662,6 +2662,55 @@ class TestMPS(TestCaseMPS):
         # Regression test for https://github.com/pytorch/pytorch/issues/96113
         torch.nn.LayerNorm((16,), elementwise_affine=True).to("mps")(torch.randn(1, 2, 16).to("mps", dtype=torch.float16))
 
+
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    @parametrize("N", [64, 256, 1024, 4096, 4097, 8192])
+    @parametrize("M_kind", ["m1", "small", "multiblock"])
+    @parametrize("elementwise_affine", [True, False])
+    def test_layer_norm_backward_metal(self, dtype, N, M_kind, elementwise_affine):
+        """Backward correctness for the Metal LayerNorm kernels vs fp32 CPU.
+
+        N routes the dx kernel (single_row <= 4096, looped above); M_kind routes
+        dw/db: m1 fast path (M == 1), single-tile (M <= 64), and the multi-row-block
+        tiled+reduce composition (M = 130 -> 3 partial blocks).
+        """
+        B, T = {"m1": (1, 1), "small": (4, 16), "multiblock": (2, 65)}[M_kind]
+        if N > 4096:
+            B, T = {"m1": (1, 1), "small": (2, 8), "multiblock": (2, 65)}[M_kind]
+        # bf16 error scales with the number of accumulated rows (input rounding,
+        # ~sqrt(M)); measured max 1.6e-1 at M<=64 and 1.9e-1 at M=130.
+        bf16_atol = 3e-1 if M_kind == "multiblock" else 2e-1
+        atol = 1e-3 if dtype == torch.float32 else (5e-2 if dtype == torch.float16 else bf16_atol)
+
+        x = torch.randn(B, T, N, dtype=torch.float32, requires_grad=True)
+        w = torch.randn(N, requires_grad=True) if elementwise_affine else None
+        b = torch.randn(N, requires_grad=True) if elementwise_affine else None
+        y = F.layer_norm(x, (N,), w, b)
+        dy = torch.randn_like(y)
+        y.backward(dy)
+
+        xm = x.detach().to(device='mps', dtype=dtype).requires_grad_()
+        wm = w.detach().to(device='mps', dtype=dtype).requires_grad_() if elementwise_affine else None
+        bm = b.detach().to(device='mps', dtype=dtype).requires_grad_() if elementwise_affine else None
+        ym = F.layer_norm(xm, (N,), wm, bm)
+        ym.backward(dy.to(device='mps', dtype=dtype))
+
+        self.assertEqual(xm.grad.float().cpu(), x.grad, atol=atol, rtol=0)
+        if elementwise_affine:
+            self.assertEqual(wm.grad.float().cpu(), w.grad, atol=atol, rtol=0)
+            self.assertEqual(bm.grad.float().cpu(), b.grad, atol=atol, rtol=0)
+
+    def test_layer_norm_backward_metal_empty(self):
+        # N == 0 with dgamma/dbeta requested must not encode zero-sized
+        # dispatches (asserts under the Metal validation layer).
+        dx, dw, db = torch.ops.aten.native_layer_norm_backward(
+            torch.empty(4, 0, device="mps"), torch.empty(4, 0, device="mps"), (0,),
+            torch.zeros(4, 1, device="mps"), torch.ones(4, 1, device="mps"),
+            torch.empty(0, device="mps"), torch.empty(0, device="mps"),
+            [False, True, True])
+        self.assertEqual(dw.shape, torch.Size([0]))
+        self.assertEqual(db.shape, torch.Size([0]))
+
     def test_ifft(self):
         # See: https://github.com/pytorch/pytorch/issues/124096
         device = torch.device("mps")


### PR DESCRIPTION
# [MPS] Migrate layer_norm backward to native Metal kernels

## What / why

Part of #187455. `layer_norm_backward_mps` is one of the remaining `LookUpOrCreateCachedGraph`
sites: every distinct input shape compiles and caches an MPSGraph with no eviction, so
training loops over shape-varying batches (GNNs, variable-length sequences) grow the cache
without bound. The forward was already migrated to native Metal (`LayerNorm.metal`
single_row/looped); this PR completes the op by migrating the backward, removing the graph
path entirely (net -156 lines of host code).

Kernels (all accumulate in fp32; extend the existing `c10/metal` reduction lineage via
`c10::metal::threadgroup_sum`):
- `layer_norm_bwd_dx_single_row` — one threadgroup per row, row cached in registers
  (N <= 4096 at N_READS=4)
- `layer_norm_bwd_dx_looped` — larger N; wdy/xhat register-cached when they fit
  (elems_per_thread <= 8), global re-read fallback beyond the register budget
- dw/db: `m1` fast path (M == 1, pure per-column, 1D dispatch) and a two-phase
  `tiled` (64x32 tiles) + `reduce` (per-column, 1D dispatch) path for M > 1
- weight/no-weight handled by templated kernel variants (no dummy buffer binding)

## Performance

Benchmark: `benchmarks/mps/bench_mps_layer_norm.py` (committed). fwd+bwd via
`Timer.blocked_autorange` (median), interleaved A/B: A = stock nightly (MPSGraph backward),
B = this PR. M4 Pro, quiet machine, 3 reps.

| config | MPSGraph (ms) | Metal (ms) | speedup |
|---|---|---|---|
| float32 (1,1,64)    batch-1 small | 0.195 | 0.118 | 1.65x |
| float32 (1,1,256)   batch-1 mid | 0.195 | 0.122 | 1.60x |
| float32 (1,1,1024)  batch-1 large | 0.194 | 0.122 | 1.59x |
| float32 (1,1,4096)  batch-1 xlarge | 0.196 | 0.129 | 1.52x |
| float32 (512,1,64)  BERT-like small-N | 0.210 | 0.142 | 1.48x |
| float32 (512,1,256) BERT-like | 0.220 | 0.149 | 1.48x |
| float32 (512,1,768) BERT hidden | 0.258 | 0.178 | 1.45x |
| float32 (512,1,1024) | 0.284 | 0.176 | 1.61x |
| float32 (512,1,4096) | 0.559 | 0.369 | 1.51x |
| float32 (4096,1,256) large-M | 0.377 | 0.257 | 1.47x |
| float16 (1,1,64)    batch-1 small | 0.194 | 0.119 | 1.63x |
| float16 (1,1,256)   batch-1 mid | 0.194 | 0.122 | 1.59x |
| float16 (1,1,1024)  batch-1 large | 0.202 | 0.123 | 1.64x |
| float16 (1,1,4096)  batch-1 xlarge | 0.197 | 0.126 | 1.56x |
| float16 (512,1,64)  BERT-like small-N | 0.217 | 0.139 | 1.56x |
| float16 (512,1,256) BERT-like | 0.239 | 0.145 | 1.65x |
| float16 (512,1,768) BERT hidden | 0.262 | 0.167 | 1.57x |
| float16 (512,1,1024) | 0.271 | 0.181 | 1.50x |
| float16 (512,1,4096) | 0.392 | 0.260 | 1.51x |
| float16 (4096,1,256) large-M | 0.338 | 0.232 | 1.46x |

All 20 cells (fp32+fp16 x 10 shapes) faster than the MPSGraph baseline; zero cells < 0.95x.

## Correctness / Test Plan

- `PYTORCH_TEST_MPS=1 python -m pytest test/test_mps.py -k "layer_norm" -q` (incl. the
  parametrized `test_layer_norm_backward_metal`: dtype x N x elementwise_affine grid, 36
  cases; the N grid routes through every kernel path).
- Coverage owner note: OpInfo consistency remains the broad semantic owner; the focused
  test owns the Metal path routing (single_row/looped boundary at 4096/4097, m1 vs
  tiled+reduce), which OpInfo's small samples do not reach.
- Full `--mps` suite: clean (3 transient parallel-run flakes re-verified passing at file level
  and in isolation on both this build and stock nightly; unrelated files).

## BC-breaking?

No public API change. f16/bf16 backward accumulates in fp32.

## Review history

Local review + gate dispositions (3-lens adversarial panel; 4 defects found and fixed pre-push): https://gist.github.com/c7770aa77f9a48fb5bf0456d644a7e6a



---

## Update: per-extent int32 bounds on the backward dispatch

Responding to review: the previous guard checked `M * N <= UINT32_MAX` but then cast each extent to signed `int` — extents in (2^31, 2^32) passed the check and wrapped before dispatch (e.g. M=1, N=3e9 selected the single-row kernel with a negative width). Each extent is now bounded to int32, which makes every existing `int` expression provably correct with no kernel changes and also closes two kernel-side `uint` tail-arithmetic wrap corners (`base + N_READS`, `N + lsize * N_READS`).

Bench 8/8 cells all-win (1.48–1.63x); full local `--mps` matrix clean apart from `test_metal` (known desktop-build artifact) and `test_output_grad_match_combinations_mps_float16`, which is a base-snapshot trunk failure (proven by reverting this PR's files to base — it fails identically — and passing on the nightly wheel); a rebase clears it.

Review log: https://gist.github.com/anagnorisis2peripeteia/81b1ebbb4b27a59f74cbd52a1ac44900
