### PR TITLE
mps: replace MPSGraph GELU forward/backward with Metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -227,3 +227,80 @@ struct silu_backward_functor {
 REGISTER_BINARY_OP(silu_backward, float, float);
 REGISTER_BINARY_OP(silu_backward, half, half);
 REGISTER_BINARY_OP(silu_backward, bfloat, bfloat);
+
+// ================================================================
+//  GELU forward and backward kernels
+//  All math done in float32 regardless of input dtype for precision.
+//
+//  Exact (none):
+//    fwd:  x * 0.5 * (1 + erf(x / sqrt(2)))
+//    bwd:  dy * (cdf(x) + x * pdf(x))
+//
+//  Tanh approximation:
+//    fwd:  0.5 * x * (1 + tanh(beta*(x + kappa*x^3)))
+//    bwd:  dy * (0.5*(1+t) + 0.5*x*(1-t^2)*beta*(1+3*kappa*x^2))
+//          where t = tanh(beta*(x+kappa*x^3))
+// ================================================================
+
+struct gelu_none_functor {
+  template <typename T>
+  inline T operator()(const T x) {
+    constexpr float kAlpha = 0.7071067811865476f; // 1/sqrt(2)
+    float xf = float(x);
+    return static_cast<T>(xf * 0.5f * (1.0f + erf(xf * kAlpha)));
+  }
+};
+
+REGISTER_UNARY_OP(gelu_none, float, float);
+REGISTER_UNARY_OP(gelu_none, half, half);
+REGISTER_UNARY_OP(gelu_none, bfloat, bfloat);
+
+struct gelu_tanh_functor {
+  template <typename T>
+  inline T operator()(const T x) {
+    constexpr float kBeta = 0.7978845608028654f; // sqrt(2/pi)
+    constexpr float kKappa = 0.044715f;
+    float xf = float(x);
+    float inner = kBeta * (xf + kKappa * xf * xf * xf);
+    return static_cast<T>(0.5f * xf * (1.0f + tanh(inner)));
+  }
+};
+
+REGISTER_UNARY_OP(gelu_tanh, float, float);
+REGISTER_UNARY_OP(gelu_tanh, half, half);
+REGISTER_UNARY_OP(gelu_tanh, bfloat, bfloat);
+
+struct gelu_backward_none_functor {
+  template <typename T>
+  inline T operator()(const T grad_output, const T x) {
+    constexpr float kAlpha = 0.7071067811865476f; // 1/sqrt(2)
+    constexpr float kBeta = 0.3989422804014327f; // 1/sqrt(2*pi)
+    float xf = float(x);
+    float cdf = 0.5f * (1.0f + erf(xf * kAlpha));
+    float pdf = exp(-0.5f * xf * xf) * kBeta;
+    return static_cast<T>(float(grad_output) * (cdf + xf * pdf));
+  }
+};
+
+REGISTER_BINARY_OP(gelu_backward_none, float, float);
+REGISTER_BINARY_OP(gelu_backward_none, half, half);
+REGISTER_BINARY_OP(gelu_backward_none, bfloat, bfloat);
+
+struct gelu_backward_tanh_functor {
+  template <typename T>
+  inline T operator()(const T grad_output, const T x) {
+    constexpr float kBeta = 0.7978845608028654f; // sqrt(2/pi)
+    constexpr float kKappa = 0.044715f;
+    float xf = float(x);
+    float inner = kBeta * (xf + kKappa * xf * xf * xf);
+    float t = tanh(inner);
+    float left_d = 0.5f * (1.0f + t);
+    float right_d =
+        0.5f * xf * (1.0f - t * t) * kBeta * (1.0f + 3.0f * kKappa * xf * xf);
+    return static_cast<T>(float(grad_output) * (left_d + right_d));
+  }
+};
+
+REGISTER_BINARY_OP(gelu_backward_tanh, float, float);
+REGISTER_BINARY_OP(gelu_backward_tanh, half, half);
+REGISTER_BINARY_OP(gelu_backward_tanh, bfloat, bfloat);

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -1,7 +1,18 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/Activation.h>
+#include <ATen/native/Gelu.h>
 #include <ATen/native/mps/OperationUtils.h>
+
+namespace at::native {
+namespace mps {
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/ActivationKernel_metallib.h>
+#endif
+} // namespace mps
+} // namespace at::native
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -476,151 +487,20 @@ static MPSGraphTensor* tanh(MPSGraph* mpsGraph, MPSGraphTensor* inputTensor) {
 }
 
 TORCH_IMPL_FUNC(gelu_out_mps)(const Tensor& self, std::string_view approximate, const Tensor& output) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryCachedGraph;
   TORCH_CHECK(output.is_mps());
   TORCH_CHECK(c10::isFloatingType(self.scalar_type()), "GELU is only implemented for floating types");
-
-  // Empty output
   if (output.numel() == 0)
     return;
-
-  auto approximate_type = get_gelutype_enum(approximate);
-  MPSStream* stream = getCurrentMPSStream();
-
-  bool executeGatherOp = needsGather(output);
-  Tensor output_;
-  if (executeGatherOp) {
-    output_ = at::empty_like(output, MemoryFormat::Contiguous);
-  }
-
-  @autoreleasepool {
-    const auto key = "gelu_out_mps" + getTensorsStringKey({self}) + ":" + gelutype_to_string(approximate_type);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(self), getMPSShape(self));
-
-      MPSGraphTensor* outputTensor = nil;
-      if (approximate_type == GeluType::Tanh) {
-        outputTensor = tanh(mpsGraph, inputTensor);
-      } else {
-        outputTensor = normcdf(mpsGraph, inputTensor);
-      }
-      outputTensor = [mpsGraph multiplicationWithPrimaryTensor:outputTensor secondaryTensor:inputTensor name:nil];
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder =
-        Placeholder(cachedGraph->outputTensor_, executeGatherOp ? output_ : output, nil, false);
-
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-
-  if (executeGatherOp) {
-    output.copy_(output_);
-  }
+  auto iter = at::TensorIteratorConfig().add_output(output).add_input(self).build();
+  mps::lib.exec_unary_kernel(iter, "gelu_" + gelutype_to_string(get_gelutype_enum(approximate)));
 }
 
 TORCH_IMPL_FUNC(gelu_backward_out_mps)
 (const Tensor& grad, const Tensor& self, std::string_view approximate, const Tensor& grad_input) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryGradCachedGraph;
-
-  // Empty output
-  if (self.numel() == 0) {
+  if (self.numel() == 0)
     return;
-  }
-
-  bool executeGatherOp = needsGather(grad_input);
-  Tensor grad_input_;
-  if (executeGatherOp) {
-    grad_input_ = at::empty_like(grad_input, MemoryFormat::Contiguous);
-  }
-
-  auto approximate_type = get_gelutype_enum(approximate);
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    const auto key =
-        "gelu_backward_out_mps" + getTensorsStringKey({self, grad}) + ":" + gelutype_to_string(approximate_type);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      auto dataType = getMPSDataType(self);
-
-      MPSGraphTensor* gradTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad), getMPSShape(grad));
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, dataType, getMPSShape(self));
-      MPSGraphTensor* outputTensor = nil;
-      if (approximate_type == GeluType::Tanh) {
-        constexpr float kBeta = M_SQRT2 * M_2_SQRTPI * (0.5f);
-        constexpr float kKappa = 0.044715f;
-        MPSGraphTensor* betaf = [mpsGraph constantWithScalar:kBeta shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* kappaf = [mpsGraph constantWithScalar:kKappa shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* halff = [mpsGraph constantWithScalar:0.5f shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* onef = [mpsGraph constantWithScalar:1.0f shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* threef = [mpsGraph constantWithScalar:3.0f shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* x_sq = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                                         secondaryTensor:inputTensor
-                                                                    name:nil];
-        MPSGraphTensor* x_cube = [mpsGraph multiplicationWithPrimaryTensor:x_sq secondaryTensor:inputTensor name:nil];
-        MPSGraphTensor* inner = [mpsGraph multiplicationWithPrimaryTensor:kappaf secondaryTensor:x_cube name:nil];
-        inner = [mpsGraph additionWithPrimaryTensor:inner secondaryTensor:inputTensor name:nil];
-        inner = [mpsGraph multiplicationWithPrimaryTensor:betaf secondaryTensor:inner name:nil];
-        MPSGraphTensor* tanhInner = [mpsGraph tanhWithTensor:inner name:nil];
-        MPSGraphTensor* left = [mpsGraph multiplicationWithPrimaryTensor:halff secondaryTensor:inputTensor name:nil];
-        MPSGraphTensor* right = [mpsGraph additionWithPrimaryTensor:onef secondaryTensor:tanhInner name:nil];
-        MPSGraphTensor* left_derivative = [mpsGraph multiplicationWithPrimaryTensor:halff
-                                                                    secondaryTensor:right
-                                                                               name:nil];
-        MPSGraphTensor* tanh_derivative = [mpsGraph multiplicationWithPrimaryTensor:tanhInner
-                                                                    secondaryTensor:tanhInner
-                                                                               name:nil];
-        tanh_derivative = [mpsGraph subtractionWithPrimaryTensor:onef secondaryTensor:tanh_derivative name:nil];
-        MPSGraphTensor* inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:threef
-                                                                     secondaryTensor:kappaf
-                                                                                name:nil];
-        inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:inner_derivative secondaryTensor:x_sq name:nil];
-        inner_derivative = [mpsGraph additionWithPrimaryTensor:inner_derivative secondaryTensor:onef name:nil];
-        inner_derivative = [mpsGraph multiplicationWithPrimaryTensor:betaf secondaryTensor:inner_derivative name:nil];
-        MPSGraphTensor* right_derivative = [mpsGraph multiplicationWithPrimaryTensor:left
-                                                                     secondaryTensor:tanh_derivative
-                                                                                name:nil];
-        right_derivative = [mpsGraph multiplicationWithPrimaryTensor:right_derivative
-                                                     secondaryTensor:inner_derivative
-                                                                name:nil];
-        outputTensor = [mpsGraph additionWithPrimaryTensor:left_derivative secondaryTensor:right_derivative name:nil];
-        outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor secondaryTensor:outputTensor name:nil];
-      } else {
-        constexpr float kBeta = M_2_SQRTPI * M_SQRT1_2 * (0.5);
-        MPSGraphTensor* halff = [mpsGraph constantWithScalar:-0.5f shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* betaf = [mpsGraph constantWithScalar:kBeta shape:@[ @1 ] dataType:dataType];
-        MPSGraphTensor* cdf = normcdf(mpsGraph, inputTensor);
-        MPSGraphTensor* pdfMul = [mpsGraph squareWithTensor:inputTensor name:nil];
-        pdfMul = [mpsGraph multiplicationWithPrimaryTensor:pdfMul secondaryTensor:halff name:nil];
-        pdfMul = [mpsGraph exponentWithTensor:pdfMul name:nil];
-        MPSGraphTensor* pdf = [mpsGraph multiplicationWithPrimaryTensor:pdfMul secondaryTensor:betaf name:nil];
-        pdf = [mpsGraph multiplicationWithPrimaryTensor:inputTensor secondaryTensor:pdf name:nil];
-        pdf = [mpsGraph additionWithPrimaryTensor:pdf secondaryTensor:cdf name:nil];
-        outputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradTensor secondaryTensor:pdf name:nil];
-      }
-
-      newCachedGraph->gradOutputTensor_ = gradTensor;
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->gradInputTensor_ = outputTensor;
-    });
-
-    Placeholder gradPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad);
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder =
-        Placeholder(cachedGraph->gradInputTensor_, executeGatherOp ? grad_input_ : grad_input);
-
-    auto feeds = dictionaryFromPlaceholders(gradPlaceholder, selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-
-  if (executeGatherOp) {
-    grad_input.copy_(grad_input_);
-  }
+  auto iter = at::TensorIteratorConfig().add_output(grad_input).add_input(grad).add_input(self).build();
+  mps::lib.exec_binary_kernel(iter, "gelu_backward_" + gelutype_to_string(get_gelutype_enum(approximate)));
 }
 
 TORCH_IMPL_FUNC(glu_out_mps)(const Tensor& self, const int64_t dim, const Tensor& output) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -7079,6 +7079,37 @@ class TestMPS(TestCaseMPS):
 
         helper((2, 8, 4, 5))
 
+
+    def test_gelu_metal(self):
+        """Verify Metal GELU kernels for both approximations, all dtypes, fwd+bwd."""
+        import torch.nn.functional as F
+
+        def run(shape, dtype, approximate):
+            tol = 1e-3 if dtype == torch.float32 else 5e-2
+            cpu_x = torch.randn(shape, dtype=torch.float32)
+            xc = cpu_x.clone().requires_grad_(True)
+            yc = F.gelu(xc, approximate=approximate)
+            dyc = torch.randn_like(yc)
+            yc.backward(dyc)
+
+            x_mps = cpu_x.to(device='mps', dtype=dtype).requires_grad_(True)
+            ym = F.gelu(x_mps, approximate=approximate)
+            ym.backward(dyc.to(device='mps', dtype=dtype))
+
+            fwd_err = (ym.float().cpu() - yc.detach()).abs().max().item()
+            bwd_err = (x_mps.grad.float().cpu() - xc.grad).abs().max().item()
+            self.assertLess(fwd_err, tol,
+                f"GELU fwd err {fwd_err:.2e} for approx={approximate} dtype={dtype} shape={shape}")
+            self.assertLess(bwd_err, tol,
+                f"GELU bwd err {bwd_err:.2e} for approx={approximate} dtype={dtype} shape={shape}")
+
+        for approximate in ['none', 'tanh']:
+            for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+                for shape in [(4,), (4, 3), (5, 4, 3), (2, 8, 4, 5)]:
+                    run(shape, dtype, approximate)
+                # non-contiguous
+                run((8, 8), dtype, approximate)
+
     # Test hardtanh
     def test_hardtanh(self):
         def helper(shape, min_val, max_val, inplace=False):


### PR DESCRIPTION
## Summary

Replaces the MPSGraph-based `gelu_out_mps` and `gelu_backward_out_mps` with four Metal element-wise functors, eliminating per-shape graph caching for a heavily-used activation function.

### New Metal functors (`ActivationKernel.metal`)

Four functors registered for `float`, `half`, and `bfloat` using the existing `REGISTER_UNARY_OP` / `REGISTER_BINARY_OP` macros:

| Functor | Approximation | Formula |
|---------|--------------|---------|
| `gelu_none` | exact | `x * 0.5 * (1 + erf(x/sqrt(2)))` |
| `gelu_tanh` | tanh | `0.5*x*(1 + tanh(beta*(x + kappa*x^3)))` |
| `gelu_backward_none` | exact | `dy * (cdf(x) + x*pdf(x))` |
| `gelu_backward_tanh` | tanh | `dy * (0.5*(1+t) + 0.5*x*(1-t^2)*beta*(1 + 3*kappa*x^2))` |

All intermediate math is done in `float32` before casting back to the input dtype for numerical stability with fp16/bf16.

### C++ dispatch (`Activation.mm`)

Removes the entire `@autoreleasepool` / `LookUpOrCreateCachedGraph` / `Placeholder` / `runMPSGraph` blocks from both functions (~130 lines combined) and replaces each with a single `mps::lib.exec_unary_kernel` / `exec_binary_kernel` call. TensorIterator handles contiguous and strided layouts automatically.

### Tests (`test/test_mps.py`)

New `test_gelu_metal` covers both approximations, all three dtypes (fp32/fp16/bf16), and fwd+bwd correctness against CPU reference.

## Status

Draft - CI pending. Part of a series replacing MPSGraph ops with direct Metal kernels:
- #181503 — MPS softmax (awaiting merge)
- #182109 — MPS LayerNorm backward (CI pending)