### PR TITLE
Forward CMake 4.x policy minimum to host-protoc cross-compilation build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -890,7 +890,7 @@ if(NOT IOS
   # CMAKE_TRY_COMPILE_TARGET_TYPE to STATIC_LIBRARY (vs executable) to succeed
   # the cmake compiler check for cross-compiling
   set(protoc_build_command
-      "./scripts/build_host_protoc.sh --other-flags -DCMAKE_OSX_ARCHITECTURES=\"x86_64;arm64\" -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DCMAKE_C_COMPILER_WORKS=1 -DCMAKE_CXX_COMPILER_WORKS=1"
+      "./scripts/build_host_protoc.sh --other-flags -DCMAKE_OSX_ARCHITECTURES=\"x86_64;arm64\" -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DCMAKE_C_COMPILER_WORKS=1 -DCMAKE_CXX_COMPILER_WORKS=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
   )
   # We write to a temp scriptfile because CMake COMMAND dislikes double quotes
   # in commands


### PR DESCRIPTION
The host-protoc build runs as a separate CMake invocation and doesn't inherit the localized CMAKE_POLICY_VERSION_MINIMUM guards that the main build already has around third-party add_subdirectory calls. Pass -DCMAKE_POLICY_VERSION_MINIMUM=3.5 so protobuf (which requires CMake 3.1.3) can build under CMake 4.x.

Co-Generated with [Claude Code](https://claude.com/claude-code)

Replaces #180240 