### PR TITLE
Add torch_enum target exposing C++ API enum definitions (#182119)

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -1545,6 +1545,25 @@ def define_buck_targets(
         ],
     )
 
+    # Standalone target for the C++ API enum tag definitions
+    # (torch/csrc/api/src/enum.cpp). Lets consumers link only the enum
+    # globals without pulling in the full torch C++ API.
+    # @lint-ignore BUCKLINT link_whole
+    pt_xplat_cxx_library(
+        name = "torch_enum",
+        srcs = ["torch/csrc/api/src/enum.cpp"],
+        compiler_flags = get_pt_compiler_flags(),
+        exported_preprocessor_flags = get_pt_preprocessor_flags(),
+        link_whole = True,
+        linker_flags = get_no_as_needed_linker_flag(),
+        visibility = ["PUBLIC"],
+        exported_deps = [
+            ":aten_cpu",
+            ":torch_headers",
+            C10,
+        ],
+    )
+
     pt_xplat_cxx_library(
         name = "torch_core",
         srcs = core_sources_full_mobile_no_backend_interface_xplat,


### PR DESCRIPTION
Summary:

Add a small standalone target wrapping torch/csrc/api/src/enum.cpp. The file contains TORCH_ENUM_DEFINE directives for the C++ API enum tags (kBilinear, kZeros, kNearest, kReLU, kMean, ...) used by torch::nn::functional::*FuncOptions default initializers and similar APIs. No kernels, no ops, just the enum tag storage.

Existing consumers had to link the full torch C++ API to get the enums (the file is part of torch_cpp_srcs). A focused target makes it possible to link just the enum definitions when only those symbols are needed - useful for link configurations that exclude the rest of the C++ API but still pull in the torch C++ API headers transitively.

Object size is small (one byte of `.rodata` per enum tag); linkers that dead-strip drop unreferenced symbols, so net binary cost is typically zero. `link_whole = True` is defensive - keeps all enum globals available where dead-stripping is disabled (debug builds, link-whole consumers).

Test Plan:
- buck2 build //xplat/caffe2:torch_enum on Linux x86_64: PASS
- buck2 build //xplat/caffe2:torch_enum on Windows x86_64: PASS
- No behavior change for existing torch_cpp_srcs consumers.

Reviewed By: patricksnape

Differential Revision: D103339766


