### PR TITLE
Replace deprecated distutils usage

### DIFF
--- a/.ci/pytorch/macos-test.sh
+++ b/.ci/pytorch/macos-test.sh
@@ -107,7 +107,7 @@ test_custom_backend() {
   pushd test/custom_backend
   rm -rf build && mkdir build
   pushd build
-  SITE_PACKAGES="$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
+  SITE_PACKAGES="$(python -c 'from sysconfig import get_path; print(get_path("purelib"))')"
   CMAKE_PREFIX_PATH="$SITE_PACKAGES/torch" cmake ..
   make VERBOSE=1
   popd
@@ -128,7 +128,7 @@ test_custom_script_ops() {
   # Build the custom operator library.
   rm -rf build && mkdir build
   pushd build
-  SITE_PACKAGES="$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
+  SITE_PACKAGES="$(python -c 'from sysconfig import get_path; print(get_path("purelib"))')"
   CMAKE_PREFIX_PATH="$SITE_PACKAGES/torch" cmake ..
   make VERBOSE=1
   popd
@@ -148,7 +148,7 @@ test_jit_hooks() {
   # Build the custom operator library.
   rm -rf build && mkdir build
   pushd build
-  SITE_PACKAGES="$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
+  SITE_PACKAGES="$(python -c 'from sysconfig import get_path; print(get_path("purelib"))')"
   CMAKE_PREFIX_PATH="$SITE_PACKAGES/torch" cmake ..
   make VERBOSE=1
   popd

--- a/.ci/pytorch/smoke_test/check_binary_symbols.py
+++ b/.ci/pytorch/smoke_test/check_binary_symbols.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import concurrent.futures
-import distutils.sysconfig
 import functools
 import itertools
 import os
 import re
+import sysconfig
 from pathlib import Path
 from typing import Any
 
@@ -476,7 +476,7 @@ def main() -> None:
         if os.getenv("PACKAGE_TYPE") == "libtorch":
             install_root = Path(os.getcwd())
         else:
-            install_root = Path(distutils.sysconfig.get_python_lib()) / "torch"
+            install_root = Path(sysconfig.get_path("purelib")) / "torch"
 
     libtorch_cpu_path = str(install_root / "lib" / "libtorch_cpu.so")
     check_lib_symbols_for_abi_correctness(libtorch_cpu_path)

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1811,7 +1811,7 @@ build_xla() {
   rm "${XLA_DIR}/torch_patches/.torch_pin" || true
 
   apply_patches
-  SITE_PACKAGES="$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
+  SITE_PACKAGES="$(python -c 'from sysconfig import get_path; print(get_path("purelib"))')"
   # These functions are defined in .circleci/common.sh in pytorch/xla repo
   retry install_pre_deps_pytorch_xla $XLA_DIR $USE_CACHE
   CMAKE_PREFIX_PATH="${SITE_PACKAGES}/torch:${CMAKE_PREFIX_PATH}" XLA_SANDBOX_BUILD=1 build_torch_xla $XLA_DIR
@@ -1826,7 +1826,7 @@ test_xla() {
   clone_pytorch_xla
   # shellcheck disable=SC1091
   source "./xla/.circleci/common.sh"
-  SITE_PACKAGES="$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
+  SITE_PACKAGES="$(python -c 'from sysconfig import get_path; print(get_path("purelib"))')"
   # Set LD_LIBRARY_PATH for C++ tests
   export LD_LIBRARY_PATH="/opt/conda/lib/:${LD_LIBRARY_PATH}"
   CMAKE_PREFIX_PATH="${SITE_PACKAGES}/torch:${CMAKE_PREFIX_PATH}" XLA_SKIP_MP_OP_TESTS=1 run_torch_xla_tests "$(pwd)" "$(pwd)/xla"

--- a/.github/scripts/generate_pytorch_version.py
+++ b/.github/scripts/generate_pytorch_version.py
@@ -5,13 +5,28 @@ import os
 import re
 import subprocess
 from datetime import datetime
-from distutils.util import strtobool
 from pathlib import Path
 
 
 LEADING_V_PATTERN = re.compile("^v")
 TRAILING_RC_PATTERN = re.compile("-rc[0-9]*$")
 LEGACY_BASE_VERSION_SUFFIX_PATTERN = re.compile("a0$")
+
+
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are "y", "yes", "t", "true", "on", and "1"; false values
+    are "n", "no", "f", "false", "off", and "0".  Raises ValueError if
+    "val" is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {val!r}")
 
 
 class NoGitTagException(Exception):

--- a/.github/scripts/generate_pytorch_version.py
+++ b/.github/scripts/generate_pytorch_version.py
@@ -4,29 +4,22 @@ import argparse
 import os
 import re
 import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+from tools.strtobool import strtobool
+
+
+sys.path.pop(0)
 
 
 LEADING_V_PATTERN = re.compile("^v")
 TRAILING_RC_PATTERN = re.compile("-rc[0-9]*$")
 LEGACY_BASE_VERSION_SUFFIX_PATTERN = re.compile("a0$")
-
-
-def strtobool(val: str) -> bool:
-    """Convert a string representation of truth to true (1) or false (0).
-
-    True values are "y", "yes", "t", "true", "on", and "1"; false values
-    are "n", "no", "f", "false", "off", and "0".  Raises ValueError if
-    "val" is anything else.
-    """
-    val = val.lower()
-    if val in ("y", "yes", "t", "true", "on", "1"):
-        return True
-    elif val in ("n", "no", "f", "false", "off", "0"):
-        return False
-    else:
-        raise ValueError(f"invalid truth value {val!r}")
 
 
 class NoGitTagException(Exception):

--- a/.github/scripts/generate_pytorch_version.py
+++ b/.github/scripts/generate_pytorch_version.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from pathlib import Path
 
 
+# Because this file is run as a script, we need to add the repo root to the
+# path to be able to import tools.strtobool.
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 from tools.strtobool import strtobool

--- a/tools/alerts/create_alerts.py
+++ b/tools/alerts/create_alerts.py
@@ -11,7 +11,6 @@ from difflib import SequenceMatcher
 from typing import Any
 
 import requests
-from setuptools import distutils  # type: ignore[import,attr-defined]
 
 
 ALL_SKIPPED_THRESHOLD = 100
@@ -64,6 +63,22 @@ DISABLED_ALERTS = [
     "rerun_disabled_tests",
     "unstable",
 ]
+
+
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are "y", "yes", "t", "true", "on", and "1"; false values
+    are "n", "no", "f", "false", "off", and "0".  Raises ValueError if
+    "val" is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {val!r}")
 
 
 class JobStatus:
@@ -299,13 +314,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--with-flaky-test-alert",
         help="Run this script with the flaky test alerting",
-        type=distutils.util.strtobool,
+        type=strtobool,
         default=os.getenv("WITH_FLAKY_TEST_ALERT", "YES"),
     )
     parser.add_argument(
         "--dry-run",
         help="Whether or not to actually post issues",
-        type=distutils.util.strtobool,
+        type=strtobool,
         default=os.getenv("DRY_RUN", "YES"),
     )
     return parser.parse_args()

--- a/tools/alerts/create_alerts.py
+++ b/tools/alerts/create_alerts.py
@@ -12,6 +12,8 @@ from typing import Any
 
 import requests
 
+from tools.strtobool import strtobool
+
 
 ALL_SKIPPED_THRESHOLD = 100
 SIMILARITY_THRESHOLD = 0.75
@@ -63,22 +65,6 @@ DISABLED_ALERTS = [
     "rerun_disabled_tests",
     "unstable",
 ]
-
-
-def strtobool(val: str) -> bool:
-    """Convert a string representation of truth to true (1) or false (0).
-
-    True values are "y", "yes", "t", "true", "on", and "1"; false values
-    are "n", "no", "f", "false", "off", and "0".  Raises ValueError if
-    "val" is anything else.
-    """
-    val = val.lower()
-    if val in ("y", "yes", "t", "true", "on", "1"):
-        return True
-    elif val in ("n", "no", "f", "false", "off", "0"):
-        return False
-    else:
-        raise ValueError(f"invalid truth value {val!r}")
 
 
 class JobStatus:

--- a/tools/alerts/create_alerts.py
+++ b/tools/alerts/create_alerts.py
@@ -12,8 +12,6 @@ from typing import Any
 
 import requests
 
-from tools.strtobool import strtobool
-
 
 ALL_SKIPPED_THRESHOLD = 100
 SIMILARITY_THRESHOLD = 0.75
@@ -278,6 +276,10 @@ def get_recurrently_failing_jobs_alerts(
 
 
 def parse_args() -> argparse.Namespace:
+    # Imported here so library users that pull in filter_job_names / JobStatus
+    # do not pay for the strtobool import path.
+    from tools.strtobool import strtobool
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--repo",

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -8,11 +8,26 @@ import subprocess
 from pathlib import Path
 
 from packaging.version import Version
-from setuptools import distutils  # type: ignore[import,attr-defined]
 
 
 UNKNOWN = "Unknown"
 RELEASE_PATTERN = re.compile(r"/v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/")
+
+
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are "y", "yes", "t", "true", "on", and "1"; false values
+    are "n", "no", "f", "false", "off", and "0".  Raises ValueError if
+    "val" is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {val!r}")
 
 
 def get_sha(pytorch_root: str | Path) -> str:
@@ -118,7 +133,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--is-debug",
         "--is_debug",
-        type=distutils.util.strtobool,
+        type=strtobool,
         help="Whether this build is debug mode or not.",
     )
     parser.add_argument("--cuda-version", "--cuda_version", type=str)

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -9,25 +9,11 @@ from pathlib import Path
 
 from packaging.version import Version
 
+from tools.strtobool import strtobool
+
 
 UNKNOWN = "Unknown"
 RELEASE_PATTERN = re.compile(r"/v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/")
-
-
-def strtobool(val: str) -> bool:
-    """Convert a string representation of truth to true (1) or false (0).
-
-    True values are "y", "yes", "t", "true", "on", and "1"; false values
-    are "n", "no", "f", "false", "off", and "0".  Raises ValueError if
-    "val" is anything else.
-    """
-    val = val.lower()
-    if val in ("y", "yes", "t", "true", "on", "1"):
-        return True
-    elif val in ("n", "no", "f", "false", "off", "0"):
-        return False
-    else:
-        raise ValueError(f"invalid truth value {val!r}")
 
 
 def get_sha(pytorch_root: str | Path) -> str:

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -9,8 +9,6 @@ from pathlib import Path
 
 from packaging.version import Version
 
-from tools.strtobool import strtobool
-
 
 UNKNOWN = "Unknown"
 RELEASE_PATTERN = re.compile(r"/v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/")
@@ -113,6 +111,11 @@ def get_torch_version(sha: str | None = None) -> str:
 
 
 if __name__ == "__main__":
+    # Imported here so library users that load this file outside the tools
+    # package (e.g. via importlib.util.spec_from_file_location) do not need
+    # the project root on sys.path just to call get_torch_version().
+    from tools.strtobool import strtobool
+
     parser = argparse.ArgumentParser(
         description="Generate torch/version.py from build and environment metadata."
     )

--- a/tools/strtobool.py
+++ b/tools/strtobool.py
@@ -1,0 +1,22 @@
+"""Local replacement for ``distutils.util.strtobool`` (removed in Python 3.12)."""
+
+from __future__ import annotations
+
+
+_TRUE_VALUES = frozenset({"y", "yes", "t", "true", "on", "1"})
+_FALSE_VALUES = frozenset({"n", "no", "f", "false", "off", "0"})
+
+
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are "y", "yes", "t", "true", "on", and "1"; false values
+    are "n", "no", "f", "false", "off", and "0".  Raises ValueError if
+    "val" is anything else.
+    """
+    val = val.lower()
+    if val in _TRUE_VALUES:
+        return True
+    if val in _FALSE_VALUES:
+        return False
+    raise ValueError(f"invalid truth value {val!r}")

--- a/tools/test/test_strtobool.py
+++ b/tools/test/test_strtobool.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import unittest
+
+from tools.strtobool import strtobool
+
+
+class TestStrtobool(unittest.TestCase):
+    def test_truthy(self) -> None:
+        for val in (
+            "y",
+            "Y",
+            "yes",
+            "YES",
+            "Yes",
+            "t",
+            "T",
+            "true",
+            "TRUE",
+            "on",
+            "ON",
+            "1",
+        ):
+            self.assertIs(strtobool(val), True, msg=val)
+
+    def test_falsy(self) -> None:
+        for val in (
+            "n",
+            "N",
+            "no",
+            "NO",
+            "No",
+            "f",
+            "F",
+            "false",
+            "FALSE",
+            "off",
+            "OFF",
+            "0",
+        ):
+            self.assertIs(strtobool(val), False, msg=val)
+
+    def test_invalid_raises(self) -> None:
+        for val in ("", "maybe", "2", "yeah", "nope"):
+            with self.assertRaises(ValueError, msg=val):
+                strtobool(val)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Replace deprecated `distutils` usage in CI scripts and tooling, in preparation
for Python 3.12+ (where `distutils` is removed). Two patterns are handled:

- `distutils.sysconfig.get_python_lib()` → `sysconfig.get_path("purelib")` in
  `.ci/pytorch/macos-test.sh`, `.ci/pytorch/test.sh`, and
  `.ci/pytorch/smoke_test/check_binary_symbols.py`.
- `distutils.util.strtobool` → a small local replacement in
  `tools/strtobool.py`, imported by `.github/scripts/generate_pytorch_version.py`,
  `tools/generate_torch_version.py`, and `tools/alerts/create_alerts.py`.

## Suggested review order

1. `tools/strtobool.py` — the consolidated helper, semantically identical to
   the removed `distutils.util.strtobool`.
2. The three Python call sites that import it. `.github/scripts/...` uses the
   same `sys.path` shim already established in
   `.github/scripts/close_nonexistent_disable_issues.py` for cross-importing
   from `tools/`.
3. The `sysconfig` substitutions in the shell scripts and
   `check_binary_symbols.py` — mechanical.

<details>
<summary>Out of scope (intentional)</summary>

- `tools/build_pytorch_libs.py` (`distutils._msvccompiler._get_vc_env`):
  deferred to a follow-up — the API is private and the replacement is not a
  one-liner.
- `tools/setup_helpers/cmake.py` (`from distutils.version import LooseVersion`)
  and `setup.py` (`setuptools.distutils.log.warn`): both files are deleted
  outright by the scikit-build-core migration (#180248); fixing them here
  would just create merge conflicts.
- `test/run_test.py:135`'s `strtobool`: deliberately permissive
  (`s.lower() not in {"", "0", "false", "off"}`) and never raises. Switching
  to the strict distutils-style helper would change behavior for callers
  passing non-canonical truthy values such as `TEST_SHOWLOCALS=yeah`.
- Other `str2bool` variants in `benchmarks/operator_benchmark/`,
  `torch/utils/hipify/`, and `.ci/lumen_cli/` do not use `distutils` and are
  not in this PR's scope.

</details>

Replaces #180241.

Authored with Claude.
