### PR TITLE
[c10d] Use multiGet and store barrier in StoreExchange

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
@@ -74,18 +74,14 @@ class StoreExchange {
       store->set(peer_keys[rank], payload);
     }
 
+    auto payloads = store->multiGet(peer_keys);
+
     std::vector<T> peer_vals;
     peer_vals.reserve(world_size);
     for (int r = 0; r < world_size; ++r) {
-      if (r == rank) {
-        peer_vals.push_back(val);
-        continue;
-      }
-      store->wait({peer_keys[r]});
-      auto payload = store->get(peer_keys[r]);
-      TORCH_CHECK(payload.size() == sizeof(T));
+      TORCH_CHECK(payloads[r].size() == sizeof(T));
       T peer_val{};
-      std::memcpy(&peer_val, payload.data(), sizeof(T));
+      std::memcpy(&peer_val, payloads[r].data(), sizeof(T));
       peer_vals.push_back(peer_val);
     }
     return peer_vals;
@@ -95,8 +91,11 @@ class StoreExchange {
       const c10::intrusive_ptr<c10d::Store>& store,
       int rank,
       int world_size) {
-    // TODO: implement an efficient one?
-    all_gather(store, rank, world_size, 0);
+    (void)rank;
+    std::ostringstream oss;
+    oss << store_prefix_ << '/' << seq_id_;
+    ++seq_id_;
+    store->barrier(oss.str(), world_size);
   }
 
  private:


### PR DESCRIPTION
## Summary
- Replace per-rank `wait`+`get` loop in `StoreExchange::all_gather` with a single `Store::multiGet` call, reducing network round trips from 2*(world_size-1) to 1 on TCPStore.
- Replace the `all_gather`-based barrier with `Store::barrier`, which performs an atomic server-side increment+wait in a single RPC on TCPStore (resolves the prior TODO).

## Test plan
- [ ] Lint passes (verified locally via `spin lint`)
- [ ] CI: distributed symmetric memory tests (`test/distributed/test_symmetric_memory.py`)
- [ ] CI: store tests (`test/distributed/test_store.py`) validate the underlying `multiGet` and `barrier` APIs