### PR TITLE
Allow torch.arange() to return empty tensor when bounds are inconsistent with step sign

### DIFF
--- a/aten/src/ATen/native/RangeUtils.h
+++ b/aten/src/ATen/native/RangeUtils.h
@@ -22,9 +22,6 @@ inline void arange_check_bounds(
       dstart,
       " -> ",
       dend);
-  TORCH_CHECK(
-      ((dstep > 0) && (dend >= dstart)) || ((dstep < 0) && (dend <= dstart)),
-      "upper bound and lower bound inconsistent with step sign");
 }
 
 template <typename scalar_t>
@@ -50,6 +47,7 @@ int64_t compute_arange_size(const Scalar& start, const Scalar& end, const Scalar
     size_d = std::ceil((end.to<double>() - start.to<double>())
                         / step.to<double>());
   }
+  size_d = std::max(size_d, 0.0);
 
   TORCH_CHECK(size_d >= 0 && size_d <= static_cast<double>(std::numeric_limits<int64_t>::max()),
             "invalid size, possible overflow?");

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5345,16 +5345,6 @@ def arange(
         end = start
         start = 0
     torch._check(step != 0, lambda: "step must be nonzero")
-    if step > 0:
-        torch._check(
-            end >= start,
-            lambda: "upper bound and lower bound inconsistent with step sign",
-        )
-    elif step < 0:
-        torch._check(
-            end <= start,
-            lambda: "upper bound and lower bound inconsistent with step sign",
-        )
 
     def is_finite(x):
         return not isinstance(x, FloatWithoutSymFloat) or math.isfinite(x)
@@ -5388,6 +5378,7 @@ def arange(
         length = (xend - xstart + xstep - sgn) // xstep  # type: ignore[possibly-undefined]
     else:
         length = math.ceil((end - start) / step)
+    length = builtins.max(length, 0)
 
     if is_integer:
         return prims.iota(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -788,12 +788,6 @@ def sample_inputs_add_sub(op, device, dtype, requires_grad, **kwargs):
 
 def error_inputs_arange(op, device, **kwargs):
     yield ErrorInput(SampleInput(0, args=(3, 0)), error_type=RuntimeError, error_regex='step must be nonzero')
-    yield ErrorInput(SampleInput(0, args=(-3, 2)), error_type=RuntimeError,
-                     error_regex='upper bound and lower bound inconsistent with step sign')
-    yield ErrorInput(SampleInput(0, args=(3, -2)), error_type=RuntimeError,
-                     error_regex='upper bound and lower bound inconsistent with step sign')
-    yield ErrorInput(SampleInput(1549556900, args=(1549556828, 1989724)), error_type=RuntimeError,
-                     error_regex='upper bound and lower bound inconsistent with step sign')
     yield ErrorInput(SampleInput(0, args=(float('inf'), 2)), error_type=RuntimeError, error_regex='unsupported range')
     yield ErrorInput(SampleInput(float('-inf'), args=(1, 2)), error_type=RuntimeError, error_regex='unsupported range')
 


### PR DESCRIPTION
Fixes #70915

Per the Array API Standard, `torch.arange(start, stop, step)` should return
an empty tensor when `stop-start` and `step` have opposite signs, rather than
raising a RuntimeError. This aligns with NumPy's behavior.

**Before:**
```python
torch.arange(1, 0)      # RuntimeError: upper bound and lower bound inconsistent with step sign
torch.arange(0, 1, -1)  # RuntimeError

**After:**
torch.arange(1, 0)      # tensor([], dtype=torch.int64)
torch.arange(0, 1, -1)  # tensor([], dtype=torch.int64)

**Changes:**
aten/src/ATen/native/RangeUtils.h: remove inconsistent-bounds check from arange_check_bounds; clamp size_d to 0 in compute_arange_size
torch/_refs/__init__.py: remove corresponding Python-layer check; clamp length to 0
torch/testing/_internal/common_methods_invocations.py: remove now-valid inputs from error_inputs_arange