### PR TITLE
[dynamo] Handle typing._GenericAlias in SourcelessBuilder

### DIFF
--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -35,6 +35,7 @@ import re
 import sys
 import time
 import types
+import typing
 import weakref
 from collections.abc import Callable, MutableMapping
 from types import ModuleType
@@ -4381,7 +4382,16 @@ class SourcelessBuilder:
             return torch._dynamo.variables.higher_order_ops.FlexAttentionBackwardHighOrderVariable(
                 value
             )
-        elif isinstance(value, (types.GenericAlias, types.UnionType)):
+        elif isinstance(
+            value,
+            (types.GenericAlias, types.UnionType, typing._GenericAlias),  # type: ignore[attr-defined]
+        ):
+            # types.GenericAlias: PEP 585 (e.g. list[int])
+            # types.UnionType:    PEP 604 (e.g. int | None)
+            # typing._GenericAlias: subscripted typing/Generic[T] classes
+            #   (e.g. typing.List[int], CallInfo[None] for Generic[T] dataclasses).
+            #   Surfaced after the pytest 7 -> 9 bump because pytest 9 added an
+            #   addSubTest hook in _pytest.unittest that calls CallInfo[None](...).
             return TypingVariable(value)
         elif is_namedtuple(value):
             output = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182135
* #182134

After the pytest 7 -> 9 bump, dynamo_cpython tests started failing on
ComplexTest.test_pow with `Unsupported: SourcelessBuilder.create does not
know how to wrap <class 'typing._GenericAlias'>`. pytest 9 added an
addSubTest hook to _pytest/unittest.py (pytest 7 had no subTest support
at all) whose body is `call_info = CallInfo[None](...)`. CallInfo is a
Generic[T] dataclass, and on subscripting it produces a
`typing._GenericAlias` rather than a `types.GenericAlias` (the PEP 585
runtime form) — only the latter was handled by SourcelessBuilder.create.

CPythonTestCase enables `enable_trace_unittest=True` and runs with
`dynamo_strict_nopython=True`, so dynamo traces all the way into pytest's
addSubTest and the unhandled type is fatal.

Add `typing._GenericAlias` to the same isinstance branch that already
handles `types.GenericAlias` and `types.UnionType`. They are conceptually
the same surface (a subscripted/parameterised type) and TypingVariable
already knows how to handle the value.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98