### PR TITLE
Update torchcomms.txt commit hash

### DIFF
--- a/.github/ci_commit_pins/torchcomms.txt
+++ b/.github/ci_commit_pins/torchcomms.txt
@@ -1,1 +1,1 @@
-567c9737f1fbc81ba3fd52b891b5d99bbfafa5ec
+33fbfdd1ebb278d8a9ed9b500d401c3c8df9a7f1


### PR DESCRIPTION
This bumps the commit hash to in theory fix the update bot. The previous hash was valid but not from main which is causing issues.

https://github.com/meta-pytorch/torchcomms/commit/33fbfdd1ebb278d8a9ed9b500d401c3c8df9a7f1

https://github.com/pytorch/pytorch/actions/runs/25196853559/job/73879319979

Test plan:

CI