### PR TITLE
Avoid raw stream name collisions in Inductor

### DIFF
--- a/test/inductor/test_user_streams.py
+++ b/test/inductor/test_user_streams.py
@@ -25,7 +25,7 @@ from torch._inductor.stream_constants import (
     DEFAULT_STREAM_IDX,
     STREAM_NAME_TEMPLATE,
 )
-from torch._inductor.stream_utils import get_stream_name
+from torch._inductor.stream_utils import get_raw_stream_name, get_stream_name
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import IndentedBuffer
 from torch.testing import FileCheck
@@ -123,6 +123,10 @@ class TestStreamUtils(InductorTestCase):
         self.assertEqual(get_stream_name(1), "stream1")
         self.assertEqual(get_stream_name(2), "stream2")
         self.assertEqual(get_stream_name(10), "stream10")
+
+    def test_get_raw_stream_name(self):
+        self.assertEqual(get_raw_stream_name(0), "raw_stream0")
+        self.assertEqual(get_raw_stream_name(1), "raw_stream1")
 
     def test_get_stream_name_cached(self):
         """Test that get_stream_name results are cached."""
@@ -227,6 +231,47 @@ class TestUserStreamCompile(InductorTestCase):
         # Verify generated code contains stream handling and synchronize survives
         self.assertIn("torch.cuda.stream", code)
         self.assertIn("synchronize_stream", code)
+
+    @unittest.skipIf(
+        not TEST_CUDA or torch.cuda.device_count() < 2,
+        "requires at least two CUDA devices",
+    )
+    def test_raw_stream_name_does_not_clobber_user_stream_on_cuda_1(self):
+        from torch._inductor.utils import run_and_get_code
+
+        device = torch.device("cuda:1")
+        aux = torch.cuda.Stream(device=device)
+        ev0 = torch.cuda.Event()
+        ev1 = torch.cuda.Event()
+
+        def fn(x, w):
+            ev0.record()
+            with torch.cuda.stream(aux):
+                ev0.wait()
+                a = torch.mm(x, w)
+                ev1.record()
+
+            ev1.wait()
+            c = (a.sin() * a.cos() + 0.1).relu()
+
+            with torch.cuda.stream(aux):
+                d = torch.mm(c, w.t())
+
+            return d
+
+        x = torch.randn(64, 128, device=device)
+        w = torch.randn(128, 64, device=device)
+
+        expected = fn(x, w)
+        torch.cuda.synchronize()
+
+        actual, (code,) = run_and_get_code(torch.compile(fn, fullgraph=True), x, w)
+        torch.cuda.synchronize()
+
+        self.assertEqual(actual, expected)
+        self.assertIn("stream1 = get_external_object_by_index", code)
+        self.assertIn("raw_stream1 = get_raw_stream(1)", code)
+        self.assertNotRegex(code, r"(?m)^\s*stream1 = get_raw_stream\(1\)")
 
     def test_compile_preserves_stream_semantics(self):
         """Test that compiled code preserves stream execution semantics."""
@@ -1190,8 +1235,8 @@ with torch.cuda._DeviceGuard(0):
         triton_kernel.run(arg0_1, buf0, 1024, stream=raw_stream)
     with torch.cuda.stream(default_stream):
         buf3 = empty_strided_cuda((1024, ), (1, ), torch.float32)
-        stream0 = get_raw_stream(0)
-        triton_kernel.run(arg0_1, buf0, buf3, 1024, stream=stream0)
+        raw_stream0 = get_raw_stream(0)
+        triton_kernel.run(arg0_1, buf0, buf3, 1024, stream=raw_stream0)
         torch.ops.streams.synchronize_stream.default(1)
     return (buf3, )""",
         )

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -66,6 +66,7 @@ from ..scheduler import (
     SchedulerNode,
 )
 from ..shape_propagation import get_broadcasted_shape
+from ..stream_utils import get_raw_stream_name
 from ..utils import (
     cache_on_self,
     DelayReplaceLine,
@@ -5465,7 +5466,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 result.writeline(
                     V.graph.device_ops.set_device(index)
                 )  # no-op to ensure context
-                stream_name = f"stream{index}"
+                stream_name = get_raw_stream_name(index)
                 result.writeline(f"{stream_name} = get_raw_stream({index})")
                 result.writeline(
                     f"{str(Placeholder.KERNEL_NAME)}.run(*args, stream={stream_name})"

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -20,6 +20,7 @@ from ..runtime.triton_heuristics import (
     SequentialFlattenComboKernelGrid,
 )
 from ..scheduler import BaseSchedulerNode
+from ..stream_utils import get_raw_stream_name
 from ..utils import Placeholder, triton_version_uses_attrs_dict
 from ..virtualized import V
 from .common import (
@@ -1071,7 +1072,7 @@ class ComboKernel(Kernel):
                 result.writeline(
                     V.graph.device_ops.set_device(index)
                 )  # no-op to ensure context
-                stream_name = f"stream{index}"
+                stream_name = get_raw_stream_name(index)
                 result.writeline(f"{stream_name} = get_raw_stream({index})")
                 result.writeline(
                     f"{str(Placeholder.KERNEL_NAME)}.run(*args, stream={stream_name})"

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -48,7 +48,7 @@ from ..ir import IRNode, ReinterpretView
 from ..runtime import triton_heuristics
 from ..runtime.hints import DeviceProperties
 from ..stream_constants import DEFAULT_STREAM, DEFAULT_STREAM_IDX, STREAM_NAME_TEMPLATE
-from ..stream_utils import get_stream_name
+from ..stream_utils import get_raw_stream_name, get_stream_name
 from ..utils import (
     cache_on_self,
     DelayReplaceLine,
@@ -1717,7 +1717,7 @@ class PythonWrapperCodegen(CodeGen):
     # is important for nested subgraph codegening.
     def write_get_raw_stream(self, device_idx: int, graph_name: str) -> str:
         self.write_get_raw_stream_header()
-        name = f"stream{device_idx}"
+        name = get_raw_stream_name(device_idx)
         if config.triton.autotune_at_compile_time:
             self.kernel_autotune_calls.writeline(
                 f"{name} = get_raw_stream({device_idx})"
@@ -1787,7 +1787,7 @@ class PythonWrapperCodegen(CodeGen):
                 # Need get_raw_stream for subgraph
                 self.write_get_raw_stream_header()
             self.kernel_autotune_calls.writeline(
-                f"stream{device_idx} = get_raw_stream({device_idx})"
+                f"{get_raw_stream_name(device_idx)} = get_raw_stream({device_idx})"
             )
         self.last_seen_device_guard_index = device_idx
         self._num_streams: int = num_streams
@@ -4313,7 +4313,7 @@ class SubgraphPythonWrapperCodegen(PythonWrapperCodegen):
             name = f"{current_stream_name}_raw"
             self.writeline(f"{name} = {current_stream_name}.cuda_stream")
         else:
-            name = f"stream{device_idx}"
+            name = get_raw_stream_name(device_idx)
             self.writeline(f"{name} = get_raw_stream({device_idx})")
         return name
 

--- a/torch/_inductor/stream_utils.py
+++ b/torch/_inductor/stream_utils.py
@@ -15,6 +15,7 @@ __all__ = [
     "DEFAULT_STREAM",
     "DEFAULT_STREAM_IDX",
     "STREAM_NAME_TEMPLATE",
+    "get_raw_stream_name",
     "get_stream_name",
 ]
 
@@ -31,3 +32,9 @@ def get_stream_name(stream_idx: int) -> str:
         return DEFAULT_STREAM
     else:
         return STREAM_NAME_TEMPLATE.format(stream_idx=stream_idx)
+
+
+@functools.lru_cache
+def get_raw_stream_name(device_idx: int) -> str:
+    """Generate variable name for a raw stream handle on the given device."""
+    return f"raw_stream{device_idx}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182139

Use raw_streamN for generated raw CUDA stream handles so they cannot clobber user stream object bindings such as stream1. Add a CUDA:1 regression test covering the aux-stream, Triton-launch, aux-stream ordering that previously crashed.

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos