### PR TITLE
fix multi backends for torchcomms

### DIFF
--- a/test/distributed/test_c10d_split_group.py
+++ b/test/distributed/test_c10d_split_group.py
@@ -165,6 +165,66 @@ class SplitGroupBackendWrapperTest(SplitGroupTestBase):
     def test_split_group_mixed_backend_subgroups(self):
         self._test_split_group_mixed_backend_subgroups()
 
+    def _assert_mixed_backend_wrappers_are_distinct(self, pg):
+        """Assert pg has separate _BackendWrapper objects per device, each
+        wrapping its declared underlying backend.
+
+        Regression guard: when ProcessGroup::setBackend deduplicated by
+        BackendType and torchcomms registered every wrapper as
+        BackendType.CUSTOM, the second register call (cuda → nccl) silently
+        reused the first (gloo) wrapper. The functional split_group tests
+        above pass even with that bug because TorchCommGloo.all_reduce on a
+        cuda tensor copies to CPU + runs gloo + copies back, so the math is
+        right. This identity check fails fast instead.
+        """
+        try:
+            from torchcomms._comms import _BackendWrapper
+        except ImportError:
+            from torchcomms._backend_wrapper import _BackendWrapper
+
+        cuda_backend = pg._get_backend(torch.device("cuda"))
+        cpu_backend = pg._get_backend(torch.device("cpu"))
+
+        self.assertIsNot(
+            cuda_backend,
+            cpu_backend,
+            "cuda and cpu backends share an object — ProcessGroup::setBackend "
+            "deduplicated distinct torchcomms wrappers (was BackendType.CUSTOM "
+            "for both); cuda collectives would silently route through gloo.",
+        )
+        self.assertIsInstance(cuda_backend, _BackendWrapper)
+        self.assertIsInstance(cpu_backend, _BackendWrapper)
+        self.assertEqual(cuda_backend.get_comm().get_backend(), "nccl")
+        self.assertEqual(cpu_backend.get_comm().get_backend(), "gloo")
+
+    @skip_if_lt_x_gpu(4)
+    @dist_config.patch(use_torchcomms=True)
+    @_with_torchcomm_env
+    def test_mixed_backend_init_uses_distinct_per_device_wrappers(self):
+        """Right after init_process_group('cpu:gloo,cuda:nccl'), the WORLD PG
+        must hold distinct nccl + gloo wrappers, not a single deduplicated
+        wrapper reused for both devices."""
+        self._init_pg("cpu:gloo,cuda:nccl")
+        try:
+            self._assert_mixed_backend_wrappers_are_distinct(dist.group.WORLD)
+        finally:
+            dist.destroy_process_group()
+
+    @skip_if_lt_x_gpu(4)
+    @dist_config.patch(use_torchcomms=True)
+    @_with_torchcomm_env
+    def test_split_group_mixed_backend_keeps_per_device_wrappers(self):
+        """split_group on a mixed cpu:gloo,cuda:nccl parent must produce a
+        child PG that also has distinct nccl + gloo wrappers. (split_group
+        re-invokes _new_process_group_helper, so the same dedup bug
+        applies.)"""
+        self._init_pg("cpu:gloo,cuda:nccl")
+        try:
+            split_pg = dist.split_group(split_ranks=[list(range(self.world_size))])
+            self._assert_mixed_backend_wrappers_are_distinct(split_pg)
+        finally:
+            dist.destroy_process_group()
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_c10d_split_group.py
+++ b/test/distributed/test_c10d_split_group.py
@@ -1,0 +1,170 @@
+# Owner(s): ["oncall: distributed"]
+
+import functools
+import os
+import sys
+import unittest
+
+import torch
+import torch.distributed as dist
+
+
+if not dist.is_available() or not dist.is_nccl_available():
+    print("c10d NCCL not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+from torch.distributed import config as dist_config
+from torch.distributed.distributed_c10d import _TORCHCOMM_AVAILABLE
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    skip_if_lt_x_gpu,
+)
+from torch.testing._internal.common_utils import run_tests
+
+
+def _with_torchcomm_env(func):
+    """Sets TORCHCOMM env vars needed by torchcomms before init_pg runs."""
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        os.environ["TORCHCOMM_RANK"] = str(self.rank)
+        os.environ["TORCHCOMM_SIZE"] = str(self.world_size)
+        os.environ["TORCHCOMM_STORE_PATH"] = self.file_name
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29500"
+        try:
+            return func(self, *args, **kwargs)
+        finally:
+            os.environ.pop("TORCHCOMM_RANK", None)
+            os.environ.pop("TORCHCOMM_SIZE", None)
+            os.environ.pop("TORCHCOMM_STORE_PATH", None)
+            os.environ.pop("MASTER_ADDR", None)
+            os.environ.pop("MASTER_PORT", None)
+
+    return wrapper
+
+
+class SplitGroupTestBase(MultiProcessTestCase):
+    """Base class with common setup, teardown, and helpers for split_group tests."""
+
+    def setUp(self):
+        super().setUp()
+        os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "1"
+        self._spawn_processes()
+
+    def tearDown(self):
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    _use_device_id = True
+
+    def _init_pg(self, backend):
+        """Initialize default process group with the given backend string."""
+        store = dist.FileStore(self.file_name, self.world_size)
+        device = torch.device(f"cuda:{self.rank}")
+        torch.cuda.set_device(device)
+        dist.init_process_group(
+            backend=backend,
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+            device_id=device if self._use_device_id else None,
+        )
+        return device
+
+    def _verify_gpu_allreduce(self, group, device, expected_world_size):
+        """Verify all_reduce works on GPU for a process group."""
+        gpu_tensor = torch.ones(10, device=device)
+        dist.all_reduce(gpu_tensor, group=group)
+        self.assertTrue(torch.all(gpu_tensor == expected_world_size))
+
+    def _verify_cpu_allreduce(self, group, expected_world_size):
+        """Verify all_reduce works on CPU for a process group."""
+        gpu_tensor = torch.ones(10)
+        dist.all_reduce(gpu_tensor, group=group)
+        self.assertTrue(torch.all(gpu_tensor == expected_world_size))
+
+    def _verify_allreduce_on_split(self, group, device, expected_world_size):
+        """Verify all_reduce works on both GPU and CPU for a process group."""
+        self._verify_gpu_allreduce(group, device, expected_world_size)
+        self._verify_cpu_allreduce(group, expected_world_size)
+
+    def _split_into_halves(self):
+        """Return split_ranks that divide world into two equal halves."""
+        split_size = self.world_size // 2
+        return [
+            list(range(i * split_size, (i + 1) * split_size))
+            for i in range(self.world_size // split_size)
+        ]
+
+    def _test_split_group_mixed_backend(self):
+        """Test split_group with cpu:gloo,cuda:nccl splits both backends on default pg."""
+        device = self._init_pg("cpu:gloo,cuda:nccl")
+
+        all_ranks = list(range(self.world_size))
+        split_pg = dist.split_group(split_ranks=[all_ranks])
+
+        self._verify_allreduce_on_split(split_pg, device, self.world_size)
+
+        dist.destroy_process_group()
+
+    def _test_split_group_mixed_backend_subgroups(self):
+        """Test split_group with mixed backend creates correct subgroups on default pg."""
+        device = self._init_pg("cpu:gloo,cuda:nccl")
+
+        split_ranks = self._split_into_halves()
+        split_size = self.world_size // 2
+        split_pg = dist.split_group(split_ranks=split_ranks)
+
+        self.assertEqual(split_pg.size(), split_size)
+        self._verify_allreduce_on_split(split_pg, device, split_size)
+
+        dist.destroy_process_group()
+
+
+class SplitGroupNativeBackendTest(SplitGroupTestBase):
+    """Tests for split_group using native NCCL/Gloo backends (no torchcomms)."""
+
+    @property
+    def world_size(self):
+        return 4
+
+    @skip_if_lt_x_gpu(4)
+    def test_split_group_mixed_backend(self):
+        self._test_split_group_mixed_backend()
+
+    @skip_if_lt_x_gpu(4)
+    def test_split_group_mixed_backend_subgroups(self):
+        self._test_split_group_mixed_backend_subgroups()
+
+
+@unittest.skipIf(
+    not _TORCHCOMM_AVAILABLE, "TorchComms is not installed, skipping torchcomms tests"
+)
+class SplitGroupBackendWrapperTest(SplitGroupTestBase):
+    """Tests for split_group via BackendWrapper (torchcomms-backed process groups)."""
+
+    _use_device_id = False
+
+    @property
+    def world_size(self):
+        return 4
+
+    @skip_if_lt_x_gpu(4)
+    @dist_config.patch(use_torchcomms=True)
+    @_with_torchcomm_env
+    def test_split_group_mixed_backend(self):
+        self._test_split_group_mixed_backend()
+
+    @skip_if_lt_x_gpu(4)
+    @dist_config.patch(use_torchcomms=True)
+    @_with_torchcomm_env
+    def test_split_group_mixed_backend_subgroups(self):
+        self._test_split_group_mixed_backend_subgroups()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2080,7 +2080,23 @@ def _new_process_group_helper(
             _world.comms.append(comm)
             group_name = GroupName(group_name)
             backend_class = _BackendWrapper(comm)
-            backend_type = ProcessGroup.BackendType.CUSTOM
+            # Map each torchcomms wrapper to its underlying backend's canonical
+            # type so ProcessGroup::setBackend doesn't deduplicate distinct
+            # wrappers in mixed-backend PGs (e.g. cpu:gloo,cuda:nccl). With
+            # BackendType.CUSTOM, the second _register_backend call would
+            # silently reuse the first (gloo) wrapper for cuda lookups,
+            # causing dist.all_gather_into_tensor on cuda tensors to route
+            # through TorchCommGloo + CPU round-trip.
+            _torchcomms_backend_type_map = {
+                Backend.NCCL: ProcessGroup.BackendType.NCCL,
+                Backend.GLOO: ProcessGroup.BackendType.GLOO,
+                Backend.UCC: ProcessGroup.BackendType.UCC,
+                Backend.MPI: ProcessGroup.BackendType.MPI,
+                Backend.XCCL: ProcessGroup.BackendType.XCCL,
+            }
+            backend_type = _torchcomms_backend_type_map.get(
+                backend_str, ProcessGroup.BackendType.CUSTOM
+            )
         elif backend_str == Backend.MPI:
             if not is_mpi_available():
                 raise RuntimeError(


### PR DESCRIPTION

Summary:
Issue in PyTorch's `ProcessGroup::setBackend` (C++): it deduplicates
backends by `BackendType`, and torchcomms's shim hook
(`distributed_c10d.py:2042-2061`) registered every wrapper as
`BackendType.CUSTOM`. So in a mixed `cpu:gloo,cuda:nccl` PG, the second call
(`cuda → nccl wrapper`) hit the dedup branch and silently *reused the first
(gloo) wrapper* for the cuda device. Every subsequent
`dist.{all_reduce,all_gather,broadcast}(group=pg)` on a cuda tensor then
routed through `TorchCommGloo`, which copies to CPU + runs gloo + copies back.

**The fix is one targeted change in `distributed_c10d.py`**: when registering
a torchcomms `_BackendWrapper`, use the underlying backend's canonical type
(`BackendType.NCCL` for nccl, `BackendType.GLOO` for gloo, etc.) instead of
the catch-all `BackendType.CUSTOM`. Distinct types → no dedup → both wrappers
survive in the per-device map.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/pytorch/pull/182142).
* __->__ #182142
* #181431