### PR TITLE
[caffe2] Add defensive fallback in get_logging_handler for unknown destinations (#182146)

### DIFF
--- a/torch/distributed/elastic/events/handlers.py
+++ b/torch/distributed/elastic/events/handlers.py
@@ -18,4 +18,14 @@ _log_handlers: dict[str, logging.Handler] = {
 
 def get_logging_handler(destination: str = "null") -> logging.Handler:
     global _log_handlers
+    if destination not in _log_handlers:
+        logger = logging.getLogger(__name__)
+        if logger.isEnabledFor(logging.WARNING):
+            logger.warning(
+                "Unknown event log handler %r, falling back to 'null'. "
+                "Available handlers: %s",
+                destination,
+                list(_log_handlers.keys()),
+            )
+        destination = "null"
     return _log_handlers[destination]


### PR DESCRIPTION
Summary:

When `PET_EVENT_LOG_HANDLER` is set to a handler name that doesn't exist in the `_log_handlers` dict (e.g., stale fbpkg built before a new handler was registered), `get_logging_handler()` previously threw a raw `KeyError` that crashed the elastic agent worker.

Now falls back to the `"null"` handler with a warning instead. Applied to both the FB override and OSS version.

Test Plan: Existing tests pass. The fallback is exercised when a stale fbpkg doesn't have the handler registered.

Differential Revision: D102715949


