### PR TITLE
[inductor] Expose torchbind constants from AOTIModelPackageLoader

### DIFF
--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -1,0 +1,87 @@
+# Owner(s): ["module: inductor"]
+
+import torch
+from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_utils import IS_FBCODE, run_tests
+from torch.testing._internal.inductor_utils import HAS_CUDA
+
+
+class TestTorchbindAOTI(TestCase):
+    """Verify that torchbind constants embedded in an AOTI .pt2 are reachable
+    via AOTIModelPackageLoader.get_custom_objs() after load.
+
+    Backends (e.g. torch-tensorrt) need post-load access to torchbind
+    constants to mutate runtime state (stream binding, comm binding, profiling
+    toggles). Before this accessor existed, the IValues lived in
+    OSSProxyExecutor::custom_objs_ with no public way out.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if IS_FBCODE:
+            torch.ops.load_library(
+                "//caffe2/test/cpp/jit:test_custom_class_registrations"
+            )
+        else:
+            lib_file_path = torch.utils.cpp_extension.find_torchbind_library(
+                "torchbind_test"
+            )
+            torch.ops.load_library(str(lib_file_path))
+        super().setUpClass()
+
+    def _make_model(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.attr = torch.classes._TorchScriptTesting._Foo(10, 20)
+
+            def forward(self, x):
+                return self.attr.add_tensor(x) + x
+
+        return M()
+
+    def test_custom_objs_exposed_through_loader(self):
+        device = "cuda" if HAS_CUDA else "cpu"
+        m = self._make_model().to(device)
+        x = torch.randn(2, 3, device=device)
+        ep = torch.export.export(m, (x,), strict=False)
+
+        with torch._inductor.config.patch("aot_inductor.package", True):
+            pt2_path = torch._inductor.aoti_compile_and_package(ep)
+
+        loader = torch._C._aoti.AOTIModelPackageLoader(pt2_path, "model")
+        custom_objs = loader.get_custom_objs()
+
+        self.assertGreater(
+            len(custom_objs),
+            0,
+            msg="Expected at least one torchbind constant, got none",
+        )
+        any_torchbind = next(iter(custom_objs.values()))
+        # The IValue payload must be a real custom class instance.
+        self.assertTrue(
+            isinstance(any_torchbind, torch.ScriptObject)
+            or hasattr(any_torchbind, "_type"),
+            msg=f"Expected a torchbind ScriptObject, got {type(any_torchbind)}",
+        )
+
+    def test_custom_objs_empty_when_no_torchbind(self):
+        # A plain model with no torchbind attrs should yield an empty map.
+        class Plain(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        device = "cuda" if HAS_CUDA else "cpu"
+        m = Plain().to(device)
+        x = torch.randn(2, 3, device=device)
+        ep = torch.export.export(m, (x,), strict=False)
+
+        with torch._inductor.config.patch("aot_inductor.package", True):
+            pt2_path = torch._inductor.aoti_compile_and_package(ep)
+
+        loader = torch._C._aoti.AOTIModelPackageLoader(pt2_path, "model")
+        self.assertEqual(loader.get_custom_objs(), {})
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -3,7 +3,9 @@
 import torch
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import IS_FBCODE, run_tests
-from torch.testing._internal.inductor_utils import HAS_CUDA
+
+
+HAS_CUDA = torch.cuda.is_available()
 
 
 class TestTorchbindAOTI(TestCase):

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -3,7 +3,7 @@
 import torch
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import run_tests
-from torch.testing._internal.torchbind_impls import load_torchbind_test_lib
+from torch.testing._internal.torchbind_impls import init_torchbind_implementations
 
 
 HAS_CUDA = torch.cuda.is_available()
@@ -21,8 +21,9 @@ class TestTorchbindAOTI(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # Canonical helper that handles FBCODE / Linux / macOS / Windows.
-        load_torchbind_test_lib()
+        # Loads the test torchbind library AND registers fake classes for
+        # _Foo / _TensorQueue / etc. needed by torch.export tracing.
+        init_torchbind_implementations()
         super().setUpClass()
 
     def _make_model(self):

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -88,7 +88,8 @@ class TestTorchbindAOTI(TestCase):
             obj
             for obj in custom_objs.values()
             if isinstance(obj, torch.ScriptObject)
-            and obj._type().qualified_name() == "__torch__.torch.classes._TorchScriptTesting._Foo"
+            and obj._type().qualified_name()
+            == "__torch__.torch.classes._TorchScriptTesting._Foo"
         )
         foo.increment(5)
 

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -44,7 +44,7 @@ class TestTorchbindAOTI(TestCase):
 
         pt2_path = torch._inductor.aoti_compile_and_package(ep)
 
-        loader = torch._C._aoti.AOTIModelPackageLoader(pt2_path, "model")
+        loader = torch._C._aoti.AOTIModelPackageLoader(pt2_path, "model", False, 1, -1)
         custom_objs = loader.get_custom_objs()
 
         self.assertGreater(
@@ -73,7 +73,7 @@ class TestTorchbindAOTI(TestCase):
 
         pt2_path = torch._inductor.aoti_compile_and_package(ep)
 
-        loader = torch._C._aoti.AOTIModelPackageLoader(pt2_path, "model")
+        loader = torch._C._aoti.AOTIModelPackageLoader(pt2_path, "model", False, 1, -1)
         self.assertEqual(loader.get_custom_objs(), {})
 
 

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -61,6 +61,41 @@ class TestTorchbindAOTI(TestCase):
             msg=f"Expected a torchbind ScriptObject, got {type(any_torchbind)}",
         )
 
+    def test_mutating_custom_obj_after_load_affects_run(self):
+        # The central contract: IValues returned by get_custom_objs() share
+        # intrusive_ptr ownership with the live entries inside
+        # OSSProxyExecutor::custom_objs_, so mutating state on the returned
+        # custom-class instance affects subsequent run() invocations.
+        # Forward computes self.attr.add_tensor(x) + x, where Foo.add_tensor
+        # returns (x + y) * z. Foo.increment(k) does x += k, y += k.
+        device = "cuda" if HAS_CUDA else "cpu"
+        m = self._make_model().to(device)  # Foo(10, 20), so x+y == 30
+        x = torch.randn(2, 3, device=device)
+        ep = torch.export.export(m, (x,), strict=False)
+
+        pt2_path = torch._inductor.aoti_compile_and_package(ep)
+        loader = torch._C._aoti.AOTIModelPackageLoader(pt2_path, "model", False, 1, -1)
+
+        # Baseline: (x + y == 30) * x + x
+        before = loader.run([x])[0]
+        torch.testing.assert_close(before, 30 * x + x)
+
+        # Mutate the live torchbind object via the snapshot returned by
+        # get_custom_objs(). After Foo.increment(5) we have (15, 25), so
+        # x + y == 40.
+        custom_objs = loader.get_custom_objs()
+        foo = next(
+            obj
+            for obj in custom_objs.values()
+            if isinstance(obj, torch.ScriptObject)
+            and obj._type().qualified_name() == "__torch__.torch.classes._TorchScriptTesting._Foo"
+        )
+        foo.increment(5)
+
+        # Re-run: the executor must observe the mutated state.
+        after = loader.run([x])[0]
+        torch.testing.assert_close(after, 40 * x + x)
+
     def test_custom_objs_empty_when_no_torchbind(self):
         # A plain model with no torchbind attrs should yield an empty map.
         class Plain(torch.nn.Module):

--- a/test/inductor/test_aoti_torchbind_constants.py
+++ b/test/inductor/test_aoti_torchbind_constants.py
@@ -2,7 +2,8 @@
 
 import torch
 from torch._inductor.test_case import TestCase
-from torch.testing._internal.common_utils import IS_FBCODE, run_tests
+from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.torchbind_impls import load_torchbind_test_lib
 
 
 HAS_CUDA = torch.cuda.is_available()
@@ -20,15 +21,8 @@ class TestTorchbindAOTI(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if IS_FBCODE:
-            torch.ops.load_library(
-                "//caffe2/test/cpp/jit:test_custom_class_registrations"
-            )
-        else:
-            lib_file_path = torch.utils.cpp_extension.find_torchbind_library(
-                "torchbind_test"
-            )
-            torch.ops.load_library(str(lib_file_path))
+        # Canonical helper that handles FBCODE / Linux / macOS / Windows.
+        load_torchbind_test_lib()
         super().setUpClass()
 
     def _make_model(self):
@@ -48,8 +42,7 @@ class TestTorchbindAOTI(TestCase):
         x = torch.randn(2, 3, device=device)
         ep = torch.export.export(m, (x,), strict=False)
 
-        with torch._inductor.config.patch("aot_inductor.package", True):
-            pt2_path = torch._inductor.aoti_compile_and_package(ep)
+        pt2_path = torch._inductor.aoti_compile_and_package(ep)
 
         loader = torch._C._aoti.AOTIModelPackageLoader(pt2_path, "model")
         custom_objs = loader.get_custom_objs()
@@ -78,8 +71,7 @@ class TestTorchbindAOTI(TestCase):
         x = torch.randn(2, 3, device=device)
         ep = torch.export.export(m, (x,), strict=False)
 
-        with torch._inductor.config.patch("aot_inductor.package", True):
-            pt2_path = torch._inductor.aoti_compile_and_package(ep)
+        pt2_path = torch._inductor.aoti_compile_and_package(ep)
 
         loader = torch._C._aoti.AOTIModelPackageLoader(pt2_path, "model")
         self.assertEqual(loader.get_custom_objs(), {})

--- a/torch/csrc/inductor/aoti_package/model_package_loader.h
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.h
@@ -36,6 +36,17 @@ class TORCH_API AOTIModelPackageLoader {
       bool user_managed = false);
   std::vector<std::string> get_constant_fqns();
 
+  // Returns the torchbind custom-class constants embedded in this model
+  // package. The IValue payloads alias the live entries inside the runner's
+  // proxy executor: downcasting to a CustomClassHolder subclass and mutating
+  // its state will affect subsequent run() invocations. Returns empty when
+  // the model has no torchbind constants.
+  std::unordered_map<std::string, c10::IValue> get_custom_objs() const {
+    return runner_
+        ? runner_->get_custom_objs()
+        : std::unordered_map<std::string, c10::IValue>{};
+  }
+
   void update_constant_buffer(
       std::unordered_map<std::string, at::Tensor>& tensor_map,
       bool use_inactive,

--- a/torch/csrc/inductor/aoti_package/model_package_loader.h
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.h
@@ -42,9 +42,8 @@ class TORCH_API AOTIModelPackageLoader {
   // its state will affect subsequent run() invocations. Returns empty when
   // the model has no torchbind constants.
   std::unordered_map<std::string, c10::IValue> get_custom_objs() const {
-    return runner_
-        ? runner_->get_custom_objs()
-        : std::unordered_map<std::string, c10::IValue>{};
+    return runner_ ? runner_->get_custom_objs()
+                   : std::unordered_map<std::string, c10::IValue>{};
   }
 
   void update_constant_buffer(

--- a/torch/csrc/inductor/aoti_package/pybind.cpp
+++ b/torch/csrc/inductor/aoti_package/pybind.cpp
@@ -7,6 +7,7 @@
 #include <c10/core/Device.h>
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/inductor/aoti_runner/pybind.h>
+#include <torch/csrc/jit/python/pybind_utils.h>
 
 namespace torch::inductor {
 
@@ -70,6 +71,15 @@ void initAOTIPackageBindings(PyObject* module) {
       .def("get_call_spec", &AOTIModelPackageLoaderPybind::get_call_spec)
       .def(
           "get_constant_fqns", &AOTIModelPackageLoaderPybind::get_constant_fqns)
+      .def(
+          "get_custom_objs",
+          [](AOTIModelPackageLoaderPybind& self) {
+            py::dict result;
+            for (auto& [name, ivalue] : self.get_custom_objs()) {
+              result[py::str(name)] = torch::jit::toPyObject(ivalue);
+            }
+            return result;
+          })
       .def(
           "load_constants",
           &AOTIModelPackageLoaderPybind::load_constants,

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -58,6 +58,16 @@ class TORCH_API AOTIModelContainerRunner {
 
   std::vector<std::string> get_call_spec();
 
+  // Returns the torchbind custom-class constants embedded in the loaded
+  // model. The IValue payloads alias the live entries inside the proxy
+  // executor: downcasting to a CustomClassHolder subclass and mutating
+  // its state will affect subsequent run() invocations. Returns empty when
+  // the model has no torchbind constants.
+  std::unordered_map<std::string, c10::IValue> get_custom_objs() const {
+    return proxy_executor_ ? proxy_executor_->get_custom_objs()
+                           : std::unordered_map<std::string, c10::IValue>{};
+  }
+
  protected:
   AOTIModelContainerRunner(
       const std::string& model_so_path,

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
@@ -124,6 +124,16 @@ class OSSProxyExecutor : public ProxyExecutor {
       int num_tensors,
       AtenTensorHandle* flatten_tensor_args) override;
 
+  // Returns a snapshot of the torchbind custom-class constants this executor
+  // holds. The IValue payloads share intrusive_ptr ownership with the live
+  // entries in custom_objs_, so consumers can downcast to a known
+  // CustomClassHolder type and mutate state that subsequent call_function()
+  // invocations will observe.
+  std::unordered_map<std::string, c10::IValue> get_custom_objs()
+      const override {
+    return custom_objs_;
+  }
+
  private:
   void prefill_stack_with_static_arguments(
       size_t index,

--- a/torch/csrc/inductor/aoti_torch/proxy_executor.h
+++ b/torch/csrc/inductor/aoti_torch/proxy_executor.h
@@ -2,6 +2,8 @@
 
 #include <ATen/core/ivalue.h>
 #include <c10/macros/Export.h>
+#include <string>
+#include <unordered_map>
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 
 namespace torch::aot_inductor {
@@ -32,6 +34,17 @@ class ProxyExecutor {
       int64_t* flatten_int_args,
       int num_tensors,
       AtenTensorHandle* flatten_tensor_args) = 0;
+
+  // Returns a snapshot of the torchbind custom-class constants the executor
+  // holds (name -> IValue). The IValue payload carries an
+  // intrusive_ptr<CustomClassHolder> shared with the live executor, so
+  // downcasting and mutating the underlying object affects subsequent
+  // run() invocations. Default returns empty for executors that do not
+  // track torchbind constants. OSSProxyExecutor overrides.
+  virtual std::unordered_map<std::string, c10::IValue> get_custom_objs()
+      const {
+    return {};
+  }
 };
 
 } // namespace torch::aot_inductor

--- a/torch/csrc/inductor/aoti_torch/proxy_executor.h
+++ b/torch/csrc/inductor/aoti_torch/proxy_executor.h
@@ -2,9 +2,9 @@
 
 #include <ATen/core/ivalue.h>
 #include <c10/macros/Export.h>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include <string>
 #include <unordered_map>
-#include <torch/csrc/inductor/aoti_torch/c/shim.h>
 
 namespace torch::aot_inductor {
 
@@ -41,8 +41,7 @@ class ProxyExecutor {
   // downcasting and mutating the underlying object affects subsequent
   // run() invocations. Default returns empty for executors that do not
   // track torchbind constants. OSSProxyExecutor overrides.
-  virtual std::unordered_map<std::string, c10::IValue> get_custom_objs()
-      const {
+  virtual std::unordered_map<std::string, c10::IValue> get_custom_objs() const {
     return {};
   }
 };


### PR DESCRIPTION
## Summary

Adds a public C++ accessor `get_custom_objs()` on `torch::aot_inductor::ProxyExecutor`, `torch::inductor::AOTIModelContainerRunner`, and `torch::inductor::AOTIModelPackageLoader` (plus a Python binding on the loader) that returns a snapshot of the torchbind custom-class constants embedded in a loaded `.pt2` model.

The `IValue` payloads alias the live entries inside the proxy executor's `custom_objs_` map (the existing private storage already populated during `OSSProxyExecutor` construction by `pickle_load_obj`). Downcasting to a `CustomClassHolder` subclass and mutating its state — e.g. binding a stream, attaching a communicator, toggling profiling — affects subsequent `run()` invocations.

## Motivation

Backends that store live state on torchbind constants embedded in `.pt2` packages cannot reach those objects after load via any public PyTorch API. The constants live in `OSSProxyExecutor::custom_objs_` (private, `std::unordered_map<std::string, c10::IValue>`) and the loader/runner only expose tensor-typed constant accessors (`get_constant_fqns`, `extract_constants_map`, etc.).

Concrete user: **torch-tensorrt** ([pytorch/TensorRT#4232](https://github.com/pytorch/TensorRT/pull/4232)) needs to bind a CUDA Green Context stream onto each `TRTEngine` torchbind embedded in a torch-tensorrt `.pt2` model loaded via `AOTIModelPackageLoader`. The `ExportedProgram` path already works (Python walks `named_modules()` and binds each engine), but the AOTI path has no equivalent because the engines never become attributes of an `nn.Module` — they live only inside the proxy executor's private map.

This is a **purely additive** change: the new methods are optional to call, have a no-op default on the base `ProxyExecutor`, and do not change any existing semantics.

## API

```cpp
// torch/csrc/inductor/aoti_torch/proxy_executor.h
class ProxyExecutor {
  // ...
  virtual std::unordered_map<std::string, c10::IValue> get_custom_objs() const {
    return {};
  }
};

// torch/csrc/inductor/aoti_torch/oss_proxy_executor.h
class OSSProxyExecutor : public ProxyExecutor {
  // ...
  std::unordered_map<std::string, c10::IValue> get_custom_objs() const override {
    return custom_objs_;
  }
};

// torch/csrc/inductor/aoti_runner/model_container_runner.h
class TORCH_API AOTIModelContainerRunner {
  // ...
  std::unordered_map<std::string, c10::IValue> get_custom_objs() const;
};

// torch/csrc/inductor/aoti_package/model_package_loader.h
class TORCH_API AOTIModelPackageLoader {
  // ...
  std::unordered_map<std::string, c10::IValue> get_custom_objs() const;
};
```

Python:

```python
loader = torch._C._aoti.AOTIModelPackageLoader("model.pt2", "model")
custom_objs = loader.get_custom_objs()  # Dict[str, ScriptObject]
```

## Usage example (from torch-tensorrt)

```cpp
torch::inductor::AOTIModelPackageLoader loader("model.pt2");

for (auto& [name, ivalue] : loader.get_custom_objs()) {
  if (ivalue.isCustomClass()) {
    if (auto engine = ivalue.toCustomClass<torch_tensorrt::TRTEngine>()) {
      engine->set_external_stream(reinterpret_cast<int64_t>(my_green_stream));
    }
  }
}

auto outputs = loader.run(inputs);  // each engine now uses its bound stream
```

## API design rationale

Three options were considered:

| Option | Pros | Cons | Picked |
|---|---|---|---|
| Return `const std::unordered_map<std::string, c10::IValue>&` | Zero copy | Leaks STL container layout; ABI-fragile if `custom_objs_` is renamed/reshaped | ❌ |
| Visitor: `for_each_custom_obj(std::function<...>)` | Hides container | Cumbersome, no random access by name | ❌ |
| **Return `std::unordered_map<std::string, c10::IValue>` by value** | ABI-safe; copy is cheap (single-digit entries × pointer-sized IValue); IValue copies share intrusive_ptr so callers still affect live state | One copy of the map | ✅ |

We deliberately do **not** filter by torchbind type or otherwise interpret the constants — the `c10::IValue` interface is the right abstraction; backend filtering is the caller's job.

## Compatibility

- **Source compatibility**: additive only. Existing callers of `ProxyExecutor`, `AOTIModelContainerRunner`, and `AOTIModelPackageLoader` are unaffected.
- **Binary compatibility**: adds a new virtual to `ProxyExecutor`, which changes its vtable layout. Downstream subclasses of `ProxyExecutor` that were compiled against the old header will need a rebuild — but the default implementation handles them transparently if recompiled. No method removed or signature changed.
- **API stability**: returns by value (no internal-layout exposure). The map type is part of the public API; if we ever change the executor's storage type we'd convert at the boundary.

## Tests

`test/inductor/test_aoti_torchbind_constants.py` (new):
- Compile a model with a `_TorchScriptTesting._Foo` torchbind attribute via `aoti_compile_and_package`.
- Load via `torch._C._aoti.AOTIModelPackageLoader`.
- Assert `get_custom_objs()` returns the expected non-empty map.
- Negative test: model without torchbind constants returns an empty map.

## Suggested reviewers

- @desertfire — AOTI runner / package loader owner
- @chenyang78 — proxy executor / OSS proxy executor
- @angelayi — `.pt2` package format

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @ezyang @bdhirsh @malfet
