### PR TITLE
[Python 3.14] Bump flake8-simplify version

### DIFF
--- a/tools/linter/adapters/flake8_linter.py
+++ b/tools/linter/adapters/flake8_linter.py
@@ -7,7 +7,7 @@
 #   "flake8-executable==2.1.3",
 #   "flake8-logging-format==2024.24.12",
 #   "flake8-pyi==25.5.0",
-#   "flake8-simplify==0.22.0",
+#   "flake8-simplify==0.30.0",
 #   "mccabe==0.7.0",
 #   "pycodestyle==2.14.0",
 #   "pyflakes==3.4.0",


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/182158

Python 3.14 removes legacy AST node classes (`ast.Str`, `ast.Num`, `ast.NameConstant`, etc.) that were deprecated since Python 3.8 and replaced by `ast.Constant` (see [Python 3.14 docs)](https://docs.python.org/3.14/deprecations/pending-removal-in-3.14.html).

This affects astor used by flake8-simplify for AST, so invoking lintrunner on flake8 will throw
```Python
AttributeError: module 'ast' has no attribute 'Str'
```

As linters in PyTorch are running in ephemeral uv venvs, it can be easily fixed by bumping flake8-simplify package to 0.30.0.