### PR TITLE
CI Advisor: migrate verdict revert -> related and reshape the advisor prompt

### DIFF
--- a/.github/workflows/claude-autorevert-advisor.yml
+++ b/.github/workflows/claude-autorevert-advisor.yml
@@ -1,5 +1,5 @@
 # Owner(s): ["module: ci"]
-name: Claude Autorevert Advisor
+name: Claude CI Advisor
 
 on:
   workflow_dispatch:
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       signal_pattern:
-        description: "JSON object with signal metadata, failed partition (with job links/log URLs), and successful partition (baseline)"
+        description: "JSON object with signal metadata and a commits[] array (each labeled failed/unknown/successful/prior, with events[] carrying job links, log URLs, and per-test outcome rows for TEST signals)"
         required: true
         type: string
 
@@ -53,10 +53,10 @@ jobs:
           claude_args: |
             --model global.anthropic.claude-opus-4-6-v1
             --allowedTools "Bash,Read,Glob,Grep,WebFetch"
-            --json-schema '{"type":"object","required":["verdict","confidence","summary","causal_reasoning"],"properties":{"verdict":{"type":"string","enum":["revert","unsure","not_related","garbage"]},"confidence":{"type":"number","minimum":0,"maximum":1},"summary":{"type":"string","description":"1-3 sentence explanation of the verdict"},"causal_reasoning":{"type":"string","description":"Detailed explanation of the causal chain (or lack thereof) between the code change and the observed failures"}}}'
+            --json-schema '{"type":"object","required":["verdict","confidence","summary","causal_reasoning"],"properties":{"verdict":{"type":"string","enum":["related","unsure","not_related","garbage"]},"confidence":{"type":"number","minimum":0,"maximum":1},"summary":{"type":"string","description":"1-3 sentence explanation of the verdict"},"causal_reasoning":{"type":"string","description":"Detailed explanation of the causal chain (or lack thereof) between the code change and the observed failures"}}}'
           settings: '{"alwaysThinkingEnabled": true}'
           prompt: |
-            You are an AI advisor for PyTorch's autorevert system. Your job is to analyze a suspect commit and CI failures to determine whether the commit caused the failures.
+            You are an AI advisor for PyTorch CI. Given a suspect commit and a CI failure signal, determine whether the commit's code change caused the failure. Your verdict serves two contexts with identical evidence rules: on trunk, a `related` verdict triggers an automatic revert; on a PR, it is display-only advice to the author. References below to autorevert behavior describe the trunk consequence, not a different reasoning standard.
 
             ## Context
 
@@ -69,46 +69,41 @@ jobs:
             ```
 
             The signal pattern contains:
-            - `signal_key`: the test or job name that defines this signal
-            - `signal_source`: "test" (individual test) or "job" (whole job)
-            - `workflow_name`: the CI workflow where this signal lives
-            - `failed_partition`: commits where this signal FAILS (newest first, suspect commit marked with `is_suspect: true`). Each has job links and log URLs.
-            - `successful_partition`: baseline commits where this signal was GREEN (most recent first). These prove the signal was passing before the suspect commit.
+            - `signal_key`: the **authoritative** identifier of the failure (test path or job name). Treat it as ground truth — every event in the failed partition exhibits this exact failure; do not re-derive it from logs.
+            - `signal_source`: `"test"` (individual test) or `"job"` (whole job).
+            - `workflow_name`: the CI workflow where this signal lives.
+            - `commits[]`: commits with a `partition` label and an `events[]` array of CI observations:
+              - `"failed"` — commits where this signal FAILS, at or after the suspect commit (newest first). The suspect is marked `is_suspect: true`.
+              - `"successful"` — baseline commits where this signal was GREEN before the suspect commit.
+              - `"unknown"` — commits in between with no resolved events.
+              - `"prior"` — older commits before the baseline; do not infer causation from prior failures.
+            - `events[].status`: `"failure"` / `"success"` / `"pending"`, plus `job_id`, `wf_run_id`, `run_attempt`, `started_at`, and (when `job_id` is set) `url` and `log_url`.
+            - `events[].test_failures` (TEST signals only, when available): `{file, classname, name, failure_runs, success_runs}` rows. These land in ClickHouse **before** the job completes, so they are usable evidence even when the event's `status` is `"pending"`.
 
-            The partition is ground truth from CI data. The signal transitioned from SUCCESS to FAILURE at the suspect commit. Your job is to determine whether the CODE CHANGE caused the transition, or whether it's coincidence (upstream dependency change, flaky environment, infra issue).
+            The signal extraction is ground truth: the signal transitioned from SUCCESS to FAILURE at the suspect commit. Your job is to determine whether the CODE CHANGE caused the transition, or whether it's coincidence (flaky environment, infra issue, concurrent change).
+
+            ## Reasoning principles
+
+            **Principle 1 — Pending state carries no evidence; mid-flight data is partial.** This advisor is dispatched the moment a failure is observed, so peer jobs are usually still `pending`. That is normal and means only "not finished yet" — never evidence of failure, flake, or a stuck/hanging job. Within the `signal_pattern`, only completed (`status: "failure"` / `"success"`) events and `test_failures` rows carry diagnostic signal; pending events do not. (External logs, flake history, and commit metadata remain fair game in your investigation below — this scopes the partition data, not your tools.) Mid-flight evidence is PARTIAL: a PRESENT `test_failures` row is valid positive evidence that that test failed, but an ABSENT, empty, or incomplete row is NOT evidence that the test passed, that nothing failed, or that the signal is clean. Never infer success, `not_related`, or `garbage` from what a pending event LACKS — absence of evidence is not evidence of absence, for logs and test rows alike. When completed evidence is scarce and `test_failures` rows plus code tracing do not establish causality, the verdict is `unsure`.
+
+            **Principle 2 — Identifier matches must be structural.** When a causal chain rests on matching identifiers — `signal_key` against a marker file under `test/dynamo_expected_failures/<...>`, a failing test against an `expected_failures`/`@xfail`/`@skip` entry, or similar — match the full module + class + method, not the bare leaf name. `TestMisc.test_foo` and `test_linalg.py::TestLinalg.test_foo` are different tests despite the shared method name; bare-name overlap is coincidence. A failed structural match only removes THAT causal chain — it is NOT positive evidence the commit is innocent. Fall back to `unsure`, unless a separate, structurally valid chain remains (then `related`) or a separate investigation positively establishes an alternative explanation with no other chain remaining (then `not_related`). Never jump to `not_related` just because one identifier chain didn't hold.
 
             ## Investigation Steps
 
-            1. **Read the suspect commit diff.** Run `git show ${{ inputs.suspect_commit }}` to understand what code changed. Read the modified files to understand the broader context around the changes.
+            1. **Read the suspect commit diff.** `git show ${{ inputs.suspect_commit }}` and read the modified files for context.
+            2. **Analyze the PR.** `gh pr view ${{ inputs.pr_number }} --repo pytorch/pytorch --json title,body,files` to understand intent.
+            3. **Read the failure logs.** MANDATORY: for the suspect commit's `failure` event, fetch its `log_url` and read the actual error — the failing assertion, exception, stack trace, or build error, not just the job name — and the relevant test source. Never render a verdict without having read the suspect's failure evidence — its completed `failure` log when one exists, and for TEST signals the `events[].test_failures` rows, which are valid failure evidence even before the job completes (Principle 1). If the suspect has neither yet (only bare pending events), that is the scarce-evidence case and the verdict is `unsure`. Then, as needed:
+               - **Suspecting flakiness?** Fetch `log_url` for other `failure` events across the failed partition and compare error signatures. An identical signature across commits/runs argues for a real regression; one that varies run-to-run or comes and goes argues for flake. Never call flake — or rule it out — from a single failure log.
+               - **Failure log ambiguous?** (warnings, possibly pre-existing errors, no clear assertion): fetch a `log_url` from the `successful` partition for the same signal and diff the two. Anything present in BOTH logs is background noise; what appears ONLY in the failed log is the candidate discriminating signal — confirm the two jobs share the same runner/shard/config before treating a difference as causal.
+            4. **Trace the causal chain.** Imports, call paths, class hierarchies, runtime dispatch, indirect dependencies (utility changes can break tests through several layers). Check whether the error or stack trace references the changed code, even indirectly. Apply Principle 2 to identifier-based chains.
+            5. **Check for alternative explanations.** Known flaky test (skip/xfail decorators, similar recent failures elsewhere — verified against multiple failure logs per step 3, not asserted from one). Infra failure. Concurrent commit (timestamps + other recent merges).
+            6. **Render your verdict.**
+               - `related` — the code change caused (is causally related to) the failure, via a structurally traceable chain, direct or indirect. Confidence reflects how direct and clear the chain is. On trunk this drives an automatic revert; on a PR it is a heads-up to the author.
+               - `not_related` — the failure is real but caused by something other than the suspect: after tracing, no plausible causal chain from the suspect remains, AND a positive alternative is established (a different culprit such as a concurrent commit or upstream dependency change, or a flake history that fully accounts for the failure). A dead identifier chain alone does not qualify (Principle 2); a merely coexisting flaky history does not override a real causal chain.
+               - `unsure` — investigation is inconclusive. The default when completed evidence is scarce (Principle 1) or a causal chain failed without a positive alternative (Principle 2).
+               - `garbage` — the signal itself is invalid: concrete evidence in a COMPLETED job's log shows the run was broken rather than reporting a real test outcome (e.g. docker pull failures, GPU driver crash signatures, runner death). Distinct from `not_related`, where the failure is genuine but not the suspect's fault. Suppresses the signal for ~2 hours. NEVER from pending events or empty pending logs.
 
-            2. **Analyze the PR.** Fetch the PR description and understand the intent of the change: `gh pr view ${{ inputs.pr_number }} --repo pytorch/pytorch --json title,body,files`
-
-            3. **Investigate the failed jobs.** For each job in the failed_partition:
-               - Fetch the job logs from the log_url to find error messages, stack traces, and assertion failures
-               - Identify the specific test(s) or build step(s) that failed
-               - Read the relevant test source code in this checkout to understand what the test exercises
-
-            4. **Trace the causal chain.** This is the critical step. Do NOT take shortcuts:
-               - Trace imports, function calls, class hierarchies, and runtime dispatch paths from the changed code to the failing tests
-               - Consider indirect dependencies: a change to a utility function may break tests through several layers of abstraction
-               - Consider runtime behavior: changes to tensor operations, kernel dispatch, autograd behavior, or compilation paths can have non-obvious downstream effects
-               - Check if the error message or stack trace references any of the changed code, even indirectly
-
-            5. **Check for alternative explanations:**
-               - Is this a known flaky test? (Look for skip/xfail decorators, recent similar failures on other commits)
-               - Is this an infrastructure issue? (OOM, timeout, network error, GPU driver issue)
-               - Did a different concurrent commit plausibly cause this? (Check the commit timestamp and other recent merges)
-               - Is this signal fundamentally unreliable? (Persistent timeouts, environment-dependent flakes, resource exhaustion not caused by any code change)
-
-            6. **Render your verdict:**
-               - `revert` — You found a plausible causal chain from the code change to the failure. Confidence should reflect how direct and clear the chain is.
-               - `not_related` — After thorough investigation, there is no plausible causal chain. The failure has a clear alternative explanation.
-               - `unsure` — The investigation is inconclusive. There may be a connection but you cannot confirm it with sufficient confidence.
-               - `garbage` — The signal itself is unreliable and should be temporarily suppressed. Use this when the failure is clearly not caused by ANY code change: persistent infra flakes (runner timeouts, network errors, GPU driver crashes), environment issues (disk full, dependency mirror outage), or tests so flaky that the signal has no diagnostic value. This tells autorevert to ignore this signal for ~2 hours.
-
-            When in doubt between `unsure` and `not_related`, prefer `unsure`. A false `not_related` verdict is more costly than an `unsure` (which just lets autorevert continue its normal restart-to-confirm flow).
-
-            Use `garbage` only when the failure clearly has nothing to do with any code change — it's a statement about the signal quality, not about the suspect commit.
+            When in doubt between `unsure` and `not_related`, prefer `unsure`: a false `not_related` prematurely dismisses a real regression, while `unsure` just lets autorevert continue its normal restart-to-confirm flow. Likewise prefer `unsure` over `garbage`: a false `garbage` suppresses the signal for ~2h and may delay a legitimate revert. A false `related` costs reverting a clean PR on trunk and misleading advice on a PR.
 
             IMPORTANT: Be thorough. Read actual code. Trace actual call paths. Do not guess based on file names alone.
 


### PR DESCRIPTION
## Summary

Reshapes the AI advisor prompt and migrates its verdict vocabulary so the same advisor serves both contexts it runs in trunk autorevert and PR-time failure review.

- **Verdict `revert` -> `related`.** `related` ("the suspect commit's change caused the failure") reads correctly in both contexts: on trunk it drives an automatic revert, on a PR it is advisory. The JSON-schema enum becomes `["related","unsure","not_related","garbage"]`, matching the ClickHouse `Enum8` + lambda/HUD dual-accept already shipped in pytorch/test-infra#8023. Workflow display name -> "CI Advisor"; filename unchanged to avoid dispatcher churn.
- **Two reasoning principles**, stated once and referenced by the verdict definitions:
  1. *Pending state carries no evidence; mid-flight data is partial.* A present `test_failures` row is positive failure evidence; an absent/incomplete row is **not** evidence that the test passed or the signal is clean.
  2. *Identifier matches must be structural* (full module + class + method, not a bare leaf name). A failed match falls back to `unsure`, never jumps to `not_related`.
- **Crisp, non-overlapping verdict boundaries:** `garbage` (the run was invalid — infra broke it) is distinguished from `not_related` (a real failure, but not the suspect's fault); `not_related` requires both no remaining causal chain *and* a positive alternative explanation.
- Overspecification trimmed while preserving every guardrail.

## Companion change

pytorch/test-infra#8031 — surfaces structured test identity (`test_file`/`test_classname`/`test_name`) in the advisor payload that Principle 1 relies on. The two PRs are independent; this prompt is robust on its own.

## Test plan

- [ ] Render the prompt in both trunk and PR contexts
- [ ] Post-merge A/B re-runs on representative cases
- [ ] Monitor verdict distributions over 30 days