### PR TITLE
[pipelining] Fix None gradient handling in backward send/recv

### DIFF
--- a/test/distributed/pipelining/model_registry.py
+++ b/test/distributed/pipelining/model_registry.py
@@ -4,6 +4,7 @@
 import torch
 from torch.autograd import Function
 from torch.distributed.pipelining import pipe_split, SplitPoint
+from torch.distributed.tensor import DTensor
 
 
 class ExampleCode(torch.nn.Module):
@@ -362,3 +363,34 @@ class MultiMLPWithDw(torch.nn.Module):
 
         for i in reversed(range(len(self.layers))):
             self.layers[i].compute_dW()
+
+
+class ConditionalGradBlock(torch.nn.Module):
+    def __init__(self, d_hid, conditional=True):
+        super().__init__()
+        self.conditional = conditional
+        self.lin = torch.nn.Linear(d_hid, d_hid)
+
+    def forward(self, x, flag):
+        local_flag = flag.to_local() if isinstance(flag, DTensor) else flag
+        if self.conditional and not bool(local_flag.flatten()[0].item()):
+            y = x.detach().requires_grad_(True)
+        else:
+            y = self.lin(x)
+        return y, flag
+
+
+class ConditionalGradStack(torch.nn.Module):
+    def __init__(self, d_hid, n_layers):
+        super().__init__()
+        self.layers = torch.nn.ModuleList(
+            [
+                ConditionalGradBlock(d_hid, conditional=i < n_layers - 1)
+                for i in range(n_layers)
+            ]
+        )
+
+    def forward(self, x, flag):
+        for layer in self.layers:
+            x, flag = layer(x, flag)
+        return x, flag

--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -97,6 +97,27 @@ class StageBackwardTests(TestCase):
             # Check that the weight gradients were not updated
             self.assertEqual(p.grad, None)
 
+    def test_stage_backward_input_ignores_non_tensor_inputs(self, device):
+        mod = MLPModule(d_hid).to(device)
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+        non_tensor_input = object()
+
+        ref_mod = copy.deepcopy(mod).to(device)
+        ref_x = x.detach().requires_grad_(True).to(device)
+
+        loss = mod(x).sum()
+        dinputs, _param_groups = stage_backward_input(
+            stage_outputs_or_loss=(loss,),
+            output_grads=None,
+            input_values=[non_tensor_input, x],
+            weights=mod.parameters(),
+        )
+
+        ref_mod(ref_x).sum().backward()
+        self.assertEqual(dinputs[0], None)
+        torch.testing.assert_close(x.grad, ref_x.grad)
+        torch.testing.assert_close(dinputs[1], ref_x.grad)
+
     @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/1682")
     def test_stage_backward_weight(self, device):
         # MLP as a stage module

--- a/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
+++ b/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
@@ -20,6 +20,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.pipelining._utils import (
+    _derive_grad_metas,
     _DTensorMeta,
     _MeshCache,
     _StageMeta,
@@ -38,6 +39,7 @@ from torch.distributed.pipelining.microbatch import (
     merge_chunks,
     TensorChunkSpec,
 )
+from torch.distributed.pipelining.stage import PipelineStage
 from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
@@ -337,6 +339,58 @@ class TestDTensorPPUnitTests(MultiProcContinuousTest):
                     expected,
                     f"Case {i} failed",
                 )
+
+    @_requires_multi_gpu
+    def test_NoneGrad_dtensor_grad_metadata_not_derived(self):
+        self.init_pg()
+        mesh = self._make_mesh()
+
+        plain_meta = self._make_tensor_meta()
+        dtensor_meta = _DTensorMeta.from_dtensor(
+            self._make_dtensor(mesh, [Replicate()], requires_grad=True)
+        )
+
+        plain_grad_meta, dtensor_grad_meta = _derive_grad_metas(
+            (plain_meta, dtensor_meta)
+        )
+        self.assertIsNotNone(plain_grad_meta)
+        self.assertIsNone(dtensor_grad_meta)
+
+    @_requires_multi_gpu
+    def test_NoneGrad_dtensor_runtime_send_contract(self):
+        self.init_pg()
+        mesh = self._make_mesh()
+        dtensor_grad = self._make_dtensor(
+            mesh,
+            [Replicate()],
+            shape=(4, 8),
+            requires_grad=False,
+        )
+        dtensor_meta = _DTensorMeta.from_dtensor(dtensor_grad)
+
+        stage = PipelineStage(
+            torch.nn.Identity(),
+            1,
+            self.world_size,
+            self.device,
+        )
+        stage.has_backward = True
+        stage.chunks = 1
+        stage.grad_send_info = [0]
+
+        stage._stage_meta = _StageMeta(input_grads=(None,))
+        stage.bwd_cache[0] = (dtensor_grad,)
+        with self.assertRaisesRegex(
+            PipeliningMetadataError,
+            "DTensor grad metadata cannot be derived",
+        ):
+            stage.get_bwd_send_ops(0)
+
+        stage._stage_meta = _StageMeta(input_grads=(dtensor_meta,))
+        stage.bwd_cache[0] = (None,)
+        ops = stage.get_bwd_send_ops(0)
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0].tensor, torch.zeros_like(dtensor_grad.to_local()))
 
     # -----------------------------------------------------------------
     # Category 3: Validation Functions

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -4,7 +4,13 @@ import copy
 import logging
 from dataclasses import dataclass
 
-from model_registry import ModelWithKwargs, MultiMLP, MultiMLPKwargs, MultiMLPWithDw
+from model_registry import (
+    ConditionalGradStack,
+    ModelWithKwargs,
+    MultiMLP,
+    MultiMLPKwargs,
+    MultiMLPWithDw,
+)
 from schedule_registry import (
     ScheduleUnbalanced,
     ScheduleVShaped,
@@ -55,6 +61,8 @@ logger = logging.getLogger(__name__)
 
 d_hid = 512
 batch_size = 64
+none_grad_d_hid = 32
+none_grad_microbatches = 8
 torch.manual_seed(0)
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 backend = dist.get_default_backend_for_device(device_type)
@@ -206,6 +214,43 @@ def zero_gradients(stage_modules):
         stage_modules = [stage_modules]
     for stage_module in stage_modules:
         stage_module.zero_grad()
+
+
+def none_grad_loss(output, target):
+    return torch.nn.functional.mse_loss(output[0], target, reduction="sum")
+
+
+def make_none_grad_flags(pattern: str, device: torch.device) -> torch.Tensor:
+    values = [False] + [True] * (none_grad_microbatches - 1)
+    if pattern == "first_true_then_false":
+        values = [True] + [False] * (none_grad_microbatches - 1)
+    chunk = batch_size // none_grad_microbatches
+    return torch.cat(
+        [
+            torch.full((chunk, 1), value, dtype=torch.bool, device=device)
+            for value in values
+        ]
+    )
+
+
+def setup_none_grad_model_and_data(config: PipelineTestConfig, n_layers: int):
+    torch.manual_seed(0)
+    mod = ConditionalGradStack(none_grad_d_hid, n_layers).to(config.device)
+    ref_mod = copy.deepcopy(mod)
+    x = torch.randn(batch_size, none_grad_d_hid, device=config.device)
+    target = torch.randn(batch_size, none_grad_d_hid, device=config.device)
+    return mod, ref_mod, x, target
+
+
+def run_none_grad_reference(ref_mod, x, flag, target) -> None:
+    ref_mod.zero_grad()
+    for x_mb, flag_mb, target_mb in zip(
+        torch.tensor_split(x, none_grad_microbatches),
+        torch.tensor_split(flag, none_grad_microbatches),
+        torch.tensor_split(target, none_grad_microbatches),
+        strict=True,
+    ):
+        none_grad_loss(ref_mod(x_mb, flag_mb), target_mb).backward()
 
 
 class ScheduleTest(MultiProcContinuousTest):
@@ -1057,6 +1102,69 @@ class ScheduleTest(MultiProcContinuousTest):
         check_gradients(
             self.config, stage_modules, ref_mod, submod_names, rtol=3e-5, atol=5e-3
         )
+
+    def _none_grad_stage_indices(self, ScheduleClass):
+        if ScheduleClass is ScheduleGPipe:
+            return self.world_size, [self.rank]
+        n_stages = 2 * self.world_size
+        if ScheduleClass is ScheduleZBVZeroBubble:
+            return n_stages, [self.rank, n_stages - 1 - self.rank]
+        return n_stages, [self.rank, self.rank + self.world_size]
+
+    def _run_none_grad_schedule(self, ScheduleClass, pattern):
+        n_stages, stage_indices = self._none_grad_stage_indices(ScheduleClass)
+        mod, ref_mod, x, target = setup_none_grad_model_and_data(self.config, n_stages)
+        flag = make_none_grad_flags(pattern, self.device)
+        run_none_grad_reference(ref_mod, x, flag, target)
+
+        stages, stage_modules, submod_names = create_multi_stage_pipeline(
+            self.config, mod, len(stage_indices), n_stages, stage_indices
+        )
+        schedule = (
+            ScheduleClass(
+                stages[0],
+                none_grad_microbatches,
+                loss_fn=none_grad_loss,
+                scale_grads=False,
+            )
+            if ScheduleClass is ScheduleGPipe
+            else ScheduleClass(
+                stages,
+                none_grad_microbatches,
+                loss_fn=none_grad_loss,
+                scale_grads=False,
+            )
+        )
+
+        losses = []
+        has_first = any(stage.is_first for stage in stages)
+        has_last = any(stage.is_last for stage in stages)
+        if has_first and has_last:
+            schedule.step(x, flag, target=target, losses=losses)
+        elif has_first:
+            schedule.step(x, flag)
+        elif has_last:
+            schedule.step(target=target, losses=losses)
+        else:
+            schedule.step()
+
+        dist.barrier()
+        check_gradients(
+            self.config, stage_modules, ref_mod, submod_names, rtol=1e-5, atol=1e-5
+        )
+
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+    )
+    @parametrize(
+        "ScheduleClass",
+        [ScheduleGPipe, ScheduleInterleaved1F1B, ScheduleZBVZeroBubble],
+    )
+    @parametrize("pattern", ["first_false_then_true", "first_true_then_false"])
+    @skip_if_lt_x_gpu(4)
+    def test_NoneGrad_conditional_input_grad(self, ScheduleClass, pattern):
+        self._run_none_grad_schedule(ScheduleClass, pattern)
 
 
 instantiate_parametrized_tests(ScheduleTest)

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -142,7 +142,7 @@ def get_param_groups(
 
 def _autograd_grad_for_inputs(
     outputs: Sequence[torch.Tensor],
-    inputs: Sequence[torch.Tensor],
+    inputs: Sequence[Any],
     grad_outputs: Sequence[torch.Tensor | None] | None = None,
     retain_graph: bool = False,
     allow_unused: bool = False,
@@ -177,7 +177,7 @@ def _autograd_grad_for_inputs(
 def stage_backward_input(
     stage_outputs_or_loss: list[torch.Tensor],
     output_grads: list[torch.Tensor] | None,
-    input_values: list[torch.Tensor],
+    input_values: list[Any],
     weights: Iterator[Parameter],
 ) -> tuple[tuple[torch.Tensor | None, ...], list[dict[str, Any]]]:
     """
@@ -190,11 +190,28 @@ def stage_backward_input(
     Detaching the stage_outputs_or_loss at the end of this function is important as
     it frees up the memory that the autograd graph is anticipating to be used later (but doesn't actually need).
     """
+    valid_outputs: list[torch.Tensor] = []
+    valid_output_grads: list[torch.Tensor | None] = []
+    for i, stage_output in enumerate(stage_outputs_or_loss):
+        if not stage_output.requires_grad and stage_output.grad_fn is None:
+            continue
+        valid_outputs.append(stage_output)
+        valid_output_grads.append(
+            torch.ones_like(stage_output) if output_grads is None else output_grads[i]
+        )
+
     stage_output_grad_fns: list[Node] = list(
-        filter(None, map(_get_grad_fn_or_grad_acc, stage_outputs_or_loss))
+        filter(None, map(_get_grad_fn_or_grad_acc, valid_outputs))
     )
     stage_input_grad_fns: list[Node] = list(
-        filter(None, map(_get_grad_fn_or_grad_acc, input_values))
+        filter(
+            None,
+            (
+                _get_grad_fn_or_grad_acc(inp)
+                for inp in input_values
+                if isinstance(inp, torch.Tensor)
+            ),
+        )
     )
     weight_grad_fns: list[Node] = list(
         filter(None, map(_get_grad_fn_or_grad_acc, weights))
@@ -225,17 +242,16 @@ def stage_backward_input(
                 handle = intermediate.register_prehook(get_hook(param_group, i))
                 handles.append(handle)
 
-        if output_grads is None:
-            output_grads = [
-                torch.ones_like(stage_output) for stage_output in stage_outputs_or_loss
-            ]
-
-        dinputs = _autograd_grad_for_inputs(
-            stage_outputs_or_loss,
-            input_values,
-            output_grads,
-            retain_graph=True,
-        )
+        if valid_outputs:
+            dinputs = _autograd_grad_for_inputs(
+                valid_outputs,
+                input_values,
+                valid_output_grads,
+                retain_graph=True,
+                allow_unused=True,
+            )
+        else:
+            dinputs = tuple(None for _ in input_values)
 
         for inp, dinput in zip(input_values, dinputs):
             if isinstance(inp, torch.Tensor) and dinput is not None:

--- a/torch/distributed/pipelining/_utils.py
+++ b/torch/distributed/pipelining/_utils.py
@@ -329,18 +329,26 @@ def _make_tensor_from_meta(
 
 def _derive_grad_metas(
     tensor_metas: tuple[TensorMeta, ...],
-) -> tuple[_TensorMeta | None, ...]:
+) -> tuple[TensorMeta | None, ...]:
     """Derive gradient metadata from tensor metadata.
 
     Returns metadata with the same shape/stride/dtype but ``requires_grad=False``.
     Entries where the source has ``requires_grad=False`` become ``None``.
     """
-    return tuple(
-        _TensorMeta(shape=m.shape, stride=m.stride, dtype=m.dtype, requires_grad=False)
-        if m.requires_grad
-        else None
-        for m in tensor_metas
-    )
+
+    def derive_one(m: TensorMeta) -> TensorMeta | None:
+        if not m.requires_grad:
+            return None
+        if isinstance(m, _DTensorMeta):
+            return None
+        return _TensorMeta(
+            shape=m.shape,
+            stride=m.stride,
+            dtype=m.dtype,
+            requires_grad=False,
+        )
+
+    return tuple(derive_one(m) for m in tensor_metas)
 
 
 class _MeshCache:

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -445,6 +445,8 @@ class _PipelineStageBase(ABC):
         recv_infos = self.grad_recv_info[mb_index]
         for info, tensor in zip(recv_infos, next_stage_bwd_outputs, strict=True):
             if tensor is None:
+                if info.buffer is not None:
+                    info.buffer.zero_()
                 continue
             if not isinstance(tensor, torch.Tensor):
                 raise AssertionError(
@@ -507,6 +509,23 @@ class _PipelineStageBase(ABC):
 
         return ops
 
+    def _get_grad_send_meta(self, input_idx: int) -> TensorMeta | None:
+        """Return gradient metadata for ``input_idx`` if a recv was allocated."""
+        input_grads = self._stage_meta.input_grads
+        if input_grads is not None and input_idx < len(input_grads):
+            return input_grads[input_idx]
+
+        inputs = self._stage_meta.inputs
+        if inputs is not None and input_idx < len(inputs):
+            meta = inputs[input_idx]
+            if meta is not None:
+                return _derive_grad_metas((meta,))[0]
+
+        raise PipeliningMetadataError(
+            f"Stage {self.stage_index}: backward produced gradient for input "
+            f"{input_idx}, but no metadata is available for the gradient send."
+        )
+
     def get_bwd_send_ops(self, bwd_chunk_id: int) -> list[dist.P2POp]:
         """
         Get the gradient send ops for current stage's backward.
@@ -527,8 +546,34 @@ class _PipelineStageBase(ABC):
         ops: list[dist.P2POp] = []
         grads_input = self.bwd_cache.pop(bwd_chunk_id)
 
-        for grad, grad_recv_stage in zip(grads_input, self.grad_send_info, strict=True):
-            if isinstance(grad, torch.Tensor) and grad_recv_stage is not None:
+        for idx, (grad, grad_recv_stage) in enumerate(
+            zip(grads_input, self.grad_send_info, strict=True)
+        ):
+            if grad_recv_stage is None:
+                if grad is not None:
+                    raise PipeliningMetadataError(
+                        f"[{self.stage_index}] for chunk {bwd_chunk_id} has gradient {grad} "
+                        f"but no stage to send it to"
+                    )
+                continue
+
+            grad_meta = self._get_grad_send_meta(idx)
+            if grad_meta is None:
+                if grad is not None:
+                    raise PipeliningMetadataError(
+                        f"Stage {self.stage_index} chunk {bwd_chunk_id} input {idx}: "
+                        f"backward produced a {type(grad).__name__} gradient, but "
+                        "backward metadata for this grad slot is None, so the "
+                        "previous stage did not allocate a recv buffer. DTensor "
+                        "grad metadata cannot be derived from forward DTensor "
+                        "metadata because gradient placements may differ from "
+                        "activation placements. Provide static input_grads "
+                        "metadata or run metadata inference with a microbatch "
+                        "that produces this grad."
+                    )
+                continue
+
+            if isinstance(grad, torch.Tensor):
                 # Extract local tensor if DTensor
                 send_tensor = to_local_if_dtensor(grad)
                 logger.debug(
@@ -541,12 +586,19 @@ class _PipelineStageBase(ABC):
                 ops.append(
                     dist.P2POp(dist.isend, send_tensor, peer_global_rank, self.group)
                 )
-            else:
-                if grad is not None or grad_recv_stage is not None:
-                    raise PipeliningMetadataError(
-                        f"[{self.stage_index}] for chunk {bwd_chunk_id} has gradients {grad} "
-                        f"and is expecting to send gradients to stage {grad_recv_stage}"
-                    )
+            elif grad is None:
+                zero_grad = _make_tensor_from_meta(grad_meta, self.device).zero_()
+                send_tensor = to_local_if_dtensor(zero_grad)
+                logger.debug(
+                    "%s Sending zero gradient to Stage %s: %s",
+                    self.log_prefix,
+                    grad_recv_stage,
+                    send_tensor.size(),
+                )
+                peer_global_rank = self._resolve_peer_global_rank(grad_recv_stage)
+                ops.append(
+                    dist.P2POp(dist.isend, send_tensor, peer_global_rank, self.group)
+                )
         return ops
 
     def clear_runtime_states(self) -> None:
@@ -1546,6 +1598,8 @@ class _PipelineStage(_PipelineStageBase):
                 )
 
         self._stage_meta.output_grads = tuple(output_grads_metas)
+        if self._stage_meta.inputs is not None:
+            self._stage_meta.input_grads = _derive_grad_metas(self._stage_meta.inputs)
         logger.debug("%s Grad recv info: %s", self.log_prefix, grad_recv_infos)
         return tuple(grad_recv_infos)
 
@@ -1783,6 +1837,7 @@ class PipelineStage(_PipelineStageBase):
             outputs,
             all_fwd_inputs,
             grad_outputs,
+            allow_unused=True,
         )
 
     def _to_tensor(self, arg: torch.Tensor | TensorMeta) -> torch.Tensor:
@@ -2029,10 +2084,17 @@ class PipelineStage(_PipelineStageBase):
                 all_input_grads = tuple(None for _ in range(len(all_fwd_inputs)))
 
         input_grads = all_input_grads[: len(fwd_inputs)]
-        self._stage_meta.input_grads = tuple(
-            extract_tensor_meta(g) if isinstance(g, torch.Tensor) else None
-            for g in input_grads
-        )
+        processed_metas: list[TensorMeta | None] = []
+        for i, g in enumerate(input_grads):
+            if isinstance(g, torch.Tensor):
+                processed_metas.append(extract_tensor_meta(g))
+            elif fwd_inputs[i].requires_grad:
+                processed_metas.append(
+                    _derive_grad_metas((extract_tensor_meta(fwd_inputs[i]),))[0]
+                )
+            else:
+                processed_metas.append(None)
+        self._stage_meta.input_grads = tuple(processed_metas)
 
         # === SEND: Pass input grad metadata to previous stage ===
         bwd_meta = _StageBackwardMeta(backward_metas=self._stage_meta.input_grads)


### PR DESCRIPTION

Pipeline backward metadata now allocates gradient recv buffers conservatively for differentiable plain tensors, so later microbatches can send real gradients even when the inference microbatch produced None. DTensor gradient metadata is not invented from activation metadata; if inference records None and runtime later produces a DTensor gradient, runtime errors instead of silently dropping or guessing its placement.

Runtime backward sends now key off metadata allocation: they send real gradients when available, send zeros when metadata captured a grad slot but runtime returns None, and error when a real gradient appears with no recv buffer allocated.

This also aligns split input-backward with full backward by filtering non-differentiable outputs before autograd.grad and allowing unused inputs, which is needed by ZBV-style schedules when a microbatch has no boundary input gradient. Split input-backward now also skips non-Tensor stage inputs when collecting input grad-fns and returns None for those positions. That treats objects such as FlexAttention BlockMask as non-differentiable stage inputs instead of calling .requires_grad on them.

The old verbose stage-only tests were replaced with concise schedule coverage for GPipe, Interleaved1F1B, and ZBV over both mismatch directions, plus DTensor unit coverage for the no-implicit-metadata runtime contract. A focused stage_backward_input test covers non-Tensor stage inputs.

Fixes https://github.com/pytorch/pytorch/issues/152827
Fixes https://github.com/pytorch/torchtitan/issues/3584

Test Plan:

```bash
python test/distributed/pipelining/test_backward.py StageBackwardTestsCPU.test_stage_backward_input_ignores_non_tensor_inputs_cpu StageBackwardTestsCPU.test_stage_backward_input_cpu -q
```

Authored with Codex.
