### PR TITLE
[PT2][export] Add unsafe_allow_callable_serialization for scoped callable serialization

### DIFF
--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -35,6 +35,7 @@ from torch._dynamo.test_case import TestCase
 from torch._dynamo.testing import normalize_gm
 from torch._export import config
 from torch._export.pass_base import _ExportPassBaseDeprecatedDoNotUse
+from torch._export.serde import unsafe_allow_callable_serialization
 from torch._export.utils import (
     get_buffer,
     get_param,
@@ -43,6 +44,13 @@ from torch._export.utils import (
     register_dataclass_as_pytree_node,
 )
 from torch._functorch.aot_autograd import aot_export_joint_with_descriptors
+from torch._functorch.predispatch import (
+    _add_batch_dim,
+    _remove_batch_dim,
+    _vmap_decrement_nesting,
+    _vmap_increment_nesting,
+    lazy_load_decompositions,
+)
 from torch._higher_order_ops.associative_scan import associative_scan
 from torch._higher_order_ops.hints_wrap import hints_wrapper
 from torch._higher_order_ops.scan import scan
@@ -823,7 +831,17 @@ class TestExport(TestCase):
                 vmapped = torch.vmap(f)(x, y)
                 return vmapped.sum(dim=0)
 
-        ep = export(VmapToAssert(), (torch.zeros(4, 4, 4, 4), torch.zeros(4, 4, 4, 4)))
+        # See comment in test_vmap for why registration is needed.
+        with unsafe_allow_callable_serialization(
+            _vmap_increment_nesting,
+            _vmap_decrement_nesting,
+            _add_batch_dim,
+            _remove_batch_dim,
+            lazy_load_decompositions,
+        ):
+            ep = export(
+                VmapToAssert(), (torch.zeros(4, 4, 4, 4), torch.zeros(4, 4, 4, 4))
+            )
         exported = ep.module()(torch.ones(4, 4, 4, 4), torch.ones(4, 4, 4, 4))
         eager = VmapToAssert()(torch.ones(4, 4, 4, 4), torch.ones(4, 4, 4, 4))
         self.assertEqual(exported, eager)
@@ -3756,10 +3774,20 @@ graph():
         DYN = torch.export.Dim.DYNAMIC
         inputs = (torch.tensor([1.0, 2.0, 3.0]), torch.tensor([0.1, 0.2, 0.3]))
         dynamic = {"x": {0: DYN}, "y": {0: DYN}}
-        ep = torch.export.export(Vmap(), inputs, {}, dynamic_shapes=dynamic)
-        self.assertExpectedInline(
-            str(ep.graph).strip(),
-            """\
+        # vmap produces predispatch callable nodes that need to be registered
+        # for serialization. Registration is needed here so that when test_serdes
+        # replaces export() with a mock that calls save/load, the callables are allowed.
+        with unsafe_allow_callable_serialization(
+            _vmap_increment_nesting,
+            _vmap_decrement_nesting,
+            _add_batch_dim,
+            _remove_batch_dim,
+            lazy_load_decompositions,
+        ):
+            ep = torch.export.export(Vmap(), inputs, {}, dynamic_shapes=dynamic)
+            self.assertExpectedInline(
+                str(ep.graph).strip(),
+                """\
 graph():
     %x : [num_users=1] = placeholder[target=x]
     %y : [num_users=2] = placeholder[target=y]
@@ -3775,13 +3803,13 @@ graph():
     %_vmap_decrement_nesting : [num_users=0] = call_function[target=torch._functorch.predispatch._vmap_decrement_nesting](args = (), kwargs = {})
     %sum_2 : [num_users=1] = call_function[target=torch.ops.aten.sum.dim_IntList](args = (%_remove_batch_dim, [0]), kwargs = {})
     return (sum_2,)""",
-        )
-        ep = torch.export.export(
-            Vmap(), inputs, {}, dynamic_shapes=dynamic, strict=True
-        )
-        self.assertExpectedInline(
-            str(ep.graph).strip(),
-            """\
+            )
+            ep = torch.export.export(
+                Vmap(), inputs, {}, dynamic_shapes=dynamic, strict=True
+            )
+            self.assertExpectedInline(
+                str(ep.graph).strip(),
+                """\
 graph():
     %x : [num_users=1] = placeholder[target=x]
     %y : [num_users=2] = placeholder[target=y]
@@ -3797,10 +3825,12 @@ graph():
     %_vmap_decrement_nesting : [num_users=0] = call_function[target=torch._functorch.predispatch._vmap_decrement_nesting](args = (), kwargs = {})
     %sum_2 : [num_users=1] = call_function[target=torch.ops.aten.sum.dim_IntList](args = (%_remove_batch_dim, [0]), kwargs = {})
     return (sum_2,)""",
-        )
-        self.assertTrue(torch.allclose(ep.module()(*inputs), Vmap()(*inputs)))
-        ep = export(Vmap(), inputs, {}, dynamic_shapes=dynamic).run_decompositions({})
-        self.assertTrue(torch.allclose(ep.module()(*inputs), Vmap()(*inputs)))
+            )
+            self.assertTrue(torch.allclose(ep.module()(*inputs), Vmap()(*inputs)))
+            ep = export(Vmap(), inputs, {}, dynamic_shapes=dynamic).run_decompositions(
+                {}
+            )
+            self.assertTrue(torch.allclose(ep.module()(*inputs), Vmap()(*inputs)))
 
     @testing.expectedFailureLegacyExportNonStrict  # Old export doesn't work with subclasses
     @testing.expectedFailureLegacyExportStrict  # Old export doesn't work with subclasses

--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -37,6 +37,7 @@ import torch.export._trace
 import torch.utils._pytree as pytree
 from torch._export.db.case import ExportCase, SupportLevel
 from torch._export.db.examples import all_examples
+from torch._export.serde import unsafe_allow_callable_serialization
 from torch._export.serde.schema import ArgumentKind
 from torch._export.serde.serialize import (
     _dict_to_dataclass,
@@ -2544,8 +2545,14 @@ class TestPredispatchSerialization(TestCase):
     def test_predispatch_jvp_serialize_roundtrip(self):
         """Test that JVP predispatch wrapper functions survive serialization round-trip."""
         from torch._functorch.predispatch import (
+            _enter_dual_level,
+            _exit_dual_level,
             _jvp_decrement_nesting,
             _jvp_increment_nesting,
+            _make_dual,
+            _unpack_dual,
+            _unwrap_for_grad,
+            lazy_load_decompositions,
         )
 
         class JVP(torch.nn.Module):
@@ -2574,10 +2581,20 @@ class TestPredispatchSerialization(TestCase):
         self.assertIn("_jvp_increment_nesting", graph_str)
         self.assertIn("_jvp_decrement_nesting", graph_str)
 
-        buffer = io.BytesIO()
-        torch.export.save(ep, buffer)
-        buffer.seek(0)
-        loaded_ep = torch.export.load(buffer)
+        with unsafe_allow_callable_serialization(
+            _jvp_increment_nesting,
+            _jvp_decrement_nesting,
+            _make_dual,
+            _unpack_dual,
+            _unwrap_for_grad,
+            _enter_dual_level,
+            _exit_dual_level,
+            lazy_load_decompositions,
+        ):
+            buffer = io.BytesIO()
+            torch.export.save(ep, buffer)
+            buffer.seek(0)
+            loaded_ep = torch.export.load(buffer)
 
         loaded_graph_str = str(loaded_ep.graph)
         self.assertIn("_jvp_increment_nesting", loaded_graph_str)
@@ -2598,6 +2615,13 @@ class TestPredispatchSerialization(TestCase):
 
     def test_predispatch_vmap_serialize_roundtrip(self):
         """Test that vmap predispatch wrapper functions survive serialization round-trip."""
+        from torch._functorch.predispatch import (
+            _add_batch_dim,
+            _remove_batch_dim,
+            _vmap_decrement_nesting,
+            _vmap_increment_nesting,
+            lazy_load_decompositions,
+        )
         from torch.export._trace import _export
 
         class Vmap(torch.nn.Module):
@@ -2614,10 +2638,17 @@ class TestPredispatchSerialization(TestCase):
         self.assertIn("_vmap_increment_nesting", graph_str)
         self.assertIn("_vmap_decrement_nesting", graph_str)
 
-        buffer = io.BytesIO()
-        torch.export.save(ep, buffer)
-        buffer.seek(0)
-        loaded_ep = torch.export.load(buffer)
+        with unsafe_allow_callable_serialization(
+            _vmap_increment_nesting,
+            _vmap_decrement_nesting,
+            _add_batch_dim,
+            _remove_batch_dim,
+            lazy_load_decompositions,
+        ):
+            buffer = io.BytesIO()
+            torch.export.save(ep, buffer)
+            buffer.seek(0)
+            loaded_ep = torch.export.load(buffer)
 
         # Verify predispatch nodes survive round-trip
         loaded_graph_str = str(loaded_ep.graph)
@@ -2627,6 +2658,35 @@ class TestPredispatchSerialization(TestCase):
         exp_out = ep.module()(*inp)
         actual_out = loaded_ep.module()(*inp)
         self.assertTrue(torch.allclose(exp_out, actual_out))
+
+    def test_callable_serialization_blocked_by_default(self):
+        """Serializing callable targets should fail without unsafe_allow_callable_serialization()."""
+
+        class JVP(torch.nn.Module):
+            def foo(self, x, r, t) -> torch.Tensor:
+                return x - 0.1 * r + 0.1 * t
+
+            def forward(self, x, y, r, t, z, o) -> tuple[torch.Tensor, torch.Tensor]:
+                return torch.func.jvp(
+                    self.foo,
+                    (x, r, t),
+                    (y, z, o),
+                )
+
+        inp = (
+            torch.rand(2, 4),
+            torch.rand(2, 4),
+            torch.rand(2, 1),
+            torch.rand(2, 1),
+            torch.zeros(2, 1),
+            torch.ones(2, 1),
+        )
+
+        ep = export(JVP(), inp, strict=False)
+
+        buffer = io.BytesIO()
+        with self.assertRaisesRegex(SerializeError, "not supported by default"):
+            torch.export.save(ep, buffer)
 
 
 if __name__ == "__main__":

--- a/torch/_export/serde/__init__.py
+++ b/torch/_export/serde/__init__.py
@@ -1,0 +1,40 @@
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+from typing import Any
+
+
+_UNSAFE_EXPORT_CALLABLES: set[Callable[..., Any]] = set()
+
+
+def _is_unsafe_callable_registered(fn: Callable[..., Any]) -> bool:
+    return fn in _UNSAFE_EXPORT_CALLABLES
+
+
+@contextmanager
+def unsafe_allow_callable_serialization(
+    *callables: Callable[..., Any],
+) -> Generator[None, None, None]:
+    """Context manager that temporarily registers callables for export serialization.
+
+    Registers the given callables on entry and removes them on exit. Callables
+    that were already registered before entering the context are preserved after
+    exit.
+
+    Args:
+        *callables: One or more callable objects to temporarily allow for serialization.
+
+    Example::
+
+        from torch._export.serde import unsafe_allow_callable_serialization
+        from torch._functorch.predispatch import _jvp_increment_nesting
+
+        with unsafe_allow_callable_serialization(_jvp_increment_nesting):
+            torch.export.save(ep, buffer)
+    """
+    already_registered = {c for c in callables if c in _UNSAFE_EXPORT_CALLABLES}
+    _UNSAFE_EXPORT_CALLABLES.update(callables)
+    try:
+        yield
+    finally:
+        newly_added = set(callables) - already_registered
+        _UNSAFE_EXPORT_CALLABLES.difference_update(newly_added)

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -27,6 +27,7 @@ import sympy
 import torch
 import torch.export.exported_program as ep
 from torch._export.non_strict_utils import _enable_graph_inputs_of_type_nn_module
+from torch._export.serde import _is_unsafe_callable_registered
 from torch._export.verifier import load_verifier
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.fx._symbolic_trace import _ConstantAttributeType
@@ -1022,8 +1023,13 @@ class GraphModuleSerializer(metaclass=Final):
                 metadata=self.serialize_metadata(node),
             )
         elif callable(node.target):
-            # Handle predispatch wrapper functions (vmap, JVP, etc.) that appear
-            # as plain Python function call_function nodes in pre_dispatch graphs.
+            if not _is_unsafe_callable_registered(node.target):
+                raise SerializeError(
+                    f"Serializing callable {node.target} is not supported by default. "
+                    "Use torch._export.serde.unsafe_allow_callable_serialization() to "
+                    "register specific callables for serialization (no backwards "
+                    "compatibility guarantee)."
+                )
             ex_node = Node(
                 name=node.name,
                 target=self.serialize_operator(node.target),
@@ -2711,7 +2717,12 @@ class GraphModuleDeserializer(metaclass=Final):
             )
             self.deserialize_outputs(serialized_node, fx_node)
         elif callable(target):
-            # Handle predispatch wrapper functions (vmap, JVP, etc.)
+            if not _is_unsafe_callable_registered(target):
+                raise SerializeError(
+                    f"Deserializing callable {target} is not supported by default. "
+                    "Use torch._export.serde.unsafe_allow_callable_serialization() to "
+                    "register specific callables for deserialization."
+                )
             args, kwargs = self.deserialize_hoo_inputs(serialized_node.inputs)
             name = serialized_node.name if serialized_node.name else None
             fx_node = self.graph.create_node(


### PR DESCRIPTION
Summary:
Add `unsafe_allow_callable_serialization`, a context manager in `torch._export.serde` that temporarily registers Python callables for export serialization and unregisters them on exit. This gates serialization/deserialization of arbitrary Python callables (e.g. predispatch wrappers like JVP/vmap) behind explicit, scoped registration.

Unregistered callables raise `SerializeError` with a guidance message pointing to `unsafe_allow_callable_serialization()`.

The context manager tracks which callables were already registered before entering and only removes newly added ones on exit, making it safe to nest or use alongside other registrations.

Changes:
- `torch/_export/serde/__init__.py`: `_UNSAFE_EXPORT_CALLABLES` private registry, `_is_unsafe_callable_registered()` check, and `unsafe_allow_callable_serialization()` public context manager
- `torch/_export/serde/serialize.py`: Gate `elif callable(...)` branches in serializer and deserializer with per-callable registry check, raising `SerializeError` if callable is not registered

Test Plan:
Added `test_callable_serialization_blocked_by_default` to verify that serializing callable targets (JVP predispatch wrappers) raises `SerializeError` without registration. Updated existing `test_predispatch_jvp_serialize_roundtrip` and `test_predispatch_vmap_serialize_roundtrip` to register the specific predispatch callables before save/load.

buck2 test //caffe2/test:test_export -- TestPredispatchSerialization

Differential Revision: D103437485


