### PR TITLE
[inductor] Fix circular import in mkldnn_lowerings

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8752,9 +8752,10 @@ from . import quantized_lowerings
 quantized_lowerings.register_quantized_ops()
 quantized_lowerings.register_woq_mm_ops()
 
-from . import mkldnn_lowerings  # noqa: F401  # registers oneDNN fusion ops on import
-
-from . import jagged_lowerings
+from . import (
+    jagged_lowerings,
+    mkldnn_lowerings,  # noqa: F401  # registers oneDNN fusion ops on import
+)
 
 
 jagged_lowerings.register_jagged_ops()

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -8752,10 +8752,7 @@ from . import quantized_lowerings
 quantized_lowerings.register_quantized_ops()
 quantized_lowerings.register_woq_mm_ops()
 
-from . import mkldnn_lowerings
-
-
-mkldnn_lowerings.register_onednn_fusion_ops()
+from . import mkldnn_lowerings  # noqa: F401  # registers oneDNN fusion ops on import
 
 from . import jagged_lowerings
 

--- a/torch/_inductor/mkldnn_lowerings.py
+++ b/torch/_inductor/mkldnn_lowerings.py
@@ -1397,3 +1397,6 @@ def register_onednn_fusion_ops():
                 return result
 
         add_needs_realized_inputs(cpu_needs_realized_inputs)
+
+
+register_onednn_fusion_ops()


### PR DESCRIPTION
When `torch._inductor.mkldnn_lowerings` is the first of its peers to be imported (e.g. via `test_circular_dependencies`'s `os.walk` order on certain filesystems), its top-level imports trigger `torch._inductor.lowering` to start executing. Before `lowering` finishes, it transitively re-enters `mkldnn_lowerings` and reaches its bottom-of-file `mkldnn_lowerings.register_onednn_fusion_ops()` call. At that point `register_onednn_fusion_ops` is not yet defined in the partially-initialized `mkldnn_lowerings` module, raising:

    AttributeError: partially initialized module
    'torch._inductor.mkldnn_lowerings' has no attribute
    'register_onednn_fusion_ops'
    (most likely due to a circular import)

The failure is filesystem-order-dependent, which is why it surfaces intermittently on rocm-mi300 (shard 4/6 most recently).

Move the `register_onednn_fusion_ops()` invocation from `lowering.py` to the bottom of `mkldnn_lowerings.py` itself, after the function definition. `lowering.py` keeps `from . import mkldnn_lowerings` so importing `lowering` still triggers oneDNN fusion-op registration as a side effect; the explicit call is no longer needed because importing `mkldnn_lowerings` now self-registers. Both import orderings produce identical `len(torch._inductor.lowering.lowerings)` (1816), and a clean subprocess `python -c "import torch._inductor.mkldnn_lowerings"` goes from exit 1 (cycle) to exit 0.

Refs #127777, #168860, #168859

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos