### PR TITLE
[Dynamo] Fix CPython test_instancecheck_and_subclasscheck with pytest 9.x

### DIFF
--- a/torch/_dynamo/test_case.py
+++ b/torch/_dynamo/test_case.py
@@ -234,6 +234,12 @@ class CPythonTestCase(TestCase):
             ),
         )
 
+    @contextlib.contextmanager
+    def subTest(self, *args, **kwargs):
+        # pytest 9.x addSubTest uses typing._GenericAlias calls that
+        # Dynamo cannot trace. Use a no-op subTest instead.
+        yield
+
     # pyrefly: ignore [implicit-any]
     def wrap_with_policy(self, method_name: str, policy: Callable) -> None:
         pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #182186
* #181942
* __->__ #182191


Fix CI test failures arising from https://github.com/pytorch/pytorch/pull/180271

Pytest 9.x's addSubTest uses CallInfo[None](...) which involves
typing._GenericAlias calls that Dynamo cannot trace through. Override
subTest in CPythonTestCase with a no-op context manager to avoid
tracing into pytest internals.



Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98