### PR TITLE
[CUDA] Fix non-deterministic failure with test/inductor/test_codecache

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -669,6 +669,10 @@ class TestFxGraphCache(TestCase):
                     "fx_graph_remote_cache": True,
                     "bundle_triton_into_fx_graph_cache": bundle_triton,
                     "use_static_triton_launcher": use_static_triton_launcher,
+                    # Disable shape padding to avoid non-deterministic pad_mm
+                    # benchmarking which can produce different FX graphs across
+                    # fresh_cache() iterations, causing flaky cache stats.
+                    "shape_padding": False,
                 }
             ),
             patch.dict(os.environ),


### PR DESCRIPTION
Background: 
During nightly testing, we encountered the following failures: 

python test/inductor/test_codecache.py TestFxGraphCache.test_remote_cache_load_function_device_cuda_float32_dynamic_False_bundle_triton_False_use_static_triton_launcher_False

AssertionError: Object comparison failed: _GlobalItemStats(num_put=2, num_get_hit=2, num_get_miss=2) != Stats(num_put=1, num_get_hit=3, num_get_miss=1)

I originally had a wrong bisect in [here](https://github.com/pytorch/pytorch/pull/179063#issuecomment-4361281289) , further triage results shown below:  

 Root cause: The _should_pad function in torch/_inductor/fx_passes/pad_mm.py runs GPU micro-benchmarks to decide whether to pad matmul operands for better Tensor Core utilization. For the 5x5 matrix used 
  in this test (y @ y), the benchmark results are non-deterministic — sometimes the padded (5→8) version is faster, sometimes it's not. Since fresh_cache() clears the padding memoizer between loop         
  iterations, each iteration re-benchmarks and can get a different answer, producing a different FX graph (with or without constant_pad_nd ops) and thus a different cache key. This breaks the test's       
  assumption that all 4 iterations produce the same graph/key.                                                                                                                                               
                                                                                                                                                                                                             
  Fix: Added "shape_padding": False to the config.patch in test_remote_cache_load_function. This disables the non-deterministic pad_mm benchmarking, ensuring the FX graph is consistent across iterations.  
  The test is about verifying remote cache hit/miss behavior, not about matmul padding, so disabling it is appropriate.  

Test: after applying this fix, the test succeeded 30 out of 30 times. 

Authored with Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @eqy @tinglvv @ptrblck @atalman @malfet @rpsilva-aws 