### PR TITLE
torch.cat/concat/concatenate: support dim=None (flatten before concat)

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -2882,7 +2882,7 @@ def broadcast_to(a: TensorLikeType, size: ShapeType) -> TensorLikeType:
     type_promoting_args=("tensors",),
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.NO_OPMATH,
 )
-def cat(tensors: TensorSequenceType, dim: int = 0) -> TensorLikeType:
+def cat(tensors: TensorSequenceType, dim: int | None = 0) -> TensorLikeType:
     def cat_compute_output_memory_format(inputs):
         format = None
         for t in inputs:
@@ -2899,6 +2899,10 @@ def cat(tensors: TensorSequenceType, dim: int = 0) -> TensorLikeType:
     if len(tensors) == 0:
         msg = "cat expects at least one tensor, but received zero!"
         raise ValueError(msg)
+
+    if dim is None:
+        tensors = [t.flatten() for t in tensors]
+        dim = 0
 
     for tensor in tensors:
         if not isinstance(tensor, TensorLike):

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -33,6 +33,9 @@ __all__ = [
     "istft",
     "lu",
     "norm",
+    "cat",
+    "concat",
+    "concatenate",
     "meshgrid",
     "pca_lowrank",
     "split",
@@ -382,6 +385,57 @@ def einsum(*args: Any) -> Tensor:
         path = [*itertools.chain.from_iterable(tupled_path)]
     return _VF.einsum(equation, operands, path=path)  # type: ignore[attr-defined]
 
+
+def cat(tensors, dim=0, *, out=None):
+    r"""Concatenates the given sequence of :attr:`tensors` in the given dimension.
+
+    All tensors must either have the same shape (except in the concatenating
+    dimension) or be a 1-D empty tensor with size ``(0,)``.
+
+    If :attr:`dim` is ``None``, each tensor is first flattened into a 1-D
+    tensor and then concatenated along ``dim=0``. This is consistent with the
+    `Python Array API Standard <https://data-apis.org/array-api/latest/>`_ and
+    :func:`numpy.concatenate`.
+
+    :func:`torch.cat` can be seen as an inverse operation for :func:`torch.split`
+    and :func:`torch.chunk`.
+
+    Args:
+        tensors (sequence of Tensors): any python sequence of tensors of the
+            same type. Non-empty tensors provided must have the same shape,
+            except in the cat dimension.
+        dim (int or None): the dimension over which the tensors are concatenated.
+            If ``None``, tensors are flattened before concatenation. Default: ``0``.
+        out (Tensor, optional): the output tensor.
+
+    Example::
+
+        >>> x = torch.randn(2, 3)
+        >>> torch.cat((x, x, x), 0)
+        tensor([[ 0.6580, -1.0969, -0.4614],
+                [-0.1034, -0.5790,  0.1497],
+                [ 0.6580, -1.0969, -0.4614],
+                [-0.1034, -0.5790,  0.1497],
+                [ 0.6580, -1.0969, -0.4614],
+                [-0.1034, -0.5790,  0.1497]])
+        >>> torch.cat((x, x, x), 1)
+        tensor([[ 0.6580, -1.0969, -0.4614,  0.6580, -1.0969, -0.4614,  0.6580,
+                 -1.0969, -0.4614],
+                [-0.1034, -0.5790,  0.1497, -0.1034, -0.5790,  0.1497, -0.1034,
+                 -0.5790,  0.1497]])
+        >>> torch.cat([torch.tensor([[1, 2], [3, 4]]), torch.tensor([[5, 6]])], dim=None)
+        tensor([1, 2, 3, 4, 5, 6])
+    """
+    if dim is None:
+        tensors = [t.flatten() for t in tensors]
+        dim = 0
+    if out is None:
+        return torch._C._VariableFunctions.cat(tensors, dim)
+    return torch._C._VariableFunctions.cat(tensors, dim, out=out)
+
+
+concat = cat
+concatenate = cat
 
 # This wrapper exists to support variadic args.
 if TYPE_CHECKING:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2486,7 +2486,9 @@ def sample_inputs_cat_concat(op_info, device, dtype, requires_grad, **kwargs):
         ((0,), (0,), {'dim': 0}),  # empty tensor
         ((0,), (S, S), {'dim': 1}),  # empty tensor with unempty and dim=1 (special case for legacy_cat_wrap_dim)
         ((0, S), (S, S), {'dim': 0}),
-        ((1,), (1,), {})  # dim not passed, fallback to default
+        ((1,), (1,), {}),  # dim not passed, fallback to default
+        ((S, S), (S, S), {'dim': None}),  # dim=None: flatten then cat
+        ((S,), (S, S), {'dim': None}),    # dim=None with different shapes
     )
 
     for input_shape1, input_shape2, kwargs in cases:


### PR DESCRIPTION
Fixes #70925

## Summary

The Python Array API Standard specifies that `concat(tensors, dim=None)`
should first flatten all tensors then concatenate them, consistent with
`numpy.concatenate(axis=None)`.

Previously, `torch.cat([t1, t2], dim=None)` raised a RuntimeError.
After this PR:

```python
t1 = torch.tensor([[1, 2], [3, 4]])
t2 = torch.tensor([[5, 6]])
torch.cat([t1, t2], dim=None)
# tensor([1, 2, 3, 4, 5, 6])

Changes
torch/functional.py: Added Python wrapper for cat with dim=None support; concat and concatenate now point to the same wrapper
torch/_refs/__init__.py: Updated _refs.cat (FakeTensor path) with the same logic
common_methods_invocations.py: Added test cases for dim=None