### PR TITLE
[autograd] Allow positional arguments to be passed as kwargs for autograd custom Function

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -546,6 +546,156 @@ class TestAutograd(TestCase):
         self.assertEqual("bar", res[5])
         self.assertEqual(t1, res[6])
 
+    def test_custom_function_apply_kwargs(self):
+        class MySin(Function):
+            @staticmethod
+            def forward(ctx, input, factor=1):
+                ctx.save_for_backward(input)
+                ctx.factor = factor
+                return factor * torch.sin(input)
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                (input,) = ctx.saved_tensors
+                return grad_output * ctx.factor * torch.cos(input), None
+
+        x = torch.tensor([0.812], requires_grad=True)
+
+        # Baseline: positional
+        out_pos = MySin.apply(x, 6)
+        out_pos.backward()
+        grad_pos = x.grad.clone()
+
+        # kwarg
+        x.grad = None
+        out_kw = MySin.apply(x, factor=6)
+        self.assertEqual(out_kw, out_pos)
+        out_kw.backward()
+        self.assertEqual(x.grad, grad_pos)
+
+        # default value (no kwarg)
+        x.grad = None
+        out_default = MySin.apply(x)
+        out_default_expected = MySin.apply(x, 1)
+        self.assertEqual(out_default, out_default_expected)
+
+    def test_custom_function_apply_kwargs_required(self):
+        class Add(Function):
+            @staticmethod
+            def forward(ctx, x, y):
+                ctx.save_for_backward(x, y)
+                return x + y
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return grad_output, grad_output
+
+        x = torch.tensor([2.0], requires_grad=True)
+        y = torch.tensor([3.0], requires_grad=True)
+
+        # All required args as kwargs
+        out = Add.apply(x=x, y=y)
+        self.assertEqual(out, torch.tensor([5.0]))
+        out.backward()
+        self.assertEqual(x.grad, torch.tensor([1.0]))
+        self.assertEqual(y.grad, torch.tensor([1.0]))
+
+        # Swap order of kwargs
+        x.grad = None
+        y.grad = None
+        out = Add.apply(y=y, x=x)
+        self.assertEqual(out, torch.tensor([5.0]))
+        out.backward()
+        self.assertEqual(x.grad, torch.tensor([1.0]))
+        self.assertEqual(y.grad, torch.tensor([1.0]))
+
+    def test_custom_function_apply_kwargs_tensor(self):
+        class ScaledMul(Function):
+            @staticmethod
+            def forward(ctx, x, y, scale=1.0):
+                ctx.save_for_backward(x, y)
+                ctx.scale = scale
+                return scale * x * y
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                x, y = ctx.saved_tensors
+                return (
+                    grad_output * ctx.scale * y,
+                    grad_output * ctx.scale * x,
+                    None,
+                )
+
+        x = torch.tensor([2.0], requires_grad=True)
+        y = torch.tensor([3.0], requires_grad=True)
+
+        # Tensor args as kwargs
+        out = ScaledMul.apply(x, y=y, scale=5.0)
+        self.assertEqual(out, torch.tensor([30.0]))
+        out.backward()
+        self.assertEqual(x.grad, torch.tensor([15.0]))
+        self.assertEqual(y.grad, torch.tensor([10.0]))
+
+    def test_custom_function_apply_kwargs_setup_context(self):
+        class MyScale(Function):
+            @staticmethod
+            def forward(x, factor=1):
+                return factor * x
+
+            @staticmethod
+            def setup_context(ctx, inputs, output):
+                x, factor = inputs
+                ctx.save_for_backward(x)
+                ctx.factor = factor
+
+            @staticmethod
+            def backward(ctx, gO):
+                return gO * ctx.factor, None
+
+        x = torch.randn([], requires_grad=True)
+        y = MyScale.apply(x, factor=3)
+        (gx,) = torch.autograd.grad(y, x)
+        self.assertEqual(gx, torch.tensor(3.0))
+
+    def test_custom_function_apply_kwargs_errors(self):
+        class MyFn(Function):
+            @staticmethod
+            def forward(ctx, x, y):
+                return x + y
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return grad_output, grad_output
+
+        x = torch.tensor([1.0])
+        y = torch.tensor([2.0])
+
+        with self.assertRaisesRegex(TypeError, "got an unexpected keyword argument"):
+            MyFn.apply(x, bad_kwarg=y)
+
+        # Duplicate: positional + kwarg for same param
+        with self.assertRaisesRegex(
+            TypeError, "got multiple values for argument"
+        ):
+            MyFn.apply(x, y, y=y)
+
+        # kwarg collides with an earlier positional arg: f(x, y, z) called
+        # as f(2, 3, y=4) — y is already filled by position 1
+        class MyFn3(Function):
+            @staticmethod
+            def forward(ctx, x, y, z):
+                return x + y + z
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return grad_output, grad_output, grad_output
+
+        z = torch.tensor([3.0])
+        with self.assertRaisesRegex(
+            TypeError, "got multiple values for argument"
+        ):
+            MyFn3.apply(x, y, y=z)
+
     def test_invalid_gradients(self):
         class MyFunction(Function):
             @staticmethod

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -618,6 +618,7 @@ class Function(_SingleLevelFunction):
         is_setup_ctx_defined = _is_setup_context_defined(cls.setup_context)
         if is_setup_ctx_defined:
             args = bind_default_args(cls.forward, *args, **kwargs)
+            kwargs = {}
 
         if not torch._C._are_functorch_transforms_active():
             # See NOTE: [functorch vjp and autograd interaction]

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -1349,8 +1349,174 @@ static PyObject* get_base_setup_context() {
   return setup_context;
 }
 
-PyObject* THPFunction_apply(PyObject* cls, PyObject* inputs) {
+// Given cls (a Function subclass), args, and kwargs, resolve kwargs into
+// positional arguments by inspecting the forward method's signature.
+// Returns a new reference to a tuple of positional args.
+static PyObject* resolve_kwargs_to_positional(
+    PyObject* cls,
+    PyObject* args,
+    PyObject* kwargs) {
+  if (!kwargs || PyDict_Size(kwargs) == 0) {
+    Py_INCREF(args);
+    return args;
+  }
+
+  THPObjectPtr forward_fn(PyObject_GetAttrString(cls, "forward"));
+  if (!forward_fn)
+    return nullptr;
+
+  // Get the function's code object to read parameter names.
+  // For staticmethod-wrapped functions, we need the underlying function.
+  PyObject* func = forward_fn.get();
+  THPObjectPtr code_obj(PyObject_GetAttrString(func, "__code__"));
+  if (!code_obj) {
+    PyErr_Clear();
+    PyErr_SetString(
+        PyExc_TypeError,
+        "apply() cannot resolve keyword arguments: "
+        "could not inspect forward() signature");
+    return nullptr;
+  }
+
+  THPObjectPtr varnames_obj(
+      PyObject_GetAttrString(code_obj.get(), "co_varnames"));
+  THPObjectPtr argcount_obj(
+      PyObject_GetAttrString(code_obj.get(), "co_argcount"));
+  if (!varnames_obj || !argcount_obj)
+    return nullptr;
+
+  Py_ssize_t co_argcount = PyLong_AsSsize_t(argcount_obj.get());
+  if (co_argcount < 0 && PyErr_Occurred())
+    return nullptr;
+
+  // Determine if forward takes ctx as first arg.
+  // If setup_context is overridden, forward does NOT take ctx.
+  auto cls_setup_context =
+      THPObjectPtr(PyObject_GetAttrString(cls, "setup_context"));
+  if (!cls_setup_context)
+    return nullptr;
+  auto orig_setup_context = get_base_setup_context();
+  if (!orig_setup_context)
+    return nullptr;
+  bool has_ctx = (cls_setup_context.get() == orig_setup_context);
+
+  // param_offset: number of leading params to skip (ctx for old-style)
+  Py_ssize_t param_offset = has_ctx ? 1 : 0;
+
+  // Number of user-visible parameters (excluding ctx)
+  Py_ssize_t num_params = co_argcount - param_offset;
+  Py_ssize_t num_positional = PyTuple_GET_SIZE(args);
+  Py_ssize_t num_kwargs = PyDict_Size(kwargs);
+
+  // Validate kwargs and find the max positional index they map to.
+  // We do this before the count check so that "multiple values for argument"
+  // takes priority over "takes N positional arguments but M were given".
+  Py_ssize_t max_kwarg_idx = num_positional - 1;
+  {
+    PyObject* key = nullptr;
+    PyObject* value = nullptr;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(kwargs, &pos, &key, &value)) {
+      if (!PyUnicode_Check(key)) {
+        PyErr_SetString(PyExc_TypeError, "keywords must be strings");
+        return nullptr;
+      }
+
+      Py_ssize_t param_idx = -1;
+      for (Py_ssize_t i = param_offset; i < co_argcount; i++) {
+        PyObject* varname = PyTuple_GET_ITEM(varnames_obj.get(), i);
+        if (PyUnicode_Compare(key, varname) == 0) {
+          param_idx = i - param_offset;
+          break;
+        }
+      }
+
+      if (param_idx < 0) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "forward() got an unexpected keyword argument '%U'",
+            key);
+        return nullptr;
+      }
+
+      if (param_idx < num_positional) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "forward() got multiple values for argument '%U'",
+            key);
+        return nullptr;
+      }
+
+      if (param_idx > max_kwarg_idx) {
+        max_kwarg_idx = param_idx;
+      }
+    }
+  }
+
+  Py_ssize_t total_args = max_kwarg_idx + 1;
+  if (total_args > num_params) {
+    PyErr_Format(
+        PyExc_TypeError,
+        "forward() takes %zd positional arguments but %zd were given",
+        num_params,
+        total_args);
+    return nullptr;
+  }
+
+  // Build result tuple
+  THPObjectPtr result(PyTuple_New(total_args));
+  if (!result)
+    return nullptr;
+
+  // Copy existing positional args
+  for (Py_ssize_t i = 0; i < num_positional; i++) {
+    PyObject* item = PyTuple_GET_ITEM(args, i);
+    Py_INCREF(item);
+    PyTuple_SET_ITEM(result.get(), i, item);
+  }
+
+  // Place kwargs into their positional slots
+  {
+    PyObject* key = nullptr;
+    PyObject* value = nullptr;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(kwargs, &pos, &key, &value)) {
+      for (Py_ssize_t i = param_offset; i < co_argcount; i++) {
+        PyObject* varname = PyTuple_GET_ITEM(varnames_obj.get(), i);
+        if (PyUnicode_Compare(key, varname) == 0) {
+          Py_INCREF(value);
+          PyTuple_SET_ITEM(result.get(), i - param_offset, value);
+          break;
+        }
+      }
+    }
+  }
+
+  // Check for gaps (kwargs that skip over unfilled positions)
+  for (Py_ssize_t i = 0; i < total_args; i++) {
+    if (PyTuple_GET_ITEM(result.get(), i) == nullptr) {
+      PyObject* varname =
+          PyTuple_GET_ITEM(varnames_obj.get(), i + param_offset);
+      PyErr_Format(
+          PyExc_TypeError,
+          "forward() missing required argument: '%U' (position %zd)",
+          varname,
+          i);
+      return nullptr;
+    }
+  }
+
+  return result.release();
+}
+
+PyObject* THPFunction_apply(PyObject* cls, PyObject* args, PyObject* kwargs) {
   HANDLE_TH_ERRORS
+
+  THPObjectPtr resolved_args(
+      resolve_kwargs_to_positional(cls, args, kwargs));
+  if (!resolved_args)
+    return nullptr;
+  PyObject* inputs = resolved_args.get();
 
   // save a local copy of seq_id before it gets incremented
   auto seq_id = at::sequence_number::peek();
@@ -1882,7 +2048,10 @@ static struct PyMethodDef THPFunction_methods[] = {
      THPFunction_maybe_clear_saved_tensors,
      METH_NOARGS,
      nullptr},
-    {(char*)"apply", THPFunction_apply, METH_CLASS | METH_VARARGS, nullptr},
+    {(char*)"apply",
+     (PyCFunction)(void*)THPFunction_apply,
+     METH_CLASS | METH_VARARGS | METH_KEYWORDS,
+     nullptr},
     {(char*)"_register_hook_dict",
      THPFunction__register_hook_dict,
      METH_O,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182205

When calling `Function.apply()`, keyword arguments are now resolved to
their positional slots by inspecting the `forward()` method's signature.
This matches standard Python calling conventions and has been a
long-requested feature (the workaround was wrapping `apply` in a helper
function that manually resolved kwargs).

The implementation reads `forward.__code__.co_varnames` to map each
kwarg to its positional index, accounting for whether `forward` takes a
`ctx` parameter (old-style) or uses `setup_context` (new-style). Error
messages match Python's conventions: "got multiple values for argument"
when a kwarg collides with a positional, and "got an unexpected keyword
argument" for unknown names.

Fixes https://github.com/pytorch/pytorch/issues/16940

Co-authored-by: Claude <noreply@anthropic.com>