### PR TITLE
Forbid Co-authored-by: Claude trailer in commit messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,11 @@ changes. Instead, if the PR is large, explain the order to review changes
 (e.g., the logical progression), or if it's short just omit the bullet list
 entirely.
 
-Disclose that the PR was authored with Claude. Do this informally in the
-commit body (e.g., "Authored by Claude."). NEVER add a `Co-authored-by: Claude`
-trailer, as it interferes with the Linux Foundation CLA bot.
+Disclose that the PR was authored with an AI assistant. Do this informally in
+the commit body (e.g., "Authored by Claude." or a similar attribution for
+whichever assistant was used). NEVER add a `Co-authored-by:` trailer
+attributing the AI assistant, as it interferes with the Linux Foundation CLA
+bot.
 
 If a commit message contains `ghstack-source-id` or `Pull-Request` trailers,
 you MUST preserve them when rewriting or splitting commit messages. ghstack

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,9 @@ changes. Instead, if the PR is large, explain the order to review changes
 (e.g., the logical progression), or if it's short just omit the bullet list
 entirely.
 
-Disclose that the PR was authored with Claude.
+Disclose that the PR was authored with Claude. Do this informally in the
+commit body (e.g., "Authored by Claude."). NEVER add a `Co-authored-by: Claude`
+trailer, as it interferes with the Linux Foundation CLA bot.
 
 If a commit message contains `ghstack-source-id` or `Pull-Request` trailers,
 you MUST preserve them when rewriting or splitting commit messages. ghstack


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #182207

The Linux Foundation CLA bot reacts to the trailer, so disclose Claude
authorship informally in the commit body instead.

Authored by Claude.