### PR TITLE
Add missing stacklevel to 57 warnings.warn() calls in torch/

### DIFF
--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -21,7 +21,7 @@ Key functionality groups:
 """
 
 import functools
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable
 from typing import Any, TYPE_CHECKING, TypeVar
 from typing_extensions import deprecated, ParamSpec
@@ -115,7 +115,7 @@ class FakeBackwardCFunction:
 
     def __getattr__(self, name: str) -> Any:
         if name == "saved_variables":
-            warnings.warn(
+            _warn_torch(
                 "'saved_variables' is deprecated; use 'saved_tensors'",
                 DeprecationWarning,
             )

--- a/torch/_dynamo/graph_id_filter.py
+++ b/torch/_dynamo/graph_id_filter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import logging
 import re
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from typing import Any, Generic, TYPE_CHECKING, TypeVar
 
 
@@ -409,7 +409,7 @@ def _create_dynamo_config_router(config_str: str) -> GraphConfigRouter:
     """
     router = GraphConfigRouter(config_str)
     if not router.is_empty():
-        warnings.warn(
+        _warn_torch(
             "TORCH_COMPILE_OVERRIDE_DYNAMO_CONFIGS is set. Dynamo config overrides are "
             "keyed by frame ID. Some dynamo configs can affect graph breaks, "
             "which may alter the number of frames and shift frame IDs, causing "

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -34,7 +34,7 @@ import sys
 import textwrap
 import traceback
 import types
-import warnings
+from torch._warn_utils import warn as _warn_torch
 import weakref
 from contextlib import contextmanager
 from copy import deepcopy
@@ -1323,7 +1323,7 @@ class GuardBuilder(GuardBuilderBase):
             and sys.version_info >= (3, 13)
             and sys.version_info < (3, 13, 1)
         ):
-            warnings.warn(
+            _warn_torch(
                 "Guards may run slower on Python 3.13.0. Consider upgrading to Python 3.13.1+.",
                 RuntimeWarning,
             )

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -33,7 +33,7 @@ import sys
 import time
 import traceback
 import types
-import warnings
+from torch._warn_utils import warn as _warn_torch
 import weakref
 from collections.abc import Callable, Generator, Sequence
 from dataclasses import dataclass, field as dc_field
@@ -2240,7 +2240,7 @@ class OutputGraph(OutputGraphCommon):
             )
             if side_effect_refs:
                 if torch._dynamo.config.side_effect_replay_policy == "warn":
-                    warnings.warn(
+                    _warn_torch(
                         f"While compiling, we found certain side effects happened in the model.forward. "
                         f"Here are the list of potential sources you can double check: {side_effect_refs}"
                     )

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -25,7 +25,7 @@ import itertools
 import logging
 import traceback
 import types
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast, Literal, Optional, TYPE_CHECKING, Union
@@ -2347,7 +2347,7 @@ class CondHigherOrderVariable(TorchHigherOrderOperatorVariable):
         # Specialize into one of the branches since pred is constant
         pred, true_fn, false_fn, operands = args
         if type(args[0]) is ConstantVariable:
-            warnings.warn(
+            _warn_torch(
                 "Pred is a Python constant. When used with torch.cond, it specializes on one of the branches."
                 " If you want torch.cond to preserve two branches, please make the predicate a boolean tensor or a SymBool.",
                 UserWarning,

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -11,7 +11,7 @@ import operator
 import os
 import os.path
 import re
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass, replace
@@ -1281,7 +1281,7 @@ def default_partition(
         if _is_functional_graph(joint_module.graph)[0] is not None:
             # Fall-back to previous behavior to avoid bc-breaking, although can
             # eventually flip the switch to make this a hard error.
-            warnings.warn(
+            _warn_torch(
                 "Trying to unsafely apply AC to a non-functional graph with the "
                 "default partitioner. Falling back to min-cut partitioner."
             )

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import threading
 import time
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable, Iterable, Sequence
 from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from ctypes import byref, c_size_t, c_void_p, CDLL
@@ -334,14 +334,14 @@ class TuningProcessPool:
                 config.max_autotune_subproc_result_timeout_seconds,
             )
         except TimeoutError:
-            warnings.warn(
+            _warn_torch(
                 f"Timed out benchmarking choice '{choice}'. It will be ignored. "
                 "Please debug the root cause in case the choice can bring perf gains."
             )
             # Set to INF so this choice will be ignored
             return float("inf")
         except Exception as process_exception:
-            warnings.warn(
+            _warn_torch(
                 f"Failed to benchmark choice '{choice}'. It will be ignored. "
                 "Please debug the root cause in case the choice can bring perf gains."
             )

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -24,7 +24,7 @@ import sys
 import tempfile
 import textwrap
 import threading
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from bisect import bisect_right
 from collections.abc import Set as AbstractSet
 from copy import copy
@@ -588,7 +588,7 @@ class FxGraphCachePickler(pickle.Pickler):
         values = t.tolist()
         elapsed = time() - start
         if elapsed > 1.0:
-            warnings.warn(
+            _warn_torch(
                 f"FX graph cache copying of a large constant took {elapsed:.1}s. "
                 "Please file an issue."
             )

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -8,7 +8,7 @@ import operator
 import os
 import re
 import sys
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable, Sequence
 from enum import Enum
 from typing import Any, cast, Optional
@@ -3897,7 +3897,7 @@ def get_loop_body_lowp_fp(_body: LoopBody) -> tuple[torch.dtype | None, bool]:
                     _use_fp32 = True
                 elif _lowp_fp_type is not None:
                     if _lowp_fp_type != opt_ctx.dtype:
-                        warnings.warn("bf16 and fp16 are mixed in the scheduler node.")
+                        _warn_torch("bf16 and fp16 are mixed in the scheduler node.")
                 else:
                     _lowp_fp_type = opt_ctx.dtype
             else:

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -11,7 +11,7 @@ import logging
 import os
 import sys
 import time
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from contextlib import AbstractContextManager
@@ -317,7 +317,7 @@ def _warn_tf32_disabled() -> None:
         and torch.backends.cuda.matmul.fp32_precision != "tf32"
         and torch.cuda.get_device_capability() >= (8, 0)
     ):
-        warnings.warn(
+        _warn_torch(
             "TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. "
             "Consider setting `torch.set_float32_matmul_precision('high')` for better performance."
         )
@@ -3126,7 +3126,7 @@ def _check_triton_bf16_support(graph: GraphLowering) -> None:
 
         device_interface = get_interface_for_device(device.type)
         device_props = device_interface.get_device_properties(device)
-        warnings.warn(
+        _warn_torch(
             f"{device_props.name} does not support bfloat16 compilation natively, skipping"
         )
         raise SkipFrame("BF16 is not supported")

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -18,7 +18,7 @@ import sys
 import sysconfig
 import tempfile
 import textwrap
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Sequence
 from ctypes import cdll, wintypes
 from ctypes.util import find_library
@@ -1265,7 +1265,7 @@ def _get_python_include_dirs() -> list[str]:
         std_lib = Path(sysconfig.get_path("stdlib"))
         include_dir = (std_lib.parent.parent / "Headers").absolute()
     if not (include_dir / "Python.h").exists():
-        warnings.warn(f"Can't find Python.h in {str(include_dir)}")
+        _warn_torch(f"Can't find Python.h in {str(include_dir)}")
     return [str(include_dir)]
 
 
@@ -1399,7 +1399,7 @@ def _get_openmp_args(
                 include_dir_paths.append(os.path.join(omp_prefix, "include"))
                 lib_dir_paths.append(os.path.join(omp_prefix, "lib"))
             else:
-                warnings.warn("environment variable `OMP_PREFIX` is invalid.")
+                _warn_torch("environment variable `OMP_PREFIX` is invalid.")
             omp_available = omp_available or valid_env
 
         if not omp_available:

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -6,7 +6,7 @@ import platform
 import re
 import subprocess
 import sys
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable
 from typing import Any
 
@@ -490,7 +490,7 @@ def get_isa_from_cpu_capability(
                 return vec_isa
 
     if capability:
-        warnings.warn(f"ignoring invalid value for ATEN_CPU_CAPABILITY {capability}")
+        _warn_torch(f"ignoring invalid value for ATEN_CPU_CAPABILITY {capability}")
 
     return vec_isa_list[0]
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -47,6 +47,7 @@ import sys
 import threading
 import traceback
 import warnings
+from torch._warn_utils import warn as _warn_torch
 import weakref
 from collections import defaultdict
 from contextlib import AbstractContextManager
@@ -2623,7 +2624,7 @@ class CUDAGraphTreeManager:
             return
 
         self.warned_functions.add(function_id)
-        warnings.warn(
+        _warn_torch(
             "Unable to hit fast path of CUDAGraphs because outputs from a previous step "
             "still require backward. Ensure backward() is invoked or detach outputs. "
             "You may also call torch.compiler.cudagraph_mark_step_begin() before each model invocation."

--- a/torch/_inductor/fx_passes/fuse_attention.py
+++ b/torch/_inductor/fx_passes/fuse_attention.py
@@ -2,7 +2,7 @@
 import functools
 import inspect
 import logging
-import warnings
+from torch._warn_utils import warn as _warn_torch
 
 import torch
 
@@ -848,7 +848,7 @@ def _warn_tf32_disabled() -> None:
         and torch.backends.cuda.matmul.fp32_precision != "tf32"
         and torch.cuda.get_device_capability() >= (8, 0)
     ):
-        warnings.warn(
+        _warn_torch(
             "TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. "
             "Skipping pattern matching to fused flash-attention. "
             "Consider setting `torch.set_float32_matmul_precision('high')` for better performance."

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 import math
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, cast, TYPE_CHECKING
@@ -794,7 +794,7 @@ def flex_attention_backward(*args, **kwargs):
                 "is not yet implemented. The TRITON backend supports deterministic backward."
             )
         if torch.is_deterministic_algorithms_warn_only_enabled() and needs_block_mask:
-            warnings.warn(
+            _warn_torch(
                 "Deterministic backward for flex_attention with block_mask using the FLASH backend "
                 "is not yet implemented. Running non-deterministic backward.",
             )

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -10,7 +10,7 @@ import math
 import operator
 import os
 import sys
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections import defaultdict
 from collections.abc import Callable, Collection, Iterable, Sequence
 from typing import Any, cast, TYPE_CHECKING, TypeGuard, TypeVar
@@ -2492,7 +2492,7 @@ def fallback_handler(kernel, add_to_fallback_set=True):
 
 @functools.cache
 def _warn_complex_not_supported():
-    warnings.warn(
+    _warn_torch(
         "Torchinductor does not support code generation for complex operators. Performance may be worse than eager."
     )
 

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import inspect
 import itertools
 import re
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from io import StringIO
 from typing import Any, Generic, Literal, NamedTuple, TYPE_CHECKING, TypeVar
 from unittest.mock import patch
@@ -789,7 +789,7 @@ class DefaultHandler(OpsHandler[Any]):
             return self._default(name, args, kwargs)
 
         # would like to remove this function entirely, but it's used in MTIA backend
-        warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")
+        _warn_torch(f"undefined OpHandler.{name}, please add missing op schema")
         return fallback
 
     @staticmethod

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -6,6 +6,7 @@ import os
 import sys
 import time
 import warnings
+from torch._warn_utils import warn as _warn_torch
 from pathlib import Path
 from types import ModuleType
 from typing import Any, TYPE_CHECKING
@@ -48,7 +49,7 @@ def _set_triton_ptxas_path() -> None:
     if ptxas.is_file() and os.access(ptxas, os.X_OK):
         os.environ["TRITON_PTXAS_PATH"] = str(ptxas)
     else:
-        warnings.warn(f"{ptxas} exists but is not an executable")
+        _warn_torch(f"{ptxas} exists but is not an executable")
 
 
 def _set_triton_libdevice_path() -> None:

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-decorators
 # mypy: allow-untyped-defs
 import math as pymath
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable
 from typing import Any, TypeVar
 
@@ -29,7 +29,7 @@ def set_driver_to_cpu():
         driver.set_active(backend.driver())
         return
     # This can be a hard error once triton-cpu is merged into fbcode
-    warnings.warn(
+    _warn_torch(
         "Could not find an active CPU backend. Generated kernels will not be executable!"
     )
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -23,7 +23,7 @@ import tempfile
 import textwrap
 import time
 import unittest
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import (
     Callable,
     Collection,
@@ -2185,7 +2185,7 @@ def use_cutlass_template(layout: Layout, m: int, n: int, k: int) -> bool:
     # for the compiled CUTLASS .so, similar to how the triton branch uses
     # static CUfunction + loadKernel for non-AOT mode.
     if V.graph.cpp_wrapper and not V.graph.aot_mode:
-        warnings.warn(
+        _warn_torch(
             "CUTLASS backend is not supported with non-AOT cpp_wrapper mode. "
             "Skipping CUTLASS backend.",
         )

--- a/torch/_subclasses/complex_tensor/_ops/aten.py
+++ b/torch/_subclasses/complex_tensor/_ops/aten.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from typing import TYPE_CHECKING
 
 import torch
@@ -731,7 +731,7 @@ def copy__impl(
     **kwargs: Any,
 ) -> ComplexTensor | torch.Tensor:
     if not self.dtype.is_complex:
-        warnings.warn(
+        _warn_torch(
             "Casting complex values to real discards the imaginary part", UserWarning
         )
         src_re, src_im = split_complex_arg(src)

--- a/torch/_warn_utils.py
+++ b/torch/_warn_utils.py
@@ -1,0 +1,37 @@
+"""Utility for issuing warnings that point to the caller outside of torch."""
+
+import os
+import sys
+import warnings
+
+# Compute the torch package directory once at import time.
+# Used as the prefix for skip_file_prefixes on Python >= 3.12.
+# Include both the raw and resolved (realpath) paths so that symlinked
+# installations are handled correctly.
+_here = os.path.dirname(__file__)
+_TORCH_PREFIXES: tuple[str, ...] = tuple(
+    {_here + os.sep, os.path.realpath(_here) + os.sep}
+)
+
+
+def warn(
+    message: str | Warning,
+    category: type[Warning] = UserWarning,
+    stacklevel: int = 2,
+) -> None:
+    """Issue a warning that points to the caller outside of ``torch``.
+
+    On Python >= 3.12, uses ``skip_file_prefixes`` to skip *all* frames
+    inside the ``torch`` package regardless of nesting depth.  On older
+    Pythons this falls back to the caller-supplied *stacklevel* (default 2,
+    i.e. one frame above the direct call site).
+    """
+    if sys.version_info >= (3, 12):
+        warnings.warn(
+            message,
+            category,
+            stacklevel=stacklevel,
+            skip_file_prefixes=_TORCH_PREFIXES,
+        )
+    else:
+        warnings.warn(message, category, stacklevel=stacklevel)

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -16,6 +16,7 @@ import os
 import threading
 import traceback
 import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable
 from functools import lru_cache
 from typing import Any, cast, NewType, Optional, TYPE_CHECKING
@@ -1347,14 +1348,14 @@ def _get_amdsmi_device_index_from_hip_index(device: int) -> int:
 
         _cached_hip_to_amdsmi = dict(gen())
         if not _cached_hip_to_amdsmi and len(amdsmi_handles) > 1:
-            warnings.warn(
+            _warn_torch(
                 "Cannot translate HIP ID to AMD SMI ID due to"
                 " lack of translation information prior to ROCm 6.4."
                 " Functions that rely on amdsmi"
                 " (e.g. temperature()) may operate on wrong devices."
             )
     if device not in _cached_hip_to_amdsmi:
-        warnings.warn(
+        _warn_torch(
             f"Cannot translate HIP ID {device} to AMD SMI ID due to"
             " undetected HIP ID from amdsmi."
             " amdsmi_get_gpu_enumeration_info() only report these HIP IDs"

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import math
 import os
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable, Iterable, Iterator
 from itertools import chain
 from types import CodeType, FunctionType, ModuleType, TracebackType
@@ -994,7 +994,7 @@ class Tracer(TracerBase):
                     )
                     self.create_proxy("call_function", _assert_is_none, args, {})
                 else:
-                    warnings.warn(
+                    _warn_torch(
                         f"Was not able to add assertion to guarantee correct input {name} to "
                         f"specialized function. It is up to the user to make sure that your inputs match the "
                         f"inputs you specialized the function with."

--- a/torch/fx/experimental/meta_tracer.py
+++ b/torch/fx/experimental/meta_tracer.py
@@ -1,6 +1,6 @@
 import builtins
 import functools
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable
 from typing import Any, TypeVar
 
@@ -279,7 +279,7 @@ class MetaTracer(torch.fx.Tracer):
                 raise AssertionError("Dont support composite output yet")
             rv.install_tensor_meta(meta_out)
         except Exception as e:
-            warnings.warn(f"Could not compute metadata for {kind} target {target}: {e}")
+            _warn_torch(f"Could not compute metadata for {kind} target {target}: {e}")
 
         return rv  # pyrefly: ignore [bad-return]
 

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -1,5 +1,5 @@
 import operator
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable, Iterable, Sequence
 from typing import TypeAlias, TypeVar
 from typing_extensions import ParamSpec
@@ -858,7 +858,7 @@ def gt_inference_rule(
         elif isinstance(e1, TVar) and isinstance(e2, int):
             # then we made the wrong assumption about the argument being a tensor
             # so we should fix the assumption
-            warnings.warn(
+            _warn_torch(
                 f"Made the wrong assumption for node {n}. Correctness not guaranteed."
             )
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -15,6 +15,7 @@ import re
 import types
 import typing
 import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections import defaultdict
 from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
 from contextlib import contextmanager
@@ -1580,7 +1581,7 @@ class Graph:
         if to_erase.graph != self:
             raise RuntimeError(f"Attempting to remove {to_erase} from wrong graph!")
         if to_erase._erased:
-            warnings.warn(f"erase_node({to_erase}) on an already erased node")
+            _warn_torch(f"erase_node({to_erase}) on an already erased node")
             return
 
         if (
@@ -1720,7 +1721,7 @@ class Graph:
             try:
                 submod: torch.nn.Module = mod.get_submodule(module_path)
             except AttributeError:
-                warnings.warn(f"Failed to fetch module {module_path}!")
+                _warn_torch(f"Failed to fetch module {module_path}!")
                 return False
 
             if not hasattr(submod, name):
@@ -1796,7 +1797,7 @@ class Graph:
             self.owning_module is not None
             and self.owning_module.get_submodule(module_name) is None
         ):
-            warnings.warn(
+            _warn_torch(
                 "Attempted to insert a call_module Node with "
                 "no underlying reference in the owning "
                 "GraphModule! Call "

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -8,7 +8,7 @@ import itertools
 import linecache
 import sys
 import traceback
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from pathlib import Path
 from typing import Any, cast, TYPE_CHECKING
 
@@ -740,7 +740,7 @@ class {module_name}(torch.nn.Module):
         init_file.write_text("from .module import *")
 
         if len(blobified_modules) > 0:
-            warnings.warn(
+            _warn_torch(
                 "Was not able to save the following children modules as reprs -"
                 f"saved as pickled files instead: {blobified_modules}"
             )

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -3,7 +3,7 @@ import inspect
 import numbers
 import types
 import typing
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable
 from typing import Any, cast, Literal, NamedTuple, overload, TYPE_CHECKING
 
@@ -303,7 +303,7 @@ def create_type_hint(x: object) -> object:
             return ret_type(base_type)
     except Exception:
         # We tried to create a type hint for list but failed.
-        warnings.warn(
+        _warn_torch(
             f"We were not able to successfully create type hint from the type {x}"
         )
     return x
@@ -330,7 +330,7 @@ def type_matches(signature_type: Any, argument_type: Any) -> bool:
             return True
 
         if not inspect.isclass(sig_el_type):
-            warnings.warn(
+            _warn_torch(
                 f"Does not support nested parametric types, got {signature_type}. Please file a bug."
             )
             return False

--- a/torch/jit/_async.py
+++ b/torch/jit/_async.py
@@ -9,7 +9,7 @@ This is not intended to be imported directly; please use the exposed
 functionalities in `torch.jit`.
 """
 
-import warnings
+from torch._warn_utils import warn as _warn_torch
 
 import torch
 from torch._jit_internal import Future
@@ -101,7 +101,7 @@ def fork(func, *args, **kwargs):
         mod = Mod()
         assert mod(input) == torch.jit.script(mod).forward(input)
     """
-    warnings.warn(
+    _warn_torch(
         "`torch.jit.fork` is deprecated. Please use `torch.compile` instead.",
         DeprecationWarning,
     )
@@ -121,7 +121,7 @@ def wait(future):
     Returns:
         `T`: the return value of the completed task
     """
-    warnings.warn(
+    _warn_torch(
         "`torch.jit.wait` is deprecated. Please use `torch.compile` instead.",
         DeprecationWarning,
     )

--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -5,7 +5,7 @@ This is not intended to be imported directly; please use the exposed
 functionalities in `torch.jit`.
 """
 
-import warnings
+from torch._warn_utils import warn as _warn_torch
 
 import torch
 from torch.jit._script import RecursiveScriptModule, ScriptModule
@@ -103,7 +103,7 @@ def freeze(
         You can remap devices by specifying `map_location` in `torch.jit.load`, however
         device-specific logic may have been baked into the model.
     """
-    warnings.warn(
+    _warn_torch(
         "`torch.jit.freeze` is deprecated. Please use `torch.compile` instead.",
         DeprecationWarning,
     )
@@ -227,7 +227,7 @@ def optimize_for_inference(
         # if built with MKLDNN, convolution will be run with MKLDNN weights
         assert "MKLDNN" in frozen_mod.graph
     """
-    warnings.warn(
+    _warn_torch(
         "`torch.jit.optimize_for_inference` is deprecated. Please use `torch.compile` instead.",
         DeprecationWarning,
     )

--- a/torch/jit/_fuser.py
+++ b/torch/jit/_fuser.py
@@ -1,6 +1,6 @@
 # mypy: allow-untyped-defs
 import contextlib
-import warnings
+from torch._warn_utils import warn as _warn_torch
 
 import torch
 
@@ -166,7 +166,7 @@ def set_fusion_strategy(strategy: list[tuple[str, int]]):
     NB: in the future, if more as more fusion backends are added there may be more granular
     apis for specific fusers.
     """
-    warnings.warn(
+    _warn_torch(
         "`torch.jit.set_fusion_strategy` is deprecated. Please use `torch.compile` instead.",
         DeprecationWarning,
     )

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -15,6 +15,7 @@ import inspect
 import pickle
 import sys
 import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Any, TypeVar
 from typing_extensions import deprecated, Self
@@ -356,13 +357,13 @@ class ScriptWarning(Warning):
 
 def script_method(fn):
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.script_method` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.compile` or `torch.export`.",
             DeprecationWarning,
         )
     else:
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.",
             DeprecationWarning,
         )
@@ -1479,13 +1480,13 @@ def script(
             print(scripted_model([20]))
     """
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.script` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.compile` or `torch.export`.",
             DeprecationWarning,
         )
     else:
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.",
             DeprecationWarning,
         )
@@ -1637,7 +1638,7 @@ def interface(obj: _T) -> _T:
         user_fn_jit(impls, 0, val)
         user_fn_jit(impls, 1, val)
     """
-    warnings.warn(
+    _warn_torch(
         "`torch.jit.interface` is deprecated. Please use `torch.compile` instead.",
         DeprecationWarning,
     )

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -11,7 +11,7 @@ functionalities in `torch.jit`.
 
 import os
 import sys
-import warnings
+from torch._warn_utils import warn as _warn_torch
 
 import torch
 from torch._jit_internal import _get_model_id
@@ -80,13 +80,13 @@ def save(m, f, _extra_files=None) -> None:
         torch.jit.save(m, 'scriptmodule.pt', _extra_files=extra_files)
     """
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.save` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.export`.",
             DeprecationWarning,
         )
     else:
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.save` is deprecated. Please switch to `torch.export`.",
             DeprecationWarning,
         )
@@ -167,13 +167,13 @@ def load(f, map_location=None, _extra_files=None, _restore_shapes=False):
         os.remove("scriptmodule.pt")
     """
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.load` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.export`.",
             DeprecationWarning,
         )
     else:
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.load` is deprecated. Please switch to `torch.export`.",
             DeprecationWarning,
         )

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -17,6 +17,7 @@ import os
 import re
 import sys
 import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable
 from enum import Enum
 from typing import Any, TypeVar
@@ -997,13 +998,13 @@ def trace(
 
     """
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.trace` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.compile` or `torch.export`.",
             DeprecationWarning,
         )
     else:
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.trace` is deprecated. Please switch to `torch.compile` or `torch.export`.",
             DeprecationWarning,
         )
@@ -1136,13 +1137,13 @@ def trace_module(
 
     """
     if sys.version_info >= (3, 14):
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.trace_method` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.compile` or `torch.export`.",
             DeprecationWarning,
         )
     else:
-        warnings.warn(
+        _warn_torch(
             "`torch.jit.trace_method` is deprecated. Please switch to `torch.compile` or `torch.export`.",
             DeprecationWarning,
         )

--- a/torch/nn/attention/_fa3.py
+++ b/torch/nn/attention/_fa3.py
@@ -9,7 +9,7 @@ For fp16/bf16: supports forward and backward pass.
 from __future__ import annotations
 
 import importlib
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from typing import TYPE_CHECKING
 
 
@@ -137,7 +137,7 @@ def _fa3_common_support_error(
     if query.dtype == torch.float8_e4m3fn and (
         q_descale is None or k_descale is None or v_descale is None
     ):
-        warnings.warn(
+        _warn_torch(
             "When using SDPA with fp8, descale tensor should always be used"
             " for accurate dequantization. Please use "
             "_scaled_dot_product_attention_quantized and "

--- a/torch/nn/attention/experimental/_scaled_dot_product_attention_quantized.py
+++ b/torch/nn/attention/experimental/_scaled_dot_product_attention_quantized.py
@@ -4,7 +4,7 @@ This operator implements FP8 scaled dot product attention using Flash Attention 
 This operator is experimental and subject to change.
 """
 
-import warnings
+from torch._warn_utils import warn as _warn_torch
 from enum import IntEnum
 
 import torch
@@ -132,7 +132,7 @@ def _scaled_dot_product_attention_quantized(
     if torch.is_grad_enabled() and (
         query.requires_grad or key.requires_grad or value.requires_grad
     ):
-        warnings.warn(
+        _warn_torch(
             "_scaled_dot_product_attention_quantized does not support backward pass. "
             "Gradients will not be computed for query, key, or value.",
             UserWarning,

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -13,6 +13,7 @@ import tarfile
 import tempfile
 import threading
 import warnings
+from torch._warn_utils import warn as _warn_torch
 from collections.abc import Callable
 from contextlib import closing, contextmanager
 from enum import Enum
@@ -1514,7 +1515,7 @@ def load(
             pickle_module = pickle
 
     if pickle_load_args != {} and weights_only:
-        warnings.warn("pickle_load_args only works if `weights_only=False`.")
+        _warn_torch("pickle_load_args only works if `weights_only=False`.")
 
     # make flipping default BC-compatible
     if mmap is None:

--- a/torch/utils/hipify/constants.py
+++ b/torch/utils/hipify/constants.py
@@ -7,8 +7,8 @@ and fall in three categories: 1) type of mapping, 2) API of mapping, 3) unsuppor
 mapping.
 """
 
-import warnings
-warnings.warn("hipify's constants.py is no longer used as of version 2.0.0", FutureWarning)
+from torch._warn_utils import warn as _warn_torch
+_warn_torch("hipify's constants.py is no longer used as of version 2.0.0", FutureWarning)
 
 CONV_VERSION = 0,
 CONV_INIT = 1


### PR DESCRIPTION
## Summary

57 `warnings.warn()` calls across 38 files in `torch/` (excluding tests) are missing `stacklevel`, causing warning messages to point to internal lines inside PyTorch rather than the caller's code.

### Problem

Without `stacklevel`, warnings reference internal PyTorch lines:
```
torch/cuda/__init__.py:1350: UserWarning: Cannot translate HIP ID...
torch/serialization.py:1517: UserWarning: pickle_load_args only works...
```

### Fix

New utility (`torch/_warn_utils.py`): A single `warn()` function that wraps `warnings.warn()` with `skip_file_prefixes` on Python ≥ 3.12 (no-op on 3.10/3.11, falling back to `stacklevel=2`).

- The torch package directory is computed once at import time. Both raw and `os.path.realpath` paths are included for symlink safety.
- On 3.12+, `skip_file_prefixes=(_TORCH_PREFIXES)` skips all frames inside `torch/`, regardless of nesting depth — no fragile stacklevel counting.
- On 3.10/3.11, falls back to `stacklevel=2`.

All 57 call sites now use `from torch._warn_utils import warn as _warn_torch` followed by `_warn_torch(msg, category)`.

No circular imports: `_warn_utils.py` only imports `os`, `sys`, and `warnings`.

With the fix, warnings correctly reference the user's code:
```
my_training.py:42: UserWarning: Cannot translate HIP ID...
checkpoint.py:15: UserWarning: pickle_load_args only works...
```

Supersedes #180144 (could not reopen after force-push).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Lucaskabela @azahed98 @aorenste