### PR TITLE
[MPS] Migrate bernoulli to Metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Distributions.metal
+++ b/aten/src/ATen/native/mps/kernels/Distributions.metal
@@ -100,6 +100,23 @@ REGISTER_EXPONENTIAL(float);
 REGISTER_EXPONENTIAL(half);
 REGISTER_EXPONENTIAL(bfloat);
 
+// Convert a 0/1 mask bit into the output dtype. For complex types we keep
+// the mask in the real component and zero the imaginary part — matching the
+// previous MPSGraph behaviour where bool was cast to complex via "1+0j / 0+0j".
+// `static_cast<float2>(v)` would broadcast to `(v, v)`, which is wrong here.
+template <typename T>
+inline T bernoulli_to(uint v) {
+  return static_cast<T>(v);
+}
+template <>
+inline float2 bernoulli_to<float2>(uint v) {
+  return float2(static_cast<float>(v), 0.0f);
+}
+template <>
+inline half2 bernoulli_to<half2>(uint v) {
+  return half2(static_cast<half>(v), 0.0h);
+}
+
 // Bernoulli with scalar probability p. Each thread processes 4 elements,
 // amortizing one Philox-4x32-10 round (4 uint32s) across the group so the
 // kernel becomes bandwidth-bound rather than RNG-bound.
@@ -117,7 +134,7 @@ kernel void bernoulli_scalar(
   uint count = min(4u, numel - base);
   for (uint i = 0; i < count; ++i) {
     float u = c10::metal::detail::uint32_to_uniform_float(raw[i]);
-    output[base + i] = static_cast<T>(u < p ? 1 : 0);
+    output[base + i] = bernoulli_to<T>(u < p ? 1u : 0u);
   }
 }
 
@@ -139,7 +156,7 @@ kernel void bernoulli_tensor(
   for (uint i = 0; i < count; ++i) {
     float u = c10::metal::detail::uint32_to_uniform_float(raw[i]);
     float p = probs[base + i];
-    output[base + i] = static_cast<T>(u < p ? 1 : 0);
+    output[base + i] = bernoulli_to<T>(u < p ? 1u : 0u);
   }
 }
 
@@ -164,6 +181,8 @@ REGISTER_BERNOULLI(char);
 REGISTER_BERNOULLI(short);
 REGISTER_BERNOULLI(int);
 REGISTER_BERNOULLI(long);
+REGISTER_BERNOULLI(float2);
+REGISTER_BERNOULLI(half2);
 
 // Marsaglia & Tsang (2000) acceptance-rejection method for Gamma distribution.
 // Adapted from aten/src/ATen/native/Distributions.h sample_gamma(),

--- a/aten/src/ATen/native/mps/kernels/Distributions.metal
+++ b/aten/src/ATen/native/mps/kernels/Distributions.metal
@@ -100,6 +100,71 @@ REGISTER_EXPONENTIAL(float);
 REGISTER_EXPONENTIAL(half);
 REGISTER_EXPONENTIAL(bfloat);
 
+// Bernoulli with scalar probability p. Each thread processes 4 elements,
+// amortizing one Philox-4x32-10 round (4 uint32s) across the group so the
+// kernel becomes bandwidth-bound rather than RNG-bound.
+template <typename T>
+kernel void bernoulli_scalar(
+    device T* output [[buffer(0)]],
+    constant float2& params [[buffer(1)]],
+    constant long2& seed_base_offset [[buffer(2)]],
+    constant uint& numel [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  uint base = tid * 4;
+  uint4 raw =
+      c10::metal::philox4::rand(seed_base_offset.x, seed_base_offset.y + tid);
+  float p = params.x;
+  uint count = min(4u, numel - base);
+  for (uint i = 0; i < count; ++i) {
+    float u = c10::metal::detail::uint32_to_uniform_float(raw[i]);
+    output[base + i] = static_cast<T>(u < p ? 1 : 0);
+  }
+}
+
+// Bernoulli with per-element probability tensor (float). The probability
+// buffer must be flattened and have the same numel as `output`; broadcasting
+// is handled host-side so this kernel is a straight zip over two contiguous
+// buffers plus a single Philox round per thread.
+template <typename T>
+kernel void bernoulli_tensor(
+    device T* output [[buffer(0)]],
+    device const float* probs [[buffer(1)]],
+    constant long2& seed_base_offset [[buffer(2)]],
+    constant uint& numel [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  uint base = tid * 4;
+  uint4 raw =
+      c10::metal::philox4::rand(seed_base_offset.x, seed_base_offset.y + tid);
+  uint count = min(4u, numel - base);
+  for (uint i = 0; i < count; ++i) {
+    float u = c10::metal::detail::uint32_to_uniform_float(raw[i]);
+    float p = probs[base + i];
+    output[base + i] = static_cast<T>(u < p ? 1 : 0);
+  }
+}
+
+#define REGISTER_BERNOULLI(DTYPE)                                              \
+  template [[host_name("bernoulli_scalar_" #DTYPE)]] kernel void               \
+  bernoulli_scalar<DTYPE>(                                                     \
+      device DTYPE*, constant float2&, constant long2&, constant uint&, uint); \
+  template [[host_name("bernoulli_tensor_" #DTYPE)]] kernel void               \
+  bernoulli_tensor<DTYPE>(                                                     \
+      device DTYPE*,                                                           \
+      device const float*,                                                     \
+      constant long2&,                                                         \
+      constant uint&,                                                          \
+      uint)
+
+REGISTER_BERNOULLI(float);
+REGISTER_BERNOULLI(half);
+REGISTER_BERNOULLI(bfloat);
+REGISTER_BERNOULLI(bool);
+REGISTER_BERNOULLI(uchar);
+REGISTER_BERNOULLI(char);
+REGISTER_BERNOULLI(short);
+REGISTER_BERNOULLI(int);
+REGISTER_BERNOULLI(long);
+
 // Marsaglia & Tsang (2000) acceptance-rejection method for Gamma distribution.
 // Adapted from aten/src/ATen/native/Distributions.h sample_gamma(),
 // which originates from NumPy's random module (Copyright 2005 Robert Kern).

--- a/aten/src/ATen/native/mps/operations/Distributions.mm
+++ b/aten/src/ATen/native/mps/operations/Distributions.mm
@@ -5,6 +5,7 @@
 #include <ATen/native/DistributionTemplates.h>
 #include <ATen/native/Distributions.h>
 #include <ATen/native/TensorFactories.h>
+#include <ATen/native/UnaryOps.h>
 #include <ATen/native/mps/OperationUtils.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -241,34 +242,15 @@ static Tensor& normal_mps_impl(Tensor& self,
                                  random_op_block);
 }
 
-static Tensor& bernoulli_mps_impl(Tensor& self,
-                                  const Tensor& prob_t,
-                                  std::optional<Generator> gen,
-                                  std::string op_name) {
-  TORCH_CHECK(prob_t.is_same_size(self) || prob_t.dim() == 0,
-              op_name,
-              ": probability and self tensor should be of the same shape")
-
-  RandomOpBlock random_op_block = ^RandomOpFn(cachedGraph, randomTensor) {
-    MPSGraph* mpsGraph = cachedGraph->graph();
-    cachedGraph->stdTensor = mpsGraphRankedPlaceHolder(mpsGraph, prob_t);
-    return [mpsGraph lessThanWithPrimaryTensor:randomTensor
-                               secondaryTensor:castMPSTensor(mpsGraph, cachedGraph->stdTensor, [randomTensor dataType])
-                                          name:nil];
-  };
-  // Bernoulli generates binary output so we use bool type
-  return mps::random_mps_impl<bool>(self,
-                                    0.0,
-                                    1.0,
-                                    std::nullopt,
-                                    prob_t,
-                                    MPSGraphRandomDistributionUniform,
-                                    gen,
-                                    op_name + getTensorsStringKey({prob_t}),
-                                    random_op_block);
-}
-
 } // namespace mps
+
+static Tensor& distribution_kernel_mps_impl(Tensor& self,
+                                            double param1,
+                                            double param2,
+                                            const std::string& kernel_name,
+                                            int64_t randoms_per_element,
+                                            std::optional<Generator> gen,
+                                            int64_t elements_per_thread = 1);
 
 Tensor& uniform_mps_(Tensor& self, double from, double to, std::optional<Generator> gen) {
   auto scalar_type = self.scalar_type();
@@ -341,20 +323,81 @@ Tensor& normal_mps_out(const Tensor& mean, const Tensor& std, std::optional<Gene
   return mps::normal_mps_impl(self, 0.0, 1.0, mean, std, gen, "normal");
 }
 
-Tensor& bernoulli_out_mps(const Tensor& p_, std::optional<Generator> gen, Tensor& result) {
-  result.resize_(p_.sizes());
-  return mps::bernoulli_mps_impl(result, p_, gen, __func__);
+// Tensor-p Bernoulli: dispatches the Metal `bernoulli_tensor` kernel with a
+// flat float32 probability buffer matching `self.numel()`.
+static Tensor& bernoulli_tensor_mps_impl(Tensor& self, const Tensor& p_, std::optional<Generator> gen) {
+  if (self.numel() == 0) {
+    return self;
+  }
+  TORCH_CHECK(p_.is_same_size(self) || p_.dim() == 0,
+              "bernoulli_mps_: probability and self tensor should be of the same shape");
+
+  using namespace mps;
+
+  // 0-dim p is a scalar — go through the scalar path.
+  if (p_.dim() == 0) {
+    double p_val = p_.item<double>();
+    TORCH_CHECK(0.0 <= p_val && p_val <= 1.0, "bernoulli_mps_ expects p to be in [0, 1], but got p=", p_val);
+    return distribution_kernel_mps_impl(self, p_val, 0.0, "bernoulli_scalar", 1, gen, /*elements_per_thread=*/4);
+  }
+
+  auto p_float = p_.scalar_type() == kFloat ? p_ : p_.to(kFloat);
+  if (!p_float.is_contiguous()) {
+    p_float = p_float.contiguous();
+  }
+  auto mps_gen = get_generator_or_default<MPSGeneratorImpl>(gen, at::mps::detail::getDefaultMPSGenerator());
+  auto stream = getCurrentMPSStream();
+  const auto needs_copy = !self.is_contiguous();
+  auto output = needs_copy ? at::empty_like(self, MemoryFormat::Contiguous) : self;
+
+  @autoreleasepool {
+    auto pso = lib.getPipelineStateForFunc("bernoulli_tensor_" + scalarToMetalTypeString(output));
+
+    int64_t seed;
+    int64_t base_offset;
+    {
+      // See Note [Acquire lock when using random generators]
+      std::lock_guard<std::mutex> lock(mps_gen->mutex_);
+      seed = static_cast<int64_t>(mps_gen->current_seed());
+      base_offset = static_cast<int64_t>(mps_gen->get_offset());
+      mps_gen->set_offset(base_offset + output.numel());
+    }
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto computeEncoder = stream->commandEncoder();
+        [computeEncoder setComputePipelineState:pso];
+        auto numel = static_cast<uint32_t>(output.numel());
+        mtl_setArgs(computeEncoder, output, p_float, std::array<long, 2>{seed, base_offset});
+        mtl_setBytes(computeEncoder, numel, 3);
+        mtl_dispatch1DJob(computeEncoder, pso, (numel + 3) / 4);
+      }
+    });
+  }
+
+  if (needs_copy) {
+    self.copy_(output);
+  }
+  return self;
 }
 
-Tensor& bernoulli_mps_(Tensor& self, double p, std::optional<Generator> gen) {
-  TORCH_CHECK(0.0 <= p && p <= 1.0, "bernoulli_mps_ expects p to be in [0, 1], but got p=", p);
-  Tensor prob_t = at::full({}, Scalar(p), c10::TensorOptions().dtype(kFloat).device(kMPS));
-  return mps::bernoulli_mps_impl(self, prob_t, gen, __func__);
+// Stub-style entry points so MPS shares the dispatch template with CPU/CUDA.
+// `const TensorBase&` mirrors the stub signature; the underlying storage is
+// still the inplace target (TensorIterator uses the same idiom).
+static void bernoulli_scalar_kernel_mps(const TensorBase& self, double p, std::optional<Generator> gen) {
+  TORCH_CHECK(0.0 <= p && p <= 1.0, "bernoulli_ expects p to be in [0, 1], but got p=", p);
+  Tensor& self_t = const_cast<Tensor&>(static_cast<const Tensor&>(self));
+  distribution_kernel_mps_impl(self_t, p, 0.0, "bernoulli_scalar", 1, gen, /*elements_per_thread=*/4);
 }
 
-Tensor& bernoulli_mps_(Tensor& self, const Tensor& p_, std::optional<Generator> gen) {
-  return mps::bernoulli_mps_impl(self, p_, gen, __func__);
+static void bernoulli_tensor_kernel_mps(const TensorBase& self, const TensorBase& p_, std::optional<Generator> gen) {
+  Tensor& self_t = const_cast<Tensor&>(static_cast<const Tensor&>(self));
+  const Tensor& p_t = static_cast<const Tensor&>(p_);
+  bernoulli_tensor_mps_impl(self_t, p_t, gen);
 }
+
+REGISTER_MPS_DISPATCH(bernoulli_scalar_stub, &bernoulli_scalar_kernel_mps)
+REGISTER_MPS_DISPATCH(bernoulli_tensor_stub, &bernoulli_tensor_kernel_mps)
 
 // random_.from
 Tensor& random_mps_(Tensor& self, int64_t from, std::optional<int64_t> to_opt, std::optional<Generator> gen) {
@@ -431,7 +474,7 @@ static Tensor& distribution_kernel_mps_impl(Tensor& self,
                                             const std::string& kernel_name,
                                             int64_t randoms_per_element,
                                             std::optional<Generator> gen,
-                                            int64_t elements_per_thread = 1) {
+                                            int64_t elements_per_thread) {
   if (self.numel() == 0) {
     return self;
   }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1136,16 +1136,14 @@
   variants: function
   tags: nondeterministic_seeded
   dispatch:
-    CPU, CUDA: bernoulli_out
-    MPS: bernoulli_out_mps
+    CPU, CUDA, MPS: bernoulli_out
 
 - func: bernoulli_.Tensor(Tensor(a!) self, Tensor p, *, Generator? generator=None) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   variants: method
   tags: nondeterministic_seeded
   dispatch:
-    CPU, CUDA: bernoulli_
-    MPS: bernoulli_mps_
+    CPU, CUDA, MPS: bernoulli_
   autogen: bernoulli.Tensor, bernoulli.Tensor_out
 
 - func: bernoulli_.float(Tensor(a!) self, float p=0.5, *, Generator? generator=None) -> Tensor(a!)
@@ -1153,8 +1151,7 @@
   variants: method
   tags: nondeterministic_seeded
   dispatch:
-    CPU, CUDA: bernoulli_
-    MPS: bernoulli_mps_
+    CPU, CUDA, MPS: bernoulli_
   autogen: bernoulli.float_out
 
 # Note [bernoulli.p schema]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #182232
* __->__ #182210
* #182231
* #182229

As MPSGraph one is unreasonably slow and there are already robust Philox RNG generating mechanism

Benchmarked perf improvements using following:

```python
import time, torch
device = torch.device("mps")
N = 1 << 24  # 16M elements
WARMUP, BENCH = 10, 100

def bench(fn):
    for _ in range(WARMUP):
        fn()
    torch.mps.synchronize()
    ts = []
    for _ in range(BENCH):
        torch.mps.synchronize()
        t0 = time.perf_counter()
        fn()
        torch.mps.synchronize()
        ts.append(time.perf_counter() - t0)
    return sum(ts) / len(ts) * 1000

print(f"{'dtype':10s}  {'ms':>8s}  {'GB/s':>8s}")
for dtype in [torch.bool, torch.float32, torch.float16, torch.bfloat16,
              torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64]:
    x = torch.empty(N, device=device, dtype=dtype)
    ms = bench(lambda: x.bernoulli_(0.1))
    gbs = N * x.element_size() / ms / 1e6
    print(f"{str(dtype).replace('torch.',''):10s}  {ms:8.3f}  {gbs:8.1f}")
```

And validated correctness using following
```python
import math
import torch
import matplotlib.pyplot as plt
import numpy as np

PS = [0.1, 0.5, 0.9]
K = 1024            # chunks for histogram and Q-Q
M = 4096            # samples per chunk
N_TOTAL = K * M
CONV_NS = np.unique(np.logspace(2, math.log10(N_TOTAL), 40).astype(int))

DEVICES = [("mps", "tab:blue"), ("cpu", "tab:orange")]


def binom_pmf(M, p):
    mu, sigma = M * p, math.sqrt(M * p * (1 - p))
    lo = max(0, int(mu - 5 * sigma))
    hi = min(M, int(mu + 5 * sigma) + 1)
    xs = np.arange(lo, hi + 1)
    log_pmf = (
        np.array([math.lgamma(M + 1) - math.lgamma(k + 1) - math.lgamma(M - k + 1)
                  for k in xs])
        + xs * math.log(p)
        + (M - xs) * math.log(1 - p)
    )
    return xs, np.exp(log_pmf)


def inv_norm(u):
    """Beasley-Springer-Moro inverse normal CDF."""
    a = [-3.969683028665376e1, 2.209460984245205e2, -2.759285104469687e2,
         1.383577518672690e2, -3.066479806614716e1, 2.506628277459239]
    b = [-5.447609879822406e1, 1.615858368580409e2, -1.556989798598866e2,
         6.680131188771972e1, -1.328068155288572e1]
    c = [-7.784894002430293e-3, -3.223964580411365e-1, -2.400758277161838,
         -2.549732539343734, 4.374664141464968, 2.938163982698783]
    d = [7.784695709041462e-3, 3.224671290700398e-1, 2.445134137142996,
         3.754408661907416]
    plow, phigh = 0.02425, 1 - 0.02425
    if u < plow:
        q = math.sqrt(-2 * math.log(u))
        return (((((c[0]*q + c[1])*q + c[2])*q + c[3])*q + c[4])*q + c[5]) / \
               ((((d[0]*q + d[1])*q + d[2])*q + d[3])*q + 1)
    if u > phigh:
        q = math.sqrt(-2 * math.log(1 - u))
        return -(((((c[0]*q + c[1])*q + c[2])*q + c[3])*q + c[4])*q + c[5]) / \
                ((((d[0]*q + d[1])*q + d[2])*q + d[3])*q + 1)
    q = u - 0.5
    r = q * q
    return (((((a[0]*r + a[1])*r + a[2])*r + a[3])*r + a[4])*r + a[5]) * q / \
           (((((b[0]*r + b[1])*r + b[2])*r + b[3])*r + b[4])*r + 1)


def sample(device, p):
    torch.manual_seed(0)
    return torch.empty(N_TOTAL, device=device).bernoulli_(p).cpu().numpy()


def main():
    fig, axes = plt.subplots(3, len(PS), figsize=(5 * len(PS), 12))

    u = (np.arange(1, K + 1) - 0.5) / K
    theoretical_q = np.array([inv_norm(ui) for ui in u])

    for col, p in enumerate(PS):
        per_dev = {name: sample(name, p) for name, _ in DEVICES}
        chunks_per_dev = {n: per_dev[n].reshape(K, M).sum(axis=1) for n, _ in DEVICES}
        mu, sigma = M * p, math.sqrt(M * p * (1 - p))

        # Row 0: per-chunk count histogram
        ax = axes[0][col]
        all_sums = np.concatenate(list(chunks_per_dev.values()))
        bins = np.arange(int(all_sums.min()) - 1, int(all_sums.max()) + 2)
        for name, color in DEVICES:
            ax.hist(chunks_per_dev[name], bins=bins, density=True, alpha=0.45,
                    label=name, color=color)
        xs, pmf = binom_pmf(M, p)
        ax.plot(xs, pmf, "o-", color="tab:red", markersize=3,
                label=f"Binomial({M},{p})")
        xx = np.linspace(xs.min(), xs.max(), 200)
        ax.plot(xx, np.exp(-0.5 * ((xx - mu) / sigma) ** 2) /
                (sigma * math.sqrt(2 * math.pi)),
                "--", color="tab:green", label="Normal approx")
        ax.set_xlabel("count of 1s per chunk")
        ax.set_ylabel("density")
        ax.set_title(f"p={p}: per-chunk distribution")
        ax.legend(fontsize=8)

        # Row 1: running mean convergence
        ax = axes[1][col]
        for name, color in DEVICES:
            arr = per_dev[name]
            means = np.array([arr[:n].mean() for n in CONV_NS])
            ax.semilogx(CONV_NS, means, ".-", color=color, label=name)
        ax.axhline(p, color="tab:red", linestyle="--", label=f"p={p}")
        sigma_n = np.sqrt(p * (1 - p) / CONV_NS)
        ax.fill_between(CONV_NS, p - 3 * sigma_n, p + 3 * sigma_n,
                        alpha=0.12, color="tab:red", label="±3σ envelope")
        ax.set_xlabel("N")
        ax.set_ylabel("running mean")
        ax.set_title(f"p={p}: mean convergence")
        ax.legend(fontsize=8)

        # Row 2: Q-Q of standardized chunk sums vs Normal(0, 1)
        ax = axes[2][col]
        for name, color in DEVICES:
            z = np.sort((chunks_per_dev[name] - mu) / sigma)
            ax.plot(theoretical_q, z, ".", color=color, markersize=3, label=name)
        lim = max(abs(theoretical_q[0]), abs(theoretical_q[-1])) * 1.1
        ax.plot([-lim, lim], [-lim, lim], "--", color="tab:red", label="y=x")
        ax.set_xlim(-lim, lim)
        ax.set_ylim(-lim, lim)
        ax.set_xlabel("theoretical quantile")
        ax.set_ylabel("standardized count")
        ax.set_title(f"p={p}: Q-Q vs Normal(0,1)")
        ax.legend(fontsize=8)

    fig.suptitle("Bernoulli: MPS (Philox) vs CPU (Mersenne-Twister)")
    fig.tight_layout()
    fig.savefig("bernoulli_dist.png", dpi=150)


if __name__ == "__main__":
    main()
```

Results on M4 Max (16M elements, p=0.1, after this change):

```
dtype             ms      GB/s
bool           0.316      53.1
float32        0.255     263.6
float16        0.216     155.4
bfloat16       0.213     157.8
uint8          0.217      77.3
int8           0.215      77.9
int16          0.224     150.0
int32          0.279     240.5
int64          0.437     307.2
```

For comparison at the dropout-relevant 537M-element shape (`(512, 4, 512, 512)`, fp32) the bool-mask `bernoulli_` went from 12.8 ms (MPSGraph) to 2.6 ms after this change.

And distribution looks as follows
<img width="2250" height="1800" alt="image" src="https://github.com/user-attachments/assets/4e586df6-42d9-4f3b-8896-90a37ad70d5d" />

Authored with Claude.