### PR TITLE
Add Half/BFloat16 copysign overloads to fix NaN sign bit loss on CUDA

### DIFF
--- a/c10/cuda/CUDAMathCompat.h
+++ b/c10/cuda/CUDAMathCompat.h
@@ -6,7 +6,9 @@
 #if defined(__CUDACC__) || defined(__HIPCC__)
 
 #include <c10/macros/Macros.h>
+#include <c10/util/BFloat16.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Half.h>
 
 #ifdef __HIPCC__
 #define __MATH_FUNCTIONS_DECL__ inline C10_DEVICE
@@ -60,6 +62,17 @@ __MATH_FUNCTIONS_DECL__ double copysign(double x, double y) {
   TORCH_INTERNAL_ASSERT(
       false, "CUDAMathCompat copysign should not run on the CPU");
 #endif
+}
+// Use bit ops for half-precision to preserve NaN sign bits that would
+// be lost by implicit conversion to float (see pytorch/pytorch#181804)
+__MATH_FUNCTIONS_DECL__ c10::Half copysign(c10::Half a, c10::Half b) {
+  return c10::Half((a.x & 0x7fff) | (b.x & 0x8000), c10::Half::from_bits());
+}
+__MATH_FUNCTIONS_DECL__ c10::BFloat16 copysign(
+    c10::BFloat16 a,
+    c10::BFloat16 b) {
+  return c10::BFloat16(
+      (a.x & 0x7fff) | (b.x & 0x8000), c10::BFloat16::from_bits());
 }
 
 __MATH_FUNCTIONS_DECL__ float floor(float x) {

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2535,13 +2535,10 @@ class TestBinaryUfuncs(TestCase):
             # Use double copysign to verify the correctness of 0.0 and -0.0, since
             # it always True for self.assertEqual(0.0 == -0.0). So, we use 1 as the
             # magnitude to verify the sign between torch and numpy results, elementwise.
-            # Special case: NaN conversions between FP32 and FP16 is not bitwise
-            # equivalent to pass this assertion.
-            if a.dtype != torch.float16 and b.dtype != torch.float16:
-                self.assertEqual(
-                    torch.copysign(torch.tensor(1.0), torch_result),
-                    torch.copysign(torch.tensor(1.0), expected),
-                )
+            self.assertEqual(
+                torch.copysign(torch.tensor(1.0), torch_result),
+                torch.copysign(torch.tensor(1.0), expected),
+            )
 
         # Compare Result with NumPy
         # Type promotion
@@ -2561,10 +2558,7 @@ class TestBinaryUfuncs(TestCase):
         # 0.0/-0.0/inf/-inf/nan
         cases = [0.0, -0.0, float("inf"), float("-inf"), float("nan")]
         # torch.bfloat16 can not hold '-nan'
-        # torch.half can not hold '-nan' on CUDA
-        types = [torch.float32, torch.float64]
-        if device == "cpu":
-            types.append(torch.float16)
+        types = [torch.float32, torch.float64, torch.float16]
         if dtypes[0] in types:
             b = make_tensor((10, 10), device=device, dtype=dtypes[1], low=-9, high=9)
             for case in cases:


### PR DESCRIPTION
## Summary

Fixes #181804

`torch.copysign` on CUDA returns incorrect results for negative NaN inputs with `float16` and `bfloat16` dtypes. The sign bit is lost because `CUDAMathCompat.h` only has `float`/`double` copysign overloads, causing implicit conversion from `Half`→`float` which drops the NaN sign bit.

This PR adds bitwise copysign overloads for `c10::Half` and `c10::BFloat16` in `CUDAMathCompat.h`, matching the existing CPU-side implementation in `c10/util/copysign.h`. It also removes the float16 CUDA test skips in `test_copysign` that were masking this bug.

## Changes

- **`c10/cuda/CUDAMathCompat.h`**: Add `Half` and `BFloat16` copysign overloads using bit operations (`(a.x & 0x7fff) | (b.x & 0x8000)`) to directly manipulate the sign bit
- **`test/test_binary_ufuncs.py`**: Remove float16 sign verification skip and CUDA-only float16 NaN test exclusion

## Reproduction

```python
import torch, numpy as np
raw = np.array([0xfe00], dtype=np.uint16)  # negative NaN in float16
neg_nan = torch.from_numpy(raw.view(np.float16)).clone()
mag = torch.tensor([1.0], dtype=torch.float16)

print(torch.copysign(mag, neg_nan))           # CPU: tensor([-1.]) ✓
print(torch.copysign(mag.cuda(), neg_nan.cuda()))  # CUDA: tensor([1.]) ✗ (should be -1.)
```

## Test plan

- [x] Bug confirmed on RTX 5090 (PyTorch 2.10.0+cu128)
- [x] BFloat16 has the same bug (also fixed by this PR)
- [x] Normal (non-NaN) float16 copysign values unaffected
- [ ] CI: `python test/test_binary_ufuncs.py -k test_copysign`

cc @ptrblck @msaroufim @eqy @jerryzh168 @tinglvv @nWEIdia @pytorch/cpu-prim-group

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>