### PR TITLE
Remove ARM xfail for disabled AMP CPU repro

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -5586,9 +5586,6 @@ class CPUReproTests(TestCase):
         x = torch.randn(1, 4, 2, 2)
         self.common(fn, (x,))
 
-    @xfailIf(
-        IS_ARM64 and IS_CPU_EXT_SVE_SUPPORTED
-    )  # see https://github.com/pytorch/pytorch/issues/142134
     @parametrize("is_inference", (True, False))
     def test_disabled_amp(self, is_inference):
         class M(torch.nn.Module):
@@ -5631,7 +5628,7 @@ class CPUReproTests(TestCase):
             torch.manual_seed(0)
             eager = mod(*inputs)
             torch.manual_seed(0)
-            self.assertEqual(compiler_mode(*inputs), eager)
+            self.assertEqual(compiler_mode(*inputs), eager, atol=1e-4, rtol=1.6e-2)
 
     def test_fused_node(self):
         # https://github.com/pytorch/pytorch/issues/138550.


### PR DESCRIPTION
This PR removes the ARM/SVE xfail for `CPUReproTests.test_disabled_amp` and replaces it with a targeted BF16 tolerance.

The underlying mismatch appears to be very small Inductor CPU SDPA numerical drift on BF16/SVE. A 50-seed sweep on latest aarch64 CPU nightly showed the default tolerance failures are extremely sparse:

  - `dropout_p=0.2`: max 7 mismatched elements out of 1,572,864 (`0.000445048%`)
  - `dropout_p=0.0`: max 5 mismatched elements out of 1,572,864 (`0.000317891%`)
  - Nonzero element drift stayed below ~0.032%
  - The largest default-tolerance-failing absolute error was `6.103515625e-05`

`rtol` is kept at the BF16 default (`1.6e-2`); only `atol` is relaxed to `1e-4`.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182220

Replace the ARM/SVE expected failure with an explicit tolerance on the final BF16 comparison. Keep rtol at the BF16 default of 1.6e-2 and only relax atol to 1e-4 based on the observed sparse SDPA numerical drift.

Fixes #142134

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo