### PR TITLE
Enable skipped static_runtime tests on AArch64

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -2311,10 +2311,6 @@ TEST(StaticRuntime, Append) {
 }
 
 TEST(StaticRuntime, QuantizedLinear) {
-#if defined(__aarch64__) || defined(_M_ARM64)
-  // See https://github.com/pytorch/pytorch/issues/178522.
-  GTEST_SKIP() << "Skipping QuantizedLinear on AArch64.";
-#endif
   const std::string quantize_script = R"IR(
     graph(%input: Tensor, %weights: Tensor):
         %scale: float = prim::Constant[value=1.]()

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -3157,11 +3157,6 @@ TEST_F(Composed, ComposedOp) {
 }
 
 TEST(ConstantPropagation, CustomClassesCanBePropagated) {
-#if defined(__aarch64__) || defined(_M_ARM64)
-  // See https://github.com/pytorch/pytorch/issues/178522.
-  GTEST_SKIP()
-      << "Skipping ConstantPropagation.CustomClassesCanBePropagated on AArch64.";
-#endif
 #ifdef USE_PYTORCH_QNNPACK
   const auto src = R"IR(
     graph():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182224

Fixes #178522