### PR TITLE
[CI] Install git-core PPA without add-apt-repository

### DIFF
--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -22,10 +22,21 @@ install_ubuntu() {
 
   # Install common dependencies
   apt-get update
-  # Install prerequisites for add-apt-repository (needs gpg-agent for PPA key import)
-  apt-get install -y --no-install-recommends software-properties-common gpg-agent
-  # Add git-core PPA for a newer version of git
-  add-apt-repository ppa:git-core/ppa -y
+  # Prerequisites for fetching the git-core PPA signing key and serving it via signed-by
+  apt-get install -y --no-install-recommends software-properties-common gpg-agent gnupg ca-certificates
+  # Add git-core PPA for a newer version of git. Bypass `add-apt-repository`, which
+  # talks to api.launchpad.net to fetch the signing key and is unreliable when that
+  # endpoint is degraded. Pull the key from keyserver.ubuntu.com instead and pin it
+  # to the repo via signed-by. Treat any failure here as fatal so we don't silently
+  # fall back to the distro's older git, which then breaks downstream steps that
+  # depend on newer git features (e.g. `git submodule update --filter=tree:0`).
+  mkdir -p /etc/apt/keyrings
+  gpg --no-default-keyring --keyring /etc/apt/keyrings/git-core.gpg \
+      --keyserver hkps://keyserver.ubuntu.com \
+      --recv-keys E1DD270288B4E6030699E45FA1715D88E1DF1F24
+  UBUNTU_CODENAME=$(. /etc/os-release && echo "$UBUNTU_CODENAME")
+  echo "deb [signed-by=/etc/apt/keyrings/git-core.gpg] https://ppa.launchpadcontent.net/git-core/ppa/ubuntu/ ${UBUNTU_CODENAME} main" \
+      > /etc/apt/sources.list.d/git-core.list
   apt-get update
   # TODO: Some of these may not be necessary
   deploy_deps="libffi-dev libbz2-dev libreadline-dev libncurses5-dev libncursesw5-dev libgdbm-dev libsqlite3-dev uuid-dev tk-dev"
@@ -68,6 +79,22 @@ install_ubuntu() {
   # Should resolve issues related to various apt package repository cert issues
   # see: https://github.com/pytorch/pytorch/issues/65931
   apt-get install -y libgnutls30
+
+  # Hard-fail if git is missing or older than 2.36 (the version required for
+  # `git submodule update --filter=tree:0`, which actions/checkout invokes).
+  # This catches the case where the git-core PPA setup silently regressed and
+  # apt fell back to the distro's older git.
+  if ! command -v git >/dev/null 2>&1; then
+    echo "ERROR: git was not installed" >&2
+    exit 1
+  fi
+  GIT_VERSION=$(git --version | awk '{print $3}')
+  GIT_MAJOR=${GIT_VERSION%%.*}
+  GIT_MINOR=${GIT_VERSION#*.}; GIT_MINOR=${GIT_MINOR%%.*}
+  if (( GIT_MAJOR < 2 || (GIT_MAJOR == 2 && GIT_MINOR < 36) )); then
+    echo "ERROR: git ${GIT_VERSION} is too old; need >= 2.36 (git-core PPA)" >&2
+    exit 1
+  fi
 
   # Cleanup package manager
   apt-get autoclean && apt-get clean


### PR DESCRIPTION
https://status.canonical.com is showing major outage in the past few days with service still being recoverd

`add-apt-repository ppa:git-core/ppa` resolves the PPA's signing key by calling api.launchpad.net, and the Docker base image build was failing when that endpoint returned 504. Switch to fetching the key from keyserver.ubuntu.com and registering the repo with `signed-by`, which keeps working when Launchpad's API is degraded.

Also assert `git --version >= 2.36` after install so a silent fallback to the distro's older git fails fast instead of breaking downstream `git submodule update --filter=tree:0`.

Authored with Claude Code.