### PR TITLE
[CI] Check installed git version during Docker build

### DIFF
--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -80,12 +80,6 @@ install_ubuntu() {
   # see: https://github.com/pytorch/pytorch/issues/65931
   apt-get install -y libgnutls30
 
-  # Hard-fail if git is missing or older than 2.36 (the minimum for
-  # `git submodule update --filter=tree:0`, which actions/checkout invokes).
-  if ! command -v git >/dev/null 2>&1; then
-    echo "ERROR: git was not installed" >&2
-    exit 1
-  fi
   GIT_VERSION=$(git --version | awk '{print $3}')
   GIT_MAJOR=${GIT_VERSION%%.*}
   GIT_MINOR=${GIT_VERSION#*.}; GIT_MINOR=${GIT_MINOR%%.*}

--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -22,7 +22,7 @@ install_ubuntu() {
 
   # Install common dependencies
   apt-get update
-# Install prerequisites for add-apt-repository (needs gpg-agent for PPA key import)
+  # Install prerequisites for add-apt-repository (needs gpg-agent for PPA key import)
   apt-get install -y --no-install-recommends software-properties-common gpg-agent
   # Add git-core PPA for a newer version of git
   add-apt-repository ppa:git-core/ppa -y

--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -22,22 +22,10 @@ install_ubuntu() {
 
   # Install common dependencies
   apt-get update
-  apt-get install -y --no-install-recommends ca-certificates curl
-  # Install git from microsoft/git prebuilt .deb. We previously used the
-  # git-core PPA via add-apt-repository, but Launchpad's API endpoint has been
-  # unreliable and the distro's stock git (2.34 on jammy) is too old for
-  # `git submodule update --filter=tree:0` that actions/checkout invokes.
-  MS_GIT_VERSION="2.53.0.vfs.0.7"
-  case "$(dpkg --print-architecture)" in
-    amd64) MS_GIT_ARCH="amd64" ;;
-    arm64) MS_GIT_ARCH="arm64" ;;
-    *) echo "ERROR: unsupported arch $(dpkg --print-architecture) for microsoft/git" >&2; exit 1 ;;
-  esac
-  MS_GIT_DEB="microsoft-git_${MS_GIT_VERSION}_${MS_GIT_ARCH}.deb"
-  curl -fsSL -o "/tmp/${MS_GIT_DEB}" \
-    "https://github.com/microsoft/git/releases/download/v${MS_GIT_VERSION}/${MS_GIT_DEB}"
-  apt-get install -y --no-install-recommends "/tmp/${MS_GIT_DEB}"
-  rm -f "/tmp/${MS_GIT_DEB}"
+# Install prerequisites for add-apt-repository (needs gpg-agent for PPA key import)
+  apt-get install -y --no-install-recommends software-properties-common gpg-agent
+  # Add git-core PPA for a newer version of git
+  add-apt-repository ppa:git-core/ppa -y
   apt-get update
   # TODO: Some of these may not be necessary
   deploy_deps="libffi-dev libbz2-dev libreadline-dev libncurses5-dev libncursesw5-dev libgdbm-dev libsqlite3-dev uuid-dev tk-dev"
@@ -52,6 +40,7 @@ install_ubuntu() {
     build-essential \
     ca-certificates \
     curl \
+    git \
     libatlas-base-dev \
     libc6-dbg \
     libyaml-dev \

--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -22,10 +22,22 @@ install_ubuntu() {
 
   # Install common dependencies
   apt-get update
-  # Install prerequisites for add-apt-repository (needs gpg-agent for PPA key import)
-  apt-get install -y --no-install-recommends software-properties-common gpg-agent
-  # Add git-core PPA for a newer version of git
-  add-apt-repository ppa:git-core/ppa -y
+  apt-get install -y --no-install-recommends ca-certificates curl
+  # Install git from microsoft/git prebuilt .deb. We previously used the
+  # git-core PPA via add-apt-repository, but Launchpad's API endpoint has been
+  # unreliable and the distro's stock git (2.34 on jammy) is too old for
+  # `git submodule update --filter=tree:0` that actions/checkout invokes.
+  MS_GIT_VERSION="2.53.0.vfs.0.7"
+  case "$(dpkg --print-architecture)" in
+    amd64) MS_GIT_ARCH="amd64" ;;
+    arm64) MS_GIT_ARCH="arm64" ;;
+    *) echo "ERROR: unsupported arch $(dpkg --print-architecture) for microsoft/git" >&2; exit 1 ;;
+  esac
+  MS_GIT_DEB="microsoft-git_${MS_GIT_VERSION}_${MS_GIT_ARCH}.deb"
+  curl -fsSL -o "/tmp/${MS_GIT_DEB}" \
+    "https://github.com/microsoft/git/releases/download/v${MS_GIT_VERSION}/${MS_GIT_DEB}"
+  apt-get install -y --no-install-recommends "/tmp/${MS_GIT_DEB}"
+  rm -f "/tmp/${MS_GIT_DEB}"
   apt-get update
   # TODO: Some of these may not be necessary
   deploy_deps="libffi-dev libbz2-dev libreadline-dev libncurses5-dev libncursesw5-dev libgdbm-dev libsqlite3-dev uuid-dev tk-dev"
@@ -40,7 +52,6 @@ install_ubuntu() {
     build-essential \
     ca-certificates \
     curl \
-    git \
     libatlas-base-dev \
     libc6-dbg \
     libyaml-dev \
@@ -68,6 +79,20 @@ install_ubuntu() {
   # Should resolve issues related to various apt package repository cert issues
   # see: https://github.com/pytorch/pytorch/issues/65931
   apt-get install -y libgnutls30
+
+  # Hard-fail if git is missing or older than 2.36 (the minimum for
+  # `git submodule update --filter=tree:0`, which actions/checkout invokes).
+  if ! command -v git >/dev/null 2>&1; then
+    echo "ERROR: git was not installed" >&2
+    exit 1
+  fi
+  GIT_VERSION=$(git --version | awk '{print $3}')
+  GIT_MAJOR=${GIT_VERSION%%.*}
+  GIT_MINOR=${GIT_VERSION#*.}; GIT_MINOR=${GIT_MINOR%%.*}
+  if (( GIT_MAJOR < 2 || (GIT_MAJOR == 2 && GIT_MINOR < 36) )); then
+    echo "ERROR: git ${GIT_VERSION} is too old; need >= 2.36" >&2
+    exit 1
+  fi
 
   # Cleanup package manager
   apt-get autoclean && apt-get clean


### PR DESCRIPTION
And error out if it's older than 2.36 (first one to support tree-less checkouts)

Otherwise, when ppa.launchpad.net is down, an much older version of git will get installed, that will fail on treeless checkout action

See https://github.com/pytorch/pytorch/issues/182227

Authored with Claude Code.