### PR TITLE
[BE] Make `test_Dropout1d` statistically robust

### DIFF
--- a/test/nn/test_dropout.py
+++ b/test/nn/test_dropout.py
@@ -218,8 +218,8 @@ class TestDropoutNNDeviceType(NNTestCase):
     def test_Dropout1d(self, device, dtype):
         with set_default_dtype(dtype):
             N, C, L = (
-                random.randint(10, 15),
-                random.randint(10, 15),
+                random.randint(50, 60),
+                random.randint(50, 60),
                 random.randint(10, 15),
             )
             input = torch.empty(N, C, L)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #182232
* #182210
* #182231
* __->__ #182229

`_test_dropout` checks `|output.mean() - (1 - p)| < 0.05` four times. For Dropout1d the mask has shape `(N, C)`, which with 10-15 ranges the test only had ~200 masked samples. At `p = 0.2` that gives $\sigma$ of the sample mean at approximately 0.027, putting the 0.05 tolerance at only $1.4\sigma$ — the test has an inherent ~15% failure rate per draw regardless of which RNG runs underneath.

Bumping to `random.randint(50, 60)` for `N` and `C` gives `N*C >= 2500`, which puts $\sigma \approx 0.008$ and the tolerance at $\approx6\sigma$ — robust against any RNG. `L` stays small since it doesn't affect the mask size.

For example, test before this change might fail on with number of random seeds, for example:

```python
import torch

torch.manual_seed(5) # Seed 0, 2, 3, 7 will also fail
p = 0.2
inp = torch.empty(13, 10, 10).fill_(1 - p)
out = torch.nn.Dropout1d(p)(inp)
diff = abs(out.mean().item() - (1 - p))
assert diff < 0.05, f"|diff|={diff:.4f}"  # raises with |diff|=0.0846
```

Authored with Claude.