### PR TITLE
[dynamo-wrapped] Skip all Dynamo wrapped tests for numpy

### DIFF
--- a/test/torch_np/conftest.py
+++ b/test/torch_np/conftest.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 
+import os
 import sys
 
 import pytest
@@ -82,3 +83,13 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)
+
+    # Skip the entire torch_np suite under dynamo_wrapped CI. These tests
+    # produce constant churn between expected_failure and unexpected_success
+    # entries; running them under dynamo provides little incremental signal.
+    if os.environ.get("PYTORCH_TEST_WITH_DYNAMO") == "1":
+        skip_dynamo = pytest.mark.skip(
+            reason="torch_np tests are skipped under dynamo_wrapped"
+        )
+        for item in items:
+            item.add_marker(skip_dynamo)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181803
* __->__ #182240

After https://github.com/pytorch/pytorch/pull/180271, dynamo wrapped tests are failing for numpy tests. We are not maintaining Dynamo-numpy integration, and running Dynamo wrapped tests on numpy do not offer meaningul signal. So skip for now.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98