### PR TITLE
Fix typo in Transformer._reset_parameters docstring

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -309,7 +309,7 @@ class Transformer(Module):
         return _generate_square_subsequent_mask(sz, dtype=dtype, device=device)
 
     def _reset_parameters(self) -> None:
-        r"""Initiate parameters in the transformer model."""
+        r"""Initialize parameters in the transformer model."""
         for p in self.parameters():
             if p.dim() > 1:
                 xavier_uniform_(p)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182243

Change "Initiate" to "Initialize" — the method initializes parameters,
it doesn't initiate them.

Authored with Claude (typo_terminator2).