### PR TITLE
Fix typo in AutoFunctionalizeKernel error message

### DIFF
--- a/torch/nativert/kernels/AutoFunctionalizeKernel.cpp
+++ b/torch/nativert/kernels/AutoFunctionalizeKernel.cpp
@@ -38,7 +38,7 @@ void UnsafeAutoFunctionalizeKernel::computeInternal(
     auto stackTrace = node_->getMetadata("stack_trace");
     TORCH_CHECK(
         false,
-        "Oringinal Python stacktrace:\n",
+        "Original Python stacktrace:\n",
         stackTrace ? *stackTrace : "<no stack trace>",
         "\n",
         ex.what())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182244

Fix "Oringinal" → "Original" in the Python stacktrace error message.

Authored with Claude (typo_terminator2).