### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/torch/_inductor/fx_passes/overlap_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_scheduling.py
@@ -1598,7 +1598,7 @@ class OverlapScheduler:
         return self.compute_potential_hidden_nodes(self.collective_info.keys())
 
     def compute_potential_hidden_waits(self) -> dict[fx.Node, fx.Node]:
-        """Compute which wait operations could be hidden by compte."""
+        """Compute which wait operations could be hidden by compute."""
         wait_nodes = [info.wait_node for info in self.collective_info.values()]
         return self.compute_potential_hidden_nodes(wait_nodes)
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4410,7 +4410,7 @@ def squeeze(a: TensorLikeType, dim: DimsType | None = None) -> TensorLikeType:
         return prims.view_of(a)
 
     # Note: squeeze does not modify tensors when the given dim is not a dimension of length 1
-    # would it be better if we just not allow 1 for unbacked at runtiume?
+    # would it be better if we just not allow 1 for unbacked at runtime?
     dims = tuple(d for d in dims if guard_or_false(a.shape[d] == 1))
     if len(dims) == 0:
         return prims.view_of(a)

--- a/torch/distributed/elastic/rendezvous/__init__.py
+++ b/torch/distributed/elastic/rendezvous/__init__.py
@@ -54,7 +54,7 @@ rendezvous is destroyed first.
 
 When a rendezvous is completed, all its members will agree on the job membership
 and everyone's role in it. This role is represented using an integer, called
-rank, that is between between 0 and world size.
+rank, that is between 0 and world size.
 
 Note that ranks are *not stable*, in the sense that the same node can be
 assigned a different rank in the next (re-)rendezvous.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182246

Fix "compte" → "compute" in overlap_scheduling.py, "runtiume" → "runtime"
in _refs/__init__.py, and "between between" → "between" in the
rendezvous module docstring.

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo