### PR TITLE
[export] Make Triton CPU AOTI work end-to-end through aoti_compile_and_package

### DIFF
--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -123,6 +123,10 @@ const char* extension_file_ext() {
 #endif
 }
 
+bool is_wrapper_library(const std::string& path) {
+  return c10::ends_with(path, ".wrapper.so");
+}
+
 const char* get_output_flags(bool compile_only) {
   if (compile_only) {
 #ifdef _WIN32
@@ -765,7 +769,30 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
         } else if (filename_extension == object_file_ext()) {
           obj_filenames.push_back(output_file_path);
         } else if (filename_extension == extension_file_ext()) {
-          so_filename = output_file_path;
+          // Triton CPU AOTI has multiple .so files: kernel.so + launcher.so
+          // alongside wrapper.so. So, prefer *.wrapper.so, and fall back to
+          // first .so for non-CPU mode.
+          if (is_wrapper_library(output_file_path)) {
+            if (!so_filename.empty() && is_wrapper_library(so_filename)) {
+              // Multiple wrapper libraries found - this is a packaging error
+              TORCH_CHECK(
+                  false,
+                  "Multiple wrapper shared libraries found in AOTI package for model '",
+                  model_name,
+                  "': '",
+                  so_filename,
+                  "' and '",
+                  output_file_path,
+                  "'. Each model should have exactly one wrapper library.");
+            }
+            so_filename = output_file_path;
+          } else if (so_filename.empty()) {
+            // Get the first .so for non Triton CPU mode, where expending a
+            // single .so
+            so_filename = output_file_path;
+          }
+          // else: auxiliary .so file (kernel.so, launcher.so for Triton CPU),
+          // ignore for wrapper selection but still extract the file
         } else if (filename_extension == ".blob") {
           weight_blob_filename = output_file_path;
         }

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -270,7 +270,6 @@ def _package_aoti_files(
     ] = {}  # model_name -> (weight_name -> (filename, shape, stride, offset))
 
     for model_name, files in aoti_files.items():
-        num_so_files = 0
         weights_configs[model_name] = {}
 
         for file in files:
@@ -281,14 +280,8 @@ def _package_aoti_files(
                 all_weights[model_name] = file
                 continue
 
-            if file.endswith(".so"):
-                num_so_files += 1
-                if num_so_files > 1:
-                    raise RuntimeError(
-                        f"Multiple .so files found in {files}. "
-                        "You might need to clear your cache "
-                        "directory before calling aoti_compile again."
-                    )
+            # Note: Previously we rejected multiple .so cases. But Triton CPU AOTI
+            # has multiple .so files per model (wrapper, launcher, kernel).
 
             filename = os.path.basename(file)
             if filename.startswith(CUSTOM_OBJ_FILENAME_PREFIX):


### PR DESCRIPTION
Summary:
[PR #181068](https://github.com/pytorch/pytorch/pull/181068) (D101914212) added Triton CPU AOTI codegen but only tested through torch._inductor.aot_compile. The public API torch._inductor.aoti_compile_and_package + aoti_load_package was never tested for Triton CPU, so two bugs went unnoticed:

1. Packager rejected multiple .so files (Triton CPU emits wrapper.so + kernel.so + launcher.so per kernel)
2. Loader picked the last .so from zip iteration (fragile - happened to work by luck)

Fix: Remove the >1 .so guard in packager, and make loader prefer *.wrapper.so with fallback to first .so for the default GPU AOTI.

Test Plan:
## Pre-fix:
```
> buck run fbcode//trp/stdlib/transforms/triton/tests:triton_cpu_aoti_packaging_test -- trp.stdlib.transforms.triton.tests.triton_cpu_aoti_packaging_test.TritonCpuAotiPackagingTest.test_aoti
...
RuntimeError: Multiple .so files found in [...]
```

## Post-fix:
Same command runs the full archive + reload roundtrip on CPU -> `Ran 3 tests in 6.640s OK`.

Reviewed By: shawnxu26

Differential Revision: D103589447
