### PR TITLE
[ROCm] Skip TestCachingAutotunerPlugin pending Triton MLIR fix

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -17,6 +17,7 @@ from torch.testing._internal.common_utils import (
     IS_LINUX,
     parametrize,
     runOnRocm,
+    skipIfRocm,
     skipIfXpu,
 )
 from torch.testing._internal.inductor_utils import (
@@ -311,6 +312,10 @@ _PLUGIN_FACTORY_PATH = (
 )
 
 
+# Triton's HIP MLIR pipeline raises AttributeError("'NoneType' object has no
+# attribute '_unflatten_ir'") inside ast_to_ttir for the trivial cos kernel
+# used by these tests. CUDA paths are unaffected.
+@skipIfRocm
 class TestCachingAutotunerPlugin(TestCase):
     device_type = GPU_TYPE
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #182254

These tests fail consistently on ROCm (gfx950 mi355 and gfx942 mi300) with

    triton.compiler.errors.CompilationError: at 1:0:
    def triton_(in_ptr0, out_ptr0, xnumel, XBLOCK: tl.constexpr):
    ^
    AttributeError("'NoneType' object has no attribute '_unflatten_ir'")

raised from Triton's ast_to_ttir while building the TTIR module for the
trivial cos kernel used by the fixture. The crash is in upstream Triton's
HIP MLIR pipeline; CUDA paths are unaffected. Roughly 58 failures across
the rocm-mi355 and rocm-mi300 default shards were observed in a 36-hour
window on trunk, so skip the whole class on ROCm until the Triton-side
fix lands.

This is a skip, not a fix.

Authored by Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben