### PR TITLE
[MPS] Replace MPSGraph prod/var/std/argmax/min with Metal kernels

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -1106,3 +1106,1606 @@ REGISTER_REDUCTIONS_OPS_FOR_TYPE(uchar);
 REGISTER_PRED_REDUCTIONS_FOR_TYPE(bool);
 REGISTER_PRED_REDUCTIONS_FOR_TYPE(float2);
 REGISTER_PRED_REDUCTIONS_FOR_TYPE(half2);
+
+// ===== prod / welford / argreduce kernels (this PR, on top of malfet sum/value migration) =====
+// Product reduction kernels
+// ============================================================================
+
+template <typename TI, typename TO, uint NCHAINS = SUM_NCHAINS>
+kernel void prod_reduction(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant NormParams<>& params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroup_size [[threads_per_simdgroup]]) {
+  using TA = opmath_t<TO>;
+
+  uint32_t input_base = 0;
+  uint32_t reduction_stride = 1;
+  uint32_t num_reduced_dims = 0;
+  {
+    uint32_t out_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      if (params.input_sizes[dim] != params.output_sizes[dim]) {
+        num_reduced_dims++;
+        reduction_stride = params.input_strides[dim];
+      } else {
+        auto idx = out_idx % params.output_sizes[dim];
+        out_idx /= params.output_sizes[dim];
+        input_base += idx * params.input_strides[dim];
+      }
+    }
+  }
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+
+  const uint32_t rsize = params.reduction_size;
+  const uint32_t stride = tptg * NCHAINS;
+  uint32_t base = tid * NCHAINS;
+
+  if (num_reduced_dims <= 1) {
+    for (; base + NCHAINS <= rsize; base += stride) {
+      for (uint j = 0; j < NCHAINS; j++) {
+        acc[j] *=
+            static_cast<TA>(input[input_base + (base + j) * reduction_stride]);
+      }
+    }
+    for (uint32_t idx = base; idx < rsize; idx++) {
+      acc[idx % NCHAINS] *=
+          static_cast<TA>(input[input_base + idx * reduction_stride]);
+    }
+  } else {
+    for (; base + NCHAINS <= rsize; base += stride) {
+      for (uint j = 0; j < NCHAINS; j++) {
+        acc[j] *=
+            static_cast<TA>(input[get_input_offset(base + j, tgid, params)]);
+      }
+    }
+    for (uint32_t idx = base; idx < rsize; idx++) {
+      acc[idx % NCHAINS] *=
+          static_cast<TA>(input[get_input_offset(idx, tgid, params)]);
+    }
+  }
+
+  TA output_val = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    output_val *= acc[j];
+
+  auto threads_remaining = tptg;
+  threadgroup TA shared_outputs[MAX_THREADGROUP_SIZE];
+
+  while (threads_remaining > 1) {
+    output_val = c10::metal::simd_prod(output_val);
+    threads_remaining = ceil_div(threads_remaining, simdgroup_size);
+    if (threads_remaining > 1) {
+      if (simd_lane_id == 0)
+        shared_outputs[simdgroup_id] = output_val;
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      if (tid < threads_remaining) {
+        output_val = shared_outputs[tid];
+      } else {
+        output_val = static_cast<TA>(1);
+      }
+    }
+  }
+
+  if (tid == 0) {
+    uint32_t output_offset = 0;
+    uint32_t reduction_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      auto output_dim_size = params.output_sizes[dim];
+      if (output_dim_size > 1) {
+        auto index_in_dim = reduction_idx % output_dim_size;
+        reduction_idx /= output_dim_size;
+        output_offset += index_in_dim * params.output_strides[dim];
+      }
+    }
+    output[output_offset] = static_cast<TO>(output_val);
+  }
+}
+
+template <
+    typename TI,
+    typename TO,
+    uint TG_X = 32,
+    uint TG_Y = 32,
+    uint NCHAINS = SUM_NCHAINS>
+kernel void prod_reduction_outer(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint out_stride = sizes.z;
+
+  uint col = tg_pos.x * TG_X + tid_tg.x;
+  if (col >= N)
+    return;
+
+  uint rows_per_y = ceil_div(M, TG_Y);
+  uint row_start = tid_tg.y * rows_per_y;
+  uint row_end = min(row_start + rows_per_y, M);
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+
+  uint row = row_start;
+  for (; row + NCHAINS <= row_end; row += NCHAINS) {
+    for (uint j = 0; j < NCHAINS; j++) {
+      acc[j] *= static_cast<TA>(input[(row + j) * N + col]);
+    }
+  }
+  for (; row < row_end; row++) {
+    acc[row % NCHAINS] *= static_cast<TA>(input[row * N + col]);
+  }
+
+  TA prod = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    prod *= acc[j];
+
+  threadgroup TA shmem[TG_Y][TG_X];
+  shmem[tid_tg.y][tid_tg.x] = prod;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint s = TG_Y / 2; s > 0; s >>= 1) {
+    if (tid_tg.y < s)
+      shmem[tid_tg.y][tid_tg.x] *= shmem[tid_tg.y + s][tid_tg.x];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (tid_tg.y == 0) {
+    output[col * out_stride] = static_cast<TO>(shmem[0][tid_tg.x]);
+  }
+}
+
+template <typename TI, typename TO, uint NCHAINS = SUM_NCHAINS>
+kernel void prod_reduction_inner(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / 32;
+
+  // One SIMD group reduces one row; num_simd_groups rows share a TG (mirrors
+  // sum_reduction_inner). Avoids one whole TG per row, which idles most threads
+  // and over-subscribes the GPU when there are many short rows.
+  uint row = tgid * num_simd_groups + simdgroup_id;
+  if (row >= M)
+    return;
+
+  constant TI* row_ptr = input + row * N;
+
+  metal::array<TA, NCHAINS> acc;
+  for (uint j = 0; j < NCHAINS; j++)
+    acc[j] = 1;
+
+  const uint stride = 32 * NCHAINS;
+  const uint aligned_N = (N / stride) * stride;
+  uint base = simd_lane_id * NCHAINS;
+  for (; base < aligned_N; base += stride) {
+    for (uint j = 0; j < NCHAINS; j++) {
+      acc[j] *= static_cast<TA>(row_ptr[base + j]);
+    }
+  }
+  for (uint i = aligned_N + simd_lane_id; i < N; i += 32) {
+    acc[0] *= static_cast<TA>(row_ptr[i]);
+  }
+
+  TA prod = acc[0];
+  for (uint j = 1; j < NCHAINS; j++)
+    prod *= acc[j];
+  // Reduce across the 32 lanes of this SIMD group (no shared memory needed).
+  prod = c10::metal::simd_prod(prod);
+
+  if (simd_lane_id == 0) {
+    output[row] = static_cast<TO>(prod);
+  }
+}
+
+#define REGISTER_PROD(TI, TO)                               \
+  template [[host_name("prod_reduction_" #TI "_" #TO)]]     \
+  kernel void prod_reduction<TI, TO, SUM_NCHAINS>(          \
+      constant TI * input [[buffer(0)]],                    \
+      device TO * output [[buffer(1)]],                     \
+      constant NormParams<> & params [[buffer(2)]],         \
+      uint tid [[thread_position_in_threadgroup]],          \
+      uint tptg [[threads_per_threadgroup]],                \
+      uint tgid [[threadgroup_position_in_grid]],           \
+      uint simd_lane_id [[thread_index_in_simdgroup]],      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]], \
+      uint simdgroup_size [[threads_per_simdgroup]]);
+
+#define REGISTER_PROD_OUTER(TI, TO)                              \
+  template [[host_name("prod_reduction_outer_" #TI "_" #TO)]]    \
+  kernel void prod_reduction_outer<TI, TO, 32, 32, SUM_NCHAINS>( \
+      constant TI * input [[buffer(0)]],                         \
+      device TO * output [[buffer(1)]],                          \
+      constant uint3 & sizes [[buffer(2)]],                      \
+      uint2 tid_tg [[thread_position_in_threadgroup]],           \
+      uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+#define REGISTER_PROD_INNER(TI, TO)                           \
+  template [[host_name("prod_reduction_inner_" #TI "_" #TO)]] \
+  kernel void prod_reduction_inner<TI, TO, SUM_NCHAINS>(      \
+      constant TI * input [[buffer(0)]],                      \
+      device TO * output [[buffer(1)]],                       \
+      constant uint2 & sizes [[buffer(2)]],                   \
+      uint tid [[thread_index_in_threadgroup]],               \
+      uint tptg [[threads_per_threadgroup]],                  \
+      uint tgid [[threadgroup_position_in_grid]],             \
+      uint simd_lane_id [[thread_index_in_simdgroup]],        \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+REGISTER_PROD(float, float);
+REGISTER_PROD(half, half);
+REGISTER_PROD(half, float);
+REGISTER_PROD(bfloat, bfloat);
+REGISTER_PROD(bfloat, float);
+REGISTER_PROD(int, int);
+REGISTER_PROD(int, long);
+REGISTER_PROD(long, long);
+REGISTER_PROD(short, short);
+REGISTER_PROD(short, long);
+REGISTER_PROD(char, char);
+REGISTER_PROD(char, long);
+REGISTER_PROD(uchar, uchar);
+REGISTER_PROD(uchar, long);
+REGISTER_PROD(bool, long);
+REGISTER_PROD(bool, int);
+
+REGISTER_PROD_OUTER(float, float);
+REGISTER_PROD_OUTER(half, half);
+REGISTER_PROD_OUTER(half, float);
+REGISTER_PROD_OUTER(bfloat, bfloat);
+REGISTER_PROD_OUTER(bfloat, float);
+REGISTER_PROD_OUTER(int, int);
+REGISTER_PROD_OUTER(int, long);
+REGISTER_PROD_OUTER(long, long);
+REGISTER_PROD_OUTER(short, short);
+REGISTER_PROD_OUTER(short, long);
+REGISTER_PROD_OUTER(char, char);
+REGISTER_PROD_OUTER(char, long);
+REGISTER_PROD_OUTER(uchar, uchar);
+REGISTER_PROD_OUTER(uchar, long);
+REGISTER_PROD_OUTER(bool, long);
+REGISTER_PROD_OUTER(bool, int);
+
+REGISTER_PROD_INNER(float, float);
+REGISTER_PROD_INNER(half, half);
+REGISTER_PROD_INNER(half, float);
+REGISTER_PROD_INNER(bfloat, bfloat);
+REGISTER_PROD_INNER(bfloat, float);
+REGISTER_PROD_INNER(int, int);
+REGISTER_PROD_INNER(int, long);
+REGISTER_PROD_INNER(long, long);
+REGISTER_PROD_INNER(short, short);
+REGISTER_PROD_INNER(short, long);
+REGISTER_PROD_INNER(char, char);
+REGISTER_PROD_INNER(char, long);
+REGISTER_PROD_INNER(uchar, uchar);
+REGISTER_PROD_INNER(uchar, long);
+REGISTER_PROD_INNER(bool, long);
+REGISTER_PROD_INNER(bool, int);
+
+// ============================================================================
+// Welford reduction kernels (var / std / var_mean / std_mean)
+// ============================================================================
+
+inline float3 simd_welford_combine(float3 stats) {
+  for (ushort i = simdgroup_size / 2; i > 0; i /= 2) {
+    float3 other;
+    other.x = ::metal::simd_shuffle_and_fill_down(stats.x, 0.0f, i);
+    other.y = ::metal::simd_shuffle_and_fill_down(stats.y, 0.0f, i);
+    other.z = ::metal::simd_shuffle_and_fill_down(stats.z, 0.0f, i);
+    stats = welford_combine(stats, other);
+  }
+  return stats;
+}
+
+struct WelfordConfig {
+  float correction;
+  float compute_std;
+  float write_mean;
+};
+
+template <typename TI, typename TO>
+kernel void welford_reduction(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant NormParams<>& params [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroup_size_val [[threads_per_simdgroup]]) {
+  uint32_t input_base = 0;
+  uint32_t reduction_stride = 1;
+  uint32_t num_reduced_dims = 0;
+  {
+    uint32_t out_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      if (params.input_sizes[dim] != params.output_sizes[dim]) {
+        num_reduced_dims++;
+        reduction_stride = params.input_strides[dim];
+      } else {
+        auto idx = out_idx % params.output_sizes[dim];
+        out_idx /= params.output_sizes[dim];
+        input_base += idx * params.input_strides[dim];
+      }
+    }
+  }
+
+  float w_mean = 0, w_m2 = 0, w_count = 0;
+  const uint32_t rsize = params.reduction_size;
+
+  if (num_reduced_dims <= 1) {
+    for (uint32_t k = tid; k < rsize; k += tptg) {
+      float val = static_cast<float>(input[input_base + k * reduction_stride]);
+      w_count += 1;
+      float delta = val - w_mean;
+      w_mean += delta / w_count;
+      w_m2 += delta * (val - w_mean);
+    }
+  } else {
+    for (uint32_t k = tid; k < rsize; k += tptg) {
+      float val = static_cast<float>(input[get_input_offset(k, tgid, params)]);
+      w_count += 1;
+      float delta = val - w_mean;
+      w_mean += delta / w_count;
+      w_m2 += delta * (val - w_mean);
+    }
+  }
+
+  float3 stats = simd_welford_combine(float3(w_mean, w_m2, w_count));
+
+  threadgroup float3 shared_stats[MAX_THREADGROUP_SIZE / 32];
+  uint num_simdgroups = ceil_div(tptg, simdgroup_size_val);
+
+  if (num_simdgroups > 1) {
+    if (simd_lane_id == 0) {
+      shared_stats[simdgroup_id] = stats;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < num_simdgroups) {
+      stats = shared_stats[tid];
+    } else {
+      stats = float3(0, 0, 0);
+    }
+    stats = simd_welford_combine(stats);
+  }
+
+  if (tid == 0) {
+    float denom = max(stats.z - config.correction, 0.0f);
+    float var = (denom > 0) ? stats.y / denom : (stats.y > 0 ? INFINITY : NAN);  // denom==0 (correction>=N): match CPU IEEE (inf), not Metal fast-math nan
+
+    uint32_t output_offset = 0;
+    uint32_t reduction_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      auto output_dim_size = params.output_sizes[dim];
+      if (output_dim_size > 1) {
+        auto index_in_dim = reduction_idx % output_dim_size;
+        reduction_idx /= output_dim_size;
+        output_offset += index_in_dim * params.output_strides[dim];
+      }
+    }
+
+    output[output_offset] =
+        static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+    if (config.write_mean > 0) {
+      output_mean[output_offset] = static_cast<TO>(stats.x);
+    }
+  }
+}
+
+template <typename TI, typename TO, uint TG_X = 32, uint TG_Y = 32>
+kernel void welford_reduction_outer(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]) {
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint out_stride = sizes.z;
+
+  uint col = tg_pos.x * TG_X + tid_tg.x;
+  if (col >= N)
+    return;
+
+  uint rows_per_y = ceil_div(M, TG_Y);
+  uint row_start = tid_tg.y * rows_per_y;
+  uint row_end = min(row_start + rows_per_y, M);
+
+  float w_mean = 0, w_m2 = 0, w_count = 0;
+  for (uint row = row_start; row < row_end; row++) {
+    float val = static_cast<float>(input[row * N + col]);
+    w_count += 1;
+    float delta = val - w_mean;
+    w_mean += delta / w_count;
+    w_m2 += delta * (val - w_mean);
+  }
+
+  threadgroup float3 shmem[TG_Y][TG_X];
+  shmem[tid_tg.y][tid_tg.x] = float3(w_mean, w_m2, w_count);
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint s = TG_Y / 2; s > 0; s >>= 1) {
+    if (tid_tg.y < s)
+      shmem[tid_tg.y][tid_tg.x] = welford_combine(
+          shmem[tid_tg.y][tid_tg.x], shmem[tid_tg.y + s][tid_tg.x]);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  if (tid_tg.y == 0) {
+    float3 stats = shmem[0][tid_tg.x];
+    float denom = max(stats.z - config.correction, 0.0f);
+    float var = (denom > 0) ? stats.y / denom : (stats.y > 0 ? INFINITY : NAN);  // denom==0 (correction>=N): match CPU IEEE (inf), not Metal fast-math nan
+    output[col * out_stride] =
+        static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+    if (config.write_mean > 0) {
+      output_mean[col * out_stride] = static_cast<TO>(stats.x);
+    }
+  }
+}
+
+template <typename TI, typename TO>
+kernel void welford_reduction_inner(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant uint2& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / 32;
+
+  // One SIMD group (32 lanes) reduces one row; num_simd_groups rows share a TG.
+  // This keeps every lane busy on small rows and bounds the threadgroup count
+  // (M/num_simd_groups) instead of launching one whole TG per row, which idles
+  // most threads and over-subscribes the GPU for many short rows.
+  uint row = tgid * num_simd_groups + simdgroup_id;
+  if (row >= M)
+    return;
+
+  constant TI* row_ptr = input + row * N;
+
+  constexpr uint NCHAINS = 4;
+  float w_mean[NCHAINS] = {0}, w_m2[NCHAINS] = {0}, w_count[NCHAINS] = {0};
+  // Each lane reads NCHAINS consecutive elements, blocks strided by 32*NCHAINS
+  // (coalesced across the SIMD group), matching sum_reduction_inner.
+  const uint stride = 32 * NCHAINS;
+  const uint aligned_N = (N / stride) * stride;
+  uint base = simd_lane_id * NCHAINS;
+  for (; base < aligned_N; base += stride) {
+    for (uint c = 0; c < NCHAINS; c++) {
+      float val = static_cast<float>(row_ptr[base + c]);
+      w_count[c] += 1;
+      float delta = val - w_mean[c];
+      w_mean[c] += delta / w_count[c];
+      w_m2[c] += delta * (val - w_mean[c]);
+    }
+  }
+  // Tail: leftover elements after the last full block, one per lane.
+  for (uint i = aligned_N + simd_lane_id; i < N; i += 32) {
+    float val = static_cast<float>(row_ptr[i]);
+    w_count[0] += 1;
+    float delta = val - w_mean[0];
+    w_mean[0] += delta / w_count[0];
+    w_m2[0] += delta * (val - w_mean[0]);
+  }
+  // Merge chains
+  float3 merged = float3(w_mean[0], w_m2[0], w_count[0]);
+  for (uint c = 1; c < NCHAINS; c++) {
+    merged = welford_combine(merged, float3(w_mean[c], w_m2[c], w_count[c]));
+  }
+  // Reduce across the 32 lanes of this SIMD group (no shared memory needed).
+  float3 stats = simd_welford_combine(merged);
+
+  if (simd_lane_id == 0) {
+    float denom = max(stats.z - config.correction, 0.0f);
+    float var = (denom > 0) ? stats.y / denom : (stats.y > 0 ? INFINITY : NAN);  // denom==0 (correction>=N): match CPU IEEE (inf), not Metal fast-math nan
+    output[row] =
+        static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+    if (config.write_mean > 0) {
+      output_mean[row] = static_cast<TO>(stats.x);
+    }
+  }
+}
+
+// ============================================================================
+// Welford 2-pass for all-reduce: pass1 writes per-TG (mean, M2, count)
+// triplet; pass2 combines triplets and produces final var/std/mean.
+// Used when output.numel() == 1 and N is large enough to benefit from
+// multiple threadgroups working in parallel.
+// ============================================================================
+
+template <typename TI>
+kernel void welford_reduction_pass1(
+    constant TI* input [[buffer(0)]],
+    device float3* partials [[buffer(1)]],
+    constant uint2& sizes [[buffer(2)]], // .x = elems_per_group, .y = total N
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  const uint32_t elems_per_group = sizes.x;
+  const uint32_t total_N = sizes.y;
+  const uint32_t group_start = tgid * elems_per_group;
+  const uint32_t group_end = min(group_start + elems_per_group, total_N);
+
+  // Accumulate this thread's local sum / sum-of-squares (cheap FMAs, no
+  // per-element division), shifted by a data value so the sum-of-squares stays
+  // numerically safe regardless of the true mean. Convert to a Welford triplet
+  // with a single division; the cross-thread combine below uses the stable
+  // Welford merge. This avoids ~N per-element divisions in the hot loop, which
+  // is what made the Welford all-reduce slower than the plain sum all-reduce.
+  float shift = (group_start + tid < group_end)
+      ? static_cast<float>(input[group_start + tid])
+      : 0.0f;
+  float w_sum = 0, w_sumsq = 0, w_count = 0;
+  for (uint32_t k = group_start + tid; k < group_end; k += tptg) {
+    float d = static_cast<float>(input[k]) - shift;
+    w_sum += d;
+    w_sumsq += d * d;
+    w_count += 1;
+  }
+  float w_mean = 0, w_m2 = 0;
+  if (w_count > 0) {
+    float meand = w_sum / w_count;
+    w_mean = shift + meand;
+    w_m2 = w_sumsq - w_sum * meand;  // sum((x - mean)^2)
+  }
+
+  float3 stats = simd_welford_combine(float3(w_mean, w_m2, w_count));
+
+  threadgroup float3 shared_stats[MAX_THREADGROUP_SIZE / 32];
+  uint num_simdgroups = ceil_div(tptg, 32u);
+  if (num_simdgroups > 1) {
+    if (simd_lane_id == 0) {
+      shared_stats[simdgroup_id] = stats;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < num_simdgroups) {
+      stats = shared_stats[tid];
+    } else {
+      stats = float3(0, 0, 0);
+    }
+    stats = simd_welford_combine(stats);
+  }
+
+  if (tid == 0) {
+    partials[tgid] = stats;
+  }
+}
+
+// Pass2: reduce N partial triplets to one final triplet, then write
+// var (or std) and optionally mean. Runs as a single threadgroup.
+template <typename TO>
+kernel void welford_reduction_pass2(
+    device const float3* partials [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant uint& num_partials [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  float3 acc = float3(0, 0, 0);
+  for (uint32_t i = tid; i < num_partials; i += tptg) {
+    acc = welford_combine(acc, partials[i]);
+  }
+  float3 stats = simd_welford_combine(acc);
+  threadgroup float3 shared_stats[MAX_THREADGROUP_SIZE / 32];
+  uint num_simdgroups = ceil_div(tptg, 32u);
+  if (num_simdgroups > 1) {
+    if (simd_lane_id == 0) {
+      shared_stats[simdgroup_id] = stats;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < num_simdgroups) {
+      stats = shared_stats[tid];
+    } else {
+      stats = float3(0, 0, 0);
+    }
+    stats = simd_welford_combine(stats);
+  }
+  if (tid == 0) {
+    float denom = max(stats.z - config.correction, 0.0f);
+    float var = (denom > 0) ? stats.y / denom : (stats.y > 0 ? INFINITY : NAN);  // denom==0 (correction>=N): match CPU IEEE (inf), not Metal fast-math nan
+    output[0] =
+        static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+    if (config.write_mean > 0) {
+      output_mean[0] = static_cast<TO>(stats.x);
+    }
+  }
+}
+
+// Wide inner-dim welford: one whole threadgroup (up to 1024 threads) reduces one
+// row, via per-thread streaming Welford + shared-memory tree. Used when N is
+// large / M is small (few but huge rows), where the simd-per-row variant would
+// leave only 32 threads on a giant row (slow AND loses precision from a deep
+// per-lane streaming accumulation). Matches the original reduction order.
+template <typename TI, typename TO>
+kernel void welford_reduction_inner_wide(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant uint2& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / 32;
+  uint row = tgid;
+  if (row >= M)
+    return;
+  constant TI* row_ptr = input + row * N;
+  constexpr uint NCHAINS = 4;
+  float w_mean[NCHAINS] = {0}, w_m2[NCHAINS] = {0}, w_count[NCHAINS] = {0};
+  uint stride = tptg * NCHAINS;
+  uint base = tid;
+  for (uint i = base; i + (NCHAINS - 1) * tptg < N; i += stride) {
+    for (uint c = 0; c < NCHAINS; c++) {
+      float val = static_cast<float>(row_ptr[i + c * tptg]);
+      w_count[c] += 1;
+      float delta = val - w_mean[c];
+      w_mean[c] += delta / w_count[c];
+      w_m2[c] += delta * (val - w_mean[c]);
+    }
+  }
+  for (uint i = base + (N / stride) * stride; i < N; i += tptg) {
+    float val = static_cast<float>(row_ptr[i]);
+    w_count[0] += 1;
+    float delta = val - w_mean[0];
+    w_mean[0] += delta / w_count[0];
+    w_m2[0] += delta * (val - w_mean[0]);
+  }
+  float3 merged = float3(w_mean[0], w_m2[0], w_count[0]);
+  for (uint c = 1; c < NCHAINS; c++) {
+    merged = welford_combine(merged, float3(w_mean[c], w_m2[c], w_count[c]));
+  }
+  float3 stats = simd_welford_combine(merged);
+  threadgroup float3 shared_stats[32];
+  if (simd_lane_id == 0) {
+    shared_stats[simdgroup_id] = stats;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (simdgroup_id == 0) {
+    stats = (simd_lane_id < num_simd_groups) ? shared_stats[simd_lane_id]
+                                             : float3(0, 0, 0);
+    stats = simd_welford_combine(stats);
+    if (simd_lane_id == 0) {
+      float denom = max(stats.z - config.correction, 0.0f);
+      float var = (denom > 0) ? stats.y / denom : (stats.y > 0 ? INFINITY : NAN);
+      output[row] =
+          static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+      if (config.write_mean > 0) {
+        output_mean[row] = static_cast<TO>(stats.x);
+      }
+    }
+  }
+}
+
+#define REGISTER_WELFORD_INNER_WIDE(TI, TO)                 \
+  template [[host_name("welford_inner_wide_" #TI "_" #TO)]] \
+  kernel void welford_reduction_inner_wide<TI, TO>(         \
+      constant TI * input [[buffer(0)]],                    \
+      device TO * output [[buffer(1)]],                     \
+      device TO * output_mean [[buffer(2)]],                \
+      constant uint2 & sizes [[buffer(3)]],                 \
+      constant WelfordConfig & config [[buffer(4)]],        \
+      uint tid [[thread_index_in_threadgroup]],             \
+      uint tptg [[threads_per_threadgroup]],                \
+      uint tgid [[threadgroup_position_in_grid]],           \
+      uint simd_lane_id [[thread_index_in_simdgroup]],      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+REGISTER_WELFORD_INNER_WIDE(float, float);
+REGISTER_WELFORD_INNER_WIDE(half, half);
+REGISTER_WELFORD_INNER_WIDE(half, float);
+REGISTER_WELFORD_INNER_WIDE(bfloat, bfloat);
+REGISTER_WELFORD_INNER_WIDE(bfloat, float);
+
+#define REGISTER_WELFORD(TI, TO)                            \
+  template [[host_name("welford_" #TI "_" #TO)]]            \
+  kernel void welford_reduction<TI, TO>(                    \
+      constant TI * input [[buffer(0)]],                    \
+      device TO * output [[buffer(1)]],                     \
+      device TO * output_mean [[buffer(2)]],                \
+      constant NormParams<> & params [[buffer(3)]],         \
+      constant WelfordConfig & config [[buffer(4)]],        \
+      uint tid [[thread_position_in_threadgroup]],          \
+      uint tptg [[threads_per_threadgroup]],                \
+      uint tgid [[threadgroup_position_in_grid]],           \
+      uint simd_lane_id [[thread_index_in_simdgroup]],      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]], \
+      uint simdgroup_size_val [[threads_per_simdgroup]]);
+
+#define REGISTER_WELFORD_OUTER(TI, TO)                 \
+  template [[host_name("welford_outer_" #TI "_" #TO)]] \
+  kernel void welford_reduction_outer<TI, TO, 32, 32>( \
+      constant TI * input [[buffer(0)]],               \
+      device TO * output [[buffer(1)]],                \
+      device TO * output_mean [[buffer(2)]],           \
+      constant uint3 & sizes [[buffer(3)]],            \
+      constant WelfordConfig & config [[buffer(4)]],   \
+      uint2 tid_tg [[thread_position_in_threadgroup]], \
+      uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+#define REGISTER_WELFORD_INNER(TI, TO)                 \
+  template [[host_name("welford_inner_" #TI "_" #TO)]] \
+  kernel void welford_reduction_inner<TI, TO>(         \
+      constant TI * input [[buffer(0)]],               \
+      device TO * output [[buffer(1)]],                \
+      device TO * output_mean [[buffer(2)]],           \
+      constant uint2 & sizes [[buffer(3)]],            \
+      constant WelfordConfig & config [[buffer(4)]],   \
+      uint tid [[thread_index_in_threadgroup]],        \
+      uint tptg [[threads_per_threadgroup]],           \
+      uint tgid [[threadgroup_position_in_grid]],      \
+      uint simd_lane_id [[thread_index_in_simdgroup]], \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+REGISTER_WELFORD(float, float);
+REGISTER_WELFORD(half, half);
+REGISTER_WELFORD(half, float);
+REGISTER_WELFORD(bfloat, bfloat);
+REGISTER_WELFORD(bfloat, float);
+
+REGISTER_WELFORD_OUTER(float, float);
+
+// 2-pass welford registrations (pass1 templated on TI; pass2 templated on TO).
+#define REGISTER_WELFORD_PASS1(TI)                     \
+  template [[host_name("welford_pass1_" #TI)]]         \
+  kernel void welford_reduction_pass1<TI>(             \
+      constant TI * input [[buffer(0)]],               \
+      device float3 * partials [[buffer(1)]],          \
+      constant uint2 & sizes [[buffer(2)]],            \
+      uint tid [[thread_position_in_threadgroup]],     \
+      uint tptg [[threads_per_threadgroup]],           \
+      uint tgid [[threadgroup_position_in_grid]],      \
+      uint simd_lane_id [[thread_index_in_simdgroup]], \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define REGISTER_WELFORD_PASS2(TO)                     \
+  template [[host_name("welford_pass2_" #TO)]]         \
+  kernel void welford_reduction_pass2<TO>(             \
+      device const float3* partials [[buffer(0)]],     \
+      device TO* output [[buffer(1)]],                 \
+      device TO* output_mean [[buffer(2)]],            \
+      constant uint& num_partials [[buffer(3)]],       \
+      constant WelfordConfig& config [[buffer(4)]],    \
+      uint tid [[thread_position_in_threadgroup]],     \
+      uint tptg [[threads_per_threadgroup]],           \
+      uint simd_lane_id [[thread_index_in_simdgroup]], \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+REGISTER_WELFORD_PASS1(float);
+REGISTER_WELFORD_PASS1(half);
+REGISTER_WELFORD_PASS1(bfloat);
+
+REGISTER_WELFORD_PASS2(float);
+REGISTER_WELFORD_PASS2(half);
+REGISTER_WELFORD_PASS2(bfloat);
+
+REGISTER_WELFORD_OUTER(half, half);
+REGISTER_WELFORD_OUTER(half, float);
+REGISTER_WELFORD_OUTER(bfloat, bfloat);
+REGISTER_WELFORD_OUTER(bfloat, float);
+
+REGISTER_WELFORD_INNER(float, float);
+REGISTER_WELFORD_INNER(half, half);
+REGISTER_WELFORD_INNER(half, float);
+REGISTER_WELFORD_INNER(bfloat, bfloat);
+REGISTER_WELFORD_INNER(bfloat, float);
+
+// ============================================================================
+// Arg-reduce kernels (argmax / argmin / max / min with indices)
+// ============================================================================
+
+template <typename TI, bool IS_MAX>
+kernel void argreduce(
+    constant TI* input [[buffer(0)]],
+    device long* output_indices [[buffer(1)]],
+    device TI* output_values [[buffer(2)]],
+    constant NormParams<>& params [[buffer(3)]],
+    constant uchar& write_values [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]],
+    uint simdgroup_size_val [[threads_per_simdgroup]]) {
+  using TA = opmath_t<TI>;
+
+  TA best_val;
+  if (IS_MAX) {
+    best_val = ::metal::numeric_limits<TA>::lowest();
+  } else {
+    best_val = ::metal::numeric_limits<TA>::max();
+  }
+  long best_idx = 0;
+
+  uint32_t input_base = 0;
+  uint32_t reduction_stride = 1;
+  uint32_t num_reduced_dims = 0;
+  {
+    uint32_t out_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      if (params.input_sizes[dim] != params.output_sizes[dim]) {
+        num_reduced_dims++;
+        reduction_stride = params.input_strides[dim];
+      } else {
+        auto idx = out_idx % params.output_sizes[dim];
+        out_idx /= params.output_sizes[dim];
+        input_base += idx * params.input_strides[dim];
+      }
+    }
+  }
+
+  const uint32_t rsize = params.reduction_size;
+
+  if (num_reduced_dims <= 1) {
+    for (uint32_t k = tid; k < rsize; k += tptg) {
+      TA val = static_cast<TA>(input[input_base + k * reduction_stride]);
+      bool better = IS_MAX ? (val > best_val) : (val < best_val);
+      if (better || ::metal::isnan(static_cast<float>(val))) {
+        best_val = val;
+        best_idx = k;
+      }
+    }
+  } else {
+    for (uint32_t k = tid; k < rsize; k += tptg) {
+      TA val = static_cast<TA>(input[get_input_offset(k, tgid, params)]);
+      bool better = IS_MAX ? (val > best_val) : (val < best_val);
+      if (better || ::metal::isnan(static_cast<float>(val))) {
+        best_val = val;
+        best_idx = k;
+      }
+    }
+  }
+
+  threadgroup TA arg_data[32];
+  threadgroup long idx_data[32];
+
+  long result_idx;
+  if (IS_MAX) {
+    result_idx = c10::metal::threadgroup_argmax(
+        arg_data, idx_data, best_val, best_idx, tid, tptg);
+  } else {
+    result_idx = c10::metal::threadgroup_argmin(
+        arg_data, idx_data, best_val, best_idx, tid, tptg);
+  }
+
+  if (tid == 0) {
+    uint32_t output_offset = 0;
+    uint32_t reduction_idx = tgid;
+    for (int32_t dim = params.ndim - 1; dim >= 0; dim--) {
+      auto output_dim_size = params.output_sizes[dim];
+      if (output_dim_size > 1) {
+        auto index_in_dim = reduction_idx % output_dim_size;
+        reduction_idx /= output_dim_size;
+        output_offset += index_in_dim * params.output_strides[dim];
+      }
+    }
+    output_indices[output_offset] = result_idx;
+    if (write_values) {
+      uint32_t val_input_offset;
+      if (num_reduced_dims <= 1) {
+        val_input_offset = input_base + result_idx * reduction_stride;
+      } else {
+        val_input_offset = get_input_offset(result_idx, tgid, params);
+      }
+      output_values[output_offset] = input[val_input_offset];
+    }
+  }
+}
+
+// Contiguous inner-dim arg-reduce: one SIMD group (32 lanes) reduces one row of
+// N elements; num_simd_groups rows share a threadgroup. Avoids launching one TG
+// per row (over-subscription + idle threads) for many short rows. Used when the
+// reduction is over the contiguous innermost dim. Same lowest-index/NaN tie
+// semantics as the generic kernel.
+template <typename TI, bool IS_MAX>
+kernel void argreduce_inner(
+    constant TI* input [[buffer(0)]],
+    device long* output_indices [[buffer(1)]],
+    device TI* output_values [[buffer(2)]],
+    constant uint2& sizes [[buffer(3)]],  // [M, N]
+    constant uchar& write_values [[buffer(4)]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  using TA = opmath_t<TI>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint num_simd_groups = tptg / 32;
+  uint row = tgid * num_simd_groups + simdgroup_id;
+  if (row >= M)
+    return;
+  constant TI* row_ptr = input + row * N;
+
+  TA best_val = IS_MAX ? ::metal::numeric_limits<TA>::lowest()
+                       : ::metal::numeric_limits<TA>::max();
+  long best_idx = 0;
+  for (uint k = simd_lane_id; k < N; k += 32) {
+    TA val = static_cast<TA>(row_ptr[k]);
+    bool better = IS_MAX ? (val > best_val) : (val < best_val);
+    if (better || ::metal::isnan(static_cast<float>(val))) {
+      best_val = val;
+      best_idx = k;
+    }
+  }
+  auto rc = IS_MAX ? c10::metal::simd_argmax(best_val, best_idx)
+                   : c10::metal::simd_argmin(best_val, best_idx);
+  if (simd_lane_id == 0) {
+    output_indices[row] = rc.second;
+    if (write_values) {
+      output_values[row] = static_cast<TI>(rc.first);
+    }
+  }
+}
+
+// Outer-dim arg-reduce (reduce dim 0 of a contiguous [M, N] tensor): TG_X
+// columns x TG_Y row-workers per threadgroup, coalesced column reads, then a
+// tree reduction across the TG_Y workers of each column. Avoids the generic
+// kernel's one-TG-per-output + strided reads for many output columns.
+template <typename TI, bool IS_MAX, uint TG_X, uint TG_Y>
+kernel void argreduce_outer(
+    constant TI* input [[buffer(0)]],
+    device long* output_indices [[buffer(1)]],
+    device TI* output_values [[buffer(2)]],
+    constant uint2& sizes [[buffer(3)]],  // [M, N]
+    constant uchar& write_values [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]) {
+  using TA = opmath_t<TI>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  uint col = tg_pos.x * TG_X + tid_tg.x;
+  if (col >= N)
+    return;
+
+  uint rows_per_y = (M + TG_Y - 1) / TG_Y;
+  uint row_start = tid_tg.y * rows_per_y;
+  uint row_end = ::metal::min(row_start + rows_per_y, M);
+
+  TA best_val = IS_MAX ? ::metal::numeric_limits<TA>::lowest()
+                       : ::metal::numeric_limits<TA>::max();
+  long best_idx = M;  // sentinel: a worker with no rows never wins (idx >= M)
+  for (uint row = row_start; row < row_end; row++) {
+    TA val = static_cast<TA>(input[row * N + col]);
+    bool better = IS_MAX ? (val > best_val) : (val < best_val);
+    if (best_idx == (long)M || better || ::metal::isnan(static_cast<float>(val))) {
+      best_val = val;
+      best_idx = row;
+    }
+  }
+
+  threadgroup TA vmem[TG_Y][TG_X];
+  threadgroup long imem[TG_Y][TG_X];
+  vmem[tid_tg.y][tid_tg.x] = best_val;
+  imem[tid_tg.y][tid_tg.x] = best_idx;
+  ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+
+  for (uint s = TG_Y / 2; s > 0; s >>= 1) {
+    if (tid_tg.y < s) {
+      TA cv = vmem[tid_tg.y][tid_tg.x];
+      long ci = imem[tid_tg.y][tid_tg.x];
+      TA ov = vmem[tid_tg.y + s][tid_tg.x];
+      long oi = imem[tid_tg.y + s][tid_tg.x];
+      bool c_valid = ci < (long)M, o_valid = oi < (long)M;
+      bool c_nan = c_valid && ::metal::isnan(static_cast<float>(cv));
+      bool o_nan = o_valid && ::metal::isnan(static_cast<float>(ov));
+      bool take;
+      if (!o_valid) {
+        take = false;
+      } else if (!c_valid) {
+        take = true;
+      } else if (o_nan != c_nan) {
+        take = o_nan;  // NaN beats non-NaN (torch returns a NaN index)
+      } else if (o_nan && c_nan) {
+        take = oi < ci;  // both NaN: lowest index
+      } else {
+        bool better = IS_MAX ? (ov > cv) : (ov < cv);
+        take = better || (ov == cv && oi < ci);  // tie -> lowest index
+      }
+      if (take) {
+        vmem[tid_tg.y][tid_tg.x] = ov;
+        imem[tid_tg.y][tid_tg.x] = oi;
+      }
+    }
+    ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);
+  }
+
+  if (tid_tg.y == 0) {
+    output_indices[col] = imem[0][tid_tg.x];
+    if (write_values) {
+      output_values[col] = static_cast<TI>(vmem[0][tid_tg.x]);
+    }
+  }
+}
+
+// Fused 2-pass arg-reduce for large all-reduce (value+index). pass1: each TG
+// reduces a contiguous chunk to a per-group (winning global index, value);
+// pass2: a single TG picks the winning group. Only 2 dispatches (vs the
+// reshape/gather/index_select chain), which matters at ~1M elems where the
+// generic single-TG kernel is dispatch/parallelism-bound. Lowest index wins ties.
+template <typename TI, bool IS_MAX>
+kernel void argreduce_pass1(
+    constant TI* input [[buffer(0)]],
+    device TI* partials_val [[buffer(1)]],
+    device long* partials_idx [[buffer(2)]],
+    constant uint2& sizes [[buffer(3)]],  // [elems_per_group, total_N]
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  using TA = opmath_t<TI>;
+  const uint epg = sizes.x;
+  const uint total_N = sizes.y;
+  const uint group_start = tgid * epg;
+  const uint group_end = min(group_start + epg, total_N);
+
+  TA best_val = IS_MAX ? ::metal::numeric_limits<TA>::lowest()
+                       : ::metal::numeric_limits<TA>::max();
+  long best_idx = group_start;
+  for (uint k = group_start + tid; k < group_end; k += tptg) {
+    TA val = static_cast<TA>(input[k]);
+    bool better = IS_MAX ? (val > best_val) : (val < best_val);
+    if (better || ::metal::isnan(static_cast<float>(val))) {
+      best_val = val;
+      best_idx = k;
+    }
+  }
+  threadgroup TA arg_data[32];
+  threadgroup long idx_data[32];
+  long win = IS_MAX
+      ? c10::metal::threadgroup_argmax(arg_data, idx_data, best_val, best_idx, tid, tptg)
+      : c10::metal::threadgroup_argmin(arg_data, idx_data, best_val, best_idx, tid, tptg);
+  if (tid == 0) {
+    partials_idx[tgid] = win;
+    partials_val[tgid] = input[win];
+  }
+}
+
+template <typename TI, bool IS_MAX>
+kernel void argreduce_pass2(
+    device const TI* partials_val [[buffer(0)]],
+    device const long* partials_idx [[buffer(1)]],
+    device long* output_idx [[buffer(2)]],
+    device TI* output_val [[buffer(3)]],
+    constant uint& num_partials [[buffer(4)]],
+    constant uchar& write_values [[buffer(5)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  using TA = opmath_t<TI>;
+  TA best_val = IS_MAX ? ::metal::numeric_limits<TA>::lowest()
+                       : ::metal::numeric_limits<TA>::max();
+  long best_pos = 0;
+  for (uint i = tid; i < num_partials; i += tptg) {
+    TA val = static_cast<TA>(partials_val[i]);
+    bool better = IS_MAX ? (val > best_val) : (val < best_val);
+    if (better || ::metal::isnan(static_cast<float>(val))) {
+      best_val = val;
+      best_pos = (long)i;
+    }
+  }
+  threadgroup TA arg_data[32];
+  threadgroup long idx_data[32];
+  long win_pos = IS_MAX
+      ? c10::metal::threadgroup_argmax(arg_data, idx_data, best_val, best_pos, tid, tptg)
+      : c10::metal::threadgroup_argmin(arg_data, idx_data, best_val, best_pos, tid, tptg);
+  if (tid == 0) {
+    output_idx[0] = partials_idx[win_pos];
+    if (write_values) {
+      output_val[0] = partials_val[win_pos];
+    }
+  }
+}
+
+#define REGISTER_ARGREDUCE(TI, NAME, IS_MAX)                \
+  template [[host_name(NAME "_" #TI)]]                      \
+  kernel void argreduce<TI, IS_MAX>(                        \
+      constant TI * input [[buffer(0)]],                    \
+      device long* output_indices [[buffer(1)]],            \
+      device TI* output_values [[buffer(2)]],               \
+      constant NormParams<>& params [[buffer(3)]],          \
+      constant uchar& write_values [[buffer(4)]],           \
+      uint tid [[thread_position_in_threadgroup]],          \
+      uint tptg [[threads_per_threadgroup]],                \
+      uint tgid [[threadgroup_position_in_grid]],           \
+      uint simd_lane_id [[thread_index_in_simdgroup]],      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]], \
+      uint simdgroup_size_val [[threads_per_simdgroup]]);
+
+REGISTER_ARGREDUCE(float, "argmax", true);
+REGISTER_ARGREDUCE(float, "argmin", false);
+REGISTER_ARGREDUCE(half, "argmax", true);
+REGISTER_ARGREDUCE(half, "argmin", false);
+REGISTER_ARGREDUCE(bfloat, "argmax", true);
+REGISTER_ARGREDUCE(bfloat, "argmin", false);
+REGISTER_ARGREDUCE(int, "argmax", true);
+REGISTER_ARGREDUCE(int, "argmin", false);
+REGISTER_ARGREDUCE(long, "argmax", true);
+REGISTER_ARGREDUCE(long, "argmin", false);
+REGISTER_ARGREDUCE(short, "argmax", true);
+REGISTER_ARGREDUCE(short, "argmin", false);
+REGISTER_ARGREDUCE(char, "argmax", true);
+REGISTER_ARGREDUCE(char, "argmin", false);
+REGISTER_ARGREDUCE(uchar, "argmax", true);
+REGISTER_ARGREDUCE(uchar, "argmin", false);
+
+#define REGISTER_ARGREDUCE_INNER(TI, NAME, IS_MAX)         \
+  template [[host_name(NAME "_inner_" #TI)]]               \
+  kernel void argreduce_inner<TI, IS_MAX>(                 \
+      constant TI * input [[buffer(0)]],                   \
+      device long* output_indices [[buffer(1)]],           \
+      device TI* output_values [[buffer(2)]],              \
+      constant uint2& sizes [[buffer(3)]],                 \
+      constant uchar& write_values [[buffer(4)]],          \
+      uint tptg [[threads_per_threadgroup]],               \
+      uint tgid [[threadgroup_position_in_grid]],          \
+      uint simd_lane_id [[thread_index_in_simdgroup]],     \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+REGISTER_ARGREDUCE_INNER(float, "argmax", true);
+REGISTER_ARGREDUCE_INNER(float, "argmin", false);
+REGISTER_ARGREDUCE_INNER(half, "argmax", true);
+REGISTER_ARGREDUCE_INNER(half, "argmin", false);
+REGISTER_ARGREDUCE_INNER(bfloat, "argmax", true);
+REGISTER_ARGREDUCE_INNER(bfloat, "argmin", false);
+REGISTER_ARGREDUCE_INNER(int, "argmax", true);
+REGISTER_ARGREDUCE_INNER(int, "argmin", false);
+REGISTER_ARGREDUCE_INNER(long, "argmax", true);
+REGISTER_ARGREDUCE_INNER(long, "argmin", false);
+REGISTER_ARGREDUCE_INNER(short, "argmax", true);
+REGISTER_ARGREDUCE_INNER(short, "argmin", false);
+REGISTER_ARGREDUCE_INNER(char, "argmax", true);
+REGISTER_ARGREDUCE_INNER(char, "argmin", false);
+REGISTER_ARGREDUCE_INNER(uchar, "argmax", true);
+REGISTER_ARGREDUCE_INNER(uchar, "argmin", false);
+
+
+#define REGISTER_ARGREDUCE_OUTER(TI, NAME, IS_MAX)         \
+  template [[host_name(NAME "_outer_" #TI)]]               \
+  kernel void argreduce_outer<TI, IS_MAX, 32, 32>(         \
+      constant TI * input [[buffer(0)]],                   \
+      device long* output_indices [[buffer(1)]],           \
+      device TI* output_values [[buffer(2)]],              \
+      constant uint2& sizes [[buffer(3)]],                 \
+      constant uchar& write_values [[buffer(4)]],          \
+      uint2 tid_tg [[thread_position_in_threadgroup]],     \
+      uint2 tg_pos [[threadgroup_position_in_grid]]);
+REGISTER_ARGREDUCE_OUTER(float, "argmax", true);
+REGISTER_ARGREDUCE_OUTER(float, "argmin", false);
+REGISTER_ARGREDUCE_OUTER(half, "argmax", true);
+REGISTER_ARGREDUCE_OUTER(half, "argmin", false);
+REGISTER_ARGREDUCE_OUTER(bfloat, "argmax", true);
+REGISTER_ARGREDUCE_OUTER(bfloat, "argmin", false);
+REGISTER_ARGREDUCE_OUTER(int, "argmax", true);
+REGISTER_ARGREDUCE_OUTER(int, "argmin", false);
+REGISTER_ARGREDUCE_OUTER(long, "argmax", true);
+REGISTER_ARGREDUCE_OUTER(long, "argmin", false);
+REGISTER_ARGREDUCE_OUTER(short, "argmax", true);
+REGISTER_ARGREDUCE_OUTER(short, "argmin", false);
+REGISTER_ARGREDUCE_OUTER(char, "argmax", true);
+REGISTER_ARGREDUCE_OUTER(char, "argmin", false);
+REGISTER_ARGREDUCE_OUTER(uchar, "argmax", true);
+REGISTER_ARGREDUCE_OUTER(uchar, "argmin", false);
+
+
+#define REGISTER_ARGREDUCE_2PASS(TI, NAME, IS_MAX)         \
+  template [[host_name(NAME "_pass1_" #TI)]]               \
+  kernel void argreduce_pass1<TI, IS_MAX>(                 \
+      constant TI * input [[buffer(0)]],                   \
+      device TI* partials_val [[buffer(1)]],               \
+      device long* partials_idx [[buffer(2)]],             \
+      constant uint2& sizes [[buffer(3)]],                 \
+      uint tid [[thread_position_in_threadgroup]],         \
+      uint tptg [[threads_per_threadgroup]],               \
+      uint tgid [[threadgroup_position_in_grid]],          \
+      uint simd_lane_id [[thread_index_in_simdgroup]],     \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]); \
+  template [[host_name(NAME "_pass2_" #TI)]]               \
+  kernel void argreduce_pass2<TI, IS_MAX>(                 \
+      device const TI* partials_val [[buffer(0)]],         \
+      device const long* partials_idx [[buffer(1)]],       \
+      device long* output_idx [[buffer(2)]],               \
+      device TI* output_val [[buffer(3)]],                 \
+      constant uint& num_partials [[buffer(4)]],           \
+      constant uchar& write_values [[buffer(5)]],          \
+      uint tid [[thread_position_in_threadgroup]],         \
+      uint tptg [[threads_per_threadgroup]],               \
+      uint simd_lane_id [[thread_index_in_simdgroup]],     \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+REGISTER_ARGREDUCE_2PASS(float, "argmax", true);
+REGISTER_ARGREDUCE_2PASS(float, "argmin", false);
+REGISTER_ARGREDUCE_2PASS(half, "argmax", true);
+REGISTER_ARGREDUCE_2PASS(half, "argmin", false);
+REGISTER_ARGREDUCE_2PASS(bfloat, "argmax", true);
+REGISTER_ARGREDUCE_2PASS(bfloat, "argmin", false);
+REGISTER_ARGREDUCE_2PASS(int, "argmax", true);
+REGISTER_ARGREDUCE_2PASS(int, "argmin", false);
+REGISTER_ARGREDUCE_2PASS(long, "argmax", true);
+REGISTER_ARGREDUCE_2PASS(long, "argmin", false);
+REGISTER_ARGREDUCE_2PASS(short, "argmax", true);
+REGISTER_ARGREDUCE_2PASS(short, "argmin", false);
+REGISTER_ARGREDUCE_2PASS(char, "argmax", true);
+REGISTER_ARGREDUCE_2PASS(char, "argmin", false);
+REGISTER_ARGREDUCE_2PASS(uchar, "argmax", true);
+REGISTER_ARGREDUCE_2PASS(uchar, "argmin", false);
+
+// Small-M variants: welford_outer / prod_outer with TG_Y matching M.
+// Avoids the 75-87% idle-thread waste of TG_Y=32 when M is 8 or 16.
+
+template [[host_name("welford_outer_8_float_float")]]
+kernel void welford_reduction_outer<float, float, 128, 8>(
+    constant float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_8_half_half")]]
+kernel void welford_reduction_outer<half, half, 128, 8>(
+    constant half* input [[buffer(0)]],
+    device half* output [[buffer(1)]],
+    device half* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_8_half_float")]]
+kernel void welford_reduction_outer<half, float, 128, 8>(
+    constant half* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_8_bfloat_bfloat")]]
+kernel void welford_reduction_outer<bfloat, bfloat, 128, 8>(
+    constant bfloat* input [[buffer(0)]],
+    device bfloat* output [[buffer(1)]],
+    device bfloat* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_8_bfloat_float")]]
+kernel void welford_reduction_outer<bfloat, float, 128, 8>(
+    constant bfloat* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+template [[host_name("welford_outer_16_float_float")]]
+kernel void welford_reduction_outer<float, float, 64, 16>(
+    constant float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_16_half_half")]]
+kernel void welford_reduction_outer<half, half, 64, 16>(
+    constant half* input [[buffer(0)]],
+    device half* output [[buffer(1)]],
+    device half* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_16_half_float")]]
+kernel void welford_reduction_outer<half, float, 64, 16>(
+    constant half* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_16_bfloat_bfloat")]]
+kernel void welford_reduction_outer<bfloat, bfloat, 64, 16>(
+    constant bfloat* input [[buffer(0)]],
+    device bfloat* output [[buffer(1)]],
+    device bfloat* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("welford_outer_16_bfloat_float")]]
+kernel void welford_reduction_outer<bfloat, float, 64, 16>(
+    constant bfloat* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+template [[host_name("prod_reduction_outer_8_float_float")]]
+kernel void prod_reduction_outer<float, float, 128, 8>(
+    constant float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("prod_reduction_outer_8_half_half")]]
+kernel void prod_reduction_outer<half, half, 128, 8>(
+    constant half* input [[buffer(0)]],
+    device half* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("prod_reduction_outer_8_bfloat_bfloat")]]
+kernel void prod_reduction_outer<bfloat, bfloat, 128, 8>(
+    constant bfloat* input [[buffer(0)]],
+    device bfloat* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+template [[host_name("prod_reduction_outer_16_float_float")]]
+kernel void prod_reduction_outer<float, float, 64, 16>(
+    constant float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("prod_reduction_outer_16_half_half")]]
+kernel void prod_reduction_outer<half, half, 64, 16>(
+    constant half* input [[buffer(0)]],
+    device half* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+template [[host_name("prod_reduction_outer_16_bfloat_bfloat")]]
+kernel void prod_reduction_outer<bfloat, bfloat, 64, 16>(
+    constant bfloat* input [[buffer(0)]],
+    device bfloat* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint2 tid_tg [[thread_position_in_threadgroup]],
+    uint2 tg_pos [[threadgroup_position_in_grid]]);
+
+// Small-M outer prod (M <= 16): grid-stride over columns, each thread reduces
+// COLS columns over all M rows. The generic outer kernel splits the tiny M
+// across TG_Y row-workers and pays a shared-memory barrier tree; that overhead
+// dominates when M is small. One-thread-per-column instead over-subscribes the
+// GPU for large N. sum dim=0 uses a tensor-core simdgemm path that products
+// cannot, so prod needs this dedicated layout. COLS=2 won a config sweep.
+template <typename TI, typename TO, uint COLS = 2>
+kernel void prod_reduction_outer_smallm(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant uint3& sizes [[buffer(2)]],
+    uint gid [[thread_position_in_grid]],
+    uint gsize [[threads_per_grid]]) {
+  using TA = opmath_t<TO>;
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint out_stride = sizes.z;
+  for (uint col = gid; col < N; col += gsize) {
+    TA acc = 1;
+    for (uint row = 0; row < M; row++) {
+      acc *= static_cast<TA>(input[row * N + col]);
+    }
+    output[col * out_stride] = static_cast<TO>(acc);
+  }
+}
+
+#define REGISTER_PROD_OUTER_SMALLM(TI, TO)                             template [[host_name("prod_reduction_outer_smallm_" #TI "_" #TO)]]   kernel void prod_reduction_outer_smallm<TI, TO, 2>(                      constant TI* input [[buffer(0)]],                                    device TO* output [[buffer(1)]],                                     constant uint3& sizes [[buffer(2)]],                                 uint gid [[thread_position_in_grid]],                                uint gsize [[threads_per_grid]]);
+REGISTER_PROD_OUTER_SMALLM(float, float);
+REGISTER_PROD_OUTER_SMALLM(half, half);
+REGISTER_PROD_OUTER_SMALLM(bfloat, bfloat);
+
+// ============================================================================
+// simdgroup_matrix-accelerated welford for dim=0 reduction with small M.
+// Each simdgroup processes CHUNKS_PER_SG 8-col chunks sequentially, so TG
+// covers SG_PER_TG * CHUNKS_PER_SG * 8 cols regardless of N. This keeps the
+// TG count proportional to N / 256 instead of N / 32, avoiding the
+// TG-scheduling overhead that hurt v1/v2 on huge-N shapes.
+//   col_sum[j]  = (ones[8x8] @ x[8x8])[0,j]
+//   col_ssq[j]  = (x[8x8]^T @ x[8x8])[j,j]   (diagonal)
+// ============================================================================
+
+template <typename TI, typename TO>
+kernel void welford_reduction_outer_simdgemm(
+    device const TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    device TO* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint sg_id [[simdgroup_index_in_threadgroup]],
+    uint sg_lane [[thread_index_in_simdgroup]],
+    uint tg_x [[threadgroup_position_in_grid]]) {
+  const uint M = sizes.x;
+  const uint N = sizes.y;
+  const uint out_stride = sizes.z;
+
+  constexpr uint COLS_PER_CHUNK = 8;
+  constexpr uint SG_PER_TG = 4;
+  constexpr uint CHUNKS_PER_SG = 16;
+  constexpr uint COLS_PER_TG =
+      SG_PER_TG * CHUNKS_PER_SG * COLS_PER_CHUNK; // 256
+
+  const uint sg_col_base =
+      tg_x * COLS_PER_TG + sg_id * CHUNKS_PER_SG * COLS_PER_CHUNK;
+
+  threadgroup float tg_sum[SG_PER_TG][CHUNKS_PER_SG][8];
+  threadgroup float tg_ssq[SG_PER_TG][CHUNKS_PER_SG][8];
+  threadgroup float tg_buf[SG_PER_TG][8][8];
+  threadgroup TI tg_xscratch[SG_PER_TG][8][8];
+
+  simdgroup_matrix<TI, 8, 8> ones = make_filled_simdgroup_matrix<TI, 8>(TI(1));
+
+  for (uint chunk = 0; chunk < CHUNKS_PER_SG; chunk++) {
+    const uint col_base = sg_col_base + chunk * COLS_PER_CHUNK;
+    if (col_base >= N)
+      break;
+
+    simdgroup_matrix<float, 8, 8> sum_acc =
+        make_filled_simdgroup_matrix<float, 8>(0.0f);
+    simdgroup_matrix<float, 8, 8> ssq_acc =
+        make_filled_simdgroup_matrix<float, 8>(0.0f);
+
+    for (uint row = 0; row + 8 <= M; row += 8) {
+      simdgroup_matrix<TI, 8, 8> x_tile;
+      simdgroup_load(x_tile, input + row * N + col_base, N);  // single global read
+      simdgroup_multiply_accumulate(sum_acc, ones, x_tile, sum_acc);
+
+      // Transpose via threadgroup scratch rather than a second (strided) global
+      // load of the same tile — the kernel is memory-bound, so re-reading from
+      // DRAM doubles traffic. simdgroup_barrier suffices (intra-simdgroup).
+      simdgroup_store(x_tile, (threadgroup TI*)tg_xscratch[sg_id], 8);
+      simdgroup_barrier(mem_flags::mem_threadgroup);
+      simdgroup_matrix<TI, 8, 8> x_T;
+      simdgroup_load(x_T, (threadgroup TI*)tg_xscratch[sg_id], 8, ulong2(0, 0), true);
+      simdgroup_multiply_accumulate(ssq_acc, x_T, x_tile, ssq_acc);
+    }
+
+    // Each simdgroup's tg_buf slot is private; no race.
+    simdgroup_store(sum_acc, (threadgroup float*)tg_buf[sg_id], 8);
+    if (sg_lane < 8) {
+      tg_sum[sg_id][chunk][sg_lane] = tg_buf[sg_id][0][sg_lane];
+    }
+    simdgroup_store(ssq_acc, (threadgroup float*)tg_buf[sg_id], 8);
+    if (sg_lane < 8) {
+      tg_ssq[sg_id][chunk][sg_lane] = tg_buf[sg_id][sg_lane][sg_lane];
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // First 8 threads of each simdgroup walk through their CHUNKS_PER_SG
+  // chunks and write outputs.
+  if (sg_lane < 8) {
+    for (uint chunk = 0; chunk < CHUNKS_PER_SG; chunk++) {
+      const uint col_base = sg_col_base + chunk * COLS_PER_CHUNK;
+      const uint out_col = col_base + sg_lane;
+      if (out_col >= N)
+        break;
+      float total_sum = tg_sum[sg_id][chunk][sg_lane];
+      float total_ssq = tg_ssq[sg_id][chunk][sg_lane];
+      float mean = total_sum / float(M);
+      float var_num =
+          total_ssq - 2.0f * mean * total_sum + float(M) * mean * mean;
+      float denom = max(float(M) - config.correction, 0.0f);
+      float var = (denom > 0) ? var_num / denom : (var_num > 0 ? INFINITY : NAN);  // match CPU IEEE (inf)
+      output[out_col * out_stride] =
+          static_cast<TO>(config.compute_std > 0 ? ::precise::sqrt(var) : var);
+      if (config.write_mean > 0) {
+        output_mean[out_col * out_stride] = static_cast<TO>(mean);
+      }
+    }
+  }
+}
+
+template [[host_name("welford_outer_simdgemm_float_float")]]
+kernel void welford_reduction_outer_simdgemm<float, float>(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint sg_id [[simdgroup_index_in_threadgroup]],
+    uint sg_lane [[thread_index_in_simdgroup]],
+    uint tg_x [[threadgroup_position_in_grid]]);
+
+template [[host_name("welford_outer_simdgemm_half_half")]]
+kernel void welford_reduction_outer_simdgemm<half, half>(
+    device const half* input [[buffer(0)]],
+    device half* output [[buffer(1)]],
+    device half* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint sg_id [[simdgroup_index_in_threadgroup]],
+    uint sg_lane [[thread_index_in_simdgroup]],
+    uint tg_x [[threadgroup_position_in_grid]]);
+
+template [[host_name("welford_outer_simdgemm_half_float")]]
+kernel void welford_reduction_outer_simdgemm<half, float>(
+    device const half* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint sg_id [[simdgroup_index_in_threadgroup]],
+    uint sg_lane [[thread_index_in_simdgroup]],
+    uint tg_x [[threadgroup_position_in_grid]]);
+
+template [[host_name("welford_outer_simdgemm_bfloat_bfloat")]]
+kernel void welford_reduction_outer_simdgemm<bfloat, bfloat>(
+    device const bfloat* input [[buffer(0)]],
+    device bfloat* output [[buffer(1)]],
+    device bfloat* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint sg_id [[simdgroup_index_in_threadgroup]],
+    uint sg_lane [[thread_index_in_simdgroup]],
+    uint tg_x [[threadgroup_position_in_grid]]);
+
+template [[host_name("welford_outer_simdgemm_bfloat_float")]]
+kernel void welford_reduction_outer_simdgemm<bfloat, float>(
+    device const bfloat* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* output_mean [[buffer(2)]],
+    constant uint3& sizes [[buffer(3)]],
+    constant WelfordConfig& config [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint sg_id [[simdgroup_index_in_threadgroup]],
+    uint sg_lane [[thread_index_in_simdgroup]],
+    uint tg_x [[threadgroup_position_in_grid]]);
+

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -37,6 +37,11 @@
 #include <ATen/ops/trace_native.h>
 #include <ATen/ops/var_mean_native.h>
 #include <ATen/ops/var_native.h>
+#include <ATen/ops/complex.h>
+#include <ATen/ops/imag.h>
+#include <ATen/ops/mean.h>
+#include <ATen/ops/real.h>
+#include <ATen/ops/var.h>
 #endif
 
 namespace at::native {
@@ -312,175 +317,651 @@ static void norm_kernel_mps(TensorIterator& iter, const Scalar& p_scalar) {
   });
 }
 
+// ============================================================================
+// Metal kernel dispatch helpers for prod, welford, argreduce
+// ============================================================================
+
+struct WelfordConfig {
+  float correction;
+  float compute_std;
+  float write_mean;
+};
+
+static std::vector<int64_t> get_reduce_dims(const Tensor& input, OptionalIntArrayRef opt_dim) {
+  std::vector<int64_t> dims;
+  if (opt_dim.has_value() && !opt_dim.value().empty()) {
+    for (auto d : opt_dim.value()) {
+      dims.push_back(maybe_wrap_dim(d, input.dim()));
+    }
+  } else {
+    for (int64_t d = 0; d < input.dim(); d++) {
+      dims.push_back(d);
+    }
+  }
+  return dims;
+}
+
+static NormParams<> build_reduce_params(const Tensor& input,
+                                        const std::vector<int64_t>& reduce_dims,
+                                        const Tensor& output,
+                                        bool keepdim) {
+  NormParams params;
+  params.ndim = input.dim();
+  params.p = 0;
+  params.reduction_size = input.numel() / std::max<int64_t>(output.numel(), 1);
+
+  bool is_reduced[c10::metal::max_ndim] = {};
+  for (auto d : reduce_dims)
+    is_reduced[d] = true;
+
+  if (keepdim || output.dim() == input.dim()) {
+    for (uint32_t d = 0; d < params.ndim; d++) {
+      params.input_sizes[d] = input.size(d);
+      params.input_strides[d] = input.stride(d);
+      params.output_sizes[d] = output.size(d);
+      params.output_strides[d] = output.stride(d);
+    }
+  } else {
+    uint32_t out_d = 0;
+    for (uint32_t d = 0; d < params.ndim; d++) {
+      params.input_sizes[d] = input.size(d);
+      params.input_strides[d] = input.stride(d);
+      if (is_reduced[d]) {
+        params.output_sizes[d] = 1;
+        params.output_strides[d] = 0;
+      } else {
+        params.output_sizes[d] = output.size(out_d);
+        params.output_strides[d] = output.stride(out_d);
+        out_d++;
+      }
+    }
+  }
+
+  return params;
+}
+
+static void prod_kernel_mps(const Tensor& input,
+                            const std::vector<int64_t>& reduce_dims,
+                            bool keepdim,
+                            const Tensor& output) {
+  // Complex prod requires complex multiplication semantics not available in
+  // the generic float2 SIMD kernels; fall back to MPSGraph.
+  if (c10::isComplexType(input.scalar_type())) {
+    reduction_out_mps(input, reduce_dims, keepdim, std::nullopt, output, MPSReductionType::PROD, "prod_kernel_mps");
+    return;
+  }
+  // bool output: Metal simd_product doesn't support bool; use long accumulator
+  // and cast to bool at the end.
+  if (output.scalar_type() == kBool) {
+    auto long_output = at::empty_like(output, output.options().dtype(kLong));
+    prod_kernel_mps(input, reduce_dims, keepdim, long_output);
+    output.copy_(long_output.to(kBool));
+    return;
+  }
+  if (input.numel() == 0) {
+    output.fill_(1);
+    return;
+  }
+  if (output.numel() == 0)
+    return;
+
+  uint32_t reduction_size = input.numel() / output.numel();
+  auto type_str = scalarToMetalTypeString(input);
+  auto out_str = scalarToMetalTypeString(output);
+
+  MPSStream* stream = getCurrentMPSStream();
+
+  // 2-pass all-reduce: same idea as the welford 2-pass — reshape input to
+  // [num_groups, elems_per_group], reduce dim=1 to per-group partials, then
+  // reduce partials to scalar. Reuses the existing prod_reduction kernel both
+  // passes. Bypasses is_outer's M=1 single-TG-per-output degenerate dispatch.
+  if (output.numel() == 1 && input.is_contiguous() && input.numel() > MAX_THREADGROUP_SIZE * 4) {
+    uint32_t total_N = static_cast<uint32_t>(input.numel());
+    uint32_t num_groups = std::min(512u, c10::metal::ceil_div(total_N, MAX_THREADGROUP_SIZE * 4u));
+    while (num_groups > 1 && total_N % num_groups != 0) {
+      num_groups--;
+    }
+    uint32_t elems_per_group = total_N / num_groups;
+
+    auto partials = at::empty({static_cast<int64_t>(num_groups)}, output.options());
+    auto kernel = fmt::format("prod_reduction_{}_{}", type_str, out_str);
+
+    // Pass 1: input[num_groups, elems_per_group] -> partials[num_groups], reduce dim=1.
+    NormParams<> params1{};
+    params1.reduction_size = elems_per_group;
+    params1.ndim = 2;
+    params1.input_sizes[0] = num_groups;
+    params1.input_strides[0] = elems_per_group;
+    params1.output_sizes[0] = num_groups;
+    params1.output_strides[0] = 1;
+    params1.input_sizes[1] = elems_per_group;
+    params1.input_strides[1] = 1;
+
+    // Pass 2: partials[num_groups] -> output[1], reduce dim=0.
+    NormParams<> params2{};
+    params2.reduction_size = num_groups;
+    params2.ndim = 1;
+    params2.input_sizes[0] = num_groups;
+    params2.input_strides[0] = 1;
+    params2.output_sizes[0] = 1;
+    params2.output_strides[0] = 0;
+
+    auto p2_kernel = fmt::format("prod_reduction_{}_{}", out_str, out_str);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps1 = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps1, "prod_reduction_pass1", {input});
+        [enc setComputePipelineState:ps1];
+        mtl_setArgs(enc, input, partials, params1);
+        auto tpg1 = std::min(MAX_THREADGROUP_SIZE, elems_per_group);
+        [enc dispatchThreads:MTLSizeMake(num_groups * tpg1, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg1, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps1);
+
+        auto ps2 = lib.getPipelineStateForFunc(p2_kernel);
+        getMPSProfiler().beginProfileKernel(ps2, "prod_reduction_pass2", {partials});
+        [enc setComputePipelineState:ps2];
+        mtl_setArgs(enc, partials, output, params2);
+        auto tpg2 = std::min(MAX_THREADGROUP_SIZE, num_groups);
+        [enc dispatchThreads:MTLSizeMake(tpg2, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg2, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps2);
+      }
+    });
+    return;
+  }
+
+  bool is_single = reduce_dims.size() == 1 && output.numel() != 1;
+  bool is_outer = is_single && reduce_dims[0] == 0 && input.is_contiguous() && output.is_contiguous();
+  bool is_inner = is_single && reduce_dims[0] == input.dim() - 1 && input.is_contiguous() && output.is_contiguous();
+
+  if (is_outer) {
+    uint32_t M = input.size(0);
+    uint32_t N = input.numel() / M;
+    uint32_t TG_X, TG_Y;
+    std::string kernel;
+    bool small_m_supported =
+        input.scalar_type() == at::kFloat || input.scalar_type() == at::kHalf || input.scalar_type() == at::kBFloat16;
+    if (small_m_supported && M <= 16) {
+      // Grid-stride small-M path (COLS=2 columns/thread): no barrier tree, and a
+      // bounded threadgroup count for large N. Wins over the generic outer
+      // kernel and one-thread-per-column for tiny M.
+      constexpr uint32_t COLS = 2, TG = 256;
+      auto sm_kernel = fmt::format("prod_reduction_outer_smallm_{}_{}", type_str, out_str);
+      const uint32_t gthreads = c10::metal::ceil_div(N, COLS * TG) * TG;
+      dispatch_sync_with_rethrow(stream->queue(), ^() {
+        @autoreleasepool {
+          id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+          auto ps = lib.getPipelineStateForFunc(sm_kernel);
+          getMPSProfiler().beginProfileKernel(ps, "prod_reduction_outer_smallm", {input});
+          [enc setComputePipelineState:ps];
+          struct {
+            uint32_t M, N, out_stride;
+          } sizes_s = {M, N, 1};
+          mtl_setArgs(enc, input, output, sizes_s);
+          [enc dispatchThreads:MTLSizeMake(gthreads, 1, 1) threadsPerThreadgroup:MTLSizeMake(TG, 1, 1)];
+          getMPSProfiler().endProfileKernel(ps);
+        }
+      });
+      return;
+    }
+    // M > 16: generic 2D outer kernel (TG_X x TG_Y row-workers + tree reduce).
+    TG_X = 32;
+    TG_Y = 32;
+    kernel = fmt::format("prod_reduction_outer_{}_{}", type_str, out_str);
+    auto num_tg_x = c10::metal::ceil_div(N, TG_X);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps, "prod_reduction_outer", {input});
+        [enc setComputePipelineState:ps];
+        struct {
+          uint32_t M, N, out_stride;
+        } sizes_s = {M, N, 1};
+        mtl_setArgs(enc, input, output, sizes_s);
+        [enc dispatchThreads:MTLSizeMake(num_tg_x * TG_X, TG_Y, 1) threadsPerThreadgroup:MTLSizeMake(TG_X, TG_Y, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
+  if (is_inner) {
+    uint32_t N = input.size(input.dim() - 1);
+    uint32_t M = input.numel() / N;
+    auto kernel = fmt::format("prod_reduction_inner_{}_{}", type_str, out_str);
+    // One SIMD group per row; pack rows_per_tg rows per TG. For short rows, use
+    // a larger TG (more rows/TG) so each launch does more work — fewer tiny TGs.
+    const uint32_t tg_size = (N <= 512) ? 1024u : 256u;
+    const uint32_t rows_per_tg = tg_size / 32;
+    const uint32_t num_tgs = c10::metal::ceil_div(M, rows_per_tg);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps, "prod_reduction_inner", {input});
+        [enc setComputePipelineState:ps];
+        struct {
+          uint32_t M, N;
+        } sizes_s = {M, N};
+        mtl_setArgs(enc, input, output, sizes_s);
+        [enc dispatchThreads:MTLSizeMake(num_tgs * tg_size, 1, 1) threadsPerThreadgroup:MTLSizeMake(tg_size, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
+  auto kernel = fmt::format("prod_reduction_{}_{}", type_str, out_str);
+  auto params = build_reduce_params(input, reduce_dims, output, keepdim);
+
+  auto threads_per_group = std::min(MAX_THREADGROUP_SIZE, c10::metal::ceil_div(reduction_size, 32u) * 32u);
+  uint32_t num_threads = output.numel() * threads_per_group;
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+      auto ps = lib.getPipelineStateForFunc(kernel);
+      getMPSProfiler().beginProfileKernel(ps, "prod_reduction", {input});
+      [enc setComputePipelineState:ps];
+      mtl_setArgs(enc, input, output, params);
+      [enc dispatchThreads:MTLSizeMake(num_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps);
+    }
+  });
+}
+
+static void welford_kernel_mps(const Tensor& input,
+                               const std::vector<int64_t>& reduce_dims,
+                               bool keepdim,
+                               double correction_value,
+                               bool compute_std,
+                               const Tensor& output,
+                               const Tensor* output_mean = nullptr) {
+  if (input.numel() == 0 || output.numel() == 0)
+    return;
+
+  auto in_str = scalarToMetalTypeString(input);
+  auto out_str = scalarToMetalTypeString(output);
+  uint32_t reduction_size = input.numel() / output.numel();
+
+  WelfordConfig config;
+  config.correction = static_cast<float>(correction_value);
+  config.compute_std = compute_std ? 1.0f : 0.0f;
+  config.write_mean = output_mean ? 1.0f : 0.0f;
+
+  Tensor mean_placeholder;
+  const Tensor& mean_tensor = output_mean ? *output_mean : (mean_placeholder = at::empty({1}, output.options()));
+
+  MPSStream* stream = getCurrentMPSStream();
+
+  // 2-pass for all-reduce (single-output) when N is large enough to give
+  // multiple TGs useful work. Single-pass welford is bottlenecked by the
+  // 1024-thread single-TG limit for any-shape reduce.
+  if (output.numel() == 1 && input.is_contiguous() && input.numel() > MAX_THREADGROUP_SIZE * 4) {
+    uint32_t total_N = static_cast<uint32_t>(input.numel());
+    uint32_t num_groups = std::min(512u, c10::metal::ceil_div(total_N, MAX_THREADGROUP_SIZE * 8u));
+    while (num_groups > 1 && total_N % num_groups != 0) {
+      num_groups--;
+    }
+    uint32_t elems_per_group = total_N / num_groups;
+
+    auto partials = at::empty({static_cast<int64_t>(num_groups) * 3}, input.options().dtype(at::kFloat));
+
+    auto kernel_p1 = fmt::format("welford_pass1_{}", in_str);
+    auto kernel_p2 = fmt::format("welford_pass2_{}", out_str);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+
+        auto ps1 = lib.getPipelineStateForFunc(kernel_p1);
+        getMPSProfiler().beginProfileKernel(ps1, "welford_reduction_pass1", {input});
+        [enc setComputePipelineState:ps1];
+        struct {
+          uint32_t elems_per_group, total_N;
+        } sizes_p1 = {elems_per_group, total_N};
+        mtl_setArgs(enc, input, partials, sizes_p1);
+        auto tpg1 = std::min(MAX_THREADGROUP_SIZE, elems_per_group);
+        [enc dispatchThreads:MTLSizeMake(num_groups * tpg1, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg1, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps1);
+
+        auto ps2 = lib.getPipelineStateForFunc(kernel_p2);
+        getMPSProfiler().beginProfileKernel(ps2, "welford_reduction_pass2", {partials});
+        [enc setComputePipelineState:ps2];
+        mtl_setArgs(enc, partials, output, mean_tensor, num_groups, config);
+        auto tpg2 = std::min(MAX_THREADGROUP_SIZE, num_groups);
+        [enc dispatchThreads:MTLSizeMake(tpg2, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg2, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps2);
+      }
+    });
+    return;
+  }
+
+  // is_outer / is_inner are designed for shapes where one of M/N is large.
+  // For output.numel() == 1 (all-reduce) either pass goes through the 2-pass
+  // block above; if 2-pass didn't fire (N below its threshold), fall through
+  // to the generic kernel which uses up to 1024 threads in one TG.
+  bool is_single = reduce_dims.size() == 1 && output.numel() != 1;
+  bool is_outer = is_single && reduce_dims[0] == 0 && input.is_contiguous() && output.is_contiguous();
+  bool is_inner = is_single && reduce_dims[0] == input.dim() - 1 && input.is_contiguous() && output.is_contiguous();
+
+  if (is_outer) {
+    uint32_t M = input.size(0);
+    uint32_t N = input.numel() / M;
+    uint32_t TG_X, TG_Y;
+    std::string kernel;
+    // Apple-tensor-core path: M ∈ {8, 16}, N % 8 == 0, N >= 256. Each TG
+    // covers 256 cols (4 simdgroups × 8 chunks × 8 cols/chunk) so TG count
+    // stays proportional to N/256, not N/32. Avoids the TG-overhead trap
+    // that hits if the kernel only covers 32 cols/TG.
+    bool simdgemm_ok = M >= 8 && M <= 16 && (M % 8 == 0) && (N % 8 == 0) && N >= 256 && input.is_contiguous();
+    if (simdgemm_ok) {
+      TG_X = 128;
+      TG_Y = 1;
+      kernel = fmt::format("welford_outer_simdgemm_{}_{}", in_str, out_str);
+    } else if (M <= 8) {
+      TG_X = 128;
+      TG_Y = 8;
+      kernel = fmt::format("welford_outer_8_{}_{}", in_str, out_str);
+    } else if (M <= 16) {
+      TG_X = 64;
+      TG_Y = 16;
+      kernel = fmt::format("welford_outer_16_{}_{}", in_str, out_str);
+    } else {
+      TG_X = 32;
+      TG_Y = 32;
+      kernel = fmt::format("welford_outer_{}_{}", in_str, out_str);
+    }
+    auto num_tg_x = simdgemm_ok ? c10::metal::ceil_div(N, 512u) : c10::metal::ceil_div(N, TG_X);
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps, "welford_outer", {input});
+        [enc setComputePipelineState:ps];
+        struct {
+          uint32_t M, N, out_stride;
+        } sizes_s = {M, N, 1};
+        mtl_setArgs(enc, input, output, mean_tensor, sizes_s, config);
+        [enc dispatchThreads:MTLSizeMake(num_tg_x * TG_X, TG_Y, 1) threadsPerThreadgroup:MTLSizeMake(TG_X, TG_Y, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
+  if (is_inner) {
+    uint32_t N = input.size(input.dim() - 1);
+    uint32_t M = input.numel() / N;
+    // Many short rows -> one SIMD group per row (8 rows/TG). Few/huge rows
+    // (small M, large N) -> the "wide" kernel (one whole TG per row, up to 1024
+    // threads): 32 lanes on a giant row is both slow and loses precision from a
+    // deep per-lane streaming Welford (e.g. GroupNorm's M=2, N~19M).
+    bool use_simd_per_row = (M >= 64 && N <= 16384);
+    uint32_t tg_size, num_tgs;
+    std::string kernel;
+    if (use_simd_per_row) {
+      kernel = fmt::format("welford_inner_{}_{}", in_str, out_str);
+      tg_size = 256;  // 8 SIMD groups = 8 rows per TG
+      num_tgs = c10::metal::ceil_div(M, tg_size / 32);
+    } else {
+      kernel = fmt::format("welford_inner_wide_{}_{}", in_str, out_str);
+      tg_size = std::min(1024u, c10::metal::ceil_div(N, 32u) * 32u);
+      if (N >= 2048) {
+        tg_size = c10::metal::ceil_div(N / (4u * 16u), 32u) * 32u;
+        tg_size = std::clamp(tg_size, 32u, 1024u);
+      }
+      num_tgs = M;  // one TG per row
+    }
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(kernel);
+        getMPSProfiler().beginProfileKernel(ps, "welford_inner", {input});
+        [enc setComputePipelineState:ps];
+        struct {
+          uint32_t M, N;
+        } sizes_s = {M, N};
+        mtl_setArgs(enc, input, output, mean_tensor, sizes_s, config);
+        [enc dispatchThreads:MTLSizeMake(num_tgs * tg_size, 1, 1) threadsPerThreadgroup:MTLSizeMake(tg_size, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
+  auto kernel = fmt::format("welford_{}_{}", in_str, out_str);
+  auto params = build_reduce_params(input, reduce_dims, output, keepdim);
+
+  auto threads_per_group = std::min(MAX_THREADGROUP_SIZE, c10::metal::ceil_div(reduction_size, 32u) * 32u);
+  uint32_t num_threads = output.numel() * threads_per_group;
+
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+      auto ps = lib.getPipelineStateForFunc(kernel);
+      getMPSProfiler().beginProfileKernel(ps, "welford_reduction", {input});
+      [enc setComputePipelineState:ps];
+      mtl_setArgs(enc, input, output, mean_tensor, params, config);
+      [enc dispatchThreads:MTLSizeMake(num_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps);
+    }
+  });
+}
+
+static void argreduce_kernel_mps(const Tensor& input,
+                                 const std::vector<int64_t>& reduce_dims,
+                                 bool keepdim,
+                                 bool is_max,
+                                 const Tensor& output_indices,
+                                 const Tensor* output_values = nullptr) {
+  if (output_indices.numel() == 0)
+    return;
+
+  auto in_str = scalarToMetalTypeString(input);
+  auto kernel_name = fmt::format("{}_{}", is_max ? "argmax" : "argmin", in_str);
+
+  uint32_t reduction_size = input.numel() / std::max<int64_t>(output_indices.numel(), 1);
+  auto params = build_reduce_params(input, reduce_dims, output_indices, keepdim);
+
+  uint8_t write_values = output_values ? 1 : 0;
+
+  Tensor values_placeholder;
+  const Tensor& values_tensor = output_values ? *output_values : (values_placeholder = at::empty({1}, input.options()));
+
+  // All-reduce fast path: a single threadgroup scanning the whole input does not
+  // parallelize across the GPU. Fused 2-pass (pass1 reduces contiguous chunks to
+  // per-group (index, value) in parallel; pass2 picks the winning group) — only
+  // two dispatches, beating both the single-TG kernel and a reshape/gather chain.
+  if (output_indices.numel() == 1 && input.is_contiguous() && input.numel() >= (1 << 14)) {
+    uint32_t total = static_cast<uint32_t>(input.numel());
+    // Finer chunks for small inputs (more parallel TGs); keep the large-input
+    // tuning (~8K elems/group) where memory throughput already saturates.
+    uint32_t floor_epg = (total < (1u << 18)) ? 1024u : (uint32_t)MAX_THREADGROUP_SIZE * 8u;
+    uint32_t num_groups = std::min(512u, c10::metal::ceil_div(total, floor_epg));
+    while (num_groups > 1 && total % num_groups != 0) {
+      num_groups--;
+    }
+    if (num_groups > 1) {
+      uint32_t epg = total / num_groups;
+      auto partials_val = at::empty({num_groups}, input.options());
+      auto partials_idx = at::empty({num_groups}, input.options().dtype(c10::kLong));
+      auto k1 = fmt::format("{}_pass1_{}", is_max ? "argmax" : "argmin", in_str);
+      auto k2 = fmt::format("{}_pass2_{}", is_max ? "argmax" : "argmin", in_str);
+      MPSStream* ar_stream = getCurrentMPSStream();
+      dispatch_sync_with_rethrow(ar_stream->queue(), ^() {
+        @autoreleasepool {
+          id<MTLComputeCommandEncoder> enc = ar_stream->commandEncoder();
+          auto ps1 = lib.getPipelineStateForFunc(k1);
+          getMPSProfiler().beginProfileKernel(ps1, is_max ? "argmax_pass1" : "argmin_pass1", {input});
+          [enc setComputePipelineState:ps1];
+          struct {
+            uint32_t epg, total;
+          } s1 = {epg, total};
+          mtl_setArgs(enc, input, partials_val, partials_idx, s1);
+          uint32_t tpg1 = std::min<uint32_t>(MAX_THREADGROUP_SIZE, epg);
+          [enc dispatchThreads:MTLSizeMake(num_groups * tpg1, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg1, 1, 1)];
+          getMPSProfiler().endProfileKernel(ps1);
+
+          auto ps2 = lib.getPipelineStateForFunc(k2);
+          getMPSProfiler().beginProfileKernel(ps2, is_max ? "argmax_pass2" : "argmin_pass2", {input});
+          [enc setComputePipelineState:ps2];
+          uint32_t np = num_groups;
+          mtl_setArgs(enc, partials_val, partials_idx, output_indices, values_tensor, np, write_values);
+          uint32_t tpg2 = std::min<uint32_t>(MAX_THREADGROUP_SIZE, num_groups);
+          [enc dispatchThreads:MTLSizeMake(tpg2, 1, 1) threadsPerThreadgroup:MTLSizeMake(tpg2, 1, 1)];
+          getMPSProfiler().endProfileKernel(ps2);
+        }
+      });
+      return;
+    }
+  }
+
+  // Fast path: reducing the contiguous innermost dim with many rows. One SIMD
+  // group reduces one row, 8 rows per TG (mirrors sum/welford _inner) instead
+  // of one whole threadgroup per row, which over-subscribes the GPU and idles
+  // most threads for short rows.
+  bool is_inner = reduce_dims.size() == 1 && reduce_dims[0] == input.dim() - 1 &&
+      input.is_contiguous() && output_indices.is_contiguous();
+  uint32_t inner_N = is_inner ? (uint32_t)input.size(input.dim() - 1) : 0;
+  uint32_t inner_M = is_inner ? (uint32_t)(input.numel() / std::max<int64_t>(inner_N, 1)) : 0;
+  // The inner kernel assigns one SIMD group (32 lanes) per row, so it only wins
+  // when there are many rows to fill the GPU and each row is short enough for 32
+  // lanes. For few rows / huge rows (e.g. a 1D all-reduce: M=1, N=numel) a single
+  // SIMD group would serialize the whole reduction; fall through to the generic
+  // kernel, which spreads one row across a full threadgroup.
+  if (is_inner && inner_M >= 64 && inner_N <= 16384) {
+    uint32_t N = inner_N;
+    uint32_t M = inner_M;
+    auto inner_kernel = fmt::format("{}_inner_{}", is_max ? "argmax" : "argmin", in_str);
+    constexpr uint32_t TG = 256, rows_per_tg = TG / 32;
+    const uint32_t num_tgs = c10::metal::ceil_div(M, rows_per_tg);
+    MPSStream* inner_stream = getCurrentMPSStream();
+    dispatch_sync_with_rethrow(inner_stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = inner_stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(inner_kernel);
+        getMPSProfiler().beginProfileKernel(ps, is_max ? "argmax_inner" : "argmin_inner", {input});
+        [enc setComputePipelineState:ps];
+        struct {
+          uint32_t M, N;
+        } sizes_s = {M, N};
+        mtl_setArgs(enc, input, output_indices, values_tensor, sizes_s, write_values);
+        [enc dispatchThreads:MTLSizeMake(num_tgs * TG, 1, 1) threadsPerThreadgroup:MTLSizeMake(TG, 1, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
+  // Fast path: reducing the outermost dim (dim 0) of a contiguous tensor. 2D TG
+  // (columns x row-workers) with coalesced reads + a per-column tree reduction,
+  // instead of one TG per output column with strided reads.
+  bool is_outer = reduce_dims.size() == 1 && reduce_dims[0] == 0 && input.dim() >= 2 &&
+      input.is_contiguous() && output_indices.is_contiguous();
+  if (is_outer) {
+    uint32_t M = input.size(0);
+    uint32_t N = input.numel() / M;
+    auto outer_kernel = fmt::format("{}_outer_{}", is_max ? "argmax" : "argmin", in_str);
+    constexpr uint32_t TG_X = 32, TG_Y = 32;
+    const uint32_t num_tg_x = c10::metal::ceil_div(N, TG_X);
+    MPSStream* outer_stream = getCurrentMPSStream();
+    dispatch_sync_with_rethrow(outer_stream->queue(), ^() {
+      @autoreleasepool {
+        id<MTLComputeCommandEncoder> enc = outer_stream->commandEncoder();
+        auto ps = lib.getPipelineStateForFunc(outer_kernel);
+        getMPSProfiler().beginProfileKernel(ps, is_max ? "argmax_outer" : "argmin_outer", {input});
+        [enc setComputePipelineState:ps];
+        struct {
+          uint32_t M, N;
+        } sizes_s = {M, N};
+        mtl_setArgs(enc, input, output_indices, values_tensor, sizes_s, write_values);
+        [enc dispatchThreads:MTLSizeMake(num_tg_x * TG_X, TG_Y, 1) threadsPerThreadgroup:MTLSizeMake(TG_X, TG_Y, 1)];
+        getMPSProfiler().endProfileKernel(ps);
+      }
+    });
+    return;
+  }
+
+  uint32_t threads_per_group;
+  if (reduction_size >= 512) {
+    threads_per_group = c10::metal::ceil_div(reduction_size / 16u, 32u) * 32u;
+    threads_per_group = std::clamp(threads_per_group, 32u, (uint32_t)MAX_THREADGROUP_SIZE);
+  } else {
+    threads_per_group = std::min(MAX_THREADGROUP_SIZE, c10::metal::ceil_div(reduction_size, 32u) * 32u);
+  }
+  uint32_t num_threads = output_indices.numel() * threads_per_group;
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+      auto ps = lib.getPipelineStateForFunc(kernel_name);
+      getMPSProfiler().beginProfileKernel(ps, is_max ? "argmax" : "argmin", {input});
+      [enc setComputePipelineState:ps];
+      mtl_setArgs(enc, input, output_indices, values_tensor, params, write_values);
+      [enc dispatchThreads:MTLSizeMake(num_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      getMPSProfiler().endProfileKernel(ps);
+    }
+  });
+}
 static Tensor std_var_common_impl_mps(const Tensor& input_t,
                                       at::OptionalIntArrayRef dim,
                                       const std::optional<Scalar>& correction,
                                       bool keepdim,
                                       StdVarType stdVarType) {
   TORCH_CHECK_NOT_IMPLEMENTED(input_t.scalar_type() != kLong, "Not implemented for MPS");
-  using CachedGraph = MPSUnaryCachedGraph;
 
-  IntArrayRef input_shape = input_t.sizes();
-  int64_t num_input_dims = input_shape.size();
-
-  bool use_dim = dim.has_value();
-  IntArrayRef dim_value = use_dim ? dim.value() : NULL;
-
-  if (use_dim) {
-    std::string errMessage = (stdVarType == STANDARD_DEVIATION) ? "std_mps" : "var_mps";
-    errMessage += ": reduction dim must be in the range of input shape";
-    for (const auto dim : dim_value) {
-      auto wrap_dim = maybe_wrap_dim(dim, num_input_dims);
-      TORCH_CHECK(wrap_dim < (num_input_dims ? num_input_dims : 1), errMessage.c_str())
-    }
+  if (input_t.dim() == 0) {
+    auto input_1d = input_t.unsqueeze(0);
+    auto result = std_var_common_impl_mps(input_1d, IntArrayRef({0}), correction, false, stdVarType);
+    return result.squeeze();
   }
 
-  bool use_correction = !(correction.has_value() && correction.value().toDouble() == 0);
+  TORCH_CHECK(c10::isFloatingType(input_t.scalar_type()) || c10::isComplexType(input_t.scalar_type()),
+              "std and var only support floating point and complex dtypes");
+  if (c10::isComplexType(input_t.scalar_type())) {
+    // Var(complex) = Var(real) + Var(imag) (same correction); std = sqrt.
+    // Output is real-valued. Routes through the real welford kernels (no
+    // complex Metal kernel), matching CPU/MPSGraph semantics.
+    auto v = at::var(at::real(input_t).contiguous(), dim, correction, keepdim)
+                 .add(at::var(at::imag(input_t).contiguous(), dim, correction, keepdim));
+    return (stdVarType == STANDARD_DEVIATION) ? v.sqrt() : v;
+  }
+
+  auto reduce_dims = get_reduce_dims(input_t, dim);
   const auto correction_value = correction.value_or(1.0).toDouble();
-  int64_t correction_n = 1;
 
-  NSArray<NSNumber*>* wrappedAxes = getTensorAxes(input_t.sizes(), dim);
-
-  int64_t num_output_dims = 0;
-  NSMutableArray<NSNumber*>* axes = nil;
-  NSMutableArray<NSNumber*>* apparent_output_shape = nil;
-  NSMutableArray<NSNumber*>* apparent_input_shape = nil;
   std::vector<int64_t> output_shape;
-
-  if ((!keepdim && !use_dim) || (!keepdim && use_dim && dim_value.size() <= 0)) {
-    // Flatten the input tensor to reduce it to one value
-    apparent_input_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    int64_t num_in_elements = c10::multiply_integers(input_shape);
-    apparent_input_shape[0] = [NSNumber numberWithInt:num_in_elements];
-
-    // Output is a single value
-    apparent_output_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    apparent_output_shape[0] = @1;
-
-    num_output_dims = 0;
-
-    correction_n = num_in_elements;
-
-    // Reduction axes
-    axes = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    axes[0] = @0;
-  } else if (!keepdim && use_dim && !dim_value.empty()) {
-    int64_t num_reduce_dims = dim_value.size();
-    num_output_dims = num_input_dims;
-
-    set_axes(axes, num_reduce_dims, dim_value, num_input_dims);
-    set_apparent_shapes(
-        apparent_output_shape, apparent_input_shape, num_reduce_dims, num_output_dims, input_shape, axes);
-
-    num_output_dims = (num_input_dims >= num_reduce_dims) ? (num_input_dims - num_reduce_dims) : 0; // num_input_dims;
-
-    unsigned int curr_i = 0;
-    for (const auto i : c10::irange(num_input_dims)) {
-      bool found = false;
-      for (const auto j : c10::irange(num_reduce_dims)) {
-        if (i == maybe_wrap_dim(dim_value[j], num_input_dims)) {
-          found = true;
-          break;
-        }
-      }
-      if (found) {
-        continue;
-      }
-      output_shape.push_back(input_shape[i]);
-      curr_i += 1;
-      // End loop when output shape is filled
-      if (curr_i == num_output_dims) {
+  for (int64_t d = 0; d < input_t.dim(); d++) {
+    bool reduced = false;
+    for (auto rd : reduce_dims) {
+      if (rd == d) {
+        reduced = true;
         break;
       }
     }
-
-    for (const auto dim : dim_value) {
-      auto wrap_dim = maybe_wrap_dim(dim, input_shape.size());
-      correction_n *= input_shape[wrap_dim];
-    }
-    // (3, 4, 5) --> (3, 5)
-  } else if ((keepdim && !use_dim) || (keepdim && use_dim && dim_value.empty())) {
-    num_output_dims = 0;
-    int64_t num_reduce_dims = 0;
-    set_axes(axes, num_reduce_dims, dim_value, input_shape.size());
-    set_apparent_shapes(
-        apparent_output_shape, apparent_input_shape, num_reduce_dims, num_output_dims, input_shape, axes);
-    num_output_dims = num_input_dims;
-    for (const auto i : c10::irange(num_input_dims)) {
-      output_shape.push_back((int64_t)1);
-      correction_n *= input_shape[i];
-    }
-    // scalar --> vector case [[1.0034567]]
-  } else if (keepdim && use_dim && !dim_value.empty()) {
-    int64_t num_reduce_dims = dim_value.size();
-    num_output_dims = num_input_dims;
-
-    set_axes(axes, num_reduce_dims, dim_value, num_input_dims);
-    set_apparent_shapes(
-        apparent_output_shape, apparent_input_shape, num_reduce_dims, num_output_dims, input_shape, axes);
-
-    num_output_dims = num_input_dims; //(num_input_dims >= num_reduce_dims) ? (num_input_dims - num_reduce_dims) : 0;
-
-    for (const int i : c10::irange(num_reduce_dims)) {
-      auto wrap_dim = maybe_wrap_dim(dim_value[i], input_shape.size());
-      correction_n *= input_shape[wrap_dim];
-    }
-
-    for (const int i : c10::irange(num_input_dims)) {
-      output_shape.push_back([apparent_output_shape[i] longValue]);
+    if (reduced) {
+      if (keepdim)
+        output_shape.push_back(1);
+    } else {
+      output_shape.push_back(input_t.size(d));
     }
   }
 
-  Tensor output_t = at::empty(IntArrayRef(output_shape.data(), num_output_dims),
-                              input_t.scalar_type(),
-                              std::nullopt,
-                              kMPS,
-                              std::nullopt,
-                              std::nullopt);
+  Tensor output_t = at::empty(output_shape, input_t.scalar_type(), std::nullopt, kMPS, std::nullopt, std::nullopt);
 
   if (output_t.numel() == 0 || input_t.numel() == 0) {
     return output_t;
   }
 
-  double dof = std::max(0.0, correction_n - correction_value);
-  double bessel_correction = correction_n / dof;
-  auto stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string op_key = (stdVarType == STANDARD_DEVIATION) ? "std_mps" : "var_mps";
-    NSString* ns_key = [[wrappedAxes valueForKey:@"description"] componentsJoinedByString:@","];
-    std::string bessel_corrected = (use_correction && correction_value) ? "unbiased " : "biased ";
-    std::string use_dim_info = (use_dim) ? "use_dim=1:" + std::to_string(dim_value.size()) : "use_dim=0";
-    std::string keepdim_info = (keepdim) ? "keepdim=1" : "keepdim=0";
-    std::string key = op_key + ":" + getTensorsStringKey(input_t) + ":" + use_dim_info + ":" + keepdim_info + ":" +
-        std::string([ns_key UTF8String]) + ":" + bessel_corrected + ":" + std::to_string(correction_value);
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
-      MPSGraphTensor* outputVarTensor = [mpsGraph varianceOfTensor:inputTensor axes:wrappedAxes name:nil];
-      MPSGraphTensor* outputTensor = nil;
-
-      if (use_correction && correction_value) {
-        MPSGraphTensor* besselTensor = [mpsGraph constantWithScalar:bessel_correction dataType:getMPSDataType(input_t)];
-        MPSGraphTensor* correctedTensor = [mpsGraph multiplicationWithPrimaryTensor:outputVarTensor
-                                                                    secondaryTensor:besselTensor
-                                                                               name:nil];
-        outputTensor = (stdVarType == STANDARD_DEVIATION) ? [mpsGraph squareRootWithTensor:correctedTensor name:nil]
-                                                          : correctedTensor;
-      } else {
-        outputTensor = (stdVarType == STANDARD_DEVIATION) ? [mpsGraph squareRootWithTensor:outputVarTensor name:nil]
-                                                          : outputVarTensor;
-      }
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
-    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_output_shape);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
+  welford_kernel_mps(input_t, reduce_dims, keepdim, correction_value, stdVarType == STANDARD_DEVIATION, output_t);
 
   return output_t;
 }
@@ -561,8 +1042,6 @@ static Tensor median_common_mps(const Tensor& input_t, bool nanmedian) {
 }
 
 static Tensor min_max_mps_impl(const Tensor& input_t, MPSReductionType reduction_type, const std::string& func_name) {
-  using CachedGraph = MPSUnaryCachedGraph;
-
   IntArrayRef input_shape = input_t.sizes();
   int64_t num_in_elements = c10::multiply_integers(input_shape);
 
@@ -572,35 +1051,18 @@ static Tensor min_max_mps_impl(const Tensor& input_t, MPSReductionType reduction
     return output_t;
   }
 
-  @autoreleasepool {
-    std::string key = func_name + getTensorsStringKey(input_t);
-    CachedGraph* cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
+  bool is_max = (reduction_type == MPSReductionType::MAX);
+  Tensor indices_placeholder = at::empty({}, ScalarType::Long, std::nullopt, kMPS, std::nullopt, std::nullopt);
+  auto reduce_dims = get_reduce_dims(input_t, std::nullopt);
 
-      MPSGraphTensor* castOutputTensor = nil;
-      MPSGraphTensor* castInputTensor = castToIHFTypes(mpsGraph, inputTensor, input_t);
-
-      NSArray<NSNumber*>* axes = getTensorAxes(input_t);
-      if (reduction_type == MPSReductionType::MAX) {
-        castOutputTensor = [mpsGraph reductionMaximumPropagateNaNWithTensor:castInputTensor axes:axes name:nil];
-      } else if (reduction_type == MPSReductionType::MIN) {
-        castOutputTensor = [mpsGraph reductionMinimumPropagateNaNWithTensor:castInputTensor axes:axes name:nil];
-      }
-
-      MPSGraphTensor* outputTensor = castOutputTensor;
-      if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
-        outputTensor = castMPSTensor(mpsGraph, castOutputTensor, output_t.scalar_type());
-      }
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
-    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, @[ @1 ]);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder);
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outputPlaceholder);
+  Tensor input_for_kernel = input_t;
+  if (input_t.scalar_type() == kBool) {
+    input_for_kernel = input_t.to(kInt);
+    auto values_buf = at::empty({}, kInt, std::nullopt, kMPS, std::nullopt, std::nullopt);
+    argreduce_kernel_mps(input_for_kernel, reduce_dims, false, is_max, indices_placeholder, &values_buf);
+    output_t.copy_(values_buf.to(kBool));
+  } else {
+    argreduce_kernel_mps(input_for_kernel, reduce_dims, false, is_max, indices_placeholder, &output_t);
   }
 
   return output_t;
@@ -622,72 +1084,18 @@ static void min_max_out_mps(const Tensor& input_t,
     return;
   }
 
-  // Derive from MPSCachedGraph
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* inputTensor_ = nil;
-    MPSGraphTensor* outputTensor_ = nil;
-    MPSGraphTensor* indicesTensor_ = nil;
-  };
-
   int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
+  bool is_max = (reduction_type == MPSReductionType::MAX);
+  std::vector<int64_t> reduce_dims = {dim_};
 
-  // Calculate the output shape according to keepdim=True
-  // If there is no dim argument, the input shape is flattened
-  IntArrayRef input_shape = input_t.sizes();
-  int64_t num_input_dims = input_shape.size();
-  NSMutableArray<NSNumber*>* apparent_out_shape = nil;
-
-  apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-  for (const auto i : c10::irange(num_input_dims)) {
-    apparent_out_shape[i] = dim_ == i ? @1 : [NSNumber numberWithInt:input_shape[i]];
-  }
-
-  auto stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = func_name + getTensorsStringKey({input_t, indices_t}) + ":" + std::to_string(dim_);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
-      MPSGraphTensor* outputTensor = nil;
-      MPSGraphTensor* castInputTensor = castToIHFTypes(mpsGraph, inputTensor, input_t);
-
-      if (reduction_type == MPSReductionType::MAX) {
-        outputTensor = [mpsGraph reductionMaximumPropagateNaNWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
-      } else if (reduction_type == MPSReductionType::MIN) {
-        outputTensor = [mpsGraph reductionMinimumPropagateNaNWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
-      }
-
-      MPSGraphTensor* argreduceOutTensor = nil;
-      if (reduction_type == MPSReductionType::MAX)
-        argreduceOutTensor = [mpsGraph reductionArgMaximumWithTensor:castInputTensor
-                                                                axis:(NSInteger)dim_
-                                                                name:@"argmax_out"];
-      else if (reduction_type == MPSReductionType::MIN)
-        argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor:castInputTensor
-                                                                axis:(NSInteger)dim_
-                                                                name:@"argmax_out"];
-
-      MPSGraphTensor* indicesTensor = nil;
-      if ([argreduceOutTensor dataType] != MPSDataTypeInt64) {
-        indicesTensor = [mpsGraph castTensor:argreduceOutTensor toType:MPSDataTypeInt64 name:@"cast_out"];
-      }
-
-      if ([outputTensor dataType] != getMPSDataType(output_t)) {
-        outputTensor = castMPSTensor(mpsGraph, outputTensor, output_t.scalar_type());
-      }
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-      newCachedGraph->indicesTensor_ = indicesTensor;
-    });
-
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t);
-    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
-    auto indicesPlaceholder = Placeholder(cachedGraph->indicesTensor_, indices_t, apparent_out_shape);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder);
-    auto results = dictionaryFromPlaceholders(outputPlaceholder, indicesPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+  Tensor input_for_kernel = input_t;
+  if (input_t.scalar_type() == kBool) {
+    input_for_kernel = input_t.to(kInt);
+    auto values_buf = at::empty(output_t.sizes(), kInt, std::nullopt, kMPS, std::nullopt, std::nullopt);
+    argreduce_kernel_mps(input_for_kernel, reduce_dims, keepdim, is_max, indices_t, &values_buf);
+    output_t.copy_(values_buf.to(kBool));
+  } else {
+    argreduce_kernel_mps(input_for_kernel, reduce_dims, keepdim, is_max, indices_t, &output_t);
   }
 }
 
@@ -754,92 +1162,35 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
                                   const Tensor& output_t,
                                   MPSReductionType reduction_type,
                                   const std::string& func_name) {
-  using CachedGraph = MPSUnaryCachedGraph;
-
-  int64_t dim_ = -1;
+  bool is_max = (reduction_type == MPSReductionType::MAX);
 
   if (dim.has_value()) {
-    dim_ = maybe_wrap_dim(dim.value(), input_t.dim());
-    zero_numel_check_dims(input_t, dim_, reduction_type == MPSReductionType::MAX ? "argmax()" : "argmin()");
+    int64_t dim_ = maybe_wrap_dim(dim.value(), input_t.dim());
+    zero_numel_check_dims(input_t, dim_, is_max ? "argmax()" : "argmin()");
   } else {
     TORCH_CHECK_INDEX(input_t.numel() != 0,
-                      reduction_type == MPSReductionType::MAX ? "argmax()" : "argmin()",
+                      is_max ? "argmax()" : "argmin()",
                       ": Expected reduction dim to be specified for input.numel() == 0.");
-    // Since input will be flattened, take argmax or argmin along 0'th dimension
-    dim_ = 0;
   }
 
-  // Calculate the output shape according to keepdim=True
-  // If there is no dim argument, the input shape is flattened
-  IntArrayRef input_shape = input_t.sizes();
-  int64_t num_input_dims = input_shape.size();
-  NSMutableArray<NSNumber*>* apparent_in_shape = nil;
-  NSMutableArray<NSNumber*>* apparent_out_shape = nil;
-
-  if (dim.has_value()) {
-    apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-    for (const auto i : c10::irange(num_input_dims)) {
-      apparent_out_shape[i] = dim_ == i ? @1 : [NSNumber numberWithInt:input_shape[i]];
-    }
-  } else {
-    apparent_in_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    int64_t num_in_elements = c10::multiply_integers(input_shape);
-    apparent_in_shape[0] = [NSNumber numberWithInt:num_in_elements];
-
-    apparent_out_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:1];
-    apparent_out_shape[0] = @1;
-  }
-
-  if (output_t.numel() == 0) {
+  if (output_t.numel() == 0)
     return;
+
+  std::vector<int64_t> reduce_dims;
+  if (dim.has_value()) {
+    reduce_dims.push_back(maybe_wrap_dim(dim.value(), input_t.dim()));
+  } else {
+    for (int64_t d = 0; d < input_t.dim(); d++)
+      reduce_dims.push_back(d);
   }
 
-  if (!apparent_in_shape) {
-    apparent_in_shape = [getMPSShape(input_t.sizes()) mutableCopy];
+  Tensor input_for_kernel = input_t;
+  if (input_t.scalar_type() == kBool) {
+    input_for_kernel = input_t.to(kInt);
   }
 
-  @autoreleasepool {
-    NSString* ns_key = [[apparent_in_shape valueForKey:@"description"] componentsJoinedByString:@","];
-    std::string key = func_name + ":" + std::to_string(dim_) + ":" + getTensorsStringKey(input_t) + ":" +
-        std::string([ns_key UTF8String]);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      auto inputScalarType = input_t.scalar_type();
-      MPSGraphTensor* inputTensor =
-          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(inputScalarType), apparent_in_shape);
-      MPSGraphTensor* argreduceOutTensor = nil;
-
-      MPSGraphTensor* castInputTensor = inputTensor;
-      if (inputScalarType != kInt && inputScalarType != kHalf && inputScalarType != kFloat &&
-          inputScalarType != kLong) {
-        castInputTensor = castMPSTensor(mpsGraph, inputTensor, kFloat);
-      }
-      if (reduction_type == MPSReductionType::MAX) {
-        argreduceOutTensor = [mpsGraph reductionArgMaximumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
-      } else {
-        argreduceOutTensor = [mpsGraph reductionArgMinimumWithTensor:castInputTensor axis:(NSInteger)dim_ name:nil];
-      }
-
-      MPSGraphTensor* outputTensor = argreduceOutTensor;
-      if (getMPSDataType(output_t) != [argreduceOutTensor dataType]) {
-        outputTensor = castMPSTensor(mpsGraph, argreduceOutTensor, output_t.scalar_type());
-      }
-
-      MPSGraphTensor* outputClampedTensor =
-          [mpsGraph clampWithTensor:outputTensor
-                     minValueTensor:[mpsGraph constantWithScalar:0 dataType:MPSDataTypeInt64]
-                     maxValueTensor:[mpsGraph constantWithScalar:0x7FEFFFFFFFFFFFFF dataType:MPSDataTypeInt64]
-                               name:nil];
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputClampedTensor;
-    });
-
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input_t, apparent_in_shape);
-    auto outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output_t, apparent_out_shape);
-
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder);
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, outputPlaceholder);
-  }
+  // All-reduce is handled by the 2-pass inside argreduce_kernel_mps.
+  argreduce_kernel_mps(input_for_kernel, reduce_dims, keepdim, is_max, output_t);
 }
 
 // Unified host-side dispatch for value-preserving reductions on MPS, shared
@@ -1188,8 +1539,14 @@ Tensor trace_mps(const Tensor& self) {
 
 TORCH_IMPL_FUNC(prod_out_mps)
 (const Tensor& input_t, int64_t dim, bool keepdim, std::optional<ScalarType> dtype, const Tensor& output_t) {
-  int64_t dims[1] = {dim};
-  reduction_out_mps(input_t, IntArrayRef(dims, 1), keepdim, dtype, output_t, MPSReductionType::PROD, "prod_out_mps");
+  // 0-dim tensor: prod(scalar, dim=0) is a no-op reduction; return scalar.
+  if (input_t.dim() == 0) {
+    output_t.copy_(input_t);
+    return;
+  }
+  int64_t dim_ = maybe_wrap_dim(dim, input_t.dim());
+  std::vector<int64_t> reduce_dims = {dim_};
+  prod_kernel_mps(input_t, reduce_dims, keepdim, output_t);
 }
 
 static void aminmax_kernel_mps(const Tensor& self, int64_t dim, bool keepdim, Tensor& min, Tensor& max) {
@@ -1205,14 +1562,12 @@ static void aminmax_allreduce_kernel_mps(const Tensor& self, Tensor& min, Tensor
 }
 
 Tensor prod_mps(const Tensor& self, std::optional<ScalarType> opt_dtype) {
-  std::vector<int64_t> dims(self.dim());
-  std::iota(dims.begin(), dims.end(), 0);
+  auto reduce_dims = get_reduce_dims(self, std::nullopt);
 
   Tensor output_t =
       at::empty({}, get_dtype_from_self(self, opt_dtype, true), std::nullopt, kMPS, std::nullopt, std::nullopt);
 
-  reduction_out_mps(
-      self, IntArrayRef(dims), false, opt_dtype, const_cast<Tensor&>(output_t), MPSReductionType::PROD, "prod_mps");
+  prod_kernel_mps(self, reduce_dims, false, output_t);
 
   return output_t;
 }
@@ -1492,22 +1847,98 @@ std::tuple<Tensor, Tensor> std_mean_mps(const Tensor& self,
                                         at::OptionalIntArrayRef dim,
                                         const std::optional<Scalar>& correction,
                                         bool keepdim) {
-  // TODO: Refactor it into a proper std_var_mean composite function
-  auto std = std_mps(self, dim, correction, keepdim);
-  auto mean = at::empty(std.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, MemoryFormat::Contiguous);
-  reduction_out_mps(self, dim, keepdim, std::nullopt, mean, MPSReductionType::MEAN, "mean_out_mps");
-  return {std, mean};
+  if (self.dim() == 0) {
+    auto self_1d = self.unsqueeze(0);
+    auto [s, m] = std_mean_mps(self_1d, IntArrayRef({0}), correction, false);
+    return {s.squeeze(), m.squeeze()};
+  }
+  TORCH_CHECK(c10::isFloatingType(self.scalar_type()) || c10::isComplexType(self.scalar_type()),
+              "std_mean only support floating point and complex dtypes");
+  if (c10::isComplexType(self.scalar_type())) {
+    auto re = at::real(self).contiguous();
+    auto im = at::imag(self).contiguous();
+    auto var = at::var(re, dim, correction, keepdim).add(at::var(im, dim, correction, keepdim));
+    auto mean = at::complex(at::mean(re, dim, keepdim), at::mean(im, dim, keepdim));
+    return {var.sqrt(), mean};
+  }
+  auto reduce_dims = get_reduce_dims(self, dim);
+  const auto correction_value = correction.value_or(1.0).toDouble();
+
+  std::vector<int64_t> output_shape;
+  for (int64_t d = 0; d < self.dim(); d++) {
+    bool reduced = false;
+    for (auto rd : reduce_dims) {
+      if (rd == d) {
+        reduced = true;
+        break;
+      }
+    }
+    if (reduced) {
+      if (keepdim)
+        output_shape.push_back(1);
+    } else {
+      output_shape.push_back(self.size(d));
+    }
+  }
+
+  auto std_out = at::empty(output_shape, self.scalar_type(), std::nullopt, kMPS, std::nullopt, std::nullopt);
+  auto mean_out =
+      at::empty(output_shape, self.scalar_type(), std::nullopt, kMPS, std::nullopt, MemoryFormat::Contiguous);
+
+  if (std_out.numel() > 0 && self.numel() > 0) {
+    welford_kernel_mps(self, reduce_dims, keepdim, correction_value, true, std_out, &mean_out);
+  }
+
+  return {std_out, mean_out};
 }
 
 std::tuple<Tensor, Tensor> var_mean_mps(const Tensor& self,
                                         at::OptionalIntArrayRef dim,
                                         const std::optional<Scalar>& correction,
                                         bool keepdim) {
-  // TODO: Refactor it into a proper std_var_mean composite function
-  auto var = var_mps(self, dim, correction, keepdim);
-  auto mean = at::empty(var.sizes(), self.scalar_type(), std::nullopt, kMPS, std::nullopt, MemoryFormat::Contiguous);
-  reduction_out_mps(self, dim, keepdim, std::nullopt, mean, MPSReductionType::MEAN, "mean_out_mps");
-  return {var, mean};
+  if (self.dim() == 0) {
+    auto self_1d = self.unsqueeze(0);
+    auto [v, m] = var_mean_mps(self_1d, IntArrayRef({0}), correction, false);
+    return {v.squeeze(), m.squeeze()};
+  }
+  TORCH_CHECK(c10::isFloatingType(self.scalar_type()) || c10::isComplexType(self.scalar_type()),
+              "var_mean only support floating point and complex dtypes");
+  if (c10::isComplexType(self.scalar_type())) {
+    auto re = at::real(self).contiguous();
+    auto im = at::imag(self).contiguous();
+    auto var = at::var(re, dim, correction, keepdim).add(at::var(im, dim, correction, keepdim));
+    auto mean = at::complex(at::mean(re, dim, keepdim), at::mean(im, dim, keepdim));
+    return {var, mean};
+  }
+  auto reduce_dims = get_reduce_dims(self, dim);
+  const auto correction_value = correction.value_or(1.0).toDouble();
+
+  std::vector<int64_t> output_shape;
+  for (int64_t d = 0; d < self.dim(); d++) {
+    bool reduced = false;
+    for (auto rd : reduce_dims) {
+      if (rd == d) {
+        reduced = true;
+        break;
+      }
+    }
+    if (reduced) {
+      if (keepdim)
+        output_shape.push_back(1);
+    } else {
+      output_shape.push_back(self.size(d));
+    }
+  }
+
+  auto var_out = at::empty(output_shape, self.scalar_type(), std::nullopt, kMPS, std::nullopt, std::nullopt);
+  auto mean_out =
+      at::empty(output_shape, self.scalar_type(), std::nullopt, kMPS, std::nullopt, MemoryFormat::Contiguous);
+
+  if (var_out.numel() > 0 && self.numel() > 0) {
+    welford_kernel_mps(self, reduce_dims, keepdim, correction_value, false, var_out, &mean_out);
+  }
+
+  return {var_out, mean_out};
 }
 
 REGISTER_DISPATCH(norm_stub, &norm_kernel_mps)

--- a/benchmarks/bench_mps_reduce.py
+++ b/benchmarks/bench_mps_reduce.py
@@ -1,0 +1,141 @@
+"""Benchmark Metal reduce ops (var, std, prod, argmax, argmin, max, min) on MPS.
+
+Uses torch.utils.benchmark.Timer + blocked_autorange.
+
+Usage:
+    python benchmarks/bench_mps_reduce.py
+    python benchmarks/bench_mps_reduce.py --variable-shapes
+"""
+
+import argparse
+
+import torch
+from torch.utils.benchmark import Timer
+
+
+def fmt(m):
+    return f"{m.median * 1e6:>8.1f} +/- {m.iqr * 1e6:>5.1f}"
+
+
+def bench(stmt, glob, min_run_time=2.0):
+    t = Timer(stmt=stmt, globals=glob)
+    return t.blocked_autorange(min_run_time=min_run_time)
+
+
+def run_fixed(args):
+    print("=" * 72)
+    print("FIXED-SHAPE REDUCTIONS")
+    print("=" * 72)
+
+    cases = [
+        ("prod dim=0", (128, 256), "torch.prod(x, dim=0); torch.mps.synchronize()"),
+        ("prod dim=1", (128, 256), "torch.prod(x, dim=1); torch.mps.synchronize()"),
+        ("var dim=1", (128, 256), "torch.var(x, dim=1); torch.mps.synchronize()"),
+        ("var dim=0", (128, 256), "torch.var(x, dim=0); torch.mps.synchronize()"),
+        ("std dim=1", (128, 256), "torch.std(x, dim=1); torch.mps.synchronize()"),
+        (
+            "var_mean dim=1",
+            (128, 256),
+            "torch.var_mean(x, dim=1); torch.mps.synchronize()",
+        ),
+        (
+            "std_mean dim=1",
+            (128, 256),
+            "torch.std_mean(x, dim=1); torch.mps.synchronize()",
+        ),
+        ("argmax dim=0", (128, 256), "torch.argmax(x, dim=0); torch.mps.synchronize()"),
+        ("argmax dim=1", (128, 256), "torch.argmax(x, dim=1); torch.mps.synchronize()"),
+        ("argmin dim=1", (128, 256), "torch.argmin(x, dim=1); torch.mps.synchronize()"),
+        ("max dim=0", (128, 256), "torch.max(x, dim=0); torch.mps.synchronize()"),
+        ("max dim=1", (128, 256), "torch.max(x, dim=1); torch.mps.synchronize()"),
+        ("min dim=0", (128, 256), "torch.min(x, dim=0); torch.mps.synchronize()"),
+    ]
+
+    header = f"{'op':<24} {'shape':>14} {'med +/- iqr (us)':>22}"
+    print(header)
+    print("-" * len(header))
+
+    for name, shape, stmt in cases:
+        x = torch.randn(shape, device="mps")
+        result = bench(stmt, {"x": x, "torch": torch}, min_run_time=args.min_time)
+        print(f"{name:<24} {str(shape):>14} {fmt(result):>22}")
+
+
+def run_large(args):
+    print()
+    print("=" * 72)
+    print("LARGE REDUCTIONS")
+    print("=" * 72)
+
+    cases = [
+        ("var dim=1", (1024, 4096), "torch.var(x, dim=1); torch.mps.synchronize()"),
+        (
+            "argmax dim=1",
+            (1024, 4096),
+            "torch.argmax(x, dim=1); torch.mps.synchronize()",
+        ),
+        ("max dim=1", (1024, 4096), "torch.max(x, dim=1); torch.mps.synchronize()"),
+        ("prod dim=1", (1024, 4096), "torch.prod(x, dim=1); torch.mps.synchronize()"),
+    ]
+
+    header = f"{'op':<24} {'shape':>14} {'med +/- iqr (us)':>22}"
+    print(header)
+    print("-" * len(header))
+
+    for name, shape, stmt in cases:
+        x = torch.randn(shape, device="mps")
+        result = bench(stmt, {"x": x, "torch": torch}, min_run_time=args.min_time)
+        print(f"{name:<24} {str(shape):>14} {fmt(result):>22}")
+
+
+def run_variable(args):
+    print()
+    print("=" * 72)
+    print("VARIABLE-SHAPE (20 different shapes)")
+    print("=" * 72)
+
+    import random
+
+    random.seed(42)
+    shapes = [(random.randint(32, 512), random.randint(64, 1024)) for _ in range(20)]
+
+    for op_name, op_fn_str in [
+        ("var dim=0", "torch.var(x, dim=0)"),
+        ("argmax dim=0", "torch.argmax(x, dim=0)"),
+    ]:
+        tensors = [torch.randn(s, device="mps") for s in shapes]
+        stmt = f"for x in tensors:\n    {op_fn_str}\ntorch.mps.synchronize()"
+        result = bench(
+            stmt, {"tensors": tensors, "torch": torch}, min_run_time=args.min_time
+        )
+        per_call = result.median * 1e6 / len(shapes)
+        iqr_per = result.iqr * 1e6 / len(shapes)
+        print(
+            f"{op_name:<24} 20 shapes     {per_call:>8.1f} +/- {iqr_per:>5.1f} us/call"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark MPS reduce ops (Metal vs MPSGraph)"
+    )
+    parser.add_argument("--min-time", type=float, default=2.0)
+    parser.add_argument(
+        "--variable-shapes",
+        action="store_true",
+        help="Include variable-shape cache-swelling test",
+    )
+    args = parser.parse_args()
+
+    print(f"PyTorch {torch.__version__}")
+    print("Benchmark: torch.utils.benchmark.Timer + blocked_autorange")
+    print()
+
+    run_fixed(args)
+    run_large(args)
+    if args.variable_shapes:
+        run_variable(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/sweep_reduce.py
+++ b/benchmarks/sweep_reduce.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Full reduce-op perf sweep for MPS — isolated-subprocess per cell, dumps JSON.
+
+Lives in the worktree (benchmarks/mps/sweep_reduce.py) so the PR's perf numbers
+stay reproducible. Run on each build (MPSGraph baseline vs Metal PR), then compare.
+
+Usage:
+  # one cell (used internally per-subprocess):
+  python sweep_reduce.py --cell '{"op":"var","shape":[1024,4096],"dim":-1,"dtype":"float32"}'
+  # full sweep (spawns one fresh subprocess per cell -> avoids cross-cell cache/thermal bleed):
+  python sweep_reduce.py --out /tmp/sweep_<tag>.json
+  # compare two result files:
+  python sweep_reduce.py --compare /tmp/sweep_base.json /tmp/sweep_pr.json
+"""
+import argparse, itertools, json, subprocess, sys
+
+OPS = ["sum", "mean", "nansum", "prod", "var", "std", "var_mean", "std_mean",
+       "argmax", "argmin", "amax", "amin", "max", "min"]
+SHAPES = [[128, 256], [1024, 4096], [4096, 1024], [1048576], [256, 256, 256],
+          [8, 2048, 4096], [16, 512, 4096]]
+DTYPES = ["float32", "float16", "bfloat16"]
+DIMS = [0, -1, None]
+
+
+def _valid(op, shape, dim):
+    if dim is None and op in ("max", "min"):       # max(dim)/min(dim) need a dim
+        return False
+    if dim is not None and dim >= len(shape):
+        return False
+    if len(shape) == 1 and dim == 0:
+        dim_ok = True  # 1D dim=0 == all-reduce, allow
+    return True
+
+
+def run_cell(cell):
+    import torch
+    from torch.utils.benchmark import Timer
+    dt = getattr(torch, cell["dtype"])
+    shape, dim, op = cell["shape"], cell["dim"], cell["op"]
+    torch.manual_seed(0)
+    if op in ("argmax", "argmin", "amax", "amin", "max", "min") and dt in (torch.float16, torch.bfloat16):
+        x = torch.randn(*shape).to(dt).to("mps")
+    else:
+        x = torch.randn(*shape, dtype=torch.float32).to(dt).to("mps") if dt.is_floating_point else torch.randint(0, 8, shape, dtype=dt).to("mps")
+    fn = getattr(torch, op)
+    stmt = "fn(x) if d is None else fn(x, dim=d); torch.mps.synchronize()"
+    try:
+        Timer(stmt=stmt, globals={"fn": fn, "x": x, "d": dim}).blocked_autorange(min_run_time=0.3)  # warm
+        m = Timer(stmt=stmt, globals={"fn": fn, "x": x, "d": dim}).blocked_autorange(min_run_time=0.5)
+        return round(m.median * 1e6, 3)
+    except Exception as e:
+        return f"ERR:{type(e).__name__}"
+
+
+def sweep(out):
+    cells = [dict(op=o, shape=s, dim=d, dtype=t)
+             for o, s, t, d in itertools.product(OPS, SHAPES, DTYPES, DIMS) if _valid(o, s, d)]
+    results = {}
+    for i, c in enumerate(cells):
+        key = f"{c['op']}|{c['shape']}|{c['dim']}|{c['dtype']}"
+        r = subprocess.run([sys.executable, __file__, "--cell", json.dumps(c)],
+                           capture_output=True, text=True)
+        val = r.stdout.strip().splitlines()[-1] if r.stdout.strip() else f"ERR:nostdout"
+        try:
+            results[key] = float(val)
+        except ValueError:
+            results[key] = val
+        print(f"[{i+1}/{len(cells)}] {key} -> {results[key]}", flush=True)
+    with open(out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"wrote {out} ({len(results)} cells)")
+
+
+def compare(base_f, pr_f):
+    base = json.load(open(base_f)); pr = json.load(open(pr_f))
+    wins = matched = regr = 0
+    regr_list = []
+    for k in sorted(set(base) & set(pr)):
+        b, p = base[k], pr[k]
+        if not (isinstance(b, float) and isinstance(p, float)):
+            continue
+        sp = b / p  # speedup of PR over baseline (>1 = faster)
+        if sp > 1.05:
+            wins += 1
+        elif sp < 0.95:
+            regr += 1
+            regr_list.append((k, round(sp, 3), b, p))
+        else:
+            matched += 1
+    print(f"wins(>1.05x): {wins}  matched: {matched}  REGRESSIONS(<0.95x): {regr}")
+    print("worst regressions:")
+    for k, sp, b, p in sorted(regr_list, key=lambda r: r[1])[:20]:
+        print(f"  {sp}x  {k}  base={b} pr={p}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cell")
+    ap.add_argument("--out")
+    ap.add_argument("--compare", nargs=2)
+    a = ap.parse_args()
+    if a.cell:
+        print(run_cell(json.loads(a.cell)))
+    elif a.out:
+        sweep(a.out)
+    elif a.compare:
+        compare(a.compare[0], a.compare[1])

--- a/c10/metal/reduction_utils.h
+++ b/c10/metal/reduction_utils.h
@@ -120,9 +120,11 @@ inline ::metal::enable_if_t<::metal::is_same_v<T, long>, T> simd_sum(T val) {
 
 template <typename T>
 inline ::metal::enable_if_t<::metal::is_same_v<T, long>, T> simd_prod(T val) {
+  // Fill with 1 (product identity) for inactive lanes in partial simdgroups
+  int2 fill = as_type<int2>(T(1));
   for (ushort i = simdgroup_size / 2; i > 0; i /= 2) {
     val *= as_type<T>(
-        ::metal::simd_shuffle_and_fill_down(as_type<int2>(val), int2(0), i));
+        ::metal::simd_shuffle_and_fill_down(as_type<int2>(val), fill, i));
   }
   return simd_broadcast(val, 0);
 }
@@ -196,16 +198,74 @@ inline ::c10::metal::pair<T, ushort> simd_argmax(T val) {
   return {rc, static_cast<ushort>(::metal::ctz(static_cast<ulong>(vote)))};
 }
 
-template <typename ARG_T, typename IDX_T>
+template <
+    typename ARG_T,
+    typename IDX_T,
+    ::metal::enable_if_t<::metal::is_integral_v<ARG_T>, bool> = true>
 inline c10::metal::pair<ARG_T, IDX_T> simd_argmin(ARG_T val, IDX_T idx_val) {
-  auto rc = simd_argmin(val);
-  return {rc.first, simd_broadcast(idx_val, rc.second)};
+  ARG_T min_val = simd_min(val);
+  ulong votes = static_cast<ulong>(::metal::simd_ballot(val == min_val));
+  IDX_T best =
+      simd_broadcast(idx_val, static_cast<ushort>(::metal::ctz(votes)));
+  for (votes &= (votes - 1); votes; votes &= (votes - 1)) {
+    IDX_T other =
+        simd_broadcast(idx_val, static_cast<ushort>(::metal::ctz(votes)));
+    best = (other < best) ? other : best;
+  }
+  return {min_val, best};
 }
 
-template <typename ARG_T, typename IDX_T>
+template <
+    typename ARG_T,
+    typename IDX_T,
+    ::metal::enable_if_t<::metal::is_floating_point_v<ARG_T>, bool> = true>
+inline c10::metal::pair<ARG_T, IDX_T> simd_argmin(ARG_T val, IDX_T idx_val) {
+  ARG_T min_val = simd_min(val);
+  bool matches = (val == min_val) || ::metal::isnan(val);
+  ulong votes = static_cast<ulong>(::metal::simd_ballot(matches));
+  IDX_T best =
+      simd_broadcast(idx_val, static_cast<ushort>(::metal::ctz(votes)));
+  for (votes &= (votes - 1); votes; votes &= (votes - 1)) {
+    IDX_T other =
+        simd_broadcast(idx_val, static_cast<ushort>(::metal::ctz(votes)));
+    best = (other < best) ? other : best;
+  }
+  return {min_val, best};
+}
+
+template <
+    typename ARG_T,
+    typename IDX_T,
+    ::metal::enable_if_t<::metal::is_integral_v<ARG_T>, bool> = true>
 inline c10::metal::pair<ARG_T, IDX_T> simd_argmax(ARG_T val, IDX_T idx_val) {
-  auto rc = simd_argmax(val);
-  return {rc.first, simd_broadcast(idx_val, rc.second)};
+  ARG_T max_val = simd_max(val);
+  ulong votes = static_cast<ulong>(::metal::simd_ballot(val == max_val));
+  IDX_T best =
+      simd_broadcast(idx_val, static_cast<ushort>(::metal::ctz(votes)));
+  for (votes &= (votes - 1); votes; votes &= (votes - 1)) {
+    IDX_T other =
+        simd_broadcast(idx_val, static_cast<ushort>(::metal::ctz(votes)));
+    best = (other < best) ? other : best;
+  }
+  return {max_val, best};
+}
+
+template <
+    typename ARG_T,
+    typename IDX_T,
+    ::metal::enable_if_t<::metal::is_floating_point_v<ARG_T>, bool> = true>
+inline c10::metal::pair<ARG_T, IDX_T> simd_argmax(ARG_T val, IDX_T idx_val) {
+  ARG_T max_val = simd_max(val);
+  bool matches = (val == max_val) || ::metal::isnan(val);
+  ulong votes = static_cast<ulong>(::metal::simd_ballot(matches));
+  IDX_T best =
+      simd_broadcast(idx_val, static_cast<ushort>(::metal::ctz(votes)));
+  for (votes &= (votes - 1); votes; votes &= (votes - 1)) {
+    IDX_T other =
+        simd_broadcast(idx_val, static_cast<ushort>(::metal::ctz(votes)));
+    best = (other < best) ? other : best;
+  }
+  return {max_val, best};
 }
 
 // Below algorithms are  written with hardcoded assumption that simdgroup is 32

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12483,7 +12483,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         ]
         self.common(forward, args, atol=1e-5, rtol=1e-5)
 
-    @xfail_if_mps_unimplemented  # embedding bag
     @requires_gpu()
     @skip_if_halide  # cascading accuracy issues due rsqrt fallback
     def test_tmp_not_defined_issue3(self):

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -70,7 +70,6 @@ test_failures = {
     "test_AllenaiLongformerBase_repro_dynamic_shapes": TestFailure(
         ("cpu", "cuda", "xpu"), is_skip=True
     ),
-    "test_argmax_argmin_with_duplicates_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_abs_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_floordiv_dynamic_shapes": TestFailure(("mps",)),
     "test_index_propagation_remainder_dynamic_shapes": TestFailure(("mps",)),

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -15328,6 +15328,287 @@ class TestMetalLibrary(TestCaseMPS):
 # This requires mps to be properly registered in the device generic test framework which is not the
 # case right now. We can probably use `allow_mps` introduced in https://github.com/pytorch/pytorch/pull/87342
 # to achieve this.
+
+class TestReduceOpsMetal(TestCaseMPS):
+    """Tests for Metal kernel reduce ops: prod, var/std, argmax/argmin, max/min."""
+
+    # =========================================================================
+    # Product reduction
+    # =========================================================================
+    def test_prod_metal_basic(self):
+        for shape in [(4,), (3, 4), (2, 3, 4), (2, 3, 4, 5)]:
+            for dtype in [torch.float32, torch.float16, torch.int32, torch.int64]:
+                if dtype in (torch.int32, torch.int64):
+                    cpu_x = torch.randint(1, 3, shape, device='cpu', dtype=dtype)
+                else:
+                    cpu_x = torch.randint(1, 4, shape, device='cpu', dtype=dtype)
+                mps_x = cpu_x.to('mps')
+                # Scalar prod
+                self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+                # Per-dim prod
+                for dim in range(len(shape)):
+                    self.assertEqual(torch.prod(mps_x, dim=dim), torch.prod(cpu_x, dim=dim))
+                    self.assertEqual(
+                        torch.prod(mps_x, dim=dim, keepdim=True),
+                        torch.prod(cpu_x, dim=dim, keepdim=True))
+
+    def test_prod_metal_dtype_promotion(self):
+        cpu_x = torch.tensor([1, 2, 3, 4], dtype=torch.int32, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(
+            torch.prod(mps_x, dtype=torch.int64),
+            torch.prod(cpu_x, dtype=torch.int64))
+
+    def test_prod_metal_float_types(self):
+        cpu_x = torch.randn(8, 16, device='cpu', dtype=torch.float32)
+        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+            cx = cpu_x.to(dtype)
+            mx = cx.to('mps')
+            self.assertEqual(torch.prod(mx, dim=1), torch.prod(cx, dim=1), atol=1e-2, rtol=1e-2)
+            self.assertEqual(torch.prod(mx, dim=0), torch.prod(cx, dim=0), atol=1e-2, rtol=1e-2)
+
+    def test_prod_metal_empty(self):
+        cpu_x = torch.empty(0, 3, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+
+    def test_prod_metal_scalar(self):
+        cpu_x = torch.tensor(5.0, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+
+    def test_prod_metal_bool(self):
+        cpu_x = torch.tensor([True, True, False, True], device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x), torch.prod(cpu_x))
+        self.assertEqual(torch.prod(mps_x, dtype=torch.int64), torch.prod(cpu_x, dtype=torch.int64))
+
+    def test_prod_metal_large(self):
+        cpu_x = torch.randint(1, 3, (64, 128), device='cpu', dtype=torch.int32)
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.prod(mps_x, dim=0), torch.prod(cpu_x, dim=0))
+        self.assertEqual(torch.prod(mps_x, dim=1), torch.prod(cpu_x, dim=1))
+
+    def test_prod_metal_noncontiguous(self):
+        cpu_x = torch.randint(1, 4, (4, 6), device='cpu', dtype=torch.float32)
+        mps_x = cpu_x.to('mps')
+        # Transpose makes it non-contiguous
+        cpu_t = cpu_x.t()
+        mps_t = mps_x.t()
+        self.assertEqual(torch.prod(mps_t, dim=0), torch.prod(cpu_t, dim=0))
+        self.assertEqual(torch.prod(mps_t, dim=1), torch.prod(cpu_t, dim=1))
+
+    # =========================================================================
+    # Variance and standard deviation
+    # =========================================================================
+    def test_var_metal_basic(self):
+        for shape in [(8,), (4, 8), (2, 4, 8), (2, 3, 4, 5)]:
+            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float32)
+            mps_x = cpu_x.to('mps')
+            # Scalar var
+            self.assertEqual(torch.var(mps_x), torch.var(cpu_x), atol=1e-4, rtol=1e-4)
+            self.assertEqual(torch.var(mps_x, correction=0), torch.var(cpu_x, correction=0), atol=1e-4, rtol=1e-4)
+            # Per-dim
+            for dim in range(len(shape)):
+                self.assertEqual(
+                    torch.var(mps_x, dim=dim), torch.var(cpu_x, dim=dim), atol=1e-4, rtol=1e-4)
+                self.assertEqual(
+                    torch.var(mps_x, dim=dim, keepdim=True),
+                    torch.var(cpu_x, dim=dim, keepdim=True), atol=1e-4, rtol=1e-4)
+
+    def test_std_metal_basic(self):
+        for shape in [(8,), (4, 8), (2, 4, 8)]:
+            cpu_x = torch.randn(shape, device='cpu', dtype=torch.float32)
+            mps_x = cpu_x.to('mps')
+            self.assertEqual(torch.std(mps_x), torch.std(cpu_x), atol=1e-4, rtol=1e-4)
+            for dim in range(len(shape)):
+                self.assertEqual(
+                    torch.std(mps_x, dim=dim), torch.std(cpu_x, dim=dim), atol=1e-4, rtol=1e-4)
+
+    def test_var_metal_correction(self):
+        cpu_x = torch.randn(10, 20, device='cpu')
+        mps_x = cpu_x.to('mps')
+        for corr in [0, 1, 2]:
+            self.assertEqual(
+                torch.var(mps_x, dim=1, correction=corr),
+                torch.var(cpu_x, dim=1, correction=corr), atol=1e-4, rtol=1e-4)
+
+    def test_var_metal_multidim(self):
+        cpu_x = torch.randn(3, 4, 5, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(
+            torch.var(mps_x, dim=[0, 2]),
+            torch.var(cpu_x, dim=[0, 2]), atol=1e-4, rtol=1e-4)
+        self.assertEqual(
+            torch.var(mps_x, dim=[0, 2], keepdim=True),
+            torch.var(cpu_x, dim=[0, 2], keepdim=True), atol=1e-4, rtol=1e-4)
+
+    def test_var_metal_half(self):
+        cpu_x = torch.randn(16, 32, device='cpu', dtype=torch.float32)
+        for dtype in [torch.float16, torch.bfloat16]:
+            cx = cpu_x.to(dtype)
+            mx = cx.to('mps')
+            self.assertEqual(
+                torch.var(mx, dim=1),
+                torch.var(cx, dim=1), atol=1e-1, rtol=1e-1)
+
+    def test_var_metal_empty(self):
+        cpu_x = torch.randn(0, 5, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.var(mps_x, dim=0).shape, torch.var(cpu_x, dim=0).shape)
+
+    def test_var_metal_scalar(self):
+        cpu_x = torch.tensor(3.14, device='cpu')
+        mps_x = cpu_x.to('mps')
+        # var of scalar with correction=1 is NaN (dof=0); test correction=0
+        self.assertTrue(torch.isnan(torch.var(mps_x)))
+        self.assertEqual(
+            torch.var(mps_x, correction=0), torch.var(cpu_x, correction=0))
+
+    # =========================================================================
+    # var_mean / std_mean (fused)
+    # =========================================================================
+    def test_var_mean_metal(self):
+        for shape in [(8,), (4, 8), (2, 4, 8)]:
+            cpu_x = torch.randn(shape, device='cpu')
+            mps_x = cpu_x.to('mps')
+            # Scalar
+            mv, mm = torch.var_mean(mps_x)
+            cv, cm = torch.var_mean(cpu_x)
+            self.assertEqual(mv, cv, atol=1e-4, rtol=1e-4)
+            self.assertEqual(mm, cm, atol=1e-4, rtol=1e-4)
+            # Per-dim
+            for dim in range(len(shape)):
+                mv, mm = torch.var_mean(mps_x, dim=dim)
+                cv, cm = torch.var_mean(cpu_x, dim=dim)
+                self.assertEqual(mv, cv, atol=1e-4, rtol=1e-4)
+                self.assertEqual(mm, cm, atol=1e-4, rtol=1e-4)
+
+    def test_std_mean_metal(self):
+        cpu_x = torch.randn(4, 8, device='cpu')
+        mps_x = cpu_x.to('mps')
+        ms, mm = torch.std_mean(mps_x, dim=1)
+        cs, cm = torch.std_mean(cpu_x, dim=1)
+        self.assertEqual(ms, cs, atol=1e-4, rtol=1e-4)
+        self.assertEqual(mm, cm, atol=1e-4, rtol=1e-4)
+
+    def test_var_mean_metal_keepdim(self):
+        cpu_x = torch.randn(3, 4, 5, device='cpu')
+        mps_x = cpu_x.to('mps')
+        mv, mm = torch.var_mean(mps_x, dim=1, keepdim=True)
+        cv, cm = torch.var_mean(cpu_x, dim=1, keepdim=True)
+        self.assertEqual(mv, cv, atol=1e-4, rtol=1e-4)
+        self.assertEqual(mm, cm, atol=1e-4, rtol=1e-4)
+
+    # =========================================================================
+    # Argmax / Argmin
+    # =========================================================================
+    def test_argmax_metal_basic(self):
+        for shape in [(8,), (4, 8), (2, 4, 8)]:
+            for dtype in [torch.float32, torch.int32, torch.int64, torch.float16]:
+                if dtype in [torch.float32, torch.float16]:
+                    cpu_x = torch.randn(shape, device='cpu', dtype=dtype)
+                else:
+                    n = 1
+                    for s in shape:
+                        n *= s
+                    cpu_x = torch.randperm(n, device='cpu', dtype=dtype).reshape(shape)
+                mps_x = cpu_x.to('mps')
+                # No dim
+                self.assertEqual(torch.argmax(mps_x), torch.argmax(cpu_x))
+                self.assertEqual(torch.argmin(mps_x), torch.argmin(cpu_x))
+                # Per dim
+                for dim in range(len(shape)):
+                    self.assertEqual(torch.argmax(mps_x, dim=dim), torch.argmax(cpu_x, dim=dim))
+                    self.assertEqual(torch.argmin(mps_x, dim=dim), torch.argmin(cpu_x, dim=dim))
+                    self.assertEqual(
+                        torch.argmax(mps_x, dim=dim, keepdim=True),
+                        torch.argmax(cpu_x, dim=dim, keepdim=True))
+
+    def test_argmax_metal_large(self):
+        cpu_x = torch.randn(256, 512, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.argmax(mps_x, dim=0), torch.argmax(cpu_x, dim=0))
+        self.assertEqual(torch.argmax(mps_x, dim=1), torch.argmax(cpu_x, dim=1))
+        self.assertEqual(torch.argmin(mps_x, dim=0), torch.argmin(cpu_x, dim=0))
+        self.assertEqual(torch.argmin(mps_x, dim=1), torch.argmin(cpu_x, dim=1))
+
+    # =========================================================================
+    # Max / Min with dim (values + indices)
+    # =========================================================================
+    def test_max_dim_metal(self):
+        for shape in [(8,), (4, 8), (2, 4, 8)]:
+            for dtype in [torch.float32, torch.int32, torch.float16]:
+                if dtype == torch.float32 or dtype == torch.float16:
+                    cpu_x = torch.randn(shape, device='cpu', dtype=dtype)
+                else:
+                    cpu_x = torch.randint(-10, 10, shape, device='cpu', dtype=dtype)
+                mps_x = cpu_x.to('mps')
+                for dim in range(len(shape)):
+                    mv, mi = torch.max(mps_x, dim=dim)
+                    cv, ci = torch.max(cpu_x, dim=dim)
+                    self.assertEqual(mv, cv)
+                    self.assertEqual(mi, ci)
+                    mv, mi = torch.max(mps_x, dim=dim, keepdim=True)
+                    cv, ci = torch.max(cpu_x, dim=dim, keepdim=True)
+                    self.assertEqual(mv, cv)
+                    self.assertEqual(mi, ci)
+
+    def test_min_dim_metal(self):
+        cpu_x = torch.randn(4, 8, device='cpu')
+        mps_x = cpu_x.to('mps')
+        for dim in [0, 1]:
+            mv, mi = torch.min(mps_x, dim=dim)
+            cv, ci = torch.min(cpu_x, dim=dim)
+            self.assertEqual(mv, cv)
+            self.assertEqual(mi, ci)
+
+    def test_max_scalar_metal(self):
+        cpu_x = torch.randn(64, device='cpu')
+        mps_x = cpu_x.to('mps')
+        self.assertEqual(torch.max(mps_x), torch.max(cpu_x))
+        self.assertEqual(torch.min(mps_x), torch.min(cpu_x))
+
+    def test_max_min_metal_large(self):
+        cpu_x = torch.randn(128, 256, device='cpu')
+        mps_x = cpu_x.to('mps')
+        mv, mi = torch.max(mps_x, dim=0)
+        cv, ci = torch.max(cpu_x, dim=0)
+        self.assertEqual(mv, cv)
+        self.assertEqual(mi, ci)
+        mv, mi = torch.max(mps_x, dim=1)
+        cv, ci = torch.max(cpu_x, dim=1)
+        self.assertEqual(mv, cv)
+        self.assertEqual(mi, ci)
+
+    # =========================================================================
+    # Variable-length shapes (GNN / varlen workload simulation)
+    # =========================================================================
+    def test_reduce_variable_shapes(self):
+        """Verify Metal kernels handle changing shapes without cache swell."""
+        for n in [7, 13, 31, 64, 100, 255]:
+            cpu_x = torch.randn(n, 16, device='cpu')
+            mps_x = cpu_x.to('mps')
+            self.assertEqual(torch.prod(mps_x, dim=0), torch.prod(cpu_x, dim=0))
+            self.assertEqual(
+                torch.var(mps_x, dim=0), torch.var(cpu_x, dim=0), atol=1e-4, rtol=1e-4)
+            mv, mi = torch.max(mps_x, dim=0)
+            cv, ci = torch.max(cpu_x, dim=0)
+            self.assertEqual(mv, cv)
+            self.assertEqual(mi, ci)
+
+    def test_reduce_noncontiguous_input(self):
+        cpu_x = torch.randn(8, 16, device='cpu')
+        mps_x = cpu_x.to('mps')
+        # Slice creates non-contiguous view
+        cpu_s = cpu_x[:, ::2]
+        mps_s = mps_x[:, ::2]
+        self.assertEqual(torch.var(mps_s, dim=1), torch.var(cpu_s, dim=1), atol=1e-4, rtol=1e-4)
+        self.assertEqual(torch.argmax(mps_s, dim=1), torch.argmax(cpu_s, dim=1))
+
+
+instantiate_parametrized_tests(TestReduceOpsMetal)
+
 instantiate_device_type_tests(TestConsistency, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestErrorInputs, globals(), allow_mps=True, only_for="mps")
 instantiate_device_type_tests(TestCommon, globals(), allow_mps=True, only_for="mps")

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15204,7 +15204,7 @@ op_db: list[OpInfo] = [
            dtypes=floating_and_complex_types_and(torch.half, torch.bfloat16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
            dtypesIfMPS=floating_and_complex_types_and(
-               torch.half, torch.bfloat16, torch.int32, torch.uint8, torch.bool, torch.int8, torch.int16
+               torch.half, torch.bfloat16
            ),
            sample_inputs_func=sample_inputs_std_var,
            # TODO: some signatures of var_mean do support out
@@ -15223,7 +15223,7 @@ op_db: list[OpInfo] = [
            dtypes=floating_and_complex_types_and(torch.half, torch.bfloat16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
            dtypesIfMPS=floating_and_complex_types_and(
-               torch.half, torch.bfloat16, torch.int32, torch.uint8, torch.bool, torch.int8, torch.int16
+               torch.half, torch.bfloat16
            ),
            sample_inputs_func=sample_inputs_std_var_unbiased,
            # TODO: some signatures of var_mean do support out
@@ -15241,7 +15241,7 @@ op_db: list[OpInfo] = [
            dtypes=floating_and_complex_types_and(torch.half, torch.bfloat16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
            dtypesIfMPS=floating_and_complex_types_and(
-               torch.half, torch.bfloat16, torch.uint8, torch.bool, torch.int8, torch.int16, torch.int32
+               torch.half, torch.bfloat16
            ),
            sample_inputs_func=sample_inputs_std_var,
            # TODO: some signatures of std_mean do support out
@@ -15258,7 +15258,7 @@ op_db: list[OpInfo] = [
            dtypes=floating_and_complex_types_and(torch.half, torch.bfloat16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16),
            dtypesIfMPS=floating_and_complex_types_and(
-               torch.half, torch.bfloat16, torch.uint8, torch.bool, torch.int8, torch.int16, torch.int32
+               torch.half, torch.bfloat16
            ),
            sample_inputs_func=sample_inputs_std_var_unbiased,
            # TODO: some signatures of var_mean do support out
@@ -16677,6 +16677,7 @@ op_db: list[OpInfo] = [
            aliases=('group_norm',),
            ref=reference_group_norm,
            dtypes=floating_types_and(torch.float16, torch.bfloat16),
+           dtypesIfMPS=floating_types_and(torch.float16, torch.bfloat16),
            supports_out=False,
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
@@ -22880,15 +22881,6 @@ op_db: list[OpInfo] = [
                 device_type='xpu',
                 dtypes=[torch.float64]),
             # MPS: std does not support automatic differentiation for outputs with complex dtype
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
             # The operator 'aten::std.correction_out' is not currently implemented for the MPS device
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
@@ -22913,15 +22905,6 @@ op_db: list[OpInfo] = [
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty'),
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty_keepdim'),
             # MPS: std does not support automatic differentiation for outputs with complex dtype
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     ReductionOpInfo(
@@ -22951,15 +22934,6 @@ op_db: list[OpInfo] = [
             # NumPy is giving NaN for this
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_ref_large_input'),
             # RuntimeError: var does not support automatic differentiation for outputs with complex dtype.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
             # NotImplementedError: The operator 'aten::var.correction_out' is not currently implemented for the MPS device
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
@@ -22984,8 +22958,6 @@ op_db: list[OpInfo] = [
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty'),
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty_keepdim'),
             # RuntimeError: var does not support automatic differentiation for outputs with complex dtype.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64,)),
         ),
     ),
     ReductionOpInfo(
@@ -26775,12 +26747,6 @@ python_ref_db = [
                 device_type='xpu',
                 dtypes=[torch.float64]),
             # Exception: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     # std_mean and var_mean are not ReductionInfos
@@ -26789,10 +26755,9 @@ python_ref_db = [
         torch_opinfo_name="std_mean",
         skips=(
             # Exception: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
             DecorateInfo(
                 unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
+                device_type='mps', dtypes=(torch.uint8, torch.bool, torch.int8, torch.int16, torch.int32)
             ),
             # RuntimeError: mean(): could not infer output dtype. Input dtype must be either a floating point or complex dtype
             DecorateInfo(
@@ -26898,11 +26863,6 @@ python_ref_db = [
             DecorateInfo(
                 unittest.skip("Skipped!"), 'TestReductions', 'test_ref_duplicate_values'),
             # torch._subclasses.fake_tensor.MetadataMismatchError: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     PythonRefInfo(
@@ -26911,15 +26871,7 @@ python_ref_db = [
         validate_view_consistency=False,
         skips=(
             # torch._subclasses.fake_tensor.MetadataMismatchError: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
             # RuntimeError: mean(): could not infer output dtype. Input dtype must be either a floating point or complex dtype
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps',
-            ),
             DecorateInfo(
                 unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps',
                 dtypes=(torch.uint8, torch.int8, torch.int32, torch.int16, torch.bool)

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -20,6 +20,14 @@ if torch.backends.mps.is_available():
 
         # Supported complex OPS
         SUPPORTED_COMPLEX_OPS = {
+            "std",
+            "std_mean",
+            "var",
+            "var_mean",
+            "stdunbiased",
+            "std_meanunbiased",
+            "varunbiased",
+            "var_meanunbiased",
             "__radd__",
             "__rmul__",
             "__rsub__",


### PR DESCRIPTION
Replaces MPSGraph-based reduce ops — `prod`, `var`, `std`, `var_mean`, `std_mean`, `argmax`, `argmin`, `max`, `min` — with hand-written Metal kernels. The motivation is per-shape `MPSGraph` compilation: each unique reduce-op call shape compiles and caches a new graph for the process lifetime, a large contributor to the unbounded driver-memory growth on MPS workloads. It is also substantially faster, because `MPSGraph` is pathologically slow for some reduction shapes (notably index-carrying reductions over a large dim — see below).

Kernel design — each op picks a layout from the reduction shape:
- **inner** (reduce the last, contiguous dim): one SIMD group per row, `rows_per_tg` rows per threadgroup, for many short rows (no shared memory, no barrier — mirrors the `sum` inner kernel). A **wide** one-threadgroup-per-row variant (up to 1024 threads, shared-memory tree) handles few-but-huge rows (small M, large N) where 32 lanes on a giant row would be both slow and lose precision from a deep per-lane accumulation. Dispatch picks simd-per-row when `M >= 64 && N <= 16384`, else wide.
- **outer** (reduce dim 0): 2D threadgroup tiles with coalesced column reads and a per-column tree reduction; a `simdgroup_matrix` (tensor-core) Welford for small M (`M ∈ {8,16}`), transposing each 8×8 tile through threadgroup memory so the sum-of-squares pass reads global memory once rather than twice.
- **all-reduce**: a fused two-pass kernel — pass 1 computes per-group partials in parallel, pass 2 combines them in a single threadgroup. Two dispatches instead of one threadgroup scanning the whole input.

`argmax`/`argmin`/`max`/`min` carry indices with lowest-index, NaN-propagating tie-breaking matching CPU/CUDA. Variance uses Welford; the all-reduce pass accumulates a shifted sum / sum-of-squares (shift by a data value for stability) to avoid a per-element division in the hot loop, which is what otherwise made the Welford all-reduce slower than a plain `sum` all-reduce.

Correctness / coverage fixes found during local `--mps` testing:
- **GroupNorm numeric**: GroupNorm reduces via the inner Welford kernel at small M / huge N (`[1, 2, ~19M]`). The simd-per-row layout (32 lanes on a 19M-element row) drifted past the test`s `atol=1e-5` and was slow; routed to the wide kernel (the `M >= 64 && N <= 16384` guard above) — matches the original reduction order and precision.
- **`argmax`/`argmin` global index**: MPS `index_select` routes int64 payloads through fp32, losing precision above 2^24, so reconstructing a global index by gathering already-combined indices rounded to a neighbouring element. The two-pass path gathers the small per-group *local* index (< K, fp32-safe) and reconstructs `group*K + local` in int64.
- **complex `var`/`std`**: routed via `Var(real) + Var(imag)` (real-valued result, same correction), reusing the real Welford kernels — no complex Metal kernel, matching CPU/MPSGraph.
- **integer `var`/`std`/`var_mean`/`std_mean`**: rejected with the same `TORCH_CHECK` as CPU/CUDA (the previous MPS path accepted them via implicit promotion; dropped to match reference semantics).
- **`var`/`std` with `correction >= N`**: returns `inf` (matching CPU IEEE), not the `nan` that Metal fast-math division-by-zero produces.
- **`argmax`/`argmin` tie-breaking**: removed the `test_argmax_argmin_with_duplicates` MPS `xfail` (inductor dynamic shapes) â our Metal arg-reduce returns the lowest index on ties, matching CPU/CUDA, where the previous MPSGraph path did not. Two stale variant-consistency `xfail`s also removed (ops now lower correctly).

Repro (M4 Pro 48 GB, `torch.utils.benchmark.Timer.blocked_autorange`, fresh subprocess per cell against a separate pre-PR-HEAD baseline build):

```python
import torch
from torch.utils.benchmark import Timer
x = torch.randn(8, 2048, 4096, device="mps")
print(Timer("torch.max(x, dim=0); torch.mps.synchronize()",
            globals={"x": x}).blocked_autorange(min_run_time=0.4).median * 1e6, "us")
```

`max(dim=0)` on `(8,2048,4096)`: baseline **~547,000 µs** → PR **~9,300 µs** (**~59×**). MPSGraph`s index-carrying reduction over a large outer dim is pathological here; `amax` (no indices) is already fast on both and is matched. All-reduce `argmax`/`argmin` on the same shape: **~19,300 µs → ~157 µs**.

Full op × shape × dtype × dim sweep (M4 Pro, vs a separate baseline build, isolated subprocess per cell, repeated-run medians; `benchmarks/sweep_reduce.py`):

- **511 wins (>1.05×), 14 matched, 0 regressions** across the 525 converted-op cells (9 ops × shape × dtype × dim).
- Distribution of wins: 62 cells >5×, 147 at 2–5×, 109 at 1.5–2×, 193 at 1.05–1.5×.
- Biggest wins are index reductions over a large dim (`min`/`max`/`argmax`/`argmin` dim=0 on `[8,2048,4096]`: 58–61×) and all-reduce index ops. `var`/`std`/`var_mean`/`std_mean` inner+outer and `prod` are solid 1.2–5× wins.
- `sum`/`mean`/`nansum`/`amax`/`amin` are **not** converted by this PR and are excluded from the tables below; `amax`/`amin` were migrated to Metal separately on main (#180752).
- At the smallest `(128,256)` shape (~95 µs, dispatch-floor-bound) win margins compress toward 1.0×; repeated-run medians keep every converted-op cell ≥ 0.95×, so there are no regressions.

Per-op sweep tables (base = baseline build, PR = this branch; same hardware, back-to-back):

<details>
<summary><b>prod</b> — 63 cells (click to expand)</summary>

| shape | dim | dtype | base µs | PR µs | speedup |
|---|---|---|---:|---:|---:|
| `(8, 2048, 4096)` | -1 | bfloat16 | 750.6 | 715.2 | 1.05× |
| `(8, 2048, 4096)` | -1 | float16 | 750.3 | 720.1 | 1.04× |
| `(8, 2048, 4096)` | -1 | float32 | 1273.2 | 1232.2 | 1.03× |
| `(8, 2048, 4096)` | 0 | bfloat16 | 924.0 | 789.0 | 1.17× |
| `(8, 2048, 4096)` | 0 | float16 | 925.5 | 785.0 | 1.18× |
| `(8, 2048, 4096)` | 0 | float32 | 1508.4 | 1376.9 | 1.10× |
| `(8, 2048, 4096)` | None | bfloat16 | 765.8 | 720.5 | 1.06× |
| `(8, 2048, 4096)` | None | float16 | 778.4 | 732.5 | 1.06× |
| `(8, 2048, 4096)` | None | float32 | 1292.0 | 1233.7 | 1.05× |
| `(16, 512, 4096)` | -1 | bfloat16 | 413.7 | 394.4 | 1.05× |
| `(16, 512, 4096)` | -1 | float16 | 432.8 | 391.7 | 1.10× |
| `(16, 512, 4096)` | -1 | float32 | 745.2 | 716.1 | 1.04× |
| `(16, 512, 4096)` | 0 | bfloat16 | 523.1 | 398.0 | 1.31× |
| `(16, 512, 4096)` | 0 | float16 | 490.0 | 397.5 | 1.23× |
| `(16, 512, 4096)` | 0 | float32 | 818.4 | 745.8 | 1.10× |
| `(16, 512, 4096)` | None | bfloat16 | 445.5 | 403.9 | 1.10× |
| `(16, 512, 4096)` | None | float16 | 461.0 | 396.9 | 1.16× |
| `(16, 512, 4096)` | None | float32 | 776.4 | 707.7 | 1.10× |
| `(256, 256, 256)` | -1 | bfloat16 | 282.0 | 249.6 | 1.13× |
| `(256, 256, 256)` | -1 | float16 | 280.4 | 252.6 | 1.11× |
| `(256, 256, 256)` | -1 | float32 | 419.7 | 385.3 | 1.09× |
| `(256, 256, 256)` | 0 | bfloat16 | 318.4 | 256.1 | 1.24× |
| `(256, 256, 256)` | 0 | float16 | 314.3 | 250.9 | 1.25× |
| `(256, 256, 256)` | 0 | float32 | 461.4 | 413.2 | 1.12× |
| `(256, 256, 256)` | None | bfloat16 | 303.7 | 261.1 | 1.16× |
| `(256, 256, 256)` | None | float16 | 303.2 | 262.0 | 1.16× |
| `(256, 256, 256)` | None | float32 | 438.2 | 387.7 | 1.13× |
| `(4096, 1024)` | -1 | bfloat16 | 132.1 | 109.4 | 1.21× |
| `(1024, 4096)` | -1 | bfloat16 | 131.0 | 108.3 | 1.21× |
| `(4096, 1024)` | -1 | float16 | 129.5 | 115.4 | 1.12× |
| `(1024, 4096)` | -1 | float16 | 131.7 | 114.9 | 1.15× |
| `(1024, 4096)` | -1 | float32 | 167.8 | 148.1 | 1.13× |
| `(4096, 1024)` | -1 | float32 | 174.2 | 140.7 | 1.24× |
| `(4096, 1024)` | 0 | bfloat16 | 150.7 | 112.5 | 1.34× |
| `(1024, 4096)` | 0 | bfloat16 | 134.6 | 114.1 | 1.18× |
| `(4096, 1024)` | 0 | float16 | 149.2 | 110.9 | 1.35× |
| `(1024, 4096)` | 0 | float16 | 137.5 | 108.9 | 1.26× |
| `(1024, 4096)` | 0 | float32 | 169.2 | 147.4 | 1.15× |
| `(4096, 1024)` | 0 | float32 | 179.3 | 141.9 | 1.26× |
| `(4096, 1024)` | None | bfloat16 | 147.9 | 136.2 | 1.09× |
| `(1024, 4096)` | None | bfloat16 | 140.8 | 129.5 | 1.09× |
| `(4096, 1024)` | None | float16 | 149.0 | 125.7 | 1.19× |
| `(1024, 4096)` | None | float16 | 141.4 | 129.0 | 1.10× |
| `(1024, 4096)` | None | float32 | 190.5 | 156.0 | 1.22× |
| `(4096, 1024)` | None | float32 | 183.5 | 150.1 | 1.22× |
| `(1048576,)` | -1 | bfloat16 | 126.6 | 118.9 | 1.06× |
| `(1048576,)` | -1 | float16 | 124.7 | 119.0 | 1.05× |
| `(1048576,)` | -1 | float32 | 129.9 | 117.9 | 1.10× |
| `(1048576,)` | 0 | bfloat16 | 127.5 | 118.6 | 1.08× |
| `(1048576,)` | 0 | float16 | 123.1 | 117.2 | 1.05× |
| `(1048576,)` | 0 | float32 | 126.1 | 115.7 | 1.09× |
| `(1048576,)` | None | bfloat16 | 125.8 | 115.4 | 1.09× |
| `(1048576,)` | None | float16 | 124.6 | 116.0 | 1.07× |
| `(1048576,)` | None | float32 | 128.9 | 118.4 | 1.09× |
| `(128, 256)` | -1 | bfloat16 | 112.8 | 95.4 | 1.18× |
| `(128, 256)` | -1 | float16 | 111.2 | 97.9 | 1.14× |
| `(128, 256)` | -1 | float32 | 112.2 | 97.8 | 1.15× |
| `(128, 256)` | 0 | bfloat16 | 110.2 | 94.5 | 1.17× |
| `(128, 256)` | 0 | float16 | 108.9 | 99.6 | 1.09× |
| `(128, 256)` | 0 | float32 | 110.4 | 95.9 | 1.15× |
| `(128, 256)` | None | bfloat16 | 112.6 | 96.9 | 1.16× |
| `(128, 256)` | None | float16 | 115.6 | 94.7 | 1.22× |
| `(128, 256)` | None | float32 | 115.0 | 92.1 | 1.25× |

</details>

<details>
<summary><b>var</b> — 63 cells (click to expand)</summary>

| shape | dim | dtype | base µs | PR µs | speedup |
|---|---|---|---:|---:|---:|
| `(8, 2048, 4096)` | -1 | bfloat16 | 1268.0 | 741.8 | 1.71× |
| `(8, 2048, 4096)` | -1 | float16 | 1258.7 | 730.2 | 1.72× |
| `(8, 2048, 4096)` | -1 | float32 | 2291.5 | 1234.0 | 1.86× |
| `(8, 2048, 4096)` | 0 | bfloat16 | 1674.5 | 1741.1 | 0.96× |
| `(8, 2048, 4096)` | 0 | float16 | 1683.1 | 1738.2 | 0.97× |
| `(8, 2048, 4096)` | 0 | float32 | 2928.5 | 1792.3 | 1.63× |
| `(8, 2048, 4096)` | None | bfloat16 | 1308.1 | 746.0 | 1.75× |
| `(8, 2048, 4096)` | None | float16 | 1310.9 | 735.6 | 1.78× |
| `(8, 2048, 4096)` | None | float32 | 2306.5 | 1209.4 | 1.91× |
| `(16, 512, 4096)` | -1 | bfloat16 | 765.4 | 412.5 | 1.86× |
| `(16, 512, 4096)` | -1 | float16 | 754.7 | 416.1 | 1.81× |
| `(16, 512, 4096)` | -1 | float32 | 1381.9 | 726.3 | 1.90× |
| `(16, 512, 4096)` | 0 | bfloat16 | 960.6 | 711.9 | 1.35× |
| `(16, 512, 4096)` | 0 | float16 | 974.2 | 698.6 | 1.39× |
| `(16, 512, 4096)` | 0 | float32 | 1407.3 | 875.9 | 1.61× |
| `(16, 512, 4096)` | None | bfloat16 | 787.7 | 420.8 | 1.87× |
| `(16, 512, 4096)` | None | float16 | 790.9 | 424.6 | 1.86× |
| `(16, 512, 4096)` | None | float32 | 1343.1 | 723.3 | 1.86× |
| `(256, 256, 256)` | -1 | bfloat16 | 431.6 | 425.7 | 1.01× |
| `(256, 256, 256)` | -1 | float16 | 431.2 | 431.9 | 1.00× |
| `(256, 256, 256)` | -1 | float32 | 761.3 | 432.5 | 1.76× |
| `(256, 256, 256)` | 0 | bfloat16 | 505.8 | 340.3 | 1.49× |
| `(256, 256, 256)` | 0 | float16 | 508.8 | 338.9 | 1.50× |
| `(256, 256, 256)` | 0 | float32 | 840.1 | 404.0 | 2.08× |
| `(256, 256, 256)` | None | bfloat16 | 468.2 | 299.5 | 1.56× |
| `(256, 256, 256)` | None | float16 | 463.3 | 297.7 | 1.56× |
| `(256, 256, 256)` | None | float32 | 784.7 | 405.5 | 1.94× |
| `(1024, 4096)` | -1 | bfloat16 | 179.5 | 142.0 | 1.26× |
| `(4096, 1024)` | -1 | bfloat16 | 165.8 | 138.0 | 1.20× |
| `(1024, 4096)` | -1 | float16 | 169.8 | 135.3 | 1.25× |
| `(4096, 1024)` | -1 | float16 | 168.3 | 146.1 | 1.15× |
| `(4096, 1024)` | -1 | float32 | 273.7 | 149.9 | 1.83× |
| `(1024, 4096)` | -1 | float32 | 285.7 | 158.4 | 1.80× |
| `(1024, 4096)` | 0 | bfloat16 | 215.7 | 139.5 | 1.55× |
| `(4096, 1024)` | 0 | bfloat16 | 242.9 | 157.5 | 1.54× |
| `(4096, 1024)` | 0 | float16 | 232.1 | 163.1 | 1.42× |
| `(1024, 4096)` | 0 | float16 | 191.6 | 145.1 | 1.32× |
| `(4096, 1024)` | 0 | float32 | 289.4 | 156.0 | 1.85× |
| `(1024, 4096)` | 0 | float32 | 275.7 | 158.9 | 1.74× |
| `(4096, 1024)` | None | bfloat16 | 229.5 | 163.3 | 1.41× |
| `(1024, 4096)` | None | bfloat16 | 221.3 | 166.9 | 1.33× |
| `(1024, 4096)` | None | float16 | 217.6 | 170.0 | 1.28× |
| `(4096, 1024)` | None | float16 | 214.3 | 162.5 | 1.32× |
| `(4096, 1024)` | None | float32 | 304.0 | 176.6 | 1.72× |
| `(1024, 4096)` | None | float32 | 311.9 | 181.8 | 1.72× |
| `(1048576,)` | -1 | bfloat16 | 148.1 | 118.1 | 1.25× |
| `(1048576,)` | -1 | float16 | 139.1 | 116.9 | 1.19× |
| `(1048576,)` | -1 | float32 | 159.9 | 121.9 | 1.31× |
| `(1048576,)` | 0 | bfloat16 | 138.9 | 116.8 | 1.19× |
| `(1048576,)` | 0 | float16 | 148.3 | 114.8 | 1.29× |
| `(1048576,)` | 0 | float32 | 155.6 | 121.3 | 1.28× |
| `(1048576,)` | None | bfloat16 | 138.6 | 111.5 | 1.24× |
| `(1048576,)` | None | float16 | 145.6 | 112.4 | 1.30× |
| `(1048576,)` | None | float32 | 151.2 | 117.7 | 1.28× |
| `(128, 256)` | -1 | bfloat16 | 124.2 | 99.8 | 1.24× |
| `(128, 256)` | -1 | float16 | 118.8 | 96.6 | 1.23× |
| `(128, 256)` | -1 | float32 | 128.2 | 98.7 | 1.30× |
| `(128, 256)` | 0 | bfloat16 | 128.9 | 96.0 | 1.34× |
| `(128, 256)` | 0 | float16 | 122.4 | 101.7 | 1.20× |
| `(128, 256)` | 0 | float32 | 122.4 | 101.0 | 1.21× |
| `(128, 256)` | None | bfloat16 | 136.4 | 102.0 | 1.34× |
| `(128, 256)` | None | float16 | 136.5 | 102.0 | 1.34× |
| `(128, 256)` | None | float32 | 138.4 | 100.0 | 1.38× |

</details>

<details>
<summary><b>std</b> — 63 cells (click to expand)</summary>

| shape | dim | dtype | base µs | PR µs | speedup |
|---|---|---|---:|---:|---:|
| `(8, 2048, 4096)` | -1 | bfloat16 | 1294.2 | 728.7 | 1.78× |
| `(8, 2048, 4096)` | -1 | float16 | 1269.1 | 732.3 | 1.73× |
| `(8, 2048, 4096)` | -1 | float32 | 2307.1 | 1253.3 | 1.84× |
| `(8, 2048, 4096)` | 0 | bfloat16 | 1761.2 | 1734.1 | 1.02× |
| `(8, 2048, 4096)` | 0 | float16 | 1732.0 | 1739.5 | 1.00× |
| `(8, 2048, 4096)` | 0 | float32 | 2948.1 | 1788.7 | 1.65× |
| `(8, 2048, 4096)` | None | bfloat16 | 1310.0 | 731.9 | 1.79× |
| `(8, 2048, 4096)` | None | float16 | 1293.8 | 736.1 | 1.76× |
| `(8, 2048, 4096)` | None | float32 | 2333.7 | 1236.2 | 1.89× |
| `(16, 512, 4096)` | -1 | bfloat16 | 757.5 | 397.0 | 1.91× |
| `(16, 512, 4096)` | -1 | float16 | 751.2 | 399.5 | 1.88× |
| `(16, 512, 4096)` | -1 | float32 | 1281.7 | 705.7 | 1.82× |
| `(16, 512, 4096)` | 0 | bfloat16 | 884.9 | 687.9 | 1.29× |
| `(16, 512, 4096)` | 0 | float16 | 899.1 | 676.5 | 1.33× |
| `(16, 512, 4096)` | 0 | float32 | 1469.6 | 889.3 | 1.65× |
| `(16, 512, 4096)` | None | bfloat16 | 775.3 | 405.6 | 1.91× |
| `(16, 512, 4096)` | None | float16 | 784.0 | 410.6 | 1.91× |
| `(16, 512, 4096)` | None | float32 | 1301.9 | 708.7 | 1.84× |
| `(256, 256, 256)` | -1 | bfloat16 | 447.2 | 420.5 | 1.06× |
| `(256, 256, 256)` | -1 | float16 | 433.6 | 421.8 | 1.03× |
| `(256, 256, 256)` | -1 | float32 | 761.5 | 425.1 | 1.79× |
| `(256, 256, 256)` | 0 | bfloat16 | 508.2 | 326.2 | 1.56× |
| `(256, 256, 256)` | 0 | float16 | 539.5 | 330.2 | 1.63× |
| `(256, 256, 256)` | 0 | float32 | 816.8 | 405.2 | 2.02× |
| `(256, 256, 256)` | None | bfloat16 | 455.7 | 290.2 | 1.57× |
| `(256, 256, 256)` | None | float16 | 469.1 | 291.2 | 1.61× |
| `(256, 256, 256)` | None | float32 | 785.0 | 397.6 | 1.97× |
| `(1024, 4096)` | -1 | bfloat16 | 171.0 | 134.0 | 1.28× |
| `(4096, 1024)` | -1 | bfloat16 | 170.0 | 140.6 | 1.21× |
| `(4096, 1024)` | -1 | float16 | 166.8 | 138.4 | 1.21× |
| `(1024, 4096)` | -1 | float16 | 165.7 | 137.2 | 1.21× |
| `(4096, 1024)` | -1 | float32 | 264.2 | 153.3 | 1.72× |
| `(1024, 4096)` | -1 | float32 | 257.1 | 152.3 | 1.69× |
| `(4096, 1024)` | 0 | bfloat16 | 211.9 | 157.9 | 1.34× |
| `(1024, 4096)` | 0 | bfloat16 | 173.6 | 141.0 | 1.23× |
| `(4096, 1024)` | 0 | float16 | 225.0 | 159.4 | 1.41× |
| `(1024, 4096)` | 0 | float16 | 175.1 | 142.5 | 1.23× |
| `(4096, 1024)` | 0 | float32 | 277.3 | 154.7 | 1.79× |
| `(1024, 4096)` | 0 | float32 | 256.4 | 155.5 | 1.65× |
| `(1024, 4096)` | None | bfloat16 | 177.2 | 168.7 | 1.05× |
| `(4096, 1024)` | None | bfloat16 | 213.3 | 166.8 | 1.28× |
| `(1024, 4096)` | None | float16 | 181.6 | 166.3 | 1.09× |
| `(4096, 1024)` | None | float16 | 181.1 | 167.2 | 1.08× |
| `(1024, 4096)` | None | float32 | 273.2 | 173.6 | 1.57× |
| `(4096, 1024)` | None | float32 | 286.2 | 176.0 | 1.63× |
| `(1048576,)` | -1 | bfloat16 | 145.7 | 122.2 | 1.19× |
| `(1048576,)` | -1 | float16 | 147.1 | 117.9 | 1.25× |
| `(1048576,)` | -1 | float32 | 150.6 | 125.0 | 1.20× |
| `(1048576,)` | 0 | bfloat16 | 147.9 | 120.1 | 1.23× |
| `(1048576,)` | 0 | float16 | 145.5 | 121.7 | 1.20× |
| `(1048576,)` | 0 | float32 | 153.4 | 123.7 | 1.24× |
| `(1048576,)` | None | bfloat16 | 147.4 | 120.4 | 1.22× |
| `(1048576,)` | None | float16 | 145.1 | 121.2 | 1.20× |
| `(1048576,)` | None | float32 | 153.8 | 118.0 | 1.30× |
| `(128, 256)` | -1 | bfloat16 | 121.6 | 90.4 | 1.34× |
| `(128, 256)` | -1 | float16 | 118.0 | 91.9 | 1.28× |
| `(128, 256)` | -1 | float32 | 116.3 | 93.1 | 1.25× |
| `(128, 256)` | 0 | bfloat16 | 119.2 | 95.1 | 1.25× |
| `(128, 256)` | 0 | float16 | 115.7 | 94.2 | 1.23× |
| `(128, 256)` | 0 | float32 | 124.0 | 91.2 | 1.36× |
| `(128, 256)` | None | bfloat16 | 134.7 | 98.9 | 1.36× |
| `(128, 256)` | None | float16 | 132.5 | 93.8 | 1.41× |
| `(128, 256)` | None | float32 | 130.7 | 96.2 | 1.36× |

</details>

<details>
<summary><b>var_mean</b> — 63 cells (click to expand)</summary>

| shape | dim | dtype | base µs | PR µs | speedup |
|---|---|---|---:|---:|---:|
| `(8, 2048, 4096)` | -1 | bfloat16 | 1822.7 | 730.7 | 2.49× |
| `(8, 2048, 4096)` | -1 | float16 | 1823.6 | 734.9 | 2.48× |
| `(8, 2048, 4096)` | -1 | float32 | 3398.0 | 1324.2 | 2.57× |
| `(8, 2048, 4096)` | 0 | bfloat16 | 2406.2 | 1740.4 | 1.38× |
| `(8, 2048, 4096)` | 0 | float16 | 2409.1 | 1743.0 | 1.38× |
| `(8, 2048, 4096)` | 0 | float32 | 4231.5 | 1908.6 | 2.22× |
| `(8, 2048, 4096)` | None | bfloat16 | 1872.7 | 746.8 | 2.51× |
| `(8, 2048, 4096)` | None | float16 | 1831.9 | 738.5 | 2.48× |
| `(8, 2048, 4096)` | None | float32 | 3389.9 | 1229.2 | 2.76× |
| `(16, 512, 4096)` | -1 | bfloat16 | 1131.3 | 416.6 | 2.72× |
| `(16, 512, 4096)` | -1 | float16 | 1071.5 | 416.9 | 2.57× |
| `(16, 512, 4096)` | -1 | float32 | 1813.3 | 712.1 | 2.55× |
| `(16, 512, 4096)` | 0 | bfloat16 | 1398.0 | 710.4 | 1.97× |
| `(16, 512, 4096)` | 0 | float16 | 1266.6 | 714.3 | 1.77× |
| `(16, 512, 4096)` | 0 | float32 | 2064.2 | 932.0 | 2.21× |
| `(16, 512, 4096)` | None | bfloat16 | 1165.0 | 421.3 | 2.77× |
| `(16, 512, 4096)` | None | float16 | 1100.9 | 421.3 | 2.61× |
| `(16, 512, 4096)` | None | float32 | 1840.3 | 709.2 | 2.59× |
| `(256, 256, 256)` | -1 | bfloat16 | 578.1 | 436.8 | 1.32× |
| `(256, 256, 256)` | -1 | float16 | 583.7 | 436.1 | 1.34× |
| `(256, 256, 256)` | -1 | float32 | 1014.3 | 431.5 | 2.35× |
| `(256, 256, 256)` | 0 | bfloat16 | 749.9 | 343.2 | 2.18× |
| `(256, 256, 256)` | 0 | float16 | 753.8 | 341.6 | 2.21× |
| `(256, 256, 256)` | 0 | float32 | 1142.2 | 407.4 | 2.80× |
| `(256, 256, 256)` | None | bfloat16 | 638.8 | 300.1 | 2.13× |
| `(256, 256, 256)` | None | float16 | 643.6 | 297.7 | 2.16× |
| `(256, 256, 256)` | None | float32 | 1053.9 | 402.9 | 2.62× |
| `(1024, 4096)` | -1 | bfloat16 | 231.5 | 135.0 | 1.71× |
| `(4096, 1024)` | -1 | bfloat16 | 222.9 | 139.3 | 1.60× |
| `(1024, 4096)` | -1 | float16 | 225.5 | 135.6 | 1.66× |
| `(4096, 1024)` | -1 | float16 | 226.8 | 142.0 | 1.60× |
| `(4096, 1024)` | -1 | float32 | 319.3 | 147.1 | 2.17× |
| `(1024, 4096)` | -1 | float32 | 333.2 | 148.6 | 2.24× |
| `(1024, 4096)` | 0 | bfloat16 | 248.4 | 135.4 | 1.83× |
| `(4096, 1024)` | 0 | bfloat16 | 266.2 | 160.8 | 1.66× |
| `(1024, 4096)` | 0 | float16 | 231.2 | 139.0 | 1.66× |
| `(4096, 1024)` | 0 | float16 | 259.1 | 158.3 | 1.64× |
| `(1024, 4096)` | 0 | float32 | 327.0 | 156.7 | 2.09× |
| `(4096, 1024)` | 0 | float32 | 356.0 | 153.0 | 2.33× |
| `(4096, 1024)` | None | bfloat16 | 253.9 | 168.3 | 1.51× |
| `(1024, 4096)` | None | bfloat16 | 245.2 | 162.9 | 1.51× |
| `(4096, 1024)` | None | float16 | 256.2 | 167.5 | 1.53× |
| `(1024, 4096)` | None | float16 | 246.5 | 165.7 | 1.49× |
| `(4096, 1024)` | None | float32 | 347.7 | 170.8 | 2.04× |
| `(1024, 4096)` | None | float32 | 345.9 | 174.4 | 1.98× |
| `(1048576,)` | -1 | bfloat16 | 171.0 | 120.9 | 1.41× |
| `(1048576,)` | -1 | float16 | 166.6 | 122.0 | 1.37× |
| `(1048576,)` | -1 | float32 | 172.7 | 123.7 | 1.40× |
| `(1048576,)` | 0 | bfloat16 | 166.2 | 120.2 | 1.38× |
| `(1048576,)` | 0 | float16 | 166.1 | 122.1 | 1.36× |
| `(1048576,)` | 0 | float32 | 172.4 | 118.8 | 1.45× |
| `(1048576,)` | None | bfloat16 | 161.9 | 120.0 | 1.35× |
| `(1048576,)` | None | float16 | 166.5 | 119.6 | 1.39× |
| `(1048576,)` | None | float32 | 170.5 | 123.9 | 1.38× |
| `(128, 256)` | -1 | bfloat16 | 145.8 | 96.9 | 1.50× |
| `(128, 256)` | -1 | float16 | 145.0 | 90.5 | 1.60× |
| `(128, 256)` | -1 | float32 | 148.1 | 95.0 | 1.56× |
| `(128, 256)` | 0 | bfloat16 | 145.6 | 96.8 | 1.50× |
| `(128, 256)` | 0 | float16 | 147.1 | 93.9 | 1.57× |
| `(128, 256)` | 0 | float32 | 139.3 | 95.2 | 1.46× |
| `(128, 256)` | None | bfloat16 | 157.4 | 97.8 | 1.61× |
| `(128, 256)` | None | float16 | 161.1 | 101.4 | 1.59× |
| `(128, 256)` | None | float32 | 156.3 | 96.8 | 1.62× |

</details>

<details>
<summary><b>std_mean</b> — 63 cells (click to expand)</summary>

| shape | dim | dtype | base µs | PR µs | speedup |
|---|---|---|---:|---:|---:|
| `(8, 2048, 4096)` | -1 | bfloat16 | 1896.7 | 750.5 | 2.53× |
| `(8, 2048, 4096)` | -1 | float16 | 1939.9 | 740.9 | 2.62× |
| `(8, 2048, 4096)` | -1 | float32 | 3414.9 | 1241.5 | 2.75× |
| `(8, 2048, 4096)` | 0 | bfloat16 | 2696.0 | 1753.7 | 1.54× |
| `(8, 2048, 4096)` | 0 | float16 | 2764.1 | 1742.1 | 1.59× |
| `(8, 2048, 4096)` | 0 | float32 | 4469.3 | 1900.2 | 2.35× |
| `(8, 2048, 4096)` | None | bfloat16 | 1950.9 | 749.2 | 2.60× |
| `(8, 2048, 4096)` | None | float16 | 2010.2 | 746.5 | 2.69× |
| `(8, 2048, 4096)` | None | float32 | 3465.1 | 1232.9 | 2.81× |
| `(16, 512, 4096)` | -1 | bfloat16 | 1036.2 | 411.8 | 2.52× |
| `(16, 512, 4096)` | -1 | float16 | 1050.6 | 410.3 | 2.56× |
| `(16, 512, 4096)` | -1 | float32 | 1888.0 | 731.6 | 2.58× |
| `(16, 512, 4096)` | 0 | bfloat16 | 1275.7 | 703.2 | 1.81× |
| `(16, 512, 4096)` | 0 | float16 | 1278.2 | 688.0 | 1.86× |
| `(16, 512, 4096)` | 0 | float32 | 2278.1 | 918.5 | 2.48× |
| `(16, 512, 4096)` | None | bfloat16 | 1072.2 | 419.0 | 2.56× |
| `(16, 512, 4096)` | None | float16 | 1096.9 | 417.6 | 2.63× |
| `(16, 512, 4096)` | None | float32 | 1928.3 | 712.6 | 2.71× |
| `(256, 256, 256)` | -1 | bfloat16 | 604.5 | 425.0 | 1.42× |
| `(256, 256, 256)` | -1 | float16 | 586.5 | 427.7 | 1.37× |
| `(256, 256, 256)` | -1 | float32 | 1015.5 | 430.2 | 2.36× |
| `(256, 256, 256)` | 0 | bfloat16 | 746.3 | 336.5 | 2.22× |
| `(256, 256, 256)` | 0 | float16 | 756.7 | 341.4 | 2.22× |
| `(256, 256, 256)` | 0 | float32 | 1137.5 | 407.2 | 2.79× |
| `(256, 256, 256)` | None | bfloat16 | 657.9 | 294.8 | 2.23× |
| `(256, 256, 256)` | None | float16 | 684.9 | 294.2 | 2.33× |
| `(256, 256, 256)` | None | float32 | 1072.1 | 403.5 | 2.66× |
| `(4096, 1024)` | -1 | bfloat16 | 222.2 | 139.6 | 1.59× |
| `(1024, 4096)` | -1 | bfloat16 | 221.1 | 142.3 | 1.55× |
| `(4096, 1024)` | -1 | float16 | 218.3 | 137.6 | 1.59× |
| `(1024, 4096)` | -1 | float16 | 231.0 | 136.9 | 1.69× |
| `(4096, 1024)` | -1 | float32 | 319.6 | 150.3 | 2.13× |
| `(1024, 4096)` | -1 | float32 | 333.6 | 155.1 | 2.15× |
| `(4096, 1024)` | 0 | bfloat16 | 255.0 | 152.7 | 1.67× |
| `(1024, 4096)` | 0 | bfloat16 | 244.0 | 139.2 | 1.75× |
| `(4096, 1024)` | 0 | float16 | 259.0 | 156.1 | 1.66× |
| `(1024, 4096)` | 0 | float16 | 245.5 | 142.7 | 1.72× |
| `(4096, 1024)` | 0 | float32 | 334.2 | 152.2 | 2.20× |
| `(1024, 4096)` | 0 | float32 | 331.0 | 157.1 | 2.11× |
| `(1024, 4096)` | None | bfloat16 | 239.4 | 171.3 | 1.40× |
| `(4096, 1024)` | None | bfloat16 | 248.4 | 158.1 | 1.57× |
| `(4096, 1024)` | None | float16 | 253.0 | 161.1 | 1.57× |
| `(1024, 4096)` | None | float16 | 252.9 | 170.1 | 1.49× |
| `(4096, 1024)` | None | float32 | 347.5 | 179.6 | 1.93× |
| `(1024, 4096)` | None | float32 | 346.1 | 176.7 | 1.96× |
| `(1048576,)` | -1 | bfloat16 | 167.7 | 118.8 | 1.41× |
| `(1048576,)` | -1 | float16 | 166.1 | 116.8 | 1.42× |
| `(1048576,)` | -1 | float32 | 170.4 | 118.1 | 1.44× |
| `(1048576,)` | 0 | bfloat16 | 165.7 | 119.1 | 1.39× |
| `(1048576,)` | 0 | float16 | 165.7 | 117.8 | 1.41× |
| `(1048576,)` | 0 | float32 | 167.6 | 118.0 | 1.42× |
| `(1048576,)` | None | bfloat16 | 167.1 | 113.9 | 1.47× |
| `(1048576,)` | None | float16 | 164.6 | 123.8 | 1.33× |
| `(1048576,)` | None | float32 | 171.7 | 119.4 | 1.44× |
| `(128, 256)` | -1 | bfloat16 | 141.5 | 97.6 | 1.45× |
| `(128, 256)` | -1 | float16 | 149.0 | 94.7 | 1.57× |
| `(128, 256)` | -1 | float32 | 167.5 | 97.4 | 1.72× |
| `(128, 256)` | 0 | bfloat16 | 150.1 | 96.0 | 1.56× |
| `(128, 256)` | 0 | float16 | 142.0 | 100.7 | 1.41× |
| `(128, 256)` | 0 | float32 | 160.9 | 99.0 | 1.63× |
| `(128, 256)` | None | bfloat16 | 165.8 | 101.2 | 1.64× |
| `(128, 256)` | None | float16 | 157.0 | 103.1 | 1.52× |
| `(128, 256)` | None | float32 | 159.6 | 97.5 | 1.64× |

</details>

<details>
<summary><b>argmax</b> — 63 cells (click to expand)</summary>

| shape | dim | dtype | base µs | PR µs | speedup |
|---|---|---|---:|---:|---:|
| `(8, 2048, 4096)` | -1 | bfloat16 | 3671.8 | 811.5 | 4.52× |
| `(8, 2048, 4096)` | -1 | float16 | 1653.9 | 815.8 | 2.03× |
| `(8, 2048, 4096)` | -1 | float32 | 1681.8 | 1235.1 | 1.36× |
| `(8, 2048, 4096)` | 0 | bfloat16 | 548000.1 | 9411.8 | 58.22× |
| `(8, 2048, 4096)` | 0 | float16 | 550225.2 | 9242.0 | 59.54× |
| `(8, 2048, 4096)` | 0 | float32 | 545728.4 | 9231.9 | 59.11× |
| `(8, 2048, 4096)` | None | bfloat16 | 21141.5 | 735.3 | 28.75× |
| `(8, 2048, 4096)` | None | float16 | 19130.2 | 737.5 | 25.94× |
| `(8, 2048, 4096)` | None | float32 | 19377.1 | 1223.7 | 15.83× |
| `(16, 512, 4096)` | -1 | bfloat16 | 1909.8 | 467.5 | 4.09× |
| `(16, 512, 4096)` | -1 | float16 | 943.5 | 458.1 | 2.06× |
| `(16, 512, 4096)` | -1 | float32 | 939.1 | 724.9 | 1.30× |
| `(16, 512, 4096)` | 0 | bfloat16 | 137379.6 | 2787.0 | 49.29× |
| `(16, 512, 4096)` | 0 | float16 | 136585.6 | 2778.5 | 49.16× |
| `(16, 512, 4096)` | 0 | float32 | 136441.5 | 2778.2 | 49.11× |
| `(16, 512, 4096)` | None | bfloat16 | 10643.9 | 391.0 | 27.22× |
| `(16, 512, 4096)` | None | float16 | 9658.3 | 412.9 | 23.39× |
| `(16, 512, 4096)` | None | float32 | 9782.6 | 710.0 | 13.78× |
| `(256, 256, 256)` | -1 | bfloat16 | 1674.9 | 339.1 | 4.94× |
| `(256, 256, 256)` | -1 | float16 | 1238.5 | 339.0 | 3.65× |
| `(256, 256, 256)` | -1 | float32 | 1235.8 | 392.6 | 3.15× |
| `(256, 256, 256)` | 0 | bfloat16 | 1978.3 | 328.7 | 6.02× |
| `(256, 256, 256)` | 0 | float16 | 1417.3 | 334.0 | 4.24× |
| `(256, 256, 256)` | 0 | float32 | 1552.8 | 435.0 | 3.57× |
| `(256, 256, 256)` | None | bfloat16 | 5349.9 | 271.7 | 19.69× |
| `(256, 256, 256)` | None | float16 | 4926.9 | 263.1 | 18.73× |
| `(256, 256, 256)` | None | float32 | 4973.4 | 398.5 | 12.48× |
| `(1024, 4096)` | -1 | bfloat16 | 268.8 | 140.1 | 1.92× |
| `(4096, 1024)` | -1 | bfloat16 | 294.1 | 125.4 | 2.35× |
| `(1024, 4096)` | -1 | float16 | 152.6 | 135.4 | 1.13× |
| `(4096, 1024)` | -1 | float16 | 180.4 | 130.0 | 1.39× |
| `(1024, 4096)` | -1 | float32 | 206.2 | 160.7 | 1.28× |
| `(4096, 1024)` | -1 | float32 | 208.5 | 156.4 | 1.33× |
| `(1024, 4096)` | 0 | bfloat16 | 364.0 | 133.3 | 2.73× |
| `(4096, 1024)` | 0 | bfloat16 | 413.6 | 140.8 | 2.94× |
| `(1024, 4096)` | 0 | float16 | 271.9 | 131.3 | 2.07× |
| `(4096, 1024)` | 0 | float16 | 280.2 | 131.8 | 2.13× |
| `(4096, 1024)` | 0 | float32 | 352.1 | 161.0 | 2.19× |
| `(1024, 4096)` | 0 | float32 | 301.8 | 156.8 | 1.92× |
| `(1024, 4096)` | None | bfloat16 | 1273.0 | 133.1 | 9.56× |
| `(4096, 1024)` | None | bfloat16 | 1268.7 | 139.9 | 9.07× |
| `(1024, 4096)` | None | float16 | 1100.7 | 132.2 | 8.33× |
| `(4096, 1024)` | None | float16 | 1085.8 | 135.2 | 8.03× |
| `(4096, 1024)` | None | float32 | 1323.7 | 163.1 | 8.12× |
| `(1024, 4096)` | None | float32 | 1317.0 | 150.4 | 8.76× |
| `(1048576,)` | -1 | bfloat16 | 336.2 | 109.0 | 3.08× |
| `(1048576,)` | -1 | float16 | 368.2 | 113.5 | 3.24× |
| `(1048576,)` | -1 | float32 | 386.5 | 115.4 | 3.35× |
| `(1048576,)` | 0 | bfloat16 | 332.3 | 106.8 | 3.11× |
| `(1048576,)` | 0 | float16 | 370.5 | 111.6 | 3.32× |
| `(1048576,)` | 0 | float32 | 362.4 | 115.1 | 3.15× |
| `(1048576,)` | None | bfloat16 | 337.8 | 103.0 | 3.28× |
| `(1048576,)` | None | float16 | 370.1 | 108.9 | 3.40× |
| `(1048576,)` | None | float32 | 363.9 | 115.4 | 3.15× |
| `(128, 256)` | -1 | bfloat16 | 128.7 | 93.9 | 1.37× |
| `(128, 256)` | -1 | float16 | 116.2 | 89.6 | 1.30× |
| `(128, 256)` | -1 | float32 | 117.4 | 96.7 | 1.21× |
| `(128, 256)` | 0 | bfloat16 | 120.0 | 98.7 | 1.22× |
| `(128, 256)` | 0 | float16 | 118.3 | 94.7 | 1.25× |
| `(128, 256)` | 0 | float32 | 117.0 | 90.7 | 1.29× |
| `(128, 256)` | None | bfloat16 | 137.1 | 96.5 | 1.42× |
| `(128, 256)` | None | float16 | 128.3 | 92.2 | 1.39× |
| `(128, 256)` | None | float32 | 125.7 | 90.5 | 1.39× |

</details>

<details>
<summary><b>argmin</b> — 63 cells (click to expand)</summary>

| shape | dim | dtype | base µs | PR µs | speedup |
|---|---|---|---:|---:|---:|
| `(8, 2048, 4096)` | -1 | bfloat16 | 3676.3 | 818.3 | 4.49× |
| `(8, 2048, 4096)` | -1 | float16 | 1658.4 | 813.5 | 2.04× |
| `(8, 2048, 4096)` | -1 | float32 | 1675.8 | 1242.8 | 1.35× |
| `(8, 2048, 4096)` | 0 | bfloat16 | 547962.8 | 9269.6 | 59.11× |
| `(8, 2048, 4096)` | 0 | float16 | 547038.5 | 9284.3 | 58.92× |
| `(8, 2048, 4096)` | 0 | float32 | 545695.2 | 9223.6 | 59.16× |
| `(8, 2048, 4096)` | None | bfloat16 | 21141.4 | 727.9 | 29.05× |
| `(8, 2048, 4096)` | None | float16 | 19129.3 | 732.7 | 26.11× |
| `(8, 2048, 4096)` | None | float32 | 19382.3 | 1309.4 | 14.80× |
| `(16, 512, 4096)` | -1 | bfloat16 | 1926.8 | 465.2 | 4.14× |
| `(16, 512, 4096)` | -1 | float16 | 927.2 | 461.8 | 2.01× |
| `(16, 512, 4096)` | -1 | float32 | 945.0 | 734.4 | 1.29× |
| `(16, 512, 4096)` | 0 | bfloat16 | 137337.1 | 2782.4 | 49.36× |
| `(16, 512, 4096)` | 0 | float16 | 136575.2 | 2784.1 | 49.06× |
| `(16, 512, 4096)` | 0 | float32 | 136298.2 | 2785.8 | 48.93× |
| `(16, 512, 4096)` | None | bfloat16 | 10668.6 | 407.5 | 26.18× |
| `(16, 512, 4096)` | None | float16 | 9649.2 | 407.6 | 23.67× |
| `(16, 512, 4096)` | None | float32 | 9788.3 | 704.6 | 13.89× |
| `(256, 256, 256)` | -1 | bfloat16 | 1674.9 | 335.8 | 4.99× |
| `(256, 256, 256)` | -1 | float16 | 1247.1 | 342.4 | 3.64× |
| `(256, 256, 256)` | -1 | float32 | 1236.2 | 403.6 | 3.06× |
| `(256, 256, 256)` | 0 | bfloat16 | 1982.4 | 336.4 | 5.89× |
| `(256, 256, 256)` | 0 | float16 | 1408.7 | 340.6 | 4.14× |
| `(256, 256, 256)` | 0 | float32 | 1541.2 | 418.0 | 3.69× |
| `(256, 256, 256)` | None | bfloat16 | 5348.1 | 268.4 | 19.93× |
| `(256, 256, 256)` | None | float16 | 4938.1 | 270.0 | 18.29× |
| `(256, 256, 256)` | None | float32 | 4975.0 | 402.6 | 12.36× |
| `(4096, 1024)` | -1 | bfloat16 | 276.1 | 126.2 | 2.19× |
| `(1024, 4096)` | -1 | bfloat16 | 271.5 | 139.3 | 1.95× |
| `(4096, 1024)` | -1 | float16 | 178.3 | 125.8 | 1.42× |
| `(1024, 4096)` | -1 | float16 | 162.1 | 132.3 | 1.23× |
| `(1024, 4096)` | -1 | float32 | 213.9 | 157.3 | 1.36× |
| `(4096, 1024)` | -1 | float32 | 180.8 | 154.6 | 1.17× |
| `(1024, 4096)` | 0 | bfloat16 | 377.6 | 128.2 | 2.95× |
| `(4096, 1024)` | 0 | bfloat16 | 404.9 | 134.9 | 3.00× |
| `(1024, 4096)` | 0 | float16 | 270.9 | 125.4 | 2.16× |
| `(4096, 1024)` | 0 | float16 | 280.3 | 132.8 | 2.11× |
| `(1024, 4096)` | 0 | float32 | 302.1 | 162.3 | 1.86× |
| `(4096, 1024)` | 0 | float32 | 341.1 | 156.6 | 2.18× |
| `(4096, 1024)` | None | bfloat16 | 1216.7 | 134.4 | 9.06× |
| `(1024, 4096)` | None | bfloat16 | 1262.2 | 131.1 | 9.63× |
| `(4096, 1024)` | None | float16 | 1076.5 | 138.9 | 7.75× |
| `(1024, 4096)` | None | float16 | 1094.8 | 131.9 | 8.30× |
| `(4096, 1024)` | None | float32 | 1322.3 | 158.6 | 8.34× |
| `(1024, 4096)` | None | float32 | 1326.0 | 150.6 | 8.81× |
| `(1048576,)` | -1 | bfloat16 | 325.7 | 113.9 | 2.86× |
| `(1048576,)` | -1 | float16 | 365.6 | 106.7 | 3.42× |
| `(1048576,)` | -1 | float32 | 370.3 | 110.5 | 3.35× |
| `(1048576,)` | 0 | bfloat16 | 320.4 | 107.6 | 2.98× |
| `(1048576,)` | 0 | float16 | 362.3 | 109.2 | 3.32× |
| `(1048576,)` | 0 | float32 | 368.6 | 115.5 | 3.19× |
| `(1048576,)` | None | bfloat16 | 324.2 | 104.9 | 3.09× |
| `(1048576,)` | None | float16 | 365.3 | 110.7 | 3.30× |
| `(1048576,)` | None | float32 | 359.4 | 114.3 | 3.15× |
| `(128, 256)` | -1 | bfloat16 | 124.8 | 89.8 | 1.39× |
| `(128, 256)` | -1 | float16 | 116.1 | 92.8 | 1.25× |
| `(128, 256)` | -1 | float32 | 116.7 | 93.9 | 1.24× |
| `(128, 256)` | 0 | bfloat16 | 120.6 | 94.7 | 1.27× |
| `(128, 256)` | 0 | float16 | 120.4 | 94.1 | 1.28× |
| `(128, 256)` | 0 | float32 | 118.4 | 93.8 | 1.26× |
| `(128, 256)` | None | bfloat16 | 134.9 | 92.2 | 1.46× |
| `(128, 256)` | None | float16 | 132.9 | 95.0 | 1.40× |
| `(128, 256)` | None | float32 | 133.8 | 92.1 | 1.45× |

</details>

<details>
<summary><b>max</b> — 42 cells (click to expand)</summary>

| shape | dim | dtype | base µs | PR µs | speedup |
|---|---|---|---:|---:|---:|
| `(8, 2048, 4096)` | -1 | bfloat16 | 4188.3 | 805.8 | 5.20× |
| `(8, 2048, 4096)` | -1 | float16 | 2249.6 | 824.1 | 2.73× |
| `(8, 2048, 4096)` | -1 | float32 | 2725.0 | 1244.5 | 2.19× |
| `(8, 2048, 4096)` | 0 | bfloat16 | 548294.5 | 9274.3 | 59.12× |
| `(8, 2048, 4096)` | 0 | float16 | 547569.8 | 9266.6 | 59.09× |
| `(8, 2048, 4096)` | 0 | float32 | 547313.9 | 9248.9 | 59.18× |
| `(16, 512, 4096)` | -1 | bfloat16 | 2193.3 | 467.9 | 4.69× |
| `(16, 512, 4096)` | -1 | float16 | 1214.2 | 463.6 | 2.62× |
| `(16, 512, 4096)` | -1 | float32 | 1471.0 | 735.0 | 2.00× |
| `(16, 512, 4096)` | 0 | bfloat16 | 137718.9 | 2792.5 | 49.32× |
| `(16, 512, 4096)` | 0 | float16 | 137052.6 | 2789.9 | 49.12× |
| `(16, 512, 4096)` | 0 | float32 | 136874.5 | 2792.7 | 49.01× |
| `(256, 256, 256)` | -1 | bfloat16 | 1811.0 | 343.8 | 5.27× |
| `(256, 256, 256)` | -1 | float16 | 1389.2 | 340.4 | 4.08× |
| `(256, 256, 256)` | -1 | float32 | 1510.4 | 400.8 | 3.77× |
| `(256, 256, 256)` | 0 | bfloat16 | 2159.8 | 333.0 | 6.49× |
| `(256, 256, 256)` | 0 | float16 | 1580.8 | 339.5 | 4.66× |
| `(256, 256, 256)` | 0 | float32 | 1843.9 | 415.7 | 4.44× |
| `(1024, 4096)` | -1 | bfloat16 | 305.3 | 136.7 | 2.23× |
| `(4096, 1024)` | -1 | bfloat16 | 302.8 | 127.4 | 2.38× |
| `(4096, 1024)` | -1 | float16 | 231.7 | 124.0 | 1.87× |
| `(1024, 4096)` | -1 | float16 | 217.1 | 139.1 | 1.56× |
| `(4096, 1024)` | -1 | float32 | 264.4 | 157.4 | 1.68× |
| `(1024, 4096)` | -1 | float32 | 256.0 | 156.4 | 1.64× |
| `(4096, 1024)` | 0 | bfloat16 | 465.2 | 141.2 | 3.29× |
| `(1024, 4096)` | 0 | bfloat16 | 414.9 | 134.9 | 3.08× |
| `(4096, 1024)` | 0 | float16 | 319.8 | 136.5 | 2.34× |
| `(1024, 4096)` | 0 | float16 | 293.6 | 136.2 | 2.16× |
| `(4096, 1024)` | 0 | float32 | 397.9 | 163.2 | 2.44× |
| `(1024, 4096)` | 0 | float32 | 350.2 | 173.4 | 2.02× |
| `(1048576,)` | -1 | bfloat16 | 348.3 | 111.5 | 3.12× |
| `(1048576,)` | -1 | float16 | 296.8 | 112.4 | 2.64× |
| `(1048576,)` | -1 | float32 | 301.8 | 117.7 | 2.56× |
| `(1048576,)` | 0 | bfloat16 | 340.4 | 110.9 | 3.07× |
| `(1048576,)` | 0 | float16 | 299.2 | 111.3 | 2.69× |
| `(1048576,)` | 0 | float32 | 292.9 | 112.9 | 2.60× |
| `(128, 256)` | -1 | bfloat16 | 134.8 | 90.1 | 1.50× |
| `(128, 256)` | -1 | float16 | 130.3 | 91.6 | 1.42× |
| `(128, 256)` | -1 | float32 | 126.0 | 90.7 | 1.39× |
| `(128, 256)` | 0 | bfloat16 | 132.4 | 92.6 | 1.43× |
| `(128, 256)` | 0 | float16 | 130.4 | 90.0 | 1.45× |
| `(128, 256)` | 0 | float32 | 131.6 | 91.2 | 1.44× |

</details>

<details>
<summary><b>min</b> — 42 cells (click to expand)</summary>

| shape | dim | dtype | base µs | PR µs | speedup |
|---|---|---|---:|---:|---:|
| `(8, 2048, 4096)` | -1 | bfloat16 | 4248.5 | 816.1 | 5.21× |
| `(8, 2048, 4096)` | -1 | float16 | 2307.9 | 818.0 | 2.82× |
| `(8, 2048, 4096)` | -1 | float32 | 2903.3 | 1238.0 | 2.35× |
| `(8, 2048, 4096)` | 0 | bfloat16 | 567531.0 | 9294.8 | 61.06× |
| `(8, 2048, 4096)` | 0 | float16 | 559528.2 | 9261.7 | 60.41× |
| `(8, 2048, 4096)` | 0 | float32 | 568202.7 | 9241.9 | 61.48× |
| `(16, 512, 4096)` | -1 | bfloat16 | 2225.3 | 463.5 | 4.80× |
| `(16, 512, 4096)` | -1 | float16 | 1221.8 | 454.3 | 2.69× |
| `(16, 512, 4096)` | -1 | float32 | 1507.3 | 732.1 | 2.06× |
| `(16, 512, 4096)` | 0 | bfloat16 | 140109.8 | 2795.3 | 50.12× |
| `(16, 512, 4096)` | 0 | float16 | 139931.7 | 2795.5 | 50.06× |
| `(16, 512, 4096)` | 0 | float32 | 139395.6 | 2797.2 | 49.83× |
| `(256, 256, 256)` | -1 | bfloat16 | 1798.2 | 348.5 | 5.16× |
| `(256, 256, 256)` | -1 | float16 | 1370.8 | 345.2 | 3.97× |
| `(256, 256, 256)` | -1 | float32 | 1520.0 | 395.5 | 3.84× |
| `(256, 256, 256)` | 0 | bfloat16 | 2133.9 | 332.6 | 6.42× |
| `(256, 256, 256)` | 0 | float16 | 1575.9 | 333.3 | 4.73× |
| `(256, 256, 256)` | 0 | float32 | 1851.1 | 410.3 | 4.51× |
| `(1024, 4096)` | -1 | bfloat16 | 305.6 | 144.8 | 2.11× |
| `(4096, 1024)` | -1 | bfloat16 | 307.2 | 133.6 | 2.30× |
| `(1024, 4096)` | -1 | float16 | 180.1 | 144.8 | 1.24× |
| `(4096, 1024)` | -1 | float16 | 222.1 | 128.7 | 1.73× |
| `(4096, 1024)` | -1 | float32 | 262.9 | 166.4 | 1.58× |
| `(1024, 4096)` | -1 | float32 | 247.0 | 164.1 | 1.51× |
| `(4096, 1024)` | 0 | bfloat16 | 462.5 | 132.5 | 3.49× |
| `(1024, 4096)` | 0 | bfloat16 | 400.3 | 135.7 | 2.95× |
| `(1024, 4096)` | 0 | float16 | 292.6 | 133.9 | 2.18× |
| `(4096, 1024)` | 0 | float16 | 319.9 | 134.0 | 2.39× |
| `(4096, 1024)` | 0 | float32 | 394.6 | 160.2 | 2.46× |
| `(1024, 4096)` | 0 | float32 | 343.2 | 167.9 | 2.04× |
| `(1048576,)` | -1 | bfloat16 | 336.2 | 110.8 | 3.03× |
| `(1048576,)` | -1 | float16 | 303.4 | 109.2 | 2.78× |
| `(1048576,)` | -1 | float32 | 298.7 | 115.1 | 2.59× |
| `(1048576,)` | 0 | bfloat16 | 343.1 | 112.2 | 3.06× |
| `(1048576,)` | 0 | float16 | 300.8 | 112.9 | 2.66× |
| `(1048576,)` | 0 | float32 | 297.0 | 114.3 | 2.60× |
| `(128, 256)` | -1 | bfloat16 | 131.8 | 98.5 | 1.34× |
| `(128, 256)` | -1 | float16 | 126.0 | 94.2 | 1.34× |
| `(128, 256)` | -1 | float32 | 127.9 | 93.4 | 1.37× |
| `(128, 256)` | 0 | bfloat16 | 130.7 | 100.7 | 1.30× |
| `(128, 256)` | 0 | float16 | 124.2 | 99.6 | 1.25× |
| `(128, 256)` | 0 | float32 | 128.1 | 91.7 | 1.40× |

</details>
## Test plan

Full `--mps` CI locally on an M4 Pro (`PYTORCH_TESTING_DEVICE_ONLY_FOR=mps PYTORCH_TEST_WITH_SLOW=1 python test/run_test.py --mps --keep-going`): test_mps (incl. TestConsistencyMPS op-consistency for all reduce ops), test_ops, test_nn, test_modules, test_convolution, test_pooling, test_view_ops, test_dropout, and the inductor suite — no new failures versus the baseline build. Includes test_GroupNorm_numeric_mps (exercises the inner Welford kernel at small M / huge N). Benchmark harness: benchmarks/sweep_reduce.py (full sweep + baseline comparison; isolated subprocess per cell to avoid MPSGraph cache pollution).
