### PR TITLE
autograd: add `list_saved_tensors` utility to traverse saved tensors in autograd graph

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -39,7 +39,7 @@ from torch.autograd import (
     Variable,
 )
 from torch.autograd.function import InplaceFunction, once_differentiable
-from torch.autograd.graph import GradientEdge
+from torch.autograd.graph import GradientEdge, list_saved_tensors
 from torch.autograd.profiler import emit_itt, emit_nvtx, profile, record_function
 from torch.autograd.profiler_util import (
     _format_time,
@@ -11181,6 +11181,28 @@ for shape in [(1,), ()]:
             # 3 is saved as a saved tensor because it is a wrapped number, but
             # wrapped numbers should be special cased to not trigger saved variable hooks
             torch.autograd.grad(out, (a,))
+
+    def test_list_saved_tensors(self):
+        self.assertEqual(list_saved_tensors(torch.tensor(1.0)), [])
+
+        x = torch.tensor([-1.0, 2.0, -3.0], requires_grad=True)
+        y = x * x
+        z = torch.relu(y)
+        loss = (z + x).sum()
+
+        result = list_saved_tensors(loss)
+        self.assertEqual(len(result), 2)
+
+        node0, tensors0 = result[0]
+        self.assertEqual(node0.name(), "ReluBackward0")
+        self.assertEqual(len(tensors0), 1)
+        self.assertTrue(torch.equal(tensors0[0], z))
+
+        node1, tensors1 = result[1]
+        self.assertEqual(node1.name(), "MulBackward0")
+        self.assertEqual(len(tensors1), 2)
+        self.assertTrue(torch.equal(tensors1[0], x))
+        self.assertTrue(torch.equal(tensors1[1], x))
 
     def test_graph_save_on_cpu(self):
         def test(get_input, cuda, pin_memory):

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -47,6 +47,7 @@ __all__ = [
     "increment_version",
     "set_warn_on_accumulate_grad_stream_mismatch",
     "set_override_stale_capture_stream",
+    "list_saved_tensors",
 ]
 
 
@@ -917,3 +918,37 @@ def _engine_run_backward(
         if attach_logging_hooks:
             unregister_hooks()  # type: ignore[possibly-undefined]
         torch._C._stash_obj_in_tls("context", None)
+
+
+def list_saved_tensors(
+    tensor: torch.Tensor,
+) -> list[tuple[Node, list[torch.Tensor]]]:
+    result = []
+    seen: set[Node] = set()
+
+    def traverse(node: Node) -> None:
+        if node in seen:
+            return
+        seen.add(node)
+
+        saved = []
+        for attr in dir(node):
+            if not attr.startswith("_saved_"):
+                continue
+            val = getattr(node, attr)
+            if torch.is_tensor(val):
+                saved.append(val)
+            elif isinstance(val, tuple):
+                saved.extend(t for t in val if torch.is_tensor(t))
+
+        if saved:
+            result.append((node, saved))
+
+        for child, _ in node.next_functions:
+            if child is not None:
+                traverse(child)
+
+    if tensor.grad_fn is not None:
+        traverse(tensor.grad_fn)
+
+    return result


### PR DESCRIPTION
Fixes #91692

## Summary

Adds a new public function `torch.autograd.graph.list_saved_tensors(tensor)` that traverses the autograd computation graph from a given tensor and collects all tensors saved by each node for backward propagation.

This is useful for:
- Understanding memory usage during forward pass
- Comparing memory footprint across different configurations (fp32 / bf16 / activation checkpointing)
- Demonstrating the effect of activation checkpointing and CPU offloading

## Usage

```python
loss = model(x).sum()

for node, tensors in torch.autograd.graph.list_saved_tensors(loss):
    print(node.name(), [t.shape for t in tensors])

# Output:
# ReluBackward0 [torch.Size([128, 256])]
# AddmmBackward0 [torch.Size([128, 256]), torch.Size([256, 512])]
Implementation
Traverses the autograd graph via next_functions (DFS) starting from tensor.grad_fn, and for each node collects all attributes starting with _saved_ that are tensors or tuples of tensors.

Test
Added test_list_saved_tensors in test/test_autograd.py.