### PR TITLE
[MPS] Fix channels_last batch_norm backward

### DIFF
--- a/aten/src/ATen/native/mps/operations/Normalization.mm
+++ b/aten/src/ATen/native/mps/operations/Normalization.mm
@@ -98,8 +98,12 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_mps_out(const Tensor& self,
                                                          Tensor& save_var) {
   // Flatten 5D to 4D: MPSGraph normalization is significantly slower for rank-5 tensors.
   // Merging spatial dims is safe since BatchNorm reduces over all dims except channel.
+  // For both contiguous and channels_last_3d inputs the D,H stride pair is compatible
+  // with a single merged dim, so reshape() returns a view (channels_last_3d becomes
+  // a channels_last 4D view, handled by the existing 4D channels-last path). Only
+  // genuinely non-contiguous inputs fall back to a copy.
   if (self.dim() == 5) {
-    auto input_4d = self.contiguous().reshape({self.size(0), self.size(1), self.size(2) * self.size(3), self.size(4)});
+    auto input_4d = self.reshape({self.size(0), self.size(1), self.size(2) * self.size(3), self.size(4)});
     auto output_4d = output.reshape(input_4d.sizes());
     return batch_norm_mps_out(input_4d,
                               weight_opt,
@@ -566,8 +570,8 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
   // Flatten 5D to 4D (see batch_norm_mps_out for rationale).
   if (input.dim() == 5) {
     auto input_4d =
-        input.contiguous().reshape({input.size(0), input.size(1), input.size(2) * input.size(3), input.size(4)});
-    auto grad_out_4d = grad_out.contiguous().reshape(input_4d.sizes());
+        input.reshape({input.size(0), input.size(1), input.size(2) * input.size(3), input.size(4)});
+    auto grad_out_4d = grad_out.reshape(input_4d.sizes());
     auto [gi, gw, gb] = batch_norm_backward_mps(grad_out_4d,
                                                 input_4d,
                                                 weight_opt,
@@ -678,8 +682,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
       int channelsDim = 1;
 
       auto inputTensorOriginal = mpsGraphRankedPlaceHolder(mpsGraph, input_mps_dtype, input_shape);
-      // Shape is the ORIGINAL NCHW shape
-      auto gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_out), input_shape_readonly);
+      auto gradOutputTensorOriginal = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_out), input_shape);
       MPSGraphTensor* weightTensor = nil;
       MPSGraphTensor* weightTensorCasted = nil;
       if (has_weight) {
@@ -706,11 +709,15 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
       MPSGraphTensor* gradWeightTensor = nil;
       MPSGraphTensor* gradBiasTensor = nil;
       MPSGraphTensor* inputTensor = nil;
+      MPSGraphTensor* gradOutputTensor = nil;
 
-      if (memory_format == at::MemoryFormat::Contiguous)
+      if (memory_format == at::MemoryFormat::Contiguous) {
         inputTensor = inputTensorOriginal;
-      else {
-        // Reshape/transpose the input as needed
+        gradOutputTensor = gradOutputTensorOriginal;
+      } else {
+        // Reshape+transpose NHWC inputs to NCHW for the graph computation.
+        // The bound tensors at the placeholder boundary are pre-permuted to NHWC
+        // logical layout so the placeholder shape matches the in-memory dim order.
         auto N = input_shape[0];
         auto H = input_shape[1];
         auto W = input_shape[2];
@@ -721,6 +728,12 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
                                          name:nil];
         inputTensor = [mpsGraph transposeTensor:inputTensor dimension:1 withDimension:2 name:nil];
         inputTensor = [mpsGraph reshapeTensor:inputTensor withShape:@[ N, C, H, W ] name:nil];
+
+        gradOutputTensor = [mpsGraph reshapeTensor:gradOutputTensorOriginal
+                                         withShape:@[ N, ([NSNumber numberWithInt:[H intValue] * [W intValue]]), C ]
+                                              name:nil];
+        gradOutputTensor = [mpsGraph transposeTensor:gradOutputTensor dimension:1 withDimension:2 name:nil];
+        gradOutputTensor = [mpsGraph reshapeTensor:gradOutputTensor withShape:@[ N, C, H, W ] name:nil];
       }
 
       if (train) {
@@ -844,16 +857,15 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
       }
 
       MPSGraphTensor* gradInputTensorFinal = nil;
-
-      if (memory_format == at::MemoryFormat::Contiguous)
+      if (memory_format == at::MemoryFormat::Contiguous) {
         gradInputTensorFinal = gradInputTensor;
-      else {
-        // Reshape/transpose the input as needed
+      } else if (gradInputTensor) {
+        // Reshape+transpose grad_input back to NHWC layout to match the bound
+        // (permuted) grad_input tensor.
         auto N = input_shape[0];
         auto H = input_shape[1];
         auto W = input_shape[2];
         auto C = input_shape[3];
-
         gradInputTensorFinal = [mpsGraph reshapeTensor:gradInputTensor
                                              withShape:@[ N, C, ([NSNumber numberWithInt:[H intValue] * [W intValue]]) ]
                                                   name:nil];
@@ -861,7 +873,7 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
         gradInputTensorFinal = [mpsGraph reshapeTensor:gradInputTensorFinal withShape:@[ N, H, W, C ] name:nil];
       }
 
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
+      newCachedGraph->gradOutputTensor_ = gradOutputTensorOriginal;
       newCachedGraph->inputTensor_ = inputTensorOriginal;
       newCachedGraph->weightTensor_ = weightTensor;
       newCachedGraph->runningMeanTensor_ = runningMeanTensor;
@@ -873,8 +885,15 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
       newCachedGraph->gradBiasTensor_ = gradBiasTensor;
     });
 
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input, input_shape);
-    auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_out, input_shape_readonly);
+    // For channels-last inputs, view the tensor through a permuted NHWC layout
+    // so the binding sees a default-contiguous tensor. Without this, Placeholder's
+    // .view([N,H,W,C]) on a CL-strided tensor with logical shape (N,C,H,W) fails
+    // because PyTorch's view requires row-major stride compatibility.
+    auto bn_input = (memory_format == at::MemoryFormat::ChannelsLast) ? input.permute({0, 2, 3, 1}) : input;
+    auto bn_grad_out =
+        (memory_format == at::MemoryFormat::ChannelsLast) ? grad_out.permute({0, 2, 3, 1}) : grad_out;
+    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, bn_input, input_shape);
+    auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, bn_grad_out, input_shape);
     auto weightPlaceholder = Placeholder();
     if (has_weight)
       weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_opt.value(), new_mean_shape);
@@ -892,8 +911,11 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_mps(const Tensor& grad_ou
     }
 
     auto gradInputPlaceholder = Placeholder();
-    if (grad_input_mask[0])
-      gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input, input_shape);
+    if (grad_input_mask[0]) {
+      auto bn_grad_input =
+          (memory_format == at::MemoryFormat::ChannelsLast) ? grad_input.permute({0, 2, 3, 1}) : grad_input;
+      gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, bn_grad_input, input_shape);
+    }
     auto gradWeightPlaceholder = Placeholder();
     if (grad_input_mask[1])
       gradWeightPlaceholder = Placeholder(cachedGraph->gradWeightTensor_, grad_weight);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2007,6 +2007,53 @@ class TestMPS(TestCaseMPS):
 
         self.assertEqual(res_cpu, res_mps)
 
+    def test_batch_norm_channels_last_backward(self):
+        # Regression test for the channels_last batch_norm backward path on MPS.
+        # Covers BatchNorm2d with channels_last 4D inputs (issue #156792) and
+        # BatchNorm3d with channels_last_3d 5D inputs (the path exposed by
+        # issue #178492's PR #180335 5D->4D flatten). The backward used to fail
+        # with a view-stride incompatibility for channels-last inputs; this test
+        # locks in the fixed forward+backward against a contiguous CPU reference.
+        cases = [
+            ((2, 4, 6, 7), torch.channels_last, nn.BatchNorm2d),
+            ((2, 4, 3, 4, 5), torch.channels_last_3d, nn.BatchNorm3d),
+        ]
+        for shape, mem_fmt, bn_cls in cases:
+            for training in (True, False):
+                for affine in (True, False):
+                    x_cpu = torch.randn(*shape, requires_grad=True)
+                    x_mps = (x_cpu.detach().clone()
+                             .to('mps')
+                             .contiguous(memory_format=mem_fmt)
+                             .requires_grad_())
+                    self.assertTrue(x_mps.is_contiguous(memory_format=mem_fmt))
+
+                    bn_cpu = bn_cls(shape[1], affine=affine).cpu()
+                    bn_mps = bn_cls(shape[1], affine=affine).to('mps')
+                    bn_mps.load_state_dict(bn_cpu.state_dict())
+                    if not training:
+                        bn_cpu.eval()
+                        bn_mps.eval()
+
+                    out_cpu = bn_cpu(x_cpu)
+                    out_mps = bn_mps(x_mps)
+                    self.assertEqual(out_cpu, out_mps)
+                    self.assertTrue(
+                        out_mps.is_contiguous(memory_format=mem_fmt),
+                        f"{bn_cls.__name__} output should preserve {mem_fmt} "
+                        f"(training={training}, affine={affine})",
+                    )
+
+                    grad_out_cpu = torch.randn_like(out_cpu)
+                    grad_out_mps = grad_out_cpu.to('mps').contiguous(memory_format=mem_fmt)
+                    out_cpu.backward(grad_out_cpu)
+                    out_mps.backward(grad_out_mps)
+
+                    self.assertEqual(x_cpu.grad, x_mps.grad)
+                    if affine:
+                        self.assertEqual(bn_cpu.weight.grad, bn_mps.weight.grad)
+                        self.assertEqual(bn_cpu.bias.grad, bn_mps.bias.grad)
+
     def test_batch_norm_backward_weight_bias_gradients(self):
         # See issue: https://github.com/pytorch/pytorch/issues/156555
         N, C, L = 4, 3, 5

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2021,38 +2021,64 @@ class TestMPS(TestCaseMPS):
         for shape, mem_fmt, bn_cls in cases:
             for training in (True, False):
                 for affine in (True, False):
-                    x_cpu = torch.randn(*shape, requires_grad=True)
-                    x_mps = (x_cpu.detach().clone()
-                             .to('mps')
-                             .contiguous(memory_format=mem_fmt)
-                             .requires_grad_())
-                    self.assertTrue(x_mps.is_contiguous(memory_format=mem_fmt))
+                    with self.subTest(bn=bn_cls.__name__, training=training, affine=affine):
+                        torch.manual_seed(0)
+                        x_cpu = torch.randn(*shape, requires_grad=True)
+                        x_mps = (x_cpu.detach().clone()
+                                 .to('mps')
+                                 .contiguous(memory_format=mem_fmt)
+                                 .requires_grad_())
+                        self.assertTrue(x_mps.is_contiguous(memory_format=mem_fmt))
 
-                    bn_cpu = bn_cls(shape[1], affine=affine).cpu()
-                    bn_mps = bn_cls(shape[1], affine=affine).to('mps')
-                    bn_mps.load_state_dict(bn_cpu.state_dict())
-                    if not training:
-                        bn_cpu.eval()
-                        bn_mps.eval()
+                        bn_cpu = bn_cls(shape[1], affine=affine).cpu()
+                        bn_mps = bn_cls(shape[1], affine=affine).to('mps')
+                        bn_mps.load_state_dict(bn_cpu.state_dict())
+                        if not training:
+                            bn_cpu.eval()
+                            bn_mps.eval()
 
-                    out_cpu = bn_cpu(x_cpu)
-                    out_mps = bn_mps(x_mps)
-                    self.assertEqual(out_cpu, out_mps)
-                    self.assertTrue(
-                        out_mps.is_contiguous(memory_format=mem_fmt),
-                        f"{bn_cls.__name__} output should preserve {mem_fmt} "
-                        f"(training={training}, affine={affine})",
-                    )
+                        out_cpu = bn_cpu(x_cpu)
+                        out_mps = bn_mps(x_mps)
+                        self.assertEqual(out_cpu, out_mps)
+                        self.assertTrue(
+                            out_mps.is_contiguous(memory_format=mem_fmt),
+                            f"{bn_cls.__name__} output should preserve {mem_fmt}",
+                        )
 
-                    grad_out_cpu = torch.randn_like(out_cpu)
-                    grad_out_mps = grad_out_cpu.to('mps').contiguous(memory_format=mem_fmt)
-                    out_cpu.backward(grad_out_cpu)
-                    out_mps.backward(grad_out_mps)
+                        grad_out_cpu = torch.randn_like(out_cpu)
+                        grad_out_mps = grad_out_cpu.to('mps').contiguous(memory_format=mem_fmt)
+                        out_cpu.backward(grad_out_cpu)
+                        out_mps.backward(grad_out_mps)
 
-                    self.assertEqual(x_cpu.grad, x_mps.grad)
-                    if affine:
-                        self.assertEqual(bn_cpu.weight.grad, bn_mps.weight.grad)
-                        self.assertEqual(bn_cpu.bias.grad, bn_mps.bias.grad)
+                        self.assertEqual(x_cpu.grad, x_mps.grad)
+                        if affine:
+                            self.assertEqual(bn_cpu.weight.grad, bn_mps.weight.grad)
+                            self.assertEqual(bn_cpu.bias.grad, bn_mps.bias.grad)
+
+    def test_batch_norm_channels_last_backward_no_input_grad(self):
+        # Regression for grad_input_mask=[False, True, True] on a channels_last
+        # input: gradInputTensor stays nil and the NHWC->NCHW transpose dance
+        # in the graph must be skipped. Without the gating guard the dance would
+        # reshape a nil tensor and crash.
+        torch.manual_seed(0)
+        shape = (2, 4, 6, 7)
+        x_cpu = torch.randn(*shape)  # requires_grad=False
+        x_mps = x_cpu.detach().to('mps').contiguous(memory_format=torch.channels_last)
+
+        bn_cpu = nn.BatchNorm2d(shape[1], affine=True).cpu()
+        bn_mps = nn.BatchNorm2d(shape[1], affine=True).to('mps')
+        bn_mps.load_state_dict(bn_cpu.state_dict())
+
+        out_cpu = bn_cpu(x_cpu)
+        out_mps = bn_mps(x_mps)
+
+        grad_out_cpu = torch.randn_like(out_cpu)
+        grad_out_mps = grad_out_cpu.to('mps').contiguous(memory_format=torch.channels_last)
+
+        gw_cpu, gb_cpu = torch.autograd.grad(out_cpu, [bn_cpu.weight, bn_cpu.bias], grad_outputs=grad_out_cpu)
+        gw_mps, gb_mps = torch.autograd.grad(out_mps, [bn_mps.weight, bn_mps.bias], grad_outputs=grad_out_mps)
+        self.assertEqual(gw_cpu, gw_mps)
+        self.assertEqual(gb_cpu, gb_mps)
 
     def test_batch_norm_backward_weight_bias_gradients(self):
         # See issue: https://github.com/pytorch/pytorch/issues/156555

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -3869,8 +3869,6 @@ module_db: list[ModuleInfo] = [
                module_inputs_func=module_inputs_torch_nn_BatchNorm2d,
                module_error_inputs_func=module_error_inputs_torch_nn_BatchNorm1d_2d_3d,
                skips=(
-                   # See https://github.com/pytorch/pytorch/issues/134580
-                   DecorateInfo(expectedFailureMPS, 'TestModule', 'test_memory_format', active_if=operator.itemgetter('training')),
                    # tracking here rather than in the list in test_aotdispatch.py as eval mode passes
                    # RuntimeError: tried to get Double out of SymInt
                    DecorateInfo(


### PR DESCRIPTION
## Summary

Extends the existing `inputTensor` NHWC→NCHW reshape+transpose dance in `batch_norm_backward_mps` to `gradOutputTensor` and `gradInputTensor`, so channels-last inputs route through the same graph path symmetrically. Also drops the now-unnecessary `.contiguous()` from the 5D→4D flatten added in #180335, since the channels-last 4D backward path now actually works.

Result:
- 4D `channels_last` backward: was broken (view-stride error from binding NHWC-strided data with the NCHW logical placeholder); now works.
- 5D `channels_last_3d` backward: no longer pays a ~50 ms layout-conversion copy; ~3.6× faster.

## Test plan
- New `test_batch_norm_channels_last_backward` covers BN2d CL and BN3d CL3D, train/eval × affine on/off.
- All existing MPS `batch_norm` tests pass.

## Benchmark (Apple M5, fp32)
Contig path unchanged. 5D `channels_last_3d` backward at (4, 64, 64, 64, 64): **117 ms → 32 ms**.
