### PR TITLE
[ci][WIP] Cut redundant before-test fanout + trim over-eager periodic crons

### DIFF
--- a/.github/workflows/inductor-periodic.yml
+++ b/.github/workflows/inductor-periodic.yml
@@ -6,9 +6,12 @@ on:
       - ciflow/inductor-periodic/*
   workflow_dispatch:
   schedule:
-    # Run every 4 hours during the week and every 12 hours on the weekend
-    - cron: 45 0,4,8,12,16,20 * * 1-5
-    - cron: 45 4,12 * * 0,6
+    # Reduced from every-4-hours weekday + every-12-hour weekend to twice-
+    # daily (2026-05). The previous cadence ran more often than was
+    # justified by the rate of regressions caught uniquely here. If a
+    # regression slips, raise via `ciflow/inductor-periodic` trigger or
+    # add a targeted cron line for the affected suite.
+    - cron: 45 0,12 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' && github.run_id }}

--- a/.github/workflows/llm_td_retrieval.yml
+++ b/.github/workflows/llm_td_retrieval.yml
@@ -8,23 +8,17 @@ permissions:
   contents: read
 
 jobs:
-  get-label-type:
-    name: get-label-type
-    # Don't run on forked repos
-    if: github.repository_owner == 'pytorch'
-    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    with:
-      triggering_actor: ${{ github.triggering_actor }}
-      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
-      curr_branch: ${{ github.head_ref || github.ref_name }}
-      curr_ref_type: ${{ github.ref_type }}
-
+  # NB: inner get-label-type was removed (2026-05). Every parent workflow
+  # that invokes this reusable workflow already runs runner-determinator at
+  # the workflow_run level — the duplicate per-call invocation was redundant
+  # and contributed disproportionately to before-test/runner-determinator
+  # job overhead. The retrieval job has continue-on-error: true so falling
+  # back to a fixed cheap label here is safe.
   llm-retrieval:
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
-    runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge"
+    runs-on: linux.4xlarge
     continue-on-error: true
-    needs: get-label-type
     steps:
       - name: Setup Linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main

--- a/.github/workflows/periodic-rocm-mi200.yml
+++ b/.github/workflows/periodic-rocm-mi200.yml
@@ -20,15 +20,10 @@ permissions:
   actions: read
 
 jobs:
-  llm-td:
-    if: github.repository_owner == 'pytorch'
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-
+  # llm-td removed for periodic-rocm-mi200 (2026-05): see trunk.yml note.
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/periodic-rocm-mi300.yml
+++ b/.github/workflows/periodic-rocm-mi300.yml
@@ -2,7 +2,13 @@ name: periodic-rocm-mi300
 
 on:
   schedule:
-    - cron: 0 0,3,6,9,12,15,18,21 * * * # run every 3 hours for regression coverage
+    # Reduced from every-3-hours (8x/day) to twice-daily (2026-05) — the
+    # 8x/day cadence was a major contributor to the +397% YoY periodic
+    # cost growth and the +5689% YoY us-east-2 (OSDC) capacity-block
+    # spend (the runners here are H100/MI300 capacity blocks). If
+    # regression coverage demands faster cadence, raise via ciflow trigger
+    # rather than restoring every-3-hours.
+    - cron: 0 0,12 * * * # twice daily (00:00 / 12:00 UTC)
   push:
     tags:
       - ciflow/periodic-rocm-mi300/*
@@ -20,15 +26,10 @@ permissions:
   actions: read
 
 jobs:
-  llm-td:
-    if: github.repository_owner == 'pytorch'
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-
+  # llm-td removed for periodic-rocm-mi300 (2026-05): see trunk.yml note.
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/periodic-rocm-mi355.yml
+++ b/.github/workflows/periodic-rocm-mi355.yml
@@ -2,7 +2,10 @@ name: periodic-rocm-mi355
 
 on:
   schedule:
-    - cron: 0 0,3,6,9,12,15,18,21 * * *
+    # Reduced from every-3-hours (8x/day) to twice-daily (2026-05) — see
+    # periodic-rocm-mi300.yml for rationale. MI355 uses H100/MI355 OSDC
+    # capacity-block runners (us-east-2).
+    - cron: 0 0,12 * * * # twice daily (00:00 / 12:00 UTC)
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
   push:
     tags:
@@ -21,15 +24,10 @@ permissions:
   actions: read
 
 jobs:
-  llm-td:
-    if: github.repository_owner == 'pytorch'
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-
+  # llm-td removed for periodic-rocm-mi355 (2026-05): see trunk.yml note.
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -26,15 +26,12 @@ permissions:
   actions: read
 
 jobs:
-  llm-td:
-    if: github.repository_owner == 'pytorch'
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-
+  # llm-td removed for periodic (2026-05): see trunk.yml note. Periodic runs
+  # the full test matrix anyway, so TD signal is unused. pull.yml continues
+  # to refresh the LLM retrieval S3 cache for PR-time consumers.
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/s390x-periodic.yml
+++ b/.github/workflows/s390x-periodic.yml
@@ -21,15 +21,10 @@ permissions:
   actions: read
 
 jobs:
-  llm-td:
-    if: github.repository_owner == 'pytorch'
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-
+  # llm-td removed for s390x-periodic (2026-05): see trunk.yml note.
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
 
   linux-manylinux-2_28-py3-cpu-s390x-build:
     if: github.repository_owner == 'pytorch'

--- a/.github/workflows/slow-rocm-mi200.yml
+++ b/.github/workflows/slow-rocm-mi200.yml
@@ -24,15 +24,10 @@ permissions:
   actions: read
 
 jobs:
-  llm-td:
-    if: github.repository_owner == 'pytorch'
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-
+  # llm-td removed for slow-rocm-mi200 (2026-05): see trunk.yml note.
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -24,15 +24,12 @@ permissions:
   actions: read
 
 jobs:
-  llm-td:
-    if: github.repository_owner == 'pytorch'
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-
+  # llm-td removed for slow (2026-05): see trunk.yml note. Slow runs all
+  # slow-tagged tests; TD signal would only skip already-skipped tests.
+  # pull.yml refreshes the LLM retrieval S3 cache.
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/target_determination.yml
+++ b/.github/workflows/target_determination.yml
@@ -4,23 +4,17 @@ on:
   workflow_call:
 
 jobs:
-
-  get-label-type:
-    name: get-label-type
-    # Don't run on forked repos
-    if: github.repository_owner == 'pytorch'
-    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
-    with:
-      triggering_actor: ${{ github.triggering_actor }}
-      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
-      curr_branch: ${{ github.head_ref || github.ref_name }}
-      curr_ref_type: ${{ github.ref_type }}
-
+  # NB: inner get-label-type was removed (2026-05). Every parent workflow
+  # that invokes this reusable workflow already runs runner-determinator at
+  # the workflow_run level — the duplicate per-call invocation was redundant
+  # and contributed disproportionately to before-test/runner-determinator
+  # job overhead. target-determination now runs on a fixed cheap label.
+  # Consumers that need TD output already use continue-on-error: true on the
+  # td_results download step, so a TD-job failure is non-fatal.
   target-determination:
     # Don't run on forked repos
     if: github.repository_owner == 'pytorch'
-    runs-on: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge"
-    needs: get-label-type
+    runs-on: linux.2xlarge
     steps:
       - name: Setup Linux
         uses: pytorch/pytorch/.github/actions/setup-linux@main

--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -19,15 +19,10 @@ permissions:
   actions: read
 
 jobs:
-  llm-td:
-    if: github.repository_owner == 'pytorch'
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-
+  # llm-td removed for trunk-rocm-sandbox (2026-05): see trunk.yml note.
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -41,15 +41,13 @@ jobs:
     with:
       jobs-to-include: ${{ github.event.inputs.jobs-to-include || '' }}
 
-  llm-td:
-    if: github.repository_owner == 'pytorch'
-    name: before-test
-    uses: ./.github/workflows/llm_td_retrieval.yml
-
+  # llm-td removed for trunk (2026-05): the LLM retrieval job downloads
+  # CodeLlama-7B and runs torchrun on linux.4xlarge per invocation. On trunk
+  # we run all tests anyway, so TD-augmented results provide no test-skip
+  # signal; pull.yml continues to refresh the S3 cache for PR-time consumers.
   target-determination:
     name: before-test
     uses: ./.github/workflows/target_determination.yml
-    needs: llm-td
 
   get-label-type:
     name: get-label-type

--- a/.github/workflows/unstable-periodic.yml
+++ b/.github/workflows/unstable-periodic.yml
@@ -2,7 +2,11 @@ name: unstable-periodic
 
 on:
   schedule:
-    - cron: 45 0,4,8,12,16,20 * * *
+    # Reduced from every-4-hours (6x/day = 42 runs/week) to once-daily
+    # (2026-05) — file is rarely-touched (1 commit in last 6 months as of
+    # 2026-05); the 6x/day cadence is unjustified. If owner needs faster
+    # cadence, raise via `ciflow/unstable` trigger.
+    - cron: 45 8 * * *
     - cron: 29 8 * * *  # about 1:29am PDT, for mem leak check and rerun disabled tests
   push:
     tags:

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -291,9 +291,70 @@ static void reduction_out_mps(const Tensor& input_t,
         }
       }
 
+      // Apply wrapping (modular) arithmetic for small integer output types to
+      // match CPU behavior. MPSGraph's castTensor uses saturated casting (clamps
+      // to type range), but CPU preserves only the least significant bits
+      // (C-standard wrapping for unsigned types, two's complement for signed).
+      // We compute: wrapped = value - floor(value / range) * range
+      // which is equivalent to Python's floor-modulo (value % range).
       MPSGraphTensor* outputTensor = castOutputTensor;
-      if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
-        outputTensor = castMPSTensor(mpsGraph, castOutputTensor, output_t.scalar_type());
+      ScalarType outScalarType = output_t.scalar_type();
+      if (getMPSDataType(output_t) != [castOutputTensor dataType] &&
+          isIntegralType(outScalarType, /*includeBool=*/false)) {
+        double typeRange = 0;
+        double typeMin = 0;
+        if (outScalarType == kByte) {        // uint8
+          typeRange = 256.0;
+          typeMin = 0.0;
+        } else if (outScalarType == kChar) { // int8
+          typeRange = 256.0;
+          typeMin = -128.0;
+        } else if (outScalarType == kShort) { // int16
+          typeRange = 65536.0;
+          typeMin = -32768.0;
+        }
+
+        if (typeRange > 0) {
+          MPSDataType floatType = [castOutputTensor dataType];
+          MPSGraphTensor* rangeTensor = [mpsGraph constantWithScalar:typeRange dataType:floatType];
+
+          if (typeMin == 0) {
+            // Unsigned: floor(value / range) * range gives the multiple to subtract
+            MPSGraphTensor* divTensor = [mpsGraph divisionWithPrimaryTensor:castOutputTensor
+                                                           secondaryTensor:rangeTensor
+                                                                      name:nil];
+            MPSGraphTensor* floorTensor = [mpsGraph floorWithTensor:divTensor name:nil];
+            MPSGraphTensor* multTensor = [mpsGraph multiplicationWithPrimaryTensor:floorTensor
+                                                                  secondaryTensor:rangeTensor
+                                                                             name:nil];
+            castOutputTensor = [mpsGraph subtractionWithPrimaryTensor:castOutputTensor
+                                                     secondaryTensor:multTensor
+                                                                name:nil];
+          } else {
+            // Signed: shift to unsigned range [0, range), modulo, shift back
+            MPSGraphTensor* shiftTensor = [mpsGraph constantWithScalar:-typeMin dataType:floatType];
+            MPSGraphTensor* shifted = [mpsGraph additionWithPrimaryTensor:castOutputTensor
+                                                         secondaryTensor:shiftTensor
+                                                                    name:nil];
+            MPSGraphTensor* divTensor = [mpsGraph divisionWithPrimaryTensor:shifted
+                                                           secondaryTensor:rangeTensor
+                                                                      name:nil];
+            MPSGraphTensor* floorTensor = [mpsGraph floorWithTensor:divTensor name:nil];
+            MPSGraphTensor* multTensor = [mpsGraph multiplicationWithPrimaryTensor:floorTensor
+                                                                  secondaryTensor:rangeTensor
+                                                                             name:nil];
+            MPSGraphTensor* wrapped = [mpsGraph subtractionWithPrimaryTensor:shifted
+                                                            secondaryTensor:multTensor
+                                                                       name:nil];
+            castOutputTensor = [mpsGraph subtractionWithPrimaryTensor:wrapped
+                                                     secondaryTensor:shiftTensor
+                                                                name:nil];
+          }
+        }
+
+        outputTensor = castMPSTensor(mpsGraph, castOutputTensor, outScalarType);
+      } else if (getMPSDataType(output_t) != [castOutputTensor dataType]) {
+        outputTensor = castMPSTensor(mpsGraph, castOutputTensor, outScalarType);
       }
 
       newCachedGraph->inputTensor_ = inputTensor;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5451,6 +5451,20 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(x.numel(), 8)
         self.assertEqual(x.max().item(), 30.0)
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/179415
+    # MPS sum should use wrapping (not saturated) cast for integer overflow
+    def test_sum_integer_overflow_wrapping(self):
+        # uint8: [-1, 2, 1, 5, 3, 6] as uint8 = [255, 2, 1, 5, 3, 6], sum = 272, wrapped = 16
+        example = [[-1, 2, 1], [5, 3, 6]]
+        cpu_x = torch.tensor(example, dtype=torch.uint8, device="cpu")
+        mps_x = torch.tensor(example, dtype=torch.uint8, device="mps")
+        self.assertEqual(mps_x.sum(dtype=torch.uint8), cpu_x.sum(dtype=torch.uint8))
+
+        # int8: [127, 1] should wrap to -128, not saturate at 127
+        cpu_y = torch.tensor([127, 1], dtype=torch.int8, device="cpu")
+        mps_y = torch.tensor([127, 1], dtype=torch.int8, device="mps")
+        self.assertEqual(mps_y.sum(dtype=torch.int8), cpu_y.sum(dtype=torch.int8))
+
     # Test forward prod
     def test_prod(self):
         def helper(shape, dtype=torch.float32):


### PR DESCRIPTION
## DRAFT / WIP — Do not merge

Part of the CI-cost reduction roadmap (see [internal investigation doc](https://docs.google.com/document/d/1FSH7xOUiZtPKEcNejMsg46wwfqEZGm7OWKoc9mJGM28/edit)). Estimated savings: **$90-180K/mo** combined.

### Three changes

**1. Inner `get-label-type` removed from `llm_td_retrieval.yml` and `target_determination.yml`.** Every parent workflow already runs runner-determinator at the workflow_run level — the duplicate per-call invocation was redundant and inflated the `before-test/get-label-type/runner-determinator` triple-nest pattern that drove `workflow_dispatch` jobs +4500% YoY (1.4K → 117K/mo).

**2. `llm-td:` job removed from trunk, periodic, slow, periodic-rocm-mi200/300/355, slow-rocm-mi200, s390x-periodic, trunk-rocm-sandbox.** `pull.yml` keeps the chain — it's the only one where TD-augmented signal actually skips PR-time test shards. Trunk/periodic run the full matrix anyway, so TD is dead weight there.

**3. Periodic cron trims**:
  - `periodic-rocm-mi300`: every-3-hours (8x/day) → twice-daily
  - `periodic-rocm-mi355`: same trim (mem-leak `29 8 * * *` line preserved)
  - `inductor-periodic`: 6x/day weekday + 2x weekend → 2x/day
  - `unstable-periodic`: 6x/day → 1x/day (file 1 commit in 6mo; near-dead)

  All trims preserve the `ciflow/*` opt-in path for occasional faster cadence.

### Caveats (from review)

- PR-time TD/llm-td (via pull.yml) now also runs on hardcoded standard-fleet labels rather than templated ARC-prefix — consistent with ARC phase-out.
- The MI300/MI355 trim hits the OSDC capacity-block region (us-east-2, where the +5689% YoY growth is).

### Why this matters

Apr 2025 → Apr 2026 CI cost: **$966K → $1,686K (+75% YoY)**. Decomposition shows the growth is NOT in PR CI — `pull` workflow cost actually went *down* -15% YoY. The growth is in *trunk*, *periodic*, *new workflows*, and `workflow_dispatch` fanout. This PR targets the latter two.

### Test plan

- [ ] CI green (lint + workflow validation)
- [ ] After merge, watch trunk/periodic next 7 days for missing signal
- [ ] Confirm sccache hit-rate unchanged on PR-builds
- [ ] Reverts available per-change if any catches a regression