### PR TITLE
[c10d] Fix device_id not propagated through ProcessGroupWrapper

### DIFF
--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -447,6 +447,25 @@ if not TEST_WITH_DEV_DBG_ASAN:
                 )
                 self.assertEqual(tensor.shape, torch.Size([1024]))
 
+        @requires_nccl()
+        @skip_if_lt_x_gpu(2)
+        @with_dist_debug_levels(levels=["DETAIL"])
+        def test_wrapper_forwards_bound_device_id(self):
+            """
+            Tests that ProcessGroupWrapper propagates bound_device_id to the
+            wrapped backend. See issue #178977.
+            """
+            torch.cuda.set_device(self.rank)
+            device = torch.device(f"cuda:{self.rank}")
+            wrapper = self._create_wrapper_pg(with_new_group=False)
+
+            self.assertIsInstance(wrapper, _ProcessGroupWrapper)
+            unwrapped = wrapper.wrapped_pg
+
+            wrapper.bound_device_id = device
+            self.assertEqual(wrapper.bound_device_id, device)
+            self.assertEqual(unwrapped.bound_device_id, device)
+
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)
         @patch(

--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -453,18 +453,23 @@ if not TEST_WITH_DEV_DBG_ASAN:
         def test_wrapper_forwards_bound_device_id(self):
             """
             Tests that ProcessGroupWrapper propagates bound_device_id to the
-            wrapped backend. See issue #178977.
+            wrapped backend when init_process_group is called with device_id.
+            See issue #178977.
             """
             torch.cuda.set_device(self.rank)
             device = torch.device(f"cuda:{self.rank}")
-            wrapper = self._create_wrapper_pg(with_new_group=False)
-
-            self.assertIsInstance(wrapper, _ProcessGroupWrapper)
-            unwrapped = wrapper.wrapped_pg
-
-            wrapper.bound_device_id = device
-            self.assertEqual(wrapper.bound_device_id, device)
-            self.assertEqual(unwrapped.bound_device_id, device)
+            store = c10d.FileStore(self.file_name, self.world_size)
+            c10d.init_process_group(
+                backend=backend,
+                rank=self.rank,
+                world_size=self.world_size,
+                store=store,
+                device_id=device,
+            )
+            pg = c10d.distributed_c10d._get_default_group()
+            pg_backend = pg._get_backend(device)
+            self.assertIsInstance(pg_backend, _ProcessGroupWrapper)
+            self.assertEqual(pg_backend.wrapped_pg.bound_device_id, device)
 
         @requires_accelerator_dist_backend(["nccl", "xccl"])
         @skip_if_lt_x_gpu(2)

--- a/torch/csrc/distributed/c10d/Backend.hpp
+++ b/torch/csrc/distributed/c10d/Backend.hpp
@@ -654,7 +654,7 @@ class TORCH_API Backend : public torch::CustomClassHolder {
   }
 
   // See similar functions in ProcessGroup.hpp for context.
-  std::optional<at::Device> getBoundDeviceId() const {
+  virtual std::optional<at::Device> getBoundDeviceId() const {
     return bound_device_id_;
   }
 
@@ -665,7 +665,7 @@ class TORCH_API Backend : public torch::CustomClassHolder {
     // backends may perform
   }
 
-  void setBoundDeviceId(std::optional<at::Device> device) {
+  virtual void setBoundDeviceId(std::optional<at::Device> device) {
     if (device) {
       TORCH_CHECK(device->has_index(), "setBoundDeviceId must have an index");
     }

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -656,7 +656,6 @@ std::optional<at::Device> ProcessGroupWrapper::getBoundDeviceId() const {
 }
 
 void ProcessGroupWrapper::setBoundDeviceId(std::optional<at::Device> device) {
-  Backend::setBoundDeviceId(device);
   backend_->setBoundDeviceId(device);
 }
 

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -651,6 +651,15 @@ ErrorType ProcessGroupWrapper::getError() {
   return backend_->getError();
 }
 
+std::optional<at::Device> ProcessGroupWrapper::getBoundDeviceId() const {
+  return backend_->getBoundDeviceId();
+}
+
+void ProcessGroupWrapper::setBoundDeviceId(std::optional<at::Device> device) {
+  Backend::setBoundDeviceId(device);
+  backend_->setBoundDeviceId(device);
+}
+
 void ProcessGroupWrapper::eagerConnectSingleDevice(at::Device device) {
   backend_->eagerConnectSingleDevice(device);
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -170,6 +170,8 @@ class TORCH_API ProcessGroupWrapper : public Backend {
   std::unordered_map<std::string, uint64_t> getMemoryStats() override;
 
   ErrorType getError() override;
+  std::optional<at::Device> getBoundDeviceId() const override;
+  void setBoundDeviceId(std::optional<at::Device> device) override;
   void eagerConnectSingleDevice(at::Device device) override;
 
   c10::intrusive_ptr<Backend> getWrappedPg() const;

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3016,10 +3016,6 @@ Arguments:
           .def("rank", &::c10d::Backend::getRank)
           .def("size", &::c10d::Backend::getSize)
           .def("name", &::c10d::Backend::getBackendName)
-          .def_property(
-              "bound_device_id",
-              &::c10d::Backend::getBoundDeviceId,
-              &::c10d::Backend::setBoundDeviceId)
           .def(
               "abort",
               &::c10d::Backend::abort,

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -3016,6 +3016,10 @@ Arguments:
           .def("rank", &::c10d::Backend::getRank)
           .def("size", &::c10d::Backend::getSize)
           .def("name", &::c10d::Backend::getBackendName)
+          .def_property(
+              "bound_device_id",
+              &::c10d::Backend::getBoundDeviceId,
+              &::c10d::Backend::setBoundDeviceId)
           .def(
               "abort",
               &::c10d::Backend::abort,


### PR DESCRIPTION
When `TORCH_DISTRIBUTED_DEBUG=DETAIL` is set, `ProcessGroupWrapper` wraps the actual backend but `setBoundDeviceId` was not forwarded to the wrapped backend. This caused NCCL to fall back to guessing the device ID based on global rank, which can hang with heterogeneous rank-to-GPU mappings.

Make `getBoundDeviceId` and `setBoundDeviceId` virtual in `Backend` and override both in `ProcessGroupWrapper` to forward to the wrapped backend. Also expose `bound_device_id` on the `Backend` Python binding.

Fixes #178977