### PR TITLE
[inductor] Unwrap ShapeAsConstantBuffer in tensor_constructor size

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -3223,6 +3223,42 @@ class <lambda>(torch.nn.Module):
         res = opt_fn(x)
         self.assertEqual(ref, res)
 
+    def test_full_size_symint_returned_from_nested_region(self):
+        """Regression test: ``torch.full`` (and other ``tensor_constructor``-
+        backed ops) lowered with a size element that is a SymInt produced by
+        an ``invoke_subgraph`` HOP.
+
+        Inductor wraps such SymInts as ``ShapeAsConstantBuffer`` at the HOP
+        boundary (see ``ExternKernel.realize_input`` constructing
+        ``ShapeAsConstantBuffer(expr=x)`` for ``sympy.Expr`` inputs, and
+        ``InvokeSubgraph.create`` passing through the same node type for
+        SymInt outputs). Before the fix in ``tensor_constructor.inner``,
+        the consumer ``aten.full`` lowering called ``sympy.expand`` on the
+        ``ShapeAsConstantBuffer`` IR node and raised
+        ``SympifyError: cannot sympify object of type ShapeAsConstantBuffer``.
+        """
+
+        @nested_compile_region
+        def gn(x):
+            # Return both a tensor and a SymInt -- the SymInt is the trigger.
+            return x.sin(), x.shape[0] * 2
+
+        def fn(x):
+            h, s2 = gn(x)
+            # ``torch.full`` is the original failing op (see PR description
+            # of #<filed>); other ``tensor_constructor``-backed ops such as
+            # ``torch.zeros``/``torch.ones`` exercise the same lowering path.
+            scratch = torch.full(
+                (s2, 8, 4), 0.0, dtype=h.dtype, device=h.device
+            )
+            return h.sum() + scratch.sum() * 0.0
+
+        x = torch.randn(16, 4, requires_grad=True)
+        torch._dynamo.mark_dynamic(x, 0)
+        ref = fn(x)
+        res = torch.compile(fn, backend="inductor", fullgraph=True)(x)
+        self.assertEqual(ref, res)
+
 
 @skipIfTorchDynamo("Not a torch._dynamo test")
 class TestInvokeSubgraphReuse(TestCase):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3981,6 +3981,18 @@ def tensor_constructor(fill_value):
         dtype = dtype or torch.get_default_dtype()
         if len(size) == 1 and isinstance(size[0], (list, tuple, torch.Size)):
             size = tuple(size[0])
+        # When this lowering is reached from a backward graph that consumes a
+        # SymInt produced by an ``invoke_subgraph`` HOP (e.g. an outer
+        # ``torch.compile`` whose body contains a ``nested_compile_region``
+        # that returns a SymInt, or whose AOT-partitioned forward saves a
+        # SymInt for backward), Inductor wraps that SymInt as a
+        # ``ShapeAsConstantBuffer`` IR node at the HOP boundary (see
+        # ``ExternKernel.realize_input`` and ``InvokeSubgraph.create``).
+        # Unwrap it back to the underlying sympy expression here so
+        # ``sympy.expand`` below works -- without this, ``sympy.expand``
+        # raises ``SympifyError: cannot sympify object of type
+        # <class 'torch._inductor.ir.ShapeAsConstantBuffer'>``.
+        size = [s.expr if isinstance(s, ir.ShapeAsConstantBuffer) else s for s in size]
         # See https://github.com/pytorch/pytorch/issues/118102
         # All sizes at lowering time should be sympy.Symbol, not SymInt!
         for s in size:


### PR DESCRIPTION
Fixes #182275.

## Summary

When the consumer of an `invoke_subgraph` HOP (e.g. a function decorated with `torch.compiler.nested_compile_region` inside an outer `torch.compile`) passes a HOP-output SymInt as a size argument to `aten.full` (or another `tensor_constructor`-backed op), Inductor wraps that SymInt as a `ShapeAsConstantBuffer` IR node at the HOP boundary (see `ExternKernel.realize_input` constructing `ShapeAsConstantBuffer(expr=x)` for `sympy.Expr` inputs in `torch/_inductor/ir.py`, and `InvokeSubgraph.create` passing the same node type through for SymInt outputs).

The downstream lowering `tensor_constructor.inner` then runs `size = [sympy.expand(s) for s in size]` over the user-supplied size list. `sympy.expand` cannot sympify the `ShapeAsConstantBuffer` IR node and raises:

```
torch._inductor.exc.LoweringException: SympifyError:
    "cannot sympify object of type
     <class 'torch._inductor.ir.ShapeAsConstantBuffer'>"
  target: aten.full.default
  args[0]: [ShapeAsConstantBuffer(expr=...), ...]
```

## Fix

Unwrap `ShapeAsConstantBuffer` to its underlying `.expr` (a `sympy.Symbol` or `sympy.Expr`) before the `sympy.expand` step in `tensor_constructor.inner`. This is the minimal change matching the failing surface; `ir` is already imported in this file.

## Alternative approaches considered

The PR keeps the change local to `tensor_constructor.inner` because that is the only currently-failing lowering. Two more general approaches were considered but not taken:

1. **Add `_sympy_` to `ShapeAsConstantBuffer`** so that `sympy.expand` / `sympy.sympify` transparently resolve it to its underlying `expr`. This is more general but changes how the IR node is treated in any sympy context, which may have wider implications.
2. **Stop wrapping size-bound SymInts as `ShapeAsConstantBuffer` at the HOP boundary** in `ExternKernel.realize_input`. This is the most root-cause fix but requires deciding which call sites need a sympy-typed view vs. an IR-node view, which is a larger refactor.

I'm happy to refactor toward either approach if maintainers prefer.

## Other call sites with the same pattern

The same `[sympy.expand(s) for s in size]` pattern is used in other lowerings in this file (`empty_strided`, etc.). They are not changed in this PR because they are not currently reachable from this HOP-output size path -- their `size` already comes in as raw sympy expressions in the failing path. They can be fixed in the same way (unwrap `ShapeAsConstantBuffer`) if they hit the same bug.

## Test plan

Added `TestInvokeSubgraphCompile.test_full_size_symint_returned_from_nested_region` in `test/higher_order_ops/test_invoke_subgraph.py`. The test:

1. Wraps a function returning `(tensor, SymInt)` with `nested_compile_region`.
2. Consumes the SymInt as a size argument to `torch.full` in the outer `torch.compile(backend="inductor", fullgraph=True)` graph.
3. Marks the input's leading dim as dynamic.
4. Without the fix this raises `SympifyError`; with the fix the compiled output matches eager.

Local reproducer (without test framework) is in the linked issue and was verified against a fresh shallow clone of `main` (after applying this PR's fix).

## CLA / DCO

* `Signed-off-by:` trailer present in commit.
* This is my first PyTorch contribution; CLA bot will gate this.

## Reviewers

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @anijain2305 @ezyang @bdhirsh -- given prior work on `invoke_subgraph` / `ShapeAsConstantBuffer` boundaries.

Made with [Cursor](https://cursor.com)