### PR TITLE
Fix XPU compilation check

### DIFF
--- a/.ci/pytorch/check_binary.sh
+++ b/.ci/pytorch/check_binary.sh
@@ -228,7 +228,9 @@ fi
 ###############################################################################
 if [[ "$DESIRED_CUDA" == 'xpu' && "$PACKAGE_TYPE" != 'libtorch' ]]; then
   echo "Checking that xpu is compiled"
+  pushd /tmp
   python -c 'import torch; exit(0 if torch.xpu._is_compiled() else 1)'
+  popd
 fi
 
 ###############################################################################


### PR DESCRIPTION
Currently, the check in `check_binary.sh` for xpu compilation is executed from within the repo root.
This is unlike all other checks in the script, which change to /tmp to avoid masking effects from the source directory.
This PR adds the `pushd /tmp [...] popd` guard that is the established pattern.