### PR TITLE
[ROCm][Inductor] Fix lookup_device_info use potentially case-mismatch names to look up _device_mapping dictionary

### DIFF
--- a/test/inductor/test_analysis.py
+++ b/test/inductor/test_analysis.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import torch
 import torch.nn.functional as F
+from torch._inductor.analysis.device_info import _device_mapping, lookup_device_info
 from torch._inductor.analysis.profile_analysis import (
     _augment_trace_helper,
     _create_extern_mapping,
@@ -271,6 +272,15 @@ class TestUtils(TestCase):
         self.assertEqual(set(res1), {("a", 1, 3), ("b", 2, 48), ("c", 32, 4)})
         res2 = zip_dicts(d1, d2)
         self.assertEqual(set(res2), {("a", 1, 3), ("b", 2, None), ("c", None, 4)})
+
+    def test_device_mapping_keys_are_upper_case(self):
+        self.assertTrue(all(k == k.upper() for k in _device_mapping))
+
+    def test_lookup_device_info_is_case_insensitive(self):
+        upper = lookup_device_info("AMD INSTINCT MI300X")
+        self.assertIsNotNone(upper)
+        self.assertEqual(lookup_device_info("AMD Instinct MI300X"), upper)
+        self.assertEqual(lookup_device_info("amd instinct mi300x"), upper)
 
 
 def has_supported_gpu():

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -197,6 +197,7 @@ def lookup_device_info(name: str) -> DeviceInfo | None:
     to the recorded device. Therefore, _device_mapping statically contains the information for lots of devices.
     If one is missing, please run DeviceInfo.get_device_info() and add it to _device_mapping.
       name (str): name of the device to lookup. Should map onto torch.cuda.get_device_name().
+      Will be upper-cased before lookup.
     """
     return _device_mapping.get(name.upper())
 

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -194,7 +194,7 @@ def lookup_device_info(name: str) -> DeviceInfo | None:
     If one is missing, please run DeviceInfo.get_device_info() and add it to _device_mapping.
       name (str): name of the device to lookup. Should map onto torch.cuda.get_device_name().
     """
-    return _device_mapping.get(name)
+    return _device_mapping.get(name.upper())
 
 
 def datasheet_tops(dtype: torch.dtype, is_tf32: bool = False) -> float | None:

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -30,7 +30,7 @@ class DeviceInfo:
     tops_sparsity_factor: int = 1
 
 
-# Indexing is based on `torch.cuda.get_device_name()`
+# Indexing is based on `torch.cuda.get_device_name()`, normalized to upper-case.
 # TODO investigate profiler support for tf32 and allow device to report correct number when it's turned on.
 _device_mapping: dict[str, DeviceInfo] = {
     # Source:
@@ -184,6 +184,10 @@ _device_mapping: dict[str, DeviceInfo] = {
 _device_mapping["AMD INSTINCT MI350X"] = _device_mapping["AMD MI350X"]
 _device_mapping["AMD INSTINCT MI300X"] = _device_mapping["AMD MI300X"]
 _device_mapping["AMD INSTINCT MI210X"] = _device_mapping["AMD MI210X"]
+
+# Enforce the upper-case-key invariant so entries cannot silently miss
+# `lookup_device_info` (which upper-cases the query before lookup).
+_device_mapping = {k.upper(): v for k, v in _device_mapping.items()}
 
 
 def lookup_device_info(name: str) -> DeviceInfo | None:


### PR DESCRIPTION
Currently, `datasheet_tops` function obtains device name from `torch.cuda.get_device_name`, then pass it into `lookup_device_info` to look up device capabilities. However, on some AMD cards, `torch.cuda.get_device_name` returns names with some words in it are only first-letter capitalized, such as `AMD Instinct MI300X`, which differs from the keys in the dict (`AMD INSTINCT MI300X`) and therefore making the function returns `None`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben