### PR TITLE
[MPS] Fix bool mask handling in 1-pass SDPA decode kernel

### DIFF
--- a/aten/src/ATen/native/mps/kernels/DecodeAttention.h
+++ b/aten/src/ATen/native/mps/kernels/DecodeAttention.h
@@ -39,9 +39,9 @@ template <typename T, int D, int V = D, bool is_causal = false>
   const uint v_seq_stride = qkv_seq_strides.z;
   const uint v_batch_stride = qkv_batch_strides_heads.z;
   const uint num_heads = qkv_batch_strides_heads.w;
-  const uint mask_head_stride = mask_strides.x;
-  const uint mask_kv_seq_stride = mask_strides.y;
-  const uint mask_q_seq_stride = mask_strides.z;
+  const uint mask_kv_seq_stride = mask_strides.x;
+  const uint mask_q_seq_stride = mask_strides.y;
+  const uint mask_head_stride = mask_strides.z;
   uint inner_k_stride = BN * int(k_seq_stride);
   uint inner_v_stride = BN * int(v_seq_stride);
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10198,6 +10198,22 @@ class TestSDPA(TestCaseMPS):
         out_mps = F.scaled_dot_product_attention(q.to('mps'), k.to('mps'), v.to('mps'), attn_mask=mask.to('mps'))
         self._compare_tensors(out_mps.cpu(), out_cpu)
 
+    @parametrize("dtype", [torch.float32, torch.float16])
+    def test_sdpa_math_mps_bool_mask_1pass(self, dtype):
+        torch.manual_seed(0)
+        q = torch.randn(1, 1, 8, 64, dtype=dtype, device='mps')
+        k = torch.randn(1, 1, 512, 64, dtype=dtype, device='mps')
+        v = torch.randn(1, 1, 512, 64, dtype=dtype, device='mps')
+        mask = torch.eye(8, 512, dtype=torch.bool, device='mps')
+
+        out_mps, _ = torch.ops.aten._scaled_dot_product_attention_math_for_mps(
+            q, k, v, mask
+        )
+        out_cpu = F.scaled_dot_product_attention(
+            q.cpu(), k.cpu(), v.cpu(), attn_mask=mask.cpu()
+        )
+        self._compare_tensors(out_mps.cpu(), out_cpu)
+
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float])
     def test_sdpa_2pass(self, dtype):
         # Regression test for https://github.com/pytorch/pytorch/issues/174861

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -10198,7 +10198,7 @@ class TestSDPA(TestCaseMPS):
         out_mps = F.scaled_dot_product_attention(q.to('mps'), k.to('mps'), v.to('mps'), attn_mask=mask.to('mps'))
         self._compare_tensors(out_mps.cpu(), out_cpu)
 
-    @parametrize("dtype", [torch.float32, torch.float16])
+    @parametrize("dtype", [torch.float32, torch.bfloat16])
     def test_sdpa_math_mps_bool_mask_1pass(self, dtype):
         torch.manual_seed(0)
         q = torch.randn(1, 1, 8, 64, dtype=dtype, device='mps')


### PR DESCRIPTION
Fix bool mask handling in 1-pass SDPA decode kernel. Small reproducer:
```python
import torch
import torch.nn.functional as F

q = torch.randn(1, 1,   8, 64, device="mps")
k = torch.randn(1, 1, 512, 64, device="mps")
v = torch.randn(1, 1, 512, 64, device="mps")
mask = torch.ones(8, 512, dtype=torch.bool, device="mps")

mps_op = torch.ops.aten._scaled_dot_product_attention_math_for_mps
out, _ = mps_op(q, k, v, mask)
ref = F.scaled_dot_product_attention(q.cpu(), k.cpu(), v.cpu(), attn_mask=mask.cpu())

print("max |mps - cpu| =", (out.cpu() - ref).abs().max().item())
```