### PR TITLE
[MPS] Pinned memory - Add pinned memory allocator

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -294,6 +294,9 @@ class MPSHeapAllocatorImpl {
   // returns a CPU-mapping of the input buffer and its retainCount,
   // if only it has Shared storage-mode and allocated on MPSAllocator
   std::pair<const void*, uint32_t> getSharedBufferPtr(const void* buffer);
+  // returns the MTLBuffer for a shared allocation when the input is either
+  // the MTLBuffer or its CPU mapping
+  const void* getSharedBuffer(const void* ptr);
   // returns a CPU-device c10::Storage aliasing the host-visible contents of
   // the MTLBuffer backing `mps_storage`. The returned storage keeps the
   // source MPS storage alive for its lifetime. Raises if `mps_storage` is
@@ -364,6 +367,8 @@ class MPSHeapAllocatorImpl {
   std::recursive_mutex m_mutex;
   // allocated buffers by device pointer
   ska::flat_hash_map<const void*, BufferBlock*> m_allocated_buffers;
+  // allocated shared buffers by CPU mapping
+  ska::flat_hash_map<const void*, BufferBlock*> m_allocated_shared_buffers_by_cpu_ptr;
   // using a container for pools to simplify iterating them
   ska::flat_hash_map<BufferPool::Kind, std::unique_ptr<BufferPool>> m_pools;
   // total memory allocated by HeapAllocator (including blocks in pools)

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -915,6 +915,9 @@ MPSPinnedAllocator& _getPinnedAllocator() {
 } // anonymous namespace
 
 IMPSAllocator* getIMPSAllocator() {
+  if (!at::mps::is_available()) {
+    return nullptr;
+  }
   auto& sa = _getSharedAllocator();
   if (sa.isSharedStorageSupported()) {
     return &sa;
@@ -923,6 +926,9 @@ IMPSAllocator* getIMPSAllocator() {
 }
 
 Allocator* getMPSPinnedAllocator() {
+  if (!at::mps::is_available()) {
+    return nullptr;
+  }
   auto& sa = _getSharedAllocator();
   if (sa.isSharedStorageSupported()) {
     return &_getPinnedAllocator();
@@ -935,6 +941,9 @@ Allocator* getMPSPinnedAllocator() {
 // will be able to use SharedStorageMode for MTLBuffer allocations. This will
 // avoid extra copies on DataLoading operations.
 bool isMPSPinnedPtr(const void* data) {
+  if (!at::mps::is_available()) {
+    return false;
+  }
   return at::mps::_getSharedAllocator().isSharedBuffer(data);
 }
 

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -313,10 +313,11 @@ void MPSHeapAllocatorImpl::free_buffer(BufferBlock* buffer_block) {
 
 BufferBlock* MPSHeapAllocatorImpl::get_allocated_buffer_block(const void* ptr) {
   auto it = m_allocated_buffers.find(ptr);
-  if (it == m_allocated_buffers.end()) {
-    return nullptr;
+  if (it != m_allocated_buffers.end()) {
+    return it->second;
   }
-  return it->second;
+  auto cpu_ptr_it = m_allocated_shared_buffers_by_cpu_ptr.find(ptr);
+  return cpu_ptr_it != m_allocated_shared_buffers_by_cpu_ptr.end() ? cpu_ptr_it->second : nullptr;
 }
 
 bool MPSHeapAllocatorImpl::release_buffer(BufferBlock* buffer_block, bool remove_empty_heap) {
@@ -325,6 +326,9 @@ bool MPSHeapAllocatorImpl::release_buffer(BufferBlock* buffer_block, bool remove
   pool.allocated_size -= buffer_block->size;
   pool.available_size -= buffer_block->size;
   m_allocated_buffers.erase(buffer_block->buffer);
+  if (buffer_block->cpu_ptr) {
+    m_allocated_shared_buffers_by_cpu_ptr.erase(buffer_block->cpu_ptr);
+  }
   pool.available_buffers.erase(buffer_block);
   pool.n_buffers--;
   // will re-insert later to keep the heaps list sorted based on heap's new available size (if heap not empty)
@@ -523,6 +527,7 @@ id<MTLBuffer> MPSHeapAllocatorImpl::allocScalarBufferWithValue(void* value, size
     }
     if (!buffer_block->cpu_ptr) {
       buffer_block->cpu_ptr = [buffer_block->buffer contents];
+      m_allocated_shared_buffers_by_cpu_ptr[buffer_block->cpu_ptr] = buffer_block;
     }
   }
   // buffer is out of the pool, so no mutex lock is needed
@@ -540,8 +545,19 @@ std::pair<const void*, uint32_t> MPSHeapAllocatorImpl::getSharedBufferPtr(const 
   }
   if (!buffer_block->cpu_ptr) {
     buffer_block->cpu_ptr = [buffer_block->buffer contents];
+    m_allocated_shared_buffers_by_cpu_ptr[buffer_block->cpu_ptr] = buffer_block;
   }
   return {buffer_block->cpu_ptr, buffer_block->retainCount()};
+}
+
+const void* MPSHeapAllocatorImpl::getSharedBuffer(const void* ptr) {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
+  BufferBlock* buffer_block = get_allocated_buffer_block(ptr);
+  if (!buffer_block || !(buffer_block->heap->pool->usage & UsageFlags::SHARED)) {
+    return nullptr;
+  }
+  return buffer_block->buffer;
 }
 
 namespace {
@@ -567,6 +583,7 @@ c10::Storage MPSHeapAllocatorImpl::getHostAliasStorage(const c10::Storage& mps_s
 
   if (!buffer_block->cpu_ptr) {
     buffer_block->cpu_ptr = [buffer_block->buffer contents];
+    m_allocated_shared_buffers_by_cpu_ptr[buffer_block->cpu_ptr] = buffer_block;
   }
 
   // Retain the source MPS storage through the DataPtr's context so the
@@ -777,6 +794,9 @@ struct TORCH_API MPSAllocator final : public IMPSAllocator {
   std::pair<const void*, uint32_t> getSharedBufferPtr(const void* ptr) const override {
     return _getAllocImpl().getSharedBufferPtr(ptr);
   }
+  const void* getSharedBuffer(const void* ptr) const override {
+    return _getAllocImpl().getSharedBuffer(ptr);
+  }
   c10::Storage getHostAliasStorage(const c10::Storage& mps_storage) const override {
     return _getAllocImpl().getHostAliasStorage(mps_storage);
   }
@@ -862,12 +882,50 @@ MPSAllocator& _getSharedAllocator() {
   return s_mps_shared_alloc;
 }
 
+struct MPSPinnedAllocator final : public Allocator {
+  DataPtr allocate(const size_t nbytes) override {
+    DataPtr shared = _getSharedAllocator().allocate(nbytes);
+    void* host_ptr = nullptr;
+    if (shared) {
+      const auto [shared_ptr, retain_count] = _getSharedAllocator().getSharedBufferPtr(shared.get());
+      (void)retain_count;
+      TORCH_INTERNAL_ASSERT(shared_ptr);
+      host_ptr = const_cast<void*>(shared_ptr);
+    }
+    return {host_ptr, shared.release_context(), &Delete, at::Device(at::DeviceType::CPU)};
+  }
+
+  void copy_data(void* dest, const void* src, std::size_t count) const final {
+    default_copy_data(dest, src, count);
+  }
+
+ private:
+  static void Delete(void* ptr) {
+    if (ptr) {
+      _getSharedAllocator().raw_deleter()(ptr);
+    }
+  }
+};
+
+MPSPinnedAllocator& _getPinnedAllocator() {
+  static MPSPinnedAllocator s_mps_pinned_alloc;
+  return s_mps_pinned_alloc;
+}
+
 } // anonymous namespace
 
 IMPSAllocator* getIMPSAllocator() {
   auto& sa = _getSharedAllocator();
   if (sa.isSharedStorageSupported()) {
     return &sa;
+  }
+  return nullptr;
+}
+
+Allocator* getMPSPinnedAllocator() {
+  auto& sa = _getSharedAllocator();
+  if (sa.isSharedStorageSupported()) {
+    return &_getPinnedAllocator();
   }
   return nullptr;
 }

--- a/aten/src/ATen/mps/MPSAllocatorInterface.h
+++ b/aten/src/ATen/mps/MPSAllocatorInterface.h
@@ -39,6 +39,9 @@ class IMPSAllocator : public c10::Allocator {
   virtual size_t getRecommendedMaxMemory() const = 0;
   virtual std::pair<const void*, uint32_t> getSharedBufferPtr(
       const void* ptr) const = 0;
+  // Returns the MTLBuffer backing a shared allocation when `ptr` is either
+  // the MTLBuffer itself or the host-visible contents pointer.
+  virtual const void* getSharedBuffer(const void* ptr) const = 0;
   // Returns a CPU-device c10::Storage that aliases the host-visible contents
   // of the MTLBuffer backing `mps_storage`. The returned storage retains the
   // source MPS storage for its lifetime, so the host pointer remains valid
@@ -71,6 +74,8 @@ TORCH_DECLARE_REGISTRY(MPSAllocatorCallbacksRegistry, IMpsAllocatorCallback);
   C10_REGISTER_CLASS(MPSAllocatorCallbacksRegistry, name, __VA_ARGS__)
 
 IMPSAllocator* getIMPSAllocator();
+
+Allocator* getMPSPinnedAllocator();
 
 bool isMPSPinnedPtr(const void* data);
 

--- a/aten/src/ATen/mps/MPSHooks.mm
+++ b/aten/src/ATen/mps/MPSHooks.mm
@@ -155,7 +155,11 @@ bool MPSHooks::isPinnedPtr(const void* data) const {
 }
 
 Allocator* MPSHooks::getPinnedMemoryAllocator() const {
-  return at::mps::getIMPSAllocator();
+  auto* allocator = at::mps::getMPSPinnedAllocator();
+  TORCH_CHECK(
+      allocator,
+      "MPS pinned memory requires a device with shared storage support.");
+  return allocator;
 }
 
 using at::MPSHooksRegistry;

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -344,7 +344,7 @@ Tensor _to_copy(
 
   bool pin_out =
       (non_blocking &&
-       at::accelerator::isAcceleratorExcluded(self.device().type(), at::kMPS) &&
+       at::accelerator::isAccelerator(self.device().type()) &&
        options.device().is_cpu() && (options.layout() == c10::kStrided));
 
   if (memory_format == MemoryFormat::Preserve) {

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -1,5 +1,6 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/mps/MPSAllocatorInterface.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/Copy.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -13,6 +14,55 @@
 
 namespace at::native {
 namespace mps {
+
+namespace {
+void storageAliasDeleter(void* ctx) {
+  delete static_cast<c10::Storage*>(ctx);
+}
+
+bool try_alias_mps_from_pinned_cpu(at::Tensor& dst, const at::Tensor& src, bool non_blocking) {
+  if (!non_blocking || !src.is_contiguous() || !dst.is_contiguous() || src.dtype() != dst.dtype() ||
+      !at::mps::isMPSPinnedPtr(src.storage().data())) {
+    return false;
+  }
+
+  auto* allocator = at::mps::getIMPSAllocator();
+  if (!allocator) {
+    return false;
+  }
+  const void* buffer = allocator->getSharedBuffer(src.storage().data());
+  if (!buffer) {
+    return false;
+  }
+
+  auto* ctx = new c10::Storage(src.storage());
+  c10::DataPtr data_ptr(
+      const_cast<void*>(buffer), ctx, &storageAliasDeleter, c10::Device(c10::DeviceType::MPS, 0));
+  c10::Storage storage(
+      c10::Storage::use_byte_size_t(),
+      src.storage().nbytes(),
+      std::move(data_ptr),
+      /*allocator=*/nullptr,
+      /*resizable=*/false);
+  dst.set_(storage, src.storage_offset(), src.sizes(), src.strides());
+  return true;
+}
+
+bool try_alias_cpu_from_mps(at::Tensor& dst, const at::Tensor& src, bool non_blocking) {
+  if (!non_blocking || !src.is_contiguous() || !dst.is_contiguous() || src.dtype() != dst.dtype() ||
+      !at::mps::isMPSPinnedPtr(dst.storage().data())) {
+    return false;
+  }
+
+  auto* allocator = at::mps::getIMPSAllocator();
+  if (!allocator || !allocator->getSharedBuffer(src.storage().data())) {
+    return false;
+  }
+  c10::Storage storage = allocator->getHostAliasStorage(src.storage());
+  dst.set_(storage, src.storage_offset(), src.sizes(), src.strides());
+  return true;
+}
+} // namespace
 
 static void* pageAlignedBlockPtr(const void* ptr, NSUInteger size, NSUInteger* alignedBlockSize) {
   uintptr_t address = (uintptr_t)ptr;
@@ -79,6 +129,10 @@ static void copy_cast_mps(at::Tensor& dst,
 }
 
 static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool non_blocking) {
+  if (try_alias_cpu_from_mps(dst_, src_, non_blocking)) {
+    return dst_;
+  }
+
   auto sameMemFormat =
       src_.is_contiguous(dst_.suggest_memory_format()) && dst_.is_contiguous(dst_.suggest_memory_format());
 
@@ -219,6 +273,9 @@ static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_, bool n
   if (src.strides() != dst_.strides()) {
     needs_copy = true;
     dst = at::empty_like(src, at::device(at::kMPS));
+  }
+  if (!needs_copy && try_alias_mps_from_pinned_cpu(dst_, src, non_blocking)) {
+    return dst_;
   }
   copy_to_mps_stride_contig(dst, src, non_blocking && !needs_copy);
   return needs_copy ? dst_.copy_(dst) : dst_;

--- a/docs/source/data.md
+++ b/docs/source/data.md
@@ -327,8 +327,8 @@ It is generally not recommended to return CUDA tensors in multi-process
 loading because of many subtleties in using CUDA and sharing CUDA tensors in
 multiprocessing (see {ref}`multiprocessing-cuda-note`). Instead, we recommend
 using {ref}`automatic memory pinning <memory-pinning>` (i.e., setting
-{attr}`pin_memory=True`), which enables fast data transfer to CUDA-enabled
-GPUs.
+{attr}`pin_memory=True`), which enables fast data transfer to accelerator
+devices such as CUDA or MPS.
 :::
 
 (platform-specific-behaviors)=
@@ -382,13 +382,13 @@ loading.
 ## Memory Pinning
 
 Host to GPU copies are much faster when they originate from pinned (page-locked)
-memory. See {ref}`cuda-memory-pinning` for more details on when and how to use
-pinned memory generally.
+memory. See {ref}`cuda-memory-pinning` and {ref}`mps-memory-pinning` for more
+details on when and how to use pinned memory generally.
 
 For data loading, passing {attr}`pin_memory=True` to a
 {class}`~torch.utils.data.DataLoader` will automatically put the fetched data
-Tensors in pinned memory, and thus enables faster data transfer to CUDA-enabled
-GPUs.
+Tensors in pinned memory, and thus enables faster data transfer to accelerator
+devices such as CUDA or MPS.
 
 The default memory pinning logic only recognizes Tensors and maps and iterables
 containing Tensors. By default, if the pinning logic sees a batch that is a

--- a/docs/source/notes/mps.rst
+++ b/docs/source/notes/mps.rst
@@ -42,3 +42,14 @@ To get started, simply move your Tensor and Module to the ``mps`` device:
 
         # Now every call runs on the GPU
         pred = model(x)
+
+.. _mps-memory-pinning:
+
+Pinned memory
+-------------
+
+On Apple Silicon systems with unified memory, CPU tensors can be placed in
+MPS-pinned memory with :meth:`~torch.Tensor.pin_memory` or by passing
+``pin_memory=True`` to :class:`~torch.utils.data.DataLoader`. Pinned CPU tensors
+are backed by shared Metal buffers, which lets non-blocking transfers to
+``mps`` tensors avoid an extra host staging copy.

--- a/test/test_accelerator.py
+++ b/test/test_accelerator.py
@@ -157,10 +157,14 @@ class TestAccelerator(TestCase):
         self.assertEqual(torch.accelerator.current_stream(), src_prev_stream)
         self.assertEqual(torch.accelerator.current_stream(dst_device), dst_prev_stream)
 
-    @unittest.skipIf(TEST_MPS, "MPS doesn't support pin memory!")
     def test_pin_memory_on_non_blocking_copy(self):
         t_acc = torch.randn(100).to(torch.accelerator.current_accelerator())
-        t_host = t_acc.to("cpu", non_blocking=True)
+        try:
+            t_host = t_acc.to("cpu", non_blocking=True)
+        except RuntimeError as e:
+            if TEST_MPS and "MPS pinned memory requires" in str(e):
+                self.skipTest("MPS device does not support shared storage")
+            raise
         torch.accelerator.synchronize()
         self.assertTrue(t_host.is_pinned())
         self.assertEqual(t_acc.cpu(), t_host)

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -37,6 +37,7 @@ from torch.testing._internal.common_utils import (
     skipIfXpu,
     slowTest,
     TEST_CUDA,
+    TEST_MPS,
     TEST_NUMPY,
     TEST_WITH_ASAN,
     TEST_WITH_TSAN,
@@ -3292,7 +3293,7 @@ class TestDictDataLoader(TestCase):
             self.assertTrue(sample["another_dict"]["a_number"].is_pinned())
 
     @skipIfXpu
-    @unittest.skipIf(TEST_CUDA, "Test for when CUDA is not available")
+    @unittest.skipIf(TEST_CUDA or TEST_MPS, "Test for when no accelerator is available")
     def test_pin_memory_no_cuda(self):
         loader = DataLoader(self.dataset, batch_size=2, pin_memory=True)
         for sample in loader:

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8243,6 +8243,99 @@ class TestMPS(TestCaseMPS):
         with self.assertRaisesRegex(TypeError, "UntypedStorage"):
             torch.mps._host_alias_storage(torch.empty(4, device="mps"))
 
+    def _pin_memory_or_skip(self, tensor, device=None):
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                return tensor.pin_memory(device=device) if device is not None else tensor.pin_memory()
+        except RuntimeError as e:
+            if "MPS pinned memory requires" in str(e):
+                self.skipTest("MPS device does not support shared storage")
+            raise
+
+    def test_pin_memory_basic(self):
+        t = torch.zeros(1024, dtype=torch.float32)
+        self.assertFalse(t.is_pinned())
+        p = self._pin_memory_or_skip(t)
+        self.assertTrue(p.is_pinned())
+        self.assertEqual(p.device.type, "cpu")
+        self.assertEqual(p, t)
+
+    def test_pin_memory_explicit_device(self):
+        p = self._pin_memory_or_skip(torch.zeros(1024), device="mps")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertTrue(p.is_pinned(device="mps"))
+
+    def test_pin_memory_from_constructor(self):
+        try:
+            p = torch.empty(1024, dtype=torch.float32, pin_memory=True)
+        except RuntimeError as e:
+            if "MPS pinned memory requires" in str(e):
+                self.skipTest("MPS device does not support shared storage")
+            raise
+        self.assertTrue(p.is_pinned())
+        self.assertEqual(p.device.type, "cpu")
+
+    def test_pinned_h2d_non_blocking_alias(self):
+        cpu = self._pin_memory_or_skip(torch.arange(1024, dtype=torch.float32))
+        mps = cpu.to("mps", non_blocking=True)
+        torch.mps.synchronize()
+        cpu.add_(1)
+        torch.mps.synchronize()
+        self.assertEqual(mps.cpu(), cpu)
+
+    def test_pinned_h2d_blocking_copy(self):
+        cpu = self._pin_memory_or_skip(torch.arange(1024, dtype=torch.float32))
+        mps = cpu.to("mps", non_blocking=False)
+        torch.mps.synchronize()
+        cpu.add_(1)
+        torch.mps.synchronize()
+        self.assertEqual(mps.cpu(), cpu - 1)
+
+    def test_pinned_d2h_non_blocking_alias(self):
+        mps = torch.arange(1024, dtype=torch.float32, device="mps")
+        torch.mps.synchronize()
+        cpu = self._pin_memory_or_skip(torch.empty(1024, dtype=torch.float32))
+        cpu.copy_(mps, non_blocking=True)
+        torch.mps.synchronize()
+        self.assertEqual(cpu, mps.cpu())
+        mps.add_(1)
+        torch.mps.synchronize()
+        self.assertEqual(cpu, mps.cpu())
+
+    def test_pinned_d2h_blocking_copy(self):
+        mps = torch.arange(1024, dtype=torch.float32, device="mps")
+        torch.mps.synchronize()
+        cpu = self._pin_memory_or_skip(torch.empty(1024, dtype=torch.float32))
+        cpu.copy_(mps, non_blocking=False)
+        torch.mps.synchronize()
+        mps.add_(1)
+        torch.mps.synchronize()
+        self.assertEqual(cpu, mps.cpu() - 1)
+
+    def test_pin_memory_autograd_roundtrip(self):
+        x = self._pin_memory_or_skip(torch.zeros(8, dtype=torch.float32)).requires_grad_()
+        (x * 2).sum().backward()
+        self.assertIsNotNone(x.grad)
+
+    def test_pin_memory_noncontiguous(self):
+        t = torch.arange(16, dtype=torch.float32).view(4, 4)[::2]
+        p = self._pin_memory_or_skip(t)
+        self.assertTrue(p.is_pinned())
+        self.assertEqual(p, t)
+
+    def test_dataloader_pin_memory_mps(self):
+        ds = torch.utils.data.TensorDataset(torch.arange(64, dtype=torch.float32))
+        dl = torch.utils.data.DataLoader(ds, batch_size=8, pin_memory=True)
+        try:
+            for (batch,) in dl:
+                self.assertTrue(batch.is_pinned())
+        except RuntimeError as e:
+            if "MPS pinned memory requires" in str(e):
+                self.skipTest("MPS device does not support shared storage")
+            raise
+
     # to verify this test, run XCode Instruments "Metal System Trace" or "Logging" tool,
     # press record, then run this python test, and press stop. Next expand
     # the os_signposts->PyTorchMPS and check if events or intervals are logged

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -665,18 +665,6 @@ class _BaseDataLoaderIter:
             else None
         )
 
-        # Currently, pin_memory would raise error on the MPS backend (see
-        # https://github.com/pytorch/pytorch/issues/86060), so forcibly
-        # disable pin_memory on MPS. Remove this restriction once pinned
-        # memory allocation for MPS is fixed.
-        if self._pin_memory_device == "mps":
-            self._pin_memory = False
-            warn_msg = (
-                "'pin_memory' argument is set as true but not supported on MPS now, "
-                "device pinned memory won't be used."
-            )
-            warnings.warn(warn_msg, stacklevel=2)
-
         self._timeout = loader.timeout
         self._collate_fn = loader.collate_fn
         self._sampler_iter = iter(self._index_sampler)


### PR DESCRIPTION
It enables CPU pinned tensors for MPS, updates non-blocking CPU<->MPS copies to alias shared storage when possible, and removes the DataLoader warning that previously disabled pin_memory for MPS.

Tested locally with:
- python test/test_accelerator.py -k pin_memory_on_non_blocking_copy
- python test/test_dataloader.py -k pin
- python test/test_mps.py -k pin_memory
- python test/test_mps.py -k pinned
