### PR TITLE
[Docathon-EXAMPLE] [DO NOT MERGE] Document custom_fwd and custom_bwd in amp.md

### DIFF
--- a/docs/source/amp.md
+++ b/docs/source/amp.md
@@ -144,6 +144,18 @@ or gradients when running with AMP/fp16, verify your model is compatible.
 ```
 
 ```{eval-rst}
+.. currentmodule:: torch.amp.autocast_mode
+```
+
+```{eval-rst}
+.. autofunction:: custom_fwd
+```
+
+```{eval-rst}
+.. autofunction:: custom_bwd
+```
+
+```{eval-rst}
 .. currentmodule:: torch.cpu.amp
 ```
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -447,9 +447,6 @@ coverage_ignore_functions = [
     "init_dropout_state",
     # torch.backends.xeon.run_cpu
     "create_args",
-    # torch.cuda.amp.autocast_mode
-    "custom_bwd",
-    "custom_fwd",
     # torch.cuda.amp.common
     "amp_definitely_not_available",
     # torch.mtia.memory


### PR DESCRIPTION
## Summary

Add `autofunction` directives for `torch.cuda.amp.autocast_mode.custom_fwd` and `torch.cuda.amp.autocast_mode.custom_bwd` to the AMP documentation page (`docs/source/amp.md`).

## Changes

1. **`docs/source/amp.md`** — Added a `currentmodule` directive for `torch.cuda.amp.autocast_mode` and two `autofunction` directives (`custom_fwd`, `custom_bwd`) after the existing `GradScaler` section.

2. **`docs/source/conf.py`** — Removed `"custom_bwd"` and `"custom_fwd"` from `coverage_ignore_functions`.

## Test Plan

- `make coverage` should no longer report these functions as undocumented
- `make html` renders the functions correctly on the AMP page

## Related

- Docathon tracking issue: https://github.com/sekyondaMeta/pytorch/issues/21
- This PR serves as an example of the functions-only docathon workflow

cc @sekyondaMeta