### PR TITLE
fix(nn): InstanceNorm always raises ValueError on channel mismatch

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9274,13 +9274,8 @@ class TestNNDeviceType(NNTestCase):
         if not no_batch_dim:
             size = [3] + size
         t = torch.randn(size)
-        if affine:
-            with self.assertRaisesRegex(ValueError, "expected input's size at dim="):
-                inst_norm(t)
-        else:
-            with warnings.catch_warnings(record=True) as w:
-                inst_norm(t)
-            self.assertIn("which is not used because affine=False", str(w[0].message))
+        with self.assertRaisesRegex(ValueError, "expected input's size at dim="):
+            inst_norm(t)
 
     def test_instancenorm_raises_error_if_less_than_one_value_per_channel(self, device):
         x = torch.rand(10)[None, :, None]

--- a/torch/nn/modules/instancenorm.py
+++ b/torch/nn/modules/instancenorm.py
@@ -1,7 +1,5 @@
 # mypy: allow-untyped-defs
 
-import warnings
-
 import torch.nn.functional as F
 from torch import Tensor
 
@@ -114,18 +112,10 @@ class _InstanceNorm(_NormBase):
 
         feature_dim = input.dim() - self._get_no_batch_dim()
         if input.size(feature_dim) != self.num_features:
-            if self.affine:
-                raise ValueError(
-                    f"expected input's size at dim={feature_dim} to match num_features"
-                    f" ({self.num_features}), but got: {input.size(feature_dim)}."
-                )
-            else:
-                warnings.warn(
-                    f"input's size at dim={feature_dim} does not match num_features. "
-                    "You can silence this warning by not passing in num_features, "
-                    "which is not used because affine=False",
-                    stacklevel=2,
-                )
+            raise ValueError(
+                f"expected input's size at dim={feature_dim} to match num_features"
+                f" ({self.num_features}), but got: {input.size(feature_dim)}."
+            )
 
         if input.dim() == self._get_no_batch_dim():
             return self._handle_no_batch_input(input)


### PR DESCRIPTION
Fixes #109652

## Summary

`_InstanceNorm.forward()` previously branched on `self.affine` when checking channel count:
- `affine=True` -- raised `ValueError` (correct)
- `affine=False` (the default) -- emitted a `UserWarning` and silently continued (bug)

This means calling `InstanceNorm1d(64)` with an 80-channel input would silently produce wrong normalization output with no error. The warning message was also misleading -- it said "num_features is not used because affine=False", but `num_features` IS used when `track_running_stats=True`.

This PR removes the `if self.affine` branch and always raises `ValueError`, consistent with `BatchNorm1d` which raises unconditionally in the same situation.

### Before
```python
m = torch.nn.InstanceNorm1d(64)
inp = torch.randn(4, 80, 300)
m(inp)  # UserWarning, then silently returns shape [4, 80, 300]
```

### After
```python
m = torch.nn.InstanceNorm1d(64)
inp = torch.randn(4, 80, 300)
m(inp)  # ValueError: expected input's size at dim=1 to match num_features (64), but got: 80.
```

## Changes
- `torch/nn/modules/instancenorm.py`: Remove `if self.affine` branch in `forward()`, always raise. Remove now-unused `import warnings`.
- `test/test_nn.py`: Update `test_instancenorm_raises_error_if_input_channels_is_not_num_features` -- `affine=False` case now asserts `ValueError` instead of a warning.