### PR TITLE
Fix torch.compile produce wrong output due to problem in decomposition

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10870,6 +10870,30 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 self.assertEqual(x.grad, x_ref.grad)
                 self.assertEqual(y.grad, y_ref.grad)
 
+    def test_diagonal_scatter_overlap_input(self):
+        # The decomposition for diagonal_scatter (and the other *_scatter ops)
+        # uses clone_preserve_strides, which must materialize a contiguous
+        # buffer when the input has internal memory overlap (e.g. an expand
+        # of a scalar with stride 0). Otherwise the diagonal write aliases
+        # the entire output and corrupts non-diagonal positions. This pattern
+        # arises naturally in the backward of diagonal_scatter(x, src).sum().
+        def fn(x, src):
+            return torch.diagonal_scatter(x, src, 0).sum()
+
+        x = torch.randn(8, 8, device=self.device, requires_grad=True)
+        src = torch.randn(8, device=self.device, requires_grad=True)
+
+        x_eager = x.clone().detach().requires_grad_(True)
+        src_eager = src.clone().detach().requires_grad_(True)
+        fn(x_eager, src_eager).backward()
+
+        x_compiled = x.clone().detach().requires_grad_(True)
+        src_compiled = src.clone().detach().requires_grad_(True)
+        torch.compile(fn)(x_compiled, src_compiled).backward()
+
+        self.assertEqual(x_eager.grad, x_compiled.grad)
+        self.assertEqual(src_eager.grad, src_compiled.grad)
+
     @skip_if_gpu_halide  # accuracy issue
     def test_slice_scatter(self):
         def fn(x, a):

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -2173,19 +2173,6 @@ def layout_or_default(layout: torch.layout | None) -> torch.layout:
 
 
 def clone_preserve_strides(x):
-    from torch.fx.experimental.symbolic_shapes import guard_or_false
-
-    # Mirror the C++ at::native::clone_preserve_strides: when the input has
-    # internal memory overlap (e.g. an expand from a scalar with stride 0),
-    # we cannot preserve strides because *_scatter ops will copy_() into the
-    # clone, and copy_ requires non-overlapping output storage. Fall back to
-    # a plain clone, which materializes a contiguous buffer.
-    if any(
-        guard_or_false(sz > 1) and guard_or_false(s == 0)
-        for sz, s in zip(x.size(), x.stride())
-    ):
-        return x.clone()
-
     needed_size = compute_required_storage_length(
         x.size(), x.stride(), x.storage_offset()
     )

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -2173,6 +2173,19 @@ def layout_or_default(layout: torch.layout | None) -> torch.layout:
 
 
 def clone_preserve_strides(x):
+    from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+    # Mirror the C++ at::native::clone_preserve_strides: when the input has
+    # internal memory overlap (e.g. an expand from a scalar with stride 0),
+    # we cannot preserve strides because *_scatter ops will copy_() into the
+    # clone, and copy_ requires non-overlapping output storage. Fall back to
+    # a plain clone, which materializes a contiguous buffer.
+    if any(
+        guard_or_false(sz > 1) and guard_or_false(s == 0)
+        for sz, s in zip(x.size(), x.stride())
+    ):
+        return x.clone()
+
     needed_size = compute_required_storage_length(
         x.size(), x.stride(), x.storage_offset()
     )

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4677,7 +4677,7 @@ def diagonal_scatter(
     # storage and corrupt non-diagonal positions. This arises in the backward
     # of diagonal_scatter(x, src).sum(), where grad_output is expanded. Fall
     # back to a plain clone, which materializes a contiguous buffer.
-    if any(
+    if builtins.any(
         guard_or_false(sz > 1) and guard_or_false(s == 0)
         for sz, s in zip(input.size(), input.stride())
     ):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -4671,7 +4671,19 @@ def diagonal_scatter(
 ) -> TensorLikeType:
     from torch.fx.experimental.symbolic_shapes import guard_or_false, sym_or
 
-    out = utils.clone_preserve_strides(input)
+    # Mirror at::native::clone_preserve_strides: when the input has internal
+    # memory overlap (e.g. an expand from a scalar with stride 0), we cannot
+    # preserve its strides because copy_to() below would write through aliased
+    # storage and corrupt non-diagonal positions. This arises in the backward
+    # of diagonal_scatter(x, src).sum(), where grad_output is expanded. Fall
+    # back to a plain clone, which materializes a contiguous buffer.
+    if any(
+        guard_or_false(sz > 1) and guard_or_false(s == 0)
+        for sz, s in zip(input.size(), input.stride())
+    ):
+        out = input.clone()
+    else:
+        out = utils.clone_preserve_strides(input)
     diag = out.diagonal(offset, dim1, dim2)
     # Use sym_or + guard_or_false to handle unbacked symbolic dimensions.
     torch._check(


### PR DESCRIPTION
Fixes #182012 



```python
import torch
def fn(x, src):
    return torch.diagonal_scatter(x, src, 0).sum()

x2 = x.clone().detach().requires_grad_(True)
s2 = src.clone().detach().requires_grad_(True)
torch.compile(fn)(x2, s2).backward()
print(f"compiled x2.grad = \n{x2.grad}")
```

Actual IR 
```text
op1: SchedulerNode(ComputedBuffer)
op1.writes = [MemoryDep('buf1', 0, {})]
op1.unmet_dependencies = [StarDep(name='buf0', mode=None)]
op1.met_dependencies = []
op1.outputs = [
    buf1: ComputedBuffer
    buf1.layout = MutationLayoutSHOULDREMOVE('cuda:0', torch.float32, size=[8], stride=[0, 0])
    buf1.mutations = ['buf0']
    buf1.users = [NodeUser(node=OUTPUT, can_inplace=False, is_weak=False)]
]
op1.group.device = cuda:0
op1.group.iteration = (8, 1)
op1.sizes = ([8], [])
buf0_layout = FixedLayout('cuda:0', torch.float32, size=[1, 1], stride=[0, 0])
buf1_layout = MutationLayoutSHOULDREMOVE('cuda:0', torch.float32, size=[8], stride=[0, 0])
class op1_loop_body:
    var_ranges = {p0: 8}
    index0 = 0
    def body(self, ops):
        constant = ops.constant(0.0, torch.float32)
        get_index = self.get_index('index0')
        store = ops.store('buf1', get_index, constant, None)
        return store
```


Expected IR 
```text
op1: SchedulerNode(ComputedBuffer)
op1.writes = [MemoryDep('buf1', 9*d0, {d0: 8})]
op1.unmet_dependencies = [StarDep(name='buf0', mode=None)]
op1.met_dependencies = []
op1.min_input_distance = 1
op1.max_input_distance = 1
op1.outputs = [
    buf1: ComputedBuffer
    buf1.layout = MutationLayoutSHOULDREMOVE('cuda:0', torch.float32, size=[8], stride=[8, 1])
    buf1.mutations = ['buf0']
    buf1.users = [NodeUser(node=OUTPUT, can_inplace=False, is_weak=False)]
]
op1.group.device = cuda:0
op1.group.iteration = (8, 1)
op1.sizes = ([8], [])
buf0_layout = FixedLayout('cuda:0', torch.float32, size=[8, 8], stride=[8, 1])
buf1_layout = MutationLayoutSHOULDREMOVE('cuda:0', torch.float32, size=[8], stride=[8, 1])
class op1_loop_body:
    var_ranges = {p0: 8}
    index0 = 9*p0
    def body(self, ops):
        constant = ops.constant(0.0, torch.float32)
        get_index = self.get_index('index0')
        store = ops.store('buf1', get_index, constant, None)
        return store
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo