### PR TITLE
[CI] Bootstrap pip/setuptools at runtime to recover py_$ANACONDA_PYTHON_VERSION conda env

### DIFF
--- a/.ci/pytorch/common.sh
+++ b/.ci/pytorch/common.sh
@@ -11,6 +11,51 @@ if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]] && [[ -f /etc/rocm_env.sh ]]; then
   source /etc/rocm_env.sh
 fi
 
+# Bootstrap pip/setuptools and the rest of requirements-ci.txt into the
+# per-Python-version conda env if they are missing. Miniforge >=26.3.x ships
+# conda 26.3+, which no longer pulls pip/setuptools into envs created by
+# `conda create python=X` from conda-forge. When that happens the
+# image-build-time `pip install -r /opt/conda/requirements-ci.txt` in
+# install_conda.sh runs in the base env (because there is no pip in
+# py_$VER/bin yet, so `conda run` falls through to base), so all the pinned
+# CI deps (`build`, `ninja`, `hypothesis`, ...) end up in the base env, not
+# in /opt/conda/envs/py_$ANACONDA_PYTHON_VERSION/. Subsequent runtime calls
+# like `python -m pip ...`, `python setup.py ...`, and
+# `python -m build --wheel ...` then break. Fix that here at runtime so we
+# don't need to rebuild the docker image.
+if [[ -n "${ANACONDA_PYTHON_VERSION:-}" ]]; then
+  CONDA_ENV_PREFIX="/opt/conda/envs/py_${ANACONDA_PYTHON_VERSION}"
+  CONDA_ENV_PYTHON="${CONDA_ENV_PREFIX}/bin/python"
+  if [[ -x "${CONDA_ENV_PYTHON}" ]]; then
+    if ! "${CONDA_ENV_PYTHON}" -c 'import pip, setuptools' >/dev/null 2>&1; then
+      echo "Bootstrapping pip and setuptools into ${CONDA_ENV_PREFIX}"
+      conda install -n "py_${ANACONDA_PYTHON_VERSION}" -y -q pip setuptools
+    fi
+    # Use `build` as the canary for "did requirements-ci.txt land in this
+    # env?" — it's pinned in that file but is not a default conda dep. The
+    # Dockerfile rm's /opt/conda/requirements-ci.txt right after
+    # install_conda.sh runs, so at runtime read the requirements file from
+    # the checked-out source tree (.ci/docker/requirements-ci.txt) and fall
+    # back to the in-image copy for older images that may still ship it.
+    REQ_CI_TXT=""
+    for candidate in \
+      "$(dirname "${BASH_SOURCE[0]}")/../docker/requirements-ci.txt" \
+      /opt/conda/requirements-ci.txt; do
+      if [[ -f "$candidate" ]]; then
+        REQ_CI_TXT="$candidate"
+        break
+      fi
+    done
+    if [[ -n "$REQ_CI_TXT" ]] && \
+       ! "${CONDA_ENV_PYTHON}" -c 'import build' >/dev/null 2>&1; then
+      echo "Re-installing $REQ_CI_TXT into ${CONDA_ENV_PREFIX}"
+      "${CONDA_ENV_PYTHON}" -m pip install -r "$REQ_CI_TXT"
+    fi
+    unset REQ_CI_TXT
+  fi
+  unset CONDA_ENV_PREFIX CONDA_ENV_PYTHON
+fi
+
 # Required environment variables:
 #   $BUILD_ENVIRONMENT (should be set by your Docker image)
 


### PR DESCRIPTION
## Summary

Linux aarch64 (and other Linux Python) builds began failing today with:

```
+ python -mpip install numpy==2.0.2
/opt/conda/envs/py_3.10/bin/python: No module named pip
```

(plus `ModuleNotFoundError: No module named 'setuptools'` a few lines earlier from `python setup.py clean`).

Example: run [25325785903](https://github.com/pytorch/pytorch/actions/runs/25325785903) / job [74246179874](https://github.com/pytorch/pytorch/actions/runs/25325785903/job/74246179874) (`linux-jammy-aarch64-py3.10 / build`).

## Root cause

`.ci/docker/common/install_conda.sh` fetches Miniforge from
`https://github.com/conda-forge/miniforge/releases/latest/download`. Miniforge
**26.3.2-0** was published on **2026-05-02 20:29 UTC** and ships **conda 26.3.2**.
With that conda version, `conda create python=X` from conda-forge no longer
pulls in `pip` and `setuptools` by default, so the freshly-created
`/opt/conda/envs/py_$VER/` env has no pip and no setuptools.

The next step in the same script —

```bash
pip_install -r /opt/conda/requirements-ci.txt
```

— calls `conda run -n py_$VER pip install ...`. Because there is no `pip` in
`py_$VER/bin`, `conda run` falls through to the base-env `pip`, which then
installs the pinned `pip==26.0.1` / `setuptools==78.1.1` from
`requirements-ci.txt` **into the base env, not into `py_$VER`**. The docker
build "succeeds" but the resulting image has no pip in the per-Python-version
env, and runtime `python -mpip ...` calls in `.ci/pytorch/build.sh` blow up.

The new aarch64 docker image (tag `…-cd624ae94772f20ff8864780d2bd0e84626d064f`) was rebuilt today (2026-05-04) and is the first image to pick up Miniforge 26.3.2, which is what surfaced the regression.

## Fix

Bootstrap `pip` and `setuptools` at **runtime** in `.ci/pytorch/common.sh` (sourced by `build.sh`, `test.sh`, and the other Linux CI entrypoints), so we do **NOT** change `.ci/docker/`, do **NOT** change the docker tree hash, and do **NOT** trigger a docker image rebuild. If the per-Python-version conda env exists but lacks `pip`/`setuptools`, install them via `conda install` before any python invocation that needs them.

```diff
+# Bootstrap pip and setuptools into the per-Python-version conda env if they
+# are missing. Miniforge >=26.3.x ships conda 26.3+, which no longer pulls
+# pip/setuptools into envs created by `conda create python=X` from
+# conda-forge. ...
+if [[ -n "${ANACONDA_PYTHON_VERSION:-}" ]]; then
+  CONDA_ENV_PREFIX="/opt/conda/envs/py_${ANACONDA_PYTHON_VERSION}"
+  if [[ -x "${CONDA_ENV_PREFIX}/bin/python" ]] && \
+     ! "${CONDA_ENV_PREFIX}/bin/python" -c 'import pip, setuptools' >/dev/null 2>&1; then
+    echo "Bootstrapping pip and setuptools into ${CONDA_ENV_PREFIX}"
+    conda install -n "py_${ANACONDA_PYTHON_VERSION}" -y -q pip setuptools
+  fi
+  unset CONDA_ENV_PREFIX
+fi
```

Once `.ci/docker/` changes for any unrelated reason and the image is rebuilt cleanly with the right pip/setuptools baked in, this bootstrap becomes a silent no-op. A follow-up patch can also explicitly add `pip setuptools` to the `conda create` line in `install_conda.sh` to avoid this footgun on future Miniforge updates — left out of this PR to keep it docker-rebuild-free.

## Test plan

- [ ] CI on this PR does **not** rebuild any docker images (no `.ci/docker/**` files changed; docker tag = `git rev-parse HEAD:.ci/docker` is unchanged).
- [ ] `linux-jammy-aarch64-py3.10 / build` and other Linux Python builds (3.10/3.11/3.12) pass on this PR using the existing pre-built images.
- [ ] Bootstrap is a no-op on environments where pip/setuptools are already present (guarded by `! python -c 'import pip, setuptools'`).
- [ ] Bootstrap is a no-op on environments without conda (guarded by `[[ -x ${CONDA_ENV_PREFIX}/bin/python ]]`).

## Notes

AI-assisted (Claude) — author has reviewed the change and is responsible for it.
