### PR TITLE
Fix typos in knapsack_evaluator docstring

### DIFF
--- a/torch/_functorch/_activation_checkpointing/knapsack_evaluator.py
+++ b/torch/_functorch/_activation_checkpointing/knapsack_evaluator.py
@@ -40,9 +40,9 @@ class KnapsackEvaluator:
                 If full graph is defined then will sort the full graph and only process the subset
                 of nodes in the node_graph.
             3. Iterate through the sorted graph nodes.
-                If the node is saved then just drop it's memory from current memory.
-                If the node is not saved then add it's memory to current memory and then traverse it's
-                predecessors to simulate recomuptation chain. Will check if new peak memory after all
+                If the node is saved then just drop its memory from current memory.
+                If the node is not saved then add its memory to current memory and then traverse its
+                predecessors to simulate recomputation chain. Will check if new peak memory after all
                 predecessors are processed.
 
         Args:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Fix possessive "it's" → "its" and misspelling "recomuptation" →
"recomputation" in the KnapsackEvaluator.evaluate docstring.

Authored with Claude (typo_terminator2).