### PR TITLE
[release/2.12] [CI] Bootstrap pip/setuptools at runtime to recover py_$ANACONDA_PYTHON_VERSION conda env

### DIFF
--- a/.ci/pytorch/common.sh
+++ b/.ci/pytorch/common.sh
@@ -11,6 +11,24 @@ if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]] && [[ -f /etc/rocm_env.sh ]]; then
   source /etc/rocm_env.sh
 fi
 
+# Bootstrap pip and setuptools into the per-Python-version conda env if they
+# are missing. Miniforge >=26.3.x ships conda 26.3+, which no longer pulls
+# pip/setuptools into envs created by `conda create python=X` from
+# conda-forge. Docker images built against that Miniforge can end up with no
+# pip/setuptools in /opt/conda/envs/py_$ANACONDA_PYTHON_VERSION/, which then
+# breaks runtime invocations like `python -m pip install ...` and
+# `python setup.py ...`. Fix that here at runtime so we don't need to rebuild
+# the docker image.
+if [[ -n "${ANACONDA_PYTHON_VERSION:-}" ]]; then
+  CONDA_ENV_PREFIX="/opt/conda/envs/py_${ANACONDA_PYTHON_VERSION}"
+  if [[ -x "${CONDA_ENV_PREFIX}/bin/python" ]] && \
+     ! "${CONDA_ENV_PREFIX}/bin/python" -c 'import pip, setuptools' >/dev/null 2>&1; then
+    echo "Bootstrapping pip and setuptools into ${CONDA_ENV_PREFIX}"
+    conda install -n "py_${ANACONDA_PYTHON_VERSION}" -y -q pip setuptools
+  fi
+  unset CONDA_ENV_PREFIX
+fi
+
 # Required environment variables:
 #   $BUILD_ENVIRONMENT (should be set by your Docker image)
 


### PR DESCRIPTION
## Summary

Manual cherry-pick of #182297 onto `release/2.12`.

Linux Python builds on `release/2.12` started failing today with:

```
+ python -mpip install numpy==2.0.2
/opt/conda/envs/py_3.10/bin/python: No module named pip
```

(plus `ModuleNotFoundError: No module named 'setuptools'` from `python setup.py clean`).

## Root cause

`.ci/docker/common/install_conda.sh` fetches Miniforge from
`https://github.com/conda-forge/miniforge/releases/latest/download`. Miniforge
**26.3.2-0** was published on **2026-05-02 20:29 UTC** and ships **conda 26.3.2**.
With that conda version, `conda create python=X` from conda-forge no longer
pulls `pip` and `setuptools` into the env by default, so freshly-built docker
images have no pip/setuptools in `/opt/conda/envs/py_$VER/`. The subsequent
`pip_install -r requirements-ci.txt` step in `install_conda.sh` silently falls
through to the base-env `pip` and installs the pinned versions into the wrong
env, so the regression is invisible at docker-build time and only surfaces at
runtime.

## Fix

Bootstrap `pip` and `setuptools` at runtime in `.ci/pytorch/common.sh`
(sourced by `build.sh`, `test.sh`, and the other Linux CI entrypoints).
Guarded so it's a no-op when `ANACONDA_PYTHON_VERSION` is unset, the env
doesn't exist, or pip/setuptools are already importable. Does **not** modify
`.ci/docker/`, so the docker tree hash is unchanged and **no docker rebuild
is triggered** on `release/2.12`.

## Cherry-pick notes

- Source PR: #182297 (commit `685c58151887df5c11640c942b151e8c392f14ab` on `main`).
- Applied cleanly to `release/2.12` — `.ci/pytorch/common.sh` is identical between `main` and `release/2.12`.
- No code changes vs. the main PR; commit message gets a `(cherry picked from commit ...)` trailer.

## Test plan

- [ ] CI on this PR does **not** rebuild any docker images (no `.ci/docker/**` files changed).
- [ ] Linux Python builds (3.10/3.11/3.12) on `release/2.12` pass on this PR using the existing pre-built images.
- [ ] Bootstrap is a no-op on environments where pip/setuptools are already present.

## Notes

AI-assisted (Claude) — author has reviewed the change and is responsible for it.
