### PR TITLE
[MPS] Fix bool mask handling in 1-pass SDPA decode kernel (#182285)

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Attention.metal
+++ b/aten/src/ATen/native/mps/kernels/Attention.metal
@@ -34,9 +34,9 @@ template <typename T, int D, int V = D>
   const uint k_seq_stride = qkv_seq_strides.y;
   const uint v_head_stride = qkv_head_strides.z;
   const uint v_seq_stride = qkv_seq_strides.z;
-  const uint mask_head_stride = mask_strides.x;
-  const uint mask_kv_seq_stride = mask_strides.y;
-  const uint mask_q_seq_stride = mask_strides.z;
+  const uint mask_kv_seq_stride = mask_strides.x;
+  const uint mask_q_seq_stride = mask_strides.y;
+  const uint mask_head_stride = mask_strides.z;
   uint inner_k_stride = BN * int(k_seq_stride);
   uint inner_v_stride = BN * int(v_seq_stride);
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9953,6 +9953,22 @@ class TestSDPA(TestCaseMPS):
         out_mps = F.scaled_dot_product_attention(q.to('mps'), k.to('mps'), v.to('mps'), attn_mask=mask.to('mps'))
         self._compare_tensors(out_mps.cpu(), out_cpu)
 
+    @parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_sdpa_math_mps_bool_mask_1pass(self, dtype):
+        torch.manual_seed(0)
+        q = torch.randn(1, 1, 8, 64, dtype=dtype, device='mps')
+        k = torch.randn(1, 1, 512, 64, dtype=dtype, device='mps')
+        v = torch.randn(1, 1, 512, 64, dtype=dtype, device='mps')
+        mask = torch.eye(8, 512, dtype=torch.bool, device='mps')
+
+        out_mps, _ = torch.ops.aten._scaled_dot_product_attention_math_for_mps(
+            q, k, v, mask
+        )
+        out_cpu = F.scaled_dot_product_attention(
+            q.cpu(), k.cpu(), v.cpu(), attn_mask=mask.cpu()
+        )
+        self._compare_tensors(out_mps.cpu(), out_cpu)
+
     @parametrize("dtype", [torch.bfloat16, torch.float16, torch.float])
     def test_sdpa_2pass(self, dtype):
         # Regression test for https://github.com/pytorch/pytorch/issues/174861


### PR DESCRIPTION
Cherry-pick of #182285 onto release/2.12.

Adapts the kernel change to apply against `aten/src/ATen/native/mps/kernels/Attention.metal` (the rename to `DecodeAttention.h` did not happen on this branch).

Original commit: f6c73b47b169496b93efeb129a5a98cf8029052a
