### PR TITLE
Document that .ci/docker/ is content-hashed for Docker rebuilds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,15 @@ When asked to review a PR, always use the /pr-review skill.
 
 If any tool you're trying to use (pip, python, spin, etc) is missing, always stop and ask the user if an environment is needed. Do NOT try to find alternatives or install these tools.
 
+# CI Docker Images
+
+The `.ci/docker/` directory is content-hashed to determine whether Docker images
+need rebuilding. Any file change inside `.ci/docker/` (including the README)
+changes the hash and triggers a full Docker image rebuild. Do not make changes
+in this directory unless you intend to rebuild Docker images. When Docker builds
+are broken (e.g., due to an upstream Ubuntu outage), avoid touching this
+directory so you don't force a rebuild against the broken state.
+
 # Build
 
 Always check local memory for build configuration (env vars, incremental-build shortcuts, etc.) before running the build, and apply what you find. If nothing applicable is in memory, ask the user.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #182320

Changing any file in .ci/docker/ triggers a full Docker image rebuild,
so avoid touching it when Docker builds are broken upstream.

Authored by Claude.