### PR TITLE
[inductor] Remove del statement to fix RUFF F821 lint in combo kernel benchmark cleanup

### DIFF
--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6949,6 +6949,8 @@ class TritonScheduling(SIMDScheduling):
             total_ms += ms
             total_clone_ms += ms_clone
             file_list.append(mod.__file__)
+            args = call = wrapped_jit_function = None
+            torch.accelerator.empty_cache()
         V.graph.removed_buffers = removed_buffers_orig
         V.graph.inplaced_to_remove = inplaced_to_remove_orig
         return total_ms, total_clone_ms, file_list


### PR DESCRIPTION
Summary:
Follow-up to D103152384. The `del args, call, wrapped_jit_function` statement
caused RUFF F821 ("undefined name") lint failures on the GitHub OSS CI because
the static linter sees the `del` and flags subsequent lambda references to those
variables as potentially undefined, even though at runtime the lambdas execute
before the `del` in each loop iteration.

Replace `del` with `args = call = wrapped_jit_function = None` which achieves
the same effect (releases tensor references so the caching allocator can reclaim
GPU memory) without triggering the RUFF lint.

Note: `torch.accelerator.empty_cache()` alone is NOT sufficient — the tensor
references must be explicitly released first, otherwise the caching allocator
cannot reclaim the memory. Verified: run with only `empty_cache()` (no `del`
or `= None`) OOMed at 188 GiB (run 34), while run with `= None` +
`empty_cache()` succeeded (run 35).

Test Plan:
- Run 34: empty_cache() only (no del or None), combo_kernels=True, truly cold cache → OOM at 188 GiB
- Run 35: args=call=wrapped_jit_function=None + empty_cache(), combo_kernels=True, truly cold cache → SUCCESS (.so generated, 0 OOM)
- Original fix (del + empty_cache): 4/4 success on truly cold cache (runs 28-30, 33)
- Without any fix: 6/6 OOM on truly cold cache (runs 17b, 18, 21-23, 26)

Differential Revision: D103576552




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo