### PR TITLE
Fix RuntimeError formatting in AdaptiveLogSoftmaxWithLoss

### DIFF
--- a/torch/nn/modules/adaptive.py
+++ b/torch/nn/modules/adaptive.py
@@ -196,16 +196,14 @@ class AdaptiveLogSoftmaxWithLoss(Module):
                 )
             if input_.dim() != 2:
                 raise RuntimeError(
-                    "1D target tensor expects 2D input tensors, "
-                    "but found inputs with size",
-                    input_.size(),
+                    f"1D target tensor expects 2D input tensors, "
+                    f"but found inputs with size {input_.size()}"
                 )
         elif targ_dim == 0:
             if input_.dim() != 1:
                 raise RuntimeError(
-                    "0D target tensor expects 1D input tensors, "
-                    "but found inputs with size",
-                    input_.size(),
+                    f"0D target tensor expects 1D input tensors, "
+                    f"but found inputs with size {input_.size()}"
                 )
         else:
             raise RuntimeError(


### PR DESCRIPTION
Summary:
**Context**: `AdaptiveLogSoftmaxWithLoss.forward()` validates input dimensions against target dimensions. When mismatched, it raises `RuntimeError` to inform the user.

**This diff**: The `RuntimeError` calls on lines 198 and 205 pass the error message and `input_.size()` as separate arguments (comma-separated), which constructs the exception with a tuple of `(str, torch.Size)` instead of a single formatted string. This means the error message displays as `('1D target tensor expects 2D input tensors, but found inputs with size', torch.Size([...]))` instead of a clean message. Fix by using f-strings to interpolate the size into the message.

Test Plan: Existing tests in `test/test_nn.py:5598` and `test/test_nn.py:5601` use `assertRaisesRegex(RuntimeError, "1D target tensor expects 2D input tensors")` and `assertRaisesRegex(RuntimeError, "0D target tensor expects 1D input tensors")` which continue to match since the message text is unchanged -- only the formatting was fixed from tuple args to f-string. No new tests needed.

Differential Revision: D103573741


