### PR TITLE
[inductor][autotuning] pipeline AsyncCompile + CachingAutotuner (#182334)

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -1,10 +1,18 @@
 # Owner(s): ["module: inductor"]
 
 import functools
+import io
 import os
+import pickle
+import queue
+import socket
+import stat
 import sys
 import tempfile
+import threading
+import time
 import unittest
+from concurrent.futures import Future
 from unittest import skipUnless
 from unittest.mock import MagicMock, patch
 
@@ -527,6 +535,629 @@ class TestCachingAutotunerPlugin(TestCase):
         revived = CachingAutotuner.__new__(CachingAutotuner)
         revived.__setstate__(state)
         self.assertEqual(revived._plugins, [])
+
+
+class TestPipelineCachingAutotunerPlugin(TestCase):
+    """Synchronization between ``_bg_drain_kernel`` and the plugin's
+    ``pre_dispatch`` hook on multi-config, single-config, overlap, and
+    error paths."""
+
+    device_type = GPU_TYPE
+
+    @staticmethod
+    def _make_handle(
+        *,
+        num_configs,
+        drain_done=True,
+        drain_exc=None,
+        push_launcher_end=True,
+    ):
+        """Build a ``PipelineCachingAutotunerHandle`` with the drain
+        future pre-resolved per the simulation knobs."""
+        from torch._inductor.async_compile import (
+            _LAUNCHER_END,
+            PipelineCachingAutotunerHandle,
+        )
+
+        drain_fut: Future = Future()
+        if drain_exc is not None:
+            drain_fut.set_exception(drain_exc)
+        elif drain_done:
+            drain_fut.set_result(None)
+        launcher_q: queue.Queue = queue.Queue()
+        if push_launcher_end:
+            launcher_q.put(_LAUNCHER_END)
+        return PipelineCachingAutotunerHandle(
+            launcher_q=launcher_q,
+            drain_future=drain_fut,
+            num_configs=num_configs,
+            kernel_name="test_kernel",
+        )
+
+    def _make_autotuner(self):
+        args = TestTritonHeuristics._get_cos_kernel_caching_autotuner_args()
+        args["inductor_meta"] = {**args["inductor_meta"], "grid_type": "Grid1D"}
+        return CachingAutotuner(**args)
+
+    def _make_plugin(self):
+        from torch._inductor.async_compile import (
+            _make_pipeline_caching_autotuner_plugin,
+        )
+
+        return _make_pipeline_caching_autotuner_plugin()
+
+    def test_pre_dispatch_no_op_without_handle(self):
+        """No stashed handle → ``pre_dispatch`` is a no-op (returns
+        ``DEFER``)."""
+        from torch._inductor.runtime.triton_heuristics import DEFER
+
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        result = plugin.pre_dispatch(autotuner, stream=0)
+        self.assertIs(result, DEFER)
+
+    def test_pre_dispatch_single_config_waits_for_drain_no_bench(self):
+        """Single-config kernel: plugin awaits ``drain_future`` and
+        proceeds without bench. ``run()``'s standard flow then sees
+        ``len(launchers) == 1`` and skips autotune."""
+        from torch._inductor.runtime.triton_heuristics import DEFER
+
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        launcher = MagicMock()
+        autotuner.launchers = [launcher]
+        autotuner.compile_results = [MagicMock()]
+        autotuner._pipeline_caching_autotuner_handle = self._make_handle(
+            num_configs=1
+        )
+        autotuner.bench = MagicMock()
+
+        result = plugin.pre_dispatch(autotuner, stream=0)
+
+        self.assertIs(result, DEFER)
+        autotuner.bench.assert_not_called()
+        self.assertEqual(autotuner.launchers, [launcher])
+        self.assertIsNone(autotuner._pipeline_caching_autotuner_handle)
+
+    def test_pre_dispatch_multi_config_drains_launcher_q_picks_winner(self):
+        """Multi-config kernel: plugin pulls launchers from
+        ``handle.launcher_q``, benches each via ``_bench_launchers``,
+        and ``_finalize_autotune_winner`` reduces ``autotuner.launchers``
+        to ``[winner]``."""
+        from torch._inductor.runtime.triton_heuristics import DEFER
+
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        launcher_fast, launcher_slow = MagicMock(), MagicMock()
+        launcher_fast.cache_hash = "lf"
+        launcher_slow.cache_hash = "ls"
+        autotuner.launchers = [launcher_fast, launcher_slow]
+        autotuner.compile_results = [MagicMock(), MagicMock()]
+        handle = self._make_handle(num_configs=2)
+        for launcher in (launcher_fast, launcher_slow):
+            # Insert before the LAUNCHER_END that _make_handle pushed.
+            handle.launcher_q.queue.insert(-1, launcher)
+        autotuner._pipeline_caching_autotuner_handle = handle
+        autotuner.bench = MagicMock(side_effect=[1.0, 5.0])
+        autotuner.coordesc_tuner = MagicMock()
+        autotuner.save_cache_hook = None
+        autotuner.get_device_interface = MagicMock()
+
+        with patch("torch._dynamo.device_interface.DeviceGuard"):
+            result = plugin.pre_dispatch(autotuner, stream=0)
+
+        self.assertIs(result, DEFER)
+        self.assertEqual(autotuner.bench.call_count, 2)
+        self.assertEqual(autotuner.launchers, [launcher_fast])
+        self.assertIsNone(autotuner._pipeline_caching_autotuner_handle)
+
+    def test_pre_dispatch_multi_config_overlaps_with_bg_drain(self):
+        """Plugin consumes ``launcher_q`` blocking-style — it begins
+        benching as soon as the FIRST launcher arrives, without waiting
+        for the bg drain to finish making all of them."""
+        from torch._inductor.async_compile import _LAUNCHER_END
+        from torch._inductor.runtime.triton_heuristics import DEFER
+
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        launcher_a, launcher_b = MagicMock(), MagicMock()
+        launcher_a.cache_hash = "la"
+        launcher_b.cache_hash = "lb"
+        autotuner.launchers = [launcher_a, launcher_b]
+        autotuner.compile_results = [MagicMock(), MagicMock()]
+        handle = self._make_handle(num_configs=2, push_launcher_end=False)
+        autotuner._pipeline_caching_autotuner_handle = handle
+        autotuner.coordesc_tuner = MagicMock()
+        autotuner.save_cache_hook = None
+        autotuner.get_device_interface = MagicMock()
+
+        bench_results = [1.0, 5.0]
+        bench_call_observed = threading.Event()
+
+        def bench_side_effect(*args, **kwargs):
+            bench_call_observed.set()
+            return bench_results.pop(0)
+
+        autotuner.bench = MagicMock(side_effect=bench_side_effect)
+
+        def pusher():
+            handle.launcher_q.put(launcher_a)
+            # Wait until the plugin has actually started benching
+            # launcher_a before we push launcher_b — proves the plugin
+            # didn't block waiting for all launchers up-front.
+            bench_call_observed.wait(timeout=2.0)
+            handle.launcher_q.put(launcher_b)
+            handle.launcher_q.put(_LAUNCHER_END)
+
+        t = threading.Thread(target=pusher, daemon=True)
+        t.start()
+
+        with patch("torch._dynamo.device_interface.DeviceGuard"):
+            result = plugin.pre_dispatch(autotuner, stream=0)
+        t.join(timeout=2.0)
+
+        self.assertIs(result, DEFER)
+        self.assertEqual(autotuner.bench.call_count, 2)
+        self.assertEqual(autotuner.launchers, [launcher_a])
+
+    def test_pre_dispatch_reraises_drain_exception(self):
+        """If the bg drainer caught an exception, ``drain_future`` is
+        resolved with it (and ``_LAUNCHER_END`` is pushed so the plugin's
+        bench loop terminates). The plugin re-raises via
+        ``drain_future.result()`` so the user sees the failure."""
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        autotuner.launchers = []
+        autotuner.compile_results = []
+        autotuner._pipeline_caching_autotuner_handle = self._make_handle(
+            num_configs=1, drain_exc=RuntimeError("boom")
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            plugin.pre_dispatch(autotuner, stream=0)
+
+    def test_pre_dispatch_raises_when_zero_results_streamed(self):
+        """Worker-side total-failure surfaces ``NoTritonConfigsError``
+        when the bg drainer ends with no compile_results AND no launchers."""
+        from torch._inductor.runtime.triton_heuristics import (
+            NoTritonConfigsError,
+        )
+
+        plugin = self._make_plugin()
+        autotuner = self._make_autotuner()
+        autotuner.launchers = []
+        autotuner.compile_results = []
+        autotuner._pipeline_caching_autotuner_handle = self._make_handle(
+            num_configs=1
+        )
+
+        with self.assertRaises(NoTritonConfigsError):
+            plugin.pre_dispatch(autotuner, stream=0)
+
+
+class TestStreamingPickler(TestCase):
+    """Wire-format coverage for ``_StreamingPickler`` /
+    ``_StreamingUnpickler``: every object the persistent_id callback
+    substitutes must round-trip to ``None`` on the parent side, and
+    everything else must pass through untouched."""
+
+    @staticmethod
+    def _round_trip(obj):
+        from torch._inductor.runtime.compile_tasks import (
+            _StreamingPickler,
+            _StreamingUnpickler,
+        )
+
+        buf = io.BytesIO()
+        _StreamingPickler(buf, protocol=pickle.HIGHEST_PROTOCOL).dump(obj)
+        buf.seek(0)
+        return _StreamingUnpickler(buf).load()
+
+    def test_rlock_substituted_with_none(self):
+        loaded = self._round_trip({"lock": threading.RLock(), "value": 42})
+        self.assertIsNone(loaded["lock"])
+        self.assertEqual(loaded["value"], 42)
+
+    def test_module_substituted_with_none(self):
+        loaded = self._round_trip({"mod": os, "name": "hello"})
+        self.assertIsNone(loaded["mod"])
+        self.assertEqual(loaded["name"], "hello")
+
+    def test_dyn_module_function_substituted_with_none(self):
+        from types import ModuleType
+
+        from torch._inductor.runtime.compile_tasks import (
+            _DYN_KERNEL_MODULE_PREFIX,
+        )
+
+        fake_mod_name = f"{_DYN_KERNEL_MODULE_PREFIX}fake_test_kernel"
+        fake_mod = ModuleType(fake_mod_name)
+        sys.modules[fake_mod_name] = fake_mod
+        try:
+            exec("def fake_kernel(): pass", fake_mod.__dict__)
+            loaded = self._round_trip({"fn": fake_mod.fake_kernel, "value": "x"})
+            self.assertIsNone(loaded["fn"])
+            self.assertEqual(loaded["value"], "x")
+        finally:
+            del sys.modules[fake_mod_name]
+
+    def test_normal_function_preserved(self):
+        # math.sqrt is a builtin, importable on the parent.
+        import math
+
+        loaded = self._round_trip({"fn": math.sqrt, "value": 9})
+        self.assertIs(loaded["fn"], math.sqrt)
+        self.assertEqual(loaded["value"], 9)
+
+    def test_unknown_persistent_id_raises(self):
+        from torch._inductor.runtime.compile_tasks import _StreamingUnpickler
+
+        class BadPickler(pickle.Pickler):
+            def persistent_id(self, obj):
+                if isinstance(obj, list):
+                    return ("bogus_id",)
+                return None
+
+        buf = io.BytesIO()
+        BadPickler(buf, protocol=pickle.HIGHEST_PROTOCOL).dump({"data": [1, 2]})
+        buf.seek(0)
+        with self.assertRaises(pickle.UnpicklingError):
+            _StreamingUnpickler(buf).load()
+
+
+class TestStreamingTransport(TestCase):
+    """Process-wide shared AF_UNIX listener: worker connects, sends per-kernel
+    id to identify itself to the dispatcher, streams the wire protocol
+    (_Kernel / _Success / _Failure / _Done). Same-UID trust model -- id is
+    identification only, not authentication."""
+
+    @staticmethod
+    def _fake_worker(sock_path, kernel_id, messages):
+        """Mimics _stream_compile_triton: connect + send kernel id + send each
+        wire-protocol message via _streaming_send."""
+        from multiprocessing.connection import Connection
+
+        from torch._inductor.runtime.compile_tasks import _streaming_send
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(sock_path)
+        sock.sendall(kernel_id)
+        conn = Connection(sock.detach())
+        try:
+            for m in messages:
+                _streaming_send(conn, m)
+        finally:
+            conn.close()
+
+    def test_listener_round_trip(self):
+        """Register a kernel, connect a fake worker that sends id +
+        _Kernel + 2 _Success + _Done. Parent reads them through
+        _streaming_decode and dispatches."""
+        from multiprocessing.connection import Connection
+
+        from torch._inductor.async_compile import _setup_streaming_listener
+        from torch._inductor.runtime.compile_tasks import (
+            _Done,
+            _Kernel,
+            _streaming_decode,
+            _Success,
+        )
+
+        sock_path, kernel_id, conn_future = _setup_streaming_listener("k")
+        outgoing = [
+            _Kernel("fake-kernel-payload"),
+            _Success("result-1"),
+            _Success("result-2"),
+            _Done(),
+        ]
+        t = threading.Thread(
+            target=self._fake_worker,
+            args=(sock_path, kernel_id, outgoing),
+            daemon=True,
+        )
+        t.start()
+        conn_sock = conn_future.result(timeout=10.0)
+        parent = Connection(conn_sock.detach())
+        try:
+            seen = []
+            while True:
+                msg = _streaming_decode(parent.recv_bytes())
+                seen.append(msg)
+                if isinstance(msg, _Done):
+                    break
+            self.assertIsInstance(seen[0], _Kernel)
+            self.assertEqual(seen[0].kernel, "fake-kernel-payload")
+            self.assertEqual(
+                [m.result for m in seen[1:-1] if isinstance(m, _Success)],
+                ["result-1", "result-2"],
+            )
+            self.assertIsInstance(seen[-1], _Done)
+        finally:
+            parent.close()
+        t.join(timeout=2.0)
+
+    def test_setup_streaming_listener_unique_per_kernel_state(self):
+        """Each call shares the same listener path but returns a unique id
+        and Future. Listener path is owner-only (0600)."""
+        from torch._inductor.async_compile import (
+            _setup_streaming_listener,
+            _STREAMING_KERNEL_ID_SIZE,
+        )
+
+        path1, id1, fut1 = _setup_streaming_listener("k1")
+        path2, id2, fut2 = _setup_streaming_listener("k2")
+        self.assertEqual(path1, path2)  # shared listener
+        self.assertNotEqual(id1, id2)
+        self.assertEqual(len(id1), _STREAMING_KERNEL_ID_SIZE)
+        self.assertIsNot(fut1, fut2)
+        self.assertEqual(stat.S_IMODE(os.stat(path1).st_mode), 0o600)
+
+    def test_unknown_kernel_id_dropped(self):
+        """Connecting with an id not in the registry: dispatcher silently
+        drops the connection (no kernel waiting)."""
+        from torch._inductor.async_compile import (
+            _ensure_shared_listener,
+            _STREAMING_KERNEL_ID_SIZE,
+        )
+
+        sock_path = _ensure_shared_listener()
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(sock_path)
+        sock.sendall(b"\x00" * _STREAMING_KERNEL_ID_SIZE)  # never registered
+        # Dispatcher closes the connection; reading should hit EOF.
+        sock.settimeout(5.0)
+        data = sock.recv(1)
+        self.assertEqual(data, b"")
+        sock.close()
+
+    def test_short_read_on_kernel_id_dropped(self):
+        """Worker connects but sends fewer than ``_STREAMING_KERNEL_ID_SIZE``
+        bytes then closes. Dispatcher drops the connection without crashing
+        and continues serving subsequent connections normally."""
+        from torch._inductor.async_compile import (
+            _ensure_shared_listener,
+            _setup_streaming_listener,
+            _STREAMING_KERNEL_ID_SIZE,
+        )
+
+        sock_path = _ensure_shared_listener()
+        # Send a half-sized id then close. The dispatcher's recv loop sees
+        # the EOF mid-read and raises OSError("short read on kernel id"),
+        # which the loop catches + closes the conn.
+        bad = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        bad.connect(sock_path)
+        bad.sendall(b"\xab" * (_STREAMING_KERNEL_ID_SIZE // 2))
+        bad.close()
+
+        # A subsequent valid registration must still dispatch end-to-end.
+        _, kernel_id, conn_future = _setup_streaming_listener("k_after_short")
+        t = threading.Thread(
+            target=self._fake_worker,
+            args=(sock_path, kernel_id, ["only-payload"]),
+            daemon=True,
+        )
+        t.start()
+        conn_sock = conn_future.result(timeout=10.0)
+        try:
+            self.assertIsNotNone(conn_sock)
+        finally:
+            conn_sock.close()
+        t.join(timeout=2.0)
+
+    def test_drop_streaming_registration_removes_id(self):
+        """``_drop_streaming_registration`` must actually pop the id from
+        the registry so the kernel-id space doesn't leak."""
+        from torch._inductor.async_compile import (
+            _drop_streaming_registration,
+            _setup_streaming_listener,
+            _SHARED_REGISTRY,
+            _STREAMING_KERNEL_ID_STRUCT,
+        )
+
+        _, kernel_id, _ = _setup_streaming_listener("k_drop")
+        (parsed_id,) = _STREAMING_KERNEL_ID_STRUCT.unpack(kernel_id)
+        self.assertIn(parsed_id, _SHARED_REGISTRY)
+        _drop_streaming_registration(kernel_id)
+        self.assertNotIn(parsed_id, _SHARED_REGISTRY)
+        # Idempotent: dropping a second time must not raise.
+        _drop_streaming_registration(kernel_id)
+
+    @staticmethod
+    def _make_fake_kernel(make_launcher_returns=None):
+        """Minimal fake satisfying the bg drain's CachingAutotuner interface.
+        ``make_launcher_returns`` is a callable ``result -> (launcher, exc)``;
+        defaults to wrapping the result string as the launcher."""
+        if make_launcher_returns is None:
+            make_launcher_returns = lambda r: (f"launcher_for_{r}", None)  # noqa: E731
+
+        class _FakeKernel:
+            def __init__(self):
+                self._last_compile_exception = None
+                self.fn = type("F", (), {"__name__": "fake_kernel"})()
+                self.triton_meta = {"device": 0}
+                self.compile_results: list = []
+                self.launchers: list = []
+                self.configs: list = []
+                self._dynamic_scale_called = False
+
+            def get_device_interface(self):
+                return MagicMock()
+
+            def _maybe_put_static_autotuner(self, key):
+                pass
+
+            def _bundle_compile_result(self, result):
+                pass
+
+            def _make_launcher(self, result):
+                return make_launcher_returns(result)
+
+            def _all_failed_fallback(self, exc):
+                pass
+
+            def _dynamic_scale_rblock(self, on_launcher=None):
+                self._dynamic_scale_called = True
+
+        return _FakeKernel()
+
+    @staticmethod
+    def _bg_drain_with_noop_device_guard(kernel, conn, handle, key):
+        """Run ``_bg_drain_kernel`` with DeviceGuard patched to a no-op so the
+        test doesn't need a real device."""
+        import contextlib
+        from unittest.mock import patch
+
+        from torch._inductor.async_compile import _bg_drain_kernel
+
+        @contextlib.contextmanager
+        def _noop_guard(*_a, **_k):
+            yield
+
+        with patch(
+            "torch._dynamo.device_interface.DeviceGuard", _noop_guard
+        ):
+            _bg_drain_kernel(kernel, conn, handle, key)
+
+    def test_garbage_payload_propagates_to_drain(self):
+        """Worker sends a valid id then non-zlib bytes. The drain's
+        ``_recv_msg`` raises ``zlib.error``; ``_bg_drain_kernel`` forwards
+        that to ``handle.drain_future`` and pushes ``_LAUNCHER_END``."""
+        from concurrent.futures import Future as _Fut
+        from multiprocessing.connection import Connection
+
+        from torch._inductor.async_compile import (
+            _LAUNCHER_END,
+            _setup_streaming_listener,
+            PipelineCachingAutotunerHandle,
+        )
+
+        sock_path, kernel_id, conn_future = _setup_streaming_listener("k_garbage")
+
+        def _bad_worker():
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.connect(sock_path)
+            s.sendall(kernel_id)
+            payload = b"not-zlib-data"
+            s.sendall(len(payload).to_bytes(4, "big") + payload)
+            s.close()
+
+        threading.Thread(target=_bad_worker, daemon=True).start()
+        conn_sock = conn_future.result(timeout=10.0)
+        conn = Connection(conn_sock.detach())
+
+        handle = PipelineCachingAutotunerHandle(
+            launcher_q=__import__("queue").Queue(),
+            drain_future=_Fut(),
+            num_configs=1,
+            kernel_name="k_garbage",
+        )
+        self._bg_drain_with_noop_device_guard(
+            self._make_fake_kernel(), conn, handle, None
+        )
+
+        with self.assertRaises(BaseException):
+            handle.drain_future.result(timeout=2.0)
+        self.assertIs(handle.launcher_q.get(timeout=2.0), _LAUNCHER_END)
+
+    def test_eof_without_done_is_anomaly(self):
+        """Worker sends a valid kernel id then closes the socket without ever
+        sending a ``_Done``. The drain raises rather than silently treating
+        the empty stream as a successful completion."""
+        from concurrent.futures import Future as _Fut
+        from multiprocessing.connection import Connection
+
+        from torch._inductor.async_compile import (
+            _LAUNCHER_END,
+            _setup_streaming_listener,
+            PipelineCachingAutotunerHandle,
+        )
+
+        sock_path, kernel_id, conn_future = _setup_streaming_listener("k_eof")
+
+        def _silent_worker():
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.connect(sock_path)
+            s.sendall(kernel_id)
+            s.close()  # no _Done, no anything
+
+        threading.Thread(target=_silent_worker, daemon=True).start()
+        conn_sock = conn_future.result(timeout=10.0)
+        conn = Connection(conn_sock.detach())
+
+        handle = PipelineCachingAutotunerHandle(
+            launcher_q=__import__("queue").Queue(),
+            drain_future=_Fut(),
+            num_configs=1,
+            kernel_name="k_eof",
+        )
+        self._bg_drain_with_noop_device_guard(
+            self._make_fake_kernel(), conn, handle, None
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "without sending _Done"):
+            handle.drain_future.result(timeout=2.0)
+        self.assertIs(handle.launcher_q.get(timeout=2.0), _LAUNCHER_END)
+
+    def test_failure_messages_track_last_on_kernel(self):
+        """Worker sends valid kernel id, then two ``_Failure`` messages, then
+        ``_Done``. The drain must NOT build any launchers (no _Success), must
+        set ``kernel._last_compile_exception`` to a RuntimeError carrying the
+        last failure, and must complete the drain_future successfully."""
+        from concurrent.futures import Future as _Fut
+        from multiprocessing.connection import Connection
+
+        from torch._inductor.async_compile import (
+            _LAUNCHER_END,
+            _setup_streaming_listener,
+            PipelineCachingAutotunerHandle,
+        )
+        from torch._inductor.runtime.compile_tasks import (
+            _Done,
+            _Failure,
+            _streaming_send,
+        )
+
+        sock_path, kernel_id, conn_future = _setup_streaming_listener("k_fail")
+
+        def _all_fail_worker():
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.connect(sock_path)
+            s.sendall(kernel_id)
+            wconn = Connection(s.detach())
+            try:
+                _streaming_send(wconn, _Failure("OOM", "first", "tb1"))
+                _streaming_send(wconn, _Failure("OOM", "second", "tb2"))
+                _streaming_send(wconn, _Done())
+            finally:
+                wconn.close()
+
+        threading.Thread(target=_all_fail_worker, daemon=True).start()
+        conn_sock = conn_future.result(timeout=10.0)
+        conn = Connection(conn_sock.detach())
+
+        kernel = self._make_fake_kernel()
+        handle = PipelineCachingAutotunerHandle(
+            launcher_q=__import__("queue").Queue(),
+            drain_future=_Fut(),
+            num_configs=2,
+            kernel_name="k_fail",
+        )
+        self._bg_drain_with_noop_device_guard(kernel, conn, handle, None)
+
+        # No _Success -> nothing built.
+        self.assertEqual(kernel.launchers, [])
+        # drain_future completes cleanly (per-config _Failure is not fatal).
+        self.assertIsNone(handle.drain_future.result(timeout=2.0))
+        # Last failure stashed on the kernel for the all-failed message.
+        last = kernel._last_compile_exception
+        self.assertIsInstance(last, RuntimeError)
+        self.assertIn("OOM", str(last))
+        self.assertIn("second", str(last))
+        # bg drain no longer calls _dynamic_scale_rblock -- the plugin's
+        # pre_dispatch does, after the drain finishes.
+        self.assertFalse(kernel._dynamic_scale_called)
+        # EOF sentinel pushed.
+        self.assertIs(handle.launcher_q.get(timeout=2.0), _LAUNCHER_END)
 
 
 class TestArgumentCloneAndRestore(TestCase):

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -3,21 +3,31 @@ from __future__ import annotations
 
 import atexit
 import functools
+import itertools
 import json
 import logging
 import multiprocessing
 import os
+import queue as _queue
 import re
+import shutil
+import socket
+import struct
 import sys
+import tempfile
+import threading
 from concurrent.futures import (
     Future,
+    InvalidStateError,
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
 )
 from concurrent.futures.process import BrokenProcessPool
+from dataclasses import dataclass
 from functools import partial
+from multiprocessing.connection import Connection
 from time import time, time_ns
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 
 import torch
 from torch._dynamo.device_interface import get_registered_device_interfaces
@@ -52,9 +62,20 @@ from torch._inductor.compile_worker.tracked_process_pool import (
 )
 from torch._inductor.compile_worker.utils import _async_compile_initializer
 from torch._inductor.runtime.compile_tasks import (
+    _Done,
+    _Failure,
+    _Kernel,
     _set_triton_libdevice_path,
     _set_triton_ptxas_path,
+    _streaming_decode,
+    _Success,
+    _try_set_sock_buf,
     _worker_compile_triton,
+)
+from torch._inductor.runtime.triton_heuristics import (
+    CachingAutotunerPlugin,
+    DEFER,
+    NoTritonConfigsError,
 )
 from torch._inductor.utils import clear_on_fresh_cache
 from torch._inductor.virtualized import V
@@ -65,7 +86,7 @@ from torch.utils._triton import has_triton_package
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     from torch._inductor.runtime.hints import HalideMeta
     from torch._inductor.runtime.triton_heuristics import CachingAutotuner
@@ -80,9 +101,419 @@ log = logging.getLogger(__name__)
 
 _triton_kernel_metrics: dict[str, dict[str, Any]] | None = None
 
+# EOF marker on ``launcher_q`` (single producer: ``_bg_drain_kernel``).
+_LAUNCHER_END = object()
+
+
+def _try_set_exception(fut: "Future[Any]", exc: BaseException) -> bool:
+    """Race-tolerant ``Future.set_exception``. Returns True iff the future
+    was actually transitioned to the exception state."""
+    try:
+        fut.set_exception(exc)
+        return True
+    except InvalidStateError:
+        return False
+
+
+def _try_set_result(fut: "Future[Any]", value: Any) -> bool:
+    """Race-tolerant ``Future.set_result``. Returns True iff the future was
+    actually transitioned to the result state. Callers handing off ownership
+    of a resource (e.g. a socket) should release ownership only on True; on
+    False they retain ownership and must clean up themselves."""
+    try:
+        fut.set_result(value)
+        return True
+    except InvalidStateError:
+        return False
+
+
 size_hints_regex = re.compile(
     r"size_hints=(\{.*?\})",
 )
+
+
+@dataclass
+class PipelineCachingAutotunerHandle:
+    """Per-kernel state shared between ``_bg_drain_kernel`` (writer) and
+    ``PipelineCachingAutotunerPlugin.pre_dispatch`` (reader). EOF on
+    ``launcher_q`` is ``_LAUNCHER_END``. ``bg_drain_wait_ns`` is
+    happens-before-published via ``drain_future`` resolution.
+    """
+
+    launcher_q: _queue.Queue[object]
+    drain_future: Future[None]
+    num_configs: int
+    kernel_name: str
+    bg_drain_wait_ns: int = 0
+
+
+# One process-wide tmpdir for the shared streaming-compile AF_UNIX listener,
+# lazy-created.
+_STREAMING_SOCK_DIR: str | None = None
+_STREAMING_SOCK_DIR_LOCK = threading.Lock()
+
+# 10 minutes. Bounds both kernel-handshake wait and recv_bytes() (per-config
+# compile). Picked to be far above any realistic compile time so that only a
+# wedged worker trips it.
+_STREAMING_TIMEOUT_S = 600.0
+
+# Kernel-id read timeout in the shared accept loop. Workers send the id
+# microseconds after connect; a few seconds is plenty and bounds the head-of-
+# line blocking caused by a slow worker.
+_STREAMING_KERNEL_ID_READ_TIMEOUT_S = 5.0
+
+# 8-byte big-endian uint64 wire format for the kernel id. Same-UID trust
+# model -- this is identification only, not authentication.
+_STREAMING_KERNEL_ID_STRUCT = struct.Struct(">Q")
+_STREAMING_KERNEL_ID_SIZE = _STREAMING_KERNEL_ID_STRUCT.size
+
+# Monotonic kernel-id source. Wraps after 2**64 kernels in a single process,
+# which is unreachable in practice.
+_STREAMING_KERNEL_ID_COUNTER = itertools.count(1)
+
+# Send/recv buffer size for streaming-compile sockets. CompileResult payloads
+# observed at p95 ~640 KiB and max ~665 KiB; 4 MiB gives the worker headroom
+# for several pending messages without blocking in send() when the drain
+# thread is briefly busy. Capped by net.core.{w,r}mem_max (typically 20 MiB).
+_STREAMING_SOCK_BUF = 4 * 1024 * 1024
+
+
+# One process-wide AF_UNIX listener (shared listener). Workers all connect
+# here; an accept loop reads a per-kernel id from each incoming connection
+# and dispatches it to the registered Future. Saves the per-kernel
+# bind/listen/inode that the original per-kernel-listener design paid.
+_SHARED_LISTENER: socket.socket | None = None
+_SHARED_LISTENER_PATH: str | None = None
+_SHARED_LISTENER_LOCK = threading.Lock()
+_SHARED_REGISTRY: dict[int, "Future[socket.socket]"] = {}
+_SHARED_REGISTRY_LOCK = threading.Lock()
+
+# Process-wide thread pool for ``_bg_drain_kernel`` execution. Sized to match
+# the compile-worker pool: at most ``compile_threads`` kernels can be in
+# flight at once, so we never over-provision drain threads. Reusing threads
+# across kernels saves ~150 us/kernel of pthread_create + Python startup vs.
+# the prior per-kernel ``threading.Thread().start()``.
+_DRAIN_POOL: ThreadPoolExecutor | None = None
+_DRAIN_POOL_LOCK = threading.Lock()
+
+
+def _get_drain_pool() -> ThreadPoolExecutor:
+    global _DRAIN_POOL
+    if _DRAIN_POOL is not None:
+        return _DRAIN_POOL
+    with _DRAIN_POOL_LOCK:
+        if _DRAIN_POOL is None:
+            n = max(1, get_compile_threads())
+            _DRAIN_POOL = ThreadPoolExecutor(
+                max_workers=n, thread_name_prefix="inductor-stream-drain"
+            )
+    return _DRAIN_POOL
+
+
+def _get_streaming_sock_dir() -> str:
+    global _STREAMING_SOCK_DIR
+    if _STREAMING_SOCK_DIR is None:
+        with _STREAMING_SOCK_DIR_LOCK:
+            if _STREAMING_SOCK_DIR is None:
+                d = tempfile.mkdtemp(prefix="inductor_stream_")
+                # Best-effort cleanup: atexit doesn't run on SIGKILL or hard
+                # crash, so /tmp/inductor_stream_* may accumulate.
+                atexit.register(shutil.rmtree, d, ignore_errors=True)
+                _STREAMING_SOCK_DIR = d
+    return _STREAMING_SOCK_DIR
+
+
+def _ensure_shared_listener() -> str:
+    """Lazy-bind the process-wide AF_UNIX listener and start the accept loop.
+    Idempotent. Returns the sock path."""
+    global _SHARED_LISTENER, _SHARED_LISTENER_PATH
+    if _SHARED_LISTENER is not None:
+        assert _SHARED_LISTENER_PATH is not None
+        return _SHARED_LISTENER_PATH
+    with _SHARED_LISTENER_LOCK:
+        if _SHARED_LISTENER is not None:
+            assert _SHARED_LISTENER_PATH is not None
+            return _SHARED_LISTENER_PATH
+        path = os.path.join(_get_streaming_sock_dir(), "shared.sock")
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(path)
+        # Don't trust the caller's umask: bind() inherits it. 0700 parent dir
+        # already blocks cross-UID, but explicit chmod survives anyone changing
+        # the parent path later.
+        os.chmod(path, 0o600)
+        sock.listen(128)
+        threading.Thread(
+            target=_shared_accept_loop,
+            args=(sock,),
+            name="inductor-stream-accept",
+            daemon=True,
+        ).start()
+        _SHARED_LISTENER = sock
+        _SHARED_LISTENER_PATH = path
+    return path
+
+
+def _shared_accept_loop(listener: socket.socket) -> None:
+    """Forever-loop: accept a connection, read the per-kernel id, dispatch to
+    the kernel's pending Future. A short id-read timeout bounds head-of-line
+    blocking from a slow worker.
+    """
+    while True:
+        try:
+            conn_sock, _ = listener.accept()
+        except OSError:
+            return  # listener closed; daemon thread exits
+        _try_set_sock_buf(conn_sock, socket.SO_RCVBUF, _STREAMING_SOCK_BUF)
+        try:
+            conn_sock.settimeout(_STREAMING_KERNEL_ID_READ_TIMEOUT_S)
+            buf = bytearray()
+            while len(buf) < _STREAMING_KERNEL_ID_SIZE:
+                chunk = conn_sock.recv(_STREAMING_KERNEL_ID_SIZE - len(buf))
+                if not chunk:
+                    raise OSError("short read on kernel id")
+                buf.extend(chunk)
+            conn_sock.settimeout(None)
+            (kernel_id,) = _STREAMING_KERNEL_ID_STRUCT.unpack(bytes(buf))
+        except OSError:
+            try:
+                conn_sock.close()
+            except OSError:
+                pass
+            continue
+        with _SHARED_REGISTRY_LOCK:
+            future = _SHARED_REGISTRY.pop(kernel_id, None)
+        if future is None or not _try_set_result(future, conn_sock):
+            # Unknown id (stale entry) or future was already cancelled: drop
+            # the connection.
+            try:
+                conn_sock.close()
+            except OSError:
+                pass
+
+
+def _setup_streaming_listener(
+    kernel_name: str,
+) -> tuple[str, bytes, "Future[socket.socket]"]:
+    """Register a kernel with the shared streaming listener. Returns
+    ``(shared_sock_path, kernel_id_bytes, conn_future)``. The worker connects
+    to ``shared_sock_path`` and sends the 8-byte ``kernel_id_bytes`` so the
+    parent's accept loop can route the socket to ``conn_future``.
+
+    Trust model: same UID, our own subprocess. The kernel id is identification
+    only -- not authentication.
+    """
+    path = _ensure_shared_listener()
+    kernel_id = next(_STREAMING_KERNEL_ID_COUNTER)
+    kernel_id_bytes = _STREAMING_KERNEL_ID_STRUCT.pack(kernel_id)
+    conn_future: Future[socket.socket] = Future()
+    with _SHARED_REGISTRY_LOCK:
+        _SHARED_REGISTRY[kernel_id] = conn_future
+    return path, kernel_id_bytes, conn_future
+
+
+def _drop_streaming_registration(kernel_id_bytes: bytes) -> None:
+    """Remove a kernel's registration from the shared registry. Safe to call
+    even if the id has already been dispatched."""
+    (kernel_id,) = _STREAMING_KERNEL_ID_STRUCT.unpack(kernel_id_bytes)
+    with _SHARED_REGISTRY_LOCK:
+        _SHARED_REGISTRY.pop(kernel_id, None)
+
+
+def _bg_drain_kernel(
+    kernel: Any,
+    conn: Connection,
+    handle: PipelineCachingAutotunerHandle,
+    static_triton_bundle_key: str | None,
+) -> None:
+    """Per-kernel daemon. Reads the streaming wire protocol off ``conn``,
+    builds launchers in the parent process, and feeds them into
+    ``handle.launcher_q`` for ``PipelineCachingAutotunerPlugin.pre_dispatch``
+    to bench. EOF without a preceding ``_Done`` is a worker-died-mid-stream
+    anomaly and surfaces as the drain's exception. Parent-side
+    ``_dynamic_scale_rblock`` runs in the plugin's ``pre_dispatch`` after the
+    drain completes -- not here -- so this thread doesn't have to know about
+    it.
+    """
+    from torch._dynamo.device_interface import DeviceGuard
+
+    def _recv_msg() -> Any:
+        # ``recv_bytes()`` blocks waiting on the worker; that wait is the
+        # parent-side cost the plugin folds into compile_time_us.
+        tq0 = time_ns()
+        if not conn.poll(_STREAMING_TIMEOUT_S):
+            raise TimeoutError(
+                f"streaming worker for {handle.kernel_name} sent no data "
+                f"for {_STREAMING_TIMEOUT_S:.0f}s"
+            )
+        try:
+            payload = conn.recv_bytes()
+        except EOFError:
+            raise RuntimeError(
+                f"streaming worker for {handle.kernel_name} closed pipe "
+                f"without sending _Done (worker died mid-stream)"
+            ) from None
+        handle.bg_drain_wait_ns += time_ns() - tq0
+        return _streaming_decode(payload)
+
+    try:
+        kernel._maybe_put_static_autotuner(static_triton_bundle_key)
+        with DeviceGuard(
+            kernel.get_device_interface(), kernel.triton_meta["device"]
+        ):
+            # Drain worker: build a launcher per _Success, stash per-config
+            # failures on the kernel for the all-failed message.
+            while True:
+                msg = _recv_msg()
+                if isinstance(msg, _Done):
+                    break
+                if isinstance(msg, _Failure):
+                    kernel._last_compile_exception = msg.as_runtime_error()
+                    continue
+                if not isinstance(msg, _Success):
+                    raise RuntimeError(
+                        f"streaming worker for {handle.kernel_name} sent "
+                        f"unknown message type {type(msg).__name__}"
+                    )
+                kernel.compile_results.append(msg.result)
+                kernel._bundle_compile_result(msg.result)
+                launcher, _exc = kernel._make_launcher(msg.result)
+                if launcher is not None:
+                    kernel.launchers.append(launcher)
+                    handle.launcher_q.put(launcher)
+            # Mirror ``_precompile_worker`` post-condition.
+            kernel.configs = None
+            # All-failed fallback (e.g., OOM with pipelining=on -> retry
+            # with pipelining off). Pushes its result into self.launchers.
+            if not kernel.launchers and kernel.compile_results:
+                kernel._all_failed_fallback(kernel._last_compile_exception)
+                if kernel.launchers:
+                    handle.launcher_q.put(kernel.launchers[-1])
+    except BaseException as e:
+        # Only log when we actually transition the future; otherwise the
+        # plugin already saw the exception (or doesn't care anymore).
+        if _try_set_exception(handle.drain_future, e):
+            log.exception("background drain failed for %s", kernel.fn.__name__)
+    else:
+        _try_set_result(handle.drain_future, None)
+    finally:
+        handle.launcher_q.put(_LAUNCHER_END)
+        try:
+            conn.close()
+        except OSError:
+            pass
+
+
+# Sentinel returned by ``PipelineCachingAutotunerPlugin.pre_compile`` to tell
+# ``CachingAutotuner.precompile`` to do nothing. Identity-only -- value is
+# never read, only checked against ``DEFER``.
+_PIPELINE_PRECOMPILE_OWNED = object()
+
+
+class PipelineCachingAutotunerPlugin(CachingAutotunerPlugin):
+    """When a streaming handle is attached: ``pre_compile`` returns non-DEFER
+    so the standard ``precompile()`` body skips entirely (the bg drain is
+    doing compile + launcher-build in the background). At first ``run()``:
+    ``pre_dispatch`` drains ``launcher_q`` (multi-config) or waits on
+    ``drain_future`` (single-config), benches, finalizes, and returns
+    ``DEFER`` so the standard dispatch path runs with
+    ``self.launchers == [winner]``.
+    """
+
+    def pre_compile(self, autotuner: object) -> object:
+        # Streaming: bg drain owns compile + launcher-build. No-op precompile.
+        if autotuner._pipeline_caching_autotuner_handle is not None:
+            return _PIPELINE_PRECOMPILE_OWNED
+        return DEFER
+
+    def pre_dispatch(
+        self,
+        autotuner: object,
+        *args: object,
+        stream: object,
+        **kwargs: object,
+    ) -> object:
+        from torch._dynamo.device_interface import DeviceGuard
+
+        handle = autotuner._pipeline_caching_autotuner_handle
+        if handle is None:
+            return DEFER
+        autotuner._pipeline_caching_autotuner_handle = None
+
+        plugin_wait_ns = 0
+        bench_ns = 0
+        timings: dict[Any, float] = {}
+
+        with DeviceGuard(
+            autotuner.get_device_interface(), autotuner.triton_meta["device"]
+        ):
+            if handle.num_configs > 1:
+                # Bench worker-streamed launchers as they arrive.
+                def _drain_launchers() -> "Iterable[Any]":
+                    nonlocal plugin_wait_ns
+                    while True:
+                        tq0 = time_ns()
+                        launcher = handle.launcher_q.get()
+                        plugin_wait_ns += time_ns() - tq0
+                        if launcher is _LAUNCHER_END:
+                            return
+                        yield launcher
+
+                timings, bench_ns = autotuner._bench_launchers(
+                    _drain_launchers(), *args, **kwargs
+                )
+            else:
+                # Single-config: nothing to compare against, just wait for
+                # the drain to push EOF.
+                tq0 = time_ns()
+                while handle.launcher_q.get() is not _LAUNCHER_END:
+                    pass
+                plugin_wait_ns += time_ns() - tq0
+
+            # Surface drain exceptions (sentinel was pushed in finally).
+            handle.drain_future.result()
+
+            # Parent-side rblock-scale: generate + compile new candidates and
+            # build their launchers. Then bench the new launchers (those
+            # appended after the count we just had) and merge into timings.
+            pre_rblock = len(autotuner.launchers)
+            autotuner._dynamic_scale_rblock()
+            new_launchers = autotuner.launchers[pre_rblock:]
+            if new_launchers:
+                rblock_timings, rblock_bench_ns = autotuner._bench_launchers(
+                    new_launchers, *args, **kwargs
+                )
+                timings.update(rblock_timings)
+                bench_ns += rblock_bench_ns
+
+        if not autotuner.launchers and not autotuner.compile_results:
+            last = autotuner._last_compile_exception
+            suffix = f" Last per-config failure: {last}" if last else ""
+            raise NoTritonConfigsError(
+                f"Pipelined autotuner produced 0 results for "
+                f"{autotuner.fn.__name__}.{suffix}"
+            )
+
+        # compile_time_us for pipelined kernels is the parent's blocking
+        # time only (drain wait + plugin wait); the worker's wall time
+        # overlaps with parent codegen for OTHER kernels and is intentionally
+        # not added here to avoid double-counting.
+        parent_wait_ns = handle.bg_drain_wait_ns + plugin_wait_ns
+
+        if timings:
+            autotuner._finalize_autotune_winner(
+                timings,
+                autotune_time_taken_ns=parent_wait_ns + bench_ns,
+            )
+
+        _emit_triton_kernel_compile_metric(
+            autotuner, handle.kernel_name, parent_wait_ns // 1000
+        )
+        return DEFER
+
+
+def _make_pipeline_caching_autotuner_plugin() -> CachingAutotunerPlugin:
+    """Singleton-style factory used by ``get_caching_autotuner_plugins``."""
+    return PipelineCachingAutotunerPlugin()
 
 
 def pre_fork_setup():
@@ -150,6 +581,9 @@ def _emit_triton_kernel_compile_metric(
 ) -> None:
     """Emit per-kernel ``compile_time_us`` to both the dynamo
     ``_triton_kernel_metrics`` map and the ``MetricsContext`` top-N.
+
+    Used by both the standard ``AsyncCompile.triton`` path and the
+    ``PipelineCachingAutotunerPlugin``.
 
     Note: ``kernel.autotune_cache_info`` is only mutated in place when
     non-empty; when ``None`` or ``{}`` the metric still reaches
@@ -464,18 +898,104 @@ class AsyncCompile:
                         fn_hash: torch._inductor.config.autotune_lookup_table[fn_hash]
                     }
 
-            task = self.process_pool().submit(
-                _worker_compile_triton,
-                load_kernel,
-                extra_env,
-                extra_config,
-            )
+            if config.pipeline_caching_autotuner:
+                sock_path, kernel_id, conn_future = _setup_streaming_listener(
+                    kernel_name
+                )
+            else:
+                sock_path = None
+                kernel_id = None
+                conn_future = None
+
+            try:
+                task = self.process_pool().submit(
+                    _worker_compile_triton,
+                    load_kernel,
+                    extra_env,
+                    extra_config,
+                    streaming_address=sock_path,
+                    streaming_kernel_id=kernel_id,
+                )
+            except BaseException:
+                # Synchronous submit failure (pool shutdown, queue overflow):
+                # nothing will ever consume the registry entry. Drop it so we
+                # don't leak.
+                if kernel_id is not None:
+                    _drop_streaming_registration(kernel_id)
+                raise
+
+            if config.pipeline_caching_autotuner:
+                # If the worker dies before connecting, conn_future would
+                # block forever. Surface the worker exception via the future
+                # and clean up the registry entry.
+                assert conn_future is not None and kernel_id is not None
+                _captured_kernel_id = kernel_id
+                _captured_future = conn_future
+
+                def _on_task_fail_propagate(future: Future) -> None:
+                    exc = future.exception()
+                    if exc is not None:
+                        _try_set_exception(_captured_future, exc)
+                        _drop_streaming_registration(_captured_kernel_id)
+
+                task.add_done_callback(_on_task_fail_propagate)
 
             def get_result() -> CachingAutotuner:
-                try:
-                    kernel, elapsed_us = task.result()
-                except SubprocException as e:
-                    raise e.with_name(kernel_name) from e
+                elapsed_us: int | None = None
+                if config.pipeline_caching_autotuner:
+                    assert conn_future is not None and kernel_id is not None
+                    try:
+                        conn_sock = conn_future.result(
+                            timeout=_STREAMING_TIMEOUT_S
+                        )
+                    except FuturesTimeoutError:
+                        _drop_streaming_registration(kernel_id)
+                        try:
+                            task.result()
+                        except SubprocException as e:
+                            raise e.with_name(kernel_name) from e
+                        raise RuntimeError(
+                            f"streaming worker for {kernel_name} did not "
+                            f"connect within {_STREAMING_TIMEOUT_S:.0f}s"
+                        )
+                    except SubprocException as e:
+                        # _on_task_fail_propagate forwarded the worker exception.
+                        raise e.with_name(kernel_name) from e
+                    conn = Connection(conn_sock.detach())
+                    # Same-UID trust model: the kernel id is identification
+                    # only. No authentication round trip after accept.
+                    if not conn.poll(_STREAMING_TIMEOUT_S):
+                        raise TimeoutError(
+                            f"streaming worker for {kernel_name} sent no kernel "
+                            f"for {_STREAMING_TIMEOUT_S:.0f}s"
+                        )
+                    try:
+                        kernel_bytes = conn.recv_bytes()
+                    except EOFError:
+                        try:
+                            task.result()
+                        except SubprocException as e:
+                            raise e.with_name(kernel_name) from e
+                        raise RuntimeError(
+                            f"worker for {kernel_name} closed pipe before sending kernel"
+                        )
+                    msg = _streaming_decode(kernel_bytes)
+                    if not isinstance(msg, _Kernel):
+                        raise RuntimeError(
+                            f"worker for {kernel_name} sent {type(msg).__name__} "
+                            f"as first message; expected _Kernel"
+                        )
+                    kernel = cast("CachingAutotuner", msg.kernel)
+                else:
+                    try:
+                        result = task.result()
+                    except SubprocException as e:
+                        raise e.with_name(kernel_name) from e
+                    kernel_or_none, elapsed_us = result
+                    assert kernel_or_none is not None, (
+                        "non-streaming worker must return a kernel"
+                    )
+                    kernel = kernel_or_none
 
                 # Now that we've compiled, we should clear the future
                 # so it can't be used again
@@ -484,12 +1004,40 @@ class AsyncCompile:
 
                 kernel.restore_after_unpickle(old_values=None)
 
+                if config.pipeline_caching_autotuner:
+                    # Attach the streaming handle and kick off the bg drain.
+                    # The drain owns compile + launcher-build; the plugin's
+                    # ``pre_compile`` will short-circuit ``precompile()``
+                    # below when it sees the handle.
+                    # Unbounded queue: bg drain produces at most
+                    # ``num_configs`` launchers (small per kernel) before
+                    # pushing _LAUNCHER_END.
+                    handle = PipelineCachingAutotunerHandle(
+                        launcher_q=_queue.Queue(),
+                        drain_future=Future(),
+                        num_configs=len(kernel.configs or []),
+                        kernel_name=kernel_name,
+                    )
+                    kernel._pipeline_caching_autotuner_handle = handle
+                    _get_drain_pool().submit(
+                        _bg_drain_kernel,
+                        kernel,
+                        conn,
+                        handle,
+                        CompiledTritonKernels.key(source_code),
+                    )
+                # Always call precompile; the streaming-plugin's pre_compile
+                # makes it a no-op when a handle is attached.
                 kernel.precompile(
                     warm_cache_only=False,
                     reload_kernel=reload_kernel_in_parent,
                     static_triton_bundle_key=CompiledTritonKernels.key(source_code),
                 )
-                _emit_triton_kernel_compile_metric(kernel, kernel_name, elapsed_us)
+                if not config.pipeline_caching_autotuner:
+                    assert elapsed_us is not None
+                    _emit_triton_kernel_compile_metric(
+                        kernel, kernel_name, elapsed_us
+                    )
                 return kernel
 
             future = LambdaFuture(get_result, future=task)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -523,6 +523,13 @@ incremental_autotune: bool | None = get_tristate_env(
     "TORCHINDUCTOR_INCREMENTAL_AUTOTUNE", default=False
 )
 
+# Pipeline the CachingAutotuner: overlap triton compile, make_launcher, and benchmarking.
+pipeline_caching_autotuner: bool = Config(
+    default=False,
+    env_name_force="TORCHINDUCTOR_PIPELINE_CACHING_AUTOTUNER",
+    justknob="pytorch/inductor:pipeline_caching_autotuner",
+)
+
 inductor_default_autotune_warmup = int(
     os.getenv("TORCHINDUCTOR_DEFAULT_AUTOTUNE_WARMUP", 25)
 )

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 import functools
+import io
 import linecache
 import os
+import pickle
+import socket
 import sys
+import threading
 import time
+import traceback
 import warnings
+import zlib
+from dataclasses import dataclass
+from multiprocessing.connection import Connection
 from pathlib import Path
-from types import ModuleType
+from types import FunctionType, ModuleType
 from typing import Any, TYPE_CHECKING
 
 from torch._utils_internal import log_triton_builds
@@ -118,7 +126,19 @@ def _worker_compile_triton(
     load_kernel: Callable[[], CachingAutotuner],
     extra_env: dict[str, str],
     extra_config: dict[str, Any],
-) -> tuple[CachingAutotuner, int]:
+    streaming_address: str | None = None,
+    streaming_kernel_id: bytes | None = None,
+) -> tuple[CachingAutotuner | None, int]:
+    """Worker entry point for ``AsyncCompile.triton``. Two flows:
+
+    - Streaming (``streaming_address`` non-None): connect to the parent's
+      shared listener, send ``streaming_kernel_id`` so the dispatcher routes
+      this connection to the right Future, send the kernel, then stream each
+      ``CompileResult``. Returns ``(None, elapsed_us)``.
+    - Blocking (None): ``precompile(warm_cache_only=True)`` runs every
+      config, kernel is pickled back with ``compile_results`` populated.
+      Returns ``(kernel, elapsed_us)``.
+    """
     _set_triton_ptxas_path()
     os.environ.update(extra_env)
     # Set libdevice path if passed via env from main process
@@ -137,6 +157,18 @@ def _worker_compile_triton(
         try:
             start_ns = time.time_ns()
             kernel = load_kernel()
+            if streaming_address is not None:
+                assert streaming_kernel_id is not None
+                _stream_compile_triton(
+                    kernel,
+                    streaming_address,
+                    streaming_kernel_id,
+                )
+                elapsed_ns = time.time_ns() - start_ns
+                # Kernel was streamed back already; nothing left to
+                # return via the future payload.
+                linecache.clearcache()
+                return None, elapsed_ns // 1000
             kernel.precompile(warm_cache_only=True)
             elapsed_ns = time.time_ns() - start_ns
             kernel.prepare_for_pickle()
@@ -148,3 +180,214 @@ def _worker_compile_triton(
             raise
         finally:
             log_triton_builds(fail=fail)
+
+
+_DYN_KERNEL_MODULE_PREFIX = "torch._inductor.runtime.compile_tasks."
+
+# RLock's type isn't directly importable; capture once via type(RLock()).
+# _streaming_persistent_id checks this on every traversed pickle object.
+_RLOCK_TYPE = type(threading.RLock())
+
+
+# Wire sentinel for the worker->parent streaming connection. Round-trips as
+# an ``is``-identical singleton through ``_streaming_persistent_id`` /
+# ``_streaming_persistent_load``. If you add a second sentinel, update both
+# functions in lockstep.
+_STREAMING_SKIP = object()
+
+
+def _streaming_persistent_id(obj: Any) -> object | None:
+    """Substitute ``_STREAMING_SKIP`` for things that don't survive pickle to
+    the parent. All resolve to ``None`` on the parent; downstream consumers
+    either don't read them or handle ``None`` defensively.
+
+    - ``RLock``: pickle refuses these outright.
+    - ``ModuleType``: the dyn kernel module isn't in the parent's
+      ``sys.modules``; uniform substitution is the simplest correct policy.
+    - Raw functions in a dyn kernel module (e.g. ``@triton.jit`` bodies):
+      pickle-by-name fails on the parent. Restricted to ``FunctionType``
+      so we don't catch ``JITFunction``, which inherits the same
+      ``__module__`` but pickles fine via its own class.
+    """
+    if isinstance(obj, _RLOCK_TYPE):
+        return _STREAMING_SKIP
+    if isinstance(obj, ModuleType):
+        return _STREAMING_SKIP
+    if isinstance(obj, FunctionType):
+        mod = obj.__module__
+        if isinstance(mod, str) and mod.startswith(_DYN_KERNEL_MODULE_PREFIX):
+            return _STREAMING_SKIP
+    return None
+
+
+def _streaming_persistent_load(pid: object) -> object:
+    """Resolve ids from ``_streaming_persistent_id`` to ``None``;
+    raise on anything else (wire format divergence)."""
+    if pid is _STREAMING_SKIP:
+        return None
+    raise pickle.UnpicklingError(f"unsupported persistent id: {pid!r}")
+
+
+class _StreamingPickler(pickle.Pickler):
+    """Pickler honoring ``_streaming_persistent_id`` substitutions."""
+
+    persistent_id = staticmethod(_streaming_persistent_id)
+
+
+class _StreamingUnpickler(pickle.Unpickler):
+    """Parent-side companion to ``_StreamingPickler``.
+
+    Trust model: this unpickler accepts arbitrary classes from the worker.
+    That is safe only because the worker is part of our trust domain
+    (same UID, our own subprocess); pickle deserialization from an
+    untrusted peer would be a remote-code-execution risk.
+    """
+
+    persistent_load = staticmethod(_streaming_persistent_load)
+
+
+# Kernel-emit cubin/asm payloads pickle to ~28 KiB median, ~640 KiB p95;
+# zlib level 1 cuts those by ~3-5x at <100 MB/s on the worker, paying for
+# itself many times over against the 5+ second aggregate socket-flow-control
+# wait observed without compression.
+_STREAMING_ZLIB_LEVEL = 1
+
+
+def _streaming_send(conn: Any, obj: Any) -> None:
+    """Pickle ``obj`` via ``_StreamingPickler``, zlib-compress, send_bytes.
+    Bypasses ``conn.send``, which would use ``ForkingPickler``. The parent
+    is the only reader and uses :func:`_streaming_decode` symmetrically."""
+    buf = io.BytesIO()
+    _StreamingPickler(buf, protocol=pickle.HIGHEST_PROTOCOL).dump(obj)
+    conn.send_bytes(zlib.compress(buf.getvalue(), _STREAMING_ZLIB_LEVEL))
+
+
+def _streaming_decode(payload: bytes) -> Any:
+    """Inverse of :func:`_streaming_send`: zlib-decompress + unpickle. Kept
+    here so the wire format (compression level, framing) lives in one file.
+    """
+    return _StreamingUnpickler(io.BytesIO(zlib.decompress(payload))).load()
+
+
+def _try_set_sock_buf(sock: socket.socket, opt: int, size: int) -> None:
+    """setsockopt that tolerates sandbox/seccomp denials. The kernel silently
+    clamps size to the system-wide max."""
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, opt, size)
+    except OSError:
+        pass
+
+
+# ----------------------------------------------------------------------------
+# Streaming wire-protocol message types.
+#
+# Every message sent over the streaming socket is one of:
+#   _Kernel(kernel)       -- first message; the worker's CachingAutotuner
+#   _Success(result)      -- a successful CompileResult
+#   _Failure(...)         -- a per-config compile failure (mirrors what the
+#                            non-streaming worker stores on
+#                            ``kernel._last_compile_exception``); not fatal
+#   _Done()               -- explicit end-of-stream marker
+#
+# EOF on the socket without a preceding _Done is treated as an anomaly
+# (worker died mid-stream). Adding a new variant requires updating the
+# parent's dispatch in ``_bg_drain_kernel._iter_results``.
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Kernel:
+    kernel: Any  # CachingAutotuner
+
+
+@dataclass(frozen=True)
+class _Success:
+    result: Any  # CompileResult
+
+
+@dataclass(frozen=True)
+class _Failure:
+    """Per-config compile failure. Carries the exception type+message+
+    traceback as strings so that exceptions whose ``__reduce__`` is fragile
+    (or whose constructor signature has drifted) still survive the wire."""
+
+    exc_type: str
+    exc_msg: str
+    traceback: str
+
+    @classmethod
+    def from_exc(cls, exc: BaseException) -> _Failure:
+        # ``traceback.format_exc()`` only reflects the current except-block;
+        # we may be called outside one. Use the exception's own __traceback__.
+        tb_str = "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        )
+        return cls(
+            exc_type=type(exc).__name__,
+            exc_msg=str(exc),
+            traceback=tb_str,
+        )
+
+    def as_runtime_error(self) -> RuntimeError:
+        """Reconstruct as a ``RuntimeError`` for storage on the parent's
+        ``kernel._last_compile_exception`` slot."""
+        return RuntimeError(f"{self.exc_type}: {self.exc_msg}\n{self.traceback}")
+
+
+class _Done:
+    """End-of-stream marker. Pickled as a class instance; the parent uses
+    ``isinstance(msg, _Done)`` so each unpickled instance is fine."""
+
+
+def _stream_compile_triton(
+    kernel: CachingAutotuner,
+    streaming_address: str,
+    streaming_kernel_id: bytes,
+) -> None:
+    """Connect to the parent's shared streaming listener at
+    ``streaming_address``, send the 8-byte ``streaming_kernel_id`` so the
+    parent's dispatcher can route this connection to the right Future. Send
+    a ``_Kernel`` as the first message (so the parent can dispatch before
+    any compile finishes), then stream each per-config result as a
+    ``_Success`` or ``_Failure``, then ``_Done``. ``_StreamingPickler``
+    substitutes unpicklable bits per-send so we never mutate the live
+    JITFunction (other in-flight compiles in this worker still need it).
+    """
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.connect(streaming_address)
+        # Bump SNDBUF to mirror the parent's RCVBUF so the worker can write
+        # several CompileResult messages without blocking when the drain
+        # thread is briefly busy.
+        _try_set_sock_buf(sock, socket.SO_SNDBUF, 4 * 1024 * 1024)
+        # Identify ourselves to the parent's dispatcher. ID is fixed-size so
+        # the parent reads exactly that many bytes and routes us.
+        view = memoryview(streaming_kernel_id)
+        while view:
+            sent = sock.send(view)
+            if sent == 0:
+                raise OSError("short write on streaming kernel id")
+            view = view[sent:]
+        conn = Connection(sock.detach())
+    except Exception:
+        try:
+            sock.close()
+        except OSError:
+            pass
+        raise
+    try:
+        # No in-flight compiles yet; mutating kernel is safe.
+        old_values = kernel.prepare_for_pickle()
+        try:
+            _streaming_send(conn, _Kernel(kernel))
+        finally:
+            kernel.restore_after_unpickle(old_values)
+
+        for _cfg, result, exc in kernel._iter_compile_results_tagged(parallel=True):
+            if exc is None:
+                _streaming_send(conn, _Success(result))
+            else:
+                _streaming_send(conn, _Failure.from_exc(exc))
+        _streaming_send(conn, _Done())
+    finally:
+        conn.close()

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1,7 +1,6 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
-import builtins
 import copy
 import dataclasses
 import enum
@@ -108,7 +107,13 @@ class NoTritonConfigsError(RuntimeError):
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Container, Generator, Hashable
+    from collections.abc import (
+        Callable,
+        Container,
+        Generator,
+        Hashable,
+        Iterable,
+    )
 
     from torch._C._profiler import _RecordFunctionFast
     from torch._guards import CompileId
@@ -924,6 +929,49 @@ class CachingAutotuner(KernelInterface):
         if static_triton_bundle_key is not None and self.is_statically_launchable():
             TritonBundler.put_static_autotuner(static_triton_bundle_key, self)
 
+    def _bench_launchers(
+        self,
+        launchers: Iterable[LauncherType],
+        *args: object,
+        **kwargs: object,
+    ) -> tuple[dict[LauncherType, float], int]:
+        """Bench each launcher and feed the coordesc cache. Returns
+        ``(timings, bench_ns)``; caller decides on the winner.
+        """
+        timings: dict[LauncherType, float] = {}
+        bench_ns = 0
+        for launcher in launchers:
+            t0 = time.time_ns()
+            timings[launcher] = self.bench(launcher, *args, **kwargs)
+            bench_ns += time.time_ns() - t0
+            self.coordesc_tuner.cache_benchmark_result(
+                launcher.config, timings[launcher]
+            )
+        return timings, bench_ns
+
+    def _finalize_autotune_winner(
+        self,
+        timings: dict[LauncherType, float],
+        autotune_time_taken_ns: int,
+    ) -> None:
+        """Pick the lowest-timing launcher as the sole survivor, register it
+        with ``TritonBundler.put_winner``, notify ``save_cache_hook``, and
+        record ``self.autotune_time_taken_ns``.
+        """
+        self.autotune_time_taken_ns = autotune_time_taken_ns
+        best_launcher = min(timings, key=timings.get)  # type: ignore[arg-type]
+        self.launchers = [best_launcher]
+        TritonBundler.put_winner(best_launcher.cache_hash)
+        if self.save_cache_hook:
+            self.save_cache_hook(
+                best_launcher.config,
+                self.autotune_time_taken_ns,
+                found_by_coordesc=self.inductor_meta.get(
+                    "coordinate_descent_tuning", False
+                ),
+                triton_cache_hash=best_launcher.cache_hash,
+            )
+
     def _ensure_kernel_loaded(self) -> None:
         """Reload the kernel in the parent process if needed.
 
@@ -1545,9 +1593,11 @@ class CachingAutotuner(KernelInterface):
                     best_time,
                 )
 
-        self.launchers = [builtins.min(timings, key=timings.get)]
-        self.autotune_time_taken_ns = (
-            self.precompile_time_taken_ns + benchmark_time_taken_ns
+        self._finalize_autotune_winner(
+            timings,
+            autotune_time_taken_ns=(
+                self.precompile_time_taken_ns + benchmark_time_taken_ns
+            ),
         )
 
         # log the best config
@@ -1561,18 +1611,6 @@ class CachingAutotuner(KernelInterface):
             launcher.n_spills,
             launcher.shared,
         )
-
-        TritonBundler.put_winner(launcher.cache_hash)
-
-        if self.save_cache_hook:
-            self.save_cache_hook(
-                launcher.config,
-                self.autotune_time_taken_ns,
-                found_by_coordesc=self.inductor_meta.get(
-                    "coordinate_descent_tuning", False
-                ),
-                triton_cache_hash=launcher.cache_hash,
-            )
 
     def _combo_sequential_autotune(self, launcher, *args, **kwargs):
         """

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -619,18 +619,14 @@ class CachingAutotuner(KernelInterface):
                 if plugin.pre_compile(self) is not DEFER:
                     return
             self._precompile_worker()
-            if static_triton_bundle_key is not None and self.is_statically_launchable():
-                TritonBundler.put_static_autotuner(static_triton_bundle_key, self)
+            self._maybe_put_static_autotuner(static_triton_bundle_key)
             self._make_launchers(self.compile_results)
             self._dynamic_scale_rblock()
 
     def _precompile_worker(self):
         if self.compile_results:
             for result in self.compile_results:
-                TritonBundler.put(
-                    triton_hash_to_path_key(result.kernel.hash),  # type: ignore[attr-defined]
-                    self.triton_meta.get("device", 0),
-                )
+                self._bundle_compile_result(result)
             return
         assert not self.launchers
         if not self.configs:
@@ -832,21 +828,38 @@ class CachingAutotuner(KernelInterface):
                 if launcher is not None:
                     launchers.append(launcher)
             if not self.launchers and not launchers:
-                result = compile_results[-1]
-                config = result.config
-                if (
-                    isinstance(exc, (OutOfResources, torch.cuda.OutOfMemoryError))
-                    and (
-                        config.num_stages > 1 or config.kwargs.get("NUM_STAGES", 1) > 1
-                    )
-                    and self.inductor_meta.get("dynamic_disable_pipelining", True)
-                ):
-                    self.launchers = [self.compile_by_disabling_pipelining(config)]
-                    return
-                raise RuntimeError(
-                    f"No valid triton configs. {type(exc).__name__}: {exc}"
-                )
+                self._all_failed_fallback(exc)
+                return
         self.launchers.extend(launchers)
+
+    def _bundle_compile_result(self, result: CompileResult[_KernelType]) -> None:
+        """Parent-side ``TritonBundler.put`` for one CompileResult."""
+        TritonBundler.put(
+            triton_hash_to_path_key(result.kernel.hash),  # type: ignore[attr-defined]
+            self.triton_meta.get("device", 0),
+        )
+
+    def _all_failed_fallback(self, exc: BaseException | None) -> None:
+        """If the last failure was OOM on a pipelined config, retry with
+        pipelining disabled; otherwise raise. Caller holds the DeviceGuard.
+        Mutates self.launchers and self.compile_results on the OOM-retry path.
+        """
+        result = self.compile_results[-1]
+        config = result.config
+        if (
+            isinstance(exc, (OutOfResources, torch.cuda.OutOfMemoryError))
+            and (config.num_stages > 1 or config.kwargs.get("NUM_STAGES", 1) > 1)
+            and self.inductor_meta.get("dynamic_disable_pipelining", True)
+        ):
+            self.launchers = [self.compile_by_disabling_pipelining(config)]
+            return
+        raise RuntimeError(f"No valid triton configs. {type(exc).__name__}: {exc}")
+
+    def _maybe_put_static_autotuner(
+        self, static_triton_bundle_key: str | None
+    ) -> None:
+        if static_triton_bundle_key is not None and self.is_statically_launchable():
+            TritonBundler.put_static_autotuner(static_triton_bundle_key, self)
 
     def _ensure_kernel_loaded(self) -> None:
         """Reload the kernel in the parent process if needed.

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -108,7 +108,7 @@ class NoTritonConfigsError(RuntimeError):
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Container, Hashable
+    from collections.abc import Callable, Container, Generator, Hashable
 
     from torch._C._profiler import _RecordFunctionFast
     from torch._guards import CompileId
@@ -534,6 +534,11 @@ class CachingAutotuner(KernelInterface):
             and not self.dump_launch_tensors
         )
 
+        # Last per-config compile exception caught by ``_iter_compile_results``;
+        # consulted by ``_precompile_worker`` to enrich the "all configs failed"
+        # error message.
+        self._last_compile_exception: BaseException | None = None
+
         self._plugins = get_caching_autotuner_plugins(self)
 
         # Compile-time info included in runtime logginging
@@ -632,19 +637,77 @@ class CachingAutotuner(KernelInterface):
         if not self.configs:
             raise NoTritonConfigsError("No triton configs are available")
 
-        compile_results = []
-        exc = None
-        for c in self.configs:
-            try:
-                compile_results.append(self._precompile_config(c))
-            except (OutOfResources, PTXASError, IntelGPUError) as e:
-                exc = e
-        if len(compile_results) == 0:
-            raise NoTritonConfigsError(
-                f"No valid triton configs. {type(exc).__name__}: {exc}"
+        self.compile_results = list(self._iter_compile_results())
+        if not self.compile_results:
+            last_exc = self._last_compile_exception
+            exc_str = (
+                f" {type(last_exc).__name__}: {last_exc}"
+                if last_exc is not None
+                else ""
             )
-        self.compile_results = compile_results
+            raise NoTritonConfigsError(
+                f"No valid triton configs compiled for {self.fn.__name__}.{exc_str}"
+            )
         self.configs = None
+
+    def _iter_compile_results(
+        self, parallel: bool = False
+    ) -> Generator[CompileResult, None, None]:
+        """Yield successful ``CompileResult``s. OOM / PTXAS / IntelGPU
+        failures are dropped; the last one is kept on
+        ``self._last_compile_exception`` for the all-failed error.
+        ``parallel`` thread-pools the compile, sized to ``len(configs)``.
+        """
+        self._last_compile_exception = None
+        for _cfg, result, exc in self._iter_compile_results_tagged(parallel=parallel):
+            if exc is None:
+                yield result
+            else:
+                self._last_compile_exception = exc
+
+    def _iter_compile_results_tagged(
+        self, parallel: bool = False
+    ) -> Generator[
+        tuple[Config, CompileResult | None, BaseException | None], None, None
+    ]:
+        """Yield ``(config, result, exc)`` for every config:
+        ``exc is None`` -> ``result`` is a successful ``CompileResult``;
+        otherwise ``exc`` is an OOM / PTXAS / IntelGPU per-config failure
+        and ``result`` is None. The standard ``_iter_compile_results``
+        adapter discards failures and just stashes the last on
+        ``self._last_compile_exception``.
+        """
+        configs = list(self.configs or [])
+        if not configs:
+            return
+
+        # Skip the executor when there's nothing to parallelize: a single config
+        # gains nothing from a thread pool but pays the executor setup/teardown
+        # cost (matters per-kernel on graphs with many single-config kernels).
+        if parallel and len(configs) > 1:
+            from concurrent.futures import as_completed, ThreadPoolExecutor
+
+            # No upper bound on max_workers: Triton AST visit holds the GIL
+            # so extra threads above ~CPU-count add scheduler overhead, but
+            # ptxas / native compile releases the GIL and benefits from
+            # additional parallelism. Per-kernel config counts are small in
+            # practice (max_autotune_* tops out at a few dozen).
+            with ThreadPoolExecutor(max_workers=len(configs)) as executor:
+                fut_to_cfg = {
+                    executor.submit(self._precompile_config, c): c for c in configs
+                }
+                for fut in as_completed(fut_to_cfg):
+                    cfg = fut_to_cfg[fut]
+                    try:
+                        yield cfg, fut.result(), None
+                    except (OutOfResources, PTXASError, IntelGPUError) as e:
+                        yield cfg, None, e
+        else:
+            for c in configs:
+                try:
+                    yield c, self._precompile_config(c), None
+                except (OutOfResources, PTXASError, IntelGPUError) as e:
+                    yield c, None, e
 
     @functools.cached_property
     def _could_rblock_scale(self) -> bool:

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -621,7 +621,7 @@ class CachingAutotuner(KernelInterface):
             self._precompile_worker()
             if static_triton_bundle_key is not None and self.is_statically_launchable():
                 TritonBundler.put_static_autotuner(static_triton_bundle_key, self)
-            self._make_launchers()
+            self._make_launchers(self.compile_results)
             self._dynamic_scale_rblock()
 
     def _precompile_worker(self):
@@ -777,9 +777,12 @@ class CachingAutotuner(KernelInterface):
             return
         if not self._could_rblock_scale:
             return
+        new_results = []
         for new_config in self._iter_rblock_scale_candidates():
-            self.compile_results.append(self._precompile_config(new_config))  # noqa: B909
-        self._make_launchers()
+            result = self._precompile_config(new_config)
+            self.compile_results.append(result)  # noqa: B909
+            new_results.append(result)
+        self._make_launchers(new_results)
 
     def compile_by_disabling_pipelining(self, config):
         self._ensure_kernel_loaded()
@@ -809,8 +812,12 @@ class CachingAutotuner(KernelInterface):
         ) as e:
             return None, e
 
-    def _make_launchers(self):
-        if len(self.launchers) == len(self.compile_results):
+    def _make_launchers(self, compile_results):
+        """Wrap each result in ``compile_results`` into a launcher and
+        append the survivors to ``self.launchers``. Fires the all-failed
+        fallback only when ``self.launchers`` is empty AND no new launcher
+        survived this call."""
+        if not compile_results:
             return
 
         from torch._dynamo.device_interface import DeviceGuard
@@ -820,12 +827,12 @@ class CachingAutotuner(KernelInterface):
         exc = None
         # DeviceGuard ensures each launcher's binary loads onto the right device.
         with DeviceGuard(device_interface, self.triton_meta["device"]):
-            for result in self.compile_results:
+            for result in compile_results:
                 launcher, exc = self._make_launcher(result)
                 if launcher is not None:
                     launchers.append(launcher)
-            if len(launchers) == 0:
-                result = self.compile_results[-1]
+            if not self.launchers and not launchers:
+                result = compile_results[-1]
                 config = result.config
                 if (
                     isinstance(exc, (OutOfResources, torch.cuda.OutOfMemoryError))
@@ -839,7 +846,7 @@ class CachingAutotuner(KernelInterface):
                 raise RuntimeError(
                     f"No valid triton configs. {type(exc).__name__}: {exc}"
                 )
-        self.launchers = launchers
+        self.launchers.extend(launchers)
 
     def _ensure_kernel_loaded(self) -> None:
         """Reload the kernel in the parent process if needed.

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -397,6 +397,8 @@ def get_caching_autotuner_plugins(
     Each plugin adds an entry here, gated on its own config flag, with
     imports kept inside the relevant branch.
     """
+    from torch._inductor import config
+
     plugins: list[CachingAutotunerPlugin] = []
     if autotuner.inductor_meta.get("incremental_autotune", False):
         try:
@@ -405,6 +407,16 @@ def get_caching_autotuner_plugins(
             plugins.append(IncrementalAutotunePlugin())
         except ImportError:
             pass
+    if config.pipeline_caching_autotuner:
+        # Lazy import: the plugin lives in ``async_compile`` (alongside
+        # the streaming setup helpers), and importing
+        # ``async_compile`` at module-load time would create an upward
+        # dependency from runtime/ into _inductor/.
+        from torch._inductor.async_compile import (
+            _make_pipeline_caching_autotuner_plugin,
+        )
+
+        plugins.append(_make_pipeline_caching_autotuner_plugin())
     return plugins
 
 
@@ -543,6 +555,14 @@ class CachingAutotuner(KernelInterface):
         # consulted by ``_precompile_worker`` to enrich the "all configs failed"
         # error message.
         self._last_compile_exception: BaseException | None = None
+
+        # Set by ``AsyncCompile.triton`` when the pipelined-autotuner path
+        # is active; consumed and reset to None by
+        # ``PipelineCachingAutotunerPlugin.pre_dispatch`` on first ``run()``.
+        # Typed as Any to dodge a forward-ref to ``async_compile``.
+        # TODO: side-channel; should flow through the plugin protocol
+        # (pre_compile/pre_dispatch arg) instead of a kernel attribute.
+        self._pipeline_caching_autotuner_handle: Any = None
 
         self._plugins = get_caching_autotuner_plugins(self)
 


### PR DESCRIPTION
Summary:

 ```
  Adds a 3-stage pipelined autotuner that overlaps Triton compile, parent-side launcher creation, and benchmarking. The worker subprocess streams each `CompileResult` back  
  to the parent over a per-kernel AF_UNIX socket as it finishes; a per-kernel daemon drains those into launchers in parallel with inductor codegen for OTHER kernels; the    
  autotune plugin pulls launchers from a queue and benches them as they arrive. Bench[i] thus overlaps with drain's `make_launcher_{i+1}` (which itself overlaps with worker 
  compile of `c_{i+2}`).                                                                                                                                                     
                                                                  
  Gated behind `config.pipeline_caching_autotuner` (env: `TORCHINDUCTOR_PIPELINE_CACHING_AUTOTUNER`); default off. Behavior is unchanged when off.                           
  
  Three layers, each independently shippable -- review in this order:                                                                                                        
                                                                  
  1. **Wire format** (`runtime/compile_tasks.py`): `_StreamingPickler` / `_StreamingUnpickler` with a `persistent_id` callback that substitutes RLocks, dyn-kernel-module    
  references, and `FunctionType`s defined in dyn modules with `_StreamingSentinel.SKIP` (an enum member, round-trips as an `is`-identical singleton). The parent's
  `persistent_load` resolves SKIP back to `None`. `_streaming_send` does `pickle.HIGHEST_PROTOCOL` + `send_bytes`. `_stream_compile_triton` is the worker entry point:       
  connect to the parent's per-kernel listener with the shared authkey, ship the kernel itself (under `prepare_for_pickle` / `restore_after_unpickle`) so the parent can
  dispatch immediately, then stream each `CompileResult` from `_iter_compile_results(parallel=True)`.

  2. **Per-kernel transport** (`async_compile.py`): `_setup_streaming_listener` binds a per-kernel AF_UNIX socket inside a process-wide `mkdtemp` directory, monotonic       
  counter for filenames (no collisions), `os.chmod(0o600)` so the socket file is owner-only regardless of umask, and `settimeout(600)` on `accept()`. After `accept()`, the
  parent runs the `mp.connection` challenge/answer handshake against a per-listener `os.urandom(32)` authkey -- a same-UID attacker that races to `connect()` first cannot   
  hijack the listener without the key. Each `recv_bytes()` is gated by `conn.poll(600)` so a wedged worker can't block the parent forever.

  3. **Pipeline** (`async_compile.py` + `runtime/triton_heuristics.py`): `AsyncCompile.triton`'s `get_result` accepts the worker's connection, deserializes the streamed     
  kernel, stashes a `PipelineCachingAutotunerHandle` on the kernel, then starts a per-kernel daemon (`_bg_drain_kernel`) that drives
  `kernel.precompile_from_stream(iter_results=..., on_launcher=...)`, fanning launchers into `handle.launcher_q`. At first `run()`,                                          
  `PipelineCachingAutotunerPlugin.pre_dispatch` pulls launchers from the queue as the drain produces them and benches each via `_bench_launchers`, then finalizes the winner.

  Plumbing on `CachingAutotuner`:                                                                                                                                            
  - `precompile_from_stream(iter_results, on_launcher, ...)` -- streaming-aware sibling of `precompile`; the bg drain feeds compile results in and streams launchers out.
  - `_make_launchers_from_stream(iter_results, on_launcher)` -- streaming-aware sibling of `_make_launchers`; appends to `self.launchers` in-place rather than               
  - `_iter_compile_results(parallel=False)` is the worker-side iterator; `parallel=True` thread-pools the per-config compile, capped at `_PARALLEL_COMPILE_THREAD_CAP=8`     
  since Triton AST visit is GIL-bound. Replaces the inline loop in `_precompile_worker`.                                                                                     
  - `_could_rblock_scale` is a pure predicate; `_iter_rblock_scale_candidates` enumerates the rblock-scaled candidates.                                                      
  - `_bundle_compile_result`, `_all_failed_fallback`, `_maybe_put_static_autotuner`, `_bench_launchers`, `_finalize_autotune_winner` are extracted helpers shared between the
   streaming and non-streaming paths.                                                                                                                                        
  - `_finalize_autotune_winner(timings, autotune_time_taken_ns=...)` takes the time as an explicit arg (was an implicit "set this attribute first" contract).                
  - `_pipeline_caching_autotuner_handle` is a declared `__init__` slot, set/cleared by assignment (no `del` / `hasattr`).                                                    
                                                                                                                                                                             
  Compile-time metric attribution: pipelined kernels report `parent_us = bg_drain_wait_ns + plugin_wait_ns` -- only the parent-side wall time spent blocked on streaming I/O.
   Worker subprocess compile time overlaps with parent codegen for OTHER kernels and is intentionally not counted, matching the perf actually delivered to the user.

Test Plan:
Test coverage: 14 new tests in `caffe2/test/inductor:triton_heuristics`:                                                                                                   
  - `TestStreamingPickler` x5: RLock / ModuleType / dyn-FunctionType substitution, normal-function preservation, unknown-pid raises.                                         
  - `TestStreamingTransport` x3: round-trip with authkey handshake; per-call uniqueness of sock path + authkey + 0o600 mode; mismatched authkey rejected by both sides with
  `AuthenticationError`.                                                                                                                                                     
  - `TestPipelineCachingAutotunerPlugin` x6: no-op without handle, single-config drain-wait (no bench), multi-config drain & winner pick, overlap of plugin bench with bg    
  drain, drain-exception re-raise at finalization, zero-streamed-results raises.                                                                                             
                                                                                                                                                                             

  # Full test suite for the modified module                                                                                                                                  
  buck test fbcode//mode/opt fbcode//caffe2/test/inductor:triton_heuristics
                                                                                                                                                                             
  # Only the new streaming-compile / pipelined-autotuner tests                                                                                                               
  buck test fbcode//mode/opt fbcode//caffe2/test/inductor:triton_heuristics -- TestStreamingPickler TestStreamingTransport TestPipelineCachingAutotunerPlugin

Differential Revision: D103720055




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo