### PR TITLE
[MPS] Metal softmax/log_softmax kernels with non-last-dim support

### DIFF
--- a/aten/src/ATen/native/mps/kernels/SoftMaxKernel.h
+++ b/aten/src/ATen/native/mps/kernels/SoftMaxKernel.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <c10/metal/common.h>
+
+struct SoftmaxParams {
+  uint32_t axis_size;
+  uint32_t ndim;
+  uint32_t stride_a;
+  uint32_t stride_b;
+  uint32_t stride_c;
+  uint32_t num_chunks;
+  ::c10::metal::array<uint32_t, 15> outer_sizes;
+  ::c10::metal::array<uint32_t, 15> outer_strides_a;
+  ::c10::metal::array<uint32_t, 15> outer_strides_b;
+  ::c10::metal::array<uint32_t, 15> outer_strides_c;
+};

--- a/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
@@ -1,0 +1,1126 @@
+#include <ATen/native/mps/kernels/SoftMaxKernel.h>
+#include <c10/metal/reduction_utils.h>
+#include <metal_simdgroup>
+#include <metal_stdlib>
+using namespace metal;
+using c10::metal::simdgroup_size;
+
+static inline uint offset_a(uint row_idx, constant SoftmaxParams& p) {
+  uint offset = 0;
+  uint idx = row_idx;
+  for (int d = int(p.ndim) - 2; d >= 0; d--) {
+    uint coord = idx % p.outer_sizes[d];
+    idx /= p.outer_sizes[d];
+    offset += coord * p.outer_strides_a[d];
+  }
+  return offset;
+}
+
+static inline uint offset_b(uint row_idx, constant SoftmaxParams& p) {
+  uint offset = 0;
+  uint idx = row_idx;
+  for (int d = int(p.ndim) - 2; d >= 0; d--) {
+    uint coord = idx % p.outer_sizes[d];
+    idx /= p.outer_sizes[d];
+    offset += coord * p.outer_strides_b[d];
+  }
+  return offset;
+}
+
+static inline uint offset_c(uint row_idx, constant SoftmaxParams& p) {
+  uint offset = 0;
+  uint idx = row_idx;
+  for (int d = int(p.ndim) - 2; d >= 0; d--) {
+    uint coord = idx % p.outer_sizes[d];
+    idx /= p.outer_sizes[d];
+    offset += coord * p.outer_strides_c[d];
+  }
+  return offset;
+}
+
+static inline float4 load_vec4(device const float* p) {
+  return *reinterpret_cast<device const packed_float4*>(p);
+}
+static inline float4 load_vec4(device const half* p) {
+  return float4(*reinterpret_cast<device const packed_half4*>(p));
+}
+static inline float4 load_vec4(device const bfloat* p) {
+  return float4(float(p[0]), float(p[1]), float(p[2]), float(p[3]));
+}
+
+static inline void store_vec4(device float* p, float4 v) {
+  *reinterpret_cast<device packed_float4*>(p) = v;
+}
+static inline void store_vec4(device half* p, float4 v) {
+  *reinterpret_cast<device packed_half4*>(p) = half4(v);
+}
+static inline void store_vec4(device bfloat* p, float4 v) {
+  p[0] = static_cast<bfloat>(v[0]);
+  p[1] = static_cast<bfloat>(v[1]);
+  p[2] = static_cast<bfloat>(v[2]);
+  p[3] = static_cast<bfloat>(v[3]);
+}
+
+// Forward single-row: values cached in registers (1 read, 1 write).
+// Reads from input using stride_a, writes to output contiguously.
+
+template <typename T>
+kernel void softmax_forward_single_row(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* x = input + offset_a(tg_id, params);
+  device T* out = output + offset_b(tg_id, params);
+  uint base = tid * N_READS;
+
+  bool contiguous = (sa == 1);
+  float vals[N_READS];
+  float local_max = -INFINITY;
+  if (base + N_READS <= axis_size) {
+    if (contiguous) {
+      float4 v = load_vec4(x + base);
+      vals[0] = v.x;
+      vals[1] = v.y;
+      vals[2] = v.z;
+      vals[3] = v.w;
+    } else {
+      for (int i = 0; i < N_READS; i++)
+        vals[i] = float(x[(base + i) * sa]);
+    }
+    local_max = fmax(fmax(vals[0], vals[1]), fmax(vals[2], vals[3]));
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      vals[i] = (base + i < axis_size)
+          ? (contiguous ? float(x[base + i]) : float(x[(base + i) * sa]))
+          : -INFINITY;
+      local_max = fmax(local_max, vals[i]);
+    }
+  }
+
+  threadgroup float shared[simdgroup_size];
+  float row_max = c10::metal::threadgroup_max(shared, local_max, tid, tptg);
+
+  float local_sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < N_READS; i++) {
+    vals[i] = metal::precise::exp(vals[i] - row_max);
+    local_sum += vals[i];
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  float total_sum = c10::metal::threadgroup_sum(shared, local_sum, tid, tptg);
+  float inv_sum = 1.0f / total_sum;
+
+  float4 result = float4(vals[0], vals[1], vals[2], vals[3]) * inv_sum;
+  if (base + N_READS <= axis_size) {
+    if (sb == 1) {
+      store_vec4(out + base, result);
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++)
+        out[(base + i) * sb] = static_cast<T>(result[i]);
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size)
+        out[(base + i) * sb] = static_cast<T>(result[i]);
+    }
+  }
+}
+
+// Forward looped: online softmax fuses max+sum into one pass over memory.
+
+template <typename T>
+kernel void softmax_forward_looped(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* x = input + offset_a(tg_id, params);
+  device T* out = output + offset_b(tg_id, params);
+  bool contiguous = (sa == 1);
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 v;
+      if (contiguous) {
+        v = load_vec4(x + base);
+      } else {
+        v = float4(
+            x[base * sa],
+            x[(base + 1) * sa],
+            x[(base + 2) * sa],
+            x[(base + 3) * sa]);
+      }
+      float chunk_max = fmax(fmax(v.x, v.y), fmax(v.z, v.w));
+      float new_max = fmax(local_max, chunk_max);
+      local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+          metal::precise::exp(v.x - new_max) +
+          metal::precise::exp(v.y - new_max) +
+          metal::precise::exp(v.z - new_max) +
+          metal::precise::exp(v.w - new_max);
+      local_max = new_max;
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        float new_max = fmax(local_max, val);
+        local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+            metal::precise::exp(val - new_max);
+        local_max = new_max;
+      }
+    }
+  }
+
+  float sg_max = simd_max(local_max);
+  local_sum *= metal::precise::exp(local_max - sg_max);
+  float sg_sum = simd_sum(local_sum);
+
+  threadgroup float shared_max[simdgroup_size];
+  threadgroup float shared_sum[simdgroup_size];
+  threadgroup float tg_result[2];
+
+  if (simd_lane_id == 0) {
+    shared_max[simdgroup_id] = sg_max;
+    shared_sum[simdgroup_id] = sg_sum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (simdgroup_id == 0) {
+    float m = shared_max[simd_lane_id];
+    float global_max = simd_max(m);
+    float s = shared_sum[simd_lane_id] * metal::precise::exp(m - global_max);
+    float global_sum = simd_sum(s);
+    if (simd_lane_id == 0) {
+      tg_result[0] = global_max;
+      tg_result[1] = global_sum;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  float row_max = tg_result[0];
+  float inv_sum = 1.0f / tg_result[1];
+
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 v;
+      if (contiguous) {
+        v = metal::precise::exp(load_vec4(x + base) - row_max) * inv_sum;
+      } else {
+        v = float4(
+            metal::precise::exp(float(x[base * sa]) - row_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 1) * sa]) - row_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 2) * sa]) - row_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 3) * sa]) - row_max) * inv_sum);
+      }
+      if (sb == 1) {
+        store_vec4(out + base, v);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          out[(base + i) * sb] = static_cast<T>(v[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        out[i * sb] = static_cast<T>(metal::precise::exp(val - row_max) * inv_sum);
+      }
+    }
+  }
+}
+
+
+// Two-pass forward for low-occupancy cases (few rows, large axis).
+// Phase 1: each threadgroup computes (chunk_max, chunk_sum) via online algorithm.
+// Phase 2: each threadgroup combines partials, re-reads input, writes output.
+
+template <typename T>
+kernel void softmax_forward_2pass_reduce(
+    device const T* input [[buffer(0)]],
+    device float* partials [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  device const T* x = input + offset_a(row_id, params);
+  bool contiguous = (sa == 1);
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      float4 v;
+      if (contiguous) {
+        v = load_vec4(x + base);
+      } else {
+        v = float4(x[base * sa], x[(base + 1) * sa],
+                    x[(base + 2) * sa], x[(base + 3) * sa]);
+      }
+      float chunk_max = fmax(fmax(v.x, v.y), fmax(v.z, v.w));
+      float new_max = fmax(local_max, chunk_max);
+      local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+          metal::precise::exp(v.x - new_max) +
+          metal::precise::exp(v.y - new_max) +
+          metal::precise::exp(v.z - new_max) +
+          metal::precise::exp(v.w - new_max);
+      local_max = new_max;
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        float new_max = fmax(local_max, val);
+        local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+            metal::precise::exp(val - new_max);
+        local_max = new_max;
+      }
+    }
+  }
+
+  float sg_max = simd_max(local_max);
+  local_sum *= metal::precise::exp(local_max - sg_max);
+  float sg_sum = simd_sum(local_sum);
+
+  threadgroup float shared_max[simdgroup_size];
+  threadgroup float shared_sum[simdgroup_size];
+
+  if (simd_lane_id == 0) {
+    shared_max[simdgroup_id] = sg_max;
+    shared_sum[simdgroup_id] = sg_sum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (simdgroup_id == 0) {
+    float m = shared_max[simd_lane_id];
+    float global_max = simd_max(m);
+    float s = shared_sum[simd_lane_id] * metal::precise::exp(m - global_max);
+    float global_sum = simd_sum(s);
+    if (simd_lane_id == 0) {
+      partials[(row_id * num_chunks + chunk_id) * 2] = global_max;
+      partials[(row_id * num_chunks + chunk_id) * 2 + 1] = global_sum;
+    }
+  }
+}
+
+template <typename T>
+kernel void softmax_forward_2pass_write(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    device const float* partials [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* x = input + offset_a(row_id, params);
+  device T* out = output + offset_b(row_id, params);
+  bool contiguous = (sa == 1);
+
+  float global_max = -INFINITY;
+  float global_sum = 0.0f;
+  for (uint i = 0; i < num_chunks; i++) {
+    float chunk_max = partials[(row_id * num_chunks + i) * 2];
+    float chunk_sum = partials[(row_id * num_chunks + i) * 2 + 1];
+    float new_max = fmax(global_max, chunk_max);
+    global_sum = global_sum * metal::precise::exp(global_max - new_max) +
+        chunk_sum * metal::precise::exp(chunk_max - new_max);
+    global_max = new_max;
+  }
+  float inv_sum = 1.0f / global_sum;
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      float4 v;
+      if (contiguous) {
+        v = metal::precise::exp(load_vec4(x + base) - global_max) * inv_sum;
+      } else {
+        v = float4(
+            metal::precise::exp(float(x[base * sa]) - global_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 1) * sa]) - global_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 2) * sa]) - global_max) * inv_sum,
+            metal::precise::exp(float(x[(base + 3) * sa]) - global_max) * inv_sum);
+      }
+      if (sb == 1) {
+        store_vec4(out + base, v);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          out[(base + i) * sb] = static_cast<T>(v[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        out[i * sb] = static_cast<T>(metal::precise::exp(val - global_max) * inv_sum);
+      }
+    }
+  }
+}
+
+// Backward: grad_input = output * (grad_output - sum(grad_output * output))
+// stride_a = grad_output strides, stride_b = output strides
+// Writes grad_input contiguously.
+
+template <typename T>
+kernel void softmax_backward_single_row(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  device const T* dy = grad_output + offset_a(tg_id, params);
+  device const T* y = output + offset_b(tg_id, params);
+  device T* dx = grad_input + offset_c(tg_id, params);
+  uint base = tid * N_READS;
+
+  bool contiguous = (sa == 1) && (sb == 1);
+  float dy_vals[N_READS];
+  float y_vals[N_READS];
+  float local_dot = 0.0f;
+  if (base + N_READS <= axis_size) {
+    if (contiguous) {
+      float4 dy_v = load_vec4(dy + base);
+      float4 y_v = load_vec4(y + base);
+      dy_vals[0] = dy_v.x;
+      dy_vals[1] = dy_v.y;
+      dy_vals[2] = dy_v.z;
+      dy_vals[3] = dy_v.w;
+      y_vals[0] = y_v.x;
+      y_vals[1] = y_v.y;
+      y_vals[2] = y_v.z;
+      y_vals[3] = y_v.w;
+      local_dot = dot(dy_v, y_v);
+    } else {
+      for (int i = 0; i < N_READS; i++) {
+        dy_vals[i] = float(dy[(base + i) * sa]);
+        y_vals[i] = float(y[(base + i) * sb]);
+        local_dot += dy_vals[i] * y_vals[i];
+      }
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size) {
+        dy_vals[i] =
+            contiguous ? float(dy[base + i]) : float(dy[(base + i) * sa]);
+        y_vals[i] = contiguous ? float(y[base + i]) : float(y[(base + i) * sb]);
+        local_dot += dy_vals[i] * y_vals[i];
+      }
+    }
+  }
+
+  threadgroup float shared_dot[simdgroup_size];
+  float dot_sum = c10::metal::threadgroup_sum(shared_dot, local_dot, tid, tptg);
+
+  float4 result = float4(y_vals[0], y_vals[1], y_vals[2], y_vals[3]) *
+      (float4(dy_vals[0], dy_vals[1], dy_vals[2], dy_vals[3]) - dot_sum);
+  if (base + N_READS <= axis_size) {
+    if (sc == 1) {
+      store_vec4(dx + base, result);
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++)
+        dx[(base + i) * sc] = static_cast<T>(result[i]);
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size)
+        dx[(base + i) * sc] = static_cast<T>(y_vals[i] * (dy_vals[i] - dot_sum));
+    }
+  }
+}
+
+// Backward looped: vectorized dot product with strided or contiguous access.
+
+template <typename T>
+kernel void softmax_backward_looped(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  device const T* dy = grad_output + offset_a(tg_id, params);
+  device const T* y = output + offset_b(tg_id, params);
+  device T* dx = grad_input + offset_c(tg_id, params);
+  bool contiguous = (sa == 1) && (sb == 1);
+
+  float local_dot = 0.0f;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      if (contiguous) {
+        local_dot += dot(load_vec4(dy + base), load_vec4(y + base));
+      } else {
+        float4 dy_v = float4(
+            dy[base * sa],
+            dy[(base + 1) * sa],
+            dy[(base + 2) * sa],
+            dy[(base + 3) * sa]);
+        float4 y_v = float4(
+            y[base * sb],
+            y[(base + 1) * sb],
+            y[(base + 2) * sb],
+            y[(base + 3) * sb]);
+        local_dot += dot(dy_v, y_v);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++)
+        local_dot += (contiguous ? float(dy[i]) : float(dy[i * sa])) *
+            (contiguous ? float(y[i]) : float(y[i * sb]));
+    }
+  }
+
+  threadgroup float shared_dot[simdgroup_size];
+  float dot_sum = c10::metal::threadgroup_sum(shared_dot, local_dot, tid, lsize);
+
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 y_v, dy_v;
+      if (contiguous) {
+        y_v = load_vec4(y + base);
+        dy_v = load_vec4(dy + base);
+      } else {
+        y_v = float4(y[base * sb], y[(base+1) * sb], y[(base+2) * sb], y[(base+3) * sb]);
+        dy_v = float4(dy[base * sa], dy[(base+1) * sa], dy[(base+2) * sa], dy[(base+3) * sa]);
+      }
+      float4 result = y_v * (dy_v - dot_sum);
+      if (sc == 1) {
+        store_vec4(dx + base, result);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          dx[(base + i) * sc] = static_cast<T>(result[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float yi = contiguous ? float(y[i]) : float(y[i * sb]);
+        float dyi = contiguous ? float(dy[i]) : float(dy[i * sa]);
+        dx[i * sc] = static_cast<T>(yi * (dyi - dot_sum));
+      }
+    }
+  }
+}
+
+// Two-pass backward for low-occupancy cases (few rows, large axis).
+// Phase 1: each threadgroup computes a partial dot(dy, y) over its chunk.
+// Phase 2: each threadgroup sums partial dots, then computes grad_input for its
+// chunk.
+
+template <typename T>
+kernel void softmax_backward_2pass_dot(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device float* partial_sums [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* dy = grad_output + offset_a(row_id, params);
+  device const T* y = output + offset_b(row_id, params);
+  bool contiguous = (sa == 1) && (sb == 1);
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  float local_dot = 0.0f;
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      if (contiguous) {
+        local_dot += dot(load_vec4(dy + base), load_vec4(y + base));
+      } else {
+        float4 dy_v = float4(
+            dy[base * sa],
+            dy[(base + 1) * sa],
+            dy[(base + 2) * sa],
+            dy[(base + 3) * sa]);
+        float4 y_v = float4(
+            y[base * sb],
+            y[(base + 1) * sb],
+            y[(base + 2) * sb],
+            y[(base + 3) * sb]);
+        local_dot += dot(dy_v, y_v);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++)
+        local_dot += (contiguous ? float(dy[i]) : float(dy[i * sa])) *
+            (contiguous ? float(y[i]) : float(y[i * sb]));
+    }
+  }
+
+  threadgroup float shared_dot[simdgroup_size];
+  float d = c10::metal::threadgroup_sum(shared_dot, local_dot, tid, lsize);
+  if (tid == 0)
+    partial_sums[row_id * num_chunks + chunk_id] = d;
+}
+
+template <typename T>
+kernel void softmax_backward_2pass_grad(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    device const float* partial_sums [[buffer(3)]],
+    constant SoftmaxParams& params [[buffer(4)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  device const T* dy = grad_output + offset_a(row_id, params);
+  device const T* y = output + offset_b(row_id, params);
+  device T* dx = grad_input + offset_c(row_id, params);
+  bool contiguous = (sa == 1) && (sb == 1);
+
+  float dot_sum = 0.0f;
+  for (uint i = 0; i < num_chunks; i++)
+    dot_sum += partial_sums[row_id * num_chunks + i];
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      float4 y_v, dy_v;
+      if (contiguous) {
+        y_v = load_vec4(y + base);
+        dy_v = load_vec4(dy + base);
+      } else {
+        y_v = float4(y[base * sb], y[(base+1) * sb], y[(base+2) * sb], y[(base+3) * sb]);
+        dy_v = float4(dy[base * sa], dy[(base+1) * sa], dy[(base+2) * sa], dy[(base+3) * sa]);
+      }
+      float4 result = y_v * (dy_v - dot_sum);
+      if (sc == 1) {
+        store_vec4(dx + base, result);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          dx[(base + i) * sc] = static_cast<T>(result[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++) {
+        float yi = contiguous ? float(y[i]) : float(y[i * sb]);
+        float dyi = contiguous ? float(dy[i]) : float(dy[i * sa]);
+        dx[i * sc] = static_cast<T>(yi * (dyi - dot_sum));
+      }
+    }
+  }
+}
+
+
+// ============================================================================
+// Log-softmax kernels
+// output[i] = (x[i] - max) - log(sum(exp(x - max)))
+// ============================================================================
+
+
+template <typename T>
+kernel void softmax_forward_tiled(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint num_tiles = params.num_chunks;
+  uint batch_idx = tg_id / num_tiles;
+  uint tile_idx = tg_id % num_tiles;
+  uint inner_pos = tile_idx * lsize + tid;
+
+  if (inner_pos >= sa) return;
+
+  uint base_a = batch_idx * axis_size * sa + inner_pos;
+  uint base_b = batch_idx * axis_size * sb + inner_pos;
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint b = 0; b < axis_size; b++) {
+    float val = float(input[base_a + b * sa]);
+    float new_max = fmax(local_max, val);
+    local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+        metal::precise::exp(val - new_max);
+    local_max = new_max;
+  }
+  float inv_sum = 1.0f / local_sum;
+
+  for (uint b = 0; b < axis_size; b++) {
+    float val = float(input[base_a + b * sa]);
+    output[base_b + b * sb] = static_cast<T>(
+        metal::precise::exp(val - local_max) * inv_sum);
+  }
+}
+
+template <typename T>
+kernel void softmax_backward_tiled(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  uint num_tiles = params.num_chunks;
+  uint batch_idx = tg_id / num_tiles;
+  uint tile_idx = tg_id % num_tiles;
+  uint inner_pos = tile_idx * lsize + tid;
+
+  if (inner_pos >= sa) return;
+
+  uint base_a = batch_idx * axis_size * sa + inner_pos;
+  uint base_b = batch_idx * axis_size * sb + inner_pos;
+  uint base_c = batch_idx * axis_size * sc + inner_pos;
+
+  float dot_sum = 0.0f;
+  for (uint b = 0; b < axis_size; b++)
+    dot_sum += float(grad_output[base_a + b * sa]) * float(output[base_b + b * sb]);
+
+  for (uint b = 0; b < axis_size; b++) {
+    float dyi = float(grad_output[base_a + b * sa]);
+    float yi = float(output[base_b + b * sb]);
+    grad_input[base_c + b * sc] = static_cast<T>(yi * (dyi - dot_sum));
+  }
+}
+
+kernel void softmax_forward_coalesced(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    threadgroup float* smem [[threadgroup(0)]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint inner_pos = tid % sa;
+  uint axis_tid = tid / sa;
+  uint num_axis_threads = params.num_chunks;
+  uint batch_idx = tg_id;
+  uint base_a = batch_idx * axis_size * sa;
+  uint total = axis_size * sa;
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint off = tid; off < total; off += lsize) {
+    float val = float(input[base_a + off]);
+    float new_max = fmax(local_max, val);
+    local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+        metal::precise::exp(val - new_max);
+    local_max = new_max;
+  }
+
+  threadgroup float* mx = smem;
+  threadgroup float* sm = smem + lsize;
+  mx[tid] = local_max;
+  sm[tid] = local_sum;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint s = num_axis_threads / 2; s > 0; s >>= 1) {
+    if (axis_tid < s) {
+      uint o = tid + s * sa;
+      float om = mx[o], os = sm[o], mm = mx[tid], ms = sm[tid];
+      float nm = fmax(mm, om);
+      sm[tid] = (nm > -INFINITY)
+          ? ms * metal::precise::exp(mm - nm) + os * metal::precise::exp(om - nm)
+          : 0.0f;
+      mx[tid] = nm;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  float fmax_val = mx[inner_pos];
+  float finv = 1.0f / sm[inner_pos];
+
+  uint base_b = batch_idx * axis_size * sb;
+  for (uint off = tid; off < total; off += lsize) {
+    float val = float(input[base_a + off]);
+    output[base_b + off] = static_cast<T>(
+        metal::precise::exp(val - fmax_val) * finv);
+  }
+}
+
+template <typename T>
+kernel void softmax_backward_coalesced(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    threadgroup float* smem [[threadgroup(0)]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  uint inner_pos = tid % sa;
+  uint axis_tid = tid / sa;
+  uint num_axis_threads = params.num_chunks;
+  uint batch_idx = tg_id;
+  uint base_a = batch_idx * axis_size * sa;
+  uint base_b = batch_idx * axis_size * sb;
+  uint total = axis_size * sa;
+
+  float local_dot = 0.0f;
+  for (uint off = tid; off < total; off += lsize) {
+    uint b_idx = off / sa;
+    local_dot += float(grad_output[base_a + off]) * float(output[base_b + off]);
+  }
+
+  smem[tid] = local_dot;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint s = num_axis_threads / 2; s > 0; s >>= 1) {
+    if (axis_tid < s) smem[tid] += smem[tid + s * sa];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  float dot_sum = smem[inner_pos];
+
+  uint base_c = batch_idx * axis_size * sc;
+  for (uint off = tid; off < total; off += lsize) {
+    float dyi = float(grad_output[base_a + off]);
+    float yi = float(output[base_b + off]);
+    grad_input[base_c + off] = static_cast<T>(yi * (dyi - dot_sum));
+  }
+}
+
+
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_forward_looped(DTYPE)                          \
+  template [[host_name("softmax_forward_looped_" #DTYPE)]] [[kernel]] void \
+  softmax_forward_looped<DTYPE>(                                           \
+      device const DTYPE* input [[buffer(0)]],                             \
+      device DTYPE* output [[buffer(1)]],                                  \
+      constant SoftmaxParams& params [[buffer(2)]],                        \
+      uint tg_id [[threadgroup_position_in_grid]],                         \
+      uint tid [[thread_position_in_threadgroup]],                         \
+      uint lsize [[threads_per_threadgroup]],                              \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                     \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_backward_single_row(DTYPE)                     \
+  template [[host_name("softmax_backward_single_row_" #DTYPE)]] [[kernel]] \
+  void softmax_backward_single_row<DTYPE>(                                 \
+      device const DTYPE* grad_output [[buffer(0)]],                       \
+      device const DTYPE* output [[buffer(1)]],                            \
+      device DTYPE* grad_input [[buffer(2)]],                              \
+      constant SoftmaxParams& params [[buffer(3)]],                        \
+      uint tg_id [[threadgroup_position_in_grid]],                         \
+      uint tid [[thread_position_in_threadgroup]],                         \
+      uint tptg [[threads_per_threadgroup]],                               \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                     \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_backward_looped(DTYPE)                          \
+  template [[host_name("softmax_backward_looped_" #DTYPE)]] [[kernel]] void \
+  softmax_backward_looped<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                        \
+      device const DTYPE* output [[buffer(1)]],                             \
+      device DTYPE* grad_input [[buffer(2)]],                               \
+      constant SoftmaxParams& params [[buffer(3)]],                         \
+      uint tg_id [[threadgroup_position_in_grid]],                          \
+      uint tid [[thread_position_in_threadgroup]],                          \
+      uint lsize [[threads_per_threadgroup]],                               \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                      \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_backward_2pass_dot(DTYPE)                          \
+  template [[host_name("softmax_backward_2pass_dot_" #DTYPE)]] [[kernel]] void \
+  softmax_backward_2pass_dot<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                           \
+      device const DTYPE* output [[buffer(1)]],                                \
+      device float* partial_sums [[buffer(2)]],                                \
+      constant SoftmaxParams& params [[buffer(3)]],                            \
+      uint tg_id [[threadgroup_position_in_grid]],                             \
+      uint tid [[thread_position_in_threadgroup]],                             \
+      uint lsize [[threads_per_threadgroup]],                                  \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                         \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_backward_2pass_grad(DTYPE)                     \
+  template                                                                 \
+      [[host_name("softmax_backward_2pass_grad_" #DTYPE)]] [[kernel]] void \
+      softmax_backward_2pass_grad<DTYPE>(                                  \
+          device const DTYPE* grad_output [[buffer(0)]],                   \
+          device const DTYPE* output [[buffer(1)]],                        \
+          device DTYPE* grad_input [[buffer(2)]],                          \
+          device const float* partial_sums [[buffer(3)]],                  \
+          constant SoftmaxParams& params [[buffer(4)]],                    \
+          uint tg_id [[threadgroup_position_in_grid]],                     \
+          uint tid [[thread_position_in_threadgroup]],                     \
+          uint lsize [[threads_per_threadgroup]]);
+
+
+#define instantiate_softmax_forward_2pass_reduce(DTYPE)                          \
+  template [[host_name("softmax_forward_2pass_reduce_" #DTYPE)]] [[kernel]] void \
+  softmax_forward_2pass_reduce<DTYPE>(                                           \
+      device const DTYPE* input [[buffer(0)]],                                   \
+      device float* partials [[buffer(1)]],                                      \
+      constant SoftmaxParams& params [[buffer(2)]],                              \
+      uint tg_id [[threadgroup_position_in_grid]],                               \
+      uint tid [[thread_position_in_threadgroup]],                               \
+      uint lsize [[threads_per_threadgroup]],                                    \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                           \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_softmax_forward_2pass_write(DTYPE)                          \
+  template [[host_name("softmax_forward_2pass_write_" #DTYPE)]] [[kernel]] void \
+  softmax_forward_2pass_write<DTYPE>(                                           \
+      device const DTYPE* input [[buffer(0)]],                                  \
+      device DTYPE* output [[buffer(1)]],                                       \
+      device const float* partials [[buffer(2)]],                               \
+      constant SoftmaxParams& params [[buffer(3)]],                             \
+      uint tg_id [[threadgroup_position_in_grid]],                              \
+      uint tid [[thread_position_in_threadgroup]],                              \
+      uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_softmax_forward_coalesced(DTYPE)                          \
+  template [[host_name("softmax_forward_coalesced_" #DTYPE)]] [[kernel]] void  \
+  softmax_forward_coalesced<DTYPE>(                                            \
+      device const DTYPE* input [[buffer(0)]],                                 \
+      device DTYPE* output [[buffer(1)]],                                      \
+      constant SoftmaxParams& params [[buffer(2)]],                            \
+      uint tg_id [[threadgroup_position_in_grid]],                             \
+      uint tid [[thread_position_in_threadgroup]],                             \
+      uint lsize [[threads_per_threadgroup]],                                  \
+      threadgroup float* smem [[threadgroup(0)]]);
+
+#define instantiate_softmax_backward_coalesced(DTYPE)                          \
+  template [[host_name("softmax_backward_coalesced_" #DTYPE)]] [[kernel]] void \
+  softmax_backward_coalesced<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                           \
+      device const DTYPE* output [[buffer(1)]],                                \
+      device DTYPE* grad_input [[buffer(2)]],                                  \
+      constant SoftmaxParams& params [[buffer(3)]],                            \
+      uint tg_id [[threadgroup_position_in_grid]],                             \
+      uint tid [[thread_position_in_threadgroup]],                             \
+      uint lsize [[threads_per_threadgroup]],                                  \
+      threadgroup float* smem [[threadgroup(0)]]);
+
+#define instantiate_softmax_forward_tiled(DTYPE)                          \
+  template [[host_name("softmax_forward_tiled_" #DTYPE)]] [[kernel]] void \
+  softmax_forward_tiled<DTYPE>(                                           \
+      device const DTYPE* input [[buffer(0)]],                            \
+      device DTYPE* output [[buffer(1)]],                                 \
+      constant SoftmaxParams& params [[buffer(2)]],                       \
+      uint tg_id [[threadgroup_position_in_grid]],                        \
+      uint tid [[thread_position_in_threadgroup]],                        \
+      uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_softmax_backward_tiled(DTYPE)                          \
+  template [[host_name("softmax_backward_tiled_" #DTYPE)]] [[kernel]] void \
+  softmax_backward_tiled<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                       \
+      device const DTYPE* output [[buffer(1)]],                            \
+      device DTYPE* grad_input [[buffer(2)]],                              \
+      constant SoftmaxParams& params [[buffer(3)]],                        \
+      uint tg_id [[threadgroup_position_in_grid]],                         \
+      uint tid [[thread_position_in_threadgroup]],                         \
+      uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_softmax(DTYPE)                              \
+  instantiate_softmax_forward_single_row(DTYPE)                 \
+      instantiate_softmax_forward_looped(DTYPE)                 \
+          instantiate_softmax_forward_tiled(DTYPE)              \
+              instantiate_softmax_forward_coalesced(DTYPE)  \
+              instantiate_softmax_forward_2pass_reduce(DTYPE)   \
+                  instantiate_softmax_forward_2pass_write(DTYPE)\
+                      instantiate_softmax_backward_single_row(DTYPE)        \
+                          instantiate_softmax_backward_looped(DTYPE)        \
+                              instantiate_softmax_backward_tiled(DTYPE)     \
+                                  instantiate_softmax_backward_coalesced(DTYPE) \
+                                  instantiate_softmax_backward_2pass_dot(DTYPE) \
+                                      instantiate_softmax_backward_2pass_grad(DTYPE)
+
+instantiate_softmax(float);
+instantiate_softmax(half);
+instantiate_softmax(bfloat);
+
+#define instantiate_log_softmax_forward_single_row(DTYPE)                         \
+  template [[host_name("log_softmax_forward_single_row_" #DTYPE)]] [[kernel]]     \
+  void log_softmax_forward_single_row<DTYPE>(                                     \
+      device const DTYPE* input [[buffer(0)]],                                    \
+      device DTYPE* output [[buffer(1)]],                                         \
+      constant SoftmaxParams& params [[buffer(2)]],                               \
+      uint tg_id [[threadgroup_position_in_grid]],                                \
+      uint tid [[thread_position_in_threadgroup]],                                \
+      uint tptg [[threads_per_threadgroup]],                                      \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                            \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_log_softmax_forward_looped(DTYPE)                              \
+  template [[host_name("log_softmax_forward_looped_" #DTYPE)]] [[kernel]] void     \
+  log_softmax_forward_looped<DTYPE>(                                               \
+      device const DTYPE* input [[buffer(0)]],                                     \
+      device DTYPE* output [[buffer(1)]],                                          \
+      constant SoftmaxParams& params [[buffer(2)]],                                \
+      uint tg_id [[threadgroup_position_in_grid]],                                 \
+      uint tid [[thread_position_in_threadgroup]],                                 \
+      uint lsize [[threads_per_threadgroup]],                                      \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                             \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_log_softmax_backward_single_row(DTYPE)                         \
+  template [[host_name("log_softmax_backward_single_row_" #DTYPE)]] [[kernel]]     \
+  void log_softmax_backward_single_row<DTYPE>(                                     \
+      device const DTYPE* grad_output [[buffer(0)]],                               \
+      device const DTYPE* output [[buffer(1)]],                                    \
+      device DTYPE* grad_input [[buffer(2)]],                                      \
+      constant SoftmaxParams& params [[buffer(3)]],                                \
+      uint tg_id [[threadgroup_position_in_grid]],                                 \
+      uint tid [[thread_position_in_threadgroup]],                                 \
+      uint tptg [[threads_per_threadgroup]],                                       \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                             \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_log_softmax_backward_looped(DTYPE)                              \
+  template [[host_name("log_softmax_backward_looped_" #DTYPE)]] [[kernel]] void     \
+  log_softmax_backward_looped<DTYPE>(                                               \
+      device const DTYPE* grad_output [[buffer(0)]],                                \
+      device const DTYPE* output [[buffer(1)]],                                     \
+      device DTYPE* grad_input [[buffer(2)]],                                       \
+      constant SoftmaxParams& params [[buffer(3)]],                                 \
+      uint tg_id [[threadgroup_position_in_grid]],                                  \
+      uint tid [[thread_position_in_threadgroup]],                                  \
+      uint lsize [[threads_per_threadgroup]],                                       \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                              \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_log_softmax_backward_2pass_sum(DTYPE)                              \
+  template [[host_name("log_softmax_backward_2pass_sum_" #DTYPE)]] [[kernel]] void     \
+  log_softmax_backward_2pass_sum<DTYPE>(                                               \
+      device const DTYPE* grad_output [[buffer(0)]],                                   \
+      device float* partial_sums [[buffer(1)]],                                        \
+      constant SoftmaxParams& params [[buffer(2)]],                                    \
+      uint tg_id [[threadgroup_position_in_grid]],                                     \
+      uint tid [[thread_position_in_threadgroup]],                                     \
+      uint lsize [[threads_per_threadgroup]],                                          \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                                 \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_log_softmax_backward_2pass_grad(DTYPE)                         \
+  template                                                                         \
+      [[host_name("log_softmax_backward_2pass_grad_" #DTYPE)]] [[kernel]] void     \
+      log_softmax_backward_2pass_grad<DTYPE>(                                      \
+          device const DTYPE* grad_output [[buffer(0)]],                           \
+          device const DTYPE* output [[buffer(1)]],                                \
+          device DTYPE* grad_input [[buffer(2)]],                                  \
+          device const float* partial_sums [[buffer(3)]],                          \
+          constant SoftmaxParams& params [[buffer(4)]],                            \
+          uint tg_id [[threadgroup_position_in_grid]],                             \
+          uint tid [[thread_position_in_threadgroup]],                             \
+          uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_log_softmax_forward_2pass_reduce(DTYPE)                              \
+  template [[host_name("log_softmax_forward_2pass_reduce_" #DTYPE)]] [[kernel]] void    \
+  log_softmax_forward_2pass_reduce<DTYPE>(                                              \
+      device const DTYPE* input [[buffer(0)]],                                          \
+      device float* partials [[buffer(1)]],                                             \
+      constant SoftmaxParams& params [[buffer(2)]],                                     \
+      uint tg_id [[threadgroup_position_in_grid]],                                      \
+      uint tid [[thread_position_in_threadgroup]],                                      \
+      uint lsize [[threads_per_threadgroup]],                                           \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                                  \
+      uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_log_softmax_forward_2pass_write(DTYPE)                              \
+  template [[host_name("log_softmax_forward_2pass_write_" #DTYPE)]] [[kernel]] void     \
+  log_softmax_forward_2pass_write<DTYPE>(                                               \
+      device const DTYPE* input [[buffer(0)]],                                          \
+      device DTYPE* output [[buffer(1)]],                                               \
+      device const float* partials [[buffer(2)]],                                       \
+      constant SoftmaxParams& params [[buffer(3)]],                                     \
+      uint tg_id [[threadgroup_position_in_grid]],                                      \
+      uint tid [[thread_position_in_threadgroup]],                                      \
+      uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_log_softmax_forward_coalesced(DTYPE)                          \
+  template [[host_name("log_softmax_forward_coalesced_" #DTYPE)]] [[kernel]] void \
+  log_softmax_forward_coalesced<DTYPE>(                                           \
+      device const DTYPE* input [[buffer(0)]],                                    \
+      device DTYPE* output [[buffer(1)]],                                         \
+

--- a/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
@@ -1517,7 +1517,6 @@ kernel void softmax_backward_coalesced(
 
   float local_dot = 0.0f;
   for (uint off = tid; off < total; off += lsize) {
-    uint b_idx = off / sa;
     local_dot += float(grad_output[base_a + off]) * float(output[base_b + off]);
   }
 

--- a/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal
@@ -688,6 +688,597 @@ kernel void softmax_backward_2pass_grad(
 // output[i] = (x[i] - max) - log(sum(exp(x - max)))
 // ============================================================================
 
+template <typename T>
+kernel void log_softmax_forward_single_row(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* x = input + offset_a(tg_id, params);
+  device T* out = output + offset_b(tg_id, params);
+  uint base = tid * N_READS;
+
+  bool contiguous = (sa == 1);
+  float vals[N_READS];
+  float local_max = -INFINITY;
+  if (base + N_READS <= axis_size) {
+    if (contiguous) {
+      float4 v = load_vec4(x + base);
+      vals[0] = v.x; vals[1] = v.y; vals[2] = v.z; vals[3] = v.w;
+    } else {
+      for (int i = 0; i < N_READS; i++)
+        vals[i] = float(x[(base + i) * sa]);
+    }
+    local_max = fmax(fmax(vals[0], vals[1]), fmax(vals[2], vals[3]));
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      vals[i] = (base + i < axis_size)
+          ? (contiguous ? float(x[base + i]) : float(x[(base + i) * sa]))
+          : -INFINITY;
+      local_max = fmax(local_max, vals[i]);
+    }
+  }
+
+  threadgroup float shared[simdgroup_size];
+  float row_max = c10::metal::threadgroup_max(shared, local_max, tid, tptg);
+
+  float local_sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < N_READS; i++)
+    local_sum += metal::precise::exp(vals[i] - row_max);
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  float total_sum = c10::metal::threadgroup_sum(shared, local_sum, tid, tptg);
+  float shift = row_max + metal::precise::log(total_sum);
+
+  float4 result = float4(vals[0], vals[1], vals[2], vals[3]) - shift;
+  if (base + N_READS <= axis_size) {
+    if (sb == 1) {
+      store_vec4(out + base, result);
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++)
+        out[(base + i) * sb] = static_cast<T>(result[i]);
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size)
+        out[(base + i) * sb] = static_cast<T>(result[i]);
+    }
+  }
+}
+
+template <typename T>
+kernel void log_softmax_forward_looped(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* x = input + offset_a(tg_id, params);
+  device T* out = output + offset_b(tg_id, params);
+  bool contiguous = (sa == 1);
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 v;
+      if (contiguous) {
+        v = load_vec4(x + base);
+      } else {
+        v = float4(x[base * sa], x[(base+1) * sa],
+                    x[(base+2) * sa], x[(base+3) * sa]);
+      }
+      float chunk_max = fmax(fmax(v.x, v.y), fmax(v.z, v.w));
+      float new_max = fmax(local_max, chunk_max);
+      local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+          metal::precise::exp(v.x - new_max) +
+          metal::precise::exp(v.y - new_max) +
+          metal::precise::exp(v.z - new_max) +
+          metal::precise::exp(v.w - new_max);
+      local_max = new_max;
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        float new_max = fmax(local_max, val);
+        local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+            metal::precise::exp(val - new_max);
+        local_max = new_max;
+      }
+    }
+  }
+
+  float sg_max = simd_max(local_max);
+  local_sum *= metal::precise::exp(local_max - sg_max);
+  float sg_sum = simd_sum(local_sum);
+
+  threadgroup float shared_max[simdgroup_size];
+  threadgroup float shared_sum[simdgroup_size];
+  threadgroup float tg_result[2];
+
+  if (simd_lane_id == 0) {
+    shared_max[simdgroup_id] = sg_max;
+    shared_sum[simdgroup_id] = sg_sum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (simdgroup_id == 0) {
+    float m = shared_max[simd_lane_id];
+    float global_max = simd_max(m);
+    float s = shared_sum[simd_lane_id] * metal::precise::exp(m - global_max);
+    float global_sum = simd_sum(s);
+    if (simd_lane_id == 0) {
+      tg_result[0] = global_max;
+      tg_result[1] = global_sum;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  float shift = tg_result[0] + metal::precise::log(tg_result[1]);
+
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 v;
+      if (contiguous) {
+        v = load_vec4(x + base) - shift;
+      } else {
+        v = float4(
+            float(x[base * sa]) - shift,
+            float(x[(base + 1) * sa]) - shift,
+            float(x[(base + 2) * sa]) - shift,
+            float(x[(base + 3) * sa]) - shift);
+      }
+      if (sb == 1) {
+        store_vec4(out + base, v);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          out[(base + i) * sb] = static_cast<T>(v[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        out[i * sb] = static_cast<T>(val - shift);
+      }
+    }
+  }
+}
+
+// Log-softmax forward 2-pass: for low-occupancy (outer_size < 4, large axis)
+// Phase 1: each threadgroup computes (chunk_max, chunk_sum) via online algorithm
+template <typename T>
+kernel void log_softmax_forward_2pass_reduce(
+    device const T* input [[buffer(0)]],
+    device float* partials [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  device const T* x = input + offset_a(row_id, params);
+  bool contiguous = (sa == 1);
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      float4 v;
+      if (contiguous) {
+        v = load_vec4(x + base);
+      } else {
+        v = float4(x[base * sa], x[(base+1) * sa],
+                    x[(base+2) * sa], x[(base+3) * sa]);
+      }
+      float chunk_max = fmax(fmax(v.x, v.y), fmax(v.z, v.w));
+      float new_max = fmax(local_max, chunk_max);
+      local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+          metal::precise::exp(v.x - new_max) +
+          metal::precise::exp(v.y - new_max) +
+          metal::precise::exp(v.z - new_max) +
+          metal::precise::exp(v.w - new_max);
+      local_max = new_max;
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        float new_max = fmax(local_max, val);
+        local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+            metal::precise::exp(val - new_max);
+        local_max = new_max;
+      }
+    }
+  }
+
+  // Reduce across simdgroup
+  float sg_max = simd_max(local_max);
+  local_sum *= metal::precise::exp(local_max - sg_max);
+  float sg_sum = simd_sum(local_sum);
+
+  threadgroup float shared_max[simdgroup_size];
+  threadgroup float shared_sum[simdgroup_size];
+
+  if (simd_lane_id == 0) {
+    shared_max[simdgroup_id] = sg_max;
+    shared_sum[simdgroup_id] = sg_sum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (simdgroup_id == 0) {
+    float m = shared_max[simd_lane_id];
+    float global_max = simd_max(m);
+    float s = shared_sum[simd_lane_id] * metal::precise::exp(m - global_max);
+    float global_sum = simd_sum(s);
+    if (simd_lane_id == 0) {
+      // Store (max, sum) pair as float2
+      partials[(row_id * num_chunks + chunk_id) * 2] = global_max;
+      partials[(row_id * num_chunks + chunk_id) * 2 + 1] = global_sum;
+    }
+  }
+}
+
+// Phase 2: combine partials, compute shift = max + log(sum), write output = x - shift
+template <typename T>
+kernel void log_softmax_forward_2pass_write(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    device const float* partials [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  device const T* x = input + offset_a(row_id, params);
+  device T* out = output + offset_b(row_id, params);
+  bool contiguous = (sa == 1);
+
+  // Combine all partial (max, sum) pairs for this row
+  float global_max = -INFINITY;
+  float global_sum = 0.0f;
+  for (uint i = 0; i < num_chunks; i++) {
+    float chunk_max = partials[(row_id * num_chunks + i) * 2];
+    float chunk_sum = partials[(row_id * num_chunks + i) * 2 + 1];
+    float new_max = fmax(global_max, chunk_max);
+    global_sum = global_sum * metal::precise::exp(global_max - new_max) +
+        chunk_sum * metal::precise::exp(chunk_max - new_max);
+    global_max = new_max;
+  }
+  float shift = global_max + metal::precise::log(global_sum);
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      float4 v;
+      if (contiguous) {
+        v = load_vec4(x + base) - shift;
+      } else {
+        v = float4(
+            float(x[base * sa]) - shift,
+            float(x[(base + 1) * sa]) - shift,
+            float(x[(base + 2) * sa]) - shift,
+            float(x[(base + 3) * sa]) - shift);
+      }
+      if (sb == 1) {
+        store_vec4(out + base, v);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          out[(base + i) * sb] = static_cast<T>(v[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++) {
+        float val = contiguous ? float(x[i]) : float(x[i * sa]);
+        out[i * sb] = static_cast<T>(val - shift);
+      }
+    }
+  }
+}
+
+// Log-softmax backward: grad_input = grad_output - exp(output) * sum(grad_output)
+
+template <typename T>
+kernel void log_softmax_backward_single_row(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  device const T* dy = grad_output + offset_a(tg_id, params);
+  device const T* y = output + offset_b(tg_id, params);
+  device T* dx = grad_input + offset_c(tg_id, params);
+  uint base = tid * N_READS;
+
+  bool contiguous = (sa == 1) && (sb == 1);
+  float dy_vals[N_READS];
+  float y_vals[N_READS];
+  float local_sum = 0.0f;
+  if (base + N_READS <= axis_size) {
+    if (contiguous) {
+      float4 dy_v = load_vec4(dy + base);
+      float4 y_v = load_vec4(y + base);
+      dy_vals[0] = dy_v.x; dy_vals[1] = dy_v.y;
+      dy_vals[2] = dy_v.z; dy_vals[3] = dy_v.w;
+      y_vals[0] = y_v.x; y_vals[1] = y_v.y;
+      y_vals[2] = y_v.z; y_vals[3] = y_v.w;
+      local_sum = dy_v.x + dy_v.y + dy_v.z + dy_v.w;
+    } else {
+      for (int i = 0; i < N_READS; i++) {
+        dy_vals[i] = float(dy[(base + i) * sa]);
+        y_vals[i] = float(y[(base + i) * sb]);
+        local_sum += dy_vals[i];
+      }
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size) {
+        dy_vals[i] = contiguous ? float(dy[base + i]) : float(dy[(base + i) * sa]);
+        y_vals[i] = contiguous ? float(y[base + i]) : float(y[(base + i) * sb]);
+        local_sum += dy_vals[i];
+      } else {
+        dy_vals[i] = 0;
+        y_vals[i] = 0;
+      }
+    }
+  }
+
+  threadgroup float shared[simdgroup_size];
+  float grad_sum = c10::metal::threadgroup_sum(shared, local_sum, tid, tptg);
+
+  float4 dy_v = float4(dy_vals[0], dy_vals[1], dy_vals[2], dy_vals[3]);
+  float4 exp_y = float4(
+      metal::precise::exp(y_vals[0]), metal::precise::exp(y_vals[1]),
+      metal::precise::exp(y_vals[2]), metal::precise::exp(y_vals[3]));
+  float4 result = dy_v - exp_y * grad_sum;
+  if (base + N_READS <= axis_size) {
+    if (sc == 1) {
+      store_vec4(dx + base, result);
+    } else {
+#pragma unroll
+      for (int i = 0; i < N_READS; i++)
+        dx[(base + i) * sc] = static_cast<T>(result[i]);
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if (base + i < axis_size)
+        dx[(base + i) * sc] = static_cast<T>(
+            dy_vals[i] - metal::precise::exp(y_vals[i]) * grad_sum);
+    }
+  }
+}
+
+template <typename T>
+kernel void log_softmax_backward_looped(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  device const T* dy = grad_output + offset_a(tg_id, params);
+  device const T* y = output + offset_b(tg_id, params);
+  device T* dx = grad_input + offset_c(tg_id, params);
+  bool contiguous = (sa == 1) && (sb == 1);
+
+  float local_sum = 0.0f;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      if (contiguous) {
+        float4 dy_v = load_vec4(dy + base);
+        local_sum += dy_v.x + dy_v.y + dy_v.z + dy_v.w;
+      } else {
+        for (int i = 0; i < N_READS; i++)
+          local_sum += float(dy[(base + i) * sa]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++)
+        local_sum += contiguous ? float(dy[i]) : float(dy[i * sa]);
+    }
+  }
+
+  threadgroup float shared[simdgroup_size];
+  float grad_sum = c10::metal::threadgroup_sum(shared, local_sum, tid, lsize);
+
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= axis_size) {
+      float4 dy_v, y_v;
+      if (contiguous) {
+        dy_v = load_vec4(dy + base);
+        y_v = load_vec4(y + base);
+      } else {
+        dy_v = float4(dy[base * sa], dy[(base+1) * sa], dy[(base+2) * sa], dy[(base+3) * sa]);
+        y_v = float4(y[base * sb], y[(base+1) * sb], y[(base+2) * sb], y[(base+3) * sb]);
+      }
+      float4 exp_y = float4(
+          metal::precise::exp(y_v.x), metal::precise::exp(y_v.y),
+          metal::precise::exp(y_v.z), metal::precise::exp(y_v.w));
+      float4 result = dy_v - exp_y * grad_sum;
+      if (sc == 1) {
+        store_vec4(dx + base, result);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          dx[(base + i) * sc] = static_cast<T>(result[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), axis_size); i++) {
+        float dyi = contiguous ? float(dy[i]) : float(dy[i * sa]);
+        float yi = contiguous ? float(y[i]) : float(y[i * sb]);
+        dx[i * sc] = static_cast<T>(dyi - metal::precise::exp(yi) * grad_sum);
+      }
+    }
+  }
+}
+
+template <typename T>
+kernel void log_softmax_backward_2pass_sum(
+    device const T* grad_output [[buffer(0)]],
+    device float* partial_sums [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simdgroup_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  device const T* dy = grad_output + offset_a(row_id, params);
+  bool contiguous = (sa == 1);
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  float local_sum = 0.0f;
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      if (contiguous) {
+        float4 v = load_vec4(dy + base);
+        local_sum += v.x + v.y + v.z + v.w;
+      } else {
+        for (int i = 0; i < N_READS; i++)
+          local_sum += float(dy[(base + i) * sa]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++)
+        local_sum += contiguous ? float(dy[i]) : float(dy[i * sa]);
+    }
+  }
+
+  threadgroup float shared[simdgroup_size];
+  float s = c10::metal::threadgroup_sum(shared, local_sum, tid, lsize);
+  if (tid == 0)
+    partial_sums[row_id * num_chunks + chunk_id] = s;
+}
+
+template <typename T>
+kernel void log_softmax_backward_2pass_grad(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    device const float* partial_sums [[buffer(3)]],
+    constant SoftmaxParams& params [[buffer(4)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  constexpr int N_READS = 4;
+  uint num_chunks = params.num_chunks;
+  uint chunk_id = tg_id % num_chunks;
+  uint row_id = tg_id / num_chunks;
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  device const T* dy = grad_output + offset_a(row_id, params);
+  device const T* y = output + offset_b(row_id, params);
+  device T* dx = grad_input + offset_c(row_id, params);
+  bool contiguous = (sa == 1) && (sb == 1);
+
+  float grad_sum = 0.0f;
+  for (uint i = 0; i < num_chunks; i++)
+    grad_sum += partial_sums[row_id * num_chunks + i];
+
+  uint elems_per_chunk = (axis_size + num_chunks - 1) / num_chunks;
+  uint start = chunk_id * elems_per_chunk;
+  uint end = min(start + elems_per_chunk, axis_size);
+
+  for (uint r = start; r < end; r += lsize * N_READS) {
+    uint base = r + tid * N_READS;
+    if (base + N_READS <= end) {
+      float4 dy_v, y_v;
+      if (contiguous) {
+        dy_v = load_vec4(dy + base);
+        y_v = load_vec4(y + base);
+      } else {
+        dy_v = float4(dy[base * sa], dy[(base+1) * sa], dy[(base+2) * sa], dy[(base+3) * sa]);
+        y_v = float4(y[base * sb], y[(base+1) * sb], y[(base+2) * sb], y[(base+3) * sb]);
+      }
+      float4 exp_y = float4(
+          metal::precise::exp(y_v.x), metal::precise::exp(y_v.y),
+          metal::precise::exp(y_v.z), metal::precise::exp(y_v.w));
+      float4 result = dy_v - exp_y * grad_sum;
+      if (sc == 1) {
+        store_vec4(dx + base, result);
+      } else {
+#pragma unroll
+        for (int i = 0; i < N_READS; i++)
+          dx[(base + i) * sc] = static_cast<T>(result[i]);
+      }
+    } else {
+      for (uint i = base; i < min(base + uint(N_READS), end); i++) {
+        float dyi = contiguous ? float(dy[i]) : float(dy[i * sa]);
+        float yi = contiguous ? float(y[i]) : float(y[i * sb]);
+        dx[i * sc] = static_cast<T>(dyi - metal::precise::exp(yi) * grad_sum);
+      }
+    }
+  }
+}
+
+
+// Tiled forward/backward kernels for non-last-dim softmax.
+// Each thread computes softmax for all axis elements at one inner position.
+// Adjacent threads access adjacent memory — coalesced reads and writes.
+// Uses num_chunks to store the number of inner tiles.
 
 template <typename T>
 kernel void softmax_forward_tiled(
@@ -763,6 +1354,87 @@ kernel void softmax_backward_tiled(
   }
 }
 
+template <typename T>
+kernel void log_softmax_forward_tiled(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint num_tiles = params.num_chunks;
+  uint batch_idx = tg_id / num_tiles;
+  uint tile_idx = tg_id % num_tiles;
+  uint inner_pos = tile_idx * lsize + tid;
+
+  if (inner_pos >= sa) return;
+
+  uint base_a = batch_idx * axis_size * sa + inner_pos;
+  uint base_b = batch_idx * axis_size * sb + inner_pos;
+
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint b = 0; b < axis_size; b++) {
+    float val = float(input[base_a + b * sa]);
+    float new_max = fmax(local_max, val);
+    local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+        metal::precise::exp(val - new_max);
+    local_max = new_max;
+  }
+  float shift = local_max + metal::precise::log(local_sum);
+
+  for (uint b = 0; b < axis_size; b++) {
+    float val = float(input[base_a + b * sa]);
+    output[base_b + b * sb] = static_cast<T>(val - shift);
+  }
+}
+
+template <typename T>
+kernel void log_softmax_backward_tiled(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  uint num_tiles = params.num_chunks;
+  uint batch_idx = tg_id / num_tiles;
+  uint tile_idx = tg_id % num_tiles;
+  uint inner_pos = tile_idx * lsize + tid;
+
+  if (inner_pos >= sa) return;
+
+  uint base_a = batch_idx * axis_size * sa + inner_pos;
+  uint base_b = batch_idx * axis_size * sb + inner_pos;
+  uint base_c = batch_idx * axis_size * sc + inner_pos;
+
+  float grad_sum = 0.0f;
+  for (uint b = 0; b < axis_size; b++)
+    grad_sum += float(grad_output[base_a + b * sa]);
+
+  for (uint b = 0; b < axis_size; b++) {
+    float dyi = float(grad_output[base_a + b * sa]);
+    float yi = float(output[base_b + b * sb]);
+    grad_input[base_c + b * sc] = static_cast<T>(dyi - metal::precise::exp(yi) * grad_sum);
+  }
+}
+
+
+// Coalesced non-last-dim kernels for inner_size < axis_size.
+// Thread t loads input[base + t] (perfectly coalesced).
+// inner_pos = tid % stride_a, axis_tid = tid / stride_a.
+// Multiple axis_tid threads share one inner_pos; reduced in shared memory.
+// num_chunks stores num_axis_threads for the reduction.
+
+template <typename T>
 kernel void softmax_forward_coalesced(
     device const T* input [[buffer(0)]],
     device T* output [[buffer(1)]],
@@ -867,7 +1539,120 @@ kernel void softmax_backward_coalesced(
   }
 }
 
+template <typename T>
+kernel void log_softmax_forward_coalesced(
+    device const T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant SoftmaxParams& params [[buffer(2)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    threadgroup float* smem [[threadgroup(0)]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint inner_pos = tid % sa;
+  uint axis_tid = tid / sa;
+  uint num_axis_threads = params.num_chunks;
+  uint batch_idx = tg_id;
+  uint base_a = batch_idx * axis_size * sa;
+  uint total = axis_size * sa;
 
+  float local_max = -INFINITY;
+  float local_sum = 0.0f;
+  for (uint off = tid; off < total; off += lsize) {
+    float val = float(input[base_a + off]);
+    float new_max = fmax(local_max, val);
+    local_sum = local_sum * metal::precise::exp(local_max - new_max) +
+        metal::precise::exp(val - new_max);
+    local_max = new_max;
+  }
+
+  threadgroup float* mx = smem;
+  threadgroup float* sm = smem + lsize;
+  mx[tid] = local_max;
+  sm[tid] = local_sum;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint s = num_axis_threads / 2; s > 0; s >>= 1) {
+    if (axis_tid < s) {
+      uint o = tid + s * sa;
+      float om = mx[o], os = sm[o], mm = mx[tid], ms = sm[tid];
+      float nm = fmax(mm, om);
+      sm[tid] = (nm > -INFINITY)
+          ? ms * metal::precise::exp(mm - nm) + os * metal::precise::exp(om - nm)
+          : 0.0f;
+      mx[tid] = nm;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  float shift = mx[inner_pos] + metal::precise::log(sm[inner_pos]);
+
+  uint base_b = batch_idx * axis_size * sb;
+  for (uint off = tid; off < total; off += lsize) {
+    float val = float(input[base_a + off]);
+    output[base_b + off] = static_cast<T>(val - shift);
+  }
+}
+
+template <typename T>
+kernel void log_softmax_backward_coalesced(
+    device const T* grad_output [[buffer(0)]],
+    device const T* output [[buffer(1)]],
+    device T* grad_input [[buffer(2)]],
+    constant SoftmaxParams& params [[buffer(3)]],
+    uint tg_id [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    threadgroup float* smem [[threadgroup(0)]]) {
+  uint axis_size = params.axis_size;
+  uint sa = params.stride_a;
+  uint sb = params.stride_b;
+  uint sc = params.stride_c;
+  uint inner_pos = tid % sa;
+  uint axis_tid = tid / sa;
+  uint num_axis_threads = params.num_chunks;
+  uint batch_idx = tg_id;
+  uint base_a = batch_idx * axis_size * sa;
+  uint total = axis_size * sa;
+
+  float local_sum = 0.0f;
+  for (uint off = tid; off < total; off += lsize) {
+    local_sum += float(grad_output[base_a + off]);
+  }
+
+  smem[tid] = local_sum;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint s = num_axis_threads / 2; s > 0; s >>= 1) {
+    if (axis_tid < s) smem[tid] += smem[tid + s * sa];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  float grad_sum = smem[inner_pos];
+
+  uint base_b = batch_idx * axis_size * sb;
+  uint base_c = batch_idx * axis_size * sc;
+  for (uint off = tid; off < total; off += lsize) {
+    float dyi = float(grad_output[base_a + off]);
+    float yi = float(output[base_b + off]);
+    grad_input[base_c + off] = static_cast<T>(dyi - metal::precise::exp(yi) * grad_sum);
+  }
+}
+
+// Template instantiations
+
+#define instantiate_softmax_forward_single_row(DTYPE)                     \
+  template [[host_name("softmax_forward_single_row_" #DTYPE)]] [[kernel]] \
+  void softmax_forward_single_row<DTYPE>(                                 \
+      device const DTYPE* input [[buffer(0)]],                            \
+      device DTYPE* output [[buffer(1)]],                                 \
+      constant SoftmaxParams& params [[buffer(2)]],                       \
+      uint tg_id [[threadgroup_position_in_grid]],                        \
+      uint tid [[thread_position_in_threadgroup]],                        \
+      uint tptg [[threads_per_threadgroup]],                              \
+      uint simd_lane_id [[thread_index_in_simdgroup]],                    \
       uint simdgroup_id [[simdgroup_index_in_threadgroup]]);
 
 #define instantiate_softmax_forward_looped(DTYPE)                          \
@@ -1123,4 +1908,59 @@ instantiate_softmax(bfloat);
   log_softmax_forward_coalesced<DTYPE>(                                           \
       device const DTYPE* input [[buffer(0)]],                                    \
       device DTYPE* output [[buffer(1)]],                                         \
+      constant SoftmaxParams& params [[buffer(2)]],                               \
+      uint tg_id [[threadgroup_position_in_grid]],                                \
+      uint tid [[thread_position_in_threadgroup]],                                \
+      uint lsize [[threads_per_threadgroup]],                                     \
+      threadgroup float* smem [[threadgroup(0)]]);
 
+#define instantiate_log_softmax_backward_coalesced(DTYPE)                          \
+  template [[host_name("log_softmax_backward_coalesced_" #DTYPE)]] [[kernel]] void \
+  log_softmax_backward_coalesced<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                               \
+      device const DTYPE* output [[buffer(1)]],                                    \
+      device DTYPE* grad_input [[buffer(2)]],                                      \
+      constant SoftmaxParams& params [[buffer(3)]],                                \
+      uint tg_id [[threadgroup_position_in_grid]],                                 \
+      uint tid [[thread_position_in_threadgroup]],                                 \
+      uint lsize [[threads_per_threadgroup]],                                      \
+      threadgroup float* smem [[threadgroup(0)]]);
+
+#define instantiate_log_softmax_forward_tiled(DTYPE)                          \
+  template [[host_name("log_softmax_forward_tiled_" #DTYPE)]] [[kernel]] void \
+  log_softmax_forward_tiled<DTYPE>(                                           \
+      device const DTYPE* input [[buffer(0)]],                                \
+      device DTYPE* output [[buffer(1)]],                                     \
+      constant SoftmaxParams& params [[buffer(2)]],                           \
+      uint tg_id [[threadgroup_position_in_grid]],                            \
+      uint tid [[thread_position_in_threadgroup]],                            \
+      uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_log_softmax_backward_tiled(DTYPE)                          \
+  template [[host_name("log_softmax_backward_tiled_" #DTYPE)]] [[kernel]] void \
+  log_softmax_backward_tiled<DTYPE>(                                           \
+      device const DTYPE* grad_output [[buffer(0)]],                           \
+      device const DTYPE* output [[buffer(1)]],                                \
+      device DTYPE* grad_input [[buffer(2)]],                                  \
+      constant SoftmaxParams& params [[buffer(3)]],                            \
+      uint tg_id [[threadgroup_position_in_grid]],                             \
+      uint tid [[thread_position_in_threadgroup]],                             \
+      uint lsize [[threads_per_threadgroup]]);
+
+#define instantiate_log_softmax(DTYPE)                                  \
+  instantiate_log_softmax_forward_single_row(DTYPE)                     \
+      instantiate_log_softmax_forward_looped(DTYPE)                     \
+          instantiate_log_softmax_forward_tiled(DTYPE)                  \
+              instantiate_log_softmax_forward_coalesced(DTYPE)      \
+              instantiate_log_softmax_forward_2pass_reduce(DTYPE)       \
+                  instantiate_log_softmax_forward_2pass_write(DTYPE)    \
+                      instantiate_log_softmax_backward_single_row(DTYPE)\
+                          instantiate_log_softmax_backward_looped(DTYPE)\
+                              instantiate_log_softmax_backward_tiled(DTYPE)     \
+                                  instantiate_log_softmax_backward_coalesced(DTYPE) \
+                                  instantiate_log_softmax_backward_2pass_sum(DTYPE)     \
+                                      instantiate_log_softmax_backward_2pass_grad(DTYPE)
+
+instantiate_log_softmax(float);
+instantiate_log_softmax(half);
+instantiate_log_softmax(bfloat);

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -7,8 +7,6 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
-#include <ATen/ops/_log_softmax_backward_data_native.h>
-#include <ATen/ops/_log_softmax_native.h>
 #include <ATen/ops/_prelu_kernel_backward_native.h>
 #include <ATen/ops/_prelu_kernel_native.h>
 #include <ATen/ops/gelu_backward_native.h>
@@ -32,98 +30,6 @@
 using namespace at::mps;
 
 namespace at::native {
-
-TORCH_IMPL_FUNC(log_softmax_mps_out)
-(const Tensor& self, const int64_t dim, const bool half_to_float, const Tensor& out) {
-  TORCH_CHECK_NOT_IMPLEMENTED(self.scalar_type() != kLong, "MPS doesn't know how to do exponent_i64");
-  TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(self.scalar_type()),
-                              "log_softmax for complex is not supported for MPS");
-  TORCH_CHECK_NOT_IMPLEMENTED(self.scalar_type() != kBool, "log_softmax for bool is not supported for MPS");
-  using namespace mps;
-  using CachedGraph = MPSUnaryCachedGraph;
-
-  if (self.numel() == 0) {
-    return;
-  }
-
-  MPSStream* stream = at::mps::getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "log_softmax_mps_out" + getTensorsStringKey({self}) + ":" + std::to_string(dim);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-      MPSGraphTensor* maximumsTensor = [mpsGraph reductionMaximumWithTensor:inputTensor axis:dim name:nil];
-      MPSGraphTensor* inputTensorSubMax = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                                 secondaryTensor:maximumsTensor
-                                                                            name:nil];
-      MPSGraphTensor* exponentTensor = [mpsGraph exponentWithTensor:inputTensorSubMax name:nil];
-
-      MPSGraphTensor* exponentTensorReduced = [mpsGraph reductionSumWithTensor:exponentTensor axis:dim name:nil];
-
-      MPSGraphTensor* logSumExpTensor = [mpsGraph logarithmWithTensor:exponentTensorReduced name:nil];
-
-      MPSGraphTensor* outputTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensorSubMax
-                                                            secondaryTensor:logSumExpTensor
-                                                                       name:nil];
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, out);
-
-    // Create dictionary of inputs and outputs
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
-  }
-}
-
-TORCH_IMPL_FUNC(log_softmax_backward_mps_out)
-(const Tensor& grad_output, const Tensor& output, int64_t dim, ScalarType input_dtype, const Tensor& out) {
-  TORCH_CHECK_NOT_IMPLEMENTED(grad_output.scalar_type() != kLong, "MPS doesn't know how to do exponent_i64");
-  TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(grad_output.scalar_type()),
-                              "log_softmax for complex is not supported for MPS");
-  TORCH_CHECK_NOT_IMPLEMENTED(grad_output.scalar_type() != kBool, "log_softmax for bool is not supported for MPS");
-  using namespace mps;
-  using CachedGraph = MPSUnaryGradCachedGraph;
-
-  if (output.numel() == 0) {
-    return;
-  }
-
-  MPSStream* stream = at::mps::getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "log_softmax_backward_mps_out:" + getMPSTypeString(grad_output) + ":" + std::to_string(dim);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
-      MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
-
-      MPSGraphTensor* expTensor = [mpsGraph exponentWithTensor:outputTensor name:nil];
-      MPSGraphTensor* sumTensor = [mpsGraph reductionSumWithTensor:gradOutputTensor axis:dim name:nil];
-      MPSGraphTensor* multiplicationTensor = [mpsGraph multiplicationWithPrimaryTensor:expTensor
-                                                                       secondaryTensor:sumTensor
-                                                                                  name:nil];
-      MPSGraphTensor* resultTensor = [mpsGraph subtractionWithPrimaryTensor:gradOutputTensor
-                                                            secondaryTensor:multiplicationTensor
-                                                                       name:nil];
-
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-      newCachedGraph->gradInputTensor_ = resultTensor;
-    });
-
-    Placeholder gradPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
-    Placeholder resultPlaceholder = Placeholder(cachedGraph->gradInputTensor_, out);
-
-    // Create dictionary of inputs and outputs
-    auto feeds = dictionaryFromPlaceholders(gradPlaceholder, outputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, resultPlaceholder);
-  }
-}
 
 std::tuple<Tensor&, Tensor&> log_sigmoid_forward_out_mps(const Tensor& self, Tensor& output, Tensor& buffer) {
   TORCH_CHECK_NOT_IMPLEMENTED(self.scalar_type() != kLong, "MPS doesn't know how to do exponent_i64");

--- a/aten/src/ATen/native/mps/operations/SoftMax.mm
+++ b/aten/src/ATen/native/mps/operations/SoftMax.mm
@@ -7,6 +7,8 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_log_softmax_backward_data_native.h>
+#include <ATen/ops/_log_softmax_native.h>
 #include <ATen/ops/_softmax_backward_data_native.h>
 #include <ATen/ops/_softmax_native.h>
 #endif
@@ -349,5 +351,285 @@ TORCH_IMPL_FUNC(softmax_backward_mps_out)
 }
 
 
+TORCH_IMPL_FUNC(log_softmax_mps_out)
+(const Tensor& input_, const int64_t dim, const bool half_to_float, const Tensor& output) {
+  TORCH_CHECK(!half_to_float, "log_softmax with half to float conversion is not supported on MPS");
+  TORCH_CHECK(c10::isFloatingType(input_.scalar_type()), "log_softmax only supported for floating types");
+
+  if (input_.numel() == 0) {
+    return;
+  }
+
+  Tensor input;
+  if (input_.dim() == 0) {
+    input = input_.view(1);
+  } else
+    input = input_;
+
+  int64_t dim_ = maybe_wrap_dim(dim, input.dim());
+  TORCH_CHECK(dim_ >= 0 && dim_ < input.dim(), "LogSoftmax:dim must be non-negative and less than input dimensions");
+
+  if (mps::canUseMetalSoftmax(input, dim_)) {
+    using namespace mps;
+    int64_t axis_size = input.size(dim_);
+    int64_t outer_size = input.numel() / axis_size;
+    auto params = makeForwardParams(input, output, dim_);
+
+    // Tiled path for non-last-dim log_softmax forward
+    {
+      int64_t ndim = input.dim();
+      bool use_tiled = (dim_ != ndim - 1) && input.is_contiguous() && output.is_contiguous();
+      int64_t inner_size = input.stride(dim_);
+      use_tiled = use_tiled && (inner_size >= axis_size);
+      if (use_tiled) {
+        int64_t outer_before = outer_size / inner_size;
+        int64_t tile_tg_size = std::min(inner_size, static_cast<int64_t>(1024));
+        int64_t num_tiles = (inner_size + tile_tg_size - 1) / tile_tg_size;
+        params.num_chunks = static_cast<uint32_t>(num_tiles);
+
+        MPSStream* stream = getCurrentMPSStream();
+        @autoreleasepool {
+          dispatch_sync_with_rethrow(stream->queue(), ^() {
+            auto metalType = mps::scalarToMetalTypeString(input);
+            auto kernel = mps::lib.getPipelineStateForFunc("log_softmax_forward_tiled_" + metalType);
+            id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+            [encoder setComputePipelineState:kernel];
+            mps::mtl_setArgs(encoder, input, output, params);
+            MTLSize threadsPerGroup = MTLSizeMake(tile_tg_size, 1, 1);
+            MTLSize numGroups = MTLSizeMake(num_tiles * outer_before, 1, 1);
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+          });
+        }
+        return;
+      }
+    }
+
+    // Coalesced path: flat loads with shared memory reduction
+    {
+      int64_t ndim = input.dim();
+      int64_t inner_size = input.stride(dim_);
+      bool use_coalesced = (dim_ != ndim - 1) && input.is_contiguous() && output.is_contiguous() && (inner_size > 1) && (inner_size < axis_size) && (axis_size <= 16384);
+      if (use_coalesced) {
+        int64_t outer_before = outer_size / inner_size;
+        int64_t nat = 1;
+        while (nat * 2 <= 1024 / inner_size) nat *= 2;
+        int64_t coal_tg_size = inner_size * nat;
+        params.num_chunks = static_cast<uint32_t>(nat);
+
+        MPSStream* stream = getCurrentMPSStream();
+        @autoreleasepool {
+          dispatch_sync_with_rethrow(stream->queue(), ^() {
+            auto metalType = mps::scalarToMetalTypeString(input);
+            auto kernel = mps::lib.getPipelineStateForFunc("log_softmax_forward_coalesced_" + metalType);
+            id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+            [encoder setComputePipelineState:kernel];
+            mps::mtl_setArgs(encoder, input, output, params);
+            [encoder setThreadgroupMemoryLength:coal_tg_size * 2 * sizeof(float) atIndex:0];
+            MTLSize threadsPerGroup = MTLSizeMake(coal_tg_size, 1, 1);
+            MTLSize numGroups = MTLSizeMake(outer_before, 1, 1);
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+          });
+        }
+        return;
+      }
+    }
+
+    MPSStream* stream = getCurrentMPSStream();
+
+    constexpr int N_READS = 4;
+    int64_t tg_size = std::min(static_cast<int64_t>((axis_size + N_READS - 1) / N_READS), static_cast<int64_t>(1024));
+    int64_t elems_per_tg = tg_size * N_READS;
+
+    constexpr int64_t kMinOccupancyTG = 8;
+    int64_t raw_chunks = axis_size / elems_per_tg;
+    int64_t max_chunks = std::min(raw_chunks, static_cast<int64_t>(16));
+    bool use_two_pass = (raw_chunks >= 8) && (outer_size < kMinOccupancyTG);
+
+    Tensor partials;
+    if (use_two_pass) {
+      params.num_chunks = static_cast<uint32_t>(max_chunks);
+      partials = at::empty({outer_size * max_chunks * 2}, input.options().dtype(at::kFloat));
+    }
+
+    @autoreleasepool {
+      dispatch_sync_with_rethrow(stream->queue(), ^() {
+        auto metalType = mps::scalarToMetalTypeString(input);
+        id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+        MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
+
+        if (use_two_pass) {
+          auto reduce_kernel = mps::lib.getPipelineStateForFunc("log_softmax_forward_2pass_reduce_" + metalType);
+          [encoder setComputePipelineState:reduce_kernel];
+          mps::mtl_setArgs(encoder, input, partials, params);
+          MTLSize numGroups = MTLSizeMake(static_cast<NSUInteger>(params.num_chunks) * outer_size, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+
+          [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
+          auto write_kernel = mps::lib.getPipelineStateForFunc("log_softmax_forward_2pass_write_" + metalType);
+          [encoder setComputePipelineState:write_kernel];
+          mps::mtl_setArgs(encoder, input, output, partials, params);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        } else {
+          id<MTLComputePipelineState> kernel;
+          if (axis_size <= 1024 * N_READS) {
+            kernel = mps::lib.getPipelineStateForFunc("log_softmax_forward_single_row_" + metalType);
+          } else {
+            kernel = mps::lib.getPipelineStateForFunc("log_softmax_forward_looped_" + metalType);
+          }
+
+          [encoder setComputePipelineState:kernel];
+          mps::mtl_setArgs(encoder, input, output, params);
+          MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        }
+      });
+    }
+
+    return;
+  }
+}
+
+TORCH_IMPL_FUNC(log_softmax_backward_mps_out)
+(const Tensor& grad_, const Tensor& output_, int64_t dim, ScalarType input_dtype, const Tensor& grad_input) {
+  if (output_.numel() == 0) {
+    return;
+  }
+
+  Tensor grad;
+  if (grad_.dim() == 0) {
+    grad = grad_.view(1);
+  } else
+    grad = grad_;
+
+  Tensor output;
+  if (output_.dim() == 0) {
+    output = output_.view(1);
+  } else
+    output = output_;
+
+  int64_t dim_ = maybe_wrap_dim(dim, grad.dim());
+  TORCH_CHECK(dim_ >= 0 && dim_ < grad.dim(), "Grad:dim must be non-negative and less than input dimensions");
+
+  if (mps::canUseMetalSoftmax(output, dim_) && mps::canUseMetalSoftmax(grad, dim_)) {
+    using namespace mps;
+    int64_t axis_size = output.size(dim_);
+    int64_t outer_size = output.numel() / axis_size;
+
+    constexpr int N_READS = 4;
+    int64_t tg_size = std::min(static_cast<int64_t>((axis_size + N_READS - 1) / N_READS), static_cast<int64_t>(1024));
+    auto params = makeBackwardParams(grad, output, grad_input, dim_);
+
+    // Tiled path for non-last-dim log_softmax backward
+    {
+      int64_t ndim = grad.dim();
+      bool use_tiled = (dim_ != ndim - 1) && grad.is_contiguous() && output.is_contiguous() && grad_input.is_contiguous();
+      int64_t inner_size = grad.stride(dim_);
+      use_tiled = use_tiled && (inner_size >= axis_size);
+      if (use_tiled) {
+        int64_t outer_before = outer_size / inner_size;
+        int64_t tile_tg_size = std::min(inner_size, static_cast<int64_t>(1024));
+        int64_t num_tiles = (inner_size + tile_tg_size - 1) / tile_tg_size;
+        params.num_chunks = static_cast<uint32_t>(num_tiles);
+
+        MPSStream* stream = getCurrentMPSStream();
+        @autoreleasepool {
+          dispatch_sync_with_rethrow(stream->queue(), ^() {
+            auto metalType = mps::scalarToMetalTypeString(output);
+            auto kernel = mps::lib.getPipelineStateForFunc("log_softmax_backward_tiled_" + metalType);
+            id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+            [encoder setComputePipelineState:kernel];
+            mps::mtl_setArgs(encoder, grad, output, grad_input, params);
+            MTLSize threadsPerGroup = MTLSizeMake(tile_tg_size, 1, 1);
+            MTLSize numGroups = MTLSizeMake(num_tiles * outer_before, 1, 1);
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+          });
+        }
+        return;
+      }
+    }
+
+    // Coalesced path: flat loads with shared memory reduction
+    {
+      int64_t ndim = grad.dim();
+      int64_t inner_size = grad.stride(dim_);
+      bool use_coalesced = (dim_ != ndim - 1) && grad.is_contiguous() && output.is_contiguous() && grad_input.is_contiguous() && (inner_size > 1) && (inner_size < axis_size) && (axis_size <= 16384);
+      if (use_coalesced) {
+        int64_t outer_before = outer_size / inner_size;
+        int64_t nat = 1;
+        while (nat * 2 <= 1024 / inner_size) nat *= 2;
+        int64_t coal_tg_size = inner_size * nat;
+        params.num_chunks = static_cast<uint32_t>(nat);
+
+        MPSStream* stream = getCurrentMPSStream();
+        @autoreleasepool {
+          dispatch_sync_with_rethrow(stream->queue(), ^() {
+            auto metalType = mps::scalarToMetalTypeString(output);
+            auto kernel = mps::lib.getPipelineStateForFunc("log_softmax_backward_coalesced_" + metalType);
+            id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+            [encoder setComputePipelineState:kernel];
+            mps::mtl_setArgs(encoder, grad, output, grad_input, params);
+            [encoder setThreadgroupMemoryLength:coal_tg_size * 2 * sizeof(float) atIndex:0];
+            MTLSize threadsPerGroup = MTLSizeMake(coal_tg_size, 1, 1);
+            MTLSize numGroups = MTLSizeMake(outer_before, 1, 1);
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+          });
+        }
+        return;
+      }
+    }
+
+    constexpr int64_t kMinOccupancyTG = 8;
+    int64_t elems_per_tg = tg_size * N_READS;
+    int64_t raw_chunks = axis_size / elems_per_tg;
+    int64_t max_chunks = std::min(raw_chunks, static_cast<int64_t>(16));
+    bool use_two_pass = (raw_chunks >= 8) && (outer_size < kMinOccupancyTG);
+
+    Tensor partial_sums;
+    if (use_two_pass) {
+      params.num_chunks = static_cast<uint32_t>(max_chunks);
+      partial_sums = at::empty({outer_size * max_chunks}, grad.options().dtype(at::kFloat));
+    }
+
+    MPSStream* stream = getCurrentMPSStream();
+
+    @autoreleasepool {
+      dispatch_sync_with_rethrow(stream->queue(), ^() {
+        auto metalType = mps::scalarToMetalTypeString(output);
+        id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+        MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
+
+        if (use_two_pass) {
+          auto sum_kernel = mps::lib.getPipelineStateForFunc("log_softmax_backward_2pass_sum_" + metalType);
+          [encoder setComputePipelineState:sum_kernel];
+          mps::mtl_setArgs(encoder, grad, partial_sums, params);
+          MTLSize numGroups = MTLSizeMake(static_cast<NSUInteger>(params.num_chunks) * outer_size, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+
+          [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
+          auto grad_kernel = mps::lib.getPipelineStateForFunc("log_softmax_backward_2pass_grad_" + metalType);
+          [encoder setComputePipelineState:grad_kernel];
+          mps::mtl_setArgs(encoder, grad, output, grad_input, partial_sums, params);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        } else {
+          id<MTLComputePipelineState> kernel;
+          if (axis_size <= 1024 * N_READS) {
+            kernel = mps::lib.getPipelineStateForFunc("log_softmax_backward_single_row_" + metalType);
+          } else {
+            kernel = mps::lib.getPipelineStateForFunc("log_softmax_backward_looped_" + metalType);
+          }
+
+          [encoder setComputePipelineState:kernel];
+          mps::mtl_setArgs(encoder, grad, output, grad_input, params);
+          MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        }
+      });
+    }
+
+    return;
+  }
+}
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/SoftMax.mm
+++ b/aten/src/ATen/native/mps/operations/SoftMax.mm
@@ -1,11 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/native/LinearAlgebraUtils.h>
 #include <ATen/native/mps/OperationUtils.h>
-
-#ifdef __OBJC__
-#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
-#endif
+#include <ATen/native/mps/kernels/SoftMaxKernel.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -16,31 +12,64 @@
 #endif
 
 namespace at::native {
+namespace mps {
 
-static void get_shapes(MPSShape* input_shape_readonly,
-                       NSMutableArray<NSNumber*>*& input_shape,
-                       int num_input_dims,
-                       c10::MemoryFormat memory_format) {
-  // Modify the shape
-  if (memory_format == at::MemoryFormat::Contiguous) {
-    for (int i = 0; i < num_input_dims; i++)
-      input_shape[i] = input_shape_readonly[i];
-  } else { // ChannelsLast
-    auto num_channels = input_shape_readonly[1];
-    input_shape[0] = input_shape_readonly[0];
-    for (int i = 1; i < num_input_dims - 1; i++)
-      input_shape[i] = input_shape_readonly[i + 1];
-    input_shape[num_input_dims - 1] = num_channels;
-  }
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/SoftMaxKernel_metallib.h>
+#endif
+
+static bool canUseMetalSoftmax(const Tensor& input, int64_t dim) {
+  return input.dim() > 0;
 }
 
-// Note - Currently only supported for 4D image tensors
+static SoftmaxParams makeForwardParams(const Tensor& input, const Tensor& output, int64_t dim) {
+  SoftmaxParams params = {};
+  int64_t ndim = input.dim();
+  params.axis_size = static_cast<uint32_t>(input.size(dim));
+  params.stride_a = static_cast<uint32_t>(input.stride(dim));
+  params.stride_b = static_cast<uint32_t>(output.stride(dim));
+  params.ndim = static_cast<uint32_t>(ndim);
+  int outer_idx = 0;
+  for (int64_t d = 0; d < ndim; d++) {
+    if (d == dim)
+      continue;
+    params.outer_sizes[outer_idx] = static_cast<uint32_t>(input.size(d));
+    params.outer_strides_a[outer_idx] = static_cast<uint32_t>(input.stride(d));
+    params.outer_strides_b[outer_idx] = static_cast<uint32_t>(output.stride(d));
+    outer_idx++;
+  }
+  return params;
+}
+
+static SoftmaxParams makeBackwardParams(const Tensor& grad, const Tensor& output, const Tensor& grad_input, int64_t dim) {
+  SoftmaxParams params = {};
+  int64_t ndim = grad.dim();
+  params.axis_size = static_cast<uint32_t>(grad.size(dim));
+  params.stride_a = static_cast<uint32_t>(grad.stride(dim));
+  params.stride_b = static_cast<uint32_t>(output.stride(dim));
+  params.stride_c = static_cast<uint32_t>(grad_input.stride(dim));
+  params.ndim = static_cast<uint32_t>(ndim);
+  int outer_idx = 0;
+  for (int64_t d = 0; d < ndim; d++) {
+    if (d == dim)
+      continue;
+    params.outer_sizes[outer_idx] = static_cast<uint32_t>(grad.size(d));
+    params.outer_strides_a[outer_idx] = static_cast<uint32_t>(grad.stride(d));
+    params.outer_strides_b[outer_idx] = static_cast<uint32_t>(output.stride(d));
+    params.outer_strides_c[outer_idx] = static_cast<uint32_t>(grad_input.stride(d));
+    outer_idx++;
+  }
+  return params;
+}
+
+} // namespace mps
 
 TORCH_IMPL_FUNC(softmax_mps_out)
 (const Tensor& input_, const int64_t dim, const bool half_to_float, const Tensor& output) {
   TORCH_CHECK(!half_to_float, "softmax with half to float conversion is not supported on MPS");
   TORCH_CHECK(c10::isFloatingType(input_.scalar_type()), "softmax only supported for floating types");
-  static const bool is_macOS_15_0_or_newer = is_macos_13_or_newer(MacOSVersion::MACOS_VER_15_0_PLUS);
 
   if (input_.numel() == 0) {
     return;
@@ -55,79 +84,125 @@ TORCH_IMPL_FUNC(softmax_mps_out)
   int64_t dim_ = maybe_wrap_dim(dim, input.dim());
   TORCH_CHECK(dim_ >= 0 && dim_ < input.dim(), "Softmax:dim must be non-negative and less than input dimensions");
 
-  const auto memory_format = input.suggest_memory_format();
-  // TORCH_CHECK(input.suggest_memory_format() == output.suggest_memory_format(), "Input and output memory format should
-  // match")
+  if (mps::canUseMetalSoftmax(input, dim_)) {
+    using namespace mps;
+    int64_t axis_size = input.size(dim_);
+    int64_t outer_size = input.numel() / axis_size;
+    auto params = makeForwardParams(input, output, dim_);
 
-  using namespace mps;
-  using CachedGraph = MPSUnaryCachedGraph;
-  MPSStream* stream = getCurrentMPSStream();
+    // Tiled path: each thread does one complete softmax row at one inner position.
+    // Gives perfect memory coalescing for non-last-dim with large inner_size.
+    {
+      int64_t ndim = input.dim();
+      bool use_tiled = (dim_ != ndim - 1) && input.is_contiguous() && output.is_contiguous();
+      int64_t inner_size = input.stride(dim_);
+      use_tiled = use_tiled && (inner_size >= axis_size);
+      if (use_tiled) {
+        int64_t outer_before = outer_size / inner_size;
+        int64_t tile_tg_size = std::min(inner_size, static_cast<int64_t>(1024));
+        int64_t num_tiles = (inner_size + tile_tg_size - 1) / tile_tg_size;
+        params.num_chunks = static_cast<uint32_t>(num_tiles);
 
-  @autoreleasepool {
-    std::string mem_format_key = get_mem_format_string(memory_format);
-    MPSShape* input_shape_readonly = mps::getMPSShape(input);
-    int num_input_dims = [input_shape_readonly count];
-    // Check - Channels last implies 4d
-    TORCH_CHECK(memory_format != at::MemoryFormat::ChannelsLast || num_input_dims == 4,
-                "ChannelsLast implies 4d tensor")
-    // Input shape changes based on memory format
-    NSMutableArray<NSNumber*>* input_shape = [NSMutableArray<NSNumber*> arrayWithCapacity:num_input_dims];
-
-    get_shapes(input_shape_readonly, input_shape, num_input_dims, memory_format);
-
-    // Change dim
-    if (memory_format == at::MemoryFormat::ChannelsLast && dim_ > 0 && !is_macOS_15_0_or_newer) {
-      switch (dim_) {
-        case 1:
-          dim_ = 3;
-          break;
-        case 2:
-          dim_ = 1;
-          break;
-        case 3:
-          dim_ = 2;
-          break;
-        default:
-          assert(0 && "Invalid dim\n");
+        MPSStream* stream = getCurrentMPSStream();
+        @autoreleasepool {
+          dispatch_sync_with_rethrow(stream->queue(), ^() {
+            auto metalType = mps::scalarToMetalTypeString(input);
+            auto kernel = mps::lib.getPipelineStateForFunc("softmax_forward_tiled_" + metalType);
+            id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+            [encoder setComputePipelineState:kernel];
+            mps::mtl_setArgs(encoder, input, output, params);
+            MTLSize threadsPerGroup = MTLSizeMake(tile_tg_size, 1, 1);
+            MTLSize numGroups = MTLSizeMake(num_tiles * outer_before, 1, 1);
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+          });
+        }
+        return;
       }
     }
 
-    NSString* ns_shape_key = [[input_shape valueForKey:@"description"] componentsJoinedByString:@","];
+    // Coalesced path: flat loads with shared memory reduction
+    {
+      int64_t ndim = input.dim();
+      int64_t inner_size = input.stride(dim_);
+      bool use_coalesced = (dim_ != ndim - 1) && input.is_contiguous() && output.is_contiguous() && (inner_size > 1) && (inner_size < axis_size) && (axis_size <= 16384);
+      if (use_coalesced) {
+        int64_t outer_before = outer_size / inner_size;
+        int64_t nat = 1;
+        while (nat * 2 <= 1024 / inner_size) nat *= 2;
+        int64_t coal_tg_size = inner_size * nat;
+        params.num_chunks = static_cast<uint32_t>(nat);
 
-    std::string key = "softmax_mps_out" + getTensorsStringKey(input, true, /*exclude_shape*/ true) + ":" +
-        mem_format_key + ":" + std::to_string(dim_);
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(input.scalar_type()));
-
-      // passing selector of softMaxWithTensor on the mpsGraph object
-      MPSGraphTensor* outputTensor = [mpsGraph softMaxWithTensor:inputTensor axis:(NSInteger)dim_ name:nil];
-
-      // Output needs to be contiguous format
-      if (memory_format == at::MemoryFormat::ChannelsLast && !is_macOS_15_0_or_newer) {
-        auto N = input_shape[0];
-        auto H = input_shape[1];
-        auto W = input_shape[2];
-        auto C = input_shape[3];
-
-        outputTensor = [mpsGraph reshapeTensor:outputTensor
-                                     withShape:@[ N, ([NSNumber numberWithInt:[H intValue] * [W intValue]]), C ]
-                                          name:nil];
-        outputTensor = [mpsGraph transposeTensor:outputTensor dimension:1 withDimension:2 name:nil];
-        outputTensor = [mpsGraph reshapeTensor:outputTensor withShape:@[ N, C, H, W ] name:nil];
+        MPSStream* stream = getCurrentMPSStream();
+        @autoreleasepool {
+          dispatch_sync_with_rethrow(stream->queue(), ^() {
+            auto metalType = mps::scalarToMetalTypeString(input);
+            auto kernel = mps::lib.getPipelineStateForFunc("softmax_forward_coalesced_" + metalType);
+            id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+            [encoder setComputePipelineState:kernel];
+            mps::mtl_setArgs(encoder, input, output, params);
+            [encoder setThreadgroupMemoryLength:coal_tg_size * 2 * sizeof(float) atIndex:0];
+            MTLSize threadsPerGroup = MTLSizeMake(coal_tg_size, 1, 1);
+            MTLSize numGroups = MTLSizeMake(outer_before, 1, 1);
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+          });
+        }
+        return;
       }
+    }
 
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
+    constexpr int N_READS = 4;
+    int64_t tg_size = std::min(static_cast<int64_t>((axis_size + N_READS - 1) / N_READS), static_cast<int64_t>(1024));
 
-    Placeholder inputPlaceholder =
-        Placeholder(cachedGraph->inputTensor_, input, is_macOS_15_0_or_newer ? nil : input_shape);
-    // This must be the Contiguous shape
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
+    constexpr int64_t kFwdMinOccupancyTG = 8;
+    int64_t elems_per_tg = tg_size * N_READS;
+    int64_t raw_chunks = axis_size / elems_per_tg;
+    int64_t max_chunks = std::min(raw_chunks, static_cast<int64_t>(16));
+    bool use_two_pass_fwd = (raw_chunks >= 8) && (outer_size < kFwdMinOccupancyTG);
 
-    auto feeds = dictionaryFromPlaceholders(inputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
+    Tensor fwd_partials;
+    if (use_two_pass_fwd) {
+      params.num_chunks = static_cast<uint32_t>(max_chunks);
+      fwd_partials = at::empty({outer_size * max_chunks * 2}, input.options().dtype(at::kFloat));
+    }
+
+    MPSStream* stream = getCurrentMPSStream();
+
+    @autoreleasepool {
+      dispatch_sync_with_rethrow(stream->queue(), ^() {
+        auto metalType = mps::scalarToMetalTypeString(input);
+        id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+        MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
+
+        if (use_two_pass_fwd) {
+          auto reduce_kernel = mps::lib.getPipelineStateForFunc("softmax_forward_2pass_reduce_" + metalType);
+          [encoder setComputePipelineState:reduce_kernel];
+          mps::mtl_setArgs(encoder, input, fwd_partials, params);
+          MTLSize numGroups = MTLSizeMake(static_cast<NSUInteger>(params.num_chunks) * outer_size, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+
+          [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
+          auto write_kernel = mps::lib.getPipelineStateForFunc("softmax_forward_2pass_write_" + metalType);
+          [encoder setComputePipelineState:write_kernel];
+          mps::mtl_setArgs(encoder, input, output, fwd_partials, params);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        } else {
+          id<MTLComputePipelineState> kernel;
+          if (axis_size <= 1024 * N_READS) {
+            kernel = mps::lib.getPipelineStateForFunc("softmax_forward_single_row_" + metalType);
+          } else {
+            kernel = mps::lib.getPipelineStateForFunc("softmax_forward_looped_" + metalType);
+          }
+
+          [encoder setComputePipelineState:kernel];
+          mps::mtl_setArgs(encoder, input, output, params);
+          MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        }
+      });
+    }
+
+    return;
   }
 }
 
@@ -152,43 +227,127 @@ TORCH_IMPL_FUNC(softmax_backward_mps_out)
   int64_t dim_ = maybe_wrap_dim(dim, grad.dim());
   TORCH_CHECK(dim_ >= 0 && dim_ < grad.dim(), "Grad:dim must be non-negative and less than input dimensions");
 
-  using namespace mps;
-  using CachedGraph = MPSUnaryGradCachedGraph;
-  MPSStream* stream = getCurrentMPSStream();
+  if (mps::canUseMetalSoftmax(output, dim_) && mps::canUseMetalSoftmax(grad, dim_)) {
+    using namespace mps;
+    int64_t axis_size = output.size(dim_);
+    int64_t outer_size = output.numel() / axis_size;
 
-  @autoreleasepool {
-    MPSShape* grad_shape = mps::getMPSShape(grad);
-    NSString* ns_shape_key = [[grad_shape valueForKey:@"description"] componentsJoinedByString:@","];
+    constexpr int N_READS = 4;
+    int64_t tg_size = std::min(static_cast<int64_t>((axis_size + N_READS - 1) / N_READS), static_cast<int64_t>(1024));
+    auto params = makeBackwardParams(grad, output, grad_input, dim_);
 
-    std::string key = "softmax_backward_mps_out:" + getMPSTypeString(output) + ":" + [ns_shape_key UTF8String] + ":" +
-        std::to_string(dim_);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* softmaxTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(output), grad_shape);
-      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad), grad_shape);
+    // Tiled path for non-last-dim backward
+    {
+      int64_t ndim = grad.dim();
+      bool use_tiled = (dim_ != ndim - 1) && grad.is_contiguous() && output.is_contiguous() && grad_input.is_contiguous();
+      int64_t inner_size = grad.stride(dim_);
+      use_tiled = use_tiled && (inner_size >= axis_size);
+      if (use_tiled) {
+        int64_t outer_before = outer_size / inner_size;
+        int64_t tile_tg_size = std::min(inner_size, static_cast<int64_t>(1024));
+        int64_t num_tiles = (inner_size + tile_tg_size - 1) / tile_tg_size;
+        params.num_chunks = static_cast<uint32_t>(num_tiles);
 
-      MPSGraphTensor* mulTensor = [mpsGraph multiplicationWithPrimaryTensor:softmaxTensor
-                                                            secondaryTensor:gradOutputTensor
-                                                                       name:nil];
-      MPSGraphTensor* mulSumTensor = [mpsGraph reductionSumWithTensor:mulTensor axis:(NSInteger)dim_ name:nil];
-      MPSGraphTensor* gradSubTensor = [mpsGraph subtractionWithPrimaryTensor:gradOutputTensor
-                                                             secondaryTensor:mulSumTensor
-                                                                        name:nil];
-      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:softmaxTensor
-                                                                  secondaryTensor:gradSubTensor
-                                                                             name:nil];
+        MPSStream* stream = getCurrentMPSStream();
+        @autoreleasepool {
+          dispatch_sync_with_rethrow(stream->queue(), ^() {
+            auto metalType = mps::scalarToMetalTypeString(output);
+            auto kernel = mps::lib.getPipelineStateForFunc("softmax_backward_tiled_" + metalType);
+            id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+            [encoder setComputePipelineState:kernel];
+            mps::mtl_setArgs(encoder, grad, output, grad_input, params);
+            MTLSize threadsPerGroup = MTLSizeMake(tile_tg_size, 1, 1);
+            MTLSize numGroups = MTLSizeMake(num_tiles * outer_before, 1, 1);
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+          });
+        }
+        return;
+      }
+    }
 
-      newCachedGraph->outputTensor_ = softmaxTensor;
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-      newCachedGraph->gradInputTensor_ = gradInputTensor;
-    });
+    // Coalesced path: flat loads with shared memory reduction
+    {
+      int64_t ndim = grad.dim();
+      int64_t inner_size = grad.stride(dim_);
+      bool use_coalesced = (dim_ != ndim - 1) && grad.is_contiguous() && output.is_contiguous() && grad_input.is_contiguous() && (inner_size > 1) && (inner_size < axis_size) && (axis_size <= 16384);
+      if (use_coalesced) {
+        int64_t outer_before = outer_size / inner_size;
+        int64_t nat = 1;
+        while (nat * 2 <= 1024 / inner_size) nat *= 2;
+        int64_t coal_tg_size = inner_size * nat;
+        params.num_chunks = static_cast<uint32_t>(nat);
 
-    Placeholder softmaxPlaceholder = Placeholder(cachedGraph->outputTensor_, output, grad_shape);
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad, grad_shape);
-    Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
+        MPSStream* stream = getCurrentMPSStream();
+        @autoreleasepool {
+          dispatch_sync_with_rethrow(stream->queue(), ^() {
+            auto metalType = mps::scalarToMetalTypeString(output);
+            auto kernel = mps::lib.getPipelineStateForFunc("softmax_backward_coalesced_" + metalType);
+            id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+            [encoder setComputePipelineState:kernel];
+            mps::mtl_setArgs(encoder, grad, output, grad_input, params);
+            [encoder setThreadgroupMemoryLength:coal_tg_size * 2 * sizeof(float) atIndex:0];
+            MTLSize threadsPerGroup = MTLSizeMake(coal_tg_size, 1, 1);
+            MTLSize numGroups = MTLSizeMake(outer_before, 1, 1);
+            [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+          });
+        }
+        return;
+      }
+    }
 
-    auto feeds = dictionaryFromPlaceholders(softmaxPlaceholder, gradOutputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
+    constexpr int64_t kMinOccupancyTG = 8;
+    int64_t elems_per_tg = tg_size * N_READS;
+    int64_t raw_chunks = axis_size / elems_per_tg;
+    int64_t max_chunks = std::min(raw_chunks, static_cast<int64_t>(16));
+    bool use_two_pass = (raw_chunks >= 8) && (outer_size < kMinOccupancyTG);
+
+    Tensor partial_sums;
+    if (use_two_pass) {
+      params.num_chunks = static_cast<uint32_t>(max_chunks);
+      partial_sums = at::empty({outer_size * max_chunks}, grad.options().dtype(at::kFloat));
+    }
+
+    MPSStream* stream = getCurrentMPSStream();
+
+    @autoreleasepool {
+      dispatch_sync_with_rethrow(stream->queue(), ^() {
+        auto metalType = mps::scalarToMetalTypeString(output);
+        id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+        MTLSize threadsPerGroup = MTLSizeMake(tg_size, 1, 1);
+
+        if (use_two_pass) {
+          auto dot_kernel = mps::lib.getPipelineStateForFunc("softmax_backward_2pass_dot_" + metalType);
+          [encoder setComputePipelineState:dot_kernel];
+          mps::mtl_setArgs(encoder, grad, output, partial_sums, params);
+          MTLSize numGroups = MTLSizeMake(static_cast<NSUInteger>(params.num_chunks) * outer_size, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+
+          [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+
+          auto grad_kernel = mps::lib.getPipelineStateForFunc("softmax_backward_2pass_grad_" + metalType);
+          [encoder setComputePipelineState:grad_kernel];
+          mps::mtl_setArgs(encoder, grad, output, grad_input, partial_sums, params);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        } else {
+          id<MTLComputePipelineState> kernel;
+          if (axis_size <= 1024 * N_READS) {
+            kernel = mps::lib.getPipelineStateForFunc("softmax_backward_single_row_" + metalType);
+          } else {
+            kernel = mps::lib.getPipelineStateForFunc("softmax_backward_looped_" + metalType);
+          }
+
+          [encoder setComputePipelineState:kernel];
+          mps::mtl_setArgs(encoder, grad, output, grad_input, params);
+          MTLSize numGroups = MTLSizeMake(outer_size, 1, 1);
+          [encoder dispatchThreadgroups:numGroups threadsPerThreadgroup:threadsPerGroup];
+        }
+      });
+    }
+
+    return;
   }
 }
+
+
 
 } // namespace at::native

--- a/benchmarks/bench_mps_softmax.py
+++ b/benchmarks/bench_mps_softmax.py
@@ -1,0 +1,164 @@
+"""Benchmark Metal softmax kernels on Apple Silicon.
+
+Measures forward and forward+backward wall-clock time across LLM-realistic
+shapes (vocab logits, attention scores) for both last-dim and non-last-dim.
+
+Methodology:
+- 300-iteration GPU warmup to reach steady-state clock frequency
+- 5 independent trials, each timed for at least 3 seconds
+- torch.mps.synchronize() inside every measurement window
+- Reports min / median / max across trials to expose thermal noise
+- Shapes run in fixed order (logits → generation → prefill) to avoid
+  thermal bias from heavy shapes warming the GPU for lighter ones
+
+Usage:
+    python benchmarks/bench_mps_softmax.py
+    python benchmarks/bench_mps_softmax.py --dtype float16
+    python benchmarks/bench_mps_softmax.py --dtype bfloat16 --backward
+"""
+import argparse
+import time
+import statistics
+import torch
+
+
+def time_forward(x, dim, n_iters):
+    torch.mps.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(n_iters):
+        torch.softmax(x, dim=dim)
+    torch.mps.synchronize()
+    return (time.perf_counter() - t0) / n_iters
+
+
+def time_fwd_bwd(x_template, dim, n_iters):
+    torch.mps.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(n_iters):
+        x = x_template.detach().requires_grad_(True)
+        y = torch.softmax(x, dim=dim)
+        y.sum().backward()
+    torch.mps.synchronize()
+    return (time.perf_counter() - t0) / n_iters
+
+
+def bench(shape, dim, dtype, include_backward, min_time=3.0, n_trials=5, warmup=300):
+    x = torch.randn(shape, device="mps", dtype=dtype)
+
+    # Warmup
+    for _ in range(warmup):
+        torch.softmax(x, dim=dim)
+    if include_backward:
+        for _ in range(warmup):
+            xw = x.detach().requires_grad_(True)
+            torch.softmax(xw, dim=dim).sum().backward()
+    torch.mps.synchronize()
+
+    # Forward trials
+    fwd_times = []
+    for _ in range(n_trials):
+        n_iters = 10
+        elapsed = time_forward(x, dim, n_iters)
+        n_iters = max(10, int(min_time / (elapsed + 1e-9)))
+        fwd_times.append(time_forward(x, dim, n_iters) * 1e6)
+
+    result = {"fwd": fwd_times}
+
+    # Forward+backward trials
+    if include_backward:
+        fb_times = []
+        for _ in range(n_trials):
+            n_iters = 10
+            elapsed = time_fwd_bwd(x, dim, n_iters)
+            n_iters = max(10, int(min_time / (elapsed + 1e-9)))
+            fb_times.append(time_fwd_bwd(x, dim, n_iters) * 1e6)
+        result["fwd_bwd"] = fb_times
+
+    return result
+
+
+def fmt_times(times):
+    mn, md, mx = min(times), statistics.median(times), max(times)
+    return f"{md:>8.1f}  ({mn:.1f} / {mx:.1f})"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark MPS softmax kernels")
+    parser.add_argument(
+        "--dtype",
+        default="float32",
+        choices=["float32", "float16", "bfloat16"],
+        help="Data type (default: float32)",
+    )
+    parser.add_argument(
+        "--backward", action="store_true", help="Include forward+backward timing"
+    )
+    parser.add_argument(
+        "--min-time",
+        type=float,
+        default=3.0,
+        help="Minimum seconds per trial (default: 3.0)",
+    )
+    parser.add_argument(
+        "--trials", type=int, default=5, help="Number of trials (default: 5)"
+    )
+    args = parser.parse_args()
+
+    dtype_map = {
+        "float32": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }
+    dtype = dtype_map[args.dtype]
+
+    # (shape, dim) pairs — ordered light to heavy to avoid thermal bias
+    cases = [
+        # Vocab logits (autoregressive generation), dim=-1
+        ((1, 32000), -1),
+        ((1, 50257), -1),
+        ((1, 128256), -1),
+        ((1, 256000), -1),
+        # Batched logits
+        ((4, 128256), -1),
+        ((8, 128256), -1),
+        # Attention scores (generation: batch * n_heads, 1, seq_len)
+        ((32, 1, 4096), -1),
+        ((32, 1, 32768), -1),
+        ((32, 1, 131072), -1),
+        # Attention scores (prefill: batch * n_heads, seq_len, seq_len)
+        ((32, 512, 512), -1),
+        ((32, 2048, 2048), -1),
+        # Non-last-dim softmax (uses permute path)
+        ((32, 4096, 1), 1),
+        ((8, 128256, 4), 1),
+        ((32, 512, 512), 0),
+    ]
+
+    print(f"PyTorch {torch.__version__}")
+    print(f"dtype: {args.dtype}")
+    print(f"Trials: {args.trials} x {args.min_time}s min each")
+    print()
+
+    header = f"{'shape':<24} {'dim':>4} {'fwd med (min/max) us':>28}"
+    if args.backward:
+        header += f"  {'fwd+bwd med (min/max) us':>28}"
+    print(header)
+    print("-" * len(header))
+
+    for shape, dim in cases:
+        result = bench(
+            shape,
+            dim,
+            dtype,
+            include_backward=args.backward,
+            min_time=args.min_time,
+            n_trials=args.trials,
+        )
+        line = f"{str(shape):<24} {dim:>4} {fmt_times(result['fwd']):>28}"
+        if args.backward:
+            line += f"  {fmt_times(result['fwd_bwd']):>28}"
+        print(line)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
> **Depends on #181503** (Metal softmax kernels). This PR adds Metal log_softmax kernels on top. Please merge #181503 first.

## Summary

Extends the Metal softmax infrastructure from #181503 to cover log_softmax forward and backward on all dimensions. Removes the old MPSGraph-based log_softmax from `Activation.mm`.

### Changes

**`aten/src/ATen/native/mps/kernels/SoftMaxKernel.metal`** (+840 lines)
- 12 log_softmax kernel functions matching the softmax variants:
  - Last-dim: `log_softmax_forward_single_row`, `log_softmax_forward_looped`, `log_softmax_forward_2pass_reduce/write`
  - Last-dim bwd: `log_softmax_backward_single_row`, `log_softmax_backward_looped`, `log_softmax_backward_2pass_sum/grad`
  - Non-last-dim: `log_softmax_forward/backward_tiled`, `log_softmax_forward/backward_coalesced`
- Log_softmax math: forward `output = x - (max + log(sum(exp(x - max))))`, backward `grad_input = grad - exp(output) * sum(grad)`
- Same dispatch paths as softmax: tiled (inner ≥ axis) → coalesced (inner < 16k) → looped fallback
- Coalesced path skips degenerate `inner_size == 1` (falls through to faster single_row/looped)

**`aten/src/ATen/native/mps/operations/SoftMax.mm`** (+282 lines)
- `log_softmax_mps_out` and `log_softmax_backward_mps_out` entry points reusing shared `makeForwardParams`/`makeBackwardParams` helpers

**`aten/src/ATen/native/mps/operations/Activation.mm`** (−94 lines)
- Removes the MPSGraph-based `log_softmax_mps_out` and `log_softmax_backward_mps_out`

### Benchmarks (M4 Pro, Metal vs MPSGraph, float32 fwd+bwd combined)

Methodology: Metal kernels benchmarked on this PR's build. MPSGraph benchmarked separately on upstream (no Metal kernels, log_softmax via Activation.mm). 15 runs, top-2 outliers trimmed, auto-scaled iterations (≥20ms wall time). Speedup > 1.0× = Metal faster.

| Shape | dim | Metal (µs) | MPSGraph (µs) | Speedup |
|-------|-----|:----------:|:-------------:|:-------:|
| `(1, 128256)` | −1 | **41.2 ± 2.1** | 80.5 ± 2.6 | **1.95×** |
| `(4, 128256)` | −1 | **72.1 ± 1.7** | 81.0 ± 6.0 | **1.12×** |
| `(32, 128256)` | −1 | **513.6 ± 3.5** | 623.5 ± 30.8 | **1.21×** |
| `(128, 4096)` | −1 | **52.6 ± 2.3** | 74.1 ± 2.4 | **1.41×** |
| `(512, 512)` | −1 | **38.9 ± 1.9** | 73.3 ± 2.2 | **1.88×** |
| `(32, 4096, 1)` | 1 | **33.9 ± 2.1** | 74.9 ± 3.2 | **2.21×** |
| `(8, 128256, 4)` | 1 | 643.7 ± 2.5 | 605.6 ± 8.2 | 0.94× |
| `(8, 16, 256)` | 1 | **30.0 ± 1.3** | 68.7 ± 1.9 | **2.29×** |
| `(32, 128, 64)` | 1 | **36.3 ± 2.3** | 74.5 ± 3.0 | **2.06×** |
| `(100, 3)` | 0 | **24.8 ± 1.0** | 69.5 ± 2.3 | **2.81×** |

9 of 10 shapes faster (1.12×–2.81×). Single regression: `(8, 128256, 4)` dim=1 at 0.94× — strided access with stride_a=4 wastes 75% memory bandwidth; same limitation as softmax (would need a tile+transpose kernel).

### Secondary benefit

Same as #181503: eliminates shape-dependent graph caching and first-call JIT compilation latency. Especially important for log_softmax which is used in cross-entropy loss with varying sequence lengths.

### Test plan
- [x] 126/126 custom correctness tests (forward + backward, all dispatch paths, fp32 + fp16)
- [x] `pytest test/test_mps.py -k softmax`: 47 failures all pre-existing (verified identical on base commit)
- [x] NaN guard verified: −∞ − (−∞) = NaN handled in coalesced reduction

cc @malfet