### PR TITLE
Bump Windows CPU trunk test shards from 4 to 5

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -216,10 +216,11 @@ jobs:
       runner: windows.4xlarge.nonephemeral
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 4, runner: "windows.4xlarge.nonephemeral" },
-          { config: "default", shard: 2, num_shards: 4, runner: "windows.4xlarge.nonephemeral" },
-          { config: "default", shard: 3, num_shards: 4, runner: "windows.4xlarge.nonephemeral" },
-          { config: "default", shard: 4, num_shards: 4, runner: "windows.4xlarge.nonephemeral" },
+          { config: "default", shard: 1, num_shards: 5, runner: "windows.4xlarge.nonephemeral" },
+          { config: "default", shard: 2, num_shards: 5, runner: "windows.4xlarge.nonephemeral" },
+          { config: "default", shard: 3, num_shards: 5, runner: "windows.4xlarge.nonephemeral" },
+          { config: "default", shard: 4, num_shards: 5, runner: "windows.4xlarge.nonephemeral" },
+          { config: "default", shard: 5, num_shards: 5, runner: "windows.4xlarge.nonephemeral" },
           { config: "openreg", shard: 1, num_shards: 1, runner: "windows.4xlarge.nonephemeral" },
         ]}
     secrets: inherit


### PR DESCRIPTION
Increase the default test-matrix sharding for win-vs2022-cpu-py3 in trunk to reduce per-shard runtime as the test keeps timing out https://github.com/pytorch/pytorch/actions/runs/25328038725/job/74262204349, probably due to pytest upgrade.

Authored by Claude.