### PR TITLE
[Inductor] Deal with choices that fail to compile in async pipelined autotuning path (#182342)

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -1590,5 +1590,11 @@ class AsyncAutotuner:
         timings = {}
         for choice in choices:
             choice_hash = AsyncAutotuner.get_choice_hash(choice, inputs_key)
-            timings[choice] = AsyncAutotuner.choice_hash_to_future[choice_hash].result()
+            if choice_hash in AsyncAutotuner.choice_hash_to_future:
+                timings[choice] = AsyncAutotuner.choice_hash_to_future[
+                    choice_hash
+                ].result()
+            else:
+                # Choice was filtered out during precompilation/prescreening
+                timings[choice] = float("inf")
         return timings


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/182342

Test Plan: Small refactor

Differential Revision: D103725434




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo