### PR TITLE
Fix grammar in FractionalMaxPool3d error message (#182346)

### DIFF
--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -655,9 +655,9 @@ class TestPoolingNNDeviceType(NNTestCase):
     @onlyNativeDeviceTypes
     def test_FractionalMaxPool3d_errors(self, device):
         samples = torch.rand([0, 16, 3], device=device)
-        with self.assertRaisesRegex(ValueError, "kernel_size must greater than 0"):
+        with self.assertRaisesRegex(ValueError, "kernel_size must be greater than 0"):
             nn.FractionalMaxPool3d(0, output_size=[1, 1, 1], _random_samples=samples)
-        with self.assertRaisesRegex(ValueError, "kernel_size must greater than 0"):
+        with self.assertRaisesRegex(ValueError, "kernel_size must be greater than 0"):
             nn.FractionalMaxPool3d(
                 [0, 0, 0], output_size=[1, 1, 1], _random_samples=samples
             )
@@ -667,7 +667,7 @@ class TestPoolingNNDeviceType(NNTestCase):
                 kernel_size=9223372036854775803,
                 output_size=[1, 1, 1],
             )(samples)
-        with self.assertRaisesRegex(ValueError, "kernel_size must greater than 0"):
+        with self.assertRaisesRegex(ValueError, "kernel_size must be greater than 0"):
             nn.FractionalMaxPool3d(
                 kernel_size=-1,
                 output_size=[1, 1, 1],

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -1013,7 +1013,7 @@ class FractionalMaxPool3d(Module):
     Args:
         kernel_size: the size of the window to take a max over.
                      Can be a single number `k` (for a square kernel of `k x k x k`) or a tuple `(kt x kh x kw)`,
-                     `k` must greater than 0.
+                     `k` must be greater than 0.
         output_size: the target output size of the image of the form `oT x oH x oW`.
                      Can be a tuple `(oT, oH, oW)` or a single number oH for a square image `oH x oH x oH`
         output_ratio: If one wants to have an output size as a ratio of the input size, this option can be given.
@@ -1058,7 +1058,9 @@ class FractionalMaxPool3d(Module):
             isinstance(kernel_size, (tuple, list))
             and not all(k > 0 for k in kernel_size)
         ):
-            raise ValueError(f"kernel_size must greater than 0, but got {kernel_size}")
+            raise ValueError(
+                f"kernel_size must be greater than 0, but got {kernel_size}"
+            )
         self.kernel_size = _triple(kernel_size)
         self.return_indices = return_indices
         self.register_buffer("_random_samples", _random_samples)


### PR DESCRIPTION
Summary:

**Context**: `FractionalMaxPool3d` validates that `kernel_size` is positive in its constructor.

**This diff**: The error message and docstring say "kernel_size must greater than 0" — missing the word "be". Fix to "kernel_size must be greater than 0".

Test Plan: Updated  to match the corrected error message string in `assertRaisesRegex` (3 occurrences). Existing test `test_FractionalMaxPool3d_errors` covers this code path.

Differential Revision: D103573740


