### PR TITLE
Replace AssertionError with ValueError for user input validation in Embedding

### DIFF
--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -231,7 +231,7 @@ class TestEmbeddingNN(NNTestCase):
             if (padding_idx < -num_embeddings) or (padding_idx >= num_embeddings):
                 with self.assertRaisesRegex(RuntimeError, functional_err_msg):
                     F.embedding_bag(a, embeddings, padding_idx=padding_idx)
-                with self.assertRaisesRegex(AssertionError, module_err_msg):
+                with self.assertRaisesRegex(ValueError, module_err_msg):
                     torch.nn.EmbeddingBag(
                         num_embeddings, num_features, padding_idx=padding_idx
                     )
@@ -487,14 +487,14 @@ class TestEmbeddingNNDeviceType(NNTestCase):
 
         # out of bounds check for padding_idx
         self.assertRaises(
-            AssertionError,
+            ValueError,
             nn.Embedding,
             num_embeddings=10,
             embedding_dim=20,
             padding_idx=25,
         )
         self.assertRaises(
-            AssertionError,
+            ValueError,
             nn.Embedding,
             num_embeddings=10,
             embedding_dim=20,

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2551,10 +2551,10 @@ def embedding(
     if padding_idx is not None:
         if padding_idx > 0:
             if padding_idx >= weight.size(0):
-                raise AssertionError("Padding_idx must be within num_embeddings")
+                raise ValueError("Padding_idx must be within num_embeddings")
         elif padding_idx < 0:
             if padding_idx < -weight.size(0):
-                raise AssertionError("Padding_idx must be within num_embeddings")
+                raise ValueError("Padding_idx must be within num_embeddings")
             padding_idx = weight.size(0) + padding_idx
     else:
         padding_idx = -1

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -152,10 +152,10 @@ class Embedding(Module):
         if padding_idx is not None:
             if padding_idx > 0:
                 if padding_idx >= self.num_embeddings:
-                    raise AssertionError("Padding_idx must be within num_embeddings")
+                    raise ValueError("Padding_idx must be within num_embeddings")
             elif padding_idx < 0:
                 if padding_idx < -self.num_embeddings:
-                    raise AssertionError("Padding_idx must be within num_embeddings")
+                    raise ValueError("Padding_idx must be within num_embeddings")
                 padding_idx = self.num_embeddings + padding_idx
         self.padding_idx = padding_idx
         self.max_norm = max_norm
@@ -169,7 +169,7 @@ class Embedding(Module):
             self.reset_parameters()
         else:
             if list(_weight.shape) != [num_embeddings, embedding_dim]:
-                raise AssertionError(
+                raise ValueError(
                     "Shape of weight does not match num_embeddings and embedding_dim"
                 )
             self.weight = Parameter(_weight, requires_grad=not _freeze)
@@ -248,7 +248,7 @@ class Embedding(Module):
             tensor([[ 4.0000,  5.1000,  6.3000]])
         """
         if embeddings.dim() != 2:
-            raise AssertionError("Embeddings parameter is expected to be 2-dimensional")
+            raise ValueError("Embeddings parameter is expected to be 2-dimensional")
         rows, cols = embeddings.shape
         embedding = cls(
             num_embeddings=rows,
@@ -392,10 +392,10 @@ class EmbeddingBag(Module):
         if padding_idx is not None:
             if padding_idx > 0:
                 if padding_idx >= self.num_embeddings:
-                    raise AssertionError("padding_idx must be within num_embeddings")
+                    raise ValueError("padding_idx must be within num_embeddings")
             elif padding_idx < 0:
                 if padding_idx < -self.num_embeddings:
-                    raise AssertionError("padding_idx must be within num_embeddings")
+                    raise ValueError("padding_idx must be within num_embeddings")
                 padding_idx = self.num_embeddings + padding_idx
         self.padding_idx = padding_idx
         if _weight is None:
@@ -405,7 +405,7 @@ class EmbeddingBag(Module):
             self.reset_parameters()
         else:
             if list(_weight.shape) != [num_embeddings, embedding_dim]:
-                raise AssertionError(
+                raise ValueError(
                     "Shape of weight does not match num_embeddings and embedding_dim"
                 )
             self.weight = Parameter(_weight)
@@ -525,7 +525,7 @@ class EmbeddingBag(Module):
             tensor([[ 2.5000,  3.7000,  4.6500]])
         """
         if embeddings.dim() != 2:
-            raise AssertionError("Embeddings parameter is expected to be 2-dimensional")
+            raise ValueError("Embeddings parameter is expected to be 2-dimensional")
         rows, cols = embeddings.shape
         embeddingbag = cls(
             num_embeddings=rows,


### PR DESCRIPTION
Summary:
**Context**: `nn.Embedding` and `nn.EmbeddingBag` validate user-provided parameters like `padding_idx`, weight shape, and embedding dimensions. The same validation also exists in `nn.functional.embedding`.

**This diff**: These validations use `raise AssertionError(...)` but assertions can be disabled with `python -O`, making the checks silently disappear. Since these validate user input (not internal invariants), they should use `ValueError` instead. This diff replaces all `AssertionError` with `ValueError` in `nn.modules.sparse` (Embedding, EmbeddingBag) and `nn.functional` (embedding function).

Test Plan: Updated `test/nn/test_embedding.py:234` to assert `ValueError` instead of `AssertionError` in `test_embedding_bag_padding_idx_error`. No other tests assert on the exception type for these validations.

Differential Revision: D103573742


