### PR TITLE
[SymmMem] Implement StoreExchange::broadcast for multicast handle exchange

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1052,7 +1052,8 @@ elseif(USE_CUDA)
     )
     # Add torch_cpu as a dependency to ensure ATen headers are available
     # torch::cudart provides CUDA include directories for .cpp files that include cuda_runtime.h
-    target_link_libraries(torch_nvshmem PRIVATE torch_cpu torch::cudart)
+    target_link_libraries(
+        torch_nvshmem PRIVATE torch_cpu torch::cudart fmt::fmt-header-only)
     set_target_properties(torch_nvshmem PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
     target_compile_options(torch_nvshmem PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-rdc=true>)
     target_compile_options(torch_nvshmem PRIVATE "-U__CUDA_NO_HALF_OPERATORS__")

--- a/test/cpp/c10d/CMakeLists.txt
+++ b/test/cpp/c10d/CMakeLists.txt
@@ -79,6 +79,10 @@ if(USE_CUDA)
       NCCLDevCommManagerTest.cpp
       LINK_LIBRARIES torch_cpu c10d_cuda_test gtest_main __caffe2_nccl INSTALL_TEST ${INSTALL_TEST})
     target_compile_definitions(NCCLDevCommManagerTest PRIVATE USE_CUDA USE_NCCL)
+    c10d_add_test(
+      StoreExchangeTest.cpp
+      LINK_LIBRARIES torch_cpu c10d_cuda_test gtest_main __caffe2_nccl INSTALL_TEST ${INSTALL_TEST})
+    target_compile_definitions(StoreExchangeTest PRIVATE USE_CUDA USE_NCCL)
     if(INSTALL_TEST)
       install(TARGETS c10d_cuda_test DESTINATION lib)
     endif()

--- a/test/cpp/c10d/StoreExchangeTest.cpp
+++ b/test/cpp/c10d/StoreExchangeTest.cpp
@@ -1,0 +1,143 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <array>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <c10/util/irange.h>
+#include <torch/csrc/distributed/c10d/HashStore.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp>
+
+using namespace c10d::symmetric_memory;
+
+namespace {
+
+struct BroadcastPayload {
+  int64_t value;
+  uint32_t tag;
+};
+
+void expect_payload_eq(
+    const BroadcastPayload& actual,
+    const BroadcastPayload& expected) {
+  EXPECT_EQ(actual.value, expected.value);
+  EXPECT_EQ(actual.tag, expected.tag);
+}
+
+std::vector<StoreExchange> make_store_exchanges(
+    int world_size,
+    const std::string& prefix) {
+  std::vector<StoreExchange> exchanges;
+  exchanges.reserve(world_size);
+  for (int rank = 0; rank < world_size; ++rank) {
+    exchanges.emplace_back(prefix);
+  }
+  return exchanges;
+}
+
+void test_broadcast_from_nonzero_source() {
+  constexpr auto world_size = 4;
+  constexpr auto src_rank = 2;
+  const BroadcastPayload src_payload{123456789, 17};
+  const BroadcastPayload peer_payload{-1, 99};
+
+  auto store = c10::make_intrusive<c10d::HashStore>();
+  auto exchanges =
+      make_store_exchanges(world_size, "StoreExchangeTest.NonzeroSource");
+
+  for (const auto rank : std::array<int, world_size>{src_rank, 0, 1, 3}) {
+    auto payload = exchanges[rank].broadcast(
+        store,
+        rank,
+        world_size,
+        src_rank,
+        rank == src_rank ? src_payload : peer_payload);
+    expect_payload_eq(payload, src_payload);
+  }
+}
+
+void test_broadcast_multiple_rounds() {
+  constexpr auto world_size = 3;
+  auto store = c10::make_intrusive<c10d::HashStore>();
+  auto exchanges =
+      make_store_exchanges(world_size, "StoreExchangeTest.MultipleRounds");
+
+  for (const auto round : std::array<int, 2>{0, 1}) {
+    const auto src_rank = round;
+    const BroadcastPayload src_payload{
+        round + 10, static_cast<uint32_t>(round)};
+    for (const auto rank :
+         std::array<int, world_size>{src_rank, 2, 1 - src_rank}) {
+      auto payload = exchanges[rank].broadcast(
+          store,
+          rank,
+          world_size,
+          src_rank,
+          rank == src_rank ? src_payload : BroadcastPayload{});
+      expect_payload_eq(payload, src_payload);
+    }
+  }
+}
+
+void test_broadcast_waits_for_source_rank() {
+  constexpr auto world_size = 4;
+  constexpr auto src_rank = 0;
+  const BroadcastPayload src_payload{987654321, 123};
+
+  auto store = c10::make_intrusive<c10d::HashStore>();
+  auto exchanges =
+      make_store_exchanges(world_size, "StoreExchangeTest.WaitsForSourceRank");
+
+  std::array<BroadcastPayload, world_size> outputs{};
+  std::atomic<int> waiting_peers{0};
+  std::vector<std::thread> threads;
+  for (int rank = 1; rank < world_size; ++rank) {
+    threads.emplace_back([&, rank] {
+      waiting_peers.fetch_add(1);
+      outputs[rank] = exchanges[rank].broadcast(
+          store, rank, world_size, src_rank, BroadcastPayload{});
+    });
+  }
+
+  while (waiting_peers.load() != world_size - 1) {
+    std::this_thread::yield();
+  }
+  outputs[src_rank] = exchanges[src_rank].broadcast(
+      store, src_rank, world_size, src_rank, src_payload);
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  for (const auto rank : c10::irange(world_size)) {
+    expect_payload_eq(outputs[rank], src_payload);
+  }
+}
+
+void test_broadcast_rejects_invalid_ranks() {
+  auto store = c10::make_intrusive<c10d::HashStore>();
+  StoreExchange exchange("StoreExchangeTest.InvalidRanks");
+
+  EXPECT_THROW(exchange.broadcast(store, -1, 2, 0, 0), c10::Error);
+  EXPECT_THROW(exchange.broadcast(store, 0, 2, 2, 0), c10::Error);
+}
+
+} // namespace
+
+TEST(StoreExchangeTest, BroadcastFromNonzeroSource) {
+  test_broadcast_from_nonzero_source();
+}
+
+TEST(StoreExchangeTest, BroadcastMultipleRounds) {
+  test_broadcast_multiple_rounds();
+}
+
+TEST(StoreExchangeTest, BroadcastWaitsForSourceRank) {
+  test_broadcast_waits_for_source_rank();
+}
+
+TEST(StoreExchangeTest, BroadcastRejectsInvalidRanks) {
+  test_broadcast_rejects_invalid_ranks();
+}

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -652,9 +652,8 @@ static void init_multicast_for_block(
   if constexpr (!use_fabric_handle) {
     recv_handle = ipc_channel.broadcast_fds(rank, 0, pids, mc_exported_handle);
   } else {
-    // TODO implement storeExchange.broadcast
-    auto gathered_handles = storeExchange.all_gather(store, rank, world_size, mc_exported_handle);
-    recv_handle = std::move(gathered_handles[0]);
+    recv_handle =
+        storeExchange.broadcast(store, rank, world_size, 0, mc_exported_handle);
   }
 
   // Check exchange result

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
@@ -5,7 +5,10 @@
 #include <torch/csrc/distributed/c10d/Store.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
+#include <cstdint>
 #include <cstring>
+#include <sstream>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -110,10 +113,7 @@ class StoreExchange {
     ++seq_id_;
 
     {
-      std::vector<uint8_t> payload(
-          reinterpret_cast<uint8_t*>(&val),
-          reinterpret_cast<uint8_t*>(&val) + sizeof(T));
-      store->set(peer_keys[rank], payload);
+      store->set(peer_keys[rank], to_payload(val));
     }
 
     auto payloads = store->multiGet(peer_keys);
@@ -121,12 +121,44 @@ class StoreExchange {
     std::vector<T> peer_vals;
     peer_vals.reserve(world_size);
     for (int r = 0; r < world_size; ++r) {
-      TORCH_CHECK(payloads[r].size() == sizeof(T));
-      T peer_val{};
-      std::memcpy(&peer_val, payloads[r].data(), sizeof(T));
-      peer_vals.push_back(peer_val);
+      peer_vals.push_back(from_payload<T>(payloads[r]));
     }
     return peer_vals;
+  }
+
+  template <typename T>
+  T broadcast(
+      const c10::intrusive_ptr<c10d::Store>& store,
+      int rank,
+      int world_size,
+      int src_rank,
+      T val) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    TORCH_CHECK(
+        rank >= 0 && rank < world_size,
+        "StoreExchange::broadcast: rank ",
+        rank,
+        " is out of range for world_size ",
+        world_size,
+        ".");
+    TORCH_CHECK(
+        src_rank >= 0 && src_rank < world_size,
+        "StoreExchange::broadcast: source rank ",
+        src_rank,
+        " is out of range for world_size ",
+        world_size,
+        ".");
+
+    std::ostringstream oss;
+    oss << store_prefix_ << '/' << seq_id_ << '/' << src_rank;
+    ++seq_id_;
+    auto key = oss.str();
+
+    if (rank == src_rank) {
+      store->set(key, to_payload(val));
+      return val;
+    }
+    return from_payload<T>(store->get(key));
   }
 
   void barrier(
@@ -141,6 +173,22 @@ class StoreExchange {
   }
 
  private:
+  template <typename T>
+  static std::vector<uint8_t> to_payload(const T& val) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    auto begin = reinterpret_cast<const uint8_t*>(&val);
+    return std::vector<uint8_t>(begin, begin + sizeof(T));
+  }
+
+  template <typename T>
+  static T from_payload(const std::vector<uint8_t>& payload) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    TORCH_CHECK(payload.size() == sizeof(T));
+    T val{};
+    std::memcpy(&val, payload.data(), sizeof(T));
+    return val;
+  }
+
   const std::string store_prefix_;
   size_t seq_id_ = 0;
 };

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <fmt/format.h>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <torch/csrc/distributed/c10d/Store.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
 #include <cstdint>
 #include <cstring>
-#include <sstream>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -106,9 +106,7 @@ class StoreExchange {
     std::vector<std::string> peer_keys;
     peer_keys.reserve(world_size);
     for (int r = 0; r < world_size; ++r) {
-      std::ostringstream oss;
-      oss << store_prefix_ << '/' << seq_id_ << '/' << r;
-      peer_keys.push_back(oss.str());
+      peer_keys.push_back(fmt::format("{}/{}/{}", store_prefix_, seq_id_, r));
     }
     ++seq_id_;
 
@@ -149,10 +147,7 @@ class StoreExchange {
         world_size,
         ".");
 
-    std::ostringstream oss;
-    oss << store_prefix_ << '/' << seq_id_ << '/' << src_rank;
-    ++seq_id_;
-    auto key = oss.str();
+    auto key = fmt::format("{}/{}/{}", store_prefix_, seq_id_++, src_rank);
 
     if (rank == src_rank) {
       store->set(key, to_payload(val));
@@ -166,10 +161,7 @@ class StoreExchange {
       int rank,
       int world_size) {
     (void)rank;
-    std::ostringstream oss;
-    oss << store_prefix_ << '/' << seq_id_;
-    ++seq_id_;
-    store->barrier(oss.str(), world_size);
+    store->barrier(fmt::format("{}/{}", store_prefix_, seq_id_++), world_size);
   }
 
  private:


### PR DESCRIPTION
Adds broadcast primitive to StoreExchange instead of all_gather for symmetric memory multicast handle exchange. All_gather was wasteful here because only the leader produces a real handle. Every other rank had to publish a meaningless value just to participate, and N-1 of the gathered values were discarded, so it was unnecessarily O(N²). Broadcast brings the complexity down to O(N). Fixes #169099.

cc @chauhang @penguinwu