### PR TITLE
Fix torch.empty(..., out=...) shape validation under torch.compile

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -8121,6 +8121,33 @@ SavedForBackwardsAOTOutput(idx=5)""",
         )
         self.assertEqual(result.dtype, torch.float32)
 
+    def test_empty_out_shape_mismatch_dynamic(self):
+        def f(size, out):
+            return torch.empty(size, out=out, dtype=torch.float32)
+
+        size = [2, 3]
+
+        # Mismatched out shape should be resized to match requested size
+        out_wrong = torch.empty([1])
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            eager_result = f(size, out_wrong.clone())
+
+        cf = torch.compile(f, dynamic=True)
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            compiled_result = cf(size, out_wrong.clone())
+
+        self.assertEqual(compiled_result.shape, eager_result.shape)
+
+        # Compatible out should pass through unchanged
+        compiled_ok = cf(size, torch.empty([2, 3]))
+        self.assertEqual(compiled_ok.shape, torch.Size([2, 3]))
+
+        # Zero-element out should be resized
+        compiled_zero = cf(size, torch.empty([0]))
+        self.assertEqual(compiled_zero.shape, torch.Size([2, 3]))
+
 
 class ReproTestsDevice(torch._dynamo.test_case.TestCase):
     def test_sub_alpha_scalar_repro(self, device):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5266,10 +5266,11 @@ def new_full(
 
 @aten.empty.out.py_impl(DispatchKey.CompositeImplicitAutograd)
 def empty_out(
-    size: TensorLikeType,
+    size: ShapeType,
     out: TensorLikeType,
     memory_format: torch.memory_format | None = None,
 ) -> TensorLikeType:
+    _maybe_resize_out(out, size, memory_format)
     return out
 
 


### PR DESCRIPTION
Summary:
**Context**

The `aten.empty.out` CompositeImplicitAutograd decomposition in `torch/_refs/__init__.py` returns the `out` tensor unconditionally without validating that its shape matches the requested size. This causes `torch.compile(dynamic=True)` to silently accept an incompatible `out` tensor and return it unchanged, diverging from eager behavior which correctly validates and resizes via `resize_output`.

**This diff**

Adds a `_maybe_resize_out(out, size, memory_format)` call in `empty_out()` before returning, matching what every other `out=` variant does via the `out_wrapper` decorator. The `memory_format` parameter is forwarded so that `resize_()` respects the requested layout. Also fixes the `size` parameter type annotation from `TensorLikeType` to `ShapeType` to match other `out` decompositions.

Test Plan:
Added `test_empty_out_shape_mismatch_dynamic` in `test/dynamo/test_repros.py` covering:
- Mismatched shapes ([1] vs [2,3]) -- verifies compiled output matches eager
- Compatible shapes ([2,3] matches) -- no-op path
- Zero-element out ([0]) -- resize without warning

```
$ buck test fbcode//caffe2/test/dynamo:test_dynamo @//mode/opt -- "test_empty_out_shape_mismatch_dynamic"
Tests finished: Pass 2. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
```

Reviewed By: Lucaskabela

Differential Revision: D103629732




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98