### PR TITLE
Fix non-deterministic backward pass for F.linear on MPS with >2D fp16/bf16 inputs (#182350)

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -244,7 +244,9 @@ static Tensor _mps_linear_backward_input(IntArrayRef input_size, const Tensor& g
 
       // MPS matrixMultiplication crashes for 5D+ tensors on 14.2.1 with `New volume should match old volume`
       // See https://github.com/pytorch/pytorch/issues/114942 for more details
-      bool needReshape = grad_output.dim() > 4;
+      // Non-deterministic results for >2D fp16/bf16 on Apple10+
+      // See https://github.com/pytorch/pytorch/issues/180776
+      bool needReshape = grad_output.dim() > 4 || needs_nd_workaround(grad_output);
       auto gradOutputTensor = needReshape
           ? [mpsGraph flatten2DTensor:newCachedGraph->gradOutputTensor_ axis:-1 name:nil]
           : newCachedGraph->gradOutputTensor_;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1549,6 +1549,27 @@ class TestMPS(TestCaseMPS):
         second = F.linear(x, w).clone()
         self.assertEqual(first, second, atol=0, rtol=0)
 
+    @parametrize("dtype", [torch.float16, torch.bfloat16])
+    @parametrize("shape", [(2, 13, 1024), (6, 6, 634), (1, 3, 28, 315),
+                           (1, 12, 4, 512), (1, 1, 5, 6, 1024)])
+    def test_linear_nd_backward_determinism(self, dtype, shape):
+        # Regression test for backward pass of
+        # https://github.com/pytorch/pytorch/issues/180776
+        h = shape[-1]
+        x = torch.randn(shape, dtype=dtype, device="mps")
+        w = torch.randn(h, h, dtype=dtype, device="mps")
+        grad = torch.randn(shape, dtype=dtype, device="mps")
+
+        def backward_test():
+            x0 = x.clone().requires_grad_()
+            y = F.linear(x0, w)
+            y.backward(grad)
+            return x0.grad.clone()
+
+        first = backward_test()
+        second = backward_test()
+        self.assertEqual(first, second, atol=0, rtol=0)
+
     def test_uniform(self):
         low = torch.zeros(5, 5, requires_grad=True)
         high = (torch.ones(5, 5) * 3).requires_grad_()


### PR DESCRIPTION
Summary:

**Context**: PR #181466 fixed non-deterministic forward results for `F.linear` on Apple M5+ GPUs (Apple10 GPU family) with >2D fp16/bf16 inputs by flattening to 2D before matrix multiplication. The same `MPSGraph matrixMultiplication` non-determinism affects the backward pass (`_mps_linear_backward_input`), which computes `grad_output @ weight` to produce `x.grad`.

**This diff**: Applies the same `needs_nd_workaround()` flatten-to-2D fix to `_mps_linear_backward_input`. The forward path already checks `needs_nd_workaround(input)` and reshapes when needed; the backward path only checked `grad_output.dim() > 4` (for the 5D crash workaround) but missed the M5 determinism workaround. Now it also calls `needs_nd_workaround(grad_output)`.

Adds `test_linear_nd_backward_determinism` to verify the backward pass produces identical gradients across consecutive calls, mirroring the existing `test_linear_nd_determinism` forward test.

Fixes https://github.com/pytorch/pytorch/issues/181936

Test Plan: New test `test_linear_nd_backward_determinism` in `test/test_mps.py` covers multiple shapes and both fp16/bf16 dtypes, verifying that `x.grad` is bitwise identical across two backward passes.

Differential Revision: D103576464


