### PR TITLE
Fix stale PYTORCH_RELEASES_CODE_CC dict (fixes #182250)

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -319,11 +319,13 @@ DEVICE_REQUIREMENT: dict[int, _CompatSet | _CompatInterval] = {
 }
 
 
-# TORCH_CUDA_ARCH_LIST for PyTorch releases
+# TORCH_CUDA_ARCH_LIST for PyTorch releases (union of x86_64 and aarch64
+# build matrices). Keep in sync with .ci/manywheel/build_cuda.sh and
+# .github/scripts/generate_binary_build_matrix.py:CUDA_ARCHES.
 PYTORCH_RELEASES_CODE_CC: dict[str, set[int]] = {
-    "12.6": {50, 60, 70, 80, 86, 90},
-    "12.8": {70, 80, 86, 90, 100, 120},
+    "12.6": {50, 60, 70, 75, 80, 86, 90},
     "13.0": {75, 80, 86, 90, 100, 110, 120},
+    "13.2": {75, 80, 86, 90, 100, 110, 120},
 }
 
 


### PR DESCRIPTION
## Summary

The release-to-CC dict in \`torch/cuda/__init__.py\` drove the *\"install a PyTorch release that supports one of these CUDA versions: ...\"* recommendation, but had drifted from the actual binary build matrix:

- **\"12.6\"** was missing CC \`7.5\` — `.ci/manywheel/build_cuda.sh` puts 7.5 in the base list for every release.
- **\"12.8\"** was deprecated in #179072 (replaced by 13.0). Recommending it is misleading and was the proximate cause of #182250.
- **\"13.2\"** was missing entirely even though it's in `CUDA_ARCHES` today.

That stale data caused the V100 false-positive in #182250 — `cu128` was recommended for a CC 7.0 device, but the actual `cu128` wheel had been built without `sm_70` (arch list \`7.5;8.0;8.6;9.0;10.0;12.0\`).

This PR updates the dict to match the union of x86_64 and aarch64 `TORCH_CUDA_ARCH_LIST` in `.ci/manywheel/build_cuda.sh` (the build-time source of truth), and adds a comment pointing readers there so the next \`CUDA_ARCHES\` change knows what else to bump.

Authored with Claude.