### PR TITLE
Fix `PYTORCH_RELEASES_CODE_CC`

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -13,9 +13,11 @@ architectures:
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import re
+import subprocess
 from pathlib import Path
 
 
@@ -232,6 +234,72 @@ def validate_cudnn_version_consistency(arch_version: str) -> None:
             f"cuDNN version mismatch for CUDA {arch_version}: "
             f"Linux has {linux_ver} (.ci/docker/common/install_cuda.sh) "
             f"but Windows has {windows_ver} (.ci/pytorch/windows/internal/cuda_install.bat)"
+        )
+
+
+_BUILD_CUDA_SH = REPO_ROOT / ".ci" / "manywheel" / "build_cuda.sh"
+_RUNTIME_CUDA_INIT = REPO_ROOT / "torch" / "cuda" / "__init__.py"
+
+
+def _extract_arch_list_block() -> str:
+    """Extract the self-contained arch-list logic from build_cuda.sh."""
+    text = _BUILD_CUDA_SH.read_text()
+    start_marker = "# Function to remove architectures from a list"
+    end_marker = 'export TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}'
+    start = text.index(start_marker)
+    end = text.index(end_marker)
+    return text[start:end]
+
+
+def _build_arch_list(cuda_version: str, arch: str) -> set[int]:
+    """Run the build_cuda.sh arch-list logic for (cuda_version, arch)."""
+    block = _extract_arch_list_block()
+    cmd = (
+        f'CUDA_VERSION="{cuda_version}" ARCH="{arch}"\n'
+        f"{{\n{block}\n}} >/dev/null\n"
+        'printf "%s" "$TORCH_CUDA_ARCH_LIST"\n'
+    )
+    out = subprocess.run(
+        ["bash", "-c", cmd], check=True, capture_output=True, text=True
+    ).stdout
+    result: set[int] = set()
+    for part in out.split(";"):
+        part = part.strip().removesuffix("+PTX")
+        if not part:
+            continue
+        major, minor = part.split(".")
+        result.add(int(major) * 10 + int(minor))
+    return result
+
+
+def _read_runtime_release_table() -> dict[str, dict[str, set[int]]]:
+    """Parse PYTORCH_RELEASES_CODE_CC out of torch/cuda/__init__.py."""
+    tree = ast.parse(_RUNTIME_CUDA_INIT.read_text())
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "PYTORCH_RELEASES_CODE_CC"
+            and node.value is not None
+        ):
+            return ast.literal_eval(node.value)
+    raise RuntimeError(
+        "PYTORCH_RELEASES_CODE_CC not found in torch/cuda/__init__.py"
+    )
+
+
+def validate_runtime_release_table_consistency() -> None:
+    """Ensure torch/cuda/__init__.py recommendation table matches the build matrix."""
+    expected = {
+        cuda: {arch: _build_arch_list(cuda, arch) for arch in ("x86_64", "aarch64")}
+        for cuda in CUDA_ARCHES
+    }
+    actual = _read_runtime_release_table()
+    if actual != expected:
+        raise RuntimeError(
+            "PYTORCH_RELEASES_CODE_CC in torch/cuda/__init__.py is out of sync "
+            "with .ci/manywheel/build_cuda.sh.\n"
+            f"Expected: {expected}\nActual:   {actual}"
         )
 
 
@@ -505,6 +573,7 @@ for arch_version in CUDA_ARCHES:
     validate_nccl_dep_consistency(arch_version)
     validate_cudnn_version_consistency(arch_version)
 del arch_version
+validate_runtime_release_table_consistency()
 
 
 if __name__ == "__main__":

--- a/test/test_cuda_compatibility.py
+++ b/test/test_cuda_compatibility.py
@@ -153,10 +153,9 @@ class TestCheckCapability(TestCase):
             torch.cuda._check_capability()
             self.assertEqual(len(w), 1)
             msg = str(w[0].message)
-            self.assertNotIn(
-                "install a PyTorch release that supports one of these CUDA versions",
-                msg,
-            )
+            self.assertNotIn("pip install torch==", msg)
+            self.assertIn("No published PyTorch CUDA builds for release", msg)
+            self.assertIn("https://pytorch.org/get-started/locally/", msg)
 
 
 if __name__ == "__main__":

--- a/test/test_cuda_compatibility.py
+++ b/test/test_cuda_compatibility.py
@@ -126,9 +126,14 @@ class TestCheckCapability(TestCase):
 
     @patch("torch.cuda.get_arch_list", return_value=["sm_60"])
     @patch("torch.cuda.get_device_capability", return_value=(7, 0))
+    @patch("torch.cuda._host_arch_key", return_value="x86_64")
     @patch(
         "torch.cuda.PYTORCH_RELEASES_CODE_CC",
-        {"12.6": {50, 60, 70}, "12.8": {70}, "13.0": {75}},
+        {
+            "12.6": {"x86_64": {50, 60, 70}, "aarch64": {50, 60, 70}},
+            "12.8": {"x86_64": {70}, "aarch64": {70}},
+            "13.0": {"x86_64": {75}, "aarch64": {75}},
+        },
     )
     def test_warning_suggests_compatible_pytorch_release(self, *args):
         with warnings.catch_warnings(record=True) as w:

--- a/test/test_cuda_compatibility.py
+++ b/test/test_cuda_compatibility.py
@@ -132,7 +132,7 @@ class TestCheckCapability(TestCase):
         {
             "12.6": {"x86_64": {50, 60, 70}, "aarch64": {50, 60, 70}},
             "12.8": {"x86_64": {70}, "aarch64": {70}},
-            "13.0": {"x86_64": {75}, "aarch64": {75}},
+            "13.2": {"x86_64": {75}, "aarch64": {75}},
         },
     )
     def test_warning_suggests_compatible_pytorch_release(self, *args):
@@ -143,7 +143,7 @@ class TestCheckCapability(TestCase):
             msg = str(w[0].message)
             self.assertIn("12.6", msg)
             self.assertIn("12.8", msg)
-            self.assertNotIn("13.0", msg)
+            self.assertNotIn("13.2", msg)
 
     @patch("torch.cuda.get_arch_list", return_value=["sm_80"])
     @patch("torch.cuda.get_device_capability", return_value=(5, 3))

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -374,11 +374,23 @@ def _warn_unsupported_code(device_index: int, device_cc: int, code_ccs: list[int
     ]
 
     if len(compatible_releases) > 0:
-        releases_str = ", ".join(compatible_releases)
-        lines.append(
-            "Please follow the instructions at https://pytorch.org/get-started/locally/ to "
-            + f"install a PyTorch release that supports one of these CUDA versions: {releases_str}"
+        version = torch.__version__
+        base_version = version.split("+")[0]
+        is_nightly = "dev" in base_version
+        index_root = (
+            "https://download.pytorch.org/whl/nightly"
+            if is_nightly
+            else "https://download.pytorch.org/whl"
         )
+        lines.append(
+            f"Your installed torch=={version} does not include kernels for this GPU. "
+            "Reinstall the same version against a CUDA build that does, e.g.:"
+        )
+        for cuda in compatible_releases:
+            cu_tag = "cu" + cuda.replace(".", "")
+            lines.append(
+                f"  pip install torch=={base_version} --index-url {index_root}/{cu_tag}"
+            )
 
     warnings.warn("\n".join(lines), stacklevel=2)
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -13,6 +13,7 @@ It is lazily initialized, so you can always import it, and use
 
 import importlib
 import os
+import platform
 import threading
 import traceback
 import warnings
@@ -319,12 +320,28 @@ DEVICE_REQUIREMENT: dict[int, _CompatSet | _CompatInterval] = {
 }
 
 
-# TORCH_CUDA_ARCH_LIST for PyTorch releases
-PYTORCH_RELEASES_CODE_CC: dict[str, set[int]] = {
-    "12.6": {50, 60, 70, 80, 86, 90},
-    "12.8": {70, 80, 86, 90, 100, 120},
-    "13.0": {75, 80, 86, 90, 100, 110, 120},
+# TORCH_CUDA_ARCH_LIST for PyTorch releases, keyed by host arch.
+# Kept in sync with .ci/manywheel/build_cuda.sh by the validator in
+# .github/scripts/generate_binary_build_matrix.py.
+PYTORCH_RELEASES_CODE_CC: dict[str, dict[str, set[int]]] = {
+    "12.6": {
+        "x86_64": {50, 60, 70, 75, 80, 86, 90},
+        "aarch64": {80, 90},
+    },
+    "13.0": {
+        "x86_64": {75, 80, 86, 90, 100, 120},
+        "aarch64": {80, 90, 100, 110, 120},
+    },
+    "13.2": {
+        "x86_64": {75, 80, 86, 90, 100, 120},
+        "aarch64": {80, 90, 100, 110, 120},
+    },
 }
+
+
+def _host_arch_key() -> str:
+    machine = platform.machine().lower()
+    return "aarch64" if machine in ("aarch64", "arm64") else "x86_64"
 
 
 def _code_compatible_with_device(device_cc: int, code_cc: int):
@@ -341,8 +358,10 @@ def _code_compatible_with_device(device_cc: int, code_cc: int):
 def _warn_unsupported_code(device_index: int, device_cc: int, code_ccs: list[int]):
     name = get_device_name(device_index)
 
+    arch = _host_arch_key()
     compatible_releases: list[str] = []
-    for cuda, build_ccs in PYTORCH_RELEASES_CODE_CC.items():
+    for cuda, by_arch in PYTORCH_RELEASES_CODE_CC.items():
+        build_ccs = by_arch.get(arch, set())
         if any(_code_compatible_with_device(device_cc, cc) for cc in build_ccs):
             compatible_releases.append(cuda)
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -389,8 +389,13 @@ def _warn_unsupported_code(device_index: int, device_cc: int, code_ccs: list[int
         for cuda in compatible_releases:
             cu_tag = "cu" + cuda.replace(".", "")
             lines.append(
-                f"  pip install torch=={base_version} --index-url {index_root}/{cu_tag}"
+                f"  For CUDA {cuda} use pip install torch=={base_version} --index-url {index_root}/{cu_tag}"
             )
+    else:
+        lines.append(
+            f"No published PyTorch CUDA builds for release {torch.__version__} support this GPU. "
+            "Visit https://pytorch.org/get-started/locally/ to find a compatible release."
+        )
 
     warnings.warn("\n".join(lines), stacklevel=2)
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -323,6 +323,7 @@ DEVICE_REQUIREMENT: dict[int, _CompatSet | _CompatInterval] = {
 # TORCH_CUDA_ARCH_LIST for PyTorch releases, keyed by host arch.
 # Kept in sync with .ci/manywheel/build_cuda.sh by the validator in
 # .github/scripts/generate_binary_build_matrix.py.
+PYTORCH_RELEASES_CODE_CC: dict[str, dict[str, set[int]]] = {
     "12.6": {
         "x86_64": {50, 60, 70, 75, 80, 86, 90},
         "aarch64": {80, 90},
@@ -335,13 +336,12 @@ DEVICE_REQUIREMENT: dict[int, _CompatSet | _CompatInterval] = {
         "x86_64": {75, 80, 86, 90, 100, 120},
         "aarch64": {80, 90, 100, 110, 120},
     },
->>>>>>> a3143e10c67 (Fix `PYTORCH_RELEASES_CODE_CC`)
 }
 
 
 def _host_arch_key() -> str:
     machine = platform.machine().lower()
-    return "aarch64" if machine in ("aarch64", "arm64") else "x86_64"
+    return "aarch64" if machine == "aarch64" else "x86_64"
 
 
 def _code_compatible_with_device(device_cc: int, code_cc: int):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #182360

----

-  Make the release map arch-specific (x86_64 / aarch64) so `_warn_unsupported_code` only suggests CUDA builds that actually exist for the host.
- Tweak the warning to emit concrete `pip install` commands for specific release, or directs users to https://pytorch.org/get-started/locally/ when none apply.
- `generate_binary_build_matrix` validates the PYTORCH_RELEASE_CODE_CC against the real build matrix for current release