### PR TITLE
[ROCm] Enable test_tanh_approx in TestCustomLowering by adding ROCm-compatible lowering

### DIFF
--- a/test/inductor/test_custom_lowering.py
+++ b/test/inductor/test_custom_lowering.py
@@ -9,7 +9,7 @@ from torch._inductor.ir import Pointwise
 from torch._inductor.lowering import make_fallback, make_pointwise, register_lowering
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.virtualized import ops
-from torch.testing._internal.common_utils import skipIfRocm, skipIfXpu
+from torch.testing._internal.common_utils import skipIfXpu
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CPU,
@@ -119,8 +119,12 @@ class TestCustomLowering(InductorTestCase):
         cls.impl_meta.impl("tanh_approx", tanh_approx_meta)
 
         def tanh_approx_lowering(inp):
-            fn = partial(ops.inline_asm_elementwise, asm="tanh.approx.f32 $0, $1;")
-            return make_pointwise(fn)(inp)
+            if torch.version.hip:
+                # AMD doesn't have a hardware tanh instruction, use portable tanh instead
+                return make_pointwise(ops.tanh)(inp)
+            else:
+                fn = partial(ops.inline_asm_elementwise, asm="tanh.approx.f32 $0, $1;")
+                return make_pointwise(fn)(inp)
 
         register_lowering(
             torch.ops.test_inductor_ops.tanh_approx, type_promotion_kind=None
@@ -218,7 +222,6 @@ class TestCustomLowering(InductorTestCase):
         )
 
     @requires_gpu()
-    @skipIfRocm
     @skipIfXpu(msg="`tl.inline_asm_elementwise` is not yet supported on Intel GPUs")
     @skipIf(GPU_TYPE == "mps", "Not applicable to MPS")
     def test_tanh_approx(self):


### PR DESCRIPTION
FIXES https://github.com/pytorch/pytorch/issues/168583
FIXES https://github.com/pytorch/pytorch/issues/168584

### Investigative summary

### Problem statement
`test_tanh_approx` was skipped on ROCm via `@skipIfRocm`. The test tests Inductor's custom lowering infrastructure using `ops.inline_asm_elementwise` with the PTX instruction `tanh.approx.f32`, which is NVIDIA-specific and not valid on AMD GPUs.

### Proposed solution & changes made
Following the same pattern used for `add_custom_lowering` (in https://github.com/pytorch/pytorch/pull/172941), the `tanh_approx_lowering` function now branches based on `torch.version.hip`:

- **ROCm path**: Uses `ops.tanh` via `make_pointwise`, since AMD GPUs do not have a single-instruction hardware tanh approximation equivalent to NVIDIA's `tanh.approx.f32` PTX instruction.
- **CUDA path**: Unchanged — continues to use `ops.inline_asm_elementwise` with `tanh.approx.f32`.

The `@skipIfRocm` decorator is removed from `test_tanh_approx`.

### Command to reproduce
`$ PYTORCH_TEST_WITH_ROCM=1 python test/inductor/test_custom_lowering.py TestCustomLowering.test_tanh_approx`

**BEFORE fix**
```
Ran 1 test in 0.003s

OK (skipped=1)
```

**AFTER fix**
```
Ran 1 test in 1.284s

OK
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben