### PR TITLE
[PyTorch][AOTI] Add timing instrumentation to AOTI model loading pipeline

### DIFF
--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -266,7 +266,10 @@ int munmap(void* addr, size_t length) {
 #include <unistd.h>
 #endif // _WIN32
 
+#include <chrono>
+#include <cstdlib>
 #include <fcntl.h>
+#include <iostream>
 #include <optional>
 #include <regex>
 #include <stdexcept>
@@ -288,6 +291,14 @@ int munmap(void* addr, size_t length) {
 #endif // USE_XPU
 #include <torch/csrc/inductor/aoti_runtime/constant_type.h>
 
+#define AOTI_LOG_LOADING(msg)                                              \
+  do {                                                                     \
+    static const bool _aoti_log_ =                                         \
+        std::getenv("AOTI_LOG_LOADING") != nullptr;                        \
+    if (_aoti_log_) {                                                      \
+      std::cerr << "[AOTI_LOAD] " << msg << std::endl;                     \
+    }                                                                      \
+  } while (0)
 // At codegen time, we write out a binary file called constants.bin.
 // We then turn the raw binary to an object file that exposes this
 // symbol and link it into the final .so.
@@ -583,6 +594,7 @@ class AOTInductorModelBase {
   }
 
   void load_constants(bool force = false) {
+    auto _lc_start = std::chrono::steady_clock::now();
     size_t num_constants = this->num_constants();
     size_t num_folded_constants = this->num_folded_constants();
     constants_map_->reserve(num_constants);
@@ -600,6 +612,11 @@ class AOTInductorModelBase {
         constants_internal_offset,
         aux_cpu_blob_size,
         aux_cpu_constants_internal_offset);
+    AOTI_LOG_LOADING(
+        "load_constants: num_constants="
+        << (num_constants - num_folded_constants)
+        << " blob_size=" << blob_size
+        << " secondary_cpu_blob_size=" << secondary_cpu_blob_size);
 
     if (!force && !include_weights) {
       return;
@@ -607,11 +624,18 @@ class AOTInductorModelBase {
 
     // Allocate main blob
     if (blob_size > 0) {
+      auto _malloc_start = std::chrono::steady_clock::now();
 #if defined(USE_CUDA) || defined(USE_XPU) || defined(USE_MPS)
       constant_blob_ = RAII_gpuMalloc(blob_size);
 #else
       constant_blob_ = RAII_cpuMalloc(blob_size);
 #endif
+      auto _malloc_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::steady_clock::now() - _malloc_start)
+                            .count();
+      AOTI_LOG_LOADING(
+          "load_constants: malloc " << blob_size << " bytes took " << _malloc_ms
+                                    << " ms");
     }
 
     // Allocate secondary blob on CPU
@@ -622,6 +646,7 @@ class AOTInductorModelBase {
     size_t bytes_read = 0;
     size_t main_blob_idx = 0;
     size_t aux_cpu_blob_idx = 0;
+    auto _copy_start = std::chrono::steady_clock::now();
 
     for (size_t i = 0; i < num_constants; i++) {
       bool from_folded = this->constant_from_folded(i);
@@ -705,9 +730,47 @@ class AOTInductorModelBase {
           opaque_metadata_size));
       constants_map_->emplace(std::move(name), tensor_handle);
     }
+    auto _copy_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - _copy_start)
+                        .count();
+    AOTI_LOG_LOADING(
+        "load_constants: H2D copy + tensor creation took " << _copy_ms
+                                          << " ms, " << bytes_read
+                                          << " bytes across "
+                                          << (num_constants - num_folded_constants)
+                                          << " constants");
     if (constants_map_) {
       this->update_constants_array_from_map();
     }
+
+#if !defined(_WIN32) && (defined(USE_CUDA) || defined(USE_XPU))
+    // After copying constants to GPU, advise the kernel to drop the
+    // file-backed pages from page cache. The constants binary is embedded
+    // in the .so via objcopy and gets mmap'd by dlopen. Without this,
+    // the page cache retains the entire constants blob (can be 100+ GB)
+    // even though the data now lives in GPU HBM.
+    {
+      auto* start = _binary_constants_bin_start;
+      auto* end = _binary_constants_bin_end;
+      size_t len = end - start;
+      if (len > 0) {
+        auto page_size = sysconf(_SC_PAGESIZE);
+        auto* aligned =
+            reinterpret_cast<uint8_t*>(
+                reinterpret_cast<uintptr_t>(start) & ~(page_size - 1));
+        size_t aligned_len = (end - aligned + page_size - 1) & ~(page_size - 1);
+        int ret = madvise(aligned, aligned_len, MADV_DONTNEED);
+        AOTI_LOG_LOADING(
+            "load_constants: madvise(MADV_DONTNEED) on constants blob "
+            << aligned_len / (1024 * 1024) << " MB, ret=" << ret);
+      }
+    }
+#endif
+
+    auto _lc_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::steady_clock::now() - _lc_start)
+                      .count();
+    AOTI_LOG_LOADING("load_constants: total time " << _lc_ms << " ms");
   }
 
   RAIIDataPtr&& release_constant_blob() {

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -46,12 +46,21 @@ class AOTInductorModelContainer {
     constants_map_ = std::make_shared<ConstantMap>();
     constants_array_ = std::make_shared<std::vector<ConstantHandle>>();
 
+    auto _ctor_start = std::chrono::steady_clock::now();
+    AOTI_LOG_LOADING(
+        "ModelContainer: creating " << num_models << " model instances");
     models_.reserve(num_models);
     available_models_.reserve(num_models);
     for (size_t i = 0; i < num_models; ++i) {
+      auto _mi_start = std::chrono::steady_clock::now();
       models_.push_back(AOTInductorModel::Create(
           constants_map_, constants_array_, device_str, cubin_dir));
       available_models_.push_back(models_.back().get());
+      auto _mi_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - _mi_start)
+                        .count();
+      AOTI_LOG_LOADING(
+          "ModelContainer: instance " << i << " created in " << _mi_ms << " ms");
     }
 
     // Note that the all following fields (input_names_, output_names,
@@ -62,6 +71,14 @@ class AOTInductorModelContainer {
     //   * reduce information fragmentation and duplication
     //   * the initialization process below is done only once when the container
     //     is constructed, so it would have little performance impact
+    {
+      auto _dt = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     std::chrono::steady_clock::now() - _ctor_start)
+                     .count();
+      AOTI_LOG_LOADING(
+          "ModelContainer: " << num_models << " instances created in " << _dt
+                             << " ms");
+    }
     auto* model = available_models_[0];
     size_t num_inputs = model->num_inputs();
     input_names_.reserve(num_inputs);
@@ -74,7 +91,15 @@ class AOTInductorModelContainer {
     for (size_t i = 0; i < num_outputs; i++) {
       output_names_.emplace_back(model->output_name(static_cast<int64_t>(i)));
     }
+    AOTI_LOG_LOADING("ModelContainer: starting load_constants");
+    auto _lc_start = std::chrono::steady_clock::now();
     model->load_constants();
+    {
+      auto _dt = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     std::chrono::steady_clock::now() - _lc_start)
+                     .count();
+      AOTI_LOG_LOADING("ModelContainer: load_constants completed in " << _dt << " ms");
+    }
     constant_blob_ = model->release_constant_blob();
     aux_cpu_constant_blob_ = model->release_aux_cpu_constant_blob();
     constants_internal_offset_.resize(
@@ -86,6 +111,10 @@ class AOTInductorModelContainer {
         constants_internal_offset_,
         aux_cpu_blob_size_,
         aux_cpu_constants_internal_offset_);
+    AOTI_LOG_LOADING(
+        "ModelContainer: blob_size=" << blob_size_
+                                     << " secondary_cpu_blob_size="
+                                     << secondary_cpu_blob_size_);
     constant_folded_ = ConstantState::INITIALIZED;
 
     for (auto& model : models_) {
@@ -94,6 +123,12 @@ class AOTInductorModelContainer {
 
     in_spec_ = model->get_in_spec();
     out_spec_ = model->get_out_spec();
+    {
+      auto _dt = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     std::chrono::steady_clock::now() - _ctor_start)
+                     .count();
+      AOTI_LOG_LOADING("ModelContainer: constructor completed in " << _dt << " ms");
+    }
   }
 
   void run(
@@ -112,13 +147,13 @@ class AOTInductorModelContainer {
     ConstantState& const_folded =
         use_secondary_ ? constant_folded_secondary_ : constant_folded_;
     if (const_folded == ConstantState::INITIALIZED) {
-      // At this point, constant is not ready yet. We need to call constant
-      // folding before we execute the model. We obtain a unique lock at this
-      // point to make sure constant is ready for all.
+      // Constant not ready yet. Obtain unique lock for constant folding.
+      AOTI_LOG_LOADING("ModelContainer::run: constant folding needed");
       model_lk.unlock();
       std::unique_lock constants_folding_lk(model_exec_mutex_);
-      // Double locking to make sure constant folding is only ran once.
+      // Double-checked locking: only run constant folding once.
       if (const_folded == ConstantState::INITIALIZED) {
+        auto _cf_start = std::chrono::steady_clock::now();
         auto folded_const_map = model->run_const_fold(
             stream, proxy_executor, /* initialization = */ true);
         update_constant_buffer(
@@ -126,6 +161,12 @@ class AOTInductorModelContainer {
             /* use_inactive = */ false,
             /* validate_full_update = */ false);
         const_folded = ConstantState::FOLDED;
+        auto _cf_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - _cf_start)
+                          .count();
+        AOTI_LOG_LOADING(
+            "ModelContainer::run: constant folding completed in " << _cf_ms
+                                                                  << " ms");
       }
       constants_folding_lk.unlock();
       model_lk.lock();


### PR DESCRIPTION
Summary:
After the AOTI model .so is loaded and extern kernel nodes JSON is parsed, there is a ~30 second gap with zero logging before the model is ready. This makes it impossible to diagnose whether the time is spent in GPU memory allocation (cudaMalloc), host-to-device weight transfer (cudaMemcpy), model instance creation, or constant folding.

Adds 16 timing-based log points across 4 files in the AOTI loading pipeline:
- model_base.h: Instruments load_constants() with constant count/blob size, malloc time, H2D copy summary, and total time. Uses AOTI_LOG_LOADING macro gated by AOTI_LOG_LOADING env var.
- model_container.h: Instruments the AOTInductorModelContainer constructor (model creation, load_constants, blob sizes, total time) and the run() method (constant folding timing).
- AOTInductorModelImpl.cpp: Instruments dlopen, FbProxyExecutor creation, container creation, and constructor total time via LOG(INFO).
- FbProxyExecutor.cpp: Instruments extern kernel node count and resolution time via LOG(INFO).

OSS-side logging (model_base.h, model_container.h) is gated behind `export AOTI_LOG_LOADING=1` to avoid noise in production. Internal logging (AOTInductorModelImpl.cpp, FbProxyExecutor.cpp) uses LOG(INFO), always on.

Test Plan: CI / CD

Differential Revision: D103286525


