### PR TITLE
[DTensor] Make DTensor OpStrategy stringification handle missing mesh

### DIFF
--- a/test/distributed/tensor/test_op_strategy.py
+++ b/test/distributed/tensor/test_op_strategy.py
@@ -1161,6 +1161,12 @@ class TestOpSpecMesh(TestCase):
         with self.assertRaisesRegex(AssertionError, "Cannot determine mesh"):
             _ = op_spec.mesh
 
+    def test_op_strategy_str_handles_all_specs_none(self):
+        """Regression test for https://github.com/pytorch/pytorch/issues/182370."""
+        op_strategy = OpStrategy([OpSpec(output_specs=None, input_specs=(None,))])
+
+        self.assertEqual(str(op_strategy), "OpStrategy[(None) -> None]")
+
 
 class TestExpandToFullMeshOpStrategy(TestCase):
     """Tests for expand_to_full_mesh_op_strategy function.

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -235,7 +235,10 @@ class OpStrategy(StrategyType):
 
     def __str__(self) -> str:
         strategy_list_str = ", ".join([str(strategy) for strategy in self.strategies])
-        mesh_shape = self.mesh_shape
+        try:
+            mesh_shape = self.mesh_shape
+        except AssertionError:
+            return f"OpStrategy[{strategy_list_str}]"
         return f"OpStrategy[{strategy_list_str}] @ mesh: {mesh_shape}"
 
     def max_num_shards(self) -> int:


### PR DESCRIPTION

OpStrategy.__str__ is used by debugging and downstream graph tooling, so it should not require mesh inference when a valid non-tensor strategy has no DTensorSpec in its input or output specs. Keep mesh and mesh_shape semantics unchanged, but omit the mesh suffix from the debug string when no mesh can be inferred.

Add a regression test for the all-None non-tensor strategy case.

Fixes https://github.com/pytorch/pytorch/issues/182370
Fixes https://github.com/meta-pytorch/autoparallel/issues/436
Co-authored-by: Claude