### PR TITLE
[distributed] Fix AssertionError in elastic c10d rendezvous when rank changes

### DIFF
--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -1249,6 +1249,39 @@ class DynamicRendezvousHandlerTest(TestCase):
             self.assertEqual(rdzv_info.bootstrap_store_info.master_port, TEST_PORT)
             self.assertNotEqual(handler._shared_tcp_store_server, handler._store)
 
+    def test_share_store_creates_tcp_store_when_rank_changes_to_zero(self):
+        self._max_nodes = 2
+        other_node = _NodeDesc("aaa_node", 1, 1)
+        self._state.participants[other_node] = 0
+        self._state.last_heartbeats[other_node] = datetime.now(timezone.utc)
+
+        handler = self._create_handler()
+
+        shared_store_info = RendezvousStoreInfo(TEST_ADDR, TEST_PORT)
+        with patch.object(RendezvousStoreInfo, "build", return_value=shared_store_info):
+            rdzv_info = handler.next_rendezvous()
+
+        self.assertEqual(rdzv_info.rank, 1)
+        self.assertIsNone(handler._shared_tcp_store_server)
+
+        del self._state.participants[other_node]
+        del self._state.last_heartbeats[other_node]
+        self._min_nodes = 1
+        self._max_nodes = 1
+        handler._settings = RendezvousSettings(
+            run_id="dummy_run_id",
+            min_nodes=1,
+            max_nodes=1,
+            timeout=RendezvousTimeout(),
+            keep_alive_interval=self._keep_alive_interval,
+            keep_alive_max_attempt=3,
+        )
+
+        rdzv_info = handler.next_rendezvous()
+
+        self.assertEqual(rdzv_info.rank, 0)
+        self.assertEqual(handler._shared_tcp_store_server, self._tcp_store_mock)
+
     @patch("torch.distributed.elastic.rendezvous.dynamic_rendezvous._delay")
     def test_next_rendezvous_skews_the_first_join_attempt(self, mock_delay) -> None:
         for round, expected_call_count in [(0, True), (1, False)]:

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -1203,9 +1203,12 @@ class DynamicRendezvousHandler(RendezvousHandler):
             )
 
         # This will only be hit when TCPStore sharing is enabled.
-        if self._bootstrap_store_info is None:
-            # To avoid race in get_free_port because we release the port after the call,
-            # we want to create a TCPStore server soon afterwards.
+        # Rebuild bootstrap store info when this is the first rendezvous or
+        # when the node became rank 0 but hasn't created a TCP store server
+        # yet (rank changed between rounds due to elastic membership changes).
+        if self._bootstrap_store_info is None or (
+            rank == 0 and self._shared_tcp_store_server is None
+        ):
             server_port = 0
             if rank == 0:
                 self._shared_tcp_store_server = self._create_tcp_store_server(


### PR DESCRIPTION
Fixes #182221

## Summary
- When a node transitions from non-zero rank to rank 0 across elastic rendezvous rounds (e.g. a peer node leaves), the cached `_bootstrap_store_info` caused the TCP store server creation block to be skipped, hitting `assert self._shared_tcp_store_server is not None`
- The fix re-enters the store setup block when the node is rank 0 but hasn't yet created a `_shared_tcp_store_server`, so the server gets created and bootstrap info is rebuilt for the new world configuration
- Added a test that reproduces the exact scenario: node starts as rank 1 with two participants, other node departs, node becomes rank 0 on re-rendezvous

## Test plan
- Added `test_share_store_creates_tcp_store_when_rank_changes_to_zero` to `DynamicRendezvousHandlerTest`
- Existing tests in `dynamic_rendezvous_test.py` should continue to pass (lintrunner passes locally)
- Note: could not run tests locally due to pre-existing C++ build breakage (`_is_kineto_stopped` import error)