### PR TITLE
[ROCm][TunableOp] Fix ROCBLAS tunable GEMM solution handling

### DIFF
--- a/aten/src/ATen/cuda/tunable/GemmRocblas.h
+++ b/aten/src/ATen/cuda/tunable/GemmRocblas.h
@@ -139,7 +139,7 @@ static rocblas_operation _rocblasOpFromChar(char op) {
 template <typename T>
 class RocblasGemmOp : public Callable<GemmParams<T>> {
   public:
-    RocblasGemmOp(int solution) : solution_{solution} {}
+    RocblasGemmOp(int32_t solution) : solution_{solution} {}
 
     TuningStatus Call(const GemmParams<T>* params) override {
       auto input_output_type = RocBlasDataTypeFor<T>();
@@ -170,13 +170,13 @@ class RocblasGemmOp : public Callable<GemmParams<T>> {
     }
 
   private:
-    int solution_;
+    int32_t solution_;
 };
 
 template <typename T>
 auto GetRocBlasGemmTypeStringAndOps() {
   rocblas_handle handle = (rocblas_handle)at::cuda::getCurrentCUDABlasHandle();
-  int solution_size;
+  rocblas_int solution_size;
   auto input_output_type = RocBlasDataTypeFor<T>();
   auto compute_type = RocBlasComputeTypeFor<T>();
   // Get the number of available solutions
@@ -187,7 +187,8 @@ auto GetRocBlasGemmTypeStringAndOps() {
                                                             rocblas_gemm_flags_none,
                                                             nullptr,
                                                             &solution_size));
-  std::vector<int> solutions(solution_size);
+  const auto solution_capacity = static_cast<size_t>(solution_size);
+  std::vector<rocblas_int> solutions(solution_capacity);
   // Get the list of available solutions
   TORCH_ROCBLAS_CHECK(rocblas_gemm_ex_get_solutions_by_type(handle,
                                                             input_output_type,
@@ -196,10 +197,14 @@ auto GetRocBlasGemmTypeStringAndOps() {
                                                             rocblas_gemm_flags_none,
                                                             solutions.data(),
                                                             &solution_size));
+  // See rocblas/internal/rocblas-beta.h: the list_size parameter
+  // (solution_size here) is updated to the number of solution indices filled.
+  solutions.resize(std::min(static_cast<size_t>(solution_size), solution_capacity));
   std::vector<std::pair<std::string, std::unique_ptr<Callable<GemmParams<T>>>>> ret;
   for (size_t i = 0; i < solutions.size(); ++i) {
-    auto callable = std::make_unique<RocblasGemmOp<T>>(solutions[i]);
-    ret.emplace_back(std::make_pair(fmt::sprintf("Gemm_Rocblas_%d", solutions[i]), std::move(callable)));
+    auto solution = static_cast<int32_t>(solutions[i]);
+    auto callable = std::make_unique<RocblasGemmOp<T>>(solution);
+    ret.emplace_back(std::make_pair(fmt::sprintf("Gemm_Rocblas_%d", solution), std::move(callable)));
   }
   return ret;
 }
@@ -207,7 +212,7 @@ auto GetRocBlasGemmTypeStringAndOps() {
 template <typename T>
 class RocblasGemmStridedBatchedOp : public Callable<GemmStridedBatchedParams<T>> {
   public:
-    RocblasGemmStridedBatchedOp(int solution) : solution_{solution} {}
+    RocblasGemmStridedBatchedOp(int32_t solution) : solution_{solution} {}
 
     TuningStatus Call(const GemmStridedBatchedParams<T>* params) override {
       auto input_output_type = RocBlasDataTypeFor<T>();
@@ -239,13 +244,13 @@ class RocblasGemmStridedBatchedOp : public Callable<GemmStridedBatchedParams<T>>
     }
 
   private:
-    int solution_;
+    int32_t solution_;
 };
 
 template <typename T>
 auto GetRocBlasGemmStridedBatchedTypeStringAndOps() {
   rocblas_handle handle = (rocblas_handle)at::cuda::getCurrentCUDABlasHandle();
-  int solution_size;
+  rocblas_int solution_size;
   auto input_output_type = RocBlasDataTypeFor<T>();
   auto compute_type = RocBlasComputeTypeFor<T>();
   // Get the number of available solutions
@@ -256,7 +261,8 @@ auto GetRocBlasGemmStridedBatchedTypeStringAndOps() {
                                                             rocblas_gemm_flags_none,
                                                             nullptr,
                                                             &solution_size));
-  std::vector<int> solutions(solution_size);
+  const auto solution_capacity = static_cast<size_t>(solution_size);
+  std::vector<rocblas_int> solutions(solution_capacity);
   // Get the list of available solutions
   TORCH_ROCBLAS_CHECK(rocblas_gemm_ex_get_solutions_by_type(handle,
                                                             input_output_type,
@@ -265,13 +271,17 @@ auto GetRocBlasGemmStridedBatchedTypeStringAndOps() {
                                                             rocblas_gemm_flags_none,
                                                             solutions.data(),
                                                             &solution_size));
+  // See rocblas/internal/rocblas-beta.h: the list_size parameter
+  // (solution_size here) is updated to the number of solution indices filled.
+  solutions.resize(std::min(static_cast<size_t>(solution_size), solution_capacity));
   // Sort the solutions in ascending order to make the solution vector deterministic across runs
   std::sort(solutions.begin(), solutions.end());
 
   std::vector<std::pair<std::string, std::unique_ptr<Callable<GemmStridedBatchedParams<T>>>>> ret;
   for (size_t i = 0; i < solutions.size(); ++i) {
-    auto callable = std::make_unique<RocblasGemmStridedBatchedOp<T>>(solutions[i]);
-    ret.emplace_back(std::make_pair(c10::str("Gemm_Rocblas_", solutions[i]), std::move(callable)));
+    auto solution = static_cast<int32_t>(solutions[i]);
+    auto callable = std::make_unique<RocblasGemmStridedBatchedOp<T>>(solution);
+    ret.emplace_back(std::make_pair(c10::str("Gemm_Rocblas_", solution), std::move(callable)));
   }
   return ret;
 }

--- a/aten/src/ATen/cuda/tunable/GemmRocblas.h
+++ b/aten/src/ATen/cuda/tunable/GemmRocblas.h
@@ -8,6 +8,8 @@
 #include <ATen/cuda/tunable/GemmCommon.h>
 #include <c10/util/StringUtil.h>
 #include <fmt/printf.h>
+#include <algorithm>
+#include <cstdint>
 
 #define ROCBLAS_BETA_FEATURES_API
 #include <rocblas/rocblas.h>


### PR DESCRIPTION
These are TunableOp rocBLAS specific changes to maintain consistency with the rocBLAS API.

No bug has been reported by customers or the community so far.

## Summary
- Use rocBLAS's `rocblas_int` type when collecting tunable GEMM solution indices.
- Resize the solution vector to the count actually filled by rocBLAS before registering candidates.
- Store selected solution indices as `int32_t`, matching the rocBLAS GEMM execution API.

## Test plan
- `/home/niromero/docker_workspace/framework_scripts/pytorch/build.sh`
- `python -u /home/niromero/docker_workspace/pytorch/test/test_linalg.py -k tunableop -v`


Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang