### PR TITLE
Allocator-level memory attribution primitives

### DIFF
--- a/c10/core/CachingDeviceAllocator.h
+++ b/c10/core/CachingDeviceAllocator.h
@@ -4,9 +4,39 @@
 #include <c10/core/Stream.h>
 #include <c10/util/ApproximateClock.h>
 
+#include <array>
+
 namespace c10::CachingDeviceAllocator {
 
 using namespace c10::CachingAllocator;
+
+// Component type for memory attribution.
+// Each allocation can be tagged with a component type to track what the memory
+// is used for (parameter, gradient, activation, optimizer state, etc.).
+enum struct ComponentType : uint8_t {
+  OTHER = 0,
+  PARAMETER = 1,
+  GRADIENT = 2,
+  ACTIVATION = 3,
+  OPTIMIZER_STATE = 4,
+  TEMP = 5,
+  BUFFER = 6,
+  COLLECTIVE_BUFFER = 7,
+  NUM_TYPES = 8
+};
+
+constexpr size_t kNumComponentTypes = static_cast<size_t>(ComponentType::NUM_TYPES);
+
+constexpr std::array<const char*, kNumComponentTypes>
+    kComponentNames = {
+        "other",
+        "parameter",
+        "gradient",
+        "activation",
+        "optimizer_state",
+        "temp",
+        "buffer",
+        "collective_buffer"};
 
 // Struct containing memory allocator summary statistics for a device.
 struct DeviceStats {
@@ -61,6 +91,11 @@ struct DeviceStats {
 
   // SIZE: maximum block size that is allowed to be split.
   int64_t max_split_size = 0;
+
+  // SUM: bytes attributed to each component type.
+  // Indexed by ComponentType enum value.
+  std::array<Stat, kNumComponentTypes>
+      component_bytes;
 };
 
 using CreateContextFn = std::shared_ptr<GatheredContext> (*)();
@@ -134,7 +169,8 @@ struct TraceEntry {
       approx_time_t time,
       std::shared_ptr<GatheredContext> context = nullptr,
       std::string compile_context = "",
-      std::string user_metadata = "")
+      std::string user_metadata = "",
+      uint8_t component_type = 0)
       : action_(action),
         device_(device),
         addr_(addr),
@@ -143,7 +179,8 @@ struct TraceEntry {
         size_(size),
         mempool_(std::move(mempool)),
         compile_context_(std::move(compile_context)),
-        user_metadata_(std::move(user_metadata)) {
+        user_metadata_(std::move(user_metadata)),
+        component_type_(component_type) {
     time_.approx_t_ = time;
   }
   Action action_;
@@ -159,6 +196,7 @@ struct TraceEntry {
   trace_time_ time_{};
   std::string compile_context_;
   std::string user_metadata_;
+  uint8_t component_type_{0};
 };
 
 inline TraceEntry::Action parseTraceEntryAction(std::string_view action) {

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -165,6 +165,7 @@ void decrease_stat_array(
 
 struct Block;
 struct PrivatePool;
+using ComponentType = CachingDeviceAllocator::ComponentType;
 typedef bool (*Comparison)(const Block*, const Block*);
 static bool BlockComparatorRegistrationCounter(const Block* a, const Block* b);
 static bool BlockComparatorAddress(const Block* a, const Block* b);
@@ -221,6 +222,10 @@ struct Block {
   std::shared_ptr<GatheredContext> context_when_segment_allocated;
 
   ExpandableSegment* expandable_segment_{nullptr};
+
+  // Component type for memory attribution tracking
+  ComponentType component_type{
+      ComponentType::OTHER};
 
   Block(
       c10::DeviceIndex device,
@@ -1505,6 +1510,10 @@ class DeviceCachingAllocator {
   // thread local user metadata for annotating allocations
   static thread_local std::string user_metadata;
 
+  // thread local component type for memory attribution
+  static thread_local ComponentType
+      current_component_type;
+
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   explicit DeviceCachingAllocator(c10::DeviceIndex id)
@@ -1565,6 +1574,32 @@ class DeviceCachingAllocator {
 
   std::string getUserMetadata() {
     return user_metadata;
+  }
+
+  void setComponentType(ComponentType type) {
+    current_component_type = type;
+  }
+
+  ComponentType getComponentType() {
+    return current_component_type;
+  }
+
+  // Retroactively re-tag an existing allocated block's component type
+  // and adjust the component_bytes counters accordingly.
+  void tagBlock(
+      Block* block,
+      ComponentType new_type) {
+    std::unique_lock<std::recursive_mutex> lock(mutex);
+    if (!block->allocated) {
+      return;
+    }
+    auto old_type = block->component_type;
+    if (old_type == new_type) {
+      return;
+    }
+    stats.component_bytes[static_cast<uint8_t>(old_type)].decrease(block->size);
+    stats.component_bytes[static_cast<uint8_t>(new_type)].increase(block->size);
+    block->component_type = new_type;
   }
 
   bool checkPoolLiveAllocations(
@@ -1966,6 +2001,9 @@ class DeviceCachingAllocator {
     block->allocated = true;
     block->requested_size = orig_size;
 
+    // Stamp the block with the current component type for attribution
+    block->component_type = current_component_type;
+
     block->context_when_allocated = std::move(context);
     record_trace(
         TraceEntry::ALLOC,
@@ -1987,6 +2025,11 @@ class DeviceCachingAllocator {
       stats.active_bytes[stat_type].increase(block->size);
       stats.requested_bytes[stat_type].increase(block->requested_size);
     });
+
+    // Update per-component stats
+    stats
+        .component_bytes[static_cast<uint8_t>(block->component_type)]
+        .increase(block->size);
     if (block->size >= AcceleratorAllocatorConfig::max_split_size())
       stats.oversize_allocations.increase(1);
 
@@ -3294,6 +3337,7 @@ class DeviceCachingAllocator {
     block->context_when_allocated = nullptr;
     size_t original_block_size = block->size;
     size_t requested_size = block->requested_size;
+    auto freed_component_type = block->component_type;
 
     auto& pool = *block->pool;
     int64_t net_change_inactive_split_blocks = 0;
@@ -3349,6 +3393,11 @@ class DeviceCachingAllocator {
       stats.active_bytes[stat_type].decrease(original_block_size);
       stats.requested_bytes[stat_type].decrease(requested_size);
     });
+
+    // Decrement per-component stats using the saved component type
+    stats
+        .component_bytes[static_cast<uint8_t>(freed_component_type)]
+        .decrease(original_block_size);
   }
 
   /** combine previously split blocks. returns the size of the subsumed block,
@@ -4171,7 +4220,8 @@ class DeviceCachingAllocator {
         getApproximateTime(),
         record_context_ >= RecordContext::ALLOC ? std::move(context) : nullptr,
         compile_string,
-        user_metadata);
+        user_metadata,
+        static_cast<uint8_t>(current_component_type));
 
     // Callbacks should not include any Pytorch call
     for (const auto& cb : trace_trackers_) {
@@ -4231,6 +4281,123 @@ static void uncached_delete(void* ptr) {
 static void local_raw_delete(void* ptr);
 thread_local std::stack<std::string> DeviceCachingAllocator::compile_context;
 thread_local std::string DeviceCachingAllocator::user_metadata;
+thread_local ComponentType
+    DeviceCachingAllocator::current_component_type{
+        ComponentType::OTHER};
+
+// Per-module memory tracker registered as an AllocatorTraceTracker callback.
+// Maintains per-(module_fqn, component_type) counters updated on every
+// alloc/free.
+// Thread safety: This tracker is shared across all device allocators.
+// Callbacks fire under each device's mutex, so concurrent calls from
+// different devices would race. enableModuleTracking() asserts that only
+// one device is active to prevent this.
+class ModuleComponentTracker {
+ public:
+  // Per-allocation metadata stored in addr_to_info_ to track which module
+  // and component type each allocation belongs to, so we can decrement the
+  // correct counters on free.
+  struct AllocInfo {
+    std::string fqn;
+    uint8_t component_type;
+    size_t size;
+  };
+
+  void operator()(const TraceEntry& te) {
+    if (!enabled_) {
+      return;
+    }
+    if (te.action_ == TraceEntry::ALLOC) {
+      const auto& fqn = te.user_metadata_;
+      if (fqn.empty()) {
+        return;
+      }
+      addr_to_info_[te.addr_] = {fqn, te.component_type_, te.size_};
+      auto key = makeKey(fqn, te.component_type_);
+      counters_[key].increase(te.size_);
+    } else if (te.action_ == TraceEntry::FREE_COMPLETED) {
+      auto it = addr_to_info_.find(te.addr_);
+      if (it == addr_to_info_.end()) {
+        return;
+      }
+      auto key = makeKey(it->second.fqn, it->second.component_type);
+      auto cit = counters_.find(key);
+      if (cit != counters_.end()) {
+        cit->second.decrease(it->second.size);
+      }
+      addr_to_info_.erase(it);
+    }
+  }
+
+  // Returns a copy of counters for thread-safe reading from Python.
+  // key format: "module_fqn:component_idx"
+  std::unordered_map<std::string, Stat> getCounters() const {
+    return counters_;
+  }
+
+  void enable() {
+    enabled_ = true;
+  }
+
+  void disable() {
+    enabled_ = false;
+  }
+
+  void reset() {
+    addr_to_info_.clear();
+    counters_.clear();
+  }
+
+  void resetPeakStats() {
+    for (auto& [key, stat] : counters_) {
+      stat.reset_peak();
+    }
+  }
+
+  bool isEnabled() const {
+    return enabled_;
+  }
+
+  // Seed an entry for a pre-existing allocation (e.g. parameters allocated
+  // before tracking was enabled). Called from Python via tagModuleBlock().
+  void seedEntry(size_t addr, const std::string& fqn, uint8_t component_type, size_t size) {
+    if (fqn.empty() || size == 0) {
+      return;
+    }
+    addr_to_info_[addr] = {fqn, component_type, size};
+    auto key = makeKey(fqn, component_type);
+    counters_[key].increase(size);
+  }
+
+  // Parse a key back into (fqn, component_type)
+  static std::pair<std::string, uint8_t> parseKey(const std::string& key) {
+    auto pos = key.find(':');
+    if (pos == std::string::npos) {
+      return {key, 0};
+    }
+    return {
+        key.substr(0, pos),
+        static_cast<uint8_t>(std::stoi(key.substr(pos + 1)))};
+  }
+
+ private:
+  static std::string makeKey(const std::string& fqn, uint8_t component_type) {
+    std::string key;
+    // +1 for ':' separator, +3 for max uint8_t digits ("255")
+    key.reserve(fqn.size() + 1 + 3);
+    key.append(fqn);
+    key.push_back(':');
+    key.append(std::to_string(component_type));
+    return key;
+  }
+
+  bool enabled_{false};
+  std::unordered_map<size_t, AllocInfo> addr_to_info_;
+  std::unordered_map<std::string, Stat> counters_;
+};
+
+// Global singleton for module-level tracking.
+static std::unique_ptr<ModuleComponentTracker> g_module_tracker;
 
 class NativeCachingAllocator : public CUDAAllocator {
  private:
@@ -4442,6 +4609,92 @@ class NativeCachingAllocator : public CUDAAllocator {
     c10::DeviceIndex device = 0;
     C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
     return device_allocator[device]->getUserMetadata();
+  }
+
+  void setComponentType(ComponentType type) override {
+    c10::DeviceIndex device = 0;
+    C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
+    device_allocator[device]->setComponentType(type);
+  }
+
+  ComponentType getComponentType() override {
+    c10::DeviceIndex device = 0;
+    C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
+    return device_allocator[device]->getComponentType();
+  }
+
+  void tagBlock(void* ptr, ComponentType type)
+      override {
+    Block* block = get_allocated_block(ptr);
+    if (!block) {
+      return;
+    }
+    device_allocator[block->device]->tagBlock(block, type);
+  }
+
+  void tagModuleBlock(
+      void* ptr,
+      const std::string& fqn,
+      ComponentType type) override {
+    if (!g_module_tracker || !g_module_tracker->isEnabled()) {
+      return;
+    }
+    Block* block = get_allocated_block(ptr);
+    if (!block || !block->allocated) {
+      return;
+    }
+    g_module_tracker->seedEntry(
+        reinterpret_cast<size_t>(ptr),
+        fqn,
+        static_cast<uint8_t>(type),
+        block->size);
+  }
+
+  void enableModuleTracking() override {
+    if (!g_module_tracker) {
+      // The shared tracker is not thread-safe across devices. Verify that
+      // only one device allocator is active (the normal case under DDP/FSDP
+      // where CUDA_VISIBLE_DEVICES restricts to 1 GPU per process).
+      size_t active_devices = 0;
+      for (auto& da : device_allocator) {
+        if (da) {
+          active_devices++;
+        }
+      }
+      TORCH_CHECK(
+          active_devices <= 1,
+          "Module tracking requires at most 1 active CUDA device per process. "
+          "Found ",
+          active_devices,
+          ". Use CUDA_VISIBLE_DEVICES to restrict to a single GPU.");
+
+      g_module_tracker = std::make_unique<ModuleComponentTracker>();
+      auto* tracker = g_module_tracker.get();
+      for (auto& da : device_allocator) {
+        if (da) {
+          da->attachAllocatorTraceTracker(
+              [tracker](const TraceEntry& te) { (*tracker)(te); });
+        }
+      }
+    }
+    g_module_tracker->enable();
+  }
+
+  void disableModuleTracking() override {
+    if (g_module_tracker) {
+      g_module_tracker->disable();
+    }
+  }
+
+  std::unordered_map<std::string, Stat> getModuleCounters() override {
+    if (g_module_tracker) {
+      return g_module_tracker->getCounters();
+    }
+    return {};
+  }
+
+  bool isModuleTrackingEnabled() override {
+    return g_module_tracker && g_module_tracker->isEnabled();
   }
 
   bool isHistoryEnabled() override {
@@ -4693,6 +4946,9 @@ class NativeCachingAllocator : public CUDAAllocator {
   void resetPeakStats(c10::DeviceIndex device) override {
     assertValidDevice(device);
     device_allocator[device]->resetPeakStats();
+    if (g_module_tracker && g_module_tracker->isEnabled()) {
+      g_module_tracker->resetPeakStats();
+    }
   }
 
   void createOrIncrefPool(

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -229,6 +229,27 @@ class CUDAAllocator : public DeviceAllocator {
   virtual std::string getUserMetadata() {
     return "";
   }
+  virtual void setComponentType(
+      CachingDeviceAllocator::ComponentType /*type*/) {}
+  virtual CachingDeviceAllocator::ComponentType getComponentType() {
+    return CachingDeviceAllocator::ComponentType::OTHER;
+  }
+  virtual void tagBlock(
+      void* /*ptr*/,
+      CachingDeviceAllocator::ComponentType /*type*/) {}
+  virtual void tagModuleBlock(
+      void* /*ptr*/,
+      const std::string& /*fqn*/,
+      CachingDeviceAllocator::ComponentType /*type*/) {}
+  virtual void enableModuleTracking() {}
+  virtual void disableModuleTracking() {}
+  virtual std::unordered_map<std::string, c10::CachingAllocator::Stat>
+  getModuleCounters() {
+    return {};
+  }
+  virtual bool isModuleTrackingEnabled() {
+    return false;
+  }
   virtual void attachOutOfMemoryObserver(OutOfMemoryObserver observer) = 0;
   virtual void attachOomRejectionObserver(OomRejectionObserver observer) = 0;
 
@@ -503,6 +524,42 @@ inline void setUserMetadata(const std::string& metadata) {
 
 inline std::string getUserMetadata() {
   return get()->getUserMetadata();
+}
+
+inline void setComponentType(CachingDeviceAllocator::ComponentType type) {
+  get()->setComponentType(type);
+}
+
+inline CachingDeviceAllocator::ComponentType getComponentType() {
+  return get()->getComponentType();
+}
+
+inline void tagBlock(void* ptr, CachingDeviceAllocator::ComponentType type) {
+  get()->tagBlock(ptr, type);
+}
+
+inline void tagModuleBlock(
+    void* ptr,
+    const std::string& fqn,
+    CachingDeviceAllocator::ComponentType type) {
+  get()->tagModuleBlock(ptr, fqn, type);
+}
+
+inline void enableModuleTracking() {
+  get()->enableModuleTracking();
+}
+
+inline void disableModuleTracking() {
+  get()->disableModuleTracking();
+}
+
+inline std::unordered_map<std::string, c10::CachingAllocator::Stat>
+getModuleCounters() {
+  return get()->getModuleCounters();
+}
+
+inline bool isModuleTrackingEnabled() {
+  return get()->isModuleTrackingEnabled();
 }
 
 } // namespace c10::cuda::CUDACachingAllocator

--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -94,6 +94,17 @@ def memory_stats(device_index: _device_t = None, /) -> OrderedDict[str, Any]:
     - ``"num_device_alloc"``: number of device memory allocation calls.
     - ``"num_device_free"``: number of device memory free calls.
 
+    When memory component tracking is enabled via
+    ``torch.accelerator.memory.component_tracking.enable()``, the
+    following per-component keys are also present:
+
+    - ``"component_bytes.{other,parameter,gradient,activation,optimizer_state,temp,buffer}.{current,peak,allocated,freed}"``:
+      amount of allocated memory attributed to each component type.
+
+    These 28 keys (7 components × 4 metrics) are always available in the
+    returned dict once ``enable_component_tracking`` has been called. Without
+    tracking, the component keys are still present but all values will be zero.
+
     Args:
         device_index (:class:`torch.device`, str, int, optional): the index of the device to target.
             If not given, use :func:`torch.accelerator.current_device_index` by default.
@@ -107,6 +118,14 @@ def memory_stats(device_index: _device_t = None, /) -> OrderedDict[str, Any]:
         return OrderedDict()
     device_index = _get_device_index(device_index, optional=True)
     stats = torch._C._accelerator_getDeviceStats(device_index)
+
+    # Merge per-module breakdown if module tracking is active (CUDA only)
+    try:
+        if torch._C._cuda_isModuleTrackingEnabled():  # pyrefly: ignore [missing-attribute]
+            stats["module_bytes"] = torch._C._cuda_getModuleCounters()  # pyrefly: ignore [missing-attribute]
+    except AttributeError:
+        pass  # Non-CUDA backend or bindings not available
+
     flat_stats = []
 
     def flatten(prefix: str, value: Any) -> None:

--- a/torch/csrc/DeviceAccelerator.cpp
+++ b/torch/csrc/DeviceAccelerator.cpp
@@ -155,6 +155,17 @@ void initModule(PyObject* module) {
         stat_array_to_dict(stats.inactive_split_bytes);
     result["oversize_allocations"] = stat_to_dict(stats.oversize_allocations);
     result["oversize_segments"] = stat_to_dict(stats.oversize_segments);
+
+    // Per-component memory attribution
+    {
+      using c10::CachingDeviceAllocator::kComponentNames;
+      py::dict comp_dict;
+      for (const auto i : c10::irange(kComponentNames.size())) {
+        comp_dict[kComponentNames[i]] = stat_to_dict(stats.component_bytes[i]);
+      }
+      result["component_bytes"] = comp_dict;
+    }
+
     return result;
   });
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -572,6 +572,33 @@ PyObject* THCPModule_emptyCache(PyObject* _unused, PyObject* noargs) {
   Py_RETURN_NONE;
 }
 
+// Convert module counter map (key "fqn:component_idx") to nested Python dict
+// {fqn: {component_name: {current, peak, allocated, freed}}}
+static py::dict moduleCountersToPyDict(
+    const std::unordered_map<std::string, c10::CachingAllocator::Stat>& counters) {
+  using c10::CachingDeviceAllocator::kComponentNames;
+  py::dict mod_dict;
+  for (const auto& [key, stat] : counters) {
+    auto pos = key.find(':');
+    std::string fqn = (pos != std::string::npos) ? key.substr(0, pos) : key;
+    uint8_t comp_idx = (pos != std::string::npos)
+        ? static_cast<uint8_t>(std::stoi(key.substr(pos + 1)))
+        : 0;
+    const char* comp_name =
+        comp_idx < kComponentNames.size() ? kComponentNames[comp_idx] : "other";
+    py::dict stat_dict;
+    stat_dict["current"] = stat.current;
+    stat_dict["peak"] = stat.peak;
+    stat_dict["allocated"] = stat.allocated;
+    stat_dict["freed"] = stat.freed;
+    if (!mod_dict.contains(fqn.c_str())) {
+      mod_dict[fqn.c_str()] = py::dict();
+    }
+    mod_dict[fqn.c_str()][comp_name] = stat_dict;
+  }
+  return mod_dict;
+}
+
 PyObject* THCPModule_memoryStats(PyObject* _unused, PyObject* arg) {
   HANDLE_TH_ERRORS
   TORCH_CHECK(THPUtils_checkLong(arg), "invalid argument to memory_allocated");
@@ -624,6 +651,22 @@ PyObject* THCPModule_memoryStats(PyObject* _unused, PyObject* arg) {
   result["requested_bytes"] = statArrayToDict(stats.requested_bytes);
   result["oversize_allocations"] = statToDict(stats.oversize_allocations);
   result["oversize_segments"] = statToDict(stats.oversize_segments);
+
+  // Per-component memory attribution
+  {
+    using c10::CachingDeviceAllocator::kComponentNames;
+    py::dict comp_dict;
+    for (const auto i : c10::irange(kComponentNames.size())) {
+      comp_dict[kComponentNames[i]] = statToDict(stats.component_bytes[i]);
+    }
+    result["component_bytes"] = comp_dict;
+  }
+
+  // Per-module breakdown (when module tracking is enabled)
+  if (c10::cuda::CUDACachingAllocator::isModuleTrackingEnabled()) {
+    result["module_bytes"] = moduleCountersToPyDict(
+        c10::cuda::CUDACachingAllocator::getModuleCounters());
+  }
 
   return result.release().ptr();
   END_HANDLE_TH_ERRORS
@@ -1191,6 +1234,47 @@ static void registerCudaDeviceProperties(PyObject* module) {
 
   m.def("_cuda_getMemoryMetadata", []() {
     return c10::cuda::CUDACachingAllocator::getUserMetadata();
+  });
+
+  m.def("_cuda_setComponentType", [](int type) {
+    c10::cuda::CUDACachingAllocator::setComponentType(
+        static_cast<c10::CachingDeviceAllocator::ComponentType>(type));
+  });
+
+  m.def("_cuda_getComponentType", []() {
+    return static_cast<int>(
+        c10::cuda::CUDACachingAllocator::getComponentType());
+  });
+
+  m.def("_cuda_tagBlock", [](size_t ptr, int type) {
+    c10::cuda::CUDACachingAllocator::tagBlock(
+        reinterpret_cast<void*>(ptr),
+        static_cast<c10::CachingDeviceAllocator::ComponentType>(type));
+  });
+
+  m.def(
+      "_cuda_tagModuleBlock", [](size_t ptr, const std::string& fqn, int type) {
+        c10::cuda::CUDACachingAllocator::tagModuleBlock(
+            reinterpret_cast<void*>(ptr),
+            fqn,
+            static_cast<c10::CachingDeviceAllocator::ComponentType>(type));
+      });
+
+  m.def("_cuda_enableModuleTracking", []() {
+    c10::cuda::CUDACachingAllocator::enableModuleTracking();
+  });
+
+  m.def("_cuda_disableModuleTracking", []() {
+    c10::cuda::CUDACachingAllocator::disableModuleTracking();
+  });
+
+  m.def("_cuda_isModuleTrackingEnabled", []() {
+    return c10::cuda::CUDACachingAllocator::isModuleTrackingEnabled();
+  });
+
+  m.def("_cuda_getModuleCounters", []() {
+    return moduleCountersToPyDict(
+        c10::cuda::CUDACachingAllocator::getModuleCounters());
   });
 
   m.def("_cuda_get_conv_benchmark_empty_cache", []() {

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -1160,6 +1160,120 @@ def _get_memory_metadata() -> str:
     return torch._C._cuda_getMemoryMetadata()
 
 
+class ComponentType:
+    """Component types for memory attribution.
+
+    Used with :func:`_set_component_type` and :func:`_tag_block` to attribute
+    GPU memory allocations to specific training components (parameters, gradients,
+    activations, optimizer state, etc.).
+
+    The values match the ``c10::CachingDeviceAllocator::ComponentType`` enum in C++.
+    """
+
+    OTHER = 0
+    PARAMETER = 1
+    GRADIENT = 2
+    ACTIVATION = 3
+    OPTIMIZER_STATE = 4
+    TEMP = 5
+    BUFFER = 6
+    COLLECTIVE_BUFFER = 7
+
+
+def _set_component_type(component_type: int) -> None:
+    """Set the component type for subsequent CUDA memory allocations.
+
+    All allocations made after this call on the current thread will be tagged
+    with the specified component type until it is changed or reset.
+
+    Args:
+        component_type: One of the ``ComponentType`` constants
+            (e.g., ``ComponentType.PARAMETER``, ``ComponentType.ACTIVATION``).
+    """
+    # pyrefly: ignore [missing-attribute]
+    torch._C._cuda_setComponentType(component_type)
+
+
+def _get_component_type() -> int:
+    """Get the current component type for CUDA memory allocations.
+
+    Returns:
+        int: The current component type value (one of ``ComponentType`` constants).
+    """
+    # pyrefly: ignore [missing-attribute]
+    return torch._C._cuda_getComponentType()
+
+
+def _tag_block(data_ptr: int, component_type: int) -> None:
+    """Retroactively re-tag an existing CUDA allocation's component type.
+
+    Looks up the Block by pointer, swaps the component type, and adjusts
+    the ``component_bytes`` counters in ``DeviceStats``.
+
+    This is used by the component tracker to re-tag:
+    - Parameters and buffers (allocated before tracking was enabled)
+    - Gradients (initially allocated as OTHER during backward, re-tagged after accumulation)
+
+    Args:
+        data_ptr: The data pointer (``tensor.data_ptr()``) of the allocation.
+        component_type: The new component type (one of ``ComponentType`` constants).
+    """
+    # pyrefly: ignore [missing-attribute]
+    torch._C._cuda_tagBlock(data_ptr, component_type)
+
+
+def _tag_module_block(data_ptr: int, fqn: str, component_type: int) -> None:
+    """Seed a pre-existing allocation into the per-module tracker.
+
+    This inserts an entry into the ``ModuleComponentTracker``'s internal map
+    and increments the per-(module, component) counters. Used for parameters
+    and buffers that were allocated before module tracking was enabled.
+
+    Args:
+        data_ptr: The data pointer (``tensor.data_ptr()``) of the allocation.
+        fqn: The fully-qualified module name (e.g., ``"layers.0.attn"``).
+        component_type: The component type (one of ``ComponentType`` constants).
+    """
+    # pyrefly: ignore [missing-attribute]
+    torch._C._cuda_tagModuleBlock(data_ptr, fqn, component_type)
+
+
+def _enable_module_tracking() -> None:
+    """Enable per-module memory tracking.
+
+    Registers an ``AllocatorTraceTracker`` callback in the CUDA caching
+    allocator that maintains per-(module_fqn, component_type) counters.
+    Module FQNs are read from the ``user_metadata`` that module forward hooks
+    set via :func:`_set_memory_metadata`.
+
+    After this call, :func:`_get_module_counters` returns per-module breakdown.
+    """
+    # pyrefly: ignore [missing-attribute]
+    torch._C._cuda_enableModuleTracking()
+
+
+def _disable_module_tracking() -> None:
+    """Disable per-module memory tracking."""
+    # pyrefly: ignore [missing-attribute]
+    torch._C._cuda_disableModuleTracking()
+
+
+def _is_module_tracking_enabled() -> bool:
+    """Return True if per-module memory tracking is enabled."""
+    # pyrefly: ignore [missing-attribute]
+    return torch._C._cuda_isModuleTrackingEnabled()
+
+
+def _get_module_counters() -> dict:
+    """Return per-(module, component) memory counters.
+
+    Returns:
+        dict: Nested dict ``{module_fqn: {component_name: {current, peak, allocated, freed}}}``
+    """
+    # pyrefly: ignore [missing-attribute]
+    return torch._C._cuda_getModuleCounters()
+
+
 def _save_segment_usage(filename="output.svg", snapshot=None):
     if snapshot is None:
         snapshot = _snapshot()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #182389
* #182388
* __->__ #182387

## Summary
This PR adds the ability to answer "what is this GPU memory being used for?" at the allocator level. Every CUDA allocation is now stamped with a component type (parameter, gradient, activation, optimizer state, etc.) at allocation time, with zero cost when tracking is not active.

What is the expected user experience?
```
   import torch
   from torch.accelerator.memory import component_tracking

   component_tracking.enable()

   # ... training loop ...

   stats = torch.accelerator.memory.memory_stats()
   print(f"Params:      {stats['component_bytes.parameter.current'] / 1e9:.2f} GB")
   print(f"Activations: {stats['component_bytes.activation.current'] / 1e9:.2f} GB")

   component_tracking.disable()
```

## tl;dr 
How is it done ?
    PyTorch hooks firing at module boundaries + clean tracking at allocator level
Why ?
    Continuous memory monitoring with component and module level breakdown for ease

## Design decisions
* Thread-local stamping, not per-allocation argument passing. The component type is set as a thread-local object before the allocation happens (by Python hooks in PR 2), rather than passed through the entire malloc() call chain. This avoids touching any existing allocation APIs or caller sites throughout PyTorch.
* Stats live in DeviceStats, not a side structure. component_bytes[8] is a fixed array in the existing DeviceStats struct, so it's returned by the existing memory_stats() API automatically.
* tagBlock() for retroactive re-tagging. Parameters and gradients are allocated before tracking is enabled (or as OTHER during backward). Rather than trying to predict what an allocation will become, we re-tag after the fact. This keeps the alloc path simple and handles the real-world ordering where model creation precedes tracker setup.
* ModuleComponentTracker as an AllocatorTraceTracker callback. Per-module counters piggyback on the existing trace tracker infrastructure. The tracker maintains an addr_to_info map to attribute frees to the correct module.
* kComponentNames and kNumComponentTypes centralized in the header. The enum, name array, and count are defined once in CachingDeviceAllocator.h — all consumers (Module.cpp, DeviceAccelerator.cpp) reference the single source of truth.

## Assumptions
* One GPU per process. The ModuleComponentTracker singleton is shared across device allocators and is not internally synchronized — an assertion enforces ≤1 active device. 
* This designed and tested assuming non-async memory allocations, ie. you ask for memory and you get the memory. No support for CudaMallocAsync yet.

## Notes
* This PR adds the basic primitives, the 2nd one makes use of them with PyTorch hooks. 
* The third PR is an attempt to make this work with FSDP. With different parallelism strategies, I expect the parallelism experts to be able to leverage these primitives to enable tracking. 
* For e2e tests and overhead see the top of the PR stack..

## Testing
* No unit tests so far
* Did a demo locally testing with DDP and FSDP on top of the final PR. The cost of enabling tracking is ~3-4% on throughput, mostly coming from python hooks. See the last PR for output.
