### PR TITLE
Training hooks and public API for memory component tracking

### DIFF
--- a/torch/accelerator/_component_tracking.py
+++ b/torch/accelerator/_component_tracking.py
@@ -1,0 +1,77 @@
+"""Public API for memory component tracking.
+
+Provides a simple interface to track GPU memory attribution by component type
+(parameter, gradient, activation, optimizer state, etc.) and optionally by
+module fully-qualified name.
+
+Usage::
+
+    from torch.accelerator.memory import component_tracking
+    import torch.accelerator.memory
+
+    component_tracking.enable()
+
+    # ... training loop ...
+
+    stats = torch.accelerator.memory.memory_stats()
+    print(f"Params:      {stats['component_bytes.parameter.current'] / 1e9:.2f} GB")
+    print(f"Activations: {stats['component_bytes.activation.current'] / 1e9:.2f} GB")
+
+    component_tracking.disable()
+
+The ``enable()`` call auto-detects models and optimizers via global hooks.
+No arguments are required for component-level breakdown. For per-module
+breakdown (``module_bytes.*``), models are discovered automatically on
+their first forward pass.
+"""
+
+from __future__ import annotations
+
+
+_tracker = None
+
+
+def enable() -> None:
+    """Enable memory component tracking.
+
+    Installs lightweight global hooks that automatically tag every GPU
+    allocation with its component type (parameter, gradient, activation,
+    optimizer state, etc.) and the owning module's fully-qualified name.
+
+    Models and optimizers are auto-detected:
+    - Models are discovered on their first forward pass (root detection).
+    - Optimizers are detected via class-level step hooks.
+
+    Calling ``enable()`` when already enabled is a no-op.
+
+    After this call, ``torch.accelerator.memory.memory_stats()`` includes:
+    - ``component_bytes.{type}.{metric}`` keys (always)
+    - ``module_bytes.{fqn}.{type}.{metric}`` keys (after first forward)
+    """
+    global _tracker
+    if _tracker is not None:
+        return
+
+    from torch.cuda.memory_component_tracker import _enable_auto
+
+    _tracker = _enable_auto()
+
+
+def disable() -> None:
+    """Disable memory component tracking and remove all hooks.
+
+    Resets all tracking state. After this call, new allocations are no
+    longer tagged. Existing ``component_bytes`` counters remain in
+    ``torch.accelerator.memory.memory_stats()`` but stop updating.
+    """
+    global _tracker
+    if _tracker is None:
+        return
+
+    _tracker.disable()
+    _tracker = None
+
+
+def is_enabled() -> bool:
+    """Return True if component tracking is currently active."""
+    return _tracker is not None

--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -4,9 +4,11 @@ from typing import Any
 import torch
 
 from ._utils import _device_t, _get_device_index
+from torch.accelerator import _component_tracking as component_tracking  # noqa: F401
 
 
 __all__ = [
+    "component_tracking",
     "empty_cache",
     "empty_host_cache",
     "get_memory_info",

--- a/torch/cuda/memory_component_tracker.py
+++ b/torch/cuda/memory_component_tracker.py
@@ -1,0 +1,220 @@
+"""Lightweight memory component tracker for CUDA memory attribution.
+
+This module provides the implementation for memory component tracking that
+auto-detects models and optimizers via global hooks. The public API is
+:mod:`torch.accelerator.memory.component_tracking`.
+
+Internal module — use ``from torch.accelerator.memory import component_tracking``
+for the public interface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch.cuda.memory import (
+    _disable_module_tracking,
+    _enable_module_tracking,
+    _set_component_type,
+    _set_memory_metadata,
+    _tag_block,
+    _tag_module_block,
+    ComponentType,
+)
+
+
+class ComponentTracker:
+    """Manages the lifecycle of memory attribution hooks.
+
+    Tracks global hooks, auto-detected roots, and provides teardown.
+    """
+
+    def __init__(self) -> None:
+        self._hook_handles: list[Any] = []
+        self._enabled = True
+        self._depth = 0
+        self._current_root: nn.Module | None = None
+        self._tagged_modules: set[int] = set()
+        self._tagged_params: set[int] = set()
+        self._grad_hooked_params: set[int] = set()
+
+    def _add_handle(self, handle: Any) -> None:
+        self._hook_handles.append(handle)
+
+    def disable(self) -> None:
+        """Remove all hooks and reset tracking state."""
+        for handle in self._hook_handles:
+            handle.remove()
+        self._hook_handles.clear()
+        _set_component_type(ComponentType.OTHER)
+        _set_memory_metadata("")
+        _disable_module_tracking()
+        self._enabled = False
+        self._depth = 0
+        self._current_root = None
+        self._tagged_modules.clear()
+        self._tagged_params.clear()
+        self._grad_hooked_params.clear()
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+
+def _enable_auto() -> ComponentTracker:
+    """Enable component tracking with auto-detection of models and optimizers.
+
+    Installs global hooks that:
+    - Auto-detect root models on first forward (builds FQN cache)
+    - Tag allocations as ACTIVATION during forward, TEMP during backward
+    - Tag gradient storage via post-accumulate-grad hooks (lazy)
+    - Tag optimizer allocations via class-level optimizer step hooks
+    - Tag parameters/buffers lazily on first module forward
+    - Enable per-module tracking and collective buffer detection
+    """
+    tracker = ComponentTracker()
+
+    # --- (a) Global forward hooks: auto-detect root, tag ACTIVATION ---
+
+    def _forward_pre_hook(module: nn.Module, args: Any) -> None:
+        if tracker._depth == 0:
+            if not hasattr(module, "_fqn_cache"):
+                module._fqn_cache = {}  # type: ignore[attr-defined]
+                for name, mod in module.named_modules():
+                    module._fqn_cache[id(mod)] = name  # type: ignore[attr-defined]
+            tracker._current_root = module
+
+        tracker._depth += 1
+
+        fqn = ""
+        if tracker._current_root is not None:
+            cache = getattr(tracker._current_root, "_fqn_cache", {})
+            fqn = cache.get(id(module), "")
+
+        # All memory allocated during a module's forward pass is an activation
+        # (intermediate tensors, attention scores, etc.)
+        _set_component_type(ComponentType.ACTIVATION)
+        _set_memory_metadata(fqn)
+
+        if id(module) in tracker._tagged_modules:
+            return
+        tracker._tagged_modules.add(id(module))
+
+        # Tag this module's parameters and buffers on first visit
+        for p in module.parameters(recurse=False):
+            if p.data.data_ptr() != 0:
+                if id(p) not in tracker._tagged_params:
+                    _tag_block(p.data.data_ptr(), ComponentType.PARAMETER)
+                    tracker._tagged_params.add(id(p))
+                if fqn:
+                    _tag_module_block(
+                        p.data.data_ptr(), fqn, ComponentType.PARAMETER
+                    )
+        for b in module.buffers(recurse=False):
+            if b.data.data_ptr() != 0:
+                _tag_block(b.data.data_ptr(), ComponentType.BUFFER)
+                if fqn:
+                    _tag_module_block(
+                        b.data.data_ptr(), fqn, ComponentType.BUFFER
+                    )
+
+        # Register gradient hooks — after backward accumulates gradients,
+        # re-tag the grad tensor from OTHER/TEMP to GRADIENT
+        for p in module.parameters(recurse=False):
+            if p.requires_grad and id(p) not in tracker._grad_hooked_params:
+                tracker._grad_hooked_params.add(id(p))
+
+                def _make_grad_hook(param: torch.Tensor) -> Any:
+                    def _grad_hook(grad: torch.Tensor) -> None:
+                        if (
+                            param.grad is not None
+                            and param.grad.data.data_ptr() != 0
+                        ):
+                            _tag_block(
+                                param.grad.data.data_ptr(),
+                                ComponentType.GRADIENT,
+                            )
+
+                    return _grad_hook
+
+                h = p.register_post_accumulate_grad_hook(_make_grad_hook(p))
+                tracker._add_handle(h)
+
+    def _forward_hook(module: nn.Module, args: Any, output: Any) -> None:
+        tracker._depth -= 1
+        if tracker._depth == 0:
+            # Forward pass complete — reset to OTHER so allocations outside
+            # model forward (e.g. loss computation) aren't tagged as ACTIVATION
+            _set_component_type(ComponentType.OTHER)
+            _set_memory_metadata("")
+
+    h_fwd_pre = nn.modules.module.register_module_forward_pre_hook(_forward_pre_hook)
+    h_fwd_post = nn.modules.module.register_module_forward_hook(_forward_hook)
+    tracker._add_handle(h_fwd_pre)
+    tracker._add_handle(h_fwd_post)
+
+    # --- (b) Global backward hooks: tag allocations as TEMP ---
+    # During backward, intermediate tensors (e.g. recomputed activations in
+    # checkpointing, gradient intermediates) are tagged as TEMP.
+
+    def _backward_pre_hook(module: nn.Module, grad_output: Any) -> None:
+        fqn = ""
+        if tracker._current_root is not None:
+            cache = getattr(tracker._current_root, "_fqn_cache", {})
+            fqn = cache.get(id(module), "")
+        # Allocations during backward are temporary intermediates
+        _set_component_type(ComponentType.TEMP)
+        _set_memory_metadata(fqn)
+
+    def _backward_post_hook(
+        module: nn.Module, grad_input: Any, grad_output: Any
+    ) -> None:
+        # Module's backward complete — reset so allocations between modules
+        # (e.g. autograd engine intermediates) fall back to OTHER
+        _set_component_type(ComponentType.OTHER)
+        _set_memory_metadata("")
+
+    h_bwd_pre = nn.modules.module.register_module_full_backward_pre_hook(
+        _backward_pre_hook
+    )
+    h_bwd_post = nn.modules.module.register_module_full_backward_hook(
+        _backward_post_hook
+    )
+    tracker._add_handle(h_bwd_pre)
+    tracker._add_handle(h_bwd_post)
+
+    # --- (c) Class-level optimizer hooks: tag OPTIMIZER_STATE ---
+    # Optimizer.step() allocates momentum/variance buffers on first call
+    # and updates them on subsequent calls. Tag all allocations during step
+    # as OPTIMIZER_STATE.
+
+    def _optimizer_pre_hook(
+        opt: torch.optim.Optimizer, args: Any, kwargs: Any
+    ) -> None:
+        _set_component_type(ComponentType.OPTIMIZER_STATE)
+        _set_memory_metadata("optimizer")
+
+    def _optimizer_post_hook(
+        opt: torch.optim.Optimizer, args: Any, kwargs: Any
+    ) -> None:
+        # Step complete — reset so allocations after optimizer.step()
+        # (e.g. zero_grad, next iteration) aren't tagged as optimizer state
+        _set_component_type(ComponentType.OTHER)
+        _set_memory_metadata("")
+
+    from torch.optim.optimizer import (
+        register_optimizer_step_post_hook,
+        register_optimizer_step_pre_hook,
+    )
+
+    h_opt_pre = register_optimizer_step_pre_hook(_optimizer_pre_hook)
+    h_opt_post = register_optimizer_step_post_hook(_optimizer_post_hook)
+    tracker._add_handle(h_opt_pre)
+    tracker._add_handle(h_opt_post)
+
+    # --- (d) Enable per-module tracking via AllocatorTraceTracker ---
+    _enable_module_tracking()
+
+    return tracker


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #182389
* __->__ #182388
* #182387

## Summary
This PR wires the allocator primitives from PR 1 into standard training via lightweight global hooks. Users call component_tracking.enable() once — no model or optimizer reference needed — and every allocation is automatically attributed.

## Design decisions
* Zero-argument enable() with auto-detection. Rather than requiring the user to pass model and optimizer, we use global hooks that detect these dynamically:
    * Root model detection: A depth counter tracks forward hook nesting. The outermost module (depth 0→1 transition) is the root. FQN cache is built lazily from it.
    * Class-level optimizer hooks: register_optimizer_step_pre_hook fires for ALL optimizer instances — no reference needed.
    * Lazy parameter tagging: Parameters and buffers are tagged on first forward visit per module, not upfront. This handles models created before or after enable().
* Separate sets for param tagging vs gradient hooking. _tagged_params tracks which parameters have been re-tagged as PARAMETER. _grad_hooked_params tracks which parameters have gradient accumulation hooks registered. These are separate because a parameter should be both tagged AND have a gradient hook.
* Component type lifecycle. Each hook pair (pre/post) forms a bracket:
    * Forward: ACTIVATION on pre → OTHER on post (when depth returns to 0)
    * Backward: TEMP on pre → OTHER on post
    * Optimizer: OPTIMIZER_STATE on pre → OTHER on post
* Resetting to OTHER on exit ensures allocations between phases (loss computation, data loading) don't get mis-attributed.
* Public API at torch.accelerator.memory.component_tracking — device-agnostic namespace, with the CUDA implementation as an internal detail. This positions the feature for future backend support without API changes.

## Assumptions
* Single-threaded Python driving training (GIL serializes hook execution).
* The depth counter assumes non-interleaved model forwards. Calling model_A.forward() then model_B.forward() sequentially works; interleaved partial forwards would confuse the depth tracking.

## Testing
* No unit tests so far
* Did a demo locally testing with DDP and FSDP on top of the final PR. The cost of enabling tracking is ~3-4% on throughput, mostly coming from python hooks. See the last PR for output.


