### PR TITLE
Collective buffer detection for DDP and FSDP

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1272,6 +1272,14 @@ static void registerCudaDeviceProperties(PyObject* module) {
     return c10::cuda::CUDACachingAllocator::isModuleTrackingEnabled();
   });
 
+  m.def("_cuda_enableCollectiveBufferTracking", []() {
+    torch::cuda::_enableCollectiveBufferTracking();
+  });
+
+  m.def("_cuda_disableCollectiveBufferTracking", []() {
+    torch::cuda::_disableCollectiveBufferTracking();
+  });
+
   m.def("_cuda_getModuleCounters", []() {
     return moduleCountersToPyDict(
         c10::cuda::CUDACachingAllocator::getModuleCounters());

--- a/torch/csrc/cuda/memory_snapshot.cpp
+++ b/torch/csrc/cuda/memory_snapshot.cpp
@@ -139,6 +139,84 @@ at::CallbackHandle _initRecordAnnotations(bool useGlobalCallback) {
           .scopes({at::RecordScope::USER_SCOPE}));
 }
 
+// Global state for the collective buffer callback, protected by mutex
+static std::mutex g_collective_mutex;
+static at::CallbackHandle g_collective_callback_handle{0};
+static bool g_collective_callback_active{false};
+
+// Observer context to save/restore component type around collective ops
+struct ComponentTypeContext : public at::ObserverContext {
+  uint8_t prev_type;
+  explicit ComponentTypeContext(uint8_t prev) : prev_type(prev) {}
+};
+
+// Check if a RecordFunction name corresponds to a collective operation scope
+// where buffer allocations should be tagged as COLLECTIVE_BUFFER.
+static bool isCollectiveScope(const std::string& name) {
+  // ProcessGroupNCCL collective ops (allreduce, allgather, etc.)
+  if (name == at::kParamCommsCallName) return true;
+  // DDP gradient bucket initialization
+  if (name.compare(0, strlen(kDDPBucketInitAnnotation), kDDPBucketInitAnnotation) == 0) return true;
+  // FSDP2 all-gather phases (copy_in allocates the buffer)
+  constexpr const char* kFSDPAllGather = "FSDP::all_gather";
+  if (name.compare(0, strlen(kFSDPAllGather), kFSDPAllGather) == 0) return true;
+  // FSDP2 reduce-scatter phases
+  constexpr const char* kFSDPReduceScatter = "FSDP::reduce_scatter";
+  if (name.compare(0, strlen(kFSDPReduceScatter), kFSDPReduceScatter) == 0) return true;
+  return false;
+}
+
+// Register a RecordFunctionCallback that intercepts collective operation
+// scopes (NCCL allreduce/allgather, DDP bucket init, FSDP all-gather/
+// reduce-scatter). When a collective scope is entered, the callback saves
+// the current component type and switches to COLLECTIVE_BUFFER. When the
+// scope exits, it restores the previous type. This way, any CUDA memory
+// allocated inside a collective operation is automatically attributed as
+// COLLECTIVE_BUFFER in the allocator's component_bytes stats.
+//
+// The callback is idempotent — calling enable when already active is a no-op.
+// Scopes: FUNCTION (for NCCL ops via record_param_comms) and USER_SCOPE
+// (for RECORD_FUNCTION annotations in DDP/FSDP).
+void enableCollectiveBufferTrackingImpl() {
+  std::lock_guard<std::mutex> lock(g_collective_mutex);
+  if (g_collective_callback_active) {
+    return;
+  }
+  g_collective_callback_handle = at::addGlobalCallback(
+      at::RecordFunctionCallback(
+          [](const at::RecordFunction& fn)
+              -> std::unique_ptr<at::ObserverContext> {
+            if (!isCollectiveScope(fn.name())) {
+              return nullptr;
+            }
+            auto prev = static_cast<uint8_t>(
+                c10::cuda::CUDACachingAllocator::getComponentType());
+            c10::cuda::CUDACachingAllocator::setComponentType(
+                c10::CachingDeviceAllocator::ComponentType::COLLECTIVE_BUFFER);
+            return std::make_unique<ComponentTypeContext>(prev);
+          },
+          [](const at::RecordFunction& /*fn*/,
+             at::ObserverContext* ctx_ptr) {
+            if (auto* ctx = dynamic_cast<ComponentTypeContext*>(ctx_ptr)) {
+              c10::cuda::CUDACachingAllocator::setComponentType(
+                  static_cast<c10::CachingDeviceAllocator::ComponentType>(
+                      ctx->prev_type));
+            }
+          })
+          .scopes({at::RecordScope::FUNCTION, at::RecordScope::USER_SCOPE}));
+  g_collective_callback_active = true;
+}
+
+void disableCollectiveBufferTrackingImpl() {
+  std::lock_guard<std::mutex> lock(g_collective_mutex);
+  if (!g_collective_callback_active) {
+    return;
+  }
+  at::removeCallback(g_collective_callback_handle);
+  g_collective_callback_handle = 0;
+  g_collective_callback_active = false;
+}
+
 at::CallbackHandle _initCompileContexts() {
   return at::addGlobalCallback(
       at::RecordFunctionCallback(
@@ -190,6 +268,14 @@ void setRecordFunctionCallbacks(
 }
 
 } // namespace
+
+void _enableCollectiveBufferTracking() {
+  enableCollectiveBufferTrackingImpl();
+}
+
+void _disableCollectiveBufferTracking() {
+  disableCollectiveBufferTrackingImpl();
+}
 
 void _record_memory_history(
     bool enabled,

--- a/torch/csrc/cuda/memory_snapshot.h
+++ b/torch/csrc/cuda/memory_snapshot.h
@@ -33,4 +33,13 @@ TORCH_CUDA_CU_API void _record_memory_history(
 
 TORCH_CUDA_CU_API std::string _memory_snapshot_pickled();
 
+TORCH_CUDA_CU_API void _enableCollectiveBufferTracking();
+TORCH_CUDA_CU_API void _disableCollectiveBufferTracking();
+
+// Annotation name used by DDP's reducer to tag bucket gradient allocations.
+// Used in reducer.cpp as RECORD_FUNCTION name and matched by
+// isCollectiveScope() in memory_snapshot.cpp.
+constexpr const char* kDDPBucketInitAnnotation =
+    "torch.distributed.ddp.reducer::initialize_bucket_gradients";
+
 } // namespace torch::cuda

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -13,6 +13,7 @@
 #include <torch/csrc/autograd/engine.h>
 #include <torch/csrc/autograd/function_hook.h>
 #include <torch/csrc/autograd/utils/grad_layout_contract.h>
+#include <torch/csrc/cuda/memory_snapshot.h>
 #include <torch/csrc/autograd/utils/lambda_post_hook.h>
 #include <torch/csrc/distributed/c10d/comm.hpp>
 #include <torch/csrc/distributed/c10d/logger.hpp>
@@ -1216,11 +1217,15 @@ void Reducer::initialize_buckets(
         LOG(INFO)
             << "Reducer: default comm backend not found, skipping bucket memory optimization";
       }
-      if (ddpDisableCommMem == 0 && backend != nullptr &&
+      if (!ddpDisableCommMem && backend != nullptr &&
           backend->supportsTensorAlloc(options.device().index())) {
         // Comm-optimized memory pool is available, use it to allocate tensor
         LOG(INFO)
             << "Reducer: found comm-optimized memory allocator, using it to create bucket";
+        // Tag bucket gradient allocations for memory component tracking
+        RECORD_FUNCTION(
+            torch::cuda::kDDPBucketInitAnnotation,
+            std::vector<c10::IValue>());
         bucket.gradients = backend->allocateTensor(bucketSize, options);
       } else {
         // Plain creation of tensor

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -1274,6 +1274,24 @@ def _get_module_counters() -> dict:
     return torch._C._cuda_getModuleCounters()
 
 
+def _enable_collective_buffer_tracking() -> None:
+    """Enable collective buffer tracking.
+
+    Registers a ``RecordFunctionCallback`` on ``RecordScope::FUNCTION`` that
+    detects NCCL collective operations (via ``RECORD_PARAM_COMMS``) and tags
+    their allocations as ``COLLECTIVE_BUFFER``. This covers DDP, FSDP, TP,
+    PP, and any other strategy that uses ProcessGroup collectives.
+    """
+    # pyrefly: ignore [missing-attribute]
+    torch._C._cuda_enableCollectiveBufferTracking()
+
+
+def _disable_collective_buffer_tracking() -> None:
+    """Disable collective buffer tracking."""
+    # pyrefly: ignore [missing-attribute]
+    torch._C._cuda_disableCollectiveBufferTracking()
+
+
 def _save_segment_usage(filename="output.svg", snapshot=None):
     if snapshot is None:
         snapshot = _snapshot()

--- a/torch/cuda/memory_component_tracker.py
+++ b/torch/cuda/memory_component_tracker.py
@@ -15,7 +15,9 @@ from typing import Any
 import torch
 import torch.nn as nn
 from torch.cuda.memory import (
+    _disable_collective_buffer_tracking,
     _disable_module_tracking,
+    _enable_collective_buffer_tracking,
     _enable_module_tracking,
     _set_component_type,
     _set_memory_metadata,
@@ -51,6 +53,7 @@ class ComponentTracker:
         _set_component_type(ComponentType.OTHER)
         _set_memory_metadata("")
         _disable_module_tracking()
+        _disable_collective_buffer_tracking()
         self._enabled = False
         self._depth = 0
         self._current_root = None
@@ -216,5 +219,8 @@ def _enable_auto() -> ComponentTracker:
 
     # --- (d) Enable per-module tracking via AllocatorTraceTracker ---
     _enable_module_tracking()
+
+    # --- (e) Enable collective buffer tracking via RecordFunctionCallback ---
+    _enable_collective_buffer_tracking()
 
     return tracker


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182389
* #182388
* #182387

## Summary
This PR automatically tags communication buffer allocations (allreduce, all-gather, reduce-scatter buffers) as COLLECTIVE_BUFFER without requiring changes to each distributed strategy's implementation. This is a change on FSDP codebase, and I expect there are other places where we would need similar changes. 

Also, haven’t looked into other parallelism strategies. I expect the parallelism experts to be able to leverage these primitives to enable tracking. 

## Design decisions
* Annotation-based detection via RecordFunctionCallback. Rather than modifying every collective implementation to call setComponentType(), we hook into the existing RecordFunction annotation system. When a collective scope is entered, the callback switches the thread-local component type to COLLECTIVE_BUFFER; on exit, it restores the previous type. This is strategy-agnostic — any code wrapped in a matching RECORD_FUNCTION annotation gets tagged automatically.
* Save/restore via ObserverContext. The callback saves the previous component type into a ComponentTypeContext object passed from the enter callback to the exit callback. This handles nested scopes correctly (e.g., a collective inside a forward hook — the forward's ACTIVATION type is restored after the collective completes).
* Three annotation patterns, one detection function:
    * record_param_comms — ProcessGroupNCCL's built-in annotation (covers all NCCL collectives for any strategy)
    * kDDPBucketInitAnnotation — DDP bucket allocation (shared constant between reducer.cpp and memory_snapshot.cpp)
    * FSDP::all_gather* / FSDP::reduce_scatter* — FSDP2's existing annotations (prefix match)
* Single change to DDP (reducer.cpp). A RECORD_FUNCTION wrapping the bucket tensor allocation inside the comm-optimized path. This is the only strategy-specific code change needed — everything else is detected via existing annotations.
* Scoped to FUNCTION + USER_SCOPE. The callback listens on both RecordScope::FUNCTION (where NCCL collectives fire) and RecordScope::USER_SCOPE (where RECORD_FUNCTION annotations fire). This ensures both automatic and manual annotations are captured.

## Assumptions
* NCCL collectives allocate their buffers synchronously within the record_param_comms scope. If a collective defers allocation to a CUDA callback, it would be missed.
* FSDP annotations (FSDP::all_gather, FSDP::reduce_scatter) are stable prefixes in FSDP2. If renamed, the prefix match would silently stop working.

## Testing
* No unit tests so far
* Did a demo locally testing with DDP and FSDP on top of this PR. The cost of enabling tracking is ~3-4% on throughput, mostly coming from python hooks.

## What do the new fields in memory_stats look like ?
```
component_bytes.* — global per-type breakdown:
component_bytes.parameter.current          = 16830976    (16.05 MB)
component_bytes.gradient.peak              = 16830976    (16.05 MB)
component_bytes.activation.peak            = 9043968     (8.63 MB)
component_bytes.optimizer_state.peak       = 50492928    (48.14 MB)
component_bytes.temp.peak                  = 17174528    (16.38 MB)
component_bytes.collective_buffer.*        = 0           (no distributed ops in single-GPU)

module_bytes.* — per-module per-component breakdown:
module_bytes.fc1.parameter.current         = 8396800     (8.01 MB)
module_bytes.fc1.activation.peak           = 9043968     (8.63 MB)
module_bytes.fc2.parameter.current         = 8392704     (8.00 MB)
module_bytes.fc2.temp.peak                 = 8654848     (8.25 MB)
module_bytes.fc3.parameter.current         = 41472       (40.5 KB)
module_bytes.optimizer.optimizer_state.peak = 50491512   (48.14 MB)
```
Each key follows the pattern {section}.{module_fqn}.{component}.{metric} where metric is one of current, peak, allocated, freed.



