### PR TITLE
[BE] Reduce build_vars duplication

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -16,15 +16,13 @@ GENERATED_LAZY_TS_CPP = [
     "lazy/generated/RegisterLazy.cpp",
 ]
 
-def libtorch_generated_sources(gencode_pattern, path_prefix="torch/csrc/"):
-    return [gencode_pattern.format(path_prefix + name) for name in [
-        "autograd/generated/Functions.cpp",
+def libtorch_generated_sources(gencode_pattern, path_prefix="torch/csrc/", only_type_vars=False):
+    type_vars = [
         "autograd/generated/VariableType_0.cpp",
         "autograd/generated/VariableType_1.cpp",
         "autograd/generated/VariableType_2.cpp",
         "autograd/generated/VariableType_3.cpp",
         "autograd/generated/VariableType_4.cpp",
-        "autograd/generated/ViewFuncs.cpp",
         "autograd/generated/TraceType_0.cpp",
         "autograd/generated/TraceType_1.cpp",
         "autograd/generated/TraceType_2.cpp",
@@ -32,7 +30,11 @@ def libtorch_generated_sources(gencode_pattern, path_prefix="torch/csrc/"):
         "autograd/generated/TraceType_4.cpp",
         "autograd/generated/ADInplaceOrViewType_0.cpp",
         "autograd/generated/ADInplaceOrViewType_1.cpp",
-    ]]
+    ] + ([] if only_type_varse slse [
+        "autograd/generated/Functions.cpp",
+        "autograd/generated/ViewFuncs.cpp",
+    ])
+    return [gencode_pattern.format(path_prefix + name) for name in type_vars]
 
 # copied from https://github.com/pytorch/pytorch/blob/f99a693cd9ff7a9b5fdc71357dac66b8192786d3/aten/src/ATen/core/CMakeLists.txt
 jit_core_headers = [

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -30,7 +30,7 @@ def libtorch_generated_sources(gencode_pattern, path_prefix="torch/csrc/", only_
         "autograd/generated/TraceType_4.cpp",
         "autograd/generated/ADInplaceOrViewType_0.cpp",
         "autograd/generated/ADInplaceOrViewType_1.cpp",
-    ] + ([] if only_type_varse slse [
+    ] + ([] if only_type_vars else [
         "autograd/generated/Functions.cpp",
         "autograd/generated/ViewFuncs.cpp",
     ])

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -256,19 +256,8 @@ set(GENERATED_CXX_TORCH
   )
 
 if(NOT INTERN_DISABLE_AUTOGRAD AND NOT BUILD_LITE_INTERPRETER)
+  append_filelist("libtorch_generated_sources('{}', only_type_vars=True)" GENERATED_CXX_TORCH)
   list(APPEND GENERATED_CXX_TORCH
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_0.cpp"
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_1.cpp"
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_2.cpp"
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_3.cpp"
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/VariableType_4.cpp"
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/TraceType_0.cpp"
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/TraceType_1.cpp"
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/TraceType_2.cpp"
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/TraceType_3.cpp"
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/TraceType_4.cpp"
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/ADInplaceOrViewType_0.cpp"
-    "${TORCH_SRC_DIR}/csrc/autograd/generated/ADInplaceOrViewType_1.cpp"
     "${TORCH_SRC_DIR}/csrc/inductor/aoti_torch/generated/c_shim_cpu.cpp"
     "${TORCH_SRC_DIR}/csrc/inductor/aoti_torch/generated/c_shim_aten.cpp"
   )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* __->__ #182390

Followup after https://github.com/pytorch/pytorch/pull/182202 - CMakeLists.txt should get filelist from build_variables, rather than defined it again