### PR TITLE
[aot_autograd] Genericize graphsafe RNG to support non-CUDA device backends

### DIFF
--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -90,7 +90,7 @@ from .schemas import (
 from .subclass_utils import compute_inner_mutated_inp_indices_from_subclass_meta
 from .utils import (
     contain_metadata_mutation_ops,
-    get_cuda_generator_meta_val,
+    get_default_generator,
     make_boxed_func,
     simple_wraps,
     strict_zip,
@@ -1907,7 +1907,9 @@ def _partition_joint_graph_into_fw_bw(
     ]
     fw_metadata.num_graphsafe_rng_states = len(rng_states)
     if rng_states:
-        fw_metadata.graphsafe_rng_state_index = rng_states[0].meta["val"].device.index
+        rng_device = rng_states[0].meta["val"].device
+        fw_metadata.graphsafe_rng_state_index = rng_device.index
+        fw_metadata.graphsafe_rng_device = rng_device
 
     return fw_module, bw_module, num_inner_fwd_outputs
 
@@ -2715,8 +2717,13 @@ def _aot_stage2b_compile_forward_or_inference(
                 raise AssertionError(
                     "fw_metadata.graphsafe_rng_state_index must not be None when num_graphsafe_rng_states > 0"
                 )
+            device = fw_metadata.graphsafe_rng_device
+            if device is None:
+                raise AssertionError(
+                    "fw_metadata.graphsafe_rng_device must not be None when num_graphsafe_rng_states > 0"
+                )
             rng_states = [
-                get_cuda_generator_meta_val(index)
+                get_default_generator(device).clone_state()
                 for _ in range(fw_metadata.num_graphsafe_rng_states)
             ]
             adjusted_flat_args.extend(rng_states)  # type: ignore[arg-type]

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2422,9 +2422,11 @@ def initialize_rng_states(
     graphsafe_idx: int,
     fwd_rng_states: list[torch.Generator],
     bwd_rng_states: list[torch.Generator],
+    *,
+    device: torch.device,
 ) -> None:
     """
-    Initialize the cudagraph safe rng states.
+    Initialize the graphsafe rng states.
 
     Initialization of rng states should have a few properties:
     - the initialization for each rng state should be independent
@@ -2436,23 +2438,16 @@ def initialize_rng_states(
     with preserve_rng_states. Seed initialization should advance the rng states so consecutive compilations
     do not give equal randomness.
     """
+    from .utils import get_default_generator
+
     with torch.utils._python_dispatch._disable_current_modes():
         seeds = torch.randint(0, torch.iinfo(torch.int64).max, (num_rng,), device="cpu")
+        generator = get_default_generator(device)
         fwd_rng_states.extend(
-            [
-                torch.cuda.default_generators[graphsafe_idx]
-                .clone_state()
-                .manual_seed(int(seeds[i]))
-                for i in range(num_rng)
-            ]
+            [generator.clone_state().manual_seed(int(seeds[i])) for i in range(num_rng)]
         )
         bwd_rng_states.extend(
-            [
-                torch.cuda.default_generators[graphsafe_idx]
-                .clone_state()
-                .manual_seed(int(seeds[i]))
-                for i in range(num_rng)
-            ]
+            [generator.clone_state().manual_seed(int(seeds[i])) for i in range(num_rng)]
         )
 
 
@@ -2715,6 +2710,7 @@ class _AutogradForwardEpilogue:
 class _AutogradRngStateTracker:
     num_rng: int
     graphsafe_idx: int | None
+    device: torch.device | None = None
     fwd_rng_states: list[torch.Generator] = field(default_factory=list)
     bwd_rng_states: list[torch.Generator] = field(default_factory=list)
     curr_fwd_iter: Any = field(default_factory=lambda: itertools.count(0))
@@ -2731,11 +2727,14 @@ class _AutogradRngStateTracker:
         if len(self.fwd_rng_states) == 0:
             if self.graphsafe_idx is None:
                 raise AssertionError("graphsafe_idx must not be None when num_rng > 0")
+            if self.device is None:
+                raise AssertionError("device must not be None when num_rng > 0")
             initialize_rng_states(
                 self.num_rng,
                 self.graphsafe_idx,
                 self.fwd_rng_states,
                 self.bwd_rng_states,
+                device=self.device,
             )
 
         curr_iter = next(self.curr_fwd_iter)
@@ -3261,6 +3260,7 @@ class _AOTDispatchAutogradFunctionFactory:
         rng_state = _AutogradRngStateTracker(
             num_rng=self.spec.fw_metadata.num_graphsafe_rng_states,
             graphsafe_idx=self.spec.fw_metadata.graphsafe_rng_state_index,
+            device=self.spec.fw_metadata.graphsafe_rng_device,
         )
         backward_compiler = _AutogradBackwardCompiler(
             compiled_bw=self.spec.compiled_bw_func,

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -529,6 +529,9 @@ class ViewAndMutationMeta:
 
     graphsafe_rng_state_index: int | None = None
 
+    # Device for graphsafe RNG states (supports CUDA, TPU, etc.)
+    graphsafe_rng_device: torch.device | None = None
+
     # Stream indices for mutated inputs in the epilogue
     # Maps from index in mutated_inp_runtime_indices to the stream index that last touched
     # the storage of the tensor that will be copied back into the original input

--- a/torch/_functorch/_aot_autograd/utils.py
+++ b/torch/_functorch/_aot_autograd/utils.py
@@ -716,15 +716,57 @@ def contain_metadata_mutation_ops(module: torch.fx.GraphModule) -> bool:
     return False
 
 
-def get_cuda_generator_meta_val(device_idx: int) -> Any:
-    """
-    Get a generator value to use as a meta val
+_GRAPHSAFE_RNG_DEVICE_TYPES: set[str] = {"cuda"}
 
-    newly cloned generator will not contain tensors. it is only Generators that are
-    registered to a CUDAGraph that contain tensors. since this does not contain Tensor
-    it is fine to use in the meta.
+
+def register_graphsafe_rng_device_type(device_type: str) -> None:
+    """Register a device type as supporting graphsafe RNG operations.
+
+    The device backend module (``torch.<device_type>``) must provide:
+    - ``_get_generator(device: torch.device) -> Generator``: return the default
+      generator for the given device. The generator must implement
+      ``graphsafe_get_state()``, ``graphsafe_set_state(state)``, and
+      ``clone_state()``.
+    - ``get_rng_state(device_index: int) -> Tensor``: return the current RNG
+      state tensor.
+
+    Args:
+        device_type: The device type string (e.g. "cuda", "xpu").
     """
-    return torch.cuda.default_generators[device_idx].clone_state()
+    from torch._prims.rng_prims import register_graphsafe_rng_dispatch
+
+    key_name = torch._C._dispatch_key_for_device(device_type)
+    dispatch_key = getattr(torch._C.DispatchKey, key_name)
+    _GRAPHSAFE_RNG_DEVICE_TYPES.add(device_type)
+    register_graphsafe_rng_dispatch(dispatch_key)
+
+
+def supports_graphsafe_rng(device: torch.device) -> bool:
+    """Check whether a device supports graphsafe RNG operations."""
+    return device.type in _GRAPHSAFE_RNG_DEVICE_TYPES
+
+
+def get_default_generator(device: torch.device) -> Any:
+    """Get the default RNG generator for a device.
+
+    Calls ``torch.<device_type>._get_generator(device)``.
+    """
+    device_mod = getattr(torch, device.type, None)
+    if device_mod is None or not hasattr(device_mod, "_get_generator"):
+        raise AssertionError(
+            f"Device type '{device.type}' does not implement _get_generator. "
+            f"Registered graphsafe RNG types: {sorted(_GRAPHSAFE_RNG_DEVICE_TYPES)}."
+        )
+    return device_mod._get_generator(device)
+
+
+def get_device_rng_state(device: torch.device) -> torch.Tensor:
+    """Get the RNG state tensor for a device."""
+    device_mod = getattr(torch, device.type, None)
+    if device_mod is not None and hasattr(device_mod, "get_rng_state"):
+        idx = device.index if device.index is not None else 0
+        return device_mod.get_rng_state(idx)
+    return torch.get_rng_state()
 
 
 def top_saved_tensors_hooks() -> Any:

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -74,7 +74,9 @@ from ._aot_autograd.utils import (
     _is_fwd_seed_offset,
     _is_primal,
     _is_tangent,
-    get_cuda_generator_meta_val,
+    get_default_generator,
+    get_device_rng_state,
+    supports_graphsafe_rng,
 )
 from .compile_utils import fx_graph_cse, get_aten_target, raise_getitems
 
@@ -1688,14 +1690,14 @@ def apply_graphsafe_rng_functionalization(
     # functionalization. See note above [CUDA Graph Safe RNG Functionalization]
     with fw_module.graph.inserting_after(last_fwd_input):
         fwd_rng_state = fw_module.graph.placeholder(f"fwd_rng_state_{rng_count}")
-        fwd_rng_state.meta["val"] = get_cuda_generator_meta_val(device_idx)
+        fwd_rng_state.meta["val"] = get_default_generator(device).clone_state()
         last_fwd_input = fwd_rng_state
 
     # Handle backward pass
     with bw_module.graph.inserting_after(last_bwd_input):
         bwd_rng_state = bw_module.graph.placeholder(f"bwd_rng_state_{rng_count}")
         # as above, clone so that meta val generator will not contain tensors
-        bwd_rng_state.meta["val"] = get_cuda_generator_meta_val(device_idx)
+        bwd_rng_state.meta["val"] = get_default_generator(device).clone_state()
         last_bwd_input = bwd_rng_state
 
     # Update forward node
@@ -1778,7 +1780,7 @@ def functionalize_rng_ops(
 
         for candidate in candidates:
             if isinstance(candidate, torch.Tensor):
-                if candidate.device.type == "cuda":
+                if supports_graphsafe_rng(candidate.device):
                     return candidate.device
 
         return torch.device("cpu")
@@ -1790,8 +1792,8 @@ def functionalize_rng_ops(
         if fake_mode is None:
             raise AssertionError("fake_mode must not be None")
         with fake_mode:
-            if device is not None and device.type == "cuda":
-                return fake_mode.from_tensor(torch.cuda.get_rng_state())
+            if device is not None and supports_graphsafe_rng(device):
+                return fake_mode.from_tensor(get_device_rng_state(device))
             return fake_mode.from_tensor(torch.get_rng_state())
 
     # Step 1 - Construct a mapping of rng node between the fwd and its counterpart in bwd.
@@ -1838,16 +1840,16 @@ def functionalize_rng_ops(
     )
     # pyrefly: ignore [unbound-name]
     devices.discard(torch.device("cpu"))
-    # multiple cuda devices won't work with cudagraphs anyway,
+    # multiple graphsafe devices won't work with cudagraphs anyway,
     # fallback to non graphsafe rng checkpointing
-    multi_cuda_devices = len(devices) > 1
+    multi_graphsafe_devices = len(devices) > 1
 
     # this changes numerics, so if fallback_random is set we will not use it
     # pyrefly: ignore [unbound-name]
     ind_config = torch._inductor.config
     use_rng_graphsafe_rng_functionalization = (
         config.graphsafe_rng_functionalization
-        and not multi_cuda_devices
+        and not multi_graphsafe_devices
         and (
             not ind_config.fallback_random
             or ind_config.test_configs.graphsafe_rng_func_ignores_fallback_random
@@ -1866,7 +1868,7 @@ def functionalize_rng_ops(
         if (
             use_rng_graphsafe_rng_functionalization
             and device is not None
-            and device.type == "cuda"
+            and supports_graphsafe_rng(device)
         ):
             last_fwd_input, last_bwd_input = apply_graphsafe_rng_functionalization(
                 fw_module,

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -140,15 +140,9 @@ def get_device(args, kwargs):
             device = torch.device(device)
         return device.type
 
-    devices = {arg.device.type for arg in args if isinstance(arg, torch.Tensor)}
-    if any(dev == "cuda" for dev in devices):
-        return "cuda"
-    elif any(dev == "xpu" for dev in devices):
-        return "xpu"
-    elif any(dev == "hpu" for dev in devices):
-        return "hpu"
-    elif any(dev == "cpu" for dev in devices):
-        return "cpu"
+    for arg in args:
+        if isinstance(arg, torch.Tensor):
+            return arg.device.type
     return None
 
 
@@ -320,6 +314,25 @@ run_and_save_rng_state = register_run_and_save_rng_state_op()
 run_with_rng_state = register_run_with_rng_state_op()
 
 
+def _impl_graphsafe_rng(op, *args, rng_state=None, **kwargs):
+    # pyrefly: ignore [missing-attribute]
+    device_idx = rng_state.device.index
+    device_type = rng_state.device.type  # pyrefly: ignore [missing-attribute]
+    device_mod = getattr(torch, device_type, None)
+    if device_mod is None or not hasattr(device_mod, "default_generators"):
+        raise AssertionError(
+            f"GraphSafe RNG operations not supported for device '{device_type}' "
+            f"(no torch.{device_type}.default_generators)"
+        )
+    generator = device_mod.default_generators[device_idx]
+    current_state = generator.graphsafe_get_state()
+
+    generator.graphsafe_set_state(rng_state)
+    out = op(*args, **kwargs)
+    generator.graphsafe_set_state(current_state)
+    return out
+
+
 def register_graphsafe_run_with_rng_state_op():
     class GraphSafeRunWithRngState(HigherOrderOperator):
         def __init__(self):
@@ -335,26 +348,17 @@ def register_graphsafe_run_with_rng_state_op():
         autograd_not_implemented(graphsafe_run_with_rng_state, deferred_error=True)
     )
 
-    @graphsafe_run_with_rng_state.py_impl(DispatchKey.CUDA)
-    def impl_cuda(op, *args, rng_state=None, **kwargs):
-        # pyrefly: ignore [missing-attribute]
-        device_idx = rng_state.device.index
-        generator = torch.cuda.default_generators[device_idx]
-        current_state = generator.graphsafe_get_state()
-
-        generator.graphsafe_set_state(rng_state)
-        out = op(*args, **kwargs)
-        generator.graphsafe_set_state(current_state)
-        return out
-
     @graphsafe_run_with_rng_state.py_impl(DispatchKey.BackendSelect)
     def impl_backend_select(op, *args, rng_state=None, **kwargs):
+        from torch._functorch._aot_autograd.utils import supports_graphsafe_rng
+
         device = get_device(args, kwargs)
-        if device != "cuda":
+        if device is None or not supports_graphsafe_rng(torch.device(device)):
             raise AssertionError(
-                f"GraphSafe RNG operations only supported for CUDA, got {device}"
+                f"GraphSafe RNG operations not supported for device '{device}'. "
+                f"Call register_graphsafe_rng_device_type('{device}') to register."
             )
-        return impl_cuda(op, *args, rng_state=rng_state, **kwargs)
+        return _impl_graphsafe_rng(op, *args, rng_state=rng_state, **kwargs)
 
     @graphsafe_run_with_rng_state.py_impl(FakeTensorMode)
     def impl_fake_tensor_mode(mode, op, *args, rng_state=None, **kwargs):
@@ -392,6 +396,20 @@ def register_graphsafe_run_with_rng_state_op():
 
 
 graphsafe_run_with_rng_state = register_graphsafe_run_with_rng_state_op()
+
+_registered_graphsafe_dispatch_keys: set["DispatchKey"] = set()
+
+
+def register_graphsafe_rng_dispatch(dispatch_key: "DispatchKey") -> None:
+    """Register graphsafe_run_with_rng_state py_impl for a dispatch key."""
+    if dispatch_key in _registered_graphsafe_dispatch_keys:
+        return
+    _registered_graphsafe_dispatch_keys.add(dispatch_key)
+    graphsafe_run_with_rng_state.py_impl(dispatch_key)(_impl_graphsafe_rng)
+
+
+# Register CUDA as a graphsafe RNG device by default
+register_graphsafe_rng_dispatch(DispatchKey.CUDA)
 
 
 # Late-bind OpaqueBaseMeta as Generator's metaclass. This is done here


### PR DESCRIPTION
Replace hardcoded CUDA-only graphsafe RNG operations with a device-generic approach using a registry pattern. Device backends (TPU, etc.) can opt in by calling `register_graphsafe_rng_device_type()` and providing `torch.<device_type>.default_generators` with `graphsafe_get/set_state()`.

Changes:
- Add registry (_GRAPHSAFE_RNG_DEVICE_TYPES) with CUDA registered by default
- Add helpers: get_default_generator(), get_generator_meta_val(), supports_graphsafe_rng(), get_device_rng_state()
- Add graphsafe_rng_device field to ViewAndMutationMeta schema
- Replace CUDA-specific code in partitioners.py, graph_compile.py, runtime_wrappers.py with generic device-based equivalents
- Register DispatchKey.PrivateUse1 for graphsafe_run_with_rng_state