### PR TITLE
Keep local_map forward/backward metadata consistent

### DIFF
--- a/test/higher_order_ops/test_local_map.py
+++ b/test/higher_order_ops/test_local_map.py
@@ -930,6 +930,9 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(mm_nodes[1].meta["custom"]["inside_local_map"], 1)
         self.assertEqual(mm_nodes[2].meta["custom"]["inside_local_map"], 1)
         self.assertEqual(mm_nodes[3].meta["custom"]["inside_local_map"], 0)
+        for node in joint_gm_inlined.graph.nodes:
+            if node.meta.get("partitioner_tag") == "is_backward":
+                self.assertTrue(node.meta.get("autograd_backward", False))
 
     @unittest.skipIf(*get_skip_reasons())
     def test_no_autograd_backward_metadata_on_inlined_forward_nodes(self):

--- a/test/higher_order_ops/test_local_map.py
+++ b/test/higher_order_ops/test_local_map.py
@@ -932,6 +932,52 @@ class GraphModule(torch.nn.Module):
         self.assertEqual(mm_nodes[3].meta["custom"]["inside_local_map"], 0)
 
     @unittest.skipIf(*get_skip_reasons())
+    def test_no_autograd_backward_metadata_on_inlined_forward_nodes(self):
+        placements = (Replicate(), Replicate(), Replicate(), Replicate())
+
+        @local_map(
+            out_placements=(placements,),
+            in_placements=(placements, placements),
+            redistribute_inputs=True,
+            in_grad_placements=None,
+            device_mesh=self.mesh,
+        )
+        def fn(x, w):
+            y = x @ w
+            y = y.view(2, 4, 16).permute(1, 0, 2).permute(1, 0, 2).reshape(8, 16)
+            return y + x
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = nn.Parameter(torch.randn(16, 16))
+
+            def forward(self, x):
+                return fn(x, self.w).sum()
+
+        def inputs_fn():
+            return (torch.randn(8, 16),)
+
+        with fx_traceback.preserve_node_meta():
+            joint_gm_deferred = ap_style_initial_capture(MyModule(), inputs_fn)
+            joint_inputs = [
+                n.meta["val"]
+                for n in joint_gm_deferred.graph.nodes
+                if n.op == "placeholder"
+            ]
+            joint_gm_inlined = make_fx(torch.fx.Interpreter(joint_gm_deferred).run)(
+                *joint_inputs
+            )
+
+        bad_nodes = [
+            n
+            for n in joint_gm_inlined.graph.nodes
+            if n.meta.get("partitioner_tag") == "is_forward"
+            and n.meta.get("autograd_backward", False)
+        ]
+        self.assertEqual(bad_nodes, [])
+
+    @unittest.skipIf(*get_skip_reasons())
     def test_local_map_make_contiguous_strides_for(self):
         # make_contiguous_strides_for inside local_map must compile with dynamic shapes.
         from torch._prims_common import make_contiguous_strides_for

--- a/torch/_higher_order_ops/local_map.py
+++ b/torch/_higher_order_ops/local_map.py
@@ -367,6 +367,7 @@ def create_hop_fw_bw(
         # default partitioner's assumptions.
         for node in new_fw_gm.graph.nodes:
             node.meta["partitioner_tag"] = "is_forward"
+            node.meta.pop("autograd_backward", None)
         for node in new_bw_gm.graph.nodes:
             node.meta["partitioner_tag"] = "is_backward"
 

--- a/torch/_higher_order_ops/local_map.py
+++ b/torch/_higher_order_ops/local_map.py
@@ -370,6 +370,7 @@ def create_hop_fw_bw(
             node.meta.pop("autograd_backward", None)
         for node in new_bw_gm.graph.nodes:
             node.meta["partitioner_tag"] = "is_backward"
+            node.meta["autograd_backward"] = True
 
         # Propagate meta onto fw/bw graphs, later will be set on proxied nodes
         new_fw_gm.meta["local_map_kwargs"] = local_map_kwargs


### PR DESCRIPTION
Fixes #182400.
Fixes #182416.

When `local_map` partitions a nested HOP graph, it force-retags the partitioned forward graph as `partitioner_tag="is_forward"` and the partitioned backward graph as `partitioner_tag="is_backward"`.

This PR keeps the metadata contract consistent at that boundary:

- clear stale `autograd_backward` metadata from the force-retagged forward graph
- set `autograd_backward=True` on the force-retagged backward graph

The forward-side stale metadata can make inlined forward nodes look like backward nodes. The backward-side missing metadata can fragment one logical backward partition for passes such as `remat_using_tags_for_fwd_loss_bwd_graph`, which currently uses `autograd_backward` to identify the backward region. #182416 has a standalone repro for that broader remat failure shape.

This keeps existing local_map FX annotation propagation intact.

Test plan:
- `lintrunner --config=.lintrunner.toml torch/_higher_order_ops/local_map.py test/higher_order_ops/test_local_map.py`
- `python -m pytest test/higher_order_ops/test_local_map.py::TestLocalMap::test_fx_annotations test/higher_order_ops/test_local_map.py::TestLocalMap::test_no_autograd_backward_metadata_on_inlined_forward_nodes -q`


cc @ydwu4 @penguinwu
