### PR TITLE
Fix CachingHostAllocator::free() not updating active stats

### DIFF
--- a/aten/src/ATen/core/CachingHostAllocator.h
+++ b/aten/src/ATen/core/CachingHostAllocator.h
@@ -385,6 +385,8 @@ struct CachingHostAllocatorImpl {
       auto index = size_index(block->size_);
       std::lock_guard<std::mutex> g(pool.free_list_[index].mutex_);
       pool.free_list_[index].list_.push_back(block);
+      stats_.active_bucket_stats[index].decrease(1);
+      stats_.active_bytes_bucket_stats[index].decrease(block->size_);
     } else if (allocated_during_capture) {
       // pass: No events are ever recorded during stream capture.
 
@@ -723,7 +725,7 @@ struct CachingHostAllocatorImpl {
         std::lock_guard<std::mutex> g(pool.free_list_[index].mutex_);
         pool.free_list_[index].list_.push_back(block);
         stats_.active_bucket_stats[index].decrease(1);
-        stats_.active_bytes_bucket_stats[index].decrease(size);
+        stats_.active_bytes_bucket_stats[index].decrease(block->size_);
         if (size != -1) {
           return;
         }

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -320,6 +320,37 @@ class TestCuda(TestCase):
 
         expected = empty_stats()
 
+    def test_host_memory_stats_free(self):
+        # Ensure a clean state
+        gc.collect()
+        torch._C._host_emptyCache()
+
+        # Allocate a pinned tensor
+        alloc_size = 10  # in 1024-element units
+        t = torch.ones(alloc_size * 1024, pin_memory=True)
+        self.assertTrue(t.is_pinned())
+
+        stats = torch.cuda.host_memory_stats()
+        allocated_size = stats["allocated_bytes.allocated"]
+
+        # active_bytes should be positive and freed should be 0
+        self.assertGreater(stats["active_bytes.current"], 0)
+        self.assertGreater(stats["active_requests.current"], 0)
+        self.assertEqual(stats["active_bytes.freed"], 0)
+        self.assertEqual(stats["active_requests.freed"], 0)
+
+        # Delete the tensor to trigger free()
+        del t
+        gc.collect()
+
+        stats = torch.cuda.host_memory_stats()
+
+        # After free, active_bytes.current should be 0 and freed should be updated
+        self.assertEqual(stats["active_bytes.current"], 0)
+        self.assertEqual(stats["active_requests.current"], 0)
+        self.assertEqual(stats["active_bytes.freed"], allocated_size)
+        self.assertEqual(stats["active_requests.freed"], 1)
+
     def test_pinned_memory_empty_cache(self):
         try:
             for alloc_settings in (True, False):


### PR DESCRIPTION
The free() function was missing decrease() calls in the code path where a block has no associated stream events. This caused host_memory_stats() active_bytes.freed and active_bytes.current to never be updated after pinned memory tensors were freed.