### PR TITLE
Fix torch.compile wrong output shape for norm() with negative dim

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2988,6 +2988,32 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         x = torch.randn(1000, device=device_type, dtype=torch.float32) + 0.1
         self.common(fn, [x])
 
+    def test_vector_norm_negative_dim_size_one(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/182181
+        def fn(x):
+            return x.norm(dim=-1)
+
+        x = torch.rand(8, 3, 1, device=device_type)
+        self.common(fn, [x])
+
+        # Multiple negative dims, all size 1
+        def fn2(x):
+            return x.norm(dim=(-2, -1))
+
+        y = torch.rand(8, 1, 1, device=device_type)
+        self.common(fn2, [y])
+
+        # torch.linalg.vector_norm directly
+        def fn3(x):
+            return torch.linalg.vector_norm(x, dim=-1)
+
+        self.common(fn3, [x])
+
+        def fn4(x):
+            return torch.linalg.vector_norm(x, dim=(-2, -1))
+
+        self.common(fn4, [y])
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_refs/linalg/__init__.py
+++ b/torch/_refs/linalg/__init__.py
@@ -168,6 +168,8 @@ def vector_norm(
         is_ord_even = ord % 2 == 0 if isinstance(ord, IntLike) else ord % 2.0 == 0.0
         if dim == []:
             dim = None
+        elif dim is not None:
+            dim = utils.canonicalize_dims(x.ndim, dim)
 
         if (dim is None and guard_or_false(x.numel() == 1)) or (
             dim is not None


### PR DESCRIPTION
The `vector_norm` decomposition has a fast path for when the reduced dimensions all have size 1 (just abs + reshape). This path built the output shape by filtering out dims using `d not in dim`, but `dim` could contain negative indices (e.g. -1) while `enumerate` produces positive indices (0, 1, 2...), so the comparison never matched and the dimension was incorrectly retained in the output.

Canonicalize dim to positive indices before entering the fast path.

Fixes #182181

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo