### PR TITLE
Fix misleading error when caching_allocator_alloc size overflows ssize_t

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -386,6 +386,10 @@ print(t.is_pinned())
         with self.assertRaisesRegex(ValueError, "Invalid memory size"):
             torch.cuda.memory.caching_allocator_alloc(-1024)
 
+    def test_caching_allocator_alloc_overflow(self):
+        with self.assertRaises(OverflowError):
+            torch.cuda.memory.caching_allocator_alloc(2**63, device=0)
+
     def test_memory_stats(self):
         gc.collect()
         torch.cuda.empty_cache()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -390,6 +390,10 @@ print(t.is_pinned())
         with self.assertRaises(OverflowError):
             torch.cuda.memory.caching_allocator_alloc(2**63, device=0)
 
+    def test_caching_allocator_alloc_invalid_type(self):
+        with self.assertRaises(TypeError):
+            torch.cuda.memory.caching_allocator_alloc(1 + 2j, device=0)
+
     def test_memory_stats(self):
         gc.collect()
         torch.cuda.empty_cache()

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -297,6 +297,9 @@ PyObject* THCPModule_cudaCachingAllocator_raw_alloc(
     return nullptr;
   }
   auto size = PyLong_AsSsize_t(size_o);
+  if (size == -1 && PyErr_Occurred()) {
+    return nullptr;
+  }
   TORCH_CHECK_VALUE(
       size >= 0,
       "Invalid memory size: ",


### PR DESCRIPTION
When a Python integer larger than SSIZE_MAX (e.g. 2**63) is passed to caching_allocator_alloc, `PyLong_AsSsize_t` returns -1 and sets an `OverflowError`. Without checking for this, the code falls through to TORCH_CHECK_VALUE which reports "Invalid memory size: -1" — hiding the real issue (integer overflow) behind a confusing message.

Add the standard Python C-API overflow check so the proper OverflowError propagates to the caller.

Fixes https://github.com/pytorch/pytorch/issues/182277