### PR TITLE
[Inductor/CuteDSL] Trim broadcast dims in ModificationWrapperCuteDSL.load

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -1107,6 +1107,69 @@ class TestFlexFlash(InductorTestCase):
 
     @xfailIfSM120OrLater
     @dtypes(torch.float16, torch.bfloat16)
+    def test_flash_attention_broadcast_capture(self, device, dtype):
+        """Regression test for the cute MLIR layout-rank mismatch when a
+        captured tensor's physical rank is smaller than the indexing
+        context rank (e.g. via .unsqueeze(0) broadcasting).
+
+        Pattern:
+            masks = rule_masks_per_query & prefix_mask.unsqueeze(0)
+            def mask_mod(b, h, q_idx, kv_idx):
+                return masks[q_idx, b, kv_idx]
+
+        rule_masks_per_query is 3-D (Q,B,KV); prefix_mask is 2-D (B,KV)
+        but appears 3-D after unsqueeze. Without the rank-trim logic in
+        ModificationWrapperCuteDSL.load, cute rejects the 3-coord access
+        on prefix_mask's 2-D layout with `expects coordinate to be weakly
+        congruent to the layout`.
+        """
+        B, H, Q_LEN, KV_LEN, D = 2, 4, 256, 512, 128
+
+        def model(q, k, v, rule_masks_per_query, prefix_mask, backend=None):
+            masks = rule_masks_per_query & prefix_mask.unsqueeze(0)
+
+            def mask_mod(b, h, q_idx, kv_idx):
+                return masks[q_idx, b, kv_idx]
+
+            block_mask = create_block_mask(
+                mask_mod,
+                B=B,
+                H=None,
+                Q_LEN=Q_LEN,
+                KV_LEN=KV_LEN,
+                device=device,
+            )
+            kernel_options = {"BACKEND": backend} if backend else {}
+            return flex_attention(
+                q,
+                k,
+                v,
+                block_mask=block_mask,
+                kernel_options=kernel_options,
+            )
+
+        q = torch.randn(B, H, Q_LEN, D, device=device, dtype=dtype)
+        k = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
+        v = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
+        rule_masks = torch.randint(
+            0, 2, (Q_LEN, B, KV_LEN), dtype=torch.bool, device=device
+        )
+        prefix = torch.randint(0, 2, (B, KV_LEN), dtype=torch.bool, device=device)
+
+        ref = model(q.float(), k.float(), v.float(), rule_masks, prefix)
+        torch._dynamo.reset()
+        triton_out = torch.compile(model, dynamic=False)(
+            q, k, v, rule_masks, prefix, "TRITON"
+        )
+        torch._dynamo.reset()
+        flash_out = torch.compile(model, dynamic=False)(
+            q, k, v, rule_masks, prefix, "FLASH"
+        )
+        torch.testing.assert_close(triton_out, ref.to(dtype), atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(flash_out, ref.to(dtype), atol=1e-2, rtol=1e-2)
+
+    @xfailIfSM120OrLater
+    @dtypes(torch.float16, torch.bfloat16)
     def test_flash_attention_kernel_called(self, device, dtype):
         q, k, v = create_test_tensors(dtype=dtype, device=device)
         compiled_fn = torch.compile(flex_attention)

--- a/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_kernel.py
@@ -502,15 +502,28 @@ class ModificationWrapperCuteDSL(V.WrapperHandler):  # type: ignore[name-defined
             cute_dtype = CuteDSLOpOverrides.TORCH_TO_CUTE_DTYPE.get(
                 var_dtype, "cutlass.Float32"
             )
+            dim_indices = (
+                list(index.args) if isinstance(index, HierarchicalIndex) else [index]
+            )
+            # The HierarchicalIndex may carry more coords than the captured
+            # buffer's physical rank when an outer-graph view (e.g.
+            # `.unsqueeze(0)`) inserted broadcast dims. Those broadcast dims
+            # have stride 0 in the underlying buffer and contribute nothing
+            # to the actual address. Trim the leading coords so the emitted
+            # `var[c0, c1, ...]` access has the same rank as the buffer's
+            # cute layout — otherwise cute's MLIR layout checker rejects the
+            # load with `expects coordinate to be weakly congruent to the
+            # layout`.
+            buffer_rank = len(buffer.get_size())
+            if len(dim_indices) > buffer_rank:
+                dim_indices = dim_indices[len(dim_indices) - buffer_rank :]
             idx_vars = [
                 self._emit_scalar_fragment(
                     self.kernel.kexpr(self.kernel.rename_indexing(dim_index)),
                     "cutlass.Int32",
                     torch.int32,
                 )
-                for dim_index in (
-                    index.args if isinstance(index, HierarchicalIndex) else (index,)
-                )
+                for dim_index in dim_indices
             ]
 
             val_frag = self.kernel.cse.newvar(dtype=var_dtype)

--- a/torch/_inductor/codegen/cutedsl/cutedsl_template.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_template.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from typing import Any
 from unittest.mock import patch
 
-from torch._inductor.utils import Placeholder
+from torch._inductor.utils import Placeholder, unique
 from torch._inductor.virtualized import V
 from torch._logging import getArtifactLogger
 
@@ -90,6 +90,21 @@ class CuteDSLTemplate(KernelTemplate):
             code = kernel.render(self.template, **kwargs)
 
             log.debug("Generated CuteDSL Code:\n%s", code)
+
+            # Append captured closure buffers discovered during rendering
+            input_call_args = tuple(kernel.args.input_buffers.keys())
+            expected_input_args = tuple(unique(x.get_name() for x in input_nodes))
+            assert input_call_args[: len(expected_input_args)] == expected_input_args, (
+                input_call_args,
+                expected_input_args,
+            )
+            if len(input_call_args) > len(expected_input_args):
+                kernel_input_nodes = tuple(
+                    V.graph.get_buffer(k) for k in input_call_args
+                )
+                input_nodes = list(input_nodes) + list(
+                    kernel_input_nodes[len(expected_input_args) :]
+                )
 
             bmreq = CuteDSLBenchmarkRequest(
                 kernel_name=kernel_name,

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -278,6 +278,10 @@ def flex_attention(
         num_score_mod_placeholders=len(placeholder_inps),
         backend=backend,
     ):
+        score_mod_other_buffers = maybe_realize(score_mod_other_buffers)
+        mask_mod_other_buffers = maybe_realize(mask_mod_other_buffers)
+        freeze_irnodes(score_mod_other_buffers)
+        freeze_irnodes(mask_mod_other_buffers)
         return create_flex_flash_attention_kernel(
             query,
             key,


### PR DESCRIPTION
### Background and stack

Stacked on #182002 (cherry-picked as the precursor commit on this branch). #182002 fixes the wrapper-level `UnboundLocalError` on captured `mask_mod` tensors by reconciling `kernel.args.input_buffers` with `TemplateBuffer.inputs` post-render, plus realizing the captures up front. With #182002 alone, compilation now reaches the cute kernel — at which point this latent multi-dim layout bug surfaces.

I'll rebase to drop the `[PRECURSOR]` commit once #182002 lands.

### What does this PR do

When a `mask_mod` / `score_mod` captures a tensor whose **physical rank** is smaller than the **indexing context rank** — typical pattern: `prefix_mask.unsqueeze(0)` is broadcast to the rank of an outer 3-D mask used by `mask_mod` — `CuteDSLTemplateKernel.modification` emits a multi-coord cute access using *all* coords from the `HierarchicalIndex`. cute's MLIR layout checker rejects the load:

```
loc(...): error: expects coordinate to be weakly congruent to the layout,
                 but got '!cute.coord<"(?,?,?)">'
ValueError: Operation creation failed
```

because the captured buffer's cute layout has rank `N` but the coord has rank `R > N`.

This PR trims the leading `R - N` coords from the index before emitting the access. Those leading coords correspond to broadcast dims (stride 0 in the underlying buffer) and contribute nothing to the actual address. The trailing `N` coords address the buffer's real dims and match the cute layout.

```diff
@@ ModificationWrapperCuteDSL.load (cutedsl_kernel.py)
-            idx_vars = [
-                self._emit_scalar_fragment(...)
-                for dim_index in (
-                    index.args if isinstance(index, HierarchicalIndex) else (index,)
-                )
-            ]
+            dim_indices = (
+                list(index.args) if isinstance(index, HierarchicalIndex) else [index]
+            )
+            # Trim leading broadcast dims so coord rank == buffer rank.
+            buffer_rank = len(buffer.get_size())
+            if len(dim_indices) > buffer_rank:
+                dim_indices = dim_indices[len(dim_indices) - buffer_rank :]
+            idx_vars = [
+                self._emit_scalar_fragment(...)
+                for dim_index in dim_indices
+            ]
```


### Repro

The bug pattern: a `mask_mod` whose captured tensor has lower rank than the indexing context. Minimal:

```python
import torch
from torch.nn.attention.flex_attention import create_block_mask, flex_attention

device = "cuda"
dtype = torch.bfloat16
B, H, Q_LEN, KV_LEN, D = 2, 4, 256, 512, 128

def model(q, k, v, rule_masks_per_query, prefix_mask):
    masks = rule_masks_per_query & prefix_mask.unsqueeze(0)   # logical 3-D, prefix is 2-D + broadcast

    def mask_mod(b, h, q_idx, kv_idx):
        return masks[q_idx, b, kv_idx]

    block_mask = create_block_mask(
        mask_mod, B=B, H=None, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device=device,
    )
    return flex_attention(
        q, k, v, block_mask=block_mask,
        kernel_options={"BACKEND": "FLASH"},
    )

q = torch.randn(B, H, Q_LEN, D, device=device, dtype=dtype)
k = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
v = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
rule_masks = torch.randint(0, 2, (Q_LEN, B, KV_LEN), dtype=torch.bool, device=device)
prefix     = torch.randint(0, 2, (B, KV_LEN), dtype=torch.bool, device=device)

torch.compile(model, dynamic=False)(q, k, v, rule_masks, prefix)
```

`prefix_mask` is `b8[2, 512]` (2-D). The unsqueeze + broadcast makes `masks` logically `b8[256, 2, 512]` (3-D). `mask_mod` indexes it with 3 coords. Inductor's cutedsl path lifts both `arg0_1` (prefix_mask) and `arg1_1` (rule_masks_per_query) into the kernel's `aux_tensors`. The mask body emitted is:

```python
def mask_mod(b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
    in_ptr8 = aux_tensors[0]   # arg1_1, shape (256, 2, 512)
    in_ptr9 = aux_tensors[1]   # arg0_1, shape (2, 512)
    ...
    tmp6[0] = (in_ptr8[tmp3, tmp4, tmp5])    # 3-coord on 3-D buffer — fine
    ...
    tmp11[0] = (in_ptr9[tmp8, tmp9, tmp10])  # 3-coord on 2-D buffer — fails
```

cute rejects the second access because the captured tensor's cute layout (built via `to_cute_aux_tensor` → `from_dlpack(...).mark_layout_dynamic()`) has rank 2, but the coord is rank 3.

After this PR:

```python
    tmp10[0] = (in_ptr9[tmp8, tmp9])         # 2-coord, matches 2-D layout
```

The kernel runs to completion and the output matches the Triton backend numerically.

### Test

`test/inductor/test_flex_flash.py::test_flash_attention_broadcast_capture` (sibling of `test_flash_attention_shared_captured_buffers` from #182002):

- Reuses the broadcast-capture pattern from this PR's repro.
- Compares eager fp32, compiled `BACKEND="TRITON"`, and compiled `BACKEND="FLASH"`. All three must match within bf16 tolerance.
- Gated `@xfailIfSM120OrLater` and `@dtypes(torch.float16, torch.bfloat16)`, matching the surrounding tests.

The test fails on `main` (with #182002 applied) with the cute layout-check error and passes after this PR.

### What I verified locally

On a SM90 H100 (cuda 13.0, torch nightly `2.13.0.dev`+`#182002`+this PR):

- `pytest test/inductor/test_flex_flash.py::TestFlexFlash::test_flash_attention_broadcast_capture -k "bfloat16"` — pass, both compile paths produce numerically-equivalent output to fp32 reference.
- The minimal `mask_mod` repro above runs cleanly on `BACKEND='FLASH'` and matches `BACKEND='TRITON'` to bf16 tolerance (max abs diff < 1e-2).
- Inspected the generated cutedsl kernel: `mask_mod` body emits the expected per-buffer rank — 3 coords for the 3-D `arg1_1`, 2 coords for the 2-D `arg0_1`.
- The pre-existing `test_flash_attention_shared_captured_buffers` (added in #182002) still passes — this PR doesn't regress that path.

### Files changed

- `torch/_inductor/codegen/cutedsl/cutedsl_kernel.py` (+15 / −3): the rank trim in `ModificationWrapperCuteDSL.load`.
- `test/inductor/test_flex_flash.py` (+64): regression test.

### Related

- Fixes the secondary cutedsl crash exposed by #182002 once that PR resolves the upstream UnboundLocalError. Together they handle the full DV365-style `mask_mod` broadcast-capture pattern.


