### PR TITLE
fix(decomp): cast padding to int in replication/reflection pad decomposition

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1540,6 +1540,15 @@ class TestTorchDeviceType(TestCase):
                     self.assertEqual(grad, input.grad, atol=0, rtol=0)
                 input.grad = None
 
+    def test_deterministic_replication_pad_tensor_padding(self, device):
+        # gh-182339: 0-d int64 tensor in padding tuple should not crash
+        x = torch.randn(2, 1, 16, device=device)
+        extra_padding = torch.tensor(4, dtype=torch.int64, device=device)
+        with DeterministicGuard(True):
+            result = torch.nn.functional.pad(x, (4, extra_padding), mode='replicate')
+        expected = torch.nn.functional.pad(x, (4, 4), mode='replicate')
+        self.assertEqual(result, expected)
+
     @skipIfTorchInductor("https://github.com/pytorch/pytorch/issues/113707")
     def test_deterministic_interpolate_bilinear(self, device):
         input = torch.randn(1, 2, 4, 4, device=device, requires_grad=True)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5165,8 +5165,8 @@ def _reflection_or_replication_pad(
     inp_shape = a.shape[-dim:]
     nc_dim = a.dim() - dim
 
-    padding_left = [padding[2 * (dim - 1 - i)] for i in range(dim)]
-    padding_right = [padding[2 * (dim - 1 - i) + 1] for i in range(dim)]
+    padding_left = [int(padding[2 * (dim - 1 - i)]) for i in range(dim)]
+    padding_right = [int(padding[2 * (dim - 1 - i) + 1]) for i in range(dim)]
 
     result = a
     for i in range(dim):
@@ -5189,8 +5189,8 @@ def _reflection_pad_backward(grad_output, x, padding):
 
     dhw = [h - 1 for h in x.shape[-dim:]]
 
-    padding_left = [padding[2 * (dim - 1 - i)] for i in range(dim)]
-    padding_right = [padding[2 * (dim - 1 - i) + 1] for i in range(dim)]
+    padding_left = [int(padding[2 * (dim - 1 - i)]) for i in range(dim)]
+    padding_right = [int(padding[2 * (dim - 1 - i) + 1]) for i in range(dim)]
 
     indices = []
     for i in range(x.ndim):


### PR DESCRIPTION
## Summary

Fixes #182339

When `use_deterministic_algorithms(True)` routes `F.pad(mode='replicate')` through the decomposition path, `@pw_cast_for_opmath` promotes **all** tensor arguments -- including 0-d int64 padding elements in the padding tuple -- to float via `increase_prec`. The resulting float index tensor from `torch.arange(-left, middle + right)` is then rejected by `aten._unsafe_index` with:

```
RuntimeError: _unsafe_index found unexpected index type Float
```

The fix casts padding elements to Python `int` before use in `_reflection_or_replication_pad` (and `_reflection_pad_backward`). `int()` is a no-op for regular Python ints and calls `.item()` implicitly for 0-d tensors (whether int64 or float-promoted).

## Repro (from the issue)

```python
import torch
import torch.nn.functional as F

torch.use_deterministic_algorithms(True)
x = torch.randn(2, 1, 16000, device='cuda')
extra_padding = torch.tensor(320, dtype=torch.int64, device='cuda')
F.pad(x, (320, extra_padding), mode='replicate')  # crashes before fix
```

## Test plan

- Added `test_deterministic_replication_pad_tensor_padding` that passes a 0-d int64 tensor in the padding tuple under deterministic mode
- Verified existing `test_deterministic_replication_pad2d` still passes