### PR TITLE
[c10d] Apply record_comm names to NCCL launch annotations

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -71,6 +71,32 @@ inline bool isUnsupportedFloat8(at::ScalarType t) {
   );
 }
 
+template <typename Fn>
+ncclResult_t runNcclWithCommProfilingName(
+    at::cuda::CUDAStream& ncclStream,
+    c10::ArrayRef<at::Tensor> inputs,
+    Fn&& fn) {
+  const auto& commProfilingName = get_comm_profiling_name();
+  if (commProfilingName.empty()) {
+    return fn();
+  }
+
+  at::cuda::CUDAStreamGuard guard(ncclStream);
+  at::RecordFunction recordingFunction(at::RecordScope::USER_SCOPE);
+  if (recordingFunction.isActive()) {
+    std::vector<c10::IValue> recordInputs;
+    recordInputs.reserve(inputs.size());
+    for (const auto& input : inputs) {
+      recordInputs.emplace_back(input);
+    }
+    recordingFunction.before(
+        std::string(commProfilingName),
+        c10::ArrayRef<const c10::IValue>(
+            recordInputs.data(), recordInputs.size()));
+  }
+  return fn();
+}
+
 #ifdef ENABLE_NCCL_PREMUL_SUM_SUPPORT
 template <typename T, ncclDataType_t dataType>
 ncclRedOpRAII unpackPreMulSum(
@@ -579,7 +605,12 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(
     bool enableTiming,
     bool cudaEventCacheEnabled,
     DebugLevel distDebugLevel)
-    : Work(rank, opType, profilingTitle, inputs),
+    : Work(
+          rank,
+          opType,
+          profilingTitle,
+          inputs,
+          /*allowProfilingNameOverride=*/false),
       pgUID_(std::move(pgUID)),
       pgDesc_(std::move(pgDesc)),
       device_(device),
@@ -610,7 +641,12 @@ ProcessGroupNCCL::WorkNCCL::WorkNCCL(
 }
 
 ProcessGroupNCCL::WorkNCCL::WorkNCCL(const WorkNCCL& w)
-    : Work(w.rank_, w.opType_),
+    : Work(
+          w.rank_,
+          w.opType_,
+          nullptr,
+          std::nullopt,
+          /*allowProfilingNameOverride=*/false),
       std::enable_shared_from_this<WorkNCCL>(w),
       pgUID_(w.pgUID_),
       pgDesc_(w.pgDesc_),
@@ -3895,11 +3931,17 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collective(
 // or removing input and output from lambda's signature).
 #ifndef NCCL_HAS_COMM_NONBLOCKING
   C10D_NCCL_CHECK(
-      fn(inputs[0], outputs[0], comm, ncclStream),
+      runNcclWithCommProfilingName(
+          ncclStream,
+          inputs,
+          [&]() { return fn(inputs[0], outputs[0], comm, ncclStream); }),
       ncclComm->getNcclCommFailureReason());
 #else
   C10D_NCCL_CHECK_TIMEOUT(
-      fn(inputs[0], outputs[0], comm, ncclStream),
+      runNcclWithCommProfilingName(
+          ncclStream,
+          inputs,
+          [&]() { return fn(inputs[0], outputs[0], comm, ncclStream); }),
       ncclComm,
       ncclComm->getNcclCommFailureReason());
 #endif // NCCL_HAS_COMM_NONBLOCKING
@@ -4065,13 +4107,20 @@ c10::intrusive_ptr<Work> ProcessGroupNCCL::collectiveCoalesced(
   {
     torch::cuda::nccl::AutoNcclGroup nccl_group_guard(comm, useNonblocking());
     for (const auto i : c10::irange(inputs.size())) {
+      c10::ArrayRef<at::Tensor> profiledInputs(inputs.data() + i, 1);
 #ifndef NCCL_HAS_COMM_NONBLOCKING
       C10D_NCCL_CHECK(
-          fn(inputs[i], outputs[i], comm, ncclStream),
+          runNcclWithCommProfilingName(
+              ncclStream,
+              profiledInputs,
+              [&]() { return fn(inputs[i], outputs[i], comm, ncclStream); }),
           ncclComm->getNcclCommFailureReason());
 #else
       C10D_NCCL_CHECK_TIMEOUT(
-          fn(inputs[i], outputs[i], comm, ncclStream),
+          runNcclWithCommProfilingName(
+              ncclStream,
+              profiledInputs,
+              [&]() { return fn(inputs[i], outputs[i], comm, ncclStream); }),
           ncclComm,
           ncclComm->getNcclCommFailureReason());
 #endif // NCCL_HAS_COMM_NONBLOCKING

--- a/torch/csrc/distributed/c10d/Work.cpp
+++ b/torch/csrc/distributed/c10d/Work.cpp
@@ -38,11 +38,13 @@ Work::Work(
     int rank,
     OpType opType,
     const char* profilingTitle,
-    const std::optional<std::vector<at::Tensor>>& inputTensors)
+    const std::optional<std::vector<at::Tensor>>& inputTensors,
+    bool allowProfilingNameOverride)
     : rank_(rank), opType_(opType) {
   // comm_profiling_name is thread-local; take a local copy so the
   // RecordFunction owns the string (the TLS can be mutated after we return).
-  const bool use_tls_name =
+  // Backends that profile the communication launch separately can opt out.
+  const bool use_tls_name = allowProfilingNameOverride &&
       comm_profiling_name != nullptr && !comm_profiling_name->empty();
   if (use_tls_name || profilingTitle != nullptr) {
     auto recordingFunction =

--- a/torch/csrc/distributed/c10d/Work.hpp
+++ b/torch/csrc/distributed/c10d/Work.hpp
@@ -59,8 +59,8 @@ class TORCH_API Work : public torch::CustomClassHolder {
       int rank = -1,
       OpType opType = OpType::UNKNOWN,
       const char* profilingTitle = nullptr,
-      const std::optional<std::vector<at::Tensor>>& inputTensors =
-          std::nullopt);
+      const std::optional<std::vector<at::Tensor>>& inputTensors = std::nullopt,
+      bool allowProfilingNameOverride = true);
 
   ~Work() override;
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -6588,10 +6588,10 @@ def _update_process_group_global_state(
 def record_comm(name: str):
     """Context manager to set a custom profiling name for communication collectives.
 
-    When active, all c10d collectives issued within this context will use ``name``
-    as their profiling title in the Work base class, overriding the default
-    backend-specific name (e.g. ``nccl:all_reduce``). This works across all
-    backends without per-backend or per-collective changes.
+    When active, c10d collectives issued within this context will use ``name``
+    as their profiling title. Backends may apply the name to the Work base class
+    range or to backend-specific launch annotations, such as NCCL collectives
+    enqueued on CUDA streams.
 
     Args:
         name (str): The profiling name to associate with collectives.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182415

record_comm currently overrides the Work profiler range name. For NCCL async work, that long Work lifetime range can span unrelated compute in traces. Keep NCCL Work lifetime ranges using their backend names and apply the record_comm name at the NCCL enqueue site under the NCCL stream guard instead.

This keeps the user-provided communication FQN on the CUDA stream annotation without creating a long default-stream annotation around later compute.

Test Plan:

python test/distributed/test_c10d_common.py RecordCommTest

torchrun --standalone --nproc_per_node=2 profiler_traces/dump_flex_shard_transformer_trace.py