### PR TITLE
Tag partitioned backward graph nodes with autograd_backward

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -6116,6 +6116,82 @@ class TestPartitioning(AOTTestCase):
         if not torch.allclose(ref_b.grad, res_b.grad, atol=1e-3, rtol=1e-3):
             raise AssertionError("ref_b.grad and res_b.grad not allclose")
 
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_partitioned_backward_nodes_are_backward_tagged(self):
+        from torch._functorch.partitioners import CheckpointPolicy
+
+        def run(partition_fn):
+            bw_gm = None
+
+            def fw_compiler(gm, _):
+                return make_boxed_func(gm.forward)
+
+            def bw_compiler(gm, _):
+                nonlocal bw_gm
+                bw_gm = gm
+                return make_boxed_func(gm.forward)
+
+            def fn(x):
+                y = torch.sin(x)
+                return torch.cos(y).sum()
+
+            x = torch.randn(4, 4, requires_grad=True)
+            compiled_fn = aot_function(
+                fn,
+                fw_compiler=fw_compiler,
+                bw_compiler=bw_compiler,
+                partition_fn=partition_fn,
+            )
+
+            compiled_fn(x).backward()
+
+            if bw_gm is None:
+                raise AssertionError("backward graph was not captured")
+
+            backward_nodes = [
+                node
+                for node in bw_gm.graph.nodes
+                if node.op in ("call_function", "get_attr")
+            ]
+            self.assertTrue(backward_nodes)
+            self.assertTrue(
+                all(
+                    node.meta.get("autograd_backward", False) for node in backward_nodes
+                )
+            )
+            return bw_gm
+
+        run(default_partition)
+
+        def min_cut_with_forced_recompute(joint_gm, joint_inputs, **kwargs):
+            for node in joint_gm.graph.nodes:
+                if node.op == "call_function" and node.target in {
+                    torch.ops.aten.sin.default,
+                    torch.ops.aten.cos.default,
+                }:
+                    node.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
+            return min_cut_rematerialization_partition(joint_gm, joint_inputs, **kwargs)
+
+        bw_gm = run(min_cut_with_forced_recompute)
+        forward_origin_recomputed_nodes = [
+            node
+            for node in bw_gm.graph.nodes
+            if node.op == "call_function"
+            and node.target
+            in {
+                torch.ops.aten.sin.default,
+                torch.ops.aten.cos.default,
+            }
+            and node.meta.get("partitioner_tag") == "is_forward"
+        ]
+        self.assertTrue(forward_origin_recomputed_nodes)
+        self.assertTrue(
+            all(
+                node.meta.get("autograd_backward", False)
+                for node in forward_origin_recomputed_nodes
+            )
+        )
+
     def test_meta_tensor_inplace_op(self):
         # Following module results in inplace ops while tracing. The test checks
         # that the meta tensor information is stored for inplace ops.

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1210,6 +1210,10 @@ def _extract_fwd_bwd_modules(
             ignore_must_be_in_fw_bw=ignore_must_be_in_fw_bw,
         )
 
+    for node in bwd_graph.nodes:
+        if node.op in ("call_function", "get_attr"):
+            node.meta["autograd_backward"] = True
+
     fwd_module = fx._lazy_graph_module._make_graph_module(joint_module, fwd_graph)
     bwd_module = fx._lazy_graph_module._make_graph_module(joint_module, bwd_graph)
     if (


### PR DESCRIPTION
Fixes #182420.

When AOTAutograd partitioning extracts the backward graph, it copies nodes from
the joint graph with `Graph.node_copy()`. That preserves the original node
metadata, which means nodes copied into the backward graph can still be missing
`autograd_backward` in the extracted backward graph.

This updates `_extract_fwd_bwd_modules()`, the shared default/min-cut partitioner
path that builds the final backward module, to tag copied `call_function` and
`get_attr` nodes with `autograd_backward=True`. This keeps the generic
`_extract_graph_with_inputs_outputs()` helper unchanged and tags metadata only
where we know the graph being produced is the backward module.

The added test checks both `default_partition` and
`min_cut_rematerialization_partition`. For min-cut, it additionally forces
`sin`/`cos` to be recomputed and verifies that forward-origin recomputed nodes in
the backward graph carry `autograd_backward`.

Test Plan:
- `python test/functorch/test_aotdispatch.py -k test_partitioned_backward_nodes_are_backward_tagged`
- `lintrunner --config=.lintrunner.toml torch/_functorch/partitioners.py test/functorch/test_aotdispatch.py`
