### PR TITLE
Warning oversized storage copy

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4592,7 +4592,7 @@ class TestSerialization(TestCase, SerializationMixin):
         t_view = t[1:3]
         with self.assertWarnsRegex(UserWarning, "Deepcopying or serializing this tensor view will include its full underlying storage"):
             copy.deepcopy(t_view)
-        
+
         if hasattr(_warn_oversized_storage_copy, "has_warned"):
             _warn_oversized_storage_copy.__dict__["has_warned"] = False
         with warnings.catch_warnings():

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -27,6 +27,7 @@ from unittest.mock import patch
 
 import torch
 from torch.utils.serialization import config as serialization_config
+from torch._tensor import _warn_oversized_storage_copy
 from torch._subclasses.fake_tensor import FakeTensorMode, FakeTensorConverter
 from torch._utils import _rebuild_tensor
 from torch._utils_internal import get_file_path_2
@@ -4583,6 +4584,54 @@ class TestSerialization(TestCase, SerializationMixin):
 
         with self.assertWarnsRegex(UserWarning, "meta device under skip_data context manager is a no-op"):
             _save_load(t)
+
+    def test_deepcopy_warns_on_oversized_storage_view(self):
+        if hasattr(_warn_oversized_storage_copy, "has_warned"):
+            _warn_oversized_storage_copy.__dict__["has_warned"] = False
+        t = torch.randn(10)
+        t_view = t[1:3]
+        with self.assertWarnsRegex(UserWarning, "Deepcopying or serializing this tensor view will include its full underlying storage"):
+            copy.deepcopy(t_view)
+        
+        if hasattr(_warn_oversized_storage_copy, "has_warned"):
+            _warn_oversized_storage_copy.__dict__["has_warned"] = False
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", "Deepcopying or serializing this tensor view will include its full underlying storage", UserWarning)
+            copy.deepcopy(t)
+
+    @parametrize("skip_data_var", (True, False))
+    def test_serialization_warns_on_oversized_storage_view(self, skip_data_var):
+        if hasattr(_warn_oversized_storage_copy, "has_warned"):
+            _warn_oversized_storage_copy.__dict__["has_warned"] = False
+        ctx_skip = skip_data if skip_data_var else contextlib.nullcontext
+        t = torch.randn(10)
+        t_view = t[1:3]
+        with BytesIOContext() as f:
+            with warnings.catch_warnings():
+                if skip_data_var:
+                    warnings.filterwarnings(
+                        "error",
+                        "Deepcopying or serializing this tensor view will include its full underlying storage",
+                        UserWarning,
+                    )
+                    with ctx_skip():
+                        torch.save(t_view, f)
+                else:
+                    with self.assertWarnsRegex(
+                        UserWarning,
+                        "Deepcopying or serializing this tensor view will include its full underlying storage",
+                    ):
+                        with ctx_skip():
+                            torch.save(t_view, f)
+
+    def test_serialization_no_warning_on_non_view(self):
+        t = torch.randn(10)
+        if hasattr(_warn_oversized_storage_copy, "has_warned"):
+            _warn_oversized_storage_copy.__dict__["has_warned"] = False
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", "Deepcopying or serializing this tensor view will include its full underlying storage", UserWarning)
+            with BytesIOContext() as f:
+                torch.save(t, f)
 
     @parametrize("force_weights_only", (True, False))
     def test_weights_only_env_variables(self, force_weights_only):

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -64,7 +64,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils._import_utils import import_dill
 from pickle import UnpicklingError
-
+from torch._dynamo.utils import warn_once_cache
 
 if not IS_WINDOWS:
     from mmap import MAP_PRIVATE, MAP_SHARED
@@ -4586,52 +4586,50 @@ class TestSerialization(TestCase, SerializationMixin):
             _save_load(t)
 
     def test_deepcopy_warns_on_oversized_storage_view(self):
-        if hasattr(_warn_oversized_storage_copy, "has_warned"):
-            _warn_oversized_storage_copy.__dict__["has_warned"] = False
-        t = torch.randn(10)
-        t_view = t[1:3]
-        with self.assertWarnsRegex(UserWarning, "Deepcopying or serializing this tensor view will include its full underlying storage"):
-            copy.deepcopy(t_view)
+        with patch("torch._dynamo.utils.warn_once_cache", set()):
+            t = torch.randn(10)
+            t_view = t[1:3]
+            with self.assertWarnsRegex(UserWarning, "Deepcopying or serializing this tensor view will include its full underlying storage"):
+                copy.deepcopy(t_view)
 
-        if hasattr(_warn_oversized_storage_copy, "has_warned"):
-            _warn_oversized_storage_copy.__dict__["has_warned"] = False
-        with warnings.catch_warnings():
-            warnings.filterwarnings("error", "Deepcopying or serializing this tensor view will include its full underlying storage", UserWarning)
-            copy.deepcopy(t)
+    def test_deepcopy_no_warning_on_non_view(self):
+        with patch("torch._dynamo.utils.warn_once_cache", set()):
+            t = torch.randn(10)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("error", "Deepcopying or serializing this tensor view will include its full underlying storage", UserWarning)
+                copy.deepcopy(t)
 
     @parametrize("skip_data_var", (True, False))
     def test_serialization_warns_on_oversized_storage_view(self, skip_data_var):
-        if hasattr(_warn_oversized_storage_copy, "has_warned"):
-            _warn_oversized_storage_copy.__dict__["has_warned"] = False
-        ctx_skip = skip_data if skip_data_var else contextlib.nullcontext
-        t = torch.randn(10)
-        t_view = t[1:3]
-        with BytesIOContext() as f:
-            with warnings.catch_warnings():
-                if skip_data_var:
-                    warnings.filterwarnings(
-                        "error",
-                        "Deepcopying or serializing this tensor view will include its full underlying storage",
-                        UserWarning,
-                    )
-                    with ctx_skip():
-                        torch.save(t_view, f)
-                else:
-                    with self.assertWarnsRegex(
-                        UserWarning,
-                        "Deepcopying or serializing this tensor view will include its full underlying storage",
-                    ):
+        with patch("torch._dynamo.utils.warn_once_cache", set()):
+            ctx_skip = skip_data if skip_data_var else contextlib.nullcontext
+            t = torch.randn(10)
+            t_view = t[1:3]
+            with BytesIOContext() as f:
+                with warnings.catch_warnings():
+                    if skip_data_var:
+                        warnings.filterwarnings(
+                            "error",
+                            "Deepcopying or serializing this tensor view will include its full underlying storage",
+                            UserWarning,
+                        )
                         with ctx_skip():
                             torch.save(t_view, f)
+                    else:
+                        with self.assertWarnsRegex(
+                            UserWarning,
+                            "Deepcopying or serializing this tensor view will include its full underlying storage",
+                        ):
+                            with ctx_skip():
+                                torch.save(t_view, f)
 
     def test_serialization_no_warning_on_non_view(self):
-        t = torch.randn(10)
-        if hasattr(_warn_oversized_storage_copy, "has_warned"):
-            _warn_oversized_storage_copy.__dict__["has_warned"] = False
-        with warnings.catch_warnings():
-            warnings.filterwarnings("error", "Deepcopying or serializing this tensor view will include its full underlying storage", UserWarning)
-            with BytesIOContext() as f:
-                torch.save(t, f)
+        with patch("torch._dynamo.utils.warn_once_cache", set()):
+            t = torch.randn(10)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("error", "Deepcopying or serializing this tensor view will include its full underlying storage", UserWarning)
+                with BytesIOContext() as f:
+                    torch.save(t, f)
 
     @parametrize("force_weights_only", (True, False))
     def test_weights_only_env_variables(self, force_weights_only):

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -64,7 +64,6 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils._import_utils import import_dill
 from pickle import UnpicklingError
-from torch._dynamo.utils import warn_once_cache
 
 if not IS_WINDOWS:
     from mmap import MAP_PRIVATE, MAP_SHARED

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -99,30 +99,32 @@ def _dtype_to_typestr(dtype):
         torch.bool: "|b1",
     }[dtype]
 
+
 def _check_and_warn_oversized_storage_copy(tensor, stacklevel=2):
     if not torch._C._has_storage(tensor):
         return
     storage_size = tensor._typed_storage().size()
     tensor_size = tensor.numel()
     if storage_size > tensor_size:
-        _warn_oversized_storage_copy(tensor_size, storage_size, stacklevel=stacklevel+1)
+        _warn_oversized_storage_copy(
+            tensor_size, storage_size, stacklevel=stacklevel + 1
+        )
 
 
 def _warn_oversized_storage_copy(view_size, storage_size, stacklevel=2):
-
     def is_first_time():
         if not hasattr(_warn_oversized_storage_copy, "has_warned"):
             return True
         else:
             return not _warn_oversized_storage_copy.__dict__["has_warned"]
-        
+
     if is_first_time():
         message = (
             f"Deepcopying or serializing this tensor view will include its full underlying storage ({storage_size} elements) "
             f"while the tensor view contains {view_size} elements. Consider using tensor.clone() before "
             "serialization or deepcopy if this is not intended."
         )
-        warnings.warn(message, UserWarning, stacklevel=stacklevel+1)
+        warnings.warn(message, UserWarning, stacklevel=stacklevel + 1)
         _warn_oversized_storage_copy.__dict__["has_warned"] = True
 
 

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -99,6 +99,32 @@ def _dtype_to_typestr(dtype):
         torch.bool: "|b1",
     }[dtype]
 
+def _check_and_warn_oversized_storage_copy(tensor, stacklevel=2):
+    if not torch._C._has_storage(tensor):
+        return
+    storage_size = tensor._typed_storage().size()
+    tensor_size = tensor.numel()
+    if storage_size > tensor_size:
+        _warn_oversized_storage_copy(tensor_size, storage_size, stacklevel=stacklevel+1)
+
+
+def _warn_oversized_storage_copy(view_size, storage_size, stacklevel=2):
+
+    def is_first_time():
+        if not hasattr(_warn_oversized_storage_copy, "has_warned"):
+            return True
+        else:
+            return not _warn_oversized_storage_copy.__dict__["has_warned"]
+        
+    if is_first_time():
+        message = (
+            f"Deepcopying or serializing this tensor view will include its full underlying storage ({storage_size} elements) "
+            f"while the tensor view contains {view_size} elements. Consider using tensor.clone() before "
+            "serialization or deepcopy if this is not intended."
+        )
+        warnings.warn(message, UserWarning, stacklevel=stacklevel+1)
+        _warn_oversized_storage_copy.__dict__["has_warned"] = True
+
 
 # NB: If you subclass Tensor, and want to share the subclassed class
 # across processes, you must also update torch/multiprocessing/reductions.py
@@ -179,6 +205,7 @@ class Tensor(torch._C.TensorBase):
                         "different type."
                     )
             else:
+                _check_and_warn_oversized_storage_copy(self, stacklevel=3)
                 new_storage = self._typed_storage()._deepcopy(memo)
                 if self.is_quantized:
                     # quantizer_params can be different type based on torch attribute
@@ -394,6 +421,8 @@ class Tensor(torch._C.TensorBase):
                 raise RuntimeError(
                     f"Serialization is not supported for tensors of type {self.qscheme()}"
                 )
+            if not skip_data:
+                _check_and_warn_oversized_storage_copy(self, stacklevel=5)
             # TODO: Once we decide to break serialization FC, no longer
             # need to wrap with TypedStorage
             args_qtensor = (
@@ -504,6 +533,8 @@ class Tensor(torch._C.TensorBase):
             )
             return (torch._utils._rebuild_wrapper_subclass, arg_wrapper_subclass)
         else:
+            if not skip_data:
+                _check_and_warn_oversized_storage_copy(self, stacklevel=5)
             v3_dtypes = torch.storage._new_dtypes()
             if self.dtype in v3_dtypes:
                 rebuild_func = torch._utils._rebuild_tensor_v3

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -107,25 +107,18 @@ def _check_and_warn_oversized_storage_copy(tensor, stacklevel=2):
     tensor_size = tensor.numel()
     if storage_size > tensor_size:
         _warn_oversized_storage_copy(
-            tensor_size, storage_size, stacklevel=stacklevel + 1
+            stacklevel=stacklevel + 1
         )
 
 
-def _warn_oversized_storage_copy(view_size, storage_size, stacklevel=2):
-    def is_first_time():
-        if not hasattr(_warn_oversized_storage_copy, "has_warned"):
-            return True
-        else:
-            return not _warn_oversized_storage_copy.__dict__["has_warned"]
-
-    if is_first_time():
-        message = (
-            f"Deepcopying or serializing this tensor view will include its full underlying storage ({storage_size} elements) "
-            f"while the tensor view contains {view_size} elements. Consider using tensor.clone() before "
-            "serialization or deepcopy if this is not intended."
-        )
-        warnings.warn(message, UserWarning, stacklevel=stacklevel + 1)
-        _warn_oversized_storage_copy.__dict__["has_warned"] = True
+def _warn_oversized_storage_copy(stacklevel=2):
+    from torch._dynamo.utils import warn_once
+    message = (
+        f"Deepcopying or serializing this tensor view will include its full underlying storage"
+        f"which may result in an oversized serialized file or copy. Consider using tensor.clone() before "
+        "serialization or deepcopy if this is not intended and preserving storage sharing is not required."
+    )
+    warn_once(message, stacklevel=stacklevel + 1)
 
 
 # NB: If you subclass Tensor, and want to share the subclassed class


### PR DESCRIPTION
Adresses #182105.

Multiple users have reported confusion regarding tensor view serialization, where the full underlying storage is serialized instead of just the viewed data (#122099, #95278, #65604, #1995). While this behavior is intentional (to preserve storage sharing semantics), it is often surprising and can lead to unintentionally large serialized objects.

This PR introduces a `UserWarning` to help detect such cases and improve user experience. The warning is triggered when the underlying storage size is larger than the tensor’s logical size. The same behavior applies to `copy.deepcopy`.

A helper function `_check_and_warn_oversized_storage_copy` performs this check and emits the warning once globally to avoid excessive noise in workloads where many small views are serialized.

The warning is not emitted under the `torch.serialization.skip_data` context.

@mruberry @mikaylagawarecki 