### PR TITLE
[reland][xpu][test] Port distributed checkpoint test cases on Intel GPU

### DIFF
--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -1,18 +1,21 @@
 # Owner(s): ["oncall: distributed checkpointing"]
 
+import unittest
 from concurrent.futures import Future
 
 import torch
-import unittest
 from torch.distributed.checkpoint._experimental.staging import (
     CheckpointStagerConfig,
     DefaultStager,
 )
-from torch.testing._internal.common_utils import requires_cuda, run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, TestCase
+
 
 requires_gpu = unittest.skipUnless(
     torch.cuda.is_available() or torch.xpu.is_available(), "requires cuda or xpu"
 )
+
+
 class TestDefaultStager(TestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -9,7 +9,7 @@ from torch.distributed.checkpoint._experimental.staging import (
     DefaultStager,
 )
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import run_tests, TestCase, TEST_ACCELERATOR
+from torch.testing._internal.common_utils import run_tests, TEST_ACCELERATOR, TestCase
 
 
 class TestDefaultStager(TestCase):

--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -25,7 +25,7 @@ class TestDefaultStager(TestCase):
             "nested": {"inner_tensor": torch.ones(2, 2), "inner_value": 42},
         }
 
-    @skipIf(not TEST_ACCELERATOR)
+    @skipIf(not TEST_ACCELERATOR, reason="requires GPU")
     def test_sync_staging(self) -> None:
         """Test synchronous staging."""
         options = CheckpointStagerConfig(use_async_staging=False)
@@ -48,7 +48,7 @@ class TestDefaultStager(TestCase):
         # Clean up
         stager.close()
 
-    @skipIf(not TEST_ACCELERATOR)
+    @skipIf(not TEST_ACCELERATOR, reason="requires GPU")
     def test_async_staging(self) -> None:
         """Test asynchronous staging."""
         options = CheckpointStagerConfig(use_async_staging=True)
@@ -144,7 +144,7 @@ class TestDefaultStager(TestCase):
 
                 stager.close()
 
-    @skipIf(not TEST_ACCELERATOR)
+    @skipIf(not TEST_ACCELERATOR, reason="requires GPU")
     def test_cuda_tensors_staging(self) -> None:
         """Test staging with CUDA tensors."""
         # Create state dict with CUDA tensors
@@ -172,7 +172,7 @@ class TestDefaultStager(TestCase):
 
         stager.close()
 
-    @skipIf(not TEST_ACCELERATOR)
+    @skipIf(not TEST_ACCELERATOR, reason="requires GPU")
     def test_resource_cleanup(self) -> None:
         """Test that resources are properly cleaned up."""
         options = CheckpointStagerConfig(use_async_staging=False)

--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -3,13 +3,16 @@
 from concurrent.futures import Future
 
 import torch
+import unittest
 from torch.distributed.checkpoint._experimental.staging import (
     CheckpointStagerConfig,
     DefaultStager,
 )
 from torch.testing._internal.common_utils import requires_cuda, run_tests, TestCase
 
-
+requires_gpu = unittest.skipUnless(
+    torch.cuda.is_available() or torch.xpu.is_available(), "requires cuda or xpu"
+)
 class TestDefaultStager(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -23,7 +26,7 @@ class TestDefaultStager(TestCase):
             "nested": {"inner_tensor": torch.ones(2, 2), "inner_value": 42},
         }
 
-    @requires_cuda
+    @requires_gpu
     def test_sync_staging(self) -> None:
         """Test synchronous staging."""
         options = CheckpointStagerConfig(use_async_staging=False)
@@ -46,7 +49,7 @@ class TestDefaultStager(TestCase):
         # Clean up
         stager.close()
 
-    @requires_cuda
+    @requires_gpu
     def test_async_staging(self) -> None:
         """Test asynchronous staging."""
         options = CheckpointStagerConfig(use_async_staging=True)
@@ -72,7 +75,7 @@ class TestDefaultStager(TestCase):
 
     def test_cuda_non_blocking_without_cuda(self) -> None:
         """Test that non-blocking copy fails when CUDA is not available."""
-        if torch.cuda.is_available():
+        if torch.accelerator.is_available():
             self.skipTest("CUDA is available, cannot test CUDA unavailable scenario")
 
         options = CheckpointStagerConfig(use_non_blocking_copy=True)
@@ -142,16 +145,17 @@ class TestDefaultStager(TestCase):
 
                 stager.close()
 
-    @requires_cuda
+    @requires_gpu
     def test_cuda_tensors_staging(self) -> None:
         """Test staging with CUDA tensors."""
         # Create state dict with CUDA tensors
+        device = torch.accelerator.current_accelerator()
         cuda_state_dict = {
-            "cuda_tensor": torch.randn(3, 4).cuda(),
+            "cuda_tensor": torch.randn(3, 4).to(device),
             "cpu_tensor": torch.randn(2, 3),
             "mixed_model": {
-                "weight": torch.randn(5, 5).cuda(),
-                "bias": torch.randn(5).cuda(),
+                "weight": torch.randn(5, 5).to(device),
+                "bias": torch.randn(5).to(device),
             },
         }
 
@@ -169,7 +173,7 @@ class TestDefaultStager(TestCase):
 
         stager.close()
 
-    @requires_cuda
+    @requires_gpu
     def test_resource_cleanup(self) -> None:
         """Test that resources are properly cleaned up."""
         options = CheckpointStagerConfig(use_async_staging=False)

--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -1,15 +1,15 @@
 # Owner(s): ["oncall: distributed checkpointing"]
 
-from unittest import skipIf
 from concurrent.futures import Future
+from unittest import skipIf
 
 import torch
 from torch.distributed.checkpoint._experimental.staging import (
     CheckpointStagerConfig,
     DefaultStager,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase, TEST_ACCELERATOR
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase, TEST_ACCELERATOR
 
 
 class TestDefaultStager(TestCase):
@@ -217,9 +217,7 @@ class TestDefaultStager(TestCase):
         stager.close()
 
 
-instantiate_device_type_tests(
-    TestDefaultStager, globals(), allow_xpu=True
-)
+instantiate_device_type_tests(TestDefaultStager, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/_experimental/test_staging.py
+++ b/test/distributed/checkpoint/_experimental/test_staging.py
@@ -1,6 +1,6 @@
 # Owner(s): ["oncall: distributed checkpointing"]
 
-import unittest
+from unittest import skipIf
 from concurrent.futures import Future
 
 import torch
@@ -8,12 +8,8 @@ from torch.distributed.checkpoint._experimental.staging import (
     CheckpointStagerConfig,
     DefaultStager,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
-
-
-requires_gpu = unittest.skipUnless(
-    torch.cuda.is_available() or torch.xpu.is_available(), "requires cuda or xpu"
-)
+from torch.testing._internal.common_utils import run_tests, TestCase, TEST_ACCELERATOR
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
 
 class TestDefaultStager(TestCase):
@@ -29,7 +25,7 @@ class TestDefaultStager(TestCase):
             "nested": {"inner_tensor": torch.ones(2, 2), "inner_value": 42},
         }
 
-    @requires_gpu
+    @skipIf(not TEST_ACCELERATOR)
     def test_sync_staging(self) -> None:
         """Test synchronous staging."""
         options = CheckpointStagerConfig(use_async_staging=False)
@@ -52,7 +48,7 @@ class TestDefaultStager(TestCase):
         # Clean up
         stager.close()
 
-    @requires_gpu
+    @skipIf(not TEST_ACCELERATOR)
     def test_async_staging(self) -> None:
         """Test asynchronous staging."""
         options = CheckpointStagerConfig(use_async_staging=True)
@@ -148,7 +144,7 @@ class TestDefaultStager(TestCase):
 
                 stager.close()
 
-    @requires_gpu
+    @skipIf(not TEST_ACCELERATOR)
     def test_cuda_tensors_staging(self) -> None:
         """Test staging with CUDA tensors."""
         # Create state dict with CUDA tensors
@@ -176,7 +172,7 @@ class TestDefaultStager(TestCase):
 
         stager.close()
 
-    @requires_gpu
+    @skipIf(not TEST_ACCELERATOR)
     def test_resource_cleanup(self) -> None:
         """Test that resources are properly cleaned up."""
         options = CheckpointStagerConfig(use_async_staging=False)
@@ -220,6 +216,10 @@ class TestDefaultStager(TestCase):
 
         stager.close()
 
+
+instantiate_device_type_tests(
+    TestDefaultStager, globals(), allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -512,11 +512,7 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 class TestNoCPU(DTensorTestBase):
     @property
     def backend(self):
-        return (
-            torch.distributed.distributed_c10d.Backend.default_device_backend_map.get(
-                torch.accelerator.current_accelerator().type
-            )
-        )
+        return "nccl"
 
     @with_comms
     def test_no_cpu(self):

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -512,7 +512,8 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 class TestNoCPU(DTensorTestBase):
     @property
     def backend(self):
-        return "nccl"
+        return torch.distributed.distributed_c10d.Backend.default_device_backend_map.get(
+            torch.accelerator.current_accelerator().type)
 
     @with_comms
     def test_no_cpu(self):

--- a/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
+++ b/test/distributed/checkpoint/e2e/test_e2e_save_and_load.py
@@ -512,8 +512,11 @@ class TestE2ESaveAndLoad(DTensorTestBase, VerifyStateDictMixin):
 class TestNoCPU(DTensorTestBase):
     @property
     def backend(self):
-        return torch.distributed.distributed_c10d.Backend.default_device_backend_map.get(
-            torch.accelerator.current_accelerator().type)
+        return (
+            torch.distributed.distributed_c10d.Backend.default_device_backend_map.get(
+                torch.accelerator.current_accelerator().type
+            )
+        )
 
     @with_comms
     def test_no_cpu(self):

--- a/test/distributed/checkpoint/test_checkpoint.py
+++ b/test/distributed/checkpoint/test_checkpoint.py
@@ -44,9 +44,7 @@ from torch.testing._internal.distributed._shard.sharded_tensor import (
 
 
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-backend = torch.distributed.distributed_c10d.Backend.default_device_backend_map.get(
-    device_type
-)
+backend = torch.distributed.get_default_backend_for_device(device_type)
 
 
 if TEST_WITH_DEV_DBG_ASAN:

--- a/test/distributed/checkpoint/test_checkpoint.py
+++ b/test/distributed/checkpoint/test_checkpoint.py
@@ -44,6 +44,9 @@ from torch.testing._internal.distributed._shard.sharded_tensor import (
 
 
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+backend = torch.distributed.distributed_c10d.Backend.default_device_backend_map.get(
+    device_type
+)
 
 
 if TEST_WITH_DEV_DBG_ASAN:
@@ -79,7 +82,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
     def world_size(self) -> int:
         return 2
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
     @requires_accelerator_dist_backend()
     def test_tensor_metadata_with_missing_rank_spec(self) -> None:
@@ -96,7 +99,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
 
         self.assertEqual(1, len(st_md.chunks))
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
     @requires_accelerator_dist_backend()
     def test_default_metadata(self) -> None:
@@ -244,7 +247,7 @@ class TestDistributedFailure(ShardedTensorTestBase):
             ],
         )
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
     @requires_accelerator_dist_backend()
     def test_dummy_writer_works(self) -> None:
@@ -256,7 +259,7 @@ class TestDistributedFailure(ShardedTensorTestBase):
 
         save_state_dict(state_dict, FaultyStorageWriter({}))
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
     @requires_accelerator_dist_backend()
     def test_dummy_reader_works(self) -> None:
@@ -319,7 +322,7 @@ class TestDistributedFailure(ShardedTensorTestBase):
 
         self._test_dist_failure(_load, kwargs)
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
     @requires_accelerator_dist_backend()
     def test_save_error_handling(self) -> None:
@@ -353,7 +356,7 @@ class TestDistributedFailure(ShardedTensorTestBase):
         self._test_save(state_dict, fail_write_data=[0])
         self._test_save(state_dict, fail_write_data_async=[0])
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(4)
     @requires_accelerator_dist_backend()
     def test_load_error_handling(self) -> None:

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -49,9 +49,7 @@ from torch.testing._internal.distributed.checkpoint_utils import (
 
 
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-backend = torch.distributed.distributed_c10d.Backend.default_device_backend_map.get(
-    device_type
-)
+backend = torch.distributed.get_default_backend_for_device(device_type)
 
 
 if TEST_WITH_DEV_DBG_ASAN:

--- a/test/distributed/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/checkpoint/test_file_system_checkpoint.py
@@ -49,6 +49,9 @@ from torch.testing._internal.distributed.checkpoint_utils import (
 
 
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
+backend = torch.distributed.distributed_c10d.Backend.default_device_backend_map.get(
+    device_type
+)
 
 
 if TEST_WITH_DEV_DBG_ASAN:
@@ -170,7 +173,7 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
     def world_size(self) -> int:
         return 2
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
     @requires_accelerator_dist_backend()
     @parametrize("extensions", [None, [Rot13Example()], [ZStandard()]])
@@ -241,7 +244,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         tensor.gather(out=res)
         return res
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
     @requires_accelerator_dist_backend()
     def test_load_with_different_shard_plan(self) -> None:
@@ -356,7 +359,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                         msg=f"{s0} vs {s1}",
                     )
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
     @requires_accelerator_dist_backend()
     def test_load_rowwise_to_colwise(self) -> None:
@@ -407,7 +410,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         if dist.get_rank() == 0:
             self.assertTrue(torch.allclose(store_tensor, load_tensor))
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
     @requires_accelerator_dist_backend()
     def test_save_load_bytes(self) -> None:
@@ -426,7 +429,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         self.assertEqual([1], state_dict_to_load["bytes0"])
         self.assertEqual("string", state_dict_to_load["bytes1"])
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
     @requires_accelerator_dist_backend()
     def test_switch_between_sharded_tensor_to_tensor(self) -> None:
@@ -518,7 +521,7 @@ class TestDistributedStateDictSaveLoadWithCaching(ShardedTensorTestBase):
     def world_size(self) -> int:
         return 2
 
-    @with_comms(init_rpc=False)
+    @with_comms(init_rpc=False, backend=backend)
     @skip_if_lt_x_gpu(2)
     @requires_accelerator_dist_backend()
     @with_temp_dir

--- a/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
@@ -8,9 +8,13 @@ from torch.distributed._shard.sharded_tensor import _sharded_op_impl, ShardedTen
 def _communicate_result(result, pg):
     # Gather results from all ranks.
     if result:
-        result_tensor = torch.ones(1, device=torch.device(torch.accelerator.current_device_index()))
+        result_tensor = torch.ones(
+            1, device=torch.device(torch.accelerator.current_device_index())
+        )
     else:
-        result_tensor = torch.zeros(1, device=torch.device(torch.accelerator.current_device_index()))
+        result_tensor = torch.zeros(
+            1, device=torch.device(torch.accelerator.current_device_index())
+        )
 
     dist.all_reduce(result_tensor, group=pg)
 

--- a/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
@@ -8,14 +8,14 @@ from torch.distributed._shard.sharded_tensor import _sharded_op_impl, ShardedTen
 def _communicate_result(result, pg):
     # Gather results from all ranks.
     if result:
-        result_tensor = torch.ones(1, device=torch.device(torch.cuda.current_device()))
+        result_tensor = torch.ones(1, device=torch.device(torch.accelerator.current_device_index()))
     else:
-        result_tensor = torch.zeros(1, device=torch.device(torch.cuda.current_device()))
+        result_tensor = torch.zeros(1, device=torch.device(torch.accelerator.current_device_index()))
 
     dist.all_reduce(result_tensor, group=pg)
 
     expected_result = torch.ones(
-        1, device=torch.device(torch.cuda.current_device())
+        1, device=torch.device(torch.accelerator.current_device_index())
     ) * dist.get_world_size(pg)
 
     return torch.equal(result_tensor, expected_result)

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -86,7 +86,8 @@ class ShardedTensorTestBase(MultiProcessTestCase):
 # wrapper to initialize comms (processgroup + rpc)
 def with_comms(func=None, init_rpc=True, backend="nccl"):
     backend = torch.distributed.distributed_c10d.Backend.default_device_backend_map.get(
-        torch.accelerator.current_accelerator().type)
+        torch.accelerator.current_accelerator().type
+    )
     if func is None:
         return partial(
             with_comms,

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -94,7 +94,14 @@ def with_comms(func=None, init_rpc=True, backend="nccl"):
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        if backend == "nccl" and torch.cuda.device_count() < self.world_size:
+        if (
+            torch.accelerator.is_available()
+            and backend
+            == dist.get_default_backend_for_device(
+                torch.accelerator.current_accelerator()
+            )
+            and torch.accelerator.device_count() < self.world_size
+        ):
             sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
         self.init_comms(init_rpc=init_rpc, backend=backend)
         func(self, *args, **kwargs)

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -95,9 +95,11 @@ def with_comms(func=None, init_rpc=True, backend="nccl"):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         # Skip test if backend requires accelerator but not enough devices available
+        acc = torch.accelerator.current_accelerator()
         if backend in ["nccl", "xccl", "hccl"]:
             if (
-                not torch.accelerator.is_available()
+                acc is None
+                or backend != dist.get_default_backend_for_device(acc)
                 or torch.accelerator.device_count() < self.world_size
             ):
                 sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will port distributed tests to Intel GPU.
We could enable Intel GPU with following methods and try the best to keep the original code styles:
- use "torch.accelerator.current_accelerator()" to determine the accelerator backend
- enabled XPU for some test path

The previous one is https://github.com/pytorch/pytorch/pull/168921