### PR TITLE
Enable FP32 emulation via BF16 in cuSOLVER for qr and lu

### DIFF
--- a/aten/src/ATen/cuda/CUDAContextLight.h
+++ b/aten/src/ATen/cuda/CUDAContextLight.h
@@ -105,7 +105,7 @@ TORCH_CUDA_CPP_API void setCUDABlasLtWorkspaceSize(size_t size);
 TORCH_CUDA_CPP_API void resetChosenWorkspaceSize();
 TORCH_CUDA_CPP_API void resetCUDABlasLtWorkspaceSize();
 
-TORCH_CUDA_CPP_API cusolverDnHandle_t getCurrentCUDASolverDnHandle();
+TORCH_CUDA_CPP_API cusolverDnHandle_t getCurrentCUDASolverDnHandle(bool allow_fp32emulation = false);
 
 #if defined(USE_CUDSS)
 TORCH_CUDA_CPP_API cudssHandle_t getCurrentCudssHandle();

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -972,7 +972,7 @@ static void apply_geqrf(const Tensor& A, const Tensor& tau) {
   int n_32 = cuda_int_cast(n, "n");
   int lda_32 = cuda_int_cast(lda, "lda");
   at::cuda::solver::geqrf_bufferSize<scalar_t>(
-      at::cuda::getCurrentCUDASolverDnHandle(), m_32, n_32, A_data, lda_32, &lwork);
+      at::cuda::getCurrentCUDASolverDnHandle(true), m_32, n_32, A_data, lda_32, &lwork);
 #endif // USE_CUSOLVER_64_BIT
 
   for (decltype(batch_size) i = 0; i < batch_size; i++) {
@@ -1663,7 +1663,7 @@ void lu_factor_looped_cusolver(const Tensor& self, const Tensor& pivots, const T
     const auto pivots_data = get_pivots ? pivots.data_ptr<int>() : nullptr;
     const auto pivots_stride = get_pivots ? pivots.size(-1) : 0;
 
-    const auto handle = at::cuda::getCurrentCUDASolverDnHandle();
+    const auto handle = at::cuda::getCurrentCUDASolverDnHandle(true);
     for (auto batch = decltype(batch_size){0}; batch < batch_size; ++batch) {
       at::cuda::solver::getrf<scalar_t>(
         handle, m, n,

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -1144,7 +1144,7 @@ static void apply_orgqr(Tensor& self, const Tensor& tau) {
   // get the optimal work size and allocate workspace tensor
   int lwork;
   at::cuda::solver::orgqr_buffersize<scalar_t>(
-    at::cuda::getCurrentCUDASolverDnHandle(), m, n, k, self_data, lda, tau_data, &lwork);
+    at::cuda::getCurrentCUDASolverDnHandle(true), m, n, k, self_data, lda, tau_data, &lwork);
 
   auto info = at::zeros({1}, self.options().dtype(at::kInt));
   auto info_data = info.data_ptr<int>();
@@ -1152,7 +1152,7 @@ static void apply_orgqr(Tensor& self, const Tensor& tau) {
   for (auto i = decltype(batchsize){0}; i < batchsize; i++) {
     scalar_t* self_working_ptr = &self_data[i * self_matrix_stride];
     const scalar_t* tau_working_ptr = &tau_data[i * tau_stride];
-    auto handle = at::cuda::getCurrentCUDASolverDnHandle();
+    auto handle = at::cuda::getCurrentCUDASolverDnHandle(true);
 
     // allocate workspace storage
     auto& allocator = *at::cuda::getCUDADeviceAllocator();

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -957,7 +957,7 @@ static void apply_geqrf(const Tensor& A, const Tensor& tau) {
   size_t worksize_host; // workspaceInBytesOnHost
   cusolverDnParams_t params = nullptr; // use default algorithm (currently it's the only option)
   at::cuda::solver::xgeqrf_bufferSize<scalar_t>(
-      at::cuda::getCurrentCUDASolverDnHandle(),
+      at::cuda::getCurrentCUDASolverDnHandle(true),
       params,
       m,
       n,
@@ -978,7 +978,7 @@ static void apply_geqrf(const Tensor& A, const Tensor& tau) {
   for (decltype(batch_size) i = 0; i < batch_size; i++) {
     scalar_t* A_working_ptr = &A_data[i * A_stride];
     scalar_t* tau_working_ptr = &tau_data[i * tau_stride];
-    auto handle = at::cuda::getCurrentCUDASolverDnHandle();
+    auto handle = at::cuda::getCurrentCUDASolverDnHandle(true);
 
 #ifdef USE_CUSOLVER_64_BIT
     // allocate workspace storage on device and host

--- a/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
@@ -42,6 +42,18 @@ cusolverDnHandle_t getCurrentCUDASolverDnHandle() {
   auto handle = myPoolWindow->reserve(device);
   auto stream = c10::cuda::getCurrentCUDAStream();
   TORCH_CUSOLVER_CHECK(cusolverDnSetStream(handle, stream));
+
+  #if CUDA_VERSION >= 12900
+    cudaDeviceProp prop;
+    AT_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
+    // Emulation of FP32 via 9xBF16 is only available on CC 10 and 10.3
+    // See: https://docs.nvidia.com/cuda/cublas/#floating-point-emulation-support-overview
+    if (prop.major == 10 && (prop.minor == 0 || prop.minor == 3)) {
+      TORCH_CUSOLVER_CHECK(cusolverDnSetMathMode(handle, CUSOLVER_FP32_EMULATED_BF16X9_MATH));
+      TORCH_CUSOLVER_CHECK(cusolverDnSetEmulationStrategy(handle, CUDA_EMULATION_STRATEGY_PERFORMANT));
+    }
+  #endif
+
   return handle;
 }
 

--- a/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
@@ -43,7 +43,7 @@ cusolverDnHandle_t getCurrentCUDASolverDnHandle() {
   auto stream = c10::cuda::getCurrentCUDAStream();
   TORCH_CUSOLVER_CHECK(cusolverDnSetStream(handle, stream));
 
-  #if CUDA_VERSION >= 12900
+  #if CUDA_VERSION >= 12090
     cudaDeviceProp prop;
     AT_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
     // Emulation of FP32 via 9xBF16 is only available on CC 10 and 10.3

--- a/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
@@ -26,7 +26,7 @@ using CuSolverDnPoolType = DeviceThreadHandlePool<cusolverDnHandle_t, createCuso
 
 } // namespace
 
-cusolverDnHandle_t getCurrentCUDASolverDnHandle() {
+cusolverDnHandle_t getCurrentCUDASolverDnHandle(bool allow_fp32emulation) {
   c10::DeviceIndex device = 0;
   AT_CUDA_CHECK(c10::cuda::GetDevice(&device));
 
@@ -48,10 +48,16 @@ cusolverDnHandle_t getCurrentCUDASolverDnHandle() {
     AT_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
     // Emulation of FP32 via 9xBF16 is only available on CC 10 and 10.3
     // See: https://docs.nvidia.com/cuda/cublas/#floating-point-emulation-support-overview
-    if (prop.major == 10 && (prop.minor == 0 || prop.minor == 3)) {
+
+    if (prop.major == 10 && (prop.minor == 0 || prop.minor == 3) && allow_fp32emulation) {
       TORCH_CUSOLVER_CHECK(cusolverDnSetMathMode(handle, CUSOLVER_FP32_EMULATED_BF16X9_MATH));
       TORCH_CUSOLVER_CHECK(cusolverDnSetEmulationStrategy(handle, CUDA_EMULATION_STRATEGY_PERFORMANT));
     }
+    else {
+      TORCH_CUSOLVER_CHECK(cusolverDnSetEmulationStrategy(handle, CUDA_EMULATION_STRATEGY_DEFAULT));
+      TORCH_CUSOLVER_CHECK(cusolverDnSetMathMode(handle, CUSOLVER_DEFAULT_MATH));
+    }
+
   #endif
 
   return handle;


### PR DESCRIPTION
Continuation of #181849 for LU and QR factorization.

### Summary

As discussed in #181849, the numerics of other operations are not reliable enough yet to enable FP32 emulation on Blackwell unconditionally. This PR therefore introduces a flag in `getCurrentCUDASolverDnHandle` to enable or disable emulation explicitly, making FP32 emulation selectable per operation.

If an operation does not opt into emulation, emulation is explicitly disabled for the cuSOLVER handle. This also prevents changes in numerics if cuSOLVER enables emulation by default in the future.

### Testing

<img width="2000" height="1200" alt="image" src="https://github.com/user-attachments/assets/f07b8139-85f1-4c50-9403-6db3aa4f8599" />

<img width="2000" height="1200" alt="image" src="https://github.com/user-attachments/assets/703fc51d-83a2-458a-b48f-697946558d46" />

Additional testing of matrix sizes that were not covered in #181849 shows slightly worse residuals for QR at `n = [32, 64, 128]`, although the effect is much smaller than what was observed for `solve` / `inv`.

Residuals were computed as the mean across 50 random `n x n` matrices for each tested size. The test was repeated multiple times, and no large run-to-run shifts were observed.

For larger matrix sizes, LU and QR show improved performance. Residuals are either unchanged or improved for the large sizes tested.

I am not sure whether adding the flag to `getCurrentCUDASolverDnHandle` is the most elegant approach, but it is functional, keeps the diff small, and makes the behavior explicit at each call site. Happy to discuss if other solutions are preferred.

cc: @albanD @nikitaved @lezcano

cc @jianyuh @nikitaved @mruberry @walterddr @xwang233 @Lezcano