### PR TITLE
Allow ACL install script to be re-runnable

### DIFF
--- a/.ci/docker/common/install_acl.sh
+++ b/.ci/docker/common/install_acl.sh
@@ -18,6 +18,9 @@ scons -j8  Werror=0 debug=0 neon=1 opencl=0 embed_kernels=0 \
 popd
 
 # Install ACL
+if [[ -d "${ACL_INSTALL_DIR}" ]]; then
+  sudo rm -rf "${ACL_INSTALL_DIR}"
+fi
 sudo mkdir -p ${ACL_INSTALL_DIR}
 for d in arm_compute include utils support src build
 do


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182429

For development and debugging, this helper may be rerun inside an existing image. Remove any existing /acl first so there is no conflict in writing new files, or any stale files left behind.