### PR TITLE
[Inductor] Elide redundant .to(tl.float32) in Triton codegen when value already has target dtype

### DIFF
--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -329,7 +329,7 @@ def triton_fused_fake_name(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.cons
     r0_base = tl.arange(0, R0_BLOCK)[None, :]
     rbase = r0_base
     x0 = xindex
-    _tmp3 = tl.full([XBLOCK, R0_BLOCK], 0, tl.float32)
+    _tmp2 = tl.full([XBLOCK, R0_BLOCK], 0, tl.float32)
     {loop_header}
         r0_index = r0_offset + r0_base
         r0_mask = r0_index < r0_numel
@@ -337,12 +337,11 @@ def triton_fused_fake_name(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.cons
         rindex = r0_index
         r0_1 = r0_index
         tmp0 = tl.load(in_ptr0 + (r0_1 + 11776*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0).to(tl.float32)
-        tmp1 = tmp0.to(tl.float32)
-        tmp2 = tl.broadcast_to(tmp1, [XBLOCK, R0_BLOCK])
-        tmp4 = _tmp3 + tmp2
-        _tmp3 = tl.where(r0_mask & xmask, tmp4, _tmp3)
-    tmp3 = tl.sum(_tmp3, 1)[:, None]
-    tl.store(out_ptr0 + (x0), tmp3, xmask)
+        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
+        tmp3 = _tmp2 + tmp1
+        _tmp2 = tl.where(r0_mask & xmask, tmp3, _tmp2)
+    tmp2 = tl.sum(_tmp2, 1)[:, None]
+    tl.store(out_ptr0 + (x0), tmp2, xmask)
 
 """
 

--- a/test/inductor/test_async_compile.py
+++ b/test/inductor/test_async_compile.py
@@ -409,7 +409,7 @@ def triton_fused_fake_name(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.cons
     r0_base = tl.arange(0, R0_BLOCK)[None, :]
     rbase = r0_base
     x0 = xindex
-    _tmp3 = tl.full([XBLOCK, R0_BLOCK], 0, tl.float32)
+    _tmp2 = tl.full([XBLOCK, R0_BLOCK], 0, tl.float32)
     {loop_header}
         r0_index = r0_offset + r0_base
         r0_mask = r0_index < r0_numel
@@ -417,12 +417,11 @@ def triton_fused_fake_name(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.cons
         rindex = r0_index
         r0_1 = r0_index
         tmp0 = tl.load(in_ptr0 + (r0_1 + 11776*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0).to(tl.float32)
-        tmp1 = tmp0.to(tl.float32)
-        tmp2 = tl.broadcast_to(tmp1, [XBLOCK, R0_BLOCK])
-        tmp4 = _tmp3 + tmp2
-        _tmp3 = tl.where(r0_mask & xmask, tmp4, _tmp3)
-    tmp3 = tl.sum(_tmp3, 1)[:, None]
-    tl.store(out_ptr0 + (x0), tmp3, xmask)
+        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
+        tmp3 = _tmp2 + tmp1
+        _tmp2 = tl.where(r0_mask & xmask, tmp3, _tmp2)
+    tmp2 = tl.sum(_tmp2, 1)[:, None]
+    tl.store(out_ptr0 + (x0), tmp2, xmask)
 
 """
 

--- a/test/inductor/test_op_dtype_prop.py
+++ b/test/inductor/test_op_dtype_prop.py
@@ -99,6 +99,34 @@ class TestCase(InductorTestCase):
             self.assertEqual(fp32_cast_in_code, upcast_to_fp32)
 
     @requires_gpu()
+    @parametrize("input_dtype", [torch.float16, torch.bfloat16])
+    @config.patch("triton.codegen_upcast_to_fp32", True)
+    def test_no_redundant_to_float32(self, input_dtype):
+        """When codegen_upcast_to_fp32 is enabled, to_dtype should not emit
+        a redundant .to(tl.float32) on a value that is already float32."""
+
+        def func(x, y):
+            a = x * y
+            b = a.float()
+            return b + 1.0
+
+        inps = (
+            torch.rand((32, 32), device=GPU_TYPE, dtype=input_dtype),
+            torch.rand((32, 32), device=GPU_TYPE, dtype=input_dtype),
+        )
+        func_opt = torch.compile(func, backend="inductor")
+        code = run_and_get_triton_code(func_opt, *inps)
+        candidate_casts = "\n".join(
+            l.strip()
+            for l in code.splitlines()
+            if ".to(tl.float32)" in l
+            and "tl.load" not in l
+            and "tl.sum" not in l
+            and l.strip().startswith("tmp")
+        )
+        FileCheck().check_not(".to(tl.float32)").run(candidate_casts)
+
+    @requires_gpu()
     @parametrize("input_shape", [(32, 32), (32, 128), (256, 32)])
     @parametrize(
         "reduction_func",

--- a/test/inductor/test_op_dtype_prop.py
+++ b/test/inductor/test_op_dtype_prop.py
@@ -100,6 +100,34 @@ class TestCase(InductorTestCase):
             self.assertEqual(fp32_cast_in_code, upcast_to_fp32)
 
     @requires_gpu()
+    @parametrize("input_dtype", [torch.float16, torch.bfloat16])
+    @config.patch("triton.codegen_upcast_to_fp32", True)
+    def test_no_redundant_to_float32(self, input_dtype):
+        """When codegen_upcast_to_fp32 is enabled, to_dtype should not emit
+        a redundant .to(tl.float32) on a value that is already float32."""
+
+        def func(x, y):
+            a = x * y
+            b = a.float()
+            return b + 1.0
+
+        inps = (
+            torch.rand((32, 32), device=GPU_TYPE, dtype=input_dtype),
+            torch.rand((32, 32), device=GPU_TYPE, dtype=input_dtype),
+        )
+        func_opt = torch.compile(func, backend="inductor")
+        code = run_and_get_triton_code(func_opt, *inps)
+        candidate_casts = "\n".join(
+            l.strip()
+            for l in code.splitlines()
+            if ".to(tl.float32)" in l
+            and "tl.load" not in l
+            and "tl.sum" not in l
+            and l.strip().startswith("tmp")
+        )
+        FileCheck().check_not(".to(tl.float32)").run(candidate_casts)
+
+    @requires_gpu()
     @parametrize("input_shape", [(32, 32), (32, 128), (256, 32)])
     @parametrize(
         "reduction_func",

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -17,6 +17,7 @@ from abc import abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from functools import lru_cache
 from typing import Any, cast, TYPE_CHECKING, TypeVar
+from typing_extensions import override
 
 import sympy
 from sympy.printing.precedence import PRECEDENCE
@@ -1333,6 +1334,7 @@ class TritonOverrides(OpOverrides):
 
     _LOG_2_E = math.log2(math.e)
 
+    @override
     @staticmethod
     def to_dtype(
         x,
@@ -1408,6 +1410,13 @@ class TritonOverrides(OpOverrides):
             and (src_dtype == torch.bool or is_integer_dtype(src_dtype))
         ):
             return f"{x}.to(tl.float32).to({out_dtype})"
+
+        if (
+            isinstance(x, CSEVariable)
+            and x.dtype is not None
+            and triton_type(x.dtype) == out_dtype
+        ):
+            return x
 
         return f"{x}.to({out_dtype})"
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -17,6 +17,7 @@ from abc import abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from functools import lru_cache
 from typing import Any, cast, TYPE_CHECKING, TypeVar
+from typing_extensions import override
 
 import sympy
 from sympy.printing.precedence import PRECEDENCE
@@ -1324,6 +1325,7 @@ class TritonOverrides(OpOverrides):
 
     _LOG_2_E = math.log2(math.e)
 
+    @override
     @staticmethod
     def to_dtype(
         x,
@@ -1399,6 +1401,13 @@ class TritonOverrides(OpOverrides):
             and (src_dtype == torch.bool or is_integer_dtype(src_dtype))
         ):
             return f"{x}.to(tl.float32).to({out_dtype})"
+
+        if (
+            isinstance(x, CSEVariable)
+            and x.dtype is not None
+            and triton_type(x.dtype) == out_dtype
+        ):
+            return x
 
         return f"{x}.to({out_dtype})"
 


### PR DESCRIPTION
`TritonOverrides.to_dtype()` unconditionally emits .to(out_dtype) even when the CSE variable already has the target dtype. This produces redundant no-op casts `(e.g. tmp3 = tmp2.to(tl.float32) where tmp2 is already float32)` when `codegen_upcast_to_fp32=True` and the IR has an `explicit to_dtype node` whose logical source dtype differs from the codegen dtype.

Fixes https://github.com/pytorch/pytorch/issues/182430

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo