### PR TITLE
[MTIA][Inductor] Add at::kMTIA to _is_any_autocast_enabled() to fix block pointer dtype mismatch

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -781,6 +781,7 @@ static PyObject* is_any_autocast_enabled(PyObject* _unused, PyObject* arg) {
       at::autocast::is_autocast_enabled(at::kIPU) ||
       at::autocast::is_autocast_enabled(at::kXLA) ||
       at::autocast::is_autocast_enabled(at::kHPU) ||
+      at::autocast::is_autocast_enabled(at::kMTIA) ||
       at::autocast::is_autocast_enabled(at::kPrivateUse1)) {
     Py_RETURN_TRUE;
   } else {


### PR DESCRIPTION
Summary:
`_is_any_autocast_enabled()` in init.cpp checks CPU, CUDA, XPU, IPU, XLA, HPU, and PrivateUse1 but not MTIA. 

Fix: add `at::kMTIA` to the device list in `is_any_autocast_enabled()`. 

Differential Revision: D102487245


