### PR TITLE
Fix import of _debug_handlers in test_debug.py

### DIFF
--- a/test/distributed/test_debug.py
+++ b/test/distributed/test_debug.py
@@ -417,6 +417,8 @@ class TestFetchTimeout(TestCase):
 
 
 class TestHandlerPartialDumps(TestCase):
+    import torch.distributed.debug._debug_handlers
+
     @patch("torch.distributed.debug._debug_handlers.fetch_all")
     def test_stacks_handler_partial_dump(self, mock_fetch_all) -> None:
         from torch.distributed.debug._debug_handlers import StacksHandler


### PR DESCRIPTION
This commit addresses a test failure that was introduced
by #174808 and discovered in NVIDIA internal PyTorch CI

```
----------- TestHandlerPartialDumps.test_stacks_handler_all_success ------------ 
Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/testing/_internal/common_utils.py", line 3532, in wrapper
    method(*args, **kwargs)
  File "/usr/lib/python3.12/unittest/mock.py", line 1387, in patched
    with self.decoration_helper(patched,
  File "/usr/lib/python3.12/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/unittest/mock.py", line 1369, in decoration_helper
    arg = exit_stack.enter_context(patching)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/contextlib.py", line 526, in enter_context
    result = _enter(cm)
             ^^^^^^^^^^
  File "/usr/lib/python3.12/unittest/mock.py", line 1442, in __enter__
    self.target = self.getter()
                  ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/pkgutil.py", line 528, in resolve_name
    result = getattr(result, p)
             ^^^^^^^^^^^^^^^^^^
AttributeError: module 'torch.distributed.debug' has no attribute '_debug_handlers'
To execute this test, run the following from the base repo dir:
    python test/distributed/test_debug.py TestHandlerPartialDumps.test_stacks_handler_all_success
```