### PR TITLE
[Inductor][ROCm] Skip test_combo_kernel_peak_memory_wide_resnet on ROCm

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -2178,6 +2178,7 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         )
         self.assertIsNotNone(combo)
 
+    @skipIfRocm  # https://github.com/pytorch/pytorch/issues/182444
     @requires_cuda_and_triton
     def test_combo_kernel_peak_memory_wide_resnet(self):
         """A tight peak-memory threshold must measurably reduce the


### PR DESCRIPTION
The combo-kernel peak-memory gating test added in #180578 fails consistently on gfx950 (MI355): the "tight" 1MB-threshold run and the gating-disabled baseline produce identical (or in one rerun, inverted) allocator-observed peaks, so `assertLess(peak_tight, peak_disabled)` fires. The other three tests in `ComboKernelPeakMemoryTests` exercise the gating logic itself and continue to pass on ROCm.

Skip on ROCm while we investigate; tracked in #182444.

Authored by Claude.

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben