### PR TITLE
[inductor] drop complex_memory_overlap cudagraph gate; storage-copy fallback for self-overlapping inputs

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -18,11 +18,7 @@ from torch._dynamo.testing import rand_strided
 from torch._dynamo.utils import same
 from torch._inductor import config, cpu_vec_isa, metrics, test_operators
 from torch._inductor.codegen.cpp import CppOverrides, CppVecOverrides
-from torch._inductor.compile_fx import (
-    compile_fx,
-    compile_fx_inner,
-    complex_memory_overlap,
-)
+from torch._inductor.compile_fx import compile_fx, compile_fx_inner
 from torch._inductor.exc import InductorError
 from torch._inductor.graph import GraphLowering
 from torch._inductor.utils import timed
@@ -2187,23 +2183,6 @@ class CPUReproTests(TestCase):
     @patch("torch.cuda.is_available", lambda: False)
     def test_timed_cpu_only(self):
         timed(lambda: torch.randn(10), ())
-
-    def test_complex_memory_overlap(self):
-        dense = torch.zeros(64, 32)
-        self.assertFalse(complex_memory_overlap(dense))
-        self.assertFalse(complex_memory_overlap(dense.t()))
-
-        strided = dense.split(4, dim=1)
-        self.assertFalse(complex_memory_overlap(strided[0]))
-        self.assertFalse(complex_memory_overlap(strided[0].t()))
-
-        unsqueezed = dense.unsqueeze(1)
-        self.assertFalse(complex_memory_overlap(unsqueezed))
-        self.assertFalse(complex_memory_overlap(unsqueezed.permute(1, 2, 0)))
-
-        gathered = dense.index_select(0, torch.IntTensor([1, 0, 1]))
-        self.assertFalse(complex_memory_overlap(gathered))
-        self.assertFalse(complex_memory_overlap(gathered.t()))
 
     @requires_vectorization
     def test_vec_dynamic_shapes(self):

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -830,6 +830,80 @@ if HAS_CUDA_AND_TRITON:
             # should be in execution mode
             self.assertEqual(all_live_block_count(), 0)
 
+        def test_forward_with_skipped_cudagraphed_backward(self):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return x * x * x
+
+            for _ in range(3):
+                inp = torch.rand([20, 20], device="cuda", requires_grad=True)
+                out = foo(inp)
+
+                with config.patch(force_disable_cudagraph_TESTING_ONLY=True):
+                    back_inp = torch.empty_strided([20, 20], [0, 1], device="cuda")
+                    out.backward(back_inp)
+
+            # we should not have cudagraph'd the backwards
+            new_id = self.get_manager().new_graph_id().id
+            self.assertEqual(new_id, 1)
+
+            self.assertFalse(self.get_manager().running_forwards_with_pending_backwards)
+
+        @torch._functorch.config.patch("enable_autograd_cache", True)
+        @torch._inductor.config.patch("fx_graph_cache", True)
+        @torch._inductor.config.patch("fx_graph_remote_cache", False)
+        # Currently fx graph cache is turned off for specialize_float=False
+        @torch._dynamo.config.patch("specialize_float", True)
+        def test_cache_hit_forward_miss_backward(self):
+            # Test that we don't cache cudagraphs, skipping cudagraphs on backward on a cache miss
+
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return x * x * x
+
+            # Run forwards, fx graph should cache miss
+            for _ in range(3):
+                torch._dynamo.reset()
+                counters.clear()
+                FxGraphCache.clear()
+                AOTAutogradCache.clear()
+
+                with config.patch(force_disable_cudagraph_TESTING_ONLY=True):
+                    inp = torch.rand([20, 20], device="cuda", requires_grad=True)
+                    out = foo(inp)
+                    self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+
+                    # Reset dynamo and related caches except for FXGraphCache
+                    torch._dynamo.reset()
+                    # Forwards should be a cache hit now, we still skip cudagraphs
+                    inp = torch.rand([20, 20], device="cuda", requires_grad=True)
+                    out = foo(inp)
+                    self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+                    self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+                # Run the backward without the force-disable knob; cache should
+                # miss for the backward, but cudagraphs should not run because
+                # the forward already skipped.
+                back_inp = torch.empty_strided([20, 20], [0, 1], device="cuda")
+                out.backward(back_inp)
+                self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+
+            # Run it one more time, this time AOTAutogradCache will hit
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+
+            torch._dynamo.reset()
+            inp = torch.rand([20, 20], device="cuda", requires_grad=True)
+            out = foo(inp)
+            back_inp = torch.empty_strided([20, 20], [0, 1], device="cuda")
+            out.backward(back_inp)
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+            # we should not have cudagraph'd anything
+            if self.get_manager() is not None:
+                raise AssertionError
+
         @torch._functorch.config.patch("enable_autograd_cache", True)
         @torch._inductor.config.patch("fx_graph_cache", True)
         @torch._inductor.config.patch("fx_graph_remote_cache", False)
@@ -3870,6 +3944,26 @@ if HAS_CUDA_AND_TRITON:
 
             # 0 cudagraph since all ops are on cpu
             self.assertEqual(self.get_manager() is None, True)
+
+        @torch._inductor.config.patch("graph_partition", True)
+        def test_graph_partition_forward_with_skipped_cudagraphed_backward(self):
+            @torch.compile(mode="reduce-overhead")
+            def foo(x):
+                return x * x * x
+
+            for _ in range(3):
+                inp = torch.rand([20, 20], device="cuda", requires_grad=True)
+                out = foo(inp)
+
+                with config.patch(force_disable_cudagraph_TESTING_ONLY=True):
+                    back_inp = torch.empty_strided([20, 20], [0, 1], device="cuda")
+                    out.backward(back_inp)
+
+            # we should not have cudagraph'd the backwards
+            new_id = self.get_manager().new_graph_id().id
+            self.assertEqual(new_id, 1)
+
+            self.assertFalse(self.get_manager().running_forwards_with_pending_backwards)
 
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_forward_backward_not_called(self):

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -830,82 +830,6 @@ if HAS_CUDA_AND_TRITON:
             # should be in execution mode
             self.assertEqual(all_live_block_count(), 0)
 
-        def test_forward_with_skipped_cudagraphed_backward(self):
-            @torch.compile(mode="reduce-overhead")
-            def foo(x):
-                return x * x * x
-
-            for _ in range(3):
-                inp = torch.rand([20, 20], device="cuda", requires_grad=True)
-                out = foo(inp)
-
-                with config.patch(always_complex_memory_overlap_TESTING_ONLY=True):
-                    back_inp = torch.empty_strided([20, 20], [0, 1], device="cuda")
-                    out.backward(back_inp)
-
-            # we should not have cudagraph'd the backwards
-            new_id = self.get_manager().new_graph_id().id
-            self.assertEqual(new_id, 1)
-
-            self.assertFalse(self.get_manager().running_forwards_with_pending_backwards)
-
-        @torch._functorch.config.patch("enable_autograd_cache", True)
-        @torch._inductor.config.patch("fx_graph_cache", True)
-        @torch._inductor.config.patch("fx_graph_remote_cache", False)
-        # Currently fx graph cache is turned off for specialize_float=False
-        @torch._dynamo.config.patch("specialize_float", True)
-        def test_cache_hit_forward_miss_backward(self):
-            # Test that we don't cache cudagraphs, skipping cudagraphs on backward on a cache miss
-
-            @torch.compile(mode="reduce-overhead")
-            def foo(x):
-                return x * x * x
-
-            # Run forwards, fx graph should cache miss
-            for _ in range(3):
-                torch._dynamo.reset()
-                counters.clear()
-                FxGraphCache.clear()
-                AOTAutogradCache.clear()
-
-                with config.patch(always_complex_memory_overlap_TESTING_ONLY=True):
-                    inp = torch.rand([20, 20], device="cuda", requires_grad=True)
-                    out = foo(inp)
-                    self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-
-                    # Reset dynamo and related caches except for FXGraphCache
-                    torch._dynamo.reset()
-                    # Forwards should be a cache hit now, we still skip cudagraphs
-                    inp = torch.rand([20, 20], device="cuda", requires_grad=True)
-                    out = foo(inp)
-                    self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-                    self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
-
-                    # Run backward without complex memory overlap being set
-
-                # Run the backward without complex memory overlap reason
-                # cache should miss, but cudagraphs should not run
-                # because forward skipped it
-                back_inp = torch.empty_strided([20, 20], [0, 1], device="cuda")
-                out.backward(back_inp)
-                self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
-
-            # Run it one more time, this time AOTAutogradCache will hit
-            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
-            self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
-
-            torch._dynamo.reset()
-            inp = torch.rand([20, 20], device="cuda", requires_grad=True)
-            out = foo(inp)
-            back_inp = torch.empty_strided([20, 20], [0, 1], device="cuda")
-            out.backward(back_inp)
-
-            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
-
-            # we should not have cudagraph'd anything
-            if self.get_manager() is not None:
-                raise AssertionError
-
         @torch._functorch.config.patch("enable_autograd_cache", True)
         @torch._inductor.config.patch("fx_graph_cache", True)
         @torch._inductor.config.patch("fx_graph_remote_cache", False)
@@ -3946,26 +3870,6 @@ if HAS_CUDA_AND_TRITON:
 
             # 0 cudagraph since all ops are on cpu
             self.assertEqual(self.get_manager() is None, True)
-
-        @torch._inductor.config.patch("graph_partition", True)
-        def test_graph_partition_forward_with_skipped_cudagraphed_backward(self):
-            @torch.compile(mode="reduce-overhead")
-            def foo(x):
-                return x * x * x
-
-            for _ in range(3):
-                inp = torch.rand([20, 20], device="cuda", requires_grad=True)
-                out = foo(inp)
-
-                with config.patch(always_complex_memory_overlap_TESTING_ONLY=True):
-                    back_inp = torch.empty_strided([20, 20], [0, 1], device="cuda")
-                    out.backward(back_inp)
-
-            # we should not have cudagraph'd the backwards
-            new_id = self.get_manager().new_graph_id().id
-            self.assertEqual(new_id, 1)
-
-            self.assertFalse(self.get_manager().running_forwards_with_pending_backwards)
 
         @torch._inductor.config.patch("graph_partition", True)
         def test_graph_partition_forward_backward_not_called(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -130,11 +130,7 @@ importlib.import_module("functorch")
 importlib.import_module("filelock")
 
 from torch._inductor import config, cpu_vec_isa, test_operators
-from torch._inductor.compile_fx import (
-    compile_fx,
-    compile_fx_inner,
-    complex_memory_overlap,
-)
+from torch._inductor.compile_fx import compile_fx, compile_fx_inner
 from torch._inductor.utils import has_torchvision_roi_align
 from torch.testing._internal.common_utils import slowTest
 from torch.testing._internal.inductor_utils import (  # noqa: F401
@@ -14609,10 +14605,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
         result = f(torch.tensor([20]))
         self.assertTrue(len(result) == 3)
-
-    def test_complex_memory_overlap(self):
-        t = rand_strided((8, 1500, 1), (1504, 1, 1), device=self.device)
-        self.assertFalse(complex_memory_overlap(t))
 
     @xfail_if_mps
     def test_generate_rand_fp8(self):

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -78,6 +78,7 @@ from torch._inductor.output_code import (
     CompiledAOTI,
     CompiledFxGraph,
     CompiledFxGraphConstantsWithGm,
+    copy_strided_storage_,
     get_expanded_dims,
     index_expanded_dims,
     OutputCode,
@@ -119,7 +120,6 @@ from .fx_passes.post_grad import post_grad_passes, view_to_reshape
 from .fx_passes.pre_grad import pre_grad_passes
 from .graph import GraphLowering
 from .ir import get_device_type, IRNode
-from .output_code import complex_memory_overlap  # noqa: F401
 from .triton_bundler import TritonBundler
 from .utils import (
     align_inputs_from_check_idxs,
@@ -1937,9 +1937,15 @@ def index_expanded_dims_and_copy_(
     expanded_dims: list[int],
 ) -> None:
     "Index into expanded dimensions of both dst and src then copy_"
-    dst = index_expanded_dims(dst, expanded_dims)
-    src = index_expanded_dims(src, expanded_dims)
-    dst.copy_(src)
+    indexed_dst = index_expanded_dims(dst, expanded_dims)
+    if torch._debug_has_internal_overlap(indexed_dst) != 0:
+        # dst still self-overlaps after dropping expanded dims (rare). A regular
+        # copy_ would have ambiguous semantics; bytewise-copy the strided extent
+        # instead so dst's overlap pattern is reproduced verbatim.
+        copy_strided_storage_(dst, src)
+        return
+    indexed_src = index_expanded_dims(src, expanded_dims)
+    indexed_dst.copy_(indexed_src)
 
 
 def cudagraphify_impl(

--- a/torch/_inductor/compile_fx_async.py
+++ b/torch/_inductor/compile_fx_async.py
@@ -13,7 +13,6 @@ from torch._inductor.output_code import (
 )
 
 from .compile_fx import _CompileFxKwargs, _InProcessFxCompile, FxCompile
-from .output_code import complex_memory_overlap  # noqa: F401
 
 
 # When async compile works with cache, remove the disabling below

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -31,7 +31,6 @@ from . import config
 from .compile_fx import _CompileFxKwargs, _InProcessFxCompile, FxCompile, log
 from .debug import DebugContext
 from .graph import GraphLowering
-from .output_code import complex_memory_overlap  # noqa: F401
 from .virtualized import V
 
 

--- a/torch/_inductor/compile_fx_subproc.py
+++ b/torch/_inductor/compile_fx_subproc.py
@@ -20,7 +20,6 @@ from .compile_fx_ext import (
     _WireProtocolPickledInput,
     _WireProtocolPickledOutput,
 )
-from .output_code import complex_memory_overlap  # noqa: F401
 
 
 if TYPE_CHECKING:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1523,9 +1523,6 @@ unsafe_ignore_unsupported_triton_autotune_args: bool = False
 # any cycles. Incompatible with cpp_wrapper.
 check_stack_no_cycles_TESTING_ONLY: bool = False
 
-# When True, complex_memory_overlap always reports True
-always_complex_memory_overlap_TESTING_ONLY: bool = False
-
 # enable linear binary folding
 enable_linear_binary_folding = (
     os.environ.get("TORCHINDUCTOR_ENABLE_LINEAR_BINARY_FOLDING", "0") == "1"
@@ -2697,8 +2694,6 @@ _cache_config_ignore_prefix: list[str] = [
     "_pre_fusion_custom_pass",
     # CUDAGraphPolicy only affects post_compile, not compiled output
     "cudagraph_policy",
-    # tests assume that changes here don't invalidate cache
-    "always_complex_memory_overlap_TESTING_ONLY",
     # timing affects cache structure, not cache content
     "pre_grad_pass_timing",
     # cache related options are not relevant to cache results

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1523,6 +1523,10 @@ unsafe_ignore_unsupported_triton_autotune_args: bool = False
 # any cycles. Incompatible with cpp_wrapper.
 check_stack_no_cycles_TESTING_ONLY: bool = False
 
+# When True, all compiled graphs report a cudagraph fail reason. Used by tests
+# that need to exercise the cudagraph-skip path.
+force_disable_cudagraph_TESTING_ONLY: bool = False
+
 # enable linear binary folding
 enable_linear_binary_folding = (
     os.environ.get("TORCHINDUCTOR_ENABLE_LINEAR_BINARY_FOLDING", "0") == "1"
@@ -2694,6 +2698,8 @@ _cache_config_ignore_prefix: list[str] = [
     "_pre_fusion_custom_pass",
     # CUDAGraphPolicy only affects post_compile, not compiled output
     "cudagraph_policy",
+    # tests assume that changes here don't invalidate cache
+    "force_disable_cudagraph_TESTING_ONLY",
     # timing affects cache structure, not cache content
     "pre_grad_pass_timing",
     # cache related options are not relevant to cache results

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -69,6 +69,7 @@ from torch._higher_order_ops.cudagraph_conditional_nodes import (
 from torch._inductor.compile_fx import (
     align_inputs_from_check_idxs,
     copy_misaligned_inputs,
+    copy_strided_storage_,
     get_expanded_dims,
     get_input_idxs_to_check,
     index_expanded_dims,
@@ -1145,7 +1146,13 @@ class CUDAGraphNode:
             if not isinstance(srcs[idx], torch.Tensor):
                 continue
             expanded_dims = self.expanded_dims[idx]
-            dst_tensors.append(index_expanded_dims(dsts[idx], expanded_dims))  # type: ignore[arg-type]
+            indexed_dst = index_expanded_dims(dsts[idx], expanded_dims)  # type: ignore[arg-type]
+            if torch._debug_has_internal_overlap(indexed_dst) != 0:
+                # rare path: dst still self-overlaps after dropping expanded dims
+                copy_strided_storage_(dsts[idx], srcs[idx])  # type: ignore[arg-type]
+                srcs[idx] = None  # type: ignore[call-overload]
+                continue
+            dst_tensors.append(indexed_dst)
             src_tensors.append(index_expanded_dims(srcs[idx], expanded_dims))  # type: ignore[arg-type]
             srcs[idx] = None  # type: ignore[call-overload]
         # Fails on empty lists

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -624,6 +624,10 @@ class CompiledFxGraph(OutputCode):
                 cudagraph_tests = [
                     (not has_mutation, "mutated inputs"),
                     (
+                        not config.force_disable_cudagraph_TESTING_ONLY,
+                        "force_disable_cudagraph_TESTING_ONLY",
+                    ),
+                    (
                         all(
                             isinstance(
                                 t,

--- a/torch/_inductor/output_code.py
+++ b/torch/_inductor/output_code.py
@@ -126,26 +126,26 @@ def index_expanded_dims(t: torch.Tensor, expanded_dims: list[int]) -> torch.Tens
     return t
 
 
-def complex_memory_overlap(t: torch.Tensor) -> bool:
-    if config.always_complex_memory_overlap_TESTING_ONLY:
-        return True
-
-    # if torch._debug_has_internal_overlap thinks this tensor potentially has
-    # memory overlap internally, let's dig deeper to find out whether it's true.
-    #
-    # Call squeeze() so that dimension with size 1 does not cause false positive.
-    t = index_expanded_dims(t, get_expanded_dims(t)).squeeze()
-    if torch._debug_has_internal_overlap(t) != 0:
-        strides = t.stride()
-        sizes = t.shape
-        indices = list(range(len(strides)))
-        indices = [x for _, x in sorted(zip(strides, indices))]
-        for i in range(len(strides)):
-            prev_stride = 1 if i == 0 else strides[indices[i - 1]]
-            prev_size = 1 if i == 0 else sizes[indices[i - 1]]
-            if strides[indices[i]] < prev_stride * prev_size:
-                return True
-    return False
+# Bytewise copy of src's reachable strided extent into dst, starting from each
+# tensor's data_ptr. Requires matching sizes/strides/dtype. Use when dst
+# self-overlaps and a regular strided copy_ would be ambiguous: the overlap
+# pattern reproduces in dst because the underlying bytes are copied verbatim.
+def copy_strided_storage_(dst: torch.Tensor, src: torch.Tensor) -> None:
+    assert dst.dtype == src.dtype
+    assert tuple(dst.size()) == tuple(src.size())
+    assert tuple(dst.stride()) == tuple(src.stride())
+    if dst.numel() == 0:
+        return
+    assert all(st >= 0 for st in src.stride()), (
+        "copy_strided_storage_ requires non-negative strides"
+    )
+    elem = src.element_size()
+    nbytes = (sum((s - 1) * st for s, st in zip(src.size(), src.stride())) + 1) * elem
+    src_off = src.storage_offset() * elem
+    dst_off = dst.storage_offset() * elem
+    dst.untyped_storage()[dst_off : dst_off + nbytes].copy_(
+        src.untyped_storage()[src_off : src_off + nbytes]
+    )
 
 
 def maybe_handle_backward_generation(
@@ -599,12 +599,6 @@ class CompiledFxGraph(OutputCode):
                     counters["inductor"]["cudagraph_skips"] += 1
                 BoxedBool.disable(cudagraphs)
             else:
-                complex_memory_overlap_inputs = any(
-                    complex_memory_overlap(t)
-                    for t in example_inputs
-                    if isinstance(t, torch.Tensor)
-                )
-
                 if not config.triton.cudagraph_support_input_mutation:
                     # Skip supports for cudagraph-managed tensors
                     from torch._inductor.cudagraph_utils import (
@@ -629,7 +623,6 @@ class CompiledFxGraph(OutputCode):
 
                 cudagraph_tests = [
                     (not has_mutation, "mutated inputs"),
-                    (not complex_memory_overlap_inputs, "complex memory overlap"),
                     (
                         all(
                             isinstance(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #182531
* __->__ #182524

We had a check in cudagraphs that looked for tensors with self-overlap because those trigger an error in `torch.copy_`. However, we can handle this case generically. In the common case, we index into expanded dimensions, and then just copy_ over the base tensor. For the more complicated, self-overlap tensors (which should be very rare), we can just copy over the storage. 

The has_complex_overlap check was causing issues with unbacked shapes.


Authored with assistance from Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

Differential Revision: [D103898327](https://our.internmc.facebook.com/intern/diff/D103898327)