### PR TITLE
[DTensor] register missing pooling backward sharding strategies

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1751,12 +1751,19 @@ class DistMathOpsTest(DTensorTestBase):
                         device_mesh,
                         [Shard(shard_dim)],
                     )
+
                     out = fn(x)
-                    (out[0] if isinstance(out, tuple) else out).sum().backward()
-                    dt_out = fn(dt_x)
-                    (
-                        dt_out[0] if isinstance(dt_out, tuple) else dt_out
-                    ).sum().backward()
+                    out_val = out[0] if isinstance(out, tuple) else out
+                    out_val.sum().backward()
+
+                    with CommDebugMode() as comm_mode:
+                        dt_out = fn(dt_x)
+                        dt_out_val = dt_out[0] if isinstance(dt_out, tuple) else dt_out
+                        dt_out_val.sum().backward()
+                    self.assertEqual(comm_mode.get_total_counts(), 0)
+
+                    self.assertEqual(dt_out_val.full_tensor(), out_val)
+                    self.assertTrue(dt_out_val.placements[0].is_shard(shard_dim))
                     self.assertEqual(dt_x.grad.full_tensor(), x.grad)
                     self.assertTrue(dt_x.grad.placements[0].is_shard(shard_dim))
 

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1728,11 +1728,6 @@ class DistMathOpsTest(DTensorTestBase):
                 "adaptive_max_pool2d",
                 lambda t: F.adaptive_max_pool2d(t, (4, 4)),
             ),
-            (
-                (8, 4, 16, 16),
-                "fractional_max_pool2d",
-                lambda t: F.fractional_max_pool2d(t, 2, output_size=(8, 8)),
-            ),
             ((8, 4, 8, 8, 8), "avg_pool3d", lambda t: F.avg_pool3d(t, 2)),
             ((8, 4, 8, 8, 8), "max_pool3d", lambda t: F.max_pool3d(t, 2)),
             (
@@ -1745,32 +1740,25 @@ class DistMathOpsTest(DTensorTestBase):
                 "adaptive_max_pool3d",
                 lambda t: F.adaptive_max_pool3d(t, (4, 4, 4)),
             ),
-            (
-                (8, 4, 8, 8, 8),
-                "fractional_max_pool3d",
-                lambda t: F.fractional_max_pool3d(t, 2, output_size=(4, 4, 4)),
-            ),
         ]
 
         for shard_dim in [0, 1]:
             for shape, name, fn in cases:
-                x = torch.randn(*shape, device=self.device_type, requires_grad=True)
-                dt_x = distribute_tensor(
-                    x.detach().clone().requires_grad_(True),
-                    device_mesh,
-                    [Shard(shard_dim)],
-                )
-                out = fn(x)
-                (out[0] if isinstance(out, tuple) else out).sum().backward()
-                dt_out = fn(dt_x)
-                (dt_out[0] if isinstance(dt_out, tuple) else dt_out).sum().backward()
-                self.assertEqual(
-                    dt_x.grad.full_tensor(), x.grad, msg=f"{name} shard={shard_dim}"
-                )
-                self.assertTrue(
-                    dt_x.grad.placements[0].is_shard(shard_dim),
-                    msg=f"{name} shard={shard_dim}: expected Shard({shard_dim}) grad placement",
-                )
+                with self.subTest(name=name, shard_dim=shard_dim):
+                    x = torch.randn(*shape, device=self.device_type, requires_grad=True)
+                    dt_x = distribute_tensor(
+                        x.detach().clone().requires_grad_(True),
+                        device_mesh,
+                        [Shard(shard_dim)],
+                    )
+                    out = fn(x)
+                    (out[0] if isinstance(out, tuple) else out).sum().backward()
+                    dt_out = fn(dt_x)
+                    (
+                        dt_out[0] if isinstance(dt_out, tuple) else dt_out
+                    ).sum().backward()
+                    self.assertEqual(dt_x.grad.full_tensor(), x.grad)
+                    self.assertTrue(dt_x.grad.placements[0].is_shard(shard_dim))
 
     @with_comms
     @skip_unless_torch_gpu

--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1711,6 +1711,68 @@ class DistMathOpsTest(DTensorTestBase):
         self.assertTrue(result.placements[0].is_shard(0))
 
     @with_comms
+    def test_pooling_backward(self):
+        device_mesh = self.build_device_mesh()
+        F = torch.nn.functional
+
+        cases = [
+            ((8, 4, 16, 16), "avg_pool2d", lambda t: F.avg_pool2d(t, 2)),
+            ((8, 4, 16, 16), "max_pool2d", lambda t: F.max_pool2d(t, 2)),
+            (
+                (8, 4, 16, 16),
+                "adaptive_avg_pool2d",
+                lambda t: F.adaptive_avg_pool2d(t, (4, 4)),
+            ),
+            (
+                (8, 4, 16, 16),
+                "adaptive_max_pool2d",
+                lambda t: F.adaptive_max_pool2d(t, (4, 4)),
+            ),
+            (
+                (8, 4, 16, 16),
+                "fractional_max_pool2d",
+                lambda t: F.fractional_max_pool2d(t, 2, output_size=(8, 8)),
+            ),
+            ((8, 4, 8, 8, 8), "avg_pool3d", lambda t: F.avg_pool3d(t, 2)),
+            ((8, 4, 8, 8, 8), "max_pool3d", lambda t: F.max_pool3d(t, 2)),
+            (
+                (8, 4, 8, 8, 8),
+                "adaptive_avg_pool3d",
+                lambda t: F.adaptive_avg_pool3d(t, (4, 4, 4)),
+            ),
+            (
+                (8, 4, 8, 8, 8),
+                "adaptive_max_pool3d",
+                lambda t: F.adaptive_max_pool3d(t, (4, 4, 4)),
+            ),
+            (
+                (8, 4, 8, 8, 8),
+                "fractional_max_pool3d",
+                lambda t: F.fractional_max_pool3d(t, 2, output_size=(4, 4, 4)),
+            ),
+        ]
+
+        for shard_dim in [0, 1]:
+            for shape, name, fn in cases:
+                x = torch.randn(*shape, device=self.device_type, requires_grad=True)
+                dt_x = distribute_tensor(
+                    x.detach().clone().requires_grad_(True),
+                    device_mesh,
+                    [Shard(shard_dim)],
+                )
+                out = fn(x)
+                (out[0] if isinstance(out, tuple) else out).sum().backward()
+                dt_out = fn(dt_x)
+                (dt_out[0] if isinstance(dt_out, tuple) else dt_out).sum().backward()
+                self.assertEqual(
+                    dt_x.grad.full_tensor(), x.grad, msg=f"{name} shard={shard_dim}"
+                )
+                self.assertTrue(
+                    dt_x.grad.placements[0].is_shard(shard_dim),
+                    msg=f"{name} shard={shard_dim}: expected Shard({shard_dim}) grad placement",
+                )
+
+    @with_comms
     @skip_unless_torch_gpu
     def test_nll_loss_backward_comm_counts(self):
         """Test backward comm counts for nll_loss/cross_entropy with Shard(0) inputs.

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1816,6 +1816,20 @@ def interp_upsample_1out_1in_strategy(
     ]
 
 
+POOL_BACKWARD_SPATIAL_RANK: dict[torch._ops.OpOverload, int] = {
+    aten._adaptive_avg_pool2d_backward.default: 2,
+    aten._adaptive_avg_pool3d_backward.default: 3,
+    aten.avg_pool2d_backward.default: 2,
+    aten.avg_pool3d_backward.default: 3,
+    aten.max_pool2d_with_indices_backward.default: 2,
+    aten.max_pool3d_with_indices_backward.default: 3,
+    aten.adaptive_max_pool2d_backward.default: 2,
+    aten.adaptive_max_pool3d_backward.default: 3,
+    aten.max_unpool2d.default: 2,
+    aten.max_unpool3d.default: 3,
+}
+
+
 @register_single_dim_strategy(
     [
         aten.max_unpool2d.default,
@@ -1832,11 +1846,15 @@ def interp_pool_1out_2in_strategy(
     args_schema: tuple[Any, ...],
     kwargs_schema: dict[str, Any],
 ) -> list[list[Placement | _ShardingPlaceholder]]:
-    # 1 output + 2 inputs = 3 placements; shard on batch (0) and channel (1)
-    return [
+    # 1 output + 2 inputs = 3 placements
+    input_meta = cast(TensorMeta, args_schema[0])
+    strategies: list[list[Placement | _ShardingPlaceholder]] = [
         [_ShardingPlaceholder(0)] * 3,
-        [_ShardingPlaceholder(1)] * 3,
     ]
+    spatial_rank = POOL_BACKWARD_SPATIAL_RANK[op]
+    if len(input_meta.shape) >= spatial_rank + 2:
+        strategies.append([_ShardingPlaceholder(1)] * 3)
+    return strategies
 
 
 @register_single_dim_strategy(
@@ -1859,7 +1877,8 @@ def pool_backward_strategy(
     strategies: list[list[Placement | _ShardingPlaceholder]] = [
         [_ShardingPlaceholder(0)] * 4,
     ]
-    if len(input_meta.shape) >= 4:  # batched: (N, C, H, W)
+    spatial_rank = POOL_BACKWARD_SPATIAL_RANK[op]
+    if len(input_meta.shape) >= spatial_rank + 2:
         strategies.append([_ShardingPlaceholder(1)] * 4)
     # The backward is linear in grad_output, so P(sum/avg) pass through.
     # indices must be replicated (integer positions, not reducible).

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1845,8 +1845,6 @@ def interp_pool_1out_2in_strategy(
         aten.max_pool3d_with_indices_backward.default,
         aten.adaptive_max_pool2d_backward.default,
         aten.adaptive_max_pool3d_backward.default,
-        aten.fractional_max_pool2d_backward.default,
-        aten.fractional_max_pool3d_backward.default,
     ],
     schema_info=RuntimeSchemaInfo(1),
 )
@@ -1855,7 +1853,7 @@ def pool_backward_strategy(
     args_schema: tuple[Any, ...],
     kwargs_schema: dict[str, Any],
 ) -> list[list[Placement | _ShardingPlaceholder]]:
-    # All max-pool backward ops: (grad_output, self, ..., indices) -> grad_input
+    # max_pool/adaptive_max_pool backward ops: (grad_output, self, ..., indices) -> grad_input
     # 1 output + 3 tensor inputs = 4 placements
     input_meta = cast(TensorMeta, args_schema[0])
     strategies: list[list[Placement | _ShardingPlaceholder]] = [

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1821,6 +1821,9 @@ def interp_upsample_1out_1in_strategy(
         aten.max_unpool2d.default,
         aten.max_unpool3d.default,
         aten._adaptive_avg_pool2d_backward.default,
+        aten._adaptive_avg_pool3d_backward.default,
+        aten.avg_pool2d_backward.default,
+        aten.avg_pool3d_backward.default,
     ],
     schema_info=RuntimeSchemaInfo(1),
 )
@@ -1837,7 +1840,14 @@ def interp_pool_1out_2in_strategy(
 
 
 @register_single_dim_strategy(
-    [aten.max_pool2d_with_indices_backward.default],
+    [
+        aten.max_pool2d_with_indices_backward.default,
+        aten.max_pool3d_with_indices_backward.default,
+        aten.adaptive_max_pool2d_backward.default,
+        aten.adaptive_max_pool3d_backward.default,
+        aten.fractional_max_pool2d_backward.default,
+        aten.fractional_max_pool3d_backward.default,
+    ],
     schema_info=RuntimeSchemaInfo(1),
 )
 def pool_backward_strategy(
@@ -1845,9 +1855,8 @@ def pool_backward_strategy(
     args_schema: tuple[Any, ...],
     kwargs_schema: dict[str, Any],
 ) -> list[list[Placement | _ShardingPlaceholder]]:
-    # max_pool2d_with_indices_backward(grad_output, self, ..., indices) -> grad_input
+    # All max-pool backward ops: (grad_output, self, ..., indices) -> grad_input
     # 1 output + 3 tensor inputs = 4 placements
-    # Order: [output, grad_output, self, indices]
     input_meta = cast(TensorMeta, args_schema[0])
     strategies: list[list[Placement | _ShardingPlaceholder]] = [
         [_ShardingPlaceholder(0)] * 4,


### PR DESCRIPTION
Eight pooling backward aten ops lacked sharding strategies, causing hard crashes (RuntimeError: no sharding strategy registered) when backpropagating through sharded pooling layers. Add them to existing strategy functions:

- interp_pool_1out_2in_strategy: avg_pool2d/3d_backward, _adaptive_avg_pool3d_backward
- pool_backward_strategy: max_pool3d, adaptive_max_pool2d/3d, 
- fractional_max_pool2d/3d exluded due to xfailed forward 

Authored with Claude.