### PR TITLE
Use NCCLCommProvider for TorchComm + NCCL symmetric memory

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLCommProvider.hpp
+++ b/torch/csrc/distributed/c10d/NCCLCommProvider.hpp
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+namespace c10d {
+
+// Internal extension point for c10d backends that can expose an underlying
+// NCCL communicator to c10d-only integrations such as NCCL symmetric memory.
+class NCCLCommProvider {
+ public:
+  virtual ~NCCLCommProvider() = default;
+  virtual void* getNCCLCommPtr() const = 0;
+};
+
+} // namespace c10d

--- a/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <vector_types.h>
 #include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
+#include <torch/csrc/distributed/c10d/NCCLCommProvider.hpp>
 #include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
 #include <torch/csrc/distributed/c10d/cuda/utils.hpp>
@@ -151,10 +152,21 @@ class NCCLPeerAllocInfo : public c10::intrusive_ptr_target {
     auto group = resolve_process_group(group_name_);
     rank_ = group->getRank();
     world_size_ = group->getSize();
-    auto* ncclPg = dynamic_cast<c10d::ProcessGroupNCCL*>(
-        group->getBackend(c10::DeviceType::CUDA).get());
-    TORCH_CHECK(ncclPg != nullptr, "backend must be a NCCL process group");
-    comm_ = reinterpret_cast<ncclComm_t>(ncclPg->getCommPtr());
+    auto backend = group->getBackend(c10::DeviceType::CUDA);
+    if (auto* ncclPg =
+            dynamic_cast<c10d::ProcessGroupNCCL*>(backend.get())) {
+      comm_ = reinterpret_cast<ncclComm_t>(ncclPg->getCommPtr());
+    } else if (auto* commProvider =
+                   dynamic_cast<c10d::NCCLCommProvider*>(backend.get())) {
+      comm_ = reinterpret_cast<ncclComm_t>(commProvider->getNCCLCommPtr());
+    } else {
+      TORCH_CHECK(
+          false,
+          "NCCL symmetric memory requires a ProcessGroupNCCL backend or a backend that exposes NCCLCommProvider");
+    }
+    TORCH_CHECK(
+        comm_ != nullptr,
+        "NCCL symmetric memory requires a non-null NCCL communicator");
 
     C10D_NCCL_CHECK(
       ncclCommWindowRegister(comm_, allocation->ptr, buffer_size_, &buffer_win_, NCCL_WIN_COLL_SYMMETRIC),


### PR DESCRIPTION
Summary:
When the CUDA backend is a TorchComm backend (use_torchcomms=True), ProcessGroupNCCL's communicator cache is empty because TorchComm owns its own NCCL communicator. NCCLSymmetricMemory previously hard-coded ProcessGroupNCCL::getCommPtr(), which is null in this configuration and leads to ncclCommWindowRegister failures.

Introduce a lightweight c10d::NCCLCommProvider interface for c10d backends that can expose a borrowed NCCL communicator. NCCLSymmetricMemory still uses ProcessGroupNCCL directly first, then falls back to this provider interface, and fails with a clear error if neither path can provide a non-null communicator.

On the TorchComm side, TorchCommNCCLX implements a matching internal torch::comms::NCCLCommProvider hook. The generic BackendWrapper stays backend-agnostic: _BackendWrapper construction now goes through createBackendWrapper(), which returns the normal BackendWrapper for generic backends and a private NCCL-specific wrapper subclass only when the underlying TorchComm backend exposes the TorchComm NCCL provider. That NCCL-specific wrapper bridges to c10d::NCCLCommProvider without adding an NCCL method/base class to the generic BackendWrapper and without introducing a c10d -> TorchComm dependency.

Test Plan: CI

Differential Revision: D103732297


