### PR TITLE
index_add_/index_reduce_: add env-var kill switch for VecSize=4 vectorized path

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -17,6 +17,7 @@
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/CUDAUtils.h>
 #include <ATen/cuda/DeviceUtils.cuh>
+#include <c10/util/env.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -998,6 +999,16 @@ static size_t getSliceSize(const Tensor & dst,
   return dstSliceSize;
 }
 
+// Kill switch for the VecSize=4 fast path in indexFuncLargeIndex. The
+// vectorized path issues 4 atomicAdds back-to-back per warp on the same dst
+// row; under heavy-tailed index distributions this can serialize at the L2
+// atomic ALU and regress vs. the scalar path. Set to "1" to disable.
+// Read on every call (not cached) so tests can flip the env between calls;
+// the per-launch getenv cost is negligible against kernel launch overhead.
+inline bool indexFuncVectorizedDisabled() {
+  return c10::utils::check_env("TORCH_DISABLE_INDEX_ADD_VECTORIZED") == true;
+}
+
 // We prefer this kernel to avoid reloading index points if the number
 // of indices is a small number.
 // This kernel in fact works for all choices of problem size, but if
@@ -1250,14 +1261,25 @@ void index_add_cuda_impl(const Tensor& self, int64_t dim, const Tensor& index, c
     const TYPE innerSizeVal =                                                \
         static_cast<TYPE>((IDX_IS_MAJOR) ? sliceSize : numIndex);            \
     cuda::detail::IntDivider<TYPE> innerSizeDivider(innerSizeVal);           \
-    indexFuncLargeIndex<TENSOR_TYPE, INDICES_TYPE, TYPE,                     \
-                        SELF_DIM, SOURCE_DIM, IDX_DIM,                       \
-                        IDX_IS_MAJOR, (IDX_IS_MAJOR) ? 4 : 1>               \
-      <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(                     \
-        selfInfo, sourceInfo, indexInfo,                                     \
-        selfAddDim, sourceAddDim, sourceTotalSize,                          \
-        innerSizeVal, selfAddDimSize, selfNumel,                            \
-        reduce_add, alpha_value, innerSizeDivider);                         \
+    if ((IDX_IS_MAJOR) && !indexFuncVectorizedDisabled()) {                  \
+      indexFuncLargeIndex<TENSOR_TYPE, INDICES_TYPE, TYPE,                   \
+                          SELF_DIM, SOURCE_DIM, IDX_DIM,                     \
+                          IDX_IS_MAJOR, 4>                                   \
+        <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(                    \
+          selfInfo, sourceInfo, indexInfo,                                   \
+          selfAddDim, sourceAddDim, sourceTotalSize,                         \
+          innerSizeVal, selfAddDimSize, selfNumel,                           \
+          reduce_add, alpha_value, innerSizeDivider);                        \
+    } else {                                                                 \
+      indexFuncLargeIndex<TENSOR_TYPE, INDICES_TYPE, TYPE,                   \
+                          SELF_DIM, SOURCE_DIM, IDX_DIM,                     \
+                          IDX_IS_MAJOR, 1>                                   \
+        <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(                    \
+          selfInfo, sourceInfo, indexInfo,                                   \
+          selfAddDim, sourceAddDim, sourceTotalSize,                         \
+          innerSizeVal, selfAddDimSize, selfNumel,                           \
+          reduce_add, alpha_value, innerSizeDivider);                        \
+    }                                                                        \
   }                                                                          \
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
@@ -1431,14 +1453,25 @@ void index_reduce_func_cuda_impl(
     const TYPE innerSizeVal =                                                             \
         static_cast<TYPE>((IDX_IS_MAJOR) ? sliceSize : numIndex);                         \
     cuda::detail::IntDivider<TYPE> innerSizeDivider(innerSizeVal);                        \
-    indexFuncLargeIndex<TENSOR_TYPE, INDICES_TYPE, TYPE,                                  \
-                        SELF_DIM, SOURCE_DIM, IDX_DIM,                                     \
-                        IDX_IS_MAJOR, (IDX_IS_MAJOR) ? 4 : 1>                              \
-      <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(                                   \
-        selfInfo, sourceInfo, indexInfo,                                                   \
-        selfReduceDim, sourceReduceDim, sourceTotalSize,                                  \
-        innerSizeVal, selfReduceDimSize, selfNumel,                                       \
-        reduce_func, alpha_value, innerSizeDivider);                                      \
+    if ((IDX_IS_MAJOR) && !indexFuncVectorizedDisabled()) {                               \
+      indexFuncLargeIndex<TENSOR_TYPE, INDICES_TYPE, TYPE,                                \
+                          SELF_DIM, SOURCE_DIM, IDX_DIM,                                  \
+                          IDX_IS_MAJOR, 4>                                                \
+        <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(                                 \
+          selfInfo, sourceInfo, indexInfo,                                                \
+          selfReduceDim, sourceReduceDim, sourceTotalSize,                                \
+          innerSizeVal, selfReduceDimSize, selfNumel,                                     \
+          reduce_func, alpha_value, innerSizeDivider);                                    \
+    } else {                                                                              \
+      indexFuncLargeIndex<TENSOR_TYPE, INDICES_TYPE, TYPE,                                \
+                          SELF_DIM, SOURCE_DIM, IDX_DIM,                                  \
+                          IDX_IS_MAJOR, 1>                                                \
+        <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(                                 \
+          selfInfo, sourceInfo, indexInfo,                                                \
+          selfReduceDim, sourceReduceDim, sourceTotalSize,                                \
+          innerSizeVal, selfReduceDimSize, selfNumel,                                     \
+          reduce_func, alpha_value, innerSizeDivider);                                    \
+    }                                                                                     \
   }                                                                                       \
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1,11 +1,13 @@
 # Owner(s): ["module: tests"]
 
 import operator
+import os
 import random
 import unittest
 import warnings
 from functools import reduce
 from itertools import product
+from unittest import mock
 
 import numpy as np
 
@@ -2026,17 +2028,23 @@ class TestIndexing(TestCase):
     @onlyNativeDeviceTypes
     @skipMPS  # https://github.com/pytorch/pytorch/issues/161029
     @dtypes(torch.float, torch.bfloat16, torch.half)
-    def test_index_add_large_index_vectorized_path(self, device, dtype):
-        # Tests that exercise both the VecSize=4 (vectorized) and VecSize=1
-        # (scalar) paths in the indexFuncLargeIndex CUDA kernel.
-        # VecSize=4 activates when: IndexIsMajor=true, sliceSize % 4 == 0,
-        # and both dst/src have stride-1 on their innermost dimension.
-        # numIndex must be > 16 to hit the LargeIndex kernel at all.
+    @parametrize("disable_vec", ["0", "1"])
+    def test_index_add_large_index_vectorized_path(
+        self, device, dtype, disable_vec
+    ):
+        # Exercises both the VecSize=4 (vectorized) and VecSize=1 (scalar)
+        # paths in the indexFuncLargeIndex CUDA kernel. The path is selected
+        # at runtime by TORCH_DISABLE_INDEX_ADD_VECTORIZED ("0"=vec on,
+        # default; "1"=vec off). VecSize=4 activates when IndexIsMajor=true,
+        # sliceSize % 4 == 0, both dst/src have stride-1 on innermost dim,
+        # and the gate is not set. numIndex must be > 16 to hit LargeIndex
+        # at all.
         #
-        # Strategy: for each shape that hits the vectorized path, also run
-        # the same operation with sliceSize+1 (which forces the scalar path)
-        # and compare both against a CPU float reference.  We use UNIQUE
-        # indices to avoid non-deterministic atomic accumulation ordering.
+        # Each shape is run with sliceSize divisible by 4 (vec-eligible),
+        # not divisible by 4 (forces scalar even with vec on), non-contig
+        # (forces scalar), IndexIsMajor=false (forces scalar), and 3-D.
+        # All against a CPU float reference. UNIQUE indices avoid
+        # nondeterministic atomic accumulation order.
         num_idx = 64
         num_dest = 100
 
@@ -2047,11 +2055,9 @@ class TestIndexing(TestCase):
             src = torch.randn(src_shape, dtype=dtype, device=device)
             index = torch.randperm(num_dest_dim, device=device)[:num_idx]
 
-            # Reference: run the same op on CPU in float
             dst_ref = dst.detach().cpu().float()
             src_ref = src.detach().cpu().float()
-            idx_cpu = index.cpu()
-            dst_ref.index_add_(dim, idx_cpu, src_ref)
+            dst_ref.index_add_(dim, index.cpu(), src_ref)
 
             dst.index_add_(dim, index, src)
 
@@ -2066,65 +2072,70 @@ class TestIndexing(TestCase):
                 msg=f"Failed for {tag}, shape={dst_shape}, dim={dim}",
             )
 
-        # --- VecSize=4 path: contiguous, dim=0, sliceSize divisible by 4 ---
-        for slice_size in [32, 128, 256]:
-            _run_and_check(
-                (num_dest, slice_size),
-                0,
-                num_idx,
-                num_dest,
-                f"vec4 sliceSize={slice_size}",
+        with mock.patch.dict(
+            os.environ, {"TORCH_DISABLE_INDEX_ADD_VECTORIZED": disable_vec}
+        ):
+            # VecSize=4-eligible: contiguous, dim=0, sliceSize divisible by 4
+            for slice_size in [32, 128, 256]:
+                _run_and_check(
+                    (num_dest, slice_size),
+                    0,
+                    num_idx,
+                    num_dest,
+                    f"vec-eligible sliceSize={slice_size}",
+                )
+
+            # Forces scalar even with vec on: sliceSize NOT divisible by 4
+            for slice_size in [3, 17, 33]:
+                _run_and_check(
+                    (num_dest, slice_size),
+                    0,
+                    num_idx,
+                    num_dest,
+                    f"scalar sliceSize={slice_size}",
+                )
+
+            # Forces scalar even with vec on: non-contiguous (stride != 1
+            # on innermost dim).
+            dst_base = torch.zeros(num_dest, 256, dtype=dtype, device=device)
+            src_base = torch.randn(num_idx, 256, dtype=dtype, device=device)
+            dst = dst_base[:, ::2]  # shape [100, 128], stride [256, 2]
+            src = src_base[:, ::2]
+            index = torch.randperm(num_dest, device=device)[:num_idx]
+
+            dst_ref = dst.detach().cpu().float().contiguous()
+            src_ref = src.detach().cpu().float().contiguous()
+            dst_ref.index_add_(0, index.cpu(), src_ref)
+            dst.index_add_(0, index, src)
+            atol, rtol = (
+                (1e-2, 1e-2) if dtype in (torch.bfloat16, torch.half) else (1e-5, 1e-5)
+            )
+            self.assertEqual(
+                dst.cpu().float(),
+                dst_ref,
+                atol=atol,
+                rtol=rtol,
+                msg="Failed for non-contiguous (stride-2)",
             )
 
-        # --- VecSize=1 path: sliceSize NOT divisible by 4 ---
-        for slice_size in [3, 17, 33]:
+            # Forces scalar even with vec on: IndexIsMajor=false (dim=1 on
+            # row-major tensor).
             _run_and_check(
-                (num_dest, slice_size),
-                0,
+                (32, num_dest),
+                1,
                 num_idx,
                 num_dest,
-                f"scalar sliceSize={slice_size}",
+                "IndexIsMajor=false dim=1",
             )
 
-        # --- VecSize=1 path: non-contiguous (stride != 1 on inner dim) ---
-        dst_base = torch.zeros(num_dest, 256, dtype=dtype, device=device)
-        src_base = torch.randn(num_idx, 256, dtype=dtype, device=device)
-        dst = dst_base[:, ::2]  # shape [100, 128], stride [256, 2]
-        src = src_base[:, ::2]
-        index = torch.randperm(num_dest, device=device)[:num_idx]
-
-        dst_ref = dst.detach().cpu().float().contiguous()
-        src_ref = src.detach().cpu().float().contiguous()
-        dst_ref.index_add_(0, index.cpu(), src_ref)
-        dst.index_add_(0, index, src)
-        atol, rtol = (
-            (1e-2, 1e-2) if dtype in (torch.bfloat16, torch.half) else (1e-5, 1e-5)
-        )
-        self.assertEqual(
-            dst.cpu().float(),
-            dst_ref,
-            atol=atol,
-            rtol=rtol,
-            msg="Failed for non-contiguous (stride-2)",
-        )
-
-        # --- VecSize=1 path: IndexIsMajor=false (dim=1 on row-major tensor) ---
-        _run_and_check(
-            (32, num_dest),
-            1,
-            num_idx,
-            num_dest,
-            "IndexIsMajor=false dim=1",
-        )
-
-        # --- VecSize=4 path: 3-D contiguous, dim=0, sliceSize divisible by 4 ---
-        _run_and_check(
-            (100, 8, 16),
-            0,
-            num_idx,
-            100,
-            "3D vec4 sliceSize=128",
-        )
+            # 3-D contiguous, dim=0, sliceSize divisible by 4
+            _run_and_check(
+                (100, 8, 16),
+                0,
+                num_idx,
+                100,
+                "3D vec-eligible sliceSize=128",
+            )
 
     @onlyNativeDeviceTypes
     @expectedFailureMPS  # See https://github.com/pytorch/pytorch/issues/161029


### PR DESCRIPTION
Summary:
D94314062 introduced a VecSize=4 fast path in indexFuncLargeIndex that amortizes divmod and index lookup by having each thread process consecutive elements. 

On uniform-random workloads this gives a ~1.8-2.0x speedup. However, when the index distribution is heavy-tailed (e.g. zipf, or skewed where a few hot rows receive millions of writes), the fast path issues 4 atomicAdds back-to-back from the same warp into consecutive cache lines of the same destination row. 

The L2 atomic queue cannot drain between the unrolled rounds, and the resulting serialization causes a 4.7x slowdown on fp32 zipf inputs (and ~2x on bf16). Measured on a B200 with dst=[1.72M,128] and nIdx=7.77M:

{F1989310065} 

Add a TORCH_DISABLE_INDEX_ADD_VECTORIZED env var as a kill switch following the TORCH_CUDNN_V8_API_DISABLED pattern. Default behavior is unchanged (vec on); setting the env var to 1 reverts to the scalar path. The check is read on every call (not cached) so tests can flip the env between calls; the per-launch getenv cost is negligible against
kernel launch overhead.

Test Plan:
test_index_add_large_index_vectorized_path is parametrized over the env var so both paths are covered by the test suite. Each parametrized instance exercises vec-eligible shapes (sliceSize divisible by 4), vec-ineligible shapes (sliceSize not divisible by 4, non-contig, IndexIsMajor=false), and a 3-D contiguous case, against a CPU float reference using unique indices to avoid nondeterministic accumulation order.


Test on a skewed workload: 

the baseline: 
https://www.internalfb.com/mast/job/fire-yujiah-20260503-1551-705541e6

trace: https://www.internalfb.com/intern/kernelhub/perfetto/?bucket=mvai_gpu_traces&trace_path=tree%2Ftraces%2Fdynocli%2Ffire-yujiah-20260503-1551-705541e6%2F0%2Frank-0.May_03_16_36_39.3929.pt.trace.json.gz

the test:
https://www.internalfb.com/mast/job/fire-yujiah-20260504-2153-59398545

trace: https://www.internalfb.com/intern/kernelhub/perfetto/?bucket=mvai_gpu_traces&trace_path=tree%2Ftraces%2Fdynocli%2Ffire-yujiah-20260504-2153-59398545%2F0%2Frank-0.May_04_23_14_03.4225.pt.trace.json.gz

Differential Revision: D103765236


