### PR TITLE
change intspec as per recent discussions

### DIFF
--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -40,6 +40,7 @@ def _apply_spec_to_tensor(tensor, shape_spec):
 def _compile_with_dynamic_shapes(fn, dynamic_spec, **compile_kwargs):
     """Compile ``fn`` and apply ``dynamic_spec`` specs on every call."""
 
+    compile_kwargs.setdefault("dynamic", False)
     compiled = torch.compile(fn, **compile_kwargs)
     sig = inspect.signature(fn)
 
@@ -247,7 +248,6 @@ class TestShapeVarCompile(TestCase):
             lambda x: x + 1,
             {"x": ts},
             backend=backend,
-            dynamic=False,
         )
 
         fn(torch.randn(4, 3))

--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -6,17 +6,13 @@ import torch
 import torch._dynamo
 import torch._dynamo.testing
 import torch.fx.experimental._config as _fx_experimental_config
-from torch._dynamo.decorators import mark_static, mark_unbacked, maybe_mark_dynamic
-from torch._dynamo.dynamic_spec import IntSpec, IntSpecType, TensorSpec
+from torch._dynamo.decorators import mark_unbacked
+from torch._dynamo.dynamic_spec import IntVar, ShapeVar, TensorSpec
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import EagerAndRecordGraphs
 from torch.fx.experimental.symbolic_shapes import (
     free_unbacked_symbols,
     GuardOnDataDependentSymNode,
-)
-from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
-    parametrize,
 )
 
 
@@ -30,29 +26,19 @@ def _tensor_placeholder_shape(gm):
     raise AssertionError("no tensor placeholder found")
 
 
-# Applies per-dim IntSpec to a tensor through ``mark_*`` on each call.
-# ``shape_spec`` must be a ``TensorSpec`` (or ``None`` to skip).
-def _apply_intspec_to_tensor(tensor, shape_spec):
+def _apply_spec_to_tensor(tensor, shape_spec):
+    """Apply per-dim spec to a tensor through ``mark_*`` on each dim.
+    This is only for testing purposes. Will be removed in next PR.
+    """
     if not isinstance(shape_spec, TensorSpec):
         return
     for idx, spec in enumerate(shape_spec):
-        if spec is None:
-            continue
-        if spec._type is IntSpecType.STATIC:
-            mark_static(tensor, idx)
-        elif spec._type is IntSpecType.BACKED:
-            maybe_mark_dynamic(tensor, idx)
-        elif spec._type is IntSpecType.UNBACKED:
+        if isinstance(spec, IntVar):
             mark_unbacked(tensor, idx)
 
 
-def _compile_with_dynamic_shapes(fn, dynamic_shapes, **compile_kwargs):
-    """Compile ``fn`` and apply ``dynamic_shapes`` specs on every call.
-
-    On each call, the wrapper inspects ``dynamic_shapes`` and calls the
-    appropriate ``mark_static`` / ``maybe_mark_dynamic`` / ``mark_unbacked``
-    on each tensor argument before forwarding to the compiled function.
-    """
+def _compile_with_dynamic_shapes(fn, dynamic_spec, **compile_kwargs):
+    """Compile ``fn`` and apply ``dynamic_spec`` specs on every call."""
 
     compiled = torch.compile(fn, **compile_kwargs)
     sig = inspect.signature(fn)
@@ -61,568 +47,165 @@ def _compile_with_dynamic_shapes(fn, dynamic_shapes, **compile_kwargs):
     def wrapper(*args, **kwargs):
         bound = sig.bind(*args, **kwargs)
         bound.apply_defaults()
-        for name, shape_spec in dynamic_shapes.items():
+        for name, shape_spec in dynamic_spec.items():
             if name in bound.arguments:
                 arg = bound.arguments[name]
                 if isinstance(arg, torch.Tensor):
-                    _apply_intspec_to_tensor(arg, shape_spec)
+                    _apply_spec_to_tensor(arg, shape_spec)
         return compiled(*bound.args, **bound.kwargs)
 
     return wrapper
 
 
-class TestIntSpecConstruction(TestCase):
-    """Construction via the classmethod factories.
+class TestShapeVarConstruction(TestCase):
+    """Construction of ShapeVar."""
 
-    Field reads use the private slots (``s._name``, ``s._min``, etc.) since
-    the fluent setters are write-only.
-    """
+    def test_basic(self):
+        s = ShapeVar("batch")
+        self.assertEqual(s.name, "batch")
+        self.assertEqual(s.min, 0)
+        self.assertIsNone(s.max)
+        self.assertIsNone(s.optimization_hint)
 
-    def test_static(self):
-        s = IntSpec.static("x", value=10)
-        self.assertEqual(s._name, "x")
-        self.assertEqual(s._type, IntSpecType.STATIC)
-        self.assertEqual(s._value, 10)
+    def test_with_max(self):
+        s = ShapeVar("batch", max=64)
+        self.assertEqual(s.max, 64)
 
-    def test_static_no_value(self):
-        s = IntSpec.static()
-        self.assertEqual(s._type, IntSpecType.STATIC)
-        self.assertIsNone(s._value)
-        # ``name=None`` auto-fills with a stable per-instance handle.
-        self.assertTrue(s._name.startswith("_intspec_static_"))
+    def test_with_optimization_hint(self):
+        s = ShapeVar("seq", max=2048, optimization_hint=512)
+        self.assertEqual(s.max, 2048)
+        self.assertEqual(s.optimization_hint, 512)
+
+    def test_anonymous_name(self):
+        s = ShapeVar()
+        self.assertTrue(s.name.startswith("_intvar_"))
 
     def test_anonymous_specs_have_distinct_names(self):
-        # Two anonymous specs of the same mode get different auto-names so
-        # they can be distinguished in error messages / logs.
-        a = IntSpec.static()
-        b = IntSpec.static()
-        self.assertNotEqual(a._name, b._name)
+        a = ShapeVar()
+        b = ShapeVar()
+        self.assertNotEqual(a.name, b.name)
 
-    def test_backed(self):
-        s = IntSpec.backed("batch", min=1, max=64, guarding_hint=32)
-        self.assertEqual(s._name, "batch")
-        self.assertEqual(s._type, IntSpecType.BACKED)
-        self.assertEqual(s._min, 1)
-        self.assertEqual(s._max, 64)
-        self.assertEqual(s._guarding_hint, 32)
-
-    def test_unbacked(self):
-        s = IntSpec.unbacked("seq", min=1, max=2048, optimization_hint=512)
-        self.assertEqual(s._type, IntSpecType.UNBACKED)
-        self.assertEqual(s._min, 1)
-        self.assertEqual(s._max, 2048)
-        self.assertEqual(s._optimization_hint, 512)
-
-    def test_type_required_on_init(self):
-        with self.assertRaises(TypeError) as cm:
-            IntSpec("x")  # no type kwarg
-        # Python-generated message; format pinned for 3.10+.
-        self.assertEqual(
-            str(cm.exception),
-            "IntSpec.__init__() missing 1 required positional argument: 'type'",
-        )
-
-    def test_type_not_none(self):
-        with self.assertRaises(TypeError) as cm:
-            IntSpec("x", type=None)  # type: ignore[arg-type]
-        self.assertEqual(
-            str(cm.exception),
-            "IntSpec type must be an IntSpecType, got None",
-        )
-
-    def test_type_as_positional_arg(self):
-        s = IntSpec("batch", IntSpecType.BACKED, min=1, max=64)
-        self.assertEqual(s._name, "batch")
-        self.assertEqual(s._type, IntSpecType.BACKED)
-        self.assertEqual(s._min, 1)
-        self.assertEqual(s._max, 64)
-
-    def test_static_with_positional_int_rejected(self):
-        # ``IntSpec.static(10)`` would silently bind 10 to ``name``. Must
-        # fail with a clear redirect to the kwarg form.
-        with self.assertRaises(TypeError) as cm:
-            IntSpec.static(10)  # type: ignore[arg-type]
-        self.assertEqual(
-            str(cm.exception),
-            "IntSpec.name must be str or None, got int; "
-            "if you meant to pass a value/hint, use a keyword argument "
-            "(e.g. IntSpec.static(value=10))",
-        )
-
-    def test_backed_with_positional_int_rejected(self):
-        with self.assertRaises(TypeError) as cm:
-            IntSpec.backed(5)  # type: ignore[arg-type]
-        self.assertEqual(
-            str(cm.exception),
-            "IntSpec.name must be str or None, got int; "
-            "if you meant to pass a value/hint, use a keyword argument "
-            "(e.g. IntSpec.backed(guarding_hint=5))",
-        )
-
-    def test_unbacked_with_positional_int_rejected(self):
-        with self.assertRaises(TypeError) as cm:
-            IntSpec.unbacked(5)  # type: ignore[arg-type]
-        self.assertEqual(
-            str(cm.exception),
-            "IntSpec.name must be str or None, got int; "
-            "if you meant to pass a value/hint, use a keyword argument "
-            "(e.g. IntSpec.unbacked(optimization_hint=5))",
-        )
-
-    def test_name_wrong_type_on_init(self):
-        with self.assertRaises(TypeError) as cm:
-            IntSpec(10, IntSpecType.STATIC)  # type: ignore[arg-type]
-        self.assertEqual(
-            str(cm.exception),
-            "IntSpec.name must be str or None, got int; "
-            "if you meant to pass a value/hint, use a keyword argument "
-            "(e.g. IntSpec.static(value=10))",
-        )
+    def test_is_instance_of_intvar(self):
+        s = ShapeVar("batch")
+        self.assertIsInstance(s, IntVar)
 
     def test_repr(self):
-        # Anonymous: name is auto-generated; check shape via prefix since
-        # the trailing id-hex is process-dependent.
-        anon = repr(IntSpec.static())
-        self.assertTrue(anon.startswith("IntSpec(name='_intspec_static_"))
-        self.assertIn("type=STATIC", anon)
-        # Named + value.
+        s = ShapeVar("batch", max=64, optimization_hint=32)
         self.assertEqual(
-            repr(IntSpec.static("x", value=10)),
-            "IntSpec(name='x', type=STATIC, value=10)",
-        )
-        # BACKED with full set of fields.
-        self.assertEqual(
-            repr(IntSpec.backed("batch", min=1, max=64, guarding_hint=32)),
-            "IntSpec(name='batch', type=BACKED, min=1, max=64, guarding_hint=32)",
-        )
-        # UNBACKED with full set of fields.
-        self.assertEqual(
-            repr(IntSpec.unbacked("seq", min=1, max=2048, optimization_hint=512)),
-            "IntSpec(name='seq', type=UNBACKED, min=1, max=2048, optimization_hint=512)",
+            repr(s), "ShapeVar(name='batch', min=0, max=64, optimization_hint=32)"
         )
 
+    def test_repr_minimal(self):
+        s = ShapeVar("x")
+        self.assertEqual(repr(s), "ShapeVar(name='x', min=0)")
 
-class TestIntSpecTypeImmutable(TestCase):
-    """Only ``type`` is pinned. All other fields can be reassigned via the
-    fluent setters. This class verifies the type-pin guard, slot discipline
-    (no new attrs, cannot delete), and that the mutable fields can in fact
-    be updated."""
+    def test_implicit_min_is_zero(self):
+        s = ShapeVar("x")
+        self.assertEqual(s.min, 0)
 
-    def test_type_reassign_via_private_slot_rejected(self):
-        # The backing ``_type`` slot is locked: our ``__setattr__``
-        # guard catches reassignment. Reads through ``_type`` are fine.
-        s = IntSpec.backed("x")
-        with self.assertRaises(AttributeError) as cm:
-            s._type = IntSpecType.STATIC
+    def test_custom_min(self):
+        s = ShapeVar("x", min=1)
+        self.assertEqual(s.min, 1)
+
+
+class TestIntVarConstruction(TestCase):
+    """Construction of IntVar."""
+
+    def test_basic(self):
+        s = IntVar("offset")
+        self.assertEqual(s.name, "offset")
+        self.assertIsNone(s.min)
+        self.assertIsNone(s.max)
+        self.assertIsNone(s.optimization_hint)
+
+    def test_with_range(self):
+        s = IntVar("offset", min=-100, max=100)
+        self.assertEqual(s.min, -100)
+        self.assertEqual(s.max, 100)
+
+    def test_with_optimization_hint(self):
+        s = IntVar("size", min=1, max=2048, optimization_hint=512)
+        self.assertEqual(s.optimization_hint, 512)
+
+    def test_anonymous_name(self):
+        s = IntVar()
+        self.assertTrue(s.name.startswith("_intvar_"))
+
+    def test_anonymous_specs_have_distinct_names(self):
+        a = IntVar()
+        b = IntVar()
+        self.assertNotEqual(a.name, b.name)
+
+    def test_allows_negative_range(self):
+        s = IntVar("offset", min=-50, max=-10)
+        self.assertEqual(s.min, -50)
+        self.assertEqual(s.max, -10)
+
+    def test_repr(self):
+        s = IntVar("offset", min=-100, max=100, optimization_hint=0)
         self.assertEqual(
-            str(cm.exception),
-            "IntSpec type is immutable; cannot reassign",
-        )
-        self.assertIs(s._type, IntSpecType.BACKED)
-
-    def test_no_fluent_type_reset(self):
-        # IntSpec has no instance method that reassigns type. The mode-named
-        # factories are classmethods: calling one "on an instance" returns a
-        # fresh IntSpec and does not mutate the original.
-        s = IntSpec.static("x")
-        new = IntSpec.backed("x")
-        self.assertIs(s._type, IntSpecType.STATIC)
-        self.assertIs(new._type, IntSpecType.BACKED)
-        self.assertIsNot(s, new)
-
-    def test_cannot_add_new_attribute(self):
-        # __slots__ rejects unknown attributes at the slot layer; message
-        # is Python-built and version-dependent, so we only assert the type.
-        s = IntSpec.static("x")
-        with self.assertRaises(AttributeError):
-            s.brand_new_field = 1  # type: ignore[attr-defined]
-
-    def test_cannot_assign_to_method_name(self):
-        # ``value`` / ``min`` / ``max`` / ``guarding_hint`` /
-        # ``optimization_hint`` are method names backed by ``_value`` /
-        # ``_min`` / etc. slots. Direct attribute assignment under those
-        # public names has no matching slot and is rejected.
-        s = IntSpec.static("x", value=10)
-        for attr in ("value", "min", "max", "guarding_hint", "optimization_hint"):
-            with self.assertRaises(AttributeError):
-                setattr(s, attr, 20)
-
-    def test_cannot_delete_attribute(self):
-        s = IntSpec.backed("x", guarding_hint=32)
-        with self.assertRaises(AttributeError) as cm:
-            del s._guarding_hint
-        self.assertEqual(
-            str(cm.exception),
-            "IntSpec attribute '_guarding_hint' cannot be deleted",
+            repr(s), "IntVar(name='offset', min=-100, max=100, optimization_hint=0)"
         )
 
-
-class TestIntSpecFluent(TestCase):
-    """Fluent setters (``name`` / ``min`` / ``max`` / ``value`` /
-    ``guarding_hint`` / ``optimization_hint``) mutate the receiver in place
-    and return ``self`` for chaining. Each chain is equivalent to the
-    kwargs-only factory form."""
-
-    def test_setter_returns_self_for_chaining(self):
-        base = IntSpec.unbacked("seq")
-        chained = base.min(1).max(2048)
-        # Mutated in place, same object back.
-        self.assertIs(base, chained)
-        self.assertEqual(base._min, 1)
-        self.assertEqual(base._max, 2048)
-
-    def test_fluent_preserves_existing_fields(self):
-        s = IntSpec.backed("batch", min=1, guarding_hint=32).max(64)
-        self.assertEqual(s._min, 1)
-        self.assertEqual(s._max, 64)
-        self.assertEqual(s._guarding_hint, 32)
-
-    def test_failed_setter_rolls_back_per_mode(self):
-        # Per-mode rejection (guarding_hint on STATIC) must roll the slot
-        # back so the spec stays in a consistent state.
-        s = IntSpec.static("x", value=10)
-        with self.assertRaises(ValueError):
-            s.guarding_hint(99)
-        self.assertIsNone(s._guarding_hint)
-        self.assertEqual(s._value, 10)
-
-    def test_failed_setter_rolls_back_min_max(self):
-        # Cross-field check (min <= max) also rolls back.
-        s = IntSpec.backed("x", min=10, max=20)
-        with self.assertRaises(ValueError):
-            s.max(5)
-        self.assertEqual(s._max, 20)
-
-
-@instantiate_parametrized_tests
-class TestIntSpecRejectionRules(TestCase):
-    """Per-mode field-rejection rules, exercised via both entry points.
-
-    Each rule fires inside :meth:`IntSpec._validate`, reached from two
-    user-visible paths:
-
-    - ``init``: direct kwargs at the raw constructor, e.g.
-      ``IntSpec("x", IntSpecType.STATIC, guarding_hint=10)``.
-    - ``fluent``: fluent setter chained off a factory, e.g.
-      ``IntSpec.static("x").guarding_hint(10)``.
-
-    Both paths produce the same error message because the constructor
-    and the fluent setter both call ``_validate`` (the fluent setter via
-    ``_try_set``). Parametrizing the entry-point axis keeps a single
-    source of truth per rule.
-    """
-
-    @parametrize("entry", ["init", "fluent"])
-    @parametrize(
-        "IntSpecFactory,mode",
-        [
-            (IntSpec.backed, IntSpecType.BACKED),
-            (IntSpec.unbacked, IntSpecType.UNBACKED),
-        ],
-    )
-    def test_value_rejected_on_non_static(self, IntSpecFactory, mode, entry):
-        if entry == "init":
-            ctor = lambda: IntSpec("x", mode, value=42)  # noqa: E731
-        else:
-            ctor = lambda: IntSpecFactory("x").value(42)  # noqa: E731
-        with self.assertRaises(ValueError) as cm:
-            ctor()
-        self.assertEqual(str(cm.exception), "value is only valid for STATIC IntSpec")
-
-    @parametrize("entry", ["init", "fluent"])
-    @parametrize(
-        "IntSpecFactory,mode",
-        [
-            (IntSpec.static, IntSpecType.STATIC),
-            (IntSpec.unbacked, IntSpecType.UNBACKED),
-        ],
-    )
-    def test_guarding_hint_rejected_on_non_backed(self, IntSpecFactory, mode, entry):
-        if entry == "init":
-            ctor = lambda: IntSpec("x", mode, guarding_hint=10)  # noqa: E731
-        else:
-            ctor = lambda: IntSpecFactory("x").guarding_hint(10)  # noqa: E731
-        with self.assertRaises(ValueError) as cm:
-            ctor()
-        self.assertEqual(
-            str(cm.exception), "guarding_hint is only valid for BACKED IntSpec"
-        )
-
-    @parametrize("entry", ["init", "fluent"])
-    @parametrize(
-        "IntSpecFactory,mode",
-        [
-            (IntSpec.static, IntSpecType.STATIC),
-            (IntSpec.backed, IntSpecType.BACKED),
-        ],
-    )
-    def test_optimization_hint_rejected_on_non_unbacked(
-        self, IntSpecFactory, mode, entry
-    ):
-        if entry == "init":
-            ctor = lambda: IntSpec("x", mode, optimization_hint=10)  # noqa: E731
-        else:
-            ctor = lambda: IntSpecFactory("x").optimization_hint(10)  # noqa: E731
-        with self.assertRaises(ValueError) as cm:
-            ctor()
-        self.assertEqual(
-            str(cm.exception),
-            "optimization_hint is only valid for UNBACKED IntSpec",
-        )
-
-    @parametrize("entry", ["init", "fluent"])
-    @parametrize("field", ["min", "max"])
-    def test_min_max_rejected_on_static(self, field, entry):
-        if entry == "init":
-            ctor = lambda: IntSpec("x", IntSpecType.STATIC, **{field: 1})  # noqa: E731
-        else:
-            ctor = lambda: getattr(IntSpec.static("x"), field)(1)  # noqa: E731
-        with self.assertRaises(ValueError) as cm:
-            ctor()
-        self.assertEqual(
-            str(cm.exception),
-            "min/max are only valid for BACKED/UNBACKED IntSpec, not STATIC",
-        )
-
-    @parametrize("IntSpecFactory", [IntSpec.backed, IntSpec.unbacked])
-    def test_IntSpec_min_greater_than_max_rejected(self, IntSpecFactory):
-        with self.assertRaises(ValueError) as cm:
-            IntSpecFactory("x", min=100, max=1)
-        self.assertEqual(
-            str(cm.exception),
-            "min must be <= max, got min=100, max=1",
-        )
-
-    # Each case: (field, bad_value, factory_name, expected_type_name).
-    # ``factory_name`` is the factory whose mode allows the field — we
-    # exercise the type check on the valid mode since mode-rejection is
-    # already covered by the four tests above.
-    _TYPE_CASES = [
-        ("value", "10", "static", "str"),
-        ("min", 1.5, "backed", "float"),
-        ("max", "64", "backed", "str"),
-        ("guarding_hint", True, "backed", "bool"),
-        ("optimization_hint", 1.0, "unbacked", "float"),
-    ]
-
-    @parametrize("entry", ["init", "fluent"])
-    @parametrize("field,bad,factory_name,type_name", _TYPE_CASES)
-    def test_field_type_rejected(self, field, bad, factory_name, type_name, entry):
-        factory = getattr(IntSpec, factory_name)
-        if entry == "init":
-            ctor = lambda: factory("x", **{field: bad})  # noqa: E731
-        else:
-            ctor = lambda: getattr(factory("x"), field)(bad)  # noqa: E731
-        with self.assertRaises(TypeError) as cm:
-            ctor()
-        self.assertEqual(
-            str(cm.exception),
-            f"IntSpec.{field} must be int or None, got {type_name}",
-        )
+    def test_repr_minimal(self):
+        s = IntVar("x")
+        self.assertEqual(repr(s), "IntVar(name='x')")
 
 
 class TestTensorSpecConstruction(TestCase):
     """Construction and list-like interface."""
 
-    def test_basic(self):
-        ts = TensorSpec(3)
-        self.assertEqual(ts._dim, 3)
-        for spec in ts:
-            self.assertIsNone(spec)
-
-    def test_zero_dim(self):
-        ts = TensorSpec(0)
-        self.assertEqual(ts._dim, 0)
-
     def test_list_construction(self):
-        static_spec = IntSpec.static(value=10)
-        backed_spec = IntSpec.backed(min=1)
-        ts = TensorSpec([static_spec, None, backed_spec])
-        self.assertEqual(
-            repr(ts),
-            f"TensorSpec([{repr(static_spec)}, None, {repr(backed_spec)}])",
-        )
+        ts = TensorSpec([ShapeVar("batch"), None, 10])
+        self.assertIsInstance(ts[0], ShapeVar)
+        self.assertIsNone(ts[1])
+        self.assertEqual(ts[2], 10)
 
-    def test_dict_construction(self):
-        backed_spec = IntSpec.backed("h")
-        static_spec = IntSpec.static()
-        ts = TensorSpec({0: backed_spec, 2: static_spec})
-        self.assertEqual(
-            repr(ts), f"TensorSpec([{repr(backed_spec)}, None, {repr(static_spec)}])"
-        )
-
-    def test_unsupported_input_type_rejected(self):
-        with self.assertRaisesRegex(TypeError, "expects int / list / tuple / dict"):
-            TensorSpec("not a spec")  # type: ignore[arg-type]
-
-    def test_getitem_setitem(self):
-        ts = TensorSpec(2)
-        spec = IntSpec.backed("batch", min=1)
-        ts[0] = spec
-        self.assertIs(ts[0], spec)
+    def test_tuple_construction(self):
+        ts = TensorSpec((ShapeVar("batch"), None))
+        self.assertEqual(len(ts), 2)
+        self.assertIsInstance(ts[0], ShapeVar)
         self.assertIsNone(ts[1])
 
+    def test_len(self):
+        ts = TensorSpec([None, None, None])
+        self.assertEqual(len(ts), 3)
+
     def test_iter(self):
-        ts = TensorSpec(2)
-        spec = IntSpec.static(value=5)
-        ts[0] = spec
+        sv = ShapeVar("batch")
+        ts = TensorSpec([sv, None])
         items = list(ts)
         self.assertEqual(len(items), 2)
-        self.assertIs(items[0], spec)
+        self.assertIs(items[0], sv)
         self.assertIsNone(items[1])
 
     def test_index_out_of_range(self):
-        ts = TensorSpec(2)
+        ts = TensorSpec([None, None])
         with self.assertRaises(IndexError):
             ts[5]
 
-    def test_sparse_set(self):
-        ts = TensorSpec(4)
-        ts.dim(1, IntSpec.backed("h"))
-        ts.dim(3, IntSpec.backed("w"))
-        self.assertIsNone(ts[0])
-        self.assertIsNotNone(ts[1])
-        self.assertIsNone(ts[2])
-        self.assertIsNotNone(ts[3])
+    def test_repr(self):
+        ts = TensorSpec([ShapeVar("batch"), None, 10])
+        r = repr(ts)
+        self.assertIn("ShapeVar(", r)
+        self.assertIn("None", r)
+        self.assertIn("10", r)
 
 
-class TestTensorSpecCompile(TestCase):
-    """TensorSpec + compile integration via the test-local
-    `_compile_with_dynamic_shapes` helper. Same scaffolding path as
-    `TestIntSpecCompile` — the helper walks per-dim ``IntSpec`` from
-    the TensorSpec and applies ``mark_*`` to the tensor.
-    """
-
-    def test_tensorspec_list_init_recompile_progression(self):
-        """TensorSpec built from a list: dim 0 BACKED absorbs shape changes;
-        dim 1 STATIC forces recompile per distinct value.
-
-        Final graph has a backed SymInt at dim 0 and a concrete int at dim 1.
-        """
-        backend = EagerAndRecordGraphs()
-        ts = TensorSpec([IntSpec.backed("batch"), IntSpec.static()])
-        fn = _compile_with_dynamic_shapes(
-            lambda x: x + 1,
-            {"x": ts},
-            backend=backend,
-        )
-
-        fn(torch.randn(4, 3))
-        self.assertEqual(len(backend.graphs), 1)
-
-        # Vary dim 0 (BACKED absorbs it → no new compile).
-        fn(torch.randn(8, 3))
-        fn(torch.randn(16, 3))
-        self.assertEqual(len(backend.graphs), 1)
-
-        # Vary dim 1 (STATIC pins it → each distinct value recompiles).
-        fn(torch.randn(16, 5))
-        self.assertEqual(len(backend.graphs), 2)
-        fn(torch.randn(16, 7))
-        self.assertEqual(len(backend.graphs), 3)
-
-        shape = _tensor_placeholder_shape(backend.graphs[-1])
-        self.assertIsInstance(shape[0], torch.SymInt)
-        self.assertEqual(len(free_unbacked_symbols(shape[0])), 0)
-        self.assertIsInstance(shape[1], int)
-        self.assertEqual(shape[1], 7)
-
-    @torch._dynamo.config.patch(automatic_dynamic_shapes=True)
-    def test_tensorspec_none_entry_inherits_automatic_dynamic(self):
-        """A ``None`` entry doesn't mark the dim — it falls through to the
-        existing default policy: dynamo's automatic-dynamic
-        (``torch._dynamo.config.automatic_dynamic_shapes``, default True).
-        That means specialize on first call, promote to backed on first
-        variation.
-
-        The decorator pins the config to ``True`` so the test is robust to
-        any CI environment that might flip the default. This mainly test
-        config inheritance, not the default policy itself.
-        """
-        backend = EagerAndRecordGraphs()
-        ts = TensorSpec([IntSpec.backed("batch"), None])
-        fn = _compile_with_dynamic_shapes(
-            lambda x: x + 1,
-            {"x": ts},
-            backend=backend,
-        )
-
-        fn(torch.randn(4, 3))  # specialize dim 1=3; BACKED dim 0
-        self.assertEqual(len(backend.graphs), 1)
-
-        fn(torch.randn(8, 3))  # dim 0 absorbed; dim 1 same → cache hit
-        self.assertEqual(len(backend.graphs), 1)
-
-        fn(torch.randn(8, 5))  # dim 1 promotes to backed → recompile
-        self.assertEqual(len(backend.graphs), 2)
-
-        fn(torch.randn(16, 7))  # dim 0 + dim 1 both backed → cache hit
-        self.assertEqual(len(backend.graphs), 2)
-
-
-class TestIntSpecCompile(TestCase):
-    """Covers IntSpec + torch.compile integration using the local
-    `_compile_with_dynamic_shapes` helper.
-
-    Includes tests for captured-graph shape properties and for precedence
-    rules between IntSpec annotations and compile-time dynamic settings.
-    """
-
-    def test_static_graph_has_concrete_shape(self):
-        """STATIC dim appears as a concrete int in the captured graph; each
-        distinct shape yields a new graph."""
-        backend = EagerAndRecordGraphs()
-        fn = _compile_with_dynamic_shapes(
-            lambda x: x + 1,
-            {"x": TensorSpec({0: IntSpec.static()})},
-            backend=backend,
-        )
-        fn(torch.randn(4, 3))
-        fn(torch.randn(8, 3))
-        fn(torch.randn(12, 3))
-        fn(torch.randn(4, 3))  # cache hit
-
-        # STATIC bakes the concrete size into the trace: 3 distinct sizes
-        # (4, 8, 12) → 3 graphs; the repeat size=4 reuses graph #1.
-        self.assertEqual(len(backend.graphs), 3)
-        for gm in backend.graphs:
-            shape = _tensor_placeholder_shape(gm)
-            self.assertIsInstance(shape[0], int)
-
-    def test_backed_graph_has_backed_symbol(self):
-        """BACKED dim appears as a backed SymInt in the final graph."""
-
-        backend = EagerAndRecordGraphs()
-        fn = _compile_with_dynamic_shapes(
-            lambda x: x.sum(0),
-            {"x": TensorSpec({0: IntSpec.backed("batch")})},
-            backend=backend,
-        )
-        for n in [4, 8, 16, 32, 64]:
-            fn(torch.randn(n, 3))
-
-        # Pre-trace maybe_mark_dynamic → backed from call 1, no branches,
-        # no 0/1 specialization → 1 compile covers all 5 sizes.
-        self.assertEqual(len(backend.graphs), 1)
-        shape = _tensor_placeholder_shape(backend.graphs[0])
-        self.assertIsInstance(shape[0], torch.SymInt)
-        # backed symbol: no free unbacked symbols
-        self.assertEqual(len(free_unbacked_symbols(shape[0])), 0)
+class TestShapeVarCompile(TestCase):
+    """ShapeVar + torch.compile integration."""
 
     def test_unbacked_graph_has_unbacked_symbol(self):
-        """UNBACKED dim appears as an unbacked SymInt; single compile covers all shapes."""
+        """ShapeVar dim appears as an unbacked SymInt; single compile covers all shapes."""
         backend = EagerAndRecordGraphs()
         fn = _compile_with_dynamic_shapes(
             lambda x: x.sum(0),
-            {"x": TensorSpec({0: IntSpec.unbacked("batch")})},
+            {"x": TensorSpec([ShapeVar("batch"), None])},
             backend=backend,
         )
         for n in [4, 8, 16, 32]:
             fn(torch.randn(n, 3))
 
-        # UNBACKED dim produces a symbol with no backing value; no guards
-        # can attach (no branch on size), and 0/1 specialization doesn't
-        # apply to unbacked → 1 compile covers all 4 sizes.
         self.assertEqual(len(backend.graphs), 1)
         shape = _tensor_placeholder_shape(backend.graphs[0])
         self.assertIsInstance(shape[0], torch.SymInt)
@@ -631,12 +214,7 @@ class TestIntSpecCompile(TestCase):
     @_fx_experimental_config.patch(no_data_dependent_graph_break=True)
     def test_unbacked_raises_dde_on_branching(self):
         """A function that branches on size(0) must raise a data-dependent
-        error when that dim is marked UNBACKED.
-
-        The ``no_data_dependent_graph_break`` config flag disables dynamo's
-        default rewrap of ``GuardOnDataDependentSymNode`` into ``UserError``,
-        so the raw exception surfaces and we can assert on ``.cond`` directly.
-        """
+        error when that dim is marked with ShapeVar (unbacked)."""
 
         def fn(x):
             if x.size(0) > 5:
@@ -645,133 +223,44 @@ class TestIntSpecCompile(TestCase):
 
         compiled = _compile_with_dynamic_shapes(
             fn,
-            {"x": TensorSpec({0: IntSpec.unbacked()})},
+            {"x": TensorSpec([ShapeVar(), None])},
             backend="eager",
             fullgraph=True,
         )
         with self.assertRaises(GuardOnDataDependentSymNode) as cm:
             compiled(torch.randn(10, 3))
-        # The guard expression must reference a free unbacked symbol —
-        # that's what makes it "data-dependent" and confirms our UNBACKED
-        # spec actually produced an unbacked dim (backed would be ``s0``,
-        # never raise DDE).
         free_syms = cm.exception.cond.free_symbols
         self.assertEqual(len(free_syms), 1)
-        # ShapeEnv names unbacked symbols with a ``u`` prefix.
         (sym,) = free_syms
         self.assertTrue(
             str(sym).startswith("u"),
             msg=f"expected unbacked symbol (u-prefix), got {sym!r}",
         )
 
-    def test_backed_branching_bounded_recompiles(self):
-        """BACKED + branching on size(0) > 8 should produce exactly 2 compiles
-        for inputs [4, 8, 16, 32, 64].
-
-        Call sequence:
-        - 4, 8  -> branch False, same compile
-        - 16    -> branch True, second compile
-        - 32, 64 -> branch True, cache hits
-
-        Total compiles: 2 (one per branch path), unlike STATIC which compiles per shape.
-        """
-        cnt = torch._dynamo.testing.CompileCounter()
-        fn = _compile_with_dynamic_shapes(
-            lambda x: x.sum(0 if x.size()[0] > 8 else 1),
-            {"x": TensorSpec({0: IntSpec.backed("batch")})},
-            backend=cnt,
-        )
-        for n in [4, 8, 16, 32, 64]:
-            fn(torch.randn(n, 3))
-        # Dim is backed from call 1; the ``> 8`` branch splits compiles by
-        # path — 2 paths (True/False) → 2 compiles, regardless of shape count.
-        self.assertEqual(cnt.frame_count, 2)
-
-    def test_backed_zero_one_specialization(self):
-        """BACKED symbols are specialized at 0 and 1 unconditionally.
-
-        For ``[0, 1, 2, 4, 8]``:
-        - n=0: specialized → Compile #1
-        - n=1: specialized → Compile #2
-        - n=2: backed SymInt with guard ``size >= 2`` → Compile #3
-        - n=4, 8: cache hits on #3
-
-        Total = 3.
-        """
-
-        cnt = torch._dynamo.testing.CompileCounter()
+    @torch._dynamo.config.patch(automatic_dynamic_shapes=False)
+    def test_none_entry_is_static(self):
+        """A ``None`` entry doesn't mark the dim — it stays static.
+        Each distinct shape at dim 1 triggers a recompile."""
+        backend = EagerAndRecordGraphs()
+        ts = TensorSpec([ShapeVar("batch"), None])
         fn = _compile_with_dynamic_shapes(
             lambda x: x + 1,
-            {"x": TensorSpec({0: IntSpec.backed("batch")})},
-            backend=cnt,
-        )
-        for n in [0, 1, 2, 4, 8]:
-            fn(torch.randn(n, 3))
-        # 0 and 1 each force their own specialized compile (PyTorch-wide
-        # 0/1 rule, applies even to backed); sizes ≥ 2 share one backed
-        # compile with guard ``size >= 2`` → 2 + 1 = 3 compiles.
-        self.assertEqual(cnt.frame_count, 3)
-
-    def test_backed_equality_branching(self):
-        """BACKED + Python branch on ``==``: point specialization.
-
-        For ``x.size(0) == 3`` against sizes ``[3, 4, 5, 6]``:
-        - n=3: branch True, guard ``size == 3`` → Compile #1
-        - n=4: guard fails → recompile, branch False, guard ``size != 3`` → Compile #2
-        - n=5, 6: cache hits on #2
-
-        Total = 2.
-        """
-
-        cnt = torch._dynamo.testing.CompileCounter()
-        fn = _compile_with_dynamic_shapes(
-            lambda x: x + 1 if x.size()[0] == 3 else x - 1,
-            {"x": TensorSpec({0: IntSpec.backed("batch")})},
-            backend=cnt,
-        )
-        for n in [3, 4, 5, 6]:
-            fn(torch.randn(n, 3))
-        # ``== 3`` splits into two branch paths: point-specialization at
-        # size=3 (compile #1) and the ``size != 3`` backed compile
-        # (compile #2). Same count as the ``>`` case, different guards.
-        self.assertEqual(cnt.frame_count, 2)
-
-    def test_static_precedence_over_dynamic_true(self):
-        """IntSpec.static() must win over compile(dynamic=True)."""
-        cnt = torch._dynamo.testing.CompileCounter()
-        fn = _compile_with_dynamic_shapes(
-            lambda x: x + 1,
-            {"x": TensorSpec({0: IntSpec.static()})},
-            backend=cnt,
-            dynamic=True,
-        )
-        fn(torch.randn(4, 3))
-        fn(torch.randn(8, 3))
-        # Spec STATIC beats ``compile(dynamic=True)``: 2 distinct shapes
-        # each get a specialized compile → 2 compiles. If ``dynamic=True``
-        # had won, we'd see 1 compile with a backed SymInt.
-        self.assertEqual(cnt.frame_count, 2)
-
-    def test_backed_precedence_over_dynamic_false(self):
-        """IntSpec.backed() must win over compile(dynamic=False).
-
-        With the compile-context integration, the spec selects
-        DimDynamic.DYNAMIC directly — the first call is already backed, no
-        initial specialization, so a single compile covers all shapes.
-        """
-        cnt = torch._dynamo.testing.CompileCounter()
-        fn = _compile_with_dynamic_shapes(
-            lambda x: x.sum(0),
-            {"x": TensorSpec({0: IntSpec.backed("batch")})},
-            backend=cnt,
+            {"x": ts},
+            backend=backend,
             dynamic=False,
         )
-        for n in [4, 8, 16, 32, 64]:
-            fn(torch.randn(n, 3))
-        # Spec BACKED beats ``compile(dynamic=False)``: dim is backed from
-        # call 1 via the pre-trace mark, no branches, no 0/1 sizes → 1
-        # compile. If ``dynamic=False`` had won, we'd see 5 (one per shape).
-        self.assertEqual(cnt.frame_count, 1)
+
+        fn(torch.randn(4, 3))
+        self.assertEqual(len(backend.graphs), 1)
+
+        fn(torch.randn(8, 3))  # dim 0 unbacked → no recompile; dim 1 same
+        self.assertEqual(len(backend.graphs), 1)
+
+        fn(torch.randn(8, 5))  # dim 1 changed → recompile (static)
+        self.assertEqual(len(backend.graphs), 2)
+
+        fn(torch.randn(16, 5))  # dim 0 unbacked → no recompile; dim 1 same
+        self.assertEqual(len(backend.graphs), 2)
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/dynamic_spec.py
+++ b/torch/_dynamo/dynamic_spec.py
@@ -1,11 +1,5 @@
-"""Dynamic shape specification types.
-
-Provides `ShapeVar` and `IntVar` to declare that a dimension size or scalar
-integer argument is dynamic. This API is unbacked-first: the underlying
-symbolic shapes will be unbacked (no guards, no 0/1 specialization).
-
-For more info on backed vs. unbacked see
-https://dev-discuss.pytorch.org/t/backed-to-unbacked-from-guardable-to-guardless-shapes-in-pytorch/3333.
+"""Spec types for controlling what is dynamic in compiled/exported code.
+Currently only supports unbacked dynamic shapes.
 """
 
 from __future__ import annotations

--- a/torch/_dynamo/dynamic_spec.py
+++ b/torch/_dynamo/dynamic_spec.py
@@ -1,369 +1,120 @@
-"""Dynamic shape specification types for ``torch.compile`` and ``torch.export``.
+"""Dynamic shape specification types.
 
-Provides class `IntSpec` for fine-grained control over whether an integer
-(dimension size or scalar argument) is treated as static, backed, or unbacked
-during compilation.
+Provides `ShapeVar` and `IntVar` to declare that a dimension size or scalar
+integer argument is dynamic. This API is unbacked-first: the underlying
+symbolic shapes will be unbacked (no guards, no 0/1 specialization).
 
-Backed vs. unbacked
--------------------
-``torch.compile`` provides two kinds of dynamic shapes: ``backed`` and
-``unbacked``. ``torch.compile`` guards on ``backed`` dynamic shapes and does
-not provide a guarantee that no guards will be added to them. User code,
-dynamo, inductor, and autograd all can add guards when tracing through
-branching, e.g. ``if x.size() > 10``. Moreover, for 0/1 specializations,
-backed symbols are specialized unconditionally to ``0``, ``1``, or ``>=2``
-even without encountering a branching on those ranges.
-
-On the contrary, ``unbacked`` dynamic shapes are guaranteed not to be guarded
-on and are not 0/1 specialized. However, there is a possibility of throwing a
-data-dependent error when a branch that requires their value is encountered
-and no explicit unbacked handling is defined. The framework is converging to
-a state where it won't throw DDE but rather pick general paths. One downside
-of using unbacked is missed optimization opportunities due to either perf
-bugs or picking general paths, or using a fixed non-example input-based hint.
-An example of picking general paths is assuming input not contiguous in
-functions called ``contiguous()`` and ``reshape()`` when it cannot be
-symbolically proven, with a change of introducing a clone.
-
-For more info see
+For more info on backed vs. unbacked see
 https://dev-discuss.pytorch.org/t/backed-to-unbacked-from-guardable-to-guardless-shapes-in-pytorch/3333.
 """
 
-import enum
-from collections.abc import Iterator
-from typing import Any, ClassVar
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 
-__all__ = ["IntSpecType", "IntSpec", "TensorSpec"]
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
 
 
-class IntSpecType(enum.Enum):
-    """How an integer should be treated during compilation.
+__all__ = ["ShapeVar", "IntVar", "TensorSpec"]
 
-    STATIC: compile-time constant; triggers recompilation if the value changes.
-    BACKED: symbolic with guards and 0/1 specialization permitted.
-    UNBACKED: symbolic, no guards, no 0/1 specialization; may raise a data-dependent error on branching.
+
+class IntVar:
+    """Indicates that a scalar integer argument is dynamic (no implicit range).
+
+    Unbacked dynamic shapes will represent the underlying value in the
+    compiled graph.
+
+    Example::
+
+        IntVar("num_heads")
+        IntVar("offset", min=-100, max=100)
+        IntVar("size", min=1, max=2048, optimization_hint=512)
     """
-
-    STATIC = "static"
-    BACKED = "backed"
-    UNBACKED = "unbacked"
-
-
-class IntSpec:
-    """Shape specification for a single integer (dimension size or scalar arg).
-
-    Create via a classmethod factory or the constructor directly:
-
-        IntSpec.static("x", value=10)
-        IntSpec.backed("batch", min=1, max=64, guarding_hint=32)
-        IntSpec.unbacked("seq", min=1, max=2048, optimization_hint=512)
-        IntSpec("x", IntSpecType.STATIC, value=10)
-
-    ``type`` is fixed at construction; all other fields are mutable via
-    fluent setters that return ``self`` for chaining:
-
-        spec = IntSpec.backed("batch", min=1, max=64)
-        spec.guarding_hint(32)   # set, returns self
-        spec.min(1).max(64)      # chain
-    """
-
-    _name: str | None
-    _type: IntSpecType
-    _value: int | None
-    _min: int | None
-    _max: int | None
-    _guarding_hint: int | None
-    _optimization_hint: int | None
-
-    __slots__ = (
-        "_name",
-        "_type",
-        "_value",
-        "_min",
-        "_max",
-        "_guarding_hint",
-        "_optimization_hint",
-    )
 
     def __init__(
         self,
-        name: str | None,
-        type: IntSpecType,
+        name: str | None = None,
         *,
         min: int | None = None,
         max: int | None = None,
-        value: int | None = None,
-        guarding_hint: int | None = None,
         optimization_hint: int | None = None,
     ) -> None:
-        if not isinstance(type, IntSpecType):
-            raise TypeError(f"IntSpec type must be an IntSpecType, got {type!r}")
-        self._type = type
-        # Auto-generate a name when the user doesn't supply one.
-        if name is None:
-            name = f"_intspec_{type.value}_{id(self):x}"
-        self._name = name
-        self._min = min
-        self._max = max
-        self._value = value
-        self._guarding_hint = guarding_hint
-        self._optimization_hint = optimization_hint
-        self._validate()
-
-    def __setattr__(self, key: str, value: Any) -> None:
-        # ``_type`` is the only pinned slot — it drives the per-mode
-        # validation rules and integration-level dispatch (BACKED vs.
-        # UNBACKED).
-        if key == "_type" and hasattr(self, "_type"):
-            raise AttributeError("IntSpec type is immutable; cannot reassign")
-        object.__setattr__(self, key, value)
-
-    def __delattr__(self, key: str) -> None:
-        raise AttributeError(f"IntSpec attribute {key!r} cannot be deleted")
-
-    _MODE_KWARG_HINT: ClassVar[dict[IntSpecType, tuple[str, str]]] = {
-        IntSpecType.STATIC: ("static", "value"),
-        IntSpecType.BACKED: ("backed", "guarding_hint"),
-        IntSpecType.UNBACKED: ("unbacked", "optimization_hint"),
-    }
-
-    @staticmethod
-    def _check_name(value: Any, type_: IntSpecType) -> None:
-        if value is not None and not isinstance(value, str):
-            factory, kwarg = IntSpec._MODE_KWARG_HINT[type_]
-            raise TypeError(
-                f"IntSpec.name must be str or None, got "
-                f"{value.__class__.__name__}; if you meant to pass a "
-                f"value/hint, use a keyword argument "
-                f"(e.g. IntSpec.{factory}({kwarg}={value!r}))"
-            )
-
-    @staticmethod
-    def _check_int_field(field_name: str, value: Any) -> None:
-        if value is not None and (
-            not isinstance(value, int) or isinstance(value, bool)
-        ):
-            raise TypeError(
-                f"IntSpec.{field_name} must be int or None, got "
-                f"{value.__class__.__name__}"
-            )
-
-    # -- validation --------------------------------------------------------
-    #
-    # Single entry point: type checks (name, int fields), per-mode rules,
-    # and cross-field invariants like ``min <= max``. Run on every
-    # construction and on every fluent set (via ``_try_set``).
-
-    def _validate(self) -> None:
-        IntSpec._check_name(self._name, self._type)
-        IntSpec._check_int_field("min", self._min)
-        IntSpec._check_int_field("max", self._max)
-        IntSpec._check_int_field("value", self._value)
-        IntSpec._check_int_field("guarding_hint", self._guarding_hint)
-        IntSpec._check_int_field("optimization_hint", self._optimization_hint)
-        if self._type is IntSpecType.STATIC:
-            if self._min is not None or self._max is not None:
-                raise ValueError(
-                    "min/max are only valid for BACKED/UNBACKED IntSpec, not STATIC"
-                )
-            if self._guarding_hint is not None:
-                raise ValueError("guarding_hint is only valid for BACKED IntSpec")
-            if self._optimization_hint is not None:
-                raise ValueError("optimization_hint is only valid for UNBACKED IntSpec")
-        elif self._type is IntSpecType.BACKED:
-            if self._value is not None:
-                raise ValueError("value is only valid for STATIC IntSpec")
-            if self._optimization_hint is not None:
-                raise ValueError("optimization_hint is only valid for UNBACKED IntSpec")
-        else:  # UNBACKED
-            if self._value is not None:
-                raise ValueError("value is only valid for STATIC IntSpec")
-            if self._guarding_hint is not None:
-                raise ValueError("guarding_hint is only valid for BACKED IntSpec")
-        if self._min is not None and self._max is not None and self._min > self._max:
-            raise ValueError(
-                f"min must be <= max, got min={self._min}, max={self._max}"
-            )
-
-    @classmethod
-    def static(cls, name: str | None = None, *, value: int | None = None) -> "IntSpec":
-        """Construct a STATIC `IntSpec`.
-
-        ``value`` pins a concrete size; if ``None`` the value is taken from
-        the example input at compile time.
-        """
-        return cls(name, type=IntSpecType.STATIC, value=value)
-
-    @classmethod
-    def backed(
-        cls,
-        name: str | None = None,
-        *,
-        min: int | None = None,
-        max: int | None = None,
-        guarding_hint: int | None = None,
-    ) -> "IntSpec":
-        """Construct a BACKED `IntSpec`.
-
-        ``guarding_hint`` is the concrete value the symbolic shape
-        environment substitutes when a hint is needed for reasoning or
-        codegen.
-        """
-        return cls(
-            name,
-            type=IntSpecType.BACKED,
-            min=min,
-            max=max,
-            guarding_hint=guarding_hint,
-        )
-
-    @classmethod
-    def unbacked(
-        cls,
-        name: str | None = None,
-        *,
-        min: int | None = None,
-        max: int | None = None,
-        optimization_hint: int | None = None,
-    ) -> "IntSpec":
-        """Construct an UNBACKED `IntSpec`.
-
-        ``optimization_hint`` is used by downstream codegen (e.g. inductor
-        autotuning) only; it never participates in symbolic reasoning.
-        """
-        return cls(
-            name,
-            type=IntSpecType.UNBACKED,
-            min=min,
-            max=max,
-            optimization_hint=optimization_hint,
-        )
-
-    # -- fluent setters ----------------------------------------------------
-    #
-    # Each setter mutates in place, revalidates, and returns ``self`` for
-    # chaining. Per-mode validity is enforced on each set, so e.g.
-    # ``IntSpec.static("x").guarding_hint(10)`` raises ``ValueError``.
-
-    def _try_set(self, slot: str, new_value: Any) -> None:
-        # Atomic: if ``_validate`` rejects the new state, roll back so the
-        # spec stays in a consistent state for the caller.
-        old = getattr(self, slot)
-        setattr(self, slot, new_value)
-        try:
-            self._validate()
-        except Exception:
-            setattr(self, slot, old)
-            raise
-
-    def name(self, value: str) -> "IntSpec":
-        self._try_set("_name", value)
-        return self
-
-    def min(self, value: int) -> "IntSpec":
-        self._try_set("_min", value)
-        return self
-
-    def max(self, value: int) -> "IntSpec":
-        self._try_set("_max", value)
-        return self
-
-    def value(self, value: int) -> "IntSpec":
-        self._try_set("_value", value)
-        return self
-
-    def guarding_hint(self, value: int) -> "IntSpec":
-        self._try_set("_guarding_hint", value)
-        return self
-
-    def optimization_hint(self, value: int) -> "IntSpec":
-        self._try_set("_optimization_hint", value)
-        return self
-
-    # -- dunder ------------------------------------------------------------
+        self.name = name if name is not None else f"_intvar_{id(self):x}"
+        self.min = min
+        self.max = max
+        self.optimization_hint = optimization_hint
 
     def __repr__(self) -> str:
-        parts: list[str] = []
-        for slot in self.__slots__:
-            val = getattr(self, slot)
-            if slot == "_type":
-                parts.append(f"type={val.name}")
-            elif slot == "_name":
-                if val is not None:
-                    parts.append(f"name={val!r}")
-            elif val is not None:
-                parts.append(f"{slot[1:]}={val}")
-        return f"IntSpec({', '.join(parts)})"
+        parts = [f"name={self.name!r}"]
+        if self.min is not None:
+            parts.append(f"min={self.min}")
+        if self.max is not None:
+            parts.append(f"max={self.max}")
+        if self.optimization_hint is not None:
+            parts.append(f"optimization_hint={self.optimization_hint}")
+        return f"{type(self).__name__}({', '.join(parts)})"
+
+
+class ShapeVar(IntVar):
+    """Indicates that a dimension size is dynamic and is >= 0.
+
+    Subclass of `IntVar` with ``min=0`` by default.
+
+    Example::
+
+        ShapeVar("batch")
+        ShapeVar("batch", max=64)
+        ShapeVar("batch", max=64, optimization_hint=32)
+    """
+
+    def __init__(
+        self,
+        name: str | None = None,
+        *,
+        min: int = 0,
+        max: int | None = None,
+        optimization_hint: int | None = None,
+    ) -> None:
+        super().__init__(name, min=min, max=max, optimization_hint=optimization_hint)
 
 
 class TensorSpec:
     """Per-dimension shape specification for a tensor.
 
-    A list-like container of ``IntSpec | None`` with length equal to the
-    tensor's dim. ``None`` entries inherit the default dynamism policy from
-    the compile context.
+    A list-like container of ``ShapeVar | int | None`` with length equal to the
+    tensor's dim.
 
-    Construct from any of:
-
-    - ``int`` — number of dims; all entries start as ``None``.
-    - ``list`` / ``tuple`` of ``IntSpec | None`` — dim is inferred from
-      length, entries used as-is.
-    - ``dict[int, IntSpec | None]`` — sparse per-dim spec; dim is inferred
-      from ``max(keys) + 1``. Empty dict rejected.
+    Per-entry semantics:
+    - ``ShapeVar``: unbacked dynamic dimension.
+    - ``int``: static dimension pinned to that concrete value.
+    - ``None``: unspecified; treated as static. Value is inferred from the
+      example input if the consuming API supports it (e.g. ``torch.compile``),
+      otherwise an error will be thrown (e.g. ``torch.export`` requires an
+      explicit value).
 
     Example::
-        TensorSpec(3)  # rank 3, all None
-        TensorSpec([IntSpec.backed("batch"), None])  # rank 2, dim 0 backed
-        TensorSpec({0: IntSpec.backed("batch")})  # rank 1, dim 0 backed
+
+        B = ShapeVar("batch")
+        TensorSpec([B, None])  # rank 2, dim 0 dynamic
+        TensorSpec([B, 10])  # rank 2, dim 0 dynamic, dim 1 static=10
     """
 
-    def __init__(
-        self,
-        arg: int
-        | list[IntSpec | None]
-        | tuple[IntSpec | None, ...]
-        | dict[int, IntSpec | None],
-    ) -> None:
-        if isinstance(arg, int):
-            self._dim = arg
-            self._specs: list[IntSpec | None] = [None] * arg
-        elif isinstance(arg, (list, tuple)):
-            self._dim = len(arg)
-            self._specs = list(arg)
-        elif isinstance(arg, dict):
-            self._dim = max(arg.keys()) + 1
-            self._specs = [None] * self._dim
-            for k, v in arg.items():
-                self._specs[k] = v
-        else:
-            raise TypeError(
-                f"TensorSpec expects int / list / tuple / dict, "
-                f"got {type(arg).__name__}"
-            )
+    _DimSpec = ShapeVar | int | None
 
-    def dim(self, index: int, spec: IntSpec) -> "TensorSpec":
-        """Set the spec at ``index`` and return ``self`` for chaining."""
-        self._specs[index] = spec
-        return self
+    def __init__(self, dims: Sequence[TensorSpec._DimSpec]) -> None:
+        self._specs: list[TensorSpec._DimSpec] = list(dims)
 
-    def __getitem__(self, index: int) -> IntSpec | None:
+    def __getitem__(self, index: int) -> TensorSpec._DimSpec:
         return self._specs[index]
 
-    def __setitem__(self, index: int, spec: IntSpec | None) -> None:
-        self._specs[index] = spec
-
     def __len__(self) -> int:
-        return self._dim
+        return len(self._specs)
 
-    def __iter__(self) -> Iterator[IntSpec | None]:
+    def __iter__(self) -> Iterator[TensorSpec._DimSpec]:
         return iter(self._specs)
 
     def __repr__(self) -> str:
         entries = ", ".join(repr(spec) for spec in self._specs)
         return f"TensorSpec([{entries}])"
-
-    # No ``__eq__`` / ``__hash__``: matches :class:`IntSpec`'s design — specs
-    # are immutable compile-time inputs compared via ``repr()`` when needed.
-    # Value-based equality would force cache keys to drift with object
-    # identity and conflict with the AOT-snapshot invariant.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #181995
* __->__ #182534

1. Replaced IntSpec/IntSpecType with IntVar + ShapeVar(IntVar).
   1.1  IntVar + ShapeVar are unbacked-only, 
   1.2 no backed for now
   1.3 static modes: pass an integer in the spec, or none/not specified) (if the underlying processing API support that,  none means infer from example input). 

3. Removed fluent API — simple constructors with public attributes more visible and clear spec.

4. Simplified TensorSpec — takes Sequence[ShapeVar | int | None] only; None = static (infer from example)
make it 3 o4 items

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 