### PR TITLE
Add generate_mobile_module_lints to mobile_optimizer docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1119,7 +1119,6 @@ coverage_ignore_functions = [
     # torch.utils.mkldnn
     "to_mkldnn",
     # torch.utils.mobile_optimizer
-    "generate_mobile_module_lints",
     # torch.utils.tensorboard.summary
     "audio",
     "compute_curve",

--- a/docs/source/mobile_optimizer.md
+++ b/docs/source/mobile_optimizer.md
@@ -22,3 +22,7 @@ and [Vulkan](https://pytorch.org/executorch/stable/native-delegates-executorch-v
 ```{eval-rst}
 .. autofunction:: optimize_for_mobile
 ```
+
+```{eval-rst}
+.. autofunction:: generate_mobile_module_lints
+```


### PR DESCRIPTION
Fixes #182522

## Description
Remove `"generate_mobile_module_lints"` & and add sphinx directives

## Checklist

[x] Entries removed from skip list(s) in [docs/source/conf.py](https://github.com/pytorch/pytorch/blob/main/docs/source/conf.py)

[x] Sphinx directives added to [docs/source/mobile_optimizer.md](https://github.com/pytorch/pytorch/blob/main/docs/source/mobile_optimizer.md)

[x] make coverage passes with no new undocumented warnings for these APIs

[ ] Screenshot(s) of the rendered documentation included in the PR