### PR TITLE
Add print.cpp to PyTorch API sources

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -812,6 +812,7 @@ torch_cpp_srcs = [
     "torch/csrc/api/src/imethod.cpp",
     "torch/csrc/api/src/jit.cpp",
     "torch/csrc/api/src/mps.cpp",
+    "torch/csrc/api/src/print.cpp",
     "torch/csrc/api/src/serialize.cpp",
     "torch/csrc/api/src/nn/init.cpp",
     "torch/csrc/api/src/nn/module.cpp",


### PR DESCRIPTION
Include `torch/csrc/api/src/print.cpp` in the build variables for the PyTorch C++ API. (related to #40613)