### PR TITLE
add regression test for weight_norm meta initialization (#96409)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1885,6 +1885,27 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         m = nn.Linear(4, 5, dtype=torch.float16)
         m = torch.nn.utils.weight_norm(m)
 
+    def test_weight_norm_init_meta(self):
+        """
+        Ensures nn.utils.weight_norm correctly transforms meta-tensors.
+        """
+        with torch.device("meta"):
+            m = nn.Linear(10, 20)
+            # Triggers weight_norm initialization on Meta
+            m = nn.utils.weight_norm(m, name="weight", dim=1)
+
+        self.assertTrue(m.weight.is_meta)
+        self.assertEqual(m.weight.shape, (20, 10))
+
+        self.assertTrue(m.weight_v.is_meta)
+        self.assertTrue(m.weight_g.is_meta)
+
+        self.assertEqual(m.weight_v.shape, (20, 10))
+
+        # dim=1 keeps one norm per input-feature column, resulting in a
+        # (1, 10) broadcastable scale tensor for a Linear(10, 20) weight
+        self.assertEqual(m.weight_g.shape, (1, 10))
+
     def test_parameterlistdict_setting_attributes(self):
         with warnings.catch_warnings(record=True) as w:
             mod = nn.ParameterList(map(nn.Parameter, [torch.rand(2), torch.rand(2)]))


### PR DESCRIPTION
## Summary

Fixes #96409 by adding regression coverage for `nn.utils.weight_norm` initialization on the Meta device.

The original issue reported a `NotImplementedError` for `aten::_weight_norm_interface` when applying `nn.utils.weight_norm` under `with torch.device("meta"):`. On current `main`, that repro now succeeds, so this PR does not add a new implementation. Instead, it adds a focused regression test to ensure this user-facing path stays working.  
## What changed

- Added a regression test in `test/test_nn.py` covering `nn.utils.weight_norm` initialization under `torch.device("meta")`
- Verified that the resulting tensors remain Meta tensors and that the reparameterized state has the expected shapes

## Why test-only

Current `main` appears to handle `_weight_norm_interface` forward through decomposition, and backward Meta support was added in [`[fcfb213]`.](https://github.com/pytorch/pytorch/commit/fcfb213c5a7f3276d950cedd25df05b5d093a5c6#diff-6dffed1ade0ba3e887f9a4eafa3bfcec267ab2365b8adcb91bd391f49b3fd2e3) Since the reported functional gap no longer reproduces locally, adding a redundant manual forward Meta implementation did not seem justified.  

## Testing

```bash
python test/test_nn.py TestNN.test_weight_norm_init_meta

cc @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki