### PR TITLE
[docs] Add documentation for 8 functions in distributed.md

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -476,10 +476,6 @@ coverage_ignore_functions = [
     # torch.distributed.algorithms.ddp_comm_hooks.quantization_hooks
     "quantization_perchannel_hook",
     "quantization_pertensor_hook",
-    # torch.distributed.algorithms.model_averaging.utils
-    "average_parameters",
-    "average_parameters_or_parameter_groups",
-    "get_params_to_average",
     # torch.distributed.checkpoint.default_planner
     "create_default_global_load_plan",
     "create_default_global_save_plan",
@@ -546,16 +542,10 @@ coverage_ignore_functions = [
     "configure",
     "expires",
     # torch.distributed.elastic.utils.api
-    "get_env_variable_or_raise",
     "get_socket_with_port",
     # torch.distributed.elastic.utils.distributed
     "create_c10d_store",
-    "get_free_port",
     "get_socket_with_port",
-    # torch.distributed.elastic.utils.log_level
-    "get_log_level",
-    # torch.distributed.elastic.utils.logging
-    "get_logger",
     # torch.distributed.elastic.utils.store
     "barrier",
     "get_all",
@@ -581,7 +571,6 @@ coverage_ignore_functions = [
     "as_functional_optim",
     "register_functional_optim",
     # torch.distributed.rendezvous
-    "register_rendezvous_handler",
     "rendezvous",
     # torch.distributed.rpc.api
     "get_worker_info",

--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -18,6 +18,66 @@ for a brief introduction to all features related to distributed training.
 .. currentmodule:: torch.distributed
 ```
 
+```{eval-rst}
+.. currentmodule:: torch.distributed.elastic.utils.api
+```
+
+```{eval-rst}
+.. autofunction:: get_env_variable_or_raise
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.elastic.utils.distributed
+```
+
+```{eval-rst}
+.. autofunction:: get_free_port
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.elastic.utils.log_level
+```
+
+```{eval-rst}
+.. autofunction:: get_log_level
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.elastic.utils.logging
+```
+
+```{eval-rst}
+.. autofunction:: get_logger
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.rendezvous
+```
+
+```{eval-rst}
+.. autofunction:: register_rendezvous_handler
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed.algorithms.model_averaging.utils
+```
+
+```{eval-rst}
+.. autofunction:: average_parameters
+```
+
+```{eval-rst}
+.. autofunction:: average_parameters_or_parameter_groups
+```
+
+```{eval-rst}
+.. autofunction:: get_params_to_average
+```
+
+```{eval-rst}
+.. currentmodule:: torch.distributed
+```
+
 ## Backends
 
 `torch.distributed` supports four built-in backends, each with


### PR DESCRIPTION
Fixes #182520

- Added Sphinx `autofunction` directives in `docs/source/distributed.md` for 8 previously undocumented APIs:
  - `torch.distributed.elastic.utils.api.get_env_variable_or_raise`
  - `torch.distributed.elastic.utils.distributed.get_free_port`
  - `torch.distributed.elastic.utils.log_level.get_log_level`
  - `torch.distributed.elastic.utils.logging.get_logger`
  - `torch.distributed.rendezvous.register_rendezvous_handler`
  - `torch.distributed.algorithms.model_averaging.utils.average_parameters`
  - `torch.distributed.algorithms.model_averaging.utils.average_parameters_or_parameter_groups`
  - `torch.distributed.algorithms.model_averaging.utils.get_params_to_average`
- Removed these 8 entries from `coverage_ignore_functions` in `docs/source/conf.py`

## Test plan

- [x] `lintrunner -a` passes with no lint issues
- [x] `make coverage` passes — all 6 affected modules report 100% coverage, 0 undocumented
- [x] None of the 8 functions appear in `build/coverage/python.txt`
- [x] Rendered documentation ([from PR preview](https://docs-preview.pytorch.org/pytorch/pytorch/182544/distributed.html))

cc @svekars @sekyondaMeta @AlannaBurke