### PR TITLE
Fix sparse compressed set_data device metadata

### DIFF
--- a/aten/src/ATen/SparseCsrTensorImpl.h
+++ b/aten/src/ATen/SparseCsrTensorImpl.h
@@ -168,6 +168,23 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
         std::move(version_counter), allow_tensor_metadata_change);
   }
 
+  /**
+   * Shallow-copies data from another TensorImpl into this TensorImpl.
+   *
+   * For why this function doesn't check this TensorImpl's
+   * `allow_tensor_metadata_change_`, see NOTE [ TensorImpl Shallow-Copying ].
+   */
+  void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override {
+    TORCH_INTERNAL_ASSERT(has_compatible_shallow_copy_type(impl->key_set()));
+    auto sparse_csr_impl = static_cast<const SparseCsrTensorImpl*>(impl.get());
+    copy_tensor_metadata(
+        /*src_sparse_impl=*/sparse_csr_impl,
+        /*dest_sparse_impl=*/this,
+        /*version_counter=*/version_counter(),
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change());
+    refresh_numel();
+  }
+
  private:
   explicit SparseCsrTensorImpl(
       at::DispatchKeySet key_set,

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -969,6 +969,88 @@ class TestSparseCompressed(TestCase):
                 dense_to_dtype = sparse.to_dense().to(to_dtype)
                 self.assertEqual(sparse_to_dtype.to_dense(), dense_to_dtype)
 
+    @skipMeta
+    @onlyCUDA
+    @suppress_warnings
+    @all_sparse_compressed_layouts()
+    @dtypes(torch.float32)
+    def test_sparse_compressed_parameter_set_data_module_to_device(self, layout, device, dtype):
+        class SparseCompressedModule(torch.nn.Module):
+            def __init__(self, tensor):
+                super().__init__()
+                self.weight = torch.nn.Parameter(tensor)
+
+        def to_layout(t):
+            if layout is torch.sparse_csr:
+                return t.to_sparse_csr()
+            if layout is torch.sparse_csc:
+                return t.to_sparse_csc()
+            if layout is torch.sparse_bsr:
+                return t.to_sparse_bsr((2, 2))
+            if layout is torch.sparse_bsc:
+                return t.to_sparse_bsc((2, 2))
+            raise AssertionError(f"unexpected layout {layout}")
+
+        def canonical_device(dev):
+            return torch.empty((), device=dev).device
+
+        compressed_indices_mth, plain_indices_mth = sparse_compressed_indices_methods[layout]
+
+        def assert_sparse_compressed_device(t, expected_device):
+            expected_device = canonical_device(expected_device)
+            self.assertEqual(t.device, expected_device)
+            self.assertEqual(compressed_indices_mth(t).device, expected_device)
+            self.assertEqual(plain_indices_mth(t).device, expected_device)
+            self.assertEqual(t.values().device, expected_device)
+
+        dense = torch.tensor([[1, 0, 2, 0],
+                              [0, 3, 0, 4],
+                              [5, 0, 6, 0],
+                              [0, 7, 0, 8]], dtype=dtype)
+
+        param = torch.nn.Parameter(to_layout(dense))
+        param.data = param.data.to(device)
+        assert_sparse_compressed_device(param.data, device)
+        param.data = param.data.cpu()
+        assert_sparse_compressed_device(param.data, "cpu")
+
+        module = SparseCompressedModule(to_layout(dense))
+        module.to(device)
+        assert_sparse_compressed_device(module.weight.data, device)
+        module.to("cpu")
+        assert_sparse_compressed_device(module.weight.data, "cpu")
+
+    @skipMeta
+    @onlyCUDA
+    @suppress_warnings
+    @dtypes(torch.float32)
+    def test_to_side_effect_controls(self, device, dtype):
+        def canonical_device(dev):
+            return torch.empty((), device=dev).device
+
+        dense_param = torch.nn.Parameter(torch.ones(2, 2, dtype=dtype))
+        moved_dense_param = dense_param.to(device)
+        self.assertEqual(dense_param.device, torch.device("cpu"))
+        self.assertEqual(moved_dense_param.device, canonical_device(device))
+
+        dense_module = torch.nn.Linear(2, 2, dtype=dtype)
+        dense_module.to(device)
+        self.assertEqual(dense_module.weight.device, canonical_device(device))
+        dense_module.to("cpu")
+        self.assertEqual(dense_module.weight.device, torch.device("cpu"))
+
+        csr = torch.tensor([[1, 0, 2],
+                            [0, 3, 0]], dtype=dtype).to_sparse_csr()
+        moved_csr = csr.to(device)
+        self.assertEqual(csr.device, torch.device("cpu"))
+        self.assertEqual(csr.crow_indices().device, torch.device("cpu"))
+        self.assertEqual(csr.col_indices().device, torch.device("cpu"))
+        self.assertEqual(csr.values().device, torch.device("cpu"))
+        self.assertEqual(moved_csr.device, canonical_device(device))
+        self.assertEqual(moved_csr.crow_indices().device, canonical_device(device))
+        self.assertEqual(moved_csr.col_indices().device, canonical_device(device))
+        self.assertEqual(moved_csr.values().device, canonical_device(device))
+
     @unittest.skipIf(IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/182086")
     @unittest.skipIf(IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/181682")
     @unittest.skipIf(IS_LINUX or TEST_WITH_SLOW, "https://github.com/pytorch/pytorch/issues/181536")


### PR DESCRIPTION
Fixes #136258

This adds a `SparseCsrTensorImpl::shallow_copy_from` override so sparse compressed tensors copy their internal component tensors during compatible shallow-copy assignment.

`nn.Module.to()` can route parameter updates through `param.data = param_applied`. For sparse compressed tensors, the base `TensorImpl::shallow_copy_from` updated base metadata such as the device/key set, but it did not copy `crow_indices_` / `col_indices_` / `values_` (or the CSC/BSC equivalents). That allowed a sparse compressed parameter to report CUDA while its component tensors still lived on CPU.

The new override mirrors the sparse COO behavior by using the existing sparse compressed metadata-copy helper and preserving the current version counter / metadata-change behavior.

Repro output:

Before this patch, on an A100 with stock torch `2.9.1+cu129`, the direct `Parameter.to("cuda")` path returned CUDA member tensors, but the `set_data` / `Module.to` path reproduced the issue:

```text
torch 2.9.1+cu129 cuda 12.9 gpu NVIDIA A100-SXM4-40GB

direct Parameter.to ok? True

direct tensor cuda:0 torch.sparse_csr
  crow cuda:0
  col cuda:0
  values cuda:0

set_data ok? False
set_data tensor cuda:0 torch.sparse_csr
  crow cpu
  col cpu
  values cpu

module.to ok? False
module tensor cuda:0 torch.sparse_csr
  crow cpu
  col cpu
  values cpu
```

After this patch, built from this branch on the same A100, the sparse compressed member tensors move with the visible tensor device for CSR/CSC/BSR/BSC through both `set_data` and `Module.to`:

```text
torch 2.13.0a0+git92255da cuda 12.9 is_available True gpu NVIDIA A100-SXM4-40GB
set_data torch.sparse_csr cuda:0 torch.sparse_csr
  crow cuda:0
  col cuda:0
  values cuda:0
set_data_back torch.sparse_csr cpu torch.sparse_csr
  crow cpu
  col cpu
  values cpu
module torch.sparse_csr cuda:0 torch.sparse_csr
  crow cuda:0
  col cuda:0
  values cuda:0
module_back torch.sparse_csr cpu torch.sparse_csr
  crow cpu
  col cpu
  values cpu
set_data torch.sparse_csc cuda:0 torch.sparse_csc
  ccol cuda:0
  row cuda:0
  values cuda:0
module torch.sparse_csc cuda:0 torch.sparse_csc
  ccol cuda:0
  row cuda:0
  values cuda:0
set_data torch.sparse_bsr cuda:0 torch.sparse_bsr
  crow cuda:0
  col cuda:0
  values cuda:0
module torch.sparse_bsr cuda:0 torch.sparse_bsr
  crow cuda:0
  col cuda:0
  values cuda:0
set_data torch.sparse_bsc cuda:0 torch.sparse_bsc
  ccol cuda:0
  row cuda:0
  values cuda:0
module torch.sparse_bsc cuda:0 torch.sparse_bsc
  ccol cuda:0
  row cuda:0
  values cuda:0
plain sparse csr tensor.to cuda:0 torch.sparse_csr
  crow cuda:0
  col cuda:0
  values cuda:0
ok
```

Test plan:
- Reproduced on NVIDIA A100-SXM4-40GB with stock torch 2.9.1+cu129: `tensor.data = tensor.to("cuda")` and `nn.Module.to("cuda")` reported CUDA while CSR member tensors stayed on CPU.
- Built this patch on the same A100 and verified CPU -> CUDA and CUDA -> CPU for CSR, CSC, BSR, and BSC through both `set_data` and `Module.to`.
- Also manually checked dense `Parameter.to`, dense `Module.to`, and non-Parameter sparse CSR `.to()`.
- Added CUDA regression coverage in `test/test_sparse_csr.py` for CSR, CSC, BSR, and BSC `Parameter.data` assignment / `nn.Module.to()` device propagation, plus controls for dense `Parameter.to`, dense `Module.to`, and non-Parameter sparse CSR `.to()`.
