### PR TITLE
[Docathon]: documented coverage_ignored_functions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -591,34 +591,22 @@ coverage_ignore_functions = [
     "loss_parallel",
     # torch.distributed.tensor.parallel.style
     "make_sharded_output_tensor",
-    # torch.fx.passes.annotate_getitem_nodes
-    "annotate_getitem_nodes",
     # torch.fx.passes.dialect.common.cse_pass
     "get_CSE_banned_ops",
     # torch.fx.passes.graph_manipulation
-    "get_size_of_all_nodes",
-    "get_size_of_node",
     "get_tensor_meta",
     # torch.fx.passes.split_module
     "split_module",
     "split_module_simple",
     # torch.fx.passes.split_utils
     "getattr_recursive",
-    "split_by_tags",
-    # torch.fx.passes.splitter_base
-    "generate_inputs_for_submodules",
     # torch.fx.passes.tools_common
     "get_acc_ops_name",
     "get_node_target",
     "legalize_graph",
-    # torch.fx.passes.utils.common
-    "lift_subgraph_as_module",
     # torch.fx.passes.utils.fuser_utils
-    "fuse_as_graphmodule",
     "fuse_by_partitions",
     "insert_subgm",
-    # torch.fx.passes.utils.source_matcher_utils
-    "get_source_partitions",
     # torch.fx.proxy
     "assert_fn",
     # torch.fx.traceback

--- a/docs/source/fx.md
+++ b/docs/source/fx.md
@@ -1231,6 +1231,8 @@ The set of leaf modules can be customized by overriding
 
 ```{eval-rst}
 .. currentmodule:: torch.fx.passes.graph_manipulation
+.. autofunction:: get_size_of_all_nodes
+.. autofunction:: get_size_of_nodes
 ```
 
 ```{eval-rst}
@@ -1345,6 +1347,7 @@ The set of leaf modules can be customized by overriding
 
 ```{eval-rst}
 .. currentmodule:: torch.fx.passes.split_utils
+.. autofunction:: split_by_tags
 ```
 
 ```{eval-rst}
@@ -1373,6 +1376,7 @@ The set of leaf modules can be customized by overriding
 
 ```{eval-rst}
 .. currentmodule:: torch.fx.passes.utils.common
+.. autofunction:: lift_subgraph_as_module
 ```
 
 ```{eval-rst}
@@ -1387,6 +1391,7 @@ The set of leaf modules can be customized by overriding
 
 ```{eval-rst}
 .. currentmodule:: torch.fx.passes.utils.fuser_utils
+.. autofunction:: fuse_as_graphmodule
 ```
 
 ```{eval-rst}
@@ -1403,6 +1408,7 @@ The set of leaf modules can be customized by overriding
 
 ```{eval-rst}
 .. currentmodule:: torch.fx.passes.utils.source_matcher_utils
+.. autofunction:: get_source_partitions
 ```
 
 ```{eval-rst}
@@ -1471,6 +1477,7 @@ The set of leaf modules can be customized by overriding
 .. py:module:: torch.fx.immutable_collections
 .. py:module:: torch.fx.interpreter
 .. py:module:: torch.fx.passes.annotate_getitem_nodes
+.. autofunction:: annotate_getitem_nodes
 .. py:module:: torch.fx.passes.backends.cudagraphs
 .. py:module:: torch.fx.passes.dialect.common.cse_pass
 .. py:module:: torch.fx.passes.fake_tensor_prop
@@ -1518,6 +1525,7 @@ The set of leaf modules can be customized by overriding
 .. py:module:: torch.fx.passes.splitter_base
 
 .. currentmodule:: torch.fx.passes.splitter_base
+.. autofunction:: generate_inputs_for_submodules
 
 .. autosummary::
     :toctree: generated

--- a/docs/source/fx.md
+++ b/docs/source/fx.md
@@ -1232,7 +1232,7 @@ The set of leaf modules can be customized by overriding
 ```{eval-rst}
 .. currentmodule:: torch.fx.passes.graph_manipulation
 .. autofunction:: get_size_of_all_nodes
-.. autofunction:: get_size_of_nodes
+.. autofunction:: get_size_of_node
 ```
 
 ```{eval-rst}

--- a/torch/fx/passes/annotate_getitem_nodes.py
+++ b/torch/fx/passes/annotate_getitem_nodes.py
@@ -13,7 +13,7 @@ def annotate_getitem_nodes(graph: torch.fx.Graph) -> None:
     Adding back known type annotation for getitem nodes to improve jit scriptability.
 
     Args:
-        graph (Graph): The graph to be annotated
+        graph (:class:`torch.fx.Graph`): The graph to be annotated
     """
     for node in graph.nodes:
         if node.target is operator.getitem:

--- a/torch/fx/passes/split_utils.py
+++ b/torch/fx/passes/split_utils.py
@@ -87,7 +87,9 @@ def split_by_tags(
     the initial submodules in the order of "a", "b", "c".
 
     To set a tag:
+    ```python
     gm.graph.nodes[idx].tag = "mytag"
+    ```
 
     This will result in all nodes with the same tag being extracted and placed in their
     own submodule. For placeholder, output and get_attr node, the tag is ignored. placeholder
@@ -96,6 +98,7 @@ def split_by_tags(
 
     Given the following module def:
 
+    ```python
     class SimpleModule(torch.nn.Module):
         def __init__(self) -> None:
             super().__init__()
@@ -108,29 +111,36 @@ def split_by_tags(
             r2 = self.linear2(in2)
             r3 = torch.cat([r1, r2])
             return self.linear3(r3)
+    ```
 
     Marking the node corresponding to in1 with the tag sc.REQUEST_ONLY.lower() results in the following split:
 
     ro:
+    ```python
     def forward(self, in1):
         self = self.root
         linear1 = self.linear1(in1)
         return linear1
+    ```
 
     main:
+    ```python
     def forward(self, in2, linear1):
         self = self.root
         linear2 = self.linear2(in2)
         cat_1 = torch.cat([linear1, linear2])
         linear3 = self.linear3(cat_1)
         return linear3
+    ```
 
     main:
+    ```python
     def forward(self, in1, in2):
         self = self.root
         ro_0 = self.ro_0(in1)
         main_1 = self.main_1(in2, ro_0)
         return main_1
+    ```
 
     Returns:
         split_gm: torch fx graph after split

--- a/torch/fx/passes/split_utils.py
+++ b/torch/fx/passes/split_utils.py
@@ -87,9 +87,10 @@ def split_by_tags(
     the initial submodules in the order of "a", "b", "c".
 
     To set a tag:
-    ```python
-    gm.graph.nodes[idx].tag = "mytag"
-    ```
+
+    .. code-block:: python
+
+        gm.graph.nodes[idx].tag = "mytag"
 
     This will result in all nodes with the same tag being extracted and placed in their
     own submodule. For placeholder, output and get_attr node, the tag is ignored. placeholder
@@ -98,54 +99,58 @@ def split_by_tags(
 
     Given the following module def:
 
-    ```python
-    class SimpleModule(torch.nn.Module):
-        def __init__(self) -> None:
-            super().__init__()
-            self.linear1 = torch.nn.Linear(...)
-            self.linear2 = torch.nn.Linear(...)
-            self.linear3 = torch.nn.Linear(...)
+    .. code-block:: python
 
-        def forward(self, in1, in2):
-            r1 = self.linear1(in1)
-            r2 = self.linear2(in2)
-            r3 = torch.cat([r1, r2])
-            return self.linear3(r3)
-    ```
+        class SimpleModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear1 = torch.nn.Linear(...)
+                self.linear2 = torch.nn.Linear(...)
+                self.linear3 = torch.nn.Linear(...)
+
+            def forward(self, in1, in2):
+                r1 = self.linear1(in1)
+                r2 = self.linear2(in2)
+                r3 = torch.cat([r1, r2])
+                return self.linear3(r3)
 
     Marking the node corresponding to in1 with the tag sc.REQUEST_ONLY.lower() results in the following split:
 
     ro:
-    ```python
-    def forward(self, in1):
-        self = self.root
-        linear1 = self.linear1(in1)
-        return linear1
-    ```
+
+    .. code-block:: python
+
+        def forward(self, in1):
+            self = self.root
+            linear1 = self.linear1(in1)
+            return linear1
 
     main:
-    ```python
-    def forward(self, in2, linear1):
-        self = self.root
-        linear2 = self.linear2(in2)
-        cat_1 = torch.cat([linear1, linear2])
-        linear3 = self.linear3(cat_1)
-        return linear3
-    ```
+
+    .. code-block:: python
+
+        def forward(self, in2, linear1):
+            self = self.root
+            linear2 = self.linear2(in2)
+            cat_1 = torch.cat([linear1, linear2])
+            linear3 = self.linear3(cat_1)
+            return linear3
 
     main:
-    ```python
-    def forward(self, in1, in2):
-        self = self.root
-        ro_0 = self.ro_0(in1)
-        main_1 = self.main_1(in2, ro_0)
-        return main_1
-    ```
+
+    .. code-block:: python
+
+        def forward(self, in1, in2):
+            self = self.root
+            ro_0 = self.ro_0(in1)
+            main_1 = self.main_1(in2, ro_0)
+            return main_1
 
     Returns:
         split_gm: torch fx graph after split
+
         orig_to_split_fqn_mapping: a map between the original fqn and the fqn
-            after split for call_module and get_attr.
+        after split for call_module and get_attr.
     """
 
     def flatten(x: torch.fx.node.Argument) -> NodeList:

--- a/torch/fx/passes/split_utils.py
+++ b/torch/fx/passes/split_utils.py
@@ -150,7 +150,7 @@ def split_by_tags(
         split_gm: torch fx graph after split
 
         orig_to_split_fqn_mapping: a map between the original fqn and the fqn
-        after split for call_module and get_attr.
+            after split for call_module and get_attr.
     """
 
     def flatten(x: torch.fx.node.Argument) -> NodeList:

--- a/torch/fx/passes/utils/common.py
+++ b/torch/fx/passes/utils/common.py
@@ -29,13 +29,13 @@ def lift_subgraph_as_module(
     class_name: str = "GraphModule",
 ) -> tuple[GraphModule, dict[str, str]]:
     """
-    Create a GraphModule for subgraph, which copies the necessary attributes 
+    Create a GraphModule for subgraph, which copies the necessary attributes
     from the original parent graph_module.
 
     Args:
         ``gm`` (GraphModule): parent graph module
 
-        ``subgraph`` (:class:`torch.fx.Graph`): a valid subgraph that contains copied nodes from the 
+        ``subgraph`` (:class:`torch.fx.Graph`): a valid subgraph that contains copied nodes from the
         parent graph
 
         ``comp_name`` (str): name for the new component

--- a/torch/fx/passes/utils/common.py
+++ b/torch/fx/passes/utils/common.py
@@ -29,16 +29,18 @@ def lift_subgraph_as_module(
     class_name: str = "GraphModule",
 ) -> tuple[GraphModule, dict[str, str]]:
     """
-    Create a GraphModule for subgraph, which copies the necessary attributes from the original parent graph_module.
+    Create a GraphModule for subgraph, which copies the necessary attributes 
+    from the original parent graph_module.
 
     Args:
-        gm (GraphModule): parent graph module
+        ``gm`` (GraphModule): parent graph module
 
-        subgraph (Graph): a valid subgraph that contains copied nodes from the parent graph
+        ``subgraph`` (:class:`torch.fx.Graph`): a valid subgraph that contains copied nodes from the 
+        parent graph
 
-        comp_name (str): name for the new component
+        ``comp_name`` (str): name for the new component
 
-        class_name (str): name for the submodule
+        ``class_name`` (str): name for the submodule
 
     """
 

--- a/torch/fx/passes/utils/common.py
+++ b/torch/fx/passes/utils/common.py
@@ -33,14 +33,14 @@ def lift_subgraph_as_module(
     from the original parent graph_module.
 
     Args:
-        ``gm`` (GraphModule): parent graph module
+        gm (GraphModule): parent graph module
 
-        ``subgraph`` (:class:`torch.fx.Graph`): a valid subgraph that contains copied nodes from the
-        parent graph
+        subgraph (:class:`torch.fx.Graph`): a valid subgraph that contains copied nodes from the
+            parent graph
 
-        ``comp_name`` (str): name for the new component
+        comp_name (str): name for the new component
 
-        ``class_name`` (str): name for the submodule
+        class_name (str): name for the submodule
 
     """
 


### PR DESCRIPTION
Fixes: #182521

documented Undocumented functions:
- split_by_tags
- generate_inputs_for_submodules
- lift_subgraph_as_module
- fuse_as_graphmodule
- get_source_partitions
- get_size_of_all_nodes
- get_size_of_node
- annotate_getitem_nodes

cc @svekars @sekyondaMeta @AlannaBurke