### PR TITLE
Document set_checkpoint_early_stop and set_device_states in checkpoint.md

### DIFF
--- a/docs/source/checkpoint.md
+++ b/docs/source/checkpoint.md
@@ -40,4 +40,6 @@ output compared to non-checkpointed passes is never guaranteed.
 .. autoclass:: SelectiveCheckpointContext
 .. autofunction:: create_selective_checkpoint_contexts
 .. autoclass:: GraphExecGroup
+.. autofunction:: set_checkpoint_early_stop
+.. autofunction:: set_device_states
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1041,8 +1041,6 @@ coverage_ignore_functions = [
     "detach_variable",
     "get_device_states",
     "noop_context_fn",
-    "set_checkpoint_early_stop",
-    "set_device_states",
     # torch.utils.cpp_backtrace
     "get_cpp_backtrace",
     # torch.utils.cpp_extension

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -759,7 +759,7 @@ _enable_checkpoint_early_stop: bool | None = None
 
 @contextlib.contextmanager
 def set_checkpoint_early_stop(enable: bool):
-    """Context manager that sets whether checkpoint should stop recomputation early.
+    """Controls whether checkpoint should stop recomputation early.
 
     By default, non-reentrant checkpoint stops recomputation as soon as it
     has computed all needed Tensors. This context manager can be used to disable
@@ -770,14 +770,14 @@ def set_checkpoint_early_stop(enable: bool):
 
     Example::
 
-    >>> # xdoctest: +SKIP(failing)
-    >>> message = "saved tensors default hooks are disabled"
-    >>> with set_checkpoint_early_stop(False):
-    ...     # Any checkpoint under this context manager will respect this
-    ...     # context manager, even if its backward is performed outside.
-    ...     out = checkpoint(fn, inputs)
-    ...
-    >>> out.backward()
+        >>> # xdoctest: +SKIP(failing)
+        >>> message = "saved tensors default hooks are disabled"
+        >>> with set_checkpoint_early_stop(False):
+        ...     # Any checkpoint under this context manager will respect this
+        ...     # context manager, even if its backward is performed outside.
+        ...     out = checkpoint(fn, inputs)
+        ...
+        >>> out.backward()
     """
     global _enable_checkpoint_early_stop
     try:


### PR DESCRIPTION
Documents `set_checkpoint_early_stop` and `set_device_states` from `torch.utils.checkpoint` as part of Docathon H1 2026.

Fixes #182516

## Changes
- Removed `set_checkpoint_early_stop` and `set_device_states` from `coverage_ignore_functions` in `docs/source/conf.py`
- Added `.. autofunction::` directives for both functions to `docs/source/checkpoint.md` under the correct `currentmodule:: torch.utils.checkpoint` scope

## Screenshots
_Will add rendered doc screenshots from the PR preview once CI build completes._


cc @svekars @sekyondaMeta @AlannaBurke