### PR TITLE
[Docs] Add CUDA SDPA determinism section to `randomness.rst`

### DIFF
--- a/docs/source/notes/randomness.rst
+++ b/docs/source/notes/randomness.rst
@@ -135,6 +135,87 @@ itself may be nondeterministic, unless either
 controls only this behavior, unlike :meth:`torch.use_deterministic_algorithms`
 which will make other PyTorch operations behave deterministically, too.
 
+CUDA Scaled Dot Product Attention
+---------------------------------
+:func:`torch.nn.functional.scaled_dot_product_attention` (SDPA) dispatches to
+multiple backends at runtime. Each backend has different determinism
+characteristics, summarized in the table below:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 15 45
+
+   * - Backend
+     - Forward
+     - Backward
+     - Notes
+   * - ``SDPBackend.MATH``
+     - Deterministic
+     - Deterministic
+     - Uses standard PyTorch operators (``matmul``, ``softmax``). Deterministic
+       when :meth:`torch.use_deterministic_algorithms` is enabled.
+   * - ``SDPBackend.FLASH_ATTENTION``
+     - Deterministic
+     - Non-deterministic
+     - The backward pass uses non-deterministic atomic operations by default.
+       Setting ``torch.use_deterministic_algorithms(True, warn_only=False)``
+       enables a deterministic backward implementation.
+   * - ``SDPBackend.EFFICIENT_ATTENTION``
+     - Deterministic
+     - Non-deterministic
+     - The backward pass may split work across keys (``num_splits_key > 1``)
+       for performance, which is non-deterministic. Setting
+       ``torch.use_deterministic_algorithms(True, warn_only=False)`` forces
+       ``num_splits_key = 1``, making the backward pass deterministic.
+   * - ``SDPBackend.CUDNN_ATTENTION``
+     - Non-deterministic
+     - Non-deterministic
+     - No deterministic implementation is available. This backend is
+       **disabled** when
+       ``torch.use_deterministic_algorithms(True, warn_only=False)`` is set,
+       and the dispatcher falls back to another backend.
+
+When :code:`torch.use_deterministic_algorithms(True, warn_only=True)` is set,
+the fused backends (Flash, Efficient, and cuDNN) emit a one-time warning but
+still use their default non-deterministic code paths. To actually enforce
+determinism, pass :code:`warn_only=False`.
+
+**Low-precision dtypes and numerical reproducibility**
+
+The fused SDPA backends (Flash Attention, Efficient Attention, and cuDNN)
+operate on low-precision inputs (``float16`` and ``bfloat16``) and perform
+internal accumulations in ``float32``. This gives consistent results across
+runs *when using the deterministic code paths described above*, but the results
+will differ numerically from the Math backend, which operates at the full
+precision of its inputs.
+
+The Math backend by default also accumulates in ``float32`` even when given
+``float16`` or ``bfloat16`` inputs. The function
+:func:`torch.backends.cuda.allow_fp16_bf16_reduction_math_sdp` can enable
+reduced-precision accumulation for higher performance, but the output may
+differ from the ``float32`` accumulation path. This setting does not affect
+determinism — results are still reproducible across runs, just computed at
+lower precision.
+
+**Selecting a specific backend**
+
+Use the :func:`torch.nn.attention.sdpa_kernel` context manager to restrict
+which backends SDPA may use. For example, to guarantee deterministic behavior
+regardless of hardware::
+
+    import torch
+    from torch.nn.attention import sdpa_kernel, SDPBackend
+
+    torch.use_deterministic_algorithms(True)
+
+    # Option 1: Use only the Math backend (always deterministic)
+    with sdpa_kernel(SDPBackend.MATH):
+        out = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+    # Option 2: Allow Flash and Efficient (deterministic with the flag above)
+    with sdpa_kernel([SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION]):
+        out = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
 CUDA RNN and LSTM
 -----------------
 In some versions of CUDA, RNNs and LSTM networks may have non-deterministic behavior.

--- a/docs/source/notes/randomness.rst
+++ b/docs/source/notes/randomness.rst
@@ -170,8 +170,13 @@ characteristics, summarized in the table below:
    * - ``SDPBackend.CUDNN_ATTENTION``
      - Deterministic
      - Non-deterministic
-     - The backward pass is non-deterministic and no deterministic
-       implementation is available. This backend is **disabled** when
+     - cuDNN provides an opt-in deterministic backward for ``float16``
+       starting in
+       `cuDNN 9.18 <https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html#cudnn-9-18-0>`_
+       (via
+       `set_deterministic_algorithm <https://docs.nvidia.com/deeplearning/cudnn/frontend/latest/operations/Attention.html#sdpa-fp16-bf16-backward>`_),
+       but this has not yet been integrated into PyTorch. This backend is
+       **disabled** when
        ``torch.use_deterministic_algorithms(True, warn_only=False)`` is set,
        regardless of whether inputs require gradients or the call is
        inside a ``torch.no_grad()`` context.

--- a/docs/source/notes/randomness.rst
+++ b/docs/source/notes/randomness.rst
@@ -173,7 +173,8 @@ characteristics, summarized in the table below:
      - The backward pass is non-deterministic and no deterministic
        implementation is available. This backend is **disabled** when
        ``torch.use_deterministic_algorithms(True, warn_only=False)`` is set,
-       and the dispatcher falls back to another backend.
+       regardless of whether inputs require gradients or the call is
+       inside a ``torch.no_grad()`` context.
 
 When :code:`torch.use_deterministic_algorithms(True, warn_only=True)` is set,
 the fused backends (Flash, Efficient, and cuDNN) emit a one-time warning but
@@ -182,20 +183,16 @@ determinism, pass :code:`warn_only=False`.
 
 **Low-precision dtypes and numerical reproducibility**
 
-The fused SDPA backends (Flash Attention, Efficient Attention, and cuDNN)
-operate on low-precision inputs (``float16`` and ``bfloat16``) and perform
-internal accumulations in ``float32``. This gives consistent results across
-runs *when using the deterministic code paths described above*, but the results
-will differ numerically from the Math backend, which operates at the full
-precision of its inputs.
+Bitwise matching numerics across different SDPA backends are **not
+guaranteed**, even for the same inputs and dtype. Each backend performs
+floating-point accumulation in a different order, and because floating-point
+addition is not associative, the results will differ between backends.
 
-The Math backend by default also accumulates in ``float32`` even when given
+The Math backend by default accumulates in ``float32`` even when given
 ``float16`` or ``bfloat16`` inputs. The function
 :func:`torch.backends.cuda.allow_fp16_bf16_reduction_math_sdp` can enable
-reduced-precision accumulation for higher performance, but the output may
-differ from the ``float32`` accumulation path. This setting does not affect
-determinism — results are still reproducible across runs, just computed at
-lower precision.
+reduced-precision accumulation for higher performance at the cost of
+different numerical results.
 
 **Selecting a specific backend**
 

--- a/docs/source/notes/randomness.rst
+++ b/docs/source/notes/randomness.rst
@@ -168,10 +168,10 @@ characteristics, summarized in the table below:
        ``torch.use_deterministic_algorithms(True, warn_only=False)`` forces
        ``num_splits_key = 1``, making the backward pass deterministic.
    * - ``SDPBackend.CUDNN_ATTENTION``
+     - Deterministic
      - Non-deterministic
-     - Non-deterministic
-     - No deterministic implementation is available. This backend is
-       **disabled** when
+     - The backward pass is non-deterministic and no deterministic
+       implementation is available. This backend is **disabled** when
        ``torch.use_deterministic_algorithms(True, warn_only=False)`` is set,
        and the dispatcher falls back to another backend.
 


### PR DESCRIPTION
Fixes #178587

Adds a new **CUDA Scaled Dot Product Attention** section to `docs/source/notes/randomness.rst` under "Avoiding nondeterministic algorithms". The section documents:
- A table showing forward/backward determinism for each `SDPBackend` (MATH, FLASH_ATTENTION, EFFICIENT_ATTENTION, CUDNN_ATTENTION)
- How `torch.use_deterministic_algorithms` interacts with each backend (`warn_only=True` vs `warn_only=False`)
- Low-precision dtype behavior (`float16`/`bfloat16`) and `allow_fp16_bf16_reduction_math_sdp`
- Code examples using `sdpa_kernel` to select deterministic backends
### Verification
All claims were verified locally against source code and at runtime on CUDA:
| Claim | Method | Result |
|-------|--------|--------|
| MATH fwd+bwd deterministic | Runtime test | PASS |
| FLASH fwd deterministic | Runtime test | PASS |
| FLASH bwd deterministic in strict mode | Runtime test | PASS |
| FLASH warns with `warn_only=True` | Runtime test (caught warning) | PASS |
| EFFICIENT fwd deterministic | Runtime test | PASS |
| EFFICIENT warns with `warn_only=True` | Runtime test (caught warning) | PASS |
| EFFICIENT bwd deterministic in strict mode | Runtime test | PASS |
| cuDNN excluded in strict mode | Runtime test (error + warning) | PASS |
| cuDNN-only strict mode raises RuntimeError | Runtime test | PASS |
| fp16/bf16 reduction disabled by default | API check | PASS |
| `sdpa_kernel` selects backends | Runtime test | PASS |


Source code cross-references:
- `aten/src/ATen/native/transformers/cuda/sdp_utils.cpp` (lines 741-752: `check_cudnn_deterministic`)
- `aten/src/ATen/native/transformers/cuda/attention_backward.cu` (lines 121-131: Flash, 898-910: MemEff)
- `test/test_transformers.py` (lines 3653-3735: determinism tests)
-  Sphinx build and lintrunner both pass locally

cc @svekars @sekyondaMeta @AlannaBurke @drisspg @liangel-02 @howardzhang-cv @famura