### PR TITLE
document assert_dicts_equal, prod, select_unit, trim_sigfig, bench_al…

### DIFF
--- a/docs/source/benchmark_utils.md
+++ b/docs/source/benchmark_utils.md
@@ -38,6 +38,34 @@
     :members:
 ```
 
+```{eval-rst}
+.. currentmodule:: torch.utils.benchmark.examples.op_benchmark
+
+.. autofunction:: assert_dicts_equal
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.benchmark.utils.fuzzer
+
+.. autofunction:: prod
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.benchmark.utils.common
+
+.. autofunction:: select_unit
+
+.. autofunction:: trim_sigfig
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.benchmark.utils.compile
+
+.. autofunction:: bench_all
+
+.. autofunction:: benchmark_compile
+```
+
 # torch.utils.benchmark.examples
 
 ```{eval-rst}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1004,28 +1004,22 @@ coverage_ignore_functions = [
     "generate_methods_for_privateuse1_backend",
     "rename_privateuse1_backend",
     # torch.utils.benchmark.examples.op_benchmark
-    "assert_dicts_equal",
     # torch.utils.benchmark.op_fuzzers.spectral
     "power_range",
     # torch.utils.benchmark.utils.common
     "ordered_unique",
-    "select_unit",
     "set_torch_threads",
-    "trim_sigfig",
     "unit_to_english",
     # torch.utils.benchmark.utils.compare
     "optional_min",
     # torch.utils.benchmark.utils.compile
-    "bench_all",
     "bench_loop",
-    "benchmark_compile",
     # torch.utils.benchmark.utils.cpp_jit
     "compile_callgrind_template",
     "compile_timeit_template",
     "get_compat_bindings",
     # torch.utils.benchmark.utils.fuzzer
     "dtype_size",
-    "prod",
     # torch.utils.benchmark.utils.timer
     "timer",
     # torch.utils.benchmark.utils.valgrind_wrapper.timer_interface

--- a/torch/utils/benchmark/examples/op_benchmark.py
+++ b/torch/utils/benchmark/examples/op_benchmark.py
@@ -18,7 +18,8 @@ _MEASURE_TIME = 1.0
 
 def assert_dicts_equal(dict_0, dict_1) -> None:
     """Builtin dict comparison will not compare numpy arrays.
-    e.g.
+    
+    e.g.::
         x = {"a": np.ones((2, 1))}
         x == x  # Raises ValueError
     """

--- a/torch/utils/benchmark/examples/op_benchmark.py
+++ b/torch/utils/benchmark/examples/op_benchmark.py
@@ -18,7 +18,7 @@ _MEASURE_TIME = 1.0
 
 def assert_dicts_equal(dict_0, dict_1) -> None:
     """Builtin dict comparison will not compare numpy arrays.
-    
+
     e.g.::
         x = {"a": np.ones((2, 1))}
         x == x  # Raises ValueError

--- a/torch/utils/benchmark/examples/op_benchmark.py
+++ b/torch/utils/benchmark/examples/op_benchmark.py
@@ -20,6 +20,7 @@ def assert_dicts_equal(dict_0, dict_1) -> None:
     """Builtin dict comparison will not compare numpy arrays.
 
     e.g.::
+ 
         x = {"a": np.ones((2, 1))}
         x == x  # Raises ValueError
     """

--- a/torch/utils/benchmark/examples/op_benchmark.py
+++ b/torch/utils/benchmark/examples/op_benchmark.py
@@ -20,7 +20,7 @@ def assert_dicts_equal(dict_0, dict_1) -> None:
     """Builtin dict comparison will not compare numpy arrays.
 
     e.g.::
- 
+
         x = {"a": np.ones((2, 1))}
         x == x  # Raises ValueError
     """

--- a/torch/utils/benchmark/examples/sparse/op_benchmark.py
+++ b/torch/utils/benchmark/examples/sparse/op_benchmark.py
@@ -16,6 +16,7 @@ _MEASURE_TIME = 1.0
 
 def assert_dicts_equal(dict_0, dict_1) -> None:
     """Builtin dict comparison will not compare numpy arrays.
+
     e.g.::
         x = {"a": np.ones((2, 1))}
         x == x  # Raises ValueError

--- a/torch/utils/benchmark/examples/sparse/op_benchmark.py
+++ b/torch/utils/benchmark/examples/sparse/op_benchmark.py
@@ -18,7 +18,7 @@ def assert_dicts_equal(dict_0, dict_1) -> None:
     """Builtin dict comparison will not compare numpy arrays.
 
     e.g.::
- 
+
         x = {"a": np.ones((2, 1))}
         x == x  # Raises ValueError
     """

--- a/torch/utils/benchmark/examples/sparse/op_benchmark.py
+++ b/torch/utils/benchmark/examples/sparse/op_benchmark.py
@@ -16,7 +16,7 @@ _MEASURE_TIME = 1.0
 
 def assert_dicts_equal(dict_0, dict_1) -> None:
     """Builtin dict comparison will not compare numpy arrays.
-    e.g.
+    e.g.::
         x = {"a": np.ones((2, 1))}
         x == x  # Raises ValueError
     """

--- a/torch/utils/benchmark/examples/sparse/op_benchmark.py
+++ b/torch/utils/benchmark/examples/sparse/op_benchmark.py
@@ -18,6 +18,7 @@ def assert_dicts_equal(dict_0, dict_1) -> None:
     """Builtin dict comparison will not compare numpy arrays.
 
     e.g.::
+ 
         x = {"a": np.ones((2, 1))}
         x == x  # Raises ValueError
     """


### PR DESCRIPTION

Fixes #182515


## Description

Modified `docs/source/benchmark_utils.md` to add directives after the compare section

Removed entries from `docs/source/conf.py` 
- assert_dicts_equal
- prod
- select_unit
- trim_sigfig
- bench_all
- benchmark_compile 

## Checklist

- [X] Entries removed from skip list(s) in [docs/source/conf.py](https://github.com/pytorch/pytorch/blob/main/docs/source/conf.py)
- [X] Sphinx directives added to [docs/source/benchmark_utils.md](https://github.com/pytorch/pytorch/blob/main/docs/source/benchmark_utils.md)
- [X] make coverage passes with no new undocumented warnings for these APIs
- [X] Screenshot(s) of the rendered documentation included in the PR description


<img width="1468" height="812" alt="image" src="https://github.com/user-attachments/assets/d10b00b7-45f2-4027-9a28-4e1015de52fd" />

<img width="1482" height="812" alt="image" src="https://github.com/user-attachments/assets/e39a7fef-bbcd-4750-885a-8278a4a0b21a" />


<img width="1487" height="812" alt="image" src="https://github.com/user-attachments/assets/df7cd2e7-69f1-4407-9dd9-14293fba9920" />


cc @svekars @sekyondaMeta @AlannaBurke