### PR TITLE
docs: convert elastic timer to markdown

### DIFF
--- a/docs/source/elastic/timer.md
+++ b/docs/source/elastic/timer.md
@@ -1,47 +1,56 @@
-Expiration Timers
-==================
+# Expiration Timers
 
+```{eval-rst}
 .. automodule:: torch.distributed.elastic.timer
 .. currentmodule:: torch.distributed.elastic.timer
+```
 
-Client Methods
----------------
+## Client Methods
+
+```{eval-rst}
 .. autofunction:: torch.distributed.elastic.timer.configure
 
 .. autofunction:: torch.distributed.elastic.timer.expires
+```
 
-Server/Client Implementations
-------------------------------
+## Server/Client Implementations
+
 Below are the timer server and client pairs that are provided by torchelastic.
 
-.. note:: Timer server and clients always have to be implemented and used
-          in pairs since there is a messaging protocol between the server
-          and client.
+```{note}
+Timer server and clients always have to be implemented and used
+in pairs since there is a messaging protocol between the server
+and client.
+```
 
 Below is a pair of timer server and client that is implemented based on
-a ``multiprocess.Queue``.
+a `multiprocess.Queue`.
 
+```{eval-rst}
 .. autoclass:: LocalTimerServer
 
 .. autoclass:: LocalTimerClient
+```
 
 Below is another pair of timer server and client that is implemented
 based on a named pipe.
 
+```{eval-rst}
 .. autoclass:: FileTimerServer
 
 .. autoclass:: FileTimerClient
+```
 
 
-Writing a custom timer server/client
---------------------------------------
+## Writing a custom timer server/client
 
 To write your own timer server and client extend the
-``torch.distributed.elastic.timer.TimerServer`` for the server and
-``torch.distributed.elastic.timer.TimerClient`` for the client. The
-``TimerRequest`` object is used to pass messages between
+`torch.distributed.elastic.timer.TimerServer` for the server and
+`torch.distributed.elastic.timer.TimerClient` for the client. The
+`TimerRequest` object is used to pass messages between
 the server and client.
 
+```{eval-rst}
 .. autoclass:: TimerRequest
    :members:
 
@@ -50,11 +59,13 @@ the server and client.
 
 .. autoclass:: TimerClient
    :members:
+```
 
 
-Debug info logging
--------------------
+## Debug info logging
 
+```{eval-rst}
 .. automodule:: torch.distributed.elastic.timer.debug_info_logging
 
 .. autofunction:: torch.distributed.elastic.timer.debug_info_logging.log_debug_info_for_expired_timers
+```


### PR DESCRIPTION
Fixes #182474

Converts `docs/source/elastic/timer.rst` to MyST Markdown using `git mv`.

Validation:
- `git diff --check`
- Local Sphinx build for `source/elastic/timer.md`
- Verified generated `docs/build/html/elastic/timer.html` contains the rendered page content and autodoc sections
- `lintrunner --data-path /home/tihor/pytorchdocathon/.lintrunner-data -m main`

Note: `check_doc_redirects.py --base-ref origin/main` reports the extension-only rename as `elastic/timer -> elastic/timer.html`. I did not add that self-redirect because it would target the same rendered URL, matching the issue seen on the previous docathon conversion.


cc @svekars @sekyondaMeta @AlannaBurke