### PR TITLE
[DTensor]: add backward gradient verification to test_single_dim_strategy

### DIFF
--- a/test/distributed/tensor/test_dtensor_ops.py
+++ b/test/distributed/tensor/test_dtensor_ops.py
@@ -31,6 +31,7 @@ from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorConverter,
     DTensorOpTestBase,
     validate_sharding_rule_sample,
+    validate_sharding_rule_sample_backward,
 )
 from torch.utils import _pytree as pytree
 from torch.utils._debug_mode import _OpCall, DebugMode
@@ -1125,8 +1126,21 @@ class TestSingleDimStrategies(DTensorOpTestBase):
                     tuple(output_placements),
                     mesh,
                 ),
-                f"{op.name}: {input_placements} -> {tuple(output_placements)} failed",
+                f"{op.name}: forward {input_placements} -> {tuple(output_placements)} failed",
             )
+
+            bwd = validate_sharding_rule_sample_backward(
+                aten_op,
+                full_args,
+                full_kwargs,
+                input_placements,
+                mesh,
+            )
+            if bwd is not None:
+                self.assertTrue(
+                    bwd,
+                    f"{op.name}: backward {input_placements} failed",
+                )
 
 
 class TestCompiledDTensorOps(TestDTensorOps):

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -1535,7 +1535,7 @@ def validate_sharding_rule_sample_backward(
     )
     dt_tensors = [
         distribute_tensor(c, device_mesh, (p,))
-        for c, p in zip(_clone_with_grad(full_tensors), input_placements)
+        for c, p in zip(_clone_with_grad(full_tensors), input_placements, strict=True)
     ]
     dt_args, dt_kwargs = _replace_tensors(full_args, full_kwargs, dt_tensors)
     try:
@@ -1551,7 +1551,7 @@ def validate_sharding_rule_sample_backward(
         raise
 
     # Compare gradients
-    for ref_t, dt_t in zip(ref_tensors, dt_tensors):
+    for ref_t, dt_t in zip(ref_tensors, dt_tensors, strict=True):
         if not ref_t.is_floating_point() or ref_t.grad is None:
             continue
         if dt_t.grad is None:

--- a/torch/testing/_internal/distributed/_tensor/common_dtensor.py
+++ b/torch/testing/_internal/distributed/_tensor/common_dtensor.py
@@ -1467,6 +1467,107 @@ def validate_sharding_rule_sample(
     return True
 
 
+def validate_sharding_rule_sample_backward(
+    op, full_args, full_kwargs, input_placements, device_mesh
+):
+    """Verify backward gradient correctness for a sharding strategy.
+
+    Returns None if the op is not differentiable or lacks backward DTensor
+    support (skip), True if gradients match, False if they differ.
+    """
+    from torch.utils import _pytree as pytree
+
+    full_tensors = [
+        a for a in pytree.tree_leaves(full_args) if isinstance(a, torch.Tensor)
+    ]
+    full_tensors += [
+        a for a in pytree.tree_leaves(full_kwargs) if isinstance(a, torch.Tensor)
+    ]
+
+    if not any(t.is_floating_point() for t in full_tensors):
+        return None
+
+    def _clone_with_grad(tensors):
+        out = []
+        for t in tensors:
+            c = t.detach().clone()
+            if c.is_floating_point():
+                c.requires_grad_(True)
+            out.append(c)
+        return out
+
+    def _replace_tensors(args, kwargs, replacements):
+        idx = 0
+
+        def _replace(a):
+            nonlocal idx
+            if isinstance(a, torch.Tensor):
+                r = replacements[idx]
+                idx += 1
+                return r
+            return a
+
+        return pytree.tree_map(_replace, (args, kwargs))
+
+    def _run_backward(output):
+        out_tensors = [
+            t
+            for t in pytree.tree_leaves(output)
+            if isinstance(t, torch.Tensor) and t.is_floating_point() and t.requires_grad
+        ]
+        if not out_tensors:
+            return False
+        sum(t.sum() for t in out_tensors).backward()
+        return True
+
+    # Reference backward
+    ref_tensors = _clone_with_grad(full_tensors)
+    ref_args, ref_kwargs = _replace_tensors(full_args, full_kwargs, ref_tensors)
+    try:
+        if not _run_backward(op(*ref_args, **ref_kwargs)):
+            return None
+    except RuntimeError:
+        return None
+
+    # DTensor backward
+    assert len(input_placements) == len(full_tensors), (  # noqa: S101
+        f"placement/tensor count mismatch: {len(input_placements)} vs {len(full_tensors)}"
+    )
+    dt_tensors = [
+        distribute_tensor(c, device_mesh, (p,))
+        for c, p in zip(_clone_with_grad(full_tensors), input_placements)
+    ]
+    dt_args, dt_kwargs = _replace_tensors(full_args, full_kwargs, dt_tensors)
+    try:
+        if not _run_backward(op(*dt_args, **dt_kwargs)):
+            return None
+    except Exception as e:
+        msg = str(e)
+        if (
+            "does not have a sharding strategy registered" in msg
+            or "got mixed torch.Tensor and DTensor" in msg
+        ):
+            return None
+        raise
+
+    # Compare gradients
+    for ref_t, dt_t in zip(ref_tensors, dt_tensors):
+        if not ref_t.is_floating_point() or ref_t.grad is None:
+            continue
+        if dt_t.grad is None:
+            return False
+        dt_grad = (
+            dt_t.grad.full_tensor() if isinstance(dt_t.grad, DTensor) else dt_t.grad
+        )
+        if ref_t.grad.shape != dt_grad.shape:
+            return False
+        if not torch.allclose(
+            ref_t.grad, dt_grad, atol=1e-5, rtol=1.3e-6, equal_nan=True
+        ):
+            return False
+    return True
+
+
 @contextlib.contextmanager
 def op_strategy_context(op_overload, strategy_func, schema_info=None):
     """


### PR DESCRIPTION
Follow on to https://github.com/pytorch/pytorch/pull/182526

Add validate_sharding_rule_sample_backward to the single-dim strategy test loop. For every forward strategy that passes, we now also run backward through DTensor dispatch and verify gradient values match a plain-tensor reference.

Ops whose backward raises "no sharding strategy registered" or "mixed torch.Tensor and DTensor" are skipped -- these lack DTensor backward support entirely.

Authored with Claude.

It would also be good to check for placement change (fallback to replicate), but I thought starting with gradient correctness was a good first step. 
also could factor out some of the forward and backward commonality in the added test function. 