### PR TITLE
docs: add source link fallback for add_docstr functions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,6 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import functools
 import inspect
 import os
 import pkgutil
@@ -2196,6 +2197,36 @@ master_doc = "index"
 # Use the linkcode extension to override [SOURCE] links to point
 # to the repo. Use the torch_version variable defined above to
 # determine link
+@functools.cache
+def _add_docstr_source_lines(module_file):
+    pattern = re.compile(r"^([A-Za-z_]\w*)\s*=\s*_add_docstr\(")
+    source_lines = {}
+    try:
+        with open(module_file, encoding="utf-8") as f:
+            for lineno, line in enumerate(f, 1):
+                match = pattern.match(line)
+                if match is not None:
+                    source_lines[match.group(1)] = lineno
+    except OSError:
+        return {}
+
+    return source_lines
+
+
+def _find_add_docstr_source(module, fullname):
+    if "." in fullname or not re.match(r"^[A-Za-z_]\w*$", fullname):
+        return None
+
+    module_file = getattr(module, "__file__", None)
+    if module_file is None or not module_file.endswith(".py"):
+        return None
+
+    lineno = _add_docstr_source_lines(module_file).get(fullname)
+    if lineno is None:
+        return None
+    return module_file, lineno
+
+
 def linkcode_resolve(domain, info):
     if domain != "py":
         return None
@@ -2204,15 +2235,21 @@ def linkcode_resolve(domain, info):
 
     try:
         module = __import__(info["module"], fromlist=[""])
+    except Exception:
+        return None
+
+    try:
         obj = module
         for part in info["fullname"].split("."):
             obj = getattr(obj, part)
-        # Get the source file and line number
         obj = inspect.unwrap(obj)
         fn = inspect.getsourcefile(obj)
         source, lineno = inspect.getsourcelines(obj)
     except Exception:
-        return None
+        resolved = _find_add_docstr_source(module, info["fullname"])
+        if resolved is None:
+            return None
+        fn, lineno = resolved
 
     # Determine the tag based on the torch_version
     if RELEASE:


### PR DESCRIPTION
Fixes #170965

Adds a `linkcode_resolve` fallback for Python symbols whose source cannot be
resolved with `inspect` because they are C++ builtins wrapped with
`_add_docstr`. The fallback scans the defining Python module for top-level
`name = _add_docstr(...)` assignments and returns the Python assignment line,
which restores the rendered `[source]` link for `torch.nn.functional.linear`.

Validation:
- `/home/tihor/pytorchdocathon/.venv/bin/python -c "import conf; print(conf.linkcode_resolve('py', {'module': 'torch.nn.functional', 'fullname': 'linear'}))"` returns `.../torch/nn/functional.py#L2334`
- `sphinx-build -b html -j 1 source build/html source/generated/torch.nn.functional.linear.rst` succeeds locally
- rendered `docs/build/html/generated/torch.nn.functional.linear.html` contains `[source]` linking to `torch/nn/functional.py#L2334`
- `/home/tihor/pytorchdocathon/.venv/bin/lintrunner --data-path /home/tihor/pytorchdocathon/.lintrunner-data -m main`
- `/home/tihor/pytorchdocathon/.venv/bin/python .github/scripts/check_doc_redirects.py --base-ref origin/main`


cc @svekars @sekyondaMeta @AlannaBurke