### PR TITLE
[inductor] Pass prescreening_elapse to log_autotuning_results (#182563)

### DIFF
--- a/test/inductor/test_debug_trace.py
+++ b/test/inductor/test_debug_trace.py
@@ -293,6 +293,43 @@ op2.node.kernel = extern_kernels.mm""",
             m(input_tensor)
 
 
+class TestLogAutotuningResultsCallSite(test_torchinductor.TestCase):
+    def test_log_results_forwards_required_args_to_debug_formatter(self):
+        # Regression: AlgorithmSelectorCache.log_results omitted
+        # prescreening_elapse, which raised TypeError under
+        # TORCH_COMPILE_DEBUG=1 + LOG_AUTOTUNE_RESULTS=1 (those flags route
+        # V.debug to the real DebugFormatter, whose signature requires it).
+        import inspect
+
+        from torch._inductor.debug import DebugFormatter
+        from torch._inductor.select_algorithm import AlgorithmSelectorCache
+        from torch._inductor.virtualized import V
+
+        captured: dict = {}
+
+        class _Recorder:
+            def log_autotuning_results(self, *args, **kwargs):
+                captured["args"] = args
+                captured["kwargs"] = kwargs
+
+        with V.set_debug_handler(_Recorder()):
+            AlgorithmSelectorCache.log_results(
+                name="test_op",
+                input_nodes=[],
+                timings={},
+                elapse=0.0,
+                precompile_elapse=0.0,
+                prescreening_elapse=None,
+            )
+
+        self.assertIn("args", captured, "V.debug.log_autotuning_results was not called")
+        # Bind the captured call to the real DebugFormatter signature; missing
+        # required positional arg (e.g. prescreening_elapse) raises TypeError
+        # exactly like the production failure under LOG_AUTOTUNE_RESULTS=1.
+        sig = inspect.signature(DebugFormatter.log_autotuning_results)
+        sig.bind(_Recorder(), *captured["args"], **captured["kwargs"])
+
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
     from torch.testing._internal.inductor_utils import HAS_CPU

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -5491,7 +5491,7 @@ class AlgorithmSelectorCache(PersistentCache):
                     )
 
         V.debug.log_autotuning_results(
-            name, input_nodes, timings, elapse, precompile_elapse
+            name, input_nodes, timings, elapse, precompile_elapse, prescreening_elapse
         )
         if not (config.max_autotune or config.max_autotune_gemm) or not PRINT_AUTOTUNE:
             return


### PR DESCRIPTION
Summary:

The call site `AlgorithmSelectorCache.log_results` in `caffe2/torch/_inductor/select_algorithm.py:5459` was passing 5 positional args to `V.debug.log_autotuning_results`, but `DebugFormatter.log_autotuning_results` (`caffe2/torch/_inductor/debug.py:656`) requires 6. 

 Under `TORCH_COMPILE_DEBUG=1` + `LOG_AUTOTUNE_RESULTS=1` (the configuration that routes `V.debug` through `DebugContext.__getattr__` to the real `DebugFormatter` instead of the no-op fallback), every autotune run hits `TypeError: log_autotuning_results() missing 1 required positional argument: 'prescreening_elapse'`. The fix forwards the existing local `prescreening_elapse` through the call.

Add a regression test in `caffe2/test/inductor/test_debug_trace.py` that installs a recording `V.debug` handler, calls `AlgorithmSelectorCache.log_results`, and binds the captured arguments to the real `DebugFormatter.log_autotuning_results` signature via `inspect.signature(...).bind(...)`. Without the fix, the bind raises the same `TypeError` users see in production.

Authored by Claude.

Test Plan:
- WITH fix (passes): https://www.internalfb.com/intern/testinfra/testrun/30680772467347189
- WITHOUT fix (fails with `TypeError: missing a required argument: 'prescreening_elapse'`): https://www.internalfb.com/intern/testinfra/testrun/7318349744475938
- `buck2 test fbcode//caffe2/test/inductor:test_debug_trace -- --regex 'TestLogAutotuningResultsCallSite'`
- `arc lint` passes.

Reviewed By: desertfire

Differential Revision: D103916461




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo