### PR TITLE
[Dynamic shape]Add ObjectSpec update

### DIFF
--- a/test/dynamo/test_dynamic_spec.py
+++ b/test/dynamo/test_dynamic_spec.py
@@ -9,11 +9,14 @@ import torch.fx.experimental._config as _fx_experimental_config
 from torch._dynamo.decorators import mark_unbacked
 from torch._dynamo.dynamic_spec import (
     IntVar,
+    lookup_spec_from_dynamo_source,
+    ObjectSpec,
     ParamsSpec,
     ShapesSpec,
     ShapeVar,
     TensorSpec,
 )
+from torch._dynamo.source import AttrSource, LocalSource
 from torch._dynamo.test_case import run_tests, TestCase
 from torch._dynamo.testing import EagerAndRecordGraphs
 from torch.fx.experimental.symbolic_shapes import (
@@ -392,6 +395,156 @@ class TestShapeVarCompile(TestCase):
         # y not in spec → all static; changing y's shape recompiles
         compiled(torch.randn(8, 3), torch.randn(8, 3))  # x dim0 absorbed, y recompiles
         self.assertEqual(cnt.frame_count, 2)
+
+
+class TestObjectSpec(TestCase):
+    """``ObjectSpec`` data class — construction, access, repr, recursion."""
+
+    def test_empty(self):
+        os = ObjectSpec()
+        self.assertEqual(len(os), 0)
+
+    def test_dict_construction(self):
+        spec = TensorSpec([ShapeVar("h"), None])
+        os = ObjectSpec({"weight": spec, "bias": None})
+        self.assertEqual(len(os), 2)
+        self.assertIn("weight", os)
+        self.assertIs(os["weight"], spec)
+        self.assertIsNone(os["bias"])
+
+    def test_iter_and_items(self):
+        spec_w = TensorSpec([ShapeVar("h"), None])
+        spec_b = TensorSpec([ShapeVar("h")])
+        os = ObjectSpec({"weight": spec_w, "bias": spec_b})
+        self.assertEqual(list(os), ["weight", "bias"])
+        self.assertEqual(list(os.items()), [("weight", spec_w), ("bias", spec_b)])
+
+    def test_recursive_nesting(self):
+        # Nested ObjectSpec — value can itself be an ObjectSpec.
+        inner = ObjectSpec({"weight": TensorSpec([ShapeVar("h"), None])})
+        outer = ObjectSpec({"inner": inner})
+        self.assertIs(outer["inner"], inner)
+        self.assertIs(outer["inner"]["weight"]._specs[0], inner["weight"]._specs[0])
+
+    def test_repr_single(self):
+        os = ObjectSpec({"weight": None})
+        self.assertEqual(
+            repr(os),
+            "ObjectSpec(\n  .weight: None\n)",
+        )
+
+    def test_repr_with_tensorspec(self):
+        os = ObjectSpec({"weight": TensorSpec([ShapeVar("h"), None])})
+        self.assertEqual(
+            repr(os),
+            "ObjectSpec(\n"
+            "  .weight:\n"
+            "    TensorSpec(\n"
+            "      0: ShapeVar(name='h', min=0)\n"
+            "      1: None\n"
+            "    )\n"
+            ")",
+        )
+
+
+class TestObjectSpecLookup(TestCase):
+    """``lookup_spec_from_dynamo_source`` walks an ``AttrSource`` chain
+    against an ``ObjectSpec`` and returns the leaf at that path."""
+
+    def _local(self, name):
+        return LocalSource(name, is_input=True)
+
+    def _attr(self, base, member):
+        return AttrSource(base, member)
+
+    def test_attr_descends_into_objectspec(self):
+        leaf = TensorSpec([ShapeVar("h"), None])
+        shapes_spec = ShapesSpec(
+            params=ParamsSpec({"model": ObjectSpec({"weight": leaf})})
+        )
+        result = lookup_spec_from_dynamo_source(
+            self._attr(self._local("model"), "weight"), shapes_spec
+        )
+        self.assertIs(result, leaf)
+
+    def test_nested_objectspec_walk(self):
+        leaf = TensorSpec([ShapeVar("h"), None])
+        shapes_spec = ShapesSpec(
+            params=ParamsSpec(
+                {"model": ObjectSpec({"inner": ObjectSpec({"weight": leaf})})}
+            )
+        )
+        # model.inner.weight
+        src = self._attr(self._attr(self._local("model"), "inner"), "weight")
+        self.assertIs(lookup_spec_from_dynamo_source(src, shapes_spec), leaf)
+
+    def test_missing_attr_returns_none(self):
+        shapes_spec = ShapesSpec(
+            params=ParamsSpec(
+                {"model": ObjectSpec({"weight": TensorSpec([None, None])})}
+            )
+        )
+        # model.bias is not in the spec → None.
+        self.assertIsNone(
+            lookup_spec_from_dynamo_source(
+                self._attr(self._local("model"), "bias"), shapes_spec
+            )
+        )
+
+    def test_attr_against_non_objectspec_returns_none(self):
+        # Top-level spec is a TensorSpec but source asks for an attr — mismatch.
+        shapes_spec = ShapesSpec(params=ParamsSpec({"x": TensorSpec([None, None])}))
+        self.assertIsNone(
+            lookup_spec_from_dynamo_source(
+                self._attr(self._local("x"), "weight"), shapes_spec
+            )
+        )
+
+    def test_local_source_root_returns_top_level_spec(self):
+        # Bare LocalSource at the root returns the top-level spec object
+        # (an ObjectSpec); preserves the v0 behavior for non-walked sources.
+        spec_obj = ObjectSpec({"weight": TensorSpec([None, None])})
+        shapes_spec = ShapesSpec(params=ParamsSpec({"model": spec_obj}))
+        self.assertIs(
+            lookup_spec_from_dynamo_source(self._local("model"), shapes_spec),
+            spec_obj,
+        )
+
+
+class TestObjectSpecCompile(TestCase):
+    """End-to-end: ``ObjectSpec`` routes through to a tensor reached
+    via attribute access on a function arg (``obj.w``)."""
+
+    def test_attr_tensor_dim_dynamic(self):
+        # Plain Python container — avoids nn.Module wrapping subtleties.
+        class Container:
+            def __init__(self, w):
+                self.w = w
+
+        def fn(obj):
+            return obj.w + 1
+
+        backend = EagerAndRecordGraphs()
+        compiled = torch.compile(
+            fn,
+            backend=backend,
+            shapes_spec=ShapesSpec(
+                params=ParamsSpec(
+                    {"obj": ObjectSpec({"w": TensorSpec([ShapeVar("h"), None])})}
+                )
+            ),
+        )
+
+        compiled(Container(torch.randn(4, 3)))
+        self.assertEqual(len(backend.graphs), 1)
+
+        # Different dim 0 size — dynamic absorbs it, no recompile.
+        compiled(Container(torch.randn(8, 3)))
+        self.assertEqual(len(backend.graphs), 1)
+
+        # Captured weight placeholder has a SymInt at dim 0.
+        shape = _tensor_placeholder_shape(backend.graphs[-1])
+        self.assertIsInstance(shape[0], torch.SymInt)
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/dynamic_spec.py
+++ b/torch/_dynamo/dynamic_spec.py
@@ -10,13 +10,14 @@ from typing import Any, TYPE_CHECKING, TypeAlias
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
 
-from torch._dynamo.source import LocalSource
+from torch._dynamo.source import AttrSource, LocalSource
 
 
 __all__ = [
     "ShapeVar",
     "IntVar",
     "TensorSpec",
+    "ObjectSpec",
     "ParamsSpec",
     "ShapesSpec",
     "lookup_spec_from_dynamo_source",
@@ -132,6 +133,55 @@ class TensorSpec:
         return "\n".join(lines)
 
 
+class ObjectSpec:
+    """Spec for any Python object's attributes.
+
+    Models attribute access on a Python object (e.g., an ``nn.Module``'s
+    parameters / buffers / submodules; ``self`` inside an instance
+    method). Each field corresponds to an ``AttrSource`` in the dynamo
+    builder — when ``model.weight`` is traced, the spec walk descends
+    via ``ObjectSpec._fields["weight"]``.
+
+    Construct with a dict; values may be leaves (``TensorSpec`` /
+    ``IntVar`` / ``None``) or another ``ObjectSpec`` for recursion.
+
+    Example::
+
+        ObjectSpec({"weight": TensorSpec([ShapeVar("h"), None])})
+        ObjectSpec({"inner": ObjectSpec({"weight": TensorSpec([ShapeVar("h")])})})
+    """
+
+    def __init__(self, fields: dict[str, Any] | None = None) -> None:
+        self._fields: dict[str, Any] = dict(fields or {})
+
+    def __getitem__(self, name: str) -> Any:
+        return self._fields[name]
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._fields
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._fields)
+
+    def __len__(self) -> int:
+        return len(self._fields)
+
+    def items(self) -> Any:
+        return self._fields.items()
+
+    def __repr__(self) -> str:
+        lines = ["ObjectSpec("]
+        for name, spec in self._fields.items():
+            spec_repr = repr(spec)
+            if "\n" in spec_repr:
+                indented = "\n".join("    " + line for line in spec_repr.splitlines())
+                lines.append(f"  .{name}:\n{indented}")
+            else:
+                lines.append(f"  .{name}: {spec_repr}")
+        lines.append(")")
+        return "\n".join(lines)
+
+
 class ParamsSpec:
     """Specification for the arguments of a compiled function.
 
@@ -222,13 +272,43 @@ class ShapesSpec:
 
 
 def lookup_spec_from_dynamo_source(source, shapes_spec: ShapesSpec | None) -> LeafSpec:
-    """Look up the spec for a function input arg from the shapes_spec.
+    """Walk a dynamo ``Source`` chain against the spec tree.
 
-    Only supports LocalSource with is_input=True (direct function args).
-    Returns TensorSpec, IntVar, or None.
+    Returns the leaf ``IntVar`` / ``TensorSpec`` at the corresponding
+    path, or ``None`` if the source isn't covered. Supported source
+    kinds:
+
+    - ``LocalSource(name, is_input=True)`` — top-level function arg
+      (the root of any walk).
+    - ``AttrSource(base, member)`` — attribute access; matched against
+      ``ObjectSpec._fields[member]``.
+
+    Other source kinds (globals, ``GetItemSource``, etc.) return
+    ``None`` — later container PRs extend this dispatch.
     """
     if shapes_spec is None or shapes_spec.params is None:
         return None
-    if not isinstance(source, LocalSource) or not source.is_input:
+
+    # Walk source.base chain to its root, collecting (kind, key) entries.
+    path: list[tuple[str, Any]] = []
+    cur = source
+    while not isinstance(cur, LocalSource):
+        if isinstance(cur, AttrSource):
+            path.append(("attr", cur.member))
+        else:
+            return None
+        cur = cur.base
+    if not cur.is_input:
         return None
-    return shapes_spec.params._named_args.get(source.local_name)
+    path.reverse()
+
+    # Walk the spec tree from the named-arg root following the path.
+    spec: Any = shapes_spec.params._named_args.get(cur.local_name)
+    for kind, key in path:
+        if spec is None:
+            return None
+        if kind == "attr":
+            if not isinstance(spec, ObjectSpec):
+                return None
+            spec = spec._fields.get(key)
+    return spec


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182566
* #181995
* #182534

## Summary

Adds `ObjectSpec` and extends `lookup_spec_from_dynamo_source` so the spec system can address tensors reached via Python attribute access (`obj.weight`, module params/buffers, `self.x` inside an instance method).

```python
torch.compile(
    fn,
    shapes_spec=ShapesSpec(
        params=ParamsSpec(
            {"model": ObjectSpec({"weight": TensorSpec([ShapeVar("h"), None])})}
        )
    ),
)
```

## What changed

- **`ObjectSpec`** — attribute-keyed container holding `{name: spec}` entries. Constructor-only (`ObjectSpec({"weight": ...})`); no fluent setters. Recursive — a value may be another `ObjectSpec` or a leaf (`TensorSpec` / `ShapeVar` / `IntVar` / `int` / `None`).
- **`lookup_spec_from_dynamo_source`** — extends the v0 `LocalSource`-only lookup to walk `Source` chains:
  - `LocalSource(name, is_input=True)` — top-level function arg (the root of any walk).
  - `AttrSource(base, member)` — attribute access; matched against `ObjectSpec._fields[member]`.

  Other source kinds (globals, `GetItemSource`, etc.) return `None` — extended in the DictSpec / ListSpec PRs that follow.

## Test plan — `python test/dynamo/test_dynamic_spec.py`

- **`TestObjectSpec`** — empty / dict construction, `__getitem__` / `__contains__` / iter / items, recursive nesting, repr (single + nested with `TensorSpec`).
- **`TestObjectSpecLookup`** — walks `AttrSource` against `ObjectSpec` (including nested `model.inner.weight`); missing attr returns `None`; mismatched node kind (e.g. `AttrSource` against a top-level `TensorSpec`) returns `None`; bare `LocalSource` root returns the top-level `ObjectSpec` itself.
- **`TestObjectSpecCompile`** — end-to-end: `shapes_spec=ShapesSpec(params=ParamsSpec({"obj": ObjectSpec({"w": TensorSpec([ShapeVar("h"), None])})}))`, compile `fn(obj)` with `obj.w` access; assert `SymInt` at the captured tensor placeholder's dim 0 and that varying dim-0 sizes don't recompile.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98