### PR TITLE
Back out "[inductor] Fix CUDA IMA during max_autotune bmm with broadcast batch dim" (#182570)

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -1580,39 +1580,6 @@ class TestMaxAutotune(TestCase):
         act = f(x, y)
         torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
 
-    def test_broadcast_batch_bmm(self):
-        # Batch size > 1 with stride[0]=0 to exercise the broadcast batch
-        # guard that skips the Triton bmm template for stride-0 inputs.
-        x = rand_strided((4, 32, 64), (0, 64, 1), dtype=torch.bfloat16, device=GPU_TYPE)
-        y = rand_strided(
-            (4, 64, 16), (1024, 16, 1), dtype=torch.bfloat16, device=GPU_TYPE
-        )
-
-        @torch.compile(mode="max-autotune")
-        def f(x, y):
-            return torch.bmm(x, y)
-
-        ref = torch.bmm(x, y)
-        act = f(x, y)
-        torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
-
-    def test_broadcast_batch_baddbmm(self):
-        # Batch size > 1 with stride[0]=0 to exercise the broadcast batch
-        # guard that skips the Triton bmm template for stride-0 inputs.
-        x = rand_strided((4, 32, 64), (0, 64, 1), dtype=torch.bfloat16, device=GPU_TYPE)
-        y = rand_strided(
-            (4, 64, 16), (1024, 16, 1), dtype=torch.bfloat16, device=GPU_TYPE
-        )
-        inp = torch.randn(4, 32, 16, dtype=torch.bfloat16, device=GPU_TYPE)
-
-        @torch.compile(mode="max-autotune")
-        def f(inp, x, y):
-            return torch.baddbmm(inp, x, y)
-
-        ref = torch.baddbmm(inp, x, y)
-        act = f(inp, x, y)
-        torch.testing.assert_close(act, ref, atol=2e-2, rtol=1e-2)
-
     @unittest.skipIf(
         config.triton.native_matmul,
         "native matmul and Triton template both have accuracy fail (2.2%)",

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -76,17 +76,6 @@ aten_baddbmm = ExternKernelChoice(
 )
 
 
-def _has_broadcast_batch_dim(mat1, mat2):
-    """Check if either input has a broadcast batch dimension (stride=0).
-
-    The Triton bmm template can trigger CUDA IMA during autotuning with
-    stride-0 inputs; the aten bmm fallback handles broadcast correctly.
-    """
-    return V.graph.sizevars.statically_known_equals(
-        mat1.get_stride()[0], 0
-    ) or V.graph.sizevars.statically_known_equals(mat2.get_stride()[0], 0)
-
-
 @L.register_lowering(aten.bmm)
 def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
     """
@@ -198,8 +187,7 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
         kwarg_overrides[aten_handler.uid] = aten_extra_kwargs
 
     if use_triton_template(layout, check_max_autotune=False):
-        if not _has_broadcast_batch_dim(mat1, mat2):
-            templates_to_use.append(bmm_template)
+        templates_to_use.append(bmm_template)
 
     # Single unified call for all templates
     choices.extend(
@@ -295,8 +283,7 @@ def tuned_baddbmm(inp, mat1, mat2, *, alpha=1, beta=1, layout=None):
         templates_to_use.append(aten_baddbmm)
 
     if use_triton_template(layout, check_max_autotune=False):
-        if not _has_broadcast_batch_dim(mat1, mat2):
-            templates_to_use.append(bmm_template)
+        templates_to_use.append(bmm_template)
 
     # Single unified call for all templates
     choices.extend(


### PR DESCRIPTION
Summary:

Backout D99497345 as it's causing perf regressions since broadcast bmm is a common scenario. The original change in D99497345 is for fixing IMA issue and now it has been fixed in D103719676.

Test Plan:
sandcastle

local perf test
[P1](https://www.internalfb.com/intern/everpaste/?phabricator_paste_number=2303290247&handle=GDBc4CjcegRQW7xdAHD8k4koSUNWbsIXAAAB) with  D99497345 vs [P2](https://www.internalfb.com/intern/everpaste/?phabricator_paste_number=2303324067&handle=GDhoZCjy3u1kBXEFAJ9JvJ_tL6ZQbsIXAAAB) without D99497345

Reviewed By: kqfu

Differential Revision: D103639296




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo