### PR TITLE
Improved static Type Hints for dataloader

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -616,7 +616,7 @@ class TestDataLoaderUtils(TestCase):
         # not a Dataset subclass, but needs to stay working so add ignore's
         # for type checking with mypy
         dataloader: DataLoader = DataLoader(
-            torch.rand(5, 3, 3, 2),  # type: ignore[arg-type]
+            torch.rand(5, 3, 3, 2),  # type: ignore[arg-type, no-matching-overload]
             batch_size=3,
             num_workers=0,
             drop_last=False,
@@ -626,7 +626,7 @@ class TestDataLoaderUtils(TestCase):
 
     def test_single_drop(self):
         dataloader: DataLoader = DataLoader(
-            torch.rand(5, 3, 3, 2),  # type: ignore[arg-type]
+            torch.rand(5, 3, 3, 2),  # type: ignore[arg-type, no-matching-overload]
             batch_size=3,
             num_workers=0,
             drop_last=True,
@@ -639,7 +639,7 @@ class TestDataLoaderUtils(TestCase):
     )
     def test_multi_keep(self):
         dataloader: DataLoader = DataLoader(
-            torch.rand(5, 3, 3, 2),  # type: ignore[arg-type]
+            torch.rand(5, 3, 3, 2),  # type: ignore[arg-type, no-matching-overload]
             batch_size=3,
             num_workers=2,
             drop_last=False,
@@ -650,7 +650,7 @@ class TestDataLoaderUtils(TestCase):
 
     def test_multi_drop(self):
         dataloader: DataLoader = DataLoader(
-            torch.rand(5, 3, 3, 2),  # type: ignore[arg-type]
+            torch.rand(5, 3, 3, 2),  # type: ignore[arg-type, no-matching-overload]
             batch_size=3,
             num_workers=2,
             drop_last=True,

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -18,7 +18,7 @@ import queue
 import threading
 import warnings
 from collections.abc import Callable
-from typing import Any, Generic, NoReturn, TYPE_CHECKING, TypeVar
+from typing import Any, Generic, NoReturn, TYPE_CHECKING, TypeVar, overload
 from typing_extensions import Self
 
 import torch
@@ -54,12 +54,14 @@ __all__ = [
 
 _T = TypeVar("_T")
 _T_co = TypeVar("_T_co", covariant=True)
-_worker_init_fn_t = Callable[[int], None]
 
-# Ideally we would parameterize `DataLoader` by the return type of `collate_fn`, but there is currently no way to have that
-# type parameter set to a default value if the user doesn't pass in a custom 'collate_fn'.
-# See https://github.com/python/mypy/issues/3737.
-_collate_fn_t = Callable[[list[_T]], Any]
+
+# An additional covariant TypeVariable that is only used as the datatype returned by the collator
+# Since dataloaders need two covariant types to be properly defined (dataset sample & training batch),
+#  a second typevar had to be defined.
+_T_Collated_co = TypeVar("_T_Collated_co", covariant=True)
+_worker_init_fn_t = Callable[[int], None]
+_collate_fn_t = Callable[[list[_T]], _T_Collated_co]
 
 
 # These functions used to be defined in this file. However, it was moved to
@@ -139,7 +141,7 @@ def _share_dist_seed(generator, pg):
     return _shared_seed.item()
 
 
-class DataLoader(Generic[_T_co]):
+class DataLoader(Generic[_T_co, _T_Collated_co]):
     r"""
     Data loader combines a dataset and a sampler, and provides an iterable over the given dataset.
 
@@ -242,9 +244,18 @@ class DataLoader(Generic[_T_co]):
     sampler: Sampler | Iterable
     pin_memory_device: str
     prefetch_factor: int | None
-    _iterator: _BaseDataLoaderIter | None
+    _iterator: _BaseDataLoaderIter[_T_Collated_co] | None
     __initialized = False
 
+    # __init__ is defined with two extras:
+    # - The first one is the specific case where the user provides `collate_fn`, in which case we can determine its _T_Collated_co
+    # - The second one is the "default" case where nothing is provided.
+    #
+    # As proposed initially in https://github.com/pytorch/pytorch/issues/179707, one could define more overloads for the __init__ with the default cases,
+    #  depending on known common dataset types, but that would make this file unreadable. If the need arises, a dataloader.pyi would be more suitable,
+    #  as it would not worsen the logic's maintenance.
+
+    @overload  # collate_fn provided
     def __init__(
         self,
         dataset: Dataset[_T_co],
@@ -253,7 +264,55 @@ class DataLoader(Generic[_T_co]):
         sampler: Sampler | Iterable | None = None,
         batch_sampler: Sampler[list] | Iterable[list] | None = None,
         num_workers: int = 0,
-        collate_fn: _collate_fn_t | None = None,
+        collate_fn: _collate_fn_t[_T_co, _T_Collated_co] = ...,
+        pin_memory: bool = False,
+        drop_last: bool = False,
+        timeout: float = 0,
+        worker_init_fn: _worker_init_fn_t | None = None,
+        multiprocessing_context=None,
+        generator=None,
+        *,
+        prefetch_factor: int | None = None,
+        persistent_workers: bool = False,
+        pin_memory_device: str = "",
+        in_order: bool = True,
+    ):
+        ...
+
+    @overload  # collate_fn not provided
+    def __init__(
+        self: "DataLoader[_T_co, Any]",
+        dataset: Dataset[_T_co],
+        batch_size: int | None = 1,
+        shuffle: bool | None = None,
+        sampler: Sampler | Iterable | None = None,
+        batch_sampler: Sampler[list] | Iterable[list] | None = None,
+        num_workers: int = 0,
+        collate_fn: None = None,
+        pin_memory: bool = False,
+        drop_last: bool = False,
+        timeout: float = 0,
+        worker_init_fn: _worker_init_fn_t | None = None,
+        multiprocessing_context=None,
+        generator=None,
+        *,
+        prefetch_factor: int | None = None,
+        persistent_workers: bool = False,
+        pin_memory_device: str = "",
+        in_order: bool = True,
+    ):
+        ...
+
+    # implementation
+    def __init__(
+        self,
+        dataset: Dataset[_T_co],
+        batch_size: int | None = 1,
+        shuffle: bool | None = None,
+        sampler: Sampler | Iterable | None = None,
+        batch_sampler: Sampler[list] | Iterable[list] | None = None,
+        num_workers: int = 0,
+        collate_fn: _collate_fn_t[_T_co, _T_Collated_co] | None = None,
         pin_memory: bool = False,
         drop_last: bool = False,
         timeout: float = 0,
@@ -423,7 +482,7 @@ class DataLoader(Generic[_T_co]):
 
         self.check_worker_number_rationality()
 
-    def _get_iterator(self) -> _BaseDataLoaderIter:
+    def _get_iterator(self) -> _BaseDataLoaderIter[_T_Collated_co]:
         if self.num_workers == 0:
             return _SingleProcessDataLoaderIter(self)
         else:
@@ -482,7 +541,7 @@ class DataLoader(Generic[_T_co]):
 
         super().__setattr__(attr, val)
 
-    def __iter__(self) -> _BaseDataLoaderIter:
+    def __iter__(self) -> _BaseDataLoaderIter[_T_Collated_co]:
         # When using a single worker the returned iterator should be
         # created every time to avoid resetting its state
         # However, in the case of a multiple workers iterator
@@ -616,8 +675,8 @@ class DataLoader(Generic[_T_co]):
             )
 
 
-class _BaseDataLoaderIter:
-    def __init__(self, loader: DataLoader) -> None:
+class _BaseDataLoaderIter(Generic[_T_Collated_co]):
+    def __init__(self, loader: DataLoader[Any, _T_Collated_co]) -> None:
         self._dataset = loader.dataset
         self._shared_seed = None
         self._pg = None
@@ -710,7 +769,7 @@ class _BaseDataLoaderIter:
     def _next_data(self) -> NoReturn:
         raise NotImplementedError
 
-    def __next__(self) -> Any:
+    def __next__(self) -> _T_Collated_co:
         with torch.autograd.profiler.record_function(self._profile_name):
             if self._sampler_iter is None:
                 # TODO(https://github.com/pytorch/pytorch/issues/76750)
@@ -747,7 +806,7 @@ class _BaseDataLoaderIter:
         raise NotImplementedError("{} cannot be pickled", self.__class__.__name__)
 
 
-class _SingleProcessDataLoaderIter(_BaseDataLoaderIter):
+class _SingleProcessDataLoaderIter(_BaseDataLoaderIter[_T_Collated_co], Generic[_T_Collated_co]):
     def __init__(self, loader) -> None:
         super().__init__(loader)
         if self._timeout != 0:
@@ -781,7 +840,7 @@ class _SingleProcessDataLoaderIter(_BaseDataLoaderIter):
         return data
 
 
-class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
+class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter[_T_Collated_co], Generic[_T_Collated_co]):
     r"""Iterates once over the DataLoader's dataset, as specified by the sampler."""
 
     # NOTE [ Data Loader Multiprocessing Shutdown Logic ]

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -59,9 +59,11 @@ _T_co = TypeVar("_T_co", covariant=True)
 # An additional covariant TypeVariable that is only used as the datatype returned by the collator
 # Since dataloaders need two covariant types to be properly defined (dataset sample & training batch),
 #  a second typevar had to be defined.
-_T_Collated_co = TypeVar("_T_Collated_co", covariant=True)
+_TCollated = TypeVar("_TCollated", covariant=True)
+# Another covariant type variable that is only used for type-hinting init overloads
+_TSample = TypeVar("_TSample", covariant=True)
 _worker_init_fn_t = Callable[[int], None]
-_collate_fn_t = Callable[[list[_T]], _T_Collated_co]
+_collate_fn_t = Callable[[list[_T]], _TCollated]
 
 
 # These functions used to be defined in this file. However, it was moved to
@@ -141,7 +143,7 @@ def _share_dist_seed(generator, pg):
     return _shared_seed.item()
 
 
-class DataLoader(Generic[_T_co, _T_Collated_co]):
+class DataLoader(Generic[_T_co, _TCollated]):
     r"""
     Data loader combines a dataset and a sampler, and provides an iterable over the given dataset.
 
@@ -244,7 +246,7 @@ class DataLoader(Generic[_T_co, _T_Collated_co]):
     sampler: Sampler | Iterable
     pin_memory_device: str
     prefetch_factor: int | None
-    _iterator: _BaseDataLoaderIter[_T_Collated_co] | None
+    _iterator: _BaseDataLoaderIter[_TCollated] | None
     __initialized = False
 
     # __init__ is defined with two extras:
@@ -255,16 +257,16 @@ class DataLoader(Generic[_T_co, _T_Collated_co]):
     #  depending on known common dataset types, but that would make this file unreadable. If the need arises, a dataloader.pyi would be more suitable,
     #  as it would not worsen the logic's maintenance.
 
-    @overload  # collate_fn provided
+    @overload  # collate_fn not provided
     def __init__(
-        self,
-        dataset: Dataset[_T_co],
+        self: "DataLoader[_TSample, Any]",  # noqa: UP037
+        dataset: Dataset[_TSample],
         batch_size: int | None = 1,
         shuffle: bool | None = None,
         sampler: Sampler | Iterable | None = None,
         batch_sampler: Sampler[list] | Iterable[list] | None = None,
         num_workers: int = 0,
-        collate_fn: _collate_fn_t[_T_co, _T_Collated_co] = ...,
+        collate_fn: None = None,
         pin_memory: bool = False,
         drop_last: bool = False,
         timeout: float = 0,
@@ -278,16 +280,16 @@ class DataLoader(Generic[_T_co, _T_Collated_co]):
         in_order: bool = True,
     ): ...
 
-    @overload  # collate_fn not provided
+    @overload  # collate_fn provided
     def __init__(
-        self: "DataLoader[_T_co, Any]",  # noqa: UP037
+        self,
         dataset: Dataset[_T_co],
         batch_size: int | None = 1,
         shuffle: bool | None = None,
         sampler: Sampler | Iterable | None = None,
         batch_sampler: Sampler[list] | Iterable[list] | None = None,
         num_workers: int = 0,
-        collate_fn: None = None,
+        collate_fn: _collate_fn_t[_T_co, _TCollated] | None = ...,
         pin_memory: bool = False,
         drop_last: bool = False,
         timeout: float = 0,
@@ -310,7 +312,7 @@ class DataLoader(Generic[_T_co, _T_Collated_co]):
         sampler: Sampler | Iterable | None = None,
         batch_sampler: Sampler[list] | Iterable[list] | None = None,
         num_workers: int = 0,
-        collate_fn: _collate_fn_t[_T_co, _T_Collated_co] | None = None,
+        collate_fn: _collate_fn_t[_T_co, _TCollated] | None = None,
         pin_memory: bool = False,
         drop_last: bool = False,
         timeout: float = 0,
@@ -480,7 +482,7 @@ class DataLoader(Generic[_T_co, _T_Collated_co]):
 
         self.check_worker_number_rationality()
 
-    def _get_iterator(self) -> _BaseDataLoaderIter[_T_Collated_co]:
+    def _get_iterator(self) -> _BaseDataLoaderIter[_TCollated]:
         if self.num_workers == 0:
             return _SingleProcessDataLoaderIter(self)
         else:
@@ -539,7 +541,7 @@ class DataLoader(Generic[_T_co, _T_Collated_co]):
 
         super().__setattr__(attr, val)
 
-    def __iter__(self) -> _BaseDataLoaderIter[_T_Collated_co]:
+    def __iter__(self) -> _BaseDataLoaderIter[_TCollated]:
         # When using a single worker the returned iterator should be
         # created every time to avoid resetting its state
         # However, in the case of a multiple workers iterator
@@ -673,8 +675,8 @@ class DataLoader(Generic[_T_co, _T_Collated_co]):
             )
 
 
-class _BaseDataLoaderIter(Generic[_T_Collated_co]):
-    def __init__(self, loader: DataLoader[Any, _T_Collated_co]) -> None:
+class _BaseDataLoaderIter(Generic[_TCollated]):
+    def __init__(self, loader: DataLoader[Any, _TCollated]) -> None:
         self._dataset = loader.dataset
         self._shared_seed = None
         self._pg = None
@@ -767,7 +769,7 @@ class _BaseDataLoaderIter(Generic[_T_Collated_co]):
     def _next_data(self) -> NoReturn:
         raise NotImplementedError
 
-    def __next__(self) -> _T_Collated_co:
+    def __next__(self) -> _TCollated:
         with torch.autograd.profiler.record_function(self._profile_name):
             if self._sampler_iter is None:
                 # TODO(https://github.com/pytorch/pytorch/issues/76750)
@@ -805,7 +807,7 @@ class _BaseDataLoaderIter(Generic[_T_Collated_co]):
 
 
 class _SingleProcessDataLoaderIter(
-    _BaseDataLoaderIter[_T_Collated_co], Generic[_T_Collated_co]
+    _BaseDataLoaderIter[_TCollated], Generic[_TCollated]
 ):
     def __init__(self, loader) -> None:
         super().__init__(loader)
@@ -841,7 +843,7 @@ class _SingleProcessDataLoaderIter(
 
 
 class _MultiProcessingDataLoaderIter(
-    _BaseDataLoaderIter[_T_Collated_co], Generic[_T_Collated_co]
+    _BaseDataLoaderIter[_TCollated], Generic[_TCollated]
 ):
     r"""Iterates once over the DataLoader's dataset, as specified by the sampler."""
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -276,12 +276,11 @@ class DataLoader(Generic[_T_co, _T_Collated_co]):
         persistent_workers: bool = False,
         pin_memory_device: str = "",
         in_order: bool = True,
-    ):
-        ...
+    ): ...
 
     @overload  # collate_fn not provided
     def __init__(
-        self: "DataLoader[_T_co, Any]",
+        self: "DataLoader[_T_co, Any]",  # noqa: UP037
         dataset: Dataset[_T_co],
         batch_size: int | None = 1,
         shuffle: bool | None = None,
@@ -300,8 +299,7 @@ class DataLoader(Generic[_T_co, _T_Collated_co]):
         persistent_workers: bool = False,
         pin_memory_device: str = "",
         in_order: bool = True,
-    ):
-        ...
+    ): ...
 
     # implementation
     def __init__(
@@ -806,7 +804,9 @@ class _BaseDataLoaderIter(Generic[_T_Collated_co]):
         raise NotImplementedError("{} cannot be pickled", self.__class__.__name__)
 
 
-class _SingleProcessDataLoaderIter(_BaseDataLoaderIter[_T_Collated_co], Generic[_T_Collated_co]):
+class _SingleProcessDataLoaderIter(
+    _BaseDataLoaderIter[_T_Collated_co], Generic[_T_Collated_co]
+):
     def __init__(self, loader) -> None:
         super().__init__(loader)
         if self._timeout != 0:
@@ -840,7 +840,9 @@ class _SingleProcessDataLoaderIter(_BaseDataLoaderIter[_T_Collated_co], Generic[
         return data
 
 
-class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter[_T_Collated_co], Generic[_T_Collated_co]):
+class _MultiProcessingDataLoaderIter(
+    _BaseDataLoaderIter[_T_Collated_co], Generic[_T_Collated_co]
+):
     r"""Iterates once over the DataLoader's dataset, as specified by the sampler."""
 
     # NOTE [ Data Loader Multiprocessing Shutdown Logic ]


### PR DESCRIPTION
## General description

* Added a second covariant type var  `_T_Collated_co`
* Added a second typevar to the DataLoader
  * Added two overloads of `DataLoader.__init__` (one with known collate_fn, one without)
  * Annotated the Iterators as yielding the `_T_Collated_co` instance.

This PR is linked to #179707 (_Improve static type hints for dataloader with known `collate_fn`_)

## Further discussions

### Checking with your type-checker that it works

For example, when running

```shell
mypy ./PR.py | grep PR.py
```

on the following file

```python
# PR.py file
from typing import reveal_type
from torch import Tensor, stack, zeros
from torch.utils.data import DataLoader, Dataset


def collate_fn(s: list[Tensor]) -> str:
    return "Hi, this is the collated data"


class MyDataset(Dataset[Tensor]):
    def __len__(self):
        return 1

    def __getitem__(self, index) -> Tensor:
        return zeros((1, 2, 3))


DL1 = DataLoader(MyDataset(), collate_fn=collate_fn)
reveal_type(DL1)  # mypy reveals torch.utils.data.dataloader.DataLoader[torch._tensor.Tensor, builtins.str]
reveal_type(next(iter(DL1)))   # mypy reveals builtins.str
DL2 = DataLoader(MyDataset())
reveal_type(DL2)  # mypy reveals torch.utils.data.dataloader.DataLoader[torch._tensor.Tensor, Any]
reveal_type(next(iter(DL2)))  # mypy reveals Any
```

Mypy complains about DL1 and DL2 not being type-hinted, but is fully able to determine their types.
Anecdotally, PyLance/Pyright was able to do the same in VSCode

### Limitations of the work

The changes made are not documented (I don't know where to document them)

### Further work in the same vein

It would be more readable for maintainers to move the overloads (but **not the inheritance of Generics**) in a `dataloader.pyi` (python type stubs file) instead of keeping it all in the `dataloader.py` (cf discussion with @divyanshk on the source issue).

I have restrained myself to the two basic overloads, but more could be added, especially since `default_collate` is well specified:

For example of what I mean, one could set

```python
# Initial proposal
class DataLoader(Generic[_T_co, _T_co_res]):
    @overload  # with collate_fn provided
    def __init__(self, dataset: Dataset[_T_co], ..., collate_fn: _collate_fn_t[_T_co, _T_co_res] = ..., ...): ...

    # Improvement: when the collator is not provided, and the dataset yields Tensor, indicate to the user what the yielded type will be
    @overload
    def __init__(self: "DataLoader[Tensor, Tensor]", dataset: Dataset[Tensor], ..., collate_fn: None = None, ...): ...
    @overload
    def __init__(self: "DataLoader[float, Tensor]", dataset: Dataset[float], ..., collate_fn: None = None, ...): ...
    @overload
    def __init__(self: "DataLoader[int, Tensor]", dataset: Dataset[int], ..., collate_fn: None = None, ...): ...
    @overload
    def __init__(self: "DataLoader[str, list[str]]", dataset: Dataset[str], ..., collate_fn: None = None, ...): ...
    @overload
    def __init__(self: "DataLoader[str, list[bytes]]", dataset: Dataset[bytes], ..., collate_fn: None = None, ...): ...
    @overload
    def __init__(self: "DataLoader[Mapping[K, Tensor], Mapping[K, Tensor]]", dataset: Mapping[K, Tensor], ..., collate_fn: None = None, ...): ...
    @overload
    def __init__(self: "DataLoader[Sequence[Tensor], Sequence[Tensor]]", dataset: Sequence[Tensor], ..., collate_fn: None = None, ...): ...
    # More overloads could be added based on common use-cases

    # The rest of the initial proposal
    @overload  # default
    def __init__(self: "DataLoader[_T_co, Any]", ..., collate_fn: _collate_fn_t[_T_co, Any] | None = None, ...): ...
```

but that should probably be its own PR