### PR TITLE
Compute .ci/docker tree hash to runner_determinator

### DIFF
--- a/.github/workflows/_runner-determinator.yml
+++ b/.github/workflows/_runner-determinator.yml
@@ -59,6 +59,9 @@ on:
       use-arc:
         description: Whether to use ARC runners
         value: ${{ jobs.runner-determinator.outputs.use-arc }}
+      ci-docker-hash:
+        description: "Git tree hash of .ci/docker, used as the suffix of CI docker image tags"
+        value: ${{ jobs.runner-determinator.outputs.ci-docker-hash }}
 
 jobs:
   runner-determinator:
@@ -71,6 +74,7 @@ jobs:
       runner-type: ${{ steps.set-runner-info.outputs.runner-type }}
       runner-label: ${{ steps.set-runner-info.outputs.runner-label }}
       use-arc: ${{ steps.set-condition.outputs.use-arc }}
+      ci-docker-hash: ${{ steps.ci-docker-hash.outputs.ci-docker-hash }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_NUMBER: ${{ inputs.issue_number }}
@@ -83,9 +87,18 @@ jobs:
       - name: Checkout PyTorch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
           sparse-checkout: |
             .github/scripts/runner_determinator.py
+            .ci/docker
+          sparse-checkout-cone-mode: false
+
+      - name: Compute .ci/docker tree hash
+        id: ci-docker-hash
+        shell: bash
+        run: |
+          echo "ci-docker-hash=$(git rev-parse HEAD:.ci/docker)" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: python3 -m pip install urllib3==1.26.18 PyGithub==2.3.0

--- a/.github/workflows/job-filter.yml
+++ b/.github/workflows/job-filter.yml
@@ -33,12 +33,16 @@ on:
       jobs:
         description: "Space-padded job filter string"
         value: ${{ jobs.compute.outputs.jobs }}
+      ci-docker-hash:
+        description: "Git tree hash of .ci/docker, used as the suffix of CI docker image tags"
+        value: ${{ jobs.compute.outputs.ci-docker-hash }}
 
 jobs:
   compute:
     runs-on: ubuntu-latest
     outputs:
       jobs: ${{ steps.set.outputs.jobs }}
+      ci-docker-hash: ${{ steps.ci-docker-hash.outputs.ci-docker-hash }}
     steps:
       - id: set
         env:
@@ -65,3 +69,19 @@ jobs:
           else
             echo "jobs=" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Checkout .ci/docker
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+          sparse-checkout: .ci/docker
+          sparse-checkout-cone-mode: false
+          submodules: false
+          show-progress: false
+
+      - name: Compute .ci/docker tree hash
+        id: ci-docker-hash
+        shell: bash
+        run: |
+          echo "ci-docker-hash=$(git rev-parse HEAD:.ci/docker)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/job-filter.yml
+++ b/.github/workflows/job-filter.yml
@@ -33,16 +33,12 @@ on:
       jobs:
         description: "Space-padded job filter string"
         value: ${{ jobs.compute.outputs.jobs }}
-      ci-docker-hash:
-        description: "Git tree hash of .ci/docker, used as the suffix of CI docker image tags"
-        value: ${{ jobs.compute.outputs.ci-docker-hash }}
 
 jobs:
   compute:
     runs-on: ubuntu-latest
     outputs:
       jobs: ${{ steps.set.outputs.jobs }}
-      ci-docker-hash: ${{ steps.ci-docker-hash.outputs.ci-docker-hash }}
     steps:
       - id: set
         env:
@@ -69,19 +65,3 @@ jobs:
           else
             echo "jobs=" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Checkout .ci/docker
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 1
-          sparse-checkout: .ci/docker
-          sparse-checkout-cone-mode: false
-          submodules: false
-          show-progress: false
-
-      - name: Compute .ci/docker tree hash
-        id: ci-docker-hash
-        shell: bash
-        run: |
-          echo "ci-docker-hash=$(git rev-parse HEAD:.ci/docker)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.12.0) (oldest at bottom):
* #182894
* #182843
* __->__ #182579

Adds a `ci-docker-hash` output to the runner-determinator reusable workflow, computed once via `git rev-parse HEAD:.ci/docker`.
This is a prep no-op: no callers consume the output yet. 
The intent is to pass a versioned docker image tag to ARC-hosted jobs so they can use the same versioned images as their non-ARC counterparts

Test plan: https://github.com/pytorch/pytorch/pull/182894 - sparse checkout is still 1 sec, computed hash looks reasonable, need to merge the change first to understand if it'll pick them up

Authored by Claude.