### PR TITLE
[FSDP] Cast forward inputs during AC recompute

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -691,12 +691,33 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
 
     @skip_if_lt_x_gpu(1)
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
-    def test_checkpoint_recompute_casts_forward_inputs_and_outputs(self):
-        class Model(nn.Module):
+    def test_checkpoint_recompute_casts_forward_inputs(self):
+        self._test_checkpoint_recompute_casts(
+            recompute_cast="input",
+        )
+
+    @skip_if_lt_x_gpu(1)
+    @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
+    def test_checkpoint_recompute_casts_outputs(self):
+        self._test_checkpoint_recompute_casts(
+            recompute_cast="output",
+        )
+
+    def _test_checkpoint_recompute_casts(self, recompute_cast: str):
+        class RecordingLinear(nn.Linear):
             def __init__(self) -> None:
+                super().__init__(1, 1)
+                self.input_dtypes: list[torch.dtype] = []
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                self.input_dtypes.append(x.dtype)
+                return super().forward(x)
+
+        class Model(nn.Module):
+            def __init__(self, checkpoint_input_dtype: torch.dtype) -> None:
                 super().__init__()
-                self.linear1 = nn.Linear(1, 1)
-                self.linear2 = nn.Linear(1, 1)
+                self.linear1 = RecordingLinear()
+                self.checkpoint_input_dtype = checkpoint_input_dtype
                 self.linear1_output_dtypes: list[torch.dtype] = []
 
             def checkpointed_linear1(self, x: torch.Tensor) -> torch.Tensor:
@@ -705,29 +726,49 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
                 return x
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
-                x = x.float()
+                x = x.to(dtype=self.checkpoint_input_dtype)
                 x = checkpoint(
                     self.checkpointed_linear1,
                     x,
                     use_reentrant=False,
                     early_stop=False,
                 )
-                return self.linear2(x).sum()
+                return x.float().sum()
+
+        if recompute_cast == "input":
+            checkpoint_input_dtype = torch.float32
+            mp_policy = MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.bfloat16,
+            )
+        elif recompute_cast == "output":
+            checkpoint_input_dtype = torch.bfloat16
+            mp_policy = MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.bfloat16,
+                output_dtype=torch.float32,
+                cast_forward_inputs=False,
+            )
+        else:
+            raise AssertionError(f"Unknown recompute_cast: {recompute_cast}")
 
         torch.manual_seed(42)
-        model = Model().to(device_type)
-        mp_policy = MixedPrecisionPolicy(
-            param_dtype=torch.bfloat16,
-            reduce_dtype=torch.bfloat16,
-            output_dtype=torch.float32,
-        )
+        model = Model(checkpoint_input_dtype).to(device_type)
         fully_shard(model.linear1, mp_policy=mp_policy)
-        fully_shard(model.linear2, mp_policy=mp_policy)
         fully_shard(model, mp_policy=mp_policy)
 
         inp = torch.randn(8, 1, device=device_type.type)
         model(inp).backward()
-        self.assertEqual(model.linear1_output_dtypes, [torch.float32, torch.float32])
+        if recompute_cast == "input":
+            self.assertEqual(
+                model.linear1.input_dtypes,
+                [torch.bfloat16, torch.bfloat16],
+            )
+        else:
+            self.assertEqual(
+                model.linear1_output_dtypes,
+                [torch.float32, torch.float32],
+            )
 
     @skip_if_lt_x_gpu(1)
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")

--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -691,22 +691,35 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
 
     @skip_if_lt_x_gpu(1)
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
-    def test_checkpoint_recompute_casts_forward_inputs(self):
+    def test_checkpoint_recompute_casts_forward_inputs_and_outputs(self):
         class Model(nn.Module):
             def __init__(self) -> None:
                 super().__init__()
                 self.linear1 = nn.Linear(1, 1)
                 self.linear2 = nn.Linear(1, 1)
+                self.linear1_output_dtypes: list[torch.dtype] = []
+
+            def checkpointed_linear1(self, x: torch.Tensor) -> torch.Tensor:
+                x = self.linear1(x)
+                self.linear1_output_dtypes.append(x.dtype)
+                return x
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 x = x.float()
-                x = checkpoint(self.linear1, x, use_reentrant=False)
+                x = checkpoint(
+                    self.checkpointed_linear1,
+                    x,
+                    use_reentrant=False,
+                    early_stop=False,
+                )
                 return self.linear2(x).sum()
 
         torch.manual_seed(42)
         model = Model().to(device_type)
         mp_policy = MixedPrecisionPolicy(
-            param_dtype=torch.bfloat16, reduce_dtype=torch.bfloat16
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.bfloat16,
+            output_dtype=torch.float32,
         )
         fully_shard(model.linear1, mp_policy=mp_policy)
         fully_shard(model.linear2, mp_policy=mp_policy)
@@ -714,6 +727,7 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
 
         inp = torch.randn(8, 1, device=device_type.type)
         model(inp).backward()
+        self.assertEqual(model.linear1_output_dtypes, [torch.float32, torch.float32])
 
     @skip_if_lt_x_gpu(1)
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")

--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -33,6 +33,7 @@ from torch.testing._internal.common_utils import (
     skipIfRocmVersionLessThan,
     TEST_HPU,
 )
+from torch.utils.checkpoint import checkpoint
 
 
 device_type = torch.device(get_devtype())
@@ -687,6 +688,32 @@ class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):
             forward_inputs["l2_input_y"].dtype,
             torch.float16 if enable_submodule_cast else torch.float32,
         )
+
+    @skip_if_lt_x_gpu(1)
+    @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
+    def test_checkpoint_recompute_casts_forward_inputs(self):
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear1 = nn.Linear(1, 1)
+                self.linear2 = nn.Linear(1, 1)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                x = x.float()
+                x = checkpoint(self.linear1, x, use_reentrant=False)
+                return self.linear2(x).sum()
+
+        torch.manual_seed(42)
+        model = Model().to(device_type)
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16, reduce_dtype=torch.bfloat16
+        )
+        fully_shard(model.linear1, mp_policy=mp_policy)
+        fully_shard(model.linear2, mp_policy=mp_policy)
+        fully_shard(model, mp_policy=mp_policy)
+
+        inp = torch.randn(8, 1, device=device_type.type)
+        model(inp).backward()
 
     @skip_if_lt_x_gpu(1)
     @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -310,7 +310,7 @@ class FSDPState(_State):
         # When composing with module-hook-based activation checkpointing, the
         # post-backward hook is responsible for the reshard
         if self._training_state == TrainingState.PRE_BACKWARD:
-            return output
+            return self._cast_output_dtype(output)
         for fsdp_param_group in self._fsdp_param_groups:
             output = fsdp_param_group.post_forward(module, input, output)
         output = self._register_pre_backward_hook(output)

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -285,7 +285,7 @@ class FSDPState(_State):
                 if not fsdp_param_group.is_unsharded:
                     fsdp_param_group.unshard()
                     fsdp_param_group.wait_for_unshard()
-            return args, kwargs
+            return self._cast_forward_inputs(args, kwargs)
         # With grouped ``fully_shard([a, b, ...])`` the pre-hook fires per
         # module (so ``cast_forward_inputs`` and ``fsdp_param_group.pre_forward``
         # run for each). Root setup and forward prefetch are one-shot, gated
@@ -294,15 +294,7 @@ class FSDPState(_State):
         self._training_state = TrainingState.FORWARD
         if state_first_in_pass:
             args, kwargs = self._root_pre_forward(module, args, kwargs)
-        if self._mp_policy.cast_forward_inputs and self._mp_policy.param_dtype:
-            with torch.profiler.record_function("FSDP::cast_forward_inputs"):
-                cast_fn = functools.partial(
-                    _cast_fp_tensor, self._mp_policy.param_dtype
-                )
-                args, kwargs = (
-                    _apply_to_tensors(cast_fn, args),
-                    _apply_to_tensors(cast_fn, kwargs),
-                )
+        args, kwargs = self._cast_forward_inputs(args, kwargs)
         for fsdp_param_group in self._fsdp_param_groups:
             args, kwargs = fsdp_param_group.pre_forward(module, args, kwargs)
         if state_first_in_pass:
@@ -335,6 +327,15 @@ class FSDPState(_State):
                 self._comm_ctx.all_gather_state = None  # free the all-gather result
             self._state_ctx.iter_forward_root = None
         return self._cast_output_dtype(output)
+
+    def _cast_forward_inputs(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        if not (self._mp_policy.cast_forward_inputs and self._mp_policy.param_dtype):
+            return args, kwargs
+        with torch.profiler.record_function("FSDP::cast_forward_inputs"):
+            cast_fn = functools.partial(_cast_fp_tensor, self._mp_policy.param_dtype)
+            return _apply_to_tensors(cast_fn, args), _apply_to_tensors(cast_fn, kwargs)
 
     def _cast_output_dtype(self, output: Any) -> Any:
         if self._mp_policy.output_dtype is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182580

fix https://github.com/pytorch/pytorch/issues/159359

Summary:
Apply FSDP mixed precision input casting in the PRE_BACKWARD path used by activation checkpoint recomputation. This keeps recomputed tensor metadata consistent with the original forward when cast_forward_inputs is enabled.

Co-authored-by: ShaoDingBao <119856501+ShaoDingBao@users.noreply.github.com>