### PR TITLE
[OSDC] Migrate dtensor.yml to OSDC (ARC) via dial-up pattern

### DIFF
--- a/.github/workflows/dtensor.yml
+++ b/.github/workflows/dtensor.yml
@@ -30,6 +30,7 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+      check_experiments: arc,lf
 
   dtensor-build:
     name: dtensor-build
@@ -44,6 +45,10 @@ jobs:
         { include: [
           { config: "dtensor", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.12xlarge.nvidia.gpu" },
         ]}
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   dtensor-test:
@@ -57,4 +62,8 @@ jobs:
         { include: [
           { config: "dtensor", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.12xlarge.nvidia.gpu" },
         ]}
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit

--- a/.github/workflows/dtensor.yml
+++ b/.github/workflows/dtensor.yml
@@ -58,10 +58,7 @@ jobs:
     with:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11
       docker-image: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
-      test-matrix: |
-        { include: [
-          { config: "dtensor", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g5.12xlarge.nvidia.gpu" },
-        ]}
+      test-matrix: ${{ needs.dtensor-build.outputs.test-matrix }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/dtensor.yml
+++ b/.github/workflows/dtensor.yml
@@ -60,7 +60,7 @@ jobs:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11
       docker-image: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
       test-matrix: ${{ needs.dtensor-build.outputs.test-matrix }}
-      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix-osdc }}
+      test-matrix-osdc: ${{ needs.dtensor-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/dtensor.yml
+++ b/.github/workflows/dtensor.yml
@@ -60,6 +60,7 @@ jobs:
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11
       docker-image: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
       test-matrix: ${{ needs.dtensor-build.outputs.test-matrix }}
+      test-matrix-osdc: ${{ needs.linux-jammy-py3_10-clang18-build.outputs.test-matrix-osdc }}
       use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
       python-version: "3.10"
       compiler: gcc11

--- a/.github/workflows/dtensor.yml
+++ b/.github/workflows/dtensor.yml
@@ -40,6 +40,7 @@ jobs:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       cuda-arch-list: '7.5 8.6 8.9'
       test-matrix: |
         { include: [


### PR DESCRIPTION
## Summary

Phase 2 OSDC migration warmup. Applies the [`migrate-workflow-ec2-to-osdc`](https://github.com/pytorch/test-infra/blob/main/.claude/skills/migrate-workflow-ec2-to-osdc/SKILL.md) skill to `dtensor.yml` so the workflow can ramp onto OSDC (ARC) runners via the runner determinator, in dial-up mode.

## Changes

- Add `check_experiments: arc,lf` to the `get-label-type` runner-determinator call.
- Plumb `use-arc`, `python-version`, `compiler`, `cuda-version` through to both `_linux-build.yml` and `_linux-test.yml` so the `build-osdc` / `test-osdc` paths activate when the determinator returns `use-arc=true`.
- Values read off the existing `docker-image-name` `pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11` → python 3.10 / gcc11 / cuda 13.0.

`dtensor-test` already had `needs: [get-label-type, dtensor-build]`, so no `needs:` change. There was no `aws-role-to-assume` to drop.

## Reference

Same dial-up shape as #181544 (B200 smoke), the skill's worked example.

Tracking: companion to #181544, #181799 (slow.yml ✅), #181802 (nightly.yml docs ✅), #180537 (trunk).

## Behavior

Dial-up: this is a no-op while the `arc` experiment is opted-out for `pytorch-auto-revert[bot]` / `pytorchmergebot` and not rolled out by default. When the determinator opts a user/run into `arc`, the OSDC build/test jobs run instead of the EC2 ones.

## Test plan

- [ ] CI on this PR runs the dtensor workflow (auto-triggered by `paths: .github/workflows/dtensor.yml`) and shows the `dtensor-build` / `dtensor-test` jobs green on the EC2 path (default, `use-arc=false`).
- [ ] Manually opt the triggering actor into `arc` via test-infra#5132 and re-run / push a `ciflow/dtensor/<sha>` tag to verify the `build-osdc` / `test-osdc` jobs activate. (Will do in a follow-up after green on the default path.)
- [ ] Verify `lint` is green (no GHA syntax / yamllint regressions).

## Why draft

End-to-end skill-validation pass — first PR Ivan / iz2 are running through the OSDC migration recipe. Holding as draft until CI confirms the workflow still parses + runs unchanged on the EC2 path.

Authored with Claude.