### PR TITLE
Add addmm quantization graph passes for PT2 readiness benchmarks (#182582)

### DIFF
--- a/torch/nativert/graph/passes/pass_manager/GraphPasses.cpp
+++ b/torch/nativert/graph/passes/pass_manager/GraphPasses.cpp
@@ -58,6 +58,92 @@ void register_base_passes() {
         return rewriter.run(graph);
       });
 
+  // Addmm variants: PT2 export decomposes nn.Linear into aten.t + aten.addmm
+  // instead of aten.linear, so the Linear* passes above don't match.
+  GraphPassRegistry::add_pass(
+      "AddmmDynamicFp16UnpackedWeight", [](Graph* graph) {
+        std::string p = R"(
+    graph(%i, %w, %b):
+    %wt = torch.ops.aten.t.default(self=%w)
+    %out_0 = torch.ops.aten.addmm.default(self=%b, mat1=%i, mat2=%wt)
+    return (%out_0))";
+
+        std::string p_new = R"(
+    graph(%i, %w, %b):
+    %pw = torch.ops.quantized.linear_prepack_fp16.default(W=%w, B=%b)
+    %out_0 = torch.ops.quantized.linear_dynamic_fp16.default(X=%i, W_prepack=%pw)
+    return (%out_0))";
+
+        SubgraphRewriter rewriter("AddmmDynamicFp16UnpackedWeight");
+        rewriter.registerRewritePattern(p, p_new);
+        return rewriter.run(graph);
+      });
+
+  GraphPassRegistry::add_pass(
+      "AddmmReluDynamicFp16UnpackedWeight", [](Graph* graph) {
+        std::string p = R"(
+    graph(%i, %w, %b):
+    %wt = torch.ops.aten.t.default(self=%w)
+    %out_0 = torch.ops.aten.addmm.default(self=%b, mat1=%i, mat2=%wt)
+    %out_1 = torch.ops.aten.relu.default(self=%out_0)
+    return (%out_1))";
+
+        std::string p_new = R"(
+    graph(%i, %w, %b):
+    %pw = torch.ops.quantized.linear_prepack_fp16.default(W=%w, B=%b)
+    %out_0 = torch.ops.quantized.linear_relu_dynamic_fp16.default(X=%i, W_prepack=%pw)
+    return (%out_0))";
+
+        SubgraphRewriter rewriter("AddmmReluDynamicFp16UnpackedWeight");
+        rewriter.registerRewritePattern(p, p_new);
+        return rewriter.run(graph);
+      });
+
+  // Folded addmm variants: When export-time constant folding folds aten.t
+  // into the weight, the graph has bare aten.addmm without a preceding aten.t.
+  // The Addmm* passes above won't match. These passes handle that case by
+  // inserting aten.t in the replacement to un-transpose the weight before
+  // prepack. Both aten.t and linear_prepack_fp16 are const-foldable, so they
+  // run once at init, not per-inference.
+  GraphPassRegistry::add_pass(
+      "AddmmFoldedDynamicFp16UnpackedWeight", [](Graph* graph) {
+        std::string p = R"(
+    graph(%i, %w, %b):
+    %out_0 = torch.ops.aten.addmm.default(self=%b, mat1=%i, mat2=%w)
+    return (%out_0))";
+
+        std::string p_new = R"(
+    graph(%i, %w, %b):
+    %w_orig = torch.ops.aten.t.default(self=%w)
+    %pw = torch.ops.quantized.linear_prepack_fp16.default(W=%w_orig, B=%b)
+    %out_0 = torch.ops.quantized.linear_dynamic_fp16.default(X=%i, W_prepack=%pw)
+    return (%out_0))";
+
+        SubgraphRewriter rewriter("AddmmFoldedDynamicFp16UnpackedWeight");
+        rewriter.registerRewritePattern(p, p_new);
+        return rewriter.run(graph);
+      });
+
+  GraphPassRegistry::add_pass(
+      "AddmmFoldedReluDynamicFp16UnpackedWeight", [](Graph* graph) {
+        std::string p = R"(
+    graph(%i, %w, %b):
+    %out_0 = torch.ops.aten.addmm.default(self=%b, mat1=%i, mat2=%w)
+    %out_1 = torch.ops.aten.relu.default(self=%out_0)
+    return (%out_1))";
+
+        std::string p_new = R"(
+    graph(%i, %w, %b):
+    %w_orig = torch.ops.aten.t.default(self=%w)
+    %pw = torch.ops.quantized.linear_prepack_fp16.default(W=%w_orig, B=%b)
+    %out_0 = torch.ops.quantized.linear_relu_dynamic_fp16.default(X=%i, W_prepack=%pw)
+    return (%out_0))";
+
+        SubgraphRewriter rewriter("AddmmFoldedReluDynamicFp16UnpackedWeight");
+        rewriter.registerRewritePattern(p, p_new);
+        return rewriter.run(graph);
+      });
+
   GraphPassRegistry::add_pass("CleanUpDeadNodes", [](Graph* graph) {
     return graph->cleanupDeadNodes();
   });


### PR DESCRIPTION
Summary:

Add addmm-based quantization passes to the Sigmoid graph pass registry for PT2-exported models.

PT2 export decomposes nn.Linear into aten.t + aten.addmm (or bare aten.addmm when export-time constant folding removes aten.t). The existing Linear* quantization passes only match aten.linear, so they are no-ops on PT2-exported models. These new passes match the addmm patterns and replace them with quantized.linear_dynamic_fp16, closing a major latency gap between sigmoid and static runtime on CPU models.

Four new passes are registered in GraphPasses.cpp (fbcode + xplat):
- AddmmDynamicFp16UnpackedWeight (aten.t + aten.addmm)
- AddmmReluDynamicFp16UnpackedWeight (aten.t + aten.addmm + relu)
- AddmmFoldedDynamicFp16UnpackedWeight (bare aten.addmm, pre-transposed weight)
- AddmmFoldedReluDynamicFp16UnpackedWeight (bare aten.addmm + relu, pre-transposed weight)

These passes are gated behind a new `RuntimeConfigs::enableAddmmQuantizationPasses` flag (default false), separate from the existing `enableQuantizationPasses` flag that controls the Linear* passes. A corresponding gflag `pytorch_predictor_sigmoid_addmm_quantization_passes_enable` is wired through PredictorSigmoidConfigurationUtil for the LNP path. Only the PT2 inference readiness pipeline enables the new flag, so production models are unaffected.

Test Plan:
Unit tests: `buck test fbcode//sigmoid/backend/passes:graph_passes_test` -- 34/34 pass (includes 4 new tests: 2 structural FileCheck + 2 numerical accuracy for the addmm passes).

Full PT2 readiness pipeline across all 5 model suites with custom LNP binary containing the new passes:

193 models tested across 5 suites:
- Quantized numerically correct: 177/193 (91.7%)
- Zero new correctness regressions: every model that fails SIGMOID_QUANTIZED_CORRECT also fails SIGMOID_CORRECT (pre-existing failures unrelated to these passes)
- Latency improved: 103/121 benchmarked models (85.1%)
- Average Sig/SR ratio: 1.69x -> 1.32x (0.36x improvement)
- 8 models where sigmoid now beats static runtime (Sig/SR < 1.0)

Per-suite breakdown:
- DISAGG_CPU_2025: 15 models, 14/15 correct, 12/13 improved
- DISAGG_CPU: 17 models, 17/17 correct, 14/15 improved
- DISAGG_GPU_2025: 13 models, 10/13 correct, 4/6 improved (GPU models, CPU quant has modest impact)
- DSNN: 46 models, 41/46 correct, 40/41 improved
- DEFAULT_PROD: 102 models, 95/102 correct, 33/46 improved

Top improvements (biggest Sig/SR ratio reduction):
- 574605442_513 (DSNN): 3.64x -> 1.27x
- 556493387_14604 (DSNN): 3.05x -> 1.25x
- 501645026_17758 (DSNN): 3.05x -> 1.46x
- 574703401_7509 (DISAGG_CPU): 2.91x -> 1.83x
- 522655924_15821 (DSNN): 2.76x -> 1.36x

18 minor regressions, largest is 0.36x on a single DEFAULT_PROD model; most are <0.05x within benchmark noise.

Differential Revision: D102716364
