### PR TITLE
Skip RST<->MD source conversions in doc-redirects-check

### DIFF
--- a/.github/scripts/check_doc_redirects.py
+++ b/.github/scripts/check_doc_redirects.py
@@ -5,6 +5,10 @@ Check for moved/deleted doc files and optionally auto-update redirects.py.
 This script detects when documentation files in docs/source/ are moved or deleted
 and verifies that corresponding redirects exist in docs/source/redirects.py.
 
+RST <-> MD source conversions (e.g. ``foo.rst`` deleted and ``foo.md`` added with
+the same stem) are treated as no-ops because Sphinx produces the same HTML output
+filename regardless of source extension; no redirect is required.
+
 Usage:
     # Check only (CI mode) - reports missing redirects
     python check_doc_redirects.py --base-ref origin/main
@@ -33,6 +37,14 @@ def get_doc_changes(base_ref: str) -> list[tuple[str, str, str | None]]:
     """
     Get moved/deleted doc files between base_ref and HEAD.
 
+    A delete of ``foo.rst`` paired with an add of ``foo.md`` (or vice versa)
+    is treated as a no-op RST <-> MD source conversion: Sphinx produces the
+    same HTML output filename regardless of source extension, so no redirect
+    is required. Such pairs are filtered out before being returned. This is
+    necessary because git's rename detection (``-M``) defaults to ~50%
+    similarity, and MyST conversions often rewrite enough of the file that
+    git classifies the change as a delete + add rather than a rename.
+
     Returns:
         List of (status, old_path, new_path) tuples.
         For deletions, new_path is None.
@@ -49,7 +61,11 @@ def get_doc_changes(base_ref: str) -> list[tuple[str, str, str | None]]:
         ]
     )
 
-    changes = []
+    renames: list[tuple[str, str, str]] = []
+    deletes: list[tuple[str, str]] = []
+    # Map redirect-key -> added file path, used to detect RST<->MD pairs.
+    adds_by_key: dict[str, str] = {}
+
     for line in diff.split("\n"):
         if not line:
             continue
@@ -58,10 +74,32 @@ def get_doc_changes(base_ref: str) -> list[tuple[str, str, str | None]]:
 
         # Renames: R100 (100% similar), R095 (95% similar), etc.
         if status.startswith("R") and len(parts) >= 3:
-            changes.append((status, parts[1], parts[2]))
+            renames.append((status, parts[1], parts[2]))
         # Deletions
         elif status == "D" and len(parts) >= 2:
-            changes.append((status, parts[1], None))
+            deletes.append((status, parts[1]))
+        # Additions (only used to detect RST<->MD conversion pairs)
+        elif status == "A" and len(parts) >= 2:
+            adds_by_key[path_to_key(parts[1])] = parts[1]
+
+    changes: list[tuple[str, str, str | None]] = list(renames)
+    skipped_pairs = 0
+    for status, old_path in deletes:
+        old_key = path_to_key(old_path)
+        paired_add = adds_by_key.get(old_key)
+        if paired_add is not None and Path(paired_add).suffix != Path(old_path).suffix:
+            # Same stem, opposite extension: this is an RST<->MD conversion.
+            # The published HTML URL is unchanged, so no redirect is needed.
+            skipped_pairs += 1
+            continue
+        changes.append((status, old_path, None))
+
+    if skipped_pairs:
+        plural = "s" if skipped_pairs != 1 else ""
+        print(
+            f"\u2139\ufe0f  Skipped {skipped_pairs} RST<->MD source conversion{plural} "
+            f"(no redirect needed; HTML URL unchanged)"
+        )
 
     return changes
 


### PR DESCRIPTION
## Summary

Fixes a `doc-redirects-check` lint failure that blocks docathon RST→MD conversion PRs.

When a contributor converts `docs/source/foo.rst` to `docs/source/foo.md` using MyST, the conversion typically rewrites enough of the file (RST directives → MyST `{eval-rst}` blocks, role syntax changes, code-fence reformat) that git's default rename detection (`-M`, ~50% similarity threshold) classifies the change as **delete + add** rather than a rename. The script then could not auto-fix it (auto-fix only handles renames) and exited 1 with `❌ Missing redirects detected! • DELETED: <path> (needs manual redirect target)`.

This is a false positive: Sphinx produces the same HTML output filename regardless of source extension (`foo.rst` and `foo.md` both build to `foo.html`), so no redirect is needed.

## Fix

In `get_doc_changes()`, also collect `A` (added) entries from the diff. Before flagging a deletion, check whether an addition with the same stem-key but the opposite extension (`.rst` ↔ `.md`) exists. If yes, drop the pair — it's a no-op source conversion.

## Failing PRs this unblocks

- #182575 (`notes/amp_examples`)
- #182569 (`elastic/quickstart`)
- #182562 (`notes/mkldnn`)
- #182557 (`notes/gradcheck`)
- ...and any future docathon-h1-2026 RST→MD PR with >50% content rewrite.

## Behavior preserved (unchanged)

- Pure renames (`R*`, different stem) → still flagged with auto-fix suggestion.
- Pure deletions (no replacement) → still flagged, manual redirect required.
- Real renames coexisting with RST↔MD pairs → real rename still flagged; pair correctly skipped.
- Different stems with both extensions → not paired (deletion still flagged).
- Existing redirect entries → still respected.
- All exit codes, messaging, and `--auto-fix` behavior identical for non-pair cases.

A small informational line is printed when pairs are skipped:
```
ℹ️  Skipped N RST<->MD source conversion(s) (no redirect needed; HTML URL unchanged)
```

## Test plan

Reproduced the bug and validated the fix with five end-to-end scenarios on a working clone:

1. **D+A pair (the bug)** — `D notes/amp_examples.rst` + `A notes/amp_examples.md` → exit 0, skipped ✅
2. **Pure deletion** — `D notes/amp_examples.rst` only → exit 1, manual redirect needed ✅ (preserved)
3. **Pure rename** — `R100 amp_examples.rst → totally_different_name.rst` → exit 1, auto-fix suggested ✅ (preserved)
4. **Mixed** — pair + unrelated delete → exit 1, only unrelated delete flagged ✅
5. **Reverse direction** — `D cuda.md` + `A cuda.rst` → exit 0, skipped ✅

cc @svekars @AlannaBurke
