### PR TITLE
[AOTI] Add UpdateConstantBufferFromCpu for host to device copy

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -7219,6 +7219,54 @@ class AOTInductorTestsTemplate:
         with self.assertRaises(AssertionError):
             torch.testing.assert_close(new_expected, new_output, atol=1e-3, rtol=1e-3)
 
+    def test_load_constants_allow_h2d_copy(self):
+        # End-to-end check that AOTICompiledModel.load_constants(allow_h2d_copy=True)
+        # accepts a CPU state_dict for a non-CPU model, the way a typical user
+        # would after torch.load(..., map_location="cpu").
+        if self.device != GPU_TYPE or self.device == "mps":
+            raise unittest.SkipTest("requires GPU")
+
+        class Model(torch.nn.Module):
+            def __init__(self, n, k, device):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(n, k, device=device))
+
+            def forward(self, a):
+                return torch.nn.functional.linear(a, self.weight)
+
+        M, N, K = 8, 6, 16
+        model = Model(N, K, self.device)
+        a = torch.randn(M, K, device=self.device)
+        example_inputs = (a,)
+
+        package_path = AOTIRunnerUtil.compile(model, example_inputs)
+        compiled = torch._inductor.aoti_load_package(package_path)
+
+        (weight_fqn,) = compiled.get_constant_fqns()
+        cpu_state_dict = {weight_fqn: torch.randn(N, K, device="cpu")}
+        compiled.load_constants(
+            cpu_state_dict, check_full_update=True, allow_h2d_copy=True
+        )
+
+        test_inputs = torch.randn(M, K, device=self.device)
+        expected = torch.nn.functional.linear(
+            test_inputs, cpu_state_dict[weight_fqn].to(self.device)
+        )
+        self.assertEqual(expected, compiled(test_inputs))
+
+        # Without allow_h2d_copy, the same call must error out.
+        with self.assertRaises(RuntimeError):
+            compiled.load_constants(cpu_state_dict, check_full_update=True)
+
+        # allow_h2d_copy + user_managed must be rejected up-front.
+        with self.assertRaises(RuntimeError):
+            compiled.load_constants(
+                cpu_state_dict,
+                check_full_update=True,
+                user_managed=True,
+                allow_h2d_copy=True,
+            )
+
     def test_cond_share_predicate(self):
         class Model(torch.nn.Module):
             def forward(self, predicate, x):

--- a/torch/_C/_aoti.pyi
+++ b/torch/_C/_aoti.pyi
@@ -79,6 +79,12 @@ class AOTIModelContainerRunnerCuda:
         validate_full_updates: bool,
         user_managed: bool = ...,
     ) -> None: ...
+    def update_constant_buffer_from_cpu(
+        self,
+        tensor_map: dict[str, Tensor],
+        use_inactive: bool,
+        validate_full_updates: bool,
+    ) -> None: ...
     def swap_constant_buffer(self) -> None: ...
     def free_inactive_constant_buffer(self) -> None: ...
 
@@ -107,6 +113,12 @@ class AOTIModelContainerRunnerXpu:
         validate_full_updates: bool,
         user_managed: bool = ...,
     ) -> None: ...
+    def update_constant_buffer_from_cpu(
+        self,
+        tensor_map: dict[str, Tensor],
+        use_inactive: bool,
+        validate_full_updates: bool,
+    ) -> None: ...
     def swap_constant_buffer(self) -> None: ...
     def free_inactive_constant_buffer(self) -> None: ...
 
@@ -125,6 +137,12 @@ class AOTIModelContainerRunnerMps:
         use_inactive: bool,
         validate_full_updates: bool,
         user_managed: bool = ...,
+    ) -> None: ...
+    def update_constant_buffer_from_cpu(
+        self,
+        tensor_map: dict[str, Tensor],
+        use_inactive: bool,
+        validate_full_updates: bool,
     ) -> None: ...
     def swap_constant_buffer(self) -> None: ...
     def free_inactive_constant_buffer(self) -> None: ...
@@ -154,6 +172,7 @@ class AOTIModelPackageLoader:
         use_inactive: bool,
         check_full_update: bool,
         user_managed: bool = ...,
+        allow_h2d_copy: bool = ...,
     ) -> None: ...
     def update_constant_buffer(
         self,

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -286,6 +286,25 @@ AOTIRuntimeError AOTInductorModelContainerUpdateConstantBuffer(
   })
 }
 
+AOTIRuntimeError AOTInductorModelContainerUpdateConstantBufferFromCpu(
+    AOTInductorModelContainerHandle container_handle,
+    AOTInductorConstantMapHandle constant_map_handle,
+    bool use_inactive,
+    bool validate_full_update) {
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  auto input_map = reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(constant_map_handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE({
+    container->update_constant_buffer(
+        *input_map,
+        use_inactive,
+        validate_full_update,
+        /*user_managed=*/false,
+        /*allow_h2d_copy=*/true);
+  })
+}
+
 AOTIRuntimeError AOTInductorModelContainerUpdateInactiveConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle) {

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -91,11 +91,10 @@ std::string create_temp_dir() {
     fs::path temp_dir = fs::temp_directory_path();
     return temp_dir.string();
   } catch (const fs::filesystem_error& e) {
-    throw std::runtime_error(
-        "Failed to get temporary directory: " + std::string(e.what()));
+    TORCH_CHECK(false, "Failed to get temporary directory: ", e.what());
   } catch (...) {
-    throw std::runtime_error(
-        "Unknown error occurred while getting temporary directory");
+    TORCH_CHECK(
+        false, "Unknown error occurred while getting temporary directory");
   }
 #else
   std::string temp_dir = "/tmp/XXXXXX";
@@ -863,7 +862,11 @@ void AOTIModelPackageLoader::load_constants(
     std::unordered_map<std::string, at::Tensor>& constants_map,
     bool use_inactive,
     bool check_full_update,
-    bool user_managed) {
+    bool user_managed,
+    bool allow_h2d_copy) {
+  TORCH_CHECK(
+      !(allow_h2d_copy && user_managed),
+      "load_constants: allow_h2d_copy is not supported with user_managed");
   std::unordered_map<std::string, std::string> constant_name_to_fqn =
       runner_->getConstantNamesToOriginalFQNs();
   std::unordered_map<std::string, std::string> fqn_to_constant_name;
@@ -880,6 +883,10 @@ void AOTIModelPackageLoader::load_constants(
     }
   }
 
+  if (allow_h2d_copy) {
+    return runner_->update_constant_buffer_from_cpu(
+        updated_constants_map, use_inactive, check_full_update);
+  }
   return runner_->update_constant_buffer(
       updated_constants_map, use_inactive, check_full_update, user_managed);
 }

--- a/torch/csrc/inductor/aoti_package/model_package_loader.h
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.h
@@ -29,11 +29,15 @@ class TORCH_API AOTIModelPackageLoader {
       void* stream_handle = nullptr);
 
   std::vector<std::string> get_call_spec();
+  // When allow_h2d_copy is true, CPU tensors in constants_map are silently
+  // copied to the model's device. allow_h2d_copy is incompatible with
+  // user_managed.
   void load_constants(
       std::unordered_map<std::string, at::Tensor>& constants_map,
       bool use_inactive,
       bool check_full_update,
-      bool user_managed = false);
+      bool user_managed = false,
+      bool allow_h2d_copy = false);
   std::vector<std::string> get_constant_fqns();
 
   void update_constant_buffer(

--- a/torch/csrc/inductor/aoti_package/pybind.cpp
+++ b/torch/csrc/inductor/aoti_package/pybind.cpp
@@ -76,7 +76,8 @@ void initAOTIPackageBindings(PyObject* module) {
           py::arg("constants_map"),
           py::arg("use_inactive"),
           py::arg("check_full_update"),
-          py::arg("user_managed") = false)
+          py::arg("user_managed") = false,
+          py::arg("allow_h2d_copy") = false)
       .def(
           "update_constant_buffer",
           &AOTIModelPackageLoaderPybind::update_constant_buffer,

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -100,6 +100,9 @@ consider rebuild your model with the latest AOTInductor.");
       update_user_managed_constant_buffer_func_,
       "AOTInductorModelContainerUpdateUserManagedConstantBuffer")
   TRY_LOAD_SYMBOL(
+      update_constant_buffer_from_cpu_func_,
+      "AOTInductorModelContainerUpdateConstantBufferFromCpu")
+  TRY_LOAD_SYMBOL(
       get_constants_blob_size_func_,
       "AOTInductorModelContainerGetConstantsBlobSize")
   TRY_LOAD_SYMBOL(
@@ -272,6 +275,31 @@ void AOTIModelContainerRunner::update_constant_buffer(
   }
 }
 
+void AOTIModelContainerRunner::update_constant_buffer_from_cpu(
+    const TensorConstantMap& const_map,
+    bool use_inactive,
+    bool check_full_update) {
+  TORCH_CHECK(
+      update_constant_buffer_from_cpu_func_ != nullptr,
+      "No update_constant_buffer_from_cpu in .so! Consider rebuild your model with the latest AOTInductor.");
+  AOTI_RUNTIME_ERROR_CODE_CHECK(update_constant_buffer_from_cpu_func_(
+      container_handle_,
+      (AOTInductorConstantMapHandle)&const_map,
+      use_inactive,
+      check_full_update));
+}
+
+void AOTIModelContainerRunner::update_constant_buffer_from_cpu(
+    std::unordered_map<std::string, at::Tensor>& tensor_map,
+    bool use_inactive,
+    bool check_full_update) {
+  TensorConstantMap const_map;
+  for (auto& [k, v] : tensor_map) {
+    const_map.emplace(k, &v);
+  }
+  update_constant_buffer_from_cpu(const_map, use_inactive, check_full_update);
+}
+
 void AOTIModelContainerRunner::update_constant_buffer_from_blob(
     const std::string& weights_path) {
   uint64_t weights_size;
@@ -291,27 +319,26 @@ void AOTIModelContainerRunner::update_constant_buffer_from_blob(
       NULL);
 
   if (hFile == INVALID_HANDLE_VALUE) {
-    throw std::runtime_error(
-        "Failed to open external weights file: " + weights_path);
+    TORCH_CHECK(false, "Failed to open external weights file: ", weights_path);
   }
 
   // Get actual file size for validation
   LARGE_INTEGER fileSize;
   if (!GetFileSizeEx(hFile, &fileSize)) {
     CloseHandle(hFile);
-    throw std::runtime_error("Failed to get file size");
+    TORCH_CHECK(false, "Failed to get file size");
   }
 
   if (static_cast<uint64_t>(fileSize.QuadPart) < weights_size) {
     CloseHandle(hFile);
-    throw std::runtime_error("File size smaller than expected weights size");
+    TORCH_CHECK(false, "File size smaller than expected weights size");
   }
 
   HANDLE hMapping = CreateFileMapping(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
   CloseHandle(hFile); // Close file handle, keep mapping handle
 
   if (hMapping == NULL) {
-    throw std::runtime_error("CreateFileMapping failed");
+    TORCH_CHECK(false, "CreateFileMapping failed");
   }
 
   uint8_t* ptr = static_cast<uint8_t*>(
@@ -319,7 +346,7 @@ void AOTIModelContainerRunner::update_constant_buffer_from_blob(
 
   if (ptr == NULL) {
     CloseHandle(hMapping);
-    throw std::runtime_error("MapViewOfFile failed");
+    TORCH_CHECK(false, "MapViewOfFile failed");
   }
 
 #else

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -49,6 +49,16 @@ class TORCH_API AOTIModelContainerRunner {
       bool use_inactive,
       bool validate_full_updates,
       bool user_managed = false);
+  // Update constants from CPU tensors. CPU tensors are silently copied to the
+  // model's device.
+  void update_constant_buffer_from_cpu(
+      std::unordered_map<std::string, at::Tensor>& tensor_map,
+      bool use_inactive,
+      bool validate_full_updates);
+  void update_constant_buffer_from_cpu(
+      const TensorConstantMap& const_map,
+      bool use_inactive,
+      bool validate_full_updates);
   void run_const_fold(
       bool use_inactive,
       AOTInductorStreamHandle cuda_stream_handle = nullptr);
@@ -94,6 +104,8 @@ class TORCH_API AOTIModelContainerRunner {
       update_user_managed_constant_buffer_func_{nullptr};
   decltype(&AOTInductorModelContainerUpdateConstantBuffer)
       update_constant_buffer_func_{nullptr};
+  decltype(&AOTInductorModelContainerUpdateConstantBufferFromCpu)
+      update_constant_buffer_from_cpu_func_{nullptr};
   decltype(&AOTInductorModelContainerUpdateInactiveConstantBuffer)
       update_inactive_constant_buffer_func_{nullptr};
   decltype(&AOTInductorModelContainerRunConstantFolding) run_const_fold_func_{

--- a/torch/csrc/inductor/aoti_runner/pybind.cpp
+++ b/torch/csrc/inductor/aoti_runner/pybind.cpp
@@ -97,6 +97,14 @@ void initAOTIRunnerBindings(PyObject* module) {
           py::arg("validate_full_updates"),
           py::arg("user_managed") = false)
       .def(
+          "update_constant_buffer_from_cpu",
+          static_cast<void (AOTIModelContainerRunnerCuda::*)(
+              std::unordered_map<std::string, at::Tensor>&, bool, bool)>(
+              &AOTIModelContainerRunnerCuda::update_constant_buffer_from_cpu),
+          py::arg("tensor_map"),
+          py::arg("use_inactive"),
+          py::arg("validate_full_updates"))
+      .def(
           "swap_constant_buffer",
           &AOTIModelContainerRunnerCuda::swap_constant_buffer)
       .def(
@@ -141,6 +149,14 @@ void initAOTIRunnerBindings(PyObject* module) {
           py::arg("validate_full_updates"),
           py::arg("user_managed") = false)
       .def(
+          "update_constant_buffer_from_cpu",
+          static_cast<void (AOTIModelContainerRunnerXpu::*)(
+              std::unordered_map<std::string, at::Tensor>&, bool, bool)>(
+              &AOTIModelContainerRunnerXpu::update_constant_buffer_from_cpu),
+          py::arg("tensor_map"),
+          py::arg("use_inactive"),
+          py::arg("validate_full_updates"))
+      .def(
           "swap_constant_buffer",
           &AOTIModelContainerRunnerXpu::swap_constant_buffer)
       .def(
@@ -179,6 +195,14 @@ void initAOTIRunnerBindings(PyObject* module) {
           py::arg("use_inactive"),
           py::arg("validate_full_updates"),
           py::arg("user_managed") = false)
+      .def(
+          "update_constant_buffer_from_cpu",
+          static_cast<void (AOTIModelContainerRunnerMps::*)(
+              std::unordered_map<std::string, at::Tensor>&, bool, bool)>(
+              &AOTIModelContainerRunnerMps::update_constant_buffer_from_cpu),
+          py::arg("tensor_map"),
+          py::arg("use_inactive"),
+          py::arg("validate_full_updates"))
       .def(
           "swap_constant_buffer",
           &AOTIModelContainerRunnerMps::swap_constant_buffer)

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -221,6 +221,15 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerUpdateConstantBuffer(
     bool use_inactive,
     bool validate_full_update);
 
+// Same as AOTInductorModelContainerUpdateConstantBuffer, but the caller is
+// allowed to pass CPU tensors even when the model lives on a non-CPU device.
+// CPU tensors are silently copied to the model's device.
+AOTI_API AOTIRuntimeError AOTInductorModelContainerUpdateConstantBufferFromCpu(
+    AOTInductorModelContainerHandle container_handle,
+    AOTInductorConstantMapHandle constant_map_handle,
+    bool use_inactive,
+    bool validate_full_update);
+
 // Setup the inactive constant buffer in model container with provided
 // ConstantMap
 AOTI_API AOTIRuntimeError AOTInductorModelContainerUpdateInactiveConstantBuffer(

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -445,18 +445,28 @@ class AOTInductorModelContainer {
 
   // This function updates the buffer for storing constants.
   // It will update the buffer, the mapping and the array mapping.
+  // When allow_h2d_copy is true, CPU input tensors are silently copied to the
+  // model's device (via the same memcpy path used for same-device copies).
+  // Note: allow_h2d_copy is incompatible with user_managed, since user_managed
+  // mode stores the tensor pointer directly rather than copying.
   void update_constant_buffer(
       const std::unordered_map<std::string, AtenTensorHandle>& constants_map,
       bool use_inactive,
       bool validate_full_update,
-      bool user_managed = false) {
+      bool user_managed = false,
+      bool allow_h2d_copy = false) {
     if (this->num_models() == 0) {
       throw std::runtime_error("No model available in container!");
     }
     if (validate_full_update) {
       assert_all_constants(constants_map);
     }
+    if (allow_h2d_copy && user_managed) {
+      throw std::runtime_error(
+          "update_constant_buffer: allow_h2d_copy is not supported with user_managed");
+    }
 
+    int32_t cpu_device_type = aoti_torch_device_type_cpu();
     auto num_constants = models_[0]->num_constants();
     for (size_t idx = 0; idx < num_constants; idx++) {
       if (models_[0]->constant_from_folded(static_cast<int64_t>(idx))) {
@@ -474,6 +484,15 @@ class AOTInductorModelContainer {
       AOTI_TORCH_ERROR_CODE_CHECK(
           aoti_torch_get_device_type(it->second, &tensor_device_type));
       if (tensor_device_type != expected_const_device_type) {
+#ifndef USE_MPS
+        if (allow_h2d_copy && tensor_device_type == cpu_device_type) {
+          // CPU input -> non-CPU expected device. The main-blob memcpy path
+          // (e.g. cudaMemcpyDefault, SYCL queue.memcpy) handles the
+          // direction. MPS is excluded: aoti_torch_mps_copy_buffer expects
+          // an MTLBuffer source, not a host pointer.
+          continue;
+        }
+#endif
         throw std::runtime_error(
             "update_constant_buffer: constant '" + constant_name +
             "' is on device type " + std::to_string(tensor_device_type) +
@@ -483,7 +502,6 @@ class AOTInductorModelContainer {
     }
 
     int32_t model_device_type = models_[0]->get_device_type();
-    int32_t cpu_device_type = aoti_torch_device_type_cpu();
 
     ConstantState& const_folded = use_inactive == use_secondary_
         ? constant_folded_

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -745,6 +745,7 @@ class AOTICompiledModel:
         *,
         check_full_update: bool,
         user_managed: bool = False,
+        allow_h2d_copy: bool = False,
     ) -> None:
         """
         Given a mapping of constant fqns to tensors, load the constants into the model.
@@ -755,9 +756,14 @@ class AOTICompiledModel:
             constants_map: A mapping of constant fqns to tensors.
             check_full_update: Whether to add check to see if all the constants
             are updated and have values.
+            user_managed: If True, the loader stores the tensor pointers
+            directly; the caller must keep them alive.
+            allow_h2d_copy: If True, CPU tensors are silently copied to the
+            model's device. Useful for loading a CPU ``state_dict()`` into a
+            non-CPU model. Incompatible with ``user_managed``.
         """
         self.loader.load_constants(
-            constants_map, False, check_full_update, user_managed
+            constants_map, False, check_full_update, user_managed, allow_h2d_copy
         )
 
     def get_constant_fqns(self) -> list[str]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182585

Opt-in path that accepts CPU tensors for a non-CPU model and implicitly
does H2C weights copy. Exposed via the runner C ABI, pybind, and
AOTICompiledModel.load_constants(allow_h2d_copy=True).

MPS is excluded since its copy primitive is MTLBuffer-only.

Authored with Claude.

Pull-Request: https://github.com/pytorch/pytorch/pull/181637

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo