### PR TITLE
docs: note backend differences for extremal values

### DIFF
--- a/docs/source/notes/numerical_accuracy.rst
+++ b/docs/source/notes/numerical_accuracy.rst
@@ -52,6 +52,15 @@ datatype. E.g.:
     a.norm() # produces tensor(inf)
     a.double().norm() # produces tensor(1.4142e+20, dtype=torch.float64), representable in fp32
 
+Different backends may use different algorithms, reduction orders, or accumulation
+precision for the same operation. As a result, finite inputs near the limits of a
+dtype may produce finite results on one backend and non-finite results, such as
+``inf`` or ``NaN``, on another backend, such as when moving a computation between
+CPU and CUDA. A value being representable in a dtype does not guarantee that all
+intermediate or output values of an operation will remain finite. For workflows
+that are sensitive to non-finite values, consider normalizing or clamping extremal
+inputs and using :func:`torch.isfinite` to detect them.
+
 .. _Linear Algebra Stability:
 
 Linear algebra (``torch.linalg``)


### PR DESCRIPTION
## Issue

Fixes #178059

## Summary

Adds a note to `docs/source/notes/numerical_accuracy.rst` explaining that finite inputs near dtype limits can produce finite results on one backend and non-finite results on another because backends may use different algorithms, reduction orders, or accumulation precision.

## Testing

- `git diff --check`
- `python .github/scripts/check_doc_redirects.py --base-ref origin/main`
- `lintrunner --data-path /home/tihor/pytorchdocathon/.lintrunner-data docs/source/notes/numerical_accuracy.rst`
- `sphinx-build -b html -j 1 source build/html source/notes/numerical_accuracy.rst`
- Verified generated `docs/build/html/notes/numerical_accuracy.html` contains the rendered note and `torch.isfinite()` link

## Checklist

- [x] Passes lint (`lintrunner`)
- [x] Added/updated tests (focused Sphinx docs build)
- [x] Updated documentation
- [x] Included benchmark results (not applicable; docs-only change)

## Docathon Checklist

- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.

## BC-breaking?

No


cc @svekars @sekyondaMeta @AlannaBurke
