### PR TITLE
docs: clarify interpolate align_corners default

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4815,8 +4815,9 @@ def interpolate(  # noqa: F811
             for out-of-boundary values, making this operation *independent* of input size
             when :attr:`scale_factor` is kept the same. This only has an effect when :attr:`mode`
             is ``'linear'``, ``'bilinear'``, ``'bicubic'`` or ``'trilinear'``.
-            Default: ``None``. When ``None`` and :attr:`mode` is one of the linear modes,
-            it is treated as ``False``.
+            Default: ``None``. ``None`` leaves :attr:`align_corners` unset for modes
+            that do not use it. For modes that use :attr:`align_corners`, ``None``
+            is treated as ``False``.
         recompute_scale_factor (bool, optional): recompute the scale_factor for use in the
             interpolation calculation. If `recompute_scale_factor` is ``True``, then
             `scale_factor` must be passed in and `scale_factor` is used to compute the


### PR DESCRIPTION
## Issue

Fixes #164073

## Summary

Clarifies the `align_corners` default in the `torch.nn.functional.interpolate` docstring by documenting that `None` leaves the option unset for modes that do not use it, while modes that use `align_corners` treat `None` as `False`.

## Testing

- `git diff --check`
- `python .github/scripts/check_doc_redirects.py --base-ref origin/main`
- `python -m py_compile torch/nn/functional.py`
- Source docstring AST inspection for the updated `interpolate` text
- `lintrunner --data-path /home/tihor/pytorchdocathon/.lintrunner-data --skip PYREFLY torch/nn/functional.py`
- `sphinx-build -b html -j 1 source build/html source/generated/torch.nn.functional.interpolate.rst`

## Checklist

- [x] Passes lint (`lintrunner`)
- [x] Added/updated tests (focused source/docstring checks and Sphinx docs build)
- [x] Updated documentation
- [x] Included benchmark results (not applicable; docs-only change)

## Docathon Checklist

- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.

## BC-breaking?

No


cc @svekars @sekyondaMeta @AlannaBurke @albanD @mruberry @jbschlosser @walterddr @mikaylagawarecki
