### PR TITLE
[OSDC] Migrate nightly inductor H100 perf workflow to OSDC via dial-up pattern

### DIFF
--- a/.github/workflows/inductor-perf-test-nightly-h100.yml
+++ b/.github/workflows/inductor-perf-test-nightly-h100.yml
@@ -91,6 +91,7 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+      check_experiments: arc
       opt_out_experiments: lf
 
   build:
@@ -133,12 +134,18 @@ jobs:
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
       build-additional-packages: "vision audio fbgemm torchao"
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   test-periodically:
     name: test-periodically
     uses: ./.github/workflows/_linux-test.yml
-    needs: build
+    needs:
+      - build
+      - get-label-type
     if: github.event.schedule == '15 0 * * 1-6'
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
@@ -152,12 +159,18 @@ jobs:
       monitor-data-collect-interval: 4
       export-profiler-trace: "1"
       enable-torch-trace: "1"
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   test-weekly:
     name: test-weekly
     uses: ./.github/workflows/_linux-test.yml
-    needs: build
+    needs:
+      - build
+      - get-label-type
     if: github.event.schedule == '0 7 * * 0'
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
@@ -171,12 +184,18 @@ jobs:
       monitor-data-collect-interval: 4
       export-profiler-trace: "1"
       enable-torch-trace: "1"
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   test:
     name: test
     uses: ./.github/workflows/_linux-test.yml
-    needs: build
+    needs:
+      - build
+      - get-label-type
     # The pull_request trigger is used in PR to bump transformers pin which always
     # needs one round of benchmark
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
@@ -192,4 +211,8 @@ jobs:
       monitor-data-collect-interval: 4
       export-profiler-trace: "1"
       enable-torch-trace: "1"
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit


### PR DESCRIPTION
Enable OSDC dial-up for inductor-perf-test-nightly-h100.yml by plumbing use-arc, python-version, compiler, and cuda-version inputs through _linux-build.yml / _linux-test.yml, matching the pattern from #182198. The H100 runner labels (linux.aws.h100) are already mapped in .github/arc.yaml, so no infra change is needed. Default behavior is unchanged until the runner-determinator opts a user/branch into the arc experiment; opt_out_experiments: lf is preserved so this perf workflow stays off LF runners.

### Test 

https://github.com/pytorch/pytorch/actions/runs/25525242007/job/74923484007

I see no difference between EC2 runner and OSDC runner on both

- Inference [dashboard](https://hud.pytorch.org/benchmark/v3/dashboard/compiler_inductor?renderGroupId=main&time.start=2026-05-01T00%3A00%3A00.000Z&time.end=2026-05-08T23%3A59%3A59.999Z&filters.repo=pytorch%2Fpytorch&filters.benchmarkName=compiler&filters.mode=inference&filters.dtype=bfloat16&filters.deviceName=cuda+%28h100%29&filters.device=cuda&filters.arch=h100&filters.suite=all&filters.compiler=cudagraphs&lbranch=main&rbranch=osdc-nightly-inductor-h100&rcommit.commit=af3c20ce49f8b417046be71a4715166f7bde344a&rcommit.workflow_id=25525242007&rcommit.date=2026-05-07T23%3A00%3A00Z&rcommit.branch=osdc-nightly-inductor-h100&lcommit.commit=eff85e34b2e5b4fd81f741c7291d9ddc86141392&lcommit.workflow_id=25470122160&lcommit.date=2026-05-07T03%3A00%3A00Z&lcommit.branch=main&maxSampling=110)
- Training [dashboard](https://hud.pytorch.org/benchmark/v3/dashboard/compiler_inductor?renderGroupId=main&time.start=2026-05-01T00%3A00%3A00.000Z&time.end=2026-05-08T23%3A59%3A59.999Z&filters.repo=pytorch%2Fpytorch&filters.benchmarkName=compiler&filters.mode=training&filters.dtype=amp&filters.deviceName=cuda+%28h100%29&filters.device=cuda&filters.arch=h100&filters.suite=all&filters.compiler=cudagraphs&lbranch=main&rbranch=osdc-nightly-inductor-h100&rcommit.commit=af3c20ce49f8b417046be71a4715166f7bde344a&rcommit.workflow_id=25525242007&rcommit.date=2026-05-07T23%3A00%3A00Z&rcommit.branch=osdc-nightly-inductor-h100&lcommit.commit=eff85e34b2e5b4fd81f741c7291d9ddc86141392&lcommit.workflow_id=25470122160&lcommit.date=2026-05-07T03%3A00%3A00Z&lcommit.branch=main&maxSampling=110)

Authored with Claude.