### PR TITLE
[AOTAutograd] Filter assert-only SymBool saves in default partitioner

### DIFF
--- a/test/dynamo/test_aot_autograd.py
+++ b/test/dynamo/test_aot_autograd.py
@@ -1871,6 +1871,39 @@ SeqNr|OrigAten|SrcFn|FwdSrcFn
             loss.backward()
         self.assertIsNotNone(x.grad)
 
+        captured_fw_graphs = []
+
+        def fw_compiler(gm, inputs):
+            captured_fw_graphs.append(gm)
+            return gm
+
+        from functorch.compile import aot_function, default_partition, nop
+
+        x = torch.randn(20, 16, requires_grad=True, device="cuda")
+        compiled_fn = aot_function(
+            fn,
+            fw_compiler=fw_compiler,
+            bw_compiler=nop,
+            partition_fn=default_partition,
+            dynamic=True,
+        )
+        loss = compiled_fn(x, splits_tensor, mask)
+        loss.backward()
+        self.assertEqual(len(captured_fw_graphs), 1)
+        output_node = next(
+            node for node in captured_fw_graphs[0].graph.nodes if node.op == "output"
+        )
+        outputs = output_node.args[0]
+        if not isinstance(outputs, (list, tuple)):
+            outputs = (outputs,)
+        self.assertFalse(
+            any(
+                isinstance(node, torch.fx.Node)
+                and isinstance(node.meta.get("val"), torch.SymBool)
+                for node in outputs
+            )
+        )
+
     def test_batched_matmul_inference_mode(self):
         # Regression test for torch.compile crash with batched matmul in inference_mode
         x = torch.randn(2, 4, 8)

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -167,6 +167,16 @@ def must_recompute(node: fx.Node) -> bool:
     ]
 
 
+def _is_assert_only_symbool(node: fx.Node) -> bool:
+    return (
+        isinstance(node.meta.get("val"), torch.SymBool)
+        and len(node.users) > 0
+        and all(
+            user.target is torch.ops.aten._assert_scalar.default for user in node.users
+        )
+    )
+
+
 def has_recomputable_ops(fx_g: fx.GraphModule) -> bool:
     for node in fx_g.graph.nodes:
         if must_recompute(node):
@@ -1409,6 +1419,12 @@ def default_partition(
 
     saved_values = list(dict.fromkeys(saved_values).keys())
     saved_sym_nodes = list(dict.fromkeys(saved_sym_nodes).keys())
+    # Skip SymBool nodes whose only consumers are _assert_scalar calls.
+    # These are runtime assertion intermediates and are not needed in backward
+    # for any real computation.
+    saved_sym_nodes = [
+        node for node in saved_sym_nodes if not _is_assert_only_symbool(node)
+    ]
     saved_opaque_nodes = list(dict.fromkeys(saved_opaque_nodes).keys())
 
     if config._sync_decision_cross_ranks:
@@ -3781,17 +3797,6 @@ def min_cut_rematerialization_partition(
     # pyrefly: ignore [unbound-name]
     if config._sync_decision_cross_ranks:
         saved_values = _sync_decision_cross_ranks(joint_graph, saved_values)
-
-    # save_for_backward on tensors and stashes symints in autograd .ctx
-    # Skip SymBool nodes whose only consumers are _assert_scalar calls.
-    # These are runtime assertion intermediates and are not needed in backward
-    # for any real computation.
-    def _is_assert_only_symbool(n: fx.Node) -> bool:
-        return (
-            isinstance(n.meta.get("val"), torch.SymBool)
-            and len(n.users) > 0
-            and all(u.target is torch.ops.aten._assert_scalar.default for u in n.users)
-        )
 
     saved_sym_nodes = list(
         filter(


### PR DESCRIPTION
Fixes #182413
Extension of #179315

AOTAutograd's min-cut partitioner already filters SymBool nodes whose only users are aten._assert_scalar, because these are runtime assertion intermediates and not real backward dependencies. default_partition could still save the same assert-only SymBool nodes into the forward/backward saved-symbol ABI. When a nested AOTAutograd function is executed under make_fx/ProxyTensor with unbacked symbols, RuntimeWrapper sees those saved values as torch.SymBool and rejects them.

This change shares the assert-only SymBool predicate between min-cut and default partitioning, and filters default_partition's saved_sym_nodes before extracting the forward/backward graphs.

The issue was reproduced with the standalone repro in #182413 and also in the TorchTitan/AutoParallel nested AOT GraphTrainer path.

Test Plan:
python test/dynamo/test_aot_autograd.py -k test_partitioner_filters_symbool_saved_for_bw
lintrunner --config=.lintrunner.toml torch/_functorch/partitioners.py test/dynamo/test_aot_autograd.py

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98