### PR TITLE
docs: clarify tile dims argument

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -5218,9 +5218,14 @@ In-place version of :meth:`~Tensor.t`
 add_docstr_all(
     "tile",
     r"""
-tile(dims) -> Tensor
+tile(*dims) -> Tensor
 
-See :func:`torch.tile`
+Constructs a tensor by repeating the elements of this tensor.
+
+The :attr:`dims` argument may be specified as a :class:`torch.Size`,
+a tuple or list of integers, or one or more integers.
+
+See :func:`torch.tile` for details.
 """,
 )
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -5108,9 +5108,14 @@ In-place version of :meth:`~Tensor.t`
 add_docstr_all(
     "tile",
     r"""
-tile(dims) -> Tensor
+tile(*dims) -> Tensor
 
-See :func:`torch.tile`
+Constructs a tensor by repeating the elements of this tensor.
+
+The :attr:`dims` argument may be specified as a :class:`torch.Size`,
+a tuple or list of integers, or one or more integers.
+
+See :func:`torch.tile` for details.
 """,
 )
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13367,11 +13367,14 @@ shape (1, 1, 4, 2).
 
 Args:
     input (Tensor): the tensor whose elements to repeat.
-    dims (tuple): the number of repetitions per dimension.
+    dims (torch.Size, int, tuple of int, or list of int): the number of
+        repetitions per dimension.
 
 Example::
 
     >>> x = torch.tensor([1, 2, 3])
+    >>> x.tile(2)
+    tensor([1, 2, 3, 1, 2, 3])
     >>> x.tile((2,))
     tensor([1, 2, 3, 1, 2, 3])
     >>> y = torch.tensor([[1, 2], [3, 4]])

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13788,11 +13788,14 @@ shape (1, 1, 4, 2).
 
 Args:
     input (Tensor): the tensor whose elements to repeat.
-    dims (tuple): the number of repetitions per dimension.
+    dims (torch.Size, int, tuple of int, or list of int): the number of
+        repetitions per dimension.
 
 Example::
 
     >>> x = torch.tensor([1, 2, 3])
+    >>> x.tile(2)
+    tensor([1, 2, 3, 1, 2, 3])
     >>> x.tile((2,))
     tensor([1, 2, 3, 1, 2, 3])
     >>> y = torch.tensor([[1, 2], [3, 4]])


### PR DESCRIPTION
Fixes #129319

## Summary
- Document `torch.tile` `dims` as accepting `torch.Size`, an `int`, a tuple of ints, or a list of ints.
- Expand the `Tensor.tile` docstring beyond the bare cross-reference so the tensor method makes the accepted `dims` forms clear.
- Add an integer `Tensor.tile` example alongside the existing tuple example.

## Test Plan
- `python3 -m py_compile torch/_torch_docs.py torch/_tensor_docs.py`