### PR TITLE
docs: cross-reference sigmoid APIs

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4714,7 +4714,9 @@ add_docstr_all(
     r"""
 sigmoid() -> Tensor
 
-See :func:`torch.sigmoid`
+Equivalent to :func:`torch.sigmoid` applied to this tensor.
+
+See :class:`torch.nn.Sigmoid` for the module form and formula.
 """,
 )
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4604,7 +4604,9 @@ add_docstr_all(
     r"""
 sigmoid() -> Tensor
 
-See :func:`torch.sigmoid`
+Equivalent to :func:`torch.sigmoid` applied to this tensor.
+
+See :class:`torch.nn.Sigmoid` for the module form and formula.
 """,
 )
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -9896,6 +9896,8 @@ add_docstr(
 sigmoid(input, *, out=None) -> Tensor
 
 Alias for :func:`torch.special.expit`.
+
+See :class:`torch.nn.Sigmoid` for the module form and formula.
 """,
 )
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -10214,6 +10214,8 @@ add_docstr(
 sigmoid(input, *, out=None) -> Tensor
 
 Alias for :func:`torch.special.expit`.
+
+See :class:`torch.nn.Sigmoid` for the module form and formula.
 """,
 )
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2304,6 +2304,8 @@ def sigmoid(input):
 
     Applies the element-wise function :math:`\text{Sigmoid}(x) = \frac{1}{1 + \exp(-x)}`
 
+    Equivalent to :func:`torch.sigmoid`.
+
     See :class:`~torch.nn.Sigmoid` for more details.
     """
     return input.sigmoid()

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2352,6 +2352,8 @@ def sigmoid(input):
 
     Applies the element-wise function :math:`\text{Sigmoid}(x) = \frac{1}{1 + \exp(-x)}`
 
+    Equivalent to :func:`torch.sigmoid`.
+
     See :class:`~torch.nn.Sigmoid` for more details.
     """
     return input.sigmoid()

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -337,6 +337,10 @@ class ReLU6(Hardtanh):
 class Sigmoid(Module):
     r"""Applies the Sigmoid function element-wise.
 
+    This function is also available as :func:`torch.sigmoid`,
+    :meth:`torch.Tensor.sigmoid`, :func:`torch.nn.functional.sigmoid`, and
+    :func:`torch.special.expit`.
+
     .. math::
         \text{Sigmoid}(x) = \sigma(x) = \frac{1}{1 + \exp(-x)}
 

--- a/torch/special/__init__.py
+++ b/torch/special/__init__.py
@@ -356,6 +356,9 @@ expit(input, *, out=None) -> Tensor
 
 Computes the expit (also known as the logistic sigmoid function) of the elements of :attr:`input`.
 
+Alias for :func:`torch.sigmoid`. See :class:`torch.nn.Sigmoid` for the
+module form and formula.
+
 .. math::
     \text{out}_{i} = \frac{1}{1 + e^{-\text{input}_{i}}}
 """


### PR DESCRIPTION
Fixes #105318

## Summary
- Make `torch.nn.Sigmoid` the central docstring that names the equivalent sigmoid APIs.
- Link `torch.sigmoid`, `Tensor.sigmoid`, `torch.nn.functional.sigmoid`, and `torch.special.expit` back to the module/formula documentation.
- Keep the wording scoped to documentation cross-references only.

## Test Plan
- `python3 -m py_compile torch/nn/modules/activation.py torch/_torch_docs.py torch/_tensor_docs.py torch/nn/functional.py torch/special/__init__.py`