### PR TITLE
test: strengthen optimizer step hook ordering checks

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2030,7 +2030,7 @@ class TestOptimRenewed(TestCase):
     def test_step_post_hook(self, device, dtype, optim_info):
         def post_hook(opt: Optimizer, args: tuple[Any, ...], kwargs: dict[Any, Any]):
             nonlocal data
-            data += 2
+            data.append("post")
 
         params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
 
@@ -2044,25 +2044,30 @@ class TestOptimRenewed(TestCase):
         )
         for optim_input in all_optim_inputs:
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
-            data = 2
+            data = []
+
+            def mark_step():
+                data.append("step")
+
+            optim._optimizer_step_code = mark_step
             hook_handle = optim.register_step_post_hook(post_hook)
 
             optim.step(closure)
             optim.step(closure)
-            # check if post hooks were registered
-            self.assertEqual(data, 6)
+            # check if post hooks were registered and fired after step
+            self.assertEqual(data, ["step", "post", "step", "post"])
 
             # remove handles, take step and verify that hook is no longer registered
             hook_handle.remove()
 
             optim.step(closure)
-            self.assertEqual(data, 6)
+            self.assertEqual(data, ["step", "post", "step", "post", "step"])
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_step_pre_hook(self, device, dtype, optim_info):
         def pre_hook(opt: Optimizer, args: tuple[Any, ...], kwargs: dict[Any, Any]):
             nonlocal data
-            data += 2
+            data.append("pre")
 
         # Create a random 2D tensor for compatibility with Muon.
         params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
@@ -2077,19 +2082,94 @@ class TestOptimRenewed(TestCase):
         )
         for optim_input in all_optim_inputs:
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
-            data = 5
+            data = []
+
+            def mark_step():
+                data.append("step")
+
+            optim._optimizer_step_code = mark_step
             hook_handle = optim.register_step_pre_hook(pre_hook)
 
             optim.step(closure)
             optim.step(closure)
-            # check if pre hooks were registered
-            self.assertEqual(data, 9)
+            # check if pre hooks were registered and fired before step
+            self.assertEqual(data, ["pre", "step", "pre", "step"])
 
             # remove handles, take step and verify that hook is no longer registered
             hook_handle.remove()
 
             optim.step(closure)
-            self.assertEqual(data, 9)
+            self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
+
+    @optims(optim_db, dtypes=[torch.float32])
+    def test_global_step_post_hook(self, device, dtype, optim_info):
+        def post_hook(opt: Optimizer, args: tuple[Any, ...], kwargs: dict[Any, Any]):
+            nonlocal data
+            data.append("post")
+
+        params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
+
+        def dummy_closure():
+            return 1
+
+        closure = dummy_closure if optim_info.step_requires_closure else None
+
+        all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
+            device, dtype, optim_info
+        )
+        for optim_input in all_optim_inputs:
+            optim = optim_info.optim_cls(params, **optim_input.kwargs)
+            data = []
+
+            def mark_step():
+                data.append("step")
+
+            optim._optimizer_step_code = mark_step
+            hook_handle = register_optimizer_step_post_hook(post_hook)
+            try:
+                optim.step(closure)
+                optim.step(closure)
+                self.assertEqual(data, ["step", "post", "step", "post"])
+            finally:
+                hook_handle.remove()
+
+            optim.step(closure)
+            self.assertEqual(data, ["step", "post", "step", "post", "step"])
+
+    @optims(optim_db, dtypes=[torch.float32])
+    def test_global_step_pre_hook(self, device, dtype, optim_info):
+        def pre_hook(opt: Optimizer, args: tuple[Any, ...], kwargs: dict[Any, Any]):
+            nonlocal data
+            data.append("pre")
+
+        params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
+
+        def dummy_closure():
+            return 1
+
+        closure = dummy_closure if optim_info.step_requires_closure else None
+
+        all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
+            device, dtype, optim_info
+        )
+        for optim_input in all_optim_inputs:
+            optim = optim_info.optim_cls(params, **optim_input.kwargs)
+            data = []
+
+            def mark_step():
+                data.append("step")
+
+            optim._optimizer_step_code = mark_step
+            hook_handle = register_optimizer_step_pre_hook(pre_hook)
+            try:
+                optim.step(closure)
+                optim.step(closure)
+                self.assertEqual(data, ["pre", "step", "pre", "step"])
+            finally:
+                hook_handle.remove()
+
+            optim.step(closure)
+            self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_step_all_hooks(self, device, dtype, optim_info):
@@ -2132,6 +2212,15 @@ class TestOptimRenewed(TestCase):
             optim2 = SGD(params)
             data = []
 
+            def mark_first_step():
+                data.append("first_step")
+
+            def mark_second_step():
+                data.append("second_step")
+
+            optim._optimizer_step_code = mark_first_step
+            optim2._optimizer_step_code = mark_second_step
+
             # register global hooks to both optimizers
             global_pre_handle = register_optimizer_step_pre_hook(global_pre_hook)
             global_post_handle = register_optimizer_step_post_hook(global_post_hook)
@@ -2142,24 +2231,67 @@ class TestOptimRenewed(TestCase):
             second_pre_handle = optim2.register_step_pre_hook(local_pre_hook)
             second_post_handle = optim2.register_step_post_hook(local_post_hook)
 
-            optim.step(closure)
-            self.assertListEqual(data, [0, 1, 2, 5])
-            optim2.step(closure)
-            self.assertListEqual(data, [0, 1, 2, 5, 0, 1, 2, 5])
-            optim.step(closure)
-            self.assertListEqual(data, [0, 1, 2, 5, 0, 1, 2, 5, 0, 1, 2, 5])
+            try:
+                optim.step(closure)
+                self.assertListEqual(data, [0, 1, "first_step", 2, 5])
+                optim2.step(closure)
+                self.assertListEqual(
+                    data, [0, 1, "first_step", 2, 5, 0, 1, "second_step", 2, 5]
+                )
+                optim.step(closure)
+                self.assertListEqual(
+                    data,
+                    [
+                        0,
+                        1,
+                        "first_step",
+                        2,
+                        5,
+                        0,
+                        1,
+                        "second_step",
+                        2,
+                        5,
+                        0,
+                        1,
+                        "first_step",
+                        2,
+                        5,
+                    ],
+                )
+            finally:
+                # remove all hooks
+                global_pre_handle.remove()
+                global_post_handle.remove()
+                first_pre_handle.remove()
+                first_post_handle.remove()
+                second_pre_handle.remove()
+                second_post_handle.remove()
 
-            # remove all hooks
-            global_pre_handle.remove()
-            global_post_handle.remove()
-            first_pre_handle.remove()
-            first_post_handle.remove()
-            second_pre_handle.remove()
-            second_post_handle.remove()
-
             optim.step(closure)
             optim2.step(closure)
-            self.assertListEqual(data, [0, 1, 2, 5, 0, 1, 2, 5, 0, 1, 2, 5])
+            self.assertListEqual(
+                data,
+                [
+                    0,
+                    1,
+                    "first_step",
+                    2,
+                    5,
+                    0,
+                    1,
+                    "second_step",
+                    2,
+                    5,
+                    0,
+                    1,
+                    "first_step",
+                    2,
+                    5,
+                    "first_step",
+                    "second_step",
+                ],
+            )
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_deepcopy_copies_all_public_attrs(self, device, dtype, optim_info):

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -3,6 +3,7 @@ import functools
 import math
 import tempfile
 import unittest
+from contextlib import ExitStack
 from copy import deepcopy
 from itertools import product
 from typing import Any
@@ -142,6 +143,19 @@ class TestOptimRenewed(TestCase):
     - With grads, we follow suit from the parameters.
         * Grads can also be None, empty, or zero-valued, and this should not disrupt training.
     """
+
+    def _make_mock_step(
+        self, data: list[Any], marker: str | dict[int, str]
+    ) -> Any:
+        def step(optim: Optimizer, closure: Any = None) -> Any:
+            data.append(marker[id(optim)] if isinstance(marker, dict) else marker)
+            if closure is not None:
+                return closure()
+            return None
+
+        mocked_step = Optimizer.profile_hook_step(step)
+        mocked_step.hooked = True  # type: ignore[attr-defined]
+        return mocked_step
 
     @onlyCPU
     @optims(optim_db)
@@ -2046,22 +2060,20 @@ class TestOptimRenewed(TestCase):
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
             data = []
 
-            def mark_step():
-                data.append("step")
+            with patch.object(
+                optim_info.optim_cls, "step", self._make_mock_step(data, "step")
+            ):
+                hook_handle = optim.register_step_post_hook(post_hook)
+                try:
+                    optim.step(closure)
+                    optim.step(closure)
+                    # check if post hooks were registered and fired after step
+                    self.assertEqual(data, ["step", "post", "step", "post"])
+                finally:
+                    hook_handle.remove()
 
-            optim._optimizer_step_code = mark_step
-            hook_handle = optim.register_step_post_hook(post_hook)
-
-            optim.step(closure)
-            optim.step(closure)
-            # check if post hooks were registered and fired after step
-            self.assertEqual(data, ["step", "post", "step", "post"])
-
-            # remove handles, take step and verify that hook is no longer registered
-            hook_handle.remove()
-
-            optim.step(closure)
-            self.assertEqual(data, ["step", "post", "step", "post", "step"])
+                optim.step(closure)
+                self.assertEqual(data, ["step", "post", "step", "post", "step"])
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_step_pre_hook(self, device, dtype, optim_info):
@@ -2084,22 +2096,20 @@ class TestOptimRenewed(TestCase):
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
             data = []
 
-            def mark_step():
-                data.append("step")
+            with patch.object(
+                optim_info.optim_cls, "step", self._make_mock_step(data, "step")
+            ):
+                hook_handle = optim.register_step_pre_hook(pre_hook)
+                try:
+                    optim.step(closure)
+                    optim.step(closure)
+                    # check if pre hooks were registered and fired before step
+                    self.assertEqual(data, ["pre", "step", "pre", "step"])
+                finally:
+                    hook_handle.remove()
 
-            optim._optimizer_step_code = mark_step
-            hook_handle = optim.register_step_pre_hook(pre_hook)
-
-            optim.step(closure)
-            optim.step(closure)
-            # check if pre hooks were registered and fired before step
-            self.assertEqual(data, ["pre", "step", "pre", "step"])
-
-            # remove handles, take step and verify that hook is no longer registered
-            hook_handle.remove()
-
-            optim.step(closure)
-            self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
+                optim.step(closure)
+                self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_global_step_post_hook(self, device, dtype, optim_info):
@@ -2121,20 +2131,19 @@ class TestOptimRenewed(TestCase):
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
             data = []
 
-            def mark_step():
-                data.append("step")
+            with patch.object(
+                optim_info.optim_cls, "step", self._make_mock_step(data, "step")
+            ):
+                hook_handle = register_optimizer_step_post_hook(post_hook)
+                try:
+                    optim.step(closure)
+                    optim.step(closure)
+                    self.assertEqual(data, ["step", "post", "step", "post"])
+                finally:
+                    hook_handle.remove()
 
-            optim._optimizer_step_code = mark_step
-            hook_handle = register_optimizer_step_post_hook(post_hook)
-            try:
                 optim.step(closure)
-                optim.step(closure)
-                self.assertEqual(data, ["step", "post", "step", "post"])
-            finally:
-                hook_handle.remove()
-
-            optim.step(closure)
-            self.assertEqual(data, ["step", "post", "step", "post", "step"])
+                self.assertEqual(data, ["step", "post", "step", "post", "step"])
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_global_step_pre_hook(self, device, dtype, optim_info):
@@ -2156,20 +2165,19 @@ class TestOptimRenewed(TestCase):
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
             data = []
 
-            def mark_step():
-                data.append("step")
+            with patch.object(
+                optim_info.optim_cls, "step", self._make_mock_step(data, "step")
+            ):
+                hook_handle = register_optimizer_step_pre_hook(pre_hook)
+                try:
+                    optim.step(closure)
+                    optim.step(closure)
+                    self.assertEqual(data, ["pre", "step", "pre", "step"])
+                finally:
+                    hook_handle.remove()
 
-            optim._optimizer_step_code = mark_step
-            hook_handle = register_optimizer_step_pre_hook(pre_hook)
-            try:
                 optim.step(closure)
-                optim.step(closure)
-                self.assertEqual(data, ["pre", "step", "pre", "step"])
-            finally:
-                hook_handle.remove()
-
-            optim.step(closure)
-            self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
+                self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_step_all_hooks(self, device, dtype, optim_info):
@@ -2211,34 +2219,66 @@ class TestOptimRenewed(TestCase):
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
             optim2 = SGD(params)
             data = []
+            step_markers = {id(optim): "first_step", id(optim2): "second_step"}
+            mocked_step = self._make_mock_step(data, step_markers)
 
-            def mark_first_step():
-                data.append("first_step")
-
-            def mark_second_step():
-                data.append("second_step")
-
-            optim._optimizer_step_code = mark_first_step
-            optim2._optimizer_step_code = mark_second_step
-
-            # register global hooks to both optimizers
-            global_pre_handle = register_optimizer_step_pre_hook(global_pre_hook)
-            global_post_handle = register_optimizer_step_post_hook(global_post_hook)
-
-            # register local hooks
-            first_pre_handle = optim.register_step_pre_hook(local_pre_hook)
-            first_post_handle = optim.register_step_post_hook(local_post_hook)
-            second_pre_handle = optim2.register_step_pre_hook(local_pre_hook)
-            second_post_handle = optim2.register_step_post_hook(local_post_hook)
-
-            try:
-                optim.step(closure)
-                self.assertListEqual(data, [0, 1, "first_step", 2, 5])
-                optim2.step(closure)
-                self.assertListEqual(
-                    data, [0, 1, "first_step", 2, 5, 0, 1, "second_step", 2, 5]
+            with ExitStack() as stack:
+                stack.enter_context(
+                    patch.object(optim_info.optim_cls, "step", mocked_step)
                 )
+                if optim_info.optim_cls is not SGD:
+                    stack.enter_context(patch.object(SGD, "step", mocked_step))
+
+                # register global hooks to both optimizers
+                global_pre_handle = register_optimizer_step_pre_hook(global_pre_hook)
+                global_post_handle = register_optimizer_step_post_hook(global_post_hook)
+
+                # register local hooks
+                first_pre_handle = optim.register_step_pre_hook(local_pre_hook)
+                first_post_handle = optim.register_step_post_hook(local_post_hook)
+                second_pre_handle = optim2.register_step_pre_hook(local_pre_hook)
+                second_post_handle = optim2.register_step_post_hook(local_post_hook)
+
+                try:
+                    optim.step(closure)
+                    self.assertListEqual(data, [0, 1, "first_step", 2, 5])
+                    optim2.step(closure)
+                    self.assertListEqual(
+                        data,
+                        [0, 1, "first_step", 2, 5, 0, 1, "second_step", 2, 5],
+                    )
+                    optim.step(closure)
+                    self.assertListEqual(
+                        data,
+                        [
+                            0,
+                            1,
+                            "first_step",
+                            2,
+                            5,
+                            0,
+                            1,
+                            "second_step",
+                            2,
+                            5,
+                            0,
+                            1,
+                            "first_step",
+                            2,
+                            5,
+                        ],
+                    )
+                finally:
+                    # remove all hooks
+                    global_pre_handle.remove()
+                    global_post_handle.remove()
+                    first_pre_handle.remove()
+                    first_post_handle.remove()
+                    second_pre_handle.remove()
+                    second_post_handle.remove()
+
                 optim.step(closure)
+                optim2.step(closure)
                 self.assertListEqual(
                     data,
                     [
@@ -2257,41 +2297,10 @@ class TestOptimRenewed(TestCase):
                         "first_step",
                         2,
                         5,
+                        "first_step",
+                        "second_step",
                     ],
                 )
-            finally:
-                # remove all hooks
-                global_pre_handle.remove()
-                global_post_handle.remove()
-                first_pre_handle.remove()
-                first_post_handle.remove()
-                second_pre_handle.remove()
-                second_post_handle.remove()
-
-            optim.step(closure)
-            optim2.step(closure)
-            self.assertListEqual(
-                data,
-                [
-                    0,
-                    1,
-                    "first_step",
-                    2,
-                    5,
-                    0,
-                    1,
-                    "second_step",
-                    2,
-                    5,
-                    0,
-                    1,
-                    "first_step",
-                    2,
-                    5,
-                    "first_step",
-                    "second_step",
-                ],
-            )
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_deepcopy_copies_all_public_attrs(self, device, dtype, optim_info):

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -3,7 +3,6 @@ import functools
 import math
 import tempfile
 import unittest
-from contextlib import ExitStack
 from copy import deepcopy
 from itertools import product
 from typing import Any
@@ -144,18 +143,17 @@ class TestOptimRenewed(TestCase):
         * Grads can also be None, empty, or zero-valued, and this should not disrupt training.
     """
 
-    def _make_mock_step(
-        self, data: list[Any], marker: str | dict[int, str]
-    ) -> Any:
-        def step(optim: Optimizer, closure: Any = None) -> Any:
-            data.append(marker[id(optim)] if isinstance(marker, dict) else marker)
-            if closure is not None:
-                return closure()
-            return None
+    def _make_step_closure(self, data, marker, device, dtype):
+        fired = False
 
-        mocked_step = Optimizer.profile_hook_step(step)
-        mocked_step.hooked = True  # type: ignore[attr-defined]
-        return mocked_step
+        def closure():
+            nonlocal fired
+            if not fired:
+                data.append(marker)
+                fired = True
+            return torch.tensor(0.0, device=device, dtype=dtype)
+
+        return closure
 
     @onlyCPU
     @optims(optim_db)
@@ -2048,11 +2046,6 @@ class TestOptimRenewed(TestCase):
 
         params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
 
-        def dummy_closure():
-            return 1
-
-        closure = dummy_closure if optim_info.step_requires_closure else None
-
         all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
             device, dtype, optim_info
         )
@@ -2060,20 +2053,17 @@ class TestOptimRenewed(TestCase):
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
             data = []
 
-            with patch.object(
-                optim_info.optim_cls, "step", self._make_mock_step(data, "step")
-            ):
-                hook_handle = optim.register_step_post_hook(post_hook)
-                try:
-                    optim.step(closure)
-                    optim.step(closure)
-                    # check if post hooks were registered and fired after step
-                    self.assertEqual(data, ["step", "post", "step", "post"])
-                finally:
-                    hook_handle.remove()
+            hook_handle = optim.register_step_post_hook(post_hook)
+            try:
+                optim.step(self._make_step_closure(data, "step", device, dtype))
+                optim.step(self._make_step_closure(data, "step", device, dtype))
+                # check if post hooks were registered and fired after step
+                self.assertEqual(data, ["step", "post", "step", "post"])
+            finally:
+                hook_handle.remove()
 
-                optim.step(closure)
-                self.assertEqual(data, ["step", "post", "step", "post", "step"])
+            optim.step(self._make_step_closure(data, "step", device, dtype))
+            self.assertEqual(data, ["step", "post", "step", "post", "step"])
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_step_pre_hook(self, device, dtype, optim_info):
@@ -2084,11 +2074,6 @@ class TestOptimRenewed(TestCase):
         # Create a random 2D tensor for compatibility with Muon.
         params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
 
-        def dummy_closure():
-            return 1
-
-        closure = dummy_closure if optim_info.step_requires_closure else None
-
         all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
             device, dtype, optim_info
         )
@@ -2096,20 +2081,17 @@ class TestOptimRenewed(TestCase):
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
             data = []
 
-            with patch.object(
-                optim_info.optim_cls, "step", self._make_mock_step(data, "step")
-            ):
-                hook_handle = optim.register_step_pre_hook(pre_hook)
-                try:
-                    optim.step(closure)
-                    optim.step(closure)
-                    # check if pre hooks were registered and fired before step
-                    self.assertEqual(data, ["pre", "step", "pre", "step"])
-                finally:
-                    hook_handle.remove()
+            hook_handle = optim.register_step_pre_hook(pre_hook)
+            try:
+                optim.step(self._make_step_closure(data, "step", device, dtype))
+                optim.step(self._make_step_closure(data, "step", device, dtype))
+                # check if pre hooks were registered and fired before step
+                self.assertEqual(data, ["pre", "step", "pre", "step"])
+            finally:
+                hook_handle.remove()
 
-                optim.step(closure)
-                self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
+            optim.step(self._make_step_closure(data, "step", device, dtype))
+            self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_global_step_post_hook(self, device, dtype, optim_info):
@@ -2119,11 +2101,6 @@ class TestOptimRenewed(TestCase):
 
         params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
 
-        def dummy_closure():
-            return 1
-
-        closure = dummy_closure if optim_info.step_requires_closure else None
-
         all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
             device, dtype, optim_info
         )
@@ -2131,19 +2108,16 @@ class TestOptimRenewed(TestCase):
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
             data = []
 
-            with patch.object(
-                optim_info.optim_cls, "step", self._make_mock_step(data, "step")
-            ):
-                hook_handle = register_optimizer_step_post_hook(post_hook)
-                try:
-                    optim.step(closure)
-                    optim.step(closure)
-                    self.assertEqual(data, ["step", "post", "step", "post"])
-                finally:
-                    hook_handle.remove()
+            hook_handle = register_optimizer_step_post_hook(post_hook)
+            try:
+                optim.step(self._make_step_closure(data, "step", device, dtype))
+                optim.step(self._make_step_closure(data, "step", device, dtype))
+                self.assertEqual(data, ["step", "post", "step", "post"])
+            finally:
+                hook_handle.remove()
 
-                optim.step(closure)
-                self.assertEqual(data, ["step", "post", "step", "post", "step"])
+            optim.step(self._make_step_closure(data, "step", device, dtype))
+            self.assertEqual(data, ["step", "post", "step", "post", "step"])
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_global_step_pre_hook(self, device, dtype, optim_info):
@@ -2153,11 +2127,6 @@ class TestOptimRenewed(TestCase):
 
         params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
 
-        def dummy_closure():
-            return 1
-
-        closure = dummy_closure if optim_info.step_requires_closure else None
-
         all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
             device, dtype, optim_info
         )
@@ -2165,19 +2134,16 @@ class TestOptimRenewed(TestCase):
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
             data = []
 
-            with patch.object(
-                optim_info.optim_cls, "step", self._make_mock_step(data, "step")
-            ):
-                hook_handle = register_optimizer_step_pre_hook(pre_hook)
-                try:
-                    optim.step(closure)
-                    optim.step(closure)
-                    self.assertEqual(data, ["pre", "step", "pre", "step"])
-                finally:
-                    hook_handle.remove()
+            hook_handle = register_optimizer_step_pre_hook(pre_hook)
+            try:
+                optim.step(self._make_step_closure(data, "step", device, dtype))
+                optim.step(self._make_step_closure(data, "step", device, dtype))
+                self.assertEqual(data, ["pre", "step", "pre", "step"])
+            finally:
+                hook_handle.remove()
 
-                optim.step(closure)
-                self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
+            optim.step(self._make_step_closure(data, "step", device, dtype))
+            self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_step_all_hooks(self, device, dtype, optim_info):
@@ -2207,11 +2173,6 @@ class TestOptimRenewed(TestCase):
 
         params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
 
-        def dummy_closure():
-            return 1
-
-        closure = dummy_closure if optim_info.step_requires_closure else None
-
         all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
             device, dtype, optim_info
         )
@@ -2219,66 +2180,28 @@ class TestOptimRenewed(TestCase):
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
             optim2 = SGD(params)
             data = []
-            step_markers = {id(optim): "first_step", id(optim2): "second_step"}
-            mocked_step = self._make_mock_step(data, step_markers)
 
-            with ExitStack() as stack:
-                stack.enter_context(
-                    patch.object(optim_info.optim_cls, "step", mocked_step)
+            # register global hooks to both optimizers
+            global_pre_handle = register_optimizer_step_pre_hook(global_pre_hook)
+            global_post_handle = register_optimizer_step_post_hook(global_post_hook)
+
+            # register local hooks
+            first_pre_handle = optim.register_step_pre_hook(local_pre_hook)
+            first_post_handle = optim.register_step_post_hook(local_post_hook)
+            second_pre_handle = optim2.register_step_pre_hook(local_pre_hook)
+            second_post_handle = optim2.register_step_post_hook(local_post_hook)
+
+            try:
+                optim.step(self._make_step_closure(data, "first_step", device, dtype))
+                self.assertListEqual(data, [0, 1, "first_step", 2, 5])
+                optim2.step(
+                    self._make_step_closure(data, "second_step", device, dtype)
                 )
-                if optim_info.optim_cls is not SGD:
-                    stack.enter_context(patch.object(SGD, "step", mocked_step))
-
-                # register global hooks to both optimizers
-                global_pre_handle = register_optimizer_step_pre_hook(global_pre_hook)
-                global_post_handle = register_optimizer_step_post_hook(global_post_hook)
-
-                # register local hooks
-                first_pre_handle = optim.register_step_pre_hook(local_pre_hook)
-                first_post_handle = optim.register_step_post_hook(local_post_hook)
-                second_pre_handle = optim2.register_step_pre_hook(local_pre_hook)
-                second_post_handle = optim2.register_step_post_hook(local_post_hook)
-
-                try:
-                    optim.step(closure)
-                    self.assertListEqual(data, [0, 1, "first_step", 2, 5])
-                    optim2.step(closure)
-                    self.assertListEqual(
-                        data,
-                        [0, 1, "first_step", 2, 5, 0, 1, "second_step", 2, 5],
-                    )
-                    optim.step(closure)
-                    self.assertListEqual(
-                        data,
-                        [
-                            0,
-                            1,
-                            "first_step",
-                            2,
-                            5,
-                            0,
-                            1,
-                            "second_step",
-                            2,
-                            5,
-                            0,
-                            1,
-                            "first_step",
-                            2,
-                            5,
-                        ],
-                    )
-                finally:
-                    # remove all hooks
-                    global_pre_handle.remove()
-                    global_post_handle.remove()
-                    first_pre_handle.remove()
-                    first_post_handle.remove()
-                    second_pre_handle.remove()
-                    second_post_handle.remove()
-
-                optim.step(closure)
-                optim2.step(closure)
+                self.assertListEqual(
+                    data,
+                    [0, 1, "first_step", 2, 5, 0, 1, "second_step", 2, 5],
+                )
+                optim.step(self._make_step_closure(data, "first_step", device, dtype))
                 self.assertListEqual(
                     data,
                     [
@@ -2297,10 +2220,41 @@ class TestOptimRenewed(TestCase):
                         "first_step",
                         2,
                         5,
-                        "first_step",
-                        "second_step",
                     ],
                 )
+            finally:
+                # remove all hooks
+                global_pre_handle.remove()
+                global_post_handle.remove()
+                first_pre_handle.remove()
+                first_post_handle.remove()
+                second_pre_handle.remove()
+                second_post_handle.remove()
+
+            optim.step(self._make_step_closure(data, "first_step", device, dtype))
+            optim2.step(self._make_step_closure(data, "second_step", device, dtype))
+            self.assertListEqual(
+                data,
+                [
+                    0,
+                    1,
+                    "first_step",
+                    2,
+                    5,
+                    0,
+                    1,
+                    "second_step",
+                    2,
+                    5,
+                    0,
+                    1,
+                    "first_step",
+                    2,
+                    5,
+                    "first_step",
+                    "second_step",
+                ],
+            )
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_deepcopy_copies_all_public_attrs(self, device, dtype, optim_info):

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -143,7 +143,7 @@ class TestOptimRenewed(TestCase):
         * Grads can also be None, empty, or zero-valued, and this should not disrupt training.
     """
 
-    def _make_step_closure(self, data, marker, device, dtype):
+    def _make_step_closure(self, data, marker):
         fired = False
 
         def closure():
@@ -151,7 +151,7 @@ class TestOptimRenewed(TestCase):
             if not fired:
                 data.append(marker)
                 fired = True
-            return torch.tensor(0.0, device=device, dtype=dtype)
+            return 0.0
 
         return closure
 
@@ -2038,38 +2038,15 @@ class TestOptimRenewed(TestCase):
             self.assertTrue(optim.state["ran_load_state_dict_pre_hook2"])
             self.assertTrue(optim.state["ran_load_state_dict_post_hook"])
 
+    @parametrize("hook_type", ["pre", "post"])
     @optims(optim_db, dtypes=[torch.float32])
-    def test_step_post_hook(self, device, dtype, optim_info):
-        def post_hook(opt: Optimizer, args: tuple[Any, ...], kwargs: dict[Any, Any]):
+    def test_step_hook_order(self, device, dtype, optim_info, hook_type):
+        def hook(opt: Optimizer, args: tuple[Any, ...], kwargs: dict[Any, Any]):
             nonlocal data
-            data.append("post")
+            data.append(hook_type)
 
-        params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
-
-        all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
-            device, dtype, optim_info
-        )
-        for optim_input in all_optim_inputs:
-            optim = optim_info.optim_cls(params, **optim_input.kwargs)
-            data = []
-
-            hook_handle = optim.register_step_post_hook(post_hook)
-            try:
-                optim.step(self._make_step_closure(data, "step", device, dtype))
-                optim.step(self._make_step_closure(data, "step", device, dtype))
-                # check if post hooks were registered and fired after step
-                self.assertEqual(data, ["step", "post", "step", "post"])
-            finally:
-                hook_handle.remove()
-
-            optim.step(self._make_step_closure(data, "step", device, dtype))
-            self.assertEqual(data, ["step", "post", "step", "post", "step"])
-
-    @optims(optim_db, dtypes=[torch.float32])
-    def test_step_pre_hook(self, device, dtype, optim_info):
-        def pre_hook(opt: Optimizer, args: tuple[Any, ...], kwargs: dict[Any, Any]):
-            nonlocal data
-            data.append("pre")
+        def expected(marker):
+            return [hook_type, marker] if hook_type == "pre" else [marker, hook_type]
 
         # Create a random 2D tensor for compatibility with Muon.
         params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
@@ -2081,69 +2058,68 @@ class TestOptimRenewed(TestCase):
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
             data = []
 
-            hook_handle = optim.register_step_pre_hook(pre_hook)
+            register_hook = (
+                optim.register_step_pre_hook
+                if hook_type == "pre"
+                else optim.register_step_post_hook
+            )
+            hook_handle = register_hook(hook)
             try:
-                optim.step(self._make_step_closure(data, "step", device, dtype))
-                optim.step(self._make_step_closure(data, "step", device, dtype))
-                # check if pre hooks were registered and fired before step
-                self.assertEqual(data, ["pre", "step", "pre", "step"])
+                optim.step(self._make_step_closure(data, "step"))
+                optim.step(self._make_step_closure(data, "step"))
+                self.assertEqual(data, expected("step") + expected("step"))
             finally:
                 hook_handle.remove()
 
-            optim.step(self._make_step_closure(data, "step", device, dtype))
-            self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
+            optim.step(self._make_step_closure(data, "step"))
+            self.assertEqual(data, expected("step") + expected("step") + ["step"])
 
+    @parametrize("hook_type", ["pre", "post"])
     @optims(optim_db, dtypes=[torch.float32])
-    def test_global_step_post_hook(self, device, dtype, optim_info):
-        def post_hook(opt: Optimizer, args: tuple[Any, ...], kwargs: dict[Any, Any]):
+    def test_global_step_hook_order(self, device, dtype, optim_info, hook_type):
+        def hook(opt: Optimizer, args: tuple[Any, ...], kwargs: dict[Any, Any]):
             nonlocal data
-            data.append("post")
+            data.append(hook_type)
+
+        def expected(marker):
+            return [hook_type, marker] if hook_type == "pre" else [marker, hook_type]
 
         params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
+        other_params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
 
         all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
             device, dtype, optim_info
         )
         for optim_input in all_optim_inputs:
             optim = optim_info.optim_cls(params, **optim_input.kwargs)
+            other_optim = SGD(other_params)
             data = []
 
-            hook_handle = register_optimizer_step_post_hook(post_hook)
+            register_hook = (
+                register_optimizer_step_pre_hook
+                if hook_type == "pre"
+                else register_optimizer_step_post_hook
+            )
+            hook_handle = register_hook(hook)
             try:
-                optim.step(self._make_step_closure(data, "step", device, dtype))
-                optim.step(self._make_step_closure(data, "step", device, dtype))
-                self.assertEqual(data, ["step", "post", "step", "post"])
+                optim.step(self._make_step_closure(data, "first_step"))
+                self.assertEqual(data, expected("first_step"))
+                other_optim.step(self._make_step_closure(data, "second_step"))
+                self.assertEqual(
+                    data,
+                    expected("first_step") + expected("second_step"),
+                )
             finally:
                 hook_handle.remove()
 
-            optim.step(self._make_step_closure(data, "step", device, dtype))
-            self.assertEqual(data, ["step", "post", "step", "post", "step"])
-
-    @optims(optim_db, dtypes=[torch.float32])
-    def test_global_step_pre_hook(self, device, dtype, optim_info):
-        def pre_hook(opt: Optimizer, args: tuple[Any, ...], kwargs: dict[Any, Any]):
-            nonlocal data
-            data.append("pre")
-
-        params = [torch.tensor([[1, 1]], device=device, dtype=dtype)]
-
-        all_optim_inputs = _get_optim_inputs_including_global_cliquey_kwargs(
-            device, dtype, optim_info
-        )
-        for optim_input in all_optim_inputs:
-            optim = optim_info.optim_cls(params, **optim_input.kwargs)
-            data = []
-
-            hook_handle = register_optimizer_step_pre_hook(pre_hook)
-            try:
-                optim.step(self._make_step_closure(data, "step", device, dtype))
-                optim.step(self._make_step_closure(data, "step", device, dtype))
-                self.assertEqual(data, ["pre", "step", "pre", "step"])
-            finally:
-                hook_handle.remove()
-
-            optim.step(self._make_step_closure(data, "step", device, dtype))
-            self.assertEqual(data, ["pre", "step", "pre", "step", "step"])
+            optim.step(self._make_step_closure(data, "first_step"))
+            other_optim.step(self._make_step_closure(data, "second_step"))
+            self.assertEqual(
+                data,
+                expected("first_step")
+                + expected("second_step")
+                + ["first_step", "second_step"],
+            )
 
     @optims(optim_db, dtypes=[torch.float32])
     def test_step_all_hooks(self, device, dtype, optim_info):
@@ -2192,16 +2168,14 @@ class TestOptimRenewed(TestCase):
             second_post_handle = optim2.register_step_post_hook(local_post_hook)
 
             try:
-                optim.step(self._make_step_closure(data, "first_step", device, dtype))
+                optim.step(self._make_step_closure(data, "first_step"))
                 self.assertListEqual(data, [0, 1, "first_step", 2, 5])
-                optim2.step(
-                    self._make_step_closure(data, "second_step", device, dtype)
-                )
+                optim2.step(self._make_step_closure(data, "second_step"))
                 self.assertListEqual(
                     data,
                     [0, 1, "first_step", 2, 5, 0, 1, "second_step", 2, 5],
                 )
-                optim.step(self._make_step_closure(data, "first_step", device, dtype))
+                optim.step(self._make_step_closure(data, "first_step"))
                 self.assertListEqual(
                     data,
                     [
@@ -2231,8 +2205,8 @@ class TestOptimRenewed(TestCase):
                 second_pre_handle.remove()
                 second_post_handle.remove()
 
-            optim.step(self._make_step_closure(data, "first_step", device, dtype))
-            optim2.step(self._make_step_closure(data, "second_step", device, dtype))
+            optim.step(self._make_step_closure(data, "first_step"))
+            optim2.step(self._make_step_closure(data, "second_step"))
             self.assertListEqual(
                 data,
                 [


### PR DESCRIPTION
Fixes #119300

## Summary
- Strengthen local and global optimizer step pre/post hook tests so they assert hook order around real `step(...)` calls.
- Use closures to mark when the step body runs, without patching optimizer `step` or relying on private profiler-hook internals.
- Parametrize pre/post coverage and make the global-hook test exercise two optimizer instances.

## Test Plan
- `git diff --check` - passed
- `python3 -m py_compile test/test_optim.py` - passed
- `PYTHONPATH=. python3 test/test_optim.py TestOptimRenewed.test_step_hook_order TestOptimRenewed.test_global_step_hook_order TestOptimRenewed.test_step_all_hooks -v` - blocked locally before collection because `typing_extensions` is not installed
- `uv run python test/test_optim.py TestOptimRenewed.test_step_hook_order TestOptimRenewed.test_global_step_hook_order TestOptimRenewed.test_step_all_hooks -v` - blocked locally because this sparse checkout is missing build support files such as `tools.build_pytorch_libs`