### PR TITLE
Fix inconsistent CPU/CUDA casting for fmax/fmin/maximum/minimum with narrower out dtype

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -536,10 +536,42 @@ TORCH_IMPL_FUNC(func_out) (const Tensor& self, const Tensor& other, const Tensor
 CREATE_BINARY_TORCH_IMPL_FUNC(bitwise_and_out, bitwise_and_stub)
 CREATE_BINARY_TORCH_IMPL_FUNC(bitwise_or_out, bitwise_or_stub)
 CREATE_BINARY_TORCH_IMPL_FUNC(bitwise_xor_out, bitwise_xor_stub)
-CREATE_BINARY_TORCH_IMPL_FUNC(maximum_out, maximum_stub)
-CREATE_BINARY_TORCH_IMPL_FUNC(minimum_out, minimum_stub)
-CREATE_BINARY_TORCH_IMPL_FUNC(fmax_out, fmax_stub)
-CREATE_BINARY_TORCH_IMPL_FUNC(fmin_out, fmin_stub)
+// maximum/minimum/fmax/fmin: On non-CPU devices, TensorIterator does not
+// create a temporary output tensor when cast_common_dtype_to_outputs is set
+// and the output dtype differs from the compute (common) dtype. The device
+// kernel's internal dynamic-casting path can produce wrong results because
+// inputs get cast to the narrower output dtype before the comparison.
+// Work around this by computing into a temporary of the correct dtype and
+// copying back when a mismatch is detected on non-CPU devices.
+// See https://github.com/pytorch/pytorch/issues/181805
+#define CREATE_MINMAX_TORCH_IMPL_FUNC(func_out, func_stub)                   \
+TORCH_IMPL_FUNC(func_out)                                                    \
+(const Tensor& self, const Tensor& other, const Tensor& result) {            \
+  if (device_type() != c10::DeviceType::CPU &&                                \
+      result.scalar_type() != this->common_dtype()) {                         \
+    auto tmp = at::empty_like(result,                                         \
+        result.options().dtype(this->common_dtype()));                         \
+    auto iter = at::TensorIteratorConfig()                                    \
+        .set_check_mem_overlap(true)                                          \
+        .allow_cpu_scalars(true)                                              \
+        .promote_inputs_to_common_dtype(true)                                 \
+        .cast_common_dtype_to_outputs(true)                                   \
+        .enforce_safe_casting_to_output(true)                                 \
+        .add_owned_output(tmp)                                                \
+        .add_owned_const_input(self)                                          \
+        .add_owned_const_input(other)                                         \
+        .build();                                                             \
+    func_stub(device_type(), iter);                                           \
+    result.copy_(tmp);                                                        \
+  } else {                                                                    \
+    func_stub(device_type(), *this);                                          \
+  }                                                                           \
+}
+
+CREATE_MINMAX_TORCH_IMPL_FUNC(maximum_out, maximum_stub)
+CREATE_MINMAX_TORCH_IMPL_FUNC(minimum_out, minimum_stub)
+CREATE_MINMAX_TORCH_IMPL_FUNC(fmax_out, fmax_stub)
+CREATE_MINMAX_TORCH_IMPL_FUNC(fmin_out, fmin_stub)
 CREATE_BINARY_TORCH_IMPL_FUNC(fmod_out, fmod_stub)
 CREATE_BINARY_TORCH_IMPL_FUNC(logaddexp_out, logaddexp_stub)
 CREATE_BINARY_TORCH_IMPL_FUNC(logaddexp2_out, logaddexp2_stub)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2396,6 +2396,31 @@ class TestBinaryUfuncs(TestCase):
         expected = torch.where(x < y, tx, ty)
         self.assertEqual(result_tangent, expected)
 
+    def test_maximum_minimum_out_dtype_mismatch(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/181805
+        # When the out tensor has a narrower dtype than the inputs, the result
+        # should be computed in the input dtype first, then cast to the output
+        # dtype. Previously CUDA would cast inputs to the output dtype before
+        # the comparison, producing wrong results.
+        lhs = torch.tensor([100000], dtype=torch.int64, device=device)
+        rhs = torch.tensor([-1], dtype=torch.int64, device=device)
+        out = torch.empty(1, dtype=torch.uint8, device=device)
+
+        # Expected: compute first, then cast
+        # fmax(100000, -1) = 100000; 100000 % 256 = 160
+        torch.fmax(lhs, rhs, out=out)
+        self.assertEqual(out.item(), 160)
+
+        # fmin(100000, -1) = -1; -1 as uint8 = 255
+        torch.fmin(lhs, rhs, out=out)
+        self.assertEqual(out.item(), 255)
+
+        torch.maximum(lhs, rhs, out=out)
+        self.assertEqual(out.item(), 160)
+
+        torch.minimum(lhs, rhs, out=out)
+        self.assertEqual(out.item(), 255)
+
     # TODO: tests like this should be generic
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     @dtypesIfXPU(torch.half, torch.float, torch.double)


### PR DESCRIPTION
## Summary

Fixes #181805.

On non-CPU devices (CUDA, XPU, etc.), `TensorIterator` does not create a temporary output tensor when `cast_common_dtype_to_outputs` is set and the output dtype differs from the compute (common) dtype. The device kernel's internal dynamic-casting path produces wrong results for `fmax`/`fmin`/`maximum`/`minimum` because inputs get cast to the narrower output dtype **before** the comparison rather than after.

For example:
```python
lhs = torch.tensor([100000], dtype=torch.int64, device="cuda")
rhs = torch.tensor([-1], dtype=torch.int64, device="cuda")
out = torch.empty(1, dtype=torch.uint8, device="cuda")
torch.fmax(lhs, rhs, out=out)
# Before fix: tensor([255]) — inputs cast to uint8 first: fmax(160, 255) = 255
# After fix:  tensor([160]) — fmax(100000, -1) = 100000, then cast: 100000 % 256 = 160
```

The fix introduces a `CREATE_MINMAX_TORCH_IMPL_FUNC` macro that detects the dtype mismatch on non-CPU devices, computes into a temporary tensor of the correct (common) dtype, and copies back. On CPU the existing TensorIterator temporary mechanism already handles this correctly.

## Test plan

- Added `test_maximum_minimum_out_dtype_mismatch` regression test in `test/test_binary_ufuncs.py`
- Verified the bug reproduces on RTX 5090 with PyTorch 2.10.0+cu128
- The test covers `torch.fmax`, `torch.fmin`, `torch.maximum`, `torch.minimum` with int64 inputs and uint8 output

cc @ptrblck @eqy

🤖 Generated with [Claude Code](https://claude.ai/claude-code)