### PR TITLE
[inductor][flex] Pass derived sym-int captures through maybe_realize

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -2722,6 +2722,42 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         torch.testing.assert_close(eager_out2, compiled_out2, atol=1e-3, rtol=1e-3)
 
     @supported_platform
+    @skip_on_cpu
+    def test_mask_mod_handles_derived_symint_closure(self, device):
+        dtype = torch.float16
+
+        def run(q, k, v, current_pos):
+            p_plus = current_pos + 1
+
+            def _opaque_mask(b, h, q_idx, kv_idx):
+                return kv_idx <= p_plus
+
+            block_mask = create_block_mask(
+                _opaque_mask,
+                B=None,
+                H=None,
+                Q_LEN=q.size(-2),
+                KV_LEN=k.size(-2),
+                device=device,
+            )
+            return flex_attention(q, k, v, block_mask=block_mask)
+
+        compiled_run = torch.compile(run, fullgraph=True, dynamic=True)
+
+        q = torch.randn(1, 2, 192, 32, device=device, dtype=dtype)
+        k = torch.randn(1, 2, 128, 32, device=device, dtype=dtype)
+        v = torch.randn(1, 2, 128, 32, device=device, dtype=dtype)
+
+        eager_out = run(q, k, v, 5)
+        compiled_out = compiled_run(q, k, v, 5)
+        torch.testing.assert_close(eager_out, compiled_out, atol=1e-3, rtol=1e-3)
+
+        # Exercise a different captured value to ensure derived SymInt captures remain well-formed.
+        eager_out2 = run(q, k, v, 9)
+        compiled_out2 = compiled_run(q, k, v, 9)
+        torch.testing.assert_close(eager_out2, compiled_out2, atol=1e-3, rtol=1e-3)
+
+    @supported_platform
     def test_multiple_score_mod_calls(self, device):
         query = torch.randn((1, 8, 1024, 64), dtype=torch.float32, device=device)
         keys = [

--- a/torch/_inductor/kernel/flex/common.py
+++ b/torch/_inductor/kernel/flex/common.py
@@ -172,9 +172,7 @@ def maybe_realize(args: list[IRNode | None]):
     """Accepts a list of optional IRNodes and returns a list of realized IRNodes"""
     return tree_map(
         lambda x: (
-            realize_inputs(x)
-            if x is not None and not isinstance(x, sympy.Symbol)
-            else x
+            realize_inputs(x) if x is not None and not isinstance(x, sympy.Expr) else x
         ),
         args,
     )

--- a/torch/_inductor/kernel/flex/flex_cpu.py
+++ b/torch/_inductor/kernel/flex/flex_cpu.py
@@ -289,7 +289,7 @@ def lower_cpu(
         input_nodes += [
             value
             for value in kernel_input_name_to_buffer.values()
-            if not isinstance(value, sympy.Symbol)
+            if not isinstance(value, sympy.Expr)
         ]
 
     skip_mask_score = kernel_options.get("SKIP_MASK_SCORE", False)

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -385,10 +385,10 @@ def create_flex_decoding_kernel(*args, **kwargs):
         )
 
     filtered_score_mod_buffers = [
-        buf for buf in score_mod_other_buffers if not isinstance(buf, sympy.Symbol)
+        buf for buf in score_mod_other_buffers if not isinstance(buf, sympy.Expr)
     ]
     filtered_mask_mod_buffers = [
-        buf for buf in mask_mod_other_buffers if not isinstance(buf, sympy.Symbol)
+        buf for buf in mask_mod_other_buffers if not isinstance(buf, sympy.Expr)
     ]
 
     inputs_for_flex_decoding = (


### PR DESCRIPTION
Fixes #182606.

Broaden the `not isinstance(x, sympy.Symbol)` guard in `maybe_realize` (`torch/_inductor/kernel/flex/common.py`) to `sympy.Expr`. This generalizes the existing fix from #157833 to cover derived sym-int captures (`Add`, `Mul`, `Mod`, `Max`, …). See the issue #182606 for the failure mode and root-cause walk.

Apply the same broadening to the two paired `isinstance(buf, sympy.Symbol)` filters in `flex_decoding.py` and `flex_cpu.py` that strip captured symbolic buffers before `autotune_select_algorithm`; without this they would now leak `sympy.Add` / `Mod` / `Max` into the autotune input list under `max_autotune`. The flex_attention prefill path already filters by `isinstance(x, ir.IRNode)`, so it doesn't need a change.

## Test plan

New `test_mask_mod_handles_derived_symint_closure` in `test/inductor/test_flex_attention.py`, modeled after the existing [`test_mask_mod_handles_symint_addition`](https://github.com/pytorch/pytorch/blob/fb43825d22650b037d55f92f695636d4c5accbf8/test/inductor/test_flex_attention.py#L2681).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos