### PR TITLE
Ignore decoding errors when reading CMake cache files (errors='ignore')

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -161,7 +161,7 @@ class CMake:
         Returns:
           dict: A ``dict`` containing the value of cached CMake variables.
         """
-        with open(self._cmake_cache_file) as f:
+        with open(self._cmake_cache_file, encoding='utf-8', errors='ignore') as f:
             return get_cmake_cache_variables_from_file(f)
 
     def generate(

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -161,7 +161,7 @@ class CMake:
         Returns:
           dict: A ``dict`` containing the value of cached CMake variables.
         """
-        with open(self._cmake_cache_file, encoding='utf-8', errors='ignore') as f:
+        with open(self._cmake_cache_file, errors='ignore') as f:
             return get_cmake_cache_variables_from_file(f)
 
     def generate(

--- a/tools/setup_helpers/env.py
+++ b/tools/setup_helpers/env.py
@@ -64,7 +64,7 @@ class BuildType:
             # Found CMakeCache.txt. Use the build type specified in it.
             from .cmake_utils import get_cmake_cache_variables_from_file
 
-            with open(cmake_cache_txt) as f:
+            with open(cmake_cache_txt, encoding='utf-8', errors='ignore') as f:
                 cmake_cache_vars = get_cmake_cache_variables_from_file(f)
             # Normally it is anti-pattern to determine build type from CMAKE_BUILD_TYPE because it is not used for
             # multi-configuration build tools, such as Visual Studio and XCode. But since we always communicate with

--- a/tools/setup_helpers/env.py
+++ b/tools/setup_helpers/env.py
@@ -64,7 +64,7 @@ class BuildType:
             # Found CMakeCache.txt. Use the build type specified in it.
             from .cmake_utils import get_cmake_cache_variables_from_file
 
-            with open(cmake_cache_txt, encoding='utf-8', errors='ignore') as f:
+            with open(cmake_cache_txt, errors='ignore') as f:
                 cmake_cache_vars = get_cmake_cache_variables_from_file(f)
             # Normally it is anti-pattern to determine build type from CMAKE_BUILD_TYPE because it is not used for
             # multi-configuration build tools, such as Visual Studio and XCode. But since we always communicate with


### PR DESCRIPTION
When reading CMakeCache.txt, invalid byte sequences may appear，which cause build error:

```
File "tools/setup_helpers/env.py", line 68, in __init__
      cmake_cache_vars = get_cmake_cache_variables_from_file(f)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "tools/setup_helpers/cmake_utils.py", line 57, in get_cmake_cache_variables_from_file
      for i, line in enumerate(cmake_cache_file, 1):
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "<frozen codecs>", line 322, in decode
  UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe0 in position 6452: invalid continuation byte
  error: subprocess-exited-with-error

```


This PR adds errors='ignore' to the open calls, invalid characters will be silently skipped, allowing the CMake cache variables to be read successfully.