### PR TITLE
[Inductor] Fix AutoHeuristic crash in non-CUDA environments (part 2)

### DIFF
--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -212,22 +212,25 @@ class AutoHeuristicTest(TestCase):
         """pad_mm set to None; with deterministic=True, use_autoheuristic should return True."""
         self.assertTrue(inductor_config.use_autoheuristic("pad_mm"))
 
-    def test_autoheuristic_init_device_capa(self):
-        """AutoHeuristic.__init__ must not crash regardless of CUDA availability."""
+    def test_autoheuristic_init_no_cuda(self):
+        """AutoHeuristic.__init__ must not crash in non-CUDA environments."""
 
         def fallback():
             return "fallback"
 
         context = AHContext()
         context.add_feature("x", 1)
-        ah = AutoHeuristic(fallback, ["a", "b"], None, context, "test_device_capa")
 
-        if torch.cuda.is_available():
-            self.assertEqual(
-                ah.metadata.device_capa, torch.cuda.get_device_capability()
-            )
-        else:
-            self.assertEqual(ah.metadata.device_capa, (0, 0))
+        with (
+            patch("torch.cuda.is_available", return_value=False),
+            patch(
+                "torch._inductor.autoheuristic.autoheuristic.get_gpu_shared_memory",
+                return_value=0,
+            ),
+        ):
+            ah = AutoHeuristic(fallback, ["a", "b"], None, context, "test_no_cuda")
+
+        self.assertEqual(ah.metadata.device_capa, (0, 0))
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/autoheuristic/autoheuristic.py
+++ b/torch/_inductor/autoheuristic/autoheuristic.py
@@ -166,8 +166,10 @@ class AutoHeuristic:
         # we store the collected data per GPU model and learn a heuristic per GPU model
 
         # TODO(AlnisM): just using the device name for now, but the same GPU model can have different names
-        device_name = torch.cuda.get_device_name().replace(" ", "_")
-        return device_name
+        if torch.cuda.is_available():
+            device_name = torch.cuda.get_device_name().replace(" ", "_")
+            return device_name
+        return "non_cuda_device"
 
     def get_default_log_path(self) -> str:
         device_name = self.get_device_identifier()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182614

PR #181745 fixed AutoHeuristic.__init__ crashing on non-CUDA builds by
guarding torch.cuda.get_device_capability() with torch.cuda.is_available().
However, the fix was incomplete: get_device_identifier() also calls
torch.cuda.get_device_name() unconditionally, which crashes the same way.
This second call is reached later in __init__ via get_default_log_path()
and was missed.

The test added in PR #181745 failed to catch this because it only ran on
GPU machines (guarded by `if HAS_GPU: run_tests()`), where
torch.cuda.get_device_name() trivially succeeds. The test verified the
behavior was correct on the machine it ran on, but never simulated the
no-CUDA environment where the crash actually occurs.

This commit:
- Guards get_device_identifier() with torch.cuda.is_available(), falling
  back to "non_cuda_device" when CUDA is absent.
- Replaces the old test with one that mocks torch.cuda.is_available()
  returning False, so the full __init__ code path (including
  get_default_log_path -> get_device_identifier) is exercised under
  simulated non-CUDA conditions regardless of the host machine. This
  ensures the test would have caught the incomplete fix.

Fixes https://github.com/intel/torch-xpu-ops/issues/3455

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo