### PR TITLE
[ROCm] Guard ck_group_gemm on USE_ROCM_CK_GEMM

### DIFF
--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -22,7 +22,7 @@
 #include <ATen/native/cuda/RowwiseScaledMM.h>
 #include <ATen/native/cuda/ScaledGroupMM.h>
 #include <ATen/native/cuda/GroupMM.h>
-#ifdef USE_ROCM
+#if defined(USE_ROCM) && defined(USE_ROCM_CK_GEMM)
 #include <ATen/native/hip/ck_group_gemm.h>
 #endif
 #include <ATen/ceil_div.h>
@@ -711,20 +711,19 @@ std::optional<c10::ScalarType> out_dtype) {
   // On ROCm fast path routes to group_gemm_ck and slow path to _grouped_mm_fallback.
   // Keep use_fast_path as false till ck kernel perf is optimal.
   // To enable CK path, use env variable ROCM_ALLOW_GROUP_GEMM_CK=1.
-  bool use_fast_path = false;
-  // ifdef USE_ROCM_CK_GEMM is required since ROCm systems w/o CK should not call ck path.
-#if defined(USE_ROCM_CK_GEMM)
-  if (at::globalContext().rocmAllowGroupGemmCk() && at::detail::getCUDAHooks().isGPUArch({"gfx942", "gfx950", "gfx90a"})) {
-    use_fast_path = true;
-  }
-#endif //USE_ROCM_CK_GEMM
   const auto out_dtype_ = _resolve_grouped_mm_out_dtype(mat_a, mat_b, out_dtype);
   Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
-  if (use_fast_path) {
+#if defined(USE_ROCM_CK_GEMM)
+  // ifdef USE_ROCM_CK_GEMM is required since ROCm systems w/o CK should not call ck path.
+  // To enable CK path, use env variable ROCM_ALLOW_GROUP_GEMM_CK=1.
+  if (at::globalContext().rocmAllowGroupGemmCk() && at::detail::getCUDAHooks().isGPUArch({"gfx942", "gfx950", "gfx90a"})) {
     at::hip::detail::group_gemm_ck(mat_a, mat_b, offs, bias, out);
   } else {
     _grouped_mm_fallback(mat_a, mat_b, offs, bias, out_dtype, out);
   }
+#else
+  _grouped_mm_fallback(mat_a, mat_b, offs, bias, out_dtype, out);
+#endif //USE_ROCM_CK_GEMM
 #endif //ifndef USE_ROCM
   return out;
 }


### PR DESCRIPTION
On ROCm builds with USE_ROCM_CK_GEMM=OFF, GroupedBlas.cpp still included ck_group_gemm.h and emitted a source-level reference to at::hip::detail::group_gemm_ck(...) inside an always-false `if (use_fast_path)` branch. The Linux/legacy-CMake build path tolerated this (dead-code-elimination hid the unresolved symbol), but the Windows build under enable_language(HIP) in #180485 surfaces it as a linker failure.

Gate the include and the call site uniformly on USE_ROCM_CK_GEMM and replace the bool indirection with explicit `#if defined(USE_ROCM_CK_GEMM)` / `#else`, so the fallback path is the only thing the compiler sees when CK is disabled.

Split out from #180485 per @malfet review.

Authored with Claude Code.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang