### PR TITLE
[ROCm][CI] Fix docker rebuild: explicit pip in conda env, fail-fast install_rocm_drm.sh

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -57,9 +57,13 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   fi
   # Install correct Python version
   # Also ensure sysroot is using a modern GLIBC to match system compilers
+  # NB: pip is no longer pulled in transitively by conda-forge's python
+  # package, so request it explicitly. Without it, `python3 -m pip` in the
+  # env fails and `conda run -n env pip` silently falls back to base.
   as_jenkins conda create -n py_$ANACONDA_PYTHON_VERSION -y\
              ${PYTHON_DEP} \
              ${SYSROOT_DEP} \
+             pip \
              "icu<78"
 
   # Miniforge installer doesn't install sqlite by default

--- a/.ci/docker/common/install_rocm_drm.sh
+++ b/.ci/docker/common/install_rocm_drm.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Script used only in CD pipeline
 
+set -ex
+
 PREFIX="$1"
 
 ###########################


### PR DESCRIPTION
## Summary

The ubuntu-rocm Docker image has stopped rebuilding cleanly. `python3 -m pip install meson ninja` inside `.ci/docker/common/install_rocm_drm.sh` fails with `No module named pip` against the `py_3.12` conda env, and because the script has no `set -e`, the build silently continues to `meson builddir` which fails with `meson: command not found`. This has broken `docker-builds` on `main` since around 2026-05-01 and trips on any PR that touches `.ci/docker/` (which forces a full image rebuild because the directory is content-hashed).

Root cause: conda-forge's `python` package no longer pulls `pip` in transitively. The env is created with just `python=$VER sysroot icu`, so it has no pip. The conda `pip_install` helper happens to silently fall back to `/opt/conda/bin/pip` from the base env, so `requirements-ci.txt` ends up installed in *base* rather than `py_3.12` — masking the problem until the script that calls `python3 -m pip` directly runs.

Two fixes:

1. **`install_conda.sh`**: add `pip` explicitly to the `conda create` line so the env actually has pip. Also fixes the silent base-env-fallback footgun for `conda run -n py_$VER pip install`.
2. **`install_rocm_drm.sh`**: add `set -ex` so a failed prereq install errors out at the real failure point instead of cascading into a confusing `meson: command not found`.

Authored with assistance from Claude.

cc @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang