### PR TITLE
Remove XPU-specific skips in gpu_cpp_wrapper

### DIFF
--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -385,20 +385,6 @@ test_failures_gpu_wrapper = {
     ),
 }
 
-# XPU: complex add decomposition can return NotImplemented in cpp_wrapper path,
-# which currently surfaces as InductorError in test_add_complex4_xpu_gpu_wrapper.
-# Keep this targeted skip to XPU only.
-if device_type == "xpu":
-    test_failures_gpu_wrapper["test_add_complex4_xpu"] = test_torchinductor.TestFailure(
-        ("gpu_wrapper",), is_skip=True
-    )
-    test_failures_gpu_wrapper["test_add_complex_xpu"] = test_torchinductor.TestFailure(
-        ("gpu_wrapper",), is_skip=True
-    )
-    test_failures_gpu_wrapper["test_adding_tensor_offsets_xpu"] = (
-        test_torchinductor.TestFailure(("gpu_wrapper",), is_skip=True)
-    )
-
 # Skip only on CUDA as wrapper dynamic shapes passes on ROCm.
 # Per https://github.com/pytorch/pytorch/pull/172780
 if not torch.version.hip:


### PR DESCRIPTION
This PR is to remove XPU-specific skips for `test_add_complex4_xpu`, `test_add_complex_xpu`, and `test_adding_tensor_offsets_xpu` from the `test_failures_gpu_wrapper`. Fixed by: #178959.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo