### PR TITLE
[Profiler] Forward declare nlohmann::json in public header

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -9,6 +9,7 @@ import shutil
 import string
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import unittest
 import warnings
@@ -65,6 +66,63 @@ class TestCppExtensionJIT(common.TestCase):
     @classmethod
     def tearDownClass(cls):
         torch.testing._internal.common_utils.remove_cpp_extensions_build_root()
+
+    @unittest.skipIf(IS_WINDOWS, "uses POSIX compiler flags")
+    def test_combined_traceback_header_does_not_include_nlohmann(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_include = os.path.join(tmpdir, "include")
+            fake_nlohmann = os.path.join(fake_include, "nlohmann")
+            os.makedirs(fake_nlohmann)
+            with open(os.path.join(fake_nlohmann, "json.hpp"), "w") as f:
+                f.write(
+                    "#error combined_traceback.h should not include "
+                    "nlohmann/json.hpp\n"
+                )
+
+            source = os.path.join(tmpdir, "test.cpp")
+            with open(source, "w") as f:
+                f.write(
+                    "#include <torch/csrc/profiler/python/combined_traceback.h>\n"
+                    "#include <utility>\n"
+                    "#include <vector>\n"
+                    "using JsonFrames = decltype(torch::json_symbolize(\n"
+                    "    std::declval<std::vector<torch::CapturedTraceback*>&>()));\n"
+                    "JsonFrames* frames = nullptr;\n"
+                    "int main() { return frames == nullptr ? 0 : 1; }\n"
+                )
+
+            try:
+                torch_include_paths = torch.utils.cpp_extension.include_paths(
+                    device_type="cpu"
+                )
+            except Exception as e:
+                self.skipTest(f"Could not compute PyTorch include paths: {e}")
+
+            cmd = [
+                get_cxx_compiler(),
+                "-std=c++17",
+                "-fsyntax-only",
+                source,
+                f"-I{fake_include}",
+                *[f"-I{path}" for path in torch_include_paths],
+            ]
+
+            python_include = sysconfig.get_path(
+                "include", scheme="nt" if IS_WINDOWS else "posix_prefix"
+            )
+            if python_include is not None:
+                cmd.append(f"-I{python_include}")
+
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=30
+            )
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"command failed: {' '.join(cmd)}\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}",
+            )
 
     def test_jit_compile_extension(self):
         module = torch.utils.cpp_extension.load(

--- a/torch/csrc/profiler/python/combined_traceback.cpp
+++ b/torch/csrc/profiler/python/combined_traceback.cpp
@@ -4,6 +4,18 @@
 #include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/utils/pythoncapi_compat.h>
+
+#include <nlohmann/json.hpp>
+
+static_assert(
+    NLOHMANN_JSON_VERSION_MAJOR == 3 && NLOHMANN_JSON_VERSION_MINOR == 12 &&
+        NLOHMANN_JSON_VERSION_PATCH == 0 && JSON_DIAGNOSTICS == 0 &&
+        JSON_DIAGNOSTIC_POSITIONS == 0 &&
+        NLOHMANN_JSON_NAMESPACE_NO_VERSION == 0,
+    "Forward declaration in combined_traceback.h hardcodes nlohmann ABI "
+    "namespace json_abi_v3_12_0; update it when bumping the vendored nlohmann "
+    "version or changing nlohmann ABI namespace options.");
+
 namespace py = pybind11;
 
 namespace torch {

--- a/torch/csrc/profiler/python/combined_traceback.h
+++ b/torch/csrc/profiler/python/combined_traceback.h
@@ -1,8 +1,55 @@
+#pragma once
+
 #include <torch/csrc/profiler/combined_traceback.h>
 
-#include <nlohmann/json.hpp>
 #include <pybind11/pybind11.h>
 #include <torch/csrc/utils/pybind.h>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace nlohmann {
+inline namespace json_abi_v3_12_0 {
+
+template <typename T, typename SFINAE>
+struct adl_serializer;
+
+template <
+    template <typename U, typename V, typename... Args> class ObjectType,
+    template <typename U, typename... Args> class ArrayType,
+    class StringType,
+    class BooleanType,
+    class NumberIntegerType,
+    class NumberUnsignedType,
+    class NumberFloatType,
+    template <typename U> class AllocatorType,
+    template <typename T, typename SFINAE> class JSONSerializer,
+    class BinaryType,
+    class CustomBaseClass>
+class basic_json;
+
+// Keep this in sync with nlohmann/json_fwd.hpp from the vendored nlohmann:
+// https://github.com/nlohmann/json/blob/55f93686c01528224f448c19128836e7df245f72/include/nlohmann/json_fwd.hpp
+// Do not include nlohmann headers here: this public header is installed without
+// vendored nlohmann.
+using json = basic_json<
+    std::map,
+    std::vector,
+    std::string,
+    bool,
+    std::int64_t,
+    std::uint64_t,
+    double,
+    std::allocator,
+    adl_serializer,
+    std::vector<std::uint8_t>,
+    void>;
+
+} // namespace json_abi_v3_12_0
+} // namespace nlohmann
 
 namespace torch {
 


### PR DESCRIPTION
Avoid including `nlohmann/json.hpp` from the profiler traceback public header by
forward declaring `nlohmann::json` and keeping the full include in the `.cpp`
file.

This follows the suggested fwd-declaration approach for
`torch/csrc/profiler/python/combined_traceback.h`. The header only needs to
declare `json_symbolize()`, so no callers or public signatures need to change.

The forward declaration mirrors nlohmann's versioned ABI namespace, so the
`.cpp` has a `static_assert` to make future vendored nlohmann upgrades fail
loudly if the declaration needs updating.

This PR only fixes `combined_traceback.h`. Other headers mentioned in the issue
use different patterns and can be handled separately.

Test plan:
- Temporarily applied this patch to an existing PyTorch build checkout and ran:
  `python test/test_cpp_extensions_jit.py TestCppExtensionJIT.test_combined_traceback_header_does_not_include_nlohmann`
- Recompiled `torch/csrc/profiler/python/combined_traceback.cpp` using that
  checkout's existing `build/compile_commands.json` entry.
- Manually verified a downstream-style `-fsyntax-only` compile with
  installed-layout PyTorch include paths, a fake `nlohmann/json.hpp` placed first
  in the include path, and no real nlohmann include path.

Fixes #181565

Prepared with assistance from Codex.