### PR TITLE
[xpu][inductor] fallback maxpool backward to eager on XPU to avoid performance drop because of atomic op

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -10957,7 +10957,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         # Note: Kernel count varies by backend (CUDA ~3, ROCm ~2) due to fusion.
         # Correctness is validated by self.common() above.
         # MPS: decomposition falls back to native kernel, so no inductor kernels generated
-        if self.device != "mps":
+        if self.device != "mps" and self.device != "xpu":
             self.assertGreater(torch._inductor.metrics.generated_kernel_count, 0)
 
     # From https://github.com/pytorch/pytorch/issues/93384
@@ -10989,7 +10989,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         # Note: Kernel count varies by backend (CUDA ~3, ROCm ~2) due to fusion.
         # Correctness is validated by self.common() above.
         # MPS: decomposition falls back to native kernel, so no inductor kernels generated
-        if self.device != "mps":
+        if self.device != "mps" and self.device != "xpu":
             self.assertGreater(torch._inductor.metrics.generated_kernel_count, 0)
 
     def test_issue102546(self):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5727,6 +5727,9 @@ def max_pool2d_with_indices_backward(
     if torch.are_deterministic_algorithms_enabled():
         return NotImplemented
 
+    if grad_output.is_xpu:
+        return NotImplemented
+
     # MPS: Use native kernel. scatter_add has correctness issues on macOS 14
     # (#163327) and numerical differences on macOS 15+.
     if grad_output.device.type == "mps":


### PR DESCRIPTION
I see some torchbench models like vgg16 has 20% performance regression due to maxpool backward being fused into inductor after #167318


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo