### PR TITLE
[xpu][fix] Enlarge test shape in `test_progressive` to avoid benchmark time result flaky.

### DIFF
--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -121,8 +121,8 @@ class TestSubprocess(TestCase):
 
         torch._inductor.compile_fx.fx_compile_progressive = True
 
-        x = torch.randn(1152, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
-        y = torch.randn(1024, 1024, device=GPU_TYPE, dtype=torch.bfloat16)
+        x = torch.randn(1152, 4096, device=GPU_TYPE, dtype=torch.bfloat16)
+        y = torch.randn(4096, 4096, device=GPU_TYPE, dtype=torch.bfloat16)
 
         @torch.compile(fullgraph=True, backend="inductor")
         def optimized(x, y):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182621

## Motivation:
Test case test_progressive assert the benchmark time of baseline(without max-autotune) kernel should be large than max-autotuned kernel. But the small test shape cause the benchmark time flaky on XPU and randomly fail the assertion.

## Solution
Enlarge the test shape.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo