### PR TITLE
[Docathon] Document undocumented functions in mtia.memory.md

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -452,7 +452,6 @@ coverage_ignore_functions = [
     "custom_fwd",
     # torch.cuda.amp.common
     "amp_definitely_not_available",
-    # torch.mtia.memory
     # torch.cuda.nccl
     "all_gather",
     "all_reduce",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -453,7 +453,6 @@ coverage_ignore_functions = [
     # torch.cuda.amp.common
     "amp_definitely_not_available",
     # torch.mtia.memory
-    "reset_peak_memory_stats",
     # torch.cuda.nccl
     "all_gather",
     "all_reduce",

--- a/docs/source/mtia.memory.md
+++ b/docs/source/mtia.memory.md
@@ -7,6 +7,10 @@ The MTIA backend is implemented out of the tree, only interfaces are defined her
 ```
 
 ```{eval-rst}
+.. autofunction:: reset_peak_memory_stats
+```
+
+```{eval-rst}
 .. currentmodule:: torch.mtia.memory
 ```
 


### PR DESCRIPTION
Fixes #182523

Adds the missing API documentation entry for `torch.mtia.memory.reset_peak_memory_stats`.

Changes:
- Remove `reset_peak_memory_stats` from the `torch.mtia.memory` coverage ignore list in `docs/source/conf.py`.
- Add an `autofunction` directive for `reset_peak_memory_stats` in `docs/source/mtia.memory.md`.

Verification:
- `make coverage` generated `docs/build/coverage/python.txt`; `torch.mtia.memory` reports `100.00%` coverage with `0` undocumented items.
- Rendered docs confirm `torch.mtia.memory.reset_peak_memory_stats(device=None)` appears on `mtia.memory.html`.

Screenshot:
<img width="1440" height="1200" alt="after-mtia-memory-top" src="https://github.com/user-attachments/assets/1c619bba-c1f7-4376-b78a-4e5f085797cd" />



cc @svekars @sekyondaMeta @AlannaBurke @egienvalue