### PR TITLE
[xpu][feature] Add is_integrated_gpu to XPU device properties

### DIFF
--- a/c10/xpu/XPUDeviceProp.h
+++ b/c10/xpu/XPUDeviceProp.h
@@ -180,7 +180,9 @@ namespace c10::xpu {
 #define DEFINE_EXT_DEVICE_PROP(property, ...) \
   _DEFINE_SYCL_PROP(sycl::ext::intel::info::device, property, property)
 
-#define DEFINE_DEVICE_ASPECT(member) bool has_##member;
+#define DEFINE_DEVICE_ASPECT(member) bool member;
+
+#define DEFINE_DEVICE_HAS_ASPECT(member) bool has_##member;
 
 #define DEFINE_EXP_DEVICE_PROP(property) \
   _DEFINE_SYCL_PROP(                     \
@@ -195,11 +197,16 @@ struct C10_XPU_API DeviceProp{
     // ext properties.
     AT_FORALL_XPU_EXT_DEVICE_PROPERTIES(DEFINE_EXT_DEVICE_PROP)
 
+#if SYCL_COMPILER_VERSION >= 20260000
     // device aspects.
-    AT_FORALL_XPU_DEVICE_ASPECT(DEFINE_DEVICE_ASPECT)
+    DEFINE_DEVICE_ASPECT(is_integrated_gpu)
+#endif
+
+    // device has aspects.
+    AT_FORALL_XPU_DEVICE_ASPECT(DEFINE_DEVICE_HAS_ASPECT)
 
     // experimental device aspects.
-    AT_FORALL_XPU_EXP_CL_ASPECT(DEFINE_DEVICE_ASPECT)
+    AT_FORALL_XPU_EXP_CL_ASPECT(DEFINE_DEVICE_HAS_ASPECT)
 
 #if SYCL_COMPILER_VERSION >= 20250000
     // experimental device properties.
@@ -212,6 +219,7 @@ struct C10_XPU_API DeviceProp{
 #undef DEFINE_PLATFORM_PROP
 #undef DEFINE_EXT_DEVICE_PROP
 #undef DEFINE_DEVICE_ASPECT
+#undef DEFINE_DEVICE_HAS_ASPECT
 #undef DEFINE_EXP_DEVICE_PROP
 
 } // namespace c10::xpu

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -43,8 +43,12 @@ void enumDevices(std::vector<std::unique_ptr<sycl::device>>& devices) {
   // See Note [Device Management] for more details.
   auto platform_list = sycl::platform::get_platforms();
   auto is_igpu = [](const sycl::device& device) {
+#if SYCL_COMPILER_VERSION < 20260000
     // Generally, iGPUs share a unified memory subsystem with the host.
     return device.get_info<sycl::info::device::host_unified_memory>();
+#else
+    return device.has(sycl::aspect::ext_oneapi_is_integrated_gpu);
+#endif
   };
 
   // Check if a platform contains at least one GPU (either iGPU or dGPU).
@@ -169,6 +173,9 @@ void initDeviceProperties(DeviceProp* device_prop, DeviceIndex device) {
       : default_value;
 
 #define ASSIGN_DEVICE_ASPECT(member) \
+  device_prop->member = raw_device.has(sycl::aspect::member);
+
+#define ASSIGN_DEVICE_HAS_ASPECT(member) \
   device_prop->has_##member = raw_device.has(sycl::aspect::member);
 
 #define ASSIGN_EXP_CL_ASPECT(member) \
@@ -186,7 +193,11 @@ void initDeviceProperties(DeviceProp* device_prop, DeviceIndex device) {
 
   AT_FORALL_XPU_EXT_DEVICE_PROPERTIES(ASSIGN_EXT_DEVICE_PROP);
 
-  AT_FORALL_XPU_DEVICE_ASPECT(ASSIGN_DEVICE_ASPECT);
+#if SYCL_COMPILER_VERSION >= 20260000
+  ASSIGN_DEVICE_ASPECT(is_integrated_gpu)
+#endif
+
+  AT_FORALL_XPU_DEVICE_ASPECT(ASSIGN_DEVICE_HAS_ASPECT);
 
   AT_FORALL_XPU_EXP_CL_ASPECT(ASSIGN_EXP_CL_ASPECT);
 

--- a/c10/xpu/XPUFunctions.cpp
+++ b/c10/xpu/XPUFunctions.cpp
@@ -173,7 +173,7 @@ void initDeviceProperties(DeviceProp* device_prop, DeviceIndex device) {
       : default_value;
 
 #define ASSIGN_DEVICE_ASPECT(member) \
-  device_prop->member = raw_device.has(sycl::aspect::member);
+  device_prop->member = raw_device.has(sycl::aspect::ext_oneapi_##member);
 
 #define ASSIGN_DEVICE_HAS_ASPECT(member) \
   device_prop->has_##member = raw_device.has(sycl::aspect::member);

--- a/test/test_xpu.py
+++ b/test/test_xpu.py
@@ -176,6 +176,11 @@ class TestXpu(TestCase):
             len(str(device_properties.uuid)), 36
         )  # xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
         self.assertEqual(len(device_properties.uuid.bytes), 16)
+        if int(torch.version.xpu) >= 20260000:
+            self.assertEqual(
+                device_properties.is_integrated_gpu,
+                device_capability["is_integrated_gpu"],
+            )
 
     def test_get_device_capability(self):
         device_capability = torch.xpu.get_device_capability()

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -2524,6 +2524,7 @@ class _XpuDeviceProperties:
     has_subgroup_matrix_multiply_accumulate: _bool
     has_subgroup_matrix_multiply_accumulate_tensor_float32: _bool
     has_subgroup_2d_block_io: _bool
+    is_integrated_gpu: _bool
     total_memory: _int
     gpu_subslice_count: _int
     architecture: _int

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -389,7 +389,7 @@ static void registerXpuDeviceProperties(PyObject* module) {
 #if SYCL_COMPILER_VERSION >= 20260000
                    << ", is_integrated_gpu=" << prop.is_integrated_gpu
 #endif
-                   << ')';
+                   << ")";
             return stream.str();
           });
 }

--- a/torch/csrc/xpu/Module.cpp
+++ b/torch/csrc/xpu/Module.cpp
@@ -349,6 +349,9 @@ static void registerXpuDeviceProperties(PyObject* module) {
       ._(has_subgroup_2d_block_io)
 
   THXP_FORALL_DEVICE_PROPERTIES(DEFINE_READONLY_MEMBER)
+#if SYCL_COMPILER_VERSION >= 20260000
+      .def_readonly("is_integrated_gpu", &DeviceProp::is_integrated_gpu)
+#endif
       .def_readonly("total_memory", &DeviceProp::global_mem_size)
       .def_property_readonly("gpu_subslice_count", gpu_subslice_count)
 #if SYCL_COMPILER_VERSION >= 20250000
@@ -382,7 +385,11 @@ static void registerXpuDeviceProperties(PyObject* module) {
                    << ", sub_group_sizes=[" << prop.sub_group_sizes
                    << "], has_fp16=" << prop.has_fp16
                    << ", has_fp64=" << prop.has_fp64
-                   << ", has_atomic64=" << prop.has_atomic64 << ')';
+                   << ", has_atomic64=" << prop.has_atomic64
+#if SYCL_COMPILER_VERSION >= 20260000
+                   << ", is_integrated_gpu=" << prop.is_integrated_gpu
+#endif
+                   << ')';
             return stream.str();
           });
 }

--- a/torch/xpu/__init__.py
+++ b/torch/xpu/__init__.py
@@ -500,6 +500,7 @@ def get_device_properties(
     - ``has_subgroup_matrix_multiply_accumulate`` (bool): whether DPAS (Dot Product Accumulate Systolic) is supported.
     - ``has_subgroup_matrix_multiply_accumulate_tensor_float32`` (bool): whether DPAS with tf32 inputs is supported.
     - ``has_subgroup_2d_block_io`` (bool): whether 2D block I/O for efficient matrix multiplication is supported.
+    - ``is_integrated_gpu`` (bool): whether the device is an integrated GPU (iGPU).
     - ``total_memory`` (int): device global memory in bytes.
     - ``gpu_subslice_count`` (int): number of subslice.
     - ``architecture`` (int): device architecture identifier (experimental).


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #182630
* __->__ #182624

# Motivation
This PR would like to add a new property `is_integrated_gpu` for XPU device properties. It represents whether the device is an integrated GPU (iGPU).

# Additional Context
Refer to https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_is_integrated_gpu.asciidoc