### PR TITLE
[Docathon] Document undocumented functions in mtia.memory.md

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -452,8 +452,6 @@ coverage_ignore_functions = [
     "custom_fwd",
     # torch.cuda.amp.common
     "amp_definitely_not_available",
-    # torch.mtia.memory
-    "reset_peak_memory_stats",
     # torch.cuda.nccl
     "all_gather",
     "all_reduce",

--- a/docs/source/mtia.memory.md
+++ b/docs/source/mtia.memory.md
@@ -7,10 +7,6 @@ The MTIA backend is implemented out of the tree, only interfaces are defined her
 ```
 
 ```{eval-rst}
-.. autofunction:: reset_peak_memory_stats
-```
-
-```{eval-rst}
 .. currentmodule:: torch.mtia.memory
 ```
 
@@ -19,6 +15,7 @@ The MTIA backend is implemented out of the tree, only interfaces are defined her
     :toctree: generated
     :nosignatures:
 
+    reset_peak_memory_stats
     max_memory_allocated
     memory_stats
     memory_allocated

--- a/docs/source/mtia.memory.md
+++ b/docs/source/mtia.memory.md
@@ -7,6 +7,10 @@ The MTIA backend is implemented out of the tree, only interfaces are defined her
 ```
 
 ```{eval-rst}
+.. autofunction:: reset_peak_memory_stats
+```
+
+```{eval-rst}
 .. currentmodule:: torch.mtia.memory
 ```
 


### PR DESCRIPTION
Fixes #182523

## Description

Documents `torch.mtia.memory.reset_peak_memory_stats` so it appears in the rendered MTIA memory documentation.

This PR:
- Removes `reset_peak_memory_stats` from `coverage_ignore_functions` in `docs/source/conf.py`.
- Adds an `autofunction` directive for `reset_peak_memory_stats` in `docs/source/mtia.memory.md`.

## Verification
- Confirmed `torch.mtia.memory` reports `100.00%` coverage with `0` undocumented items
- Rendered docs confirm `torch.mtia.memory.reset_peak_memory_stats(device=None)` appears on `mtia.memory.html`

## Screenshot

<img width="1440" height="1200" alt="after-mtia-memory-top" src="https://github.com/user-attachments/assets/bf2d9e4c-f0f5-45a0-aa85-b923a797072a" />


## Checklist

- [x] The issue that is being fixed is referred in the description
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request

cc @svekars @sekyondaMeta @AlannaBurke @egienvalue