### PR TITLE
[docs] Add documentation for 4 functions in cuda.md

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -462,12 +462,8 @@ coverage_ignore_functions = [
     "reduce",
     "reduce_scatter",
     "unique_id",
-    "version",
     # torch.cuda.profiler
     "init",
-    "profile",
-    "start",
-    "stop",
     # torch.distributed.algorithms.ddp_comm_hooks.ddp_zero_hook
     "hook_with_zero_step",
     "hook_with_zero_step_interleaved",

--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -177,6 +177,24 @@
 .. autoclass:: torch.cuda.use_mem_pool
 ```
 
+```{eval-rst}
+.. currentmodule:: torch.cuda.nccl
+.. autofunction:: version
+```
+
+```{eval-rst}
+.. currentmodule:: torch.cuda.profiler
+.. autofunction:: profile
+.. autofunction:: start
+.. autofunction:: stop
+```
+
+```{eval-rst}
+.. currentmodule:: torch.cuda
+```
+
+```
+
 ## NVIDIA Tools Extension (NVTX)
 
 ```{eval-rst}

--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -179,13 +179,25 @@
 
 ```{eval-rst}
 .. currentmodule:: torch.cuda.nccl
+```
+
+```{eval-rst}
 .. autofunction:: version
 ```
 
 ```{eval-rst}
 .. currentmodule:: torch.cuda.profiler
+```
+
+```{eval-rst}
 .. autofunction:: profile
+```
+
+```{eval-rst}
 .. autofunction:: start
+```
+
+```{eval-rst}
 .. autofunction:: stop
 ```
 

--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -193,8 +193,6 @@
 .. currentmodule:: torch.cuda
 ```
 
-```
-
 ## NVIDIA Tools Extension (NVTX)
 
 ```{eval-rst}

--- a/docs/source/cuda.md
+++ b/docs/source/cuda.md
@@ -187,18 +187,14 @@
 
 ```{eval-rst}
 .. currentmodule:: torch.cuda.profiler
-```
 
-```{eval-rst}
-.. autofunction:: profile
-```
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
 
-```{eval-rst}
-.. autofunction:: start
-```
-
-```{eval-rst}
-.. autofunction:: stop
+    profile
+    start
+    stop
 ```
 
 ```{eval-rst}


### PR DESCRIPTION
Fixes #182517

## Description

documented Undocumented functions:
- torch.cuda.nccl.version
- torch.cuda.profiler.profile
- torch.cuda.profiler.start
- torch.cuda.profiler.stop


## Test plan

- [x] lintrunner -a passes with no lint issues
- [x] make coverage passes — all 4 affected modules report 100% coverage, 0 undocumented
- [x] None of the 4 functions appear in build/coverage/python.txt
- [ ] Rendered documentation ([from PR preview](TO_BE_FILLED))



cc @svekars @sekyondaMeta @AlannaBurke