### PR TITLE
[dynamo] Reland: fix f-string mutation ordering for Python values

### DIFF
--- a/test/dynamo/test_str_protocol.py
+++ b/test/dynamo/test_str_protocol.py
@@ -56,5 +56,123 @@ class TpStrTests(TestCase):
         assert str([1, 2, 3]) == "[1, 2, 3]"  # noqa: S101
 
 
+class FStringMutationTests(TestCase):
+    """Tests for f-string mutation ordering (issue #177582).
+
+    Dynamo must evaluate f-string formatting at the correct bytecode point
+    so that mutations between two f-strings are reflected in the output.
+    """
+
+    def _check(self, fn, *args_factory):
+        import copy
+
+        import torch
+        import torch._dynamo.testing
+
+        eager_result = fn(*copy.deepcopy(args_factory))
+        cnt = torch._dynamo.testing.CompileCounter()
+        compiled_fn = torch.compile(fn, backend=cnt)
+        compiled_result = compiled_fn(*copy.deepcopy(args_factory))
+        self.assertEqual(eager_result, compiled_result)
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_fstring_tracks_user_defined_object_mutations(self):
+        import torch
+
+        class Obj:
+            def __init__(self, val):
+                self.val = val
+
+            def __repr__(self):
+                return f"Obj({self.val})"
+
+        def fn(x, obj):
+            x = x + 1
+            s1 = f"obj = {obj}"
+            obj.val.append(0)
+            s2 = f"obj = {obj}"
+            return x, s1, s2
+
+        self._check(fn, torch.randn(3), Obj([1, 2]))
+
+    def test_fstring_tracks_frozen_dataclass_field_mutations(self):
+        from dataclasses import dataclass
+
+        import torch
+
+        @dataclass(frozen=True)
+        class FrozenObj:
+            val: list
+
+            def __repr__(self):
+                return f"FrozenObj({self.val})"
+
+        def fn(x, obj):
+            x = x + 1
+            s1 = f"obj = {obj}"
+            obj.val.append(0)
+            s2 = f"obj = {obj}"
+            return x, s1, s2
+
+        self._check(fn, torch.randn(3), FrozenObj([1, 2]))
+
+    def test_fstring_str_conversion_tracks_mutations(self):
+        import torch
+
+        class Obj:
+            def __init__(self, val):
+                self.val = val
+
+            def __repr__(self):
+                return f"Obj({self.val})"
+
+        def fn(x, obj):
+            x = x + 1
+            s1 = f"{obj!s}"
+            obj.val.append(0)
+            s2 = f"{obj!s}"
+            return x, s1, s2
+
+        self._check(fn, torch.randn(3), Obj([1, 2]))
+
+    def test_fstring_repr_conversion_tracks_mutations(self):
+        import torch
+
+        class Obj:
+            def __init__(self, val):
+                self.val = val
+
+            def __repr__(self):
+                return f"Obj({self.val})"
+
+        def fn(x, obj):
+            x = x + 1
+            s1 = f"{obj!r}"
+            obj.val.append(0)
+            s2 = f"{obj!r}"
+            return x, s1, s2
+
+        self._check(fn, torch.randn(3), Obj([1, 2]))
+
+    def test_explicit_str_tracks_mutations(self):
+        import torch
+
+        class Obj:
+            def __init__(self, val):
+                self.val = val
+
+            def __repr__(self):
+                return f"Obj({self.val})"
+
+        def fn(x, obj):
+            x = x + 1
+            s1 = str(obj)
+            obj.val.append(0)
+            s2 = str(obj)
+            return x, s1, s2
+
+        self._check(fn, torch.randn(3), Obj([1, 2]))
+
+
 if __name__ == "__main__":
     run_tests()

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -4762,6 +4762,16 @@
       ]
     }
   ],
+  "GB4399": [
+    {
+      "Gb_type": "untraceable user-defined __str__",
+      "Context": "Could not trace __str__ override for {type(self.value).__name__}",
+      "Explanation": "Dynamo could not safely trace this user-defined __str__ override.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
   "GB1297": [
     {
       "Gb_type": "Reconstruction failure (self-referential)",

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -4173,6 +4173,33 @@ class InstructionTranslatorBase(
 
         value = self._convert_value(value, flags & 0x03)
 
+        # For plain f"{obj}" (no conversion, empty format spec, default
+        # __format__), eagerly evaluate str() via generic_str to capture
+        # the current symbolic state.  This avoids deferring to
+        # StringFormatVariable whose reconstruct runs before mutations
+        # are replayed in the epilogue.
+        # Skip when __format__ is overridden since format(obj, "") may
+        # differ from str(obj) in that case.
+        if (
+            (flags & 0x03) == 0
+            and fmt_spec.is_python_constant()
+            and fmt_spec.as_python_constant() == ""
+        ):
+            realized = value.realize()
+            try:
+                py_type = realized.python_type()
+            except NotImplementedError:
+                py_type = None
+            if py_type is not None and py_type.__format__ is object.__format__:
+                try:
+                    from .variables.object_protocol import generic_str
+
+                    str_result = generic_str(self, realized)
+                    self.push(str_result)
+                    return
+                except Unsupported:
+                    pass
+
         fmt_var = VariableTracker.build(
             self, "{:" + fmt_spec.as_python_constant() + "}"
         )

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -72,7 +72,6 @@ from ..utils import (
     get_fake_value,
     guard_if_dyn,
     is_tensor_getset_descriptor,
-    is_wrapper_or_member_descriptor,
     istype,
     numpy_operator_wrapper,
     proxy_args_kwargs,
@@ -1768,50 +1767,7 @@ class BuiltinVariable(BaseBuiltinVariable):
         if isinstance(arg, (variables.UserFunctionVariable)):
             return VariableTracker.build(tx, str(arg.fn))
         elif isinstance(arg, (variables.UserDefinedObjectVariable)):
-            # Check if object has __str__ method
-            if hasattr(arg.value, "__str__"):
-                str_method = arg.value.__str__
-            elif hasattr(arg.value, "__repr__"):
-                # account for __repr__ functions when __str__ is absent
-                str_method = arg.value.__repr__
-            else:
-                unimplemented(
-                    gb_type="failed to call str() on user defined object",
-                    context=str(arg),
-                    explanation="User defined object has no __str__ or __repr__ method",
-                    hints=[*graph_break_hints.USER_ERROR],
-                )
-
-            if type(arg.value).__str__ is object.__str__:
-                # Rely on the object str method
-                try:
-                    # pyrefly: ignore [unbound-name]
-                    return VariableTracker.build(tx, str_method())
-                except AttributeError:
-                    # Graph break
-                    return None
-            elif is_wrapper_or_member_descriptor(str_method):
-                unimplemented(
-                    gb_type="Attempted to a str() method implemented in C/C++",
-                    context="",
-                    explanation=f"{type(arg.value)} has a C/C++ based str method. This is not supported.",
-                    hints=["Write the str method in Python"],
-                )
-            else:
-                # Overrides for custom str method
-                # Pass method as function to call tx.inline_user_function_return
-                bound_method = str_method.__func__  # type: ignore[attr-defined]
-
-                try:
-                    # Only supports certain function types
-                    user_func_variable = VariableTracker.build(tx, bound_method)
-                except AssertionError:
-                    # Won't be able to do inline the str method, return to avoid graph break
-                    log.warning("Failed to create UserFunctionVariable", exc_info=True)
-                    return None
-
-                # Inline the user function
-                return user_func_variable.call_function(tx, [arg], {})
+            return generic_str(tx, arg)
         return None
 
     def call___build_class__(self, tx, *args, **kwargs):

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -4418,7 +4418,7 @@ class MemberDescriptorVariable(VariableTracker):
                 return obj.var_getattr(tx, attr_name)
         try:
             resolved = self.descriptor.__get__(obj_value)
-        except AttributeError:
+        except (AttributeError, TypeError):
             raise_observed_exception(
                 AttributeError,
                 tx,
@@ -4505,7 +4505,7 @@ class GetSetDescriptorVariable(VariableTracker):
                 return obj.var_getattr(tx, attr_name)
         try:
             resolved = self.descriptor.__get__(obj_value)
-        except AttributeError:
+        except (AttributeError, TypeError):
             raise_observed_exception(
                 AttributeError,
                 tx,

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1874,6 +1874,69 @@ class UserDefinedObjectVariable(UserDefinedVariable):
                 skip_frame=True,
             )
 
+    def str_impl(
+        self,
+        tx: "InstructionTranslatorBase",
+    ) -> VariableTracker:
+        from .object_protocol import generic_repr
+
+        type_attr = self.lookup_class_mro_attr("__str__")
+        if type_attr is NO_SUCH_SUBOBJ:
+            return super().str_impl(tx)
+        if type_attr is None:
+            raise_type_error(tx, "'NoneType' object is not callable")
+
+        method = self._maybe_get_baseclass_method("__str__")
+        if (
+            self._base_vt is not None
+            and self._base_methods is not None
+            and method in self._base_methods
+        ):
+            return self._base_vt.str_impl(tx)
+
+        if type(self.value).__str__ is object.__str__:
+            return generic_repr(tx, self)
+
+        if (
+            is_wrapper_or_member_descriptor(type_attr)
+            or torch._C._dynamo.utils.is_instancemethod(type_attr)  # type: ignore[attr-defined]
+            or is_cython_function(type_attr)
+        ):
+            try:
+                inspect.getattr_static(type(type_attr), "__get__")(
+                    type_attr, self.value, type(self.value)
+                )
+            except (AttributeError, TypeError) as e:
+                raise_observed_exception(type(e), tx, args=list(e.args))
+            else:
+                unimplemented(
+                    gb_type="untraceable user-defined __str__",
+                    context=f"Could not trace __str__ override for {type(self.value).__name__}",
+                    explanation="Dynamo could not safely trace this user-defined __str__ override.",
+                    hints=[*graph_break_hints.SUPPORTABLE],
+                    skip_frame=True,
+                )
+
+        source = self.source and self.get_source_by_walking_mro(tx, "__str__")
+        method_var = self.resolve_type_attr(tx, "__str__", type_attr, source)
+        if not isinstance(method_var, variables.GetAttrVariable):
+            return method_var.call_function(tx, [], {})
+
+        try:
+            inspect.getattr_static(type(type_attr), "__get__")(
+                type_attr, self.value, type(self.value)
+            )
+        except (AttributeError, TypeError) as e:
+            raise_observed_exception(type(e), tx, args=list(e.args))
+        else:
+            unimplemented(
+                gb_type="untraceable user-defined __str__",
+                context=f"Could not trace __str__ override for {type(self.value).__name__}",
+                explanation="Dynamo could not safely trace this user-defined __str__ override.",
+                hints=[*graph_break_hints.SUPPORTABLE],
+                skip_frame=True,
+            )
+
     def nb_index_impl(
         self,
         tx: "InstructionTranslatorBase",


### PR DESCRIPTION
Fixes #177582

Continuation of #179002 which was closed due to rebase corruption. Cherry-picked and rebased onto current main with conflict resolution.

## Summary

**Root cause**: Dynamo deferred default f-string formatting into `StringFormatVariable` replay, so Python-side object and container formatting could be evaluated out of order with later mutations instead of at the original bytecode point.

**Fix**: Detect the default `"{}"` / `"{:}"` formatting pattern used by f-strings and eagerly route supported Python-side values through Dynamo's `str` / `repr` handlers. Extend those handlers for container values and default-`__str__` user objects so custom `__repr__` implementations, including frozen dataclass reprs, are evaluated at the correct point.

This restores Python ordering semantics for mutable Python-side values without disturbing the deferred formatting path that Dynamo still needs for tensor and symbolic values.


## Local test results

| Test | Result |
|------|--------|
| Original issue repro (user-defined object + mutation) | PASS |
| Custom op repro (from [comment](https://github.com/pytorch/pytorch/issues/177582#issuecomment-4078235731)) | PASS |
| Frozen dataclass repro | PASS |
| `test_fstring_tracks_user_defined_object_mutations` | PASS |
| `test_fstring_tracks_frozen_dataclass_field_mutations` | PASS |
| `test_fstring_user_defined_list_variable` | PASS |
| `test_fstring_str_on_container` | PASS |
| `test_fstring_unspecialized_python_variable` | PASS |
| `test/dynamo/test_misc.py` (full suite) | 758 passed, 1 pre-existing failure (`test_packaging_version_parse` — fails on clean `upstream/main` too, unrelated frozenset/set tracing issue) |
| `test/dynamo/test_repros.py` | 366 passed, 1 pre-existing failure (`test_named_tuple_vt_clone_cuda` — LAPACK env issue) |
| `test/dynamo/test_functions.py` (494 tests) | PASS |
| `test/dynamo/test_export.py` (184 tests) | PASS |
| `test/dynamo/test_subclasses.py` (130 tests) | PASS |
| `lintrunner` on changed files | Clean |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98 @williamwen42