### PR TITLE
Fix pipelining crash when split_module interleaves get_attr with placeholder

### DIFF
--- a/test/distributed/pipelining/test_unflatten.py
+++ b/test/distributed/pipelining/test_unflatten.py
@@ -74,6 +74,57 @@ class UnflattenTests(TestCase):
         print(f"Equivalence test passed {torch.sum(out)} ref {torch.sum(ref)}")
 
 
+class UnflattenPlaceholderOrderingTests(TestCase):
+    """regression tests for https://github.com/pytorch/pytorch/issues/162898"""
+
+    def _check(self, node_ops, expected_ops):
+        from torch.distributed.pipelining._IR import _move_placeholders_to_front
+
+        g = torch.fx.Graph()
+        for i, op in enumerate(node_ops):
+            if op == "placeholder":
+                g.placeholder(f"n{i}")
+            elif op == "get_attr":
+                g.create_node("get_attr", f"submod_{i}")
+        g.output(None)
+
+        _move_placeholders_to_front(g)
+        g.lint()
+
+        result = [n.op for n in g.nodes if n.op != "output"]
+        self.assertEqual(result, expected_ops)
+
+    def test_get_attr_between_placeholders(self):
+        self._check(
+            ["placeholder", "placeholder", "get_attr", "placeholder", "placeholder"],
+            ["placeholder", "placeholder", "placeholder", "placeholder", "get_attr"],
+        )
+
+    def test_get_attr_before_all_placeholders(self):
+        self._check(
+            ["get_attr", "placeholder", "placeholder", "placeholder"],
+            ["placeholder", "placeholder", "placeholder", "get_attr"],
+        )
+
+    def test_multiple_get_attrs(self):
+        self._check(
+            ["placeholder", "get_attr", "placeholder", "get_attr", "placeholder"],
+            ["placeholder", "placeholder", "placeholder", "get_attr", "get_attr"],
+        )
+
+    def test_no_interleaving(self):
+        self._check(
+            ["placeholder", "placeholder", "placeholder", "get_attr"],
+            ["placeholder", "placeholder", "placeholder", "get_attr"],
+        )
+
+    def test_only_placeholders(self):
+        self._check(
+            ["placeholder", "placeholder", "placeholder"],
+            ["placeholder", "placeholder", "placeholder"],
+        )
+
+
 devices = ["cpu", "cuda", "hpu", "xpu"]
 instantiate_device_type_tests(
     UnflattenTests, globals(), only_for=devices, allow_xpu=True

--- a/torch/distributed/pipelining/_IR.py
+++ b/torch/distributed/pipelining/_IR.py
@@ -232,6 +232,27 @@ def _insert_stage_symbolic_backward(
     return g
 
 
+def _move_placeholders_to_front(graph: fx.Graph):
+    """Ensure all placeholder nodes form a contiguous prefix of the graph.
+    split_module can interleave get_attr nodes with placeholders."""
+    last_ph = None
+    for node in graph.nodes:
+        if node.op == "placeholder":
+            last_ph = node
+    if last_ph is None:
+        return
+    nodes_to_move = []
+    for node in graph.nodes:
+        if node is last_ph:
+            break
+        if node.op != "placeholder":
+            nodes_to_move.append(node)
+    insert_point = last_ph
+    for node in nodes_to_move:
+        insert_point.append(node)
+        insert_point = node
+
+
 class PipeSequential(torch.nn.Sequential):
     @staticmethod
     def from_sequential(sequential_instance: torch.nn.Sequential):
@@ -764,6 +785,7 @@ class Pipe(torch.nn.Module):
 
         for name, submodule in split.named_children():
             if isinstance(submodule, fx.GraphModule):
+                _move_placeholders_to_front(submodule.graph)
                 new_submod = _outline_submodules(submodule.graph)
                 # Replace old submod
                 split.register_module(name, new_submod)


### PR DESCRIPTION
Fixes #162898 

`split_module` can produce partition subgraphs where get_attr nodes  are interleaved with placeholder nodes. `_ModuleFrame.run_outer()` assumes placeholders form a contiguous prefix, so it crashes when this invariant is violated.

added `_move_placeholders_to_front` to reorder the graph before` _outline_submodules` runs and added tests.

also verified with the actual `SmolLM2` model from the issue

