### PR TITLE
[CI] Increase ROCm MI355 test shards to reduce timeout pressure

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -269,15 +269,20 @@ jobs:
       # sync-tag: rocm-build
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 2, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 3, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 4, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 5, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "default", shard: 6, num_shards: 6, runner: "linux.rocm.gpu.gfx950.1" },
-          { config: "distributed", shard: 1, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2" },
-          { config: "distributed", shard: 2, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2" },
-          { config: "distributed", shard: 3, num_shards: 3, runner: "linux.rocm.gpu.gfx950.2" },
+          { config: "default", shard: 1, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 2, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 3, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 4, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 5, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 6, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 7, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 8, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 9, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "default", shard: 10, num_shards: 10, runner: "linux.rocm.gpu.gfx950.1" },
+          { config: "distributed", shard: 1, num_shards: 4, runner: "linux.rocm.gpu.gfx950.2" },
+          { config: "distributed", shard: 2, num_shards: 4, runner: "linux.rocm.gpu.gfx950.2" },
+          { config: "distributed", shard: 3, num_shards: 4, runner: "linux.rocm.gpu.gfx950.2" },
+          { config: "distributed", shard: 4, num_shards: 4, runner: "linux.rocm.gpu.gfx950.2" },
         ]}
       use-arc: false
       python-version: "3.10"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182646

Increase default shards from 6 to 10 and distributed shards from 3 to 4
for the linux-jammy-rocm-py3.10-mi355 trunk CI job.

Authored by Claude.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang