### PR TITLE
[xpu] Enable mixed-type dispatch for Nested and Dense Tensors.

### DIFF
--- a/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBinaryOps.cpp
@@ -100,8 +100,9 @@ static Tensor NestedTensor_elementwise_Tensor(
       self_impl->get_storage_offsets()
     );
   }
-  // special case when other is dense (CUDA only for now)
-  if (self.is_nested() && !other.is_nested() && self.is_cuda() && other.is_cuda()) {
+  // special case when other is dense (CUDA/XPU only for now)
+  if (self.is_nested() && !other.is_nested() &&
+      ((self.is_cuda() && other.is_cuda()) || (self.is_xpu() && other.is_xpu()))) {
     auto self_ptr = get_nested_tensor_impl(self);
     auto other_ = other;
     // check for the [B, *, D], [B, 1, D] case -> use custom kernel


### PR DESCRIPTION
Part of solution for: https://github.com/intel/torch-xpu-ops/issues/2412
Part of solution for: https://github.com/intel/torch-xpu-ops/issues/2425

This PR enables Nested Tensor and Dense Tensor mixed-type operations (such as add and mul) on XPU devices by modifying the dispatcher logic to accept the hybrid signature, thereby resolving the previous type mismatch error: https://github.com/intel/torch-xpu-ops/issues/2412

This change is dependent on the prior PR https://github.com/intel/torch-xpu-ops/pull/2483 which implements the necessary XPU kernels (op_dense_esuhm) and **must** be merged after that underlying compute infrastructure is in place.

This PR is basically the same as https://github.com/pytorch/pytorch/pull/169928. I continue work on this issue and couldn't even reopen the mentioned PR, so I am creating this new one with same changes.