### PR TITLE
[dynamo] Fix PendingUnbackedSymbolNotFound when ops receive 0-d tensor as Scalar arg

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -6984,6 +6984,52 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         actual = torch.compile(fn_pow, backend="eager", fullgraph=True)(a, val)
         self.assertEqual(expected, actual)
 
+    # Test that ops with Scalar arguments (alpha, beta, value) work with
+    # 0-d tensor inputs under fullgraph=True. The C++ arg parser calls
+    # .item() on 0-d tensors to convert them to Scalars, creating unbacked
+    # symbols that should be ignored since they only affect tensor values,
+    # not shapes.
+    @parametrize(
+        "op",
+        [
+            "add_method",
+            "add_positional",
+            "add_func",
+            "addcmul",
+            "addcmul_positional",
+            "addcdiv",
+            "addcdiv_positional",
+            subtest("baddbmm", decorators=[expectedFailureDynamic]),
+        ],
+    )
+    def test_scalar_arg_0d_tensor(self, op):
+        a = torch.randn(4, 4)
+        b = torch.randn(4, 4)
+        c = torch.randn(4, 4)
+        alpha = torch.tensor(2.0)
+        beta = torch.tensor(0.5)
+        batch1 = torch.randn(2, 4, 3)
+        batch2 = torch.randn(2, 3, 4)
+        m_batch = torch.randn(2, 4, 4)
+
+        cases = {
+            "add_method": lambda: a.add(b, alpha=alpha),
+            "add_positional": lambda: a.add(alpha, b),
+            "add_func": lambda: torch.add(a, b, alpha=alpha),
+            "addcmul": lambda: a.addcmul(b, c, value=beta),
+            "addcmul_positional": lambda: a.addcmul(beta, b, c),
+            "addcdiv": lambda: a.addcdiv(b, c.abs() + 1, value=beta),
+            "addcdiv_positional": lambda: a.addcdiv(beta, b, c.abs() + 1),
+            # Z3 translation validation doesn't support unbacked symbols from
+            # baddbmm's scalar args (https://github.com/pytorch/pytorch/issues/162287).
+            "baddbmm": lambda: m_batch.baddbmm(batch1, batch2, alpha=alpha, beta=beta),
+        }
+
+        fn = cases[op]
+        expected = fn()
+        actual = torch.compile(fn, backend="eager", fullgraph=True)()
+        self.assertEqual(expected, actual)
+
     @unittest.skip("https://github.com/pytorch/pytorch/issues/99726")
     def test_cross_entropy_loss_fancy_ctor1(self):
         rand_5 = torch.randn(5)
@@ -15829,6 +15875,9 @@ def forward(self, L_x_ : torch.Tensor):
             exec(code, scope)
             compiled = torch.compile(scope["op"], fullgraph=True)
             self.assertEqual(compiled(x), torch.tensor(0.0))
+
+
+instantiate_parametrized_tests(MiscTests)
 
 
 class MiscTestsPyTree(torch._inductor.test_case.TestCase):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -969,50 +969,15 @@ class TensorVariable(VariableTracker):
         # We only synchronize when there's a tensor argument, since that's when
         # metadata propagation is relevant.
 
-        # [Note: 0-d tensor Scalar args and unbacked symbols]
-        # Many ATen ops accept Scalar arguments (e.g., alpha= in add/sub, beta=
-        # in addmm, value= in addcmul/addcdiv). When a 0-d tensor is passed for
-        # these arguments, the C++ arg parser (python_arg_parser.cpp:scalar_slow)
-        # calls .item() to convert it to a Scalar. During fake tensor
-        # propagation, .item() dispatches to aten._local_scalar_dense, which
-        # creates an unbacked symbol (e.g., zuf0). This symbol is consumed
-        # internally for arithmetic and doesn't affect the output tensor's
-        # shape, stride, or storage offset. Without suppression,
-        # compute_unbacked_bindings raises PendingUnbackedSymbolNotFound because
-        # it can't locate the symbol in the output. We use
-        # ignore_fresh_unbacked_symbols to suppress these value-only unbacked
-        # symbols, matching the pattern used for _foreach_* ops in
-        # TorchInGraphFunctionVariable.call_function.
-        #
-        # We use an explicit allowlist rather than generically suppressing for
-        # any 0-d tensor argument because an op could legitimately create
-        # unbacked symbols for data-dependent output shapes (e.g., nonzero).
-        # Suppressing those would silently drop binding information.
-        methods_with_scalar_args = {
-            "add",
-            "add_",
-            "sub",
-            "sub_",
-            "addcmul",
-            "addcmul_",
-            "addcdiv",
-            "addcdiv_",
-            "addmm",
-            "addmm_",
-            "addmv",
-            "addmv_",
-            "addr",
-            "addr_",
-            "addbmm",
-            "addbmm_",
-            "baddbmm",
-            "baddbmm_",
-        }
+        # See ops_consuming_unbacked_scalars in torch.py for the full allowlist
+        # and reasoning.
+        from .torch import methods_consuming_unbacked_scalars
+
         ctx = (
             tx.fake_mode.shape_env.ignore_fresh_unbacked_symbols
             if tx.fake_mode
             and tx.fake_mode.shape_env
-            and name in methods_with_scalar_args
+            and name in methods_consuming_unbacked_scalars
             and any(
                 isinstance(v, TensorVariable) and v.ndim == 0
                 for v in chain(args, kwargs.values())

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -968,8 +968,61 @@ class TensorVariable(VariableTracker):
         # after wrap_fx_proxy (which runs get_fake_value internally).
         # We only synchronize when there's a tensor argument, since that's when
         # metadata propagation is relevant.
+
+        # [Note: 0-d tensor Scalar args and unbacked symbols]
+        # Many ATen ops accept Scalar arguments (e.g., alpha= in add/sub, beta=
+        # in addmm, value= in addcmul/addcdiv). When a 0-d tensor is passed for
+        # these arguments, the C++ arg parser (python_arg_parser.cpp:scalar_slow)
+        # calls .item() to convert it to a Scalar. During fake tensor
+        # propagation, .item() dispatches to aten._local_scalar_dense, which
+        # creates an unbacked symbol (e.g., zuf0). This symbol is consumed
+        # internally for arithmetic and doesn't affect the output tensor's
+        # shape, stride, or storage offset. Without suppression,
+        # compute_unbacked_bindings raises PendingUnbackedSymbolNotFound because
+        # it can't locate the symbol in the output. We use
+        # ignore_fresh_unbacked_symbols to suppress these value-only unbacked
+        # symbols, matching the pattern used for _foreach_* ops in
+        # TorchInGraphFunctionVariable.call_function.
+        #
+        # We use an explicit allowlist rather than generically suppressing for
+        # any 0-d tensor argument because an op could legitimately create
+        # unbacked symbols for data-dependent output shapes (e.g., nonzero).
+        # Suppressing those would silently drop binding information.
+        methods_with_scalar_args = {
+            "add",
+            "add_",
+            "sub",
+            "sub_",
+            "addcmul",
+            "addcmul_",
+            "addcdiv",
+            "addcdiv_",
+            "addmm",
+            "addmm_",
+            "addmv",
+            "addmv_",
+            "addr",
+            "addr_",
+            "addbmm",
+            "addbmm_",
+            "baddbmm",
+            "baddbmm_",
+        }
+        ctx = (
+            tx.fake_mode.shape_env.ignore_fresh_unbacked_symbols
+            if tx.fake_mode
+            and tx.fake_mode.shape_env
+            and name in methods_with_scalar_args
+            and any(
+                isinstance(v, TensorVariable) and v.ndim == 0
+                for v in chain(args, kwargs.values())
+            )
+            else nullcontext
+        )
+
         version_before = self._get_fake_version()
-        result = wrap_fx_proxy(tx, proxy)
+        with ctx():
+            result = wrap_fx_proxy(tx, proxy)
         self._sync_if_inplace_mutation(
             tx, version_before, any(arg.is_tensor() for arg in args)
         )

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -3059,12 +3059,31 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                     out_kwarg_vt.as_proxy().node.meta["example_value"].shape
                 )
 
-        # Ops that consume scalar values from tensors (via .item()) for computation only,
-        # not for output shapes. When capture_scalar_outputs is enabled, these ops would
-        # create unbacked symbols that are not in the outputs, causing
-        # PendingUnbackedSymbolNotFound errors. We ignore these fresh unbacked symbols
-        # since they only affect tensor values, not shapes.
+        # Ops that consume scalar values from tensors (via .item()) for computation
+        # only, not for output shapes. When capture_scalar_outputs is enabled,
+        # these ops would create unbacked symbols that don't affect the outputs,
+        # causing PendingUnbackedSymbolNotFound errors. We ignore these fresh
+        # unbacked symbols since they only affect tensor values, not shapes.
+        # When a 0-d tensor is passed for a Scalar argument, the C++ arg parser
+        # (python_arg_parser.cpp:scalar_slow) calls .item() on it, creating an
+        # unbacked symbol consumed for arithmetic only.
+        #
+        # We use an explicit allowlist rather than generically suppressing for
+        # any 0-d tensor argument because an op could legitimately create
+        # unbacked symbols for data-dependent output shapes (e.g., nonzero).
+        # Suppressing those would silently drop binding information.
+        # See also: [Note: 0-d tensor Scalar args and unbacked symbols] in tensor.py.
         ops_consuming_unbacked_scalars = {
+            # ops with Scalar alpha/beta/value arguments
+            torch.add,
+            torch.sub,
+            torch.addmm,
+            torch.addmv,
+            torch.addr,
+            torch.addbmm,
+            torch.baddbmm,
+            torch.addcmul,
+            torch.addcdiv,
             # foreach ops with scalar/alpha arguments
             torch._foreach_add,
             torch._foreach_add_,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -217,6 +217,66 @@ if torch.distributed.is_available():
 constant_fold_functions_need_guards = dict.fromkeys(constant_fold_functions_need_guards)
 constant_fold_functions = dict.fromkeys(constant_fold_functions)
 
+# Ops that consume scalar values from 0-d tensors (via .item()) for computation
+# only, not for output shapes. When capture_scalar_outputs is enabled, these ops
+# create unbacked symbols that don't affect the outputs, causing
+# PendingUnbackedSymbolNotFound errors.
+#
+# We use an explicit allowlist rather than generically suppressing for any 0-d
+# tensor argument because an op could legitimately create unbacked symbols for
+# data-dependent output shapes. Suppressing those would silently drop binding
+# information.
+ops_consuming_unbacked_scalars: frozenset[Callable[..., Any]] = frozenset(
+    {
+        # ops with Scalar alpha/beta/value arguments
+        torch.add,
+        torch.sub,
+        torch.addmm,
+        torch.addmv,
+        torch.addr,
+        torch.addbmm,
+        torch.baddbmm,
+        torch.addcmul,
+        torch.addcdiv,
+        # foreach ops with scalar/alpha arguments
+        torch._foreach_add,
+        torch._foreach_add_,
+        torch._foreach_sub,
+        torch._foreach_sub_,
+        torch._foreach_mul,
+        torch._foreach_mul_,
+        torch._foreach_div,
+        torch._foreach_div_,
+        torch._foreach_clamp_max,
+        torch._foreach_clamp_max_,
+        torch._foreach_clamp_min,
+        torch._foreach_clamp_min_,
+        torch._foreach_maximum,
+        torch._foreach_maximum_,
+        torch._foreach_minimum,
+        torch._foreach_minimum_,
+        torch._foreach_pow,
+        torch._foreach_pow_,
+        torch._foreach_lerp,
+        torch._foreach_lerp_,
+        torch._foreach_addcmul,
+        torch._foreach_addcmul_,
+        torch._foreach_addcdiv,
+        torch._foreach_addcdiv_,
+    }
+)
+
+# Derived set of method names for TensorVariable.call_method. Includes inplace
+# variants (e.g., "add_") since those are only callable as tensor methods.
+# This is a set of strings (not function objects) because the call_method path
+# only has the method name, whereas call_function has the actual function object.
+methods_consuming_unbacked_scalars: frozenset[str] = frozenset(
+    name
+    for fn in ops_consuming_unbacked_scalars
+    for name in (fn.__name__, fn.__name__ + "_")
+    if hasattr(torch.Tensor, name)
+)
+
 
 @functools.cache
 def tracing_state_functions() -> dict[Callable[[], Any], bool | None]:
@@ -3059,57 +3119,6 @@ For now, dynamo will explicitly graph break when it encounters user code with th
                     out_kwarg_vt.as_proxy().node.meta["example_value"].shape
                 )
 
-        # Ops that consume scalar values from tensors (via .item()) for computation
-        # only, not for output shapes. When capture_scalar_outputs is enabled,
-        # these ops would create unbacked symbols that don't affect the outputs,
-        # causing PendingUnbackedSymbolNotFound errors. We ignore these fresh
-        # unbacked symbols since they only affect tensor values, not shapes.
-        # When a 0-d tensor is passed for a Scalar argument, the C++ arg parser
-        # (python_arg_parser.cpp:scalar_slow) calls .item() on it, creating an
-        # unbacked symbol consumed for arithmetic only.
-        #
-        # We use an explicit allowlist rather than generically suppressing for
-        # any 0-d tensor argument because an op could legitimately create
-        # unbacked symbols for data-dependent output shapes (e.g., nonzero).
-        # Suppressing those would silently drop binding information.
-        # See also: [Note: 0-d tensor Scalar args and unbacked symbols] in tensor.py.
-        ops_consuming_unbacked_scalars = {
-            # ops with Scalar alpha/beta/value arguments
-            torch.add,
-            torch.sub,
-            torch.addmm,
-            torch.addmv,
-            torch.addr,
-            torch.addbmm,
-            torch.baddbmm,
-            torch.addcmul,
-            torch.addcdiv,
-            # foreach ops with scalar/alpha arguments
-            torch._foreach_add,
-            torch._foreach_add_,
-            torch._foreach_sub,
-            torch._foreach_sub_,
-            torch._foreach_mul,
-            torch._foreach_mul_,
-            torch._foreach_div,
-            torch._foreach_div_,
-            torch._foreach_clamp_max,
-            torch._foreach_clamp_max_,
-            torch._foreach_clamp_min,
-            torch._foreach_clamp_min_,
-            torch._foreach_maximum,
-            torch._foreach_maximum_,
-            torch._foreach_minimum,
-            torch._foreach_minimum_,
-            torch._foreach_pow,
-            torch._foreach_pow_,
-            torch._foreach_lerp,
-            torch._foreach_lerp_,
-            torch._foreach_addcmul,
-            torch._foreach_addcmul_,
-            torch._foreach_addcdiv,
-            torch._foreach_addcdiv_,
-        }
         ctx = nullcontext
         if fn_ in ops_consuming_unbacked_scalars:
             if tx.fake_mode and tx.fake_mode.shape_env:


### PR DESCRIPTION
When `torch.compile(fullgraph=True)` is used with ops that accept Scalar arguments (alpha, beta, value), passing a 0-d tensor for those arguments causes compilation to fail with PendingUnbackedSymbolNotFound. This happens because the C++ arg parser calls .item() on 0-d tensors to convert them to Scalars, which creates an unbacked symbol during fake tensor propagation that doesn't appear in output shapes.

Fix by wrapping fake tensor propagation in ignore_fresh_unbacked_symbols when any argument is a 0-d tensor. This covers both the method call path (TensorVariable.call_method) and the function call path (TorchInGraphFunctionVariable.call_function), for both keyword and positional Scalar arguments (including deprecated positional forms).

Fixes https://github.com/pytorch/pytorch/issues/182408

Assisted by claude

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98