### PR TITLE
[distributed] Make LocalTensorMode transparent to torch.compile

### DIFF
--- a/test/distributed/test_local_tensor.py
+++ b/test/distributed/test_local_tensor.py
@@ -5,6 +5,7 @@ from contextlib import nullcontext
 
 import torch
 import torch.distributed as dist
+from torch.distributed._functional_collectives import all_gather_tensor
 from torch.distributed._local_tensor import (
     local_tensor_mode,
     LocalIntNode,
@@ -652,6 +653,19 @@ class TestLocalTensorWorld4(LocalTensorWorldTest):
             dist_res = torch.cat([d1, d2], dim=-1)
             full_tensor = dist_res.full_tensor()
             self.assertEqual(full_tensor, local_res)
+
+    def test_compile_all_gather(self):
+        fake_pg = dist.distributed_c10d._get_default_group()
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def my_func(x):
+            return all_gather_tensor(x, gather_dim=0, group=fake_pg)
+
+        different_tensors = {r: torch.randn(2, 3) + r for r in range(self.world_size)}
+        with LocalTensorMode(self.world_size):
+            lt = LocalTensor(different_tensors)
+            result = my_func(lt)
+            self.assertEqual(result.shape, torch.Size([8, 3]))
 
 
 class TestLocalTensorWorld8(LocalTensorWorldTest):

--- a/torch/distributed/_local_tensor/__init__.py
+++ b/torch/distributed/_local_tensor/__init__.py
@@ -1240,6 +1240,10 @@ class LocalTensorMode(TorchDispatchMode):
     functions over ranks.
     """
 
+    @classmethod
+    def ignore_compile_internals(cls) -> bool:
+        return True
+
     # What ranks this local tensor mode is operating over
     def __init__(self, ranks: int | frozenset[int]):
         if isinstance(ranks, int):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182667

LocalTensorMode is a debugging mode that simulates SPMD execution on a
single process. It should not affect how torch.compile traces code --
compilation should proceed as if the mode isn't there, and the mode
applies at dispatch time when the compiled code runs.

Override ignore_compile_internals() to return True so dynamo no longer
skips frames when LocalTensorMode is active.

Authored by Claude.