### PR TITLE
Fix test_reconstruction_failure_gb expected string for Python 3.13 Linux

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -872,10 +872,18 @@ User code traceback:
 """,
         )
 
+        # macOS produces NullVariable; Linux produces
+        # LazyVariableTracker(realized: SkipFunctionVariable()).
+        var_attribution = (
+            "NullVariable"
+            if IS_MACOS
+            else "LazyVariableTracker(realized: SkipFunctionVariable())"
+        )
+
         if sys.version_info >= (3, 14) or sys.version_info < (3, 11):
             self.assertExpectedInline(
                 post_munge(_munge_graph_break_message(records[1].getMessage())),
-                """\
+                f"""\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
 
@@ -890,7 +898,7 @@ Reconstruction failure
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0092.html
 
 Stack variable source attribution:
-  LazyVariableTracker(realized: SkipFunctionVariable()) originated from:
+  {var_attribution} originated from:
   File "test_error_messages.py", line N
                 torch._dynamo.graph_break()
 
@@ -904,7 +912,7 @@ User code traceback:
         elif _load_global_has_positions():
             self.assertExpectedInline(
                 post_munge(_munge_graph_break_message(records[1].getMessage())),
-                """\
+                f"""\
 Graph break in user code at test_error_messages.py:N
 Graph Break Reason: Failed to handle graph break gracefully. Skipping the function and falling back to eager. Graph break encountered:
 
@@ -919,7 +927,7 @@ Reconstruction failure
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0092.html
 
 Stack variable source attribution:
-  LazyVariableTracker(realized: SkipFunctionVariable()) originated from:
+  {var_attribution} originated from:
   File "test_error_messages.py", line N
                 torch._dynamo.graph_break()
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -919,7 +919,7 @@ Reconstruction failure
  For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0092.html
 
 Stack variable source attribution:
-  NullVariable originated from:
+  LazyVariableTracker(realized: SkipFunctionVariable()) originated from:
   File "test_error_messages.py", line N
                 torch._dynamo.graph_break()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182672

The _load_global_has_positions() branch hardcoded NullVariable in the
expected source attribution, but the actual output on non-macOS is
LazyVariableTracker(realized: SkipFunctionVariable()). This was a bug
introduced when b433c1f80ea replaced the dynamic IS_MACOS-based helper
with inline assertExpectedInline strings and used the wrong value for
this branch.

Authored by Claude.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @Lucaskabela @jataylo @azahed98