### PR TITLE
Run dynamo-unittest on every commit to main

### DIFF
--- a/.github/workflows/dynamo-unittest.yml
+++ b/.github/workflows/dynamo-unittest.yml
@@ -4,11 +4,12 @@ name: dynamo-unittest
 
 on:
   push:
+    branches:
+      - main
+      - release/*
     tags:
       - ciflow/dynamo/*
   workflow_call:
-  schedule:
-    - cron: 29 8 * * * # about 1:29am PDT
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182674

Add push trigger for main and release/* branches so dynamo-unittest runs on every landed commit instead of only on a daily cron schedule.
Remove the now-redundant cron schedule.

Authored by Claude.