### PR TITLE
docs: convert elastic NUMA and control plane to markdown

### DIFF
--- a/docs/source/elastic/control_plane.md
+++ b/docs/source/elastic/control_plane.md
@@ -1,10 +1,13 @@
-Control Plane
-=============
+# Control Plane
 
+```{eval-rst}
 .. automodule:: torch.distributed.elastic.control_plane
 .. currentmodule:: torch.distributed.elastic.control_plane
+```
 
 This module contains optional helpers that add extra debug and control handlers
 into your application.
 
+```{eval-rst}
 .. autofunction:: torch.distributed.elastic.control_plane.worker_main
+```

--- a/docs/source/elastic/numa.md
+++ b/docs/source/elastic/numa.md
@@ -1,8 +1,8 @@
-.. _numa-api:
+(numa-api)=
 
-NUMA Binding
-============
+# NUMA Binding
 
+```{eval-rst}
 .. automodule:: torch.numa
    :members:
 
@@ -10,3 +10,4 @@ NUMA Binding
    :members:
    :undoc-members:
    :member-order: bysource
+```


### PR DESCRIPTION
## Issue

Fixes #182464

## Summary

Converts `docs/source/elastic/control_plane.rst` and `docs/source/elastic/numa.rst` to MyST Markdown while preserving the page content, labels, and autodoc rendering.

## Testing

- `git diff --check origin/main..HEAD`
- `lintrunner` on `docs/source/elastic/control_plane.md` and `docs/source/elastic/numa.md`
- `sphinx-build -b html source build/html source/elastic/control_plane.md source/elastic/numa.md`
- Verified generated HTML renders the `worker_main` autodoc section and NUMA API sections correctly

Note: `check_doc_redirects.py --base-ref origin/main` reports extension-only renames from `.rst` to `.md`. I did not add those self-redirects because the rendered URLs stay the same.

## Checklist

- [x] Passes lint (`lintrunner`)
- [x] Added/updated tests (focused Sphinx docs build)
- [x] Updated documentation
- [x] Included benchmark results (not applicable; docs-only change)

## Docathon Checklist

- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.

## BC-breaking?

No


cc @svekars @sekyondaMeta @AlannaBurke
