### PR TITLE
docs: convert elastic customization to markdown

### DIFF
--- a/docs/source/elastic/customization.md
+++ b/docs/source/elastic/customization.md
@@ -1,22 +1,19 @@
-Customization
-=============
+# Customization
 
 This section describes how to customize TorchElastic to fit your needs.
 
-Launcher
-------------------------
+## Launcher
 
 The launcher program that ships with TorchElastic
-should be sufficient for most use-cases (see :ref:`launcher-api`).
+should be sufficient for most use-cases (see {ref}`launcher-api`).
 You can implement a custom launcher by
 programmatically creating an agent and passing it specs for your workers as
 shown below.
 
-.. code-block:: python
+```python
+# my_launcher.py
 
-  # my_launcher.py
-
-  if __name__ == "__main__":
+if __name__ == "__main__":
     args = parse_args(sys.argv[1:])
     rdzv_handler = RendezvousHandler(...)
     spec = WorkerSpec(
@@ -37,82 +34,80 @@ shown below.
             print(f"worker 0 return value is: run_result.return_values[0]")
     except Exception ex:
         # handle exception
+```
 
+## Rendezvous Handler
 
-Rendezvous Handler
-------------------------
-
-To implement your own rendezvous, extend ``torch.distributed.elastic.rendezvous.RendezvousHandler``
+To implement your own rendezvous, extend `torch.distributed.elastic.rendezvous.RendezvousHandler`
 and implement its methods.
 
-.. warning:: Rendezvous handlers are tricky to implement. Before you begin
-          make sure you completely understand the properties of rendezvous.
-          Please refer to :ref:`rendezvous-api` for more information.
+```{warning}
+Rendezvous handlers are tricky to implement. Before you begin
+make sure you completely understand the properties of rendezvous.
+Please refer to {ref}`rendezvous-api` for more information.
+```
 
 Once implemented you can pass your custom rendezvous handler to the worker
 spec when creating the agent.
 
-.. code-block:: python
+```python
+spec = WorkerSpec(
+    rdzv_handler=MyRendezvousHandler(params),
+    ...
+)
+elastic_agent = LocalElasticAgent(spec, start_method=start_method)
+elastic_agent.run(spec.role)
+```
 
-    spec = WorkerSpec(
-        rdzv_handler=MyRendezvousHandler(params),
-        ...
-    )
-    elastic_agent = LocalElasticAgent(spec, start_method=start_method)
-    elastic_agent.run(spec.role)
+## Metric Handler
 
-
-Metric Handler
------------------------------
-
-TorchElastic emits platform level metrics (see :ref:`metrics-api`).
+TorchElastic emits platform level metrics (see {ref}`metrics-api`).
 By default metrics are emitted to `/dev/null` so you will not see them.
 To have the metrics pushed to a metric handling service in your infrastructure,
 implement a `torch.distributed.elastic.metrics.MetricHandler` and `configure` it in your
 custom launcher.
 
-.. code-block:: python
+```python
+# my_launcher.py
 
-  # my_launcher.py
+import torch.distributed.elastic.metrics as metrics
 
-  import torch.distributed.elastic.metrics as metrics
+class MyMetricHandler(metrics.MetricHandler):
+    def emit(self, metric_data: metrics.MetricData):
+        # push metric_data to your metric sink
 
-  class MyMetricHandler(metrics.MetricHandler):
-      def emit(self, metric_data: metrics.MetricData):
-          # push metric_data to your metric sink
-
-  def main():
+def main():
     metrics.configure(MyMetricHandler())
 
     spec = WorkerSpec(...)
     agent = LocalElasticAgent(spec)
     agent.run()
+```
 
-Events Handler
------------------------------
+## Events Handler
 
-TorchElastic supports events recording (see :ref:`events-api`).
+TorchElastic supports events recording (see {ref}`events-api`).
 The events module defines API that allows you to record events and
 implement custom EventHandler. EventHandler is used for publishing events
-produced during torchelastic execution to different sources, e.g.  AWS CloudWatch.
+produced during torchelastic execution to different sources, e.g. AWS CloudWatch.
 By default it uses `torch.distributed.elastic.events.NullEventHandler` that ignores
 events. To configure custom events handler you need to implement
 `torch.distributed.elastic.events.EventHandler` interface and `configure` it
 in your custom launcher.
 
-.. code-block:: python
+```python
+# my_launcher.py
 
-  # my_launcher.py
+import torch.distributed.elastic.events as events
 
-  import torch.distributed.elastic.events as events
+class MyEventHandler(events.EventHandler):
+    def record(self, event: events.Event):
+        # process event
 
-  class MyEventHandler(events.EventHandler):
-      def record(self, event: events.Event):
-          # process event
-
-  def main():
+def main():
     events.configure(MyEventHandler())
 
     spec = WorkerSpec(...)
     agent = LocalElasticAgent(spec)
     agent.run()
+```


### PR DESCRIPTION
## Issue

Fixes #182465

## Summary

Converts `docs/source/elastic/customization.rst` to MyST Markdown while preserving the page content, code examples, admonition, and docs links.

## Testing

- `git diff --check origin/main..HEAD`
- `lintrunner` on `docs/source/elastic/customization.md`
- `sphinx-build -b html source build/html source/elastic/customization.md`
- Verified generated HTML renders the section headings, warning admonition, code blocks, and docs links correctly

Note: `check_doc_redirects.py --base-ref origin/main` reports an extension-only rename from `.rst` to `.md`. I did not add that self-redirect because the rendered URL stays the same.

## Checklist

- [x] Passes lint (`lintrunner`)
- [x] Added/updated tests (focused Sphinx docs build)
- [x] Updated documentation
- [x] Included benchmark results (not applicable; docs-only change)

## Docathon Checklist

- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.

## BC-breaking?

No


cc @svekars @sekyondaMeta @AlannaBurke
