### PR TITLE
[Docathon] Document undocumented functions in data.md (6 functions)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1085,21 +1085,21 @@ coverage_ignore_functions = [
     "get_file_binaries_from_pathnames",
     "get_file_pathnames_from_root",
     "match_masks",
-    "validate_input_col",
+    # "validate_input_col",
     "validate_pathname_binary_tuple",
     # torch.utils.data.datapipes.utils.decoder
     "audiohandler",
-    "basichandlers",
+    # "basichandlers",
     "extension_extract_fn",
-    "handle_extension",
+    # "handle_extension",
     "imagehandler",
     "mathandler",
     "videohandler",
     # torch.utils.data.dataset
-    "random_split",
+    # "random_split",
     # torch.utils.data.graph
-    "traverse",
-    "traverse_dps",
+    # "traverse",
+    # "traverse_dps",
     # torch.utils.data.graph_settings
     "apply_random_seed",
     "apply_sharding",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1085,21 +1085,13 @@ coverage_ignore_functions = [
     "get_file_binaries_from_pathnames",
     "get_file_pathnames_from_root",
     "match_masks",
-    # "validate_input_col",
     "validate_pathname_binary_tuple",
     # torch.utils.data.datapipes.utils.decoder
     "audiohandler",
-    # "basichandlers",
     "extension_extract_fn",
-    # "handle_extension",
     "imagehandler",
     "mathandler",
     "videohandler",
-    # torch.utils.data.dataset
-    # "random_split",
-    # torch.utils.data.graph
-    # "traverse",
-    # "traverse_dps",
     # torch.utils.data.graph_settings
     "apply_random_seed",
     "apply_sharding",

--- a/docs/source/data.md
+++ b/docs/source/data.md
@@ -4,6 +4,42 @@
 .. automodule:: torch.utils.data
 ```
 
+```{eval-rst}
+.. currentmodule:: torch.utils.data.dataset
+```
+
+```{eval-rst}
+.. autofunction:: random_split
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.data.datapipes.utils.decoder
+```
+
+```{eval-rst}
+.. autofunction:: basichandlers
+```
+
+```{eval-rst}
+.. autofunction:: handle_extension
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.data.graph
+```
+
+```{eval-rst}
+.. autofunction:: traverse
+```
+
+```{eval-rst}
+.. autofunction:: traverse_dps
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.data
+```
+
 At the heart of PyTorch data loading utility is the {class}`torch.utils.data.DataLoader`
 class. It represents a Python iterable over a dataset, with support for
 
@@ -548,6 +584,8 @@ for batch_ndx, sample in enumerate(loader):
 .. automodule:: torch.utils.data.datapipes.utils.common
 
 .. currentmodule:: torch.utils.data.datapipes.utils.common
+
+.. autofunction:: validate_input_col
 
 .. autosummary::
     :toctree: generated

--- a/docs/source/data.md
+++ b/docs/source/data.md
@@ -4,42 +4,6 @@
 .. automodule:: torch.utils.data
 ```
 
-```{eval-rst}
-.. currentmodule:: torch.utils.data.dataset
-```
-
-```{eval-rst}
-.. autofunction:: random_split
-```
-
-```{eval-rst}
-.. currentmodule:: torch.utils.data.datapipes.utils.decoder
-```
-
-```{eval-rst}
-.. autofunction:: basichandlers
-```
-
-```{eval-rst}
-.. autofunction:: handle_extension
-```
-
-```{eval-rst}
-.. currentmodule:: torch.utils.data.graph
-```
-
-```{eval-rst}
-.. autofunction:: traverse
-```
-
-```{eval-rst}
-.. autofunction:: traverse_dps
-```
-
-```{eval-rst}
-.. currentmodule:: torch.utils.data
-```
-
 At the heart of PyTorch data loading utility is the {class}`torch.utils.data.DataLoader`
 class. It represents a Python iterable over a dataset, with support for
 
@@ -516,7 +480,9 @@ for batch_ndx, sample in enumerate(loader):
 ```
 
 ```{eval-rst}
-.. autofunction:: torch.utils.data.random_split
+.. currentmodule:: torch.utils.data.dataset
+
+.. autofunction:: random_split
 ```
 
 ```{eval-rst}
@@ -546,6 +512,14 @@ for batch_ndx, sample in enumerate(loader):
 ```{eval-rst}
 .. autoclass:: torch.utils.data.distributed.DistributedSampler
 
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.data.graph
+
+.. autofunction:: traverse
+
+.. autofunction:: traverse_dps
 ```
 
 % These modules are documented as part of torch/data listing them here for
@@ -596,4 +570,12 @@ for batch_ndx, sample in enumerate(loader):
 
 ```{eval-rst}
 .. py:module:: torch.utils.data.datapipes.utils
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.data.datapipes.utils.decoder
+
+.. autofunction:: basichandlers
+
+.. autofunction:: handle_extension
 ```

--- a/docs/source/data.md
+++ b/docs/source/data.md
@@ -543,6 +543,27 @@ for batch_ndx, sample in enumerate(loader):
 ```
 
 ```{eval-rst}
+.. py:module:: torch.utils.data.datapipes.utils
+```
+
+```{eval-rst}
+.. currentmodule:: torch.utils.data.datapipes.utils.decoder
+
+.. autofunction:: basichandlers
+
+.. autofunction:: handle_extension
+```
+
+```{eval-rst}
+.. automodule:: torch.utils.data.datapipes.utils.common
+
+.. currentmodule:: torch.utils.data.datapipes.utils.common
+
+.. autofunction:: validate_input_col
+
+```
+
+```{eval-rst}
 .. automodule:: torch.utils.data.datapipes.iter.streamreader
 
 .. currentmodule:: torch.utils.data.datapipes.iter.streamreader
@@ -555,27 +576,11 @@ for batch_ndx, sample in enumerate(loader):
 ```
 
 ```{eval-rst}
-.. automodule:: torch.utils.data.datapipes.utils.common
-
 .. currentmodule:: torch.utils.data.datapipes.utils.common
-
-.. autofunction:: validate_input_col
 
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     StreamWrapper
-```
-
-```{eval-rst}
-.. py:module:: torch.utils.data.datapipes.utils
-```
-
-```{eval-rst}
-.. currentmodule:: torch.utils.data.datapipes.utils.decoder
-
-.. autofunction:: basichandlers
-
-.. autofunction:: handle_extension
 ```

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -44,8 +44,8 @@ def validate_input_col(fn: Callable, input_col: int | tuple | list | None) -> No
         >>> assert validate_input_col(f_def, [1, 2])
 
     Notes:
-        If the function contains variable positional (`inspect.VAR_POSITIONAL`) arguments,
-        for example, f(a, *args), the validator will accept any size of input column
+        If the function contains variable positional (``inspect.VAR_POSITIONAL``) arguments,
+        for example, ``f(a, *args)``, the validator will accept any size of input column
         greater than or equal to the number of positional arguments.
         (in this case, 1).
 


### PR DESCRIPTION
Fixes #182518

## Description

Documents six public `torch.utils.data` APIs by adding Sphinx autodoc directives to `docs/source/data.md` and removing the corresponding entries from `coverage_ignore_functions` in `docs/source/conf.py`.

Documented APIs:
- `torch.utils.data.dataset.random_split`
- `torch.utils.data.datapipes.utils.decoder.basichandlers`
- `torch.utils.data.datapipes.utils.decoder.handle_extension`
- `torch.utils.data.graph.traverse`
- `torch.utils.data.graph.traverse_dps`
- `torch.utils.data.datapipes.utils.common.validate_input_col`

Fixed a small existing RST inline-literal markup issue in the `validate_input_col` docstring so the newly rendered autodoc section builds cleanly.

## Verification

- `make coverage` passes with no undocumented warnings for these APIs.
- `make html` passes.
- Rendered documentation was checked in `docs/build/html/data.html`.

## Screenshots

Attach the rendered screenshots for:
- `random_split` : 
<img width="820" height="733" alt="random_split" src="https://github.com/user-attachments/assets/3ed7b228-71b5-4d83-acff-d78e0d37c960" />

- `basichandlers` :  
<img width="820" height="733" alt="basichandlers" src="https://github.com/user-attachments/assets/bb4c928e-e4c3-4da6-ae64-162a3e9c5f31" />

- `handle_extension` : 
<img width="820" height="733" alt="handle_extension" src="https://github.com/user-attachments/assets/c216bd92-aca0-4f23-9ecd-9efce005634c" />

- `traverse` :
<img width="820" height="733" alt="traverse" src="https://github.com/user-attachments/assets/abef9192-6211-4e3e-9d52-135851553dc4" />

- `traverse_dps` : 
<img width="820" height="733" alt="traverse_dps" src="https://github.com/user-attachments/assets/044d3e45-6a87-4497-ae70-d7b71a0efd26" />

- `validate_input_col` : 
<img width="820" height="733" alt="validate_input_col" src="https://github.com/user-attachments/assets/6bd389aa-f4fc-4d49-9693-f7a67fb1c337" />


## Checklist

<!-- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request


cc @svekars @sekyondaMeta @AlannaBurke