### PR TITLE
Fix typos in comment and deprecation message

### DIFF
--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -567,7 +567,7 @@ void initJITBindings(PyObject* module) {
             arg_spec_creator.specializeTypes(*graph, spec);
             // We only get partial specialization from the arg_spec_creator, but
             // we want full shape specialization. The alternative would be to
-            // have a "complete type inference" function in ArguemntSpecCreator.
+            // have a "complete type inference" function in ArgumentSpecCreator.
             auto g_inputs = graph->inputs();
             for (const auto i : c10::irange(inputs.size())) {
               if (stack[i].isTensor()) {

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -46,7 +46,7 @@ def _addindent(s_, numSpaces):
 
 @deprecated(
     "`nn.Container` is deprecated. "
-    "All of it's functionality is now implemented in `nn.Module`. Subclass that instead.",
+    "All of its functionality is now implemented in `nn.Module`. Subclass that instead.",
     category=FutureWarning,
 )
 class Container(Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182685

Fix "ArguemntSpecCreator" → "ArgumentSpecCreator" in a JIT code comment,
and "it's" → "its" (possessive) in the nn.Container deprecation message.

Authored with Claude (typo_terminator2).