### PR TITLE
Fix typo "constrains" → "constraints" in FlightRecorder.hpp

### DIFF
--- a/torch/csrc/distributed/c10d/FlightRecorder.hpp
+++ b/torch/csrc/distributed/c10d/FlightRecorder.hpp
@@ -58,7 +58,7 @@ DEFINE_CONSTANT(thread_name_key, "thread_name")
 #undef DEFINE_CONSTANT
 
 // Write NCCL debug info to local disk or any storage users define.
-// There are some constrains we set for the debug info writer:
+// There are some constraints we set for the debug info writer:
 // 1. The writer should only be registered once.
 // 2. Once registered, users cannot change it including un-register.
 // 3. It is recommended to register the customized writer in the trainer setup,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182686

The comment describing the debug info writer constraints had
"constrains" instead of "constraints".

Authored with Claude (typo_terminator2).