### PR TITLE
Support generator arg in dirichlet and beta torch.distributions API

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -4011,6 +4011,55 @@ class TestDistributions(DistributionsTestCase):
         self.assertEqual(frac_zeros, 0.5, atol=0.12, rtol=0)
         self.assertEqual(frac_ones, 0.5, atol=0.12, rtol=0)
 
+    def test_dirichlet_generator(self):
+        # Test that passing a generator produces reproducible samples
+        concentration = torch.tensor([0.5, 0.5, 0.5])
+        gen1 = torch.Generator().manual_seed(12345)
+        gen2 = torch.Generator().manual_seed(12345)
+        d1 = Dirichlet(concentration, generator=gen1)
+        d2 = Dirichlet(concentration, generator=gen2)
+        self.assertEqual(d1.sample((5,)), d2.sample((5,)))
+
+    def test_dirichlet_generator_different_seeds(self):
+        # Test that different seeds give different samples
+        concentration = torch.tensor([2.0, 3.0, 5.0])
+        gen1 = torch.Generator().manual_seed(1)
+        gen2 = torch.Generator().manual_seed(2)
+        d1 = Dirichlet(concentration, generator=gen1)
+        d2 = Dirichlet(concentration, generator=gen2)
+        s1 = d1.sample((100,))
+        s2 = d2.sample((100,))
+        self.assertFalse(torch.allclose(s1, s2))
+
+    def test_beta_generator(self):
+        # Test that passing a generator produces reproducible samples
+        gen1 = torch.Generator().manual_seed(12345)
+        gen2 = torch.Generator().manual_seed(12345)
+        b1 = Beta(2.0, 5.0, generator=gen1)
+        b2 = Beta(2.0, 5.0, generator=gen2)
+        self.assertEqual(b1.sample((5,)), b2.sample((5,)))
+
+    def test_beta_generator_different_seeds(self):
+        # Test that different seeds give different samples
+        gen1 = torch.Generator().manual_seed(1)
+        gen2 = torch.Generator().manual_seed(2)
+        b1 = Beta(2.0, 5.0, generator=gen1)
+        b2 = Beta(2.0, 5.0, generator=gen2)
+        s1 = b1.sample((100,))
+        s2 = b2.sample((100,))
+        self.assertFalse(torch.allclose(s1, s2))
+
+    def test_beta_generator_rsample_grad(self):
+        # Test that gradients flow through rsample with a generator
+        gen = torch.Generator().manual_seed(42)
+        con1 = torch.tensor([2.0], requires_grad=True)
+        con0 = torch.tensor([5.0], requires_grad=True)
+        b = Beta(con1, con0, generator=gen)
+        sample = b.rsample()
+        sample.sum().backward()
+        self.assertIsNotNone(con1.grad)
+        self.assertIsNotNone(con0.grad)
+
     @set_default_dtype(torch.double)
     def test_continuous_bernoulli(self):
         p = torch.tensor([0.7, 0.2, 0.4], requires_grad=True)

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -28,6 +28,7 @@ class Beta(ExponentialFamily):
             (often referred to as alpha)
         concentration0 (float or Tensor): 2nd concentration parameter of the distribution
             (often referred to as beta)
+        generator (torch.Generator, optional): a pseudorandom number generator for sampling
     """
 
     # pyrefly: ignore [bad-override]

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -43,6 +43,7 @@ class Beta(ExponentialFamily):
         concentration1: Tensor | float,
         concentration0: Tensor | float,
         validate_args: bool | None = None,
+        generator: torch.Generator | None = None,
     ) -> None:
         if isinstance(concentration1, _Number) and isinstance(concentration0, _Number):
             concentration1_concentration0 = torch.tensor(
@@ -56,7 +57,9 @@ class Beta(ExponentialFamily):
                 [concentration1, concentration0], -1
             )
         self._dirichlet = Dirichlet(
-            concentration1_concentration0, validate_args=validate_args
+            concentration1_concentration0,
+            validate_args=validate_args,
+            generator=generator,
         )
         super().__init__(self._dirichlet._batch_shape, validate_args=validate_args)
 

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -49,6 +49,7 @@ class Dirichlet(ExponentialFamily):
     Args:
         concentration (Tensor): concentration parameter of the distribution
             (often referred to as alpha)
+        generator (torch.Generator, optional): a pseudorandom number generator for sampling
     """
 
     # pyrefly: ignore [bad-override]

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -22,8 +22,8 @@ def _Dirichlet_backward(x, concentration, grad_output):
 class _Dirichlet(Function):
     @staticmethod
     # pyrefly: ignore [bad-override]
-    def forward(ctx, concentration):
-        x = torch._sample_dirichlet(concentration)
+    def forward(ctx, concentration, generator=None):
+        x = torch._sample_dirichlet(concentration, generator)
         ctx.save_for_backward(x, concentration)
         return x
 
@@ -32,7 +32,7 @@ class _Dirichlet(Function):
     # pyrefly: ignore [bad-override]
     def backward(ctx, grad_output):
         x, concentration = ctx.saved_tensors
-        return _Dirichlet_backward(x, concentration, grad_output)
+        return _Dirichlet_backward(x, concentration, grad_output), None
 
 
 class Dirichlet(ExponentialFamily):
@@ -62,12 +62,14 @@ class Dirichlet(ExponentialFamily):
         self,
         concentration: Tensor,
         validate_args: bool | None = None,
+        generator: torch.Generator | None = None,
     ) -> None:
         if concentration.dim() < 1:
             raise ValueError(
                 "`concentration` parameter must be at least one-dimensional."
             )
         self.concentration = concentration
+        self.generator = generator
         batch_shape, event_shape = concentration.shape[:-1], concentration.shape[-1:]
         # pyrefly: ignore [bad-argument-type]
         super().__init__(batch_shape, event_shape, validate_args=validate_args)
@@ -85,7 +87,7 @@ class Dirichlet(ExponentialFamily):
     def rsample(self, sample_shape: _size = ()) -> Tensor:
         shape = self._extended_shape(sample_shape)
         concentration = self.concentration.expand(shape)
-        return _Dirichlet.apply(concentration)
+        return _Dirichlet.apply(concentration, self.generator)
 
     def log_prob(self, value):
         if self._validate_args:

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -79,6 +79,7 @@ class Dirichlet(ExponentialFamily):
         new = self._get_checked_instance(Dirichlet, _instance)
         batch_shape = torch.Size(batch_shape)
         new.concentration = self.concentration.expand(batch_shape + self.event_shape)
+        new.generator = self.generator
         super(Dirichlet, new).__init__(
             batch_shape, self.event_shape, validate_args=False
         )


### PR DESCRIPTION
Adds an optional `generator: torch.Generator | None` parameter to `Beta` and `Dirichlet`, enabling users to sample with a custom RNG instead of the global state. This is needed for torchvision transforms (e.g., Mixup, CutMix) to be able to support user defined generators.

Authored with Claude.

cc @fritzo @neerajprad @alicanb @nikitaved