### PR TITLE
[MPS] Sum sliced reduction fix

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ReduceOps.metal
+++ b/aten/src/ATen/native/mps/kernels/ReduceOps.metal
@@ -364,6 +364,35 @@ kernel void sum_reduction(
   }
 }
 
+template <
+    typename TI,
+    typename TO,
+    uint NCHAINS = SUM_NCHAINS,
+    LoadMode MODE = LOAD_IDENTITY>
+kernel void sum_reduction_strided_pass1(
+    constant TI* input [[buffer(0)]],
+    device TO* output [[buffer(1)]],
+    constant NormParams<>& params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]]) {
+  using TA = ::metal::conditional_t<MODE == LOAD_NONZERO, uint, opmath_t<TO>>;
+
+  const uint32_t E = params.reduction_size;
+  const uint32_t base_flat = tgid * E;
+
+  TA acc = 0;
+  for (uint32_t k = tid; k < E; k += tptg) {
+    acc += load_val<MODE>(input[get_input_offset(base_flat + k, 0u, params)]);
+  }
+
+  threadgroup TA shared[MAX_THREADGROUP_SIZE / 32];
+  TA total = c10::metal::threadgroup_sum(shared, acc, tid, tptg);
+  if (tid == 0) {
+    output[tgid] = static_cast<TO>(total);
+  }
+}
+
 // Specialized kernel for reducing a non-innermost dim of a contiguous 2D
 // tensor. Each thread handles one column, iterating over all rows with
 // coalesced reads. Multiple row-workers per threadgroup reduce via shared
@@ -589,11 +618,25 @@ REGISTER_SUM_INNER(half2, half2);
       uint simdgroup_id [[simdgroup_index_in_threadgroup]], \
       uint simdgroup_size [[threads_per_simdgroup]]);
 
-#define REGISTER_SUM(TI, TO) REGISTER_SUM_IMPL(TI, TO, "sum_", LOAD_IDENTITY)
-#define REGISTER_NANSUM(TI, TO) \
-  REGISTER_SUM_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO)
-#define REGISTER_COUNT_NONZERO(TI) \
-  REGISTER_SUM_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO)
+#define REGISTER_SUM_STRIDED_IMPL(TI, TO, PREFIX, MODE)               \
+  template [[host_name(PREFIX "reduction_strided_" #TI "_" #TO)]]     \
+  kernel void sum_reduction_strided_pass1<TI, TO, SUM_NCHAINS, MODE>( \
+      constant TI * input [[buffer(0)]],                              \
+      device TO * output [[buffer(1)]],                               \
+      constant NormParams<> & params [[buffer(2)]],                   \
+      uint tid [[thread_position_in_threadgroup]],                    \
+      uint tptg [[threads_per_threadgroup]],                          \
+      uint tgid [[threadgroup_position_in_grid]]);
+
+#define REGISTER_SUM(TI, TO)                       \
+  REGISTER_SUM_IMPL(TI, TO, "sum_", LOAD_IDENTITY) \
+  REGISTER_SUM_STRIDED_IMPL(TI, TO, "sum_", LOAD_IDENTITY)
+#define REGISTER_NANSUM(TI, TO)                          \
+  REGISTER_SUM_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO) \
+  REGISTER_SUM_STRIDED_IMPL(TI, TO, "nansum_", LOAD_NAN_TO_ZERO)
+#define REGISTER_COUNT_NONZERO(TI)                            \
+  REGISTER_SUM_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO) \
+  REGISTER_SUM_STRIDED_IMPL(TI, long, "count_nonzero_", LOAD_NONZERO)
 
 REGISTER_SUM(float, float);
 REGISTER_SUM(float, half);

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -907,27 +907,32 @@ static void sum_nansum_kernel_mps(TensorIterator& iter, const std::string& kerne
     const auto elems_per_group = reduction_size / num_groups;
 
     auto out_metal = scalarToMetalTypeString(output);
-    auto p1_kernel = fmt::format("{}reduction_{}_{}", kernel_prefix, scalarToMetalTypeString(input), out_metal);
+    auto is_contig = input.is_contiguous();
+    auto p1_kernel = fmt::format(
+        "{}reduction{}_{}_{}", kernel_prefix, is_contig ? "" : "_strided", scalarToMetalTypeString(input), out_metal);
     // Pass 2 combines partials by summing them regardless of pass-1 mode.
     // For count_nonzero the partials are already per-block counts (long);
     // counting them again would be wrong, so always use "sum_" here.
     auto p2_kernel = fmt::format("sum_reduction_{}_{}", out_metal, out_metal);
 
-    // Model as 2D: input is [num_groups, elems_per_group], reduce dim=1
-    // Dim 0 (non-reduced): size=num_groups, input_stride=elems_per_group, output_stride=1
-    // Dim 1 (reduced):     size=elems_per_group, input_stride=1
-    NormParams params1;
-    params1.ndim = 2;
-    params1.p = 0;
+    NormParams params1{};
     params1.reduction_size = elems_per_group;
-    params1.input_sizes[0] = num_groups;
-    params1.input_strides[0] = elems_per_group;
-    params1.output_sizes[0] = num_groups;
-    params1.output_strides[0] = 1;
-    params1.input_sizes[1] = elems_per_group;
-    params1.input_strides[1] = 1;
-    params1.output_sizes[1] = 1;
-    params1.output_strides[1] = 0;
+    if (is_contig) {
+      // Model as 2D: input is [num_groups, elems_per_group], reduce dim=1.
+      params1.ndim = 2;
+      params1.input_sizes[0] = num_groups;
+      params1.input_strides[0] = elems_per_group;
+      params1.output_sizes[0] = num_groups;
+      params1.output_strides[0] = 1;
+      params1.input_sizes[1] = elems_per_group;
+      params1.input_strides[1] = 1;
+    } else {
+      params1.ndim = input.dim();
+      for (const auto d : c10::irange(input.dim())) {
+        params1.input_sizes[d] = input.size(d);
+        params1.input_strides[d] = input.stride(d);
+      }
+    }
 
     // Pass 2: partials[num_groups] -> output[1], reduce dim=0.
     // divisor applies here (not on pass 1), so pass 2 produces

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5108,6 +5108,13 @@ class TestMPS(TestCaseMPS):
 
     # TODO: fold into OpInfo-based consistency tests once there's a hook to
     # exercise the two-pass reduction path for scalar outputs.
+    def test_sum_full_reduction_non_contiguous(self):
+        x = torch.randn((2, 4, 256, 64), device="mps")
+        for s in (x[:, :, 128:, :], x.transpose(-1, -2), x[::2]):
+            self.assertEqual(s.sum().cpu(), s.cpu().sum())
+            self.assertEqual(s.mean().cpu(), s.cpu().mean())
+            self.assertEqual(s.count_nonzero().cpu(), s.cpu().count_nonzero())
+
     def test_sum_full_reduction_repeated(self):
         """Regression test for the two-pass full reduction: when
         reduction_size doesn't divide evenly into num_groups, the last TG


### PR DESCRIPTION
Doing:
```python
import torch
torch.manual_seed(42)
x = torch.randn((2, 4, 256, 64), device="mps")
print("CPU:", x[:, :, 128:, :].cpu().sum().item())
print("MPS:", x[:, :, 128:, :].sum().item())
```

leads to wrong results on the latest main build of torch. This fixes it