### PR TITLE
Convert elastic metrics rST to MyST markdown

### DIFF
--- a/docs/source/elastic/metrics.md
+++ b/docs/source/elastic/metrics.md
@@ -1,31 +1,40 @@
-.. _metrics-api:
+(metrics-api)=
+# Metrics
 
-Metrics
-=========
-
+```{eval-rst}
 .. automodule:: torch.distributed.elastic.metrics
+```
 
+## Metric Handlers
 
-Metric Handlers
------------------
-
+```{eval-rst}
 .. currentmodule:: torch.distributed.elastic.metrics.api
+```
 
 Below are the metric handlers that come included with torchelastic.
 
+```{eval-rst}
 .. autoclass:: MetricHandler
+```
 
+```{eval-rst}
 .. autoclass:: ConsoleMetricHandler
+```
 
+```{eval-rst}
 .. autoclass:: NullMetricHandler
+```
 
+## Methods
 
-
-Methods
-------------
-
+```{eval-rst}
 .. autofunction:: torch.distributed.elastic.metrics.configure
+```
 
+```{eval-rst}
 .. autofunction:: torch.distributed.elastic.metrics.prof
+```
 
+```{eval-rst}
 .. autofunction:: torch.distributed.elastic.metrics.put_metric
+```


### PR DESCRIPTION
Convert elastic/metrics.rst from rST to MyST Markdown.

re: docathon-2026

Fixes #182468

cc @svekars @sekyondaMeta @AlannaBurke