### PR TITLE
Back out "[pytorch] Vectorize indexFuncLargeIndex for contiguous tensors (#175760)" (#182693)

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -38,7 +38,6 @@
 
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/cub.h>
-#include <ATen/cuda/detail/IntegerDivider.cuh>
 #include <c10/util/irange.h>
 #include <c10/core/QScheme.h>
 #include <ATen/native/quantized/AffineQuantizerBase.h>
@@ -1025,7 +1024,7 @@ __global__ void indexFuncSmallIndex(cuda::detail::TensorInfo<T, IndexType> dst,
     // Lua indices begin at 1
     IndexType dstIndex =
         indices.data[cuda::detail::IndexToOffset<const IndicesType, IndexType, IdxDim>::get(srcIndex, indices)];
-    CUDA_KERNEL_ASSERT(dstIndex < static_cast<IndexType>(dstAddDimSize));
+    CUDA_KERNEL_ASSERT(dstIndex < dstAddDimSize);
 
     // We stride over the output ignoring the indexed dimension
     // (innerSize), whose offset calculation is handled differently
@@ -1053,18 +1052,8 @@ __global__ void indexFuncSmallIndex(cuda::detail::TensorInfo<T, IndexType> dst,
 // the number of indices chosen is small, then the
 // indexFuncSmallIndex kernel is a better choice to reduce memory
 // accesses.
-//
-// When VecSize > 1, each thread processes VecSize consecutive elements,
-// amortizing the divmod and index lookup cost.  Boundary cases (where
-// VecSize elements would cross a slice boundary) are handled inline so
-// the dispatch site does not need to check sliceSize alignment or stride.
-// When VecSize == 1 (default), this is the original scalar kernel.
-//
-// Uses IntDivider for fast integer divmod (multiply+shift instead of
-// hardware division).  For uint32_t this is a significant win on
-// non-power-of-2 innerSize; for power-of-2 it matches compiler shifts.
 template <typename T, typename IndicesType, typename IndexType, int DstDim, int SrcDim, int IdxDim,
-          bool IndexIsMajor, int VecSize = 1, typename func_t>
+          bool IndexIsMajor, typename func_t>
 __global__ void indexFuncLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst,
                                     cuda::detail::TensorInfo<const T, IndexType> src,
                                     cuda::detail::TensorInfo<const IndicesType, IndexType> indices,
@@ -1075,86 +1064,37 @@ __global__ void indexFuncLargeIndex(cuda::detail::TensorInfo<T, IndexType> dst,
                                     int64_t dstAddDimSize,
                                     int64_t dstNumel,
                                     const func_t& op,
-                                    T alpha,
-                                    cuda::detail::IntDivider<IndexType> innerSizeDivider) {
-  // Helper to process a single element at linearIndex.
-  auto processElement = [&](IndexType linearIndex) {
-    auto dm = innerSizeDivider.divmod(linearIndex);
+                                    T alpha) {
+  // We stride over the output including the indexed dimension
+  // (totalSize), and calculate the destination index point based on that
+  for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
+       linearIndex < totalSize;
+       linearIndex += gridDim.x * blockDim.x) {
     IndexType srcIndex, elementInSlice;
-    if constexpr (IndexIsMajor) {
-      srcIndex = dm.div;
-      elementInSlice = dm.mod;
-    } else {
-      elementInSlice = dm.div;
-      srcIndex = dm.mod;
+    if (IndexIsMajor) {
+      srcIndex = linearIndex / innerSize;
+      elementInSlice = linearIndex % innerSize;
+    }
+    else {
+      elementInSlice = linearIndex / innerSize;
+      srcIndex = linearIndex % innerSize;
     }
 
+    // Lua indices begin at 1
     IndexType dstIndex =
         indices.data[cuda::detail::IndexToOffset<const IndicesType, IndexType, IdxDim>::get(srcIndex, indices)];
-    CUDA_KERNEL_ASSERT(dstIndex < static_cast<IndexType>(dstAddDimSize));
+    CUDA_KERNEL_ASSERT(dstIndex < dstAddDimSize);
 
     IndexType dstOffset =
-        cuda::detail::IndexToOffset<T, IndexType, DstDim>::get(elementInSlice, dst);
+      cuda::detail::IndexToOffset<T, IndexType, DstDim>::get(elementInSlice, dst);
     dstOffset += dstIndex * dst.strides[dstAddDim];
 
     IndexType srcOffset =
-        cuda::detail::IndexToOffset<const T, IndexType, SrcDim>::get(elementInSlice, src);
+      cuda::detail::IndexToOffset<const T, IndexType, SrcDim>::get(elementInSlice, src);
     srcOffset += srcIndex * src.strides[srcAddDim];
 
     T val = src.data[srcOffset] * alpha;
     op(dst.data, dstOffset, dstNumel, &val);
-  };
-
-  if constexpr (VecSize > 1) {
-    // Round up to include tail elements in the vectorized loop.
-    const IndexType totalVecs = at::ceil_div(totalSize, (IndexType)VecSize);
-    for (IndexType vecIdx = blockIdx.x * blockDim.x + threadIdx.x;
-         vecIdx < totalVecs;
-         vecIdx += gridDim.x * blockDim.x) {
-      IndexType baseLinear = vecIdx * VecSize;
-      auto dm = innerSizeDivider.divmod(baseLinear);
-      IndexType srcIndex = dm.div;
-      IndexType elementBase = dm.mod;
-
-      if (elementBase + VecSize <= innerSize && baseLinear + VecSize <= totalSize) {
-        // Fast path: all VecSize elements are in the same slice and within bounds.
-        // Hoist index lookup outside the unrolled loop.
-        IndexType dstIndex =
-            indices.data[cuda::detail::IndexToOffset<const IndicesType, IndexType, IdxDim>::get(srcIndex, indices)];
-        CUDA_KERNEL_ASSERT(dstIndex < static_cast<IndexType>(dstAddDimSize));
-
-        #pragma unroll
-        for (int v = 0; v < VecSize; ++v) {
-          IndexType elementInSlice = elementBase + v;
-          IndexType dstOffset =
-              cuda::detail::IndexToOffset<T, IndexType, DstDim>::get(elementInSlice, dst);
-          dstOffset += dstIndex * dst.strides[dstAddDim];
-
-          IndexType srcOffset =
-              cuda::detail::IndexToOffset<const T, IndexType, SrcDim>::get(elementInSlice, src);
-          srcOffset += srcIndex * src.strides[srcAddDim];
-
-          T val = src.data[srcOffset] * alpha;
-          op(dst.data, dstOffset, dstNumel, &val);
-        }
-      } else {
-        // Slow path: elements cross a slice boundary or are in the tail.
-        #pragma unroll
-        for (int v = 0; v < VecSize; ++v) {
-          IndexType li = baseLinear + v;
-          if (li < totalSize) {
-            processElement(li);
-          }
-        }
-      }
-    }
-  } else {
-    // Scalar path: one element per thread.
-    for (IndexType linearIndex = blockIdx.x * blockDim.x + threadIdx.x;
-         linearIndex < totalSize;
-         linearIndex += gridDim.x * blockDim.x) {
-      processElement(linearIndex);
-    }
   }
 }
 
@@ -1236,12 +1176,6 @@ void index_add_cuda_impl(const Tensor& self, int64_t dim, const Tensor& index, c
 
   const int mpc = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
 
-  #ifdef USE_ROCM
-    constexpr bool is_rocm = true;
-  #else
-    constexpr bool is_rocm = false;
-  #endif
-
 #define SMALL_INDEX(TENSOR_TYPE, INDICES_TYPE, TYPE, SELF_DIM, SOURCE_DIM, IDX_DIM)     \
   indexFuncSmallIndex<TENSOR_TYPE, INDICES_TYPE, TYPE, SELF_DIM, SOURCE_DIM, IDX_DIM>   \
     <<<smallIndexGrid, smallIndexBlock, 0, stream>>>(                                   \
@@ -1252,19 +1186,13 @@ void index_add_cuda_impl(const Tensor& self, int64_t dim, const Tensor& index, c
 
 #define LARGE_INDEX(TENSOR_TYPE, INDICES_TYPE, TYPE,                        \
                     SELF_DIM, SOURCE_DIM, IDX_DIM, IDX_IS_MAJOR)            \
-  {                                                                          \
-    const TYPE innerSizeVal =                                                \
-        static_cast<TYPE>((IDX_IS_MAJOR) ? sliceSize : numIndex);            \
-    cuda::detail::IntDivider<TYPE> innerSizeDivider(innerSizeVal);           \
-    indexFuncLargeIndex<TENSOR_TYPE, INDICES_TYPE, TYPE,                     \
-                        SELF_DIM, SOURCE_DIM, IDX_DIM,                       \
-                        IDX_IS_MAJOR, (!is_rocm && IDX_IS_MAJOR) ? 4 : 1>    \
-      <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(                     \
-        selfInfo, sourceInfo, indexInfo,                                     \
-        selfAddDim, sourceAddDim, sourceTotalSize,                          \
-        innerSizeVal, selfAddDimSize, selfNumel,                            \
-        reduce_add, alpha_value, innerSizeDivider);                         \
-  }                                                                          \
+  indexFuncLargeIndex<TENSOR_TYPE, INDICES_TYPE, TYPE,                      \
+                      SELF_DIM, SOURCE_DIM, IDX_DIM, IDX_IS_MAJOR>          \
+    <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(                       \
+      selfInfo, sourceInfo, indexInfo,                                      \
+      selfAddDim, sourceAddDim, sourceTotalSize,                            \
+      (IDX_IS_MAJOR) ? sliceSize : numIndex,                                \
+      selfAddDimSize, selfNumel, reduce_add, alpha_value);                  \
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   uint64_t defaultMaxBlockThreads = getDefaultMaxThreadsPerBlock();
@@ -1423,12 +1351,6 @@ void index_reduce_func_cuda_impl(
 
   int mpc = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
 
-  #ifdef USE_ROCM
-    constexpr bool is_rocm = true;
-  #else
-    constexpr bool is_rocm = false;
-  #endif
-
 #define SMALL_INDEX(TENSOR_TYPE, INDICES_TYPE, TYPE, SELF_DIM, SOURCE_DIM, IDX_DIM)                  \
   indexFuncSmallIndex<TENSOR_TYPE, INDICES_TYPE, TYPE, SELF_DIM, SOURCE_DIM, IDX_DIM>                \
     <<<smallIndexGrid, smallIndexBlock, 0, stream>>>(                                                \
@@ -1439,19 +1361,13 @@ void index_reduce_func_cuda_impl(
 
 #define LARGE_INDEX(TENSOR_TYPE, INDICES_TYPE, TYPE,                                     \
                     SELF_DIM, SOURCE_DIM, IDX_DIM, IDX_IS_MAJOR)                         \
-  {                                                                                       \
-    const TYPE innerSizeVal =                                                             \
-        static_cast<TYPE>((IDX_IS_MAJOR) ? sliceSize : numIndex);                         \
-    cuda::detail::IntDivider<TYPE> innerSizeDivider(innerSizeVal);                        \
-    indexFuncLargeIndex<TENSOR_TYPE, INDICES_TYPE, TYPE,                                  \
-                        SELF_DIM, SOURCE_DIM, IDX_DIM,                                     \
-                        IDX_IS_MAJOR, (!is_rocm && IDX_IS_MAJOR) ? 4 : 1>                 \
-      <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(                                   \
-        selfInfo, sourceInfo, indexInfo,                                                   \
-        selfReduceDim, sourceReduceDim, sourceTotalSize,                                  \
-        innerSizeVal, selfReduceDimSize, selfNumel,                                       \
-        reduce_func, alpha_value, innerSizeDivider);                                      \
-  }                                                                                       \
+  indexFuncLargeIndex<TENSOR_TYPE, INDICES_TYPE, TYPE,                                   \
+                     SELF_DIM, SOURCE_DIM, IDX_DIM, IDX_IS_MAJOR>                        \
+    <<<largeIndexGrid, largeIndexBlock, 0, stream>>>(                                    \
+      selfInfo, sourceInfo, indexInfo,                                                   \
+      selfReduceDim, sourceReduceDim, sourceTotalSize,                                   \
+      (IDX_IS_MAJOR) ? sliceSize : numIndex,                                             \
+      selfReduceDimSize, selfNumel, reduce_func, alpha_value);                           \
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   uint64_t defaultMaxBlockThreads = getDefaultMaxThreadsPerBlock();

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -23,7 +23,6 @@ from torch.testing._internal.common_device_type import (
     onlyCPU,
     onlyNativeDeviceTypes,
     onlyOn,
-    skipMPS,
     skipXLA,
     skipXPUIf,
 )
@@ -2022,109 +2021,6 @@ class TestIndexing(TestCase):
                     x0[:, :, index_list[i]] = src[:, :, i]
 
             self.assertEqual(x0, y0, atol=0, rtol=0)
-
-    @onlyNativeDeviceTypes
-    @skipMPS  # https://github.com/pytorch/pytorch/issues/161029
-    @dtypes(torch.float, torch.bfloat16, torch.half)
-    def test_index_add_large_index_vectorized_path(self, device, dtype):
-        # Tests that exercise both the VecSize=4 (vectorized) and VecSize=1
-        # (scalar) paths in the indexFuncLargeIndex CUDA kernel.
-        # VecSize=4 activates when: IndexIsMajor=true, sliceSize % 4 == 0,
-        # and both dst/src have stride-1 on their innermost dimension.
-        # numIndex must be > 16 to hit the LargeIndex kernel at all.
-        #
-        # Strategy: for each shape that hits the vectorized path, also run
-        # the same operation with sliceSize+1 (which forces the scalar path)
-        # and compare both against a CPU float reference.  We use UNIQUE
-        # indices to avoid non-deterministic atomic accumulation ordering.
-        num_idx = 64
-        num_dest = 100
-
-        def _run_and_check(dst_shape, dim, num_idx, num_dest_dim, tag):
-            dst = torch.zeros(dst_shape, dtype=dtype, device=device)
-            src_shape = list(dst_shape)
-            src_shape[dim] = num_idx
-            src = torch.randn(src_shape, dtype=dtype, device=device)
-            index = torch.randperm(num_dest_dim, device=device)[:num_idx]
-
-            # Reference: run the same op on CPU in float
-            dst_ref = dst.detach().cpu().float()
-            src_ref = src.detach().cpu().float()
-            idx_cpu = index.cpu()
-            dst_ref.index_add_(dim, idx_cpu, src_ref)
-
-            dst.index_add_(dim, index, src)
-
-            atol, rtol = (
-                (1e-2, 1e-2) if dtype in (torch.bfloat16, torch.half) else (1e-5, 1e-5)
-            )
-            self.assertEqual(
-                dst.cpu().float(),
-                dst_ref,
-                atol=atol,
-                rtol=rtol,
-                msg=f"Failed for {tag}, shape={dst_shape}, dim={dim}",
-            )
-
-        # --- VecSize=4 path: contiguous, dim=0, sliceSize divisible by 4 ---
-        for slice_size in [32, 128, 256]:
-            _run_and_check(
-                (num_dest, slice_size),
-                0,
-                num_idx,
-                num_dest,
-                f"vec4 sliceSize={slice_size}",
-            )
-
-        # --- VecSize=1 path: sliceSize NOT divisible by 4 ---
-        for slice_size in [3, 17, 33]:
-            _run_and_check(
-                (num_dest, slice_size),
-                0,
-                num_idx,
-                num_dest,
-                f"scalar sliceSize={slice_size}",
-            )
-
-        # --- VecSize=1 path: non-contiguous (stride != 1 on inner dim) ---
-        dst_base = torch.zeros(num_dest, 256, dtype=dtype, device=device)
-        src_base = torch.randn(num_idx, 256, dtype=dtype, device=device)
-        dst = dst_base[:, ::2]  # shape [100, 128], stride [256, 2]
-        src = src_base[:, ::2]
-        index = torch.randperm(num_dest, device=device)[:num_idx]
-
-        dst_ref = dst.detach().cpu().float().contiguous()
-        src_ref = src.detach().cpu().float().contiguous()
-        dst_ref.index_add_(0, index.cpu(), src_ref)
-        dst.index_add_(0, index, src)
-        atol, rtol = (
-            (1e-2, 1e-2) if dtype in (torch.bfloat16, torch.half) else (1e-5, 1e-5)
-        )
-        self.assertEqual(
-            dst.cpu().float(),
-            dst_ref,
-            atol=atol,
-            rtol=rtol,
-            msg="Failed for non-contiguous (stride-2)",
-        )
-
-        # --- VecSize=1 path: IndexIsMajor=false (dim=1 on row-major tensor) ---
-        _run_and_check(
-            (32, num_dest),
-            1,
-            num_idx,
-            num_dest,
-            "IndexIsMajor=false dim=1",
-        )
-
-        # --- VecSize=4 path: 3-D contiguous, dim=0, sliceSize divisible by 4 ---
-        _run_and_check(
-            (100, 8, 16),
-            0,
-            num_idx,
-            100,
-            "3D vec4 sliceSize=128",
-        )
 
     @onlyNativeDeviceTypes
     @expectedFailureMPS  # See https://github.com/pytorch/pytorch/issues/161029


### PR DESCRIPTION
Summary:

D94314062 introduced a VecSize=4 fast path in indexFuncLargeIndex that amortizes divmod and index lookup by having each thread process consecutive elements.

On uniform-random workloads this gives a ~1.8-2.0x speedup. However, when the index distribution is heavy-tailed (e.g. zipf, or skewed where a few hot rows receive millions of writes), the fast path issues 4 atomicAdds back-to-back from the same warp into consecutive cache lines of the same destination row.

The L2 atomic queue cannot drain between the unrolled rounds, and the resulting serialization causes a 4.7x slowdown on fp32 zipf inputs (and ~2x on bf16). Measured on a B200 with dst=[1.72M,128] and nIdx=7.77M:

{F1989310065}


Proposal https://fb.workplace.com/groups/482605989533128/permalink/1656067795520269/  exhibits highly skewed behavior and saw a regression with the diffs 


We back the current implementation out temporarily and will be following the approach of https://github.com/pytorch/pytorch/pull/182675 instead and address the contention problem

Test Plan: CI

Reviewed By: yjhao

Differential Revision: D104098792


