### PR TITLE
[Docathon] Convert nn.rst from rST to MyST Markdown

### DIFF
--- a/docs/source/nn.md
+++ b/docs/source/nn.md
@@ -1,27 +1,36 @@
+```{eval-rst}
 .. role:: hidden
     :class: hidden-section
+```
 
+```{eval-rst}
 .. toctree::
    :maxdepth: 2
    :hidden:
 
-   nn.aliases.rst
+   nn.aliases
+```
 
-torch.nn
-===================================
+# torch.nn
+
+```{eval-rst}
 .. automodule:: torch.nn
+```
 
 These are the basic building blocks for graphs:
 
+```{eval-rst}
 .. contents:: torch.nn
     :depth: 2
     :local:
     :backlinks: top
+```
 
-
+```{eval-rst}
 .. currentmodule:: torch.nn
+```
 
-
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -31,10 +40,11 @@ These are the basic building blocks for graphs:
     ~parameter.Parameter
     ~parameter.UninitializedParameter
     ~parameter.UninitializedBuffer
+```
 
-Containers
-----------------------------------
+## Containers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -46,10 +56,15 @@ Containers
     ModuleDict
     ParameterList
     ParameterDict
+```
 
 Global Hooks For Module
 
+```{eval-rst}
 .. currentmodule:: torch.nn.modules.module
+```
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -62,12 +77,15 @@ Global Hooks For Module
     register_module_buffer_registration_hook
     register_module_module_registration_hook
     register_module_parameter_registration_hook
+```
 
+```{eval-rst}
 .. currentmodule:: torch
+```
 
-Convolution Layers
-----------------------------------
+## Convolution Layers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -87,10 +105,11 @@ Convolution Layers
     nn.LazyConvTranspose3d
     nn.Unfold
     nn.Fold
+```
 
-Pooling layers
-----------------------------------
+## Pooling layers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -116,10 +135,11 @@ Pooling layers
     nn.AdaptiveAvgPool1d
     nn.AdaptiveAvgPool2d
     nn.AdaptiveAvgPool3d
+```
 
-Padding Layers
---------------
+## Padding Layers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -140,10 +160,11 @@ Padding Layers
     nn.CircularPad1d
     nn.CircularPad2d
     nn.CircularPad3d
+```
 
-Non-linear Activations (weighted sum, nonlinearity)
----------------------------------------------------
+## Non-linear Activations (weighted sum, nonlinearity)
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -174,10 +195,11 @@ Non-linear Activations (weighted sum, nonlinearity)
     nn.Tanhshrink
     nn.Threshold
     nn.GLU
+```
 
-Non-linear Activations (other)
-------------------------------
+## Non-linear Activations (other)
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -188,10 +210,11 @@ Non-linear Activations (other)
     nn.Softmax2d
     nn.LogSoftmax
     nn.AdaptiveLogSoftmaxWithLoss
+```
 
-Normalization Layers
-----------------------------------
+## Normalization Layers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -214,10 +237,11 @@ Normalization Layers
     nn.LayerNorm
     nn.LocalResponseNorm
     nn.RMSNorm
+```
 
-Recurrent Layers
-----------------
+## Recurrent Layers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -230,10 +254,11 @@ Recurrent Layers
     nn.RNNCell
     nn.LSTMCell
     nn.GRUCell
+```
 
-Transformer Layers
-----------------------------------
+## Transformer Layers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -244,10 +269,11 @@ Transformer Layers
     nn.TransformerDecoder
     nn.TransformerEncoderLayer
     nn.TransformerDecoderLayer
+```
 
-Linear Layers
-----------------------------------
+## Linear Layers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -257,10 +283,11 @@ Linear Layers
     nn.Linear
     nn.Bilinear
     nn.LazyLinear
+```
 
-Dropout Layers
---------------
+## Dropout Layers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -272,10 +299,11 @@ Dropout Layers
     nn.Dropout3d
     nn.AlphaDropout
     nn.FeatureAlphaDropout
+```
 
-Sparse Layers
--------------
+## Sparse Layers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -283,10 +311,11 @@ Sparse Layers
 
     nn.Embedding
     nn.EmbeddingBag
+```
 
-Distance Functions
-------------------
+## Distance Functions
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -294,10 +323,11 @@ Distance Functions
 
     nn.CosineSimilarity
     nn.PairwiseDistance
+```
 
-Loss Functions
---------------
+## Loss Functions
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -325,10 +355,11 @@ Loss Functions
     nn.MultiMarginLoss
     nn.TripletMarginLoss
     nn.TripletMarginWithDistanceLoss
+```
 
-Vision Layers
-----------------
+## Vision Layers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -339,22 +370,30 @@ Vision Layers
     nn.Upsample
     nn.UpsamplingNearest2d
     nn.UpsamplingBilinear2d
+```
 
-Shuffle Layers
-----------------
+## Shuffle Layers
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
     :template: classtemplate.rst
 
     nn.ChannelShuffle
+```
 
-DataParallel Layers (multi-GPU, distributed)
---------------------------------------------
+## DataParallel Layers (multi-GPU, distributed)
+
+```{eval-rst}
 .. automodule:: torch.nn.parallel
-.. currentmodule:: torch
+```
 
+```{eval-rst}
+.. currentmodule:: torch
+```
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -362,16 +401,23 @@ DataParallel Layers (multi-GPU, distributed)
 
     nn.DataParallel
     nn.parallel.DistributedDataParallel
+```
 
-Utilities
----------
+## Utilities
+
+```{eval-rst}
 .. automodule:: torch.nn.utils
+```
 
-From the ``torch.nn.utils`` module:
+From the `torch.nn.utils` module:
 
 Utility functions to clip parameter gradients.
 
+```{eval-rst}
 .. currentmodule:: torch.nn.utils
+```
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -381,18 +427,22 @@ Utility functions to clip parameter gradients.
     clip_grad_value_
     get_total_norm
     clip_grads_with_norm_
+```
 
 Utility functions to flatten and unflatten Module parameters to and from a single vector.
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     parameters_to_vector
     vector_to_parameters
+```
 
 Utility functions to fuse Modules with BatchNorm modules.
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -401,18 +451,22 @@ Utility functions to fuse Modules with BatchNorm modules.
     fuse_conv_bn_weights
     fuse_linear_bn_eval
     fuse_linear_bn_weights
+```
 
 Utility functions to convert Module parameter memory formats.
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     convert_conv2d_weight_memory_format
     convert_conv3d_weight_memory_format
+```
 
 Utility functions to apply and remove weight normalization from Module parameters.
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -421,17 +475,21 @@ Utility functions to apply and remove weight normalization from Module parameter
     remove_weight_norm
     spectral_norm
     remove_spectral_norm
+```
 
 Utility functions for initializing Module parameters.
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     skip_init
+```
 
 Utility classes and functions for pruning Module parameters.
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -453,10 +511,12 @@ Utility classes and functions for pruning Module parameters.
     prune.custom_from_mask
     prune.remove
     prune.is_pruned
+```
 
 Parametrizations implemented using the new parametrization functionality
-in :func:`torch.nn.utils.parameterize.register_parametrization`.
+in {func}`torch.nn.utils.parameterize.register_parametrization`.
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -464,15 +524,17 @@ in :func:`torch.nn.utils.parameterize.register_parametrization`.
     parametrizations.orthogonal
     parametrizations.weight_norm
     parametrizations.spectral_norm
+```
 
 Utility functions to parametrize Tensors on existing Modules.
 Note that these functions can be used to parametrize a given Parameter
 or Buffer given a specific function that maps from an input space to the
 parametrized space. They are not parameterizations that would transform
 an object into a parameter. See the
-`Parametrizations tutorial <https://pytorch.org/tutorials/intermediate/parametrizations.html>`_
+[Parametrizations tutorial](https://pytorch.org/tutorials/intermediate/parametrizations.html)
 for more information on how to implement your own parametrizations.
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -483,25 +545,34 @@ for more information on how to implement your own parametrizations.
     parametrize.is_parametrized
     parametrize.transfer_parametrizations_and_params
     parametrize.type_before_parametrizations
+```
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
     :template: classtemplate.rst
 
     parametrize.ParametrizationList
+```
 
 Utility functions to call a given Module in a stateless manner.
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     stateless.functional_call
+```
 
 Utility functions in other modules
 
+```{eval-rst}
 .. currentmodule:: torch
+```
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -516,7 +587,9 @@ Utility functions in other modules
     nn.utils.rnn.invert_permutation
     nn.parameter.is_lazy
     nn.factory_kwargs
+```
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -524,27 +597,32 @@ Utility functions in other modules
 
     nn.modules.flatten.Flatten
     nn.modules.flatten.Unflatten
+```
 
-Quantized Functions
---------------------
+## Quantized Functions
 
 Quantization refers to techniques for performing computations and storing tensors at lower bitwidths than
-floating point precision. PyTorch supports both per tensor and per channel asymmetric linear quantization. To learn more how to use quantized functions in PyTorch, please refer to the :ref:`quantization-doc` documentation.
+floating point precision. PyTorch supports both per tensor and per channel asymmetric linear quantization. To learn more how to use quantized functions in PyTorch, please refer to the {ref}`quantization-doc` documentation.
 
-Lazy Modules Initialization
----------------------------
+## Lazy Modules Initialization
 
+```{eval-rst}
 .. currentmodule:: torch
+```
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
     :template: classtemplate.rst
 
     nn.modules.lazy.LazyModuleMixin
+```
 
+% This module needs to be documented. Adding here in the meantime
+% for tracking purposes
 
-.. This module needs to be documented. Adding here in the meantime
-.. for tracking purposes
+```{eval-rst}
 .. py:module:: torch.nn.backends
 .. py:module:: torch.nn.utils.stateless
 .. py:module:: torch.nn.backends.thnn
@@ -592,3 +670,4 @@ Lazy Modules Initialization
 .. py:module:: torch.nn.utils.parametrize
 .. py:module:: torch.nn.utils.prune
 .. py:module:: torch.nn.utils.rnn
+```

--- a/docs/source/nn.md
+++ b/docs/source/nn.md
@@ -19,12 +19,10 @@
 
 These are the basic building blocks for graphs:
 
-```{eval-rst}
-.. contents:: torch.nn
-    :depth: 2
-    :local:
-    :backlinks: top
-```
+```{contents}
+:depth: 2
+:local:
+:backlinks: top
 
 ```{eval-rst}
 .. currentmodule:: torch.nn

--- a/docs/source/nn.md
+++ b/docs/source/nn.md
@@ -23,6 +23,7 @@ These are the basic building blocks for graphs:
 :depth: 2
 :local:
 :backlinks: top
+```
 
 ```{eval-rst}
 .. currentmodule:: torch.nn


### PR DESCRIPTION
## Description
Converts `docs/source/nn.rst` from reStructuredText to MyST Markdown as part of the PyTorch Docathon 2026.

## Checklist
- [X] The issue that is being fixed is referenced in the description ("Fixes #182476")
- [X] Only one issue is addressed in this pull request
- [X] Labels from the issue that this PR is fixing are added to this pull request
- [X] No unnecessary issues are included into this pull request

cc @svekars @sekyondaMeta @AlannaBurke