### PR TITLE
Update FA3 wheel to be the official cuda 13 variant

### DIFF
--- a/.ci/pytorch/test_fa3_abi_stable.sh
+++ b/.ci/pytorch/test_fa3_abi_stable.sh
@@ -16,9 +16,7 @@ env
 echo "Testing FA3 stable wheel still works with currently built torch"
 
 echo "Installing ABI Stable FA3 wheel"
-# The wheel was built on https://github.com/Dao-AILab/flash-attention/commit/3e87e421f898c6919fa417d00e5afcec5909debe
-# on torch 2.10rc for CUDA 12.8
-$MAYBE_SUDO pip -q install https://s3.amazonaws.com/ossci-linux/wheels/flash_attn_3-3.0.0b1-cp39-abi3-linux_x86_64.whl
+$MAYBE_SUDO pip -q install flash-attn-3 –-index-url=https://download.pytorch.org/whl/cu13
 
 pushd flash-attention/hopper
 export FLASH_ATTENTION_ENABLE_OPCHECK=TRUE  # Enable testing for compile on the smoke tests

--- a/.ci/pytorch/test_fa3_abi_stable.sh
+++ b/.ci/pytorch/test_fa3_abi_stable.sh
@@ -16,7 +16,7 @@ env
 echo "Testing FA3 stable wheel still works with currently built torch"
 
 echo "Installing ABI Stable FA3 wheel"
-$MAYBE_SUDO pip -q install flash-attn-3 –-index-url=https://download.pytorch.org/whl/cu13
+$MAYBE_SUDO pip -q install flash-attn-3 --index-url https://download.pytorch.org/whl/cu130
 
 pushd flash-attention/hopper
 export FLASH_ATTENTION_ENABLE_OPCHECK=TRUE  # Enable testing for compile on the smoke tests

--- a/.ci/pytorch/test_fa3_abi_stable.sh
+++ b/.ci/pytorch/test_fa3_abi_stable.sh
@@ -16,6 +16,7 @@ env
 echo "Testing FA3 stable wheel still works with currently built torch"
 
 echo "Installing ABI Stable FA3 wheel"
+$MAYBE_SUDO pip -q install einops ninja
 $MAYBE_SUDO pip -q install flash-attn-3 --index-url https://download.pytorch.org/whl/cu130
 
 pushd flash-attention/hopper

--- a/.github/workflows/_linux-test-stable-fa3.yml
+++ b/.github/workflows/_linux-test-stable-fa3.yml
@@ -1,5 +1,5 @@
 # The point of this workflow is to test that a FA3 wheel that was built based off the
-# stable ABI as of torch nightly 20250830 can still run on the newer torch.
+# stable ABI targeting 2.9 can still run on the newer torch.
 #
 # This workflow is very similar to the _linux-test.yml workflow, with the following
 # differences:


### PR DESCRIPTION
The old workflow was built for CUDA 12.8 which is no longer in our CI. Let's use the new more official cuda 13.0 wheel. We can delete the old wheel from s3 when the time comes.
 
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182695

