### PR TITLE
Fix inductor float16 explicit conversions with reductions

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -2879,6 +2879,23 @@ class CommonTemplate:
 
         self.common(fn, (torch.ones(32, 32) * 70,))
 
+    def test_float16_explicit_cast_with_reduction(self):
+        # Test that explicit float16 conversions are respected in fused reductions
+        x = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4) / 10
+        c = (torch.arange(24) % 5 == 0).reshape(2, 3, 4)
+
+        def fn(x, c):
+            z = torch.where(c, torch.full_like(x, 0.5), torch.full_like(x, -0.5))
+            y = z.to(torch.float16) + x.to(torch.float16)
+            return y, y.float().sum()
+
+        eager_result, eager_sum = fn(x, c)
+        compiled_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+        compiled_result, compiled_sum = compiled_fn(x, c)
+
+        torch.testing.assert_close(compiled_result, eager_result, rtol=0, atol=0)
+        torch.testing.assert_close(compiled_sum, eager_sum, rtol=0, atol=0)
+
     @skip_if_halide
     def test_cummin(self):
         def fn(x):

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -710,7 +710,7 @@ class CppOverrides(OpOverrides):
         expr = V.kernel.get_to_dtype_expr(x, dtype, src_dtype)
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("to_dtype", (x, dtype), {"src_dtype": src_dtype})
-        if dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
+        if use_compute_types and dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
             """
             https://github.com/pytorch/pytorch/issues/115260
             For FusedSchedulerNode[node1, node2], the node2 loads what node1 stores and the buffer is
@@ -1730,7 +1730,7 @@ class CppVecOverrides(CppOverrides):
         expr = V.kernel.get_to_dtype_expr(x, dtype, src_dtype)
         csevar = V.kernel.cse.generate(V.kernel.compute, expr)
         csevar.update_on_args("to_dtype", (x, dtype), {"src_dtype": src_dtype})
-        if dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
+        if use_compute_types and dtype in DTYPE_LOWP_FP and src_dtype == torch.float:
             V.kernel.cache_dtype_convert(x, src_dtype, csevar, dtype)
         return csevar
 

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1129,7 +1129,14 @@ class Pointwise(Loops):
         if self.is_zero_elements():
             return partial(nop_loader_fn, dtype=self.dtype)
 
-        return self.inner_fn
+        inner_fn = self.inner_fn
+        buffer_dtype = self.dtype
+
+        def wrapped_loader(index):
+            value = inner_fn(index)
+            return ops.to_dtype(value, buffer_dtype, use_compute_types=False)
+
+        return wrapped_loader
 
     def __str__(self) -> str:
         return self._to_str(("ranges",))

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -875,10 +875,9 @@ def to_dtype(
         )
         low_pr_fp = (torch.bfloat16, torch.float16)
         if not use_compute_types and dtype in low_pr_fp:
-            # Upcast back to compute type so fused consumers see a compute-type
-            # value. Without this, a raw low-precision value gets a redundant
-            # downcast from the consumer's input emulation.
-            result = ops.to_dtype(result, dtype)
+            result = ops.to_dtype(
+                result, torch.float32, src_dtype=dtype, use_compute_types=False
+            )
         return result
 
     return make_pointwise(_to_dtype, override_return_dtype=dtype)(x)
@@ -944,10 +943,7 @@ def _convert_element_type(x: TensorBox, dtype: torch.dtype):
             )(x, dtype)
     src_dtype = x.get_dtype()
     low_pr_fp = (torch.bfloat16, torch.float16)
-    use_compute_types = not (
-        config.emulate_precision_casts
-        and (src_dtype in low_pr_fp or dtype in low_pr_fp)
-    )
+    use_compute_types = not (src_dtype in low_pr_fp or dtype in low_pr_fp)
     return to_dtype(x, dtype, copy=True, use_compute_types=use_compute_types)
 
 


### PR DESCRIPTION
Fixes #182131 

The root cause was that when users explicitly convert to float16, values should be rounded to 16 bit precision but optimizations in both fused and unfused execution paths were bypassing this rounding. In fused kernels reductions directly used prerounding flaot32 values instead of loading them from the flota16 buffer. And in unfused code path, caching opitmizations allowed skipping the buffer load and reusing the original float32 values. 

I made 3 file changes. In torch/_inductor/lowering.py I removed the config flag dependency that was allowing them to be optimized away by default. Also ensured that when values are upcast to float32 for CPU computation, the system tracks that they came from actual float16 storage to prevent caching shortcuts. 

In torch_inductor/codegen_cppy (unfused path) I prevented the C++ code gen from caching dtype conversions when the buffer is read from memory so reductions that load from the float16 buffer should see the values after float16 rounding has been applied.

And then in ir.py I fixed fused execution path where ops are combined into a single loop and buffer is bypassed entirely. Loader now applies float16 conversion so reductions see values as if they were loaded from the float16 buffer. 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @mlazos