### PR TITLE
Fix "dont" typos across JIT, dynamo, and fx modules

### DIFF
--- a/torch/csrc/dynamo/extra_state.h
+++ b/torch/csrc/dynamo/extra_state.h
@@ -167,7 +167,7 @@ void destroy_extra_state(void* obj);
 //  set_extra_state responsibility to clean it up. It will be deleted during
 //  the reset_code, when the set_extra_state is called with NULL.
 
-// Invariant - Dont set the extra state for the extra state that is already on
+// Invariant - Don't set the extra state for the extra state that is already on
 // the code object. Otherwise, we will first free up the old extra state
 // (which is also the new extra state) and write something invalid on the
 // scratch space.

--- a/torch/csrc/jit/backends/backend_debug_info.h
+++ b/torch/csrc/jit/backends/backend_debug_info.h
@@ -45,10 +45,10 @@ class TORCH_API PyTorchBackendDebugInfo : public torch::CustomClassHolder {
  * __backend_debug_info is of type BackendDebugInfo which is a torchbind'
  * class backed by cpp class PyTorchBackendDebugInfo.
  * PyTorchBackendDebugInfo, depends on ir.h., scope.h, source_range etc.
- * We dont include this on lite interpreter side. Thus on lite interpreter side
+ * We don't include this on lite interpreter side. Thus on lite interpreter side
  * we cannot have valid definition of PyTorchBackendDebugInfo. However we do not
  * need valid instance of __backend_debug_info in lite interpreter anyway as we
- * dont serialize this info as part of LowerdModule as mentioned ealrier.
+ * don't serialize this info as part of LoweredModule as mentioned earlier.
  * However since LoweredModule has registered attribute of __backend_debug_info
  * we still need to make sure that BackendDebugInfo is registered with
  * TorchScript. However in this instance it does not have to be backed by

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -1633,9 +1633,9 @@ void InsertQuantDeQuantHelper::runForOnDevicePTQ(
 
   Method method = module.get_method(method_name);
   auto graph = method.graph();
-  // Unliked the run method we dont need to extract new qparam values for the
+  // Unlike the run method we don't need to extract new qparam values for
   // the same graph used in different call site.
-  // Reason is that for on device PTQ we dont:
+  // Reason is that for on device PTQ we don't:
   // 1. Run calculate_qparams
   // 2. Get the scale and zero point
   // 3. get axis and dtype
@@ -1830,9 +1830,9 @@ Module InsertQuantDeQuantOnDevicePTQ(
   InsertQuantDeQuantHelper h(quant_type, debug);
   h.runForOnDevicePTQ(module, quantize_method_name);
   h.removeObserverNodes(module);
-  // Dont need:
+  // Don't need:
   // ReplicateChooseQParamsQuantDequant: This is propagating dynamic quant's
-  // quant dequant RemoveRedundantQuantizationOps: THis is removing activation
+  // quant dequant RemoveRedundantQuantizationOps: This is removing activation
   // observers for dynamic quant when the op related to it is not dynamically
   // quantizable. Doesn't really make sense. In our case we won't have those
   // anyway since for dynamic quant activations won't be observed We can still

--- a/torch/csrc/jit/passes/quantization/register_packed_params.cpp
+++ b/torch/csrc/jit/passes/quantization/register_packed_params.cpp
@@ -79,11 +79,12 @@ std::unordered_set<std::string> RegisterPrePackParams(
         while (m.hasattr(attr_name)) {
           attr_name = attr_name_base + "_" + std::to_string(uid++);
         }
-        // Now register attribute for this packed param but dont set it to any
-        // value. No value because we dont know what the value is at this point.
-        // Only when we run on-device ptq workflow, e.g. run quantize_forward
-        // method, is when the linear_prepack op will be executed and at that
-        // point we will have the actual value for this attribute.
+        // Now register attribute for this packed param but don't set it to any
+        // value. No value because we don't know what the value is at this
+        // point. Only when we run on-device ptq workflow, e.g. run
+        // quantize_forward method, is when the linear_prepack op will be
+        // executed and at that point we will have the actual value for this
+        // attribute.
         m.register_attribute(attr_name, n->output(0)->type(), IValue());
         // In order to add the output of linear_prepack, we now have to do
         // setAttr Thus when quantize_forward is actually called the attribute

--- a/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
@@ -814,9 +814,9 @@ struct SymbolicShapeGraphAnalyzer {
 
     auto stitched_shape_compute_graph = std::make_shared<Graph>();
     // We want to build up a computational graph which computes all shapes
-    // we dont know statically - that is, all symbolic shapes within
+    // we don't know statically - that is, all symbolic shapes within
     // the region [beg, end). it must be executable before beg.
-    // TODO: dont require dimensions of tensors to be set AOT ?
+    // TODO: don't require dimensions of tensors to be set AOT ?
 
     for (auto it = beg_->iterator(); it != end_->iterator(); it++) {
       auto curr = *it;
@@ -849,7 +849,7 @@ struct SymbolicShapeGraphAnalyzer {
           return std::nullopt;
         }
         auto symbolic_sizes = tt->symbolic_sizes();
-        // TODO: dont require # of dimensions of tensors set ?
+        // TODO: don't require # of dimensions of tensors set ?
         if (!symbolic_sizes.rank()) {
           GRAPH_DEBUG("No rank on output ", getHeader(curr));
           return std::nullopt;

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -697,7 +697,7 @@ void ScriptModuleSerializer::writeByteCode(
     // Note that stripping off debug map will not strip off
     // debug handles.
     // The reason we save debug handles conditionally is so that
-    // we dont end up with a model that has debug handles but has not
+    // we don't end up with a model that has debug handles but has not
     // debug map to correlate debug handles with.
     // Once we have a model with both handles and debug map, we can
     // strip off debug map and have a lean model served to production.
@@ -712,7 +712,7 @@ void ScriptModuleSerializer::writeByteCode(
     // For delegated backends get source ranges that are in the debug info
     // map. Since delegated backend replace original module with lowered
     // module we will not serialize original module's code which is what would
-    // have contained source range. Since we dont have that anymore, extract
+    // have contained source range. Since we don't have that anymore, extract
     // source ranges out of delegated module and store in a separate archive.
     // Note that we must do this first because in order to serialize inlined
     // CS appropriate source_range_tags must have been generated.

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -414,7 +414,7 @@ ExprPtr PolynomialTransformer::mutate(const AddPtr& v) {
   }
 
   // If this is a floating point Add then order of operations is important, we
-  // dont want to combine ops.
+  // don't want to combine ops.
   if (lhs_new->dtype().is_floating_point() ||
       rhs_new->dtype().is_floating_point()) {
     return alloc<Add>(lhs_new, rhs_new);
@@ -598,7 +598,7 @@ ExprPtr PolynomialTransformer::mutate(const SubPtr& v) {
   }
 
   // If this is a floating point Sub then order of operations is important, we
-  // dont want to combine ops.
+  // don't want to combine ops.
   if (lhs_new->dtype().is_floating_point() ||
       rhs_new->dtype().is_floating_point()) {
     return alloc<Sub>(lhs_new, rhs_new);
@@ -938,7 +938,7 @@ ExprPtr PolynomialTransformer::mutate(const MulPtr& v) {
   }
 
   // If this is a floating point Mul then order of operations is important, we
-  // dont want to combine ops.
+  // don't want to combine ops.
   if (lhs_new->dtype().is_floating_point() ||
       rhs_new->dtype().is_floating_point()) {
     return alloc<Mul>(lhs_new, rhs_new);
@@ -1089,7 +1089,7 @@ ExprPtr PolynomialTransformer::mutate(const DivPtr& v) {
   }
 
   // If this is a floating point Div then order of operations is important, we
-  // dont want to combine ops.
+  // don't want to combine ops.
   if (lhs_new->dtype().is_floating_point() ||
       rhs_new->dtype().is_floating_point()) {
     return alloc<Div>(lhs_new, rhs_new);

--- a/torch/fx/experimental/meta_tracer.py
+++ b/torch/fx/experimental/meta_tracer.py
@@ -52,7 +52,7 @@ def torch_nn_relu_override(self: torch.nn.ReLU, x: torch.Tensor) -> torch.Tensor
 def functional_relu_override(x: torch.Tensor, inplace: bool = False) -> torch.Tensor:
     if inplace:
         raise AssertionError(
-            "dont support inplace functional.relu for metatensor analysis"
+            "don't support inplace functional.relu for metatensor analysis"
         )
     return x
 
@@ -69,7 +69,7 @@ def torch_abs_override(
     input: torch.Tensor, *, out: torch.Tensor | None = None
 ) -> torch.Tensor:
     if out is not None:
-        raise AssertionError("Dont support in-place abs for MetaTensor analysis")
+        raise AssertionError("Don't support in-place abs for MetaTensor analysis")
     return input
 
 
@@ -276,7 +276,7 @@ class MetaTracer(torch.fx.Tracer):
 
             # TODO
             if not isinstance(rv, torch.fx.Proxy):
-                raise AssertionError("Dont support composite output yet")
+                raise AssertionError("Don't support composite output yet")
             rv.install_tensor_meta(meta_out)
         except Exception as e:
             warnings.warn(f"Could not compute metadata for {kind} target {target}: {e}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182702

Correct "dont" to "don't" in comments, docstrings, and error messages
across multiple C++ and Python files. Also fix a few adjacent typos:
"ealrier" → "earlier", "LowerdModule" → "LoweredModule",
"THis" → "This", and "Unliked" → "Unlike".

Authored with Claude (typo_terminator2).

cc @EikanWang @jgong5 @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98