### PR TITLE
[MPS] Enhance Im2Col tensor op to avoid unnecessary .contiguous() call

### DIFF
--- a/aten/src/ATen/native/mps/operations/Im2Col.mm
+++ b/aten/src/ATen/native/mps/operations/Im2Col.mm
@@ -43,7 +43,7 @@ static void im2col_out_mps_template(Tensor& output,
   int64_t stride_height = stride[0];
   int64_t stride_width = stride[1];
 
-  Tensor input = input_.contiguous();
+  Tensor input = input_;
 
   bool batched_input = true;
 


### PR DESCRIPTION
Removing the `.contiguous()` call on input tensor as the `im2col()` kernel in Im2Col.metal already supports strided tensors


Benchmarked using following script:
```python
import torch
import torch.nn.functional as F
import torch.utils.benchmark as benchmark

x = torch.randn(4, 64, 1024, 512, device=self._device)[:, :, ::2, :]
self.assertFalse(x.is_contiguous())

_stmt = "F.unfold(x, kernel_size=(1, 1))"

m = benchmark.Timer(
    stmt=_stmt,
    globals={"F": F, "x": x},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

m_c = benchmark.Timer(
    stmt=_stmt,
    globals={"F": F, "x": x.contiguous()},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

print(f"non-contiguous: mean={m.mean   * 1e6:.2f} us  median={m.median   * 1e6:.2f} us  iqr={m.iqr   * 1e6:.2f} us")
print(f"contiguous    : mean={m_c.mean * 1e6:.2f} us  median={m_c.median * 1e6:.2f} us  iqr={m_c.iqr * 1e6:.2f} us")

```


On an M3 Macbook Pro with 48GB memory we observe a 1.25x speedup on non-contiguous tensors:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
9,677.00 | 7,740.15 | 1.25x

And for contiguous tensors we do not observe any performance regression:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
7,729.17 | 7,728.26 | 1.00x



Issue #181946 