### PR TITLE
Add TorchComms backend docs to torch.distributed

### DIFF
--- a/docs/source/distributed.md
+++ b/docs/source/distributed.md
@@ -854,6 +854,85 @@ the new backend.
 The support of third-party backend is experimental and subject to change.
 :::
 
+## TorchComms backend
+
+[TorchComms](https://github.com/meta-pytorch/torchcomms) is an optional
+communication backend for ``torch.distributed``. When enabled, it
+overrides the normal backend instantiation in {func}`init_process_group`
+so that all process groups are created through TorchComms instead of
+the built-in ``ProcessGroup`` implementations.
+
+:::{note}
+TorchComms is experimental and must be installed separately.
+The ``torchcomms`` package must be importable for the flags below to
+take effect.
+:::
+
+### Enabling TorchComms
+
+Set the ``TORCH_DISTRIBUTED_USE_TORCHCOMMS`` environment variable
+before calling {func}`init_process_group`:
+
+```bash
+export TORCH_DISTRIBUTED_USE_TORCHCOMMS=1
+```
+
+Or set the config flag programmatically:
+
+```python
+import torch.distributed.config as dist_config
+
+dist_config.use_torchcomms = True
+```
+
+The ``backend`` argument to {func}`init_process_group` (e.g. ``"nccl"``,
+``"gloo"``) is still respected -- it is forwarded to TorchComms, which
+selects the corresponding vendor plugin. No other application code
+changes are required; all ``torch.distributed`` collective APIs continue
+to work as before.
+
+### Behavior when enabled
+
+When TorchComms is enabled, {func}`init_process_group` changes its
+backend instantiation path for every device/backend pair in the process
+group (except the ``fake`` backend, which is always handled natively):
+
+1. A TorchComms communicator is created via ``torchcomms.new_comm()``
+   using the requested backend string and device.
+2. The communicator is wrapped in a ``_BackendWrapper`` that implements
+   the ``c10d::Backend`` C++ interface, making it a drop-in replacement
+   for the native ``ProcessGroup`` backends.
+3. A ``FlightRecorderHook`` is automatically registered on the
+   communicator. The hook respects the ``TORCH_FR_BUFFER_SIZE`` and
+   ``TORCH_NCCL_TRACE_BUFFER_SIZE`` environment variables for
+   configuring the trace buffer size.
+4. {func}`destroy_process_group` calls ``finalize()`` on TorchComms
+   communicators during cleanup.
+5. {func}`split_group` creates sub-communicators through TorchComms'
+   native splitting rather than constructing a new process group from
+   scratch.
+
+### Eager initialization
+
+TorchComms communicators are eagerly initialized during
+{func}`init_process_group` and only support a single backend device per
+group. The ``device_id`` argument must be specified at initialization
+time:
+
+```python
+dist.init_process_group(backend="nccl", device_id=torch.device("cuda", local_rank))
+```
+
+### Point-to-point operation concurrency
+
+Each TorchComms process group maps 1:1 to a single underlying
+communicator. Point-to-point operations (``send``/``recv``) issued on
+the same group and stream are **not guaranteed to run concurrently**.
+Code that relies on concurrent point-to-point operations must either:
+
+- Use the batched P2P APIs ({func}`batch_isend_irecv`), or
+- Issue the operations on separate groups or communicators.
+
 (distributed-launch)=
 
 ## Launch utility


### PR DESCRIPTION
## Summary
- Adds a new "TorchComms backend" section to `docs/source/distributed.md`
- Documents how to enable TorchComms (`TORCH_DISTRIBUTED_USE_TORCHCOMMS` env var / `dist_config.use_torchcomms`)
- Describes behavior changes when enabled: communicator creation, `_BackendWrapper`, flight recorder integration, `destroy_process_group` cleanup, and `split_group` native splitting
- Documents eager initialization requirement (`device_id` must be specified)
- Documents P2P concurrency semantics (same-group send/recv not guaranteed concurrent; use `batch_isend_irecv` or separate groups)

## Test plan
- Documentation-only change, no code changes