### PR TITLE
[MPS] Enhance Linear tensor ops to avoid unnecessary .contiguous() calls on weight tensor

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -219,8 +219,6 @@ static Tensor _mps_linear_backward_input(IntArrayRef input_size, const Tensor& g
   TORCH_CHECK(supportedFloatingOrComplexType(grad_output),
               "MPS device does not support linear backward for non-float inputs");
 
-  const Tensor weight_reshaped = weight.is_contiguous() ? weight : weight.contiguous();
-
   struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* weightTensor_ = nil;
@@ -237,9 +235,9 @@ static Tensor _mps_linear_backward_input(IntArrayRef input_size, const Tensor& g
   MPSStream* stream = getCurrentMPSStream();
 
   @autoreleasepool {
-    std::string key = "mps_linear_backward_input" + getTensorsStringKey({grad_output, weight_reshaped});
+    std::string key = "mps_linear_backward_input" + getTensorsStringKey({grad_output, weight});
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto* mpsGraph, auto* newCachedGraph) {
-      newCachedGraph->weightTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, weight_reshaped);
+      newCachedGraph->weightTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, weight);
       newCachedGraph->gradOutputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
 
       // MPS matrixMultiplication crashes for 5D+ tensors on 14.2.1 with `New volume should match old volume`
@@ -259,7 +257,7 @@ static Tensor _mps_linear_backward_input(IntArrayRef input_size, const Tensor& g
       newCachedGraph->outputTensor_ = outputTensor;
     });
 
-    Placeholder weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight_reshaped);
+    Placeholder weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight);
     Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
 


### PR DESCRIPTION
### Summary:
- Removing `.contiguous()` call on `weight` tensor as it goes through Placeholder which natively makes tensor contiguous on any device running macOS < 15.0 without strided tensor support.


### Performance Analysis:
Benchmarked using following script:
```python
import torch
import torch.nn.functional as F
import torch.utils.benchmark as benchmark


x = torch.randn(512, 2048, device=self._device, requires_grad=True)
w = torch.randn(2048, 4096, device=self._device)
w_nc = w.t()  # (4096, 2048), strides (1, 2048), non-contiguous
self.assertFalse(w_nc.is_contiguous())
# Pre-compute forward outputs and grad to isolate backward cost
out_nc = F.linear(x, w_nc)
grad = torch.ones_like(out_nc)

_stmt = "out.backward(grad, retain_graph=True)"

m = benchmark.Timer(
    stmt=_stmt,
    globals={"out": out_nc, "grad": grad},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

out_c = F.linear(x, w_nc.contiguous())

m_c = benchmark.Timer(
    stmt=_stmt,
    globals={"out": out_c, "grad": grad},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

print(f"non-contiguous: mean={m.mean   * 1e6:.2f} us  median={m.median   * 1e6:.2f} us  iqr={m.iqr   * 1e6:.2f} us")
print(f"contiguous    : mean={m_c.mean * 1e6:.2f} us  median={m_c.median * 1e6:.2f} us  iqr={m_c.iqr * 1e6:.2f} us")

```

On an M3 Macbook Pro with 48GB memory we observe a 1.77x speedup on non-contiguous tensors:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
1,613.97 | 912.29 | 1.77x

And for contiguous tensors we do not observe any performance regression:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
856.26 | 849.40 | 1.01x


### Correctness Analysis:
- Locally tested through an expanded version of the OpsInfo noncontig tests (PR [#183759](https://github.com/pytorch/pytorch/pull/183759)) that covers several more complicated cases of non-contiguity. 
- MPS Results show this modification introduces no regressions (existing bugs that were uncovered through the test expansion are excluded through XFail).


**Pytorch** | **Passed** | **Skipped** | **Deselected** | **XFailed**
------------ | ----------- | ------------ | --------------- | ------------
Baseline       | 16384 | 1074 | 53457 | 1052
Updated       | 16384 | 1074 | 53457 | 1052



Issue #181946 