### PR TITLE
[Docathon 2026] Convert torch.rst to MyST Markdown

### DIFF
--- a/docs/source/torch.md
+++ b/docs/source/torch.md
@@ -1,10 +1,16 @@
-torch
-=====
-.. automodule:: torch
-.. currentmodule:: torch
+# torch
 
-Tensors
--------
+```{eval-rst}
+.. automodule:: torch
+```
+
+```{eval-rst}
+.. currentmodule:: torch
+```
+
+## Tensors
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -27,26 +33,28 @@ Tensors
     numel
     set_printoptions
     set_flush_denormal
+```
 
-.. _tensor-creation-ops:
+(tensor-creation-ops)=
 
-Creation Ops
-~~~~~~~~~~~~
+### Creation Ops
 
-.. note::
-    Random sampling creation ops are listed under :ref:`random-sampling` and
-    include:
-    :func:`torch.rand`
-    :func:`torch.rand_like`
-    :func:`torch.randn`
-    :func:`torch.randn_like`
-    :func:`torch.randint`
-    :func:`torch.randint_like`
-    :func:`torch.randperm`
-    You may also use :func:`torch.empty` with the :ref:`inplace-random-sampling`
-    methods to create :class:`torch.Tensor` s with values sampled from a broader
-    range of distributions.
+:::{note}
+Random sampling creation ops are listed under {ref}`random-sampling` and
+include:
+{func}`torch.rand`
+{func}`torch.rand_like`
+{func}`torch.randn`
+{func}`torch.randn_like`
+{func}`torch.randint`
+{func}`torch.randint_like`
+{func}`torch.randperm`
+You may also use {func}`torch.empty` with the {ref}`inplace-random-sampling`
+methods to create {class}`torch.Tensor` s with values sampled from a broader
+range of distributions.
+:::
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -88,11 +96,13 @@ Creation Ops
     polar
     scalar_tensor
     heaviside
+```
 
-.. _indexing-slicing-joining:
+(indexing-slicing-joining)=
 
-Indexing, Slicing, Joining, Mutating Ops
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+### Indexing, Slicing, Joining, Mutating Ops
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -181,54 +191,60 @@ Indexing, Slicing, Joining, Mutating Ops
     vsplit
     vstack
     where
+```
 
-.. _accelerators:
+(accelerators)=
 
-Accelerators
-----------------------------------
-Within the PyTorch repo, we define an "Accelerator" as a :class:`torch.device` that is being used
+## Accelerators
+
+Within the PyTorch repo, we define an "Accelerator" as a {class}`torch.device` that is being used
 alongside a CPU to speed up computation. These devices use an asynchronous execution scheme,
-using :class:`torch.Stream` and :class:`torch.Event` as their main way to perform synchronization.
+using {class}`torch.Stream` and {class}`torch.Event` as their main way to perform synchronization.
 We also assume that only one such accelerator can be available at once on a given host. This allows
 us to use the current accelerator as the default device for relevant concepts such as pinned memory,
 Stream device_type, FSDP, etc.
 
-As of today, accelerator devices are (in no particular order) :doc:`"CUDA" <cuda>`, :doc:`"MTIA" <mtia>`,
-:doc:`"XPU" <xpu>`, :doc:`"MPS" <mps>`, "HPU", and PrivateUse1 (many device not in the PyTorch repo itself).
+As of today, accelerator devices are (in no particular order) {doc}`"CUDA" <cuda>`, {doc}`"MTIA" <mtia>`,
+{doc}`"XPU" <xpu>`, {doc}`"MPS" <mps>`, "HPU", and PrivateUse1 (many device not in the PyTorch repo itself).
 
 Many tools in the PyTorch Ecosystem use fork to create subprocesses (for example dataloading
 or intra-op parallelism), it is thus important to delay as much as possible any
 operation that would prevent further forks. This is especially important here as most accelerator's initialization has such effect.
-In practice, you should keep in mind that checking :func:`torch.accelerator.current_accelerator`
+In practice, you should keep in mind that checking {func}`torch.accelerator.current_accelerator`
 is a compile-time check by default, it is thus always fork-safe.
-On the contrary, passing the ``check_available=True`` flag to this function or calling
-:func:`torch.accelerator.is_available()` will usually prevent later fork.
+On the contrary, passing the `check_available=True` flag to this function or calling
+{func}`torch.accelerator.is_available()` will usually prevent later fork.
 
 Some backends provide an experimental opt-in option to make the runtime availability
-check fork-safe. When using the CUDA device ``PYTORCH_NVML_BASED_CUDA_CHECK=1`` can be
+check fork-safe. When using the CUDA device `PYTORCH_NVML_BASED_CUDA_CHECK=1` can be
 used for example.
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     Stream
     Event
+```
 
-.. _generators:
+(generators)=
 
-Generators
-----------------------------------
+## Generators
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     Generator
+```
 
-.. _random-sampling:
+(random-sampling)=
 
-Random sampling
-----------------------------------
+## Random sampling
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -238,16 +254,21 @@ Random sampling
     initial_seed
     get_rng_state
     set_rng_state
+```
 
+```{eval-rst}
 .. autoattribute:: torch.default_generator
    :annotation:  Returns the default CPU torch.Generator
+```
 
-.. The following doesn't actually seem to exist.
-   https://github.com/pytorch/pytorch/issues/27780
-   .. autoattribute:: torch.cuda.default_generators
-      :annotation:  If cuda is available, returns a tuple of default CUDA torch.Generator-s.
-                    The number of CUDA torch.Generator-s returned is equal to the number of
-                    GPUs available in the system.
+% The following doesn't actually seem to exist.
+% https://github.com/pytorch/pytorch/issues/27780
+% .. autoattribute:: torch.cuda.default_generators
+%    :annotation:  If cuda is available, returns a tuple of default CUDA torch.Generator-s.
+%                  The number of CUDA torch.Generator-s returned is equal to the number of
+%                  GPUs available in the system.
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -263,51 +284,64 @@ Random sampling
     randn
     randn_like
     randperm
+```
 
-.. _inplace-random-sampling:
+(inplace-random-sampling)=
 
-In-place random sampling
-~~~~~~~~~~~~~~~~~~~~~~~~
+### In-place random sampling
 
 There are a few more in-place random sampling functions defined on Tensors as well. Click through to refer to their documentation:
 
-- :func:`torch.Tensor.bernoulli_` - in-place version of :func:`torch.bernoulli`
-- :func:`torch.Tensor.cauchy_` - numbers drawn from the Cauchy distribution
-- :func:`torch.Tensor.exponential_` - numbers drawn from the exponential distribution
-- :func:`torch.Tensor.geometric_` - elements drawn from the geometric distribution
-- :func:`torch.Tensor.log_normal_` - samples from the log-normal distribution
-- :func:`torch.Tensor.normal_` - in-place version of :func:`torch.normal`
-- :func:`torch.Tensor.random_` - numbers sampled from the discrete uniform distribution
-- :func:`torch.Tensor.uniform_` - numbers sampled from the continuous uniform distribution
+- {func}`torch.Tensor.bernoulli_` - in-place version of {func}`torch.bernoulli`
+- {func}`torch.Tensor.cauchy_` - numbers drawn from the Cauchy distribution
+- {func}`torch.Tensor.exponential_` - numbers drawn from the exponential distribution
+- {func}`torch.Tensor.geometric_` - elements drawn from the geometric distribution
+- {func}`torch.Tensor.log_normal_` - samples from the log-normal distribution
+- {func}`torch.Tensor.normal_` - in-place version of {func}`torch.normal`
+- {func}`torch.Tensor.random_` - numbers sampled from the discrete uniform distribution
+- {func}`torch.Tensor.uniform_` - numbers sampled from the continuous uniform distribution
 
-Quasi-random sampling
-~~~~~~~~~~~~~~~~~~~~~
+### Quasi-random sampling
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
     :template: sobolengine.rst
 
     quasirandom.SobolEngine
+```
 
-Serialization
-----------------------------------
+## Serialization
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     save
     load
+```
 
+```{eval-rst}
 .. currentmodule:: torch.serialization
+```
 
+```{eval-rst}
 .. autofunction:: check_module_version_greater_or_equal
+```
 
+```{eval-rst}
 .. autofunction:: default_restore_location
+```
 
+```{eval-rst}
 .. currentmodule:: torch
+```
 
-Parallelism
-----------------------------------
+## Parallelism
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -319,41 +353,45 @@ Parallelism
     get_num_interop_threads
     set_num_interop_threads
     wait
+```
 
-.. _torch-rst-local-disable-grad:
+(torch-rst-local-disable-grad)=
 
-Locally disabling gradient computation
---------------------------------------
-The context managers :func:`torch.no_grad`, :func:`torch.enable_grad`, and
-:func:`torch.set_grad_enabled` are helpful for locally disabling and enabling
-gradient computation. See :ref:`locally-disable-grad` for more details on
-their usage.  These context managers are thread local, so they won't
-work if you send work to another thread using the ``threading`` module, etc.
+## Locally disabling gradient computation
 
-Examples::
+The context managers {func}`torch.no_grad`, {func}`torch.enable_grad`, and
+{func}`torch.set_grad_enabled` are helpful for locally disabling and enabling
+gradient computation. See {ref}`locally-disable-grad` for more details on
+their usage. These context managers are thread local, so they won't
+work if you send work to another thread using the `threading` module, etc.
 
-  >>> x = torch.zeros(1, requires_grad=True)
-  >>> with torch.no_grad():
-  ...     y = x * 2
-  >>> y.requires_grad
-  False
+Examples:
 
-  >>> is_train = False
-  >>> with torch.set_grad_enabled(is_train):
-  ...     y = x * 2
-  >>> y.requires_grad
-  False
+```
+>>> x = torch.zeros(1, requires_grad=True)
+>>> with torch.no_grad():
+...     y = x * 2
+>>> y.requires_grad
+False
 
-  >>> torch.set_grad_enabled(True)  # this can also be used as a function
-  >>> y = x * 2
-  >>> y.requires_grad
-  True
+>>> is_train = False
+>>> with torch.set_grad_enabled(is_train):
+...     y = x * 2
+>>> y.requires_grad
+False
 
-  >>> torch.set_grad_enabled(False)
-  >>> y = x * 2
-  >>> y.requires_grad
-  False
+>>> torch.set_grad_enabled(True)  # this can also be used as a function
+>>> y = x * 2
+>>> y.requires_grad
+True
 
+>>> torch.set_grad_enabled(False)
+>>> y = x * 2
+>>> y.requires_grad
+False
+```
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -364,23 +402,24 @@ Examples::
     is_grad_enabled
     autograd.grad_mode.inference_mode
     is_inference_mode_enabled
+```
 
-Math operations
----------------
+## Math operations
 
-Constants
-~~~~~~~~~~~~~~~~~~~~~~
+### Constants
 
+```{eval-rst}
 ======================================= ===========================================
 ``e``                                       Euler's number, the base of natural logarithms (~2.7183). Alias for :attr:`math.e`.
 ``inf``                                     A floating-point positive infinity. Alias for :attr:`math.inf`.
 ``nan``                                     A floating-point "not a number" value. This value is not a legal number. Alias for :attr:`math.nan`.
 ``pi``                                      The ratio of a circle's circumference to its diameter (~3.1416). Alias for :attr:`math.pi`.
 ======================================= ===========================================
+```
 
-Pointwise Ops
-~~~~~~~~~~~~~~~~~~~~~~
+### Pointwise Ops
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -549,9 +588,11 @@ Pointwise Ops
     xlogy
     xlogy_
     zero_
+```
 
-Reduction Ops
-~~~~~~~~~~~~~~~~~~~~~~
+### Reduction Ops
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -588,9 +629,11 @@ Reduction Ops
     var_mean
     count_nonzero
     hash_tensor
+```
 
-Comparison Ops
-~~~~~~~~~~~~~~~~~~~~~~
+### Comparison Ops
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -626,9 +669,11 @@ Comparison Ops
     topk
     msort
 
+```
 
-Spectral Ops
-~~~~~~~~~~~~~~~~~~~~~~
+### Spectral Ops
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -641,10 +686,11 @@ Spectral Ops
     hann_window
     kaiser_window
 
+```
 
-Other Operations
-~~~~~~~~~~~~~~~~~~~~~~
+### Other Operations
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -826,9 +872,11 @@ Other Operations
     resolve_conj
     resolve_neg
 
+```
 
-BLAS and LAPACK Operations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+### BLAS and LAPACK Operations
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -878,14 +926,16 @@ BLAS and LAPACK Operations
     cumulative_trapezoid
     triangular_solve
     vdot
+```
 
-Foreach Operations
-~~~~~~~~~~~~~~~~~~
+### Foreach Operations
 
-.. warning::
-    This API is in beta and subject to future changes.
-    Forward-mode AD is not supported.
+:::{warning}
+This API is in beta and subject to future changes.
+Forward-mode AD is not supported.
+:::
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -946,9 +996,11 @@ Foreach Operations
     _foreach_trunc
     _foreach_trunc_
     _foreach_zero_
+```
 
-Utilities
-----------------------------------
+## Utilities
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -1005,23 +1057,33 @@ Utilities
     vmap
     _assert
     typename
+```
 
-Type Information
-----------------
+## Type Information
+
+```{eval-rst}
 .. autoclass:: TensorType
     :no-members:
+```
 
-Symbolic Numbers
-----------------
+## Symbolic Numbers
+
+```{eval-rst}
 .. autoclass:: SymInt
     :members:
+```
 
+```{eval-rst}
 .. autoclass:: SymFloat
     :members:
+```
 
+```{eval-rst}
 .. autoclass:: SymBool
     :members:
+```
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -1037,93 +1099,158 @@ Symbolic Numbers
     sym_ite
     sym_sqrt
     sym_sum
+```
 
-Export Path
--------------
+## Export Path
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
+```
 
-.. warning::
-    This feature is a prototype and may have compatibility breaking changes in the future.
+:::{warning}
+This feature is a prototype and may have compatibility breaking changes in the future.
 
-    export
-    generated/exportdb/index
+export
+generated/exportdb/index
+:::
 
-Control Flow
-------------
+## Control Flow
 
-.. warning::
-    This feature is a prototype and may have compatibility breaking changes in the future.
+:::{warning}
+This feature is a prototype and may have compatibility breaking changes in the future.
+:::
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     cond
+```
 
-Optimizations
--------------
+## Optimizations
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     compile
+```
 
-`torch.compile documentation <https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler.html>`__
+[torch.compile documentation](https://docs.pytorch.org/docs/main/user_guide/torch_compiler/torch.compiler.html)
 
-Operator Tags
-------------------------------------
+## Operator Tags
+
+```{eval-rst}
 .. autoclass:: Tag
     :members:
+```
 
-.. Empty submodules added only for tracking.
+% Empty submodules added only for tracking.
+
+```{eval-rst}
 .. py:module:: torch.contrib
+```
+
+```{eval-rst}
 .. py:module:: torch.utils.backcompat
+```
 
-.. This module is only used internally for ROCm builds.
+% This module is only used internally for ROCm builds.
+
+```{eval-rst}
 .. py:module:: torch.utils.hipify
+```
 
+```{eval-rst}
 .. py:module:: torch.utils.model_dump
+```
 
+```{eval-rst}
 .. currentmodule:: torch.utils.model_dump
+```
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     get_inline_skeleton
     get_model_info
+```
 
+```{eval-rst}
 .. py:module:: torch.utils.viz
+```
+
+```{eval-rst}
 .. py:module:: torch.quasirandom
+```
+
+```{eval-rst}
 .. py:module:: torch.return_types
+```
+
+```{eval-rst}
 .. automodule:: torch.serialization
+```
 
+```{eval-rst}
 .. currentmodule:: torch.serialization
+```
 
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
     StorageType
+```
 
+```{eval-rst}
 .. py:module:: torch.serialization
    :noindex:
-.. py:module:: torch.signal.windows.windows
-.. py:module:: torch.sparse.semi_structured
-.. py:module:: torch.storage
-.. py:module:: torch.torch_version
-.. py:module:: torch.types
-.. py:module:: torch.version
+```
 
-.. Compiler configuration module - documented in torch.compiler.config.md
+```{eval-rst}
+.. py:module:: torch.signal.windows.windows
+```
+
+```{eval-rst}
+.. py:module:: torch.sparse.semi_structured
+```
+
+```{eval-rst}
+.. py:module:: torch.storage
+```
+
+```{eval-rst}
+.. py:module:: torch.torch_version
+```
+
+```{eval-rst}
+.. py:module:: torch.types
+```
+
+```{eval-rst}
+.. py:module:: torch.version
+```
+
+% Compiler configuration module - documented in torch.compiler.config.md
+
+```{eval-rst}
 .. py:module:: torch.compiler.config
    :noindex:
+```
 
-.. Hidden aliases (e.g. torch.functional.broadcast_tensors()). We want `torch.broadcast_tensors()` to
-   be visible only.
-.. toctree::
-    :hidden:
+% Hidden aliases (e.g. torch.functional.broadcast_tensors()). We want `torch.broadcast_tensors()` to
+% be visible only.
 
-    torch.aliases.md
+```{toctree}
+:hidden: true
+
+torch.aliases.md
+```


### PR DESCRIPTION
Description
This PR converts the core docs/source/torch.rst file to MyST Markdown (.md).
Fixes https://github.com/pytorch/pytorch/issues/182512

Changes Made
File Migration: Used git mv to rename docs/source/torch.rst to docs/source/torch.md to preserve the git history and log.

File Conversion: Used rst-to-myst tool for converting the file

Test
Local Build: Successfully ran make html and verified the documentation builds without errors.

Visual Verification: Used make serve to verify that the rendered HTML for torch.md is identical in appearance and functionality to the original .rst version.

Linting: Ran lintrunner -m main from the root; no issues were found.

cc @svekars @sekyondaMeta @AlannaBurke