### PR TITLE
[MPS] Enhance LossOps tensor ops to avoid unnecessary .contiguous() calls on grad_output tensor

### DIFF
--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -920,8 +920,6 @@ Tensor& huber_loss_backward_out_mps(const Tensor& grad_output,
   auto is_mean_reduction = reduction == Reduction::Mean;
   auto input_numel = input.numel();
 
-  auto new_grad_output = grad_output.contiguous();
-
   struct CachedGraph : public MPSCachedGraph {
     CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
     MPSGraphTensor* gradOutputTensor_ = nil;
@@ -940,14 +938,13 @@ Tensor& huber_loss_backward_out_mps(const Tensor& grad_output,
         ":" + [ns_shape_key UTF8String] + ":" + getMPSTypeString(input) + ":" + getMPSTypeString(target);
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       MPSGraphTensor* gradOutputTensor =
-          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(new_grad_output), getMPSShape(new_grad_output));
+          mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(grad_output), getMPSShape(grad_output));
       MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(input), input_shape);
       MPSGraphTensor* targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSDataType(target), getMPSShape(target));
       MPSGraphTensor* isMeanReductionTensor =
           [mpsGraph constantWithScalar:is_mean_reduction
                               dataType:MPSDataTypeInt64]; // constant does not support MPSDataTypeBool
-      MPSGraphTensor* inputNumelTensor = [mpsGraph constantWithScalar:input_numel
-                                                             dataType:getMPSDataType(new_grad_output)];
+      MPSGraphTensor* inputNumelTensor = [mpsGraph constantWithScalar:input_numel dataType:getMPSDataType(grad_output)];
 
       MPSGraphTensor* normGradOutputTensor =
           [mpsGraph selectWithPredicateTensor:isMeanReductionTensor
@@ -1001,7 +998,7 @@ Tensor& huber_loss_backward_out_mps(const Tensor& grad_output,
       newCachedGraph->outputTensor_ = outputTensor;
     });
 
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, new_grad_output);
+    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
     Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input);
     Placeholder targetPlaceholder = Placeholder(cachedGraph->targetTensor_, target);
     Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, grad_input);


### PR DESCRIPTION
### Summary:
- Removing `.contiguous()` call on `grad_output` as it goes through `Placeholder` before being sent to `huber_loss_backward_out_mps()` MPSGraph which natively makes tensor contiguous on `macOS < 15.0` without strided tensor support.


### Performance Analysis:
Benchmarked using following script:
```python
import torch
import torch.nn.functional as F
import torch.utils.benchmark as benchmark


input = torch.randn(2000, 2000, device=self._device, requires_grad=True)
target = torch.randn(2000, 2000, device=self._device)
loss = F.huber_loss(input, target, reduction="none")
# Transpose grad so it is non-contiguous when passed to backward
grad = loss.detach().transpose(0, 1).contiguous().transpose(0, 1)
self.assertFalse(grad.is_contiguous())

_stmt = "loss.backward(grad, retain_graph=True)"

m = benchmark.Timer(
    stmt=_stmt,
    globals={"loss": loss, "grad": grad},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

m_c = benchmark.Timer(
    stmt=_stmt,
    globals={"loss": loss, "grad": grad.contiguous()},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

print(f"non-contiguous: mean={m.mean   * 1e6:.2f} us  median={m.median   * 1e6:.2f} us  iqr={m.iqr   * 1e6:.2f} us")
print(f"contiguous    : mean={m_c.mean * 1e6:.2f} us  median={m_c.median * 1e6:.2f} us  iqr={m_c.iqr * 1e6:.2f} us")

```

On an M3 Macbook Pro with 48GB memory we observe a 1.44x speedup on non-contiguous tensors:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
504.54 | 351.55 | 1.44x

And for contiguous tensors we do not observe any performance regression:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
322.80 | 294.03 | 1.1x


### Correctness Analysis:
- Locally tested through an expanded version of the OpsInfo noncontig tests (PR [#183759](https://github.com/pytorch/pytorch/pull/183759)) that covers several more complicated cases of non-contiguity. 
- MPS Results show this modification introduces no regressions (existing bugs that were uncovered through the test expansion are excluded through XFail).


**Pytorch** | **Passed** | **Skipped** | **Deselected** | **XFailed**
------------ | ----------- | ------------ | --------------- | ------------
Baseline       | 16384 | 1074 | 53457 | 1052
Updated       | 16384 | 1074 | 53457 | 1052


Issue #181946 