### PR TITLE
[MPS] Enhance Pooling tensor ops to avoid unnecessary .contiguous() calls on grad_output tensor and leverage useMPSStridedAPI instead

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -228,7 +228,7 @@ static void pool2d_template(const Tensor& input,
                                                                         gradOutputShape,
                                                                         memory_format != MemoryFormat::ChannelsLast,
                                                                         MPSDataTypeInvalid,
-                                                                        /*useMPSStridedAPI=*/false);
+                                                                        /*useMPSStridedAPI=*/true);
     Placeholder indicesPlaceholder = has_indices
         ? Placeholder(
               cachedGraph->indicesTensor, indices, nullptr, true, MPSDataTypeInvalid, /*useMPSStridedAPI=*/false)
@@ -939,7 +939,7 @@ Tensor mps_max_pool2d_backward(const Tensor& grad_output,
   mps::pool2d_template(input,
                        grad_input,
                        std::nullopt,
-                       grad_output.contiguous(input.suggest_memory_format()),
+                       grad_output,
                        kernel_size,
                        stride,
                        padding,


### PR DESCRIPTION
Removing `.contiguous()` call on `grad_output` and enabling `useMPSStridedAPI` on `gradOutputPlaceholder` so it only calls contiguous on `macOS < 15.0` without strided tensor support.

Benchmarked using following script:
```python
import torch
import torch.nn.functional as F
import torch.utils.benchmark as benchmark

x = torch.randn(16, 128, 112, 112, device=self._device)
out = F.max_pool2d(x, kernel_size=3, stride=2, padding=1)  # (16,128,56,56)
grad = torch.ones_like(out).permute(0, 2, 3, 1).contiguous().permute(0, 3, 1, 2)
self.assertFalse(grad.is_contiguous())

_stmt = "torch.ops.aten.max_pool2d_backward(grad, x, [3], [2], [1], [1], False)"

m = benchmark.Timer(
    stmt=_stmt,
    globals={"torch": torch, "grad": grad, "x": x},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

m_c = benchmark.Timer(
    stmt=_stmt,
    globals={"torch": torch, "grad": grad.contiguous(), "x": x},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

print(f"non-contiguous: mean={m.mean   * 1e6:.2f} us  median={m.median   * 1e6:.2f} us  iqr={m.iqr   * 1e6:.2f} us")
print(f"contiguous    : mean={m_c.mean * 1e6:.2f} us  median={m_c.median * 1e6:.2f} us  iqr={m_c.iqr * 1e6:.2f} us")

```


On an M3 Macbook Pro with 48GB memory we observe a 1.11x speedup on non-contiguous tensors:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
2,400.80 | 2,171.40 | 1.11x

And for contiguous tensors we do not observe any performance regression:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
2,170.10 | 2,169.22 | 1.00x



Issue #181946 