### PR TITLE
[MPS] Enhance Repeat tensor ops to avoid .contiguous() call on repeat tensor and make Metal shader stride aware instead

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Repeat.metal
+++ b/aten/src/ATen/native/mps/kernels/Repeat.metal
@@ -3,9 +3,10 @@ kernel void repeat_interleave(
     constant T* repeat_ptr [[buffer(0)]],
     constant int64_t* cumsum_ptr [[buffer(1)]],
     device T* result_ptr [[buffer(2)]],
+    constant int64_t& repeat_stride [[buffer(3)]],
     uint tid [[thread_position_in_grid]]) {
   int64_t end = cumsum_ptr[tid];
-  T repeat = repeat_ptr[tid];
+  T repeat = repeat_ptr[tid * repeat_stride];
   int64_t start = end - repeat;
   for (uint j = start; j < end; j++) {
     result_ptr[j] = tid;
@@ -17,6 +18,7 @@ repeat_interleave<int32_t>(
     constant int32_t*,
     constant int64_t*,
     device int32_t*,
+    constant int64_t&,
     uint);
 
 template [[host_name("repeat_interleave_int64_t")]] kernel void
@@ -24,4 +26,5 @@ repeat_interleave<int64_t>(
     constant int64_t*,
     constant int64_t*,
     device int64_t*,
+    constant int64_t&,
     uint);

--- a/aten/src/ATen/native/mps/operations/Repeat.mm
+++ b/aten/src/ATen/native/mps/operations/Repeat.mm
@@ -118,7 +118,6 @@ Tensor repeat_interleave_mps(const Tensor& repeat, std::optional<int64_t> output
   if (repeat.size(0) == 0) {
     return at::empty_like(repeat, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   }
-  Tensor repeat_ = repeat.contiguous();
   Tensor cumsum = repeat.cumsum(0);
   int64_t total = 0;
   if (output_size.has_value()) {
@@ -140,7 +139,7 @@ Tensor repeat_interleave_mps(const Tensor& repeat, std::optional<int64_t> output
       getMPSProfiler().beginProfileKernel(pipelineState, "repeat_interleave:" + scalar_type, false);
 
       [computeEncoder setComputePipelineState:pipelineState];
-      mps::mtl_setArgs(computeEncoder, repeat_, cumsum, result, repeat.size(0));
+      mps::mtl_setArgs(computeEncoder, repeat, cumsum, result, repeat.stride(0));
       mps::mtl_dispatch1DJob(computeEncoder, pipelineState, repeat.size(0));
 
       getMPSProfiler().endProfileKernel(pipelineState);


### PR DESCRIPTION
  * Removing the `.contiguous()` call on the `repeat` tensor and using it as is
  * Updating the `repeat_interleave_mps` custom Metal kernel to support non-contiguous tensors instead by taking in strides as an input buffer
  * The added overhead of stride calculation in Metal shader is negligible, and is worth the improvement of not calling `.contiguous()` on the CPU.

Benchmarked using following script:
```python
import torch
import torch.nn.functional as F
import torch.utils.benchmark as benchmark

repeats_buf = torch.ones(1_000_000, dtype=torch.long, device=self._device).mul_(2)
repeats = repeats_buf[::2]  # 500_000 elements, stride=2, non-contiguous
self.assertFalse(repeats.is_contiguous())
        
_stmt = "torch.repeat_interleave(repeats)"

m = benchmark.Timer(
    stmt=_stmt,
    globals={"torch": torch, "repeats": repeats},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

m_c = benchmark.Timer(
    stmt=_stmt,
    globals={"torch": torch, "repeats": repeats.contiguous()},
    num_threads=1,
).blocked_autorange(min_run_time=10.0)

print(f"non-contiguous: mean={m.mean   * 1e6:.2f} us  median={m.median   * 1e6:.2f} us  iqr={m.iqr   * 1e6:.2f} us")
print(f"contiguous    : mean={m_c.mean * 1e6:.2f} us  median={m_c.median * 1e6:.2f} us  iqr={m_c.iqr * 1e6:.2f} us")

```


On an M3 Macbook Pro with 48GB memory we observe a 1.35x speedup on non-contiguous tensors:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
1,118.27 | 826.58 | 1.35x

And for contiguous tensors we do not observe any performance regression:
Baseline (µs) | Update (µs) | Speedup
-------------|-------------|----------
767.74 | 768.85 | 1.00x



Issue #181946 