### PR TITLE
[DTensor] Preserve placement for aten.clone.default

### DIFF
--- a/torch/distributed/tensor/_ops/_pointwise_ops.py
+++ b/torch/distributed/tensor/_ops/_pointwise_ops.py
@@ -96,6 +96,13 @@ _FUSED_OP_SCALAR_IDX = 5
 # when partial_extra_rules is not None, to avoid double-registration from tag discovery.
 _specially_registered_ops: set[OpOverload] = set()
 
+# ``aten.clone.default`` is tagged ``pointwise`` but is fundamentally an
+# identity op: it must preserve any input placement (including Partial),
+# not redistribute. Skip auto-registration here so the
+# ``propagate_single_input_strategy`` registration in ``_tensor_ops.py``
+# (which is a 1:1 placement passthrough) takes effect.
+_pointwise_skip_ops: set[OpOverload] = {aten.clone.default}
+
 
 def _register_single_dim_pointwise(
     op: OpOverload,
@@ -572,7 +579,7 @@ def _get_pointwise_ops_from_tag() -> list[OpOverload]:
 pointwise_ops = [
     op
     for op in _get_pointwise_ops_from_tag() + _extra_pointwise_ops
-    if op not in _specially_registered_ops
+    if op not in _specially_registered_ops and op not in _pointwise_skip_ops
 ]
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182729
* #180937
* #180936

We registered clone twice, one in _tensor_ops.py and another one in _pointwise_ops.py

aten.clone.default is tagged torch.Tag.pointwise and was getting auto-registered with the default pointwise single-dim strategy, which only enumerates Replicate/Shard placements. A Partial input was silently redistributed to Replicate via implicit all-reduce.

Skip clone from the pointwise auto-registration via a new _pointwise_skip_ops set. The existing register_op_strategy registration in _tensor_ops.py then takes effect, preserving the placements. clone is fundamentally an identity op and should never redistribute.