### PR TITLE
[MPS] Zero-copy scalar extraction via unified memory in _local_scalar_dense

### DIFF
--- a/aten/src/ATen/native/mps/operations/Scalar.mm
+++ b/aten/src/ATen/native/mps/operations/Scalar.mm
@@ -2,6 +2,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
 #include <ATen/Dispatch_v2.h>
+#include <ATen/mps/MPSAllocatorInterface.h>
 #include <ATen/native/mps/Copy.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/ops/_local_scalar_dense_native.h>
@@ -14,14 +15,34 @@ Scalar _local_scalar_dense_mps(const Tensor& self) {
   Scalar r;
   TORCH_CHECK(self.numel() > 0, "_local_scalar_dense: Empty tensor not supported");
 
-  auto output = at::empty_like(self, TensorOptions(kCPU));
-  mps::mps_copy_(output, self, false);
+  const void* data_ptr = self.storage().data();
+  auto [cpu_ptr, retain_count] = getIMPSAllocator()->getSharedBufferPtr(data_ptr);
+
+  // On Apple Silicon (unified memory), all MPS tensors use MTLStorageModeShared --
+  // the CPU can read the buffer directly after syncing without a blit copy.
+  std::optional<at::Tensor> cpu_staging;
+  const char* src;
+  if (cpu_ptr) {
+    // Serialize the COMMIT_AND_WAIT on the stream queue so it cannot race a
+    // concurrent encoder on the same command buffer from another thread --
+    // a multi-threaded .item() otherwise aborts with "setCurrentCommandEncoder
+    // after committed". Mirrors the CPU<->MPS copy fast paths. The CPU read of
+    // cpu_ptr below is safe once the wait has drained pending GPU writes.
+    MPSStream* stream = getCurrentMPSStream();
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      stream->synchronize(SyncType::COMMIT_AND_WAIT);
+    });
+    src = static_cast<const char*>(cpu_ptr) + self.storage_offset() * self.itemsize();
+  } else {
+    // Fallback for private storage (discrete GPU or future hardware)
+    cpu_staging = at::empty_like(self, TensorOptions(kCPU));
+    mps::mps_copy_(*cpu_staging, self, false);
+    src = static_cast<const char*>(cpu_staging->data_ptr());
+  }
+
   AT_DISPATCH_V2(self.scalar_type(),
                  "_local_scalar_dense_mps",
-                 AT_WRAP([&] {
-                   scalar_t value = *output.data_ptr<scalar_t>();
-                   r = Scalar(value);
-                 }),
+                 AT_WRAP([&] { r = Scalar(*reinterpret_cast<const scalar_t*>(src)); }),
                  AT_EXPAND(AT_ALL_TYPES),
                  AT_EXPAND(AT_COMPLEX_TYPES),
                  at::ScalarType::ComplexHalf,

--- a/benchmarks/bench_mps_item.py
+++ b/benchmarks/bench_mps_item.py
@@ -1,0 +1,28 @@
+"""Benchmark _local_scalar_dense_mps (.item()) on Apple Silicon UMA (PR #182731).
+
+On Apple Silicon, MPS tensors use shared CPU/GPU memory. This PR adds a fast
+path that reads directly from the shared buffer after GPU sync, avoiding the
+Metal blit command that the previous implementation used.
+
+Fast path: getSharedBufferPtr() + COMMIT_AND_WAIT + direct read  (~0.5 us)
+Blit path: encode blit command + commit + wait + CPU staging copy (~100 us)
+
+Usage:
+    python benchmarks/bench_mps_item.py
+"""
+
+import torch
+from torch.utils.benchmark import Timer
+
+
+print(f"torch={torch.__version__}  device=mps (Apple Silicon UMA)")
+print("Methodology: torch.utils.benchmark.Timer.blocked_autorange (median +/- IQR)")
+print()
+print(f"{'Tensor':>16} {'item() (us)':>13}")
+print("-" * 32)
+
+for n in [1, 64, 256, 1024, 4096]:
+    setup = f"import torch; x = torch.randn({n}, device='mps')"
+    stmt = "x[-1].item(); torch.mps.synchronize()"
+    t = Timer(stmt=stmt, setup=setup).blocked_autorange(min_run_time=1.0)
+    print(f"{str(n) + ' elem':>16} {t.median * 1e6:>9.2f} +/- {t.iqr * 1e6:.2f}")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1339,6 +1339,32 @@ class TestMPS(TestCaseMPS):
         x_cpu = torch.randn(1)
         y_mps = x_cpu.to("mps")
         torch.testing.assert_close(x_cpu.item(), y_mps.item())
+    def test_item_uma_fast_path(self):
+        # UMA fast path: direct CPU read from shared MTLBuffer via getSharedBufferPtr()
+        dtypes = [torch.float32, torch.float16, torch.bfloat16, torch.int32, torch.int64, torch.bool]
+        for dtype in dtypes:
+            if dtype == torch.bool:
+                x_cpu = torch.tensor([True, False, True], dtype=dtype)
+            elif dtype.is_floating_point:
+                x_cpu = torch.tensor([1.5, -2.5, 0.0], dtype=dtype)
+            else:
+                x_cpu = torch.tensor([42, -7, 0], dtype=dtype)
+            x_mps = x_cpu.to("mps")
+            for i in range(len(x_cpu)):
+                self.assertEqual(x_cpu[i].item(), x_mps[i].item(), msg=f"dtype={dtype}, idx={i}")
+
+        # Non-contiguous tensor with storage offset
+        base = torch.arange(10, dtype=torch.float32, device="mps")
+        view = base[3]  # scalar tensor with offset
+        self.assertEqual(3.0, view.item())
+
+        # After GPU computation: sync must flush pending writes before CPU read
+        a = torch.ones(4, device="mps")
+        b = torch.ones(4, device="mps")
+        c = a + b  # GPU op, writes 2.0
+        self.assertEqual(2.0, c[0].item())
+
+
 
     def test_linear_1d_weight(self):
         device = 'cpu'


### PR DESCRIPTION
Tracked under #187455 until a dedicated UMA/direct-memory tracking issue exists.

## Current status

Pending rework into the UMA stack. Please do not review this as the final standalone shape.

Order:

1. Extract a UMA base helper first: shared `MTLStorageModeShared` pointer detection plus the stream-queue synchronization pattern needed before direct CPU reads/writes.
2. Rebase this PR on that helper as the scalar-read leaf.
3. Then stack the larger copy/fill leaves: #182736, #182749, #182791.

This PR should remain small after the split: `_local_scalar_dense` / `.item()` / scalar truthiness direct CPU read, a focused regression test, and the scalar benchmark.

## Summary

On Apple Silicon (unified memory), all MPS tensors use `MTLStorageModeShared`.
The CPU can read the buffer directly after synchronizing the stream, so
`_local_scalar_dense` (`.item()`, `.tolist()`, scalar comparisons, `if tensor:`)
does not need a Metal blit + staging copy.

The fast path reads through the shared `MTLBuffer` pointer after `COMMIT_AND_WAIT`.
The existing blit/staging path remains the fallback for private storage or future
hardware where no CPU-visible shared pointer exists.

## Benchmark (M4 Pro, fast path vs forced blit)

| Tensor | Blit | Fast path | Speedup |
| --- | --- | --- | --- |
| 1 elem | 101.0 us | 0.52 us | 194x |
| 64 elem | 103.3 us | 0.52 us | 199x |
| 256 elem | 99.8 us | 0.52 us | 192x |
| 1024 elem | 101.8 us | 0.53 us | 192x |
| 4096 elem | 103.0 us | 0.52 us | 198x |

The fast path is flat at about 0.52 us; the old path is dominated by Metal command-buffer overhead.

## Test Plan

Refresh after the UMA base helper is split out:

```
python test/test_mps.py -k local_scalar_dense
python benchmarks/bench_mps_item.py
```

Authored with Claude.
