### PR TITLE
[FSDP2] Support input JVP through replicate

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed as dist
 import torch.distributed._functional_collectives as funcol
 import torch.nn as nn
+from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import fully_shard, MixedPrecisionPolicy
 from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
     _get_gradient_divide_factors,
@@ -573,6 +574,78 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
             # fp32 tolerances, so only check full param/grad parity for fp32.
             if param_dtype is None:
                 check_sharded_parity(self, ref_model, model)
+
+
+class TestFullyShardMixedPrecisionJVP(FSDPTest):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @skip_if_lt_x_gpu(2)
+    @requires_nccl_version((2, 10), "Need NCCL 2.10+ for bf16 collectives")
+    def test_no_warmup_jvp_reshard_after_forward_false(self):
+        dtype = torch.bfloat16
+        mesh = init_device_mesh(
+            device_type.type,
+            (self.world_size,),
+            mesh_dim_names=("fsdp",),
+        )
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=dtype,
+            reduce_dtype=torch.float32,
+            cast_forward_inputs=True,
+        )
+
+        with torch.device("meta"):
+            enc = nn.Linear(128, 256, bias=False)
+            dec = nn.Linear(256, 320, bias=False)
+
+        for module in (enc, dec):
+            fully_shard(
+                module,
+                mesh=mesh,
+                mp_policy=mp_policy,
+                reshard_after_forward=False,
+            )
+
+        gen = torch.Generator(device_type.type)
+        for idx, module in enumerate((enc, dec)):
+            module.to_empty(device=device_type.type)
+            with torch.no_grad():
+                module.weight.normal_(
+                    std=module.in_features**-0.5,
+                    generator=gen.manual_seed(42 + idx),
+                )
+
+        x = torch.randn(
+            (128,),
+            device=device_type.type,
+            dtype=dtype,
+            generator=gen.manual_seed(0),
+        )
+        primal = torch.randn(
+            (320,),
+            device=device_type.type,
+            dtype=dtype,
+            generator=gen.manual_seed(1),
+            requires_grad=True,
+        )
+        tangent = torch.randn(
+            (320,),
+            device=device_type.type,
+            dtype=dtype,
+            generator=gen.manual_seed(2),
+        )
+        e = enc(x)
+
+        def fn(unused: torch.Tensor) -> torch.Tensor:
+            return dec(e)
+
+        output, tangent_output = torch.func.jvp(fn, (primal,), (tangent,))
+
+        self.assertEqual(output.shape, (320,))
+        self.assertEqual(output.dtype, dtype)
+        self.assertEqual(tangent_output, torch.zeros_like(output))
 
 
 class TestFullyShardMixedPrecisionCasts(FSDPTestMultiThread):

--- a/test/distributed/_composable/test_replicate_mixed_precision.py
+++ b/test/distributed/_composable/test_replicate_mixed_precision.py
@@ -9,6 +9,7 @@ import torch.distributed as dist
 import torch.distributed._functional_collectives as funcol
 import torch.nn as nn
 from torch.distributed._composable.replicate_with_fsdp import replicate
+from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import MixedPrecisionPolicy
 from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
     _get_gradient_divide_factors,
@@ -132,6 +133,157 @@ class TestReplicateMixedPrecisionTraining(FSDPTestContinuous):
                 param_bf16.detach().copy_(param_fp32)
 
             self.assertEqual(fsdp_loss, ref_loss)
+            check_sharded_parity(self, ref_model, model)
+
+    @skip_if_lt_x_gpu(2)
+    def test_input_jvp(self):
+        class ThreeInputMLP(nn.Module):
+            def __init__(self, dim: int) -> None:
+                super().__init__()
+                self.in_proj = nn.Linear(dim + 2, dim)
+                self.out_proj = nn.Linear(dim, dim)
+
+            def forward(
+                self, z: torch.Tensor, t: torch.Tensor, r: torch.Tensor
+            ) -> torch.Tensor:
+                x = torch.cat((z, t, r), dim=-1)
+                return self.out_proj(torch.relu(self.in_proj(x)))
+
+        class MixedOutputMLP(ThreeInputMLP):
+            def forward(
+                self, z: torch.Tensor, t: torch.Tensor, r: torch.Tensor
+            ) -> tuple[torch.Tensor, torch.Tensor]:
+                return super().forward(z, t, r), self.out_proj.weight.sum()
+
+        torch.manual_seed(42)
+        dim = 16
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+            output_dtype=None,
+            cast_forward_inputs=True,
+        )
+        mesh = init_device_mesh(
+            device_type.type,
+            mesh_shape=(self.world_size,),
+            mesh_dim_names=("replicate",),
+        )
+        replicate_fn = functools.partial(replicate, mesh=mesh, mp_policy=mp_policy)
+
+        def init_model(model_cls):
+            model = model_cls(dim)
+            ref_model = copy.deepcopy(model).to(device_type.type)
+            ref_optim = torch.optim.Adam(ref_model.parameters(), lr=1e-3)
+            ref_model_bf16 = copy.deepcopy(ref_model).to(torch.bfloat16)
+            replicate_fn(model.in_proj)
+            replicate_fn(model.out_proj)
+            replicate_fn(model)
+            optim = torch.optim.Adam(model.parameters(), lr=1e-3)
+            return model, optim, ref_model, ref_optim, ref_model_bf16
+
+        def reduce_ref_grads_and_step(ref_model, ref_model_bf16, ref_optim) -> None:
+            for param in ref_model_bf16.parameters():
+                param.grad.data = param.grad.to(torch.float32)
+                dist.all_reduce(param.grad)
+                param.grad.div_(self.world_size)
+            for param_fp32, param_bf16 in zip(
+                ref_model.parameters(), ref_model_bf16.parameters()
+            ):
+                param_fp32.grad = param_bf16.grad
+                param_bf16.grad = None
+            ref_optim.step()
+            for param_fp32, param_bf16 in zip(
+                ref_model.parameters(), ref_model_bf16.parameters()
+            ):
+                param_bf16.detach().copy_(param_fp32)
+
+        model, optim, ref_model, ref_optim, ref_model_bf16 = init_model(ThreeInputMLP)
+
+        z_batch = torch.randn((6, dim), device=device_type.type)
+        t_batch = torch.rand((6, 1), device=device_type.type)
+        r_batch = t_batch * torch.rand((6, 1), device=device_type.type)
+        fsdp_vmap_out = torch.vmap(model)(z_batch, t_batch, r_batch)
+        ref_vmap_out = torch.vmap(
+            lambda z_, t_, r_: ref_model_bf16(
+                z_.to(torch.bfloat16),
+                t_.to(torch.bfloat16),
+                r_.to(torch.bfloat16),
+            )
+        )(z_batch, t_batch, r_batch)
+        self.assertEqual(fsdp_vmap_out, ref_vmap_out)
+
+        mixed_model, mixed_optim, mixed_ref_model, mixed_ref_optim, mixed_ref_bf16 = (
+            init_model(MixedOutputMLP)
+        )
+        mixed_optim.zero_grad(set_to_none=True)
+        mixed_ref_optim.zero_grad(set_to_none=True)
+        fsdp_mixed_out, fsdp_aux = torch.vmap(mixed_model)(z_batch, t_batch, r_batch)
+        ref_mixed_out, ref_aux = torch.vmap(
+            lambda z_, t_, r_: mixed_ref_bf16(
+                z_.to(torch.bfloat16),
+                t_.to(torch.bfloat16),
+                r_.to(torch.bfloat16),
+            )
+        )(z_batch, t_batch, r_batch)
+        self.assertEqual(fsdp_mixed_out, ref_mixed_out)
+        self.assertEqual(fsdp_aux, ref_aux)
+        fsdp_mixed_loss = fsdp_mixed_out.square().mean()
+        ref_mixed_loss = ref_mixed_out.square().mean()
+        self.assertEqual(fsdp_mixed_loss, ref_mixed_loss)
+        fsdp_mixed_loss.backward()
+        mixed_optim.step()
+        ref_mixed_loss.backward()
+        reduce_ref_grads_and_step(mixed_ref_model, mixed_ref_bf16, mixed_ref_optim)
+        check_sharded_parity(self, mixed_ref_model, mixed_model)
+
+        num_iters = 5
+        for iter_idx in range(num_iters):
+            optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            ref_optim.zero_grad(set_to_none=(iter_idx % 2 == 0))
+            torch.manual_seed(42 + self.rank * 10 + iter_idx)
+            x = torch.randn((4, dim), device=device_type.type)
+            e = torch.randn((4, dim), device=device_type.type)
+            t = torch.rand((4, 1), device=device_type.type)
+            r = t * torch.rand((4, 1), device=device_type.type)
+            # Require input grads to exercise backward through the JVP primal.
+            z = ((1 - t) * x + t * e).detach().requires_grad_()
+            t = t.detach().requires_grad_()
+            r = r.detach().requires_grad_()
+            v = e - x
+
+            fsdp_out, fsdp_tangent = torch.func.jvp(
+                lambda z_, t_, r_: model(z_, t_, r_),
+                (z, t, r),
+                (v, torch.ones_like(t), torch.zeros_like(r)),
+            )
+            ref_out, ref_tangent = torch.func.jvp(
+                lambda z_, t_, r_: ref_model_bf16(
+                    z_.to(torch.bfloat16),
+                    t_.to(torch.bfloat16),
+                    r_.to(torch.bfloat16),
+                ),
+                (z, t, r),
+                (v, torch.ones_like(t), torch.zeros_like(r)),
+            )
+            self.assertEqual(fsdp_out, ref_out, msg=f"iter {iter_idx}")
+            self.assertEqual(fsdp_tangent, ref_tangent, msg=f"iter {iter_idx}")
+
+            fsdp_target = v - (t - r) * fsdp_tangent
+            ref_target = v - (t - r) * ref_tangent
+            fsdp_loss = ((fsdp_out - fsdp_target.detach()) ** 2).mean()
+            ref_loss = ((ref_out - ref_target.detach()) ** 2).mean()
+            # Include the tangent in the loss so backward enters FSDP through
+            # the JVP tangent output, not only through the primal output.
+            fsdp_loss = fsdp_loss + fsdp_tangent.square().mean()
+            ref_loss = ref_loss + ref_tangent.square().mean()
+            self.assertEqual(fsdp_loss, ref_loss, msg=f"iter {iter_idx}")
+
+            fsdp_loss.backward()
+            optim.step()
+
+            ref_loss.backward()
+            reduce_ref_grads_and_step(ref_model, ref_model_bf16, ref_optim)
+
             check_sharded_parity(self, ref_model, model)
 
     @skipIfRocmVersionLessThan((7, 0))

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_common.py
@@ -2,9 +2,11 @@
 import functools
 import math
 import traceback
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import auto, Enum
-from typing import Any
+from typing import Any, TypeVar
+from typing_extensions import ParamSpec
 
 import torch
 import torch.distributed as dist
@@ -16,6 +18,10 @@ from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from ._fsdp_api import DataParallelMeshDims
 
 
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
 def _dynamo_disable(func):
     """Disable dynamo tracing for FSDP hooks."""
 
@@ -24,6 +30,17 @@ def _dynamo_disable(func):
         return torch._dynamo.disable(
             func, recursive=True, reason="skipping FSDP hooks"
         )(*args, **kwargs)
+
+    return wrapper
+
+
+def _disable_functorch_if_active(func: Callable[_P, _R]) -> Callable[_P, _R]:
+    @functools.wraps(func)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        if torch._C._are_functorch_transforms_active():
+            with torch._C._DisableFuncTorch():
+                return func(*args, **kwargs)
+        return func(*args, **kwargs)
 
     return wrapper
 

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from typing import Any, cast, Literal, NamedTuple, TYPE_CHECKING
+from typing_extensions import TypeVarTuple, Unpack
 
 import torch
 import torch.distributed as dist
@@ -33,6 +34,7 @@ from ._fsdp_collectives import (
     SymmMemReduceScatter,
 )
 from ._fsdp_common import (
+    _disable_functorch_if_active,
     _dynamo_disable,
     DataParallelMeshInfo,
     DDPMeshInfo,
@@ -52,6 +54,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("torch.distributed.fsdp.fully_shard")
 
 _ModuleToHandleDict = dict[nn.Module, RemovableHandle]  # for state dict
+_GradInputs = TypeVarTuple("_GradInputs")
 
 
 """
@@ -347,6 +350,7 @@ class FSDPParamGroup:
         )
 
     # Runtime #
+    @_disable_functorch_if_active
     def unshard(self, async_op: bool = False):
         if self._all_gather_result is not None:  # already called, pending wait
             return
@@ -391,6 +395,7 @@ class FSDPParamGroup:
                 self._all_gather_comm,
             )
 
+    @_disable_functorch_if_active
     def wait_for_unshard(self):
         """
         1. In forward with implicit prefetching, to overlap the current copy-out
@@ -472,6 +477,7 @@ class FSDPParamGroup:
         if hasattr(self.comm_ctx, "all_gather_stream") and event is not None:
             self.comm_ctx.all_gather_stream.wait_event(event)
 
+    @_disable_functorch_if_active
     def reshard(self):
         if self._training_state == TrainingState.FORWARD:
             if not self._reshard_after_forward:
@@ -1007,14 +1013,31 @@ def _get_param_module_infos(
 
 
 class RegisterPostBackwardFunction(torch.autograd.Function):
+    generate_vmap_rule = True
+
     @staticmethod
     # pyrefly: ignore [bad-override]
-    def forward(ctx, param_group: FSDPParamGroup, *inputs: torch.Tensor):
+    def forward(param_group: FSDPParamGroup, *inputs: torch.Tensor):
         # All tensors in `inputs` should require gradient
-        ctx.param_group = param_group
         return inputs
+
+    @staticmethod
+    def setup_context(ctx, inputs: tuple[Any, ...], output: Any) -> None:
+        param_group, *_ = inputs
+        ctx.param_group = param_group
 
     @staticmethod
     def backward(ctx, *grads: torch.Tensor):
         ctx.param_group.post_backward()
         return (None,) + grads
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def jvp(
+        ctx: Any,
+        param_group_tangent: object,
+        *grad_inputs: Unpack[_GradInputs],
+    ) -> tuple[Unpack[_GradInputs]]:
+        # Drop the non-tensor param_group tangent. The output pre-backward hook
+        # queues final post-backward after all primal/tangent paths finish.
+        return grad_inputs

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_state.py
@@ -416,8 +416,7 @@ class FSDPState(_State):
     def _register_pre_backward_hook(self, output: Any) -> Any:
         if not torch.is_grad_enabled():
             return output
-        # output is the forward return value — pass directly without wrapping
-        # (unlike _register_post_backward_hook which wraps (args, kwargs))
+        # In eager, register hooks directly on grad-requiring outputs.
         tensors = collect_grad_tensors(output)
         for t in tensors:
             if t._base is not None:
@@ -433,6 +432,17 @@ class FSDPState(_State):
                     stacklevel=2,
                 )
             t.register_hook(self._pre_backward)
+        if torch._C._are_functorch_transforms_active():
+            # Under functorch, some differentiable outputs report
+            # requires_grad=False inside the transform even when returned
+            # primals participate in outer autograd.
+            return _apply_to_tensors(
+                lambda t: RegisterPreBackwardFunction.apply(self, t)
+                if not t.requires_grad
+                and (torch.is_floating_point(t) or torch.is_complex(t))
+                else t,
+                output,
+            )
         return output
 
     def _register_root_post_backward_final_callback(self):
@@ -478,6 +488,34 @@ def _get_module_fsdp_state(module: nn.Module) -> FSDPState | None:
     if isinstance(state, FSDPState):
         return state
     return None
+
+
+class RegisterPreBackwardFunction(torch.autograd.Function):
+    generate_vmap_rule = True
+
+    @staticmethod
+    # pyrefly: ignore [bad-override]
+    def forward(state: FSDPState, output: torch.Tensor):
+        return output
+
+    @staticmethod
+    def setup_context(ctx, inputs: tuple[Any, ...], output: Any) -> None:
+        state, _ = inputs
+        ctx.state = state
+
+    @staticmethod
+    def backward(ctx: Any, *grad_outputs: Any) -> Any:
+        (grad,) = grad_outputs
+        return None, ctx.state._pre_backward(grad)
+
+    @staticmethod
+    def jvp(ctx: Any, *grad_inputs: Any) -> Any:
+        # Drop the non-tensor FSDP state tangent; keep tangent backward on the
+        # FSDP pre-backward path.
+        tangent = grad_inputs[1]
+        if tangent is None:
+            return None
+        return RegisterPreBackwardFunction.apply(ctx.state, tangent)
 
 
 def _register_group_forward_hooks(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #182732

Keep FSDP2 internal unshard and reshard storage bookkeeping outside active functorch transforms while leaving the user module forward under the transform. This also updates the post-backward registration autograd function to use setup_context with identity forward-mode behavior and adds mixed-precision replicate and fully_shard coverage for torch.func.jvp.

Authored by Codex.

Co-authored-by: Birch-san <6141784+Birch-san@users.noreply.github.com>