### PR TITLE
Fix typos in export, native, and nativert docs and headers

### DIFF
--- a/torch/_export/passes/replace_with_hop_pass_util.py
+++ b/torch/_export/passes/replace_with_hop_pass_util.py
@@ -118,7 +118,7 @@ def _sequential_split_and_maybe_inline_subgraphs_helper(
     maybe_inline_or_replace_with_hop: Callable[[torch.fx.Node], None],
 ) -> tuple[torch.fx.GraphModule, ExportGraphSignature | None]:
     """
-    Helper function for replacing graph nodse with higher order nodes.
+    Helper function for replacing graph nodes with higher order nodes.
     For each subgraph in `new_gm`, decides whether to construct a HOO subgraph, or inline the calls
     back into the parent graph module, depending on `maybe_inline_or_replace_with_hop`.
     """

--- a/torch/_native/README.md
+++ b/torch/_native/README.md
@@ -16,7 +16,7 @@ For overrides that always apply (no predicate), pass `unconditional_override=Tru
 
 ## A Note on Imports
 
-All registrations will happen at the end of `import torch`. It is expected at that point that **no DSL runtime library is loaded by registration code** - this means that the runtime(s) must only be imported lazily. We can still check the presence of a module, and get it's version without importing, but special care must be taken when writing op kernels to not import DSLs too early. An illustrative example is below, using `triton`:
+All registrations will happen at the end of `import torch`. It is expected at that point that **no DSL runtime library is loaded by registration code** - this means that the runtime(s) must only be imported lazily. We can still check the presence of a module, and get its version without importing, but special care must be taken when writing op kernels to not import DSLs too early. An illustrative example is below, using `triton`:
 
 First, we're going to write the registration function, and a top-level call, being very careful to not pull in the `triton` package early:
 

--- a/torch/nativert/OVERVIEW.md
+++ b/torch/nativert/OVERVIEW.md
@@ -5,8 +5,8 @@ high-performance CPU inference on the PT2 stack, it's designed to be a drop-in
 replacement for
 [Static Runtime](https://github.com/pytorch/pytorch/blob/main/torch/csrc/jit/runtime/static/README.md).
 
-However, it's support doesn't end there; by default it integrates with the torch
-dispatcher, inheriting it's backend
+However, its support doesn't end there; by default it integrates with the torch
+dispatcher, inheriting its backend
 [support matrix](https://docs.pytorch.org/docs/stable/backends.html). Moreover,
 it supports the execution of
 [AOTInductor](https://github.com/pytorch/pytorch/blob/main/docs/source/torch.compiler_aot_inductor.rst)-lowered
@@ -120,7 +120,7 @@ output values.
 
 ### Value
 
-Values are a internal construct that represent the edges of our graph. In the
+Values are an internal construct that represent the edges of our graph. In the
 graph, a value could only carry one of these permissible types: Tensor,
 TensorList, SymInt, SymIntList and CustomObj. Values are uniquely identifiable
 by an integer. Values also have a string name for logging purposes, but we don’t
@@ -160,7 +160,7 @@ Weights is a class that manages the static states of a model, which remains
 immutable throughout the execution. For example module parameters, buffers, and
 constants are all managed in Weights. These tensors are "read-only constants" in
 a single inference run(). As such, they can be shared across all threads.
-Weights is also an user-facing class that provides some APIs for advanced weight
+Weights is also a user-facing class that provides some APIs for advanced weight
 management, such as customized weight loading, weight swapping, and/or in-place
 updates.
 
@@ -249,7 +249,7 @@ one, the dispatcher doesn't deal with kernel out-variants.
 
 In addition, the dispatcher acts as a stack machine. You push the inputs to the
 stack, run the op on the specified device, and then pop the outputs. This in
-itself is much more inefficient then accessing the values directly without
+itself is much more inefficient than accessing the values directly without
 having to play musical chairs.
 
 Registering statically-dispatched cpu kernels is pretty easy. Here is an example

--- a/torch/nativert/executor/DelegateExecutor.h
+++ b/torch/nativert/executor/DelegateExecutor.h
@@ -38,12 +38,12 @@ class DelegateExecutor {
   // affect the weight tensors in the delegate backend.
   // When a weight tensor is no longer used by the delegate backend, the backend
   // must release it by decreasing a refcount. Runtime would
-  // also release the refcount for weight tensor if it's no longer activate. The
+  // also release the refcount for weight tensor if it's no longer active. The
   // underlying storage for weight tensors will be freed when the refcount
   // reaches 0.
   virtual void processWeights(std::shared_ptr<Weights> weights) = 0;
 
-  // This call activate the processed weights.
+  // This call activates the processed weights.
   virtual void commitWeights() = 0;
 
   virtual void initWeights(std::shared_ptr<Weights> weights) = 0;

--- a/torch/nativert/executor/ETDelegateExecutor.h
+++ b/torch/nativert/executor/ETDelegateExecutor.h
@@ -15,7 +15,7 @@ class ETDelegateExecutor : public DelegateExecutor {
               std::get_if<std::string>(&node.attributes()[0].value);
           TORCH_CHECK(
               path != nullptr,
-              "et hop's first attribute should correspond to it's path");
+              "et hop's first attribute should correspond to its path");
           return std::string(dir_prefix) + *path;
         }()) {
     VLOG(1) << "ETDelegateExecutor: " << delegate_dir_;

--- a/torch/nativert/executor/memory/LayoutPlanner.h
+++ b/torch/nativert/executor/memory/LayoutPlanner.h
@@ -104,7 +104,7 @@ class LayoutPlanner {
   //
   // note: planning algorithms are allowed to change the ordering
   // of allocation specs -- so we pass the index of the spec during
-  // it's insertion s.t., each execution frame can use it to
+  // its insertion s.t., each execution frame can use it to
   // reference the correct associated max historical size / underlying
   // tensor value
   void initialize_vectors(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182734

Fix possessive "it's" → "its" in several places, correct "nodse" →
"nodes", "a internal" → "an internal", "a user-facing" (was wrongly
"an user-facing"), "then" → "than" for comparison, and verb agreement
fixes ("activate" → "active"/"activates").

Authored with Claude (typo_terminator2).