### PR TITLE
[MPS] Zero-copy MPS->CPU transfer via unified memory in copy_from_mps_

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -1,5 +1,6 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/mps/MPSAllocatorInterface.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/Copy.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -105,6 +106,28 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
 
   id<MTLBuffer> sourceBuffer = getMTLBufferStorage(src);
   size_t dst_tensor_nbytes = dst.nbytes();
+
+  // Fast path: on Apple Silicon (unified memory), MPS tensors use MTLStorageModeShared --
+  // the CPU can read the buffer directly after syncing, with no blit copy needed.
+  if (!non_blocking && src_.dtype() == dst_.dtype()) {
+    auto [cpu_ptr, _unused] = getIMPSAllocator()->getSharedBufferPtr(src.storage().data());
+    if (cpu_ptr) {
+      // Serialize on the stream queue so the COMMIT_AND_WAIT + direct CPU read do
+      // not race a concurrent encoder on the same command buffer from another
+      // thread. Without this, multi-threaded copy_from_mps_ aborts with
+      // "setCurrentCommandEncoder after committed" (mirrors the CPU->MPS fast path).
+      const char* src_byte_ptr = static_cast<const char*>(cpu_ptr) + storage_byte_offset;
+      char* dst_byte_ptr = static_cast<char*>(dst.data_ptr());
+      dispatch_sync_with_rethrow(stream->queue(), ^() {
+        stream->synchronize(SyncType::COMMIT_AND_WAIT);
+        std::memcpy(dst_byte_ptr, src_byte_ptr, dst_tensor_nbytes);
+      });
+      if (!dst.is_same(dst_)) {
+        dst_.copy_(dst, non_blocking);
+      }
+      return dst_;
+    }
+  }
 
   @autoreleasepool {
     MTLResourceOptions options = MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeShared;

--- a/benchmarks/bench_mps_copy.py
+++ b/benchmarks/bench_mps_copy.py
@@ -1,0 +1,34 @@
+"""Benchmark copy_from_mps_ (MPS->CPU): zero-copy via shared buffer vs blit (PR #182736).
+
+On Apple Silicon UMA, MPS tensors share physical memory with CPU. This PR adds a
+fast path in copy_from_mps_ that reads directly from the shared MTLBuffer via
+getSharedBufferPtr(), avoiding a Metal blit command.
+
+Fast path: getSharedBufferPtr() + COMMIT_AND_WAIT + memcpy  (bandwidth-bound)
+Blit path: encode blit + commit + wait + staging copy        (command overhead dominates at small sizes)
+
+Usage:
+    python benchmarks/bench_mps_copy.py
+"""
+
+import torch
+from torch.utils.benchmark import Timer
+
+
+sizes_kb = [64, 256, 1024, 4096, 16384]
+
+print(f"torch={torch.__version__}  device=mps (Apple Silicon UMA)")
+print("Methodology: torch.utils.benchmark.Timer.blocked_autorange (median +/- IQR)")
+print()
+print(f"{'Size':>10} {'to(cpu) (us)':>14}  {'GB/s':>6}")
+print("-" * 36)
+
+for kb in sizes_kb:
+    n = kb * 1024 // 4  # float32 = 4 bytes
+    setup = f"import torch; x = torch.randn({n}, device='mps')"
+    stmt = "x.to('cpu'); torch.mps.synchronize()"
+    t = Timer(stmt=stmt, setup=setup).blocked_autorange(min_run_time=1.0)
+    bw = (kb / 1024) / (t.median * 1e3)  # GB/s
+    print(
+        f"{str(kb) + 'KB':>10} {t.median * 1e6:>10.2f} +/- {t.iqr * 1e6:<6.2f}  {bw:>5.1f}"
+    )

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4057,6 +4057,55 @@ class TestMPS(TestCaseMPS):
         x_cpu[2:4] = update_mps  # implicit device moving and copy
         self.assertEqual(x_cpu, x_mps)
 
+
+    def test_mps_to_cpu_zero_copy(self):
+        # Correctness for the UMA zero-copy MPS->CPU fast path (getSharedBufferPtr).
+        # Covers: all float/int dtypes contiguous, non-contiguous (blit fallback),
+        # storage_offset > 0, zero-size, and non_blocking=True (blit path).
+        dtypes = [
+            torch.float32, torch.float16, torch.bfloat16,
+            torch.int32, torch.int64, torch.int8, torch.uint8, torch.bool,
+        ]
+        for dtype in dtypes:
+            if dtype.is_floating_point:
+                cpu_ref = torch.randn(128, 128).to(dtype)
+            elif dtype == torch.bool:
+                cpu_ref = torch.randint(0, 2, (128, 128), dtype=dtype)
+            else:
+                cpu_ref = torch.randint(0, 10, (128, 128), dtype=dtype)
+
+            mps_t = cpu_ref.to("mps")
+
+            # Contiguous, same dtype: fast path (getSharedBufferPtr)
+            result = mps_t.to("cpu")
+            self.assertEqual(cpu_ref, result, msg=f"contiguous {dtype}")
+
+            # Non-contiguous: must fall through to blit and still be correct
+            mps_nc = mps_t[:, ::2]
+            self.assertFalse(mps_nc.is_contiguous())
+            self.assertEqual(cpu_ref[:, ::2], mps_nc.to("cpu"), msg=f"non-contiguous {dtype}")
+
+            # storage_offset > 0: sliced view (still contiguous, fast path)
+            mps_sl = mps_t[1:, 1:]
+            self.assertGreater(mps_sl.storage_offset(), 0)
+            self.assertEqual(cpu_ref[1:, 1:], mps_sl.to("cpu"), msg=f"storage_offset {dtype}")
+
+            # dtype mismatch: falls through to cast+blit path
+            if dtype != torch.float32 and dtype.is_floating_point:
+                result_cast = mps_t.to("cpu", dtype=torch.float32)
+                self.assertEqual(cpu_ref.float(), result_cast, msg=f"cast {dtype}->float32")
+
+        # zero-size tensor (no data, must not crash)
+        z = torch.empty(0, device="mps")
+        self.assertEqual(z.to("cpu"), torch.empty(0))
+
+        # non_blocking=True falls through to blit; result is still correct after sync
+        cpu_ref2 = torch.randn(64, 64)
+        mps2 = cpu_ref2.to("mps")
+        result_nb = mps2.to("cpu", non_blocking=True)
+        torch.mps.synchronize()
+        self.assertEqual(cpu_ref2, result_nb, msg="non_blocking=True")
+
     def test_copy_broadcasting(self):
         def helper(src_shape, dst_shape, src_dtype, dst_dtype):
             cpu_src = torch.randint(0, 127, src_shape).to(src_dtype)


### PR DESCRIPTION
Tracked under #187455 until a dedicated UMA/direct-memory tracking issue exists.

## Current status

Pending rework into the UMA stack. Please do not review this as the final standalone shape.

Order:

1. UMA base helper: shared `MTLStorageModeShared` pointer detection plus stream-queue synchronization.
2. Scalar-read leaf: #182731.
3. This PR: MPS->CPU contiguous same-dtype copy leaf.
4. CPU->MPS copy leaf: #182749.
5. Fill/zero leaf: #182791.

This PR should contain only the MPS->CPU copy fast path, its fallback coverage, benchmark, and tests. The common direct-memory/synchronization helper should live in the base split, not be duplicated here.

## Summary

On Apple Silicon, all MPS tensors use `MTLStorageModeShared`, so CPU and GPU share
the same physical memory. `copy_from_mps_` previously wrapped the CPU destination
in a temporary `MTLBuffer` and issued a blit command even when no cross-bus copy
was needed.

The leaf fast path is for contiguous, same-dtype MPS->CPU copies:

- synchronize the stream;
- read through the CPU-visible shared buffer pointer;
- `memcpy` into the CPU destination.

The blit path remains the fallback for non-contiguous tensors, dtype casts, and future private-storage hardware.

## Benchmark (M4 Pro, fast path vs forced blit)

| Size | Blit | Fast path | Speedup | GB/s |
| --- | --- | --- | --- | --- |
| 64 KB | 103.9 us | 1.54 us | 67x | 41.6 |
| 256 KB | 111.7 us | 4.29 us | 26x | 58.8 |
| 1 MB | 116.4 us | 13.8 us | 8.5x | 74.2 |
| 4 MB | 155.0 us | 52.1 us | 3.0x | 78.2 |
| 16 MB | 363.1 us | 233.0 us | 1.56x | 69.5 |

## Test Plan

Refresh after the UMA base helper is split out:

```
python test/test_mps.py -k copy_from_mps
python benchmarks/bench_mps_copy.py
```

Partially addresses #172987: this covers the MPS->CPU copy fast path for contiguous same-dtype tensors; the broader zero-copy alias proposal remains out of scope.

Authored with Claude.
