### PR TITLE
Materialize score_mod / mask_mod captures with copy_input before building modification subgraphs

### DIFF
--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -15,6 +15,7 @@ import sympy
 import torch
 from torch._inductor.virtualized import V
 from torch.nn.attention.flex_attention import _Backend
+from torch.utils._pytree import tree_map
 from torch.utils._sympy.functions import FloorDiv, Mod
 
 from ...ir import ComputedBuffer, ExternKernel, FixedLayout, TensorBox
@@ -180,6 +181,23 @@ def flex_attention(
                 "value as a tensor on device instead of capturing a Python scalar."
             )
 
+    # Materialize captures as fresh ComputedBuffers before build_subgraph_buffer
+    # so the modification subgraph and the runtime tensor agree on rank/layout.
+    def _realize_captures_fresh(buffers):
+        return tree_map(
+            lambda x: (
+                ExternKernel.copy_input(ExternKernel.realize_input(x))
+                if x is not None and not isinstance(x, sympy.Symbol)
+                else x
+            ),
+            buffers,
+        )
+
+    score_mod_other_buffers = _realize_captures_fresh(score_mod_other_buffers)
+    mask_mod_other_buffers = _realize_captures_fresh(mask_mod_other_buffers)
+    freeze_irnodes(score_mod_other_buffers)
+    freeze_irnodes(mask_mod_other_buffers)
+
     placeholder_inps = [
         create_placeholder(name, dtype, query.get_device())
         for name, dtype in [
@@ -298,12 +316,6 @@ def flex_attention(
             mask_graph=mask_graph,
             subgraph=subgraph,
         )
-
-    score_mod_other_buffers = maybe_realize(score_mod_other_buffers)
-    mask_mod_other_buffers = maybe_realize(mask_mod_other_buffers)
-
-    freeze_irnodes(score_mod_other_buffers)
-    freeze_irnodes(mask_mod_other_buffers)
 
     Bq, Hq, seq_len_q, qk_head_dim = query.get_size()
     Bkv, Hkv, seq_len_kv, v_head_dim = value.get_size()


### PR DESCRIPTION
## Related

- Issue: https://github.com/pytorch/pytorch/issues/181800
- Based on earlier fix attempt: https://github.com/pytorch/pytorch/pull/182002

## Summary

The fix https://github.com/pytorch/pytorch/pull/182002 does not fix the https://github.com/pytorch/pytorch/issues/181800 entirely. 


### How to Reproduce
Same as https://github.com/pytorch/pytorch/issues/181800

```python
"""OSS repro for cutedsl flex_attention Bug (UnboundLocalError).

Pattern: a captured mask tensor is computed by a triton-eligible op
(`rule_masks_per_query & prefix_mask.unsqueeze(0)`) and then captured by
mask_mod, which flows into the cutedsl FLASH backend kernel. The wrapper
codegen `del`s the mask after the upstream triton kernel that produced it,
then the cutedsl kernel still references it -> UnboundLocalError.

Run on a pristine torch (no PR 182002 applied):
    python oss_repro_bug1.py
Expected: UnboundLocalError: cannot access local variable 'arg1_1' ...
"""
import os
import shutil

os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", os.path.abspath("./_inductor_cache_oss_bug1"))
shutil.rmtree(os.environ["TORCHINDUCTOR_CACHE_DIR"], ignore_errors=True)

import torch
from torch.nn.attention.flex_attention import create_block_mask, flex_attention

device = "cuda"
dtype = torch.bfloat16
B, H, Q_LEN, KV_LEN, D = 2, 4, 256, 512, 128


def model(q, k, v, rule_masks_per_query, prefix_mask):
    masks = rule_masks_per_query & prefix_mask.unsqueeze(0)

    def mask_mod(b, h, q_idx, kv_idx):
        return masks[q_idx, b, kv_idx]

    block_mask = create_block_mask(
        mask_mod, B=B, H=None, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device=device,
    )
    return flex_attention(
        q, k, v,
        block_mask=block_mask,
        kernel_options={"BACKEND": "FLASH"},
    )


compiled = torch.compile(model, dynamic=False)

q = torch.randn(B, H, Q_LEN, D, device=device, dtype=dtype)
k = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
v = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
rule_masks = torch.randint(0, 2, (Q_LEN, B, KV_LEN), dtype=torch.bool, device=device)
prefix     = torch.randint(0, 2, (B, KV_LEN), dtype=torch.bool, device=device)


out = compiled(q, k, v, rule_masks, prefix)
print("OK shape:", tuple(out.shape))

```
Without fix in https://github.com/pytorch/pytorch/issues/181800

it reports 
```
`UnboundLocalError: cannot access local variable 'arg1_1'`
```
With the fix in https://github.com/pytorch/pytorch/issues/181800
it reports another error

```
loc("tmp11[0] = (in_ptr9[tmp8, tmp9, tmp10])"(".../cesirsnyjn7j224adjtdedr6xtej4zfx3qmi763ydykzx7t6zmlw.py":60:16)):
  error: expects coordinate to be weakly congruent to the layout,
  but got '!cute.coord<"(?,?,?)">'

Traceback (most recent call last):
  File "repro.py", line 19, in <module>
    out = compiled(q, k, v, rule_masks, prefix)
  File ".../torch/_dynamo/eval_frame.py", line 1052, in compile_wrapper
    result = fn(*args, **kwargs)
  File ".../torch/_dynamo/eval_frame.py", line 1304, in _fn
    return fn(*args, **kwargs)
  File ".../torch/_functorch/aot_autograd.py", line 1273, in forward
    return compiled_fn(full_args)
  File ".../torch/_functorch/_aot_autograd/runtime_wrappers.py", line 924, in runtime_wrapper
    all_outs = compiled_invoker.run(args, on_before_call=exit_prologue)
  File ".../torch/_functorch/_aot_autograd/runtime_wrappers.py", line 522, in run
    return call_func_at_runtime_with_args(...)
  File ".../torch/_functorch/_aot_autograd/utils.py", line 126, in call_func_at_runtime_with_args
    out = normalize_as_list(f(args))
  File ".../torch/_functorch/_aot_autograd/runtime_wrappers.py", line 2560, in __call__
    return self.compiled_fn(*args, **kwargs)
  File ".../torch/_inductor/output_code.py", line 725, in __call__
    return self.current_callable(inputs)
  File ".../_inductor_cache/ck/cckb65ez6pg6oukx3xi5yexph33c2ldwtglwkgztf64zbst6yqvq.py", line 537, in call
    cutedsl_fused__to_copy_bitwise_and_clone_eq_flex_attention_gt_lt_slice_sort_sum_transpose_unsqueeze_ea758616.run(
        arg2_1, arg3_1, arg4_1, buf25, buf15, buf16, buf17, buf18, arg1_1, arg0_1, buf26, stream=stream0)
  File ".../torch/_inductor/codegen/cutedsl/cutedsl_kernel.py", line 67, in run
    return self.kernel_fn(*args, stream=stream, **kwargs)
  File ".../_inductor_cache/es/cesirsnyjn7j224adjtdedr6xtej4zfx3qmi763ydykzx7t6zmlw.py", line 74, in cutedsl_fused__to_copy_bitwise_and_clone_eq_flex_attention_gt_lt_slice_sort_sum_transpose_unsqueeze_ea758616_main
    _flash_attn_fwd(
  File ".../flash_attn/cute/interface.py", line 845, in _flash_attn_fwd
    _flash_attn_fwd.compile_cache[compile_key] = cute.compile(...)
  File ".../flash_attn/cute/flash_fwd_sm90.py", line 393, in __call__
    ).launch(...)
  File ".../flash_attn/cute/flash_fwd_sm90.py", line 571, in kernel
    if warp_idx < 4:  # Producer
  File ".../flash_attn/cute/flash_fwd_sm90.py", line 601, in else_block_7
    self.mma(...)
  File ".../flash_attn/cute/flash_fwd_sm90.py", line 1035, in mma
    while work_tile.is_valid_tile:
  File ".../flash_attn/cute/flash_fwd_sm90.py", line 1186, in while_after_block_3
    kv_consumer_state, O_should_accumulate, processed_any = consume_block_sparse_loads(...)
  File ".../flash_attn/cute/block_sparse_utils.py", line 419, in consume_block_sparse_loads
    if curr_mask_block_cnt > 0:
  File ".../flash_attn/cute/block_sparse_utils.py", line 421, in then_block_15
    kv_consumer_state = process_first_half_block(...)
  File ".../flash_attn/cute/flash_fwd_sm90.py", line 1288, in first_half_block_overlap
    mask_fn(acc_S, n_block=n_block, mask_seqlen=True)
  File ".../flash_attn/cute/mask.py", line 208, in apply_mask
    mask_value = mask_mod(...)
  File ".../_inductor_cache/es/cesirsnyjn7j224adjtdedr6xtej4zfx3qmi763ydykzx7t6zmlw.py", line 60, in mask_mod
    tmp11[0] = (in_ptr9[tmp8, tmp9, tmp10])
  File ".../nvidia_cutlass_dsl/python_packages/cutlass/_mlir/dialects/_cute_ops_gen.py", line 2606, in __init__
    super().__init__(self.OPERATION_NAME, ..., loc=loc, ip=ip)
ValueError: Operation creation failed
```

The chain shows the cute layout rejection happens inside the inductor-generated `mask_mod` (line 60: `tmp11[0] = (in_ptr9[tmp8, tmp9, tmp10])`) — `in_ptr9` is the captured `prefix_mask` (physically rank 2), but the modification body emits 3 coords because the `mask_mod` indexing context is rank 3. With #182002's late realize, `prefix_mask` and `rule_masks` are *both* threaded into the modification body as separate captures with the `bitwise_and` inlined inside the kernel; the rank-2 capture receives rank-3 coords and cute rejects.


### Environment
```
  PyTorch version: 2.13.0.dev20260426+cu130
  Is debug build: False                                                                                                                                                                                                                                 
  CUDA used to build PyTorch: 13.0                                                       
  ROCM used to build PyTorch: N/A                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                        
  OS: Microsoft Azure Linux 3.0 (x86_64)       
  GCC version: (GCC) 13.2.0                                                                                                                                                                                                                             
  CMake version: version 3.30.3                                                                                                                                                                                                                         
  Libc version: glibc-2.38                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                        
  Python version: 3.12.6 (main, Dec  8 2025, 20:40:21) [GCC 11.2.0]                                                                                                                                                                                     
  Python platform: Linux-6.6.104.2-4.azl3-x86_64-with-glibc2.38                                                                                                                                                                                         
  Is CUDA available: True                                                                                                                                                                                                                               
  CUDA runtime version: 13.1.115                                                         
  GPU: NVIDIA H100 80GB HBM3                                                                                                                                                                                                                            
  Nvidia driver version: 570.133.20                                                      
  cuDNN version: 9.17.0                                                                                                                                                                                                                                 
                                                                                         
  Versions of relevant libraries:                                                                                                                                                                                                                       
  [pip3] numpy==1.26.4                                                                   
  [pip3] nvidia-cusparselt-cu13==0.8.1                                                                                                                                                                                                                  
  [pip3] nvidia-nccl-cu13==2.29.7                                                        
  [pip3] torch==2.13.0.dev20260426+cu130                                                                                                                                                                                                                
  [pip3] torchrec==1.7.0.dev20260424+cu130
  [pip3] triton==3.7.0+git88b227e2                                                                                                                                                                                                                      
  [pip3] nvidia-cutlass-dsl==4.5.0.dev0   
```
## Root Cause and Fix

**Failure mode 1 — Pointwise inlining.** When a capture is still an unrealized `TensorBox(Pointwise)` (e.g. it was produced by a fused upstream op like `bitwise_and`, `unsqueeze` + broadcast, or any other pointwise chain), `PointwiseSubgraphLowering` inlines the entire upstream closure into the modification body via `make_loader`. The modification subgraph references the *operands* of the upstream computation, not the single captured buffer the user wrote.

**Failure mode 2 — view-vs-realized-buffer rank/stride mismatch.** When a capture is a view of an already-realized buffer (e.g. `bitwise_and(...).reshape([342, 128, 2047])`), `realize_input` keeps the view. `require_contiguous` is a no-op because the view's IR-level stride hint already says contiguous. But the runtime allocation chosen by inductor for the upstream Pointwise can have **padded strides** (e.g. last-dim padded `2047 -> 2048`). The cutedsl wrapper then passes the underlying rank-(N+k) buffer to the FLASH kernel while the modification subgraph emits rank-N coords for the view's logical shape. cute rejects the rank mismatch with `expects coordinate to be weakly congruent to the layout`.

This change 
1. move the realize materialization before the `build_subgraph_buffer`  
2. replaces the `maybe_realize` block with a pre-build `ExternKernel.copy_input(ExternKernel.realize_input(x))` on each capture. `copy_input` always emits a fresh `Pointwise` + `realize`, producing a `ComputedBuffer` with the capture's logical shape and standard strides regardless of the original view's stride hint. The result: the modification subgraph references a single `ComputedBuffer` per closure variable, and the runtime tensor's shape and strides match what the FLASH cute kernel expects.


## Testing Done 


| test code                                   | result                              |
|----------------------------------------------|-------------------------------------|
| origin/main                                  | `UnboundLocalError: arg1_1 ...`     |
| origin/main + #182002                        | cute "weakly congruent" `ValueError`|
| origin/main + #182002 + this PR              | OK                                  |


### Generated kernel diff (concrete example)

For the model `masks = rule_masks_per_query & prefix_mask.unsqueeze(0); mask_mod(b,h,q,k): return masks[q,b,k]` with `BACKEND="FLASH"`:

**Before (origin/main with #182002 applied):**
```python
def mask_mod(b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
    in_ptr8 = aux_tensors[0]
    in_ptr9 = aux_tensors[1]
    ...
    tmp6  = cute.make_rmem_tensor(1, cutlass.Boolean)
    tmp6[0]  = (in_ptr8[tmp3, tmp4, tmp5])    # rule_masks (rank 3)
    tmp7  = tmp6.load()
    tmp11 = cute.make_rmem_tensor(1, cutlass.Boolean)
    tmp11[0] = (in_ptr9[tmp8, tmp9, tmp10])   # prefix_mask (rank 2!) — crash
    tmp12 = tmp11.load()
    tmp13 = (tmp7 & tmp12)                    # bitwise_and inlined here
    mask_mod_output = tmp13
    ...
buffers = [in_ptr8, in_ptr9]
```

**After (this PR):**
```python
def mask_mod(b_idx, h_idx, q_idx, kv_idx, seqlen_info, aux_tensors):
    in_ptr8 = aux_tensors[0]
    ...
    tmp6 = cute.make_rmem_tensor(1, cutlass.Boolean)
    tmp6[0] = (in_ptr8[tmp3, tmp4, tmp5])     # masks (rank 3) — coord matches
    tmp7 = tmp6.load()
    mask_mod_output = tmp7
    ...
buffers = [in_ptr8]
```

The bitwise_and is now upstream in its own pointwise kernel (cost: one HBM round-trip on the realized capture), and `mask_mod` performs a single load from the unified buffer.

