### PR TITLE
[DTensor] add DTensor sharding strategy for batch norm backward

### DIFF
--- a/test/distributed/tensor/test_math_ops.py
+++ b/test/distributed/tensor/test_math_ops.py
@@ -1755,13 +1755,72 @@ class DistMathOpsTest(DTensorTestBase):
         dt_running_mean = distribute_tensor(running_mean, device_mesh, replicate)
         dt_running_var = distribute_tensor(running_var, device_mesh, replicate)
 
-        # batch_norm (eval mode with running stats) — replicate-only strategy
+        # batch_norm (eval mode) with batch-dim sharded input — falls back to replicate
         expected = F.batch_norm(inp, running_mean, running_var, weight, bias)
         result = F.batch_norm(
             dt_inp, dt_running_mean, dt_running_var, dt_weight, dt_bias
         )
         self.assertEqual(result.full_tensor(), expected)
         self.assertTrue(result.placements[0].is_replicate())
+
+        # batch_norm with channel-dim sharding — forward + backward
+        # Use C divisible by world_size for even channel sharding across ranks
+        C_s = self.world_size * 2
+        inp_s = torch.randn(N, C_s, H, W, device=self.device_type)
+        weight_s = torch.randn(C_s, device=self.device_type)
+        bias_s = torch.randn(C_s, device=self.device_type)
+
+        ref_inp = inp_s.clone().detach().requires_grad_(True)
+        ref_w = weight_s.clone().detach().requires_grad_(True)
+        ref_b = bias_s.clone().detach().requires_grad_(True)
+        dt_inp_c = distribute_tensor(
+            inp_s.clone().detach().requires_grad_(True), device_mesh, [Shard(1)]
+        )
+        dt_w = distribute_tensor(
+            weight_s.clone().detach().requires_grad_(True), device_mesh, [Shard(0)]
+        )
+        dt_b = distribute_tensor(
+            bias_s.clone().detach().requires_grad_(True), device_mesh, [Shard(0)]
+        )
+        dt_rmean = distribute_tensor(
+            torch.zeros(C_s, device=self.device_type), device_mesh, [Shard(0)]
+        )
+        dt_rvar = distribute_tensor(
+            torch.ones(C_s, device=self.device_type), device_mesh, [Shard(0)]
+        )
+
+        expected_out = F.batch_norm(
+            ref_inp,
+            torch.zeros(C_s, device=self.device_type),
+            torch.ones(C_s, device=self.device_type),
+            ref_w,
+            ref_b,
+            training=True,
+        )
+        comm_mode = CommDebugMode()
+        with comm_mode:
+            result_out = F.batch_norm(
+                dt_inp_c,
+                dt_rmean,
+                dt_rvar,
+                dt_w,
+                dt_b,
+                training=True,
+            )
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(result_out.full_tensor(), expected_out)
+        self.assertEqual(result_out.placements, dt_inp_c.placements)
+
+        expected_out.sum().backward()
+        with comm_mode:
+            result_out.sum().backward()
+        self.assertEqual(comm_mode.get_total_counts(), 0)
+        self.assertEqual(dt_inp_c.grad.full_tensor(), ref_inp.grad)
+        self.assertEqual(dt_inp_c.grad.placements, dt_inp_c.placements)
+        self.assertEqual(dt_w.grad.full_tensor(), ref_w.grad)
+        self.assertEqual(dt_w.grad.placements, dt_w.placements)
+        self.assertEqual(dt_b.grad.full_tensor(), ref_b.grad)
+        self.assertEqual(dt_b.grad.placements, dt_b.placements)
 
         # group_norm with batch-dim sharding — scalar N/C/HxW args are adjusted
         num_groups = 3

--- a/torch/distributed/tensor/_ops/_math_ops.py
+++ b/torch/distributed/tensor/_ops/_math_ops.py
@@ -1803,8 +1803,8 @@ def _adjust_group_norm_scalars(
 # Normalization ops
 #
 # Batch norm reduces over batch (dim 0) + spatial dims (2+), keeping only
-# channel (dim 1).  Neither batch nor channel sharding is safe, so we fall
-# back to replicate-only.
+# channel (dim 1).  Channel-dim sharding is valid for both forward and
+# backward: each shard processes independent channels.
 #
 # Group norm reduces over (C/groups, spatial) within each group per sample.
 # Batch dim (0) is safe to shard — each sample is independent.
@@ -1844,6 +1844,30 @@ def batch_norm_strategy(
     # input [N,C,*] shards on dim 1; weight, bias, running_mean, running_var [C] on dim 0
     rule.append(_ShardingPlaceholder(1))  # input
     rule.extend([_ShardingPlaceholder(0)] * (num_tensor_inputs - 1))
+    return [rule]
+
+
+@register_single_dim_strategy(
+    [aten.native_batch_norm_backward.default],
+    schema_info=RuntimeSchemaInfo(1),
+)
+def batch_norm_backward_strategy(
+    op: torch._ops.OpOverload,
+    args_schema: tuple[Any, ...],
+    kwargs_schema: dict[str, Any],
+) -> list[list[Placement | _ShardingPlaceholder]]:
+    # Backward reduces over batch + spatial dims, orthogonal to the channel dim,
+    # so channel sharding commutes with the op (same principle as forward).
+    # Tensors are [N,C,*] -> Shard(1) or [C] -> Shard(0).
+    num_tensor_inputs = sum(isinstance(a, TensorMeta) for a in args_schema)
+    rule: list[Placement | _ShardingPlaceholder] = [
+        _ShardingPlaceholder(1),  # grad_input [N,C,*]
+        _ShardingPlaceholder(0),  # grad_weight [C]
+        _ShardingPlaceholder(0),  # grad_bias [C]
+        _ShardingPlaceholder(1),  # grad_out [N,C,*]
+        _ShardingPlaceholder(1),  # input [N,C,*]
+    ]
+    rule.extend([_ShardingPlaceholder(0)] * (num_tensor_inputs - 2))
     return [rule]
 
 


### PR DESCRIPTION
Fixes #182739
Register a single-dim strategy for aten.native_batch_norm_backward.default that enables channel-dim (Shard(1)) sharding. Each channel shard computes its own gradients independently, so no cross-shard communication is needed.

Without this, DTensor's decomposition sharding propagator enters an
infinite loop when resolving cudnn_batch_norm_backward with Shard(1)
inputs, causing the backward pass to hang indefinitely.

The dispatch path is: cudnn_batch_norm_backward (no strategy, decomp
fallback) → native_batch_norm_backward (no strategy, decomp fallback
again) → infinite loop in to_meta(). This strategy intercepts at the
native_batch_norm_backward level, short-circuiting the decomposition.


Authored with Claude.

cc @Skylion007 @ezyang 