### PR TITLE
Implement `can_fuse_horizontal` on CuteDSLScheduling

### DIFF
--- a/test/inductor/test_cutedsl_template.py
+++ b/test/inductor/test_cutedsl_template.py
@@ -19,10 +19,14 @@ except ImportError:
     HAS_CUTLASS = False
 
 if HAS_CUTLASS:
+    from torch._inductor import config as inductor_config
     from torch._inductor.codegen.cutedsl.cutedsl_kernel import CuteDSLTemplateKernel
-    from torch._inductor.codegen.cutedsl.cutedsl_template import CuteDSLTemplate
     from torch._inductor.codegen.cutedsl.cutedsl_scheduling import CuteDSLScheduling
+    from torch._inductor.codegen.cutedsl.cutedsl_template import CuteDSLTemplate
+    from torch._inductor.kernel.flex.flex_flash_attention import ensure_flash_available
     from torch._inductor.select_algorithm import PartialRender
+    from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+    from torch.testing._internal.common_cuda import IS_SM90
 
 
 CUTEDSL_ADD_TEMPLATE = r"""
@@ -641,6 +645,66 @@ class TestCuteDSLScheduling(TestCase):
     def test_can_fuse_horizontal_returns_false(self):
         sched = CuteDSLScheduling(scheduler=None)
         self.assertIs(sched.can_fuse_horizontal(MagicMock(), MagicMock()), False)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    @unittest.skipIf(
+        not HAS_CUTLASS or not ensure_flash_available(),
+        "Flash attention (CUTE) library is not available",
+    )
+    @unittest.skipIf(not IS_SM90, "FLASH backend requires SM90 (H100)")
+    @inductor_config.patch(score_fusion_memory_threshold=0)
+    def test_can_fuse_horizontal_compile_dispatch(self):
+        """End-to-end: compile a graph that puts a cutedsl FLASH template
+        next to non-template siblings (pointwise/reduction reading the same
+        Q/K/V) so the scheduler reaches
+        ``CUDACombinedScheduling.can_fuse_horizontal`` and dispatches into
+        ``CuteDSLScheduling.can_fuse_horizontal``. Without the override,
+        this falls through to ``BaseScheduling.can_fuse_horizontal`` and
+        raises ``NotImplementedError`` during compilation.
+
+        ``score_fusion_memory_threshold=0`` ensures any sibling pair becomes
+        a fusion candidate, surfacing the dispatch deterministically on a
+        small graph.
+        """
+        device = "cuda"
+        dtype = torch.bfloat16
+        B, H_, Q_LEN, KV_LEN, D = 4, 8, 512, 1024, 128
+
+        def causal(b, h, q, k):
+            return q >= k
+
+        def model(q, k, v, bias_q, bias_kv):
+            block_mask = create_block_mask(
+                causal, B=None, H=None, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device=device,
+            )
+            a1 = flex_attention(
+                q, k, v, block_mask=block_mask,
+                kernel_options={"BACKEND": "FLASH"},
+            )
+            a2 = flex_attention(
+                q + bias_q, k, v, block_mask=block_mask,
+                kernel_options={"BACKEND": "FLASH"},
+            )
+            a3 = flex_attention(
+                q, k + bias_kv, v + bias_kv, block_mask=block_mask,
+                kernel_options={"BACKEND": "FLASH"},
+            )
+            s1 = (q * 2.0).relu().sum(dim=-2, keepdim=True)
+            s2 = (k * 3.0).relu().sum(dim=-2, keepdim=True)
+            s3 = (v * 4.0).relu().sum(dim=-2, keepdim=True)
+            return a1 + a2 + a3 + s1 + s2 + s3
+
+        compiled = torch.compile(model, dynamic=False)
+
+        q = torch.randn(B, H_, Q_LEN, D, device=device, dtype=dtype)
+        k = torch.randn(B, H_, KV_LEN, D, device=device, dtype=dtype)
+        v = torch.randn(B, H_, KV_LEN, D, device=device, dtype=dtype)
+        bias_q = torch.randn(B, H_, Q_LEN, D, device=device, dtype=dtype)
+        bias_kv = torch.randn(B, H_, KV_LEN, D, device=device, dtype=dtype)
+
+        out = compiled(q, k, v, bias_q, bias_kv)
+        self.assertEqual(tuple(out.shape), (B, H_, Q_LEN, D))
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_cutedsl_template.py
+++ b/test/inductor/test_cutedsl_template.py
@@ -21,6 +21,7 @@ except ImportError:
 if HAS_CUTLASS:
     from torch._inductor.codegen.cutedsl.cutedsl_kernel import CuteDSLTemplateKernel
     from torch._inductor.codegen.cutedsl.cutedsl_template import CuteDSLTemplate
+    from torch._inductor.codegen.cutedsl.cutedsl_scheduling import CuteDSLScheduling
     from torch._inductor.select_algorithm import PartialRender
 
 
@@ -635,6 +636,11 @@ SCALE_FACTOR: cutlass.Constexpr = 1.5
                 var = kernel.cse.generate(kernel.body, test_expr, dtype=None)
                 self.assertTrue(str(var).startswith("tmp"))
 
+@unittest.skipUnless(HAS_CUTLASS, "requires cutlass")
+class TestCuteDSLScheduling(TestCase):
+    def test_can_fuse_horizontal_returns_false(self):
+        sched = CuteDSLScheduling(scheduler=None)
+        self.assertIs(sched.can_fuse_horizontal(MagicMock(), MagicMock()), False)
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/codegen/cutedsl/cutedsl_scheduling.py
+++ b/torch/_inductor/codegen/cutedsl/cutedsl_scheduling.py
@@ -56,6 +56,18 @@ class CuteDSLScheduling(BaseScheduling):
         """
         return False
 
+    def can_fuse_horizontal(
+        self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
+    ) -> bool:
+        """
+        CuteDSL doesn't support horizontal fusion. Without this override,
+        CUDACombinedScheduling dispatches into BaseScheduling.can_fuse_horizontal
+        which raises NotImplementedError, so any model with two cutedsl-template
+        adjacent scheduler nodes (e.g. multiple flex_attention calls) fails to
+        compile during fusion analysis.
+        """
+        return False
+
     def define_kernel(self, src_code_str: str, node_schedule) -> str:
         """Produce the kernel string
         Args:


### PR DESCRIPTION
## Related

- Issue: https://github.com/pytorch/pytorch/issues/181800
- Sibling PR (different root cause, also CuteDSL FlexAttention): https://github.com/pytorch/pytorch/pull/182737

## Summary

`CuteDSLScheduling` overrides `can_fuse_vertical` to return `False` but does not implement `can_fuse_horizontal`. `CUDACombinedScheduling` dispatches horizontal-fusion checks to the per-backend scheduler when one of the nodes is a CuteDSL template; the call falls through to `BaseScheduling.can_fuse_horizontal`, which raises `NotImplementedError`. Any model whose scheduler ends up evaluating two cutedsl-template scheduler nodes as horizontal-fusion candidates fails to compile.

The dispatch comment in `cuda_combined_scheduling.py` already reads `# always False at the moment`, suggesting the override was simply forgotten when the CuteDSL backend was wired up.


### How to Reproduce

The bug surfaces when `Scheduler.can_fuse` reaches `self.get_backend(device).can_fuse_horizontal(node1, node2)` (`scheduler.py:6586`) with one of the nodes being a `CuteDSLTemplateBuffer`. That requires:
- The two nodes to be siblings (`node1.get_operation_names() & node2.ancestors == set()`).
- Pass through `V.choices.can_fuse(...)` and `V.choices.can_fuse_horizontal(...)` (`choices.py:625`), which require `shared_data_score >= config.score_fusion_memory_threshold` (default 10) and not "long distant" by `Scheduler.are_long_distant_nodes`.
- Pass the early `_can_fuse` checks: in particular, `(node1, node2)` cannot both be templates because the prologue-fusion guard at `scheduler.py:6446` short-circuits when `node2.is_template() and node1.is_template()`.

Self-contained repro:

```python
"""OSS repro for cutedsl flex_attention can_fuse_horizontal NotImplementedError.

Three flex_attention(BACKEND="FLASH") calls plus three pointwise side
branches reading the same q/k/v. With score_fusion_memory_threshold=0,
the scheduler picks a (cutedsl template, non-template sibling) pair and
dispatches into get_backend(device).can_fuse_horizontal ->
CuteDSLScheduling.can_fuse_horizontal, which falls through to
BaseScheduling.can_fuse_horizontal -> NotImplementedError.
"""
import os, shutil
os.environ["TORCHINDUCTOR_CACHE_DIR"] = os.path.abspath("./_inductor_cache_bug3")
shutil.rmtree(os.environ["TORCHINDUCTOR_CACHE_DIR"], ignore_errors=True)

import torch
import torch._inductor.config as ic
ic.score_fusion_memory_threshold = 0

from torch.nn.attention.flex_attention import create_block_mask, flex_attention

device, dtype = "cuda", torch.bfloat16
B, H, Q_LEN, KV_LEN, D = 4, 8, 512, 1024, 128


def causal(b, h, q, k):
    return q >= k


def model(q, k, v, bias_q, bias_kv):
    block_mask = create_block_mask(causal, B=None, H=None, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device=device)
    a1 = flex_attention(q, k, v, block_mask=block_mask, kernel_options={"BACKEND": "FLASH"})
    a2 = flex_attention(q + bias_q, k, v, block_mask=block_mask, kernel_options={"BACKEND": "FLASH"})
    a3 = flex_attention(q, k + bias_kv, v + bias_kv, block_mask=block_mask, kernel_options={"BACKEND": "FLASH"})
    s1 = (q * 2.0).relu().sum(dim=-2, keepdim=True)
    s2 = (k * 3.0).relu().sum(dim=-2, keepdim=True)
    s3 = (v * 4.0).relu().sum(dim=-2, keepdim=True)
    return a1 + a2 + a3 + s1 + s2 + s3


compiled = torch.compile(model, dynamic=False)

q = torch.randn(B, H, Q_LEN, D, device=device, dtype=dtype)
k = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
v = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)
bias_q = torch.randn(B, H, Q_LEN, D, device=device, dtype=dtype)
bias_kv = torch.randn(B, H, KV_LEN, D, device=device, dtype=dtype)

out = compiled(q, k, v, bias_q, bias_kv)
print(f"OK shape: {tuple(out.shape)}")
```

Without this PR (origin/main + #182737):
```
Traceback (most recent call last):
  File ".../torch/_inductor/compile_fx.py", line 1058, in _compile_fx_inner
    mb_compiled_graph = fx_codegen_and_compile(...)
  File ".../torch/_inductor/graph.py", line 2625, in compile_to_module
    return self._compile_to_module()
  File ".../torch/_inductor/graph.py", line 2563, in codegen
    self._update_scheduler()
  File ".../torch/_inductor/graph.py", line 2557, in _update_scheduler
    self.scheduler = Scheduler(self.operations)
  File ".../torch/_inductor/scheduler.py", line 3131, in __init__
    self._init(nodes)
  File ".../torch/_inductor/scheduler.py", line 3234, in _init
    self.nodes = self.fuse_nodes(self.nodes)
  File ".../torch/_inductor/scheduler.py", line 4102, in fuse_nodes
    nodes = self.fuse_nodes_once(nodes, is_reorder_round=False)
  File ".../torch/_inductor/scheduler.py", line 5055, in fuse_nodes_once
    possible_fusions = self.get_possible_fusions(...)
  File ".../torch/_inductor/scheduler.py", line 5186, in get_possible_fusions
    check_all_pairs(node_grouping)
  File ".../torch/_inductor/scheduler.py", line 5171, in check_all_pairs
    if self.can_fuse(node1, node2, is_reorder_round):
  File ".../torch/_inductor/scheduler.py", line 6258, in can_fuse
    ) and self.get_backend(device).can_fuse_horizontal(node1, node2)
  File ".../torch/_inductor/codegen/cuda_combined_scheduling.py", line 96, in can_fuse_horizontal
    return self._cutedsl_scheduling.can_fuse_horizontal(node1, node2)
  File ".../torch/_inductor/scheduler.py", line 8126, in can_fuse_horizontal
    raise NotImplementedError
torch._inductor.exc.InductorError: NotImplementedError
```

With this PR: `OK shape: (4, 8, 512, 128)`.

Note: the repro lowers `score_fusion_memory_threshold` to 0 to force the scheduler to consider any sibling pair as a fusion candidate. This isolates the bug in a small graph; in larger ranking-model training graphs the default threshold (10) is also crossed naturally, where this same dispatch fires without any config change.


After this PR, the same training run compiles cleanly and trains 100 steps end-to-end.

I attempted several minimal OSS reductions (two `flex_attention` calls sharing q/k/v with different captured masks, two `flex_attention` calls with backward, single `flex_attention` plus a sibling pointwise that shares Q) — none reliably reach the backend dispatch on the current torch build because the shared-data score and prologue-fusion guards filter them out. A reliable minimal repro is graph-structure-dependent; the trigger is observable in larger ranking-model training graphs.


### Environment
```
PyTorch version: 2.13.0.dev20260426+cu130
Is debug build: False
CUDA used to build PyTorch: 13.0
ROCM used to build PyTorch: N/A

OS: Microsoft Azure Linux 3.0 (x86_64)
GCC version: (GCC) 13.2.0
CMake version: version 3.30.3
Libc version: glibc-2.38

Python version: 3.12.6 (main, Dec  8 2025, 20:40:21) [GCC 11.2.0]
Python platform: Linux-6.6.104.2-4.azl3-x86_64-with-glibc2.38
Is CUDA available: True
CUDA runtime version: 13.1.115
GPU: NVIDIA H100 80GB HBM3
Nvidia driver version: 570.133.20
cuDNN version: 9.17.0

Versions of relevant libraries:
[pip3] numpy==1.26.4
[pip3] nvidia-cusparselt-cu13==0.8.1
[pip3] nvidia-nccl-cu13==2.29.7
[pip3] torch==2.13.0.dev20260426+cu130
[pip3] torchrec==1.7.0.dev20260424+cu130
[pip3] triton==3.7.0+git88b227e2
[pip3] nvidia-cutlass-dsl==4.5.0.dev0
```

## Root Cause and Fix

`CUDACombinedScheduling.can_fuse_horizontal` (in `torch/_inductor/codegen/cuda_combined_scheduling.py`) routes horizontal-fusion candidates to the per-backend scheduler when one node is a CuteDSL template:

```python
def can_fuse_horizontal(self, node1, node2):
    for node in (node1, node2):
        ...
        if self._cutedsl_scheduling.is_cutedsl_template(node):
            return self._cutedsl_scheduling.can_fuse_horizontal(
                node1, node2
            )  # always False at the moment
    ...
```

`CuteDSLScheduling` provided `can_fuse_vertical` but not `can_fuse_horizontal`, so the call fell through to `BaseScheduling.can_fuse_horizontal` → `NotImplementedError`.

The fix is a one-line override returning `False`, matching the existing `can_fuse_vertical` behavior. CuteDSL templates do not support fusion in either direction yet.

```python
def can_fuse_horizontal(
    self, node1: BaseSchedulerNode, node2: BaseSchedulerNode
) -> bool:
    """
    CuteDSL doesn't support horizontal fusion. Without this override,
    CUDACombinedScheduling dispatches into BaseScheduling.can_fuse_horizontal
    which raises NotImplementedError, so any model with two cutedsl-template
    adjacent scheduler nodes (e.g. multiple flex_attention calls) fails to
    compile during fusion analysis.
    """
    return False
```

## Testing Done

| test code                                     | result                                                                  |
|-----------------------------------------------|-------------------------------------------------------------------------|
| origin/main + #182737                         | `InductorError: NotImplementedError` from `BaseScheduling.can_fuse_horizontal` (multi-billion-parameter ranking model, FLASH backend) |
| origin/main + #182737 + this PR               | Same model compiles and runs 100 steps end-to-end                       |


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo