### PR TITLE
Avoid Triton sort compile cliff in create_block_mask

### DIFF
--- a/test/dynamo/test_fx_annotate.py
+++ b/test/dynamo/test_fx_annotate.py
@@ -8,7 +8,11 @@ import torch.fx.traceback as fx_traceback
 import torch.utils.checkpoint
 from torch._dynamo.test_case import run_tests
 from torch._dynamo.testing import AotEagerAndRecordGraphs
-from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+from torch.nn.attention.flex_attention import (
+    _dense_to_ordered,
+    create_block_mask,
+    flex_attention,
+)
 from torch.testing._internal.triton_utils import requires_cuda_and_triton
 
 
@@ -66,6 +70,21 @@ class AnnotateTests(torch._dynamo.test_case.TestCase):
 ('call_function', 'cos', {'pp_stage': 0, 'fdsp_bucket': 0})
 ('call_function', 'mul_2', {'pp_stage': 0, 'fdsp_bucket': 0})""",
         )
+
+    def test_flex_attention_block_mask_fallback_to_eager(self):
+        backend = AotEagerAndRecordGraphs()
+        opt_fn = torch.compile(
+            lambda x: _dense_to_ordered(x)[1], backend=backend, fullgraph=True
+        )
+        opt_fn(torch.randint(0, 2, (2, 3), dtype=torch.bool))
+
+        annotated_sorts = [
+            node
+            for node in backend.graphs[0].graph.nodes
+            if node.op == "call_function" and node.target == torch.argsort
+        ]
+        self.assertEqual(len(annotated_sorts), 1)
+        self.assertTrue(annotated_sorts[0].meta["custom"]["fallback_to_eager"])
 
     def test_activation_checkpointing(self):
         @checkpoint_wrapper

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1488,7 +1488,9 @@ class GraphLowering(torch.fx.Interpreter):
                 else:
                     args, kwargs = layout_constraints(n, *args, **kwargs)
 
-            if "should_fallback" in n.meta:
+            if "should_fallback" in n.meta or n.meta.get("custom", {}).get(
+                "fallback_to_eager"
+            ):
                 out = fallback_handler(target, add_to_fallback_set=False)(
                     *args, **kwargs
                 )

--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -422,7 +422,8 @@ def _ordered_to_dense(num_blocks_in_row: Tensor, col_indices: Tensor) -> Tensor:
 def _dense_to_ordered(dense_mask: Tensor) -> tuple[Tensor, Tensor]:
     dense_mask = dense_mask.to(dtype=torch.int32)
     num_blocks_in_row = dense_mask.sum(dim=-1)
-    col_indices = torch.argsort(dense_mask, dim=-1, descending=True, stable=True)
+    with torch.fx.traceback.annotate({"fallback_to_eager": True}):
+        col_indices = torch.argsort(dense_mask, dim=-1, descending=True, stable=True)
     return (
         num_blocks_in_row.to(torch.int32, memory_format=torch.contiguous_format),
         col_indices.to(torch.int32, memory_format=torch.contiguous_format),


### PR DESCRIPTION
## Human Note
Not married to this solution, but we are getting insane compile times for sort; https://github.com/pytorch/pytorch/issues/182060

## Agent Report
# Report

## Summary of the issue

`torch.compile(create_block_mask)` has pathological cold compile time because `create_block_mask()` eventually lowers two operations that are hostile to Triton cold compile time:

1. `_dense_to_ordered()` uses `torch.argsort(..., descending=True, stable=True)` to convert a binary block mask into ordered column indices.
2. Block-mask construction also performs a large blockwise reduction (`sum` over the 128x128 tile) whose persistent-reduction codegen can hardcode a very large `R0_BLOCK`.

The important historical conclusion is that **“limit `rnumel`” is not the root fix**. It is a fallback/workaround that avoids a problematic Triton compilation regime. The more fundamental regression is that compiled `argsort` now goes through Triton persistent sort codegen instead of falling back to ATen eager.

## Root cause analysis

### 1. The flex-attention code path has used `argsort` for a long time

`torch/nn/attention/flex_attention.py::_dense_to_ordered()` has used:

```python
col_indices = torch.argsort(dense_mask, dim=-1, descending=True, stable=True)
```

since commit `6024fea0f89` (2024-07-16). This is a generic stable-partition trick for binary masks: sort 1s ahead of 0s while preserving original column order.

### 2. What changed historically is not flex-attention; it is compiled `argsort`

The key history is:

- `48171806010` (2024-06-17): explicitly made `aten.argsort.stable` an Inductor fallback.
- `90d5a6f001e` (2024-06-25): added Triton lowering/codegen for `aten.sort`.
- `3fc279633b4` (2024-06-27): made `argsort.stable` CompositeImplicitAutograd and removed the Inductor fallback, so compiled `argsort` now decomposes through `sort`.

That means the old compiled behavior was effectively:

- `argsort` -> eager/ATen fallback

and the newer behavior became:

- `argsort` -> `sort` decomposition -> `ir.Sort` -> Triton persistent sort kernel

This is the clearest answer to “why was this not happening before?”

### 3. Sort lowering is on a separate heuristic path from generic reduction heuristics

This matters for the proposed `rnumel` limit.

`torch/_inductor/ir.py::Sort.create()` does **not** use `V.choices.should_use_persistent_reduction()`. Instead it has its own gate:

```python
max_rblock = 512
is_persistent_kernel = (
    config.triton.persistent_reductions
    and sizevars.statically_known_true(sympy.Le(sort_numel, max_rblock))
)
```

and `torch/_inductor/codegen/triton.py` forces sort kernels to persistent reduction:

```python
if kernel_features.contains_op("sort"):
    kernel_kwargs["override_persistent_reduction"] = True
```

So a generic change to persistent-reduction `rnumel` heuristics would **not directly fix the dominant `argsort` path** unless sort gets its own fallback heuristic.

### 4. The existing sort threshold change does not explain this repro

`16cd1aaa1dc` (2024-07-25) raised the sort small-dimension limit from 256 to 512 for runtime-performance reasons.

That is not the main regression here:

- the issue reproduces around block-grid widths of about 106/107,
- which are already below the old 256 threshold.

So reverting 512 -> 256 would not solve this case.

### 5. Large persistent `R0_BLOCK` compile-time pathologies are already known elsewhere

There is prior evidence in-tree that this class of problem is real:

- `174ef33342d` (2026-02-28)
- `d428a3f9c9e` (2026-03-20)

added ROCm-specific filtering for combo-kernel configs when a persistent subkernel would imply a very large hardcoded `R0_BLOCK`, explicitly because of pathological Triton compile times.

Also, generic persistent codegen still hardcodes persistent reduction block sizes as:

```python
R0_BLOCK = next_power_of_2(rnumel)
```

in `torch/_inductor/codegen/triton.py::_get_persistent_RBLOCK()` / `codegen_static_numels()`.

So “limit `rnumel`” matches an existing pattern of **targeted compile-time mitigation**, but it is still fundamentally a workaround for compiler/codegen cost, not a principled semantic fix.

### 6. Most likely root-cause framing

The best root-cause framing is:

- `create_block_mask` uses a generic stable `argsort` to do binary-mask compaction.
- Compiled `argsort` stopped falling back and started going through Triton persistent sort in June 2024.
- Triton cold compile for these sort/reduction kernels is pathological for some shapes.
- Therefore limiting `rnumel` only restores a fallback/non-persistent path; it does not fix the underlying mismatch between this workload and the Triton sort/persistent-reduction codegen.

## What the fix does

No code change was made in this run.

The investigation conclusion is:

- **Limiting `rnumel` is a workaround, not the root fix.**
- If this is fixed in PyTorch, the most principled places are either:
  - add a dedicated fallback heuristic for compiled `sort`/`argsort` cold-compile pathologies, or
  - stop using generic stable `argsort` for `_dense_to_ordered()` and replace it with a direct compaction algorithm specialized for binary masks.

## Repro script

<details>
<summary>Repro Script</summary>

```python
import argparse
import time

import torch
from torch.nn.attention.flex_attention import create_block_mask


def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser()
    parser.add_argument("seq_len", type=int)
    return parser.parse_args()


def causal_mask_mod(
    batch: torch.Tensor,
    head: torch.Tensor,
    query_index: torch.Tensor,
    kv_index: torch.Tensor,
) -> torch.Tensor:
    return query_index >= kv_index


args = parse_args()

print("starting compile")
compiled = torch.compile(create_block_mask)

print(f"calling compiled create_block_mask with Q_LEN=KV_LEN={args.seq_len}")
call_start = time.perf_counter()
block_mask = compiled(
    causal_mask_mod,
    B=1,
    H=1,
    Q_LEN=args.seq_len,
    KV_LEN=args.seq_len,
    device="cuda",
    BLOCK_SIZE=(128, 128),
)
call_elapsed = time.perf_counter() - call_start
print(f"compiled create_block_mask returned in {call_elapsed:.6f}s")

torch.cuda.synchronize()
print("done")
```

Output from this job environment:

```text
Traceback (most recent call last):
  File "/home/dev/.ptq_workspace/jobs/20260504-pytorch-182060/repro.py", line 4, in <module>
    import torch
ModuleNotFoundError: No module named 'torch'
```

The local job venv is not currently built/installable, so runtime repro was blocked here. The source-history investigation above was completed directly from the worktree.

</details>

## Test results

- Source inspection completed for:
  - `torch/nn/attention/flex_attention.py`
  - `torch/_inductor/ir.py`
  - `torch/_inductor/lowering.py`
  - `torch/_inductor/codegen/triton.py`
  - `torch/_inductor/runtime/triton_heuristics.py`
  - `torch/_inductor/runtime/triton_helpers.py`
- Git history inspected for:
  - `argsort` fallback/composite history
  - `sort` Triton lowering history
  - persistent-reduction heuristic history
  - prior compile-time mitigations for large persistent `R0_BLOCK`
- Runtime repro: blocked because the job venv cannot import `torch` and the worktree is not built.


Fixes #182060


<details>
<summary>Repro Script</summary>

```python
import argparse
import time

import torch
from torch.nn.attention.flex_attention import create_block_mask


def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser()
    parser.add_argument("seq_len", type=int)
    return parser.parse_args()


def causal_mask_mod(
    batch: torch.Tensor,
    head: torch.Tensor,
    query_index: torch.Tensor,
    kv_index: torch.Tensor,
) -> torch.Tensor:
    return query_index >= kv_index


args = parse_args()

print("starting compile")
compiled = torch.compile(create_block_mask)


print(f"calling compiled create_block_mask with Q_LEN=KV_LEN={args.seq_len}")
call_start = time.perf_counter()
block_mask = compiled(
    causal_mask_mod,
    B=1,
    H=1,
    Q_LEN=args.seq_len,
    KV_LEN=args.seq_len,
    device="cuda",
    BLOCK_SIZE=(128, 128),
)
call_elapsed = time.perf_counter() - call_start
print(f"compiled create_block_mask returned in {call_elapsed:.6f}s")

torch.cuda.synchronize()
print("done")
```

</details>


<details>
<summary>Agent Worklog</summary>

## Run 2

> **User:** Investigate whether limiting rnumel is actually the correct solution for this issue or just a workaround. Please dig into whether something changed recently about this setting/heuristic, whether this is a new regression, and why this was not happening before. Focus on root cause/history, not just patching around it.

### Repro environment bootstrap
- Tried the provided repro with `~/.ptq_workspace/jobs/20260504-pytorch-182060/.venv/bin/python`, but the job venv cannot currently import `torch`.
- Importing from the repo root also fails because `torch/version.py` has not been generated, and there is no editable install metadata in the venv site-packages.
- I can still inspect source and git history now; if runtime validation is needed, the checkout will need to be built or made importable first.

### Source/history trace
- `create_block_mask()` still reaches `_dense_to_ordered()`, which has used `torch.argsort(... stable=True, descending=True)` since `6024fea0f89` (2024-07-16).
- The key behavioral regression is earlier: `48171806010` added an explicit Inductor fallback for `aten.argsort.stable`, then `90d5a6f001e` added Triton `sort`, and `3fc279633b4` made `argsort.stable` CompositeImplicitAutograd and removed the fallback. From that point on, compiled `argsort` decomposed through Triton `sort` instead of staying on the ATen fallback path.
- Sort lowering is on its own path: `ir.Sort.create()` uses a small-sort threshold and `codegen/triton.py` force-enables persistent reduction for sort. This means a generic persistent-reduction `rnumel` heuristic does not directly cover the dominant `argsort` path.
- The sort gate was widened from `256` to `512` by `16cd1aaa1dc` (2024-07-25), but the reported flex block-mask case is only ~106/107 blocks wide, so this issue is not explained by that change.
- Generic persistent reductions have been default-enabled since `e28ba6813d5` (2023-02-15); there is no evidence in current git history of a recent PyTorch-side default flip causing this bug.
- More recent history shows only targeted compile-time mitigations for pathological persistent `R0_BLOCK` on ROCm combo kernels (`174ef33342d`, `d428a3f9c9e`), which looks like a workaround for Triton compile cost rather than a root fix.

### Report artifacts
- Wrote `report.md` with the investigation conclusion: limiting `rnumel` is a workaround that restores fallback/non-persistent behavior, not the root fix.
- Generated `fix.diff` (empty, because no source changes were made in this investigation-only run).

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98