### PR TITLE
Resolve PYTHON_SIX_SOURCE_DIR from installed `six` to skip pypi download

### DIFF
--- a/cmake/External/nnpack.cmake
+++ b/cmake/External/nnpack.cmake
@@ -56,6 +56,34 @@ if(ANDROID OR IOS OR ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAM
   set(PTHREADPOOL_SOURCE_DIR "${CAFFE2_THIRD_PARTY_ROOT}/pthreadpool" CACHE STRING "pthreadpool source directory")
   set(GOOGLETEST_SOURCE_DIR "${CAFFE2_THIRD_PARTY_ROOT}/googletest" CACHE STRING "Google Test source directory")
 
+  # NNPACK's x86-64 PeachPy codegen runs with PYTHON_SIX_SOURCE_DIR on its
+  # PYTHONPATH; if the var is unset NNPACK fetches six from pypi at configure
+  # time, which fails on network-restricted runners (e.g. OSDC). Resolve it
+  # from the already-pip-installed `six` instead. PyTorch's top-level
+  # CMakeLists uses the modern FindPython, which sets `Python_EXECUTABLE`;
+  # the legacy `PYTHON_EXECUTABLE` is only populated later by NNPACK's own
+  # FIND_PACKAGE(PythonInterp) call, so we must not rely on it here.
+  if(NOT DEFINED PYTHON_SIX_SOURCE_DIR)
+    if(Python_EXECUTABLE)
+      set(_nnpack_python "${Python_EXECUTABLE}")
+    elseif(PYTHON_EXECUTABLE)
+      set(_nnpack_python "${PYTHON_EXECUTABLE}")
+    endif()
+    if(_nnpack_python)
+      execute_process(
+        COMMAND "${_nnpack_python}" -c
+          "import importlib.util, os, sys; s = importlib.util.find_spec('six'); print(os.path.dirname(s.origin)) if s and s.origin else sys.exit(1)"
+        OUTPUT_VARIABLE _six_dir
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE _six_rc
+        ERROR_QUIET)
+      if(_six_rc EQUAL 0 AND _six_dir)
+        set(PYTHON_SIX_SOURCE_DIR "${_six_dir}" CACHE STRING "six (Python package) source directory")
+        message(STATUS "Resolved PYTHON_SIX_SOURCE_DIR from installed six: ${_six_dir}")
+      endif()
+    endif()
+  endif()
+
   if(NOT TARGET nnpack)
     set(NNPACK_BUILD_TESTS OFF CACHE BOOL "")
     set(NNPACK_BUILD_BENCHMARKS OFF CACHE BOOL "")


### PR DESCRIPTION
NNPACK's `cmake/DownloadSix.cmake` fetches `six-1.11.0.tar.gz` from `pypi.python.org` at configure time on x86-64 unless `PYTHON_SIX_SOURCE_DIR` is predefined. Network-restricted runners (OSDC) can't reach pypi and fail the configure step with `SSL connect error`.

For example, https://github.com/pytorch/pytorch/actions/runs/25463806591/job/74712279279#step:8:625

```
CMake Error at /__w/pytorch/pytorch/build/confu-deps/six-download/six-prefix/src/six-stamp/download-six.cmake:163 (message):
  Each download failed!

    error: downloading 'https://pypi.python.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe/six-1.11.0.tar.gz' failed
          status_code: 35
          status_string: "SSL connect error.  If this is due to https certificate verification failure, one may set environment variable CMAKE_TLS_VERIFY=0 to suppress it."
          log:
          --- LOG BEGIN ---
          timeout on name lookup is not supported

  Host pypi.python.org:443 was resolved.

  IPv6: 2a04:4e42:83::223

  IPv4: 146.75.76.223

    Trying [2a04:4e42:83::223]:443...

  Immediate connect fail for 2a04:4e42:83::223: Unknown error 101
```

`six` is already required at runtime and is pinned in `.ci/docker/requirements-ci.txt`, so query the active Python interpreter for its location and feed that path to NNPACK. NNPACK uses the var only as a PYTHONPATH entry when invoking PeachPy codegen, so a site-packages directory containing `six.py` is sufficient.

Upstream NNPACK is dormant and the same URL still ships on its master, so this is the practical place to fix it. 

### Testing

https://github.com/pytorch/pytorch/actions/runs/25471598390/job/74736495831#step:8:566

Authored by Claude.