### PR TITLE
[MPS] Zero-copy CPU->MPS via memcpy on Apple Silicon UMA

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -163,7 +163,10 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool
 }
 
 // Copies tensor from cpu to mps backed by identical strided-contiguous data
-static void copy_to_mps_stride_contig(at::Tensor& dst, const at::Tensor& src, bool non_blocking) {
+static void copy_to_mps_stride_contig(at::Tensor& dst,
+                                      const at::Tensor& src,
+                                      bool non_blocking,
+                                      bool is_direct = false) {
   MPSStream* stream = getCurrentMPSStream();
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   auto dst_byte_offset = dst.storage_offset() * dst.itemsize();
@@ -173,6 +176,27 @@ static void copy_to_mps_stride_contig(at::Tensor& dst, const at::Tensor& src, bo
   const void* host_src = static_cast<const char*>(src.storage().data()) + src_byte_offset;
 
   TORCH_INTERNAL_ASSERT(src.dtype() == dst.dtype() && src.strides() == dst.strides() && is_dense_in_storage(src));
+  TORCH_INTERNAL_ASSERT(host_src != nullptr, "CPU source storage data is null");
+
+  // Fast path: on Apple Silicon (unified memory), MPS buffers use MTLStorageModeShared.
+  // CPU can write directly to the shared buffer without issuing a Metal blit command.
+  // Restrict this to strict tensor-to-tensor copies only; scalar/broadcast-style copy_
+  // semantics must go through the normal path to preserve correctness in compiled/dynamic
+  // shape flows.
+  const bool strict_elementwise_copy = src.numel() == dst.numel() && src.nbytes() == dst.nbytes() && src.numel() > 1;
+  if (is_direct && !non_blocking && strict_elementwise_copy && [destBuffer storageMode] == MTLStorageModeShared) {
+    // Preserve stream ordering semantics for blocking copy_: previous queued GPU writes to
+    // destination must complete before direct CPU write, otherwise later completion of those
+    // writes can clobber memcpy results (e.g. zeros_like + copy_(scalar) in compiled flows).
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      stream->synchronize(SyncType::COMMIT_AND_WAIT);
+      void* contents = [destBuffer contents];
+      TORCH_INTERNAL_ASSERT(contents != nullptr, "MTLBuffer contents is null");
+      void* dst_ptr = static_cast<char*>(contents) + dst_byte_offset;
+      std::memcpy(dst_ptr, host_src, size_to_copy);
+    });
+    return;
+  }
 
   @autoreleasepool {
     MTLResourceOptions options = MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeShared;
@@ -220,8 +244,12 @@ static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_, bool n
     needs_copy = true;
     dst = at::empty_like(src, at::device(at::kMPS));
   }
-  copy_to_mps_stride_contig(dst, src, non_blocking && !needs_copy);
-  return needs_copy ? dst_.copy_(dst) : dst_;
+  copy_to_mps_stride_contig(dst, src, non_blocking && !needs_copy, /*is_direct=*/!needs_copy);
+  if (needs_copy) {
+    dst_.copy_(dst);
+    return dst_;
+  }
+  return dst_;
 }
 
 void copy_blit_mps(void* dst, const void* src, size_t size) {

--- a/benchmarks/bench_mps_copy_to_mps.py
+++ b/benchmarks/bench_mps_copy_to_mps.py
@@ -1,0 +1,34 @@
+"""Benchmark copy_to_mps_stride_contig (CPU->MPS): zero-copy fast path vs blit (PR #182749).
+
+On Apple Silicon UMA, CPU and GPU share physical memory. This PR adds a fast path in
+copy_to_mps_stride_contig: for contiguous, same-dtype copies, write directly to the
+MTLBuffer's CPU-visible memory via [destBuffer contents] + memcpy. No Metal blit needed.
+
+Fast path: [destBuffer contents] + memcpy  (bandwidth-bound, no GPU command)
+Blit path: encode blit command + GPU staging copy (command overhead dominates at small sizes)
+
+Usage:
+    python benchmarks/bench_mps_copy_to_mps.py
+"""
+
+import torch
+from torch.utils.benchmark import Timer
+
+
+sizes_kb = [64, 256, 1024, 4096, 16384]
+
+print(f"torch={torch.__version__}  device=mps (Apple Silicon UMA)")
+print("Methodology: torch.utils.benchmark.Timer.blocked_autorange (median +/- IQR)")
+print()
+print(f"{'Size':>10} {'to(mps) (us)':>14}  {'GB/s':>6}")
+print("-" * 36)
+
+for kb in sizes_kb:
+    n = kb * 1024 // 4  # float32 = 4 bytes
+    setup = f"import torch; x = torch.randn({n})"  # CPU tensor
+    stmt = "x.to('mps'); torch.mps.synchronize()"
+    t = Timer(stmt=stmt, setup=setup).blocked_autorange(min_run_time=1.0)
+    bw = (kb / 1024) / (t.median * 1e3)  # GB/s
+    print(
+        f"{str(kb) + 'KB':>10} {t.median * 1e6:>10.2f} +/- {t.iqr * 1e6:<6.2f}  {bw:>5.1f}"
+    )

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -2972,6 +2972,71 @@ class TestMPS(TestCaseMPS):
         mps_x.transpose_(0, 1)
         self.assertEqual(cpu_x, mps_x.to('cpu'))
 
+
+    def test_cpu_to_mps_zero_copy(self):
+        # Correctness for the UMA zero-copy CPU->MPS fast path ([destBuffer contents] + memcpy).
+        # Covers: all float/int dtypes contiguous, non-contiguous (clone then fast path),
+        # storage_offset > 0, zero-size, non_blocking=True, dtype cast (goes through clone).
+        dtypes = [
+            torch.float32, torch.float16, torch.bfloat16,
+            torch.int32, torch.int64, torch.int8, torch.uint8, torch.bool,
+        ]
+        for dtype in dtypes:
+            if dtype.is_floating_point:
+                cpu_ref = torch.randn(128, 128).to(dtype)
+            elif dtype == torch.bool:
+                cpu_ref = torch.randint(0, 2, (128, 128), dtype=dtype)
+            else:
+                cpu_ref = torch.randint(0, 10, (128, 128), dtype=dtype)
+
+            # Contiguous same-dtype: fast path
+            mps_result = cpu_ref.to("mps")
+            self.assertEqual(cpu_ref, mps_result.cpu(), msg=f"contiguous {dtype}")
+
+            # Non-contiguous CPU tensor: cloned to contiguous first, then fast path
+            cpu_nc = cpu_ref[:, ::2]
+            self.assertFalse(cpu_nc.is_contiguous())
+            mps_nc = cpu_nc.to("mps")
+            self.assertEqual(cpu_nc, mps_nc.cpu(), msg=f"non-contiguous {dtype}")
+
+            # storage_offset > 0 on CPU src: dense_in_storage check passes (sliced rows)
+            cpu_sl = cpu_ref[1:, :]
+            mps_sl = cpu_sl.to("mps")
+            self.assertEqual(cpu_sl, mps_sl.cpu(), msg=f"storage_offset {dtype}")
+
+            # dtype cast: copy_to_mps_ handles this via src_.to(dst_.dtype()) before calling us
+            if dtype != torch.float32 and dtype.is_floating_point:
+                cpu_fp32 = cpu_ref.float()
+                mps_cast = cpu_ref.to("mps", dtype=torch.float32)
+                self.assertEqual(cpu_fp32, mps_cast.cpu(), msg=f"cast {dtype}->float32")
+
+        # zero-size tensor
+        z = torch.empty(0)
+        self.assertEqual(z.to("mps").cpu(), z)
+
+        # non_blocking=True: goes through blit path (fast path is gated on !non_blocking); result correct after sync
+        cpu_ref2 = torch.randn(64, 64)
+        mps_nb = cpu_ref2.to("mps", non_blocking=True)
+        torch.mps.synchronize()
+        self.assertEqual(cpu_ref2, mps_nb.cpu(), msg="non_blocking=True")
+
+        # round-trip: CPU->MPS->CPU
+        cpu_orig = torch.randn(256, 256)
+        self.assertEqual(cpu_orig, cpu_orig.to("mps").to("cpu"), msg="round-trip")
+
+    def test_cpu_to_mps_zero_copy_ordering(self):
+        # The fast path's COMMIT_AND_WAIT must drain pending GPU writes to the
+        # destination before the CPU memcpy; otherwise a later-completing GPU
+        # fill clobbers the copied data. Construct a dest with queued GPU work,
+        # overwrite it via the fast path, and check the memcpy result wins.
+        N = 4096
+        for _ in range(50):  # repeat to surface any ordering race
+            dst = torch.full((N,), 7.0, device="mps")  # queues a GPU fill
+            src = torch.arange(N, dtype=torch.float32)  # contiguous CPU source
+            dst.copy_(src)  # blocking, same-dtype, numel>1 -> fast path
+            torch.mps.synchronize()
+            self.assertEqual(dst.cpu(), src)  # memcpy result, not the 7.0 fill
+
     def test_expand_cpu_to_mps_copy(self):
         # https://github.com/pytorch/pytorch/issues/78642
 


### PR DESCRIPTION
Tracked under #187455 until a dedicated UMA/direct-memory tracking issue exists.

## Current status

Pending rework into the UMA stack. Please do not review this as the final standalone shape.

Order:

1. UMA base helper: shared `MTLStorageModeShared` pointer detection plus stream-queue synchronization.
2. Scalar-read leaf: #182731.
3. MPS->CPU copy leaf: #182736.
4. This PR: CPU->MPS contiguous same-dtype copy leaf.
5. Fill/zero leaf: #182791.

This PR should contain only the CPU->MPS direct-write fast path, fallback coverage, benchmark, and tests. The common direct-memory/synchronization helper should live in the base split, not be duplicated here.

## Summary

On Apple Silicon, `MTLStorageModeShared` buffers expose a CPU-writable pointer via
`[buffer contents]`. For contiguous same-dtype CPU->MPS copies, this can `memcpy`
directly instead of issuing a Metal blit command.

The leaf fast path is gated on direct contiguous same-dtype copies and preserves
the existing fallbacks for non-blocking, non-contiguous, dtype-cast, and other
non-direct cases.

## Benchmark (M4 Pro, fast path vs forced blit)

| Size | Blit | Fast path | Speedup | GB/s |
| --- | --- | --- | --- | --- |
| 64 KB | 113.5 us | 1.50 us | 75.7x | 41.6 |
| 256 KB | 109.4 us | 4.25 us | 25.7x | 58.8 |
| 1 MB | 119.1 us | 13.5 us | 8.8x | 74.2 |
| 4 MB | 159.7 us | 51.2 us | 3.1x | 78.2 |
| 16 MB | 445.5 us | 230.3 us | 1.93x | 69.5 |

## Test Plan

Refresh after the UMA base helper is split out:

```
python test/test_mps.py -k copy_to_mps
python benchmarks/bench_mps_copy_to_mps.py
```

Tests should cover all dtypes, storage offsets, non-contiguous fallback, dtype-cast fallback, non-blocking fallback, and multi-threaded copy.

Authored with Claude.
