### PR TITLE
[CI] Check installed git version during Docker build (#182228)

### DIFF
--- a/.ci/docker/common/install_base.sh
+++ b/.ci/docker/common/install_base.sh
@@ -69,6 +69,14 @@ install_ubuntu() {
   # see: https://github.com/pytorch/pytorch/issues/65931
   apt-get install -y libgnutls30
 
+  GIT_VERSION=$(git --version | awk '{print $3}')
+  GIT_MAJOR=${GIT_VERSION%%.*}
+  GIT_MINOR=${GIT_VERSION#*.}; GIT_MINOR=${GIT_MINOR%%.*}
+  if (( GIT_MAJOR < 2 || (GIT_MAJOR == 2 && GIT_MINOR < 36) )); then
+    echo "ERROR: git ${GIT_VERSION} is too old; need >= 2.36" >&2
+    exit 1
+  fi
+
   # Cleanup package manager
   apt-get autoclean && apt-get clean
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
And error out if it's older than 2.36 (first one to support tree-less checkouts)

Otherwise, when ppa.launchpad.net is down, an much older version of git will get installed, that will fail on treeless checkout action

See https://github.com/pytorch/pytorch/issues/182227