### PR TITLE
[aoti] Fix arrayref proxy executor tensor args

### DIFF
--- a/test/inductor/test_aot_inductor_arrayref.py
+++ b/test/inductor/test_aot_inductor_arrayref.py
@@ -64,6 +64,44 @@ def fail_minimal_arrayref_interface(is_skip=False):
 
 
 class AOTInductorArrayRefTestsTemplate(AOTInductorTestsTemplate):
+    def test_proxy_executor_runtime_lookup_handles_arrayref_tensor_inputs(self):
+        @torch.library.custom_op(
+            "aoti_arrayref_test::proxy_executor_tensor_arg", mutates_args=()
+        )
+        def proxy_executor_tensor_arg(
+            x: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            return x + 1, x + 2
+
+        @proxy_executor_tensor_arg.register_fake
+        def _(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            return torch.empty_like(x), torch.empty_like(x)
+
+        class Model(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                y, z = torch.ops.aoti_arrayref_test.proxy_executor_tensor_arg(x)
+                return y + z
+
+        example_inputs = (torch.randn(4, device=self.device),)
+        model = Model()
+        with config.patch(
+            {
+                "aot_inductor.allow_stack_allocation": self.allow_stack_allocation,
+                "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
+            }
+        ):
+            # run() compiles the generated wrapper.cpp into an AOTI package before
+            # loading it, so this catches ArrayRefTensor -> AtenTensorHandle C++
+            # compiler failures in the proxy-executor path.
+            actual, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.run, model, example_inputs
+            )
+
+        self.assertTrue(torch.allclose(actual, model(*example_inputs)))
+        FileCheck().check("aoti_torch_proxy_executor_call_function").check(
+            "borrow_arrayref_tensor_as_tensor("
+        ).run(code)
+
     def test_simple_v2_interface(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3239,6 +3239,9 @@ if (!custom_op_wrapper) {
         int_call_str = self._generate_temporary_array_pointer(
             "int64_t", int_call_args, force_mutable=True
         )
+        tensor_call_args = self.codegen_runtime_lookup_tensor_call_args(
+            tensor_call_args
+        )
         tensor_call_str = self._generate_temporary_array_pointer(
             "AtenTensorHandle", tensor_call_args, force_mutable=True
         )
@@ -3252,6 +3255,11 @@ if (!custom_op_wrapper) {
             f"{len(tensor_call_args)}, "
             f"{tensor_call_str}));"
         )
+
+    def codegen_runtime_lookup_tensor_call_args(
+        self, tensor_call_args: Sequence[str]
+    ) -> Sequence[str]:
+        return tensor_call_args
 
     def generate_reset_kernel_saved_flags(self):
         pass

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -1116,6 +1116,12 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             buf_name, python_kernel_name, get_args, op_overload, raw_args, outputs
         )
 
+    def codegen_runtime_lookup_tensor_call_args(
+        self, tensor_call_args: Sequence[str]
+    ) -> Sequence[str]:
+        self._assert_safe_to_use_borrow_arrayref_tensor_as_tensor()
+        return [f"borrow_arrayref_tensor_as_tensor({arg})" for arg in tensor_call_args]
+
     def codegen_device_copy(self, src, dst, non_blocking: bool | str):
         # aoti_torch_tensor_copy_ takes AtenTensorHandle as input,
         # while stack-allocation results in ArrayRefTensor


### PR DESCRIPTION
Summary:
Fix the AOT proxy-executor runtime lookup path for minimal-arrayref wrappers. The proxy-executor API takes an AtenTensorHandle array, but minimal-arrayref graph inputs are emitted as ArrayRefTensor<T>. When a custom op is routed through proxy executor, the generated wrapper tried to construct std::array<AtenTensorHandle, ...>{arg0_1, ...}, which fails to compile because arg0_1 is an ArrayRefTensor.

The fix keeps the proxy-executor call emission centralized in CppWrapperCpu. The base emitter now calls a small codegen_runtime_lookup_tensor_call_args hook immediately before constructing the AtenTensorHandle argument array. The default hook is identity. CppWrapperCpuArrayRef overrides the hook to wrap tensor args with borrow_arrayref_tensor_as_tensor(...), so ArrayRefTensor inputs are converted to borrowed AtenTensorHandle values only for the arrayref wrapper.

This avoids duplicating generate_fallback_kernel_with_runtime_lookup_aot while keeping the arrayref-specific conversion in cpp_wrapper_cpu_array_ref.py.

The diff also adds a regression test with a custom op that forces the AOT proxy-executor path and uses AOTIRunnerUtil.run so generated wrapper.cpp is compiled and loaded, not just FileChecked.

Test Plan:
Reproduced the failure before the fix with the new regression test.

The test intentionally routes a minimal-arrayref AOTI model through the AOT proxy-executor runtime lookup path, then uses AOTIRunnerUtil.run so the generated wrapper.cpp is actually compiled and loaded.

After adding the hook at the existing proxy-executor emission site and overriding it in CppWrapperCpuArrayRef to wrap tensor args with borrow_arrayref_tensor_as_tensor(...), the targeted regression test passed:

```
buck test fbcode//mode/opt fbcode//caffe2/test/inductor:aot_inductor_arrayref_cpu_local -- test_proxy_executor_runtime_lookup_handles_arrayref_tensor_inputs_cpu_with_stack_allocation_and_minimal_arrayref_interface
```

Reviewed By: ColinPeppler, desertfire

Differential Revision: D104122896




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo