### PR TITLE
[CI] Add A100 OSDC mapping and migrate inductor A100 perf nightly

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -22,6 +22,7 @@ self-hosted-runner:
     - linux.arm64.m7g.4xlarge
     - linux.arm64.m7g.4xlarge.ephemeral
     - linux.arm64.r7g.12xlarge.memory
+    - linux.aws.a100
     - linux.aws.h100
     - linux.aws.h100.4
     - linux.aws.h100.8

--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -83,6 +83,10 @@ runner_mapping:
   linux.arm64.m7g.metal: l-barm64g4-62-226                       # m7g.metal
 
 
+  # ---- x86 GPU — A100 (p4de family) ----
+
+  linux.aws.a100: l-x86iavx512-11-125-a100                          # 1 GPU
+
   # ---- x86 GPU — H100 (p5 family) ----
 
   linux.aws.h100: l-x86iamx-22-225-h100                             # 1 GPU

--- a/.github/workflows/inductor-perf-test-nightly.yml
+++ b/.github/workflows/inductor-perf-test-nightly.yml
@@ -76,6 +76,7 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+      check_experiments: arc
       opt_out_experiments: lf
 
   build:
@@ -113,12 +114,18 @@ jobs:
         ]}
       selected-test-configs: ${{ inputs.benchmark_configs }}
       build-additional-packages: "vision audio fbgemm torchao"
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   test-nightly:
     name: cuda13.0-py3.10-gcc11-sm80
     uses: ./.github/workflows/_linux-test.yml
-    needs: build
+    needs:
+      - build
+      - get-label-type
     if: github.event.schedule == '0 7 * * 1-6'
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
@@ -129,12 +136,18 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   test-weekly:
     name: cuda13.0-py3.10-gcc11-sm80
     uses: ./.github/workflows/_linux-test.yml
-    needs: build
+    needs:
+      - build
+      - get-label-type
     if: github.event.schedule == '0 7 * * 0'
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
@@ -146,12 +159,18 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   test:
     name: cuda13.0-py3.10-gcc11-sm80
     uses: ./.github/workflows/_linux-test.yml
-    needs: build
+    needs:
+      - build
+      - get-label-type
     if: github.event_name == 'workflow_dispatch'
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
@@ -162,4 +181,8 @@ jobs:
       disable-monitor: false
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #182758
* #182757
* #182756
* #182755
* #182754
* __->__ #182753

Add `linux.aws.a100` -> `l-x86iavx512-11-125-a100` to .github/arc.yaml so
map_ec2_to_arc.py can translate A100 jobs to the new OSDC ARC runners
(p4de.24xlarge, 1x A100 80GB), and whitelist the label in actionlint.yaml.

Wire the dial-up pattern (`check_experiments: arc`, `use-arc`,
`python-version`/`compiler`/`cuda-version`) into
inductor-perf-test-nightly's build and three test jobs so the workflow
moves to OSDC when the runner-determinator opts the ARC experiment in.

The arc.yaml/actionlint.yaml addition is a prerequisite for the
subsequent per-workflow migrations.

### Testing

https://github.com/pytorch/pytorch/actions/runs/25471464987

Authored by Claude.