### PR TITLE
[CI] Migrate operator_microbenchmark A100/H100 jobs to OSDC

### DIFF
--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -47,17 +47,27 @@ jobs:
           { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.aws.h100" },
           { config: "operator_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.aws.a100" },
         ]}
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   opmicrobenchmark-test:
     name: opmicrobenchmark-test
     uses: ./.github/workflows/_linux-test.yml
-    needs: opmicrobenchmark-build
+    needs:
+      - opmicrobenchmark-build
+      - get-label-type
     with:
       timeout-minutes: 500
       build-environment: ${{ needs.opmicrobenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.opmicrobenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.opmicrobenchmark-build.outputs.test-matrix }}
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   # B200 runner (OSDC), always use OSDC runner to test this workflow

--- a/.github/workflows/operator_microbenchmark.yml
+++ b/.github/workflows/operator_microbenchmark.yml
@@ -38,6 +38,7 @@ jobs:
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       runner: linux.12xlarge.memory
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11-sm80
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #182758
* #182757
* #182756
* #182755
* __->__ #182754
* #182753

opmicrobenchmark-build/opmicrobenchmark-test share a matrix that targets
both linux.aws.a100 and linux.aws.h100. Add the dial-up plumbing
(use-arc + python-version/compiler/cuda-version, plus get-label-type as
a direct dependency on the test job) so both runners switch to OSDC
ARC when the runner-determinator enables the arc experiment.

Authored by Claude.