### PR TITLE
[CI] Migrate attention_op_microbenchmark A100/H100 jobs to OSDC

### DIFF
--- a/.github/workflows/attention_op_microbenchmark.yml
+++ b/.github/workflows/attention_op_microbenchmark.yml
@@ -33,6 +33,7 @@ jobs:
   attn-microbenchmark-build:
     if: github.repository_owner == 'pytorch'
     uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
     with:
       runner: linux.12xlarge.memory
       build-environment: linux-jammy-cuda13.0-py3.10-gcc11-sm80
@@ -43,17 +44,27 @@ jobs:
           { config: "attention_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.aws.a100" },
           { config: "attention_microbenchmark_test", shard: 1, num_shards: 1, runner: "linux.aws.h100" },
         ]}
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   attn-microbenchmark-test:
     name: attn-microbenchmark-test
     uses: ./.github/workflows/_linux-test.yml
-    needs: attn-microbenchmark-build
+    needs:
+      - attn-microbenchmark-build
+      - get-label-type
     with:
       timeout-minutes: 500
       build-environment: ${{ needs.attn-microbenchmark-build.outputs.build-environment }}
       docker-image: ${{ needs.attn-microbenchmark-build.outputs.docker-image }}
       test-matrix: ${{ needs.attn-microbenchmark-build.outputs.test-matrix }}
+      use-arc: ${{ needs.get-label-type.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   # B200 runner (OSDC), always use OSDC runner to test this workflow


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #182758
* #182757
* #182756
* __->__ #182755
* #182754
* #182753

attn-microbenchmark-build/attn-microbenchmark-test share a matrix that
targets both linux.aws.a100 and linux.aws.h100. Wire the dial-up plumbing
(use-arc + python-version/compiler/cuda-version, plus get-label-type as
a direct dependency on the test job) so both runners switch to OSDC
ARC when the runner-determinator enables the arc experiment.

Authored by Claude.