### PR TITLE
[CI] Migrate inductor-A100-perf-compare to OSDC ARC

### DIFF
--- a/.github/workflows/inductor-perf-compare.yml
+++ b/.github/workflows/inductor-perf-compare.yml
@@ -25,6 +25,7 @@ jobs:
       issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
       curr_branch: ${{ github.head_ref || github.ref_name }}
       curr_ref_type: ${{ github.ref_type }}
+      check_experiments: arc
       opt_out_experiments: lf
 
   build:
@@ -46,12 +47,18 @@ jobs:
           { config: "inductor_torchbench_perf_compare", shard: 1, num_shards: 1, runner: "linux.aws.a100" },
         ]}
       build-additional-packages: "vision audio fbgemm torchao"
+      use-arc: ${{ needs.get-default-label-prefix.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit
 
   test:
     name: cuda13.0-py3.10-gcc11-sm80
     uses: ./.github/workflows/_linux-test.yml
-    needs: build
+    needs:
+      - build
+      - get-default-label-prefix
     with:
       build-environment: ${{ needs.build.outputs.build-environment }}
       docker-image: ${{ needs.build.outputs.docker-image }}
@@ -61,4 +68,8 @@ jobs:
       monitor-log-interval: 15
       monitor-data-collect-interval: 4
       export-profiler-trace: "1"
+      use-arc: ${{ needs.get-default-label-prefix.outputs.use-arc == 'true' }}
+      python-version: "3.10"
+      compiler: gcc11
+      cuda-version: "13.0"
     secrets: inherit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #182758
* __->__ #182757
* #182756
* #182755
* #182754
* #182753

Add the ARC dial-up plumbing (check_experiments: arc, use-arc + the
python-version/compiler/cuda-version inputs, and a direct
get-default-label-prefix dependency on the test job) so the A100 perf
comparison shards run on OSDC ARC when the runner-determinator enables
the arc experiment.

Authored by Claude.