### PR TITLE
[dynamo_compile] Log functorch_config to Scuba per compile region (#182762)

### DIFF
--- a/test/dynamo/test_utils.py
+++ b/test/dynamo/test_utils.py
@@ -655,6 +655,7 @@ class TestDynamoTimed(TestCase):
             e.co_filename = None
             e.co_firstlineno = None
             e.inductor_config = None
+            e.functorch_config = None
             e.compiler_config = None
             e.cuda_version = None
             e.triton_version = None
@@ -714,6 +715,7 @@ class TestDynamoTimed(TestCase):
  'fail_user_frame_filename': None,
  'fail_user_frame_lineno': None,
  'frame_key': '1',
+ 'functorch_config': None,
  'gc_time_us': 0,
  'graph_input_count': 3,
  'graph_node_count': 5,
@@ -807,6 +809,7 @@ class TestDynamoTimed(TestCase):
  'fail_user_frame_filename': None,
  'fail_user_frame_lineno': None,
  'frame_key': '1',
+ 'functorch_config': None,
  'gc_time_us': 0,
  'graph_input_count': 3,
  'graph_node_count': 5,
@@ -914,6 +917,7 @@ class TestDynamoTimed(TestCase):
  'fail_user_frame_filename': None,
  'fail_user_frame_lineno': None,
  'frame_key': None,
+ 'functorch_config': None,
  'gc_time_us': None,
  'graph_input_count': None,
  'graph_node_count': None,
@@ -1007,6 +1011,7 @@ class TestDynamoTimed(TestCase):
  'fail_user_frame_filename': None,
  'fail_user_frame_lineno': None,
  'frame_key': None,
+ 'functorch_config': None,
  'gc_time_us': None,
  'graph_input_count': None,
  'graph_node_count': None,
@@ -1319,6 +1324,39 @@ class TestInductorConfigParsingForLogging(TestCase):
         mocked_inductor_config.get_config_copy.return_value = None
         inductor_config_json = utils._scrubbed_inductor_config_for_logging()
         self.assertEqual(inductor_config_json, expected)
+
+
+class TestFunctorchConfigParsingForLogging(TestCase):
+    def test_functorch_config_jsonify(self):
+        functorch_config_json = utils._functorch_config_for_logging()
+        self.assertIsInstance(functorch_config_json, str)
+        parsed = json.loads(functorch_config_json)
+        self.assertIn("activation_memory_budget", parsed)
+        self.assertEqual(parsed["activation_memory_budget"], 1.0)
+
+    def test_functorch_config_blocklist(self):
+        functorch_config_json = utils._functorch_config_for_logging()
+        parsed = json.loads(functorch_config_json)
+        self.assertNotIn("TYPE_CHECKING", parsed)
+        self.assertNotIn("_save_config_ignore", parsed)
+
+    @mock.patch("torch._dynamo.utils.torch._functorch.config")
+    def test_functorch_config_none(self, mocked_config):
+        mocked_config.get_config_copy.side_effect = AttributeError
+        result = utils._functorch_config_for_logging()
+        self.assertIsNone(result)
+
+    @mock.patch("torch._dynamo.utils.torch._functorch.config")
+    def test_functorch_config_runtime_error(self, mocked_config):
+        mocked_config.get_config_copy.side_effect = RuntimeError
+        result = utils._functorch_config_for_logging()
+        self.assertIsNone(result)
+
+    @mock.patch("torch._dynamo.utils.justknobs_check", return_value=False)
+    def test_functorch_config_jk_disabled(self, mocked_jk):
+        result = utils._functorch_config_for_logging()
+        self.assertIsNone(result)
+        mocked_jk.assert_called_once_with("pytorch/dynamo:log_functorch_config")
 
 
 if __name__ == "__main__":

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1594,6 +1594,7 @@ class CompilationMetrics:
     inline_inbuilt_nn_modules_candidate: bool | None = False
     pytorch_version: str | None = None
     inductor_provenance: set[str] | None = None
+    functorch_config: str | None = None
 
     @classmethod
     def create(cls, metrics: dict[str, Any]) -> CompilationMetrics:
@@ -1845,6 +1846,31 @@ def _scrubbed_inductor_config_for_logging() -> str | None:
     return inductor_conf_str
 
 
+def _functorch_config_for_logging() -> str | None:
+    """Serialize functorch config (AOT autograd settings) for Scuba logging."""
+    if not justknobs_check("pytorch/dynamo:log_functorch_config"):
+        return None
+
+    try:
+        functorch_config_copy = torch._functorch.config.get_config_copy()
+    except (TypeError, AttributeError, RuntimeError, AssertionError):
+        return None
+
+    try:
+        blocklist = {
+            "TYPE_CHECKING",
+            "_save_config_ignore",
+        }
+        clean = {
+            k: (list(v) if isinstance(v, set) else v)
+            for k, v in functorch_config_copy.items()
+            if k not in blocklist and isinstance(k, str)
+        }
+        return json.dumps(clean, sort_keys=True, default=str)
+    except Exception:
+        return "Functorch Config is not JSON serializable"
+
+
 def record_compilation_metrics(
     start_time_ns: int,
     end_time_ns: int,
@@ -1891,6 +1917,7 @@ def record_compilation_metrics(
         "inductor_fx_remote_cache_backend_type": inductor_fx_remote_cache_backend_type,
         "python_version": sys.version,
         "pytorch_version": torch.__version__,
+        "functorch_config": _functorch_config_for_logging(),
     }
 
     compilation_metrics = CompilationMetrics.create({**common_metrics, **metrics})


### PR DESCRIPTION
Summary:

Adds `functorch_config` as a JSON blob column in the `dynamo_compile` Scuba table,
completing the visibility into all three stages of the torch.compile() pipeline:

```
Python code
    ↓
[dynamo_config]       ← Graph capture: tracing, guards, cache     ✅ already logged
    ↓ FX Graph
[functorch_config]    ← AOT Autograd: partitioning, AutoAC        ← THIS DIFF
    ↓ Forward + Backward graphs
[inductor_config]     ← Code generation: triton, fusion, tuning   ✅ already logged
    ↓ Compiled code
```

`functorch_config` captures AOT autograd settings per compile region, including:
- `activation_memory_budget` — AutoAC budget (0.0-1.0), the primary use case
- `activation_memory_budget_solver` — solver for min-cut partitioning (dp, ilp, greedy)
- `activation_memory_budget_runtime_estimator` — how op runtimes are estimated (flops, profile)
- Other functorch settings https://fburl.com/code/0zg42buq

Since `record_compilation_metrics` fires per compile region and `functorch_config_override.as_patch()`
sets per-FQN values, this captures the per-region budget — different modules can have different budgets.

**Use case example:**
- fire-jackienguyen-auto_ac_0504_204046: this job has autoac activation_memory_budget in pt2 config set as 0.1 as it inherits from model config. However, I custom override it via functorch_config to have activation_memory_budget=0.4. This logging will let us able to quickly check what is the correct budget that was set without checking job config/log.
- This enables efficiency automation platform to query `dynamo_compile` to check both "is PT2 on" and "what AutoAC budget is set" in a single query, without grepping job logs, which is expensive at scale.

Follows the same pattern as the existing `dynamo_config` and `inductor_config` JSON blob columns.

**Rollback safety:** Gated behind JK `pytorch/dynamo:log_functorch_config` (defaults to `True`). If
the new field causes issues, flip the JK to `False` to stop populating it without reverting the diff.

Exception handling matches the inductor config pattern (`TypeError, AttributeError, RuntimeError,
AssertionError`) to avoid losing all compilation metrics if `get_config_copy()` raises unexpectedly.

Test Plan:
## Unit tests

Added 5 tests in `TestFunctorchConfigParsingForLogging` (test/dynamo/test_utils.py):
- `test_functorch_config_jsonify` — verifies real functorch config serializes and contains `activation_memory_budget`
- `test_functorch_config_blocklist` — verifies `TYPE_CHECKING` and `_save_config_ignore` are excluded
- `test_functorch_config_none` — verifies graceful handling when `get_config_copy` raises `AttributeError`
- `test_functorch_config_runtime_error` — verifies graceful handling when `get_config_copy` raises `RuntimeError`
- `test_functorch_config_jk_disabled` — verifies JK `pytorch/dynamo:log_functorch_config` returns `None` when disabled

Updated 4 golden `CompilationMetrics` dicts to include `'functorch_config': None`.

Follows the same test pattern as `TestInductorConfigParsingForLogging` (D65806399).

```
buck2 test caffe2/test/dynamo:test_dynamo -- TestFunctorchConfigParsingForLogging
```

## Drift check

```
buck2 build --flagfile //mode/dev dsi/logger/thrift_configs/GeneratedDynamoCompileLoggerConfig:GeneratedDynamoCompileLoggerConfig_drift_check
```
Passes after running `loggercli codegen GeneratedDynamoCompileLoggerConfig`.

## Local serialization verification
```python
>>> import json
>>> from torch._dynamo import utils
>>> result = utils._functorch_config_for_logging()
>>> print(json.dumps(json.loads(result), indent=2))
{
  "activation_memory_budget": 1.0,
  "activation_memory_budget_runtime_estimator": "flops",
  "activation_memory_budget_solver": "dp",
  "debug_partitioner": false,
  "functionalize_rng_ops": false,
  "static_weight_shapes": true
}
```

## E2E verification (post-land)
After landing and next light_cli fbpkg build:
1. Run any MVAI job with PT2 compile enabled
2. Query: `SELECT functorch_config FROM dynamo_compile WHERE mast_job_name = '...' LIMIT 5`
3. Extract: `JSON_EXTRACT(functorch_config, '$.activation_memory_budget')`

Differential Revision: D104097781




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98