### PR TITLE
[ROCm][CI] Skip tests which consume excessive run time in CI

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -199,7 +199,7 @@ ROCM_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
     "distributed/pipelining/test_dtensor_pp_integration",
-    "inductor/test_cpu_repro", # excessive runtimes compared to CUDA
+    "inductor/test_cpu_repro",  # excessive runtimes compared to CUDA
 ]
 
 # Add architecture-specific blocklist entries

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -199,6 +199,7 @@ ROCM_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
     "distributed/pipelining/test_dtensor_pp_integration",
+    "inductor/test_cpu_repro", # excessive runtimes compared to CUDA
 ]
 
 # Add architecture-specific blocklist entries

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -74,6 +74,7 @@ from torch.testing._internal.common_utils import (
     IS_ARM64,
     IS_LINUX,
     IS_WINDOWS,
+    TEST_WITH_ROCM,
     run_tests,
     skipIfTorchDynamo,
     xfailIf,
@@ -5475,6 +5476,9 @@ class TestVisionTracing(JitTestCase):
             )
             kwargs = dict(num_classes=50)
             model_test = cls.generate_test_fn(k, x, kwargs)
+            model_test = unittest.skipIf(
+                TEST_WITH_ROCM, "Skipped on ROCm"
+            )(model_test)
             setattr(cls, test_name, model_test)
 
     @classmethod


### PR DESCRIPTION
## Motivation
ROCm test jobs on trunk have been [timing out intermittently](https://hud.pytorch.org/hud/pytorch/pytorch/c229b735fe475f5d312a202b711156a28290ffe2/4?per_page=50&name_filter=trunk%20.*rocm&useRegexFilter=true&mergeEphemeralLF=true). It doesn't appear to be a case of under-sharding due to faulty test-times.json data. Identify various slow-running tests for ROCm and skip them while we debug the root cause of their slowness. The intention is to get back to 6/4 shards for default/distributed, if possible, to relieve [extra pressure on CI capacity](https://hud.pytorch.org/queue_time_analysis?dateRange=3&startDate=2026-05-05T04%3A43%3A30.180Z&endDate=2026-05-08T04%3A43%3A30.180Z&granularity=half_hour&chartType=bar&repos=pytorch%2Fpytorch&category=machine_type&machineTypes=linux.rocm.gpu.gfx950.1&machineTypes=linux.rocm.gpu.gfx950.4&items=linux.rocm.gpu.gfx950.1&items=linux.rocm.gpu.gfx950.4) observed after [moving to more shards](https://github.com/pytorch/pytorch/pull/182646).

## Validation
* Confirmed that test_cpu_repro test suite is [entirely skipped for ROCm](https://github.com/pytorch/pytorch/actions/runs/25500017396/job/74832490125): `2026-05-07T14:17:36.2466312Z Excluding inductor/test_cpu_repro on ROCm`
* Confirmed that test_fx test_torchvision tests are [skipped for ROCm](https://github.com/pytorch/pytorch/actions/runs/25500017396/job/74832490157):
```
<testcase classname="TestVisionTracing" name="test_torchvision_models_convnext_base" time="0.000" file="test_fx.py">
<skipped type="pytest.skip" message="Skipped on ROCm">/var/lib/jenkins/pytorch/test/test_fx.py:5443: Skipped on ROCm</skipped>
</testcase>
<testcase classname="TestVisionTracing" name="test_torchvision_models_densenet121" time="0.000" file="test_fx.py">
<skipped type="pytest.skip" message="Skipped on ROCm">/var/lib/jenkins/pytorch/test/test_fx.py:5443: Skipped on ROCm</skipped>
</testcase>
```

cc @jeffdaily @sunway513 @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang