### PR TITLE
Fix typos in C++ comments

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -398,7 +398,7 @@ void GraphTaskGuard::restore_current_graph_task() {
   current_graph_task = std::move(last_graph_task_);
 }
 
-// The current graph task's exec_info is being used to trim unnecessary edegs
+// The current graph task's exec_info is being used to trim unnecessary edges
 // during node evaluation, see `Node.task_should_compute_output()` function.
 const std::unordered_map<Node*, GraphTask::ExecInfo>*
 get_current_graph_task_exec_info() {

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -370,8 +370,8 @@ std::vector<IValue> ScriptTypeParser::evaluateDefaults(
   // we are going to log all the calls for GraphFunction::run. The logging was
   // noisy we also call GraphFunction::run for the default value evaluation
   // which generates a lot of useless log samples. Therefore as a workaround we
-  // just directly use the executor API which avoids this placing producing
-  // un-necessary log entries.
+  // just directly use the executor API which avoids producing
+  // unnecessary log entries.
   gf->get_executor().run(stack);
   return stack.at(0).toTupleRef().elements().vec();
 }

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -617,7 +617,7 @@ auto handle_torch_function_no_python_arg_parser(
   // (5) FakeTensorMode.__torch_dispatch__ (infra modes next highest)
   // (6) FakeTensor.__torch_fake_dispatch__ (infra subclasses next highest)
 
-  // Why does do FunctionalTensor and FakeTensor even need to be special-cased
+  // Why do FunctionalTensor and FakeTensor even need to be special-cased
   // in the ordering?
   // In theory we could remove their __torch_dispatch__, but both of these
   // subclasses override sizes/strides metadata calls with __torch_dispatch__,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182767

Fix minor typos in comments across three files: "edegs" → "edges" in
autograd engine, "this placing producing un-necessary" → "producing
unnecessary" in script type parser, and "Why does do" → "Why do" in
python arg parser.

Authored with Claude (typo_terminator2).