### PR TITLE
fix(resize): rollback tensor metadata when storage resize fails

### DIFF
--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -204,6 +204,13 @@ static TensorImpl* _resize_impl_(
   const auto itemsize = self->dtype().itemsize();
   const auto storage_offset = self->generic_storage_offset<T>();
   T storage_size = T(1);
+
+  // Save old metadata so we can rollback if storage resize fails.
+  // This provides strong exception guarantee for non-resizable storage
+  // (e.g., numpy-backed tensors). See pytorch/pytorch#170298.
+  auto old_sizes = self->generic_sizes<T>().vec();
+  auto old_strides = self->generic_strides<T>().vec();
+
   if (stride) {
     self->set_sizes_and_strides(size, *stride);
     storage_size = at::detail::computeStorageNbytes(
@@ -215,7 +222,13 @@ static TensorImpl* _resize_impl_(
   }
 
   if (resize_storage) {
-    _maybe_resize_storage(self, std::move(storage_size));
+    try {
+      _maybe_resize_storage(self, std::move(storage_size));
+    } catch (...) {
+      // Rollback metadata to maintain strong exception guarantee
+      self->set_sizes_and_strides(old_sizes, old_strides);
+      throw;
+    }
   }
 
   return self;


### PR DESCRIPTION
## Summary

Provides **strong exception guarantee** for `resize_()` on non-resizable storage (e.g., numpy-backed tensors).

Previously, `_resize_impl_` updated tensor metadata (sizes/strides) *before* attempting to resize storage. When `_maybe_resize_storage` threw (e.g., for non-resizable numpy storage), the tensor was left in a "zombie" state — shape says one thing, storage says another.

This PR saves old sizes/strides before mutation and rolls them back if storage resize throws.

Fixes #170298

## Changes

- `aten/src/ATen/native/Resize.cpp`: Save old metadata before `set_sizes_and_strides`, wrap `_maybe_resize_storage` in try/catch, rollback on exception.

## Test plan

```python
import torch, numpy as np
a = torch.from_numpy(np.array([1, 2, 3]))
try:
    a.resize_(10)
except RuntimeError:
    pass
assert a.shape == (3,), f"Expected (3,) got {a.shape}"
assert a.numel() == 3
print("PASS: tensor metadata consistent after failed resize")
```

Before this fix: `a.shape == (10,)` (zombie tensor)
After this fix: `a.shape == (3,)` (metadata rolled back)

cc @ezyang