### PR TITLE
Fix typos across autograd, distributed, and export modules

### DIFF
--- a/torch/autograd/forward_ad.py
+++ b/torch/autograd/forward_ad.py
@@ -38,7 +38,7 @@ def enter_dual_level():
     if new_level != _current_level + 1:
         raise RuntimeError(
             "Entering a new forward AD level but the current level "
-            "is not valid. Make sure you did not modified it directly."
+            "is not valid. Make sure you did not modify it directly."
         )
     _current_level = new_level
     return new_level

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -428,7 +428,7 @@ def disable_saved_tensors_hooks(error_message: str) -> Generator[None, None, Non
 
     Args:
         error_message (str): When saved tensors default hooks are used when they
-                             have been are disabled, a RuntimeError with this
+                             have been disabled, a RuntimeError with this
                              error message gets raised.
 
     Example::

--- a/torch/csrc/distributed/c10d/reducer.hpp
+++ b/torch/csrc/distributed/c10d/reducer.hpp
@@ -529,7 +529,7 @@ class TORCH_API Reducer {
  private:
   // reset counting for buckets before backward starts
   void reset_bucket_counting();
-  // search unused parameters beore backward starts
+  // search unused parameters before backward starts
   void search_unused_parameters(
       const std::vector<torch::autograd::Variable>& outputs);
   void set_divide_factor();

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -561,7 +561,7 @@ def all_to_all_single_autograd(
 
 
 # ============================================================================
-# Collecive Autograd Functions / Custom Ops
+# Collective Autograd Functions / Custom Ops
 # ============================================================================
 
 

--- a/torch/distributed/checkpoint/planner.py
+++ b/torch/distributed/checkpoint/planner.py
@@ -150,7 +150,7 @@ class SavePlanner(abc.ABC):
     There are 3 usual patterns of extension:
 
     Rewriting state_dict. This is the simplest way to extend the save process as it
-    doesn't requite understanding the intrincacies of how SavePlan works:
+    doesn't require understanding the intricacies of how SavePlan works:
 
     >>> # xdoctest: +SKIP("undefined vars")
     >>> class RenamePlanner(DefaultSavePlanner):
@@ -246,7 +246,7 @@ class SavePlanner(abc.ABC):
         """
         Initialize this planner to save ``state_dict``.
 
-        Implementations should save those values as they won't be provided lated in the save process.
+        Implementations should save those values as they won't be provided later in the save process.
 
         This is called on all ranks.
         """
@@ -333,7 +333,7 @@ class LoadPlanner:
     There are two usual patterns of extension:
 
     Rewriting state_dict. This is the simplest way to extend the load process as it
-    doesn't requite understanding the intrincacies of how LoadPlan works. We need
+    doesn't require understanding the intricacies of how LoadPlan works. We need
     to keep a reference to the original state_dict as load happens in place so
     we need to be able to perform it in place
 

--- a/torch/distributed/checkpoint/storage.py
+++ b/torch/distributed/checkpoint/storage.py
@@ -47,7 +47,7 @@ class StorageWriter(abc.ABC):
         """
         Calls to indicates a brand new checkpoint write is going to happen.
         A checkpoint_id may be present if users set the checkpoint_id for
-        this checkpoint write. The meaning of the checkpiont_id is
+        this checkpoint write. The meaning of the checkpoint_id is
         storage-dependent. It can be a path to a folder/file or a key for
         a key-value storage.
 
@@ -188,7 +188,7 @@ class StorageReader(abc.ABC):
         """
         Calls to indicates a brand new checkpoint read is going to happen.
         A checkpoint_id may be present if users set the checkpoint_id for
-        this checkpoint read. The meaning of the checkpiont_id is
+        this checkpoint read. The meaning of the checkpoint_id is
         storage-dependent. It can be a path to a folder/file or a key for
         a key-value storage.
 

--- a/torch/export/_draft_export.py
+++ b/torch/export/_draft_export.py
@@ -185,7 +185,7 @@ class DraftExportReport:
         if self.successful():
             return f"""{GREEN_COLOR}
 ##############################################################################################
-Congratuations: No issues are found during export, and it was able to soundly produce a graph.
+Congratulations: No issues are found during export, and it was able to soundly produce a graph.
 You can now change back to torch.export.export()
 ##############################################################################################
 {END_COLOR}"""
@@ -528,7 +528,7 @@ with torch._library.fake_profile.unsafe_generate_fake_kernels(ep._report.op_prof
         log.info(
             """
 ##############################################################################################
-Congratuations: No issues are found during export, and it was able to soundly produce a graph.
+Congratulations: No issues are found during export, and it was able to soundly produce a graph.
 You can now change back to torch.export.export()
 ##############################################################################################
     """

--- a/torch/export/unflatten.py
+++ b/torch/export/unflatten.py
@@ -620,7 +620,7 @@ class UnflattenedModule(_SubmoduleBase, torch.nn.Module):
             if len(flat_args) != signature.in_spec.num_leaves:
                 raise TypeError(
                     f"Flat args adaption failed, number of args mismatch "
-                    f"Adatped: {len(flat_args)} \n"
+                    f"Adapted: {len(flat_args)} \n"
                     f"Exported module: {signature.in_spec.num_leaves}"
                 )
             return flat_args


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182771

Correct spelling mistakes in comments, docstrings, and user-facing
messages including "requite" → "require", "intrincacies" → "intricacies",
"checkpiont" → "checkpoint", "Congratuations" → "Congratulations",
"Adatped" → "Adapted", and several others.

Authored with Claude (typo_terminator2).