### PR TITLE
Adapt compiled autograd twin path

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -8923,6 +8923,26 @@ def forward(self, primals_1, tangents_1):
         self.assertEqual(actual[0], expected[0])
         self.assertEqual(actual[1], expected[1])
 
+    # --- Compiled autograd adaptation test ---
+
+    def test_compiled_autograd_uses_codegen_prologue(self):
+        torch._dynamo.config.compiled_autograd = True
+        try:
+            with self._capture_codegen_source("backward_prologue") as captured:
+
+                @torch.compile(backend="aot_eager")
+                def f(x):
+                    return x * 2
+
+                x = torch.randn(4, requires_grad=True)
+                out = f(x)
+                out.sum().backward()
+
+            self.assertEqual(len(captured), 1)
+            self.assertEqual(x.grad, torch.full((4,), 2.0))
+        finally:
+            torch._dynamo.config.compiled_autograd = False
+
     def test_collect_metadata_subclass_fw_outs_follow_input_mutation_type(self):
         from torch._functorch._aot_autograd.collect_metadata_analysis import (
             run_functionalized_fw_and_collect_metadata,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #182778
* __->__ #182777
* #182699

The compiled_autograd proxy_call_aot_backward path now calls the
codegen'd bw_prologue_fn directly instead of the interpreted
_backward_prologue_functional, matching the eager backward path.

No generated code change; this commit adds a test verifying that
compiled autograd correctly uses the codegen prologue.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen
@XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng
@chauhang @amjames