### PR TITLE
[Inductor] Fix FX wrapper codegen for symbolic floor/ceil offsets in ReinterpretView (#182785)

### DIFF
--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -325,6 +325,8 @@ class FxConverter:
         stride: tuple[Any, ...],
         offset: int | sympy.Expr,
     ) -> torch.fx.Node:
+        if isinstance(offset, sympy.Expr):
+            offset = replace_floor_div(offset)
         return self.gm.graph.call_function(
             torch.as_strided,
             args=(

--- a/torch/utils/_sympy/reference.py
+++ b/torch/utils/_sympy/reference.py
@@ -362,6 +362,24 @@ class OptimizedPythonReferenceAnalysis(PythonReferenceAnalysis):
     def sym_sum(args):
         return torch.sym_sum(args)
 
+    @staticmethod
+    def floor_to_int(x, dtype):
+        if isinstance(x, (int, float)):
+            return math.floor(x)
+        return x
+
+    @staticmethod
+    def ceil_to_int(x, dtype):
+        if isinstance(x, (int, float)):
+            return math.ceil(x)
+        return x
+
+    @staticmethod
+    def trunc_to_int(x, dtype):
+        if isinstance(x, (int, float)):
+            return math.trunc(x)
+        return x
+
 
 def _to_dtype(x: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
     return torch.ops.prims.convert_element_type.default(x, dtype)


### PR DESCRIPTION
Summary:

The FX wrapper codegen (`wrapper_fxir.py`) crashes when generating `as_strided` nodes for `ReinterpretView` with symbolic offsets containing `sympy.floor`. This surfaces for ops like median/mode whose sort decomposition creates views with offset `floor(rows * cols / 2 - 0.5)`.

Two issues fixed:

1. `OptimizedPythonReferenceAnalysis.floor_to_int` inherits `math.floor(x)` from `PythonReferenceAnalysis`, which crashes on Proxy objects: `TypeError: must be real number, not Proxy`. Override to pass through non-concrete values — the integer conversion is handled downstream.

2. `_generate_sym_node` produces FX nodes with SymFloat metadata for integer-valued sympy expressions (e.g., `floor(s0*s1/2 - 1/2)` involves `/2` which converts SymInt to SymFloat). `as_strided` then rejects the SymFloat offset. Fix: when the sympy expression is integer-valued (`s.is_integer`) but the node has SymFloat metadata, insert a `torch.sym_int` conversion node.

Test Plan: 2-stage opinfo compile: `median; 1; 0; tensor, f32x3x5` and `mode; 1; 0; tensor, f32x5x5x5` now compile with auto-DS (were BackendCompilerFailed)

Differential Revision: D103067075




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo