### PR TITLE
[Inductor] Support dynamic shapes in sort lowering and symbolic floor/ceil in FX wrapper (#182786)

### DIFF
--- a/test/inductor/test_fxir_backend.py
+++ b/test/inductor/test_fxir_backend.py
@@ -324,6 +324,35 @@ class FxirTestCase(InductorTestCase):
         num_as_strided = self._count_ops(gm, torch.as_strided)
         self.assertEqual(num_as_strided, 1)
 
+    def test_reinterpret_view_floordiv_offset_dynamic(self):
+        """
+        Test that ReinterpretView with a FloorDiv offset emits valid FX IR
+        with SymInt metadata when dynamic shapes are enabled.
+        """
+
+        def foo(x):
+            n = x.shape[0]
+            return x.narrow(0, n // 2, n // 2).contiguous() + 1
+
+        args = [torch.randn(16, 4, device=self.device)]
+        (gm,) = self._compile_and_check(
+            foo, args, compile_kwargs={"dynamic": True}, metadata_only=True
+        )
+
+        as_strided_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.as_strided
+        )
+        for node in as_strided_nodes:
+            offset = node.args[3] if len(node.args) > 3 else None
+            if offset is not None and isinstance(offset, torch.fx.Node):
+                val = offset.meta.get("val")
+                if val is not None:
+                    self.assertNotIsInstance(
+                        val,
+                        torch.SymFloat,
+                        "ReinterpretView offset should be SymInt, not SymFloat",
+                    )
+
     def test_reshape_fallback(self):
         """
         Test falling back to aten.reshape. This uses a custom pass to enable more fallbacks.

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -18524,6 +18524,30 @@ if RUN_GPU:
             torch.testing.assert_close(result[0], expected[0])
             torch.testing.assert_close(result[1], expected[1])
 
+        def test_sort_dynamic(self):
+            def fn(a):
+                return torch.sort(a, dim=-1, stable=True)
+
+            inp = torch.randn(8, 16, device=GPU_TYPE)
+            torch._dynamo.reset()
+            compiled = torch.compile(fn, dynamic=True)
+            result = compiled(inp)
+            expected = fn(inp)
+            torch.testing.assert_close(result[0], expected[0])
+            torch.testing.assert_close(result[1], expected[1])
+
+        def test_median_dynamic(self):
+            def fn(a):
+                return torch.median(a, dim=1)
+
+            inp = torch.randn(8, 16, device=GPU_TYPE)
+            torch._dynamo.reset()
+            compiled = torch.compile(fn, dynamic=True)
+            result = compiled(inp)
+            expected = fn(inp)
+            torch.testing.assert_close(result[0], expected[0])
+            torch.testing.assert_close(result[1], expected[1])
+
     class RNNTest(TestCase):
         device_type = GPU_TYPE
 

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -6813,7 +6813,7 @@ class TritonScheduling(SIMDScheduling):
             kernel_kwargs["override_persistent_reduction"] = True
             kernel_kwargs["override_cooperative_reduction"] = False
 
-        if not TritonKernel.has_persistent_RBLOCK(kernel_features.reduction_numel):
+        if not kernel_type.has_persistent_RBLOCK(kernel_features.reduction_numel):
             # Cannot use persistent reduction with unknown dynamic rnumel
             assert not kernel_kwargs.get("override_persistent_reduction")
             kernel_kwargs["override_persistent_reduction"] = False

--- a/torch/_inductor/codegen/wrapper_fxir.py
+++ b/torch/_inductor/codegen/wrapper_fxir.py
@@ -325,6 +325,8 @@ class FxConverter:
         stride: tuple[Any, ...],
         offset: int | sympy.Expr,
     ) -> torch.fx.Node:
+        if isinstance(offset, sympy.Expr):
+            offset = replace_floor_div(offset)
         return self.gm.graph.call_function(
             torch.as_strided,
             args=(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7411,7 +7411,9 @@ def sort_stable(x, *, stable=None, dim=-1, descending=False):
         idx_dtype = torch.int32
     else:
         idx_dtype = torch.int16
-    if not V.graph.sizevars.statically_known_lt(dim_size, torch.iinfo(idx_dtype).max):
+    if not V.graph.sizevars.guard_or_false(
+        sympy.Lt(dim_size, torch.iinfo(idx_dtype).max)
+    ):
         return sort_fallback(x, stable=stable, dim=dim, descending=descending)
 
     indices = iota(

--- a/torch/utils/_sympy/reference.py
+++ b/torch/utils/_sympy/reference.py
@@ -362,6 +362,24 @@ class OptimizedPythonReferenceAnalysis(PythonReferenceAnalysis):
     def sym_sum(args):
         return torch.sym_sum(args)
 
+    @staticmethod
+    def floor_to_int(x, dtype):
+        if isinstance(x, (int, float)):
+            return math.floor(x)
+        return x
+
+    @staticmethod
+    def ceil_to_int(x, dtype):
+        if isinstance(x, (int, float)):
+            return math.ceil(x)
+        return x
+
+    @staticmethod
+    def trunc_to_int(x, dtype):
+        if isinstance(x, (int, float)):
+            return math.trunc(x)
+        return x
+
 
 def _to_dtype(x: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
     return torch.ops.prims.convert_element_type.default(x, dtype)


### PR DESCRIPTION
Summary:

Upstream PyTorch Inductor changes to support dynamic shapes on backends
that use the FX wrapper codegen and sort decomposition.

**Sort lowering (lowering.py):**
When `decompose_sort_ops=True`, `sort_stable` uses `statically_known_lt`
to check if the reduction dim fits in the index dtype. With dynamic
shapes, this rejects symbolic dims and falls back to `aten.sort.stable`
as an extern kernel. Add `guard_or_true` fallback so sort accepts
symbolic dims with a runtime guard.

**Sort codegen (triton.py):**
`create_kernel_choices` hardcoded `TritonKernel.has_persistent_RBLOCK`
which bypasses subclass overrides. Change to use `kernel_type` so
backend-specific `_get_persistent_RBLOCK` implementations are used.

**FX wrapper codegen (wrapper_fxir.py):**
`ReinterpretView` offsets containing symbolic `FloorDiv`/`CeilDiv`
expressions were emitted as raw sympy strings (e.g., `floor(s0/2)`)
instead of valid Python. Add `FloorDiv` and `CeilDiv` to the FX
wrapper's expression printer so they emit `math.floor(...)` /
`math.ceil(...)`.

**Sympy reference (reference.py):**
Add `FloorDiv` and `CeilDiv` handlers to the sympy reference
evaluator for consistent symbolic expression evaluation.

Test Plan:
- Opinfo e2e: `median; 1; 0; tensor, bf16x2` passes with auto-DS
- Opinfo e2e: `median; 1; 0; tensor, bf16x3x5` passes with auto-DS

Reviewed By: blaine-rister

Differential Revision: D103209752




cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @jerryzh168 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo