### PR TITLE
Fix decorators of `ProcessGroupGlooTest` & `ProcessGroupNCCLTest`

### DIFF
--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -21,7 +21,6 @@ from torch.testing._internal.common_distributed import (
     create_device,
     MultiProcessTestCase,
     requires_accelerator_dist_backend,
-    requires_gloo,
     requires_nccl,
     skip_if_lt_x_gpu,
     with_dist_debug_levels,
@@ -218,8 +217,9 @@ class AbstractProcessGroupWrapperTest(MultiProcessTestCase):
 # ASAN is not safe since we are spawning processes.
 if not TEST_WITH_DEV_DBG_ASAN:
 
-    @requires_gloo()
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @unittest.skipUnless(
+        c10d.is_gloo_available(), "c10d was not compiled with the Gloo backend"
+    )
     class ProcessGroupNCCLWrapperTest(AbstractProcessGroupWrapperTest):
         def setUp(self):
             super(AbstractProcessGroupWrapperTest, self).setUp()
@@ -469,7 +469,9 @@ if not TEST_WITH_DEV_DBG_ASAN:
                 # an unexpected NameError if not.
 
 
-@requires_gloo()
+@unittest.skipUnless(
+    c10d.is_gloo_available(), "c10d was not compiled with the Gloo backend"
+)
 class ProcessGroupGlooWrapperTest(AbstractProcessGroupWrapperTest):
     def opts(self, threads=2, timeout=10.0):
         opts = c10d.ProcessGroupGloo._Options()

--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -21,7 +21,6 @@ from torch.testing._internal.common_distributed import (
     create_device,
     MultiProcessTestCase,
     requires_accelerator_dist_backend,
-    requires_gloo,
     requires_nccl,
     skip_if_lt_x_gpu,
     with_dist_debug_levels,
@@ -255,8 +254,9 @@ class AbstractProcessGroupWrapperTest(MultiProcessTestCase):
 # ASAN is not safe since we are spawning processes.
 if not TEST_WITH_DEV_DBG_ASAN:
 
-    @requires_gloo()
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @unittest.skipUnless(
+        c10d.is_gloo_available(), "c10d was not compiled with the Gloo backend"
+    )
     class ProcessGroupNCCLWrapperTest(AbstractProcessGroupWrapperTest):
         def setUp(self):
             super(AbstractProcessGroupWrapperTest, self).setUp()
@@ -575,7 +575,9 @@ if not TEST_WITH_DEV_DBG_ASAN:
                 # an unexpected NameError if not.
 
 
-@requires_gloo()
+@unittest.skipUnless(
+    c10d.is_gloo_available(), "c10d was not compiled with the Gloo backend"
+)
 class ProcessGroupGlooWrapperTest(AbstractProcessGroupWrapperTest):
     def opts(self, threads=2, timeout=10.0):
         opts = c10d.ProcessGroupGloo._Options()


### PR DESCRIPTION
The requires_gloo/requires_nccl decorator cause the function to just return. In the way they are used this skips the initialization done by a helper function. So the test is not skipped and then fails due to missing variables.

Decorate the class instead.