### PR TITLE
Skip `test_norm_matrix_degenerate_shapes` on NumPy >= 2.3.0

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2115,6 +2115,7 @@ class TestLinalg(TestCase):
                     self.assertEqual(result, result_n, msg=msg)
 
     # Test degenerate shape results match numpy for linalg.norm vector norms
+    @unittest.skipIf(np.lib.NumpyVersion(np.__version__) >= '2.3.0', 'Numpy changed handling of degenerate inputs in 2.3.0')
     @skipCUDAIfNoMagmaAndNoLinalgsolver
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)


### PR DESCRIPTION
This test no longer works with numpy >= 2.3.0 since a4a5d03779d876043b0a1f0c565659fc2298afd2