### PR TITLE
[docs] Convert nn.attention.rst from rST to MyST Markdown

### DIFF
--- a/docs/source/nn.attention.md
+++ b/docs/source/nn.attention.md
@@ -1,13 +1,17 @@
+```{eval-rst}
 .. role:: hidden
     :class: hidden-section
+```
 
-torch.nn.attention
-==================
+# torch.nn.attention
 
+```{eval-rst}
 .. automodule:: torch.nn.attention
+```
 
-Utils
--------------------
+## Utils
+
+```{eval-rst}
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -19,9 +23,11 @@ Utils
     list_flash_attention_impls
     current_flash_attention_impl
     restore_flash_attention_impl
+```
 
-Submodules
-----------
+## Submodules
+
+```{eval-rst}
 .. autosummary::
     :nosignatures:
 
@@ -29,7 +35,9 @@ Submodules
     bias
     experimental
     varlen
+```
 
+```{eval-rst}
 .. toctree::
     :hidden:
 
@@ -37,3 +45,4 @@ Submodules
     nn.attention.bias
     nn.attention.experimental
     nn.attention.varlen
+```


### PR DESCRIPTION
## Summary

Converts `docs/source/nn.attention.rst` from reStructuredText to MyST Markdown syntax.

- Uses `git mv` to preserve file history
- All Sphinx directives (`automodule`, `autosummary`, `toctree`, `role`) wrapped in `{eval-rst}` fenced blocks
- Section headings converted from rST underline style to Markdown `#`/`##`
- Follows the exact pattern used by the already-converted sibling files (`nn.attention.bias.md`, `nn.attention.flex_attention.md`, `nn.attention.experimental.md`, `nn.attention.varlen.md`)

## Verification

- `lintrunner` passes with zero issues
- Local docs build succeeds, generated HTML contains all expected content (Utils section with 7 API items, Submodules section with 4 entries, hidden toctree)
- No cross-reference updates needed — `pytorch-api.md` references `nn.attention` without file extension, which Sphinx resolves correctly

Fixes #182477

cc @svekars @sekyondaMeta @AlannaBurke