### PR TITLE
[inductor][rocm] Fix AOTInductor autotune int64 Triton kernel test on ROCm

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6796,7 +6796,6 @@ class AOTInductorTestsTemplate:
         self.check_model(sin_triton, none_inputs)
         self.check_model(sin_triton, not_none_inputs)
 
-    @skipIfRocm  # RoCM does not support the config block size in test suite.
     @skipIfXpu(
         msg="SYCL work-item index overflow issue when block sizes are used in this test."
     )
@@ -6812,13 +6811,17 @@ class AOTInductorTestsTemplate:
             n_elements,
             BLOCK_SIZE: "tl.constexpr",
         ):
-            pid = tl.program_id(axis=0).to(tl.int64)
-            block_start = pid * BLOCK_SIZE
+            pid0 = tl.program_id(axis=0).to(tl.int64)
+            pid1 = tl.program_id(axis=1).to(tl.int64)
+            grid0 = tl.num_programs(axis=0).to(tl.int64)
+            block_id = pid1 * grid0 + pid0
+            block_start = block_id * BLOCK_SIZE
             offsets = block_start + tl.arange(0, BLOCK_SIZE)
             mask = offsets < n_elements
             x = tl.load(in_ptr0 + offsets, mask=mask)
             y = tl.load(in_ptr1 + offsets, mask=mask)
-            output = x + y
+            s = x.to(tl.int32) + y.to(tl.int32)
+            output = (s & 0xFF).to(tl.int8)
             tl.store(out_ptr + offsets, output, mask=mask)
 
         @torch.library.triton_op("mylib::add", mutates_args=())
@@ -6827,9 +6830,12 @@ class AOTInductorTestsTemplate:
             n_elements = output.numel()
 
             def grid(meta):
-                return (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+                num_blocks = triton.cdiv(n_elements, meta["BLOCK_SIZE"])
+                grid0 = min(num_blocks, 65535)
+                grid1 = triton.cdiv(num_blocks, grid0)
+                return (grid0, grid1)
 
-            capture_triton(add_kernel)[grid](x, y, output, n_elements, 16)
+            capture_triton(add_kernel)[grid](x, y, output, n_elements, 256)
             return output
 
         class Model(torch.nn.Module):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6831,8 +6831,11 @@ class AOTInductorTestsTemplate:
 
             def grid(meta):
                 num_blocks = triton.cdiv(n_elements, meta["BLOCK_SIZE"])
-                grid0 = min(num_blocks, 65535)
-                grid1 = triton.cdiv(num_blocks, grid0)
+                # 2D split to respect the 65535 grid-x limit. Use cdiv-by-constant
+                # rather than min(num_blocks, 65535): a symbolic min introduces an
+                # inequality guard that AOTInductor dynamic-shape export rejects.
+                grid1 = triton.cdiv(num_blocks, 65535)
+                grid0 = triton.cdiv(num_blocks, grid1)
                 return (grid0, grid1)
 
             capture_triton(add_kernel)[grid](x, y, output, n_elements, 256)


### PR DESCRIPTION
Fixes #168566

Enables `test_autotune_int64_user_defined_triton_kernel` in `test/inductor/test_aot_inductor.py` on ROCm. The test was `@skipIfRocm` because a single-dimension Triton launch grid over a large tensor exceeds ROCm's 65535 grid-x limit.

## Changes
- Remove the `@skipIfRocm` decorator (the unrelated `@skipIfXpu` is kept).
- Use a 2D launch grid so the block count is split across grid.x / grid.y, staying under the 65535 grid-x limit. The split is computed with cdiv-by-constant so it stays compatible with AOTInductor dynamic-shape export.
- Make the kernel arithmetic int8-overflow-safe.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben