### PR TITLE
[Docathon] Convert notes/mps.rst from rST to MyST Markdown (#182495)

### DIFF
--- a/docs/source/notes/mps.md
+++ b/docs/source/notes/mps.md
@@ -1,9 +1,8 @@
-.. _MPS-Backend:
+(MPS-Backend)=
 
-MPS backend
-===========
+# MPS backend
 
-:mod:`mps` device enables high-performance
+{mod}`mps` device enables high-performance
 training on GPU for macOS devices with Metal programming framework.  It
 introduces a new device to map Machine Learning computational graphs and
 primitives on highly efficient Metal Performance Shaders Graph framework and
@@ -12,9 +11,10 @@ tuned kernels provided by Metal Performance Shaders framework respectively.
 The new MPS backend extends the PyTorch ecosystem and provides existing scripts
 capabilities to setup and run operations on GPU.
 
-To get started, simply move your Tensor and Module to the ``mps`` device:
+To get started, simply move your Tensor and Module to the `mps` device:
 
-.. code:: python
+```{code-block} python
+:dedent: 4
 
     # Check that MPS is available
     if not torch.backends.mps.is_available():
@@ -42,3 +42,4 @@ To get started, simply move your Tensor and Module to the ``mps`` device:
 
         # Now every call runs on the GPU
         pred = model(x)
+```


### PR DESCRIPTION
Fixes #182495

This PR converts `docs/source/notes/mps.rst` to MyST Markdown format (`.md`) as requested for the Docathon.

### Changes Made:
- Used `git mv` to rename the file to `.md` to preserve git history.
- Converted internal targets (`.. _MPS-Backend:` -> `(MPS-Backend)=`).
- Updated header styles from `===========` to `#`.
- Migrated Sphinx cross-reference roles (`:mod:` -> `{mod}`).
- Converted code block format to standard Markdown fenced code blocks.

cc @svekars @sekyondaMeta @AlannaBurke