### PR TITLE
[Docathon]: Convert nn.init.rst to MyST Markdown

### DIFF
--- a/docs/source/nn.init.md
+++ b/docs/source/nn.init.md
@@ -1,16 +1,18 @@
-.. role:: hidden
-    :class: hidden-section
+```{role} hidden
+:class: hidden-section
+```
 
-.. _nn-init-doc:
+(nn-init-doc)=
 
-torch.nn.init
-=============
+# torch.nn.init
 
-.. warning::
-    All the functions in this module are intended to be used to initialize neural network
-    parameters, so they all run in :func:`torch.no_grad` mode and will not be taken into
-    account by autograd.
+:::{warning}
+All the functions in this module are intended to be used to initialize neural network
+parameters, so they all run in {func}`torch.no_grad` mode and will not be taken into
+account by autograd.
+:::
 
+```{eval-rst}
 .. currentmodule:: torch.nn.init
 .. autofunction:: calculate_gain
 .. autofunction:: uniform_
@@ -27,3 +29,4 @@ torch.nn.init
 .. autofunction:: trunc_normal_
 .. autofunction:: orthogonal_
 .. autofunction:: sparse_
+```


### PR DESCRIPTION
Fixes #182479

Converted `docs/source/nn.init.rst` to MyST Markdown.

- Used `git mv` to preserve history
- Converted headings, warning block, and cross-references to MyST syntax
- Autodoc directives kept in `eval-rst` block

cc @svekars