### PR TITLE
Fix torch.trapz documentation signature

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13175,7 +13175,7 @@ Examples::
 add_docstr(
     torch.trapz,
     r"""
-trapz(y, x=None, *, dim=-1) -> Tensor
+trapz(y, x=None, *, dx=None, dim=-1) -> Tensor
 
 Alias for :func:`torch.trapezoid`.
 """,


### PR DESCRIPTION
## Summary

This PR updates the `torch.trapz` documentation signature so it matches `torch.trapezoid`, since `torch.trapz` is documented as an alias of `torch.trapezoid`.

Specifically, it adds the missing `dx=None` keyword argument to the `torch.trapz` docstring signature.

## Verification

This is a documentation-only change. I compared the existing `torch.trapezoid` signature in `torch/_torch_docs.py` with the `torch.trapz` signature and updated `torch.trapz` to match.

Fixes #71392