### PR TITLE
[Docathon] Convert notes/faq.rst to MyST Markdown [#182487]

### DIFF
--- a/docs/source/notes/faq.md
+++ b/docs/source/notes/faq.md
@@ -1,8 +1,6 @@
-Frequently Asked Questions
-==========================
+# Frequently Asked Questions
 
-My model reports "cuda runtime error(2): out of memory"
--------------------------------------------------------
+## My model reports "cuda runtime error(2): out of memory"
 
 As the error message suggests, you have run out of memory on your
 GPU.  Since we often deal with large amounts of data in PyTorch,
@@ -18,10 +16,10 @@ e.g., when tracking statistics. Instead, you should detach the variable
 or access its underlying data.
 
 Sometimes, it can be non-obvious when differentiable variables can
-occur.  Consider the following training loop (abridged from `source
-<https://discuss.pytorch.org/t/high-memory-usage-while-training/162>`_):
+occur.  Consider the following training loop (abridged from [source](https://discuss.pytorch.org/t/high-memory-usage-while-training/162)):
 
-.. code-block:: python
+```{code-block} python
+:dedent: 4
 
     total_loss = 0
     for i in range(10000):
@@ -31,18 +29,19 @@ occur.  Consider the following training loop (abridged from `source
         loss.backward()
         optimizer.step()
         total_loss += loss
+```
 
-Here, ``total_loss`` is accumulating history across your training loop, since
-``loss`` is a differentiable variable with autograd history. You can fix this by
+Here, `total_loss` is accumulating history across your training loop, since
+`loss` is a differentiable variable with autograd history. You can fix this by
 writing `total_loss += float(loss)` instead.
 
 Other instances of this problem:
-`1 <https://discuss.pytorch.org/t/resolved-gpu-out-of-memory-error-with-batch-size-1/3719>`_.
+[1](https://discuss.pytorch.org/t/resolved-gpu-out-of-memory-error-with-batch-size-1/3719).
 
 **Don't hold onto tensors and variables you don't need.**
 If you assign a Tensor or Variable to a local, Python will not
 deallocate until the local goes out of scope.  You can free
-this reference by using ``del x``.  Similarly, if you assign
+this reference by using `del x`.  Similarly, if you assign
 a Tensor or Variable to a member variable of an object, it will
 not deallocate until the object goes out of scope.  You will
 get the best memory usage if you don't hold onto temporaries
@@ -50,71 +49,75 @@ you don't need.
 
 The scopes of locals can be larger than you expect.  For example:
 
-.. code-block:: python
+```{code-block} python
+:dedent: 4
 
     for i in range(5):
         intermediate = f(input[i])
         result += g(intermediate)
     output = h(result)
     return output
+```
 
-Here, ``intermediate`` remains live even while ``h`` is executing,
+Here, `intermediate` remains live even while `h` is executing,
 because its scope extrudes past the end of the loop.  To free it
-earlier, you should ``del intermediate`` when you are done with it.
+earlier, you should `del intermediate` when you are done with it.
 
 **Avoid running RNNs on sequences that are too large.**
 The amount of memory required to backpropagate through an RNN scales
 linearly with the length of the RNN input; thus, you will run out of memory
 if you try to feed an RNN a sequence that is too long.
 
-The technical term for this phenomenon is `backpropagation through time
-<https://en.wikipedia.org/wiki/Backpropagation_through_time>`_,
+The technical term for this phenomenon is [backpropagation through time](https://en.wikipedia.org/wiki/Backpropagation_through_time),
 and there are plenty of references for how to implement truncated
-BPTT, including in the `word language model <https://github.com/pytorch/examples/tree/master/word_language_model>`_ example; truncation is handled by the
-``repackage`` function as described in
-`this forum post <https://discuss.pytorch.org/t/help-clarifying-repackage-hidden-in-word-language-model/226>`_.
+BPTT, including in the [word language model](https://github.com/pytorch/examples/tree/master/word_language_model) example; truncation is handled by the
+`repackage` function as described in
+[this forum post](https://discuss.pytorch.org/t/help-clarifying-repackage-hidden-in-word-language-model/226).
 
 **Don't use linear layers that are too large.**
-A linear layer ``nn.Linear(m, n)`` uses :math:`O(nm)` memory: that is to say,
+A linear layer `nn.Linear(m, n)` uses $O(nm)$ memory: that is to say,
 the memory requirements of the weights
 scales quadratically with the number of features.  It is very easy
-to `blow through your memory <https://github.com/pytorch/pytorch/issues/958>`_
+to [blow through your memory](https://github.com/pytorch/pytorch/issues/958)
 this way (and remember that you will need at least twice the size of the
 weights, since you also need to store the gradients.)
 
 **Consider checkpointing.**
-You can trade-off memory for compute by using `checkpoint <https://pytorch.org/docs/stable/checkpoint.html>`_.
+You can trade-off memory for compute by using [checkpoint](https://pytorch.org/docs/stable/checkpoint.html).
 
-My GPU memory isn't freed properly
-----------------------------------
+## My GPU memory isn't freed properly
+
 PyTorch uses a caching memory allocator to speed up memory allocations. As a
-result, the values shown in ``nvidia-smi`` usually don't reflect the true
-memory usage. See :ref:`cuda-memory-management` for more details about GPU
+result, the values shown in `nvidia-smi` usually don't reflect the true
+memory usage. See {ref}`cuda-memory-management` for more details about GPU
 memory management.
 
 If your GPU memory isn't freed even after Python quits, it is very likely that
 some Python subprocesses are still alive. You may find them via
-``ps -elf | grep python`` and manually kill them with ``kill -9 [pid]``.
+`ps -elf | grep python` and manually kill them with `kill -9 [pid]`.
 
-My out of memory exception handler can't allocate memory
---------------------------------------------------------
+## My out of memory exception handler can't allocate memory
+
 You may have some code that tries to recover from out of memory errors.
 
-.. code-block:: python
+```{code-block} python
+:dedent: 4
 
     try:
         run_model(batch_size)
     except RuntimeError: # Out of memory
         for _ in range(batch_size):
             run_model(1)
+```
 
 But find that when you do run out of memory, your recovery code can't allocate
 either. That's because the python exception object holds a reference to the
 stack frame where the error was raised. Which prevents the original tensor
 objects from being freed. The solution is to move you OOM recovery code outside
-of the ``except`` clause.
+of the `except` clause.
 
-.. code-block:: python
+```{code-block} python
+:dedent: 4
 
     oom = False
     try:
@@ -125,33 +128,36 @@ of the ``except`` clause.
     if oom:
         for _ in range(batch_size):
             run_model(1)
+```
 
+(dataloader-workers-random-seed)=
 
-.. _dataloader-workers-random-seed:
+## My data loader workers return identical random numbers
 
-My data loader workers return identical random numbers
--------------------------------------------------------
 You are likely using other libraries to generate random numbers in the dataset
-and worker subprocesses are started via ``fork``. See
-:class:`torch.utils.data.DataLoader`'s documentation for how to
-properly set up random seeds in workers with its :attr:`worker_init_fn` option.
+and worker subprocesses are started via `fork`. See
+{class}`torch.utils.data.DataLoader`'s documentation for how to
+properly set up random seeds in workers with its {attr}`worker_init_fn` option.
 
-.. _pack-rnn-unpack-with-data-parallelism:
+(pack-rnn-unpack-with-data-parallelism)=
 
-My recurrent network doesn't work with data parallelism
--------------------------------------------------------
+## My recurrent network doesn't work with data parallelism
+
 There is a subtlety in using the
-``pack sequence -> recurrent network -> unpack sequence`` pattern in a
-:class:`~torch.nn.Module` with :class:`~torch.nn.DataParallel` or
-:func:`~torch.nn.parallel.data_parallel`. Input to each the :meth:`forward` on
+`pack sequence -> recurrent network -> unpack sequence` pattern in a
+{class}`~torch.nn.Module` with {class}`~torch.nn.DataParallel` or
+{func}`~torch.nn.parallel.data_parallel`. Input to each the {meth}`forward` on
 each device will only be part of the entire input. Because the unpack operation
-:func:`torch.nn.utils.rnn.pad_packed_sequence` by default only pads up to the
+{func}`torch.nn.utils.rnn.pad_packed_sequence` by default only pads up to the
 longest input it sees, i.e., the longest on that particular device, size
 mismatches will happen when results are gathered together. Therefore, you can
-instead take advantage of the :attr:`total_length` argument of
-:func:`~torch.nn.utils.rnn.pad_packed_sequence` to make sure that the
-:meth:`forward` calls return sequences of same length. For example, you can
-write::
+instead take advantage of the {attr}`total_length` argument of
+{func}`~torch.nn.utils.rnn.pad_packed_sequence` to make sure that the
+{meth}`forward` calls return sequences of same length. For example, you can
+write:
+
+```{code-block} python
+:dedent: 4
 
     from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 
@@ -174,11 +180,11 @@ write::
 
     m = MyModule().cuda()
     dp_m = nn.DataParallel(m)
+```
 
-
-Additionally, extra care needs to be taken when batch dimension is dim ``1``
-(i.e., ``batch_first=False``) with data parallelism. In this case, the first
-argument of pack_padded_sequence ``padding_input`` will be of shape
-``[T x B x *]`` and should be scattered along dim ``1``, but the second argument
-``input_lengths`` will be of shape ``[B]`` and should be scattered along dim
-``0``. Extra code to manipulate the tensor shapes will be needed.
+Additionally, extra care needs to be taken when batch dimension is dim `1`
+(i.e., `batch_first=False`) with data parallelism. In this case, the first
+argument of pack_padded_sequence `padding_input` will be of shape
+`[T x B x *]` and should be scattered along dim `1`, but the second argument
+`input_lengths` will be of shape `[B]` and should be scattered along dim
+`0`. Extra code to manipulate the tensor shapes will be needed.


### PR DESCRIPTION
Fixes #182487

### Description

This PR addresses the Docathon 2026 initiative to migrate documentation from reStructuredText to MyST Markdown.
Specifically, it converts `docs/source/notes/faq.rst` to `docs/source/notes/faq.md`.

**Changes made:**

- Used `git mv` to preserve the Git commit history.
- Converted internal anchor targets (e.g., `(target)=`).
- Transformed header underlines into standard markdown headers (`#`, `##`).
- Updated Sphinx cross-reference roles to their MyST equivalents (`{func}`, `{meth}`, `{ref}`).
- Converted rST tables into GitHub-flavored markdown tables (if applicable).
- Converted Python code blocks to standard markdown fenced code blocks.

cc @svekars @sekyondaMeta @AlannaBurke