### PR TITLE
Fix grammar typos in comments and error messages

### DIFF
--- a/torch/_inductor/kernel/flex/templates/flex_backwards.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/flex_backwards.py.jinja
@@ -480,7 +480,7 @@ def bwd_dq_block_mn(
 
 
     {# Note: Selective masking DQ
-    We load elements beyond KV_LEN w/ zero, some score mods may convert this elements to NaN
+    We load elements beyond KV_LEN w/ zero, some score mods may convert these elements to NaN
     Example: lambda x, *_: 1 / score, this NaN would propagate regardless of other masking
     We only need to do this on the m1 dim since these elements take part in the final reduction
     for DQ #}
@@ -665,7 +665,7 @@ def bwd_dkdv_block_mn(
     ) | indent_except_first(1) }}
 
     {# Note: Selective masking DK/DV
-    We load elements beyond Q_LEN w/ zero, some score mods may convert this elements to NaN
+    We load elements beyond Q_LEN w/ zero, some score mods may convert these elements to NaN
     Example: lambda x, *_: 1 / score, this NaN would propagate regardless of other masking
     We only need to do this on the m1 dim since these elements take part in the final reduction
     for DK/DV #}

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -292,7 +292,7 @@ def backward(
     .. note::
 
         When ``inputs`` are provided and a given input is not a leaf,
-        the current implementation will call its grad_fn (even though it is not strictly needed to get this gradients).
+        the current implementation will call its grad_fn (even though it is not strictly needed to get these gradients).
         It is an implementation detail on which the user should not rely.
         See https://github.com/pytorch/pytorch/pull/60521#issuecomment-867061780 for more details.
 

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -970,7 +970,7 @@ def _check_inputs(tupled_inputs) -> bool:
     if not any_input_requiring_grad:
         raise ValueError(
             "gradcheck expects at least one input tensor to require gradient, "
-            "but none of the them have requires_grad=True."
+            "but none of them have requires_grad=True."
         )
     return True
 

--- a/torch/csrc/autograd/autograd.h
+++ b/torch/csrc/autograd/autograd.h
@@ -40,7 +40,7 @@ namespace torch::autograd {
 ///     compute param `tensors`.
 //      When inputs are provided and a given input is not a leaf,
 //      the current implementation will call its grad_fn (even though it is not
-//      strictly needed to get this gradients). It is an implementation detail
+//      strictly needed to get these gradients). It is an implementation detail
 //      on which the user should not rely. See
 //      https://github.com/pytorch/pytorch/pull/60521#issuecomment-867061780 for
 //      more details.

--- a/torch/csrc/distributed/c10d/Work.hpp
+++ b/torch/csrc/distributed/c10d/Work.hpp
@@ -74,7 +74,7 @@ class TORCH_API Work : public torch::CustomClassHolder {
   // Returns exception if isSuccess() returned false.
   virtual std::exception_ptr exception() const;
 
-  // Returns source rank if this objects represents a recv-from-any.
+  // Returns source rank if this object represents a recv-from-any.
   virtual int sourceRank() const;
 
   // Returns result tensors, if applicable.

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -1060,7 +1060,7 @@ class SwapSavedVariables {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   TraceState& state;
   // This is a borrowed reference, we do not increment ownership, or lower it,
-  // it's lifecycle is entirely longer than this objects.
+  // its lifecycle is entirely longer than this object's.
   PyObject* py_compiler;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const NodeCall& curr_node_call;

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -682,7 +682,7 @@ static void ConstantFoldONNX(
     node->outputs().at(0)->replaceAllUsesWith(newSourceNodeOutput);
     // Next we remove the current node that has been replaced by
     // an initializer. But before we start de-wiring this node,
-    // we check if any parents of this nodes were onnx::Constant
+    // we check if any parents of this node were onnx::Constant
     // and remove them first, and then remove the current node.
     // If the parent was an initializer (not onnx::Constant) then
     // they are all removed by the eraseUnusedBlockInputs() call

--- a/torch/onnx/_internal/exporter/_core.py
+++ b/torch/onnx/_internal/exporter/_core.py
@@ -260,7 +260,7 @@ def _set_shape_type(
         # we don't need to set it again.
         #
         # When a user specifies complex in onnx_symbolic, we consider that to
-        # be the intention even though non of the ONNX ops deals with complex values.
+        # be the intention even though none of the ONNX ops deals with complex values.
         # In this case, we don't change the dtype or the shape of the tensor.
         if value.dtype is None:
             value.dtype = torch_dtype_to_onnx_dtype(meta_val.dtype)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #182806

Correct demonstrative pronoun agreement ("this elements" → "these
elements", "this gradients" → "these gradients", "this objects" →
"this object"), fix possessive ("it's lifecycle" → "its lifecycle"),
and fix misspellings ("none of the them" → "none of them", "non of" →
"none of") across autograd, distributed, inductor, JIT, and ONNX code.

Authored with Claude (typo_terminator2).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @xmfan @aditvenk