### PR TITLE
[Inductor] Set flatten for BlackwellGPUGemmConfig based on AutoWS version (#182808)

### DIFF
--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -51,6 +51,8 @@ if TYPE_CHECKING:
 else:
     from torch._inductor.runtime.triton_compat import Config as TritonConfig
 
+USE_META_WS = os.environ.get("TRITON_USE_META_WS", "0") == "0"
+
 
 # Gemm Configs
 @dataclasses.dataclass
@@ -2276,7 +2278,12 @@ class BlackwellTMATemplateConfigMixin(TMATemplateConfigMixin):
                 template_kwargs.get("WARP_SPECIALIZE", True)
                 and not constraints_violated
             )
-            flatten = template_kwargs.get("FLATTEN", True) and not constraints_violated
+            # Meta WS pass has only validated flatten=False; OSS Triton uses flatten=True
+            flatten = (
+                template_kwargs.get("FLATTEN", True)
+                and not constraints_violated
+                and USE_META_WS
+            )
             yield {
                 **template_kwargs,
                 "NUM_SMS": get_num_sms(),


### PR DESCRIPTION
Summary:

Set `flatten` Triton config for `BlackwellGPUGemmConfig` based on whether the Triton AutoWS version is Meta or OAI.

Test Plan: n/a

Reviewed By: njriasan

Differential Revision: D104214077




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo