### PR TITLE
[ROCm] Implement TORCH_HIP_VERSION 

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -352,6 +352,10 @@ COMMON_HIP_FLAGS = [
     '-DHIPBLAS_V2',
 ]
 
+if ROCM_VERSION is not None:
+    COMMON_HIP_FLAGS.append(
+        f'-DTORCH_HIP_VERSION={ROCM_VERSION[0] * 100 + ROCM_VERSION[1]}')
+
 if not IS_WINDOWS:
     COMMON_HIP_FLAGS.append('-fPIC')
 


### PR DESCRIPTION
This PR is to update `torch.utils.cpp_extension` to define `TORCH_HIP_VERSION` for HIP extension builds.

This PR is needed as Torchaudio (https://github.com/pytorch/audio) requires` TORCH_HIP_VERSION` for ROCm version checks.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang