### PR TITLE
Reenable test_addcmul_alpha_one_fma_parity dtypes F32 and F64 on XPU.

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -16,7 +16,6 @@ from torch.testing._comparison import default_tolerances
 from torch.testing._internal.common_cuda import _get_torch_cuda_version, SM90OrLater
 from torch.testing._internal.common_device_type import (
     dtypes,
-    dtypesIfXPU,
     instantiate_device_type_tests,
     largeTensorTest,
     onlyAccelerator,
@@ -1497,7 +1496,6 @@ class TestForeach(TestCase):
 
     @onlyAccelerator
     @dtypes(*floating_types_and(torch.half, torch.bfloat16))
-    @dtypesIfXPU(torch.half, torch.bfloat16)
     def test_addcmul_alpha_one_fma_parity(self, device, dtype):
         # Test that addcmul with alpha=1 produces bitwise identical results
         # to add with alpha=scalar_val (when tensor1 is a 0D tensor with that value).

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -16,7 +16,6 @@ from torch.testing._comparison import default_tolerances
 from torch.testing._internal.common_cuda import _get_torch_cuda_version, SM90OrLater
 from torch.testing._internal.common_device_type import (
     dtypes,
-    dtypesIfXPU,
     instantiate_device_type_tests,
     largeTensorTest,
     onlyAccelerator,
@@ -1499,7 +1498,6 @@ class TestForeach(TestCase):
 
     @onlyAccelerator
     @dtypes(*floating_types_and(torch.half, torch.bfloat16))
-    @dtypesIfXPU(torch.half, torch.bfloat16)
     def test_addcmul_alpha_one_fma_parity(self, device, dtype):
         # Test that addcmul with alpha=1 produces bitwise identical results
         # to add with alpha=scalar_val (when tensor1 is a 0D tensor with that value).


### PR DESCRIPTION
To be merged after https://github.com/intel/torch-xpu-ops/pull/3275 is merged and reference updated.