### PR TITLE
[Docathon] Convert nn.init.rst from rST to MyST Markdown

### DIFF
--- a/docs/source/nn.init.md
+++ b/docs/source/nn.init.md
@@ -1,16 +1,14 @@
-.. role:: hidden
-    :class: hidden-section
+(nn-init-doc)=
 
-.. _nn-init-doc:
+# torch.nn.init
 
-torch.nn.init
-=============
+:::{warning}
+All the functions in this module are intended to be used to initialize neural network
+parameters, so they all run in {func}`torch.no_grad` mode and will not be taken into
+account by autograd.
+:::
 
-.. warning::
-    All the functions in this module are intended to be used to initialize neural network
-    parameters, so they all run in :func:`torch.no_grad` mode and will not be taken into
-    account by autograd.
-
+```{eval-rst}
 .. currentmodule:: torch.nn.init
 .. autofunction:: calculate_gain
 .. autofunction:: uniform_
@@ -27,3 +25,4 @@ torch.nn.init
 .. autofunction:: trunc_normal_
 .. autofunction:: orthogonal_
 .. autofunction:: sparse_
+```

--- a/docs/source/redirects.py
+++ b/docs/source/redirects.py
@@ -159,4 +159,6 @@ redirects = {
         "user_guide/torch_compiler/compile/"
         "programming_model.where_to_apply_compile.html"
     ),
+    # Auto-generated redirects for moved files
+    "nn.init": "nn.init.html",
 }


### PR DESCRIPTION
Fixes #182479

Converts `docs/source/nn.init.rst` to MyST Markdown format:

- RST label (`.. _nn-init-doc:`) → MyST target (`(nn-init-doc)=`)
- RST warning directive → MyST colon-fence `:::{warning}`
- RST role reference (`:func:`) → MyST inline role (`{func}`)
- Sphinx autodoc directives wrapped in `eval-rst` block
- Removed unused `.. role:: hidden` directive
- Preserved git history via `git mv`

cc @svekars @sekyondaMeta @AlannaBurke