### PR TITLE
Add `spin docs` command wrapping `make -C docs`

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -1,5 +1,7 @@
 import hashlib
+import importlib.util
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -459,6 +461,62 @@ def regenerate_github_workflows():
     """Regenerate GitHub workflows from templates."""
     cmd = [sys.executable, "scripts/generate_ci_workflows.py"]
     spin.util.run(cmd, cwd="./.github")
+
+
+#: Canary imports for the docs build environment. If any of these are missing
+#: in the active env, the `make` invocation in spin docs would fail deep inside
+#: a Sphinx extension or a figure-generation script with an unhelpful traceback.
+#: Listing them up-front lets us surface a single actionable hint instead.
+_DOCS_DEP_CANARIES = ("sphinx", "matplotlib")
+
+
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.argument("make_args", nargs=-1, type=click.UNPROCESSED)
+def docs(make_args):
+    """Build documentation.
+
+    Wraps `make` in `docs/`. With no arguments runs `make html`. Pass any
+    Make target or argument through, e.g.
+
+    \b
+        spin docs                     # html (default)
+        spin docs doctest             # run doctests
+        spin docs coverage            # API coverage report
+        spin docs html-stable         # release-style build
+        spin docs serve               # local http server on build/html
+        spin docs html O="-D katex_prerender=0"  # no Node.js needed
+
+    Requires the docs build dependencies (`docs/requirements.txt`) to be
+    installed in the active environment. The default build also prerenders
+    math with KaTeX, which needs Node.js (`node`) on PATH; pass
+    `O="-D katex_prerender=0"` to render math in the browser instead. (Use
+    `O=` rather than `SPHINXOPTS=` so the Makefile's default options are kept.)
+    """
+    missing = [
+        name for name in _DOCS_DEP_CANARIES if importlib.util.find_spec(name) is None
+    ]
+    if missing:
+        raise click.ClickException(
+            f"Docs build dependencies missing: {', '.join(missing)}.\n"
+            f"Install them with:\n\n"
+            f"    pip install -r docs/requirements.txt"
+        )
+
+    # docs/source/conf.py sets katex_prerender=True, so sphinxcontrib-katex
+    # spawns a Node.js server to prerender math. Missing node otherwise fails
+    # deep in the Sphinx run with a bare "No such file or directory: 'node'".
+    # Only a warning: node is unnecessary when the user disables prerender.
+    prerender_disabled = any("katex_prerender=0" in arg for arg in make_args)
+    if not prerender_disabled and shutil.which("node") is None:
+        click.echo(
+            "Warning: `node` not found on PATH. The docs build prerenders math "
+            "with KaTeX (katex_prerender=True), which needs Node.js. Either "
+            "install nodejs, or skip prerender with:\n\n"
+            '    spin docs html O="-D katex_prerender=0"\n',
+            err=True,
+        )
+    cmd = ["make", *(make_args or ("html",))]
+    spin.util.run(cmd, cwd="docs")
 
 
 PYREFLY_LINTER_SCRIPT = CWD / "tools" / "linter" / "adapters" / "pyrefly_linter.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -376,6 +376,9 @@ package = 'torch'
   ".spin/cmds.py:regenerate_clangtidy_files",
   ".spin/cmds.py:regenerate_github_workflows",
 ]
+"Documentation" = [
+  ".spin/cmds.py:docs",
+]
 "Type" = [
     ".spin/cmds.py:pyrefly",
 ]


### PR DESCRIPTION
Add a `spin docs` command that wraps the documentation build (`make` in
`docs/`), defaulting to `make html` and passing any target or option through
(e.g. `spin docs doctest`, `spin docs coverage`, `spin docs serve`). This
hides the `cd docs && make ...` invocation behind the unified spin CLI as
tier 1 of the Spin RFC (#164469).

The command runs a pre-flight dependency canary so a missing build dependency
surfaces as one actionable hint instead of a cryptic failure deep inside
Sphinx:

- `sphinx` and `matplotlib` are hard-required; if either is missing the
  command stops with a pointer to `pip install -r docs/requirements.txt`.
- `node` is also checked, because `docs/source/conf.py` sets
  `katex_prerender = True`, which starts a Node.js server to prerender math;
  without it the build dies with a bare `FileNotFoundError: 'node'`. This is
  a warning rather than a hard error (Node.js is unnecessary when prerender is
  disabled) and is suppressed when the invocation already disables prerender.
  The hint gives both remedies: install nodejs, or append
  `O="-D katex_prerender=0"` to render math in the browser. `O=` appends to
  the Makefile's default `SPHINXOPTS` (keeping `-j`/`-WT`/`--keep-going`),
  whereas `SPHINXOPTS=` would replace it.

Test Plan:

Built PyTorch and ran the command end-to-end against the real docs on a CUDA
box (all succeeded):

```
spin docs html                 # default build: build succeeded, 3485 pages
spin docs serve PORT=8765      # HTTP 200 serving build/html/index.html
spin docs coverage             # exit 0
spin docs doctest              # exit 0 (under the default -WT)
spin docs html-stable          # exit 0
```

Node.js handling, with `node` removed from the environment:

```
spin docs html                          # FileNotFoundError: 'node' (the failure being pre-empted)
spin docs html O="-D katex_prerender=0" # build succeeded, stays strict (-WT), exit 0
```

Canary logic unit-checked by invoking the command with `spin.util.run`,
`shutil.which`, and `importlib.util.find_spec` mocked: missing
sphinx/matplotlib raises with the pip hint and does not run make; missing node
warns and still runs make; `katex_prerender=0` suppresses the warning; bare
`spin docs` defaults to `make html`.

Confirmed the `O=` vs `SPHINXOPTS=` semantics with `make -n`: the default
expands to `sphinx-build ... -j 64 -WT --keep-going`; `O=` appends to that,
`SPHINXOPTS=` replaces it.

Co-Authored with Claude.